### PR TITLE
fix(cloud): add explicit delete capture recovery

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts
@@ -262,6 +262,67 @@ describe("agent deletion lifecycle", () => {
     expect(triggerImmediate).toHaveBeenCalledTimes(1);
   });
 
+  test("persists an explicit state-loss acknowledgement on the async delete job", async () => {
+    enqueueAgentDeleteOnce.mockResolvedValueOnce({
+      created: false,
+      job: {
+        id: "delete-job-1",
+        status: "pending",
+        data: { stateLossAcknowledged: true },
+      },
+    });
+    const response = await deleteRequest({ stateLossAcknowledged: true });
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: {
+        jobId: "delete-job-1",
+        stateLossAcknowledged: true,
+      },
+    });
+    expect(enqueueAgentDeleteOnce).toHaveBeenCalledWith({
+      agentId: "agent-1",
+      organizationId: "org-1",
+      userId: "user-1",
+      authorization: "user_request",
+      stateLossAcknowledged: true,
+    });
+  });
+
+  test("fails closed instead of claiming a waiver when reuse did not persist authority", async () => {
+    enqueueAgentDeleteOnce.mockResolvedValueOnce({
+      created: false,
+      job: { id: "delete-job-1", status: "pending", data: {} },
+    });
+
+    const response = await deleteRequest({ stateLossAcknowledged: true });
+
+    expect(response.status).toBe(500);
+  });
+
+  test("does not infer the waiver when stateLossAcknowledged is false", async () => {
+    const response = await deleteRequest({ stateLossAcknowledged: false });
+
+    expect(response.status).toBe(202);
+    expect(enqueueAgentDeleteOnce).toHaveBeenCalledWith({
+      agentId: "agent-1",
+      organizationId: "org-1",
+      userId: "user-1",
+      authorization: "user_request",
+    });
+  });
+
+  test("rejects partial conditional identity even when the waiver is explicit", async () => {
+    const response = await deleteRequest({
+      expectedAgentName: "Canary Agent",
+      stateLossAcknowledged: true,
+    });
+
+    expect(response.status).toBe(400);
+    expect(enqueueAgentDeleteOnce).not.toHaveBeenCalled();
+  });
+
   test("keeps the synchronous fast path for a sandbox-less shared delete", async () => {
     getAgent.mockResolvedValueOnce(sharedAgent({ sandbox_id: null }));
     deleteAgent.mockResolvedValueOnce({
@@ -437,6 +498,13 @@ describe("agent deletion lifecycle", () => {
       expectedCreatedAt: "not-a-timestamp",
       expectedExecutionTier: "dedicated-always",
     });
+
+    expect(response.status).toBe(400);
+    expect(enqueueAgentDeleteOnce).not.toHaveBeenCalled();
+  });
+
+  test("rejects a non-boolean state-loss acknowledgement", async () => {
+    const response = await deleteRequest({ stateLossAcknowledged: "true" });
 
     expect(response.status).toBe(400);
     expect(enqueueAgentDeleteOnce).not.toHaveBeenCalled();

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/route.ts
@@ -48,22 +48,40 @@ const editAgentSchema = z
 
 const conditionalDeleteSchema = z
   .object({
-    expectedAgentName: z.string().min(1).max(100),
-    expectedCreatedAt: z.string().datetime({ offset: true }),
-    expectedExecutionTier: z.enum([
-      "shared",
-      "dedicated-lazy",
-      "dedicated-always",
-      "custom",
-    ]),
+    expectedAgentName: z.string().min(1).max(100).optional(),
+    expectedCreatedAt: z.string().datetime({ offset: true }).optional(),
+    expectedExecutionTier: z
+      .enum(["shared", "dedicated-lazy", "dedicated-always", "custom"])
+      .optional(),
     // Cleanup canaries bind deletion to the serving deployment. Older route
     // versions keep this request fail-closed because their schema is strict.
     expectedDeployCommit: z
       .string()
       .regex(/^[a-f0-9]{40}$/)
       .optional(),
+    /** Explicit recovery from a capture refusal; never inferred from absence. */
+    stateLossAcknowledged: z.boolean().optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((value, ctx) => {
+    const identityFields = [
+      value.expectedAgentName,
+      value.expectedCreatedAt,
+      value.expectedExecutionTier,
+    ];
+    const supplied = identityFields.filter(
+      (field) => field !== undefined,
+    ).length;
+    if (
+      (supplied !== 0 && supplied !== identityFields.length) ||
+      (value.expectedDeployCommit !== undefined && supplied === 0)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Conditional delete identity fields must be supplied together",
+      });
+    }
+  });
 
 type Agent = NonNullable<
   Awaited<ReturnType<typeof elizaSandboxService.getAgent>>
@@ -428,6 +446,7 @@ app.delete("/", async (c) => {
             | "custom";
         }
       | undefined;
+    let stateLossAcknowledged = false;
     if (c.req.raw.body !== null) {
       const rawBody = await c.req.text();
       if (rawBody.trim() !== "") {
@@ -457,11 +476,18 @@ app.delete("/", async (c) => {
             409,
           );
         }
-        expectedIdentity = {
-          agentName: parsed.data.expectedAgentName,
-          createdAt: parsed.data.expectedCreatedAt,
-          executionTier: parsed.data.expectedExecutionTier,
-        };
+        stateLossAcknowledged = parsed.data.stateLossAcknowledged === true;
+        if (
+          parsed.data.expectedAgentName !== undefined &&
+          parsed.data.expectedCreatedAt !== undefined &&
+          parsed.data.expectedExecutionTier !== undefined
+        ) {
+          expectedIdentity = {
+            agentName: parsed.data.expectedAgentName,
+            createdAt: parsed.data.expectedCreatedAt,
+            executionTier: parsed.data.expectedExecutionTier,
+          };
+        }
       }
     }
 
@@ -494,7 +520,10 @@ app.delete("/", async (c) => {
       const result = await elizaSandboxService.deleteAgent(
         agentId,
         user.organization_id,
-        { authorization: "user_request" },
+        {
+          authorization: "user_request",
+          ...(stateLossAcknowledged ? { stateLossAcknowledged: true } : {}),
+        },
       );
       if (!result.success) {
         const status =
@@ -552,8 +581,14 @@ app.delete("/", async (c) => {
       organizationId: user.organization_id,
       userId: user.id,
       authorization: "user_request",
+      ...(stateLossAcknowledged ? { stateLossAcknowledged: true } : {}),
       expectedIdentity,
     });
+    const durableStateLossAcknowledged =
+      enqueueResult.job.data?.stateLossAcknowledged === true;
+    if (stateLossAcknowledged && !durableStateLossAcknowledged) {
+      throw new Error("Delete state-loss acknowledgement was not persisted");
+    }
 
     // Best-effort wake of the worker so the user does not wait for the
     // next cron tick. Same pattern as the provision path.
@@ -580,6 +615,7 @@ app.delete("/", async (c) => {
           jobId: enqueueResult.job.id,
           agentId,
           status: enqueueResult.job.status,
+          stateLossAcknowledged: durableStateLossAcknowledged || undefined,
         },
         polling: {
           endpoint: `/api/v1/jobs/${enqueueResult.job.id}`,

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -2722,6 +2722,21 @@ export class AgentSandboxesRepository {
       nodeId,
       and(eq(agentSandboxes.id, agentId), eq(agentSandboxes.node_id, nodeId)) as SQL,
     );
+    // The reaper has proved this workload absent on the named node. A retained
+    // bridge/health locator would make the recovery delete try to capture from
+    // that dead generation again, permanently stranding the tombstone. Clear
+    // only the network locators, fenced to the same node and terminal delete
+    // states; the remaining container/node identity stays available for audit.
+    await dbWrite
+      .update(agentSandboxes)
+      .set({ bridge_url: null, health_url: null, updated_at: new Date() })
+      .where(
+        and(
+          eq(agentSandboxes.id, agentId),
+          eq(agentSandboxes.node_id, nodeId),
+          inArray(agentSandboxes.status, ["deletion_pending", "deletion_failed"]),
+        ),
+      );
     return result.outcome;
   }
 }

--- a/packages/cloud/shared/src/lib/services/__tests__/deletion-allocation-ownership.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/deletion-allocation-ownership.test.ts
@@ -565,6 +565,47 @@ describe("releaseDeletionAllocationOnReap — absence proven by the orphan reape
   );
 
   test(
+    "absence proof clears stale network locators so recovery does not recapture a dead generation",
+    async () => {
+      if (!pgliteReady) return;
+      const { agentId, nodeId } = await seedNodeWithTargetAndSibling({
+        allocationCounted: true,
+        status: "deletion_failed",
+      });
+      await dbWrite
+        .update(agentSandboxes)
+        .set({
+          bridge_url: "http://100.64.0.10:3000",
+          health_url: "http://100.64.0.10:3000/api/health",
+        })
+        .where(eq(agentSandboxes.id, agentId));
+
+      expect(await agentSandboxesRepository.releaseDeletionAllocationOnReap(agentId, nodeId)).toBe(
+        "released",
+      );
+
+      const [retained] = await dbWrite
+        .select({
+          bridgeUrl: agentSandboxes.bridge_url,
+          healthUrl: agentSandboxes.health_url,
+          containerName: agentSandboxes.container_name,
+          nodeId: agentSandboxes.node_id,
+          status: agentSandboxes.status,
+        })
+        .from(agentSandboxes)
+        .where(eq(agentSandboxes.id, agentId));
+      expect(retained).toMatchObject({
+        bridgeUrl: null,
+        healthUrl: null,
+        nodeId,
+        status: "deletion_failed",
+      });
+      expect(retained.containerName).not.toBeNull();
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
     "a second reap of the same agent does not free the live sibling's slot",
     async () => {
       if (!pgliteReady) return;
@@ -732,6 +773,70 @@ describe("workload reconciliation counts a deletion row exactly while it owns a 
 });
 
 describe("enqueueAgentDeleteOnce initializes ownership from the pre-delete state", () => {
+  test(
+    "an explicit state-loss acknowledgement is durable job authority",
+    async () => {
+      if (!pgliteReady) return;
+      const { agentId, orgId, userId } = await seedAgentViaService();
+
+      const enqueued = await new ProvisioningJobService().enqueueAgentDeleteOnce({
+        agentId,
+        organizationId: orgId,
+        userId,
+        authorization: "user_request",
+        stateLossAcknowledged: true,
+      });
+
+      expect(enqueued.job.data).toMatchObject({
+        agentId,
+        organizationId: orgId,
+        userId,
+        authorization: "user_request",
+        stateLossAcknowledged: true,
+      });
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a repeated delete monotonically upgrades the in-flight job with state-loss authority",
+    async () => {
+      if (!pgliteReady) return;
+      const { agentId, orgId, userId } = await seedAgentViaService();
+      const service = new ProvisioningJobService();
+
+      const first = await service.enqueueAgentDeleteOnce({
+        agentId,
+        organizationId: orgId,
+        userId,
+        authorization: "user_request",
+      });
+      expect(first.created).toBe(true);
+      expect(first.job.data.stateLossAcknowledged).toBeUndefined();
+
+      const upgraded = await service.enqueueAgentDeleteOnce({
+        agentId,
+        organizationId: orgId,
+        userId,
+        authorization: "user_request",
+        stateLossAcknowledged: true,
+      });
+      expect(upgraded.created).toBe(false);
+      expect(upgraded.job.id).toBe(first.job.id);
+      expect(upgraded.job.data.stateLossAcknowledged).toBe(true);
+
+      const reusedWithoutAuthority = await service.enqueueAgentDeleteOnce({
+        agentId,
+        organizationId: orgId,
+        userId,
+        authorization: "user_request",
+      });
+      expect(reusedWithoutAuthority.created).toBe(false);
+      expect(reusedWithoutAuthority.job.data.stateLossAcknowledged).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
   test(
     "a placed, running agent starts its deletion owning one slot; a re-enqueue keeps that answer",
     async () => {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -4008,6 +4008,41 @@ describe("ElizaSandboxService.deleteAgent fail-closed pre-deletion capture (#185
     }
   });
 
+  test("an explicit state-loss acknowledgement binds a capture waiver to this generation", async () => {
+    const { svc, spyTarget } = await makeCaptureSvc();
+    const rec = customSandbox();
+    const getForWrite = spyOn(spyTarget, "getAgentForWrite").mockResolvedValue(rec);
+    const fetchSnap = spyOn(spyTarget, "fetchSnapshotState").mockRejectedValue(
+      new Error("available-memory budget exceeded"),
+    );
+    const prepare = spyOn(spyTarget, "prepareAgentDelete").mockResolvedValue({
+      ok: false,
+      error: "halted by test after capture phase",
+    });
+    try {
+      await expect(
+        svc.deleteAgent(rec.id, rec.organization_id, {
+          authorization: "user_request",
+          stateLossAcknowledged: true,
+        }),
+      ).resolves.toEqual({ success: false, error: "halted by test after capture phase" });
+      expect(prepare).toHaveBeenCalledWith(rec.id, rec.organization_id, "user_request", {
+        snapshot: null,
+        captureWaiverGeneration: {
+          bridgeUrl: rec.bridge_url,
+          environmentRevision: rec.environment_revision,
+          sandboxId: rec.sandbox_id,
+        },
+        captureWaiverAlreadyPersisted: false,
+        existingBackup: null,
+      });
+    } finally {
+      getForWrite.mockRestore();
+      fetchSnap.mockRestore();
+      prepare.mockRestore();
+    }
+  });
+
   test("a transient capture failure refuses the delete with the transient message", async () => {
     const { mod, svc, spyTarget } = await makeCaptureSvc();
     const rec = customSandbox();
@@ -4049,7 +4084,7 @@ describe("ElizaSandboxService.deleteAgent fail-closed pre-deletion capture (#185
       ).resolves.toEqual({ success: false, error: "halted by test after capture phase" });
       expect(prepare).toHaveBeenCalledWith(rec.id, rec.organization_id, "user_request", {
         snapshot: null,
-        captureUnsupportedGeneration: {
+        captureWaiverGeneration: {
           bridgeUrl: rec.bridge_url,
           environmentRevision: rec.environment_revision,
           sandboxId: rec.sandbox_id,
@@ -4091,7 +4126,7 @@ describe("ElizaSandboxService.deleteAgent fail-closed pre-deletion capture (#185
       expect(fetchSnap).not.toHaveBeenCalled();
       expect(prepare).toHaveBeenCalledWith(rec.id, rec.organization_id, undefined, {
         snapshot: null,
-        captureUnsupportedGeneration: null,
+        captureWaiverGeneration: null,
         captureWaiverAlreadyPersisted: true,
         existingBackup: null,
       });
@@ -4136,7 +4171,7 @@ describe("ElizaSandboxService.deleteAgent fail-closed pre-deletion capture (#185
           }
         ).prepareAgentDelete(live.id, live.organization_id, "user_request", {
           snapshot: null,
-          captureUnsupportedGeneration: null,
+          captureWaiverGeneration: null,
           captureWaiverAlreadyPersisted: true,
           existingBackup: null,
         }),
@@ -4201,7 +4236,7 @@ describe("ElizaSandboxService.deleteAgent fail-closed pre-deletion capture (#185
       expect(fetchSnap).not.toHaveBeenCalled();
       expect(prepare).toHaveBeenCalledWith(rec.id, rec.organization_id, undefined, {
         snapshot: null,
-        captureUnsupportedGeneration: null,
+        captureWaiverGeneration: null,
         captureWaiverAlreadyPersisted: false,
         existingBackup: null,
       });
@@ -4226,7 +4261,7 @@ describe("ElizaSandboxService.deleteAgent fail-closed pre-deletion capture (#185
       expect(fetchSnap).not.toHaveBeenCalled();
       expect(prepare).toHaveBeenCalledWith(rec.id, rec.organization_id, undefined, {
         snapshot: null,
-        captureUnsupportedGeneration: null,
+        captureWaiverGeneration: null,
         captureWaiverAlreadyPersisted: false,
         existingBackup: null,
       });
@@ -4302,7 +4337,7 @@ describe("ElizaSandboxService.deleteAgent fail-closed pre-deletion capture (#185
       expect(fetchSnap).not.toHaveBeenCalled();
       expect(prepare).toHaveBeenCalledWith(rec.id, rec.organization_id, "user_request", {
         snapshot: null,
-        captureUnsupportedGeneration: null,
+        captureWaiverGeneration: null,
         captureWaiverAlreadyPersisted: false,
         existingBackup: {
           id: priorBackupId,
@@ -4338,7 +4373,7 @@ describe("ElizaSandboxService.deleteAgent fail-closed pre-deletion capture (#185
       expect(fetchSnap).not.toHaveBeenCalled();
       expect(prepare).toHaveBeenCalledWith(rec.id, rec.organization_id, undefined, {
         snapshot: null,
-        captureUnsupportedGeneration: null,
+        captureWaiverGeneration: null,
         captureWaiverAlreadyPersisted: false,
         existingBackup: null,
       });
@@ -4383,7 +4418,7 @@ describe("ElizaSandboxService.deleteAgent fail-closed pre-deletion capture (#185
       expect(fetchSnap).toHaveBeenCalledTimes(1);
       expect(prepare).toHaveBeenCalledWith(rec.id, rec.organization_id, undefined, {
         snapshot,
-        captureUnsupportedGeneration: null,
+        captureWaiverGeneration: null,
         captureWaiverAlreadyPersisted: false,
         existingBackup: null,
       });
@@ -4421,7 +4456,7 @@ describe("ElizaSandboxService.deleteAgent fail-closed pre-deletion capture (#185
             sizeBytes: 12,
             bridgeUrl: "https://a-different-generation.example",
           },
-          captureUnsupportedGeneration: null,
+          captureWaiverGeneration: null,
           captureWaiverAlreadyPersisted: false,
           existingBackup: null,
         }),
@@ -4485,7 +4520,7 @@ describe("ElizaSandboxService.deleteAgent fail-closed pre-deletion capture (#185
         }
       ).prepareAgentDelete(live.id, live.organization_id, "user_request", {
         snapshot: { stateData, sizeBytes: 34, bridgeUrl: live.bridge_url as string },
-        captureUnsupportedGeneration: null,
+        captureWaiverGeneration: null,
         captureWaiverAlreadyPersisted: false,
         existingBackup: null,
       })) as { ok: boolean };
@@ -4539,7 +4574,7 @@ describe("ElizaSandboxService.deleteAgent fail-closed pre-deletion capture (#185
         }
       ).prepareAgentDelete(live.id, live.organization_id, "user_request", {
         snapshot: null,
-        captureUnsupportedGeneration: {
+        captureWaiverGeneration: {
           bridgeUrl: live.bridge_url,
           environmentRevision: live.environment_revision,
           sandboxId: live.sandbox_id,
@@ -4611,7 +4646,7 @@ describe("ElizaSandboxService.deleteAgent fail-closed pre-deletion capture (#185
           }
         ).prepareAgentDelete(live.id, live.organization_id, "user_request", {
           snapshot: null,
-          captureUnsupportedGeneration: null,
+          captureWaiverGeneration: null,
           captureWaiverAlreadyPersisted: false,
           existingBackup: { id: backupId, deletionAttemptId },
         }),
@@ -4783,7 +4818,7 @@ describe("ElizaSandboxService.deleteAgent teardown cap (#9066)", () => {
             sizeBytes: 1,
             bridgeUrl: live.bridge_url,
           },
-          captureUnsupportedGeneration: null,
+          captureWaiverGeneration: null,
           captureWaiverAlreadyPersisted: false,
           existingBackup: null,
         }),

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -1947,7 +1947,10 @@ export class ElizaSandboxService {
   async deleteAgent(
     agentId: string,
     orgId: string,
-    options: { authorization?: DeleteAuthorization } = {},
+    options: {
+      authorization?: DeleteAuthorization;
+      stateLossAcknowledged?: boolean;
+    } = {},
   ): Promise<DeleteAgentResult> {
     // Phase 0 — fail-closed pre-deletion capture (#18517), the discipline
     // shutdown() applies before stopping: a live dedicated container is never
@@ -1959,7 +1962,7 @@ export class ElizaSandboxService {
     // its bridge intact, the capture happens before any teardown, and a
     // refusal leaves a recoverable tombstone the next attempt retries.
     let captureWaiverAlreadyPersisted = false;
-    let captureUnsupportedGeneration: {
+    let captureWaiverGeneration: {
       bridgeUrl: string;
       environmentRevision: number;
       sandboxId: string | null;
@@ -2032,7 +2035,7 @@ export class ElizaSandboxService {
           // an image that cannot snapshot by construction proceeds.
           const message = error instanceof Error ? error.message : String(error);
           if (message === SNAPSHOT_ENDPOINT_UNSUPPORTED) {
-            captureUnsupportedGeneration = {
+            captureWaiverGeneration = {
               bridgeUrl: snapshotSource.bridge_url,
               environmentRevision: snapshotSource.environment_revision,
               sandboxId: snapshotSource.sandbox_id,
@@ -2040,6 +2043,20 @@ export class ElizaSandboxService {
             logger.warn(
               "[agent-sandbox] Delete proceeding without capture: image has no snapshot endpoint",
               { agentId },
+            );
+          } else if (options.stateLossAcknowledged) {
+            // Explicit customer/operator recovery path: a capture failure can
+            // otherwise make a data-bearing agent undeletable forever. Bind the
+            // waiver to this exact deletion/container generation and persist it
+            // under the lifecycle lock before any destructive work begins.
+            captureWaiverGeneration = {
+              bridgeUrl: snapshotSource.bridge_url,
+              environmentRevision: snapshotSource.environment_revision,
+              sandboxId: snapshotSource.sandbox_id,
+            };
+            logger.error(
+              "[agent-sandbox] Delete proceeding WITHOUT pre-deletion capture: state loss acknowledged",
+              { agentId, captureError: message },
             );
           } else if (message === SNAPSHOT_CAPTURE_TRANSIENT) {
             logger.warn(
@@ -2075,7 +2092,7 @@ export class ElizaSandboxService {
     // same agent/org. The lock + transaction are released the moment this returns.
     const precheck = await this.prepareAgentDelete(agentId, orgId, options.authorization, {
       snapshot: preDeleteSnapshot,
-      captureUnsupportedGeneration,
+      captureWaiverGeneration,
       captureWaiverAlreadyPersisted,
       existingBackup: preDeleteBackupCandidate,
     });
@@ -2351,7 +2368,7 @@ export class ElizaSandboxService {
         sizeBytes: number;
         bridgeUrl: string;
       } | null;
-      captureUnsupportedGeneration: {
+      captureWaiverGeneration: {
         bridgeUrl: string;
         environmentRevision: number;
         sandboxId: string | null;
@@ -2442,12 +2459,12 @@ export class ElizaSandboxService {
           preDeleteCapture?.captureWaiverAlreadyPersisted === true &&
           this.hasCurrentPreDeleteCaptureWaiver(rec);
         if (preDeleteBackupId === null && !captureWaiverIsCurrent) {
-          const unsupported = preDeleteCapture?.captureUnsupportedGeneration ?? null;
-          if (unsupported) {
+          const waiver = preDeleteCapture?.captureWaiverGeneration ?? null;
+          if (waiver) {
             if (
-              rec.bridge_url !== unsupported.bridgeUrl ||
-              rec.environment_revision !== unsupported.environmentRevision ||
-              rec.sandbox_id !== unsupported.sandboxId
+              rec.bridge_url !== waiver.bridgeUrl ||
+              rec.environment_revision !== waiver.environmentRevision ||
+              rec.sandbox_id !== waiver.sandboxId
             ) {
               return {
                 ok: false as const,
@@ -2455,7 +2472,7 @@ export class ElizaSandboxService {
                   "Refusing to delete: the agent's lifecycle generation moved after the pre-deletion capture; retry the delete.",
               };
             }
-            captureWaiverToPersist = unsupported;
+            captureWaiverToPersist = waiver;
           } else {
             const snapshot = preDeleteCapture?.snapshot ?? null;
             // The capture must be OF THIS generation (shutdown's rule): a
@@ -2930,6 +2947,7 @@ export class ElizaSandboxService {
     agentId: string,
     orgId: string,
     authorization?: DeleteAuthorization,
+    stateLossAcknowledged?: boolean,
   ): Promise<{
     success: boolean;
     containerStopped: boolean;
@@ -2937,7 +2955,10 @@ export class ElizaSandboxService {
     error?: string;
     retryable?: true;
   }> {
-    const result = await this.deleteAgent(agentId, orgId, { authorization });
+    const result = await this.deleteAgent(agentId, orgId, {
+      authorization,
+      stateLossAcknowledged,
+    });
     if (!result.success) {
       // If the row is already gone, treat as success. This covers the retry
       // case where a prior attempt deleted the row but failed before updating

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
@@ -645,6 +645,66 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
     }
   });
 
+  test("agent_delete carries explicit state-loss authority through execution and completion", async () => {
+    const ctx = harness(
+      makeJob(JOB_TYPES.AGENT_DELETE, {
+        authorization: "billing_request",
+        stateLossAcknowledged: true,
+      }),
+    );
+    const executeDeletionSpy = stub("executeDeletion", {
+      success: true,
+      containerStopped: true,
+      rowDeleted: true,
+    });
+
+    try {
+      const res = await run(JOB_TYPES.AGENT_DELETE);
+      expect(res).toMatchObject({ succeeded: 1, failed: 0, retried: 0 });
+      expect(executeDeletionSpy).toHaveBeenCalledWith(AGENT, ORG, "billing_request", true);
+      expect(completedCall(ctx)?.[2]?.result).toMatchObject({ stateLossAcknowledged: true });
+    } finally {
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+
+  test("agent_delete retains explicit state-loss authority on a failed partial result", async () => {
+    const ctx = harness(
+      makeJob(JOB_TYPES.AGENT_DELETE, {
+        authorization: "billing_request",
+        stateLossAcknowledged: true,
+      }),
+    );
+    stub("executeDeletion", {
+      success: false,
+      retryable: false,
+      containerStopped: false,
+      rowDeleted: false,
+      error: "provider teardown failed",
+    });
+
+    try {
+      const res = await run(JOB_TYPES.AGENT_DELETE);
+      expect(res).toMatchObject({ succeeded: 0, failed: 1, retried: 0 });
+      expect(ctx.updateSpy.mock.calls[0]?.[1]?.result).toMatchObject({
+        stateLossAcknowledged: true,
+        error: "provider teardown failed",
+      });
+    } finally {
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+
   test("an unresolved delete completes the hot queue attempt with rowDeleted false", async () => {
     const ctx = harness(makeJob(JOB_TYPES.AGENT_DELETE));
     stub("executeDeletion", {

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
@@ -99,6 +99,9 @@ function harness(job: Job) {
   );
   const leaseSpy = spyOn(jobsRepository, "assertExecutionLease").mockResolvedValue(undefined);
   const renewLeaseSpy = spyOn(jobsRepository, "renewExecutionLease").mockResolvedValue("lost");
+  // agent_delete re-reads durable job data under the lease right before the
+  // destructive boundary; by default the durable row matches the claimed one.
+  const durableReadSpy = spyOn(jobsRepository, "findByIdForWrite").mockResolvedValue(job);
   const sharedClaimSpy = spyOn(
     jobsRepository,
     "claimPendingJobsWithinSharedRunningLimit",
@@ -110,6 +113,7 @@ function harness(job: Job) {
       sharedClaimSpy.mockRestore();
       leaseSpy.mockRestore();
       renewLeaseSpy.mockRestore();
+      durableReadSpy.mockRestore();
     },
   };
   const recoverSpy = spyOn(jobsRepository, "recoverStaleJobs").mockResolvedValue(EMPTY_RECOVERY);
@@ -131,6 +135,7 @@ function harness(job: Job) {
     claimSpy,
     leaseSpy,
     renewLeaseSpy,
+    durableReadSpy,
     recoverSpy,
     updateStatusSpy,
     updateSpy,
@@ -663,6 +668,61 @@ describe("executeJob dispatch — type-specific disposition rules", () => {
       expect(res).toMatchObject({ succeeded: 1, failed: 0, retried: 0 });
       expect(executeDeletionSpy).toHaveBeenCalledWith(AGENT, ORG, "billing_request", true);
       expect(completedCall(ctx)?.[2]?.result).toMatchObject({ stateLossAcknowledged: true });
+    } finally {
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+
+  test("agent_delete honors an acknowledgement upgraded after this execution was claimed", async () => {
+    // Race regression: the claimed in-memory job snapshot has no waiver, but a
+    // concurrent acknowledged DELETE upgraded the durable row via upgradeReuse.
+    // The pre-destructive durable re-read must observe and honor it.
+    const ctx = harness(makeJob(JOB_TYPES.AGENT_DELETE, { authorization: "user_request" }));
+    ctx.durableReadSpy.mockResolvedValue({
+      ...ctx.job,
+      data: { ...ctx.job.data, stateLossAcknowledged: true },
+    });
+    const executeDeletionSpy = stub("executeDeletion", {
+      success: true,
+      containerStopped: true,
+      rowDeleted: true,
+    });
+
+    try {
+      const res = await run(JOB_TYPES.AGENT_DELETE);
+      expect(res).toMatchObject({ succeeded: 1, failed: 0, retried: 0 });
+      expect(executeDeletionSpy).toHaveBeenCalledWith(AGENT, ORG, "user_request", true);
+      expect(completedCall(ctx)?.[2]?.result).toMatchObject({ stateLossAcknowledged: true });
+    } finally {
+      ctx.claimSpy.mockRestore();
+      ctx.recoverSpy.mockRestore();
+      ctx.updateStatusSpy.mockRestore();
+      ctx.updateSpy.mockRestore();
+      ctx.incrementSpy.mockRestore();
+      ctx.retryLaterSpy.mockRestore();
+    }
+  });
+
+  test("agent_delete stays unacknowledged when the durable row was deleted mid-execution", async () => {
+    const ctx = harness(makeJob(JOB_TYPES.AGENT_DELETE, { authorization: "user_request" }));
+    ctx.durableReadSpy.mockResolvedValue(undefined);
+    const executeDeletionSpy = stub("executeDeletion", {
+      success: true,
+      containerStopped: true,
+      rowDeleted: true,
+    });
+
+    try {
+      const res = await run(JOB_TYPES.AGENT_DELETE);
+      expect(res).toMatchObject({ succeeded: 1, failed: 0, retried: 0 });
+      expect(executeDeletionSpy).toHaveBeenCalledWith(AGENT, ORG, "user_request");
+      const result = completedCall(ctx)?.[2]?.result as Record<string, unknown> | undefined;
+      expect(result?.stateLossAcknowledged).toBeUndefined();
     } finally {
       ctx.claimSpy.mockRestore();
       ctx.recoverSpy.mockRestore();

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -5311,7 +5311,18 @@ export class ProvisioningJobService {
     });
 
     await this.assertExecutionMutationLease(job);
-    const delResult = data.stateLossAcknowledged
+    // A concurrent acknowledged DELETE may have upgraded the durable job data
+    // after this worker claimed its in-memory snapshot (`upgradeReuse`). The
+    // claimed object cannot observe that write, so re-read the row from the
+    // primary under the execution lease immediately before the destructive
+    // boundary. Authority is monotonic: the durable read may strengthen the
+    // claimed snapshot, never weaken it.
+    const durableJob = await jobsRepository.findByIdForWrite(job.id);
+    const stateLossAcknowledged =
+      data.stateLossAcknowledged === true ||
+      (durableJob !== undefined &&
+        readAgentDeleteJobData(durableJob).stateLossAcknowledged === true);
+    const delResult = stateLossAcknowledged
       ? await elizaSandboxService.executeDeletion(
           data.agentId,
           data.organizationId,
@@ -5344,7 +5355,7 @@ export class ProvisioningJobService {
           cloudAgentId: data.agentId,
           containerStopped: delResult.containerStopped,
           rowDeleted: false,
-          ...(data.stateLossAcknowledged ? { stateLossAcknowledged: true } : {}),
+          ...(stateLossAcknowledged ? { stateLossAcknowledged: true } : {}),
           error: delResult.error,
           ...(captureRetryCount > 0 ? { captureRetryCount } : {}),
         }),
@@ -5384,7 +5395,7 @@ export class ProvisioningJobService {
       cloudAgentId: data.agentId,
       containerStopped: delResult.containerStopped,
       rowDeleted: delResult.rowDeleted,
-      ...(data.stateLossAcknowledged ? { stateLossAcknowledged: true } : {}),
+      ...(stateLossAcknowledged ? { stateLossAcknowledged: true } : {}),
     };
 
     await this.settleClaimedExecution(job, "completed", {

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -162,6 +162,8 @@ export interface AgentDeleteJobData {
   organizationId: string;
   userId: string;
   authorization?: DeleteAuthorization;
+  /** Explicit customer/operator acceptance that the current live delta may be lost. */
+  stateLossAcknowledged?: boolean;
 }
 
 export interface AgentSuspendJobData {
@@ -299,6 +301,8 @@ export interface AgentDeleteJobResult {
   cloudAgentId: string;
   containerStopped: boolean;
   rowDeleted: boolean;
+  /** The caller explicitly accepted loss of uncaptured state for this delete. */
+  stateLossAcknowledged?: true;
   error?: string;
   /** Free (attempt-preserving) requeues this delete has spent waiting for a
    *  transient pre-deletion capture. Persisted on the job result because
@@ -515,6 +519,10 @@ function isAgentDeleteJobData(value: unknown): value is AgentDeleteJobData {
     typeof value === "object" && value !== null
       ? (value as { authorization?: unknown }).authorization
       : undefined;
+  const stateLossAcknowledged =
+    typeof value === "object" && value !== null
+      ? (value as { stateLossAcknowledged?: unknown }).stateLossAcknowledged
+      : undefined;
   return (
     typeof value === "object" &&
     value !== null &&
@@ -523,7 +531,8 @@ function isAgentDeleteJobData(value: unknown): value is AgentDeleteJobData {
     typeof (value as { userId?: unknown }).userId === "string" &&
     (authorization === undefined ||
       authorization === "user_request" ||
-      authorization === "billing_request")
+      authorization === "billing_request") &&
+    (stateLossAcknowledged === undefined || typeof stateLossAcknowledged === "boolean")
   );
 }
 
@@ -921,6 +930,11 @@ interface LifecycleJobOptions<TData extends object> {
    * either match the in-flight job or be rejected loudly (#15603 B6).
    */
   validateReuse?: (existing: Job) => void;
+  /**
+   * Monotonically strengthens durable authority on a reused in-flight job.
+   * Runs under the same lifecycle transaction and advisory lock as lookup.
+   */
+  upgradeReuse?: (tx: DbTransaction, existing: Job) => Promise<Job>;
   /**
    * Called inside the transaction after the "no existing job" check
    * and before the new job is inserted. Used by delete to flip the
@@ -1522,11 +1536,12 @@ export class ProvisioningJobService {
     if (existing) {
       const hydrated = await hydrateJob(existing);
       opts.validateReuse?.(hydrated);
+      const reused = opts.upgradeReuse ? await opts.upgradeReuse(tx, hydrated) : hydrated;
       logger.info(`[provisioning-jobs] Reusing active ${opts.logName} job`, {
         jobId: existing.id,
         ...logFields,
       });
-      return { job: hydrated, created: false };
+      return { job: reused, created: false };
     }
 
     await opts.beforeInsert?.(tx, sandbox);
@@ -1655,6 +1670,7 @@ export class ProvisioningJobService {
     userId: string;
     webhookUrl?: string;
     authorization?: DeleteAuthorization;
+    stateLossAcknowledged?: boolean;
     expectedIdentity?: {
       agentName: string;
       createdAt: Date | string;
@@ -1677,6 +1693,7 @@ export class ProvisioningJobService {
         organizationId: params.organizationId,
         userId: params.userId,
         authorization: params.authorization,
+        ...(params.stateLossAcknowledged ? { stateLossAcknowledged: true } : {}),
       },
       toRecord: agentDeleteJobDataToRecord,
       agentId: params.agentId,
@@ -1689,6 +1706,35 @@ export class ProvisioningJobService {
       // sub-second. 30s matches the Docker deletion-stop command timeout.
       estimatedDurationMs: 30_000,
       logName: "agent_delete",
+      upgradeReuse: params.stateLossAcknowledged
+        ? async (tx, existing) => {
+            const existingData = readAgentDeleteJobData(existing);
+            if (existingData.stateLossAcknowledged === true) return existing;
+            const [upgraded] = await tx
+              .update(jobs)
+              .set({
+                data: agentDeleteJobDataToRecord({
+                  ...existingData,
+                  stateLossAcknowledged: true,
+                }),
+                data_storage: "inline",
+                data_key: null,
+                updated_at: new Date(),
+              })
+              .where(
+                and(eq(jobs.id, existing.id), sql`${jobs.status} IN ('pending', 'in_progress')`),
+              )
+              .returning();
+            if (!upgraded) {
+              throw new ApiError(
+                409,
+                "session_not_ready",
+                "Agent deletion changed while recording state-loss authority",
+              );
+            }
+            return hydrateJob(upgraded);
+          }
+        : undefined,
       validateSandbox: expectedIdentity
         ? (sandbox) => {
             if (
@@ -5265,11 +5311,18 @@ export class ProvisioningJobService {
     });
 
     await this.assertExecutionMutationLease(job);
-    const delResult = await elizaSandboxService.executeDeletion(
-      data.agentId,
-      data.organizationId,
-      data.authorization,
-    );
+    const delResult = data.stateLossAcknowledged
+      ? await elizaSandboxService.executeDeletion(
+          data.agentId,
+          data.organizationId,
+          data.authorization,
+          true,
+        )
+      : await elizaSandboxService.executeDeletion(
+          data.agentId,
+          data.organizationId,
+          data.authorization,
+        );
 
     if (!delResult.success) {
       // The free requeue is bounded. `retryLaterWithoutIncrementingAttempts`
@@ -5291,6 +5344,7 @@ export class ProvisioningJobService {
           cloudAgentId: data.agentId,
           containerStopped: delResult.containerStopped,
           rowDeleted: false,
+          ...(data.stateLossAcknowledged ? { stateLossAcknowledged: true } : {}),
           error: delResult.error,
           ...(captureRetryCount > 0 ? { captureRetryCount } : {}),
         }),
@@ -5330,6 +5384,7 @@ export class ProvisioningJobService {
       cloudAgentId: data.agentId,
       containerStopped: delResult.containerStopped,
       rowDeleted: delResult.rowDeleted,
+      ...(data.stateLossAcknowledged ? { stateLossAcknowledged: true } : {}),
     };
 
     await this.settleClaimedExecution(job, "completed", {


### PR DESCRIPTION
# Scope

Refs #23235.

This narrowly restores a customer recovery path when a pre-deletion capture cannot succeed, without claiming the issue's protected live-row repair:

- accepts only an explicit boolean `stateLossAcknowledged` on the authenticated DELETE boundary;
- persists that authority in the async delete job and completion result;
- binds the capture waiver to the exact deletion attempt, environment revision, sandbox, and bridge under the existing lifecycle lock;
- keeps the ordinary fail-closed and bounded retry behavior unchanged when authority is absent;
- clears stale bridge/health locators only after the orphan reaper proves the workload absent, while retaining node/container identity for audit and retry convergence.

The issue's suspected infinite RSS retry is not present in current source: free capture requeues are already capped, and the RSS-budget error is not classified as the special transient signal. This PR fixes the remaining deterministic recovery gaps instead.

# Exact-head verification

Candidate: `62c704d4cb7086ee31b5253122ea4475a3586389`

Parent develop: `d4b1af0f68a392b59db5923afde84fd4c7d4f592`

- route: 17/17, 54 assertions
- exact waiver service regression: pass
- real PGlite durability/reaper regressions: 2/2
- real PGlite repeated-enqueue monotonic authority upgrade: pass
- exact worker propagation regression: pass
- failed partial result retains explicit authority: pass
- broader capture lane: 17/17 on byte-identical repair
- broader real PGlite allocation lane: 29/29 on byte-identical repair
- Biome 8 files and diff check: pass

Sparse-checkout typecheck and teardown limitations are recorded truthfully in the immutable receipt.

# Evidence Gate

<!-- evidence-head:62c704d4cb7086ee31b5253122ea4475a3586389 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual or interactive flow changes.
<!-- evidence-row:backend-logs -->
- [x] [23235-exact-62c704.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23235-exact-62c704.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changes.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model or planner behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [23235-domain-62c704.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23235-domain-62c704.md)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Known limits

- No protected production row was mutated.
- #23235 remains open for the live stuck-row repair and deployed readback.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->
