### PR TITLE
fix(security): harden HTML normalization boundaries

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-google-connector/gmail.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/gmail.error-policy.test.ts
@@ -28,7 +28,7 @@ mock.module("./shared", () => ({
   getManagedGoogleConnectorStatus: () => statusImpl(),
 }));
 
-const { fetchManagedGoogleGmailTriage } = await import("./gmail");
+const { fetchManagedGoogleGmailTriage, readManagedGoogleGmailMessage } = await import("./gmail");
 
 const ORG = "org-1";
 const USER = "user-1";
@@ -108,6 +108,39 @@ describe("gmail.ts error-policy — fail-closed vs designed-empty", () => {
 
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0]?.subject).toBe("Hello");
+  });
+
+  test("body normalization decodes entities once and strips spaced script/style end tags", async () => {
+    const body =
+      "<p>&amp;lt;kept&amp;gt;</p><script>credential-stealer()</script ><style>hidden{}</style >";
+    fetchImpl = async () =>
+      jsonResponse({
+        id: "m1",
+        threadId: "t1",
+        labelIds: ["INBOX"],
+        internalDate: "1700000000000",
+        payload: {
+          mimeType: "text/html",
+          body: { data: Buffer.from(body).toString("base64url") },
+          headers: [
+            { name: "Subject", value: "HTML" },
+            { name: "From", value: "Alice <alice@example.com>" },
+            { name: "To", value: "me@example.com" },
+          ],
+        },
+      });
+
+    const result = await readManagedGoogleGmailMessage({
+      organizationId: ORG,
+      userId: USER,
+      side: SIDE,
+      messageId: "m1",
+    });
+
+    expect(result.bodyText).toContain("&lt;kept&gt;");
+    expect(result.bodyText).not.toContain("<kept>");
+    expect(result.bodyText).not.toContain("credential-stealer");
+    expect(result.bodyText).not.toContain("hidden");
   });
 
   test("internal failure on the LIST call propagates (never fabricates empty)", async () => {

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/gmail.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/gmail.error-policy.test.ts
@@ -110,9 +110,9 @@ describe("gmail.ts error-policy — fail-closed vs designed-empty", () => {
     expect(result.messages[0]?.subject).toBe("Hello");
   });
 
-  test("body normalization decodes entities once and strips spaced script/style end tags", async () => {
+  test("body normalization decodes entities once and strips malformed script/style end tags", async () => {
     const body =
-      "<p>&amp;lt;kept&amp;gt;</p><script>credential-stealer()</script ><style>hidden{}</style >";
+      '<p>&amp;lt;kept&amp;gt;</p><script>credential-stealer()</script \t\n bar><style>hidden{}</style data-x="1">';
     fetchImpl = async () =>
       jsonResponse({
         id: "m1",

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/gmail.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/gmail.ts
@@ -166,20 +166,24 @@ function normalizeSnippet(value: string | undefined): string {
 }
 
 function decodeHtmlEntities(value: string): string {
-  return value
-    .replace(/&nbsp;/gi, " ")
-    .replace(/&amp;/gi, "&")
-    .replace(/&lt;/gi, "<")
-    .replace(/&gt;/gi, ">")
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/gi, "'");
+  const namedEntities: Record<string, string> = {
+    amp: "&",
+    gt: ">",
+    lt: "<",
+    nbsp: " ",
+    quot: '"',
+    "#39": "'",
+  };
+  return value.replace(/&(nbsp|amp|lt|gt|quot|#39);/gi, (entity, name: string) => {
+    return namedEntities[name.toLowerCase()] ?? entity;
+  });
 }
 
 function htmlToPlainText(value: string): string {
   return decodeHtmlEntities(
     value
-      .replace(/<style[\s\S]*?<\/style>/gi, " ")
-      .replace(/<script[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, " ")
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, " ")
       .replace(/<br\s*\/?>/gi, "\n")
       .replace(/<\/(?:p|div|section|article|li|tr|table|h[1-6])>/gi, "\n")
       .replace(/<(?:li)[^>]*>/gi, "- ")

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/gmail.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/gmail.ts
@@ -182,8 +182,8 @@ function decodeHtmlEntities(value: string): string {
 function htmlToPlainText(value: string): string {
   return decodeHtmlEntities(
     value
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, " ")
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, " ")
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, " ")
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, " ")
       .replace(/<br\s*\/?>/gi, "\n")
       .replace(/<\/(?:p|div|section|article|li|tr|table|h[1-6])>/gi, "\n")
       .replace(/<(?:li)[^>]*>/gi, "- ")

--- a/packages/core/src/features/basic-capabilities/evaluators/__tests__/link-extraction.test.ts
+++ b/packages/core/src/features/basic-capabilities/evaluators/__tests__/link-extraction.test.ts
@@ -194,10 +194,10 @@ describe("linkExtractionEvaluator", () => {
 		);
 	});
 
-	it("decodes title entities once and strips script/style tags with spaced closers", async () => {
+	it("decodes title entities once and strips script/style tags with malformed closers", async () => {
 		stubPreviewFetch(
 			makeFetchResponse(
-				"<title>&amp;lt;literal&amp;gt;</title><body>safe<script>steal()</script ><style>hidden{}</style ></body>",
+				'<title>&amp;lt;literal&amp;gt;</title><body>safe<script>steal()</script \t\n bar><style>hidden{}</style data-x="1"></body>',
 			),
 		);
 		const runtime = makeRuntime(async (_modelType, params) => {

--- a/packages/core/src/features/basic-capabilities/evaluators/__tests__/link-extraction.test.ts
+++ b/packages/core/src/features/basic-capabilities/evaluators/__tests__/link-extraction.test.ts
@@ -194,6 +194,30 @@ describe("linkExtractionEvaluator", () => {
 		);
 	});
 
+	it("decodes title entities once and strips script/style tags with spaced closers", async () => {
+		stubPreviewFetch(
+			makeFetchResponse(
+				"<title>&amp;lt;literal&amp;gt;</title><body>safe<script>steal()</script ><style>hidden{}</style ></body>",
+			),
+		);
+		const runtime = makeRuntime(async (_modelType, params) => {
+			const prompt = (params as { prompt: string }).prompt;
+			expect(prompt).toContain("Title: &lt;literal&gt;");
+			expect(prompt).toContain("safe");
+			expect(prompt).not.toContain("steal()");
+			expect(prompt).not.toContain("hidden{}");
+			return "summary";
+		});
+		const context = {
+			...makeContext(runtime, makeMessage("see https://example.com/hostile")),
+			state: { values: {}, data: {}, text: "" } as State,
+		};
+
+		const prepared = await linkExtractionEvaluator.prepare?.(context);
+
+		expect(prepared?.links[0]?.title).toBe("&lt;literal&gt;");
+	});
+
 	it("prepare dedupes repeated URLs and strips trailing punctuation", async () => {
 		stubPreviewFetch(
 			makeFetchResponse("<html><title>doc</title><body>x</body></html>"),

--- a/packages/core/src/features/basic-capabilities/evaluators/link-extraction.ts
+++ b/packages/core/src/features/basic-capabilities/evaluators/link-extraction.ts
@@ -128,19 +128,24 @@ function extractTitle(html: string): string {
 }
 
 function decodeHtmlEntities(value: string): string {
-	return value
-		.replace(/&amp;/gi, "&")
-		.replace(/&lt;/gi, "<")
-		.replace(/&gt;/gi, ">")
-		.replace(/&quot;/gi, '"')
-		.replace(/&#39;/gi, "'")
-		.replace(/&nbsp;/gi, " ");
+	const namedEntities: Record<string, string> = {
+		amp: "&",
+		gt: ">",
+		lt: "<",
+		nbsp: " ",
+		quot: '"',
+		"#39": "'",
+	};
+	return value.replace(
+		/&(amp|lt|gt|quot|#39|nbsp);/gi,
+		(entity, name: string) => namedEntities[name.toLowerCase()] ?? entity,
+	);
 }
 
 function stripTags(html: string): string {
 	return html
-		.replace(/<script[\s\S]*?<\/script>/gi, " ")
-		.replace(/<style[\s\S]*?<\/style>/gi, " ")
+		.replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, " ")
+		.replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, " ")
 		.replace(/<[^>]+>/g, " ")
 		.replace(/\s+/g, " ")
 		.trim();

--- a/packages/core/src/features/basic-capabilities/evaluators/link-extraction.ts
+++ b/packages/core/src/features/basic-capabilities/evaluators/link-extraction.ts
@@ -144,8 +144,8 @@ function decodeHtmlEntities(value: string): string {
 
 function stripTags(html: string): string {
 	return html
-		.replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, " ")
-		.replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, " ")
+		.replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, " ")
+		.replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, " ")
 		.replace(/<[^>]+>/g, " ")
 		.replace(/\s+/g, " ")
 		.trim();

--- a/plugins/plugin-coding-tools/src/actions/web-fetch.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.test.ts
@@ -284,12 +284,22 @@ describe("coding-tools WEB_FETCH", () => {
     expect(htmlToReadableText("<p>&quot;&apos;&nbsp;x</p>")).toBe("\"' x");
   });
 
-  it("removes script and style blocks whose closing tags contain whitespace", () => {
+  it("removes script and style blocks whose closing tags carry whitespace or attributes", () => {
     expect(
       htmlToReadableText(
         "<p>visible</p><script>steal()</script ><style>hidden{}</style ><p>after</p>",
       ),
     ).toBe("visible\n\nafter");
+    expect(
+      htmlToReadableText(
+        '<p>visible</p><script>steal()</script \t\n bar><style>hidden{}</style data-x="1"><p>after</p>',
+      ),
+    ).toBe("visible\n\nafter");
+    // A non-boundary suffix is not a real closer; the block must keep consuming
+    // until an accepted end tag so early content cannot leak.
+    expect(
+      htmlToReadableText("<p>a</p><script>steal()</scriptx></script><p>b</p>"),
+    ).toBe("a\n\nb");
   });
 
   it("degrades invalid numeric entities without throwing and keeps surrounding text", () => {

--- a/plugins/plugin-coding-tools/src/actions/web-fetch.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.test.ts
@@ -284,6 +284,14 @@ describe("coding-tools WEB_FETCH", () => {
     expect(htmlToReadableText("<p>&quot;&apos;&nbsp;x</p>")).toBe("\"' x");
   });
 
+  it("removes script and style blocks whose closing tags contain whitespace", () => {
+    expect(
+      htmlToReadableText(
+        "<p>visible</p><script>steal()</script ><style>hidden{}</style ><p>after</p>",
+      ),
+    ).toBe("visible\n\nafter");
+  });
+
   it("degrades invalid numeric entities without throwing and keeps surrounding text", () => {
     // Invalid scalar values must remain literal instead of hard-failing the
     // fetch or introducing an unpaired UTF-16 surrogate into readable text.

--- a/plugins/plugin-coding-tools/src/actions/web-fetch.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.ts
@@ -72,8 +72,8 @@ export function htmlToReadableText(html: string): string {
   const title = /<title\b[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1];
   const withoutNoise = html
     .replace(/<head\b[^>]*>[\s\S]*?<\/head>/gi, " ")
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, " ")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, " ")
     .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, " ")
     .replace(/<svg\b[^>]*>[\s\S]*?<\/svg>/gi, " ");
   const text = withoutNoise

--- a/plugins/plugin-coding-tools/src/actions/web-fetch.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.ts
@@ -72,8 +72,8 @@ export function htmlToReadableText(html: string): string {
   const title = /<title\b[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1];
   const withoutNoise = html
     .replace(/<head\b[^>]*>[\s\S]*?<\/head>/gi, " ")
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, " ")
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, " ")
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, " ")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, " ")
     .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, " ")
     .replace(/<svg\b[^>]*>[\s\S]*?<\/svg>/gi, " ");
   const text = withoutNoise

--- a/plugins/plugin-native-canvas/src/web.test.ts
+++ b/plugins/plugin-native-canvas/src/web.test.ts
@@ -322,32 +322,24 @@ describe("CanvasWeb eval message source", () => {
     );
   });
 
-  it("fails closed when navigating to an invalid or opaque URL and attempting postMessage", async () => {
-    const canvas = new CanvasWeb();
-    await canvas.navigate({ url: "data:text/html,opaque" });
+  it.each([
+    "data:text/html,opaque",
+    "vbscript:msgbox(1)",
+    "file:///etc/passwd",
+    "javascript:alert(1)",
+    "http://[",
+  ])(
+    "rejects non-allowlisted navigation %s before replacing the active view",
+    async (url) => {
+      const canvas = new CanvasWeb();
+      await canvas.navigate({ url: "https://canvas.eliza.how/view" });
+      const originalFrame = document.querySelector("iframe");
 
-    await expect(canvas.a2uiPush({ messages: [] })).rejects.toThrow(
-      "Cannot determine web view target origin",
-    );
-    await expect(canvas.a2uiReset()).rejects.toThrow(
-      "Cannot determine web view target origin",
-    );
-    await expect(canvas.eval({ script: "1+1" })).rejects.toThrow(
-      "Cannot determine web view target origin",
-    );
-  });
+      await expect(canvas.navigate({ url })).rejects.toThrow(
+        "Web view URL must use an allowed navigation scheme",
+      );
 
-  it("rejects javascript navigation before it can execute or replace the active view", async () => {
-    const canvas = new CanvasWeb();
-    await canvas.navigate({ url: "https://canvas.eliza.how/view" });
-    const originalFrame = document.querySelector("iframe");
-    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
-
-    await expect(
-      canvas.navigate({ url: "javascript:alert(1)" }),
-    ).rejects.toThrow("javascript: web view URLs are not allowed");
-
-    expect(alertSpy).not.toHaveBeenCalled();
-    expect(document.querySelector("iframe")).toBe(originalFrame);
-  });
+      expect(document.querySelector("iframe")).toBe(originalFrame);
+    },
+  );
 });

--- a/plugins/plugin-native-canvas/src/web.ts
+++ b/plugins/plugin-native-canvas/src/web.ts
@@ -890,8 +890,13 @@ export class CanvasWeb extends WebPlugin {
     }
 
     const navigation = this.resolveWebViewNavigation(options.url);
-    if (navigation.protocol === "javascript:") {
-      throw new Error("javascript: web view URLs are not allowed");
+    if (
+      navigation.protocol !== "http:" &&
+      navigation.protocol !== "https:" &&
+      navigation.protocol !== "blob:" &&
+      navigation.protocol !== "about:"
+    ) {
+      throw new Error("Web view URL must use an allowed navigation scheme");
     }
 
     this.destroyWebView();
@@ -1224,10 +1229,10 @@ export class CanvasWeb extends WebPlugin {
         }
       }
 
-      return { origin: null, protocol: parsed.protocol };
+      return { origin: null, protocol: null };
     } catch {
-      // error-policy:J3 malformed URLs remain displayable only if the browser
-      // accepts them, but all messaging fails closed because no origin is set.
+      // error-policy:J3 malformed and non-allowlisted schemes are rejected by
+      // navigate before browser-controlled iframe or popup state is created.
       return { origin: null, protocol: null };
     }
   }

--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -87,6 +87,10 @@ describe("stripSlackFormatting", () => {
     expect(stripSlackFormatting("a &amp; b")).toBe("a & b");
   });
 
+  it("decodes each Slack entity exactly once", () => {
+    expect(stripSlackFormatting("&amp;lt;tag&amp;gt;")).toBe("&lt;tag&gt;");
+  });
+
   it("unwraps plain links to their URL instead of deleting them", () => {
     expect(stripSlackFormatting("see <https://a.com> ok")).toBe(
       "see https://a.com ok",

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -554,7 +554,7 @@ export function truncateText(
  * Strips Slack mrkdwn formatting from text
  */
 export function stripSlackFormatting(text: string): string {
-  return text
+  const withoutMarkup = text
     .replace(/```[\s\S]*?```/g, "") // Code blocks (must be before inline code)
     .replace(/\*([^*]+)\*/g, "$1") // Bold
     .replace(/_([^_]+)_/g, "$1") // Italic
@@ -565,10 +565,13 @@ export function stripSlackFormatting(text: string): string {
     .replace(/<!subteam\^[A-Z0-9]+(?:\|[^>]*)?>/gi, "") // User group mentions
     .replace(/<!(?:here|channel|everyone)(?:\|[^>]*)?>/gi, "") // Special mentions
     .replace(/<((?:https?|slack|mailto|tel):[^|>]+)\|([^>]*)>/g, "$2") // Links with text → label
-    .replace(/<((?:https?|slack|mailto|tel):[^>]+)>/g, "$1") // Plain links → URL
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
+    .replace(/<((?:https?|slack|mailto|tel):[^>]+)>/g, "$1"); // Plain links → URL
+  const entities: Record<string, string> = { amp: "&", lt: "<", gt: ">" };
+  return withoutMarkup
+    .replace(
+      /&(amp|lt|gt);/g,
+      (entity, name: string) => entities[name] ?? entity,
+    )
     .trim();
 }
 

--- a/plugins/plugin-web-search/src/services/webSearchService.test.ts
+++ b/plugins/plugin-web-search/src/services/webSearchService.test.ts
@@ -349,6 +349,18 @@ describe("WebSearchService", () => {
         expect(pageInfo.title).toBe("😀 🚀 &#0; &#xD800; &#1114112;");
     });
 
+    it("decodes each HTML entity exactly once", async () => {
+        const html = `<title>&amp;lt;literal&amp;gt; &amp;#65;</title>`;
+        setPageInfoHttpTransportForTests({
+            fetchImpl: vi.fn(async () => new Response(html)),
+        });
+        const service = await WebSearchService.start(runtime({ TAVILY_API_KEY: "tvly-test" }));
+
+        const pageInfo = await service.getPageInfo("https://example.test/entities-once");
+
+        expect(pageInfo.title).toBe("&lt;literal&gt; &#65;");
+    });
+
     it("accepts page HTML exactly at the byte limit", async () => {
         const exactLimitHtml = "a".repeat(1024 * 1024);
         setPageInfoHttpTransportForTests({

--- a/plugins/plugin-web-search/src/services/webSearchService.ts
+++ b/plugins/plugin-web-search/src/services/webSearchService.ts
@@ -220,17 +220,26 @@ function decodeHtmlEntities(text: string): string {
         return String.fromCodePoint(codePoint);
     };
 
-    return text
-        .replace(/&amp;/g, "&")
-        .replace(/&lt;/g, "<")
-        .replace(/&gt;/g, ">")
-        .replace(/&quot;/g, '"')
-        .replace(/&#39;/g, "'")
-        .replace(/&apos;/g, "'")
-        .replace(/&#(\d+);/g, (entity, digits: string) => decodeNumericEntity(entity, digits, 10))
-        .replace(/&#x([0-9a-fA-F]+);/g, (entity, digits: string) =>
-            decodeNumericEntity(entity, digits, 16)
-        );
+    const namedEntities: Record<string, string> = {
+        amp: "&",
+        apos: "'",
+        gt: ">",
+        lt: "<",
+        quot: '"',
+        "#39": "'",
+    };
+    return text.replace(
+        /&(amp|lt|gt|quot|apos|#39|#\d+|#x[0-9a-fA-F]+);/g,
+        (entity, name: string) => {
+            if (name.startsWith("#x")) {
+                return decodeNumericEntity(entity, name.slice(2), 16);
+            }
+            if (name.startsWith("#") && name !== "#39") {
+                return decodeNumericEntity(entity, name.slice(1), 10);
+            }
+            return namedEntities[name] ?? entity;
+        }
+    );
 }
 
 type PageBodyCanceller = {

--- a/scripts/lifeops/hitl-credential-dashboard.mjs
+++ b/scripts/lifeops/hitl-credential-dashboard.mjs
@@ -181,6 +181,23 @@ function tokenMatches(actual, expected) {
   );
 }
 
+function escapeHtml(value) {
+  return String(value).replace(/[&<>"']/g, (character) => {
+    switch (character) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
+}
+
 function assertDashboardPost(req) {
   const remoteAddress = req.socket?.remoteAddress;
   if (remoteAddress && !LOOPBACK_REMOTE_ADDRESSES.has(remoteAddress)) {
@@ -645,9 +662,9 @@ async function handleDiscordOAuthCallback(url, res) {
     "Cache-Control": "no-store",
   });
   res.end(
-    `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>${title}</title>` +
+    `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>${escapeHtml(title)}</title>` +
       `<style>body{margin:0;background:#101014;color:#e8e6e3;font:15px/1.5 system-ui,sans-serif;display:grid;place-items:center;min-height:100vh}main{max-width:26rem;padding:1rem;text-align:center}h1{font-size:1.1rem}</style>` +
-      `</head><body><main><h1>${title}</h1><p>${note}</p><p>You can close this tab.</p></main></body></html>`,
+      `</head><body><main><h1>${escapeHtml(title)}</h1><p>${escapeHtml(note)}</p><p>You can close this tab.</p></main></body></html>`,
   );
 }
 

--- a/scripts/lifeops/hitl-credential-dashboard.test.mjs
+++ b/scripts/lifeops/hitl-credential-dashboard.test.mjs
@@ -50,6 +50,15 @@ function waitForDashboard(child) {
   });
 }
 
+async function stopDashboard(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise((resolvePromise) => {
+    child.once("exit", resolvePromise);
+  });
+  child.kill("SIGTERM");
+  await exited;
+}
+
 async function postEnv(baseUrl, headers, value) {
   return fetch(`${baseUrl}api/env`, {
     method: "POST",
@@ -135,8 +144,7 @@ test("credential dashboard rejects cross-site writes and requires its page sessi
       /TELEGRAM_BOT_TOKEN=operator-token-value/,
     );
   } finally {
-    child.kill("SIGTERM");
-    await new Promise((resolvePromise) => child.once("exit", resolvePromise));
+    await stopDashboard(child);
     rmSync(home, { recursive: true, force: true });
   }
 });
@@ -189,9 +197,50 @@ test("discord loopback OAuth surfaces fail closed without registration or a know
     const callbackHtml = await callback.text();
     assert.match(callbackHtml, /unknown or expired/);
     assert.equal(existsSync(envPath), false);
+
+    const authHeaders = {
+      Origin: sameOrigin,
+      "Content-Type": "application/json",
+      "X-HITL-Session": tokenMatch[1],
+    };
+    for (const [key, value] of [
+      ["DISCORD_CLIENT_ID", "123456789"],
+      ["DISCORD_CLIENT_SECRET", "test-only-secret"],
+    ]) {
+      const saved = await fetch(`${baseUrl}api/env`, {
+        method: "POST",
+        headers: authHeaders,
+        body: JSON.stringify({ key, value, target: "home" }),
+      });
+      assert.equal(saved.status, 200);
+    }
+
+    const registeredStart = await fetch(
+      `${baseUrl}api/oneclick/discord-oauth/start`,
+      {
+        method: "POST",
+        headers: authHeaders,
+        body: JSON.stringify({ target: "home" }),
+      },
+    );
+    assert.equal(registeredStart.status, 200);
+    const { authorizeUrl } = await registeredStart.json();
+    const state = new URL(authorizeUrl).searchParams.get("state");
+    assert.ok(state);
+
+    const payload = `<img src=x onerror=alert(1)>"'&`;
+    const hostileCallback = await fetch(
+      `${baseUrl}oauth/discord/callback?state=${encodeURIComponent(state)}&error=${encodeURIComponent(payload)}`,
+    );
+    assert.equal(hostileCallback.status, 400);
+    const hostileCallbackHtml = await hostileCallback.text();
+    assert.doesNotMatch(hostileCallbackHtml, /<img src=x/);
+    assert.match(
+      hostileCallbackHtml,
+      /&lt;img src=x onerror=alert\(1\)&gt;&quot;&#39;&amp;/,
+    );
   } finally {
-    child.kill("SIGTERM");
-    await new Promise((resolvePromise) => child.once("exit", resolvePromise));
+    await stopDashboard(child);
     rmSync(home, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

- decode HTML entities in one pass so double-encoded text is not reprocessed into active syntax
- make script/style plain-text filtering accept valid whitespace before closing-tag delimiters
- enforce the native-canvas navigation protocol allowlist for HTTP(S), supported blob URLs, and `about:blank`
- HTML-escape Discord OAuth callback values before dashboard rendering
- add adversarial regressions for double encoding, spaced tags, dangerous schemes, and reflected markup

This fixes CodeQL alerts #682, #684, #862, #892, #931, #970, #972, and #1096 tracked in #22087 without adding CodeQL to pull-request workflows.

## Verification

- exact-head focused tests: 168 passed, 0 failed across Gmail, core link extraction, web search, Slack, coding tools, native canvas, and the HITL dashboard
- typechecks passed: cloud shared, core, web search, Slack, coding tools, and native canvas
- changed-file Biome passed all 14 files
- affected package lint gates passed; core reported only seven pre-existing warnings in an unrelated test

Full repository and hosted gates remain required before merge.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@771d493fe6d50c33ef8eb3b0560260da7dffe55c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@771d493fe6d50c33ef8eb3b0560260da7dffe55c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-codeql]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@771d493fe6d50c33ef8eb3b0560260da7dffe55c:packages/skills/skills/contribute-to-eliza"} -->

## Evidence Gate

<!-- evidence-head:771d493fe6d50c33ef8eb3b0560260da7dffe55c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered product pixels or layout changed in this scoped boundary-hardening change.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered product pixels or layout changed in this scoped boundary-hardening change.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no product interaction flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - focused parser, navigation, and loopback boundary validation is documented above; no protected backend was mutated.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no rendered product state or browser-network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no production prompt, model selection, or model-output behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact focused test counts and adversarial coverage are documented above; no separate runtime artifact was produced.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no product pixels changed.
