### PR TITLE
perf(cloud): route Magic Link email auth through the thin Steward shell

### DIFF
--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -11,6 +11,8 @@ import cloudApiWorker, {
   isElizaAppWebhookPath,
   isInternalDiscordGatewayPath,
   isThinInferenceEnabled,
+  isThinStewardEmailAuthPath,
+  isThinStewardPath,
   isThinStewardPublicPath,
   isUnsupportedLegacyWildcardHostname,
   redirectFrontendHost,
@@ -398,6 +400,66 @@ describe("thin Steward public path dispatch (#18049)", () => {
     expect(isThinStewardPublicPath("/steward/auth/email/send")).toBe(false);
     expect(isThinStewardPublicPath("/steward/auth/nonce")).toBe(false);
     expect(isThinStewardPublicPath("/api/v1/oauth/providers")).toBe(false);
+  });
+
+  test("POST Magic Link email legs are thin-eligible; other mutations are not", () => {
+    expect(isThinStewardEmailAuthPath("/steward/auth/email/send")).toBe(true);
+    expect(isThinStewardEmailAuthPath("/steward/auth/email/code/verify")).toBe(
+      true,
+    );
+    expect(isThinStewardEmailAuthPath("/steward/auth/email/status")).toBe(true);
+    expect(isThinStewardEmailAuthPath("/steward/vault/keys")).toBe(false);
+    expect(isThinStewardPath("POST", "/steward/auth/email/send")).toBe(true);
+    expect(isThinStewardPath("POST", "/steward/auth/providers")).toBe(false);
+    expect(isThinStewardPath("GET", "/steward/auth/email/send")).toBe(false);
+    expect(isThinStewardPath("DELETE", "/steward/auth/email/send")).toBe(false);
+    expect(isThinStewardPath("OPTIONS", "/steward/auth/email/send")).toBe(true);
+  });
+
+  test("dispatches POST /steward/auth/email/send through the thin shell", async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      expect(url).toBe("https://steward.example.test/auth/email/send");
+      return Response.json({
+        ok: true,
+        data: {
+          expiresAt: "2026-01-01T00:00:00.000Z",
+          challengeId: "c1",
+          pollSecret: "p1",
+        },
+      });
+    }) as unknown as typeof fetch;
+
+    try {
+      const response = await cloudApiWorker.fetch(
+        new Request("https://api.eliza.app/steward/auth/email/send", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            origin: "https://cloud.eliza.app",
+          },
+          body: JSON.stringify({ email: "user@example.com" }),
+        }),
+        stewardEnv,
+        executionCtx,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("x-eliza-steward-path")).toBe("thin");
+      const body = (await response.json()) as {
+        ok?: boolean;
+        data?: { challengeId?: string };
+      };
+      expect(body.ok).toBe(true);
+      expect(body.data?.challengeId).toBe("c1");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("dispatches GET /steward/auth/providers through the thin shell", async () => {

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -33,7 +33,7 @@ import { isStorageReadCapabilityPath, serveBlobHostRequest } from "./blob-host";
 import { isThinCliSessionPath } from "./cli-session-paths";
 import { isPersonalSharedTelegramEdgeEnabled } from "./personal-shared-telegram-edge";
 import { serveRegistryHostRequest } from "./registry-host";
-import { isThinStewardPublicPath } from "./steward/public-paths";
+import { isThinStewardPath } from "./steward/public-paths";
 
 export { AnonymousChatGate } from "./anonymous-chat-gate";
 export { isThinCliSessionPath } from "./cli-session-paths";
@@ -43,7 +43,11 @@ export { OnboardingSessionCoordinator } from "./onboarding-session-coordinator";
 export { PersonalDeliveryProjection } from "./personal-delivery-projection";
 export { PersonalTelegramDelivery } from "./personal-telegram-delivery";
 export { SharedRuntimeConversation } from "./shared-runtime-conversation";
-export { isThinStewardPublicPath } from "./steward/public-paths";
+export {
+  isThinStewardEmailAuthPath,
+  isThinStewardPath,
+  isThinStewardPublicPath,
+} from "./steward/public-paths";
 export { TwitterOAuthRefreshCoordinator } from "./twitter-oauth-refresh-coordinator";
 
 let appPromise: Promise<Hono<AppEnv>> | undefined;
@@ -461,12 +465,8 @@ async function dispatchThinSteward(
   env: AppEnv["Bindings"],
   ctx: ExecutionContext,
 ): Promise<Response | null> {
-  const method = request.method.toUpperCase();
-  if (method !== "GET" && method !== "HEAD" && method !== "OPTIONS") {
-    return null;
-  }
   const pathname = new URL(request.url).pathname;
-  if (!isThinStewardPublicPath(pathname)) return null;
+  if (!isThinStewardPath(request.method, pathname)) return null;
 
   const dispatchStartedAt = performance.now();
   const moduleWasInitialized = stewardThinAppPromise !== undefined;

--- a/packages/cloud/api/src/steward/public-paths.ts
+++ b/packages/cloud/api/src/steward/public-paths.ts
@@ -20,3 +20,62 @@ export function isThinStewardPublicPath(pathname: string): boolean {
     normalized === "/steward/tenants/config"
   );
 }
+
+/**
+ * Login-critical pre-auth Steward email mutations (Magic Link) that must not
+ * wait on full-app bootstrap either.
+ *
+ * Every one of these is a serial, user-blocking leg of the email sign-in
+ * flow, and each was paying the monolithic bootstrap as multi-second cold
+ * dispatch (measured 2.5–4.4s `full_app_dispatch` per request against the
+ * production Worker while the Steward upstream itself answered in 0.2–0.5s —
+ * a ~10s "Magic Link" click for the user):
+ *
+ * - POST /steward/auth/email/send — fires on the "Magic Link" click; gates
+ *   the "Check your email" screen transition.
+ * - POST /steward/auth/email/code/verify — fires on six-digit-code submit;
+ *   gates login completion.
+ * - POST /steward/auth/email/status — the companion-code 3s status poll.
+ *
+ * All three are pre-auth by design: the full app applies no additional
+ * protection to them — `authMiddleware` and the cookie-mutation CSRF guard
+ * both pass every non-`/api/` path straight through — so the thin shell's
+ * replicated stack (CORS, secure headers, Redis fail-closed guard, global IP
+ * limiter) is the exact same effective protection. Request signing and tenant
+ * pinning live in `embeddedStewardHandler`, which both shells share.
+ *
+ * OPTIONS preflight for these paths is also eligible: cross-origin cloud
+ * hosts POST `application/json`, so the preflight is a second serial
+ * full-bootstrap leg without this.
+ *
+ * Deliberately narrow: other mutating `/steward/*` paths (vault, agents,
+ * payments) stay on the full app.
+ */
+export function isThinStewardEmailAuthPath(pathname: string): boolean {
+  const normalized = pathname.replace(/\/+$/, "") || "/";
+  return (
+    normalized === "/steward/auth/email/send" ||
+    normalized === "/steward/auth/email/code/verify" ||
+    normalized === "/steward/auth/email/status"
+  );
+}
+
+/**
+ * Method-aware eligibility for the thin Steward shell: read-only for the
+ * public discovery paths, POST (+ preflight) for the login email mutations.
+ */
+export function isThinStewardPath(method: string, pathname: string): boolean {
+  const upper = method.toUpperCase();
+  if (upper === "GET" || upper === "HEAD") {
+    return isThinStewardPublicPath(pathname);
+  }
+  if (upper === "POST") {
+    return isThinStewardEmailAuthPath(pathname);
+  }
+  if (upper === "OPTIONS") {
+    return (
+      isThinStewardPublicPath(pathname) || isThinStewardEmailAuthPath(pathname)
+    );
+  }
+  return false;
+}

--- a/packages/cloud/api/src/steward/thin-app.test.ts
+++ b/packages/cloud/api/src/steward/thin-app.test.ts
@@ -12,7 +12,11 @@ import {
   providersCacheControlForAgeMs,
   resetProvidersResponseCacheForTests,
 } from "./embedded";
-import { isThinStewardPublicPath } from "./public-paths";
+import {
+  isThinStewardEmailAuthPath,
+  isThinStewardPath,
+  isThinStewardPublicPath,
+} from "./public-paths";
 import { createStewardThinApp } from "./thin-app";
 
 const UPSTREAM = "https://steward.example.test";
@@ -70,6 +74,51 @@ describe("isThinStewardPublicPath", () => {
     expect(isThinStewardPublicPath("/steward/auth/email/send")).toBe(false);
     expect(isThinStewardPublicPath("/steward/auth/nonce")).toBe(false);
     expect(isThinStewardPublicPath("/api/v1/oauth/providers")).toBe(false);
+  });
+});
+
+describe("isThinStewardEmailAuthPath", () => {
+  test("matches only the three Magic Link email legs", () => {
+    expect(isThinStewardEmailAuthPath("/steward/auth/email/send")).toBe(true);
+    expect(isThinStewardEmailAuthPath("/steward/auth/email/send/")).toBe(true);
+    expect(isThinStewardEmailAuthPath("/steward/auth/email/code/verify")).toBe(
+      true,
+    );
+    expect(isThinStewardEmailAuthPath("/steward/auth/email/status")).toBe(true);
+    expect(isThinStewardEmailAuthPath("/steward/auth/providers")).toBe(false);
+    expect(isThinStewardEmailAuthPath("/steward/auth/email/verify")).toBe(
+      false,
+    );
+    expect(isThinStewardEmailAuthPath("/steward/vault/keys")).toBe(false);
+    expect(isThinStewardEmailAuthPath("/steward/auth/passkey/register")).toBe(
+      false,
+    );
+  });
+});
+
+describe("isThinStewardPath", () => {
+  test("GET/HEAD only for public reads", () => {
+    expect(isThinStewardPath("GET", "/steward/auth/providers")).toBe(true);
+    expect(isThinStewardPath("HEAD", "/steward/tenants/config")).toBe(true);
+    expect(isThinStewardPath("GET", "/steward/auth/email/send")).toBe(false);
+  });
+
+  test("POST only for the Magic Link email legs", () => {
+    expect(isThinStewardPath("POST", "/steward/auth/email/send")).toBe(true);
+    expect(isThinStewardPath("POST", "/steward/auth/email/code/verify")).toBe(
+      true,
+    );
+    expect(isThinStewardPath("POST", "/steward/auth/email/status")).toBe(true);
+    expect(isThinStewardPath("POST", "/steward/auth/providers")).toBe(false);
+    expect(isThinStewardPath("POST", "/steward/vault/keys")).toBe(false);
+    expect(isThinStewardPath("PUT", "/steward/auth/email/send")).toBe(false);
+    expect(isThinStewardPath("DELETE", "/steward/auth/email/send")).toBe(false);
+  });
+
+  test("OPTIONS eligible for both path families", () => {
+    expect(isThinStewardPath("OPTIONS", "/steward/auth/providers")).toBe(true);
+    expect(isThinStewardPath("OPTIONS", "/steward/auth/email/send")).toBe(true);
+    expect(isThinStewardPath("OPTIONS", "/steward/vault/keys")).toBe(false);
   });
 });
 
