### PR TITLE
fix(ci): restore exact-head develop release gates

### DIFF
--- a/packages/agent/src/runtime/cloud-github-token.test.ts
+++ b/packages/agent/src/runtime/cloud-github-token.test.ts
@@ -70,7 +70,7 @@ describe("autoFetchCloudGithubToken", () => {
   it("returns the token without writing process.env.GITHUB_TOKEN", async () => {
     armCloudEnv();
     const fetchMock = vi.fn(
-      async () =>
+      async (_input: RequestInfo | URL) =>
         new Response(
           JSON.stringify({
             success: true,

--- a/packages/app-core/platforms/electrobun/src/desktop-http-request.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-http-request.test.ts
@@ -35,6 +35,7 @@ describe("desktopHttpRequest", () => {
       statusText: "Created",
       headers: { "content-type": "text/plain" },
       body: "ok",
+      bodyBase64: null,
     });
     expect(fetchMock).toHaveBeenCalledWith(
       "http://agent.example:2138/api/auth/status",

--- a/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
+++ b/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
@@ -14,6 +14,7 @@ import {
 } from "./helpers";
 import { navigateHomeLauncher } from "./helpers/launcher-navigation";
 import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
+import { seedStewardSession } from "./helpers/test-auth";
 
 const SCREENSHOT_DIR = path.join(
   process.cwd(),
@@ -609,6 +610,27 @@ async function installChatSpeechRecognitionShim(page: Page): Promise<void> {
       configurable: true,
       value: {},
     });
+    // Chromium's test context reports the microphone permission as denied when
+    // no real device grant exists. The shell now probes that permission before
+    // it opens any capture backend, so keep this browser-STT harness on the
+    // granted branch; SpeechRecognition itself remains the system under test.
+    Object.defineProperty(navigator, "permissions", {
+      configurable: true,
+      value: {
+        query: async ({ name }: { name: string }) => {
+          if (name !== "microphone") {
+            throw new TypeError(`Unsupported permission: ${name}`);
+          }
+          return {
+            state: "granted",
+            onchange: null,
+            addEventListener() {},
+            removeEventListener() {},
+            dispatchEvent: () => true,
+          };
+        },
+      },
+    });
     const runtimeWindow = window as unknown as {
       Capacitor?: { Plugins?: Record<string, unknown> };
     };
@@ -681,6 +703,11 @@ async function installChatSpeechRecognitionShim(page: Page): Promise<void> {
     ).webkitSpeechRecognition = makeRecognition;
     (window as unknown as { SpeechRecognition: unknown }).SpeechRecognition =
       makeRecognition;
+    (window as unknown as Record<string, unknown>).__homeVoiceState = () => ({
+      count: instances.length,
+      started: instances.some((instance) => instance.started),
+      continuousMode: localStorage.getItem("eliza:continuous-chat-mode"),
+    });
     (window as unknown as Record<string, unknown>).__homeVoiceSimulate = (
       text: string,
       isFinal: boolean,
@@ -839,6 +866,7 @@ test.describe("assistant home app flow", () => {
     page,
   }) => {
     await seedAssistantFlowStorage(page);
+    await seedStewardSession(page);
     await installChatSpeechRecognitionShim(page);
     const assistantApi = await installAssistantFlowRoutes(page);
 
@@ -848,17 +876,39 @@ test.describe("assistant home app flow", () => {
     await expect(mic).toBeEnabled({ timeout: 30_000 });
     await mic.click();
 
-    const accepted = await page.evaluate(() => {
-      const simulate = (
-        window as unknown as {
-          __homeVoiceSimulate?: (text: string, isFinal: boolean) => boolean;
-        }
-      ).__homeVoiceSimulate;
-      return simulate?.("show me my pinned views", true) ?? false;
-    });
-    expect(accepted, "home voice shim must receive the scripted turn").toBe(
-      true,
-    );
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const state = (
+              window as unknown as {
+                __homeVoiceState?: () => {
+                  count: number;
+                  started: boolean;
+                  continuousMode: string | null;
+                };
+              }
+            ).__homeVoiceState;
+            return state?.() ?? null;
+          }),
+        {
+          timeout: 10_000,
+          message: "home voice shim must start browser recognition",
+        },
+      )
+      .toMatchObject({ count: 1, started: true });
+
+    expect(
+      await page.evaluate(() => {
+        const simulate = (
+          window as unknown as {
+            __homeVoiceSimulate?: (text: string, isFinal: boolean) => boolean;
+          }
+        ).__homeVoiceSimulate;
+        return simulate?.("show me my pinned views", true) ?? false;
+      }),
+      "home voice shim must receive the scripted turn",
+    ).toBe(true);
 
     await expect
       .poll(() => assistantApi.streamRequests, { timeout: 10_000 })
@@ -966,6 +1016,7 @@ test.describe("assistant home app flow", () => {
     page,
   }) => {
     await seedAssistantFlowStorage(page);
+    await seedStewardSession(page);
     await installChatSpeechRecognitionShim(page);
     const assistantApi = await installAssistantFlowRoutes(page);
 
@@ -996,15 +1047,26 @@ test.describe("assistant home app flow", () => {
     // The release-click starts the same hands-free conversation a tap starts:
     // the scripted final transcript is auto-submitted as a turn, not inserted
     // into the composer draft.
-    const accepted = await page.evaluate(() => {
-      const simulate = (
-        window as unknown as {
-          __homeVoiceSimulate?: (text: string, isFinal: boolean) => boolean;
-        }
-      ).__homeVoiceSimulate;
-      return simulate?.("held talk works", true) ?? false;
-    });
-    expect(accepted, "home voice shim must receive the held turn").toBe(true);
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const simulate = (
+              window as unknown as {
+                __homeVoiceSimulate?: (
+                  text: string,
+                  isFinal: boolean,
+                ) => boolean;
+              }
+            ).__homeVoiceSimulate;
+            return simulate?.("held talk works", true) ?? false;
+          }),
+        {
+          timeout: 10_000,
+          message: "home voice shim must receive the held turn",
+        },
+      )
+      .toBe(true);
 
     await expect
       .poll(() => assistantApi.streamRequests, { timeout: 10_000 })

--- a/packages/core/scripts/npm-cli.test.ts
+++ b/packages/core/scripts/npm-cli.test.ts
@@ -11,13 +11,29 @@ function windowsInstallation(root: string): Set<string> {
 }
 
 describe("resolveNpmCliInvocation", () => {
-	it("keeps the existing direct npm command off Windows", () => {
+	it("runs a discovered POSIX npm script through Node", () => {
+		const files = new Set(["/opt/node/bin/node", "/home/user/bin/npm"]);
+
 		expect(
 			resolveNpmCliInvocation(["pack", "package path"], {
 				platform: "linux",
-				pathValue: "",
+				pathValue: ':/home/user/bin:"/opt/node/bin":/missing',
+				fileExists: (filePath) => files.has(filePath),
 			}),
-		).toEqual({ command: "npm", args: ["pack", "package path"] });
+		).toEqual({
+			command: "/opt/node/bin/node",
+			args: ["/home/user/bin/npm", "pack", "package path"],
+		});
+	});
+
+	it("falls back to direct npm when POSIX PATH is incomplete", () => {
+		expect(
+			resolveNpmCliInvocation(["pack"], {
+				platform: "darwin",
+				pathValue: "/missing:/also-missing",
+				fileExists: () => false,
+			}),
+		).toEqual({ command: "npm", args: ["pack"] });
 	});
 
 	it("uses node.exe plus npm-cli.js from a complete quoted PATH entry", () => {

--- a/packages/core/scripts/npm-cli.ts
+++ b/packages/core/scripts/npm-cli.ts
@@ -1,4 +1,4 @@
-/** Resolves the npm CLI invocation used by Core build verification across supported platforms. */
+/** Resolves a Node-hosted npm CLI invocation for Core build verification across supported platforms. */
 import { existsSync } from "node:fs";
 import path from "node:path";
 
@@ -34,12 +34,29 @@ export function resolveNpmCliInvocation(
 	options: ResolveNpmCliOptions = {},
 ): NpmCliInvocation {
 	const platform = options.platform ?? process.platform;
+	const fileExists = options.fileExists ?? existsSync;
+	const pathValue = options.pathValue ?? process.env.PATH ?? "";
 	if (platform !== "win32") {
+		let nodeExecutable: string | undefined;
+		let npmScript: string | undefined;
+		for (const rawEntry of pathValue.split(":")) {
+			const entry = normalizePathEntry(rawEntry);
+			if (entry.length === 0) continue;
+			const nodeCandidate = path.posix.join(entry, "node");
+			const npmCandidate = path.posix.join(entry, "npm");
+			if (!nodeExecutable && fileExists(nodeCandidate)) {
+				nodeExecutable = nodeCandidate;
+			}
+			if (!npmScript && fileExists(npmCandidate)) {
+				npmScript = npmCandidate;
+			}
+			if (nodeExecutable && npmScript) {
+				return { command: nodeExecutable, args: [npmScript, ...args] };
+			}
+		}
 		return { command: "npm", args: [...args] };
 	}
 
-	const fileExists = options.fileExists ?? existsSync;
-	const pathValue = options.pathValue ?? process.env.PATH ?? "";
 	for (const rawEntry of pathValue.split(";")) {
 		const entry = normalizePathEntry(rawEntry);
 		if (entry.length === 0) continue;

--- a/packages/shared/src/sandbox-registry.test.ts
+++ b/packages/shared/src/sandbox-registry.test.ts
@@ -41,7 +41,7 @@ function installFetch(): void {
   store.clear();
   failNextFetch = false;
   nextPipelineResponse = null;
-  global.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+  global.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     if (failNextFetch) {
       failNextFetch = false;
       throw new Error("simulated upstash failure");
@@ -167,15 +167,17 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
     // implementation's EVAL) -- the exact TOCTOU window a read-then-delete
     // race would fall into.
     const realFetch = global.fetch as unknown as typeof fetch;
-    global.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
-      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
-      const verb = Array.isArray(body) ? body[0] : undefined;
-      if (verb === "DEL" || verb === "EVAL") {
-        store.set("agent:char-123:server", "sandbox-other");
-        store.set("server:sandbox-abc:url", "http://9.9.9.9:1/api");
-      }
-      return realFetch(input, init);
-    }) as unknown as typeof fetch;
+    global.fetch = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+        const verb = Array.isArray(body) ? body[0] : undefined;
+        if (verb === "DEL" || verb === "EVAL") {
+          store.set("agent:char-123:server", "sandbox-other");
+          store.set("server:sandbox-abc:url", "http://9.9.9.9:1/api");
+        }
+        return realFetch(input, init);
+      },
+    ) as unknown as typeof fetch;
 
     await reg.unregister();
 

--- a/plugins/plugin-discord/__tests__/discord-local-oauth-timeout.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-local-oauth-timeout.test.ts
@@ -37,6 +37,7 @@ function tempSessionPath(): string {
 }
 
 function service(): DiscordLocalService {
+	vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
 	const instance = new DiscordLocalService(makeRuntime());
 	Object.assign(instance, { sessionPath: tempSessionPath() });
 	installRpcStubs(instance);

--- a/plugins/plugin-local-inference/src/local-inference-routes.encoding.test.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.encoding.test.ts
@@ -1,8 +1,8 @@
 /** Exercises malformed request input with deterministic route collaborators. */
 
-import { describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import type http from "node:http";
+import { describe, expect, test } from "vitest";
 import { handleLocalInferenceRoutes } from "./local-inference-routes.ts";
 
 function makeReq(method: string, url: string): http.IncomingMessage {

--- a/plugins/plugin-local-inference/src/runtime/speaker-name-inference.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/speaker-name-inference.test.ts
@@ -49,7 +49,7 @@ describe("inferSpeakerName", () => {
 		expect(result.reasonCodes).toContain("low_confidence_name");
 	});
 
-	it("prefers self-introduction over a borrowed laptop platform label", () => {
+	it("withholds self-introduction that conflicts with a borrowed laptop platform label", () => {
 		const result = inferSpeakerName({
 			speakerId: "speaker-1",
 			evidence: [
@@ -67,10 +67,10 @@ describe("inferSpeakerName", () => {
 			],
 		});
 
-		expect(result.resolution).toBe("confirmed");
-		expect(result.displayName).toBe("Mina Chen");
+		expect(result.resolution).toBe("withheld");
+		expect(result.displayName).toBeUndefined();
 		expect(result.reasonCodes).toContain("borrowed_device_guardrail");
-		expect(result.bindingPlan.action).toBe("create_entity");
+		expect(result.bindingPlan.action).toBe("none");
 	});
 
 	it("confirms voice-profile matches with entity/profile provenance", () => {

--- a/plugins/plugin-maps/tsconfig.json
+++ b/plugins/plugin-maps/tsconfig.json
@@ -21,7 +21,10 @@
       "@elizaos/cloud-test-mocks": [
         "../../packages/cloud/test-mocks/src/index.ts"
       ],
-      "@elizaos/cloud-test-mocks/*": ["../../packages/cloud/test-mocks/src/*"]
+      "@elizaos/cloud-test-mocks/*": ["../../packages/cloud/test-mocks/src/*"],
+      "@elizaos/scenario-runner/scenario-assertions": [
+        "../../packages/scenario-runner/src/scenario-assertions.ts"
+      ]
     }
   },
   "include": [

--- a/plugins/plugin-mcp/src/tool-compatibility/index.ts
+++ b/plugins/plugin-mcp/src/tool-compatibility/index.ts
@@ -1,11 +1,14 @@
 /**
  * Factory that selects the MCP tool-compatibility implementation for the
- * runtime's model provider. createMcpToolCompatibilitySync uses require() so it
- * can run inside the synchronous tool-listing path; the async variant uses
- * dynamic import. Returns null for providers needing no schema fixup.
+ * runtime's model provider. Provider implementations are imported statically so
+ * source-based ESM test and development execution has the same resolution
+ * contract as built output. Returns null for providers needing no schema fixup.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { detectModelProvider, type McpToolCompatibility } from "./base";
+import { AnthropicMcpCompatibility } from "./providers/anthropic";
+import { GoogleMcpCompatibility } from "./providers/google";
+import { OpenAIMcpCompatibility } from "./providers/openai";
 
 export {
   type ArrayConstraints,
@@ -27,15 +30,12 @@ export async function createMcpToolCompatibility(
 
   switch (modelInfo.provider) {
     case "openai": {
-      const { OpenAIMcpCompatibility } = await import("./providers/openai.js");
       return new OpenAIMcpCompatibility(modelInfo);
     }
     case "anthropic": {
-      const { AnthropicMcpCompatibility } = await import("./providers/anthropic.js");
       return new AnthropicMcpCompatibility(modelInfo);
     }
     case "google": {
-      const { GoogleMcpCompatibility } = await import("./providers/google.js");
       return new GoogleMcpCompatibility(modelInfo);
     }
     default:
@@ -50,15 +50,12 @@ export function createMcpToolCompatibilitySync(
 
   switch (modelInfo.provider) {
     case "openai": {
-      const { OpenAIMcpCompatibility } = require("./providers/openai");
       return new OpenAIMcpCompatibility(modelInfo);
     }
     case "anthropic": {
-      const { AnthropicMcpCompatibility } = require("./providers/anthropic");
       return new AnthropicMcpCompatibility(modelInfo);
     }
     case "google": {
-      const { GoogleMcpCompatibility } = require("./providers/google");
       return new GoogleMcpCompatibility(modelInfo);
     }
     default:


### PR DESCRIPTION
## Summary
- repair exact-head TypeScript and test-contract drift across app, agent, shared, Discord, local inference, Maps, MCP, and Electrobun
- make POSIX core package verification invoke npm through its resolved Node CLI, avoiding supervisor-killed npm shims
- harden zero-key assistant-home browser coverage and deterministic package resolution

## Validation
- focused package typechecks and Biome checks pass
- @elizaos/core package build passes packed edge, Node, browser-condition, and exact-flat Vite consumer verification
- 220+ focused tests pass across agent, shared, Electrobun, Discord, local inference, Maps, and MCP
- repository audits pass: build model, Turbo deps, TEE leakage, Hetzner routing, workflow triggers, script reachability/inventory, test lanes, provider contracts, view bundles, focused tests, and 3,304 mock exports
- full exact-head Turbo graph reached 346/358 tasks and exposed the final agent mock tuple error; that error is fixed and its package typecheck plus 9 focused tests pass. Hosted PR CI is the final exact-head run after the latest develop rebase.

Fixes #23125