### PR TITLE
fix(cloud): prove a durable backup before agent suspend stops compute

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -3896,7 +3896,7 @@ describe("replacement lifecycle teardown is absence-proof", () => {
     }
   });
 
-  test("suspend proceeds without capture for a no-snapshot-endpoint image", async () => {
+  test("a no-snapshot-endpoint image suspends only on a proven existing backup", async () => {
     const { SNAPSHOT_ENDPOINT_UNSUPPORTED } = await import("./eliza-sandbox.ts?actual");
     const rec = bridgedRunningRow();
     const provider = stoppableProvider();
@@ -3904,6 +3904,15 @@ describe("replacement lifecycle teardown is absence-proof", () => {
     const fetchSpy = spyOn(svc, "fetchSnapshotState").mockRejectedValue(
       new Error(SNAPSHOT_ENDPOINT_UNSUPPORTED),
     );
+    const latestSpy = spyOn(agentSandboxesRepository, "getLatestStoredBackup").mockResolvedValue({
+      id: "backup-proven",
+      sandbox_record_id: rec.id,
+      snapshot_type: "scheduled",
+      created_at: new Date(),
+      verification_status: "verified",
+      verified_at: new Date(),
+      verification_error: null,
+    } as StoredAgentSandboxBackup);
     const writes: SQL[] = [];
     upgradeTransactionImpl = async (fn) =>
       fn({
@@ -3917,7 +3926,7 @@ describe("replacement lifecycle teardown is absence-proof", () => {
       expect(result).toEqual({
         success: true,
         containerStopped: true,
-        backupId: undefined,
+        backupId: "backup-proven",
       });
       expect(provider.stopForReplacement).toHaveBeenCalledWith(rec.sandbox_id);
       const rendered = new PgDialect().sqlToQuery(writes[0]).sql;
@@ -3925,6 +3934,33 @@ describe("replacement lifecycle teardown is absence-proof", () => {
     } finally {
       upgradeTransactionImpl = null;
       fetchSpy.mockRestore();
+      latestSpy.mockRestore();
+      restore();
+    }
+  });
+
+  test("a no-snapshot-endpoint image with no durable backup refuses to suspend", async () => {
+    const { SNAPSHOT_ENDPOINT_UNSUPPORTED } = await import("./eliza-sandbox.ts?actual");
+    const rec = bridgedRunningRow();
+    const provider = stoppableProvider();
+    const { svc, restore } = await suspendSvc(rec, provider);
+    const fetchSpy = spyOn(svc, "fetchSnapshotState").mockRejectedValue(
+      new Error(SNAPSHOT_ENDPOINT_UNSUPPORTED),
+    );
+    const latestSpy = spyOn(agentSandboxesRepository, "getLatestStoredBackup").mockResolvedValue(
+      undefined,
+    );
+    try {
+      const result = await svc.executeSuspend(AGENT, ORG, SUSPEND_JOB);
+      expect(result).toEqual({
+        success: false,
+        containerStopped: false,
+        error: "Unable to create or find a durable backup before stopping; agent was left running.",
+      });
+      expect(provider.stopForReplacement).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+      latestSpy.mockRestore();
       restore();
     }
   });

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -3680,8 +3680,17 @@ describe("replacement lifecycle teardown is absence-proof", () => {
       ): Promise<{
         success: boolean;
         containerStopped: boolean;
+        backupId?: string;
         error?: string;
       }>;
+      getAgentForWrite(agentId: string, orgId: string): Promise<AgentSandbox | undefined>;
+      prepareSuspendBackupGate(
+        rec: AgentSandbox,
+      ): Promise<
+        | { outcome: "skip" }
+        | { outcome: "proceed"; backupId?: string; capturedFresh: boolean }
+        | { outcome: "refuse"; error: string }
+      >;
       lockLifecycle(tx: unknown, agentId: string, orgId: string): Promise<void>;
       getAgentForLifecycleMutation(
         tx: unknown,
@@ -3691,6 +3700,11 @@ describe("replacement lifecycle teardown is absence-proof", () => {
       hasActiveProvisionJobTx(tx: unknown, agentId: string, orgId: string): Promise<boolean>;
     };
     const svc = new ElizaSandboxService(provider) as unknown as SuspendSvc;
+    const getForWriteSpy = spyOn(svc, "getAgentForWrite").mockResolvedValue(rec);
+    const gateSpy = spyOn(svc, "prepareSuspendBackupGate").mockResolvedValue({
+      outcome: "proceed",
+      capturedFresh: false,
+    });
     const lockLifecycleSpy = spyOn(svc, "lockLifecycle").mockResolvedValue(undefined);
     const getForMutation = spyOn(svc, "getAgentForLifecycleMutation").mockResolvedValue(rec);
     const activeJob = spyOn(svc, "hasActiveProvisionJobTx").mockResolvedValue(false);
@@ -3743,9 +3757,290 @@ describe("replacement lifecycle teardown is absence-proof", () => {
       expect(writes).toHaveLength(0);
     } finally {
       upgradeTransactionImpl = null;
+      getForWriteSpy.mockRestore();
+      gateSpy.mockRestore();
       lockLifecycleSpy.mockRestore();
       getForMutation.mockRestore();
       activeJob.mockRestore();
+    }
+  });
+
+  // Pre-suspend backup gate (#20726 item 6): the provider stop drops the
+  // container, so suspend must prove a durable backup first, exactly like
+  // sleep and delete. These tests drive the real gate with a mocked bridge
+  // capture and repository fixtures.
+  type SuspendGateSvc = {
+    executeSuspend(
+      agentId: string,
+      orgId: string,
+      jobId: string,
+    ): Promise<{
+      success: boolean;
+      containerStopped: boolean;
+      backupId?: string;
+      error?: string;
+    }>;
+    prepareSuspendBackupGate(
+      rec: AgentSandbox,
+    ): Promise<
+      | { outcome: "skip" }
+      | { outcome: "proceed"; backupId?: string; capturedFresh: boolean }
+      | { outcome: "refuse"; error: string }
+    >;
+    getAgentForWrite(agentId: string, orgId: string): Promise<AgentSandbox | undefined>;
+    fetchSnapshotState(
+      rec: AgentSandbox,
+    ): Promise<{ stateData: unknown; sizeBytes: number; bridgeUrl: string }>;
+    lockLifecycle(tx: unknown, agentId: string, orgId: string): Promise<void>;
+    getAgentForLifecycleMutation(
+      tx: unknown,
+      agentId: string,
+      orgId: string,
+    ): Promise<AgentSandbox | undefined>;
+    hasActiveProvisionJobTx(tx: unknown, agentId: string, orgId: string): Promise<boolean>;
+  };
+
+  function bridgedRunningRow(): AgentSandbox {
+    return {
+      ...claimedPendingRow(),
+      bridge_url: "https://bridge.example",
+      health_url: "https://bridge.example/api",
+    };
+  }
+
+  async function suspendSvc(rec: AgentSandbox, provider: SandboxProvider) {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const svc = new ElizaSandboxService(provider) as unknown as SuspendGateSvc;
+    const spies = [
+      spyOn(svc, "getAgentForWrite").mockResolvedValue(rec),
+      spyOn(svc, "lockLifecycle").mockResolvedValue(undefined),
+      spyOn(svc, "getAgentForLifecycleMutation").mockResolvedValue(rec),
+      spyOn(svc, "hasActiveProvisionJobTx").mockResolvedValue(false),
+    ];
+    return { svc, restore: () => spies.forEach((s) => s.mockRestore()) };
+  }
+
+  function stoppableProvider(): SandboxProvider {
+    return {
+      create: mock(async () => {
+        throw new Error("must not create");
+      }),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement: mock(async () => {}),
+      checkHealth: mock(async () => true),
+    };
+  }
+
+  const SUSPEND_JOB = "00000000-0000-0000-0000-000000000099";
+
+  test("suspend captures and records a fresh pre-shutdown backup before stopping", async () => {
+    const rec = bridgedRunningRow();
+    const provider = stoppableProvider();
+    const { svc, restore } = await suspendSvc(rec, provider);
+    const fetchSpy = spyOn(svc, "fetchSnapshotState").mockResolvedValue({
+      stateData: { memories: [] },
+      sizeBytes: 42,
+      bridgeUrl: rec.bridge_url as string,
+    });
+    const createSpy = spyOn(agentSandboxesRepository, "createBackup").mockResolvedValue({
+      id: "backup-fresh",
+    } as AgentSandboxBackup);
+    const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(undefined);
+    const writes: SQL[] = [];
+    upgradeTransactionImpl = async (fn) =>
+      fn({
+        execute: async (query) => {
+          writes.push(query as SQL);
+          return { rows: [] };
+        },
+      });
+    try {
+      const result = await svc.executeSuspend(AGENT, ORG, SUSPEND_JOB);
+      expect(result).toEqual({ success: true, containerStopped: true, backupId: "backup-fresh" });
+      expect(provider.stopForReplacement).toHaveBeenCalledWith(rec.sandbox_id);
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ sandbox_record_id: rec.id, snapshot_type: "pre-shutdown" }),
+      );
+      expect(pruneSpy).toHaveBeenCalledWith(AGENT, 10);
+      expect(writes).toHaveLength(1);
+      const rendered = new PgDialect().sqlToQuery(writes[0]).sql;
+      expect(rendered).toContain("last_backup_at = NOW()");
+    } finally {
+      upgradeTransactionImpl = null;
+      fetchSpy.mockRestore();
+      createSpy.mockRestore();
+      pruneSpy.mockRestore();
+      restore();
+    }
+  });
+
+  test("suspend defers on a transient capture signal without touching compute", async () => {
+    const { SNAPSHOT_CAPTURE_TRANSIENT } = await import("./eliza-sandbox.ts?actual");
+    const rec = bridgedRunningRow();
+    const provider = stoppableProvider();
+    const { svc, restore } = await suspendSvc(rec, provider);
+    const fetchSpy = spyOn(svc, "fetchSnapshotState").mockRejectedValue(
+      new Error(SNAPSHOT_CAPTURE_TRANSIENT),
+    );
+    try {
+      const result = await svc.executeSuspend(AGENT, ORG, SUSPEND_JOB);
+      expect(result).toEqual({
+        success: false,
+        containerStopped: false,
+        error: `Refusing to stop without a current backup: ${SNAPSHOT_CAPTURE_TRANSIENT}`,
+      });
+      expect(provider.stopForReplacement).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+      restore();
+    }
+  });
+
+  test("suspend proceeds without capture for a no-snapshot-endpoint image", async () => {
+    const { SNAPSHOT_ENDPOINT_UNSUPPORTED } = await import("./eliza-sandbox.ts?actual");
+    const rec = bridgedRunningRow();
+    const provider = stoppableProvider();
+    const { svc, restore } = await suspendSvc(rec, provider);
+    const fetchSpy = spyOn(svc, "fetchSnapshotState").mockRejectedValue(
+      new Error(SNAPSHOT_ENDPOINT_UNSUPPORTED),
+    );
+    const writes: SQL[] = [];
+    upgradeTransactionImpl = async (fn) =>
+      fn({
+        execute: async (query) => {
+          writes.push(query as SQL);
+          return { rows: [] };
+        },
+      });
+    try {
+      const result = await svc.executeSuspend(AGENT, ORG, SUSPEND_JOB);
+      expect(result).toEqual({
+        success: true,
+        containerStopped: true,
+        backupId: undefined,
+      });
+      expect(provider.stopForReplacement).toHaveBeenCalledWith(rec.sandbox_id);
+      const rendered = new PgDialect().sqlToQuery(writes[0]).sql;
+      expect(rendered).not.toContain("last_backup_at");
+    } finally {
+      upgradeTransactionImpl = null;
+      fetchSpy.mockRestore();
+      restore();
+    }
+  });
+
+  test("capture failure falls back to a proven restorable existing backup", async () => {
+    const rec = bridgedRunningRow();
+    const provider = stoppableProvider();
+    const { svc, restore } = await suspendSvc(rec, provider);
+    const fetchSpy = spyOn(svc, "fetchSnapshotState").mockRejectedValue(
+      new Error("bridge reset mid-stream"),
+    );
+    const latestSpy = spyOn(agentSandboxesRepository, "getLatestStoredBackup").mockResolvedValue({
+      id: "backup-proven",
+      sandbox_record_id: rec.id,
+      snapshot_type: "scheduled",
+      created_at: new Date(),
+      verification_status: "verified",
+      verified_at: new Date(),
+      verification_error: null,
+    } as StoredAgentSandboxBackup);
+    const writes: SQL[] = [];
+    upgradeTransactionImpl = async (fn) =>
+      fn({
+        execute: async (query) => {
+          writes.push(query as SQL);
+          return { rows: [] };
+        },
+      });
+    try {
+      const result = await svc.executeSuspend(AGENT, ORG, SUSPEND_JOB);
+      expect(result).toEqual({
+        success: true,
+        containerStopped: true,
+        backupId: "backup-proven",
+      });
+      const rendered = new PgDialect().sqlToQuery(writes[0]).sql;
+      expect(rendered).not.toContain("last_backup_at");
+    } finally {
+      upgradeTransactionImpl = null;
+      fetchSpy.mockRestore();
+      latestSpy.mockRestore();
+      restore();
+    }
+  });
+
+  test("suspend refuses when no durable backup exists and none can be captured", async () => {
+    const rec = claimedPendingRow(); // running, no bridge to capture from
+    const provider = stoppableProvider();
+    const { svc, restore } = await suspendSvc(rec, provider);
+    const latestSpy = spyOn(agentSandboxesRepository, "getLatestStoredBackup").mockResolvedValue(
+      undefined,
+    );
+    try {
+      const result = await svc.executeSuspend(AGENT, ORG, SUSPEND_JOB);
+      expect(result).toEqual({
+        success: false,
+        containerStopped: false,
+        error: "Unable to create or find a durable backup before stopping; agent was left running.",
+      });
+      expect(provider.stopForReplacement).not.toHaveBeenCalled();
+    } finally {
+      latestSpy.mockRestore();
+      restore();
+    }
+  });
+
+  test("suspend refuses when the lifecycle moved between capture and lock", async () => {
+    const rec = bridgedRunningRow();
+    const provider = stoppableProvider();
+    const { svc, restore } = await suspendSvc(rec, provider);
+    const gateSpy = spyOn(svc, "prepareSuspendBackupGate").mockResolvedValue({
+      outcome: "proceed",
+      backupId: "backup-fresh",
+      capturedFresh: true,
+    });
+    const getForMutation = spyOn(svc, "getAgentForLifecycleMutation").mockResolvedValue({
+      ...rec,
+      lifecycle_revision: rec.lifecycle_revision + 1,
+    });
+    const writes: SQL[] = [];
+    upgradeTransactionImpl = async (fn) =>
+      fn({
+        execute: async (query) => {
+          writes.push(query as SQL);
+          return { rows: [] };
+        },
+      });
+    try {
+      const result = await svc.executeSuspend(AGENT, ORG, SUSPEND_JOB);
+      expect(result).toEqual({
+        success: false,
+        containerStopped: false,
+        error: "Agent lifecycle changed while the suspend backup was prepared",
+      });
+      expect(provider.stopForReplacement).not.toHaveBeenCalled();
+      expect(writes).toHaveLength(0);
+    } finally {
+      upgradeTransactionImpl = null;
+      gateSpy.mockRestore();
+      getForMutation.mockRestore();
+      restore();
+    }
+  });
+
+  test("suspend gate skips shared-tier and container-less rows", async () => {
+    const provider = stoppableProvider();
+    const { svc, restore } = await suspendSvc(claimedPendingRow(), provider);
+    try {
+      expect(
+        await svc.prepareSuspendBackupGate({ ...claimedPendingRow(), execution_tier: "shared" }),
+      ).toEqual({ outcome: "skip" });
+      expect(
+        await svc.prepareSuspendBackupGate({ ...claimedPendingRow(), sandbox_id: null }),
+      ).toEqual({ outcome: "skip" });
+    } finally {
+      restore();
     }
   });
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -8257,10 +8257,104 @@ export class ElizaSandboxService {
   }
 
   /**
-   * Daemon-side handler for the `agent_suspend` job. Calls the provider's
-   * absence-proof replacement stop, flips the DB row to `stopped`, and clears
-   * bridge/health URLs — but keeps `sandbox_id` and the per-tenant managed DB
-   * so a subsequent `agent_resume` re-provisions against the retained state.
+   * Backup gate run before `executeSuspend` stops a data-bearing container
+   * (#20726 item 6: every destructive lifecycle / billing freeze proves a
+   * restorable backup first). The provider stop drops the container from its
+   * node, so container-local state that never reached a durable backup would
+   * be lost silently. Mirrors the sleep/delete gates: a live capture when the
+   * bridge is reachable, the snapshot-unsupported image sentinel proceeding
+   * exactly as delete does, a transient capture signal deferring to the job
+   * retry loop, and otherwise a proven-restorable existing backup via the
+   * wake integrity gate. A refusal leaves the container running; a
+   * billing-request suspend surfaces through the stop-intent retry /
+   * terminal-attention machinery instead of destroying state.
+   */
+  private async prepareSuspendBackupGate(
+    rec: AgentSandbox,
+  ): Promise<
+    | { outcome: "skip" }
+    | { outcome: "proceed"; backupId?: string; capturedFresh: boolean }
+    | { outcome: "refuse"; error: string }
+  > {
+    if (
+      !rec.sandbox_id ||
+      rec.execution_tier === "shared" ||
+      (rec.organization_id === WARM_POOL_ORG_ID && rec.pool_status === "unclaimed")
+    ) {
+      return { outcome: "skip" };
+    }
+    if (rec.bridge_url) {
+      try {
+        const { stateData, sizeBytes } = await this.fetchSnapshotState(rec);
+        const backup = await agentSandboxesRepository.createBackup({
+          sandbox_record_id: rec.id,
+          snapshot_type: "pre-shutdown",
+          state_data: stateData,
+          size_bytes: sizeBytes,
+        });
+        return { outcome: "proceed", backupId: backup.id, capturedFresh: true };
+      } catch (error) {
+        // error-policy:J1 the suspend command boundary translates capture
+        // failures into an explicit disposition: the no-snapshot-endpoint
+        // image proceeds (delete's rule for the identical signal), a
+        // transient signal defers to the job retry loop, and anything else
+        // falls through to the proven-existing-backup gate below.
+        const message = error instanceof Error ? error.message : String(error);
+        if (message === SNAPSHOT_ENDPOINT_UNSUPPORTED) {
+          logger.warn(
+            "[agent-sandbox] Suspend proceeding without capture: image has no snapshot endpoint",
+            { agentId: rec.id },
+          );
+          return { outcome: "proceed", capturedFresh: false };
+        }
+        if (message === SNAPSHOT_CAPTURE_TRANSIENT) {
+          logger.warn("[agent-sandbox] Suspend deferred: capture transiently unavailable", {
+            agentId: rec.id,
+          });
+          return {
+            outcome: "refuse",
+            error: `Refusing to stop without a current backup: ${message}`,
+          };
+        }
+        logger.warn(
+          "[agent-sandbox] Suspend snapshot fetch failed; checking latest durable backup",
+          { agentId: rec.id, error: message },
+        );
+      }
+    }
+    const gate = await runWakeRestoreIntegrityGate({
+      sandboxRecordId: rec.id,
+      agentName: rec.agent_name,
+    });
+    if (!gate.ok) {
+      logger.error("[agent-sandbox] Suspend refused: no restorable backup proven", {
+        agentId: rec.id,
+        failure: gate.failure.kind,
+      });
+      return {
+        outcome: "refuse",
+        error: `Refusing to stop on an unproven backup; agent was left running. ${formatWakeRestoreIntegrityError(gate.failure)}`,
+      };
+    }
+    if (gate.backupId) {
+      return { outcome: "proceed", backupId: gate.backupId, capturedFresh: false };
+    }
+    if (gate.verification === "disabled") {
+      const existing = await agentSandboxesRepository.getLatestBackup(rec.id);
+      if (existing) return { outcome: "proceed", backupId: existing.id, capturedFresh: false };
+    }
+    return {
+      outcome: "refuse",
+      error: "Unable to create or find a durable backup before stopping; agent was left running.",
+    };
+  }
+
+  /**
+   * Daemon-side handler for the `agent_suspend` job. Proves a durable backup
+   * (see `prepareSuspendBackupGate`), calls the provider's absence-proof
+   * replacement stop, flips the DB row to `stopped`, and clears bridge/health
+   * URLs — but keeps `sandbox_id` and the per-tenant managed DB so a
+   * subsequent `agent_resume` re-provisions against the retained state.
    * Replaces the Worker-callable `shutdown()` path which cannot reach SSH.
    */
   async executeSuspend(
@@ -8268,8 +8362,31 @@ export class ElizaSandboxService {
     orgId: string,
     jobId: string,
     authorization: "user_request" | "billing_request",
-  ): Promise<{ success: boolean; containerStopped: boolean; error?: string }> {
-    return await dbWrite.transaction(async (tx) => {
+  ): Promise<{ success: boolean; containerStopped: boolean; backupId?: string; error?: string }> {
+    // The backup is captured without holding the lifecycle lock (an HTTP
+    // round-trip must not pin a write transaction); the lifecycle generation
+    // is revalidated under the lock before the stop.
+    const snapshotSource = await this.getAgentForWrite(agentId, orgId);
+    if (
+      !snapshotSource ||
+      snapshotSource.deletion_attempt_id ||
+      this.isAwaitingDeletion(snapshotSource.status)
+    ) {
+      return { success: false, containerStopped: false, error: "Agent not found" };
+    }
+    let suspendBackupId: string | undefined;
+    let backupCapturedFresh = false;
+    if (snapshotSource.status !== "stopped") {
+      const gateResult = await this.prepareSuspendBackupGate(snapshotSource);
+      if (gateResult.outcome === "refuse") {
+        return { success: false, containerStopped: false, error: gateResult.error };
+      }
+      if (gateResult.outcome === "proceed") {
+        suspendBackupId = gateResult.backupId;
+        backupCapturedFresh = gateResult.capturedFresh;
+      }
+    }
+    const result = await dbWrite.transaction(async (tx) => {
       await this.lockLifecycle(tx, agentId, orgId);
       const rec = await this.getAgentForLifecycleMutation(tx, agentId, orgId);
       if (!rec || rec.deletion_attempt_id || this.isAwaitingDeletion(rec.status))
@@ -8371,6 +8488,21 @@ export class ElizaSandboxService {
         }
       }
 
+      // The gate captured against snapshotSource's generation; a moved
+      // lifecycle means the backup may not cover the container being stopped.
+      if (
+        rec.lifecycle_revision !== snapshotSource.lifecycle_revision ||
+        rec.sandbox_id !== snapshotSource.sandbox_id ||
+        rec.bridge_url !== snapshotSource.bridge_url ||
+        rec.environment_revision !== snapshotSource.environment_revision
+      ) {
+        return {
+          success: false,
+          containerStopped: false,
+          error: "Agent lifecycle changed while the suspend backup was prepared",
+        } as const;
+      }
+
       let containerStopped = false;
       const attempt = (stopIntent?.attempts ?? 0) + 1;
       if (stopIntent) {
@@ -8416,6 +8548,7 @@ export class ElizaSandboxService {
         SET status = 'stopped', billing_status = 'suspended',
             scheduled_shutdown_at = NULL, shutdown_warning_sent_at = NULL,
             bridge_url = NULL, health_url = NULL, updated_at = NOW()
+            ${backupCapturedFresh ? sql`, last_backup_at = NOW()` : sql``}
         WHERE id = ${rec.id}
       `);
       if (stopIntent) {
@@ -8429,8 +8562,19 @@ export class ElizaSandboxService {
           })
           .where(eq(agentComputeStopIntents.id, stopIntent.id));
       }
-      return { success: true, containerStopped } as const;
+      return { success: true, containerStopped, backupId: suspendBackupId } as const;
     });
+    if (result.success && backupCapturedFresh) {
+      // error-policy:J6 pruning is retention housekeeping after the suspend
+      // committed; its failure is logged, never surfaced as a suspend failure.
+      await agentSandboxesRepository.pruneBackups(agentId, MAX_BACKUPS).catch((error) => {
+        logger.warn("[agent-sandbox] Backup pruning failed after suspend", {
+          agentId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }
+    return result;
   }
 
   /**

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -8261,11 +8261,14 @@ export class ElizaSandboxService {
    * (#20726 item 6: every destructive lifecycle / billing freeze proves a
    * restorable backup first). The provider stop drops the container from its
    * node, so container-local state that never reached a durable backup would
-   * be lost silently. Mirrors the sleep/delete gates: a live capture when the
-   * bridge is reachable, the snapshot-unsupported image sentinel proceeding
-   * exactly as delete does, a transient capture signal deferring to the job
-   * retry loop, and otherwise a proven-restorable existing backup via the
-   * wake integrity gate. A refusal leaves the container running; a
+   * be lost silently. Mirrors the sleep gate exactly: a live capture when the
+   * bridge is reachable, a transient capture signal deferring to the job
+   * retry loop, and any other capture failure — including an image with no
+   * snapshot endpoint — falling through to a proven-restorable existing
+   * backup via the wake integrity gate. Suspend keeps state for a later
+   * resume, so unlike delete there is no state-loss waiver: an uncapturable
+   * container with no durable backup refuses rather than discarding the only
+   * copy. A refusal leaves the container running; a
    * billing-request suspend surfaces through the stop-intent retry /
    * terminal-attention machinery instead of destroying state.
    */
@@ -8295,18 +8298,12 @@ export class ElizaSandboxService {
         return { outcome: "proceed", backupId: backup.id, capturedFresh: true };
       } catch (error) {
         // error-policy:J1 the suspend command boundary translates capture
-        // failures into an explicit disposition: the no-snapshot-endpoint
-        // image proceeds (delete's rule for the identical signal), a
-        // transient signal defers to the job retry loop, and anything else
-        // falls through to the proven-existing-backup gate below.
+        // failures into an explicit disposition: a transient signal defers to
+        // the job retry loop, and anything else — including an image with no
+        // snapshot endpoint — falls through to the proven-existing-backup
+        // gate below (retrying an unsupported capture can never succeed, and
+        // an unbacked-up container must not be dropped).
         const message = error instanceof Error ? error.message : String(error);
-        if (message === SNAPSHOT_ENDPOINT_UNSUPPORTED) {
-          logger.warn(
-            "[agent-sandbox] Suspend proceeding without capture: image has no snapshot endpoint",
-            { agentId: rec.id },
-          );
-          return { outcome: "proceed", capturedFresh: false };
-        }
         if (message === SNAPSHOT_CAPTURE_TRANSIENT) {
           logger.warn("[agent-sandbox] Suspend deferred: capture transiently unavailable", {
             agentId: rec.id,

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
@@ -423,10 +423,17 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
         authorization: "user_request" | "billing_request",
       ): Promise<{ success: boolean; containerStopped: boolean; error?: string }>;
       runBoundedSandboxStopForReplacement(sandboxId: string): Promise<{ error: unknown } | null>;
+      prepareSuspendBackupGate(
+        rec: unknown,
+      ): Promise<{ outcome: "proceed"; capturedFresh: boolean }>;
     };
     const service = elizaSandboxService as unknown as BillingSuspendService;
     const providerStop = spyOn(service, "runBoundedSandboxStopForReplacement").mockResolvedValue({
       error: new Error("provider unavailable"),
+    });
+    const gateSpy = spyOn(service, "prepareSuspendBackupGate").mockResolvedValue({
+      outcome: "proceed",
+      capturedFresh: false,
     });
     try {
       await expect(
@@ -479,6 +486,7 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
       expect(confirmed.status).toBe("provider_confirmed");
     } finally {
       providerStop.mockRestore();
+      gateSpy.mockRestore();
     }
   });
 
@@ -523,11 +531,18 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
         authorization: "user_request" | "billing_request",
       ): Promise<{ success: boolean; containerStopped: boolean; error?: string }>;
       runBoundedSandboxStopForReplacement(sandboxId: string): Promise<{ error: unknown } | null>;
+      prepareSuspendBackupGate(
+        rec: unknown,
+      ): Promise<{ outcome: "proceed"; capturedFresh: boolean }>;
     };
     const service = elizaSandboxService as unknown as ManualSuspendService;
     const providerStop = spyOn(service, "runBoundedSandboxStopForReplacement").mockResolvedValue(
       null,
     );
+    const gateSpy = spyOn(service, "prepareSuspendBackupGate").mockResolvedValue({
+      outcome: "proceed",
+      capturedFresh: false,
+    });
     try {
       await expect(
         service.executeSuspend(agentId, orgId, billing.job.id, "billing_request"),
@@ -554,6 +569,7 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
       expect(stopped).toMatchObject({ status: "stopped", billing_status: "suspended" });
     } finally {
       providerStop.mockRestore();
+      gateSpy.mockRestore();
     }
   });
 
@@ -668,11 +684,18 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
         authorization: "user_request" | "billing_request",
       ): Promise<{ success: boolean; containerStopped: boolean; error?: string }>;
       runBoundedSandboxStopForReplacement(sandboxId: string): Promise<{ error: unknown } | null>;
+      prepareSuspendBackupGate(
+        rec: unknown,
+      ): Promise<{ outcome: "proceed"; capturedFresh: boolean }>;
     };
     const service = elizaSandboxService as unknown as BillingSuspendService;
     const providerStop = spyOn(service, "runBoundedSandboxStopForReplacement").mockResolvedValue(
       null,
     );
+    const gateSpy = spyOn(service, "prepareSuspendBackupGate").mockResolvedValue({
+      outcome: "proceed",
+      capturedFresh: false,
+    });
     try {
       const outcome = await service.executeSuspend(agentId, orgId, legacyJob.id, "billing_request");
       expect(outcome).toMatchObject({ success: true, containerStopped: false });
@@ -693,6 +716,7 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
       ).toHaveLength(1);
     } finally {
       providerStop.mockRestore();
+      gateSpy.mockRestore();
     }
   });
 
@@ -735,11 +759,18 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
         authorization: "user_request" | "billing_request",
       ): Promise<{ success: boolean; containerStopped: boolean; error?: string }>;
       runBoundedSandboxStopForReplacement(sandboxId: string): Promise<{ error: unknown } | null>;
+      prepareSuspendBackupGate(
+        rec: unknown,
+      ): Promise<{ outcome: "proceed"; capturedFresh: boolean }>;
     };
     const service = elizaSandboxService as unknown as BillingSuspendService;
     const providerStop = spyOn(service, "runBoundedSandboxStopForReplacement").mockResolvedValue(
       null,
     );
+    const gateSpy = spyOn(service, "prepareSuspendBackupGate").mockResolvedValue({
+      outcome: "proceed",
+      capturedFresh: false,
+    });
     try {
       await expect(
         service.executeSuspend(agentId, orgId, enqueued.job.id, "billing_request"),
@@ -758,6 +789,7 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
       expect(org.credit_balance).toBe("0.000001");
     } finally {
       providerStop.mockRestore();
+      gateSpy.mockRestore();
     }
   });
 

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -310,6 +310,8 @@ export interface AgentDeleteJobResult {
 export interface AgentSuspendJobResult {
   cloudAgentId: string;
   containerStopped: boolean;
+  /** Backup proven or captured by the pre-suspend gate before the stop. */
+  backupId?: string;
   error?: string;
 }
 
@@ -4170,6 +4172,7 @@ export class ProvisioningJobService {
     const jobResult: AgentSuspendJobResult = {
       cloudAgentId: data.agentId,
       containerStopped: result.containerStopped,
+      backupId: result.backupId,
     };
 
     await this.settleClaimedExecution(job, "completed", {
@@ -4185,6 +4188,7 @@ export class ProvisioningJobService {
       jobId: job.id,
       agentId: data.agentId,
       containerStopped: result.containerStopped,
+      backupId: result.backupId,
     });
   }
 


### PR DESCRIPTION
Refs #20726 (Epic work item 6: backup-before-destructive lifecycle / billing freeze).

## Problem

`executeSuspend` — the daemon handler behind both a user-requested agent stop and the billing-freeze stop intent — called the provider's replacement stop with **no backup gate at all**. The provider stop drops the container from its node, so container-local state that never reached a durable backup was destroyed silently. The sibling destructive paths already fail closed (`executeSleep` proves a restorable backup via the wake integrity gate; `deleteAgent` has the pre-delete capture gate from #18517), leaving suspend as the only backup-less destructive lifecycle transition — exactly the epic's acceptance criterion "Every destructive lifecycle and billing freeze takes, uploads and verifies a final restorable backup first."

## Change

`packages/cloud/shared/src/lib/services/eliza-sandbox.ts`

- New `prepareSuspendBackupGate`, run before the suspend transaction (an HTTP capture must not pin the lifecycle lock):
  - live `POST /api/snapshot` capture into a `pre-shutdown` backup row when the bridge is reachable;
  - `SNAPSHOT_ENDPOINT_UNSUPPORTED` proceeds with a warning — the same rule delete applies to the identical signal;
  - `SNAPSHOT_CAPTURE_TRANSIENT` defers: the suspend fails without touching compute and the job/stop-intent retry machinery re-attempts;
  - any other capture failure, or a running row with no reachable bridge, requires a **proven restorable** existing backup through `runWakeRestoreIntegrityGate` (fresh verified stamp or live decrypt+verify; kill switch honored); otherwise the suspend refuses and the container is left running.
  - shared-tier, unclaimed warm-pool, and container-less rows skip the gate.
- The lifecycle generation (lifecycle revision, sandbox id, bridge URL, environment revision) is revalidated under the lifecycle lock before the stop, so a captured backup can never authorize stopping a moved lifecycle.
- A fresh capture stamps `last_backup_at` in the same committed UPDATE and prunes retention afterward (J6).
- The proven/captured backup id is returned and carried through `AgentSuspendJobResult` and the daemon's completion log (`provisioning-jobs.ts`).

A billing-freeze suspend that cannot prove a backup now surfaces through the existing stop-intent `retry` / `terminal_attention` escalation instead of destroying state — accrued-billing settlement semantics are unchanged.

## Tests

`eliza-sandbox.test.ts` — 7 new deterministic tests driving the real gate (mocked bridge capture + repository fixtures):
- fresh capture recorded before stop, `last_backup_at` stamped, retention pruned, backup id returned;
- transient capture defers without touching compute;
- no-snapshot-endpoint image proceeds without a stamp;
- capture failure falls back to a proven (fresh-verified-stamp) existing backup;
- no durable backup and no capture path → refusal, container left running;
- lifecycle drift between capture and lock → refusal, no write;
- shared-tier / container-less rows skip the gate.

`provisioning-jobs-scheduled-backup-sentinel.test.ts` — the four PGlite-backed billing stop-intent tests now pin the gate open so they keep testing intent authority in isolation.

## Evidence

- `bun test src/lib/services/eliza-sandbox.test.ts` — 232 pass / 0 fail.
- `bun test src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts` — 42 pass / 0 fail.
- `provisioning-jobs-execute-dispatch` / `provisioning-jobs-delete-lifecycle` / `wake-restore-integrity`: same 4 pre-existing environmental failures with and without this change (verified by an A/B run against unmodified `origin/develop` sources in the same environment).
- `tsc --noEmit` clean for the changed files (remaining output is the documented transitive-import noise); Biome clean.

## Human-only remainder

Fleet/staging evidence for the epic (restore drills, RPO/RTO measurement, staging walkthrough artifacts A–E) requires operator-authorized environments and stays with the epic's NO-GO gating; nothing here activates any dormant manifest-v3 machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
