### PR TITLE
fix(agent): make push-token registry bounds transactional and durable

### DIFF
--- a/packages/agent/src/api/push-token-routes.test.ts
+++ b/packages/agent/src/api/push-token-routes.test.ts
@@ -5,12 +5,23 @@
  * register, 400 validation, GET count with per-platform breakdown, DELETE
  * existence reporting, and the 503 returned when the push service is
  * unregistered.
+ *
+ * Also covers the uniform UTF-8 byte-cap rejection (POST body and the
+ * `:token` DELETE shape) and the typed-error HTTP mapping: a token-validation
+ * failure becomes 400 on every register/delete shape, while a genuine
+ * persistence failure propagates (server boundary → 500) and is never swallowed
+ * into a fake success.
  */
 import type http from "node:http";
+import { ElizaError } from "@elizaos/core";
 import { createMockRuntime } from "@elizaos/core/testing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NotificationPushService } from "../services/push/notification-push-service.ts";
-import type { PushTokenRegistry } from "../services/push/push-token-registry.ts";
+import {
+  PUSH_TOKEN_INVALID_CODE,
+  PUSH_TOKEN_PERSIST_FAILED_CODE,
+  type PushTokenRegistry,
+} from "../services/push/push-token-registry.ts";
 import { handlePushTokenRoute } from "./push-token-routes.ts";
 
 async function makeRuntimeWithService(): Promise<{
@@ -223,6 +234,168 @@ describe("handlePushTokenRoute", () => {
       );
     }
     expect(unregister).not.toHaveBeenCalled();
+  });
+
+  it("POST over the UTF-8 byte cap is rejected 400 by registry validation", async () => {
+    const helpers = makeHelpers();
+    // '€' is 3 bytes; 2000 chars = 6000 bytes, over the 4096-byte cap while the
+    // char count stays small (a char-only guard would wrongly accept it).
+    helpers.readJsonBody.mockResolvedValue({
+      platform: "ios",
+      token: "€".repeat(2000),
+    });
+    await handlePushTokenRoute(
+      req(PREFIX),
+      res,
+      PREFIX,
+      "POST",
+      { runtime },
+      helpers,
+    );
+    expect(helpers.error).toHaveBeenCalledWith(res, "invalid push token", 400);
+    expect(helpers.json).not.toHaveBeenCalled();
+    expect(await registry.count()).toBe(0);
+  });
+
+  it("DELETE :token over the UTF-8 byte cap is rejected 400 without persisting", async () => {
+    const helpers = makeHelpers();
+    const unregister = vi.spyOn(registry, "unregister");
+    // decodeURIComponent("%E2%82%AC") === '€' (3 bytes); 2000 copies = 6000 bytes.
+    const path = `${PREFIX}/${"%E2%82%AC".repeat(2000)}`;
+    await handlePushTokenRoute(
+      req(path),
+      res,
+      path,
+      "DELETE",
+      { runtime },
+      helpers,
+    );
+    expect(helpers.error).toHaveBeenCalledWith(res, "invalid push token", 400);
+    expect(helpers.json).not.toHaveBeenCalled();
+    // The over-cap token cannot exist, but the response must be a 400, not a
+    // silent ok:false; unregister still runs and fails validation internally.
+    unregister.mockRestore();
+  });
+
+  it("POST maps typed validation to 400 and persistence failure to 500", async () => {
+    const register = vi.spyOn(registry, "register");
+
+    const badHelpers = makeHelpers();
+    badHelpers.readJsonBody.mockResolvedValue({ platform: "ios", token: "t" });
+    register.mockRejectedValueOnce(
+      new ElizaError("invalid", { code: PUSH_TOKEN_INVALID_CODE }),
+    );
+    await handlePushTokenRoute(
+      req(PREFIX),
+      res,
+      PREFIX,
+      "POST",
+      { runtime },
+      badHelpers,
+    );
+    expect(badHelpers.error).toHaveBeenCalledWith(
+      res,
+      "invalid push token",
+      400,
+    );
+    expect(badHelpers.json).not.toHaveBeenCalled();
+
+    const downHelpers = makeHelpers();
+    downHelpers.readJsonBody.mockResolvedValue({ platform: "ios", token: "t" });
+    register.mockRejectedValueOnce(
+      new ElizaError("persist failed", {
+        code: PUSH_TOKEN_PERSIST_FAILED_CODE,
+      }),
+    );
+    // A genuine persistence failure propagates so the server boundary serves
+    // 500 — it must never be swallowed into a fake 201 or a 400.
+    await expect(
+      handlePushTokenRoute(
+        req(PREFIX),
+        res,
+        PREFIX,
+        "POST",
+        { runtime },
+        downHelpers,
+      ),
+    ).rejects.toThrow(/persist/);
+    expect(downHelpers.error).not.toHaveBeenCalled();
+    register.mockRestore();
+  });
+
+  it("DELETE maps validation to 400 and persistence to 500 for BOTH route shapes", async () => {
+    const unregister = vi.spyOn(registry, "unregister");
+    const bodyPath = PREFIX;
+    const tokenPath = `${PREFIX}/tok`;
+
+    // ── body shape ──────────────────────────────────────────────────
+    const bodyBad = makeHelpers();
+    bodyBad.readJsonBody.mockResolvedValue({ token: "tok" });
+    unregister.mockRejectedValueOnce(
+      new ElizaError("invalid", { code: PUSH_TOKEN_INVALID_CODE }),
+    );
+    await handlePushTokenRoute(
+      req(bodyPath),
+      res,
+      bodyPath,
+      "DELETE",
+      { runtime },
+      bodyBad,
+    );
+    expect(bodyBad.error).toHaveBeenCalledWith(res, "invalid push token", 400);
+
+    const bodyDown = makeHelpers();
+    bodyDown.readJsonBody.mockResolvedValue({ token: "tok" });
+    unregister.mockRejectedValueOnce(
+      new ElizaError("persist failed", {
+        code: PUSH_TOKEN_PERSIST_FAILED_CODE,
+      }),
+    );
+    await expect(
+      handlePushTokenRoute(
+        req(bodyPath),
+        res,
+        bodyPath,
+        "DELETE",
+        { runtime },
+        bodyDown,
+      ),
+    ).rejects.toThrow(/persist/);
+    expect(bodyDown.error).not.toHaveBeenCalled();
+
+    // ── :token shape ────────────────────────────────────────────────
+    const tokenBad = makeHelpers();
+    unregister.mockRejectedValueOnce(
+      new ElizaError("invalid", { code: PUSH_TOKEN_INVALID_CODE }),
+    );
+    await handlePushTokenRoute(
+      req(tokenPath),
+      res,
+      tokenPath,
+      "DELETE",
+      { runtime },
+      tokenBad,
+    );
+    expect(tokenBad.error).toHaveBeenCalledWith(res, "invalid push token", 400);
+
+    const tokenDown = makeHelpers();
+    unregister.mockRejectedValueOnce(
+      new ElizaError("persist failed", {
+        code: PUSH_TOKEN_PERSIST_FAILED_CODE,
+      }),
+    );
+    await expect(
+      handlePushTokenRoute(
+        req(tokenPath),
+        res,
+        tokenPath,
+        "DELETE",
+        { runtime },
+        tokenDown,
+      ),
+    ).rejects.toThrow(/persist/);
+    expect(tokenDown.error).not.toHaveBeenCalled();
+    unregister.mockRestore();
   });
 
   it("DELETE :token decodes valid percent-encoded token before unregister", async () => {

--- a/packages/agent/src/api/push-token-routes.ts
+++ b/packages/agent/src/api/push-token-routes.ts
@@ -29,7 +29,7 @@ import {
   NotificationPushService,
 } from "../services/push/notification-push-service.ts";
 import {
-  MAX_PUSH_TOKEN_LENGTH,
+  isPushTokenValidationError,
   type PushPlatform,
   type PushTokenRegistry,
 } from "../services/push/push-token-registry.ts";
@@ -94,11 +94,20 @@ export async function handlePushTokenRoute(
       helpers.error(res, "token is required", 400);
       return true;
     }
-    if (token.length > MAX_PUSH_TOKEN_LENGTH) {
-      helpers.error(res, "token exceeds the length cap", 400);
-      return true;
+    // The registry re-validates the token (byte cap included). A typed
+    // validation failure is a client error (400); a durable-write failure
+    // propagates and the server boundary maps it to 500.
+    try {
+      await registry.register(platform, token);
+    } catch (err) {
+      // error-policy:J4 user-facing degrade — only the expected validation
+      // shape becomes a 400; every other failure rethrows to the 500 boundary.
+      if (isPushTokenValidationError(err)) {
+        helpers.error(res, "invalid push token", 400);
+        return true;
+      }
+      throw err;
     }
-    await registry.register(platform, token);
     helpers.json(res, { ok: true }, 201);
     return true;
   }
@@ -114,9 +123,7 @@ export async function handlePushTokenRoute(
       helpers.error(res, "token is required", 400);
       return true;
     }
-    const ok = await registry.unregister(token);
-    helpers.json(res, { ok });
-    return true;
+    return unregisterOrError(registry, token, res, helpers);
   }
 
   // ── Legacy DELETE /api/notifications/push-tokens/:token ───────────
@@ -132,11 +139,35 @@ export async function handlePushTokenRoute(
       helpers.error(res, "invalid push token", 400);
       return true;
     }
-    const ok = await registry.unregister(token);
-    helpers.json(res, { ok });
-    return true;
+    return unregisterOrError(registry, token, res, helpers);
   }
 
   helpers.error(res, "push-token route not found", 404);
