### PR TITLE
release: promote certified develop snapshot 44c82ac to main

### DIFF
--- a/packages/agent/src/api/push-token-routes.test.ts
+++ b/packages/agent/src/api/push-token-routes.test.ts
@@ -5,12 +5,23 @@
  * register, 400 validation, GET count with per-platform breakdown, DELETE
  * existence reporting, and the 503 returned when the push service is
  * unregistered.
+ *
+ * Also covers the uniform UTF-8 byte-cap rejection (POST body and the
+ * `:token` DELETE shape) and the typed-error HTTP mapping: a token-validation
+ * failure becomes 400 on every register/delete shape, while a genuine
+ * persistence failure propagates (server boundary → 500) and is never swallowed
+ * into a fake success.
  */
 import type http from "node:http";
+import { ElizaError } from "@elizaos/core";
 import { createMockRuntime } from "@elizaos/core/testing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NotificationPushService } from "../services/push/notification-push-service.ts";
-import type { PushTokenRegistry } from "../services/push/push-token-registry.ts";
+import {
+  PUSH_TOKEN_INVALID_CODE,
+  PUSH_TOKEN_PERSIST_FAILED_CODE,
+  type PushTokenRegistry,
+} from "../services/push/push-token-registry.ts";
 import { handlePushTokenRoute } from "./push-token-routes.ts";
 
 async function makeRuntimeWithService(): Promise<{
@@ -223,6 +234,168 @@ describe("handlePushTokenRoute", () => {
       );
     }
     expect(unregister).not.toHaveBeenCalled();
+  });
+
+  it("POST over the UTF-8 byte cap is rejected 400 by registry validation", async () => {
+    const helpers = makeHelpers();
+    // '€' is 3 bytes; 2000 chars = 6000 bytes, over the 4096-byte cap while the
+    // char count stays small (a char-only guard would wrongly accept it).
+    helpers.readJsonBody.mockResolvedValue({
+      platform: "ios",
+      token: "€".repeat(2000),
+    });
+    await handlePushTokenRoute(
+      req(PREFIX),
+      res,
+      PREFIX,
+      "POST",
+      { runtime },
+      helpers,
+    );
+    expect(helpers.error).toHaveBeenCalledWith(res, "invalid push token", 400);
+    expect(helpers.json).not.toHaveBeenCalled();
+    expect(await registry.count()).toBe(0);
+  });
+
+  it("DELETE :token over the UTF-8 byte cap is rejected 400 without persisting", async () => {
+    const helpers = makeHelpers();
+    const unregister = vi.spyOn(registry, "unregister");
+    // decodeURIComponent("%E2%82%AC") === '€' (3 bytes); 2000 copies = 6000 bytes.
+    const path = `${PREFIX}/${"%E2%82%AC".repeat(2000)}`;
+    await handlePushTokenRoute(
+      req(path),
+      res,
+      path,
+      "DELETE",
+      { runtime },
+      helpers,
+    );
+    expect(helpers.error).toHaveBeenCalledWith(res, "invalid push token", 400);
+    expect(helpers.json).not.toHaveBeenCalled();
+    // The over-cap token cannot exist, but the response must be a 400, not a
+    // silent ok:false; unregister still runs and fails validation internally.
+    unregister.mockRestore();
+  });
+
+  it("POST maps typed validation to 400 and persistence failure to 500", async () => {
+    const register = vi.spyOn(registry, "register");
+
+    const badHelpers = makeHelpers();
+    badHelpers.readJsonBody.mockResolvedValue({ platform: "ios", token: "t" });
+    register.mockRejectedValueOnce(
+      new ElizaError("invalid", { code: PUSH_TOKEN_INVALID_CODE }),
+    );
+    await handlePushTokenRoute(
+      req(PREFIX),
+      res,
+      PREFIX,
+      "POST",
+      { runtime },
+      badHelpers,
+    );
+    expect(badHelpers.error).toHaveBeenCalledWith(
+      res,
+      "invalid push token",
+      400,
+    );
+    expect(badHelpers.json).not.toHaveBeenCalled();
+
+    const downHelpers = makeHelpers();
+    downHelpers.readJsonBody.mockResolvedValue({ platform: "ios", token: "t" });
+    register.mockRejectedValueOnce(
+      new ElizaError("persist failed", {
+        code: PUSH_TOKEN_PERSIST_FAILED_CODE,
+      }),
+    );
+    // A genuine persistence failure propagates so the server boundary serves
+    // 500 — it must never be swallowed into a fake 201 or a 400.
+    await expect(
+      handlePushTokenRoute(
+        req(PREFIX),
+        res,
+        PREFIX,
+        "POST",
+        { runtime },
+        downHelpers,
+      ),
+    ).rejects.toThrow(/persist/);
+    expect(downHelpers.error).not.toHaveBeenCalled();
+    register.mockRestore();
+  });
+
+  it("DELETE maps validation to 400 and persistence to 500 for BOTH route shapes", async () => {
+    const unregister = vi.spyOn(registry, "unregister");
+    const bodyPath = PREFIX;
+    const tokenPath = `${PREFIX}/tok`;
+
+    // ── body shape ──────────────────────────────────────────────────
+    const bodyBad = makeHelpers();
+    bodyBad.readJsonBody.mockResolvedValue({ token: "tok" });
+    unregister.mockRejectedValueOnce(
+      new ElizaError("invalid", { code: PUSH_TOKEN_INVALID_CODE }),
+    );
+    await handlePushTokenRoute(
+      req(bodyPath),
+      res,
+      bodyPath,
+      "DELETE",
+      { runtime },
+      bodyBad,
+    );
+    expect(bodyBad.error).toHaveBeenCalledWith(res, "invalid push token", 400);
+
+    const bodyDown = makeHelpers();
+    bodyDown.readJsonBody.mockResolvedValue({ token: "tok" });
+    unregister.mockRejectedValueOnce(
+      new ElizaError("persist failed", {
+        code: PUSH_TOKEN_PERSIST_FAILED_CODE,
+      }),
+    );
+    await expect(
+      handlePushTokenRoute(
+        req(bodyPath),
+        res,
+        bodyPath,
+        "DELETE",
+        { runtime },
+        bodyDown,
+      ),
+    ).rejects.toThrow(/persist/);
+    expect(bodyDown.error).not.toHaveBeenCalled();
+
+    // ── :token shape ────────────────────────────────────────────────
+    const tokenBad = makeHelpers();
+    unregister.mockRejectedValueOnce(
+      new ElizaError("invalid", { code: PUSH_TOKEN_INVALID_CODE }),
+    );
+    await handlePushTokenRoute(
+      req(tokenPath),
+      res,
+      tokenPath,
+      "DELETE",
+      { runtime },
+      tokenBad,
+    );
+    expect(tokenBad.error).toHaveBeenCalledWith(res, "invalid push token", 400);
+
+    const tokenDown = makeHelpers();
+    unregister.mockRejectedValueOnce(
+      new ElizaError("persist failed", {
+        code: PUSH_TOKEN_PERSIST_FAILED_CODE,
+      }),
+    );
+    await expect(
+      handlePushTokenRoute(
+        req(tokenPath),
+        res,
+        tokenPath,
+        "DELETE",
+        { runtime },
+        tokenDown,
+      ),
+    ).rejects.toThrow(/persist/);
+    expect(tokenDown.error).not.toHaveBeenCalled();
+    unregister.mockRestore();
   });
 
   it("DELETE :token decodes valid percent-encoded token before unregister", async () => {

--- a/packages/agent/src/api/push-token-routes.ts
+++ b/packages/agent/src/api/push-token-routes.ts
@@ -29,7 +29,7 @@ import {
   NotificationPushService,
 } from "../services/push/notification-push-service.ts";
 import {
-  MAX_PUSH_TOKEN_LENGTH,
+  isPushTokenValidationError,
   type PushPlatform,
   type PushTokenRegistry,
 } from "../services/push/push-token-registry.ts";
@@ -94,11 +94,20 @@ export async function handlePushTokenRoute(
       helpers.error(res, "token is required", 400);
       return true;
     }
-    if (token.length > MAX_PUSH_TOKEN_LENGTH) {
-      helpers.error(res, "token exceeds the length cap", 400);
-      return true;
+    // The registry re-validates the token (byte cap included). A typed
+    // validation failure is a client error (400); a durable-write failure
+    // propagates and the server boundary maps it to 500.
+    try {
+      await registry.register(platform, token);
+    } catch (err) {
+      // error-policy:J4 user-facing degrade — only the expected validation
+      // shape becomes a 400; every other failure rethrows to the 500 boundary.
+      if (isPushTokenValidationError(err)) {
+        helpers.error(res, "invalid push token", 400);
+        return true;
+      }
+      throw err;
     }
-    await registry.register(platform, token);
     helpers.json(res, { ok: true }, 201);
     return true;
   }
@@ -114,9 +123,7 @@ export async function handlePushTokenRoute(
       helpers.error(res, "token is required", 400);
       return true;
     }
-    const ok = await registry.unregister(token);
-    helpers.json(res, { ok });
-    return true;
+    return unregisterOrError(registry, token, res, helpers);
   }
 
   // ── Legacy DELETE /api/notifications/push-tokens/:token ───────────
@@ -132,11 +139,35 @@ export async function handlePushTokenRoute(
       helpers.error(res, "invalid push token", 400);
       return true;
     }
-    const ok = await registry.unregister(token);
-    helpers.json(res, { ok });
-    return true;
+    return unregisterOrError(registry, token, res, helpers);
   }
 
   helpers.error(res, "push-token route not found", 404);
