### PR TITLE
feat(ui): visible policy-controlled browser session panel

### DIFF
--- a/packages/ui/src/api/client-browser-bridge.ts
+++ b/packages/ui/src/api/client-browser-bridge.ts
@@ -1,0 +1,129 @@
+/**
+ * ElizaClient extension for the policy-controlled browser bridge session
+ * surface (`/api/browser-bridge/*`): listing agent browser sessions, reading
+ * and updating the bridge domain-policy settings, and confirming or declining
+ * a session that is awaiting user takeover. The wire shapes mirror the
+ * plugin-browser route contracts; no transformation happens here.
+ */
+import type {
+  BrowserBridgeSettings,
+  UpdateBrowserBridgeSettingsRequest,
+} from "./browser-contracts";
+import { ElizaClient } from "./client-base";
+
+export const BROWSER_BRIDGE_SESSION_STATUSES = [
+  "awaiting_confirmation",
+  "queued",
+  "running",
+  "done",
+  "cancelled",
+  "failed",
+] as const;
+
+export type BrowserBridgeSessionStatus =
+  (typeof BROWSER_BRIDGE_SESSION_STATUSES)[number];
+
+/** One scripted step inside a bridge session, as persisted by the host plugin. */
+export interface BrowserBridgeSessionAction {
+  id: string;
+  kind: string;
+  label: string;
+  url: string | null;
+  selector: string | null;
+  text: string | null;
+  accountAffecting: boolean;
+  requiresConfirmation: boolean;
+  metadata: Record<string, unknown>;
+}
+
+/** A policy-controlled agent browser session (wire mirror of the plugin contract). */
+export interface BrowserBridgeSession {
+  id: string;
+  agentId: string;
+  domain: string;
+  workflowId: string | null;
+  browser: string | null;
+  companionId: string | null;
+  profileId: string | null;
+  windowId: string | null;
+  tabId: string | null;
+  title: string;
+  status: BrowserBridgeSessionStatus;
+  actions: BrowserBridgeSessionAction[];
+  currentActionIndex: number;
+  awaitingConfirmationForActionId: string | null;
+  result: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+  finishedAt: string | null;
+}
+
+export interface BrowserBridgeSessionsResponse {
+  sessions: BrowserBridgeSession[];
+}
+
+export interface BrowserBridgeSettingsResponse {
+  settings: BrowserBridgeSettings;
+}
+
+export interface BrowserBridgeSessionResponse {
+  session: BrowserBridgeSession;
+}
+
+declare module "./client-base" {
+  interface ElizaClient {
+    listBrowserBridgeSessions(): Promise<BrowserBridgeSessionsResponse>;
+    getBrowserBridgeSettings(): Promise<BrowserBridgeSettingsResponse>;
+    updateBrowserBridgeSettings(
+      request: UpdateBrowserBridgeSettingsRequest,
+    ): Promise<BrowserBridgeSettingsResponse>;
+    confirmBrowserBridgeSession(
+      id: string,
+      confirmed: boolean,
+    ): Promise<BrowserBridgeSessionResponse>;
+  }
+}
+
+ElizaClient.prototype.listBrowserBridgeSessions = async function (
+  this: ElizaClient,
+): Promise<BrowserBridgeSessionsResponse> {
+  return this.fetch<BrowserBridgeSessionsResponse>(
+    "/api/browser-bridge/sessions",
+  );
+};
+
+ElizaClient.prototype.getBrowserBridgeSettings = async function (
+  this: ElizaClient,
+): Promise<BrowserBridgeSettingsResponse> {
+  return this.fetch<BrowserBridgeSettingsResponse>(
+    "/api/browser-bridge/settings",
+  );
+};
+
+ElizaClient.prototype.updateBrowserBridgeSettings = async function (
+  this: ElizaClient,
+  request: UpdateBrowserBridgeSettingsRequest,
+): Promise<BrowserBridgeSettingsResponse> {
+  return this.fetch<BrowserBridgeSettingsResponse>(
+    "/api/browser-bridge/settings",
+    {
+      method: "POST",
+      body: JSON.stringify(request),
+    },
+  );
+};
+
+ElizaClient.prototype.confirmBrowserBridgeSession = async function (
+  this: ElizaClient,
+  id: string,
+  confirmed: boolean,
+): Promise<BrowserBridgeSessionResponse> {
+  return this.fetch<BrowserBridgeSessionResponse>(
+    `/api/browser-bridge/sessions/${encodeURIComponent(id)}/confirm`,
+    {
+      method: "POST",
+      body: JSON.stringify({ confirmed }),
+    },
+  );
+};

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -110,6 +110,15 @@ export type {
 // Re-export the class from client-base (no circular dependency issues)
 export { ElizaClient } from "./client-base";
 export {
+  BROWSER_BRIDGE_SESSION_STATUSES,
+  type BrowserBridgeSession,
+  type BrowserBridgeSessionAction,
+  type BrowserBridgeSessionResponse,
+  type BrowserBridgeSessionStatus,
+  type BrowserBridgeSessionsResponse,
+  type BrowserBridgeSettingsResponse,
+} from "./client-browser-bridge";
+export {
   CloudAgentWakeError,
   type CloudAgentWakePhase,
   waitForCloudAgentRunning,
@@ -244,6 +253,7 @@ import "./client-accounts";
 import "./client-approvals";
 import "./client-automations";
 import "./client-background";
+import "./client-browser-bridge";
 import "./client-browser-workspace";
 import "./client-chat";
 import "./client-cloud";

--- a/packages/ui/src/components/browser/BrowserSessionPolicyPanel.stories.tsx
+++ b/packages/ui/src/components/browser/BrowserSessionPolicyPanel.stories.tsx
@@ -1,0 +1,168 @@
+/**
+ * Storybook stories for the policy-controlled browser session panel: the
+ * empty, error, takeover, blocked-domain, and finished-with-receipt states,
+ * each backed by a deterministic in-memory transport fake.
+ */
+import type { Meta, StoryObj } from "@storybook/react";
+import type { BrowserBridgeSettings } from "../../api/browser-contracts";
+import type { BrowserBridgeSession } from "../../api/client-browser-bridge";
+import type { BrowserSessionPolicyApi } from "./BrowserSessionPolicyPanel";
+import { BrowserSessionPolicyPanel } from "./BrowserSessionPolicyPanel";
+
+const SETTINGS: BrowserBridgeSettings = {
+  enabled: true,
+  trackingMode: "active_tabs",
+  allowBrowserControl: true,
+  requireConfirmationForAccountAffecting: true,
+  incognitoEnabled: false,
+  siteAccessMode: "granted_sites",
+  grantedOrigins: ["docs.example.com"],
+  blockedOrigins: ["trading.example.com"],
+  maxRememberedTabs: 8,
+  pauseUntil: null,
+  metadata: {},
+  updatedAt: "2026-08-20T11:00:00.000Z",
+};
+
+function makeSession(
+  overrides: Partial<BrowserBridgeSession>,
+): BrowserBridgeSession {
+  return {
+    id: "s-1",
+    agentId: "agent-1",
+    domain: "docs.example.com",
+    workflowId: null,
+    browser: "chrome",
+    companionId: "c-1",
+    profileId: "default",
+    windowId: "w-1",
+    tabId: "t-1",
+    title: "Summarize the docs page",
+    status: "running",
+    actions: [],
+    currentActionIndex: 0,
+    awaitingConfirmationForActionId: null,
+    result: {},
+    metadata: {},
+    createdAt: "2026-08-20T10:00:00.000Z",
+    updatedAt: "2026-08-20T11:30:00.000Z",
+    finishedAt: null,
+    ...overrides,
+  };
+}
+
+function staticApi(sessions: BrowserBridgeSession[]): BrowserSessionPolicyApi {
+  let settings = { ...SETTINGS };
+  const state = sessions.map((s) => ({ ...s }));
+  return {
+    async listBrowserBridgeSessions() {
+      return { sessions: state.map((s) => ({ ...s })) };
+    },
+    async getBrowserBridgeSettings() {
+      return { settings: { ...settings } };
+    },
+    async updateBrowserBridgeSettings(request) {
+      settings = { ...settings, ...request } as BrowserBridgeSettings;
+      return { settings: { ...settings } };
+    },
+    async confirmBrowserBridgeSession(id, confirmed) {
+      const existing = state.find((s) => s.id === id);
+      if (!existing) throw new Error(`Browser session not found: ${id}`);
+      existing.status = confirmed ? "queued" : "cancelled";
+      return { session: { ...existing } };
+    },
+  };
+}
+
+const failingApi: BrowserSessionPolicyApi = {
+  async listBrowserBridgeSessions() {
+    throw new Error("bridge offline");
+  },
+  async getBrowserBridgeSettings() {
+    throw new Error("bridge offline");
+  },
+  async updateBrowserBridgeSettings() {
+    throw new Error("bridge offline");
+  },
+  async confirmBrowserBridgeSession() {
+    throw new Error("bridge offline");
+  },
+};
+
+const meta: Meta<typeof BrowserSessionPolicyPanel> = {
+  title: "Browser/BrowserSessionPolicyPanel",
+  component: BrowserSessionPolicyPanel,
+};
+export default meta;
+
+type Story = StoryObj<typeof BrowserSessionPolicyPanel>;
+
+export const Empty: Story = {
+  args: { api: staticApi([]) },
+};
+
+export const LoadError: Story = {
+  args: { api: failingApi },
+};
+
+export const AwaitingTakeover: Story = {
+  args: {
+    api: staticApi([
+      makeSession({
+        id: "s-takeover",
+        status: "awaiting_confirmation",
+        awaitingConfirmationForActionId: "a-1",
+        actions: [
+          {
+            id: "a-1",
+            kind: "submit",
+            label: "Submit reservation",
+            url: null,
+            selector: "#reserve",
+            text: null,
+            accountAffecting: true,
+            requiresConfirmation: true,
+            metadata: {},
+          },
+        ],
+      }),
+    ]),
+  },
+};
+
+export const BlockedAndOutsideGrants: Story = {
+  args: {
+    api: staticApi([
+      makeSession({
+        id: "s-blocked",
+        domain: "trading.example.com",
+        title: "Place a trade",
+        status: "failed",
+        finishedAt: "2026-08-20T11:35:00.000Z",
+        result: { reason: "domain blocked by policy" },
+      }),
+      makeSession({
+        id: "s-outside",
+        domain: "social.example.net",
+        title: "Post an update",
+      }),
+    ]),
+  },
+};
+
+export const FinishedWithReceipt: Story = {
+  args: {
+    api: staticApi([
+      makeSession({
+        id: "s-done",
+        status: "done",
+        finishedAt: "2026-08-20T11:40:00.000Z",
+        result: {
+          summary: "Copied the release notes into a draft.",
+          pagesVisited: 3,
+          accessToken: "never-shown",
+        },
+      }),
+    ]),
+  },
+};

--- a/packages/ui/src/components/browser/BrowserSessionPolicyPanel.test.tsx
+++ b/packages/ui/src/components/browser/BrowserSessionPolicyPanel.test.tsx
@@ -1,0 +1,290 @@
+/**
+ * Behaviour coverage for the policy-controlled browser session panel under
+ * jsdom with a protocol-faithful in-memory transport (the fake keeps real
+ * session/settings state and applies confirm/settings writes the way the
+ * bridge routes do). Verifies the three distinct load states, takeover
+ * confirm/decline, domain grant/block writes, submit interception surfacing,
+ * receipt redaction, and the action-error banner on a failed write.
+ */
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type {
+  BrowserBridgeSettings,
+  UpdateBrowserBridgeSettingsRequest,
+} from "../../api/browser-contracts";
+import type { BrowserBridgeSession } from "../../api/client-browser-bridge";
+import type { BrowserSessionPolicyApi } from "./BrowserSessionPolicyPanel";
+import { BrowserSessionPolicyPanel } from "./BrowserSessionPolicyPanel";
+
+const NOW_SETTINGS: BrowserBridgeSettings = {
+  enabled: true,
+  trackingMode: "active_tabs",
+  allowBrowserControl: true,
+  requireConfirmationForAccountAffecting: true,
+  incognitoEnabled: false,
+  siteAccessMode: "granted_sites",
+  grantedOrigins: ["docs.example.com"],
+  blockedOrigins: ["trading.example.com"],
+  maxRememberedTabs: 8,
+  pauseUntil: null,
+  metadata: {},
+  updatedAt: "2026-08-20T11:00:00.000Z",
+};
+
+function makeSession(
+  overrides: Partial<BrowserBridgeSession> = {},
+): BrowserBridgeSession {
+  return {
+    id: "s-1",
+    agentId: "agent-1",
+    domain: "docs.example.com",
+    workflowId: null,
+    browser: "chrome",
+    companionId: "c-1",
+    profileId: "default",
+    windowId: "w-1",
+    tabId: "t-1",
+    title: "Summarize the docs page",
+    status: "running",
+    actions: [],
+    currentActionIndex: 0,
+    awaitingConfirmationForActionId: null,
+    result: {},
+    metadata: {},
+    createdAt: "2026-08-20T10:00:00.000Z",
+    updatedAt: "2026-08-20T11:30:00.000Z",
+    finishedAt: null,
+    ...overrides,
+  };
+}
+
+/**
+ * In-memory transport that mirrors the bridge route semantics: confirm flips
+ * an awaiting session to queued (true) or cancelled (false); settings writes
+ * merge the patch and bump updatedAt.
+ */
+function makeFakeApi(
+  sessions: BrowserBridgeSession[],
+  settings: BrowserBridgeSettings = NOW_SETTINGS,
+) {
+  const state = {
+    sessions: sessions.map((s) => ({ ...s })),
+    settings: { ...settings },
+    settingsWrites: [] as UpdateBrowserBridgeSettingsRequest[],
+    confirmCalls: [] as Array<{ id: string; confirmed: boolean }>,
+  };
+  const api: BrowserSessionPolicyApi = {
+    async listBrowserBridgeSessions() {
+      return { sessions: state.sessions.map((s) => ({ ...s })) };
+    },
+    async getBrowserBridgeSettings() {
+      return { settings: { ...state.settings } };
+    },
+    async updateBrowserBridgeSettings(request) {
+      state.settingsWrites.push(request);
+      state.settings = {
+        ...state.settings,
+        ...request,
+        updatedAt: "2026-08-20T11:45:00.000Z",
+      } as BrowserBridgeSettings;
+      return { settings: { ...state.settings } };
+    },
+    async confirmBrowserBridgeSession(id, confirmed) {
+      state.confirmCalls.push({ id, confirmed });
+      const existing = state.sessions.find((s) => s.id === id);
+      if (!existing) {
+        throw new Error(`Browser session not found: ${id}`);
+      }
+      existing.status = confirmed ? "queued" : "cancelled";
+      existing.awaitingConfirmationForActionId = null;
+      return { session: { ...existing } };
+    },
+  };
+  return { api, state };
+}
+
+describe("BrowserSessionPolicyPanel", () => {
+  it("shows the loading state, then the designed-empty state", async () => {
+    const { api } = makeFakeApi([]);
+    render(<BrowserSessionPolicyPanel api={api} />);
+    expect(screen.getByTestId("browser-session-policy-loading")).toBeTruthy();
+    await waitFor(() =>
+      expect(screen.getByTestId("browser-session-policy-empty")).toBeTruthy(),
+    );
+  });
+
+  it("shows a distinct error state with retry when loading fails", async () => {
+    const { api } = makeFakeApi([makeSession()]);
+    let fail = true;
+    const flaky: BrowserSessionPolicyApi = {
+      ...api,
+      async listBrowserBridgeSessions() {
+        if (fail) throw new Error("bridge offline");
+        return api.listBrowserBridgeSessions();
+      },
+    };
+    render(<BrowserSessionPolicyPanel api={flaky} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("browser-session-policy-error")).toBeTruthy(),
+    );
+    expect(screen.getByText("bridge offline")).toBeTruthy();
+    fail = false;
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() =>
+      expect(screen.getByTestId("browser-session-policy-panel")).toBeTruthy(),
+    );
+  });
+
+  it("renders policy verdicts per session domain", async () => {
+    const { api } = makeFakeApi([
+      makeSession({ id: "s-granted", domain: "docs.example.com" }),
+      makeSession({ id: "s-blocked", domain: "trading.example.com" }),
+      makeSession({ id: "s-outside", domain: "social.example.net" }),
+    ]);
+    render(<BrowserSessionPolicyPanel api={api} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("browser-session-policy-panel")).toBeTruthy(),
+    );
+    expect(
+      screen.getByTestId("browser-session-s-granted-policy").textContent,
+    ).toBe("Granted");
+    expect(
+      screen.getByTestId("browser-session-s-blocked-policy").textContent,
+    ).toBe("Blocked");
+    expect(
+      screen.getByTestId("browser-session-s-outside-policy").textContent,
+    ).toBe("Not granted");
+  });
+
+  it("approves a takeover session through the confirm route", async () => {
+    const { api, state } = makeFakeApi([
+      makeSession({
+        id: "s-takeover",
+        status: "awaiting_confirmation",
+        awaitingConfirmationForActionId: "a-1",
+      }),
+    ]);
+    render(<BrowserSessionPolicyPanel api={api} />);
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("browser-session-s-takeover-approve"),
+      ).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByTestId("browser-session-s-takeover-approve"));
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("browser-session-s-takeover-status").textContent,
+      ).toBe("Queued"),
+    );
+    expect(state.confirmCalls).toEqual([{ id: "s-takeover", confirmed: true }]);
+  });
+
+  it("declines a takeover session, cancelling it", async () => {
+    const { api, state } = makeFakeApi([
+      makeSession({ id: "s-decline", status: "awaiting_confirmation" }),
+    ]);
+    render(<BrowserSessionPolicyPanel api={api} />);
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("browser-session-s-decline-decline"),
+      ).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByTestId("browser-session-s-decline-decline"));
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("browser-session-s-decline-status").textContent,
+      ).toBe("Cancelled"),
+    );
+    expect(state.confirmCalls).toEqual([{ id: "s-decline", confirmed: false }]);
+  });
+
+  it("grants and blocks a domain through the settings route", async () => {
+    const { api, state } = makeFakeApi([
+      makeSession({ id: "s-grantable", domain: "social.example.net" }),
+    ]);
+    render(<BrowserSessionPolicyPanel api={api} />);
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("browser-session-s-grantable-grant"),
+      ).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByTestId("browser-session-s-grantable-grant"));
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("browser-session-s-grantable-policy").textContent,
+      ).toBe("Granted"),
+    );
+    expect(state.settingsWrites[0]?.grantedOrigins).toContain(
+      "social.example.net",
+    );
+    fireEvent.click(screen.getByTestId("browser-session-s-grantable-block"));
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("browser-session-s-grantable-policy").textContent,
+      ).toBe("Blocked"),
+    );
+    expect(state.settingsWrites[1]?.blockedOrigins).toContain(
+      "social.example.net",
+    );
+  });
+
+  it("surfaces intercepted submit steps and a redacted receipt", async () => {
+    const { api } = makeFakeApi([
+      makeSession({
+        id: "s-receipt",
+        status: "done",
+        finishedAt: "2026-08-20T11:40:00.000Z",
+        actions: [
+          {
+            id: "a-submit",
+            kind: "submit",
+            label: "Submit checkout",
+            url: null,
+            selector: "#checkout",
+            text: null,
+            accountAffecting: false,
+            requiresConfirmation: false,
+            metadata: {},
+          },
+        ],
+        result: { orderId: "ORD-9", accessToken: "sk-live-nope" },
+      }),
+    ]);
+    render(<BrowserSessionPolicyPanel api={api} />);
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("browser-session-s-receipt-receipt"),
+      ).toBeTruthy(),
+    );
+    expect(
+      screen.getByTestId("browser-session-s-receipt-intercepted").textContent,
+    ).toContain("Submit checkout");
+    const receipt = screen.getByTestId("browser-session-s-receipt-receipt");
+    expect(receipt.textContent).toContain("ORD-9");
+    expect(receipt.textContent).toContain("[redacted]");
+    expect(receipt.textContent).not.toContain("sk-live-nope");
+  });
+
+  it("shows the action-error banner when a policy write fails", async () => {
+    const { api } = makeFakeApi([
+      makeSession({ id: "s-fail", domain: "social.example.net" }),
+    ]);
+    const failing: BrowserSessionPolicyApi = {
+      ...api,
+      async updateBrowserBridgeSettings() {
+        throw new Error("settings write rejected");
+      },
+    };
+    render(<BrowserSessionPolicyPanel api={failing} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("browser-session-s-fail-block")).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByTestId("browser-session-s-fail-block"));
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("browser-session-policy-action-error").textContent,
+      ).toBe("settings write rejected"),
+    );
+  });
+});

