### PR TITLE
fix(cloud): bound MCP built-in provider fetches with timeout

### DIFF
--- a/packages/cloud/api/src/lib/mcp/mcps-transport-gateway.timeout.test.ts
+++ b/packages/cloud/api/src/lib/mcp/mcps-transport-gateway.timeout.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Deterministic unit tests for MCP built-in provider request timeouts.
+ * Proves every external fetch in the Workers-safe gateway receives the
+ * shared AbortSignal deadline.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("@/lib/mcp/mcp-upstream-forward", () => ({
+  forwardMcpUpstreamRequest: async () =>
+    new Response("mocked upstream", { status: 200 }),
+}));
+
+const realFetch = globalThis.fetch;
+const realTimeout = AbortSignal.timeout;
+
+function jsonRpcCall(name: string, args: Record<string, unknown>) {
+  return {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name, arguments: args },
+  };
+}
+
+describe("MCP built-in provider timeout", () => {
+  let timeoutCalls: number[];
+  let fetchedSignals: unknown[];
+
+  beforeEach(() => {
+    timeoutCalls = [];
+    fetchedSignals = [];
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    (
+      AbortSignal as unknown as { timeout: typeof AbortSignal.timeout }
+    ).timeout = realTimeout;
+  });
+
+  test("exports 10-second provider deadline", async () => {
+    const { MCP_PROVIDER_REQUEST_TIMEOUT_MS } = await import(
+      "./mcps-transport-gateway"
+    );
+    expect(MCP_PROVIDER_REQUEST_TIMEOUT_MS).toBe(10_000);
+  });
+
+  test("weather search_location wires deadline to geocoding fetch", async () => {
+    const spy = mock((ms: number) => {
+      timeoutCalls.push(ms);
+      return realTimeout(ms);
+    });
+    (
+      AbortSignal as unknown as { timeout: typeof AbortSignal.timeout }
+    ).timeout = spy as unknown as typeof AbortSignal.timeout;
+
+    globalThis.fetch = mock(async (url: unknown, init?: RequestInit) => {
+      fetchedSignals.push(init?.signal);
+      const u = String(url);
+      if (u.includes("geocoding-api.open-meteo.com")) {
+        return Response.json({
+          results: [
+            {
+              name: "Berlin",
+              latitude: 52.52,
+              longitude: 13.41,
+              country: "DE",
+              admin1: "Berlin",
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    }) as unknown as typeof fetch;
+
+    const { createMcpsTransportApp } = await import("./mcps-transport-gateway");
+    const { Hono } = await import("hono");
+    const bridge = createMcpsTransportApp("weather");
+    const parent = new Hono();
+    parent.route("/:transport", bridge);
+    const req = new Request("http://example.test/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(jsonRpcCall("search_location", { query: "Berlin" })),
+    });
+    const res = await parent.fetch(req, {} as never);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result?: { content?: Array<{ text?: string }> };
+    };
+    const text = body.result?.content?.[0]?.text ?? "";
+    expect(text).toContain("Berlin");
+    expect(timeoutCalls).toEqual([10_000]);
+    expect(fetchedSignals).toHaveLength(1);
+    for (const sig of fetchedSignals) expect(sig).toBeInstanceOf(AbortSignal);
+  });
+
+  test("weather get_current_weather wires deadline to forecast fetch", async () => {
+    const spy = mock((ms: number) => {
+      timeoutCalls.push(ms);
+      return realTimeout(ms);
+    });
+    (
+      AbortSignal as unknown as { timeout: typeof AbortSignal.timeout }
+    ).timeout = spy as unknown as typeof AbortSignal.timeout;
+
+    globalThis.fetch = mock(async (url: unknown, init?: RequestInit) => {
+      fetchedSignals.push(init?.signal);
+      const u = String(url);
+      if (u.includes("api.open-meteo.com/v1/forecast")) {
+        return Response.json({
+          current_weather: { temperature: 20, windspeed: 5 },
+        });
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    }) as unknown as typeof fetch;
+
+    const { createMcpsTransportApp } = await import("./mcps-transport-gateway");
+    const { Hono } = await import("hono");
+    const bridge = createMcpsTransportApp("weather");
+    const parent = new Hono();
+    parent.route("/:transport", bridge);
+    const req = new Request("http://example.test/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(
+        jsonRpcCall("get_current_weather", {
+          latitude: 52.52,
+          longitude: 13.41,
+        }),
+      ),
+    });
+    const res = await parent.fetch(req, {} as never);
+    expect(res.status).toBe(200);
+    expect(timeoutCalls).toEqual([10_000]);
+    expect(fetchedSignals).toHaveLength(1);
+    expect(fetchedSignals[0]).toBeInstanceOf(AbortSignal);
+  });
+
+  test("crypto list_trending wires deadline", async () => {
+    const spy = mock((ms: number) => {
+      timeoutCalls.push(ms);
+      return realTimeout(ms);
+    });
+    (
+      AbortSignal as unknown as { timeout: typeof AbortSignal.timeout }
+    ).timeout = spy as unknown as typeof AbortSignal.timeout;
+
+    globalThis.fetch = mock(async (url: unknown, init?: RequestInit) => {
+      fetchedSignals.push(init?.signal);
+      const u = String(url);
+      if (u.includes("api.coingecko.com/api/v3/search/trending")) {
+        return Response.json({
+          coins: [{ item: { id: "bitcoin", name: "Bitcoin", symbol: "btc" } }],
+        });
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    }) as unknown as typeof fetch;
+
+    const { createMcpsTransportApp } = await import("./mcps-transport-gateway");
+    const { Hono } = await import("hono");
+    const bridge = createMcpsTransportApp("crypto");
+    const parent = new Hono();
+    parent.route("/:transport", bridge);
+    const req = new Request("http://example.test/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(jsonRpcCall("list_trending", {})),
+    });
+    const res = await parent.fetch(req, {} as never);
+    expect(res.status).toBe(200);
+    expect(timeoutCalls).toEqual([10_000]);
+    expect(fetchedSignals[0]).toBeInstanceOf(AbortSignal);
+  });
+
+  test("crypto get_price wires deadline", async () => {
+    const spy = mock((ms: number) => {
+      timeoutCalls.push(ms);
+      return realTimeout(ms);
+    });
+    (
+      AbortSignal as unknown as { timeout: typeof AbortSignal.timeout }
+    ).timeout = spy as unknown as typeof AbortSignal.timeout;
+
+    globalThis.fetch = mock(async (url: unknown, init?: RequestInit) => {
+      fetchedSignals.push(init?.signal);
+      const u = String(url);
+      if (u.includes("api.coingecko.com/api/v3/simple/price")) {
+        return Response.json({ bitcoin: { usd: 50000 } });
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    }) as unknown as typeof fetch;
+
+    const { createMcpsTransportApp } = await import("./mcps-transport-gateway");
+    const { Hono } = await import("hono");
+    const bridge = createMcpsTransportApp("crypto");
+    const parent = new Hono();
+    parent.route("/:transport", bridge);
+    const req = new Request("http://example.test/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(
+        jsonRpcCall("get_price", { coin: "bitcoin", currency: "usd" }),
+      ),
+    });
+    const res = await parent.fetch(req, {} as never);
+    expect(res.status).toBe(200);
+    expect(timeoutCalls).toEqual([10_000]);
+    expect(fetchedSignals[0]).toBeInstanceOf(AbortSignal);
+  });
+
+  test("crypto get_market_data wires deadline", async () => {
+    const spy = mock((ms: number) => {
+      timeoutCalls.push(ms);
+      return realTimeout(ms);
+    });
+    (
+      AbortSignal as unknown as { timeout: typeof AbortSignal.timeout }
+    ).timeout = spy as unknown as typeof AbortSignal.timeout;
+
+    globalThis.fetch = mock(async (url: unknown, init?: RequestInit) => {
+      fetchedSignals.push(init?.signal);
+      const u = String(url);
+      if (u.includes("api.coingecko.com/api/v3/coins/bitcoin")) {
+        return Response.json({
+          id: "bitcoin",
+          market_data: { current_price: { usd: 50000 } },
+        });
+      }
+      throw new Error(`unexpected fetch ${u}`);
+    }) as unknown as typeof fetch;
+
+    const { createMcpsTransportApp } = await import("./mcps-transport-gateway");
+    const { Hono } = await import("hono");
+    const bridge = createMcpsTransportApp("crypto");
+    const parent = new Hono();
+    parent.route("/:transport", bridge);
+    const req = new Request("http://example.test/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(jsonRpcCall("get_market_data", { coin: "bitcoin" })),
+    });
+    const res = await parent.fetch(req, {} as never);
+    expect(res.status).toBe(200);
+    expect(timeoutCalls).toEqual([10_000]);
+    expect(fetchedSignals[0]).toBeInstanceOf(AbortSignal);
+  });
+
+  test("aborts stalled response body at deadline", async () => {
+    const controller = new AbortController();
+    const spy = mock(() => {
+      timeoutCalls.push(10_000);
+      return controller.signal;
+    });
+    (
+      AbortSignal as unknown as { timeout: typeof AbortSignal.timeout }
+    ).timeout = spy as unknown as typeof AbortSignal.timeout;
+
+    let jsonStarted: (() => void) | undefined;
+    const jsonStartedPromise = new Promise<void>((resolve) => {
+      jsonStarted = resolve;
+    });
+
+    globalThis.fetch = mock(async (_url: unknown, init?: RequestInit) => {
+      fetchedSignals.push(init?.signal);
+      // Return headers immediately but stall body
+      const sig = init?.signal;
+      return {
+        ok: true,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => {
+          jsonStarted?.();
+          return new Promise<unknown>((_resolve, reject) => {
+            if (sig?.aborted) {
+              reject((sig as AbortSignal).reason);
+              return;
+            }
+            sig?.addEventListener(
+              "abort",
+              () => reject((sig as AbortSignal).reason),
+              { once: true },
+            );
+          });
+        },
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const { createMcpsTransportApp } = await import("./mcps-transport-gateway");
+    const { Hono } = await import("hono");
+    const bridge = createMcpsTransportApp("weather");
+    const parent = new Hono();
+    parent.route("/:transport", bridge);
+    const req = new Request("http://example.test/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(
+        jsonRpcCall("get_current_weather", {
+          latitude: 52.52,
+          longitude: 13.41,
+        }),
+      ),
+    });
+    const pending = parent.fetch(req, {} as never);
+    await jsonStartedPromise;
+    controller.abort(
+      new DOMException("MCP provider body deadline exceeded", "TimeoutError"),
+    );
+    const res = await pending;
+    expect([500, 200]).toContain(res.status);
+    expect(timeoutCalls).toEqual([10_000]);
+    expect(fetchedSignals[0]).toBe(controller.signal);
+  });
+
+  test("deadline abort is observable via signal", async () => {
+    const controller = new AbortController();
+    const spy = mock(() => {
+      timeoutCalls.push(10_000);
+      return controller.signal;
+    });
+    (
+      AbortSignal as unknown as { timeout: typeof AbortSignal.timeout }
+    ).timeout = spy as unknown as typeof AbortSignal.timeout;
+
+    let fetchStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      fetchStarted = resolve;
+    });
+
+    globalThis.fetch = mock(async (_url: unknown, init?: RequestInit) => {
+      fetchStarted?.();
+      return new Promise<Response>((_resolve, reject) => {
+        const sig = init?.signal;
+        if (sig?.aborted) {
+          reject((sig as AbortSignal).reason);
+          return;
+        }
+        sig?.addEventListener(
+          "abort",
+          () => reject((sig as AbortSignal).reason),
+          { once: true },
+        );
+      });
+    }) as unknown as typeof fetch;
+
+    const { createMcpsTransportApp } = await import("./mcps-transport-gateway");
+    const { Hono } = await import("hono");
+    const bridge = createMcpsTransportApp("crypto");
+    const parent = new Hono();
+    parent.route("/:transport", bridge);
+    const req = new Request("http://example.test/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(jsonRpcCall("list_trending", {})),
+    });
+    const pending = parent.fetch(req, {} as never);
+    await started;
+    controller.abort(
+      new DOMException("MCP provider deadline exceeded", "TimeoutError"),
+    );
+    const res = await pending;
+    expect([500, 200]).toContain(res.status);
+    expect(timeoutCalls).toEqual([10_000]);
+  });
+});

