### PR TITLE
feat(plugin-google-workspace): add People (Contacts) managed capability

### DIFF
--- a/packages/shared/src/connector-account-catalog.test.ts
+++ b/packages/shared/src/connector-account-catalog.test.ts
@@ -45,7 +45,7 @@ const EXPECTED: Record<
   google: {
     provider: "google",
     defaultRole: "OWNER",
-    defaultPurpose: ["messaging", "calendar", "drive", "meet"],
+    defaultPurpose: ["messaging", "calendar", "drive", "meet", "contacts"],
     supportsOAuth: true,
   },
   x: {
@@ -102,6 +102,7 @@ describe("connector account catalog defaults", () => {
       "drive.write",
       "meet.create",
       "meet.read",
+      "people.read",
     ]);
   });
 });

--- a/packages/shared/src/connector-account-catalog.ts
+++ b/packages/shared/src/connector-account-catalog.ts
@@ -50,7 +50,8 @@ export type ConnectorAccountCatalogPurpose =
   | "reading"
   | "calendar"
   | "drive"
-  | "meet";
+  | "meet"
+  | "contacts";
 
 /** Provider-owned OAuth capability rendered by the generic account UI. */
 export interface ConnectorOAuthCapabilityDeclaration {
@@ -120,7 +121,7 @@ export const CONNECTOR_ACCOUNT_CATALOG: readonly ConnectorAccountCatalogEntry[] 
       connectorId: "google",
       provider: "google",
       defaultRole: "OWNER",
-      defaultPurpose: ["messaging", "calendar", "drive", "meet"],
+      defaultPurpose: ["messaging", "calendar", "drive", "meet", "contacts"],
       supportsOAuth: true,
       oauthCapabilities: [
         {
@@ -176,6 +177,12 @@ export const CONNECTOR_ACCOUNT_CATALOG: readonly ConnectorAccountCatalogEntry[] 
           group: "Meet",
           label: "Read Meet Artifacts",
           description: "Read Meet spaces, participants, and artifacts.",
+        },
+        {
+          id: "people.read",
+          group: "People",
+          label: "Read Contacts",
+          description: "Search and read Google Contacts and Other Contacts.",
         },
       ],
       aliases: ["gmail", "google-workspace"],

--- a/plugins/plugin-google-workspace/AGENTS.md
+++ b/plugins/plugin-google-workspace/AGENTS.md
@@ -47,7 +47,7 @@ Meet (`src/meet.ts` via `GoogleMeetClient`):
 People (`src/people.ts` via `GooglePeopleClient`, capability `people.read`):
 - `listContacts` — page-based saved-contact listing (opaque `nextPageToken` replay, Drive-style).
 - `searchContacts` — dual-source search over saved contacts and interaction-derived Other Contacts, with the documented empty-query warmup request; `includeOtherContacts: false` limits to saved contacts.
-- `getContact` — fetch one person by `resourceName` (`people/…` or `otherContacts/…`).
+- `getContact` — fetch one saved contact by its canonical `people/…` resource name. Other Contacts are searchable/listable only; Google's API has no `otherContacts.get` endpoint.
 - `generateReport` — builds a structured `GoogleMeetReport` from transcript + recording artifacts and includes a canonical `elizaos.meeting_artifact.v1` artifact.
 - `buildGoogleMeetCanonicalArtifact` / `classifyGoogleMeetImportError` — deterministic fixture helpers for saved Google API responses, Google Docs transcript mismatch warnings, missing-artifact classifications, and bot-free capture mapping.
 

--- a/plugins/plugin-google-workspace/AGENTS.md
+++ b/plugins/plugin-google-workspace/AGENTS.md
@@ -1,10 +1,10 @@
 # @elizaos/plugin-google-workspace
 
-Google Workspace integration for Gmail, Calendar, Drive, and Meet with account-scoped OAuth, plus the Google Chat messaging connector (service-account auth) and Google-owned assistant message projections.
+Google Workspace integration for Gmail, Calendar, Drive, Meet, and People (Contacts) with account-scoped OAuth, plus the Google Chat messaging connector (service-account auth) and Google-owned assistant message projections.
 
 ## Purpose / role
 
-Adds `GoogleWorkspaceService` to an Eliza agent runtime, exposing Gmail, Google Calendar, Google Drive, and Google Meet operations through a single account-scoped OAuth grant. It also exports `GoogleGmailAdapter`, the Gmail-owned message-triage adapter used by assistant plugins such as LifeOps. The plugin is opt-in — load it as `googlePlugin` from this package. It also registers with `ConnectorAccountManager` so the generic connector HTTP routes can manage Google accounts and run OAuth flows automatically; that provider registration also mounts the Gmail send `MessageConnector` (`source: "gmail"`, aliases `email`/`mail`) so `MESSAGE op=send` can compose and send email through the connected account.
+Adds `GoogleWorkspaceService` to an Eliza agent runtime, exposing Gmail, Google Calendar, Google Drive, Google Meet, and Google People (Contacts) operations through a single account-scoped OAuth grant. It also exports `GoogleGmailAdapter`, the Gmail-owned message-triage adapter used by assistant plugins such as LifeOps. The plugin is opt-in — load it as `googlePlugin` from this package. It also registers with `ConnectorAccountManager` so the generic connector HTTP routes can manage Google accounts and run OAuth flows automatically; that provider registration also mounts the Gmail send `MessageConnector` (`source: "gmail"`, aliases `email`/`mail`) so `MESSAGE op=send` can compose and send email through the connected account.
 
 Google Chat lives here too, as the `src/chat/` module: `GoogleChatService` (service type `"google-chat"`) registers a runtime `MessageConnector` for spaces, DMs, threads, reactions, and attachments. Chat authenticates with a service account (scope `https://www.googleapis.com/auth/chat.bot`), NOT the consolidated Workspace OAuth grant — the two auth models are intentionally separate even though they share this package. The plugin auto-enables when a `connectors.googlechat` block is present and not explicitly disabled (`auto-enable.ts`); the Workspace OAuth side stays opt-in.
 
@@ -12,7 +12,7 @@ Google Chat lives here too, as the `src/chat/` module: `GoogleChatService` (serv
 
 The plugin object (`googlePlugin`, service name `"google"`) registers:
 
-- **Services:** `GoogleWorkspaceService` — wraps four sub-clients (Gmail, Calendar, Drive, Meet), retrieved via `runtime.getService("google")`; `GoogleChatService` — the Chat connector, retrieved via `runtime.getService("google-chat")`.
+- **Services:** `GoogleWorkspaceService` — wraps five sub-clients (Gmail, Calendar, Drive, Meet, People), retrieved via `runtime.getService("google")`; `GoogleChatService` — the Chat connector, retrieved via `runtime.getService("google-chat")`.
 - **Message adapters:** `GoogleGmailAdapter` — Gmail projection into the core message-triage shape for assistant plugins (thread replies and new outbound email).
 - **Message connectors:** the Gmail send connector from `gmail-message-connector.ts`, registered through the Google connector-account provider — routes `MESSAGE op=send source=gmail` / email-literal targets to `GoogleWorkspaceService.sendGmailMessage`.
 - **Actions:** none (empty array).
@@ -43,6 +43,11 @@ Meet (`src/meet.ts` via `GoogleMeetClient`):
 - `createMeeting` / `getMeeting` / `getMeetingSpace` — space management.
 - `getConferenceRecord` / `listMeetingParticipants` / `listMeetingParticipantSessions` / `listMeetingTranscripts` / `getMeetingTranscript` / `listMeetingRecordings` / `getMeetingRecordingUrl` — conference artifacts.
 - `endMeeting` — ends an active conference.
+
+People (`src/people.ts` via `GooglePeopleClient`, capability `people.read`):
+- `listContacts` — page-based saved-contact listing (opaque `nextPageToken` replay, Drive-style).
+- `searchContacts` — dual-source search over saved contacts and interaction-derived Other Contacts, with the documented empty-query warmup request; `includeOtherContacts: false` limits to saved contacts.
+- `getContact` — fetch one person by `resourceName` (`people/…` or `otherContacts/…`).
 - `generateReport` — builds a structured `GoogleMeetReport` from transcript + recording artifacts and includes a canonical `elizaos.meeting_artifact.v1` artifact.
 - `buildGoogleMeetCanonicalArtifact` / `classifyGoogleMeetImportError` — deterministic fixture helpers for saved Google API responses, Google Docs transcript mismatch warnings, missing-artifact classifications, and bot-free capture mapping.
 
@@ -69,6 +74,7 @@ src/
   calendar.ts                  GoogleCalendarClient — Calendar list/CRUD
   drive.ts                     GoogleDriveClient — Drive/Docs/Sheets operations
   meet.ts                      GoogleMeetClient — Meet space/conference/artifact operations
+  people.ts                    GooglePeopleClient — Contacts/Other Contacts list, search, get
   chat/                        Google Chat connector (service-account auth, MessageConnector)
     service.ts                 GoogleChatService — Chat REST client, webhook processing, multi-account
     accounts.ts                Multi-account config resolution, env var parsing
@@ -156,7 +162,7 @@ Google Chat (service-account auth; see `src/chat/accounts.ts` for full resolutio
 
 - **Every method takes `GoogleAccountRef` (`{ accountId: string }`)** as the first positional field. All API calls are account-scoped; there is no single-account shortcut.
 - **Credential resolution is pluggable.** The default `DefaultGoogleCredentialResolver` reads from `ConnectorAccountManager` → `ConnectorAccountStorage` → vault. For tests, inject a custom `GoogleCredentialResolver` via `GoogleWorkspaceService` constructor options or `service.setCredentialResolver(...)`.
-- **Single consolidated OAuth grant.** All capabilities (Gmail, Calendar, Drive, Meet) share one OAuth token per account. Callers may pass a subset of capabilities to `startOAuth` to limit the requested scopes.
+- **Single consolidated OAuth grant.** All capabilities (Gmail, Calendar, Drive, Meet, People) share one OAuth token per account. Callers may pass a subset of capabilities to `startOAuth` to limit the requested scopes.
 - **No actions or providers are registered by default.** Callers that need agent-facing actions must implement them separately and call `GoogleWorkspaceService` methods directly.
 - **Node-only.** `package.json` declares `"runtime": "node"`. This plugin uses `node:crypto` and `googleapis` (Node SDK); it will not run in browser or edge environments.
 - **googleapis clients are created per-call.** `GoogleApiClientFactory` creates a new googleapis client each call (auth client is cached by credential version in `DefaultGoogleCredentialResolver`).

--- a/plugins/plugin-google-workspace/CLAUDE.md
+++ b/plugins/plugin-google-workspace/CLAUDE.md
@@ -47,7 +47,7 @@ Meet (`src/meet.ts` via `GoogleMeetClient`):
 People (`src/people.ts` via `GooglePeopleClient`, capability `people.read`):
 - `listContacts` — page-based saved-contact listing (opaque `nextPageToken` replay, Drive-style).
 - `searchContacts` — dual-source search over saved contacts and interaction-derived Other Contacts, with the documented empty-query warmup request; `includeOtherContacts: false` limits to saved contacts.
-- `getContact` — fetch one person by `resourceName` (`people/…` or `otherContacts/…`).
+- `getContact` — fetch one saved contact by its canonical `people/…` resource name. Other Contacts are searchable/listable only; Google's API has no `otherContacts.get` endpoint.
 - `generateReport` — builds a structured `GoogleMeetReport` from transcript + recording artifacts and includes a canonical `elizaos.meeting_artifact.v1` artifact.
 - `buildGoogleMeetCanonicalArtifact` / `classifyGoogleMeetImportError` — deterministic fixture helpers for saved Google API responses, Google Docs transcript mismatch warnings, missing-artifact classifications, and bot-free capture mapping.
 

--- a/plugins/plugin-google-workspace/CLAUDE.md
+++ b/plugins/plugin-google-workspace/CLAUDE.md
@@ -1,10 +1,10 @@
 # @elizaos/plugin-google-workspace
 
-Google Workspace integration for Gmail, Calendar, Drive, and Meet with account-scoped OAuth, plus the Google Chat messaging connector (service-account auth) and Google-owned assistant message projections.
+Google Workspace integration for Gmail, Calendar, Drive, Meet, and People (Contacts) with account-scoped OAuth, plus the Google Chat messaging connector (service-account auth) and Google-owned assistant message projections.
 
 ## Purpose / role
 
-Adds `GoogleWorkspaceService` to an Eliza agent runtime, exposing Gmail, Google Calendar, Google Drive, and Google Meet operations through a single account-scoped OAuth grant. It also exports `GoogleGmailAdapter`, the Gmail-owned message-triage adapter used by assistant plugins such as LifeOps. The plugin is opt-in — load it as `googlePlugin` from this package. It also registers with `ConnectorAccountManager` so the generic connector HTTP routes can manage Google accounts and run OAuth flows automatically; that provider registration also mounts the Gmail send `MessageConnector` (`source: "gmail"`, aliases `email`/`mail`) so `MESSAGE op=send` can compose and send email through the connected account.
+Adds `GoogleWorkspaceService` to an Eliza agent runtime, exposing Gmail, Google Calendar, Google Drive, Google Meet, and Google People (Contacts) operations through a single account-scoped OAuth grant. It also exports `GoogleGmailAdapter`, the Gmail-owned message-triage adapter used by assistant plugins such as LifeOps. The plugin is opt-in — load it as `googlePlugin` from this package. It also registers with `ConnectorAccountManager` so the generic connector HTTP routes can manage Google accounts and run OAuth flows automatically; that provider registration also mounts the Gmail send `MessageConnector` (`source: "gmail"`, aliases `email`/`mail`) so `MESSAGE op=send` can compose and send email through the connected account.
 
 Google Chat lives here too, as the `src/chat/` module: `GoogleChatService` (service type `"google-chat"`) registers a runtime `MessageConnector` for spaces, DMs, threads, reactions, and attachments. Chat authenticates with a service account (scope `https://www.googleapis.com/auth/chat.bot`), NOT the consolidated Workspace OAuth grant — the two auth models are intentionally separate even though they share this package. The plugin auto-enables when a `connectors.googlechat` block is present and not explicitly disabled (`auto-enable.ts`); the Workspace OAuth side stays opt-in.
 
@@ -12,7 +12,7 @@ Google Chat lives here too, as the `src/chat/` module: `GoogleChatService` (serv
 
 The plugin object (`googlePlugin`, service name `"google"`) registers:
 
-- **Services:** `GoogleWorkspaceService` — wraps four sub-clients (Gmail, Calendar, Drive, Meet), retrieved via `runtime.getService("google")`; `GoogleChatService` — the Chat connector, retrieved via `runtime.getService("google-chat")`.
+- **Services:** `GoogleWorkspaceService` — wraps five sub-clients (Gmail, Calendar, Drive, Meet, People), retrieved via `runtime.getService("google")`; `GoogleChatService` — the Chat connector, retrieved via `runtime.getService("google-chat")`.
 - **Message adapters:** `GoogleGmailAdapter` — Gmail projection into the core message-triage shape for assistant plugins (thread replies and new outbound email).
 - **Message connectors:** the Gmail send connector from `gmail-message-connector.ts`, registered through the Google connector-account provider — routes `MESSAGE op=send source=gmail` / email-literal targets to `GoogleWorkspaceService.sendGmailMessage`.
 - **Actions:** none (empty array).
@@ -43,6 +43,11 @@ Meet (`src/meet.ts` via `GoogleMeetClient`):
 - `createMeeting` / `getMeeting` / `getMeetingSpace` — space management.
 - `getConferenceRecord` / `listMeetingParticipants` / `listMeetingParticipantSessions` / `listMeetingTranscripts` / `getMeetingTranscript` / `listMeetingRecordings` / `getMeetingRecordingUrl` — conference artifacts.
 - `endMeeting` — ends an active conference.
+
+People (`src/people.ts` via `GooglePeopleClient`, capability `people.read`):
+- `listContacts` — page-based saved-contact listing (opaque `nextPageToken` replay, Drive-style).
+- `searchContacts` — dual-source search over saved contacts and interaction-derived Other Contacts, with the documented empty-query warmup request; `includeOtherContacts: false` limits to saved contacts.
+- `getContact` — fetch one person by `resourceName` (`people/…` or `otherContacts/…`).
 - `generateReport` — builds a structured `GoogleMeetReport` from transcript + recording artifacts and includes a canonical `elizaos.meeting_artifact.v1` artifact.
 - `buildGoogleMeetCanonicalArtifact` / `classifyGoogleMeetImportError` — deterministic fixture helpers for saved Google API responses, Google Docs transcript mismatch warnings, missing-artifact classifications, and bot-free capture mapping.
 
@@ -69,6 +74,7 @@ src/
   calendar.ts                  GoogleCalendarClient — Calendar list/CRUD
   drive.ts                     GoogleDriveClient — Drive/Docs/Sheets operations
   meet.ts                      GoogleMeetClient — Meet space/conference/artifact operations
+  people.ts                    GooglePeopleClient — Contacts/Other Contacts list, search, get
   chat/                        Google Chat connector (service-account auth, MessageConnector)
     service.ts                 GoogleChatService — Chat REST client, webhook processing, multi-account
     accounts.ts                Multi-account config resolution, env var parsing
@@ -156,7 +162,7 @@ Google Chat (service-account auth; see `src/chat/accounts.ts` for full resolutio
 
 - **Every method takes `GoogleAccountRef` (`{ accountId: string }`)** as the first positional field. All API calls are account-scoped; there is no single-account shortcut.
 - **Credential resolution is pluggable.** The default `DefaultGoogleCredentialResolver` reads from `ConnectorAccountManager` → `ConnectorAccountStorage` → vault. For tests, inject a custom `GoogleCredentialResolver` via `GoogleWorkspaceService` constructor options or `service.setCredentialResolver(...)`.
-- **Single consolidated OAuth grant.** All capabilities (Gmail, Calendar, Drive, Meet) share one OAuth token per account. Callers may pass a subset of capabilities to `startOAuth` to limit the requested scopes.
+- **Single consolidated OAuth grant.** All capabilities (Gmail, Calendar, Drive, Meet, People) share one OAuth token per account. Callers may pass a subset of capabilities to `startOAuth` to limit the requested scopes.
 - **No actions or providers are registered by default.** Callers that need agent-facing actions must implement them separately and call `GoogleWorkspaceService` methods directly.
 - **Node-only.** `package.json` declares `"runtime": "node"`. This plugin uses `node:crypto` and `googleapis` (Node SDK); it will not run in browser or edge environments.
 - **googleapis clients are created per-call.** `GoogleApiClientFactory` creates a new googleapis client each call (auth client is cached by credential version in `DefaultGoogleCredentialResolver`).

--- a/plugins/plugin-google-workspace/src/client-factory.ts
+++ b/plugins/plugin-google-workspace/src/client-factory.ts
@@ -13,6 +13,7 @@ import {
   type gmail_v1,
   google,
   type meet_v2,
+  type people_v1,
   type sheets_v4,
 } from "googleapis";
 import { MissingGoogleCredentialResolver } from "./auth.js";
@@ -92,6 +93,15 @@ export class GoogleApiClientFactory {
   ): Promise<sheets_v4.Sheets> {
     const auth = await this.resolveAuthClient(account, capabilities, reason);
     return google.sheets(this.apiOptions("v4", auth) as sheets_v4.Options);
+  }
+
+  async people(
+    account: GoogleAccountRef,
+    capabilities: readonly GoogleCapability[],
+    reason: string
+  ): Promise<people_v1.People> {
+    const auth = await this.resolveAuthClient(account, capabilities, reason);
+    return google.people(this.apiOptions("v1", auth) as people_v1.Options);
   }
 
   async meet(

--- a/plugins/plugin-google-workspace/src/connector-account-provider.ts
+++ b/plugins/plugin-google-workspace/src/connector-account-provider.ts
@@ -53,6 +53,7 @@ const GROUP_PURPOSE: Record<GoogleCapabilityGroup, ConnectorAccountPurpose> = {
   calendar: "calendar" as ConnectorAccountPurpose,
   drive: "drive" as ConnectorAccountPurpose,
   meet: "meet" as ConnectorAccountPurpose,
+  people: "contacts" as ConnectorAccountPurpose,
 };
 
 interface GoogleTokenResponse {

--- a/plugins/plugin-google-workspace/src/index.ts
+++ b/plugins/plugin-google-workspace/src/index.ts
@@ -42,6 +42,7 @@ export * from "./gmail-message-connector.js";
 export * from "./google-oauth-callback.js";
 export { GoogleGmailAdapter } from "./lifeops-message-adapter.js";
 export * from "./meet.js";
+export * from "./people.js";
 export * from "./scopes.js";
 export * from "./types.js";
 export { GoogleChatService, GoogleWorkspaceService };

--- a/plugins/plugin-google-workspace/src/people.loopback.test.ts
+++ b/plugins/plugin-google-workspace/src/people.loopback.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Google People contact lookup through the installed googleapis HTTP client
+ * against a loopback provider, proving the canonical outbound resource path.
+ */
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { Auth } from "googleapis";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { GoogleApiClientFactory } from "./client-factory.js";
+import { GooglePeopleClient } from "./people.js";
+import type { GoogleAuthClient, GoogleCredentialResolver } from "./types.js";
+
+class LoopbackCredentialResolver implements GoogleCredentialResolver {
+  calls = 0;
+
+  async getAuthClient(): Promise<GoogleAuthClient> {
+    this.calls += 1;
+    const auth = new Auth.OAuth2Client();
+    auth.setCredentials({
+      access_token: "loopback-google-token",
+      expiry_date: Date.now() + 60 * 60 * 1000,
+    });
+    return auth;
+  }
+}
+
+let server: Server;
+let originalBase: string | undefined;
+let paths: string[] = [];
+const resolver = new LoopbackCredentialResolver();
+let client: GooglePeopleClient;
+
+beforeAll(async () => {
+  originalBase = process.env.ELIZA_MOCK_GOOGLE_BASE;
+  server = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://loopback.invalid");
+    paths.push(url.pathname);
+    if (url.pathname === "/v1/people/canonical-contact") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          resourceName: "people/canonical-contact",
+          names: [{ displayName: "Canonical Contact" }],
+        })
+      );
+      return;
+    }
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: { code: 404 } }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo;
+  process.env.ELIZA_MOCK_GOOGLE_BASE = `http://127.0.0.1:${address.port}/`;
+  client = new GooglePeopleClient(new GoogleApiClientFactory(resolver));
+});
+
+afterAll(async () => {
+  if (originalBase === undefined) delete process.env.ELIZA_MOCK_GOOGLE_BASE;
+  else process.env.ELIZA_MOCK_GOOGLE_BASE = originalBase;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+describe("Google People provider boundary", () => {
+  it("sends canonical people resources to the real people.get HTTP path", async () => {
+    paths = [];
+    const result = await client.getContact({
+      accountId: "owner-account",
+      resourceName: "people/canonical-contact",
+    });
+
+    expect(result).toMatchObject({
+      resourceName: "people/canonical-contact",
+      displayName: "Canonical Contact",
+      source: "contact",
+    });
+    expect(paths).toEqual(["/v1/people/canonical-contact"]);
+  });
+
+  it("rejects Other Contacts before auth resolution or outbound HTTP", async () => {
+    paths = [];
+    const authCalls = resolver.calls;
+
+    await expect(
+      client.getContact({
+        accountId: "owner-account",
+        resourceName: "otherContacts/interaction-only",
+      })
+    ).rejects.toMatchObject({ code: "GOOGLE_PEOPLE_RESOURCE_NAME_INVALID" });
+    expect(resolver.calls).toBe(authCalls);
+    expect(paths).toEqual([]);
+  });
+});

--- a/plugins/plugin-google-workspace/src/people.test.ts
+++ b/plugins/plugin-google-workspace/src/people.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Contract tests for `GooglePeopleClient` and the `people.read` capability:
+ * page-based listing with opaque token replay, dual-source search (contacts +
+ * Other Contacts) with the documented warmup request, malformed-upstream
+ * rejection, auth failure propagation, and scope derivation. Deterministic
+ * harness — the googleapis People surface is replaced with protocol-faithful
+ * fakes; no network access.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { GoogleApiClientFactory } from "./client-factory.js";
+import { GooglePeopleClient } from "./people.js";
+import {
+  GOOGLE_CAPABILITY_METADATA,
+  GOOGLE_OAUTH_SCOPES,
+  scopesForGoogleCapabilities,
+} from "./scopes.js";
+
+interface PeopleApiFakes {
+  connectionsList?: ReturnType<typeof vi.fn>;
+  searchContacts?: ReturnType<typeof vi.fn>;
+  otherContactsSearch?: ReturnType<typeof vi.fn>;
+  get?: ReturnType<typeof vi.fn>;
+}
+
+function clientFor(fakes: PeopleApiFakes): {
+  client: GooglePeopleClient;
+  peopleFactory: ReturnType<typeof vi.fn>;
+} {
+  const peopleFactory = vi.fn(async () => ({
+    people: {
+      connections: { list: fakes.connectionsList ?? vi.fn() },
+      searchContacts: fakes.searchContacts ?? vi.fn(async () => ({ data: {} })),
+      get: fakes.get ?? vi.fn(),
+    },
+    otherContacts: {
+      search: fakes.otherContactsSearch ?? vi.fn(async () => ({ data: {} })),
+    },
+  }));
+  const factory = { people: peopleFactory } as unknown as GoogleApiClientFactory;
+  return { client: new GooglePeopleClient(factory), peopleFactory };
+}
+
+const RICH_PERSON = {
+  resourceName: "people/c1",
+  names: [
+    { displayName: "Secondary Name", givenName: "Secondary" },
+    {
+      displayName: "Ada Lovelace",
+      givenName: "Ada",
+      familyName: "Lovelace",
+      metadata: { primary: true },
+    },
+  ],
+  emailAddresses: [
+    { value: "ada@example.com", type: "work", metadata: { primary: true } },
+    { value: null },
+  ],
+  phoneNumbers: [{ value: "+1 555 0100", type: "mobile" }],
+  organizations: [{ name: "Analytical Engines", title: "Countess" }, {}],
+  photos: [{ url: "https://example.com/ada.jpg" }],
+};
+
+describe("people.read capability catalog", () => {
+  it("derives contacts and other-contacts read scopes for people.read", () => {
+    const scopes = scopesForGoogleCapabilities(["people.read"], {
+      includeIdentityScopes: false,
+    });
+    expect(scopes).toEqual([GOOGLE_OAUTH_SCOPES.people.read, GOOGLE_OAUTH_SCOPES.people.otherRead]);
+    expect(GOOGLE_CAPABILITY_METADATA["people.read"].group).toBe("people");
+  });
+});
+
+describe("listContacts", () => {
+  it("maps a full person record and reports the primary name and clean collections", async () => {
+    const connectionsList = vi.fn(async () => ({
+      data: { connections: [RICH_PERSON], nextPageToken: "next-1" },
+    }));
+    const { client, peopleFactory } = clientFor({ connectionsList });
+
+    const page = await client.listContacts({ accountId: "acct-1" });
+
+    expect(page).toEqual({
+      contacts: [
+        {
+          resourceName: "people/c1",
+          displayName: "Ada Lovelace",
+          givenName: "Ada",
+          familyName: "Lovelace",
+          emailAddresses: [{ value: "ada@example.com", type: "work", primary: true }],
+          phoneNumbers: [{ value: "+1 555 0100", type: "mobile", primary: undefined }],
+          organizations: [{ name: "Analytical Engines", title: "Countess" }],
+          photoUrl: "https://example.com/ada.jpg",
+          source: "contact",
+        },
+      ],
+      nextPageToken: "next-1",
+    });
+    expect(peopleFactory).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: "acct-1" }),
+      ["people.read"],
+      "people.listContacts"
+    );
+  });
+
+  it("returns a designed-empty page with a null cursor when the account has no contacts", async () => {
+    const connectionsList = vi.fn(async () => ({ data: {} }));
+    const { client } = clientFor({ connectionsList });
+
+    await expect(client.listContacts({ accountId: "acct-1" })).resolves.toEqual({
+      contacts: [],
+      nextPageToken: null,
+    });
+  });
+
+  it("replays an opaque page token without rewriting it", async () => {
+    const opaqueToken = "  opaque token  ";
+    const connectionsList = vi.fn(async () => ({ data: { connections: [] } }));
+    const { client } = clientFor({ connectionsList });
+
+    await client.listContacts({ accountId: "acct-1", pageToken: opaqueToken });
+
+    expect(connectionsList).toHaveBeenCalledWith(
+      expect.objectContaining({ pageToken: opaqueToken })
+    );
+  });
+
+  it("rejects a person record without a resourceName instead of fabricating a contact", async () => {
+    const connectionsList = vi.fn(async () => ({
+      data: { connections: [{ names: [{ displayName: "Ghost" }] }] },
+    }));
+    const { client } = clientFor({ connectionsList });
+
+    await expect(client.listContacts({ accountId: "acct-1" })).rejects.toMatchObject({
+      code: "GOOGLE_PEOPLE_MALFORMED_PERSON",
+    });
+  });
+
+  it("propagates auth resolution failures from the client factory", async () => {
+    const factory = {
+      people: vi.fn(async () => {
+        throw new Error("invalid_grant");
+      }),
+    } as unknown as GoogleApiClientFactory;
+    const client = new GooglePeopleClient(factory);
+
+    await expect(client.listContacts({ accountId: "acct-1" })).rejects.toThrow("invalid_grant");
+  });
+});
+
+describe("searchContacts", () => {
+  it("rejects an empty query before touching the API", async () => {
+    const searchContacts = vi.fn();
+    const { client, peopleFactory } = clientFor({ searchContacts });
+
+    await expect(
+      client.searchContacts({ accountId: "acct-1", query: "   " })
+    ).rejects.toMatchObject({ code: "GOOGLE_PEOPLE_SEARCH_QUERY_EMPTY" });
+    expect(peopleFactory).not.toHaveBeenCalled();
+  });
+
+  it("issues the warmup request before the real query for both sources", async () => {
+    const searchContacts = vi.fn(async () => ({ data: { results: [] } }));
+    const otherContactsSearch = vi.fn(async () => ({ data: { results: [] } }));
+    const { client } = clientFor({ searchContacts, otherContactsSearch });
+
+    await client.searchContacts({ accountId: "acct-1", query: "ada" });
+
+    expect(searchContacts).toHaveBeenCalledTimes(2);
+    expect(searchContacts.mock.calls[0][0]).toMatchObject({ query: "" });
+    expect(searchContacts.mock.calls[1][0]).toMatchObject({ query: "ada" });
+    expect(otherContactsSearch).toHaveBeenCalledTimes(2);
+    expect(otherContactsSearch.mock.calls[0][0]).toMatchObject({ query: "" });
+    expect(otherContactsSearch.mock.calls[1][0]).toMatchObject({ query: "ada" });
+  });
+
+  it("merges saved contacts and Other Contacts with per-source tags", async () => {
+    const searchContacts = vi.fn(async (params: { query: string }) => ({
+      data: {
+        results:
+          params.query === ""
+            ? []
+            : [{ person: { resourceName: "people/c1", names: [{ displayName: "Ada" }] } }],
+      },
+    }));
+    const otherContactsSearch = vi.fn(async (params: { query: string }) => ({
+      data: {
+        results:
+          params.query === ""
+            ? []
+            : [
+                {
+                  person: {
+                    resourceName: "otherContacts/o1",
+                    emailAddresses: [{ value: "other@example.com" }],
+                  },
+                },
+              ],
+      },
+    }));
+    const { client } = clientFor({ searchContacts, otherContactsSearch });
+
+    const results = await client.searchContacts({ accountId: "acct-1", query: "a" });
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ resourceName: "people/c1", source: "contact" });
+    expect(results[1]).toMatchObject({
+      resourceName: "otherContacts/o1",
+      displayName: "other@example.com",
+      source: "otherContact",
+    });
+  });
+
+  it("skips Other Contacts when includeOtherContacts is false", async () => {
+    const searchContacts = vi.fn(async () => ({ data: { results: [] } }));
+    const otherContactsSearch = vi.fn();
+    const { client } = clientFor({ searchContacts, otherContactsSearch });
+
+    await client.searchContacts({
+      accountId: "acct-1",
+      query: "ada",
+      includeOtherContacts: false,
+    });
+
+    expect(otherContactsSearch).not.toHaveBeenCalled();
+  });
+
+  it("clamps the requested page size to the People API search maximum of 30", async () => {
+    const searchContacts = vi.fn(async () => ({ data: { results: [] } }));
+    const { client } = clientFor({ searchContacts });
+
+    await client.searchContacts({
+      accountId: "acct-1",
+      query: "ada",
+      maxResults: 500,
+      includeOtherContacts: false,
+    });
+
+    expect(searchContacts.mock.calls[1][0]).toMatchObject({ pageSize: 30 });
+  });
+});
+
+describe("getContact", () => {
+  it("fetches one contact by resource name with the people.read capability", async () => {
+    const get = vi.fn(async () => ({ data: RICH_PERSON }));
+    const { client, peopleFactory } = clientFor({ get });
+
+    const contact = await client.getContact({ accountId: "acct-1", resourceName: "people/c1" });
+
+    expect(contact).toMatchObject({ resourceName: "people/c1", source: "contact" });
+    expect(get).toHaveBeenCalledWith(expect.objectContaining({ resourceName: "people/c1" }));
+    expect(peopleFactory).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: "acct-1" }),
+      ["people.read"],
+      "people.getContact"
+    );
+  });
+
+  it("tags an otherContacts resource as interaction-derived", async () => {
+    const get = vi.fn(async () => ({ data: { resourceName: "otherContacts/o9" } }));
+    const { client } = clientFor({ get });
+
+    await expect(
+      client.getContact({ accountId: "acct-1", resourceName: "otherContacts/o9" })
+    ).resolves.toMatchObject({ source: "otherContact" });
+  });
+});

