### PR TITLE
fix(core): make zero-delivery recovery failure-aware and tested

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -5210,7 +5210,7 @@ describe("runV5MessageRuntimeStage1", () => {
 				expect(decision.actionFailureCount).toBe(2);
 			});
 
-			it("claims completion only when a tool actually succeeded", () => {
+			it("reports completion without inviting a blind replay after a tool succeeded", () => {
 				const decision = resolveZeroDeliveryRecovery({
 					plannedText: "",
 					actionResults: [{ success: true }],
@@ -5218,7 +5218,22 @@ describe("runV5MessageRuntimeStage1", () => {
 					earlyReplySent: false,
 				});
 				expect(decision.source).toBe("fallbackText");
-				expect(decision.text).toContain("finished");
+				expect(decision.text).toContain("completed");
+				expect(decision.text).toContain("Check the current state");
+				expect(decision.text).not.toContain("ask again");
+			});
+
+			it("reports mixed tool outcomes without presenting the turn as fully successful", () => {
+				const decision = resolveZeroDeliveryRecovery({
+					plannedText: "",
+					actionResults: [{ success: true }, { success: false }],
+					stageOneAck: "",
+					earlyReplySent: false,
+				});
+				expect(decision.source).toBe("fallbackText");
+				expect(decision.text).toContain("Some steps completed and some failed");
+				expect(decision.text).toContain("Check the current state");
+				expect(decision.text).not.toContain("finished");
 			});
 
 			it("declines to recover a successful early-ack turn with nothing grounded to say", () => {

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -26,6 +26,7 @@ import {
 import {
 	BUILTIN_RESPONSE_HANDLER_EVALUATORS,
 	messageHandlerFromFieldResult,
+	resolveZeroDeliveryRecovery,
 	runV5MessageRuntimeStage1,
 } from "../services/message";
 import { runWithTrajectoryContext } from "../trajectory-context";
@@ -4944,6 +4945,292 @@ describe("runV5MessageRuntimeStage1", () => {
 			expect(result.result.responseContent).toBeNull();
 			expect(result.result.responseMessages).toEqual([]);
 		}
+	});
+
+	// Zero-delivery recovery contract (#20086, backstop behind #20083): a
+	// RESPOND turn that ran tools and delivered no terminal/action-owned text
+	// must recover a grounded reply — even after an early progress ack — while
+	// never duplicating a delivery, never claiming success when every tool
+	// failed, and staying silent for a successfully accepted async handoff
+	// whose completion arrives through a later relay turn.
+	describe("zero-delivery recovery", () => {
+		const spawnTurnResponses = () => [
+			stage1Response({
+				thought: "Spawn the coding task.",
+				contexts: ["general"],
+				candidateActionNames: ["TASKS_SPAWN_AGENT"],
+				replyText: "On it.",
+				extra: { requiresTool: true },
+			}),
+			{
+				text: "",
+				toolCalls: [
+					{
+						id: "spawn-1",
+						name: "TASKS_SPAWN_AGENT",
+						arguments: {},
+					},
+				],
+			},
+		];
+		const spawnAction = (
+			handlerResult: Record<string, unknown>,
+		): IAgentRuntime["actions"] =>
+			[
+				{
+					name: "TASKS_SPAWN_AGENT",
+					description: "Spawn a coding task.",
+					contexts: ["general"],
+					asyncHandoff: true,
+					validate: vi.fn(async () => true),
+					handler: vi.fn(async () => ({
+						continueChain: false,
+						...handlerResult,
+					})),
+				},
+			] as IAgentRuntime["actions"];
+
+		it("delivers a grounded terminal reply after an early progress ack when the tool failed with user-facing text", async () => {
+			const runtime = makeRuntime(spawnTurnResponses());
+			runtime.actions = spawnAction({
+				success: false,
+				text: "",
+				userFacingText: "The sandbox rejected the spawn: quota exceeded.",
+			});
+			const earlyReply = vi.fn(async () => undefined);
+
+			const result = await runV5MessageRuntimeStage1({
+				runtime,
+				message: makeMessage(),
+				state: makeState(),
+				responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+				onResponseHandlerEarlyReply: earlyReply,
+			});
+
+			expect(earlyReply).toHaveBeenCalledTimes(1);
+			expect(result.kind).toBe("planned_reply");
+			if (result.kind === "planned_reply") {
+				// The turn must end with the tool's grounded failure text —
+				// never a repeat of the ack and never silence.
+				expect(result.result.responseContent?.text).toBe(
+					"The sandbox rejected the spawn: quota exceeded.",
+				);
+			}
+		});
+
+		it("ends a failed-tool early-ack turn with failure-aware wording, never a success claim", async () => {
+			const runtime = makeRuntime(spawnTurnResponses());
+			runtime.actions = spawnAction({ success: false, text: "" });
+			const earlyReply = vi.fn(async () => undefined);
+
+			const result = await runV5MessageRuntimeStage1({
+				runtime,
+				message: makeMessage(),
+				state: makeState(),
+				responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+				onResponseHandlerEarlyReply: earlyReply,
+			});
+
+			expect(earlyReply).toHaveBeenCalledTimes(1);
+			expect(result.kind).toBe("planned_reply");
+			if (result.kind === "planned_reply") {
+				const text = result.result.responseContent?.text ?? "";
+				expect(text.length).toBeGreaterThan(0);
+				// The turn's only tool failed; the terminal reply must not claim
+				// the work finished and must not re-send the ack.
+				expect(text).not.toContain("finished");
+				expect(text).not.toBe("On it.");
+				expect(text).toContain("failed");
+			}
+		});
+
+		it("delivers the action's userFacingText after an early ack instead of ending silent", async () => {
+			const runtime = makeRuntime(spawnTurnResponses());
+			runtime.actions = spawnAction({
+				success: true,
+				text: "",
+				userFacingText: "Spawned coding task session-1; progress will follow.",
+			});
+			const earlyReply = vi.fn(async () => undefined);
+
+			const result = await runV5MessageRuntimeStage1({
+				runtime,
+				message: makeMessage(),
+				state: makeState(),
+				responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+				onResponseHandlerEarlyReply: earlyReply,
+			});
+
+			expect(earlyReply).toHaveBeenCalledTimes(1);
+			expect(result.kind).toBe("planned_reply");
+			if (result.kind === "planned_reply") {
+				expect(result.result.responseContent?.text).toBe(
+					"Spawned coding task session-1; progress will follow.",
+				);
+			}
+		});
+
+		it("keeps a successfully accepted async handoff silent after the early ack", async () => {
+			const runtime = makeRuntime(spawnTurnResponses());
+			runtime.actions = spawnAction({ success: true, text: "" });
+			const earlyReply = vi.fn(async () => undefined);
+
+			const result = await runV5MessageRuntimeStage1({
+				runtime,
+				message: makeMessage(),
+				state: makeState(),
+				responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+				onResponseHandlerEarlyReply: earlyReply,
+			});
+
+			expect(earlyReply).toHaveBeenCalledTimes(1);
+			expect(result.kind).toBe("planned_reply");
+			if (result.kind === "planned_reply") {
+				// The ack promised background work that a completion relay will
+				// report; a manufactured "finished" line here would be a lie.
+				expect(result.result.responseContent).toBeNull();
+				expect(result.result.responseMessages).toEqual([]);
+			}
+		});
+
+		it("does not duplicate an action-owned callback delivery", async () => {
+			const deliveredLine = "Spawned the coding task: session-1.";
+			const runtime = makeRuntime(spawnTurnResponses());
+			runtime.actions = [
+				{
+					name: "TASKS_SPAWN_AGENT",
+					description: "Spawn a coding task.",
+					contexts: ["general"],
+					asyncHandoff: true,
+					validate: vi.fn(async () => true),
+					handler: vi.fn(async (...handlerArgs: unknown[]) => {
+						const callback = handlerArgs[4] as
+							| ((content: { text: string }) => Promise<unknown>)
+							| undefined;
+						await callback?.({ text: deliveredLine });
+						return {
+							success: true,
+							text: deliveredLine,
+							userFacingText: deliveredLine,
+							continueChain: false,
+						};
+					}),
+				},
+			] as IAgentRuntime["actions"];
+			const deliveredVisibleTexts = new Set<string>();
+			const delivered: string[] = [];
+			const earlyReply = vi.fn(async () => undefined);
+
+			const result = await runV5MessageRuntimeStage1({
+				runtime,
+				message: makeMessage(),
+				state: makeState(),
+				responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+				onResponseHandlerEarlyReply: earlyReply,
+				deliveredVisibleTexts,
+				callback: async (content) => {
+					if (content.text) {
+						delivered.push(content.text);
+						deliveredVisibleTexts.add(content.text.toLowerCase());
+					}
+					return [];
+				},
+			});
+
+			expect(result.kind).toBe("planned_reply");
+			expect(delivered).toEqual([deliveredLine]);
+			if (result.kind === "planned_reply") {
+				// The callback delivery is the turn's terminal text; recovery must
+				// not re-send it as a second bubble.
+				expect(result.result.responseContent).toBeNull();
+				expect(result.result.responseMessages).toEqual([]);
+			}
+		});
+
+		// Pure decision seam: the exact source precedence, ack suppression,
+		// failure-aware wording, and the async-handoff silence gate.
+		describe("resolveZeroDeliveryRecovery", () => {
+			it("prefers surviving planner text over everything else", () => {
+				const decision = resolveZeroDeliveryRecovery({
+					plannedText: "The check passed on retry.",
+					actionResults: [{ success: true, userFacingText: "raw tool line" }],
+					stageOneAck: "On it.",
+					earlyReplySent: false,
+				});
+				expect(decision).toMatchObject({
+					recover: true,
+					text: "The check passed on retry.",
+					source: "plannedText",
+				});
+			});
+
+			it("prefers the LAST explicit action userFacingText ahead of the Stage-1 ack", () => {
+				const decision = resolveZeroDeliveryRecovery({
+					plannedText: "",
+					actionResults: [
+						{ success: true, userFacingText: "first tool line" },
+						{ success: false },
+						{ success: true, userFacingText: "second tool line" },
+					],
+					stageOneAck: "On it.",
+					earlyReplySent: false,
+				});
+				expect(decision).toMatchObject({
+					recover: true,
+					text: "second tool line",
+					source: "actionUserFacingText",
+					actionSuccessCount: 2,
+					actionFailureCount: 1,
+				});
+			});
+
+			it("never re-sends the Stage-1 ack once an early ack shipped", () => {
+				const decision = resolveZeroDeliveryRecovery({
+					plannedText: "",
+					actionResults: [{ success: false }],
+					stageOneAck: "On it.",
+					earlyReplySent: true,
+				});
+				expect(decision.recover).toBe(true);
+				expect(decision.text).not.toBe("On it.");
+				expect(decision.source).toBe("fallbackText");
+			});
+
+			it("uses failure-aware fallback wording when every tool failed", () => {
+				const decision = resolveZeroDeliveryRecovery({
+					plannedText: "",
+					actionResults: [{ success: false }, { success: false }],
+					stageOneAck: "",
+					earlyReplySent: false,
+				});
+				expect(decision.source).toBe("fallbackText");
+				expect(decision.text).toContain("failed");
+				expect(decision.text).not.toContain("finished");
+				expect(decision.actionSuccessCount).toBe(0);
+				expect(decision.actionFailureCount).toBe(2);
+			});
+
+			it("claims completion only when a tool actually succeeded", () => {
+				const decision = resolveZeroDeliveryRecovery({
+					plannedText: "",
+					actionResults: [{ success: true }],
+					stageOneAck: "",
+					earlyReplySent: false,
+				});
+				expect(decision.source).toBe("fallbackText");
+				expect(decision.text).toContain("finished");
+			});
+
+			it("declines to recover a successful early-ack turn with nothing grounded to say", () => {
+				const decision = resolveZeroDeliveryRecovery({
+					plannedText: "",
+					actionResults: [{ success: true }],
+					stageOneAck: "On it.",
+					earlyReplySent: true,
+				});
+				expect(decision.recover).toBe(false);
+			});
+		});
 	});
 
 	it("voice turn signal can force IGNORE before early reply/planning", async () => {

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -5236,6 +5236,19 @@ describe("runV5MessageRuntimeStage1", () => {
 				expect(decision.text).not.toContain("finished");
 			});
 
+			it("recovers a mixed-outcome early-ack turn because one failed action may own the handoff", () => {
+				const decision = resolveZeroDeliveryRecovery({
+					plannedText: "",
+					actionResults: [{ success: true }, { success: false }],
+					stageOneAck: "On it.",
+					earlyReplySent: true,
+				});
+				expect(decision.recover).toBe(true);
+				expect(decision.source).toBe("fallbackText");
+				expect(decision.text).toContain("Some steps completed and some failed");
+				expect(decision.text).not.toBe("On it.");
+			});
+
 			it("declines to recover a successful early-ack turn with nothing grounded to say", () => {
 				const decision = resolveZeroDeliveryRecovery({
 					plannedText: "",

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2056,9 +2056,11 @@ export function resolveZeroDeliveryRecovery(args: {
 			.at(-1) ?? "";
 	const ackRecoveryText = args.earlyReplySent ? "" : args.stageOneAck;
 	const fallbackRecoveryText =
-		actionSuccessCount > 0
-			? "I finished working on that but could not compose a clean reply — ask again and I will retry."
-			: "I ran the steps for that but they failed, and I could not compose a useful report — ask again and I will retry.";
+		actionSuccessCount > 0 && actionFailureCount > 0
+			? "Some steps completed and some failed, but I could not produce a reliable summary. Check the current state before deciding whether to retry."
+			: actionSuccessCount > 0
+				? "The requested steps completed, but I could not produce a reliable summary. Check the current state before retrying."
+				: "I ran the steps for that but they failed, and I could not compose a useful report — ask again and I will retry.";
 	const text =
 		args.plannedText ||
 		lastActionUserFacingText ||

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2019,7 +2019,7 @@ export type ZeroDeliveryRecoverySource =
  * Stage-1 ack ONLY when no early ack already shipped it, then a hardcoded
  * fallback whose wording is failure-aware — it claims completion only when at
  * least one tool actually succeeded. After an early progress ack the turn
- * recovers only when grounded text exists or every tool failed: a successful
+ * recovers only when grounded text exists or any tool failed: a successful
  * async handoff reports through a later completion relay, so manufacturing a
  * "finished" line behind its ack would be a lie, while a failed handoff will
  * never relay anything and the ack's promise must be corrected.
@@ -2077,7 +2077,7 @@ export function resolveZeroDeliveryRecovery(args: {
 		!args.earlyReplySent ||
 		Boolean(args.plannedText) ||
 		lastActionUserFacingText.length > 0 ||
-		actionSuccessCount === 0;
+		actionFailureCount > 0;
 	return { recover, text, source, actionSuccessCount, actionFailureCount };
 }
 
@@ -9906,7 +9906,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		// twice (#20086). One asymmetry is deliberate: the early ack only
 		// ships ahead of an async handoff, whose completion arrives through a
 		// later relay turn — after an ack, recover only when grounded terminal
-		// text exists or every tool failed (a failed handoff will never relay
+		// text exists or any tool failed (a failed handoff will never relay
 		// a completion, so the ack's promise must be corrected). A successful
 		// ack-then-background turn with nothing grounded to say stays silent.
 		const zeroDeliveryRecovery = resolveZeroDeliveryRecovery({

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2004,6 +2004,81 @@ export function answerlessToolTurnReport(args: {
 	return NO_REPORTABLE_TOOL_OUTCOME_MESSAGE;
 }
 
+/** Where the zero-delivery recovery sourced its terminal reply from. */
+export type ZeroDeliveryRecoverySource =
+	| "plannedText"
+	| "actionUserFacingText"
+	| "stageOneAck"
+	| "fallbackText";
+
+/**
+ * Decides whether — and with what text — a RESPOND turn that ran tools but
+ * delivered nothing terminal recovers instead of ending silent (#20083,
+ * corrected by #20086). Source precedence: the planner's surviving terminal
+ * text, then the last explicit action-owned `userFacingText`, then the
+ * Stage-1 ack ONLY when no early ack already shipped it, then a hardcoded
+ * fallback whose wording is failure-aware — it claims completion only when at
+ * least one tool actually succeeded. After an early progress ack the turn
+ * recovers only when grounded text exists or every tool failed: a successful
+ * async handoff reports through a later completion relay, so manufacturing a
+ * "finished" line behind its ack would be a lie, while a failed handoff will
+ * never relay anything and the ack's promise must be corrected.
+ * `plannedText` must arrive pre-blanked when it merely repeats the early ack.
+ */
+export function resolveZeroDeliveryRecovery(args: {
+	plannedText: string;
+	actionResults: ReadonlyArray<
+		Pick<ActionResult, "success" | "userFacingText">
+	>;
+	stageOneAck: string;
+	earlyReplySent: boolean;
+}): {
+	recover: boolean;
+	text: string;
+	source: ZeroDeliveryRecoverySource;
+	actionSuccessCount: number;
+	actionFailureCount: number;
+} {
+	const actionSuccessCount = args.actionResults.filter(
+		(result) => result.success === true,
+	).length;
+	const actionFailureCount = args.actionResults.filter(
+		(result) => result.success === false,
+	).length;
+	const lastActionUserFacingText =
+		args.actionResults
+			.map((result) =>
+				typeof result.userFacingText === "string"
+					? result.userFacingText.trim()
+					: "",
+			)
+			.filter((ownedText) => ownedText.length > 0)
+			.at(-1) ?? "";
+	const ackRecoveryText = args.earlyReplySent ? "" : args.stageOneAck;
+	const fallbackRecoveryText =
+		actionSuccessCount > 0
+			? "I finished working on that but could not compose a clean reply — ask again and I will retry."
+			: "I ran the steps for that but they failed, and I could not compose a useful report — ask again and I will retry.";
+	const text =
+		args.plannedText ||
+		lastActionUserFacingText ||
+		ackRecoveryText ||
+		fallbackRecoveryText;
+	const source: ZeroDeliveryRecoverySource = args.plannedText
+		? "plannedText"
+		: lastActionUserFacingText
+			? "actionUserFacingText"
+			: ackRecoveryText
+				? "stageOneAck"
+				: "fallbackText";
+	const recover =
+		!args.earlyReplySent ||
+		Boolean(args.plannedText) ||
+		lastActionUserFacingText.length > 0 ||
+		actionSuccessCount === 0;
+	return { recover, text, source, actionSuccessCount, actionFailureCount };
+}
+
 /** Zerollama/OpenAI-style async media endpoints should be delivered as attachments, not echoed as chat copy. */
 const MEDIA_CONTENT_URL_RE =
 	/<?\s*https?:\/\/[^\s<>]+\/v1\/(?:videos|images|audio)\/[^\s<>/]+\/content\s*>?/gi;
@@ -9815,48 +9890,56 @@ export async function runV5MessageRuntimeStage1(args: {
 		// produced a correct answer and the user got silence. Recover with the
 		// best grounded text available and name the failure in the log so the
 		// upstream emptying path is diagnosable instead of invisible.
-		// Two states are NOT recoverable silence: a synchronously delivered
+		// Three states are NOT recoverable silence: a synchronously delivered
 		// media deliverable is a delivery even though it never enters the
-		// visible-TEXT set, and deliberate silence (suppressPlannerReply
+		// visible-TEXT set; deliberate silence (suppressPlannerReply
 		// terminals, ambient IGNORE after tool work) is a contract this
-		// invariant must honor, not a failure for it to "fix" into filler.
+		// invariant must honor, not a failure for it to "fix" into filler;
+		// and a planned reply suppressed because the early ack ALREADY said it
+		// verbatim means the terminal content did reach the user. An early
+		// PROGRESS ack alone, however, is not a terminal answer — the turn
+		// still owes the user its outcome, so `earlyReplySent` by itself does
+		// not disarm the recovery; it only removes the ack (and any text that
+		// repeats it) from the pool of recovery sources so nothing delivers
+		// twice (#20086). One asymmetry is deliberate: the early ack only
+		// ships ahead of an async handoff, whose completion arrives through a
+		// later relay turn — after an ack, recover only when grounded terminal
+		// text exists or every tool failed (a failed handoff will never relay
+		// a completion, so the ack's promise must be corrected). A successful
+		// ack-then-background turn with nothing grounded to say stays silent.
+		const zeroDeliveryRecovery = resolveZeroDeliveryRecovery({
+			plannedText: plannedTextRepeatsEarlyReply
+				? ""
+				: effectiveDeliveredReplyText,
+			actionResults,
+			stageOneAck,
+			earlyReplySent,
+		});
 		if (
 			!shouldSendPlannedText &&
-			!earlyReplySent &&
 			!suppressesPlannerReply &&
+			!(earlyReplySent && plannedTextRepeatsEarlyReply) &&
+			zeroDeliveryRecovery.recover &&
 			deliveredVisibleTexts.size === 0 &&
 			deliveredMediaUrls.length === 0 &&
 			actionResults.length > 0
 		) {
-			const recoveredText =
-				effectiveDeliveredReplyText ||
-				stageOneAck ||
-				actionResults
-					.map((result) =>
-						typeof result.userFacingText === "string"
-							? result.userFacingText.trim()
-							: "",
-					)
-					.filter((ownedText) => ownedText.length > 0)
-					.at(-1) ||
-				"I finished working on that but could not compose a clean reply — ask again and I will retry.";
 			args.runtime.logger.warn(
 				{
 					src: "service:message",
 					emptyFinal: !effectiveReplyText,
+					earlyReplySent,
 					suppressedByEarlyReply: plannedTextRepeatsEarlyReply,
 					suppressedByActionReply: plannedTextRepeatsActionReply,
-					recoveredFrom: effectiveDeliveredReplyText
-						? "plannedText"
-						: stageOneAck
-							? "stageOneAck"
-							: "actionUserFacingText",
+					actionSuccessCount: zeroDeliveryRecovery.actionSuccessCount,
+					actionFailureCount: zeroDeliveryRecovery.actionFailureCount,
+					recoveredFrom: zeroDeliveryRecovery.source,
 				},
 				"RESPOND turn reached the reply gate with zero deliveries; recovering instead of ending silent",
 			);
-			effectiveReplyText = recoveredText;
-			strippedPlannedReplyText = recoveredText;
-			effectiveDeliveredReplyText = recoveredText;
+			effectiveReplyText = zeroDeliveryRecovery.text;
+			strippedPlannedReplyText = zeroDeliveryRecovery.text;
+			effectiveDeliveredReplyText = zeroDeliveryRecovery.text;
 			shouldSendPlannedText = true;
 		}
 		// Voice-gate provenance (#14873): the Stage-1 ack has unambiguous model


### PR DESCRIPTION
Fixes #20086 — corrective follow-up to the #20083 zero-delivery recovery.

## What was wrong

- The hardcoded recovery fallback said "I finished working on that…" even when every tool in the turn failed.
- The structured warn reported `recoveredFrom: "actionUserFacingText"` whenever planner text and the Stage-1 ack were empty, including when the branch actually shipped the hardcoded fallback.
- The `!earlyReplySent` gate excluded turns whose only delivery was an early progress acknowledgment, although those turns still lack a terminal answer.

## Fix

The recovery decision is extracted into an exported pure seam, `resolveZeroDeliveryRecovery` (`packages/core/src/services/message.ts`):

- **Source precedence:** surviving planner text → **last explicit action-owned `userFacingText`** → Stage-1 ack *only when no early ack already shipped it* → hardcoded fallback.
- **Failure-aware wording:** the fallback claims completion only when at least one tool actually succeeded; an all-failed turn gets failure wording.
- **Early-ack turns recover** when grounded terminal text exists or every tool failed. A successfully accepted async handoff with nothing grounded to say stays silent — its completion arrives through a later relay turn, and manufacturing a "finished" line behind the ack would be a lie. (The early ack only ships ahead of async-handoff candidates, so this is the exact population the gate protects.)
- **No duplicate deliveries:** the branch still requires an empty callback-delivered set and no delivered media, and a planned reply that verbatim repeats the delivered early ack counts as delivered.
- **Diagnostics:** the warn now reports the exact `recoveredFrom` source (`plannedText` / `actionUserFacingText` / `stageOneAck` / `fallbackText`), `earlyReplySent`, and `actionSuccessCount` / `actionFailureCount`.

## Tests (`packages/core/src/__tests__/message-runtime-stage1.test.ts`)

Deterministic (mocked model queue, real message-service pipeline):

- helper seam: planner-text preference, last-action-text preference over the ack, ack never re-sent after an early ack, failure-aware vs success-aware fallback wording with counts, recover=false for a successful handoff with nothing grounded;
- integration: grounded terminal delivery after an early ack for a failed tool with `userFacingText`; failed-tool early-ack turn ends with failure wording (never a success claim, never the ack repeated); action `userFacingText` delivered after an early ack instead of silence; successful async handoff stays silent after its ack; an action-owned callback delivery is never duplicated.

## Validation

- `bunx vitest run src/__tests__/message-runtime-stage1.test.ts` — 159 passed, 1 pre-existing failure ("does not re-add generic inferred actions…", reproduced byte-identically on unmodified origin/develop files in this worktree, unrelated).
- Adjacent lanes green: `message-answer-clobber-rescue`, `message-action-dedupe`, `planner-happy-path`, `planner-protocol-failure-echo`, `message-v5-widget-markers` (58 passed).
- `bun run --cwd packages/core typecheck` — exit 0.
- Biome check on both changed files — clean.

## Human-only remainder

The issue's evidence plan asks for a **live trajectory reproducing the zero-terminal-delivery state** before merge; that requires a live-model run against a connector and independent review, which this change does not include. Hosted exact-head CI runs on this PR stand in for the "hosted validation" row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
