### PR TITLE
fix(cloud): bind e2e cleanup to reviewed agents

### DIFF
--- a/packages/app/test/android/README.md
+++ b/packages/app/test/android/README.md
@@ -262,12 +262,22 @@ credits and makes later runs look less like a first run. Before rerunning
 the lanes, reconcile the org with the cleanup lane from the repo root:
 
 ```bash
-bun run cloud:e2e:agents:cleanup                 # dry run: list + selection
-bun run cloud:e2e:agents:cleanup -- --apply --wait   # delete leaked agents
+bun run cloud:e2e:agents:cleanup -- --report /tmp/cloud-agent-dry-run.json
+
+# Review the dry-run identity and candidate rows, then bind mutation to them:
+bun run cloud:e2e:agents:cleanup -- \
+  --apply --wait \
+  --candidate <reviewed-agent-id> \
+  --expected-address <siwe-wallet-address> \
+  --expected-org <organization-id> \
+  --report /tmp/cloud-agent-cleanup-receipt.json
 ```
 
-It only selects `dedicated-always` agents with a valid creation time, keeps the
-newest eligible agent, and never touches eligible agents younger than 30
-minutes (so it cannot race an in-flight onboarding run). It also supports
-`--protect <agentId>`, `--keep <n>`, and `--report <path>`. See
+The dry run proposes only dated `dedicated-always` rows older than 30 minutes.
+Age is not mutation authority: `--apply` requires every reviewed candidate ID,
+the expected SIWE wallet and organization, `--wait`, and a receipt path. Each
+request is conditionally bound to the listed name, creation timestamp, and
+execution tier; success also requires a fresh list proving absence. Omit an
+active run's ID or pass `--protect <agentId>`. `--keep <n>` retains the newest
+eligible rows when preparing the candidate set. See
 `scripts/cloud/e2e-agent-cleanup.mjs`.

--- a/scripts/cloud/__tests__/e2e-agent-cleanup.test.mjs
+++ b/scripts/cloud/__tests__/e2e-agent-cleanup.test.mjs
@@ -5,25 +5,36 @@
  * or cloud credentials.
  */
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import {
+  assertExpectedCleanupIdentity,
+  bindReviewedCleanupCandidates,
   normalizeAgentRow,
   resolveE2eWalletPrivateKey,
   selectAgentsForCleanup,
 } from "../e2e-agent-cleanup-lib.mjs";
 
+setDefaultTimeout(30_000);
+
 const HOUR = 60 * 60 * 1000;
 const NOW = Date.parse("2026-08-20T12:00:00Z");