@@ -316,6 +365,93 @@ describe("createStewardThinApp", () => {
     expect([200, 204].includes(response.status) || response.status < 500).toBe(
       true,
     );
+  });
+
+  test("proxies POST /steward/auth/email/send with signing headers", async () => {
+    const upstreamUrls: string[] = [];
+    let upstreamHeaders: Headers | null = null;
+    stubFetch(async (input: RequestInfo | URL, init?: RequestInit) => {
+      upstreamUrls.push(
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url,
+      );
+      upstreamHeaders = new Headers(init?.headers);
+      return Response.json({
+        ok: true,
+        data: {
+          expiresAt: "2026-01-01T00:00:00.000Z",
+          challengeId: "c1",
+          pollSecret: "p1",
+        },
+      });
+    });
+
+    const app = createStewardThinApp();
+    const response = await app.request(
+      "https://api.elizacloud.ai/steward/auth/email/send",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "https://app.elizacloud.ai",
+        },
+        body: JSON.stringify({ email: "user@example.com" }),
+      },
+      {
+        ...stewardEnv,
+        STEWARD_REQUEST_SIGNING_SECRET: "test-signing-secret",
+      } as unknown as AppEnv["Bindings"],
+    );
+
+    expect(response.status).toBe(200);
+    expect(upstreamUrls).toEqual([`${UPSTREAM}/auth/email/send`]);
+    const sentHeaders = upstreamHeaders as Headers | null;
+    expect(sentHeaders?.get("x-steward-signature")).toMatch(/^v1=[0-9a-f]+$/);
+    expect(sentHeaders?.get("x-steward-request-expires-at")).toMatch(/^\d+$/);
+    expect(sentHeaders?.get("idempotency-key")).toBeTruthy();
+    expect(sentHeaders?.get("x-steward-tenant")).toBe("elizacloud-staging");
+    const body = (await response.json()) as {
+      ok?: boolean;
+      data?: { challengeId?: string };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.data?.challengeId).toBe("c1");
+  });
+
+  test("proxies POST /steward/auth/email/status without a signing secret", async () => {
+    const upstreamUrls: string[] = [];
+    stubFetch(async (input: RequestInfo | URL) => {
+      upstreamUrls.push(
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url,
+      );
+      return Response.json({ ok: true, data: { status: "pending" } });
+    });
+
+    const app = createStewardThinApp();
+    const response = await app.request(
+      "https://api.elizacloud.ai/steward/auth/email/status",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ challengeId: "c1", pollSecret: "p1" }),
+      },
+      stewardEnv,
+    );
+
+    expect(response.status).toBe(200);
+    expect(upstreamUrls).toEqual([`${UPSTREAM}/auth/email/status`]);
+    const body = (await response.json()) as {
+      ok?: boolean;
+      data?: { status?: string };
+    };
+    expect(body.data?.status).toBe("pending");
   });
 
   test("OPTIONS preflight gets first-party CORS for app origin", async () => {


### PR DESCRIPTION
## Problem

Shadow reported ~10s from clicking **Magic Link** to the "Check your email" screen, and ~10s again on six-digit code submit, on eliza.app login. Functionality works; it's purely slow.

## Root cause (measured, not guessed)

The Steward upstream is fast. The Worker's monolithic full-app bootstrap is what the user is waiting on:

| leg | direct to Steward upstream | via eliza.app Worker proxy |
|---|---|---|
| POST /auth/email/send | 0.41 / 0.43 / 0.47s | 3.6 / 4.9 / 4.7s |
| POST /auth/email/code/verify | 0.25 / 0.26 / 0.28s | 4.1 / 4.0 / 4.5 / 3.6 / 3.3s |
| POST /auth/email/status | 0.22 / 0.23 / 0.23s | 3.9 / 4.0 / 4.6 / 5.9s |

`Server-Timing` on the proxied responses attributes it directly: `full_app_dispatch;dur=2558..4350` with `full_app_module_init;dur=0` — i.e. cold-isolate full-app bootstrap (~580 route modules), the exact mechanism already diagnosed for providers (#18049) and the CLI-session poll (#22948). Note workerd freezes the clock across pure CPU so the init cost surfaces as dispatch time, per the #22948 finding. GET `/steward/auth/providers` (already on the thin shell) answers in 0.27-0.68s from the same Worker at the same time — same isolate conditions, thin path fast, full path slow.

The browser flow serializes at least two of these (preflight + send; then verify + cookie sync), so the user sees roughly double the per-request penalty: the reported ~10s.

## Fix

Extend the existing thin Steward shell (`createStewardThinApp`, #18049) to also dispatch the three pre-auth Magic Link email legs (plus their OPTIONS preflights) before full-app bootstrap:

- `POST /steward/auth/email/send`
- `POST /steward/auth/email/code/verify`
- `POST /steward/auth/email/status`

New `isThinStewardEmailAuthPath` / method-aware `isThinStewardPath` in `steward/public-paths.ts`; `dispatchThinSteward` now uses the method-aware matcher. No changes to the thin shell itself or to `embeddedStewardHandler` — request signing, tenant pinning, and the 25s upstream timeout are shared by both shells.

**Security parity:** these paths are pre-auth by design. On the full app, `authMiddleware` and the cookie-mutation CSRF guard both pass every non-`/api/` path straight through, so the thin shell's replicated stack (CORS, secure headers, Redis fail-closed rate-limit guard, 600/min global IP limiter) is the exact same effective protection. Deliberately narrow: all other mutating `/steward/*` paths (vault, agents, payments) stay on the full app.

## Tests

- `src/steward/thin-app.test.ts`: path-matcher coverage (three legs only, methods gated, OPTIONS eligible, vault/passkey excluded) + functional proxy tests for send (asserts HMAC signature, expiry, idempotency key, tenant pin reach the upstream) and status (no signing secret path). 18 pass.
- `src/index.test.ts`: entrypoint dispatch test proving `POST /steward/auth/email/send` gets `X-Eliza-Steward-Path: thin`. 45 pass, 1 pre-existing failure (`redirects every legacy browser...` trailing-slash assertion) fails identically on clean develop.
- `node test/run-unit-isolated.mjs steward`: all 14 files pass.
- tsc: no new errors in touched files (pre-existing errors in unrelated `shared/src/db` tests).

## Verification after deploy

`curl -w '%{time_total}' -X POST https://eliza.app/steward/auth/email/send ...` should drop from ~4-5s to well under 1s and carry `X-Eliza-Steward-Path: thin`.