### PR TITLE
fix(core): harden flat entrypoint validation

### DIFF
--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -9,7 +9,7 @@
 import { execFile } from "node:child_process";
 import { existsSync, type FSWatcher, mkdirSync, watch } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import type { BuildConfig, BunPlugin } from "bun";
@@ -1054,7 +1054,9 @@ export async function buildNodeOnly(
 	options: {
 		argv?: string[];
 		runnerFactory?: typeof createBuildRunner;
-		generateDeclarations?: () => Promise<void>;
+		generateDeclarations?: (
+			options?: GenerateTypeScriptDeclarationOptions,
+		) => Promise<void>;
 	} = {},
 ) {
 	console.log("🚀 Starting Node-only build process for @elizaos/core");
@@ -1068,7 +1070,7 @@ export async function buildNodeOnly(
 	const tasks: Array<Promise<void>> = [buildNode(runnerFactory)];
 	if (!skipTesting) tasks.push(buildTesting(runnerFactory));
 	await Promise.all(tasks);
-	await generateDeclarations();
+	await generateDeclarations({ skipTesting });
 
 	const totalDuration = ((Date.now() - totalStart) / 1000).toFixed(2);
 	console.log(`\n🎉 Node-only build complete in ${totalDuration}s`);
@@ -1080,7 +1082,9 @@ export async function buildNodeOnly(
 export async function buildAll(
 	options: {
 		runnerFactory?: typeof createBuildRunner;
-		generateDeclarations?: () => Promise<void>;
+		generateDeclarations?: (
+			options?: GenerateTypeScriptDeclarationOptions,
+		) => Promise<void>;
 		edgeBundleIo?: EdgeBundleIo;
 	} = {},
 ) {
@@ -1251,10 +1255,183 @@ export async function fixDtsExtensions(rootDir: string): Promise<void> {
 	);
 }
 
+type PackageExportMap = Record<string, unknown>;
+
+export interface FlatEntrypointPlan {
+	exportPath: string;
+	flatFile: string;
+	targetFile: string;
+	moduleSpecifier: string;
+}
+
+export interface FlatEntrypointOptions {
+	rootDir?: string;
+	excludedExportPaths?: ReadonlySet<string>;
+}
+
+export interface GenerateTypeScriptDeclarationOptions {
+	skipTesting?: boolean;
+}
+
+const RUNTIME_CONDITION_PRIORITY = [
+	"default",
+	"node",
+	"bun",
+	"import",
+	"browser",
+	"workerd",
+] as const;
+
+function selectRuntimeExportTarget(value: unknown): string | null {
+	if (typeof value === "string") {
+		return value.startsWith("./dist/") && value.endsWith(".js") ? value : null;
+	}
+	if (Array.isArray(value)) {
+		for (const candidate of value) {
+			const target = selectRuntimeExportTarget(candidate);
+			if (target) return target;
+		}
+		return null;
+	}
+	if (typeof value !== "object" || value === null) return null;
+
+	const conditions = value as Record<string, unknown>;
+	for (const condition of RUNTIME_CONDITION_PRIORITY) {
+		if (!Object.hasOwn(conditions, condition)) continue;
+		const target = selectRuntimeExportTarget(conditions[condition]);
+		if (target) return target;
+	}
+	for (const [condition, candidate] of Object.entries(conditions)) {
+		if (
+			condition === "types" ||
+			condition === "eliza-source" ||
+			RUNTIME_CONDITION_PRIORITY.includes(
+				condition as (typeof RUNTIME_CONDITION_PRIORITY)[number],
+			)
+		) {
+			continue;
+		}
+		const target = selectRuntimeExportTarget(candidate);
+		if (target) return target;
+	}
+	return null;
+}
+
+function isTopLevelDirectoryEntrypoint(targetFile: string): boolean {
+	return /^dist\/[^/]+\/index(?:\.[^/.]+)?\.js$/.test(targetFile);
+}
+
+function toModuleSpecifier(fromFile: string, targetFile: string): string {
+	const pathFromEntrypoint = relative(dirname(fromFile), targetFile).replaceAll(
+		"\\",
+		"/",
+	);
+	return pathFromEntrypoint.startsWith(".")
+		? pathFromEntrypoint
+		: `./${pathFromEntrypoint}`;
+}
+
+/**
+ * Enumerates the flat runtime artifacts required by fixed package subpaths.
+ * Package conditions may be arbitrarily nested or array-backed; the selected
+ * target follows the package's runtime fallback before audience-specific
+ * branches. Top-level audience directories such as `./node` and `./testing`
+ * deliberately retain their directory-index layout.
+ */
+export function planFlatEntrypoints(
+	exportsMap: PackageExportMap,
+	options: FlatEntrypointOptions = {},
+): FlatEntrypointPlan[] {
+	const excluded = options.excludedExportPaths ?? new Set<string>();
+	const plans: FlatEntrypointPlan[] = [];
+	for (const [exportPath, config] of Object.entries(exportsMap)) {
+		if (
+			!exportPath.startsWith("./") ||
+			exportPath === "./package.json" ||
+			exportPath.includes("*") ||
+			excluded.has(exportPath)
+		) {
+			continue;
+		}
+
+		const target = selectRuntimeExportTarget(config);
+		if (!target) continue;
+		const targetFile = target.slice(2);
+		if (isTopLevelDirectoryEntrypoint(targetFile)) continue;
+
+		const flatFile = `dist/${exportPath.slice(2)}.js`;
+		plans.push({
+			exportPath,
+			flatFile,
+			targetFile,
+			moduleSpecifier: toModuleSpecifier(flatFile, targetFile),
+		});
+	}
+	return plans;
+}
+
+async function isFile(path: string): Promise<boolean> {
+	const fs = await import("node:fs/promises");
+	try {
+		return (await fs.stat(path)).isFile();
+	} catch (error) {
+		// error-policy:J3 an absent generated artifact is an explicit invalid
+		// result; other filesystem failures still abort the build.
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+		throw error;
+	}
+}
+
+export async function emitFlatEntrypoints(
+	exportsMap: PackageExportMap,
+	options: FlatEntrypointOptions = {},
+): Promise<FlatEntrypointPlan[]> {
+	const fs = await import("node:fs/promises");
+	const rootDir = options.rootDir ?? process.cwd();
+	const plans = planFlatEntrypoints(exportsMap, options);
+	for (const plan of plans) {
+		const target = join(rootDir, plan.targetFile);
+		if (!(await isFile(target))) {
+			throw new Error(
+				`${plan.exportPath}: runtime target ${plan.targetFile} was not emitted`,
+			);
+		}
+		if (plan.flatFile === plan.targetFile) continue;
+		const flat = join(rootDir, plan.flatFile);
+		await fs.mkdir(dirname(flat), { recursive: true });
+		await fs.writeFile(
+			flat,
+			`// Flat ${plan.exportPath} build entrypoint\nexport * from ${JSON.stringify(plan.moduleSpecifier)};\n`,
+			"utf8",
+		);
+	}
+	return plans;
+}
+
+export async function validateFlatEntrypoints(
+	plans: readonly FlatEntrypointPlan[],
+	options: Pick<FlatEntrypointOptions, "rootDir"> = {},
+): Promise<void> {
+	const rootDir = options.rootDir ?? process.cwd();
+	const missing: string[] = [];
+	for (const plan of plans) {
+		if (!(await isFile(join(rootDir, plan.flatFile)))) {
+			missing.push(`${plan.exportPath}: ${plan.flatFile}`);
+		}
+	}
+	if (missing.length > 0) {
+		throw new Error(
+			`Missing flat entrypoints for package subpaths:\n${missing.join("\n")}`,
+		);
+	}
+}
+
 /**
  * Generate TypeScript declarations for all entry points
  */
-export async function generateTypeScriptDeclarations() {
+export async function generateTypeScriptDeclarations(
+	options: GenerateTypeScriptDeclarationOptions = {},
+) {
 	const fs = await import("node:fs/promises");
 	const { $ } = await import("bun");
 
@@ -1321,22 +1498,6 @@ export async function generateTypeScriptDeclarations() {
 		"dist/roles.js",
 		`// Roles subpath entry point (explicit)\nexport * from './node/roles.js';\n`,
 	);
-	await fs.writeFile(
-		"dist/client-public.js",
-		`// Client-public subpath entry point (explicit)\nexport * from './node/client-public.js';\n`,
-	);
-	await fs.writeFile(
-		"dist/atomic-json.js",
-		`// Atomic-json subpath entry point (explicit)\nexport * from './node/utils/atomic-json.js';\n`,
-	);
-	await fs.writeFile(
-		"dist/security/kms.js",
-		`// Security/kms subpath entry point (explicit)\nexport * from './node/security/kms/index.js';\n`,
-	);
-	await fs.writeFile(
-		"dist/security/mcp-server-config.js",
-		`// Security/mcp-server-config subpath entry point (explicit)\nexport * from './node/security/mcp-server-config.js';\n`,
-	);
 	// Create main index.d.ts to re-export all types from node build
 	// This ensures TypeScript resolves all exports when using moduleResolution: bundler
 	// Note: Use .js extension for NodeNext module resolution compatibility
@@ -1347,59 +1508,15 @@ export async function generateTypeScriptDeclarations() {
 
 	// Ensure testing module directory and declarations exist
 	await fs.mkdir("dist/testing", { recursive: true });
-
-	// Verify all flat entrypoints exist — prevents regressions like #22847
-	// where a subpath export in package.json has no corresponding dist/<subpath>.js
-	//
-	// Strategy: for file-style subpaths whose default/import resolves to a
-	// specific .js file inside a subdirectory (dist/node/..., dist/browser/...),
-	// assert that a flat dist/<subpath>.js exists. Directory-style subpaths
-	// (./node, ./browser, ./edge, ./testing) and wildcards are skipped.
-	const pkg = JSON.parse(
-		await fs.readFile("package.json", "utf-8"),
-	) as { exports?: Record<string, unknown> };
-	const missing: string[] = [];
-	for (const [exportPath, config] of Object.entries(pkg.exports ?? {})) {
-		if (
-			!exportPath.startsWith("./") ||
-			exportPath === "./package.json" ||
-			exportPath.includes("*")
-		) {
-			continue;
-		}
-		const subpath = exportPath.slice(2); // strip ./
-		const flatFile = `dist/${subpath}.js`;
-		if (await fs.stat(flatFile).catch(() => null)) {
-			continue; // flat entrypoint already exists
-		}
-		// Determine if this is a file-style subpath that needs a flat entrypoint.
-		// Extract the default/import path from the export config.
-		const defaultPath =
-			typeof config === "object" && config !== null
-				? (config.default ?? config.import ?? "")
-				: "";
-		if (typeof defaultPath !== "string" || !defaultPath.endsWith(".js")) {
-			continue; // not a file-style export
-		}
-		// Skip directory-style subpaths: if defaultPath resolves to
-		//   dist/<dir>/index.js  or  dist/<dir>/index.<variant>.js
-		// (e.g. dist/node/index.node.js, dist/testing/index.js)
-		// it resolves to a directory, not a flat entrypoint.
-		const relative = defaultPath.replace(/^\.\//, "");
-		const dirIndex = relative.match(/^dist\/[^/]+\/index(?:\.[^.]+)?\.js$/);
-		if (dirIndex) {
-			continue;
-		}
-		// For file-style subpaths the flat entrypoint is mandatory.
-		missing.push(
-			`${exportPath}: flat entrypoint ${flatFile} is missing (build must emit it as a re-export)`,
-		);
-	}
-	if (missing.length > 0) {
-		throw new Error(
-			`Missing flat entrypoints for subpath exports:\n${missing.join("\n")}`,
-		);
-	}
+	const pkg = JSON.parse(await fs.readFile("package.json", "utf-8")) as {
+		exports?: Record<string, unknown>;
+	};
+	const flatEntrypoints = await emitFlatEntrypoints(pkg.exports ?? {}, {
+		excludedExportPaths: options.skipTesting
+			? new Set(["./testing"])
+			: undefined,
+	});
+	await validateFlatEntrypoints(flatEntrypoints);
 
 	const duration = ((Date.now() - startTime) / 1000).toFixed(2);
 	console.log(`✅ TypeScript declarations generated in ${duration}s`);
@@ -1482,6 +1599,97 @@ async function verifyPackedEdgeContract(): Promise<void> {
 		});
 		console.log(
 			"✅ Packed @elizaos/core/edge declarations and runtime import verified",
+		);
+
+		const expectedFlatFiles = [
+			"dist/client-public.js",
+			"dist/atomic-json.js",
+			"dist/security/kms.js",
+			"dist/security/mcp-server-config.js",
+		];
+		for (const flatFile of expectedFlatFiles) {
+			if (!(await isFile(join(packageRoot, flatFile)))) {
+				throw new Error(`packed @elizaos/core is missing ${flatFile}`);
+			}
+		}
+
+		await fs.writeFile(
+			join(contractRoot, "node-flat-consumer.mjs"),
+			[
+				'import * as packageSubpath from "@elizaos/core/client-public";',
+				'import * as flatArtifact from "./node_modules/@elizaos/core/dist/client-public.js";',
+				'for (const name of ["formatError", "isTruthyEnvValue", "resolveAliasedEnvValue", "sanitizeForSettingsDebug", "sanitizeSpeechText"]) {',
+				'  if (typeof packageSubpath[name] !== "function") throw new Error("package subpath is missing " + name);',
+				'  if (packageSubpath[name] !== flatArtifact[name]) throw new Error("flat artifact diverges for " + name);',
+				"}",
+				'if (!packageSubpath.isTruthyEnvValue("yes")) throw new Error("node subpath did not execute");',
+				"",
+			].join("\n"),
+			"utf8",
+		);
+		await execFileAsync("node", ["node-flat-consumer.mjs"], {
+			cwd: contractRoot,
+		});
+
+		const viteCli = join(
+			process.cwd(),
+			"../../node_modules/@elizaos/vitest-vite/bin/vite.js",
+		);
+		for (const mode of ["package-browser", "flat-alias"] as const) {
+			const consumerRoot = join(contractRoot, mode);
+			await fs.mkdir(consumerRoot, { recursive: true });
+			await fs.writeFile(
+				join(consumerRoot, "node-module-browser.js"),
+				[
+					"export function createRequire() {",
+					'  return () => { throw new Error("browser consumer called createRequire"); };',
+					"}",
+					"",
+				].join("\n"),
+				"utf8",
+			);
+			await fs.writeFile(
+				join(consumerRoot, "entry.js"),
+				[
+					'import { isTruthyEnvValue, sanitizeSpeechText } from "@elizaos/core/client-public";',
+					'if (!isTruthyEnvValue("yes")) throw new Error("browser consumer helper did not execute");',
+					'if (sanitizeSpeechText(" hello ") !== "hello") throw new Error("browser consumer speech helper diverged");',
+					"export const verified = true;",
+					"",
+				].join("\n"),
+				"utf8",
+			);
+			const aliases = [
+				`{ find: "node:module", replacement: ${JSON.stringify(join(consumerRoot, "node-module-browser.js"))} }`,
+			];
+			if (mode === "flat-alias") {
+				aliases.push(
+					`{ find: "@elizaos/core/client-public", replacement: ${JSON.stringify(join(packageRoot, "dist/client-public.js"))} }`,
+				);
+			}
+			await fs.writeFile(
+				join(consumerRoot, "vite.config.mjs"),
+				[
+					"export default {",
+					`  resolve: { alias: [${aliases.join(", ")}] },`,
+					'  build: { outDir: "dist", emptyOutDir: true, lib: { entry: "entry.js", formats: ["es"], fileName: () => "bundle.js" } },',
+					'  logLevel: "error",',
+					"};",
+					"",
+				].join("\n"),
+				"utf8",
+			);
+			await execFileAsync(
+				"node",
+				[viteCli, "build", "--config", "vite.config.mjs"],
+				{ cwd: consumerRoot },
+			);
+			await execFileAsync("node", ["dist/bundle.js"], {
+				cwd: consumerRoot,
+			});
+		}
+		console.log(
+			"✅ Packed Node, browser-condition, and exact-flat Vite consumers verified",
 		);
 	} finally {
 		await execFileAsync("node", [RM_RECURSIVE_SCRIPT, contractRoot], {

--- a/packages/core/src/build-flat-entrypoints.test.ts
+++ b/packages/core/src/build-flat-entrypoints.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Verifies the deterministic package-export planner and build orchestration
+ * against nested conditions, deleted artifacts, and node-only skip behavior.
+ * The harness uses temporary files and injected build runners; it does not run
+ * a compiler or import generated product code.
+ */
+import {
+	mkdir,
+	mkdtemp,
+	readFile,
+	rm,
+	unlink,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	buildNodeOnly,
+	emitFlatEntrypoints,
+	planFlatEntrypoints,
+	validateFlatEntrypoints,
+} from "../build";
+
+const temporaryRoots: string[] = [];
+
+async function makeTemporaryRoot(): Promise<string> {
+	const root = await mkdtemp(join(tmpdir(), "eliza-core-flat-entrypoints-"));
+	temporaryRoots.push(root);
+	return root;
+}
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryRoots.splice(0).map((root) => rm(root, { recursive: true })),
+	);
+});
+
+describe("core flat package entrypoints", () => {
+	it("recursively selects runtime fallbacks and computes nested specifiers", () => {
+		const plans = planFlatEntrypoints({
+			"./package.json": "./package.json",
+			"./node": {
+				default: "./dist/node/index.node.js",
+			},
+			"./recursive": {
+				types: "./dist/recursive.d.ts",
+				browser: {
+					import: "./dist/browser/recursive.js",
+				},
+				default: [
+					{
+						custom: {
+							import: "./dist/node/deep/recursive.js",
+						},
+					},
+				],
+			},
+			"./security/kms": {
+				node: {
+					import: "./dist/node/security/kms/index.js",
+				},
+			},
+			"./services/*": "./dist/services/*.js",
+		});
+
+		expect(plans).toEqual([
+			{
+				exportPath: "./recursive",
+				flatFile: "dist/recursive.js",
+				targetFile: "dist/node/deep/recursive.js",
+				moduleSpecifier: "./node/deep/recursive.js",
+			},
+			{
+				exportPath: "./security/kms",
+				flatFile: "dist/security/kms.js",
+				targetFile: "dist/node/security/kms/index.js",
+				moduleSpecifier: "../node/security/kms/index.js",
+			},
+		]);
+	});
+
+	it("fails validation when a generated flat artifact is deleted", async () => {
+		const rootDir = await makeTemporaryRoot();
+		const exportsMap = {
+			"./client-public": {
+				browser: "./dist/browser/client-public.js",
+				default: "./dist/node/client-public.js",
+			},
+			"./security/kms": {
+				default: "./dist/node/security/kms/index.js",
+			},
+		};
+		for (const target of [
+			"dist/node/client-public.js",
+			"dist/node/security/kms/index.js",
+		]) {
+			const absoluteTarget = join(rootDir, target);
+			await mkdir(dirname(absoluteTarget), { recursive: true });
+			await writeFile(absoluteTarget, "export const ok = true;\n", "utf8");
+		}
+
+		const plans = await emitFlatEntrypoints(exportsMap, { rootDir });
+		await validateFlatEntrypoints(plans, { rootDir });
+		expect(
+			await readFile(join(rootDir, "dist/security/kms.js"), "utf8"),
+		).toContain('export * from "../node/security/kms/index.js";');
+
+		await unlink(join(rootDir, "dist/security/kms.js"));
+		await expect(validateFlatEntrypoints(plans, { rootDir })).rejects.toThrow(
+			"./security/kms: dist/security/kms.js",
+		);
+	});
+
+	it("does not build or validate the testing target with --skip-testing", async () => {
+		const outdirs: string[] = [];
+		const declarationOptions: Array<{ skipTesting?: boolean } | undefined> = [];
+
+		await buildNodeOnly({
+			argv: ["bun", "build.ts", "--node-only", "--skip-testing"],
+			runnerFactory: (options) => {
+				outdirs.push(options.buildOptions.outdir ?? "dist");
+				return async () => {};
+			},
+			generateDeclarations: async (options) => {
+				declarationOptions.push(options);
+			},
+		});
+
+		expect(outdirs).toEqual(["dist/node"]);
+		expect(declarationOptions).toEqual([{ skipTesting: true }]);
+	});
+});


### PR DESCRIPTION
## What

Hardens the flat package-entrypoint build contract that #23064 introduced:

- recursively enumerates runtime targets across nested conditional exports and arrays
- emits nested flat entrypoints with correct relative specifiers
- validates the generated flat files after emission
- preserves `--node-only --skip-testing` semantics
- executes packed Node, browser-condition Vite, and exact-flat-alias Vite consumers
- adds an adversarial regression that deletes `dist/security/kms.js` and proves validation fails

Closes #22847.

## Context and credit

This is a corrective follow-up to contributor PR #23064 by @michaelshapkin. That PR supplied the initial flat artifacts and validation and has already merged; this follow-up preserves that work and closes the recursive-condition, nested-specifier, no-op-validation, and executable-consumer gaps found during independent review.

## Evidence

Reviewed head: `4fef2e3bfcfec594ff9eed3233fc4e6b2aafd3d0`

- `node packages/scripts/run-vitest.mjs run packages/core/src/build-flat-entrypoints.test.ts packages/core/src/client-public.duplicate-safe.test.ts` — 2 files, 10 tests passed after final rebase
- `bun run --cwd packages/core build` — Node/browser/edge/testing bundles and declarations passed; packed edge import plus packed Node, browser-condition Vite, and exact-flat Vite consumers executed successfully
- `bun run --cwd packages/core typecheck` — passed
- `bun run --cwd packages/shared build` — passed
- `bun run --cwd packages/shared test` — 159 files, 2,078 tests passed
- `bun run --cwd packages/app build:web` — 9,473 modules transformed; renderer manifest emitted; chunk-safety and viewport verifiers passed
- `bunx @biomejs/biome check packages/core/build.ts packages/core/src/build-flat-entrypoints.test.ts` — passed
- `git diff --check` — passed

The final restack changed no files under the build's core/shared/app inputs; the hardened `build.ts` and regression-test blob IDs remained identical, and the focused acceptance suite was replayed on the final head.

### Existing baseline failures observed

- Full core aggregate testing reproduced failures in current-source message routing, service-collision, PGlite memory, trajectory, action-callsite, and provider-latency suites outside this two-file diff; the lane was stopped after 13 minutes once those failures and a lingering worker were established.
- Shared typecheck reports the current `packages/shared/src/sandbox-registry.test.ts:177` `unknown`-to-`RequestInfo` error; shared build and all 2,078 runtime tests pass.

No UI source changed, so screenshots/video are N/A. The real production app Vite build is the relevant frontend acceptance boundary.

<!-- evidence-head:4fef2e3bfcfec594ff9eed3233fc4e6b2aafd3d0 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI source changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI source changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - build tooling only; no interactive surface changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - package build tooling does not start a backend service

<!-- evidence-row:frontend-logs -->
- [ ] N/A - production Vite compilation is the frontend boundary and emitted no browser session logs

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent behavior or model prompt changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the npm tarball was generated ephemerally and its Node, edge, browser-condition, and exact-flat consumers executed successfully; no persistent artifact belongs in the repository

---
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@8f2b65b02ba3ac67755bbb7d9488255d1625e2d7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@8f2b65b02ba3ac67755bbb7d9488255d1625e2d7:packages/skills/skills/contribute-to-eliza","attribution_status":"self-reported"} -->
