### PR TITLE
fix(cloud): make passthrough stream milestones and terminal state truthful

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -1346,9 +1346,85 @@ describe("passthrough streaming — #16079 milestone telemetry", () => {
       (e) => e.path === "passthrough",
     );
     if (!event) throw new Error("no passthrough milestone event recorded");
-    // The errored tee discards buffered chunks, so mid-stream milestones may
-    // legitimately be null here — what MUST hold: the event exists, is marked
-    // aborted, and never claims a completion it did not observe.
+    // An errored source discards queued chunks (whatwg streams), so mid-stream
+    // milestones may legitimately be null here — what MUST hold: the event
+    // exists, is marked aborted, and never claims a completion it did not
+    // observe. The fan-out meter sees exactly the chunks the client saw.
+    expect(event.aborted).toBe(true);
+    expect(event.completionMs).toBeNull();
+  });
+
+  test("clean EOF without [DONE] records aborted=true and no completion (#20032)", async () => {
+    // A truncated OpenAI-compatible stream (connection closed before the
+    // protocol terminal) must be distinguishable from a completed one.
+    fetchImpl = async () =>
+      sseResponse(
+        `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"cut "},"finish_reason":null}],"usage":null}\n\n`,
+      );
+
+    const res = await callStreaming(async () => null, {});
+    expect(await res.text()).toContain("cut ");
+
+    const snapshot = getCloudTelemetrySnapshot(10);
+    const event = snapshot.streamMilestones.find(
+      (e) => e.path === "passthrough",
+    );
+    if (!event) throw new Error("no passthrough milestone event recorded");
+    expect(event.firstContentMs).not.toBeNull();
+    expect(event.aborted).toBe(true);
+    expect(event.completionMs).toBeNull();
+  });
+
+  test("upstream pulling is bounded by client backpressure — no tee queue (#20032)", async () => {
+    // With `tee()`, the fast meter branch drove upstream pulls while a slow
+    // client's branch queued every chunk unbounded. The single-reader fan-out
+    // pulls only when the client reads: a stalled client stalls the upstream.
+    const TOTAL_CHUNKS = 200;
+    let pulled = 0;
+    fetchImpl = async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (pulled >= TOTAL_CHUNKS) {
+              controller.close();
+              return;
+            }
+            pulled += 1;
+            controller.enqueue(
+              encoder.encode(
+                `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"x"},"finish_reason":null}],"usage":null}\n\n`,
+              ),
+            );
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      );
+
+    const waitUntilPromises: Array<Promise<unknown>> = [];
+    const res = await callStreaming(async () => null, {
+      executionCtx: {
+        waitUntil(promise: Promise<unknown>) {
+          waitUntilPromises.push(promise);
+        },
+      },
+    });
+    const reader = res.body?.getReader();
+    if (!reader) throw new Error("expected passthrough response body");
+    // Read one chunk, then stall the client entirely.
+    await reader.read();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    // Bounded: the upstream advanced only by the client's single read plus
+    // small fixed internal queues — never anywhere near the full stream.
+    expect(pulled).toBeLessThan(10);
+    expect(pulled).toBeLessThan(TOTAL_CHUNKS);
+    await reader.cancel(new DOMException("client stalled out", "AbortError"));
+    await Promise.all(waitUntilPromises);
+
+    const snapshot = getCloudTelemetrySnapshot(10);
+    const event = snapshot.streamMilestones.find(
+      (e) => e.path === "passthrough",
+    );
+    if (!event) throw new Error("no passthrough milestone event recorded");
     expect(event.aborted).toBe(true);
     expect(event.completionMs).toBeNull();
   });

--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -893,7 +893,11 @@ describe("passthrough streaming — client abort cancels upstream and settles th
     await Promise.resolve();
 
     expect(releaseUpstreamCancel).toBeDefined();
-    expect(waitUntilPromises).toHaveLength(1);
+    // Settlement is registered while the upstream cancel is still stalled. A
+    // concurrently pending pull may observe the cancel-induced EOF and
+    // register a second guarded no-op, so assert presence — exactly-once
+    // billing is proven by reconcileCalls below.
+    expect(waitUntilPromises.length).toBeGreaterThanOrEqual(1);
 
     releaseUpstreamCancel?.();
     await cancellation;

--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -850,6 +850,57 @@ describe("passthrough streaming — client abort cancels upstream and settles th
     expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
   });
 
