### PR TITLE
fix(plugin-zai): reject invalid provider options before dispatch

### DIFF
--- a/plugins/plugin-zai/__tests__/text-params.test.ts
+++ b/plugins/plugin-zai/__tests__/text-params.test.ts
@@ -227,4 +227,64 @@ describe("z.ai text parameter resolution", () => {
       })
     );
   });
+
+  it("handles valid providerOptions and rejects cyclic providerOptions with ZAI_PROVIDER_OPTIONS_UNBOUNDED", async () => {
+    const runtime = {
+      character: {},
+      getSetting(key: string) {
+        if (key === "ZAI_API_KEY") return "test-key";
+        return undefined;
+      },
+    };
+
+    const { handleTextSmall } = await import("../models/text");
+
+    await expect(
+      handleTextSmall(runtime as never, {
+        prompt: "hello",
+        providerOptions: { agentName: "test-agent", extra: { foo: "bar" } },
+      })
+    ).resolves.toBe("ok");
+
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+
+    await expect(
+      handleTextSmall(runtime as never, {
+        prompt: "hello",
+        providerOptions: cyclic as never,
+      })
+    ).rejects.toMatchObject({
+      code: "ZAI_PROVIDER_OPTIONS_UNBOUNDED",
+    });
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["small", "handleTextSmall"],
+    ["large", "handleTextLarge"],
+  ] as const)(
+    "rejects malformed present providerOptions before %s provider dispatch",
+    async (_size, handlerName) => {
+      const runtime = {
+        character: {},
+        getSetting(key: string) {
+          if (key === "ZAI_API_KEY") return "test-key";
+          return undefined;
+        },
+      };
+      const handlers = await import("../models/text");
+      const handler = handlers[handlerName];
+
+      await expect(
+        handler(runtime as never, {
+          prompt: "hello",
+          providerOptions: { agentName: "keep", bad: 1n } as never,
+        })
+      ).rejects.toMatchObject({ code: "ZAI_PROVIDER_OPTIONS_UNBOUNDED" });
+
+      expect(generateTextMock).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/plugins/plugin-zai/__tests__/zai-provider-options.test.ts
+++ b/plugins/plugin-zai/__tests__/zai-provider-options.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Deterministic tests for the z.ai providerOptions walk. No live model:
+ * the walker is the production readProviderOptions used on generate-text
+ * params.
+ */
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  MAX_ZAI_PROVIDER_OPTIONS_DEPTH,
+  MAX_ZAI_PROVIDER_OPTIONS_NODES,
+  readProviderOptions,
+  ZAI_PROVIDER_OPTIONS_UNBOUNDED,
+} from "../models/zai-provider-options";
+
+function nestArray(depth: number): unknown {
+  let value: unknown = "x";
+  for (let index = 0; index < depth; index += 1) {
+    value = [value];
+  }
+  return value;
+}
+
+describe("readProviderOptions", () => {
+  it("preserves root and nested __proto__ keys as inert own data", () => {
+    const nested = Object.fromEntries([["__proto__", { nested: true }]]);
+    const input = Object.fromEntries([
+      ["__proto__", { root: true }],
+      ["zai", nested],
+    ]);
+
+    const copied = readProviderOptions(input);
+
+    expect(Object.getPrototypeOf(copied)).toBe(Object.prototype);
+    expect(Object.hasOwn(copied ?? {}, "__proto__")).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(copied, "__proto__")?.value).toEqual({ root: true });
+    const copiedNested = copied?.zai as Record<string, unknown>;
+    expect(Object.getPrototypeOf(copiedNested)).toBe(Object.prototype);
+    expect(Object.hasOwn(copiedNested, "__proto__")).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(copiedNested, "__proto__")?.value).toEqual({
+      nested: true,
+    });
+  });
+
+  it("preserves honest scalars, lists, and nested records", () => {
+    expect(
+      readProviderOptions({
+        agentName: "eliza",
+        zai: { effort: "high", tags: ["a", { b: true }] },
+      })
+    ).toEqual({
+      agentName: "eliza",
+      zai: { effort: "high", tags: ["a", { b: true }] },
+    });
+    for (const invalid of [null, ["not", "a", "record"], "scalar"]) {
+      expect(() => readProviderOptions(invalid)).toThrow(
+        expect.objectContaining({ code: ZAI_PROVIDER_OPTIONS_UNBOUNDED })
+      );
+    }
+  });
+
+  it("rejects invalid present leaves instead of fabricating empty options", () => {
+    for (const invalid of [() => "fn", Symbol("bad"), 1n]) {
+      expect(() => readProviderOptions({ agentName: "keep", bad: invalid })).toThrow(
+        expect.objectContaining({ code: ZAI_PROVIDER_OPTIONS_UNBOUNDED })
+      );
+    }
+  });
+
+  it("preserves allowed undefined fields and the JSON numeric normalization", () => {
+    expect(
+      readProviderOptions({ missing: undefined, nan: Number.NaN, infinite: Infinity })
+    ).toEqual({ missing: undefined, nan: null, infinite: null });
+  });
+
+  it(`accepts a ${MAX_ZAI_PROVIDER_OPTIONS_DEPTH}-deep nest under payload`, () => {
+    // Root options object is depth 0, so payload may nest MAX-1 arrays.
+    const accepted = nestArray(MAX_ZAI_PROVIDER_OPTIONS_DEPTH - 1);
+    expect(readProviderOptions({ payload: accepted })).toEqual({ payload: accepted });
+  });
+
+  it(`throws ${ZAI_PROVIDER_OPTIONS_UNBOUNDED} one past depth ${MAX_ZAI_PROVIDER_OPTIONS_DEPTH}`, () => {
+    try {
+      readProviderOptions({
+        payload: nestArray(MAX_ZAI_PROVIDER_OPTIONS_DEPTH),
+      });
+      expect.unreachable("parse should fail closed on over-budget depth");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(ZAI_PROVIDER_OPTIONS_UNBOUNDED);
+    }
+  });
+
+  it(`throws ${ZAI_PROVIDER_OPTIONS_UNBOUNDED} past ${MAX_ZAI_PROVIDER_OPTIONS_NODES} sparse holes`, () => {
+    const sparse: unknown[] = [];
+    sparse[MAX_ZAI_PROVIDER_OPTIONS_NODES] = "x";
+    try {
+      readProviderOptions({ payload: sparse });
+      expect.unreachable("parse should fail closed on over-budget sparse length");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(ZAI_PROVIDER_OPTIONS_UNBOUNDED);
+    }
+  });
+
+  it("preserves within-budget sparse holes and length", () => {
+    const payload: unknown[] = [];
+    payload[2] = "x";
+    const result = readProviderOptions({ payload })?.payload as unknown[];
+    expect(result).toHaveLength(3);
+    expect(0 in result).toBe(false);
+    expect(1 in result).toBe(false);
+    expect(result[2]).toBe("x");
+  });
+
+  it("throws on a cyclic record without hanging", () => {
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+
+    try {
+      readProviderOptions(cyclic);
+      expect.unreachable("parse should fail closed on cyclic input");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(ZAI_PROVIDER_OPTIONS_UNBOUNDED);
+    }
+  });
+
+  it("copies a shared acyclic subgraph without treating it as a cycle", () => {
+    const shared = { enabled: true };
+    expect(readProviderOptions({ first: shared, second: shared })).toEqual({
+      first: { enabled: true },
+      second: { enabled: true },
+    });
+  });
+
+  it("fails closed on accessor properties", () => {
+    const hostile = {};
+    Object.defineProperty(hostile, "trap", {
+      get() {
+        throw new Error("getter side effect");
+      },
+      enumerable: true,
+    });
+
+    try {
+      readProviderOptions(hostile);
+      expect.unreachable("parse should fail closed on accessor descriptor");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ElizaError);
+      expect((error as ElizaError).code).toBe(ZAI_PROVIDER_OPTIONS_UNBOUNDED);
+    }
+  });
+
+  it("translates proxy reflection failures to the typed boundary error", () => {
+    const hostile = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("reflection trap");
+        },
+      }
+    );
+
+    expect(() => readProviderOptions(hostile)).toThrow(
+      expect.objectContaining({ code: ZAI_PROVIDER_OPTIONS_UNBOUNDED })
+    );
+  });
+});

