### PR TITLE
fix(agent): fail closed on cyclic or over-deep remote-plugin provenance walks

### DIFF
--- a/packages/agent/src/services/remote-plugin-adapter.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.ts
@@ -1237,66 +1237,192 @@ function remotePluginModuleProvenancePayload(
 
 /** Nesting cap for untrusted remote-plugin provenance canonicalization. */
 const MAX_REMOTE_PLUGIN_PROVENANCE_DEPTH = 32;
-/** Node cap so a wide DAG cannot exhaust the heap during digest hashing. */
+/**
+ * Width/work cap. Every slot the walk visits (one array element, one own
+ * enumerable string key) costs one node, and a container charges its whole
+ * declared width BEFORE any slot is allocated, read, or traversed, so a huge
+ * primitive-width array/object cannot burn CPU or heap ahead of the bound.
+ */
 const MAX_REMOTE_PLUGIN_PROVENANCE_NODES = 4_096;
 
-class RemotePluginProvenanceWalkBoundError extends Error {
-  readonly reason: "cycle" | "depth" | "nodes";
+type RemotePluginProvenanceWalkBound =
+  | "cycle"
+  | "depth"
+  | "nodes"
+  | "reflection";
 
-  constructor(reason: "cycle" | "depth" | "nodes") {
-    super(`Remote plugin provenance walk exceeded ${reason} bound`);
+type RemotePluginProvenanceWalkBudget = { remaining: number };
+
+class RemotePluginProvenanceWalkBoundError extends Error {
+  readonly reason: RemotePluginProvenanceWalkBound;
+
+  constructor(
+    reason: RemotePluginProvenanceWalkBound,
+    options?: { cause?: unknown },
+  ) {
+    super(
+      reason === "reflection"
+        ? "Remote plugin provenance walk could not reflect on the module value"
+        : `Remote plugin provenance walk exceeded ${reason} bound`,
+      options,
+    );
     this.name = "RemotePluginProvenanceWalkBoundError";
     this.reason = reason;
   }
 }
 
+/**
+ * Runs one descriptor-only reflection step on untrusted module data. A hostile
+ * or revoked proxy can throw from any trap; that failure becomes the typed
+ * walk-bound rejection (cause preserved internally) instead of leaking a raw
+ * TypeError out of the trust evaluation.
+ */
+function reflectForRemotePluginProvenance<T>(read: () => T): T {
+  try {
+    return read();
+  } catch (error) {
+    throw new RemotePluginProvenanceWalkBoundError("reflection", {
+      cause: error,
+    });
+  }
+}
+
+function chargeRemotePluginProvenanceNodes(
+  budget: RemotePluginProvenanceWalkBudget,
+  cost: number,
+): void {
+  budget.remaining -= cost;
+  if (budget.remaining < 0) {
+    throw new RemotePluginProvenanceWalkBoundError("nodes");
+  }
+}
+
+/**
+ * Reads one own property descriptor's data value. Accessor properties are
+ * refused rather than invoked: running an untrusted getter during trust
+ * evaluation is exactly the execution this walk must not perform.
+ */
+function remotePluginProvenanceDescriptorValue(
+  descriptor: PropertyDescriptor | undefined,
+): unknown {
+  if (descriptor === undefined) return undefined;
+  if (!("value" in descriptor)) {
+    throw new RemotePluginProvenanceWalkBoundError("reflection");
+  }
+  return descriptor.value;
+}
+
 function canonicalizeForRemotePluginProvenance(
   value: unknown,
-  seen: WeakSet<object> = new WeakSet(),
+  ancestors: Set<object> = new Set(),
   depth = 0,
-  budget = { remaining: MAX_REMOTE_PLUGIN_PROVENANCE_NODES },
+  budget: RemotePluginProvenanceWalkBudget = {
+    remaining: MAX_REMOTE_PLUGIN_PROVENANCE_NODES,
+  },
 ): unknown {
+  if (value === null || typeof value !== "object") return value;
   if (depth > MAX_REMOTE_PLUGIN_PROVENANCE_DEPTH) {
     throw new RemotePluginProvenanceWalkBoundError("depth");
   }
-  if (Array.isArray(value)) {
-    if (seen.has(value)) {
-      throw new RemotePluginProvenanceWalkBoundError("cycle");
-    }
-    seen.add(value);
-    budget.remaining -= 1;
-    if (budget.remaining < 0) {
-      throw new RemotePluginProvenanceWalkBoundError("nodes");
-    }
-    return value.map((entry) =>
-      canonicalizeForRemotePluginProvenance(entry, seen, depth + 1, budget),
+  // Path-local visiting: only the ancestors of the current path count as a
+  // cycle and each is dropped on unwind, so an acyclic DAG that repeats a
+  // shared reference still serializes at every path exactly like the
+  // unbounded walker did.
+  if (ancestors.has(value)) {
+    throw new RemotePluginProvenanceWalkBoundError("cycle");
+  }
+  const isArray = reflectForRemotePluginProvenance(() => Array.isArray(value));
+  ancestors.add(value);
+  try {
+    return isArray
+      ? canonicalizeRemotePluginProvenanceArray(value, ancestors, depth, budget)
+      : canonicalizeRemotePluginProvenanceObject(
+          value,
+          ancestors,
+          depth,
+          budget,
+        );
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function canonicalizeRemotePluginProvenanceArray(
+  value: object,
+  ancestors: Set<object>,
+  depth: number,
+  budget: RemotePluginProvenanceWalkBudget,
+): unknown[] {
+  const lengthDescriptor = reflectForRemotePluginProvenance(() =>
+    Object.getOwnPropertyDescriptor(value, "length"),
+  );
+  const length = remotePluginProvenanceDescriptorValue(lengthDescriptor);
+  if (
+    typeof length !== "number" ||
+    !Number.isSafeInteger(length) ||
+    length < 0
+  ) {
+    throw new RemotePluginProvenanceWalkBoundError("reflection");
+  }
+  chargeRemotePluginProvenanceNodes(budget, length);
+  const canonical: unknown[] = new Array(length);
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = reflectForRemotePluginProvenance(() =>
+      Object.getOwnPropertyDescriptor(value, String(index)),
+    );
+    canonical[index] = canonicalizeForRemotePluginProvenance(
+      remotePluginProvenanceDescriptorValue(descriptor),
+      ancestors,
+      depth + 1,
+      budget,
     );
   }
-  if (value && typeof value === "object") {
-    if (seen.has(value)) {
-      throw new RemotePluginProvenanceWalkBoundError("cycle");
-    }
-    seen.add(value);
-    budget.remaining -= 1;
-    if (budget.remaining < 0) {
-      throw new RemotePluginProvenanceWalkBoundError("nodes");
-    }
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>)
-        .filter(([, entry]) => entry !== undefined)
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([key, entry]) => [
-          key,
-          canonicalizeForRemotePluginProvenance(entry, seen, depth + 1, budget),
-        ]),
+  return canonical;
+}
+
+function canonicalizeRemotePluginProvenanceObject(
+  value: object,
+  ancestors: Set<object>,
+  depth: number,
+  budget: RemotePluginProvenanceWalkBudget,
+): Record<string, unknown> {
+  const keys = reflectForRemotePluginProvenance(() => Reflect.ownKeys(value));
+  chargeRemotePluginProvenanceNodes(budget, keys.length);
+  const entries: Array<[string, unknown]> = [];
+  for (const key of keys) {
+    if (typeof key !== "string") continue;
+    const descriptor = reflectForRemotePluginProvenance(() =>
+      Object.getOwnPropertyDescriptor(value, key),
+    );
+    if (descriptor === undefined || !descriptor.enumerable) continue;
+    const entry = remotePluginProvenanceDescriptorValue(descriptor);
+    if (entry === undefined) continue;
+    entries.push([key, entry]);
+  }
+  entries.sort(([left], [right]) => left.localeCompare(right));
+  const canonical: Record<string, unknown> = {};
+  for (const [key, entry] of entries) {
+    canonical[key] = canonicalizeForRemotePluginProvenance(
+      entry,
+      ancestors,
+      depth + 1,
+      budget,
     );
   }
-  return value;
+  return canonical;
 }
 
 function remotePluginModuleProvenanceDigestResult(
   module: RemotePluginModuleManifest,
-): { ok: true } | { ok: false; reason: "mismatch" | "walk-bound" } {
+):
+  | { ok: true }
+  | { ok: false; reason: "mismatch" }
+  | {
+      ok: false;
+      reason: "walk-bound";
+      bound: RemotePluginProvenanceWalkBound;
+      cause: RemotePluginProvenanceWalkBoundError;
+    } {
   const provenance = module.provenance;
   if (!provenance) return { ok: false, reason: "mismatch" };
   try {
@@ -1309,16 +1435,17 @@ function remotePluginModuleProvenanceDigestResult(
     return { ok: false, reason: "mismatch" };
   } catch (error) {
     if (error instanceof RemotePluginProvenanceWalkBoundError) {
-      return { ok: false, reason: "walk-bound" };
+      // The bound and the underlying trap failure stay internal; the public
+      // trust decision only says the walk hit its bound.
+      return {
+        ok: false,
+        reason: "walk-bound",
+        bound: error.reason,
+        cause: error,
+      };
     }
     throw error;
   }
-}
-
-function remotePluginModuleProvenanceDigestMatches(
-  module: RemotePluginModuleManifest,
-): boolean {
-  return remotePluginModuleProvenanceDigestResult(module).ok;
 }
 
 function hashRemotePluginModuleForProvenance(
@@ -1332,12 +1459,16 @@ function hashRemotePluginModuleForProvenance(
 function canonicalJsonForRemotePluginProvenance(
   module: RemotePluginModuleManifest,
 ): string {
-  const {
-    capabilityEndpointId: _endpointId,
-    provenance: _provenance,
-    ...rest
-  } = module;
-  return JSON.stringify(canonicalizeForRemotePluginProvenance(rest));
+  const rest = reflectForRemotePluginProvenance(() => {
+    const {
+      capabilityEndpointId: _endpointId,
+      provenance: _provenance,
+      ...clone
+    } = module;
+    return clone;
+  });
+  const canonical = canonicalizeForRemotePluginProvenance(rest);
+  return reflectForRemotePluginProvenance(() => JSON.stringify(canonical));
 }
 
 function trustDecision(

--- a/packages/agent/src/services/remote-plugin-adapter.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.ts
@@ -100,7 +100,8 @@ export type RemotePluginTrustDecision = {
     | "provenance-issuer-not-allowed"
     | "missing-provenance-public-key"
     | "invalid-provenance-signature"
-    | "invalid-provenance-digest";
+    | "invalid-provenance-digest"
+    | "provenance-walk-bound";
   provenanceIssuer?: string;
 };
 
@@ -1178,17 +1179,20 @@ function evaluateRemotePluginTrustPolicy(
           details: { trustDecision: decision },
         });
       }
-      if (!remotePluginModuleProvenanceDigestMatches(module)) {
-        const decision = trustDecision(
-          module,
-          endpointId,
-          false,
-          "invalid-provenance-digest",
-        );
+      const digestMatch = remotePluginModuleProvenanceDigestResult(module);
+      if (!digestMatch.ok) {
+        const reason =
+          digestMatch.reason === "walk-bound"
+            ? "provenance-walk-bound"
+            : "invalid-provenance-digest";
+        const decision = trustDecision(module, endpointId, false, reason);
         decisions.push(decision);
         throw new CapabilityError({
           code: "CAPABILITY_UNAVAILABLE",
-          message: `Remote plugin module "${module.id}" provenance digest does not match module contents.`,
+          message:
+            digestMatch.reason === "walk-bound"
+              ? `Remote plugin module "${module.id}" provenance walk exceeded bound.`
+              : `Remote plugin module "${module.id}" provenance digest does not match module contents.`,
           capability: "plugin",
           method: "plugin.modules.list",
           details: { trustDecision: decision },
@@ -1231,15 +1235,90 @@ function remotePluginModuleProvenancePayload(
   ].join("\n");
 }
 
+/** Nesting cap for untrusted remote-plugin provenance canonicalization. */
+const MAX_REMOTE_PLUGIN_PROVENANCE_DEPTH = 32;
+/** Node cap so a wide DAG cannot exhaust the heap during digest hashing. */
+const MAX_REMOTE_PLUGIN_PROVENANCE_NODES = 4_096;
+
+class RemotePluginProvenanceWalkBoundError extends Error {
+  readonly reason: "cycle" | "depth" | "nodes";
+
+  constructor(reason: "cycle" | "depth" | "nodes") {
+    super(`Remote plugin provenance walk exceeded ${reason} bound`);
+    this.name = "RemotePluginProvenanceWalkBoundError";
+    this.reason = reason;
+  }
+}
+
+function canonicalizeForRemotePluginProvenance(
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+  depth = 0,
+  budget = { remaining: MAX_REMOTE_PLUGIN_PROVENANCE_NODES },
+): unknown {
+  if (depth > MAX_REMOTE_PLUGIN_PROVENANCE_DEPTH) {
+    throw new RemotePluginProvenanceWalkBoundError("depth");
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      throw new RemotePluginProvenanceWalkBoundError("cycle");
+    }
+    seen.add(value);
+    budget.remaining -= 1;
+    if (budget.remaining < 0) {
+      throw new RemotePluginProvenanceWalkBoundError("nodes");
+    }
+    return value.map((entry) =>
+      canonicalizeForRemotePluginProvenance(entry, seen, depth + 1, budget),
+    );
+  }
+  if (value && typeof value === "object") {
+    if (seen.has(value)) {
+      throw new RemotePluginProvenanceWalkBoundError("cycle");
+    }
+    seen.add(value);
+    budget.remaining -= 1;
+    if (budget.remaining < 0) {
+      throw new RemotePluginProvenanceWalkBoundError("nodes");
+    }
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, entry]) => entry !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [
+          key,
+          canonicalizeForRemotePluginProvenance(entry, seen, depth + 1, budget),
+        ]),
+    );
+  }
+  return value;
+}
+
+function remotePluginModuleProvenanceDigestResult(
+  module: RemotePluginModuleManifest,
+): { ok: true } | { ok: false; reason: "mismatch" | "walk-bound" } {
+  const provenance = module.provenance;
+  if (!provenance) return { ok: false, reason: "mismatch" };
+  try {
+    if (
+      hashRemotePluginModuleForProvenance(module) ===
+      provenance.digestSha256.toLowerCase()
+    ) {
+      return { ok: true };
+    }
+    return { ok: false, reason: "mismatch" };
+  } catch (error) {
+    if (error instanceof RemotePluginProvenanceWalkBoundError) {
+      return { ok: false, reason: "walk-bound" };
+    }
+    throw error;
+  }
+}
+
 function remotePluginModuleProvenanceDigestMatches(
   module: RemotePluginModuleManifest,
 ): boolean {
-  const provenance = module.provenance;
-  if (!provenance) return false;
-  return (
-    hashRemotePluginModuleForProvenance(module) ===
-    provenance.digestSha256.toLowerCase()
-  );
+  return remotePluginModuleProvenanceDigestResult(module).ok;
 }
 
 function hashRemotePluginModuleForProvenance(
@@ -1259,24 +1338,6 @@ function canonicalJsonForRemotePluginProvenance(
     ...rest
   } = module;
   return JSON.stringify(canonicalizeForRemotePluginProvenance(rest));
-}
-
-function canonicalizeForRemotePluginProvenance(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map((entry) => canonicalizeForRemotePluginProvenance(entry));
-  }
-  if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>)
-        .filter(([, entry]) => entry !== undefined)
-        .sort(([left], [right]) => left.localeCompare(right))
-        .map(([key, entry]) => [
-          key,
-          canonicalizeForRemotePluginProvenance(entry),
-        ]),
-    );
-  }
-  return value;
 }
 
 function trustDecision(

--- a/packages/agent/src/services/remote-plugin-adapter.walk-bound.test.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.walk-bound.test.ts
@@ -2,8 +2,14 @@
  * Fail-closed provenance canonicalize walk. Origin develop
  * 3775f57b4e51c7fe6e5a1bb76aeaf00b487b2cbc recurses without a cycle/depth
  * bound, so a cyclic or over-deep remote module RangeError'd the agent
- * during requireProvenanceDigestMatch. This suite is the overlay proof.
+ * during requireProvenanceDigestMatch. This suite is the overlay proof, and
+ * also pins the three properties the bound must not break: an acyclic DAG that
+ * repeats a shared reference still hashes exactly like the unbounded walker,
+ * width is charged from the declared length/key count before any allocation,
+ * and the walk reflects on descriptors only — no [[Get]], no [[Has]], no
+ * accessor invocation on untrusted remote module data.
  */
+import { createHash } from "node:crypto";
 import {
   CAPABILITY_ROUTER_SERVICE_TYPE,
   CapabilityError,
@@ -111,6 +117,58 @@ const digestPolicy = {
   requireProvenanceDigestMatch: true,
 };
 
+/**
+ * Independent reimplementation of the pre-bound canonicalizer: sort own
+ * enumerable string keys, drop `undefined` values, expand every reference at
+ * every path it occurs. Used as the compatibility oracle — a module whose
+ * provenance digest is computed this way must still be trusted by the bounded
+ * walk.
+ */
+function legacyCanonical(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(legacyCanonical);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, entry]) => entry !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, legacyCanonical(entry)]),
+    );
+  }
+  return value;
+}
+
+function legacyProvenanceDigest(module: RemotePluginModuleManifest): string {
+  const {
+    capabilityEndpointId: _endpointId,
+    provenance: _provenance,
+    ...rest
+  } = module;
+  return createHash("sha256")
+    .update(JSON.stringify(legacyCanonical(rest)), "utf8")
+    .digest("hex");
+}
+
+/** A module carrying `nest`, with a provenance digest that already matches. */
+function moduleWithNest(nest: unknown): RemotePluginModuleManifest {
+  const module = { ...baseModule(), nest } as RemotePluginModuleManifest;
+  const provenance = module.provenance;
+  if (!provenance) throw new Error("baseModule must carry provenance");
+  return {
+    ...module,
+    provenance: { ...provenance, digestSha256: legacyProvenanceDigest(module) },
+  };
+}
+
+const walkBoundRejection = {
+  code: "CAPABILITY_UNAVAILABLE",
+  capability: "plugin",
+  method: "plugin.modules.list",
+  message: 'Remote plugin module "remote-demo" provenance walk exceeded bound.',
+  details: {
+    trustDecision: { reason: "provenance-walk-bound", trusted: false },
+  },
+};
+
 describe("remote plugin provenance canonicalize walk bound", () => {
   it("fail-closes a cyclic remote module instead of overflowing the stack", async () => {
     const runtime = makeRuntime(makeRouter());
@@ -191,5 +249,312 @@ describe("remote plugin provenance canonicalize walk bound", () => {
         },
       },
     });
+  });
+});
+
+describe("remote plugin provenance repeated-reference compatibility", () => {
+  it("trusts an acyclic DAG that repeats a shared reference", async () => {
+    const runtime = makeRuntime(makeRouter());
+    const shared = { label: "shared", values: [1, 2, 3] };
+    const module = moduleWithNest({
+      left: shared,
+      right: shared,
+      deep: { shared },
+    });
+
+    const result = await syncRemoteCapabilityPlugins(runtime, {
+      modules: [module],
+      trustPolicy: digestPolicy,
+    });
+
+    expect(result.trustDecisions).toMatchObject([
+      { moduleId: "remote-demo", trusted: true, reason: "allowed" },
+    ]);
+  });
+
+  it("trusts a repeated shared array reference at sibling paths", async () => {
+    const runtime = makeRuntime(makeRouter());
+    const shared = ["a", "b"];
+    const module = moduleWithNest([shared, shared, [shared]]);
+
+    const result = await syncRemoteCapabilityPlugins(runtime, {
+      modules: [module],
+      trustPolicy: digestPolicy,
+    });
+
+    expect(result.trustDecisions).toMatchObject([
+      { trusted: true, reason: "allowed" },
+    ]);
+  });
+
+  it("still fail-closes when the repeated reference is a real back edge", async () => {
+    const runtime = makeRuntime(makeRouter());
+    const shared: Record<string, unknown> = { label: "shared" };
+    const cycle: Record<string, unknown> = { shared };
+    shared.parent = cycle;
+
+    await expect(
+      syncRemoteCapabilityPlugins(runtime, {
+        modules: [
+          { ...baseModule(), nest: cycle } as RemotePluginModuleManifest,
+        ],
+        trustPolicy: digestPolicy,
+      }),
+    ).rejects.toMatchObject(walkBoundRejection);
+  });
+});
+
+describe("remote plugin provenance width bound", () => {
+  // The stripped module carries id/name/version plus `nest`: four slots. The
+  // node budget is 4096, so a 4092-entry array lands exactly on the bound.
+  const EXACT_WIDTH = 4096 - 4;
+
+  it("accepts a primitive array exactly on the node bound", async () => {
+    const runtime = makeRuntime(makeRouter());
+    const module = moduleWithNest(
+      Array.from({ length: EXACT_WIDTH }, (_, index) => index),
+    );
+
+    const result = await syncRemoteCapabilityPlugins(runtime, {
+      modules: [module],
+      trustPolicy: digestPolicy,
+    });
+
+    expect(result.trustDecisions).toMatchObject([
+      { trusted: true, reason: "allowed" },
+    ]);
+  });
+
+  it("fail-closes a primitive array one slot past the node bound", async () => {
+    const runtime = makeRuntime(makeRouter());
+    const module = moduleWithNest(
+      Array.from({ length: EXACT_WIDTH + 1 }, (_, index) => index),
+    );
+
+    await expect(
+      syncRemoteCapabilityPlugins(runtime, {
+        modules: [module],
+        trustPolicy: digestPolicy,
+      }),
+    ).rejects.toMatchObject(walkBoundRejection);
+  });
+
+  it("accepts an object exactly on the node bound", async () => {
+    const runtime = makeRuntime(makeRouter());
+    const module = moduleWithNest(
+      Object.fromEntries(
+        Array.from({ length: EXACT_WIDTH }, (_, index) => [`k${index}`, index]),
+      ),
+    );
+
+    const result = await syncRemoteCapabilityPlugins(runtime, {
+      modules: [module],
+      trustPolicy: digestPolicy,
+    });
+
+    expect(result.trustDecisions).toMatchObject([
+      { trusted: true, reason: "allowed" },
+    ]);
+  });
+
+  it("fail-closes an object one key past the node bound", async () => {
+    const runtime = makeRuntime(makeRouter());
+    const module = moduleWithNest(
+      Object.fromEntries(
+        Array.from({ length: EXACT_WIDTH + 1 }, (_, index) => [
+          `k${index}`,
+          index,
+        ]),
+      ),
+    );
+
+    await expect(
+      syncRemoteCapabilityPlugins(runtime, {
+        modules: [module],
+        trustPolicy: digestPolicy,
+      }),
+    ).rejects.toMatchObject(walkBoundRejection);
+  });
+
+  it("charges declared length, so a huge sparse array never allocates", async () => {
+    const runtime = makeRuntime(makeRouter());
+    const sparse = new Array(4_000_000);
+    const started = Date.now();
+
+    await expect(
+      syncRemoteCapabilityPlugins(runtime, {
+        modules: [
+          { ...baseModule(), nest: sparse } as RemotePluginModuleManifest,
+        ],
+        trustPolicy: digestPolicy,
+      }),
+    ).rejects.toMatchObject(walkBoundRejection);
+    expect(Date.now() - started).toBeLessThan(2_000);
+  });
+
+  it("charges every key of a huge primitive-width object", async () => {
+    const runtime = makeRuntime(makeRouter());
+    const wide = Object.fromEntries(
+      Array.from({ length: 200_000 }, (_, index) => [`k${index}`, index]),
+    );
+
+    await expect(
+      syncRemoteCapabilityPlugins(runtime, {
+        modules: [
+          { ...baseModule(), nest: wide } as RemotePluginModuleManifest,
+        ],
+        trustPolicy: digestPolicy,
+      }),
+    ).rejects.toMatchObject(walkBoundRejection);
+  });
+});
+
+describe("remote plugin provenance hostile-value reflection", () => {
+  it("hashes a proxied module value with zero get/has trap calls", async () => {
+    const runtime = makeRuntime(makeRouter());
+    const trapCalls = { get: 0, has: 0 };
+    const probed = new Proxy(
+      { plain: "value", nested: { list: [1, 2, 3] } },
+      {
+        get(inner, key, receiver) {
+          trapCalls.get += 1;
+          return Reflect.get(inner, key, receiver);
+        },
+        has(inner, key) {
+          trapCalls.has += 1;
+          return Reflect.has(inner, key);
+        },
+      },
+    );
+    const module = moduleWithNest(probed);
+    // The oracle digest above walks with [[Get]]; only the bounded walk under
+    // test is measured.
+    trapCalls.get = 0;
+    trapCalls.has = 0;
+
+    const result = await syncRemoteCapabilityPlugins(runtime, {
+      modules: [module],
+      trustPolicy: digestPolicy,
+    });
+
+    expect(result.trustDecisions).toMatchObject([
+      { trusted: true, reason: "allowed" },
+    ]);
+    expect(trapCalls).toEqual({ get: 0, has: 0 });
+  });
+
+  it("refuses a proxied accessor property without invoking it", async () => {
+    const runtime = makeRuntime(makeRouter());
+    const trapCalls = { get: 0, has: 0, getter: 0 };
+    const probed = new Proxy(
+      {
+        plain: "value",
+        get accessorFree() {
+          trapCalls.getter += 1;
+          return "never-read";
+        },
+      },
+      {
+        get(inner, key, receiver) {
+          trapCalls.get += 1;
+          return Reflect.get(inner, key, receiver);
+        },
+        has(inner, key) {
+          trapCalls.has += 1;
+          return Reflect.has(inner, key);
+        },
+      },
+    );
+
+    await expect(
+      syncRemoteCapabilityPlugins(runtime, {
+        modules: [
+          { ...baseModule(), nest: probed } as RemotePluginModuleManifest,
+        ],
+        trustPolicy: digestPolicy,
+      }),
+    ).rejects.toMatchObject(walkBoundRejection);
+    expect(trapCalls).toEqual({ get: 0, has: 0, getter: 0 });
+  });
+
+  it("fail-closes a revoked proxy instead of leaking a raw TypeError", async () => {
+    const runtime = makeRuntime(makeRouter());
+    const { proxy, revoke } = Proxy.revocable({ a: 1 }, {});
+    revoke();
+
+    await expect(
+      syncRemoteCapabilityPlugins(runtime, {
+        modules: [
+          { ...baseModule(), nest: proxy } as RemotePluginModuleManifest,
+        ],
+        trustPolicy: digestPolicy,
+      }),
+    ).rejects.toMatchObject(walkBoundRejection);
+  });
+
+  it("fail-closes a hostile proxy whose reflection traps throw", async () => {
+    const runtime = makeRuntime(makeRouter());
+    const hostile = new Proxy(
+      { a: 1 },
+      {
+        ownKeys() {
+          throw new TypeError("hostile ownKeys");
+        },
+      },
+    );
+
+    await expect(
+      syncRemoteCapabilityPlugins(runtime, {
+        modules: [
+          { ...baseModule(), nest: hostile } as RemotePluginModuleManifest,
+        ],
+        trustPolicy: digestPolicy,
+      }),
+    ).rejects.toMatchObject(walkBoundRejection);
+  });
+
+  it("fail-closes a hostile proxy whose descriptor trap throws", async () => {
+    const runtime = makeRuntime(makeRouter());
+    const hostile = new Proxy(
+      { a: 1 },
+      {
+        getOwnPropertyDescriptor() {
+          throw new TypeError("hostile descriptor");
+        },
+      },
+    );
+
+    await expect(
+      syncRemoteCapabilityPlugins(runtime, {
+        modules: [
+          { ...baseModule(), nest: hostile } as RemotePluginModuleManifest,
+        ],
+        trustPolicy: digestPolicy,
+      }),
+    ).rejects.toMatchObject(walkBoundRejection);
+  });
+
+  it("refuses an accessor property instead of invoking it", async () => {
+    const runtime = makeRuntime(makeRouter());
+    let invoked = 0;
+    const accessor = {};
+    Object.defineProperty(accessor, "trap", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        invoked += 1;
+        return "should-never-be-read";
+      },
+    });
+
+    await expect(
+      syncRemoteCapabilityPlugins(runtime, {
+        modules: [
+          { ...baseModule(), nest: accessor } as RemotePluginModuleManifest,
+        ],
+        trustPolicy: digestPolicy,
+      }),
+    ).rejects.toMatchObject(walkBoundRejection);
+    expect(invoked).toBe(0);
   });
 });

