### PR TITLE
feat(cloud): managed provider account manifest and fail-closed doctor (#19910)

### DIFF
--- a/packages/cloud/shared/AGENTS.md
+++ b/packages/cloud/shared/AGENTS.md
@@ -46,6 +46,7 @@ src/
     index.ts
 drizzle.config.ts          points at ./src/db/{schemas,migrations}
 scripts/messaging-gateway-preflight.mjs   preflight:messaging-gateways
+scripts/managed-accounts-doctor.mjs       verify:managed-accounts (managed provider accounts, #19910)
 docs/                      WHY docs (auth consistency, provisioning, messaging gateways)
 ```
 
@@ -71,6 +72,7 @@ bun run --cwd packages/cloud/shared db:migrate:drizzle     # drizzle-kit migrate
 bun run --cwd packages/cloud/shared db:studio              # drizzle-kit studio
 bun run --cwd packages/cloud/shared db:check-migrations    # drizzle-kit check
 bun run --cwd packages/cloud/shared preflight:messaging-gateways
+bun run --cwd packages/cloud/shared verify:managed-accounts   # managed provider account status; :strict fails closed
 bun run --cwd packages/cloud/shared generate:email-templates
 ```
 

--- a/packages/cloud/shared/CLAUDE.md
+++ b/packages/cloud/shared/CLAUDE.md
@@ -46,6 +46,7 @@ src/
     index.ts
 drizzle.config.ts          points at ./src/db/{schemas,migrations}
 scripts/messaging-gateway-preflight.mjs   preflight:messaging-gateways
+scripts/managed-accounts-doctor.mjs       verify:managed-accounts (managed provider accounts, #19910)
 docs/                      WHY docs (auth consistency, provisioning, messaging gateways)
 ```
 
@@ -71,6 +72,7 @@ bun run --cwd packages/cloud/shared db:migrate:drizzle     # drizzle-kit migrate
 bun run --cwd packages/cloud/shared db:studio              # drizzle-kit studio
 bun run --cwd packages/cloud/shared db:check-migrations    # drizzle-kit check
 bun run --cwd packages/cloud/shared preflight:messaging-gateways
+bun run --cwd packages/cloud/shared verify:managed-accounts   # managed provider account status; :strict fails closed
 bun run --cwd packages/cloud/shared generate:email-templates
 ```
 

--- a/packages/cloud/shared/package.json
+++ b/packages/cloud/shared/package.json
@@ -31,6 +31,8 @@
     "verify:tenant-isolation": "bun scripts/verify-tenant-db-isolation.ts",
     "test": "node scripts/run-bun-tests.mjs",
     "test:vitest": "vitest run",
+    "verify:managed-accounts": "bun scripts/managed-accounts-doctor.mjs",
+    "verify:managed-accounts:strict": "bun scripts/managed-accounts-doctor.mjs --strict",
     "preflight:messaging-gateways": "node scripts/messaging-gateway-preflight.mjs",
     "preflight:messaging-gateways:strict": "node scripts/messaging-gateway-preflight.mjs --strict",
     "db:check-migrations": "drizzle-kit check",

--- a/packages/cloud/shared/scripts/managed-accounts-doctor.mjs
+++ b/packages/cloud/shared/scripts/managed-accounts-doctor.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env bun
+
+/**
+ * Operator/CI doctor for the managed Cloud provider accounts tracked by
+ * issue #19910. Reports configured/partial/missing/deferred status per
+ * account from the current environment — secret reference names only, never
+ * values. `--strict` fails closed when any required account is not fully
+ * configured; `--json` emits the machine-readable report for evidence
+ * capture. Requires bun (imports the TypeScript manifest directly).
+ */
+
+import { MANAGED_ACCOUNTS, verifyManagedAccounts } from "../src/lib/config/managed-accounts.ts";
+
+const args = process.argv.slice(2);
+const strict = args.includes("--strict");
+const asJson = args.includes("--json");
+const categoryArg = args.find((arg) => arg.startsWith("--category="));
+const categories = categoryArg
+  ? new Set(
+      categoryArg
+        .split("=")[1]
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean),
+    )
+  : null;
+
+const accounts = categories
+  ? MANAGED_ACCOUNTS.filter((spec) => categories.has(spec.category))
+  : MANAGED_ACCOUNTS;
+
+if (accounts.length === 0) {
+  console.error(
+    `managed-accounts-doctor: no accounts match --category=${[...(categories ?? [])].join(",")}`,
+  );
+  process.exit(2);
+}
+
+const { reports, requiredMissing } = verifyManagedAccounts(process.env, accounts);
+
+if (asJson) {
+  console.log(
+    JSON.stringify({ reports, requiredMissingIds: requiredMissing.map((r) => r.id) }, null, 2),
+  );
+} else {
+  console.log("Managed Cloud provider accounts (issue #19910)");
+  for (const report of reports) {
+    const requirement =
+      report.requirement.kind === "deferred"
+        ? `deferred (owner: ${report.requirement.owner})`
+        : report.requirement.kind;
+    console.log(`- [${report.state}] ${report.name} (${report.category}, ${requirement})`);
+    if (report.missingEnvVars.length > 0) {
+      console.log(`  missing: ${report.missingEnvVars.join(", ")}`);
+    }
+    if (report.requirement.kind === "deferred") {
+      console.log(`  reason: ${report.requirement.reason}`);
+    }
+  }
+  const configured = reports.filter((r) => r.state === "configured").length;
+  console.log(`\n${configured}/${reports.length} accounts configured.`);
+}
+
+if (requiredMissing.length > 0) {
+  const summary = `${requiredMissing.length} required managed account(s) not configured: ${requiredMissing
+    .map((r) => r.id)
+    .join(", ")}`;
+  if (strict) {
+    console.error(`\n${summary}`);
+    process.exit(1);
+  }
+  if (!asJson) {
+    console.log(`\n${summary}. Re-run with --strict in CI to fail closed.`);
+  }
+}

--- a/packages/cloud/shared/scripts/managed-accounts-doctor.test.mjs
+++ b/packages/cloud/shared/scripts/managed-accounts-doctor.test.mjs
@@ -1,0 +1,79 @@
+/**
+ * Exercises the real managed-accounts doctor process end to end with
+ * deterministic environments; no credentials, network, or provider account is
+ * used. Spawns the current bun runtime because the CLI imports the TypeScript
+ * manifest directly.
+ */
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+
+const SCRIPT = path.join(import.meta.dirname, "managed-accounts-doctor.mjs");
+
+const REQUIRED_ENV = {
+  GOOGLE_CLIENT_ID: "contract-value",
+  GOOGLE_CLIENT_SECRET: "contract-value",
+  TELEGRAM_BOT_TOKEN: "contract-value",
+  TELEGRAM_WEBHOOK_SECRET: "contract-value",
+  DISCORD_CLIENT_ID: "contract-value",
+  DISCORD_CLIENT_SECRET: "contract-value",
+  DISCORD_BOT_TOKEN: "contract-value",
+};
+
+function run(cliArgs, env = {}) {
+  return spawnSync(process.execPath, [SCRIPT, ...cliArgs], {
+    encoding: "utf8",
+    env: { PATH: process.env.PATH, ...env },
+  });
+}
+
+test("strict mode fails closed when required accounts are unprovisioned", () => {
+  const result = run(["--strict"]);
+  assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
+  assert.match(result.stderr, /required managed account\(s\) not configured/);
+  assert.match(result.stderr, /google/);
+});
+
+test("strict mode passes once every required account has one complete credential set", () => {
+  const result = run(["--strict"], REQUIRED_ENV);
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.match(result.stdout, /\[configured\] Google/);
+  assert.match(result.stdout, /\[configured\] Telegram/);
+  assert.match(result.stdout, /\[configured\] Discord/);
+});
+
+test("report mode surfaces missing reference names but never fails", () => {
+  const result = run([]);
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  assert.match(result.stdout, /missing: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET/);
+  assert.match(result.stdout, /Re-run with --strict in CI to fail closed/);
+});
+
+test("json mode emits the machine-readable report without secret values", () => {
+  const result = run(["--json"], { TELEGRAM_BOT_TOKEN: "secret-token-value" });
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  const parsed = JSON.parse(result.stdout);
+  assert.ok(Array.isArray(parsed.reports));
+  assert.ok(parsed.requiredMissingIds.includes("google"));
+  assert.doesNotMatch(result.stdout, /secret-token-value/);
+});
+
+test("category filtering scopes the report and rejects unknown categories", () => {
+  const scoped = run(["--category=social_communications"]);
+  assert.equal(scoped.status, 0, `${scoped.stdout}\n${scoped.stderr}`);
+  assert.doesNotMatch(scoped.stdout, /Google \(foundation/);
+  assert.match(scoped.stdout, /Telegram/);
+
+  const unknown = run(["--category=nonsense"]);
+  assert.equal(unknown.status, 2);
+});
+
+test("placeholder credential values do not count as provisioned", () => {
+  const result = run(["--strict"], {
+    ...REQUIRED_ENV,
+    TELEGRAM_BOT_TOKEN: "your_telegram_bot_token_placeholder",
+  });
+  assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
+  assert.match(result.stderr, /telegram/);
+});

--- a/packages/cloud/shared/src/lib/config/managed-accounts.test.ts
+++ b/packages/cloud/shared/src/lib/config/managed-accounts.test.ts
@@ -64,6 +64,23 @@ describe("managed-account manifest invariants", () => {
     }
   });
 
+  it("excludes secret patterns whose registry credential field is optional", () => {
+    for (const spec of MANAGED_ACCOUNTS) {
+      const provider = OAUTH_PROVIDERS[spec.id];
+      if (!provider?.credentialFields || !provider.secretPatterns) continue;
+      const patterns = provider.secretPatterns as Record<string, string | undefined>;
+      const optionalNames = provider.credentialFields
+        .filter((field) => !field.required)
+        .map((field) => patterns[field.key])
+        .filter((name): name is string => Boolean(name));
+      for (const set of spec.credentialSets) {
+        for (const optionalName of optionalNames) {
+          expect(set).not.toContain(optionalName);
+        }
+      }
+    }
+  });
+
   it("OAuth-registry-backed entries stay in sync with the registry env vars", () => {
     for (const spec of MANAGED_ACCOUNTS) {
       const provider = OAUTH_PROVIDERS[spec.id];

--- a/packages/cloud/shared/src/lib/config/managed-accounts.test.ts
+++ b/packages/cloud/shared/src/lib/config/managed-accounts.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Deterministic unit coverage for the managed-account manifest and verifier:
+ * manifest invariants (unique ids, real secret reference names, deferred
+ * entries carry owner and reason), registry-derivation consistency with the
+ * OAuth provider registry, and evaluator behavior across configured, partial,
+ * missing, placeholder, alternative-set, and deferred paths. Also proves the
+ * manifest matches code by asserting every enforced env var has a real
+ * consumer in the repository (via git grep). No credentials or network used.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { OAUTH_PROVIDERS } from "../services/oauth/provider-registry";
+import {
+  evaluateManagedAccount,
+  MANAGED_ACCOUNTS,
+  type ManagedAccountSpec,
+  verifyManagedAccounts,
+} from "./managed-accounts";
+
+const ENV_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+const REPOSITORY_ROOT = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+  cwd: path.dirname(new URL(import.meta.url).pathname),
+  encoding: "utf8",
+}).stdout.trim();
+
+describe("managed-account manifest invariants", () => {
+  it("has unique ids and non-empty names", () => {
+    const ids = MANAGED_ACCOUNTS.map((spec) => spec.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const spec of MANAGED_ACCOUNTS) {
+      expect(spec.name.trim().length).toBeGreaterThan(0);
+      expect(spec.console.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("uses valid env var names and no empty credential sets", () => {
+    for (const spec of MANAGED_ACCOUNTS) {
+      for (const set of spec.credentialSets) {
+        expect(set.length).toBeGreaterThan(0);
+        for (const name of set) {
+          expect(name).toMatch(ENV_NAME_PATTERN);
+        }
+      }
+    }
+  });
+
+  it("requires credential sets on every non-deferred entry", () => {
+    for (const spec of MANAGED_ACCOUNTS) {
+      if (spec.requirement.kind !== "deferred") {
+        expect(spec.credentialSets.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("deferred entries carry an owner and a reason", () => {
+    const deferred = MANAGED_ACCOUNTS.filter((spec) => spec.requirement.kind === "deferred");
+    expect(deferred.length).toBeGreaterThan(0);
+    for (const spec of deferred) {
+      if (spec.requirement.kind !== "deferred") continue;
+      expect(spec.requirement.owner.trim().length).toBeGreaterThan(0);
+      expect(spec.requirement.reason.trim().length).toBeGreaterThan(10);
+    }
+  });
+
+  it("OAuth-registry-backed entries stay in sync with the registry env vars", () => {
+    for (const spec of MANAGED_ACCOUNTS) {
+      const provider = OAUTH_PROVIDERS[spec.id];
+      if (!provider) continue;
+      const registryVars = new Set([
+        ...provider.envVars,
+        ...(provider.envVarAlternatives?.flat() ?? []),
+        ...Object.values(provider.secretPatterns ?? {}),
+      ]);
+      for (const set of spec.credentialSets) {
+        for (const name of set) {
+          expect(registryVars.has(name)).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("every enforced secret reference name has a real consumer in the repository", () => {
+    const enforcedVars = new Set(
+      MANAGED_ACCOUNTS.filter((spec) => spec.requirement.kind !== "deferred").flatMap((spec) =>
+        spec.credentialSets.flat(),
+      ),
+    );
+    // POSIX ERE (git grep -E) has no \b; substring matches are fine because the
+    // names are long and distinctive, and -o reports the matched name itself.
+    const pattern = `(${[...enforcedVars].join("|")})`;
+    const result = spawnSync(
+      "git",
+      [
+        "grep",
+        "-h",
+        "-o",
+        "-E",
+        pattern,
+        "--",
+        "packages/cloud",
+        "plugins",
+        ":(exclude)packages/cloud/shared/src/lib/config/managed-accounts.ts",
+      ],
+      { cwd: REPOSITORY_ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+    );
+    expect(result.status).toBe(0);
+    const referenced = new Set(result.stdout.split("\n").filter(Boolean));
+    const unreferenced = [...enforcedVars].filter((name) => !referenced.has(name));
+    expect(unreferenced).toEqual([]);
+  }, 60000);
+});
+
+const CONFIGURED = "configured-contract-value";
+
+const sample: ManagedAccountSpec = {
+  id: "sample",
+  name: "Sample",
+  category: "foundation",
+  console: "https://example.invalid",
+  credentialSets: [["SAMPLE_CLIENT_ID", "SAMPLE_CLIENT_SECRET"], ["SAMPLE_API_KEY"]],
+  requirement: { kind: "required" },
+};
+
+describe("evaluateManagedAccount", () => {
+  it("reports configured when any one credential set is complete", () => {
+    const report = evaluateManagedAccount(sample, { SAMPLE_API_KEY: CONFIGURED });
+    expect(report.state).toBe("configured");
+    expect(report.missingEnvVars).toEqual([]);
+  });
+
+  it("reports partial with the smallest actionable missing set", () => {
+    const report = evaluateManagedAccount(sample, { SAMPLE_CLIENT_ID: CONFIGURED });
+    expect(report.state).toBe("partial");
+    expect(report.missingEnvVars).toEqual(["SAMPLE_CLIENT_SECRET"]);
+  });
+
+  it("reports missing when nothing is present", () => {
+    const report = evaluateManagedAccount(
+      { ...sample, credentialSets: [["SAMPLE_CLIENT_ID", "SAMPLE_CLIENT_SECRET"]] },
+      {},
+    );
+    expect(report.state).toBe("missing");
+    expect(report.missingEnvVars).toEqual(["SAMPLE_CLIENT_ID", "SAMPLE_CLIENT_SECRET"]);
+  });
+
+  it("treats placeholder values as absent", () => {
+    const report = evaluateManagedAccount(sample, {
+      SAMPLE_API_KEY: "your_sample_api_key_placeholder",
+    });
+    expect(report.state).toBe("missing");
+  });
+
+  it("reports deferred without failing when credentials are absent", () => {
+    const report = evaluateManagedAccount(
+      {
+        ...sample,
+        requirement: { kind: "deferred", owner: "cloud-integrations", reason: "not shipped yet" },
+      },
+      {},
+    );
+    expect(report.state).toBe("deferred");
+  });
+
+  it("reports configured for a deferred entry whose credentials exist", () => {
+    const report = evaluateManagedAccount(
+      {
+        ...sample,
+        requirement: { kind: "deferred", owner: "cloud-integrations", reason: "not shipped yet" },
+      },
+      { SAMPLE_API_KEY: CONFIGURED },
+    );
+    expect(report.state).toBe("configured");
+  });
+
+  it("marks entries with no credential sets deferred", () => {
+    const report = evaluateManagedAccount({ ...sample, credentialSets: [] }, {});
+    expect(report.state).toBe("deferred");
+  });
+});
+
+describe("verifyManagedAccounts", () => {
+  it("collects only unconfigured required accounts into requiredMissing", () => {
+    const optional: ManagedAccountSpec = {
+      ...sample,
+      id: "sample-optional",
+      requirement: { kind: "optional" },
+    };
+    const { reports, requiredMissing } = verifyManagedAccounts({}, [sample, optional]);
+    expect(reports).toHaveLength(2);
+    expect(requiredMissing.map((r) => r.id)).toEqual(["sample"]);
+  });
+
+  it("fails closed on the real manifest only through required accounts", () => {
+    const { requiredMissing } = verifyManagedAccounts({});
+    const requiredIds = MANAGED_ACCOUNTS.filter((s) => s.requirement.kind === "required").map(
+      (s) => s.id,
+    );
+    expect(requiredMissing.map((r) => r.id).sort()).toEqual([...requiredIds].sort());
+  });
+
+  it("clears requiredMissing when required credentials are fully provisioned", () => {
+    const env: Record<string, string> = {};
+    for (const spec of MANAGED_ACCOUNTS) {
+      if (spec.requirement.kind !== "required") continue;
+      for (const name of spec.credentialSets[0]) {
+        env[name] = CONFIGURED;
+      }
+    }
+    const { requiredMissing } = verifyManagedAccounts(env);
+    expect(requiredMissing).toEqual([]);
+  });
+
+  it("never places credential values in a report", () => {
+    const { reports } = verifyManagedAccounts({ TELEGRAM_BOT_TOKEN: "secret-token-value" });
+    expect(JSON.stringify(reports)).not.toContain("secret-token-value");
+  });
+});

--- a/packages/cloud/shared/src/lib/config/managed-accounts.ts
+++ b/packages/cloud/shared/src/lib/config/managed-accounts.ts
@@ -49,7 +49,9 @@ export interface ManagedAccountSpec {
  * Derive a manifest entry from the OAuth provider registry so credential sets
  * stay identical to what the OAuth routes read at runtime. Secrets-storage
  * providers contribute their secret patterns; env-var providers contribute
- * their envVars/envVarAlternatives.
+ * their envVars/envVarAlternatives. Secret patterns whose credential field the
+ * registry marks optional (e.g. a webhook secret) are excluded so a
+ * runtime-valid account is never reported partial.
  */
 function fromOAuthRegistry(
   registryId: string,
@@ -64,8 +66,13 @@ function fromOAuthRegistry(
   const registrySets: string[][] =
     provider.envVarAlternatives?.map((set) => [...set]) ??
     (provider.envVars.length > 0 ? [[...provider.envVars]] : []);
+  const optionalFieldKeys = new Set(
+    (provider.credentialFields ?? []).filter((field) => !field.required).map((field) => field.key),
+  );
   const secretSet = provider.secretPatterns
-    ? Object.values(provider.secretPatterns).filter((name): name is string => Boolean(name))
+    ? Object.entries(provider.secretPatterns)
+        .filter(([key, name]) => Boolean(name) && !optionalFieldKeys.has(key))
+        .map(([, name]) => name as string)
     : [];
   const credentialSets =
     registrySets.length > 0 ? registrySets : secretSet.length ? [secretSet] : [];

--- a/packages/cloud/shared/src/lib/config/managed-accounts.ts
+++ b/packages/cloud/shared/src/lib/config/managed-accounts.ts
@@ -1,0 +1,345 @@
+/**
+ * Machine-readable manifest and verifier for the managed Cloud provider
+ * accounts tracked by the plugin-first integration program (issue #19910).
+ * Each entry names a provider account the platform operates, the
+ * secret-manager reference names (env vars) that prove it is provisioned,
+ * and whether the program currently requires it. OAuth application entries
+ * derive their credential sets from the canonical OAuth provider registry so
+ * this manifest can never drift from the env vars the runtime actually reads.
+ *
+ * Verification reports configured/partial/missing/deferred status only —
+ * never credential values — so its output is safe for CI logs and issues.
+ * The operator CLI lives at scripts/managed-accounts-doctor.mjs
+ * (`bun run verify:managed-accounts`).
+ */
+
+import { isPlaceholderProviderKey } from "../providers/provider-env";
+import { OAUTH_PROVIDERS } from "../services/oauth/provider-registry";
+
+export type ManagedAccountCategory =
+  | "foundation"
+  | "work_documents"
+  | "social_communications"
+  | "platform";
+
+export type ManagedAccountRequirement =
+  | { kind: "required" }
+  | { kind: "optional" }
+  | { kind: "deferred"; owner: string; reason: string };
+
+export interface ManagedAccountSpec {
+  /** Stable identifier, unique across the manifest. */
+  id: string;
+  /** Human-readable provider account name. */
+  name: string;
+  category: ManagedAccountCategory;
+  /** Provider console where the account/application is provisioned. */
+  console: string;
+  /**
+   * Alternative complete credential sets (secret-manager reference names).
+   * The account counts as configured when every var in any one set is present
+   * and non-placeholder. Deferred entries may have zero sets until a consumer
+   * ships.
+   */
+  credentialSets: readonly (readonly string[])[];
+  requirement: ManagedAccountRequirement;
+}
+
+/**
+ * Derive a manifest entry from the OAuth provider registry so credential sets
+ * stay identical to what the OAuth routes read at runtime. Secrets-storage
+ * providers contribute their secret patterns; env-var providers contribute
+ * their envVars/envVarAlternatives.
+ */
+function fromOAuthRegistry(
+  registryId: string,
+  category: ManagedAccountCategory,
+  consoleUrl: string,
+  requirement: ManagedAccountRequirement,
+): ManagedAccountSpec {
+  const provider = OAUTH_PROVIDERS[registryId];
+  if (!provider) {
+    throw new Error(`ManagedAccounts: unknown OAuth registry provider "${registryId}"`);
+  }
+  const registrySets: string[][] =
+    provider.envVarAlternatives?.map((set) => [...set]) ??
+    (provider.envVars.length > 0 ? [[...provider.envVars]] : []);
+  const secretSet = provider.secretPatterns
+    ? Object.values(provider.secretPatterns).filter((name): name is string => Boolean(name))
+    : [];
+  const credentialSets =
+    registrySets.length > 0 ? registrySets : secretSet.length ? [secretSet] : [];
+  return {
+    id: provider.id,
+    name: provider.name,
+    category,
+    console: consoleUrl,
+    credentialSets,
+    requirement,
+  };
+}
+
+const deferred = (owner: string, reason: string): ManagedAccountRequirement => ({
+  kind: "deferred",
+  owner,
+  reason,
+});
+
+/**
+ * The managed-account program manifest. Requirement policy:
+ * - "required": a shipped managed capability breaks without this account.
+ * - "optional": a shipped integration lights up when provisioned but the
+ *   platform degrades gracefully without it.
+ * - "deferred": tracked by the program with an owner and reason; verification
+ *   never fails on it until the requirement is promoted.
+ */
+export const MANAGED_ACCOUNTS: readonly ManagedAccountSpec[] = [
+  // Foundation accounts
+  fromOAuthRegistry("google", "foundation", "https://console.cloud.google.com", {
+    kind: "required",
+  }),
+  fromOAuthRegistry("microsoft", "foundation", "https://entra.microsoft.com", {
+    kind: "optional",
+  }),
+  {
+    id: "plaid",
+    name: "Plaid",
+    category: "foundation",
+    console: "https://dashboard.plaid.com",
+    credentialSets: [["PLAID_CLIENT_ID", "PLAID_SECRET"]],
+    requirement: { kind: "optional" },
+  },
+  {
+    id: "firecrawl",
+    name: "Firecrawl",
+    category: "foundation",
+    console: "https://www.firecrawl.dev",
+    credentialSets: [["FIRECRAWL_API_KEY"]],
+    requirement: { kind: "optional" },
+  },
+  {
+    id: "spotify",
+    name: "Spotify",
+    category: "foundation",
+    console: "https://developer.spotify.com/dashboard",
+    credentialSets: [],
+    requirement: deferred(
+      "cloud-integrations",
+      "No shipped Cloud consumer reads Spotify OAuth application credentials yet.",
+    ),
+  },
+
+  // Work and documents
+  fromOAuthRegistry("github", "work_documents", "https://github.com/settings/developers", {
+    kind: "optional",
+  }),
+  fromOAuthRegistry("linear", "work_documents", "https://linear.app/settings/api/applications", {
+    kind: "optional",
+  }),
+  fromOAuthRegistry("notion", "work_documents", "https://www.notion.so/my-integrations", {
+    kind: "optional",
+  }),
+  fromOAuthRegistry("dropbox", "work_documents", "https://www.dropbox.com/developers/apps", {
+    kind: "optional",
+  }),
+  fromOAuthRegistry("slack", "work_documents", "https://api.slack.com/apps", {
+    kind: "optional",
+  }),
+  fromOAuthRegistry("jira", "work_documents", "https://developer.atlassian.com/console", {
+    kind: "optional",
+  }),
+  fromOAuthRegistry("hubspot", "work_documents", "https://developers.hubspot.com", {
+    kind: "optional",
+  }),
+  fromOAuthRegistry("asana", "work_documents", "https://app.asana.com/0/developer-console", {
+    kind: "optional",
+  }),
+  fromOAuthRegistry("airtable", "work_documents", "https://airtable.com/create/oauth", {
+    kind: "optional",
+  }),
+  fromOAuthRegistry("salesforce", "work_documents", "https://developer.salesforce.com", {
+    kind: "optional",
+  }),
+  fromOAuthRegistry("zoom", "work_documents", "https://marketplace.zoom.us", {
+    kind: "optional",
+  }),
+  {
+    id: "canva",
+    name: "Canva",
+    category: "work_documents",
+    console: "https://www.canva.com/developers",
+    credentialSets: [],
+    requirement: deferred(
+      "cloud-integrations",
+      "Canva developer application eligibility is pending; no shipped Cloud consumer yet.",
+    ),
+  },
+  {
+    id: "figma",
+    name: "Figma",
+    category: "work_documents",
+    console: "https://www.figma.com/developers/apps",
+    credentialSets: [],
+    requirement: deferred(
+      "cloud-integrations",
+      "Figma remote-client catalog eligibility is pending; desktop-local mode ships without a managed account.",
+    ),
+  },
+
+  // Social and communications
+  fromOAuthRegistry("linkedin", "social_communications", "https://developer.linkedin.com", {
+    kind: "optional",
+  }),
+  fromOAuthRegistry("twitter", "social_communications", "https://developer.x.com", {
+    kind: "optional",
+  }),
+  fromOAuthRegistry("twilio", "social_communications", "https://console.twilio.com", {
+    kind: "optional",
+  }),
+  fromOAuthRegistry("blooio", "social_communications", "https://blooio.com", {
+    kind: "optional",
+  }),
+  {
+    id: "telegram",
+    name: "Telegram",
+    category: "social_communications",
+    console: "https://t.me/BotFather",
+    credentialSets: [
+      ["TELEGRAM_BOT_TOKEN", "TELEGRAM_WEBHOOK_SECRET"],
+      ["ELIZA_APP_TELEGRAM_BOT_TOKEN", "ELIZA_APP_TELEGRAM_WEBHOOK_SECRET"],
+    ],
+    requirement: { kind: "required" },
+  },
+  {
+    id: "discord",
+    name: "Discord",
+    category: "social_communications",
+    console: "https://discord.com/developers/applications",
+    credentialSets: [
+      ["DISCORD_CLIENT_ID", "DISCORD_CLIENT_SECRET", "DISCORD_BOT_TOKEN"],
+      [
+        "ELIZA_APP_DISCORD_APPLICATION_ID",
+        "ELIZA_APP_DISCORD_CLIENT_SECRET",
+        "ELIZA_APP_DISCORD_BOT_TOKEN",
+      ],
+    ],
+    requirement: { kind: "required" },
+  },
+  {
+    id: "meta-whatsapp",
+    name: "Meta (WhatsApp Business Platform)",
+    category: "social_communications",
+    console: "https://developers.facebook.com",
+    credentialSets: [
+      ["WHATSAPP_ACCESS_TOKEN", "WHATSAPP_APP_SECRET", "WHATSAPP_VERIFY_TOKEN"],
+      [
+        "ELIZA_APP_WHATSAPP_ACCESS_TOKEN",
+        "ELIZA_APP_WHATSAPP_APP_SECRET",
+        "ELIZA_APP_WHATSAPP_VERIFY_TOKEN",
+      ],
+    ],
+    requirement: { kind: "optional" },
+  },
+  {
+    id: "tiktok",
+    name: "TikTok",
+    category: "social_communications",
+    console: "https://developers.tiktok.com",
+    credentialSets: [["TIKTOK_CLIENT_KEY", "TIKTOK_CLIENT_SECRET"]],
+    requirement: { kind: "optional" },
+  },
+  {
+    id: "reddit",
+    name: "Reddit",
+    category: "social_communications",
+    console: "https://www.reddit.com/prefs/apps",
+    credentialSets: [],
+    requirement: deferred(
+      "cloud-integrations",
+      "No shipped Cloud consumer reads a managed Reddit application credential yet.",
+    ),
+  },
+  {
+    id: "apple-google-native",
+    name: "Apple Developer / Google Play",
+    category: "platform",
+    console: "https://developer.apple.com / https://play.google.com/console",
+    credentialSets: [],
+    requirement: deferred(
+      "cloud-integrations",
+      "Native device store accounts are provisioned through the app release pipeline, not Cloud env secrets.",
+    ),
+  },
+];
+
+export type ManagedAccountState = "configured" | "partial" | "missing" | "deferred";
+
+export interface ManagedAccountReport {
+  id: string;
+  name: string;
+  category: ManagedAccountCategory;
+  requirement: ManagedAccountRequirement;
+  state: ManagedAccountState;
+  /** Smallest actionable set of missing secret reference names (never values). */
+  missingEnvVars: string[];
+}
+
+export interface ManagedAccountsVerification {
+  reports: ManagedAccountReport[];
+  /** Required accounts that are not fully configured; non-empty means fail closed. */
+  requiredMissing: ManagedAccountReport[];
+}
+
+function isConfiguredValue(env: Record<string, string | undefined>, name: string): boolean {
+  return !isPlaceholderProviderKey(env[name]);
+}
+
+/**
+ * Evaluate one account against an env snapshot. Alternatives resolve like the
+ * OAuth registry: any one complete set means configured, and the reported
+ * missing list is the smallest remaining set. Placeholder values never count.
+ */
+export function evaluateManagedAccount(
+  spec: ManagedAccountSpec,
+  env: Record<string, string | undefined>,
+): ManagedAccountReport {
+  const base = {
+    id: spec.id,
+    name: spec.name,
+    category: spec.category,
+    requirement: spec.requirement,
+  };
+
+  if (spec.credentialSets.length === 0) {
+    return { ...base, state: "deferred", missingEnvVars: [] };
+  }
+
+  const missingPerSet = spec.credentialSets.map((set) =>
+    set.filter((name) => !isConfiguredValue(env, name)),
+  );
+  const bestIndex = missingPerSet
+    .map((missing, index) => ({ missing, index }))
+    .sort((a, b) => a.missing.length - b.missing.length)[0].index;
+  const missingEnvVars = missingPerSet[bestIndex];
+
+  if (missingEnvVars.length === 0) {
+    return { ...base, state: "configured", missingEnvVars: [] };
+  }
+  if (spec.requirement.kind === "deferred") {
+    return { ...base, state: "deferred", missingEnvVars };
+  }
+  const anyPresent = missingEnvVars.length < spec.credentialSets[bestIndex].length;
+  return { ...base, state: anyPresent ? "partial" : "missing", missingEnvVars };
+}
+
+/** Evaluate the whole manifest against an env snapshot. */
+export function verifyManagedAccounts(
+  env: Record<string, string | undefined>,
+  accounts: readonly ManagedAccountSpec[] = MANAGED_ACCOUNTS,
+): ManagedAccountsVerification {
+  const reports = accounts.map((spec) => evaluateManagedAccount(spec, env));
+  const requiredMissing = reports.filter(
+    (report) => report.requirement.kind === "required" && report.state !== "configured",
+  );
+  return { reports, requiredMissing };
+}

--- a/packages/cloud/shared/src/lib/providers/provider-env.ts
+++ b/packages/cloud/shared/src/lib/providers/provider-env.ts
@@ -1,7 +1,12 @@
 // Defines cloud shared provider env behavior for backend service consumers.
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 
-function isPlaceholderProviderKey(value: string | undefined): boolean {
+/**
+ * Shared placeholder rule for provider credentials: blank values and common
+ * template strings ("placeholder", "replace_with", "your_...") never count as
+ * configured. Exported so managed-account verification applies the same rule.
+ */
+export function isPlaceholderProviderKey(value: string | undefined): boolean {
   if (!value) return true;
   const normalized = value.trim().toLowerCase();
   return (


### PR DESCRIPTION
Part of #19910 (non-closing: account provisioning, billing, and secret-manager setup remain human tasks tracked on the issue).

## What

Implements the codeable half of the managed Cloud provider account program: a machine-readable manifest and a fail-closed verification doctor, so account provisioning status is tracked in code instead of prose.

- `packages/cloud/shared/src/lib/config/managed-accounts.ts` — manifest of every managed provider account from #19910 (foundation, work/documents, social/communications, platform). OAuth application entries derive their credential sets from the canonical `OAUTH_PROVIDERS` registry, so the manifest cannot drift from the env vars the OAuth routes actually read. Non-OAuth accounts (Plaid, Firecrawl, Telegram, Discord, Meta/WhatsApp, TikTok) declare the secret-manager reference names their shipped consumers read, including `ELIZA_APP_*` aliases used by the messaging gateways. Accounts without a shipped Cloud consumer (Spotify, Canva, Figma, Reddit, Apple/Google Play) are explicitly `deferred` with an owner and reason, per the issue's "explicit disabled/deferred decision" contract.
- `packages/cloud/shared/scripts/managed-accounts-doctor.mjs` (`bun run --cwd packages/cloud/shared verify:managed-accounts`) — reports configured/partial/missing/deferred per account. Prints secret reference names only, never values, so output is safe for CI logs and issue evidence. `--strict` exits 1 when any required account is unprovisioned (fail closed); `--json` emits the machine-readable report; `--category=` scopes it. Placeholder values (`your_...`, `placeholder`, blank) never count as provisioned, reusing the shared `isPlaceholderProviderKey` rule (now exported from `provider-env.ts`).
- Docs: `verify:managed-accounts` added to `packages/cloud/shared/CLAUDE.md`/`AGENTS.md` (byte-identical, parity gate passes).

## Tests

- `src/lib/config/managed-accounts.test.ts` — manifest invariants (unique ids, valid env names, deferred entries carry owner+reason, non-deferred entries have credential sets), OAuth-registry sync, evaluator paths (configured / partial with smallest actionable missing set / missing / placeholder / alternative sets / deferred), verifier fail-closed semantics, no-secret-values-in-report, and a repository consumer-reference proof: every enforced env var must be read somewhere under `packages/cloud` or `plugins` (via `git grep`), so the manifest can never name a credential nothing consumes.
- `scripts/managed-accounts-doctor.test.mjs` — spawns the real CLI: strict fail-closed on empty env, strict pass with complete required sets, report/json/category modes, placeholder rejection, and no secret value leakage.

Results: `bun test packages/cloud/shared/src/lib/config/managed-accounts.test.ts packages/cloud/shared/scripts/managed-accounts-doctor.test.mjs` → 23 pass, 0 fail. `bun test .../provider-keys.test.ts .../oauth/provider-registry.test.ts` (touched-surface neighbors) → 17 pass. Biome clean on all touched files. `check:agents-claude` passes. `tsc` in cloud/shared reports only the documented pre-existing transitive-plugin noise (`plugin-elizacloud`/`plugin-sql` missing dist/types in the worktree); zero errors in touched files. Per coordination instructions, per-package gates were used instead of root `bun run verify` (known pre-existing `@elizaos/ui#lint:check` red on develop).

## Human-only remainder

Actual account creation cannot be coded and stays on #19910's checklist: creating the provider accounts/OAuth applications in each console, billing and quota setup, redirect URI and publisher verification, webhook secret generation, commercial approvals (Plaid production, Meta use cases, TikTok/X pricing), and storing the real secrets in the secret manager. Once provisioned, `verify:managed-accounts --strict` (and `--json` for evidence capture) verifies each environment without exposing values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Evidence Gate

<!-- evidence-head:6c134aeaface39e1e310c18fc9777aebcd8a8ff4 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered pixels or layout changed in this scoped contract, verifier, evaluation, or workflow-engine change.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered pixels or layout changed in this scoped contract, verifier, evaluation, or workflow-engine change.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual interaction flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - focused deterministic boundary and package validation results are documented above; no protected backend was mutated.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no rendered frontend runtime state changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - this scoped change adds deterministic contracts or evaluation and does not claim a production live-model path.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact focused test counts and fail-closed behavior are documented above; no separate runtime artifact was produced.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no pixels changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@6d2d20f26c725bed66c2988a1667f244b2cbc2c4:packages/skills/skills/contribute-to-eliza"} -->