### PR TITLE
style(agent): repair develop's lint:check baseline — format push-token-registry.test.ts

### DIFF
--- a/packages/agent/src/services/push/push-token-registry.test.ts
+++ b/packages/agent/src/services/push/push-token-registry.test.ts
@@ -228,10 +228,7 @@ describe("PushTokenRegistry", () => {
         createdAt: i + 1,
       });
     }
-    ctx.cache.set(
-      "push-tokens:00000000-0000-0000-0000-0000000000aa",
-      dumped,
-    );
+    ctx.cache.set("push-tokens:00000000-0000-0000-0000-0000000000aa", dumped);
     const fresh = new PushTokenRegistry(ctx.runtime);
     const list = await fresh.list();
     expect(list).toHaveLength(MAX_PUSH_TOKENS_PER_AGENT);


### PR DESCRIPTION
## Summary

Restores develop's `turbo lint:check` baseline to green. The only remaining pinned-Biome (2.5.8) formatter failure on current `origin/develop` is one line-wrap hunk in `packages/agent/src/services/push/push-token-registry.test.ts`, landed by #23015. This is a format-only diff (1 insertion, 4 deletions, no code-token change).

Fixes #20523

## How the red landed (and what is already fixed in-repo)

- #23015 was merged with **zero completed check runs** on its head SHA (`gh api .../check-runs` returns empty): a fork PR whose approval-gated CI never ran, admin-merged by a maintainer. No repository-side workflow can block that path.
- The structural gates the issue asked for already exist on develop:
  - `develop-pr.yml` runs the pinned `bun run lint:check` + `bun run format:check` on every develop PR (called from `ci.yml`).
  - `.github/workflows/merge-candidate-biome.yml` (#22185) runs the pinned Biome on the synthesized merge-queue candidate tree, with contract tests in `packages/scripts/__tests__/merge-candidate-biome-workflow.test.ts`.
  - `quality.yml`'s `develop-lint-gate` runs the full-graph `lint:check` post-merge with non-cancelling concurrency, so reds are detected within one push wave.
- The previously reported `@elizaos/ui#lint:check` and `plugin-bluebubbles#lint:check` reds are already green on current develop head (verified locally with the pinned Biome).

## Human-only remainder (cannot be closed in-repo)

- **Branch protection / ruleset:** mark the develop-PR lint check as a *required* status check and enable the merge queue so `merge-candidate-biome.yml` actually fires; today an admin merge with no completed checks bypasses every gate above.
- Until then, any admin merge of an unreviewed-CI fork PR can reintroduce a red; the post-merge `quality.yml` lane will flag it but not block it.

## Verification

- `bunx @biomejs/biome check` (pinned 2.5.8) clean on the file and on `packages/agent` (`bun run lint:check`: 975 files, no diagnostics).
- Full-graph `node packages/scripts/run-turbo.mjs run lint:check`: 134/136 green; the two non-green tasks are this file (now fixed) and `@elizaos/capacitor-gateway#lint:check`, which fails locally only because `node-swiftlint` is not installed in this environment (its Biome half passes).
- Root `bun run format:check`: 136/136 green.
- Focused suite `packages/agent/src/services/push/push-token-registry.test.ts`: 14/14 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)