### PR TITLE
feat(test): add synthetic native platform adapter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1072,6 +1072,18 @@
         "typescript": "^6.0.3",
       },
     },
+    "packages/synthetic-world": {
+      "name": "@elizaos/synthetic-world",
+      "version": "0.0.0",
+      "dependencies": {
+        "zod": "^4.4.3",
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "@typescript/native": "npm:typescript@^7.0.2",
+        "vitest": "^4.1.10",
+      },
+    },
     "packages/test": {
       "name": "@elizaos/test-corpus",
       "version": "0.0.0",
@@ -4229,6 +4241,8 @@
     "@elizaos/shared": ["@elizaos/shared@workspace:packages/shared"],
 
     "@elizaos/skills": ["@elizaos/skills@workspace:packages/skills"],
+
+    "@elizaos/synthetic-world": ["@elizaos/synthetic-world@workspace:packages/synthetic-world"],
 
     "@elizaos/test-corpus": ["@elizaos/test-corpus@workspace:packages/test"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -359,6 +359,7 @@
       },
       "devDependencies": {
         "@elizaos/plugin-app-control": "workspace:*",
+        "@elizaos/synthetic-world": "workspace:*",
         "@playwright/test": "^1.62.1",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -2376,6 +2377,7 @@
       "version": "2.0.3-beta.7",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
+        "@elizaos/synthetic-world": "workspace:*",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@typescript/native": "npm:typescript@^7.0.2",
         "rollup": "^4.62.4",

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -317,6 +317,7 @@
     "directory": "dist"
   },
   "devDependencies": {
+    "@elizaos/synthetic-world": "workspace:*",
     "@elizaos/plugin-app-control": "workspace:*",
     "@playwright/test": "^1.62.1",
     "@types/react": "^19.0.0",

--- a/packages/app-core/src/connectors/capacitor-jsc.ts
+++ b/packages/app-core/src/connectors/capacitor-jsc.ts
@@ -120,12 +120,19 @@ class CapacitorJscBridge implements JsRuntimeBridge {
   }
 }
 
+/** Builds the production bridge adapter around a native or simulator host. */
+export function createCapacitorJscBridge(
+  plugin: CapacitorJscPlugin,
+): JsRuntimeBridge {
+  return new CapacitorJscBridge(plugin);
+}
+
 registerJsRuntimeFactory({
   kind: "jsc-ios",
   async create() {
     if (!isJscPluginAvailable()) {
       return null;
     }
-    return new CapacitorJscBridge(CapacitorJsc);
+    return createCapacitorJscBridge(CapacitorJsc);
   },
 });

--- a/packages/app-core/src/connectors/capacitor-quickjs.ts
+++ b/packages/app-core/src/connectors/capacitor-quickjs.ts
@@ -127,13 +127,21 @@ class CapacitorQuickJsBridge implements JsRuntimeBridge {
   }
 }
 
+/** Builds the production bridge adapter around a native or simulator host. */
+export function createCapacitorQuickJsBridge(
+  plugin: CapacitorQuickJsPlugin,
+  kind: Extract<JsRuntimeKind, "quickjs-android" | "quickjs-ios-fallback">,
+): JsRuntimeBridge {
+  return new CapacitorQuickJsBridge(plugin, kind);
+}
+
 registerJsRuntimeFactory({
   kind: "quickjs-android",
   async create() {
     if (!isQuickJsPluginAvailable("android")) {
       return null;
     }
-    return new CapacitorQuickJsBridge(CapacitorQuickJs, "quickjs-android");
+    return createCapacitorQuickJsBridge(CapacitorQuickJs, "quickjs-android");
   },
 });
 
@@ -143,6 +151,9 @@ registerJsRuntimeFactory({
     if (!isQuickJsPluginAvailable("ios")) {
       return null;
     }
-    return new CapacitorQuickJsBridge(CapacitorQuickJs, "quickjs-ios-fallback");
+    return createCapacitorQuickJsBridge(
+      CapacitorQuickJs,
+      "quickjs-ios-fallback",
+    );
   },
 });

--- a/packages/app-core/src/connectors/native-synthetic-platform.test.ts
+++ b/packages/app-core/src/connectors/native-synthetic-platform.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Runs production JSC and QuickJS adapters against the deterministic native
+ * simulator; these receipts never claim signed-device certification.
+ */
+import {
+  bootInProcessWorld,
+  SYNTHETIC_WORLD_SCHEMA_VERSION,
+  SyntheticNativePlatform,
+} from "@elizaos/synthetic-world";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type CapacitorJscPlugin,
+  createCapacitorJscBridge,
+} from "./capacitor-jsc.ts";
+import {
+  type CapacitorQuickJsPlugin,
+  createCapacitorQuickJsBridge,
+} from "./capacitor-quickjs.ts";
+
+vi.mock("@elizaos/agent", () => ({ registerJsRuntimeFactory: vi.fn() }));
+
+const active: Array<{
+  platform: SyntheticNativePlatform;
+  world: ReturnType<typeof bootInProcessWorld>;
+}> = [];
+
+function boot(namespace: string, surfaceId: string, kind: string) {
+  const world = bootInProcessWorld(
+    {
+      schemaVersion: SYNTHETIC_WORLD_SCHEMA_VERSION,
+      worldId: `native-${kind}`,
+      seed: `native-${kind}-v1`,
+      clock: { epoch: "2030-01-01T08:00:00.000Z", timezone: "UTC" },
+      fixturePolicy: {
+        allowedEmailDomains: ["example.invalid"],
+        allowedUrlHosts: ["example.invalid"],
+      },
+      data: {
+        identities: [],
+        organizations: [],
+        agents: [],
+        rooms: [],
+        threads: [],
+        messages: [],
+        connectorAccounts: [],
+        grants: [],
+        calendars: [],
+        calendarEvents: [],
+        tasks: [],
+        reminders: [],
+        contacts: [],
+        relationships: [],
+        memories: [],
+        approvals: [],
+        outbox: [],
+        notifications: [],
+        media: [],
+        billingAccounts: [],
+        billingTransactions: [],
+        providerState: [],
+        backgroundJobs: [],
+        extensions: {},
+      },
+      faults: [],
+    },
+    { namespace },
+  );
+  const platform = new SyntheticNativePlatform(world, [
+    {
+      id: surfaceId,
+      initialState: { disposed: false, imports: 0 },
+      handlers: {
+        evaluate: (input) => ({
+          value: {
+            kind: "string",
+            value: `${kind}:${(input as { code: string }).code}`,
+          },
+        }),
+        importModule: (input, context) => {
+          const state = context.state as { disposed: boolean; imports: number };
+          context.setState({ ...state, imports: state.imports + 1 });
+          return {
+            exports: {
+              kind: "object",
+              entries: [
+                [
+                  "path",
+                  {
+                    kind: "string",
+                    value: (input as { absolutePath: string }).absolutePath,
+                  },
+                ],
+              ],
+            },
+          };
+        },
+        dispose: (_input, context) => {
+          const state = context.state as { disposed: boolean; imports: number };
+          context.setState({ ...state, disposed: true });
+          return null;
+        },
+      },
+    },
+  ]);
+  active.push({ world, platform });
+  const invoke = (method: string, input: unknown) =>
+    platform.invoke({ surfaceId, method, input: input as never });
+  return {
+    world,
+    platform,
+    plugin: {
+      evaluate: (options: unknown) => invoke("evaluate", options),
+      importModule: (options: unknown) => invoke("importModule", options),
+      dispose: () => invoke("dispose", null),
+    },
+  };
+}
+
+afterEach(() => {
+  for (const item of active.splice(0)) {
+    item.platform.teardown();
+    item.world.teardown();
+  }
+});
+
+describe("native JavaScript runtime synthetic host", () => {
+  it("executes the production JSC bridge with ledger and reset proof", async () => {
+    const surface = "@elizaos/app-core:native-bridge:capacitorjsc";
+    const { world, platform, plugin } = boot("native:jsc", surface, "jsc");
+    const bridge = createCapacitorJscBridge(
+      plugin as unknown as CapacitorJscPlugin,
+    );
+    await expect(bridge.evaluate({ code: "6 * 7" })).resolves.toEqual({
+      kind: "string",
+      value: "jsc:6 * 7",
+    });
+    await bridge.importModule({ absolutePath: "/synthetic/module.mjs" });
+    await bridge.dispose();
+    expect(world.ledger.byKind("readback")).toHaveLength(3);
+    expect(platform.readback().surfaces[surface]).toEqual({
+      disposed: true,
+      imports: 1,
+    });
+    expect(platform.reset().surfaces[surface]).toEqual({
+      disposed: false,
+      imports: 0,
+    });
+    expect(world.ledger.all()).toEqual([]);
+  });
+
+  it("executes both production QuickJS kinds and fails on unavailable host", async () => {
+    const surface = "@elizaos/app-core:native-bridge:capacitorquickjs";
+    const { platform, plugin } = boot("native:quickjs", surface, "quickjs");
+    const android = createCapacitorQuickJsBridge(
+      plugin as unknown as CapacitorQuickJsPlugin,
+      "quickjs-android",
+    );
+    const ios = createCapacitorQuickJsBridge(
+      plugin as unknown as CapacitorQuickJsPlugin,
+      "quickjs-ios-fallback",
+    );
+    expect(android.kind).toBe("quickjs-android");
+    expect(ios.kind).toBe("quickjs-ios-fallback");
+    await expect(android.evaluate({ code: "1 + 1" })).resolves.toEqual({
+      kind: "string",
+      value: "quickjs:1 + 1",
+    });
+    platform.setAvailable(surface, false);
+    await expect(ios.evaluate({ code: "2 + 2" })).rejects.toMatchObject({
+      code: "platform-unavailable",
+    });
+  });
+});

--- a/packages/synthetic-world/AGENTS.md
+++ b/packages/synthetic-world/AGENTS.md
@@ -1,0 +1,36 @@
+# `@elizaos/synthetic-world`
+
+This private package owns the versioned, deterministic synthetic-world contract
+shared by scenario-runner, plugin integration tests, local development, and
+Cloud E2E. Repository-wide engineering and evidence requirements are inherited
+from the root [`CLAUDE.md`](../../CLAUDE.md).
+
+## Ownership boundary
+
+The package owns manifests, canonical hashing, virtual-time injection, named
+fault scripts, observation ledgers, lifecycle/reset semantics, and worker
+namespaces. It does not own production schedulers, queues, provider clients, or
+storage repositories. Consumers inject its clock and boundary adapters into the
+real production implementations.
+
+The manifest is data, not executable setup. Add domain objects or provider
+fixtures to the versioned schema and keep scenario overlays declarative.
+
+## Safety and determinism
+
+- Fixtures must contain only reserved example domains, synthetic phone numbers,
+  and obvious non-secret tokens.
+- State hashes are computed from canonical JSON and must reproduce across
+  processes.
+- Reset and restore clear every observation ledger.
+- Virtual time must never depend on wall-clock sleeps.
+- Parallel consumers must allocate a worker namespace and never share a
+  `SyntheticWorld` instance.
+
+## Commands
+
+```bash
+bun run --cwd packages/synthetic-world test
+bun run --cwd packages/synthetic-world typecheck
+bun run --cwd packages/synthetic-world lint:check
+```

--- a/packages/synthetic-world/AGENTS.md
+++ b/packages/synthetic-world/AGENTS.md
@@ -27,6 +27,21 @@ fixtures to the versioned schema and keep scenario overlays declarative.
 - Parallel consumers must allocate a worker namespace and never share a
   `SyntheticWorld` instance.
 
+## Native simulator boundary
+
+`SyntheticNativePlatform` is the keyless host-side boundary for production
+JavaScript bridge clients. Definitions seed protocol-shaped state and handlers;
+the adapter owns availability and permission failures, cancellable virtual-time
+work, idempotent receipts, callback queues, restart/reset, ledger evidence, and
+authoritative readback. Its readback always says
+`certification: "synthetic-simulator-only"`.
+
+The exact platform-deferred inventory is pinned in
+`native-platform-ownership.ts`. Update it only from the canonical runtime
+surface scanner and preserve the source commit. Simulator coverage does not
+promote a row that also requires signed iOS, Android, macOS, or Electrobun
+qualification; device evidence remains a separate lane.
+
 ## Commands
 
 ```bash

--- a/packages/synthetic-world/CLAUDE.md
+++ b/packages/synthetic-world/CLAUDE.md
@@ -1,0 +1,36 @@
+# `@elizaos/synthetic-world`
+
+This private package owns the versioned, deterministic synthetic-world contract
+shared by scenario-runner, plugin integration tests, local development, and
+Cloud E2E. Repository-wide engineering and evidence requirements are inherited
+from the root [`CLAUDE.md`](../../CLAUDE.md).
+
+## Ownership boundary
+
+The package owns manifests, canonical hashing, virtual-time injection, named
+fault scripts, observation ledgers, lifecycle/reset semantics, and worker
+namespaces. It does not own production schedulers, queues, provider clients, or
+storage repositories. Consumers inject its clock and boundary adapters into the
+real production implementations.
+
+The manifest is data, not executable setup. Add domain objects or provider
+fixtures to the versioned schema and keep scenario overlays declarative.
+
+## Safety and determinism
+
+- Fixtures must contain only reserved example domains, synthetic phone numbers,
+  and obvious non-secret tokens.
+- State hashes are computed from canonical JSON and must reproduce across
+  processes.
+- Reset and restore clear every observation ledger.
+- Virtual time must never depend on wall-clock sleeps.
+- Parallel consumers must allocate a worker namespace and never share a
+  `SyntheticWorld` instance.
+
+## Commands
+
+```bash
+bun run --cwd packages/synthetic-world test
+bun run --cwd packages/synthetic-world typecheck
+bun run --cwd packages/synthetic-world lint:check
+```

--- a/packages/synthetic-world/CLAUDE.md
+++ b/packages/synthetic-world/CLAUDE.md
@@ -27,6 +27,21 @@ fixtures to the versioned schema and keep scenario overlays declarative.
 - Parallel consumers must allocate a worker namespace and never share a
   `SyntheticWorld` instance.
 
+## Native simulator boundary
+
+`SyntheticNativePlatform` is the keyless host-side boundary for production
+JavaScript bridge clients. Definitions seed protocol-shaped state and handlers;
+the adapter owns availability and permission failures, cancellable virtual-time
+work, idempotent receipts, callback queues, restart/reset, ledger evidence, and
+authoritative readback. Its readback always says
+`certification: "synthetic-simulator-only"`.
+
+The exact platform-deferred inventory is pinned in
+`native-platform-ownership.ts`. Update it only from the canonical runtime
+surface scanner and preserve the source commit. Simulator coverage does not
+promote a row that also requires signed iOS, Android, macOS, or Electrobun
+qualification; device evidence remains a separate lane.
+
 ## Commands
 
 ```bash

--- a/packages/synthetic-world/README.md
+++ b/packages/synthetic-world/README.md
@@ -39,4 +39,19 @@ domain state.
 virtual clock and ordered timer metadata, random position, fault attempts, and
 the observation ledger. Timer callback source is intentionally excluded.
 
+`SyntheticNativePlatform` adds a versioned native-host simulator around the
+same world. Production TypeScript/JavaScript bridge adapters invoke registered
+surface handlers, while the simulator records request/response/readback
+evidence and controls seeded state, permissions, availability, virtual delay,
+cancellation, idempotency, events, restart, reset, and teardown. Every readback
+is labeled `synthetic-simulator-only`; it is never evidence that a signed app or
+physical device passed.
+
+`NATIVE_PLATFORM_SURFACE_IDS` pins the 37 platform-deferred rows from runtime
+inventory commit `256cdd67bbd2459291e55100046fb909daa47f6d`. The list is an
+ownership ratchet, not a claim that all rows are qualified. Current production
+client integration covers app-core JSC/QuickJS and the Electrobun desktop
+permission bridge; the remaining rows require their own client bindings plus
+the supported-target evidence required by repository policy.
+
 See [`CLAUDE.md`](./CLAUDE.md) for ownership and fixture-safety rules.

--- a/packages/synthetic-world/README.md
+++ b/packages/synthetic-world/README.md
@@ -1,0 +1,37 @@
+# `@elizaos/synthetic-world`
+
+The canonical resettable test-world foundation for elizaOS. A single typed
+manifest can boot an in-process test, a scenario-runner process, or a Cloud E2E
+sidecar with identical state and virtual time.
+
+```ts
+import {
+  SYNTHETIC_WORLD_SCHEMA_VERSION,
+  bootInProcessWorld,
+} from "@elizaos/synthetic-world";
+
+const world = bootInProcessWorld({
+  schemaVersion: SYNTHETIC_WORLD_SCHEMA_VERSION,
+  worldId: "mail-reminder",
+  seed: "mail-reminder-v1",
+  clock: { epoch: "2030-01-01T08:00:00.000Z", timezone: "UTC" },
+  data: {},
+});
+
+await world.clock.advanceBy(60_000);
+world.reset();
+```
+
+Consumers keep using real production schedulers, repositories, queues, and
+provider clients. They inject `world.clock.adapter` for time, wrap external
+boundaries with `world.executeBoundary`, and inspect `world.ledger` for typed
+evidence. `createProcessBootstrap` carries the same validated manifest and
+namespace across a process or sidecar boundary.
+
+`world.snapshot()` is a state-and-clock snapshot, not a serialization of live
+callbacks. Restoring it clears the observation ledger and pending virtual
+timers, resets named-fault attempts and the seeded random stream, and expects
+production schedulers and queues to rehydrate their callbacks from restored
+domain state.
+
+See [`CLAUDE.md`](./CLAUDE.md) for ownership and fixture-safety rules.

--- a/packages/synthetic-world/README.md
+++ b/packages/synthetic-world/README.md
@@ -34,4 +34,9 @@ timers, resets named-fault attempts and the seeded random stream, and expects
 production schedulers and queues to rehydrate their callbacks from restored
 domain state.
 
