### PR TITLE
fix(cloud): normalize terminal deletion timestamps

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-completed-at.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-completed-at.test.ts
@@ -3,8 +3,9 @@
  * status (failed, cancelled, completed) sets `completed_at` transactionally,
  * and retry transitions back to `pending` clear it. Uses real PGlite state.
  */
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { eq } from "drizzle-orm";
+import { type RuntimeR2Bucket, setRuntimeR2Bucket } from "../../../lib/storage/r2-runtime-binding";
 import { type Job, jobs } from "../../schemas/jobs";
 
 process.env.DATABASE_URL ||= "pglite://memory";
@@ -20,6 +21,29 @@ const JOB_STARTED_AT = new Date("2020-01-01T00:00:00.000Z");
 let dbWrite: typeof import("../../client").dbWrite;
 let closeDb: typeof import("../../client").closeDatabaseConnectionsForTests | undefined;
 let repo: typeof import("../jobs").jobsRepository;
+
+function memoryBucket(objects: Map<string, string>): RuntimeR2Bucket {
+  return {
+    async get(key) {
+      const value = objects.get(key);
+      return value === undefined
+        ? null
+        : {
+            async text() {
+              return value;
+            },
+          };
+    },
+    async put(key, value) {
+      objects.set(key, typeof value === "string" ? value : String(value ?? ""));
+      return {};
+    },
+    async delete(key) {
+      objects.delete(key);
+      return {};
+    },
+  };
+}
 
 async function seedJob(params: {
   id: string;
@@ -114,6 +138,9 @@ afterAll(async () => {
 
 describe("completed_at terminal-timestamp contract", () => {
   beforeEach(async () => {
+    setRuntimeR2Bucket(null);
+    delete process.env.SQL_HEAVY_PAYLOAD_STORAGE;
+    delete process.env.SQL_HEAVY_PAYLOAD_MIN_BYTES;
     await dbWrite.execute("DELETE FROM jobs;");
   });
 
@@ -202,6 +229,33 @@ describe("completed_at terminal-timestamp contract", () => {
       const job = await getJob(id);
       expect(job?.status).toBe("failed");
       expect(job?.completed_at).not.toBeNull();
+    });
+
+    test("terminalizes a JSON-round-tripped deletion job without calling toISOString on a string", async () => {
+      const id = "00000000-0000-4900-8000-000000000012";
+      await seedJob({ id, maxAttempts: 1, attempts: 0, type: "agent_delete" });
+      const stored = await repo.findById(id);
+      if (!stored) throw new Error("seeded job not found");
+      const roundTripped = JSON.parse(JSON.stringify(stored)) as Job;
+      const findSpy = spyOn(repo, "findByIdForWrite").mockResolvedValueOnce(roundTripped);
+      const objects = new Map<string, string>();
+      setRuntimeR2Bucket(memoryBucket(objects));
+      process.env.SQL_HEAVY_PAYLOAD_STORAGE = "r2";
+      process.env.SQL_HEAVY_PAYLOAD_MIN_BYTES = "1";
+
+      try {
+        const failed = await repo.incrementAttempt(id, "delete failed", 1);
+        expect(failed?.status).toBe("failed");
+        expect(failed?.scheduled_for).toEqual(JOB_STARTED_AT);
+        expect(failed?.completed_at).not.toBeNull();
+        expect(failed?.error).toBe("delete failed");
+        expect([...objects.keys()]).toEqual([`job-payloads/${ORG_ID}/2020-01-01/${id}/error.txt`]);
+      } finally {
+        findSpy.mockRestore();
+        setRuntimeR2Bucket(null);
+        delete process.env.SQL_HEAVY_PAYLOAD_STORAGE;
+        delete process.env.SQL_HEAVY_PAYLOAD_MIN_BYTES;
+      }
     });
 
     test("keeps completed_at null on retry (not yet exhausted)", async () => {

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -144,6 +144,14 @@ function timestampMillis(value: Date | string | null): number | null {
       : Date.parse(String(value));
 }
 
+function timestampDate(value: Date | string, field: string): Date {
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(parsed.getTime())) {
+    throw new Error(`Persisted job ${field} is not a valid timestamp`);
+  }
+  return parsed;
+}
+
 function sameTimestamp(left: Date | string | null, right: Date | string | null): boolean {
   return timestampMillis(left) === timestampMillis(right);
 }
@@ -1605,13 +1613,19 @@ export class JobsRepository {
     // Exponential backoff: 30s, 2min, 8min for attempts 1, 2, 3
     const backoffMs = isFailed ? 0 : 4 ** (newAttempts - 1) * 30 * 1000;
     const scheduledFor = new Date(Date.now() + backoffMs);
+    // Validate every transported timestamp before object upload or SQL bind.
+    // This prevents both the R2 key builder and Drizzle timestamp encoder from
+    // receiving a JSON-round-tripped ISO string, and avoids uploading an
+    // orphaned error object before discovering a malformed scheduled value.
+    const createdAt = timestampDate(job.created_at, "created_at");
+    const terminalScheduledFor = timestampDate(job.scheduled_for, "scheduled_for");
 
     const payload = await prepareJobPayload(
       { error },
       {
         id: job.id,
         organization_id: job.organization_id,
-        created_at: job.created_at,
+        created_at: createdAt,
       },
     );
 
@@ -1655,7 +1669,7 @@ export class JobsRepository {
             ? new Date()
             : job.execution_quiesced_at,
           updated_at: new Date(),
-          scheduled_for: isFailed ? job.scheduled_for : scheduledFor,
+          scheduled_for: isFailed ? terminalScheduledFor : scheduledFor,
         })
         .where(
           and(


### PR DESCRIPTION
# Scope

Refs #23117.

Terminal deletion settlement preserves the job's original `scheduled_for`. If the row crossed a JSON/object-storage boundary, that valid timestamp is an ISO string, while Drizzle's timestamp encoder calls `.toISOString()` on a `Date`. The resulting failure exactly matches the dominant production error.

This patch restores and validates the timestamp at the repository write boundary. It adds a real PGlite regression that JSON-round-trips an `agent_delete` row before `incrementAttempt` terminalizes it.

# Load-bearing proof

Candidate: `fc3f43f585081636abb7f705e9748691776723d3`

Parent develop: `84f58095b90b425d81bbaf6ff93914797045a332`

- complete real PGlite terminal timestamp lane: 22/22
- exact JSON-round-tripped deletion regression: pass
- real in-memory R2 offload stores and rehydrates the complete error under the original creation day
- negative controls restoring either raw transported timestamp fail with `TypeError: ...toISOString is not a function`
- pinned Biome on both files: pass
- `git diff --check`: pass

# Evidence Gate

<!-- evidence-head:fc3f43f585081636abb7f705e9748691776723d3 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual or interactive flow changes.
<!-- evidence-row:backend-logs -->
- [x] [23117-exact-fc3f4.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23117-exact-fc3f4.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changes.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model or planner behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [23117-domain-fc3f4.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23117-domain-fc3f4.md)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Known limits

- No production job replay or row mutation was performed.
- #23117 remains open for protected repair/readback of already stranded rows.
- #23244 carries the explicit customer recovery path and is independently reviewed.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->
