### PR TITLE
feat(plugin-design): local-mode Canva and Figma design adapters behind eligibility-gated managed mode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1659,6 +1659,22 @@
         "react-dom": "^19.0.0",
       },
     },
+    "plugins/plugin-design": {
+      "name": "@elizaos/plugin-design",
+      "version": "2.0.3-beta.7",
+      "dependencies": {
+        "@elizaos/core": "workspace:*",
+        "zod": "^4.4.3",
+      },
+      "devDependencies": {
+        "@elizaos/cloud-test-mocks": "workspace:*",
+        "@types/node": "^25.0.6",
+        "@typescript/native": "npm:typescript@^7.0.2",
+        "tsup": "^8.5.1",
+        "typescript": "^6.0.3",
+        "vitest": "^4.0.17",
+      },
+    },
     "plugins/plugin-discord": {
       "name": "@elizaos/plugin-discord",
       "version": "2.0.3-beta.7",
@@ -4090,6 +4106,8 @@
     "@elizaos/plugin-computeruse": ["@elizaos/plugin-computeruse@workspace:plugins/plugin-computeruse"],
 
     "@elizaos/plugin-contacts": ["@elizaos/plugin-contacts@workspace:plugins/plugin-contacts"],
+
+    "@elizaos/plugin-design": ["@elizaos/plugin-design@workspace:plugins/plugin-design"],
 
     "@elizaos/plugin-discord": ["@elizaos/plugin-discord@workspace:plugins/plugin-discord"],
 

--- a/plugins/plugin-design/AGENTS.md
+++ b/plugins/plugin-design/AGENTS.md
@@ -1,0 +1,65 @@
+# @elizaos/plugin-design
+
+Provider-neutral design domain for elizaOS agents: design search, lookup,
+node/design export, and comment reads, with local BYO-credential Canva and
+Figma adapters.
+
+## Ownership and boundaries
+
+- `DesignService` owns normalized design behavior, adapter registration, and
+  the local-versus-managed connection policy.
+- `FigmaDesignAdapter` and `CanvaDesignAdapter` map the real provider wire
+  formats into the normalized domain. They run only in local mode from
+  explicit user-supplied credentials (`FIGMA_PERSONAL_ACCESS_TOKEN`,
+  `CANVA_ACCESS_TOKEN`) and never fall back to Cloud silently.
+- Managed Cloud OAuth for both providers is eligibility-gated behind human
+  provider app registration/review. `MANAGED_DESIGN_ELIGIBILITY` is the
+  authoritative ineligible state and `connectManaged` throws
+  `DESIGN_MANAGED_MODE_INELIGIBLE`; flipping eligibility is a deliberate code
+  change made with approved app credentials custodied in Cloud, never a
+  runtime toggle.
+- The domain is read/search/export-first. There are no create/edit/delete
+  capabilities in this package until provider approval and the managed
+  adapter SDK path land.
+- Export artifacts carry short-lived provider HTTPS URLs only; bytes are never
+  fetched or rehosted here. Attachment ingestion goes through the canonical
+  media store when a consumer needs bytes.
+- Paid/beta provider limitations surface as typed `DESIGN_PLAN_LIMITED` or
+  `DESIGN_UNSUPPORTED` failures, never as fabricated empty results.
+
+## Public surface
+
+- `DesignRef`, `DesignPage`, `DesignExportArtifact`, and `DesignCommentPage`
+  are validated normalized types; deep links and thumbnails must be HTTPS and
+  Canva links are pinned to `canva.com`.
+- `DesignProviderAdapter` is the connector seam. Adapters declare a
+  `capabilities` set; deterministic code — never prompt text — selects
+  behavior and rejects unsupported capabilities.
+- All outbound HTTP flows through `DesignHttpCore`: one pinned origin,
+  DNS-pinned SSRF-guarded transport, no redirects, bounded response bytes,
+  bounded deadlines, and strict schema decoding.
+- Connection handles are opaque (`conn_...`); credentials never appear in
+  types, logs, errors, or test fixtures.
+
+## Commands
+
+```bash
+bun run --cwd plugins/plugin-design test
+bun run --cwd plugins/plugin-design typecheck
+bun run --cwd plugins/plugin-design lint:check
+bun run --cwd plugins/plugin-design build
+```
+
+## Verification
+
+The provider-contract tests drive the real adapters over HTTP against the
+repository's protocol-faithful fake upstream speaking Figma and Canva wire
+shapes. Keep success, designed-empty, invalid input, pagination (Canva),
+rate-limit metadata, malformed/schema-drift responses, expired/revoked/plan
+auth distinctions, network failures, SSRF/DNS rebinding, redirects, response
+bounds, provider identity binding, opaque connection IDs, redaction, async
+export-job lifecycle, and read-policy coverage intact. Live sandbox evidence
+against real Figma/Canva accounts is a release gate for promotion, not a CI
+requirement.
+
+Follow the root `AGENTS.md` and `CONTRIBUTING.md` evidence requirements.

--- a/plugins/plugin-design/CLAUDE.md
+++ b/plugins/plugin-design/CLAUDE.md
@@ -1,0 +1,65 @@
+# @elizaos/plugin-design
+
+Provider-neutral design domain for elizaOS agents: design search, lookup,
+node/design export, and comment reads, with local BYO-credential Canva and
+Figma adapters.
+
+## Ownership and boundaries
+
+- `DesignService` owns normalized design behavior, adapter registration, and
+  the local-versus-managed connection policy.
+- `FigmaDesignAdapter` and `CanvaDesignAdapter` map the real provider wire
+  formats into the normalized domain. They run only in local mode from
+  explicit user-supplied credentials (`FIGMA_PERSONAL_ACCESS_TOKEN`,
+  `CANVA_ACCESS_TOKEN`) and never fall back to Cloud silently.
+- Managed Cloud OAuth for both providers is eligibility-gated behind human
+  provider app registration/review. `MANAGED_DESIGN_ELIGIBILITY` is the
+  authoritative ineligible state and `connectManaged` throws
+  `DESIGN_MANAGED_MODE_INELIGIBLE`; flipping eligibility is a deliberate code
+  change made with approved app credentials custodied in Cloud, never a
+  runtime toggle.
+- The domain is read/search/export-first. There are no create/edit/delete
+  capabilities in this package until provider approval and the managed
+  adapter SDK path land.
+- Export artifacts carry short-lived provider HTTPS URLs only; bytes are never
+  fetched or rehosted here. Attachment ingestion goes through the canonical
+  media store when a consumer needs bytes.
+- Paid/beta provider limitations surface as typed `DESIGN_PLAN_LIMITED` or
+  `DESIGN_UNSUPPORTED` failures, never as fabricated empty results.
+
+## Public surface
+
+- `DesignRef`, `DesignPage`, `DesignExportArtifact`, and `DesignCommentPage`
+  are validated normalized types; deep links and thumbnails must be HTTPS and
+  Canva links are pinned to `canva.com`.
+- `DesignProviderAdapter` is the connector seam. Adapters declare a
+  `capabilities` set; deterministic code — never prompt text — selects
+  behavior and rejects unsupported capabilities.
+- All outbound HTTP flows through `DesignHttpCore`: one pinned origin,
+  DNS-pinned SSRF-guarded transport, no redirects, bounded response bytes,
+  bounded deadlines, and strict schema decoding.
+- Connection handles are opaque (`conn_...`); credentials never appear in
+  types, logs, errors, or test fixtures.
+
+## Commands
+
+```bash
+bun run --cwd plugins/plugin-design test
+bun run --cwd plugins/plugin-design typecheck
+bun run --cwd plugins/plugin-design lint:check
+bun run --cwd plugins/plugin-design build
+```
+
+## Verification
+
+The provider-contract tests drive the real adapters over HTTP against the
+repository's protocol-faithful fake upstream speaking Figma and Canva wire
+shapes. Keep success, designed-empty, invalid input, pagination (Canva),
+rate-limit metadata, malformed/schema-drift responses, expired/revoked/plan
+auth distinctions, network failures, SSRF/DNS rebinding, redirects, response
+bounds, provider identity binding, opaque connection IDs, redaction, async
+export-job lifecycle, and read-policy coverage intact. Live sandbox evidence
+against real Figma/Canva accounts is a release gate for promotion, not a CI
+requirement.
+
+Follow the root `AGENTS.md` and `CONTRIBUTING.md` evidence requirements.

--- a/plugins/plugin-design/README.md
+++ b/plugins/plugin-design/README.md
@@ -1,0 +1,50 @@
+# @elizaos/plugin-design
+
+Provider-neutral design capabilities for Eliza agents: search, lookup,
+node/design export, and comment reads, backed by local-mode Canva and Figma
+adapters.
+
+## Local mode (BYO credentials)
+
+| Setting | Purpose |
+| --- | --- |
+| `FIGMA_PERSONAL_ACCESS_TOKEN` | Enables the Figma adapter (`X-Figma-Token`). |
+| `FIGMA_PROJECT_ID` | Optional numeric project id; enables Figma search by scoping the project file listing. |
+| `FIGMA_API_BASE_URL` | Optional origin override for tests or a local desktop bridge. |
+| `CANVA_ACCESS_TOKEN` | Enables the Canva Connect adapter (Bearer token from your own Connect integration). |
+| `CANVA_API_BASE_URL` | Optional origin override for tests. |
+
+There is no silent Cloud fallback: with no credentials configured, requests
+fail with a typed `DESIGN_NOT_CONNECTED` error.
+
+## Managed Cloud mode
+
+Managed OAuth connections for Canva and Figma are gated on provider app
+registration and review, which are human-only steps. Until then,
+`MANAGED_DESIGN_ELIGIBILITY` reports both providers ineligible and
+`DesignService.connectManaged` throws `DESIGN_MANAGED_MODE_INELIGIBLE` with
+the runbook reason.
+
+## Capabilities
+
+| Capability | Figma | Canva |
+| --- | --- | --- |
+| `search` | Project file listing filtered by query (requires `FIGMA_PROJECT_ID`; no pagination) | `/rest/v1/designs` with continuation cursors |
+| `get` | `/v1/files/:key` | `/rest/v1/designs/:id` |
+| `export` | `/v1/images/:key` node renders (nodeId required) | Async export job create + bounded polling (`svg` unsupported) |
+| `comments` | `/v1/files/:key/comments` | Unsupported until the Comment API beta capability is granted |
+
+Exports return short-lived provider HTTPS URLs; bytes are never rehosted by
+this package. Paid/beta limitations surface as `DESIGN_PLAN_LIMITED` or
+`DESIGN_UNSUPPORTED`.
+
+## Testing
+
+```bash
+bun run --cwd plugins/plugin-design test
+```
+
+The contract suites run the real adapters over HTTP against the repository's
+protocol-faithful fake provider upstream, covering the full outbound-http
+conformance matrix plus auth-state distinctions, the Canva export-job
+lifecycle, SSRF/redirect/byte-bound defenses, and provider identity binding.

--- a/plugins/plugin-design/package.json
+++ b/plugins/plugin-design/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@elizaos/plugin-design",
+  "version": "2.0.3-beta.7",
+  "type": "module",
+  "description": "Provider-neutral design read/search/export/comment capabilities with local-mode Canva and Figma adapters for Eliza agents.",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "eliza-source": {
+        "types": "./src/index.ts",
+        "import": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./plugin": {
+      "types": "./dist/plugin.d.ts",
+      "eliza-source": {
+        "types": "./src/plugin.ts",
+        "import": "./src/plugin.ts",
+        "default": "./src/plugin.ts"
+      },
+      "import": "./dist/plugin.js",
+      "default": "./dist/plugin.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "eliza-source": {
+        "types": "./src/*.ts",
+        "import": "./src/*.ts",
+        "default": "./src/*.ts"
+      },
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "bun run build:js && bun run build:types",
+    "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",
+    "build:types": "tsc6 --noCheck -p tsconfig.build.json",
+    "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo",
+    "test": "vitest run --config vitest.config.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
+  },
+  "dependencies": {
+    "@elizaos/core": "workspace:*",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@elizaos/cloud-test-mocks": "workspace:*",
+    "@types/node": "^25.0.6",
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.0.17"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "agentConfig": {
+    "pluginType": "elizaos:plugin:1.0.0",
+    "pluginParameters": {}
+  }
+}

--- a/plugins/plugin-design/src/adapter.ts
+++ b/plugins/plugin-design/src/adapter.ts
@@ -1,0 +1,28 @@
+/**
+ * Provider seam for the design domain. Adapters declare their supported
+ * capabilities so deterministic code — never prompt text — selects behavior,
+ * and expose only an opaque connection handle instead of credentials.
+ */
+
+import type {
+  DesignCapability,
+  DesignCommentPage,
+  DesignExportArtifact,
+  DesignExportRequest,
+  DesignPage,
+  DesignRef,
+  DesignSearchRequest,
+} from "./types.js";
+
+export interface DesignProviderAdapter {
+  readonly id: string;
+  readonly connectionId: string;
+  readonly capabilities: ReadonlySet<DesignCapability>;
+  searchDesigns(request: DesignSearchRequest): Promise<DesignPage>;
+  getDesign(providerDesignId: string): Promise<DesignRef | null>;
+  exportDesign(request: DesignExportRequest): Promise<DesignExportArtifact>;
+  listComments(
+    providerDesignId: string,
+    cursor?: string,
+  ): Promise<DesignCommentPage>;
+}

