### PR TITLE
test(agent): add cold reload strategy coverage

### DIFF
--- a/packages/agent/src/runtime/operations/cold-strategy.test.ts
+++ b/packages/agent/src/runtime/operations/cold-strategy.test.ts
@@ -3,7 +3,7 @@
  * success/failure phase reporting, and intent description.
  */
 import { describe, expect, it, vi } from "vitest";
-import { createColdStrategy } from "./runtime/operations/cold-strategy.ts";
+import { createColdStrategy } from "./cold-strategy.ts";
 
 function makeCtx(overrides: Partial<Record<string, unknown>> = {}) {
   return {
@@ -53,7 +53,9 @@ describe("createColdStrategy", () => {
 
   it("describes a provider-switch intent in the restart reason", async () => {
     const restartRuntime = vi.fn(async () => ({ id: "rt" }));
-    const ctx = makeCtx({ intent: { kind: "provider-switch", provider: "anthropic" } });
+    const ctx = makeCtx({
+      intent: { kind: "provider-switch", provider: "anthropic" },
+    });
     const strategy = createColdStrategy({ restartRuntime });
     await strategy.apply(ctx);
     expect(restartRuntime).toHaveBeenCalledWith("provider switch to anthropic");
@@ -70,9 +72,13 @@ describe("createColdStrategy", () => {
   it("describes plugin enable/disable intents", async () => {
     const restartRuntime = vi.fn(async () => ({ id: "rt" }));
     const strategy = createColdStrategy({ restartRuntime });
-    await strategy.apply(makeCtx({ intent: { kind: "plugin-enable", pluginId: "p1" } }));
+    await strategy.apply(
+      makeCtx({ intent: { kind: "plugin-enable", pluginId: "p1" } }),
+    );
     expect(restartRuntime).toHaveBeenLastCalledWith("plugin enable: p1");
-    await strategy.apply(makeCtx({ intent: { kind: "plugin-disable", pluginId: "p2" } }));
+    await strategy.apply(
+      makeCtx({ intent: { kind: "plugin-disable", pluginId: "p2" } }),
+    );
     expect(restartRuntime).toHaveBeenLastCalledWith("plugin disable: p2");
   });
 

--- a/packages/agent/src/runtime/operations/cold-strategy.test.ts
+++ b/packages/agent/src/runtime/operations/cold-strategy.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit coverage for the cold reload strategy — restart closure delegation,
+ * success/failure phase reporting, and intent description.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { createColdStrategy } from "./runtime/operations/cold-strategy.ts";
+
+function makeCtx(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    intent: { kind: "restart", reason: "manual" },
+    reportPhase: vi.fn(),
+    ...overrides,
+  } as never;
+}
+
+describe("createColdStrategy", () => {
+  it("reports a succeeded phase and returns the new runtime", async () => {
+    const newRuntime = { id: "rt-2" };
+    const restartRuntime = vi.fn(async () => newRuntime);
+    const ctx = makeCtx();
+    const strategy = createColdStrategy({ restartRuntime });
+
+    const result = await strategy.apply(ctx);
+
+    expect(result).toBe(newRuntime);
+    expect(restartRuntime).toHaveBeenCalledWith("manual");
+    expect(ctx.reportPhase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "cold-restart",
+        status: "succeeded",
+      }),
+    );
+  });
+
+  it("reports a failed phase and throws when restart returns null", async () => {
+    const restartRuntime = vi.fn(async () => null);
+    const ctx = makeCtx();
+    const strategy = createColdStrategy({ restartRuntime });
+
+    await expect(strategy.apply(ctx)).rejects.toThrow(
+      "Cold restart returned null runtime",
+    );
+    expect(ctx.reportPhase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "cold-restart",
+        status: "failed",
+        error: expect.objectContaining({
+          message: "Cold restart returned null runtime",
+        }),
+      }),
+    );
+  });
+
+  it("describes a provider-switch intent in the restart reason", async () => {
+    const restartRuntime = vi.fn(async () => ({ id: "rt" }));
+    const ctx = makeCtx({ intent: { kind: "provider-switch", provider: "anthropic" } });
+    const strategy = createColdStrategy({ restartRuntime });
+    await strategy.apply(ctx);
+    expect(restartRuntime).toHaveBeenCalledWith("provider switch to anthropic");
+  });
+
+  it("describes config-reload intent", async () => {
+    const restartRuntime = vi.fn(async () => ({ id: "rt" }));
+    const ctx = makeCtx({ intent: { kind: "config-reload" } });
+    const strategy = createColdStrategy({ restartRuntime });
+    await strategy.apply(ctx);
+    expect(restartRuntime).toHaveBeenCalledWith("config reload");
+  });
+
+  it("describes plugin enable/disable intents", async () => {
+    const restartRuntime = vi.fn(async () => ({ id: "rt" }));
+    const strategy = createColdStrategy({ restartRuntime });
+    await strategy.apply(makeCtx({ intent: { kind: "plugin-enable", pluginId: "p1" } }));
+    expect(restartRuntime).toHaveBeenLastCalledWith("plugin enable: p1");
+    await strategy.apply(makeCtx({ intent: { kind: "plugin-disable", pluginId: "p2" } }));
+    expect(restartRuntime).toHaveBeenLastCalledWith("plugin disable: p2");
+  });
+
+  it("propagates restartRuntime rejection", async () => {
+    const restartRuntime = vi.fn(async () => {
+      throw new Error("boot failed");
+    });
+    const ctx = makeCtx();
+    const strategy = createColdStrategy({ restartRuntime });
+    await expect(strategy.apply(ctx)).rejects.toThrow("boot failed");
+  });
+
+  it("has the cold tier", () => {
+    const strategy = createColdStrategy({ restartRuntime: vi.fn() });
+    expect(strategy.tier).toBe("cold");
+  });
+});


### PR DESCRIPTION
## Summary

Unit coverage for `createColdStrategy` (`packages/agent/src/runtime/operations/cold-strategy.ts`).

## Coverage (7 cases)

- Succeeded phase + returned runtime
- Failed phase + throw on null runtime
- Intent description: provider-switch, config-reload, plugin enable/disable
- restartRuntime rejection propagation
- `tier === "cold"`

## Evidence

All 7 cases pass in isolation (vitest). No production code changed.

## Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash