### PR TITLE
fix(plugin-bluebubbles): restore develop verify import ordering

### DIFF
--- a/plugins/plugin-bluebubbles/src/accounts.test.ts
+++ b/plugins/plugin-bluebubbles/src/accounts.test.ts
@@ -7,9 +7,9 @@
 import type { Character, IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
+	type BlueBubblesMultiAccountConfig,
 	listEnabledBlueBubblesAccounts,
 	resolveBlueBubblesAccount,
-	type BlueBubblesMultiAccountConfig,
 } from "./accounts";
 
 function createRuntime(


### PR DESCRIPTION
# Relates to

Fixes #23194

# What

Restores repository-pinned Biome import ordering in the BlueBubbles multi-account test file. Scheduled develop-health run 32431130030 reached the real package lint gate and failed only on this deterministic organizeImports diagnostic.

# Evidence

<!-- evidence-head:20952106185c64358b02e90a88e2e45a524c0f7f -->

- Failing hosted boundary: https://github.com/elizaOS/eliza/actions/runs/32431130030/job/96622722313
- Exact change: one type-only import moved before value imports; no executable token or test behavior changed.
- Owning lint/test and repository verify: pending exact-head hosted checks; this PR remains draft until they are green.
- UI/screenshots/video/model trajectory: N/A, test import ordering only.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: repository AGENTS.md at exact base
<!-- attribution-row:status -->
- Provenance status: self-reported