--- a/plugins/plugin-design/src/canva.ts
+++ b/plugins/plugin-design/src/canva.ts
@@ -1,0 +1,380 @@
+/**
+ * Canva Connect adapter for the design domain, running in local BYO-credential
+ * mode with a user-supplied Connect access token. Search maps the paginated
+ * `/rest/v1/designs` listing with opaque continuation cursors; exports create
+ * an asynchronous export job and poll it under a bounded attempt budget,
+ * returning short-lived Canva download URLs without rehosting bytes. Comment
+ * reads and SVG export are designed-unsupported until Canva grants the
+ * corresponding beta/paid capability to the connected integration, and the
+ * limitation surfaces as a typed error instead of a fabricated empty result.
+ */
+
+import * as z from "zod";
+import type { DesignProviderAdapter } from "./adapter.js";
+import { DesignError } from "./errors.js";
+import { DesignHttpCore, type DesignTestTransport } from "./http.js";
+import {
+  type DesignCapability,
+  type DesignCommentPage,
+  type DesignExportArtifact,
+  type DesignExportRequest,
+  type DesignPage,
+  type DesignRef,
+  type DesignSearchRequest,
+  designExportArtifactSchema,
+  designExportRequestSchema,
+  designPageSchema,
+  designRefSchema,
+  designSearchRequestSchema,
+} from "./types.js";
+
+export const CANVA_PROVIDER_ID = "canva";
+export const CANVA_API_ORIGIN = "https://api.canva.com";
+
+const wireText = z.string().min(1).max(2_048);
+
+const canvaDesignItemSchema = z.object({
+  id: wireText,
+  title: z.string().max(300).optional(),
+  thumbnail: z.object({ url: z.string().max(2_048) }).optional(),
+  urls: z.object({
+    view_url: z.string().max(2_048),
+    edit_url: z.string().max(2_048).optional(),
+  }),
+  updated_at: z.number().int().nonnegative().optional(),
+});
+
+const canvaDesignListSchema = z.object({
+  items: z.array(canvaDesignItemSchema).max(100),
+  continuation: wireText.optional(),
+});
+
+const canvaDesignGetSchema = z.object({ design: canvaDesignItemSchema });
+
+const canvaExportJobSchema = z.object({
+  job: z.object({
+    id: wireText,
+    status: z.enum(["in_progress", "success", "failed"]),
+    urls: z.array(z.string().max(2_048)).max(20).optional(),
+    error: z
+      .object({ code: wireText, message: z.string().max(2_048) })
+      .optional(),
+  }),
+});
+
+const PLAN_LIMITED_CODES = new Set([
+  "license_required",
+  "premium_feature",
+  "plan_limited",
+  "feature_not_available",
+]);
+const REVOKED_CODES = new Set(["revoked_token", "banned_user"]);
+
+export interface CanvaDesignAdapterOptions {
+  connectionId: string;
+  accessToken: string;
+  /** Override for tests only; defaults to the public Connect API. */
+  baseUrl?: string;
+  timeoutMs?: number;
+  responseByteLimit?: number;
+  /** Export-job polling bounds; tests inject a zero-delay sleep. */
+  maxPollAttempts?: number;
+  pollDelayMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  testTransport?: DesignTestTransport;
+  allowPrivateNetworkForTests?: boolean;
+}
+
+function classifyCanvaError(
+  status: number,
+  body: unknown,
+  retryAfterMs: number | undefined,
+): DesignError {
+  const code =
+    body && typeof body === "object" && "code" in body
+      ? String((body as { code?: unknown }).code)
+      : "";
+  if (status === 429) {
+    return new DesignError("Canva is rate limited.", {
+      code: "DESIGN_RATE_LIMITED",
+      retryAfterMs,
+      context: { status },
+    });
+  }
+  if (PLAN_LIMITED_CODES.has(code)) {
+    return new DesignError(
+      "This Canva operation requires a paid or beta capability the connected account lacks.",
+      { code: "DESIGN_PLAN_LIMITED", context: { status, providerCode: code } },
+    );
+  }
+  if (status === 401) {
+    return new DesignError("The Canva access token has expired.", {
+      code: "DESIGN_AUTH_EXPIRED",
+      context: { status },
+    });
+  }
+  if (status === 403 && REVOKED_CODES.has(code)) {
+    return new DesignError("The Canva connection was revoked.", {
+      code: "DESIGN_AUTH_REVOKED",
+      context: { status },
+    });
+  }
+  if (status >= 500) {
+    return new DesignError("Canva failed.", {
+      code: "DESIGN_PROVIDER_FAILURE",
+      context: { status },
+    });
+  }
+  return new DesignError("Canva rejected the request.", {
+    code: "DESIGN_PROVIDER_REJECTED",
+    context: { status, ...(code ? { providerCode: code } : {}) },
+  });
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  });
+}
+
+export class CanvaDesignAdapter implements DesignProviderAdapter {
+  readonly id = CANVA_PROVIDER_ID;
+  readonly capabilities: ReadonlySet<DesignCapability> = new Set([
+    "search",
+    "get",
+    "export",
+  ]);
+  private readonly core: DesignHttpCore;
+  private readonly maxPollAttempts: number;
+  private readonly pollDelayMs: number;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  constructor(options: CanvaDesignAdapterOptions) {
+    if (!options.accessToken.trim()) {
+      throw new DesignError("Canva requires a Connect access token.", {
+        code: "DESIGN_INVALID_INPUT",
+      });
+    }
+    const maxPollAttempts = options.maxPollAttempts ?? 20;
+    const pollDelayMs = options.pollDelayMs ?? 500;
+    if (
+      !Number.isInteger(maxPollAttempts) ||
+      maxPollAttempts < 1 ||
+      maxPollAttempts > 120 ||
+      !Number.isInteger(pollDelayMs) ||
+      pollDelayMs < 0 ||
+      pollDelayMs > 10_000
+    ) {
+      throw new DesignError("Canva export polling bounds are invalid.", {
+        code: "DESIGN_INVALID_INPUT",
+      });
+    }
+    this.maxPollAttempts = maxPollAttempts;
+    this.pollDelayMs = pollDelayMs;
+    this.sleep = options.sleep ?? defaultSleep;
+    this.core = new DesignHttpCore({
+      providerId: CANVA_PROVIDER_ID,
+      connectionId: options.connectionId,
+      baseUrl: options.baseUrl ?? CANVA_API_ORIGIN,
+      credentialHeader: {
+        name: "authorization",
+        value: `Bearer ${options.accessToken}`,
+      },
+      timeoutMs: options.timeoutMs,
+      responseByteLimit: options.responseByteLimit,
+      testTransport: options.testTransport,
+      allowPrivateNetworkForTests: options.allowPrivateNetworkForTests,
+      classifyError: classifyCanvaError,
+    });
+  }
+
+  get connectionId(): string {
+    return this.core.connectionId;
+  }
+
+  async searchDesigns(request: DesignSearchRequest): Promise<DesignPage> {
+    const parsed = designSearchRequestSchema.safeParse(request);
+    if (!parsed.success) {
+      throw new DesignError("Design search request is invalid.", {
+        code: "DESIGN_INVALID_INPUT",
+        cause: parsed.error,
+      });
+    }
+    const url = new URL("/rest/v1/designs", this.core.baseOrigin);
+    url.searchParams.set("query", parsed.data.query);
+    if (parsed.data.cursor)
+      url.searchParams.set("continuation", parsed.data.cursor);
+    if (parsed.data.limit !== undefined)
+      url.searchParams.set("limit", String(parsed.data.limit));
+    const listing = await this.core.requestJson(
+      url,
+      { method: "GET" },
+      canvaDesignListSchema,
+    );
+    if (listing === null) {
+      throw new DesignError("Canva design listing was unexpectedly absent.", {
+        code: "DESIGN_MALFORMED_RESPONSE",
+      });
+    }
+    return designPageSchema.parse({
+      designs: listing.items.map((item) => this.normalizedRef(item)),
+      nextCursor: listing.continuation ?? null,
+    });
+  }
+
+  async getDesign(providerDesignId: string): Promise<DesignRef | null> {
+    if (!providerDesignId || providerDesignId.length > 512) {
+      throw new DesignError("Design id is invalid.", {
+        code: "DESIGN_INVALID_INPUT",
+      });
+    }
+    const url = new URL(
+      `/rest/v1/designs/${encodeURIComponent(providerDesignId)}`,
+      this.core.baseOrigin,
+    );
+    const detail = await this.core.requestJson(
+      url,
+      { method: "GET" },
+      canvaDesignGetSchema,
+      { allowNotFound: true },
+    );
+    return detail === null ? null : this.normalizedRef(detail.design);
+  }
+
+  async exportDesign(
+    request: DesignExportRequest,
+  ): Promise<DesignExportArtifact> {
+    const parsed = designExportRequestSchema.safeParse(request);
+    if (!parsed.success) {
+      throw new DesignError("Design export request is invalid.", {
+        code: "DESIGN_INVALID_INPUT",
+        cause: parsed.error,
+      });
+    }
+    if (parsed.data.format === "svg") {
+      throw new DesignError("Canva does not export SVG.", {
+        code: "DESIGN_UNSUPPORTED",
+      });
+    }
+    const createUrl = new URL("/rest/v1/exports", this.core.baseOrigin);
+    const created = await this.core.requestJson(
+      createUrl,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          design_id: parsed.data.providerDesignId,
+          format: { type: parsed.data.format },
+        }),
+      },
+      canvaExportJobSchema,
+    );
+    if (created === null) {
+      throw new DesignError("Canva export job was unexpectedly absent.", {
+        code: "DESIGN_MALFORMED_RESPONSE",
+      });
+    }
+    let job = created.job;
+    for (
+      let attempt = 0;
+      job.status === "in_progress" && attempt < this.maxPollAttempts;
+      attempt += 1
+    ) {
+      if (this.pollDelayMs > 0) await this.sleep(this.pollDelayMs);
+      const pollUrl = new URL(
+        `/rest/v1/exports/${encodeURIComponent(job.id)}`,
+        this.core.baseOrigin,
+      );
+      const polled = await this.core.requestJson(
+        pollUrl,
+        { method: "GET" },
+        canvaExportJobSchema,
+      );
+      if (polled === null) {
+        throw new DesignError("Canva export job was unexpectedly absent.", {
+          code: "DESIGN_MALFORMED_RESPONSE",
+        });
+      }
+      job = polled.job;
+    }
+    if (job.status === "in_progress") {
+      throw new DesignError(
+        "The Canva export did not complete within the polling budget.",
+        {
+          code: "DESIGN_PROVIDER_TIMEOUT",
+          context: { jobId: job.id, attempts: this.maxPollAttempts },
+        },
+      );
+    }
+    if (job.status === "failed") {
+      if (job.error && PLAN_LIMITED_CODES.has(job.error.code)) {
+        throw new DesignError(
+          "This Canva export requires a paid or beta capability the connected account lacks.",
+          {
+            code: "DESIGN_PLAN_LIMITED",
+            context: { jobId: job.id, providerCode: job.error.code },
+          },
+        );
+      }
+      throw new DesignError("Canva could not export the design.", {
+        code: "DESIGN_EXPORT_FAILED",
+        context: {
+          jobId: job.id,
+          ...(job.error ? { providerCode: job.error.code } : {}),
+        },
+      });
+    }
+    const artifact = designExportArtifactSchema.safeParse({
+      provider: this.id,
+      providerDesignId: parsed.data.providerDesignId,
+      format: parsed.data.format,
+      urls: job.urls ?? [],
+    });
+    if (!artifact.success) {
+      throw new DesignError(
+        "Canva reported a successful export without valid download URLs.",
+        { code: "DESIGN_MALFORMED_RESPONSE", cause: artifact.error },
+      );
+    }
+    return artifact.data;
+  }
+
+  async listComments(): Promise<DesignCommentPage> {
+    throw new DesignError(
+      "Canva comment reads require the Comment API beta capability, which is not granted to BYO Connect integrations.",
+      { code: "DESIGN_UNSUPPORTED" },
+    );
+  }
+
+  private normalizedRef(
+    item: z.infer<typeof canvaDesignItemSchema>,
+  ): DesignRef {
+    const parsed = designRefSchema.safeParse({
+      provider: this.id,
+      providerDesignId: item.id,
+      // Canva permits untitled designs; mirror the provider's own placeholder.
+      name: item.title?.trim() ? item.title : "Untitled design",
+      deepLinkUrl: item.urls.view_url,
+      ...(item.thumbnail ? { thumbnailUrl: item.thumbnail.url } : {}),
+      ...(item.updated_at !== undefined
+        ? { updatedAt: new Date(item.updated_at * 1_000).toISOString() }
+        : {}),
+    });
+    if (!parsed.success) {
+      throw new DesignError("Canva returned an invalid design record.", {
+        code: "DESIGN_MALFORMED_RESPONSE",
+        cause: parsed.error,
+      });
+    }
+    for (const link of [parsed.data.deepLinkUrl, parsed.data.thumbnailUrl]) {
+      if (link && !/(^|\.)canva\.com$/.test(new URL(link).hostname)) {
+        throw new DesignError(
+          "Canva returned a deep link outside the canva.com domain.",
+          { code: "DESIGN_MALFORMED_RESPONSE", context: { link } },
+        );
+      }
+    }
+    return parsed.data;
+  }
+}

--- a/plugins/plugin-design/src/errors.ts
+++ b/plugins/plugin-design/src/errors.ts
@@ -1,0 +1,50 @@
+/** Carries typed design validation, eligibility, provider, and transport failures. */
+
+import { ElizaError } from "@elizaos/core";
+
+export type DesignErrorCode =
+  | "DESIGN_INVALID_INPUT"
+  | "DESIGN_NOT_CONNECTED"
+  | "DESIGN_UNSUPPORTED"
+  | "DESIGN_MANAGED_MODE_INELIGIBLE"
+  | "DESIGN_PLAN_LIMITED"
+  | "DESIGN_AUTH_EXPIRED"
+  | "DESIGN_AUTH_REVOKED"
+  | "DESIGN_RATE_LIMITED"
+  | "DESIGN_PROVIDER_REJECTED"
+  | "DESIGN_PROVIDER_FAILURE"
+  | "DESIGN_PROVIDER_TIMEOUT"
+  | "DESIGN_PROVIDER_NETWORK"
+  | "DESIGN_ENDPOINT_BLOCKED"
+  | "DESIGN_RESPONSE_TOO_LARGE"
+  | "DESIGN_MALFORMED_RESPONSE"
+  | "DESIGN_EXPORT_FAILED";
+
+export class DesignError extends ElizaError {
+  override readonly name = "DesignError";
+  readonly retryAfterMs?: number;
+
+  constructor(
+    message: string,
+    options: {
+      code: DesignErrorCode;
+      retryAfterMs?: number;
+      cause?: unknown;
+      context?: Record<string, unknown>;
+    },
+  ) {
+    super(message, {
+      code: options.code,
+      cause: options.cause,
+      context: options.context,
+      severity:
+        options.code === "DESIGN_RATE_LIMITED" ||
+        options.code === "DESIGN_PROVIDER_TIMEOUT" ||
+        options.code === "DESIGN_PROVIDER_NETWORK" ||
+        options.code === "DESIGN_PROVIDER_FAILURE"
+          ? "ephemeral"
+          : "fatal",
+    });
+    this.retryAfterMs = options.retryAfterMs;
+  }
+}

