### PR TITLE
fix(cloud): serialize direct container deploy intents

### DIFF
--- a/packages/cloud/api/__tests__/containers-quota-race.test.ts
+++ b/packages/cloud/api/__tests__/containers-quota-race.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Drives the real container POST boundary with deterministic collaborators to
+ * prove an at-cap replica preflight still reaches primary admission and an
+ * atomic quota loser receives the canonical 402 response rather than a 500.
+ */
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import { QuotaExceededError } from "@/db/repositories/containers";
+import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
+import * as codingContainersActual from "@/lib/services/coding-containers";
+import * as containersActual from "@/lib/services/containers";
+import * as clientActual from "@/lib/services/containers/hetzner-client/client";
+import * as loggerActual from "@/lib/utils/logger";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "00000000-0000-4000-8000-000000000002",
+  organization_id: "00000000-0000-4000-8000-000000000001",
+}));
+const getActiveByProjectName = mock(async () => null);
+const checkQuota = mock(async () => ({
+  availability: "ready" as const,
+  allowed: false,
+  current: 2,
+  max: 2,
+  error: "Container quota exceeded (2/2)",
+}));
+const createContainer = mock(async () => {
+  throw new QuotaExceededError(
+    "Container quota exceeded. Current: 2, Max: 2",
+    2,
+    2,
+  );
+});
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...workersHonoAuthActual,
+  requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/lib/services/containers", () => ({
+  ...containersActual,
+  containersService: {
+    ...containersActual.containersService,
+    getActiveByProjectName,
+    checkQuota,
+  },
+}));
+mock.module("@/lib/services/containers/hetzner-client/client", () => ({
+  ...clientActual,
+  getHetznerContainersClient: () => ({ createContainer }),
+}));
+mock.module("@/lib/services/coding-containers", () => ({
+  ...codingContainersActual,
+  isCodingContainerImageAllowed: () => true,
+  imageRequiresDigestPin: () => false,
+}));
+mock.module("@/lib/utils/logger", () => ({
+  ...loggerActual,
+  logger: { info() {}, warn() {}, error() {}, debug() {} },
+}));
+
+const { default: route } = await import("../v1/containers/route");
+const app = new Hono().route("/api/v1/containers", route);
+
+afterAll(() => {
+  mock.module("@/lib/auth/workers-hono-auth", () => workersHonoAuthActual);
+  mock.module("@/lib/services/containers", () => containersActual);
+  mock.module(
+    "@/lib/services/containers/hetzner-client/client",
+    () => clientActual,
+  );
+  mock.module("@/lib/services/coding-containers", () => codingContainersActual);
+  mock.module("@/lib/utils/logger", () => loggerActual);
+});
+
+beforeEach(() => {
+  getActiveByProjectName.mockClear();
+  checkQuota.mockClear();
+  createContainer.mockClear();
+});
+
+describe("POST /api/v1/containers quota race", () => {
+  test("maps the primary quota loser to the preflight 402 contract", async () => {
+    const response = await app.request("/api/v1/containers", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "race contender",
+        projectName: "project-two",
+        image: "ghcr.io/elizaos/eliza:stable",
+      }),
+    });
+
+    expect(response.status).toBe(402);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Container quota exceeded (2/2)",
+      quota: {
+        availability: "ready",
+        allowed: false,
+        current: 2,
+        max: 2,
+        error: "Container quota exceeded (2/2)",
+      },
+    });
+    expect(checkQuota).toHaveBeenCalledTimes(1);
+    expect(createContainer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/api/__tests__/containers-quota-race.test.ts
+++ b/packages/cloud/api/__tests__/containers-quota-race.test.ts
@@ -91,7 +91,8 @@ describe("POST /api/v1/containers quota race", () => {
     });
 
     expect(response.status).toBe(402);
-    expect(await response.json()).toEqual({
+    const payload = (await response.json()) as unknown;
+    expect(payload).toEqual({
       success: false,
       error: "Container quota exceeded (2/2)",
       quota: {

--- a/packages/cloud/api/v1/containers/route.ts
+++ b/packages/cloud/api/v1/containers/route.ts
@@ -44,6 +44,7 @@ import {
   imageRequiresDigestPin,
   isCodingContainerImageAllowed,
 } from "@/lib/services/coding-containers";
+import { QuotaExceededError } from "@/lib/services/container-quota";
 import { type Container, containersService } from "@/lib/services/containers";
 import { getHetznerContainersClient } from "@/lib/services/containers/hetzner-client/client";
 import {
@@ -322,7 +323,7 @@ app.post("/", async (c) => {
 
     // Quota + credit pre-check (the create path also enforces this atomically).
     const quota = await containersService.checkQuota(user.organization_id);
-    if (!quota.allowed) {
+    if (!quota.allowed && quota.availability === "unavailable") {
       return c.json(
         {
           success: false,
@@ -332,6 +333,11 @@ app.post("/", async (c) => {
         402,
       );
     }
+    // An authoritative at-cap preflight is advisory: the primary admission
+    // below must still run because a replica can miss an already-committed row
+    // for this same project. The locked path either reconstructs that existing
+    // intent or throws QuotaExceededError, which the boundary maps to this same
+    // 402 shape. No provider call occurs before that decision.
 
     const client = getHetznerContainersClient();
     const container = await client.createContainer({
@@ -359,6 +365,16 @@ app.post("/", async (c) => {
     });
     return c.json({ success: true, data: toContainerDto(container) }, 201);
   } catch (error) {
+    if (error instanceof QuotaExceededError) {
+      const quota = {
+        availability: "ready" as const,
+        allowed: false,
+        current: error.current,
+        max: error.max,
+        error: `Container quota exceeded (${error.current}/${error.max})`,
+      };
+      return c.json({ success: false, error: quota.error, quota }, 402);
+    }
     if (error instanceof HetznerClientError) {
       const status = error.code === "invalid_input" ? 400 : 502;
       logger.warn("[Containers API] container deploy failed", {

--- a/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
@@ -338,6 +338,34 @@ describe("AppsRepository.update", () => {
   });
 });
 
+describe("AppsRepository.claimDeploymentStart", () => {
+  test("admits one active generation and allows a new generation after failure", async () => {
+    expect(pgliteReady).toBe(true);
+    const { organizationId, userId } = await seedOrgAndUser();
+    const created = await createApp({
+      name: "Single Flight Deploy",
+      organization_id: organizationId,
+      created_by_user_id: userId,
+    });
+
+    const firstStartedAt = new Date("2026-08-20T12:00:00.000Z");
+    const [left, right] = await Promise.all([
+      appsRepository.claimDeploymentStart(created.id, { last_deployed_at: firstStartedAt }),
+      appsRepository.claimDeploymentStart(created.id, { last_deployed_at: firstStartedAt }),
+    ]);
+    expect([left, right].filter(Boolean)).toHaveLength(1);
+    expect((left ?? right)?.deployment_status).toBe("building");
+
+    await appsRepository.update(created.id, { deployment_status: "failed" });
+    const nextStartedAt = new Date("2026-08-20T12:01:00.000Z");
+    const next = await appsRepository.claimDeploymentStart(created.id, {
+      last_deployed_at: nextStartedAt,
+    });
+    expect(next?.deployment_status).toBe("building");
+    expect(next?.last_deployed_at?.toISOString()).toBe(nextStartedAt.toISOString());
+  });
+});
+
 describe("AppsRepository.delete", () => {
   test("delete removes the row (findById -> undefined) and evicts the cache", async () => {
     expect(pgliteReady).toBe(true);

--- a/packages/cloud/shared/src/db/repositories/__tests__/containers-project-intent.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/containers-project-intent.pglite.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Exercises project-intent admission and quota serialization against real
+ * in-process PGlite. Parallel callers share the production repository and SQL;
+ * no provider or network boundary is used.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const ORG_ID = "00000000-0000-4000-8000-000000000001";
+const USER_ID = "00000000-0000-4000-8000-000000000002";
+const TIMEOUT = 60_000;
+
+let dbWrite: typeof import("../../client").dbWrite;
+let closeDb: typeof import("../../client").closeDatabaseConnectionsForTests | undefined;
+let repository: typeof import("../containers").containersRepository;
+let QuotaExceededError: typeof import("../containers").QuotaExceededError;
+let ready = true;
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../client"));
+    ({ containersRepository: repository, QuotaExceededError } = await import("../containers"));
+    const ddl = [
+      `CREATE TABLE organizations (
+        id uuid PRIMARY KEY,
+        credit_balance numeric(12,6) NOT NULL DEFAULT 0
+      )`,
+      `CREATE TABLE organization_config (
+        id uuid PRIMARY KEY,
+        organization_id uuid NOT NULL UNIQUE,
+        webhook_url text,
+        webhook_secret text,
+        max_api_requests integer DEFAULT 1000,
+        max_tokens_per_request integer,
+        allowed_models jsonb NOT NULL DEFAULT '[]',
+        allowed_providers jsonb NOT NULL DEFAULT '[]',
+        settings jsonb NOT NULL DEFAULT '{}',
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now()
+      )`,
+      `CREATE TABLE containers (
+        id uuid PRIMARY KEY,
+        name text NOT NULL,
+        project_name text NOT NULL,
+        description text,
+        organization_id uuid NOT NULL,
+        user_id uuid NOT NULL,
+        api_key_id uuid,
+        character_id uuid,
+        load_balancer_url text,
+        public_hostname text,
+        status text NOT NULL DEFAULT 'pending',
+        image_tag text,
+        environment_vars jsonb NOT NULL DEFAULT '{}',
+        desired_count integer NOT NULL DEFAULT 1,
+        cpu integer NOT NULL DEFAULT 1792,
+        memory integer NOT NULL DEFAULT 1792,
+        port integer NOT NULL DEFAULT 3000,
+        health_check_path text DEFAULT '/health',
+        node_id text,
+        volume_path text,
+        volume_size_gb integer,
+        hcloud_volume_id integer,
+        volume_location text,
+        last_deployed_at timestamp,
+        last_health_check timestamp,
+        deployment_log text,
+        deployment_log_storage text NOT NULL DEFAULT 'inline',
+        deployment_log_key text,
+        error_message text,
+        metadata jsonb NOT NULL DEFAULT '{}',
+        last_billed_at timestamp,
+        next_billing_at timestamp,
+        billing_status text NOT NULL DEFAULT 'active',
+        shutdown_warning_sent_at timestamp,
+        scheduled_shutdown_at timestamp,
+        total_billed numeric(10,2) NOT NULL DEFAULT 0,
+        lifecycle_revision integer NOT NULL DEFAULT 0,
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now()
+      )`,
+      `INSERT INTO organizations (id, credit_balance) VALUES ('${ORG_ID}', 0)`,
+      `INSERT INTO organization_config (id, organization_id, settings)
+       VALUES ('00000000-0000-4000-8000-000000000003', '${ORG_ID}', '{"max_containers":2}')`,
+    ];
+    for (const statement of ddl) {
+      await dbWrite.execute(statement);
+    }
+  } catch (error) {
+    ready = false;
+    console.error("[containers-project-intent] PGlite setup failed", error);
+  }
+}, TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+function candidate(projectName: string) {
+  return {
+    name: projectName,
+    project_name: projectName,
+    organization_id: ORG_ID,
+    user_id: USER_ID,
+    image_tag: "ghcr.io/elizaos/eliza:stable",
+    status: "pending",
+  };
+}
+
+async function countRows(): Promise<number> {
+  const result = await dbWrite.execute("SELECT count(*)::int AS count FROM containers");
+  return Number((result.rows[0] as { count: number }).count);
+}
+
+describe("ContainersRepository project intent", () => {
+  test(
+    "same-project callers create one row and retry reconstructs it at cap",
+    async () => {
+      expect(ready).toBe(true);
+      await dbWrite.execute("DELETE FROM containers");
+
+      const [left, right] = await Promise.all([
+        repository.createWithProjectIntentAndQuotaCheck(candidate("same-project")),
+        repository.createWithProjectIntentAndQuotaCheck(candidate("same-project")),
+      ]);
+      expect([left.created, right.created].sort()).toEqual([false, true]);
+      expect(left.container.id).toBe(right.container.id);
+      expect(await countRows()).toBe(1);
+
+      await repository.createWithQuotaCheck(candidate("fills-cap"));
+      const retry = await repository.createWithProjectIntentAndQuotaCheck(
+        candidate("same-project"),
+      );
+      expect(retry.created).toBe(false);
+      expect(retry.container.id).toBe(left.container.id);
+      expect(await countRows()).toBe(2);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "distinct projects at limit minus one admit one and reject one canonically",
+    async () => {
+      expect(ready).toBe(true);
+      await dbWrite.execute("DELETE FROM containers");
+      await repository.createWithQuotaCheck(candidate("baseline"));
+
+      const settled = await Promise.allSettled([
+        repository.createWithProjectIntentAndQuotaCheck(candidate("left")),
+        repository.createWithProjectIntentAndQuotaCheck(candidate("right")),
+      ]);
+      expect(settled.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+      const rejection = settled.find((result) => result.status === "rejected");
+      expect(rejection?.status).toBe("rejected");
+      if (rejection?.status === "rejected") {
+        expect(rejection.reason).toBeInstanceOf(QuotaExceededError);
+        expect(rejection.reason).toMatchObject({ current: 2, max: 2 });
+      }
+      expect(await countRows()).toBe(2);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "a terminal prior generation does not block redeploy",
+    async () => {
+      expect(ready).toBe(true);
+      await dbWrite.execute("DELETE FROM containers");
+      const prior = await repository.createWithProjectIntentAndQuotaCheck(candidate("redeploy"));
+      await dbWrite.execute(
+        `UPDATE containers SET status = 'failed' WHERE id = '${prior.container.id}'`,
+      );
+
+      const next = await repository.createWithProjectIntentAndQuotaCheck(candidate("redeploy"));
+      expect(next.created).toBe(true);
+      expect(next.container.id).not.toBe(prior.container.id);
+      expect(await countRows()).toBe(2);
+    },
+    TIMEOUT,
+  );
+});
+
+test("PGlite schema applied — never a silent skip", () => {
+  expect(ready).toBe(true);
+});

--- a/packages/cloud/shared/src/db/repositories/apps.ts
+++ b/packages/cloud/shared/src/db/repositories/apps.ts
@@ -1,6 +1,6 @@
 /** Persists apps and serializes their database-backed cache identities across processes. */
 import { ElizaError } from "@elizaos/core";
-import { and, count, countDistinct, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { and, count, countDistinct, desc, eq, gte, lte, notInArray, sql } from "drizzle-orm";
 import { cache } from "../../lib/cache/client";
 import { CacheKeys } from "../../lib/cache/keys";
 import { invalidateInferenceAppByIdState } from "../../lib/services/inference-app-memory-cache";
@@ -565,6 +565,32 @@ export class AppsRepository {
       await invalidateAppCacheEntries(id, updated.api_key_id, updated.slug);
     }
 
+    return updated;
+  }
+
+  /**
+   * Claims the only active deployment generation for an app on the primary.
+   * Terminal states may claim a new generation; building/deploying states lose
+   * without overwriting the winner's timestamp or metadata.
+   */
+  async claimDeploymentStart(
+    id: string,
+    data: Pick<NewApp, "last_deployed_at"> & { metadata?: Record<string, unknown> },
+  ): Promise<App | undefined> {
+    const [updated] = await dbWrite
+      .update(apps)
+      .set({
+        deployment_status: "building",
+        last_deployed_at: data.last_deployed_at,
+        ...(data.metadata ? { metadata: data.metadata } : {}),
+        updated_at: new Date(),
+      })
+      .where(and(eq(apps.id, id), notInArray(apps.deployment_status, ["building", "deploying"])))
+      .returning();
+
+    if (updated) {
+      await invalidateAppCacheEntries(id, updated.api_key_id, updated.slug);
+    }
     return updated;
   }
 

--- a/packages/cloud/shared/src/db/repositories/containers.ts
+++ b/packages/cloud/shared/src/db/repositories/containers.ts
@@ -57,6 +57,12 @@ export interface QuotaCheckResult {
   error?: string;
 }
 
+/** Result of admitting one canonical project intent under the organization lock. */
+export interface ContainerProjectIntentResult {
+  container: Container;
+  created: boolean;
+}
+
 function resolveContainerLimitFromDatabaseSources(
   creditBalance: string | number | null | undefined,
   orgSettings: unknown,
@@ -728,6 +734,29 @@ export class ContainersRepository {
    * Uses row-level locking (FOR UPDATE) to ensure atomicity.
    */
   async createWithQuotaCheck(data: NewContainer, transaction?: Database): Promise<Container> {
+    const result = await this.createWithQuotaAndOptionalProjectIntent(data, false, transaction);
+    return result.container;
+  }
+
+  /**
+   * Atomically admits one active `(organization_id, project_name)` intent.
+   *
+   * The organization row lock is shared with quota enforcement, so a replica
+   * preflight can never authorize a second provider-bound create. A retry sees
+   * the primary row and returns it without consuming quota or inserting again.
+   */
+  async createWithProjectIntentAndQuotaCheck(
+    data: NewContainer,
+    transaction?: Database,
+  ): Promise<ContainerProjectIntentResult> {
+    return await this.createWithQuotaAndOptionalProjectIntent(data, true, transaction);
+  }
+
+  private async createWithQuotaAndOptionalProjectIntent(
+    data: NewContainer,
+    enforceProjectIntent: boolean,
+    transaction?: Database,
+  ): Promise<ContainerProjectIntentResult> {
     const executeInTransaction = async (tx: Database) => {
       // 1. Lock the organization row to prevent concurrent quota checks
       const [org] = await tx
@@ -741,6 +770,27 @@ export class ContainersRepository {
 
       if (!org) {
         throw new Error("Organization not found");
+      }
+
+      if (enforceProjectIntent) {
+        const [existing] = await tx
+          .select()
+          .from(containers)
+          .where(
+            and(
+              eq(containers.organization_id, data.organization_id),
+              eq(containers.project_name, data.project_name),
+              notInArray(containers.status, ["stopped", "failed", "deleting", "deleted"]),
+            ),
+          )
+          .orderBy(desc(containers.created_at))
+          .limit(1);
+        if (existing) {
+          return {
+            container: await hydrateContainerDeploymentLog(existing),
+            created: false,
+          };
+        }
       }
 
       // Get organization config for settings
@@ -804,7 +854,10 @@ export class ContainersRepository {
 
       const [container] = await tx.insert(containers).values(values).returning();
 
-      return await hydrateContainerDeploymentLog(container);
+      return {
+        container: await hydrateContainerDeploymentLog(container),
+        created: true,
+      };
     };
 
     // Use external transaction if provided, otherwise create new one

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deployments-helpers.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deployments-helpers.test.ts
@@ -68,14 +68,11 @@ describe("assertDeployable", () => {
     }
   });
 
-  test("does not throw for draft / deployed / failed / deploying", () => {
+  test("allows terminal states but rejects the deploying state", () => {
     expect(() => assertDeployable({ deployment_status: "draft" })).not.toThrow();
     expect(() => assertDeployable({ deployment_status: "deployed" })).not.toThrow();
     expect(() => assertDeployable({ deployment_status: "failed" })).not.toThrow();
-    // `deploying` is the immediate-after-build state — callers may want to
-    // retry from a fresh deploy after a deploy-side failure during upload,
-    // so we don't reject it here.
-    expect(() => assertDeployable({ deployment_status: "deploying" })).not.toThrow();
+    expect(() => assertDeployable({ deployment_status: "deploying" })).toThrow(ApiError);
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deployments-options.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deployments-options.test.ts
@@ -12,7 +12,7 @@ type AppRow = {
   created_by_user_id: string;
   github_repo: string | null;
   metadata: Record<string, unknown>;
-  deployment_status: "draft" | "building" | "deployed" | "failed";
+  deployment_status: "draft" | "building" | "deploying" | "deployed" | "failed";
   production_url: string | null;
   last_deployed_at: Date | null;
 };
@@ -37,6 +37,17 @@ mock.module("../apps", () => ({
     update: async (id: string, data: Partial<AppRow>) => {
       if (id !== APP_ID) return undefined;
       appRow = { ...appRow, ...data };
+      return appRow;
+    },
+    claimDeploymentStart: async (id: string, data: Partial<AppRow>) => {
+      if (
+        id !== APP_ID ||
+        appRow.deployment_status === "building" ||
+        appRow.deployment_status === "deploying"
+      ) {
+        return undefined;
+      }
+      appRow = { ...appRow, ...data, deployment_status: "building" };
       return appRow;
     },
   },

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deployments.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deployments.test.ts
@@ -27,6 +27,20 @@ mock.module("../apps", () => ({
       appStore.current = { ...appStore.current, ...data };
       return appStore.current;
     },
+    claimDeploymentStart: async (id: string, data: Partial<AppRow>) => {
+      if (
+        id !== APP_ID ||
+        !appStore.current ||
+        appStore.current.deployment_status === "building" ||
+        appStore.current.deployment_status === "deploying"
+      ) {
+        return undefined;
+      }
+      const update = { ...data, deployment_status: "building" as const };
+      updates.push(update);
+      appStore.current = { ...appStore.current, ...update };
+      return appStore.current;
+    },
   },
 }));
 
@@ -103,5 +117,21 @@ describe("AppDeploymentsService", () => {
       error: null,
       startedAt: "2026-05-19T15:00:00.000Z",
     });
+  });
+
+  test("only one concurrent request claims and enqueues the active deployment", async () => {
+    const service = new AppDeploymentsService();
+    const enqueued: unknown[] = [];
+    service.setDeployEnqueuer(async (payload) => void enqueued.push(payload));
+
+    const settled = await Promise.allSettled([
+      service.createDeployment({ appId: APP_ID, organizationId: ORG_ID, userId: USER_ID }),
+      service.createDeployment({ appId: APP_ID, organizationId: ORG_ID, userId: USER_ID }),
+    ]);
+
+    expect(settled.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(settled.filter((result) => result.status === "rejected")).toHaveLength(1);
+    expect(enqueued).toHaveLength(1);
+    expect(updates).toHaveLength(1);
   });
 });

--- a/packages/cloud/shared/src/lib/services/app-deployments-helpers.ts
+++ b/packages/cloud/shared/src/lib/services/app-deployments-helpers.ts
@@ -58,7 +58,7 @@ export function deploymentIdFor(app: {
  * Greptile flagged on PR #7804.
  */
 export function assertDeployable(app: { deployment_status: AppDeploymentStatus }): void {
-  if (app.deployment_status === "building") {
+  if (app.deployment_status === "building" || app.deployment_status === "deploying") {
     throw new ApiError(
       409,
       "session_not_ready",

--- a/packages/cloud/shared/src/lib/services/app-deployments.ts
+++ b/packages/cloud/shared/src/lib/services/app-deployments.ts
@@ -13,14 +13,11 @@
  * image otherwise). This service is that integration boundary — callers keep
  * polling `getLatestDeployment` regardless of which backend is wired.
  */
+
+import { ApiError } from "../api/cloud-worker-errors";
 import { logger } from "../utils/logger";
 import type { AppDeployRunner, AppDeployRunOptions } from "./app-deploy-orchestrator";
-import {
-  assertDeployable,
-  type DeploymentStatus,
-  deploymentIdFor,
-  publicStatusFor,
-} from "./app-deployments-helpers";
+import { type DeploymentStatus, deploymentIdFor, publicStatusFor } from "./app-deployments-helpers";
 import { appsService } from "./apps";
 
 export type { DeploymentStatus } from "./app-deployments-helpers";
@@ -131,17 +128,18 @@ export class AppDeploymentsService {
     if (!existing) {
       throw new Error("App not found");
     }
-    assertDeployable(existing);
-
     const startedAt = new Date();
     const deploymentMetadata = deployMetadataFor(existing.metadata ?? {}, input);
-    const updated = await appsService.update(input.appId, {
-      deployment_status: "building",
+    const updated = await appsService.claimDeploymentStart(input.appId, {
       last_deployed_at: startedAt,
       ...(deploymentMetadata ? { metadata: deploymentMetadata } : {}),
     });
     if (!updated) {
-      throw new Error("Failed to record deployment start");
+      throw new ApiError(
+        409,
+        "session_not_ready",
+        "A deployment is already in progress for this app",
+      );
     }
 
     // Apps lane (Product 2): trigger the real isolated deploy.

--- a/packages/cloud/shared/src/lib/services/apps.ts
+++ b/packages/cloud/shared/src/lib/services/apps.ts
@@ -546,6 +546,13 @@ export class AppsService {
     return updated;
   }
 
+  async claimDeploymentStart(
+    id: string,
+    data: { last_deployed_at: Date; metadata?: Record<string, unknown> },
+  ): Promise<App | undefined> {
+    return await appsRepository.claimDeploymentStart(id, data);
+  }
+
   async delete(id: string): Promise<void> {
     const app = await appsRepository.findById(id);
 

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.error-policy.test.ts
@@ -27,6 +27,12 @@ const deleteRow = mock(async (_id: string, _org: string): Promise<void> => {});
 const tryReleaseNodeSlot = mock(async (): Promise<void> => {});
 const updateRow = mock(async (): Promise<unknown> => null);
 const updateStatus = mock(async (): Promise<void> => {});
+const createWithProjectIntentAndQuotaCheck = mock(
+  async (): Promise<unknown> => ({
+    container: ROW,
+    created: false,
+  }),
+);
 
 const readMetadata = mock((_row: unknown): unknown => null);
 
@@ -34,6 +40,13 @@ const execMock = mock(async (_cmd: string, _timeout?: number): Promise<string> =
 const fakeSsh = { exec: execMock, execStream: mock(async () => {}) };
 const getClient = mock(() => fakeSsh);
 const findByNodeId = mock(async (_id: string): Promise<unknown> => null);
+const getOrCreateProjectVolume = mock(
+  async (): Promise<unknown> => ({
+    id: 11,
+    location: { name: "fsn1" },
+  }),
+);
+let volumesAvailable = false;
 
 mock.module("../../../../db/repositories/containers", () => ({
   ...realContainersRepo,
@@ -45,6 +58,7 @@ mock.module("../../../../db/repositories/containers", () => ({
     tryReleaseNodeSlot,
     update: updateRow,
     updateStatus,
+    createWithProjectIntentAndQuotaCheck,
   },
 }));
 
@@ -58,8 +72,8 @@ mock.module("../../../../db/repositories/docker-nodes", () => ({
 
 mock.module("../hetzner-volumes", () => ({
   ...realHetznerVolumes,
-  isHetznerVolumesAvailable: () => false,
-  getHetznerVolumeService: () => ({}),
+  isHetznerVolumesAvailable: () => volumesAvailable,
+  getHetznerVolumeService: () => ({ getOrCreateProjectVolume }),
 }));
 
 mock.module("../../docker-ssh", () => ({
@@ -86,9 +100,17 @@ const META = {
 
 const ROW = {
   id: "ct1",
+  name: "existing",
+  project_name: "project-one",
   organization_id: "org1",
   hcloud_volume_id: null,
   lifecycle_revision: 7,
+  status: "running",
+  load_balancer_url: "https://existing.example",
+  metadata: META,
+  error_message: null,
+  created_at: new Date("2026-08-20T12:00:00.000Z"),
+  updated_at: new Date("2026-08-20T12:00:00.000Z"),
 };
 
 afterAll(() => {
@@ -107,10 +129,12 @@ beforeEach(() => {
     tryReleaseNodeSlot,
     updateRow,
     updateStatus,
+    createWithProjectIntentAndQuotaCheck,
     readMetadata,
     execMock,
     getClient,
     findByNodeId,
+    getOrCreateProjectVolume,
   ]) {
     m.mockReset();
   }
@@ -120,10 +144,70 @@ beforeEach(() => {
   tryReleaseNodeSlot.mockResolvedValue(undefined);
   updateRow.mockResolvedValue(null);
   updateStatus.mockResolvedValue(undefined);
+  createWithProjectIntentAndQuotaCheck.mockResolvedValue({
+    container: ROW,
+    created: false,
+  });
   readMetadata.mockReturnValue(META);
   execMock.mockResolvedValue("");
   getClient.mockReturnValue(fakeSsh);
   findByNodeId.mockResolvedValue(null);
+  getOrCreateProjectVolume.mockResolvedValue({ id: 11, location: { name: "fsn1" } });
+  volumesAvailable = false;
+});
+
+describe("createContainer — primary project intent", () => {
+  test("returns the existing row without any provider-side effect", async () => {
+    const client = getHetznerContainersClient();
+    await expect(
+      client.createContainer({
+        name: "existing",
+        projectName: "project-one",
+        organizationId: "org1",
+        userId: "user1",
+        image: "ghcr.io/elizaos/eliza:stable",
+        port: 3000,
+        desiredCount: 1,
+        cpu: 1024,
+        memoryMb: 1024,
+      }),
+    ).resolves.toMatchObject({ id: "ct1", projectName: "project-one" });
+
+    expect(createWithProjectIntentAndQuotaCheck).toHaveBeenCalledTimes(1);
+    expect(getClient).not.toHaveBeenCalled();
+    expect(execMock).not.toHaveBeenCalled();
+    expect(updateRow).not.toHaveBeenCalled();
+  });
+
+  test("marks a newly admitted intent failed when provider preflight rejects", async () => {
+    createWithProjectIntentAndQuotaCheck.mockResolvedValue({
+      container: ROW,
+      created: true,
+    });
+    volumesAvailable = true;
+    getOrCreateProjectVolume.mockRejectedValue(new Error("volume preflight unavailable"));
+
+    const client = getHetznerContainersClient();
+    await expect(
+      client.createContainer({
+        name: "existing",
+        projectName: "project-one",
+        organizationId: "org1",
+        userId: "user1",
+        image: "ghcr.io/elizaos/eliza:stable",
+        port: 3000,
+        desiredCount: 1,
+        cpu: 1024,
+        memoryMb: 1024,
+        persistVolume: true,
+        useHetznerVolume: true,
+      }),
+    ).rejects.toMatchObject({ code: "container_create_failed" });
+
+    expect(updateStatus).toHaveBeenCalledWith("ct1", "failed", "volume preflight unavailable");
+    expect(getClient).not.toHaveBeenCalled();
+    expect(execMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("deleteContainer — fail-closed host teardown", () => {

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
@@ -122,7 +122,11 @@ export class HetznerContainersClient {
       metadata: { provider: "hetzner-docker", image: input.image },
     };
 
-    const row = await containersRepository.createWithQuotaCheck(newRow);
+    const admitted = await containersRepository.createWithProjectIntentAndQuotaCheck(newRow);
+    const row = admitted.container;
+    if (!admitted.created) {
+      return rowToSummary(row);
+    }
 
     // 2. Hetzner Cloud volume pre-flight. Create or find the volume before
     // node selection so scheduling can respect the volume's location.
@@ -142,50 +146,59 @@ export class HetznerContainersClient {
     let hcloudVolumeId: number | undefined;
     let hcloudVolumeLocation: string | undefined;
 
-    if (wantHcloudVolume) {
-      const volService = getHetznerVolumeService();
-      const defaultLocation = containersEnv.defaultHcloudLocation();
-      const volume = await volService.getOrCreateProjectVolume(
-        { organizationId: input.organizationId, projectName: input.projectName },
-        { sizeGb: input.volumeSizeGb ?? 10, location: defaultLocation },
-      );
-      hcloudVolumeId = volume.id;
-      hcloudVolumeLocation = volume.location.name;
-    }
-
-    // 3. Node selection.
-    //
-    // Stateful workloads need to land on the same node as the existing
-    // volume. For Hetzner Cloud volumes, the node MUST be in the same
-    // Hetzner location as the volume (location-bound block storage).
-    //
-    // Priority:
-    //   a) Sticky node from a prior container in this project (if healthy,
-    //      has capacity, and for hcloud volumes is in the right location)
-    //   b) Least-loaded node in the volume's location (hcloud volumes only)
-    //   c) Global least-loaded node (stateless or local-volume workloads)
     let node: DockerNode | null = null;
+    try {
+      if (wantHcloudVolume) {
+        const volService = getHetznerVolumeService();
+        const defaultLocation = containersEnv.defaultHcloudLocation();
+        const volume = await volService.getOrCreateProjectVolume(
+          { organizationId: input.organizationId, projectName: input.projectName },
+          { sizeGb: input.volumeSizeGb ?? 10, location: defaultLocation },
+        );
+        hcloudVolumeId = volume.id;
+        hcloudVolumeLocation = volume.location.name;
+      }
 
-    if (input.persistVolume) {
-      const sticky = await findStickyNodeForProject(input.organizationId, input.projectName);
-      if (sticky) {
-        if (hcloudVolumeLocation) {
-          if (getDockerNodeLocation(sticky) === hcloudVolumeLocation) {
+      // 3. Node selection.
+      //
+      // Stateful workloads need to land on the same node as the existing
+      // volume. For Hetzner Cloud volumes, the node MUST be in the same
+      // Hetzner location as the volume (location-bound block storage).
+      //
+      // Priority:
+      //   a) Sticky node from a prior container in this project (if healthy,
+      //      has capacity, and for hcloud volumes is in the right location)
+      //   b) Least-loaded node in the volume's location (hcloud volumes only)
+      //   c) Global least-loaded node (stateless or local-volume workloads)
+      if (input.persistVolume) {
+        const sticky = await findStickyNodeForProject(input.organizationId, input.projectName);
+        if (sticky) {
+          if (hcloudVolumeLocation) {
+            if (getDockerNodeLocation(sticky) === hcloudVolumeLocation) {
+              node = (await dockerNodeManager.ensureNodeReady(sticky)) ? sticky : null;
+            }
+          } else {
             node = (await dockerNodeManager.ensureNodeReady(sticky)) ? sticky : null;
           }
-        } else {
-          node = (await dockerNodeManager.ensureNodeReady(sticky)) ? sticky : null;
         }
       }
-    }
 
-    if (!node && hcloudVolumeLocation) {
-      const located = await findNodeInLocation(hcloudVolumeLocation);
-      node = located && (await dockerNodeManager.ensureNodeReady(located)) ? located : null;
-    }
+      if (!node && hcloudVolumeLocation) {
+        const located = await findNodeInLocation(hcloudVolumeLocation);
+        node = located && (await dockerNodeManager.ensureNodeReady(located)) ? located : null;
+      }
 
-    if (!node && !hcloudVolumeLocation) {
-      node = await dockerNodeManager.getAvailableNode();
+      if (!node && !hcloudVolumeLocation) {
+        node = await dockerNodeManager.getAvailableNode();
+      }
+    } catch (error) {
+      // error-policy:J2 a created intent must become terminal when provider
+      // preflight fails; otherwise future single-flight retries would
+      // reconstruct a permanently-pending row and never retry provisioning.
+      const message = error instanceof Error ? error.message : String(error);
+      await containersRepository.updateStatus(row.id, "failed", message);
+      if (error instanceof HetznerClientError) throw error;
+      throw new HetznerClientError("container_create_failed", message, error);
     }
 
     if (!node) {


### PR DESCRIPTION
Closes #23004.

## What changed

- serialize direct container project intents under the existing organization quota lock, returning the existing active intent before any provider, volume, node, or SSH side effect;
- atomically claim app deployment generations so concurrent direct starts produce one winner and one explicit `409 session_not_ready` loser;
- preserve the existing quota authority and canonical `402` response while allowing a primary-store same-project retry when a replica preflight appears full;
- add real PGlite concurrency/admission coverage plus service, provider-boundary, and route regressions.

No new counter, migration, provider mutation, or protected deployment was introduced. Terminal failed/stopped generations remain eligible for a new intent.

## Exact verification

- Exact head: `f6ffac90924d8d9c6496146915ea7392876148e1`
- Exact base: `e927af91aca08403dfb6e9ec7c3c3518692b7bc1`
- Focused aggregate: **62/62**, 221 assertions
- Real PGlite project intent: **4/4**
- Real PGlite apps repository: **26/26**
- App deployment service/helper/options: **20/20**
- Hetzner client boundary: **11/11**
- Cloud API route boundary: **1/1**
- Biome: all 14 changed files pass
- All 14 intended paths were reconstructed on the exact live develop parent; unrelated billing-stop, restart-fence, delete, and provider-absence behavior is preserved.

Broad donor-backed typecheck attempts were environment-limited by unrelated missing optional workspace packages (`@cloudflare/workers-types` in Cloud API); no changed-file diagnostic was emitted. No real Hetzner, deployment, quota, tier, pricing, or production mutation was performed.

## Evidence Gate

<!-- evidence-head:f6ffac90924d8d9c6496146915ea7392876148e1 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered pixels or layout changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered pixels or layout changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual interaction flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no live backend or protected provider was mutated; the deterministic route and repository execution is recorded in the domain artifact.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior or prompt changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Independent rebased exact-head concurrency/admission receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23181-container-intent-exact-f6ff.txt)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no pixels changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->