### PR TITLE
test(agent): restore HTTP access context lint

### DIFF
--- a/packages/agent/src/api/http-access-context.test.ts
+++ b/packages/agent/src/api/http-access-context.test.ts
@@ -2,11 +2,13 @@
  * Unit coverage for resolveHttpAccessContext — boundary principal → core
  * AccessContext mapping, UUID normalization, and the undefined owner path.
  */
-import { describe, expect, it, vi } from "vitest";
+
 import type http from "node:http";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@elizaos/core", () => {
-  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  const UUID_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   return {
     validateUuid: (v: string) => (UUID_RE.test(v) ? v : null),
     stringToUuid: (s: string) => {
@@ -22,8 +24,8 @@ vi.mock("./boundary-role-resolver.ts", () => ({
   resolveRegisteredTokenRoleAccess: vi.fn(),
 }));
 
-import { resolveHttpAccessContext } from "./http-access-context.ts";
 import { resolveRegisteredTokenRoleAccess } from "./boundary-role-resolver.ts";
+import { resolveHttpAccessContext } from "./http-access-context.ts";
 
 const mockResolve = vi.mocked(resolveRegisteredTokenRoleAccess);
 const req = {} as http.IncomingMessage;
@@ -66,9 +68,7 @@ describe("resolveHttpAccessContext", () => {
     // Deterministic: same input → same uuid, and it matches the uuid shape
     const again = resolveHttpAccessContext(req);
     expect(ctx?.requesterEntityId).toBe(again?.requesterEntityId);
-    expect(ctx?.requesterEntityId).toMatch(
-      /^[0-9a-f-]{36}$/i,
-    );
+    expect(ctx?.requesterEntityId).toMatch(/^[0-9a-f-]{36}$/i);
   });
 
   it("maps a UUID principal directly without namespace transform", () => {


### PR DESCRIPTION
Fixes #23341.

## Summary

Applies Biome's deterministic import organization and formatting to the HTTP access context test merged on `develop`. No assertions or production code change.

## Exact-head validation

- `src/api/http-access-context.test.ts`: 4/4 pass
- `bun run --cwd packages/agent lint:check`: pass (992 files)
- `bun run --cwd packages/agent typecheck`: pass
- `git diff --check`: pass
