### PR TITLE
feat(desktop): signed Linux GTK/WebKit artifact producer and verifier

### DIFF
--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -52,6 +52,8 @@
     "build:fused-desktop": "node ./scripts/stage-desktop-fused-lib.mjs",
     "build:fused-desktop:ensure": "node ./scripts/stage-desktop-fused-lib.mjs --ensure",
     "build:fused-desktop:check": "node ./scripts/stage-desktop-fused-lib.mjs --check",
+    "build:linux-gtk-artifact": "node ./scripts/package-linux-gtk-artifact.mjs produce",
+    "verify:linux-gtk-artifact": "node ./scripts/package-linux-gtk-artifact.mjs verify",
     "build:flatpak": "node ./scripts/build-flatpak.mjs",
     "build:flatpak:store": "ELIZA_BUILD_VARIANT=store node ./scripts/build-flatpak.mjs",
     "build:flatpak:direct": "ELIZA_BUILD_VARIANT=direct node ./scripts/build-flatpak.mjs",

--- a/packages/app-core/scripts/__tests__/package-linux-gtk-artifact.test.ts
+++ b/packages/app-core/scripts/__tests__/package-linux-gtk-artifact.test.ts
@@ -3,11 +3,16 @@
  * verifier. The harness is real: it stages fake shell binaries on disk,
  * produces genuine tar.zst archives via the system tar, signs with real
  * Ed25519 keys, and asserts that tampering with any byte of the archive or
- * manifest is rejected. It also pins the vendored manifest schema to the
- * fields the validator enforces so cross-repository drift is caught here.
+ * manifest is rejected. Archive-side regressions re-sign deliberately
+ * wrong-type, wrong-mode, and symlinked entrypoints with the genuine key, so a
+ * verifier that trusted digests and member names alone would fail here. The
+ * vendored manifest schema is pinned by digest and the validator is generated
+ * from those bytes, so cross-repository drift is caught here rather than in
+ * the OS image.
  */
 
