### PR TITLE
fix(elizacloud): fail closed on circular or invalid rpc gateway metadata

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/unit/cloud-managed-gateway-relay-metadata.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/cloud-managed-gateway-relay-metadata.test.ts
@@ -45,4 +45,20 @@ describe("toJsonMetadataRecord", () => {
 
     expect(toJsonMetadataRecord(throwingObj)).toBeUndefined();
   });
+
+  it("fails closed to undefined on non-serializable values such as BigInt", () => {
+    expect(toJsonMetadataRecord({ n: 1n })).toBeUndefined();
+  });
+
+  it("fails closed to undefined when toJSON replaces the record root", () => {
+    expect(toJsonMetadataRecord({ toJSON: () => 7 })).toBeUndefined();
+    expect(toJsonMetadataRecord({ toJSON: () => null })).toBeUndefined();
+    expect(toJsonMetadataRecord({ toJSON: () => [1, 2] })).toBeUndefined();
+    expect(toJsonMetadataRecord({ toJSON: () => "scalar" })).toBeUndefined();
+    expect(toJsonMetadataRecord({ toJSON: () => undefined })).toBeUndefined();
+  });
+
+  it("accepts toJSON replacements that remain plain records", () => {
+    expect(toJsonMetadataRecord({ toJSON: () => ({ ok: true }) })).toEqual({ ok: true });
+  });
 });

--- a/plugins/plugin-elizacloud/__tests__/unit/cloud-managed-gateway-relay-metadata.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/cloud-managed-gateway-relay-metadata.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Exercises metadata sanitization for cloud managed gateway relay RPC requests,
+ * proving circular, throwing, or invalid JSON records safely fail closed to undefined.
+ */
+import { describe, expect, it } from "vitest";
+import { toJsonMetadataRecord } from "../../src/services/cloud-managed-gateway-relay";
+
+describe("toJsonMetadataRecord", () => {
+  it("returns undefined for non-record inputs", () => {
+    expect(toJsonMetadataRecord(null)).toBeUndefined();
+    expect(toJsonMetadataRecord(undefined)).toBeUndefined();
+    expect(toJsonMetadataRecord("string")).toBeUndefined();
+    expect(toJsonMetadataRecord(123)).toBeUndefined();
+    expect(toJsonMetadataRecord(true)).toBeUndefined();
+    expect(toJsonMetadataRecord([1, 2, 3])).toBeUndefined();
+  });
+
+  it("safely serializes valid metadata records", () => {
+    const valid = {
+      channelId: "12345",
+      isDirect: true,
+      count: 42,
+      tags: ["alpha", "beta"],
+      nested: { key: "value" },
+    };
+
+    expect(toJsonMetadataRecord(valid)).toEqual(valid);
+  });
+
+  it("fails closed to undefined on circular structures without throwing", () => {
+    const circular: Record<string, unknown> = {
+      name: "alice",
+    };
+    circular.self = circular;
+
+    expect(toJsonMetadataRecord(circular)).toBeUndefined();
+  });
+
+  it("fails closed to undefined on objects with throwing getters", () => {
+    const throwingObj = {
+      get badProperty() {
+        throw new Error("trap");
+      },
+    };
+
+    expect(toJsonMetadataRecord(throwingObj)).toBeUndefined();
+  });
+});

--- a/plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts
@@ -116,12 +116,19 @@ function toJsonRecord(value: unknown): Record<string, unknown> | undefined {
   return isRecord(value) ? value : undefined;
 }
 
-function toJsonMetadataRecord(value: unknown): Record<string, JsonValue> | undefined {
+export function toJsonMetadataRecord(
+  value: unknown,
+): Record<string, JsonValue> | undefined {
   if (!isRecord(value)) {
     return undefined;
   }
 
-  return JSON.parse(JSON.stringify(value)) as Record<string, JsonValue>;
+  try {
+    return JSON.parse(JSON.stringify(value)) as Record<string, JsonValue>;
+  } catch {
+    // error-policy:J3 untrusted metadata may contain circular references or invalid JSON values; fail closed to undefined.
+    return undefined;
+  }
 }
 
 type GatewayMessagePayload = {

--- a/plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts
+++ b/plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts
@@ -124,7 +124,10 @@ export function toJsonMetadataRecord(
   }
 
   try {
-    return JSON.parse(JSON.stringify(value)) as Record<string, JsonValue>;
+    const parsed: unknown = JSON.parse(JSON.stringify(value));
+    // A hostile toJSON() can replace the record root with any JSON value; only
+    // a plain record may flow onward as sender/transport metadata.
+    return isRecord(parsed) ? (parsed as Record<string, JsonValue>) : undefined;
   } catch {
     // error-policy:J3 untrusted metadata may contain circular references or invalid JSON values; fail closed to undefined.
     return undefined;


### PR DESCRIPTION
## Summary
- Guard `toJsonMetadataRecord()` with `try / catch` and `// error-policy:J3` in `plugins/plugin-elizacloud/src/services/cloud-managed-gateway-relay.ts`
- Fails closed to `undefined` when external RPC `senderMetadata` or `transportMetadata` contains circular structures, throwing getters, or non-serializable values instead of throwing uncaught `TypeError` / `RangeError`
- Add unit test coverage in `plugins/plugin-elizacloud/__tests__/unit/cloud-managed-gateway-relay-metadata.test.ts`

## Verification
- Ran `bun run --cwd plugins/plugin-elizacloud test` (513 passed)
- Ran `bun run --cwd plugins/plugin-elizacloud typecheck` (passed)
- Ran Biome check on modified files (passed)