--- a/plugins/plugin-design/src/figma.ts
+++ b/plugins/plugin-design/src/figma.ts
@@ -1,0 +1,409 @@
+/**
+ * Figma REST adapter for the design domain, running in local BYO-credential
+ * mode with a personal access token (`X-Figma-Token`). Search lists the files
+ * of one configured project (the Figma REST API has no search endpoint, so the
+ * query filters that listing client-side and pagination is designed-absent).
+ * Exports resolve node renders through `/v1/images` and return the short-lived
+ * Figma URLs without rehosting bytes. Managed Cloud OAuth is a separate,
+ * eligibility-gated path owned by the design service.
+ */
+
+import * as z from "zod";
+import type { DesignProviderAdapter } from "./adapter.js";
+import { DesignError } from "./errors.js";
+import { DesignHttpCore, type DesignTestTransport } from "./http.js";
+import {
+  type DesignCapability,
+  type DesignCommentPage,
+  type DesignExportArtifact,
+  type DesignExportRequest,
+  type DesignPage,
+  type DesignRef,
+  type DesignSearchRequest,
+  designCommentPageSchema,
+  designExportArtifactSchema,
+  designExportRequestSchema,
+  designPageSchema,
+  designRefSchema,
+  designSearchRequestSchema,
+} from "./types.js";
+
+export const FIGMA_PROVIDER_ID = "figma";
+export const FIGMA_API_ORIGIN = "https://api.figma.com";
+
+const wireText = z.string().min(1).max(2_048);
+
+const figmaProjectFilesSchema = z.object({
+  files: z
+    .array(
+      z.object({
+        key: wireText,
+        name: z.string().min(1).max(300),
+        thumbnail_url: z.string().max(2_048).optional(),
+        last_modified: wireText,
+      }),
+    )
+    .max(1_000),
+});
+
+const figmaFileSchema = z.object({
+  name: z.string().min(1).max(300),
+  lastModified: wireText,
+  thumbnailUrl: z.string().max(2_048).optional(),
+  version: wireText.optional(),
+});
+
+const figmaImagesSchema = z.object({
+  err: z.string().max(2_048).nullable(),
+  images: z.record(z.string(), z.string().max(2_048).nullable()),
+});
+
+const figmaCommentsSchema = z.object({
+  comments: z
+    .array(
+      z.object({
+        id: wireText,
+        message: z.string().max(10_000),
+        user: z.object({ handle: z.string().min(1).max(300) }),
+        created_at: wireText,
+        resolved_at: wireText.nullable().optional(),
+      }),
+    )
+    .max(1_000),
+});
+
+export interface FigmaDesignAdapterOptions {
+  connectionId: string;
+  personalAccessToken: string;
+  /** Enables search by scoping the listing to one Figma project. */
+  projectId?: string;
+  /** Override for tests or a local desktop-bridge endpoint; defaults to the public API. */
+  baseUrl?: string;
+  timeoutMs?: number;
+  responseByteLimit?: number;
+  testTransport?: DesignTestTransport;
+  allowPrivateNetworkForTests?: boolean;
+}
+
+function classifyFigmaError(
+  status: number,
+  body: unknown,
+  retryAfterMs: number | undefined,
+): DesignError {
+  const err =
+    body && typeof body === "object" && "err" in body
+      ? String((body as { err?: unknown }).err ?? "").toLowerCase()
+      : "";
+  if (status === 429) {
+    return new DesignError("Figma is rate limited.", {
+      code: "DESIGN_RATE_LIMITED",
+      retryAfterMs,
+      context: { status },
+    });
+  }
+  if (status === 401 || status === 403) {
+    if (err.includes("expired")) {
+      return new DesignError("The Figma token has expired.", {
+        code: "DESIGN_AUTH_EXPIRED",
+        context: { status },
+      });
+    }
+    if (err.includes("plan") || err.includes("seat")) {
+      return new DesignError(
+        "This Figma operation is limited by the account's plan or seat.",
+        { code: "DESIGN_PLAN_LIMITED", context: { status } },
+      );
+    }
+    return new DesignError("The Figma token was revoked or is invalid.", {
+      code: "DESIGN_AUTH_REVOKED",
+      context: { status },
+    });
+  }
+  if (status >= 500) {
+    return new DesignError("Figma failed.", {
+      code: "DESIGN_PROVIDER_FAILURE",
+      context: { status },
+    });
+  }
+  return new DesignError("Figma rejected the request.", {
+    code: "DESIGN_PROVIDER_REJECTED",
+    context: { status },
+  });
+}
+
+function figmaDeepLink(fileKey: string): string {
+  return `https://www.figma.com/design/${encodeURIComponent(fileKey)}`;
+}
+
+function isoOrUndefined(value: string): string | undefined {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : undefined;
+}
+
+function httpsOrUndefined(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    return new URL(value).protocol === "https:" ? value : undefined;
+  } catch {
+    // error-policy:J3 A malformed provider thumbnail URL becomes an explicit
+    // absent optional field, never a fake-valid value.
+    return undefined;
+  }
+}
+
+export class FigmaDesignAdapter implements DesignProviderAdapter {
+  readonly id = FIGMA_PROVIDER_ID;
+  readonly capabilities: ReadonlySet<DesignCapability>;
+  private readonly core: DesignHttpCore;
+  private readonly projectId?: string;
+
+  constructor(options: FigmaDesignAdapterOptions) {
+    if (!options.personalAccessToken.trim()) {
+      throw new DesignError("Figma requires a personal access token.", {
+        code: "DESIGN_INVALID_INPUT",
+      });
+    }
+    if (
+      options.projectId !== undefined &&
+      !/^\d{1,64}$/.test(options.projectId)
+    ) {
+      throw new DesignError("Figma project id must be numeric.", {
+        code: "DESIGN_INVALID_INPUT",
+      });
+    }
+    this.projectId = options.projectId;
+    this.capabilities = new Set<DesignCapability>([
+      ...(this.projectId ? (["search"] as const) : []),
+      "get",
+      "export",
+      "comments",
+    ]);
+    this.core = new DesignHttpCore({
+      providerId: FIGMA_PROVIDER_ID,
+      connectionId: options.connectionId,
+      baseUrl: options.baseUrl ?? FIGMA_API_ORIGIN,
+      credentialHeader: {
+        name: "x-figma-token",
+        value: options.personalAccessToken,
+      },
+      timeoutMs: options.timeoutMs,
+      responseByteLimit: options.responseByteLimit,
+      testTransport: options.testTransport,
+      allowPrivateNetworkForTests: options.allowPrivateNetworkForTests,
+      classifyError: classifyFigmaError,
+    });
+  }
+
+  get connectionId(): string {
+    return this.core.connectionId;
+  }
+
+  async searchDesigns(request: DesignSearchRequest): Promise<DesignPage> {
+    const parsed = designSearchRequestSchema.safeParse(request);
+    if (!parsed.success) {
+      throw new DesignError("Design search request is invalid.", {
+        code: "DESIGN_INVALID_INPUT",
+        cause: parsed.error,
+      });
+    }
+    if (!this.projectId) {
+      throw new DesignError(
+        "Figma search requires FIGMA_PROJECT_ID because the REST API has no search endpoint.",
+        { code: "DESIGN_UNSUPPORTED" },
+      );
+    }
+    if (parsed.data.cursor !== undefined) {
+      throw new DesignError(
+        "Figma project listings are not paginated; a cursor is invalid here.",
+        { code: "DESIGN_INVALID_INPUT" },
+      );
+    }
+    const url = new URL(
+      `/v1/projects/${encodeURIComponent(this.projectId)}/files`,
+      this.core.baseOrigin,
+    );
+    const listing = await this.core.requestJson(
+      url,
+      { method: "GET" },
+      figmaProjectFilesSchema,
+    );
+    if (listing === null) {
+      throw new DesignError("Figma project listing was unexpectedly absent.", {
+        code: "DESIGN_MALFORMED_RESPONSE",
+      });
+    }
+    const query = parsed.data.query.toLowerCase();
+    const limit = parsed.data.limit ?? 100;
+    const designs = listing.files
+      .filter((file) => file.name.toLowerCase().includes(query))
+      .slice(0, limit)
+      .map((file) =>
+        this.normalizedRef({
+          providerDesignId: file.key,
+          name: file.name,
+          thumbnailUrl: httpsOrUndefined(file.thumbnail_url),
+          updatedAt: isoOrUndefined(file.last_modified),
+        }),
+      );
+    return designPageSchema.parse({ designs, nextCursor: null });
+  }
+
+  async getDesign(providerDesignId: string): Promise<DesignRef | null> {
+    this.assertDesignId(providerDesignId);
+    const url = new URL(
+      `/v1/files/${encodeURIComponent(providerDesignId)}`,
+      this.core.baseOrigin,
+    );
+    url.searchParams.set("depth", "1");
+    const file = await this.core.requestJson(
+      url,
+      { method: "GET" },
+      figmaFileSchema,
+      { allowNotFound: true },
+    );
+    if (file === null) return null;
+    return this.normalizedRef({
+      providerDesignId,
+      name: file.name,
+      thumbnailUrl: httpsOrUndefined(file.thumbnailUrl),
+      updatedAt: isoOrUndefined(file.lastModified),
+    });
+  }
+
+  async exportDesign(
+    request: DesignExportRequest,
+  ): Promise<DesignExportArtifact> {
+    const parsed = designExportRequestSchema.safeParse(request);
+    if (!parsed.success) {
+      throw new DesignError("Design export request is invalid.", {
+        code: "DESIGN_INVALID_INPUT",
+        cause: parsed.error,
+      });
+    }
+    if (!parsed.data.nodeId) {
+      throw new DesignError(
+        "Figma exports render specific nodes; a nodeId is required.",
+        { code: "DESIGN_INVALID_INPUT" },
+      );
+    }
+    const url = new URL(
+      `/v1/images/${encodeURIComponent(parsed.data.providerDesignId)}`,
+      this.core.baseOrigin,
+    );
+    url.searchParams.set("ids", parsed.data.nodeId);
+    url.searchParams.set("format", parsed.data.format);
+    if (parsed.data.scale !== undefined)
+      url.searchParams.set("scale", String(parsed.data.scale));
+    const rendered = await this.core.requestJson(
+      url,
+      { method: "GET" },
+      figmaImagesSchema,
+    );
+    if (rendered === null || rendered.err !== null) {
+      throw new DesignError("Figma could not render the requested export.", {
+        code: "DESIGN_EXPORT_FAILED",
+        context: { providerError: rendered?.err ?? "absent response" },
+      });
+    }
+    const urls = Object.values(rendered.images).filter(
+      (value): value is string => typeof value === "string",
+    );
+    if (
+      urls.length === 0 ||
+      urls.length !== Object.keys(rendered.images).length
+    ) {
+      throw new DesignError(
+        "Figma reported one or more nodes it could not render.",
+        { code: "DESIGN_EXPORT_FAILED" },
+      );
+    }
+    const artifact = designExportArtifactSchema.safeParse({
+      provider: this.id,
+      providerDesignId: parsed.data.providerDesignId,
+      format: parsed.data.format,
+      urls,
+    });
+    if (!artifact.success) {
+      throw new DesignError("Figma returned invalid export URLs.", {
+        code: "DESIGN_MALFORMED_RESPONSE",
+        cause: artifact.error,
+      });
+    }
+    return artifact.data;
+  }
+
+  async listComments(
+    providerDesignId: string,
+    cursor?: string,
+  ): Promise<DesignCommentPage> {
+    this.assertDesignId(providerDesignId);
+    if (cursor !== undefined) {
+      throw new DesignError(
+        "Figma comment listings are not paginated; a cursor is invalid here.",
+        { code: "DESIGN_INVALID_INPUT" },
+      );
+    }
+    const url = new URL(
+      `/v1/files/${encodeURIComponent(providerDesignId)}/comments`,
+      this.core.baseOrigin,
+    );
+    const listing = await this.core.requestJson(
+      url,
+      { method: "GET" },
+      figmaCommentsSchema,
+    );
+    if (listing === null) {
+      throw new DesignError("Figma comment listing was unexpectedly absent.", {
+        code: "DESIGN_MALFORMED_RESPONSE",
+      });
+    }
+    const comments = listing.comments.slice(0, 200).map((comment) => {
+      const createdAt = isoOrUndefined(comment.created_at);
+      if (!createdAt) {
+        throw new DesignError("Figma returned an invalid comment timestamp.", {
+          code: "DESIGN_MALFORMED_RESPONSE",
+        });
+      }
+      return {
+        provider: this.id,
+        commentId: comment.id,
+        message: comment.message,
+        author: comment.user.handle,
+        createdAt,
+        resolved: typeof comment.resolved_at === "string",
+      };
+    });
+    return designCommentPageSchema.parse({ comments, nextCursor: null });
+  }
+
+  private assertDesignId(providerDesignId: string): void {
+    if (!providerDesignId || providerDesignId.length > 512) {
+      throw new DesignError("Design id is invalid.", {
+        code: "DESIGN_INVALID_INPUT",
+      });
+    }
+  }
+
+  private normalizedRef(fields: {
+    providerDesignId: string;
+    name: string;
+    thumbnailUrl?: string;
+    updatedAt?: string;
+  }): DesignRef {
+    const parsed = designRefSchema.safeParse({
+      provider: this.id,
+      providerDesignId: fields.providerDesignId,
+      name: fields.name,
+      deepLinkUrl: figmaDeepLink(fields.providerDesignId),
+      ...(fields.thumbnailUrl ? { thumbnailUrl: fields.thumbnailUrl } : {}),
+      ...(fields.updatedAt ? { updatedAt: fields.updatedAt } : {}),
+    });
+    if (!parsed.success) {
+      throw new DesignError("Figma returned an invalid design record.", {
+        code: "DESIGN_MALFORMED_RESPONSE",
+        cause: parsed.error,
+      });
+    }
+    return parsed.data;
+  }
+}