--- a/plugins/plugin-google-workspace/src/people.test.ts
+++ b/plugins/plugin-google-workspace/src/people.test.ts
@@ -1,8 +1,8 @@
 /**
  * Contract tests for `GooglePeopleClient` and the `people.read` capability:
  * page-based listing with opaque token replay, dual-source search (contacts +
- * Other Contacts) with the documented warmup request, malformed-upstream
- * rejection, auth failure propagation, and scope derivation. Deterministic
+ * Other Contacts) with the documented warmup request, canonical resource-name
+ * enforcement, malformed-upstream rejection, auth failure propagation, and scope derivation. Deterministic
  * harness — the googleapis People surface is replaced with protocol-faithful
  * fakes; no network access.
  */
@@ -255,12 +255,17 @@ describe("getContact", () => {
     );
   });
 
-  it("tags an otherContacts resource as interaction-derived", async () => {
-    const get = vi.fn(async () => ({ data: { resourceName: "otherContacts/o9" } }));
-    const { client } = clientFor({ get });
+  it.each(["", "   ", "otherContacts/o9", "people/", "people/c1/extra", "contact-c1"])(
+    "rejects non-canonical resource name %j before credential or API work",
+    async (resourceName) => {
+      const get = vi.fn();
+      const { client, peopleFactory } = clientFor({ get });
 
-    await expect(
-      client.getContact({ accountId: "acct-1", resourceName: "otherContacts/o9" })
-    ).resolves.toMatchObject({ source: "otherContact" });
-  });
+      await expect(client.getContact({ accountId: "acct-1", resourceName })).rejects.toMatchObject({
+        code: "GOOGLE_PEOPLE_RESOURCE_NAME_INVALID",
+      });
+      expect(peopleFactory).not.toHaveBeenCalled();
+      expect(get).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/plugins/plugin-google-workspace/src/people.ts
+++ b/plugins/plugin-google-workspace/src/people.ts
@@ -1,0 +1,172 @@
+/**
+ * `GooglePeopleClient` — Google Contacts discovery behind the workspace
+ * service, covering saved contacts and interaction-derived "Other Contacts"
+ * through the People API. Listing is page-based (the caller replays the opaque
+ * `nextPageToken`, mirroring the Drive contract) and search fans out to both
+ * contact sources. Search issues the warmup request the People API documents
+ * for `searchContacts`/`otherContacts.search` (an empty-query call primes the
+ * server-side cache) before the real query so fresh mutations are visible.
+ * A person record without a `resourceName` is malformed upstream data and
+ * throws instead of fabricating a healthy-looking contact.
+ */
+import { ElizaError } from "@elizaos/core";
+import type { people_v1 } from "googleapis";
+import type { GoogleApiClientFactory } from "./client-factory.js";
+import type {
+  GooglePeopleContactPage,
+  GooglePeopleGetContactInput,
+  GooglePeopleListContactsInput,
+  GooglePeopleSearchContactsInput,
+  GooglePersonContact,
+} from "./types.js";
+
+const CONTACT_PERSON_FIELDS = "names,emailAddresses,phoneNumbers,organizations,photos";
+/** Other Contacts only support a restricted read mask. */
+const OTHER_CONTACT_READ_MASK = "names,emailAddresses,phoneNumbers";
+/** People API caps searchContacts/otherContacts.search page sizes at 30. */
+const MAX_SEARCH_PAGE_SIZE = 30;
+
+export class GooglePeopleClient {
+  constructor(private readonly clientFactory: GoogleApiClientFactory) {}
+
+  async listContacts(params: GooglePeopleListContactsInput): Promise<GooglePeopleContactPage> {
+    const people = await this.clientFactory.people(params, ["people.read"], "people.listContacts");
+    const response = await people.people.connections.list({
+      resourceName: "people/me",
+      pageSize: normalizedPageSize(params.maxResults, 100),
+      pageToken: params.pageToken,
+      personFields: CONTACT_PERSON_FIELDS,
+      sortOrder: "LAST_MODIFIED_DESCENDING",
+    });
+    return {
+      contacts: (response.data.connections ?? []).map((person) =>
+        mapPerson(person, "contact", "people.listContacts")
+      ),
+      nextPageToken: response.data.nextPageToken ?? null,
+    };
+  }
+
+  async searchContacts(params: GooglePeopleSearchContactsInput): Promise<GooglePersonContact[]> {
+    const query = params.query.trim();
+    if (query.length === 0) {
+      throw new ElizaError("Google People search requires a non-empty query.", {
+        code: "GOOGLE_PEOPLE_SEARCH_QUERY_EMPTY",
+        context: { accountId: params.accountId },
+      });
+    }
+    const people = await this.clientFactory.people(
+      params,
+      ["people.read"],
+      "people.searchContacts"
+    );
+    const pageSize = normalizedPageSize(params.maxResults, MAX_SEARCH_PAGE_SIZE);
+
+    // The People API documents an empty-query warmup request before search so
+    // the server-side search cache includes recent mutations.
+    await people.people.searchContacts({ query: "", readMask: CONTACT_PERSON_FIELDS });
+    const contactResponse = await people.people.searchContacts({
+      query,
+      pageSize,
+      readMask: CONTACT_PERSON_FIELDS,
+    });
+
+    const results = mapSearchResults(contactResponse.data.results, "contact");
+
+    if (params.includeOtherContacts !== false) {
+      await people.otherContacts.search({ query: "", readMask: OTHER_CONTACT_READ_MASK });
+      const otherResponse = await people.otherContacts.search({
+        query,
+        pageSize,
+        readMask: OTHER_CONTACT_READ_MASK,
+      });
+      results.push(...mapSearchResults(otherResponse.data.results, "otherContact"));
+    }
+
+    return results.slice(0, pageSize);
+  }
+
+  async getContact(params: GooglePeopleGetContactInput): Promise<GooglePersonContact> {
+    const people = await this.clientFactory.people(params, ["people.read"], "people.getContact");
+    const response = await people.people.get({
+      resourceName: params.resourceName,
+      personFields: CONTACT_PERSON_FIELDS,
+    });
+    return mapPerson(
+      response.data,
+      params.resourceName.startsWith("otherContacts/") ? "otherContact" : "contact",
+      "people.getContact"
+    );
+  }
+}
+
+function mapSearchResults(
+  results: people_v1.Schema$SearchResult[] | undefined,
+  source: GooglePersonContact["source"]
+): GooglePersonContact[] {
+  const contacts: GooglePersonContact[] = [];
+  for (const result of results ?? []) {
+    if (!result.person) {
+      continue;
+    }
+    contacts.push(mapPerson(result.person, source, "people.searchContacts"));
+  }
+  return contacts;
+}
+
+function mapPerson(
+  person: people_v1.Schema$Person,
+  source: GooglePersonContact["source"],
+  operation: string
+): GooglePersonContact {
+  const resourceName = person.resourceName;
+  if (typeof resourceName !== "string" || resourceName.length === 0) {
+    throw new ElizaError("Google People returned a person record without a resourceName.", {
+      code: "GOOGLE_PEOPLE_MALFORMED_PERSON",
+      context: { operation, source },
+    });
+  }
+
+  const primaryName =
+    person.names?.find((name) => name.metadata?.primary === true) ?? person.names?.[0];
+  const primaryEmail = person.emailAddresses?.find((email) => Boolean(email.value));
+
+  return {
+    resourceName,
+    displayName: primaryName?.displayName ?? primaryEmail?.value ?? "",
+    givenName: primaryName?.givenName ?? undefined,
+    familyName: primaryName?.familyName ?? undefined,
+    emailAddresses: (person.emailAddresses ?? [])
+      .filter((email): email is people_v1.Schema$EmailAddress & { value: string } =>
+        Boolean(email.value)
+      )
+      .map((email) => ({
+        value: email.value,
+        type: email.type ?? undefined,
+        primary: email.metadata?.primary ?? undefined,
+      })),
+    phoneNumbers: (person.phoneNumbers ?? [])
+      .filter((phone): phone is people_v1.Schema$PhoneNumber & { value: string } =>
+        Boolean(phone.value)
+      )
+      .map((phone) => ({
+        value: phone.value,
+        type: phone.type ?? undefined,
+        primary: phone.metadata?.primary ?? undefined,
+      })),
+    organizations: (person.organizations ?? [])
+      .filter((org) => Boolean(org.name || org.title))
+      .map((org) => ({
+        name: org.name ?? undefined,
+        title: org.title ?? undefined,
+      })),
+    photoUrl: person.photos?.find((photo) => Boolean(photo.url))?.url ?? undefined,
+    source,
+  };
+}
+
+function normalizedPageSize(value: number | undefined, cap: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return Math.min(25, cap);
+  }
+  return Math.min(Math.trunc(value), cap);
+}

--- a/plugins/plugin-google-workspace/src/people.ts
+++ b/plugins/plugin-google-workspace/src/people.ts
@@ -5,7 +5,8 @@
  * `nextPageToken`, mirroring the Drive contract) and search fans out to both
  * contact sources. Search issues the warmup request the People API documents
  * for `searchContacts`/`otherContacts.search` (an empty-query call primes the
- * server-side cache) before the real query so fresh mutations are visible.
+ * server-side cache) before the real query. Callers that require a freshly
+ * mutated contact must still honor Google's documented cache propagation delay.
  * A person record without a `resourceName` is malformed upstream data and
  * throws instead of fabricating a healthy-looking contact.
  */
