### PR TITLE
feat(calendar): extend Microsoft Graph connector to multi-domain incremental managed capabilities

### DIFF
--- a/packages/shared/src/contracts/personal-assistant.ts
+++ b/packages/shared/src/contracts/personal-assistant.ts
@@ -323,6 +323,11 @@ export const LIFEOPS_MICROSOFT_CAPABILITIES = [
   "microsoft.calendar.read",
   "microsoft.calendar.freebusy",
   "microsoft.calendar.write",
+  "microsoft.mail.triage",
+  "microsoft.mail.send",
+  "microsoft.mail.manage",
+  "microsoft.contacts.read",
+  "microsoft.files.read",
 ] as const;
 export type LifeOpsMicrosoftCapability =
   (typeof LIFEOPS_MICROSOFT_CAPABILITIES)[number];

--- a/plugins/plugin-calendar/src/microsoft/accounts.capabilities.test.ts
+++ b/plugins/plugin-calendar/src/microsoft/accounts.capabilities.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Deterministic mapping coverage for granted Microsoft Graph scopes onto the
+ * normalized multi-domain capability catalog. Pure-function tests; no network
+ * or storage involved.
+ */
+
+import { describe, expect, it } from "vitest";
+import { capabilitiesForScopes } from "./accounts.js";
+
+describe("capabilitiesForScopes", () => {
+  it("derives identity and calendar capabilities as before", () => {
+    expect(
+      new Set(
+        capabilitiesForScopes(["openid", "User.Read", "Calendars.ReadWrite"]),
+      ),
+    ).toEqual(
+      new Set([
+        "microsoft.basic_identity",
+        "microsoft.calendar.read_basic",
+        "microsoft.calendar.freebusy",
+        "microsoft.calendar.read",
+        "microsoft.calendar.write",
+      ]),
+    );
+  });
+
+  it("derives mail triage from read and manage from readwrite grants", () => {
+    expect(capabilitiesForScopes(["Mail.Read"])).toEqual([
+      "microsoft.mail.triage",
+    ]);
+    expect(new Set(capabilitiesForScopes(["Mail.ReadWrite.Shared"]))).toEqual(
+      new Set(["microsoft.mail.triage", "microsoft.mail.manage"]),
+    );
+    expect(capabilitiesForScopes(["Mail.Send"])).toEqual([
+      "microsoft.mail.send",
+    ]);
+  });
+
+  it("derives contacts and files read capabilities including write grants", () => {
+    expect(capabilitiesForScopes(["Contacts.ReadWrite"])).toEqual([
+      "microsoft.contacts.read",
+    ]);
+    expect(capabilitiesForScopes(["Files.Read.All"])).toEqual([
+      "microsoft.files.read",
+    ]);
+    expect(
+      capabilitiesForScopes(["https://graph.microsoft.com/Files.ReadWrite"]),
+    ).toEqual(["microsoft.files.read"]);
+  });
+
+  it("yields no capability for unknown or empty scope input", () => {
+    expect(capabilitiesForScopes([])).toEqual([]);
+    expect(capabilitiesForScopes(["Sites.Read.All", "not-a-scope"])).toEqual(
+      [],
+    );
+  });
+});

--- a/plugins/plugin-calendar/src/microsoft/accounts.ts
+++ b/plugins/plugin-calendar/src/microsoft/accounts.ts
@@ -159,7 +159,13 @@ function normalizedScopeName(scope: string): string {
   return lastPathSegment.trim().toLowerCase();
 }
 
