### PR TITLE
fix(cloud): harden e2e cleanup execution boundaries

### DIFF
--- a/scripts/cloud/__tests__/e2e-agent-cleanup.test.mjs
+++ b/scripts/cloud/__tests__/e2e-agent-cleanup.test.mjs
@@ -14,6 +14,7 @@ import {
   assertExpectedCleanupIdentity,
   bindReviewedCleanupCandidates,
   normalizeAgentRow,
+  remainingJobBudget,
   resolveE2eWalletPrivateKey,
   selectAgentsForCleanup,
 } from "../e2e-agent-cleanup-lib.mjs";
@@ -198,6 +199,15 @@ describe("destructive binding", () => {
   });
 });
 
+describe("job deadline", () => {
+  test("caps both requests and sleeps to the remaining overall budget", () => {
+    expect(remainingJobBudget(150, Number.POSITIVE_INFINITY, 100)).toBe(50);
+    expect(remainingJobBudget(150, 1_000, 100)).toBe(50);
+    expect(remainingJobBudget(150, 20, 100)).toBe(20);
+    expect(remainingJobBudget(150, 20, 151)).toBe(0);
+  });
+});
+
 describe("cli", () => {
   test("--help exits 0 without touching the network", () => {
     const script = path.join(
@@ -217,11 +227,29 @@ describe("cli", () => {
     const malformedNumber = await runCli(["--keep", "1x"]);
     expect(malformedNumber.exitCode).toBe(1);
     expect(malformedNumber.stderr).toContain("--keep must be");
-    const unknownFlag = await runCli(["--keeep", "1"]);
-    expect(unknownFlag.exitCode).toBe(1);
-    expect(unknownFlag.stderr).toContain(
-      "unknown or positional argument: --keeep",
-    );
+    let requests = 0;
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        requests += 1;
+        return new Response("unexpected request", { status: 500 });
+      },
+    });
+    try {
+      const unknownFlag = await runCli([
+        "--base",
+        server.url.toString(),
+        "--keeep",
+        "1",
+      ]);
+      expect(unknownFlag.exitCode).toBe(1);
+      expect(unknownFlag.stderr).toContain(
+        "unknown or positional argument: --keeep",
+      );
+      expect(requests).toBe(0);
+    } finally {
+      server.stop(true);
+    }
     const positional = await runCli(["reviewed-agent-id"]);
     expect(positional.exitCode).toBe(1);
     expect(positional.stderr).toContain(
@@ -247,6 +275,19 @@ describe("cli", () => {
     } finally {
       receipt.cleanup();
     }
+  });
+
+  test("rejects credential-bearing and ambiguous base URLs before network", async () => {
+    const credentials = await runCli([
+      "--base",
+      "https://operator:secret@api.eliza.app",
+    ]);
+    expect(credentials.exitCode).toBe(1);
+    expect(credentials.stderr).toContain("must not contain credentials");
+
+    const query = await runCli(["--base", "https://api.eliza.app?target=dev"]);
+    expect(query.exitCode).toBe(1);
+    expect(query.stderr).toContain("must not contain a query or fragment");
   });
 
   test("loopback apply binds conditional identity, waits, verifies absence, and resumes as a no-op", async () => {
@@ -328,6 +369,46 @@ describe("cli", () => {
         attempts: [],
         verifiedAbsent: ["old-dedicated"],
       });
+    } finally {
+      server.stop(true);
+      receipt.cleanup();
+    }
+  });
+
+  test("concurrent report writers leave one complete private receipt", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === "/api/v1/credits/balance") {
+          return Response.json({ balance: 10 });
+        }
+        if (url.pathname === "/api/v1/eliza/agents") {
+          return Response.json({ data: [oldAgentRow("old")] });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const receipt = temporaryReport();
+    try {
+      const results = await Promise.all(
+        Array.from({ length: 4 }, () =>
+          runCli([
+            "--base",
+            server.url.toString(),
+            "--report",
+            receipt.reportPath,
+            "--min-age-minutes",
+            "0",
+          ]),
+        ),
+      );
+      expect(results.every(({ exitCode }) => exitCode === 0)).toBe(true);
+      expect(
+        JSON.parse(fs.readFileSync(receipt.reportPath, "utf8")),
+      ).toMatchObject({ apply: false, eligible: ["old"], failure: null });
+      expect(fs.statSync(receipt.reportPath).mode & 0o777).toBe(0o600);
+      expect(fs.readdirSync(receipt.directory)).toEqual(["receipt.json"]);
     } finally {
       server.stop(true);
       receipt.cleanup();
@@ -539,7 +620,8 @@ describe("cli", () => {
     },
   );
 
-  test("allows only one concurrent writer to own a report receipt", async () => {
+  test("caps a stalled job response at the remaining job deadline", async () => {
+    let jobPolls = 0;
     const server = Bun.serve({
       port: 0,
       async fetch(request) {
@@ -548,31 +630,44 @@ describe("cli", () => {
           return Response.json({ balance: 10 });
         }
         if (url.pathname === "/api/v1/eliza/agents") {
-          await Bun.sleep(100);
-          return Response.json({ data: [] });
+          return Response.json({ data: [oldAgentRow("old")] });
+        }
+        if (url.pathname === "/api/v1/eliza/agents/old") {
+          return Response.json(
+            { data: { jobId: "delete-job" } },
+            { status: 202 },
+          );
+        }
+        if (url.pathname === "/api/v1/jobs/delete-job") {
+          jobPolls += 1;
+          if (jobPolls === 1) {
+            await Bun.sleep(50);
+            return Response.json({ data: { status: "running" } });
+          }
+          return new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode('{"data":'));
+              },
+            }),
+            { headers: { "Content-Type": "application/json" } },
+          );
         }
         return new Response("not found", { status: 404 });
       },
     });
     const receipt = temporaryReport();
-    const args = [
-      "--base",
-      server.url.toString(),
-      "--report",
-      receipt.reportPath,
-      "--job-timeout-ms",
-      "1000",
-    ];
     try {
-      const results = await Promise.all([runCli(args), runCli(args)]);
-      expect(results.map((result) => result.exitCode).sort()).toEqual([0, 1]);
-      expect(results.find((result) => result.exitCode === 1)?.stderr).toContain(
-        "report is already locked by another cleanup",
-      );
-      expect(
-        JSON.parse(fs.readFileSync(receipt.reportPath, "utf8")),
-      ).toMatchObject({ apply: false, attempts: [] });
-      expect(fs.existsSync(`${receipt.reportPath}.lock`)).toBe(false);
+      const result = await runCli([
+        ...applyArgs(server, receipt.reportPath, ["old"]),
+        "--job-timeout-ms",
+        "200",
+        "--poll-interval-ms",
+        "0",
+      ]);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toMatch(/aborted|timed out|timeout/i);
+      expect(jobPolls).toBe(2);
     } finally {
       server.stop(true);
       receipt.cleanup();

--- a/scripts/cloud/__tests__/e2e-agent-cleanup.test.mjs
+++ b/scripts/cloud/__tests__/e2e-agent-cleanup.test.mjs
@@ -217,6 +217,16 @@ describe("cli", () => {
     const malformedNumber = await runCli(["--keep", "1x"]);
     expect(malformedNumber.exitCode).toBe(1);
     expect(malformedNumber.stderr).toContain("--keep must be");
+    const unknownFlag = await runCli(["--keeep", "1"]);
+    expect(unknownFlag.exitCode).toBe(1);
+    expect(unknownFlag.stderr).toContain(
+      "unknown or positional argument: --keeep",
+    );
+    const positional = await runCli(["reviewed-agent-id"]);
+    expect(positional.exitCode).toBe(1);
+    expect(positional.stderr).toContain(
+      "unknown or positional argument: reviewed-agent-id",
+    );
 
     const receipt = temporaryReport();
     try {
@@ -282,6 +292,9 @@ describe("cli", () => {
       },
     });
     const receipt = temporaryReport();
+    const sentinelPath = path.join(receipt.directory, "sentinel.txt");
+    fs.writeFileSync(sentinelPath, "untouched\n");
+    fs.symlinkSync(sentinelPath, `${receipt.reportPath}.tmp`);
     try {
       const args = applyArgs(server, receipt.reportPath, ["old-dedicated"]);
       const result = await runCli(args);
@@ -302,6 +315,8 @@ describe("cli", () => {
         verifiedAbsent: ["old-dedicated"],
         attempts: [{ agentId: "old-dedicated", status: "completed" }],
       });
+      expect(fs.readFileSync(sentinelPath, "utf8")).toBe("untouched\n");
+      expect(fs.statSync(receipt.reportPath).mode & 0o777).toBe(0o600);
 
       const second = await runCli(args);
       expect(second.exitCode).toBe(0);
@@ -482,6 +497,87 @@ describe("cli", () => {
       receipt.cleanup();
     }
   });
+
+  test.each(["headers", "body"])(
+    "bounds a provider request that stalls before %s completion",
+    async (stallKind) => {
+      const server = Bun.serve({
+        port: 0,
+        async fetch(request) {
+          const url = new URL(request.url);
+          if (url.pathname === "/api/v1/credits/balance") {
+            return Response.json({ balance: 10 });
+          }
+          if (url.pathname === "/api/v1/eliza/agents") {
+            if (stallKind === "headers") {
+              return await new Promise(() => {});
+            }
+            return new Response(
+              new ReadableStream({
+                start(controller) {
+                  controller.enqueue(new TextEncoder().encode('{"data":['));
+                },
+              }),
+              { headers: { "Content-Type": "application/json" } },
+            );
+          }
+          return new Response("not found", { status: 404 });
+        },
+      });
+      try {
+        const result = await runCli([
+          "--base",
+          server.url.toString(),
+          "--job-timeout-ms",
+          "30",
+        ]);
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toMatch(/aborted|timed out|timeout/i);
+      } finally {
+        server.stop(true);
+      }
+    },
+  );
+
+  test("allows only one concurrent writer to own a report receipt", async () => {
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === "/api/v1/credits/balance") {
+          return Response.json({ balance: 10 });
+        }
+        if (url.pathname === "/api/v1/eliza/agents") {
+          await Bun.sleep(100);
+          return Response.json({ data: [] });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const receipt = temporaryReport();
+    const args = [
+      "--base",
+      server.url.toString(),
+      "--report",
+      receipt.reportPath,
+      "--job-timeout-ms",
+      "1000",
+    ];
+    try {
+      const results = await Promise.all([runCli(args), runCli(args)]);
+      expect(results.map((result) => result.exitCode).sort()).toEqual([0, 1]);
+      expect(results.find((result) => result.exitCode === 1)?.stderr).toContain(
+        "report is already locked by another cleanup",
+      );
+      expect(
+        JSON.parse(fs.readFileSync(receipt.reportPath, "utf8")),
+      ).toMatchObject({ apply: false, attempts: [] });
+      expect(fs.existsSync(`${receipt.reportPath}.lock`)).toBe(false);
+    } finally {
+      server.stop(true);
+      receipt.cleanup();
+    }
+  });
 });
 
 const TEST_ADDRESS = "0x1111111111111111111111111111111111111111";
@@ -501,6 +597,7 @@ function temporaryReport() {
     path.join(os.tmpdir(), "eliza-e2e-cleanup-"),
   );
   return {
+    directory,
     reportPath: path.join(directory, "receipt.json"),
     cleanup: () => fs.rmSync(directory, { recursive: true, force: true }),
   };

--- a/scripts/cloud/__tests__/e2e-agent-cleanup.test.mjs
+++ b/scripts/cloud/__tests__/e2e-agent-cleanup.test.mjs
@@ -375,7 +375,83 @@ describe("cli", () => {
     }
   });
 
-  test("concurrent report writers leave one complete private receipt", async () => {
+  test("rejects a concurrent apply before network and preserves the active receipt", async () => {
+    let agents = [oldAgentRow("first"), oldAgentRow("second")];
+    const requests = [];
+    let markDeleteEntered;
+    let releaseDelete;
+    const deleteEntered = new Promise((resolve) => {
+      markDeleteEntered = resolve;
+    });
+    const deleteReleased = new Promise((resolve) => {
+      releaseDelete = resolve;
+    });
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url);
+        requests.push(`${request.method} ${url.pathname}`);
+        if (url.pathname === "/api/v1/credits/balance") {
+          return Response.json({ balance: 10 });
+        }
+        if (url.pathname === "/api/v1/eliza/agents") {
+          return Response.json({ data: agents });
+        }
+        if (url.pathname === "/api/v1/eliza/agents/first") {
+          markDeleteEntered();
+          await deleteReleased;
+          agents = agents.filter(({ id }) => id !== "first");
+          return Response.json({ success: true });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const receipt = temporaryReport();
+    let firstRun;
+    try {
+      firstRun = runCli(applyArgs(server, receipt.reportPath, ["first"]));
+      await deleteEntered;
+      const requestsBeforeSecondRun = requests.length;
+      const secondRun = await runCli(
+        applyArgs(server, receipt.reportPath, ["second"]),
+      );
+      expect(secondRun.exitCode).toBe(1);
+      expect(secondRun.stderr).toContain("locked by active pid");
+      expect(requests).toHaveLength(requestsBeforeSecondRun);
+
+      releaseDelete();
+      const firstResult = await firstRun;
+      expect(firstResult.exitCode).toBe(0);
+      expect(
+        JSON.parse(fs.readFileSync(receipt.reportPath, "utf8")),
+      ).toMatchObject({
+        apply: true,
+        failure: null,
+        attempts: [{ agentId: "first", status: "completed" }],
+        verifiedAbsent: ["first"],
+      });
+      expect(fs.statSync(receipt.reportPath).mode & 0o777).toBe(0o600);
+      expect(fs.readdirSync(receipt.directory)).toEqual(["receipt.json"]);
+    } finally {
+      releaseDelete();
+      await firstRun?.catch(() => {});
+      server.stop(true);
+      receipt.cleanup();
+    }
+  });
+
+  test("reclaims only a verifiably stale same-host report lock", async () => {
+    const exited = Bun.spawn(["bun", "-e", ""], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    await exited.exited;
+    const receipt = temporaryReport();
+    fs.writeFileSync(
+      `${receipt.reportPath}.lock`,
+      `${JSON.stringify({ pid: exited.pid, hostname: os.hostname(), startedAt: new Date().toISOString() })}\n`,
+      { mode: 0o600 },
+    );
     const server = Bun.serve({
       port: 0,
       fetch(request) {
@@ -384,31 +460,49 @@ describe("cli", () => {
           return Response.json({ balance: 10 });
         }
         if (url.pathname === "/api/v1/eliza/agents") {
-          return Response.json({ data: [oldAgentRow("old")] });
+          return Response.json({ data: [] });
         }
         return new Response("not found", { status: 404 });
       },
     });
-    const receipt = temporaryReport();
     try {
-      const results = await Promise.all(
-        Array.from({ length: 4 }, () =>
-          runCli([
-            "--base",
-            server.url.toString(),
-            "--report",
-            receipt.reportPath,
-            "--min-age-minutes",
-            "0",
-          ]),
-        ),
-      );
-      expect(results.every(({ exitCode }) => exitCode === 0)).toBe(true);
-      expect(
-        JSON.parse(fs.readFileSync(receipt.reportPath, "utf8")),
-      ).toMatchObject({ apply: false, eligible: ["old"], failure: null });
-      expect(fs.statSync(receipt.reportPath).mode & 0o777).toBe(0o600);
-      expect(fs.readdirSync(receipt.directory)).toEqual(["receipt.json"]);
+      const result = await runCli([
+        "--base",
+        server.url.toString(),
+        "--report",
+        receipt.reportPath,
+      ]);
+      expect(result.exitCode).toBe(0);
+      expect(fs.existsSync(`${receipt.reportPath}.lock`)).toBe(false);
+    } finally {
+      server.stop(true);
+      receipt.cleanup();
+    }
+  });
+
+  test("fails closed on a symlinked report lock before network", async () => {
+    let requests = 0;
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        requests += 1;
+        return new Response("unexpected", { status: 500 });
+      },
+    });
+    const receipt = temporaryReport();
+    const sentinel = path.join(receipt.directory, "sentinel.txt");
+    fs.writeFileSync(sentinel, "untouched\n");
+    fs.symlinkSync(sentinel, `${receipt.reportPath}.lock`);
+    try {
+      const result = await runCli([
+        "--base",
+        server.url.toString(),
+        "--report",
+        receipt.reportPath,
+      ]);
+      expect(result.exitCode).toBe(1);
+      expect(requests).toBe(0);
+      expect(fs.readFileSync(sentinel, "utf8")).toBe("untouched\n");
     } finally {
       server.stop(true);
       receipt.cleanup();
@@ -498,11 +592,11 @@ describe("cli", () => {
   });
 
   test.each([
-    ["failed", "delete job delete-job for old failed"],
-    ["running", "delete job delete-job for old timed out"],
+    ["failed", "delete job delete-job for old failed", "2000"],
+    ["running", "delete job delete-job for old timed out", "50"],
   ])(
     "fails closed on a %s delete job and writes the failure receipt",
-    async (jobStatus, expectedError) => {
+    async (jobStatus, expectedError, timeoutMs) => {
       const server = Bun.serve({
         port: 0,
         fetch(request) {
@@ -529,7 +623,7 @@ describe("cli", () => {
         const result = await runCli([
           ...applyArgs(server, receipt.reportPath, ["old"]),
           "--job-timeout-ms",
-          "20",
+          timeoutMs,
           "--poll-interval-ms",
           "1",
         ]);

--- a/scripts/cloud/e2e-agent-cleanup-lib.mjs
+++ b/scripts/cloud/e2e-agent-cleanup-lib.mjs
@@ -178,3 +178,8 @@ export function assertExpectedCleanupIdentity(
     );
   }
 }
+
+/** Cap one polling operation to the unspent portion of its overall deadline. */
+export function remainingJobBudget(deadlineMs, requestedMs, now = Date.now()) {
+  return Math.min(requestedMs, Math.max(0, deadlineMs - now));
+}

--- a/scripts/cloud/e2e-agent-cleanup.mjs
+++ b/scripts/cloud/e2e-agent-cleanup.mjs
@@ -31,6 +31,7 @@ import {
   assertExpectedCleanupIdentity,
   bindReviewedCleanupCandidates,
   normalizeAgentRow,
+  remainingJobBudget,
   resolveE2eWalletPrivateKey,
   selectAgentsForCleanup,
 } from "./e2e-agent-cleanup-lib.mjs";
@@ -133,6 +134,12 @@ function parseOptions() {
   if (!/^https?:$/.test(parsedBase.protocol)) {
     throw new Error("--base must be an http(s) URL");
   }
+  if (parsedBase.username || parsedBase.password) {
+    throw new Error("--base must not contain credentials");
+  }
+  if (parsedBase.search || parsedBase.hash) {
+    throw new Error("--base must not contain a query or fragment");
+  }
   const isLoopback = ["127.0.0.1", "localhost", "::1"].includes(
     parsedBase.hostname,
   );
@@ -225,9 +232,18 @@ async function resolveToken(options) {
   };
 }
 
-async function cloud(options, token, path, init = {}) {
-  const requestTimeoutMs = Math.min(options.jobTimeoutMs, 15_000);
-  const res = await fetch(`${options.baseUrl}${path}`, {
+async function cloud(
+  options,
+  token,
+  requestPath,
+  init = {},
+  timeoutMs = options.jobTimeoutMs,
+) {
+  const requestTimeoutMs = Math.min(timeoutMs, 15_000);
+  if (!Number.isFinite(requestTimeoutMs) || requestTimeoutMs <= 0) {
+    throw new Error(`Cloud request deadline elapsed before ${requestPath}`);
+  }
+  const res = await fetch(`${options.baseUrl}${requestPath}`, {
     ...init,
     signal: AbortSignal.timeout(requestTimeoutMs),
     headers: {
@@ -246,7 +262,7 @@ async function cloud(options, token, path, init = {}) {
   }
   if (!res.ok) {
     throw new Error(
-      `Cloud request failed (${res.status}) ${path}: ${text.slice(0, 300)}`,
+      `Cloud request failed (${res.status}) ${requestPath}: ${text.slice(0, 300)}`,
     );
   }
   return { status: res.status, body };
@@ -314,10 +330,16 @@ async function deleteAgent(options, token, agent) {
     }
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
+      const remainingMs = remainingJobBudget(
+        deadline,
+        Number.POSITIVE_INFINITY,
+      );
       const job = await cloud(
         options,
         token,
         `/api/v1/jobs/${encodeURIComponent(jobId)}`,
+        {},
+        remainingMs,
       );
       const status = String(
         job.body?.data?.status ?? job.body?.status ?? "",
@@ -328,7 +350,10 @@ async function deleteAgent(options, token, agent) {
         throw new Error(
           `delete job ${jobId} for ${agent.id} failed: ${status}`,
         );
-      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+      const sleepMs = remainingJobBudget(deadline, pollIntervalMs);
+      if (sleepMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, sleepMs));
+      }
     }
     throw new Error(`delete job ${jobId} for ${agent.id} timed out`);
   }
@@ -369,13 +394,23 @@ function writeReport(reportPath, report) {
       fs.closeSync(directoryDescriptor);
     }
   } catch (error) {
+    // error-policy:J2 receipt persistence is a required boundary, so retain
+    // the filesystem cause while adding the destination needed to diagnose it.
     if (fileDescriptor !== undefined) fs.closeSync(fileDescriptor);
     try {
       fs.unlinkSync(temporaryPath);
     } catch (cleanupError) {
-      if (cleanupError?.code !== "ENOENT") throw cleanupError;
+      // error-policy:J6 a failed temp-file cleanup must not replace the
+      // receipt write failure that stopped mutation and remains actionable.
+      if (cleanupError?.code !== "ENOENT") {
+        console.warn(
+          `[e2e-agent-cleanup] WARN: failed to clean temporary receipt: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+        );
+      }
     }
-    throw error;
+    throw new Error(`failed to persist cleanup receipt at ${reportPath}`, {
+      cause: error,
+    });
   }
 }
 

--- a/scripts/cloud/e2e-agent-cleanup.mjs
+++ b/scripts/cloud/e2e-agent-cleanup.mjs
@@ -26,6 +26,7 @@
  */
 
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import {
   assertExpectedCleanupIdentity,
@@ -414,43 +415,132 @@ function writeReport(reportPath, report) {
   }
 }
 
-let reportLockPath = null;
-
-function acquireReportLock(reportPath) {
-  if (!reportPath) return;
-  const lockPath = `${reportPath}.lock`;
-  try {
-    fs.mkdirSync(lockPath, { mode: 0o700 });
-  } catch (error) {
-    if (error?.code === "EEXIST") {
-      throw new Error(
-        `report is already locked by another cleanup: ${reportPath}`,
-        {
-          cause: error,
-        },
-      );
-    }
-    throw error;
-  }
-  reportLockPath = lockPath;
+function sameFileIdentity(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
 }
 
-process.on("exit", () => {
-  if (!reportLockPath) return;
-  try {
-    fs.rmdirSync(reportLockPath);
-  } catch (error) {
-    // error-policy:J6 process teardown cannot safely recover a report lock;
-    // leave it fail-closed for explicit operator inspection.
-    console.error(
-      `[e2e-agent-cleanup] WARN: could not release report lock ${reportLockPath}: ${error.message}`,
-    );
-  }
-});
+function acquireReportLock(reportPath) {
+  if (!reportPath) return () => {};
+  const lockPath = `${reportPath}.lock`;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    let descriptor;
+    let createdIdentity;
+    try {
+      descriptor = fs.openSync(
+        lockPath,
+        fs.constants.O_WRONLY |
+          fs.constants.O_CREAT |
+          fs.constants.O_EXCL |
+          fs.constants.O_NOFOLLOW,
+        0o600,
+      );
+      createdIdentity = fs.fstatSync(descriptor);
+      fs.writeFileSync(
+        descriptor,
+        `${JSON.stringify({ pid: process.pid, hostname: os.hostname(), startedAt: new Date().toISOString() })}\n`,
+        "utf8",
+      );
+      fs.fsyncSync(descriptor);
+      const identity = fs.fstatSync(descriptor);
+      fs.closeSync(descriptor);
+      descriptor = undefined;
+      return () => {
+        try {
+          const current = fs.lstatSync(lockPath);
+          if (!sameFileIdentity(identity, current)) {
+            throw new Error("report lock changed while cleanup was running");
+          }
+          fs.unlinkSync(lockPath);
+        } catch (error) {
+          // error-policy:J6 releasing the advisory receipt lock is teardown;
+          // the receipt itself already records the authoritative run result.
+          console.warn(
+            `[e2e-agent-cleanup] WARN: failed to release report lock: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      };
+    } catch (error) {
+      // error-policy:J2 lock acquisition failures gain report-path context and
+      // preserve their filesystem cause; EEXIST is inspected fail-closed below.
+      if (descriptor !== undefined) fs.closeSync(descriptor);
+      if (createdIdentity !== undefined) {
+        try {
+          const current = fs.lstatSync(lockPath);
+          if (sameFileIdentity(createdIdentity, current))
+            fs.unlinkSync(lockPath);
+        } catch (cleanupError) {
+          // error-policy:J6 this cleanup only removes a lock created by this
+          // failed acquisition; the original failure remains authoritative.
+          if (cleanupError?.code !== "ENOENT") {
+            console.warn(
+              `[e2e-agent-cleanup] WARN: failed to clean incomplete report lock: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+            );
+          }
+        }
+      }
+      if (error?.code !== "EEXIST") {
+        throw new Error(
+          `failed to acquire cleanup report lock at ${lockPath}`,
+          {
+            cause: error,
+          },
+        );
+      }
+    }
 
-async function main() {
-  const options = parseOptions();
-  acquireReportLock(options.reportPath);
+    let existingDescriptor;
+    let owner;
+    let existingIdentity;
+    try {
+      existingDescriptor = fs.openSync(
+        lockPath,
+        fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW,
+      );
+      existingIdentity = fs.fstatSync(existingDescriptor);
+      const text = fs.readFileSync(existingDescriptor, "utf8");
+      try {
+        owner = JSON.parse(text);
+      } catch (error) {
+        // error-policy:J3 lock contents are untrusted; malformed ownership can
+        // never authorize removal of a potentially live process's lock.
+        throw new Error(`cleanup report lock is malformed at ${lockPath}`, {
+          cause: error,
+        });
+      }
+    } finally {
+      if (existingDescriptor !== undefined) fs.closeSync(existingDescriptor);
+    }
+    if (
+      owner?.hostname !== os.hostname() ||
+      !Number.isInteger(owner?.pid) ||
+      owner.pid <= 0
+    ) {
+      throw new Error(`cleanup report is locked by an unverifiable owner`);
+    }
+
+    let ownerAlive = true;
+    try {
+      process.kill(owner.pid, 0);
+    } catch (error) {
+      // error-policy:J3 only the OS's definitive no-such-process result makes
+      // a same-host lock stale; permissions and unknown errors stay locked.
+      if (error?.code === "ESRCH") ownerAlive = false;
+      else throw new Error(`cleanup report is locked by pid ${owner.pid}`);
+    }
+    if (ownerAlive) {
+      throw new Error(`cleanup report is locked by active pid ${owner.pid}`);
+    }
+
+    const currentIdentity = fs.lstatSync(lockPath);
+    if (!sameFileIdentity(existingIdentity, currentIdentity)) {
+      throw new Error("cleanup report lock changed during stale-lock recovery");
+    }
+    fs.unlinkSync(lockPath);
+  }
+  throw new Error(`failed to acquire cleanup report lock at ${lockPath}`);
+}
+
+async function executeCleanup(options) {
   const { token, identity } = await resolveToken(options);
   if (options.apply) {
     assertExpectedCleanupIdentity(identity, options);
@@ -547,6 +637,16 @@ async function main() {
       ? `done: verified ${report.verifiedAbsent.length} reviewed candidate(s) absent`
       : `dry run: ${toDelete.length} eligible agent(s); review IDs before --apply`,
   );
+}
+
+async function main() {
+  const options = parseOptions();
+  const releaseReportLock = acquireReportLock(options.reportPath);
+  try {
+    await executeCleanup(options);
+  } finally {
+    releaseReportLock();
+  }
 }
 
 main().catch((error) => {

--- a/scripts/cloud/e2e-agent-cleanup.mjs
+++ b/scripts/cloud/e2e-agent-cleanup.mjs
@@ -26,6 +26,7 @@
  */
 
 import fs from "node:fs";
+import path from "node:path";
 import {
   assertExpectedCleanupIdentity,
   bindReviewedCleanupCandidates,
@@ -47,11 +48,42 @@ function argAll(name) {
   return values;
 }
 
+const BOOLEAN_OPTIONS = new Set(["--apply", "--wait", "--help", "-h"]);
+const VALUE_OPTIONS = new Set([
+  "--base",
+  "--candidate",
+  "--expected-address",
+  "--expected-org",
+  "--keep",
+  "--min-age-minutes",
+  "--protect",
+  "--report",
+  "--job-timeout-ms",
+  "--poll-interval-ms",
+]);
+
+function validateArgv(tokens) {
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (BOOLEAN_OPTIONS.has(token)) continue;
+    if (!VALUE_OPTIONS.has(token)) {
+      throw new Error(`unknown or positional argument: ${token}`);
+    }
+    const value = tokens[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`${token} requires a value`);
+    }
+    index += 1;
+  }
+}
+
 function arg(name, fallback = null) {
   const values = argAll(name);
   if (values.length > 1) throw new Error(`${name} may only be provided once`);
   return values[0] ?? fallback;
 }
+
+validateArgv(process.argv.slice(2));
 
 const has = (name) => process.argv.includes(name);
 const log = (message) => console.log(`[e2e-agent-cleanup] ${message}`);
@@ -194,8 +226,10 @@ async function resolveToken(options) {
 }
 
 async function cloud(options, token, path, init = {}) {
+  const requestTimeoutMs = Math.min(options.jobTimeoutMs, 15_000);
   const res = await fetch(`${options.baseUrl}${path}`, {
     ...init,
+    signal: AbortSignal.timeout(requestTimeoutMs),
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json",
@@ -303,13 +337,85 @@ async function deleteAgent(options, token, agent) {
 
 function writeReport(reportPath, report) {
   if (!reportPath) return;
-  const temporaryPath = `${reportPath}.tmp`;
-  fs.writeFileSync(temporaryPath, `${JSON.stringify(report, null, 2)}\n`);
-  fs.renameSync(temporaryPath, reportPath);
+  const directory = path.dirname(reportPath);
+  const temporaryPath = path.join(
+    directory,
+    `.${path.basename(reportPath)}.${process.pid}.${crypto.randomUUID()}.tmp`,
+  );
+  let fileDescriptor;
+  try {
+    fileDescriptor = fs.openSync(
+      temporaryPath,
+      fs.constants.O_WRONLY |
+        fs.constants.O_CREAT |
+        fs.constants.O_EXCL |
+        fs.constants.O_NOFOLLOW,
+      0o600,
+    );
+    fs.writeFileSync(
+      fileDescriptor,
+      `${JSON.stringify(report, null, 2)}\n`,
+      "utf8",
+    );
+    fs.fsyncSync(fileDescriptor);
+    fs.closeSync(fileDescriptor);
+    fileDescriptor = undefined;
+    fs.renameSync(temporaryPath, reportPath);
+
+    const directoryDescriptor = fs.openSync(directory, fs.constants.O_RDONLY);
+    try {
+      fs.fsyncSync(directoryDescriptor);
+    } finally {
+      fs.closeSync(directoryDescriptor);
+    }
+  } catch (error) {
+    if (fileDescriptor !== undefined) fs.closeSync(fileDescriptor);
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch (cleanupError) {
+      if (cleanupError?.code !== "ENOENT") throw cleanupError;
+    }
+    throw error;
+  }
 }
+
+let reportLockPath = null;
+
+function acquireReportLock(reportPath) {
+  if (!reportPath) return;
+  const lockPath = `${reportPath}.lock`;
+  try {
+    fs.mkdirSync(lockPath, { mode: 0o700 });
+  } catch (error) {
+    if (error?.code === "EEXIST") {
+      throw new Error(
+        `report is already locked by another cleanup: ${reportPath}`,
+        {
+          cause: error,
+        },
+      );
+    }
+    throw error;
+  }
+  reportLockPath = lockPath;
+}
+
+process.on("exit", () => {
+  if (!reportLockPath) return;
+  try {
+    fs.rmdirSync(reportLockPath);
+  } catch (error) {
+    // error-policy:J6 process teardown cannot safely recover a report lock;
+    // leave it fail-closed for explicit operator inspection.
+    console.error(
+      `[e2e-agent-cleanup] WARN: could not release report lock ${reportLockPath}: ${error.message}`,
+    );
+  }
+});
 
 async function main() {
   const options = parseOptions();
+  acquireReportLock(options.reportPath);
   const { token, identity } = await resolveToken(options);
   if (options.apply) {
     assertExpectedCleanupIdentity(identity, options);


### PR DESCRIPTION
Fixes #23253.
Corrective successor to merged #23262; no production cleanup was run.

## What changed

- consume the complete CLI argv stream and reject unknown or positional tokens before auth/network/mutation, so misspelled protection and age flags cannot silently fall back to destructive defaults;
- bound every Cloud fetch, including stalled response bodies, to at most 15 seconds (or the smaller configured job deadline);
- replace the predictable, symlink-following `${report}.tmp` write with a same-directory unique `O_EXCL | O_NOFOLLOW` 0600 file, fsync the receipt, atomically rename it, and fsync the directory;
- acquire a fail-closed run-scoped report lock before auth/network/mutation so concurrent cleanup processes cannot overwrite each other's mutation receipts;
- add deterministic regressions for typo/positional rejection, malicious fixed-temp symlinks, receipt permissions, concurrent report ownership, and both pre-header and response-body stalls.

## Exact-head verification

Final PR head: `6b6c2d834df9325e1d7efa8f6f725dd4263f8bb6`

Squash merge: `673fb8e986f517b390ff4e82d005354409fceda2`

Parent develop: `84f58095b90b425d81bbaf6ff93914797045a332`

- `bun test scripts/cloud/__tests__/e2e-agent-cleanup.test.mjs`: 28/28, 89 assertions;
- pinned Bun 1.3.14;
- `node --check` on production and test scripts: pass;
- Biome on both files: format/lint pass, retaining only the two pre-existing non-failing undeclared-Turbo-env warnings from #23262;
- `git diff --check`: pass.

The full root verify is not claimed from this isolated sparse worktree. Keep draft until independent exact-head review and hosted gates.

## Evidence Gate

<!-- evidence-head:6b6c2d834df9325e1d7efa8f6f725dd4263f8bb6 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - headless script and test changes only.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic loopback CLI tests are the applicable interaction proof.
<!-- evidence-row:backend-logs -->
- [x] [23267-postmerge-exact.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23267-postmerge-exact.log)

```text
28 pass
0 fail
89 expect() calls
```
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or planner behavior.
<!-- evidence-row:domain-artifacts -->
- [x] [23267-postmerge-domain.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23267-postmerge-domain.md)

```text
concurrent apply: loser rejected before network; winner receipt preserved
lock ownership: PID-host bound, symlink-safe stale recovery
receipt mode: 0600 and durable atomic rename
whole job including response bodies: bounded deadline
```
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual artifact.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@84f58095b90b425d81bbaf6ff93914797045a332:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`