-const agent = (id, ageMs, extra = {}) => ({
-  id,
-  agentName: `a-${id}`,
-  status: "running",
-  executionTier: "dedicated-always",
-  createdAtMs: ageMs === null ? null : NOW - ageMs,
-  ...extra,
-});
+const agent = (id, ageMs, extra = {}) => {
+  const createdAtMs = ageMs === null ? null : NOW - ageMs;
+  return {
+    id,
+    agentName: `a-${id}`,
+    status: "running",
+    executionTier: "dedicated-always",
+    createdAt:
+      createdAtMs === null ? null : new Date(createdAtMs).toISOString(),
+    createdAtMs,
+    ...extra,
+  };
+};
 
 describe("resolveE2eWalletPrivateKey", () => {
   test("assembles the deterministic default wallet", () => {
@@ -55,6 +66,7 @@ describe("normalizeAgentRow", () => {
       agentName: "Eliza",
       status: "running",
       executionTier: "dedicated-always",
+      createdAt: "2026-08-20T11:00:00.000Z",
       createdAtMs: Date.parse("2026-08-20T11:00:00Z"),
     });
   });
@@ -136,9 +148,53 @@ describe("selectAgentsForCleanup", () => {
     expect(toDelete).toEqual([]);
   });
 
+  test("defaults to selecting a singleton stale leak", () => {
+    expect(
+      selectAgentsForCleanup([agent("only", 20 * HOUR)], {
+        minAgeMs: 0,
+        now: NOW,
+      }).toDelete.map((entry) => entry.id),
+    ).toEqual(["only"]);
+  });
+
   test("rejects invalid options", () => {
     expect(() => selectAgentsForCleanup([], { keepNewest: -1 })).toThrow();
     expect(() => selectAgentsForCleanup([], { minAgeMs: -5 })).toThrow();
+  });
+});
+
+describe("destructive binding", () => {
+  test("requires reviewed IDs and treats absent IDs as resumable completion", () => {
+    const listed = [agent("safe", 20 * HOUR), agent("blocked", 5 * 60 * 1000)];
+    const selectable = selectAgentsForCleanup(listed, {
+      minAgeMs: HOUR,
+      now: NOW,
+    }).toDelete;
+    expect(
+      bindReviewedCleanupCandidates(listed, selectable, ["safe", "absent"]),
+    ).toEqual({ toDelete: [listed[0]], alreadyAbsent: ["absent"] });
+    expect(() =>
+      bindReviewedCleanupCandidates(listed, selectable, ["blocked"]),
+    ).toThrow("not safely selectable");
+  });
+
+  test("requires independently expected wallet and organization identity", () => {
+    const identity = {
+      address: "0x1111111111111111111111111111111111111111",
+      organizationId: "11111111-1111-4111-8111-111111111111",
+    };
+    expect(() =>
+      assertExpectedCleanupIdentity(identity, {
+        expectedAddress: identity.address,
+        expectedOrganizationId: identity.organizationId,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertExpectedCleanupIdentity(identity, {
+        expectedAddress: "0x2222222222222222222222222222222222222222",
+        expectedOrganizationId: identity.organizationId,
+      }),
+    ).toThrow("identity mismatch");
   });
 });
 
@@ -154,7 +210,248 @@ describe("cli", () => {
     expect(result.stdout).toContain("--min-age-minutes");
   });
 
-  test("real loopback apply deletes only an old dedicated agent and waits for its job", async () => {
+  test("rejects missing flag values and unverifiable non-loopback token mutation before network", async () => {
+    const missing = await runCli(["--protect", "--apply"]);
+    expect(missing.exitCode).toBe(1);
+    expect(missing.stderr).toContain("--protect requires a value");
+    const malformedNumber = await runCli(["--keep", "1x"]);
+    expect(malformedNumber.exitCode).toBe(1);
+    expect(malformedNumber.stderr).toContain("--keep must be");
+
+    const receipt = temporaryReport();
+    try {
+      const remote = await runCli([
+        "--apply",
+        "--wait",
+        "--candidate",
+        "agent-1",
+        "--expected-address",
+        TEST_ADDRESS,
+        "--expected-org",
+        TEST_ORG,
+        "--report",
+        receipt.reportPath,
+      ]);
+      expect(remote.exitCode).toBe(1);
+      expect(remote.stderr).toContain("may not apply cleanup");
+    } finally {
+      receipt.cleanup();
+    }
+  });
+
+  test("loopback apply binds conditional identity, waits, verifies absence, and resumes as a no-op", async () => {
+    const requests = [];
+    const deleteBodies = [];
+    let agents = [
+      {
+        id: "old-dedicated",
+        agentName: "Device E2E residue",
+        executionTier: "dedicated-always",
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "old-shared",
+        agentName: "Shared",
+        executionTier: "shared",
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+    ];
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url);
+        requests.push(`${request.method} ${url.pathname}`);
+        if (url.pathname === "/api/v1/credits/balance") {
+          return Response.json({ balance: 10 });
+        }
+        if (url.pathname === "/api/v1/eliza/agents") {
+          return Response.json({ data: agents });
+        }
+        if (url.pathname === "/api/v1/eliza/agents/old-dedicated") {
+          deleteBodies.push(await request.json());
+          agents = agents.filter((entry) => entry.id !== "old-dedicated");
+          return Response.json(
+            { data: { jobId: "delete-job" } },
+            { status: 202 },
+          );
+        }
+        if (url.pathname === "/api/v1/jobs/delete-job") {
+          return Response.json({ data: { status: "completed" } });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const receipt = temporaryReport();
+    try {
+      const args = applyArgs(server, receipt.reportPath, ["old-dedicated"]);
+      const result = await runCli(args);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("deleted old-dedicated: job/completed");
+      expect(requests).toContain("DELETE /api/v1/eliza/agents/old-dedicated");
+      expect(deleteBodies).toEqual([
+        {
+          expectedAgentName: "Device E2E residue",
+          expectedCreatedAt: "2026-01-01T00:00:00.000Z",
+          expectedExecutionTier: "dedicated-always",
+        },
+      ]);
+      expect(
+        JSON.parse(fs.readFileSync(receipt.reportPath, "utf8")),
+      ).toMatchObject({
+        failure: null,
+        verifiedAbsent: ["old-dedicated"],
+        attempts: [{ agentId: "old-dedicated", status: "completed" }],
+      });
+
+      const second = await runCli(args);
+      expect(second.exitCode).toBe(0);
+      expect(deleteBodies).toHaveLength(1);
+      expect(
+        JSON.parse(fs.readFileSync(receipt.reportPath, "utf8")),
+      ).toMatchObject({
+        alreadyAbsent: ["old-dedicated"],
+        attempts: [],
+        verifiedAbsent: ["old-dedicated"],
+      });
+    } finally {
+      server.stop(true);
+      receipt.cleanup();
+    }
+  });
+
+  test("treats HTTP failure as authoritative and persists a resumable partial receipt", async () => {
+    let agents = [oldAgentRow("first"), oldAgentRow("second")];
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === "/api/v1/credits/balance") {
+          return Response.json({ balance: 10 });
+        }
+        if (url.pathname === "/api/v1/eliza/agents") {
+          return Response.json({ data: agents });
+        }
+        if (url.pathname.endsWith("/first")) {
+          agents = agents.filter((entry) => entry.id !== "first");
+          return Response.json({ success: true });
+        }
+        if (url.pathname.endsWith("/second")) {
+          return Response.json(
+            { success: true, error: "identity mismatch" },
+            { status: 409 },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const receipt = temporaryReport();
+    try {
+      const result = await runCli(
+        applyArgs(server, receipt.reportPath, ["first", "second"]),
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Cloud request failed (409)");
+      const report = JSON.parse(fs.readFileSync(receipt.reportPath, "utf8"));
+      expect(
+        report.attempts.map(({ agentId, status }) => [agentId, status]),
+      ).toEqual([
+        ["first", "completed"],
+        ["second", "failed"],
+      ]);
+      expect(report.failure).toContain("Cloud request failed (409)");
+    } finally {
+      server.stop(true);
+      receipt.cleanup();
+    }
+  });
+
+  test("fails when post-delete readback still lists the reviewed candidate", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === "/api/v1/credits/balance")
+          return Response.json({ balance: 10 });
+        if (url.pathname === "/api/v1/eliza/agents") {
+          return Response.json({ data: [oldAgentRow("still-listed")] });
+        }
+        if (url.pathname === "/api/v1/eliza/agents/still-listed") {
+          return Response.json({ success: true });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const receipt = temporaryReport();
+    try {
+      const result = await runCli(
+        applyArgs(server, receipt.reportPath, ["still-listed"]),
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("post-delete verification still listed");
+      expect(
+        JSON.parse(fs.readFileSync(receipt.reportPath, "utf8")),
+      ).toMatchObject({
+        failure: "post-delete verification still listed: still-listed",
+        attempts: [{ agentId: "still-listed", status: "completed" }],
+        verifiedAbsent: [],
+      });
+    } finally {
+      server.stop(true);
+      receipt.cleanup();
+    }
+  });
+
+  test.each([
+    ["failed", "delete job delete-job for old failed"],
+    ["running", "delete job delete-job for old timed out"],
+  ])(
+    "fails closed on a %s delete job and writes the failure receipt",
+    async (jobStatus, expectedError) => {
+      const server = Bun.serve({
+        port: 0,
+        fetch(request) {
+          const url = new URL(request.url);
+          if (url.pathname === "/api/v1/credits/balance")
+            return Response.json({ balance: 10 });
+          if (url.pathname === "/api/v1/eliza/agents") {
+            return Response.json({ data: [oldAgentRow("old")] });
+          }
+          if (url.pathname === "/api/v1/eliza/agents/old") {
+            return Response.json(
+              { data: { jobId: "delete-job" } },
+              { status: 202 },
+            );
+          }
+          if (url.pathname === "/api/v1/jobs/delete-job") {
+            return Response.json({ data: { status: jobStatus } });
+          }
+          return new Response("not found", { status: 404 });
+        },
+      });
+      const receipt = temporaryReport();
+      try {
+        const result = await runCli([
+          ...applyArgs(server, receipt.reportPath, ["old"]),
+          "--job-timeout-ms",
+          "20",
+          "--poll-interval-ms",
+          "1",
+        ]);
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toContain(expectedError);
+        expect(
+          JSON.parse(fs.readFileSync(receipt.reportPath, "utf8")),
+        ).toMatchObject({
+          attempts: [{ agentId: "old", status: "failed" }],
+        });
+      } finally {
+        server.stop(true);
+        receipt.cleanup();
+      }
+    },
+  );
+
+  test("fails before DELETE when the list contains a malformed row", async () => {
     const requests = [];
     const server = Bun.serve({
       port: 0,
@@ -166,95 +463,74 @@ describe("cli", () => {
         }
         if (url.pathname === "/api/v1/eliza/agents") {
           return Response.json({
-            data: [
-              {
-                id: "old-dedicated",
-                executionTier: "dedicated-always",
-                createdAt: "2026-01-01T00:00:00Z",
-              },
-              {
-                id: "old-shared",
-                executionTier: "shared",
-                createdAt: "2026-01-01T00:00:00Z",
-              },
-              {
-                id: "undated-dedicated",
-                executionTier: "dedicated-always",
-              },
-            ],
+            data: [{ executionTier: "dedicated-always" }],
           });
         }
-        if (url.pathname === "/api/v1/eliza/agents/old-dedicated") {
-          return Response.json({ data: { jobId: "delete-job" } }, { status: 202 });
-        }
-        if (url.pathname === "/api/v1/jobs/delete-job") {
-          return Response.json({ data: { status: "completed" } });
-        }
         return new Response("not found", { status: 404 });
       },
     });
+    const receipt = temporaryReport();
     try {
-      const result = await runCli([
-        "--base",
-        server.url.toString(),
-        "--apply",
-        "--wait",
-        "--keep",
-        "0",
-        "--min-age-minutes",
-        "0",
-      ]);
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("deleted old-dedicated: job/completed");
-      expect(requests).toContain("DELETE /api/v1/eliza/agents/old-dedicated");
-      expect(requests.some((entry) => entry.includes("old-shared"))).toBe(false);
-      expect(requests.some((entry) => entry.includes("undated-dedicated"))).toBe(
-        false,
+      const result = await runCli(
+        applyArgs(server, receipt.reportPath, ["malformed"]),
       );
-    } finally {
-      server.stop(true);
-    }
-  });
-
-  test("real loopback apply fails closed when the list contains a malformed row", async () => {
-    const requests = [];
-    const server = Bun.serve({
-      port: 0,
-      fetch(request) {
-        const url = new URL(request.url);
-        requests.push(`${request.method} ${url.pathname}`);
-        if (url.pathname === "/api/v1/credits/balance") {
-          return Response.json({ balance: 10 });
-        }
-        if (url.pathname === "/api/v1/eliza/agents") {
-          return Response.json({ data: [{ executionTier: "dedicated-always" }] });
-        }
-        return new Response("not found", { status: 404 });
-      },
-    });
-    try {
-      const result = await runCli([
-        "--base",
-        server.url.toString(),
-        "--apply",
-      ]);
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain("without a usable id");
       expect(requests.some((entry) => entry.startsWith("DELETE "))).toBe(false);
     } finally {
       server.stop(true);
+      receipt.cleanup();
     }
   });
 });
 
-async function runCli(args) {
-  const script = path.join(
-    import.meta.dirname,
-    "..",
-    "e2e-agent-cleanup.mjs",
+const TEST_ADDRESS = "0x1111111111111111111111111111111111111111";
+const TEST_ORG = "11111111-1111-4111-8111-111111111111";
+
+function oldAgentRow(id) {
+  return {
+    id,
+    agentName: `Device E2E ${id}`,
+    executionTier: "dedicated-always",
+    createdAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+function temporaryReport() {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "eliza-e2e-cleanup-"),
   );
+  return {
+    reportPath: path.join(directory, "receipt.json"),
+    cleanup: () => fs.rmSync(directory, { recursive: true, force: true }),
+  };
+}
+
+function applyArgs(server, reportPath, candidateIds) {
+  return [
+    "--base",
+    server.url.toString(),
+    "--apply",
+    "--wait",
+    ...candidateIds.flatMap((id) => ["--candidate", id]),
+    "--expected-address",
+    TEST_ADDRESS,
+    "--expected-org",
+    TEST_ORG,
+    "--report",
+    reportPath,
+    "--min-age-minutes",
+    "0",
+  ];
+}
+
+async function runCli(args) {
+  const script = path.join(import.meta.dirname, "..", "e2e-agent-cleanup.mjs");
   const process = Bun.spawn(["bun", script, ...args], {
-    env: { ...Bun.env, ELIZA_CLOUD_AUTH_TOKEN: "loopback-test-token" },
+    env: {
+      ...Bun.env,
+      ELIZA_CLOUD_AUTH_TOKEN: "loopback-test-token",
+    },
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/scripts/cloud/e2e-agent-cleanup-lib.mjs
+++ b/scripts/cloud/e2e-agent-cleanup-lib.mjs
@@ -52,13 +52,17 @@ export function normalizeAgentRow(raw) {
   if (!id) return null;
   const createdAtRaw = firstString(rec.createdAt, rec.created_at);
   const createdAtMs = createdAtRaw ? Date.parse(createdAtRaw) : Number.NaN;
+  const createdAt = Number.isFinite(createdAtMs)
+    ? new Date(createdAtMs).toISOString()
+    : null;
   return {
     id,
     agentName: firstString(rec.agentName, rec.agent_name, rec.name) ?? "",
     status: firstString(rec.status) ?? "unknown",
     executionTier:
       firstString(rec.executionTier, rec.execution_tier) ?? "unknown",
-    createdAtMs: Number.isFinite(createdAtMs) ? createdAtMs : null,
+    createdAt,
+    createdAtMs: createdAt === null ? null : createdAtMs,
   };
 }
 
@@ -73,15 +77,17 @@ function firstString(...values) {
  * Select the leaked agents to delete. Contract:
  * - agents in `protectIds` are never selected;
  * - only `dedicated-always` agents with a valid creation time are eligible;
+ * - rows missing the identity required by conditional DELETE are retained;
  * - the `keepNewest` most recently created eligible agents are retained;
- * - agents younger than `minAgeMs` are retained, so the lane can never race
- *   an onboarding run that is provisioning its agent right now.
+ * - agents younger than `minAgeMs` are retained as a first filter; explicit
+ *   reviewed IDs remain the mutation authority because age does not prove a
+ *   provisioning run is inactive.
  * Returns { toDelete, kept } with reasons on every kept row.
  */
 export function selectAgentsForCleanup(
   agents,
   {
-    keepNewest = 1,
+    keepNewest = 0,
     minAgeMs = 30 * 60 * 1000,
     protectIds = [],
     now = Date.now(),
@@ -105,9 +111,9 @@ export function selectAgentsForCleanup(
       kept.push({ agent, reason: "not-dedicated-always" });
     } else if (agent.createdAtMs === null) {
       kept.push({ agent, reason: "unknown-created-at" });
-    } else if (
-      now - agent.createdAtMs < minAgeMs
-    ) {
+    } else if (!agent.agentName || !agent.createdAt) {
+      kept.push({ agent, reason: "missing-conditional-identity" });
+    } else if (now - agent.createdAtMs < minAgeMs) {
       kept.push({ agent, reason: "younger-than-min-age" });
     } else {
       eligible.push(agent);
@@ -118,4 +124,57 @@ export function selectAgentsForCleanup(
     kept.push({ agent, reason: "kept-newest" });
   }
   return { toDelete: eligible.slice(keepNewest), kept };
+}
+
+/**
+ * Bind a destructive run to IDs explicitly reviewed from a prior dry run.
+ * Missing IDs are already-complete resume entries; listed IDs outside the
+ * safe selection are rejected rather than silently skipped.
+ */
+export function bindReviewedCleanupCandidates(
+  agents,
+  selectableAgents,
+  candidateIds,
+) {
+  const listed = new Map(agents.map((agent) => [agent.id, agent]));
+  const selectable = new Map(
+    selectableAgents.map((agent) => [agent.id, agent]),
+  );
+  const uniqueCandidates = [...new Set(candidateIds)];
+  const alreadyAbsent = [];
+  const blocked = [];
+  const toDelete = [];
+  for (const id of uniqueCandidates) {
+    if (!listed.has(id)) {
+      alreadyAbsent.push(id);
+    } else if (!selectable.has(id)) {
+      blocked.push(id);
+    } else {
+      toDelete.push(selectable.get(id));
+    }
+  }
+  if (blocked.length > 0) {
+    throw new Error(
+      `reviewed candidate(s) are not safely selectable: ${blocked.join(", ")}`,
+    );
+  }
+  return { toDelete, alreadyAbsent };
+}
+
+/** Require the authenticated SIWE identity to match independent operator input. */
+export function assertExpectedCleanupIdentity(
+  identity,
+  { expectedAddress, expectedOrganizationId },
+) {
+  if (!identity) {
+    throw new Error("apply requires a verifiable SIWE identity");
+  }
+  if (
+    identity.address.toLowerCase() !== expectedAddress.toLowerCase() ||
+    identity.organizationId !== expectedOrganizationId
+  ) {
+    throw new Error(
+      `authenticated identity mismatch: address=${identity.address} org=${identity.organizationId}`,
+    );
+  }
 }

--- a/scripts/cloud/e2e-agent-cleanup.mjs
+++ b/scripts/cloud/e2e-agent-cleanup.mjs
@@ -7,38 +7,52 @@
  *
  * Signs in headlessly with the same deterministic e2e wallet the onboarding
  * lanes use (real EIP-4361 handshake — no mock), lists the org's agents, and
- * deletes the leaked ones. Dry-run by default; --apply performs deletions.
- * DELETE either completes synchronously (shared runtime) or returns a 202
- * job which --wait polls to completion.
+ * proposes leaked candidates. Dry-run is the only implicit mode. Mutation
+ * requires reviewed candidate IDs, an independently expected SIWE wallet and
+ * organization, a durable receipt path, conditional DELETE identity, job
+ * completion, and post-delete absence verification.
  *
  * Usage:
  *   bun run cloud:e2e:agents:cleanup                    # dry run vs https://api.eliza.app
- *   bun run cloud:e2e:agents:cleanup -- --apply --wait
+ *   bun run cloud:e2e:agents:cleanup -- --report /tmp/cleanup-dry-run.json
+ *   bun run cloud:e2e:agents:cleanup -- --apply --wait \
+ *     --candidate <reviewed-id> --expected-address <wallet> \
+ *     --expected-org <org-id> --report /tmp/cleanup-receipt.json
  *   bun run cloud:e2e:agents:cleanup -- --base <url> --keep 2 --min-age-minutes 10
  *   bun run cloud:e2e:agents:cleanup -- --protect <agentId> --report <path>
- *   ELIZA_E2E_WALLET_PK=0x... overrides the wallet; ELIZA_CLOUD_AUTH_TOKEN
- *   skips SIWE and uses an existing bearer token instead.
+ *   ELIZA_E2E_WALLET_PK=0x... overrides the wallet. ELIZA_CLOUD_AUTH_TOKEN
+ *   supports remote dry runs only; mutation requires verifiable SIWE except
+ *   in deterministic loopback tests.
  */
 
 import fs from "node:fs";
 import {
+  assertExpectedCleanupIdentity,
+  bindReviewedCleanupCandidates,
   normalizeAgentRow,
   resolveE2eWalletPrivateKey,
   selectAgentsForCleanup,
 } from "./e2e-agent-cleanup-lib.mjs";
 
-const argIndex = (name) => process.argv.indexOf(name);
-const arg = (name, fallback = null) => {
-  const i = argIndex(name);
-  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
-};
-const argAll = (name) => {
+function argAll(name) {
   const values = [];
-  for (let i = 0; i < process.argv.length - 1; i += 1) {
-    if (process.argv[i] === name) values.push(process.argv[i + 1]);
+  for (let i = 2; i < process.argv.length; i += 1) {
+    if (process.argv[i] !== name) continue;
+    const value = process.argv[i + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`${name} requires a value`);
+    }
+    values.push(value);
   }
   return values;
-};
+}
+
+function arg(name, fallback = null) {
+  const values = argAll(name);
+  if (values.length > 1) throw new Error(`${name} may only be provided once`);
+  return values[0] ?? fallback;
+}
+
 const has = (name) => process.argv.includes(name);
 const log = (message) => console.log(`[e2e-agent-cleanup] ${message}`);
 
@@ -48,39 +62,122 @@ if (has("--help") || has("-h")) {
       "Usage: bun scripts/cloud/e2e-agent-cleanup.mjs [options]",
       "  --base <url>             cloud API base (default https://api.eliza.app)",
       "  --apply                  actually delete (default is dry run)",
-      "  --wait                   poll 202 delete jobs to completion",
-      "  --keep <n>               newest agents to retain (default 1)",
+      "  --wait                   required with --apply; verify delete jobs",
+      "  --candidate <agentId>    reviewed deletion candidate (repeatable)",
+      "  --expected-address <0x>  expected SIWE wallet (required to apply)",
+      "  --expected-org <uuid>    expected cloud org (required to apply)",
+      "  --keep <n>               newest eligible agents to retain (default 0)",
       "  --min-age-minutes <n>    never touch agents younger than this (default 30)",
       "  --protect <agentId>      never delete this agent (repeatable)",
-      "  --report <path>          write a JSON report",
+      "  --report <path>          write a JSON receipt (required to apply)",
+      "  --job-timeout-ms <n>     delete-job timeout (default 120000)",
+      "  --poll-interval-ms <n>   delete-job poll interval (default 5000)",
     ].join("\n"),
   );
   process.exit(0);
 }
 
-const baseUrl = (
-  arg("--base") ??
-  process.env.ELIZA_CLOUD_API_BASE ??
-  "https://api.eliza.app"
-).replace(/\/+$/, "");
-const keepNewest = Number.parseInt(arg("--keep", "1"), 10);
-const minAgeMs = Number.parseFloat(arg("--min-age-minutes", "30")) * 60_000;
-const protectIds = argAll("--protect");
-const apply = has("--apply");
-const wait = has("--wait");
-const reportPath = arg("--report");
+function parseNumberOption(name, fallback, { integer = false } = {}) {
+  const raw = arg(name, fallback);
+  if (!/^\d+(?:\.\d+)?$/.test(raw)) {
+    throw new Error(`${name} must be a non-negative number`);
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value) || (integer && !Number.isInteger(value))) {
+    throw new Error(
+      `${name} must be a non-negative ${integer ? "integer" : "number"}`,
+    );
+  }
+  return value;
+}
 
-async function resolveToken() {
+function parseOptions() {
+  const baseUrl = (
+    arg("--base") ??
+    process.env.ELIZA_CLOUD_API_BASE ??
+    "https://api.eliza.app"
+  ).replace(/\/+$/, "");
+  const parsedBase = new URL(baseUrl);
+  if (!/^https?:$/.test(parsedBase.protocol)) {
+    throw new Error("--base must be an http(s) URL");
+  }
+  const isLoopback = ["127.0.0.1", "localhost", "::1"].includes(
+    parsedBase.hostname,
+  );
+  if (parsedBase.protocol !== "https:" && !isLoopback) {
+    throw new Error("--base must use HTTPS unless it is loopback");
+  }
+  const options = {
+    baseUrl,
+    apply: has("--apply"),
+    wait: has("--wait"),
+    candidateIds: argAll("--candidate"),
+    expectedAddress: arg("--expected-address"),
+    expectedOrganizationId: arg("--expected-org"),
+    keepNewest: parseNumberOption("--keep", "0", { integer: true }),
+    minAgeMs: parseNumberOption("--min-age-minutes", "30") * 60_000,
+    protectIds: argAll("--protect"),
+    reportPath: arg("--report"),
+    jobTimeoutMs: parseNumberOption("--job-timeout-ms", "120000"),
+    pollIntervalMs: parseNumberOption("--poll-interval-ms", "5000"),
+    isLoopback,
+  };
+  for (const id of [...options.candidateIds, ...options.protectIds]) {
+    if (!/^[A-Za-z0-9_-]{1,128}$/.test(id)) {
+      throw new Error(`agent id is malformed: ${id}`);
+    }
+  }
+  if (options.jobTimeoutMs <= 0) {
+    throw new Error("--job-timeout-ms must be positive");
+  }
+  if (options.wait && !options.apply) {
+    throw new Error("--wait requires --apply");
+  }
+  if (options.apply) {
+    if (!options.wait) throw new Error("--apply requires --wait");
+    if (!options.reportPath) throw new Error("--apply requires --report");
+    if (options.candidateIds.length === 0) {
+      throw new Error("--apply requires at least one --candidate");
+    }
+    if (!/^0x[a-fA-F0-9]{40}$/.test(options.expectedAddress ?? "")) {
+      throw new Error("--apply requires a valid --expected-address");
+    }
+    if (
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        options.expectedOrganizationId ?? "",
+      )
+    ) {
+      throw new Error("--apply requires a valid --expected-org");
+    }
+  }
+  return options;
+}
+
+async function resolveToken(options) {
   const preset = process.env.ELIZA_CLOUD_AUTH_TOKEN?.trim();
   if (preset) {
+    if (options.apply && !options.isLoopback) {
+      throw new Error(
+        "ELIZA_CLOUD_AUTH_TOKEN may not apply cleanup against a non-loopback host; use verifiable SIWE",
+      );
+    }
     log("using ELIZA_CLOUD_AUTH_TOKEN (skipping SIWE login)");
-    return { token: preset, identity: null };
+    return {
+      token: preset,
+      identity: options.apply
+        ? {
+            address: options.expectedAddress,
+            organizationId: options.expectedOrganizationId,
+            userId: "loopback-test-user",
+          }
+        : null,
+    };
   }
   const { siweTestLogin } = await import(
     "@elizaos/cloud-shared/lib/auth/siwe-test-login"
   );
   const session = await siweTestLogin({
-    baseUrl,
+    baseUrl: options.baseUrl,
     privateKey: resolveE2eWalletPrivateKey(),
   });
   log(
@@ -96,8 +193,8 @@ async function resolveToken() {
   };
 }
 
-async function cloud(token, path, init = {}) {
-  const res = await fetch(`${baseUrl}${path}`, {
+async function cloud(options, token, path, init = {}) {
+  const res = await fetch(`${options.baseUrl}${path}`, {
     ...init,
     headers: {
       Accept: "application/json",
@@ -113,7 +210,7 @@ async function cloud(token, path, init = {}) {
   } catch {
     // error-policy:J3 non-JSON body is reported through the structured error below
   }
-  if (!res.ok && body?.success !== true) {
+  if (!res.ok) {
     throw new Error(
       `Cloud request failed (${res.status}) ${path}: ${text.slice(0, 300)}`,
     );
@@ -121,9 +218,9 @@ async function cloud(token, path, init = {}) {
   return { status: res.status, body };
 }
 
-async function creditBalance(token) {
+async function creditBalance(options, token) {
   try {
-    const res = await cloud(token, "/api/v1/credits/balance");
+    const res = await cloud(options, token, "/api/v1/credits/balance");
     return res.body?.balance ?? res.body?.data?.balance ?? null;
   } catch (error) {
     // error-policy:J4 balance is advisory context for the report; the cleanup
@@ -134,8 +231,8 @@ async function creditBalance(token) {
   }
 }
 
-async function listAgents(token) {
-  const res = await cloud(token, "/api/v1/eliza/agents");
+async function listAgents(options, token) {
+  const res = await cloud(options, token, "/api/v1/eliza/agents");
   const rows = Array.isArray(res.body?.data)
     ? res.body.data
     : Array.isArray(res.body)
@@ -154,44 +251,71 @@ async function listAgents(token) {
   return normalized;
 }
 
-async function deleteAgent(token, agent) {
+async function deleteAgent(options, token, agent) {
   const res = await cloud(
+    options,
     token,
     `/api/v1/eliza/agents/${encodeURIComponent(agent.id)}`,
-    { method: "DELETE" },
+    {
+      method: "DELETE",
+      body: JSON.stringify({
+        expectedAgentName: agent.agentName,
+        expectedCreatedAt: agent.createdAt,
+        expectedExecutionTier: agent.executionTier,
+      }),
+    },
   );
   if (res.status === 202) {
     const jobId = res.body?.data?.jobId ?? null;
-    if (wait && !jobId) {
+    if (!jobId) {
       throw new Error(`delete request for ${agent.id} omitted its job id`);
     }
-    if (wait) {
-      const deadline = Date.now() + 120_000;
-      while (Date.now() < deadline) {
-        const job = await cloud(
-          token,
-          `/api/v1/jobs/${encodeURIComponent(jobId)}`,
-        );
-        const status = String(
-          job.body?.data?.status ?? job.body?.status ?? "",
-        ).toLowerCase();
-        if (["completed", "complete", "success", "succeeded"].includes(status))
-          return { mode: "job", jobId, final: status };
-        if (["failed", "error"].includes(status))
-          throw new Error(`delete job ${jobId} for ${agent.id} failed`);
-        await new Promise((r) => setTimeout(r, 5_000));
-      }
-      throw new Error(`delete job ${jobId} for ${agent.id} timed out`);
+    const timeoutMs = options.jobTimeoutMs;
+    const pollIntervalMs = options.pollIntervalMs;
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      throw new Error("--job-timeout-ms must be positive");
     }
-    return { mode: "job", jobId, final: wait ? "unknown" : "enqueued" };
+    if (!Number.isFinite(pollIntervalMs) || pollIntervalMs < 0) {
+      throw new Error("--poll-interval-ms must be non-negative");
+    }
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const job = await cloud(
+        options,
+        token,
+        `/api/v1/jobs/${encodeURIComponent(jobId)}`,
+      );
+      const status = String(
+        job.body?.data?.status ?? job.body?.status ?? "",
+      ).toLowerCase();
+      if (["completed", "complete", "success", "succeeded"].includes(status))
+        return { mode: "job", jobId, final: status };
+      if (["failed", "error", "cancelled", "canceled"].includes(status))
+        throw new Error(
+          `delete job ${jobId} for ${agent.id} failed: ${status}`,
+        );
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+    throw new Error(`delete job ${jobId} for ${agent.id} timed out`);
   }
   return { mode: "sync", final: "deleted" };
 }
 
+function writeReport(reportPath, report) {
+  if (!reportPath) return;
+  const temporaryPath = `${reportPath}.tmp`;
+  fs.writeFileSync(temporaryPath, `${JSON.stringify(report, null, 2)}\n`);
+  fs.renameSync(temporaryPath, reportPath);
+}
+
 async function main() {
-  const { token, identity } = await resolveToken();
-  const balanceBefore = await creditBalance(token);
-  const agents = await listAgents(token);
+  const options = parseOptions();
+  const { token, identity } = await resolveToken(options);
+  if (options.apply) {
+    assertExpectedCleanupIdentity(identity, options);
+  }
+  const balanceBefore = await creditBalance(options, token);
+  const agents = await listAgents(options, token);
   log(`org has ${agents.length} agent(s); credits=${balanceBefore}`);
   for (const agent of agents) {
     log(
@@ -204,43 +328,83 @@ async function main() {
   }
 
   const { toDelete, kept } = selectAgentsForCleanup(agents, {
-    keepNewest,
-    minAgeMs,
-    protectIds,
+    keepNewest: options.keepNewest,
+    minAgeMs: options.minAgeMs,
+    protectIds: options.protectIds,
   });
   for (const { agent, reason } of kept) log(`keep   ${agent.id} (${reason})`);
   for (const agent of toDelete)
     log(
-      `${apply ? "DELETE" : "would delete"} ${agent.id} ("${agent.agentName}")`,
+      `${options.apply ? "eligible" : "would delete"} ${agent.id} ("${agent.agentName}")`,
     );
 
-  const deletions = [];
-  if (apply) {
-    for (const agent of toDelete) {
-      const result = await deleteAgent(token, agent);
-      log(`deleted ${agent.id}: ${result.mode}/${result.final}`);
-      deletions.push({ agentId: agent.id, ...result });
-    }
-  }
-  const balanceAfter = apply ? await creditBalance(token) : balanceBefore;
-
+  const bound = options.apply
+    ? bindReviewedCleanupCandidates(agents, toDelete, options.candidateIds)
+    : { toDelete, alreadyAbsent: [] };
   const report = {
-    baseUrl,
-    apply,
+    baseUrl: options.baseUrl,
+    apply: options.apply,
     identity,
     balanceBefore,
-    balanceAfter,
+    balanceAfter: balanceBefore,
     agents,
     kept: kept.map(({ agent, reason }) => ({ agentId: agent.id, reason })),
-    toDelete: toDelete.map((agent) => agent.id),
-    deletions,
+    eligible: toDelete.map((agent) => agent.id),
+    reviewedCandidates: options.candidateIds,
+    alreadyAbsent: bound.alreadyAbsent,
+    attempts: [],
+    verifiedAbsent: [],
+    failure: null,
   };
-  if (reportPath)
-    fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  writeReport(options.reportPath, report);
+
+  if (options.apply) {
+    for (const agent of bound.toDelete) {
+      const attempt = {
+        agentId: agent.id,
+        expectedAgentName: agent.agentName,
+        expectedCreatedAt: agent.createdAt,
+        expectedExecutionTier: agent.executionTier,
+        status: "started",
+      };
+      report.attempts.push(attempt);
+      writeReport(options.reportPath, report);
+      try {
+        const result = await deleteAgent(options, token, agent);
+        Object.assign(attempt, { status: "completed", ...result });
+        log(`deleted ${agent.id}: ${result.mode}/${result.final}`);
+      } catch (error) {
+        attempt.status = "failed";
+        attempt.error = error instanceof Error ? error.message : String(error);
+        report.failure = attempt.error;
+        writeReport(options.reportPath, report);
+        throw error;
+      }
+      writeReport(options.reportPath, report);
+    }
+
+    const remaining = new Set(
+      (await listAgents(options, token)).map((agent) => agent.id),
+    );
+    const notAbsent = bound.toDelete.filter((agent) => remaining.has(agent.id));
+    if (notAbsent.length > 0) {
+      report.failure = `post-delete verification still listed: ${notAbsent
+        .map((agent) => agent.id)
+        .join(", ")}`;
+      writeReport(options.reportPath, report);
+      throw new Error(report.failure);
+    }
+    report.verifiedAbsent = [
+      ...bound.alreadyAbsent,
+      ...bound.toDelete.map((agent) => agent.id),
+    ];
+    report.balanceAfter = await creditBalance(options, token);
+    writeReport(options.reportPath, report);
+  }
   log(
-    apply
-      ? `done: deleted ${deletions.length}/${toDelete.length}`
-      : `dry run: ${toDelete.length} agent(s) would be deleted (pass --apply)`,
+    options.apply
+      ? `done: verified ${report.verifiedAbsent.length} reviewed candidate(s) absent`
+      : `dry run: ${toDelete.length} eligible agent(s); review IDs before --apply`,
   );
 }
 


### PR DESCRIPTION
Fixes #23253.
Refs #14358; real Android/iOS device acceptance remains open there.

## Summary

Corrects the destructive boundary of the device-onboarding leaked-agent cleanup introduced by #22863:

- remote mutation now requires verifiable SIWE, an independently expected wallet address and organization, `--wait`, a durable receipt path, and at least one explicitly reviewed candidate ID
- bearer-token mutation is prohibited against non-loopback hosts
- each DELETE sends the route's exact conditional identity: agent name, canonical creation timestamp, and execution tier
- HTTP status is authoritative even if an error body says `success: true`
- async deletion must complete, and a fresh agent list must prove every reviewed candidate absent before success
- the receipt is atomically updated before/after each attempt and on failure, so partial multi-delete runs are resumable; already absent candidates are a safe second-run no-op
- the common single stale leak is proposed by default (`--keep 0`), while age remains only a filter and never mutation authority
- missing/malformed option values fail before network or mutation
- operator documentation now shows the dry-run/review/bound-apply workflow

## Exact-head validation

<!-- evidence-head:072b38f938a206cbc34e1aee603da26d2f2903b0 -->

Base: `44c82ac3efe571f452495df5d0f44c57d92e51e9`

- `bun test scripts/cloud/__tests__/e2e-agent-cleanup.test.mjs`: 20/20 passed, 55 assertions, 100% functions / 98.37% lines in the selection library
- covers wallet/org mismatch, malformed flags, remote bearer-token mutation refusal, singleton selection, conditional identity body, reused 202 job completion, successful and failed post-delete readback, second-run no-op, authoritative 409 despite `success:true`, failed job, timed-out job, malformed list, and partial multi-delete receipt
- Biome: clean on the three JavaScript files (the two environment variables already present in #22863 remain non-failing Turbo declaration warnings)
- `git diff --check`: clean
- `bun run check:agents-claude`: passed
- `bun run verify`: attempted; `check:agents-claude` passed, then the isolated sparse review checkout stopped at `check:biome-version` because unrelated workspace `packages/auth/package.json` is not materialized. No verify pass is claimed.
- final rebase onto current `develop` was patch-identical by range-diff; the 20-test suite was rerun and passed after rebase

No production deletion was performed. Mutation proof uses a real loopback HTTP server so failure, retry, conditional body, job polling, receipt, and readback paths are exercised without risking a credited organization.

## Evidence gate

<!-- evidence-row:before-screenshots -->
- [x] N/A — scripts and operator documentation only; no rendered UI changes.

<!-- evidence-row:after-screenshots -->
- [x] N/A — no rendered UI changes.

<!-- evidence-row:walkthrough-video -->
- [x] N/A — headless cleanup CLI; deterministic loopback transcripts are the domain evidence.

<!-- evidence-row:backend-logs -->
- [x] 20-test loopback suite exercises list, conditional DELETE, job polling, failure, retry, receipt, and post-delete readback.

<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend runtime path.

<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model, prompt, provider, or planner behavior.

<!-- evidence-row:domain-artifacts -->
- [x] Exact-head 20/20 test transcript summarized above; receipts are asserted from temporary files and removed by the test harness.

<!-- evidence-row:ocr-review -->
- [x] N/A — no visual artifact.

<!-- contribution-attribution:v1 -->
- AI assistance: yes
- Model(s) used: OpenAI Codex
- Agent tooling: Codex Desktop
- Provenance status: self-reported
