### PR TITLE
test(core): make planner-continuation evidence await terminal trajectory persistence

### DIFF
--- a/packages/core/src/__tests__/planner-continuation-trajectory.test.ts
+++ b/packages/core/src/__tests__/planner-continuation-trajectory.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Exercises the planner-continuation evidence barrier with the real
+ * post-delivery tracker and deterministic delayed and nested terminal work.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+	drainPostDeliveryTasks,
+	trackPostDeliveryTask,
+} from "../services/post-delivery-task-tracker.ts";
+import type { IAgentRuntime } from "../types/runtime.ts";
+import {
+	type PlannerContinuationTrajectoryDetail,
+	readCompletedPlannerContinuationTrajectory,
+} from "./planner-continuation-trajectory.ts";
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve!: () => void;
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+function runtimeStub(): Pick<IAgentRuntime, "agentId" | "reportError"> {
+	return {
+		agentId: "00000000-0000-4000-8000-000000000045",
+		reportError: vi.fn(),
+	};
+}
+
+function trajectoryService(
+	readDetail: () => PlannerContinuationTrajectoryDetail | null,
+) {
+	const calls: string[] = [];
+	return {
+		calls,
+		flushWriteQueue: vi.fn(async (trajectoryId: string) => {
+			calls.push(`flush:${trajectoryId}`);
+		}),
+		getTrajectoryDetail: vi.fn(async (trajectoryId: string) => {
+			calls.push(`read:${trajectoryId}`);
+			return readDetail();
+		}),
+	};
+}
+
+describe("planner continuation trajectory persistence barrier", () => {
+	it("waits for delayed terminalization before one flush and one read", async () => {
+		const runtime = runtimeStub();
+		const terminalGate = deferred();
+		const taskStarted = deferred();
+		let detail: PlannerContinuationTrajectoryDetail = {
+			metrics: { finalStatus: "active" },
+		};
+		trackPostDeliveryTask(runtime, "delayed-terminal", async () => {
+			taskStarted.resolve();
+			await terminalGate.promise;
+			detail = { metrics: { finalStatus: "completed" } };
+		});
+		const service = trajectoryService(() => detail);
+
+		const read = readCompletedPlannerContinuationTrajectory(
+			runtime,
+			"trajectory-delayed",
+			service,
+		);
+		await taskStarted.promise;
+		expect(service.flushWriteQueue).not.toHaveBeenCalled();
+		expect(service.getTrajectoryDetail).not.toHaveBeenCalled();
+
+		terminalGate.resolve();
+		await expect(read).resolves.toEqual({
+			metrics: { finalStatus: "completed" },
+		});
+		expect(service.flushWriteQueue).toHaveBeenCalledOnce();
+		expect(service.flushWriteQueue).toHaveBeenCalledWith("trajectory-delayed");
+		expect(service.getTrajectoryDetail).toHaveBeenCalledOnce();
+		expect(service.getTrajectoryDetail).toHaveBeenCalledWith(
+			"trajectory-delayed",
+		);
+		expect(service.calls).toEqual([
+			"flush:trajectory-delayed",
+			"read:trajectory-delayed",
+		]);
+	});
+
+	it("drains separately gated nested tracked work before persistence", async () => {
+		const runtime = runtimeStub();
+		const nestedGate = deferred();
+		const nestedStarted = deferred();
+		let detail: PlannerContinuationTrajectoryDetail = {
+			metrics: { finalStatus: "active" },
+		};
+		const outer = trackPostDeliveryTask(runtime, "outer-terminal", async () => {
+			trackPostDeliveryTask(runtime, "nested-terminal", async () => {
+				nestedStarted.resolve();
+				await nestedGate.promise;
+				detail = { metrics: { finalStatus: "completed" } };
+			});
+		});
+		const service = trajectoryService(() => detail);
+		const read = readCompletedPlannerContinuationTrajectory(
+			runtime,
+			"trajectory-nested",
+			service,
+		);
+
+		await nestedStarted.promise;
+		await outer;
+		expect(service.flushWriteQueue).not.toHaveBeenCalled();
+		expect(service.getTrajectoryDetail).not.toHaveBeenCalled();
+
+		nestedGate.resolve();
+		await expect(read).resolves.toEqual({
+			metrics: { finalStatus: "completed" },
+		});
+		expect(service.flushWriteQueue).toHaveBeenCalledTimes(1);
+		expect(service.getTrajectoryDetail).toHaveBeenCalledTimes(1);
+		await expect(drainPostDeliveryTasks(runtime)).resolves.toBe(0);
+	});
+
+	it("rejects a missing detail after exactly one flush and one read", async () => {
+		const runtime = runtimeStub();
+		const service = trajectoryService(() => null);
+
+		await expect(
+			readCompletedPlannerContinuationTrajectory(
+				runtime,
+				"trajectory-missing",
+				service,
+			),
+		).rejects.toThrow('trajectory "trajectory-missing" was not persisted');
+		expect(service.flushWriteQueue).toHaveBeenCalledTimes(1);
+		expect(service.getTrajectoryDetail).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects a nonterminal detail and names its observed status", async () => {
+		const runtime = runtimeStub();
+		const service = trajectoryService(() => ({
+			metrics: { finalStatus: "active" },
+		}));
+
+		await expect(
+			readCompletedPlannerContinuationTrajectory(
+				runtime,
+				"trajectory-active",
+				service,
+			),
+		).rejects.toThrow(
+			'trajectory "trajectory-active" is not completed (observed: active)',
+		);
+		expect(service.flushWriteQueue).toHaveBeenCalledTimes(1);
+		expect(service.getTrajectoryDetail).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects blank ids and incomplete trajectory services as harness errors", async () => {
+		const runtime = runtimeStub();
+		const completeService = trajectoryService(() => ({
+			metrics: { finalStatus: "completed" },
+		}));
+
+		await expect(
+			readCompletedPlannerContinuationTrajectory(
+				runtime,
+				"  ",
+				completeService,
+			),
+		).rejects.toThrow("trajectoryId must be non-empty");
+		await expect(
+			readCompletedPlannerContinuationTrajectory(runtime, "trajectory-id", {
+				getTrajectoryDetail: completeService.getTrajectoryDetail,
+			}),
+		).rejects.toThrow("requires flushWriteQueue");
+		await expect(
+			readCompletedPlannerContinuationTrajectory(runtime, "trajectory-id", {
+				flushWriteQueue: completeService.flushWriteQueue,
+			}),
+		).rejects.toThrow("requires getTrajectoryDetail");
+		expect(completeService.flushWriteQueue).not.toHaveBeenCalled();
+		expect(completeService.getTrajectoryDetail).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/src/__tests__/planner-continuation-trajectory.ts
+++ b/packages/core/src/__tests__/planner-continuation-trajectory.ts
@@ -1,0 +1,78 @@
+/**
+ * Provides the causal persistence barrier used by planner-continuation
+ * evidence after visible message delivery has completed.
+ */
+
+import { drainPostDeliveryTasks } from "../services/post-delivery-task-tracker.ts";
+import type { IAgentRuntime } from "../types/runtime.ts";
+
+export interface PlannerContinuationTrajectoryDetail {
+	metrics?: { finalStatus?: string };
+}
+
+interface PlannerContinuationTrajectoryService<
+	TDetail extends PlannerContinuationTrajectoryDetail,
+> {
+	flushWriteQueue(trajectoryId: string): Promise<void>;
+	getTrajectoryDetail(trajectoryId: string): Promise<TDetail | null>;
+}
+
+type PlannerContinuationRuntime = Pick<
+	IAgentRuntime,
+	"agentId" | "reportError"
+> &
+	Partial<Pick<IAgentRuntime, "roomHandlerQueue">>;
+
+function requireTrajectoryService<
+	TDetail extends PlannerContinuationTrajectoryDetail,
+>(service: unknown): PlannerContinuationTrajectoryService<TDetail> {
+	if (
+		typeof service !== "object" ||
+		service === null ||
+		typeof (service as { flushWriteQueue?: unknown }).flushWriteQueue !==
+			"function"
+	) {
+		throw new Error(
+			"Planner continuation trajectory service requires flushWriteQueue(trajectoryId)",
+		);
+	}
+	if (
+		typeof (service as { getTrajectoryDetail?: unknown })
+			.getTrajectoryDetail !== "function"
+	) {
+		throw new Error(
+			"Planner continuation trajectory service requires getTrajectoryDetail(trajectoryId)",
+		);
+	}
+	return service as PlannerContinuationTrajectoryService<TDetail>;
+}
+
+/** Drain terminal work, flush its queued write once, then read one terminal row. */
+export async function readCompletedPlannerContinuationTrajectory<
+	TDetail extends PlannerContinuationTrajectoryDetail,
+>(
+	runtime: PlannerContinuationRuntime,
+	trajectoryId: string,
+	service: unknown,
+): Promise<TDetail> {
+	if (typeof trajectoryId !== "string" || !trajectoryId.trim()) {
+		throw new Error("Planner continuation trajectoryId must be non-empty");
+	}
+	const trajectoryService = requireTrajectoryService<TDetail>(service);
+
+	await drainPostDeliveryTasks(runtime);
+	await trajectoryService.flushWriteQueue(trajectoryId);
+	const detail = await trajectoryService.getTrajectoryDetail(trajectoryId);
+	if (!detail) {
+		throw new Error(
+			`Planner continuation trajectory "${trajectoryId}" was not persisted after post-delivery drain`,
+		);
+	}
+	const finalStatus = detail.metrics?.finalStatus;
+	if (finalStatus !== "completed") {
+		throw new Error(
+			`Planner continuation trajectory "${trajectoryId}" is not completed (observed: ${finalStatus ?? "missing"})`,
+		);
+	}
+	return detail;
+}

--- a/packages/core/src/__tests__/planner-continuation.live.test.ts
+++ b/packages/core/src/__tests__/planner-continuation.live.test.ts
@@ -18,22 +18,17 @@ import {
 	createRealTestRuntime,
 	type RealTestRuntimeResult,
 } from "../testing/index.ts";
+import { readCompletedPlannerContinuationTrajectory } from "./planner-continuation-trajectory.ts";
 
 interface LiveTrajectoryDetail {
 	metrics?: { finalStatus?: string };
 	steps?: Array<{
 		llmCalls?: Array<{
 			provider?: string;
+			model?: string;
 			response?: string;
 		}>;
 	}>;
-}
-
-interface LiveTrajectoryService {
-	flushWriteQueue?: (trajectoryId: string) => Promise<void>;
-	getTrajectoryDetail?: (
-		trajectoryId: string,
-	) => Promise<LiveTrajectoryDetail | null>;
 }
 
 const liveDescribe =
@@ -112,7 +107,8 @@ liveDescribe("planner continuation — live Cerebras message loop", () => {
 					{
 						provider: harness.providerName,
 						baseUrl: harness.providerConfig?.baseUrl,
-						model: harness.providerConfig?.model,
+						smallModel: harness.providerConfig?.smallModel,
+						largeModel: harness.providerConfig?.largeModel,
 						evidence,
 					},
 					null,
@@ -205,33 +201,25 @@ liveDescribe("planner continuation — live Cerebras message loop", () => {
 		if (typeof trajectoryId !== "string" || !trajectoryId.trim()) {
 			throw new Error("live continuation turn did not create a trajectory");
 		}
-		const trajectoryService = harness.runtime.getService(
-			"trajectories",
-		) as LiveTrajectoryService | null;
-		if (typeof trajectoryService?.getTrajectoryDetail !== "function") {
-			throw new Error(
-				"live continuation turn has no readable trajectory service",
+		const trajectoryService = harness.runtime.getService("trajectories");
+		const trajectory =
+			await readCompletedPlannerContinuationTrajectory<LiveTrajectoryDetail>(
+				harness.runtime,
+				trajectoryId,
+				trajectoryService,
 			);
-		}
-		let trajectory: LiveTrajectoryDetail | null = null;
-		for (let attempt = 0; attempt < 50; attempt += 1) {
-			await trajectoryService.flushWriteQueue?.(trajectoryId);
-			trajectory = await trajectoryService.getTrajectoryDetail(trajectoryId);
-			if (trajectory?.metrics?.finalStatus === "completed") break;
-			await new Promise((resolve) => setTimeout(resolve, 20));
-		}
-		if (!trajectory)
-			throw new Error("live continuation trajectory was not persisted");
 		const modelResponses =
 			trajectory.steps
 				?.flatMap((step) => step.llmCalls ?? [])
 				.map((call) => ({
 					provider: call.provider,
+					model: call.model,
 					response: call.response,
 				}))
 				.filter((call) => Boolean(call.response?.trim())) ?? [];
 		const record = {
 			caseName: params.caseName,
+			trajectoryId,
 			priorUser: priorUser.content,
 			priorAssistant: priorAssistant.content,
 			currentText: params.currentText,


### PR DESCRIPTION
# Relates to

Relates to #22845

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] This PR targets `develop`; it was cleanly rebased immediately before publication, but `develop` advanced again after the push and requires a final resync before readiness.
- [x] `bun install --frozen-lockfile` and the focused owning gates were run after sync; the incomplete broader gates are recorded below.
- [x] A reviewer can confirm the deterministic causal-barrier behavior from the exact tests below; the credentialed live artifact remains an explicit draft gate.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@432b9c221ae78c9f7588877cc1e15b537ddcc5ef:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [ ] Exact head is based on `origin/develop@e896286b3dc1bd692c079d75d967e7c1de7429e4` with zero conflicts. GitHub `develop` advanced after publication; final resync remains pending.
- [ ] `bun run verify` passes post-sync. It remains pending; focused verification and broader-attempt limitations are recorded below.

# Risks

Low production risk: the diff changes only the planner-continuation live evidence harness and deterministic tests. Production message delivery and trajectory tracking are untouched. The primary review risk is falsely treating deterministic coverage as the credentialed live artifact; this PR remains draft and non-closing until that artifact is captured and inspected.

# Background

## What does this PR do?

- Extracts an always-importable planner-continuation trajectory barrier outside the credential-gated live suite.
- Enforces the causal order `drainPostDeliveryTasks(runtime)` → exactly one `flushWriteQueue(trajectoryId)` → exactly one `getTrajectoryDetail(trajectoryId)`.
- Rejects missing, non-completed, or structurally incomplete trajectory-service states.
- Covers delayed and nested work through the real post-delivery tracker while retaining the actual `RUN_ENDED` detach regression.
- Corrects live evidence attribution to record each `trajectoryId`, each call's provider/model, and configured `smallModel`/`largeModel` values.

## What kind of change is this?

Test/evidence-boundary correctness improvement. No production behavior changes.

# Documentation changes needed?

No. The scope is an owning live-test harness and its deterministic contract tests.

# Testing

## Where should a reviewer start?

- `packages/core/src/__tests__/planner-continuation-trajectory.ts`
- `packages/core/src/__tests__/planner-continuation-trajectory.test.ts`
- `packages/core/src/__tests__/planner-continuation.live.test.ts`

## Detailed testing steps

Exact head: `8a1aeaed6b22ddc445cf0fecfa9f9eaca87eccbf`

- `bun install --frozen-lockfile` — PASS, no lock changes.
- `bunx vitest run packages/core/src/__tests__/planner-continuation-trajectory.test.ts packages/core/src/services/post-delivery-task-tracker.test.ts packages/core/src/services/message.run-ended-detach.test.ts --config packages/core/vitest.config.ts` — PASS, 3 files / 10 tests.
- `bun run --cwd packages/core typecheck` — PASS.
- `bunx @biomejs/biome check packages/core/src/__tests__/planner-continuation.live.test.ts packages/core/src/__tests__/planner-continuation-trajectory.ts packages/core/src/__tests__/planner-continuation-trajectory.test.ts` — PASS.
- `git diff --check origin/develop...HEAD` — PASS.
- Independent exact-source review — NO SOURCE BLOCKER.

# Evidence Gate

<!-- evidence-head:8a1aeaed6b22ddc445cf0fecfa9f9eaca87eccbf -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual or interactive user flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend behavior changes; this is a test/evidence harness.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network behavior changes.
<!-- evidence-row:llm-trajectory -->
- [ ] Pending - rerun all three live Cerebras cases at this exact head and attach the content-reviewed trajectory artifact.
<!-- evidence-row:domain-artifacts -->
- [ ] Pending - attach the exact-head JSON containing all three case names, nonblank trajectory IDs, completed statuses, and Cerebras provider/model attribution.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text.

# Evidence Details

## Real LLM-call trajectory

Pending. Run the exact head with OpenAI explicitly absent:

```bash
env -u OPENAI_API_KEY ELIZA_RUN_LIVE_TESTS=1 CEREBRAS_API_KEY='<redacted>' PR20227_EVIDENCE_PATH=/tmp/22845-planner-continuation-evidence.json bunx vitest run packages/core/src/__tests__/planner-continuation.live.test.ts --config packages/core/vitest.config.ts
```

Before making this PR closing or ready, inspect and attach the JSON proving all three live cases, nonblank trajectory IDs, completed final statuses, and Cerebras provider/model attribution.

## Backend + frontend logs

N/A - no deployed backend/frontend code changes.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no voice surface changes.

## Known gaps / failures

- Real Cerebras/PGlite three-case evidence is unavailable in this environment because `CEREBRAS_API_KEY` is not set.
- `develop` advanced after the publication-time rebase; rebase and rerun the exact gates before readiness.
- `bun run verify` has not completed at this exact head.
- A broader core test attempt stopped after unrelated failures in `message-runtime-stage1.test.ts`, `runtime/action-retrieval.test.ts`, `message.side-effect-claim.test.ts`, and `canonical-memory-pglite.integration.test.ts`; no touched-file failure was observed.
- A core Node build produced the Node and testing bundles, then declaration generation remained silent for roughly 110 seconds and was stopped; build success is not claimed.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@432b9c221ae78c9f7588877cc1e15b537ddcc5ef:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-22845]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@432b9c221ae78c9f7588877cc1e15b537ddcc5ef:packages/skills/skills/contribute-to-eliza"} -->