-function capabilitiesForScopes(
+/**
+ * Maps granted Microsoft Graph scopes onto the normalized capability catalog
+ * shared across the calendar, mail, contacts, and files domains. Consumed by
+ * grant derivation and exported so domain plugins and tests can reason about
+ * an account's effective capabilities without reparsing scope strings.
+ */
+export function capabilitiesForScopes(
   scopes: readonly string[],
 ): LifeOpsMicrosoftCapability[] {
   const normalized = new Set(scopes.map(normalizedScopeName));
@@ -192,6 +198,35 @@ function capabilitiesForScopes(
   }
   if (hasRead) capabilities.add("microsoft.calendar.read");
   if (hasWrite) capabilities.add("microsoft.calendar.write");
+  const hasMailManage =
+    normalized.has("mail.readwrite") || normalized.has("mail.readwrite.shared");
+  if (
+    hasMailManage ||
+    normalized.has("mail.read") ||
+    normalized.has("mail.read.shared")
+  ) {
+    capabilities.add("microsoft.mail.triage");
+  }
+  if (hasMailManage) capabilities.add("microsoft.mail.manage");
+  if (normalized.has("mail.send") || normalized.has("mail.send.shared")) {
+    capabilities.add("microsoft.mail.send");
+  }
+  if (
+    normalized.has("contacts.read") ||
+    normalized.has("contacts.read.shared") ||
+    normalized.has("contacts.readwrite") ||
+    normalized.has("contacts.readwrite.shared")
+  ) {
+    capabilities.add("microsoft.contacts.read");
+  }
+  if (
+    normalized.has("files.read") ||
+    normalized.has("files.read.all") ||
+    normalized.has("files.readwrite") ||
+    normalized.has("files.readwrite.all")
+  ) {
+    capabilities.add("microsoft.files.read");
+  }
   return [...capabilities];
 }
 

--- a/plugins/plugin-calendar/src/microsoft/connector-account-provider.test.ts
+++ b/plugins/plugin-calendar/src/microsoft/connector-account-provider.test.ts
@@ -667,3 +667,224 @@ describe("Microsoft connector account provider", () => {
     ).rejects.toBeInstanceOf(ElizaError);
   });
 });