--- a/plugins/plugin-design/src/http.ts
+++ b/plugins/plugin-design/src/http.ts
@@ -1,0 +1,450 @@
+/**
+ * Shared bounded, SSRF-guarded JSON-over-HTTP transport core for design
+ * provider adapters. Credentials are pinned to one configured origin;
+ * redirects are rejected and every production connection uses core's
+ * DNS-pinned transport. Provider-specific wire semantics stay in the
+ * adapters, which supply the error classifier for non-2xx statuses.
+ */
+
+import {
+  fetchWithSsrfGuard,
+  type GuardedFetchOptions,
+  isBlockedHostname,
+  isPrivateIpAddress,
+  logger,
+  SsrfBlockedError,
+} from "@elizaos/core";
+import { DesignError } from "./errors.js";
+
+export type DesignTestTransport = Pick<
+  GuardedFetchOptions,
+  "fetchImpl" | "pinnedFetchImpl" | "lookupFn"
+>;
+
+export interface DesignHttpCoreOptions {
+  providerId: string;
+  connectionId: string;
+  baseUrl: string;
+  /** Header name plus formatted value; the raw credential never appears elsewhere. */
+  credentialHeader?: { name: string; value: string };
+  timeoutMs?: number;
+  responseByteLimit?: number;
+  /** Explicit transport seam for deterministic SSRF/adversarial tests only. */
+  testTransport?: DesignTestTransport;
+  /** Allows an injected test transport to reach its loopback fake upstream. */
+  allowPrivateNetworkForTests?: boolean;
+  /** Maps a non-2xx provider response to a typed domain failure. */
+  classifyError: (
+    status: number,
+    body: unknown,
+    retryAfterMs: number | undefined,
+  ) => DesignError;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MIN_TIMEOUT_MS = 100;
+const MAX_TIMEOUT_MS = 60_000;
+const DEFAULT_RESPONSE_BYTES = 1024 * 1024;
+const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+
+interface RequestDeadline {
+  signal: AbortSignal;
+  dispose(): void;
+}
+
+function requestDeadline(timeoutMs: number): RequestDeadline {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () =>
+      controller.abort(
+        new DOMException("Design deadline elapsed", "TimeoutError"),
+      ),
+    timeoutMs,
+  );
+  timeout.unref?.();
+  return {
+    signal: controller.signal,
+    dispose: () => clearTimeout(timeout),
+  };
+}
+
+function observeTeardown(operation: Promise<unknown>, surface: string): void {
+  // error-policy:J6 Teardown is intentionally non-blocking; a redacted debug
+  // observation keeps cancellation failures visible without delaying results.
+  void operation.catch((error) => {
+    logger.debug(
+      {
+        errorName: error instanceof Error ? error.name : typeof error,
+        surface,
+      },
+      "[DesignHttpCore] Response-stream teardown did not complete cleanly",
+    );
+  });
+}
+
+function cancelBody(response: Response, reason: string): void {
+  // error-policy:J6 Cancellation is teardown only and must never delay the
+  // typed terminal result from an untrusted response stream.
+  if (response.body) observeTeardown(response.body.cancel(reason), reason);
+}
+
+export function retryAfterMs(response: Response): number | undefined {
+  const raw = response.headers.get("retry-after");
+  if (!raw) return undefined;
+  const seconds = Number(raw);
+  if (Number.isFinite(seconds) && seconds >= 0)
+    return Math.round(seconds * 1_000);
+  const date = Date.parse(raw);
+  return Number.isFinite(date) ? Math.max(0, date - Date.now()) : undefined;
+}
+
+export interface JsonSchemaLike<T> {
+  safeParse(
+    value: unknown,
+  ): { success: true; data: T } | { success: false; error: unknown };
+}
+
+export class DesignHttpCore {
+  readonly providerId: string;
+  readonly connectionId: string;
+  readonly baseOrigin: string;
+  private readonly credentialHeader?: { name: string; value: string };
+  private readonly timeoutMs: number;
+  private readonly responseByteLimit: number;
+  private readonly testTransport?: DesignTestTransport;
+  private readonly allowPrivateNetworkForTests: boolean;
+  private readonly classifyError: DesignHttpCoreOptions["classifyError"];
+
+  constructor(options: DesignHttpCoreOptions) {
+    if (!/^[a-z0-9][a-z0-9_-]*$/i.test(options.providerId)) {
+      throw new DesignError("Design adapter id is invalid.", {
+        code: "DESIGN_INVALID_INPUT",
+      });
+    }
+    if (!/^conn_[A-Za-z0-9_-]{16,}$/.test(options.connectionId)) {
+      throw new DesignError("Design adapter connection id must be opaque.", {
+        code: "DESIGN_INVALID_INPUT",
+      });
+    }
+    let baseUrl: URL;
+    try {
+      baseUrl = new URL(options.baseUrl);
+    } catch (error) {
+      throw new DesignError("Design adapter endpoint is invalid.", {
+        code: "DESIGN_INVALID_INPUT",
+        cause: error,
+      });
+    }
+    const allowPrivateTest = options.allowPrivateNetworkForTests === true;
+    if (allowPrivateTest && !options.testTransport?.fetchImpl) {
+      throw new DesignError(
+        "Private-network design endpoints require an explicit injected test transport.",
+        { code: "DESIGN_INVALID_INPUT" },
+      );
+    }
+    if (
+      baseUrl.protocol !== "https:" &&
+      !(allowPrivateTest && baseUrl.protocol === "http:")
+    ) {
+      throw new DesignError("Design adapter endpoint must use HTTPS.", {
+        code: "DESIGN_INVALID_INPUT",
+      });
+    }
+    if (
+      baseUrl.username ||
+      baseUrl.password ||
+      baseUrl.search ||
+      baseUrl.hash
+    ) {
+      throw new DesignError(
+        "Design adapter endpoint cannot contain userinfo, query, or fragment data.",
+        { code: "DESIGN_INVALID_INPUT" },
+      );
+    }
+    if (baseUrl.pathname !== "/") {
+      throw new DesignError("Design adapter endpoint must be an origin URL.", {
+        code: "DESIGN_INVALID_INPUT",
+      });
+    }
+    if (
+      !allowPrivateTest &&
+      (isBlockedHostname(baseUrl.hostname) ||
+        isPrivateIpAddress(baseUrl.hostname))
+    ) {
+      throw new DesignError("Design adapter endpoint is not a public origin.", {
+        code: "DESIGN_ENDPOINT_BLOCKED",
+      });
+    }
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    if (
+      !Number.isFinite(timeoutMs) ||
+      !Number.isInteger(timeoutMs) ||
+      timeoutMs < MIN_TIMEOUT_MS ||
+      timeoutMs > MAX_TIMEOUT_MS
+    ) {
+      throw new DesignError(
+        `Design adapter timeout must be an integer from ${MIN_TIMEOUT_MS} to ${MAX_TIMEOUT_MS} ms.`,
+        { code: "DESIGN_INVALID_INPUT" },
+      );
+    }
+    const responseByteLimit =
+      options.responseByteLimit ?? DEFAULT_RESPONSE_BYTES;
+    if (
+      !Number.isFinite(responseByteLimit) ||
+      !Number.isInteger(responseByteLimit) ||
+      responseByteLimit < 1 ||
+      responseByteLimit > MAX_RESPONSE_BYTES
+    ) {
+      throw new DesignError("Design adapter response byte limit is invalid.", {
+        code: "DESIGN_INVALID_INPUT",
+      });
+    }
+    this.providerId = options.providerId;
+    this.connectionId = options.connectionId;
+    this.baseOrigin = baseUrl.origin;
+    this.credentialHeader = options.credentialHeader;
+    this.timeoutMs = timeoutMs;
+    this.responseByteLimit = responseByteLimit;
+    this.testTransport = options.testTransport;
+    this.allowPrivateNetworkForTests = allowPrivateTest;
+    this.classifyError = options.classifyError;
+  }
+
+  /** Requests and strictly decodes one JSON resource; 404 resolves null when allowed. */
+  async requestJson<T>(
+    url: URL,
+    init: RequestInit,
+    schema: JsonSchemaLike<T>,
+    options?: { allowNotFound?: boolean },
+  ): Promise<T | null> {
+    const deadline = requestDeadline(this.timeoutMs);
+    try {
+      const guarded = await this.fetchResponse(url, init, deadline);
+      try {
+        if (options?.allowNotFound && guarded.response.status === 404) {
+          cancelBody(guarded.response, "design resource was not found");
+          return null;
+        }
+        return await this.decodeResponse(guarded.response, schema, deadline);
+      } finally {
+        await guarded.release();
+      }
+    } finally {
+      deadline.dispose();
+    }
+  }
+
+  private async fetchResponse(
+    url: URL,
+    init: RequestInit,
+    deadline: RequestDeadline,
+  ): ReturnType<typeof fetchWithSsrfGuard> {
+    if (url.origin !== this.baseOrigin) {
+      throw new DesignError(
+        "Design request escaped the configured provider origin.",
+        { code: "DESIGN_ENDPOINT_BLOCKED" },
+      );
+    }
+    const headers = new Headers(init.headers);
+    if (this.credentialHeader)
+      headers.set(this.credentialHeader.name, this.credentialHeader.value);
+    headers.set("x-design-connection-id", this.connectionId);
+    try {
+      return await fetchWithSsrfGuard({
+        url: url.href,
+        init: { ...init, headers, redirect: "manual", signal: deadline.signal },
+        maxRedirects: 0,
+        timeoutMs: this.timeoutMs,
+        signal: deadline.signal,
+        policy: this.allowPrivateNetworkForTests
+          ? { allowPrivateNetwork: true }
+          : undefined,
+        ...this.testTransport,
+      });
+    } catch (error) {
+      // error-policy:J2 Add a typed provider/network classification while
+      // preserving the original transport failure as the cause.
+      if (
+        deadline.signal.aborted ||
+        (error instanceof Error &&
+          (error.name === "AbortError" || error.name === "TimeoutError"))
+      ) {
+        throw new DesignError("The design provider timed out.", {
+          code: "DESIGN_PROVIDER_TIMEOUT",
+          cause: error,
+        });
+      }
+      if (error instanceof SsrfBlockedError) {
+        throw new DesignError(
+          "The design provider endpoint was blocked by network policy.",
+          { code: "DESIGN_ENDPOINT_BLOCKED", cause: error },
+        );
+      }
+      throw new DesignError("The design provider connection failed.", {
+        code: "DESIGN_PROVIDER_NETWORK",
+        cause: error,
+      });
+    }
+  }
+
+  private async readBoundedBody(
+    response: Response,
+    deadline: RequestDeadline,
+  ): Promise<string> {
+    const declared = response.headers.get("content-length");
+    if (
+      declared &&
+      /^\d+$/.test(declared) &&
+      Number(declared) > this.responseByteLimit
+    ) {
+      cancelBody(response, "design declared response exceeded byte limit");
+      throw new DesignError(
+        "The design provider response exceeded the byte limit.",
+        {
+          code: "DESIGN_RESPONSE_TOO_LARGE",
+          context: { status: response.status, limit: this.responseByteLimit },
+        },
+      );
+    }
+    if (!response.body) return "";
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder("utf-8", { fatal: true });
+    let body = "";
+    let bytes = 0;
+    try {
+      while (true) {
+        const chunk = await new Promise<ReadableStreamReadResult<Uint8Array>>(
+          (resolve, reject) => {
+            const onAbort = () =>
+              reject(
+                deadline.signal.reason ??
+                  new DOMException("Design deadline elapsed", "TimeoutError"),
+              );
+            if (deadline.signal.aborted) return onAbort();
+            deadline.signal.addEventListener("abort", onAbort, { once: true });
+            void reader
+              .read()
+              .then(resolve, reject)
+              .finally(() =>
+                deadline.signal.removeEventListener("abort", onAbort),
+              );
+          },
+        );
+        if (chunk.done) break;
+        bytes += chunk.value.byteLength;
+        if (bytes > this.responseByteLimit) {
+          observeTeardown(
+            reader.cancel("design response exceeded byte limit"),
+            "response-too-large",
+          );
+          throw new DesignError(
+            "The design provider response exceeded the byte limit.",
+            {
+              code: "DESIGN_RESPONSE_TOO_LARGE",
+              context: {
+                status: response.status,
+                limit: this.responseByteLimit,
+              },
+            },
+          );
+        }
+        body += decoder.decode(chunk.value, { stream: true });
+      }
+      body += decoder.decode();
+      return body;
+    } catch (error) {
+      if (error instanceof DesignError) throw error;
+      if (
+        deadline.signal.aborted ||
+        (error instanceof Error &&
+          (error.name === "AbortError" || error.name === "TimeoutError"))
+      ) {
+        observeTeardown(
+          reader.cancel("design response deadline elapsed"),
+          "response-deadline",
+        );
+        throw new DesignError("The design provider timed out.", {
+          code: "DESIGN_PROVIDER_TIMEOUT",
+          cause: error,
+          context: { status: response.status },
+        });
+      }
+      // error-policy:J2 Provider bytes are untrusted; preserve bounded read and
+      // UTF-8 failures without retaining or exposing response content.
+      throw new DesignError(
+        "The design provider response body could not be read.",
+        {
+          code: "DESIGN_MALFORMED_RESPONSE",
+          cause: error,
+          context: { status: response.status },
+        },
+      );
+    } finally {
+      try {
+        reader.releaseLock();
+      } catch (error) {
+        // error-policy:J6 A pending untrusted read owns the lock until its
+        // non-blocking cancellation settles; terminal classification is fixed.
+        logger.debug(
+          {
+            errorName: error instanceof Error ? error.name : typeof error,
+            surface: "reader-release-lock",
+          },
+          "[DesignHttpCore] Response reader lock remained pending during teardown",
+        );
+      }
+    }
+  }
+
+  private async decodeResponse<T>(
+    response: Response,
+    schema: JsonSchemaLike<T>,
+    deadline: RequestDeadline,
+  ): Promise<T> {
+    if (!response.ok) {
+      let errorBody: unknown;
+      if (response.status < 500) {
+        try {
+          const text = await this.readBoundedBody(response, deadline);
+          if (text) errorBody = JSON.parse(text);
+        } catch {
+          // error-policy:J3 Diagnostic bytes are optional; once headers carry
+          // an error status, timeout/size/parse failures cannot replace it.
+          errorBody = undefined;
+        }
+      } else {
+        cancelBody(response, "design provider returned an error status");
+      }
+      throw this.classifyError(
+        response.status,
+        errorBody,
+        retryAfterMs(response),
+      );
+    }
+    const text = await this.readBoundedBody(response, deadline);
+    let body: unknown;
+    try {
+      body = JSON.parse(text);
+    } catch (error) {
+      // error-policy:J2 Provider bytes are untrusted; preserve the JSON parse
+      // failure without retaining or exposing the response body.
+      throw new DesignError("The design provider returned malformed JSON.", {
+        code: "DESIGN_MALFORMED_RESPONSE",
+        cause: error,
+        context: { status: response.status },
+      });
+    }
+    const parsed = schema.safeParse(body);
+    if (!parsed.success) {
+      throw new DesignError(
+        "The design provider response did not match the contract.",
+        {
+          code: "DESIGN_MALFORMED_RESPONSE",
+          cause: parsed.error,
+          context: { status: response.status },
+        },
+      );
+    }
+    return parsed.data;
+  }
+}

--- a/plugins/plugin-design/src/index.ts
+++ b/plugins/plugin-design/src/index.ts
@@ -1,0 +1,43 @@
+/** Public surface of the design domain plugin and its provider adapters. */
+
+export type { DesignProviderAdapter } from "./adapter.js";
+export {
+  CANVA_API_ORIGIN,
+  CANVA_PROVIDER_ID,
+  CanvaDesignAdapter,
+  type CanvaDesignAdapterOptions,
+} from "./canva.js";
+export { DesignError, type DesignErrorCode } from "./errors.js";
+export {
+  FIGMA_API_ORIGIN,
+  FIGMA_PROVIDER_ID,
+  FigmaDesignAdapter,
+  type FigmaDesignAdapterOptions,
+} from "./figma.js";
+export { default, designPlugin } from "./plugin.js";
+export {
+  DESIGN_SERVICE_TYPE,
+  DesignService,
+  MANAGED_DESIGN_ELIGIBILITY,
+  type ManagedDesignEligibility,
+  type ManagedDesignProvider,
+} from "./service.js";
+export type {
+  DesignCapability,
+  DesignComment,
+  DesignCommentPage,
+  DesignExportArtifact,
+  DesignExportFormat,
+  DesignExportRequest,
+  DesignPage,
+  DesignRef,
+  DesignSearchRequest,
+} from "./types.js";
+export {
+  designCommentPageSchema,
+  designExportArtifactSchema,
+  designExportRequestSchema,
+  designPageSchema,
+  designRefSchema,
+  designSearchRequestSchema,
+} from "./types.js";

--- a/plugins/plugin-design/src/plugin.ts
+++ b/plugins/plugin-design/src/plugin.ts
@@ -1,0 +1,13 @@
+/** Registers the design service; action/view wiring lands with the domain UI issues. */
+
+import type { Plugin } from "@elizaos/core";
+import { DesignService } from "./service.js";
+
+export const designPlugin: Plugin = {
+  name: "design",
+  description:
+    "Provider-neutral design search, lookup, export, and comment reads with local-mode Canva and Figma adapters.",
+  services: [DesignService],
+};
+
+export default designPlugin;