+  return true;
+}
+
+/**
+ * Run `registry.unregister`, applying the same byte-bound validation as the
+ * register path across BOTH DELETE shapes. A typed validation failure maps to
+ * 400; a durable-write failure rethrows to the server's 500 boundary.
+ */
+async function unregisterOrError(
+  registry: PushTokenRegistry,
+  token: string,
+  res: http.ServerResponse,
+  helpers: RouteHelpers,
+): Promise<boolean> {
+  try {
+    const ok = await registry.unregister(token);
+    helpers.json(res, { ok });
+  } catch (err) {
+    // error-policy:J4 user-facing degrade — expected validation shape → 400;
+    // anything else rethrows so genuine persistence failures surface as 500.
+    if (isPushTokenValidationError(err)) {
+      helpers.error(res, "invalid push token", 400);
+      return true;
+    }
+    throw err;
+  }
   return true;
 }

--- a/packages/agent/src/services/push/push-token-registry.test.ts
+++ b/packages/agent/src/services/push/push-token-registry.test.ts
@@ -1,20 +1,44 @@
 /**
  * Covers the push-token registry: register/list/count/unregister, idempotent
  * upsert, moving a token between platforms, whitespace trimming and empty-token
- * rejection, platform filtering, cache-backed persistence with rehydration, and
+ * rejection, platform filtering, cache-backed persistence with rehydration,
  * dropping malformed records on hydrate, concurrent first-use hydration, and
- * serialized persistence. Backed by a Map-backed mock runtime cache — no real
- * storage.
+ * serialized persistence.
+ *
+ * Adversarial persistence-boundary coverage: UTF-8 byte-length bounding (not
+ * char length), malformed-timestamp rejection (NaN/Infinity/negative/fractional
+ * /unsafe-integer/non-number), dedup-before-cap so duplicate-heavy dumps do not
+ * underfill, the persisted-record ceiling (exact boundary hydrates, one above
+ * fails closed without destroying the durable row), one-time durable repair
+ * that never rewrites a clean load (including a resolved-false repair write that
+ * leaves the dirty row intact, reports a redacted diagnostic without failing the
+ * read, retries on the next cold start, and stops rewriting once it lands),
+ * failed-write rollback (in-memory and durable
+ * state unchanged, typed error, token redacted), mutation-queue recovery after a
+ * failed op, resolved-false persistence failure (register/unregister and a
+ * deferred false-return all leave in-memory and durable state unchanged with the
+ * typed persist-failed error), observable atomicity (list/count never see an
+ * uncommitted mutation while its write is pending and stay unchanged on
+ * rejection), and
+ * persistence-boundary validation of direct callers (unsupported platform and
+ * non-string token become the typed invalid error). Backed by a Map-backed mock
+ * runtime cache — no real storage.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import { createMockRuntime } from "@elizaos/core/testing";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
-  MAX_PUSH_TOKEN_LENGTH,
+  MAX_PERSISTED_PUSH_TOKENS,
+  MAX_PUSH_TOKEN_BYTES,
   MAX_PUSH_TOKENS_PER_AGENT,
+  PUSH_TOKEN_INVALID_CODE,
+  PUSH_TOKEN_PERSIST_FAILED_CODE,
   type PushTokenRecord,
   PushTokenRegistry,
 } from "./push-token-registry.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa";
+const KEY = `push-tokens:${AGENT_ID}`;
 
 function createRuntime(): {
   runtime: IAgentRuntime;
@@ -238,9 +262,515 @@ describe("PushTokenRegistry", () => {
     expect(list.map((r) => r.token)).not.toContain("old-0");
   });
 
-  it("rejects a token longer than the length cap", async () => {
-    const huge = "x".repeat(MAX_PUSH_TOKEN_LENGTH + 1);
-    await expect(registry.register("ios", huge)).rejects.toThrow(/length cap/);
+  it("rejects a token longer than the byte cap", async () => {
+    const huge = "x".repeat(MAX_PUSH_TOKEN_BYTES + 1);
+    await expect(registry.register("ios", huge)).rejects.toThrow(/byte cap/);
     expect(await registry.count()).toBe(0);
+  });
+
+  it("bounds tokens by UTF-8 byte length, not char length", async () => {
+    // '€' encodes to 3 UTF-8 bytes, so a char-length check would accept a token
+    // over the byte cap. Register the largest token that fits by bytes, then one
+    // char more (still tiny by char count) and confirm it is rejected.
+    const maxChars = Math.floor(MAX_PUSH_TOKEN_BYTES / 3);
+    const atLimit = "€".repeat(maxChars);
+    expect(Buffer.byteLength(atLimit, "utf8")).toBeLessThanOrEqual(
+      MAX_PUSH_TOKEN_BYTES,
+    );
+    await registry.register("ios", atLimit);
+    expect(await registry.count()).toBe(1);
+
+    const overByBytes = "€".repeat(maxChars + 1);
+    expect(overByBytes.length).toBeLessThan(MAX_PUSH_TOKEN_BYTES);
+    expect(Buffer.byteLength(overByBytes, "utf8")).toBeGreaterThan(
+      MAX_PUSH_TOKEN_BYTES,
+    );
+    await expect(registry.register("android", overByBytes)).rejects.toThrow(
+      /byte cap/,
+    );
+    expect(await registry.count()).toBe(1);
+  });
+
+  it("rejects hydrated records with malformed timestamps", async () => {
+    ctx.cache.set(KEY, [
+      { token: "ok", platform: "ios", createdAt: 5 },
+      { token: "nan", platform: "ios", createdAt: Number.NaN },
+      { token: "inf", platform: "ios", createdAt: Number.POSITIVE_INFINITY },
+      { token: "negative", platform: "ios", createdAt: -1 },
+      { token: "fractional", platform: "ios", createdAt: 1.5 },
+      {
+        token: "unsafe",
+        platform: "ios",
+        createdAt: Number.MAX_SAFE_INTEGER + 1,
+      },
+      { token: "stringified", platform: "ios", createdAt: "5" },
+    ]);
+    const fresh = new PushTokenRegistry(ctx.runtime);
+    expect((await fresh.list()).map((r) => r.token)).toEqual(["ok"]);
+  });
+
+  it("drops hydrated records whose token exceeds the UTF-8 byte cap", async () => {
+    ctx.cache.set(KEY, [
+      { token: "small", platform: "ios", createdAt: 1 },
+      {
+        token: "€".repeat(Math.floor(MAX_PUSH_TOKEN_BYTES / 3) + 1),
+        platform: "android",
+        createdAt: 2,
+      },
+    ]);
+    const fresh = new PushTokenRegistry(ctx.runtime);
+    expect((await fresh.list()).map((r) => r.token)).toEqual(["small"]);
+  });
+
+  it("dedups before capping so duplicate-heavy data does not underfill", async () => {
+    // Naive cap-then-dedup would keep only the single hottest token (its 64
+    // newest duplicates fill the cap, then collapse to one). Dedup-before-cap
+    // must retain the newest hot record PLUS every unique older token.
+    const dump: PushTokenRecord[] = [];
+    for (let i = 0; i < MAX_PUSH_TOKENS_PER_AGENT; i++) {
+      dump.push({ token: "hot", platform: "ios", createdAt: 1000 + i });
+    }
+    for (let i = 0; i < 40; i++) {
+      dump.push({ token: `uniq-${i}`, platform: "android", createdAt: 1 + i });
+    }
+    ctx.cache.set(KEY, dump);
+    const fresh = new PushTokenRegistry(ctx.runtime);
+    const list = await fresh.list();
+    expect(list).toHaveLength(41);
+    expect(list.find((r) => r.token === "hot")?.createdAt).toBe(1063);
+    expect(list.filter((r) => r.token.startsWith("uniq-"))).toHaveLength(40);
+  });
+
+  it("hydrates exactly at the persisted-record ceiling but fails closed above it", async () => {
+    const makeDump = (n: number): PushTokenRecord[] =>
+      Array.from({ length: n }, (_, i) => ({
+        token: `t-${i}`,
+        platform: "ios" as const,
+        createdAt: i + 1,
+      }));
+
+    // Exactly at the ceiling: traversed, deduped, capped to the live cap.
+    ctx.cache.set(KEY, makeDump(MAX_PERSISTED_PUSH_TOKENS));
+    const atCeiling = new PushTokenRegistry(ctx.runtime);
+    expect(await atCeiling.count()).toBe(MAX_PUSH_TOKENS_PER_AGENT);
+
+    // One above the ceiling: fail closed to empty and DO NOT destroy the
+    // durable row (a later mutation overwrites it with a bounded array).
+    const over = createRuntime();
+    const oversized = makeDump(MAX_PERSISTED_PUSH_TOKENS + 1);
+    over.cache.set(KEY, oversized);
+    const aboveCeiling = new PushTokenRegistry(over.runtime);
+    expect(await aboveCeiling.count()).toBe(0);
+    expect((over.cache.get(KEY) as PushTokenRecord[]).length).toBe(
+      MAX_PERSISTED_PUSH_TOKENS + 1,
+    );
+  });
+
+  it("persists the repaired form exactly once and never rewrites a clean load", async () => {
+    const setCalls: PushTokenRecord[][] = [];
+    const cache = new Map<string, unknown>();
+    cache.set(KEY, [
+      { token: "  spaced  ", platform: "ios", createdAt: 2, extra: "junk" },
+      { token: "dupe", platform: "android", createdAt: 1 },
+      { token: "dupe", platform: "android", createdAt: 9 },
+      { token: "", platform: "ios", createdAt: 3 },
+    ]);
+    const runtime = createMockRuntime({
+      agentId: AGENT_ID,
+      getCache: async <T>(k: string): Promise<T | undefined> =>
+        cache.get(k) as T | undefined,
+      setCache: async <T>(k: string, value: T): Promise<boolean> => {
+        setCalls.push(value as PushTokenRecord[]);
+        cache.set(k, value);
+        return true;
+      },
+    });
+
+    const first = new PushTokenRegistry(runtime);
+    const list = await first.list();
+    expect(list.map((r) => r.token).sort()).toEqual(["dupe", "spaced"]);
+    expect(setCalls).toHaveLength(1);
+    const repaired = setCalls[0];
+    expect(repaired.find((r) => r.token === "dupe")?.createdAt).toBe(9);
+    for (const record of repaired) {
+      expect(Object.keys(record).sort()).toEqual([
+        "createdAt",
+        "platform",
+        "token",
+      ]);
+    }
+
+    // A second cold registry over the already-repaired cache must not rewrite.
+    const second = new PushTokenRegistry(runtime);
+    await second.list();
+    expect(setCalls).toHaveLength(1);
+  });
+
+  it("leaves the dirty row intact and reports when a repair write resolves false, then a later true repair stops rewriting", async () => {
+    const setCalls: PushTokenRecord[][] = [];
+    const reported: Array<{ scope: string; error: unknown }> = [];
+    const cache = new Map<string, unknown>();
+    // A bounded-but-dirty dump (unsorted extra field + dupe) that normalizes.
+    const dirty = [
+      { token: "  spaced  ", platform: "ios", createdAt: 2, extra: "junk" },
+      { token: "dupe", platform: "android", createdAt: 1 },
+      { token: "dupe", platform: "android", createdAt: 9 },
+    ];
+    cache.set(KEY, dirty);
+    let repairSucceeds = false;
+    const runtime = createMockRuntime({
+      agentId: AGENT_ID,
+      getCache: async <T>(k: string): Promise<T | undefined> =>
+        cache.get(k) as T | undefined,
+      setCache: async <T>(k: string, value: T): Promise<boolean> => {
+        setCalls.push(value as PushTokenRecord[]);
+        // The adapter reports `false` when the durable row did not land.
+        if (!repairSucceeds) return false;
+        cache.set(k, value);
+        return true;
+      },
+    });
+    runtime.reportError = ((scope: string, error: unknown) => {
+      reported.push({ scope, error });
+    }) as IAgentRuntime["reportError"];
+
+    // Cold start #1: repair write resolves false. The read still succeeds with
+    // the normalized in-memory view, the diagnostic is reported (redacted), and
+    // the original dirty durable row is left intact for a later retry.
+    const first = new PushTokenRegistry(runtime);
+    expect((await first.list()).map((r) => r.token).sort()).toEqual([
+      "dupe",
+      "spaced",
+    ]);
+    expect(setCalls).toHaveLength(1);
+    expect(reported).toHaveLength(1);
+    expect(reported[0].scope).toBe("push.registry.repair");
+    expect((reported[0].error as ElizaError).code).toBe(
+      PUSH_TOKEN_PERSIST_FAILED_CODE,
+    );
+    // No token leaks into the reported error surface.
+    expect(JSON.stringify(reported[0].error)).not.toContain("spaced");
+    // Durable row is still the original dirty dump (repair did not land).
+    expect(cache.get(KEY)).toBe(dirty);
+
+    // Cold start #2: the dirty row is still present, so the registry scans and
+    // re-normalizes again — but now the repair write lands.
+    repairSucceeds = true;
+    const second = new PushTokenRegistry(runtime);
+    expect((await second.list()).map((r) => r.token).sort()).toEqual([
+      "dupe",
+      "spaced",
+    ]);
+    expect(setCalls).toHaveLength(2);
+    const repaired = cache.get(KEY) as PushTokenRecord[];
+    for (const record of repaired) {
+      expect(Object.keys(record).sort()).toEqual([
+        "createdAt",
+        "platform",
+        "token",
+      ]);
+    }
+
+    // Cold start #3: the durable row is now canonical, so no rewrite occurs.
+    const third = new PushTokenRegistry(runtime);
+    await third.list();
+    expect(setCalls).toHaveLength(2);
+  });
+
+  it("rolls the in-memory registry back when a durable write is rejected", async () => {
+    let failNextWrite = false;
+    const cache = new Map<string, unknown>();
+    const runtime = createMockRuntime({
+      agentId: AGENT_ID,
+      getCache: async <T>(k: string): Promise<T | undefined> =>
+        cache.get(k) as T | undefined,
+      setCache: async <T>(k: string, value: T): Promise<boolean> => {
+        if (failNextWrite) throw new Error("cache offline");
+        cache.set(k, value);
+        return true;
+      },
+    });
+    const reg = new PushTokenRegistry(runtime);
+    await reg.register("ios", "keep");
+    expect(await reg.count()).toBe(1);
+
+    failNextWrite = true;
+    await reg.register("android", "reject-me").then(
+      () => {
+        throw new Error("expected the rejected write to throw");
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ElizaError);
+        expect((err as ElizaError).code).toBe(PUSH_TOKEN_PERSIST_FAILED_CODE);
+        // Tokens are never leaked into the error surface.
+        expect(String((err as ElizaError).message)).not.toContain("reject-me");
+        expect(JSON.stringify((err as ElizaError).context)).not.toContain(
+          "reject-me",
+        );
+      },
+    );
+    failNextWrite = false;
+
+    // In-memory registry unchanged (rejected token absent, prior token intact).
+    expect((await reg.list()).map((r) => r.token)).toEqual(["keep"]);
+    // Durable cache never received the rejected token either.
+    expect((cache.get(KEY) as PushTokenRecord[]).map((r) => r.token)).toEqual([
+      "keep",
+    ]);
+  });
+
+  it("treats a resolved false setCache as a persistence failure on register", async () => {
+    let denyNextWrite = false;
+    const cache = new Map<string, unknown>();
+    const runtime = createMockRuntime({
+      agentId: AGENT_ID,
+      getCache: async <T>(k: string): Promise<T | undefined> =>
+        cache.get(k) as T | undefined,
+      setCache: async <T>(k: string, value: T): Promise<boolean> => {
+        // The SQL adapter resolves `false` when the durable row did not land.
+        if (denyNextWrite) return false;
+        cache.set(k, value);
+        return true;
+      },
+    });
+    const reg = new PushTokenRegistry(runtime);
+    await reg.register("ios", "keep");
+    expect(await reg.count()).toBe(1);
+
+    denyNextWrite = true;
+    await reg.register("android", "denied").then(
+      () => {
+        throw new Error("expected a false setCache to reject");
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ElizaError);
+        expect((err as ElizaError).code).toBe(PUSH_TOKEN_PERSIST_FAILED_CODE);
+      },
+    );
+    denyNextWrite = false;
+
+    // Observable registry and durable cache stay on the committed token.
+    expect((await reg.list()).map((r) => r.token)).toEqual(["keep"]);
+    expect((cache.get(KEY) as PushTokenRecord[]).map((r) => r.token)).toEqual([
+      "keep",
+    ]);
+  });
+
+  it("treats a resolved false setCache as a persistence failure on unregister", async () => {
+    let denyNextWrite = false;
+    const cache = new Map<string, unknown>();
+    const runtime = createMockRuntime({
+      agentId: AGENT_ID,
+      getCache: async <T>(k: string): Promise<T | undefined> =>
+        cache.get(k) as T | undefined,
+      setCache: async <T>(k: string, value: T): Promise<boolean> => {
+        if (denyNextWrite) return false;
+        cache.set(k, value);
+        return true;
+      },
+    });
+    const reg = new PushTokenRegistry(runtime);
+    await reg.register("ios", "keep");
+    expect(await reg.count()).toBe(1);
+
+    denyNextWrite = true;
+    await reg.unregister("keep").then(
+      () => {
+        throw new Error("expected a false setCache to reject");
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ElizaError);
+        expect((err as ElizaError).code).toBe(PUSH_TOKEN_PERSIST_FAILED_CODE);
+      },
+    );
+    denyNextWrite = false;
+
+    // The delete was never published: the token remains in memory and durably.
+    expect((await reg.list()).map((r) => r.token)).toEqual(["keep"]);
+    expect((cache.get(KEY) as PushTokenRecord[]).map((r) => r.token)).toEqual([
+      "keep",
+    ]);
+  });
+
+  it("never publishes a deferred false setCache while its write is pending", async () => {
+    const cache = new Map<string, unknown>();
+    let gateNextWrite = false;
+    let resolvePendingWrite!: (result: boolean) => void;
+    let pendingWriteStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      pendingWriteStarted = resolve;
+    });
+    const runtime = createMockRuntime({
+      agentId: AGENT_ID,
+      getCache: async <T>(k: string): Promise<T | undefined> =>
+        cache.get(k) as T | undefined,
+      setCache: <T>(k: string, value: T): Promise<boolean> => {
+        if (!gateNextWrite) {
+          cache.set(k, value);
+          return Promise.resolve(true);
+        }
+        return new Promise<boolean>((resolve) => {
+          resolvePendingWrite = resolve;
+          pendingWriteStarted();
+        });
+      },
+    });
+    const reg = new PushTokenRegistry(runtime);
+    await reg.register("ios", "keep");
+    expect(await reg.count()).toBe(1);
+
+    gateNextWrite = true;
+    const pending = reg.register("android", "pending-token");
+    await started;
+    // Staged but not published while the durable write is in flight.
+    expect((await reg.list()).map((r) => r.token)).toEqual(["keep"]);
+
+    resolvePendingWrite(false);
+    await pending.then(
+      () => {
+        throw new Error("expected the false write to reject");
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ElizaError);
+        expect((err as ElizaError).code).toBe(PUSH_TOKEN_PERSIST_FAILED_CODE);
+      },
+    );
+
+    // Observable registry and durable cache are unchanged after the false write.
+    expect((await reg.list()).map((r) => r.token)).toEqual(["keep"]);
+    expect((cache.get(KEY) as PushTokenRecord[]).map((r) => r.token)).toEqual([
+      "keep",
+    ]);
+  });
+
+  it("keeps processing later mutations after a failed one (no queue wedge)", async () => {
+    let failCount = 0;
+    const cache = new Map<string, unknown>();
+    const runtime = createMockRuntime({
+      agentId: AGENT_ID,
+      getCache: async <T>(k: string): Promise<T | undefined> =>
+        cache.get(k) as T | undefined,
+      setCache: async <T>(k: string, value: T): Promise<boolean> => {
+        if (failCount > 0) {
+          failCount--;
+          throw new Error("transient cache failure");
+        }
+        cache.set(k, value);
+        return true;
+      },
+    });
+    const reg = new PushTokenRegistry(runtime);
+    await reg.register("ios", "a");
+
+    failCount = 1;
+    const failing = reg.register("android", "b");
+    const following = reg.register("ios", "c");
+    await expect(failing).rejects.toThrow(/persist/);
+    // The queue is not wedged: the op enqueued after the failure still resolves.
+    await following;
+
+    expect((await reg.list()).map((r) => r.token).sort()).toEqual(["a", "c"]);
+    expect(
+      (cache.get(KEY) as PushTokenRecord[]).map((r) => r.token).sort(),
+    ).toEqual(["a", "c"]);
+  });
+
+  it("never exposes an uncommitted mutation while its write is pending, and stays unchanged on rejection", async () => {
+    const cache = new Map<string, unknown>();
+    let gateNextWrite = false;
+    let rejectPendingWrite!: (reason: Error) => void;
+    let pendingWriteStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      pendingWriteStarted = resolve;
+    });
+    const runtime = createMockRuntime({
+      agentId: AGENT_ID,
+      getCache: async <T>(k: string): Promise<T | undefined> =>
+        cache.get(k) as T | undefined,
+      setCache: <T>(k: string, value: T): Promise<boolean> => {
+        if (!gateNextWrite) {
+          cache.set(k, value);
+          return Promise.resolve(true);
+        }
+        return new Promise<boolean>((_resolve, reject) => {
+          rejectPendingWrite = reject;
+          pendingWriteStarted();
+        });
+      },
+    });
+    const reg = new PushTokenRegistry(runtime);
+    await reg.register("ios", "keep");
+    expect(await reg.count()).toBe(1);
+
+    gateNextWrite = true;
+    const pending = reg.register("android", "pending-token");
+    await started;
+    // The candidate is staged but not published: readers observe only committed
+    // state while the durable write is in flight.
+    expect(await reg.count()).toBe(1);
+    expect((await reg.list()).map((r) => r.token)).toEqual(["keep"]);
+
+    rejectPendingWrite(new Error("cache offline"));
+    await pending.then(
+      () => {
+        throw new Error("expected the rejected write to throw");
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ElizaError);
+        expect((err as ElizaError).code).toBe(PUSH_TOKEN_PERSIST_FAILED_CODE);
+      },
+    );
+
+    // Observable registry and durable cache are unchanged after the rejection.
+    expect((await reg.list()).map((r) => r.token)).toEqual(["keep"]);
+    expect((cache.get(KEY) as PushTokenRecord[]).map((r) => r.token)).toEqual([
+      "keep",
+    ]);
+  });
+
+  it("rejects an unsupported platform from a direct caller with a typed error", async () => {
+    const untyped = registry as unknown as {
+      register(platform: unknown, token: string): Promise<void>;
+    };
+    await untyped.register("web", "tok-web").then(
+      () => {
+        throw new Error("expected unsupported platform to reject");
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ElizaError);
+        expect((err as ElizaError).code).toBe(PUSH_TOKEN_INVALID_CODE);
+      },
+    );
+    expect(await registry.count()).toBe(0);
+    expect(ctx.cache.get(KEY)).toBeUndefined();
+  });
+
+  it("turns a non-string runtime token into the typed invalid error, not a TypeError", async () => {
+    const untyped = registry as unknown as {
+      register(platform: string, token: unknown): Promise<void>;
+    };
+    await untyped.register("ios", 12345).then(
+      () => {
+        throw new Error("expected a non-string token to reject");
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ElizaError);
+        expect((err as ElizaError).code).toBe(PUSH_TOKEN_INVALID_CODE);
+      },
+    );
+    expect(await registry.count()).toBe(0);
+  });
+
+  it("rejects an empty token with a typed validation error", async () => {
+    await registry.register("ios", "real").catch(() => undefined);
+    await registry.register("ios", "   ").then(
+      () => {
+        throw new Error("expected empty token to reject");
+      },
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(ElizaError);
+        expect((err as ElizaError).code).toBe(PUSH_TOKEN_INVALID_CODE);
+      },
+    );
   });
 });

--- a/packages/agent/src/services/push/push-token-registry.ts
+++ b/packages/agent/src/services/push/push-token-registry.ts
@@ -10,9 +10,42 @@
  * `runtime.setCache`) under a single stable key, mirroring the persistence
  * pattern in `@elizaos/core`'s `NotificationService`. A cold/headless runtime
  * with no cache adapter starts empty and degrades to in-memory only.
+ *
+ * Boundary invariants (a cache row is untrusted, possibly-hostile input):
+ *   1. Hydration bounds work BEFORE traversing. A stored array larger than
+ *      {@link MAX_PERSISTED_PUSH_TOKENS} is rejected without filter/copy/sort,
+ *      so a hostile/oversized dump cannot force unbounded validation work.
+ *   2. Every hydrated record is validated at the persistence boundary
+ *      ({@link parsePushTokenRecord}): trimmed non-empty token, token within an
+ *      explicit UTF-8 BYTE limit, supported platform, and a finite,
+ *      non-negative, safe-integer timestamp. The same validator gates
+ *      `register`/`unregister`, so byte/platform/timestamp checks are identical
+ *      everywhere.
+ *   3. Dedup happens BEFORE the live cap: the newest valid record per token is
+ *      kept, then the {@link MAX_PUSH_TOKENS_PER_AGENT} cap is applied, so
+ *      duplicate-heavy data cannot underfill the registry.
+ *   4. When a bounded-but-dirty legacy dump is normalized, the repaired form is
+ *      persisted once (guarded so a clean load never rewrites), so later
+ *      restarts do not repeatedly re-scan and re-normalize the same dump. The
+ *      repair write must resolve exactly `true`; a rejected OR resolved-`false`
+ *      write is reported (best-effort, never failing the read) and the dirty
+ *      row is left intact so a later restart retries the repair.
+ *   5. `register`/`unregister` are observably atomic w.r.t. `setCache`: the
+ *      mutation is staged on a candidate Map that is published to `this.tokens`
+ *      only after the durable write succeeds, so `list`/`count` never observe an
+ *      uncommitted add/delete. A write that rejects OR resolves a non-`true`
+ *      value (`setCache` returns `Promise<boolean>`; adapters resolve `false`
+ *      when the row did not land) is treated as a failure that leaves the
+ *      observable registry unchanged, and the same-process mutation queue keeps
+ *      processing later operations after a failure (no wedge).
+ *
+ * Concurrency scope: mutations are serialized and failure-atomic WITHIN a
+ * single process. Cross-process compare-and-swap is out of scope because the
+ * runtime cache contract exposes no transactional CAS primitive; do not read
+ * multi-process atomicity into this class.
  */
 
