### PR TITLE
fix(discord): harden credential probe foundation

### DIFF
--- a/plugins/plugin-discord/actions/setup-credentials.test.ts
+++ b/plugins/plugin-discord/actions/setup-credentials.test.ts
@@ -33,10 +33,14 @@ describe("credential probe network boundary", () => {
 		[
 			"anthropic",
 			{ apiKey: "anthropic-secret" },
-			"https://api.anthropic.com/v1/messages",
+			"https://api.anthropic.com/v1/models?limit=1",
 		],
 		["openai", { apiKey: "openai-secret" }, "https://api.openai.com/v1/models"],
-		["fal", { apiKey: "fal-secret" }, "https://rest.fal.run/fal-ai/fast-sdxl"],
+		[
+			"fal",
+			{ apiKey: "fal-secret" },
+			"https://queue.fal.run/fal-ai/flux/schnell/requests/00000000-0000-0000-0000-000000000000/status",
+		],
 	])(
 		"fences %s redirects and supplies a deadline",
 		async (name, credentials, url) => {
@@ -63,6 +67,26 @@ describe("credential probe network boundary", () => {
 			);
 		},
 	);
+
+	it("uses non-billable read probes for Anthropic and fal credentials", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(new Response(null, { status: 204 }))
+			.mockResolvedValueOnce(new Response(null, { status: 404 }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			preset("anthropic").validate({ apiKey: "secret" }),
+		).resolves.toMatchObject({ valid: true });
+		await expect(
+			preset("fal").validate({ apiKey: "secret" }),
+		).resolves.toMatchObject({ valid: true });
+
+		for (const [, init] of fetchMock.mock.calls) {
+			expect(init?.method).toBeUndefined();
+			expect(init?.body).toBeUndefined();
+		}
+	});
 
 	it("rejects an oversized declared JSON response before parsing", async () => {
 		vi.stubGlobal(
@@ -250,6 +274,61 @@ describe("credential probe network boundary", () => {
 			valid: false,
 			error: "Anthropic credential validation timed out",
 		});
+	});
+
+	it("preserves timeout identity when the deadline races valid JSON parsing", async () => {
+		const controller = new AbortController();
+		const response = Response.json({ login: "owner" });
+		vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => response),
+		);
+		const parse = JSON.parse.bind(JSON);
+		vi.spyOn(JSON, "parse").mockImplementation((text) => {
+			const parsed = parse(text);
+			controller.abort(new DOMException("sensitive detail", "TimeoutError"));
+			return parsed;
+		});
+
+		await expect(
+			preset("github").validate({ token: "secret" }),
+		).resolves.toEqual({
+			valid: false,
+			error: "GitHub credential validation timed out",
+		});
+	});
+
+	it("rejects and cancels a response returned after the deadline", async () => {
+		let cancelled = false;
+		vi.spyOn(AbortSignal, "timeout").mockReturnValue(
+			AbortSignal.abort(
+				new DOMException("sensitive upstream detail", "TimeoutError"),
+			),
+		);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						new ReadableStream({
+							pull() {},
+							cancel() {
+								cancelled = true;
+							},
+						}),
+						{ status: 200 },
+					),
+			),
+		);
+
+		await expect(
+			preset("openai").validate({ apiKey: "secret" }),
+		).resolves.toEqual({
+			valid: false,
+			error: "OpenAI credential validation timed out",
+		});
+		await vi.waitFor(() => expect(cancelled).toBe(true));
 	});
 
 	it("applies the deadline through body reads even when stream cancellation hangs", async () => {

--- a/plugins/plugin-discord/actions/setup-credentials.test.ts
+++ b/plugins/plugin-discord/actions/setup-credentials.test.ts
@@ -4,7 +4,10 @@
  * failure translation without contacting third-party services.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getPreset } from "./setup-credentials";
+import {
+	getPreset,
+	SETUP_CREDENTIAL_FETCH_TIMEOUT_MS,
+} from "./setup-credentials";
 
 function preset(name: string) {
 	const value = getPreset(name);
@@ -18,6 +21,10 @@ afterEach(() => {
 });
 
 describe("credential probe network boundary", () => {
+	it("preserves the public credential-probe timeout contract", () => {
+		expect(SETUP_CREDENTIAL_FETCH_TIMEOUT_MS).toBe(15_000);
+	});
+
 	it.each([
 		["github", { token: "github-secret" }, "https://api.github.com/user"],
 		[

--- a/plugins/plugin-discord/actions/setup-credentials.test.ts
+++ b/plugins/plugin-discord/actions/setup-credentials.test.ts
@@ -39,7 +39,7 @@ describe("credential probe network boundary", () => {
 		[
 			"fal",
 			{ apiKey: "fal-secret" },
-			"https://queue.fal.run/fal-ai/flux/schnell/requests/00000000-0000-0000-0000-000000000000/status",
+			"https://api.fal.ai/v1/models/pricing?endpoint_id=fal-ai%2Fflux%2Fdev",
 		],
 	])(
 		"fences %s redirects and supplies a deadline",
@@ -52,6 +52,13 @@ describe("credential probe network boundary", () => {
 					if (name === "vercel") return Response.json({ projects: [] });
 					if (name === "cloudflare") {
 						return Response.json({ success: true, result: [] });
+					}
+					if (name === "fal") {
+						return Response.json({
+							prices: [],
+							next_cursor: null,
+							has_more: false,
+						});
 					}
 					return new Response(null, { status: 204 });
 				},
@@ -72,7 +79,9 @@ describe("credential probe network boundary", () => {
 		const fetchMock = vi
 			.fn()
 			.mockResolvedValueOnce(new Response(null, { status: 204 }))
-			.mockResolvedValueOnce(new Response(null, { status: 404 }));
+			.mockResolvedValueOnce(
+				Response.json({ prices: [], next_cursor: null, has_more: false }),
+			);
 		vi.stubGlobal("fetch", fetchMock);
 
 		await expect(
@@ -86,6 +95,17 @@ describe("credential probe network boundary", () => {
 			expect(init?.method).toBeUndefined();
 			expect(init?.body).toBeUndefined();
 		}
+	});
+
+	it("rejects a method mismatch from the fal credential probe", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response(null, { status: 405 })),
+		);
+
+		await expect(preset("fal").validate({ apiKey: "secret" })).resolves.toEqual(
+			{ valid: false, error: "fal.ai returned 405" },
+		);
 	});
 
 	it("rejects an oversized declared JSON response before parsing", async () => {

--- a/plugins/plugin-discord/actions/setup-credentials.test.ts
+++ b/plugins/plugin-discord/actions/setup-credentials.test.ts
@@ -186,13 +186,13 @@ describe("credential probe network boundary", () => {
 
 		await expect(preset("github").validate({})).resolves.toEqual({
 			valid: false,
-			error: "GitHub returned an invalid response",
+			error: "Invalid token value; provide a non-empty single-line value",
 		});
 		await expect(
 			preset("openai").validate({ apiKey: "x".repeat(16 * 1024 + 1) }),
 		).resolves.toEqual({
 			valid: false,
-			error: "OpenAI returned an invalid response",
+			error: "Invalid apiKey value; provide a non-empty single-line value",
 		});
 		await expect(
 			preset("cloudflare").validate({
@@ -201,9 +201,20 @@ describe("credential probe network boundary", () => {
 			}),
 		).resolves.toEqual({
 			valid: false,
-			error: "Cloudflare returned an invalid response",
+			error: "Invalid email value; provide a non-empty single-line value",
 		});
 		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("accepts underscore-bearing Enterprise Managed User GitHub logins", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => Response.json({ login: "mona_acme" })),
+		);
+
+		await expect(
+			preset("github").validate({ token: "secret" }),
+		).resolves.toEqual({ valid: true, identity: "@mona_acme" });
 	});
 
 	it("does not mistake throttling or request validation for authenticated success", async () => {

--- a/plugins/plugin-discord/actions/setup-credentials.test.ts
+++ b/plugins/plugin-discord/actions/setup-credentials.test.ts
@@ -1,66 +1,311 @@
 /**
- * Unit tests for connector `/setup` credential presets: honest GitHub probe
- * success and hung-probe fail-closed. Deterministic fetch mocks; no live APIs.
+ * Credential-probe boundary tests use deterministic fetch responses to verify
+ * deadlines, redirect policy, bounded bodies, response schemas, and secret-free
+ * failure translation without contacting third-party services.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getPreset } from "./setup-credentials";
+
+function preset(name: string) {
+	const value = getPreset(name);
+	if (!value) throw new Error(`Missing preset ${name}`);
+	return value;
+}
 
 afterEach(() => {
 	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
 });
 
-describe("setup-credentials presets", () => {
-	it("vends a verified GitHub identity from a successful user probe", async () => {
-		const fetchMock = vi.fn(async () =>
-			Response.json({ login: "octocat" }, { status: 200 }),
+describe("credential probe network boundary", () => {
+	it.each([
+		["github", { token: "github-secret" }, "https://api.github.com/user"],
+		[
+			"vercel",
+			{ token: "vercel-secret" },
+			"https://api.vercel.com/v9/projects",
+		],
+		[
+			"cloudflare",
+			{ apiKey: "cloudflare-secret", email: "owner@example.com" },
+			"https://api.cloudflare.com/client/v4/zones",
+		],
+		[
+			"anthropic",
+			{ apiKey: "anthropic-secret" },
+			"https://api.anthropic.com/v1/messages",
+		],
+		["openai", { apiKey: "openai-secret" }, "https://api.openai.com/v1/models"],
+		["fal", { apiKey: "fal-secret" }, "https://rest.fal.run/fal-ai/fast-sdxl"],
+	])(
+		"fences %s redirects and supplies a deadline",
+		async (name, credentials, url) => {
+			const fetchMock = vi.fn(
+				async (_url: string | URL | Request, init?: RequestInit) => {
+					expect(init?.redirect).toBe("error");
+					expect(init?.signal).toBeInstanceOf(AbortSignal);
+					if (name === "github") return Response.json({ login: "octocat" });
+					if (name === "vercel") return Response.json({ projects: [] });
+					if (name === "cloudflare") {
+						return Response.json({ success: true, result: [] });
+					}
+					return new Response(null, { status: 204 });
+				},
+			);
+			vi.stubGlobal("fetch", fetchMock);
+
+			const result = await preset(name).validate(credentials);
+
+			expect(result.valid).toBe(true);
+			expect(fetchMock).toHaveBeenCalledWith(
+				url,
+				expect.objectContaining({ redirect: "error" }),
+			);
+		},
+	);
+
+	it("rejects an oversized declared JSON response before parsing", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response("{}", {
+						headers: {
+							"content-type": "application/json",
+							"content-length": String(64 * 1024 + 1),
+						},
+					}),
+			),
 		);
-		vi.stubGlobal("fetch", fetchMock);
-		const preset = getPreset("github");
-		expect(preset).toBeDefined();
-		await expect(preset?.validate({ token: "ghp_test" })).resolves.toEqual({
-			valid: true,
-			identity: "@octocat",
+
+		await expect(
+			preset("github").validate({ token: "secret" }),
+		).resolves.toEqual({
+			valid: false,
+			error: "GitHub returned an invalid response",
 		});
-		expect(fetchMock).toHaveBeenCalledWith(
-			"https://api.github.com/user",
-			expect.objectContaining({
-				signal: expect.any(AbortSignal),
+	});
+
+	it("rejects a streamed response that crosses the body cap", async () => {
+		const chunk = new Uint8Array(33 * 1024);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						new ReadableStream({
+							start(controller) {
+								controller.enqueue(chunk);
+								controller.enqueue(chunk);
+								controller.close();
+							},
+						}),
+						{ headers: { "content-type": "application/json" } },
+					),
+			),
+		);
+
+		const result = await preset("github").validate({ token: "secret" });
+
+		expect(result).toEqual({
+			valid: false,
+			error: "GitHub returned an invalid response",
+		});
+	});
+
+	it("requires JSON media types and the provider's success schema", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response("{}", { headers: { "content-type": "text/plain" } }),
+			)
+			.mockResolvedValueOnce(Response.json({ projects: "not-an-array" }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			preset("github").validate({ token: "secret" }),
+		).resolves.toEqual({
+			valid: false,
+			error: "GitHub returned an invalid response",
+		});
+		await expect(
+			preset("vercel").validate({ token: "secret" }),
+		).resolves.toEqual({
+			valid: false,
+			error: "Vercel returned an invalid response",
+		});
+	});
+
+	it("rejects missing, oversized, and header-breaking credentials before fetch", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(preset("github").validate({})).resolves.toEqual({
+			valid: false,
+			error: "GitHub returned an invalid response",
+		});
+		await expect(
+			preset("openai").validate({ apiKey: "x".repeat(16 * 1024 + 1) }),
+		).resolves.toEqual({
+			valid: false,
+			error: "OpenAI returned an invalid response",
+		});
+		await expect(
+			preset("cloudflare").validate({
+				apiKey: "key",
+				email: "owner@example.com\r\nx-leak: secret",
 			}),
+		).resolves.toEqual({
+			valid: false,
+			error: "Cloudflare returned an invalid response",
+		});
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("does not mistake throttling or request validation for authenticated success", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValueOnce(new Response(null, { status: 429 }))
+				.mockResolvedValueOnce(new Response(null, { status: 429 }))
+				.mockResolvedValueOnce(new Response(null, { status: 422 })),
+		);
+
+		await expect(
+			preset("anthropic").validate({ apiKey: "secret" }),
+		).resolves.toEqual({ valid: false, error: "Anthropic returned 429" });
+		await expect(
+			preset("openai").validate({ apiKey: "secret" }),
+		).resolves.toEqual({ valid: false, error: "OpenAI returned 429" });
+		await expect(preset("fal").validate({ apiKey: "secret" })).resolves.toEqual(
+			{ valid: false, error: "fal.ai returned 422" },
 		);
 	});
 
-	it("fails closed on a hung GitHub credential probe instead of waiting forever", async () => {
-		vi.spyOn(AbortSignal, "timeout").mockImplementation(() => {
-			const controller = new AbortController();
-			setTimeout(() => {
-				controller.abort(
-					Object.assign(new Error("The operation was aborted due to timeout"), {
-						name: "TimeoutError",
-					}),
-				);
-			}, 50);
-			return controller.signal;
-		});
-		const fetchMock = vi.fn(
-			(_url: string, init?: { signal?: AbortSignal }) =>
-				new Promise<Response>((_resolve, reject) => {
-					const signal = init?.signal;
-					if (!signal) return;
-					if (signal.aborted) {
-						reject(signal.reason);
-						return;
-					}
-					signal.addEventListener("abort", () => reject(signal.reason));
-				}),
+	it("requires provider identity fields instead of accepting empty success envelopes", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValueOnce(Response.json({}))
+				.mockResolvedValueOnce(Response.json({ success: false, result: [] })),
 		);
-		vi.stubGlobal("fetch", fetchMock);
-		const preset = getPreset("github");
-		const started = Date.now();
-		await expect(preset?.validate({ token: "ghp_test" })).resolves.toEqual({
+
+		await expect(
+			preset("github").validate({ token: "secret" }),
+		).resolves.toEqual({
 			valid: false,
-			error: "The operation was aborted due to timeout",
+			error: "GitHub returned an invalid response",
 		});
-		expect(Date.now() - started).toBeLessThan(1_000);
+		await expect(
+			preset("cloudflare").validate({
+				apiKey: "secret",
+				email: "owner@example.com",
+			}),
+		).resolves.toEqual({
+			valid: false,
+			error: "Cloudflare returned an invalid response",
+		});
+	});
+
+	it("does not expose provider, transport, or credential text from failures", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				throw new Error(
+					"request with super-secret-token failed at internal.proxy",
+				);
+			}),
+		);
+
+		const result = await preset("openai").validate({
+			apiKey: "super-secret-token",
+		});
+
+		expect(result).toEqual({
+			valid: false,
+			error: "Unable to reach OpenAI credential service",
+		});
+		expect(result.error).not.toContain("secret");
+		expect(result.error).not.toContain("internal.proxy");
+	});
+
+	it("preserves timeout identity without exposing the abort reason", async () => {
+		vi.spyOn(AbortSignal, "timeout").mockReturnValue(
+			AbortSignal.abort(
+				new DOMException("sensitive upstream detail", "TimeoutError"),
+			),
+		);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+				throw init?.signal?.reason;
+			}),
+		);
+
+		await expect(
+			preset("anthropic").validate({ apiKey: "secret" }),
+		).resolves.toEqual({
+			valid: false,
+			error: "Anthropic credential validation timed out",
+		});
+	});
+
+	it("applies the deadline through body reads even when stream cancellation hangs", async () => {
+		const controller = new AbortController();
+		vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						new ReadableStream({
+							pull() {},
+							cancel: () => new Promise<void>(() => undefined),
+						}),
+						{ headers: { "content-type": "application/json" } },
+					),
+			),
+		);
+		setTimeout(
+			() =>
+				controller.abort(new DOMException("private detail", "TimeoutError")),
+			0,
+		);
+
+		await expect(
+			preset("vercel").validate({ token: "secret" }),
+		).resolves.toEqual({
+			valid: false,
+			error: "Vercel credential validation timed out",
+		});
+	});
+
+	it("cancels status-only response bodies without buffering them", async () => {
+		let cancelled = false;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				async () =>
+					new Response(
+						new ReadableStream({
+							pull() {},
+							cancel() {
+								cancelled = true;
+							},
+						}),
+						{ status: 429 },
+					),
+			),
+		);
+
+		await expect(preset("fal").validate({ apiKey: "secret" })).resolves.toEqual(
+			{
+				valid: false,
+				error: "fal.ai returned 429",
+			},
+		);
+		expect(cancelled).toBe(true);
 	});
 });

--- a/plugins/plugin-discord/actions/setup-credentials.ts
+++ b/plugins/plugin-discord/actions/setup-credentials.ts
@@ -1,9 +1,7 @@
 /**
  * Credential preset definitions and loader for the connector `/setup` flow.
  * Describes the fields each credential preset requires and reads their values
- * from disk. Preset `validate` probes honor `SETUP_CREDENTIAL_FETCH_TIMEOUT_MS`
- * so a hung GitHub / Vercel / Cloudflare / Anthropic / OpenAI / fal.ai hop
- * cannot stall `/setup`.
+ * from disk.
  */
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -27,16 +25,201 @@ export interface CredentialField {
 }
 
 const SAFE_PRESET_NAME_RE = /^[A-Za-z0-9_-]+$/;
+const CREDENTIAL_PROBE_TIMEOUT_MS = 15_000;
+const CREDENTIAL_PROBE_MAX_BODY_BYTES = 64 * 1024;
+const CREDENTIAL_VALUE_MAX_LENGTH = 16 * 1024;
 const presets = new Map<string, CredentialPreset>();
 
-/** Bound for untrusted credential-probe HTTP so `/setup` cannot hang forever. */
-export const SETUP_CREDENTIAL_FETCH_TIMEOUT_MS = 15_000;
+class CredentialProbeError extends Error {
+	constructor(readonly kind: "timeout" | "response" | "network") {
+		super(kind);
+		this.name = "CredentialProbeError";
+	}
+}
 
-function probeFetch(input: string, init: RequestInit): Promise<Response> {
-	return fetch(input, {
-		...init,
-		signal: AbortSignal.timeout(SETUP_CREDENTIAL_FETCH_TIMEOUT_MS),
+function isJsonContentType(contentType: string | null): boolean {
+	if (!contentType) return false;
+	const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase();
+	return (
+		mediaType === "application/json" || mediaType?.endsWith("+json") === true
+	);
+}
+
+function parseContentLength(value: string | null): number | null {
+	if (value === null) return null;
+	if (!/^\d+$/.test(value)) throw new CredentialProbeError("response");
+	const parsed = Number(value);
+	if (!Number.isSafeInteger(parsed)) throw new CredentialProbeError("response");
+	return parsed;
+}
+
+async function startBodyCancellation(
+	stream:
+		| ReadableStream<Uint8Array>
+		| ReadableStreamDefaultReader<Uint8Array>
+		| null,
+	reason?: unknown,
+): Promise<void> {
+	if (!stream) return;
+	// Starting cancellation is sufficient for this boundary. A provider stream's
+	// teardown promise must not extend the probe deadline, while Promise.race still
+	// observes a later cancellation rejection.
+	await Promise.race([stream.cancel(reason), Promise.resolve()]);
+}
+
+async function readBodyChunk(
+	reader: ReadableStreamDefaultReader<Uint8Array>,
+	signal: AbortSignal,
+): Promise<{ done: boolean; value?: Uint8Array }> {
+	if (signal.aborted) throw new CredentialProbeError("timeout");
+	return await new Promise((resolve, reject) => {
+		const onAbort = () => reject(new CredentialProbeError("timeout"));
+		signal.addEventListener("abort", onAbort, { once: true });
+		reader.read().then(
+			(value) => {
+				signal.removeEventListener("abort", onAbort);
+				resolve(value);
+			},
+			(error: unknown) => {
+				signal.removeEventListener("abort", onAbort);
+				reject(error);
+			},
+		);
 	});
+}
+
+async function readBoundedBody(
+	response: Response,
+	signal: AbortSignal,
+): Promise<Uint8Array> {
+	const declaredLength = parseContentLength(
+		response.headers.get("content-length"),
+	);
+	if (
+		declaredLength !== null &&
+		declaredLength > CREDENTIAL_PROBE_MAX_BODY_BYTES
+	) {
+		await startBodyCancellation(response.body, "credential response too large");
+		throw new CredentialProbeError("response");
+	}
+
+	if (!response.body) return new Uint8Array();
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let received = 0;
+	try {
+		while (true) {
+			const chunk = await readBodyChunk(reader, signal);
+			if (chunk.done) break;
+			if (!chunk.value) throw new CredentialProbeError("response");
+			received += chunk.value.byteLength;
+			if (received > CREDENTIAL_PROBE_MAX_BODY_BYTES) {
+				throw new CredentialProbeError("response");
+			}
+			chunks.push(chunk.value);
+		}
+	} catch (error) {
+		// error-policy:J2 cancel the bounded reader before preserving its typed failure.
+		await startBodyCancellation(reader, error);
+		throw error;
+	} finally {
+		reader.releaseLock();
+	}
+
+	const body = new Uint8Array(received);
+	let offset = 0;
+	for (const chunk of chunks) {
+		body.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return body;
+}
+
+async function readProbeJson(
+	response: Response,
+	signal: AbortSignal,
+): Promise<unknown> {
+	if (!isJsonContentType(response.headers.get("content-type"))) {
+		await startBodyCancellation(
+			response.body,
+			"invalid credential response type",
+		);
+		throw new CredentialProbeError("response");
+	}
+	const bytes = await readBoundedBody(response, signal);
+	try {
+		const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+		return JSON.parse(text) as unknown;
+	} catch {
+		// error-policy:J3 malformed provider JSON is an explicit invalid response.
+		throw new CredentialProbeError("response");
+	}
+}
+
+async function credentialProbe(
+	url: string,
+	init: RequestInit,
+): Promise<{ response: Response; signal: AbortSignal }> {
+	const signal = AbortSignal.timeout(CREDENTIAL_PROBE_TIMEOUT_MS);
+	try {
+		const response = await fetch(url, {
+			...init,
+			redirect: "error",
+			signal,
+		});
+		return { response, signal };
+	} catch {
+		// error-policy:J1 network and timeout failures become stable probe errors.
+		if (signal.aborted) throw new CredentialProbeError("timeout");
+		throw new CredentialProbeError("network");
+	}
+}
+
+async function discardProbeBody(
+	response: Response,
+	_signal: AbortSignal,
+): Promise<void> {
+	await startBodyCancellation(
+		response.body,
+		"credential response not consumed",
+	);
+}
+
+function invalidProbeResult(
+	service: string,
+	error: unknown,
+): { valid: false; error: string } {
+	const kind = error instanceof CredentialProbeError ? error.kind : "network";
+	return {
+		valid: false,
+		error:
+			kind === "timeout"
+				? `${service} credential validation timed out`
+				: kind === "response"
+					? `${service} returned an invalid response`
+					: `Unable to reach ${service} credential service`,
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireCredential(
+	credentials: Record<string, string>,
+	key: string,
+	maxLength = CREDENTIAL_VALUE_MAX_LENGTH,
+): string {
+	const value = credentials[key];
+	if (
+		typeof value !== "string" ||
+		value.trim().length === 0 ||
+		value.length > maxLength ||
+		/[\r\n\0]/.test(value)
+	) {
+		throw new CredentialProbeError("response");
+	}
+	return value;
 }
 
 function getCredentialsDir(): string {
@@ -81,29 +264,38 @@ registerPreset({
 		"Create a fine-grained PAT at the link above. Give it the repository permissions you need.",
 	async validate(credentials) {
 		try {
-			const response = await probeFetch("https://api.github.com/user", {
-				headers: {
-					Authorization: `Bearer ${credentials.token}`,
-					Accept: "application/vnd.github+json",
+			const token = requireCredential(credentials, "token");
+			const { response, signal } = await credentialProbe(
+				"https://api.github.com/user",
+				{
+					headers: {
+						Authorization: `Bearer ${token}`,
+						Accept: "application/vnd.github+json",
+					},
 				},
-			});
+			);
 			if (!response.ok) {
+				await discardProbeBody(response, signal);
 				return {
 					valid: false,
 					error: `GitHub returned ${response.status}`,
 				};
 			}
-			const data = (await response.json()) as { login?: string };
+			const data = await readProbeJson(response, signal);
+			if (
+				!isRecord(data) ||
+				typeof data.login !== "string" ||
+				!/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(data.login)
+			) {
+				throw new CredentialProbeError("response");
+			}
 			return {
 				valid: true,
-				identity: data.login ? `@${data.login}` : "verified",
+				identity: `@${data.login}`,
 			};
 		} catch (error) {
-			// error-policy:J1 hung or failed credential probe is invalid, never a hang
-			return {
-				valid: false,
-				error: error instanceof Error ? error.message : String(error),
-			};
+			// error-policy:J1 credential probes expose only bounded, secret-free failures.
+			return invalidProbeResult("GitHub", error);
 		}
 	},
 });
@@ -116,28 +308,29 @@ registerPreset({
 	helpText: "Create a token at the link above. Full Account scope works best.",
 	async validate(credentials) {
 		try {
-			const response = await probeFetch("https://api.vercel.com/v9/projects", {
-				headers: { Authorization: `Bearer ${credentials.token}` },
-			});
+			const token = requireCredential(credentials, "token");
+			const { response, signal } = await credentialProbe(
+				"https://api.vercel.com/v9/projects",
+				{ headers: { Authorization: `Bearer ${token}` } },
+			);
 			if (!response.ok) {
+				await discardProbeBody(response, signal);
 				return {
 					valid: false,
 					error: `Vercel returned ${response.status}`,
 				};
 			}
-			const data = (await response.json()) as {
-				projects?: Array<{ name: string }>;
-			};
+			const data = await readProbeJson(response, signal);
+			if (!isRecord(data) || !Array.isArray(data.projects)) {
+				throw new CredentialProbeError("response");
+			}
 			return {
 				valid: true,
-				identity: `${data.projects?.length ?? 0} project(s) accessible`,
+				identity: `${data.projects.length} project(s) returned by probe`,
 			};
 		} catch (error) {
-			// error-policy:J1 hung or failed credential probe is invalid, never a hang
-			return {
-				valid: false,
-				error: error instanceof Error ? error.message : String(error),
-			};
+			// error-policy:J1 credential probes expose only bounded, secret-free failures.
+			return invalidProbeResult("Vercel", error);
 		}
 	},
 });
@@ -154,37 +347,39 @@ registerPreset({
 		'Go to Cloudflare > Profile > API Tokens > "Global API Key". You will also need your account email.',
 	async validate(credentials) {
 		try {
-			const response = await probeFetch(
+			const apiKey = requireCredential(credentials, "apiKey");
+			const email = requireCredential(credentials, "email", 320);
+			const { response, signal } = await credentialProbe(
 				"https://api.cloudflare.com/client/v4/zones",
 				{
 					headers: {
-						"X-Auth-Key": credentials.apiKey,
-						"X-Auth-Email": credentials.email,
+						"X-Auth-Key": apiKey,
+						"X-Auth-Email": email,
 					},
 				},
 			);
 			if (!response.ok) {
+				await discardProbeBody(response, signal);
 				return {
 					valid: false,
 					error: `Cloudflare returned ${response.status}`,
 				};
 			}
-			const data = (await response.json()) as {
-				result?: Array<{ name: string }>;
-			};
+			const data = await readProbeJson(response, signal);
+			if (
+				!isRecord(data) ||
+				data.success !== true ||
+				!Array.isArray(data.result)
+			) {
+				throw new CredentialProbeError("response");
+			}
 			return {
 				valid: true,
-				identity:
-					data.result && data.result.length > 0
-						? `zones: ${data.result.map((zone) => zone.name).join(", ")}`
-						: "verified",
+				identity: `${data.result.length} zone(s) returned by probe`,
 			};
 		} catch (error) {
-			// error-policy:J1 hung or failed credential probe is invalid, never a hang
-			return {
-				valid: false,
-				error: error instanceof Error ? error.message : String(error),
-			};
+			// error-policy:J1 credential probes expose only bounded, secret-free failures.
+			return invalidProbeResult("Cloudflare", error);
 		}
 	},
 });
@@ -197,13 +392,14 @@ registerPreset({
 	helpText: "Create an API key in the Anthropic console.",
 	async validate(credentials) {
 		try {
+			const apiKey = requireCredential(credentials, "apiKey");
 			// @duplicate-component-audit-allow: credential probe validates the key; response content is ignored.
-			const response = await probeFetch(
+			const { response, signal } = await credentialProbe(
 				"https://api.anthropic.com/v1/messages",
 				{
 					method: "POST",
 					headers: {
-						"x-api-key": credentials.apiKey,
+						"x-api-key": apiKey,
 						"anthropic-version": "2023-06-01",
 						"Content-Type": "application/json",
 					},
@@ -214,19 +410,18 @@ registerPreset({
 					}),
 				},
 			);
-			if (response.ok || response.status === 429) {
+			if (response.ok) {
+				await discardProbeBody(response, signal);
 				return { valid: true, identity: "key verified" };
 			}
+			await discardProbeBody(response, signal);
 			return {
 				valid: false,
 				error: `Anthropic returned ${response.status}`,
 			};
 		} catch (error) {
-			// error-policy:J1 hung or failed credential probe is invalid, never a hang
-			return {
-				valid: false,
-				error: error instanceof Error ? error.message : String(error),
-			};
+			// error-policy:J1 credential probes expose only bounded, secret-free failures.
+			return invalidProbeResult("Anthropic", error);
 		}
 	},
 });
@@ -239,22 +434,23 @@ registerPreset({
 	helpText: "Create an API key at the OpenAI platform link above.",
 	async validate(credentials) {
 		try {
-			const response = await probeFetch("https://api.openai.com/v1/models", {
-				headers: { Authorization: `Bearer ${credentials.apiKey}` },
-			});
-			if (response.ok || response.status === 429) {
+			const apiKey = requireCredential(credentials, "apiKey");
+			const { response, signal } = await credentialProbe(
+				"https://api.openai.com/v1/models",
+				{ headers: { Authorization: `Bearer ${apiKey}` } },
+			);
+			if (response.ok) {
+				await discardProbeBody(response, signal);
 				return { valid: true, identity: "key verified" };
 			}
+			await discardProbeBody(response, signal);
 			return {
 				valid: false,
 				error: `OpenAI returned ${response.status}`,
 			};
 		} catch (error) {
-			// error-policy:J1 hung or failed credential probe is invalid, never a hang
-			return {
-				valid: false,
-				error: error instanceof Error ? error.message : String(error),
-			};
+			// error-policy:J1 credential probes expose only bounded, secret-free failures.
+			return invalidProbeResult("OpenAI", error);
 		}
 	},
 });
@@ -267,12 +463,13 @@ registerPreset({
 	helpText: "Generate an API key from your fal.ai dashboard.",
 	async validate(credentials) {
 		try {
-			const response = await probeFetch(
+			const apiKey = requireCredential(credentials, "apiKey");
+			const { response, signal } = await credentialProbe(
 				"https://rest.fal.run/fal-ai/fast-sdxl",
 				{
 					method: "POST",
 					headers: {
-						Authorization: `Key ${credentials.apiKey}`,
+						Authorization: `Key ${apiKey}`,
 						"Content-Type": "application/json",
 					},
 					body: JSON.stringify({
@@ -282,19 +479,18 @@ registerPreset({
 					}),
 				},
 			);
-			if (response.ok || response.status === 422 || response.status === 429) {
+			if (response.ok) {
+				await discardProbeBody(response, signal);
 				return { valid: true, identity: "key verified" };
 			}
+			await discardProbeBody(response, signal);
 			return {
 				valid: false,
 				error: `fal.ai returned ${response.status}`,
 			};
 		} catch (error) {
-			// error-policy:J1 hung or failed credential probe is invalid, never a hang
-			return {
-				valid: false,
-				error: error instanceof Error ? error.message : String(error),
-			};
+			// error-policy:J1 credential probes expose only bounded, secret-free failures.
+			return invalidProbeResult("fal.ai", error);
 		}
 	},
 });
@@ -331,6 +527,7 @@ export function loadCredentials(
 			string
 		>;
 	} catch {
+		// error-policy:J3 malformed credential files are treated as absent input.
 		return null;
 	}
 }

--- a/plugins/plugin-discord/actions/setup-credentials.ts
+++ b/plugins/plugin-discord/actions/setup-credentials.ts
@@ -46,6 +46,21 @@ class CredentialProbeError extends ElizaError {
 	}
 }
 
+/**
+ * Raised when supplied credential input is rejected locally, before any
+ * request leaves the process. Kept distinct from CredentialProbeError so the
+ * user-facing message never blames the provider for input that was never sent.
+ */
+class CredentialInputError extends ElizaError {
+	constructor(readonly field: string) {
+		super("Credential input rejected before probing the provider.", {
+			code: "CREDENTIAL_INPUT_INVALID",
+			context: { field },
+			severity: "fatal",
+		});
+	}
+}
+
 function isJsonContentType(contentType: string | null): boolean {
 	if (!contentType) return false;
 	const mediaType = contentType.split(";", 1)[0]?.trim().toLowerCase();
@@ -219,6 +234,12 @@ function invalidProbeResult(
 	service: string,
 	error: unknown,
 ): { valid: false; error: string } {
+	if (error instanceof CredentialInputError) {
+		return {
+			valid: false,
+			error: `Invalid ${error.field} value; provide a non-empty single-line value`,
+		};
+	}
 	const kind = error instanceof CredentialProbeError ? error.kind : "network";
 	return {
 		valid: false,
@@ -247,7 +268,7 @@ function requireCredential(
 		value.length > maxLength ||
 		/[\r\n\0]/.test(value)
 	) {
-		throw new CredentialProbeError("response");
+		throw new CredentialInputError(key);
 	}
 	return value;
 }
@@ -312,10 +333,12 @@ registerPreset({
 				};
 			}
 			const data = await readProbeJson(response, signal);
+			// The character class includes underscores because Enterprise Managed
+			// User logins (for example "mona_acme") are valid GitHub identities.
 			if (
 				!isRecord(data) ||
 				typeof data.login !== "string" ||
-				!/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(data.login)
+				!/^[A-Za-z0-9][A-Za-z0-9_-]{0,38}$/.test(data.login)
 			) {
 				throw new CredentialProbeError("response");
 			}

--- a/plugins/plugin-discord/actions/setup-credentials.ts
+++ b/plugins/plugin-discord/actions/setup-credentials.ts
@@ -2,6 +2,15 @@
  * Credential preset definitions and loader for the connector `/setup` flow.
  * Describes the fields each credential preset requires and reads their values
  * from disk.
+ *
+ * Preset `validate` hooks probe third-party APIs with attacker-influenced
+ * responses, so every probe is bounded and fails closed: a shared deadline
+ * covers the request and every body read, redirects are refused rather than
+ * followed, bodies are capped and must be JSON matching the provider's success
+ * schema, and unconsumed bodies are cancelled. Failures are translated into a
+ * fixed set of messages that never echo transport detail or credential text,
+ * and input rejected before a request leaves the process is reported as local
+ * input error rather than as provider misbehaviour.
  */
 import * as fs from "node:fs";
 import * as os from "node:os";

--- a/plugins/plugin-discord/actions/setup-credentials.ts
+++ b/plugins/plugin-discord/actions/setup-credentials.ts
@@ -35,6 +35,10 @@ export interface CredentialField {
 }
 
 const SAFE_PRESET_NAME_RE = /^[A-Za-z0-9_-]+$/;
+/**
+ * Deadline shared by a credential probe's request and every one of its body
+ * reads, so `/setup` cannot hang on an untrusted provider hop.
+ */
 export const SETUP_CREDENTIAL_FETCH_TIMEOUT_MS = 15_000;
 const CREDENTIAL_PROBE_MAX_BODY_BYTES = 64 * 1024;
 const CREDENTIAL_VALUE_MAX_LENGTH = 16 * 1024;

--- a/plugins/plugin-discord/actions/setup-credentials.ts
+++ b/plugins/plugin-discord/actions/setup-credentials.ts
@@ -6,6 +6,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { ElizaError, logger } from "@elizaos/core";
 
 export interface CredentialPreset {
 	name: string;
@@ -30,10 +31,18 @@ const CREDENTIAL_PROBE_MAX_BODY_BYTES = 64 * 1024;
 const CREDENTIAL_VALUE_MAX_LENGTH = 16 * 1024;
 const presets = new Map<string, CredentialPreset>();
 
-class CredentialProbeError extends Error {
+class CredentialProbeError extends ElizaError {
 	constructor(readonly kind: "timeout" | "response" | "network") {
-		super(kind);
-		this.name = "CredentialProbeError";
+		super("Credential validation probe failed.", {
+			code:
+				kind === "timeout"
+					? "CREDENTIAL_PROBE_TIMEOUT"
+					: kind === "response"
+						? "CREDENTIAL_PROBE_RESPONSE_INVALID"
+						: "CREDENTIAL_PROBE_NETWORK_FAILED",
+			context: { kind },
+			severity: kind === "response" ? "fatal" : "ephemeral",
+		});
 	}
 }
 
@@ -53,25 +62,39 @@ function parseContentLength(value: string | null): number | null {
 	return parsed;
 }
 
-async function startBodyCancellation(
+function cancelProbeBody(
 	stream:
 		| ReadableStream<Uint8Array>
 		| ReadableStreamDefaultReader<Uint8Array>
 		| null,
 	reason?: unknown,
-): Promise<void> {
+): void {
 	if (!stream) return;
-	// Starting cancellation is sufficient for this boundary. A provider stream's
-	// teardown promise must not extend the probe deadline, while Promise.race still
-	// observes a later cancellation rejection.
-	await Promise.race([stream.cancel(reason), Promise.resolve()]);
+	try {
+		// error-policy:J6 provider-stream teardown is best effort and must not
+		// extend the probe deadline; its rejection is observed and safely logged.
+		void stream.cancel(reason).catch(() => {
+			logger.debug(
+				"[DiscordCredentialProbe] Failed to cancel provider response body",
+			);
+		});
+	} catch {
+		// error-policy:J6 synchronous provider-stream teardown failure is safe to ignore.
+		logger.debug(
+			"[DiscordCredentialProbe] Failed to cancel provider response body",
+		);
+	}
+}
+
+function throwIfProbeTimedOut(signal: AbortSignal): void {
+	if (signal.aborted) throw new CredentialProbeError("timeout");
 }
 
 async function readBodyChunk(
 	reader: ReadableStreamDefaultReader<Uint8Array>,
 	signal: AbortSignal,
 ): Promise<{ done: boolean; value?: Uint8Array }> {
-	if (signal.aborted) throw new CredentialProbeError("timeout");
+	throwIfProbeTimedOut(signal);
 	return await new Promise((resolve, reject) => {
 		const onAbort = () => reject(new CredentialProbeError("timeout"));
 		signal.addEventListener("abort", onAbort, { once: true });
@@ -92,6 +115,7 @@ async function readBoundedBody(
 	response: Response,
 	signal: AbortSignal,
 ): Promise<Uint8Array> {
+	throwIfProbeTimedOut(signal);
 	const declaredLength = parseContentLength(
 		response.headers.get("content-length"),
 	);
@@ -99,11 +123,14 @@ async function readBoundedBody(
 		declaredLength !== null &&
 		declaredLength > CREDENTIAL_PROBE_MAX_BODY_BYTES
 	) {
-		await startBodyCancellation(response.body, "credential response too large");
+		cancelProbeBody(response.body, "credential response too large");
 		throw new CredentialProbeError("response");
 	}
 
-	if (!response.body) return new Uint8Array();
+	if (!response.body) {
+		throwIfProbeTimedOut(signal);
+		return new Uint8Array();
+	}
 	const reader = response.body.getReader();
 	const chunks: Uint8Array[] = [];
 	let received = 0;
@@ -120,7 +147,7 @@ async function readBoundedBody(
 		}
 	} catch (error) {
 		// error-policy:J2 cancel the bounded reader before preserving its typed failure.
-		await startBodyCancellation(reader, error);
+		cancelProbeBody(reader, error);
 		throw error;
 	} finally {
 		reader.releaseLock();
@@ -132,6 +159,7 @@ async function readBoundedBody(
 		body.set(chunk, offset);
 		offset += chunk.byteLength;
 	}
+	throwIfProbeTimedOut(signal);
 	return body;
 }
 
@@ -140,20 +168,22 @@ async function readProbeJson(
 	signal: AbortSignal,
 ): Promise<unknown> {
 	if (!isJsonContentType(response.headers.get("content-type"))) {
-		await startBodyCancellation(
-			response.body,
-			"invalid credential response type",
-		);
+		cancelProbeBody(response.body, "invalid credential response type");
 		throw new CredentialProbeError("response");
 	}
 	const bytes = await readBoundedBody(response, signal);
+	let parsed: unknown;
 	try {
 		const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-		return JSON.parse(text) as unknown;
+		parsed = JSON.parse(text) as unknown;
 	} catch {
 		// error-policy:J3 malformed provider JSON is an explicit invalid response.
 		throw new CredentialProbeError("response");
 	}
+	// Keep the deadline check outside the parse catch so a timeout that races a
+	// valid payload retains its typed timeout identity.
+	throwIfProbeTimedOut(signal);
+	return parsed;
 }
 
 async function credentialProbe(
@@ -167,6 +197,10 @@ async function credentialProbe(
 			redirect: "error",
 			signal,
 		});
+		if (signal.aborted) {
+			cancelProbeBody(response.body, "credential probe timed out");
+			throw new CredentialProbeError("timeout");
+		}
 		return { response, signal };
 	} catch {
 		// error-policy:J1 network and timeout failures become stable probe errors.
@@ -175,14 +209,10 @@ async function credentialProbe(
 	}
 }
 
-async function discardProbeBody(
-	response: Response,
-	_signal: AbortSignal,
-): Promise<void> {
-	await startBodyCancellation(
-		response.body,
-		"credential response not consumed",
-	);
+function discardProbeBody(response: Response, signal: AbortSignal): void {
+	throwIfProbeTimedOut(signal);
+	cancelProbeBody(response.body, "credential response not consumed");
+	throwIfProbeTimedOut(signal);
 }
 
 function invalidProbeResult(
@@ -275,7 +305,7 @@ registerPreset({
 				},
 			);
 			if (!response.ok) {
-				await discardProbeBody(response, signal);
+				discardProbeBody(response, signal);
 				return {
 					valid: false,
 					error: `GitHub returned ${response.status}`,
@@ -314,7 +344,7 @@ registerPreset({
 				{ headers: { Authorization: `Bearer ${token}` } },
 			);
 			if (!response.ok) {
-				await discardProbeBody(response, signal);
+				discardProbeBody(response, signal);
 				return {
 					valid: false,
 					error: `Vercel returned ${response.status}`,
@@ -359,7 +389,7 @@ registerPreset({
 				},
 			);
 			if (!response.ok) {
-				await discardProbeBody(response, signal);
+				discardProbeBody(response, signal);
 				return {
 					valid: false,
 					error: `Cloudflare returned ${response.status}`,
@@ -395,26 +425,19 @@ registerPreset({
 			const apiKey = requireCredential(credentials, "apiKey");
 			// @duplicate-component-audit-allow: credential probe validates the key; response content is ignored.
 			const { response, signal } = await credentialProbe(
-				"https://api.anthropic.com/v1/messages",
+				"https://api.anthropic.com/v1/models?limit=1",
 				{
-					method: "POST",
 					headers: {
 						"x-api-key": apiKey,
 						"anthropic-version": "2023-06-01",
-						"Content-Type": "application/json",
 					},
-					body: JSON.stringify({
-						model: "claude-3-5-haiku-20241022",
-						max_tokens: 1,
-						messages: [{ role: "user", content: "hi" }],
-					}),
 				},
 			);
 			if (response.ok) {
-				await discardProbeBody(response, signal);
+				discardProbeBody(response, signal);
 				return { valid: true, identity: "key verified" };
 			}
-			await discardProbeBody(response, signal);
+			discardProbeBody(response, signal);
 			return {
 				valid: false,
 				error: `Anthropic returned ${response.status}`,
@@ -440,10 +463,10 @@ registerPreset({
 				{ headers: { Authorization: `Bearer ${apiKey}` } },
 			);
 			if (response.ok) {
-				await discardProbeBody(response, signal);
+				discardProbeBody(response, signal);
 				return { valid: true, identity: "key verified" };
 			}
-			await discardProbeBody(response, signal);
+			discardProbeBody(response, signal);
 			return {
 				valid: false,
 				error: `OpenAI returned ${response.status}`,
@@ -465,25 +488,20 @@ registerPreset({
 		try {
 			const apiKey = requireCredential(credentials, "apiKey");
 			const { response, signal } = await credentialProbe(
-				"https://rest.fal.run/fal-ai/fast-sdxl",
+				"https://queue.fal.run/fal-ai/flux/schnell/requests/00000000-0000-0000-0000-000000000000/status",
 				{
-					method: "POST",
 					headers: {
 						Authorization: `Key ${apiKey}`,
-						"Content-Type": "application/json",
 					},
-					body: JSON.stringify({
-						prompt: "test",
-						image_size: { width: 64, height: 64 },
-						num_images: 1,
-					}),
 				},
 			);
-			if (response.ok) {
-				await discardProbeBody(response, signal);
+			// A deliberately nonexistent request proves authorization without
+			// submitting billable inference. fal documents 404 as "not found".
+			if (response.ok || response.status === 404) {
+				discardProbeBody(response, signal);
 				return { valid: true, identity: "key verified" };
 			}
-			await discardProbeBody(response, signal);
+			discardProbeBody(response, signal);
 			return {
 				valid: false,
 				error: `fal.ai returned ${response.status}`,

--- a/plugins/plugin-discord/actions/setup-credentials.ts
+++ b/plugins/plugin-discord/actions/setup-credentials.ts
@@ -35,7 +35,7 @@ export interface CredentialField {
 }
 
 const SAFE_PRESET_NAME_RE = /^[A-Za-z0-9_-]+$/;
-const CREDENTIAL_PROBE_TIMEOUT_MS = 15_000;
+export const SETUP_CREDENTIAL_FETCH_TIMEOUT_MS = 15_000;
 const CREDENTIAL_PROBE_MAX_BODY_BYTES = 64 * 1024;
 const CREDENTIAL_VALUE_MAX_LENGTH = 16 * 1024;
 const presets = new Map<string, CredentialPreset>();
@@ -214,7 +214,7 @@ async function credentialProbe(
 	url: string,
 	init: RequestInit,
 ): Promise<{ response: Response; signal: AbortSignal }> {
-	const signal = AbortSignal.timeout(CREDENTIAL_PROBE_TIMEOUT_MS);
+	const signal = AbortSignal.timeout(SETUP_CREDENTIAL_FETCH_TIMEOUT_MS);
 	try {
 		const response = await fetch(url, {
 			...init,

--- a/plugins/plugin-discord/actions/setup-credentials.ts
+++ b/plugins/plugin-discord/actions/setup-credentials.ts
@@ -488,24 +488,32 @@ registerPreset({
 		try {
 			const apiKey = requireCredential(credentials, "apiKey");
 			const { response, signal } = await credentialProbe(
-				"https://queue.fal.run/fal-ai/flux/schnell/requests/00000000-0000-0000-0000-000000000000/status",
+				"https://api.fal.ai/v1/models/pricing?endpoint_id=fal-ai%2Fflux%2Fdev",
 				{
 					headers: {
 						Authorization: `Key ${apiKey}`,
 					},
 				},
 			);
-			// A deliberately nonexistent request proves authorization without
-			// submitting billable inference. fal documents 404 as "not found".
-			if (response.ok || response.status === 404) {
+			if (!response.ok) {
 				discardProbeBody(response, signal);
-				return { valid: true, identity: "key verified" };
+				return {
+					valid: false,
+					error: `fal.ai returned ${response.status}`,
+				};
 			}
-			discardProbeBody(response, signal);
-			return {
-				valid: false,
-				error: `fal.ai returned ${response.status}`,
-			};
+			// fal's authenticated Platform Pricing API is a read-only metadata
+			// request, so validation cannot enqueue or bill model inference.
+			const data = await readProbeJson(response, signal);
+			if (
+				!isRecord(data) ||
+				!Array.isArray(data.prices) ||
+				typeof data.has_more !== "boolean" ||
+				!(data.next_cursor === null || typeof data.next_cursor === "string")
+			) {
+				throw new CredentialProbeError("response");
+			}
+			return { valid: true, identity: "key verified" };
 		} catch (error) {
 			// error-policy:J1 credential probes expose only bounded, secret-free failures.
 			return invalidProbeResult("fal.ai", error);


### PR DESCRIPTION
# Relates to

Follow-up to #22867, #22868, and closed review #23321.

# Contribution provenance

<!-- contribution-attribution:v1 -->
- AI assistance: `yes`
- Model(s) used: `openai/gpt-5.6-sol`
- Agent tooling: `Codex Desktop`
- Provenance status: `self-reported`

# What does this PR do?

Maintains and hardens the latent Discord preset credential-validation foundation with bounded response reads, typed failures, authoritative timeout identity, redirect fencing, authenticated non-billable read probes, and teardown that cannot replace the primary result. fal validation uses its authenticated, read-only Platform Pricing API rather than submitting inference: https://fal.ai/docs/platform-apis/v1/models/pricing.

# Testing

Exact head: `23bf7aa9e576d6f2f5431a07b4815ac1e8b85ad1`. Maintainer verification at this exact head: focused suite `vitest run actions/setup-credentials.test.ts` passed 22/22, `turbo run typecheck --filter=@elizaos/plugin-discord` passed (9/9 tasks), and both changed files pass Biome, all in a clean worktree rebased on current develop.

# Evidence gate

<!-- evidence-head:23bf7aa9e576d6f2f5431a07b4815ac1e8b85ad1 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend/runtime boundary with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend/runtime boundary with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive visual flow.
<!-- evidence-row:backend-logs -->
- [x] Deterministic provider-response, cancellation, body-limit, redirect, and schema tests; authenticated probes never log credential values.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or prompt behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Provider-response fixtures prove read-only validation semantics and rejection of the prior 405 endpoint.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text.

# Known gaps

- Production Discord DM setup still prompts only the first credential and does not collect or persist it. This PR deliberately confines itself to the reusable public validation boundary.
- Exact-head focused tests, package typecheck, and Biome were re-run and verified by the merging maintainer.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop"} -->