### PR TITLE
fix(cloud): fence app deployment retries by generation

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
@@ -349,20 +349,71 @@ describe("AppsRepository.claimDeploymentStart", () => {
     });
 
     const firstStartedAt = new Date("2026-08-20T12:00:00.000Z");
+    const firstGeneration = "11111111-1111-4111-8111-111111111111";
     const [left, right] = await Promise.all([
-      appsRepository.claimDeploymentStart(created.id, { last_deployed_at: firstStartedAt }),
-      appsRepository.claimDeploymentStart(created.id, { last_deployed_at: firstStartedAt }),
+      appsRepository.claimDeploymentStart(created.id, firstGeneration, {
+        last_deployed_at: firstStartedAt,
+        metadata: created.metadata,
+      }),
+      appsRepository.claimDeploymentStart(created.id, firstGeneration, {
+        last_deployed_at: firstStartedAt,
+        metadata: created.metadata,
+      }),
     ]);
     expect([left, right].filter(Boolean)).toHaveLength(1);
     expect((left ?? right)?.deployment_status).toBe("building");
+    expect((left ?? right)?.metadata.deploymentGeneration).toBe(firstGeneration);
 
-    await appsRepository.update(created.id, { deployment_status: "failed" });
+    const staleFailure = await appsRepository.updateDeploymentGeneration(
+      created.id,
+      "22222222-2222-4222-8222-222222222222",
+      { deployment_status: "failed" },
+    );
+    expect(staleFailure).toBeUndefined();
+
+    await appsRepository.updateDeploymentGeneration(created.id, firstGeneration, {
+      deployment_status: "failed",
+    });
     const nextStartedAt = new Date("2026-08-20T12:01:00.000Z");
