### PR TITLE
perf(cloud): degrade personal delivery projection failures to the canonical resolver

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -452,6 +452,54 @@ describe("personal Shared messaging deliveries", () => {
     });
   });
 
+  test("classifies a both-path account resolution failure as a retryable 503", async () => {
+    const { PersonalDeliveryAccountResolutionError } = await import(
+      "@/api-app/personal-delivery-projection"
+    );
+    const errorLog = mock(() => undefined);
+    const originalError = logger.error;
+    logger.error = errorLog;
+    resolvePersonalDelivery.mockImplementationOnce(async () => {
+      throw new PersonalDeliveryAccountResolutionError(
+        "status-502:TypeError",
+        new Error("private SQL detail"),
+      );
+    });
+
+    try {
+      const response = await request(valid);
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get("retry-after")).toBe("1");
+      expect(response.headers.get("x-eliza-failure-stage")).toBe(
+        "account_resolution",
+      );
+      expect(response.headers.get("x-eliza-failure-name")).toBe(
+        "PersonalDeliveryAccountResolutionError",
+      );
+      await expect(response.json()).resolves.toEqual({
+        success: false,
+        error:
+          "Account resolution is temporarily unavailable. Retry this turn shortly.",
+        code: "service_unavailable",
+        retryable: true,
+      });
+      expect(errorLog).toHaveBeenCalledWith(
+        "[personal-shared-messaging] delivery failed",
+        expect.objectContaining({
+          stage: "account_resolution",
+          errorName: "PersonalDeliveryAccountResolutionError",
+          projectionFailure: "status-502:TypeError",
+        }),
+      );
+      expect(JSON.stringify(errorLog.mock.calls)).not.toContain(
+        "private SQL detail",
+      );
+    } finally {
+      logger.error = originalError;
+    }
+  });
+
   test("redacts an unrecognized error name from headers and logs", async () => {
     const errorLog = mock(() => undefined);
     const originalError = logger.error;

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -2,7 +2,10 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
-import { resolvePersonalDeliveryProjection } from "@/api-app/personal-delivery-projection";
+import {
+  PersonalDeliveryAccountResolutionError,
+  resolvePersonalDeliveryProjection,
+} from "@/api-app/personal-delivery-projection";
 import type { AgentSandbox } from "@/db/schemas/agent-sandboxes";
 import { failureResponse, jsonError } from "@/lib/api/cloud-worker-errors";
 import { resolveElizaTraceId } from "@/lib/observability/http-telemetry";
@@ -50,6 +53,7 @@ const SAFE_ERROR_NAMES = new Set([
   "Error",
   "HTTPException",
   "InsufficientCreditsError",
+  "PersonalDeliveryAccountResolutionError",
   "RangeError",
   "RateLimitError",
   "SharedRuntimeCacheWarmingError",
@@ -681,12 +685,31 @@ app.post("/", async (c) => {
       traceId,
       stage,
       errorName,
+      ...(error instanceof PersonalDeliveryAccountResolutionError
+        ? { projectionFailure: error.projectionFailure }
+        : {}),
     });
     // This route is internal-authenticated. Safe classification headers let
     // the connector correlate a retry without exposing exception messages or
     // provider/SQL payloads in its logs.
     c.header(FAILURE_STAGE_HEADER, stage);
     c.header(FAILURE_NAME_HEADER, errorName);
+    if (error instanceof PersonalDeliveryAccountResolutionError) {
+      // Account resolution only fails here after both the projection and the
+      // canonical resolver failed — a transient storage condition the
+      // connector should retry, not an opaque terminal 500.
+      return c.json(
+        {
+          success: false,
+          error:
+            "Account resolution is temporarily unavailable. Retry this turn shortly.",
+          code: "service_unavailable",
+          retryable: true,
+        },
+        503,
+        { "Retry-After": "1" },
+      );
+    }
     if (error instanceof SharedRuntimeCacheWarmingError) {
       return c.json(
         {

--- a/packages/cloud/api/src/personal-delivery-projection.test.ts
+++ b/packages/cloud/api/src/personal-delivery-projection.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, mock, test } from "bun:test";
 import type { PersonalDeliveryInput } from "@/lib/services/eliza-app/user-service";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import {
+  PersonalDeliveryAccountResolutionError,
   PersonalDeliveryProjection,
   resolvePersonalDeliveryProjection,
 } from "./personal-delivery-projection";
@@ -278,22 +279,159 @@ describe("resolvePersonalDeliveryProjection", () => {
     expect(getByName).not.toHaveBeenCalled();
   });
 
-  test("fails closed when a bound projection returns malformed state", async () => {
+  test("bounds the projection read with an abort signal", async () => {
+    let signal: unknown;
+    const namespace = {
+      getByName: () => ({
+        fetch: async (_url: string, init: RequestInit) => {
+          signal = init.signal;
+          return Response.json({
+            ...sharedResult(),
+            resolution: "sender-projection-hit",
+          });
+        },
+      }),
+    };
+
+    await resolvePersonalDeliveryProjection(
+      {
+        PERSONAL_DELIVERY_PROJECTIONS: namespace,
+        PERSONAL_DELIVERY_PROJECTION_READ_ENABLED: "true",
+      } as unknown as AppEnv["Bindings"],
+      TELEGRAM,
+      { resolvePersonalDelivery: async () => sharedResult() },
+    );
+
+    expect(signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("degrades a malformed projection result to the canonical resolver", async () => {
     const namespace = {
       getByName: () => ({
         fetch: async () => Response.json({ success: true }),
       }),
     };
+    const resolvePersonalDelivery = mock(async () => sharedResult());
 
-    await expect(
-      resolvePersonalDeliveryProjection(
-        {
-          PERSONAL_DELIVERY_PROJECTIONS: namespace,
-          PERSONAL_DELIVERY_PROJECTION_READ_ENABLED: "true",
-        } as unknown as AppEnv["Bindings"],
-        TELEGRAM,
-        { resolvePersonalDelivery: async () => sharedResult() },
-      ),
-    ).rejects.toThrow("Personal delivery projection failed with status 200");
+    const result = await resolvePersonalDeliveryProjection(
+      {
+        PERSONAL_DELIVERY_PROJECTIONS: namespace,
+        PERSONAL_DELIVERY_PROJECTION_READ_ENABLED: "true",
+      } as unknown as AppEnv["Bindings"],
+      TELEGRAM,
+      { resolvePersonalDelivery },
+    );
+
+    expect(result).toEqual(sharedResult());
+    expect(resolvePersonalDelivery).toHaveBeenCalledTimes(1);
+  });
+
+  test("degrades a projection 502 to the canonical resolver in one attempt", async () => {
+    const namespace = {
+      getByName: () => ({
+        fetch: async () =>
+          Response.json(
+            {
+              error: "Personal delivery resolution failed",
+              failureName: "TypeError",
+            },
+            { status: 502 },
+          ),
+      }),
+    };
+    const resolvePersonalDelivery = mock(async () => sharedResult());
+
+    const result = await resolvePersonalDeliveryProjection(
+      {
+        PERSONAL_DELIVERY_PROJECTIONS: namespace,
+        PERSONAL_DELIVERY_PROJECTION_READ_ENABLED: "true",
+      } as unknown as AppEnv["Bindings"],
+      TELEGRAM,
+      { resolvePersonalDelivery },
+    );
+
+    expect(result).toEqual(sharedResult());
+    expect(resolvePersonalDelivery).toHaveBeenCalledTimes(1);
+  });
+
+  test("degrades a projection transport failure to the canonical resolver", async () => {
+    const namespace = {
+      getByName: () => ({
+        fetch: async () => {
+          throw new DOMException("The operation timed out.", "TimeoutError");
+        },
+      }),
+    };
+    const resolvePersonalDelivery = mock(async () => sharedResult());
+
+    const result = await resolvePersonalDeliveryProjection(
+      {
+        PERSONAL_DELIVERY_PROJECTIONS: namespace,
+        PERSONAL_DELIVERY_PROJECTION_READ_ENABLED: "true",
+      } as unknown as AppEnv["Bindings"],
+      TELEGRAM,
+      { resolvePersonalDelivery },
+    );
+
+    expect(result).toEqual(sharedResult());
+    expect(resolvePersonalDelivery).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws typed classification only after both paths fail", async () => {
+    const namespace = {
+      getByName: () => ({
+        fetch: async () =>
+          Response.json(
+            {
+              error: "Personal delivery resolution failed",
+              failureName: "TypeError",
+            },
+            { status: 502 },
+          ),
+      }),
+    };
+    const databaseFailure = new Error("connection reset");
+
+    const attempt = resolvePersonalDeliveryProjection(
+      {
+        PERSONAL_DELIVERY_PROJECTIONS: namespace,
+        PERSONAL_DELIVERY_PROJECTION_READ_ENABLED: "true",
+      } as unknown as AppEnv["Bindings"],
+      TELEGRAM,
+      {
+        resolvePersonalDelivery: async () => {
+          throw databaseFailure;
+        },
+      },
+    );
+
+    const caught: unknown = await attempt.then(
+      () => undefined,
+      (failure: unknown) => failure,
+    );
+    expect(caught).toBeInstanceOf(PersonalDeliveryAccountResolutionError);
+    const error = caught as PersonalDeliveryAccountResolutionError;
+    expect(error.name).toBe("PersonalDeliveryAccountResolutionError");
+    expect(error.projectionFailure).toBe("status-502:TypeError");
+    expect(error.cause).toBe(databaseFailure);
+    expect(error.message).not.toContain("connection reset");
+  });
+
+  test("reports a tenant-safe failure name from the projection boundary", async () => {
+    const memory = state();
+    const object = new PersonalDeliveryProjection(memory.durableState, ENV, {
+      resolvePersonalDelivery: async () => {
+        throw new TypeError(
+          "secret column list must never reach the connector",
+        );
+      },
+    });
+
+    const response = await object.fetch(request("/resolve", TELEGRAM));
+
+    expect(response.status).toBe(502);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.failureName).toBe("TypeError");
+    expect(JSON.stringify(body)).not.toContain("secret column list");
   });
 });

--- a/packages/cloud/api/src/personal-delivery-projection.ts
+++ b/packages/cloud/api/src/personal-delivery-projection.ts
@@ -6,6 +6,11 @@
  * cached: their lifecycle and bridge fields remain authoritative in Postgres.
  * Identity writers and tier cutover explicitly delete the sender projection;
  * a one-hour hard expiry is the final safety bound, not the coherence model.
+ *
+ * The projection is an accelerator, never a gate: a slow, failed, or
+ * malformed projection read degrades to the canonical database resolver in
+ * the same request, and only a both-path failure surfaces as the typed
+ * `PersonalDeliveryAccountResolutionError`.
  */
 
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
@@ -23,6 +28,41 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const CACHE_KEY = "shared-account";
 const CACHE_TTL_MS = 60 * 60_000;
+// A projection read slower than this bound is worse than the canonical
+// indexed Postgres statement it replaces, so the caller stops waiting and
+// resolves directly instead of letting a slow Durable Object own the tail.
+const PROJECTION_RESOLVE_TIMEOUT_MS = 1_500;
+
+const SAFE_PROJECTION_FAILURE_NAMES = new Set([
+  "AbortError",
+  "ApiError",
+  "Error",
+  "RangeError",
+  "SyntaxError",
+  "TimeoutError",
+  "TypeError",
+]);
+
+function safeProjectionFailureName(error: unknown): string {
+  const name = error instanceof Error ? error.name : "";
+  return SAFE_PROJECTION_FAILURE_NAMES.has(name) ? name : "OtherError";
+}
+
+/**
+ * Raised when both the sender projection and the canonical database resolver
+ * failed for one turn. Carries only tenant-safe classification (never SQL or
+ * provider payloads) so the internal route can emit an actionable failure
+ * name instead of a bare `Error`.
+ */
+export class PersonalDeliveryAccountResolutionError extends Error {
+  readonly projectionFailure: string;
+
+  constructor(projectionFailure: string, cause: unknown) {
+    super("Personal delivery account resolution failed", { cause });
+    this.name = "PersonalDeliveryAccountResolutionError";
+    this.projectionFailure = projectionFailure;
+  }
+}
 
 interface SharedAccountProjection {
   profileKey: string;
@@ -137,25 +177,50 @@ export async function resolvePersonalDeliveryProjection(
     return fallback.resolvePersonalDelivery(input);
   }
 
-  const response = await namespace
-    .getByName(
-      personalDeliveryProjectionObjectName(input.platform, senderId(input)),
-    )
-    .fetch(
-      `https://personal-delivery-projection${PERSONAL_DELIVERY_PROJECTION_RESOLVE_PATH}`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(input),
-      },
-    );
-  const body: unknown = await response.json();
-  if (!response.ok || !isPersonalDeliveryResult(body)) {
-    throw new Error(
-      `Personal delivery projection failed with status ${response.status}`,
-    );
+  let projectionFailure: string;
+  try {
+    const response = await namespace
+      .getByName(
+        personalDeliveryProjectionObjectName(input.platform, senderId(input)),
+      )
+      .fetch(
+        `https://personal-delivery-projection${PERSONAL_DELIVERY_PROJECTION_RESOLVE_PATH}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(input),
+          signal: AbortSignal.timeout(PROJECTION_RESOLVE_TIMEOUT_MS),
+        },
+      );
+    const body: unknown = await response.json();
+    if (response.ok && isPersonalDeliveryResult(body)) return body;
+    const upstreamName =
+      body !== null &&
+      typeof body === "object" &&
+      typeof (body as Record<string, unknown>).failureName === "string"
+        ? ((body as Record<string, unknown>).failureName as string)
+        : undefined;
+    projectionFailure = response.ok
+      ? "malformed-projection-result"
+      : `status-${response.status}${upstreamName ? `:${upstreamName}` : ""}`;
+  } catch (error) {
+    // error-policy:J4 a projection transport failure (timeout, DO restart,
+    // isolate teardown) degrades to the canonical database resolver below; it
+    // never fabricates account state and both-path failure still throws.
+    projectionFailure = safeProjectionFailureName(error);
   }
-  return body;
+
+  logger.warn(
+    "[PersonalDeliveryProjection] projection read degraded to canonical resolver",
+    { platform: input.platform, projectionFailure },
+  );
+  try {
+    return await fallback.resolvePersonalDelivery(input);
+  } catch (error) {
+    // error-policy:J2 both the projection and the canonical resolver failed;
+    // rethrow typed with tenant-safe classification and the original cause.
+    throw new PersonalDeliveryAccountResolutionError(projectionFailure, error);
+  }
 }
 
 export class PersonalDeliveryProjection {
@@ -278,7 +343,10 @@ export class PersonalDeliveryProjection {
           error: error instanceof Error ? error.message : String(error),
         });
         return Response.json(
-          { error: "Personal delivery resolution failed" },
+          {
+            error: "Personal delivery resolution failed",
+            failureName: safeProjectionFailureName(error),
+          },
           { status: 502 },
         );
       }


### PR DESCRIPTION
Fixes #20313

## Problem

The latest staging canaries on #20313 show the remaining warm failure mode of the sender projection: a warm turn hit HTTP 500 after 466ms with `failureStage=account_resolution`, `failureName=Error`, and only the connector retry rescued the message (trace `fc25899f-00f4-45aa-a8e9-4bc908077c15`). Two structural defects caused this:

1. `resolvePersonalDeliveryProjection` treated the projection Durable Object as a gate: any DO transport hiccup, slow read, non-OK status, or malformed body threw a bare `Error`, failing the whole turn even though the canonical database resolver was available and healthy in the same request. The DO read also had no time bound, so a slow DO owned the account-stage p95 tail.
2. The failure classification was lost at every hop: the DO's 502 body carried no failure type, the client threw an untyped `Error`, and the route's safe-name header could only say `Error`.

## Change

- **Projection is now an accelerator, never a gate.** The DO read is bounded at 1.5s (`AbortSignal.timeout`) — slower than that it is worse than the indexed Postgres statement it replaces. Any projection failure (timeout, DO restart, non-OK status, malformed result) logs a structured warn with a tenant-safe classification and degrades to the canonical `resolvePersonalDelivery` inside the same request. The warm 500+retry disappears for every projection-only failure, and the DO can no longer own the account p95 tail.
- **Both-path failures are typed.** Only when the projection *and* the canonical resolver fail does the turn fail, now with `PersonalDeliveryAccountResolutionError` carrying the projection failure kind (e.g. `status-502:TypeError`, `TimeoutError`) and the database `cause` — never SQL or provider payloads.
- **The internal route classifies it.** `PersonalDeliveryAccountResolutionError` joins `SAFE_ERROR_NAMES`, is logged with its `projectionFailure`, and maps to a retryable `503` + `Retry-After: 1` (like cache warming) instead of an opaque terminal 500, so the gateway retry becomes a designed path with a real name in `X-Eliza-Failure-Name`.
- **The DO boundary reports a whitelisted `failureName`** in its 502 body so the Worker log shows *why* a degrade happened, tenant-safe.

Coherence semantics are unchanged: fallback goes to the authoritative resolver, so no stale `agentId`/`dedicatedTarget` state can strand messages; invalidation writers and the Dedicated never-cache rule are untouched.

## Tests

`packages/cloud/api/src/personal-delivery-projection.test.ts` (17 pass): existing persistence/coherence/serialization suite plus new coverage for the abort-signal bound, malformed-result degrade, 502 degrade, transport-failure degrade, typed both-path failure (name, classification, cause preserved, message leak-free), and the tenant-safe DO `failureName` (asserts the raw TypeError message never reaches the body).

`packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts` (31 pass): new route-boundary test asserting a both-path account failure returns retryable 503 with `X-Eliza-Failure-Stage: account_resolution`, `X-Eliza-Failure-Name: PersonalDeliveryAccountResolutionError`, structured log includes `projectionFailure`, and the private DB detail never appears in logs.

- `bun run --cwd packages/cloud/api test` (full isolated unit suite, 479 files): 471 pass; the 8 failing files (`analytics-dashboard-empty-org-guard`, `compat-agent-credit-gate`, `credits-agent-bridge-service-key`, `stripe-event-waifu`, and four `route.json` tests under `v1/browser|credits|models|user`) fail byte-identically with this PR's two source files reverted to `origin/develop` — pre-existing in this environment, none import the touched modules.
- `bun run --cwd packages/cloud/api lint`: green
- `bun run --cwd packages/cloud/api typecheck`: the only errors are pre-existing on `origin/develop` in three untouched `packages/cloud/shared` agent-backup-restore test files (`TS18048 'reserved' is possibly 'undefined'` etc.); no errors in any file this PR touches. Root `bun run verify` was substituted with per-package gates due to shared-host load, per lane guidance.

## Human-only remainder

The issue's final acceptance (30 real warm staging Telegram messages with account p50 <100ms / p95 <250ms, plus protected staging deploy and promotion) requires the staging bot, protected deploy gate, and live Telegram/Discord clients — that measured proof must be run by the staging owner after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
