### PR TITLE
fix(telegram): keep UTF-16 surrogate pairs intact in standalone reply chunking

### DIFF
--- a/plugins/plugin-telegram/__tests__/core-test-mock.ts
+++ b/plugins/plugin-telegram/__tests__/core-test-mock.ts
@@ -41,6 +41,9 @@ vi.mock("@elizaos/core", async () => {
   const { checkPairingAllowed } = await import(
     "../../../packages/core/src/services/pairing-integration"
   );
+  const { toWellFormedUnicode, truncateWellFormed } = await import(
+    "../../../packages/core/src/utils/well-formed"
+  );
 
   const logger = {
     debug: vi.fn(),
@@ -151,5 +154,7 @@ vi.mock("@elizaos/core", async () => {
     lifeOpsPassiveConnectorsEnabled,
     logger,
     stringToUuid,
+    toWellFormedUnicode,
+    truncateWellFormed,
   };
 });

--- a/plugins/plugin-telegram/src/standalone/handler.test.ts
+++ b/plugins/plugin-telegram/src/standalone/handler.test.ts
@@ -5,7 +5,11 @@
 import { type IAgentRuntime, logger } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveTelegramRuntimeEntityId } from "../identity";
-import { handleTelegramStandaloneMessage } from "./handler";
+import {
+  handleTelegramStandaloneMessage,
+  splitTelegramText,
+  TELEGRAM_MESSAGE_MAX_LENGTH,
+} from "./handler";
 
 function makeRuntime(
   options: {
@@ -231,5 +235,47 @@ describe("standalone Telegram DM policy gate", () => {
 
     expect(handleMessage).toHaveBeenCalledTimes(1);
     expect(pairingService.isAllowed).not.toHaveBeenCalled();
+  });
+});
+
+describe("splitTelegramText", () => {
+  it("keeps short text intact without chunking", () => {
+    expect(splitTelegramText("hello world")).toEqual(["hello world"]);
+  });
+
+  it("splits text longer than 4096 characters", () => {
+    const longText = "a".repeat(4096 * 2 + 100);
+    const chunks = splitTelegramText(longText);
+
+    expect(chunks.length).toBe(3);
+    expect(chunks[0].length).toBe(TELEGRAM_MESSAGE_MAX_LENGTH);
+    expect(chunks[1].length).toBe(TELEGRAM_MESSAGE_MAX_LENGTH);
+    expect(chunks[2].length).toBe(100);
+    expect(chunks.join("")).toBe(longText);
+  });
+
+  it("keeps UTF-16 surrogate pairs intact across the 4096 boundary", () => {
+    // 4095 single-unit chars + 2-unit emoji (🦊 \uD83E\uDD8A) + 100 chars
+    // Naive split at 4096 would split the emoji between \uD83E and \uDD8A.
+    const text = `${"x".repeat(4095)}🦊${"y".repeat(100)}`;
+    const chunks = splitTelegramText(text);
+
+    expect(chunks.length).toBe(2);
+    expect(chunks[0].length).toBe(4095); // backed off by 1 so emoji moves to chunk 2
+    expect(chunks[0]).toBe("x".repeat(4095));
+    expect(chunks[1]).toBe(`🦊${"y".repeat(100)}`);
+
+    for (const chunk of chunks) {
+      expect(chunk.isWellFormed()).toBe(true);
+      expect(chunk.length).toBeLessThanOrEqual(TELEGRAM_MESSAGE_MAX_LENGTH);
+    }
+  });
+
+  it("sanitizes pre-existing lone surrogates before chunking", () => {
+    const text = "a\ud800bc";
+    const chunks = splitTelegramText(text);
+
+    expect(chunks).toEqual(["a\ufffdbc"]);
+    expect(chunks.every((c) => c.isWellFormed())).toBe(true);
   });
 });

--- a/plugins/plugin-telegram/src/standalone/handler.ts
+++ b/plugins/plugin-telegram/src/standalone/handler.ts
@@ -11,6 +11,8 @@ import {
   type IAgentRuntime,
   logger,
   type Memory,
+  toWellFormedUnicode,
+  truncateWellFormed,
   type UUID,
 } from "@elizaos/core";
 import { checkTelegramDmAccess, resolveTelegramDmPolicy } from "../dm-policy";
@@ -92,14 +94,24 @@ function getTelegramChannelType(chatType: string | undefined): ChannelType {
   }
 }
 
-function splitTelegramText(text: string): string[] {
-  const maxLength = 4096;
-  if (text.length <= maxLength) {
-    return [text];
+export const TELEGRAM_MESSAGE_MAX_LENGTH = 4096;
+
+export function splitTelegramText(text: string): string[] {
+  const wellFormed = toWellFormedUnicode(text);
+  if (wellFormed.length <= TELEGRAM_MESSAGE_MAX_LENGTH) {
+    return [wellFormed];
   }
   const chunks: string[] = [];
-  for (let start = 0; start < text.length; start += maxLength) {
-    chunks.push(text.slice(start, start + maxLength));
+  let remaining = wellFormed;
+  while (remaining.length > 0) {
+    if (remaining.length <= TELEGRAM_MESSAGE_MAX_LENGTH) {
+      chunks.push(remaining);
+      break;
+    }
+    const head = truncateWellFormed(remaining, TELEGRAM_MESSAGE_MAX_LENGTH);
+    const cut = head.length > 0 ? head.length : 1;
+    chunks.push(remaining.slice(0, cut));
+    remaining = remaining.slice(cut);
   }
   return chunks;
 }


### PR DESCRIPTION
## Summary
- Export `TELEGRAM_MESSAGE_MAX_LENGTH = 4096` in `plugins/plugin-telegram/src/standalone/handler.ts`
- Use `toWellFormedUnicode` and `truncateWellFormed` in `splitTelegramText()` to prevent cutting UTF-16 surrogate pairs (such as emojis) in half when splitting messages longer than 4096 characters
- Add unit test coverage in `plugins/plugin-telegram/src/standalone/handler.test.ts`

## Verification
- Ran `bun run --cwd plugins/plugin-telegram test` (23 test files, 219 passed)
- Ran `bun run --cwd plugins/plugin-telegram typecheck` (passed)
- Ran Biome check on modified files (passed)