+  return true;
+}
+
+/**
+ * Run `registry.unregister`, applying the same byte-bound validation as the
+ * register path across BOTH DELETE shapes. A typed validation failure maps to
+ * 400; a durable-write failure rethrows to the server's 500 boundary.
+ */
+async function unregisterOrError(
+  registry: PushTokenRegistry,
+  token: string,
+  res: http.ServerResponse,
+  helpers: RouteHelpers,
+): Promise<boolean> {
+  try {
+    const ok = await registry.unregister(token);
+    helpers.json(res, { ok });
+  } catch (err) {
+    // error-policy:J4 user-facing degrade — expected validation shape → 400;
+    // anything else rethrows so genuine persistence failures surface as 500.
+    if (isPushTokenValidationError(err)) {
+      helpers.error(res, "invalid push token", 400);
+      return true;
+    }
+    throw err;
+  }
   return true;
 }

--- a/packages/agent/src/services/push/push-token-registry.test.ts
+++ b/packages/agent/src/services/push/push-token-registry.test.ts
@@ -12,8 +12,11 @@
  * fails closed without destroying the durable row), one-time durable repair
  * that never rewrites a clean load, failed-write rollback (in-memory and durable
  * state unchanged, typed error, token redacted), mutation-queue recovery after a
- * failed op, observable atomicity (list/count never see an uncommitted mutation
- * while its write is pending and stay unchanged on rejection), and
+ * failed op, resolved-false persistence failure (register/unregister and a
+ * deferred false-return all leave in-memory and durable state unchanged with the
+ * typed persist-failed error), observable atomicity (list/count never see an
+ * uncommitted mutation while its write is pending and stay unchanged on
+ * rejection), and
  * persistence-boundary validation of direct callers (unsupported platform and
  * non-string token become the typed invalid error). Backed by a Map-backed mock
  * runtime cache — no real storage.
@@ -437,6 +440,130 @@ describe("PushTokenRegistry", () => {
     // In-memory registry unchanged (rejected token absent, prior token intact).
     expect((await reg.list()).map((r) => r.token)).toEqual(["keep"]);
     // Durable cache never received the rejected token either.
+    expect((cache.get(KEY) as PushTokenRecord[]).map((r) => r.token)).toEqual([
+      "keep",
+    ]);
+  });
+
+  it("treats a resolved false setCache as a persistence failure on register", async () => {
+    let denyNextWrite = false;
+    const cache = new Map<string, unknown>();
+    const runtime = createMockRuntime({
+      agentId: AGENT_ID,
+      getCache: async <T>(k: string): Promise<T | undefined> =>
+        cache.get(k) as T | undefined,
+      setCache: async <T>(k: string, value: T): Promise<boolean> => {
+        // The SQL adapter resolves `false` when the durable row did not land.
+        if (denyNextWrite) return false;
+        cache.set(k, value);
+        return true;
+      },
+    });
+    const reg = new PushTokenRegistry(runtime);
+    await reg.register("ios", "keep");
+    expect(await reg.count()).toBe(1);
+
+    denyNextWrite = true;
+    await reg.register("android", "denied").then(
+      () => {
+        throw new Error("expected a false setCache to reject");
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ElizaError);
+        expect((err as ElizaError).code).toBe(PUSH_TOKEN_PERSIST_FAILED_CODE);
+      },
+    );
+    denyNextWrite = false;
+
+    // Observable registry and durable cache stay on the committed token.
+    expect((await reg.list()).map((r) => r.token)).toEqual(["keep"]);
+    expect((cache.get(KEY) as PushTokenRecord[]).map((r) => r.token)).toEqual([
+      "keep",
+    ]);
+  });
+
+  it("treats a resolved false setCache as a persistence failure on unregister", async () => {
+    let denyNextWrite = false;
+    const cache = new Map<string, unknown>();
+    const runtime = createMockRuntime({
+      agentId: AGENT_ID,
+      getCache: async <T>(k: string): Promise<T | undefined> =>
+        cache.get(k) as T | undefined,
+      setCache: async <T>(k: string, value: T): Promise<boolean> => {
+        if (denyNextWrite) return false;
+        cache.set(k, value);
+        return true;
+      },
+    });
+    const reg = new PushTokenRegistry(runtime);
+    await reg.register("ios", "keep");
+    expect(await reg.count()).toBe(1);
+
+    denyNextWrite = true;
+    await reg.unregister("keep").then(
+      () => {
+        throw new Error("expected a false setCache to reject");
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ElizaError);
+        expect((err as ElizaError).code).toBe(PUSH_TOKEN_PERSIST_FAILED_CODE);
+      },
+    );
+    denyNextWrite = false;
+
+    // The delete was never published: the token remains in memory and durably.
+    expect((await reg.list()).map((r) => r.token)).toEqual(["keep"]);
+    expect((cache.get(KEY) as PushTokenRecord[]).map((r) => r.token)).toEqual([
+      "keep",
+    ]);
+  });
+
+  it("never publishes a deferred false setCache while its write is pending", async () => {
+    const cache = new Map<string, unknown>();
+    let gateNextWrite = false;
+    let resolvePendingWrite!: (result: boolean) => void;
+    let pendingWriteStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      pendingWriteStarted = resolve;
+    });
+    const runtime = createMockRuntime({
+      agentId: AGENT_ID,
+      getCache: async <T>(k: string): Promise<T | undefined> =>
+        cache.get(k) as T | undefined,
+      setCache: <T>(k: string, value: T): Promise<boolean> => {
+        if (!gateNextWrite) {
+          cache.set(k, value);
+          return Promise.resolve(true);
+        }
+        return new Promise<boolean>((resolve) => {
+          resolvePendingWrite = resolve;
+          pendingWriteStarted();
+        });
+      },
+    });
+    const reg = new PushTokenRegistry(runtime);
+    await reg.register("ios", "keep");
+    expect(await reg.count()).toBe(1);
+
+    gateNextWrite = true;
+    const pending = reg.register("android", "pending-token");
+    await started;
+    // Staged but not published while the durable write is in flight.
+    expect((await reg.list()).map((r) => r.token)).toEqual(["keep"]);
+
+    resolvePendingWrite(false);
+    await pending.then(
+      () => {
+        throw new Error("expected the false write to reject");
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ElizaError);
+        expect((err as ElizaError).code).toBe(PUSH_TOKEN_PERSIST_FAILED_CODE);
+      },
+    );
+
+    // Observable registry and durable cache are unchanged after the false write.
+    expect((await reg.list()).map((r) => r.token)).toEqual(["keep"]);
     expect((cache.get(KEY) as PushTokenRecord[]).map((r) => r.token)).toEqual([
       "keep",
     ]);

