### PR TITLE
fix(logger): honor maxMemoryLogs by resizing the shared ring buffer instead of clearing it

### DIFF
--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -437,20 +437,60 @@ describe("in-memory buffer retention (maxMemoryLogs)", () => {
     expect(lineCount(recentLogs())).toBe(100);
   });
 
-  it("ignores non-positive or NaN caps without clearing the buffer", () => {
+  it("ignores invalid caps without clearing the buffer or disabling retention", () => {
     const logger = createLogger({ level: "info", maxMemoryLogs: 4 });
     logger.clear();
     for (let i = 0; i < 4; i++) logger.info(`keep-${i}`);
     const before = recentLogs();
     expect(lineCount(before)).toBe(4);
 
-    // A zero, negative, or NaN cap must be ignored: prior cap and history stand.
-    createLogger({ level: "info", maxMemoryLogs: 0 });
-    createLogger({ level: "info", maxMemoryLogs: -10 });
-    createLogger({ level: "info", maxMemoryLogs: Number.NaN });
+    // Every invalid shape must be ignored so the prior cap (4) and the retained
+    // history both stand. A fractional value such as 0.5 is the specific
+    // fail-open guarded here: floored it would become 0 and empty the ring.
+    const invalidCaps = [
+      0,
+      -10,
+      0.5,
+      1.5,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      Number.MAX_SAFE_INTEGER + 1,
+    ];
+    for (const cap of invalidCaps) {
+      createLogger({ level: "info", maxMemoryLogs: cap });
+      const after = recentLogs();
+      expect(after).toBe(before);
+      expect(lineCount(after)).toBe(4);
+    }
+
+    // The prior cap remains 4, not silenced: a fifth write still evicts the
+    // oldest entry rather than growing unbounded or dropping everything.
+    logger.info("keep-4");
+    const grown = recentLogs();
+    expect(lineCount(grown)).toBe(4);
+    expect(grown).toContain("keep-4");
+    expect(grown).not.toContain("keep-0");
+  });
+
+  it("an invalid cap on one logger cannot wipe another logger's shared history", () => {
+    // The in-memory destination is a process-wide singleton, so a bad binding
+    // on any constructed logger must not perturb an unrelated logger's view.
+    const base = createLogger({ level: "info", maxMemoryLogs: 100 });
+    base.clear();
+    base.info("shared-A");
+    base.info("shared-B");
+    const before = recentLogs();
+
+    createLogger({ level: "info", maxMemoryLogs: 0.5 });
+    createLogger({ level: "info", maxMemoryLogs: Number.POSITIVE_INFINITY });
+
+    // A second, unrelated logger reads the same untouched shared buffer.
+    createLogger({ level: "info" });
     const after = recentLogs();
     expect(after).toBe(before);
-    expect(lineCount(after)).toBe(4);
+    expect(after).toContain("shared-A");
+    expect(after).toContain("shared-B");
   });
 });
 

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -377,6 +377,83 @@ describe("logger", () => {
   });
 });
 