--- a/plugins/plugin-design/src/service.test.ts
+++ b/plugins/plugin-design/src/service.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Covers the design service's adapter registry, capability routing, provider
+ * response binding, settings-driven local-mode startup, and the managed-mode
+ * eligibility gate. Deterministic; adapters are in-memory doubles for the
+ * registry seams while the settings path builds the real adapters.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import type { DesignProviderAdapter } from "./adapter.js";
+import { DesignError } from "./errors.js";
+import { DesignService, MANAGED_DESIGN_ELIGIBILITY } from "./service.js";
+import type { DesignCapability, DesignRef } from "./types.js";
+
+function stubRuntime(settings: Record<string, string>): IAgentRuntime {
+  return {
+    getSetting: (key: string) => settings[key],
+  } as unknown as IAgentRuntime;
+}
+
+function design(provider: string): DesignRef {
+  return {
+    provider,
+    providerDesignId: "d-1",
+    name: "Poster",
+    deepLinkUrl: "https://www.figma.com/design/d-1",
+  };
+}
+
+function fakeAdapter(
+  id: string,
+  overrides: Partial<DesignProviderAdapter> = {},
+): DesignProviderAdapter {
+  return {
+    id,
+    connectionId: `conn_${id.padEnd(4, "x")}_abcdefghij123456`,
+    capabilities: new Set<DesignCapability>([
+      "search",
+      "get",
+      "export",
+      "comments",
+    ]),
+    searchDesigns: async () => ({ designs: [design(id)], nextCursor: null }),
+    getDesign: async () => design(id),
+    exportDesign: async () => ({
+      provider: id,
+      providerDesignId: "d-1",
+      format: "png" as const,
+      urls: ["https://example-cdn.test/render.png"],
+    }),
+    listComments: async () => ({ comments: [], nextCursor: null }),
+    ...overrides,
+  };
+}
+
+async function expectCode(
+  operation: Promise<unknown> | (() => unknown),
+  code: DesignError["code"],
+): Promise<void> {
+  try {
+    await (typeof operation === "function" ? operation() : operation);
+  } catch (error) {
+    // error-policy:J1 The test assertion boundary verifies the typed failure
+    // instead of allowing it to escape the case.
+    expect(error).toBeInstanceOf(DesignError);
+    expect((error as DesignError).code).toBe(code);
+    return;
+  }
+  throw new Error(`Expected ${code}`);
+}
+
+describe("DesignService", () => {
+  it("starts with no adapters and fails requests with a typed not-connected error", async () => {
+    const service = await DesignService.start(stubRuntime({}));
+    expect(service.listAdapters()).toEqual([]);
+    await expectCode(
+      service.searchDesigns({ query: "poster" }),
+      "DESIGN_NOT_CONNECTED",
+    );
+    await expectCode(service.getDesign("d-1", "figma"), "DESIGN_NOT_CONNECTED");
+  });
+
+  it("builds local-mode adapters only from explicit settings, never a Cloud fallback", async () => {
+    const figmaOnly = await DesignService.start(
+      stubRuntime({ FIGMA_PERSONAL_ACCESS_TOKEN: "figd_local" }),
+    );
+    expect(figmaOnly.listAdapters()).toEqual(["figma"]);
+
+    const both = await DesignService.start(
+      stubRuntime({
+        FIGMA_PERSONAL_ACCESS_TOKEN: "figd_local",
+        FIGMA_PROJECT_ID: "123",
+        CANVA_ACCESS_TOKEN: "canva_local",
+      }),
+    );
+    expect(both.listAdapters()).toEqual(["figma", "canva"]);
+
+    const blank = await DesignService.start(
+      stubRuntime({ FIGMA_PERSONAL_ACCESS_TOKEN: "   " }),
+    );
+    expect(blank.listAdapters()).toEqual([]);
+  });
+
+  it("keeps managed Cloud mode a typed ineligible state for both providers", async () => {
+    const service = await DesignService.start(stubRuntime({}));
+    for (const provider of ["canva", "figma"] as const) {
+      expect(service.managedEligibility(provider)).toEqual(
+        MANAGED_DESIGN_ELIGIBILITY[provider],
+      );
+      expect(MANAGED_DESIGN_ELIGIBILITY[provider].eligible).toBe(false);
+      await expectCode(
+        () => service.connectManaged(provider),
+        "DESIGN_MANAGED_MODE_INELIGIBLE",
+      );
+    }
+  });
+
+  it("rejects adapters with invalid identity or non-opaque connection ids", async () => {
+    const service = await DesignService.start(stubRuntime({}));
+    await expectCode(
+      () => service.registerAdapter(fakeAdapter("bad id!")),
+      "DESIGN_INVALID_INPUT",
+    );
+    await expectCode(
+      () =>
+        service.registerAdapter(
+          fakeAdapter("figma", { connectionId: "figd_raw_token_value" }),
+        ),
+      "DESIGN_INVALID_INPUT",
+    );
+  });
+
+  it("routes by provider, enforces capabilities, and re-defaults on unregister", async () => {
+    const service = await DesignService.start(stubRuntime({}));
+    service.registerAdapter(fakeAdapter("figma"));
+    service.registerAdapter(
+      fakeAdapter("canva", {
+        capabilities: new Set<DesignCapability>(["search", "get", "export"]),
+        searchDesigns: async () => ({
+          designs: [
+            {
+              ...design("canva"),
+              deepLinkUrl: "https://www.canva.com/design/d-1/view",
+            },
+          ],
+          nextCursor: null,
+        }),
+      }),
+    );
+
+    const page = await service.searchDesigns({ query: "poster" }, "canva");
+    expect(page.designs[0]?.provider).toBe("canva");
+    await expectCode(
+      service.listComments("d-1", "canva"),
+      "DESIGN_UNSUPPORTED",
+    );
+
+    service.unregisterAdapter("figma");
+    const defaulted = await service.searchDesigns({ query: "poster" });
+    expect(defaulted.designs[0]?.provider).toBe("canva");
+    service.unregisterAdapter("canva");
+    await expectCode(
+      service.searchDesigns({ query: "poster" }),
+      "DESIGN_NOT_CONNECTED",
+    );
+  });
+
+  it("rejects provider-spoofed responses and invalid provider payloads", async () => {
+    const service = await DesignService.start(stubRuntime({}));
+    service.registerAdapter(
+      fakeAdapter("figma", {
+        searchDesigns: async () => ({
+          designs: [design("canva")],
+          nextCursor: null,
+        }),
+      }),
+    );
+    await expectCode(
+      service.searchDesigns({ query: "poster" }),
+      "DESIGN_MALFORMED_RESPONSE",
+    );
+
+    service.registerAdapter(
+      fakeAdapter("figma", {
+        exportDesign: async () =>
+          ({
+            provider: "figma",
+            providerDesignId: "d-1",
+            format: "png",
+            urls: ["http://insecure.example.test/render.png"],
+          }) as never,
+      }),
+      true,
+    );
+    await expectCode(
+      service.exportDesign({ providerDesignId: "d-1", format: "png" }),
+      "DESIGN_INVALID_INPUT",
+    );
+  });
+
+  it("stops cleanly and clears registered adapters", async () => {
+    const service = await DesignService.start(stubRuntime({}));
+    service.registerAdapter(fakeAdapter("figma"));
+    await service.stop();
+    expect(service.listAdapters()).toEqual([]);
+    await expectCode(
+      service.searchDesigns({ query: "poster" }),
+      "DESIGN_NOT_CONNECTED",
+    );
+  });
+});

--- a/plugins/plugin-design/src/service.ts
+++ b/plugins/plugin-design/src/service.ts
@@ -1,0 +1,299 @@
+/**
+ * Owns normalized design operations, provider adapter selection, and the
+ * local-versus-managed connection policy. Local mode builds adapters only
+ * from explicit user-supplied credentials in runtime settings and never
+ * silently falls back to Cloud; managed Cloud OAuth for Canva and Figma is
+ * eligibility-gated and stays a typed ineligible state until the provider
+ * apps are approved and the managed adapter SDK path is wired.
+ */
+
+import { randomBytes } from "node:crypto";
+import type { IAgentRuntime } from "@elizaos/core";
+import { logger, Service } from "@elizaos/core";
+import type { DesignProviderAdapter } from "./adapter.js";
+import { CanvaDesignAdapter } from "./canva.js";
+import { DesignError } from "./errors.js";
+import { FigmaDesignAdapter } from "./figma.js";
+import {
+  type DesignCommentPage,
+  type DesignExportArtifact,
+  type DesignExportRequest,
+  type DesignPage,
+  type DesignRef,
+  type DesignSearchRequest,
+  designCommentPageSchema,
+  designExportArtifactSchema,
+  designPageSchema,
+  designRefSchema,
+} from "./types.js";
+
+export const DESIGN_SERVICE_TYPE = "design";
+
+export type ManagedDesignProvider = "canva" | "figma";
+
+export interface ManagedDesignEligibility {
+  eligible: false;
+  reason: string;
+}
+
+/**
+ * Managed Cloud OAuth is blocked on human-only provider app registration and
+ * review. Flipping a provider to eligible is a deliberate code change made
+ * with the approved app credentials custody in Cloud, never a runtime toggle.
+ */
+export const MANAGED_DESIGN_ELIGIBILITY: Readonly<
+  Record<ManagedDesignProvider, ManagedDesignEligibility>
+> = {
+  canva: {
+    eligible: false,
+    reason:
+      "Canva Connect integration review has not been granted; use local mode with CANVA_ACCESS_TOKEN.",
+  },
+  figma: {
+    eligible: false,
+    reason:
+      "Figma OAuth app approval has not been granted; use local mode with FIGMA_PERSONAL_ACCESS_TOKEN.",
+  },
+};
+
+function localConnectionId(provider: string): string {
+  return `conn_local_${provider}_${randomBytes(12).toString("base64url")}`;
+}
+
+function validated<T>(
+  schema: {
+    safeParse(
+      value: unknown,
+    ): { success: true; data: T } | { success: false; error: unknown };
+  },
+  value: unknown,
+  message: string,
+): T {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
+    throw new DesignError(message, {
+      code: "DESIGN_INVALID_INPUT",
+      cause: parsed.error,
+    });
+  }
+  return parsed.data;
+}
+
+function assertProviderBinding<T extends { provider: string }>(
+  record: T,
+  adapter: DesignProviderAdapter,
+  surface: string,
+): T {
+  if (record.provider !== adapter.id) {
+    throw new DesignError(
+      "Design provider response spoofed another provider.",
+      {
+        code: "DESIGN_MALFORMED_RESPONSE",
+        context: {
+          adapterId: adapter.id,
+          responseProvider: record.provider,
+          surface,
+        },
+      },
+    );
+  }
+  return record;
+}
+
+export class DesignService extends Service {
+  static override readonly serviceType = DESIGN_SERVICE_TYPE;
+  override capabilityDescription =
+    "Provider-neutral design search, lookup, node/design export, and comment reads over Canva and Figma adapters.";
+
+  private readonly adapters = new Map<string, DesignProviderAdapter>();
+  private defaultAdapterId: string | null = null;
+
+  static override async start(runtime: IAgentRuntime): Promise<DesignService> {
+    const service = new DesignService(runtime);
+    const figmaToken = runtime.getSetting("FIGMA_PERSONAL_ACCESS_TOKEN");
+    if (typeof figmaToken === "string" && figmaToken.trim()) {
+      const projectId = runtime.getSetting("FIGMA_PROJECT_ID");
+      const baseUrl = runtime.getSetting("FIGMA_API_BASE_URL");
+      service.registerAdapter(
+        new FigmaDesignAdapter({
+          connectionId: localConnectionId("figma"),
+          personalAccessToken: figmaToken,
+          ...(typeof projectId === "string" && projectId.trim()
+            ? { projectId: projectId.trim() }
+            : {}),
+          ...(typeof baseUrl === "string" && baseUrl.trim()
+            ? { baseUrl: baseUrl.trim() }
+            : {}),
+        }),
+      );
+      logger.info(
+        "[DesignService] Registered local-mode Figma adapter from runtime settings",
+      );
+    }
+    const canvaToken = runtime.getSetting("CANVA_ACCESS_TOKEN");
+    if (typeof canvaToken === "string" && canvaToken.trim()) {
+      const baseUrl = runtime.getSetting("CANVA_API_BASE_URL");
+      service.registerAdapter(
+        new CanvaDesignAdapter({
+          connectionId: localConnectionId("canva"),
+          accessToken: canvaToken,
+          ...(typeof baseUrl === "string" && baseUrl.trim()
+            ? { baseUrl: baseUrl.trim() }
+            : {}),
+        }),
+      );
+      logger.info(
+        "[DesignService] Registered local-mode Canva adapter from runtime settings",
+      );
+    }
+    return service;
+  }
+
+  override async stop(): Promise<void> {
+    this.adapters.clear();
+    this.defaultAdapterId = null;
+  }
+
+  registerAdapter(adapter: DesignProviderAdapter, makeDefault = false): void {
+    if (
+      !/^[a-z0-9][a-z0-9_-]*$/i.test(adapter.id) ||
+      !/^conn_[A-Za-z0-9_-]{16,}$/.test(adapter.connectionId)
+    ) {
+      throw new DesignError("Design adapter identity is invalid.", {
+        code: "DESIGN_INVALID_INPUT",
+      });
+    }
+    this.adapters.set(adapter.id, adapter);
+    if (makeDefault || this.defaultAdapterId === null)
+      this.defaultAdapterId = adapter.id;
+  }
+
+  unregisterAdapter(adapterId: string): void {
+    this.adapters.delete(adapterId);
+    if (this.defaultAdapterId === adapterId) {
+      this.defaultAdapterId = this.adapters.keys().next().value ?? null;
+    }
+  }
+
+  listAdapters(): readonly string[] {
+    return [...this.adapters.keys()];
+  }
+
+  /** Managed Cloud OAuth is not yet eligible for any design provider. */
+  managedEligibility(
+    provider: ManagedDesignProvider,
+  ): ManagedDesignEligibility {
+    return MANAGED_DESIGN_ELIGIBILITY[provider];
+  }
+
+  connectManaged(provider: ManagedDesignProvider): never {
+    throw new DesignError(
+      `Managed ${provider} connections are not yet eligible: ${MANAGED_DESIGN_ELIGIBILITY[provider].reason}`,
+      {
+        code: "DESIGN_MANAGED_MODE_INELIGIBLE",
+        context: { provider },
+      },
+    );
+  }
+
+  async searchDesigns(
+    request: DesignSearchRequest,
+    provider?: string,
+  ): Promise<DesignPage> {
+    const adapter = this.adapter(provider, "search");
+    const page = validated(
+      designPageSchema,
+      await adapter.searchDesigns(request),
+      "Design provider returned an invalid design page.",
+    );
+    return {
+      ...page,
+      designs: page.designs.map((design) =>
+        assertProviderBinding(design, adapter, "design search result"),
+      ),
+    };
+  }
+
+  async getDesign(
+    providerDesignId: string,
+    provider?: string,
+  ): Promise<DesignRef | null> {
+    const adapter = this.adapter(provider, "get");
+    const design = await adapter.getDesign(providerDesignId);
+    if (design === null) return null;
+    return assertProviderBinding(
+      validated(
+        designRefSchema,
+        design,
+        "Design provider returned an invalid design record.",
+      ),
+      adapter,
+      "design detail",
+    );
+  }
+
+  async exportDesign(
+    request: DesignExportRequest,
+    provider?: string,
+  ): Promise<DesignExportArtifact> {
+    const adapter = this.adapter(provider, "export");
+    return assertProviderBinding(
+      validated(
+        designExportArtifactSchema,
+        await adapter.exportDesign(request),
+        "Design provider returned an invalid export artifact.",
+      ),
+      adapter,
+      "design export",
+    );
+  }
+
+  async listComments(
+    providerDesignId: string,
+    provider?: string,
+    cursor?: string,
+  ): Promise<DesignCommentPage> {
+    const adapter = this.adapter(provider, "comments");
+    const page = validated(
+      designCommentPageSchema,
+      await adapter.listComments(providerDesignId, cursor),
+      "Design provider returned an invalid comment page.",
+    );
+    return {
+      ...page,
+      comments: page.comments.map((comment) =>
+        assertProviderBinding(comment, adapter, "design comment"),
+      ),
+    };
+  }
+
+  private adapter(
+    provider: string | undefined,
+    capability: "search" | "get" | "export" | "comments",
+  ): DesignProviderAdapter {
+    const id = provider ?? this.defaultAdapterId;
+    if (!id) {
+      throw new DesignError(
+        "No design provider is connected. Local mode requires FIGMA_PERSONAL_ACCESS_TOKEN or CANVA_ACCESS_TOKEN; managed Cloud connections are not yet eligible.",
+        { code: "DESIGN_NOT_CONNECTED" },
+      );
+    }
+    const adapter = this.adapters.get(id);
+    if (!adapter) {
+      throw new DesignError(`Design provider "${id}" is not connected.`, {
+        code: "DESIGN_NOT_CONNECTED",
+        context: { provider: id, connected: [...this.adapters.keys()] },
+      });
+    }
+    if (!adapter.capabilities.has(capability)) {
+      throw new DesignError(
+        `Design provider "${adapter.id}" does not support ${capability}.`,
+        {
+          code: "DESIGN_UNSUPPORTED",
+          context: { provider: adapter.id, capability },
+        },
+      );
+    }
+    return adapter;
+  }
+}