--- a/plugins/plugin-zai/models/text.ts
+++ b/plugins/plugin-zai/models/text.ts
@@ -13,7 +13,7 @@ import type { GenerateTextParams, IAgentRuntime } from "@elizaos/core";
 import { ElizaError, logger, ModelType } from "@elizaos/core";
 import { generateText } from "ai";
 import { createZaiClient, type ZaiFetch } from "../providers";
-import { createModelName, type ModelName, type ModelSize, type ProviderOptions } from "../types";
+import { createModelName, type ModelName, type ModelSize } from "../types";
 import {
   getApiKey,
   getExperimentalTelemetry,
@@ -24,6 +24,7 @@ import {
   type ZaiThinkingConfig,
 } from "../utils/config";
 import { emitModelUsageEvent } from "../utils/events";
+import { type ProviderOptions, readProviderOptions } from "./zai-provider-options";
 
 interface ResolvedTextParams {
   readonly prompt: string;
@@ -62,10 +63,9 @@ function resolveTextParams(
   const defaultMaxTokens = modelName.includes("air") || modelName.includes("flash") ? 4096 : 8192;
   const maxTokens = params.omitMaxTokens ? undefined : (params.maxTokens ?? defaultMaxTokens);
 
-  const rawProviderOptions = rawParams.providerOptions as ProviderOptions | undefined;
-  const providerOptions: ProviderOptions = rawProviderOptions
-    ? JSON.parse(JSON.stringify(rawProviderOptions))
-    : {};
+  const rawProviderOptions = rawParams.providerOptions;
+  const providerOptions: ProviderOptions =
+    rawProviderOptions === undefined ? {} : readProviderOptions(rawProviderOptions);
 
   return {
     prompt,
@@ -121,12 +121,11 @@ async function generateTextWithModel(
   }
   const experimentalTelemetry = getExperimentalTelemetry(runtime);
   const thinking = getThinkingConfig(runtime, modelSize);
+  const resolved = resolveTextParams(params, modelName, thinking);
   const requestFetch = createZaiRequestFetch(thinking, (runtime.fetch ?? fetch) as ZaiFetch);
   const zai = createZaiClient(runtime, { fetch: requestFetch });
 
   logger.log(`[z.ai] Using ${modelType} model: ${modelName}`);
-
-  const resolved = resolveTextParams(params, modelName, thinking);
 
   const agentName = resolved.providerOptions.agentName;
   const telemetryConfig = {

--- a/plugins/plugin-zai/models/zai-provider-options.ts
+++ b/plugins/plugin-zai/models/zai-provider-options.ts
@@ -1,0 +1,177 @@
+/**
+ * Bounds the nested provider-options walk used when z.ai text handlers
+ * accept `GenerateTextParams.providerOptions`. Hostile nests RangeError'd
+ * or threw TypeError on JSON.stringify. Depth, node, and cycle limits
+ * are all load-bearing. Descriptor-only reads so a getter cannot hang
+ * the z.ai generate path.
+ */
+
+import { ElizaError } from "@elizaos/core";
+
+export const MAX_ZAI_PROVIDER_OPTIONS_DEPTH = 32;
+export const MAX_ZAI_PROVIDER_OPTIONS_NODES = 2_048;
+export const ZAI_PROVIDER_OPTIONS_UNBOUNDED = "ZAI_PROVIDER_OPTIONS_UNBOUNDED";
+
+type WalkContext = {
+  visits: number;
+  visiting: WeakSet<object>;
+};
+
+type ProviderOptionValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ProviderOptionValue[]
+  | { [key: string]: ProviderOptionValue | undefined };
+
+export type ProviderOptions = {
+  [key: string]: ProviderOptionValue | undefined;
+  agentName?: string;
+};
+
+function failUnbounded(context: Record<string, unknown>, cause?: unknown): never {
+  throw new ElizaError("z.ai providerOptions JSON exceeds the parse walk budget", {
+    code: ZAI_PROVIDER_OPTIONS_UNBOUNDED,
+    context,
+    cause,
+    severity: "fatal",
+  });
+}
+
+function reserve(ctx: WalkContext, count: number): void {
+  if (count > MAX_ZAI_PROVIDER_OPTIONS_NODES - ctx.visits) {
+    failUnbounded({
+      visits: ctx.visits + count,
+      maxNodes: MAX_ZAI_PROVIDER_OPTIONS_NODES,
+    });
+  }
+  ctx.visits += count;
+}
+
+function inspectRecord<T>(operation: string, inspect: () => T): T {
+  try {
+    return inspect();
+  } catch (cause) {
+    // error-policy:J2 Preserve reflection failures while adding the failed operation.
+    failUnbounded({ inspection: operation }, cause);
+  }
+}
+
+function ownDescriptor(value: object, key: PropertyKey): PropertyDescriptor | undefined {
+  return inspectRecord("getOwnPropertyDescriptor", () =>
+    Object.getOwnPropertyDescriptor(value, key)
+  );
+}
+
+function isArrayRecord(value: unknown): value is unknown[] {
+  return inspectRecord("isArray", () => Array.isArray(value));
+}
+
+function newWalkContext(): WalkContext {
+  return {
+    visits: 0,
+    visiting: new WeakSet<object>(),
+  };
+}
+
+/**
+ * Production z.ai boundary: descriptor-only validation/copy of
+ * `providerOptions` with one shared node/cycle budget.
+ */
+export function readProviderOptions(value: unknown): ProviderOptions {
+  if (typeof value !== "object" || value === null || isArrayRecord(value)) {
+    failUnbounded({ invalidRoot: true });
+  }
+  const copied = readProviderOptionValue(value, 0, newWalkContext());
+  if (copied === null || typeof copied !== "object" || Array.isArray(copied)) {
+    failUnbounded({ invalidRoot: true });
+  }
+  return copied as ProviderOptions;
+}
+
+function readProviderOptionValue(
+  value: unknown,
+  depth: number,
+  ctx: WalkContext,
+  visitAlreadyReserved = false
+): ProviderOptionValue | undefined {
+  if (depth > MAX_ZAI_PROVIDER_OPTIONS_DEPTH) {
+    failUnbounded({ depth, max: MAX_ZAI_PROVIDER_OPTIONS_DEPTH });
+  }
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    if (!visitAlreadyReserved) reserve(ctx, 1);
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!visitAlreadyReserved) reserve(ctx, 1);
+    return Number.isFinite(value) ? value : null;
+  }
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "object") {
+    if (!visitAlreadyReserved) reserve(ctx, 1);
+    failUnbounded({ invalidType: typeof value });
+  }
+  if (!visitAlreadyReserved) reserve(ctx, 1);
+  if (ctx.visiting.has(value)) {
+    failUnbounded({ cycle: true });
+  }
+  ctx.visiting.add(value);
+  try {
+    if (isArrayRecord(value)) {
+      const lengthDescriptor = ownDescriptor(value, "length");
+      if (!lengthDescriptor || !("value" in lengthDescriptor)) {
+        failUnbounded({ invalidArrayLength: true });
+      }
+      const length = lengthDescriptor.value;
+      if (!Number.isSafeInteger(length) || length < 0) {
+        failUnbounded({ invalidArrayLength: true });
+      }
+      reserve(ctx, length);
+      const out = new Array<ProviderOptionValue>(length);
+      for (let index = 0; index < length; index += 1) {
+        const descriptor = ownDescriptor(value, String(index));
+        if (!descriptor) continue;
+        if (!("value" in descriptor)) {
+          failUnbounded({ accessor: true, side: "array", index });
+        }
+        const nested = readProviderOptionValue(descriptor.value, depth + 1, ctx, true);
+        out[index] = nested ?? null;
+      }
+      return out;
+    }
+
+    const keys = inspectRecord("ownKeys", () => Reflect.ownKeys(value));
+    reserve(ctx, keys.length);
+    const record: { [key: string]: ProviderOptionValue | undefined } = {};
+    for (const key of keys) {
+      if (typeof key !== "string") continue;
+      const descriptor = ownDescriptor(value, key);
+      if (!descriptor?.enumerable) continue;
+      if (!("value" in descriptor)) {
+        failUnbounded({ accessor: true, side: "object", key });
+      }
+      if (descriptor.value === undefined) {
+        Object.defineProperty(record, key, {
+          value: undefined,
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
+        continue;
+      }
+      const nested = readProviderOptionValue(descriptor.value, depth + 1, ctx, true);
+      Object.defineProperty(record, key, {
+        value: nested,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+    return record;
+  } finally {
+    ctx.visiting.delete(value);
+  }
+}


### PR DESCRIPTION
# Relates to

Fixes #23300. Supersedes #22955.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on exact current `origin/develop@9f971dccb113a6736b84e7c85c29d193ca28b4c8` with zero conflicts.
- [ ] Full `bun install` and root `bun run verify` were not rerun in the isolated sparse repair clone; focused gates are recorded below.
- [x] A reviewer can confirm malformed options never reach `generateText` from the small or large production handler tests.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@9f971dccb113a6736b84e7c85c29d193ca28b4c8:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on exact latest `origin/develop@9f971dccb113a6736b84e7c85c29d193ca28b4c8`; zero conflicts at push time.
- [ ] Root `bun run verify` is left for hosted/current-head validation; focused package gates pass.

# Risks

Medium. This makes malformed present `providerOptions` a typed local failure instead of silently converting it to `{}`. Valid JSON-shaped records retain their copied shape; allowed `undefined` fields remain explicit and non-finite numbers preserve the prior JSON normalization to `null`.

# Background

## What does this PR do?

- Bounds z.ai `providerOptions` at 32 levels and 2,048 visits with path-scoped cycle detection.
- Uses own data descriptors, rejects accessors and reflection failures, and preserves `__proto__` as inert own data.
- Distinguishes absent options (`{}`) from invalid present roots or function/symbol/BigInt leaves, which throw `ZAI_PROVIDER_OPTIONS_UNBOUNDED` before client construction and `generateText` dispatch.
- Covers valid records, depth/node limits, sparse arrays, cycles, shared DAGs, accessors, proxy reflection, invalid leaves, and both small/large production handlers.

## What kind of change is this?

Bug fix (non-breaking for valid provider options; intentionally fail-closed for malformed input).

# Documentation changes needed?

No product documentation change: this hardens an existing internal provider boundary and its behavior is captured in tests.

# Testing

## Where should a reviewer start?

`plugins/plugin-zai/models/zai-provider-options.ts`, then the zero-dispatch cases in `plugins/plugin-zai/__tests__/text-params.test.ts`.

## Detailed testing steps

- `bun run --cwd plugins/plugin-zai test` -> PASS, 7 files / 49 tests.
- `bun run --cwd plugins/plugin-zai typecheck` -> PASS.
- `bunx biome check` on the four changed files -> PASS.
- `git diff --check` -> PASS.

# Evidence Gate

<!-- evidence-head:b631e60f0106e8d22cef649a2a16fdac370d3f80 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic provider-boundary change with no UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend service changed; the exact local Vitest transcript is recorded under Testing.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - the changed behavior is local rejection before any live-model call; valid provider dispatch behavior is unchanged.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact is produced; typed error and zero-dispatch assertions are the owning contract evidence.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text.

# Evidence Details

## Real LLM-call trajectory

N/A - malformed inputs are required to stop before any model request; a live call would not add evidence for the rejection boundary.

## Backend + frontend logs

Backend: focused Vitest result was 7 files / 49 tests passing. Frontend: N/A.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Known gaps / failures

The isolated sparse clone reused the existing locked dependency installation and ran package-local tests/typecheck plus scoped Biome/diff gates. Full root `bun run verify` and hosted checks remain required on this exact head before merge.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@9f971dccb113a6736b84e7c85c29d193ca28b4c8:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-byt61-provider-repair]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@9f971dccb113a6736b84e7c85c29d193ca28b4c8:packages/skills/skills/contribute-to-eliza"} -->