### PR TITLE
fix(homepage): commit SIWS session only after identity validation

### DIFF
--- a/packages/homepage/src/lib/api/siws.ts
+++ b/packages/homepage/src/lib/api/siws.ts
@@ -74,14 +74,18 @@ function containsControlCharacter(value: string): boolean {
   return false;
 }
 
+function isSafeIdentifier(value: unknown): value is string {
+  return isBoundedString(value, 256) && !containsControlCharacter(value);
+}
+
 function isOrganization(
   value: unknown,
 ): value is { id: string; name: string; slug: string } {
   return (
     isRecord(value) &&
-    isBoundedString(value.id, 256) &&
+    isSafeIdentifier(value.id) &&
     isBoundedString(value.name, 256) &&
-    isBoundedString(value.slug, 256)
+    isSafeIdentifier(value.slug)
   );
 }
 
@@ -172,13 +176,12 @@ function parseVerifyResponse(value: unknown): SiwsVerifyResponse {
     !SOLANA_ADDRESS_RE.test(value.address) ||
     typeof value.isNewAccount !== "boolean" ||
     !isRecord(value.user) ||
-    !isBoundedString(value.user.id, 256) ||
+    !isSafeIdentifier(value.user.id) ||
     typeof value.user.wallet_address !== "string" ||
     !SOLANA_ADDRESS_RE.test(value.user.wallet_address) ||
-    !isBoundedString(value.user.organization_id, 256) ||
-    !(value.organization === null || isOrganization(value.organization)) ||
-    (isRecord(value.organization) &&
-      value.organization.id !== value.user.organization_id)
+    !isSafeIdentifier(value.user.organization_id) ||
+    !isOrganization(value.organization) ||
+    value.organization.id !== value.user.organization_id
   ) {
     throw new Error("SIWS verification response has an invalid shape");
   }
@@ -192,14 +195,11 @@ function parseVerifyResponse(value: unknown): SiwsVerifyResponse {
       wallet_address: value.user.wallet_address,
       organization_id: value.user.organization_id,
     },
-    organization:
-      organization === null
-        ? null
-        : {
-            id: organization.id,
-            name: organization.name,
-            slug: organization.slug,
-          },
+    organization: {
+      id: organization.id,
+      name: organization.name,
+      slug: organization.slug,
+    },
   };
 }
 

--- a/packages/homepage/src/lib/context/auth-context.tsx
+++ b/packages/homepage/src/lib/context/auth-context.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from "react";
 import { elizacloudFetch, getAuthToken } from "@/lib/api/client";