-import type { IAgentRuntime } from "@elizaos/core";
+import { ElizaError, type IAgentRuntime, logger } from "@elizaos/core";
 
 /** Mobile push transport a token belongs to. */
 export type PushPlatform = "ios" | "android";
@@ -31,18 +64,100 @@ export interface PushTokenRecord {
 const cacheKeyFor = (agentId: string): string => `push-tokens:${agentId}`;
 
 /**
- * Hard cap on distinct tokens stored per agent. A device re-register is an
- * upsert; unique tokens are unbounded on origin and `persist()` writes the
- * entire Map to the durable runtime cache. Oldest `createdAt` is evicted first.
+ * Hard cap on distinct tokens stored per agent (the live cap). A device
+ * re-register is an upsert; unique tokens are unbounded on origin and
+ * `persist()` writes the entire Map to the durable runtime cache. Oldest
+ * `createdAt` is evicted first.
  */
 export const MAX_PUSH_TOKENS_PER_AGENT = 64;
 
 /**
- * Hard cap on a single token string. The HTTP body reader already stops at
- * 8 KiB; this keeps a direct `register()` caller from planting a huge Map key
- * and a huge cache row.
+ * Hard cap on a single token, measured in UTF-8 BYTES (not char length, so a
+ * multi-byte token cannot smuggle past a char check). The HTTP body reader
+ * already stops at 8 KiB; this keeps a direct `register()` caller from planting
+ * a huge Map key and a huge cache row.
  */
-export const MAX_PUSH_TOKEN_LENGTH = 4096;
+export const MAX_PUSH_TOKEN_BYTES = 4096;
+
+/**
+ * Persisted-record ceiling: the largest stored array the registry will even
+ * traverse. A cache row longer than this (hostile or corrupt) is rejected
+ * fail-closed WITHOUT filtering/copying/sorting it, bounding worst-case
+ * hydration work to a single `Array.isArray`/`length` check. The ceiling sits
+ * far above any legitimate dump (16x the live cap) so real dirty-but-bounded
+ * legacy data is repaired rather than discarded.
+ */
+export const MAX_PERSISTED_PUSH_TOKENS = MAX_PUSH_TOKENS_PER_AGENT * 16;
+
+/** Stable `ElizaError.code` for a rejected token (empty or over the byte cap). */
+export const PUSH_TOKEN_INVALID_CODE = "PUSH_TOKEN_INVALID";
+/** Stable `ElizaError.code` for a durable-write failure during a mutation. */
+export const PUSH_TOKEN_PERSIST_FAILED_CODE = "PUSH_TOKEN_PERSIST_FAILED";
+
+/**
+ * True when `error` is a token-validation failure the caller should translate
+ * to a client error (HTTP 400), as opposed to a genuine persistence failure
+ * (HTTP 500). Never inspects or exposes the offending token.
+ */
+export function isPushTokenValidationError(error: unknown): boolean {
+  return error instanceof ElizaError && error.code === PUSH_TOKEN_INVALID_CODE;
+}
+
+/** UTF-8 byte length of `value` without allocating an intermediate Buffer view. */
+function utf8ByteLength(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+/**
+ * Validate and canonicalize a token for a mutation. Returns the trimmed token
+ * or throws a typed {@link PUSH_TOKEN_INVALID_CODE} error. Accepts `unknown` so
+ * a non-string runtime value from untyped/plugin callers becomes the typed
+ * invalid error instead of leaking a raw `token.trim` TypeError. The error
+ * context records only the byte length or received type, never the token.
+ */
+function assertValidToken(token: unknown): string {
+  if (typeof token !== "string") {
+    throw new ElizaError("[PushTokenRegistry] token must be a string", {
+      code: PUSH_TOKEN_INVALID_CODE,
+      context: { reason: "not_a_string", received: typeof token },
+      severity: "ephemeral",
+    });
+  }
+  const trimmed = token.trim();
+  if (!trimmed) {
+    throw new ElizaError("[PushTokenRegistry] token is required", {
+      code: PUSH_TOKEN_INVALID_CODE,
+      context: { reason: "empty" },
+      severity: "ephemeral",
+    });
+  }
+  const byteLength = utf8ByteLength(trimmed);
+  if (byteLength > MAX_PUSH_TOKEN_BYTES) {
+    throw new ElizaError("[PushTokenRegistry] token exceeds the byte cap", {
+      code: PUSH_TOKEN_INVALID_CODE,
+      context: { reason: "too_large", byteLength, limit: MAX_PUSH_TOKEN_BYTES },
+      severity: "ephemeral",
+    });
+  }
+  return trimmed;
+}
+
+/**
+ * Validate a platform at the persistence boundary. Direct `register()` callers
+ * in untyped/plugin code can pass an unsupported value (e.g. "web"); this
+ * rejects it with a typed {@link PUSH_TOKEN_INVALID_CODE} error before it
+ * reaches the durable cache, rather than persisting an arbitrary runtime string.
+ */
+function assertValidPlatform(platform: unknown): PushPlatform {
+  if (platform !== "ios" && platform !== "android") {
+    throw new ElizaError("[PushTokenRegistry] unsupported platform", {
+      code: PUSH_TOKEN_INVALID_CODE,
+      context: { reason: "unsupported_platform" },
+      severity: "ephemeral",
+    });
+  }
+  return platform;
+}
 
 export class PushTokenRegistry {
   private tokens = new Map<string, PushTokenRecord>();
@@ -74,19 +189,52 @@ export class PushTokenRegistry {
   }
 
   private async loadPersistedTokens(): Promise<void> {
-    const stored = await this.runtime.getCache<PushTokenRecord[]>(
-      this.cacheKey,
-    );
-    if (Array.isArray(stored)) {
-      this.tokens = new Map(
-        newestPushTokenRecords(stored).map((record) => [record.token, record]),
-      );
-    }
+    const stored = await this.runtime.getCache<unknown>(this.cacheKey);
+    const { records, repaired } = normalizePersistedTokens(stored);
+    this.tokens = new Map(records.map((record) => [record.token, record]));
     this.hydrated = true;
+    if (repaired) {
+      // Durable one-time repair: rewrite the normalized (validated, deduped,
+      // capped) form so later restarts do not re-scan the same dirty dump.
+      // Best-effort: a failed repair write only means we re-normalize next
+      // start; it must not fail the read path.
+      try {
+        await this.persist();
+      } catch (error) {
+        // error-policy:J7 diagnostics must not kill the loop — a failed
+        // one-time repair write degrades to re-scanning on the next start.
+        this.runtime.reportError("push.registry.repair", error, {
+          tokenCount: this.tokens.size,
+        });
+        logger.warn(
+          "[PushTokenRegistry] durable repair write failed; will re-normalize on next hydrate",
+        );
+      }
+    }
   }
 
+  /**
+   * Durably rewrite the current in-memory tokens (repair path only). Requires
+   * `setCache` to resolve exactly `true`; a rejected write OR a resolved
+   * non-`true` value (an adapter reports `false` when the row did not land) is a
+   * failed durable repair and throws {@link PUSH_TOKEN_PERSIST_FAILED_CODE}, so
+   * the caller degrades to re-normalizing on the next start instead of treating
+   * an unpersisted repair as durable.
+   */
   private async persist(): Promise<void> {
-    await this.runtime.setCache(this.cacheKey, [...this.tokens.values()]);
+    const persisted = await this.runtime.setCache(this.cacheKey, [
+      ...this.tokens.values(),
+    ]);
+    if (persisted !== true) {
+      throw new ElizaError(
+        "[PushTokenRegistry] durable cache rejected the push-token repair write",
+        {
+          code: PUSH_TOKEN_PERSIST_FAILED_CODE,
+          context: { tokenCount: this.tokens.size },
+          severity: "ephemeral",
+        },
+      );
+    }
   }
 
   private enqueueMutation<T>(mutation: () => Promise<T>): Promise<T> {
@@ -101,38 +249,92 @@ export class PushTokenRegistry {
   }
 
   /**
+   * Persist `candidate` and, only after the durable write reports success,
+   * publish it as the observable registry. Because `this.tokens` is reassigned
+   * solely on a `true` result, `list`/`count` running while the write is pending
+   * observe the still-committed prior state; a write that rejects OR resolves a
+   * non-`true` value leaves the observable registry unchanged and throws a typed
+   * error. Callers run this inside {@link enqueueMutation}, so the next queued
+   * mutation still proceeds.
+   */
+  private async commit(candidate: Map<string, PushTokenRecord>): Promise<void> {
+    let persisted: boolean;
+    try {
+      persisted = await this.runtime.setCache(this.cacheKey, [
+        ...candidate.values(),
+      ]);
+    } catch (error) {
+      // error-policy:J2 context-adding rethrow — surface a typed persistence
+      // failure with a redacted count while preserving the underlying cause. The
+      // candidate was never published, so the observable registry is unchanged.
+      throw new ElizaError(
+        "[PushTokenRegistry] failed to persist push-token mutation",
+        {
+          code: PUSH_TOKEN_PERSIST_FAILED_CODE,
+          cause: error,
+          context: { tokenCount: candidate.size },
+          severity: "ephemeral",
+        },
+      );
+    }
+    if (persisted !== true) {
+      // error-policy:J2 context-adding rethrow — `setCache` resolving a
+      // non-`true` value is a durable-write failure (the SQL adapter propagates
+      // `false` when the underlying write did not land). The candidate was never
+      // published, so the observable registry stays on the committed state.
+      throw new ElizaError(
+        "[PushTokenRegistry] durable cache rejected the push-token mutation",
+        {
+          code: PUSH_TOKEN_PERSIST_FAILED_CODE,
+          context: { tokenCount: candidate.size },
+          severity: "ephemeral",
+        },
+      );
+    }
+    this.tokens = candidate;
+  }
+
+  /**
    * Register (upsert) a device token. Re-registering an existing token under a
    * new platform moves it to that platform and refreshes `createdAt`.
+   *
+   * Observably atomic w.r.t. persistence: the mutation is staged on a candidate
+   * Map and published only after the durable write succeeds, so a rejected write
+   * leaves the observable registry unchanged and a typed error is thrown.
+   * `platform` is validated at this boundary so a direct/untyped caller cannot
+   * persist an unsupported transport.
    */
   async register(platform: PushPlatform, token: string): Promise<void> {
-    const trimmed = token.trim();
-    if (!trimmed) {
-      throw new Error("[PushTokenRegistry] token is required");
-    }
-    if (trimmed.length > MAX_PUSH_TOKEN_LENGTH) {
-      throw new Error("[PushTokenRegistry] token exceeds the length cap");
-    }
+    const validPlatform = assertValidPlatform(platform);
+    const trimmed = assertValidToken(token);
     await this.enqueueMutation(async () => {
       await this.hydrate();
-      this.tokens.set(trimmed, {
+      const candidate = new Map(this.tokens);
+      candidate.set(trimmed, {
         token: trimmed,
-        platform,
+        platform: validPlatform,
         createdAt: Date.now(),
       });
-      evictOldestPushTokens(this.tokens);
-      await this.persist();
+      evictOldestPushTokens(candidate);
+      await this.commit(candidate);
     });
   }
 
-  /** Unregister a device token. Returns true if it existed. */
+  /**
+   * Unregister a device token. Returns true if it existed. Applies the same
+   * token validation as {@link register}, and is atomic w.r.t. persistence.
+   */
   async unregister(token: string): Promise<boolean> {
+    const trimmed = assertValidToken(token);
     return this.enqueueMutation(async () => {
       await this.hydrate();
-      const removed = this.tokens.delete(token.trim());
-      if (removed) {
-        await this.persist();
+      if (!this.tokens.has(trimmed)) {
+        return false;
       }
-      return removed;
+      const candidate = new Map(this.tokens);
+      candidate.delete(trimmed);
+      await this.commit(candidate);
+      return true;
     });
   }
 
@@ -155,15 +357,82 @@ export class PushTokenRegistry {
   }
 }
 
-function newestPushTokenRecords(stored: unknown[]): PushTokenRecord[] {
-  const valid = stored.filter(isPushTokenRecord);
-  if (valid.length <= MAX_PUSH_TOKENS_PER_AGENT) {
-    return valid;
+/**
+ * Normalize a raw cache value into the registry's canonical records and report
+ * whether the stored form differed (so the caller can durably repair once).
+ *
+ * Order matters and is load-bearing:
+ *   1. Reject non-arrays and over-ceiling arrays WITHOUT traversal.
+ *   2. Validate each record and keep the NEWEST per token (dedup-before-cap).
+ *   3. Apply the live cap to the deduped set.
+ */
+function normalizePersistedTokens(stored: unknown): {
+  records: PushTokenRecord[];
+  repaired: boolean;
+} {
+  if (!Array.isArray(stored)) {
+    return { records: [], repaired: false };
   }
-  return valid
-    .slice()
-    .sort((left, right) => right.createdAt - left.createdAt)
-    .slice(0, MAX_PUSH_TOKENS_PER_AGENT);
+  // Bound BEFORE any filter/copy/sort. A hostile/corrupt oversized dump fails
+  // closed to empty; we deliberately do NOT rewrite it here (a later mutation
+  // overwrites it with a bounded array), so a transient never destroys a large
+  // legitimate row.
+  if (stored.length > MAX_PERSISTED_PUSH_TOKENS) {
+    logger.warn(
+      `[PushTokenRegistry] persisted token array exceeds ceiling (${stored.length} > ${MAX_PERSISTED_PUSH_TOKENS}); failing closed`,
+    );
+    return { records: [], repaired: false };
+  }
+
+  const newestByToken = new Map<string, PushTokenRecord>();
+  for (const value of stored) {
+    const record = parsePushTokenRecord(value);
+    if (!record) continue;
+    const existing = newestByToken.get(record.token);
+    if (!existing || record.createdAt > existing.createdAt) {
+      newestByToken.set(record.token, record);
+    }
+  }
+
+  let unique = [...newestByToken.values()];
+  if (unique.length > MAX_PUSH_TOKENS_PER_AGENT) {
+    unique = unique
+      .sort((left, right) => right.createdAt - left.createdAt)
+      .slice(0, MAX_PUSH_TOKENS_PER_AGENT);
+  }
+
+  return {
+    records: unique,
+    repaired: !isCanonicalPersistedArray(stored, unique),
+  };
+}
+
+/**
+ * True when `stored` is already exactly the canonical persisted form of
+ * `canonical` (same length, same order, and each element is a plain object with
+ * exactly the three canonical fields equal to the normalized values). Used to
+ * suppress a repair write on an already-clean load.
+ */
+function isCanonicalPersistedArray(
+  stored: unknown[],
+  canonical: PushTokenRecord[],
+): boolean {
+  if (stored.length !== canonical.length) return false;
+  for (let i = 0; i < stored.length; i++) {
+    const raw = stored[i];
+    if (typeof raw !== "object" || raw === null) return false;
+    const record = raw as Record<string, unknown>;
+    if (Object.keys(record).length !== 3) return false;
+    const expected = canonical[i];
+    if (
+      record.token !== expected.token ||
+      record.platform !== expected.platform ||
+      record.createdAt !== expected.createdAt
+    ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function evictOldestPushTokens(tokens: Map<string, PushTokenRecord>): void {
@@ -183,13 +452,32 @@ function evictOldestPushTokens(tokens: Map<string, PushTokenRecord>): void {
   }
 }
 
-function isPushTokenRecord(value: unknown): value is PushTokenRecord {
-  if (typeof value !== "object" || value === null) return false;
+/**
+ * Validate an untrusted persisted value and return a canonical record, or null
+ * if it fails any boundary check. The returned record is a fresh plain object
+ * with a trimmed token so the durable repair writes a clean shape (extra fields
+ * stripped). Mirrors the mutation-path checks in {@link assertValidToken} plus
+ * the platform and timestamp constraints.
+ */
+function parsePushTokenRecord(value: unknown): PushTokenRecord | null {
+  if (typeof value !== "object" || value === null) return null;
   const record = value as Record<string, unknown>;
-  return (
-    typeof record.token === "string" &&
-    record.token.length > 0 &&
-    (record.platform === "ios" || record.platform === "android") &&
-    typeof record.createdAt === "number"
-  );
+
+  if (typeof record.token !== "string") return null;
+  const token = record.token.trim();
+  if (!token) return null;
+  if (utf8ByteLength(token) > MAX_PUSH_TOKEN_BYTES) return null;
+
+  if (record.platform !== "ios" && record.platform !== "android") return null;
+
+  const createdAt = record.createdAt;
+  if (
+    typeof createdAt !== "number" ||
+    !Number.isSafeInteger(createdAt) ||
+    createdAt < 0
+  ) {
+    return null;
+  }
+
+  return { token, platform: record.platform, createdAt };
 }

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
@@ -160,6 +160,7 @@ describe("classifyDestructiveCommand — must NOT fire", () => {
     ["single-quoted", "cat <<'EOF'\nrm -rf ./data\nEOF"],
     ["double-quoted", 'cat <<"EOF"\nDROP DATABASE production\nEOF'],
     ["concatenated quoted word", "cat <<'E'OF\nrm -rf ./data\nEOF"],
+    ["empty quoted delimiter", "cat <<''\nrm -rf ./data\n\n"],
     ["tab-stripped", "cat <<-EOF\n\trm -rf ./data\n\tEOF"],
   ])(
     "%s heredoc payload is data, not an executable segment",

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
@@ -95,6 +95,7 @@ function parseHeredocDelimiter(
   let delimiter = "";
   let quote: string | null = null;
   let quoted = false;
+  let wordStarted = false;
 
   while (cursor < line.length) {
     const ch = line[cursor] as string;
@@ -117,12 +118,14 @@ function parseHeredocDelimiter(
       continue;
     }
     if (ch === '"' || ch === "'") {
+      wordStarted = true;
       quoted = true;
       quote = ch;
       cursor += 1;
       continue;
     }
     if (ch === "\\" && cursor + 1 < line.length) {
+      wordStarted = true;
       quoted = true;
       cursor += 1;
       delimiter += line[cursor] as string;
@@ -130,11 +133,12 @@ function parseHeredocDelimiter(
       continue;
     }
     if (/[\s|;&<>()]/.test(ch)) break;
+    wordStarted = true;
     delimiter += ch;
     cursor += 1;
   }
 
-  return quote === null && delimiter ? { delimiter, quoted } : null;
+  return quote === null && wordStarted ? { delimiter, quoted } : null;
 }
 
 function isInsideArrayAssignmentSubscript(
@@ -245,9 +249,12 @@ function heredocDeclarations(line: string): HeredocDeclaration[] {
   return declarations;
 }
 
-// Heredoc bodies are shell input, not commands. Preserve their newlines so
-// later executable lines remain segment boundaries, but hide payload bytes
-// from both the command and SQL classifiers.
+// Literal heredoc payload tokens are shell input rather than command
+// positions. Preserve newlines so later executable lines remain segment
+// boundaries, but hide literal payload bytes from the command and SQL
+// classifiers. Unquoted bodies can evaluate nested expansions; those require
+// their own recursive inspection rather than treating the whole body as a
+// command list.
 function maskHeredocBodies(command: string): string {
   const lines = command.match(/[^\r\n]*(?:\r\n|\r|\n|$)/g) ?? [];
   const pending: HeredocDeclaration[] = [];


### PR DESCRIPTION
## Summary
- promote the complete develop snapshot `44c82ac3efe571f452495df5d0f44c57d92e51e9` to main
- pin the release tree so concurrent develop commits cannot invalidate staging certification during deployment
- this is a full develop promotion, not a hotfix or cherry-pick

## Release process
- forced canonical staging dispatch is running on the same exact develop SHA
- production dispatch will require the immutable staging certification artifact for this Git tree

Refs #23125