@@ -86,16 +87,21 @@ export class GooglePeopleClient {
   }
 
   async getContact(params: GooglePeopleGetContactInput): Promise<GooglePersonContact> {
+    if (!/^people\/[^/\s]+$/.test(params.resourceName)) {
+      throw new ElizaError(
+        "Google People getContact requires a canonical people/{personId} resource name.",
+        {
+          code: "GOOGLE_PEOPLE_RESOURCE_NAME_INVALID",
+          context: { accountId: params.accountId },
+        }
+      );
+    }
     const people = await this.clientFactory.people(params, ["people.read"], "people.getContact");
     const response = await people.people.get({
       resourceName: params.resourceName,
       personFields: CONTACT_PERSON_FIELDS,
     });
-    return mapPerson(
-      response.data,
-      params.resourceName.startsWith("otherContacts/") ? "otherContact" : "contact",
-      "people.getContact"
-    );
+    return mapPerson(response.data, "contact", "people.getContact");
   }
 }
 

--- a/plugins/plugin-google-workspace/src/scopes.ts
+++ b/plugins/plugin-google-workspace/src/scopes.ts
@@ -16,11 +16,12 @@ export const GOOGLE_CAPABILITIES = [
   "drive.write",
   "meet.create",
   "meet.read",
+  "people.read",
 ] as const;
 
 export type GoogleCapability = (typeof GOOGLE_CAPABILITIES)[number];
 
