### PR TITLE
fix(app): resolve client-public from browser source

### DIFF
--- a/packages/app/test/vite-source-resolution.test.ts
+++ b/packages/app/test/vite-source-resolution.test.ts
@@ -1,12 +1,14 @@
-/** Verifies development resolves workspace source without changing production builds. */
+/** Verifies the app's real Vite aliases preserve browser-safe package entry contracts. */
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  type Alias,
   type ConfigEnv,
   createServer,
   defaultClientConditions,
   normalizePath,
+  type UserConfig,
 } from "vite";
 import { describe, expect, test } from "vitest";
 import appViteConfig from "../vite.config";
@@ -26,6 +28,43 @@ async function resolveAppViteConfig(command: ConfigEnv["command"]) {
     isPreview: false,
     isSsrBuild: false,
   });
+}
+
+function appAliases(config: UserConfig): Alias[] {
+  const aliases = config.resolve?.alias;
+  if (!Array.isArray(aliases)) {
+    throw new Error("app Vite aliases must use ordered array semantics");
+  }
+  return aliases;
+}
+
+function firstMatchingAlias(aliases: readonly Alias[], specifier: string) {
+  return aliases.find((alias) =>
+    typeof alias.find === "string"
+      ? alias.find === specifier
+      : alias.find.test(specifier),
+  );
+}
+
+async function createAppResolutionServer(
+  command: ConfigEnv["command"],
+): Promise<{
+  config: UserConfig;
+  server: Awaited<ReturnType<typeof createServer>>;
+}> {
+  const config = await resolveAppViteConfig(command);
+  const server = await createServer({
+    configFile: false,
+    root: appRoot,
+    logLevel: "silent",
+    optimizeDeps: { noDiscovery: true },
+    resolve: {
+      alias: appAliases(config),
+      conditions: config.resolve?.conditions,
+    },
+    server: { middlewareMode: true },
+  });
+  return { config, server };
 }
 
 describe("workspace package resolution", () => {
@@ -71,15 +110,7 @@ describe("workspace package resolution", () => {
   });
 
   test("resolves the shared terminal palette from workspace source while serving", async () => {
-    const serveConfig = await resolveAppViteConfig("serve");
-    const server = await createServer({
-      configFile: false,
-      root: appRoot,
-      logLevel: "silent",
-      optimizeDeps: { noDiscovery: true },
-      resolve: { conditions: serveConfig.resolve?.conditions },
-      server: { middlewareMode: true },
-    });
+    const { server } = await createAppResolutionServer("serve");
 
     try {
       const resolved =
@@ -98,15 +129,7 @@ describe("workspace package resolution", () => {
   });
 
   test("keeps browser conditional exports on their browser entry", async () => {
-    const serveConfig = await resolveAppViteConfig("serve");
-    const server = await createServer({
-      configFile: false,
-      root: appRoot,
-      logLevel: "silent",
-      optimizeDeps: { noDiscovery: true },
-      resolve: { conditions: serveConfig.resolve?.conditions },
-      server: { middlewareMode: true },
-    });
+    const { server } = await createAppResolutionServer("serve");
 
     try {
       const resolved =
@@ -119,4 +142,56 @@ describe("workspace package resolution", () => {
       await server.close();
     }
   });
+
+  test.each(["serve", "build"] as const)(
+    "binds client-public to its browser-safe source leaf while %s config resolves",
+    async (command) => {
+      const { config, server } = await createAppResolutionServer(command);
+      const aliases = appAliases(config);
+      const clientPublicTarget = normalizePath(
+        path.resolve(appRoot, "../core/src/client-public.ts"),
+      );
+      const importer = path.resolve(appRoot, "../shared/src/env-utils.ts");
+
+      try {
+        const clientPublic =
+          await server.environments.client.pluginContainer.resolveId(
+            "@elizaos/core/client-public",
+            importer,
+          );
+        expect(clientPublic?.id).toBe(clientPublicTarget);
+        expect(clientPublic?.id).not.toContain("/dist/node/");
+
+        const clientPublicAlias = firstMatchingAlias(
+          aliases,
+          "@elizaos/core/client-public",
+        );
+        const bareCoreAlias = firstMatchingAlias(aliases, "@elizaos/core");
+        expect(clientPublicAlias?.replacement).toBe(clientPublicTarget);
+        expect(bareCoreAlias).toBeDefined();
+        expect(aliases.indexOf(clientPublicAlias as Alias)).toBeLessThan(
+          aliases.indexOf(bareCoreAlias as Alias),
+        );
+
+        const bareCore =
+          await server.environments.client.pluginContainer.resolveId(
+            "@elizaos/core",
+            importer,
+          );
+        expect(normalizePath(bareCore?.id ?? "")).toBe(
+          normalizePath(bareCoreAlias?.replacement ?? ""),
+        );
+
+        for (const subpath of [
+          "@elizaos/core/testing",
+          "@elizaos/core/roles",
+          "@elizaos/core/client-public-extra",
+        ]) {
+          expect(firstMatchingAlias(aliases, subpath)).toBeUndefined();
+        }
+      } finally {
+        await server.close();
+      }
+    },
+  );
 });

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -2952,6 +2952,16 @@ export const INVALID_TRACER_PROVIDER = {};
               "platform/empty-node-module.ts",
             ),
           },
+          // Shared browser facades import this duplicate-safe leaf directly.
+          // Bind it to source before the bare-core alias so fast-dist builds do
+          // not fall through to the package's Node/default compatibility shim.
+          {
+            find: /^@elizaos\/core\/client-public$/,
+            replacement: path.resolve(
+              elizaRoot,
+              "packages/core/src/client-public.ts",
+            ),
+          },
           // @elizaos/core — force ALL copies (including nested ones in plugins
           // that bundle their own older core) to the
           // main workspace copy's browser entry.  The browser entry has all


### PR DESCRIPTION
# Relates to

Relates to #22849

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto the publication-time `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` have not completed at the final publication head; exact focused and production-path attempts are recorded below.
- [x] A reviewer can inspect the executable alias contract and the production fast-dist/browser smoke evidence below; full backend-backed browser evidence remains a draft gate.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@432b9c221ae78c9f7588877cc1e15b537ddcc5ef:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@84f58095b90b425d81bbaf6ff93914797045a332`; zero conflicts.
- [ ] `bun run verify` remains pending; exact blockers are documented under **Known gaps / failures**.

# Risks

Low and localized: one exact renderer subpath is bound to its browser-safe source leaf before the existing bare-core alias. A wrong alias or ordering could break renderer module resolution, so the tests exercise the real ordered Vite aliases in both serve and build modes and preserve the existing bare-core behavior.

# Background

## What does this PR do?

- Binds exact `@elizaos/core/client-public` imports to `packages/core/src/client-public.ts` before the bare `@elizaos/core` alias.
- Exercises the real app alias array in both serve and build configurations.
- Proves the subpath cannot fall through to `dist/node`, while `@elizaos/core`, `testing`, `roles`, and a near-miss subpath retain their existing resolution behavior.

No core export/build rewrite and no UI pixel change are included.

## What kind of change is this?

Bug fix for production Vite/browser module resolution.

# Documentation changes needed?

No. This is an executable build-resolution contract with adjacent tests.

# Testing

## Where should a reviewer start?

- `packages/app/vite.config.ts`
- `packages/app/test/vite-source-resolution.test.ts`

## Detailed testing steps

Exact reviewed head: `d3a5567ef9145116145088099d1a10fe1c676fc4`.

- Focused app Vite resolution test — PASS, 6/6 at the committed head (five owning assertions plus the newly merged adjacent Cloud SDK alias contract).
- Biome on both changed files — PASS.
- `git diff --check` — PASS.
- `ELIZA_DESKTOP_VITE_FAST_DIST=1 bun run --cwd packages/app build:web` — PASS on the patch-identical pre-rebase tree: 9,874 modules, 659 assets; chunk-safety and viewport verification passed.
- Real Chromium preview of that build — HTTP 200, app root mounted, zero request failures, and zero module-resolution errors. Console output contained only expected API 502/backend-unavailable diagnostics because no API server was running.
- `bun run --cwd packages/app audit:app` — attempted after rebase, but blocked before capture by a current-develop packed-core verifier resolving absent packaged `src/client-public.ts`.

# Evidence Gate

<!-- evidence-head:d3a5567ef9145116145088099d1a10fe1c676fc4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - build configuration and resolver tests only; no rendered UI pixels change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - build configuration and resolver tests only; no rendered UI pixels change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user interaction or visual-state change; the affected contract is module resolution during build/startup.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code or deployed backend behavior changes.
<!-- evidence-row:frontend-logs -->
- [x] Patch-identical predecessor Chromium smoke transcript:

  ```text
  preview HTTP status: 200; application root mounted
  requestfailed events: 0; module-resolution errors: 0
  console: expected API 502/backend-unavailable diagnostics only (API server intentionally absent)
  ```
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Patch-identical predecessor production-build transcript:

  ```text
  ELIZA_DESKTOP_VITE_FAST_DIST=1 build:web: PASS
  transformed modules: 9,874; emitted assets: 659
  chunk-safety verifier: PASS; viewport verifier: PASS
  ```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/runtime behavior changes.

## Backend + frontend logs

The frontend smoke transcript is included in the evidence row. No backend was started because the bug is browser module resolution; the resulting expected 502 diagnostics are explicitly not claimed as an end-to-end product journey.

## Screenshots (before / after) + video walkthrough

N/A - no UI source or pixels changed. The required app audit was attempted but stopped at the unrelated packed-core verifier before capture.

## Audio / voice walkthrough

N/A - no voice surface changes.

## Known gaps / failures

- Exact-head frozen install, focused test, Biome, and diff checks pass after the publication-time rebase.
- `bun run --cwd packages/app audit:app` is blocked before capture by the current-develop packed-core verifier resolving an absent packaged `src/client-public.ts`; this lane does not modify core packaging.
- App typecheck is blocked in the isolated checkout by missing built `@elizaos/app-core` declarations.
- The broader aggregate reached 877 passing tests and 1 skip before the environment guard rejected the unavailable pinned Node 24.15.0 runtime.
- Full backend-backed Chromium journey and root `bun run verify` remain pending; keep this PR draft and non-closing.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@432b9c221ae78c9f7588877cc1e15b537ddcc5ef:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-22849-app-alias]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@432b9c221ae78c9f7588877cc1e15b537ddcc5ef:packages/skills/skills/contribute-to-eliza"} -->
