### PR TITLE
fix(agent): preserve remote runner request timeout

### DIFF
--- a/packages/agent/src/services/e2b-capability-router.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.test.ts
@@ -980,6 +980,34 @@ describe("E2BRemoteCapabilityRouterService", () => {
     }
   });
 
+  it("uses the configured request timeout when command options provide no timeout", async () => {
+    const originalFetch = globalThis.fetch;
+    replaceGlobalFetch(healthThenProcessFetch(hungFetch));
+    const service = new E2BRemoteCapabilityRouterService(
+      makeRuntime(),
+      makeConfig({
+        provider: "home",
+        remoteHttpBaseUrl: "https://remote-runner.test",
+        remoteHttpToken: "token",
+        timeoutMs: 5_000,
+        requestTimeoutMs: 50,
+      }),
+    );
+    const sandbox = await (
+      service as unknown as { getSandbox(): Promise<E2BSandboxClient> }
+    ).getSandbox();
+    const started = Date.now();
+    try {
+      await expect(sandbox.commands.run("sleep 30")).rejects.toMatchObject({
+        name: "TimeoutError",
+        message: expect.stringMatching(/timed out.*50ms/i),
+      });
+      expect(Date.now() - started).toBeLessThan(1_000);
+    } finally {
+      replaceGlobalFetch(originalFetch);
+    }
+  });
+
   it("returns timedOut from pty.runCommand when process headers arrive then the body stalls", async () => {
     const originalFetch = globalThis.fetch;
     replaceGlobalFetch(

--- a/packages/agent/src/services/e2b-capability-router.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.test.ts
@@ -949,6 +949,37 @@ describe("E2BRemoteCapabilityRouterService", () => {
     }
   });
 
+  it("uses an explicit command timeout instead of the configured runner default", async () => {
+    const originalFetch = globalThis.fetch;
+    replaceGlobalFetch(healthThenProcessFetch(hungFetch));
+    const service = new E2BRemoteCapabilityRouterService(
+      makeRuntime(),
+      makeConfig({
+        provider: "home",
+        remoteHttpBaseUrl: "https://remote-runner.test",
+        remoteHttpToken: "token",
+        timeoutMs: 5_000,
+        requestTimeoutMs: 5_000,
+      }),
+    );
+    const started = Date.now();
+    try {
+      await expect(
+        service.pty.runCommand({
+          command: "sleep",
+          args: ["30"],
+          timeoutMs: 50,
+        }),
+      ).resolves.toMatchObject({
+        timedOut: true,
+        exitCode: null,
+      });
+      expect(Date.now() - started).toBeLessThan(1_000);
+    } finally {
+      replaceGlobalFetch(originalFetch);
+    }
+  });
+
   it("returns timedOut from pty.runCommand when process headers arrive then the body stalls", async () => {
     const originalFetch = globalThis.fetch;
     replaceGlobalFetch(

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -182,7 +182,12 @@ class RemoteRunnerHttpFactory implements E2BSandboxFactory {
     } finally {
       timeout.dispose();
     }
-    return new RemoteRunnerHttpClient(config.provider, apiBase, headers);
+    return new RemoteRunnerHttpClient(
+      config.provider,
+      apiBase,
+      headers,
+      config.requestTimeoutMs,
+    );
   }
 }
 
@@ -209,6 +214,7 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
     readonly sandboxId: string,
     private readonly apiBase: string,
     private readonly headers: Record<string, string>,
+    private readonly requestTimeoutMs: number,
   ) {}
 
   async kill(): Promise<void> {}
@@ -219,7 +225,9 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
   ): Promise<SandboxEntryInfo[]> {
     const url = new URL(`${this.apiBase}/v1/fs/entries`);
     url.searchParams.set("path", path);
-    const timeout = timeoutSignal(opts?.requestTimeoutMs);
+    const timeout = timeoutSignal(
+      opts?.requestTimeoutMs ?? this.requestTimeoutMs,
+    );
     try {
       const response = await fetch(url, {
         headers: this.headers,
@@ -266,7 +274,9 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
     path: string,
     opts?: { format?: "text" | "bytes"; requestTimeoutMs?: number },
   ): Promise<string | Uint8Array> {
-    const timeout = timeoutSignal(opts?.requestTimeoutMs);
+    const timeout = timeoutSignal(
+      opts?.requestTimeoutMs ?? this.requestTimeoutMs,
+    );
     try {
       const url = new URL(`${this.apiBase}/v1/fs/file`);
       url.searchParams.set("path", path);
@@ -296,7 +306,9 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
   ): Promise<{ path: string; name: string }> {
     const url = new URL(`${this.apiBase}/v1/fs/file`);
     url.searchParams.set("path", path);
-    const timeout = timeoutSignal(opts?.requestTimeoutMs);
+    const timeout = timeoutSignal(
+      opts?.requestTimeoutMs ?? this.requestTimeoutMs,
+    );
     try {
       const response = await fetch(url, {
         method: "PUT",

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -330,7 +330,9 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
     cmd: string,
     opts: SandboxCommandRunOptions = {},
   ): Promise<SandboxCommandResult> {
-    const timeout = timeoutSignal(opts.timeoutMs ?? opts.requestTimeoutMs);
+    const timeout = timeoutSignal(
+      opts.timeoutMs ?? opts.requestTimeoutMs ?? this.requestTimeoutMs,
+    );
     try {
       const response = await fetch(`${this.apiBase}/v1/processes/run`, {
         method: "POST",


### PR DESCRIPTION
# Relates to

Closes #23289.

## Summary

Passes the configured request timeout into the remote-runner HTTP client and uses it as the final fallback when a direct command call supplies neither a command timeout nor a per-request timeout. Explicit command and request overrides retain precedence.

## Verification

Exact head: `698bb279d9c3f6757d894e853d910881bc13de24`

- Pinned Bun 1.3.14 / Node 24.15.0 focused suites: 35/35 pass.
- Configured-default hang and explicit-override hang both abort deterministically.
- Changed-file Biome and diff integrity pass.
- Agent package typecheck has only unrelated optional-workspace resolution errors; neither changed file has a diagnostic.

## Evidence Gate

<!-- evidence-head:698bb279d9c3f6757d894e853d910881bc13de24 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only capability routing.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only capability routing.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head focused Vitest transcript: 2 files, 35 tests passed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Hanging pre-header/body and timeout precedence regressions are the domain proof.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact.

## Contribution provenance

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@c890b8b95ccd07d58b86b72f9c98f4a4dee22e60:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-fast-small-pr-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@c890b8b95ccd07d58b86b72f9c98f4a4dee22e60:packages/skills/skills/contribute-to-eliza"} -->