### PR TITLE
fix(homepage): reject dot-segment open-redirect bypass in safeReturnTo

### DIFF
--- a/packages/homepage/src/lib/auth-return.ts
+++ b/packages/homepage/src/lib/auth-return.ts
@@ -10,9 +10,11 @@ export function safeReturnTo(value: string | null | undefined): string | null {
 
   try {
     const url = new URL(value, "https://eliza.app");
-    return url.origin === "https://eliza.app"
-      ? `${url.pathname}${url.search}${url.hash}`
-      : null;
+    if (url.origin !== "https://eliza.app") return null;
+    const dest = `${url.pathname}${url.search}${url.hash}`;
+    // Dot-segment inputs like "/..//host" pass the raw "//" guard but normalize
+    // to a protocol-relative path that escapes the origin; reject the result too.
+    return dest.startsWith("//") ? null : dest;
   } catch {
     // error-policy:J3 Malformed navigation input is an explicit invalid value.
     return null;

--- a/packages/homepage/tests/auth-return.test.ts
+++ b/packages/homepage/tests/auth-return.test.ts
@@ -23,6 +23,26 @@ describe("safe auth return paths", () => {
     expect(safeReturnTo("profile/edit")).toBeNull();
     expect(safeReturnTo(null)).toBeNull();
   });
+
+  test("rejects dot-segment inputs that normalize into origin-escaping //host", () => {
+    // Each input starts with a single "/" so it slips past the raw "//" guard,
+    // but URL normalization collapses the traversal into a protocol-relative
+    // "//evil.com" that escapes the homepage origin.
+    expect(safeReturnTo("/..//evil.com")).toBeNull();
+    expect(safeReturnTo("/..//..//evil.com")).toBeNull();
+    expect(safeReturnTo("/./..//evil.com")).toBeNull();
+    expect(safeReturnTo("/x/../..//evil.com")).toBeNull();
+    expect(safeReturnTo("/%2e%2e//evil.com")).toBeNull();
+  });
+
+  test("still accepts legitimate internal paths after the traversal guard", () => {
+    expect(safeReturnTo("/profile/edit")).toBe("/profile/edit");
+    expect(safeReturnTo("/connected")).toBe("/connected");
+    expect(safeReturnTo("/get-started?returnTo=%2Fcloud")).toBe(
+      "/get-started?returnTo=%2Fcloud",
+    );
+    expect(safeReturnTo("/a/../b")).toBe("/b");
+  });
 });
 
 describe("Telegram onboarding continuation", () => {


### PR DESCRIPTION
# Relates to

Closes #23190

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were attempted after sync; the unrelated blocker is recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0027cefec5f42d0a9bad5db3e1ba80e63f4eb16d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — blocked by an unrelated install policy documented in **Known gaps / failures**.

# Risks

Low. The change is a 3-line hardening of one exported sanitizer, `safeReturnTo`. It only rejects additional origin-escaping inputs; every currently-accepted internal path (including `/a/../b` -> `/b`, query strings, and hashes) continues to normalize and return exactly as before. No consumer signature changes.

# Background

## What does this PR do?

Fixes an open-redirect sanitizer bypass in `packages/homepage/src/lib/auth-return.ts`. `safeReturnTo` is the post-authentication return-to sanitizer whose documented contract is "rejects any destination that can escape the homepage origin." Its input guard rejects raw protocol-relative destinations (`value.startsWith("//") -> null`), but URL normalization defeats it:

- Input `/..//evil.com` starts with a single `/`, so it passes the guard.
- `new URL("/..//evil.com", "https://eliza.app")` resolves to origin `https://eliza.app` with `pathname === "//evil.com"`.
- The function therefore returned `"//evil.com"` — a protocol-relative, origin-escaping destination, exactly the value the sanitizer must reject.

The whole dot-segment class bypasses the raw guard: `/..//`, `/./..//`, `/x/../..//`, and the percent-encoded `/%2e%2e//`.

The fix composes the destination after normalization and rejects any result that still begins with `//`:

```ts
const url = new URL(value, "https://eliza.app");
if (url.origin !== "https://eliza.app") return null;
const dest = `${url.pathname}${url.search}${url.hash}`;
return dest.startsWith("//") ? null : dest;
```

**Real reachability:** the sanitized value is consumed by `src/pages/login.tsx` line 26, `navigate(returnTo ?? "/connected", { replace: true })`, and is also re-emitted into `?returnTo=${encodeURIComponent(returnTo)}` query strings in the same effect. So the origin-escaping value lands on a real post-auth navigation path and any consumer that renders it as an `href`/assigns `location` is a latent open redirect.

## What kind of change is this?

Bug fix (non-breaking change which fixes a security-boundary defect).

# Documentation changes needed?

No. The file's header contract ("rejects any destination that can escape the homepage origin") already describes the corrected behavior; this PR makes the implementation honor it.

# Testing

## Where should a reviewer start?

`packages/homepage/tests/auth-return.test.ts` and `packages/homepage/src/lib/auth-return.ts`.

## Detailed testing steps

```bash
cd packages/homepage
PATH=$HOME/.bun/bin:$PATH bun test tests/auth-return.test.ts
```

Two new test blocks were added:
- `rejects dot-segment inputs that normalize into origin-escaping //host` — asserts `toBeNull()` for `/..//evil.com`, `/..//..//evil.com`, `/./..//evil.com`, `/x/../..//evil.com`, and `/%2e%2e//evil.com`.
- `still accepts legitimate internal paths after the traversal guard` — asserts `/profile/edit`, `/connected`, `/get-started?returnTo=%2Fcloud`, and `/a/../b` -> `/b` still pass.

The existing direct `//example.com/profile/edit` control is retained.

# Evidence Gate

<!-- evidence-head:9adf70293d2f79c4e954758057821b81de7a7eda -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changed; the diff is a pure string-sanitizer function and its unit tests.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing visual flow; behavior is a security guard on a string helper covered by deterministic unit tests.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server code path; `safeReturnTo` is a synchronous client-side pure function.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no runtime request/response; the change is exercised by the unit tests below, not a network call.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model surface is touched.
<!-- evidence-row:domain-artifacts -->
- [x] Failing-before / passing-after unit-test output attached below (the domain artifact for a sanitizer regression).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - pure client-side string function; no backend path and no network request. Reachability is documented above: the sanitized value flows into `src/pages/login.tsx` `navigate(returnTo ?? "/connected")` and back into `?returnTo=` query strings.

## Failing-before / passing-after reproduction

Pre-fix (implementation reverted, new tests present) — the traversal input escapes the origin:

```
31 |     expect(safeReturnTo("/..//evil.com")).toBeNull();
                                               ^
error: expect(received).toBeNull()
Received: "//evil.com"
      at tests/auth-return.test.ts:31:43
(fail) safe auth return paths > rejects dot-segment inputs that normalize into origin-escaping //host
 1 fail
```

Post-fix — full package unit file green:

```
tests/auth-return.test.ts:
(pass) safe auth return paths > accepts internal paths with query strings and hashes
(pass) safe auth return paths > rejects external, scheme-relative, and malformed destinations
(pass) safe auth return paths > rejects dot-segment inputs that normalize into origin-escaping //host
(pass) safe auth return paths > still accepts legitimate internal paths after the traversal guard
(pass) Telegram onboarding continuation > returns to the bot only after a bot continuation auth flow
(pass) Telegram onboarding continuation > preserves ordinary Telegram account linking

 6 pass
 0 fail
 16 expect() calls
Ran 6 tests across 1 file.
```

Biome check on both changed files:

```
Checked 2 files in 97ms. No fixes applied.
```

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

- `bun install` / `bun run verify` could not complete on this machine: the environment enforces a global `minimumReleaseAge = 604800` install policy that refuses a recently-published transitive dependency (`viem@2.55.17`), unrelated to this change. Because `auth-return.ts` has no external dependencies, focused checks were run directly instead: `bun test tests/auth-return.test.ts` (6 pass), an isolated `tsc --noEmit --strict` typecheck of the module (clean), and `biome check` on both files (clean).

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@0027cefec5f42d0a9bad5db3e1ba80e63f4eb16d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@0027cefec5f42d0a9bad5db3e1ba80e63f4eb16d:packages/skills/skills/contribute-to-eliza"} -->