+  test("registers deferred settlement before a stalled upstream cancel resolves", async () => {
+    const ledger = makeLedgerReservation(100, 0.9);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    const waitUntilPromises: Promise<unknown>[] = [];
+    let releaseUpstreamCancel: (() => void) | undefined;
+
+    fetchImpl = async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'data: {"id":"c1","choices":[{"index":0,"delta":{"content":"partial"},"finish_reason":null}],"usage":null}\n\n',
+              ),
+            );
+          },
+          cancel() {
+            return new Promise<void>((resolve) => {
+              releaseUpstreamCancel = resolve;
+            });
+          },
+        }),
+        { status: 200 },
+      );
+
+    const res = await callStreaming(settle, {
+      estimatedInputTokens: 9,
+      executionCtx: {
+        waitUntil(promise: Promise<unknown>) {
+          waitUntilPromises.push(promise);
+        },
+      },
+    });
+    const reader = res.body?.getReader();
+    if (!reader) throw new Error("expected passthrough response body");
+    await reader.read();
+
+    const cancellation = reader.cancel(
+      new DOMException("client disconnected", "AbortError"),
+    );
+    await Promise.resolve();
+
+    expect(releaseUpstreamCancel).toBeDefined();
+    expect(waitUntilPromises).toHaveLength(1);
+
+    releaseUpstreamCancel?.();
+    await cancellation;
+    await Promise.all(waitUntilPromises);
+    expect(ledger.reconcileCalls).toBe(1);
+  });
+
   test("abort mid-stream: upstream signal aborted, estimate-based partial settle", async () => {
     const ledger = makeLedgerReservation(100, 0.9);
     const settle = createCreditReservationSettler(ledger.reservation);

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -2773,12 +2773,18 @@ async function tryPassthroughStreamingRequest(params: {
             "AbortError",
           ),
       );
-      // error-policy:J6 best-effort teardown — the upstream connection may
-      // already be errored/closed; settlement proceeds from the observed tail.
-      await upstreamReader.cancel(reason).catch(() => undefined);
-      await settleOffResponsePath(params.executionCtx, () =>
+      // Register/run settlement before teardown: an upstream implementation
+      // may never resolve cancel(), but billing must still enter waitUntil (or
+      // start inline for non-Worker callers) as soon as the client disconnects.
+      const settlement = settleOffResponsePath(params.executionCtx, () =>
         settleFromTail(tail),
       );
+      // error-policy:J6 best-effort teardown — the upstream connection may
+      // already be errored/closed; settlement proceeds from the observed tail.
+      await Promise.all([
+        upstreamReader.cancel(reason).catch(() => undefined),
+        settlement,
+      ]);
     },
   });
 

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -104,8 +104,9 @@ import {
 } from "@/lib/services/inference-auth-context";
 import { InferenceBalanceCacheWarmingError } from "@/lib/services/inference-billing-fast-path";
 import {
+  createPassthroughStreamMeter,
   isPassthroughStreamingEnabled,
-  readPassthroughStreamTail,
+  type PassthroughStreamTail,
 } from "@/lib/services/inference-passthrough";
 import {
   isKnownUnacceptedProviderError,
@@ -2367,11 +2368,13 @@ function sanitizeProviderRequestId(value: string | null): string | undefined {
  * chat/completions directly with `stream: true` and return the response body
  * piped to the client byte-for-byte — no AI-SDK decode, no per-part
  * processing, no SSE re-encode (the measured ~1.5s TTFB / ~5s total gateway
- * overhead vs ~0.17s / ~0.6s direct). Billing parity comes from
- * `response.body.tee()`: one branch goes to the client untouched while the
- * other is read in the background (via the same settleOffResponsePath seam as
- * the SDK path) to extract the terminal usage frame + delivered text for the
- * EXISTING settle chain (billUsage → settleReservation → analytics → audit).
+ * overhead vs ~0.17s / ~0.6s direct). Billing parity comes from a push-based
+ * meter that observes every chunk as it is forwarded from the single upstream
+ * reader (no `tee()` — its slow-branch queue is unbounded, #20032); the
+ * stream's terminal event feeds the tail (via the same settleOffResponsePath
+ * seam as the SDK path) to extract the terminal usage frame + delivered text
+ * for the EXISTING settle chain (billUsage → settleReservation → analytics →
+ * audit).
  *
  * Returns null when the fast path does not apply (flag off, non-qualifying
  * request, no direct upstream) — callers fall through to streamText. Runs
@@ -2582,44 +2585,24 @@ async function tryPassthroughStreamingRequest(params: {
   const providerRequestId = sanitizeProviderRequestId(
     upstreamResponse.headers.get("x-request-id"),
   );
-  const [clientBranch, meterBranch] = upstreamResponse.body.tee();
-  const meterAbortController = new AbortController();
-  const clientReader = clientBranch.getReader();
-  const cancelAwareClientBranch = new ReadableStream<Uint8Array>({
-    async pull(controller) {
-      try {
-        const { done, value } = await clientReader.read();
-        if (done) {
-          controller.close();
-        } else {
-          controller.enqueue(value);
-        }
-      } catch (error) {
-        // error-policy:J1 translate upstream read failure to the client stream.
-        controller.error(error);
-      }
-    },
-    async cancel(reason) {
-      // A tee keeps the upstream alive until both branches stop. Explicitly
-      // stop the metering branch when the client disconnects so billing can
-      // settle the observed partial output inside Cloudflare's waitUntil window.
-      meterAbortController.abort(reason);
-      await clientReader.cancel(reason);
-    },
+  // Single-reader fan-out (#20032 defect 4): the client stream is the ONLY
+  // consumer of the upstream body, and the meter observes each chunk
+  // synchronously as it is forwarded. Upstream pulling is therefore bounded
+  // by the client's own backpressure — a slow or stalled client stalls the
+  // upstream instead of accumulating an unbounded tee queue in Worker memory.
+  const upstreamReader = upstreamResponse.body.getReader();
+  const meter = createPassthroughStreamMeter({
+    // #16079: milestones measured from the provider fetch dispatch.
+    startedAt: upstreamFetchStartedAt,
   });
   const billingPrompt = buildChatPromptForBilling(request);
-
-  // Meter + settle on the teed branch, OFF the response path when a Workers
-  // executionCtx exists (the same seam the SDK path defers its settlement
-  // through); inline for tests / non-Worker callers — tee buffers the client
-  // branch, so inline draining never deadlocks the response.
-  await settleOffResponsePath(params.executionCtx, async () => {
-    const tail = await readPassthroughStreamTail(
-      meterBranch,
-      meterAbortController.signal,
-      // #16079: milestones measured from the provider fetch dispatch.
-      { startedAt: upstreamFetchStartedAt },
-    );
+  // Settlement is triggered by the stream's terminal event (EOF, read error,
+  // or client cancel) — first terminal wins; the meter's own terminal guard
+  // makes the tail snapshot stable across a cancel racing an EOF.
+  let settlementStarted = false;
+  const settleFromTail = async (tail: PassthroughStreamTail) => {
+    if (settlementStarted) return;
+    settlementStarted = true;
     // Always-on correlated milestone record (#16079): the ring buffer is read
     // back via the admin cloud-observability endpoint, so unlike logger.info
     // it survives without VERBOSE_LOGGING. Bounded fields only.
@@ -2634,9 +2617,10 @@ async function tryPassthroughStreamingRequest(params: {
       firstReasoningMs: tail.milestones.firstReasoningMs,
       firstContentMs: tail.milestones.firstContentMs,
       completionMs: tail.milestones.completionMs,
-      // An in-stream SSE error frame is an upstream-reported failure: record
-      // it as not-completed rather than a healthy run (#16079).
-      aborted: tail.readError !== null || tail.sawErrorFrame,
+      // An in-stream SSE error frame is an upstream-reported failure, and a
+      // stream that ended without [DONE] is truncated: both are recorded as
+      // not-completed rather than a healthy run (#16079, #20032).
+      aborted: tail.readError !== null || tail.sawErrorFrame || !tail.sawDone,
       createdAt: new Date().toISOString(),
     });
     if (tail.usage) {
@@ -2748,6 +2732,54 @@ async function tryPassthroughStreamingRequest(params: {
       "[Chat Completions] Passthrough stream ended without usage frame; settled from estimates",
       { model, readAborted: tail.readError !== null, sawDone: tail.sawDone },
     );
+  };
+
+  // The settle chain runs OFF the response path when a Workers executionCtx
+  // exists (the same seam the SDK path defers through) and inline at the
+  // terminal event otherwise — for a non-Worker caller the final read (or the
+  // cancel acknowledgement) resolves only after settlement completes, so
+  // draining the response is a deterministic settlement barrier in tests.
+  const cancelAwareClientBranch = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      let read: Awaited<ReturnType<typeof upstreamReader.read>>;
+      try {
+        read = await upstreamReader.read();
+      } catch (error) {
+        await settleOffResponsePath(params.executionCtx, () =>
+          settleFromTail(meter.fail(error)),
+        );
+        // error-policy:J1 translate upstream read failure to the client stream.
+        controller.error(error);
+        return;
+      }
+      if (read.done) {
+        await settleOffResponsePath(params.executionCtx, () =>
+          settleFromTail(meter.finish()),
+        );
+        controller.close();
+        return;
+      }
+      meter.observe(read.value);
+      controller.enqueue(read.value);
+    },
+    async cancel(reason) {
+      // The single upstream reader keeps the provider connection alive only
+      // while the client reads. On disconnect, stop the upstream and settle
+      // the observed partial output inside Cloudflare's waitUntil window.
+      const tail = meter.fail(
+        reason ??
+          new DOMException(
+            "The client stopped reading the stream",
+            "AbortError",
+          ),
+      );
+      // error-policy:J6 best-effort teardown — the upstream connection may
+      // already be errored/closed; settlement proceeds from the observed tail.
+      await upstreamReader.cancel(reason).catch(() => undefined);
+      await settleOffResponsePath(params.executionCtx, () =>
+        settleFromTail(tail),
+      );
+    },
   });
 
   return addCorsHeaders(

--- a/packages/cloud/shared/src/lib/services/__tests__/inference-passthrough-milestones.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-passthrough-milestones.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  createPassthroughStreamMeter,
   type PassthroughStreamMilestones,
   readPassthroughStreamTail,
 } from "../inference-passthrough";
@@ -133,15 +134,27 @@ describe("readPassthroughStreamTail — milestones (#16079)", () => {
     expect(tail.milestones.firstEventMs).toBe(4);
   });
 
-  test("malformed frames never produce milestones", async () => {
+  test("a malformed data event still marks firstEvent at receipt (#20032)", async () => {
     const clock = scriptedClock(0, 2);
     const tail = await readWithClock(
       [`data: not-json\n\n`, `: comment line\n\n`, `data: [DONE]\n\n`],
       0,
       clock,
     );
-    expect(tail.milestones.firstEventMs).toBeNull();
+    // The upstream verifiably emitted an event at tick 2 even though its
+    // payload never parsed; only content/reasoning/usage stay unobserved.
+    expect(tail.milestones.firstEventMs).toBe(2);
+    expect(tail.milestones.firstContentMs).toBeNull();
+    expect(tail.milestones.firstReasoningMs).toBeNull();
     expect(tail.milestones.completionMs).toBe(6);
+  });
+
+  test("a [DONE]-only stream marks firstEvent and completion at the same receipt (#20032)", async () => {
+    const clock = scriptedClock(0, 4);
+    const tail = await readWithClock([`data: [DONE]\n\n`], 0, clock);
+    expect(tail.milestones.firstEventMs).toBe(4);
+    expect(tail.milestones.completionMs).toBe(4);
+    expect(tail.sawDone).toBe(true);
   });
 
   test("abort leaves completion null and observed partial milestones intact", async () => {
@@ -175,26 +188,49 @@ describe("readPassthroughStreamTail — milestones (#16079)", () => {
     expect(tail.milestones.completionMs).toBeNull();
   });
 
-  test("milestones default to null for a stream with no data frames", async () => {
+  test("milestones stay all-null for a stream with no data frames (#20032)", async () => {
     const tail = await readPassthroughStreamTail(sseStream(["event: ping\n\n"]), undefined, {
       startedAt: 0,
       now: () => 42,
     });
+    // A close without [DONE] is a truncated stream, not a completion.
     const allNull: PassthroughStreamMilestones = {
       firstEventMs: null,
       firstReasoningMs: null,
       firstContentMs: null,
-      completionMs: 42,
+      completionMs: null,
     };
     expect(tail.milestones).toEqual(allNull);
+    expect(tail.sawDone).toBe(false);
   });
 
-  test("defaults: startedAt/now resolve to performance.now when omitted", async () => {
+  test("defaults: startedAt/now resolve to a live clock when omitted", async () => {
     const tail = await readPassthroughStreamTail(sseStream([`data: [DONE]\n\n`]));
-    // No crash, milestone fields present and completion observed.
-    expect(tail.milestones.firstEventMs).toBeNull();
+    // No crash, first event and completion observed at [DONE] receipt.
+    expect(tail.milestones.firstEventMs).not.toBeNull();
     expect(typeof tail.milestones.completionMs).toBe("number");
     expect(tail.milestones.completionMs).not.toBeNull();
+  });
+
+  test("default clock survives a receiver-enforcing performance.now (#20032)", async () => {
+    // workerd and browsers throw "Illegal invocation" when performance.now is
+    // called without its receiver; the old default stored the unbound method.
+    const original = globalThis.performance;
+    const strict = {
+      now(this: unknown) {
+        if (this !== strict) throw new TypeError("Illegal invocation");
+        return 5;
+      },
+    };
+    (globalThis as { performance: unknown }).performance = strict;
+    try {
+      const tail = await readPassthroughStreamTail(sseStream([`data: [DONE]\n\n`]));
+      expect(tail.readError).toBeNull();
+      expect(tail.milestones.completionMs).toBe(0);
+      expect(tail.sawDone).toBe(true);
+    } finally {
+      (globalThis as { performance: unknown }).performance = original;
+    }
   });
 });
 
@@ -299,5 +335,69 @@ describe("readPassthroughStreamTail — RP review round 1 hardening (#16079)", (
     expect(tail.sawDone).toBe(true);
     expect(tail.sawErrorFrame).toBe(true);
     expect(tail.milestones.completionMs).toBeNull();
+  });
+});
+
+describe("truthful terminal state and push meter (#20032)", () => {
+  test("clean EOF without [DONE] is truncation: no completion, sawDone=false", async () => {
+    const clock = scriptedClock(0, 10);
+    const tail = await readWithClock(
+      [
+        `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}\n\n`,
+      ],
+      0,
+      clock,
+    );
+    expect(tail.readError).toBeNull();
+    expect(tail.sawDone).toBe(false);
+    expect(tail.deliveredText).toBe("Hi");
+    expect(tail.milestones.firstContentMs).toBe(10);
+    expect(tail.milestones.completionMs).toBeNull();
+  });
+
+  test("meter observes chunks split at arbitrary byte boundaries", () => {
+    let t = 0;
+    const meter = createPassthroughStreamMeter({ startedAt: 0, now: () => ++t });
+    const frame = `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}\n\ndata: [DONE]\n\n`;
+    const bytes = encoder.encode(frame);
+    // Split mid-multibyte-safe ASCII payload into 7-byte chunks.
+    for (let i = 0; i < bytes.length; i += 7) {
+      meter.observe(bytes.slice(i, i + 7));
+    }
+    const tail = meter.finish();
+    expect(tail.deliveredText).toBe("Hello");
+    expect(tail.usage).toEqual({ inputTokens: 1, outputTokens: 2, totalTokens: 3 });
+    expect(tail.sawDone).toBe(true);
+    expect(tail.milestones.firstEventMs).not.toBeNull();
+    expect(tail.milestones.completionMs).not.toBeNull();
+    expect(tail.readError).toBeNull();
+  });
+
+  test("meter terminal calls are first-wins and stable", () => {
+    const meter = createPassthroughStreamMeter({ startedAt: 0, now: () => 1 });
+    meter.observe(encoder.encode(`data: [DONE]\n\n`));
+    const finished = meter.finish();
+    // A later fail (e.g. a cancel racing EOF) must not rewrite the settled tail.
+    const failed = meter.fail(new Error("late cancel"));
+    expect(failed).toBe(finished);
+    expect(failed.readError).toBeNull();
+    expect(failed.sawDone).toBe(true);
+    // Chunks after a terminal are ignored.
+    meter.observe(encoder.encode(`data: {"error":{"message":"late"}}\n\n`));
+    expect(finished.sawErrorFrame).toBe(false);
+  });
+
+  test("meter fail records the reason and a finish cannot fabricate completion after it", () => {
+    const meter = createPassthroughStreamMeter({ startedAt: 0, now: () => 1 });
+    meter.observe(
+      encoder.encode(
+        `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"partial"},"finish_reason":null}]}\n\n`,
+      ),
+    );
+    const reason = new Error("client disconnected");
+    const tail = meter.fail(reason);
+    expect(tail.readError).toBe(reason);
+    expect(tail.deliveredText).toBe("partial");
+    expect(meter.finish().milestones.completionMs).toBeNull();
   });
 });

--- a/packages/cloud/shared/src/lib/services/inference-passthrough.ts
+++ b/packages/cloud/shared/src/lib/services/inference-passthrough.ts
@@ -8,17 +8,18 @@
  * decode/re-encode pipeline, not the provider. For requests that need NO
  * transformation (plain streaming chat against an OpenAI-compatible upstream,
  * no tools / response_format / web search), the route can instead pipe the
- * upstream response body straight to the client and meter a teed copy in the
- * background.
+ * upstream response body straight to the client while a push-based meter
+ * observes the same chunks in-line (no `tee()` — a second branch would let a
+ * slow client accumulate an unbounded queue, #20032).
  *
  * This module owns the pieces that are independent of the route:
  *   - the `INFERENCE_PASSTHROUGH_STREAMING` flag (default OFF — same
  *     soak-then-cutover discipline as the #9899 INFERENCE_* flags; flag off is
  *     byte-identical to today),
- *   - the background meter: an SSE reader for the teed branch that extracts
- *     the terminal `stream_options.include_usage` usage frame plus the
- *     delivered text, which the route feeds into the EXISTING billing settle
- *     chain (billUsage → settleReservation → analytics → audit),
+ *   - the stream meter: an incremental SSE observer that extracts the
+ *     terminal `stream_options.include_usage` usage frame plus the delivered
+ *     text, which the route feeds into the EXISTING billing settle chain
+ *     (billUsage → settleReservation → analytics → audit),
  *   - stream milestone observation (#16079): the same reader records when the
  *     first SSE frame, the first reasoning delta, the first visible content
  *     delta, and stream completion were observed, so one correlated trace can
@@ -69,18 +70,28 @@ export interface PassthroughUsage {
 }
 
 /**
- * Stream milestones observed on the teed branch (#16079). `null` means the
+ * Stream milestones observed on the metered branch (#16079). `null` means the
  * boundary was never observed (no such frame arrived, or the read failed
  * first) — absence is reported as absence, never as zero.
  */
 export interface PassthroughStreamMilestones {
-  /** First successfully parsed JSON `data:` frame (malformed frames and `[DONE]` do not count). */
+  /**
+   * First non-empty SSE `data:` event, timed at receipt. Malformed payloads
+   * and `[DONE]` count: the upstream verifiably produced an event even when
+   * its payload cannot be parsed (#20032), so time-to-first-event stays
+   * truthful for degenerate streams.
+   */
   firstEventMs: number | null;
   /** First delta carrying reasoning (`reasoning`, `reasoning_content`, or `thinking`). */
   firstReasoningMs: number | null;
   /** First delta carrying visible `content` text. */
   firstContentMs: number | null;
-  /** Reader observed stream termination (upstream close or `[DONE]`). */
+  /**
+   * Protocol completion: the provider's `data: [DONE]` marker, timed when it
+   * was parsed. A clean EOF WITHOUT `[DONE]` is a truncated stream and leaves
+   * this null (#20032) — a cut connection must never look like a completed
+   * one.
+   */
   completionMs: number | null;
 }
 
@@ -152,35 +163,49 @@ function roundedElapsed(now: () => number, origin: number): number {
   return Math.round((now() - origin) * 100) / 100;
 }
 
+/** Injectable timing options shared by the meter and the reader wrapper. */
+export interface PassthroughMeterOptions {
+  /** Monotonic origin the milestone timestamps are measured from. */
+  startedAt?: number;
+  /** Injectable clock; defaults to a receiver-safe `performance.now()` call. */
+  now?: () => number;
+}
+
 /**
- * Drain one tee branch of the upstream SSE response and report what it
- * carried. This is the billing meter, so it must never throw: a read failure
- * (client abort propagated to the upstream fetch, upstream drop) is returned
- * as `readError` with everything observed up to that point intact, and the
- * route settles from it exactly like today's onAbort path. Malformed frames
- * are skipped — the meter reports only what the provider verifiably sent,
- * never fabricated tokens (error-policy: J3 — an unparseable frame yields "no
- * data", not fake-valid data).
+ * Push-based incremental SSE meter for the pass-through pipe. The route feeds
+ * it the exact chunks it forwards to the client (single upstream reader, no
+ * `tee()`), so upstream pulling stays bounded by the client's own
+ * backpressure and the meter can never accumulate an unbounded queue behind a
+ * slow consumer (#20032 defect 4).
  *
- * Milestone timestamps (#16079) are taken when a frame is PARSED, using
- * `startedAt` as the monotonic origin and the injectable `now` clock (tests
- * pin both). The tee delivers both branches at the reader's pace, so these
- * timestamps bound the upstream's frame availability; they are not proof of
- * exactly when the client branch delivered the same bytes.
+ * `observe` is synchronous and never throws — this is the billing meter, and
+ * a parsing defect must not corrupt the byte pipe (error-policy: J7, recorded
+ * as `readError`). `finish` (clean upstream EOF) and `fail` (read error /
+ * client abort) are terminal and idempotent; both return the tail snapshot
+ * the settle chain consumes.
  */
-export async function readPassthroughStreamTail(
-  stream: ReadableStream<Uint8Array>,
-  abortSignal?: AbortSignal,
-  options: {
-    /** Monotonic origin the milestone timestamps are measured from. */
-    startedAt?: number;
-    /** Injectable clock; defaults to `performance.now`. */
-    now?: () => number;
-  } = {},
-): Promise<PassthroughStreamTail> {
-  const now = options.now ?? performance.now;
+export interface PassthroughStreamMeter {
+  observe(chunk: Uint8Array): void;
+  finish(): PassthroughStreamTail;
+  fail(error: unknown): PassthroughStreamTail;
+}
+
+/**
+ * Build a stream meter. Milestone timestamps (#16079) are taken when a frame
+ * is observed, elapsed from `startedAt` against the injected `now` clock
+ * (tests pin both; the route pins `startedAt` to the provider fetch
+ * dispatch). The default clock closes over `performance` — never the unbound
+ * `performance.now` reference, which throws on receiver-enforcing runtimes
+ * (#20032 defect 1).
+ */
+export function createPassthroughStreamMeter(
+  options: PassthroughMeterOptions = {},
+): PassthroughStreamMeter {
+  const now = options.now ?? (() => performance.now());
   const startedAt = options.startedAt ?? now();
   const decoder = new TextDecoder();
+  let buffer = "";
+  let terminal = false;
   const tail: PassthroughStreamTail = {
     usage: null,
     deliveredText: "",
@@ -200,13 +225,17 @@ export async function readPassthroughStreamTail(
     if (!line.startsWith("data:")) return;
     const payload = line.slice("data:".length).trim();
     if (!payload) return;
+    // First-event is a receipt-time boundary (#20032 defect 2): the upstream
+    // verifiably emitted an event, so it counts even when the payload is
+    // malformed or is the bare `[DONE]` terminal.
+    tail.milestones.firstEventMs ??= roundedElapsed(now, startedAt);
     if (payload === "[DONE]") {
       tail.sawDone = true;
       // [DONE] IS the provider's completion marker (#16079): record it now
       // rather than at EOF, so a provider that delays the connection close
-      // after [DONE] (or drops it) cannot skew or lose the boundary. Gated on
-      // !sawErrorFrame: an error frame already parsed means the provider
-      // reported failure — [DONE] after it must not resurrect completion.
+      // after [DONE] cannot skew the boundary. Gated on !sawErrorFrame: an
+      // error frame already parsed means the provider reported failure —
+      // [DONE] after it must not resurrect completion.
       if (!tail.sawErrorFrame) {
         tail.milestones.completionMs ??= roundedElapsed(now, startedAt);
       }
@@ -225,7 +254,6 @@ export async function readPassthroughStreamTail(
       usage?: SseUsageRecord | null;
       error?: unknown;
     };
-    tail.milestones.firstEventMs ??= roundedElapsed(now, startedAt);
     if (record.error !== undefined && record.error !== null) {
       tail.sawErrorFrame = true;
       // An error frame parsed AFTER [DONE] revokes that completion (#16079):
@@ -257,14 +285,80 @@ export async function readPassthroughStreamTail(
     }
   };
 
+  const consume = (text: string) => {
+    buffer += text;
+    let newlineAt = buffer.indexOf("\n");
+    while (newlineAt !== -1) {
+      handleLine(buffer.slice(0, newlineAt));
+      buffer = buffer.slice(newlineAt + 1);
+      newlineAt = buffer.indexOf("\n");
+    }
+  };
+
+  return {
+    observe(chunk: Uint8Array): void {
+      if (terminal) return;
+      try {
+        consume(decoder.decode(chunk, { stream: true }));
+      } catch (error) {
+        // error-policy:J7 metering must not corrupt the byte pipe — the route
+        // observes the failure via readError and settles conservatively.
+        tail.readError ??= error;
+      }
+    },
+    finish(): PassthroughStreamTail {
+      if (terminal) return tail;
+      terminal = true;
+      try {
+        consume(decoder.decode());
+        if (buffer) {
+          handleLine(buffer);
+          buffer = "";
+        }
+      } catch (error) {
+        // error-policy:J7 see observe().
+        tail.readError ??= error;
+      }
+      // A clean EOF does NOT fabricate completion: only [DONE] proves the
+      // provider finished its protocol (#20032 defect 3). A truncated stream
+      // (EOF without [DONE]) keeps completionMs null and sawDone false so
+      // telemetry and settlement see it as incomplete.
+      return tail;
+    },
+    fail(error: unknown): PassthroughStreamTail {
+      if (!terminal) {
+        terminal = true;
+        tail.readError ??=
+          error ?? new DOMException("The client stopped reading the stream", "AbortError");
+      }
+      return tail;
+    },
+  };
+}
+
+/**
+ * Drain a whole SSE stream through the meter and report what it carried —
+ * the pull-based wrapper for callers that own a dedicated branch (tests, any
+ * future non-piped consumer). Never throws: a read failure (client abort,
+ * upstream drop) is returned as `readError` with everything observed up to
+ * that point intact, and the route settles from it exactly like the onAbort
+ * path.
+ */
+export async function readPassthroughStreamTail(
+  stream: ReadableStream<Uint8Array>,
+  abortSignal?: AbortSignal,
+  options: PassthroughMeterOptions = {},
+): Promise<PassthroughStreamTail> {
+  const meter = createPassthroughStreamMeter(options);
   const reader = stream.getReader();
+  let abortError: unknown = null;
   const abortMeter = () => {
-    tail.readError ??=
+    abortError ??=
       abortSignal?.reason ??
       new DOMException("The client stopped reading the stream", "AbortError");
     // error-policy:J7 metering cancellation records failure for settlement.
-    void reader.cancel(tail.readError).catch((error) => {
-      tail.readError ??= error;
+    void reader.cancel(abortError).catch((error) => {
+      abortError ??= error;
     });
   };
   if (abortSignal?.aborted) {
@@ -273,38 +367,19 @@ export async function readPassthroughStreamTail(
     abortSignal?.addEventListener("abort", abortMeter, { once: true });
   }
   try {
-    let buffer = "";
     for (;;) {
       const { done, value } = await reader.read();
       if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      let newlineAt = buffer.indexOf("\n");
-      while (newlineAt !== -1) {
-        handleLine(buffer.slice(0, newlineAt));
-        buffer = buffer.slice(newlineAt + 1);
-        newlineAt = buffer.indexOf("\n");
-      }
+      meter.observe(value);
     }
-    buffer += decoder.decode();
-    if (buffer) handleLine(buffer);
-    // Normal termination (upstream close, with or without [DONE]) still counts
-    // as observed completion; abort/error paths fall through with the
-    // milestone left null so they cannot masquerade as a completed stream.
-    // `??=` — NOT assignment — so a completion already recorded at [DONE]
-    // parse time keeps the [DONE] boundary even when the provider delays the
-    // connection close after it (#16079). An in-stream SSE error frame is NOT
-    // completion: the provider reported failure mid-stream and the stream must
-    // not be recorded as if it ran to a healthy end.
-    if (tail.readError === null && !tail.sawErrorFrame) {
-      tail.milestones.completionMs ??= roundedElapsed(now, startedAt);
-    }
+    if (abortError !== null) return meter.fail(abortError);
+    return meter.finish();
   } catch (error) {
     // error-policy:J7 metering must not kill the settle chain — the route
     // observes the failure via readError and settles the delivered portion.
-    tail.readError = error;
+    return meter.fail(abortError ?? error);
   } finally {
     abortSignal?.removeEventListener("abort", abortMeter);
     reader.releaseLock();
   }
-  return tail;
 }


### PR DESCRIPTION
Fixes #20032

## What

Makes the pass-through stream meter's milestones and terminal state truthful, and removes the unbounded `tee()` fan-out:

1. **Receiver-safe default clock** — the meter's default clock is now `() => performance.now()` instead of storing the unbound `performance.now` reference, which throws `Illegal invocation` on receiver-enforcing runtimes (workerd/browsers) and turned healthy streams into the read-error settlement path.
2. **`firstEventMs` at receipt** — the first non-empty SSE `data:` event marks `firstEventMs` when it is received, before payload parsing. Malformed payloads and bare `[DONE]` count: the upstream verifiably emitted an event, so time-to-first-event stays truthful for degenerate streams. Content/reasoning/usage extraction still requires a parsed frame (J3 — the meter never invents data).
3. **Only `[DONE]` is completion** — a clean EOF without `[DONE]` is a truncated stream: `completionMs` stays `null`, `sawDone` stays `false`, and the milestone ring-buffer event records `aborted: true` (`readError !== null || sawErrorFrame || !sawDone`). A cut connection can no longer masquerade as a protocol-complete stream. The existing error-frame gating ([DONE] cannot resurrect a failed run; a late error frame revokes completion) is preserved.
4. **Bounded fan-out (no `tee()`)** — `packages/cloud/shared/src/lib/services/inference-passthrough.ts` now exports a push-based `createPassthroughStreamMeter` (`observe`/`finish`/`fail`, terminal-once, never throws), and the chat-completions route reads the upstream body with a **single reader**: each chunk is observed by the meter synchronously and forwarded to the client. Upstream pulling is therefore bounded by the client's own backpressure — a slow or stalled client stalls the upstream instead of accumulating an unbounded tee queue in Worker memory. Settlement fires at the stream's terminal event (EOF / read error / client cancel), first-terminal-wins, through the same `settleOffResponsePath` seam: `waitUntil` on Workers, deterministic inline barrier for non-Worker callers/tests. The billing settle chain (billUsage → settleReservation → analytics → audit), estimate-based abort settle, and conservative unknown settle are unchanged.

`readPassthroughStreamTail` remains as the pull-based wrapper over the meter (same signature) for branch-owning callers and the deterministic suites.

## Tests

- `packages/cloud/shared/src/lib/services/__tests__/inference-passthrough-milestones.test.ts` — 19 pass, including new regressions: receiver-enforcing `performance.now` (defect 1), malformed/`[DONE]`-only `firstEventMs` at receipt (defect 2), clean-EOF-without-`[DONE]` truncation (defect 3), meter chunk-splitting, terminal idempotence, and fail-then-finish stability (defect 4 plumbing).
- `packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts` — 46 pass, including new regressions: truncated stream records `aborted=true` / no completion, and **bounded upstream pulling under a stalled client** (a 200-chunk upstream advances < 10 pulls when the client stalls after one read; with `tee()` the meter branch drained all 200).
- `bun run --cwd packages/cloud/shared typecheck` / `lint` — clean.
- `bun run --cwd packages/cloud/api typecheck` / `lint` — clean for the touched files.

Pre-existing failures on `origin/develop` (verified by re-running the same suites with the touched sources reverted to develop — identical results, unrelated routes): `analytics-dashboard-empty-org-guard`, `compat-agent-credit-gate`, and the malformed-JSON `route.json` suites in cloud-api; `@elizaos/ui#lint:check` is the known develop red.

## Remainder

Live Worker/Cerebras staging proof of the flagged path (`INFERENCE_PASSTHROUGH_STREAMING` defaults OFF) requires staging credentials/deploy authority and remains a human-run validation step, per the issue's soak-then-cutover discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