--- a/packages/ui/src/components/browser/BrowserSessionPolicyPanel.tsx
+++ b/packages/ui/src/components/browser/BrowserSessionPolicyPanel.tsx
@@ -1,0 +1,411 @@
+/**
+ * Visible policy-controlled browser session surface: lists the agent's bridge
+ * sessions with the effective domain-mode verdict for each, exposes user
+ * takeover (confirm / decline) for sessions parked awaiting confirmation,
+ * surfaces intercepted submit/account-affecting steps, per-domain grant and
+ * block controls, session TTL, and a credential-redacted receipt for
+ * finished sessions.
+ *
+ * Data flows through the injected {@link BrowserSessionPolicyApi} (the shared
+ * `client` implements it via `client-browser-bridge`), so tests drive the
+ * panel with a protocol-faithful transport fake. Loading, designed-empty, and
+ * error are three distinct states. The clock is owned here via an effect —
+ * never read in render — so renders stay deterministic.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  BrowserBridgeSettings,
+  UpdateBrowserBridgeSettingsRequest,
+} from "../../api/browser-contracts";
+import type {
+  BrowserBridgeSession,
+  BrowserBridgeSessionResponse,
+  BrowserBridgeSessionsResponse,
+  BrowserBridgeSettingsResponse,
+} from "../../api/client-browser-bridge";
+import { cn } from "../../lib/utils";
+import { Button } from "../ui/button";
+import {
+  type BrowserDomainPolicyMode,
+  browserSessionExpiresAt,
+  interceptedSessionActions,
+  isBrowserSessionExpired,
+  resolveBrowserDomainPolicy,
+  sessionRequiresTakeover,
+  summarizeBrowserSessionReceipt,
+} from "./browser-session-policy";
+
+export interface BrowserSessionPolicyApi {
+  listBrowserBridgeSessions(): Promise<BrowserBridgeSessionsResponse>;
+  getBrowserBridgeSettings(): Promise<BrowserBridgeSettingsResponse>;
+  updateBrowserBridgeSettings(
+    request: UpdateBrowserBridgeSettingsRequest,
+  ): Promise<BrowserBridgeSettingsResponse>;
+  confirmBrowserBridgeSession(
+    id: string,
+    confirmed: boolean,
+  ): Promise<BrowserBridgeSessionResponse>;
+}
+
+export interface BrowserSessionPolicyPanelProps {
+  api: BrowserSessionPolicyApi;
+  /** Clock refresh cadence for TTL annotations; defaults to 30s. */
+  clockIntervalMs?: number;
+}
+
+const POLICY_MODE_LABELS: Record<BrowserDomainPolicyMode, string> = {
+  bridge_disabled: "Bridge disabled",
+  control_disabled: "Browser control off",
+  paused: "Paused",
+  blocked: "Blocked",
+  all_sites: "All sites allowed",
+  granted: "Granted",
+  current_site_only: "Current site only",
+  outside_grants: "Not granted",
+  unresolved: "Unknown domain",
+};
+
+const STATUS_LABELS: Record<BrowserBridgeSession["status"], string> = {
+  awaiting_confirmation: "Awaiting your confirmation",
+  queued: "Queued",
+  running: "Running",
+  done: "Done",
+  cancelled: "Cancelled",
+  failed: "Failed",
+};
+
+function policyBadgeClass(allowed: boolean, mode: BrowserDomainPolicyMode) {
+  if (mode === "blocked") {
+    return "border-danger/50 bg-danger/15 text-danger";
+  }
+  return allowed
+    ? "border-accent/50 bg-accent/15 text-accent"
+    : "border-border bg-muted/40 text-muted-foreground";
+}
+
+type LoadPhase = "loading" | "error" | "ready";
+
+export function BrowserSessionPolicyPanel({
+  api,
+  clockIntervalMs = 30_000,
+}: BrowserSessionPolicyPanelProps) {
+  const [phase, setPhase] = useState<LoadPhase>("loading");
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [sessions, setSessions] = useState<BrowserBridgeSession[]>([]);
+  const [settings, setSettings] = useState<BrowserBridgeSettings | null>(null);
+  const [nowIso, setNowIso] = useState<string | null>(null);
+  const [pendingSessionId, setPendingSessionId] = useState<string | null>(null);
+  const [pendingDomain, setPendingDomain] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    setNowIso(new Date().toISOString());
+    const timer = setInterval(() => {
+      setNowIso(new Date().toISOString());
+    }, clockIntervalMs);
+    return () => clearInterval(timer);
+  }, [clockIntervalMs]);
+
+  const load = useCallback(async () => {
+    setPhase("loading");
+    setLoadError(null);
+    try {
+      const [sessionsResponse, settingsResponse] = await Promise.all([
+        api.listBrowserBridgeSessions(),
+        api.getBrowserBridgeSettings(),
+      ]);
+      if (!mountedRef.current) return;
+      setSessions(sessionsResponse.sessions);
+      setSettings(settingsResponse.settings);
+      setPhase("ready");
+    } catch (error) {
+      // error-policy:J4 user-facing degrade — the fetch failure becomes the
+      // panel's visibly distinct error state with a retry affordance.
+      if (!mountedRef.current) return;
+      setLoadError(error instanceof Error ? error.message : String(error));
+      setPhase("error");
+    }
+  }, [api]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const confirmSession = useCallback(
+    async (id: string, confirmed: boolean) => {
+      setPendingSessionId(id);
+      setActionError(null);
+      try {
+        const { session } = await api.confirmBrowserBridgeSession(
+          id,
+          confirmed,
+        );
+        if (!mountedRef.current) return;
+        setSessions((current) =>
+          current.map((existing) =>
+            existing.id === session.id ? session : existing,
+          ),
+        );
+      } catch (error) {
+        // error-policy:J4 user-facing degrade — a failed takeover call becomes
+        // the panel's visible action-error banner; the session keeps its state.
+        if (!mountedRef.current) return;
+        setActionError(error instanceof Error ? error.message : String(error));
+      } finally {
+        if (mountedRef.current) setPendingSessionId(null);
+      }
+    },
+    [api],
+  );
+
+  const updateDomainPolicy = useCallback(
+    async (domain: string, action: "grant" | "block" | "unblock") => {
+      if (!settings) return;
+      setPendingDomain(domain);
+      setActionError(null);
+      const grantedOrigins =
+        action === "grant"
+          ? Array.from(new Set([...settings.grantedOrigins, domain]))
+          : settings.grantedOrigins.filter((origin) => origin !== domain);
+      const blockedOrigins =
+        action === "block"
+          ? Array.from(new Set([...settings.blockedOrigins, domain]))
+          : action === "unblock"
+            ? settings.blockedOrigins.filter((origin) => origin !== domain)
+            : settings.blockedOrigins;
+      try {
+        const { settings: updated } = await api.updateBrowserBridgeSettings({
+          grantedOrigins,
+          blockedOrigins,
+        });
+        if (!mountedRef.current) return;
+        setSettings(updated);
+      } catch (error) {
+        // error-policy:J4 user-facing degrade — a failed policy write becomes
+        // the visible action-error banner; the stored settings are untouched.
+        if (!mountedRef.current) return;
+        setActionError(error instanceof Error ? error.message : String(error));
+      } finally {
+        if (mountedRef.current) setPendingDomain(null);
+      }
+    },
+    [api, settings],
+  );
+
+  const visibleSessions = useMemo(() => {
+    if (!nowIso) return sessions;
+    return sessions.filter(
+      (session) => !isBrowserSessionExpired(session, nowIso),
+    );
+  }, [sessions, nowIso]);
+
+  if (phase === "loading") {
+    return (
+      <div
+        data-testid="browser-session-policy-loading"
+        className="flex items-center gap-2 p-4 text-sm text-muted-foreground"
+      >
+        <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-accent" />
+        Loading browser sessions…
+      </div>
+    );
+  }
+
+  if (phase === "error" || !settings) {
+    return (
+      <div
+        data-testid="browser-session-policy-error"
+        className="flex flex-col gap-2 rounded-sm border border-danger/50 bg-danger/10 p-4 text-sm text-danger"
+      >
+        <span>Failed to load browser sessions.</span>
+        {loadError ? (
+          <span className="text-xs opacity-80">{loadError}</span>
+        ) : null}
+        <Button size="sm" variant="outline" onClick={() => void load()}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (visibleSessions.length === 0) {
+    return (
+      <div
+        data-testid="browser-session-policy-empty"
+        className="rounded-sm border border-border bg-muted/30 p-4 text-sm text-muted-foreground"
+      >
+        No browser sessions yet. When the agent drives a website, the session
+        appears here with its domain policy and controls.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="browser-session-policy-panel"
+      className="flex flex-col gap-3"
+    >
+      {actionError ? (
+        <div
+          data-testid="browser-session-policy-action-error"
+          className="rounded-sm border border-danger/50 bg-danger/10 px-3 py-2 text-xs text-danger"
+        >
+          {actionError}
+        </div>
+      ) : null}
+      {visibleSessions.map((session) => {
+        const verdict = resolveBrowserDomainPolicy(
+          session.domain,
+          settings,
+          nowIso ?? session.updatedAt,
+        );
+        const intercepted = interceptedSessionActions(session, settings);
+        const receipt =
+          session.status === "done" || session.status === "failed"
+            ? summarizeBrowserSessionReceipt(session)
+            : [];
+        const expiresAt = browserSessionExpiresAt(session);
+        const takeover = sessionRequiresTakeover(session);
+        const busy = pendingSessionId === session.id;
+        const domainBusy = pendingDomain === session.domain;
+        const blocked = verdict.mode === "blocked";
+        return (
+          <div
+            key={session.id}
+            data-testid={`browser-session-${session.id}`}
+            className="flex flex-col gap-2 rounded-sm border border-border bg-background/60 p-3"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm font-medium">{session.title}</span>
+              <span
+                data-testid={`browser-session-${session.id}-policy`}
+                className={cn(
+                  "rounded-sm border px-1.5 py-0.5 text-[11px] leading-4",
+                  policyBadgeClass(verdict.allowed, verdict.mode),
+                )}
+              >
+                {POLICY_MODE_LABELS[verdict.mode]}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {session.domain}
+              </span>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <span data-testid={`browser-session-${session.id}-status`}>
+                {STATUS_LABELS[session.status]}
+              </span>
+              {expiresAt &&
+              (session.status === "done" ||
+                session.status === "cancelled" ||
+                session.status === "failed") ? (
+                <span data-testid={`browser-session-${session.id}-expiry`}>
+                  Removed after {expiresAt}
+                </span>
+              ) : null}
+            </div>
+            {intercepted.length > 0 ? (
+              <div
+                data-testid={`browser-session-${session.id}-intercepted`}
+                className="rounded-sm border border-accent/40 bg-accent/10 px-2 py-1.5 text-xs"
+              >
+                <span className="font-medium">Held for confirmation:</span>{" "}
+                {intercepted.map((action) => action.label).join(", ")}
+              </div>
+            ) : null}
+            {takeover ? (
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  disabled={busy}
+                  data-testid={`browser-session-${session.id}-approve`}
+                  onClick={() => void confirmSession(session.id, true)}
+                >
+                  Approve and continue
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={busy}
+                  data-testid={`browser-session-${session.id}-decline`}
+                  onClick={() => void confirmSession(session.id, false)}
+                >
+                  Decline
+                </Button>
+              </div>
+            ) : null}
+            <div className="flex gap-2">
+              {blocked ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={domainBusy}
+                  data-testid={`browser-session-${session.id}-unblock`}
+                  onClick={() =>
+                    void updateDomainPolicy(session.domain, "unblock")
+                  }
+                >
+                  Unblock {session.domain}
+                </Button>
+              ) : (
+                <>
+                  {verdict.mode === "outside_grants" ? (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={domainBusy}
+                      data-testid={`browser-session-${session.id}-grant`}
+                      onClick={() =>
+                        void updateDomainPolicy(session.domain, "grant")
+                      }
+                    >
+                      Grant {session.domain}
+                    </Button>
+                  ) : null}
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={domainBusy}
+                    data-testid={`browser-session-${session.id}-block`}
+                    onClick={() =>
+                      void updateDomainPolicy(session.domain, "block")
+                    }
+                  >
+                    Block {session.domain}
+                  </Button>
+                </>
+              )}
+            </div>
+            {receipt.length > 0 ? (
+              <dl
+                data-testid={`browser-session-${session.id}-receipt`}
+                className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 rounded-sm border border-border bg-muted/20 px-2 py-1.5 text-xs"
+              >
+                {receipt.map((entry) => (
+                  <div key={entry.key} className="contents">
+                    <dt className="text-muted-foreground">{entry.key}</dt>
+                    <dd
+                      className={cn(
+                        "break-all",
+                        entry.redacted && "italic text-muted-foreground",
+                      )}
+                    >
+                      {entry.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/ui/src/components/browser/browser-session-policy.test.ts
+++ b/packages/ui/src/components/browser/browser-session-policy.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Deterministic unit coverage for the pure browser-session policy math:
+ * domain-mode resolution ordering (disabled/paused/blocked pre-emption),
+ * origin normalization and subdomain matching, submit/account-affecting
+ * interception, TTL expiry, and credential redaction in receipts. No DOM,
+ * no mocks — pure inputs to values.
+ */
+import { describe, expect, it } from "vitest";
+import type { BrowserBridgeSettings } from "../../api/browser-contracts";
+import type { BrowserBridgeSession } from "../../api/client-browser-bridge";
+import {
+  BROWSER_SESSION_TTL_MS,
+  browserSessionExpiresAt,
+  domainMatchesOrigin,
+  interceptedSessionActions,
+  isBrowserSessionExpired,
+  normalizeOriginHost,
+  resolveBrowserDomainPolicy,
+  sessionRequiresTakeover,
+  summarizeBrowserSessionReceipt,
+} from "./browser-session-policy";
+
+const NOW = "2026-08-20T12:00:00.000Z";
+
+function settings(
+  overrides: Partial<BrowserBridgeSettings> = {},
+): BrowserBridgeSettings {
+  return {
+    enabled: true,
+    trackingMode: "active_tabs",
+    allowBrowserControl: true,
+    requireConfirmationForAccountAffecting: true,
+    incognitoEnabled: false,
+    siteAccessMode: "granted_sites",
+    grantedOrigins: [],
+    blockedOrigins: [],
+    maxRememberedTabs: 8,
+    pauseUntil: null,
+    metadata: {},
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function session(
+  overrides: Partial<BrowserBridgeSession> = {},
+): BrowserBridgeSession {
+  return {
+    id: "s-1",
+    agentId: "agent-1",
+    domain: "example.com",
+    workflowId: null,
+    browser: "chrome",
+    companionId: null,
+    profileId: null,
+    windowId: null,
+    tabId: null,
+    title: "Book a table",
+    status: "running",
+    actions: [],
+    currentActionIndex: 0,
+    awaitingConfirmationForActionId: null,
+    result: {},
+    metadata: {},
+    createdAt: "2026-08-20T10:00:00.000Z",
+    updatedAt: "2026-08-20T11:00:00.000Z",
+    finishedAt: null,
+    ...overrides,
+  };
+}
+
+describe("normalizeOriginHost / domainMatchesOrigin", () => {
+  it("normalizes scheme, path, port, and wildcard prefixes", () => {
+    expect(normalizeOriginHost("https://Example.com/*")).toBe("example.com");
+    expect(normalizeOriginHost("*.example.com")).toBe("example.com");
+    expect(normalizeOriginHost("example.com:8443/path")).toBe("example.com");
+    expect(normalizeOriginHost("   ")).toBeNull();
+    expect(normalizeOriginHost("*.")).toBeNull();
+  });
+
+  it("matches exact hosts and subdomains, never suffix fragments", () => {
+    expect(domainMatchesOrigin("example.com", "https://example.com")).toBe(
+      true,
+    );
+    expect(domainMatchesOrigin("app.example.com", "example.com")).toBe(true);
+    expect(domainMatchesOrigin("notexample.com", "example.com")).toBe(false);
+    expect(domainMatchesOrigin("", "example.com")).toBe(false);
+  });
+});
+
+describe("resolveBrowserDomainPolicy", () => {
+  it("fails closed when the bridge or control is disabled", () => {
+    expect(
+      resolveBrowserDomainPolicy(
+        "example.com",
+        settings({ enabled: false }),
+        NOW,
+      ),
+    ).toEqual({ mode: "bridge_disabled", allowed: false });
+    expect(
+      resolveBrowserDomainPolicy(
+        "example.com",
+        settings({ allowBrowserControl: false }),
+        NOW,
+      ),
+    ).toEqual({ mode: "control_disabled", allowed: false });
+  });
+
+  it("reports paused while pauseUntil is in the future, then resumes", () => {
+    const paused = settings({ pauseUntil: "2026-08-20T13:00:00.000Z" });
+    expect(resolveBrowserDomainPolicy("example.com", paused, NOW).mode).toBe(
+      "paused",
+    );
+    expect(
+      resolveBrowserDomainPolicy(
+        "example.com",
+        paused,
+        "2026-08-20T14:00:00.000Z",
+      ).mode,
+    ).toBe("outside_grants");
+  });
+
+  it("blocklist wins over every allow mode, including all_sites", () => {
+    const verdict = resolveBrowserDomainPolicy(
+      "trading.example.com",
+      settings({
+        siteAccessMode: "all_sites",
+        blockedOrigins: ["example.com"],
+      }),
+      NOW,
+    );
+    expect(verdict).toEqual({ mode: "blocked", allowed: false });
+  });
+
+  it("resolves granted vs outside_grants under granted_sites mode", () => {
+    const withGrant = settings({ grantedOrigins: ["https://example.com/*"] });
+    expect(
+      resolveBrowserDomainPolicy("app.example.com", withGrant, NOW),
+    ).toEqual({ mode: "granted", allowed: true });
+    expect(resolveBrowserDomainPolicy("other.com", withGrant, NOW)).toEqual({
+      mode: "outside_grants",
+      allowed: false,
+    });
+  });
+
+  it("passes all_sites and current_site_only through as allowed", () => {
+    expect(
+      resolveBrowserDomainPolicy(
+        "example.com",
+        settings({ siteAccessMode: "all_sites" }),
+        NOW,
+      ),
+    ).toEqual({ mode: "all_sites", allowed: true });
+    expect(
+      resolveBrowserDomainPolicy(
+        "example.com",
+        settings({ siteAccessMode: "current_site_only" }),
+        NOW,
+      ),
+    ).toEqual({ mode: "current_site_only", allowed: true });
+  });
+
+  it("treats a missing or blank domain as unresolved, not allowed", () => {
+    expect(resolveBrowserDomainPolicy(null, settings(), NOW)).toEqual({
+      mode: "unresolved",
+      allowed: false,
+    });
+    expect(resolveBrowserDomainPolicy("  ", settings(), NOW).mode).toBe(
+      "unresolved",
+    );
+  });
+});
+
+describe("interception and takeover", () => {
+  const submitAction = {
+    id: "a-1",
+    kind: "submit",
+    label: "Submit order",
+    url: null,
+    selector: "#buy",
+    text: null,
+    accountAffecting: false,
+    requiresConfirmation: false,
+    metadata: {},
+  };
+  const clickAction = {
+    ...submitAction,
+    id: "a-2",
+    kind: "click",
+    label: "Open cart",
+  };
+  const flaggedAction = {
+    ...clickAction,
+    id: "a-3",
+    label: "Transfer funds",
+    accountAffecting: true,
+  };
+  const explicitAction = {
+    ...clickAction,
+    id: "a-4",
+    label: "Post message",
+    requiresConfirmation: true,
+  };
+
+  it("intercepts submit, account-affecting, and explicit-confirmation steps", () => {
+    const s = session({
+      actions: [submitAction, clickAction, flaggedAction, explicitAction],
+    });
+    const intercepted = interceptedSessionActions(s, settings());
+    expect(intercepted.map((a) => a.id)).toEqual(["a-1", "a-3", "a-4"]);
+  });
+
+  it("keeps only explicit-confirmation steps when the setting is off", () => {
+    const s = session({
+      actions: [submitAction, flaggedAction, explicitAction],
+    });
+    const intercepted = interceptedSessionActions(
+      s,
+      settings({ requireConfirmationForAccountAffecting: false }),
+    );
+    expect(intercepted.map((a) => a.id)).toEqual(["a-4"]);
+  });
+
+  it("flags takeover only for awaiting_confirmation", () => {
+    expect(
+      sessionRequiresTakeover(session({ status: "awaiting_confirmation" })),
+    ).toBe(true);
+    expect(sessionRequiresTakeover(session({ status: "running" }))).toBe(false);
+  });
+});
+
+describe("session TTL", () => {
+  it("anchors expiry on finishedAt when present, else updatedAt", () => {
+    const finished = session({
+      status: "done",
+      finishedAt: "2026-08-19T11:00:00.000Z",
+    });
+    expect(browserSessionExpiresAt(finished)).toBe(
+      new Date(
+        Date.parse("2026-08-19T11:00:00.000Z") + BROWSER_SESSION_TTL_MS,
+      ).toISOString(),
+    );
+    expect(isBrowserSessionExpired(finished, NOW)).toBe(true);
+  });
+
+  it("never expires an unfinished session and tolerates bad timestamps", () => {
+    expect(
+      isBrowserSessionExpired(
+        session({ status: "running", updatedAt: "2026-08-01T00:00:00.000Z" }),
+        NOW,
+      ),
+    ).toBe(false);
+    expect(
+      browserSessionExpiresAt(
+        session({ status: "done", finishedAt: "not-a-date" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps a freshly finished session inside its window", () => {
+    expect(
+      isBrowserSessionExpired(
+        session({ status: "done", finishedAt: "2026-08-20T11:59:00.000Z" }),
+        NOW,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("summarizeBrowserSessionReceipt", () => {
+  it("redacts credential-looking keys unconditionally", () => {
+    const entries = summarizeBrowserSessionReceipt(
+      session({
+        result: {
+          orderId: "ORD-42",
+          sessionToken: "sk-live-abc",
+          Password: "hunter2",
+          cookieJar: { a: 1 },
+        },
+      }),
+    );
+    const byKey = Object.fromEntries(entries.map((e) => [e.key, e]));
+    expect(byKey.orderId).toEqual({
+      key: "orderId",
+      value: "ORD-42",
+      redacted: false,
+    });
+    expect(byKey.sessionToken.value).toBe("[redacted]");
+    expect(byKey.Password.value).toBe("[redacted]");
+    expect(byKey.cookieJar.value).toBe("[redacted]");
+  });
+
+  it("stringifies and truncates long non-secret values", () => {
+    const entries = summarizeBrowserSessionReceipt(
+      session({
+        result: {
+          summary: "x".repeat(500),
+          count: 3,
+          detail: { pages: [1, 2, 3] },
+        },
+      }),
+    );
+    const byKey = Object.fromEntries(entries.map((e) => [e.key, e]));
+    expect(byKey.summary.value.length).toBe(201);
+    expect(byKey.summary.value.endsWith("…")).toBe(true);
+    expect(byKey.count.value).toBe("3");
+    expect(byKey.detail.value).toBe('{"pages":[1,2,3]}');
+  });
+});

--- a/packages/ui/src/components/browser/browser-session-policy.test.ts
+++ b/packages/ui/src/components/browser/browser-session-policy.test.ts
@@ -306,4 +306,36 @@ describe("summarizeBrowserSessionReceipt", () => {
     expect(byKey.count.value).toBe("3");
     expect(byKey.detail.value).toBe('{"pages":[1,2,3]}');
   });
+
+  it("redacts credential-looking keys nested under benign keys", () => {
+    const entries = summarizeBrowserSessionReceipt(
+      session({
+        result: {
+          formData: {
+            username: "shaw",
+            password: "hunter2",
+            extra: [{ apiKey: "sk-nested" }, "plain"],
+          },
+        },
+      }),
+    );
+    const byKey = Object.fromEntries(entries.map((e) => [e.key, e]));
+    expect(byKey.formData.value).not.toContain("hunter2");
+    expect(byKey.formData.value).not.toContain("sk-nested");
+    expect(byKey.formData.value).toContain("shaw");
+    expect(byKey.formData.value).toContain("plain");
+    expect(byKey.formData.value).toContain("[redacted]");
+  });
+
+  it("collapses over-deep nested payloads to the redaction marker", () => {
+    let deep: Record<string, unknown> = { password: "leaky" };
+    for (let i = 0; i < 20; i += 1) {
+      deep = { wrap: deep };
+    }
+    const entries = summarizeBrowserSessionReceipt(
+      session({ result: { audit: deep } }),
+    );
+    expect(entries[0]?.value).not.toContain("leaky");
+    expect(entries[0]?.value).toContain("[redacted]");
+  });
 });

--- a/packages/ui/src/components/browser/browser-session-policy.ts
+++ b/packages/ui/src/components/browser/browser-session-policy.ts
@@ -174,6 +174,30 @@ export interface BrowserSessionReceiptEntry {
 }
 
 const RECEIPT_VALUE_MAX_LENGTH = 200;
+const RECEIPT_REDACTION_MAX_DEPTH = 8;
+
+/**
+ * Recursively replaces values under credential-looking keys anywhere inside a
+ * nested result structure. Depth is bounded so a cyclic or absurdly deep
+ * payload collapses to the redaction marker instead of recursing forever —
+ * fail closed, never fail open.
+ */
+function redactNestedValue(value: unknown, depth: number): unknown {
+  if (depth >= RECEIPT_REDACTION_MAX_DEPTH) return "[redacted]";
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactNestedValue(entry, depth + 1));
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, nested]) =>
+        REDACTED_KEY_PATTERN.test(key)
+          ? [key, "[redacted]"]
+          : [key, redactNestedValue(nested, depth + 1)],
+      ),
+    );
+  }
+  return value;
+}
 
 function renderReceiptValue(value: unknown): string {
   if (typeof value === "string") {
@@ -188,7 +212,7 @@ function renderReceiptValue(value: unknown): string {
   ) {
     return String(value);
   }
-  const serialized = JSON.stringify(value) ?? "";
+  const serialized = JSON.stringify(redactNestedValue(value, 0)) ?? "";
   return serialized.length > RECEIPT_VALUE_MAX_LENGTH
     ? `${serialized.slice(0, RECEIPT_VALUE_MAX_LENGTH)}…`
     : serialized;

--- a/packages/ui/src/components/browser/browser-session-policy.ts
+++ b/packages/ui/src/components/browser/browser-session-policy.ts
@@ -1,0 +1,212 @@
+/**
+ * Pure policy math for the visible browser-session surface: resolves the
+ * effective domain mode for a session against the bridge settings, decides
+ * which scripted actions are intercepted pending user confirmation, computes
+ * session TTL/expiry, and projects a session result into a credential-safe
+ * receipt. Everything here is `(inputs) -> value` with an explicit `nowIso`
+ * so renders stay deterministic; the panel component owns the clock.
+ *
+ * Domain matching fails closed: an unresolvable domain never matches a grant,
+ * and a blocked origin wins over every allow mode.
+ */
+import type { BrowserBridgeSettings } from "../../api/browser-contracts";
+import type {
+  BrowserBridgeSession,
+  BrowserBridgeSessionAction,
+} from "../../api/client-browser-bridge";
+
+/** Default retention window after which a finished session is prune-eligible. */
+export const BROWSER_SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+
+export type BrowserDomainPolicyMode =
+  | "bridge_disabled"
+  | "control_disabled"
+  | "paused"
+  | "blocked"
+  | "all_sites"
+  | "granted"
+  | "current_site_only"
+  | "outside_grants"
+  | "unresolved";
+
+export interface BrowserDomainPolicyVerdict {
+  mode: BrowserDomainPolicyMode;
+  /** Whether the agent may drive this domain under the current settings. */
+  allowed: boolean;
+}
+
+/**
+ * Normalizes an origin entry (`https://example.com/*`, `*.example.com`,
+ * `example.com`) to a bare lowercase hostname, or null when unusable.
+ */
+export function normalizeOriginHost(origin: string): string | null {
+  const trimmed = origin.trim().toLowerCase();
+  if (!trimmed) return null;
+  const withoutScheme = trimmed.replace(/^[a-z][a-z0-9+.-]*:\/\//, "");
+  const hostPart = withoutScheme.split("/")[0] ?? "";
+  const withoutPort = hostPart.split(":")[0] ?? "";
+  const host = withoutPort.replace(/^\*\.?/, "").replace(/\.+$/, "");
+  return host.length > 0 ? host : null;
+}
+
+/** True when `domain` equals the origin host or is a subdomain of it. */
+export function domainMatchesOrigin(domain: string, origin: string): boolean {
+  const host = normalizeOriginHost(origin);
+  if (!host) return false;
+  const normalizedDomain = domain.trim().toLowerCase().replace(/\.+$/, "");
+  if (!normalizedDomain) return false;
+  return normalizedDomain === host || normalizedDomain.endsWith(`.${host}`);
+}
+
+/**
+ * Resolves the visible domain-mode verdict for one session domain against the
+ * bridge settings. Ordering is deliberate: disabled bridge, disabled control,
+ * and an active pause all pre-empt per-domain rules; a blocklist match then
+ * beats every allow mode.
+ */
+export function resolveBrowserDomainPolicy(
+  domain: string | null,
+  settings: BrowserBridgeSettings,
+  nowIso: string,
+): BrowserDomainPolicyVerdict {
+  if (!settings.enabled) {
+    return { mode: "bridge_disabled", allowed: false };
+  }
+  if (!settings.allowBrowserControl) {
+    return { mode: "control_disabled", allowed: false };
+  }
+  if (settings.pauseUntil) {
+    const pauseUntilMs = Date.parse(settings.pauseUntil);
+    const nowMs = Date.parse(nowIso);
+    if (
+      Number.isFinite(pauseUntilMs) &&
+      Number.isFinite(nowMs) &&
+      pauseUntilMs > nowMs
+    ) {
+      return { mode: "paused", allowed: false };
+    }
+  }
+  const normalizedDomain = domain?.trim().toLowerCase() ?? "";
+  if (!normalizedDomain) {
+    return { mode: "unresolved", allowed: false };
+  }
+  if (
+    settings.blockedOrigins.some((origin) =>
+      domainMatchesOrigin(normalizedDomain, origin),
+    )
+  ) {
+    return { mode: "blocked", allowed: false };
+  }
+  if (settings.siteAccessMode === "all_sites") {
+    return { mode: "all_sites", allowed: true };
+  }
+  if (settings.siteAccessMode === "current_site_only") {
+    return { mode: "current_site_only", allowed: true };
+  }
+  if (
+    settings.grantedOrigins.some((origin) =>
+      domainMatchesOrigin(normalizedDomain, origin),
+    )
+  ) {
+    return { mode: "granted", allowed: true };
+  }
+  return { mode: "outside_grants", allowed: false };
+}
+
+/** True when the session is parked waiting for the user to take over. */
+export function sessionRequiresTakeover(
+  session: BrowserBridgeSession,
+): boolean {
+  return session.status === "awaiting_confirmation";
+}
+
+const SUBMIT_ACTION_KINDS = new Set(["submit"]);
+
+/**
+ * Actions the panel must surface as intercepted: explicit
+ * `requiresConfirmation` steps, and — when the settings demand confirmation
+ * for account-affecting work — every account-affecting or submit step.
+ */
+export function interceptedSessionActions(
+  session: BrowserBridgeSession,
+  settings: BrowserBridgeSettings,
+): BrowserBridgeSessionAction[] {
+  return session.actions.filter((action) => {
+    if (action.requiresConfirmation) return true;
+    if (!settings.requireConfirmationForAccountAffecting) return false;
+    return action.accountAffecting || SUBMIT_ACTION_KINDS.has(action.kind);
+  });
+}
+
+const FINISHED_SESSION_STATUSES = new Set(["done", "cancelled", "failed"]);
+
+/** ISO timestamp at which the session leaves its retention window. */
+export function browserSessionExpiresAt(
+  session: BrowserBridgeSession,
+  ttlMs: number = BROWSER_SESSION_TTL_MS,
+): string | null {
+  const anchor = session.finishedAt ?? session.updatedAt;
+  const anchorMs = Date.parse(anchor);
+  if (!Number.isFinite(anchorMs)) return null;
+  return new Date(anchorMs + ttlMs).toISOString();
+}
+
+/** True when a finished session has aged past its TTL and may be pruned. */
+export function isBrowserSessionExpired(
+  session: BrowserBridgeSession,
+  nowIso: string,
+  ttlMs: number = BROWSER_SESSION_TTL_MS,
+): boolean {
+  if (!FINISHED_SESSION_STATUSES.has(session.status)) return false;
+  const expiresAt = browserSessionExpiresAt(session, ttlMs);
+  if (!expiresAt) return false;
+  const nowMs = Date.parse(nowIso);
+  return Number.isFinite(nowMs) && nowMs >= Date.parse(expiresAt);
+}
+
+const REDACTED_KEY_PATTERN =
+  /token|secret|password|passwd|cookie|authorization|credential|api[-_]?key|session[-_]?id/i;
+
+export interface BrowserSessionReceiptEntry {
+  key: string;
+  value: string;
+  redacted: boolean;
+}
+
+const RECEIPT_VALUE_MAX_LENGTH = 200;
+
+function renderReceiptValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value.length > RECEIPT_VALUE_MAX_LENGTH
+      ? `${value.slice(0, RECEIPT_VALUE_MAX_LENGTH)}…`
+      : value;
+  }
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value === null
+  ) {
+    return String(value);
+  }
+  const serialized = JSON.stringify(value) ?? "";
+  return serialized.length > RECEIPT_VALUE_MAX_LENGTH
+    ? `${serialized.slice(0, RECEIPT_VALUE_MAX_LENGTH)}…`
+    : serialized;
+}
+
+/**
+ * Projects a session's result into displayable receipt entries. Keys that
+ * look credential-bearing are redacted unconditionally — the receipt surface
+ * must never leak tokens, cookies, or passwords even when an upstream service
+ * put them in the result payload.
+ */
+export function summarizeBrowserSessionReceipt(
+  session: BrowserBridgeSession,
+): BrowserSessionReceiptEntry[] {
+  return Object.entries(session.result).map(([key, value]) => {
+    if (REDACTED_KEY_PATTERN.test(key)) {
+      return { key, value: "[redacted]", redacted: true };
+    }
+    return { key, value: renderReceiptValue(value), redacted: false };
+  });
+}

--- a/packages/ui/src/components/browser/index.ts
+++ b/packages/ui/src/components/browser/index.ts
@@ -1,0 +1,7 @@
+/** Barrel for the visible policy-controlled browser session surface. */
+export {
+  type BrowserSessionPolicyApi,
+  BrowserSessionPolicyPanel,
+  type BrowserSessionPolicyPanelProps,
+} from "./BrowserSessionPolicyPanel";
+export * from "./browser-session-policy";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -171,6 +171,7 @@ export * from "./apps/FullscreenView.helpers";
 export * from "./apps/GameViewOverlay";
 export * from "./apps/overlay-app-api";
 export * from "./apps/overlay-app-registry";
+export * from "./browser";
 export * from "./character/CharacterEditor";
 export * from "./character/CharacterRoster";
 export * from "./character/CharacterRoster.helpers";

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -1,6 +1,8 @@
 /**
  * The Browser workspace view (`/browser`): a tabbed embedded-browser surface
- * whose tabs fold into a switcher sheet, with companion-bridge status.
+ * whose tabs fold into a switcher sheet, with companion-bridge status and the
+ * policy-controlled agent browser session panel (takeover, domain modes,
+ * receipts) when the bridge plugin is available.
  *
  * The builtin registry declares this view `header: "fullscreen"`, so the shell
  * mounts it edge-to-edge and the view owns its chrome: a floating glass
@@ -45,6 +47,7 @@ import {
   BROWSER_TAB_PRELOAD_SCRIPT,
   setBrowserTabsRendererImpl,
 } from "../../utils/browser-tabs-renderer-registry";
+import { BrowserSessionPolicyPanel } from "../browser/BrowserSessionPolicyPanel";
 import { PagePanel } from "../composites/page-panel";
 import { ViewBackButton } from "../shared/ViewHeader";
 import { Button } from "../ui/button";
@@ -2943,6 +2946,18 @@ export function BrowserWorkspaceView(): React.JSX.Element {
                       })}
                     </span>
                   </Button>
+                </div>
+              ) : null}
+              {workspace.mode === "web" &&
+              browserBridgeSupported &&
+              !browserBridgeUnsupportedInNativeLocalMode ? (
+                <div className="mt-4 flex w-full max-w-xl flex-col gap-2 px-6 pb-4">
+                  <div className="text-[11px] font-medium uppercase tracking-wide text-muted">
+                    {t("browserworkspace.AgentBrowserSessions", {
+                      defaultValue: "Agent browser sessions",
+                    })}
+                  </div>
+                  <BrowserSessionPolicyPanel api={client} />
                 </div>
               ) : null}
             </div>


### PR DESCRIPTION
Fixes #19905

## What

Builds the visible, policy-controlled browser session UI on top of what is on `develop` today (the `/api/browser-bridge` sessions/settings/confirm routes and the plugin-browser policy helpers):

- **`BrowserSessionPolicyPanel`** (`packages/ui/src/components/browser/BrowserSessionPolicyPanel.tsx`) — lists the agent's bridge sessions with:
  - the effective **domain-mode verdict** per session domain (granted / blocked / all-sites / current-site-only / outside grants / paused / control off / bridge disabled / unresolved), rendered as an accent (orange) or danger badge;
  - **user takeover**: approve/decline controls for `awaiting_confirmation` sessions via `POST /api/browser-bridge/sessions/:id/confirm`;
  - **domain modes**: per-domain grant / block / unblock controls writing `grantedOrigins`/`blockedOrigins` via `POST /api/browser-bridge/settings`;
  - **submit interception**: sessions surface their held steps (explicit `requiresConfirmation`, and account-affecting/submit steps when `requireConfirmationForAccountAffecting` is on);
  - **session TTL**: finished sessions show their retention deadline and are hidden once expired (24h default);
  - **receipts**: finished sessions render their result as a receipt with unconditional redaction of credential-looking keys (token/secret/password/cookie/authorization/…) — no cookie export, no rehosting, ever.
  - Loading, designed-empty, and error are three distinct states with a retry affordance; the clock lives in an effect (never read in render) so renders stay deterministic.
- **`browser-session-policy.ts`** — pure policy math: fail-closed domain-mode resolution ordering (disabled → paused → blocklist → allow modes), origin normalization (`https://x/*`, `*.x`, ports/paths) and subdomain matching, interception selection, TTL expiry, receipt redaction/truncation.
- **`client-browser-bridge.ts`** — typed `ElizaClient` extension over the existing bridge routes (`listBrowserBridgeSessions`, `getBrowserBridgeSettings`, `updateBrowserBridgeSettings`, `confirmBrowserBridgeSession`), registered in `api/client.ts`.
- Storybook stories for empty / load-error / awaiting-takeover / blocked+outside-grants / finished-with-receipt states (story-gate coverage).

## Tests

- `browser-session-policy.test.ts` — 16 deterministic unit tests: disabled/paused pre-emption, blocklist-beats-all_sites, granted vs outside grants, subdomain vs suffix-fragment matching, unresolved-domain fail-closed, interception on/off, TTL anchor (finishedAt vs updatedAt), bad-timestamp tolerance, redaction (including nested objects) and truncation.
- `BrowserSessionPolicyPanel.test.tsx` — 8 jsdom behaviour tests driven through a protocol-faithful in-memory transport (confirm flips awaiting→queued/cancelled; settings writes merge like the route): loading→empty, error→retry→ready, per-domain verdict rendering, approve and decline takeover, grant then block a domain, intercepted-step + redacted-receipt rendering (secret value never in DOM), action-error banner on a failed write.

All 24 pass: `bunx vitest run src/components/browser` in `packages/ui`. Scoped `biome check` on every touched file is clean. `bun run --cwd packages/ui typecheck` reports zero errors in the touched files; the run as a whole is red in this worktree with 846 pre-existing environment errors (missing `lucide-react`/`jsdom` type packages and plugin-sql `pg` types in the shared install) unrelated to this change.

## Human-only remainder

- Live desktop/mobile visual audit (`bun run --cwd packages/app audit:app`) and real companion-extension evidence (paired Chrome/Safari companion driving a real session) need an interactive, fully-installed environment; this worktree's shared install is missing type/runtime packages and cannot boot the app shell.
- Remote live-view streaming of the session page is intentionally not added here: the existing workspace live-view surface (`BrowserWorkspaceView`) owns pixels; this panel is the policy/receipt/takeover surface and links state, never rehosts pages or exports cookies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)