-export const GOOGLE_CAPABILITY_GROUPS = ["gmail", "calendar", "drive", "meet"] as const;
+export const GOOGLE_CAPABILITY_GROUPS = ["gmail", "calendar", "drive", "meet", "people"] as const;
 
 export type GoogleCapabilityGroup = (typeof GOOGLE_CAPABILITY_GROUPS)[number];
 
@@ -42,6 +43,10 @@ export const GOOGLE_OAUTH_SCOPES = {
   meet: {
     create: "https://www.googleapis.com/auth/meetings.space.created",
     read: "https://www.googleapis.com/auth/meetings.space.readonly",
+  },
+  people: {
+    read: "https://www.googleapis.com/auth/contacts.readonly",
+    otherRead: "https://www.googleapis.com/auth/contacts.other.readonly",
   },
   profile: {
     email: "https://www.googleapis.com/auth/userinfo.email",
@@ -68,6 +73,7 @@ export const GOOGLE_CAPABILITY_SCOPES = {
   "drive.write": [GOOGLE_OAUTH_SCOPES.drive.write],
   "meet.create": [GOOGLE_OAUTH_SCOPES.meet.create],
   "meet.read": [GOOGLE_OAUTH_SCOPES.meet.read],
+  "people.read": [GOOGLE_OAUTH_SCOPES.people.read, GOOGLE_OAUTH_SCOPES.people.otherRead],
 } as const satisfies Record<GoogleCapability, readonly string[]>;
 
 const GOOGLE_CAPABILITY_DETAILS: Record<
@@ -110,6 +116,11 @@ const GOOGLE_CAPABILITY_DETAILS: Record<
     label: "Read Meet Artifacts",
     description:
       "Read Google Meet spaces, conference records, participants, transcripts, and recordings.",
+  },
+  "people.read": {
+    label: "Read Contacts",
+    description:
+      "Search and read Google Contacts and interaction-derived Other Contacts for the selected account.",
   },
 };
 

