### PR TITLE
fix(homepage): contain multi-person typing indicator

### DIFF
--- a/packages/homepage/src/index.css
+++ b/packages/homepage/src/index.css
@@ -1971,24 +1971,54 @@ html:has(.landing-page)::-webkit-scrollbar-thumb:hover {
   transform: scale(1.18);
 }
 
-.landing-message--typing-multiple .landing-message-avatar-slot {
-  justify-content: flex-start;
-  overflow: visible;
-}
-
-.landing-message--typing-multiple
-  .landing-message-avatar
-  + .landing-message-avatar {
-  margin-left: -0.95rem;
-  box-shadow: 0 0 0 2px #ffffff;
-}
-
 .landing-message-author {
   margin: 0 0 0.16rem 0.7rem;
   color: #76767c;
   font-size: 0.64rem;
   font-weight: 620;
   line-height: 1;
+}
+
+.landing-message--typing {
+  flex: 0 0 auto;
+  min-height: 2.65rem;
+  margin-top: 0.1rem;
+}
+
+.landing-message--typing .landing-message-body {
+  align-content: end;
+  min-height: 2.65rem;
+}
+
+.landing-message--typing .landing-message-author {
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.landing-message--typing-multiple .landing-message-avatar-slot {
+  position: relative;
+  overflow: hidden;
+}
+
+.landing-message--typing-multiple .landing-message-avatar {
+  position: absolute;
+  width: 1.15rem;
+  height: 1.15rem;
+  border: 1.5px solid #ffffff;
+}
+
+.landing-message--typing-multiple .landing-message-avatar:first-child {
+  top: 0;
+  left: 0;
+  z-index: 1;
+}
+
+.landing-message--typing-multiple .landing-message-avatar:last-child {
+  right: 0;
+  bottom: 0;
+  z-index: 2;
 }
 
 .landing-bubble--user {

--- a/packages/homepage/tests/e2e/landing-single-viewport.spec.ts
+++ b/packages/homepage/tests/e2e/landing-single-viewport.spec.ts
@@ -261,6 +261,24 @@ test("concurrent human replies share one compact typing row", async ({
   const multipleBubbleBox = await indicator
     .locator(".landing-typing")
     .boundingBox();
+  const multipleAvatarSlotBox = await indicator
+    .locator(".landing-message-avatar-slot")
+    .boundingBox();
+  const multipleBodyBox = await indicator
+    .locator(".landing-message-body")
+    .boundingBox();
+  const latestMessageBox = await page
+    .locator('[data-demo-item="true"]')
+    .last()
+    .boundingBox();
+  const multipleIndicatorBox = await indicator.boundingBox();
+
+  expect(
+    (multipleAvatarSlotBox?.x ?? 0) + (multipleAvatarSlotBox?.width ?? 0),
+  ).toBeLessThanOrEqual((multipleBodyBox?.x ?? 0) + 1);
+  expect(multipleIndicatorBox?.y ?? 0).toBeGreaterThanOrEqual(
+    (latestMessageBox?.y ?? 0) + (latestMessageBox?.height ?? 0),
+  );
 
   await expect(phone).toHaveAttribute("data-demo-typing", "Jules", {
     timeout: 3_000,


### PR DESCRIPTION
## Summary
- reserve a dedicated row below the latest message for typing state
- contain the two-person avatar cluster inside the normal iMessage avatar gutter
- lock the no-overlap and below-latest-message geometry in Playwright

## Verification
- `bun run --cwd packages/homepage lint:check`
- `bun run --cwd packages/homepage typecheck`
- focused Chromium Playwright test: 1 passed
- visual inspection at 390x844 and 1440x1000
- Impeccable detector: only pre-existing Geist font warnings outside this change

AI provider/model: OpenAI / GPT-5.6
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [codex-homepage-typing-polish]