### PR TITLE
fix(agent): unify configured remote command timeout

### DIFF
--- a/packages/agent/src/services/e2b-capability-router.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.test.ts
@@ -1049,6 +1049,35 @@ describe("E2BRemoteCapabilityRouterService", () => {
     }
   });
 
+  it("reports the timeout selected before command options are mutated", async () => {
+    const originalFetch = globalThis.fetch;
+    replaceGlobalFetch(healthThenProcessFetch(hungFetch));
+    const service = new E2BRemoteCapabilityRouterService(
+      makeRuntime(),
+      makeConfig({
+        provider: "home",
+        remoteHttpBaseUrl: "https://remote-runner.test",
+        remoteHttpToken: "token",
+        timeoutMs: 5_000,
+        requestTimeoutMs: 5_000,
+      }),
+    );
+    const sandbox = await (
+      service as unknown as { getSandbox(): Promise<E2BSandboxClient> }
+    ).getSandbox();
+    const options = { requestTimeoutMs: 50 };
+    try {
+      const command = sandbox.commands.run("sleep 30", options);
+      options.requestTimeoutMs = 5_000;
+      await expect(command).rejects.toMatchObject({
+        name: "TimeoutError",
+        message: expect.stringMatching(/timed out.*50ms/i),
+      });
+    } finally {
+      replaceGlobalFetch(originalFetch);
+    }
+  });
+
   it.each([0, -1, Number.NaN, 2_147_483_648])(
     "rejects an invalid explicit command timeout without dispatching it (%s)",
     async (timeoutMs) => {

--- a/packages/agent/src/services/e2b-capability-router.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.test.ts
@@ -1071,7 +1071,7 @@ describe("E2BRemoteCapabilityRouterService", () => {
           code: "CAPABILITY_REQUEST_FAILED",
           capability: "pty",
           method: "pty.command.run",
-          message: expect.stringMatching(/timeout must be an integer/i),
+          message: expect.stringMatching(/duration must be an integer/i),
         });
         expect(processCalls).toBe(0);
       } finally {

--- a/packages/agent/src/services/e2b-capability-router.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.test.ts
@@ -588,6 +588,18 @@ describe("E2BRemoteCapabilityRouterService", () => {
     expect(config.agentRunners).toEqual(["codex", "claude-code", "opencode"]);
   });
 
+  it("rejects runner timeout settings that overflow the JavaScript timer range", () => {
+    expect(() =>
+      resolveE2BRemoteRunnerConfig(
+        makeRuntime({
+          ELIZA_CODING_REMOTE_RUNNER: "home",
+          ELIZA_HOME_REMOTE_RUNNER_URL: "http://home.local:2468",
+          ELIZA_HOME_REMOTE_RUNNER_REQUEST_TIMEOUT_MS: "2147483648",
+        }),
+      ),
+    ).toThrow(/must be an integer between 1 and 2147483647/i);
+  });
+
   it("keeps Vercel, Cloudflare, and Rivet as disabled direct providers", () => {
     for (const provider of ["vercel", "cloudflare", "rivet"]) {
       expect(() =>
@@ -1007,6 +1019,66 @@ describe("E2BRemoteCapabilityRouterService", () => {
       replaceGlobalFetch(originalFetch);
     }
   });
+
+  it("preserves a structured timeout returned by the remote runner", async () => {
+    const originalFetch = globalThis.fetch;
+    replaceGlobalFetch(
+      healthThenProcessFetch(async () =>
+        jsonResponse(200, {
+          exitCode: 124,
+          stdout: "partial output",
+          stderr: "command deadline reached",
+          timedOut: true,
+        }),
+      ),
+    );
+    const service = new E2BRemoteCapabilityRouterService(
+      makeRuntime(),
+      remoteCommandTimeoutConfig(),
+    );
+    try {
+      await expect(
+        service.pty.runCommand({ command: "sleep", args: ["30"] }),
+      ).resolves.toEqual({
+        output: "partial output\ncommand deadline reached",
+        exitCode: 124,
+        timedOut: true,
+      });
+    } finally {
+      replaceGlobalFetch(originalFetch);
+    }
+  });
+
+  it.each([0, -1, Number.NaN, 2_147_483_648])(
+    "rejects an invalid explicit command timeout without dispatching it (%s)",
+    async (timeoutMs) => {
+      const originalFetch = globalThis.fetch;
+      let processCalls = 0;
+      replaceGlobalFetch(
+        healthThenProcessFetch(async () => {
+          processCalls += 1;
+          return jsonResponse(200, { exitCode: 0, stdout: "", stderr: "" });
+        }),
+      );
+      const service = new E2BRemoteCapabilityRouterService(
+        makeRuntime(),
+        remoteCommandTimeoutConfig(),
+      );
+      try {
+        await expect(
+          service.pty.runCommand({ command: "echo", timeoutMs }),
+        ).rejects.toMatchObject({
+          code: "CAPABILITY_REQUEST_FAILED",
+          capability: "pty",
+          method: "pty.command.run",
+          message: expect.stringMatching(/timeout must be an integer/i),
+        });
+        expect(processCalls).toBe(0);
+      } finally {
+        replaceGlobalFetch(originalFetch);
+      }
+    },
+  );
 
   it("returns timedOut from pty.runCommand when process headers arrive then the body stalls", async () => {
     const originalFetch = globalThis.fetch;

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -1162,7 +1162,7 @@ function timeoutSignal(ms: number | undefined): {
   }
   if (!Number.isSafeInteger(ms) || ms <= 0 || ms > MAX_TIMER_TIMEOUT_MS) {
     throw new RangeError(
-      `Timeout must be an integer between 1 and ${MAX_TIMER_TIMEOUT_MS}ms.`,
+      `Duration must be an integer between 1 and ${MAX_TIMER_TIMEOUT_MS}ms.`,
     );
   }
   const controller = new AbortController();

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -1500,10 +1500,7 @@ function commandRunResult(
   return {
     output: `${result.stdout}${stderr}`,
     exitCode: result.exitCode,
-    timedOut:
-      timedOut ||
-      (result as SandboxCommandResult & { timedOut?: unknown }).timedOut ===
-        true,
+    timedOut: timedOut || result.timedOut === true,
   };
 }
 

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -330,9 +330,9 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
     cmd: string,
     opts: SandboxCommandRunOptions = {},
   ): Promise<SandboxCommandResult> {
-    const timeout = timeoutSignal(
-      opts.timeoutMs ?? opts.requestTimeoutMs ?? this.requestTimeoutMs,
-    );
+    const effectiveTimeoutMs =
+      opts.timeoutMs ?? opts.requestTimeoutMs ?? this.requestTimeoutMs;
+    const timeout = timeoutSignal(effectiveTimeoutMs);
     try {
       const response = await fetch(`${this.apiBase}/v1/processes/run`, {
         method: "POST",
@@ -373,9 +373,7 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
       };
     } catch (error) {
       if (timeout.timedOut()) {
-        throw createTimeoutError(
-          opts.timeoutMs ?? opts.requestTimeoutMs ?? this.requestTimeoutMs,
-        );
+        throw createTimeoutError(effectiveTimeoutMs);
       }
       throw error;
     } finally {

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -61,6 +61,7 @@ const DEFAULT_E2B_WORKDIR = "/home/user";
 const DEFAULT_REMOTE_WORKDIR = "/workspace";
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 60 * 1000;
+const MAX_TIMER_TIMEOUT_MS = 2_147_483_647;
 const MAX_READ_BYTES = 5 * 1024 * 1024;
 const MAX_LIST_LIMIT = 1000;
 
@@ -370,6 +371,7 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
         exitCode,
         stdout,
         stderr: typeof payload.stderr === "string" ? payload.stderr : "",
+        ...(payload.timedOut === true ? { timedOut: true } : {}),
       };
     } catch (error) {
       if (timeout.timedOut()) {
@@ -1151,12 +1153,17 @@ function timeoutSignal(ms: number | undefined): {
   dispose(): void;
   timedOut(): boolean;
 } {
-  if (!ms) {
+  if (ms === undefined) {
     return {
       signal: undefined,
       dispose: () => {},
       timedOut: () => false,
     };
+  }
+  if (!Number.isSafeInteger(ms) || ms <= 0 || ms > MAX_TIMER_TIMEOUT_MS) {
+    throw new RangeError(
+      `Timeout must be an integer between 1 and ${MAX_TIMER_TIMEOUT_MS}ms.`,
+    );
   }
   const controller = new AbortController();
   const reason = createTimeoutError(ms);
@@ -1428,8 +1435,16 @@ function positiveIntSetting(
   const value = readSetting(runtime, key);
   if (value === undefined) return fallback;
   const parsed = Number(value);
-  if (Number.isInteger(parsed) && parsed > 0) return parsed;
-  throw new Error(`${key} must be a positive integer.`);
+  if (
+    Number.isSafeInteger(parsed) &&
+    parsed > 0 &&
+    parsed <= MAX_TIMER_TIMEOUT_MS
+  ) {
+    return parsed;
+  }
+  throw new Error(
+    `${key} must be an integer between 1 and ${MAX_TIMER_TIMEOUT_MS}.`,
+  );
 }
 
 function agentRunnersSetting(
@@ -1485,7 +1500,10 @@ function commandRunResult(
   return {
     output: `${result.stdout}${stderr}`,
     exitCode: result.exitCode,
-    timedOut,
+    timedOut:
+      timedOut ||
+      (result as SandboxCommandResult & { timedOut?: unknown }).timedOut ===
+        true,
   };
 }
 

--- a/packages/core/src/capabilities/sandbox-factory.ts
+++ b/packages/core/src/capabilities/sandbox-factory.ts
@@ -44,6 +44,7 @@ export interface SandboxCommandResult {
 	stdout: string;
 	stderr: string;
 	error?: string;
+	timedOut?: boolean;
 }
 
 export interface SandboxFileCapability {


### PR DESCRIPTION
Corrective follow-up to #23296. Fixes #23289.

The merged implementation selected the timeout expression once for the abort signal and again after the asynchronous fetch rejected. A caller that retained and mutated its options could therefore receive an error naming a different timeout from the timer that fired. This correction snapshots one effective timeout and uses it for both the signal and the resulting error.

The independent review also closes two adjacent timeout-contract gaps:

- preserves a remote runner structured `{ timedOut: true }` result, including partial stdout/stderr, through the typed `SandboxCommandResult` contract;
- rejects zero, negative, non-finite, unsafe, and greater-than-`2^31 - 1` timeout values before dispatch so JavaScript timer overflow cannot turn a huge configured timeout into an immediate abort.

## Exact-head verification

Head: `2cb837c5bcaee2ba257f8523f9ba800e7a6fb869`
Rebased base: `9f6e368bd14b6e73c31cf55fd650034a6198551f`

- Focused Vitest: `38/38` passed. This includes configured fallback, explicit override, caller mutation, structured remote timeout, pre-header abort, stalled response body, and four invalid-duration cases.
- `bun run --cwd packages/agent typecheck`: passed.
- `bun run --cwd packages/core typecheck`: passed.
- Changed-file Biome and `git diff --check`: passed.
- `bun run --cwd packages/core build`: Node, browser, edge, testing, declarations, packed edge import, packed conditional consumers, and exact-flat Vite consumer all passed.
- Full agent lint was executed and is blocked only by pre-existing formatting in `src/api/http-access-context.test.ts`, which is outside this diff; all three changed files pass Biome.

The public capability types and runner documentation do not define `timeoutMs: 0` as an unbounded sentinel. All PTY callers found use positive configured durations.

## Evidence matrix

<!-- evidence-head:2cb837c5bcaee2ba257f8523f9ba800e7a6fb869 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only timeout and transport-contract correction.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-interface journey changed.
<!-- evidence-row:backend-logs -->
<details><summary>Exact-head focused and static verification transcript</summary>

```text
RUN v4.1.10 /private/tmp/eliza-fix23289/packages/agent
Test Files  1 passed (1); Tests  38 passed (38); Duration 21.41s
Agent tsc --noEmit -p tsconfig.json: exit 0; Core tsc --noEmit -p tsconfig.json: exit 0
Changed-file Biome: Checked 3 files, no fixes applied; git diff --check: exit 0
Core build: Node, browser, edge, testing, declarations, packed imports, and exact-flat Vite consumer passed
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend execution path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior changed.
<!-- evidence-row:domain-artifacts -->
<details><summary>Timeout contract observations</summary>

```text
Configured fallback and explicit per-command override both aborted the hanging production fetch path at their selected deadline.
Mutating the retained options after dispatch still produced the original 50ms TimeoutError, proving one immutable selected timeout.
A remote `{ timedOut: true }` response preserved exit 124 plus partial stdout/stderr and surfaced `timedOut: true` through the typed result.
Explicit 0, -1, NaN, and 2147483648 durations failed before process dispatch; overflowed configured duration failed during config resolution.
```
</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact.

## Contribution provenance

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop"} -->