### PR TITLE
fix(security): replace ambiguous regex scanners

### DIFF
--- a/packages/agent/src/runtime/tool-call-cache/redact.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/redact.test.ts
@@ -77,6 +77,24 @@ describe("defaultPrivacyRedactor", () => {
     expect(defaultPrivacyRedactor(input)).toBe("{[REDACTED_GEO]}");
   });
 
+  it("scans many overlapping malformed coordinate candidates in linear time", () => {
+    // Every "coords" marker starts a candidate whose scan runs to the end of
+    // the unterminated input; a non-monotonic cursor would rescan each
+    // remaining suffix and go quadratic.
+    const input = '"coords":{"latitude":0,"longitude":0,'.repeat(50_000);
+    const out = defaultPrivacyRedactor(input) as string;
+    expect(out).toContain("[REDACTED_GEO]");
+    expect(out).not.toContain('"latitude":0');
+  });
+
+  it("still redacts a valid coords block after malformed candidates", () => {
+    const out = defaultPrivacyRedactor(
+      '"coords": nope, "coords" {}, {"coords":{"latitude":1.5,"longitude":2.5}}',
+    ) as string;
+    expect(out).toContain("{[REDACTED_GEO]}");
+    expect(out).not.toContain("1.5");
+  });
+
   it("redacts lat/lng pair", () => {
     const out = defaultPrivacyRedactor(
       '{"latitude": 48.8566, "longitude": 2.3522}',

--- a/packages/agent/src/runtime/tool-call-cache/redact.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/redact.test.ts
@@ -65,6 +65,18 @@ describe("defaultPrivacyRedactor", () => {
     expect(out).not.toContain("37.7749");
   });
 
+  it("redacts coordinate objects with additional scalar fields", () => {
+    const out = defaultPrivacyRedactor(
+      '{"coords" : { "latitude" : 37.7749, "longitude" : -122.4194, "accuracy" : 12, "source_name": "gps" }}',
+    ) as string;
+    expect(out).toBe("{[REDACTED_GEO]}");
+  });
+
+  it("scans adversarial coordinate-like text in linear time", () => {
+    const input = `{"coords":{"latitude":0,"longitude":0${',"A":+\t'.repeat(50_000)}}}`;
+    expect(defaultPrivacyRedactor(input)).toBe("{[REDACTED_GEO]}");
+  });
+
   it("redacts lat/lng pair", () => {
     const out = defaultPrivacyRedactor(
       '{"latitude": 48.8566, "longitude": 2.3522}',

--- a/packages/agent/src/runtime/tool-call-cache/redact.ts
+++ b/packages/agent/src/runtime/tool-call-cache/redact.ts
@@ -105,35 +105,45 @@ function scanIdentifierKey(input: string, start: number): number | null {
   return null;
 }
 
-function scanCoordsBlock(input: string, start: number): number | null {
+type CoordsScan =
+  | { matched: true; end: number }
+  | { matched: false; resumeAt: number };
+
+// On failure the scan reports how far it walked so the caller never rescans a
+// rejected span. Skipping it is provably safe: the sub-scans (whitespace,
+// number, identifier key) can never contain `"` or `}`, and value scans stop
+// at — never consume — `}`, so any complete coords block inside the span would
+// have terminated this scan successfully instead of letting it fail.
+function scanCoordsBlock(input: string, start: number): CoordsScan {
   let cursor = skipWhitespace(input, start + COORDS_MARKER.length);
-  if (input[cursor] !== ":") return null;
+  const fail = (): CoordsScan => ({ matched: false, resumeAt: cursor });
+  if (input[cursor] !== ":") return fail();
   cursor = skipWhitespace(input, cursor + 1);
-  if (input[cursor] !== "{") return null;
+  if (input[cursor] !== "{") return fail();
   cursor = skipWhitespace(input, cursor + 1);
-  if (!input.startsWith(LATITUDE_MARKER, cursor)) return null;
+  if (!input.startsWith(LATITUDE_MARKER, cursor)) return fail();
   cursor = skipWhitespace(input, cursor + LATITUDE_MARKER.length);
-  if (input[cursor] !== ":") return null;
+  if (input[cursor] !== ":") return fail();
   cursor = skipWhitespace(input, cursor + 1);
   const latitudeEnd = scanNumber(input, cursor);
-  if (latitudeEnd === null) return null;
+  if (latitudeEnd === null) return fail();
   cursor = skipWhitespace(input, latitudeEnd);
-  if (input[cursor] !== ",") return null;
+  if (input[cursor] !== ",") return fail();
   cursor = skipWhitespace(input, cursor + 1);
-  if (!input.startsWith(LONGITUDE_MARKER, cursor)) return null;
+  if (!input.startsWith(LONGITUDE_MARKER, cursor)) return fail();
   cursor = skipWhitespace(input, cursor + LONGITUDE_MARKER.length);
-  if (input[cursor] !== ":") return null;
+  if (input[cursor] !== ":") return fail();
   cursor = skipWhitespace(input, cursor + 1);
   const longitudeEnd = scanNumber(input, cursor);
-  if (longitudeEnd === null) return null;
+  if (longitudeEnd === null) return fail();
   cursor = skipWhitespace(input, longitudeEnd);
 
   while (input[cursor] === ",") {
     cursor = skipWhitespace(input, cursor + 1);
     const keyEnd = scanIdentifierKey(input, cursor);
-    if (keyEnd === null) return null;
+    if (keyEnd === null) return fail();
     cursor = skipWhitespace(input, keyEnd);
-    if (input[cursor] !== ":") return null;
+    if (input[cursor] !== ":") return fail();
     cursor = skipWhitespace(input, cursor + 1);
     const valueStart = cursor;
     while (
@@ -143,30 +153,34 @@ function scanCoordsBlock(input: string, start: number): number | null {
     ) {
       cursor += 1;
     }
-    if (cursor === valueStart) return null;
+    if (cursor === valueStart) return fail();
     cursor = skipWhitespace(input, cursor);
   }
 
-  return input[cursor] === "}" ? cursor + 1 : null;
+  return input[cursor] === "}" ? { matched: true, end: cursor + 1 } : fail();
 }
 
 function redactCoordsBlocks(input: string): string {
   let searchFrom = 0;
   let copiedThrough = 0;
   let output = "";
+  let matchedAny = false;
   while (searchFrom < input.length) {
     const start = input.indexOf(COORDS_MARKER, searchFrom);
     if (start === -1) break;
-    const end = scanCoordsBlock(input, start);
-    if (end === null) {
-      searchFrom = start + COORDS_MARKER.length;
+    const scan = scanCoordsBlock(input, start);
+    if (!scan.matched) {
+      // Monotonic cursor: never re-walk a failed candidate span, so total
+      // work stays linear even with many overlapping malformed candidates.
+      searchFrom = Math.max(start + COORDS_MARKER.length, scan.resumeAt);
       continue;
     }
+    matchedAny = true;
     output += `${input.slice(copiedThrough, start)}[REDACTED_GEO]`;
-    copiedThrough = end;
-    searchFrom = end;
+    copiedThrough = scan.end;
+    searchFrom = scan.end;
   }
-  return copiedThrough === 0 ? input : output + input.slice(copiedThrough);
+  return matchedAny ? output + input.slice(copiedThrough) : input;
 }
 
 function snapshotEnvCredentials(): string[] {

--- a/packages/agent/src/runtime/tool-call-cache/redact.ts
+++ b/packages/agent/src/runtime/tool-call-cache/redact.ts
@@ -23,7 +23,6 @@ const CREDENTIAL_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
 ];
 
 const GEO_PATTERNS: RegExp[] = [
-  /"coords"\s*:\s*\{\s*"latitude"\s*:\s*-?\d+(?:\.\d+)?\s*,\s*"longitude"\s*:\s*-?\d+(?:\.\d+)?(?:\s*,\s*"[A-Za-z_][A-Za-z0-9_]*"\s*:\s*[^,}]+)*\s*\}/g,
   /"latitude"\s*:\s*-?\d+(?:\.\d+)?\s*,\s*"longitude"\s*:\s*-?\d+(?:\.\d+)?/g,
   /\b(?:current\s+location|location|coords|coordinates)\s*[:=]\s*-?\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?/gi,
   /\b(?:lat|latitude)\s*[:=]\s*-?\d+(?:\.\d+)?\s*[,;]\s*(?:lng|lon|long|longitude)\s*[:=]\s*-?\d+(?:\.\d+)?/gi,
@@ -31,6 +30,144 @@ const GEO_PATTERNS: RegExp[] = [
 ];
 
 const SECRET_NAME = /KEY|TOKEN|SECRET|PASSWORD|API|CREDENTIAL/i;
+const COORDS_MARKER = '"coords"';
+const LATITUDE_MARKER = '"latitude"';
+const LONGITUDE_MARKER = '"longitude"';
+
+function skipWhitespace(input: string, start: number): number {
+  let cursor = start;
+  while (cursor < input.length) {
+    const code = input.charCodeAt(cursor);
+    const whitespace =
+      (code >= 9 && code <= 13) ||
+      code === 32 ||
+      code === 160 ||
+      code === 5760 ||
+      (code >= 8192 && code <= 8202) ||
+      code === 8232 ||
+      code === 8233 ||
+      code === 8239 ||
+      code === 8287 ||
+      code === 12288 ||
+      code === 65279;
+    if (!whitespace) break;
+    cursor += 1;
+  }
+  return cursor;
+}
+
+function scanNumber(input: string, start: number): number | null {
+  let cursor = start;
+  if (input[cursor] === "-") cursor += 1;
+  const integerStart = cursor;
+  while (
+    cursor < input.length &&
+    input.charCodeAt(cursor) >= 48 &&
+    input.charCodeAt(cursor) <= 57
+  ) {
+    cursor += 1;
+  }
+  if (cursor === integerStart) return null;
+  if (input[cursor] !== ".") return cursor;
+  cursor += 1;
+  const fractionStart = cursor;
+  while (
+    cursor < input.length &&
+    input.charCodeAt(cursor) >= 48 &&
+    input.charCodeAt(cursor) <= 57
+  ) {
+    cursor += 1;
+  }
+  return cursor === fractionStart ? null : cursor;
+}
+
+function scanIdentifierKey(input: string, start: number): number | null {
+  if (input[start] !== '"') return null;
+  let cursor = start + 1;
+  const first = input.charCodeAt(cursor);
+  const firstValid =
+    (first >= 65 && first <= 90) ||
+    (first >= 97 && first <= 122) ||
+    first === 95;
+  if (!firstValid) return null;
+  cursor += 1;
+  while (cursor < input.length) {
+    const code = input.charCodeAt(cursor);
+    if (code === 34) return cursor + 1;
+    const valid =
+      (code >= 48 && code <= 57) ||
+      (code >= 65 && code <= 90) ||
+      (code >= 97 && code <= 122) ||
+      code === 95;
+    if (!valid) return null;
+    cursor += 1;
+  }
+  return null;
+}
+
+function scanCoordsBlock(input: string, start: number): number | null {
+  let cursor = skipWhitespace(input, start + COORDS_MARKER.length);
+  if (input[cursor] !== ":") return null;
+  cursor = skipWhitespace(input, cursor + 1);
+  if (input[cursor] !== "{") return null;
+  cursor = skipWhitespace(input, cursor + 1);
+  if (!input.startsWith(LATITUDE_MARKER, cursor)) return null;
+  cursor = skipWhitespace(input, cursor + LATITUDE_MARKER.length);
+  if (input[cursor] !== ":") return null;
+  cursor = skipWhitespace(input, cursor + 1);
+  const latitudeEnd = scanNumber(input, cursor);
+  if (latitudeEnd === null) return null;
+  cursor = skipWhitespace(input, latitudeEnd);
+  if (input[cursor] !== ",") return null;
+  cursor = skipWhitespace(input, cursor + 1);
+  if (!input.startsWith(LONGITUDE_MARKER, cursor)) return null;
+  cursor = skipWhitespace(input, cursor + LONGITUDE_MARKER.length);
+  if (input[cursor] !== ":") return null;
+  cursor = skipWhitespace(input, cursor + 1);
+  const longitudeEnd = scanNumber(input, cursor);
+  if (longitudeEnd === null) return null;
+  cursor = skipWhitespace(input, longitudeEnd);
+
+  while (input[cursor] === ",") {
+    cursor = skipWhitespace(input, cursor + 1);
+    const keyEnd = scanIdentifierKey(input, cursor);
+    if (keyEnd === null) return null;
+    cursor = skipWhitespace(input, keyEnd);
+    if (input[cursor] !== ":") return null;
+    cursor = skipWhitespace(input, cursor + 1);
+    const valueStart = cursor;
+    while (
+      cursor < input.length &&
+      input[cursor] !== "," &&
+      input[cursor] !== "}"
+    ) {
+      cursor += 1;
+    }
+    if (cursor === valueStart) return null;
+    cursor = skipWhitespace(input, cursor);
+  }
+
+  return input[cursor] === "}" ? cursor + 1 : null;
+}
+
+function redactCoordsBlocks(input: string): string {
+  let searchFrom = 0;
+  let copiedThrough = 0;
+  let output = "";
+  while (searchFrom < input.length) {
+    const start = input.indexOf(COORDS_MARKER, searchFrom);
+    if (start === -1) break;
+    const end = scanCoordsBlock(input, start);
+    if (end === null) {
+      searchFrom = start + COORDS_MARKER.length;
+      continue;
+    }
+    output += `${input.slice(copiedThrough, start)}[REDACTED_GEO]`;
+    copiedThrough = end;
+    searchFrom = end;
+  }
+  return copiedThrough === 0 ? input : output + input.slice(copiedThrough);
+}
 
 function snapshotEnvCredentials(): string[] {
   const out: string[] = [];
@@ -43,7 +180,7 @@ function snapshotEnvCredentials(): string[] {
 }
 
 function redactString(input: string, envValues: string[]): string {
-  let out = input;
+  let out = redactCoordsBlocks(input);
   for (const pattern of GEO_PATTERNS) {
     out = out.replace(pattern, "[REDACTED_GEO]");
   }

--- a/packages/scenario-runner/src/native-export.test.ts
+++ b/packages/scenario-runner/src/native-export.test.ts
@@ -541,6 +541,47 @@ describe("exportScenarioNativeJsonl", () => {
     }
   });
 
+  it("redacts across many overlapping malformed coordinate candidates in linear time", () => {
+    const runDir = mkdtempSync(path.join(tmpdir(), "scenario-native-coords2-"));
+    try {
+      const trajDir = path.join(runDir, "trajectories", "agent-test");
+      mkdirSync(trajDir, { recursive: true });
+      const trajectory = syntheticTrajectory() as ReturnType<
+        typeof syntheticTrajectory
+      >;
+      const planner = trajectory.stages[1];
+      if (!planner || !("model" in planner) || !planner.model) {
+        throw new Error("synthetic planner stage missing");
+      }
+      // Every "coords" marker starts a candidate whose scan runs to the end of
+      // the unterminated tail; a non-monotonic cursor would rescan each
+      // remaining suffix and go quadratic. The valid block at the front must
+      // still be redacted, and the pair pattern catches the malformed tail.
+      planner.model.response = `{"coords":{"latitude":3.25,"longitude":4.5}}${'"coords":{"latitude":0,"longitude":0,'.repeat(50_000)}`;
+      writeFileSync(
+        path.join(trajDir, "tj-test-1.json"),
+        JSON.stringify(trajectory),
+        "utf-8",
+      );
+
+      const outPath = path.join(runDir, "native.jsonl");
+      expect(exportScenarioNativeJsonl(runDir, outPath)).toBe(1);
+      const body = readFileSync(outPath, "utf-8");
+      expect(body).toContain("[REDACTED_GEO]");
+      expect(body).not.toContain("3.25");
+      expect(body).not.toContain('latitude\\":0');
+      const attestation = JSON.parse(
+        readFileSync(
+          path.join(runDir, "native.privacy-attestation.json"),
+          "utf-8",
+        ),
+      );
+      expect(attestation.categories.geo).toBeGreaterThanOrEqual(2);
+    } finally {
+      rmSync(runDir, { recursive: true, force: true });
+    }
+  });
+
   it("labels scenario native exports as synthetic, not a reviewed real-user export (#13623)", () => {
     const runDir = mkdtempSync(path.join(tmpdir(), "scenario-native-src-"));
     try {

--- a/packages/scenario-runner/src/native-export.test.ts
+++ b/packages/scenario-runner/src/native-export.test.ts
@@ -504,6 +504,43 @@ describe("exportScenarioNativeJsonl", () => {
     }
   });
 
+  it("redacts long coordinate objects without regex backtracking", () => {
+    const runDir = mkdtempSync(path.join(tmpdir(), "scenario-native-coords-"));
+    try {
+      const trajDir = path.join(runDir, "trajectories", "agent-test");
+      mkdirSync(trajDir, { recursive: true });
+      const trajectory = syntheticTrajectory() as ReturnType<
+        typeof syntheticTrajectory
+      >;
+      const planner = trajectory.stages[1];
+      if (!planner || !("model" in planner) || !planner.model) {
+        throw new Error("synthetic planner stage missing");
+      }
+      planner.model.response = `{"coords":{"latitude":0,"longitude":0${',"A":+\t'.repeat(50_000)}}}`;
+      writeFileSync(
+        path.join(trajDir, "tj-test-1.json"),
+        JSON.stringify(trajectory),
+        "utf-8",
+      );
+
+      const outPath = path.join(runDir, "native.jsonl");
+      expect(exportScenarioNativeJsonl(runDir, outPath)).toBe(1);
+      const body = readFileSync(outPath, "utf-8");
+      expect(body).toContain("[REDACTED_GEO]");
+      expect(body).not.toContain('"latitude":0');
+      const attestation = JSON.parse(
+        readFileSync(
+          path.join(runDir, "native.privacy-attestation.json"),
+          "utf-8",
+        ),
+      );
+      expect(attestation.redaction_count).toBeGreaterThanOrEqual(1);
+      expect(attestation.categories.geo).toBeGreaterThanOrEqual(1);
+    } finally {
+      rmSync(runDir, { recursive: true, force: true });
+    }
+  });
+
   it("labels scenario native exports as synthetic, not a reviewed real-user export (#13623)", () => {
     const runDir = mkdtempSync(path.join(tmpdir(), "scenario-native-src-"));
     try {

--- a/packages/scenario-runner/src/native-export.ts
+++ b/packages/scenario-runner/src/native-export.ts
@@ -455,35 +455,48 @@ function scanPrivacyIdentifierKey(input: string, start: number): number | null {
   return null;
 }
 
-function scanCoordsPrivacyBlock(input: string, start: number): number | null {
+type CoordsPrivacyScan =
+  | { matched: true; end: number }
+  | { matched: false; resumeAt: number };
+
+// On failure the scan reports how far it walked so the caller never rescans a
+// rejected span. Skipping it is provably safe: the sub-scans (whitespace,
+// number, identifier key) can never contain `"` or `}`, and value scans stop
+// at — never consume — `}`, so any complete coords block inside the span would
+// have terminated this scan successfully instead of letting it fail.
+function scanCoordsPrivacyBlock(
+  input: string,
+  start: number,
+): CoordsPrivacyScan {
   let cursor = skipPrivacyWhitespace(input, start + COORDS_MARKER.length);
-  if (input[cursor] !== ":") return null;
+  const fail = (): CoordsPrivacyScan => ({ matched: false, resumeAt: cursor });
+  if (input[cursor] !== ":") return fail();
   cursor = skipPrivacyWhitespace(input, cursor + 1);
-  if (input[cursor] !== "{") return null;
+  if (input[cursor] !== "{") return fail();
   cursor = skipPrivacyWhitespace(input, cursor + 1);
-  if (!input.startsWith(LATITUDE_MARKER, cursor)) return null;
+  if (!input.startsWith(LATITUDE_MARKER, cursor)) return fail();
   cursor = skipPrivacyWhitespace(input, cursor + LATITUDE_MARKER.length);
-  if (input[cursor] !== ":") return null;
+  if (input[cursor] !== ":") return fail();
   cursor = skipPrivacyWhitespace(input, cursor + 1);
   const latitudeEnd = scanPrivacyNumber(input, cursor);
-  if (latitudeEnd === null) return null;
+  if (latitudeEnd === null) return fail();
   cursor = skipPrivacyWhitespace(input, latitudeEnd);
-  if (input[cursor] !== ",") return null;
+  if (input[cursor] !== ",") return fail();
   cursor = skipPrivacyWhitespace(input, cursor + 1);
-  if (!input.startsWith(LONGITUDE_MARKER, cursor)) return null;
+  if (!input.startsWith(LONGITUDE_MARKER, cursor)) return fail();
   cursor = skipPrivacyWhitespace(input, cursor + LONGITUDE_MARKER.length);
-  if (input[cursor] !== ":") return null;
+  if (input[cursor] !== ":") return fail();
   cursor = skipPrivacyWhitespace(input, cursor + 1);
   const longitudeEnd = scanPrivacyNumber(input, cursor);
-  if (longitudeEnd === null) return null;
+  if (longitudeEnd === null) return fail();
   cursor = skipPrivacyWhitespace(input, longitudeEnd);
 
   while (input[cursor] === ",") {
     cursor = skipPrivacyWhitespace(input, cursor + 1);
     const keyEnd = scanPrivacyIdentifierKey(input, cursor);
-    if (keyEnd === null) return null;
+    if (keyEnd === null) return fail();
     cursor = skipPrivacyWhitespace(input, keyEnd);
-    if (input[cursor] !== ":") return null;
+    if (input[cursor] !== ":") return fail();
     cursor = skipPrivacyWhitespace(input, cursor + 1);
     const valueStart = cursor;
     while (
@@ -493,10 +506,10 @@ function scanCoordsPrivacyBlock(input: string, start: number): number | null {
     ) {
       cursor += 1;
     }
-    if (cursor === valueStart) return null;
+    if (cursor === valueStart) return fail();
     cursor = skipPrivacyWhitespace(input, cursor);
   }
-  return input[cursor] === "}" ? cursor + 1 : null;
+  return input[cursor] === "}" ? { matched: true, end: cursor + 1 } : fail();
 }
 
 function redactCoordsPrivacyBlocks(
@@ -506,20 +519,24 @@ function redactCoordsPrivacyBlocks(
   let searchFrom = 0;
   let copiedThrough = 0;
   let output = "";
+  let matchedAny = false;
   while (searchFrom < input.length) {
     const start = input.indexOf(COORDS_MARKER, searchFrom);
     if (start === -1) break;
-    const end = scanCoordsPrivacyBlock(input, start);
-    if (end === null) {
-      searchFrom = start + COORDS_MARKER.length;
+    const scan = scanCoordsPrivacyBlock(input, start);
+    if (!scan.matched) {
+      // Monotonic cursor: never re-walk a failed candidate span, so total
+      // work stays linear even with many overlapping malformed candidates.
+      searchFrom = Math.max(start + COORDS_MARKER.length, scan.resumeAt);
       continue;
     }
+    matchedAny = true;
     output += `${input.slice(copiedThrough, start)}${GEO_REPLACEMENT}`;
-    copiedThrough = end;
-    searchFrom = end;
+    copiedThrough = scan.end;
+    searchFrom = scan.end;
     noteRedaction(stats, "geo", "coords-json-block");
   }
-  return copiedThrough === 0 ? input : output + input.slice(copiedThrough);
+  return matchedAny ? output + input.slice(copiedThrough) : input;
 }
 
 function noteResidual(stats: PrivacyFilterStats, label: string): void {

--- a/packages/scenario-runner/src/native-export.ts
+++ b/packages/scenario-runner/src/native-export.ts
@@ -270,6 +270,9 @@ const ORCHESTRATOR_NATIVE_TASKS = ["goal_verification"] as const;
 const ORCHESTRATOR_NATIVE_TASK_SET = new Set<string>(ORCHESTRATOR_NATIVE_TASKS);
 
 const GEO_REPLACEMENT = "[REDACTED_GEO]" as const;
+const COORDS_MARKER = '"coords"';
+const LATITUDE_MARKER = '"latitude"';
+const LONGITUDE_MARKER = '"longitude"';
 const PRIVACY_CATEGORIES: PrivacyCategory[] = [
   "secret",
   "geo",
@@ -306,13 +309,6 @@ const PRIVACY_PATTERNS: PrivacyFilterPattern[] = [
     label: "aws-access-key",
     pattern: /\bAKIA[0-9A-Z]{16}\b/g,
     replacement: "<REDACTED:aws-access-key>",
-  },
-  {
-    category: "geo",
-    label: "coords-json-block",
-    pattern:
-      /"coords"\s*:\s*\{\s*"latitude"\s*:\s*-?\d+(?:\.\d+)?\s*,\s*"longitude"\s*:\s*-?\d+(?:\.\d+)?(?:\s*,\s*"[A-Za-z_][A-Za-z0-9_]*"\s*:\s*[^,}]+)*\s*\}/g,
-    replacement: GEO_REPLACEMENT,
   },
   {
     category: "geo",
@@ -390,6 +386,140 @@ function noteRedaction(
   stats.redactionsTotal += 1;
   stats.redactionsByCategory[category] += 1;
   stats.redactionsByLabel[label] = (stats.redactionsByLabel[label] ?? 0) + 1;
+}
+
+function skipPrivacyWhitespace(input: string, start: number): number {
+  let cursor = start;
+  while (cursor < input.length) {
+    const code = input.charCodeAt(cursor);
+    const whitespace =
+      (code >= 9 && code <= 13) ||
+      code === 32 ||
+      code === 160 ||
+      code === 5760 ||
+      (code >= 8192 && code <= 8202) ||
+      code === 8232 ||
+      code === 8233 ||
+      code === 8239 ||
+      code === 8287 ||
+      code === 12288 ||
+      code === 65279;
+    if (!whitespace) break;
+    cursor += 1;
+  }
+  return cursor;
+}
+
+function scanPrivacyNumber(input: string, start: number): number | null {
+  let cursor = start;
+  if (input[cursor] === "-") cursor += 1;
+  const integerStart = cursor;
+  while (cursor < input.length) {
+    const code = input.charCodeAt(cursor);
+    if (code < 48 || code > 57) break;
+    cursor += 1;
+  }
+  if (cursor === integerStart) return null;
+  if (input[cursor] !== ".") return cursor;
+  cursor += 1;
+  const fractionStart = cursor;
+  while (cursor < input.length) {
+    const code = input.charCodeAt(cursor);
+    if (code < 48 || code > 57) break;
+    cursor += 1;
+  }
+  return cursor === fractionStart ? null : cursor;
+}
+
+function scanPrivacyIdentifierKey(input: string, start: number): number | null {
+  if (input[start] !== '"') return null;
+  let cursor = start + 1;
+  const first = input.charCodeAt(cursor);
+  const firstValid =
+    (first >= 65 && first <= 90) ||
+    (first >= 97 && first <= 122) ||
+    first === 95;
+  if (!firstValid) return null;
+  cursor += 1;
+  while (cursor < input.length) {
+    const code = input.charCodeAt(cursor);
+    if (code === 34) return cursor + 1;
+    const valid =
+      (code >= 48 && code <= 57) ||
+      (code >= 65 && code <= 90) ||
+      (code >= 97 && code <= 122) ||
+      code === 95;
+    if (!valid) return null;
+    cursor += 1;
+  }
+  return null;
+}
+
+function scanCoordsPrivacyBlock(input: string, start: number): number | null {
+  let cursor = skipPrivacyWhitespace(input, start + COORDS_MARKER.length);
+  if (input[cursor] !== ":") return null;
+  cursor = skipPrivacyWhitespace(input, cursor + 1);
+  if (input[cursor] !== "{") return null;
+  cursor = skipPrivacyWhitespace(input, cursor + 1);
+  if (!input.startsWith(LATITUDE_MARKER, cursor)) return null;
+  cursor = skipPrivacyWhitespace(input, cursor + LATITUDE_MARKER.length);
+  if (input[cursor] !== ":") return null;
+  cursor = skipPrivacyWhitespace(input, cursor + 1);
+  const latitudeEnd = scanPrivacyNumber(input, cursor);
+  if (latitudeEnd === null) return null;
+  cursor = skipPrivacyWhitespace(input, latitudeEnd);
+  if (input[cursor] !== ",") return null;
+  cursor = skipPrivacyWhitespace(input, cursor + 1);
+  if (!input.startsWith(LONGITUDE_MARKER, cursor)) return null;
+  cursor = skipPrivacyWhitespace(input, cursor + LONGITUDE_MARKER.length);
+  if (input[cursor] !== ":") return null;
+  cursor = skipPrivacyWhitespace(input, cursor + 1);
+  const longitudeEnd = scanPrivacyNumber(input, cursor);
+  if (longitudeEnd === null) return null;
+  cursor = skipPrivacyWhitespace(input, longitudeEnd);
+
+  while (input[cursor] === ",") {
+    cursor = skipPrivacyWhitespace(input, cursor + 1);
+    const keyEnd = scanPrivacyIdentifierKey(input, cursor);
+    if (keyEnd === null) return null;
+    cursor = skipPrivacyWhitespace(input, keyEnd);
+    if (input[cursor] !== ":") return null;
+    cursor = skipPrivacyWhitespace(input, cursor + 1);
+    const valueStart = cursor;
+    while (
+      cursor < input.length &&
+      input[cursor] !== "," &&
+      input[cursor] !== "}"
+    ) {
+      cursor += 1;
+    }
+    if (cursor === valueStart) return null;
+    cursor = skipPrivacyWhitespace(input, cursor);
+  }
+  return input[cursor] === "}" ? cursor + 1 : null;
+}
+
+function redactCoordsPrivacyBlocks(
+  input: string,
+  stats: PrivacyFilterStats,
+): string {
+  let searchFrom = 0;
+  let copiedThrough = 0;
+  let output = "";
+  while (searchFrom < input.length) {
+    const start = input.indexOf(COORDS_MARKER, searchFrom);
+    if (start === -1) break;
+    const end = scanCoordsPrivacyBlock(input, start);
+    if (end === null) {
+      searchFrom = start + COORDS_MARKER.length;
+      continue;
+    }
+    output += `${input.slice(copiedThrough, start)}${GEO_REPLACEMENT}`;
+    copiedThrough = end;
+    searchFrom = end;
+    noteRedaction(stats, "geo", "coords-json-block");
+  }
+  return copiedThrough === 0 ? input : output + input.slice(copiedThrough);
 }
 
 function noteResidual(stats: PrivacyFilterStats, label: string): void {
@@ -473,7 +603,7 @@ function redactEmailContacts(text: string, stats: PrivacyFilterStats): string {
 }
 
 function filterPrivacyText(text: string, stats: PrivacyFilterStats): string {
-  let out = redactEmailContacts(text, stats);
+  let out = redactCoordsPrivacyBlocks(redactEmailContacts(text, stats), stats);
   for (const spec of PRIVACY_PATTERNS) {
     out = out.replace(spec.pattern, () => {
       noteRedaction(stats, spec.category, spec.label);

--- a/packages/scripts/__tests__/ci-bun-version-contract.test.ts
+++ b/packages/scripts/__tests__/ci-bun-version-contract.test.ts
@@ -20,9 +20,6 @@
  * (fail-fast, not skip). Deterministic — no workflow runs, no network.
  */
 import { describe, expect, test } from "bun:test";
-// Bun's test runner can return empty stdio pipes from node:child_process
-// spawnSync; the captured adapter routes output through files instead.
-import { spawnSync } from "../lib/spawn-sync-captured.mjs";
 import {
   mkdirSync,
   mkdtempSync,
@@ -33,8 +30,11 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+// Bun's test runner can return empty stdio pipes from node:child_process
+// spawnSync; the captured adapter routes output through files instead.
+import { spawnSync } from "../lib/spawn-sync-captured.mjs";
 
-const { runContract, classifyTypeRange } = await import(
+const { runContract, classifyTypeRange, isConcretePin } = await import(
   new URL("../ci-bun-version-contract.mjs", import.meta.url).href
 );
 
@@ -182,6 +182,13 @@ function inventoryOf(
 }
 
 describe("ci-bun-version-contract", () => {
+  test("parses concrete versions without backtracking on long invalid suffixes", () => {
+    expect(isConcretePin("1.3.14")).toBe(true);
+    expect(isConcretePin("1.3.14-canary.1+darwin-arm64")).toBe(true);
+    expect(isConcretePin(`0.0.0+${"--".repeat(100_000)}!`)).toBe(false);
+    expect(isConcretePin(`0.0.0-${"a.".repeat(100_000)}`)).toBe(false);
+  });
+
   test("passes a clean tree with every gate pinned to canonical", () => {
     const root = buildRepo({});
     try {

--- a/packages/scripts/ci-bun-version-contract.mjs
+++ b/packages/scripts/ci-bun-version-contract.mjs
@@ -75,11 +75,11 @@
  * device-proven shipping boundary: they are inventoried as excluded, never
  * version-checked here.
  */
-import { spawnSync } from "./lib/spawn-sync-captured.mjs";
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { isMap, isScalar, isSeq, parseDocument } from "yaml";
+import { spawnSync } from "./lib/spawn-sync-captured.mjs";
 
 const DEFAULT_REPO_ROOT = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -159,8 +159,61 @@ const GATE_WORKFLOWS = [
 const CONTRACT_ENFORCEMENT_WORKFLOWS = new Set(["test.yml", "develop-pr.yml"]);
 
 // A concrete pin: a plain semver, optionally with a prerelease/build suffix.
-// `canary`, `latest`, and `${{ ... }}` expressions deliberately do not match.
-const CONCRETE_PIN = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*$/;
+// Parse it deterministically because nested suffix quantifiers let a malformed
+// version consume unbounded CI time before it is rejected.
+function scanSemverIdentifiers(value, start, stopAtBuild) {
+  let cursor = start;
+  let identifierLength = 0;
+  while (cursor < value.length) {
+    const code = value.charCodeAt(cursor);
+    if (stopAtBuild && code === 43) {
+      return identifierLength === 0 ? null : cursor;
+    }
+    if (code === 46) {
+      if (identifierLength === 0) return null;
+      identifierLength = 0;
+      cursor += 1;
+      continue;
+    }
+    const valid =
+      (code >= 48 && code <= 57) ||
+      (code >= 65 && code <= 90) ||
+      (code >= 97 && code <= 122) ||
+      code === 45;
+    if (!valid) return null;
+    identifierLength += 1;
+    cursor += 1;
+  }
+  return identifierLength === 0 ? null : cursor;
+}
+
+export function isConcretePin(value) {
+  if (typeof value !== "string" || value.length === 0) return false;
+  let cursor = 0;
+  for (let component = 0; component < 3; component += 1) {
+    const start = cursor;
+    while (cursor < value.length) {
+      const code = value.charCodeAt(cursor);
+      if (code < 48 || code > 57) break;
+      cursor += 1;
+    }
+    if (cursor === start) return false;
+    if (component < 2) {
+      if (value[cursor] !== ".") return false;
+      cursor += 1;
+    }
+  }
+  if (cursor === value.length) return true;
+  if (value[cursor] === "-") {
+    const prereleaseEnd = scanSemverIdentifiers(value, cursor + 1, true);
+    if (prereleaseEnd === null) return false;
+    cursor = prereleaseEnd;
+  }
+  if (cursor === value.length) return true;
+  if (value[cursor] !== "+") return false;
+  const buildEnd = scanSemverIdentifiers(value, cursor + 1, false);
+  return buildEnd === value.length;
+}
 const FLOATING = new Set(["canary", "latest"]);
 
 // Fixture-tree walk only (real repos are enumerated via git ls-files);
@@ -544,7 +597,7 @@ export function runContract(repoRoot = DEFAULT_REPO_ROOT, overrides = {}) {
 
   const manifest = JSON.parse(read(VERSION_FILE));
   const canonical = manifest.version;
-  if (typeof canonical !== "string" || !CONCRETE_PIN.test(canonical)) {
+  if (!isConcretePin(canonical)) {
     throw new Error(
       `${VERSION_FILE}: "version" must be a concrete Bun pin (semver), got ${JSON.stringify(canonical)}`,
     );
@@ -732,7 +785,7 @@ export function runContract(repoRoot = DEFAULT_REPO_ROOT, overrides = {}) {
         }
         continue;
       }
-      if (!CONCRETE_PIN.test(raw)) {
+      if (!isConcretePin(raw)) {
         record({ ...site, classification: "unparseable" });
         violate(
           `${rel}:${line}: unparseable Bun version value ${JSON.stringify(raw)} — pin the canonical ${canonical} (${VERSION_FILE}).`,
@@ -898,9 +951,14 @@ export function runContract(repoRoot = DEFAULT_REPO_ROOT, overrides = {}) {
         const pin = def
           ? null
           : line.match(
-              /^\s*(?:export\s+)?BUN_VERSION=["']?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*)["']?\s*(?:#.*)?$/,
+              /^\s*(?:export\s+)?BUN_VERSION=(?:"([^"]+)"|'([^']+)'|([^\s#]+))\s*(?:#.*)?$/,
             );
-        const value = def?.[1] ?? pin?.[1];
+        const pinValue = pin?.[1] ?? pin?.[2] ?? pin?.[3];
+        const value =
+          def?.[1] ??
+          (pinValue !== undefined && isConcretePin(pinValue)
+            ? pinValue
+            : undefined);
         if (value === undefined) continue;
         defaults.push({ line: i + 1, value });
         record({
@@ -918,10 +976,10 @@ export function runContract(repoRoot = DEFAULT_REPO_ROOT, overrides = {}) {
       }
     } else if (/\.mjs$/.test(rel)) {
       for (const [i, line] of lines.entries()) {
-        const def = line.match(
-          /\bBUN_VERSION\s*=\s*["'](\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*)["']/,
-        );
-        if (!def) continue;
+        const def =
+          line.match(/\bBUN_VERSION\s*=\s*"([^"]+)"/) ??
+          line.match(/\bBUN_VERSION\s*=\s*'([^']+)'/);
+        if (!def || !isConcretePin(def[1])) continue;
         defaults.push({ line: i + 1, value: def[1] });
         record({
           surface: "script-default",
@@ -942,10 +1000,11 @@ export function runContract(repoRoot = DEFAULT_REPO_ROOT, overrides = {}) {
       // workflow-shaped files, so validate the literal here).
       for (const [i, line] of lines.entries()) {
         const def = line.match(
-          /^\s*BUN_VERSION:\s*["']?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*)["']?\s*(?:#.*)?$/,
+          /^\s*BUN_VERSION:\s*(?:"([^"]+)"|'([^']+)'|([^\s#]+))\s*(?:#.*)?$/,
         );
-        if (!def) continue;
-        defaults.push({ line: i + 1, value: def[1] });
+        const value = def?.[1] ?? def?.[2] ?? def?.[3];
+        if (value === undefined || !isConcretePin(value)) continue;
+        defaults.push({ line: i + 1, value });
       }
     }
     scanInstallLines({

--- a/plugins/plugin-coding-tools/src/shell/utils/shellUtils.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/shellUtils.test.ts
@@ -6,7 +6,7 @@
  * the real exported chunkString.
  */
 import { describe, expect, it } from "vitest";
-import { chunkString } from "./shellUtils";
+import { chunkString, deriveSessionName } from "./shellUtils";
 
 const CHUNK_LIMIT = 8 * 1024;
 
@@ -44,5 +44,29 @@ describe("chunkString surrogate-safe chunking", () => {
 
   it("returns the input unchanged when within the limit", () => {
     expect(chunkString("hello world")).toEqual(["hello world"]);
+  });
+});
+
+describe("deriveSessionName command tokenization", () => {
+  it("preserves quoted targets and embedded quoted segments", () => {
+    expect(deriveSessionName('node "path with spaces.js" --watch')).toBe(
+      "node path with spaces.js",
+    );
+    expect(deriveSessionName('git refs/heads/"feature branch"')).toBe(
+      'git refs/heads/"feature branch"',
+    );
+  });
+
+  it("handles long unmatched quoted input without regex backtracking", () => {
+    const escaped = "\\!".repeat(100_000);
+    const name = deriveSessionName(`run "${escaped}`);
+    expect(name?.startsWith("run \\!\\!")).toBe(true);
+    expect(name?.length).toBeLessThanOrEqual("run ".length + 48);
+  });
+
+  it("handles both quote styles in adversarial input", () => {
+    const escaped = "\\&".repeat(100_000);
+    const name = deriveSessionName(`run '${escaped}`);
+    expect(name?.startsWith("run \\&\\&")).toBe(true);
   });
 });

--- a/plugins/plugin-coding-tools/src/shell/utils/shellUtils.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/shellUtils.test.ts
@@ -69,4 +69,12 @@ describe("deriveSessionName command tokenization", () => {
     const name = deriveSessionName(`run '${escaped}`);
     expect(name?.startsWith("run \\&\\&")).toBe(true);
   });
+
+  it("handles many unmatched quote delimiters in linear time", () => {
+    // Each quote's escape (\") consumes the next delimiter, so every
+    // unmatched-quote fallback used to rescan the remaining suffix and go
+    // quadratic; the bounded tokenization prefix caps that work.
+    const name = deriveSessionName(`run ${'"\\'.repeat(100_000)}`);
+    expect(name).toBe("run \\");
+  });
 });

--- a/plugins/plugin-coding-tools/src/shell/utils/shellUtils.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/shellUtils.ts
@@ -287,9 +287,52 @@ export function deriveSessionName(command: string): string | undefined {
 }
 
 function tokenizeCommand(command: string): string[] {
-  const matches =
-    command.match(/(?:[^\s"']+|"(?:\\.|[^"])*"|'(?:\\.|[^'])*')+/g) ?? [];
-  return matches.map((token) => stripQuotes(token)).filter(Boolean);
+  const tokens: string[] = [];
+  let token = "";
+  let cursor = 0;
+  const flush = () => {
+    if (!token) return;
+    const stripped = stripQuotes(token);
+    if (stripped) tokens.push(stripped);
+    token = "";
+  };
+
+  while (cursor < command.length) {
+    const char = command[cursor];
+    if (/\s/.test(char)) {
+      flush();
+      cursor += 1;
+      continue;
+    }
+    if (char !== '"' && char !== "'") {
+      token += char;
+      cursor += 1;
+      continue;
+    }
+
+    const quote = char;
+    let quoteEnd = cursor + 1;
+    while (quoteEnd < command.length) {
+      if (command[quoteEnd] === "\\" && quoteEnd + 1 < command.length) {
+        quoteEnd += 2;
+        continue;
+      }
+      if (command[quoteEnd] === quote) break;
+      quoteEnd += 1;
+    }
+    if (quoteEnd === command.length) {
+      // The former matcher skipped an unmatched delimiter and resumed at the
+      // following text. Preserve that behavior without repeatedly exploring
+      // alternate quoted/unquoted parses.
+      flush();
+      cursor += 1;
+      continue;
+    }
+    token += command.slice(cursor, quoteEnd + 1);
+    cursor = quoteEnd + 1;
+  }
+  flush();
+  return tokens;
 }
 
 function stripQuotes(value: string): string {

--- a/plugins/plugin-coding-tools/src/shell/utils/shellUtils.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/shellUtils.ts
@@ -286,7 +286,15 @@ export function deriveSessionName(command: string): string | undefined {
   return `${stripQuotes(verb)} ${cleaned}`;
 }
 
-function tokenizeCommand(command: string): string[] {
+// The derived session name only ever surfaces the leading verb and one
+// truncated target token, so tokenization never needs to look past a short
+// prefix. Bounding the input also bounds the unmatched-quote fallback below:
+// without it, many unmatched quote delimiters (each escaping the next quote)
+// would make every fallback rescan the remaining suffix, going quadratic.
+const TOKENIZE_LIMIT = 2048;
+
+function tokenizeCommand(rawCommand: string): string[] {
+  const command = rawCommand.slice(0, TOKENIZE_LIMIT);
   const tokens: string[] = [];
   let token = "";
   let cursor = 0;


### PR DESCRIPTION
## Summary

- replace coordinate-object redaction regexes with forward-only scanners
- replace ambiguous Bun-version assignment and SemVer parsing with disjoint deterministic parsing
- replace ambiguous shell quote tokenization with a one-pass scanner that preserves escapes and both quote styles
- add long adversarial regressions at each real boundary

This fixes CodeQL alerts #667, #834-#838, #896, and #897 tracked in #22087 without adding CodeQL to pull-request workflows.

## Verification

- agent redactor: 14 passed, 0 failed
- scenario native export: 23 passed, 0 failed
- coding-tools shell utilities: 7 passed, 0 failed
- 100,000-repeat SemVer adversarial parser test passed
- changed-file Biome passed
- agent lint passed (976 files)
- coding-tools lint passed (106 files)

Package-wide typechecks in the isolated checkout were blocked by unrelated missing optional/workspace declarations; no diagnostic referenced a changed file. Full repository and hosted gates remain required before merge.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@28d89e4eacefecae27025e828ffd5618fb88d225:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@28d89e4eacefecae27025e828ffd5618fb88d225:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-codeql]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@28d89e4eacefecae27025e828ffd5618fb88d225:packages/skills/skills/contribute-to-eliza"} -->

## Evidence Gate

<!-- evidence-head:28d89e4eacefecae27025e828ffd5618fb88d225 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered pixels or layout changed in this scoped parser-hardening change.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered pixels or layout changed in this scoped parser-hardening change.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual interaction flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - focused boundary validation results are documented above; no protected backend was mutated.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no rendered frontend state or browser-network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no production prompt, model selection, or model-output behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact focused test counts and adversarial coverage are documented above; no separate runtime artifact was produced.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no pixels changed.
