### PR TITLE
test(core): cover HTML raw-text delimiter matrix

### DIFF
--- a/packages/core/src/utils/html-raw-text.test.ts
+++ b/packages/core/src/utils/html-raw-text.test.ts
@@ -25,6 +25,36 @@ describe("stripHtmlRawTextElements", () => {
 		).toBe("before after");
 	});
 
+	it.each(["!", "?", "=", "-", "_", "\u00a0"])(
+		"keeps raw text past the invalid %j end-tag delimiter",
+		(delimiter) => {
+			for (const tag of ["script", "style"] as const) {
+				expect(
+					stripHtmlRawTextElements(
+						`before<${tag}>first</${tag}${delimiter}fake>second</${tag}>after`,
+					),
+				).toBe("before after");
+			}
+		},
+	);
+
+	it.each([" ", "\t", "\n", "\f", "\r"])(
+		"accepts the ASCII-whitespace %j end-tag delimiter",
+		(delimiter) => {
+			expect(
+				stripHtmlRawTextElements(
+					`before<style>hidden</style${delimiter}data-x=1>after`,
+				),
+			).toBe("before after");
+		},
+	);
+
+	it("accepts an end-tag name followed by EOF", () => {
+		expect(stripHtmlRawTextElements("before<script>hidden</script")).toBe(
+			"before ",
+		);
+	});
+
 	it.each(["<script>hidden", "<style data-x='>' hidden"])(
 		"removes an unclosed raw-text element through EOF",
 		(markup) => {


### PR DESCRIPTION
## Summary

- retain the unique boundary evidence from the original draft after #23316 superseded its duplicated regex changes with the shared tokenizer
- cover every accepted raw-text end-tag boundary: EOF, `>`, `/`, and all five ASCII-whitespace code points
- cover representative rejected boundaries (`!`, `?`, `=`, `-`, `_`, and non-breaking space) for both `script` and `style`

The production fix and all five consumers were merged in #23316. This PR is now intentionally test-only and no longer carries the obsolete per-consumer regex implementation.

Relates to #22087 and #23316.

## Verification

- exact-head tokenizer suite: 22 passed, 0 failed, 28 assertions
- direct caller-shape probes for `</script!fake>` and `</style?fake>` remain inside raw text until a valid closer
- repository-pinned Biome passed on the changed test
- `git diff --check` passed
- broad core typecheck is blocked by sparse-review missing workspace and optional dependency declarations; no changed-file diagnostic was reported

The delimiter expectations match the WHATWG RAWTEXT/script-data end-tag-name states: only ASCII whitespace, `/`, or `>` transition to an accepted appropriate end tag, while EOF is handled without leaking the raw-text body.

## Evidence Gate

<!-- evidence-head:e34ab5dd9bf6eae9ccbd29de702ae6a6fcb8c1bd -->

- [x] N/A - test-only parser coverage; no rendered pixels or interaction flow changed.
- [x] N/A - no protected backend, external account, or production state was mutated.
- [x] Domain evidence is the exact tokenizer test receipt above.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e34ab5dd9bf6eae9ccbd29de702ae6a6fcb8c1bd:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@e34ab5dd9bf6eae9ccbd29de702ae6a6fcb8c1bd:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-codeql-html-end-tags]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@e34ab5dd9bf6eae9ccbd29de702ae6a6fcb8c1bd:packages/skills/skills/contribute-to-eliza"} -->