+
+async function startFlowWith(harness: Harness, scopes: string[]) {
+  const flow = await harness.manager.startOAuth("microsoft", {
+    scopes,
+    metadata: { requestedRole: "OWNER" },
+  });
+  const metadata = flow.metadata as Record<string, unknown>;
+  harness.setReturnedNonce(String(metadata.nonce));
+  return flow;
+}
+
+describe("Microsoft Graph multi-domain incremental scopes", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["microsoft.mail.triage", ["Mail.Read"]],
+    ["Mail.Read", ["Mail.Read"]],
+    ["microsoft.mail.manage", ["Mail.ReadWrite"]],
+    ["microsoft.mail.send", ["Mail.Send"]],
+    ["microsoft.contacts.read", ["Contacts.Read"]],
+    ["Contacts.Read", ["Contacts.Read"]],
+    ["microsoft.files.read", ["Files.Read"]],
+  ] as const)(
+    "requests identity plus only the %s permission and never a calendar scope",
+    async (capability, expectedScopes) => {
+      const harness = createHarness();
+      const provider = createMicrosoftConnectorAccountProvider(harness.runtime);
+      const started = await provider.startOAuth?.(
+        {
+          provider: "microsoft",
+          flow: unsignedFlow(),
+          scopes: [capability],
+        },
+        harness.manager,
+      );
+      const url = new URL(started?.authUrl ?? "");
+      const scopes = new Set(
+        (url.searchParams.get("scope") ?? "").split(" ").filter(Boolean),
+      );
+
+      expect(scopes).toEqual(
+        new Set([
+          "openid",
+          "profile",
+          "email",
+          "offline_access",
+          "User.Read",
+          ...expectedScopes,
+        ]),
+      );
+      expect([...scopes].some((scope) => scope.startsWith("Calendars."))).toBe(
+        false,
+      );
+    },
+  );
+
+  it("composes one consent request across calendar, mail, contacts, and files", async () => {
+    const harness = createHarness();
+    const provider = createMicrosoftConnectorAccountProvider(harness.runtime);
+    const started = await provider.startOAuth?.(
+      {
+        provider: "microsoft",
+        flow: unsignedFlow(),
+        scopes: [
+          "microsoft.calendar.read",
+          "microsoft.mail.manage",
+          "microsoft.mail.send",
+          "microsoft.contacts.read",
+          "microsoft.files.read",
+        ],
+      },
+      harness.manager,
+    );
+    const scopes = new Set(
+      (new URL(started?.authUrl ?? "").searchParams.get("scope") ?? "")
+        .split(" ")
+        .filter(Boolean),
+    );
+
+    expect(scopes).toEqual(
+      new Set([
+        "openid",
+        "profile",
+        "email",
+        "offline_access",
+        "User.Read",
+        "Calendars.Read",
+        "Mail.ReadWrite",
+        "Mail.Send",
+        "Contacts.Read",
+        "Files.Read",
+      ]),
+    );
+  });
+
+  it("still rejects scopes outside the supported Graph capability catalog", async () => {
+    const harness = createHarness();
+    const provider = createMicrosoftConnectorAccountProvider(harness.runtime);
+
+    for (const scope of ["Files.ReadWrite.All", "Mail.ReadWrite.Shared"]) {
+      await expect(
+        provider.startOAuth?.(
+          {
+            provider: "microsoft",
+            flow: unsignedFlow(),
+            scopes: [scope],
+          },
+          harness.manager,
+        ),
+      ).rejects.toMatchObject({ code: "MICROSOFT_OAUTH_SCOPE_UNRECOGNIZED" });
+    }
+  });
+
+  it("rejects a broader mail grant than the requested triage privilege", async () => {
+    const harness = createHarness({
+      returnedScope: "openid profile email User.Read Mail.ReadWrite",
+    });
+    const flow = await startFlowWith(harness, ["microsoft.mail.triage"]);
+
+    await expect(
+      harness.manager.completeOAuth("microsoft", {
+        state: flow.state,
+        code: "authorization-code",
+        query: { state: flow.state },
+      }),
+    ).rejects.toMatchObject({
+      code: "CONNECTOR_OAUTH_COMPLETION_FAILED",
+      cause: expect.objectContaining({
+        code: "MICROSOFT_OAUTH_SCOPE_ESCALATION",
+      }),
+    });
+    expect(await harness.storage.listAccounts("microsoft")).toEqual([]);
+    expect(harness.vault.size).toBe(0);
+  });
+
+  it("rejects an unrequested cross-domain grant on a calendar-only flow", async () => {
+    const harness = createHarness({
+      returnedScope:
+        "openid profile email User.Read Calendars.Read Contacts.Read",
+    });
+    const flow = await startFlowWith(harness, ["microsoft.calendar.read"]);
+
+    await expect(
+      harness.manager.completeOAuth("microsoft", {
+        state: flow.state,
+        code: "authorization-code",
+        query: { state: flow.state },
+      }),
+    ).rejects.toMatchObject({
+      code: "CONNECTOR_OAUTH_COMPLETION_FAILED",
+      cause: expect.objectContaining({
+        code: "MICROSOFT_OAUTH_SCOPE_ESCALATION",
+      }),
+    });
+    expect(harness.vault.size).toBe(0);
+  });
+
+  it("rejects a completion whose token grant dropped a requested domain", async () => {
+    const harness = createHarness({
+      returnedScope: "openid profile email User.Read Mail.Read",
+    });
+    const flow = await startFlowWith(harness, [
+      "microsoft.mail.triage",
+      "microsoft.contacts.read",
+    ]);
+
+    await expect(
+      harness.manager.completeOAuth("microsoft", {
+        state: flow.state,
+        code: "authorization-code",
+        query: { state: flow.state },
+      }),
+    ).rejects.toMatchObject({
+      code: "CONNECTOR_OAUTH_COMPLETION_FAILED",
+      cause: expect.objectContaining({
+        code: "MICROSOFT_OAUTH_GRANTED_SCOPE_MISSING",
+      }),
+    });
+    expect(harness.vault.size).toBe(0);
+  });
+
+  it("connects a mail-only account without any calendar grant", async () => {
+    const harness = createHarness({
+      returnedScope: "openid profile email User.Read Mail.Read Mail.Send",
+    });
+    const flow = await startFlowWith(harness, [
+      "microsoft.mail.triage",
+      "microsoft.mail.send",
+    ]);
+    const result = await harness.manager.completeOAuth("microsoft", {
+      state: flow.state,
+      code: "authorization-code",
+      query: { state: flow.state },
+    });
+
+    expect(result.flow.status).toBe("completed");
+    expect(result.account).toMatchObject({
+      provider: "microsoft",
+      status: "connected",
+      externalId: `${TENANT_ID}:${OBJECT_ID}`,
+    });
+    expect(result.account?.metadata).toMatchObject({
+      grantedScopes: [
+        "openid",
+        "profile",
+        "email",
+        "User.Read",
+        "Mail.Read",
+        "Mail.Send",
+      ],
+      hasRefreshToken: true,
+    });
+    expect(harness.vault.size).toBe(1);
+    const secret = JSON.parse([...harness.vault.values()][0] ?? "{}");
+    expect(secret.scope).toBe(
+      "openid profile email User.Read Mail.Read Mail.Send",
+    );
+  });
+});