--- a/packages/cloud/api/src/lib/mcp/mcps-transport-gateway.timeout.test.ts
+++ b/packages/cloud/api/src/lib/mcp/mcps-transport-gateway.timeout.test.ts
@@ -307,7 +307,8 @@ describe("MCP built-in provider timeout", () => {
       new DOMException("MCP provider body deadline exceeded", "TimeoutError"),
     );
     const res = await pending;
-    expect([500, 200]).toContain(res.status);
+    expect(res.status).toBe(500);
+    expect(await res.text()).toBe("Internal Server Error");
     expect(timeoutCalls).toEqual([10_000]);
     expect(fetchedSignals[0]).toBe(controller.signal);
   });
@@ -359,7 +360,8 @@ describe("MCP built-in provider timeout", () => {
       new DOMException("MCP provider deadline exceeded", "TimeoutError"),
     );
     const res = await pending;
-    expect([500, 200]).toContain(res.status);
+    expect(res.status).toBe(500);
+    expect(await res.text()).toBe("Internal Server Error");
     expect(timeoutCalls).toEqual([10_000]);
   });
 });

--- a/packages/cloud/api/src/lib/mcp/mcps-transport-gateway.ts
+++ b/packages/cloud/api/src/lib/mcp/mcps-transport-gateway.ts
@@ -17,6 +17,8 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 const BUILTIN = new Set<string>(["time", "weather", "crypto"]);
 const COINGECKO = "https://api.coingecko.com/api/v3";
 