--- a/plugins/plugin-design/src/types.ts
+++ b/plugins/plugin-design/src/types.ts
@@ -1,0 +1,113 @@
+/** Defines and validates the provider-neutral design domain contracts. */
+
+import * as z from "zod";
+
+const boundedText = (max: number) => z.string().trim().min(1).max(max);
+const opaqueText = (max: number) => z.string().min(1).max(max);
+
+/** Provider artifact and deep-link URLs must be absolute HTTPS with no userinfo. */
+export const httpsUrlSchema = z
+  .string()
+  .min(1)
+  .max(2_048)
+  .refine((value) => {
+    let url: URL;
+    try {
+      url = new URL(value);
+    } catch {
+      // error-policy:J3 An unparseable provider URL is an explicit invalid
+      // result for the refinement, never a fake-valid default.
+      return false;
+    }
+    return url.protocol === "https:" && !url.username && !url.password;
+  }, "must be an absolute HTTPS URL without userinfo");
+
+export const providerIdSchema = boundedText(64).regex(/^[a-z0-9][a-z0-9_-]*$/i);
+
+export const designRefSchema = z
+  .object({
+    provider: providerIdSchema,
+    providerDesignId: opaqueText(512),
+    name: boundedText(300),
+    deepLinkUrl: httpsUrlSchema,
+    thumbnailUrl: httpsUrlSchema.optional(),
+    updatedAt: z.string().datetime({ offset: true }).optional(),
+  })
+  .strict();
+
+export const designPageSchema = z
+  .object({
+    designs: z.array(designRefSchema).max(100),
+    nextCursor: opaqueText(2_048).nullable(),
+  })
+  .strict();
+
+export const designSearchRequestSchema = z
+  .object({
+    query: boundedText(500),
+    cursor: opaqueText(2_048).optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+  })
+  .strict();
+
+export const designExportFormatSchema = z.enum(["png", "jpg", "svg", "pdf"]);
+
+export const designExportRequestSchema = z
+  .object({
+    providerDesignId: opaqueText(512),
+    format: designExportFormatSchema,
+    /** Provider-specific node/page selector (for example a Figma node id). */
+    nodeId: opaqueText(256).optional(),
+    scale: z.number().finite().min(0.01).max(4).optional(),
+  })
+  .strict();
+
+export const designExportArtifactSchema = z
+  .object({
+    provider: providerIdSchema,
+    providerDesignId: opaqueText(512),
+    format: designExportFormatSchema,
+    /** Short-lived provider download URLs; bytes are never rehosted here. */
+    urls: z.array(httpsUrlSchema).min(1).max(20),
+  })
+  .strict();
+
+export const designCommentSchema = z
+  .object({
+    provider: providerIdSchema,
+    commentId: opaqueText(512),
+    message: z.string().max(10_000),
+    author: boundedText(300),
+    createdAt: z.string().datetime({ offset: true }),
+    resolved: z.boolean(),
+  })
+  .strict();
+
+export const designCommentPageSchema = z
+  .object({
+    comments: z.array(designCommentSchema).max(200),
+    nextCursor: opaqueText(2_048).nullable(),
+  })
+  .strict();
+
+export type DesignRef = z.infer<typeof designRefSchema>;
+export type DesignPage = z.infer<typeof designPageSchema>;
+export type DesignExportFormat = z.infer<typeof designExportFormatSchema>;
+export type DesignExportArtifact = z.infer<typeof designExportArtifactSchema>;
+export type DesignComment = z.infer<typeof designCommentSchema>;
+export type DesignCommentPage = z.infer<typeof designCommentPageSchema>;
+
+export interface DesignSearchRequest {
+  query: string;
+  cursor?: string;
+  limit?: number;
+}
+
+export interface DesignExportRequest {
+  providerDesignId: string;
+  format: DesignExportFormat;
+  nodeId?: string;
+  scale?: number;
+}
+
+export type DesignCapability = "search" | "get" | "export" | "comments";

--- a/plugins/plugin-design/test/canva-contract.test.ts
+++ b/plugins/plugin-design/test/canva-contract.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Exercises the real Canva Connect adapter over HTTP against the repository's
+ * protocol-faithful fake upstream speaking Canva wire shapes, including the
+ * asynchronous export-job lifecycle. Deterministic; no live Canva account or
+ * network access is used.
+ */
+
+import {
+  type ProviderContractObservation,
+  type ProviderProtocolFixture,
+  redactProviderDiagnostics,
+  runProviderAdapterConformance,
+  startFakeProvider,
+} from "@elizaos/cloud-test-mocks/provider-contract";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { CanvaDesignAdapter } from "../src/canva.js";
+import { DesignError } from "../src/errors.js";
+
+const canvaItem = {
+  id: "DAF-design-1",
+  title: "Launch Banner",
+  thumbnail: { url: "https://document-export.canva.com/thumb/daf1.png" },
+  urls: {
+    view_url: "https://www.canva.com/design/DAF-design-1/view",
+    edit_url: "https://www.canva.com/design/DAF-design-1/edit",
+  },
+  updated_at: 1_754_000_000,
+};
+
+const normalizedItem = {
+  provider: "canva",
+  providerDesignId: "DAF-design-1",
+  name: "Launch Banner",
+  deepLinkUrl: "https://www.canva.com/design/DAF-design-1/view",
+  thumbnailUrl: "https://document-export.canva.com/thumb/daf1.png",
+  updatedAt: new Date(1_754_000_000 * 1_000).toISOString(),
+};
+
+const fixtures: ProviderProtocolFixture[] = [
+  {
+    id: "canva-designs",
+    method: "GET",
+    path: "/rest/v1/designs",
+    response: {
+      status: 200,
+      body: { items: [canvaItem], continuation: "cont-page-2" },
+    },
+  },
+  {
+    id: "canva-design",
+    method: "GET",
+    path: "/rest/v1/designs/DAF-design-1",
+    response: { status: 200, body: { design: canvaItem } },
+  },
+  {
+    id: "canva-export-create",
+    method: "POST",
+    path: "/rest/v1/exports",
+    response: {
+      status: 200,
+      body: { job: { id: "exp-1", status: "in_progress" } },
+    },
+  },
+  {
+    id: "canva-export-poll",
+    method: "GET",
+    path: "/rest/v1/exports/exp-1",
+    response: {
+      status: 200,
+      body: {
+        job: {
+          id: "exp-1",
+          status: "success",
+          urls: ["https://export-download.canva.com/exp-1/page-1.png"],
+        },
+      },
+    },
+  },
+];
+
+function passed(
+  scenario: ProviderContractObservation["scenario"],
+  detail: string,
+  extra: Partial<ProviderContractObservation> = {},
+): ProviderContractObservation {
+  return { scenario, status: "passed", detail, ...extra };
+}
+
+async function expectCode(
+  operation: Promise<unknown>,
+  code: DesignError["code"],
+): Promise<DesignError> {
+  try {
+    await operation;
+  } catch (error) {
+    // error-policy:J1 The test assertion boundary verifies the typed failure
+    // returned by the real adapter instead of allowing it to escape the case.
+    expect(error).toBeInstanceOf(DesignError);
+    expect((error as DesignError).code).toBe(code);
+    return error as DesignError;
+  }
+  throw new Error(`Expected ${code}`);
+}
+
+describe("CanvaDesignAdapter provider contract", () => {
+  let upstream: Awaited<ReturnType<typeof startFakeProvider>>;
+  let adapter: CanvaDesignAdapter;
+
+  beforeAll(async () => {
+    upstream = await startFakeProvider({ fixtures });
+    adapter = new CanvaDesignAdapter({
+      connectionId: upstream.createConnectionId(),
+      accessToken: "canva_contract_secret",
+      baseUrl: upstream.url,
+      timeoutMs: 2_000,
+      pollDelayMs: 0,
+      testTransport: { fetchImpl: globalThis.fetch },
+      allowPrivateNetworkForTests: true,
+    });
+  });
+
+  afterAll(async () => {
+    await upstream.stop();
+  });
+
+  it("executes every outbound read and pagination scenario", async () => {
+    const report = await runProviderAdapterConformance({
+      adapterName: "CanvaDesignAdapter",
+      profile: "outbound-http",
+      capabilities: ["http-read", "pagination"],
+      scenarios: {
+        success: async () => {
+          const page = await adapter.searchDesigns({ query: "banner" });
+          expect(page.designs).toEqual([normalizedItem]);
+          expect(page.nextCursor).toBe("cont-page-2");
+          return passed("success", "normalized Canva design page inspected");
+        },
+        "designed-empty": async () => {
+          upstream.enqueueFault("GET", "/rest/v1/designs", {
+            type: "schema-drift",
+            body: { items: [] },
+          });
+          const page = await adapter.searchDesigns({ query: "nothing" });
+          expect(page).toEqual({ designs: [], nextCursor: null });
+          return passed(
+            "designed-empty",
+            "empty listing remained distinct from failure",
+          );
+        },
+        "invalid-input": async () => {
+          await expectCode(
+            adapter.searchDesigns({ query: " " }),
+            "DESIGN_INVALID_INPUT",
+          );
+          await expectCode(
+            adapter.searchDesigns({ query: "banner", limit: 0 }),
+            "DESIGN_INVALID_INPUT",
+          );
+          return passed(
+            "invalid-input",
+            "blank query and zero limit rejected before HTTP",
+          );
+        },
+        "pagination-cursors": async () => {
+          const page = await adapter.searchDesigns({
+            query: "banner",
+            cursor: "cont-page-1",
+          });
+          expect(page.nextCursor).toBe("cont-page-2");
+          expect(upstream.requests.at(-1)?.query.continuation).toBe(
+            "cont-page-1",
+          );
+          return passed(
+            "pagination-cursors",
+            "opaque continuation cursors inspected on request and response",
+          );
+        },
+        "rate-limit-retry-metadata": async () => {
+          upstream.enqueueFault("GET", "/rest/v1/designs", {
+            type: "status",
+            status: 429,
+            headers: { "retry-after": "5" },
+            body: { code: "too_many_requests", message: "Rate limited" },
+          });
+          const error = await expectCode(
+            adapter.searchDesigns({ query: "banner" }),
+            "DESIGN_RATE_LIMITED",
+          );
+          expect(error.retryAfterMs).toBe(5_000);
+          return passed(
+            "rate-limit-retry-metadata",
+            "Retry-After preserved as 5000ms",
+          );
+        },
+        "malformed-json": async () => {
+          upstream.enqueueFault("GET", "/rest/v1/designs", {
+            type: "malformed-json",
+          });
+          await expectCode(
+            adapter.searchDesigns({ query: "banner" }),
+            "DESIGN_MALFORMED_RESPONSE",
+          );
+          return passed("malformed-json", "invalid provider JSON rejected");
+        },
+        "schema-drift": async () => {
+          upstream.enqueueFault("GET", "/rest/v1/designs", {
+            type: "schema-drift",
+            body: { items: [{ id: "DAF-design-1" }] },
+          });
+          await expectCode(
+            adapter.searchDesigns({ query: "banner" }),
+            "DESIGN_MALFORMED_RESPONSE",
+          );
+          return passed("schema-drift", "field-dropped listing rejected");
+        },
+        timeout: async () => {
+          const timeoutAdapter = new CanvaDesignAdapter({
+            connectionId: "conn_timeout_contract_123",
+            accessToken: "canva_timeout",
+            baseUrl: "https://canva-timeout.example.test",
+            timeoutMs: 100,
+            testTransport: {
+              fetchImpl: vi.fn(
+                async (_input, init) =>
+                  await new Promise<Response>((_resolve, reject) => {
+                    init?.signal?.addEventListener(
+                      "abort",
+                      () => reject(init.signal?.reason),
+                      { once: true },
+                    );
+                  }),
+              ),
+            },
+          });
+          await expectCode(
+            timeoutAdapter.searchDesigns({ query: "banner" }),
+            "DESIGN_PROVIDER_TIMEOUT",
+          );
+          return passed("timeout", "bounded abort surfaced as timeout");
+        },
+        "connection-reset": async () => {
+          const resetUpstream = await startFakeProvider({ fixtures });
+          const resetAdapter = new CanvaDesignAdapter({
+            connectionId: resetUpstream.createConnectionId(),
+            accessToken: "canva_reset",
+            baseUrl: resetUpstream.url,
+            testTransport: { fetchImpl: globalThis.fetch },
+            allowPrivateNetworkForTests: true,
+          });
+          await resetUpstream.resetConnections();
+          await expectCode(
+            resetAdapter.searchDesigns({ query: "banner" }),
+            "DESIGN_PROVIDER_NETWORK",
+          );
+          return passed(
+            "connection-reset",
+            "closed upstream surfaced as network failure",
+          );
+        },
+        "provider-4xx": async () => {
+          upstream.enqueueFault("GET", "/rest/v1/designs", {
+            type: "status",
+            status: 400,
+            body: { code: "bad_request", message: "Bad request" },
+          });
+          await expectCode(
+            adapter.searchDesigns({ query: "banner" }),
+            "DESIGN_PROVIDER_REJECTED",
+          );
+          return passed("provider-4xx", "provider rejection remained explicit");
+        },
+        "provider-5xx": async () => {
+          upstream.enqueueFault("GET", "/rest/v1/designs", {
+            type: "status",
+            status: 502,
+            body: { code: "internal_error", message: "boom" },
+          });
+          await expectCode(
+            adapter.searchDesigns({ query: "banner" }),
+            "DESIGN_PROVIDER_FAILURE",
+          );
+          return passed("provider-5xx", "provider outage remained explicit");
+        },
+        "opaque-connection-id": async () =>
+          passed(
+            "opaque-connection-id",
+            "adapter exposes only an opaque connection handle",
+            { connectionId: adapter.connectionId },
+          ),
+        "secret-redaction": async () => {
+          await adapter.searchDesigns({ query: "banner" });
+          const diagnostic = redactProviderDiagnostics(upstream.requests, [
+            "canva_contract_secret",
+          ]);
+          expect(JSON.stringify(diagnostic)).not.toContain(
+            "canva_contract_secret",
+          );
+          return passed(
+            "secret-redaction",
+            "recorded requests redact bearer credentials",
+            { diagnostic },
+          );
+        },
+        "read-policy": async () => {
+          const page = await adapter.searchDesigns({
+            query: "banner",
+            limit: 1,
+          });
+          expect(page.designs).toHaveLength(1);
+          return passed(
+            "read-policy",
+            "read completed without mutation receipt",
+          );
+        },
+      },
+    });
+    expect(report.observations).toHaveLength(14);
+  });
+
+  it("keeps expired, revoked, and plan-limited authorization failures distinct", async () => {
+    upstream.enqueueFault("GET", "/rest/v1/designs", {
+      type: "status",
+      status: 401,
+      body: { code: "expired_token", message: "Token expired" },
+    });
+    await expectCode(
+      adapter.searchDesigns({ query: "banner" }),
+      "DESIGN_AUTH_EXPIRED",
+    );
+
+    upstream.enqueueFault("GET", "/rest/v1/designs", {
+      type: "status",
+      status: 403,
+      body: { code: "revoked_token", message: "Token revoked" },
+    });
+    await expectCode(
+      adapter.searchDesigns({ query: "banner" }),
+      "DESIGN_AUTH_REVOKED",
+    );
+
+    upstream.enqueueFault("GET", "/rest/v1/designs", {
+      type: "status",
+      status: 403,
+      body: { code: "license_required", message: "Premium required" },
+    });
+    await expectCode(
+      adapter.searchDesigns({ query: "banner" }),
+      "DESIGN_PLAN_LIMITED",
+    );
+  });
+
+  it("resolves detail, missing designs, and the asynchronous export job", async () => {
+    await expect(adapter.getDesign("DAF-design-1")).resolves.toEqual(
+      normalizedItem,
+    );
+    await expect(adapter.getDesign("DAF-missing")).resolves.toBeNull();
+
+    const artifact = await adapter.exportDesign({
+      providerDesignId: "DAF-design-1",
+      format: "png",
+    });
+    expect(artifact).toEqual({
+      provider: "canva",
+      providerDesignId: "DAF-design-1",
+      format: "png",
+      urls: ["https://export-download.canva.com/exp-1/page-1.png"],
+    });
+    const create = upstream.requests.find(
+      (request) =>
+        request.method === "POST" && request.path === "/rest/v1/exports",
+    );
+    expect(create?.body).toContain('"design_id":"DAF-design-1"');
+  });
+
+  it("classifies failed export jobs, plan-limited exports, and stuck jobs", async () => {
+    upstream.enqueueFault("GET", "/rest/v1/exports/exp-1", {
+      type: "schema-drift",
+      body: {
+        job: {
+          id: "exp-1",
+          status: "failed",
+          error: { code: "internal_failure", message: "render failed" },
+        },
+      },
+    });
+    await expectCode(
+      adapter.exportDesign({ providerDesignId: "DAF-design-1", format: "png" }),
+      "DESIGN_EXPORT_FAILED",
+    );
+
+    upstream.enqueueFault("GET", "/rest/v1/exports/exp-1", {
+      type: "schema-drift",
+      body: {
+        job: {
+          id: "exp-1",
+          status: "failed",
+          error: { code: "license_required", message: "premium element" },
+        },
+      },
+    });
+    await expectCode(
+      adapter.exportDesign({ providerDesignId: "DAF-design-1", format: "png" }),
+      "DESIGN_PLAN_LIMITED",
+    );
+
+    const stuck = new CanvaDesignAdapter({
+      connectionId: upstream.createConnectionId(),
+      accessToken: "canva_stuck",
+      baseUrl: upstream.url,
+      pollDelayMs: 0,
+      maxPollAttempts: 2,
+      testTransport: { fetchImpl: globalThis.fetch },
+      allowPrivateNetworkForTests: true,
+    });
+    for (let i = 0; i < 2; i += 1) {
+      upstream.enqueueFault("GET", "/rest/v1/exports/exp-1", {
+        type: "schema-drift",
+        body: { job: { id: "exp-1", status: "in_progress" } },
+      });
+    }
+    await expectCode(
+      stuck.exportDesign({ providerDesignId: "DAF-design-1", format: "png" }),
+      "DESIGN_PROVIDER_TIMEOUT",
+    );
+  });
+
+  it("rejects unsupported capabilities and off-domain deep links", async () => {
+    await expectCode(adapter.listComments(), "DESIGN_UNSUPPORTED");
+    await expectCode(
+      adapter.exportDesign({ providerDesignId: "DAF-design-1", format: "svg" }),
+      "DESIGN_UNSUPPORTED",
+    );
+
+    upstream.enqueueFault("GET", "/rest/v1/designs", {
+      type: "schema-drift",
+      body: {
+        items: [
+          {
+            ...canvaItem,
+            urls: { view_url: "https://evil.example.test/design" },
+          },
+        ],
+      },
+    });
+    await expectCode(
+      adapter.searchDesigns({ query: "banner" }),
+      "DESIGN_MALFORMED_RESPONSE",
+    );
+  });
+});

