### PR TITLE
feat(core): capability retrieval and deterministic provider selection with evaluation corpus

### DIFF
--- a/packages/core/src/capability-selection/account-selection.ts
+++ b/packages/core/src/capability-selection/account-selection.ts
@@ -1,0 +1,383 @@
+/**
+ * Deterministic connected-account selection for a capability intent. The LLM
+ * proposes a provider-neutral capability; this module — never the model —
+ * decides which connected account (and therefore adapter) is eligible, using
+ * policy, health, location, and cost in a fixed total order. A pinned
+ * `requestedAccountId` is honored exactly or fails loudly: an ineligible
+ * pinned account is never silently substituted with a different account
+ * (wrong-account prevention). Failures reuse the typed policy-denial and
+ * unavailable codes from `types/provider-integrations`.
+ */
+import { ElizaError } from "../errors";
+import {
+	CAPABILITY_RISK_LEVELS,
+	type CapabilityPolicyDenialCode,
+	type CapabilityRiskLevel,
+	type CapabilityUnavailableCode,
+	type ConnectedAccount,
+	type ConnectedAccountMode,
+} from "../types/provider-integrations";
+
+const RISK_RANK: Readonly<Record<CapabilityRiskLevel, number>> = Object.freeze({
+	R0: 0,
+	R1: 1,
+	R2: 2,
+	R3: 3,
+});
+
+/** Provider-neutral intent evaluated before dispatch binding. */
+export interface AccountSelectionIntent {
+	capabilityId: string;
+	riskLevel: CapabilityRiskLevel;
+	/** Exact pinned account, or null to let deterministic ranking choose. */
+	requestedAccountId: string | null;
+}
+
+/** Deterministic policy inputs; absent constraints are explicitly null. */
+export interface AccountSelectionPolicy {
+	allowedModes: readonly ConnectedAccountMode[] | null;
+	allowedProviderIds: readonly string[] | null;
+	blockedAccountIds: readonly string[];
+	maxRiskLevel: CapabilityRiskLevel;
+	preferredRegion: string | null;
+	maxUnitCostMicros: number | null;
+}
+
+/** Operational signal for one account; every candidate account must have one. */
+export interface AccountSelectionSignal {
+	accountId: string;
+	healthy: boolean;
+	region: string | null;
+	unitCostMicros: number;
+}
+
+export interface AccountSelectionRationale {
+	regionMatched: boolean;
+	unitCostMicros: number;
+	consideredAccountIds: readonly string[];
+}
+
+export type AccountSelectionResult =
+	| {
+			outcome: "selected";
+			account: ConnectedAccount;
+			rationale: AccountSelectionRationale;
+	  }
+	| {
+			outcome: "denied";
+			reasonCode: CapabilityPolicyDenialCode;
+			accountId: string | null;
+	  }
+	| {
+			outcome: "unavailable";
+			code: CapabilityUnavailableCode;
+			retryable: boolean;
+	  };
+
+type Ineligibility =
+	| { kind: "denied"; reasonCode: CapabilityPolicyDenialCode }
+	| {
+			kind: "unavailable";
+			code: CapabilityUnavailableCode;
+			retryable: boolean;
+	  };
+
+function invalidSelectionInput(
+	message: string,
+	context: Record<string, unknown>,
+): never {
+	throw new ElizaError(message, {
+		code: "INVALID_ACCOUNT_SELECTION_INPUT",
+		context,
+		severity: "fatal",
+	});
+}
+
+const ACCOUNT_STATUS_UNAVAILABILITY: Readonly<
+	Record<string, { code: CapabilityUnavailableCode; retryable: boolean }>
+> = Object.freeze({
+	disabled: { code: "account_disabled", retryable: false },
+	error: { code: "account_error", retryable: true },
+	reauth_required: { code: "needs_scope", retryable: false },
+	revoked: { code: "account_revoked", retryable: false },
+	unavailable: { code: "provider_unavailable", retryable: true },
+});
+
+const UNAVAILABLE_RETRYABLE: Readonly<
+	Record<CapabilityUnavailableCode, boolean>
+> = Object.freeze({
+	account_disabled: false,
+	account_error: true,
+	account_revoked: false,
+	cost_blocked: false,
+	needs_admin: false,
+	needs_review: false,
+	needs_scope: false,
+	not_configured: false,
+	provider_unavailable: true,
+	unsupported: false,
+});
+
+/**
+ * Failure precedence when no account is eligible: report the most actionable
+ * cause. A policy denial anywhere is surfaced over mere unavailability so a
+ * blocked request is a deterministic denial, never a vague "not configured".
+ */
+const UNAVAILABLE_PRECEDENCE: readonly CapabilityUnavailableCode[] =
+	Object.freeze([
+		"needs_scope",
+		"needs_admin",
+		"needs_review",
+		"account_revoked",
+		"account_disabled",
+		"cost_blocked",
+		"account_error",
+		"provider_unavailable",
+		"unsupported",
+		"not_configured",
+	]);
+
+function evaluateAccount(
+	account: ConnectedAccount,
+	intent: AccountSelectionIntent,
+	policy: AccountSelectionPolicy,
+	signal: AccountSelectionSignal,
+): Ineligibility | null {
+	if (policy.blockedAccountIds.includes(account.accountId)) {
+		return { kind: "denied", reasonCode: "account_policy_denied" };
+	}
+	if (
+		policy.allowedModes !== null &&
+		!policy.allowedModes.includes(account.mode)
+	) {
+		return { kind: "denied", reasonCode: "organization_policy_denied" };
+	}
+	if (
+		policy.allowedProviderIds !== null &&
+		!policy.allowedProviderIds.includes(account.providerId)
+	) {
+		return { kind: "denied", reasonCode: "organization_policy_denied" };
+	}
+	if (account.status !== "connected") {
+		const mapped = ACCOUNT_STATUS_UNAVAILABILITY[account.status];
+		if (mapped === undefined) {
+			invalidSelectionInput("Connected account has an unknown status.", {
+				accountId: account.accountId,
+				status: account.status,
+			});
+		}
+		return { kind: "unavailable", ...mapped };
+	}
+	const capability = account.capabilities.find(
+		(entry) => entry.capabilityId === intent.capabilityId,
+	);
+	if (capability === undefined) {
+		return { kind: "unavailable", code: "unsupported", retryable: false };
+	}
+	if (capability.status !== "available") {
+		return {
+			kind: "unavailable",
+			code: capability.status,
+			retryable: UNAVAILABLE_RETRYABLE[capability.status],
+		};
+	}
+	if (RISK_RANK[intent.riskLevel] > RISK_RANK[policy.maxRiskLevel]) {
+		return { kind: "denied", reasonCode: "risk_policy_denied" };
+	}
+	if (RISK_RANK[intent.riskLevel] > RISK_RANK[capability.riskLevel]) {
+		return { kind: "unavailable", code: "needs_scope", retryable: false };
+	}
+	if (
+		policy.maxUnitCostMicros !== null &&
+		signal.unitCostMicros > policy.maxUnitCostMicros
+	) {
+		return { kind: "unavailable", code: "cost_blocked", retryable: false };
+	}
+	if (!signal.healthy) {
+		return {
+			kind: "unavailable",
+			code: "provider_unavailable",
+			retryable: true,
+		};
+	}
+	return null;
+}
+
+function compareEligible(
+	a: { account: ConnectedAccount; signal: AccountSelectionSignal },
+	b: { account: ConnectedAccount; signal: AccountSelectionSignal },
+	preferredRegion: string | null,
+): number {
+	if (preferredRegion !== null) {
+		const aMatch = a.signal.region === preferredRegion ? 1 : 0;
+		const bMatch = b.signal.region === preferredRegion ? 1 : 0;
+		if (aMatch !== bMatch) return bMatch - aMatch;
+	}
+	if (a.signal.unitCostMicros !== b.signal.unitCostMicros) {
+		return a.signal.unitCostMicros - b.signal.unitCostMicros;
+	}
+	const aUsed =
+		a.account.lastUsedAt === null ? 0 : Date.parse(a.account.lastUsedAt);
+	const bUsed =
+		b.account.lastUsedAt === null ? 0 : Date.parse(b.account.lastUsedAt);
+	if (aUsed !== bUsed) return bUsed - aUsed;
+	return a.account.accountId.localeCompare(b.account.accountId);
+}
+
+/**
+ * Selects the single eligible account for the intent, or the typed reason
+ * there is none. Deterministic: identical inputs always yield the identical
+ * result, ranked by region match, then unit cost ascending, then most recent
+ * use, then `accountId` ascending.
+ */
+export function selectConnectedAccount(
+	intent: AccountSelectionIntent,
+	accounts: readonly ConnectedAccount[],
+	policy: AccountSelectionPolicy,
+	signals: readonly AccountSelectionSignal[],
+): AccountSelectionResult {
+	if (intent.capabilityId.trim().length === 0) {
+		invalidSelectionInput(
+			"Account selection intent capabilityId must be non-empty.",
+			{},
+		);
+	}
+	if (!CAPABILITY_RISK_LEVELS.includes(intent.riskLevel)) {
+		invalidSelectionInput("Account selection intent riskLevel is invalid.", {
+			riskLevel: intent.riskLevel,
+		});
+	}
+	const accountIds = new Set(accounts.map((account) => account.accountId));
+	if (accountIds.size !== accounts.length) {
+		invalidSelectionInput(
+			"Connected accounts contain a duplicate accountId.",
+			{},
+		);
+	}
+	const signalsById = new Map(
+		signals.map((signal) => [signal.accountId, signal]),
+	);
+	if (signalsById.size !== signals.length) {
+		invalidSelectionInput(
+			"Account selection signals contain a duplicate accountId.",
+			{},
+		);
+	}
+	for (const account of accounts) {
+		if (!signalsById.has(account.accountId)) {
+			invalidSelectionInput(
+				"Every connected account requires a selection signal.",
+				{
+					accountId: account.accountId,
+				},
+			);
+		}
+	}
+
+	if (intent.requestedAccountId !== null) {
+		const account = accounts.find(
+			(candidate) => candidate.accountId === intent.requestedAccountId,
+		);
+		if (account === undefined) {
+			return {
+				outcome: "unavailable",
+				code: "not_configured",
+				retryable: false,
+			};
+		}
+		const signal = signalsById.get(account.accountId) as AccountSelectionSignal;
+		const ineligibility = evaluateAccount(account, intent, policy, signal);
+		if (ineligibility !== null) {
+			return ineligibility.kind === "denied"
+				? {
+						outcome: "denied",
+						reasonCode: ineligibility.reasonCode,
+						accountId: account.accountId,
+					}
+				: {
+						outcome: "unavailable",
+						code: ineligibility.code,
+						retryable: ineligibility.retryable,
+					};
+		}
+		return {
+			outcome: "selected",
+			account,
+			rationale: {
+				regionMatched:
+					policy.preferredRegion !== null &&
+					signal.region === policy.preferredRegion,
+				unitCostMicros: signal.unitCostMicros,
+				consideredAccountIds: Object.freeze([account.accountId]),
+			},
+		};
+	}
+
+	const eligible: Array<{
+		account: ConnectedAccount;
+		signal: AccountSelectionSignal;
+	}> = [];
+	const ineligibilities: Ineligibility[] = [];
+	for (const account of accounts) {
+		const signal = signalsById.get(account.accountId) as AccountSelectionSignal;
+		const ineligibility = evaluateAccount(account, intent, policy, signal);
+		if (ineligibility === null) {
+			eligible.push({ account, signal });
+		} else {
+			ineligibilities.push(ineligibility);
+		}
+	}
+
+	if (eligible.length === 0) {
+		const denial = ineligibilities.find(
+			(entry): entry is Extract<Ineligibility, { kind: "denied" }> =>
+				entry.kind === "denied",
+		);
+		if (denial !== undefined) {
+			return {
+				outcome: "denied",
+				reasonCode: denial.reasonCode,
+				accountId: null,
+			};
+		}
+		const unavailable = ineligibilities.filter(
+			(entry): entry is Extract<Ineligibility, { kind: "unavailable" }> =>
+				entry.kind === "unavailable",
+		);
+		if (unavailable.length === 0) {
+			return {
+				outcome: "unavailable",
+				code: "not_configured",
+				retryable: false,
+			};
+		}
+		const best = [...unavailable].sort(
+			(a, b) =>
+				UNAVAILABLE_PRECEDENCE.indexOf(a.code) -
+				UNAVAILABLE_PRECEDENCE.indexOf(b.code),
+		)[0];
+		return {
+			outcome: "unavailable",
+			code: best.code,
+			retryable: best.retryable,
+		};
+	}
+
+	const ranked = [...eligible].sort((a, b) =>
+		compareEligible(a, b, policy.preferredRegion),
+	);
+	const winner = ranked[0];
+	return {
+		outcome: "selected",
+		account: winner.account,
+		rationale: {
+			regionMatched:
+				policy.preferredRegion !== null &&
+				winner.signal.region === policy.preferredRegion,
+			unitCostMicros: winner.signal.unitCostMicros,
+			consideredAccountIds: Object.freeze(
+				ranked.map((candidate) => candidate.account.accountId),
+			),
+		},
+	};
+}

