### PR TITLE
fix(coding-tools): recognize empty heredoc delimiters

### DIFF
--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
@@ -160,6 +160,7 @@ describe("classifyDestructiveCommand — must NOT fire", () => {
     ["single-quoted", "cat <<'EOF'\nrm -rf ./data\nEOF"],
     ["double-quoted", 'cat <<"EOF"\nDROP DATABASE production\nEOF'],
     ["concatenated quoted word", "cat <<'E'OF\nrm -rf ./data\nEOF"],
+    ["empty quoted delimiter", "cat <<''\nrm -rf ./data\n\n"],
     ["tab-stripped", "cat <<-EOF\n\trm -rf ./data\n\tEOF"],
   ])(
     "%s heredoc payload is data, not an executable segment",

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
@@ -95,6 +95,7 @@ function parseHeredocDelimiter(
   let delimiter = "";
   let quote: string | null = null;
   let quoted = false;
+  let wordStarted = false;
 
   while (cursor < line.length) {
     const ch = line[cursor] as string;
@@ -117,12 +118,14 @@ function parseHeredocDelimiter(
       continue;
     }
     if (ch === '"' || ch === "'") {
+      wordStarted = true;
       quoted = true;
       quote = ch;
       cursor += 1;
       continue;
     }
     if (ch === "\\" && cursor + 1 < line.length) {
+      wordStarted = true;
       quoted = true;
       cursor += 1;
       delimiter += line[cursor] as string;
@@ -130,11 +133,12 @@ function parseHeredocDelimiter(
       continue;
     }
     if (/[\s|;&<>()]/.test(ch)) break;
+    wordStarted = true;
     delimiter += ch;
     cursor += 1;
   }
 
-  return quote === null && delimiter ? { delimiter, quoted } : null;
+  return quote === null && wordStarted ? { delimiter, quoted } : null;
 }
 
 function isInsideArrayAssignmentSubscript(
@@ -245,9 +249,12 @@ function heredocDeclarations(line: string): HeredocDeclaration[] {
   return declarations;
 }
 
-// Heredoc bodies are shell input, not commands. Preserve their newlines so
-// later executable lines remain segment boundaries, but hide payload bytes
-// from both the command and SQL classifiers.
+// Literal heredoc payload tokens are shell input rather than command
+// positions. Preserve newlines so later executable lines remain segment
+// boundaries, but hide literal payload bytes from the command and SQL
+// classifiers. Unquoted bodies can evaluate nested expansions; those require
+// their own recursive inspection rather than treating the whole body as a
+// command list.
 function maskHeredocBodies(command: string): string {
   const lines = command.match(/[^\r\n]*(?:\r\n|\r|\n|$)/g) ?? [];
   const pending: HeredocDeclaration[] = [];


### PR DESCRIPTION
Closes #23254. Follow-up to merged #22848.

## Summary

Bash accepts an empty quoted heredoc word. The destructive-command classifier previously required the parsed delimiter string to be truthy, so it treated that valid declaration as unknown and classified literal heredoc payload as an executable command. This change tracks whether a syntactically complete delimiter word was consumed independently from the post-quote-removal delimiter value.

## Exact-head verification

- Exact head: `370139976c6c465c7e96435f7f4bcf4efcc2c173`
- `bun test plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts`: **63 passed, 0 failed**
- Biome on both changed files: passed
- `git diff --check`: passed
- Package typecheck/build were attempted but the lightweight shared install lacks unrelated optional document and shell dependencies (`ai`, `mammoth`, `unpdf`, `cross-spawn`, native PTY/ripgrep). Hosted exact-head Quality is required before merge.

Nested executable expansion inspection remains separately tracked by #23239.

## Evidence Gate

<!-- evidence-head:370139976c6c465c7e96435f7f4bcf4efcc2c173 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend command classification only; no rendered pixels changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend command classification only; no rendered pixels changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - the exact deterministic classifier suite result is documented above; no protected backend was mutated.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, or model-output behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the exact empty-delimiter boundary is asserted directly by the focused regression.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->