### PR TITLE
fix(agent): restore test fixture type safety

### DIFF
--- a/packages/agent/src/api/auth-routes.test.ts
+++ b/packages/agent/src/api/auth-routes.test.ts
@@ -7,28 +7,28 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthRouteContext } from "./auth-routes.ts";
 import { handleAuthRoutes } from "./auth-routes.ts";
 
-type JsonFn = (res: unknown, data: unknown, status?: number) => void;
-type ErrorFn = (res: unknown, message: string, status?: number) => void;
+type JsonRecorder = (data: unknown, status?: number) => void;
+type ErrorRecorder = (message: string, status?: number) => void;
 
-function makeCtx(overrides: Partial<AuthRouteContext> = {}): {
-  ctx: AuthRouteContext;
-  json: ReturnType<typeof vi.fn>;
-  error: ReturnType<typeof vi.fn>;
-} {
-  const json = vi.fn() as unknown as JsonFn;
-  const error = vi.fn() as unknown as ErrorFn;
-  const ctx = {
+function makeJsonBody(
+  value: Record<string, unknown>,
+): AuthRouteContext["readJsonBody"] {
+  return async <T extends object>() => value as T;
+}
+
+function makeCtx(overrides: Partial<AuthRouteContext> = {}) {
+  const json = vi.fn<JsonRecorder>();
+  const error = vi.fn<ErrorRecorder>();
+  const ctx: AuthRouteContext = {
     req: { socket: { remoteAddress: "127.0.0.1" } } as AuthRouteContext["req"],
     res: {} as AuthRouteContext["res"],
     method: "GET",
     pathname: "",
-    readJsonBody: vi.fn(),
-    json: ((_res, data, status) =>
-      status === undefined ? json(data) : json(data, status)) as JsonFn,
-    error: ((_res, message, status) =>
-      status === undefined
-        ? error(message)
-        : error(message, status)) as ErrorFn,
+    readJsonBody: async <T extends object>() => null as T | null,
+    json: (_res, data, status) =>
+      status === undefined ? json(data) : json(data, status),
+    error: (_res, message, status) =>
+      status === undefined ? error(message) : error(message, status),
     pairingEnabled: vi.fn(() => true),
     ensurePairingCode: vi.fn(() => "ABCD-EFGH"),
     normalizePairingCode: vi.fn((s: string) => s.replace(/-/g, "")),
@@ -36,7 +36,7 @@ function makeCtx(overrides: Partial<AuthRouteContext> = {}): {
     getPairingExpiresAt: vi.fn(() => Date.now() + 600_000),
     clearPairing: vi.fn(),
     ...overrides,
-  } as unknown as AuthRouteContext;
+  };
   return { ctx, json, error };
 }
 
@@ -48,7 +48,7 @@ vi.mock("./server-helpers-auth.ts", () => ({
 }));
 vi.mock("@elizaos/shared", () => ({
   isCloudProvisionedContainer: vi.fn(() => false),
-  resolveApiToken: vi.fn(() => undefined),
+  resolveApiToken: vi.fn(() => null),
   PostAuthPairRequestSchema: {
     safeParse: vi.fn(() => ({ success: true, data: { code: "ABCDEFGH" } })),
   },
@@ -76,7 +76,7 @@ beforeEach(() => {
   mockIsTrustedLocalRequest.mockReturnValue(true);
   mockResolveBoundaryRole.mockReturnValue("GUEST");
   mockIsCloud.mockReturnValue(false);
-  vi.mocked(resolveApiToken).mockReturnValue(undefined);
+  vi.mocked(resolveApiToken).mockReturnValue(null);
   mockParse.mockReturnValue({
     success: true,
     data: { code: "ABCDEFGH" },
@@ -162,7 +162,7 @@ describe("GET /api/auth/status", () => {
     mockIsCloud.mockReturnValue(false);
     vi.mocked(
       (await import("@elizaos/shared")).resolveApiToken,
-    ).mockReturnValue(undefined);
+    ).mockReturnValue(null);
     const { ctx, json } = makeCtx({
       method: "GET",
       pathname: "/api/auth/status",
@@ -243,7 +243,7 @@ describe("POST /api/auth/pair", () => {
     const { ctx, json } = makeCtx({
       method: "POST",
       pathname: "/api/auth/pair",
-      readJsonBody: vi.fn(async () => ({ code: "correct-token" })),
+      readJsonBody: makeJsonBody({ code: "correct-token" }),
     });
     await handleAuthRoutes(ctx);
     expect(json).toHaveBeenCalledWith({ token: "correct-token" });
@@ -262,7 +262,7 @@ describe("POST /api/auth/pair", () => {
     const { ctx, error } = makeCtx({
       method: "POST",
       pathname: "/api/auth/pair",
-      readJsonBody: vi.fn(async () => ({ code: "wrong-token" })),
+      readJsonBody: makeJsonBody({ code: "wrong-token" }),
       normalizePairingCode: vi.fn((s) => s),
       ensurePairingCode: vi.fn(() => "ABCDEFGH"),
     });
@@ -275,7 +275,7 @@ describe("POST /api/auth/pair", () => {
     const { ctx, error } = makeCtx({
       method: "POST",
       pathname: "/api/auth/pair",
-      readJsonBody: vi.fn(async () => ({ code: "anything" })),
+      readJsonBody: makeJsonBody({ code: "anything" }),
       rateLimitPairing: vi.fn(() => false),
     });
     await handleAuthRoutes(ctx);
@@ -293,7 +293,7 @@ describe("POST /api/auth/pair", () => {
     const { ctx, error } = makeCtx({
       method: "POST",
       pathname: "/api/auth/pair",
-      readJsonBody: vi.fn(async () => ({})),
+      readJsonBody: makeJsonBody({}),
     });
     await handleAuthRoutes(ctx);
     expect(error).toHaveBeenCalledWith(
@@ -315,7 +315,7 @@ describe("POST /api/auth/pair", () => {
     const { ctx, error } = makeCtx({
       method: "POST",
       pathname: "/api/auth/pair",
-      readJsonBody: vi.fn(async () => ({ code: "WRONG" })),
+      readJsonBody: makeJsonBody({ code: "WRONG" }),
       getPairingExpiresAt: vi.fn(() => Date.now() - 1000),
       ensurePairingCode: vi.fn(() => "ABCDEFGH"),
     });

--- a/packages/agent/src/providers/session-bridge.test.ts
+++ b/packages/agent/src/providers/session-bridge.test.ts
@@ -10,7 +10,7 @@ vi.mock("@elizaos/core", () => {
     DM: "dm",
     SELF: "self",
     GROUP: "group",
-    CHANNEL: "channel",
+    FEED: "feed",
   };
   return {
     ChannelType,
@@ -75,9 +75,9 @@ describe("resolveSessionKeyFromRoom", () => {
     ).toBe("agent:a1:discord:group:real-group");
   });
 
-  it("maps a channel room to agent:{id}:{channel}:channel:{channelId}", () => {
+  it("maps a feed room to agent:{id}:{channel}:channel:{channelId}", () => {
     const room = makeRoom({
-      type: ChannelType.CHANNEL,
+      type: ChannelType.FEED,
       source: "slack",
       channelId: "c-42",
     });

--- a/packages/agent/src/runtime/operations/cold-strategy.test.ts
+++ b/packages/agent/src/runtime/operations/cold-strategy.test.ts
@@ -2,21 +2,36 @@
  * Unit coverage for the cold reload strategy — restart closure delegation,
  * success/failure phase reporting, and intent description.
  */
+import type { AgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { createColdStrategy } from "./cold-strategy.ts";
+import type { OperationIntent, ReloadContext } from "./types.ts";
 
-function makeCtx(overrides: Partial<Record<string, unknown>> = {}) {
+function makeRuntime(id: string): AgentRuntime {
+  return { agentId: id } as AgentRuntime;
+}
+
+function makeCtx(
+  intent: OperationIntent = { kind: "restart", reason: "manual" },
+) {
+  const reportPhase = vi.fn<ReloadContext["reportPhase"]>(async () => {});
   return {
-    intent: { kind: "restart", reason: "manual" },
-    reportPhase: vi.fn(),
-    ...overrides,
-  } as never;
+    runtime: makeRuntime("current-runtime"),
+    intent,
+    reportPhase,
+  } satisfies ReloadContext;
+}
+
+function restartWith(runtime: AgentRuntime | null) {
+  return vi.fn<(reason: string) => Promise<AgentRuntime | null>>(
+    async () => runtime,
+  );
 }
 
 describe("createColdStrategy", () => {
   it("reports a succeeded phase and returns the new runtime", async () => {
-    const newRuntime = { id: "rt-2" };
-    const restartRuntime = vi.fn(async () => newRuntime);
+    const newRuntime = makeRuntime("rt-2");
+    const restartRuntime = restartWith(newRuntime);
     const ctx = makeCtx();
     const strategy = createColdStrategy({ restartRuntime });
 
@@ -33,7 +48,7 @@ describe("createColdStrategy", () => {
   });
 
   it("reports a failed phase and throws when restart returns null", async () => {
-    const restartRuntime = vi.fn(async () => null);
+    const restartRuntime = restartWith(null);
     const ctx = makeCtx();
     const strategy = createColdStrategy({ restartRuntime });
 
@@ -52,38 +67,34 @@ describe("createColdStrategy", () => {
   });
 
   it("describes a provider-switch intent in the restart reason", async () => {
-    const restartRuntime = vi.fn(async () => ({ id: "rt" }));
-    const ctx = makeCtx({
-      intent: { kind: "provider-switch", provider: "anthropic" },
-    });
+    const restartRuntime = restartWith(makeRuntime("rt"));
+    const ctx = makeCtx({ kind: "provider-switch", provider: "anthropic" });
     const strategy = createColdStrategy({ restartRuntime });
     await strategy.apply(ctx);
     expect(restartRuntime).toHaveBeenCalledWith("provider switch to anthropic");
   });
 
   it("describes config-reload intent", async () => {
-    const restartRuntime = vi.fn(async () => ({ id: "rt" }));
-    const ctx = makeCtx({ intent: { kind: "config-reload" } });
+    const restartRuntime = restartWith(makeRuntime("rt"));
+    const ctx = makeCtx({ kind: "config-reload" });
     const strategy = createColdStrategy({ restartRuntime });
     await strategy.apply(ctx);
     expect(restartRuntime).toHaveBeenCalledWith("config reload");
   });
 
   it("describes plugin enable/disable intents", async () => {
-    const restartRuntime = vi.fn(async () => ({ id: "rt" }));
+    const restartRuntime = restartWith(makeRuntime("rt"));
     const strategy = createColdStrategy({ restartRuntime });
-    await strategy.apply(
-      makeCtx({ intent: { kind: "plugin-enable", pluginId: "p1" } }),
-    );
+    await strategy.apply(makeCtx({ kind: "plugin-enable", pluginId: "p1" }));
     expect(restartRuntime).toHaveBeenLastCalledWith("plugin enable: p1");
-    await strategy.apply(
-      makeCtx({ intent: { kind: "plugin-disable", pluginId: "p2" } }),
-    );
+    await strategy.apply(makeCtx({ kind: "plugin-disable", pluginId: "p2" }));
     expect(restartRuntime).toHaveBeenLastCalledWith("plugin disable: p2");
   });
 
   it("propagates restartRuntime rejection", async () => {
-    const restartRuntime = vi.fn(async () => {
+    const restartRuntime = vi.fn<
+      (reason: string) => Promise<AgentRuntime | null>
+    >(async () => {
       throw new Error("boot failed");
     });
     const ctx = makeCtx();
@@ -92,7 +103,9 @@ describe("createColdStrategy", () => {
   });
 
   it("has the cold tier", () => {
-    const strategy = createColdStrategy({ restartRuntime: vi.fn() });
+    const strategy = createColdStrategy({
+      restartRuntime: vi.fn<(reason: string) => Promise<AgentRuntime | null>>(),
+    });
     expect(strategy.tier).toBe("cold");
   });
 });


### PR DESCRIPTION
Closes #23302.

## Summary

Restores the `packages/agent` typecheck after test-only drift without weakening production contracts:

- auth-route tests now use the real generic request-body reader signature and correctly typed JSON/error recorders
- token absence uses the production `null` contract instead of an invalid `undefined` mock
- session-bridge coverage uses current `ChannelType.FEED` for the non-DM channel projection instead of removed `CHANNEL`
- cold-restart tests supply typed `AgentRuntime`, `ReloadContext`, phase reporter, and restart function fixtures

No production source changes.

## Exact-head verification

Head: `6a5c2c9ae58180b47caedaea1d84a9d3a13865e4` rebased onto `develop@54764fae42`.

- focused auth/session/cold-restart tests: 34/34 pass
- `bun run --cwd packages/agent typecheck`: pass
- `bun run --cwd packages/agent lint:check`: pass across 986 files
- touched-file Biome: pass
- `git diff --check`: pass

A root install/verify is not claimed locally because concurrent worktree materialization reduced free disk below a safe install threshold; hosted exact-head gates are required before merge.

## Attribution

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - repository completion workflow
Attribution status: self-reported

<!-- evidence-head:6a5c2c9ae58180b47caedaea1d84a9d3a13865e4 -->
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - repository completion workflow"} -->