--- a/plugins/plugin-calendar/src/microsoft/connector-account-provider.ts
+++ b/plugins/plugin-calendar/src/microsoft/connector-account-provider.ts
@@ -1,7 +1,9 @@
 /**
- * Connects delegated Microsoft calendar accounts through the runtime's shared
- * connector-account OAuth boundary. Authorization uses PKCE, state, and a
- * signed nonce-bearing ID token; account identity comes from Microsoft Graph.
+ * Connects delegated Microsoft Graph accounts (calendar, Outlook mail,
+ * contacts, and files capabilities with incremental consent) through the
+ * runtime's shared connector-account OAuth boundary. Authorization uses PKCE,
+ * state, and a signed nonce-bearing ID token; account identity comes from
+ * Microsoft Graph.
  * Token material is committed only to a durable secret backend and represented
  * in account storage by credential references.
  */
@@ -50,11 +52,16 @@ const MICROSOFT_IDENTITY_SCOPES = [
   "offline_access",
   "User.Read",
 ] as const;
-const MICROSOFT_CALENDAR_CAPABILITIES = [
+const MICROSOFT_CONNECTOR_CAPABILITIES = [
   "microsoft.calendar.read_basic",
   "microsoft.calendar.read",
   "microsoft.calendar.freebusy",
   "microsoft.calendar.write",
+  "microsoft.mail.triage",
+  "microsoft.mail.send",
+  "microsoft.mail.manage",
+  "microsoft.contacts.read",
+  "microsoft.files.read",
 ] as const satisfies readonly LifeOpsMicrosoftCapability[];
 // Durable secret writers only. The in-memory core SECRETS service is
 // deliberately absent: tokens written there die with the process while the
@@ -74,8 +81,8 @@ const FORBIDDEN_CREDENTIAL_KEYS = new Set([
   "tokens",
 ]);
 
-type MicrosoftCalendarCapability =
-  (typeof MICROSOFT_CALENDAR_CAPABILITIES)[number];
+type MicrosoftConnectorCapability =
+  (typeof MICROSOFT_CONNECTOR_CAPABILITIES)[number];
 type JsonScalar = string | number | boolean | null;
 type JsonValue =
   | JsonScalar
@@ -302,7 +309,7 @@ function normalizedScopeName(scope: string): string {
 
 function capabilityForInput(
   value: string,
-): MicrosoftCalendarCapability | "identity" | null {
+): MicrosoftConnectorCapability | "identity" | null {
   const normalized = value.trim().toLowerCase();
   if (
     normalized === "microsoft.basic_identity" ||
@@ -312,7 +319,7 @@ function capabilityForInput(
   ) {
     return "identity";
   }
-  if (isMicrosoftCalendarCapability(normalized)) {
+  if (isMicrosoftConnectorCapability(normalized)) {
     return normalized;
   }
   switch (normalizedScopeName(normalized)) {
@@ -322,24 +329,36 @@ function capabilityForInput(
       return "microsoft.calendar.read";
     case "calendars.readwrite":
       return "microsoft.calendar.write";
+    case "mail.read":
+      return "microsoft.mail.triage";
+    case "mail.send":
+      return "microsoft.mail.send";
+    case "mail.readwrite":
+      return "microsoft.mail.manage";
+    case "contacts.read":
+      return "microsoft.contacts.read";
+    case "files.read":
+      return "microsoft.files.read";
     default:
       return null;
   }
 }
 
-function isMicrosoftCalendarCapability(
+function isMicrosoftConnectorCapability(
   value: string,
-): value is MicrosoftCalendarCapability {
-  return (MICROSOFT_CALENDAR_CAPABILITIES as readonly string[]).includes(value);
+): value is MicrosoftConnectorCapability {
+  return (MICROSOFT_CONNECTOR_CAPABILITIES as readonly string[]).includes(
+    value,
+  );
 }
 
 function normalizeRequestedCapabilities(
   requested: readonly string[] | undefined,
-): MicrosoftCalendarCapability[] {
+): MicrosoftConnectorCapability[] {
   if (!requested || requested.length === 0) {
     return ["microsoft.calendar.read"];
   }
-  const capabilities = new Set<MicrosoftCalendarCapability>();
+  const capabilities = new Set<MicrosoftConnectorCapability>();
   for (const value of requested) {
     const normalized = stringValue(value);
     const capability = normalized ? capabilityForInput(normalized) : null;
@@ -362,7 +381,7 @@ function normalizeRequestedCapabilities(
   }
   if (capabilities.size === 0) {
     throw new ElizaError(
-      "Microsoft calendar OAuth requires an explicit calendar capability.",
+      "Microsoft OAuth requires an explicit Graph capability beyond identity.",
       {
         code: "MICROSOFT_OAUTH_CALENDAR_CAPABILITY_REQUIRED",
         severity: "fatal",
@@ -373,23 +392,55 @@ function normalizeRequestedCapabilities(
 }
 
 function calendarPrivilege(
-  capabilities: readonly MicrosoftCalendarCapability[],
-): 1 | 2 | 3 {
+  capabilities: readonly MicrosoftConnectorCapability[],
+): 0 | 1 | 2 | 3 {
   if (capabilities.includes("microsoft.calendar.write")) return 3;
   if (capabilities.includes("microsoft.calendar.read")) return 2;
-  return 1;
+  if (
+    capabilities.includes("microsoft.calendar.read_basic") ||
+    capabilities.includes("microsoft.calendar.freebusy")
+  ) {
+    return 1;
+  }
+  return 0;
 }
 
+function mailReadPrivilege(
+  capabilities: readonly MicrosoftConnectorCapability[],
+): 0 | 1 | 2 {
+  if (capabilities.includes("microsoft.mail.manage")) return 2;
+  if (capabilities.includes("microsoft.mail.triage")) return 1;
+  return 0;
+}
+
+const CALENDAR_SCOPE_BY_PRIVILEGE = [
+  null,
+  "Calendars.ReadBasic",
+  "Calendars.Read",
+  "Calendars.ReadWrite",
+] as const;
+const MAIL_SCOPE_BY_PRIVILEGE = [null, "Mail.Read", "Mail.ReadWrite"] as const;
+
+/**
+ * Incremental-consent scope request: only the Graph permissions for the
+ * capabilities the caller asked for are placed on the authorization URL, so a
+ * mail-only or contacts-only connect never prompts for calendar access.
+ */
 function requestedScopes(
-  capabilities: readonly MicrosoftCalendarCapability[],
+  capabilities: readonly MicrosoftConnectorCapability[],
 ): string[] {
+  const scopes: string[] = [...MICROSOFT_IDENTITY_SCOPES];
   const calendarScope =
-    calendarPrivilege(capabilities) === 3
-      ? "Calendars.ReadWrite"
-      : calendarPrivilege(capabilities) === 2
-        ? "Calendars.Read"
-        : "Calendars.ReadBasic";
-  return [...MICROSOFT_IDENTITY_SCOPES, calendarScope];
+    CALENDAR_SCOPE_BY_PRIVILEGE[calendarPrivilege(capabilities)];
+  if (calendarScope) scopes.push(calendarScope);
+  const mailScope = MAIL_SCOPE_BY_PRIVILEGE[mailReadPrivilege(capabilities)];
+  if (mailScope) scopes.push(mailScope);
+  if (capabilities.includes("microsoft.mail.send")) scopes.push("Mail.Send");
+  if (capabilities.includes("microsoft.contacts.read")) {
+    scopes.push("Contacts.Read");
+  }
+  if (capabilities.includes("microsoft.files.read")) scopes.push("Files.Read");
+  return scopes;
 }
 
 function roleFromMetadata(metadata: unknown): ConnectorAccountRole {
@@ -591,6 +642,16 @@ function canonicalGrantedScope(scope: string): string | null {
       return "Calendars.Read";
     case "calendars.readwrite":
       return "Calendars.ReadWrite";
+    case "mail.read":
+      return "Mail.Read";
+    case "mail.send":
+      return "Mail.Send";
+    case "mail.readwrite":
+      return "Mail.ReadWrite";
+    case "contacts.read":
+      return "Contacts.Read";
+    case "files.read":
+      return "Files.Read";
     default:
       return null;
   }
@@ -598,7 +659,7 @@ function canonicalGrantedScope(scope: string): string | null {
 
 function validateGrantedScopes(args: {
   rawScope: string;
-  requestedCapabilities: readonly MicrosoftCalendarCapability[];
+  requestedCapabilities: readonly MicrosoftConnectorCapability[];
 }): string[] {
   const scopes = args.rawScope
     .split(/\s+/u)
@@ -637,34 +698,99 @@ function validateGrantedScopes(args: {
       },
     );
   }
-  const grantedPrivilege = canonical.has("Calendars.ReadWrite")
+  const assertExactPrivilege = (
+    domain: "calendar" | "mail",
+    grantedPrivilege: number,
+    requiredPrivilege: number,
+    missingCode: string,
+  ): void => {
+    if (grantedPrivilege < requiredPrivilege) {
+      throw new ElizaError(
+        `Microsoft OAuth did not grant the requested ${domain} capability.`,
+        {
+          code: missingCode,
+          context: { domain, requiredPrivilege, grantedPrivilege },
+          severity: "fatal",
+        },
+      );
+    }
+    if (grantedPrivilege > requiredPrivilege) {
+      throw new ElizaError(
+        `Microsoft OAuth returned broader ${domain} access than requested.`,
+        {
+          code: "MICROSOFT_OAUTH_SCOPE_ESCALATION",
+          context: { domain, requiredPrivilege, grantedPrivilege },
+          severity: "fatal",
+        },
+      );
+    }
+  };
+  const assertExactBooleanScope = (
+    domain: "mail.send" | "contacts" | "files",
+    scope: string,
+    requested: boolean,
+  ): void => {
+    const granted = canonical.has(scope);
+    if (requested && !granted) {
+      throw new ElizaError(
+        `Microsoft OAuth did not grant the requested ${domain} capability.`,
+        {
+          code: "MICROSOFT_OAUTH_GRANTED_SCOPE_MISSING",
+          context: { domain, scope },
+          severity: "fatal",
+        },
+      );
+    }
+    if (!requested && granted) {
+      throw new ElizaError(
+        `Microsoft OAuth returned unrequested ${domain} access.`,
+        {
+          code: "MICROSOFT_OAUTH_SCOPE_ESCALATION",
+          context: { domain, scope },
+          severity: "fatal",
+        },
+      );
+    }
+  };
+  const grantedCalendarPrivilege = canonical.has("Calendars.ReadWrite")
     ? 3
     : canonical.has("Calendars.Read")
       ? 2
       : canonical.has("Calendars.ReadBasic")
         ? 1
         : 0;
-  const requiredPrivilege = calendarPrivilege(args.requestedCapabilities);
-  if (grantedPrivilege < requiredPrivilege) {
-    throw new ElizaError(
-      "Microsoft OAuth did not grant the requested calendar capability.",
-      {
-        code: "MICROSOFT_OAUTH_CALENDAR_SCOPE_MISSING",
-        context: { requiredPrivilege, grantedPrivilege },
-        severity: "fatal",
-      },
-    );
-  }
-  if (grantedPrivilege > requiredPrivilege) {
-    throw new ElizaError(
-      "Microsoft OAuth returned broader calendar access than requested.",
-      {
-        code: "MICROSOFT_OAUTH_SCOPE_ESCALATION",
-        context: { requiredPrivilege, grantedPrivilege },
-        severity: "fatal",
-      },
-    );
-  }
+  assertExactPrivilege(
+    "calendar",
+    grantedCalendarPrivilege,
+    calendarPrivilege(args.requestedCapabilities),
+    "MICROSOFT_OAUTH_CALENDAR_SCOPE_MISSING",
+  );
+  const grantedMailPrivilege = canonical.has("Mail.ReadWrite")
+    ? 2
+    : canonical.has("Mail.Read")
+      ? 1
+      : 0;
+  assertExactPrivilege(
+    "mail",
+    grantedMailPrivilege,
+    mailReadPrivilege(args.requestedCapabilities),
+    "MICROSOFT_OAUTH_GRANTED_SCOPE_MISSING",
+  );
+  assertExactBooleanScope(
+    "mail.send",
+    "Mail.Send",
+    args.requestedCapabilities.includes("microsoft.mail.send"),
+  );
+  assertExactBooleanScope(
+    "contacts",
+    "Contacts.Read",
+    args.requestedCapabilities.includes("microsoft.contacts.read"),
+  );
+  assertExactBooleanScope(
+    "files",
+    "Files.Read",
+    args.requestedCapabilities.includes("microsoft.files.read"),
+  );
   return [...canonical];
 }
 
@@ -675,7 +801,7 @@ async function exchangeAuthorizationCode(args: {
   code: string;
   codeVerifier: string;
   scopes: readonly string[];
-  requestedCapabilities: readonly MicrosoftCalendarCapability[];
+  requestedCapabilities: readonly MicrosoftConnectorCapability[];
 }): Promise<MicrosoftTokenSet> {
   const params = new URLSearchParams({
     client_id: args.config.clientId,
@@ -1622,7 +1748,7 @@ function callbackRedirectUri(args: {
 
 function requestedCapabilitiesFromFlow(
   request: ConnectorOAuthCallbackRequest,
-): MicrosoftCalendarCapability[] {
+): MicrosoftConnectorCapability[] {
   const values = flowMetadata(request).requestedCapabilities;
   if (
     !Array.isArray(values) ||

--- a/plugins/plugin-calendar/src/microsoft/index.ts
+++ b/plugins/plugin-calendar/src/microsoft/index.ts
@@ -1,5 +1,6 @@
 /** Microsoft delegated-account resolution and Graph calendar provider port. */
 export {
+  capabilitiesForScopes as microsoftCapabilitiesForScopes,
   DefaultMicrosoftCalendarTokenResolver,
   isMicrosoftCalendarGrantId,
   listMicrosoftCalendarAccounts,


### PR DESCRIPTION
Part of #19898 (foundation only — deliberately non-closing; #19898 stays open for the Outlook mail/contacts/files data-path ports in their owning domain plugins)

## What

Migrates the Microsoft Graph integration toward plugin-first managed capabilities by extending the shared Microsoft connector-account OAuth boundary from calendar-only to the full Outlook domain set the issue names — mail, contacts, and files — with incremental consent and strict per-domain grant validation.

- `packages/shared/src/contracts/personal-assistant.ts`: the normalized Microsoft capability catalog gains `microsoft.mail.triage`, `microsoft.mail.send`, `microsoft.mail.manage`, `microsoft.contacts.read`, and `microsoft.files.read`, mirroring the Google capability naming so domain plugins select provider-neutral capabilities while deterministic code maps them to Graph permissions.
- `plugins/plugin-calendar/src/microsoft/connector-account-provider.ts`: the OAuth start path now composes an **incremental** scope request — only the Graph permissions for the capabilities the caller asked for go on the consent URL (a mail-only or contacts-only connect never prompts for calendar access, and vice versa). Completion validates granted scopes per domain and fails closed on: escalated grants (broader privilege than requested), unrequested cross-domain grants, and grants that dropped a requested domain. Unknown scopes remain rejected.
- `plugins/plugin-calendar/src/microsoft/accounts.ts`: granted-scope→capability derivation covers the new domains (including `.Shared` / `.All` Graph variants) and is exported as `microsoftCapabilitiesForScopes`, so domain plugins consume normalized `LifeOpsConnectorGrant` capabilities instead of reparsing scope strings.

Token custody is unchanged: tokens are committed only to a durable secret backend and represented by credential references; no credential material appears in metadata, logs, or tests.

## Tests

Deterministic, protocol-faithful OAuth mock coverage (locally signed ID tokens, real PKCE/state/nonce flow — the system under test is not mocked):

- per-capability incremental start scopes for mail/contacts/files, including scope-alias inputs, asserting no calendar scope is requested
- composed multi-domain consent request across calendar+mail+send+contacts+files
- rejection of out-of-catalog scopes (`Files.ReadWrite.All`, `Mail.ReadWrite.Shared`)
- completion escalation: `Mail.ReadWrite` granted when triage requested; unrequested `Contacts.Read` on a calendar-only flow — no account or secret persisted
- completion missing-grant: requested contacts domain dropped by the token grant
- successful mail-only connect with durable secret persistence and exact granted-scope metadata
- pure derivation matrix for `capabilitiesForScopes` (identity/calendar unchanged, mail read/manage/send, contacts and files including write/`.All` grants, unknown scopes yield no capability)

Results: `plugins/plugin-calendar` microsoft suites 36/36 passed; full `plugin-calendar` suite 629 passed / 4 skipped (one unrelated sandbox `ETIMEDOUT` flake passed on isolated rerun); `packages/shared` 2076/2076 passed; `plugin-calendar` typecheck clean; Biome clean on touched files.

## Remaining scope (documented, not stubbed)

- **Human-only**: Microsoft Entra app registration for the Cloud-managed client (client ID/redirect URIs, delegated `Mail.*`/`Contacts.Read`/`Files.Read` permissions, publisher verification) per the epic's Cloud provider account checklist (#19910), plus real personal-Microsoft-account OAuth evidence, which requires that registration.
- **Follow-up engineering** (tracked by the epic's domain issues): Outlook mail/contacts/files data-path ports in their owning domain plugins consuming these grants, analogous to the existing Graph calendar port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)