### PR TITLE
fix(coding-tools): enforce pseudo-path blocklist

### DIFF
--- a/plugins/plugin-coding-tools/AGENTS.md
+++ b/plugins/plugin-coding-tools/AGENTS.md
@@ -96,7 +96,7 @@ All settings are read via `runtime.getSetting(key)` or `process.env`. None are r
 | Env var | Default | Description |
 |---|---|---|
 | `CODING_TOOLS_WORKSPACE_ROOTS` | `process.cwd()` | Comma-separated absolute paths the tools may access. When set, paths outside these roots are rejected. |
-| `CODING_TOOLS_BLOCKED_PATHS` | (built-in list) | Comma-separated absolute paths — **replaces** the default blocklist. |
+| `CODING_TOOLS_BLOCKED_PATHS` | (built-in list) | Comma-separated absolute paths — **replaces** the configurable default blocklist; unconditional device and `/proc/<pid>/fd` exclusions remain enforced. |
 | `CODING_TOOLS_BLOCKED_PATHS_ADD` | — | Comma-separated paths to **add** to the default blocklist. |
 | `CODING_TOOLS_SHELL` | (auto-detected) | Override the shell binary used by SHELL action. Takes priority over `SHELL`. Useful on Android/AOSP where the default shell path may not be executable. |
 | `CODING_TOOLS_SHELL_TIMEOUT_MS` | `120000` | Optional canonical decimal integer from `100` through `600000` used as the default SHELL timeout (ms); invalid values fail before execution and per-call `timeout` takes precedence within the same range. |

--- a/plugins/plugin-coding-tools/CLAUDE.md
+++ b/plugins/plugin-coding-tools/CLAUDE.md
@@ -96,7 +96,7 @@ All settings are read via `runtime.getSetting(key)` or `process.env`. None are r
 | Env var | Default | Description |
 |---|---|---|
 | `CODING_TOOLS_WORKSPACE_ROOTS` | `process.cwd()` | Comma-separated absolute paths the tools may access. When set, paths outside these roots are rejected. |
-| `CODING_TOOLS_BLOCKED_PATHS` | (built-in list) | Comma-separated absolute paths — **replaces** the default blocklist. |
+| `CODING_TOOLS_BLOCKED_PATHS` | (built-in list) | Comma-separated absolute paths — **replaces** the configurable default blocklist; unconditional device and `/proc/<pid>/fd` exclusions remain enforced. |
 | `CODING_TOOLS_BLOCKED_PATHS_ADD` | — | Comma-separated paths to **add** to the default blocklist. |
 | `CODING_TOOLS_SHELL` | (auto-detected) | Override the shell binary used by SHELL action. Takes priority over `SHELL`. Useful on Android/AOSP where the default shell path may not be executable. |
 | `CODING_TOOLS_SHELL_TIMEOUT_MS` | `120000` | Optional canonical decimal integer from `100` through `600000` used as the default SHELL timeout (ms); invalid values fail before execution and per-call `timeout` takes precedence within the same range. |