+`world.stateHash` remains the compatibility hash for manifest data only.
+`world.executionStateHash` additionally hashes manifest identity, namespace,
+virtual clock and ordered timer metadata, random position, fault attempts, and
+the observation ledger. Timer callback source is intentionally excluded.
+
 See [`CLAUDE.md`](./CLAUDE.md) for ownership and fixture-safety rules.

--- a/packages/synthetic-world/package.json
+++ b/packages/synthetic-world/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@elizaos/synthetic-world",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Versioned, deterministic synthetic-world contracts for scenario and Cloud test harnesses.",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "node ../scripts/run-vitest.mjs run --config ./vitest.config.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "lint": "node ../scripts/run-biome-typescript.mjs src check",
+    "lint:check": "node ../scripts/run-biome-typescript.mjs src check",
+    "lint:fix": "node ../scripts/run-biome-typescript.mjs src check --write",
+    "format": "node ../scripts/run-biome-typescript.mjs src format",
+    "format:fix": "node ../scripts/run-biome-typescript.mjs src format --write"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "@types/node": "^24.0.0",
+    "vitest": "^4.1.10"
+  },
+  "elizaos": {
+    "scripts": {
+      "testLanes": [
+        "server"
+      ]
+    }
+  }
+}

--- a/packages/synthetic-world/src/adapters.test.ts
+++ b/packages/synthetic-world/src/adapters.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Verifies identical state across scenario-runner and Cloud bootstrap wires and
+ * exercises the transport-neutral sidecar control boundary.
+ */
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import {
+  bootWorldFromEnvironment,
+  bootWorldFromProcessBootstrap,
+  createProcessBootstrap,
+  processBootstrapEnvironment,
+  SyntheticWorldControlAdapter,
+  serializeProcessBootstrap,
+} from "./adapters.ts";
+import { testManifest } from "./test-fixture.ts";
+
+describe("synthetic-world process adapters", () => {
+  it("boots scenario-runner and Cloud profiles from the same canonical manifest", () => {
+    const manifest = testManifest();
+    const scenarioBootstrap = createProcessBootstrap(
+      manifest,
+      "scenario-runner",
+      { namespace: "world:scenario:one" },
+    );
+    const cloudBootstrap = createProcessBootstrap(manifest, "cloud-e2e", {
+      namespace: "world:cloud:one",
+    });
+    expect(scenarioBootstrap.manifestHash).toBe(cloudBootstrap.manifestHash);
+    const scenario = bootWorldFromProcessBootstrap(
+      serializeProcessBootstrap(scenarioBootstrap),
+    );
+    const cloud = bootWorldFromEnvironment(
+      processBootstrapEnvironment(cloudBootstrap),
+    );
+    expect(scenario.stateHash).toBe(cloud.stateHash);
+    expect(scenario.clock.nowIso()).toBe(cloud.clock.nowIso());
+    scenario.teardown();
+    cloud.teardown();
+  });
+
+  it("reproduces the same state hash in an isolated process", () => {
+    const bootstrap = createProcessBootstrap(
+      testManifest(),
+      "scenario-runner",
+      {
+        namespace: "world:subprocess:one",
+      },
+    );
+    const encoded = serializeProcessBootstrap(bootstrap);
+    const script = `
+      import { bootWorldFromProcessBootstrap } from "./src/index.ts";
+      const world = bootWorldFromProcessBootstrap(process.argv[1]);
+      process.stdout.write(world.stateHash);
+      world.teardown();
+    `;
+    const subprocessHash = execFileSync("bun", ["--eval", script, encoded], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+    const world = bootWorldFromProcessBootstrap({
+      ...bootstrap,
+      namespace: "world:subprocess:parent",
+    });
+    expect(subprocessHash).toBe(world.stateHash);
+    world.teardown();
+  });
+
+  it("rejects bootstrap drift and unsupported wire versions", () => {
+    const bootstrap = createProcessBootstrap(testManifest(), "cloud-e2e", {
+      namespace: "world:drift:one",
+    });
+    const drifted = { ...bootstrap, manifestHash: "0".repeat(64) };
+    expect(() => bootWorldFromProcessBootstrap(drifted)).toThrow(
+      /hash mismatch/,
+    );
+    const unsupported = Buffer.from(
+      JSON.stringify({ ...bootstrap, bootstrapVersion: "2" }),
+    ).toString("base64url");
+    expect(() => bootWorldFromProcessBootstrap(unsupported)).toThrow(
+      /Unsupported/,
+    );
+  });
+
+  it("exposes reset, snapshot, restore, time, state, and ledger controls", async () => {
+    const bootstrap = createProcessBootstrap(testManifest(), "cloud-e2e", {
+      namespace: "world:control:one",
+    });
+    const world = bootWorldFromProcessBootstrap(bootstrap);
+    const control = new SyntheticWorldControlAdapter(world);
+    const initial = await control.handle({ operation: "state" });
+    const snapshotResponse = await control.handle({ operation: "snapshot" });
+    if (snapshotResponse.operation !== "snapshot")
+      throw new Error("Expected snapshot response");
+    const advanced = await control.handle({
+      operation: "advanceBy",
+      durationMs: 1_000,
+    });
+    expect(advanced).toMatchObject({
+      operation: "advanceBy",
+      callbacks: 0,
+      now: "2030-01-01T08:00:01.000Z",
+    });
+    await control.handle({
+      operation: "restore",
+      snapshot: snapshotResponse.snapshot,
+    });
+    expect(await control.handle({ operation: "state" })).toEqual(initial);
+    expect(await control.handle({ operation: "ledger" })).toEqual({
+      operation: "ledger",
+      entries: [],
+    });
+    await control.handle({ operation: "reset" });
+    world.teardown();
+  });
+});

--- a/packages/synthetic-world/src/adapters.ts
+++ b/packages/synthetic-world/src/adapters.ts
@@ -1,0 +1,213 @@
+/**
+ * Carries one validated world contract across in-process, scenario-runner, and
+ * Cloud sidecar boundaries without coupling the world to a transport server.
+ */
+import { canonicalJson, payloadHash } from "./canonical.ts";
+import {
+  type JsonValue,
+  parseWorldManifest,
+  type WorldManifest,
+} from "./manifest.ts";
+import { createWorkerNamespace } from "./namespace.ts";
+import { SyntheticWorld, type WorldSnapshot } from "./world.ts";
+
+export const SYNTHETIC_WORLD_BOOTSTRAP_VERSION = "1" as const;
+export const SYNTHETIC_WORLD_BOOTSTRAP_ENV =
+  "ELIZA_SYNTHETIC_WORLD_BOOTSTRAP" as const;
+
+export type SyntheticWorldProfile =
+  | "in-process"
+  | "scenario-runner"
+  | "cloud-e2e";
+
+export interface ProcessBootstrap {
+  readonly bootstrapVersion: typeof SYNTHETIC_WORLD_BOOTSTRAP_VERSION;
+  readonly profile: SyntheticWorldProfile;
+  readonly namespace: string;
+  readonly manifest: WorldManifest;
+  readonly manifestHash: string;
+}
+
+export interface BootWorldOptions {
+  readonly namespace?: string;
+  readonly workerId?: string;
+  readonly runId?: string;
+}
+
+function resolveNamespace(
+  manifest: WorldManifest,
+  profile: SyntheticWorldProfile,
+  options: BootWorldOptions,
+): string {
+  if (options.namespace) return options.namespace;
+  return createWorkerNamespace(
+    manifest.worldId,
+    options.workerId ?? profile,
+    options.runId ?? "default",
+  );
+}
+
+export function bootInProcessWorld(
+  manifestInput: WorldManifest,
+  options: BootWorldOptions = {},
+): SyntheticWorld {
+  const manifest = parseWorldManifest(manifestInput);
+  return new SyntheticWorld(
+    manifest,
+    resolveNamespace(manifest, "in-process", options),
+  );
+}
+
+export function createProcessBootstrap(
+  manifestInput: WorldManifest,
+  profile: Exclude<SyntheticWorldProfile, "in-process">,
+  options: BootWorldOptions = {},
+): ProcessBootstrap {
+  const manifest = parseWorldManifest(manifestInput);
+  return {
+    bootstrapVersion: SYNTHETIC_WORLD_BOOTSTRAP_VERSION,
+    profile,
+    namespace: resolveNamespace(manifest, profile, options),
+    manifest,
+    manifestHash: payloadHash(manifest as unknown as JsonValue),
+  };
+}
+
+export function serializeProcessBootstrap(bootstrap: ProcessBootstrap): string {
+  return Buffer.from(
+    canonicalJson(bootstrap as unknown as JsonValue),
+    "utf8",
+  ).toString("base64url");
+}
+
+export function parseProcessBootstrap(encoded: string): ProcessBootstrap {
+  let value: unknown;
+  try {
+    value = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+  } catch (cause) {
+    // error-policy:J3 Process input is rejected explicitly instead of producing a partial world.
+    throw new Error("Invalid synthetic-world process bootstrap encoding", {
+      cause,
+    });
+  }
+  if (typeof value !== "object" || value === null)
+    throw new Error("Synthetic-world bootstrap must be an object");
+  const candidate = value as Record<string, unknown>;
+  if (candidate.bootstrapVersion !== SYNTHETIC_WORLD_BOOTSTRAP_VERSION) {
+    throw new Error(
+      `Unsupported synthetic-world bootstrap version: ${String(candidate.bootstrapVersion)}`,
+    );
+  }
+  if (
+    candidate.profile !== "scenario-runner" &&
+    candidate.profile !== "cloud-e2e"
+  ) {
+    throw new Error(
+      `Unsupported synthetic-world profile: ${String(candidate.profile)}`,
+    );
+  }
+  if (typeof candidate.namespace !== "string")
+    throw new Error("Synthetic-world bootstrap namespace is required");
+  const manifest = parseWorldManifest(candidate.manifest);
+  const manifestHash = payloadHash(manifest as unknown as JsonValue);
+  if (candidate.manifestHash !== manifestHash)
+    throw new Error("Synthetic-world bootstrap manifest hash mismatch");
+  return {
+    bootstrapVersion: SYNTHETIC_WORLD_BOOTSTRAP_VERSION,
+    profile: candidate.profile,
+    namespace: candidate.namespace,
+    manifest,
+    manifestHash,
+  };
+}
+
+export function bootWorldFromProcessBootstrap(
+  input: string | ProcessBootstrap,
+): SyntheticWorld {
+  const bootstrap =
+    typeof input === "string"
+      ? parseProcessBootstrap(input)
+      : parseProcessBootstrap(serializeProcessBootstrap(input));
+  return new SyntheticWorld(bootstrap.manifest, bootstrap.namespace);
+}
+
+export function processBootstrapEnvironment(
+  bootstrap: ProcessBootstrap,
+): Readonly<Record<string, string>> {
+  return {
+    [SYNTHETIC_WORLD_BOOTSTRAP_ENV]: serializeProcessBootstrap(bootstrap),
+  };
+}
+
+export function bootWorldFromEnvironment(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): SyntheticWorld {
+  const encoded = environment[SYNTHETIC_WORLD_BOOTSTRAP_ENV];
+  if (!encoded) throw new Error(`${SYNTHETIC_WORLD_BOOTSTRAP_ENV} is required`);
+  return bootWorldFromProcessBootstrap(encoded);
+}
+
+export type ControlRequest =
+  | { readonly operation: "state" }
+  | { readonly operation: "snapshot" }
+  | { readonly operation: "restore"; readonly snapshot: WorldSnapshot }
+  | { readonly operation: "reset" }
+  | { readonly operation: "advanceBy"; readonly durationMs: number }
+  | { readonly operation: "ledger" };
+
+export type ControlResponse =
+  | {
+      readonly operation: "state";
+      readonly stateHash: string;
+      readonly now: string;
+    }
+  | { readonly operation: "snapshot"; readonly snapshot: WorldSnapshot }
+  | { readonly operation: "restore" | "reset"; readonly stateHash: string }
+  | {
+      readonly operation: "advanceBy";
+      readonly callbacks: number;
+      readonly now: string;
+    }
+  | {
+      readonly operation: "ledger";
+      readonly entries: ReturnType<SyntheticWorld["ledger"]["all"]>;
+    };
+
+export interface SyntheticWorldControlBoundary {
+  handle(request: ControlRequest): Promise<ControlResponse>;
+}
+
+export class SyntheticWorldControlAdapter
+  implements SyntheticWorldControlBoundary
+{
+  public constructor(private readonly world: SyntheticWorld) {}
+
+  public async handle(request: ControlRequest): Promise<ControlResponse> {
+    switch (request.operation) {
+      case "state":
+        return {
+          operation: "state",
+          stateHash: this.world.stateHash,
+          now: this.world.clock.nowIso(),
+        };
+      case "snapshot":
+        return { operation: "snapshot", snapshot: this.world.snapshot() };
+      case "restore":
+        this.world.restore(request.snapshot);
+        return { operation: "restore", stateHash: this.world.stateHash };
+      case "reset":
+        this.world.reset();
+        return { operation: "reset", stateHash: this.world.stateHash };
+      case "advanceBy": {
+        const callbacks = await this.world.clock.advanceBy(request.durationMs);
+        return {
+          operation: "advanceBy",
+          callbacks,
+          now: this.world.clock.nowIso(),
+        };
+      }
+      case "ledger":
+        return { operation: "ledger", entries: this.world.ledger.all() };
+    }
+  }
+}

--- a/packages/synthetic-world/src/canonical.ts
+++ b/packages/synthetic-world/src/canonical.ts
@@ -68,4 +68,8 @@ export class DeterministicRandom {
       minInclusive + Math.floor(this.next() * (maxExclusive - minInclusive))
     );
   }
+
+  public snapshot(): { readonly state: number } {
+    return { state: this.state };
+  }
 }

