### PR TITLE
fix(ui): login buttons render invisible/gray labels in idle state

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.button-contrast.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.button-contrast.test.tsx
@@ -1,0 +1,209 @@
+/** Verifies StewardLoginSection button label contrast through the package's configured test harness. */
+// @vitest-environment jsdom
+
+/**
+ * Regression coverage for the invisible-label login buttons. The primary CTAs
+ * pass `variant="ghost"` plus a `bg-accent` className; the ghost variant's
+ * `text-txt-strong` (white on .theme-cloud, where --accent is ALSO white)
+ * combined with a blanket `disabled:opacity-50` rendered the labels as a flat
+ * washed-out bar — only the loading spinner was legible. These tests pin the
+ * merged class list: the accent fill must keep `text-accent-foreground` in
+ * idle/hover/disabled (never the ghost variant's `text-txt-strong`, never
+ * `disabled:opacity-50`), and the idle button must render its label enabled.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const emailLoginSpies = vi.hoisted(() => ({
+  start: vi.fn(),
+  verify: vi.fn(),
+  poll: vi.fn(),
+}));
+
+const sessionSpies = vi.hoisted(() => ({
+  sync: vi.fn(),
+  recover: vi.fn(),
+  recoverEmail: vi.fn(),
+  hasAuthedCookie: vi.fn(),
+}));
+
+vi.mock("./passkey-capability", () => ({
+  resolveWebPasskeyCapability: () =>
+    Promise.resolve({ usable: false, reason: "native-without-bridge" }),
+}));
+
+vi.mock("@stwd/sdk", () => ({
+  StewardAuth: class {
+    getProviders() {
+      return Promise.resolve({
+        passkey: false,
+        email: true,
+        siwe: false,
+        siws: false,
+        google: true,
+        discord: false,
+        github: false,
+        twitter: false,
+        oauth: [],
+      });
+    }
+    getSession() {
+      return null;
+    }
+    refreshSession() {
+      return Promise.resolve(null);
+    }
+  },
+}));
+
+vi.mock("../../../shell/steward-url", () => ({
+  resolveBrowserStewardApiUrl: () => "https://api.example.test/steward",
+}));
+
+vi.mock("../../../shell/steward-config", () => ({
+  configuredStewardTenantId: () => "elizacloud",
+  DEFAULT_STEWARD_TENANT_ID: "elizacloud",
+}));
+
+vi.mock("../../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? _key,
+}));
+
+vi.mock("@elizaos/shared/steward-session-client", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@elizaos/shared/steward-session-client")
+  >()),
+  hasStewardAuthedCookie: sessionSpies.hasAuthedCookie,
+}));
+
+vi.mock("../../lib/steward-email-login", () => ({
+  StewardEmailLoginError: class StewardEmailLoginError extends Error {
+    status: number;
+    code: string | null;
+    constructor(message: string, status: number, code: string | null) {
+      super(message);
+      this.name = "StewardEmailLoginError";
+      this.status = status;
+      this.code = code;
+    }
+  },
+  startStewardEmailLogin: emailLoginSpies.start,
+  verifyStewardEmailSignInCode: emailLoginSpies.verify,
+  pollStewardEmailSignInStatus: emailLoginSpies.poll,
+}));
+
+vi.mock("../../lib/steward-session", () => ({
+  hasStewardOAuthCallbackInUrl: () => false,
+  consumeStewardCodeFromQuery: () => null,
+  stripLegacyTokenHashFromAddressBar: () => false,
+  exchangeStewardCodeViaApi: vi.fn(),
+  recoverStewardEmailSessionViaCookie: sessionSpies.recoverEmail,
+  recoverStewardSessionViaCookie: sessionSpies.recover,
+  refreshStewardSessionViaCookie: vi.fn(),
+  syncStewardSessionCookie: sessionSpies.sync,
+}));
+
+vi.mock("../../lib/steward-email-login-complete", () => ({
+  subscribeStewardEmailLoginComplete: vi.fn(() => vi.fn()),
+}));
+
+import StewardLoginSection from "./steward-login-section";
+
+function renderSection() {
+  return render(
+    <MemoryRouter initialEntries={["/login"]}>
+      <StewardLoginSection />
+    </MemoryRouter>,
+  );
+}
+
+/**
+ * Asserts the merged class list keeps the accent CTA's label legible on the
+ * accent fill in every state instead of inheriting the ghost variant's
+ * neutral text color or a blanket disabled fade.
+ */
+function expectAccentLabelContrast(button: HTMLElement) {
+  const classes = button.className;
+  // Idle: label color must be the accent's paired foreground, not the ghost
+  // variant's text-txt-strong (which equals the accent fill on .theme-cloud).
+  expect(classes).toMatch(/(^| )text-accent-foreground( |$)/);
+  expect(classes).not.toMatch(/(^| )text-txt-strong( |$)/);
+  // Hover: keep the paired foreground (ghost's hover:text-txt-strong loses).
+  expect(classes).toContain("hover:text-accent-foreground");
+  // Disabled: dim the FILL, never fade the whole button to a gray bar.
+  expect(classes).not.toContain("disabled:opacity-50");
+  expect(classes).toContain("disabled:text-accent-foreground");
+}
+
+describe("StewardLoginSection button label contrast", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    emailLoginSpies.start.mockResolvedValue({
+      expiresAt: Date.now() + 600_000,
+      challengeId: "challenge-1",
+      pollSecret: "poll-secret",
+    });
+    emailLoginSpies.poll.mockResolvedValue("pending");
+    sessionSpies.sync.mockResolvedValue(undefined);
+    sessionSpies.recover.mockResolvedValue({ ok: true });
+    sessionSpies.recoverEmail.mockResolvedValue({ ok: true });
+    sessionSpies.hasAuthedCookie.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders the idle Magic Link button enabled with a visible label", async () => {
+    renderSection();
+    const magicLink = await screen.findByRole<HTMLButtonElement>("button", {
+      name: /Magic Link/i,
+    });
+    expect(magicLink.disabled).toBe(false);
+    expect(magicLink.textContent).toContain("Magic Link");
+    // The bordered secondary CTA keeps explicit label color + border in the
+    // disabled state instead of a whole-button opacity fade.
+    expect(magicLink.className).toMatch(/(^| )text-txt( |$)/);
+    expect(magicLink.className).not.toContain("disabled:opacity-50");
+  });
+
+  it("keeps OAuth button labels legible without a blanket disabled fade", async () => {
+    renderSection();
+    const google = await screen.findByRole<HTMLButtonElement>("button", {
+      name: /Google/i,
+    });
+    expect(google.textContent).toContain("Google");
+    expect(google.className).toMatch(/(^| )text-txt( |$)/);
+    expect(google.className).not.toContain("disabled:opacity-50");
+  });
+
+  it("renders the email-sent Verify button with accent-contrast label classes in idle and disabled states", async () => {
+    renderSection();
+    const input = await screen.findByPlaceholderText("you@example.com");
+    fireEvent.change(input, { target: { value: "person@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: /Magic Link/i }));
+
+    const codeInput = await screen.findByLabelText("Six-digit code");
+    const verify = screen.getByRole<HTMLButtonElement>("button", {
+      name: /Verify code/i,
+    });
+    expect(verify.textContent).toContain("Verify code");
+    expectAccentLabelContrast(verify);
+
+    // Empty code: the button is disabled but its classes must still pair the
+    // accent fill with its foreground (no opacity fade, no gray bar).
+    expect(verify.disabled).toBe(true);
+
+    // With a complete code the button enables and keeps the same label color.
+    fireEvent.change(codeInput, { target: { value: "123456" } });
+    const enabledVerify = screen.getByRole<HTMLButtonElement>("button", {
+      name: /Verify code/i,
+    });
+    expect(enabledVerify.disabled).toBe(false);
+    expectAccentLabelContrast(enabledVerify);
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -1441,7 +1441,7 @@ export default function StewardLoginSection() {
           type="button"
           onClick={handleVerifySms}
           disabled={loading !== null || smsCode.length !== 6}
-          className="hosted-signin-focus-emphasis flex w-full min-h-touch items-center justify-center gap-2 rounded-md bg-accent px-4 py-3 font-semibold text-accent-foreground transition-[background-color,transform] hover:bg-accent-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+          className="hosted-signin-focus-emphasis flex w-full min-h-touch items-center justify-center gap-2 rounded-md bg-accent px-4 py-3 font-semibold text-accent-foreground transition-[background-color,transform] hover:bg-accent-hover hover:text-accent-foreground active:scale-[0.99] disabled:pointer-events-none disabled:bg-accent/80 disabled:text-accent-foreground"
         >
           {loading === "sms" ? (
             <Spinner />
@@ -1457,7 +1457,7 @@ export default function StewardLoginSection() {
           <Button
             variant="ghost"
             type="button"
-            className="hosted-signin-focus-emphasis inline-flex min-h-touch items-center rounded-md border border-transparent px-3 font-medium text-muted transition-colors hover:text-txt active:scale-[0.98] disabled:pointer-events-none disabled:opacity-50"
+            className="hosted-signin-focus-emphasis inline-flex min-h-touch items-center rounded-md border border-transparent px-3 font-medium text-muted transition-colors hover:text-txt active:scale-[0.98] disabled:pointer-events-none disabled:text-muted"
             onClick={handleSendSms}
             disabled={resendDisabled}
           >
@@ -1503,7 +1503,7 @@ export default function StewardLoginSection() {
           </p>
           <Button
             type="button"
-            className="hosted-signin-focus-emphasis min-h-touch w-full rounded-md bg-accent px-4 py-3 font-semibold text-accent-foreground hover:bg-accent-hover"
+            className="hosted-signin-focus-emphasis min-h-touch w-full rounded-md bg-accent px-4 py-3 font-semibold text-accent-foreground hover:bg-accent-hover hover:text-accent-foreground"
             onClick={() =>
               setRedirectTo(
                 externalSuccessDestination ??
@@ -1618,7 +1618,7 @@ export default function StewardLoginSection() {
               emailCode.length !== 6 ||
               emailCheckState !== "pending"
             }
-            className="flex w-full min-h-touch items-center justify-center gap-2 rounded-md bg-accent px-4 py-3 font-semibold text-accent-foreground transition-[background-color,transform] hover:bg-accent-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+            className="flex w-full min-h-touch items-center justify-center gap-2 rounded-md bg-accent px-4 py-3 font-semibold text-accent-foreground transition-[background-color,transform] hover:bg-accent-hover hover:text-accent-foreground active:scale-[0.99] disabled:pointer-events-none disabled:bg-accent/80 disabled:text-accent-foreground"
           >
             {loading === "email" ? <Spinner /> : <EmailIcon />}{" "}
             {t("cloud.login.emailCode.verify", {
@@ -1647,7 +1647,7 @@ export default function StewardLoginSection() {
         <Button
           variant="ghost"
           type="button"
-          className="inline-flex min-h-touch items-center rounded-md px-3 text-sm font-medium text-muted transition-colors hover:text-txt active:scale-[0.98] disabled:pointer-events-none disabled:opacity-50"
+          className="inline-flex min-h-touch items-center rounded-md px-3 text-sm font-medium text-muted transition-colors hover:text-txt active:scale-[0.98] disabled:pointer-events-none disabled:text-muted"
           onClick={handleEmail}
           disabled={resendDisabled}
         >
@@ -1716,7 +1716,7 @@ export default function StewardLoginSection() {
           type="button"
           onClick={handleVerifyOtpAndRegister}
           disabled={loading !== null || otpCode.trim().length < 4}
-          className="flex w-full min-h-touch items-center justify-center gap-2 rounded-md bg-accent px-4 py-3 font-semibold text-accent-foreground transition-[background-color,transform] hover:bg-accent-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+          className="flex w-full min-h-touch items-center justify-center gap-2 rounded-md bg-accent px-4 py-3 font-semibold text-accent-foreground transition-[background-color,transform] hover:bg-accent-hover hover:text-accent-foreground active:scale-[0.99] disabled:pointer-events-none disabled:bg-accent/80 disabled:text-accent-foreground"
         >
           {loading === "passkey" ? <Spinner /> : <PasskeyIcon />}{" "}
           {t("cloud.login.otp.createPasskey", {
@@ -1741,7 +1741,7 @@ export default function StewardLoginSection() {
           <Button
             variant="ghost"
             type="button"
-            className="inline-flex min-h-touch items-center rounded-md px-2 font-medium text-muted transition-colors hover:text-txt active:scale-[0.98] disabled:pointer-events-none disabled:opacity-50"
+            className="inline-flex min-h-touch items-center rounded-md px-2 font-medium text-muted transition-colors hover:text-txt active:scale-[0.98] disabled:pointer-events-none disabled:text-muted"
             disabled={loading !== null}
             onClick={startPasskeySignup}
           >
@@ -1815,7 +1815,7 @@ export default function StewardLoginSection() {
             type="button"
             onClick={handleSendSms}
             disabled={isLoading}
-            className="hosted-signin-focus-emphasis flex w-full min-h-touch items-center justify-center gap-2 rounded-md bg-accent px-4 py-3 font-semibold text-accent-foreground transition-[background-color,transform] hover:bg-accent-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+            className="hosted-signin-focus-emphasis flex w-full min-h-touch items-center justify-center gap-2 rounded-md bg-accent px-4 py-3 font-semibold text-accent-foreground transition-[background-color,transform] hover:bg-accent-hover hover:text-accent-foreground active:scale-[0.99] disabled:pointer-events-none disabled:bg-accent/80 disabled:text-accent-foreground"
           >
             {loading === "sms" ? (
               <Spinner />
@@ -1881,7 +1881,7 @@ export default function StewardLoginSection() {
             type="button"
             onClick={handlePasskey}
             disabled={isLoading}
-            className="flex min-h-touch flex-1 items-center justify-center gap-2 rounded-md border border-transparent bg-accent px-4 py-3 font-semibold text-accent-foreground transition-[background-color,border-color,transform] hover:bg-accent-hover hover:text-accent-foreground active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+            className="flex min-h-touch flex-1 items-center justify-center gap-2 rounded-md border border-transparent bg-accent px-4 py-3 font-semibold text-accent-foreground transition-[background-color,border-color,transform] hover:bg-accent-hover hover:text-accent-foreground active:scale-[0.99] disabled:pointer-events-none disabled:bg-accent/80 disabled:text-accent-foreground"
           >
             {loading === "passkey" ? <Spinner /> : <PasskeyIcon />}{" "}
             {t("cloud.login.button.passkey", { defaultValue: "Passkey" })}
@@ -1893,7 +1893,7 @@ export default function StewardLoginSection() {
             type="button"
             onClick={handleEmail}
             disabled={isLoading}
-            className="hosted-signin-focus-emphasis flex min-h-touch flex-1 items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-3 font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+            className="hosted-signin-focus-emphasis flex min-h-touch flex-1 items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-3 font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:border-border/60 disabled:text-muted-strong"
           >
             {loading === "email" ? <Spinner /> : <EmailIcon />}{" "}
             {t("cloud.login.button.magicLink", { defaultValue: "Magic Link" })}
@@ -1955,7 +1955,7 @@ export default function StewardLoginSection() {
               type="button"
               onClick={startPasskeySignup}
               disabled={isLoading}
-              className="hosted-signin-focus-emphasis min-h-touch rounded-md bg-accent px-3 py-2.5 text-sm font-semibold text-accent-foreground hover:bg-accent-hover"
+              className="hosted-signin-focus-emphasis min-h-touch rounded-md bg-accent px-3 py-2.5 text-sm font-semibold text-accent-foreground hover:bg-accent-hover hover:text-accent-foreground"
             >
               {t("cloud.login.passkeyRecovery.setup", {
                 defaultValue: "Set up passkey",
@@ -1985,7 +1985,7 @@ export default function StewardLoginSection() {
               type="button"
               onClick={() => handleOAuth("google")}
               disabled={isLoading}
-              className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+              className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:border-border/60 disabled:text-muted-strong"
             >
               {loading === "google" ? <Spinner /> : <GoogleIcon />}{" "}
               {t("cloud.login.button.google", { defaultValue: "Google" })}
@@ -1997,7 +1997,7 @@ export default function StewardLoginSection() {
               type="button"
               onClick={() => handleOAuth("discord")}
               disabled={isLoading}
-              className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+              className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:border-border/60 disabled:text-muted-strong"
             >
               {loading === "discord" ? (
                 <Spinner />
@@ -2013,7 +2013,7 @@ export default function StewardLoginSection() {
               type="button"
               onClick={() => handleOAuth("github")}
               disabled={isLoading}
-              className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+              className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:border-border/60 disabled:text-muted-strong"
             >
               {loading === "github" ? (
                 <Spinner />
@@ -2035,7 +2035,7 @@ export default function StewardLoginSection() {
             aria-controls="steward-wallet-options"
             onClick={() => setShowWalletOptions((v) => !v)}
             disabled={isLoading || walletButtonsMounted}
-            className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+            className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:border-border/60 disabled:text-muted-strong"
           >
             {t("cloud.login.moreOptions", {
               defaultValue: "Continue with a wallet",
@@ -2102,7 +2102,7 @@ export default function StewardLoginSection() {
                         type="button"
                         onClick={() => handleWalletIntent("ethereum")}
                         disabled={isLoading}
-                        className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+                        className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:border-border/60 disabled:text-muted-strong"
                       >
                         {t("cloud.login.wallet.evm", {
                           defaultValue: "EVM wallet",
@@ -2115,7 +2115,7 @@ export default function StewardLoginSection() {
                         type="button"
                         onClick={() => handleWalletIntent("solana")}
                         disabled={isLoading}
-                        className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+                        className="hosted-signin-focus-emphasis flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:border-border/60 disabled:text-muted-strong"
                       >
                         {t("cloud.login.wallet.solana", {
                           defaultValue: "Solana wallet",


### PR DESCRIPTION
## Symptom

On the eliza.app login screens, the primary action buttons render as a washed-out gray/white bar with the label nearly invisible. Only the loading spinner state is legible. Affects the main login step (Magic Link / Passkey / Text me a code) and the "Check your email" step (Verify code button), plus SMS verify, OTP passkey setup, and the third-party-success Continue button.

## Root cause (styling, not data)

Three compounding class bugs in `steward-login-section.tsx`:

1. **White-on-white idle label.** The primary CTAs pass `variant="ghost"` to the kit `Button` plus a `bg-accent ... text-accent-foreground` override className. On `.theme-cloud` (the login page theme), `--accent` is **brand-white** and the ghost variant's `text-txt-strong` is **also white**. The override's `text-accent-foreground` does win the merge for the idle state, but:
2. **Hover state regressed to variant color.** tailwind-merge treats `hover:text-*` as a separate group, so the ghost variant's `hover:text-txt-strong` (white) survived on buttons whose override only set `hover:bg-accent-hover`, turning the label white-on-white on hover.
3. **Blanket `disabled:opacity-50` gray bar.** The Verify button is disabled until 6 digits are typed, so its default presentation was the whole-button 50% fade: a flat gray block with an illegible label (exactly the screenshot). The kit Button explicitly moved away from blanket opacity fades for this reason (c6bcd8f907d "opacity-50 made CTAs look muddy/gray"), but these inline classNames never picked that up.

## Fix (classes only, zero handler/flow changes)

- **Accent-fill CTAs** (Magic Link primary, Passkey, Verify code, Verify phone, Create passkey, Text me a code, Continue): add `hover:text-accent-foreground`; replace `disabled:opacity-50` with `disabled:bg-accent/80 disabled:text-accent-foreground`, mirroring the kit default variant's disabled treatment.
- **Bordered secondary CTAs** (Magic Link next to Passkey, Google/Discord/GitHub, wallet buttons): replace `disabled:opacity-50` with `disabled:border-border/60 disabled:text-muted-strong`.
- **Text-link buttons** (Resend, Back to login): drop the opacity fade, keep `disabled:text-muted`.

Loading spinner rendering is untouched.

## Before / after

- Before: idle Verify = flat gray bar, label invisible; hover on Magic Link = white label on white fill.
- After: idle/hover/disabled all show the label with proper contrast against the accent fill; disabled reads as a slightly dimmed fill with a legible label.

## Tests

- New `steward-login-section.button-contrast.test.tsx` pins the merged class contract: accent CTAs keep `text-accent-foreground` across idle/hover/disabled, never inherit ghost's `text-txt-strong`, and no login button reintroduces `disabled:opacity-50`. Also asserts the idle Magic Link button renders enabled with its label.
- Full login dir suite: **85/85 passing** (82 existing + 3 new).
- biome clean.

Related: #23023 (the 6-digit-code email mismatch on the same screen; separate concern), #23126 (passkey autocomplete; no scope overlap).