--- a/packages/agent/src/services/push/push-token-registry.test.ts
+++ b/packages/agent/src/services/push/push-token-registry.test.ts
@@ -1,20 +1,35 @@
 /**
  * Covers the push-token registry: register/list/count/unregister, idempotent
  * upsert, moving a token between platforms, whitespace trimming and empty-token
- * rejection, platform filtering, cache-backed persistence with rehydration, and
+ * rejection, platform filtering, cache-backed persistence with rehydration,
  * dropping malformed records on hydrate, concurrent first-use hydration, and
- * serialized persistence. Backed by a Map-backed mock runtime cache — no real
+ * serialized persistence.
+ *
+ * Adversarial persistence-boundary coverage: UTF-8 byte-length bounding (not
+ * char length), malformed-timestamp rejection (NaN/Infinity/negative/fractional
+ * /unsafe-integer/non-number), dedup-before-cap so duplicate-heavy dumps do not
+ * underfill, the persisted-record ceiling (exact boundary hydrates, one above
+ * fails closed without destroying the durable row), one-time durable repair
+ * that never rewrites a clean load, failed-write rollback (in-memory and durable
+ * state unchanged, typed error, token redacted), and mutation-queue recovery
+ * after a failed op. Backed by a Map-backed mock runtime cache — no real
  * storage.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import { createMockRuntime } from "@elizaos/core/testing";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
-  MAX_PUSH_TOKEN_LENGTH,
+  MAX_PERSISTED_PUSH_TOKENS,
+  MAX_PUSH_TOKEN_BYTES,
   MAX_PUSH_TOKENS_PER_AGENT,
+  PUSH_TOKEN_INVALID_CODE,
+  PUSH_TOKEN_PERSIST_FAILED_CODE,
   type PushTokenRecord,
   PushTokenRegistry,
 } from "./push-token-registry.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa";
+const KEY = `push-tokens:${AGENT_ID}`;
 
 function createRuntime(): {
   runtime: IAgentRuntime;
@@ -238,9 +253,234 @@ describe("PushTokenRegistry", () => {
     expect(list.map((r) => r.token)).not.toContain("old-0");
   });
 
-  it("rejects a token longer than the length cap", async () => {
-    const huge = "x".repeat(MAX_PUSH_TOKEN_LENGTH + 1);
-    await expect(registry.register("ios", huge)).rejects.toThrow(/length cap/);
+  it("rejects a token longer than the byte cap", async () => {
+    const huge = "x".repeat(MAX_PUSH_TOKEN_BYTES + 1);
+    await expect(registry.register("ios", huge)).rejects.toThrow(/byte cap/);
     expect(await registry.count()).toBe(0);
+  });
+
+  it("bounds tokens by UTF-8 byte length, not char length", async () => {
+    // '€' encodes to 3 UTF-8 bytes, so a char-length check would accept a token
+    // over the byte cap. Register the largest token that fits by bytes, then one
+    // char more (still tiny by char count) and confirm it is rejected.
+    const maxChars = Math.floor(MAX_PUSH_TOKEN_BYTES / 3);
+    const atLimit = "€".repeat(maxChars);
+    expect(Buffer.byteLength(atLimit, "utf8")).toBeLessThanOrEqual(
+      MAX_PUSH_TOKEN_BYTES,
+    );
+    await registry.register("ios", atLimit);
+    expect(await registry.count()).toBe(1);
+
+    const overByBytes = "€".repeat(maxChars + 1);
+    expect(overByBytes.length).toBeLessThan(MAX_PUSH_TOKEN_BYTES);
+    expect(Buffer.byteLength(overByBytes, "utf8")).toBeGreaterThan(
+      MAX_PUSH_TOKEN_BYTES,
+    );
+    await expect(registry.register("android", overByBytes)).rejects.toThrow(
+      /byte cap/,
+    );
+    expect(await registry.count()).toBe(1);
+  });
+
+  it("rejects hydrated records with malformed timestamps", async () => {
+    ctx.cache.set(KEY, [
+      { token: "ok", platform: "ios", createdAt: 5 },
+      { token: "nan", platform: "ios", createdAt: Number.NaN },
+      { token: "inf", platform: "ios", createdAt: Number.POSITIVE_INFINITY },
+      { token: "negative", platform: "ios", createdAt: -1 },
+      { token: "fractional", platform: "ios", createdAt: 1.5 },
+      {
+        token: "unsafe",
+        platform: "ios",
+        createdAt: Number.MAX_SAFE_INTEGER + 1,
+      },
+      { token: "stringified", platform: "ios", createdAt: "5" },
+    ]);
+    const fresh = new PushTokenRegistry(ctx.runtime);
+    expect((await fresh.list()).map((r) => r.token)).toEqual(["ok"]);
+  });
+
+  it("drops hydrated records whose token exceeds the UTF-8 byte cap", async () => {
+    ctx.cache.set(KEY, [
+      { token: "small", platform: "ios", createdAt: 1 },
+      {
+        token: "€".repeat(Math.floor(MAX_PUSH_TOKEN_BYTES / 3) + 1),
+        platform: "android",
+        createdAt: 2,
+      },
+    ]);
+    const fresh = new PushTokenRegistry(ctx.runtime);
+    expect((await fresh.list()).map((r) => r.token)).toEqual(["small"]);
+  });
+
+  it("dedups before capping so duplicate-heavy data does not underfill", async () => {
+    // Naive cap-then-dedup would keep only the single hottest token (its 64
+    // newest duplicates fill the cap, then collapse to one). Dedup-before-cap
+    // must retain the newest hot record PLUS every unique older token.
+    const dump: PushTokenRecord[] = [];
+    for (let i = 0; i < MAX_PUSH_TOKENS_PER_AGENT; i++) {
+      dump.push({ token: "hot", platform: "ios", createdAt: 1000 + i });
+    }
+    for (let i = 0; i < 40; i++) {
+      dump.push({ token: `uniq-${i}`, platform: "android", createdAt: 1 + i });
+    }
+    ctx.cache.set(KEY, dump);
+    const fresh = new PushTokenRegistry(ctx.runtime);
+    const list = await fresh.list();
+    expect(list).toHaveLength(41);
+    expect(list.find((r) => r.token === "hot")?.createdAt).toBe(1063);
+    expect(list.filter((r) => r.token.startsWith("uniq-"))).toHaveLength(40);
+  });
+
+  it("hydrates exactly at the persisted-record ceiling but fails closed above it", async () => {
+    const makeDump = (n: number): PushTokenRecord[] =>
+      Array.from({ length: n }, (_, i) => ({
+        token: `t-${i}`,
+        platform: "ios" as const,
+        createdAt: i + 1,
+      }));
+
+    // Exactly at the ceiling: traversed, deduped, capped to the live cap.
+    ctx.cache.set(KEY, makeDump(MAX_PERSISTED_PUSH_TOKENS));
+    const atCeiling = new PushTokenRegistry(ctx.runtime);
+    expect(await atCeiling.count()).toBe(MAX_PUSH_TOKENS_PER_AGENT);
+
+    // One above the ceiling: fail closed to empty and DO NOT destroy the
+    // durable row (a later mutation overwrites it with a bounded array).
+    const over = createRuntime();
+    const oversized = makeDump(MAX_PERSISTED_PUSH_TOKENS + 1);
+    over.cache.set(KEY, oversized);
+    const aboveCeiling = new PushTokenRegistry(over.runtime);
+    expect(await aboveCeiling.count()).toBe(0);
+    expect((over.cache.get(KEY) as PushTokenRecord[]).length).toBe(
+      MAX_PERSISTED_PUSH_TOKENS + 1,
+    );
+  });
+
+  it("persists the repaired form exactly once and never rewrites a clean load", async () => {
+    const setCalls: PushTokenRecord[][] = [];
+    const cache = new Map<string, unknown>();
+    cache.set(KEY, [
+      { token: "  spaced  ", platform: "ios", createdAt: 2, extra: "junk" },
+      { token: "dupe", platform: "android", createdAt: 1 },
+      { token: "dupe", platform: "android", createdAt: 9 },
+      { token: "", platform: "ios", createdAt: 3 },
+    ]);
+    const runtime = createMockRuntime({
+      agentId: AGENT_ID,
+      getCache: async <T>(k: string): Promise<T | undefined> =>
+        cache.get(k) as T | undefined,
+      setCache: async <T>(k: string, value: T): Promise<boolean> => {
+        setCalls.push(value as PushTokenRecord[]);
+        cache.set(k, value);
+        return true;
+      },
+    });
+
+    const first = new PushTokenRegistry(runtime);
+    const list = await first.list();
+    expect(list.map((r) => r.token).sort()).toEqual(["dupe", "spaced"]);
+    expect(setCalls).toHaveLength(1);
+    const repaired = setCalls[0];
+    expect(repaired.find((r) => r.token === "dupe")?.createdAt).toBe(9);
+    for (const record of repaired) {
+      expect(Object.keys(record).sort()).toEqual([
+        "createdAt",
+        "platform",
+        "token",
+      ]);
+    }
+
+    // A second cold registry over the already-repaired cache must not rewrite.
+    const second = new PushTokenRegistry(runtime);
+    await second.list();
+    expect(setCalls).toHaveLength(1);
+  });
+
+  it("rolls the in-memory registry back when a durable write is rejected", async () => {
+    let failNextWrite = false;
+    const cache = new Map<string, unknown>();
+    const runtime = createMockRuntime({
+      agentId: AGENT_ID,
+      getCache: async <T>(k: string): Promise<T | undefined> =>
+        cache.get(k) as T | undefined,
+      setCache: async <T>(k: string, value: T): Promise<boolean> => {
+        if (failNextWrite) throw new Error("cache offline");
+        cache.set(k, value);
+        return true;
+      },
+    });
+    const reg = new PushTokenRegistry(runtime);
+    await reg.register("ios", "keep");
+    expect(await reg.count()).toBe(1);
+
+    failNextWrite = true;
+    await reg.register("android", "reject-me").then(
+      () => {
+        throw new Error("expected the rejected write to throw");
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ElizaError);
+        expect((err as ElizaError).code).toBe(PUSH_TOKEN_PERSIST_FAILED_CODE);
+        // Tokens are never leaked into the error surface.
+        expect(String((err as ElizaError).message)).not.toContain("reject-me");
+        expect(JSON.stringify((err as ElizaError).context)).not.toContain(
+          "reject-me",
+        );
+      },
+    );
+    failNextWrite = false;
+
+    // In-memory registry unchanged (rejected token absent, prior token intact).
+    expect((await reg.list()).map((r) => r.token)).toEqual(["keep"]);
+    // Durable cache never received the rejected token either.
+    expect((cache.get(KEY) as PushTokenRecord[]).map((r) => r.token)).toEqual([
+      "keep",
+    ]);
+  });
+
+  it("keeps processing later mutations after a failed one (no queue wedge)", async () => {
+    let failCount = 0;
+    const cache = new Map<string, unknown>();
+    const runtime = createMockRuntime({
+      agentId: AGENT_ID,
+      getCache: async <T>(k: string): Promise<T | undefined> =>
+        cache.get(k) as T | undefined,
+      setCache: async <T>(k: string, value: T): Promise<boolean> => {
+        if (failCount > 0) {
+          failCount--;
+          throw new Error("transient cache failure");
+        }
+        cache.set(k, value);
+        return true;
+      },
+    });
+    const reg = new PushTokenRegistry(runtime);
+    await reg.register("ios", "a");
+
+    failCount = 1;
+    const failing = reg.register("android", "b");
+    const following = reg.register("ios", "c");
+    await expect(failing).rejects.toThrow(/persist/);
+    // The queue is not wedged: the op enqueued after the failure still resolves.
+    await following;
+
+    expect((await reg.list()).map((r) => r.token).sort()).toEqual(["a", "c"]);
+    expect(
+      (cache.get(KEY) as PushTokenRecord[]).map((r) => r.token).sort(),
+    ).toEqual(["a", "c"]);
+  });
+
+  it("rejects an empty token with a typed validation error", async () => {
+    await registry.register("ios", "real").catch(() => undefined);
+    await registry.register("ios", "   ").then(
+      () => {
+        throw new Error("expected empty token to reject");
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ElizaError);
+        expect((err as ElizaError).code).toBe(PUSH_TOKEN_INVALID_CODE);
+      },
+    );
   });
 });

--- a/packages/agent/src/services/push/push-token-registry.test.ts
+++ b/packages/agent/src/services/push/push-token-registry.test.ts
@@ -10,7 +10,10 @@
  * /unsafe-integer/non-number), dedup-before-cap so duplicate-heavy dumps do not
  * underfill, the persisted-record ceiling (exact boundary hydrates, one above
  * fails closed without destroying the durable row), one-time durable repair
- * that never rewrites a clean load, failed-write rollback (in-memory and durable
+ * that never rewrites a clean load (including a resolved-false repair write that
+ * leaves the dirty row intact, reports a redacted diagnostic without failing the
+ * read, retries on the next cold start, and stops rewriting once it lands),
+ * failed-write rollback (in-memory and durable
  * state unchanged, typed error, token redacted), mutation-queue recovery after a
  * failed op, resolved-false persistence failure (register/unregister and a
  * deferred false-return all leave in-memory and durable state unchanged with the
@@ -401,6 +404,77 @@ describe("PushTokenRegistry", () => {
     const second = new PushTokenRegistry(runtime);
     await second.list();
     expect(setCalls).toHaveLength(1);
+  });
+
+  it("leaves the dirty row intact and reports when a repair write resolves false, then a later true repair stops rewriting", async () => {
+    const setCalls: PushTokenRecord[][] = [];
+    const reported: Array<{ scope: string; error: unknown }> = [];
+    const cache = new Map<string, unknown>();
+    // A bounded-but-dirty dump (unsorted extra field + dupe) that normalizes.
+    const dirty = [
+      { token: "  spaced  ", platform: "ios", createdAt: 2, extra: "junk" },
+      { token: "dupe", platform: "android", createdAt: 1 },
+      { token: "dupe", platform: "android", createdAt: 9 },
+    ];
+    cache.set(KEY, dirty);
+    let repairSucceeds = false;
+    const runtime = createMockRuntime({
+      agentId: AGENT_ID,
+      getCache: async <T>(k: string): Promise<T | undefined> =>
+        cache.get(k) as T | undefined,
+      setCache: async <T>(k: string, value: T): Promise<boolean> => {
+        setCalls.push(value as PushTokenRecord[]);
+        // The adapter reports `false` when the durable row did not land.
+        if (!repairSucceeds) return false;
+        cache.set(k, value);
+        return true;
+      },
+    });
+    runtime.reportError = ((scope: string, error: unknown) => {
+      reported.push({ scope, error });
+    }) as IAgentRuntime["reportError"];
+
+    // Cold start #1: repair write resolves false. The read still succeeds with
+    // the normalized in-memory view, the diagnostic is reported (redacted), and
+    // the original dirty durable row is left intact for a later retry.
+    const first = new PushTokenRegistry(runtime);
+    expect((await first.list()).map((r) => r.token).sort()).toEqual([
+      "dupe",
+      "spaced",
+    ]);
+    expect(setCalls).toHaveLength(1);
+    expect(reported).toHaveLength(1);
+    expect(reported[0].scope).toBe("push.registry.repair");
+    expect((reported[0].error as ElizaError).code).toBe(
+      PUSH_TOKEN_PERSIST_FAILED_CODE,
+    );
+    // No token leaks into the reported error surface.
+    expect(JSON.stringify(reported[0].error)).not.toContain("spaced");
+    // Durable row is still the original dirty dump (repair did not land).
+    expect(cache.get(KEY)).toBe(dirty);
+
+    // Cold start #2: the dirty row is still present, so the registry scans and
+    // re-normalizes again — but now the repair write lands.
+    repairSucceeds = true;
+    const second = new PushTokenRegistry(runtime);
+    expect((await second.list()).map((r) => r.token).sort()).toEqual([
+      "dupe",
+      "spaced",
+    ]);
+    expect(setCalls).toHaveLength(2);
+    const repaired = cache.get(KEY) as PushTokenRecord[];
+    for (const record of repaired) {
+      expect(Object.keys(record).sort()).toEqual([
+        "createdAt",
+        "platform",
+        "token",
+      ]);
+    }
+
+    // Cold start #3: the durable row is now canonical, so no rewrite occurs.
+    const third = new PushTokenRegistry(runtime);
+    await third.list();
+    expect(setCalls).toHaveLength(2);
   });
 
   it("rolls the in-memory registry back when a durable write is rejected", async () => {

--- a/packages/agent/src/services/push/push-token-registry.test.ts
+++ b/packages/agent/src/services/push/push-token-registry.test.ts
@@ -11,9 +11,12 @@
  * underfill, the persisted-record ceiling (exact boundary hydrates, one above
  * fails closed without destroying the durable row), one-time durable repair
  * that never rewrites a clean load, failed-write rollback (in-memory and durable
- * state unchanged, typed error, token redacted), and mutation-queue recovery
- * after a failed op. Backed by a Map-backed mock runtime cache — no real
- * storage.
+ * state unchanged, typed error, token redacted), mutation-queue recovery after a
+ * failed op, observable atomicity (list/count never see an uncommitted mutation
+ * while its write is pending and stay unchanged on rejection), and
+ * persistence-boundary validation of direct callers (unsupported platform and
+ * non-string token become the typed invalid error). Backed by a Map-backed mock
+ * runtime cache — no real storage.
  */
 import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import { createMockRuntime } from "@elizaos/core/testing";
