### PR TITLE
fix(security): harden inline output escaping

### DIFF
--- a/packages/agent/src/api/inline-script-serialization.ts
+++ b/packages/agent/src/api/inline-script-serialization.ts
@@ -1,0 +1,19 @@
+/**
+ * Serializes server values for JavaScript literals embedded in HTML script
+ * elements, preserving JSON semantics without allowing an HTML end tag to
+ * terminate the script early.
+ */
+
+/** Serialize a defined value for interpolation into an inline script. */
+export function serializeInlineScriptValue(value: unknown): string {
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    throw new TypeError("Inline script values must be JSON-serializable");
+  }
+  return serialized
+    .replace(/&/g, "\\u0026")
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}

--- a/packages/agent/src/api/static-file-server.test.ts
+++ b/packages/agent/src/api/static-file-server.test.ts
@@ -134,6 +134,50 @@ describe("injectApiBaseIntoHtml token embedding", () => {
     expect(out).toContain("__ELIZA_API_TOKEN__");
   });
 
+  it("keeps script-shaped configuration inside the generated JavaScript literal", () => {
+    const externalBase =
+      'https://agent.example.test/</script><script data-owned="no">alert(1)</script>?x=&';
+    const token =
+      'token</script><script data-owned="no">alert(2)</script>&A\u2028\u2029B';
+    const out = injectApiBaseIntoHtml(Buffer.from(html), externalBase, {
+      apiToken: token,
+      webPushVapidPublicKey: 'vapid</script><img src=x onerror="alert(3)">&',
+    }).toString("utf-8");
+
+    expect(out.match(/<script>/g)).toHaveLength(1);
+    expect(out.match(/<\/script>/g)).toHaveLength(1);
+    expect(out).not.toContain('</script><script data-owned="no">');
+    expect(out).toContain("\\u003c/script\\u003e");
+    expect(out).toContain("\\u0026");
+    expect(out).toContain("\\u2028\\u2029");
+
+    const script = out.slice(
+      out.indexOf("<script>") + "<script>".length,
+      out.indexOf("</script>"),
+    );
+    const store = new Map<string, string>();
+    const localStorage = {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => store.set(key, value),
+    };
+    const win: Record<PropertyKey, unknown> = {};
+    new Function("window", "localStorage", script)(win, localStorage);
+
+    expect(
+      (
+        win.__ELIZAOS_APP_BOOT_CONFIG__ as {
+          apiBase: string;
+          apiToken: string;
+          webPushVapidPublicKey: string;
+        }
+      ).apiBase,
+    ).toBe(externalBase);
+    expect(
+      (win.__ELIZAOS_APP_BOOT_CONFIG__ as { apiToken: string }).apiToken,
+    ).toBe(token);
+    expect(win.__ELIZA_API_TOKEN__).toBe(token);
+  });
+
   // String matching cannot tell a working seed from a syntactically broken one.
   // Run the injected script against a stubbed browser global and assert the
   // state every reader actually consults.

--- a/packages/agent/src/api/static-file-server.ts
+++ b/packages/agent/src/api/static-file-server.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { isTruthyEnvValue, logger, sendJsonError } from "@elizaos/core";
 import { isCloudProvisionedContainer, resolveApiToken } from "@elizaos/shared";