--- a/packages/agent/src/services/remote-plugin-adapter.walk-bound.test.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.walk-bound.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Fail-closed provenance canonicalize walk. Origin develop
+ * 3775f57b4e51c7fe6e5a1bb76aeaf00b487b2cbc recurses without a cycle/depth
+ * bound, so a cyclic or over-deep remote module RangeError'd the agent
+ * during requireProvenanceDigestMatch. This suite is the overlay proof.
+ */
+import {
+  CAPABILITY_ROUTER_SERVICE_TYPE,
+  CapabilityError,
+  type ElizaCapabilityRouter,
+  type IAgentRuntime,
+  type RemotePluginModuleManifest,
+  type UUID,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { syncRemoteCapabilityPlugins } from "./remote-plugin-adapter.ts";
+
+function makeRouter(): ElizaCapabilityRouter {
+  const unavailable = async () => {
+    throw new CapabilityError({
+      code: "CAPABILITY_UNAVAILABLE",
+      message: "capability unavailable in walk-bound test router",
+      capability: "plugin",
+    });
+  };
+  return {
+    environment: "server",
+    availability: async () => ({
+      environment: "server",
+      available: true,
+      capabilities: {
+        fs: false,
+        pty: false,
+        git: false,
+        model: false,
+        plugin: true,
+      },
+    }),
+    fs: {
+      list: unavailable,
+      readText: unavailable,
+      writeText: unavailable,
+    },
+    pty: { runCommand: unavailable },
+    git: {
+      status: unavailable,
+      diff: unavailable,
+      commandRun: unavailable,
+    },
+    model: { status: unavailable },
+    plugin: {
+      listModules: unavailable,
+      invokeAction: unavailable,
+      getProvider: unavailable,
+      callRoute: unavailable,
+      getAsset: unavailable,
+      shouldRunEvaluator: unavailable,
+      prepareEvaluator: unavailable,
+      promptEvaluator: unavailable,
+      processEvaluator: unavailable,
+      shouldRunResponseHandlerEvaluator: unavailable,
+      evaluateResponseHandlerEvaluator: unavailable,
+      shouldRunResponseHandlerFieldEvaluator: unavailable,
+      parseResponseHandlerFieldEvaluator: unavailable,
+      handleResponseHandlerFieldEvaluator: unavailable,
+      callLifecycle: unavailable,
+      handleEvent: unavailable,
+      invokeModel: unavailable,
+      callService: unavailable,
+      callAppBridge: unavailable,
+    },
+  };
+}
+
+function makeRuntime(router: ElizaCapabilityRouter): IAgentRuntime {
+  return {
+    agentId: "11111111-1111-1111-1111-111111111111" as UUID,
+    character: { name: "Remote Plugin Walk Bound" },
+    getService: (serviceType: string) =>
+      serviceType === CAPABILITY_ROUTER_SERVICE_TYPE ? router : null,
+    registerPlugin: async () => {},
+    reloadPlugin: async () => {},
+    unloadPlugin: async () => null,
+    getAllPluginOwnership: () => [],
+    hasService: (serviceType: string) =>
+      serviceType === CAPABILITY_ROUTER_SERVICE_TYPE,
+    getServiceLoadPromise: async () => router as never,
+  } as Partial<IAgentRuntime> as IAgentRuntime;
+}
+
+function baseModule(): RemotePluginModuleManifest {
+  return {
+    id: "remote-demo",
+    name: "@remote/demo",
+    version: "1.0.0",
+    capabilityEndpointId: "trusted-cloud",
+    provenance: {
+      issuer: "eliza-cloud-build",
+      subject: "cloud://agents/trusted-cloud/modules/remote-demo",
+      digestSha256:
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      signatureAlgorithm: "ed25519",
+      signature: "not-verified-in-this-suite",
+    },
+  };
+}
+
+const digestPolicy = {
+  allowedEndpointIds: ["trusted-cloud"],
+  requireEndpointId: true,
+  requireProvenanceDigestMatch: true,
+};
+
+describe("remote plugin provenance canonicalize walk bound", () => {
+  it("fail-closes a cyclic remote module instead of overflowing the stack", async () => {
+    const runtime = makeRuntime(makeRouter());
+    const module = baseModule() as RemotePluginModuleManifest & {
+      nest?: unknown;
+    };
+    const cycle: Record<string, unknown> = { id: "loop" };
+    cycle.self = cycle;
+    module.nest = cycle;
+
+    await expect(
+      syncRemoteCapabilityPlugins(runtime, {
+        modules: [module],
+        trustPolicy: digestPolicy,
+      }),
+    ).rejects.toMatchObject({
+      code: "CAPABILITY_UNAVAILABLE",
+      capability: "plugin",
+      method: "plugin.modules.list",
+      message:
+        'Remote plugin module "remote-demo" provenance walk exceeded bound.',
+      details: {
+        trustDecision: {
+          moduleId: "remote-demo",
+          pluginName: "@remote/demo",
+          endpointId: "trusted-cloud",
+          trusted: false,
+          reason: "provenance-walk-bound",
+        },
+      },
+    });
+  });
+
+  it("fail-closes an over-deep remote module instead of overflowing the stack", async () => {
+    const runtime = makeRuntime(makeRouter());
+    let deep: unknown = "leaf";
+    for (let i = 0; i < 64; i += 1) {
+      deep = { n: deep };
+    }
+    const module = {
+      ...baseModule(),
+      nest: deep,
+    };
+
+    await expect(
+      syncRemoteCapabilityPlugins(runtime, {
+        modules: [module],
+        trustPolicy: digestPolicy,
+      }),
+    ).rejects.toMatchObject({
+      code: "CAPABILITY_UNAVAILABLE",
+      message:
+        'Remote plugin module "remote-demo" provenance walk exceeded bound.',
+      details: {
+        trustDecision: {
+          reason: "provenance-walk-bound",
+          trusted: false,
+        },
+      },
+    });
+  });
+
+  it("still rejects an honest finite module whose digest does not match", async () => {
+    const runtime = makeRuntime(makeRouter());
+    await expect(
+      syncRemoteCapabilityPlugins(runtime, {
+        modules: [baseModule()],
+        trustPolicy: digestPolicy,
+      }),
+    ).rejects.toMatchObject({
+      code: "CAPABILITY_UNAVAILABLE",
+      message:
+        'Remote plugin module "remote-demo" provenance digest does not match module contents.',
+      details: {
+        trustDecision: {
+          reason: "invalid-provenance-digest",
+          trusted: false,
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #23292 — the owning issue for this hole, filed after review feedback
that this PR had none.

Host is `canonicalizeForRemotePluginProvenance` in
`packages/agent/src/services/remote-plugin-adapter.ts` — not a new-URL TypeError
twin of #23216, not a substituteInValue walk, not secret-swap / pii-pseudonymizer
/ schema-compat / character-history / agent-export, not leftover-decode or
nested-quantifier ReDoS.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` was run after sync. `bun run verify` was NOT rerun; the exact
      blocker is recorded in **Known gaps / failures** below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` `a9a786e18f40` (2026-08-21); zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Fail-closed cycle/depth/width bounds on the provenance canonicalize walk so
`requireProvenanceDigestMatch` cannot RangeError, hang, or execute untrusted
accessor code on a hostile remote module. Compatibility is the property under
test: honest finite modules — including acyclic modules that repeat a shared
reference at more than one path — hash to exactly the digest the unbounded
walker produced, and a real mismatch still reports `invalid-provenance-digest`.
A bound hit becomes `provenance-walk-bound` + `CAPABILITY_UNAVAILABLE` instead
of a process-killing stack overflow or a raw `TypeError`. No schema or storage
migration. Did not edit HARD_SKIP
`remote-capability-router.ts`, `remote-capability-url-endpoint-providers.ts`,
#23216 `remote-capability-endpoint-provider.ts`, agent-export canonicalize,
or occupied substituteInValue hosts.

# Background

## What does this PR do?

`canonicalizeForRemotePluginProvenance` is the live JSON canonicalizer for
remote-plugin provenance digest matching (`requireProvenanceDigestMatch` on
`syncRemoteCapabilityPlugins` / `registerRemoteCapabilityPlugins`). On origin
`develop` `3775f57b4e51c7fe6e5a1bb76aeaf00b487b2cbc` it recursed with no cycle, depth, or node bound, so a
cyclic module or a 14000-deep nest RangeError'd (`Maximum call stack size
exceeded`) instead of a structured trust rejection.

Independent origin proof (byte-identical origin walker, TypeScript types
stripped only so bun can eval):

```text
origin develop 3775f57b4e51c7fe6e5a1bb76aeaf00b487b2cbc
CYCLE_THREW RangeError Maximum call stack size exceeded.
DEPTH_OK 8
DEPTH_OK 16
DEPTH_OK 32
DEPTH_OK 64
DEPTH_OK 256
DEPTH_OK 2048
DEPTH_OK 8000
DEPTH_THREW 14000 RangeError Maximum call stack size exceeded.
```

This head caps depth at 32 and the node budget at 4096, and maps a bound hit to
`CAPABILITY_UNAVAILABLE` / `provenance-walk-bound`.

## Review repair at `24010b8b3bfa1a2e6351f8c6b1c58c781945bfe2`

The exact-head review of `91fe3df75430` raised three P1s. All three are fixed in
commit `24010b8b3bfa`:

1. **Repeated-reference compatibility.** The global `WeakSet` treated a repeated
   shared reference in an honest acyclic DAG as a cycle, so a valid module lost
   trust. The visiting set is now **path-local**: it holds only the ancestors of
   the current path and drops each on unwind, so a shared reference serializes
   at every path exactly like the unbounded walker did. A real back edge is
   still refused as `cycle`.
2. **Width is charged before work.** A container now charges its **declared**
   array length (read from the `length` descriptor) or own-key count against the
   node budget **before** any slot is allocated, read, or traversed. `value.map`
   and `Object.entries` are gone, so a huge sparse or primitive-width value
   cannot consume CPU or heap ahead of the bound.
3. **Descriptor-only reflection on untrusted data.** The walk uses
   `Reflect.ownKeys` + `Object.getOwnPropertyDescriptor` and never runs
   `[[Get]]`, `[[Has]]`, or an accessor on remote module data. An accessor
   property, a revoked `Proxy`, or any throwing trap becomes the same typed
   `RemotePluginProvenanceWalkBoundError` (reason `reflection`, original failure
   preserved as an internal `cause`) and therefore the same
   `provenance-walk-bound` trust rejection — no raw `TypeError` escapes
   `remotePluginModuleProvenanceDigestResult`.

Delivery items from the same review: owning issue #23292 filed, branch rebased
onto `origin/develop` `a9a786e18f40`, and the focused package gates actually
executed (receipts below).

Provenance note: head `91fe3df75430` was produced with `xai/grok-4.6`; this
review-repair head `24010b8b3bfa` was produced with `anthropic/claude-opus-5`,
which is what the attribution rows and footer declare.

Occupancy-FREE at scannedAt 2026-08-21T00:51:14.871Z
(`packages/agent/src/services/remote-plugin-adapter.ts` and the new walk-bound
test were absent from occupancy-paths).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/services/remote-plugin-adapter.ts`:
`canonicalizeForRemotePluginProvenance` (path-local ancestors + descriptor-only
reflection), `canonicalizeRemotePluginProvenanceArray` /
`canonicalizeRemotePluginProvenanceObject` (width charged before allocation),
and `remotePluginModuleProvenanceDigestResult`. Then
`packages/agent/src/services/remote-plugin-adapter.walk-bound.test.ts`, which
pins repeated-reference compatibility, the exact width boundary, and the
zero-trap / hostile-proxy behaviour through `syncRemoteCapabilityPlugins`.

## Detailed testing steps

Automated. From the repo root, after `bun install` and
`node packages/shared/scripts/generate-keywords.mjs`:

```bash
bunx vitest run \
  packages/agent/src/services/remote-plugin-adapter.walk-bound.test.ts \
  packages/agent/src/services/remote-plugin-adapter.test.ts \
  --coverage.enabled=false
bun run --cwd packages/agent typecheck
bunx @biomejs/biome check \
  packages/agent/src/services/remote-plugin-adapter.ts \
  packages/agent/src/services/remote-plugin-adapter.walk-bound.test.ts
```

The compatibility tests do not trust the implementation for their expected
value: the suite recomputes each module's provenance digest with an independent
reimplementation of the **pre-bound** walker (`legacyCanonical`) and then
requires `syncRemoteCapabilityPlugins` to return `trusted: true`. If the bound
changed the digest of any honest module, those tests fail.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:24010b8b3bfa1a2e6351f8c6b1c58c781945bfe2 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface in this change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface in this change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live server hop in this unit; focused origin/overlay proofs are the receipt.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Focused Vitest, package typecheck, and Biome executed at this exact head
      (inline transcripts).
<details>
<summary>domain receipt — focused Vitest at 24010b8b3bfa1a2e6351f8c6b1c58c781945bfe2</summary>

```text
$ bunx vitest run packages/agent/src/services/remote-plugin-adapter.walk-bound.test.ts \
    --coverage.enabled=false --reporter=verbose
 RUN  v4.1.10

 ✓ walk bound > fail-closes a cyclic remote module instead of overflowing the stack 16ms
 ✓ walk bound > fail-closes an over-deep remote module instead of overflowing the stack 0ms
 ✓ walk bound > still rejects an honest finite module whose digest does not match 0ms
 ✓ repeated-reference compatibility > trusts an acyclic DAG that repeats a shared reference 2ms
 ✓ repeated-reference compatibility > trusts a repeated shared array reference at sibling paths 1ms
 ✓ repeated-reference compatibility > still fail-closes when the repeated reference is a real back edge 1ms
 ✓ width bound > accepts a primitive array exactly on the node bound 4ms
 ✓ width bound > fail-closes a primitive array one slot past the node bound 0ms
 ✓ width bound > accepts an object exactly on the node bound 27ms
 ✓ width bound > fail-closes an object one key past the node bound 11ms
 ✓ width bound > charges declared length, so a huge sparse array never allocates 6ms
 ✓ width bound > charges every key of a huge primitive-width object 218ms
 ✓ hostile-value reflection > hashes a proxied module value with zero get/has trap calls 1ms
 ✓ hostile-value reflection > refuses a proxied accessor property without invoking it 0ms
 ✓ hostile-value reflection > fail-closes a revoked proxy instead of leaking a raw TypeError 0ms
 ✓ hostile-value reflection > fail-closes a hostile proxy whose reflection traps throw 1ms
 ✓ hostile-value reflection > fail-closes a hostile proxy whose descriptor trap throws 0ms
 ✓ hostile-value reflection > refuses an accessor property instead of invoking it 0ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
   Duration  52.28s
```

The `accepts … exactly on the node bound` / `fail-closes … one slot past the
node bound` pairs are the exact boundary: the stripped module carries
`id`/`name`/`version` plus `nest` (4 slots), so a 4092-entry array or 4092-key
object lands exactly on the 4096 budget and 4093 does not. The sparse case is a
`new Array(4_000_000)` with zero own index properties — refused from the
declared `length` in 6ms, without allocating or visiting a slot.

</details>

<details>
<summary>domain receipt — adapter regression suite, package typecheck, Biome</summary>

```text
$ bunx vitest run packages/agent/src/services/remote-plugin-adapter.walk-bound.test.ts \
    packages/agent/src/services/remote-plugin-adapter.test.ts --coverage.enabled=false
 Test Files  2 passed (2)
      Tests  61 passed | 3 skipped (64)
(recorded through the factory run recorder at 24010b8b3 -> exit 0)

$ bun run --cwd packages/agent typecheck
25 pre-existing errors, 0 of them in remote-plugin-adapter.*
   (same command with this commit's two files stashed: 25 errors — unchanged)

$ bunx @biomejs/biome check packages/agent/src/services/remote-plugin-adapter.ts \
    packages/agent/src/services/remote-plugin-adapter.walk-bound.test.ts
Checked 2 files in 294ms. No fixes applied.
```

</details>

<details>
<summary>origin proof (unchanged, from the original head)</summary>

```text
origin develop 3775f57b4e51c7fe6e5a1bb76aeaf00b487b2cbc
CYCLE_THREW RangeError Maximum call stack size exceeded.
DEPTH_THREW 14000 RangeError Maximum call stack size exceeded.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no live server or browser hop in this unit; focused tests are the proof.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

The previous head's blocker is gone: this tree now has its own `bun install`
plus `node packages/shared/scripts/generate-keywords.mjs`, and the exact focused
Vitest command runs (18 passed on the new suite, 61 passed / 3 skipped with the
existing adapter suite).

Remaining gaps, exactly:

- Root `bun run verify` was NOT rerun on this head. It drives turbo `typecheck`
  + `lint:check` across every workspace package, and this checkout cannot
  complete that: `bun run --cwd packages/agent typecheck` already reports 25
  module-resolution errors for workspace packages that are not built here
  (`@elizaos/cloud-routing`, `@elizaos/plugin-capacitor-bridge/*`,
  `@elizaos/plugin-wallet/diagnostic`, `@elizaos/plugin-video|vision|notes`,
  `@elizaos/plugin-todos/edge`). That count is **identical with this commit's
  two files stashed**, so this change introduces none of them, and none of them
  is in `remote-plugin-adapter.*`. CI on the PR is the authority for the full
  root gate.
- Fork cannot upload `pr-evidence` release assets, so the receipts are inline.

AI provider/model: Anthropic / claude-opus-5
Client / agent tooling: Claude Code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza"} -->
