### PR TITLE
fix(security): tokenize HTML raw-text boundaries

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-google-connector/gmail.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/gmail.error-policy.test.ts
@@ -110,9 +110,9 @@ describe("gmail.ts error-policy — fail-closed vs designed-empty", () => {
     expect(result.messages[0]?.subject).toBe("Hello");
   });
 
-  test("body normalization decodes entities once and strips malformed script/style end tags", async () => {
+  test("body normalization strips browser-tokenized script/style end tags", async () => {
     const body =
-      '<p>&amp;lt;kept&amp;gt;</p><script>credential-stealer()</script \t\n bar><style>hidden{}</style data-x="1">';
+      "<p>&amp;lt;kept&amp;gt;</p><script>credential-stealer()</sCrIpT data-x=1><style>hidden{}</style/ignored><p>safe</p><script>unclosed";
     fetchImpl = async () =>
       jsonResponse({
         id: "m1",
@@ -141,6 +141,8 @@ describe("gmail.ts error-policy — fail-closed vs designed-empty", () => {
     expect(result.bodyText).not.toContain("<kept>");
     expect(result.bodyText).not.toContain("credential-stealer");
     expect(result.bodyText).not.toContain("hidden");
+    expect(result.bodyText).not.toContain("unclosed");
+    expect(result.bodyText).toContain("safe");
   });
 
   test("internal failure on the LIST call propagates (never fabricates empty)", async () => {

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/gmail.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/gmail.ts
@@ -1,4 +1,5 @@
 // Coordinates cloud service gmail behavior behind route handlers.
+import { stripHtmlRawTextElements } from "@elizaos/core";
 import { extractBody, sanitizeHeaderValue } from "../../utils/google-mcp-shared";
 import type { OAuthConnectionRole } from "../oauth/types";
 import {
@@ -181,9 +182,7 @@ function decodeHtmlEntities(value: string): string {
 
 function htmlToPlainText(value: string): string {
   return decodeHtmlEntities(
-    value
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, " ")
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, " ")
+    stripHtmlRawTextElements(value)
       .replace(/<br\s*\/?>/gi, "\n")
       .replace(/<\/(?:p|div|section|article|li|tr|table|h[1-6])>/gi, "\n")
       .replace(/<(?:li)[^>]*>/gi, "- ")

--- a/packages/core/src/features/basic-capabilities/evaluators/__tests__/link-extraction.test.ts
+++ b/packages/core/src/features/basic-capabilities/evaluators/__tests__/link-extraction.test.ts
@@ -194,10 +194,10 @@ describe("linkExtractionEvaluator", () => {
 		);
 	});
 
-	it("decodes title entities once and strips script/style tags with malformed closers", async () => {
+	it("decodes title entities once and strips browser-tokenized raw-text tags", async () => {
 		stubPreviewFetch(
 			makeFetchResponse(
-				'<title>&amp;lt;literal&amp;gt;</title><body>safe<script>steal()</script \t\n bar><style>hidden{}</style data-x="1"></body>',
+				"<title>&amp;lt;literal&amp;gt;</title><body>safe<script>steal()</sCrIpT data-x=1><style>hidden{}</style/ignored><p>after</p><script>unclosed",
 			),
 		);
 		const runtime = makeRuntime(async (_modelType, params) => {
@@ -206,6 +206,8 @@ describe("linkExtractionEvaluator", () => {
 			expect(prompt).toContain("safe");
 			expect(prompt).not.toContain("steal()");
 			expect(prompt).not.toContain("hidden{}");
+			expect(prompt).not.toContain("unclosed");
+			expect(prompt).toContain("after");
 			return "summary";
 		});
 		const context = {

--- a/packages/core/src/features/basic-capabilities/evaluators/link-extraction.ts
+++ b/packages/core/src/features/basic-capabilities/evaluators/link-extraction.ts
@@ -22,6 +22,7 @@ import type {
 	Memory,
 } from "../../../types/index.ts";
 import { asUUID, MemoryType, ModelType } from "../../../types/index.ts";
+import { stripHtmlRawTextElements } from "../../../utils/html-raw-text.ts";
 import { truncateWellFormed } from "../../../utils/well-formed.ts";
 
 const EVALUATOR_NAME = "linkExtraction";
@@ -143,9 +144,7 @@ function decodeHtmlEntities(value: string): string {
 }
 
 function stripTags(html: string): string {
-	return html
-		.replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, " ")
-		.replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, " ")
+	return stripHtmlRawTextElements(html)
 		.replace(/<[^>]+>/g, " ")
 		.replace(/\s+/g, " ")
 		.trim();

--- a/packages/core/src/features/documents/url-ingest.ts
+++ b/packages/core/src/features/documents/url-ingest.ts
@@ -24,6 +24,7 @@ import {
 	isPrivateIpAddress,
 	normalizeHostLike,
 } from "../../network/ssrf.ts";
+import { stripHtmlRawTextElements } from "../../utils/html-raw-text.ts";
 
 const MAX_URL_IMPORT_BYTES = 10 * 1024 * 1024; // 10 MB
 const MAX_YOUTUBE_WATCH_PAGE_BYTES = 2 * 1024 * 1024; // 2 MB
@@ -523,9 +524,7 @@ function decodeBasicHtmlEntities(value: string): string {
 
 function htmlToPlainText(value: string): string {
 	return decodeBasicHtmlEntities(
-		value
-			.replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, " ")
-			.replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, " ")
+		stripHtmlRawTextElements(value)
 			.replace(/<br\s*\/?>/gi, "\n")
 			.replace(/<\/(?:p|div|section|article|li|tr|table|h[1-6])>/gi, "\n")
 			.replace(/<li\b[^>]*>/gi, "- ")

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -245,6 +245,7 @@ export * from "./utils/deterministic";
 export * from "./utils/environment";
 export { getEnv } from "./utils/environment";
 export { formatError } from "./utils/format-error";
+export * from "./utils/html-raw-text";
 export * from "./utils/project-memory-scope";
 export * from "./utils/read-env";
 export * from "./utils/resolve-setting";

--- a/packages/core/src/index.edge.ts
+++ b/packages/core/src/index.edge.ts
@@ -111,6 +111,7 @@ export * from "./utils/channel-utils";
 export * from "./utils/description-compressed-lint";
 export { stableStringify } from "./utils/deterministic";
 export * from "./utils/environment";
+export * from "./utils/html-raw-text";
 export * from "./utils/prompt-compression";
 export * from "./utils/read-env";
 export * from "./utils/resolve-setting";

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -476,6 +476,7 @@ export * from "./utils/deterministic";
 export * from "./utils/environment";
 export { getEnv } from "./utils/environment";
 export { formatError } from "./utils/format-error";
+export * from "./utils/html-raw-text";
 /** Single-lane local inference scheduling: interactive-over-background gate + device-class background budgets (#11914). */
 export * from "./utils/inference-priority-gate";
 // Export Node-specific utilities

--- a/packages/core/src/utils/html-raw-text.test.ts
+++ b/packages/core/src/utils/html-raw-text.test.ts
@@ -1,0 +1,43 @@
+/** Tests the bounded HTML raw-text tokenizer against browser end-tag states. */
+
+import { describe, expect, it } from "vitest";
+import { stripHtmlRawTextElements } from "./html-raw-text";
+
+describe("stripHtmlRawTextElements", () => {
+	it.each([
+		["ordinary", "<script>hidden</script>"],
+		["mixed case", "<ScRiPt>hidden</sCrIpT>"],
+		["whitespace", "<style>hidden</style \t>"],
+		["trailing attribute", "<script>hidden</script data-x=1>"],
+		["slash delimiter", "<style>hidden</style/ignored>"],
+		["quoted closer material", "<script>hidden</script data-x='>' >"],
+	])("removes %s raw-text markup", (_label, markup) => {
+		expect(stripHtmlRawTextElements(`before${markup}after`)).toBe(
+			"before after",
+		);
+	});
+
+	it("does not accept a non-delimited end-tag name", () => {
+		expect(
+			stripHtmlRawTextElements(
+				"before<script>first</scriptx>second</script>after",
+			),
+		).toBe("before after");
+	});
+
+	it.each(["<script>hidden", "<style data-x='>' hidden"])(
+		"removes an unclosed raw-text element through EOF",
+		(markup) => {
+			expect(stripHtmlRawTextElements(`before${markup}`)).toBe("before ");
+		},
+	);
+
+	it("is linear and preserves text around a large raw-text body", () => {
+		const body = "x".repeat(250_000);
+		expect(
+			stripHtmlRawTextElements(
+				`before<script data-x=">">${body}</script trailing>after`,
+			),
+		).toBe("before after");
+	});
+});

--- a/packages/core/src/utils/html-raw-text.ts
+++ b/packages/core/src/utils/html-raw-text.ts
@@ -1,0 +1,124 @@
+/**
+ * Removes HTML script and style elements with a bounded tokenizer pass.
+ *
+ * HTML end tags accept whitespace, a slash, or attributes after the tag name.
+ * Regex-based filters routinely miss those parser-accepted forms and expose
+ * raw script/style bodies as visible text after a later generic tag strip.
+ */
+
+const RAW_TEXT_TAGS = ["script", "style"] as const;
+
+function isAsciiWhitespace(character: string): boolean {
+	return (
+		character === "\t" ||
+		character === "\n" ||
+		character === "\f" ||
+		character === "\r" ||
+		character === " "
+	);
+}
+
+function matchesAsciiCaseInsensitive(
+	value: string,
+	index: number,
+	expected: string,
+): boolean {
+	if (index + expected.length > value.length) return false;
+	for (let offset = 0; offset < expected.length; offset += 1) {
+		const code = value.charCodeAt(index + offset);
+		const normalized = code >= 65 && code <= 90 ? code + 32 : code;
+		if (normalized !== expected.charCodeAt(offset)) return false;
+	}
+	return true;
+}
+
+function isTagNameDelimiter(character: string | undefined): boolean {
+	return (
+		character === undefined ||
+		character === ">" ||
+		character === "/" ||
+		isAsciiWhitespace(character)
+	);
+}
+
+function findTagEnd(value: string, index: number): number {
+	let quote: '"' | "'" | null = null;
+	for (let cursor = index; cursor < value.length; cursor += 1) {
+		const character = value[cursor];
+		if (quote !== null) {
+			if (character === quote) quote = null;
+			continue;
+		}
+		if (character === '"' || character === "'") {
+			quote = character;
+		} else if (character === ">") {
+			return cursor + 1;
+		}
+	}
+	return value.length;
+}
+
+function matchTag(
+	value: string,
+	index: number,
+	tagName: (typeof RAW_TEXT_TAGS)[number],
+	closing: boolean,
+): number | null {
+	if (value[index] !== "<") return null;
+	const nameIndex = index + (closing ? 2 : 1);
+	if (closing && value[index + 1] !== "/") return null;
+	if (!matchesAsciiCaseInsensitive(value, nameIndex, tagName)) return null;
+	const afterName = nameIndex + tagName.length;
+	if (!isTagNameDelimiter(value[afterName])) return null;
+	return findTagEnd(value, afterName);
+}
+
+/** Remove script/style elements, including parser-accepted malformed end tags. */
+export function stripHtmlRawTextElements(value: string): string {
+	const output: string[] = [];
+	let copiedThrough = 0;
+	let cursor = 0;
+
+	while (cursor < value.length) {
+		if (value[cursor] !== "<") {
+			cursor += 1;
+			continue;
+		}
+
+		let matchedTag: (typeof RAW_TEXT_TAGS)[number] | null = null;
+		let openingEnd = 0;
+		for (const tagName of RAW_TEXT_TAGS) {
+			const end = matchTag(value, cursor, tagName, false);
+			if (end !== null) {
+				matchedTag = tagName;
+				openingEnd = end;
+				break;
+			}
+		}
+		if (matchedTag === null) {
+			cursor += 1;
+			continue;
+		}
+
+		output.push(value.slice(copiedThrough, cursor), " ");
+		cursor = openingEnd;
+		let closingEnd: number | null = null;
+		while (cursor < value.length) {
+			if (value[cursor] === "<" && value[cursor + 1] === "/") {
+				closingEnd = matchTag(value, cursor, matchedTag, true);
+				if (closingEnd !== null) break;
+			}
+			cursor += 1;
+		}
+		if (closingEnd === null) {
+			copiedThrough = value.length;
+			cursor = value.length;
+		} else {
+			copiedThrough = closingEnd;
+			cursor = closingEnd;
+		}
+	}
+
+	output.push(value.slice(copiedThrough));
+	return output.join("");
+}

--- a/plugins/plugin-coding-tools/src/actions/web-fetch.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.test.ts
@@ -284,22 +284,12 @@ describe("coding-tools WEB_FETCH", () => {
     expect(htmlToReadableText("<p>&quot;&apos;&nbsp;x</p>")).toBe("\"' x");
   });
 
-  it("removes script and style blocks whose closing tags carry whitespace or attributes", () => {
+  it("removes browser-tokenized and unclosed script/style blocks", () => {
     expect(
       htmlToReadableText(
-        "<p>visible</p><script>steal()</script ><style>hidden{}</style ><p>after</p>",
+        "<p>visible</p><script>steal()</sCrIpT data-x=1><style>hidden{}</style/ignored><p>after</p><script>unclosed",
       ),
     ).toBe("visible\n\nafter");
-    expect(
-      htmlToReadableText(
-        '<p>visible</p><script>steal()</script \t\n bar><style>hidden{}</style data-x="1"><p>after</p>',
-      ),
-    ).toBe("visible\n\nafter");
-    // A non-boundary suffix is not a real closer; the block must keep consuming
-    // until an accepted end tag so early content cannot leak.
-    expect(
-      htmlToReadableText("<p>a</p><script>steal()</scriptx></script><p>b</p>"),
-    ).toBe("a\n\nb");
   });
 
   it("degrades invalid numeric entities without throwing and keeps surrounding text", () => {

--- a/plugins/plugin-coding-tools/src/actions/web-fetch.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.ts
@@ -12,6 +12,7 @@ import type {
   Memory,
   State,
 } from "@elizaos/core";
+import { stripHtmlRawTextElements } from "@elizaos/core";
 import {
   failureToActionResult,
   readStringParam,
@@ -70,10 +71,8 @@ function normalizeWhitespace(text: string): string {
 
 export function htmlToReadableText(html: string): string {
   const title = /<title\b[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1];
-  const withoutNoise = html
+  const withoutNoise = stripHtmlRawTextElements(html)
     .replace(/<head\b[^>]*>[\s\S]*?<\/head>/gi, " ")
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, " ")
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, " ")
     .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, " ")
     .replace(/<svg\b[^>]*>[\s\S]*?<\/svg>/gi, " ");
   const text = withoutNoise

--- a/plugins/plugin-google-workspace/src/gmail.ts
+++ b/plugins/plugin-google-workspace/src/gmail.ts
@@ -8,7 +8,7 @@
  * MIME `parts` trees are bounded in `gmail-mime-parts.ts` so a hostile nest
  * cannot RangeError ingest.
  */
-import { ElizaError } from "@elizaos/core";
+import { ElizaError, stripHtmlRawTextElements } from "@elizaos/core";
 import type { gmail_v1 } from "googleapis";
 import type { GoogleApiClientFactory } from "./client-factory.js";
 import {
@@ -1036,9 +1036,7 @@ function extractGoogleGmailBodyByMime(
 
 function htmlToPlainText(value: string): string {
   return decodeHtmlEntities(
-    value
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style\b[^>]*>/gi, " ")
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, " ")
+    stripHtmlRawTextElements(value)
       .replace(/<br\s*\/?>/gi, "\n")
       .replace(/<\/(?:p|div|section|article|li|tr|table|h[1-6])>/gi, "\n")
       .replace(/<(?:li)[^>]*>/gi, "- ")


### PR DESCRIPTION
## Summary

Follow-up to #23260 under #22087. Replaces duplicated script/style removal regexes with one bounded, quote-aware raw-text scanner and applies it consistently across all five HTML-to-text consumers.

The scanner handles case-insensitive tag names, parser-accepted trailing end-tag material, quoted `>` characters, missing closers, and large inputs without backtracking.

## Evidence

Head: `96b0bdb7d101ef6409d90d228705546535ee0b29`

- raw-text scanner + core link + coding WEB_FETCH: 37/37 passing
- cloud Gmail boundary: 6/6 passing
- Google Workspace Gmail MIME suite: 21/21 passing with source exports
- core and coding-tools typechecks passing
- Biome (13 changed source/test files) and `git diff --check` passing

Google Workspace package typecheck was not authoritative locally because the interrupted pre-existing core declaration build left `dist` declarations unavailable; the source-conditioned runtime suite passes. Hosted type/build/security checks remain pending, so this PR is intentionally draft.

Related: #22087, #23260.