+import { serializeInlineScriptValue } from "./inline-script-serialization.ts";
 import { getOrReadCachedFile } from "./memory-bounds.ts";
 import {
   isPathWithinRoot,
@@ -174,7 +175,7 @@ export function injectApiBaseIntoHtml(
     // transport, and the native web shims resolve this reverse-proxy base
     // through one accessor instead of a bespoke API-base window global.
     parts.push(
-      `(function(){var k=Symbol.for("elizaos.app.boot-config"),w=window,prev=w.__ELIZAOS_APP_BOOT_CONFIG__||(w[k]&&w[k].current)||{},next=Object.assign({},prev,${JSON.stringify(bootOverrides)});w.__ELIZAOS_APP_BOOT_CONFIG__=next;w[k]={current:next};})();`,
+      `(function(){var k=Symbol.for("elizaos.app.boot-config"),w=window,prev=w.__ELIZAOS_APP_BOOT_CONFIG__||(w[k]&&w[k].current)||{},next=Object.assign({},prev,${serializeInlineScriptValue(bootOverrides)});w.__ELIZAOS_APP_BOOT_CONFIG__=next;w[k]={current:next};})();`,
     );
   }
   if (trimmedToken) {
@@ -208,7 +209,7 @@ export function injectApiBaseIntoHtml(
     // suppressing onboarding off the back of it would strand a partially
     // configured self-hosted deployment.
     parts.push(
-      `(function(){var t=${JSON.stringify(trimmedToken)},k=Symbol.for("elizaos.app.boot-config"),w=window,prev=w.__ELIZAOS_APP_BOOT_CONFIG__||(w[k]&&w[k].current)||{},next=Object.assign({},prev,{apiToken:t});w.__ELIZAOS_APP_BOOT_CONFIG__=next;w[k]={current:next};w.__ELIZA_API_TOKEN__=t;try{var sk="elizaos:active-server",sp=null;try{sp=JSON.parse(localStorage.getItem(sk)||"null");}catch(e){sp=null;}if(!sp||typeof sp!=="object"){localStorage.setItem(sk,JSON.stringify({id:"local:embedded",kind:"local",label:"This device",accessToken:t}));}else if(sp.kind==="local"){localStorage.setItem(sk,JSON.stringify(Object.assign({},sp,{accessToken:t})));}}catch(e){}})();`,
+      `(function(){var t=${serializeInlineScriptValue(trimmedToken)},k=Symbol.for("elizaos.app.boot-config"),w=window,prev=w.__ELIZAOS_APP_BOOT_CONFIG__||(w[k]&&w[k].current)||{},next=Object.assign({},prev,{apiToken:t});w.__ELIZAOS_APP_BOOT_CONFIG__=next;w[k]={current:next};w.__ELIZA_API_TOKEN__=t;try{var sk="elizaos:active-server",sp=null;try{sp=JSON.parse(localStorage.getItem(sk)||"null");}catch(e){sp=null;}if(!sp||typeof sp!=="object"){localStorage.setItem(sk,JSON.stringify({id:"local:embedded",kind:"local",label:"This device",accessToken:t}));}else if(sp.kind==="local"){localStorage.setItem(sk,JSON.stringify(Object.assign({},sp,{accessToken:t})));}}catch(e){}})();`,
     );
   }
   const injection = Buffer.from(`<script>${parts.join("")}</script>`);

--- a/packages/app/scripts/mvp-visual-verify.mjs
+++ b/packages/app/scripts/mvp-visual-verify.mjs
@@ -34,6 +34,7 @@ import {
   evaluateExpectations,
   resolveSpec,
 } from "./mvp-visual-verify/expectation-eval.mjs";
+import { renderContactSheet } from "./mvp-visual-verify/html-report.mjs";
 import {
   closeOcrEngines,
   ocrImage,
@@ -411,91 +412,6 @@ export function countExpectationChecks(results, status) {
       r.expectation.checks.filter((check) => check.status === status).length,
     0,
   );
-}
-
-function esc(s) {
-  return String(s)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
-function renderContactSheet(summary, results) {
-  const rows = results
-    .map((r) => {
-      const swatches = r.palette.swatches
-        .map(
-          (s) =>
-            `<span class="sw" title="${esc(s.hex)} ${esc(s.bucket)} ${(s.ratio * 100).toFixed(1)}%" style="background:${esc(s.hex)}">${(s.ratio * 100).toFixed(0)}</span>`,
-        )
-        .join("");
-      const verdict = r.expectation.pass
-        ? '<span class="pass">PASS</span>'
-        : `<span class="fail">FAIL</span>`;
-      const checks = r.expectation.checks
-        .map(
-          (c) =>
-            `<div class="chk ${c.status}">${esc(c.name)}: ${esc(c.detail)}</div>`,
-        )
-        .join("");
-      const ocrCell = r.ocr.available
-        ? `<div class="ocr">${esc(r.ocr.text || "(no glyphs)")}</div><div class="meta">${r.ocr.words} words</div>`
-        : `<div class="na">N/A — ${esc(r.ocr.reason)}</div>`;
-      const diffCell =
-        r.diff.status === "new"
-          ? '<span class="new">NEW baseline</span>'
-          : `${r.diff.changedPercent}% changed${r.diff.resized ? " (resized)" : ""}${r.diff.diffPng ? `<br><img class="thumb" src="${esc(r.diff.diffPng)}">` : ""}`;
-      return `<tr class="${r.expectation.pass ? "" : "row-fail"}">
-        <td class="slug">${esc(r.slug)}<br><span class="meta">${esc(r.viewport)}</span></td>
-        <td><img class="thumb" src="${esc(r.screenshot)}" loading="lazy"></td>
-        <td>${ocrCell}</td>
-        <td class="pal">${swatches}<div class="meta">${Object.entries(
-          r.palette.buckets,
-        )
-          .map(([k, v]) => `${k} ${(v * 100).toFixed(0)}%`)
-          .join(" · ")}</div></td>
-        <td class="diff">${diffCell}</td>
-        <td>${verdict}<div class="checks">${checks}</div></td>
-      </tr>`;
-    })
-    .join("\n");
-  return `<!doctype html><meta charset="utf-8"><title>mvp visual verify</title>
-<style>
-  body{font:13px system-ui,sans-serif;margin:16px;color:#1a1a1a;background:#faf9f7}
-  h1{font-size:18px} .summary{margin:8px 0 16px;padding:8px 12px;background:#fff;border:1px solid #e5e0d8;border-radius:6px}
-  table{border-collapse:collapse;width:100%} td,th{border:1px solid #e5e0d8;padding:6px;vertical-align:top;text-align:left}
-  th{background:#f0ece5;position:sticky;top:0}
-  .thumb{max-width:260px;max-height:180px;border:1px solid #ddd}
-  .slug{font-weight:600;white-space:nowrap} .meta{color:#8a8378;font-size:11px}
-  .ocr{max-width:280px;max-height:160px;overflow:auto;font-size:11px;white-space:pre-wrap;color:#444}
-  .sw{display:inline-block;width:26px;height:26px;line-height:26px;text-align:center;font-size:9px;color:#000;mix-blend-mode:difference;border:1px solid #ccc;margin:1px}
-  .pass{color:#0a7d3c;font-weight:700} .fail{color:#c0392b;font-weight:700} .na{color:#b58900}
-  .row-fail{background:#fff4f2} .checks{margin-top:4px}
-  .chk{font-size:11px;padding:1px 0} .chk.pass{color:#0a7d3c} .chk.fail{color:#c0392b} .chk.skip{color:#8a8378}
-  .new{color:#b58900;font-weight:600} .missing{margin-top:6px;color:#c0392b;font-weight:600}
-</style>
-<h1>mvp visual verify</h1>
-<div class="summary">
-  ${esc(summary.states)} states · OCR: ${esc(summary.ocrEngine)} · expectation failures: <b>${summary.expectationFailures}</b> ·
-  skipped checks: <b>${summary.expectationSkips}</b> · missing required states: <b>${summary.missingRequiredStates.length}</b> · overflow states: <b>${summary.overflowStates}</b> ·
-  new baselines: ${summary.newBaselines} · audit report: ${summary.auditReportPresent ? "loaded" : "ABSENT"} ·
-  baseline: ${esc(summary.baselineDir)} · ${esc(summary.generatedAt)}
-  ${
-    summary.missingRequiredStates.length
-      ? `<div class="missing">Missing required: ${esc(
-          summary.missingRequiredStates
-            .map((state) =>
-              state.viewport ? `${state.slug}@${state.viewport}` : state.slug,
-            )
-            .join(", "),
-        )}</div>`
-      : ""
-  }
-</div>
-<table>
-  <tr><th>state</th><th>screenshot</th><th>OCR text</th><th>palette</th><th>diff vs baseline</th><th>expectations</th></tr>
-  ${rows}
-</table>`;
 }
 
 if (

--- a/packages/app/scripts/mvp-visual-verify.test.mjs
+++ b/packages/app/scripts/mvp-visual-verify.test.mjs
@@ -48,7 +48,7 @@ describe("contact-sheet HTML serialization", () => {
           ocr: { available: true, text: payload, words: 1 },
           palette: {
             swatches: [{ hex: payload, bucket: payload, ratio: 0.5 }],
-            buckets: { orange: 1 },
+            buckets: { [payload]: 1 },
           },
           diff: {
             status: "compared",
@@ -58,7 +58,7 @@ describe("contact-sheet HTML serialization", () => {
           },
           expectation: {
             pass: true,
-            checks: [{ status: "pass", name: payload, detail: payload }],
+            checks: [{ status: payload, name: payload, detail: payload }],
           },
         },
       ],
@@ -66,7 +66,9 @@ describe("contact-sheet HTML serialization", () => {
 
     expect(html).not.toContain("<script data-owned");
     expect(html).not.toContain(' onmouseover="alert(1)');
+    expect(html).not.toContain(`class="chk ${payload}`);
     expect(html).not.toContain("background:&quot;");
+    expect(html).toContain('class="chk unknown"');
     expect(html).toContain('style="background:transparent"');
     expect(html).toContain("&quot; onmouseover=&quot;alert(1) &amp;");
   });

--- a/packages/app/scripts/mvp-visual-verify.test.mjs
+++ b/packages/app/scripts/mvp-visual-verify.test.mjs
@@ -1,0 +1,73 @@
+/**
+ * Exercises the deterministic contact-sheet HTML boundary with adversarial
+ * report strings; image, OCR, and browser capture integrations are not mocked
+ * because this suite targets only serialization of an already-built report.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  contactSheetSwatchColor,
+  escapeContactSheetHtml,
+  renderContactSheet,
+} from "./mvp-visual-verify/html-report.mjs";
+
+describe("contact-sheet HTML serialization", () => {
+  test("escapes text and quoted-attribute metacharacters", () => {
+    expect(escapeContactSheetHtml(`<tag a="b" c='d'>&`)).toBe(
+      "&lt;tag a=&quot;b&quot; c=&#039;d&#039;&gt;&amp;",
+    );
+  });
+
+  test("allows only six-digit hex colors in inline styles", () => {
+    expect(contactSheetSwatchColor("#aBc123")).toBe("#aBc123");
+    expect(contactSheetSwatchColor('#fff;" onmouseover="alert(1)')).toBe(
+      "transparent",
+    );
+  });
+
+  test("keeps quotes, ampersands, and style payloads inside report data", () => {
+    const payload = `" onmouseover="alert(1) & <script data-owned='no'>`;
+    const html = renderContactSheet(
+      {
+        states: 1,
+        ocrEngine: payload,
+        expectationFailures: 0,
+        expectationSkips: 0,
+        missingRequiredStates: [],
+        overflowStates: 0,
+        newBaselines: 0,
+        auditReportPresent: true,
+        baselineDir: payload,
+        generatedAt: payload,
+      },
+      [
+        {
+          slug: payload,
+          viewport: payload,
+          screenshot: `shot-${payload}.png`,
+          ocr: { available: true, text: payload, words: 1 },
+          palette: {
+            swatches: [{ hex: payload, bucket: payload, ratio: 0.5 }],
+            buckets: { orange: 1 },
+          },
+          diff: {
+            status: "compared",
+            changedPercent: 0,
+            resized: false,
+            diffPng: `diff-${payload}.png`,
+          },
+          expectation: {
+            pass: true,
+            checks: [{ status: "pass", name: payload, detail: payload }],
+          },
+        },
+      ],
+    );
+
+    expect(html).not.toContain("<script data-owned");
+    expect(html).not.toContain(' onmouseover="alert(1)');
+    expect(html).not.toContain("background:&quot;");
+    expect(html).toContain('style="background:transparent"');
+    expect(html).toContain("&quot; onmouseover=&quot;alert(1) &amp;");
+  });
+});

--- a/packages/app/scripts/mvp-visual-verify/html-report.mjs
+++ b/packages/app/scripts/mvp-visual-verify/html-report.mjs
@@ -17,6 +17,12 @@ export function contactSheetSwatchColor(value) {
   return /^#[0-9a-f]{6}$/i.test(String(value)) ? String(value) : "transparent";
 }
 
+function contactSheetCheckClass(value) {
+  return value === "pass" || value === "fail" || value === "skip"
+    ? value
+    : "unknown";
+}
+
 export function renderContactSheet(summary, results) {
   const rows = results
     .map((result) => {
@@ -32,16 +38,16 @@ export function renderContactSheet(summary, results) {
       const checks = result.expectation.checks
         .map(
           (check) =>
-            `<div class="chk ${check.status}">${escapeContactSheetHtml(check.name)}: ${escapeContactSheetHtml(check.detail)}</div>`,
+            `<div class="chk ${contactSheetCheckClass(check.status)}">${escapeContactSheetHtml(check.name)}: ${escapeContactSheetHtml(check.detail)}</div>`,
         )
         .join("");
       const ocrCell = result.ocr.available
-        ? `<div class="ocr">${escapeContactSheetHtml(result.ocr.text || "(no glyphs)")}</div><div class="meta">${result.ocr.words} words</div>`
+        ? `<div class="ocr">${escapeContactSheetHtml(result.ocr.text || "(no glyphs)")}</div><div class="meta">${escapeContactSheetHtml(result.ocr.words)} words</div>`
         : `<div class="na">N/A — ${escapeContactSheetHtml(result.ocr.reason)}</div>`;
       const diffCell =
         result.diff.status === "new"
           ? '<span class="new">NEW baseline</span>'
-          : `${result.diff.changedPercent}% changed${result.diff.resized ? " (resized)" : ""}${result.diff.diffPng ? `<br><img class="thumb" src="${escapeContactSheetHtml(result.diff.diffPng)}">` : ""}`;
+          : `${escapeContactSheetHtml(result.diff.changedPercent)}% changed${result.diff.resized ? " (resized)" : ""}${result.diff.diffPng ? `<br><img class="thumb" src="${escapeContactSheetHtml(result.diff.diffPng)}">` : ""}`;
       return `<tr class="${result.expectation.pass ? "" : "row-fail"}">
         <td class="slug">${escapeContactSheetHtml(result.slug)}<br><span class="meta">${escapeContactSheetHtml(result.viewport)}</span></td>
         <td><img class="thumb" src="${escapeContactSheetHtml(result.screenshot)}" loading="lazy"></td>
@@ -49,7 +55,10 @@ export function renderContactSheet(summary, results) {
         <td class="pal">${swatches}<div class="meta">${Object.entries(
           result.palette.buckets,
         )
-          .map(([key, value]) => `${key} ${(value * 100).toFixed(0)}%`)
+          .map(
+            ([key, value]) =>
+              `${escapeContactSheetHtml(key)} ${escapeContactSheetHtml((value * 100).toFixed(0))}%`,
+          )
           .join(" · ")}</div></td>
         <td class="diff">${diffCell}</td>
         <td>${verdict}<div class="checks">${checks}</div></td>
@@ -73,9 +82,9 @@ export function renderContactSheet(summary, results) {
 </style>
 <h1>mvp visual verify</h1>
 <div class="summary">
-  ${escapeContactSheetHtml(summary.states)} states · OCR: ${escapeContactSheetHtml(summary.ocrEngine)} · expectation failures: <b>${summary.expectationFailures}</b> ·
-  skipped checks: <b>${summary.expectationSkips}</b> · missing required states: <b>${summary.missingRequiredStates.length}</b> · overflow states: <b>${summary.overflowStates}</b> ·
-  new baselines: ${summary.newBaselines} · audit report: ${summary.auditReportPresent ? "loaded" : "ABSENT"} ·
+  ${escapeContactSheetHtml(summary.states)} states · OCR: ${escapeContactSheetHtml(summary.ocrEngine)} · expectation failures: <b>${escapeContactSheetHtml(summary.expectationFailures)}</b> ·
+  skipped checks: <b>${escapeContactSheetHtml(summary.expectationSkips)}</b> · missing required states: <b>${escapeContactSheetHtml(summary.missingRequiredStates.length)}</b> · overflow states: <b>${escapeContactSheetHtml(summary.overflowStates)}</b> ·
+  new baselines: ${escapeContactSheetHtml(summary.newBaselines)} · audit report: ${summary.auditReportPresent ? "loaded" : "ABSENT"} ·
   baseline: ${escapeContactSheetHtml(summary.baselineDir)} · ${escapeContactSheetHtml(summary.generatedAt)}
   ${
     summary.missingRequiredStates.length

--- a/packages/app/scripts/mvp-visual-verify/html-report.mjs
+++ b/packages/app/scripts/mvp-visual-verify/html-report.mjs
@@ -1,0 +1,96 @@
+/**
+ * Renders visual-verification results as a standalone contact sheet. All
+ * report strings cross one HTML boundary here, while style values use a
+ * narrower allowlist instead of HTML escaping.
+ */
+
+export function escapeContactSheetHtml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+export function contactSheetSwatchColor(value) {
+  return /^#[0-9a-f]{6}$/i.test(String(value)) ? String(value) : "transparent";
+}
+
+export function renderContactSheet(summary, results) {
+  const rows = results
+    .map((result) => {
+      const swatches = result.palette.swatches
+        .map(
+          (swatch) =>
+            `<span class="sw" title="${escapeContactSheetHtml(swatch.hex)} ${escapeContactSheetHtml(swatch.bucket)} ${(swatch.ratio * 100).toFixed(1)}%" style="background:${contactSheetSwatchColor(swatch.hex)}">${(swatch.ratio * 100).toFixed(0)}</span>`,
+        )
+        .join("");
+      const verdict = result.expectation.pass
+        ? '<span class="pass">PASS</span>'
+        : '<span class="fail">FAIL</span>';
+      const checks = result.expectation.checks
+        .map(
+          (check) =>
+            `<div class="chk ${check.status}">${escapeContactSheetHtml(check.name)}: ${escapeContactSheetHtml(check.detail)}</div>`,
+        )
+        .join("");
+      const ocrCell = result.ocr.available
+        ? `<div class="ocr">${escapeContactSheetHtml(result.ocr.text || "(no glyphs)")}</div><div class="meta">${result.ocr.words} words</div>`
+        : `<div class="na">N/A — ${escapeContactSheetHtml(result.ocr.reason)}</div>`;
+      const diffCell =
+        result.diff.status === "new"
+          ? '<span class="new">NEW baseline</span>'
+          : `${result.diff.changedPercent}% changed${result.diff.resized ? " (resized)" : ""}${result.diff.diffPng ? `<br><img class="thumb" src="${escapeContactSheetHtml(result.diff.diffPng)}">` : ""}`;
+      return `<tr class="${result.expectation.pass ? "" : "row-fail"}">
+        <td class="slug">${escapeContactSheetHtml(result.slug)}<br><span class="meta">${escapeContactSheetHtml(result.viewport)}</span></td>
+        <td><img class="thumb" src="${escapeContactSheetHtml(result.screenshot)}" loading="lazy"></td>
+        <td>${ocrCell}</td>
+        <td class="pal">${swatches}<div class="meta">${Object.entries(
+          result.palette.buckets,
+        )
+          .map(([key, value]) => `${key} ${(value * 100).toFixed(0)}%`)
+          .join(" · ")}</div></td>
+        <td class="diff">${diffCell}</td>
+        <td>${verdict}<div class="checks">${checks}</div></td>
+      </tr>`;
+    })
+    .join("\n");
+  return `<!doctype html><meta charset="utf-8"><title>mvp visual verify</title>
+<style>
+  body{font:13px system-ui,sans-serif;margin:16px;color:#1a1a1a;background:#faf9f7}
+  h1{font-size:18px} .summary{margin:8px 0 16px;padding:8px 12px;background:#fff;border:1px solid #e5e0d8;border-radius:6px}
+  table{border-collapse:collapse;width:100%} td,th{border:1px solid #e5e0d8;padding:6px;vertical-align:top;text-align:left}
+  th{background:#f0ece5;position:sticky;top:0}
+  .thumb{max-width:260px;max-height:180px;border:1px solid #ddd}
+  .slug{font-weight:600;white-space:nowrap} .meta{color:#8a8378;font-size:11px}
+  .ocr{max-width:280px;max-height:160px;overflow:auto;font-size:11px;white-space:pre-wrap;color:#444}
+  .sw{display:inline-block;width:26px;height:26px;line-height:26px;text-align:center;font-size:9px;color:#000;mix-blend-mode:difference;border:1px solid #ccc;margin:1px}
+  .pass{color:#0a7d3c;font-weight:700} .fail{color:#c0392b;font-weight:700} .na{color:#b58900}
+  .row-fail{background:#fff4f2} .checks{margin-top:4px}
+  .chk{font-size:11px;padding:1px 0} .chk.pass{color:#0a7d3c} .chk.fail{color:#c0392b} .chk.skip{color:#8a8378}
+  .new{color:#b58900;font-weight:600} .missing{margin-top:6px;color:#c0392b;font-weight:600}
+</style>
+<h1>mvp visual verify</h1>
+<div class="summary">
+  ${escapeContactSheetHtml(summary.states)} states · OCR: ${escapeContactSheetHtml(summary.ocrEngine)} · expectation failures: <b>${summary.expectationFailures}</b> ·
+  skipped checks: <b>${summary.expectationSkips}</b> · missing required states: <b>${summary.missingRequiredStates.length}</b> · overflow states: <b>${summary.overflowStates}</b> ·
+  new baselines: ${summary.newBaselines} · audit report: ${summary.auditReportPresent ? "loaded" : "ABSENT"} ·
+  baseline: ${escapeContactSheetHtml(summary.baselineDir)} · ${escapeContactSheetHtml(summary.generatedAt)}
+  ${
+    summary.missingRequiredStates.length
+      ? `<div class="missing">Missing required: ${escapeContactSheetHtml(
+          summary.missingRequiredStates
+            .map((state) =>
+              state.viewport ? `${state.slug}@${state.viewport}` : state.slug,
+            )
+            .join(", "),
+        )}</div>`
+      : ""
+  }
+</div>
+<table>
+  <tr><th>state</th><th>screenshot</th><th>OCR text</th><th>palette</th><th>diff vs baseline</th><th>expectations</th></tr>
+  ${rows}
+</table>`;
+}

--- a/packages/cloud/shared/src/lib/services/agent-github-return.ts
+++ b/packages/cloud/shared/src/lib/services/agent-github-return.ts
@@ -1,5 +1,5 @@
-// Coordinates cloud service agent github return behavior behind route handlers.
-import { escapeHtml } from "../utils/html";
+/** Coordinates Cloud agent GitHub return behavior behind route handlers. */
+import { escapeHtml, serializeInlineScriptValue } from "../utils/html";
 import type { ManagedAgentGithubMode } from "./eliza-agent-config";
 
 export const LIFEOPS_GITHUB_POST_MESSAGE_TYPE = "agent-lifeops-github-complete";
@@ -13,10 +13,6 @@ export interface LifeOpsGithubReturnDetail {
   bindingMode?: ManagedAgentGithubMode | null;
   message?: string | null;
   restarted?: boolean;
-}
-
-function serializeInlineScriptValue(value: unknown): string {
-  return JSON.stringify(value).replace(/</g, "\\u003c");
 }
 
 export function normalizePostMessageTargetOrigin(value: string | null | undefined): string | null {

--- a/packages/cloud/shared/src/lib/services/app-frontend-hosting.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-frontend-hosting.test.ts
@@ -163,6 +163,20 @@ describe("injectBeacon", () => {
     expect(out).toContain("visitor_id:v");
     expect(out).toContain("session_id:sid");
   });
+  test("keeps every script-shaped beacon value inside its JavaScript literal", () => {
+    const breakout = '</script><script data-owned="no">alert(1)</script>&\u2028\u2029';
+    const out = injectBeacon("<body></body>", `app-${breakout}`, `https://site.test/${breakout}`, {
+      visitorId: `visitor-${breakout}`,
+      sessionId: `session-${breakout}`,
+    });
+
+    expect(out.match(/<script>/g)).toHaveLength(1);
+    expect(out.match(/<\/script>/g)).toHaveLength(1);
+    expect(out).not.toContain('</script><script data-owned="no">');
+    expect(out).toContain("\\u003c/script\\u003e");
+    expect(out).toContain("\\u0026");
+    expect(out).toContain("\\u2028\\u2029");
+  });
   test("no-op without a body", () => {
     expect(injectBeacon("<div></div>", "app-123")).toBe("<div></div>");
   });

--- a/packages/cloud/shared/src/lib/services/app-frontend-hosting.ts
+++ b/packages/cloud/shared/src/lib/services/app-frontend-hosting.ts
@@ -26,6 +26,7 @@ import type {
 } from "../../db/schemas/app-frontend-deployments";
 import { ObjectNamespaces } from "../storage/object-namespace";
 import { getRuntimeR2Bucket } from "../storage/r2-runtime-binding";
+import { serializeInlineScriptValue } from "../utils/html";
 import { logger } from "../utils/logger";
 
 /** A file to publish. `content` is UTF-8 text unless `encoding: "base64"`. */
@@ -535,7 +536,7 @@ export function injectSeo(html: string, seo: FrontendSeo): string {
   }
   if (seo.jsonLd && !lower.includes("application/ld+json")) {
     tags.push(
-      `<script type="application/ld+json">${JSON.stringify(seo.jsonLd).replace(/</g, "\\u003c")}</script>`,
+      `<script type="application/ld+json">${serializeInlineScriptValue(seo.jsonLd)}</script>`,
     );
   }
 
@@ -560,7 +561,7 @@ export function injectBeacon(
   const bodyClose = /<\/body\s*>/i;
   if (!bodyClose.test(html)) return html;
   const url = `${(beaconBase ?? "").replace(/\/$/, "")}/api/v1/track/pageview`;
-  const script = `<script>(function(){var vk="eliza_visitor_id",sk="eliza_session_id";function id(){try{return crypto.randomUUID()}catch(e){return "v-"+Date.now().toString(36)+"-"+Math.random().toString(36).slice(2)}}function g(k,s,f){try{var x=s.getItem(k);if(!x){x=f||id();s.setItem(k,x)}return x}catch(e){return f||id()}}var v=g(vk,localStorage,${JSON.stringify(analytics?.visitorId ?? "")});var sid=g(sk,sessionStorage,${JSON.stringify(analytics?.sessionId ?? "")});function s(){try{var d={app_id:${JSON.stringify(appId)},visitor_id:v,session_id:sid,page_url:location.pathname+location.search,referrer:document.referrer,pathname:location.pathname,screen_width:screen.width,screen_height:screen.height};navigator.sendBeacon(${JSON.stringify(url)},new Blob([JSON.stringify(d)],{type:"text/plain"}));}catch(e){}}var p=history.pushState,r=history.replaceState;history.pushState=function(){p.apply(this,arguments);s();};history.replaceState=function(){r.apply(this,arguments);s();};addEventListener("popstate",s);})();</script>`;
+  const script = `<script>(function(){var vk="eliza_visitor_id",sk="eliza_session_id";function id(){try{return crypto.randomUUID()}catch(e){return "v-"+Date.now().toString(36)+"-"+Math.random().toString(36).slice(2)}}function g(k,s,f){try{var x=s.getItem(k);if(!x){x=f||id();s.setItem(k,x)}return x}catch(e){return f||id()}}var v=g(vk,localStorage,${serializeInlineScriptValue(analytics?.visitorId ?? "")});var sid=g(sk,sessionStorage,${serializeInlineScriptValue(analytics?.sessionId ?? "")});function s(){try{var d={app_id:${serializeInlineScriptValue(appId)},visitor_id:v,session_id:sid,page_url:location.pathname+location.search,referrer:document.referrer,pathname:location.pathname,screen_width:screen.width,screen_height:screen.height};navigator.sendBeacon(${serializeInlineScriptValue(url)},new Blob([JSON.stringify(d)],{type:"text/plain"}));}catch(e){}}var p=history.pushState,r=history.replaceState;history.pushState=function(){p.apply(this,arguments);s();};history.replaceState=function(){r.apply(this,arguments);s();};addEventListener("popstate",s);})();</script>`;
   return html.replace(bodyClose, `${script}</body>`);
 }
 

--- a/packages/cloud/shared/src/lib/utils/html.ts
+++ b/packages/cloud/shared/src/lib/utils/html.ts
@@ -1,3 +1,5 @@
+/** Encodes Cloud response values at HTML text, attribute, and script boundaries. */
+
 /** Escape a string for safe interpolation into HTML text/attributes. */
 export function escapeHtml(value: string): string {
   return value
@@ -6,4 +8,22 @@ export function escapeHtml(value: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#039;");
+}
+
+/**
+ * Serialize a defined value for a JavaScript literal inside an HTML script
+ * element. JSON quoting alone does not prevent a literal `</script>` from
+ * terminating the element before the JavaScript parser sees the string.
+ */
+export function serializeInlineScriptValue(value: unknown): string {
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    throw new TypeError("Inline script values must be JSON-serializable");
+  }
+  return serialized
+    .replace(/&/g, "\\u0026")
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
 }


### PR DESCRIPTION
## Summary

- escape inline-script values across agent and cloud HTML boundaries, including HTML end-tag and JavaScript line-separator characters
- route cloud JSON-LD, GitHub return, and beacon payloads through the shared safe serializer
- escape contact-sheet text and attributes, allowlist status class tokens, constrain CSS colors, and normalize summary scalars
- add adversarial breakout, quote, ampersand, status, palette-key, and malformed-value render tests

This fixes CodeQL alerts #949-#952, #1018-#1021, #1079, and #1080 tracked in #22087 without adding CodeQL to pull-request workflows.

## Verification

- exact-head focused tests: 61 passed across agent static serving, cloud hosting/GitHub return, and contact-sheet rendering
- cloud-shared typecheck passed
- agent build and current core Node/browser/edge/declaration/packed-consumer build passed
- targeted Biome passed all 10 changed files; `git diff --check` passed
- agent and app typechecks currently stop on the same unrelated current-base error at `packages/agent/src/services/e2b-capability-router.ts:363` (`requestTimeoutMs` missing from `RemoteRunnerHttpClient`); no changed file is diagnosed
- the prior head's hosted Format, lint, and consolidated frontend build jobs passed; its UI-determinism job failed only on two unrelated `Date.now()` calls in `packages/ui/src/cloud/monetization/earnings/EarningsPageClient.tsx`

Independent source review approved the repaired escaping boundaries before this base-only rebase. Exact-head hosted CI, CodeQL, and renewed review remain required before merge.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@9b9d0fbdff7921c4338363e9c2cbb21594d6c4f7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@9b9d0fbdff7921c4338363e9c2cbb21594d6c4f7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-codeql]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@9b9d0fbdff7921c4338363e9c2cbb21594d6c4f7:packages/skills/skills/contribute-to-eliza"} -->

## Evidence Gate

<!-- evidence-head:9b9d0fbdff7921c4338363e9c2cbb21594d6c4f7 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered product pixels or layout changed; the app change is an offline verification-report generator.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered product pixels or layout changed; the app change is an offline verification-report generator.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no product interaction flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - focused HTML-boundary tests are documented above; no protected backend was mutated.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no rendered product state or browser-network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no production prompt, model selection, or model-output behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact adversarial render tests are documented above; no separate runtime artifact was produced.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no product pixels changed.