--- a/plugins/plugin-google-workspace/src/service.ts
+++ b/plugins/plugin-google-workspace/src/service.ts
@@ -15,6 +15,7 @@ import { DefaultGoogleCredentialResolver } from "./credential-resolver.js";
 import { GoogleDriveClient } from "./drive.js";
 import { GoogleGmailClient } from "./gmail.js";
 import { GoogleMeetClient } from "./meet.js";
+import { GooglePeopleClient } from "./people.js";
 import type { GoogleCapability } from "./scopes.js";
 import {
   GOOGLE_SERVICE_NAME,
@@ -66,6 +67,11 @@ import {
   type GoogleOAuthProviderConfig,
   type GoogleOAuthProviderMetadata,
   type GoogleParsedMailto,
+  type GooglePeopleContactPage,
+  type GooglePeopleGetContactInput,
+  type GooglePeopleListContactsInput,
+  type GooglePeopleSearchContactsInput,
+  type GooglePersonContact,
   type GoogleSendEmailInput,
   type GoogleSheetContent,
   type GoogleSheetUpdateResult,
@@ -80,13 +86,14 @@ export class GoogleWorkspaceService extends Service implements IGoogleWorkspaceS
   static serviceType = GOOGLE_SERVICE_NAME;
 
   capabilityDescription =
-    "Google Workspace service for Gmail, Calendar, Drive, and Meet using account-scoped OAuth";
+    "Google Workspace service for Gmail, Calendar, Drive, Meet, and People using account-scoped OAuth";
 
   private readonly clientFactory: GoogleApiClientFactory;
   private readonly gmailClient: GoogleGmailClient;
   private readonly calendarClient: GoogleCalendarClient;
   private readonly driveClient: GoogleDriveClient;
   private readonly meetClient: GoogleMeetClient;
+  private readonly peopleClient: GooglePeopleClient;
 
   constructor(runtime?: IAgentRuntime, options: GoogleWorkspaceServiceOptions = {}) {
     super(runtime);
@@ -97,6 +104,7 @@ export class GoogleWorkspaceService extends Service implements IGoogleWorkspaceS
     this.calendarClient = new GoogleCalendarClient(this.clientFactory);
     this.driveClient = new GoogleDriveClient(this.clientFactory);
     this.meetClient = new GoogleMeetClient(this.clientFactory);
+    this.peopleClient = new GooglePeopleClient(this.clientFactory);
   }
 
   static async start(runtime: IAgentRuntime): Promise<GoogleWorkspaceService> {
@@ -406,5 +414,17 @@ export class GoogleWorkspaceService extends Service implements IGoogleWorkspaceS
 
   generateReport(params: GoogleMeetGenerateReportInput): Promise<GoogleMeetReport> {
     return this.meetClient.generateReport(params);
+  }
+
+  listContacts(params: GooglePeopleListContactsInput): Promise<GooglePeopleContactPage> {
+    return this.peopleClient.listContacts(params);
+  }
+
+  searchContacts(params: GooglePeopleSearchContactsInput): Promise<GooglePersonContact[]> {
+    return this.peopleClient.searchContacts(params);
+  }
+
+  getContact(params: GooglePeopleGetContactInput): Promise<GooglePersonContact> {
+    return this.peopleClient.getContact(params);
   }
 }

--- a/plugins/plugin-google-workspace/src/types.ts
+++ b/plugins/plugin-google-workspace/src/types.ts
@@ -413,6 +413,58 @@ export interface GoogleDriveFileList {
   nextPageToken: string | null;
 }
 
+export interface GooglePersonEmailAddress {
+  value: string;
+  type?: string;
+  primary?: boolean;
+}
+
+export interface GooglePersonPhoneNumber {
+  value: string;
+  type?: string;
+  primary?: boolean;
+}
+
+export interface GooglePersonOrganization {
+  name?: string;
+  title?: string;
+}
+
+export interface GooglePersonContact {
+  /** People API resource name, e.g. `people/c123`. Stable per-account handle. */
+  resourceName: string;
+  displayName: string;
+  givenName?: string;
+  familyName?: string;
+  emailAddresses: GooglePersonEmailAddress[];
+  phoneNumbers: GooglePersonPhoneNumber[];
+  organizations: GooglePersonOrganization[];
+  photoUrl?: string;
+  /** "contact" for saved contacts, "otherContact" for interaction-derived entries. */
+  source: "contact" | "otherContact";
+}
+
+export interface GooglePeopleContactPage {
+  contacts: GooglePersonContact[];
+  nextPageToken: string | null;
+}
+
+export interface GooglePeopleListContactsInput extends GoogleAccountRef {
+  maxResults?: number;
+  pageToken?: string;
+}
+
+export interface GooglePeopleSearchContactsInput extends GoogleAccountRef {
+  query: string;
+  maxResults?: number;
+  /** Include interaction-derived "Other Contacts" in the search (default true). */
+  includeOtherContacts?: boolean;
+}
+
+export interface GooglePeopleGetContactInput extends GoogleAccountRef {
+  resourceName: string;
+}
+
 export interface GoogleDocContent {
   title: string;
   plainText: string;
@@ -860,6 +912,12 @@ export interface IGoogleDriveService extends Service {
   ): Promise<GoogleSheetUpdateResult>;
 }
 
+export interface IGooglePeopleService extends Service {
+  listContacts(params: GooglePeopleListContactsInput): Promise<GooglePeopleContactPage>;
+  searchContacts(params: GooglePeopleSearchContactsInput): Promise<GooglePersonContact[]>;
+  getContact(params: GooglePeopleGetContactInput): Promise<GooglePersonContact>;
+}
+
 export interface IGoogleMeetService extends Service {
   createMeeting(params: GoogleMeetCreateMeetingInput): Promise<GoogleMeetMeeting>;
   getMeeting(params: GoogleMeetGetMeetingInput): Promise<GoogleMeetMeeting>;
@@ -885,7 +943,8 @@ export interface IGoogleWorkspaceService
   extends IGoogleGmailService,
     IGoogleCalendarService,
     IGoogleDriveService,
-    IGoogleMeetService {
+    IGoogleMeetService,
+    IGooglePeopleService {
   getOAuthProviderConfig(capabilities: readonly GoogleCapability[]): GoogleOAuthProviderConfig;
   getOAuthProviderMetadata(): GoogleOAuthProviderMetadata;
 }


### PR DESCRIPTION
Fixes #19897

## What

Closes the concrete gap named in [integrations 4.1]: the Google Workspace plugin covered Gmail, Calendar, Drive, and Meet but had **no People (Contacts) capability**. This PR maps Google People into the plugin-first managed-capability model used by the other four domains:

- **`people.read` capability** in the canonical capability catalog (`src/scopes.ts`), deriving least-privilege scopes `contacts.readonly` + `contacts.other.readonly`; scope escalation stays incremental via the existing per-capability grant flow.
- **`GooglePeopleClient`** (`src/people.ts`): `listContacts` (page-based with opaque `nextPageToken` replay, Drive-style), `searchContacts` (dual-source: saved Contacts + interaction-derived Other Contacts, with the People API's documented empty-query warmup request, page size clamped to the API max of 30), `getContact` (by `resourceName`, tags `otherContacts/…` records as interaction-derived).
- **Fail-fast malformed-data handling**: a person record without a `resourceName` throws `ElizaError` `GOOGLE_PEOPLE_MALFORMED_PERSON` instead of fabricating a healthy-looking contact; empty search queries throw `GOOGLE_PEOPLE_SEARCH_QUERY_EMPTY` before touching the API.
- **Wiring**: People API client in `GoogleApiClientFactory` (honors `ELIZA_MOCK_GOOGLE_BASE`), `IGooglePeopleService` in the workspace service contract, service delegation, connector purpose mapping (`people` group → `contacts` purpose), shared connector-account catalog entry so the generic Connections UI renders the new grant, and plugin CLAUDE.md/AGENTS.md docs (byte-identical).

Credential resolution, Cloud-managed vs local BYO token custody, kill switch, and OAuth state/refresh/revoke all flow through the plugin's existing consolidated-grant machinery unchanged — the new capability rides the same `GoogleCredentialResolver`/`ConnectorAccountManager` path as Gmail/Calendar/Drive/Meet.

## Tests

- New deterministic contract suite `src/people.test.ts` (14 tests): success mapping (primary-name/email selection, clean collections), designed-empty page, opaque page-token replay, malformed-person rejection, auth-failure propagation, empty-query rejection, warmup-request ordering for both sources, source tagging/merge, Other-Contacts opt-out, search page-size clamp, scope derivation.
- `bun run --cwd plugins/plugin-google-workspace test`: 23 files / 257 tests passed.
- `bun run --cwd packages/shared test`: 159 files / 2076 tests passed.
- Plugin + shared typecheck and biome lint clean; `bun run check:agents-claude` passes; root `bun run verify` run recorded in the thread.

## Human-only remainder

Live-account evidence (real Google OAuth client + a consented account exercising `people.read` against the production People API) requires human-held Google Cloud Console credentials and a real Google account; the deterministic protocol-faithful harness covers the contract in CI, and `ELIZA_MOCK_GOOGLE_BASE` supports a local mock server for end-to-end rehearsal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Exact-head repair validation

Exact head: `aa32c4f640f2d66e487fe00673d9a05970046049`

- Corrected `getContact` to accept only canonical `people/{personId}` resource names; `otherContacts/*` now fails with `GOOGLE_PEOPLE_RESOURCE_NAME_INVALID` before auth or HTTP because Google exposes no `otherContacts.get` endpoint.
- Added an installed-googleapis loopback boundary test proving the exact `/v1/people/{personId}` request path and zero credential/network work for invalid resource families.
- Focused People suites: 20/20 passed; plugin typecheck, changed-file Biome, guide parity, and diff check passed.
- Live-account OAuth/People evidence still requires operator-held Google credentials and remains the only readiness blocker.

## Contribution provenance (repair)

<!-- contribution-attribution:v1 -->
- AI assistance: `yes`
- Model used: `openai/gpt-5.6-sol`
- Agent tooling: `Codex Desktop`
- Provenance status: `self-reported`
