### PR TITLE
fix(coding-tools): inspect nested destructive shell expansions

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -3260,6 +3260,63 @@ describe("destructive-bulk confirm gate", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "blocks recursive deletes inside command, backtick, and unquoted-heredoc expansions",
+    async () => {
+      const commandShapes = [
+        (command: string) => `printf '%s' "$(${command})"`,
+        (command: string) => `printf '%s' \`${command}\``,
+        (command: string) => `cat <<EOF\n$(${command})\nEOF`,
+      ];
+
+      for (const shape of commandShapes) {
+        const { command, target } = await createRecursiveDeleteCommand();
+        const { runtime } = await makeRuntime();
+        try {
+          const result = await shellAction.handler?.(
+            runtime,
+            makeMessage(undefined, "inspect the generated value"),
+            undefined,
+            { command: shape(command) },
+          );
+
+          expect(result.success).toBe(false);
+          expect(result.text).toContain("needs_confirmation");
+          expect(result.data).toMatchObject({
+            destructive_reason: "recursive delete",
+          });
+          expect(await pathExists(target)).toBe(true);
+        } finally {
+          await fs.rm(target, { recursive: true, force: true });
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "runs nested destructive-looking text when shell quoting makes it literal",
+    async () => {
+      const { runtime } = await makeRuntime();
+      const literal = await shellAction.handler?.(
+        runtime,
+        makeMessage(undefined, "print the literal example"),
+        undefined,
+        { command: "printf '%s' '$(rm -rf ./data)'" },
+      );
+      const quotedHeredoc = await shellAction.handler?.(
+        runtime,
+        makeMessage(undefined, "print the quoted heredoc example"),
+        undefined,
+        { command: "cat <<'EOF'\n$(rm -rf ./data)\nEOF" },
+      );
+
+      expect(literal.success).toBe(true);
+      expect(literal.text).toContain("$(rm -rf ./data)");
+      expect(quotedHeredoc.success).toBe(true);
+      expect(quotedHeredoc.text).toContain("$(rm -rf ./data)");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "does not let parameter expansion text hide a recursive delete",
     async () => {
       const { command, target } = await createRecursiveDeleteCommand();

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -3260,15 +3260,25 @@ describe("destructive-bulk confirm gate", () => {
   );
 
   it.runIf(process.platform !== "win32")(
-    "blocks recursive deletes inside command, backtick, and unquoted-heredoc expansions",
+    "blocks recursive deletes across nested executable expansion shapes",
     async () => {
       const commandShapes = [
         (command: string) => `printf '%s' "$(${command})"`,
         (command: string) => `printf '%s' \`${command}\``,
         (command: string) => `cat <<EOF\n$(${command})\nEOF`,
+        (command: string) => `printf '%s' "prefix ' $(${command})"`,
+        (command: string) => `printf '%s' "$(printf safe # )\n${command}\n)"`,
       ];
 
       for (const shape of commandShapes) {
+        const syntaxProbe = await execFileAsync("/bin/bash", [
+          "--noprofile",
+          "--norc",
+          "-c",
+          shape("printf nested-expansion-boundary"),
+        ]);
+        expect(syntaxProbe.stdout).toContain("nested-expansion-boundary");
+
         const { command, target } = await createRecursiveDeleteCommand();
         const { runtime } = await makeRuntime();
         try {
@@ -3308,11 +3318,21 @@ describe("destructive-bulk confirm gate", () => {
         undefined,
         { command: "cat <<'EOF'\n$(rm -rf ./data)\nEOF" },
       );
+      const commentedLiteral = await shellAction.handler?.(
+        runtime,
+        makeMessage(undefined, "print the benign generated value"),
+        undefined,
+        {
+          command: `printf '%s' "$(printf safe # rm -rf ./data )\n)"`,
+        },
+      );
 
       expect(literal.success).toBe(true);
       expect(literal.text).toContain("$(rm -rf ./data)");
       expect(quotedHeredoc.success).toBe(true);
       expect(quotedHeredoc.text).toContain("$(rm -rf ./data)");
+      expect(commentedLiteral.success).toBe(true);
+      expect(commentedLiteral.text).toContain("safe");
     },
   );
 

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
@@ -114,6 +114,60 @@ describe("classifyDestructiveCommand — fires", () => {
     expect(v.destructive).toBe(true);
     expect(v.targets[0]).toContain("eliza");
   });
+
+  it.each([
+    ["command substitution", "printf '%s' $(rm -rf ./nested)"],
+    ["double-quoted command substitution", 'printf "%s" "$(rm -rf ./nested)"'],
+    ["backtick substitution", "printf '%s' `rm -rf ./nested`"],
+    [
+      "nested legacy backticks",
+      "printf '%s' `printf '%s' \\`rm -rf ./nested\\``",
+    ],
+    [
+      "command substitution inside backticks",
+      "printf '%s' `printf '%s' \"$(rm -rf ./nested)\"`",
+    ],
+    [
+      "mixed nested substitutions",
+      'printf "%s" "$(printf \'%s\' "$(rm -rf ./nested)")"',
+    ],
+  ])("recursive delete inside %s", (_name, command) => {
+    expect(classifyDestructiveCommand(command)).toMatchObject({
+      destructive: true,
+      reason: "recursive delete",
+      targets: ["./nested"],
+    });
+  });
+
+  it.each([
+    ["command substitution", "cat <<EOF\n$(rm -rf ./nested)\nEOF"],
+    ["backtick substitution", "cat <<EOF\n`rm -rf ./nested`\nEOF"],
+    [
+      "quoted-looking payload around an expansion",
+      "cat <<EOF\n'$(rm -rf ./nested)'\nEOF",
+    ],
+  ])("recursive delete inside an unquoted heredoc %s", (_name, command) => {
+    expect(classifyDestructiveCommand(command)).toMatchObject({
+      destructive: true,
+      reason: "recursive delete",
+      targets: ["./nested"],
+    });
+  });
+
+  it.each([
+    ["unterminated command substitution", "printf '%s' $(rm -rf ./nested"],
+    ["unterminated backtick substitution", "printf '%s' `rm -rf ./nested"],
+  ])("fails safe for an %s", (_name, command) => {
+    expect(classifyDestructiveCommand(command)).toMatchObject({
+      destructive: true,
+      reason: "nested shell expansion could not be inspected safely",
+    });
+  });
+
+  it("fails safe when nested expansion depth exceeds the inspection bound", () => {
+    const command = `${"$(printf %s ".repeat(18)}safe${")".repeat(18)}`;
+    expect(classifyDestructiveCommand(command).destructive).toBe(true);
+  });
 });
 
 describe("classifyDestructiveCommand — must NOT fire", () => {
@@ -140,6 +194,15 @@ describe("classifyDestructiveCommand — must NOT fire", () => {
     expect(
       classifyDestructiveCommand('echo "rm -rf would be bad"').destructive,
     ).toBe(false);
+  });
+  it.each([
+    ["single-quoted command substitution", "printf '%s' '$(rm -rf ./data)'"],
+    ["escaped command substitution", "printf '%s' \\$(rm -rf ./data)"],
+    ["single-quoted backticks", "printf '%s' '`rm -rf ./data`'"],
+    ["escaped backticks", "printf '%s' \\`rm -rf ./data\\`"],
+    ["benign nested substitution", "printf '%s' \"$(printf safe)\""],
+  ])("%s remains literal or benign", (_name, command) => {
+    expect(classifyDestructiveCommand(command).destructive).toBe(false);
   });
   it.each([
     ["line feed", "printf 'safe\nrm -rf ./data'"],
@@ -235,5 +298,13 @@ describe("classifyDestructiveCommand — must NOT fire", () => {
       classifyDestructiveCommand("cat <<'EOF'\nEO\\\nF\nrm -rf ./data\nEOF")
         .destructive,
     ).toBe(false);
+  });
+
+  it.each([
+    ["single-quoted", "cat <<'EOF'\n$(rm -rf ./data)\nEOF"],
+    ["double-quoted", 'cat <<"EOF"\n`rm -rf ./data`\nEOF'],
+    ["backslash-quoted", "cat <<\\EOF\n$(rm -rf ./data)\nEOF"],
+  ])("keeps expansions in a %s heredoc literal", (_name, command) => {
+    expect(classifyDestructiveCommand(command).destructive).toBe(false);
   });
 });

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts
@@ -131,6 +131,14 @@ describe("classifyDestructiveCommand — fires", () => {
       "mixed nested substitutions",
       'printf "%s" "$(printf \'%s\' "$(rm -rf ./nested)")"',
     ],
+    [
+      "substitution after an apostrophe inside double quotes",
+      'printf "%s" "prefix \' $(rm -rf ./nested)"',
+    ],
+    [
+      "substitution after a commented closing parenthesis",
+      'printf "%s" "$(printf safe # )\nrm -rf ./nested\n)"',
+    ],
   ])("recursive delete inside %s", (_name, command) => {
     expect(classifyDestructiveCommand(command)).toMatchObject({
       destructive: true,
@@ -201,6 +209,22 @@ describe("classifyDestructiveCommand — must NOT fire", () => {
     ["single-quoted backticks", "printf '%s' '`rm -rf ./data`'"],
     ["escaped backticks", "printf '%s' \\`rm -rf ./data\\`"],
     ["benign nested substitution", "printf '%s' \"$(printf safe)\""],
+    [
+      "apostrophe before a benign double-quoted substitution",
+      'printf "%s" "prefix \' $(printf safe)"',
+    ],
+    [
+      "closing parenthesis quoted inside a substitution",
+      "printf \"%s\" \"$(printf '%s' '# )')\"",
+    ],
+    [
+      "destructive-looking text inside a substitution comment",
+      'printf "%s" "$(printf safe # rm -rf ./data )\n)"',
+    ],
+    [
+      "escaped comment marker before the substitution delimiter",
+      'printf "%s" "$(printf \\# )"',
+    ],
   ])("%s remains literal or benign", (_name, command) => {
     expect(classifyDestructiveCommand(command).destructive).toBe(false);
   });

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
@@ -79,6 +79,18 @@ interface ParsedHeredocDelimiter {
   quoted: boolean;
 }
 
+interface MaskedShellInput {
+  executableCommand: string;
+  unquotedHeredocBodies: string[];
+}
+
+interface NestedCommandInspection {
+  commands: string[];
+  unsafe: boolean;
+}
+
+const MAX_NESTED_EXPANSION_DEPTH = 16;
+
 function hasTrailingLineContinuation(line: string): boolean {
   let backslashes = 0;
   for (let i = line.length - 1; i >= 0 && line[i] === "\\"; i -= 1) {
@@ -255,12 +267,14 @@ function heredocDeclarations(line: string): HeredocDeclaration[] {
 // classifiers. Unquoted bodies can evaluate nested expansions; those require
 // their own recursive inspection rather than treating the whole body as a
 // command list.
-function maskHeredocBodies(command: string): string {
+function maskHeredocBodies(command: string): MaskedShellInput {
   const lines = command.match(/[^\r\n]*(?:\r\n|\r|\n|$)/g) ?? [];
   const pending: HeredocDeclaration[] = [];
   let continuedBodyLine = "";
+  let activeUnquotedBody = "";
+  const unquotedHeredocBodies: string[] = [];
 
-  return lines
+  const executableCommand = lines
     .map((line) => {
       const newline = line.endsWith("\r\n")
         ? "\r\n"
@@ -280,8 +294,17 @@ function maskHeredocBodies(command: string): string {
         continuedBodyLine += joinsNextLine
           ? comparable.slice(0, -1)
           : comparable;
+        const terminatesBody =
+          !joinsNextLine && continuedBodyLine === active.delimiter;
+        if (!active.quoted && !terminatesBody) activeUnquotedBody += line;
         if (!joinsNextLine) {
-          if (continuedBodyLine === active.delimiter) pending.shift();
+          if (terminatesBody) {
+            pending.shift();
+            if (!active.quoted) {
+              unquotedHeredocBodies.push(activeUnquotedBody);
+              activeUnquotedBody = "";
+            }
+          }
           continuedBodyLine = "";
         }
         return `${" ".repeat(content.length)}${newline}`;
@@ -295,6 +318,132 @@ function maskHeredocBodies(command: string): string {
       return line;
     })
     .join("");
+
+  if (activeUnquotedBody) unquotedHeredocBodies.push(activeUnquotedBody);
+  return { executableCommand, unquotedHeredocBodies };
+}
+
+function nestedCommands(
+  source: string,
+  shellQuotesAreSyntax: boolean,
+): NestedCommandInspection {
+  const commands: string[] = [];
+  let quote: string | null = null;
+
+  for (let cursor = 0; cursor < source.length; cursor += 1) {
+    const ch = source[cursor] as string;
+    if (shellQuotesAreSyntax && quote === "'") {
+      if (ch === "'") quote = null;
+      continue;
+    }
+    if (ch === "\\" && cursor + 1 < source.length) {
+      cursor += 1;
+      continue;
+    }
+    if (shellQuotesAreSyntax && ch === "'") {
+      quote = "'";
+      continue;
+    }
+    if (shellQuotesAreSyntax && ch === '"') {
+      quote = quote === '"' ? null : '"';
+      continue;
+    }
+    if (
+      shellQuotesAreSyntax &&
+      quote === null &&
+      ch === "#" &&
+      (cursor === 0 || /[\s;|&()]/.test(source[cursor - 1] as string))
+    ) {
+      while (
+        cursor + 1 < source.length &&
+        !/[\r\n]/.test(source[cursor + 1] as string)
+      ) {
+        cursor += 1;
+      }
+      continue;
+    }
+
+    if (ch === "`" && (!shellQuotesAreSyntax || quote !== "'")) {
+      let end = cursor + 1;
+      let body = "";
+      for (; end < source.length; end += 1) {
+        const nested = source[end] as string;
+        if (nested === "\\" && end + 1 < source.length) {
+          const escaped = source[end + 1] as string;
+          if (!/[$`\\\r\n]/.test(escaped)) body += nested;
+          body += escaped;
+          end += 1;
+          continue;
+        }
+        if (nested === "`") break;
+        body += nested;
+      }
+      if (end >= source.length) return { commands, unsafe: true };
+      commands.push(body);
+      cursor = end;
+      continue;
+    }
+
+    if (ch !== "$" || source[cursor + 1] !== "(") continue;
+    // Arithmetic expansion is data, but command substitutions nested inside
+    // it are still executable and will be found while scanning onward.
+    if (source[cursor + 2] === "(") continue;
+
+    let end = cursor + 2;
+    let parenDepth = 1;
+    let nestedBacktick = false;
+    let nestedQuote: string | null = null;
+    let body = "";
+    for (; end < source.length; end += 1) {
+      const nested = source[end] as string;
+      if (nestedQuote === "'") {
+        body += nested;
+        if (nested === "'") nestedQuote = null;
+        continue;
+      }
+      if (nested === "\\" && end + 1 < source.length) {
+        body += nested;
+        body += source[end + 1] as string;
+        end += 1;
+        continue;
+      }
+      if (nestedQuote === null && nested === "`") {
+        nestedBacktick = !nestedBacktick;
+        body += nested;
+        continue;
+      }
+      if (nestedBacktick) {
+        body += nested;
+        continue;
+      }
+      if (nested === "'") {
+        nestedQuote = "'";
+        body += nested;
+        continue;
+      }
+      if (nested === '"') {
+        nestedQuote = nestedQuote === '"' ? null : '"';
+        body += nested;
+        continue;
+      }
+      if (nestedQuote === null && nested === "(") parenDepth += 1;
+      else if (nestedQuote === null && nested === ")") {
+        parenDepth -= 1;
+        if (parenDepth === 0) break;
+      }
+      if (parenDepth > MAX_NESTED_EXPANSION_DEPTH) {
+        return { commands, unsafe: true };
+      }
+      body += nested;
+    }
+    if (end >= source.length || parenDepth !== 0) {
+      return { commands, unsafe: true };
+    }
+    commands.push(body);
+    cursor = end;
+  }
+
+  return { commands, unsafe: false };
 }
 
 function splitSegments(command: string): string[] {
@@ -345,7 +494,51 @@ function tokens(segment: string): string[] {
 export function classifyDestructiveCommand(
   command: string,
 ): DestructiveVerdict {
-  const executableCommand = maskHeredocBodies(command);
+  return classifyDestructiveCommandAtDepth(command, 0);
+}
+
+function classifyDestructiveCommandAtDepth(
+  command: string,
+  depth: number,
+): DestructiveVerdict {
+  if (depth > MAX_NESTED_EXPANSION_DEPTH) {
+    return {
+      destructive: true,
+      reason: "nested shell expansion exceeds inspection depth",
+      targets: ["nested shell expansion"],
+    };
+  }
+
+  const { executableCommand, unquotedHeredocBodies } =
+    maskHeredocBodies(command);
+  const inspectionSources = [
+    { shellQuotesAreSyntax: true, source: executableCommand },
+    ...unquotedHeredocBodies.map((source) => ({
+      shellQuotesAreSyntax: false,
+      source,
+    })),
+  ];
+  for (const inspectionSource of inspectionSources) {
+    const nested = nestedCommands(
+      inspectionSource.source,
+      inspectionSource.shellQuotesAreSyntax,
+    );
+    if (nested.unsafe) {
+      return {
+        destructive: true,
+        reason: "nested shell expansion could not be inspected safely",
+        targets: ["nested shell expansion"],
+      };
+    }
+    for (const nestedCommand of nested.commands) {
+      const nestedVerdict = classifyDestructiveCommandAtDepth(
+        nestedCommand,
+        depth + 1,
+      );
+      if (nestedVerdict.destructive) return nestedVerdict;
+    }
+  }
+
   const sql = DROP_SQL.exec(executableCommand);
   if (sql) {
     return {

--- a/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
+++ b/plugins/plugin-coding-tools/src/lib/destructive-gate.ts
@@ -340,7 +340,7 @@ function nestedCommands(
       cursor += 1;
       continue;
     }
-    if (shellQuotesAreSyntax && ch === "'") {
+    if (shellQuotesAreSyntax && quote === null && ch === "'") {
       quote = "'";
       continue;
     }
@@ -416,7 +416,7 @@ function nestedCommands(
         body += nested;
         continue;
       }
-      if (nested === "'") {
+      if (nestedQuote === null && nested === "'") {
         nestedQuote = "'";
         body += nested;
         continue;
@@ -424,6 +424,19 @@ function nestedCommands(
       if (nested === '"') {
         nestedQuote = nestedQuote === '"' ? null : '"';
         body += nested;
+        continue;
+      }
+      if (
+        nestedQuote === null &&
+        nested === "#" &&
+        (end === cursor + 2 || /[\s;|&()]/.test(source[end - 1] as string))
+      ) {
+        while (end < source.length && !/[\r\n]/.test(source[end] as string)) {
+          body += source[end] as string;
+          end += 1;
+        }
+        if (end >= source.length) break;
+        body += source[end] as string;
         continue;
       }
       if (nestedQuote === null && nested === "(") parenDepth += 1;


### PR DESCRIPTION
# Relates to

Fixes #23239.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto `origin/develop` at `48e5f5ce9bdc8c7bc3458b35b2c5e9bec61f06b0` with zero conflicts.
- [ ] `bun install` and scoped package gates pass after sync; root `bun run verify` remains for independent verification before this draft is promoted.
- [x] A reviewer can confirm the classifier and exported SHELL behavior from the immediately pre-sync package evidence plus the exact-head diff/type/build evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@432b9c221ae78c9f7588877cc1e15b537ddcc5ef:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@48e5f5ce9bdc8c7bc3458b35b2c5e9bec61f06b0`; zero conflicts.
- [ ] Root `bun run verify` is intentionally left to the independent/root verification lane before promotion from draft.

# Risks

Medium security-boundary change. The bounded lexer can add confirmation for malformed or over-depth nested expansions by design; executable substitutions must fail closed. Negative tests pin single-quoted, escaped, benign, and quoted-heredoc literals so they do not acquire ordinary false-positive confirmations.

# Background

## What does this PR do?

- Recursively inspects executable `$()` and legacy backtick substitutions without executing classifier input.
- Extracts substitutions from unquoted heredoc bodies while preserving quoted heredocs as literal data.
- Bounds recursive and parenthesis inspection at 16 levels and requires confirmation when malformed or over-depth input cannot be inspected safely.
- Exercises must-fire and must-not-fire behavior through both `classifyDestructiveCommand` and the exported `SHELL` action, including target-survival assertions proving blocked commands did not run.

## What kind of change is this?

Bug fix / security hardening (non-breaking).

# Documentation changes needed?

No public configuration or action schema changed. The implementation extends the existing destructive-confirmation contract documented by its source header and tests.

# Testing

## Where should a reviewer start?

`plugins/plugin-coding-tools/src/lib/destructive-gate.ts`, followed by its classifier tests and the `destructive-bulk confirm gate` section of `src/actions/bash.test.ts`.

## Detailed testing steps

Exact head: `accb1593281cd22f0cd0ddcfc727dd8d5ef9de09`  
Immediately pre-final-sync tested head: `80a8f07120618d3cc186c9b57fbafbd2c271a256`

```text
PATH=/private/tmp/eliza-toolbin:$PATH bun run --cwd plugins/plugin-coding-tools test # 80a8f071
  38 test files passed
  691 passed, 1 skipped

PATH=/private/tmp/eliza-toolbin:$PATH bun run --cwd plugins/plugin-coding-tools test -- src/lib/destructive-gate.test.ts src/actions/bash.test.ts # 80a8f071
  2 test files passed
  214 passed

PATH=/private/tmp/eliza-toolbin:$PATH bun test plugins/plugin-coding-tools/src/lib/destructive-gate.test.ts # accb1593
  89 passed, 0 failed
  Includes the independent-review apostrophe and comment-delimiter mutations

PATH=/private/tmp/eliza-toolbin:$PATH bun run --cwd plugins/plugin-coding-tools typecheck
  PASS

PATH=/private/tmp/eliza-toolbin:$PATH bun run --cwd plugins/plugin-coding-tools lint:check
  Checked 106 files; PASS

PATH=/private/tmp/eliza-toolbin:$PATH bun run --cwd plugins/plugin-coding-tools build
  Node bundle and TypeScript declarations; PASS

PATH=/private/tmp/eliza-toolbin:$PATH bun run check:agents-claude
  156 tracked guide pairs; PASS

git diff --check origin/develop...HEAD
  PASS
```

# Evidence Gate

<!-- evidence-head:accb1593281cd22f0cd0ddcfc727dd8d5ef9de09 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI flow changes.
<!-- evidence-row:backend-logs -->
- [x] Exact-head build/typecheck output plus immediately pre-sync package/SHELL test output is included inline above; the SHELL integration tests invoke the real local shell boundary and assert blocked targets remain present.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, state, console, or network surface changes.
<!-- evidence-row:llm-trajectory -->
- [ ] Pending independent live-model trajectory through the planner-to-SHELL confirmation flow before promotion from draft.
<!-- evidence-row:domain-artifacts -->
- [x] The exported-SHELL tests create real temporary deletion targets, invoke all three nested expansion shapes, and verify each target still exists after the confirmation response; no persistent DB/domain artifact applies.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changes.

# Evidence Details

## Real LLM-call trajectory

Pending independent live-model evidence before this draft is promoted. The deterministic exact-head tests cover classifier correctness and the exported action boundary but do not substitute for that trajectory.

## Backend + frontend logs

The exact-head command transcript and counts are included in **Detailed testing steps**. Frontend logs are not applicable because this diff touches no frontend path.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio surface changed.

## Known gaps / failures

- Root-wide `bun run verify` and independent review remain pending; this PR stays draft until both complete.
- A live-model trajectory remains pending as called out in the evidence row.
- The first focused SHELL test attempt lacked generated i18n modules and `cross-spawn` in the fresh worktree. Running the repository keyword generator and pinned `bun install` repaired the environment.
- The full package and focused Vitest reruns after the final develop-only rebase stalled during Vitest import/finalization under severe shared-host CPU contention and were stopped cleanly (exit 130). The immediately pre-sync implementation head passed the full 691/1 package lane and focused 214/214 lane.
- Independent review found two lexer mutations on `b2ffb1c`: an apostrophe inside active double quotes incorrectly entered single-quote mode, and `)` inside a shell comment prematurely closed `$()` inspection. Exact head `accb1593` repairs both contextual rules and passes the standalone mutation-sensitive classifier lane 89/89, typecheck, 106-file Biome, and diff integrity. Exported-SHELL tests now run each adversarial shape safely under Bash before verifying the destructive target survives the confirmation response. Canonical focused Vitest should be rerun on the exact PR head under a less-contended host before promotion.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@432b9c221ae78c9f7588877cc1e15b537ddcc5ef:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [/root/implement_23239]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@432b9c221ae78c9f7588877cc1e15b537ddcc5ef:packages/skills/skills/contribute-to-eliza"} -->