--- a/packages/core/src/capability-selection/account-selection.ts
+++ b/packages/core/src/capability-selection/account-selection.ts
@@ -93,6 +93,80 @@ function invalidSelectionInput(
 	});
 }
 
+function isUnitCostMicros(value: number): boolean {
+	return Number.isSafeInteger(value) && value >= 0;
+}
+
+/**
+ * Fail-closed validation of policy, account, and signal facts. Malformed
+ * inputs (unknown risk level, non-finite or negative cost, unparseable
+ * `lastUsedAt`, duplicate capability grants, signals for unknown accounts)
+ * must throw rather than silently disable a policy check or perturb the
+ * documented total order.
+ */
+function validateSelectionFacts(
+	accounts: readonly ConnectedAccount[],
+	policy: AccountSelectionPolicy,
+	signals: readonly AccountSelectionSignal[],
+	signalsById: ReadonlyMap<string, AccountSelectionSignal>,
+): void {
+	if (!CAPABILITY_RISK_LEVELS.includes(policy.maxRiskLevel)) {
+		invalidSelectionInput("Account selection policy maxRiskLevel is invalid.", {
+			maxRiskLevel: policy.maxRiskLevel,
+		});
+	}
+	if (
+		policy.maxUnitCostMicros !== null &&
+		!isUnitCostMicros(policy.maxUnitCostMicros)
+	) {
+		invalidSelectionInput(
+			"Account selection policy maxUnitCostMicros must be a nonnegative safe integer.",
+			{ maxUnitCostMicros: policy.maxUnitCostMicros },
+		);
+	}
+	const accountIds = new Set(accounts.map((account) => account.accountId));
+	for (const signal of signals) {
+		if (!accountIds.has(signal.accountId)) {
+			invalidSelectionInput(
+				"Account selection signal references an unknown accountId.",
+				{ accountId: signal.accountId },
+			);
+		}
+		if (!isUnitCostMicros(signal.unitCostMicros)) {
+			invalidSelectionInput(
+				"Account selection signal unitCostMicros must be a nonnegative safe integer.",
+				{ accountId: signal.accountId, unitCostMicros: signal.unitCostMicros },
+			);
+		}
+	}
+	for (const account of accounts) {
+		if (!signalsById.has(account.accountId)) {
+			invalidSelectionInput(
+				"Every connected account requires a selection signal.",
+				{ accountId: account.accountId },
+			);
+		}
+		if (
+			account.lastUsedAt !== null &&
+			Number.isNaN(Date.parse(account.lastUsedAt))
+		) {
+			invalidSelectionInput(
+				"Connected account lastUsedAt must be a parseable timestamp or null.",
+				{ accountId: account.accountId, lastUsedAt: account.lastUsedAt },
+			);
+		}
+		const capabilityIds = new Set(
+			account.capabilities.map((entry) => entry.capabilityId),
+		);
+		if (capabilityIds.size !== account.capabilities.length) {
+			invalidSelectionInput(
+				"Connected account has a duplicate capability grant.",
+				{ accountId: account.accountId },
+			);
+		}
+	}
+}
+
 const ACCOUNT_STATUS_UNAVAILABILITY: Readonly<
 	Record<string, { code: CapabilityUnavailableCode; retryable: boolean }>
 > = Object.freeze({
@@ -221,7 +295,9 @@ function compareEligible(
 	const bUsed =
 		b.account.lastUsedAt === null ? 0 : Date.parse(b.account.lastUsedAt);
 	if (aUsed !== bUsed) return bUsed - aUsed;
-	return a.account.accountId.localeCompare(b.account.accountId);
+	// Code-unit comparison keeps the accountId tie-breaker locale-independent.
+	if (a.account.accountId === b.account.accountId) return 0;
+	return a.account.accountId < b.account.accountId ? -1 : 1;
 }
 
 /**
@@ -263,16 +339,7 @@ export function selectConnectedAccount(
 			{},
 		);
 	}
-	for (const account of accounts) {
-		if (!signalsById.has(account.accountId)) {
-			invalidSelectionInput(
-				"Every connected account requires a selection signal.",
-				{
-					accountId: account.accountId,
-				},
-			);
-		}
-	}
+	validateSelectionFacts(accounts, policy, signals, signalsById);
 
 	if (intent.requestedAccountId !== null) {
 		const account = accounts.find(

--- a/packages/core/src/capability-selection/capability-selection.test.ts
+++ b/packages/core/src/capability-selection/capability-selection.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Exercises the real capability-selection surface: deterministic retrieval
+ * (ranking, ambiguity flagging, designed-empty, flood metrics), account
+ * selection (policy denial, unavailability mapping, wrong-account prevention,
+ * ranking order), invalid-input rejection, and the evaluation harness run
+ * against the built-in corpus. Deterministic and mock-free — the corpus data
+ * are real contract values, not stand-ins for the system under test.
+ */
+import { describe, expect, it } from "vitest";
+import { ElizaError } from "../errors";
+import { PROVIDER_INTEGRATION_CONTRACT_VERSION } from "../types/provider-integrations";
+import {
+	type AccountSelectionPolicy,
+	selectConnectedAccount,
+} from "./account-selection";
+import { runCapabilitySelectionEvaluation } from "./evaluation";
+import {
+	CAPABILITY_EVALUATION_CATALOG,
+	CAPABILITY_EVALUATION_CORPUS,
+} from "./evaluation-corpus";
+import { retrieveCapabilities } from "./retrieval";
+
+const OPEN_POLICY: AccountSelectionPolicy = {
+	allowedModes: null,
+	allowedProviderIds: null,
+	blockedAccountIds: [],
+	maxRiskLevel: "R2",
+	preferredRegion: null,
+	maxUnitCostMicros: null,
+};
+
+describe("capability retrieval", () => {
+	it("ranks the intended capability first and bounds the retrieved token budget", () => {
+		const result = retrieveCapabilities({
+			catalog: CAPABILITY_EVALUATION_CATALOG,
+			intentText: "send an email to sam about the offsite",
+		});
+		expect(result.results[0]?.entry.capabilityId).toBe("email.message.send");
+		expect(result.metrics.retrievedCount).toBeLessThanOrEqual(5);
+		expect(result.metrics.retrievedPromptTokenEstimate).toBeLessThan(
+			result.metrics.catalogPromptTokenEstimate,
+		);
+		expect(result.metrics.floodRatio).toBeLessThan(0.6);
+	});
+
+	it("flags cross-domain near-ties as ambiguous with both contenders", () => {
+		const result = retrieveCapabilities({
+			catalog: CAPABILITY_EVALUATION_CATALOG,
+			intentText: "send a message",
+		});
+		expect(result.ambiguity.ambiguous).toBe(true);
+		expect(result.ambiguity.contenders).toContain("messaging.chat.send");
+		expect(result.ambiguity.contenders).toContain("email.message.send");
+	});
+
+	it("returns designed-empty for a non-matching intent instead of the full catalog", () => {
+		const result = retrieveCapabilities({
+			catalog: CAPABILITY_EVALUATION_CATALOG,
+			intentText: "zzqx flibberwock",
+		});
+		expect(result.results).toHaveLength(0);
+		expect(result.ambiguity.ambiguous).toBe(false);
+		expect(result.metrics.retrievedPromptTokenEstimate).toBe(0);
+	});
+
+	it("is idempotent for identical inputs", () => {
+		const run = () =>
+			retrieveCapabilities({
+				catalog: CAPABILITY_EVALUATION_CATALOG,
+				intentText: "search my files and documents",
+			});
+		expect(run()).toEqual(run());
+	});
+
+	it("rejects duplicate capability ids, bad token estimates, and bad limits", () => {
+		const entry = CAPABILITY_EVALUATION_CATALOG[0];
+		expect(() =>
+			retrieveCapabilities({ catalog: [entry, entry], intentText: "email" }),
+		).toThrowError(ElizaError);
+		expect(() =>
+			retrieveCapabilities({
+				catalog: [{ ...entry, promptTokenEstimate: 0 }],
+				intentText: "email",
+			}),
+		).toThrowError(ElizaError);
+		expect(() =>
+			retrieveCapabilities({
+				catalog: CAPABILITY_EVALUATION_CATALOG,
+				intentText: "email",
+				limit: 0,
+			}),
+		).toThrowError(ElizaError);
+	});
+});
+
+describe("deterministic account selection", () => {
+	const capability = {
+		capabilityId: "email.message.send",
+		riskLevel: "R2",
+		status: "available",
+	} as const;
+	const baseAccount = {
+		contractVersion: PROVIDER_INTEGRATION_CONTRACT_VERSION,
+		providerId: "google-mail",
+		mode: "cloud",
+		status: "connected",
+		displayName: null,
+		capabilities: [capability],
+		lastUsedAt: null,
+	} as const;
+	const intent = {
+		capabilityId: "email.message.send",
+		riskLevel: "R2",
+		requestedAccountId: null,
+	} as const;
+
+	it("never substitutes a different account for an ineligible pinned account", () => {
+		const result = selectConnectedAccount(
+			{ ...intent, requestedAccountId: "acct-b" },
+			[
+				{ ...baseAccount, accountId: "acct-a" },
+				{ ...baseAccount, accountId: "acct-b", status: "revoked" },
+			],
+			OPEN_POLICY,
+			[
+				{ accountId: "acct-a", healthy: true, region: "us", unitCostMicros: 1 },
+				{ accountId: "acct-b", healthy: true, region: "us", unitCostMicros: 1 },
+			],
+		);
+		expect(result).toEqual({
+			outcome: "unavailable",
+			code: "account_revoked",
+			retryable: false,
+		});
+	});
+
+	it("prefers a policy denial over unavailability when nothing is eligible", () => {
+		const result = selectConnectedAccount(
+			intent,
+			[
+				{ ...baseAccount, accountId: "acct-a", status: "unavailable" },
+				{ ...baseAccount, accountId: "acct-b" },
+			],
+			{ ...OPEN_POLICY, blockedAccountIds: ["acct-b"] },
+			[
+				{ accountId: "acct-a", healthy: true, region: "us", unitCostMicros: 1 },
+				{ accountId: "acct-b", healthy: true, region: "us", unitCostMicros: 1 },
+			],
+		);
+		expect(result).toEqual({
+			outcome: "denied",
+			reasonCode: "account_policy_denied",
+			accountId: null,
+		});
+	});
+
+	it("orders eligible accounts by region, cost, recency, then accountId", () => {
+		const result = selectConnectedAccount(
+			intent,
+			[
+				{ ...baseAccount, accountId: "acct-c" },
+				{ ...baseAccount, accountId: "acct-a" },
+				{ ...baseAccount, accountId: "acct-b" },
+			],
+			{ ...OPEN_POLICY, preferredRegion: "eu" },
+			[
+				{ accountId: "acct-a", healthy: true, region: "us", unitCostMicros: 1 },
+				{ accountId: "acct-b", healthy: true, region: "eu", unitCostMicros: 9 },
+				{ accountId: "acct-c", healthy: true, region: "eu", unitCostMicros: 9 },
+			],
+		);
+		expect(result.outcome).toBe("selected");
+		if (result.outcome === "selected") {
+			expect(result.account.accountId).toBe("acct-b");
+			expect(result.rationale.consideredAccountIds).toEqual([
+				"acct-b",
+				"acct-c",
+				"acct-a",
+			]);
+			expect(result.rationale.regionMatched).toBe(true);
+		}
+	});
+
+	it("maps a stricter capability grant than the intent risk to needs_scope", () => {
+		const result = selectConnectedAccount(
+			{ ...intent, riskLevel: "R2" },
+			[
+				{
+					...baseAccount,
+					accountId: "acct-a",
+					capabilities: [{ ...capability, riskLevel: "R1" }],
+				},
+			],
+			{ ...OPEN_POLICY, maxRiskLevel: "R3" },
+			[{ accountId: "acct-a", healthy: true, region: "us", unitCostMicros: 1 }],
+		);
+		expect(result).toEqual({
+			outcome: "unavailable",
+			code: "needs_scope",
+			retryable: false,
+		});
+	});
+
+	it("rejects missing signals and duplicate accounts as invalid input", () => {
+		expect(() =>
+			selectConnectedAccount(
+				intent,
+				[{ ...baseAccount, accountId: "acct-a" }],
+				OPEN_POLICY,
+				[],
+			),
+		).toThrowError(ElizaError);
+		expect(() =>
+			selectConnectedAccount(
+				intent,
+				[
+					{ ...baseAccount, accountId: "acct-a" },
+					{ ...baseAccount, accountId: "acct-a" },
+				],
+				OPEN_POLICY,
+				[
+					{
+						accountId: "acct-a",
+						healthy: true,
+						region: "us",
+						unitCostMicros: 1,
+					},
+				],
+			),
+		).toThrowError(ElizaError);
+	});
+});
+
+describe("evaluation harness", () => {
+	it("passes every built-in corpus case and reports flood metrics", () => {
+		const report = runCapabilitySelectionEvaluation(
+			CAPABILITY_EVALUATION_CATALOG,
+			CAPABILITY_EVALUATION_CORPUS,
+		);
+		const failed = report.cases.filter((entry) => !entry.passed);
+		expect(
+			failed.map((entry) => `${entry.name}: ${entry.failures.join("; ")}`),
+		).toEqual([]);
+		expect(report.summary.total).toBe(CAPABILITY_EVALUATION_CORPUS.length);
+		expect(report.summary.passed).toBe(report.summary.total);
+		expect(report.summary.meanFloodRatio).toBeGreaterThan(0);
+		expect(report.summary.meanFloodRatio).toBeLessThan(0.6);
+		expect(report.summary.maxLatencyMs).toBeGreaterThanOrEqual(0);
+	});
+
+	it("produces identical outcomes across repeated runs", () => {
+		const strip = (
+			report: ReturnType<typeof runCapabilitySelectionEvaluation>,
+		) => report.cases.map((entry) => ({ ...entry, latencyMs: 0 }));
+		expect(
+			strip(
+				runCapabilitySelectionEvaluation(
+					CAPABILITY_EVALUATION_CATALOG,
+					CAPABILITY_EVALUATION_CORPUS,
+				),
+			),
+		).toEqual(
+			strip(
+				runCapabilitySelectionEvaluation(
+					CAPABILITY_EVALUATION_CATALOG,
+					CAPABILITY_EVALUATION_CORPUS,
+				),
+			),
+		);
+	});
+
+	it("rejects an empty corpus and duplicate case names", () => {
+		expect(() =>
+			runCapabilitySelectionEvaluation(CAPABILITY_EVALUATION_CATALOG, []),
+		).toThrowError(ElizaError);
+		const dup = CAPABILITY_EVALUATION_CORPUS[0];
+		expect(() =>
+			runCapabilitySelectionEvaluation(CAPABILITY_EVALUATION_CATALOG, [
+				dup,
+				dup,
+			]),
+		).toThrowError(ElizaError);
+	});
+
+	it("reports a failing case with actionable failure text", () => {
+		const report = runCapabilitySelectionEvaluation(
+			CAPABILITY_EVALUATION_CATALOG,
+			[
+				{
+					name: "expected wrong top capability",
+					intentText: "send an email to sam",
+					retrieval: {
+						topCapabilityId: "calendar.event.create",
+						mustInclude: [],
+						expectAmbiguous: false,
+					},
+					selection: null,
+				},
+			],
+		);
+		expect(report.summary.failed).toBe(1);
+		expect(report.cases[0].failures[0]).toContain("calendar.event.create");
+	});
+});

--- a/packages/core/src/capability-selection/capability-selection.test.ts
+++ b/packages/core/src/capability-selection/capability-selection.test.ts
@@ -91,6 +91,21 @@ describe("capability retrieval", () => {
 			}),
 		).toThrowError(ElizaError);
 	});