--- a/plugins/plugin-design/test/figma-contract.test.ts
+++ b/plugins/plugin-design/test/figma-contract.test.ts
@@ -1,0 +1,533 @@
+/**
+ * Exercises the real Figma REST adapter over HTTP against the repository's
+ * protocol-faithful fake upstream speaking Figma wire shapes. Deterministic;
+ * no live Figma account or network access is used.
+ */
+
+import {
+  type ProviderContractObservation,
+  type ProviderProtocolFixture,
+  redactProviderDiagnostics,
+  runProviderAdapterConformance,
+  startFakeProvider,
+} from "@elizaos/cloud-test-mocks/provider-contract";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { DesignError } from "../src/errors.js";
+import { FigmaDesignAdapter } from "../src/figma.js";
+
+const projectFile = {
+  key: "FKEY123",
+  name: "Launch Poster",
+  thumbnail_url: "https://s3-alpha.figma.com/thumbnails/fkey123.png",
+  last_modified: "2026-08-01T12:00:00Z",
+};
+
+const fixtures: ProviderProtocolFixture[] = [
+  {
+    id: "figma-project-files",
+    method: "GET",
+    path: "/v1/projects/123/files",
+    response: {
+      status: 200,
+      body: {
+        files: [
+          projectFile,
+          {
+            key: "OTHER",
+            name: "Roadmap",
+            last_modified: "2026-08-02T00:00:00Z",
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: "figma-file",
+    method: "GET",
+    path: "/v1/files/FKEY123",
+    response: {
+      status: 200,
+      body: {
+        name: "Launch Poster",
+        lastModified: "2026-08-01T12:00:00Z",
+        thumbnailUrl: "https://s3-alpha.figma.com/thumbnails/fkey123.png",
+        version: "42",
+      },
+    },
+  },
+  {
+    id: "figma-images",
+    method: "GET",
+    path: "/v1/images/FKEY123",
+    response: {
+      status: 200,
+      body: {
+        err: null,
+        images: {
+          "1:2":
+            "https://figma-alpha-api.s3.us-west-2.amazonaws.com/render/1-2.png",
+        },
+      },
+    },
+  },
+  {
+    id: "figma-comments",
+    method: "GET",
+    path: "/v1/files/FKEY123/comments",
+    response: {
+      status: 200,
+      body: {
+        comments: [
+          {
+            id: "c-1",
+            message: "Bump the headline size",
+            user: { handle: "reviewer" },
+            created_at: "2026-08-03T09:00:00Z",
+            resolved_at: null,
+          },
+        ],
+      },
+    },
+  },
+];
+
+function passed(
+  scenario: ProviderContractObservation["scenario"],
+  detail: string,
+  extra: Partial<ProviderContractObservation> = {},
+): ProviderContractObservation {
+  return { scenario, status: "passed", detail, ...extra };
+}
+
+async function expectCode(
+  operation: Promise<unknown>,
+  code: DesignError["code"],
+): Promise<DesignError> {
+  try {
+    await operation;
+  } catch (error) {
+    // error-policy:J1 The test assertion boundary verifies the typed failure
+    // returned by the real adapter instead of allowing it to escape the case.
+    expect(error).toBeInstanceOf(DesignError);
+    expect((error as DesignError).code).toBe(code);
+    return error as DesignError;
+  }
+  throw new Error(`Expected ${code}`);
+}
+
+describe("FigmaDesignAdapter provider contract", () => {
+  let upstream: Awaited<ReturnType<typeof startFakeProvider>>;
+  let adapter: FigmaDesignAdapter;
+
+  beforeAll(async () => {
+    upstream = await startFakeProvider({ fixtures });
+    adapter = new FigmaDesignAdapter({
+      connectionId: upstream.createConnectionId(),
+      personalAccessToken: "figd_contract_secret",
+      projectId: "123",
+      baseUrl: upstream.url,
+      timeoutMs: 2_000,
+      testTransport: { fetchImpl: globalThis.fetch },
+      allowPrivateNetworkForTests: true,
+    });
+  });
+
+  afterAll(async () => {
+    await upstream.stop();
+  });
+
+  it("executes every outbound read scenario", async () => {
+    const report = await runProviderAdapterConformance({
+      adapterName: "FigmaDesignAdapter",
+      profile: "outbound-http",
+      capabilities: ["http-read"],
+      scenarios: {
+        success: async () => {
+          const page = await adapter.searchDesigns({ query: "poster" });
+          expect(page.designs).toEqual([
+            {
+              provider: "figma",
+              providerDesignId: "FKEY123",
+              name: "Launch Poster",
+              deepLinkUrl: "https://www.figma.com/design/FKEY123",
+              thumbnailUrl: projectFile.thumbnail_url,
+              updatedAt: "2026-08-01T12:00:00.000Z",
+            },
+          ]);
+          expect(page.nextCursor).toBeNull();
+          return passed("success", "normalized Figma project file inspected");
+        },
+        "designed-empty": async () => {
+          const page = await adapter.searchDesigns({ query: "no-such-name" });
+          expect(page).toEqual({ designs: [], nextCursor: null });
+          return passed(
+            "designed-empty",
+            "unmatched query produced an empty page distinct from failure",
+          );
+        },
+        "invalid-input": async () => {
+          await expectCode(
+            adapter.searchDesigns({ query: " " }),
+            "DESIGN_INVALID_INPUT",
+          );
+          await expectCode(
+            adapter.searchDesigns({ query: "poster", cursor: "page-2" }),
+            "DESIGN_INVALID_INPUT",
+          );
+          return passed(
+            "invalid-input",
+            "blank query and unsupported cursor rejected before HTTP",
+          );
+        },
+        "rate-limit-retry-metadata": async () => {
+          upstream.enqueueFault("GET", "/v1/projects/123/files", {
+            type: "status",
+            status: 429,
+            headers: { "retry-after": "3" },
+            body: { status: 429, err: "Rate limit exceeded" },
+          });
+          const error = await expectCode(
+            adapter.searchDesigns({ query: "poster" }),
+            "DESIGN_RATE_LIMITED",
+          );
+          expect(error.retryAfterMs).toBe(3_000);
+          return passed(
+            "rate-limit-retry-metadata",
+            "Retry-After preserved as 3000ms",
+          );
+        },
+        "malformed-json": async () => {
+          upstream.enqueueFault("GET", "/v1/projects/123/files", {
+            type: "malformed-json",
+          });
+          await expectCode(
+            adapter.searchDesigns({ query: "poster" }),
+            "DESIGN_MALFORMED_RESPONSE",
+          );
+          return passed("malformed-json", "invalid provider JSON rejected");
+        },
+        "schema-drift": async () => {
+          upstream.enqueueFault("GET", "/v1/projects/123/files", {
+            type: "schema-drift",
+            body: { files: [{ key: "FKEY123" }] },
+          });
+          await expectCode(
+            adapter.searchDesigns({ query: "poster" }),
+            "DESIGN_MALFORMED_RESPONSE",
+          );
+          return passed("schema-drift", "field-dropped listing rejected");
+        },
+        timeout: async () => {
+          const timeoutAdapter = new FigmaDesignAdapter({
+            connectionId: "conn_timeout_contract_123",
+            personalAccessToken: "figd_timeout",
+            projectId: "123",
+            baseUrl: "https://figma-timeout.example.test",
+            timeoutMs: 100,
+            testTransport: {
+              fetchImpl: vi.fn(
+                async (_input, init) =>
+                  await new Promise<Response>((_resolve, reject) => {
+                    init?.signal?.addEventListener(
+                      "abort",
+                      () => reject(init.signal?.reason),
+                      { once: true },
+                    );
+                  }),
+              ),
+            },
+          });
+          await expectCode(
+            timeoutAdapter.searchDesigns({ query: "poster" }),
+            "DESIGN_PROVIDER_TIMEOUT",
+          );
+          return passed("timeout", "bounded abort surfaced as timeout");
+        },
+        "connection-reset": async () => {
+          const resetUpstream = await startFakeProvider({ fixtures });
+          const resetAdapter = new FigmaDesignAdapter({
+            connectionId: resetUpstream.createConnectionId(),
+            personalAccessToken: "figd_reset",
+            projectId: "123",
+            baseUrl: resetUpstream.url,
+            testTransport: { fetchImpl: globalThis.fetch },
+            allowPrivateNetworkForTests: true,
+          });
+          await resetUpstream.resetConnections();
+          await expectCode(
+            resetAdapter.searchDesigns({ query: "poster" }),
+            "DESIGN_PROVIDER_NETWORK",
+          );
+          return passed(
+            "connection-reset",
+            "closed upstream surfaced as network failure",
+          );
+        },
+        "provider-4xx": async () => {
+          upstream.enqueueFault("GET", "/v1/projects/123/files", {
+            type: "status",
+            status: 400,
+            body: { status: 400, err: "Bad request" },
+          });
+          await expectCode(
+            adapter.searchDesigns({ query: "poster" }),
+            "DESIGN_PROVIDER_REJECTED",
+          );
+          return passed("provider-4xx", "provider rejection remained explicit");
+        },
+        "provider-5xx": async () => {
+          upstream.enqueueFault("GET", "/v1/projects/123/files", {
+            type: "status",
+            status: 503,
+            body: { status: 503, err: "unavailable" },
+          });
+          await expectCode(
+            adapter.searchDesigns({ query: "poster" }),
+            "DESIGN_PROVIDER_FAILURE",
+          );
+          return passed("provider-5xx", "provider outage remained explicit");
+        },
+        "opaque-connection-id": async () =>
+          passed(
+            "opaque-connection-id",
+            "adapter exposes only an opaque connection handle",
+            { connectionId: adapter.connectionId },
+          ),
+        "secret-redaction": async () => {
+          await adapter.searchDesigns({ query: "poster" });
+          const diagnostic = redactProviderDiagnostics(upstream.requests, [
+            "figd_contract_secret",
+          ]);
+          expect(JSON.stringify(diagnostic)).not.toContain(
+            "figd_contract_secret",
+          );
+          return passed(
+            "secret-redaction",
+            "recorded requests redact the personal access token",
+            { diagnostic },
+          );
+        },
+        "read-policy": async () => {
+          const page = await adapter.searchDesigns({
+            query: "poster",
+            limit: 1,
+          });
+          expect(page.designs).toHaveLength(1);
+          return passed(
+            "read-policy",
+            "read completed without mutation receipt",
+          );
+        },
+      },
+    });
+    expect(report.observations).toHaveLength(13);
+  });
+
+  it("keeps expired, revoked, and plan-limited authorization failures distinct", async () => {
+    upstream.enqueueFault("GET", "/v1/projects/123/files", {
+      type: "status",
+      status: 403,
+      body: { status: 403, err: "Token expired" },
+    });
+    await expectCode(
+      adapter.searchDesigns({ query: "poster" }),
+      "DESIGN_AUTH_EXPIRED",
+    );
+
+    upstream.enqueueFault("GET", "/v1/projects/123/files", {
+      type: "status",
+      status: 403,
+      body: { status: 403, err: "Invalid token" },
+    });
+    await expectCode(
+      adapter.searchDesigns({ query: "poster" }),
+      "DESIGN_AUTH_REVOKED",
+    );
+
+    upstream.enqueueFault("GET", "/v1/projects/123/files", {
+      type: "status",
+      status: 403,
+      body: { status: 403, err: "Limited by plan tier" },
+    });
+    await expectCode(
+      adapter.searchDesigns({ query: "poster" }),
+      "DESIGN_PLAN_LIMITED",
+    );
+  });
+
+  it("resolves file detail, missing files, exports, and comments", async () => {
+    const detail = await adapter.getDesign("FKEY123");
+    expect(detail).toEqual({
+      provider: "figma",
+      providerDesignId: "FKEY123",
+      name: "Launch Poster",
+      deepLinkUrl: "https://www.figma.com/design/FKEY123",
+      thumbnailUrl: projectFile.thumbnail_url,
+      updatedAt: "2026-08-01T12:00:00.000Z",
+    });
+    await expect(adapter.getDesign("MISSING")).resolves.toBeNull();
+
+    const artifact = await adapter.exportDesign({
+      providerDesignId: "FKEY123",
+      format: "png",
+      nodeId: "1:2",
+      scale: 2,
+    });
+    expect(artifact).toEqual({
+      provider: "figma",
+      providerDesignId: "FKEY123",
+      format: "png",
+      urls: [
+        "https://figma-alpha-api.s3.us-west-2.amazonaws.com/render/1-2.png",
+      ],
+    });
+    const lastRequest = upstream.requests.at(-1);
+    expect(lastRequest?.query.ids).toBe("1:2");
+    expect(lastRequest?.query.format).toBe("png");
+    expect(lastRequest?.query.scale).toBe("2");
+
+    const comments = await adapter.listComments("FKEY123");
+    expect(comments).toEqual({
+      comments: [
+        {
+          provider: "figma",
+          commentId: "c-1",
+          message: "Bump the headline size",
+          author: "reviewer",
+          createdAt: "2026-08-03T09:00:00.000Z",
+          resolved: false,
+        },
+      ],
+      nextCursor: null,
+    });
+  });
+
+  it("surfaces provider-declared render failures and null render URLs", async () => {
+    upstream.enqueueFault("GET", "/v1/images/FKEY123", {
+      type: "schema-drift",
+      body: { err: "Render timeout", images: {} },
+    });
+    await expectCode(
+      adapter.exportDesign({
+        providerDesignId: "FKEY123",
+        format: "png",
+        nodeId: "1:2",
+      }),
+      "DESIGN_EXPORT_FAILED",
+    );
+
+    upstream.enqueueFault("GET", "/v1/images/FKEY123", {
+      type: "schema-drift",
+      body: { err: null, images: { "1:2": null } },
+    });
+    await expectCode(
+      adapter.exportDesign({
+        providerDesignId: "FKEY123",
+        format: "png",
+        nodeId: "1:2",
+      }),
+      "DESIGN_EXPORT_FAILED",
+    );
+  });
+
+  it("requires a nodeId for exports and rejects malformed requests before I/O", async () => {
+    const transport = vi.fn(async () => Response.json({}));
+    const strict = new FigmaDesignAdapter({
+      connectionId: "conn_strict_boundary_1234",
+      personalAccessToken: "figd_strict",
+      baseUrl: "https://figma-strict.example.test",
+      testTransport: { fetchImpl: transport },
+    });
+    await expectCode(
+      strict.exportDesign({ providerDesignId: "FKEY123", format: "png" }),
+      "DESIGN_INVALID_INPUT",
+    );
+    await expectCode(
+      strict.exportDesign({
+        providerDesignId: "FKEY123",
+        format: "png",
+        nodeId: "1:2",
+        scale: 100,
+      }),
+      "DESIGN_INVALID_INPUT",
+    );
+    await expectCode(strict.getDesign(""), "DESIGN_INVALID_INPUT");
+    await expectCode(
+      strict.searchDesigns({ query: "poster" }),
+      "DESIGN_UNSUPPORTED",
+    );
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("blocks unsafe endpoints, DNS rebinding, and redirects", async () => {
+    for (const baseUrl of [
+      "http://169.254.169.254/",
+      "https://127.0.0.1/",
+      "https://user:pass@figma.example.test/",
+      "https://figma.example.test/?token=secret",
+    ]) {
+      expect(
+        () =>
+          new FigmaDesignAdapter({
+            connectionId: "conn_blocked_endpoint_123",
+            personalAccessToken: "figd_blocked",
+            baseUrl,
+          }),
+      ).toThrow(DesignError);
+    }
+
+    const pinnedFetch = vi.fn(async () => new Response("{}"));
+    const rebinding = new FigmaDesignAdapter({
+      connectionId: "conn_rebinding_guard_123",
+      personalAccessToken: "figd_rebind",
+      baseUrl: "https://figma-rebind.example.test",
+      testTransport: {
+        lookupFn: async () => [{ address: "169.254.169.254", family: 4 }],
+        pinnedFetchImpl: pinnedFetch,
+      },
+    });
+    await expectCode(rebinding.getDesign("FKEY123"), "DESIGN_ENDPOINT_BLOCKED");
+    expect(pinnedFetch).not.toHaveBeenCalled();
+
+    const requests: Array<{ url: string; token: string | null }> = [];
+    const redirects = new FigmaDesignAdapter({
+      connectionId: "conn_redirect_guard_1234",
+      personalAccessToken: "must_not_cross_origin",
+      baseUrl: "https://figma-redirect.example.test",
+      testTransport: {
+        fetchImpl: vi.fn(async (input, init) => {
+          requests.push({
+            url: String(input),
+            token: new Headers(init?.headers).get("x-figma-token"),
+          });
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://other-origin.example.test/steal" },
+          });
+        }),
+      },
+    });
+    await expectCode(redirects.getDesign("FKEY123"), "DESIGN_PROVIDER_NETWORK");
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.url).toContain("figma-redirect.example.test");
+  });
+
+  it("bounds oversized response bodies", async () => {
+    const oversized = new FigmaDesignAdapter({
+      connectionId: "conn_response_bound_1234",
+      personalAccessToken: "figd_bounded",
+      projectId: "123",
+      baseUrl: "https://figma-bounded.example.test",
+      responseByteLimit: 8,
+      testTransport: {
+        fetchImpl: vi.fn(
+          async () => new Response('{"files":[]}', { status: 200 }),
+        ),
+      },
+    });
+    await expectCode(
+      oversized.searchDesigns({ query: "poster" }),
+      "DESIGN_RESPONSE_TOO_LARGE",
+    );
+  });
+});

--- a/plugins/plugin-design/tsconfig.build.json
+++ b/plugins/plugin-design/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.build.shared.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**"]
+}

--- a/plugins/plugin-design/tsconfig.json
+++ b/plugins/plugin-design/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "paths": {
+      "@elizaos/core": ["../../packages/core/src/index.node.ts"],
+      "@elizaos/core/*": ["../../packages/core/src/*"],
+      "@elizaos/cloud-routing": ["../../packages/cloud/routing/src/index.ts"],
+      "@elizaos/cloud-routing/*": ["../../packages/cloud/routing/src/*"],
+      "@elizaos/cloud-test-mocks": [
+        "../../packages/cloud/test-mocks/src/index.ts"
+      ],
+      "@elizaos/cloud-test-mocks/*": ["../../packages/cloud/test-mocks/src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "vitest.config.ts"],
+  "exclude": []
+}

--- a/plugins/plugin-design/vitest.config.ts
+++ b/plugins/plugin-design/vitest.config.ts
@@ -1,0 +1,36 @@
+/** Runs the design domain and provider-contract suites in a Node environment. */
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const root = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts", "test/**/*.test.ts"],
+  },
+  resolve: {
+    conditions: ["node"],
+    alias: [
+      {
+        find: /^@elizaos\/core$/,
+        replacement: path.join(root, "packages/core/src/index.node.ts"),
+      },
+      {
+        find: /^@elizaos\/core\/(.+)$/,
+        replacement: path.join(root, "packages/core/src/$1"),
+      },
+      {
+        find: /^@elizaos\/cloud-routing$/,
+        replacement: path.join(root, "packages/cloud/routing/src/index.ts"),
+      },
+    ],
+  },
+  ssr: {
+    resolve: { conditions: ["node"] },
+  },
+});


