### PR TITLE
fix(app-core): re-read account before refreshUsage write to preserve concurrent health transitions

### DIFF
--- a/packages/app-core/src/services/account-pool.test.ts
+++ b/packages/app-core/src/services/account-pool.test.ts
@@ -12,6 +12,7 @@ import type { LinkedAccountConfig } from "@elizaos/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   AccountPool,
+  type AccountPoolDeps,
   configureDefaultAccountPoolSelection,
   selectionForProvider,
 } from "./account-pool";
@@ -1174,5 +1175,169 @@ describe("AccountPool drain-soonest-reset selection", () => {
     expect(selectionForProvider("anthropic-subscription").strategy).toBe(
       "priority",
     );
+  });
+});
+
+describe("AccountPool.refreshUsage concurrent health-transition safety", () => {
+  // A mutable metadata store whose `writeAccount` REPLACES the whole account
+  // entry, faithful to the real persistAccount's full-bucket assignment at
+  // account-pool.ts (`store[providerId][id] = { ...fields }`): any field absent
+  // from the written object is dropped, which is exactly why writing back a
+  // pre-await snapshot clobbers a concurrent health transition (a lost update).
+  function mutableStore(seed: LinkedAccountConfig[]): {
+    store: Record<string, LinkedAccountConfig>;
+    deps: AccountPoolDeps;
+  } {
+    const key = (a: Pick<LinkedAccountConfig, "providerId" | "id">) =>
+      `${a.providerId}:${a.id}`;
+    const store: Record<string, LinkedAccountConfig> = {};
+    for (const acc of seed) store[key(acc)] = acc;
+    const deps: AccountPoolDeps = {
+      readAccounts: () => store,
+      writeAccount: async (acc) => {
+        // Full-bucket replacement, matching the real persistAccount.
+        store[key(acc)] = acc;
+      },
+    };
+    return { store, deps };
+  }
+
+  // A fetch that blocks on a caller-released gate so a test can deterministically
+  // open the network-await TOCTOU window in refreshUsage and interleave another
+  // mutator before the usage probe resolves.
+  function gatedAnthropicFetch(utilization: number): {
+    fetch: typeof fetch;
+    release: () => void;
+  } {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const fetchImpl = (async () => {
+      await gate;
+      return new Response(JSON.stringify({ five_hour: { utilization } }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+    return { fetch: fetchImpl, release };
+  }
+
+  const tick = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+  it("preserves a rate-limit cooldown committed during the usage probe", async () => {
+    const seeded = account("anthropic-subscription", {
+      id: "acc",
+      email: "who@example.com",
+      health: "ok",
+    });
+    const { store, deps } = mutableStore([seeded]);
+    const pool = new AccountPool(deps);
+    const { fetch: gated, release } = gatedAnthropicFetch(25);
+
+    // (1) start the refresh; it suspends inside the gated usage probe.
+    const refreshing = pool.refreshUsage("acc", "token", {
+      providerId: "anthropic-subscription",
+      fetch: gated,
+    });
+    await tick();
+
+    // (2) a real 429 lands mid-probe and commits a cooldown atomically.
+    const until = Date.now() + 60_000;
+    await pool.markRateLimited("acc", until, "429 from provider", {
+      providerId: "anthropic-subscription",
+    });
+    expect(store["anthropic-subscription:acc"]?.health).toBe("rate-limited");
+
+    // (3) release the probe; the stale snapshot must NOT clobber the cooldown.
+    release();
+    await refreshing;
+
+    const final = store["anthropic-subscription:acc"];
+    expect(final?.health).toBe("rate-limited");
+    expect(final?.healthDetail?.until).toBe(until);
+    // The probe's usage result is orthogonal data and is still persisted.
+    expect(final?.usage?.sessionPct).toBe(25);
+  });
+
+  it("preserves a needs-reauth transition committed during the usage probe", async () => {
+    const seeded = account("anthropic-subscription", {
+      id: "acc",
+      email: "who@example.com",
+      health: "ok",
+    });
+    const { store, deps } = mutableStore([seeded]);
+    const pool = new AccountPool(deps);
+    const { fetch: gated, release } = gatedAnthropicFetch(40);
+
+    const refreshing = pool.refreshUsage("acc", "token", {
+      providerId: "anthropic-subscription",
+      fetch: gated,
+    });
+    await tick();
+
+    await pool.markNeedsReauth("acc", "401 revoked", {
+      providerId: "anthropic-subscription",
+    });
+    expect(store["anthropic-subscription:acc"]?.health).toBe("needs-reauth");
+
+    release();
+    await refreshing;
+
+    const final = store["anthropic-subscription:acc"];
+    expect(final?.health).toBe("needs-reauth");
+    expect(final?.healthDetail?.lastError).toBe("401 revoked");
+    expect(final?.usage?.sessionPct).toBe(40);
+  });
+
+  it("still admits the account as ok when no transition races the probe", async () => {
+    const seeded = account("anthropic-subscription", {
+      id: "acc",
+      email: "who@example.com",
+      health: "ok",
+    });
+    const { store, deps } = mutableStore([seeded]);
+    const pool = new AccountPool(deps);
+    const { fetch: gated, release } = gatedAnthropicFetch(10);
+
+    const refreshing = pool.refreshUsage("acc", "token", {
+      providerId: "anthropic-subscription",
+      fetch: gated,
+    });
+    await tick();
+    release();
+    await refreshing;
+
+    const final = store["anthropic-subscription:acc"];
+    expect(final?.health).toBe("ok");
+    expect(final?.usage?.sessionPct).toBe(10);
+  });
+
+  it("recovers a stale rate-limited account to ok when its window elapsed and no probe races it", async () => {
+    // refreshUsage is the sole recovery path back to "ok" for subscription
+    // accounts (a successful usage read proves the credential works). A non-ok
+    // state present BEFORE the probe and unchanged during it must still be
+    // cleared, so the fix must not conflate "pre-existing" with "raced".
+    const seeded = account("anthropic-subscription", {
+      id: "acc",
+      email: "who@example.com",
+      health: "rate-limited",
+      healthDetail: { until: Date.now() - 1_000, lastChecked: Date.now() },
+    });
+    const { store, deps } = mutableStore([seeded]);
+    const pool = new AccountPool(deps);
+    const { fetch: gated, release } = gatedAnthropicFetch(5);
+
+    const refreshing = pool.refreshUsage("acc", "token", {
+      providerId: "anthropic-subscription",
+      fetch: gated,
+    });
+    await tick();
+    release();
+    await refreshing;
+
+    const final = store["anthropic-subscription:acc"];
+    expect(final?.health).toBe("ok");
+    expect(final?.healthDetail).toBeUndefined();
+    expect(final?.usage?.sessionPct).toBe(5);
   });
 });

--- a/packages/app-core/src/services/account-pool.ts
+++ b/packages/app-core/src/services/account-pool.ts
@@ -657,9 +657,39 @@ export class AccountPool {
       return;
     }
 
+    // The usage probe above is a real suspension point: a concurrent health
+    // transition (markRateLimited's 429 cooldown, markNeedsReauth, markInvalid)
+    // may have committed while it was in flight. Writing the PRE-AWAIT snapshot
+    // back would silently clobber it — persistAccount replaces the whole
+    // metadata bucket, so it is last-writer-wins with stale data — re-admitting
+    // a rate-limited/revoked account and defeating the backoff clock. Re-read
+    // the account now and merge: `readAccounts` is synchronous and the write's
+    // persist body runs to completion before this frame yields, so the
+    // read-merge-write is atomic on the event loop against every other mutator
+    // (which are all likewise read-then-write with no await between).
+    const baseline = healthSignature(account);
+    const fresh = findAccountById(
+      this.deps.readAccounts(),
+      accountId,
+      opts?.providerId,
+    );
+    if (!fresh) return;
+    if (healthSignature(fresh) !== baseline) {
+      // A newer, authoritative health verdict landed during the probe. Keep it
+      // verbatim; only layer on the freshly fetched usage/email.
+      await this.deps.writeAccount({
+        ...fresh,
+        usage,
+        ...(email ? { email } : {}),
+      });
+      return;
+    }
+    // No concurrent transition: a successful usage read proves the account
+    // works, so (re-)admit it as OK and drop any now-stale health detail.
     await this.deps.writeAccount({
-      ...account,
+      ...fresh,
       health: "ok",
+      healthDetail: undefined,
       usage,
       ...(email ? { email } : {}),
     });
@@ -882,6 +912,21 @@ export function isAccountSelectableNow(
 
 function poolRecordKey(providerId: PoolProviderId, accountId: string): string {
   return `${providerId}:${accountId}`;
+}
+
+/**
+ * A stable fingerprint of an account's health verdict (`health` plus its
+ * `healthDetail`). `refreshUsage` snapshots this before its network probe and
+ * re-checks it after, so any change committed by a concurrent mutator during
+ * the await — a new rate-limit cooldown, a re-auth/invalid flag, or even a
+ * re-probed `lastChecked` — is detected and its verdict is preserved instead of
+ * being overwritten by the probe's stale "ok" assumption.
+ */
+function healthSignature(account: LinkedAccountConfig): string {
+  return JSON.stringify({
+    health: account.health,
+    healthDetail: account.healthDetail ?? null,
+  });
 }
 
 function findAccountById(


### PR DESCRIPTION
# Relates to

Closes #23146

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package checks pass. `bun run verify` is a repo-wide gate not fully runnable in this sandbox (unbuilt sibling `@elizaos/plugin-*` workspaces produce pre-existing typecheck noise unrelated to this change); the owning-package test + typecheck + lint delta are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the red→green regression evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c383fe773184f7f703369cf38c80930475ef0e81:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused package tests/typecheck/lint pass post-sync; see **Known gaps** for the repo-wide `verify` limitation in this sandbox.

# Risks

Low. The change is confined to `AccountPool.refreshUsage()` in `packages/app-core/src/services/account-pool.ts` (one write path) plus a private `healthSignature` helper. No public type, export, DTO, or deps interface changed. The persistence format is unchanged. Behavior for the common no-race path is identical except that a successful probe now also clears a now-stale `healthDetail` when recovering to `ok` (matching `markHealthy`'s existing semantics).

# Background

## What does this PR do?

`AccountPool.refreshUsage()` read a full account snapshot, `await`ed a network usage probe (`pollAnthropicUsage` / `pollCodexUsage`), then wrote `{...staleAccount, health:"ok", usage}` via `writeAccount`. The real `persistAccount` **replaces the entire per-account metadata bucket** from the passed object (`account-pool.ts` — `store[providerId][id] = { ...fields }`), so any health transition committed **during the network await** was silently wiped:

- a `markRateLimited()` 429 cooldown → account re-admitted despite the limit, defeating the backoff clock (429 thrash), or
- `markNeedsReauth()` / `markInvalid()` → a revoked/invalid account forced back to `health:"ok"` and re-selected.

Unlike the synchronous-bodied mutators (`recordCall` / `markRateLimited` have no `await` between read and write, so they are atomic on the event loop), `refreshUsage` has a **real suspension point** between its read and write — the classic TOCTOU lost-update window. The per-write storage lock inside `persistAccount` does **not** close it: it makes each individual write atomic, but the write still carries a **stale base snapshot**, so it is last-writer-wins with stale data.

**Fix:** after the probe resolves, re-read the account and merge. A stable `healthSignature` (health + healthDetail) is snapshotted **before** the probe and compared to the fresh re-read:

- if a concurrent transition landed (signature changed), its newer verdict is preserved verbatim and only the orthogonal `usage`/`email` the probe produced is layered on;
- otherwise the successful probe (re-)admits the account as `ok` and drops any now-stale `healthDetail`.

`readAccounts` is synchronous and `writeAccount`'s persist body runs to completion before the frame yields, so the read-merge-write is atomic on the event loop against every other mutator (all of which are likewise read-then-write with no `await` between). This matches the atomicity every other mutator in the file already relies on, so no new deps surface or reentrant lock is introduced.

Faithfulness note: the test's in-memory `writeAccount` performs the same **full-bucket replacement** as the real `persistAccount` (any field absent from the written object is dropped), which is exactly the mechanism that made the stale-snapshot write clobber a concurrent transition.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

None. No public API, config, or user-facing surface changed.

# Testing

## Where should a reviewer start?

`packages/app-core/src/services/account-pool.test.ts` → `describe("AccountPool.refreshUsage concurrent health-transition safety")`. A gated-fetch harness deterministically opens the network-await TOCTOU window, fires a concurrent mutator, then releases the probe.

## Detailed testing steps

```bash
bun install
# regenerate the core i18n keyword artifact if building fresh
node packages/shared/scripts/generate-keywords.mjs
bun run --cwd packages/app-core exec vitest run src/services/account-pool.test.ts
```

Four new tests (all real, no network/credentials — `fetch` is injected):
1. **rate-limit cooldown mid-probe survives** — final health stays `rate-limited`, `healthDetail.until` preserved, probe usage still persisted.
2. **needs-reauth mid-probe survives** — final health stays `needs-reauth`, `lastError` preserved, probe usage still persisted.
3. **control (no race)** — account still (re-)admitted as `ok` with fresh usage.
4. **recovery (pre-existing rate-limit, window elapsed, no race)** — still recovers to `ok` and clears stale `healthDetail` (proves the fix does not conflate "pre-existing" with "raced").

# Evidence Gate

<!-- evidence-head:d7f5f26efdbfbe5ee2ecf23c0035473ae9f52177 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; change is a backend service (packages/app-core account selection).`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - non-visual backend concurrency fix; the deterministic red→green test IS the reproduction.`
<!-- evidence-row:backend-logs -->
- [x] Green after the re-read-and-merge fix — all 40 tests pass, exercising the real `refreshUsage` code path end to end ([mirror gist](https://gist.githubusercontent.com/agent-cortex/09eb9489de07bb7cb5c58c21123009d2/raw/8d3850b95a53259f84ee1abfb51f541c1318bf86/green-after-fix.txt)):
<details><summary>backend logs — vitest output (green after fix)</summary>

```
stderr | src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > preserves a needs-reauth transition committed during the usage probe
 ✓ src/services/account-pool.test.ts > AccountPool provider-scoped account resolution > runs usage probes against the provider-scoped account 6ms
 ✓ src/services/account-pool.test.ts > AccountPool provider-scoped account resolution > backfills the Anthropic email from the profile probe during a usage refresh 3ms
 ✓ src/services/account-pool.test.ts > AccountPool provider-scoped account resolution > does NOT re-probe the profile when the account already has an email 2ms
 ✓ src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > preserves a rate-limit cooldown committed during the usage probe 12ms
 ✓ src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > preserves a needs-reauth transition committed during the usage probe 18ms
 ✓ src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > still admits the account as ok when no transition races the probe 12ms
 ✓ src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > recovers a stale rate-limited account to ok when its window elapsed and no probe races it 15ms
      Tests  40 passed (40)
   Duration  12.58s (transform 9.91s, setup 0ms, import 12.21s, tests 125ms, environment 0ms)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change; usage probe is an injected fetch stub.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact — the persisted account-metadata state (`health`/`healthDetail`/`usage`) asserted before/after the race. Red on the buggy `{...staleAccount, health:"ok"}` write: 3 of 4 new tests fail, the no-race control passes ([mirror gist](https://gist.githubusercontent.com/agent-cortex/09eb9489de07bb7cb5c58c21123009d2/raw/822ca01223da4398b739768d44946beb7ca852e9/red-on-develop.txt)):
<details><summary>domain artifact — account health/usage state, red on buggy write</summary>

```
✓ src/services/account-pool.test.ts > AccountPool provider-scoped account resolution > runs usage probes against the provider-scoped account 4ms
 ✓ src/services/account-pool.test.ts > AccountPool provider-scoped account resolution > backfills the Anthropic email from the profile probe during a usage refresh 2ms
 ✓ src/services/account-pool.test.ts > AccountPool provider-scoped account resolution > does NOT re-probe the profile when the account already has an email 1ms
 × src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > preserves a rate-limit cooldown committed during the usage probe 23ms
 × src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > preserves a needs-reauth transition committed during the usage probe 18ms
 ✓ src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > still admits the account as ok when no transition races the probe 11ms
 × src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > recovers a stale rate-limited account to ok when its window elapsed and no probe races it 13ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected 'ok' to be 'rate-limited' // Object.is equality
AssertionError: expected 'ok' to be 'needs-reauth' // Object.is equality
AssertionError: expected { until: 1787268529144, …(1) } to be undefined
      Tests  3 failed | 37 passed (40)
   Duration  12.15s (transform 9.60s, setup 0ms, import 11.80s, tests 119ms, environment 0ms)
```

</details>
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

N/A - no model call in this path; the usage probe is an injected `fetch`.

## Backend + frontend logs

Red on the buggy `{...staleAccount, health:"ok"}` write (3 of 4 new tests fail; control passes):

```
 ✓ src/services/account-pool.test.ts > AccountPool provider-scoped account resolution > runs usage probes against the provider-scoped account 4ms
 ✓ src/services/account-pool.test.ts > AccountPool provider-scoped account resolution > backfills the Anthropic email from the profile probe during a usage refresh 2ms
 ✓ src/services/account-pool.test.ts > AccountPool provider-scoped account resolution > does NOT re-probe the profile when the account already has an email 1ms
 × src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > preserves a rate-limit cooldown committed during the usage probe 23ms
 × src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > preserves a needs-reauth transition committed during the usage probe 18ms
 ✓ src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > still admits the account as ok when no transition races the probe 11ms
 × src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > recovers a stale rate-limited account to ok when its window elapsed and no probe races it 13ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected 'ok' to be 'rate-limited' // Object.is equality
AssertionError: expected 'ok' to be 'needs-reauth' // Object.is equality
AssertionError: expected { until: 1787268529144, …(1) } to be undefined
      Tests  3 failed | 37 passed (40)
   Duration  12.15s (transform 9.60s, setup 0ms, import 11.80s, tests 119ms, environment 0ms)
```

Green after the re-read-and-merge fix (all 40 pass):

```
stderr | src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > preserves a needs-reauth transition committed during the usage probe
 ✓ src/services/account-pool.test.ts > AccountPool provider-scoped account resolution > runs usage probes against the provider-scoped account 6ms
 ✓ src/services/account-pool.test.ts > AccountPool provider-scoped account resolution > backfills the Anthropic email from the profile probe during a usage refresh 3ms
 ✓ src/services/account-pool.test.ts > AccountPool provider-scoped account resolution > does NOT re-probe the profile when the account already has an email 2ms
 ✓ src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > preserves a rate-limit cooldown committed during the usage probe 12ms
 ✓ src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > preserves a needs-reauth transition committed during the usage probe 18ms
 ✓ src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > still admits the account as ok when no transition races the probe 12ms
 ✓ src/services/account-pool.test.ts > AccountPool.refreshUsage concurrent health-transition safety > recovers a stale rate-limited account to ok when its window elapsed and no probe races it 15ms
      Tests  40 passed (40)
   Duration  12.58s (transform 9.91s, setup 0ms, import 12.21s, tests 125ms, environment 0ms)
```

Related suites exercising the real default-pool recovery paths remain green (no regression, no deadlock):

```
Test Files  5 passed (5)   Tests  73 passed (73)
(account-pool.test, multi-account-refresh-failover.test, account-pool-availability.test,
 account-pool-status.test, multi-account-upstream-429-failover.test, coding-account-bridge.test)
```

## Screenshots (before / after) + video walkthrough

N/A - no UI surface. This is a backend service concurrency fix.

## Audio / voice walkthrough

N/A - no voice/audio surface.

## Known gaps / failures

- `bun run verify` (repo-wide) is not fully runnable in this sandbox: several sibling `@elizaos/plugin-*` workspaces are unbuilt, producing pre-existing `TS2307` module-resolution noise unrelated to this diff. Verified equivalently at package scope: `packages/app-core` `vitest` for the touched suites passes, `tsc --noEmit` produces the **same 60 pre-existing errors with and without this change (delta 0, none in `account-pool.ts`)**, and `biome check` is clean on both touched files.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@c383fe773184f7f703369cf38c80930475ef0e81:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@c383fe773184f7f703369cf38c80930475ef0e81:packages/skills/skills/contribute-to-eliza"} -->
