### PR TITLE
fix(plugin-x): reject partial and zero TWITTER_*_INTERVAL settings in safeParseInt

### DIFF
--- a/plugins/plugin-x/src/direct-messages.test.ts
+++ b/plugins/plugin-x/src/direct-messages.test.ts
@@ -69,6 +69,37 @@ describe("X DM conversation classification", () => {
 });
 
 describe("TwitterDirectMessageClient", () => {
+  it("does not prefix-parse a partial DM polling interval", async () => {
+    vi.useFakeTimers();
+    const listDmEvents = vi.fn(async () => ({ events: [] }));
+    const runtime = {
+      agentId: "00000000-0000-0000-0000-000000000001",
+      getCache: vi.fn(async () => null),
+      setCache: vi.fn(async () => undefined),
+      reportError: vi.fn(),
+      getSetting: vi.fn(() => null),
+    } as unknown as IAgentRuntime;
+    const client = {
+      accountId: "agent",
+      profile: { id: "agent-user-id", username: "elizamakesmagic" },
+      twitterClient: authenticatedTwitterClient("agent-user-id", {
+        listDmEvents,
+      }),
+    } as unknown as ClientBase;
+    const dmClient = new TwitterDirectMessageClient(client, runtime, {
+      TWITTER_DM_POLICY: "open",
+      TWITTER_DM_POLL_INTERVAL_SECONDS: "90s",
+    });
+
+    await dmClient.start();
+    expect(listDmEvents).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(60_000 - 1);
+    expect(listDmEvents).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(listDmEvents).toHaveBeenCalledTimes(2);
+    await dmClient.stop();
+  });
+
   it("routes configured DMs to personal Eliza without invoking the public agent", async () => {
     vi.useFakeTimers();
     const listDmEvents = vi.fn(async () => ({

--- a/plugins/plugin-x/src/direct-messages.ts
+++ b/plugins/plugin-x/src/direct-messages.ts
@@ -27,6 +27,7 @@ import {
 import type { ClientBase } from "./base";
 import type { AuthenticatedTwitterSession } from "./client/auth";
 import { checkTwitterDmAccess, resolveTwitterDmPolicy } from "./dm-policy";
+import { parseTwitterInterval } from "./environment";
 import type { TwitterClientState } from "./types";
 import { createMemorySafe, reconcileTwitterWorld } from "./utils/memory";
 import { normalizeXReceiptId } from "./utils/provider-receipt";
@@ -66,13 +67,15 @@ function parseBoolean(value: unknown, fallback: boolean): boolean {
 }
 
 function parsePollIntervalMs(value: unknown): number {
-  const seconds =
+  const seconds = parseTwitterInterval(
     typeof value === "number"
-      ? value
+      ? String(value)
       : typeof value === "string"
-        ? Number.parseInt(value, 10)
-        : Number.NaN;
-  return Math.max(15, Number.isFinite(seconds) ? seconds : 60) * 1_000;
+        ? value
+        : undefined,
+    60,
+  );
+  return Math.max(15, seconds) * 1_000;
 }
 
 function compareEventIds(left: string, right: string): number {

--- a/plugins/plugin-x/src/environment.test.ts
+++ b/plugins/plugin-x/src/environment.test.ts
@@ -1,8 +1,9 @@
 /**
- * Deterministic unit coverage for getRandomInterval's env parsing: negative
- * TWITTER_*_INTERVAL values must fall back like NaN instead of surviving the
- * min < max guard and collapsing the scheduler's setTimeout delay to ~0.
- * Fake runtime whose getSetting reads a map; Math.random is stubbed.
+ * Deterministic unit coverage for getRandomInterval's env parsing: negative,
+ * zero, partial (`1h`, `90s`), and non-numeric TWITTER_*_INTERVAL values must
+ * fall back instead of surviving parseInt's prefix match and collapsing the
+ * scheduler's setTimeout delay to ~0. Fake runtime whose getSetting reads a
+ * map; Math.random is stubbed.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -32,8 +33,7 @@ describe("getRandomInterval", () => {
     expect(interval).toBe(135);
   });
 
-  it("treats a negative min like NaN so the interval clamps to [0, max] instead of going negative", () => {
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
+  it("ignores a negative min instead of treating it as 0 and drawing in [0, max]", () => {
     const interval = getRandomInterval(
       makeRuntime({
         TWITTER_POST_INTERVAL_MIN: "-9999999",
@@ -41,8 +41,7 @@ describe("getRandomInterval", () => {
       }),
       "post",
     );
-    expect(interval).toBe(90);
-    expect(interval).toBeGreaterThanOrEqual(0);
+    expect(interval).toBe(120);
   });
 
   it("falls back to the fixed interval when both bounds are negative", () => {
@@ -71,5 +70,24 @@ describe("getRandomInterval", () => {
       "post",
     );
     expect(interval).toBe(120);
+  });
+
+  it.each(["1h", "90s", "120min", "12.5", "1e3", "0", "+120", " 120 min"])(
+    "rejects partial or zero interval %p and uses the documented default",
+    (value) => {
+      const interval = getRandomInterval(
+        makeRuntime({ TWITTER_POST_INTERVAL: value }),
+        "post",
+      );
+      expect(interval).toBe(120);
+    },
+  );
+
+  it("still accepts a whitespace-padded whole minute count", () => {
+    const interval = getRandomInterval(
+      makeRuntime({ TWITTER_POST_INTERVAL: "  90  " }),
+      "post",
+    );
+    expect(interval).toBe(90);
   });
 });

--- a/plugins/plugin-x/src/environment.test.ts
+++ b/plugins/plugin-x/src/environment.test.ts
@@ -103,14 +103,18 @@ describe("validateTwitterConfig interval settings", () => {
     TWITTER_DISCOVERY_INTERVAL_MAX: "30",
   } as const;
 
-  it.each(Object.entries(intervalDefaults))(
-    "rejects a partial %s value at the public configuration boundary",
-    async (key, defaultValue) => {
+  it.each(
+    Object.entries(intervalDefaults).flatMap(([key, defaultValue]) =>
+      ["1h", "0", "12.5", "1e3"].map((value) => [key, value, defaultValue]),
+    ),
+  )(
+    "rejects invalid %s value %s at the public configuration boundary",
+    async (key, value, defaultValue) => {
       const config = await validateTwitterConfig(
         makeRuntime({
           TWITTER_AUTH_MODE: "broker",
           TWITTER_BROKER_TOKEN: "test-token",
-          [key]: "1h",
+          [key]: value,
         }),
       );
       expect(config[key as keyof typeof intervalDefaults]).toBe(defaultValue);
@@ -136,10 +140,12 @@ describe("validateTwitterConfig interval settings", () => {
         TWITTER_AUTH_MODE: "broker",
         TWITTER_BROKER_TOKEN: "test-token",
         TWITTER_MAX_ENGAGEMENTS_PER_RUN: "0",
+        TWITTER_MAX_TWEET_LENGTH: "0",
         TWITTER_RETRY_LIMIT: "0",
       }),
     );
     expect(config.TWITTER_MAX_ENGAGEMENTS_PER_RUN).toBe("0");
+    expect(config.TWITTER_MAX_TWEET_LENGTH).toBe("0");
     expect(config.TWITTER_RETRY_LIMIT).toBe("0");
   });
 });

--- a/plugins/plugin-x/src/environment.test.ts
+++ b/plugins/plugin-x/src/environment.test.ts
@@ -1,14 +1,12 @@
 /**
- * Deterministic unit coverage for getRandomInterval's env parsing: negative,
- * zero, partial (`1h`, `90s`), and non-numeric TWITTER_*_INTERVAL values must
- * fall back instead of surviving parseInt's prefix match and collapsing the
- * scheduler's setTimeout delay to ~0. Fake runtime whose getSetting reads a
- * map; Math.random is stubbed.
+ * Deterministic production-boundary coverage for plugin-x interval parsing.
+ * A fake runtime supplies settings while the real configuration validator and
+ * scheduler helper reject partial or zero interval magnitudes.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { getRandomInterval } from "./environment";
+import { getRandomInterval, validateTwitterConfig } from "./environment";
 
 function makeRuntime(settings: Record<string, string>): IAgentRuntime {
   return {
@@ -89,5 +87,59 @@ describe("getRandomInterval", () => {
       "post",
     );
     expect(interval).toBe(90);
+  });
+});
+
+describe("validateTwitterConfig interval settings", () => {
+  const intervalDefaults = {
+    TWITTER_DM_POLL_INTERVAL_SECONDS: "60",
+    TWITTER_POST_INTERVAL: "120",
+    TWITTER_POST_INTERVAL_MIN: "90",
+    TWITTER_POST_INTERVAL_MAX: "180",
+    TWITTER_ENGAGEMENT_INTERVAL: "30",
+    TWITTER_ENGAGEMENT_INTERVAL_MIN: "20",
+    TWITTER_ENGAGEMENT_INTERVAL_MAX: "40",
+    TWITTER_DISCOVERY_INTERVAL_MIN: "15",
+    TWITTER_DISCOVERY_INTERVAL_MAX: "30",
+  } as const;
+
+  it.each(Object.entries(intervalDefaults))(
+    "rejects a partial %s value at the public configuration boundary",
+    async (key, defaultValue) => {
+      const config = await validateTwitterConfig(
+        makeRuntime({
+          TWITTER_AUTH_MODE: "broker",
+          TWITTER_BROKER_TOKEN: "test-token",
+          [key]: "1h",
+        }),
+      );
+      expect(config[key as keyof typeof intervalDefaults]).toBe(defaultValue);
+    },
+  );
+
+  it("accepts whitespace-padded whole interval values", async () => {
+    const config = await validateTwitterConfig(
+      makeRuntime({
+        TWITTER_AUTH_MODE: "broker",
+        TWITTER_BROKER_TOKEN: "test-token",
+        TWITTER_DM_POLL_INTERVAL_SECONDS: "  15  ",
+        TWITTER_POST_INTERVAL: "  90  ",
+      }),
+    );
+    expect(config.TWITTER_DM_POLL_INTERVAL_SECONDS).toBe("15");
+    expect(config.TWITTER_POST_INTERVAL).toBe("90");
+  });
+
+  it("does not widen the interval fix to zero-valued non-interval settings", async () => {
+    const config = await validateTwitterConfig(
+      makeRuntime({
+        TWITTER_AUTH_MODE: "broker",
+        TWITTER_BROKER_TOKEN: "test-token",
+        TWITTER_MAX_ENGAGEMENTS_PER_RUN: "0",
+        TWITTER_RETRY_LIMIT: "0",
+      }),
+    );
+    expect(config.TWITTER_MAX_ENGAGEMENTS_PER_RUN).toBe("0");
+    expect(config.TWITTER_RETRY_LIMIT).toBe("0");
   });
 });

--- a/plugins/plugin-x/src/environment.ts
+++ b/plugins/plugin-x/src/environment.ts
@@ -100,7 +100,7 @@ function safeParseInt(value: string | undefined, defaultValue: number): number {
 }
 
 /** Parse an interval magnitude without accepting zero or partial integers. */
-function safeParseInterval(
+export function parseTwitterInterval(
   value: string | undefined,
   defaultValue: number,
 ): number {
@@ -267,7 +267,7 @@ export async function validateTwitterConfig(
         getSetting(runtime, "TWITTER_DM_POLICY") ??
         "",
       TWITTER_DM_POLL_INTERVAL_SECONDS: String(
-        safeParseInterval(
+        parseTwitterInterval(
           config.TWITTER_DM_POLL_INTERVAL_SECONDS ??
             getSetting(runtime, "TWITTER_DM_POLL_INTERVAL_SECONDS"),
           60,
@@ -281,56 +281,56 @@ export async function validateTwitterConfig(
         ).toLowerCase() === "true",
       ),
       TWITTER_POST_INTERVAL: String(
-        safeParseInterval(
+        parseTwitterInterval(
           config.TWITTER_POST_INTERVAL ??
             getSetting(runtime, "TWITTER_POST_INTERVAL"),
           120,
         ),
       ),
       TWITTER_POST_INTERVAL_MIN: String(
-        safeParseInterval(
+        parseTwitterInterval(
           config.TWITTER_POST_INTERVAL_MIN ??
             getSetting(runtime, "TWITTER_POST_INTERVAL_MIN"),
           90,
         ),
       ),
       TWITTER_POST_INTERVAL_MAX: String(
-        safeParseInterval(
+        parseTwitterInterval(
           config.TWITTER_POST_INTERVAL_MAX ??
             getSetting(runtime, "TWITTER_POST_INTERVAL_MAX"),
           180,
         ),
       ),
       TWITTER_ENGAGEMENT_INTERVAL: String(
-        safeParseInterval(
+        parseTwitterInterval(
           config.TWITTER_ENGAGEMENT_INTERVAL ??
             getSetting(runtime, "TWITTER_ENGAGEMENT_INTERVAL"),
           30,
         ),
       ),
       TWITTER_ENGAGEMENT_INTERVAL_MIN: String(
-        safeParseInterval(
+        parseTwitterInterval(
           config.TWITTER_ENGAGEMENT_INTERVAL_MIN ??
             getSetting(runtime, "TWITTER_ENGAGEMENT_INTERVAL_MIN"),
           20,
         ),
       ),
       TWITTER_ENGAGEMENT_INTERVAL_MAX: String(
-        safeParseInterval(
+        parseTwitterInterval(
           config.TWITTER_ENGAGEMENT_INTERVAL_MAX ??
             getSetting(runtime, "TWITTER_ENGAGEMENT_INTERVAL_MAX"),
           40,
         ),
       ),
       TWITTER_DISCOVERY_INTERVAL_MIN: String(
-        safeParseInterval(
+        parseTwitterInterval(
           config.TWITTER_DISCOVERY_INTERVAL_MIN ??
             getSetting(runtime, "TWITTER_DISCOVERY_INTERVAL_MIN"),
           15,
         ),
       ),
       TWITTER_DISCOVERY_INTERVAL_MAX: String(
-        safeParseInterval(
+        parseTwitterInterval(
           config.TWITTER_DISCOVERY_INTERVAL_MAX ??
             getSetting(runtime, "TWITTER_DISCOVERY_INTERVAL_MAX"),
           30,
@@ -565,7 +565,7 @@ export function getRandomInterval(
       ) as string;
       minInterval = parseStrictPositiveInt(postMin);
       maxInterval = parseStrictPositiveInt(postMax);
-      fixedInterval = safeParseInterval(
+      fixedInterval = parseTwitterInterval(
         getSetting(runtime, "TWITTER_POST_INTERVAL") as string,
         120,
       );
@@ -582,7 +582,7 @@ export function getRandomInterval(
       ) as string;
       minInterval = parseStrictPositiveInt(engagementMin);
       maxInterval = parseStrictPositiveInt(engagementMax);
-      fixedInterval = safeParseInterval(
+      fixedInterval = parseTwitterInterval(
         getSetting(runtime, "TWITTER_ENGAGEMENT_INTERVAL") as string,
         30,
       );

--- a/plugins/plugin-x/src/environment.ts
+++ b/plugins/plugin-x/src/environment.ts
@@ -78,16 +78,30 @@ export const twitterEnvSchema = z.object({
 export type TwitterConfig = z.infer<typeof twitterEnvSchema>;
 
 /**
- * Parse safe integer with a default value. Negative values fall back to the
- * default like NaN does: every numeric TWITTER_* setting (intervals, retry
- * limit, tweet length, follower counts) is a magnitude, and a negative
- * interval survives getRandomInterval's min < max guard only to collapse the
- * scheduler's setTimeout delay to ~0, defeating the posting-rate limiter.
+ * Parse a strictly whole positive integer. `parseInt` stops at the first
+ * non-digit, so `"1h"` / `"90s"` / `"12.5"` would otherwise become 1 / 90 / 12
+ * and collapse the posting-rate limiter the same way a negative interval did
+ * (#21661). Zero is rejected because a 0-minute delay is that same collapse.
+ */
+function parseStrictPositiveInt(value: unknown): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!/^[0-9]+$/.test(trimmed)) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return undefined;
+  return parsed;
+}
+
+/**
+ * Parse safe integer with a default value. Negative, zero, partial, and
+ * non-numeric values fall back to the default: every numeric TWITTER_* setting
+ * (intervals, retry limit, tweet length, follower counts) is a magnitude, and
+ * a junk or zero interval survives getRandomInterval's min < max guard only to
+ * collapse the scheduler's setTimeout delay to ~0, defeating the posting-rate
+ * limiter.
  */
 function safeParseInt(value: string | undefined, defaultValue: number): number {
-  if (!value) return defaultValue;
-  const parsed = parseInt(value, 10);
-  return Number.isNaN(parsed) || parsed < 0 ? defaultValue : parsed;
+  return parseStrictPositiveInt(value) ?? defaultValue;
 }
 
 /**
@@ -546,8 +560,8 @@ export function getRandomInterval(
         runtime,
         "TWITTER_POST_INTERVAL_MAX",
       ) as string;
-      minInterval = postMin ? safeParseInt(postMin, 0) : undefined;
-      maxInterval = postMax ? safeParseInt(postMax, 0) : undefined;
+      minInterval = parseStrictPositiveInt(postMin);
+      maxInterval = parseStrictPositiveInt(postMax);
       fixedInterval = safeParseInt(
         getSetting(runtime, "TWITTER_POST_INTERVAL") as string,
         120,
@@ -563,8 +577,8 @@ export function getRandomInterval(
         runtime,
         "TWITTER_ENGAGEMENT_INTERVAL_MAX",
       ) as string;
-      minInterval = engagementMin ? safeParseInt(engagementMin, 0) : undefined;
-      maxInterval = engagementMax ? safeParseInt(engagementMax, 0) : undefined;
+      minInterval = parseStrictPositiveInt(engagementMin);
+      maxInterval = parseStrictPositiveInt(engagementMax);
       fixedInterval = safeParseInt(
         getSetting(runtime, "TWITTER_ENGAGEMENT_INTERVAL") as string,
         30,
@@ -580,8 +594,8 @@ export function getRandomInterval(
         runtime,
         "TWITTER_DISCOVERY_INTERVAL_MAX",
       ) as string;
-      minInterval = discoveryMin ? safeParseInt(discoveryMin, 0) : undefined;
-      maxInterval = discoveryMax ? safeParseInt(discoveryMax, 0) : undefined;
+      minInterval = parseStrictPositiveInt(discoveryMin);
+      maxInterval = parseStrictPositiveInt(discoveryMax);
       fixedInterval = 20; // Default discovery interval
       break;
     }

--- a/plugins/plugin-x/src/environment.ts
+++ b/plugins/plugin-x/src/environment.ts
@@ -92,15 +92,18 @@ function parseStrictPositiveInt(value: unknown): number | undefined {
   return parsed;
 }
 
-/**
- * Parse safe integer with a default value. Negative, zero, partial, and
- * non-numeric values fall back to the default: every numeric TWITTER_* setting
- * (intervals, retry limit, tweet length, follower counts) is a magnitude, and
- * a junk or zero interval survives getRandomInterval's min < max guard only to
- * collapse the scheduler's setTimeout delay to ~0, defeating the posting-rate
- * limiter.
- */
+/** Parse a safe integer while preserving legacy zero/prefix behavior. */
 function safeParseInt(value: string | undefined, defaultValue: number): number {
+  if (!value) return defaultValue;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) || parsed < 0 ? defaultValue : parsed;
+}
+
+/** Parse an interval magnitude without accepting zero or partial integers. */
+function safeParseInterval(
+  value: string | undefined,
+  defaultValue: number,
+): number {
   return parseStrictPositiveInt(value) ?? defaultValue;
 }
 
@@ -264,7 +267,7 @@ export async function validateTwitterConfig(
         getSetting(runtime, "TWITTER_DM_POLICY") ??
         "",
       TWITTER_DM_POLL_INTERVAL_SECONDS: String(
-        safeParseInt(
+        safeParseInterval(
           config.TWITTER_DM_POLL_INTERVAL_SECONDS ??
             getSetting(runtime, "TWITTER_DM_POLL_INTERVAL_SECONDS"),
           60,
@@ -278,56 +281,56 @@ export async function validateTwitterConfig(
         ).toLowerCase() === "true",
       ),
       TWITTER_POST_INTERVAL: String(
-        safeParseInt(
+        safeParseInterval(
           config.TWITTER_POST_INTERVAL ??
             getSetting(runtime, "TWITTER_POST_INTERVAL"),
           120,
         ),
       ),
       TWITTER_POST_INTERVAL_MIN: String(
-        safeParseInt(
+        safeParseInterval(
           config.TWITTER_POST_INTERVAL_MIN ??
             getSetting(runtime, "TWITTER_POST_INTERVAL_MIN"),
           90,
         ),
       ),
       TWITTER_POST_INTERVAL_MAX: String(
-        safeParseInt(
+        safeParseInterval(
           config.TWITTER_POST_INTERVAL_MAX ??
             getSetting(runtime, "TWITTER_POST_INTERVAL_MAX"),
           180,
         ),
       ),
       TWITTER_ENGAGEMENT_INTERVAL: String(
-        safeParseInt(
+        safeParseInterval(
           config.TWITTER_ENGAGEMENT_INTERVAL ??
             getSetting(runtime, "TWITTER_ENGAGEMENT_INTERVAL"),
           30,
         ),
       ),
       TWITTER_ENGAGEMENT_INTERVAL_MIN: String(
-        safeParseInt(
+        safeParseInterval(
           config.TWITTER_ENGAGEMENT_INTERVAL_MIN ??
             getSetting(runtime, "TWITTER_ENGAGEMENT_INTERVAL_MIN"),
           20,
         ),
       ),
       TWITTER_ENGAGEMENT_INTERVAL_MAX: String(
-        safeParseInt(
+        safeParseInterval(
           config.TWITTER_ENGAGEMENT_INTERVAL_MAX ??
             getSetting(runtime, "TWITTER_ENGAGEMENT_INTERVAL_MAX"),
           40,
         ),
       ),
       TWITTER_DISCOVERY_INTERVAL_MIN: String(
-        safeParseInt(
+        safeParseInterval(
           config.TWITTER_DISCOVERY_INTERVAL_MIN ??
             getSetting(runtime, "TWITTER_DISCOVERY_INTERVAL_MIN"),
           15,
         ),
       ),
       TWITTER_DISCOVERY_INTERVAL_MAX: String(
-        safeParseInt(
+        safeParseInterval(
           config.TWITTER_DISCOVERY_INTERVAL_MAX ??
             getSetting(runtime, "TWITTER_DISCOVERY_INTERVAL_MAX"),
           30,
@@ -562,7 +565,7 @@ export function getRandomInterval(
       ) as string;
       minInterval = parseStrictPositiveInt(postMin);
       maxInterval = parseStrictPositiveInt(postMax);
-      fixedInterval = safeParseInt(
+      fixedInterval = safeParseInterval(
         getSetting(runtime, "TWITTER_POST_INTERVAL") as string,
         120,
       );
@@ -579,7 +582,7 @@ export function getRandomInterval(
       ) as string;
       minInterval = parseStrictPositiveInt(engagementMin);
       maxInterval = parseStrictPositiveInt(engagementMax);
-      fixedInterval = safeParseInt(
+      fixedInterval = safeParseInterval(
         getSetting(runtime, "TWITTER_ENGAGEMENT_INTERVAL") as string,
         30,
       );

--- a/plugins/plugin-x/src/services/x.service.test.ts
+++ b/plugins/plugin-x/src/services/x.service.test.ts
@@ -1,7 +1,7 @@
 /** Unit tests for X account status and trusted multi-account connector routing. Network clients are deterministic fakes. */
 import type { Content, IAgentRuntime, TargetInfo } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
-import type { ClientBase } from "../base";
+import { ClientBase } from "../base";
 import type { AuthenticatedTwitterSession } from "../client/auth";
 import type { TwitterClientState } from "../types";
 import { TwitterPostService } from "./PostService";
@@ -45,6 +45,43 @@ function deferred<T>() {
 }
 
 describe("XService account status", () => {
+  it("passes validated interval state into production clients", async () => {
+    const runtime = runtimeWithSettings({
+      TWITTER_AUTH_MODE: "broker",
+      TWITTER_BROKER_TOKEN: "test-token",
+      TWITTER_ENABLE_DMS: "false",
+      TWITTER_ENABLE_REPLIES: "false",
+      TWITTER_ENABLE_ACTIONS: "false",
+      TWITTER_ENABLE_DISCOVERY: "false",
+      TWITTER_ENABLE_POST: "false",
+    });
+    const service = new XService(runtime);
+    const init = vi
+      .spyOn(ClientBase.prototype, "init")
+      .mockResolvedValue(undefined);
+
+    const instance = await (
+      service as unknown as {
+        getTwitterClientForAccount(
+          accountId: string,
+          options: { state: TwitterClientState },
+        ): Promise<TwitterClientInstance>;
+      }
+    ).getTwitterClientForAccount("default", {
+      state: {
+        accountId: "default",
+        TWITTER_AUTH_MODE: "broker",
+        TWITTER_BROKER_TOKEN: "test-token",
+        TWITTER_POST_INTERVAL: "1h",
+        TWITTER_DM_POLL_INTERVAL_SECONDS: "90s",
+      },
+    });
+
+    expect(instance.client.state.TWITTER_POST_INTERVAL).toBe("120");
+    expect(instance.client.state.TWITTER_DM_POLL_INTERVAL_SECONDS).toBe("60");
+    init.mockRestore();
+  });
+
   it("honors account-scoped DM disablement over the runtime default", () => {
     const instance = new TwitterClientInstance(
       runtimeWithSettings({ TWITTER_ENABLE_DMS: "true" }),

--- a/plugins/plugin-x/src/services/x.service.ts
+++ b/plugins/plugin-x/src/services/x.service.ts
@@ -354,7 +354,10 @@ export class XService extends Service {
       }
 
       const defaultState = await resolveTwitterAccountConfig(runtime);
-      await validateTwitterConfig(runtime, defaultState);
+      const validatedDefaultState = {
+        ...defaultState,
+        ...(await validateTwitterConfig(runtime, defaultState)),
+      };
       service.defaultAccountId = resolveDefaultXAccountId(
         runtime,
         defaultState,
@@ -363,7 +366,7 @@ export class XService extends Service {
 
       service.twitterClient = await service.getTwitterClientForAccount(
         service.defaultAccountId,
-        { startAutonomousClients: true, state: defaultState },
+        { startAutonomousClients: true, state: validatedDefaultState },
       );
 
       logger.log("✅ Twitter service started successfully");
@@ -421,8 +424,11 @@ export class XService extends Service {
     }
 
     const startPromise = (async () => {
-      await validateTwitterConfig(runtime, state);
-      const instance = new TwitterClientInstance(runtime, state);
+      const validatedState = {
+        ...state,
+        ...(await validateTwitterConfig(runtime, state)),
+      };
+      const instance = new TwitterClientInstance(runtime, validatedState);
       await instance.client.init();
 
       if (options.startAutonomousClients) {

--- a/plugins/plugin-x/src/timeline.test.ts
+++ b/plugins/plugin-x/src/timeline.test.ts
@@ -4,7 +4,7 @@ import {
   ModelType,
   type ModelTypeName,
 } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ClientBase } from "./base";
 import type { Client, Tweet } from "./client/index";
 import { TwitterTimelineClient } from "./timeline";
@@ -72,6 +72,32 @@ function makeTweet(partial: Partial<Tweet>): Tweet {
     ...partial,
   } as Tweet;
 }
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("TwitterTimelineClient scheduling", () => {
+  it("does not prefix-parse a partial engagement interval", async () => {
+    vi.useFakeTimers();
+    const client = new TwitterTimelineClient(makeClient(), makeRuntime({}), {
+      TWITTER_ENGAGEMENT_INTERVAL: "1h",
+    } as TwitterClientState);
+    const handleTimeline = vi
+      .spyOn(client, "handleTimeline")
+      .mockResolvedValue(undefined);
+
+    await client.start();
+    expect(handleTimeline).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1_000 - 1);
+    expect(handleTimeline).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handleTimeline).toHaveBeenCalledTimes(2);
+    await client.stop();
+    vi.clearAllTimers();
+  });
+});
 
 describe("TwitterTimelineClient.describeTweetMedia", () => {
   it("interprets photos and video previews via IMAGE_DESCRIPTION", async () => {

--- a/plugins/plugin-x/src/timeline.ts
+++ b/plugins/plugin-x/src/timeline.ts
@@ -20,6 +20,7 @@ import {
 } from "@elizaos/core";
 import type { ClientBase, TwitterAccountSession, TwitterProfile } from "./base";
 import type { Client, Tweet } from "./client/index";
+import { parseTwitterInterval } from "./environment";
 import {
   quoteTweetTemplate,
   replyTweetTemplate,
@@ -178,12 +179,12 @@ export class TwitterTimelineClient {
       }
 
       // Use shared engagement interval
-      const engagementIntervalMinutes = parseInt(
+      const engagementIntervalMinutes = parseTwitterInterval(
         this.state?.TWITTER_ENGAGEMENT_INTERVAL ||
           (getSetting(this.runtime, "TWITTER_ENGAGEMENT_INTERVAL") as string) ||
           process.env.TWITTER_ENGAGEMENT_INTERVAL ||
           "30",
-        10,
+        30,
       );
       const actionInterval = engagementIntervalMinutes * 60 * 1000;
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Fixes #23250

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash, openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity, Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@48e5f5ce9bdc8c7bc3458b35b2c5e9bec61f06b0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Strict positive integer parsing for interval configurations in `plugin-x` only rejects malformed/non-numeric strings (like "1h", "90s", "12.5", "0") and falls back to documented defaults.

# Background

## What does this PR do?

Rejects partial strings, fractions, scientific notation, unit suffixes, and zero values for `TWITTER_*_INTERVAL*` settings in `@elizaos/plugin-x`.

`parseInt` stops at the first non-digit, so unit suffixes like `1h`, `90s`, `120min` or fractions like `12.5` were partially parsed into 1, 90, 12, defeating the posting-rate limiter and causing unintended frequent posts. Zero was also accepted, which collapsed the setTimeout delay.

Add a strict positive whole-integer interval parser and use it at configuration validation plus every production timer seam; non-interval numeric controls retain legacy behavior.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `plugins/plugin-x/src/environment.ts`: strict interval parsing and configuration normalization
- `plugins/plugin-x/src/environment.test.ts`: vitest test cases for `getRandomInterval`

## Detailed testing steps

Run `bun vitest run plugins/plugin-x/src/environment.test.ts`

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:d8a349ba383325c1d2aa298ab3ef47aae7f7b448 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - scheduler interval parser; no rendered visual surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - scheduler interval parser; no rendered visual surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - scheduler interval parser; no rendered visual surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - scheduler interval parser; test output pasted inline in Evidence Details.
<!-- evidence-row:frontend-logs -->
- [x] N/A - backend interval parser; no frontend UI or network request path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic interval parse logic; no model invocation.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - in-memory settings parsing; no persistent database or on-chain state.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic interval parser; no LLM calls.

## Backend + frontend logs

Vitest test run output for `plugins/plugin-x/src/environment.test.ts`:

```
 RUN  v4.1.5 /home/deepanshu/os/eliza

 ✓ plugins/plugin-x/src/environment.test.ts (14 tests) 8ms

 Test Files  1 passed (1)
      Tests  14 passed (14)
```

## Screenshots (before / after) + video walkthrough

N/A - scheduler interval parser; no rendered visual surface.

## Audio / voice walkthrough

N/A - not a voice/audio change.

## Known gaps / failures

None in touched package (`plugin-x` environment parsing).

AI provider/model: google/gemini-3.7-flash, openai/gpt-5.6-sol
Client / agent tooling: Antigravity
Contribution skill revision: elizaOS/eliza@48e5f5ce9bdc8c7bc3458b35b2c5e9bec61f06b0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity","skill_revision":"elizaOS/eliza@48e5f5ce9bdc8c7bc3458b35b2c5e9bec61f06b0:packages/skills/skills/contribute-to-eliza"} -->

## Maintainer repair (exact head d8a349ba383325c1d2aa298ab3ef47aae7f7b448)

Deep caller review found two production gaps beyond the submitted helper: the shared-parser rewrite widened behavior into non-interval controls, while timeline and DM schedulers bypassed the validated DTO and still prefix-parsed raw state. The final repair scopes strict parsing to scheduler intervals, propagates validated state into production clients, and uses the same parser at both direct timer seams. Zero-valued retry/engagement/tweet controls retain their legacy meaning.

Exact evidence:
- Public validator + getRandomInterval + production timeline timer: 49 pass / 11 filtered skips.
- Production DM timer + XService validated-state wiring: 2 pass / 33 filtered skips.
- plugin-x typecheck: PASS on exact head.
- plugin-x ESM + declarations build: PASS on exact head.
- Biome on all 8 changed files and git diff --check: PASS.
- Final base rebase changed none of the eight reviewed plugin blobs.
- Rendered/live-model/domain evidence: N/A — deterministic backend configuration parsing and timer scheduling; no visual/model/persistence surface.

Repair provenance: OpenAI / gpt-5.6-sol via Codex.
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex"} -->

