### PR TITLE
fix(cloud): retry structured staging warming

### DIFF
--- a/packages/cloud/scripts/admin/live-cloud-provision-smoke.test.ts
+++ b/packages/cloud/scripts/admin/live-cloud-provision-smoke.test.ts
@@ -32,7 +32,12 @@ interface RequestRecord {
 
 interface HarnessOptions {
   asyncDelete?: boolean;
-  bridgeReply?: "valid" | "invalid" | "warming-once";
+  bridgeReply?:
+    | "valid"
+    | "invalid"
+    | "warming-once"
+    | "warming-always"
+    | "foreign-retryable-503";
   bridgeDelayMs?: number;
   cleanupDelete?: "success" | "fail" | "retain";
   create?:
@@ -47,7 +52,8 @@ interface HarnessOptions {
     | "throw-without-commit";
   existingPreflight?: JsonObject[];
   pairing?: "negative" | "positive";
-  sseReply?: "valid" | "invalid";
+  retryAfter?: string;
+  sseReply?: "valid" | "invalid" | "warming-once";
 }
 
 function requestBody(init: RequestInit | undefined): JsonObject | null {
@@ -84,6 +90,8 @@ function makeHarness(options: HarnessOptions = {}) {
   let clock = 1_000;
   let agentExists = false;
   let bridgeAttempts = 0;
+  let sseAttempts = 0;
+  const sleeps: number[] = [];
   const agentTier =
     options.create === "wrong-tier" ? "dedicated-lazy" : "shared";
   const createdAgentName =
@@ -186,14 +194,32 @@ function makeHarness(options: HarnessOptions = {}) {
     ) {
       bridgeAttempts += 1;
       clock += options.bridgeDelayMs ?? 0;
-      if (options.bridgeReply === "warming-once" && bridgeAttempts === 1) {
+      if (
+        options.bridgeReply === "warming-always" ||
+        (options.bridgeReply === "warming-once" && bridgeAttempts === 1)
+      ) {
         return Response.json(
           {
             success: false,
             error: "Shared runtime cache is warming. Retry shortly.",
+            code: "shared_runtime_cache_warming",
             retryable: true,
           },
-          { status: 503 },
+          {
+            status: 503,
+            headers: { "Retry-After": options.retryAfter ?? "1" },
+          },
+        );
+      }
+      if (options.bridgeReply === "foreign-retryable-503") {
+        return Response.json(
+          {
+            success: false,
+            error: "Inference is unavailable.",
+            code: "inference_unavailable",
+            retryable: true,
+          },
+          { status: 503, headers: { "Retry-After": "1" } },
         );
       }
       const token = tokenFromBody(body, "shared-bridge-");
@@ -214,6 +240,21 @@ function makeHarness(options: HarnessOptions = {}) {
       parsedUrl.pathname === `/api/v1/eliza/agents/${AGENT_ID}/stream` &&
       method === "POST"
     ) {
+      sseAttempts += 1;
+      if (options.sseReply === "warming-once" && sseAttempts === 1) {
+        return Response.json(
+          {
+            success: false,
+            error: "Agent authorization cache is warming. Retry shortly.",
+            code: "agent_cache_warming",
+            retryable: true,
+          },
+          {
+            status: 503,
+            headers: { "Retry-After": options.retryAfter ?? "1" },
+          },
+        );
+      }
       const token = tokenFromBody(body, "shared-sse-");
       const text =
         options.sseReply === "invalid"
@@ -307,18 +348,20 @@ function makeHarness(options: HarnessOptions = {}) {
 
   return {
     requests,
+    sleeps,
     options: {
       apiKey: "test-staging-key",
       baseUrl: BASE_URL,
       fetch: fetchImpl as typeof fetch,
       now: () => clock,
       sleep: async (ms: number) => {
+        sleeps.push(ms);
         clock += Math.max(1, ms);
       },
       suffix: SUFFIX,
       cleanupTimeoutMs: 5,
-      totalTimeoutMs: 100,
-      cleanupReserveMs: 20,
+      totalTimeoutMs: 100_000,
+      cleanupReserveMs: 20_000,
       createRecoveryTimeoutMs: 5,
       pollIntervalMs: 1,
     },
@@ -564,15 +607,87 @@ describe("shared staging onboarding smoke", () => {
     ).toBe(true);
   });
 
-  test("retries one cache-warming bridge response within the request budget", async () => {
-    const harness = makeHarness({ bridgeReply: "warming-once" });
+  test("retries only a structured bridge warming response and honors Retry-After", async () => {
+    const harness = makeHarness({
+      bridgeReply: "warming-once",
+      retryAfter: "7",
+    });
     const evidence = await runSharedStagingOnboardingSmoke(harness.options);
 
     expect(evidence.verdict).toBe("pass");
     expect(evidence.capacity.chatRequests).toBe(3);
+    expect(harness.sleeps).toContain(7_000);
     expect(evidence.capacity.chatRequests).toBeLessThanOrEqual(
       evidence.capacity.maxChatRequests,
     );
+    expect(
+      harness.requests.filter(
+        (request) =>
+          request.method === "POST" &&
+          new URL(request.url).pathname.endsWith("/pairing-token"),
+      ),
+    ).toHaveLength(1);
+    expect(
+      harness.requests.filter((request) => request.method === "DELETE"),
+    ).toHaveLength(1);
+    expect(evidence.path.pairingUnavailable).toBe(true);
+    expect(evidence.cleanup).toEqual({
+      status: "passed",
+      possibleOrphan: false,
+    });
+  });
+
+  test("retries structured SSE warming without consuming the bridge budget", async () => {
+    const harness = makeHarness({ sseReply: "warming-once", retryAfter: "3" });
+    const evidence = await runSharedStagingOnboardingSmoke(harness.options);
+
+    expect(evidence.verdict).toBe("pass");
+    expect(evidence.capacity.chatRequests).toBe(3);
+    expect(harness.sleeps).toContain(3_000);
+    expect(evidence.path.successfulPaths).toBe(2);
+    expect(evidence.path.pairingUnavailable).toBe(true);
+    expect(evidence.cleanup).toEqual({
+      status: "passed",
+      possibleOrphan: false,
+    });
+  });
+
+  test("does not retry a non-warming retryable 503", async () => {
+    const harness = makeHarness({ bridgeReply: "foreign-retryable-503" });
+    const evidence = await runSharedStagingOnboardingSmoke(harness.options);
+
+    expect(evidence.failure).toEqual({
+      phase: "bridge",
+      code: "unexpected_http_503",
+    });
+    expect(evidence.capacity.chatRequests).toBe(1);
+    expect(harness.sleeps).not.toContain(1_000);
+    expect(evidence.path.pairingUnavailable).toBe(false);
+    expect(evidence.cleanup).toEqual({
+      status: "passed",
+      possibleOrphan: false,
+    });
+  });
+
+  test("bounds repeated structured warming and still performs exact cleanup", async () => {
+    const harness = makeHarness({
+      bridgeReply: "warming-always",
+      retryAfter: "0",
+    });
+    const evidence = await runSharedStagingOnboardingSmoke(harness.options);
+
+    expect(evidence.failure).toEqual({
+      phase: "bridge",
+      code: "unexpected_http_503",
+    });
+    expect(evidence.capacity.chatRequests).toBe(
+      evidence.capacity.maxChatRequests / 2,
+    );
+    expect(evidence.path.pairingUnavailable).toBe(false);
+    expect(evidence.cleanup).toEqual({
+      status: "passed",
+      possibleOrphan: false,
+    });
   });
 
   test("reserves cleanup capacity when the operation deadline is exhausted", async () => {

--- a/packages/cloud/scripts/admin/live-cloud-provision-smoke.ts
+++ b/packages/cloud/scripts/admin/live-cloud-provision-smoke.ts
@@ -44,8 +44,18 @@ const CLEANUP_RESERVE_MS = 3 * 60_000;
 const CREATE_RECOVERY_TIMEOUT_MS = 15_000;
 const POLL_INTERVAL_MS = 2_000;
 const MAX_CREATE_RECOVERY_ATTEMPTS = 4;
-const MAX_CHAT_ATTEMPTS_PER_PATH = 2;
+const MAX_CHAT_ATTEMPTS_PER_PATH = 15;
 const TERMINAL_JOB_STATUSES = new Set(["failed", "cancelled", "canceled"]);
+const SHARED_RUNTIME_WARMING_CODES = new Set([
+  "agent_cache_warming",
+  "shared_runtime_cache_warming",
+]);
+
+interface JsonResponse {
+  status: number;
+  body: JsonObject;
+  retryAfterMs: number | null;
+}
 
 interface AgentIdentity {
   id: string;
@@ -128,6 +138,22 @@ function stringField(value: JsonObject | null, key: string): string | null {
 
 function dataRecord(body: JsonObject): JsonObject | null {
   return isRecord(body.data) ? body.data : null;
+}
+
+function parseRetryAfterMs(value: string | null): number | null {
+  if (value === null || value.trim() === "") return null;
+  const seconds = Number(value);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds * 1_000 : null;
+}
+
+function isSharedRuntimeWarming(response: JsonResponse): boolean {
+  const code = response.body.code;
+  return (
+    response.status === 503 &&
+    response.body.retryable === true &&
+    typeof code === "string" &&
+    SHARED_RUNTIME_WARMING_CODES.has(code)
+  );
 }
 
 function asExecutionTier(value: string | null): AgentExecutionTier | null {
@@ -357,7 +383,7 @@ export async function runSharedStagingOnboardingSmoke(
     expectedStatuses: readonly number[] = [200],
     timeoutMs = requestTimeoutMs,
     deadline = operationDeadline,
-  ): Promise<{ status: number; body: JsonObject }> {
+  ): Promise<JsonResponse> {
     const headers = new Headers(init.headers);
     headers.set("authorization", `Bearer ${apiKey}`);
     headers.set("accept", "application/json");
@@ -407,10 +433,17 @@ export async function runSharedStagingOnboardingSmoke(
         `invalid_response_shape_http_${response.status}`,
       );
     }
-    return { status: response.status, body: parsed };
+    return {
+      status: response.status,
+      body: parsed,
+      retryAfterMs: parseRetryAfterMs(response.headers.get("Retry-After")),
+    };
   }
 
-  async function requestStream(path: string, body: string): Promise<Response> {
+  async function requestStream(
+    path: string,
+    body: string,
+  ): Promise<Response | JsonResponse> {
     let response: Response;
     try {
       response = await fetchImpl(`${baseUrl}${path}`, {
@@ -437,7 +470,27 @@ export async function runSharedStagingOnboardingSmoke(
       throw new SharedSmokeFailure("sse", "redirect_refused");
     }
     if (response.status !== 200) {
-      throw new SharedSmokeFailure("sse", `unexpected_http_${response.status}`);
+      let parsed: unknown;
+      try {
+        const text = await response.text();
+        parsed = text ? JSON.parse(text) : {};
+      } catch {
+        throw new SharedSmokeFailure(
+          "sse",
+          `invalid_json_response_http_${response.status}`,
+        );
+      }
+      if (!isRecord(parsed)) {
+        throw new SharedSmokeFailure(
+          "sse",
+          `invalid_response_shape_http_${response.status}`,
+        );
+      }
+      return {
+        status: response.status,
+        body: parsed,
+        retryAfterMs: parseRetryAfterMs(response.headers.get("Retry-After")),
+      };
     }
     if (!response.body) throw new SharedSmokeFailure("sse", "missing_body");
     return response;
@@ -491,11 +544,11 @@ export async function runSharedStagingOnboardingSmoke(
     phase: string,
     method: string,
     params: JsonObject = {},
-  ): Promise<JsonObject> {
+  ): Promise<JsonResponse> {
     if (!identity) {
       throw new SharedSmokeFailure(phase, "agent_not_initialized");
     }
-    const { body } = await request(
+    return request(
       phase,
       `/api/v1/eliza/agents/${encodeURIComponent(identity.id)}/bridge`,
       {
@@ -507,7 +560,15 @@ export async function runSharedStagingOnboardingSmoke(
           params,
         }),
       },
+      [200, 503],
     );
+  }
+
+  function rpcResult(response: JsonResponse, phase: string): JsonObject {
+    if (response.status !== 200) {
+      throw new SharedSmokeFailure(phase, `unexpected_http_${response.status}`);
+    }
+    const { body } = response;
     if (body.error !== undefined) {
       throw new SharedSmokeFailure(phase, "rpc_error");
     }
@@ -523,13 +584,30 @@ export async function runSharedStagingOnboardingSmoke(
     for (let attempt = 0; attempt < MAX_CHAT_ATTEMPTS_PER_PATH; attempt += 1) {
       evidence.capacity.chatRequests += 1;
       try {
-        const result = await jsonRpc("bridge", "message.send", {
+        const response = await jsonRpc("bridge", "message.send", {
           text: `Include the token ${token} in one short sentence.`,
           roomId: `shared-smoke-bridge-${suffix}`,
           userId: `shared-smoke-user-${suffix}`,
           mode: "simple",
         });
-        const verdict = classifyBridgeReply(result, token);
+        if (isSharedRuntimeWarming(response)) {
+          lastFailure = new SharedSmokeFailure(
+            "bridge",
+            `unexpected_http_${response.status}`,
+          );
+          if (attempt + 1 < MAX_CHAT_ATTEMPTS_PER_PATH) {
+            await sleepWithin(
+              "bridge",
+              response.retryAfterMs ?? pollIntervalMs,
+            );
+            continue;
+          }
+          break;
+        }
+        const verdict = classifyBridgeReply(
+          rpcResult(response, "bridge"),
+          token,
+        );
         if (verdict.ok && verdict.transport === "shared-runtime") {
           evidence.path.bridgeTransport = "shared-runtime";
           evidence.path.bridgeReply = true;
@@ -540,14 +618,12 @@ export async function runSharedStagingOnboardingSmoke(
       } catch (error) {
         lastFailure = asFailure(error);
       }
-      if (attempt + 1 < MAX_CHAT_ATTEMPTS_PER_PATH) {
-        await sleepWithin("bridge", pollIntervalMs);
-      }
+      break;
     }
     throw lastFailure;
   }
 
-  async function streamTurn(token: string): Promise<void> {
+  async function streamTurn(token: string): Promise<JsonResponse | null> {
     if (!identity) {
       throw new SharedSmokeFailure("sse", "agent_not_initialized");
     }
@@ -564,6 +640,10 @@ export async function runSharedStagingOnboardingSmoke(
         },
       }),
     );
+    if (!(response instanceof Response)) {
+      if (isSharedRuntimeWarming(response)) return response;
+      throw new SharedSmokeFailure("sse", `unexpected_http_${response.status}`);
+    }
     const stream = response.body;
     if (!stream) throw new SharedSmokeFailure("sse", "missing_body");
     const reader = stream.getReader();
@@ -602,21 +682,27 @@ export async function runSharedStagingOnboardingSmoke(
     if (!verdict.ok) {
       throw new SharedSmokeFailure("sse", "invalid_shared_reply");
     }
+    return null;
   }
 
   async function proveSse(): Promise<void> {
     const token = `shared-sse-${suffix}`;
     for (let attempt = 0; attempt < MAX_CHAT_ATTEMPTS_PER_PATH; attempt += 1) {
       evidence.capacity.chatRequests += 1;
-      try {
-        await streamTurn(token);
-        evidence.path.sseCompleted = true;
-        evidence.path.successfulPaths += 1;
-        return;
-      } catch (error) {
-        if (attempt + 1 >= MAX_CHAT_ATTEMPTS_PER_PATH) throw error;
-        await sleepWithin("sse", pollIntervalMs);
+      const warming = await streamTurn(token);
+      if (warming) {
+        if (attempt + 1 < MAX_CHAT_ATTEMPTS_PER_PATH) {
+          await sleepWithin("sse", warming.retryAfterMs ?? pollIntervalMs);
+          continue;
+        }
+        throw new SharedSmokeFailure(
+          "sse",
+          `unexpected_http_${warming.status}`,
+        );
       }
+      evidence.path.sseCompleted = true;
+      evidence.path.successfulPaths += 1;
+      return;
     }
   }
 


### PR DESCRIPTION
# Relates to

Fixes #22822.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [ ] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was available or used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@84f58095b90b425d81bbaf6ff93914797045a332`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Medium. This changes only the staging-only manual onboarding smoke retry policy, not product request handling. A classifier mistake could either absorb a real failure or end the protected smoke before a cold shared runtime converges. The policy therefore matches only the two stable machine codes on `503` with `retryable: true`, preserves `Retry-After`, caps each chat path at 15 attempts, and retains the total-operation and cleanup deadlines.

# Background

## What does this PR do?

The live smoke previously converted every non-200 response into `unexpected_http_<status>` before its caller could inspect the structured warming envelope. It then retried arbitrary bridge and SSE failures only once. A fresh shared runtime can cross several named hydration barriers, so authoritative staging run 32353776774 stopped at the first bridge `503` even though credential isolation, one-agent creation, and exact cleanup passed.

This change preserves status, body `code`, `retryable`, and `Retry-After`; retries only `agent_cache_warming` and `shared_runtime_cache_warming`; honors the advertised delay; bounds bridge and SSE independently; and fails foreign retryable 503s immediately. Tests pin success, budget exhaustion, non-warming refusal, negative pairing, and exact cleanup.

## What kind of change is this?

Bug fix (non-breaking change to a staging-only manual verification harness).

# Documentation changes needed?

No project documentation change is required. The maintained source header and focused contract tests describe the retry boundary.

# Testing

## Where should a reviewer start?

- `packages/cloud/scripts/admin/live-cloud-provision-smoke.ts`
- `packages/cloud/scripts/admin/live-cloud-provision-smoke.test.ts`

## Detailed testing steps

At exact head `c04aeed7be34ac19534f836c33023257b939d31c`:

1. `bun test packages/cloud/scripts/admin/live-cloud-provision-smoke.test.ts` — PASS: 23 tests, 0 failures, 105 assertions.
2. Strict direct TypeScript check of both changed files with the repository compiler — PASS.
3. Repository-pinned Biome on both changed files — PASS: 2 files checked, no fixes.
4. `git diff --check origin/develop...HEAD` — PASS.

# Evidence Gate

<!-- evidence-head:c04aeed7be34ac19534f836c33023257b939d31c -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - this is a non-visual staging CLI harness change.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - this is a non-visual staging CLI harness change.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - there is no rendered user interface.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: pending an authorized protected-staging Live Smoke rerun at this exact head; this PR does not dispatch protected workflows.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: N/A - no frontend code or browser path changes.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: pending the authorized protected-staging bridge and SSE run at this exact head.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: pending the exact-head `shared-staging-onboarding` evidence JSON proving both paths, negative pairing, and cleanup with `possibleOrphan=false`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

Pending: an authorized operator must rerun the protected staging Live Smoke at exact head `c04aeed7be34ac19534f836c33023257b939d31c`. No protected dispatch or provider call was performed while preparing this draft.

## Backend + frontend logs

Backend logs are pending the same authorized protected-staging run. Frontend logs are N/A because this change has no frontend surface.

## Screenshots (before / after) + video walkthrough

N/A - non-visual CLI harness change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changes.

## Known gaps / failures

- `bun install` was not run: the fresh worktree used the repository-pinned Bun 1.3.14 and existing shared dependencies; available disk was 10 GiB after concurrent worktree activity, so a new monorepo install was intentionally not started.
- Root `bun run verify` was not run for this draft. Focused exact-head tests, strict TypeScript, changed-file Biome, and diff check are green.
- Protected staging acceptance is intentionally pending. This PR did not access or mutate secrets, provider configuration, agents outside the deterministic harness, billing, or deployment state, and did not dispatch a protected workflow.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: N/A - no contribution skill was available or used
Attribution status: self-reported
— [codex-22822-warming-smoke]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"N/A - no contribution skill was available or used"} -->