+// #23217: `maxMemoryLogs` on LoggerBindings must resize the shared in-memory
+// ring buffer in place instead of destructively clearing it. Prior code only
+// called `.clear()` (never resized), so the documented option wiped every other
+// logger's recent-log history and left retention hardcoded at 100. The buffer
+// is a process-wide singleton, so these assertions cover both the sizing
+// contract and the no-wipe invariant.
+describe("in-memory buffer retention (maxMemoryLogs)", () => {
+  const lineCount = (s: string): number =>
+    s === "" ? 0 : s.split("\n").length;
+
+  afterEach(() => {
+    // Restore the process-wide default cap and empty the shared singleton so
+    // later suites observe the original 100-entry buffer.
+    createLogger({ level: "info", maxMemoryLogs: 100 });
+    createLogger({ level: "info" }).clear();
+    vi.restoreAllMocks();
+  });
+
+  it("bounds retention to the requested cap and evicts oldest entries", () => {
+    const logger = createLogger({ level: "info", maxMemoryLogs: 3 });
+    logger.clear();
+    for (let i = 0; i < 8; i++) logger.info(`entry-${i}`);
+    const logs = recentLogs();
+    expect(lineCount(logs)).toBeLessThanOrEqual(3);
+    expect(logs).toContain("entry-7");
+    expect(logs).not.toContain("entry-0");
+  });
+
+  it("does not wipe the shared buffer when a sized logger is constructed", () => {
+    const base = createLogger({ level: "info", maxMemoryLogs: 100 });
+    base.clear();
+    base.info("prior-A");
+    base.info("prior-B");
+    const before = recentLogs();
+    expect(before).toContain("prior-A");
+    expect(before).toContain("prior-B");
+
+    // Constructing a sized logger must preserve the earlier history.
+    createLogger({ level: "info", maxMemoryLogs: 5 });
+    const after = recentLogs();
+    expect(after).toContain("prior-A");
+    expect(after).toContain("prior-B");
+  });
+
+  it("raising the cap retains all entries up to the new size", () => {
+    const logger = createLogger({ level: "info", maxMemoryLogs: 200 });
+    logger.clear();
+    for (let i = 0; i < 150; i++) logger.info(`n-${i}`);
+    expect(lineCount(recentLogs())).toBe(150);
+  });
+
+  it("keeps the default 100 cap when maxMemoryLogs is omitted", () => {
+    // Reset to the documented default, then build a logger that omits the field.
+    createLogger({ level: "info", maxMemoryLogs: 100 });
+    const logger = createLogger({ level: "info" });
+    logger.clear();
+    for (let i = 0; i < 130; i++) logger.info(`d-${i}`);
+    expect(lineCount(recentLogs())).toBe(100);
+  });
+
+  it("ignores non-positive or NaN caps without clearing the buffer", () => {
+    const logger = createLogger({ level: "info", maxMemoryLogs: 4 });
+    logger.clear();
+    for (let i = 0; i < 4; i++) logger.info(`keep-${i}`);
+    const before = recentLogs();
+    expect(lineCount(before)).toBe(4);
+
+    // A zero, negative, or NaN cap must be ignored: prior cap and history stand.
+    createLogger({ level: "info", maxMemoryLogs: 0 });
+    createLogger({ level: "info", maxMemoryLogs: -10 });
+    createLogger({ level: "info", maxMemoryLogs: Number.NaN });
+    const after = recentLogs();
+    expect(after).toBe(before);
+    expect(lineCount(after)).toBe(4);
+  });
+});
+
 // #16356: the file-log path's stripAnsi built an invalid regex (an extra escape
 // level made `\\(B` an unterminated group), so `new RegExp` threw on every call
 // and output.log silently stayed empty. Guard the regex compiles and strips.

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -93,6 +93,14 @@ export interface LoggerBindings extends Record<string, unknown> {
   level?: string;
   namespace?: string;
   namespaces?: string[];
+  /**
+   * Retention cap for the process-wide in-memory ring buffer backing
+   * `recentLogs()` and WebSocket log streaming. A positive value resizes the
+   * shared buffer in place, preserving already-captured history; raising the
+   * cap keeps prior entries and lowering it trims the oldest. Non-positive or
+   * non-finite values are ignored, leaving the current cap (default 100)
+   * unchanged. Constructing a logger never clears the shared buffer.
+   */
   maxMemoryLogs?: number;
   __forceType?: "browser" | "node"; // For testing - forces specific environment behavior
 }
@@ -146,6 +154,14 @@ interface InMemoryDestination {
   write: (entry: LogEntry) => void;
   clear: () => void;
   recentLogs: () => string;
+  /**
+   * Resize the ring buffer's retention cap in place. Raising the cap keeps
+   * existing entries; lowering it trims the oldest entries from the front so
+   * at most `maxLogs` remain. Non-positive or non-finite values are ignored so
+   * a bad binding cannot silently disable retention. Never clears the buffer —
+   * the buffer is shared process-wide, so prior history is preserved.
+   */
+  setMaxLogs: (maxLogs: number) => void;
 }
 
 // ============================================================================
@@ -1147,13 +1163,14 @@ export function logChatOut(params: ChatOutLogParams): string {
 /**
  * Creates an in-memory destination for storing recent logs
  */
-function createInMemoryDestination(maxLogs = 100): InMemoryDestination {
+function createInMemoryDestination(initialMaxLogs = 100): InMemoryDestination {
   const logs: LogEntry[] = [];
+  let maxLogs = initialMaxLogs;
 
   return {
     write(entry: LogEntry): void {
       logs.push(entry);
-      if (logs.length > maxLogs) {
+      while (logs.length > maxLogs) {
         logs.shift();
       }
       if (logListeners.size === 0) return;
@@ -1184,6 +1201,16 @@ function createInMemoryDestination(maxLogs = 100): InMemoryDestination {
     },
     clear(): void {
       logs.length = 0;
+    },
+    setMaxLogs(nextMaxLogs: number): void {
+      // Ignore non-positive or non-finite caps: a bad binding must not disable
+      // retention or wipe the shared buffer. Only trim when the cap shrinks
+      // below the current fill so existing history is preserved.
+      if (!Number.isFinite(nextMaxLogs) || nextMaxLogs <= 0) return;
+      maxLogs = Math.floor(nextMaxLogs);
+      while (logs.length > maxLogs) {
+        logs.shift();
+      }
     },
     recentLogs(): string {
       return logs
@@ -1455,9 +1482,12 @@ function extractBindingsConfig(bindings: LoggerBindings | boolean): {
 function createLogger(bindings: LoggerBindings | boolean = false): Logger {
   const { level, base, maxMemoryLogs } = extractBindingsConfig(bindings);
 
-  // Reset memory buffer if custom limit requested
-  if (typeof maxMemoryLogs === "number" && maxMemoryLogs > 0) {
-    globalInMemoryDestination.clear();
+  // Apply the requested retention cap in place. Resizing preserves the shared
+  // buffer's existing history instead of destroying every other logger's
+  // recent-logs/streaming window; non-positive or NaN values are ignored by
+  // setMaxLogs so the prior cap stands.
+  if (typeof maxMemoryLogs === "number") {
+    globalInMemoryDestination.setMaxLogs(maxMemoryLogs);
   }
 
   // Check if we should force browser behavior (for testing)

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -157,9 +157,11 @@ interface InMemoryDestination {
   /**
    * Resize the ring buffer's retention cap in place. Raising the cap keeps
    * existing entries; lowering it trims the oldest entries from the front so
-   * at most `maxLogs` remain. Non-positive or non-finite values are ignored so
-   * a bad binding cannot silently disable retention. Never clears the buffer —
-   * the buffer is shared process-wide, so prior history is preserved.
+   * at most `maxLogs` remain. Only a finite safe integer `>= 1` is honored;
+   * fractional, non-finite, unsafe-integer, and non-positive values are ignored
+   * so a bad binding cannot silently disable or wipe retention. Never clears
+   * the buffer — the buffer is shared process-wide, so prior history is
+   * preserved.
    */
   setMaxLogs: (maxLogs: number) => void;
 }
@@ -1203,11 +1205,15 @@ function createInMemoryDestination(initialMaxLogs = 100): InMemoryDestination {
       logs.length = 0;
     },
     setMaxLogs(nextMaxLogs: number): void {
-      // Ignore non-positive or non-finite caps: a bad binding must not disable
-      // retention or wipe the shared buffer. Only trim when the cap shrinks
-      // below the current fill so existing history is preserved.
-      if (!Number.isFinite(nextMaxLogs) || nextMaxLogs <= 0) return;
-      maxLogs = Math.floor(nextMaxLogs);
+      // A bad binding must not disable retention or wipe the shared buffer, and
+      // there is no public rounding contract, so honor only a finite safe
+      // integer cap of at least 1. `Number.isSafeInteger` rejects fractional
+      // (e.g. 0.5, which would otherwise floor to 0 and empty the ring), NaN,
+      // ±Infinity, and unsafe-integer inputs in one check; the prior cap and
+      // history then stand. Only trim when the cap shrinks below the current
+      // fill so existing history is preserved.
+      if (!Number.isSafeInteger(nextMaxLogs) || nextMaxLogs < 1) return;
+      maxLogs = nextMaxLogs;
       while (logs.length > maxLogs) {
         logs.shift();
       }
@@ -1484,8 +1490,8 @@ function createLogger(bindings: LoggerBindings | boolean = false): Logger {
 
   // Apply the requested retention cap in place. Resizing preserves the shared
   // buffer's existing history instead of destroying every other logger's
-  // recent-logs/streaming window; non-positive or NaN values are ignored by
-  // setMaxLogs so the prior cap stands.
+  // recent-logs/streaming window; fractional, non-finite, unsafe-integer, and
+  // non-positive values are ignored by setMaxLogs so the prior cap stands.
   if (typeof maxMemoryLogs === "number") {
     globalInMemoryDestination.setMaxLogs(maxMemoryLogs);
   }


### PR DESCRIPTION
# Relates to

Closes #23217

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run; the owning package's `test`, `typecheck`, and `lint` all pass (logs below). `bun run verify` was not run to completion on this constrained host — see **Known gaps / failures**.
- [x] A reviewer can confirm the change works from the before/after reproduction and the failing-then-passing regression tests attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@3775f57b4e51c7fe6e5a1bb76aeaf00b487b2cbc:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from and current with the latest `origin/develop` (`b89c5eee9e`); zero conflicts.
- [ ] `bun run verify` completed post-sync — not run to completion on this host; unrelated blocker documented in **Known gaps / failures**. Focused package gates (`test`, `typecheck`, `lint`) pass.

# Risks

Low. The change is confined to `@elizaos/logger`'s in-memory ring buffer. It removes a destructive `clear()` and adds an additive in-place resize, so it only ever *preserves more* recent-log/streaming history than before. No public signature changes; `setMaxLogs` is added to an internal-only `InMemoryDestination` interface.

# Background

## What does this PR do?

`LoggerBindings.maxMemoryLogs` is a published public option documented to size the process-wide in-memory ring buffer that backs `recentLogs()` and WebSocket log streaming. It did neither:

- `createLogger` only used the value to call `globalInMemoryDestination.clear()` — it never resized any destination.
- The single in-memory destination is a module-level singleton built once via `createInMemoryDestination(100)` and never rebuilt, so the cap stayed hardcoded at **100** regardless of the requested value.
- Worse: merely constructing a logger that passed `maxMemoryLogs` **wiped the entire shared buffer**, destroying the recent-log history and streaming window belonging to every other logger in the process.

This PR makes the option honor its contract without destroying shared state:

- Adds `InMemoryDestination.setMaxLogs(n)` which raises or lowers the retention cap **in place**. Raising keeps existing entries; lowering trims only the oldest from the front so at most `n` remain. Non-positive/non-finite values are ignored so a bad binding cannot silently disable retention or wipe the buffer.
- `createLogger` now calls `setMaxLogs(maxMemoryLogs)` instead of `clear()`, preserving prior history.
- The `write` path's overflow trim is now a `while` loop so a shrink applied mid-stream stays bounded.
- Documents the honored contract as JSDoc on the exported `maxMemoryLogs` field.

## What kind of change is this?

Bug fix (non-breaking change which fixes a contract break and a destructive side effect on a published public API).

# Documentation changes needed?

Interface-level JSDoc for `LoggerBindings.maxMemoryLogs` is added in this PR. No separate docs site page references this option.

# Testing

## Where should a reviewer start?

`packages/logger/src/logger.test.ts` → the new `describe("in-memory buffer retention (maxMemoryLogs)")` block, and `packages/logger/src/logger.ts` (`createInMemoryDestination` / `createLogger`).

## Detailed testing steps

```bash
bun install --filter='@elizaos/logger'   # (full install also works; see notes)
cd packages/logger
bun run test        # 58 passed
bun run typecheck   # clean
bun run lint        # clean
```

The seven cases assert: (a) sizing bounds retention + evicts oldest, (b) constructing a sized logger does **not** wipe the shared buffer, (c) raising the cap retains all entries up to the new size, (d) omitting the field leaves the default 100 unchanged, (e) an invalid cap (`0`, `-10`, `0.5`, `1.5`, `NaN`, `±Infinity`, `MAX_SAFE_INTEGER+1`) is ignored — no clear, prior cap and history stand, and the cap is not silenced, and (f) an invalid cap on one logger cannot wipe another logger's shared history. Cases (a)–(c), (e), and (f) fail on the pre-fix code and pass with the fix.

# Evidence Gate

<!-- evidence-head:0e249cdf44ce899dcd7515bae371593a834b2add -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; `@elizaos/logger` is a headless library. Evidence is the CLI reproduction + unit-test output below.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; `@elizaos/logger` is a headless library.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior is verified by the reproduction script and unit tests below.
<!-- evidence-row:backend-logs -->
- [x] Real `recentLogs()` line counts through the actual buffer code path, before (develop) vs after (this PR):
<details><summary>reproduction output — recentLogs() line counts (backend logger path)</summary>

```
=== BEFORE (develop, broken) ===
before createLogger(maxMemoryLogs): 2 lines
after createLogger(maxMemoryLogs): 0 lines            <-- shared buffer WIPED on construction
after 12 logs into maxMemoryLogs=5 buffer: 12 lines   <-- retention NOT bounded to 5

=== AFTER (this PR, fixed) ===
before createLogger(maxMemoryLogs): 2 lines
after createLogger(maxMemoryLogs): 2 lines            <-- prior history PRESERVED
after 12 logs into maxMemoryLogs=5 buffer: 5 lines    <-- retention bounded to requested 5
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved; this is a Node logging-buffer fix.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change; this is a logging-buffer fix.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = the in-memory ring-buffer state, exercised by the regression tests (failing on the pre-fix code, passing with the fix). The fractional-cap fail-open (`maxMemoryLogs: 0.5` floored to `0` and emptied the shared ring) is now guarded by requiring a finite safe integer `>= 1` in `setMaxLogs`:
<details><summary>logger.test.ts output — regressions fail on the pre-fix code, all 58 pass with the fix</summary>

```
--- pre-fix logger.ts (original clear-based fix reverted) ---
 × bounds retention to the requested cap and evicts oldest entries
 × does not wipe the shared buffer when a sized logger is constructed
 × raising the cap retains all entries up to the new size
      Tests  3 failed | 54 passed (57)

--- pre-fix setMaxLogs (floor-based validation, this review's fractional-cap defect) ---
 × ignores invalid caps without clearing the buffer or disabling retention
 × an invalid cap on one logger cannot wipe another logger's shared history
      Tests  2 failed | 56 passed (58)

--- with this PR's fix ---
 Test Files  2 passed (2)
      Tests  58 passed (58)

--- typecheck / lint (with fix) ---
$ tsc --noEmit -p tsconfig.json        (clean, no output)
$ node ../scripts/run-biome-typescript.mjs src check
Checked 5 files in 65ms. No fixes applied.
```
</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/model behavior changes in this PR.

## Backend + frontend logs

See the **backend-logs** and **domain-artifacts** rows above; all output is real, captured from `packages/logger`. A mirror copy of the raw artifacts is also published as a public gist: https://gist.github.com/agent-cortex/ee37a1f48cbf4aa36071e1ab71868b82

## Screenshots (before / after) + video walkthrough

N/A - headless logging library; there is no rendered surface to screenshot. Behavior evidence is the before/after reproduction above.

## Audio / voice walkthrough

N/A - no audio/voice path touched.

## Known gaps / failures

- **`bun run verify` not run to completion**: the full repo install is gated on this host by a global bun `minimumReleaseAge` policy (a freshly-published `viem@2.55.17`, already pinned in the committed lockfile, is younger than the 7-day window). The workspace was installed to run the focused gates; the repo-wide `verify` aggregate was not completed. The change is isolated to `packages/logger`, whose `test`, `typecheck`, and `lint` all pass (output above).
- **Immutable attachment URLs**: the evidence is pasted inline (per CONTRIBUTING.md § Evidence "long logs in a `<details>` block"), with a public gist mirror, because the headless GitHub attachment-upload session could not clear a device-verification interstitial on this host and fork contributors cannot upload to the `pr-evidence` release. All output is real, captured command output.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@3775f57b4e51c7fe6e5a1bb76aeaf00b487b2cbc:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@3775f57b4e51c7fe6e5a1bb76aeaf00b487b2cbc:packages/skills/skills/contribute-to-eliza"} -->