-import { generateKeyPairSync } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { createHash, generateKeyPairSync } from "node:crypto";
 import {
   chmodSync,
   existsSync,
@@ -18,6 +23,7 @@ import {
   rmSync,
   statSync,
   symlinkSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
@@ -34,6 +40,8 @@ import {
   manifestViolations,
   produceArtifact,
   SCHEMA_PATH,
+  signBytes,
+  VENDORED_SCHEMA_SHA256,
   verifyArtifactDir,
   writeSigningKeyPair,
 } from "../package-linux-gtk-artifact.mjs";
@@ -423,16 +431,16 @@ describe("manifest schema contract", () => {
     const problems = manifestViolations(bad);
     expect(problems).toEqual(
       expect.arrayContaining([
-        "schemaVersion must be 1",
+        "schemaVersion must equal 1",
         'unknown field "unexpected"',
-        'shell must be "gtk-webkit"',
+        'shell must equal "gtk-webkit"',
         "architecture must be one of x86_64, arm64, riscv64",
-        "archive must be a bare *.tar.zst filename",
-        "entrypoints.desktop must match bin/<name>",
-        "entrypoints.doctor must match bin/<name>",
-        'unknown entrypoint "extra"',
-        "capabilities.tray must be true",
-        "capabilities.overlay must be true",
+        "archive must match /^[A-Za-z0-9._-]+\\.tar\\.zst$/",
+        "entrypoints.desktop must match /^bin/[A-Za-z0-9._-]+$/",
+        'missing required field "entrypoints.doctor"',
+        'unknown field "entrypoints.extra"',
+        "capabilities.tray must equal true",
+        'missing required field "capabilities.overlay"',
       ]),
     );
   });
@@ -440,30 +448,137 @@ describe("manifest schema contract", () => {
   it("keeps the vendored schema aligned with the validator", () => {
     const schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf8"));
     expect(schema.properties.architecture.enum).toEqual(ARCHITECTURES);
-    expect(schema.properties.shell.const).toBe("gtk-webkit");
     expect(schema.properties.manifestSignature.const).toBe(
       MANIFEST_SIGNATURE_NAME,
     );
-    expect(schema.required).toEqual([
-      "schemaVersion",
-      "sourceCommit",
-      "version",
-      "architecture",
-      "shell",
-      "archive",
-      "sha256",
-      "signature",
-      "manifestSignature",
-      "entrypoints",
-      "capabilities",
-    ]);
-    expect(Object.keys(schema.properties.capabilities.properties)).toEqual([
-      "tray",
-      "overlay",
-      "wayland",
-      "cloudAuth",
-      "computerUse",
-      "remoteControl",
-    ]);
+  });
+
+  it("validates every schema-declared field, not a hand-picked subset", () => {
+    const schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf8"));
+    const walk = (node: Record<string, unknown>, prefix: string): string[] =>
+      ((node.required as string[]) ?? []).flatMap((key) => {
+        const child = (node.properties as Record<string, never>)[key] as
+          | Record<string, unknown>
+          | undefined;
+        const here = prefix ? `${prefix}.${key}` : key;
+        return [here, ...(child?.type === "object" ? walk(child, here) : [])];
+      });
+    const allRequired = walk(schema, "");
+    expect(allRequired.length).toBe(20);
+    const { outDir } = produce("x86_64");
+    const pristine = readFileSync(path.join(outDir, MANIFEST_NAME), "utf8");
+    for (const dotted of allRequired) {
+      const manifest = JSON.parse(pristine);
+      const parts = dotted.split(".");
+      let cursor = manifest;
+      for (const part of parts.slice(0, -1)) cursor = cursor[part];
+      delete cursor[parts[parts.length - 1]];
+      expect(manifestViolations(manifest)).toContain(
+        `missing required field "${dotted}"`,
+      );
+    }
+  });
+
+  it("pins the vendored OS schema bytes and fails on any drift", () => {
+    const bytes = readFileSync(SCHEMA_PATH);
+    expect(createHash("sha256").update(bytes).digest("hex")).toBe(
+      VENDORED_SCHEMA_SHA256,
+    );
+    // Even a semantically neutral edit is drift the pin must reject.
+    const drifted = Buffer.concat([bytes, Buffer.from("\n")]);
+    expect(createHash("sha256").update(drifted).digest("hex")).not.toBe(
+      VENDORED_SCHEMA_SHA256,
+    );
+  });
+});
+
+/** Replaces the archive in `outDir` and re-signs everything with the real key. */
+function resignWithArchiveFrom(
+  outDir: string,
+  stage: string,
+  privateKeyPem: string,
+): void {
+  const manifestPath = path.join(outDir, MANIFEST_NAME);
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const archivePath = path.join(outDir, manifest.archive);
+  unlinkSync(archivePath);
+  execFileSync("tar", ["--zstd", "-cf", archivePath, "-C", stage, "."]);
+  const archiveBytes = readFileSync(archivePath);
+  manifest.sha256 = createHash("sha256").update(archiveBytes).digest("hex");
+  writeFileSync(
+    path.join(outDir, manifest.signature),
+    signBytes(privateKeyPem, archiveBytes),
+  );
+  const manifestBytes = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
+  writeFileSync(manifestPath, manifestBytes);
+  writeFileSync(
+    path.join(outDir, MANIFEST_SIGNATURE_NAME),
+    signBytes(privateKeyPem, manifestBytes),
+  );
+}
+
+describe("signed archives with an off-contract entrypoint", () => {
+  it("rejects an entrypoint that is not executable in the archive", () => {
+    const { outDir, publicKeyPem, privateKeyPem } = produce("x86_64");
+    const rogue = stageShell();
+    chmodSync(path.join(rogue, "bin", "eliza-agent"), 0o644);
+    resignWithArchiveFrom(outDir, rogue, privateKeyPem);
+    expect(() => verifyArtifactDir(outDir, publicKeyPem)).toThrow(
+      /not executable in the archive/,
+    );
+  });
+
+  it("rejects an entrypoint that is a directory in the archive", () => {
+    const { outDir, publicKeyPem, privateKeyPem } = produce("arm64");
+    const rogue = stageShell();
+    const entry = path.join(rogue, "bin", "eliza-desktop");
+    unlinkSync(entry);
+    mkdirSync(entry);
+    resignWithArchiveFrom(outDir, rogue, privateKeyPem);
+    expect(() => verifyArtifactDir(outDir, publicKeyPem)).toThrow(
+      /is not a regular archive file/,
+    );
+  });
+
+  it("rejects an entrypoint that is an absolute symlink in the archive", () => {
+    const { outDir, publicKeyPem, privateKeyPem } = produce("riscv64");
+    const rogue = stageShell();
+    const entry = path.join(rogue, "bin", "eliza-desktop");
+    unlinkSync(entry);
+    symlinkSync("/bin/true", entry);
+    resignWithArchiveFrom(outDir, rogue, privateKeyPem);
+    expect(() => verifyArtifactDir(outDir, publicKeyPem)).toThrow(
+      ArtifactContractError,
+    );
+  });
+
+  it("rejects an entrypoint that is a relative in-tree symlink", () => {
+    const { outDir, publicKeyPem, privateKeyPem } = produce("x86_64");
+    const rogue = stageShell();
+    mkdirSync(path.join(rogue, "libexec"), { recursive: true });
+    const real = path.join(rogue, "libexec", "eliza-desktop.real");
+    writeFileSync(real, "#!/bin/sh\necho real\n");
+    chmodSync(real, 0o755);
+    const entry = path.join(rogue, "bin", "eliza-desktop");
+    unlinkSync(entry);
+    symlinkSync("../libexec/eliza-desktop.real", entry);
+    resignWithArchiveFrom(outDir, rogue, privateKeyPem);
+    // Rejected as an unsafe traversing link target before the entrypoint
+    // check; either refusal is the contract, a verified symlink is not.
+    expect(() => verifyArtifactDir(outDir, publicKeyPem)).toThrow(
+      ArtifactContractError,
+    );
+  });
+
+  it("rejects an entrypoint whose archive symlink dangles", () => {
+    const { outDir, publicKeyPem, privateKeyPem } = produce("arm64");
+    const rogue = stageShell();
+    const entry = path.join(rogue, "bin", "eliza-desktop");
+    unlinkSync(entry);
+    symlinkSync("./gone", entry);
+    resignWithArchiveFrom(outDir, rogue, privateKeyPem);
+    expect(() => verifyArtifactDir(outDir, publicKeyPem)).toThrow(
+      /is not a regular archive file/,
+    );
   });
 });

--- a/packages/app-core/scripts/__tests__/package-linux-gtk-artifact.test.ts
+++ b/packages/app-core/scripts/__tests__/package-linux-gtk-artifact.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Contract tests for the Linux GTK/WebKit desktop artifact producer and
+ * verifier. The harness is real: it stages fake shell binaries on disk,
+ * produces genuine tar.zst archives via the system tar, signs with real
+ * Ed25519 keys, and asserts that tampering with any byte of the archive or
+ * manifest is rejected. It also pins the vendored manifest schema to the
+ * fields the validator enforces so cross-repository drift is caught here.
+ */
+
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ARCHITECTURES,
+  ArtifactContractError,
+  assertValidManifest,
+  generateSigningKeyPair,
+  listArchiveMembers,
+  MANIFEST_NAME,
+  MANIFEST_SIGNATURE_NAME,
+  manifestViolations,
+  produceArtifact,
+  SCHEMA_PATH,
+  verifyArtifactDir,
+} from "../package-linux-gtk-artifact.mjs";
+
+const tempDirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "linux-gtk-artifact-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const COMMIT = "a".repeat(40);
+
+function stageShell(): string {
+  const stage = tempDir();
+  mkdirSync(path.join(stage, "bin"), { recursive: true });
+  mkdirSync(path.join(stage, "share"), { recursive: true });
+  for (const name of ["eliza-desktop", "eliza-agent", "eliza-desktop-doctor"]) {
+    const file = path.join(stage, "bin", name);
+    writeFileSync(file, `#!/bin/sh\necho ${name}\n`);
+    chmodSync(file, 0o755);
+  }
+  writeFileSync(path.join(stage, "share", "renderer.txt"), "renderer payload");
+  return stage;
+}
+
+function produce(
+  architecture: string,
+  overrides: Record<string, unknown> = {},
+) {
+  const { privateKeyPem, publicKeyPem } = generateSigningKeyPair();
+  const outDir = tempDir();
+  const result = produceArtifact({
+    stageDir: stageShell(),
+    outDir,
+    privateKeyPem,
+    version: "1.2.3",
+    architecture,
+    sourceCommit: COMMIT,
+    ...overrides,
+  });
+  return { result, outDir, publicKeyPem, privateKeyPem };
+}
+
+describe("produceArtifact", () => {
+  it("emits a verifiable artifact set for every supported architecture", () => {
+    for (const architecture of ARCHITECTURES) {
+      const { outDir, publicKeyPem } = produce(architecture);
+      const manifest = verifyArtifactDir(outDir, publicKeyPem);
+      expect(manifest.architecture).toBe(architecture);
+      expect(manifest.shell).toBe("gtk-webkit");
+      expect(manifest.archive).toBe(
+        `eliza-desktop-gtk-1.2.3-${architecture}.tar.zst`,
+      );
+      expect(manifest.manifestSignature).toBe(MANIFEST_SIGNATURE_NAME);
+    }
+  });
+
+  it("packages the staged tree with bin entrypoints as archive members", () => {
+    const { result } = produce("x86_64");
+    const members = listArchiveMembers(result.archivePath);
+    expect(members).toContain("bin/eliza-desktop");
+    expect(members).toContain("bin/eliza-agent");
+    expect(members).toContain("bin/eliza-desktop-doctor");
+    expect(members).toContain("share/renderer.txt");
+  });
+
+  it("refuses a stage with a missing entrypoint", () => {
+    const stage = stageShell();
+    rmSync(path.join(stage, "bin", "eliza-desktop-doctor"));
+    const { privateKeyPem } = generateSigningKeyPair();
+    expect(() =>
+      produceArtifact({
+        stageDir: stage,
+        outDir: tempDir(),
+        privateKeyPem,
+        version: "1.2.3",
+        architecture: "arm64",
+        sourceCommit: COMMIT,
+      }),
+    ).toThrow(ArtifactContractError);
+  });
+
+  it("refuses a non-executable entrypoint", () => {
+    const stage = stageShell();
+    chmodSync(path.join(stage, "bin", "eliza-agent"), 0o644);
+    const { privateKeyPem } = generateSigningKeyPair();
+    expect(() =>
+      produceArtifact({
+        stageDir: stage,
+        outDir: tempDir(),
+        privateKeyPem,
+        version: "1.2.3",
+        architecture: "riscv64",
+        sourceCommit: COMMIT,
+      }),
+    ).toThrow(/not executable/);
+  });
+
+  it("refuses unsupported architectures and malformed versions", () => {
+    expect(() => produce("amd64")).toThrow(/unsupported architecture/);
+    expect(() => produce("x86_64", { version: "1.2" })).toThrow(
+      /invalid version/,
+    );
+    expect(() => produce("x86_64", { sourceCommit: "deadbeef" })).toThrow(
+      /invalid sourceCommit/,
+    );
+  });
+});
+
+describe("verifyArtifactDir", () => {
+  it("rejects a tampered archive byte", () => {
+    const { result, outDir, publicKeyPem } = produce("x86_64");
+    const bytes = readFileSync(result.archivePath);
+    bytes[bytes.length - 1] ^= 0xff;
+    writeFileSync(result.archivePath, bytes);
+    expect(() => verifyArtifactDir(outDir, publicKeyPem)).toThrow(
+      /digest mismatch/,
+    );
+  });
+
+  it("rejects a tampered manifest even when the digest still matches", () => {
+    const { outDir, publicKeyPem } = produce("arm64");
+    const manifestPath = path.join(outDir, MANIFEST_NAME);
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    manifest.version = "9.9.9";
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    expect(() => verifyArtifactDir(outDir, publicKeyPem)).toThrow(
+      /manifest signature does not verify/,
+    );
+  });
+
+  it("rejects an archive signature made by a different key", () => {
+    const { result, outDir, publicKeyPem } = produce("riscv64");
+    const other = produce("riscv64");
+    writeFileSync(
+      result.archiveSignaturePath,
+      readFileSync(other.result.archiveSignaturePath),
+    );
+    // Digest still matches the untouched archive; only the signature is wrong.
+    expect(() => verifyArtifactDir(outDir, publicKeyPem)).toThrow(
+      /archive signature does not verify/,
+    );
+  });
+
+  it("rejects verification with the wrong public key", () => {
+    const { outDir } = produce("x86_64");
+    const stranger = generateSigningKeyPair();
+    expect(() => verifyArtifactDir(outDir, stranger.publicKeyPem)).toThrow(
+      /manifest signature does not verify/,
+    );
+  });
+});
+
+describe("manifest schema contract", () => {
+  it("accepts a manifest that satisfies the vendored schema", () => {
+    const { outDir } = produce("x86_64");
+    const manifest = JSON.parse(
+      readFileSync(path.join(outDir, MANIFEST_NAME), "utf8"),
+    );
+    expect(manifestViolations(manifest)).toEqual([]);
+    expect(() => assertValidManifest(manifest)).not.toThrow();
+  });
+
+  it("flags every contract violation", () => {
+    const bad = {
+      schemaVersion: 2,
+      sourceCommit: "nothex",
+      version: "1.2",
+      architecture: "amd64",
+      shell: "electron",
+      archive: "a.tar.gz",
+      sha256: "short",
+      signature: "sig.txt",
+      manifestSignature: "other.sig",
+      entrypoints: { desktop: "usr/bin/x", agent: "bin/ok", extra: "bin/y" },
+      capabilities: { tray: false },
+      unexpected: true,
+    };
+    const problems = manifestViolations(bad);
+    expect(problems).toEqual(
+      expect.arrayContaining([
+        "schemaVersion must be 1",
+        'unknown field "unexpected"',
+        'shell must be "gtk-webkit"',
+        "architecture must be one of x86_64, arm64, riscv64",
+        "archive must be a bare *.tar.zst filename",
+        "entrypoints.desktop must match bin/<name>",
+        "entrypoints.doctor must match bin/<name>",
+        'unknown entrypoint "extra"',
+        "capabilities.tray must be true",
+        "capabilities.overlay must be true",
+      ]),
+    );
+  });
+
+  it("keeps the vendored schema aligned with the validator", () => {
+    const schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf8"));
+    expect(schema.properties.architecture.enum).toEqual(ARCHITECTURES);
+    expect(schema.properties.shell.const).toBe("gtk-webkit");
+    expect(schema.properties.manifestSignature.const).toBe(
+      MANIFEST_SIGNATURE_NAME,
+    );
+    expect(schema.required).toEqual([
+      "schemaVersion",
+      "sourceCommit",
+      "version",
+      "architecture",
+      "shell",
+      "archive",
+      "sha256",
+      "signature",
+      "manifestSignature",
+      "entrypoints",
+      "capabilities",
+    ]);
+    expect(Object.keys(schema.properties.capabilities.properties)).toEqual([
+      "tray",
+      "overlay",
+      "wayland",
+      "cloudAuth",
+      "computerUse",
+      "remoteControl",
+    ]);
+  });
+});

--- a/packages/app-core/scripts/__tests__/package-linux-gtk-artifact.test.ts
+++ b/packages/app-core/scripts/__tests__/package-linux-gtk-artifact.test.ts
@@ -7,12 +7,17 @@
  * fields the validator enforces so cross-repository drift is caught here.
  */
 
+import { generateKeyPairSync } from "node:crypto";
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  renameSync,
   rmSync,
+  statSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
@@ -30,6 +35,7 @@ import {
   produceArtifact,
   SCHEMA_PATH,
   verifyArtifactDir,
+  writeSigningKeyPair,
 } from "../package-linux-gtk-artifact.mjs";
 
 const tempDirs: string[] = [];
@@ -134,6 +140,132 @@ describe("produceArtifact", () => {
     ).toThrow(/not executable/);
   });
 
