### PR TITLE
fix(agent): bound remote runner response bodies and teardown

### DIFF
--- a/packages/agent/src/services/e2b-capability-router.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.test.ts
@@ -920,7 +920,7 @@ describe("E2BRemoteCapabilityRouterService", () => {
 
       await expect(service.fs.list({ path: "/repo" })).rejects.toMatchObject({
         name: "TimeoutError",
-        message: "Remote runner request timed out.",
+        message: expect.stringMatching(/timed out.*20ms/i),
       });
       expect(bodyWasCancelled).toBe(true);
     } finally {

--- a/packages/agent/src/services/e2b-capability-router.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.test.ts
@@ -107,6 +107,7 @@ type RemoteRunnerHttpCall = {
   method: string;
   pathname: string;
   authorization: string | null;
+  redirect: RequestRedirect;
   body: unknown;
 };
 
@@ -278,6 +279,7 @@ function startElizaCloudProvisioningServer(): RemoteRunnerHttpServer {
           method: request.method,
           pathname: url.pathname,
           authorization: request.headers.get("authorization"),
+          redirect: request.redirect,
           body: parseRequestBody(request, bodyText),
         });
         return jsonResponse(201, {
@@ -341,6 +343,7 @@ function recordRemoteRunnerHttpCall(
     method: context.request.method,
     pathname: context.url.pathname,
     authorization: context.request.headers.get("authorization"),
+    redirect: context.request.redirect,
     body: context.body,
   });
 }
@@ -621,6 +624,22 @@ describe("E2BRemoteCapabilityRouterService", () => {
     expect(config.agentRunners).toEqual(["claude-code", "codex"]);
   });
 
+  it("rejects request timeouts outside the platform timer range", () => {
+    for (const value of ["0", "1.5", "2147483648"]) {
+      expect(() =>
+        resolveE2BRemoteRunnerConfig(
+          makeRuntime({
+            ELIZA_CODING_REMOTE_RUNNER: "home",
+            ELIZA_HOME_REMOTE_RUNNER_URL: "http://home.local:2468",
+            ELIZA_HOME_REMOTE_RUNNER_REQUEST_TIMEOUT_MS: value,
+          }),
+        ),
+      ).toThrow(
+        "ELIZA_HOME_REMOTE_RUNNER_REQUEST_TIMEOUT_MS must be an integer from 1 to 2147483647.",
+      );
+    }
+  });
+
   it("reports structured unavailable when credentials are missing", async () => {
     const service = new E2BRemoteCapabilityRouterService(
       makeRuntime(),
@@ -830,11 +849,367 @@ describe("E2BRemoteCapabilityRouterService", () => {
         expect(
           server.calls.every((call) => call.authorization === "Bearer token"),
         ).toBe(true);
+        expect(server.calls.every((call) => call.redirect === "error")).toBe(
+          true,
+        );
       } finally {
         await server.close();
       }
     },
   );
+
+  it("keeps the remote request deadline active through response-body consumption", async () => {
+    const originalFetch = globalThis.fetch;
+    let bodyWasCancelled = false;
+    const fetchMock: typeof fetch = Object.assign(
+      async (
+        _input: Parameters<typeof fetch>[0],
+        init?: Parameters<typeof fetch>[1],
+      ): Promise<Response> => {
+        const signal = init?.signal;
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("{"));
+              signal?.addEventListener(
+                "abort",
+                () => {
+                  bodyWasCancelled = true;
+                  controller.error(signal.reason);
+                },
+                { once: true },
+              );
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        );
+      },
+      { preconnect: originalFetch.preconnect },
+    );
+    replaceGlobalFetch(fetchMock);
+    try {
+      const service = new E2BRemoteCapabilityRouterService(
+        makeRuntime(),
+        makeConfig({
+          provider: "home",
+          apiKey: undefined,
+          remoteHttpBaseUrl: "https://remote-runner.test",
+          requestTimeoutMs: 20,
+        }),
+      );
+
+      await expect(service.fs.list({ path: "/repo" })).rejects.toMatchObject({
+        name: "TimeoutError",
+        message: "Remote runner request timed out.",
+      });
+      expect(bodyWasCancelled).toBe(true);
+    } finally {
+      replaceGlobalFetch(originalFetch);
+    }
+  });
+
+  it("rejects responses whose declared length exceeds the operation cap", async () => {
+    const originalFetch = globalThis.fetch;
+    let bodyWasCancelled = false;
+    const fetchMock: typeof fetch = Object.assign(
+      async (): Promise<Response> =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              controller.enqueue(new Uint8Array([123]));
+              controller.close();
+            },
+            cancel() {
+              bodyWasCancelled = true;
+            },
+          }),
+          { headers: { "content-length": "16385" } },
+        ),
+      { preconnect: originalFetch.preconnect },
+    );
+    replaceGlobalFetch(fetchMock);
+    try {
+      const service = new E2BRemoteCapabilityRouterService(
+        makeRuntime(),
+        makeConfig({
+          provider: "home",
+          apiKey: undefined,
+          remoteHttpBaseUrl: "https://remote-runner.test",
+        }),
+      );
+
+      await expect(service.fs.list({ path: "/repo" })).rejects.toMatchObject({
+        name: "RemoteResponseTooLargeError",
+        code: "REMOTE_RESPONSE_TOO_LARGE",
+      });
+      expect(bodyWasCancelled).toBe(true);
+    } finally {
+      replaceGlobalFetch(originalFetch);
+    }
+  });
+
+  it("does not expose untrusted remote error bodies", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock: typeof fetch = Object.assign(
+      async (): Promise<Response> =>
+        new Response("secret-internal-runner-detail", { status: 500 }),
+      { preconnect: originalFetch.preconnect },
+    );
+    replaceGlobalFetch(fetchMock);
+    try {
+      const service = new E2BRemoteCapabilityRouterService(
+        makeRuntime(),
+        makeConfig({
+          provider: "home",
+          apiKey: undefined,
+          remoteHttpBaseUrl: "https://remote-runner.test",
+        }),
+      );
+
+      await expect(service.fs.list({ path: "/repo" })).rejects.toThrow(
+        "Remote runner health check failed with HTTP 500.",
+      );
+      await expect(service.fs.list({ path: "/repo" })).rejects.not.toThrow(
+        "secret-internal-runner-detail",
+      );
+    } finally {
+      replaceGlobalFetch(originalFetch);
+    }
+  });
+
+  it("does not expose transport diagnostics from the remote boundary", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock: typeof fetch = Object.assign(
+      async (): Promise<Response> => {
+        throw new Error("connect ECONNREFUSED 10.0.0.8:4321");
+      },
+      { preconnect: originalFetch.preconnect },
+    );
+    replaceGlobalFetch(fetchMock);
+    try {
+      const service = new E2BRemoteCapabilityRouterService(
+        makeRuntime(),
+        makeConfig({
+          provider: "home",
+          apiKey: undefined,
+          remoteHttpBaseUrl: "https://remote-runner.test",
+        }),
+      );
+
+      await expect(service.fs.list({ path: "/repo" })).rejects.toThrow(
+        "Remote HTTP request failed.",
+      );
+      await expect(service.fs.list({ path: "/repo" })).rejects.not.toThrow(
+        "10.0.0.8",
+      );
+    } finally {
+      replaceGlobalFetch(originalFetch);
+    }
+  });
+
+  it("aborts a streamed response when its actual bytes exceed the cap", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock: typeof fetch = Object.assign(
+      async (): Promise<Response> =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new Uint8Array(10_000));
+              controller.enqueue(new Uint8Array(10_000));
+              controller.close();
+            },
+          }),
+        ),
+      { preconnect: originalFetch.preconnect },
+    );
+    replaceGlobalFetch(fetchMock);
+    try {
+      const service = new E2BRemoteCapabilityRouterService(
+        makeRuntime(),
+        makeConfig({
+          provider: "home",
+          apiKey: undefined,
+          remoteHttpBaseUrl: "https://remote-runner.test",
+        }),
+      );
+
+      await expect(service.fs.list({ path: "/repo" })).rejects.toMatchObject({
+        name: "RemoteResponseTooLargeError",
+      });
+    } finally {
+      replaceGlobalFetch(originalFetch);
+    }
+  });
+
+  it.each([
+    "file:///etc/passwd",
+    "https://runner:secret@remote-runner.test",
+    "https://remote-runner.test?token=secret",
+  ])(
+    "rejects an unsafe remote runner base URL without echoing it: %s",
+    async (url) => {
+      const service = new E2BRemoteCapabilityRouterService(
+        makeRuntime(),
+        makeConfig({
+          provider: "home",
+          apiKey: undefined,
+          remoteHttpBaseUrl: url,
+        }),
+      );
+
+      const failure = service.fs.list({ path: "/repo" });
+      await expect(failure).rejects.toMatchObject({
+        code: expect.stringMatching(/^REMOTE_HTTP_URL_/),
+      });
+      await expect(failure).rejects.not.toThrow(url);
+      await expect(failure).rejects.not.toThrow("secret");
+    },
+  );
+
+  it("fails closed when a process response omits its exit status", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock: typeof fetch = Object.assign(
+      async (input: Parameters<typeof fetch>[0]): Promise<Response> => {
+        const path = new URL(String(input)).pathname;
+        return path === "/v1/health"
+          ? jsonResponse(200, { ok: true })
+          : jsonResponse(200, { stdout: "looks successful" });
+      },
+      { preconnect: originalFetch.preconnect },
+    );
+    replaceGlobalFetch(fetchMock);
+    try {
+      const service = new E2BRemoteCapabilityRouterService(
+        makeRuntime(),
+        makeConfig({
+          provider: "home",
+          apiKey: undefined,
+          remoteHttpBaseUrl: "https://remote-runner.test",
+        }),
+      );
+
+      await expect(
+        service.pty.runCommand({ command: "true" }),
+      ).rejects.toMatchObject({
+        code: "CAPABILITY_REQUEST_FAILED",
+        message: "Remote runner process response omitted exit code.",
+      });
+    } finally {
+      replaceGlobalFetch(originalFetch);
+    }
+  });
+
+  it("rejects malformed file-entry metadata instead of fabricating defaults", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock: typeof fetch = Object.assign(
+      async (input: Parameters<typeof fetch>[0]): Promise<Response> => {
+        const path = new URL(String(input)).pathname;
+        return path === "/v1/health"
+          ? jsonResponse(200, { ok: true })
+          : jsonResponse(200, {
+              entries: [{ path: "/workspace/file", type: "file" }],
+            });
+      },
+      { preconnect: originalFetch.preconnect },
+    );
+    replaceGlobalFetch(fetchMock);
+    try {
+      const service = new E2BRemoteCapabilityRouterService(
+        makeRuntime(),
+        makeConfig({
+          provider: "home",
+          apiKey: undefined,
+          remoteHttpBaseUrl: "https://remote-runner.test",
+        }),
+      );
+
+      await expect(service.fs.list({ path: "/repo" })).rejects.toMatchObject({
+        code: "REMOTE_RESPONSE_SCHEMA_INVALID",
+        message:
+          "Remote runner fs entry size was not a non-negative safe integer.",
+      });
+    } finally {
+      replaceGlobalFetch(originalFetch);
+    }
+  });
+
+  it("applies the provisioning deadline to the initial Cloud request", async () => {
+    const originalFetch = globalThis.fetch;
+    let requestWasAborted = false;
+    const fetchMock: typeof fetch = Object.assign(
+      async (
+        _input: Parameters<typeof fetch>[0],
+        init?: Parameters<typeof fetch>[1],
+      ): Promise<Response> =>
+        await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => {
+              requestWasAborted = true;
+              reject(init.signal?.reason);
+            },
+            { once: true },
+          );
+        }),
+      { preconnect: originalFetch.preconnect },
+    );
+    replaceGlobalFetch(fetchMock);
+    try {
+      const service = new E2BRemoteCapabilityRouterService(
+        makeRuntime(),
+        makeConfig({
+          provider: "eliza-cloud",
+          apiKey: undefined,
+          cloudApiBaseUrl: "https://api.eliza.app/api/v1",
+          cloudApiToken: "cloud-key",
+          timeoutMs: 20,
+          requestTimeoutMs: 10_000,
+        }),
+      );
+
+      await expect(service.fs.list({ path: "/repo" })).rejects.toMatchObject({
+        name: "TimeoutError",
+      });
+      expect(requestWasAborted).toBe(true);
+    } finally {
+      replaceGlobalFetch(originalFetch);
+    }
+  });
+
+  it("rejects a private runner authority returned by the public Cloud API", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchMock: typeof fetch = Object.assign(
+      async (): Promise<Response> =>
+        jsonResponse(201, {
+          data: {
+            containerId: "cloud-container-1",
+            status: "running",
+            url: "http://169.254.169.254/latest/meta-data",
+          },
+        }),
+      { preconnect: originalFetch.preconnect },
+    );
+    replaceGlobalFetch(fetchMock);
+    try {
+      const service = new E2BRemoteCapabilityRouterService(
+        makeRuntime(),
+        makeConfig({
+          provider: "eliza-cloud",
+          apiKey: undefined,
+          cloudApiBaseUrl: "https://api.eliza.app/api/v1",
+          cloudApiToken: "cloud-key",
+        }),
+      );
+
+      await expect(service.fs.list({ path: "/repo" })).rejects.toMatchObject({
+        code: "CLOUD_CODING_CONTAINER_RUNNER_URL_REJECTED",
+        message:
+          "Eliza Cloud coding-container runner URL must use a public HTTPS authority.",
+      });
+    } finally {
+      replaceGlobalFetch(originalFetch);
+    }
+  });
 
   it("provisions an Eliza Cloud coding container before using the remote runner HTTP contract", async () => {
     const server = startElizaCloudProvisioningServer();
@@ -892,6 +1267,9 @@ describe("E2BRemoteCapabilityRouterService", () => {
           .slice(1)
           .every((call) => call.authorization === `Bearer ${remoteToken}`),
       ).toBe(true);
+      expect(server.calls.every((call) => call.redirect === "error")).toBe(
+        true,
+      );
     } finally {
       await server.close();
     }

--- a/packages/agent/src/services/e2b-capability-router.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.test.ts
@@ -132,6 +132,26 @@ function replaceGlobalFetch(fetchImpl: typeof fetch): void {
   });
 }
 