@@ -187,6 +188,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const siwsAttemptRef = useRef(0);
 
   const setSessionToken = useCallback((token: string | null) => {
     if (typeof window === "undefined") return;
@@ -459,6 +461,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 
   const loginWithSolana = useCallback(async (): Promise<SolanaLoginResult> => {
+    const attempt = ++siwsAttemptRef.current;
     setIsLoading(true);
     setError(null);
     try {
@@ -468,26 +471,31 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         validateCanonicalUser: (canonicalUser) => {
           assertCanonicalSiwsIdentity(result, canonicalUser);
         },
-        commitSession: (token, canonicalUser) => {
-          commitUserInfo(canonicalUser);
-          setSessionToken(token);
-        },
+        isCurrentAttempt: () => attempt === siwsAttemptRef.current,
+        storeToken: setSessionToken,
+        publishCanonicalUser: commitUserInfo,
       });
       return { success: true, address: result.address };
     } catch (err) {
       const result = parseAuthError(err);
-      setError(result.error ?? "Solana sign-in failed");
+      if (attempt === siwsAttemptRef.current) {
+        setError(result.error ?? "Solana sign-in failed");
+      }
       return result;
     } finally {
-      setIsLoading(false);
+      if (attempt === siwsAttemptRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [setSessionToken, loadUserInfo, commitUserInfo]);
 
   const logout = useCallback(() => {
+    siwsAttemptRef.current += 1;
     setSessionToken(null);
     setUser(null);
     setOrganization(null);
     setError(null);
+    setIsLoading(false);
   }, [setSessionToken]);
 
   const refreshUser = useCallback(async () => {

--- a/packages/homepage/src/lib/context/auth-context.tsx
+++ b/packages/homepage/src/lib/context/auth-context.tsx
@@ -12,7 +12,10 @@ import {
 } from "react";
 import { elizacloudFetch, getAuthToken } from "@/lib/api/client";
 import { signInWithSolana as siwsSignIn } from "@/lib/api/siws";
-import { confirmSiwsSession } from "@/lib/context/siws-session";
+import {
+  assertCanonicalSiwsIdentity,
+  confirmSiwsSession,
+} from "@/lib/context/siws-session";
 
 export interface TelegramAuthData {
   id: number;
@@ -194,27 +197,31 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
+  const loadUserInfo = useCallback(
+    async (token: string): Promise<UserInfoResponse> =>
+      elizacloudFetch<UserInfoResponse>("/api/eliza-app/user/me", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }),
+    [],
+  );
+
+  const commitUserInfo = useCallback((data: UserInfoResponse) => {
+    setUser(data.user);
+    setOrganization(data.organization);
+  }, []);
+
   const fetchUserInfo = useCallback(
     async (tokenOverride?: string): Promise<boolean> => {
       const token = tokenOverride || getAuthToken();
-      if (!token) {
-        return false;
-      }
+      if (!token) return false;
 
-      const data = await elizacloudFetch<UserInfoResponse>(
-        "/api/eliza-app/user/me",
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        },
-      );
-
-      setUser(data.user);
-      setOrganization(data.organization);
+      const data = await loadUserInfo(token);
+      commitUserInfo(data);
       return true;
     },
-    [],
+    [loadUserInfo, commitUserInfo],
   );
 
   useEffect(() => {
@@ -457,11 +464,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       const result = await siwsSignIn();
       await confirmSiwsSession(result.apiKey, {
-        storeToken: setSessionToken,
-        loadCanonicalUser: fetchUserInfo,
-        clearIdentity: () => {
-          setUser(null);
-          setOrganization(null);
+        loadCanonicalUser: loadUserInfo,
+        validateCanonicalUser: (canonicalUser) => {
+          assertCanonicalSiwsIdentity(result, canonicalUser);
+        },
+        commitSession: (token, canonicalUser) => {
+          commitUserInfo(canonicalUser);
+          setSessionToken(token);
         },
       });
       return { success: true, address: result.address };
@@ -472,7 +481,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } finally {
       setIsLoading(false);
     }
-  }, [setSessionToken, fetchUserInfo]);
+  }, [setSessionToken, loadUserInfo, commitUserInfo]);
 
   const logout = useCallback(() => {
     setSessionToken(null);

--- a/packages/homepage/src/lib/context/siws-session.ts
+++ b/packages/homepage/src/lib/context/siws-session.ts
@@ -1,19 +1,63 @@
-/** Finalizes a SIWS bearer only after the canonical user endpoint accepts it. */
+/** Validates and atomically commits a SIWS session after canonical identity confirmation. */
 
-export async function confirmSiwsSession(
+import type { SiwsVerifyResponse } from "@/lib/api/siws";
+
+const IDENTITY_FIELD_MAX_BYTES = 256;
+
+interface CanonicalSiwsIdentity {
+  user: { id: string; organization_id: string | null };
+  organization: { id: string } | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSafeIdentifier(value: unknown): value is string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    new TextEncoder().encode(value).byteLength > IDENTITY_FIELD_MAX_BYTES
+  ) {
+    return false;
+  }
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (codePoint <= 0x1f || codePoint === 0x7f) return false;
+  }
+  return true;
+}
+
+export function assertCanonicalSiwsIdentity(
+  verified: SiwsVerifyResponse,
+  value: unknown,
+): asserts value is CanonicalSiwsIdentity {
+  if (
+    verified.organization === null ||
+    !isRecord(value) ||
+    !isRecord(value.user) ||
+    !isSafeIdentifier(value.user.id) ||
+    !isSafeIdentifier(value.user.organization_id) ||
+    !isRecord(value.organization) ||
+    !isSafeIdentifier(value.organization.id) ||
+    value.user.id !== verified.user.id ||
+    value.user.organization_id !== verified.user.organization_id ||
+    value.organization.id !== verified.organization.id ||
+    value.organization.id !== value.user.organization_id
+  ) {
+    throw new Error("Canonical SIWS identity does not match verification");
+  }
+}
+
+export async function confirmSiwsSession<T>(
   apiKey: string,
   dependencies: {
-    storeToken: (token: string | null) => void;
-    loadCanonicalUser: (token: string) => Promise<unknown>;
-    clearIdentity: () => void;
+    loadCanonicalUser: (token: string) => Promise<T>;
+    validateCanonicalUser: (value: T) => void;
+    commitSession: (token: string, value: T) => void;
   },
 ): Promise<void> {
-  dependencies.storeToken(apiKey);
-  try {
-    await dependencies.loadCanonicalUser(apiKey);
-  } catch (error) {
-    dependencies.storeToken(null);
-    dependencies.clearIdentity();
-    throw error;
-  }
+  const canonicalUser = await dependencies.loadCanonicalUser(apiKey);
+  dependencies.validateCanonicalUser(canonicalUser);
+  dependencies.commitSession(apiKey, canonicalUser);
 }

--- a/packages/homepage/src/lib/context/siws-session.ts
+++ b/packages/homepage/src/lib/context/siws-session.ts
@@ -54,10 +54,19 @@ export async function confirmSiwsSession<T>(
   dependencies: {
     loadCanonicalUser: (token: string) => Promise<T>;
     validateCanonicalUser: (value: T) => void;
-    commitSession: (token: string, value: T) => void;
+    isCurrentAttempt: () => boolean;
+    storeToken: (token: string) => void;
+    publishCanonicalUser: (value: T) => void;
   },
 ): Promise<void> {
   const canonicalUser = await dependencies.loadCanonicalUser(apiKey);
   dependencies.validateCanonicalUser(canonicalUser);
-  dependencies.commitSession(apiKey, canonicalUser);
+  if (!dependencies.isCurrentAttempt()) {
+    throw new Error("SIWS session attempt was superseded");
+  }
+
+  // Persist first so a storage failure cannot publish identity for a bearer
+  // that no observer can subsequently load.
+  dependencies.storeToken(apiKey);
+  dependencies.publishCanonicalUser(canonicalUser);
 }

--- a/packages/homepage/tests/e2e/aesthetic-audit.spec.ts
+++ b/packages/homepage/tests/e2e/aesthetic-audit.spec.ts
@@ -35,7 +35,7 @@ const VIEWPORTS = [
 const ARTIFACT_DIR = path.resolve(process.cwd(), "test-results/aesthetic");
 
 const mockUser = {
-  id: "user_aesthetic_audit",
+  id: "user_siws_audit",
   telegram_id: "1",
   telegram_username: "audit_user",
   telegram_first_name: "Audit",
@@ -48,7 +48,7 @@ const mockUser = {
   phone_number: "+15555550100",
   name: "Audit User",
   avatar: null,
-  organization_id: "org_aesthetic_audit",
+  organization_id: "org_siws_audit",
   created_at: "2026-01-01T00:00:00.000Z",
 };
 
@@ -60,7 +60,7 @@ async function installCloudMocks(page: Page) {
         json: {
           user: mockUser,
           organization: {
-            id: "org_aesthetic_audit",
+            id: "org_siws_audit",
             name: "Audit Org",
             credit_balance: "12.34",
           },
@@ -69,14 +69,14 @@ async function installCloudMocks(page: Page) {
     }
     return route.fulfill({ status: 404, json: { error: "Unhandled mock" } });
   });
-  await page.route("https://elizacloud.ai/api/auth/siws/**", async (route) => {
+  await page.route("https://api.eliza.app/api/auth/siws/**", async (route) => {
     const u = new URL(route.request().url());
     if (u.pathname === "/api/auth/siws/nonce") {
       return route.fulfill({
         json: {
-          nonce: "test-nonce-abcdef",
-          domain: "www.elizacloud.ai",
-          uri: "https://www.elizacloud.ai",
+          nonce: "0123456789abcdef0123456789abcdef",
+          domain: "cloud.eliza.app",
+          uri: "https://cloud.eliza.app",
           chainId: "solana:mainnet",
           version: "1",
           statement: "Sign in to Eliza Cloud",
@@ -394,37 +394,41 @@ test.describe("brand chrome consistency", () => {
 });
 
 // ── SIWS Playwright flow: simulated wallet sign + verify roundtrip. ──
-test.describe("Sign-In With Solana", () => {
-  test.use({ viewport: { width: 1440, height: 900 } });
+for (const viewport of VIEWPORTS) {
+  test.describe(`Sign-In With Solana (${viewport.name})`, () => {
+    test.use({ viewport });
 
-  test("Solana button signs in and routes to /connected", async ({ page }) => {
-    test.setTimeout(45_000);
-    await installCloudMocks(page);
+    test("Solana button signs in and routes to /connected", async ({
+      page,
+    }) => {
+      test.setTimeout(45_000);
+      await installCloudMocks(page);
 
-    // Inject a deterministic test signer before the page boots.
-    await page.addInitScript(() => {
-      const SIG = new Uint8Array(64);
-      for (let i = 0; i < 64; i++) SIG[i] = i + 1;
-      window.__siwsTestSigner = {
-        publicKey: "11111111111111111111111111111111",
-        sign: () => SIG,
-      };
+      // Inject a deterministic test signer before the page boots.
+      await page.addInitScript(() => {
+        const SIG = new Uint8Array(64);
+        for (let i = 0; i < 64; i++) SIG[i] = i + 1;
+        window.__siwsTestSigner = {
+          publicKey: "11111111111111111111111111111111",
+          sign: () => SIG,
+        };
+      });
+
+      await page.goto("/get-started", { waitUntil: "domcontentloaded" });
+      await settle(page, "/get-started");
+
+      const button = page.getByTestId("solana-signin");
+      await expect(button).toBeVisible();
+      await button.click();
+
+      // Explicit navigation wait: after the SIWS verify roundtrip completes the
+      // auth context sets isAuthenticated=true, which triggers navigate("/connected")
+      // both from handleSolanaConnect directly and from the auth-guard effect.
+      await page.waitForURL(/\/connected$/, { timeout: 15_000 });
+      await expect(page).toHaveURL(/\/connected$/);
+      await expect(
+        page.getByRole("heading", { name: /Connected\./i }),
+      ).toBeVisible();
     });
-
-    await page.goto("/get-started", { waitUntil: "domcontentloaded" });
-    await settle(page, "/get-started");
-
-    const button = page.getByTestId("solana-signin");
-    await expect(button).toBeVisible();
-    await button.click();
-
-    // Explicit navigation wait: after the SIWS verify roundtrip completes the
-    // auth context sets isAuthenticated=true, which triggers navigate("/connected")
-    // both from handleSolanaConnect directly and from the auth-guard effect.
-    await page.waitForURL(/\/connected$/, { timeout: 15_000 });
-    await expect(page).toHaveURL(/\/connected$/);
-    await expect(
-      page.getByRole("heading", { name: /Connected\./i }),
-    ).toBeVisible();
   });
-});
+}

--- a/packages/homepage/tests/siws-hung-http.test.ts
+++ b/packages/homepage/tests/siws-hung-http.test.ts
@@ -107,9 +107,11 @@ describe("SIWS HTTP boundary", () => {
       validateCanonicalUser: (value) => {
         expect(value.user.id).toBe("user-1");
       },
-      commitSession: (token) => {
+      isCurrentAttempt: () => true,
+      storeToken: (token) => {
         visibleToken = token;
       },
+      publishCanonicalUser: () => {},
     });
 
     await Promise.resolve();
@@ -132,10 +134,12 @@ describe("SIWS HTTP boundary", () => {
         validateCanonicalUser: () => {
           throw new Error("validation must not run");
         },
-        commitSession: (token) => {
+        isCurrentAttempt: () => true,
+        storeToken: (token) => {
           visibleToken = token;
           commits += 1;
         },
+        publishCanonicalUser: () => {},
       }),
     ).rejects.toBe(failure);
     expect(visibleToken).toBe("prior-token");
@@ -156,14 +160,127 @@ describe("SIWS HTTP boundary", () => {
         validateCanonicalUser: (value) => {
           assertCanonicalSiwsIdentity(verified, value);
         },
-        commitSession: (token) => {
+        isCurrentAttempt: () => true,
+        storeToken: (token) => {
           visibleToken = token;
           commits += 1;
         },
+        publishCanonicalUser: () => {},
       }),
     ).rejects.toThrow("Canonical SIWS identity does not match verification");
     expect(visibleToken).toBe("prior-token");
     expect(commits).toBe(0);
+  });
+
+  test("preserves prior identity when candidate token storage fails", async () => {
+    const priorIdentity = { user: "prior-user", organization: "prior-org" };
+    const visibleToken = "prior-token";
+    let visibleIdentity = priorIdentity;
+    const failure = new Error("storage unavailable");
+
+    await expect(
+      confirmSiwsSession("issued-token", {
+        loadCanonicalUser: async () => verified,
+        validateCanonicalUser: (value) => {
+          assertCanonicalSiwsIdentity(verified, value);
+        },
+        isCurrentAttempt: () => true,
+        storeToken: () => {
+          throw failure;
+        },
+        publishCanonicalUser: () => {
+          visibleIdentity = {
+            user: verified.user.id,
+            organization: verified.organization.id,
+          };
+        },
+      }),
+    ).rejects.toBe(failure);
+    expect(visibleToken).toBe("prior-token");
+    expect(visibleIdentity).toBe(priorIdentity);
+  });
+
+  test("stores the accepted bearer before publishing its canonical identity", async () => {
+    let visibleToken = "prior-token";
+    let visibleIdentity = { user: "prior-user", organization: "prior-org" };
+    const order: string[] = [];
+
+    await confirmSiwsSession("issued-token", {
+      loadCanonicalUser: async () => verified,
+      validateCanonicalUser: (value) => {
+        assertCanonicalSiwsIdentity(verified, value);
+      },
+      isCurrentAttempt: () => true,
+      storeToken: (token) => {
+        order.push("token");
+        visibleToken = token;
+      },
+      publishCanonicalUser: (value) => {
+        order.push("identity");
+        expect(visibleToken).toBe("issued-token");
+        visibleIdentity = {
+          user: value.user.id,
+          organization: value.organization.id,
+        };
+      },
+    });
+
+    expect(order).toEqual(["token", "identity"]);
+    expect(visibleIdentity).toEqual({ user: "user-1", organization: "org-1" });
+  });
+
+  test("a superseded load cannot mix an older token with the current identity", async () => {
+    type Session = { token: string; user: string; organization: string };
+    let currentAttempt = 1;
+    let visible: Session = {
+      token: "prior-token",
+      user: "prior-user",
+      organization: "prior-org",
+    };
+    let resolveOlder!: (value: typeof verified) => void;
+    const olderCanonical = new Promise<typeof verified>((resolve) => {
+      resolveOlder = resolve;
+    });
+
+    const confirm = (
+      attempt: number,
+      token: string,
+      load: () => Promise<typeof verified>,
+    ) =>
+      confirmSiwsSession(token, {
+        loadCanonicalUser: load,
+        validateCanonicalUser: (value) => {
+          assertCanonicalSiwsIdentity(verified, value);
+        },
+        isCurrentAttempt: () => attempt === currentAttempt,
+        storeToken: (nextToken) => {
+          visible = { ...visible, token: nextToken };
+        },
+        publishCanonicalUser: (value) => {
+          visible = {
+            ...visible,
+            user: value.user.id,
+            organization: value.organization.id,
+          };
+        },
+      });
+
+    const older = confirm(1, "older-token", async () => olderCanonical);
+    currentAttempt = 2;
+    await confirm(2, "current-token", async () => verified);
+    expect(visible).toEqual({
+      token: "current-token",
+      user: "user-1",
+      organization: "org-1",
+    });
+
+    resolveOlder(verified);
+    await expect(older).rejects.toThrow("SIWS session attempt was superseded");
+    expect(visible).toEqual({
+      token: "current-token",
+      user: "user-1",
+      organization: "org-1",
+    });
   });
 
   test("times out while consuming the nonce response body", async () => {

--- a/packages/homepage/tests/siws-hung-http.test.ts
+++ b/packages/homepage/tests/siws-hung-http.test.ts
@@ -4,7 +4,10 @@
  */
 import { afterEach, describe, expect, test } from "bun:test";
 import { signInWithSolana } from "../src/lib/api/siws";
-import { confirmSiwsSession } from "../src/lib/context/siws-session";
+import {
+  assertCanonicalSiwsIdentity,
+  confirmSiwsSession,
+} from "../src/lib/context/siws-session";
 
 const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
 const originalTimeoutDescriptor = Object.getOwnPropertyDescriptor(
@@ -92,24 +95,75 @@ afterEach(() => {
 });
 
 describe("SIWS HTTP boundary", () => {
-  test("rolls back an issued bearer when canonical session loading fails", async () => {
-    const stored: Array<string | null> = [];
-    let cleared = 0;
+  test("does not publish a candidate bearer while canonical loading is pending", async () => {
+    let visibleToken = "prior-token";
+    let resolveCanonical!: (value: typeof verified) => void;
+    const canonical = new Promise<typeof verified>((resolve) => {
+      resolveCanonical = resolve;
+    });
+
+    const confirmation = confirmSiwsSession("issued-token", {
+      loadCanonicalUser: async () => canonical,
+      validateCanonicalUser: (value) => {
+        expect(value.user.id).toBe("user-1");
+      },
+      commitSession: (token) => {
+        visibleToken = token;
+      },
+    });
+
+    await Promise.resolve();
+    expect(visibleToken).toBe("prior-token");
+    resolveCanonical(verified);
+    await confirmation;
+    expect(visibleToken).toBe("issued-token");
+  });
+
+  test("preserves a prior session when canonical loading fails", async () => {
+    let visibleToken = "prior-token";
+    let commits = 0;
     const failure = new Error("canonical session rejected");
 
     await expect(
       confirmSiwsSession("issued-token", {
-        storeToken: (token) => stored.push(token),
         loadCanonicalUser: async () => {
           throw failure;
         },
-        clearIdentity: () => {
-          cleared += 1;
+        validateCanonicalUser: () => {
+          throw new Error("validation must not run");
+        },
+        commitSession: (token) => {
+          visibleToken = token;
+          commits += 1;
         },
       }),
     ).rejects.toBe(failure);
-    expect(stored).toEqual(["issued-token", null]);
-    expect(cleared).toBe(1);
+    expect(visibleToken).toBe("prior-token");
+    expect(commits).toBe(0);
+  });
+
+  test("preserves a prior session when canonical identity validation fails", async () => {
+    let visibleToken = "prior-token";
+    let commits = 0;
+    const mismatched = {
+      user: { id: "other-user", organization_id: "org-1" },
+      organization: { id: "org-1" },
+    };
+
+    await expect(
+      confirmSiwsSession("issued-token", {
+        loadCanonicalUser: async () => mismatched,
+        validateCanonicalUser: (value) => {
+          assertCanonicalSiwsIdentity(verified, value);
+        },
+        commitSession: (token) => {
+          visibleToken = token;
+          commits += 1;
+        },
+      }),
+    ).rejects.toThrow("Canonical SIWS identity does not match verification");
+    expect(visibleToken).toBe("prior-token");
+    expect(commits).toBe(0);
   });
 
   test("times out while consuming the nonce response body", async () => {
@@ -362,6 +416,36 @@ describe("SIWS HTTP boundary", () => {
     await expect(signInWithSolana()).rejects.toThrow(
       "SIWS verification response has an invalid shape",
     );
+  });
+
+  test("rejects missing organizations and control characters in identity fields", async () => {
+    const invalidResponses = [
+      { ...verified, organization: null },
+      { ...verified, user: { ...verified.user, id: "user-1\nadmin" } },
+      {
+        ...verified,
+        user: { ...verified.user, organization_id: "org-1\tother" },
+      },
+      {
+        ...verified,
+        organization: { ...verified.organization, id: "org-1\u007f" },
+      },
+      {
+        ...verified,
+        organization: { ...verified.organization, slug: "org\radmin" },
+      },
+    ];
+
+    for (const invalid of invalidResponses) {
+      let request = 0;
+      installBrowserDoubles(async () => {
+        request += 1;
+        return jsonResponse(request === 1 ? nonce : invalid);
+      });
+      await expect(signInWithSolana()).rejects.toThrow(
+        "SIWS verification response has an invalid shape",
+      );
+    }
   });
 
   test("rejects malformed wallet outputs before verification", async () => {


### PR DESCRIPTION
# Relates to

Fixes #23309. Corrective follow-up to merged PR #23310.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8d3f3137b4cc9cb8ffcd06bdc7a828393b8d64bc:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What changed

- Keep a candidate SIWS bearer private while `/user/me` is pending.
- Validate the canonical user and organization against the verified SIWS identity before publishing either token or identity.
- Reject superseded attempts, null organizations, inconsistent bindings, and control characters.
- Preserve the prior valid session on candidate load, validation, or storage failure.
- Repair the browser acceptance fixture to use the canonical API origin, a valid nonce, one consistent identity, and both desktop and mobile viewports.

# Testing

Validated on exact head `8d3f3137b4cc9cb8ffcd06bdc7a828393b8d64bc`, direct base `5d412662d335fda557a31a338193068e6ccffdd1`:

- `bun --conditions=eliza-source test packages/homepage/tests/siws-hung-http.test.ts` — 20 passed, 0 failed, 70 assertions.
- `bun run --cwd packages/homepage typecheck` — passed.
- Biome on all five changed files — passed.
- Recorded Playwright SIWS acceptance — desktop and mobile, 2 passed, 0 failed.
- `bun run --cwd packages/app build:web` — passed after materializing the workspace core build; 9,568 modules transformed, chunk-safety and viewport-policy verification passed.
- `git diff --check` — passed.

# Evidence Gate

<!-- evidence-head:8b20f0c69848678f763065ea81b45aff4a685166 -->

<!-- evidence-row:before-screenshots -->
- [x] Desktop: ![before desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23348-before-desktop.png) Mobile: ![before mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23348-before-mobile.png)
<!-- evidence-row:after-screenshots -->
- [x] Desktop: ![after desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23348-after-desktop.png) Mobile: ![after mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23348-after-mobile.png)
<!-- evidence-row:walkthrough-video -->
- [x] [Desktop SIWS walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23348-walkthrough-desktop.mp4) and [mobile SIWS walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23348-walkthrough-mobile.mp4).
<!-- evidence-row:backend-logs -->
- [x] N/A — client-only change; the Cloud boundary is deterministically intercepted by the browser acceptance test.
<!-- evidence-row:frontend-logs -->
- [x] [23348-8b20-frontend-network-console.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23348-8b20-frontend-network-console.txt)
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no agent, model, provider, prompt, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [23348-8b20-siws-session-receipt.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23348-8b20-siws-session-receipt.txt)
<!-- evidence-row:ocr-review -->
- [x] [23348-8b20-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23348-8b20-ocr-review.txt)

# Delivery status

Source, scoped package gates, production app build, and desktop/mobile browser acceptance are complete at the exact head. The PR is ready so hosted CI and a final non-author approval can run; those gates remain required before merge.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@8d3f3137b4cc9cb8ffcd06bdc7a828393b8d64bc:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-siws-corrective]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@8d3f3137b4cc9cb8ffcd06bdc7a828393b8d64bc:packages/skills/skills/contribute-to-eliza"} -->