+  it("refuses an entrypoint symlink even when its target is executable", () => {
+    const stage = stageShell();
+    const entrypoint = path.join(stage, "bin", "eliza-agent");
+    rmSync(entrypoint);
+    const external = path.join(tempDir(), "external-agent");
+    writeFileSync(external, "#!/bin/sh\nexit 0\n");
+    chmodSync(external, 0o755);
+    symlinkSync(external, entrypoint);
+    const { privateKeyPem } = generateSigningKeyPair();
+    expect(() =>
+      produceArtifact({
+        stageDir: stage,
+        outDir: tempDir(),
+        privateKeyPem,
+        version: "1.2.3",
+        architecture: "x86_64",
+        sourceCommit: COMMIT,
+      }),
+    ).toThrow(/stage symlinks|regular non-symlink file/);
+  });
+
+  it("refuses an intermediate bin symlink and an escaping payload symlink", () => {
+    const externalStage = stageShell();
+    const stage = tempDir();
+    symlinkSync(path.join(externalStage, "bin"), path.join(stage, "bin"));
+    const { privateKeyPem } = generateSigningKeyPair();
+    expect(() =>
+      produceArtifact({
+        stageDir: stage,
+        outDir: tempDir(),
+        privateKeyPem,
+        version: "1.2.3",
+        architecture: "x86_64",
+        sourceCommit: COMMIT,
+      }),
+    ).toThrow(/stage symlinks must use a non-traversing relative target/);
+
+    const regularStage = stageShell();
+    symlinkSync("/etc/passwd", path.join(regularStage, "share", "escape"));
+    expect(() =>
+      produceArtifact({
+        stageDir: regularStage,
+        outDir: tempDir(),
+        privateKeyPem,
+        version: "1.2.3",
+        architecture: "x86_64",
+        sourceCommit: COMMIT,
+      }),
+    ).toThrow(/stage symlinks must use a non-traversing relative target/);
+  });
+
+  it("allows a non-traversing relative payload symlink", () => {
+    const stage = stageShell();
+    symlinkSync(
+      "renderer.txt",
+      path.join(stage, "share", "renderer-current.txt"),
+    );
+    const { privateKeyPem, publicKeyPem } = generateSigningKeyPair();
+    const outDir = tempDir();
+    produceArtifact({
+      stageDir: stage,
+      outDir,
+      privateKeyPem,
+      version: "1.2.3",
+      architecture: "x86_64",
+      sourceCommit: COMMIT,
+    });
+    expect(() => verifyArtifactDir(outDir, publicKeyPem)).not.toThrow();
+  });
+
+  it("refuses recursive output and existing artifact outputs", () => {
+    const stage = stageShell();
+    const { privateKeyPem } = generateSigningKeyPair();
+    expect(() =>
+      produceArtifact({
+        stageDir: stage,
+        outDir: path.join(stage, "artifacts"),
+        privateKeyPem,
+        version: "1.2.3",
+        architecture: "x86_64",
+        sourceCommit: COMMIT,
+      }),
+    ).toThrow(/must not be the stage directory/);
+
+    const outDir = tempDir();
+    const first = produceArtifact({
+      stageDir: stage,
+      outDir,
+      privateKeyPem,
+      version: "1.2.3",
+      architecture: "x86_64",
+      sourceCommit: COMMIT,
+    });
+    const originalArchive = readFileSync(first.archivePath);
+    expect(() =>
+      produceArtifact({
+        stageDir: stage,
+        outDir,
+        privateKeyPem,
+        version: "1.2.3",
+        architecture: "x86_64",
+        sourceCommit: COMMIT,
+      }),
+    ).toThrow(/refusing to overwrite existing artifact output/);
+    expect(readFileSync(first.archivePath)).toEqual(originalArchive);
+  });
+
+  it("refuses dangling output symlinks without creating their targets", () => {
+    const stage = stageShell();
+    const outDir = tempDir();
+    const externalTarget = path.join(tempDir(), "external-manifest.json");
+    symlinkSync(externalTarget, path.join(outDir, MANIFEST_NAME));
+    const { privateKeyPem } = generateSigningKeyPair();
+    expect(() =>
+      produceArtifact({
+        stageDir: stage,
+        outDir,
+        privateKeyPem,
+        version: "1.2.3",
+        architecture: "x86_64",
+        sourceCommit: COMMIT,
+      }),
+    ).toThrow(/refusing to overwrite existing artifact output/);
+    expect(existsSync(externalTarget)).toBe(false);
+  });
+
   it("refuses unsupported architectures and malformed versions", () => {
     expect(() => produce("amd64")).toThrow(/unsupported architecture/);
     expect(() => produce("x86_64", { version: "1.2" })).toThrow(
@@ -142,6 +274,69 @@ describe("produceArtifact", () => {
     expect(() => produce("x86_64", { sourceCommit: "deadbeef" })).toThrow(
       /invalid sourceCommit/,
     );
+  });
+
+  it("refuses a signing key from the wrong algorithm before emitting output", () => {
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const outDir = tempDir();
+    expect(() =>
+      produceArtifact({
+        stageDir: stageShell(),
+        outDir,
+        privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }),
+        version: "1.2.3",
+        architecture: "x86_64",
+        sourceCommit: COMMIT,
+      }),
+    ).toThrow(/signing key must be Ed25519/);
+    expect(() => readFileSync(path.join(outDir, MANIFEST_NAME))).toThrow();
+  });
+
+  it("translates malformed key input to a typed contract failure", () => {
+    const outDir = tempDir();
+    expect(() =>
+      produceArtifact({
+        stageDir: stageShell(),
+        outDir,
+        privateKeyPem: "not a private key",
+        version: "1.2.3",
+        architecture: "x86_64",
+        sourceCommit: COMMIT,
+      }),
+    ).toThrow(ArtifactContractError);
+    expect(() => readFileSync(path.join(outDir, MANIFEST_NAME))).toThrow();
+  });
+});
+
+describe("writeSigningKeyPair", () => {
+  it("creates a private key with mode 0600 and never overwrites it", () => {
+    const outDir = tempDir();
+    const { privateKeyPath } = writeSigningKeyPair(outDir);
+    const originalPrivateKey = readFileSync(privateKeyPath);
+    expect(statSync(privateKeyPath).mode & 0o777).toBe(0o600);
+    expect(() => writeSigningKeyPair(outDir)).toThrow(
+      /refusing to overwrite an existing desktop signing keypair/,
+    );
+    expect(readFileSync(privateKeyPath)).toEqual(originalPrivateKey);
+  });
+
+  it("rejects a public-key collision without leaving a half keypair", () => {
+    const outDir = tempDir();
+    const publicKeyPath = path.join(outDir, "desktop-signing.pub.pem");
+    writeFileSync(publicKeyPath, "existing public key");
+    expect(() => writeSigningKeyPair(outDir)).toThrow(/refusing to overwrite/);
+    expect(existsSync(path.join(outDir, "desktop-signing.key.pem"))).toBe(
+      false,
+    );
+    expect(readFileSync(publicKeyPath, "utf8")).toBe("existing public key");
+  });
+
+  it("rejects a dangling private-key symlink without creating its target", () => {
+    const outDir = tempDir();
+    const externalTarget = path.join(tempDir(), "external-private.pem");
+    symlinkSync(externalTarget, path.join(outDir, "desktop-signing.key.pem"));
+    expect(() => writeSigningKeyPair(outDir)).toThrow(/refusing to overwrite/);
+    expect(existsSync(externalTarget)).toBe(false);
   });
 });
 
@@ -185,6 +380,17 @@ describe("verifyArtifactDir", () => {
     const stranger = generateSigningKeyPair();
     expect(() => verifyArtifactDir(outDir, stranger.publicKeyPem)).toThrow(
       /manifest signature does not verify/,
+    );
+  });
+
+  it("rejects symlinked external contract files", () => {
+    const { outDir, publicKeyPem } = produce("x86_64");
+    const manifestPath = path.join(outDir, MANIFEST_NAME);
+    const externalManifest = path.join(tempDir(), MANIFEST_NAME);
+    renameSync(manifestPath, externalManifest);
+    symlinkSync(externalManifest, manifestPath);
+    expect(() => verifyArtifactDir(outDir, publicKeyPem)).toThrow(
+      /regular non-symlink file/,
     );
   });
 });

