### PR TITLE
fix(homepage): restore minimal desktop hero actions

### DIFF
--- a/packages/homepage/src/index.css
+++ b/packages/homepage/src/index.css
@@ -1441,10 +1441,10 @@ html:has(.landing-page)::-webkit-scrollbar-thumb:hover {
 
 .landing-hero-heading {
   margin: 0;
-  max-width: 14ch;
-  font-size: clamp(2.25rem, 4.2vw, 4.15rem);
+  max-width: 18ch;
+  font-size: clamp(2.5rem, 3.45vw, 3.25rem);
   font-weight: 720;
-  line-height: 0.98;
+  line-height: 1.03;
   letter-spacing: -0.035em;
   text-wrap: balance;
   color: var(--brand-black);
@@ -1525,16 +1525,12 @@ html:has(.landing-page)::-webkit-scrollbar-thumb:hover {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.4rem;
-  min-height: 2.55rem;
-  padding: 0 0.8rem;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
   border-radius: 999px;
   background: rgb(255 255 255 / 82%);
-  color: rgb(17 17 17 / 72%);
   box-shadow: 0 6px 18px rgb(0 0 0 / 8%);
-  font-size: 0.82rem;
-  font-weight: 620;
-  line-height: 1;
   text-decoration: none;
   cursor: pointer;
   transition:
@@ -1553,6 +1549,16 @@ html:has(.landing-page)::-webkit-scrollbar-thumb:hover {
 .landing-channel:focus-visible {
   outline: 3px solid #111;
   outline-offset: 2px;
+}
+
+.landing-channel span {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
 }
 
 .landing-cta {
@@ -1581,15 +1587,15 @@ html:has(.landing-page)::-webkit-scrollbar-thumb:hover {
 }
 
 .landing-cta--black {
-  background: var(--landing-orange);
+  background: #000000;
   color: var(--brand-white);
-  box-shadow: 0 12px 28px rgb(255 88 0 / 24%);
+  box-shadow: 0 12px 28px rgb(0 0 0 / 18%);
 }
 
 .landing-cta--black:hover {
-  background: #d94b00;
+  background: #171717;
   color: var(--brand-white);
-  box-shadow: 0 14px 32px rgb(217 75 0 / 30%);
+  box-shadow: 0 14px 32px rgb(0 0 0 / 24%);
   transform: translateY(-1px);
 }
 

--- a/packages/homepage/tests/e2e/app-routes-flow.spec.ts
+++ b/packages/homepage/tests/e2e/app-routes-flow.spec.ts
@@ -378,8 +378,14 @@ test("landing leads with iMessage and keeps secondary channels available", async
     .toBe("+18087881821");
   const channels = page.locator(".landing-secondary-channels");
   await expect(channels.locator(".landing-channel")).toHaveCount(2);
-  await expect(channels.getByText("Telegram", { exact: true })).toBeVisible();
-  await expect(channels.getByText("Discord", { exact: true })).toBeVisible();
+  await expect(channels.getByText("Telegram", { exact: true })).toHaveCSS(
+    "clip-path",
+    "inset(50%)",
+  );
+  await expect(channels.getByText("Discord", { exact: true })).toHaveCSS(
+    "clip-path",
+    "inset(50%)",
+  );
   await expect(
     channels.getByRole("link", { name: /Telegram/ }),
   ).toHaveAttribute("href", /^https:\/\/t\.me\//);
@@ -387,6 +393,10 @@ test("landing leads with iMessage and keeps secondary channels available", async
     "href",
     /^https:\/\/discord\.com\//,
   );
+  for (const channel of await channels.locator(".landing-channel").all()) {
+    await expect(channel).toHaveCSS("width", "44px");
+    await expect(channel).toHaveCSS("height", "44px");
+  }
   await expect(channels.getByRole("link", { name: /WhatsApp/ })).toHaveCount(0);
 
   const keyboard = page.locator(".landing-keyboard");


### PR DESCRIPTION
## Summary
- restore the approved two-line desktop headline composition
- return Text Eliza to black and keep the newer hover motion
- return Telegram and Discord to accessible icon-only circles
- preserve the mobile phone demo and all group-chat behavior

## Verification
- `bun run --cwd packages/homepage lint:check`
- `bun run --cwd packages/homepage typecheck` (used the existing release-data file after a transient GitHub 504)
- focused Chromium landing CTA test: 1 passed
- local interaction check: no error overlay or console errors
- visual comparison at 1440x1000 against the supplied desktop reference: passed

AI provider/model: OpenAI / GPT-5.6
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [codex-homepage-desktop-polish]