### PR DESCRIPTION
## Summary

Implements the codeable-now scope of #19903: a provider-neutral design domain package (`@elizaos/plugin-design`) with real local-mode **Figma** and **Canva** provider adapters, read/search-first per the issue, while managed Cloud OAuth stays an explicit, typed eligibility-gated state until provider app approval.

### What's included

- **Normalized design domain** (`src/types.ts`): validated `DesignRef` / `DesignPage` / `DesignExportArtifact` / `DesignCommentPage` contracts; deep links and thumbnails must be HTTPS, Canva links pinned to `canva.com`.
- **Bounded transport core** (`src/http.ts`): one pinned origin, core `fetchWithSsrfGuard` DNS-pinned transport, no redirects, bounded deadlines and response bytes, strict schema decoding, adapter-supplied provider error classification. Modeled on the merged `plugin-maps` adapter from the same epic.
- **`FigmaDesignAdapter`** (`src/figma.ts`): real Figma REST wire — `/v1/projects/:id/files` (search; designed-unpaginated), `/v1/files/:key`, `/v1/images/:key` node renders, `/v1/files/:key/comments` — BYO `X-Figma-Token` personal access token (local mode; `FIGMA_API_BASE_URL` supports a local desktop-bridge/test origin).
- **`CanvaDesignAdapter`** (`src/canva.ts`): real Canva Connect wire — `/rest/v1/designs` with continuation cursors, `/rest/v1/designs/:id`, async export job create + bounded polling — BYO Connect access token. Comment reads and SVG export are typed `DESIGN_UNSUPPORTED` (Canva beta/paid capability), not fabricated empties; paid/beta provider codes map to `DESIGN_PLAN_LIMITED`.
- **`DesignService`** (`src/service.ts`): adapter registry, capability routing on typed `capabilities` sets, provider identity binding on every response, settings-driven local-mode startup, no silent Cloud fallback (`DESIGN_NOT_CONNECTED`), and `MANAGED_DESIGN_ELIGIBILITY` + `connectManaged` throwing `DESIGN_MANAGED_MODE_INELIGIBLE`.
- Typed `DesignError` codes distinguish expired vs revoked vs plan-limited auth, rate limit (with `retryAfterMs`), timeout, network, endpoint-blocked, oversized, malformed, and export failure.

### Tests (deterministic, protocol-faithful — not mocks of the system under test)

Both adapters run the repository's managed-provider conformance harness (`@elizaos/cloud-test-mocks/provider-contract`) over real HTTP against the fake upstream speaking Figma/Canva wire shapes:

- Figma: full 13-scenario `outbound-http` matrix; Canva: 14 with `pagination`.
- Expired / revoked / plan-limited auth distinctions per provider.
- Canva async export lifecycle: success, failed job, plan-limited job, stuck-job polling budget.
- Figma render failures (`err`, null image URLs), missing-file 404 → null, nodeId requirement.
- SSRF/private-origin/userinfo/query endpoint rejection, DNS-rebinding block, redirect refusal, response byte bounds, provider identity spoof rejection, off-domain deep-link rejection, secret redaction, opaque connection ids.
- `DesignService` registry/routing/binding/eligibility/settings suite.

```
Test Files  3 passed (3) | Tests 19 passed (19)
typecheck: clean · lint:check: clean · build: clean · check:agents-claude: PASS
```

### Human-only remainder (why the issue is titled "after provider eligibility")

- **Canva**: registering a Canva Connect integration and passing Canva's review, then custodying the approved client credentials in Cloud for managed OAuth.
- **Figma**: registering the Figma OAuth app and approval, same custody path.
- Once granted, flipping `MANAGED_DESIGN_ELIGIBILITY` and wiring the managed adapter SDK path (#19885, still open) is a deliberate follow-on code change; local BYO mode above is unaffected. Live sandbox/real-account evidence is a promotion gate at that point (this package is intentionally not added to the promoted managed-integration inventory ratchet yet).

No UI surfaces are touched (no app visual audit applies).

Fixes #19903

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Evidence Gate

<!-- evidence-head:a1176670eafd709f1001422b25d52086d8df88aa -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no shipped rendered pixels or layout changed; this is a local adapter or test-contract change.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no shipped rendered pixels or layout changed; this is a local adapter or test-contract change.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no shipped visual interaction flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - focused deterministic adapter or UI-smoke validation results are documented above; no protected backend was mutated.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - the exact UI-smoke/typecheck results are documented above; no production browser-network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact focused test counts and contract behavior are documented above; no separate runtime artifact was produced.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no shipped pixels changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `Anthropic/Claude; OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code; Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->