### PR TITLE
fix(ui): bound cloud bridge, bundle manifest, and steward session fetches with a portable timeout

### DIFF
--- a/packages/ui/src/api/client-cloud-steward-token.test.ts
+++ b/packages/ui/src/api/client-cloud-steward-token.test.ts
@@ -189,7 +189,11 @@ describe("refreshCloudStewardSession (web/fetch branch)", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.elizacloud.ai/api/v1/auth/steward/refresh",
-      expect.objectContaining({ method: "POST", credentials: "include" }),
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        signal: expect.any(AbortSignal),
+      }),
     );
     expect(result).toEqual({ token: "rotated-jwt", expiresIn: 900 });
   });
@@ -281,5 +285,180 @@ describe("refreshCloudStewardSession (web/fetch branch)", () => {
       endpoint: "https://api.elizacloud.ai/api/v1/auth/steward/refresh",
     });
     expect(result).toBeNull();
+  });
+});
+
+describe("refreshCloudStewardSession timeouts (portable fallback, fake timers)", () => {
+  const ENDPOINT = "https://api.elizacloud.ai/api/v1/auth/steward/refresh";
+  const TIMEOUT_MS = 30_000;
+  let originalTimeout: unknown;
+
+  beforeEach(() => {
+    // Force the AbortController+setTimeout fallback so fake timers control the
+    // timeout deterministically. Native AbortSignal.timeout uses an internal
+    // timer not governed by vi.useFakeTimers() in all runtimes, so forcing
+    // fallback makes the 30 s contract testable.
+    originalTimeout = (AbortSignal as unknown as { timeout?: unknown }).timeout;
+    Object.defineProperty(AbortSignal, "timeout", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    Object.defineProperty(AbortSignal, "timeout", {
+      value: originalTimeout,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it("aborts a headers-stalled fetch at 30 s and maps to STEWARD_SESSION_REFRESH_TRANSIENT (throwOnTransient)", async () => {
+    const fetchMock = vi.fn(
+      (_url: RequestInfo | URL, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          const signal = init?.signal as AbortSignal | undefined;
+          if (signal?.aborted) {
+            reject(new DOMException("TimeoutError", "TimeoutError"));
+            return;
+          }
+          signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("TimeoutError", "TimeoutError")),
+            { once: true },
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = refreshCloudStewardSession({
+      endpoint: ENDPOINT,
+      throwOnTransientHttpFailure: true,
+    });
+
+    // Must NOT settle before the timeout fires.
+    let settled = false;
+    pending.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const signal = (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)
+      ?.signal as AbortSignal | undefined;
+    expect(signal).toBeInstanceOf(AbortSignal);
+
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS);
+
+    await expect(pending).rejects.toMatchObject({
+      code: "STEWARD_SESSION_REFRESH_TRANSIENT",
+      context: { endpoint: ENDPOINT },
+    });
+    // Timer is disposed after abort so success-before-timeout does not leak.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("returns null on headers stall when not in throwOnTransient mode (fail-closed)", async () => {
+    const fetchMock = vi.fn(
+      (_url: RequestInfo | URL, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          const signal = init?.signal as AbortSignal | undefined;
+          signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("AbortError", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const pending = refreshCloudStewardSession({ endpoint: ENDPOINT });
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS);
+    await expect(pending).resolves.toBeNull();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("aborts a headers-received plus stalled body at 30 s (signal kept alive through json)", async () => {
+    const fetchMock = vi.fn(
+      async (_url: RequestInfo | URL, init?: RequestInit) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        return {
+          ok: true,
+          status: 200,
+          json: () =>
+            new Promise((_resolve, reject) => {
+              if (signal?.aborted) {
+                reject(new DOMException("TimeoutError", "TimeoutError"));
+                return;
+              }
+              signal?.addEventListener(
+                "abort",
+                () => reject(new DOMException("TimeoutError", "TimeoutError")),
+                { once: true },
+              );
+            }),
+        };
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = refreshCloudStewardSession({
+      endpoint: ENDPOINT,
+      throwOnTransientHttpFailure: true,
+    });
+
+    // Let the fetch resolve headers (microtask) but json stays pending.
+    await Promise.resolve();
+    await Promise.resolve();
+    // Still pending before timeout.
+    let settled = false;
+    pending.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS);
+
+    await expect(pending).rejects.toMatchObject({
+      code: "STEWARD_SESSION_REFRESH_TRANSIENT",
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clears the pending timer on success before timeout (no leak under fake timers)", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ token: "fresh-jwt", expiresIn: 900 }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await refreshCloudStewardSession({ endpoint: ENDPOINT });
+    expect(result).toEqual({ token: "fresh-jwt", expiresIn: 900 });
+    // dispose() cleared the fallback timer; no pending timers remain.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not mutate the global AbortSignal.timeout across tests (fallback proof)", () => {
+    // This test proves the fallback path was exercised without leaking the
+    // stub — the afterEach restores the original, so a later test sees the
+    // native impl again.
+    expect(
+      (AbortSignal as unknown as { timeout?: unknown }).timeout,
+    ).toBeUndefined();
   });
 });

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -78,6 +78,7 @@ import {
   resolveDirectCloudAuthApiBase,
   resolveDirectCloudWebBase,
 } from "./direct-cloud-endpoints";
+import { createTimeoutSignal, isTimeoutAbortError } from "./timeout-signal";
 import { fetchAgentTransport } from "./transport";
 
 // ---------------------------------------------------------------------------
@@ -718,46 +719,80 @@ export async function refreshCloudStewardSession(opts?: {
   }
 
   if (typeof fetch === "undefined") return null;
-  const response = await fetch(endpoint, {
-    method: "POST",
-    credentials: "include",
-  });
-  if (!response.ok) {
-    if (
-      opts?.throwOnTransientHttpFailure &&
-      (response.status === 429 || response.status >= 500)
-    ) {
+  // Cloud account reads can legitimately take longer than 15 seconds on a cold
+  // regional worker. Keep the request bounded at DIRECT_CLOUD_HTTP_TIMEOUT_MS,
+  // but use the portable helper — `AbortSignal.timeout` is missing on iOS
+  // 16.0-16.3 WKWebView and would throw TypeError before fetch is issued.
+  const { signal: stewardSignal, dispose: disposeStewardSignal } =
+    createTimeoutSignal(DIRECT_CLOUD_HTTP_TIMEOUT_MS);
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      credentials: "include",
+      signal: stewardSignal,
+    });
+    if (!response.ok) {
+      if (
+        opts?.throwOnTransientHttpFailure &&
+        (response.status === 429 || response.status >= 500)
+      ) {
+        throw new ElizaError(
+          "Steward session refresh is temporarily unavailable",
+          {
+            code: "STEWARD_SESSION_REFRESH_TRANSIENT",
+            context: { endpoint, status: response.status },
+          },
+        );
+      }
+      return null;
+    }
+    // Keep the timeout signal alive through the body stream — headers may
+    // arrive quickly while `response.json()` stalls indefinitely, so the
+    // timeout must abort the body read too.
+    // error-policy:J3 an unparseable refresh body reads as "no refreshed
+    // session" (null) — callers keep/drop the stored token by its own expiry.
+    // Timeout aborts rethrow so the boundary catch below maps them.
+    const parsed = (await response.json().catch((err: unknown) => {
+      if (isTimeoutAbortError(err)) throw err;
+      return null;
+    })) as {
+      token?: string;
+      expiresAt?: number;
+      expiresIn?: number;
+    } | null;
+    if (opts?.throwOnTransientHttpFailure && !parsed?.token?.trim()) {
+      // A 2xx whose body carries no usable token is out of the endpoint's
+      // success contract (authoritative logout is a 401, never an empty 200):
+      // treat it as an outage artifact so cookie-only recovery preserves the
+      // shared-agent binding instead of tearing it down.
       throw new ElizaError(
-        "Steward session refresh is temporarily unavailable",
+        "Steward session refresh returned a success response without a token",
         {
           code: "STEWARD_SESSION_REFRESH_TRANSIENT",
           context: { endpoint, status: response.status },
         },
       );
     }
-    return null;
+    return parsed;
+  } catch (err) {
+    // error-policy:J2 a timeout abort becomes the typed transient-refresh
+    // error in throwOnTransient mode; otherwise it fails closed to null,
+    // matching every other refresh failure on this endpoint. Non-abort
+    // errors rethrow untouched.
+    if (isTimeoutAbortError(err)) {
+      if (opts?.throwOnTransientHttpFailure) {
+        throw new ElizaError("Steward session refresh timed out", {
+          code: "STEWARD_SESSION_REFRESH_TRANSIENT",
+          context: { endpoint },
+          cause: err,
+        });
+      }
+      return null;
+    }
+    throw err;
+  } finally {
+    disposeStewardSignal();
   }
-  // error-policy:J3 an unparseable refresh body reads as "no refreshed
-  // session" (null) — callers keep/drop the stored token by its own expiry.
-  const parsed = (await response.json().catch(() => null)) as {
-    token?: string;
-    expiresAt?: number;
-    expiresIn?: number;
-  } | null;
-  if (opts?.throwOnTransientHttpFailure && !parsed?.token?.trim()) {
-    // A 2xx whose body carries no usable token is out of the endpoint's
-    // success contract (authoritative logout is a 401, never an empty 200):
-    // treat it as an outage artifact so cookie-only recovery preserves the
-    // shared-agent binding instead of tearing it down.
-    throw new ElizaError(
-      "Steward session refresh returned a success response without a token",
-      {
-        code: "STEWARD_SESSION_REFRESH_TRANSIENT",
-        context: { endpoint, status: response.status },
-      },
-    );
-  }
-  return parsed;
 }
 
 function isDirectCloudAuthMissing(client: ElizaClient): boolean {
@@ -4758,13 +4793,22 @@ ElizaClient.prototype.deleteSharedBridgeAgent = async function (
             { method: "DELETE", url },
           )
         ).status
-      : (
-          await directCloudFetch(resolveBrowserCloudApiRequestUrl(url), {
-            method: "DELETE",
-            headers,
-            signal: AbortSignal.timeout(20_000),
-          })
-        ).status;
+      : await (async () => {
+          // Portable 20 s bound — `AbortSignal.timeout` throws on iOS 16.0-16.3;
+          // use the same helper as the steward/bridge/manifest paths.
+          const { signal, dispose } = createTimeoutSignal(20_000);
+          try {
+            return (
+              await directCloudFetch(resolveBrowserCloudApiRequestUrl(url), {
+                method: "DELETE",
+                headers,
+                signal,
+              })
+            ).status;
+          } finally {
+            dispose();
+          }
+        })();
     if (status < 200 || status >= 300) {
       return {
         success: false,

--- a/packages/ui/src/api/ios-local-agent-kernel.local-inference.test.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.local-inference.test.ts
@@ -2,7 +2,7 @@
  * Unit coverage for the iOS in-renderer kernel's local-inference routes.
  * In-process, no real device.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type KernelModule = Pick<
   typeof import("./ios-local-agent-kernel"),
@@ -401,6 +401,11 @@ describe("iOS local-agent local inference flow", () => {
   });
 
   it("fails an Eliza-1 bundle download when a native SHA256 check mismatches", async () => {
+    // The kernel logs the failed download through its logging boundary; spy
+    // and assert it so the console guard treats the output as intentional.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     const kernel = await loadKernel({
       hashFile: vi.fn(async (path: string) => ({
         sha256: path.endsWith(".manifest.json")
@@ -426,6 +431,7 @@ describe("iOS local-agent local inference flow", () => {
       expect(payload.job?.state).toBe("failed");
       expect(payload.job?.error).toContain("SHA256 mismatch");
     });
+    expect(consoleError).toHaveBeenCalled();
   });
 
   it("does not persist native download exception text", async () => {
@@ -654,5 +660,176 @@ describe("iOS local-agent local inference flow", () => {
       }),
     );
     expect(load.mock.calls[0]?.[0]).not.toHaveProperty("draftModelPath");
+  });
+});
+
+describe("Eliza-1 manifest download timeout (real route, portable fallback, fake timers)", () => {
+  let originalTimeout: unknown;
+
+  beforeEach(() => {
+    // Force the AbortController+setTimeout fallback so vi fake timers drive
+    // the 30 s manifest bound deterministically, proving the production
+    // download path stays bounded on runtimes without AbortSignal.timeout.
+    originalTimeout = (AbortSignal as unknown as { timeout?: unknown }).timeout;
+    Object.defineProperty(AbortSignal, "timeout", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    Object.defineProperty(AbortSignal, "timeout", {
+      value: originalTimeout,
+      configurable: true,
+      writable: true,
+    });
+    await handleIosLocalAgentRequest(
+      new Request("http://127.0.0.1:31337/api/agent/reset", {
+        method: "POST",
+        body: "{}",
+      }),
+    ).catch(() => undefined);
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  async function jobFor(
+    kernel: KernelModule,
+    modelId: string,
+  ): Promise<{ state?: string; error?: string }> {
+    const response = await kernel.handleIosLocalAgentRequest(
+      new Request(
+        `http://127.0.0.1:31337/api/local-inference/downloads/${modelId}`,
+      ),
+    );
+    const payload = (await response.json()) as {
+      job?: { state?: string; error?: string };
+    };
+    return payload.job ?? {};
+  }
+
+  it("fails the download job when the manifest fetch stalls past 30 s", async () => {
+    const kernel = await loadKernel();
+    // Replace the harness manifest stub with a headers-stalled fetch that only
+    // settles when the kernel's timeout signal aborts it.
+    const fetchMock = vi.fn(
+      (_url: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal as AbortSignal | undefined;
+          if (signal?.aborted) {
+            reject(signal.reason ?? new DOMException("aborted", "AbortError"));
+            return;
+          }
+          signal?.addEventListener(
+            "abort",
+            () =>
+              reject(
+                signal.reason ?? new DOMException("aborted", "AbortError"),
+              ),
+            { once: true },
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    vi.useFakeTimers();
+
+    // The failed job is logged through the kernel's logging boundary; spy
+    // and assert it so the console guard treats the output as intentional.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    await jsonRequest(kernel, "POST", "/api/local-inference/downloads", {
+      modelId: "eliza-1-4b",
+    });
+
+    // Let the queued job's async pipeline reach the manifest fetch.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+    expect((await jobFor(kernel, "eliza-1-4b")).state).toBe("downloading");
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    const job = await jobFor(kernel, "eliza-1-4b");
+    expect(job.state).toBe("failed");
+    expect(job.error).toContain("Timed out fetching");
+    expect(job.error).toContain("manifest after 30 s");
+    expect(consoleError).toHaveBeenCalled();
+    // dispose() ran in the manifest boundary's finally — no leaked timer.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("fails the download job when manifest headers arrive but the body stalls past 30 s", async () => {
+    const kernel = await loadKernel();
+    const fetchMock = vi.fn(
+      async (_url: RequestInfo | URL, init?: RequestInit) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        return {
+          ok: true,
+          status: 200,
+          json: () =>
+            new Promise((_resolve, reject) => {
+              if (signal?.aborted) {
+                reject(
+                  signal.reason ?? new DOMException("aborted", "AbortError"),
+                );
+                return;
+              }
+              signal?.addEventListener(
+                "abort",
+                () =>
+                  reject(
+                    signal.reason ?? new DOMException("aborted", "AbortError"),
+                  ),
+                { once: true },
+              );
+            }),
+        } as Response;
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    vi.useFakeTimers();
+
+    await jsonRequest(kernel, "POST", "/api/local-inference/downloads", {
+      modelId: "eliza-1-4b",
+    });
+
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((await jobFor(kernel, "eliza-1-4b")).state).toBe("downloading");
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    const job = await jobFor(kernel, "eliza-1-4b");
+    expect(job.state).toBe("failed");
+    expect(job.error).toContain("Timed out fetching");
+    expect(job.error).toContain("manifest after 30 s");
+    expect(consoleError).toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("completes the download and leaves no pending manifest timer when the fetch is fast", async () => {
+    const kernel = await loadKernel();
+    vi.useFakeTimers();
+
+    await jsonRequest(kernel, "POST", "/api/local-inference/downloads", {
+      modelId: "eliza-1-4b",
+    });
+
+    // Drain the bundle pipeline (manifest fetch + per-file downloads/hashes
+    // are all mocked microtasks) without ever reaching the 30 s deadline.
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    const job = await jobFor(kernel, "eliza-1-4b");
+    expect(job.error).toBeUndefined();
+    expect(job.state).toBe("completed");
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/packages/ui/src/api/ios-local-agent-kernel.test.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.test.ts
@@ -2,9 +2,13 @@
  * Unit coverage for the iOS in-renderer fetch kernel's route handling. In-process
  * Request/Response, no real device.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_DIRECT_CLOUD_API_BASE_URL } from "./direct-cloud-endpoints";
-import { handleIosLocalAgentRequest } from "./ios-local-agent-kernel";
+import {
+  CLOUD_BRIDGE_REQUEST_TIMEOUT_MS,
+  handleIosLocalAgentRequest,
+  IOS_BUNDLE_MANIFEST_TIMEOUT_MS,
+} from "./ios-local-agent-kernel";
 
 async function getJson(pathname: string): Promise<unknown> {
   const response = await handleIosLocalAgentRequest(
@@ -781,5 +785,172 @@ describe("handleIosLocalAgentRequest", () => {
       state: "running",
       model: null,
     });
+  });
+
+  it("exports bound request timeout constants for bundle manifest and cloud bridge", () => {
+    expect(CLOUD_BRIDGE_REQUEST_TIMEOUT_MS).toBe(60_000);
+    expect(IOS_BUNDLE_MANIFEST_TIMEOUT_MS).toBe(30_000);
+  });
+});
+
+describe("handleIosLocalAgentRequest cloud bridge timeouts (portable fallback, fake timers)", () => {
+  let originalTimeout: unknown;
+
+  beforeEach(() => {
+    originalTimeout = (AbortSignal as unknown as { timeout?: unknown }).timeout;
+    Object.defineProperty(AbortSignal, "timeout", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    Object.defineProperty(AbortSignal, "timeout", {
+      value: originalTimeout,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  function pairedStorage(): Storage {
+    const s = stubLocalStorage();
+    s.setItem(
+      "elizaos:active-server",
+      JSON.stringify({
+        id: "cloud:agent-1",
+        kind: "cloud",
+        label: "Cloud Agent",
+        apiBase: "eliza-local-agent://ipc",
+        accessToken: "cloud-token",
+      }),
+    );
+    return s;
+  }
+
+  it("aborts a headers-stalled Cloud bridge at 60 s and surfaces 502 (fallback proof)", async () => {
+    vi.stubGlobal("window", { localStorage: pairedStorage() });
+    const fetchMock = vi.fn(
+      (_url: RequestInfo | URL, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          const signal = init?.signal as AbortSignal | undefined;
+          if (signal?.aborted) {
+            reject(new DOMException("TimeoutError", "TimeoutError"));
+            return;
+          }
+          signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("TimeoutError", "TimeoutError")),
+            { once: true },
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    // The kernel logs the failed cloud chat through its logging boundary;
+    // spy and assert it so the console guard treats the output as intentional.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const pending = handleIosLocalAgentRequest(
+      new Request("http://127.0.0.1:31337/api/cloud/chat", {
+        method: "POST",
+        body: JSON.stringify({ prompt: "hello" }),
+      }),
+    );
+
+    // Allow async routing (request.json()) to reach fetch before the 60 s
+    // timeout fires; with fake timers the microtask flush may need ticks.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    // Defer the fetch-called assertion until after the timeout has had a chance
+    // to fire — the contract is that the 60 s bound surfaces 502.
+    await vi.advanceTimersByTimeAsync(CLOUD_BRIDGE_REQUEST_TIMEOUT_MS);
+
+    // The bridge should have been attempted before the timeout aborted it.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const signal = (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)
+      ?.signal as AbortSignal | undefined;
+    expect(signal).toBeInstanceOf(AbortSignal);
+
+    const response = await pending;
+    expect(response.status).toBe(502);
+    expect(consoleError).toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("aborts a headers-received plus stalled body at 60 s (signal kept alive through json)", async () => {
+    vi.stubGlobal("window", { localStorage: pairedStorage() });
+    const fetchMock = vi.fn(
+      async (_url: RequestInfo | URL, init?: RequestInit) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ "content-type": "application/json" }),
+          json: () =>
+            new Promise((_resolve, reject) => {
+              if (signal?.aborted) {
+                reject(new DOMException("AbortError", "AbortError"));
+                return;
+              }
+              signal?.addEventListener(
+                "abort",
+                () => reject(new DOMException("AbortError", "AbortError")),
+                { once: true },
+              );
+            }),
+        } as Response;
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const pending = handleIosLocalAgentRequest(
+      new Request("http://127.0.0.1:31337/api/cloud/chat", {
+        method: "POST",
+        body: JSON.stringify({ prompt: "hello" }),
+      }),
+    );
+
+    // Let headers resolve but body stays stalled.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    await vi.advanceTimersByTimeAsync(CLOUD_BRIDGE_REQUEST_TIMEOUT_MS);
+
+    const response = await pending;
+    // Body stall is treated as bridge failure → 502, not 200.
+    expect(response.status).toBe(502);
+    expect(consoleError).toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clears the pending timer on Cloud bridge success before timeout", async () => {
+    vi.stubGlobal("window", { localStorage: pairedStorage() });
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        jsonrpc: "2.0",
+        id: "cloud-1",
+        result: { text: "cloud answer", model: "cloud-model" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await handleIosLocalAgentRequest(
+      new Request("http://127.0.0.1:31337/api/cloud/chat", {
+        method: "POST",
+        body: JSON.stringify({ prompt: "hello" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/packages/ui/src/api/ios-local-agent-kernel.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.ts
@@ -64,6 +64,7 @@ import {
   positiveFiniteNumber,
 } from "./ios-local-agent-mobile-policy";
 import type { IttpAgentRequestContext } from "./ittp-agent-transport";
+import { createTimeoutSignal, isTimeoutAbortError } from "./timeout-signal";
 
 const STORAGE_PREFIX = "eliza:ios-local-agent";
 const CONVERSATIONS_KEY = `${STORAGE_PREFIX}:conversations:v1`;
@@ -83,6 +84,12 @@ const DEFAULT_CLOUD_MARKET_PREVIEW_BASE_URL = "https://eliza.app";
 const CLOUD_WALLET_MARKET_OVERVIEW_PATH = "/market/preview/wallet-overview";
 const WALLET_MARKET_OVERVIEW_CACHE_TTL_MS = 120_000;
 const WALLET_MARKET_OVERVIEW_FETCH_TIMEOUT_MS = 8_000;
+// Cloud bridge relays a full LLM turn; 60 s matches the model gateway's server
+// timeout so the client does not hang forever on a cold regional worker.
+export const CLOUD_BRIDGE_REQUEST_TIMEOUT_MS = 60_000;
+// Eliza-1 manifest is a small JSON (< 50 KB) over Hugging Face CDN; 30 s is
+// generous even for a cold link while still bounding a hung fetch.
+export const IOS_BUNDLE_MANIFEST_TIMEOUT_MS = 30_000;
 const EMPTY_ROUTING_PREFERENCES: RoutingPreferences = {
   preferredProvider: {},
   policy: {},
@@ -2389,51 +2396,67 @@ async function sendPromptToIosCloud(
     throw new IosCloudNotPairedError("Eliza Cloud is not paired.");
   }
 
-  const response = await fetch(
-    `${pairing.apiBase}/api/v1/eliza/agents/${encodeURIComponent(pairing.agentId)}/bridge`,
-    {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        accept: "application/json",
-        authorization: `Bearer ${pairing.token}`,
+  // Portable 60 s bound — `AbortSignal.timeout` is missing on iOS 16.0-16.3.
+  const { signal: cloudBridgeSignal, dispose: disposeCloudBridgeSignal } =
+    createTimeoutSignal(CLOUD_BRIDGE_REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(
+      `${pairing.apiBase}/api/v1/eliza/agents/${encodeURIComponent(pairing.agentId)}/bridge`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json",
+          authorization: `Bearer ${pairing.token}`,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: randomId("cloud"),
+          method: "message.send",
+          params: { text: prompt },
+        }),
+        signal: cloudBridgeSignal,
       },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: randomId("cloud"),
-        method: "message.send",
-        params: { text: prompt },
-      }),
-    },
-  );
-  if (!response.ok) {
-    throw new Error(`Cloud bridge failed: HTTP ${response.status}`);
-  }
-
-  // error-policy:J3 body-parse failure becomes the explicit non-object throw
-  // below instead of a fabricated bridge reply.
-  const body = asRecord(await response.json().catch(() => null));
-  if (!body) {
-    throw new Error("Cloud bridge returned a non-object response.");
-  }
-  const error = asRecord(body.error);
-  if (error) {
-    throw new Error(
-      stringValue(error.message) ?? "Cloud bridge returned an error.",
     );
+    if (!response.ok) {
+      throw new Error(`Cloud bridge failed: HTTP ${response.status}`);
+    }
+
+    // Keep the timeout signal alive through the body stream — headers may
+    // arrive well before the timeout while the body is still stalled.
+    // error-policy:J3 body-parse failure becomes the explicit non-object
+    // throw below instead of a fabricated bridge reply; timeout aborts
+    // rethrow so handleIosCloudChat surfaces the 502 bridge failure.
+    const body = asRecord(
+      await response.json().catch((err: unknown) => {
+        if (isTimeoutAbortError(err)) throw err;
+        return null;
+      }),
+    );
+    if (!body) {
+      throw new Error("Cloud bridge returned a non-object response.");
+    }
+    const error = asRecord(body.error);
+    if (error) {
+      throw new Error(
+        stringValue(error.message) ?? "Cloud bridge returned an error.",
+      );
+    }
+    const result = asRecord(body.result);
+    const text = cloudBridgeResultText(result);
+    if (!text) {
+      throw new Error("Cloud bridge response missing text.");
+    }
+    const modelId = stringValue(result?.model);
+    return {
+      text,
+      promptTokens: 0,
+      completionTokens: 0,
+      ...(modelId ? { modelId } : {}),
+    };
+  } finally {
+    disposeCloudBridgeSignal();
   }
-  const result = asRecord(body.result);
-  const text = cloudBridgeResultText(result);
-  if (!text) {
-    throw new Error("Cloud bridge response missing text.");
-  }
-  const modelId = stringValue(result?.model);
-  return {
-    text,
-    promptTokens: 0,
-    completionTokens: 0,
-    ...(modelId ? { modelId } : {}),
-  };
 }
 
 async function handleIosCloudChat(request: Request): Promise<Response> {
@@ -2857,13 +2880,43 @@ async function downloadIosBundle(
     model,
     model.bundleManifestFile,
   );
-  const manifestResponse = await fetch(manifestUrl, { redirect: "follow" });
-  if (!manifestResponse.ok) {
-    throw new PublicLocalModelDownloadError(
-      `HTTP ${manifestResponse.status} while fetching ${model.displayName} manifest`,
+  // Portable 30 s bound — small JSON over Hugging Face CDN; keep the signal
+  // alive through `response.json()` so a headers-received + stalled-body hang
+  // is still bounded. `AbortSignal.timeout` would throw on iOS 16.0-16.3.
+  // Fetch, parse, and timeout aborts all propagate to startDownload's job
+  // boundary, which records the failed download state.
+  const manifest = await (async () => {
+    const { signal, dispose } = createTimeoutSignal(
+      IOS_BUNDLE_MANIFEST_TIMEOUT_MS,
     );
-  }
-  const manifest = parseIosBundleManifest(await manifestResponse.json(), model);
+    try {
+      const manifestResponse = await fetch(manifestUrl, {
+        redirect: "follow",
+        signal,
+      });
+      if (!manifestResponse.ok) {
+        throw new PublicLocalModelDownloadError(
+          `HTTP ${manifestResponse.status} while fetching ${model.displayName} manifest`,
+        );
+      }
+      return parseIosBundleManifest(await manifestResponse.json(), model);
+    } catch (err) {
+      // error-policy:J2 a manifest timeout becomes a public download error so
+      // the models UI names the cause; other failures keep their contained
+      // "Model download failed" diagnostics from startDownload's boundary.
+      if (isTimeoutAbortError(err)) {
+        throw new PublicLocalModelDownloadError(
+          `Timed out fetching ${model.displayName} manifest after ${Math.round(
+            IOS_BUNDLE_MANIFEST_TIMEOUT_MS / 1000,
+          )} s`,
+          { cause: err },
+        );
+      }
+      throw err;
+    } finally {
+      dispose();
+    }
+  })();
 
   const files: Record<string, string> = {};
   let bundleSizeBytes = 0;

--- a/packages/ui/src/api/timeout-signal.ts
+++ b/packages/ui/src/api/timeout-signal.ts
@@ -1,0 +1,45 @@
+/**
+ * Portable timeout signal for fetch bounds. `AbortSignal.timeout` is missing
+ * on iOS 16.0-16.3 WKWebView (it shipped in Safari 16.4), so a bare
+ * `AbortSignal.timeout(ms)` call throws TypeError *before* fetch is issued on
+ * supported devices, turning an intended bound into a hard crash. When the
+ * native factory is absent this falls back to `AbortController` plus
+ * `setTimeout`, preserving the same abort contract through fetch's `signal`
+ * option.
+ *
+ * Callers must invoke `dispose` only after both fetch *and* any body read
+ * (`response.json()` / `response.text()`) settle — headers can arrive well
+ * before `ms` while the body is still stalled, and disposing early would
+ * unbound that stall on fallback runtimes. `dispose` clears the fallback
+ * timer so success-before-timeout does not leak a pending timer.
+ */
+export function createTimeoutSignal(ms: number): {
+  signal: AbortSignal;
+  dispose: () => void;
+} {
+  const nativeTimeout = (
+    AbortSignal as unknown as { timeout?: (ms: number) => AbortSignal }
+  ).timeout;
+  if (typeof nativeTimeout === "function") {
+    return { signal: nativeTimeout.call(AbortSignal, ms), dispose: () => {} };
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort(
+      new DOMException(`Timeout after ${ms} ms`, "TimeoutError"),
+    );
+  }, ms);
+  return { signal: controller.signal, dispose: () => clearTimeout(timer) };
+}
+
+/**
+ * True when an error is the abort produced by a timeout signal — native
+ * `AbortSignal.timeout` rejects with `TimeoutError`, plain aborts with
+ * `AbortError`. Matched by `name` because `DOMException` does not extend
+ * `Error` on every supported runtime (Node's does not).
+ */
+export function isTimeoutAbortError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const name = (err as { name?: unknown }).name;
+  return name === "AbortError" || name === "TimeoutError";
+}


### PR DESCRIPTION
## Summary

Maintainer-repaired continuation of #23209 (closed at head `fd4bedea` for error-policy and coverage blockers). Credit to @byt61 for the original change; the commit carries co-authorship.

Three UI fetches had no timeout, and a bare `AbortSignal.timeout` would throw `TypeError` before fetch on iOS 16.0-16.3 WKWebView (Safari ships it in 16.4) while the native app targets iOS 16.0:

- **`packages/ui/src/api/timeout-signal.ts` (new):** `createTimeoutSignal(ms)` uses native `AbortSignal.timeout` when present, otherwise `AbortController` + `setTimeout` with a `dispose()` handle owned by call sites. No empty catches, no dispose-discarding export (the review-flagged `getTimeoutSignal` is gone). Shared `isTimeoutAbortError` matches aborts by name because `DOMException` does not extend `Error` on every runtime.
- **`sendPromptToIosCloud`** bounded at 60 s (`CLOUD_BRIDGE_REQUEST_TIMEOUT_MS`, matching the model gateway); timeout surfaces as the existing 502 bridge failure.
- **`downloadIosBundle`** manifest fetch bounded at 30 s (`IOS_BUNDLE_MANIFEST_TIMEOUT_MS`); a timeout becomes a `PublicLocalModelDownloadError` naming the cause so the failed job stays diagnosable under #23263's contained-diagnostics policy.
- **`refreshCloudStewardSession`** bounded at `DIRECT_CLOUD_HTTP_TIMEOUT_MS` (timeout maps to typed `STEWARD_SESSION_REFRESH_TRANSIENT` with preserved `cause`, or fail-closed `null`); **`deleteSharedBridgeAgent`** keeps its 20 s bound via the portable helper.
- Signals stay alive through `response.json()` so a headers-received + stalled-body hang is still bounded; every retained catch is J-tagged.

Resolves both close blockers on #23209: the error-policy violations in `timeout-signal.ts` are gone, and the manifest bound is proven against the production route — `POST /api/local-inference/downloads` driven through the kernel with the native module stubbed, covering header stall, body stall, terminal failed-job state, and timer cleanup.

Also repairs the pre-existing develop failure in the SHA256-mismatch download test (introduced by #23263's logging) by spying the logging boundary as the console guard requires.

## Verification

- `bun run --cwd packages/ui test -- src/api/client-cloud-steward-token.test.ts src/api/ios-local-agent-kernel.test.ts src/api/ios-local-agent-kernel.local-inference.test.ts` — 62/62 pass on this head (the SHA256-mismatch test fails on clean `origin/develop`).
- `bun run --cwd packages/ui typecheck` — passes.
- `bunx biome check packages/ui/src/api/` — clean.
- No `packages/app` view is touched; changes are transport-boundary timeouts and tests, so no visual audit applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)