-    const next = await appsRepository.claimDeploymentStart(created.id, {
+    const nextGeneration = "33333333-3333-4333-8333-333333333333";
+    const next = await appsRepository.claimDeploymentStart(created.id, nextGeneration, {
       last_deployed_at: nextStartedAt,
+      metadata: (left ?? right)?.metadata,
     });
     expect(next?.deployment_status).toBe("building");
+    expect(next?.metadata.deploymentGeneration).toBe(nextGeneration);
     expect(next?.last_deployed_at?.toISOString()).toBe(nextStartedAt.toISOString());
+
+    const deploying = await appsRepository.updateDeploymentGeneration(
+      created.id,
+      nextGeneration,
+      { deployment_status: "deploying", metadata: { containerId: "container-1" } },
+      ["building"],
+    );
+    expect(deploying?.metadata).toMatchObject({
+      deploymentGeneration: nextGeneration,
+      containerId: "container-1",
+    });
+    expect(await appsRepository.isDeploymentGenerationCurrent(created.id, nextGeneration)).toBe(
+      true,
+    );
+    await appsRepository.updateDeploymentGeneration(
+      created.id,
+      nextGeneration,
+      { deployment_status: "failed" },
+      ["deploying"],
+    );
+    expect(await appsRepository.isDeploymentGenerationCurrent(created.id, nextGeneration)).toBe(
+      false,
+    );
+    await expect(
+      appsRepository.updateDeploymentGeneration(
+        created.id,
+        nextGeneration,
+        { deployment_status: "deploying" },
+        ["building"],
+      ),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
@@ -7,6 +7,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { eq, type SQL } from "drizzle-orm";
 import { type RuntimeR2Bucket, setRuntimeR2Bucket } from "../../../lib/storage/r2-runtime-binding";
+import { apps } from "../../schemas/apps";
 import { jobExecutionLeases } from "../../schemas/job-execution-leases";
 import { type Job, jobs } from "../../schemas/jobs";
 
@@ -237,8 +238,17 @@ beforeAll(async () => {
         organization_id uuid NOT NULL,
         slug text,
         api_key_id uuid,
+        metadata jsonb,
         deployment_status text NOT NULL,
         updated_at timestamp NOT NULL DEFAULT now()
+      );`,
+    );
+    await dbWrite.execute(
+      `CREATE TABLE IF NOT EXISTS containers (
+        id uuid PRIMARY KEY,
+        project_name text NOT NULL,
+        organization_id uuid NOT NULL,
+        metadata jsonb
       );`,
     );
   } catch (error) {
@@ -256,7 +266,104 @@ describe("jobsRepository.recoverStaleJobs", () => {
     expect(pgliteReady).toBe(true);
     await dbWrite.delete(jobExecutionLeases);
     await dbWrite.execute("DELETE FROM jobs;");
+    await dbWrite.execute("DELETE FROM containers;");
     await dbWrite.execute("DELETE FROM apps;");
+  });
+
+  test("reconstructs one deterministic APP_DEPLOY job across enqueue replay", async () => {
+    const deploymentGeneration = "00000000-0000-4000-8000-000000180858";
+    const appId = "00000000-0000-4000-8000-000000180859";
+    const insert = {
+      id: deploymentGeneration,
+      type: "app_deploy",
+      organization_id: ORG_ID,
+      user_id: ACTOR_ID,
+      data: { appId, deploymentGeneration },
+    };
+
+    const first = await repo.createOrGetById(insert);
+    const replay = await repo.createOrGetById(insert);
+
+    expect(first.id).toBe(deploymentGeneration);
+    expect(replay.id).toBe(deploymentGeneration);
+    expect(replay.data).toEqual(insert.data);
+    const persisted = await dbWrite.select().from(jobs).where(eq(jobs.id, deploymentGeneration));
+    expect(persisted).toHaveLength(1);
+  });
+
+  test("a stale APP_DEPLOY failure cannot overwrite the current generation", async () => {
+    const appId = "00000000-0000-4000-8000-000000180860";
+    const staleGeneration = "00000000-0000-4000-8000-000000180861";
+    const currentGeneration = "00000000-0000-4000-8000-000000180862";
+    await dbWrite.execute(
+      `INSERT INTO apps (id, organization_id, slug, api_key_id, metadata, deployment_status, updated_at)
+       VALUES ('${appId}', '${ORG_ID}', 'newer-generation', null,
+         '{"deploymentGeneration":"${currentGeneration}"}'::jsonb, 'building', NOW());`,
+    );
+    await seedJob({
+      id: staleGeneration,
+      maxAttempts: 1,
+      type: jobTypes.APP_DEPLOY,
+      data: { appId, deploymentGeneration: staleGeneration },
+      executionInterruptions: 5,
+    });
+
+    const recovery = await new ProvisioningJobServiceCtor().recoverInterruptedJobsOnStartup(
+      new Date("2021-01-01T00:00:00.000Z"),
+      [jobTypes.APP_DEPLOY],
+    );
+
+    expect(recovery).toMatchObject({ permanentlyFailed: 1, failures: [] });
+    const [persistedApp] = await dbWrite
+      .select({ status: apps.deployment_status, metadata: apps.metadata })
+      .from(apps)
+      .where(eq(apps.id, appId));
+    expect(persistedApp).toMatchObject({
+      status: "building",
+      metadata: { deploymentGeneration: currentGeneration },
+    });
+    expect(await repo.findByIdForWrite(cacheInvalidationJobId(staleGeneration))).toBeUndefined();
+  });
+
+  test("a stale CONTAINER_PROVISION failure cannot overwrite the current generation", async () => {
+    const appId = "00000000-0000-4000-8000-000000180863";
+    const containerId = "00000000-0000-4000-8000-000000180864";
+    const staleGeneration = "00000000-0000-4000-8000-000000180865";
+    const currentGeneration = "00000000-0000-4000-8000-000000180866";
+    const provisionJobId = "00000000-0000-4000-8000-000000180867";
+    await dbWrite.execute(
+      `INSERT INTO apps (id, organization_id, slug, api_key_id, metadata, deployment_status, updated_at)
+       VALUES ('${appId}', '${ORG_ID}', 'newer-container-generation', null,
+         '{"deploymentGeneration":"${currentGeneration}"}'::jsonb, 'building', NOW());`,
+    );
+    await dbWrite.execute(
+      `INSERT INTO containers (id, project_name, organization_id, metadata)
+       VALUES ('${containerId}', '${appId}', '${ORG_ID}',
+         '{"appId":"${appId}","deploymentGeneration":"${staleGeneration}"}'::jsonb);`,
+    );
+    await seedJob({
+      id: provisionJobId,
+      maxAttempts: 1,
+      type: jobTypes.CONTAINER_PROVISION,
+      data: { containerId, organizationId: ORG_ID, userId: ACTOR_ID },
+      executionInterruptions: 5,
+    });
+
+    const recovery = await new ProvisioningJobServiceCtor().recoverInterruptedJobsOnStartup(
+      new Date("2021-01-01T00:00:00.000Z"),
+      [jobTypes.CONTAINER_PROVISION],
+    );
+
+    expect(recovery).toMatchObject({ permanentlyFailed: 1, failures: [] });
+    const [persistedApp] = await dbWrite
+      .select({ status: apps.deployment_status, metadata: apps.metadata })
+      .from(apps)
+      .where(eq(apps.id, appId));
+    expect(persistedApp).toMatchObject({
+      status: "building",
+      metadata: { deploymentGeneration: currentGeneration },
+    });
+    expect(await repo.findByIdForWrite(cacheInvalidationJobId(provisionJobId))).toBeUndefined();
   });
 
   test("two live processors cannot reclaim one another before the winning lease expires", async () => {
@@ -1294,16 +1401,17 @@ describe("jobsRepository.recoverStaleJobs", () => {
       const sourceJobId = "00000000-0000-4000-8000-000000180914";
       const appId = "00000000-0000-4000-8000-000000180915";
       const apiKeyId = "00000000-0000-4000-8000-000000180918";
+      const deploymentGeneration = "00000000-0000-4000-8000-000000180919";
       const slug = "durable-cache-retry";
       await dbWrite.execute(
-        `INSERT INTO apps (id, organization_id, slug, api_key_id, deployment_status, updated_at)
-         VALUES ('${appId}', '${ORG_ID}', '${slug}', '${apiKeyId}', 'building', NOW());`,
+        `INSERT INTO apps (id, organization_id, slug, api_key_id, metadata, deployment_status, updated_at)
+         VALUES ('${appId}', '${ORG_ID}', '${slug}', '${apiKeyId}', '{"deploymentGeneration":"${deploymentGeneration}"}'::jsonb, 'building', NOW());`,
       );
       await seedJob({
         id: sourceJobId,
         maxAttempts: 1,
         type: jobTypes.APP_DEPLOY,
-        data: { appId },
+        data: { appId, deploymentGeneration },
         executionInterruptions: 5,
       });
       const service = new ProvisioningJobServiceCtor();
@@ -1386,16 +1494,17 @@ describe("jobsRepository.recoverStaleJobs", () => {
       const sourceJobId = "00000000-0000-4000-8000-000000180920";
       const appId = "00000000-0000-4000-8000-000000180921";
       const apiKeyId = "00000000-0000-4000-8000-000000180922";
+      const deploymentGeneration = "00000000-0000-4000-8000-000000180923";
       const slug = "durable-cache-all-identities";
       await dbWrite.execute(
-        `INSERT INTO apps (id, organization_id, slug, api_key_id, deployment_status, updated_at)
-         VALUES ('${appId}', '${ORG_ID}', '${slug}', '${apiKeyId}', 'building', NOW());`,
+        `INSERT INTO apps (id, organization_id, slug, api_key_id, metadata, deployment_status, updated_at)
+         VALUES ('${appId}', '${ORG_ID}', '${slug}', '${apiKeyId}', '{"deploymentGeneration":"${deploymentGeneration}"}'::jsonb, 'building', NOW());`,
       );
       await seedJob({
         id: sourceJobId,
         maxAttempts: 1,
         type: jobTypes.APP_DEPLOY,
-        data: { appId },
+        data: { appId, deploymentGeneration },
         executionInterruptions: 5,
       });
 

--- a/packages/cloud/shared/src/db/repositories/apps.ts
+++ b/packages/cloud/shared/src/db/repositories/apps.ts
@@ -1,8 +1,23 @@
 /** Persists apps and serializes their database-backed cache identities across processes. */
 import { ElizaError } from "@elizaos/core";
-import { and, count, countDistinct, desc, eq, gte, lte, notInArray, sql } from "drizzle-orm";
+import {
+  and,
+  count,
+  countDistinct,
+  desc,
+  eq,
+  gte,
+  inArray,
+  lte,
+  notInArray,
+  sql,
+} from "drizzle-orm";
 import { cache } from "../../lib/cache/client";
 import { CacheKeys } from "../../lib/cache/keys";
+import {
+  APP_DEPLOYMENT_GENERATION_KEY,
+  metadataForDeploymentGeneration,
+} from "../../lib/services/app-deployment-generation";
 import { invalidateInferenceAppByIdState } from "../../lib/services/inference-app-memory-cache";
 import type { DbTransaction } from "../client";
 import { sqlRows } from "../execute-helpers";
@@ -575,6 +590,7 @@ export class AppsRepository {
    */
   async claimDeploymentStart(
     id: string,
+    generation: string,
     data: Pick<NewApp, "last_deployed_at"> & { metadata?: Record<string, unknown> },
   ): Promise<App | undefined> {
     const [updated] = await dbWrite
@@ -582,7 +598,7 @@ export class AppsRepository {
       .set({
         deployment_status: "building",
         last_deployed_at: data.last_deployed_at,
-        ...(data.metadata ? { metadata: data.metadata } : {}),
+        metadata: metadataForDeploymentGeneration(data.metadata, generation),
         updated_at: new Date(),
       })
       .where(and(eq(apps.id, id), notInArray(apps.deployment_status, ["building", "deploying"])))
@@ -592,6 +608,69 @@ export class AppsRepository {
       await invalidateAppCacheEntries(id, updated.api_key_id, updated.slug);
     }
     return updated;
+  }
+
+  /** Reads one app only when the caller still owns its persisted generation. */
+  async findByDeploymentGeneration(id: string, generation: string): Promise<App | undefined> {
+    const [app] = await dbWrite
+      .select()
+      .from(apps)
+      .where(
+        and(
+          eq(apps.id, id),
+          sql`${apps.metadata}->>${APP_DEPLOYMENT_GENERATION_KEY} = ${generation}`,
+        ),
+      )
+      .limit(1);
+    return app;
+  }
+
+  /** Applies a generation-owned transition without touching a newer deployment. */
+  async updateDeploymentGeneration(
+    id: string,
+    generation: string | null,
+    data: Partial<NewApp>,
+    expectedStatuses?: readonly NonNullable<NewApp["deployment_status"]>[],
+  ): Promise<App | undefined> {
+    const generationFilter = generation
+      ? sql`${apps.metadata}->>${APP_DEPLOYMENT_GENERATION_KEY} = ${generation}`
+      : sql`${apps.metadata}->>${APP_DEPLOYMENT_GENERATION_KEY} IS NULL`;
+    const statusFilter = expectedStatuses?.length
+      ? inArray(apps.deployment_status, [...expectedStatuses])
+      : undefined;
+    const nextData =
+      generation && data.metadata
+        ? { ...data, metadata: metadataForDeploymentGeneration(data.metadata, generation) }
+        : data;
+    const [updated] = await dbWrite
+      .update(apps)
+      .set({ ...nextData, updated_at: new Date() })
+      .where(and(eq(apps.id, id), generationFilter, statusFilter))
+      .returning();
+
+    if (updated) {
+      await invalidateAppCacheEntries(id, updated.api_key_id, updated.slug);
+    }
+    return updated;
+  }
+
+  /** Uses the primary row to fence provider work for current and legacy deployments. */
+  async isDeploymentGenerationCurrent(id: string, generation: string | null): Promise<boolean> {
+    const generationFilter = generation
+      ? sql`${apps.metadata}->>${APP_DEPLOYMENT_GENERATION_KEY} = ${generation}`
+      : sql`${apps.metadata}->>${APP_DEPLOYMENT_GENERATION_KEY} IS NULL`;
+    const [current] = await dbWrite
+      .select({ id: apps.id })
+      .from(apps)
+      .where(
+        and(
+          eq(apps.id, id),
+          generationFilter,
+          inArray(apps.deployment_status, ["building", "deploying"]),
+        ),
+      )
+      .limit(1);
+    return current !== undefined;
   }
 
   /**

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -729,6 +729,23 @@ export class JobsRepository {
     return await hydrateJob(job);
   }
 
+  /** Inserts a deterministic job id once and reconstructs the committed row on retry. */
+  async createOrGetById(jobData: NewJob & { id: string }): Promise<Job> {
+    const insertData = await prepareJobInsertData({ ...jobData, data_storage: "inline" });
+    const [created] = await dbWrite
+      .insert(jobs)
+      .values(insertData)
+      .onConflictDoNothing({ target: jobs.id })
+      .returning();
+    if (created) return await hydrateJob(created);
+
+    const existing = await this.findByIdForWrite(jobData.id);
+    if (!existing) {
+      throw new Error(`Idempotent job ${jobData.id} conflicted but could not be reconstructed`);
+    }
+    return existing;
+  }
+
   /**
    * Atomically claims pending jobs for processing using FOR UPDATE SKIP LOCKED.
    * This prevents race conditions where multiple workers could grab the same jobs.

--- a/packages/cloud/shared/src/lib/services/__tests__/app-container-provider.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-container-provider.test.ts
@@ -251,3 +251,18 @@ describe("AppContainerProvider.provision", () => {
     ]);
   });
 });
+
+describe("AppContainerProvider.deletePrimaryById", () => {
+  test("removes only the immutable primary and preserves the shared ambassador", async () => {
+    const { calls, ssh } = recordingSsh();
+    const provider = new AppContainerProvider({
+      ssh,
+      nodeId: "node-1",
+      allocateHostPort: async () => 49001,
+    });
+
+    await provider.deletePrimaryById("docker-stale-1");
+
+    expect(calls).toEqual(["docker rm -f 'docker-stale-1'"]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/app-container-store.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-container-store.test.ts
@@ -49,6 +49,14 @@ describe("mapContainerRowToAppContainerRow", () => {
     );
   });
 
+  test("projects a valid deployment generation from container metadata", () => {
+    const deploymentGeneration = "11111111-1111-4111-8111-111111111111";
+    expect(
+      mapContainerRowToAppContainerRow(row({ metadata: { deploymentGeneration } }))
+        .deploymentGeneration,
+    ).toBe(deploymentGeneration);
+  });
+
   test("null image_tag becomes empty string", () => {
     expect(mapContainerRowToAppContainerRow(row({ image_tag: null })).image).toBe("");
   });
@@ -77,6 +85,7 @@ describe("toNewContainer", () => {
   test("the app's OWN DSN rides in environment_vars; project_name + metadata key off appId", () => {
     const nc = toNewContainer({
       appId: "app-id-123",
+      deploymentGeneration: "11111111-1111-4111-8111-111111111111",
       organizationId: "org-1",
       userId: "user-1",
       containerName: "app-abc",
@@ -86,7 +95,10 @@ describe("toNewContainer", () => {
     });
     expect(nc.environment_vars).toEqual({ DATABASE_URL: DSN });
     expect(nc.project_name).toBe("app-id-123");
-    expect(nc.metadata).toEqual({ appId: "app-id-123" });
+    expect(nc.metadata).toEqual({
+      appId: "app-id-123",
+      deploymentGeneration: "11111111-1111-4111-8111-111111111111",
+    });
     expect(nc.status).toBe("pending");
     expect(nc.image_tag).toBe("ghcr.io/elizaos/app-x:latest");
   });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-db-ambassador.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-db-ambassador.test.ts
@@ -21,6 +21,7 @@ describe("ambassador naming", () => {
     expect(ambassadorNameForContainer("app-111111112222")).toBe("app-db-111111112222");
     // round-trips with ambassadorName for the same app
     expect(ambassadorNameForContainer("app-111111112222")).toBe(ambassadorName(APP_ID));
+    expect(ambassadorNameForContainer("app-111111112222-gabcdef12")).toBe(ambassadorName(APP_ID));
   });
 
   test("appContainerNameForAmbassador recovers only complete managed names", () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-job-service.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-job-service.test.ts
@@ -9,9 +9,13 @@ import {
 } from "../app-deploy-job-service";
 import type { ContainerJobInsert, ContainerJobsWriter } from "../container-job-service";
 
+const GENERATION = "11111111-1111-4111-8111-111111111111";
+
 describe("readAppDeployJobData", () => {
   test("extracts appId", () => {
-    expect(readAppDeployJobData({ data: { appId: "app-1" } })).toEqual({ appId: "app-1" });
+    expect(
+      readAppDeployJobData({ data: { appId: "app-1", deploymentGeneration: GENERATION } }),
+    ).toEqual({ appId: "app-1", deploymentGeneration: GENERATION });
   });
 
   test("extracts deploy options", () => {
@@ -19,6 +23,7 @@ describe("readAppDeployJobData", () => {
       readAppDeployJobData({
         data: {
           appId: "app-1",
+          deploymentGeneration: GENERATION,
           options: {
             repoUrl: "https://github.com/elizaOS/eliza.git",
             ref: "develop",
@@ -29,6 +34,7 @@ describe("readAppDeployJobData", () => {
       }),
     ).toEqual({
       appId: "app-1",
+      deploymentGeneration: GENERATION,
       options: {
         repoUrl: "https://github.com/elizaOS/eliza.git",
         ref: "develop",
@@ -41,11 +47,16 @@ describe("readAppDeployJobData", () => {
   test("throws when appId missing/blank", () => {
     expect(() => readAppDeployJobData({ data: {} })).toThrow(/missing data.appId/);
     expect(() => readAppDeployJobData({ data: { appId: "" } })).toThrow(/missing data.appId/);
+    expect(() => readAppDeployJobData({ data: { appId: "app-1" } })).toThrow(
+      /deploymentGeneration/,
+    );
   });
 
   test("throws when deploy options are malformed", () => {
     expect(() =>
-      readAppDeployJobData({ data: { appId: "app-1", options: { env: { A: 1 } } } }),
+      readAppDeployJobData({
+        data: { appId: "app-1", deploymentGeneration: GENERATION, options: { env: { A: 1 } } },
+      }),
     ).toThrow(/env values must be strings/);
   });
 });
@@ -57,15 +68,18 @@ describe("app deploy runner injection", () => {
 
   test("dispatchAppDeployJob runs the injected runner with the appId and options", async () => {
     const calls: unknown[] = [];
-    setAppDeployRunner({ run: async (id, options) => void calls.push([id, options]) });
+    setAppDeployRunner({
+      run: async (id, generation, options) => void calls.push([id, generation, options]),
+    });
     await dispatchAppDeployJob({
       data: {
         appId: "app-42",
+        deploymentGeneration: GENERATION,
         options: { repoUrl: "https://github.com/elizaOS/eliza.git", ref: "develop" },
       },
     });
     expect(calls).toEqual([
-      ["app-42", { repoUrl: "https://github.com/elizaOS/eliza.git", ref: "develop" }],
+      ["app-42", GENERATION, { repoUrl: "https://github.com/elizaOS/eliza.git", ref: "develop" }],
     ]);
   });
 });
@@ -81,6 +95,7 @@ describe("enqueueAppDeploy", () => {
     };
     const r = await enqueueAppDeploy(writer, {
       appId: "app-1",
+      deploymentGeneration: GENERATION,
       organizationId: "org-1",
       userId: "u-1",
       options: {
@@ -90,16 +105,44 @@ describe("enqueueAppDeploy", () => {
     });
     expect(r.id).toBe("job-1");
     expect(inserted[0]).toEqual({
+      id: GENERATION,
       type: "app_deploy",
       organizationId: "org-1",
       userId: "u-1",
       data: {
         appId: "app-1",
+        deploymentGeneration: GENERATION,
         options: {
           repoUrl: "https://github.com/elizaOS/eliza.git",
           ref: "develop",
         },
       },
     });
+  });
+
+  test("reconstructs a committed insert after the caller loses its response", async () => {
+    const inserted = new Map<string, ContainerJobInsert>();
+    let calls = 0;
+    const writer: ContainerJobsWriter = {
+      insertJob: async (job) => {
+        calls += 1;
+        if (!job.id) throw new Error("missing deterministic id");
+        const existing = inserted.get(job.id);
+        if (existing) return { id: job.id };
+        inserted.set(job.id, job);
+        throw new Error("response lost after commit");
+      },
+    };
+
+    await expect(
+      enqueueAppDeploy(writer, {
+        appId: "app-1",
+        deploymentGeneration: GENERATION,
+        organizationId: "org-1",
+        userId: "u-1",
+      }),
+    ).resolves.toEqual({ id: GENERATION });
+    expect(calls).toBe(2);
+    expect(inserted.size).toBe(1);
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-orchestrator.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-orchestrator.test.ts
@@ -9,6 +9,7 @@ import {
 
 const REQ: DeployAppRequest = {
   appId: "11111111-2222-3333-4444-555555555555",
+  deploymentGeneration: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
   organizationId: "org-1",
   userId: "user-1",
   containerName: "app-nubilio",
@@ -23,7 +24,7 @@ const TENANT_DSN = "postgresql://app_x:pw@apps-cluster-1/db_app_x?sslmode=requir
 function deps(over: Partial<AppDeployDeps> = {}) {
   const seen: {
     row?: NewAppContainerRow;
-    enqueued?: { containerId: string };
+    enqueued?: { containerId: string; deploymentGeneration: string };
     linked?: { appId: string; containerId: string };
   } = {};
   const base: AppDeployDeps = {
@@ -35,7 +36,10 @@ function deps(over: Partial<AppDeployDeps> = {}) {
       return { containerId: "container-1" };
     },
     async enqueueProvision(p) {
-      seen.enqueued = { containerId: p.containerId };
+      seen.enqueued = {
+        containerId: p.containerId,
+        deploymentGeneration: p.deploymentGeneration,
+      };
       return { id: "job-1" };
     },
     async linkContainerToApp(appId, containerId) {
@@ -60,6 +64,7 @@ describe("deployApp", () => {
     expect(seen.row?.port).toBe(3000);
     // provision was enqueued for the created container
     expect(seen.enqueued?.containerId).toBe("container-1");
+    expect(seen.enqueued?.deploymentGeneration).toBe(REQ.deploymentGeneration);
     // container linked back to the app
     expect(seen.linked).toEqual({ appId: REQ.appId, containerId: "container-1" });
   });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner-env-dsn-teardown.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner-env-dsn-teardown.test.ts
@@ -58,12 +58,24 @@ const ORG_ID = "org-env-dsn";
 const USER_ID = "user-env-dsn";
 const CLUSTER_HOST = "tenant-cluster.internal";
 const ADMIN_DSN = `postgresql://admin:pw@${CLUSTER_HOST}/postgres`;
+const GENERATION = "11111111-1111-4111-8111-111111111111";
 
 // The deploy runner loads the app via appsService.getById (twice: once to
 // resolve the image, once in linkContainerToApp). databaseMode "isolated" is
 // what makes the orchestrator call ensureTenantDb.
 mock.module("../apps", () => ({
   appsService: {
+    updateDeploymentGeneration: async (id: string, generation: string) =>
+      id === APP_ID && generation === GENERATION
+        ? {
+            id: APP_ID,
+            name: "my-app",
+            organization_id: ORG_ID,
+            created_by_user_id: USER_ID,
+            github_repo: null,
+            metadata: { databaseMode: "isolated", deploymentGeneration: GENERATION },
+          }
+        : undefined,
     getById: async (id: string) =>
       id === APP_ID
         ? {
@@ -181,7 +193,7 @@ describe("env-DSN deploy mode — per-tenant DB teardown (#8342)", () => {
       jobsWriter,
       resolveImage: () => "ghcr.io/elizaos/app:test",
     });
-    await runner.run(APP_ID);
+    await runner.run(APP_ID, GENERATION);
 
     // The per-tenant DB is live and a cluster slot is claimed.
     expect(live.size).toBe(1);
@@ -240,7 +252,9 @@ describe("env-DSN deploy mode — per-tenant DB teardown (#8342)", () => {
     persistControl.failUpdateState = true;
     try {
       // The deploy fails (the persist throws) and the error surfaces.
-      await expect(runner.run(APP_ID)).rejects.toThrow("app_databases updateState failed");
+      await expect(runner.run(APP_ID, GENERATION)).rejects.toThrow(
+        "app_databases updateState failed",
+      );
     } finally {
       persistControl.failUpdateState = false;
     }

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner-retire.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner-retire.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, mock, test } from "bun:test";
 const APP_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 const ORG_ID = "org-retire";
 const USER_ID = "user-retire";
+const GENERATION = "11111111-1111-4111-8111-111111111111";
 
 interface Row {
   id: string;
@@ -49,6 +50,19 @@ mock.module("../../../db/repositories/containers", () => ({
 
 mock.module("../apps", () => ({
   appsService: {
+    updateDeploymentGeneration: async (id: string, generation: string) =>
+      id === APP_ID
+        ? generation === GENERATION
+          ? {
+              id: APP_ID,
+              name: "retire-app",
+              organization_id: ORG_ID,
+              created_by_user_id: USER_ID,
+              github_repo: null,
+              metadata: { databaseMode: "none", deploymentGeneration: GENERATION },
+            }
+          : undefined
+        : undefined,
     getById: async (id: string) =>
       id === APP_ID
         ? {
@@ -112,6 +126,22 @@ function makeRunner(
 }
 
 describe("DefaultAppDeployRunner prior-container retirement", () => {
+  test("a delayed prior generation performs no retire, create, or enqueue", async () => {
+    seedPrior();
+    const retired: string[] = [];
+    const { runner, provisionJobs } = makeRunner(async (containerId) => {
+      retired.push(containerId);
+      return { containerId, jobId: "delete-stale", outcome: "retired" };
+    });
+
+    await runner.run(APP_ID, "22222222-2222-4222-8222-222222222222");
+
+    expect(retired).toEqual([]);
+    expect(provisionJobs).toEqual([]);
+    expect(rows.get("container-prior")?.status).toBe("running");
+    expect(rows.size).toBe(1);
+  });
+
   test("retires the prior row before creating the replacement", async () => {
     seedPrior();
     const deleteJobs: string[] = [];
@@ -121,7 +151,7 @@ describe("DefaultAppDeployRunner prior-container retirement", () => {
       return { containerId, jobId: "delete-1", outcome: "retired" };
     });
 
-    await runner.run(APP_ID);
+    await runner.run(APP_ID, GENERATION);
 
     expect(rows.get("container-prior")?.status).toBe("deleting");
     expect(deleteJobs).toEqual(["container-prior"]);
@@ -135,7 +165,7 @@ describe("DefaultAppDeployRunner prior-container retirement", () => {
       throw new Error("transaction rolled back");
     });
 
-    await runner.run(APP_ID);
+    await runner.run(APP_ID, GENERATION);
 
     expect(rows.get("container-prior")?.status).toBe("running");
     expect(provisionJobs).toEqual([JOB_TYPES.CONTAINER_PROVISION]);
@@ -150,7 +180,7 @@ describe("DefaultAppDeployRunner prior-container retirement", () => {
       throw new Error("connection lost after commit");
     });
 
-    await runner.run(APP_ID);
+    await runner.run(APP_ID, GENERATION);
 
     expect(rows.get("container-prior")?.status).toBe("deleting");
     expect(durableDeleteJobs).toEqual(["container-prior"]);
@@ -164,7 +194,7 @@ describe("DefaultAppDeployRunner prior-container retirement", () => {
       throw new Error("response lost after worker completion");
     });
 
-    await runner.run(APP_ID);
+    await runner.run(APP_ID, GENERATION);
 
     expect(rows.get("container-prior")?.status).toBe("deleted");
   });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts
@@ -24,6 +24,15 @@ describe("containerNameForApp (#9145)", () => {
     const id = "550e8400-e29b-41d4-a716-446655440000";
     expect(containerNameForApp(id)).toBe("app-550e8400e29b");
   });
+
+  test("isolates Docker names by deployment generation", () => {
+    expect(
+      containerNameForApp(
+        "550e8400-e29b-41d4-a716-446655440000",
+        "11111111-2222-4333-8444-555555555555",
+      ),
+    ).toBe("app-550e8400e29b-g11111111");
+  });
 });
 
 // build-from-repo is intentionally deferred (prebuilt-image only). A repo-configured

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deployments-options.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deployments-options.test.ts
@@ -39,7 +39,7 @@ mock.module("../apps", () => ({
       appRow = { ...appRow, ...data };
       return appRow;
     },
-    claimDeploymentStart: async (id: string, data: Partial<AppRow>) => {
+    claimDeploymentStart: async (id: string, generation: string, data: Partial<AppRow>) => {
       if (
         id !== APP_ID ||
         appRow.deployment_status === "building" ||
@@ -47,7 +47,17 @@ mock.module("../apps", () => ({
       ) {
         return undefined;
       }
-      appRow = { ...appRow, ...data, deployment_status: "building" };
+      appRow = {
+        ...appRow,
+        ...data,
+        metadata: { ...(data.metadata ?? {}), deploymentGeneration: generation },
+        deployment_status: "building",
+      };
+      return appRow;
+    },
+    updateDeploymentGeneration: async (id: string, generation: string, data: Partial<AppRow>) => {
+      if (id !== APP_ID || appRow.metadata.deploymentGeneration !== generation) return undefined;
+      appRow = { ...appRow, ...data };
       return appRow;
     },
   },
@@ -78,6 +88,7 @@ describe("AppDeploymentsService deploy options", () => {
     expect(enqueued).toEqual([
       {
         appId: APP_ID,
+        deploymentGeneration: expect.any(String),
         organizationId: ORG_ID,
         userId: USER_ID,
         options: {
@@ -94,7 +105,7 @@ describe("AppDeploymentsService deploy options", () => {
     const service = new AppDeploymentsService();
     const calls: unknown[] = [];
     service.setDeployRunner({
-      run: async (appId, options) => void calls.push([appId, options]),
+      run: async (appId, generation, options) => void calls.push([appId, generation, options]),
     });
 
     await service.createDeployment({
@@ -109,6 +120,7 @@ describe("AppDeploymentsService deploy options", () => {
     expect(calls).toEqual([
       [
         APP_ID,
+        expect.any(String),
         {
           repoUrl: "https://github.com/elizaOS/eliza.git",
           ref: "develop",

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deployments.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deployments.test.ts
@@ -27,7 +27,7 @@ mock.module("../apps", () => ({
       appStore.current = { ...appStore.current, ...data };
       return appStore.current;
     },
-    claimDeploymentStart: async (id: string, data: Partial<AppRow>) => {
+    claimDeploymentStart: async (id: string, generation: string, data: Partial<AppRow>) => {
       if (
         id !== APP_ID ||
         !appStore.current ||
@@ -36,15 +36,41 @@ mock.module("../apps", () => ({
       ) {
         return undefined;
       }
-      const update = { ...data, deployment_status: "building" as const };
+      const update = {
+        ...data,
+        metadata: { ...(data.metadata ?? {}), deploymentGeneration: generation },
+        deployment_status: "building" as const,
+      };
       updates.push(update);
       appStore.current = { ...appStore.current, ...update };
+      return appStore.current;
+    },
+    updateDeploymentGeneration: async (
+      id: string,
+      generation: string,
+      data: Partial<AppRow>,
+      expectedStatuses?: AppDeploymentStatus[],
+    ) => {
+      if (
+        id !== APP_ID ||
+        !appStore.current ||
+        appStore.current.metadata.deploymentGeneration !== generation ||
+        (expectedStatuses && !expectedStatuses.includes(appStore.current.deployment_status))
+      ) {
+        return undefined;
+      }
+      updates.push(data);
+      appStore.current = { ...appStore.current, ...data };
       return appStore.current;
     },
   },
 }));
 
-import { type AppDeployEnqueuer, AppDeploymentsService } from "../app-deployments";
+import {
+  AppDeployEnqueueAmbiguousError,
+  type AppDeployEnqueuer,
+  AppDeploymentsService,
+} from "../app-deployments";
 
 describe("AppDeploymentsService", () => {
   beforeEach(() => {
@@ -80,6 +106,7 @@ describe("AppDeploymentsService", () => {
     // so the daemon job rebuilds from the same source the caller specified.
     expect(enqueued).toEqual({
       appId: APP_ID,
+      deploymentGeneration: expect.any(String),
       organizationId: ORG_ID,
       userId: USER_ID,
       options: {
@@ -95,6 +122,7 @@ describe("AppDeploymentsService", () => {
         repoUrl: "https://github.com/elizaOS/eliza.git",
         ref: "develop",
         dockerfile: "apps/example/Dockerfile",
+        deploymentGeneration: expect.any(String),
       },
     });
     expect(appStore.current?.metadata.repoUrl).toBe("https://github.com/elizaOS/eliza.git");
@@ -133,5 +161,54 @@ describe("AppDeploymentsService", () => {
     expect(settled.filter((result) => result.status === "rejected")).toHaveLength(1);
     expect(enqueued).toHaveLength(1);
     expect(updates).toHaveLength(1);
+  });
+
+  test("an ambiguous enqueue terminalizes its generation so admission can recover", async () => {
+    const service = new AppDeploymentsService();
+    let generation = "";
+    service.setDeployEnqueuer(async (payload) => {
+      generation = payload.deploymentGeneration;
+      throw new AppDeployEnqueueAmbiguousError(payload.deploymentGeneration, new Error("lost"));
+    });
+
+    await expect(
+      service.createDeployment({ appId: APP_ID, organizationId: ORG_ID, userId: USER_ID }),
+    ).rejects.toBeInstanceOf(AppDeployEnqueueAmbiguousError);
+
+    expect(appStore.current?.deployment_status).toBe("failed");
+    expect(appStore.current?.metadata.deploymentGeneration).toBe(generation);
+    expect(updates).toHaveLength(2);
+
+    service.setDeployEnqueuer(async () => undefined);
+    await expect(
+      service.createDeployment({ appId: APP_ID, organizationId: ORG_ID, userId: USER_ID }),
+    ).resolves.toMatchObject({ status: "BUILDING" });
+  });
+
+  test("a direct runner failure terminalizes a generation that already entered deploying", async () => {
+    const service = new AppDeploymentsService({
+      async run() {
+        if (appStore.current) appStore.current.deployment_status = "deploying";
+        throw new Error("build failed after runner claim");
+      },
+    });
+
+    await expect(
+      service.createDeployment({ appId: APP_ID, organizationId: ORG_ID, userId: USER_ID }),
+    ).rejects.toThrow("build failed after runner claim");
+    expect(appStore.current?.deployment_status).toBe("failed");
+  });
+
+  test("an ambiguous enqueue cannot overwrite a worker that already claimed deploying", async () => {
+    const service = new AppDeploymentsService();
+    service.setDeployEnqueuer(async (payload) => {
+      if (appStore.current) appStore.current.deployment_status = "deploying";
+      throw new AppDeployEnqueueAmbiguousError(payload.deploymentGeneration, new Error("lost"));
+    });
+
+    await expect(
+      service.createDeployment({ appId: APP_ID, organizationId: ORG_ID, userId: USER_ID }),
+    ).rejects.toBeInstanceOf(AppDeployEnqueueAmbiguousError);
+    expect(appStore.current?.deployment_status).toBe("deploying");
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts
@@ -76,6 +76,9 @@ function fakeProvider(over: Partial<Record<keyof AppContainerProvider, unknown>>
     async deleteById(hostContainerId: string, name: string) {
       calls.push({ op: "deleteById", arg: { hostContainerId, name } });
     },
+    async deletePrimaryById(hostContainerId: string) {
+      calls.push({ op: "deletePrimaryById", arg: hostContainerId });
+    },
     async restart(name: string) {
       calls.push({ op: "restart", arg: name });
     },
@@ -149,7 +152,7 @@ describe("executeContainerProvision", () => {
       {
         provider,
         store,
-        markAppDeployed: async (appId, url) => {
+        markAppDeployed: async (appId, _generation, url) => {
           deployed.push({ appId, url });
         },
       },
@@ -179,6 +182,112 @@ describe("executeContainerProvision", () => {
       ),
     ).rejects.toThrow("docker create failed");
     expect(deployedOnFail).toEqual([]);
+  });
+
+  test("a stale container generation performs no provider or state mutation", async () => {
+    const deploymentGeneration = "11111111-1111-4111-8111-111111111111";
+    const { events, slotEvents, store } = fakeStore({ ...ROW, deploymentGeneration });
+    const { calls, provider } = fakeProvider();
+
+    await executeContainerProvision(
+      job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
+      {
+        provider,
+        store,
+        isAppDeploymentCurrent: async (_appId, generation) => {
+          expect(generation).toBe(deploymentGeneration);
+          return false;
+        },
+      },
+    );
+
+    expect(calls).toEqual([]);
+    expect(events).toEqual([]);
+    expect(slotEvents).toEqual([]);
+  });
+
+  test("a provision job whose generation disagrees with its row performs no mutation", async () => {
+    const deploymentGeneration = "11111111-1111-4111-8111-111111111111";
+    const { events, slotEvents, store } = fakeStore({ ...ROW, deploymentGeneration });
+    const { calls, provider } = fakeProvider();
+
+    await executeContainerProvision(
+      job({
+        containerId: "container-1",
+        organizationId: "org-1",
+        userId: "user-1",
+        deploymentGeneration: "22222222-2222-4222-8222-222222222222",
+      }),
+      {
+        provider,
+        store,
+        isAppDeploymentCurrent: async () => true,
+      },
+    );
+
+    expect(calls).toEqual([]);
+    expect(events).toEqual([]);
+    expect(slotEvents).toEqual([]);
+  });
+
+  test("a generated container fails closed when the generation fence is not wired", async () => {
+    const deploymentGeneration = "11111111-1111-4111-8111-111111111111";
+    const { events, slotEvents, store } = fakeStore({ ...ROW, deploymentGeneration });
+    const { calls, provider } = fakeProvider();
+
+    await expect(
+      executeContainerProvision(
+        job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
+        { provider, store },
+      ),
+    ).rejects.toMatchObject({ code: "APP_DEPLOYMENT_GENERATION_FENCE_MISSING" });
+
+    expect(calls).toEqual([]);
+    expect(events).toEqual([]);
+    expect(slotEvents).toEqual([]);
+  });
+
+  test("a generation that becomes stale during provision is discarded before state mutation", async () => {
+    const deploymentGeneration = "11111111-1111-4111-8111-111111111111";
+    const { events, slotEvents, store } = fakeStore({ ...ROW, deploymentGeneration });
+    const provisionStarted = Promise.withResolvers<void>();
+    const releaseProvision = Promise.withResolvers<void>();
+    let current = true;
+    const { calls, provider } = fakeProvider({
+      async provision(params: unknown) {
+        calls.push({ op: "provision", arg: params });
+        provisionStarted.resolve();
+        await releaseProvision.promise;
+        return {
+          containerId: "docker-stale-1",
+          hostPort: 49001,
+          network: "app-net-x",
+          nodeId: "node-1",
+          nodeHost: "node.example.test",
+        };
+      },
+    });
+
+    const execution = executeContainerProvision(
+      job({
+        containerId: "container-1",
+        organizationId: "org-1",
+        userId: "user-1",
+        deploymentGeneration,
+      }),
+      { provider, store, isAppDeploymentCurrent: async () => current },
+    );
+    await provisionStarted.promise;
+    current = false;
+    releaseProvision.resolve();
+    await execution;
+
+    expect(calls.map((call) => call.op)).toEqual(["provision", "deletePrimaryById"]);
+    expect(events).toEqual([]);
+    expect(slotEvents).toEqual([
+      { op: "claim", nodeId: "node-1" },
+      { op: "rollback", nodeId: "node-1" },
+    ]);
   });
 
   test("marks error and rethrows when provisioning fails", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts
@@ -290,6 +290,38 @@ describe("executeContainerProvision", () => {
     ]);
   });
 
+  test("a generation that becomes stale before markRunning discards the primary and slot", async () => {
+    const deploymentGeneration = "11111111-1111-4111-8111-111111111111";
+    const { events, slotEvents, store } = fakeStore({ ...ROW, deploymentGeneration });
+    const { calls, provider } = fakeProvider();
+    let currentChecks = 0;
+
+    await executeContainerProvision(
+      job({
+        containerId: "container-1",
+        organizationId: "org-1",
+        userId: "user-1",
+        deploymentGeneration,
+      }),
+      {
+        provider,
+        store,
+        isAppDeploymentCurrent: async () => {
+          currentChecks += 1;
+          return currentChecks < 3;
+        },
+      },
+    );
+
+    expect(currentChecks).toBe(3);
+    expect(calls.map((call) => call.op)).toEqual(["provision", "deletePrimaryById"]);
+    expect(events).toEqual([]);
+    expect(slotEvents).toEqual([
+      { op: "claim", nodeId: "node-1" },
+      { op: "rollback", nodeId: "node-1" },
+    ]);
+  });
+
   test("marks error and rethrows when provisioning fails", async () => {
     const { events, slotEvents, store } = fakeStore();
     const { provider } = fakeProvider({

--- a/packages/cloud/shared/src/lib/services/__tests__/container-job-service.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-job-service.test.ts
@@ -143,7 +143,12 @@ describe("ContainerJobEnqueuer", () => {
   test("enqueues each lifecycle verb with the right type + data", async () => {
     const { inserts, writer } = fakeWriter();
     const e = new ContainerJobEnqueuer(writer);
-    await e.enqueueProvision({ containerId: "c1", organizationId: "o1", userId: "u1" });
+    await e.enqueueProvision({
+      containerId: "c1",
+      organizationId: "o1",
+      userId: "u1",
+      deploymentGeneration: "11111111-1111-4111-8111-111111111111",
+    });
     await e.enqueueDelete({ containerId: "c1", organizationId: "o1" });
     await e.enqueueUpgrade({ containerId: "c1", organizationId: "o1", image: "ghcr.io/x:2" });
 
@@ -152,7 +157,11 @@ describe("ContainerJobEnqueuer", () => {
       JOB_TYPES.CONTAINER_DELETE,
       JOB_TYPES.CONTAINER_UPGRADE,
     ]);
-    expect(inserts[0].data).toMatchObject({ containerId: "c1", userId: "u1" });
+    expect(inserts[0].data).toMatchObject({
+      containerId: "c1",
+      userId: "u1",
+      deploymentGeneration: "11111111-1111-4111-8111-111111111111",
+    });
     expect(inserts[2].data).toMatchObject({ image: "ghcr.io/x:2" });
   });
 

--- a/packages/cloud/shared/src/lib/services/__tests__/container-jobs-data.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-jobs-data.test.ts
@@ -21,7 +21,12 @@ const job = (data: unknown): JobLike => ({ id: "job-1", data });
 
 describe("container-jobs-data codecs", () => {
   test("provision round-trips through toRecord -> read", () => {
-    const data = { containerId: "c1", organizationId: "o1", userId: "u1" };
+    const data = {
+      containerId: "c1",
+      organizationId: "o1",
+      userId: "u1",
+      deploymentGeneration: "11111111-1111-4111-8111-111111111111",
+    };
     const record = containerProvisionJobDataToRecord(data);
     expect(readContainerProvisionJobData(job(record))).toEqual(data);
   });
@@ -45,6 +50,14 @@ describe("container-jobs-data codecs", () => {
   test("guards reject malformed data", () => {
     expect(isContainerProvisionJobData({ containerId: "c1", organizationId: "o1" })).toBe(false); // missing userId
     expect(isContainerProvisionJobData(null)).toBe(false);
+    expect(
+      isContainerProvisionJobData({
+        containerId: "c1",
+        organizationId: "o1",
+        userId: "u1",
+        deploymentGeneration: "not-a-uuid",
+      }),
+    ).toBe(false);
     expect(
       isContainerProvisionJobData({ containerId: " ", organizationId: "o1", userId: "u1" }),
     ).toBe(false);

--- a/packages/cloud/shared/src/lib/services/__tests__/provisioning-jobs-failure-writeback.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/provisioning-jobs-failure-writeback.test.ts
@@ -20,11 +20,18 @@ import { ProvisioningJobService } from "../provisioning-jobs";
 const APP_ID = "11111111-2222-4333-8444-555555555555";
 const ORG_ID = "99999999-aaaa-4bbb-8ccc-dddddddddddd";
 const CONTAINER_ID = "cccccccc-dddd-4eee-8fff-000000000000";
+const DEPLOYMENT_GENERATION = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
 
 // Minimal DbTransaction stand-in: serves one container row for the select chain
 // (project_name + organization_id, since the writeback org-scopes the flip) and
 // records every update(table).set(values) the writeback issues.
-function mockTx(containerRow: { projectName: string; organizationId: string } | null) {
+function mockTx(
+  containerRow: {
+    projectName: string;
+    organizationId: string;
+    metadata?: Record<string, unknown>;
+  } | null,
+) {
   const updates: Array<{ table: unknown; values: Record<string, unknown> }> = [];
   const inserts: Array<{ table: unknown; values: Record<string, unknown> }> = [];
   const tx = {
@@ -96,7 +103,11 @@ describe("buildPermanentFailureWriteback: CONTAINER_PROVISION", () => {
   test("app container (UUID project_name) -> apps.deployment_status flipped to failed", async () => {
     const { job, cb } = containerProvisionWriteback();
     expect(cb).toBeDefined();
-    const { tx, updates, inserts } = mockTx({ projectName: APP_ID, organizationId: ORG_ID });
+    const { tx, updates, inserts } = mockTx({
+      projectName: APP_ID,
+      organizationId: ORG_ID,
+      metadata: { deploymentGeneration: DEPLOYMENT_GENERATION },
+    });
     await cb!(tx, job);
     expect(updates).toHaveLength(1);
     expect(updates[0].table).toBe(apps);

--- a/packages/cloud/shared/src/lib/services/app-container-provider.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-provider.ts
@@ -233,6 +233,11 @@ export class AppContainerProvider {
     await this.deps.ssh.exec(buildRemoveAmbassadorCmdForContainer(containerName));
   }
 
+  /** Remove only one immutable primary container, preserving the app ambassador. */
+  async deletePrimaryById(hostContainerId: string): Promise<void> {
+    await this.removeContainerAndConfirmAbsent(hostContainerId);
+  }
+
   /** Remove one persisted Docker object without trusting its reusable app name. */
   async deleteById(hostContainerId: string, containerName: string): Promise<void> {
     await this.removeContainerAndConfirmAbsent(hostContainerId);

--- a/packages/cloud/shared/src/lib/services/app-container-record.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-record.ts
@@ -16,7 +16,7 @@ export function toNewContainer(row: NewAppContainerRow): NewContainer {
     port: row.port,
     // Database credentials belong to the app tenant, never the shared agent DB.
     environment_vars: row.environmentVars,
-    metadata: { appId: row.appId },
+    metadata: { appId: row.appId, deploymentGeneration: row.deploymentGeneration },
     status: "pending",
   };
 }

--- a/packages/cloud/shared/src/lib/services/app-container-store.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-store.ts
@@ -19,6 +19,7 @@ import {
   type ProjectableContainerRow,
   rollbackAppContainerNodeSlotClaim,
 } from "./app-container-store-queries";
+import { deploymentGenerationFromMetadata } from "./app-deployment-generation";
 import { deriveAppPublicUrl } from "./app-url";
 import type { AppContainerRow, AppContainerStore } from "./container-job-executors";
 
@@ -59,11 +60,13 @@ export function mapContainerRowToAppContainerRow(row: ProjectableContainerRow): 
     typeof row.metadata?.appId === "string" ? (row.metadata.appId as string) : undefined;
   const hostContainerId =
     typeof row.metadata?.hostContainerId === "string" ? row.metadata.hostContainerId : undefined;
+  const deploymentGeneration = deploymentGenerationFromMetadata(row.metadata);
   return {
     id: row.id,
     // project_name is set to the appId by the deploy orchestrator's
     // createContainerRow; metadata.appId is a belt-and-suspenders fallback.
     appId: metaAppId ?? row.project_name,
+    ...(deploymentGeneration ? { deploymentGeneration } : {}),
     containerName: row.name,
     image: row.image_tag ?? "",
     port: row.port,

--- a/packages/cloud/shared/src/lib/services/app-db-ambassador.ts
+++ b/packages/cloud/shared/src/lib/services/app-db-ambassador.ts
@@ -51,9 +51,10 @@ export function ambassadorName(appId: string): string {
  * without the appId.
  */
 export function ambassadorNameForContainer(containerName: string): string {
-  const slug = containerName.startsWith("app-")
-    ? containerName.slice("app-".length)
-    : containerName;
+  const withoutGeneration = containerName.replace(/-g[a-f0-9]{8}$/i, "");
+  const slug = withoutGeneration.startsWith("app-")
+    ? withoutGeneration.slice("app-".length)
+    : withoutGeneration;
   return `${APP_DB_AMBASSADOR_NAME_PREFIX}${slug}`;
 }
 

--- a/packages/cloud/shared/src/lib/services/app-deploy-job-service.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-job-service.ts
@@ -14,8 +14,9 @@
  * module imports no `pg`/SSH and stays safe to load anywhere.
  */
 
+import { isValidUUID } from "../utils/validation";
 import type { AppDeployRunner, AppDeployRunOptions } from "./app-deploy-orchestrator";
-import { appDeploymentsService } from "./app-deployments";
+import { AppDeployEnqueueAmbiguousError, appDeploymentsService } from "./app-deployments";
 import type { ContainerJobsWriter } from "./container-job-service";
 import { containerJobsWriter } from "./container-jobs-writer";
 import { JOB_TYPES } from "./provisioning-job-types";
@@ -39,33 +40,62 @@ export function getAppDeployRunner(): AppDeployRunner {
 /** Extract deploy data from an APP_DEPLOY job payload (throws if malformed). */
 export function readAppDeployJobData(job: { data: unknown }): {
   appId: string;
+  deploymentGeneration: string;
   options?: AppDeployRunOptions;
 } {
   const data = (job.data ?? {}) as Record<string, unknown>;
   if (typeof data.appId !== "string" || data.appId.length === 0) {
     throw new Error("APP_DEPLOY job missing data.appId");
   }
+  if (typeof data.deploymentGeneration !== "string" || !isValidUUID(data.deploymentGeneration)) {
+    throw new Error("APP_DEPLOY job missing valid data.deploymentGeneration");
+  }
   const options = parseDeployOptions(data.options);
-  return options ? { appId: data.appId, options } : { appId: data.appId };
+  return options
+    ? { appId: data.appId, deploymentGeneration: data.deploymentGeneration, options }
+    : { appId: data.appId, deploymentGeneration: data.deploymentGeneration };
 }
 
 /** Daemon: run the full deploy for a claimed APP_DEPLOY job via the injected runner. */
 export async function dispatchAppDeployJob(job: { data: unknown }): Promise<void> {
-  const { appId, options } = readAppDeployJobData(job);
-  await getAppDeployRunner().run(appId, options);
+  const { appId, deploymentGeneration, options } = readAppDeployJobData(job);
+  await getAppDeployRunner().run(appId, deploymentGeneration, options);
 }
 
 // ── enqueue (Worker / request side) ─────────────────────────────────────────
 /** Enqueue an APP_DEPLOY job (pg-free) over the shared job writer. */
 export function enqueueAppDeploy(
   writer: ContainerJobsWriter,
-  p: { appId: string; organizationId: string; userId?: string; options?: AppDeployRunOptions },
+  p: {
+    appId: string;
+    deploymentGeneration: string;
+    organizationId: string;
+    userId?: string;
+    options?: AppDeployRunOptions;
+  },
 ): Promise<{ id: string }> {
-  return writer.insertJob({
+  const insert = {
+    id: p.deploymentGeneration,
     type: JOB_TYPES.APP_DEPLOY,
     organizationId: p.organizationId,
     userId: p.userId,
-    data: p.options ? { appId: p.appId, options: p.options } : { appId: p.appId },
+    data: p.options
+      ? { appId: p.appId, deploymentGeneration: p.deploymentGeneration, options: p.options }
+      : { appId: p.appId, deploymentGeneration: p.deploymentGeneration },
+  };
+  return writer.insertJob(insert).catch(async (firstError) => {
+    // error-policy:J2 the generation UUID is the durable job id: retrying the
+    // exact insert either creates the missing row or reconstructs a commit whose
+    // response was lost. A second unknown outcome remains explicit and cannot
+    // authorize an app-status rollback.
+    try {
+      return await writer.insertJob(insert);
+    } catch (secondError) {
+      throw new AppDeployEnqueueAmbiguousError(p.deploymentGeneration, {
+        firstError,
+        secondError,
+      });
+    }
   });
 }
 

--- a/packages/cloud/shared/src/lib/services/app-deploy-orchestrator.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-orchestrator.test.ts
@@ -18,6 +18,7 @@ function makeDeps(): { deps: AppDeployDeps; captured: { row?: NewAppContainerRow
 
 const baseReq = {
   appId: "app-1",
+  deploymentGeneration: "11111111-1111-4111-8111-111111111111",
   organizationId: "org-1",
   userId: "user-1",
   containerName: "my-app",

--- a/packages/cloud/shared/src/lib/services/app-deploy-orchestrator.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-orchestrator.ts
@@ -16,6 +16,7 @@ import { RESERVED_PLATFORM_ENV_KEYS, stripReservedEnvKeys } from "./reserved-env
 
 export interface DeployAppRequest {
   appId: string;
+  deploymentGeneration: string;
   organizationId: string;
   userId: string;
   containerName: string;
@@ -44,6 +45,7 @@ export interface AppDeployRunOptions {
 
 export interface NewAppContainerRow {
   appId: string;
+  deploymentGeneration: string;
   organizationId: string;
   userId: string;
   containerName: string;
@@ -62,6 +64,7 @@ export interface AppDeployDeps {
     containerId: string;
     organizationId: string;
     userId: string;
+    deploymentGeneration: string;
   }) => Promise<{ id: string }>;
   /** Record the container id on the app (e.g. apps.metadata.containerId). */
   linkContainerToApp: (appId: string, containerId: string) => Promise<void>;
@@ -79,7 +82,7 @@ export interface DeployAppResult {
  * `AppDeploymentsService` invokes it after marking the app `building`.
  */
 export interface AppDeployRunner {
-  run(appId: string, options?: AppDeployRunOptions): Promise<void>;
+  run(appId: string, deploymentGeneration: string, options?: AppDeployRunOptions): Promise<void>;
 }
 
 /**
@@ -123,6 +126,7 @@ export async function deployApp(
 
   const { containerId } = await deps.createContainerRow({
     appId: req.appId,
+    deploymentGeneration: req.deploymentGeneration,
     organizationId: req.organizationId,
     userId: req.userId,
     containerName: req.containerName,
@@ -141,6 +145,7 @@ export async function deployApp(
     containerId,
     organizationId: req.organizationId,
     userId: req.userId,
+    deploymentGeneration: req.deploymentGeneration,
   });
 
   await deps.linkContainerToApp(req.appId, containerId);

--- a/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
@@ -197,10 +197,13 @@ export async function resolveImageRef(
   return image;
 }
 
-/** A stable, DNS/Docker-safe container name for an app: `app-<first 12 of id>`. */
-export function containerNameForApp(appId: string): string {
+/** A DNS/Docker-safe name isolated to one deployment generation when supplied. */
+export function containerNameForApp(appId: string, deploymentGeneration?: string): string {
   const slug = appId.toLowerCase().replace(/[^a-z0-9]/g, "");
-  return `app-${slug.slice(0, 12)}`;
+  const base = `app-${slug.slice(0, 12)}`;
+  if (!deploymentGeneration) return base;
+  const generationSlug = deploymentGeneration.toLowerCase().replace(/[^a-f0-9]/g, "");
+  return `${base}-g${generationSlug.slice(0, 8)}`;
 }
 
 export class DefaultAppDeployRunner implements AppDeployRunner {
@@ -210,10 +213,23 @@ export class DefaultAppDeployRunner implements AppDeployRunner {
     this.deps = deps;
   }
 
-  async run(appId: string, options: AppDeployRunOptions = {}): Promise<void> {
-    const app = await appsService.getById(appId);
+  async run(
+    appId: string,
+    deploymentGeneration: string,
+    options: AppDeployRunOptions = {},
+  ): Promise<void> {
+    const app = await appsService.updateDeploymentGeneration(
+      appId,
+      deploymentGeneration,
+      { deployment_status: "deploying" },
+      ["building"],
+    );
     if (!app) {
-      throw new Error(`App ${appId} not found`);
+      logger.info("[AppDeployRunner] ignored stale deployment generation", {
+        appId,
+        deploymentGeneration,
+      });
+      return;
     }
 
     const appMetadata = (app.metadata as Record<string, unknown>) ?? {};
@@ -230,7 +246,7 @@ export class DefaultAppDeployRunner implements AppDeployRunner {
       repoUrl: app.github_repo ?? undefined,
       organizationId: app.organization_id,
     });
-    const containerName = containerNameForApp(appId);
+    const containerName = containerNameForApp(appId, deploymentGeneration);
 
     const enqueuer = new ContainerJobEnqueuer(this.deps.jobsWriter);
 
@@ -268,16 +284,22 @@ export class DefaultAppDeployRunner implements AppDeployRunner {
         // derivation as the agent path), so the deploy-status poll can surface
         // it immediately. Skipped when no public base domain is configured.
         const endpoint = deriveAppPublicUrl(containerId);
-        await appsService.update(id, {
-          metadata: { ...existingMeta, containerId },
-          ...(endpoint ? { production_url: endpoint.url } : {}),
-        });
+        await appsService.updateDeploymentGeneration(
+          id,
+          deploymentGeneration,
+          {
+            metadata: { ...existingMeta, containerId },
+            ...(endpoint ? { production_url: endpoint.url } : {}),
+          },
+          ["deploying"],
+        );
       },
     };
 
     const result = await deployApp(
       {
         appId,
+        deploymentGeneration,
         organizationId: app.organization_id,
         userId: app.created_by_user_id,
         containerName,

--- a/packages/cloud/shared/src/lib/services/app-deployment-generation.ts
+++ b/packages/cloud/shared/src/lib/services/app-deployment-generation.ts
@@ -1,0 +1,24 @@
+/** Owns the immutable app-deployment generation stored in app and container metadata. */
+
+import { isValidUUID } from "../utils/validation";
+
+export const APP_DEPLOYMENT_GENERATION_KEY = "deploymentGeneration";
+
+/** Returns a valid persisted deployment generation, or null for legacy/invalid metadata. */
+export function deploymentGenerationFromMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): string | null {
+  const value = metadata?.[APP_DEPLOYMENT_GENERATION_KEY];
+  return typeof value === "string" && isValidUUID(value) ? value : null;
+}
+
+/** Preserves unrelated app metadata while binding it to one deployment generation. */
+export function metadataForDeploymentGeneration(
+  metadata: Record<string, unknown> | null | undefined,
+  generation: string,
+): Record<string, unknown> {
+  if (!isValidUUID(generation)) {
+    throw new Error(`Invalid app deployment generation: ${generation}`);
+  }
+  return { ...(metadata ?? {}), [APP_DEPLOYMENT_GENERATION_KEY]: generation };
+}

--- a/packages/cloud/shared/src/lib/services/app-deployments-helpers.ts
+++ b/packages/cloud/shared/src/lib/services/app-deployments-helpers.ts
@@ -8,6 +8,7 @@
 
 import type { App, AppDeploymentStatus } from "../../db/schemas/apps";
 import { ApiError } from "../api/cloud-worker-errors";
+import { deploymentGenerationFromMetadata } from "./app-deployment-generation";
 
 export type { AppDeploymentStatus };
 
@@ -34,12 +35,15 @@ export function publicStatusFor(persisted: AppDeploymentStatus): DeploymentStatu
 
 export function deploymentIdFor(app: {
   id: string;
+  metadata?: Record<string, unknown> | null;
   // Cached reads (`appsService.getById` → Redis/KV) round-trip the timestamp
   // through JSON, so `last_deployed_at` arrives as an ISO STRING, not a Date.
   // Accept both and coerce — calling `.toISOString()` on a string 500s the
   // deploy-status route (the real-staging deploy bug behind #9300).
   last_deployed_at: Date | string | null;
 }): string {
+  const generation = deploymentGenerationFromMetadata(app.metadata);
+  if (generation) return generation;
   const ts = app.last_deployed_at ? new Date(app.last_deployed_at).toISOString() : "0";
   return `${app.id}:${ts}`;
 }

--- a/packages/cloud/shared/src/lib/services/app-deployments.ts
+++ b/packages/cloud/shared/src/lib/services/app-deployments.ts
@@ -5,8 +5,9 @@
  *
  * Source of truth is the `apps` table itself: the `deployment_status`,
  * `production_url`, and `last_deployed_at` columns added in migration 0007.
- * A deployment is identified by `<appId>:<last_deployed_at_iso>` so the
- * CLI can correlate POST → GET polls without a separate `deployments` table.
+ * A deployment is identified by an immutable UUID stored in app metadata so
+ * queued work and status writes can reject stale generations without another
+ * deployments table.
  * The real build/deploy pipeline has landed (Apps / Product 2): when a deploy
  * runner or APP_DEPLOY enqueuer is wired, `createDeployment` triggers a real
  * isolated provision (the daemon runs it — build-from-repo when armed, prebuilt
@@ -14,6 +15,7 @@
  * polling `getLatestDeployment` regardless of which backend is wired.
  */
 
+import { ElizaError } from "@elizaos/core";
 import { ApiError } from "../api/cloud-worker-errors";
 import { logger } from "../utils/logger";
 import type { AppDeployRunner, AppDeployRunOptions } from "./app-deploy-orchestrator";
@@ -72,10 +74,23 @@ function deployMetadataFor(
  */
 export type AppDeployEnqueuer = (p: {
   appId: string;
+  deploymentGeneration: string;
   organizationId: string;
   userId: string;
   options?: AppDeployRunOptions;
 }) => Promise<unknown>;
+
+/** A queue write may have committed even though its caller lost the response. */
+export class AppDeployEnqueueAmbiguousError extends ElizaError {
+  constructor(deploymentGeneration: string, cause: unknown) {
+    super(`APP_DEPLOY enqueue outcome is ambiguous for generation ${deploymentGeneration}`, {
+      code: "APP_DEPLOY_ENQUEUE_AMBIGUOUS",
+      context: { deploymentGeneration },
+      cause,
+      severity: "fatal",
+    });
+  }
+}
 
 export class AppDeploymentsService {
   private deployRunner?: AppDeployRunner;
@@ -129,10 +144,11 @@ export class AppDeploymentsService {
       throw new Error("App not found");
     }
     const startedAt = new Date();
+    const deploymentGeneration = crypto.randomUUID();
     const deploymentMetadata = deployMetadataFor(existing.metadata ?? {}, input);
-    const updated = await appsService.claimDeploymentStart(input.appId, {
+    const updated = await appsService.claimDeploymentStart(input.appId, deploymentGeneration, {
       last_deployed_at: startedAt,
-      ...(deploymentMetadata ? { metadata: deploymentMetadata } : {}),
+      metadata: deploymentMetadata ?? existing.metadata ?? {},
     });
     if (!updated) {
       throw new ApiError(
@@ -153,19 +169,31 @@ export class AppDeploymentsService {
         if (this.deployEnqueuer) {
           await this.deployEnqueuer({
             appId: input.appId,
+            deploymentGeneration,
             organizationId: input.organizationId,
             userId: input.userId,
             ...(deployOptions ? { options: deployOptions } : {}),
           });
         } else if (this.deployRunner) {
-          await this.deployRunner.run(input.appId, deployOptions);
+          await this.deployRunner.run(input.appId, deploymentGeneration, deployOptions);
         }
       } catch (error) {
+        // error-policy:J1 terminalize this generation before preserving the
+        // trigger error. If an ambiguous insert actually committed, the queued
+        // runner's building-only claim becomes a no-op; if it did not commit,
+        // admission is no longer stranded behind an unreplayable generation.
         logger.error("[AppDeployments] deploy trigger failed", {
           appId: input.appId,
           error: error instanceof Error ? error.message : String(error),
         });
-        await appsService.update(input.appId, { deployment_status: "failed" });
+        await appsService.updateDeploymentGeneration(
+          input.appId,
+          deploymentGeneration,
+          { deployment_status: "failed" },
+          error instanceof AppDeployEnqueueAmbiguousError
+            ? ["building"]
+            : ["building", "deploying"],
+        );
         throw error;
       }
     }

--- a/packages/cloud/shared/src/lib/services/apps.ts
+++ b/packages/cloud/shared/src/lib/services/apps.ts
@@ -548,9 +548,27 @@ export class AppsService {
 
   async claimDeploymentStart(
     id: string,
+    generation: string,
     data: { last_deployed_at: Date; metadata?: Record<string, unknown> },
   ): Promise<App | undefined> {
-    return await appsRepository.claimDeploymentStart(id, data);
+    return await appsRepository.claimDeploymentStart(id, generation, data);
+  }
+
+  async findByDeploymentGeneration(id: string, generation: string): Promise<App | undefined> {
+    return await appsRepository.findByDeploymentGeneration(id, generation);
+  }
+
+  async updateDeploymentGeneration(
+    id: string,
+    generation: string | null,
+    data: Partial<NewApp>,
+    expectedStatuses?: readonly NonNullable<NewApp["deployment_status"]>[],
+  ): Promise<App | undefined> {
+    return await appsRepository.updateDeploymentGeneration(id, generation, data, expectedStatuses);
+  }
+
+  async isDeploymentGenerationCurrent(id: string, generation: string | null): Promise<boolean> {
+    return await appsRepository.isDeploymentGenerationCurrent(id, generation);
   }
 
   async delete(id: string): Promise<void> {

--- a/packages/cloud/shared/src/lib/services/container-executor-deps.ts
+++ b/packages/cloud/shared/src/lib/services/container-executor-deps.ts
@@ -244,15 +244,22 @@ export function buildContainerExecutorDeps(): ContainerExecutorDeps {
       listVerifiedAppOrigins(appId).then((origins) =>
         origins.map((origin) => origin.replace(/^https?:\/\//, "").replace(/\/+$/, "")),
       ),
-    markAppDeployed: async (appId, productionUrl) => {
+    isAppDeploymentCurrent: (appId, deploymentGeneration) =>
+      appsService.isDeploymentGenerationCurrent(appId, deploymentGeneration),
+    markAppDeployed: async (appId, deploymentGeneration, productionUrl) => {
       // App ids are UUIDs; a non-UUID project_name (a plain /v1/containers row,
       // which is not an app) is skipped so this never mis-updates or UUID-casts.
       if (!isValidUUID(appId)) return;
-      await appsService.update(appId, {
-        deployment_status: "deployed",
-        production_url: productionUrl,
-        last_deployed_at: new Date(),
-      });
+      await appsService.updateDeploymentGeneration(
+        appId,
+        deploymentGeneration,
+        {
+          deployment_status: "deployed",
+          production_url: productionUrl,
+          last_deployed_at: new Date(),
+        },
+        ["deploying"],
+      );
     },
     ...ingress,
   };

--- a/packages/cloud/shared/src/lib/services/container-job-executors.ts
+++ b/packages/cloud/shared/src/lib/services/container-job-executors.ts
@@ -293,11 +293,15 @@ export async function executeContainerProvision(
       deps.isAppDeploymentCurrent &&
       !(await deps.isAppDeploymentCurrent(row.appId, generation))
     ) {
-      logger.info("[ContainerExecutor] skipped stale app deployment ingress mutation", {
-        containerId,
-        appId: row.appId,
-        deploymentGeneration: generation,
-      });
+      await discardStaleProvision(deps, row, result);
+      logger.info(
+        "[ContainerExecutor] discarded app deployment that became stale before state mutation",
+        {
+          containerId,
+          appId: row.appId,
+          deploymentGeneration: generation,
+        },
+      );
       return;
     }
     await deps.store.markRunning(containerId, {

--- a/packages/cloud/shared/src/lib/services/container-job-executors.ts
+++ b/packages/cloud/shared/src/lib/services/container-job-executors.ts
@@ -30,6 +30,7 @@ import { buildContainerProvisionInput } from "./container-provider-input";
 export interface AppContainerRow {
   id: string;
   appId: string;
+  deploymentGeneration?: string;
   containerName: string;
   image: string;
   port: number;
@@ -68,6 +69,8 @@ export interface AppContainerStore {
 export interface ContainerExecutorDeps {
   provider: AppContainerProvider;
   store: AppContainerStore;
+  /** Rejects stale app-container work before provider or app-state mutation. */
+  isAppDeploymentCurrent?: (appId: string, deploymentGeneration: string | null) => Promise<boolean>;
   /**
    * Ingress hooks (optional). When set, the executor registers the per-app route
    * `<shortid>.<base>` -> `127.0.0.1:hostPort` (node-local Caddy) right after the
@@ -99,7 +102,11 @@ export interface ContainerExecutorDeps {
    * impl resolves by app id). Optional/injected; best-effort is NOT acceptable
    * here — a failure must surface so the deploy is retried, not silently stuck.
    */
-  markAppDeployed?: (appId: string, productionUrl: string | null) => Promise<void>;
+  markAppDeployed?: (
+    appId: string,
+    deploymentGeneration: string | null,
+    productionUrl: string | null,
+  ) => Promise<void>;
   /**
    * Probe whether the app's public URL is HTTP-reachable (#9853). Runs after the
    * ingress route is registered and BEFORE the app is marked `deployed`, so a
@@ -169,12 +176,83 @@ async function settleFailedProvision(
   throw failure;
 }
 
+async function discardStaleProvision(
+  deps: ContainerExecutorDeps,
+  row: AppContainerRow,
+  result: Awaited<ReturnType<AppContainerProvider["provision"]>>,
+): Promise<void> {
+  try {
+    await deps.provider.deletePrimaryById(result.containerId);
+  } catch (cleanupError) {
+    const cleanupMessage =
+      cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+    await deps.store.markCleanupRequired(
+      row.id,
+      `Stale deployment primary cleanup unproven: ${cleanupMessage}`,
+    );
+    throw new ElizaError(`Could not discard stale app deployment container ${row.id}`, {
+      code: "APP_DEPLOYMENT_STALE_CLEANUP_UNPROVEN",
+      context: {
+        containerId: row.id,
+        hostContainerId: result.containerId,
+        cleanupError: cleanupMessage,
+      },
+      cause: cleanupError,
+      severity: "fatal",
+    });
+  }
+  const rolledBack = await deps.store.rollbackNodeSlotClaim(
+    row.id,
+    row.organizationId,
+    deps.provider.targetNodeId,
+  );
+  if (!rolledBack) {
+    await deps.store.markCleanupRequired(
+      row.id,
+      "Stale deployment primary is absent but the node-slot claim could not be released",
+    );
+    throw new ElizaError(`Could not release stale app deployment slot ${row.id}`, {
+      code: "APP_DEPLOYMENT_STALE_SLOT_ROLLBACK_UNAPPLIED",
+      context: { containerId: row.id, nodeId: deps.provider.targetNodeId },
+      severity: "fatal",
+    });
+  }
+}
+
 export async function executeContainerProvision(
   job: JobLike,
   deps: ContainerExecutorDeps,
 ): Promise<void> {
-  const { containerId } = readContainerProvisionJobData(job);
+  const { containerId, deploymentGeneration: jobGeneration } = readContainerProvisionJobData(job);
   const row = await requireRow(deps.store, containerId);
+  const generation = row.deploymentGeneration ?? null;
+  if (jobGeneration && jobGeneration !== generation) {
+    logger.info("[ContainerExecutor] ignored mismatched app deployment job", {
+      containerId,
+      appId: row.appId,
+      jobDeploymentGeneration: jobGeneration,
+      rowDeploymentGeneration: generation,
+    });
+    return;
+  }
+  if (generation && !deps.isAppDeploymentCurrent) {
+    throw new ElizaError(
+      `App container ${containerId} has a deployment generation but no generation fence`,
+      {
+        code: "APP_DEPLOYMENT_GENERATION_FENCE_MISSING",
+        context: { containerId, appId: row.appId, deploymentGeneration: generation },
+        severity: "fatal",
+      },
+    );
+  }
+  if (deps.isAppDeploymentCurrent && !(await deps.isAppDeploymentCurrent(row.appId, generation))) {
+    logger.info("[ContainerExecutor] ignored stale app deployment container", {
+      containerId,
+      appId: row.appId,
+      deploymentGeneration: generation,
+    });
+    return;
+  }
   const input = buildContainerProvisionInput({
     name: row.containerName,
     projectName: row.appId,
@@ -200,7 +278,28 @@ export async function executeContainerProvision(
     return settleFailedProvision(deps, row, containerId, error);
   }
 
+  if (deps.isAppDeploymentCurrent && !(await deps.isAppDeploymentCurrent(row.appId, generation))) {
+    await discardStaleProvision(deps, row, result);
+    logger.info("[ContainerExecutor] discarded app deployment that became stale during provision", {
+      containerId,
+      appId: row.appId,
+      deploymentGeneration: generation,
+    });
+    return;
+  }
+
   try {
+    if (
+      deps.isAppDeploymentCurrent &&
+      !(await deps.isAppDeploymentCurrent(row.appId, generation))
+    ) {
+      logger.info("[ContainerExecutor] skipped stale app deployment ingress mutation", {
+        containerId,
+        appId: row.appId,
+        deploymentGeneration: generation,
+      });
+      return;
+    }
     await deps.store.markRunning(containerId, {
       hostContainerId: result.containerId,
       hostPort: result.hostPort,
@@ -261,7 +360,18 @@ export async function executeContainerProvision(
     // Container is running and routable — flip the app to `deployed` so the
     // deploy-status route reports READY (instead of `building` forever).
     if (deps.markAppDeployed) {
-      await deps.markAppDeployed(row.appId, endpoint?.url ?? null);
+      if (
+        deps.isAppDeploymentCurrent &&
+        !(await deps.isAppDeploymentCurrent(row.appId, generation))
+      ) {
+        logger.info("[ContainerExecutor] skipped stale app deployment success writeback", {
+          containerId,
+          appId: row.appId,
+          deploymentGeneration: generation,
+        });
+        return;
+      }
+      await deps.markAppDeployed(row.appId, generation, endpoint?.url ?? null);
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/cloud/shared/src/lib/services/container-job-service.ts
+++ b/packages/cloud/shared/src/lib/services/container-job-service.ts
@@ -89,6 +89,8 @@ export function getContainerExecutorDeps(): ContainerExecutorDeps {
 // ── enqueue ──────────────────────────────────────────────────────────────────
 
 export interface ContainerJobInsert {
+  /** Deterministic id for a generation-owned idempotent insert. */
+  id?: string;
   type: string;
   organizationId: string;
   userId?: string;
@@ -111,6 +113,7 @@ export class ContainerJobEnqueuer {
     containerId: string;
     organizationId: string;
     userId: string;
+    deploymentGeneration?: string;
   }): Promise<{ id: string }> {
     return this.writer.insertJob({
       type: JOB_TYPES.CONTAINER_PROVISION,

--- a/packages/cloud/shared/src/lib/services/container-jobs-data.ts
+++ b/packages/cloud/shared/src/lib/services/container-jobs-data.ts
@@ -20,6 +20,8 @@ export interface ContainerProvisionJobData {
   containerId: string;
   organizationId: string;
   userId: string;
+  /** Immutable app deployment generation; absent only for legacy/generic containers. */
+  deploymentGeneration?: string;
 }
 
 export interface ContainerDeleteJobData {
@@ -56,7 +58,15 @@ function hasStrings(value: unknown, keys: readonly string[]): boolean {
 }
 
 export function isContainerProvisionJobData(value: unknown): value is ContainerProvisionJobData {
-  return hasStrings(value, ["containerId", "organizationId", "userId"]);
+  return (
+    hasStrings(value, ["containerId", "organizationId", "userId"]) &&
+    (!isRecord(value) ||
+      value.deploymentGeneration === undefined ||
+      (typeof value.deploymentGeneration === "string" &&
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+          value.deploymentGeneration,
+        )))
+  );
 }
 
 export function isContainerDeleteJobData(value: unknown): value is ContainerDeleteJobData {

--- a/packages/cloud/shared/src/lib/services/container-jobs-writer.ts
+++ b/packages/cloud/shared/src/lib/services/container-jobs-writer.ts
@@ -27,10 +27,22 @@
 import { jobsRepository } from "../../db/repositories/jobs";
 import type { ContainerJobInsert, ContainerJobsWriter } from "./container-job-service";
 
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, next]) => `${JSON.stringify(key)}:${canonicalJson(next)}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "undefined";
+}
+
 /** Real writer over `jobsRepository`. Construct once; inject into ContainerJobEnqueuer. */
 export class JobsRepositoryContainerJobsWriter implements ContainerJobsWriter {
   async insertJob(job: ContainerJobInsert): Promise<{ id: string }> {
-    const created = await jobsRepository.create({
+    const jobData = {
+      ...(job.id ? { id: job.id } : {}),
       type: job.type,
       organization_id: job.organizationId,
       // user_id is a nullable FK; container jobs may be enqueued without a user
@@ -38,7 +50,18 @@ export class JobsRepositoryContainerJobsWriter implements ContainerJobsWriter {
       // the column is explicitly cleared rather than relying on insert defaults.
       user_id: job.userId ?? null,
       data: job.data,
-    });
+    };
+    const created = job.id
+      ? await jobsRepository.createOrGetById({ ...jobData, id: job.id })
+      : await jobsRepository.create(jobData);
+    if (
+      created.type !== job.type ||
+      created.organization_id !== job.organizationId ||
+      created.user_id !== (job.userId ?? null) ||
+      canonicalJson(created.data) !== canonicalJson(job.data)
+    ) {
+      throw new Error(`Deterministic job id ${created.id} is bound to a different intent`);
+    }
     return { id: created.id };
   }
 }

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -84,6 +84,10 @@ import {
 } from "./app-cache-invalidation-job";
 import { dispatchAppDbDeprovisionJob } from "./app-db-deprovision-job-service";
 import { dispatchAppDeployJob, readAppDeployJobData } from "./app-deploy-job-service";
+import {
+  APP_DEPLOYMENT_GENERATION_KEY,
+  deploymentGenerationFromMetadata,
+} from "./app-deployment-generation";
 import { dispatchContainerJob, getContainerExecutorDeps } from "./container-job-service";
 import { readContainerProvisionJobData } from "./container-jobs-data";
 import { dispatchContainerStopJob } from "./container-stop-job-service";
@@ -3797,12 +3801,18 @@ export class ProvisioningJobService {
       // CP worker (still default=all lanes) claims an APP_DEPLOY it can't run
       // and exhausts retries.
       case JOB_TYPES.APP_DEPLOY: {
-        const { appId } = readAppDeployJobData(job);
+        const { appId, deploymentGeneration } = readAppDeployJobData(job);
         return async (tx, failedJob) => {
           const [failedApp] = await tx
             .update(apps)
             .set({ deployment_status: "failed", updated_at: new Date() })
-            .where(and(eq(apps.id, appId), eq(apps.organization_id, failedJob.organization_id)))
+            .where(
+              and(
+                eq(apps.id, appId),
+                eq(apps.organization_id, failedJob.organization_id),
+                sql`${apps.metadata}->>${APP_DEPLOYMENT_GENERATION_KEY} = ${deploymentGeneration}`,
+              ),
+            )
             .returning({ id: apps.id, api_key_id: apps.api_key_id, slug: apps.slug });
           if (failedApp) {
             await enqueueAppCacheInvalidation(tx, failedJob, failedApp);
@@ -3829,12 +3839,14 @@ export class ProvisioningJobService {
       // container after ANOTHER tenant's app id and flip that app to `failed`,
       // because the cross-org WHERE matches zero rows.
       case JOB_TYPES.CONTAINER_PROVISION: {
-        const { containerId } = readContainerProvisionJobData(job);
+        const { containerId, deploymentGeneration: jobGeneration } =
+          readContainerProvisionJobData(job);
         return async (tx, failedJob) => {
           const [row] = await tx
             .select({
               projectName: containers.project_name,
               organizationId: containers.organization_id,
+              metadata: containers.metadata,
             })
             .from(containers)
             .where(
@@ -3846,10 +3858,22 @@ export class ProvisioningJobService {
             .limit(1);
           const appId = row?.projectName;
           if (!appId || !isValidUUID(appId)) return;
+          const rowGeneration = deploymentGenerationFromMetadata(row.metadata);
+          if (jobGeneration && jobGeneration !== rowGeneration) return;
+          const deploymentGeneration = jobGeneration ?? rowGeneration;
+          const generationFilter = deploymentGeneration
+            ? sql`${apps.metadata}->>${APP_DEPLOYMENT_GENERATION_KEY} = ${deploymentGeneration}`
+            : sql`${apps.metadata}->>${APP_DEPLOYMENT_GENERATION_KEY} IS NULL`;
           const [failedApp] = await tx
             .update(apps)
             .set({ deployment_status: "failed", updated_at: new Date() })
-            .where(and(eq(apps.id, appId), eq(apps.organization_id, row.organizationId)))
+            .where(
+              and(
+                eq(apps.id, appId),
+                eq(apps.organization_id, row.organizationId),
+                generationFilter,
+              ),
+            )
             .returning({ id: apps.id, api_key_id: apps.api_key_id, slug: apps.slug });
           if (failedApp) {
             await enqueueAppCacheInvalidation(tx, failedJob, failedApp);


### PR DESCRIPTION
# Relates to

Fixes #23339.
Fixes #23004.
Follow-up to merged #23181.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Final branch is two review commits ending at `a0adb783455277b43989848fb48f9bc678fe964a` on the tested lineage from `develop@c722737178f39cd095bc8081eb4dbde6cb5bfb20`; GitHub currently reports the branch CLEAN against live develop.
- [x] The exact 36-file PR tree was verified after the final coordinated rebase.
- [x] GitHub reports the PR CLEAN and it is ready for review.

# Risks

Medium lifecycle risk. This changes deployment status ownership, APP_DEPLOY job identity, generation-scoped container identity, and stale container cleanup. It uses existing JSONB metadata columns, so no schema migration is introduced.

# Background

## What does this PR do?

Adds one immutable UUID deployment generation and carries it through app admission, APP_DEPLOY payload parsing and deterministic enqueue identity, runner/container creation, provider fencing, and every success/failure writeback.

The finishing review closes the original lifecycle races:

- metadata updates preserve the immutable generation;
- only `building` or `deploying` rows are current, never terminal rows;
- an ambiguous enqueue fails only an unclaimed `building` generation, while a worker-claimed `deploying` generation proceeds;
- CONTAINER_PROVISION carries and verifies the generation before provider or state mutation;
- Docker primary names include the generation while the shared DB ambassador remains app-stable;
- a primary created after its generation becomes stale is removed by immutable container id in both post-provision race windows, and slot cleanup fails closed if it cannot be proven.

Status transitions use compare-and-set expected states, stale writebacks are no-ops, and direct runner failures terminalize the active generation without overwriting a newer one.

## What kind of change is this?

Bug fix correcting the post-merge lifecycle gap documented on #23181.

# Testing

Exact head: `a0adb783455277b43989848fb48f9bc678fe964a`.

The final head changes two blobs after the fully tested `b34f3d6d…` review. Those two exact Git blobs were created from and byte-identical to the isolated workspace used for the final adversarial test; the other 34 PR blobs remain byte-identical to the prior exact-tested head.

- 145/145 focused tests across the 15 non-PGlite changed test files.
- 26/26 real PGlite apps repository tests.
- 28/28 real PGlite jobs recovery tests.
- Total exact-PR-tree receipt: 199 passed, 0 failed.
- `bunx biome check` on all 36 PR TypeScript files: pass.
- Cloud-shared typecheck reaches only unchanged sparse/base dependency errors (redemption SDK exports and missing `ai`/`mammoth`/`unpdf`/`markdown-it`/`file-type` declarations); no PR-path diagnostic.
- The PGlite files run in isolated processes. A combined Bun invocation reproduces the repository's existing cross-file module-mock collision; each affected file passes independently in the attached receipt.

# Evidence Gate

<!-- evidence-head:a0adb783455277b43989848fb48f9bc678fe964a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend lifecycle-only correction.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head focused and real-PGlite receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23340-app-deployment-generation-a0adb.txt) (SHA-256 `649960b31721662806d5d37f14d49a5e7de566429c16dd3585e73efba1712196`).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network contract changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider-model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head lifecycle domain receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23340-app-deployment-generation-domain-a0adb.txt) exercises generation admission, replay, stale APP_DEPLOY/CONTAINER_PROVISION no-ops, ambiguous outcomes, generation-scoped primary identity, stale-primary cleanup, and real PGlite status ownership.
<!-- evidence-row:ocr-review -->
- [x] N/A - no pixels or visual text changed.

# Known gaps / failures

- Root `bun run verify` is not claimed green in the sparse review clone; package typecheck is blocked only by the unchanged dependency diagnostics listed above.
- Hosted CI and additional review are acceptance holds, not source blockers; this PR remains ready for review.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no repository contribution skill used"} -->