+
+	it("rejects a catalog whose aggregate token estimate overflows the safe range", () => {
+		const base = CAPABILITY_EVALUATION_CATALOG[0];
+		const huge = (suffix: string) => ({
+			...base,
+			capabilityId: `${base.capabilityId}.${suffix}`,
+			promptTokenEstimate: Number.MAX_SAFE_INTEGER,
+		});
+		expect(() =>
+			retrieveCapabilities({
+				catalog: [huge("a"), huge("b")],
+				intentText: "email",
+			}),
+		).toThrowError(ElizaError);
+	});
 });
 
 describe("deterministic account selection", () => {
@@ -199,6 +214,161 @@ describe("deterministic account selection", () => {
 			code: "needs_scope",
 			retryable: false,
 		});
+	});
+
+	it("fails closed on an invalid policy maxRiskLevel instead of skipping the risk check", () => {
+		expect(() =>
+			selectConnectedAccount(
+				{ ...intent, riskLevel: "R2" },
+				[{ ...baseAccount, accountId: "acct-a" }],
+				{
+					...OPEN_POLICY,
+					maxRiskLevel:
+						"R9" as unknown as AccountSelectionPolicy["maxRiskLevel"],
+				},
+				[
+					{
+						accountId: "acct-a",
+						healthy: true,
+						region: "us",
+						unitCostMicros: 1,
+					},
+				],
+			),
+		).toThrowError(ElizaError);
+	});
+
+	it("rejects NaN, negative, fractional, and unsafe unitCostMicros signals", () => {
+		for (const unitCostMicros of [Number.NaN, -1, 2 ** 53, 0.5]) {
+			expect(() =>
+				selectConnectedAccount(
+					intent,
+					[{ ...baseAccount, accountId: "acct-a" }],
+					OPEN_POLICY,
+					[
+						{
+							accountId: "acct-a",
+							healthy: true,
+							region: "us",
+							unitCostMicros,
+						},
+					],
+				),
+			).toThrowError(ElizaError);
+		}
+	});
+
+	it("rejects an invalid policy maxUnitCostMicros instead of bypassing the ceiling", () => {
+		expect(() =>
+			selectConnectedAccount(
+				intent,
+				[{ ...baseAccount, accountId: "acct-a" }],
+				{ ...OPEN_POLICY, maxUnitCostMicros: Number.NaN },
+				[
+					{
+						accountId: "acct-a",
+						healthy: true,
+						region: "us",
+						unitCostMicros: 1,
+					},
+				],
+			),
+		).toThrowError(ElizaError);
+	});
+
+	it("rejects an unparseable lastUsedAt timestamp", () => {
+		expect(() =>
+			selectConnectedAccount(
+				intent,
+				[{ ...baseAccount, accountId: "acct-a", lastUsedAt: "not-a-date" }],
+				OPEN_POLICY,
+				[
+					{
+						accountId: "acct-a",
+						healthy: true,
+						region: "us",
+						unitCostMicros: 1,
+					},
+				],
+			),
+		).toThrowError(ElizaError);
+	});
+
+	it("rejects duplicate capability grants within one account", () => {
+		expect(() =>
+			selectConnectedAccount(
+				intent,
+				[
+					{
+						...baseAccount,
+						accountId: "acct-a",
+						capabilities: [capability, capability],
+					},
+				],
+				OPEN_POLICY,
+				[
+					{
+						accountId: "acct-a",
+						healthy: true,
+						region: "us",
+						unitCostMicros: 1,
+					},
+				],
+			),
+		).toThrowError(ElizaError);
+	});
+
+	it("rejects a signal referencing an unknown account", () => {
+		expect(() =>
+			selectConnectedAccount(
+				intent,
+				[{ ...baseAccount, accountId: "acct-a" }],
+				OPEN_POLICY,
+				[
+					{
+						accountId: "acct-a",
+						healthy: true,
+						region: "us",
+						unitCostMicros: 1,
+					},
+					{
+						accountId: "acct-ghost",
+						healthy: true,
+						region: "us",
+						unitCostMicros: 1,
+					},
+				],
+			),
+		).toThrowError(ElizaError);
+	});
+
+	it("selects the same account regardless of input order for equal candidates", () => {
+		const accounts = [
+			{ ...baseAccount, accountId: "acct-b" },
+			{ ...baseAccount, accountId: "acct-a" },
+		];
+		const signals = [
+			{ accountId: "acct-a", healthy: true, region: "us", unitCostMicros: 1 },
+			{ accountId: "acct-b", healthy: true, region: "us", unitCostMicros: 1 },
+		];
+		const forward = selectConnectedAccount(
+			intent,
+			accounts,
+			OPEN_POLICY,
+			signals,
+		);
+		const reversed = selectConnectedAccount(
+			intent,
+			[...accounts].reverse(),
+			OPEN_POLICY,
+			[...signals].reverse(),
+		);
+		expect(forward.outcome).toBe("selected");
+		expect(reversed.outcome).toBe("selected");
+		if (forward.outcome === "selected" && reversed.outcome === "selected") {
+			expect(forward.account.accountId).toBe("acct-a");
+			expect(reversed.account.accountId).toBe("acct-a");
+		}
 	});
 
 	it("rejects missing signals and duplicate accounts as invalid input", () => {

--- a/packages/core/src/capability-selection/evaluation-corpus.ts
+++ b/packages/core/src/capability-selection/evaluation-corpus.ts
@@ -1,0 +1,397 @@
+/**
+ * Built-in evaluation corpus for capability retrieval and account selection.
+ * The catalog models representative Wave 2-5 normalized capabilities (email,
+ * calendar, messaging, files, payments, contacts, commerce, health, code);
+ * the cases cover unambiguous intents, cross-domain ambiguous intents,
+ * designed-empty intents, unavailable and policy-blocked accounts, cost and
+ * health gating, and wrong-account prevention for pinned account requests.
+ * All identifiers are synthetic; no credentials or provider data appear here.
+ */
+import {
+	type ConnectedAccount,
+	type ConnectedAccountCapability,
+	type ConnectedAccountMode,
+	type ConnectedAccountStatus,
+	PROVIDER_INTEGRATION_CONTRACT_VERSION,
+} from "../types/provider-integrations";
+import type {
+	AccountSelectionPolicy,
+	AccountSelectionSignal,
+} from "./account-selection";
+import type { CapabilitySelectionEvalCase } from "./evaluation";
+import type { CapabilityCatalogEntry } from "./retrieval";
+
+export const CAPABILITY_EVALUATION_CATALOG: readonly CapabilityCatalogEntry[] =
+	Object.freeze([
+		{
+			capabilityId: "email.message.send",
+			domain: "email",
+			summary: "Send or reply to an email message from a connected mailbox.",
+			keywords: ["email", "send", "compose", "reply"],
+			operations: ["send", "reply"],
+			promptTokenEstimate: 120,
+		},
+		{
+			capabilityId: "email.message.search",
+			domain: "email",
+			summary: "Search email messages in a connected mailbox.",
+			keywords: ["email", "inbox", "search", "find"],
+			operations: ["search"],
+			promptTokenEstimate: 90,
+		},
+		{
+			capabilityId: "calendar.event.create",
+			domain: "calendar",
+			summary: "Create a calendar event with attendees and reminders.",
+			keywords: ["calendar", "event", "schedule", "meeting"],
+			operations: ["create"],
+			promptTokenEstimate: 110,
+		},
+		{
+			capabilityId: "messaging.chat.send",
+			domain: "messaging",
+			summary: "Send a chat message to a channel or person.",
+			keywords: ["message", "chat", "dm", "send"],
+			operations: ["send"],
+			promptTokenEstimate: 100,
+		},
+		{
+			capabilityId: "files.document.search",
+			domain: "files",
+			summary: "Search documents and files in connected storage.",
+			keywords: ["file", "document", "drive", "search"],
+			operations: ["search"],
+			promptTokenEstimate: 95,
+		},
+		{
+			capabilityId: "payments.transfer.create",
+			domain: "payments",
+			summary: "Create a money transfer between linked accounts.",
+			keywords: ["payment", "transfer", "money", "pay"],
+			operations: ["create"],
+			promptTokenEstimate: 140,
+		},
+		{
+			capabilityId: "contacts.person.search",
+			domain: "contacts",
+			summary: "Search people in the connected address book.",
+			keywords: ["contact", "person", "people", "address"],
+			operations: ["search"],
+			promptTokenEstimate: 80,
+		},
+		{
+			capabilityId: "commerce.order.create",
+			domain: "commerce",
+			summary: "Place a purchase order from a connected storefront.",
+			keywords: ["order", "purchase", "buy", "cart"],
+			operations: ["create"],
+			promptTokenEstimate: 130,
+		},
+		{
+			capabilityId: "health.metrics.read",
+			domain: "health",
+			summary: "Read step, sleep, and heart-rate metrics from a device.",
+			keywords: ["health", "steps", "sleep", "metrics"],
+			operations: ["read"],
+			promptTokenEstimate: 85,
+		},
+		{
+			capabilityId: "code.repository.search",
+			domain: "code",
+			summary: "Search source code in connected repositories.",
+			keywords: ["code", "repository", "repo", "commit"],
+			operations: ["search"],
+			promptTokenEstimate: 105,
+		},
+	]);
+
+function account(input: {
+	accountId: string;
+	providerId: string;
+	mode?: ConnectedAccountMode;
+	status?: ConnectedAccountStatus;
+	capabilities: readonly ConnectedAccountCapability[];
+	lastUsedAt?: string | null;
+}): ConnectedAccount {
+	return Object.freeze({
+		contractVersion: PROVIDER_INTEGRATION_CONTRACT_VERSION,
+		accountId: input.accountId,
+		providerId: input.providerId,
+		mode: input.mode ?? "cloud",
+		status: input.status ?? "connected",
+		displayName: null,
+		capabilities: Object.freeze([...input.capabilities]),
+		lastUsedAt: input.lastUsedAt ?? null,
+	});
+}
+
+const EMAIL_CAPS: readonly ConnectedAccountCapability[] = Object.freeze([
+	{ capabilityId: "email.message.send", riskLevel: "R2", status: "available" },
+	{
+		capabilityId: "email.message.search",
+		riskLevel: "R1",
+		status: "available",
+	},
+]);
+
+const EMAIL_WORK = account({
+	accountId: "acct-email-work",
+	providerId: "google-mail",
+	capabilities: EMAIL_CAPS,
+	lastUsedAt: "2026-08-01T00:00:00.000Z",
+});
+const EMAIL_PERSONAL = account({
+	accountId: "acct-email-personal",
+	providerId: "google-mail",
+	capabilities: EMAIL_CAPS,
+	lastUsedAt: "2026-08-10T00:00:00.000Z",
+});
+const EMAIL_LEGACY = account({
+	accountId: "acct-email-legacy",
+	providerId: "microsoft-mail",
+	status: "revoked",
+	capabilities: EMAIL_CAPS,
+});
+const BANK_PRIMARY = account({
+	accountId: "acct-bank-primary",
+	providerId: "plaid",
+	capabilities: [
+		{
+			capabilityId: "payments.transfer.create",
+			riskLevel: "R3",
+			status: "available",
+		},
+	],
+});
+
+function signal(
+	accountId: string,
+	overrides: Partial<Omit<AccountSelectionSignal, "accountId">> = {},
+): AccountSelectionSignal {
+	return {
+		accountId,
+		healthy: overrides.healthy ?? true,
+		region: overrides.region ?? "us",
+		unitCostMicros: overrides.unitCostMicros ?? 10,
+	};
+}
+
+const OPEN_POLICY: AccountSelectionPolicy = Object.freeze({
+	allowedModes: null,
+	allowedProviderIds: null,
+	blockedAccountIds: Object.freeze([]),
+	maxRiskLevel: "R2",
+	preferredRegion: null,
+	maxUnitCostMicros: null,
+});
+
+const EMAIL_SEND_INTENT = {
+	capabilityId: "email.message.send",
+	riskLevel: "R2",
+	requestedAccountId: null,
+} as const;
+
+const EMAIL_RETRIEVAL = {
+	topCapabilityId: "email.message.send",
+	mustInclude: ["email.message.send"],
+	expectAmbiguous: false,
+} as const;
+
+export const CAPABILITY_EVALUATION_CORPUS: readonly CapabilitySelectionEvalCase[] =
+	Object.freeze([
+		{
+			name: "unambiguous email send selects the cheapest healthy account",
+			intentText: "send an email to sam about the offsite",
+			retrieval: EMAIL_RETRIEVAL,
+			selection: {
+				intent: EMAIL_SEND_INTENT,
+				accounts: [EMAIL_WORK, EMAIL_PERSONAL],
+				signals: [
+					signal("acct-email-work", { unitCostMicros: 10 }),
+					signal("acct-email-personal", { region: "eu", unitCostMicros: 5 }),
+				],
+				policy: OPEN_POLICY,
+				expected: { outcome: "selected", accountId: "acct-email-personal" },
+			},
+		},
+		{
+			name: "region preference outranks cost",
+			intentText: "send an email to sam about the offsite",
+			retrieval: EMAIL_RETRIEVAL,
+			selection: {
+				intent: EMAIL_SEND_INTENT,
+				accounts: [EMAIL_WORK, EMAIL_PERSONAL],
+				signals: [
+					signal("acct-email-work", { unitCostMicros: 10 }),
+					signal("acct-email-personal", { region: "eu", unitCostMicros: 5 }),
+				],
+				policy: { ...OPEN_POLICY, preferredRegion: "us" },
+				expected: { outcome: "selected", accountId: "acct-email-work" },
+			},
+		},
+		{
+			name: "ambiguous cross-domain send intent is flagged, never auto-resolved",
+			intentText: "send a message",
+			retrieval: {
+				topCapabilityId: "messaging.chat.send",
+				mustInclude: ["messaging.chat.send", "email.message.send"],
+				expectAmbiguous: true,
+			},
+			selection: null,
+		},
+		{
+			name: "unrelated intent retrieves nothing instead of the full catalog",
+			intentText: "zzqx flibberwock unrelated gibberish",
+			retrieval: {
+				topCapabilityId: null,
+				mustInclude: [],
+				expectAmbiguous: false,
+			},
+			selection: null,
+		},
+		{
+			name: "pinned blocked account is denied, never substituted",
+			intentText: "send an email from my personal account",
+			retrieval: EMAIL_RETRIEVAL,
+			selection: {
+				intent: {
+					...EMAIL_SEND_INTENT,
+					requestedAccountId: "acct-email-personal",
+				},
+				accounts: [EMAIL_WORK, EMAIL_PERSONAL],
+				signals: [signal("acct-email-work"), signal("acct-email-personal")],
+				policy: { ...OPEN_POLICY, blockedAccountIds: ["acct-email-personal"] },
+				expected: { outcome: "denied", reasonCode: "account_policy_denied" },
+			},
+		},
+		{
+			name: "pinned unknown account is not_configured",
+			intentText: "send an email from my old account",
+			retrieval: EMAIL_RETRIEVAL,
+			selection: {
+				intent: { ...EMAIL_SEND_INTENT, requestedAccountId: "acct-missing" },
+				accounts: [EMAIL_WORK],
+				signals: [signal("acct-email-work")],
+				policy: OPEN_POLICY,
+				expected: {
+					outcome: "unavailable",
+					code: "not_configured",
+					retryable: false,
+				},
+			},
+		},
+		{
+			name: "high-risk transfer above the policy ceiling is deterministically denied",
+			intentText: "transfer money to my savings account",
+			retrieval: {
+				topCapabilityId: "payments.transfer.create",
+				mustInclude: ["payments.transfer.create"],
+				expectAmbiguous: false,
+			},
+			selection: {
+				intent: {
+					capabilityId: "payments.transfer.create",
+					riskLevel: "R3",
+					requestedAccountId: null,
+				},
+				accounts: [BANK_PRIMARY],
+				signals: [signal("acct-bank-primary")],
+				policy: OPEN_POLICY,
+				expected: { outcome: "denied", reasonCode: "risk_policy_denied" },
+			},
+		},
+		{
+			name: "only-revoked accounts surface account_revoked",
+			intentText: "search email from legacy inbox",
+			retrieval: {
+				topCapabilityId: "email.message.search",
+				mustInclude: ["email.message.search"],
+				expectAmbiguous: false,
+			},
+			selection: {
+				intent: {
+					capabilityId: "email.message.search",
+					riskLevel: "R1",
+					requestedAccountId: null,
+				},
+				accounts: [EMAIL_LEGACY],
+				signals: [signal("acct-email-legacy")],
+				policy: OPEN_POLICY,
+				expected: {
+					outcome: "unavailable",
+					code: "account_revoked",
+					retryable: false,
+				},
+			},
+		},
+		{
+			name: "cost policy blocks every account as cost_blocked",
+			intentText: "send an email to sam about the offsite",
+			retrieval: EMAIL_RETRIEVAL,
+			selection: {
+				intent: EMAIL_SEND_INTENT,
+				accounts: [EMAIL_WORK, EMAIL_PERSONAL],
+				signals: [
+					signal("acct-email-work", { unitCostMicros: 10 }),
+					signal("acct-email-personal", { unitCostMicros: 8 }),
+				],
+				policy: { ...OPEN_POLICY, maxUnitCostMicros: 3 },
+				expected: {
+					outcome: "unavailable",
+					code: "cost_blocked",
+					retryable: false,
+				},
+			},
+		},
+		{
+			name: "unhealthy cheapest account loses to the healthy alternative",
+			intentText: "send an email to sam about the offsite",
+			retrieval: EMAIL_RETRIEVAL,
+			selection: {
+				intent: EMAIL_SEND_INTENT,
+				accounts: [EMAIL_WORK, EMAIL_PERSONAL],
+				signals: [
+					signal("acct-email-work", { unitCostMicros: 10 }),
+					signal("acct-email-personal", { unitCostMicros: 5, healthy: false }),
+				],
+				policy: OPEN_POLICY,
+				expected: { outcome: "selected", accountId: "acct-email-work" },
+			},
+		},
+		{
+			name: "capability lacking on every account is unsupported",
+			intentText: "create a calendar event for friday",
+			retrieval: {
+				topCapabilityId: "calendar.event.create",
+				mustInclude: ["calendar.event.create"],
+				expectAmbiguous: false,
+			},
+			selection: {
+				intent: {
+					capabilityId: "calendar.event.create",
+					riskLevel: "R1",
+					requestedAccountId: null,
+				},
+				accounts: [EMAIL_WORK],
+				signals: [signal("acct-email-work")],
+				policy: OPEN_POLICY,
+				expected: {
+					outcome: "unavailable",
+					code: "unsupported",
+					retryable: false,
+				},
+			},
+		},
+		{
+			name: "equal candidates fall back to most-recent use then accountId",
+			intentText: "send an email to sam about the offsite",
+			retrieval: EMAIL_RETRIEVAL,
+			selection: {
+				intent: EMAIL_SEND_INTENT,
+				accounts: [EMAIL_WORK, EMAIL_PERSONAL],
+				signals: [signal("acct-email-work"), signal("acct-email-personal")],
+				policy: OPEN_POLICY,
+				expected: { outcome: "selected", accountId: "acct-email-personal" },
+			},
+		},
+	]);

--- a/packages/core/src/capability-selection/evaluation.ts
+++ b/packages/core/src/capability-selection/evaluation.ts
@@ -1,0 +1,209 @@
+/**
+ * Evaluation harness for capability retrieval and deterministic account
+ * selection. Each corpus case declares expected retrieval (top capability,
+ * ambiguity) and selection (selected account or typed denial/unavailable)
+ * outcomes; the runner executes the real retrieval and selection paths,
+ * records per-case latency and aggregate prompt-token metrics, and returns a
+ * deterministic report. Latency is measured but never asserted — assertions
+ * belong to the corpus expectations, which are exact.
+ */
+import { ElizaError } from "../errors";
+import type { ConnectedAccount } from "../types/provider-integrations";
+import {
+	type AccountSelectionIntent,
+	type AccountSelectionPolicy,
+	type AccountSelectionResult,
+	type AccountSelectionSignal,
+	selectConnectedAccount,
+} from "./account-selection";
+import { type CapabilityCatalogEntry, retrieveCapabilities } from "./retrieval";
+
+export interface RetrievalExpectation {
+	/** Exact capabilityId expected at rank 1, or null for designed-empty. */
+	topCapabilityId: string | null;
+	/** Every listed capabilityId must appear in the retrieved set. */
+	mustInclude: readonly string[];
+	expectAmbiguous: boolean;
+}
+
+export type SelectionExpectation =
+	| { outcome: "selected"; accountId: string }
+	| { outcome: "denied"; reasonCode: string }
+	| { outcome: "unavailable"; code: string; retryable: boolean };
+
+export interface CapabilitySelectionEvalCase {
+	name: string;
+	intentText: string;
+	retrieval: RetrievalExpectation;
+	/** Null skips the selection stage (retrieval-only case). */
+	selection: {
+		intent: AccountSelectionIntent;
+		accounts: readonly ConnectedAccount[];
+		signals: readonly AccountSelectionSignal[];
+		policy: AccountSelectionPolicy;
+		expected: SelectionExpectation;
+	} | null;
+}
+
+export interface CapabilitySelectionEvalCaseResult {
+	name: string;
+	passed: boolean;
+	failures: readonly string[];
+	retrievedCapabilityIds: readonly string[];
+	selection: AccountSelectionResult | null;
+	retrievedPromptTokenEstimate: number;
+	floodRatio: number;
+	latencyMs: number;
+}
+
+export interface CapabilitySelectionEvalReport {
+	cases: readonly CapabilitySelectionEvalCaseResult[];
+	summary: {
+		total: number;
+		passed: number;
+		failed: number;
+		meanFloodRatio: number;
+		maxRetrievedPromptTokenEstimate: number;
+		maxLatencyMs: number;
+	};
+}
+
+function selectionFailures(
+	expected: SelectionExpectation,
+	actual: AccountSelectionResult,
+): string[] {
+	if (expected.outcome !== actual.outcome) {
+		return [
+			`expected selection outcome ${expected.outcome}, got ${actual.outcome}`,
+		];
+	}
+	const failures: string[] = [];
+	if (expected.outcome === "selected" && actual.outcome === "selected") {
+		if (actual.account.accountId !== expected.accountId) {
+			failures.push(
+				`expected account ${expected.accountId}, got ${actual.account.accountId}`,
+			);
+		}
+	}
+	if (expected.outcome === "denied" && actual.outcome === "denied") {
+		if (actual.reasonCode !== expected.reasonCode) {
+			failures.push(
+				`expected denial ${expected.reasonCode}, got ${actual.reasonCode}`,
+			);
+		}
+	}
+	if (expected.outcome === "unavailable" && actual.outcome === "unavailable") {
+		if (actual.code !== expected.code) {
+			failures.push(
+				`expected unavailable code ${expected.code}, got ${actual.code}`,
+			);
+		}
+		if (actual.retryable !== expected.retryable) {
+			failures.push(
+				`expected retryable ${expected.retryable}, got ${actual.retryable}`,
+			);
+		}
+	}
+	return failures;
+}
+
+/**
+ * Runs every corpus case against the shared catalog. The report is
+ * deterministic apart from latency measurements.
+ */
+export function runCapabilitySelectionEvaluation(
+	catalog: readonly CapabilityCatalogEntry[],
+	corpus: readonly CapabilitySelectionEvalCase[],
+): CapabilitySelectionEvalReport {
+	if (corpus.length === 0) {
+		throw new ElizaError("Capability selection evaluation corpus is empty.", {
+			code: "INVALID_CAPABILITY_EVALUATION_CORPUS",
+			severity: "fatal",
+		});
+	}
+	const names = new Set(corpus.map((evalCase) => evalCase.name));
+	if (names.size !== corpus.length) {
+		throw new ElizaError(
+			"Capability selection evaluation case names must be unique.",
+			{
+				code: "INVALID_CAPABILITY_EVALUATION_CORPUS",
+				severity: "fatal",
+			},
+		);
+	}
+
+	const results: CapabilitySelectionEvalCaseResult[] = corpus.map(
+		(evalCase) => {
+			const startedAt = performance.now();
+			const failures: string[] = [];
+
+			const retrieval = retrieveCapabilities({
+				catalog,
+				intentText: evalCase.intentText,
+			});
+			const retrievedCapabilityIds = retrieval.results.map(
+				(match) => match.entry.capabilityId,
+			);
+			const top = retrievedCapabilityIds[0] ?? null;
+			if (top !== evalCase.retrieval.topCapabilityId) {
+				failures.push(
+					`expected top capability ${String(evalCase.retrieval.topCapabilityId)}, got ${String(top)}`,
+				);
+			}
+			for (const required of evalCase.retrieval.mustInclude) {
+				if (!retrievedCapabilityIds.includes(required)) {
+					failures.push(`expected retrieval to include ${required}`);
+				}
+			}
+			if (
+				retrieval.ambiguity.ambiguous !== evalCase.retrieval.expectAmbiguous
+			) {
+				failures.push(
+					`expected ambiguous=${evalCase.retrieval.expectAmbiguous}, got ${retrieval.ambiguity.ambiguous}`,
+				);
+			}
+
+			let selection: AccountSelectionResult | null = null;
+			if (evalCase.selection !== null) {
+				selection = selectConnectedAccount(
+					evalCase.selection.intent,
+					evalCase.selection.accounts,
+					evalCase.selection.policy,
+					evalCase.selection.signals,
+				);
+				failures.push(
+					...selectionFailures(evalCase.selection.expected, selection),
+				);
+			}
+
+			return {
+				name: evalCase.name,
+				passed: failures.length === 0,
+				failures: Object.freeze(failures),
+				retrievedCapabilityIds: Object.freeze(retrievedCapabilityIds),
+				selection,
+				retrievedPromptTokenEstimate:
+					retrieval.metrics.retrievedPromptTokenEstimate,
+				floodRatio: retrieval.metrics.floodRatio,
+				latencyMs: performance.now() - startedAt,
+			};
+		},
+	);
+
+	const passed = results.filter((result) => result.passed).length;
+	return {
+		cases: Object.freeze(results),
+		summary: {
+			total: results.length,
+			passed,
+			failed: results.length - passed,
+			meanFloodRatio:
+				results.reduce((sum, result) => sum + result.floodRatio, 0) /
+				results.length,
+			maxRetrievedPromptTokenEstimate: Math.max(
+				...results.map((result) => result.retrievedPromptTokenEstimate),
+			),
+			maxLatencyMs: Math.max(...results.map((result) => result.latencyMs)),
+		},
+	};
+}

--- a/packages/core/src/capability-selection/index.ts
+++ b/packages/core/src/capability-selection/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Capability retrieval and deterministic account selection: bounded,
+ * relevance-ranked catalog retrieval (anti prompt-flooding), policy/health/
+ * location/cost account selection, and the evaluation harness plus built-in
+ * corpus that verify both behaviors.
+ */
+export * from "./account-selection";
+export * from "./evaluation";
+export * from "./evaluation-corpus";
+export * from "./retrieval";

--- a/packages/core/src/capability-selection/retrieval.ts
+++ b/packages/core/src/capability-selection/retrieval.ts
@@ -1,0 +1,259 @@
+/**
+ * Deterministic capability retrieval over the normalized capability catalog.
+ * Given an intent's text, it scores compact catalog entries (id, domain,
+ * keywords, summary — never provider/MCP schemas) and returns a bounded,
+ * relevance-ranked subset plus prompt-flooding metrics so callers can prove
+ * the model context carries only the relevant slice of the catalog. An empty
+ * or non-matching intent yields a designed-empty result, never the full
+ * catalog. Consumed by the planner-side capability router and by the
+ * evaluation harness in `./evaluation`.
+ */
+import { ElizaError } from "../errors";
+
+/**
+ * Normalized, provider-neutral catalog entry. `promptTokenEstimate` is the
+ * producer-measured token cost of rendering this capability into model
+ * context; it powers the flood-reduction metrics.
+ */
+export interface CapabilityCatalogEntry {
+	capabilityId: string;
+	domain: string;
+	summary: string;
+	keywords: readonly string[];
+	operations: readonly string[];
+	promptTokenEstimate: number;
+}
+
+export interface CapabilityRetrievalMatch {
+	entry: CapabilityCatalogEntry;
+	score: number;
+	rank: number;
+	matchedTokens: readonly string[];
+}
+
+/**
+ * Ambiguity is reported, never silently resolved: when the top two matches
+ * come from different domains and their score margin is below the threshold,
+ * the caller must disambiguate (clarify or confirm) instead of dispatching.
+ */
+export interface CapabilityRetrievalAmbiguity {
+	ambiguous: boolean;
+	margin: number | null;
+	contenders: readonly string[];
+}
+
+export interface CapabilityRetrievalMetrics {
+	catalogSize: number;
+	retrievedCount: number;
+	catalogPromptTokenEstimate: number;
+	retrievedPromptTokenEstimate: number;
+	/** retrievedTokens / catalogTokens — lower means less prompt flooding. */
+	floodRatio: number;
+}
+
+export interface CapabilityRetrievalResult {
+	results: readonly CapabilityRetrievalMatch[];
+	ambiguity: CapabilityRetrievalAmbiguity;
+	metrics: CapabilityRetrievalMetrics;
+	queryTokens: readonly string[];
+}
+
+export interface RetrieveCapabilitiesInput {
+	catalog: readonly CapabilityCatalogEntry[];
+	intentText: string;
+	/** Maximum entries returned. Defaults to 5; must be a positive integer. */
+	limit?: number;
+	/** Score margin (relative to the top score) below which cross-domain ties are ambiguous. Defaults to 0.25. */
+	ambiguityMargin?: number;
+}
+
+const DEFAULT_LIMIT = 5;
+const DEFAULT_AMBIGUITY_MARGIN = 0.25;
+
+const KEYWORD_WEIGHT = 3;
+const IDENTITY_WEIGHT = 2;
+const OPERATION_WEIGHT = 2;
+const SUMMARY_WEIGHT = 1;
+
+export function tokenizeCapabilityIntent(text: string): string[] {
+	return text
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter((token) => token.length > 1);
+}
+
+function invalidRetrievalInput(
+	message: string,
+	context: Record<string, unknown>,
+): never {
+	throw new ElizaError(message, {
+		code: "INVALID_CAPABILITY_RETRIEVAL_INPUT",
+		context,
+		severity: "fatal",
+	});
+}
+
+function validateCatalog(catalog: readonly CapabilityCatalogEntry[]): void {
+	const seen = new Set<string>();
+	for (const entry of catalog) {
+		if (entry.capabilityId.trim().length === 0) {
+			invalidRetrievalInput(
+				"Capability catalog entry has an empty capabilityId.",
+				{},
+			);
+		}
+		if (seen.has(entry.capabilityId)) {
+			invalidRetrievalInput(
+				"Capability catalog contains a duplicate capabilityId.",
+				{
+					capabilityId: entry.capabilityId,
+				},
+			);
+		}
+		seen.add(entry.capabilityId);
+		if (
+			!Number.isInteger(entry.promptTokenEstimate) ||
+			entry.promptTokenEstimate <= 0
+		) {
+			invalidRetrievalInput(
+				"Capability catalog entry promptTokenEstimate must be a positive integer.",
+				{
+					capabilityId: entry.capabilityId,
+					promptTokenEstimate: entry.promptTokenEstimate,
+				},
+			);
+		}
+	}
+}
+
+function scoreEntry(
+	entry: CapabilityCatalogEntry,
+	queryTokens: readonly string[],
+): { score: number; matchedTokens: string[] } {
+	const keywordSet = new Set(
+		entry.keywords.map((keyword) => keyword.toLowerCase()),
+	);
+	const identityTokens = new Set([
+		...tokenizeCapabilityIntent(entry.capabilityId),
+		...tokenizeCapabilityIntent(entry.domain),
+	]);
+	const operationTokens = new Set(
+		entry.operations.flatMap((operation) =>
+			tokenizeCapabilityIntent(operation),
+		),
+	);
+	const summaryTokens = new Set(tokenizeCapabilityIntent(entry.summary));
+
+	let score = 0;
+	const matchedTokens: string[] = [];
+	for (const token of new Set(queryTokens)) {
+		let tokenScore = 0;
+		if (keywordSet.has(token)) tokenScore += KEYWORD_WEIGHT;
+		if (identityTokens.has(token)) tokenScore += IDENTITY_WEIGHT;
+		if (operationTokens.has(token)) tokenScore += OPERATION_WEIGHT;
+		if (summaryTokens.has(token)) tokenScore += SUMMARY_WEIGHT;
+		if (tokenScore > 0) {
+			score += tokenScore;
+			matchedTokens.push(token);
+		}
+	}
+	return { score, matchedTokens };
+}
+
+/**
+ * Scores and ranks catalog entries against the intent text. Fully
+ * deterministic: identical inputs always produce identical rankings, with
+ * `capabilityId` ascending as the final tie-breaker.
+ */
+export function retrieveCapabilities(
+	input: RetrieveCapabilitiesInput,
+): CapabilityRetrievalResult {
+	const limit = input.limit ?? DEFAULT_LIMIT;
+	if (!Number.isInteger(limit) || limit <= 0) {
+		invalidRetrievalInput(
+			"Capability retrieval limit must be a positive integer.",
+			{ limit },
+		);
+	}
+	const ambiguityMargin = input.ambiguityMargin ?? DEFAULT_AMBIGUITY_MARGIN;
+	if (!(ambiguityMargin >= 0 && ambiguityMargin < 1)) {
+		invalidRetrievalInput(
+			"Capability retrieval ambiguityMargin must be in [0, 1).",
+			{
+				ambiguityMargin,
+			},
+		);
+	}
+	validateCatalog(input.catalog);
+
+	const catalogPromptTokenEstimate = input.catalog.reduce(
+		(sum, entry) => sum + entry.promptTokenEstimate,
+		0,
+	);
+	const queryTokens = tokenizeCapabilityIntent(input.intentText);
+
+	const scored = input.catalog
+		.map((entry) => ({ entry, ...scoreEntry(entry, queryTokens) }))
+		.filter((candidate) => candidate.score > 0)
+		.sort((a, b) =>
+			b.score !== a.score
+				? b.score - a.score
+				: a.entry.capabilityId.localeCompare(b.entry.capabilityId),
+		)
+		.slice(0, limit);
+
+	const results: CapabilityRetrievalMatch[] = scored.map(
+		(candidate, index) => ({
+			entry: candidate.entry,
+			score: candidate.score,
+			rank: index + 1,
+			matchedTokens: Object.freeze(candidate.matchedTokens.sort()),
+		}),
+	);
+
+	let ambiguity: CapabilityRetrievalAmbiguity = {
+		ambiguous: false,
+		margin: null,
+		contenders: Object.freeze([]),
+	};
+	if (results.length >= 2) {
+		const [first, second] = results;
+		const margin = (first.score - second.score) / first.score;
+		if (
+			first.entry.domain !== second.entry.domain &&
+			margin < ambiguityMargin
+		) {
+			ambiguity = {
+				ambiguous: true,
+				margin,
+				contenders: Object.freeze([
+					first.entry.capabilityId,
+					second.entry.capabilityId,
+				]),
+			};
+		} else {
+			ambiguity = { ambiguous: false, margin, contenders: Object.freeze([]) };
+		}
+	}
+
+	const retrievedPromptTokenEstimate = results.reduce(
+		(sum, match) => sum + match.entry.promptTokenEstimate,
+		0,
+	);
+
+	return {
+		results: Object.freeze(results),
+		ambiguity,
+		metrics: {
+			catalogSize: input.catalog.length,
+			retrievedCount: results.length,
+			catalogPromptTokenEstimate,
+			retrievedPromptTokenEstimate,
+			floodRatio:
+				catalogPromptTokenEstimate === 0
+					? 0
+					: retrievedPromptTokenEstimate / catalogPromptTokenEstimate,
+		},
+		queryTokens: Object.freeze(queryTokens),
+	};
+}

--- a/packages/core/src/capability-selection/retrieval.ts
+++ b/packages/core/src/capability-selection/retrieval.ts
@@ -112,11 +112,11 @@ function validateCatalog(catalog: readonly CapabilityCatalogEntry[]): void {
 		}
 		seen.add(entry.capabilityId);
 		if (
-			!Number.isInteger(entry.promptTokenEstimate) ||
+			!Number.isSafeInteger(entry.promptTokenEstimate) ||
 			entry.promptTokenEstimate <= 0
 		) {
 			invalidRetrievalInput(
-				"Capability catalog entry promptTokenEstimate must be a positive integer.",
+				"Capability catalog entry promptTokenEstimate must be a positive safe integer.",
 				{
 					capabilityId: entry.capabilityId,
 					promptTokenEstimate: entry.promptTokenEstimate,
@@ -190,16 +190,25 @@ export function retrieveCapabilities(
 		(sum, entry) => sum + entry.promptTokenEstimate,
 		0,
 	);
+	// Per-entry estimates are safe integers, but their sum can still exceed
+	// the safe range and corrupt the flood metrics; fail closed instead.
+	if (!Number.isSafeInteger(catalogPromptTokenEstimate)) {
+		invalidRetrievalInput(
+			"Capability catalog aggregate promptTokenEstimate exceeds the safe integer range.",
+			{ catalogSize: input.catalog.length },
+		);
+	}
 	const queryTokens = tokenizeCapabilityIntent(input.intentText);
 
 	const scored = input.catalog
 		.map((entry) => ({ entry, ...scoreEntry(entry, queryTokens) }))
 		.filter((candidate) => candidate.score > 0)
-		.sort((a, b) =>
-			b.score !== a.score
-				? b.score - a.score
-				: a.entry.capabilityId.localeCompare(b.entry.capabilityId),
-		)
+		.sort((a, b) => {
+			if (b.score !== a.score) return b.score - a.score;
+			// Code-unit comparison keeps the tie-breaker locale-independent.
+			if (a.entry.capabilityId === b.entry.capabilityId) return 0;
+			return a.entry.capabilityId < b.entry.capabilityId ? -1 : 1;
+		})
 		.slice(0, limit);
 
 	const results: CapabilityRetrievalMatch[] = scored.map(

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -26,6 +26,7 @@ export * from "./app-route-plugin-registry";
 export * from "./boot-env";
 export * from "./build-variant";
 export * from "./capabilities";
+export * from "./capability-selection";
 // Export configuration and plugin modules - will be removed once cli cleanup
 export * from "./character";
 // Export character utilities


### PR DESCRIPTION
Fixes #19906

## What

Adds `packages/core/src/capability-selection/`, building on the Wave 0 provider-integration contracts (`types/provider-integrations.ts`):

- **`retrieval.ts`** — deterministic capability retrieval over the normalized capability catalog (id/domain/keywords/summary — never provider or MCP schemas). Returns a bounded, relevance-ranked subset with prompt-flood metrics (`catalogPromptTokenEstimate` vs `retrievedPromptTokenEstimate`, `floodRatio`) and explicit cross-domain ambiguity reporting. Empty or non-matching intents yield a designed-empty result, never the full catalog.
- **`account-selection.ts`** — deterministic connected-account/adapter selection using policy (blocked accounts, allowed modes/providers, risk ceiling), health, region, and cost, with a fixed total order (region match → unit cost → recency → accountId). A pinned `requestedAccountId` is honored exactly or fails with a typed reason — an ineligible pinned account is never silently substituted (wrong-account prevention). Failures reuse the typed `CapabilityPolicyDenialCode` / `CapabilityUnavailableCode` contracts, and a policy denial takes precedence over mere unavailability.
- **`evaluation.ts` + `evaluation-corpus.ts`** — evaluation harness and built-in corpus (12 cases over a 10-capability representative catalog): unambiguous intents, ambiguous cross-domain intents, designed-empty intents, revoked/blocked/cost-blocked/unhealthy accounts, risk-policy denial, pinned-account prevention, and tie-break ordering. The report carries per-case latency and aggregate token/flood metrics.

Exported from `index.node.ts`.

## Verification

- `bunx vitest run src/capability-selection/capability-selection.test.ts` — 14/14 passing (retrieval ranking/ambiguity/designed-empty/idempotency/invalid-input, selection policy-denial precedence, wrong-account prevention, ranking order, needs_scope mapping, invalid-input rejection, full corpus run, repeat-run determinism, failing-case reporting).
- `bun run --cwd packages/core typecheck` — clean.
- `bun run --cwd packages/core lint` — no errors (7 pre-existing warnings elsewhere).
- Full `packages/core` vitest lane and root `bun run verify` results reported in a follow-up comment.

## Human-only remainder

Live-model evidence (an agent trajectory selecting via this path) requires wiring into the planner loop, which is a Wave 2+ integration concern outside this issue's evaluation scope; the harness here is deterministic and mock-free per the issue's CI baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Evidence Gate

<!-- evidence-head:567dece18f74e053bb7b8714e721da96c6091502 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered pixels or layout changed in this scoped contract, verifier, evaluation, or workflow-engine change.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered pixels or layout changed in this scoped contract, verifier, evaluation, or workflow-engine change.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual interaction flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - focused deterministic boundary and package validation results are documented above; no protected backend was mutated.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no rendered frontend runtime state changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - this scoped change adds deterministic contracts or evaluation and does not claim a production live-model path.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact focused test counts and fail-closed behavior are documented above; no separate runtime artifact was produced.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no pixels changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->