### PR TITLE
fix(matrix): restore format parity

### DIFF
--- a/plugins/plugin-matrix/src/accounts.ts
+++ b/plugins/plugin-matrix/src/accounts.ts
@@ -194,7 +194,9 @@ export function resolveMatrixAccountSettings(
       (allowOwnerBind ? base.deviceId : undefined) ??
       (allowOwnerBind ? stringSetting(runtime, "MATRIX_DEVICE_ID") : undefined),
     rooms: roomsValue(
-      account.rooms ?? base.rooms ?? (allowOwnerBind ? stringSetting(runtime, "MATRIX_ROOMS") : undefined)
+      account.rooms ??
+        base.rooms ??
+        (allowOwnerBind ? stringSetting(runtime, "MATRIX_ROOMS") : undefined)
     ),
     verifyAllowlist: roomsValue(
       account.verifyAllowlist ??


### PR DESCRIPTION
## Summary
- restore Biome format parity for Matrix account room fallback wrapping
- unblock the repository-wide format lane exposed by the merged BlueBubbles parity repair

## Verification
- exact diff is formatter-only in `plugins/plugin-matrix/src/accounts.ts`
- hosted CI is the acceptance gate for this current-develop baseline repair

## Provenance
- AI-assisted: Codex prepared the exact formatter output and verification notes
- Human author: Shaw Walters remains responsible for review and merge