### PR TITLE
fix(ui): restore deterministic earnings quote clock

### DIFF
--- a/packages/ui/src/cloud/monetization/earnings/EarningsPageClient.determinism.test.ts
+++ b/packages/ui/src/cloud/monetization/earnings/EarningsPageClient.determinism.test.ts
@@ -1,0 +1,26 @@
+/** Guards the earnings quote's no-quote render and invalidation boundaries. */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  new URL("./EarningsPageClient.tsx", import.meta.url),
+  "utf8",
+);
+
+describe("EarningsPageClient quote-clock determinism", () => {
+  it("uses a deterministic sentinel until the first quote arrives", () => {
+    expect(source).toMatch(
+      /const \[quoteClock, setQuoteClock\] = useState\(0\);/,
+    );
+  });
+
+  it("does not read wall time while invalidating an absent quote", () => {
+    const invalidateQuote = source.match(
+      /const invalidateQuote = \(\) => \{([\s\S]*?)\n {2}\};/,
+    )?.[1];
+
+    expect(invalidateQuote).toBeDefined();
+    expect(invalidateQuote).not.toMatch(/Date\.|new Date\s*\(/);
+  });
+});

--- a/packages/ui/src/cloud/monetization/earnings/EarningsPageClient.test.tsx
+++ b/packages/ui/src/cloud/monetization/earnings/EarningsPageClient.test.tsx
@@ -242,6 +242,15 @@ afterEach(() => {
 });
 
 describe("EarningsPageClient redemption contract", () => {
+  it("does not read wall time while the initial quote is absent", async () => {
+    const now = vi.spyOn(Date, "now");
+
+    render(<EarningsPageClient />);
+
+    await screen.findByRole("button", { name: "Redeem for elizaOS" });
+    expect(now).not.toHaveBeenCalled();
+  });
+
   it("renders canonical camelCase history with the server asset label", async () => {
     apiMock.mockReset();
     installApiResponses({

--- a/packages/ui/src/cloud/monetization/earnings/EarningsPageClient.tsx
+++ b/packages/ui/src/cloud/monetization/earnings/EarningsPageClient.tsx
@@ -174,7 +174,9 @@ export function EarningsPageClient() {
   const [quote, setQuote] = useState<RedemptionQuoteResponse | null>(null);
   const [quoteLoading, setQuoteLoading] = useState(false);
   const [quoteRefreshNonce, setQuoteRefreshNonce] = useState(0);
-  const [quoteClock, setQuoteClock] = useState(() => Date.now());
+  // A quote is absent during the initial render, so wall time is irrelevant
+  // until the quote response arrives and advances this clock.
+  const [quoteClock, setQuoteClock] = useState(0);
   const [redemptionIdempotencyKey, setRedemptionIdempotencyKey] = useState<
     string | null
   >(null);
@@ -372,7 +374,6 @@ export function EarningsPageClient() {
 
   const invalidateQuote = () => {
     setQuote(null);
-    setQuoteClock(Date.now());
   };
 
   const rotateRedemptionIntent = () => {


### PR DESCRIPTION
Closes #23259.

## Summary

- initialize the earnings quote clock with a deterministic sentinel while no quote exists;
- remove the redundant wall-clock write when invalidating an already-cleared quote;
- preserve all real expiry updates when a quote arrives, expires, or is submitted.

This restores the develop UI-determinism gate and unblocks exact Quality runs for unrelated security PRs without changing rendered state.

## Exact verification

- Exact head: `2375e9d19d01ba34d828751205327927c4411d3b`
- Exact base: `1f1a0d920ad8e66385d956d7a837605215dbbe10`
- UI determinism audit: PASS (`render-time=36`, no new occurrences)
- Earnings component suite: 14/14 PASS
- Biome and diff-check: PASS
- UI package typecheck reached the owning compiler but the source-light borrowed dependency layout lacked Cloud/SQL package-local dependencies; no diagnostic referenced the changed file.

## Evidence Gate

<!-- evidence-head:2375e9d19d01ba34d828751205327927c4411d3b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - the initial state still has no quote and renders identically; bundle-first app audit is pending.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no intended pixel change; bundle-first app audit is pending.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interaction behavior changed; bundle-first app audit is pending.
<!-- evidence-row:backend-logs -->
- [ ] N/A - frontend-only deterministic state initialization.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - exact component and static audit output are documented above; browser bundle pending.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the UI determinism audit and component suite are the deterministic contract proof.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no intended pixel change; bundle-first app OCR pending.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-cortex-plugins]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