@@ -469,6 +472,92 @@ describe("PushTokenRegistry", () => {
     expect(
       (cache.get(KEY) as PushTokenRecord[]).map((r) => r.token).sort(),
     ).toEqual(["a", "c"]);
+  });
+
+  it("never exposes an uncommitted mutation while its write is pending, and stays unchanged on rejection", async () => {
+    const cache = new Map<string, unknown>();
+    let gateNextWrite = false;
+    let rejectPendingWrite!: (reason: Error) => void;
+    let pendingWriteStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      pendingWriteStarted = resolve;
+    });
+    const runtime = createMockRuntime({
+      agentId: AGENT_ID,
+      getCache: async <T>(k: string): Promise<T | undefined> =>
+        cache.get(k) as T | undefined,
+      setCache: <T>(k: string, value: T): Promise<boolean> => {
+        if (!gateNextWrite) {
+          cache.set(k, value);
+          return Promise.resolve(true);
+        }
+        return new Promise<boolean>((_resolve, reject) => {
+          rejectPendingWrite = reject;
+          pendingWriteStarted();
+        });
+      },
+    });
+    const reg = new PushTokenRegistry(runtime);
+    await reg.register("ios", "keep");
+    expect(await reg.count()).toBe(1);
+
+    gateNextWrite = true;
+    const pending = reg.register("android", "pending-token");
+    await started;
+    // The candidate is staged but not published: readers observe only committed
+    // state while the durable write is in flight.
+    expect(await reg.count()).toBe(1);
+    expect((await reg.list()).map((r) => r.token)).toEqual(["keep"]);
+
+    rejectPendingWrite(new Error("cache offline"));
+    await pending.then(
+      () => {
+        throw new Error("expected the rejected write to throw");
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ElizaError);
+        expect((err as ElizaError).code).toBe(PUSH_TOKEN_PERSIST_FAILED_CODE);
+      },
+    );
+
+    // Observable registry and durable cache are unchanged after the rejection.
+    expect((await reg.list()).map((r) => r.token)).toEqual(["keep"]);
+    expect((cache.get(KEY) as PushTokenRecord[]).map((r) => r.token)).toEqual([
+      "keep",
+    ]);
+  });
+
+  it("rejects an unsupported platform from a direct caller with a typed error", async () => {
+    const untyped = registry as unknown as {
+      register(platform: unknown, token: string): Promise<void>;
+    };
+    await untyped.register("web", "tok-web").then(
+      () => {
+        throw new Error("expected unsupported platform to reject");
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ElizaError);
+        expect((err as ElizaError).code).toBe(PUSH_TOKEN_INVALID_CODE);
+      },
+    );
+    expect(await registry.count()).toBe(0);
+    expect(ctx.cache.get(KEY)).toBeUndefined();
+  });
+
+  it("turns a non-string runtime token into the typed invalid error, not a TypeError", async () => {
+    const untyped = registry as unknown as {
+      register(platform: string, token: unknown): Promise<void>;
+    };
+    await untyped.register("ios", 12345).then(
+      () => {
+        throw new Error("expected a non-string token to reject");
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ElizaError);
+        expect((err as ElizaError).code).toBe(PUSH_TOKEN_INVALID_CODE);
+      },
+    );
+    expect(await registry.count()).toBe(0);
   });
 
   it("rejects an empty token with a typed validation error", async () => {

--- a/packages/agent/src/services/push/push-token-registry.ts
+++ b/packages/agent/src/services/push/push-token-registry.ts
@@ -27,10 +27,12 @@
  *   4. When a bounded-but-dirty legacy dump is normalized, the repaired form is
  *      persisted once (guarded so a clean load never rewrites), so later
  *      restarts do not repeatedly re-scan and re-normalize the same dump.
- *   5. `register`/`unregister` are atomic w.r.t. `setCache`: a rejected durable
- *      write rolls the in-memory Map back to its pre-mutation snapshot, and the
- *      same-process mutation queue keeps processing later operations after a
- *      failure (no wedge).
+ *   5. `register`/`unregister` are observably atomic w.r.t. `setCache`: the
+ *      mutation is staged on a candidate Map that is published to `this.tokens`
+ *      only after the durable write succeeds, so `list`/`count` never observe an
+ *      uncommitted add/delete. A rejected write leaves the observable registry
+ *      unchanged, and the same-process mutation queue keeps processing later
+ *      operations after a failure (no wedge).
  *
  * Concurrency scope: mutations are serialized and failure-atomic WITHIN a
  * single process. Cross-process compare-and-swap is out of scope because the
@@ -103,10 +105,19 @@ function utf8ByteLength(value: string): number {
 
 /**
  * Validate and canonicalize a token for a mutation. Returns the trimmed token
- * or throws a typed {@link PUSH_TOKEN_INVALID_CODE} error. The error context
- * records only the byte length, never the token itself.
+ * or throws a typed {@link PUSH_TOKEN_INVALID_CODE} error. Accepts `unknown` so
+ * a non-string runtime value from untyped/plugin callers becomes the typed
+ * invalid error instead of leaking a raw `token.trim` TypeError. The error
+ * context records only the byte length or received type, never the token.
  */
-function assertValidToken(token: string): string {
+function assertValidToken(token: unknown): string {
+  if (typeof token !== "string") {
+    throw new ElizaError("[PushTokenRegistry] token must be a string", {
+      code: PUSH_TOKEN_INVALID_CODE,
+      context: { reason: "not_a_string", received: typeof token },
+      severity: "ephemeral",
+    });
+  }
   const trimmed = token.trim();
   if (!trimmed) {
     throw new ElizaError("[PushTokenRegistry] token is required", {
@@ -124,6 +135,23 @@ function assertValidToken(token: string): string {
     });
   }
   return trimmed;
+}
+
+/**
+ * Validate a platform at the persistence boundary. Direct `register()` callers
+ * in untyped/plugin code can pass an unsupported value (e.g. "web"); this
+ * rejects it with a typed {@link PUSH_TOKEN_INVALID_CODE} error before it
+ * reaches the durable cache, rather than persisting an arbitrary runtime string.
+ */
+function assertValidPlatform(platform: unknown): PushPlatform {
+  if (platform !== "ios" && platform !== "android") {
+    throw new ElizaError("[PushTokenRegistry] unsupported platform", {
+      code: PUSH_TOKEN_INVALID_CODE,
+      context: { reason: "unsupported_platform" },
+      severity: "ephemeral",
+    });
+  }
+  return platform;
 }
 
 export class PushTokenRegistry {
@@ -196,49 +224,56 @@ export class PushTokenRegistry {
   }
 
   /**
-   * Persist the current Map. On a durable-write rejection, roll the in-memory
-   * Map back to `snapshot` so the observable registry is unchanged, then rethrow
-   * a typed error. Callers run this inside {@link enqueueMutation}, so the next
-   * queued mutation still proceeds.
+   * Persist `candidate` and, only after the durable write succeeds, publish it
+   * as the observable registry. Because `this.tokens` is reassigned solely on
+   * success, `list`/`count` running while the write is pending observe the
+   * still-committed prior state; a rejected write leaves the observable registry
+   * unchanged and rethrows a typed error. Callers run this inside
+   * {@link enqueueMutation}, so the next queued mutation still proceeds.
    */
-  private async commit(snapshot: Map<string, PushTokenRecord>): Promise<void> {
+  private async commit(candidate: Map<string, PushTokenRecord>): Promise<void> {
     try {
-      await this.persist();
+      await this.runtime.setCache(this.cacheKey, [...candidate.values()]);
     } catch (error) {
-      this.tokens = snapshot;
       // error-policy:J2 context-adding rethrow — surface a typed persistence
-      // failure with a redacted count while preserving the underlying cause.
+      // failure with a redacted count while preserving the underlying cause. The
+      // candidate was never published, so the observable registry is unchanged.
       throw new ElizaError(
         "[PushTokenRegistry] failed to persist push-token mutation",
         {
           code: PUSH_TOKEN_PERSIST_FAILED_CODE,
           cause: error,
-          context: { tokenCount: snapshot.size },
+          context: { tokenCount: candidate.size },
           severity: "ephemeral",
         },
       );
     }
+    this.tokens = candidate;
   }
 
   /**
    * Register (upsert) a device token. Re-registering an existing token under a
    * new platform moves it to that platform and refreshes `createdAt`.
    *
-   * Atomic w.r.t. persistence: if the durable write rejects, the in-memory Map
-   * is restored to its pre-mutation snapshot and a typed error is thrown.
+   * Observably atomic w.r.t. persistence: the mutation is staged on a candidate
+   * Map and published only after the durable write succeeds, so a rejected write
+   * leaves the observable registry unchanged and a typed error is thrown.
+   * `platform` is validated at this boundary so a direct/untyped caller cannot
+   * persist an unsupported transport.
    */
   async register(platform: PushPlatform, token: string): Promise<void> {
+    const validPlatform = assertValidPlatform(platform);
     const trimmed = assertValidToken(token);
     await this.enqueueMutation(async () => {
       await this.hydrate();
-      const snapshot = new Map(this.tokens);
-      this.tokens.set(trimmed, {
+      const candidate = new Map(this.tokens);
+      candidate.set(trimmed, {
         token: trimmed,
-        platform,
+        platform: validPlatform,
         createdAt: Date.now(),
       });
-      evictOldestPushTokens(this.tokens);
-      await this.commit(snapshot);
+      evictOldestPushTokens(candidate);
+      await this.commit(candidate);
     });
   }
 
@@ -253,9 +288,9 @@ export class PushTokenRegistry {
       if (!this.tokens.has(trimmed)) {
         return false;
       }
-      const snapshot = new Map(this.tokens);
-      this.tokens.delete(trimmed);
-      await this.commit(snapshot);
+      const candidate = new Map(this.tokens);
+      candidate.delete(trimmed);
+      await this.commit(candidate);
       return true;
     });
   }

--- a/packages/agent/src/services/push/push-token-registry.ts
+++ b/packages/agent/src/services/push/push-token-registry.ts
@@ -30,9 +30,11 @@
  *   5. `register`/`unregister` are observably atomic w.r.t. `setCache`: the
  *      mutation is staged on a candidate Map that is published to `this.tokens`
  *      only after the durable write succeeds, so `list`/`count` never observe an
- *      uncommitted add/delete. A rejected write leaves the observable registry
- *      unchanged, and the same-process mutation queue keeps processing later
- *      operations after a failure (no wedge).
+ *      uncommitted add/delete. A write that rejects OR resolves a non-`true`
+ *      value (`setCache` returns `Promise<boolean>`; adapters resolve `false`
+ *      when the row did not land) is treated as a failure that leaves the
+ *      observable registry unchanged, and the same-process mutation queue keeps
+ *      processing later operations after a failure (no wedge).
  *
  * Concurrency scope: mutations are serialized and failure-atomic WITHIN a
  * single process. Cross-process compare-and-swap is out of scope because the
@@ -224,16 +226,20 @@ export class PushTokenRegistry {
   }
 
   /**
-   * Persist `candidate` and, only after the durable write succeeds, publish it
-   * as the observable registry. Because `this.tokens` is reassigned solely on
-   * success, `list`/`count` running while the write is pending observe the
-   * still-committed prior state; a rejected write leaves the observable registry
-   * unchanged and rethrows a typed error. Callers run this inside
-   * {@link enqueueMutation}, so the next queued mutation still proceeds.
+   * Persist `candidate` and, only after the durable write reports success,
+   * publish it as the observable registry. Because `this.tokens` is reassigned
+   * solely on a `true` result, `list`/`count` running while the write is pending
+   * observe the still-committed prior state; a write that rejects OR resolves a
+   * non-`true` value leaves the observable registry unchanged and throws a typed
+   * error. Callers run this inside {@link enqueueMutation}, so the next queued
+   * mutation still proceeds.
    */
   private async commit(candidate: Map<string, PushTokenRecord>): Promise<void> {
+    let persisted: boolean;
     try {
-      await this.runtime.setCache(this.cacheKey, [...candidate.values()]);
+      persisted = await this.runtime.setCache(this.cacheKey, [
+        ...candidate.values(),
+      ]);
     } catch (error) {
       // error-policy:J2 context-adding rethrow — surface a typed persistence
       // failure with a redacted count while preserving the underlying cause. The
@@ -243,6 +249,20 @@ export class PushTokenRegistry {
         {
           code: PUSH_TOKEN_PERSIST_FAILED_CODE,
           cause: error,
+          context: { tokenCount: candidate.size },
+          severity: "ephemeral",
+        },
+      );
+    }
+    if (persisted !== true) {
+      // error-policy:J2 context-adding rethrow — `setCache` resolving a
+      // non-`true` value is a durable-write failure (the SQL adapter propagates
+      // `false` when the underlying write did not land). The candidate was never
+      // published, so the observable registry stays on the committed state.
+      throw new ElizaError(
+        "[PushTokenRegistry] durable cache rejected the push-token mutation",
+        {
+          code: PUSH_TOKEN_PERSIST_FAILED_CODE,
           context: { tokenCount: candidate.size },
           severity: "ephemeral",
         },

--- a/packages/agent/src/services/push/push-token-registry.ts
+++ b/packages/agent/src/services/push/push-token-registry.ts
@@ -10,9 +10,35 @@
  * `runtime.setCache`) under a single stable key, mirroring the persistence
  * pattern in `@elizaos/core`'s `NotificationService`. A cold/headless runtime
  * with no cache adapter starts empty and degrades to in-memory only.
+ *
+ * Boundary invariants (a cache row is untrusted, possibly-hostile input):
+ *   1. Hydration bounds work BEFORE traversing. A stored array larger than
+ *      {@link MAX_PERSISTED_PUSH_TOKENS} is rejected without filter/copy/sort,
+ *      so a hostile/oversized dump cannot force unbounded validation work.
+ *   2. Every hydrated record is validated at the persistence boundary
+ *      ({@link parsePushTokenRecord}): trimmed non-empty token, token within an
+ *      explicit UTF-8 BYTE limit, supported platform, and a finite,
+ *      non-negative, safe-integer timestamp. The same validator gates
+ *      `register`/`unregister`, so byte/platform/timestamp checks are identical
+ *      everywhere.
+ *   3. Dedup happens BEFORE the live cap: the newest valid record per token is
+ *      kept, then the {@link MAX_PUSH_TOKENS_PER_AGENT} cap is applied, so
+ *      duplicate-heavy data cannot underfill the registry.
+ *   4. When a bounded-but-dirty legacy dump is normalized, the repaired form is
+ *      persisted once (guarded so a clean load never rewrites), so later
+ *      restarts do not repeatedly re-scan and re-normalize the same dump.
+ *   5. `register`/`unregister` are atomic w.r.t. `setCache`: a rejected durable
+ *      write rolls the in-memory Map back to its pre-mutation snapshot, and the
+ *      same-process mutation queue keeps processing later operations after a
+ *      failure (no wedge).
+ *
+ * Concurrency scope: mutations are serialized and failure-atomic WITHIN a
+ * single process. Cross-process compare-and-swap is out of scope because the
+ * runtime cache contract exposes no transactional CAS primitive; do not read
+ * multi-process atomicity into this class.
  */
 
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime, logger } from "@elizaos/core";
 
 /** Mobile push transport a token belongs to. */
 export type PushPlatform = "ios" | "android";
@@ -31,18 +57,74 @@ export interface PushTokenRecord {
 const cacheKeyFor = (agentId: string): string => `push-tokens:${agentId}`;
 
 /**
- * Hard cap on distinct tokens stored per agent. A device re-register is an
- * upsert; unique tokens are unbounded on origin and `persist()` writes the
- * entire Map to the durable runtime cache. Oldest `createdAt` is evicted first.
+ * Hard cap on distinct tokens stored per agent (the live cap). A device
+ * re-register is an upsert; unique tokens are unbounded on origin and
+ * `persist()` writes the entire Map to the durable runtime cache. Oldest
+ * `createdAt` is evicted first.
  */
 export const MAX_PUSH_TOKENS_PER_AGENT = 64;
 
 /**
- * Hard cap on a single token string. The HTTP body reader already stops at
- * 8 KiB; this keeps a direct `register()` caller from planting a huge Map key
- * and a huge cache row.
+ * Hard cap on a single token, measured in UTF-8 BYTES (not char length, so a
+ * multi-byte token cannot smuggle past a char check). The HTTP body reader
+ * already stops at 8 KiB; this keeps a direct `register()` caller from planting
+ * a huge Map key and a huge cache row.
  */
-export const MAX_PUSH_TOKEN_LENGTH = 4096;
+export const MAX_PUSH_TOKEN_BYTES = 4096;
+
+/**
+ * Persisted-record ceiling: the largest stored array the registry will even
+ * traverse. A cache row longer than this (hostile or corrupt) is rejected
+ * fail-closed WITHOUT filtering/copying/sorting it, bounding worst-case
+ * hydration work to a single `Array.isArray`/`length` check. The ceiling sits
+ * far above any legitimate dump (16x the live cap) so real dirty-but-bounded
+ * legacy data is repaired rather than discarded.
+ */
+export const MAX_PERSISTED_PUSH_TOKENS = MAX_PUSH_TOKENS_PER_AGENT * 16;
+
+/** Stable `ElizaError.code` for a rejected token (empty or over the byte cap). */
+export const PUSH_TOKEN_INVALID_CODE = "PUSH_TOKEN_INVALID";
+/** Stable `ElizaError.code` for a durable-write failure during a mutation. */
+export const PUSH_TOKEN_PERSIST_FAILED_CODE = "PUSH_TOKEN_PERSIST_FAILED";
+
+/**
+ * True when `error` is a token-validation failure the caller should translate
+ * to a client error (HTTP 400), as opposed to a genuine persistence failure
+ * (HTTP 500). Never inspects or exposes the offending token.
+ */
+export function isPushTokenValidationError(error: unknown): boolean {
+  return error instanceof ElizaError && error.code === PUSH_TOKEN_INVALID_CODE;
+}
+
+/** UTF-8 byte length of `value` without allocating an intermediate Buffer view. */
+function utf8ByteLength(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+/**
+ * Validate and canonicalize a token for a mutation. Returns the trimmed token
+ * or throws a typed {@link PUSH_TOKEN_INVALID_CODE} error. The error context
+ * records only the byte length, never the token itself.
+ */
+function assertValidToken(token: string): string {
+  const trimmed = token.trim();
+  if (!trimmed) {
+    throw new ElizaError("[PushTokenRegistry] token is required", {
+      code: PUSH_TOKEN_INVALID_CODE,
+      context: { reason: "empty" },
+      severity: "ephemeral",
+    });
+  }
+  const byteLength = utf8ByteLength(trimmed);
+  if (byteLength > MAX_PUSH_TOKEN_BYTES) {
+    throw new ElizaError("[PushTokenRegistry] token exceeds the byte cap", {
+      code: PUSH_TOKEN_INVALID_CODE,
+      context: { reason: "too_large", byteLength, limit: MAX_PUSH_TOKEN_BYTES },
+      severity: "ephemeral",
+    });
+  }
+  return trimmed;
+}
 
 export class PushTokenRegistry {
   private tokens = new Map<string, PushTokenRecord>();
@@ -74,15 +156,28 @@ export class PushTokenRegistry {
   }
 
   private async loadPersistedTokens(): Promise<void> {
-    const stored = await this.runtime.getCache<PushTokenRecord[]>(
-      this.cacheKey,
-    );
-    if (Array.isArray(stored)) {
-      this.tokens = new Map(
-        newestPushTokenRecords(stored).map((record) => [record.token, record]),
-      );
-    }
+    const stored = await this.runtime.getCache<unknown>(this.cacheKey);
+    const { records, repaired } = normalizePersistedTokens(stored);
+    this.tokens = new Map(records.map((record) => [record.token, record]));
     this.hydrated = true;
+    if (repaired) {
+      // Durable one-time repair: rewrite the normalized (validated, deduped,
+      // capped) form so later restarts do not re-scan the same dirty dump.
+      // Best-effort: a failed repair write only means we re-normalize next
+      // start; it must not fail the read path.
+      try {
+        await this.persist();
+      } catch (error) {
+        // error-policy:J7 diagnostics must not kill the loop — a failed
+        // one-time repair write degrades to re-scanning on the next start.
+        this.runtime.reportError("push.registry.repair", error, {
+          tokenCount: this.tokens.size,
+        });
+        logger.warn(
+          "[PushTokenRegistry] durable repair write failed; will re-normalize on next hydrate",
+        );
+      }
+    }
   }
 
   private async persist(): Promise<void> {
@@ -101,38 +196,67 @@ export class PushTokenRegistry {
   }
 
   /**
+   * Persist the current Map. On a durable-write rejection, roll the in-memory
+   * Map back to `snapshot` so the observable registry is unchanged, then rethrow
+   * a typed error. Callers run this inside {@link enqueueMutation}, so the next
+   * queued mutation still proceeds.
+   */
+  private async commit(snapshot: Map<string, PushTokenRecord>): Promise<void> {
+    try {
+      await this.persist();
+    } catch (error) {
+      this.tokens = snapshot;
+      // error-policy:J2 context-adding rethrow — surface a typed persistence
+      // failure with a redacted count while preserving the underlying cause.
+      throw new ElizaError(
+        "[PushTokenRegistry] failed to persist push-token mutation",
+        {
+          code: PUSH_TOKEN_PERSIST_FAILED_CODE,
+          cause: error,
+          context: { tokenCount: snapshot.size },
+          severity: "ephemeral",
+        },
+      );
+    }
+  }
+
+  /**
    * Register (upsert) a device token. Re-registering an existing token under a
    * new platform moves it to that platform and refreshes `createdAt`.
+   *
+   * Atomic w.r.t. persistence: if the durable write rejects, the in-memory Map
+   * is restored to its pre-mutation snapshot and a typed error is thrown.
    */
   async register(platform: PushPlatform, token: string): Promise<void> {
-    const trimmed = token.trim();
-    if (!trimmed) {
-      throw new Error("[PushTokenRegistry] token is required");
-    }
-    if (trimmed.length > MAX_PUSH_TOKEN_LENGTH) {
-      throw new Error("[PushTokenRegistry] token exceeds the length cap");
-    }
+    const trimmed = assertValidToken(token);
     await this.enqueueMutation(async () => {
       await this.hydrate();
+      const snapshot = new Map(this.tokens);
       this.tokens.set(trimmed, {
         token: trimmed,
         platform,
         createdAt: Date.now(),
       });
       evictOldestPushTokens(this.tokens);
-      await this.persist();
+      await this.commit(snapshot);
     });
   }
 
-  /** Unregister a device token. Returns true if it existed. */
+  /**
+   * Unregister a device token. Returns true if it existed. Applies the same
+   * token validation as {@link register}, and is atomic w.r.t. persistence.
+   */
   async unregister(token: string): Promise<boolean> {
+    const trimmed = assertValidToken(token);
     return this.enqueueMutation(async () => {
       await this.hydrate();
-      const removed = this.tokens.delete(token.trim());
-      if (removed) {
-        await this.persist();
+      if (!this.tokens.has(trimmed)) {
+        return false;
       }
-      return removed;
+      const snapshot = new Map(this.tokens);
+      this.tokens.delete(trimmed);
+      await this.commit(snapshot);
+      return true;
     });
   }
 
@@ -155,15 +279,82 @@ export class PushTokenRegistry {
   }
 }
 
-function newestPushTokenRecords(stored: unknown[]): PushTokenRecord[] {
-  const valid = stored.filter(isPushTokenRecord);
-  if (valid.length <= MAX_PUSH_TOKENS_PER_AGENT) {
-    return valid;
+/**
+ * Normalize a raw cache value into the registry's canonical records and report
+ * whether the stored form differed (so the caller can durably repair once).
+ *
+ * Order matters and is load-bearing:
+ *   1. Reject non-arrays and over-ceiling arrays WITHOUT traversal.
+ *   2. Validate each record and keep the NEWEST per token (dedup-before-cap).
+ *   3. Apply the live cap to the deduped set.
+ */
+function normalizePersistedTokens(stored: unknown): {
+  records: PushTokenRecord[];
+  repaired: boolean;
+} {
+  if (!Array.isArray(stored)) {
+    return { records: [], repaired: false };
   }
-  return valid
-    .slice()
-    .sort((left, right) => right.createdAt - left.createdAt)
-    .slice(0, MAX_PUSH_TOKENS_PER_AGENT);
+  // Bound BEFORE any filter/copy/sort. A hostile/corrupt oversized dump fails
+  // closed to empty; we deliberately do NOT rewrite it here (a later mutation
+  // overwrites it with a bounded array), so a transient never destroys a large
+  // legitimate row.
+  if (stored.length > MAX_PERSISTED_PUSH_TOKENS) {
+    logger.warn(
+      `[PushTokenRegistry] persisted token array exceeds ceiling (${stored.length} > ${MAX_PERSISTED_PUSH_TOKENS}); failing closed`,
+    );
+    return { records: [], repaired: false };
+  }
+
+  const newestByToken = new Map<string, PushTokenRecord>();
+  for (const value of stored) {
+    const record = parsePushTokenRecord(value);
+    if (!record) continue;
+    const existing = newestByToken.get(record.token);
+    if (!existing || record.createdAt > existing.createdAt) {
+      newestByToken.set(record.token, record);
+    }
+  }
+
+  let unique = [...newestByToken.values()];
+  if (unique.length > MAX_PUSH_TOKENS_PER_AGENT) {
+    unique = unique
+      .sort((left, right) => right.createdAt - left.createdAt)
+      .slice(0, MAX_PUSH_TOKENS_PER_AGENT);
+  }
+
+  return {
+    records: unique,
+    repaired: !isCanonicalPersistedArray(stored, unique),
+  };
+}
+
+/**
+ * True when `stored` is already exactly the canonical persisted form of
+ * `canonical` (same length, same order, and each element is a plain object with
+ * exactly the three canonical fields equal to the normalized values). Used to
+ * suppress a repair write on an already-clean load.
+ */
+function isCanonicalPersistedArray(
+  stored: unknown[],
+  canonical: PushTokenRecord[],
+): boolean {
+  if (stored.length !== canonical.length) return false;
+  for (let i = 0; i < stored.length; i++) {
+    const raw = stored[i];
+    if (typeof raw !== "object" || raw === null) return false;
+    const record = raw as Record<string, unknown>;
+    if (Object.keys(record).length !== 3) return false;
+    const expected = canonical[i];
+    if (
+      record.token !== expected.token ||
+      record.platform !== expected.platform ||
+      record.createdAt !== expected.createdAt
+    ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function evictOldestPushTokens(tokens: Map<string, PushTokenRecord>): void {
@@ -183,13 +374,32 @@ function evictOldestPushTokens(tokens: Map<string, PushTokenRecord>): void {
   }
 }
 
-function isPushTokenRecord(value: unknown): value is PushTokenRecord {
-  if (typeof value !== "object" || value === null) return false;
+/**
+ * Validate an untrusted persisted value and return a canonical record, or null
+ * if it fails any boundary check. The returned record is a fresh plain object
+ * with a trimmed token so the durable repair writes a clean shape (extra fields
+ * stripped). Mirrors the mutation-path checks in {@link assertValidToken} plus
+ * the platform and timestamp constraints.
+ */
+function parsePushTokenRecord(value: unknown): PushTokenRecord | null {
+  if (typeof value !== "object" || value === null) return null;
   const record = value as Record<string, unknown>;
-  return (
-    typeof record.token === "string" &&
-    record.token.length > 0 &&
-    (record.platform === "ios" || record.platform === "android") &&
-    typeof record.createdAt === "number"
-  );
+
+  if (typeof record.token !== "string") return null;
+  const token = record.token.trim();
+  if (!token) return null;
+  if (utf8ByteLength(token) > MAX_PUSH_TOKEN_BYTES) return null;
+
+  if (record.platform !== "ios" && record.platform !== "android") return null;
+
+  const createdAt = record.createdAt;
+  if (
+    typeof createdAt !== "number" ||
+    !Number.isSafeInteger(createdAt) ||
+    createdAt < 0
+  ) {
+    return null;
+  }
+
+  return { token, platform: record.platform, createdAt };
 }

--- a/packages/agent/src/services/push/push-token-registry.ts
+++ b/packages/agent/src/services/push/push-token-registry.ts
@@ -26,7 +26,10 @@
  *      duplicate-heavy data cannot underfill the registry.
  *   4. When a bounded-but-dirty legacy dump is normalized, the repaired form is
  *      persisted once (guarded so a clean load never rewrites), so later
- *      restarts do not repeatedly re-scan and re-normalize the same dump.
+ *      restarts do not repeatedly re-scan and re-normalize the same dump. The
+ *      repair write must resolve exactly `true`; a rejected OR resolved-`false`
+ *      write is reported (best-effort, never failing the read) and the dirty
+ *      row is left intact so a later restart retries the repair.
  *   5. `register`/`unregister` are observably atomic w.r.t. `setCache`: the
  *      mutation is staged on a candidate Map that is published to `this.tokens`
  *      only after the durable write succeeds, so `list`/`count` never observe an
@@ -210,8 +213,28 @@ export class PushTokenRegistry {
     }
   }
 
+  /**
+   * Durably rewrite the current in-memory tokens (repair path only). Requires
+   * `setCache` to resolve exactly `true`; a rejected write OR a resolved
+   * non-`true` value (an adapter reports `false` when the row did not land) is a
+   * failed durable repair and throws {@link PUSH_TOKEN_PERSIST_FAILED_CODE}, so
+   * the caller degrades to re-normalizing on the next start instead of treating
+   * an unpersisted repair as durable.
+   */
   private async persist(): Promise<void> {
-    await this.runtime.setCache(this.cacheKey, [...this.tokens.values()]);
+    const persisted = await this.runtime.setCache(this.cacheKey, [
+      ...this.tokens.values(),
+    ]);
+    if (persisted !== true) {
+      throw new ElizaError(
+        "[PushTokenRegistry] durable cache rejected the push-token repair write",
+        {
+          code: PUSH_TOKEN_PERSIST_FAILED_CODE,
+          context: { tokenCount: this.tokens.size },
+          severity: "ephemeral",
+        },
+      );
+    }
   }
 
   private enqueueMutation<T>(mutation: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
# Relates to

Closes #23224 — production follow-up to merged #23015 ("cap per-agent push-token registry before cache overflow"). The maintainer filed #23224 and explicitly delegated implementation to an eligible contributor; this PR is that follow-up and is not authored by the delegator.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`origin/develop` head `e927af91ac` at push time).
- [x] `bun install` and focused checks were run after sync; the repo-wide `bun run verify` blocker is recorded under **Known gaps / failures** (unbuilt sibling-workspace type resolution, pre-existing and independent of this diff).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@870fdcee673ac659643aba52d15b52013e6903da:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`e927af91ac`); zero conflicts.
- [x] Focused package checks pass post-sync; `bun run verify` blocker documented under **Known gaps / failures**.

# Risks

Low. Scope is confined to `PushTokenRegistry` and its two HTTP routes. Behavior changes are strictly hardening: the durable cache format is unchanged (`{ token, platform, createdAt }[]`), and hydration now normalizes legacy/dirty rows into that same shape. The only externally-visible surface change is the exported constant rename `MAX_PUSH_TOKEN_LENGTH` → `MAX_PUSH_TOKEN_BYTES` (both were internal to the agent package; only these files imported it). New validation can now reject previously-accepted malformed rows (that is the intent) and returns HTTP 400 instead of silently upserting.

# Background

## What does this PR do?

PR #23015 added a 64-record in-memory cap, but the merged implementation crossed resource and consistency boundaries *before* that cap took effect. This PR closes those gaps:

1. **Bound hydration before work.** `MAX_PERSISTED_PUSH_TOKENS` (16× the live cap = 1024) is the largest stored array the registry will traverse. A cache row longer than that is rejected fail-closed to empty **without** filter/copy/sort — worst-case hydration is a single `Array.isArray`/`length` check. Fail-closed does **not** destroy the durable row (a later mutation overwrites it), so a transient never nukes a large legitimate dump.
2. **Validate at the persistence boundary.** One pure validator (`parsePushTokenRecord` / `assertValidToken`) enforces: trimmed non-empty token, token within an explicit **UTF-8 byte** cap (`MAX_PUSH_TOKEN_BYTES = 4096`, computed with `Buffer.byteLength(token, "utf8")`, not char length), supported platform (`ios`|`android`), and a finite, non-negative, safe-integer timestamp. The same checks gate hydrate and `register`/`unregister`.
3. **Dedup-before-cap.** Keep the newest valid record per token, **then** apply the 64 live cap. Duplicate-heavy data can no longer underfill the registry (see domain repro below).
4. **Durable repair.** When a bounded-but-dirty legacy dump is normalized, the repaired form is persisted **once** (guarded by a canonical-form check so a clean load never rewrites). Best-effort: a failed repair write only re-normalizes on the next start and is reported via `runtime.reportError`, never failing the read path.
5. **Transactional mutations.** `register`/`unregister` snapshot the `Map`, mutate, then `commit()`. On a rejected `setCache` the snapshot is restored (observable registry unchanged) and a typed `ElizaError` (`PUSH_TOKEN_PERSIST_FAILED`) is thrown. The same-process mutation queue keeps processing later ops after a failure (no wedge).
6. **Uniform byte bound + HTTP mapping.** The byte cap now applies to direct callers **and both DELETE route shapes** (`{ token }` body and legacy `/:token`). Typed validation failures (`PUSH_TOKEN_INVALID`) map to **400** via `isPushTokenValidationError`; genuine persistence failures propagate to the server's **500** boundary and are never swallowed into a fake success.
7. **ElizaError + redaction.** New domain failures use `ElizaError` codes + context. Tokens never appear in any error message or log (only byte length / counts).

**Concurrency scope (per acceptance criterion 8):** cross-process compare-and-swap is out of scope — the runtime cache contract exposes no transactional CAS primitive. Atomicity here is guaranteed **within a single process** only. This is stated in the class header and in `commit()`.

## What kind of change is this?

Bug fix / hardening (non-breaking except the internal `MAX_PUSH_TOKEN_LENGTH` → `MAX_PUSH_TOKEN_BYTES` constant rename).

# Documentation changes needed?

My changes do not require project-docs changes. The behavior contract is documented in the class header of `push-token-registry.ts` and in the two test-file headers.

# Testing

## Where should a reviewer start?

- `packages/agent/src/services/push/push-token-registry.ts` — registry hardening.
- `packages/agent/src/api/push-token-routes.ts` — uniform byte bound + 400/500 mapping across both DELETE shapes.
- `packages/agent/src/services/push/push-token-registry.test.ts` and `push-token-routes.test.ts` — 45 focused tests (30 registry + 15 routes), including the adversarial cases required by AC #9.

## Detailed testing steps

```bash
bunx vitest run --config packages/agent/vitest.config.ts \
  packages/agent/src/services/push/push-token-registry.test.ts \
  packages/agent/src/api/push-token-routes.test.ts
```

Adversarial coverage added: exact boundary sizes (persisted ceiling exactly-at vs one-above), multi-byte UTF-8 tokens at/over the byte bound, malformed timestamps (NaN / Infinity / negative / fractional / unsafe-integer / non-number), duplicates (newest wins, no underfill), oversized persisted arrays (fail-closed without destroying the row), one-time durable repair (persist called exactly once; a clean reload never rewrites), failed-write rollback (in-memory **and** durable state unchanged, typed error, token redacted), mutation-queue recovery after a failed op, observable atomicity (list/count never see an uncommitted mutation while its durable write is pending and stay unchanged on rejection), direct-caller persistence-boundary validation (unsupported platform such as `web`, and a non-string runtime token, both become the typed invalid error rather than persisting junk or leaking a `token.trim` TypeError), and both HTTP DELETE shapes (400 vs 500 mapping).

# Evidence Gate

<!-- evidence-head:80cbce5638376095b3453e160e8ef743cfc939c4 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - server/runtime change with no rendered UI surface (registry + HTTP JSON routes only).`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - server/runtime change with no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no UI/user flow; the changed contract is exercised by the focused test run and domain repro below.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - full focused test log (45 passed: 30 registry + 15 routes) + biome/tsc output are pasted inline under "Backend + frontend logs"; immutable release-asset upload is unavailable from this fork account (no write access to elizaOS/eliza releases).
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend surface in this change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model behavior changes; this is a persistence-boundary + HTTP-mapping fix.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the dedup-before-cap failing->passing reproduction output is pasted inline under "Backend + frontend logs"; release-asset upload unavailable from this fork account.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior changes.`

## Backend + frontend logs

**Domain reproduction — dedup-before-cap (failing pre-fix → passing post-fix).** The pre-fix algorithm (merged #23015) capped the raw array then deduped, so 64 duplicates of one "hot" token consumed the cap and collapsed to a single record, dropping 40 valid unique tokens. Dedup-before-cap retains all 41.

<details><summary>node repro output</summary>

```
unique tokens present in data: 41 (expected retained: 41)
PRE-FIX  registry size: 1 <- UNDERFILLED (bug: 64 hot dups eat the cap, collapse to 1)
POST-FIX registry size: 41 <- correct (1 hot + 40 unique)
```
</details>

**Focused verbose test run (45 passed).**

<details><summary>vitest verbose — registry (30) + routes (15)</summary>

```
✓ PushTokenRegistry > registers, lists, and counts a token
✓ PushTokenRegistry > upserts the same token idempotently (no duplicate)
✓ PushTokenRegistry > moves a token to a new platform on re-registration
✓ PushTokenRegistry > trims whitespace and rejects an empty token
✓ PushTokenRegistry > unregisters and reports existence
✓ PushTokenRegistry > filters by platform
✓ PushTokenRegistry > persists to the runtime cache and rehydrates a fresh registry
✓ PushTokenRegistry > drops malformed records on hydrate
✓ PushTokenRegistry > preserves registrations made while first-use hydration is in flight
✓ PushTokenRegistry > serializes concurrent mutations so persisted tokens cannot regress
✓ PushTokenRegistry > evicts the oldest unique token once the per-agent cap is exceeded
✓ PushTokenRegistry > does not grow the registry when an existing token is re-registered at the cap
✓ PushTokenRegistry > hydrates only the newest capped records from an oversized cache dump
✓ PushTokenRegistry > rejects a token longer than the byte cap
✓ PushTokenRegistry > bounds tokens by UTF-8 byte length, not char length
✓ PushTokenRegistry > rejects hydrated records with malformed timestamps
✓ PushTokenRegistry > drops hydrated records whose token exceeds the UTF-8 byte cap
✓ PushTokenRegistry > dedups before capping so duplicate-heavy data does not underfill
✓ PushTokenRegistry > hydrates exactly at the persisted-record ceiling but fails closed above it
✓ PushTokenRegistry > persists the repaired form exactly once and never rewrites a clean load
✓ PushTokenRegistry > leaves the dirty row intact and reports when a repair write resolves false, then a later true repair stops rewriting
✓ PushTokenRegistry > rolls the in-memory registry back when a durable write is rejected
✓ PushTokenRegistry > treats a resolved false setCache as a persistence failure on register
✓ PushTokenRegistry > treats a resolved false setCache as a persistence failure on unregister
✓ PushTokenRegistry > never publishes a deferred false setCache while its write is pending
✓ PushTokenRegistry > keeps processing later mutations after a failed one (no queue wedge)
✓ PushTokenRegistry > never exposes an uncommitted mutation while its write is pending, and stays unchanged on rejection
✓ PushTokenRegistry > rejects an unsupported platform from a direct caller with a typed error
✓ PushTokenRegistry > turns a non-string runtime token into the typed invalid error, not a TypeError
✓ PushTokenRegistry > rejects an empty token with a typed validation error
✓ handlePushTokenRoute > ignores non push-token paths
✓ handlePushTokenRoute > POST registers a token (201) and persists it
✓ handlePushTokenRoute > POST rejects an invalid platform with 400
✓ handlePushTokenRoute > POST rejects a missing token with 400
✓ handlePushTokenRoute > DELETE accepts a body token without exposing it in the request URL
✓ handlePushTokenRoute > GET returns count + per-platform breakdown
✓ handlePushTokenRoute > DELETE :token unregisters and reports existence
✓ handlePushTokenRoute > DELETE :token returns ok:false for an unknown token
✓ handlePushTokenRoute > returns 503 when the push service is not registered
✓ handlePushTokenRoute > DELETE :token returns 400 on malformed percent-encoded token
✓ handlePushTokenRoute > POST over the UTF-8 byte cap is rejected 400 by registry validation
✓ handlePushTokenRoute > DELETE :token over the UTF-8 byte cap is rejected 400 without persisting
✓ handlePushTokenRoute > POST maps typed validation to 400 and persistence failure to 500
✓ handlePushTokenRoute > DELETE maps validation to 400 and persistence to 500 for BOTH route shapes
✓ handlePushTokenRoute > DELETE :token decodes valid percent-encoded token before unregister

 Test Files  2 passed (2)
      Tests  45 passed (45)
```
</details>

**Lint + typecheck.**

<details><summary>biome + tsc</summary>

```
=== biome check (4 changed files) ===
Checked 4 files in 82ms. No fixes applied.

=== agent tsc ===
push-token errors: 0
baseline errors (no diff): 25 | with diff: 25   (the 25 are pre-existing unbuilt-sibling-workspace module resolutions, identical with/without this diff)
```
</details>

**Build.**

<details><summary>bun run --cwd packages/agent build:dist</summary>

```
[rewrite-dist-relative-imports] rewrote 199 file(s)
EXIT 0
```
</details>

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface.`

### After

`N/A - no UI surface.`

### Walkthrough video

`N/A - no UI surface.`

## Audio / voice walkthrough

`N/A - no audio/voice surface.`

## Known gaps / failures

- Repo-wide `bun run verify` / full `tsc` reports 25 errors from unbuilt sibling workspaces (`@elizaos/cloud-routing`, `@elizaos/plugin-wallet`, `@elizaos/plugin-capacitor-bridge` test shims, optional plugin generated imports). These are a build-order artifact of this checkout, **identical with and without this diff** (verified by stashing the change: 25 → 25), and none reference the four files this PR touches (`push-token` error count: 0). Not a blocker for this change.
- `bun install` required a local `--minimum-release-age` override for an unrelated recently-published `viem` transitive; `bun.lock` was reverted and is **not** part of this PR's diff.

AI provider/model: anthropic / claude-opus-4-8
Client / agent tooling: pi-coding-agent
Contribution skill revision: elizaOS/eliza@870fdcee673ac659643aba52d15b52013e6903da:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-swarm]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent","skill_revision":"elizaOS/eliza@870fdcee673ac659643aba52d15b52013e6903da:packages/skills/skills/contribute-to-eliza"} -->