--- a/plugins/plugin-coding-tools/README.md
+++ b/plugins/plugin-coding-tools/README.md
@@ -79,7 +79,11 @@ The following paths are blocked by default (plus platform-specific system direct
 - `~/pvt`, `~/Library`
 - `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.docker`, `~/.kube`, `~/.netrc`
 
-Override with `CODING_TOOLS_BLOCKED_PATHS` (replace) or `CODING_TOOLS_BLOCKED_PATHS_ADD` (extend).
+`/dev/{zero,random,urandom,stdin,stdout,stderr}` and Linux
+`/proc/<pid>/fd/*` are unconditional pseudo-path exclusions, including symlink
+aliases. `CODING_TOOLS_BLOCKED_PATHS` replaces the configurable default list;
+it does not disable those exclusions. Use `CODING_TOOLS_BLOCKED_PATHS_ADD` to
+extend the configurable list.
 
 ## Requirements
 

--- a/plugins/plugin-coding-tools/src/lib/path-utils.ts
+++ b/plugins/plugin-coding-tools/src/lib/path-utils.ts
@@ -49,6 +49,55 @@ export function isBlockedPath(p: string): boolean {
   return false;
 }
 
+/**
+ * Detect blocked pseudo-paths before realpath erases an intermediate symlink.
+ * This is a policy inspection, not a replacement for the separate descriptor-
+ * relative TOCTOU boundary tracked by #23210.
+ */
+export async function traversesBlockedPath(p: string): Promise<boolean> {
+  let candidate = path.resolve(p);
+  const seen = new Set<string>();
+
+  for (let hop = 0; hop < 40; hop += 1) {
+    if (isBlockedPath(candidate)) return true;
+    if (seen.has(candidate)) return false;
+    seen.add(candidate);
+
+    const parsed = path.parse(candidate);
+    const parts = candidate
+      .slice(parsed.root.length)
+      .split(path.sep)
+      .filter(Boolean);
+    let current = parsed.root;
+    let followedLink = false;
+
+    for (let index = 0; index < parts.length; index += 1) {
+      current = path.join(current, parts[index]);
+      if (isBlockedPath(current)) return true;
+      try {
+        const stat = await fs.lstat(current);
+        if (!stat.isSymbolicLink()) continue;
+        const target = await fs.readlink(current);
+        const expandedTarget = path.isAbsolute(target)
+          ? path.resolve(target)
+          : path.resolve(path.dirname(current), target);
+        if (isBlockedPath(expandedTarget)) return true;
+        candidate = path.join(expandedTarget, ...parts.slice(index + 1));
+        followedLink = true;
+        break;
+      } catch {
+        // error-policy:J3 Missing, cyclic, or unreadable tails retain the
+        // existing lexical policy result; the consuming operation remains
+        // authoritative for its filesystem error.
+        return false;
+      }
+    }
+
+    if (!followedLink) return false;
+  }
+  return false;
+}
+
 export function normalizeAbsolute(p: string): string {
   return path.resolve(p);
 }

--- a/plugins/plugin-coding-tools/src/services/sandbox-service.test.ts
+++ b/plugins/plugin-coding-tools/src/services/sandbox-service.test.ts
@@ -1,5 +1,14 @@
 /** Tests for the SandboxService path policy: blocklist defaults and allow-root enforcement. */
-import { mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs";
+import {
+  closeSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import * as path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
@@ -181,6 +190,114 @@ describe("SandboxService default blocklist", () => {
     expect(v.ok).toBe(false);
     if (!v.ok) expect(v.reason).toBe("not_absolute");
   });
+
+  const itPosix = process.platform === "win32" ? it.skip : it;
+
+  itPosix("rejects device files directly and through a symlink", async () => {
+    const rawRoot = mkdtempSync(path.join(tmpdir(), "eliza-sandbox-device-"));
+    try {
+      const root = realpathSync(rawRoot);
+      const alias = path.join(root, "random-device");
+      symlinkSync("/dev/urandom", alias, "file");
+      const svc = await SandboxService.start(
+        mockRuntime({ CODING_TOOLS_BLOCKED_PATHS: path.join(root, "unused") }),
+      );
+
+      const stdinAlias = path.join(root, "stdin-device");
+      symlinkSync("/dev/stdin", stdinAlias, "file");
+      const chainedAlias = path.join(root, "chained-stdin-device");
+      symlinkSync(stdinAlias, chainedAlias, "file");
+
+      for (const candidate of [
+        "/dev/urandom",
+        alias,
+        "/dev/stdin",
+        stdinAlias,
+        chainedAlias,
+      ]) {
+        const result = await svc.validatePath(undefined, candidate);
+        expect(result.ok, candidate).toBe(false);
+        if (!result.ok) expect(result.reason).toBe("blocked");
+      }
+    } finally {
+      rmSync(rawRoot, { recursive: true, force: true });
+    }
+  });
+
+  itPosix("does not throw while canonicalizing a cyclic symlink", async () => {
+    const rawRoot = mkdtempSync(path.join(tmpdir(), "eliza-sandbox-loop-"));
+    try {
+      const root = realpathSync(rawRoot);
+      const loop = path.join(root, "loop");
+      symlinkSync("loop", loop, "file");
+      const svc = await SandboxService.start(
+        mockRuntime({ CODING_TOOLS_BLOCKED_PATHS: path.join(root, "unused") }),
+      );
+
+      await expect(svc.validatePath(undefined, loop)).resolves.toEqual({
+        ok: true,
+        resolved: loop,
+      });
+    } finally {
+      rmSync(rawRoot, { recursive: true, force: true });
+    }
+  });
+
+  const itLinux = process.platform === "linux" ? it : it.skip;
+
+  itLinux(
+    "rejects process file descriptors directly and through a directory symlink",
+    async () => {
+      const rawRoot = mkdtempSync(
+        path.join(tmpdir(), "eliza-sandbox-proc-fd-"),
+      );
+      try {
+        const root = realpathSync(rawRoot);
+        const fdDirectory = `/proc/${process.pid}/fd`;
+        const alias = path.join(root, "process-fds");
+        symlinkSync(fdDirectory, alias, "dir");
+        const entryAlias = path.join(root, "stdin-fd");
+        symlinkSync(path.join(fdDirectory, "0"), entryAlias, "file");
+        const directoryTarget = path.join(root, "directory-target");
+        mkdirSync(directoryTarget);
+        writeFileSync(
+          path.join(directoryTarget, "child.txt"),
+          "blocked through fd identity",
+        );
+        const directoryFd = openSync(directoryTarget, "r");
+        const directoryEntryAlias = path.join(root, "directory-fd");
+        symlinkSync(
+          path.join(fdDirectory, String(directoryFd)),
+          directoryEntryAlias,
+          "dir",
+        );
+        const svc = await SandboxService.start(
+          mockRuntime({
+            CODING_TOOLS_BLOCKED_PATHS: path.join(root, "unused"),
+          }),
+        );
+
+        try {
+          for (const candidate of [
+            path.join(fdDirectory, "0"),
+            `/proc/self/fd/0`,
+            path.join(alias, "0"),
+            entryAlias,
+            directoryEntryAlias,
+            path.join(directoryEntryAlias, "child.txt"),
+          ]) {
+            const result = await svc.validatePath(undefined, candidate);
+            expect(result.ok, candidate).toBe(false);
+            if (!result.ok) expect(result.reason).toBe("blocked");
+          }
+        } finally {
+          closeSync(directoryFd);
+        }
+      } finally {
+        rmSync(rawRoot, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("limits access to configured CODING_TOOLS_WORKSPACE_ROOTS", async () => {
     const root = path.join(homedir(), "coding-tools-root");

--- a/plugins/plugin-coding-tools/src/services/sandbox-service.ts
+++ b/plugins/plugin-coding-tools/src/services/sandbox-service.ts
@@ -15,9 +15,11 @@ import {
 import { readAliasedEnv } from "@elizaos/shared";
 import {
   isAbsolutePath,
+  isBlockedPath,
   isUncPath,
   isWithin,
   resolveRealPath,
+  traversesBlockedPath,
 } from "../lib/path-utils.js";
 import { CODING_TOOLS_LOG_PREFIX, SANDBOX_SERVICE } from "../types.js";
 
@@ -173,6 +175,24 @@ export class SandboxService extends Service {
       };
     }
     const resolved = await resolveRealPath(absPath);
+    // A proc fd entry is itself a symlink, so resolving the full path erases
+    // its pseudo-filesystem identity. Canonicalize its parent separately to
+    // retain that identity while still catching directory aliases into /proc.
+    const resolvedEntry = path.join(
+      await resolveRealPath(path.dirname(absPath)),
+      path.basename(absPath),
+    );
+    if (
+      isBlockedPath(resolved) ||
+      isBlockedPath(resolvedEntry) ||
+      (await traversesBlockedPath(absPath))
+    ) {
+      return {
+        ok: false,
+        reason: "blocked",
+        message: `Path ${absPath} resolves to a blocked device or process file descriptor.`,
+      };
+    }
     for (const blocked of this.blockedPaths) {
       if (isWithin(resolved, blocked) || resolved === blocked) {
         return {


### PR DESCRIPTION
# Relates to

Relates to #23212

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop@84f58095b90b425d81bbaf6ff93914797045a332` with zero conflicts.
- [x] Focused tests, package typecheck/lint/build, guide parity, and diff checks pass after sync; full root verification remains recorded below.
- [x] A reviewer can verify the real filesystem policy from the direct and symlink-backed adversarial tests; Linux `/proc` execution remains a hosted gate.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@432b9c221ae78c9f7588877cc1e15b537ddcc5ef:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the publication-time `origin/develop`; zero conflicts.
- [ ] `bun run verify` remains pending; exact owning gates are green and the limitation is documented below.

# Risks

Medium security-boundary change. FILE operations that currently reach special device or process-descriptor paths, including through symlink aliases, now fail closed. The separate pathname check-to-use race remains explicitly owned by #23210; this PR does not claim descriptor-relative confinement or shell sandboxing.

# Background

## What does this PR do?

- Makes the existing device and `/proc/<pid>/fd` pseudo-path policy reachable from `SandboxService.validatePath`.
- Preserves pseudo-path identity across symlink hops so aliases such as `alias -> /dev/stdin` cannot disappear into the final realpath target (`/dev/null`).
- Checks both the final canonical path and the parent-resolved entry identity needed for `/proc/<pid>/fd/N`.
- Adds real-filesystem direct, directory-alias, entry-alias, missing-tail, and cyclic-symlink regressions.
- Documents that these pseudo-path exclusions are unconditional even when `CODING_TOOLS_BLOCKED_PATHS` replaces the configurable default list.

## What kind of change is this?

Security-boundary bug fix.

# Documentation changes needed?

Yes. README and paired package guides now describe the actual override boundary.

# Testing

## Where should a reviewer start?

- `plugins/plugin-coding-tools/src/lib/path-utils.ts`
- `plugins/plugin-coding-tools/src/services/sandbox-service.ts`
- `plugins/plugin-coding-tools/src/services/sandbox-service.test.ts`

## Detailed testing steps

Exact head: `17b007deb308a4e8833886d11bd63f4d1f1d0e86`.

- `bun test src/services/sandbox-service.test.ts src/lib/path-utils.test.ts --timeout 20000` — PASS, 25 tests; one Linux-only `/proc` case skipped on macOS.
- `bun run typecheck` — PASS.
- `bun run lint:check` — PASS, 106 files.
- `bun run build` — PASS, Node bundle and declarations.
- `bun run check:agents-claude` — PASS, 156 guide pairs.
- `git diff --check origin/develop...HEAD` — PASS.
- Predecessor exact-source full package run — PASS, 619 tests and one Linux-only skip; final repair only strengthens the same policy helper/tests/docs.

# Evidence Gate

<!-- evidence-head:17b007deb308a4e8833886d11bd63f4d1f1d0e86 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or rendered flow changes.
<!-- evidence-row:backend-logs -->
- [x] Real filesystem boundary transcript:

  ```text
  direct /dev/stdin: blocked
  temp symlink -> /dev/stdin: blocked (previously resolved /dev/null and passed)
  direct and symlinked /dev/urandom: blocked; cyclic alias remains a non-throwing filesystem error path
  ```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network surface changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action selection, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head test artifact:

  ```text
  path-utils + SandboxService: 25 passed, 1 Linux-only skipped, 0 failed
  device boundary: direct and symlink-backed /dev paths rejected
  stability: missing-leaf parent aliases and cyclic-symlink non-throw behavior preserved
  ```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text.

# Evidence Details

## Real LLM-call trajectory

N/A - no model behavior changes.

## Backend + frontend logs

The real-filesystem policy transcript is inline above. No frontend surface applies.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no voice surface changes.

## Known gaps / failures

- The `/proc/<pid>/fd` direct/directory-alias/entry-alias regression is Linux-only and skipped on this macOS host; keep draft until hosted Linux runs it.
- Root `bun run verify` is not complete at this head.
- This closes only the previously dead pseudo-path guard. Descriptor-relative ancestor-swap confinement remains #23210, and SHELL policy remains #23211.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@432b9c221ae78c9f7588877cc1e15b537ddcc5ef:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-23212]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@432b9c221ae78c9f7588877cc1e15b537ddcc5ef:packages/skills/skills/contribute-to-eliza"} -->