+export const MCP_PROVIDER_REQUEST_TIMEOUT_MS = 10_000;
+
 type JsonRpcId = string | number | null;
 type JsonObject = Record<string, unknown>;
 
@@ -248,6 +250,7 @@ async function geocode(query: string): Promise<GeocodeItem | null> {
   url.searchParams.set("language", "en");
   const res = await fetch(url.toString(), {
     headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(MCP_PROVIDER_REQUEST_TIMEOUT_MS),
   });
   if (!res.ok) return null;
   const data = (await res.json()) as GeocodeResponse;
@@ -338,6 +341,7 @@ async function callWeatherTool(
 
   const res = await fetch(forecastUrl.toString(), {
     headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(MCP_PROVIDER_REQUEST_TIMEOUT_MS),
   });
   if (!res.ok) return errorResult({ error: "Weather provider request failed" });
   const data = (await res.json()) as ForecastResponse;
@@ -359,6 +363,7 @@ async function callCryptoTool(
         Accept: "application/json",
         "User-Agent": "eliza-cloud-mcp/1.0",
       },
+      signal: AbortSignal.timeout(MCP_PROVIDER_REQUEST_TIMEOUT_MS),
     });
     if (!res.ok) return errorResult({ error: "CoinGecko trending failed" });
     const data = (await res.json()) as {
@@ -387,6 +392,7 @@ async function callCryptoTool(
         Accept: "application/json",
         "User-Agent": "eliza-cloud-mcp/1.0",
       },
+      signal: AbortSignal.timeout(MCP_PROVIDER_REQUEST_TIMEOUT_MS),
     });
     if (!res.ok) return errorResult({ error: "CoinGecko request failed" });
     const data = (await res.json()) as Record<string, Record<string, number>>;
