### PR TITLE
fix(cloud): restore API release typecheck

### DIFF
--- a/packages/cloud/shared/src/db/agent-backup-restore-locks.integration.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-restore-locks.integration.test.ts
@@ -24,6 +24,7 @@ import {
   acquireEphemeralPostgres,
   type EphemeralPostgres,
 } from "../lib/services/tenant-db/__tests__/ephemeral-postgres";
+import type { AgentBackupRestoreLeaseAuthorityReceipt } from "./repositories/agent-backup-restore-lease";
 import {
   agentBackupCatalogAuthorities,
   agentBackupObjects,
@@ -255,16 +256,15 @@ async function buildLockManifest(operationId: string): Promise<{
   canonicalDraft: string;
   digest: string;
 }> {
-  const emptyComponent = (name: "character" | "media" | "state-files" | "vault") =>
-    ({
-      name,
-      format: "raw-v1",
-      compression: "none" as const,
-      payloadContentHmacSha256: SHA,
-      state: { kind: "full" as const, resultContentHmacSha256: SHA },
-      totals: { plainBytes: 0, compressedBytes: 0, encryptedBytes: 0, chunkCount: 0 },
-      chunks: [],
-    }) as const;
+  const emptyComponent = (name: "character" | "media" | "state-files" | "vault") => ({
+    name,
+    format: "raw-v1",
+    compression: "none" as const,
+    payloadContentHmacSha256: SHA,
+    state: { kind: "full" as const, resultContentHmacSha256: SHA },
+    totals: { plainBytes: 0, compressedBytes: 0, encryptedBytes: 0, chunkCount: 0 },
+    chunks: [],
+  });
   const plainBytes = 4;
   const encryptedBytes = 32;
   const aadSha256 = await computeAgentBackupChunkAadDigest({
@@ -476,25 +476,12 @@ async function seedLockBackup(input: {
 
 async function seedRestoreOperationLockFixture(includeSecondBackup = false): Promise<{
   operationId: string;
-  authority: {
-    organizationId: string;
-    agentId: string;
-    backupId: string;
-    operationId: string;
-    sourceActivationGeneration: string;
-    sourceLifecycleRevision: string;
-    expectedManifestSha256: string;
-    restoreAttemptId: string;
-    leaseId: string;
-    ownerId: string;
-    fencingToken: string;
-    catalogEpoch: string;
-    copyRole: "primary";
-  };
+  authority: AgentBackupRestoreLeaseAuthorityReceipt;
 }> {
   const open = openAgentBackupRestoreOperation;
+  const acquire = acquireAgentBackupRestoreLease;
   const inventoryDigest = agentBackupObjectInventoryDigest;
-  if (!dbWrite || !open || !inventoryDigest) {
+  if (!dbWrite || !open || !acquire || !inventoryDigest) {
     throw new Error("real PostgreSQL harness was not initialized");
   }
   await dbWrite
@@ -569,21 +556,20 @@ async function seedRestoreOperationLockFixture(includeSecondBackup = false): Pro
     catalog_epoch: catalog.revision,
     expires_at: new Date(Date.now() + 300_000),
   });
-  const authority = {
+  const acquired = await acquire({
     organizationId: ORG_ID,
-    agentId: AGENT_ID,
     backupId: LOCK_BACKUP_ONE,
     operationId: LOCK_OPERATION_ONE,
     sourceActivationGeneration: ACTIVATION_GENERATION,
     sourceLifecycleRevision: "0",
     expectedManifestSha256: firstManifest.digest,
     restoreAttemptId: LOCK_ATTEMPT_ID,
-    leaseId: LOCK_LEASE_ID,
     ownerId: LOCK_OWNER_ID,
     fencingToken: LOCK_FENCE,
-    catalogEpoch: catalog.revision.toString(),
-    copyRole: "primary" as const,
-  };
+    copyRole: "primary",
+    leaseMs: 300_000,
+  });
+  const authority = acquired.authority;
   const opened = await open({ authority, leaseId: LOCK_LEASE_ID });
   return { operationId: opened.operation.id, authority };
 }

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
@@ -1966,7 +1966,7 @@ describe("strict restore catalogue authority", () => {
     const fixture = await acquireVaultPassphraseFixture(0x4b);
     const secretRelease = captureVaultRawKeyAtRelease();
     let borrowedPassphrase: Uint8Array | null = null;
-    let handoffSignal: AbortSignal | null = null;
+    const handoff = { signal: null as AbortSignal | null };
     let handoffStartedAt: number | null = null;
     const callbackFinished = Promise.withResolvers<void>();
     try {
@@ -1976,7 +1976,7 @@ describe("strict restore catalogue authority", () => {
           async (passphrase, signal) => {
             handoffStartedAt = Date.now();
             borrowedPassphrase = passphrase;
-            handoffSignal = signal;
+            handoff.signal = signal;
             await new Promise<void>((resolve) => {
               signal.addEventListener("abort", () => resolve(), { once: true });
             });
@@ -1989,7 +1989,7 @@ describe("strict restore catalogue authority", () => {
       await callbackFinished.promise;
       expect(handoffStartedAt).not.toBeNull();
       expect(Date.now() - (handoffStartedAt ?? 0)).toBeLessThan(1_000);
-      expect(handoffSignal?.aborted).toBe(true);
+      expect(handoff.signal?.aborted).toBe(true);
       expect(isZeroized(borrowedPassphrase)).toBe(true);
       expect(isZeroized(secretRelease.rawKey)).toBe(true);
     } finally {

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-operations.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-operations.pglite.test.ts
@@ -539,6 +539,9 @@ describe("restore operation spine", () => {
       const replay = results.find((result) => result.replayed);
       expect(reserved).toBeDefined();
       expect(replay).toBeDefined();
+      if (!reserved || !replay) {
+        throw new Error("concurrent reservation did not return one reservation and one replay");
+      }
       expect(reserved.target).toEqual({
         nodeRecordId: TARGET_NODE_RECORD_ID,
         nodeId: "restore-target-a",

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-quarantine.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-quarantine.pglite.test.ts
@@ -859,8 +859,12 @@ describe("restore activation quarantine", () => {
       expect(outcomes.filter((outcome) => outcome.status === "fulfilled")).toHaveLength(1);
       expect(outcomes.filter((outcome) => outcome.status === "rejected")).toHaveLength(1);
       const { sandbox, operation } = await readRows();
-      expect([CONTAINER_A, CONTAINER_B]).toContain(operation.expected_container_id);
-      expect(sandbox.activation_container_id).toBe(operation.expected_container_id);
+      const expectedContainerId = operation.expected_container_id;
+      if (!expectedContainerId) {
+        throw new Error("winning quarantine contender did not persist its container id");
+      }
+      expect([CONTAINER_A, CONTAINER_B]).toContain(expectedContainerId);
+      expect(sandbox.activation_container_id).toBe(expectedContainerId);
       expect(operation.phase).toBe("container_created");
     },
     TIMEOUT,


### PR DESCRIPTION
## Summary
- use mutable manifest fixture chunks and real lease authority receipts in restore lock proofs
- narrow async signal and concurrent reservation fixtures for TypeScript
- narrow the persisted quarantine container id before membership assertions

## Verification
- `bun run --cwd packages/cloud/api typecheck`
- `bunx biome check` on all four changed test files
- focused PGlite suites passed before Bun hit a coverage-output write failure after test completion

This unblocks the Cloud CF staging release currently preventing the already-merged eliza.app homepage from deploying.