### PR TITLE
fix(cloud): certify canonical manual staging releases

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -274,7 +274,7 @@ jobs:
               --arg repo "$GITHUB_REPOSITORY" \
               '.status == "completed"
                 and .conclusion == "success"
-                and .event == "push"
+                and (.event == "push" or .event == "workflow_dispatch")
                 and .head_branch == "develop"
                 and .path == ".github/workflows/cloud-cf-deploy.yml"
                 and .repository.full_name == $repo' \
@@ -392,7 +392,10 @@ jobs:
     needs: release
     # A superseded release ends neutrally without mutating anything, so its
     # tree was never actually deployed and must not receive a certification.
-    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.release.result == 'success' && needs.release.outputs.superseded != 'true' }}
+    # A canonical manual staging dispatch is equally authoritative after the
+    # same release and routing checks; supporting it makes intentional pinned
+    # releases certifiable when develop is moving faster than hosted runners.
+    if: ${{ always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/develop' && needs.release.result == 'success' && needs.release.outputs.superseded != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -427,6 +430,7 @@ jobs:
             --repository "$GITHUB_REPOSITORY" \
             --run-id "$GITHUB_RUN_ID" \
             --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --event "$GITHUB_EVENT_NAME" \
             --source-sha "$GITHUB_SHA" \
             --tree-sha "$tree_sha" \
             --artifact-name "$artifact_name" \

--- a/packages/cloud/scripts/staging-release-certification.mjs
+++ b/packages/cloud/scripts/staging-release-certification.mjs
@@ -16,7 +16,7 @@ export const CERTIFICATION_SCHEMA =
   "eliza.cloud.staging-release-certification/v1";
 export const CERTIFICATION_WORKFLOW = ".github/workflows/cloud-cf-deploy.yml";
 export const CERTIFICATION_ENVIRONMENT = "staging";
-export const CERTIFICATION_EVENT = "push";
+export const CERTIFICATION_EVENTS = ["push", "workflow_dispatch"];
 export const CERTIFICATION_REF = "refs/heads/develop";
 export const CERTIFICATION_ARTIFACT_PREFIX = "cloud-staging-certification-v1-";
 export const CERTIFICATION_FILENAME = "staging-cloud-certification.json";
@@ -86,6 +86,7 @@ export function createStagingReleaseCertification({
   sourceSha,
   treeSha,
   workflowSha256,
+  event = "push",
   artifactName = artifactNameForTree(treeSha),
   issuedAt = new Date().toISOString(),
   expiresAt,
@@ -96,6 +97,10 @@ export function createStagingReleaseCertification({
   requireString(sourceSha, "source SHA", SHA40);
   requireString(treeSha, "tree SHA", SHA40);
   requireString(workflowSha256, "workflow SHA-256", SHA256);
+  requireString(event, "event");
+  if (!CERTIFICATION_EVENTS.includes(event)) {
+    fail("event is not an admitted staging release trigger");
+  }
   if (artifactName !== artifactNameForTree(treeSha)) {
     fail("artifact name does not bind the certified tree");
   }
@@ -113,7 +118,7 @@ export function createStagingReleaseCertification({
     workflow: CERTIFICATION_WORKFLOW,
     workflow_sha256: workflowSha256,
     environment: CERTIFICATION_ENVIRONMENT,
-    event: CERTIFICATION_EVENT,
+    event,
     ref: CERTIFICATION_REF,
     run_id: String(runId),
     run_attempt: String(runAttempt),
@@ -154,8 +159,11 @@ export function verifyStagingReleaseCertification({
   if (cert.environment !== CERTIFICATION_ENVIRONMENT) {
     fail("environment is not staging");
   }
-  if (cert.event !== CERTIFICATION_EVENT || cert.ref !== CERTIFICATION_REF) {
-    fail("certificate is not from a develop push");
+  if (
+    !CERTIFICATION_EVENTS.includes(cert.event) ||
+    cert.ref !== CERTIFICATION_REF
+  ) {
+    fail("certificate is not from an admitted develop release");
   }
   requireString(cert.source_sha, "certificate source SHA", SHA40);
   requireString(cert.tree_sha, "certificate tree SHA", SHA40);
@@ -197,7 +205,8 @@ export function verifyStagingReleaseCertification({
     fail("originating run did not complete successfully");
   }
   if (
-    runMetadata.event !== CERTIFICATION_EVENT ||
+    !CERTIFICATION_EVENTS.includes(runMetadata.event) ||
+    runMetadata.event !== cert.event ||
     runMetadata.head_branch !== "develop" ||
     runMetadata.path !== CERTIFICATION_WORKFLOW
   ) {
@@ -287,6 +296,7 @@ function runCli(argv) {
       sourceSha: args["source-sha"],
       treeSha: args["tree-sha"],
       workflowSha256: sha256File(workflowFile),
+      event: args.event ?? "push",
       artifactName: args["artifact-name"],
       issuedAt: args["issued-at"] ?? new Date().toISOString(),
     });

--- a/packages/cloud/scripts/staging-release-certification.test.mjs
+++ b/packages/cloud/scripts/staging-release-certification.test.mjs
@@ -114,6 +114,23 @@ describe("staging release certification payload", () => {
     });
   });
 
+  test("accepts an explicit canonical staging dispatch", () => {
+    const input = fixture();
+    input.certification = createStagingReleaseCertification({
+      repository: "elizaOS/eliza",
+      runId: "12345",
+      runAttempt: "2",
+      sourceSha,
+      treeSha,
+      workflowSha256,
+      event: "workflow_dispatch",
+      artifactName,
+      issuedAt,
+    });
+    input.run.event = "workflow_dispatch";
+    expect(verifyStagingReleaseCertification(input).treeSha).toBe(treeSha);
+  });
+
   test.each([
     ["wrong tree", (input) => (input.expectedTreeSha = "e".repeat(40))],
     [
@@ -128,10 +145,7 @@ describe("staging release certification payload", () => {
       "wrong environment",
       (input) => (input.certification.environment = "production"),
     ],
-    [
-      "wrong event",
-      (input) => (input.certification.event = "workflow_dispatch"),
-    ],
+    ["wrong event", (input) => (input.certification.event = "pull_request")],
     ["wrong ref", (input) => (input.certification.ref = "refs/heads/main")],
     ["expired", (input) => (input.now = "2026-08-30T12:00:00.000Z")],
     [
@@ -149,7 +163,8 @@ describe("staging release certification payload", () => {
   test.each([
     ["failed", (run) => (run.conclusion = "failure")],
     ["incomplete", (run) => (run.status = "in_progress")],
-    ["manual", (run) => (run.event = "workflow_dispatch")],
+    ["pull request", (run) => (run.event = "pull_request")],
+    ["event mismatch", (run) => (run.event = "workflow_dispatch")],
     ["main", (run) => (run.head_branch = "main")],
     ["wrong workflow", (run) => (run.path = ".github/workflows/ci.yml")],
     ["wrong repository", (run) => (run.repository.full_name = "attacker/fork")],
@@ -275,14 +290,16 @@ describe("staging release certification CLI", () => {
 });
 
 describe("Cloud CF workflow staging certification gate", () => {
-  test("emits a certificate only after a successful develop push release", () => {
+  test("emits a certificate only after a successful canonical develop release", () => {
     const block = jobBlock(workflow, "certify-staging-release");
     expect(block).toContain("needs: release");
     expect(block).toContain("github.event_name == 'push'");
+    expect(block).toContain("github.event_name == 'workflow_dispatch'");
     expect(block).toContain("github.ref == 'refs/heads/develop'");
     expect(block).toContain("needs.release.result == 'success'");
     expect(block).toContain("git rev-parse 'HEAD^{tree}'");
     expect(block).toContain("staging-release-certification.mjs create");
+    expect(block).toContain('--event "$GITHUB_EVENT_NAME"');
     expect(block).toContain(
       "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
     );
@@ -299,7 +316,9 @@ describe("Cloud CF workflow staging certification gate", () => {
     expect(validate).toContain("ref: $" + "{{ github.sha }}");
     expect(validate).toContain("persist-credentials: false");
     expect(validate).toContain("git rev-parse 'HEAD^{tree}'");
-    expect(validate).toContain('event == "push"');
+    expect(validate).toContain(
+      '(.event == "push" or .event == "workflow_dispatch")',
+    );
     expect(validate).toContain('head_branch == "develop"');
     expect(validate).toContain(
       'path == ".github/workflows/cloud-cf-deploy.yml"',


### PR DESCRIPTION
Closes #23305.

## What changed

- allows the post-release certification job for canonical `develop` push or `workflow_dispatch` staging runs
- records the actual admitted event in the tree-bound certificate
- requires certificate/run event parity and allows only `push` or `workflow_dispatch`
- keeps exact workflow bytes, Git tree, successful run, canonical branch/workflow/repository, immutable artifact digest/ownership, expiry, and production authorization checks

## Verification

- `bun test packages/cloud/scripts/staging-release-certification.test.mjs` — 30 passed
- `bunx biome check packages/cloud/scripts/staging-release-certification.mjs packages/cloud/scripts/staging-release-certification.test.mjs` — passed
- `git diff --check` — passed
- deployed pinned staging run 32442267806 completed migrations, API, Pages, and routing successfully; health served exact `44c82ac3efe571f452495df5d0f44c57d92e51e9`, while the old event-only certificate condition skipped as reproduced

Published as an exact one-commit child of current `develop` (`54764fae42cad3ef9361d7cf198ad6acee0b6a06`) using the immutable Git tree API because the shared host disk was at 100%; the three edited base blobs were verified identical to the locally tested base before publication.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Attribution status: self-reported
— [codex-cloud-release-gate]