@@ -406,6 +412,7 @@ async function callCryptoTool(
         Accept: "application/json",
         "User-Agent": "eliza-cloud-mcp/1.0",
       },
+      signal: AbortSignal.timeout(MCP_PROVIDER_REQUEST_TIMEOUT_MS),
     });
     if (!res.ok)
       return errorResult({ error: `CoinGecko error: ${res.status}` });


### PR DESCRIPTION
## Summary

- Export `MCP_PROVIDER_REQUEST_TIMEOUT_MS = 10_000` in `packages/cloud/api/src/lib/mcp/mcps-transport-gateway.ts`
- Wire `signal: AbortSignal.timeout(MCP_PROVIDER_REQUEST_TIMEOUT_MS)` to 5 bare `fetch`es in the Workers-safe gateway: `geocode` (geocoding-api.open-meteo.com), `callWeatherTool` forecast (api.open-meteo.com/v1/forecast), and 3 CoinGecko hops (`search/trending`, `simple/price`, `coins/:id`)
- A stalled Open-Meteo or CoinGecko endpoint no longer hangs the `time`/`weather`/`crypto` MCP tool calls; the hop aborts at 10s and surfaces as a provider error (fail-closed)

Fixes #23257 — follow-up to approved timeout precedent `fix(mcp): bound registry marketplace search pagination` (#22670) and `fix(cloud/gateways): bound EndpointSlice resolution with timeout` (#22658) — same `AbortSignal.timeout` pattern, single-unit churn.

## Verification

- `bun test packages/cloud/api/src/lib/mcp/mcps-transport-gateway.timeout.test.ts` — **8 passed, 0 failed** (26 expects)
  - `exports 10-second provider deadline`
  - `weather search_location wires deadline to geocoding fetch`
  - `weather get_current_weather wires deadline to forecast fetch`
  - `crypto list_trending wires deadline`
  - `crypto get_price wires deadline`
  - `crypto get_market_data wires deadline`
  - `aborts stalled response body at deadline` — returns headers then stalls `json()`, abort `TimeoutError` observable
  - `deadline abort is observable via signal` — pre-header stall (hanging fetch) abort observable
- `bun --cwd packages/cloud/api typecheck` — passed (wrangler dry-run, env bindings ok)
- `biome check` — 2 files clean, `git diff --check` — clean
- Merged exact `03e731a6e60ee1695faa7247861b5c8c454778bb`; both scoped blobs are byte-identical in merge `c7828dd057c5af0118912f0dff05a9bd7a6d8cf2`

## Evidence Gate

<!-- evidence-head:03e731a6e60ee1695faa7247861b5c8c454778bb -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; Workers-safe MCP gateway is headless Cloudflare Worker transport (no rendered pixels). Verified via deterministic unit coverage.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; same as before.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior is verified by the timeout unit tests that stall both headers and body.

<!-- evidence-row:backend-logs -->
- [x] [Exact landed audit receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23246-exact-03e731.log) — real timeout paths exercised via `parent.fetch` through the Hono bridge with mocked `fetch` and `AbortSignal.timeout` spy:

```log
bun test packages/cloud/api/src/lib/mcp/mcps-transport-gateway.timeout.test.ts
bun test v1.3.11 (af24e281)
  8 pass
  0 fail
  26 expect() calls
Ran 8 tests across 1 file. [147ms]
typecheck: wrangler dry-run exiting now.
biome: 2 files clean
git diff --check: clean
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved; this is a Worker-only MCP transport with no browser console or network trace.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change; this is a Worker fetch-timeout bound, not an LLM trajectory.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = abort signal wiring on every provider hop, proven by 8 deterministic tests:

```log
Each hop asserts AbortSignal.timeout called with 10_000 and init.signal is AbortSignal instance
Two abort-observable tests cover pre-header stall (hanging fetch) and body stall (headers ok, json() hanging), and require the real Hono boundary to return 500 Internal Server Error
All 8 tests pass; without signal they would hang or miss timeout
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface; headless Worker transport has no OCR text.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e927af91aca08403dfb6e9ec7c3c3518692b7bc1:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`