--- a/packages/app-core/scripts/package-linux-gtk-artifact.mjs
+++ b/packages/app-core/scripts/package-linux-gtk-artifact.mjs
@@ -1,0 +1,445 @@
+#!/usr/bin/env node
+/**
+ * Produces and verifies the signed Linux GTK/WebKit desktop artifact set that
+ * the elizaOS OS image consumes: one `<name>-<arch>.tar.zst` archive per
+ * architecture plus `desktop-artifact-manifest.json`, the fixed adjacent
+ * `desktop-artifact-manifest.json.sig` over the exact manifest bytes, and a
+ * manifest-named detached signature over the exact archive bytes — all
+ * Ed25519, matching `schemas/desktop-artifact-manifest.schema.json` (the
+ * vendored copy of `elizaOS/os:packages/os/linux/schemas/`; the OS repository
+ * owns the contract, this copy must track it byte-for-byte).
+ *
+ * The producer takes an already-built shell stage directory (the GTK shell
+ * build output containing `bin/` entrypoints) so the same command covers
+ * x86_64, arm64, and riscv64 cross-builds. It refuses to package a stage
+ * whose declared entrypoints are missing or non-executable, and the verifier
+ * re-derives every digest and signature from bytes rather than trusting the
+ * manifest. Refs elizaOS/eliza#21783.
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  sign as edSign,
+  verify as edVerify,
+  generateKeyPairSync,
+} from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+
+export const MANIFEST_NAME = "desktop-artifact-manifest.json";
+export const MANIFEST_SIGNATURE_NAME = "desktop-artifact-manifest.json.sig";
+export const SCHEMA_PATH = path.join(
+  scriptDir,
+  "schemas",
+  "desktop-artifact-manifest.schema.json",
+);
+
+export const ARCHITECTURES = ["x86_64", "arm64", "riscv64"];
+
+const VERSION_RE = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
+const COMMIT_RE = /^[a-f0-9]{40}$/;
+const SHA256_RE = /^[a-f0-9]{64}$/;
+const ARCHIVE_RE = /^[A-Za-z0-9._-]+\.tar\.zst$/;
+const SIGNATURE_RE = /^[A-Za-z0-9._-]+\.sig$/;
+const ENTRYPOINT_RE = /^bin\/[A-Za-z0-9._-]+$/;
+
+const REQUIRED_ENTRYPOINTS = ["desktop", "agent", "doctor"];
+const REQUIRED_CAPABILITIES = [
+  "tray",
+  "overlay",
+  "wayland",
+  "cloudAuth",
+  "computerUse",
+  "remoteControl",
+];
+
+/** Error type for every contract violation this module detects. */
+export class ArtifactContractError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ArtifactContractError";
+  }
+}
+
+function fail(message) {
+  throw new ArtifactContractError(message);
+}
+
+/** SHA-256 hex digest of a file's exact bytes. */
+export function sha256File(filePath) {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+/** Detached Ed25519 signature (raw 64 bytes) over `bytes`. */
+export function signBytes(privateKeyPem, bytes) {
+  return edSign(null, bytes, createPrivateKey(privateKeyPem));
+}
+
+/** Verifies a detached Ed25519 signature over `bytes`. */
+export function verifyBytes(publicKeyPem, bytes, signature) {
+  return edVerify(null, bytes, createPublicKey(publicKeyPem), signature);
+}
+
+/** Generates a PEM Ed25519 keypair for local/dev signing. */
+export function generateSigningKeyPair() {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  return {
+    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }),
+    publicKeyPem: publicKey.export({ type: "spki", format: "pem" }),
+  };
+}
+
+/**
+ * Validates a parsed manifest object against the vendored schema contract.
+ * Returns the list of violations (empty when valid); `assertValidManifest`
+ * throws instead.
+ */
+export function manifestViolations(manifest) {
+  const problems = [];
+  if (typeof manifest !== "object" || manifest === null) {
+    return ["manifest is not an object"];
+  }
+  const allowedTop = [
+    "schemaVersion",
+    "sourceCommit",
+    "version",
+    "architecture",
+    "shell",
+    "archive",
+    "sha256",
+    "signature",
+    "manifestSignature",
+    "entrypoints",
+    "capabilities",
+  ];
+  for (const key of allowedTop) {
+    if (!(key in manifest)) problems.push(`missing required field "${key}"`);
+  }
+  for (const key of Object.keys(manifest)) {
+    if (!allowedTop.includes(key)) problems.push(`unknown field "${key}"`);
+  }
+  if (manifest.schemaVersion !== 1) problems.push("schemaVersion must be 1");
+  if (!COMMIT_RE.test(String(manifest.sourceCommit ?? ""))) {
+    problems.push("sourceCommit must be a 40-char lowercase hex commit");
+  }
+  if (!VERSION_RE.test(String(manifest.version ?? ""))) {
+    problems.push("version must be semver (x.y.z with optional prerelease)");
+  }
+  if (!ARCHITECTURES.includes(manifest.architecture)) {
+    problems.push(`architecture must be one of ${ARCHITECTURES.join(", ")}`);
+  }
+  if (manifest.shell !== "gtk-webkit") {
+    problems.push('shell must be "gtk-webkit"');
+  }
+  if (!ARCHIVE_RE.test(String(manifest.archive ?? ""))) {
+    problems.push("archive must be a bare *.tar.zst filename");
+  }
+  if (!SHA256_RE.test(String(manifest.sha256 ?? ""))) {
+    problems.push("sha256 must be a 64-char lowercase hex digest");
+  }
+  if (!SIGNATURE_RE.test(String(manifest.signature ?? ""))) {
+    problems.push("signature must be a bare *.sig filename");
+  }
+  if (manifest.manifestSignature !== MANIFEST_SIGNATURE_NAME) {
+    problems.push(`manifestSignature must be "${MANIFEST_SIGNATURE_NAME}"`);
+  }
+  const entrypoints = manifest.entrypoints;
+  if (typeof entrypoints !== "object" || entrypoints === null) {
+    problems.push("entrypoints must be an object");
+  } else {
+    for (const key of REQUIRED_ENTRYPOINTS) {
+      if (!ENTRYPOINT_RE.test(String(entrypoints[key] ?? ""))) {
+        problems.push(`entrypoints.${key} must match bin/<name>`);
+      }
+    }
+    for (const key of Object.keys(entrypoints)) {
+      if (!REQUIRED_ENTRYPOINTS.includes(key)) {
+        problems.push(`unknown entrypoint "${key}"`);
+      }
+    }
+  }
+  const capabilities = manifest.capabilities;
+  if (typeof capabilities !== "object" || capabilities === null) {
+    problems.push("capabilities must be an object");
+  } else {
+    for (const key of REQUIRED_CAPABILITIES) {
+      if (capabilities[key] !== true) {
+        problems.push(`capabilities.${key} must be true`);
+      }
+    }
+    for (const key of Object.keys(capabilities)) {
+      if (!REQUIRED_CAPABILITIES.includes(key)) {
+        problems.push(`unknown capability "${key}"`);
+      }
+    }
+  }
+  return problems;
+}
+
+/** Throws ArtifactContractError listing every schema violation. */
+export function assertValidManifest(manifest) {
+  const problems = manifestViolations(manifest);
+  if (problems.length > 0) {
+    fail(
+      `manifest violates the desktop artifact contract:\n- ${problems.join("\n- ")}`,
+    );
+  }
+}
+
+/**
+ * Asserts every declared entrypoint exists in the stage directory as an
+ * executable regular file. Entrypoint paths are manifest-relative (bin/...).
+ */
+export function assertStageEntrypoints(stageDir, entrypoints) {
+  for (const key of REQUIRED_ENTRYPOINTS) {
+    const rel = entrypoints[key];
+    if (!ENTRYPOINT_RE.test(String(rel ?? ""))) {
+      fail(`entrypoints.${key} "${rel}" does not match bin/<name>`);
+    }
+    const full = path.join(stageDir, rel);
+    if (!existsSync(full)) {
+      fail(`entrypoint ${key} missing from stage: ${rel}`);
+    }
+    const stats = statSync(full);
+    if (!stats.isFile()) {
+      fail(`entrypoint ${key} is not a regular file: ${rel}`);
+    }
+    if ((stats.mode & 0o111) === 0) {
+      fail(`entrypoint ${key} is not executable: ${rel}`);
+    }
+  }
+}
+
+function runTar(args) {
+  execFileSync("tar", args, { stdio: ["ignore", "pipe", "inherit"] });
+}
+
+/** Lists archive member paths, normalized without a leading "./". */
+export function listArchiveMembers(archivePath) {
+  const out = execFileSync("tar", ["--zstd", "-tf", archivePath], {
+    encoding: "utf8",
+  });
+  return out
+    .split("\n")
+    .map((line) => line.replace(/^\.\//, "").replace(/\/$/, ""))
+    .filter((line) => line.length > 0 && line !== ".");
+}
+
+/**
+ * Packages a staged shell build into the signed artifact set. Returns the
+ * absolute paths of the four emitted files.
+ */
+export function produceArtifact({
+  stageDir,
+  outDir,
+  privateKeyPem,
+  version,
+  architecture,
+  sourceCommit,
+  artifactBaseName = "eliza-desktop-gtk",
+  entrypoints = {
+    desktop: "bin/eliza-desktop",
+    agent: "bin/eliza-agent",
+    doctor: "bin/eliza-desktop-doctor",
+  },
+}) {
+  if (!ARCHITECTURES.includes(architecture)) {
+    fail(`unsupported architecture "${architecture}"`);
+  }
+  if (!VERSION_RE.test(version)) fail(`invalid version "${version}"`);
+  if (!COMMIT_RE.test(sourceCommit)) {
+    fail(`invalid sourceCommit "${sourceCommit}"`);
+  }
+  if (!existsSync(stageDir) || !statSync(stageDir).isDirectory()) {
+    fail(`stage directory does not exist: ${stageDir}`);
+  }
+  assertStageEntrypoints(stageDir, entrypoints);
+
+  mkdirSync(outDir, { recursive: true });
+  const archiveName = `${artifactBaseName}-${version}-${architecture}.tar.zst`;
+  if (!ARCHIVE_RE.test(archiveName)) {
+    fail(`derived archive name "${archiveName}" violates the contract`);
+  }
+  const archivePath = path.join(outDir, archiveName);
+  runTar(["--zstd", "-cf", archivePath, "-C", stageDir, "."]);
+
+  const archiveBytes = readFileSync(archivePath);
+  const archiveDigest = createHash("sha256").update(archiveBytes).digest("hex");
+  const archiveSignatureName = `${archiveName.replace(/\.tar\.zst$/, "")}.sig`;
+  writeFileSync(
+    path.join(outDir, archiveSignatureName),
+    signBytes(privateKeyPem, archiveBytes),
+  );
+
+  const manifest = {
+    schemaVersion: 1,
+    sourceCommit,
+    version,
+    architecture,
+    shell: "gtk-webkit",
+    archive: archiveName,
+    sha256: archiveDigest,
+    signature: archiveSignatureName,
+    manifestSignature: MANIFEST_SIGNATURE_NAME,
+    entrypoints,
+    capabilities: {
+      tray: true,
+      overlay: true,
+      wayland: true,
+      cloudAuth: true,
+      computerUse: true,
+      remoteControl: true,
+    },
+  };
+  assertValidManifest(manifest);
+
+  const manifestBytes = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
+  const manifestPath = path.join(outDir, MANIFEST_NAME);
+  writeFileSync(manifestPath, manifestBytes);
+  writeFileSync(
+    path.join(outDir, MANIFEST_SIGNATURE_NAME),
+    signBytes(privateKeyPem, manifestBytes),
+  );
+
+  return {
+    archivePath,
+    archiveSignaturePath: path.join(outDir, archiveSignatureName),
+    manifestPath,
+    manifestSignaturePath: path.join(outDir, MANIFEST_SIGNATURE_NAME),
+  };
+}
+
+/**
+ * Fully verifies an artifact directory: schema validity, manifest signature
+ * over exact manifest bytes, archive digest, archive signature over exact
+ * archive bytes, and presence of every declared entrypoint in the archive.
+ * Throws ArtifactContractError on the first failure; returns the manifest.
+ */
+export function verifyArtifactDir(outDir, publicKeyPem) {
+  const manifestPath = path.join(outDir, MANIFEST_NAME);
+  if (!existsSync(manifestPath)) fail(`missing ${MANIFEST_NAME} in ${outDir}`);
+  const manifestBytes = readFileSync(manifestPath);
+  let manifest;
+  try {
+    manifest = JSON.parse(manifestBytes.toString("utf8"));
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow: name the file that failed to parse.
+    throw new ArtifactContractError(
+      `${MANIFEST_NAME} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  assertValidManifest(manifest);
+
+  const manifestSigPath = path.join(outDir, MANIFEST_SIGNATURE_NAME);
+  if (!existsSync(manifestSigPath)) {
+    fail(`missing ${MANIFEST_SIGNATURE_NAME} next to the manifest`);
+  }
+  if (
+    !verifyBytes(publicKeyPem, manifestBytes, readFileSync(manifestSigPath))
+  ) {
+    fail("manifest signature does not verify over the exact manifest bytes");
+  }
+
+  const archivePath = path.join(outDir, manifest.archive);
+  if (!existsSync(archivePath)) fail(`missing archive ${manifest.archive}`);
+  const archiveBytes = readFileSync(archivePath);
+  const digest = createHash("sha256").update(archiveBytes).digest("hex");
+  if (digest !== manifest.sha256) {
+    fail(
+      `archive digest mismatch: manifest says ${manifest.sha256}, archive is ${digest}`,
+    );
+  }
+  const archiveSigPath = path.join(outDir, manifest.signature);
+  if (!existsSync(archiveSigPath)) {
+    fail(`missing archive signature ${manifest.signature}`);
+  }
+  if (!verifyBytes(publicKeyPem, archiveBytes, readFileSync(archiveSigPath))) {
+    fail("archive signature does not verify over the exact archive bytes");
+  }
+
+  const members = new Set(listArchiveMembers(archivePath));
+  for (const key of REQUIRED_ENTRYPOINTS) {
+    if (!members.has(manifest.entrypoints[key])) {
+      fail(
+        `entrypoint ${key} (${manifest.entrypoints[key]}) is not present in the archive`,
+      );
+    }
+  }
+  return manifest;
+}
+
+function parseArgs(argv) {
+  const args = new Map();
+  for (const arg of argv) {
+    const [key, ...rest] = arg.replace(/^--/, "").split("=");
+    args.set(key, rest.join("=") || "true");
+  }
+  return args;
+}
+
+function cliMain() {
+  const [command, ...rest] = process.argv.slice(2);
+  const args = parseArgs(rest);
+  if (command === "produce") {
+    const keyPath = args.get("key");
+    if (!keyPath) fail("--key=<ed25519-private-key.pem> is required");
+    const sourceCommit =
+      args.get("source-commit") ??
+      execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+    const result = produceArtifact({
+      stageDir: path.resolve(args.get("stage") ?? ""),
+      outDir: path.resolve(args.get("out") ?? ""),
+      privateKeyPem: readFileSync(keyPath, "utf8"),
+      version: args.get("version") ?? "",
+      architecture: args.get("arch") ?? "",
+      sourceCommit,
+    });
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+  if (command === "verify") {
+    const pubPath = args.get("public-key");
+    if (!pubPath) fail("--public-key=<ed25519-public-key.pem> is required");
+    const manifest = verifyArtifactDir(
+      path.resolve(args.get("dir") ?? ""),
+      readFileSync(pubPath, "utf8"),
+    );
+    process.stdout.write(
+      `verified ${manifest.archive} (${manifest.architecture}) at schema v${manifest.schemaVersion}\n`,
+    );
+    return;
+  }
+  if (command === "generate-key") {
+    const outDir = path.resolve(args.get("out") ?? ".");
+    mkdirSync(outDir, { recursive: true });
+    const { privateKeyPem, publicKeyPem } = generateSigningKeyPair();
+    writeFileSync(path.join(outDir, "desktop-signing.key.pem"), privateKeyPem, {
+      mode: 0o600,
+    });
+    writeFileSync(path.join(outDir, "desktop-signing.pub.pem"), publicKeyPem);
+    process.stdout.write(`wrote Ed25519 keypair under ${outDir}\n`);
+    return;
+  }
+  fail(
+    "usage: package-linux-gtk-artifact.mjs <produce|verify|generate-key> [--stage= --out= --key= --version= --arch= | --dir= --public-key=]",
+  );
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  cliMain();
+}

--- a/packages/app-core/scripts/package-linux-gtk-artifact.mjs
+++ b/packages/app-core/scripts/package-linux-gtk-artifact.mjs
@@ -46,31 +46,18 @@ import { fileURLToPath } from "node:url";
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 
 export const MANIFEST_NAME = "desktop-artifact-manifest.json";
-export const MANIFEST_SIGNATURE_NAME = "desktop-artifact-manifest.json.sig";
 export const SCHEMA_PATH = path.join(
   scriptDir,
   "schemas",
   "desktop-artifact-manifest.schema.json",
 );
 
-export const ARCHITECTURES = ["x86_64", "arm64", "riscv64"];
-
-const VERSION_RE = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/;
-const COMMIT_RE = /^[a-f0-9]{40}$/;
-const SHA256_RE = /^[a-f0-9]{64}$/;
-const ARCHIVE_RE = /^[A-Za-z0-9._-]+\.tar\.zst$/;
-const SIGNATURE_RE = /^[A-Za-z0-9._-]+\.sig$/;
-const ENTRYPOINT_RE = /^bin\/[A-Za-z0-9._-]+$/;
-
-const REQUIRED_ENTRYPOINTS = ["desktop", "agent", "doctor"];
-const REQUIRED_CAPABILITIES = [
-  "tray",
-  "overlay",
-  "wayland",
-  "cloudAuth",
-  "computerUse",
-  "remoteControl",
-];
+/**
+ * SHA-256 of the authoritative OS-owned schema bytes. Re-pin this only when
+ * the vendored copy is deliberately resynchronised with `elizaOS/os`.
+ */
+export const VENDORED_SCHEMA_SHA256 =
+  "4e0051f4918f4c37b604727b46693c1ffedd0b29a380366b0f9897a061f84203";
 
 /** Error type for every contract violation this module detects. */
 export class ArtifactContractError extends Error {
@@ -83,6 +70,36 @@ export class ArtifactContractError extends Error {
 function fail(message) {
   throw new ArtifactContractError(message);
 }
+
+/**
+ * Reads the vendored schema, refusing any drift from the pinned OS-owned
+ * bytes. Producer and verifier entry points call this first, so the validator
+ * generated from it can never come from an unreviewed contract.
+ */
+export function readVendoredSchema() {
+  assertRegularFile(SCHEMA_PATH, "vendored manifest schema");
+  const bytes = readFileSync(SCHEMA_PATH);
+  const digest = createHash("sha256").update(bytes).digest("hex");
+  if (digest !== VENDORED_SCHEMA_SHA256) {
+    fail(
+      `vendored manifest schema drifted from the pinned elizaOS/os bytes: expected sha256 ${VENDORED_SCHEMA_SHA256}, found ${digest}. Resynchronise with elizaOS/os and re-pin VENDORED_SCHEMA_SHA256.`,
+    );
+  }
+  return JSON.parse(bytes.toString("utf8"));
+}
+
+const SCHEMA = readVendoredSchema();
+
+export const ARCHITECTURES = SCHEMA.properties.architecture.enum;
+export const MANIFEST_SIGNATURE_NAME =
+  SCHEMA.properties.manifestSignature.const;
+const REQUIRED_ENTRYPOINTS = SCHEMA.properties.entrypoints.required;
+const VERSION_RE = new RegExp(SCHEMA.properties.version.pattern);
+const COMMIT_RE = new RegExp(SCHEMA.properties.sourceCommit.pattern);
+const ARCHIVE_RE = new RegExp(SCHEMA.properties.archive.pattern);
+const ENTRYPOINT_RE = new RegExp(
+  SCHEMA.properties.entrypoints.properties[REQUIRED_ENTRYPOINTS[0]].pattern,
+);
 
 function pathEntryExists(filePath) {
   try {
@@ -268,89 +285,66 @@ export function writeSigningKeyPair(outDir) {
 }
 
 /**
+ * Applies the subset of JSON-Schema keywords the vendored contract uses
+ * (`type`, `const`, `enum`, `pattern`, `required`, `properties`, and
+ * `additionalProperties: false`) to `value`, appending one message per
+ * violation. Generating validation from the schema document is what keeps the
+ * validator and the cross-repository contract from diverging field by field.
+ */
+function collectViolations(schema, value, label, problems) {
+  const qualify = (key) => (label ? `${label}.${key}` : key);
+  const name = label || "manifest";
+
+  if (schema.type === "object") {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      problems.push(`${name} must be an object`);
+      return;
+    }
+    for (const key of schema.required ?? []) {
+      if (!(key in value)) {
+        problems.push(`missing required field "${qualify(key)}"`);
+      }
+    }
+    if (schema.additionalProperties === false) {
+      for (const key of Object.keys(value)) {
+        if (!(key in (schema.properties ?? {}))) {
+          problems.push(`unknown field "${qualify(key)}"`);
+        }
+      }
+    }
+    for (const [key, childSchema] of Object.entries(schema.properties ?? {})) {
+      if (key in value) {
+        collectViolations(childSchema, value[key], qualify(key), problems);
+      }
+    }
+    return;
+  }
+
+  if ("const" in schema && value !== schema.const) {
+    problems.push(`${name} must equal ${JSON.stringify(schema.const)}`);
+    return;
+  }
+  if (Array.isArray(schema.enum) && !schema.enum.includes(value)) {
+    problems.push(`${name} must be one of ${schema.enum.join(", ")}`);
+    return;
+  }
+  if (schema.type === "string" && typeof value !== "string") {
+    problems.push(`${name} must be a string`);
+    return;
+  }
+  if (schema.pattern && !new RegExp(schema.pattern).test(String(value))) {
+    problems.push(`${name} must match /${schema.pattern}/`);
+  }
+}
+
+/**
  * Validates a parsed manifest object against the vendored schema contract.
  * Returns the list of violations (empty when valid); `assertValidManifest`
  * throws instead.
  */
 export function manifestViolations(manifest) {
   const problems = [];
-  if (typeof manifest !== "object" || manifest === null) {
-    return ["manifest is not an object"];
-  }
-  const allowedTop = [
-    "schemaVersion",
-    "sourceCommit",
-    "version",
-    "architecture",
-    "shell",
-    "archive",
-    "sha256",
-    "signature",
-    "manifestSignature",
-    "entrypoints",
-    "capabilities",
-  ];
-  for (const key of allowedTop) {
-    if (!(key in manifest)) problems.push(`missing required field "${key}"`);
-  }
-  for (const key of Object.keys(manifest)) {
-    if (!allowedTop.includes(key)) problems.push(`unknown field "${key}"`);
-  }
-  if (manifest.schemaVersion !== 1) problems.push("schemaVersion must be 1");
-  if (!COMMIT_RE.test(String(manifest.sourceCommit ?? ""))) {
-    problems.push("sourceCommit must be a 40-char lowercase hex commit");
-  }
-  if (!VERSION_RE.test(String(manifest.version ?? ""))) {
-    problems.push("version must be semver (x.y.z with optional prerelease)");
-  }
-  if (!ARCHITECTURES.includes(manifest.architecture)) {
-    problems.push(`architecture must be one of ${ARCHITECTURES.join(", ")}`);
-  }
-  if (manifest.shell !== "gtk-webkit") {
-    problems.push('shell must be "gtk-webkit"');
-  }
-  if (!ARCHIVE_RE.test(String(manifest.archive ?? ""))) {
-    problems.push("archive must be a bare *.tar.zst filename");
-  }
-  if (!SHA256_RE.test(String(manifest.sha256 ?? ""))) {
-    problems.push("sha256 must be a 64-char lowercase hex digest");
-  }
-  if (!SIGNATURE_RE.test(String(manifest.signature ?? ""))) {
-    problems.push("signature must be a bare *.sig filename");
-  }
-  if (manifest.manifestSignature !== MANIFEST_SIGNATURE_NAME) {
-    problems.push(`manifestSignature must be "${MANIFEST_SIGNATURE_NAME}"`);
-  }
-  const entrypoints = manifest.entrypoints;
-  if (typeof entrypoints !== "object" || entrypoints === null) {
-    problems.push("entrypoints must be an object");
-  } else {
-    for (const key of REQUIRED_ENTRYPOINTS) {
-      if (!ENTRYPOINT_RE.test(String(entrypoints[key] ?? ""))) {
-        problems.push(`entrypoints.${key} must match bin/<name>`);
-      }
-    }
-    for (const key of Object.keys(entrypoints)) {
-      if (!REQUIRED_ENTRYPOINTS.includes(key)) {
-        problems.push(`unknown entrypoint "${key}"`);
-      }
-    }
-  }
-  const capabilities = manifest.capabilities;
-  if (typeof capabilities !== "object" || capabilities === null) {
-    problems.push("capabilities must be an object");
-  } else {
-    for (const key of REQUIRED_CAPABILITIES) {
-      if (capabilities[key] !== true) {
-        problems.push(`capabilities.${key} must be true`);
-      }
-    }
-    for (const key of Object.keys(capabilities)) {
-      if (!REQUIRED_CAPABILITIES.includes(key)) {
-        problems.push(`unknown capability "${key}"`);
-      }
-    }
-  }
+  collectViolations(SCHEMA, manifest, "", problems);
   return problems;
 }
 
@@ -482,6 +476,7 @@ export function produceArtifact({
     doctor: "bin/eliza-desktop-doctor",
   },
 }) {
+  readVendoredSchema();
   if (!ARCHITECTURES.includes(architecture)) {
     fail(`unsupported architecture "${architecture}"`);
   }
@@ -619,6 +614,7 @@ export function produceArtifact({
  * Throws ArtifactContractError on the first failure; returns the manifest.
  */
 export function verifyArtifactDir(outDir, publicKeyPem) {
+  readVendoredSchema();
   const manifestPath = path.join(outDir, MANIFEST_NAME);
   assertRegularFile(manifestPath, MANIFEST_NAME);
   const manifestBytes = readFileSync(manifestPath);

--- a/packages/app-core/scripts/package-linux-gtk-artifact.mjs
+++ b/packages/app-core/scripts/package-linux-gtk-artifact.mjs
@@ -27,10 +27,17 @@ import {
   generateKeyPairSync,
 } from "node:crypto";
 import {
-  existsSync,
+  linkSync,
+  lstatSync,
   mkdirSync,
+  mkdtempSync,
+  readdirSync,
   readFileSync,
+  readlinkSync,
+  realpathSync,
+  rmSync,
   statSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
@@ -67,14 +74,138 @@ const REQUIRED_CAPABILITIES = [
 
 /** Error type for every contract violation this module detects. */
 export class ArtifactContractError extends Error {
-  constructor(message) {
-    super(message);
+  constructor(message, options) {
+    super(message, options);
     this.name = "ArtifactContractError";
   }
 }
 
 function fail(message) {
   throw new ArtifactContractError(message);
+}
+
+function pathEntryExists(filePath) {
+  try {
+    lstatSync(filePath);
+    return true;
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function assertRegularFile(filePath, label) {
+  let stats;
+  try {
+    stats = lstatSync(filePath);
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") {
+      fail(`missing ${label}`);
+    }
+    throw error;
+  }
+  if (!stats.isFile()) {
+    fail(`${label} must be a regular non-symlink file`);
+  }
+}
+
+function isWithinDirectory(rootDir, candidatePath) {
+  return (
+    candidatePath === rootDir ||
+    candidatePath.startsWith(`${rootDir}${path.sep}`)
+  );
+}
+
+function hasControlCharacters(value) {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint <= 0x1f || codePoint === 0x7f) return true;
+  }
+  return false;
+}
+
+/** Rejects stage entries that could escape or create special files on extraction. */
+export function assertSafeStageTree(stageDir) {
+  const canonicalStageDir = realpathSync(stageDir);
+  const pending = [canonicalStageDir];
+  let entryCount = 0;
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      entryCount += 1;
+      if (entryCount > 100_000) fail("stage contains more than 100000 entries");
+      if (hasControlCharacters(entry.name)) {
+        fail("stage entry names must not contain control characters");
+      }
+      const fullPath = path.join(directory, entry.name);
+      const stats = lstatSync(fullPath);
+      if (stats.isDirectory()) {
+        pending.push(fullPath);
+        continue;
+      }
+      if (stats.isFile()) {
+        if (stats.nlink > 1) fail("stage must not contain hard-linked files");
+        continue;
+      }
+      if (stats.isSymbolicLink()) {
+        const target = readlinkSync(fullPath);
+        if (path.isAbsolute(target) || target.split(/[\\/]/).includes("..")) {
+          fail("stage symlinks must use a non-traversing relative target");
+        }
+        let resolvedTarget;
+        try {
+          resolvedTarget = realpathSync(fullPath);
+        } catch (error) {
+          // error-policy:J2 context-adding rethrow: identify the unsafe stage link.
+          throw new ArtifactContractError(
+            `stage symlink target is missing: ${path.relative(canonicalStageDir, fullPath)}`,
+            { cause: error },
+          );
+        }
+        if (!isWithinDirectory(canonicalStageDir, resolvedTarget)) {
+          fail("stage symlink resolves outside the stage directory");
+        }
+        continue;
+      }
+      fail("stage contains a socket, device, FIFO, or unsupported entry type");
+    }
+  }
+}
+
+function requireEd25519PrivateKey(privateKeyPem) {
+  let privateKey;
+  try {
+    privateKey = createPrivateKey(privateKeyPem);
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow: keep parser diagnostics as cause.
+    throw new ArtifactContractError(
+      "artifact signing key is not a valid private key",
+      { cause: error },
+    );
+  }
+  if (privateKey.asymmetricKeyType !== "ed25519") {
+    fail("artifact signing key must be Ed25519");
+  }
+  return privateKey;
+}
+
+function requireEd25519PublicKey(publicKeyPem) {
+  let publicKey;
+  try {
+    publicKey = createPublicKey(publicKeyPem);
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow: keep parser diagnostics as cause.
+    throw new ArtifactContractError(
+      "artifact verification key is not a valid public key",
+      { cause: error },
+    );
+  }
+  if (publicKey.asymmetricKeyType !== "ed25519") {
+    fail("artifact verification key must be Ed25519");
+  }
+  return publicKey;
 }
 
 /** SHA-256 hex digest of a file's exact bytes. */
@@ -84,12 +215,17 @@ export function sha256File(filePath) {
 
 /** Detached Ed25519 signature (raw 64 bytes) over `bytes`. */
 export function signBytes(privateKeyPem, bytes) {
-  return edSign(null, bytes, createPrivateKey(privateKeyPem));
+  return edSign(null, bytes, requireEd25519PrivateKey(privateKeyPem));
 }
 
 /** Verifies a detached Ed25519 signature over `bytes`. */
 export function verifyBytes(publicKeyPem, bytes, signature) {
-  return edVerify(null, bytes, createPublicKey(publicKeyPem), signature);
+  return edVerify(
+    null,
+    bytes,
+    requireEd25519PublicKey(publicKeyPem),
+    signature,
+  );
 }
 
 /** Generates a PEM Ed25519 keypair for local/dev signing. */
@@ -99,6 +235,36 @@ export function generateSigningKeyPair() {
     privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }),
     publicKeyPem: publicKey.export({ type: "spki", format: "pem" }),
   };
+}
+
+/** Creates a signing keypair without rotating or weakening an existing key. */
+export function writeSigningKeyPair(outDir) {
+  mkdirSync(outDir, { recursive: true });
+  const privateKeyPath = path.join(outDir, "desktop-signing.key.pem");
+  const publicKeyPath = path.join(outDir, "desktop-signing.pub.pem");
+  if (pathEntryExists(privateKeyPath) || pathEntryExists(publicKeyPath)) {
+    fail("refusing to overwrite an existing desktop signing keypair");
+  }
+  const { privateKeyPem, publicKeyPem } = generateSigningKeyPair();
+  let privateKeyCreated = false;
+  try {
+    writeFileSync(privateKeyPath, privateKeyPem, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    privateKeyCreated = true;
+    writeFileSync(publicKeyPath, publicKeyPem, { flag: "wx", mode: 0o644 });
+  } catch (error) {
+    if (privateKeyCreated) {
+      try {
+        unlinkSync(privateKeyPath);
+      } catch {
+        // error-policy:J6 best-effort teardown: preserve the original write failure.
+      }
+    }
+    throw error;
+  }
+  return { privateKeyPath, publicKeyPath };
 }
 
 /**
@@ -203,18 +369,27 @@ export function assertValidManifest(manifest) {
  * executable regular file. Entrypoint paths are manifest-relative (bin/...).
  */
 export function assertStageEntrypoints(stageDir, entrypoints) {
+  const binStats = lstatSync(path.join(stageDir, "bin"));
+  if (!binStats.isDirectory()) {
+    fail("stage bin must be a real directory, not a symlink");
+  }
   for (const key of REQUIRED_ENTRYPOINTS) {
     const rel = entrypoints[key];
     if (!ENTRYPOINT_RE.test(String(rel ?? ""))) {
       fail(`entrypoints.${key} "${rel}" does not match bin/<name>`);
     }
     const full = path.join(stageDir, rel);
-    if (!existsSync(full)) {
-      fail(`entrypoint ${key} missing from stage: ${rel}`);
+    let stats;
+    try {
+      stats = lstatSync(full);
+    } catch (error) {
+      if (error && typeof error === "object" && error.code === "ENOENT") {
+        fail(`entrypoint ${key} missing from stage: ${rel}`);
+      }
+      throw error;
     }
-    const stats = statSync(full);
     if (!stats.isFile()) {
-      fail(`entrypoint ${key} is not a regular file: ${rel}`);
+      fail(`entrypoint ${key} is not a regular non-symlink file: ${rel}`);
     }
     if ((stats.mode & 0o111) === 0) {
       fail(`entrypoint ${key} is not executable: ${rel}`);
@@ -235,6 +410,58 @@ export function listArchiveMembers(archivePath) {
     .split("\n")
     .map((line) => line.replace(/^\.\//, "").replace(/\/$/, ""))
     .filter((line) => line.length > 0 && line !== ".");
+}
+
+function assertSafeArchiveMembers(archivePath) {
+  for (const member of listArchiveMembers(archivePath)) {
+    if (
+      path.posix.isAbsolute(member) ||
+      member.split("/").some((segment) => segment === "..") ||
+      hasControlCharacters(member)
+    ) {
+      fail(`archive contains an unsafe member path: ${JSON.stringify(member)}`);
+    }
+  }
+  const verbose = execFileSync("tar", ["--zstd", "-tvf", archivePath], {
+    encoding: "utf8",
+    env: { ...process.env, LC_ALL: "C" },
+  });
+  for (const line of verbose.split("\n").filter(Boolean)) {
+    const type = line[0];
+    if (type !== "-" && type !== "d" && type !== "l") {
+      fail(
+        "archive contains a hard link, socket, device, FIFO, or unsupported type",
+      );
+    }
+    if (type === "l") {
+      const arrow = line.lastIndexOf(" -> ");
+      const target = arrow >= 0 ? line.slice(arrow + 4) : "";
+      if (
+        !target ||
+        path.posix.isAbsolute(target) ||
+        target.split("/").includes("..")
+      ) {
+        fail("archive contains an unsafe symlink target");
+      }
+    }
+  }
+}
+
+function assertArchivedEntrypoint(archivePath, relativePath, key) {
+  const listing = execFileSync(
+    "tar",
+    ["--zstd", "-tvf", archivePath, `./${relativePath}`],
+    { encoding: "utf8", env: { ...process.env, LC_ALL: "C" } },
+  ).trim();
+  const mode = listing.split(/\s+/, 1)[0] ?? "";
+  if (!/^-[rwx-]{9}$/.test(mode)) {
+    fail(`entrypoint ${key} (${relativePath}) is not a regular archive file`);
+  }
+  if (mode[3] !== "x" && mode[6] !== "x" && mode[9] !== "x") {
+    fail(
+      `entrypoint ${key} (${relativePath}) is not executable in the archive`,
+    );
+  }
 }
 
 /**
@@ -262,63 +489,127 @@ export function produceArtifact({
   if (!COMMIT_RE.test(sourceCommit)) {
     fail(`invalid sourceCommit "${sourceCommit}"`);
   }
-  if (!existsSync(stageDir) || !statSync(stageDir).isDirectory()) {
+  const signingKey = requireEd25519PrivateKey(privateKeyPem);
+  if (!pathEntryExists(stageDir) || !statSync(stageDir).isDirectory()) {
     fail(`stage directory does not exist: ${stageDir}`);
   }
-  assertStageEntrypoints(stageDir, entrypoints);
 
   mkdirSync(outDir, { recursive: true });
+  const canonicalStageDir = realpathSync(stageDir);
+  const canonicalOutDir = realpathSync(outDir);
+  if (
+    canonicalOutDir === canonicalStageDir ||
+    canonicalOutDir.startsWith(`${canonicalStageDir}${path.sep}`)
+  ) {
+    fail(
+      "output directory must not be the stage directory or one of its descendants",
+    );
+  }
+  assertSafeStageTree(canonicalStageDir);
+  assertStageEntrypoints(canonicalStageDir, entrypoints);
   const archiveName = `${artifactBaseName}-${version}-${architecture}.tar.zst`;
   if (!ARCHIVE_RE.test(archiveName)) {
     fail(`derived archive name "${archiveName}" violates the contract`);
   }
-  const archivePath = path.join(outDir, archiveName);
-  runTar(["--zstd", "-cf", archivePath, "-C", stageDir, "."]);
-
-  const archiveBytes = readFileSync(archivePath);
-  const archiveDigest = createHash("sha256").update(archiveBytes).digest("hex");
   const archiveSignatureName = `${archiveName.replace(/\.tar\.zst$/, "")}.sig`;
-  writeFileSync(
-    path.join(outDir, archiveSignatureName),
-    signBytes(privateKeyPem, archiveBytes),
+  const outputNames = [
+    archiveName,
+    archiveSignatureName,
+    MANIFEST_SIGNATURE_NAME,
+    MANIFEST_NAME,
+  ];
+  for (const outputName of outputNames) {
+    if (pathEntryExists(path.join(canonicalOutDir, outputName))) {
+      fail(`refusing to overwrite existing artifact output: ${outputName}`);
+    }
+  }
+  const stagingDir = mkdtempSync(
+    path.join(canonicalOutDir, ".linux-gtk-artifact-"),
   );
+  const publishedEntries = [];
+  try {
+    const stagedArchivePath = path.join(stagingDir, archiveName);
+    runTar(["--zstd", "-cf", stagedArchivePath, "-C", canonicalStageDir, "."]);
+    assertSafeArchiveMembers(stagedArchivePath);
+    const archiveBytes = readFileSync(stagedArchivePath);
+    const archiveDigest = createHash("sha256")
+      .update(archiveBytes)
+      .digest("hex");
+    writeFileSync(
+      path.join(stagingDir, archiveSignatureName),
+      edSign(null, archiveBytes, signingKey),
+      { flag: "wx" },
+    );
 
-  const manifest = {
-    schemaVersion: 1,
-    sourceCommit,
-    version,
-    architecture,
-    shell: "gtk-webkit",
-    archive: archiveName,
-    sha256: archiveDigest,
-    signature: archiveSignatureName,
-    manifestSignature: MANIFEST_SIGNATURE_NAME,
-    entrypoints,
-    capabilities: {
-      tray: true,
-      overlay: true,
-      wayland: true,
-      cloudAuth: true,
-      computerUse: true,
-      remoteControl: true,
-    },
-  };
-  assertValidManifest(manifest);
+    const manifest = {
+      schemaVersion: 1,
+      sourceCommit,
+      version,
+      architecture,
+      shell: "gtk-webkit",
+      archive: archiveName,
+      sha256: archiveDigest,
+      signature: archiveSignatureName,
+      manifestSignature: MANIFEST_SIGNATURE_NAME,
+      entrypoints,
+      capabilities: {
+        tray: true,
+        overlay: true,
+        wayland: true,
+        cloudAuth: true,
+        computerUse: true,
+        remoteControl: true,
+      },
+    };
+    assertValidManifest(manifest);
+    const manifestBytes = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
+    writeFileSync(path.join(stagingDir, MANIFEST_NAME), manifestBytes, {
+      flag: "wx",
+    });
+    writeFileSync(
+      path.join(stagingDir, MANIFEST_SIGNATURE_NAME),
+      edSign(null, manifestBytes, signingKey),
+      { flag: "wx" },
+    );
 
-  const manifestBytes = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
-  const manifestPath = path.join(outDir, MANIFEST_NAME);
-  writeFileSync(manifestPath, manifestBytes);
-  writeFileSync(
-    path.join(outDir, MANIFEST_SIGNATURE_NAME),
-    signBytes(privateKeyPem, manifestBytes),
-  );
-
-  return {
-    archivePath,
-    archiveSignaturePath: path.join(outDir, archiveSignatureName),
-    manifestPath,
-    manifestSignaturePath: path.join(outDir, MANIFEST_SIGNATURE_NAME),
-  };
+    for (const outputName of outputNames) {
+      const publishedPath = path.join(canonicalOutDir, outputName);
+      linkSync(path.join(stagingDir, outputName), publishedPath);
+      const publishedStats = lstatSync(publishedPath);
+      publishedEntries.push({
+        dev: publishedStats.dev,
+        ino: publishedStats.ino,
+        path: publishedPath,
+      });
+    }
+    return {
+      archivePath: path.join(canonicalOutDir, archiveName),
+      archiveSignaturePath: path.join(canonicalOutDir, archiveSignatureName),
+      manifestPath: path.join(canonicalOutDir, MANIFEST_NAME),
+      manifestSignaturePath: path.join(
+        canonicalOutDir,
+        MANIFEST_SIGNATURE_NAME,
+      ),
+    };
+  } catch (error) {
+    for (const published of publishedEntries.reverse()) {
+      try {
+        const current = lstatSync(published.path);
+        if (current.dev === published.dev && current.ino === published.ino) {
+          unlinkSync(published.path);
+        }
+      } catch {
+        // error-policy:J6 best-effort teardown: preserve the publication failure.
+      }
+    }
+    throw error;
+  } finally {
+    try {
+      rmSync(stagingDir, { force: true, recursive: true });
+    } catch {
+      // error-policy:J6 best-effort teardown: published bytes remain authoritative.
+    }
+  }
 }
 
 /**
@@ -329,7 +620,7 @@ export function produceArtifact({
  */
 export function verifyArtifactDir(outDir, publicKeyPem) {
   const manifestPath = path.join(outDir, MANIFEST_NAME);
-  if (!existsSync(manifestPath)) fail(`missing ${MANIFEST_NAME} in ${outDir}`);
+  assertRegularFile(manifestPath, MANIFEST_NAME);
   const manifestBytes = readFileSync(manifestPath);
   let manifest;
   try {
@@ -338,14 +629,13 @@ export function verifyArtifactDir(outDir, publicKeyPem) {
     // error-policy:J2 context-adding rethrow: name the file that failed to parse.
     throw new ArtifactContractError(
       `${MANIFEST_NAME} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
     );
   }
   assertValidManifest(manifest);
 
   const manifestSigPath = path.join(outDir, MANIFEST_SIGNATURE_NAME);
-  if (!existsSync(manifestSigPath)) {
-    fail(`missing ${MANIFEST_SIGNATURE_NAME} next to the manifest`);
-  }
+  assertRegularFile(manifestSigPath, MANIFEST_SIGNATURE_NAME);
   if (
     !verifyBytes(publicKeyPem, manifestBytes, readFileSync(manifestSigPath))
   ) {
@@ -353,7 +643,7 @@ export function verifyArtifactDir(outDir, publicKeyPem) {
   }
 
   const archivePath = path.join(outDir, manifest.archive);
-  if (!existsSync(archivePath)) fail(`missing archive ${manifest.archive}`);
+  assertRegularFile(archivePath, `archive ${manifest.archive}`);
   const archiveBytes = readFileSync(archivePath);
   const digest = createHash("sha256").update(archiveBytes).digest("hex");
   if (digest !== manifest.sha256) {
@@ -362,20 +652,20 @@ export function verifyArtifactDir(outDir, publicKeyPem) {
     );
   }
   const archiveSigPath = path.join(outDir, manifest.signature);
-  if (!existsSync(archiveSigPath)) {
-    fail(`missing archive signature ${manifest.signature}`);
-  }
+  assertRegularFile(archiveSigPath, `archive signature ${manifest.signature}`);
   if (!verifyBytes(publicKeyPem, archiveBytes, readFileSync(archiveSigPath))) {
     fail("archive signature does not verify over the exact archive bytes");
   }
 
   const members = new Set(listArchiveMembers(archivePath));
+  assertSafeArchiveMembers(archivePath);
   for (const key of REQUIRED_ENTRYPOINTS) {
     if (!members.has(manifest.entrypoints[key])) {
       fail(
         `entrypoint ${key} (${manifest.entrypoints[key]}) is not present in the archive`,
       );
     }
+    assertArchivedEntrypoint(archivePath, manifest.entrypoints[key], key);
   }
   return manifest;
 }
@@ -423,12 +713,7 @@ function cliMain() {
   }
   if (command === "generate-key") {
     const outDir = path.resolve(args.get("out") ?? ".");
-    mkdirSync(outDir, { recursive: true });
-    const { privateKeyPem, publicKeyPem } = generateSigningKeyPair();
-    writeFileSync(path.join(outDir, "desktop-signing.key.pem"), privateKeyPem, {
-      mode: 0o600,
-    });
-    writeFileSync(path.join(outDir, "desktop-signing.pub.pem"), publicKeyPem);
+    writeSigningKeyPair(outDir);
     process.stdout.write(`wrote Ed25519 keypair under ${outDir}\n`);
     return;
   }

--- a/packages/app-core/scripts/schemas/desktop-artifact-manifest.schema.json
+++ b/packages/app-core/scripts/schemas/desktop-artifact-manifest.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://elizaos.ai/schemas/linux-desktop-artifact-manifest.v1.json",
+  "title": "elizaOS Linux desktop artifact manifest",
+  "description": "Cross-repository contract for signed desktop artifacts produced by elizaOS/eliza and consumed by the mkosi image.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "sourceCommit",
+    "version",
+    "architecture",
+    "shell",
+    "archive",
+    "sha256",
+    "signature",
+    "manifestSignature",
+    "entrypoints",
+    "capabilities"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "sourceCommit": { "type": "string", "pattern": "^[a-f0-9]{40}$" },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?$"
+    },
+    "architecture": { "enum": ["x86_64", "arm64", "riscv64"] },
+    "shell": { "const": "gtk-webkit" },
+    "archive": { "type": "string", "pattern": "^[A-Za-z0-9._-]+\\.tar\\.zst$" },
+    "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "signature": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._-]+\\.sig$",
+      "description": "Detached Ed25519 signature over the exact archive bytes. The file is adjacent to this manifest."
+    },
+    "manifestSignature": {
+      "const": "desktop-artifact-manifest.json.sig",
+      "description": "Detached Ed25519 signature over the exact bytes of desktop-artifact-manifest.json, stored adjacent to it."
+    },
+    "entrypoints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["desktop", "agent", "doctor"],
+      "properties": {
+        "desktop": { "type": "string", "pattern": "^bin/[A-Za-z0-9._-]+$" },
+        "agent": { "type": "string", "pattern": "^bin/[A-Za-z0-9._-]+$" },
+        "doctor": { "type": "string", "pattern": "^bin/[A-Za-z0-9._-]+$" }
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tray",
+        "overlay",
+        "wayland",
+        "cloudAuth",
+        "computerUse",
+        "remoteControl"
+      ],
+      "properties": {
+        "tray": { "const": true },
+        "overlay": { "const": true },
+        "wayland": { "const": true },
+        "cloudAuth": { "const": true },
+        "computerUse": { "const": true },
+        "remoteControl": { "const": true }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Refs #21783

## What

First codeable slice of the Linux GTK/WebKit shell work: the **signed artifact producer/verifier** implementing the cross-repo contract in `elizaOS/os:packages/os/linux/schemas/desktop-artifact-manifest.schema.json` (acceptance bullets "manifest entrypoints and archive digest verify" and "fixed adjacent manifest signature + manifest-named archive signature").

- `packages/app-core/scripts/package-linux-gtk-artifact.mjs` — `produce` / `verify` / `generate-key` CLI plus exported functions:
  - packages a staged shell build (`bin/eliza-desktop`, `bin/eliza-agent`, `bin/eliza-desktop-doctor` + payload) into `eliza-desktop-gtk-<version>-<arch>.tar.zst` for **x86_64, arm64, riscv64** from one code path;
  - refuses missing or non-executable entrypoints, bad arch/version/commit;
  - writes a schema-valid `desktop-artifact-manifest.json`, the fixed adjacent `desktop-artifact-manifest.json.sig` (Ed25519 over the exact manifest bytes) and `<archive-stem>.sig` (Ed25519 over the exact archive bytes);
  - verifier re-derives digest and both signatures from bytes, rejects linked contract files, audits archive member types/paths/link targets, and checks each entrypoint is a regular executable archive member.
- producer audits the staged tree, rejects unsafe links and special files, creates private build/key output exclusively, and publishes the complete set atomically with the manifest last.
- `packages/app-core/scripts/schemas/desktop-artifact-manifest.schema.json` — vendored byte-for-byte copy of the OS-repo contract, pinned by a drift test.
- `packages/app-core/scripts/__tests__/package-linux-gtk-artifact.test.ts` — 23 real-harness tests (real tar.zst via system tar, real Ed25519 keys): all three architectures round-trip, tampered-archive-byte rejection, tampered-manifest rejection, wrong-key rejection, entrypoint/stage refusals, full schema-violation matrix.
- `bun run --cwd packages/app-core build:linux-gtk-artifact` / `verify:linux-gtk-artifact` manifest scripts.

## Evidence

Vitest (23/23):
```
Test Files  1 passed (1)
     Tests  23 passed (23)
```

Real CLI round-trip (generate-key → produce riscv64 → verify → tamper):
```
verified eliza-desktop-gtk-1.0.0-riscv64.tar.zst (riscv64) at schema v1
desktop-artifact-manifest.json      706 B
desktop-artifact-manifest.json.sig   64 B
eliza-desktop-gtk-1.0.0-riscv64.sig  64 B
eliza-desktop-gtk-1.0.0-riscv64.tar.zst
tamper check: ArtifactContractError: archive digest mismatch … tamper correctly rejected
```

## Out of scope (human / follow-up, per issue)

- The GTK/WebKitGTK shell binaries themselves (tray/overlay/portals/AT-SPI/etc.) — the existing riscv64 cross-toolchain spec lives in `packages/app-core/platforms/electrobun/docs/riscv64-port.md`.
- Cross-arch physical proof (GNOME Wayland packaged runs on real x86_64/arm64/riscv64 hardware) is human-only and must be captured per CONTRIBUTING before OS integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:f942ec7b060cc2794d2e5ea56ac014352a0f5432 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - producer-only release tooling with no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - producer-only release tooling with no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic CLI producer and verifier, no interactive flow

<!-- evidence-row:backend-logs -->
- [x] [23352-exact-head-verification.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23352-exact-head-verification.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend execution path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [23352-desktop-artifact-manifest.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23352-desktop-artifact-manifest.json)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots or rendered text




<!-- contribution-attribution:v1 -->


<!-- attribution-row:ai-assistance -->


- AI assistance: Yes


<!-- attribution-row:models -->


- Model(s) used: `anthropic/claude-fable-5`, `openai/gpt-5.6-sol`


<!-- attribution-row:client -->


- Agent tooling: Claude Code, Codex


<!-- attribution-row:skill-revision -->


- Skill path: elizaOS/eliza@f942ec7b060cc2794d2e5ea56ac014352a0f5432:packages/skills/skills/contribute-to-eliza


<!-- attribution-row:status -->


- Provenance status: self-reported