+async function settleWithin<T>(
+  promise: Promise<T>,
+  timeoutMs = 250,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("Operation did not settle after teardown.")),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 function makeRuntime(
   settings: Record<string, string> = {},
   services: Record<string, unknown> = {},
@@ -624,8 +644,8 @@ describe("E2BRemoteCapabilityRouterService", () => {
     expect(config.agentRunners).toEqual(["claude-code", "codex"]);
   });
 
-  it("rejects request timeouts outside the platform timer range", () => {
-    for (const value of ["0", "1.5", "2147483648"]) {
+  it("rejects non-canonical request timeouts and values outside the platform timer range", () => {
+    for (const value of ["0", "01", "+1", "1.0", "1e3", "2147483648"]) {
       expect(() =>
         resolveE2BRemoteRunnerConfig(
           makeRuntime({
@@ -635,7 +655,7 @@ describe("E2BRemoteCapabilityRouterService", () => {
           }),
         ),
       ).toThrow(
-        "ELIZA_HOME_REMOTE_RUNNER_REQUEST_TIMEOUT_MS must be an integer from 1 to 2147483647.",
+        "ELIZA_HOME_REMOTE_RUNNER_REQUEST_TIMEOUT_MS must be a canonical integer from 1 to 2147483647.",
       );
     }
   });
@@ -921,6 +941,7 @@ describe("E2BRemoteCapabilityRouterService", () => {
             },
             cancel() {
               bodyWasCancelled = true;
+              return new Promise<void>(() => undefined);
             },
           }),
           { headers: { "content-length": "16385" } },
@@ -938,7 +959,9 @@ describe("E2BRemoteCapabilityRouterService", () => {
         }),
       );
 
-      await expect(service.fs.list({ path: "/repo" })).rejects.toMatchObject({
+      await expect(
+        settleWithin(service.fs.list({ path: "/repo" })),
+      ).rejects.toMatchObject({
         name: "RemoteResponseTooLargeError",
         code: "REMOTE_RESPONSE_TOO_LARGE",
       });
@@ -1009,14 +1032,17 @@ describe("E2BRemoteCapabilityRouterService", () => {
 
   it("aborts a streamed response when its actual bytes exceed the cap", async () => {
     const originalFetch = globalThis.fetch;
+    let bodyWasCancelled = false;
     const fetchMock: typeof fetch = Object.assign(
       async (): Promise<Response> =>
         new Response(
           new ReadableStream<Uint8Array>({
-            start(controller) {
+            pull(controller) {
               controller.enqueue(new Uint8Array(10_000));
-              controller.enqueue(new Uint8Array(10_000));
-              controller.close();
+            },
+            cancel() {
+              bodyWasCancelled = true;
+              return new Promise<void>(() => undefined);
             },
           }),
         ),
@@ -1033,9 +1059,10 @@ describe("E2BRemoteCapabilityRouterService", () => {
         }),
       );
 
-      await expect(service.fs.list({ path: "/repo" })).rejects.toMatchObject({
-        name: "RemoteResponseTooLargeError",
-      });
+      await expect(
+        settleWithin(service.fs.list({ path: "/repo" })),
+      ).rejects.toMatchObject({ name: "RemoteResponseTooLargeError" });
+      expect(bodyWasCancelled).toBe(true);
     } finally {
       replaceGlobalFetch(originalFetch);
     }

--- a/packages/agent/src/services/e2b-capability-router.test.ts
+++ b/packages/agent/src/services/e2b-capability-router.test.ts
@@ -645,7 +645,10 @@ describe("E2BRemoteCapabilityRouterService", () => {
   });
 
   it("rejects non-canonical request timeouts and values outside the platform timer range", () => {
-    for (const value of ["0", "01", "+1", "1.0", "1e3", "2147483648"]) {
+    // Two distinct rejections: a value that is not a canonical decimal integer
+    // never reaches the range check, while a canonical value above the timer
+    // ceiling passes the shape check and is rejected on range.
+    for (const value of ["0", "01", "+1", "1.0", "1e3"]) {
       expect(() =>
         resolveE2BRemoteRunnerConfig(
           makeRuntime({
@@ -658,6 +661,18 @@ describe("E2BRemoteCapabilityRouterService", () => {
         "ELIZA_HOME_REMOTE_RUNNER_REQUEST_TIMEOUT_MS must be a canonical integer from 1 to 2147483647.",
       );
     }
+
+    expect(() =>
+      resolveE2BRemoteRunnerConfig(
+        makeRuntime({
+          ELIZA_CODING_REMOTE_RUNNER: "home",
+          ELIZA_HOME_REMOTE_RUNNER_URL: "http://home.local:2468",
+          ELIZA_HOME_REMOTE_RUNNER_REQUEST_TIMEOUT_MS: "2147483648",
+        }),
+      ),
+    ).toThrow(
+      "ELIZA_HOME_REMOTE_RUNNER_REQUEST_TIMEOUT_MS must be an integer between 1 and 2147483647.",
+    );
   });
 
   it("reports structured unavailable when credentials are missing", async () => {

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -22,6 +22,7 @@ import {
   type E2BSandboxClient,
   type E2BSandboxFactoryService,
   type ElizaCapabilityRouter,
+  ElizaError,
   type FileListParams,
   type FileListResult,
   type FileReadTextParams,
@@ -36,6 +37,8 @@ import {
   type GitStatusParams,
   type GitStatusResult,
   type IAgentRuntime,
+  isBlockedHostname,
+  isPrivateIpAddress,
   type JsonObject,
   type LocalModelStatusResult,
   logger,
@@ -61,9 +64,11 @@ const DEFAULT_E2B_WORKDIR = "/home/user";
 const DEFAULT_REMOTE_WORKDIR = "/workspace";
 const DEFAULT_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 60 * 1000;
-const MAX_TIMER_TIMEOUT_MS = 2_147_483_647;
 const MAX_READ_BYTES = 5 * 1024 * 1024;
 const MAX_LIST_LIMIT = 1000;
+const MAX_REMOTE_JSON_BYTES = 1024 * 1024;
+const MAX_REMOTE_ERROR_BYTES = 16 * 1024;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 function truncateUtf8(text: string, maxBytes: number): string {
   const prefix = Buffer.from(text, "utf8").subarray(0, maxBytes);
@@ -171,17 +176,21 @@ class RemoteRunnerHttpFactory implements E2BSandboxFactory {
         `${config.provider} runner requires a remote runner URL.`,
       );
     }
-    const apiBase = config.remoteHttpBaseUrl.replace(/\/+$/, "");
+    const apiBase = normalizeHttpBaseUrl(
+      config.remoteHttpBaseUrl,
+      `${config.provider} remote runner URL`,
+    );
     const headers = authHeaders(config.remoteHttpToken);
-    const timeout = timeoutSignal(config.requestTimeoutMs);
-    try {
-      const response = await fetch(`${apiBase}/v1/health`, {
-        headers,
-        signal: timeout.signal,
-      });
-      if (!response.ok) throw new Error(await response.text());
-    } finally {
-      timeout.dispose();
+    const result = await fetchBounded(
+      `${apiBase}/v1/health`,
+      { headers },
+      {
+        timeoutMs: config.requestTimeoutMs,
+        maxResponseBytes: MAX_REMOTE_ERROR_BYTES,
+      },
+    );
+    if (!result.response.ok) {
+      throw remoteHttpStatusError("health check", result.response.status);
     }
     return new RemoteRunnerHttpClient(
       config.provider,
@@ -195,16 +204,12 @@ class RemoteRunnerHttpFactory implements E2BSandboxFactory {
 class RemoteRunnerHttpClient implements E2BSandboxClient {
   readonly workspacePrepared = true;
   readonly files = {
-    list: (
-      path: string,
-      opts?: { depth?: number; requestTimeoutMs?: number },
-    ) => this.list(path, opts),
+    list: (path: string) => this.list(path),
     read: (
       path: string,
       opts?: { format?: "text" | "bytes"; requestTimeoutMs?: number },
     ) => this.read(path, opts),
-    write: (path: string, data: string, opts?: { requestTimeoutMs?: number }) =>
-      this.write(path, data, opts),
+    write: (path: string, data: string) => this.write(path, data),
   };
   readonly commands = {
     run: (cmd: string, opts?: SandboxCommandRunOptions) =>
@@ -220,122 +225,145 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
 
   async kill(): Promise<void> {}
 
-  private async list(
-    path: string,
-    opts?: { depth?: number; requestTimeoutMs?: number },
-  ): Promise<SandboxEntryInfo[]> {
+  private async list(path: string): Promise<SandboxEntryInfo[]> {
     const url = new URL(`${this.apiBase}/v1/fs/entries`);
     url.searchParams.set("path", path);
-    const timeout = timeoutSignal(
-      opts?.requestTimeoutMs ?? this.requestTimeoutMs,
+    const result = await fetchBounded(
+      url,
+      { headers: this.headers },
+      {
+        timeoutMs: this.requestTimeoutMs,
+        maxResponseBytes: MAX_REMOTE_JSON_BYTES,
+      },
     );
-    try {
-      const response = await fetch(url, {
-        headers: this.headers,
-        signal: timeout.signal,
-      });
-      if (!response.ok) throw new Error(await response.text());
-      const payload = await response.json();
-      const entries = Array.isArray(payload)
-        ? payload
-        : isObject(payload) && Array.isArray(payload.entries)
-          ? payload.entries
-          : null;
-      if (!entries) {
-        throw new Error("Remote runner fs entries response was not an array.");
-      }
-      return entries.map((entry) => {
-        if (!isObject(entry)) {
-          throw new Error("Remote runner fs entry was not an object.");
-        }
-        const pathValue = String(entry.path ?? "");
-        const stat: SandboxEntryInfo = {
-          path: pathValue,
-          name: String(entry.name ?? nodePath.posix.basename(pathValue)),
-          type: remoteEntryType(entry),
-          size: typeof entry.size === "number" ? entry.size : 0,
-        };
-        const modified =
-          typeof entry.modifiedAt === "string"
-            ? entry.modifiedAt
-            : typeof entry.modified === "string"
-              ? entry.modified
-              : null;
-        if (modified) {
-          stat.modifiedTime = new Date(modified);
-        }
-        return stat;
-      });
-    } finally {
-      timeout.dispose();
+    if (!result.response.ok) {
+      throw remoteHttpStatusError("file listing", result.response.status);
     }
+    const payload = decodeJson(
+      result.body,
+      "Remote runner fs entries response",
+    );
+    const entries = Array.isArray(payload)
+      ? payload
+      : isObject(payload) && Array.isArray(payload.entries)
+        ? payload.entries
+        : null;
+    if (!entries) {
+      throw remoteProtocolError(
+        "REMOTE_FS_RESPONSE_INVALID",
+        "Remote runner fs entries response was not an array.",
+      );
+    }
+    return entries.map((entry) => {
+      if (!isObject(entry)) {
+        throw remoteProtocolError(
+          "REMOTE_FS_ENTRY_INVALID",
+          "Remote runner fs entry was not an object.",
+        );
+      }
+      const pathValue = requiredNonEmptyString(
+        entry.path,
+        "Remote runner fs entry path",
+      );
+      const name =
+        entry.name === undefined
+          ? nodePath.posix.basename(pathValue)
+          : requiredNonEmptyString(entry.name, "Remote runner fs entry name");
+      const size = requiredNonNegativeSafeInteger(
+        entry.size,
+        "Remote runner fs entry size",
+      );
+      const modifiedValue = entry.modifiedAt ?? entry.modified;
+      const modified =
+        modifiedValue === undefined || modifiedValue === null
+          ? undefined
+          : requiredNonEmptyString(
+              modifiedValue,
+              "Remote runner fs entry modified time",
+            );
+      const stat: SandboxEntryInfo = {
+        path: pathValue,
+        name,
+        type: remoteEntryType(entry),
+        size,
+      };
+      if (modified) {
+        const modifiedTime = new Date(modified);
+        if (Number.isNaN(modifiedTime.getTime())) {
+          throw remoteProtocolError(
+            "REMOTE_FS_ENTRY_INVALID",
+            "Remote runner fs entry modified time was not a valid date.",
+          );
+        }
+        stat.modifiedTime = modifiedTime;
+      }
+      return stat;
+    });
   }
 
   private async read(
     path: string,
     opts?: { format?: "text" | "bytes"; requestTimeoutMs?: number },
   ): Promise<string | Uint8Array> {
-    const timeout = timeoutSignal(
-      opts?.requestTimeoutMs ?? this.requestTimeoutMs,
-    );
-    try {
-      const url = new URL(`${this.apiBase}/v1/fs/file`);
-      url.searchParams.set("path", path);
-      const response = await fetch(url, {
+    const url = new URL(`${this.apiBase}/v1/fs/file`);
+    url.searchParams.set("path", path);
+    const result = await fetchBounded(
+      url,
+      {
         headers: this.headers,
-        signal: timeout.signal,
-      });
-      if (response.status === 404) {
-        const error = new Error(`File not found: ${path}`);
-        error.name = "FileNotFoundError";
-        throw error;
-      }
-      if (!response.ok) throw new Error(await response.text());
-      const bytes = new Uint8Array(await response.arrayBuffer());
-      return opts?.format === "bytes"
-        ? bytes
-        : Buffer.from(bytes).toString("utf8");
-    } finally {
-      timeout.dispose();
+      },
+      {
+        timeoutMs: opts?.requestTimeoutMs ?? this.requestTimeoutMs,
+        maxResponseBytes: MAX_READ_BYTES,
+      },
+    );
+    if (result.response.status === 404) {
+      const error = new Error(`File not found: ${path}`);
+      error.name = "FileNotFoundError";
+      throw error;
     }
+    if (!result.response.ok) {
+      throw remoteHttpStatusError("file read", result.response.status);
+    }
+    return opts?.format === "bytes"
+      ? result.body
+      : decodeUtf8(result.body, "Remote runner file response");
   }
 
   private async write(
     path: string,
     data: string,
-    opts?: { requestTimeoutMs?: number },
   ): Promise<{ path: string; name: string }> {
     const url = new URL(`${this.apiBase}/v1/fs/file`);
     url.searchParams.set("path", path);
-    const timeout = timeoutSignal(
-      opts?.requestTimeoutMs ?? this.requestTimeoutMs,
-    );
-    try {
-      const response = await fetch(url, {
+    const result = await fetchBounded(
+      url,
+      {
         method: "PUT",
         headers: {
           ...this.headers,
           "content-type": "text/plain",
         },
         body: data,
-        signal: timeout.signal,
-      });
-      if (!response.ok) throw new Error(await response.text());
-      return { path, name: nodePath.posix.basename(path) };
-    } finally {
-      timeout.dispose();
+      },
+      {
+        timeoutMs: this.requestTimeoutMs,
+        maxResponseBytes: MAX_REMOTE_ERROR_BYTES,
+      },
+    );
+    if (!result.response.ok) {
+      throw remoteHttpStatusError("file write", result.response.status);
     }
+    return { path, name: nodePath.posix.basename(path) };
   }
 
   private async runCommand(
     cmd: string,
     opts: SandboxCommandRunOptions = {},
   ): Promise<SandboxCommandResult> {
-    const effectiveTimeoutMs =
-      opts.timeoutMs ?? opts.requestTimeoutMs ?? this.requestTimeoutMs;
-    const timeout = timeoutSignal(effectiveTimeoutMs);
-    try {
-      const response = await fetch(`${this.apiBase}/v1/processes/run`, {
+    const result = await fetchBounded(
+      `${this.apiBase}/v1/processes/run`,
+      {
         method: "POST",
         headers: {
           ...this.headers,
@@ -348,39 +376,41 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
           env: opts.envs,
           timeoutMs: opts.timeoutMs,
         }),
-        signal: timeout.signal,
-      });
-      if (!response.ok) throw new Error(await response.text());
-      const payload = await response.json();
-      if (!isObject(payload)) {
-        throw new Error("Remote runner process response was not an object.");
-      }
-      const exitCode =
-        typeof payload.exitCode === "number"
-          ? payload.exitCode
-          : payload.timedOut === true
-            ? 124
-            : 0;
-      const stdout =
-        typeof payload.stdout === "string"
-          ? payload.stdout
-          : typeof payload.output === "string"
-            ? payload.output
-            : "";
-      return {
-        exitCode,
-        stdout,
-        stderr: typeof payload.stderr === "string" ? payload.stderr : "",
-        ...(payload.timedOut === true ? { timedOut: true } : {}),
-      };
-    } catch (error) {
-      if (timeout.timedOut()) {
-        throw createTimeoutError(effectiveTimeoutMs);
-      }
-      throw error;
-    } finally {
-      timeout.dispose();
+      },
+      {
+        timeoutMs:
+          opts.timeoutMs ?? opts.requestTimeoutMs ?? this.requestTimeoutMs,
+        maxResponseBytes: MAX_REMOTE_JSON_BYTES,
+      },
+    );
+    if (!result.response.ok) {
+      throw remoteHttpStatusError("process execution", result.response.status);
     }
+    const payload = decodeJson(result.body, "Remote runner process response");
+    if (!isObject(payload)) {
+      throw remoteProtocolError(
+        "REMOTE_PROCESS_RESPONSE_INVALID",
+        "Remote runner process response was not an object.",
+      );
+    }
+    const exitCode = parseRemoteExitCode(payload);
+    const stdout = optionalStringAlias(
+      payload,
+      ["stdout", "output"],
+      "Remote runner process stdout",
+      true,
+    );
+    const stderr = optionalStringAlias(
+      payload,
+      ["stderr"],
+      "Remote runner process stderr",
+      true,
+    );
+    return {
+      exitCode,
+      stdout: stdout ?? "",
+      stderr: stderr ?? "",
+    };
   }
 }
 
@@ -407,7 +437,12 @@ class ElizaCloudCodingContainerFactory implements E2BSandboxFactory {
       );
     }
     const remoteToken = randomUUID();
-    const session = await this.requestCodingContainer(config, remoteToken);
+    const deadline = deadlineFromNow(Math.min(config.timeoutMs, 120_000));
+    const session = await this.requestCodingContainer(
+      config,
+      remoteToken,
+      deadline,
+    );
     if (!session.url) {
       throw new Error(
         `Eliza Cloud coding container ${session.containerId} did not return a remote runner URL.`,
@@ -415,7 +450,10 @@ class ElizaCloudCodingContainerFactory implements E2BSandboxFactory {
     }
     return this.remoteHttpFactory.create({
       ...config,
-      remoteHttpBaseUrl: session.url,
+      remoteHttpBaseUrl: normalizeProvisionedRunnerUrl(
+        session.url,
+        config.cloudApiBaseUrl,
+      ),
       remoteHttpToken: remoteToken,
     });
   }
@@ -423,76 +461,81 @@ class ElizaCloudCodingContainerFactory implements E2BSandboxFactory {
   private async requestCodingContainer(
     config: E2BRemoteRunnerConfig,
     remoteToken: string,
+    deadline: number,
   ): Promise<CloudCodingContainerSession> {
-    const timeout = timeoutSignal(config.requestTimeoutMs);
-    try {
-      const response = await fetch(
-        `${config.cloudApiBaseUrl}/coding-containers`,
-        {
-          method: "POST",
-          headers: {
-            authorization: `Bearer ${config.cloudApiToken}`,
-            "content-type": "application/json",
-          },
-          body: JSON.stringify({
-            agent: toCloudCodingAgent(config.agentRunners[0] ?? "codex"),
-            workspacePath: config.workdir,
-            container: {
-              ...(config.cloudContainerImage
-                ? { image: config.cloudContainerImage }
-                : {}),
-              environmentVars: {
-                HOST: "0.0.0.0",
-                ELIZA_REMOTE_RUNNER_HTTP_TOKEN: remoteToken,
-                REMOTE_RUNNER_HTTP_TOKEN: remoteToken,
-                ELIZA_CODING_WORKSPACE: config.workdir,
-                ELIZA_SANDBOX_AGENT_RUNNERS: config.agentRunners.join(","),
-                ...config.envs,
-              },
-            },
-            metadata: config.metadata,
-          }),
-          signal: timeout.signal,
+    const result = await fetchBounded(
+      `${config.cloudApiBaseUrl}/coding-containers`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${config.cloudApiToken}`,
+          "content-type": "application/json",
         },
-      );
-      const payload = await readCloudEnvelope(response);
-      if (!response.ok) {
-        throw new Error(cloudErrorMessage(payload, response.statusText));
-      }
-
-      const session = parseCloudCodingContainerSession(payload);
-      return session.url
-        ? session
-        : await this.pollCodingContainer(config, session);
-    } finally {
-      timeout.dispose();
+        body: JSON.stringify({
+          agent: toCloudCodingAgent(config.agentRunners[0] ?? "codex"),
+          workspacePath: config.workdir,
+          container: {
+            ...(config.cloudContainerImage
+              ? { image: config.cloudContainerImage }
+              : {}),
+            environmentVars: {
+              HOST: "0.0.0.0",
+              ELIZA_REMOTE_RUNNER_HTTP_TOKEN: remoteToken,
+              REMOTE_RUNNER_HTTP_TOKEN: remoteToken,
+              ELIZA_CODING_WORKSPACE: config.workdir,
+              ELIZA_SANDBOX_AGENT_RUNNERS: config.agentRunners.join(","),
+              ...config.envs,
+            },
+          },
+          metadata: config.metadata,
+        }),
+      },
+      {
+        timeoutMs: requestTimeoutWithinDeadline(
+          deadline,
+          config.requestTimeoutMs,
+        ),
+        maxResponseBytes: MAX_REMOTE_JSON_BYTES,
+      },
+    );
+    const payload = readCloudEnvelope(result.body);
+    if (!result.response.ok) {
+      throw cloudHttpStatusError("provisioning", result.response.status);
     }
+    const session = parseCloudCodingContainerSession(payload);
+    return session.url
+      ? session
+      : await this.pollCodingContainer(config, session, deadline);
   }
+
   private async pollCodingContainer(
     config: E2BRemoteRunnerConfig,
     session: CloudCodingContainerSession,
+    deadline: number,
   ): Promise<CloudCodingContainerSession> {
-    const deadline = Date.now() + Math.min(config.timeoutMs, 120_000);
     let current = session;
     while (!current.url && Date.now() < deadline) {
-      await sleep(5000);
-      const timeout = timeoutSignal(config.requestTimeoutMs);
-      try {
-        const response = await fetch(
-          `${config.cloudApiBaseUrl}/containers/${encodeURIComponent(current.containerId)}`,
-          {
-            headers: { authorization: `Bearer ${config.cloudApiToken}` },
-            signal: timeout.signal,
-          },
-        );
-        const payload = await readCloudEnvelope(response);
-        if (!response.ok) {
-          throw new Error(cloudErrorMessage(payload, response.statusText));
-        }
-        current = parseCloudCodingContainerSession(payload);
-      } finally {
-        timeout.dispose();
+      await sleep(Math.min(5000, Math.max(0, deadline - Date.now())));
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) break;
+      const result = await fetchBounded(
+        `${config.cloudApiBaseUrl}/containers/${encodeURIComponent(current.containerId)}`,
+        {
+          headers: { authorization: `Bearer ${config.cloudApiToken}` },
+        },
+        {
+          timeoutMs: requestTimeoutWithinDeadline(
+            deadline,
+            config.requestTimeoutMs,
+          ),
+          maxResponseBytes: MAX_REMOTE_JSON_BYTES,
+        },
+      );
+      const payload = readCloudEnvelope(result.body);
+      if (!result.response.ok) {
+        throw cloudHttpStatusError("status polling", result.response.status);
       }
+      current = parseCloudCodingContainerSession(payload);
       if (current.status === "failed" || current.status === "stopped") {
         throw new Error(
           `Eliza Cloud coding container ${current.containerId} reached status ${current.status}.`,
@@ -1120,89 +1163,249 @@ function authHeaders(apiKey: string | undefined): Record<string, string> {
 }
 
 function remoteEntryType(entry: JsonObject): SandboxEntryInfo["type"] {
-  const value =
-    typeof entry.type === "string"
-      ? entry.type
-      : typeof entry.entryType === "string"
-        ? entry.entryType
-        : typeof entry.kind === "string"
-          ? entry.kind
-          : undefined;
+  const value = optionalStringAlias(
+    entry,
+    ["type", "entryType", "kind"],
+    "Remote runner fs entry type",
+  );
+  if (value === undefined) {
+    throw remoteProtocolError(
+      "REMOTE_FS_ENTRY_INVALID",
+      "Remote runner fs entry type was missing.",
+    );
+  }
   return normalizeSandboxEntryType(value);
 }
 
-function createTimeoutError(ms: number): Error {
-  const error = new Error(`The operation timed out after ${ms}ms.`);
-  error.name = "TimeoutError";
-  return error;
+type BoundedFetchResult = {
+  response: Response;
+  body: Uint8Array;
+};
+
+class RemoteResponseProtocolError extends ElizaError {
+  override readonly name: string = "RemoteResponseProtocolError";
 }
 
-function isTimeoutErrorLike(value: unknown): boolean {
-  if (!(value instanceof Error)) return false;
+class RemoteResponseTooLargeError extends RemoteResponseProtocolError {
+  override readonly name = "RemoteResponseTooLargeError";
+}
+
+async function fetchBounded(
+  input: string | URL,
+  init: RequestInit,
+  options: { timeoutMs: number; maxResponseBytes: number },
+): Promise<BoundedFetchResult> {
   if (
-    value.name === "TimeoutError" ||
-    /timed? out|timeout/i.test(value.message)
+    !Number.isInteger(options.timeoutMs) ||
+    options.timeoutMs <= 0 ||
+    options.timeoutMs > MAX_TIMER_DELAY_MS
   ) {
-    return true;
-  }
-  return isTimeoutErrorLike((value as Error & { cause?: unknown }).cause);
-}
-
-function timeoutSignal(ms: number | undefined): {
-  signal: AbortSignal | undefined;
-  dispose(): void;
-  timedOut(): boolean;
-} {
-  if (ms === undefined) {
-    return {
-      signal: undefined,
-      dispose: () => {},
-      timedOut: () => false,
-    };
-  }
-  if (!Number.isSafeInteger(ms) || ms <= 0 || ms > MAX_TIMER_TIMEOUT_MS) {
     throw new RangeError(
-      `Duration must be an integer between 1 and ${MAX_TIMER_TIMEOUT_MS}ms.`,
+      `Remote HTTP timeout must be an integer from 1 to ${MAX_TIMER_DELAY_MS} milliseconds.`,
     );
   }
   const controller = new AbortController();
-  const reason = createTimeoutError(ms);
-  let timedOut = false;
-  const timer = setTimeout(() => {
-    timedOut = true;
-    controller.abort(reason);
-  }, ms);
-  return {
-    signal: controller.signal,
-    dispose: () => clearTimeout(timer),
-    timedOut: () =>
-      timedOut ||
-      (controller.signal.aborted &&
-        isTimeoutErrorLike(controller.signal.reason)),
-  };
+  const timeoutError = new DOMException(
+    "Remote runner request timed out.",
+    "TimeoutError",
+  );
+  const timer = setTimeout(
+    () => controller.abort(timeoutError),
+    options.timeoutMs,
+  );
+  timer.unref?.();
+  try {
+    const response = await fetch(input, {
+      ...init,
+      redirect: "error",
+      signal: controller.signal,
+    });
+    const declaredLength = response.headers.get("content-length");
+    if (declaredLength !== null) {
+      if (!/^(0|[1-9]\d*)$/.test(declaredLength)) {
+        throw remoteProtocolError(
+          "REMOTE_RESPONSE_LENGTH_INVALID",
+          "Remote response declared an invalid content length.",
+        );
+      }
+      const declaredBytes = Number(declaredLength);
+      if (
+        !Number.isSafeInteger(declaredBytes) ||
+        declaredBytes > options.maxResponseBytes
+      ) {
+        const error = responseTooLargeError(options.maxResponseBytes);
+        await cancelResponseBody(response, error);
+        throw error;
+      }
+    }
+    return {
+      response,
+      body: await readBoundedBody(
+        response,
+        options.maxResponseBytes,
+        controller,
+      ),
+    };
+  } catch (error) {
+    // error-policy:J1 the outbound HTTP boundary preserves stable local
+    // protocol errors but translates implementation-specific network failures
+    // so an internal host, socket detail, or redirect target cannot escape.
+    if (
+      controller.signal.aborted &&
+      controller.signal.reason === timeoutError
+    ) {
+      throw timeoutError;
+    }
+    controller.abort();
+    if (error instanceof RemoteResponseProtocolError) throw error;
+    throw new ElizaError("Remote HTTP request failed.", {
+      code: "REMOTE_HTTP_REQUEST_FAILED",
+      severity: "ephemeral",
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function readBoundedBody(
+  response: Response,
+  maxBytes: number,
+  controller: AbortController,
+): Promise<Uint8Array> {
+  if (!response.body) return new Uint8Array();
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        const error = responseTooLargeError(maxBytes);
+        controller.abort(error);
+        await cancelReader(reader, error);
+        throw error;
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
+async function cancelResponseBody(
+  response: Response,
+  reason: Error,
+): Promise<void> {
+  if (!response.body) return;
+  try {
+    await response.body.cancel(reason);
+  } catch (error) {
+    // error-policy:J6 cancellation is teardown after a rejected response.
+    logger.debug(
+      { ...LOG_CONTEXT, error },
+      "[E2BRemoteCapabilityRouter] Failed to cancel rejected response body",
+    );
+  }
+}
+
+async function cancelReader(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reason: Error,
+): Promise<void> {
+  try {
+    await reader.cancel(reason);
+  } catch (error) {
+    // error-policy:J6 cancellation is teardown after the response exceeded its cap.
+    logger.debug(
+      { ...LOG_CONTEXT, error },
+      "[E2BRemoteCapabilityRouter] Failed to cancel oversized response stream",
+    );
+  }
+}
+
+function responseTooLargeError(maxBytes: number): RemoteResponseTooLargeError {
+  return new RemoteResponseTooLargeError(
+    `Remote response exceeded the ${maxBytes}-byte safety limit.`,
+    {
+      code: "REMOTE_RESPONSE_TOO_LARGE",
+      context: { maxBytes },
+    },
+  );
+}
+
+function remoteHttpStatusError(operation: string, status: number): ElizaError {
+  return new ElizaError(
+    `Remote runner ${operation} failed with HTTP ${status}.`,
+    {
+      code: "REMOTE_HTTP_STATUS_FAILED",
+      context: { operation, status },
+      severity: status >= 500 ? "ephemeral" : "fatal",
+    },
+  );
+}
+
+function cloudHttpStatusError(operation: string, status: number): ElizaError {
+  return new ElizaError(
+    `Eliza Cloud coding-container ${operation} failed with HTTP ${status}.`,
+    {
+      code: "CLOUD_CODING_CONTAINER_HTTP_STATUS_FAILED",
+      context: { operation, status },
+      severity: status >= 500 ? "ephemeral" : "fatal",
+    },
+  );
+}
+
+function decodeUtf8(body: Uint8Array, context: string): string {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(body);
+  } catch {
+    // error-policy:J1 malformed upstream bytes are translated without retaining
+    // an implementation error that may quote attacker-controlled content.
+    throw remoteProtocolError(
+      "REMOTE_RESPONSE_UTF8_INVALID",
+      `${context} was not valid UTF-8.`,
+    );
+  }
+}
+
+function decodeJson(body: Uint8Array, context: string): unknown {
+  const text = decodeUtf8(body, context);
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    // error-policy:J1 JSON parser diagnostics may quote the untrusted response,
+    // so the boundary exposes only a stable protocol failure.
+    throw remoteProtocolError(
+      "REMOTE_RESPONSE_JSON_INVALID",
+      `${context} was not valid JSON.`,
+    );
+  }
 }
 
 function isObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-async function readCloudEnvelope(response: Response): Promise<CloudEnvelope> {
-  const text = await response.text();
+function readCloudEnvelope(body: Uint8Array): CloudEnvelope {
+  const text = decodeUtf8(body, "Eliza Cloud coding-container response");
   if (!text.trim()) return {};
-  try {
-    const parsed = JSON.parse(text) as unknown;
-    return isObject(parsed) ? parsed : {};
-  } catch {
-    return { data: { error: text } };
+  const parsed = decodeJson(body, "Eliza Cloud coding-container response");
+  if (!isObject(parsed)) {
+    throw remoteProtocolError(
+      "CLOUD_CODING_CONTAINER_RESPONSE_INVALID",
+      "Eliza Cloud coding-container response was not a JSON object.",
+    );
   }
-}
-
-function cloudErrorMessage(payload: CloudEnvelope, fallback: string): string {
-  const body: JsonObject = isObject(payload.data)
-    ? payload.data
-    : (payload as JsonObject);
-  const error = body.error ?? body.message;
-  return typeof error === "string" && error.trim() ? error.trim() : fallback;
+  return parsed;
 }
 
 function parseCloudCodingContainerSession(
@@ -1211,33 +1414,100 @@ function parseCloudCodingContainerSession(
   const data: JsonObject = isObject(payload.data)
     ? payload.data
     : (payload as JsonObject);
-  const containerId = stringValue(data, ["containerId", "id"]);
+  const containerId = optionalStringAlias(
+    data,
+    ["containerId", "id"],
+    "Eliza Cloud coding-container id",
+  );
   if (!containerId) {
-    throw new Error(
+    throw remoteProtocolError(
+      "CLOUD_CODING_CONTAINER_RESPONSE_INVALID",
       "Eliza Cloud coding-container response omitted container id.",
     );
   }
   return {
     containerId,
-    status: stringValue(data, ["status"]),
-    url: stringValue(data, [
-      "url",
-      "publicUrl",
-      "load_balancer_url",
-      "bridge_url",
-    ]),
+    status: optionalStringAlias(
+      data,
+      ["status"],
+      "Eliza Cloud coding-container status",
+    ),
+    url: optionalStringAlias(
+      data,
+      ["url", "publicUrl", "load_balancer_url", "bridge_url"],
+      "Eliza Cloud coding-container runner URL",
+    ),
   };
 }
 
-function stringValue(
+function optionalStringAlias(
   record: JsonObject,
   keys: readonly string[],
+  context: string,
+  allowEmpty = false,
 ): string | undefined {
   for (const key of keys) {
     const value = record[key];
-    if (typeof value === "string" && value.trim()) return value.trim();
+    if (value === undefined || value === null) continue;
+    if (typeof value === "string" && (allowEmpty || value.trim())) {
+      return allowEmpty ? value : value.trim();
+    }
+    throw remoteProtocolError(
+      "REMOTE_RESPONSE_SCHEMA_INVALID",
+      `${context} was not a non-empty string.`,
+    );
   }
   return undefined;
+}
+
+function requiredNonEmptyString(value: unknown, context: string): string {
+  if (typeof value === "string" && value.trim()) return value;
+  throw remoteProtocolError(
+    "REMOTE_RESPONSE_SCHEMA_INVALID",
+    `${context} was not a non-empty string.`,
+  );
+}
+
+function requiredNonNegativeSafeInteger(
+  value: unknown,
+  context: string,
+): number {
+  if (Number.isSafeInteger(value) && (value as number) >= 0) {
+    return value as number;
+  }
+  throw remoteProtocolError(
+    "REMOTE_RESPONSE_SCHEMA_INVALID",
+    `${context} was not a non-negative safe integer.`,
+  );
+}
+
+function parseRemoteExitCode(payload: JsonObject): number {
+  if (Number.isSafeInteger(payload.exitCode)) {
+    return payload.exitCode as number;
+  }
+  if (payload.exitCode !== undefined && payload.exitCode !== null) {
+    throw remoteProtocolError(
+      "REMOTE_PROCESS_RESPONSE_INVALID",
+      "Remote runner process exit code was not a safe integer.",
+    );
+  }
+  if (payload.timedOut === true) return 124;
+  throw remoteProtocolError(
+    "REMOTE_PROCESS_RESPONSE_INVALID",
+    "Remote runner process response omitted exit code.",
+  );
+}
+
+function remoteProtocolError(
+  code: string,
+  message: string,
+  cause?: unknown,
+): RemoteResponseProtocolError {
+  return new RemoteResponseProtocolError(message, {
+    code,
+    ...(cause === undefined ? {} : { cause }),
+    severity: "fatal",
+  });
 }
 
 function toCloudCodingAgent(value: CodingAgentRunner): CloudCodingAgent {
@@ -1246,6 +1516,24 @@ function toCloudCodingAgent(value: CodingAgentRunner): CloudCodingAgent {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function deadlineFromNow(timeoutMs: number): number {
+  return Date.now() + timeoutMs;
+}
+
+function requestTimeoutWithinDeadline(
+  deadline: number,
+  requestTimeoutMs: number,
+): number {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs <= 0) {
+    throw new DOMException(
+      "Eliza Cloud coding-container provisioning timed out.",
+      "TimeoutError",
+    );
+  }
+  return Math.max(1, Math.min(requestTimeoutMs, remainingMs));
 }
 
 function readSetting(runtime: IAgentRuntime, key: string): string | undefined {
@@ -1406,9 +1694,76 @@ function remoteHttpToken(
 }
 
 function normalizeCloudApiBaseUrl(value: string): string {
-  const trimmed = value.trim().replace(/\/+$/, "");
+  const trimmed = normalizeHttpBaseUrl(value, "Eliza Cloud API base URL");
   if (trimmed.endsWith("/api/v1")) return trimmed;
   return `${trimmed}/api/v1`;
+}
+
+function normalizeHttpBaseUrl(value: string, context: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    // error-policy:J3 configured and upstream endpoint text is validated before use.
+    throw new ElizaError(`${context} must be a valid HTTP(S) URL.`, {
+      code: "REMOTE_HTTP_URL_INVALID",
+      context: { field: context },
+      severity: "fatal",
+    });
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new ElizaError(`${context} must use HTTP or HTTPS.`, {
+      code: "REMOTE_HTTP_URL_INVALID",
+      context: { field: context, protocol: parsed.protocol },
+      severity: "fatal",
+    });
+  }
+  if (parsed.username || parsed.password) {
+    throw new ElizaError(`${context} must not contain embedded credentials.`, {
+      code: "REMOTE_HTTP_URL_CREDENTIALS_REJECTED",
+      context: { field: context },
+      severity: "fatal",
+    });
+  }
+  if (parsed.search || parsed.hash) {
+    throw new ElizaError(`${context} must not contain a query or fragment.`, {
+      code: "REMOTE_HTTP_URL_INVALID",
+      context: { field: context },
+      severity: "fatal",
+    });
+  }
+  parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+  return parsed.toString().replace(/\/+$/, "");
+}
+
+function normalizeProvisionedRunnerUrl(
+  value: string,
+  cloudApiBaseUrl: string,
+): string {
+  const normalized = normalizeHttpBaseUrl(
+    value,
+    "Eliza Cloud coding-container runner URL",
+  );
+  const runnerUrl = new URL(normalized);
+  const cloudApiUrl = new URL(cloudApiBaseUrl);
+  const cloudApiUsesPrivateAuthority =
+    isBlockedHostname(cloudApiUrl.hostname) ||
+    isPrivateIpAddress(cloudApiUrl.hostname);
+  if (
+    !cloudApiUsesPrivateAuthority &&
+    (runnerUrl.protocol !== "https:" ||
+      isBlockedHostname(runnerUrl.hostname) ||
+      isPrivateIpAddress(runnerUrl.hostname))
+  ) {
+    throw new ElizaError(
+      "Eliza Cloud coding-container runner URL must use a public HTTPS authority.",
+      {
+        code: "CLOUD_CODING_CONTAINER_RUNNER_URL_REJECTED",
+        severity: "fatal",
+      },
+    );
+  }
+  return normalized;
 }
 
 function remoteAccessUrl(
@@ -1435,16 +1790,10 @@ function positiveIntSetting(
   const value = readSetting(runtime, key);
   if (value === undefined) return fallback;
   const parsed = Number(value);
-  if (
-    Number.isSafeInteger(parsed) &&
-    parsed > 0 &&
-    parsed <= MAX_TIMER_TIMEOUT_MS
-  ) {
+  if (Number.isInteger(parsed) && parsed > 0 && parsed <= MAX_TIMER_DELAY_MS) {
     return parsed;
   }
-  throw new Error(
-    `${key} must be an integer between 1 and ${MAX_TIMER_TIMEOUT_MS}.`,
-  );
+  throw new Error(`${key} must be an integer from 1 to ${MAX_TIMER_DELAY_MS}.`);
 }
 
 function agentRunnersSetting(
@@ -1500,7 +1849,7 @@ function commandRunResult(
   return {
     output: `${result.stdout}${stderr}`,
     exitCode: result.exitCode,
-    timedOut: timedOut || result.timedOut === true,
+    timedOut,
   };
 }
 
@@ -1524,7 +1873,9 @@ function commandResultFromError(error: Error): SandboxCommandResult | null {
 }
 
 function isTimeoutError(error: Error): boolean {
-  return isTimeoutErrorLike(error);
+  return (
+    error.name === "TimeoutError" || /timed? out|timeout/i.test(error.message)
+  );
 }
 
 function normalizeSandboxPath(input: string): string {

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -1214,7 +1214,7 @@ async function fetchBounded(
   }
   const controller = new AbortController();
   const timeoutError = new DOMException(
-    "Remote runner request timed out.",
+    `Remote runner request timed out after ${options.timeoutMs}ms.`,
     "TimeoutError",
   );
   const timer = setTimeout(
@@ -1266,6 +1266,9 @@ async function fetchBounded(
     }
     controller.abort();
     if (error instanceof RemoteResponseProtocolError) throw error;
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new DOMException("The operation was aborted.", "AbortError");
+    }
     throw new ElizaError("Remote HTTP request failed.", {
       code: "REMOTE_HTTP_REQUEST_FAILED",
       severity: "ephemeral",

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -369,6 +369,8 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
     cmd: string,
     opts: SandboxCommandRunOptions = {},
   ): Promise<SandboxCommandResult> {
+    const effectiveTimeoutMs =
+      opts.timeoutMs ?? opts.requestTimeoutMs ?? this.requestTimeoutMs;
     const result = await fetchBounded(
       `${this.apiBase}/v1/processes/run`,
       {
@@ -386,8 +388,7 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
         }),
       },
       {
-        timeoutMs:
-          opts.timeoutMs ?? opts.requestTimeoutMs ?? this.requestTimeoutMs,
+        timeoutMs: effectiveTimeoutMs,
         maxResponseBytes: MAX_REMOTE_JSON_BYTES,
       },
     );
@@ -418,6 +419,7 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
       exitCode,
       stdout: stdout ?? "",
       stderr: stderr ?? "",
+      ...(payload.timedOut === true ? { timedOut: true } : {}),
     };
   }
 }
@@ -781,12 +783,14 @@ export class E2BRemoteCapabilityRouterService
     };
     try {
       const result = await sandbox.commands.run(command, opts);
-      return commandRunResult(result, false);
+      return commandRunResult(result, result.timedOut === true);
     } catch (error) {
       const normalized =
         error instanceof Error ? error : new Error(String(error));
       const commandResult = commandResultFromError(normalized);
-      if (commandResult) return commandRunResult(commandResult, false);
+      if (commandResult) {
+        return commandRunResult(commandResult, commandResult.timedOut === true);
+      }
       if (isTimeoutError(normalized)) {
         return {
           output: normalized.message,
@@ -1209,7 +1213,7 @@ async function fetchBounded(
     options.timeoutMs > MAX_TIMER_DELAY_MS
   ) {
     throw new RangeError(
-      `Remote HTTP timeout must be an integer from 1 to ${MAX_TIMER_DELAY_MS} milliseconds.`,
+      `Duration must be an integer between 1 and ${MAX_TIMER_DELAY_MS}ms.`,
     );
   }
   const controller = new AbortController();
@@ -1815,7 +1819,7 @@ function positiveIntSetting(
   if (value === undefined) return fallback;
   if (!/^[1-9]\d*$/.test(value)) {
     throw new ElizaError(
-      `${key} must be a canonical integer from 1 to ${MAX_TIMER_DELAY_MS}.`,
+      `${key} must be an integer between 1 and ${MAX_TIMER_DELAY_MS}.`,
       {
         code: "REMOTE_RUNNER_CONFIG_INVALID",
         context: { key },
@@ -1828,7 +1832,7 @@ function positiveIntSetting(
     return parsed;
   }
   throw new ElizaError(
-    `${key} must be a canonical integer from 1 to ${MAX_TIMER_DELAY_MS}.`,
+    `${key} must be an integer between 1 and ${MAX_TIMER_DELAY_MS}.`,
     {
       code: "REMOTE_RUNNER_CONFIG_INVALID",
       context: { key },

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -204,12 +204,16 @@ class RemoteRunnerHttpFactory implements E2BSandboxFactory {
 class RemoteRunnerHttpClient implements E2BSandboxClient {
   readonly workspacePrepared = true;
   readonly files = {
-    list: (path: string) => this.list(path),
+    list: (
+      path: string,
+      opts?: { depth?: number; requestTimeoutMs?: number },
+    ) => this.list(path, opts),
     read: (
       path: string,
       opts?: { format?: "text" | "bytes"; requestTimeoutMs?: number },
     ) => this.read(path, opts),
-    write: (path: string, data: string) => this.write(path, data),
+    write: (path: string, data: string, opts?: { requestTimeoutMs?: number }) =>
+      this.write(path, data, opts),
   };
   readonly commands = {
     run: (cmd: string, opts?: SandboxCommandRunOptions) =>
@@ -225,14 +229,17 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
 
   async kill(): Promise<void> {}
 
-  private async list(path: string): Promise<SandboxEntryInfo[]> {
+  private async list(
+    path: string,
+    opts?: { depth?: number; requestTimeoutMs?: number },
+  ): Promise<SandboxEntryInfo[]> {
     const url = new URL(`${this.apiBase}/v1/fs/entries`);
     url.searchParams.set("path", path);
     const result = await fetchBounded(
       url,
       { headers: this.headers },
       {
-        timeoutMs: this.requestTimeoutMs,
+        timeoutMs: opts?.requestTimeoutMs ?? this.requestTimeoutMs,
         maxResponseBytes: MAX_REMOTE_JSON_BYTES,
       },
     );
@@ -333,6 +340,7 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
   private async write(
     path: string,
     data: string,
+    opts?: { requestTimeoutMs?: number },
   ): Promise<{ path: string; name: string }> {
     const url = new URL(`${this.apiBase}/v1/fs/file`);
     url.searchParams.set("path", path);
@@ -347,7 +355,7 @@ class RemoteRunnerHttpClient implements E2BSandboxClient {
         body: data,
       },
       {
-        timeoutMs: this.requestTimeoutMs,
+        timeoutMs: opts?.requestTimeoutMs ?? this.requestTimeoutMs,
         maxResponseBytes: MAX_REMOTE_ERROR_BYTES,
       },
     );

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -1234,7 +1234,7 @@ async function fetchBounded(
         declaredBytes > options.maxResponseBytes
       ) {
         const error = responseTooLargeError(options.maxResponseBytes);
-        await cancelResponseBody(response, error);
+        cancelResponseBody(response, error);
         throw error;
       }
     }
@@ -1284,7 +1284,7 @@ async function readBoundedBody(
       if (totalBytes > maxBytes) {
         const error = responseTooLargeError(maxBytes);
         controller.abort(error);
-        await cancelReader(reader, error);
+        cancelReader(reader, error);
         throw error;
       }
       chunks.push(value);
@@ -1301,13 +1301,18 @@ async function readBoundedBody(
   return body;
 }
 
-async function cancelResponseBody(
-  response: Response,
-  reason: Error,
-): Promise<void> {
+function cancelResponseBody(response: Response, reason: Error): void {
   if (!response.body) return;
   try {
-    await response.body.cancel(reason);
+    // error-policy:J6 cancellation is teardown after a rejected response; its
+    // rejection is logged by the attached diagnostic handler, while a
+    // hostile stream cannot delay the primary size-limit failure.
+    void response.body.cancel(reason).catch((error: unknown) => {
+      logger.debug(
+        { ...LOG_CONTEXT, error },
+        "[E2BRemoteCapabilityRouter] Failed to cancel rejected response body",
+      );
+    });
   } catch (error) {
     // error-policy:J6 cancellation is teardown after a rejected response.
     logger.debug(
@@ -1317,12 +1322,20 @@ async function cancelResponseBody(
   }
 }
 
-async function cancelReader(
+function cancelReader(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   reason: Error,
-): Promise<void> {
+): void {
   try {
-    await reader.cancel(reason);
+    // error-policy:J6 cancellation is teardown after a rejected response; its
+    // rejection is logged by the attached diagnostic handler, while a
+    // hostile stream cannot delay the primary size-limit failure.
+    void reader.cancel(reason).catch((error: unknown) => {
+      logger.debug(
+        { ...LOG_CONTEXT, error },
+        "[E2BRemoteCapabilityRouter] Failed to cancel oversized response stream",
+      );
+    });
   } catch (error) {
     // error-policy:J6 cancellation is teardown after the response exceeded its cap.
     logger.debug(
@@ -1789,11 +1802,28 @@ function positiveIntSetting(
 ): number {
   const value = readSetting(runtime, key);
   if (value === undefined) return fallback;
+  if (!/^[1-9]\d*$/.test(value)) {
+    throw new ElizaError(
+      `${key} must be a canonical integer from 1 to ${MAX_TIMER_DELAY_MS}.`,
+      {
+        code: "REMOTE_RUNNER_CONFIG_INVALID",
+        context: { key },
+        severity: "fatal",
+      },
+    );
+  }
   const parsed = Number(value);
-  if (Number.isInteger(parsed) && parsed > 0 && parsed <= MAX_TIMER_DELAY_MS) {
+  if (Number.isSafeInteger(parsed) && parsed <= MAX_TIMER_DELAY_MS) {
     return parsed;
   }
-  throw new Error(`${key} must be an integer from 1 to ${MAX_TIMER_DELAY_MS}.`);
+  throw new ElizaError(
+    `${key} must be a canonical integer from 1 to ${MAX_TIMER_DELAY_MS}.`,
+    {
+      code: "REMOTE_RUNNER_CONFIG_INVALID",
+      context: { key },
+      severity: "fatal",
+    },
+  );
 }
 
 function agentRunnersSetting(

--- a/packages/agent/src/services/e2b-capability-router.ts
+++ b/packages/agent/src/services/e2b-capability-router.ts
@@ -1819,7 +1819,7 @@ function positiveIntSetting(
   if (value === undefined) return fallback;
   if (!/^[1-9]\d*$/.test(value)) {
     throw new ElizaError(
-      `${key} must be an integer between 1 and ${MAX_TIMER_DELAY_MS}.`,
+      `${key} must be a canonical integer from 1 to ${MAX_TIMER_DELAY_MS}.`,
       {
         code: "REMOTE_RUNNER_CONFIG_INVALID",
         context: { key },


### PR DESCRIPTION
# Relates to

Follow-up to #22864 and #22865.

# Contribution provenance

<!-- contribution-attribution:v1 -->
- AI assistance: `yes`
- Model(s) used: `openai/gpt-5.6-sol`
- Agent tooling: `Codex Desktop`
- Provenance status: `self-reported`

# What does this PR do?

Bounds remote-runner HTTP response bodies, validates response schemas, keeps request deadlines active through body consumption, makes rejected-body teardown nonblocking, preserves per-call deadline snapshots and stable timeout/abort identity, and carries the remote runner structured `timedOut` result through the public terminal contract.

# Testing

Exact head: `fd3f1b6a7a193ecb67588b6782f6ddd0cbeba16e`. The complete focused suite passed 49/51 before the final current-base contract reconciliation exposed two semantic mismatches. After correcting both, exact targeted tests for timer-range validation and structured timeout propagation pass 2/2. The subsequent latest-`develop` rebase was conflict-free. Both files pass Biome and diff checks.

# Evidence gate

<!-- evidence-head:fd3f1b6a7a193ecb67588b6782f6ddd0cbeba16e -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend/runtime boundary with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend/runtime boundary with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive visual flow.
<!-- evidence-row:backend-logs -->
- [x] Focused remote-runner HTTP tests cover stalled headers and bodies, declared and actual size caps, invalid schemas, URL policy, deadline overrides, option mutation, timeout identity, abort identity, and teardown.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or prompt behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Deterministic response fixtures verify bounded reads and exact structured terminal results.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text.

# Known gaps

- Hosted exact-head checks remain a merge prerequisite.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop"} -->
