### PR TITLE
docs(coding-tools): state trusted shell boundary

### DIFF
--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -885,7 +885,7 @@
     {
       "id": "coding-tools",
       "name": "Coding Tools",
-      "description": "Native coding tools (FILE, SHELL, WORKTREE) running directly in the agent. AST-validated commands, mtime-gated writes, sealed workspace roots, optional per-OS process sandboxing (sandbox-exec on macOS, bwrap on Linux).",
+      "description": "Native coding tools (FILE, SHELL, WORKTREE) running directly in the agent. Commands are analyzed before trusted host execution; mtime-gated file writes and configured path roots apply to FILE, WORKTREE, and the SHELL working directory.",
       "npmName": "@elizaos/plugin-coding-tools",
       "version": "0.1.0",
       "source": "bundled",
@@ -896,7 +896,7 @@
           "required": false,
           "sensitive": false,
           "label": "Workspace roots",
-          "help": "Comma-separated absolute paths the coding tools may read/write under. Defaults to the runtime's cwd.",
+          "help": "Comma-separated absolute roots for FILE and WORKTREE paths and the SHELL working directory. SHELL commands may address paths outside these roots. Defaults to the runtime's cwd.",
           "advanced": false
         },
         "CODING_TOOLS_DENY_COMMANDS": {
@@ -927,14 +927,6 @@
           "advanced": true,
           "min": 1000,
           "unit": "ms"
-        },
-        "CODING_TOOLS_OS_SANDBOX": {
-          "type": "boolean",
-          "required": false,
-          "sensitive": false,
-          "label": "OS-level sandbox",
-          "help": "Wrap bash invocations in sandbox-exec (macOS) or bwrap (Linux) when available. AST analysis runs regardless.",
-          "advanced": true
         }
       },
       "render": {

--- a/plugins/plugin-coding-tools/AGENTS.md
+++ b/plugins/plugin-coding-tools/AGENTS.md
@@ -25,7 +25,7 @@ Adds filesystem operations, shell command execution, and git worktree management
 |---|---|---|
 | `ShellService` | `"shell"` | Core shell executor (formerly @elizaos/plugin-shell): `executeCommand()` (simple), `exec()` (PTY, background, yield, session tracking), `processAction()` session management. Lives in `src/shell/`. |
 | `ExecApprovalService` | `"exec_approval"` | Command approval gating: file-backed allowlist, routes unapproved commands through the elizaOS `ApprovalService` UI. Lives in `src/shell/approvals/`. |
-| `SandboxService` | `CODING_TOOLS_SANDBOX` | Path-blocklist policy. Validates every path before read/write. Defaults block `~/pvt`, `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.docker`, `~/.kube`, `~/.netrc`, `~/Library`, plus per-OS system paths. Optional allow-roots via `CODING_TOOLS_WORKSPACE_ROOTS`. |
+| `SandboxService` | `CODING_TOOLS_SANDBOX` | Path-blocklist policy for FILE, WORKTREE, and the SHELL working directory. Defaults block `~/pvt`, `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.docker`, `~/.kube`, `~/.netrc`, `~/Library`, plus per-OS system paths. Optional allow-roots via `CODING_TOOLS_WORKSPACE_ROOTS`; these do not confine paths referenced by a shell command. |
 | `FileStateService` | `CODING_TOOLS_FILE_STATE` | Per-(conversation, file) mtime tracking. Write/Edit check that the file was not externally modified since the last Read. |
 | `SessionCwdService` | `CODING_TOOLS_SESSION_CWD` | Per-conversation working directory. Defaults to `process.cwd()`. Read/Write/Edit resolve relative paths against it; Glob/Grep/LS/Shell use it when no explicit `path`/`cwd` is given. Worktree push/pop mutates it. |
 | `BackgroundShellService` | `CODING_TOOLS_BACKGROUND_SHELL` | Per-conversation background shell process manager. Owns stable handles, stdin writes, bounded stdout/stderr rings, SIGTERM→SIGKILL termination, and teardown reaping. |
@@ -95,7 +95,7 @@ All settings are read via `runtime.getSetting(key)` or `process.env`. None are r
 
 | Env var | Default | Description |
 |---|---|---|
-| `CODING_TOOLS_WORKSPACE_ROOTS` | `process.cwd()` | Comma-separated absolute paths the tools may access. When set, paths outside these roots are rejected. |
+| `CODING_TOOLS_WORKSPACE_ROOTS` | `process.cwd()` | Comma-separated absolute roots for FILE and WORKTREE paths and the SHELL working directory. This does not restrict paths that a SHELL command reads or writes. |
 | `CODING_TOOLS_BLOCKED_PATHS` | (built-in list) | Comma-separated absolute paths — **replaces** the configurable default blocklist; unconditional device and `/proc/<pid>/fd` exclusions remain enforced. |
 | `CODING_TOOLS_BLOCKED_PATHS_ADD` | — | Comma-separated paths to **add** to the default blocklist. |
 | `CODING_TOOLS_SHELL` | (auto-detected) | Override the shell binary used by SHELL action. Takes priority over `SHELL`. Useful on Android/AOSP where the default shell path may not be executable. |
@@ -159,6 +159,7 @@ Runtime gating env vars (read by `auto-enable.ts` and `index.ts`):
 
 - **READ/WRITE/EDIT paths may be absolute or relative.** Relative paths resolve against `SessionCwdService.getCwd(message.roomId)`; the resolved absolute path must still pass `SandboxService.validatePath`. A missing session-cwd service is an explicit failure.
 - **Always validate paths through `SandboxService.validatePath`** before any filesystem access. Never bypass this.
+- **SHELL is trusted host execution, not filesystem confinement.** `CODING_TOOLS_WORKSPACE_ROOTS` validates SHELL's `cwd` only. Commands may address paths outside those roots, so the OWNER role and deployment host/container boundary must be trusted.
 - **Read before write**: `FileStateService.assertWritable` will reject a write if the file was modified externally since the last read. The agent must re-read first.
 - **`conversationId` = `message.roomId`** (string-coerced). Missing `roomId` is a hard failure.
 - **Never throw from a handler** — return `failureToActionResult({ reason, message })` instead.

--- a/plugins/plugin-coding-tools/AGENT_CONTRACT.md
+++ b/plugins/plugin-coding-tools/AGENT_CONTRACT.md
@@ -104,6 +104,9 @@ export const myAction: Action = {
   validated through SandboxService.
 - **SHELL** — runs with `cwd` defaulting to `SessionCwdService.getCwd(...)`.
   Optional `cwd` parameter overrides; must be absolute and within roots.
+  Workspace roots validate only this working directory. SHELL is trusted host
+  execution and commands may read or write outside configured roots; do not
+  describe the path policy or command analyzer as OS filesystem confinement.
 - **WORKTREE action=enter** — call `SandboxService.addRoot` and
   `SessionCwdService.pushWorktree` so the new path is reachable.
 

--- a/plugins/plugin-coding-tools/CLAUDE.md
+++ b/plugins/plugin-coding-tools/CLAUDE.md
@@ -25,7 +25,7 @@ Adds filesystem operations, shell command execution, and git worktree management
 |---|---|---|
 | `ShellService` | `"shell"` | Core shell executor (formerly @elizaos/plugin-shell): `executeCommand()` (simple), `exec()` (PTY, background, yield, session tracking), `processAction()` session management. Lives in `src/shell/`. |
 | `ExecApprovalService` | `"exec_approval"` | Command approval gating: file-backed allowlist, routes unapproved commands through the elizaOS `ApprovalService` UI. Lives in `src/shell/approvals/`. |
-| `SandboxService` | `CODING_TOOLS_SANDBOX` | Path-blocklist policy. Validates every path before read/write. Defaults block `~/pvt`, `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.docker`, `~/.kube`, `~/.netrc`, `~/Library`, plus per-OS system paths. Optional allow-roots via `CODING_TOOLS_WORKSPACE_ROOTS`. |
+| `SandboxService` | `CODING_TOOLS_SANDBOX` | Path-blocklist policy for FILE, WORKTREE, and the SHELL working directory. Defaults block `~/pvt`, `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.docker`, `~/.kube`, `~/.netrc`, `~/Library`, plus per-OS system paths. Optional allow-roots via `CODING_TOOLS_WORKSPACE_ROOTS`; these do not confine paths referenced by a shell command. |
 | `FileStateService` | `CODING_TOOLS_FILE_STATE` | Per-(conversation, file) mtime tracking. Write/Edit check that the file was not externally modified since the last Read. |
 | `SessionCwdService` | `CODING_TOOLS_SESSION_CWD` | Per-conversation working directory. Defaults to `process.cwd()`. Read/Write/Edit resolve relative paths against it; Glob/Grep/LS/Shell use it when no explicit `path`/`cwd` is given. Worktree push/pop mutates it. |
 | `BackgroundShellService` | `CODING_TOOLS_BACKGROUND_SHELL` | Per-conversation background shell process manager. Owns stable handles, stdin writes, bounded stdout/stderr rings, SIGTERM→SIGKILL termination, and teardown reaping. |
@@ -95,7 +95,7 @@ All settings are read via `runtime.getSetting(key)` or `process.env`. None are r
 
 | Env var | Default | Description |
 |---|---|---|
-| `CODING_TOOLS_WORKSPACE_ROOTS` | `process.cwd()` | Comma-separated absolute paths the tools may access. When set, paths outside these roots are rejected. |
+| `CODING_TOOLS_WORKSPACE_ROOTS` | `process.cwd()` | Comma-separated absolute roots for FILE and WORKTREE paths and the SHELL working directory. This does not restrict paths that a SHELL command reads or writes. |
 | `CODING_TOOLS_BLOCKED_PATHS` | (built-in list) | Comma-separated absolute paths — **replaces** the configurable default blocklist; unconditional device and `/proc/<pid>/fd` exclusions remain enforced. |
 | `CODING_TOOLS_BLOCKED_PATHS_ADD` | — | Comma-separated paths to **add** to the default blocklist. |
 | `CODING_TOOLS_SHELL` | (auto-detected) | Override the shell binary used by SHELL action. Takes priority over `SHELL`. Useful on Android/AOSP where the default shell path may not be executable. |
@@ -159,6 +159,7 @@ Runtime gating env vars (read by `auto-enable.ts` and `index.ts`):
 
 - **READ/WRITE/EDIT paths may be absolute or relative.** Relative paths resolve against `SessionCwdService.getCwd(message.roomId)`; the resolved absolute path must still pass `SandboxService.validatePath`. A missing session-cwd service is an explicit failure.
 - **Always validate paths through `SandboxService.validatePath`** before any filesystem access. Never bypass this.
+- **SHELL is trusted host execution, not filesystem confinement.** `CODING_TOOLS_WORKSPACE_ROOTS` validates SHELL's `cwd` only. Commands may address paths outside those roots, so the OWNER role and deployment host/container boundary must be trusted.
 - **Read before write**: `FileStateService.assertWritable` will reject a write if the file was modified externally since the last read. The agent must re-read first.
 - **`conversationId` = `message.roomId`** (string-coerced). Missing `roomId` is a hard failure.
 - **Never throw from a handler** — return `failureToActionResult({ reason, message })` instead.

--- a/plugins/plugin-coding-tools/README.md
+++ b/plugins/plugin-coding-tools/README.md
@@ -14,7 +14,7 @@ The plugin registers three umbrella actions and a set of supporting services:
 
 Supporting services (automatically started):
 
-- **SandboxService** — path policy engine. Blocks user-private and OS-system paths by default; optionally constrains access to configured workspace roots.
+- **SandboxService** — path policy engine for FILE, WORKTREE, and the SHELL working directory. Blocks user-private and OS-system paths by default; optionally constrains those validated paths to configured workspace roots. It does not confine paths referenced by a shell command.
 - **FileStateService** — tracks file mtimes per conversation so write/edit operations are rejected if the file was externally modified since the agent last read it.
 - **SessionCwdService** — per-conversation working directory used by relative file operations and default-path tools. Defaults to `process.cwd()`; updated by WORKTREE operations.
 - **BackgroundShellService** — owns per-conversation background shell sessions and reaps all child process groups on plugin teardown.
@@ -46,7 +46,7 @@ All settings are optional. Configure via environment variables or agent settings
 
 | Setting | Default | Description |
 |---|---|---|
-| `CODING_TOOLS_WORKSPACE_ROOTS` | `process.cwd()` | Comma-separated absolute paths the tools may access. Files outside these roots are rejected. |
+| `CODING_TOOLS_WORKSPACE_ROOTS` | `process.cwd()` | Comma-separated absolute roots for FILE and WORKTREE paths and the SHELL working directory. This does not restrict paths that a SHELL command reads or writes. |
 | `CODING_TOOLS_BLOCKED_PATHS` | (built-in) | Comma-separated absolute paths to block — replaces the default blocklist. |
 | `CODING_TOOLS_BLOCKED_PATHS_ADD` | — | Paths to add to the default blocklist. |
 | `CODING_TOOLS_SHELL_TIMEOUT_MS` | `120000` | Optional canonical decimal integer from `100` through `600000` used as the default SHELL timeout (ms); invalid values fail before execution and per-call `timeout` takes precedence within the same range. |
@@ -56,6 +56,15 @@ All settings are optional. Configure via environment variables or agent settings
 | `CODING_TOOLS_MAX_READ_LINES` | `2000` | Max lines returned by FILE action=read. |
 | `CODING_TOOLS_MAX_FILE_SIZE_BYTES` | `262144` | File size cap for reads (bytes). Larger files are rejected. |
 | `CODING_TOOLS_GREP_HEAD_LIMIT` | `250` | Max output lines for GREP. Set to 0 to disable. |
+
+### SHELL trust boundary
+
+SHELL is an owner-only trusted command executor, not an OS filesystem sandbox.
+`CODING_TOOLS_WORKSPACE_ROOTS` validates where a command starts, but an
+arbitrary shell command can still address paths outside those roots. Deploy the
+plugin only where the OWNER role and host/container boundary are trusted for
+that access. Static command analysis and the command denylist are safety checks,
+not filesystem confinement.
 
 The folded `ShellService` retains these compatibility settings for external
 callers of `runtime.getService("shell").exec()` / `executeCommand()`; the

--- a/plugins/plugin-coding-tools/package.json
+++ b/plugins/plugin-coding-tools/package.json
@@ -98,7 +98,7 @@
     "pluginParameters": {
       "CODING_TOOLS_WORKSPACE_ROOTS": {
         "type": "string",
-        "description": "Comma-separated absolute paths the coding tools may read/write under. Defaults to the runtime's process.cwd() when unset.",
+        "description": "Comma-separated absolute roots for FILE and WORKTREE paths and the SHELL working directory. Does not restrict paths referenced by a SHELL command. Defaults to the runtime's process.cwd() when unset.",
         "required": false,
         "sensitive": false
       },

--- a/plugins/plugin-coding-tools/registry-entry.json
+++ b/plugins/plugin-coding-tools/registry-entry.json
@@ -1,7 +1,7 @@
 {
   "id": "coding-tools",
   "name": "Coding Tools",
-  "description": "Native coding tools (FILE, SHELL, WORKTREE) running directly in the agent. AST-validated commands, mtime-gated writes, sealed workspace roots, optional per-OS process sandboxing (sandbox-exec on macOS, bwrap on Linux).",
+  "description": "Native coding tools (FILE, SHELL, WORKTREE) running directly in the agent. Commands are analyzed before trusted host execution; mtime-gated file writes and configured path roots apply to FILE, WORKTREE, and the SHELL working directory.",
   "npmName": "@elizaos/plugin-coding-tools",
   "shortIds": ["coding-agent", "codingAgent", "coding-tools", "codingTools"],
   "version": "0.1.0",
@@ -13,7 +13,7 @@
       "required": false,
       "sensitive": false,
       "label": "Workspace roots",
-      "help": "Comma-separated absolute paths the coding tools may read/write under. Defaults to the runtime's cwd.",
+      "help": "Comma-separated absolute roots for FILE and WORKTREE paths and the SHELL working directory. SHELL commands may address paths outside these roots. Defaults to the runtime's cwd.",
       "advanced": false
     },
     "CODING_TOOLS_DENY_COMMANDS": {
@@ -44,14 +44,6 @@
       "advanced": true,
       "min": 1000,
       "unit": "ms"
-    },
-    "CODING_TOOLS_OS_SANDBOX": {
-      "type": "boolean",
-      "required": false,
-      "sensitive": false,
-      "label": "OS-level sandbox",
-      "help": "Wrap bash invocations in sandbox-exec (macOS) or bwrap (Linux) when available. AST analysis runs regardless.",
-      "advanced": true
     }
   },
   "render": {


### PR DESCRIPTION
Closes #23211

## Summary

- Record the issue's explicit trusted-SHELL decision: workspace roots validate FILE and WORKTREE paths and the SHELL working directory, not paths referenced by an arbitrary command.
- Make that boundary visible in the README, package metadata, registry settings UI, maintainer guides, and action-author contract.
- Remove the unimplemented `CODING_TOOLS_OS_SANDBOX` registry switch and false `sandbox-exec`/`bwrap` capability claim.
- Keep #23210 open for the separate enforced process-sandbox architecture.

## Exact-head verification

Candidate: `58559d0190139d437951e6c04af9f3ec62904b74`

Parent develop: `569ec35fe452ee9c2d264b74b64b08823cf7d055`

- `CLAUDE.md` / `AGENTS.md` byte parity: passed
- package and registry JSON parsing: passed
- registry source validation through `registryEntrySchema`: passed
- generated coding-tools description/config equality with `registry-entry.json`: passed
- stale setting/claim grep: passed
- pinned Biome 2.5.7 formatting for all changed JSON: passed
- scoped diff/whitespace inspection: passed

## Evidence Gate

<!-- evidence-head:58559d0190139d437951e6c04af9f3ec62904b74 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - documentation and registry metadata only; no rendered UI changes
<!-- evidence-row:after-screenshots -->
- [ ] N/A - documentation and registry metadata only; no rendered UI changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no executable user flow changed
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend or runtime implementation changed
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend implementation or network path changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action implementation, or provider behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [23346-generated.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23346-generated.json)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text changed

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@80a5f22603ab4454f26b294b349352952bd32d7e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@80a5f22603ab4454f26b294b349352952bd32d7e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@80a5f22603ab4454f26b294b349352952bd32d7e:packages/skills/skills/contribute-to-eliza"} -->