--- a/packages/synthetic-world/src/canonical.ts
+++ b/packages/synthetic-world/src/canonical.ts
@@ -1,0 +1,71 @@
+/**
+ * Produces process-independent canonical JSON, hashes, stable fixture IDs, and
+ * seeded pseudo-random values for reproducible synthetic worlds.
+ */
+import { createHash } from "node:crypto";
+import type { JsonValue } from "./manifest.ts";
+
+function sortJson(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, sortJson(child)]),
+    );
+  }
+  return value;
+}
+
+export function canonicalJson(value: JsonValue): string {
+  return JSON.stringify(sortJson(value));
+}
+
+export function payloadHash(value: JsonValue): string {
+  return createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
+export function stableFixtureId(
+  worldId: string,
+  kind: string,
+  key: string,
+): string {
+  const suffix = createHash("sha256")
+    .update(`${worldId}\0${kind}\0${key}`)
+    .digest("hex")
+    .slice(0, 24);
+  return `${kind}_${suffix}`;
+}
+
+export class DeterministicRandom {
+  private state: number;
+
+  public constructor(seed: string) {
+    const digest = createHash("sha256").update(seed).digest();
+    this.state = digest.readUInt32LE(0) || 1;
+  }
+
+  public next(): number {
+    let value = this.state;
+    value ^= value << 13;
+    value ^= value >>> 17;
+    value ^= value << 5;
+    this.state = value >>> 0;
+    return this.state / 0x1_0000_0000;
+  }
+
+  public integer(minInclusive: number, maxExclusive: number): number {
+    if (
+      !Number.isInteger(minInclusive) ||
+      !Number.isInteger(maxExclusive) ||
+      maxExclusive <= minInclusive
+    ) {
+      throw new RangeError(
+        "DeterministicRandom.integer requires a non-empty integer range",
+      );
+    }
+    return (
+      minInclusive + Math.floor(this.next() * (maxExclusive - minInclusive))
+    );
+  }
+}

--- a/packages/synthetic-world/src/clock.test.ts
+++ b/packages/synthetic-world/src/clock.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Verifies virtual-time ordering, timer cancellation, interval stepping, sleep,
+ * and runaway protection without using wall-clock delays.
+ */
+import { describe, expect, it } from "vitest";
+import { VirtualClock } from "./clock.ts";
+
+describe("VirtualClock", () => {
+  it("runs timers deterministically in due-time and registration order", async () => {
+    const clock = new VirtualClock("2030-01-01T00:00:00.000Z");
+    const events: string[] = [];
+    clock.setTimeout(() => {
+      events.push("late");
+    }, 20);
+    clock.setTimeout(() => {
+      events.push("first");
+    }, 10);
+    clock.setTimeout(() => {
+      events.push("second");
+    }, 10);
+    expect(await clock.advanceBy(20)).toBe(3);
+    expect(events).toEqual(["first", "second", "late"]);
+    expect(clock.nowIso()).toBe("2030-01-01T00:00:00.020Z");
+  });
+
+  it("drives sleep and recurring work through explicit advancement", async () => {
+    const clock = new VirtualClock("2030-01-01T00:00:00.000Z");
+    let intervals = 0;
+    const interval = clock.setInterval(() => {
+      intervals += 1;
+      if (intervals === 2) clock.clearTimeout(interval);
+    }, 5);
+    let slept = false;
+    const sleeping = clock.sleep(7).then(() => {
+      slept = true;
+    });
+    expect(await clock.step()).toBe(true);
+    expect(intervals).toBe(1);
+    await clock.advanceBy(2);
+    await sleeping;
+    expect(slept).toBe(true);
+    await clock.advanceBy(3);
+    expect(intervals).toBe(2);
+    expect(clock.pendingTimerCount).toBe(0);
+  });
+
+  it("rejects backward time and invalid timers", async () => {
+    const clock = new VirtualClock("2030-01-01T00:00:00.000Z");
+    await expect(clock.advanceTo("2029-01-01T00:00:00.000Z")).rejects.toThrow(
+      /cannot move backwards/,
+    );
+    expect(() => clock.setInterval(() => undefined, 0)).toThrow(/positive/);
+  });
+});

--- a/packages/synthetic-world/src/clock.ts
+++ b/packages/synthetic-world/src/clock.ts
@@ -1,0 +1,165 @@
+/**
+ * Supplies an explicitly advanced clock and timer seam so production workers
+ * can run schedules, retries, expiries, and notifications without wall time.
+ */
+export interface ClockAdapter {
+  now(): Date;
+  setTimeout(callback: () => void | Promise<void>, delayMs: number): string;
+  clearTimeout(timerId: string): void;
+  setInterval(callback: () => void | Promise<void>, intervalMs: number): string;
+  clearInterval(timerId: string): void;
+  sleep(delayMs: number): Promise<void>;
+}
+
+interface ScheduledTimer {
+  id: string;
+  dueMs: number;
+  callback: () => void | Promise<void>;
+  intervalMs?: number;
+}
+
+export class VirtualClock {
+  private currentMs: number;
+  private sequence = 0;
+  private readonly timers = new Map<string, ScheduledTimer>();
+  public readonly timezone: string;
+
+  public readonly adapter: ClockAdapter = {
+    now: () => this.now(),
+    setTimeout: (callback, delayMs) => this.setTimeout(callback, delayMs),
+    clearTimeout: (timerId) => this.clearTimeout(timerId),
+    setInterval: (callback, intervalMs) =>
+      this.setInterval(callback, intervalMs),
+    clearInterval: (timerId) => this.clearTimeout(timerId),
+    sleep: (delayMs) => this.sleep(delayMs),
+  };
+
+  public constructor(epoch: string | Date, timezone = "UTC") {
+    this.currentMs = new Date(epoch).getTime();
+    if (!Number.isFinite(this.currentMs))
+      throw new RangeError("VirtualClock epoch must be a valid timestamp");
+    this.timezone = timezone;
+  }
+
+  public now(): Date {
+    return new Date(this.currentMs);
+  }
+
+  public nowIso(): string {
+    return this.now().toISOString();
+  }
+
+  public setTimeout(
+    callback: () => void | Promise<void>,
+    delayMs: number,
+  ): string {
+    return this.schedule(callback, delayMs);
+  }
+
+  public setInterval(
+    callback: () => void | Promise<void>,
+    intervalMs: number,
+  ): string {
+    if (!Number.isFinite(intervalMs) || intervalMs <= 0)
+      throw new RangeError("Virtual interval must be positive");
+    return this.schedule(callback, intervalMs, intervalMs);
+  }
+
+  public clearTimeout(timerId: string): void {
+    this.timers.delete(timerId);
+  }
+
+  public sleep(delayMs: number): Promise<void> {
+    return new Promise((resolve) => {
+      this.setTimeout(resolve, delayMs);
+    });
+  }
+
+  public async advanceBy(durationMs: number): Promise<number> {
+    if (!Number.isFinite(durationMs) || durationMs < 0)
+      throw new RangeError("Virtual duration must be non-negative");
+    return this.advanceTo(new Date(this.currentMs + durationMs));
+  }
+
+  public async advanceTo(target: string | Date): Promise<number> {
+    const targetMs = new Date(target).getTime();
+    if (!Number.isFinite(targetMs) || targetMs < this.currentMs) {
+      throw new RangeError("Virtual time cannot move backwards");
+    }
+    let executed = 0;
+    while (true) {
+      const next = this.nextDueTimer(targetMs);
+      if (!next) break;
+      this.currentMs = next.dueMs;
+      if (next.intervalMs === undefined) this.timers.delete(next.id);
+      else next.dueMs += next.intervalMs;
+      await next.callback();
+      executed += 1;
+      if (executed > 100_000)
+        throw new Error("VirtualClock advance exceeded 100000 timer callbacks");
+    }
+    this.currentMs = targetMs;
+    return executed;
+  }
+
+  public async runUntilIdle(maxCallbacks = 10_000): Promise<number> {
+    let executed = 0;
+    while (this.timers.size > 0) {
+      const nextDueMs = Math.min(
+        ...[...this.timers.values()].map((timer) => timer.dueMs),
+      );
+      executed += await this.advanceTo(new Date(nextDueMs));
+      if (executed >= maxCallbacks)
+        throw new Error(
+          `VirtualClock did not become idle within ${maxCallbacks} callbacks`,
+        );
+    }
+    return executed;
+  }
+
+  public async step(): Promise<boolean> {
+    const next = this.nextDueTimer(Number.POSITIVE_INFINITY);
+    if (!next) return false;
+    await this.advanceTo(new Date(next.dueMs));
+    return true;
+  }
+
+  public reset(epoch: string | Date): void {
+    const epochMs = new Date(epoch).getTime();
+    if (!Number.isFinite(epochMs))
+      throw new RangeError("VirtualClock epoch must be a valid timestamp");
+    this.timers.clear();
+    this.sequence = 0;
+    this.currentMs = epochMs;
+  }
+
+  public get pendingTimerCount(): number {
+    return this.timers.size;
+  }
+
+  private schedule(
+    callback: () => void | Promise<void>,
+    delayMs: number,
+    intervalMs?: number,
+  ): string {
+    if (!Number.isFinite(delayMs) || delayMs < 0)
+      throw new RangeError("Virtual timer delay must be non-negative");
+    const id = `timer-${++this.sequence}`;
+    this.timers.set(id, {
+      id,
+      dueMs: this.currentMs + delayMs,
+      callback,
+      intervalMs,
+    });
+    return id;
+  }
+
+  private nextDueTimer(targetMs: number): ScheduledTimer | undefined {
+    return [...this.timers.values()]
+      .filter((timer) => timer.dueMs <= targetMs)
+      .sort(
+        (left, right) =>
+          left.dueMs - right.dueMs || left.id.localeCompare(right.id),
+      )[0];
+  }
+}

--- a/packages/synthetic-world/src/clock.ts
+++ b/packages/synthetic-world/src/clock.ts
@@ -18,6 +18,17 @@ interface ScheduledTimer {
   intervalMs?: number;
 }
 
+export interface VirtualClockSnapshot {
+  readonly now: string;
+  readonly timezone: string;
+  readonly sequence: number;
+  readonly timers: readonly {
+    readonly id: string;
+    readonly dueAt: string;
+    readonly intervalMs?: number;
+  }[];
+}
+
 export class VirtualClock {
   private currentMs: number;
   private sequence = 0;
@@ -135,6 +146,26 @@ export class VirtualClock {
 
   public get pendingTimerCount(): number {
     return this.timers.size;
+  }
+
+  public snapshot(): VirtualClockSnapshot {
+    return {
+      now: this.nowIso(),
+      timezone: this.timezone,
+      sequence: this.sequence,
+      timers: [...this.timers.values()]
+        .sort(
+          (left, right) =>
+            left.dueMs - right.dueMs || left.id.localeCompare(right.id),
+        )
+        .map((timer) => ({
+          id: timer.id,
+          dueAt: new Date(timer.dueMs).toISOString(),
+          ...(timer.intervalMs === undefined
+            ? {}
+            : { intervalMs: timer.intervalMs }),
+        })),
+    };
   }
 
   private schedule(

--- a/packages/synthetic-world/src/faults.ts
+++ b/packages/synthetic-world/src/faults.ts
@@ -1,0 +1,59 @@
+/**
+ * Selects deterministic fault steps at named external boundaries and exposes
+ * typed failures that production-client adapters can translate into protocols.
+ */
+import type { FaultEffect, FaultScript } from "./manifest.ts";
+
+export class SyntheticFaultError extends Error {
+  public constructor(
+    public readonly boundary: string,
+    public readonly attempt: number,
+    public readonly effect: FaultEffect,
+  ) {
+    super(`Synthetic fault ${effect.kind} at ${boundary} attempt ${attempt}`);
+    this.name = "SyntheticFaultError";
+  }
+}
+
+export class FaultController {
+  private readonly attempts = new Map<string, number>();
+  private readonly scriptsByBoundary: ReadonlyMap<string, FaultScript>;
+
+  public constructor(scripts: readonly FaultScript[]) {
+    const grouped = new Map<string, FaultScript>();
+    for (const script of scripts) {
+      if (grouped.has(script.boundary)) {
+        throw new Error(
+          `Only one fault script may target boundary ${script.boundary}`,
+        );
+      }
+      const attempts = new Set<number>();
+      for (const step of script.steps) {
+        if (attempts.has(step.onAttempt)) {
+          throw new Error(
+            `Fault script ${script.id} repeats attempt ${step.onAttempt}`,
+          );
+        }
+        attempts.add(step.onAttempt);
+      }
+      grouped.set(script.boundary, script);
+    }
+    this.scriptsByBoundary = grouped;
+  }
+
+  public next(boundary: string): {
+    readonly attempt: number;
+    readonly effect?: FaultEffect;
+  } {
+    const attempt = (this.attempts.get(boundary) ?? 0) + 1;
+    this.attempts.set(boundary, attempt);
+    const effect = this.scriptsByBoundary
+      .get(boundary)
+      ?.steps.find((step) => step.onAttempt === attempt)?.effect;
+    return { attempt, effect };
+  }
+
+  public reset(): void {
+    this.attempts.clear();
+  }
+}

--- a/packages/synthetic-world/src/faults.ts
+++ b/packages/synthetic-world/src/faults.ts
@@ -56,4 +56,13 @@ export class FaultController {
   public reset(): void {
     this.attempts.clear();
   }
+
+  public snapshot(): readonly {
+    readonly boundary: string;
+    readonly attempts: number;
+  }[] {
+    return [...this.attempts.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([boundary, attempts]) => ({ boundary, attempts }));
+  }
 }

--- a/packages/synthetic-world/src/index.ts
+++ b/packages/synthetic-world/src/index.ts
@@ -9,5 +9,7 @@ export * from "./faults.ts";
 export * from "./ledger.ts";
 export * from "./manifest.ts";
 export * from "./namespace.ts";
+export * from "./native-platform.ts";
+export * from "./native-platform-ownership.ts";
 export * from "./overlay.ts";
 export * from "./world.ts";

--- a/packages/synthetic-world/src/index.ts
+++ b/packages/synthetic-world/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Exposes the transport-neutral synthetic-world contract used by all elizaOS
+ * deterministic integration harnesses.
+ */
+export * from "./adapters.ts";
+export * from "./canonical.ts";
+export * from "./clock.ts";
+export * from "./faults.ts";
+export * from "./ledger.ts";
+export * from "./manifest.ts";
+export * from "./namespace.ts";
+export * from "./overlay.ts";
+export * from "./world.ts";

--- a/packages/synthetic-world/src/ledger.ts
+++ b/packages/synthetic-world/src/ledger.ts
@@ -1,0 +1,90 @@
+/**
+ * Records append-only, virtual-time evidence across provider requests, model
+ * calls, queues, retries, schedules, notifications, and state transitions.
+ */
+import type { JsonValue } from "./manifest.ts";
+
+export type LedgerKind =
+  | "request"
+  | "response"
+  | "fault"
+  | "model"
+  | "queue"
+  | "retry"
+  | "schedule"
+  | "notification"
+  | "approval"
+  | "state-transition"
+  | "readback"
+  | "lifecycle";
+
+export type LedgerStatus =
+  | "started"
+  | "succeeded"
+  | "failed"
+  | "committed"
+  | "observed";
+
+export interface LedgerEntry {
+  readonly sequence: number;
+  readonly id: string;
+  readonly namespace: string;
+  readonly kind: LedgerKind;
+  readonly status: LedgerStatus;
+  readonly timestamp: string;
+  readonly target: string;
+  readonly attempt: number;
+  readonly payloadHash: string;
+  readonly input?: JsonValue;
+  readonly output?: JsonValue;
+  readonly idempotencyKey?: string;
+  readonly stateTransition?: {
+    readonly from: JsonValue;
+    readonly to: JsonValue;
+  };
+  readonly authoritativeReadback?: JsonValue;
+  readonly metadata?: Readonly<Record<string, JsonValue>>;
+}
+
+export type LedgerAppend = Omit<
+  LedgerEntry,
+  "sequence" | "id" | "namespace" | "timestamp"
+> & {
+  readonly timestamp?: string;
+};
+
+export class ObservationLedger {
+  private entries: LedgerEntry[] = [];
+  private sequence = 0;
+
+  public constructor(
+    public readonly namespace: string,
+    private readonly nowIso: () => string,
+  ) {}
+
+  public append(entry: LedgerAppend): LedgerEntry {
+    const sequence = ++this.sequence;
+    const stored: LedgerEntry = Object.freeze({
+      ...structuredClone(entry),
+      sequence,
+      id: `${this.namespace}:observation:${sequence}`,
+      namespace: this.namespace,
+      timestamp: entry.timestamp ?? this.nowIso(),
+    });
+    this.entries.push(stored);
+    return structuredClone(stored);
+  }
+
+  public all(): readonly LedgerEntry[] {
+    return structuredClone(this.entries);
+  }
+
+  public byKind(kind: LedgerKind): readonly LedgerEntry[] {
+    return structuredClone(this.entries.filter((entry) => entry.kind === kind));
+  }
+
+  public clear(): void {
+    this.entries = [];
+    this.sequence = 0;
+  }
+}

--- a/packages/synthetic-world/src/ledger.ts
+++ b/packages/synthetic-world/src/ledger.ts
@@ -87,4 +87,17 @@ export class ObservationLedger {
     this.entries = [];
     this.sequence = 0;
   }
+
+  public snapshot(): {
+    readonly policy: { readonly excludedTargets: readonly string[] };
+    readonly entries: readonly LedgerEntry[];
+  } {
+    const excludedTargets = ["world.boot"];
+    return {
+      policy: { excludedTargets },
+      entries: this.all().filter(
+        (entry) => !excludedTargets.includes(entry.target),
+      ),
+    };
+  }
 }

--- a/packages/synthetic-world/src/manifest.test.ts
+++ b/packages/synthetic-world/src/manifest.test.ts
@@ -34,6 +34,14 @@ describe("synthetic-world manifest", () => {
     );
   });
 
+  it("rejects a memory owned by an unknown identity", () => {
+    const manifest = testManifest();
+    manifest.data.memories[0].ownerIdentityId = "missing-owner";
+    expect(() => parseWorldManifest(manifest)).toThrow(
+      /memories\[0\]\.ownerIdentityId: unknown reference missing-owner/,
+    );
+  });
+
   it("rejects unsafe PII, URLs, and credential-like values", () => {
     const manifest = testManifest();
     manifest.data.identities[0].email = "person@production.example.org";

--- a/packages/synthetic-world/src/manifest.test.ts
+++ b/packages/synthetic-world/src/manifest.test.ts
@@ -62,6 +62,19 @@ describe("synthetic-world manifest", () => {
     );
   });
 
+  it("does not mistake scoped native boundary identifiers for email", () => {
+    const manifest = testManifest();
+    manifest.faults = [
+      {
+        id: "native-timeout",
+        boundary:
+          "native.@elizaos/capacitor-messages:native-bridge:elizamessages.send",
+        steps: [{ onAttempt: 1, effect: { kind: "timeout", durationMs: 100 } }],
+      },
+    ];
+    expect(() => parseWorldManifest(manifest)).not.toThrow();
+  });
+
   it("canonicalizes object keys and reproduces seeded values", () => {
     expect(canonicalJson({ z: 1, a: { y: true, b: false } })).toBe(
       '{"a":{"b":false,"y":true},"z":1}',

--- a/packages/synthetic-world/src/manifest.test.ts
+++ b/packages/synthetic-world/src/manifest.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Verifies manifest schema, referential integrity, fixture safety, canonical
+ * hashing, deterministic seeds, and declarative overlays in-process.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  canonicalJson,
+  DeterministicRandom,
+  payloadHash,
+  stableFixtureId,
+} from "./canonical.ts";
+import { parseWorldManifest, UnsafeFixtureError } from "./manifest.ts";
+import { applyWorldOverlay } from "./overlay.ts";
+import { testManifest } from "./test-fixture.ts";
+
+describe("synthetic-world manifest", () => {
+  it("validates a complete shared-domain world", () => {
+    const parsed = parseWorldManifest(testManifest());
+    expect(parsed.data.messages).toHaveLength(1);
+    expect(parsed.data.backgroundJobs).toHaveLength(1);
+  });
+
+  it("rejects unknown references and duplicate stable IDs", () => {
+    const manifest = testManifest();
+    manifest.data.messages.push({
+      ...manifest.data.messages[0],
+      roomId: "missing",
+    });
+    expect(() => parseWorldManifest(manifest)).toThrow(
+      /duplicate id message-one/,
+    );
+    expect(() => parseWorldManifest(manifest)).toThrow(
+      /unknown reference missing/,
+    );
+  });
+
+  it("rejects unsafe PII, URLs, and credential-like values", () => {
+    const manifest = testManifest();
+    manifest.data.identities[0].email = "person@production.example.org";
+    manifest.data.identities[0].phone = "+1-415-867-5309";
+    manifest.data.extensions = {
+      apiKey: "secret-production-value",
+      url: "https://production.example.org/data",
+    };
+    expect(() => parseWorldManifest(manifest)).toThrow(UnsafeFixtureError);
+    expect(() => parseWorldManifest(manifest)).toThrow(
+      /email domain is not allowed/,
+    );
+    expect(() => parseWorldManifest(manifest)).toThrow(
+      /reserved 555 synthetic number/,
+    );
+    expect(() => parseWorldManifest(manifest)).toThrow(
+      /credential-like fields/,
+    );
+  });
+
+  it("canonicalizes object keys and reproduces seeded values", () => {
+    expect(canonicalJson({ z: 1, a: { y: true, b: false } })).toBe(
+      '{"a":{"b":false,"y":true},"z":1}',
+    );
+    expect(payloadHash({ b: 2, a: 1 })).toBe(payloadHash({ a: 1, b: 2 }));
+    expect(stableFixtureId("world", "message", "one")).toBe(
+      stableFixtureId("world", "message", "one"),
+    );
+    const first = new DeterministicRandom("seed");
+    const second = new DeterministicRandom("seed");
+    expect([first.next(), first.integer(1, 10)]).toEqual([
+      second.next(),
+      second.integer(1, 10),
+    ]);
+  });
+
+  it("merges overlay entities by stable ID without mutating the base", () => {
+    const base = testManifest();
+    const overlaid = applyWorldOverlay(base, {
+      data: {
+        tasks: [
+          { ...base.data.tasks[0], status: "completed" },
+          {
+            id: "task-two",
+            ownerIdentityId: "person-peer",
+            title: "Review",
+            status: "pending",
+          },
+        ],
+      },
+    });
+    expect(base.data.tasks[0].status).toBe("pending");
+    expect(overlaid.data.tasks).toMatchObject([
+      { id: "task-one", status: "completed" },
+      { id: "task-two", status: "pending" },
+    ]);
+  });
+});

--- a/packages/synthetic-world/src/manifest.ts
+++ b/packages/synthetic-world/src/manifest.ts
@@ -395,7 +395,9 @@ function inspectFixtureValue(
   if (typeof value === "string") {
     if (credentialPattern.test(value))
       findings.push(`${path}: resembles a production credential`);
-    const emailMatch = value.match(/^[^@\s]+@([^@\s]+)$/);
+    const emailMatch = value.match(
+      /^[^@\s]+@([A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?\.[A-Za-z]{2,})$/,
+    );
     if (
       emailMatch &&
       !policy.allowedEmailDomains.includes(emailMatch[1].toLowerCase())

--- a/packages/synthetic-world/src/manifest.ts
+++ b/packages/synthetic-world/src/manifest.ts
@@ -1,0 +1,698 @@
+/**
+ * Defines and validates the versioned declarative state shared by every
+ * synthetic-world execution profile, including provider-owned fixture data.
+ */
+import { z } from "zod";
+
+export const SYNTHETIC_WORLD_SCHEMA_VERSION = "1.0.0" as const;
+
+export type JsonPrimitive = boolean | number | string | null;
+export type JsonValue =
+  | JsonPrimitive
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+const id = z.string().min(1).max(256);
+const timestamp = z.iso.datetime({ offset: true });
+const jsonValue: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number().finite(),
+    z.boolean(),
+    z.null(),
+    z.array(jsonValue),
+    z.record(z.string(), jsonValue),
+  ]),
+);
+const baseEntity = z.object({ id }).strict();
+
+export const faultEffectSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("latency"),
+      durationMs: z.number().int().nonnegative(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("timeout"),
+      durationMs: z.number().int().nonnegative(),
+    })
+    .strict(),
+  z.object({ kind: z.literal("disconnect") }).strict(),
+  z.object({ kind: z.literal("malformedData"), value: jsonValue }).strict(),
+  z.object({ kind: z.literal("authExpired") }).strict(),
+  z
+    .object({
+      kind: z.literal("rateLimit"),
+      retryAfterMs: z.number().int().positive(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("partialResponse"),
+      omitFields: z.array(z.string().min(1)).min(1),
+    })
+    .strict(),
+  z.object({ kind: z.literal("ambiguousCommit") }).strict(),
+  z
+    .object({
+      kind: z.literal("retry"),
+      retryAfterMs: z.number().int().nonnegative(),
+    })
+    .strict(),
+  z.object({ kind: z.literal("recovery") }).strict(),
+]);
+
+export const faultScriptSchema = z
+  .object({
+    id,
+    boundary: z.string().min(1),
+    steps: z
+      .array(
+        z
+          .object({
+            onAttempt: z.number().int().positive(),
+            effect: faultEffectSchema,
+          })
+          .strict(),
+      )
+      .min(1),
+  })
+  .strict();
+
+const identitySchema = baseEntity
+  .extend({
+    kind: z.enum(["person", "service"]),
+    displayName: z.string().min(1),
+    email: z.email().optional(),
+    phone: z.string().min(3).optional(),
+    attributes: z.record(z.string(), jsonValue).optional(),
+  })
+  .strict();
+
+const organizationSchema = baseEntity
+  .extend({
+    name: z.string().min(1),
+    memberIdentityIds: z.array(id),
+    attributes: z.record(z.string(), jsonValue).optional(),
+  })
+  .strict();
+
+const agentSchema = baseEntity
+  .extend({
+    name: z.string().min(1),
+    ownerIdentityId: id,
+    organizationId: id.optional(),
+    settings: z.record(z.string(), jsonValue).optional(),
+  })
+  .strict();
+
+const roomSchema = baseEntity
+  .extend({
+    kind: z.enum(["direct", "group", "channel"]),
+    participantIdentityIds: z.array(id),
+    connectorAccountId: id.optional(),
+    externalId: z.string().min(1).optional(),
+  })
+  .strict();
+
+const threadSchema = baseEntity
+  .extend({
+    roomId: id,
+    title: z.string().min(1).optional(),
+    participantIdentityIds: z.array(id).optional(),
+    externalId: z.string().min(1).optional(),
+  })
+  .strict();
+
+const messageSchema = baseEntity
+  .extend({
+    roomId: id,
+    senderIdentityId: id,
+    body: z.string(),
+    sentAt: timestamp,
+    threadId: id.optional(),
+    replyToMessageId: id.optional(),
+    mediaIds: z.array(id).optional(),
+    metadata: z.record(z.string(), jsonValue).optional(),
+  })
+  .strict();
+
+const grantSchema = baseEntity
+  .extend({
+    subjectIdentityId: id,
+    scopes: z.array(z.string().min(1)),
+    grantedAt: timestamp,
+    expiresAt: timestamp.optional(),
+    revokedAt: timestamp.optional(),
+  })
+  .strict();
+
+const connectorAccountSchema = baseEntity
+  .extend({
+    provider: z.string().min(1),
+    ownerIdentityId: id,
+    grantIds: z.array(id),
+    status: z.enum(["connected", "expired", "revoked", "error"]),
+    externalAccountId: z.string().min(1),
+    expiresAt: timestamp.optional(),
+    fixture: jsonValue.optional(),
+  })
+  .strict();
+
+const calendarSchema = baseEntity
+  .extend({
+    ownerIdentityId: id,
+    name: z.string().min(1),
+    timezone: z.string().min(1),
+  })
+  .strict();
+const calendarEventSchema = baseEntity
+  .extend({
+    calendarId: id,
+    title: z.string().min(1),
+    startsAt: timestamp,
+    endsAt: timestamp,
+    attendeeIdentityIds: z.array(id),
+    recurrence: z.string().min(1).optional(),
+  })
+  .strict();
+const taskSchema = baseEntity
+  .extend({
+    ownerIdentityId: id,
+    title: z.string().min(1),
+    status: z.enum(["pending", "running", "completed", "failed", "cancelled"]),
+    dueAt: timestamp.optional(),
+    payload: jsonValue.optional(),
+  })
+  .strict();
+const reminderSchema = baseEntity
+  .extend({
+    taskId: id.optional(),
+    ownerIdentityId: id,
+    message: z.string().min(1),
+    fireAt: timestamp,
+    status: z.enum([
+      "scheduled",
+      "delivered",
+      "acknowledged",
+      "dismissed",
+      "cancelled",
+    ]),
+  })
+  .strict();
+const contactSchema = baseEntity
+  .extend({
+    ownerIdentityId: id,
+    identityId: id,
+    notes: z.string().optional(),
+    tags: z.array(z.string()),
+  })
+  .strict();
+const relationshipSchema = baseEntity
+  .extend({
+    fromIdentityId: id,
+    toIdentityId: id,
+    kind: z.string().min(1),
+    attributes: z.record(z.string(), jsonValue).optional(),
+  })
+  .strict();
+const memorySchema = baseEntity
+  .extend({
+    agentId: id,
+    ownerIdentityId: id.optional(),
+    roomId: id.optional(),
+    content: jsonValue,
+    createdAt: timestamp,
+  })
+  .strict();
+const approvalSchema = baseEntity
+  .extend({
+    requesterIdentityId: id,
+    approverIdentityId: id,
+    action: z.string().min(1),
+    status: z.enum(["pending", "approved", "rejected", "expired", "cancelled"]),
+    requestedAt: timestamp,
+    decidedAt: timestamp.optional(),
+    payload: jsonValue.optional(),
+  })
+  .strict();
+const outboxEntrySchema = baseEntity
+  .extend({
+    target: z.string().min(1),
+    payload: jsonValue,
+    status: z.enum(["pending", "sending", "sent", "failed", "cancelled"]),
+    idempotencyKey: z.string().min(1),
+    attempts: z.number().int().nonnegative(),
+    availableAt: timestamp,
+  })
+  .strict();
+const notificationSchema = baseEntity
+  .extend({
+    recipientIdentityId: id,
+    channel: z.string().min(1),
+    body: z.string(),
+    status: z.enum(["queued", "delivered", "read", "failed", "cancelled"]),
+    deliverAt: timestamp,
+  })
+  .strict();
+const mediaSchema = baseEntity
+  .extend({
+    sha256: z.string().regex(/^[a-f0-9]{64}$/),
+    mimeType: z.string().min(1),
+    byteLength: z.number().int().nonnegative(),
+    url: z.url(),
+  })
+  .strict();
+const billingAccountSchema = baseEntity
+  .extend({
+    ownerIdentityId: id,
+    currency: z.string().length(3),
+    balanceMinor: z.number().int(),
+  })
+  .strict();
+const billingTransactionSchema = baseEntity
+  .extend({
+    accountId: id,
+    amountMinor: z.number().int(),
+    currency: z.string().length(3),
+    kind: z.string().min(1),
+    occurredAt: timestamp,
+    externalId: z.string().min(1).optional(),
+  })
+  .strict();
+const providerStateSchema = baseEntity
+  .extend({ provider: z.string().min(1), state: jsonValue })
+  .strict();
+const backgroundJobSchema = baseEntity
+  .extend({
+    queue: z.string().min(1),
+    kind: z.string().min(1),
+    status: z.enum(["queued", "running", "completed", "failed", "cancelled"]),
+    runAt: timestamp,
+    attempts: z.number().int().nonnegative(),
+    payload: jsonValue,
+  })
+  .strict();
+
+export const worldDataSchema = z
+  .object({
+    identities: z.array(identitySchema).default([]),
+    organizations: z.array(organizationSchema).default([]),
+    agents: z.array(agentSchema).default([]),
+    rooms: z.array(roomSchema).default([]),
+    threads: z.array(threadSchema).default([]),
+    messages: z.array(messageSchema).default([]),
+    connectorAccounts: z.array(connectorAccountSchema).default([]),
+    grants: z.array(grantSchema).default([]),
+    calendars: z.array(calendarSchema).default([]),
+    calendarEvents: z.array(calendarEventSchema).default([]),
+    tasks: z.array(taskSchema).default([]),
+    reminders: z.array(reminderSchema).default([]),
+    contacts: z.array(contactSchema).default([]),
+    relationships: z.array(relationshipSchema).default([]),
+    memories: z.array(memorySchema).default([]),
+    approvals: z.array(approvalSchema).default([]),
+    outbox: z.array(outboxEntrySchema).default([]),
+    notifications: z.array(notificationSchema).default([]),
+    media: z.array(mediaSchema).default([]),
+    billingAccounts: z.array(billingAccountSchema).default([]),
+    billingTransactions: z.array(billingTransactionSchema).default([]),
+    providerState: z.array(providerStateSchema).default([]),
+    backgroundJobs: z.array(backgroundJobSchema).default([]),
+    extensions: z.record(z.string(), jsonValue).default({}),
+  })
+  .strict();
+
+export const worldManifestSchema = z
+  .object({
+    schemaVersion: z.literal(SYNTHETIC_WORLD_SCHEMA_VERSION),
+    worldId: id,
+    seed: z.string().min(1),
+    clock: z.object({ epoch: timestamp, timezone: z.string().min(1) }).strict(),
+    fixturePolicy: z
+      .object({
+        allowedEmailDomains: z
+          .array(z.string().min(1))
+          .default(["example.com", "example.invalid"]),
+        allowedUrlHosts: z
+          .array(z.string().min(1))
+          .default([
+            "example.com",
+            "example.invalid",
+            "localhost",
+            "127.0.0.1",
+          ]),
+      })
+      .strict()
+      .default({
+        allowedEmailDomains: ["example.com", "example.invalid"],
+        allowedUrlHosts: [
+          "example.com",
+          "example.invalid",
+          "localhost",
+          "127.0.0.1",
+        ],
+      }),
+    data: worldDataSchema,
+    faults: z.array(faultScriptSchema).default([]),
+  })
+  .strict();
+
+export type FaultEffect = z.infer<typeof faultEffectSchema>;
+export type FaultScript = z.infer<typeof faultScriptSchema>;
+export type WorldData = z.infer<typeof worldDataSchema>;
+export type WorldManifest = z.infer<typeof worldManifestSchema>;
+
+const credentialKey =
+  /(api[-_]?key|access[-_]?token|refresh[-_]?token|password|client[-_]?secret|private[-_]?key)/i;
+const obviousSyntheticSecret =
+  /^(mock|synthetic|test|example|redacted|fake)([-_:].*)?$/i;
+const credentialPattern =
+  /(-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|\bsk_live_[A-Za-z0-9]+|\bghp_[A-Za-z0-9]{20,}|\bxox[baprs]-[A-Za-z0-9-]+)/;
+const syntheticPhone =
+  /^(?:\+?1[- .]?)?(?:555|[2-9]\d{2}[- .]?555)[- .]?\d{4}$/;
+
+export class UnsafeFixtureError extends Error {
+  public readonly findings: readonly string[];
+
+  public constructor(findings: readonly string[]) {
+    super(
+      `Synthetic-world fixture safety validation failed:\n${findings.join("\n")}`,
+    );
+    this.name = "UnsafeFixtureError";
+    this.findings = findings;
+  }
+}
+
+function inspectFixtureValue(
+  value: JsonValue,
+  path: string,
+  policy: WorldManifest["fixturePolicy"],
+  findings: string[],
+): void {
+  if (typeof value === "string") {
+    if (credentialPattern.test(value))
+      findings.push(`${path}: resembles a production credential`);
+    const emailMatch = value.match(/^[^@\s]+@([^@\s]+)$/);
+    if (
+      emailMatch &&
+      !policy.allowedEmailDomains.includes(emailMatch[1].toLowerCase())
+    ) {
+      findings.push(`${path}: email domain is not allowed by fixturePolicy`);
+    }
+    if (/^https?:\/\//i.test(value)) {
+      try {
+        const hostname = new URL(value).hostname.toLowerCase();
+        if (!policy.allowedUrlHosts.includes(hostname))
+          findings.push(`${path}: URL host is not allowed by fixturePolicy`);
+      } catch {
+        // error-policy:J3 Fixture strings resembling malformed URLs are explicitly invalid.
+        findings.push(`${path}: URL is malformed`);
+      }
+    }
+    return;
+  }
+  if (value === null || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const [index, child] of value.entries())
+      inspectFixtureValue(child, `${path}[${index}]`, policy, findings);
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = `${path}.${key}`;
+    if (
+      credentialKey.test(key) &&
+      typeof child === "string" &&
+      !obviousSyntheticSecret.test(child)
+    ) {
+      findings.push(
+        `${childPath}: credential-like fields must contain an obvious synthetic value`,
+      );
+    }
+    inspectFixtureValue(child, childPath, policy, findings);
+  }
+}
+
+function validateReferences(manifest: WorldManifest, findings: string[]): void {
+  const { extensions: _extensions, ...entityCollections } = manifest.data;
+  for (const [collection, entities] of Object.entries(entityCollections)) {
+    const seen = new Set<string>();
+    for (const entity of entities) {
+      if (seen.has(entity.id))
+        findings.push(`$.data.${collection}: duplicate id ${entity.id}`);
+      seen.add(entity.id);
+    }
+  }
+
+  const identities = new Set(manifest.data.identities.map(({ id }) => id));
+  const organizations = new Set(
+    manifest.data.organizations.map(({ id }) => id),
+  );
+  const agents = new Set(manifest.data.agents.map(({ id }) => id));
+  const rooms = new Set(manifest.data.rooms.map(({ id }) => id));
+  const threads = new Set(manifest.data.threads.map(({ id }) => id));
+  const messages = new Set(manifest.data.messages.map(({ id }) => id));
+  const tasks = new Set(manifest.data.tasks.map(({ id }) => id));
+  const calendars = new Set(manifest.data.calendars.map(({ id }) => id));
+  const media = new Set(manifest.data.media.map(({ id }) => id));
+  const accounts = new Set(manifest.data.billingAccounts.map(({ id }) => id));
+  const grants = new Set(manifest.data.grants.map(({ id }) => id));
+  const connectors = new Set(
+    manifest.data.connectorAccounts.map(({ id }) => id),
+  );
+
+  const requireId = (
+    set: ReadonlySet<string>,
+    value: string,
+    path: string,
+  ): void => {
+    if (!set.has(value)) findings.push(`${path}: unknown reference ${value}`);
+  };
+  for (const [index, identity] of manifest.data.identities.entries()) {
+    if (identity.phone && !syntheticPhone.test(identity.phone)) {
+      findings.push(
+        `$.data.identities[${index}].phone: must use a reserved 555 synthetic number`,
+      );
+    }
+  }
+  for (const [index, agent] of manifest.data.agents.entries()) {
+    requireId(
+      identities,
+      agent.ownerIdentityId,
+      `$.data.agents[${index}].ownerIdentityId`,
+    );
+    if (agent.organizationId)
+      requireId(
+        organizations,
+        agent.organizationId,
+        `$.data.agents[${index}].organizationId`,
+      );
+  }
+  for (const [index, organization] of manifest.data.organizations.entries()) {
+    for (const identityId of organization.memberIdentityIds)
+      requireId(
+        identities,
+        identityId,
+        `$.data.organizations[${index}].memberIdentityIds`,
+      );
+  }
+  for (const [index, room] of manifest.data.rooms.entries()) {
+    for (const identityId of room.participantIdentityIds) {
+      requireId(
+        identities,
+        identityId,
+        `$.data.rooms[${index}].participantIdentityIds`,
+      );
+    }
+    if (room.connectorAccountId) {
+      requireId(
+        connectors,
+        room.connectorAccountId,
+        `$.data.rooms[${index}].connectorAccountId`,
+      );
+    }
+  }
+  for (const [index, message] of manifest.data.messages.entries()) {
+    requireId(rooms, message.roomId, `$.data.messages[${index}].roomId`);
+    requireId(
+      identities,
+      message.senderIdentityId,
+      `$.data.messages[${index}].senderIdentityId`,
+    );
+    if (message.threadId)
+      requireId(
+        threads,
+        message.threadId,
+        `$.data.messages[${index}].threadId`,
+      );
+    if (message.replyToMessageId)
+      requireId(
+        messages,
+        message.replyToMessageId,
+        `$.data.messages[${index}].replyToMessageId`,
+      );
+    for (const mediaId of message.mediaIds ?? [])
+      requireId(media, mediaId, `$.data.messages[${index}].mediaIds`);
+  }
+  for (const [index, thread] of manifest.data.threads.entries()) {
+    requireId(rooms, thread.roomId, `$.data.threads[${index}].roomId`);
+    for (const identityId of thread.participantIdentityIds ?? [])
+      requireId(
+        identities,
+        identityId,
+        `$.data.threads[${index}].participantIdentityIds`,
+      );
+  }
+  for (const [index, grant] of manifest.data.grants.entries())
+    requireId(
+      identities,
+      grant.subjectIdentityId,
+      `$.data.grants[${index}].subjectIdentityId`,
+    );
+  for (const [index, connector] of manifest.data.connectorAccounts.entries()) {
+    requireId(
+      identities,
+      connector.ownerIdentityId,
+      `$.data.connectorAccounts[${index}].ownerIdentityId`,
+    );
+    for (const grantId of connector.grantIds) {
+      requireId(grants, grantId, `$.data.connectorAccounts[${index}].grantIds`);
+    }
+  }
+  for (const [index, calendar] of manifest.data.calendars.entries()) {
+    requireId(
+      identities,
+      calendar.ownerIdentityId,
+      `$.data.calendars[${index}].ownerIdentityId`,
+    );
+  }
+  for (const [index, event] of manifest.data.calendarEvents.entries()) {
+    requireId(
+      calendars,
+      event.calendarId,
+      `$.data.calendarEvents[${index}].calendarId`,
+    );
+    if (Date.parse(event.endsAt) < Date.parse(event.startsAt)) {
+      findings.push(
+        `$.data.calendarEvents[${index}]: endsAt precedes startsAt`,
+      );
+    }
+    for (const identityId of event.attendeeIdentityIds)
+      requireId(
+        identities,
+        identityId,
+        `$.data.calendarEvents[${index}].attendeeIdentityIds`,
+      );
+  }
+  for (const [index, task] of manifest.data.tasks.entries())
+    requireId(
+      identities,
+      task.ownerIdentityId,
+      `$.data.tasks[${index}].ownerIdentityId`,
+    );
+  for (const [index, reminder] of manifest.data.reminders.entries()) {
+    requireId(
+      identities,
+      reminder.ownerIdentityId,
+      `$.data.reminders[${index}].ownerIdentityId`,
+    );
+    if (reminder.taskId)
+      requireId(tasks, reminder.taskId, `$.data.reminders[${index}].taskId`);
+  }
+  for (const [index, memory] of manifest.data.memories.entries()) {
+    requireId(agents, memory.agentId, `$.data.memories[${index}].agentId`);
+    if (memory.roomId)
+      requireId(rooms, memory.roomId, `$.data.memories[${index}].roomId`);
+  }
+  for (const [index, contact] of manifest.data.contacts.entries()) {
+    requireId(
+      identities,
+      contact.ownerIdentityId,
+      `$.data.contacts[${index}].ownerIdentityId`,
+    );
+    requireId(
+      identities,
+      contact.identityId,
+      `$.data.contacts[${index}].identityId`,
+    );
+  }
+  for (const [index, relationship] of manifest.data.relationships.entries()) {
+    requireId(
+      identities,
+      relationship.fromIdentityId,
+      `$.data.relationships[${index}].fromIdentityId`,
+    );
+    requireId(
+      identities,
+      relationship.toIdentityId,
+      `$.data.relationships[${index}].toIdentityId`,
+    );
+  }
+  for (const [index, approval] of manifest.data.approvals.entries()) {
+    requireId(
+      identities,
+      approval.requesterIdentityId,
+      `$.data.approvals[${index}].requesterIdentityId`,
+    );
+    requireId(
+      identities,
+      approval.approverIdentityId,
+      `$.data.approvals[${index}].approverIdentityId`,
+    );
+  }
+  for (const [index, notification] of manifest.data.notifications.entries())
+    requireId(
+      identities,
+      notification.recipientIdentityId,
+      `$.data.notifications[${index}].recipientIdentityId`,
+    );
+  for (const [index, account] of manifest.data.billingAccounts.entries())
+    requireId(
+      identities,
+      account.ownerIdentityId,
+      `$.data.billingAccounts[${index}].ownerIdentityId`,
+    );
+  for (const [
+    index,
+    transaction,
+  ] of manifest.data.billingTransactions.entries()) {
+    requireId(
+      accounts,
+      transaction.accountId,
+      `$.data.billingTransactions[${index}].accountId`,
+    );
+  }
+
+  const boundaries = new Set<string>();
+  for (const [index, script] of manifest.faults.entries()) {
+    if (boundaries.has(script.boundary))
+      findings.push(
+        `$.faults[${index}]: duplicate boundary ${script.boundary}`,
+      );
+    boundaries.add(script.boundary);
+    const attempts = new Set<number>();
+    for (const step of script.steps) {
+      if (attempts.has(step.onAttempt))
+        findings.push(
+          `$.faults[${index}]: duplicate attempt ${step.onAttempt}`,
+        );
+      attempts.add(step.onAttempt);
+    }
+  }
+}
+
+export function parseWorldManifest(input: unknown): WorldManifest {
+  const manifest = worldManifestSchema.parse(input);
+  const findings: string[] = [];
+  inspectFixtureValue(
+    manifest as unknown as JsonValue,
+    "$",
+    manifest.fixturePolicy,
+    findings,
+  );
+  validateReferences(manifest, findings);
+  if (findings.length > 0) throw new UnsafeFixtureError(findings);
+  return manifest;
+}

--- a/packages/synthetic-world/src/manifest.ts
+++ b/packages/synthetic-world/src/manifest.ts
@@ -603,6 +603,12 @@ function validateReferences(manifest: WorldManifest, findings: string[]): void {
   }
   for (const [index, memory] of manifest.data.memories.entries()) {
     requireId(agents, memory.agentId, `$.data.memories[${index}].agentId`);
+    if (memory.ownerIdentityId)
+      requireId(
+        identities,
+        memory.ownerIdentityId,
+        `$.data.memories[${index}].ownerIdentityId`,
+      );
     if (memory.roomId)
       requireId(rooms, memory.roomId, `$.data.memories[${index}].roomId`);
   }

--- a/packages/synthetic-world/src/namespace.ts
+++ b/packages/synthetic-world/src/namespace.ts
@@ -1,0 +1,49 @@
+/**
+ * Allocates process-local worker namespaces and rejects accidental concurrent
+ * reuse so parallel test workers cannot share mutable synthetic state.
+ */
+const activeNamespaces = new Set<string>();
+
+const namespacePattern = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,255}$/;
+
+export class NamespaceInUseError extends Error {
+  public constructor(namespace: string) {
+    super(`Synthetic-world namespace is already active: ${namespace}`);
+    this.name = "NamespaceInUseError";
+  }
+}
+
+export interface NamespaceLease {
+  readonly namespace: string;
+  release(): void;
+}
+
+export function createWorkerNamespace(
+  worldId: string,
+  workerId: string,
+  runId: string,
+): string {
+  const namespace = `${worldId}:${workerId}:${runId}`;
+  if (!namespacePattern.test(namespace)) {
+    throw new RangeError(
+      "Synthetic-world namespace contains unsupported characters or is too long",
+    );
+  }
+  return namespace;
+}
+
+export function acquireNamespace(namespace: string): NamespaceLease {
+  if (!namespacePattern.test(namespace))
+    throw new RangeError("Invalid synthetic-world namespace");
+  if (activeNamespaces.has(namespace)) throw new NamespaceInUseError(namespace);
+  activeNamespaces.add(namespace);
+  let released = false;
+  return {
+    namespace,
+    release(): void {
+      if (released) return;
+      activeNamespaces.delete(namespace);
+      released = true;
+    },
+  };
+}

--- a/packages/synthetic-world/src/native-platform-ownership.ts
+++ b/packages/synthetic-world/src/native-platform-ownership.ts
@@ -1,0 +1,64 @@
+/**
+ * Pins ownership of every platform-deferred surface emitted by the canonical
+ * runtime inventory so additions, removals, or silent reclassification fail.
+ */
+export const NATIVE_PLATFORM_INVENTORY_SOURCE =
+  "elizaOS/eliza@256cdd67bbd2459291e55100046fb909daa47f6d:packages/scripts/e2e-coverage/runtime-surface-baseline.json" as const;
+
+export const NATIVE_PLATFORM_SURFACE_IDS = [
+  "@elizaos/app-core:native-bridge:capacitorjsc",
+  "@elizaos/app-core:native-bridge:capacitorquickjs",
+  "@elizaos/app-core:native-bridge:elizabunruntime",
+  "@elizaos/capacitor-agent:native-bridge:agent",
+  "@elizaos/capacitor-appblocker:native-bridge:elizaappblocker",
+  "@elizaos/capacitor-browser-surface:native-bridge:elizasurfacemanager",
+  "@elizaos/capacitor-bun-runtime:native-bridge:elizabunruntime",
+  "@elizaos/capacitor-calendar:native-bridge:applecalendar",
+  "@elizaos/capacitor-camera:native-bridge:elizacamera",
+  "@elizaos/capacitor-canvas:native-bridge:elizacanvas",
+  "@elizaos/capacitor-contacts:native-bridge:elizacontacts",
+  "@elizaos/capacitor-desktop:native-bridge:desktop",
+  "@elizaos/capacitor-eliza-tasks:native-bridge:elizatasks",
+  "@elizaos/capacitor-gateway:native-bridge:gateway",
+  "@elizaos/capacitor-llama:service:localinferenceloader",
+  "@elizaos/capacitor-location:native-bridge:elizalocation",
+  "@elizaos/capacitor-messages:native-bridge:elizamessages",
+  "@elizaos/capacitor-mlkit-text:native-bridge:tesseract",
+  "@elizaos/capacitor-mobile-agent-bridge:native-bridge:mobileagentbridge",
+  "@elizaos/capacitor-mobile-signals:native-bridge:mobilesignals",
+  "@elizaos/capacitor-network-policy:native-bridge:elizanetworkpolicy",
+  "@elizaos/capacitor-phone:native-bridge:elizaphone",
+  "@elizaos/capacitor-screencapture:native-bridge:screencapture",
+  "@elizaos/capacitor-swabble:native-bridge:swabble",
+  "@elizaos/capacitor-system:native-bridge:elizasystem",
+  "@elizaos/capacitor-talkmode:native-bridge:talkmode",
+  "@elizaos/capacitor-websiteblocker:native-bridge:elizawebsiteblocker",
+  "@elizaos/capacitor-wifi:native-bridge:elizawifi",
+  "@elizaos/macosalarm:action:alarm",
+  "@elizaos/plugin-native-filesystem:service:devicefilesystembridge",
+  "@elizaos/plugin-native-inference:model-handler:text_embedding",
+  "@elizaos/plugin-native-inference:model-handler:text_large",
+  "@elizaos/plugin-native-inference:model-handler:text_small",
+  "@elizaos/plugin-native-inference:model-handler:text_to_speech",
+  "@elizaos/plugin-native-inference:model-handler:transcription",
+  "@elizaos/plugin-native-settings:view:elizaos/plugin-native-settings",
+  "@elizaos/plugin-phone:native-bridge:elizaintent",
+] as const;
+
+export function assertNativePlatformOwnership(
+  platformDeferredSurfaceIds: readonly string[],
+): void {
+  const expected = [...NATIVE_PLATFORM_SURFACE_IDS].sort();
+  const expectedSet = new Set<string>(expected);
+  const actual = [...new Set(platformDeferredSurfaceIds)].sort();
+  const missing = expected.filter((id) => !actual.includes(id));
+  const unexpected = actual.filter((id) => !expectedSet.has(id));
+  if (actual.length !== platformDeferredSurfaceIds.length) {
+    throw new Error("Native platform inventory contains duplicate surface ids");
+  }
+  if (missing.length > 0 || unexpected.length > 0) {
+    throw new Error(
+      `Native platform ownership drifted (missing: ${missing.join(", ") || "none"}; unexpected: ${unexpected.join(", ") || "none"})`,
+    );
+  }
+}

--- a/packages/synthetic-world/src/native-platform.test.ts
+++ b/packages/synthetic-world/src/native-platform.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Exercises deterministic native-host lifecycle, permissions, faults,
+ * cancellation, idempotency, event delivery, reset, and teardown semantics.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { bootInProcessWorld } from "./adapters.ts";
+import type { WorldManifest } from "./manifest.ts";
+import {
+  SyntheticNativePlatform,
+  SyntheticNativePlatformError,
+} from "./native-platform.ts";
+import {
+  assertNativePlatformOwnership,
+  NATIVE_PLATFORM_SURFACE_IDS,
+} from "./native-platform-ownership.ts";
+import { testManifest } from "./test-fixture.ts";
+
+function boot(namespace: string, faults: WorldManifest["faults"] = []) {
+  const manifest = testManifest();
+  manifest.faults = faults;
+  const world = bootInProcessWorld(manifest, { namespace });
+  const platform = new SyntheticNativePlatform(world, [
+    {
+      id: "@elizaos/capacitor-messages:native-bridge:elizamessages",
+      initialState: { sent: [] },
+      handlers: {
+        send: async (input, context) => {
+          if (
+            !input ||
+            typeof input !== "object" ||
+            Array.isArray(input) ||
+            typeof input.body !== "string"
+          ) {
+            throw new SyntheticNativePlatformError(
+              "invalid-input",
+              "message body is required",
+            );
+          }
+          await context.sleep(50);
+          const state = context.state as { sent: JsonValue[] };
+          const next = { sent: [...state.sent, input] };
+          context.setState(next);
+          context.emit("messageSent", input);
+          return { accepted: true, count: next.sent.length };
+        },
+      },
+    },
+  ]);
+  return { world, platform };
+}
+
+type JsonValue =
+  | boolean
+  | number
+  | string
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+describe("SyntheticNativePlatform", () => {
+  it("pins the exact canonical platform-deferred ownership set", () => {
+    expect(NATIVE_PLATFORM_SURFACE_IDS).toHaveLength(37);
+    expect(() =>
+      assertNativePlatformOwnership(NATIVE_PLATFORM_SURFACE_IDS),
+    ).not.toThrow();
+    expect(() =>
+      assertNativePlatformOwnership(NATIVE_PLATFORM_SURFACE_IDS.slice(1)),
+    ).toThrow(/missing/);
+    expect(() =>
+      assertNativePlatformOwnership([...NATIVE_PLATFORM_SURFACE_IDS, "new"]),
+    ).toThrow(/unexpected/);
+  });
+
+  it("commits once, emits readback evidence, and survives process restart", async () => {
+    const { world, platform } = boot("native:success");
+    const event = vi.fn();
+    platform.subscribe(
+      "@elizaos/capacitor-messages:native-bridge:elizamessages",
+      "messageSent",
+      event,
+    );
+    const call = platform.invoke({
+      surfaceId: "@elizaos/capacitor-messages:native-bridge:elizamessages",
+      method: "send",
+      input: { body: "synthetic hello" },
+      idempotencyKey: "message-one",
+    });
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+    await world.clock.advanceBy(50);
+    await expect(call).resolves.toEqual({ accepted: true, count: 1 });
+    await expect(
+      platform.invoke({
+        surfaceId: "@elizaos/capacitor-messages:native-bridge:elizamessages",
+        method: "send",
+        input: { body: "synthetic hello" },
+        idempotencyKey: "message-one",
+      }),
+    ).resolves.toEqual({ accepted: true, count: 1 });
+    expect(platform.flushEvents()).toBe(1);
+    expect(event).toHaveBeenCalledWith({ body: "synthetic hello" });
+    expect(world.ledger.byKind("readback")).toHaveLength(2);
+    const beforeRestart = platform.readback();
+    const restarted = platform.restart();
+    expect(restarted.generation).toBe(2);
+    expect(restarted.stateHash).toBe(beforeRestart.stateHash);
+    expect(restarted.idempotentResults).toBe(1);
+    platform.teardown();
+    world.teardown();
+  });
+
+  it("fails closed for availability, permission, invalid input, and cancellation", async () => {
+    const { world, platform } = boot("native:failures");
+    const surface = "@elizaos/capacitor-messages:native-bridge:elizamessages";
+    platform.setAvailable(surface, false);
+    await expect(
+      platform.invoke({ surfaceId: surface, method: "send", input: {} }),
+    ).rejects.toMatchObject({ code: "platform-unavailable" });
+    platform.setAvailable(surface, true);
+    platform.setPermission(surface, "denied");
+    await expect(
+      platform.invoke({ surfaceId: surface, method: "send", input: {} }),
+    ).rejects.toMatchObject({ code: "permission-denied" });
+    platform.setPermission(surface, "granted");
+    await expect(
+      platform.invoke({ surfaceId: surface, method: "send", input: {} }),
+    ).rejects.toMatchObject({ code: "invalid-input" });
+
+    const controller = new AbortController();
+    const call = platform.invoke({
+      surfaceId: surface,
+      method: "send",
+      input: { body: "cancel me" },
+      signal: controller.signal,
+    });
+    controller.abort();
+    await expect(call).rejects.toMatchObject({ code: "aborted" });
+    expect(world.clock.pendingTimerCount).toBe(0);
+    expect(platform.readback().inFlight).toBe(0);
+    platform.teardown();
+    world.teardown();
+  });
+
+  it("records deterministic timeout and recovery attempts", async () => {
+    const surface = "@elizaos/capacitor-messages:native-bridge:elizamessages";
+    const { world, platform } = boot("native:timeout", [
+      {
+        id: "native-timeout",
+        boundary: `native.${surface}.send`,
+        steps: [{ onAttempt: 1, effect: { kind: "timeout", durationMs: 100 } }],
+      },
+    ]);
+    await expect(
+      platform.invoke({
+        surfaceId: surface,
+        method: "send",
+        input: { body: "retry me" },
+      }),
+    ).rejects.toMatchObject({ effect: { kind: "timeout" }, attempt: 1 });
+    expect(world.clock.nowIso()).toBe("2030-01-01T08:00:00.100Z");
+    expect(world.ledger.byKind("fault")).toHaveLength(1);
+    const recovered = platform.invoke({
+      surfaceId: surface,
+      method: "send",
+      input: { body: "retry me" },
+    });
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+    await world.clock.advanceBy(50);
+    await expect(recovered).resolves.toEqual({ accepted: true, count: 1 });
+    platform.teardown();
+    world.teardown();
+  });
+
+  it("restores the exact seed and clears queues, callbacks, and receipts", async () => {
+    const { world, platform } = boot("native:reset");
+    const initial = platform.readback();
+    const call = platform.invoke({
+      surfaceId: "@elizaos/capacitor-messages:native-bridge:elizamessages",
+      method: "send",
+      input: { body: "reset me" },
+      idempotencyKey: "reset-message",
+    });
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+    await world.clock.advanceBy(50);
+    await call;
+    expect(platform.readback().stateHash).not.toBe(initial.stateHash);
+    const reset = platform.reset();
+    expect(reset).toEqual(initial);
+    expect(world.ledger.all()).toEqual([]);
+    platform.teardown();
+    expect(() => platform.readback()).toThrow(/torn down/);
+    world.teardown();
+  });
+});

--- a/packages/synthetic-world/src/native-platform.ts
+++ b/packages/synthetic-world/src/native-platform.ts
@@ -1,0 +1,352 @@
+/**
+ * Provides a deterministic native-host boundary that production JavaScript
+ * bridge clients can call in keyless tests without representing simulator
+ * receipts as device certification.
+ */
+import { payloadHash } from "./canonical.ts";
+import type { JsonValue } from "./manifest.ts";
+import type { SyntheticWorld } from "./world.ts";
+
+export const NATIVE_PLATFORM_ADAPTER_VERSION =
+  "eliza.synthetic-native-platform/v1" as const;
+
+export type NativePermission = "granted" | "denied" | "prompt";
+
+export class SyntheticNativePlatformError extends Error {
+  public constructor(
+    public readonly code:
+      | "aborted"
+      | "invalid-input"
+      | "permission-denied"
+      | "platform-unavailable"
+      | "surface-unavailable",
+    message: string,
+  ) {
+    super(message);
+    this.name = "SyntheticNativePlatformError";
+  }
+}
+
+export interface NativeInvocation {
+  readonly surfaceId: string;
+  readonly method: string;
+  readonly input: JsonValue;
+  readonly idempotencyKey?: string;
+  readonly signal?: AbortSignal;
+}
+
+export interface NativeHandlerContext {
+  readonly generation: number;
+  readonly now: Date;
+  readonly permission: NativePermission;
+  readonly state: JsonValue;
+  setState(value: JsonValue): void;
+  sleep(durationMs: number): Promise<void>;
+  emit(event: string, payload: JsonValue): void;
+}
+
+export type NativeHandler = (
+  input: JsonValue,
+  context: NativeHandlerContext,
+) => JsonValue | Promise<JsonValue>;
+
+export interface NativeSurfaceDefinition {
+  readonly id: string;
+  readonly available?: boolean;
+  readonly permission?: NativePermission;
+  readonly initialState?: JsonValue;
+  readonly handlers: Readonly<Record<string, NativeHandler>>;
+}
+
+export interface NativePlatformReadback {
+  readonly schema: typeof NATIVE_PLATFORM_ADAPTER_VERSION;
+  readonly namespace: string;
+  readonly generation: number;
+  readonly stateHash: string;
+  readonly surfaces: Readonly<Record<string, JsonValue>>;
+  readonly queuedEvents: number;
+  readonly inFlight: number;
+  readonly idempotentResults: number;
+  readonly certification: "synthetic-simulator-only";
+}
+
+type EventListener = (payload: JsonValue) => void;
+
+function assertIdentifier(value: string, label: string): void {
+  if (!/^[A-Za-z0-9@._:/-]{1,256}$/.test(value)) {
+    throw new SyntheticNativePlatformError(
+      "invalid-input",
+      `${label} must be a bounded native boundary identifier`,
+    );
+  }
+}
+
+function abortError(): SyntheticNativePlatformError {
+  return new SyntheticNativePlatformError("aborted", "Native call aborted");
+}
+
+export class SyntheticNativePlatform {
+  private readonly definitions = new Map<string, NativeSurfaceDefinition>();
+  private readonly initialState = new Map<string, JsonValue>();
+  private readonly state = new Map<string, JsonValue>();
+  private readonly permissions = new Map<string, NativePermission>();
+  private readonly available = new Map<string, boolean>();
+  private readonly listeners = new Map<string, Set<EventListener>>();
+  private readonly eventQueue: Array<{
+    surfaceId: string;
+    event: string;
+    payload: JsonValue;
+  }> = [];
+  private readonly idempotentResults = new Map<string, JsonValue>();
+  private readonly inFlight = new Set<AbortController>();
+  private generation = 1;
+  private closed = false;
+
+  public constructor(
+    private readonly world: SyntheticWorld,
+    definitions: readonly NativeSurfaceDefinition[],
+  ) {
+    for (const definition of definitions) {
+      assertIdentifier(definition.id, "surface id");
+      if (this.definitions.has(definition.id)) {
+        throw new Error(`Duplicate native surface ${definition.id}`);
+      }
+      const seeded = structuredClone(definition.initialState ?? null);
+      this.definitions.set(definition.id, definition);
+      this.initialState.set(definition.id, seeded);
+      this.state.set(definition.id, structuredClone(seeded));
+      this.permissions.set(definition.id, definition.permission ?? "granted");
+      this.available.set(definition.id, definition.available ?? true);
+    }
+  }
+
+  public async invoke(invocation: NativeInvocation): Promise<JsonValue> {
+    this.assertOpen();
+    assertIdentifier(invocation.surfaceId, "surface id");
+    assertIdentifier(invocation.method, "method");
+    const definition = this.definitions.get(invocation.surfaceId);
+    if (!definition) {
+      throw new SyntheticNativePlatformError(
+        "surface-unavailable",
+        `Unknown native surface ${invocation.surfaceId}`,
+      );
+    }
+    const handler = definition.handlers[invocation.method];
+    if (invocation.signal?.aborted) throw abortError();
+
+    const idempotencyCacheKey = invocation.idempotencyKey
+      ? `${invocation.surfaceId}:${invocation.method}:${invocation.idempotencyKey}`
+      : undefined;
+    const cachedResult = idempotencyCacheKey
+      ? this.idempotentResults.get(idempotencyCacheKey)
+      : undefined;
+
+    const controller = new AbortController();
+    const onAbort = () => controller.abort();
+    invocation.signal?.addEventListener("abort", onAbort, { once: true });
+    this.inFlight.add(controller);
+    const boundary = `native.${invocation.surfaceId}.${invocation.method}`;
+    try {
+      const result = await this.world.executeBoundary(boundary, {
+        input: invocation.input,
+        idempotencyKey: invocation.idempotencyKey,
+        execute: async () => {
+          if (controller.signal.aborted) throw abortError();
+          if (!this.available.get(invocation.surfaceId)) {
+            throw new SyntheticNativePlatformError(
+              "platform-unavailable",
+              `Native surface ${invocation.surfaceId} is unavailable`,
+            );
+          }
+          if (this.permissions.get(invocation.surfaceId) === "denied") {
+            throw new SyntheticNativePlatformError(
+              "permission-denied",
+              `Permission denied for native surface ${invocation.surfaceId}`,
+            );
+          }
+          if (!handler) {
+            throw new SyntheticNativePlatformError(
+              "invalid-input",
+              `Unknown method ${invocation.method} on ${invocation.surfaceId}`,
+            );
+          }
+          if (cachedResult !== undefined) return structuredClone(cachedResult);
+          return handler(structuredClone(invocation.input), {
+            generation: this.generation,
+            now: this.world.clock.now(),
+            permission: this.permissions.get(invocation.surfaceId) ?? "prompt",
+            state: structuredClone(
+              this.state.get(invocation.surfaceId) ?? null,
+            ),
+            setState: (value) => {
+              if (controller.signal.aborted) throw abortError();
+              this.state.set(invocation.surfaceId, structuredClone(value));
+            },
+            sleep: (durationMs) => this.sleep(durationMs, controller.signal),
+            emit: (event, payload) => {
+              assertIdentifier(event, "event");
+              if (controller.signal.aborted) throw abortError();
+              this.eventQueue.push({
+                surfaceId: invocation.surfaceId,
+                event,
+                payload: structuredClone(payload),
+              });
+            },
+          });
+        },
+        authoritativeReadback: () => this.readback() as unknown as JsonValue,
+      });
+      if (idempotencyCacheKey && cachedResult === undefined) {
+        this.idempotentResults.set(
+          idempotencyCacheKey,
+          structuredClone(result),
+        );
+      }
+      return structuredClone(result);
+    } finally {
+      invocation.signal?.removeEventListener("abort", onAbort);
+      this.inFlight.delete(controller);
+    }
+  }
+
+  public subscribe(
+    surfaceId: string,
+    event: string,
+    listener: EventListener,
+  ): () => void {
+    this.assertOpen();
+    assertIdentifier(surfaceId, "surface id");
+    assertIdentifier(event, "event");
+    const key = `${surfaceId}:${event}`;
+    const group = this.listeners.get(key) ?? new Set<EventListener>();
+    group.add(listener);
+    this.listeners.set(key, group);
+    return () => group.delete(listener);
+  }
+
+  public flushEvents(): number {
+    this.assertOpen();
+    let delivered = 0;
+    for (const queued of this.eventQueue.splice(0)) {
+      for (const listener of this.listeners.get(
+        `${queued.surfaceId}:${queued.event}`,
+      ) ?? []) {
+        listener(structuredClone(queued.payload));
+        delivered += 1;
+      }
+      this.world.ledger.append({
+        kind: "notification",
+        status: "observed",
+        target: `native.${queued.surfaceId}.event.${queued.event}`,
+        attempt: 1,
+        output: queued.payload,
+        payloadHash: payloadHash(queued.payload),
+      });
+    }
+    return delivered;
+  }
+
+  public setPermission(surfaceId: string, permission: NativePermission): void {
+    this.assertKnown(surfaceId);
+    this.permissions.set(surfaceId, permission);
+  }
+
+  public setAvailable(surfaceId: string, available: boolean): void {
+    this.assertKnown(surfaceId);
+    this.available.set(surfaceId, available);
+  }
+
+  public restart(): NativePlatformReadback {
+    this.assertOpen();
+    for (const controller of this.inFlight) controller.abort();
+    this.inFlight.clear();
+    this.eventQueue.length = 0;
+    this.listeners.clear();
+    this.generation += 1;
+    return this.readback();
+  }
+
+  public reset(): NativePlatformReadback {
+    this.assertOpen();
+    for (const controller of this.inFlight) controller.abort();
+    this.inFlight.clear();
+    this.eventQueue.length = 0;
+    this.listeners.clear();
+    this.idempotentResults.clear();
+    this.generation = 1;
+    for (const [surfaceId, value] of this.initialState) {
+      this.state.set(surfaceId, structuredClone(value));
+      const definition = this.definitions.get(surfaceId);
+      this.permissions.set(surfaceId, definition?.permission ?? "granted");
+      this.available.set(surfaceId, definition?.available ?? true);
+    }
+    this.world.reset();
+    return this.readback();
+  }
+
+  public readback(): NativePlatformReadback {
+    this.assertOpen();
+    const surfaces = Object.fromEntries(
+      [...this.state.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([id, value]) => [id, structuredClone(value)]),
+    );
+    return {
+      schema: NATIVE_PLATFORM_ADAPTER_VERSION,
+      namespace: this.world.namespace,
+      generation: this.generation,
+      stateHash: payloadHash(surfaces as JsonValue),
+      surfaces,
+      queuedEvents: this.eventQueue.length,
+      inFlight: this.inFlight.size,
+      idempotentResults: this.idempotentResults.size,
+      certification: "synthetic-simulator-only",
+    };
+  }
+
+  public teardown(): void {
+    if (this.closed) return;
+    for (const controller of this.inFlight) controller.abort();
+    this.inFlight.clear();
+    this.eventQueue.length = 0;
+    this.listeners.clear();
+    this.idempotentResults.clear();
+    this.state.clear();
+    this.closed = true;
+  }
+
+  private sleep(durationMs: number, signal: AbortSignal): Promise<void> {
+    if (!Number.isFinite(durationMs) || durationMs < 0) {
+      throw new SyntheticNativePlatformError(
+        "invalid-input",
+        "Native delay must be a non-negative finite number",
+      );
+    }
+    if (signal.aborted) return Promise.reject(abortError());
+    return new Promise((resolve, reject) => {
+      const timerId = this.world.clock.setTimeout(() => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, durationMs);
+      const onAbort = () => {
+        this.world.clock.clearTimeout(timerId);
+        reject(abortError());
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+
+  private assertKnown(surfaceId: string): void {
+    this.assertOpen();
+    if (!this.definitions.has(surfaceId)) {
+      throw new SyntheticNativePlatformError(
+        "surface-unavailable",
+        `Unknown native surface ${surfaceId}`,
+      );
+    }
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw new Error("Synthetic native platform is torn down");
+  }
+}

--- a/packages/synthetic-world/src/overlay.ts
+++ b/packages/synthetic-world/src/overlay.ts
@@ -1,0 +1,51 @@
+/**
+ * Applies declarative scenario overlays by merging entity collections on their
+ * stable IDs while leaving the base manifest immutable.
+ */
+import {
+  type JsonValue,
+  parseWorldManifest,
+  type WorldData,
+  type WorldManifest,
+} from "./manifest.ts";
+
+export interface WorldOverlay {
+  readonly seed?: string;
+  readonly clock?: Partial<WorldManifest["clock"]>;
+  readonly data?: Partial<WorldData>;
+  readonly faults?: WorldManifest["faults"];
+}
+
+function isEntityArray(value: unknown): value is Array<{ id: string }> {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (item) => typeof item === "object" && item !== null && "id" in item,
+    )
+  );
+}
+
+export function applyWorldOverlay(
+  baseInput: WorldManifest,
+  overlay: WorldOverlay,
+): WorldManifest {
+  const base = structuredClone(baseInput);
+  const data = structuredClone(base.data) as Record<string, JsonValue>;
+  for (const [key, overlayValue] of Object.entries(overlay.data ?? {})) {
+    const baseValue = data[key];
+    if (isEntityArray(baseValue) && isEntityArray(overlayValue)) {
+      const merged = new Map(baseValue.map((entity) => [entity.id, entity]));
+      for (const entity of overlayValue) merged.set(entity.id, entity);
+      data[key] = [...merged.values()] as JsonValue;
+    } else {
+      data[key] = structuredClone(overlayValue) as JsonValue;
+    }
+  }
+  return parseWorldManifest({
+    ...base,
+    seed: overlay.seed ?? base.seed,
+    clock: { ...base.clock, ...overlay.clock },
+    data,
+    faults: overlay.faults ?? base.faults,
+  });
+}

--- a/packages/synthetic-world/src/test-fixture.ts
+++ b/packages/synthetic-world/src/test-fixture.ts
@@ -1,0 +1,230 @@
+/**
+ * Supplies one realistic, entirely synthetic manifest for package contract
+ * tests without weakening production fixture validation.
+ */
+import {
+  SYNTHETIC_WORLD_SCHEMA_VERSION,
+  type WorldManifest,
+} from "./manifest.ts";
+
+export function testManifest(): WorldManifest {
+  return {
+    schemaVersion: SYNTHETIC_WORLD_SCHEMA_VERSION,
+    worldId: "mail-reminder",
+    seed: "mail-reminder-v1",
+    clock: {
+      epoch: "2030-01-01T08:00:00.000Z",
+      timezone: "America/Los_Angeles",
+    },
+    fixturePolicy: {
+      allowedEmailDomains: ["example.com", "example.invalid"],
+      allowedUrlHosts: [
+        "example.com",
+        "example.invalid",
+        "localhost",
+        "127.0.0.1",
+      ],
+    },
+    data: {
+      identities: [
+        {
+          id: "person-owner",
+          kind: "person",
+          displayName: "Avery Example",
+          email: "avery@example.com",
+          phone: "+1-555-0100",
+        },
+        {
+          id: "person-peer",
+          kind: "person",
+          displayName: "Morgan Example",
+          email: "morgan@example.invalid",
+        },
+      ],
+      organizations: [
+        {
+          id: "org-example",
+          name: "Example Org",
+          memberIdentityIds: ["person-owner", "person-peer"],
+        },
+      ],
+      agents: [
+        {
+          id: "agent-helper",
+          name: "Helper",
+          ownerIdentityId: "person-owner",
+          organizationId: "org-example",
+        },
+      ],
+      rooms: [
+        {
+          id: "room-direct",
+          kind: "direct",
+          participantIdentityIds: ["person-owner", "person-peer"],
+        },
+      ],
+      threads: [
+        {
+          id: "thread-reminder",
+          roomId: "room-direct",
+          title: "Reminder request",
+          participantIdentityIds: ["person-owner", "person-peer"],
+        },
+      ],
+      messages: [
+        {
+          id: "message-one",
+          roomId: "room-direct",
+          senderIdentityId: "person-peer",
+          body: "Please remind me tomorrow.",
+          sentAt: "2030-01-01T08:00:00.000Z",
+          threadId: "thread-reminder",
+        },
+      ],
+      connectorAccounts: [],
+      grants: [],
+      calendars: [
+        {
+          id: "calendar-main",
+          ownerIdentityId: "person-owner",
+          name: "Main",
+          timezone: "America/Los_Angeles",
+        },
+      ],
+      calendarEvents: [
+        {
+          id: "event-one",
+          calendarId: "calendar-main",
+          title: "Planning",
+          startsAt: "2030-01-02T18:00:00.000Z",
+          endsAt: "2030-01-02T19:00:00.000Z",
+          attendeeIdentityIds: ["person-owner", "person-peer"],
+        },
+      ],
+      tasks: [
+        {
+          id: "task-one",
+          ownerIdentityId: "person-owner",
+          title: "Reply",
+          status: "pending",
+          dueAt: "2030-01-02T08:00:00.000Z",
+        },
+      ],
+      reminders: [
+        {
+          id: "reminder-one",
+          taskId: "task-one",
+          ownerIdentityId: "person-owner",
+          message: "Reply",
+          fireAt: "2030-01-02T08:00:00.000Z",
+          status: "scheduled",
+        },
+      ],
+      contacts: [
+        {
+          id: "contact-peer",
+          ownerIdentityId: "person-owner",
+          identityId: "person-peer",
+          tags: ["work"],
+        },
+      ],
+      relationships: [
+        {
+          id: "relationship-peer",
+          fromIdentityId: "person-owner",
+          toIdentityId: "person-peer",
+          kind: "colleague",
+        },
+      ],
+      memories: [
+        {
+          id: "memory-one",
+          agentId: "agent-helper",
+          ownerIdentityId: "person-owner",
+          roomId: "room-direct",
+          content: { text: "Morgan prefers mornings" },
+          createdAt: "2030-01-01T08:00:00.000Z",
+        },
+      ],
+      approvals: [
+        {
+          id: "approval-one",
+          requesterIdentityId: "person-owner",
+          approverIdentityId: "person-peer",
+          action: "send-payment",
+          status: "pending",
+          requestedAt: "2030-01-01T08:00:00.000Z",
+        },
+      ],
+      outbox: [
+        {
+          id: "outbox-one",
+          target: "mail.send",
+          payload: { messageId: "message-one" },
+          status: "pending",
+          idempotencyKey: "synthetic-outbox-one",
+          attempts: 0,
+          availableAt: "2030-01-01T08:00:00.000Z",
+        },
+      ],
+      notifications: [
+        {
+          id: "notification-one",
+          recipientIdentityId: "person-owner",
+          channel: "push",
+          body: "Reply due",
+          status: "queued",
+          deliverAt: "2030-01-02T08:00:00.000Z",
+        },
+      ],
+      media: [
+        {
+          id: "media-one",
+          sha256:
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          mimeType: "text/plain",
+          byteLength: 7,
+          url: "https://example.invalid/media/one",
+        },
+      ],
+      billingAccounts: [
+        {
+          id: "billing-one",
+          ownerIdentityId: "person-owner",
+          currency: "USD",
+          balanceMinor: 5000,
+        },
+      ],
+      billingTransactions: [
+        {
+          id: "transaction-one",
+          accountId: "billing-one",
+          amountMinor: -100,
+          currency: "USD",
+          kind: "purchase",
+          occurredAt: "2030-01-01T08:00:00.000Z",
+        },
+      ],
+      providerState: [
+        {
+          id: "provider-mail",
+          provider: "mail",
+          state: { cursor: "synthetic-cursor" },
+        },
+      ],
+      backgroundJobs: [
+        {
+          id: "job-one",
+          queue: "notifications",
+          kind: "deliver",
+          status: "queued",
+          runAt: "2030-01-02T08:00:00.000Z",
+          attempts: 0,
+          payload: { notificationId: "notification-one" },
+        },
+      ],
+      extensions: {},
+    },
+    faults: [],
+  };
+}

--- a/packages/synthetic-world/src/world.test.ts
+++ b/packages/synthetic-world/src/world.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Verifies deterministic world lifecycle, typed evidence, named fault behavior,
+ * authoritative readback, reset equivalence, and namespace isolation.
+ */
+import { describe, expect, it } from "vitest";
+import { bootInProcessWorld } from "./adapters.ts";
+import { SyntheticFaultError } from "./faults.ts";
+import type { FaultEffect } from "./manifest.ts";
+import { NamespaceInUseError } from "./namespace.ts";
+import { testManifest } from "./test-fixture.ts";
+
+describe("SyntheticWorld", () => {
+  it("restores snapshots and reset state while clearing every observation", () => {
+    const world = bootInProcessWorld(testManifest(), {
+      namespace: "world:lifecycle:one",
+    });
+    const initialHash = world.stateHash;
+    const initialRandom = world.random.next();
+    const snapshot = world.snapshot();
+    world.updateData((data) => {
+      data.tasks[0].status = "completed";
+    });
+    expect(world.stateHash).not.toBe(initialHash);
+    expect(world.ledger.byKind("state-transition")).toHaveLength(1);
+    world.restore(snapshot);
+    expect(world.stateHash).toBe(initialHash);
+    expect(world.ledger.all()).toHaveLength(0);
+    expect(world.random.next()).toBe(initialRandom);
+    world.updateData((data) => {
+      data.notifications[0].status = "delivered";
+    });
+    world.reset();
+    expect(world.stateHash).toBe(initialHash);
+    expect(world.ledger.all()).toHaveLength(0);
+    world.teardown();
+  });
+
+  it("rejects namespace sharing until teardown releases the lease", () => {
+    const first = bootInProcessWorld(testManifest(), {
+      namespace: "world:isolation:one",
+    });
+    expect(() =>
+      bootInProcessWorld(testManifest(), { namespace: "world:isolation:one" }),
+    ).toThrow(NamespaceInUseError);
+    const second = bootInProcessWorld(testManifest(), {
+      namespace: "world:isolation:two",
+    });
+    second.updateData((data) => {
+      data.tasks[0].status = "completed";
+    });
+    expect(first.data.tasks[0].status).toBe("pending");
+    first.teardown();
+    const replacement = bootInProcessWorld(testManifest(), {
+      namespace: "world:isolation:one",
+    });
+    replacement.teardown();
+    second.teardown();
+  });
+
+  it("records request, response, idempotency, transition, and authoritative readback evidence", async () => {
+    const world = bootInProcessWorld(testManifest(), {
+      namespace: "world:ledger:one",
+    });
+    const output = await world.executeBoundary("mail.send", {
+      input: { to: "morgan@example.invalid", body: "Hello" },
+      idempotencyKey: "synthetic-send-one",
+      execute: () => ({ accepted: true }),
+      authoritativeReadback: () => ({ delivered: true }),
+    });
+    expect(output).toEqual({ accepted: true });
+    expect(world.ledger.byKind("request")[0]).toMatchObject({
+      target: "mail.send",
+      attempt: 1,
+      idempotencyKey: "synthetic-send-one",
+    });
+    expect(world.ledger.byKind("response")[0]).toMatchObject({
+      output: { accepted: true },
+      authoritativeReadback: { delivered: true },
+    });
+    expect(world.ledger.byKind("readback")).toHaveLength(1);
+    world.teardown();
+  });
+
+  it("keeps nested ledger evidence immutable across append and read boundaries", () => {
+    const world = bootInProcessWorld(testManifest(), {
+      namespace: "world:ledger:immutability",
+    });
+    const input = { nested: { value: "original" } };
+    const appended = world.ledger.append({
+      kind: "model",
+      status: "observed",
+      target: "model.generate",
+      input,
+      payloadHash: "synthetic-hash",
+      attempt: 1,
+    });
+    input.nested.value = "mutated-after-append";
+    if (
+      appended.input &&
+      !Array.isArray(appended.input) &&
+      typeof appended.input === "object"
+    ) {
+      const nested = appended.input.nested;
+      if (nested && !Array.isArray(nested) && typeof nested === "object")
+        nested.value = "mutated-return";
+    }
+    const firstRead = world.ledger.byKind("model");
+    expect(firstRead[0].input).toEqual({ nested: { value: "original" } });
+    const readInput = firstRead[0].input;
+    if (
+      readInput &&
+      !Array.isArray(readInput) &&
+      typeof readInput === "object"
+    ) {
+      const nested = readInput.nested;
+      if (nested && !Array.isArray(nested) && typeof nested === "object")
+        nested.value = "mutated-read";
+    }
+    expect(world.ledger.byKind("model")[0].input).toEqual({
+      nested: { value: "original" },
+    });
+    world.teardown();
+  });
+
+  it("defines restore as state-and-clock restoration with execution progression reset", async () => {
+    const manifest = testManifest();
+    manifest.faults = [
+      {
+        id: "fault-reset-proof",
+        boundary: "reset-proof",
+        steps: [{ onAttempt: 1, effect: { kind: "disconnect" } }],
+      },
+    ];
+    const world = bootInProcessWorld(manifest, {
+      namespace: "world:restore:semantics",
+    });
+    const snapshot = world.snapshot();
+    expect(snapshot.semantics).toBe("state-and-clock-reset-execution");
+    await expect(
+      world.executeBoundary("reset-proof", {
+        input: {},
+        execute: () => ({ ok: true }),
+      }),
+    ).rejects.toBeInstanceOf(SyntheticFaultError);
+    await expect(
+      world.executeBoundary("reset-proof", {
+        input: {},
+        execute: () => ({ ok: true }),
+      }),
+    ).resolves.toEqual({ ok: true });
+    world.clock.setTimeout(() => undefined, 10);
+    world.restore(snapshot);
+    expect(world.clock.pendingTimerCount).toBe(0);
+    await expect(
+      world.executeBoundary("reset-proof", {
+        input: {},
+        execute: () => ({ ok: true }),
+      }),
+    ).rejects.toBeInstanceOf(SyntheticFaultError);
+    world.teardown();
+  });
+
+  it.each([
+    { kind: "timeout", durationMs: 50 },
+    { kind: "disconnect" },
+    { kind: "authExpired" },
+    { kind: "rateLimit", retryAfterMs: 100 },
+    { kind: "retry", retryAfterMs: 10 },
+  ] satisfies FaultEffect[])(
+    "injects and records $kind failures",
+    async (effect) => {
+      const manifest = testManifest();
+      manifest.faults = [
+        {
+          id: `fault-${effect.kind}`,
+          boundary: "provider.call",
+          steps: [{ onAttempt: 1, effect }],
+        },
+      ];
+      const world = bootInProcessWorld(manifest, {
+        namespace: `world:fault:${effect.kind}`,
+      });
+      await expect(
+        world.executeBoundary("provider.call", {
+          input: {},
+          execute: () => ({ ok: true }),
+        }),
+      ).rejects.toBeInstanceOf(SyntheticFaultError);
+      expect(world.ledger.byKind("fault")).toHaveLength(1);
+      expect(world.ledger.all().at(-1)?.status).toBe("failed");
+      world.teardown();
+    },
+  );
+
+  it("supports latency, malformed, partial, ambiguous commit, and recovery", async () => {
+    const manifest = testManifest();
+    manifest.faults = [
+      {
+        id: "fault-latency",
+        boundary: "latency",
+        steps: [{ onAttempt: 1, effect: { kind: "latency", durationMs: 25 } }],
+      },
+      {
+        id: "fault-malformed",
+        boundary: "malformed",
+        steps: [
+          {
+            onAttempt: 1,
+            effect: { kind: "malformedData", value: { broken: true } },
+          },
+        ],
+      },
+      {
+        id: "fault-partial",
+        boundary: "partial",
+        steps: [
+          {
+            onAttempt: 1,
+            effect: { kind: "partialResponse", omitFields: ["secret"] },
+          },
+        ],
+      },
+      {
+        id: "fault-ambiguous",
+        boundary: "ambiguous",
+        steps: [{ onAttempt: 1, effect: { kind: "ambiguousCommit" } }],
+      },
+      {
+        id: "fault-recovery",
+        boundary: "recovery",
+        steps: [{ onAttempt: 1, effect: { kind: "recovery" } }],
+      },
+    ];
+    const world = bootInProcessWorld(manifest, {
+      namespace: "world:fault:matrix",
+    });
+    await expect(
+      world.executeBoundary("latency", {
+        input: {},
+        execute: () => ({ ok: true }),
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(world.clock.nowIso()).toBe("2030-01-01T08:00:00.025Z");
+    await expect(
+      world.executeBoundary("malformed", {
+        input: {},
+        execute: () => ({ ok: true }),
+      }),
+    ).resolves.toEqual({ broken: true });
+    await expect(
+      world.executeBoundary("partial", {
+        input: {},
+        execute: () => ({ ok: true, secret: "remove" }),
+      }),
+    ).resolves.toEqual({ ok: true });
+    let committed = false;
+    await expect(
+      world.executeBoundary("ambiguous", {
+        input: {},
+        execute: () => {
+          committed = true;
+          return { ok: true };
+        },
+      }),
+    ).rejects.toBeInstanceOf(SyntheticFaultError);
+    expect(committed).toBe(true);
+    await expect(
+      world.executeBoundary("recovery", {
+        input: {},
+        execute: () => ({ ok: true }),
+      }),
+    ).resolves.toEqual({ ok: true });
+    world.teardown();
+  });
+});

--- a/packages/synthetic-world/src/world.test.ts
+++ b/packages/synthetic-world/src/world.test.ts
@@ -35,6 +35,57 @@ describe("SyntheticWorld", () => {
     world.teardown();
   });
 
+  it("distinguishes execution progression while preserving the data-only hash", async () => {
+    const manifest = testManifest();
+    manifest.faults = [
+      {
+        id: "execution-hash-fault",
+        boundary: "execution.hash",
+        steps: [{ onAttempt: 1, effect: { kind: "disconnect" } }],
+      },
+    ];
+    const world = bootInProcessWorld(manifest, {
+      namespace: "world:execution-hash",
+    });
+    const stateHash = world.stateHash;
+    const initial = world.executionStateHash;
+    const expectProgression = () => {
+      expect(world.stateHash).toBe(stateHash);
+      expect(world.executionStateHash).not.toBe(initial);
+      world.reset();
+      expect(world.executionStateHash).toBe(initial);
+    };
+
+    await world.clock.advanceBy(1);
+    expectProgression();
+    world.clock.setTimeout(() => undefined, 10);
+    expectProgression();
+    world.random.next();
+    expectProgression();
+    await expect(
+      world.executeBoundary("execution.hash", {
+        input: {},
+        execute: () => ({ ok: true }),
+      }),
+    ).rejects.toBeInstanceOf(SyntheticFaultError);
+    world.ledger.clear();
+    expectProgression();
+    world.ledger.append({
+      kind: "model",
+      status: "observed",
+      target: "fixture.best-case.consume",
+      attempt: 1,
+      payloadHash: "fixture-one",
+      metadata: { fixtureIndex: 1 },
+    });
+    expectProgression();
+
+    const snapshot = world.executionSnapshot();
+    expect(snapshot.clock.timers).toEqual([]);
+    expect(snapshot.ledger.policy.excludedTargets).toEqual(["world.boot"]);
+    world.teardown();
+  });
+
   it("rejects namespace sharing until teardown releases the lease", () => {
     const first = bootInProcessWorld(testManifest(), {
       namespace: "world:isolation:one",

--- a/packages/synthetic-world/src/world.ts
+++ b/packages/synthetic-world/src/world.ts
@@ -31,6 +31,19 @@ export interface WorldStateSnapshot {
 
 export type WorldSnapshot = WorldStateSnapshot;
 
+export interface WorldExecutionSnapshot {
+  readonly schemaVersion: WorldManifest["schemaVersion"];
+  readonly worldId: string;
+  readonly manifestHash: string;
+  readonly namespace: string;
+  readonly stateHash: string;
+  readonly data: WorldData;
+  readonly clock: ReturnType<VirtualClock["snapshot"]>;
+  readonly random: ReturnType<DeterministicRandom["snapshot"]>;
+  readonly faults: ReturnType<FaultController["snapshot"]>;
+  readonly ledger: ReturnType<ObservationLedger["snapshot"]>;
+}
+
 export interface BoundaryExecutionOptions<T extends JsonValue> {
   readonly input: JsonValue;
   readonly idempotencyKey?: string;
@@ -91,6 +104,26 @@ export class SyntheticWorld {
 
   public get stateHash(): string {
     return payloadHash(this.currentData as unknown as JsonValue);
+  }
+
+  public executionSnapshot(): WorldExecutionSnapshot {
+    this.assertOpen();
+    return {
+      schemaVersion: this.initialManifest.schemaVersion,
+      worldId: this.initialManifest.worldId,
+      manifestHash: payloadHash(this.initialManifest as unknown as JsonValue),
+      namespace: this.namespace,
+      stateHash: this.stateHash,
+      data: this.data,
+      clock: this.clock.snapshot(),
+      random: this.random.snapshot(),
+      faults: this.faults.snapshot(),
+      ledger: this.ledger.snapshot(),
+    };
+  }
+
+  public get executionStateHash(): string {
+    return payloadHash(this.executionSnapshot() as unknown as JsonValue);
   }
 
   public snapshot(): WorldStateSnapshot {

--- a/packages/synthetic-world/src/world.ts
+++ b/packages/synthetic-world/src/world.ts
@@ -1,0 +1,298 @@
+/**
+ * Owns one isolated synthetic world's deterministic lifecycle while delegating
+ * scheduling, persistence, queues, and provider behavior to injected systems.
+ */
+import { DeterministicRandom, payloadHash } from "./canonical.ts";
+import { VirtualClock } from "./clock.ts";
+import { FaultController, SyntheticFaultError } from "./faults.ts";
+import { ObservationLedger } from "./ledger.ts";
+import {
+  type FaultEffect,
+  type JsonValue,
+  parseWorldManifest,
+  type WorldData,
+  type WorldManifest,
+} from "./manifest.ts";
+import { acquireNamespace, type NamespaceLease } from "./namespace.ts";
+
+export interface WorldStateSnapshot {
+  /**
+   * Restoring state resets timers, fault attempts, and the seeded random stream;
+   * production schedulers rehydrate their callbacks from the restored data.
+   */
+  readonly semantics: "state-and-clock-reset-execution";
+  readonly schemaVersion: WorldManifest["schemaVersion"];
+  readonly worldId: string;
+  readonly seed: string;
+  readonly capturedAt: string;
+  readonly data: WorldData;
+  readonly stateHash: string;
+}
+
+export type WorldSnapshot = WorldStateSnapshot;
+
+export interface BoundaryExecutionOptions<T extends JsonValue> {
+  readonly input: JsonValue;
+  readonly idempotencyKey?: string;
+  readonly execute: () => Promise<T> | T;
+  readonly authoritativeReadback?: () => Promise<JsonValue> | JsonValue;
+}
+
+function omitFields(value: JsonValue, fields: readonly string[]): JsonValue {
+  if (value === null || Array.isArray(value) || typeof value !== "object")
+    return value;
+  const copy = structuredClone(value);
+  for (const field of fields) delete copy[field];
+  return copy;
+}
+
+export class SyntheticWorld {
+  public readonly clock: VirtualClock;
+  public readonly ledger: ObservationLedger;
+  public random: DeterministicRandom;
+
+  private readonly lease: NamespaceLease;
+  private readonly initialManifest: WorldManifest;
+  private faults: FaultController;
+  private currentData: WorldData;
+  private closed = false;
+
+  public constructor(
+    manifestInput: WorldManifest,
+    public readonly namespace: string,
+  ) {
+    this.initialManifest = parseWorldManifest(manifestInput);
+    this.lease = acquireNamespace(namespace);
+    this.currentData = structuredClone(this.initialManifest.data);
+    this.clock = new VirtualClock(
+      this.initialManifest.clock.epoch,
+      this.initialManifest.clock.timezone,
+    );
+    this.ledger = new ObservationLedger(namespace, () => this.clock.nowIso());
+    this.random = new DeterministicRandom(this.initialManifest.seed);
+    this.faults = new FaultController(this.initialManifest.faults);
+    this.ledger.append({
+      kind: "lifecycle",
+      status: "observed",
+      target: "world.boot",
+      attempt: 1,
+      payloadHash: this.stateHash,
+    });
+  }
+
+  public get manifest(): WorldManifest {
+    return structuredClone({ ...this.initialManifest, data: this.currentData });
+  }
+
+  public get data(): WorldData {
+    this.assertOpen();
+    return structuredClone(this.currentData);
+  }
+
+  public get stateHash(): string {
+    return payloadHash(this.currentData as unknown as JsonValue);
+  }
+
+  public snapshot(): WorldStateSnapshot {
+    this.assertOpen();
+    return {
+      semantics: "state-and-clock-reset-execution",
+      schemaVersion: this.initialManifest.schemaVersion,
+      worldId: this.initialManifest.worldId,
+      seed: this.initialManifest.seed,
+      capturedAt: this.clock.nowIso(),
+      data: this.data,
+      stateHash: this.stateHash,
+    };
+  }
+
+  public updateData(update: (draft: WorldData) => void): string {
+    this.assertOpen();
+    const before = this.currentData as unknown as JsonValue;
+    const draft = structuredClone(this.currentData);
+    update(draft);
+    this.currentData = parseWorldManifest({
+      ...this.initialManifest,
+      data: draft,
+    }).data;
+    this.ledger.append({
+      kind: "state-transition",
+      status: "committed",
+      target: "world.data",
+      attempt: 1,
+      payloadHash: this.stateHash,
+      stateTransition: {
+        from: before,
+        to: this.currentData as unknown as JsonValue,
+      },
+    });
+    return this.stateHash;
+  }
+
+  public reset(): void {
+    this.assertOpen();
+    this.currentData = structuredClone(this.initialManifest.data);
+    this.clock.reset(this.initialManifest.clock.epoch);
+    this.random = new DeterministicRandom(this.initialManifest.seed);
+    this.faults.reset();
+    this.ledger.clear();
+  }
+
+  public restore(snapshot: WorldStateSnapshot): void {
+    this.assertOpen();
+    if (
+      snapshot.semantics !== "state-and-clock-reset-execution" ||
+      snapshot.schemaVersion !== this.initialManifest.schemaVersion ||
+      snapshot.worldId !== this.initialManifest.worldId ||
+      snapshot.seed !== this.initialManifest.seed
+    ) {
+      throw new Error("Snapshot does not belong to this synthetic world");
+    }
+    const data = parseWorldManifest({
+      ...this.initialManifest,
+      data: snapshot.data,
+    }).data;
+    const restoredHash = payloadHash(data as unknown as JsonValue);
+    if (restoredHash !== snapshot.stateHash)
+      throw new Error("Snapshot state hash does not match its data");
+    this.currentData = data;
+    this.clock.reset(snapshot.capturedAt);
+    this.random = new DeterministicRandom(this.initialManifest.seed);
+    this.faults.reset();
+    this.ledger.clear();
+  }
+
+  public async executeBoundary<T extends JsonValue>(
+    boundary: string,
+    options: BoundaryExecutionOptions<T>,
+  ): Promise<T> {
+    this.assertOpen();
+    const { attempt, effect } = this.faults.next(boundary);
+    const hash = payloadHash(options.input);
+    this.ledger.append({
+      kind: "request",
+      status: "started",
+      target: boundary,
+      input: options.input,
+      payloadHash: hash,
+      idempotencyKey: options.idempotencyKey,
+      attempt,
+    });
+    if (effect) {
+      this.ledger.append({
+        kind: "fault",
+        status: "observed",
+        target: boundary,
+        input: effect as unknown as JsonValue,
+        payloadHash: payloadHash(effect as unknown as JsonValue),
+        idempotencyKey: options.idempotencyKey,
+        attempt,
+      });
+    }
+
+    try {
+      const early = await this.applyPreExecutionFault(
+        boundary,
+        attempt,
+        effect,
+      );
+      if (early !== undefined) {
+        this.ledger.append({
+          kind: "response",
+          status: "succeeded",
+          target: boundary,
+          output: early,
+          payloadHash: hash,
+          idempotencyKey: options.idempotencyKey,
+          attempt,
+        });
+        return early as T;
+      }
+      const output = await options.execute();
+      const transformed =
+        effect?.kind === "partialResponse"
+          ? omitFields(output, effect.omitFields)
+          : output;
+      const readback = options.authoritativeReadback
+        ? await options.authoritativeReadback()
+        : undefined;
+      this.ledger.append({
+        kind: "response",
+        status: "succeeded",
+        target: boundary,
+        output: transformed,
+        payloadHash: hash,
+        idempotencyKey: options.idempotencyKey,
+        attempt,
+        authoritativeReadback: readback,
+      });
+      if (readback !== undefined) {
+        this.ledger.append({
+          kind: "readback",
+          status: "observed",
+          target: boundary,
+          output: readback,
+          payloadHash: payloadHash(readback),
+          idempotencyKey: options.idempotencyKey,
+          attempt,
+        });
+      }
+      if (effect?.kind === "ambiguousCommit")
+        throw new SyntheticFaultError(boundary, attempt, effect);
+      return transformed as T;
+    } catch (error) {
+      // error-policy:J2 Boundary failures retain their typed cause for the caller.
+      this.ledger.append({
+        kind:
+          effect?.kind === "retry" || effect?.kind === "rateLimit"
+            ? "retry"
+            : "response",
+        status: "failed",
+        target: boundary,
+        output: {
+          error: error instanceof Error ? error.message : String(error),
+        },
+        payloadHash: hash,
+        idempotencyKey: options.idempotencyKey,
+        attempt,
+      });
+      throw error;
+    }
+  }
+
+  public teardown(): void {
+    if (this.closed) return;
+    this.clock.reset(this.initialManifest.clock.epoch);
+    this.faults.reset();
+    this.ledger.clear();
+    this.closed = true;
+    this.lease.release();
+  }
+
+  private async applyPreExecutionFault(
+    boundary: string,
+    attempt: number,
+    effect: FaultEffect | undefined,
+  ): Promise<JsonValue | undefined> {
+    if (
+      !effect ||
+      effect.kind === "recovery" ||
+      effect.kind === "partialResponse" ||
+      effect.kind === "ambiguousCommit"
+    ) {
+      return undefined;
+    }
+    if (effect.kind === "latency") {
+      await this.clock.advanceBy(effect.durationMs);
+      return undefined;
+    }
+    if (effect.kind === "timeout")
+      await this.clock.advanceBy(effect.durationMs);
+    if (effect.kind === "malformedData") return effect.value;
+    throw new SyntheticFaultError(boundary, attempt, effect);
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw new Error("Synthetic world has been torn down");
+  }
+}

--- a/packages/synthetic-world/tsconfig.json
+++ b/packages/synthetic-world/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"],
+    "typeRoots": [
+      "../../node_modules/@types",
+      "../../node_modules/.bun/node_modules/@types"
+    ]
+  },
+  "include": ["src"]
+}

--- a/packages/synthetic-world/vitest.config.ts
+++ b/packages/synthetic-world/vitest.config.ts
@@ -1,0 +1,16 @@
+/**
+ * Vitest configuration for deterministic synthetic-world contract tests.
+ */
+import { defineConfig, mergeConfig } from "vitest/config";
+import rootConfig from "../../vitest.config.ts";
+
+export default mergeConfig(
+  rootConfig,
+  defineConfig({
+    test: {
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+      exclude: ["**/node_modules/**"],
+    },
+  }),
+);

--- a/plugins/plugin-native-desktop/package.json
+++ b/plugins/plugin-native-desktop/package.json
@@ -46,6 +46,7 @@
     "format:check": "bunx @biomejs/biome format ."
   },
   "devDependencies": {
+    "@elizaos/synthetic-world": "workspace:*",
     "@capacitor/core": "^8.3.1",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "rollup": "^4.62.4",

--- a/plugins/plugin-native-desktop/src/synthetic-platform.test.ts
+++ b/plugins/plugin-native-desktop/src/synthetic-platform.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+/**
+ * Runs the production DesktopWeb permission client against the resettable
+ * synthetic native host while keeping device certification out of this lane.
+ */
+import {
+  bootInProcessWorld,
+  SYNTHETIC_WORLD_SCHEMA_VERSION,
+  SyntheticNativePlatform,
+} from "@elizaos/synthetic-world";
+import { afterEach, describe, expect, it } from "vitest";
+import type { DesktopPermissionState } from "./definitions.ts";
+import { DesktopWeb } from "./web.ts";
+
+const surfaceId = "@elizaos/capacitor-desktop:native-bridge:desktop";
+
+function harness(namespace: string) {
+  const world = bootInProcessWorld(
+    {
+      schemaVersion: SYNTHETIC_WORLD_SCHEMA_VERSION,
+      worldId: "native-desktop-permissions",
+      seed: "native-desktop-permissions-v1",
+      clock: { epoch: "2030-01-01T08:00:00.000Z", timezone: "UTC" },
+      fixturePolicy: {
+        allowedEmailDomains: ["example.invalid"],
+        allowedUrlHosts: ["example.invalid"],
+      },
+      data: {},
+      faults: [],
+    },
+    { namespace },
+  );
+  const platform = new SyntheticNativePlatform(world, [
+    {
+      id: surfaceId,
+      initialState: { permission: "granted" },
+      handlers: {
+        permissionsCheck: (input, context) => ({
+          id: (input as { id: string }).id,
+          status: (context.state as { permission: string }).permission,
+          canRequest: false,
+          lastChecked: context.now.getTime(),
+          platform: "darwin",
+        }),
+      },
+    },
+  ]);
+  const request = async (params?: unknown) =>
+    platform.invoke({
+      surfaceId,
+      method: "permissionsCheck",
+      input: (params ?? null) as never,
+    });
+  Object.defineProperty(window, "__ELIZA_ELECTROBUN_RPC__", {
+    configurable: true,
+    value: { request: { permissionsCheck: request } },
+  });
+  return { world, platform };
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(window, "__ELIZA_ELECTROBUN_RPC__");
+});
+
+describe("DesktopWeb synthetic native host", () => {
+  it("uses the production bridge client and records authoritative readback", async () => {
+    const { world, platform } = harness("native:desktop:success");
+    const client = new DesktopWeb();
+    await expect(client.checkPermission({ id: "camera" })).resolves.toEqual({
+      id: "camera",
+      status: "granted",
+      canRequest: false,
+      lastChecked: new Date("2030-01-01T08:00:00.000Z").getTime(),
+      platform: "darwin",
+    } satisfies DesktopPermissionState);
+    expect(world.ledger.byKind("request")).toHaveLength(1);
+    expect(world.ledger.byKind("readback")).toHaveLength(1);
+    expect(platform.readback().certification).toBe("synthetic-simulator-only");
+    platform.teardown();
+    world.teardown();
+  });
+
+  it("does not turn native unavailability into a successful receipt", async () => {
+    const { world, platform } = harness("native:desktop:unavailable");
+    platform.setAvailable(surfaceId, false);
+    const client = new DesktopWeb();
+    await expect(
+      client.checkPermission({ id: "camera" }),
+    ).rejects.toMatchObject({ code: "platform-unavailable" });
+    expect(world.ledger.byKind("readback")).toHaveLength(0);
+    platform.teardown();
+    world.teardown();
+  });
+});


### PR DESCRIPTION
# Relates to

Relates to #23270. Depends on the synthetic-world contract in #22898 / PR #23134 and the canonical inventory in #22897 / PR #23160.

- [x] This PR targets develop and is rebased onto origin/develop commit 9f6e368bd1 with zero conflicts.
- [x] bun install and bun run verify were run after sync; the unrelated root i18n blocker is recorded below.
- [x] A reviewer can confirm the keyless adapter behavior from the deterministic test receipts below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@a9a786e18f40491c4fc3c017f8b8d23f40d5712e:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto current origin/develop; zero conflicts.
- [x] Root verify was executed and stopped at the pre-existing check:i18n debt before package gates; exact output class is recorded below.

# Risks

Medium. This introduces test infrastructure at native protocol boundaries and exports two existing adapter constructors. Production registration still uses the same classes. Simulator readback is permanently labeled synthetic-simulator-only so it cannot be confused with device certification.

# Background

## What does this PR do?

- Pins the exact 37-row platform-deferred set from canonical inventory head 256cdd67bbd2459291e55100046fb909daa47f6d.
- Adds a versioned SyntheticNativePlatform with seeded state, availability and permission failures, cancellable virtual time, named world faults, idempotency, callback queues, restart/reset/teardown, ledger records, and authoritative readback.
- Exercises real production clients for app-core CapacitorJsc, app-core CapacitorQuickJs on Android and iOS fallback kinds, and the DesktopWeb Electrobun permission RPC.
- Corrects fixture email detection so scoped package boundary ids are not misclassified as email addresses.
- Keeps simulator evidence explicitly separate from signed iOS, Android, macOS, and Electrobun evidence.

This is a non-breaking testing feature. It is intentionally a stacked draft: the first three commits mirror PR #23134 so this branch can compile and prove the adapter before that prerequisite merges.

# Documentation changes needed?

Updated the synthetic-world README plus identical package CLAUDE.md and AGENTS.md guides.

# Testing

## Where should a reviewer start?

Start with packages/synthetic-world/src/native-platform.test.ts, then the two production-client suites in app-core and plugin-native-desktop.

## Detailed testing steps

- packages/synthetic-world: 5 files, 31 tests passed; typecheck passed; lint passed.
- plugin-native-desktop: 2 files, 8 tests passed; typecheck passed; lint passed.
- app-core focused native simulator suite: 1 file, 2 tests passed.
- guide parity: 158 tracked pairs byte-identical.
- canonical ownership comparison: scanner rows 37, checked manifest rows 37, exact diff empty.
- git diff --check passed.

# Evidence Gate

<!-- evidence-head:2af2464c14b955a48f40fb5fa0d714b0d6fffd30 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI is changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI is changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic protocol and host test infrastructure only.
<!-- evidence-row:backend-logs -->
- [x] Focused test counts and authoritative ledger/readback assertions are included in Testing.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser-visible interaction or network UI is changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, provider, model output, or agent policy behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Simulator readback proves state hash, generation, event queue, in-flight calls, idempotency receipts, and synthetic-only certification; tests assert ledger readbacks and exact reset.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text or rendered UI.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changes.

## Backend + frontend logs

Backend evidence is the deterministic Vitest transcript summarized above. Frontend logs are N/A.

## Screenshots and video walkthrough

N/A - no rendered UI.

## Audio / voice walkthrough

N/A - no audio path is changed.

## Known gaps / failures

- 34 of 37 canonical rows still lack a production-client binding in this shard. This PR proves the common adapter and covers the app-core JSC, app-core QuickJS, and desktop bridge rows; it does not claim the others complete.
- No row is promoted from platform-deferred here. Signed-device and supported-host certification remains required separately.
- Full app-core typecheck is blocked by pre-existing missing built optional workspace exports such as plugin-app-control, plugin-scheduling, capacitor-bun-runtime, and generated i18n data; focused changed-path tests pass.
- bun run verify stops at repository-wide check:i18n debt: en.json is missing 11 currently used keys and the non-English catalogs have roughly 983 to 1056 missing used keys. No changed file adds an i18n call or catalog key.
- The branch is stacked on the three exact synthetic-world commits from PR #23134. Rebase this PR after #23134 merges to remove duplicated prerequisite commits.
- Real-device screenshots, recordings, signed builds, and platform logs remain absent and are not represented as green.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@a9a786e18f40491c4fc3c017f8b8d23f40d5712e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [synthetic-world-platform]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@a9a786e18f40491c4fc3c017f8b8d23f40d5712e:packages/skills/skills/contribute-to-eliza"} -->