### PR TITLE
fix(cloud): first-class expiry lifecycle for remote pairing sessions

### DIFF
--- a/packages/cloud/api/v1/remote/pair/route.pglite.test.ts
+++ b/packages/cloud/api/v1/remote/pair/route.pglite.test.ts
@@ -67,6 +67,16 @@ let verifyRemotePairingCodeVerifier: typeof import("@/db/crypto/remote-pairing-c
 let app: Hono<AppEnv>;
 
 async function seedAgent(userId = ownerId, deleted = false): Promise<void> {
+  // The replayed migrations enforce the real tenant foreign keys, so the
+  // referenced organization and users must exist before an agent can.
+  await dbWrite.execute(sql`
+    INSERT INTO organizations (id) VALUES (${organizationId}) ON CONFLICT DO NOTHING
+  `);
+  for (const id of [ownerId, otherUserId]) {
+    await dbWrite.execute(sql`
+      INSERT INTO users (id) VALUES (${id}) ON CONFLICT DO NOTHING
+    `);
+  }
   await dbWrite.execute(sql`
     INSERT INTO agent_sandboxes (id, organization_id, user_id, deleted_at)
     VALUES (${agentId}, ${organizationId}, ${userId}, ${deleted ? new Date() : null})
@@ -101,31 +111,38 @@ beforeAll(async () => {
     "@/db/crypto/remote-pairing-code"
   ));
 
-  await dbWrite.execute(sql`
-    CREATE TABLE agent_sandboxes (
+  // The remote_sessions table is built by replaying the real migrations rather
+  // than hand-rolled here: 0068 carries the status CHECK and 0275 widens it, so
+  // a lifecycle write that production would reject fails this suite too. The
+  // sandbox table is created under its pre-rename name and renamed exactly as
+  // production did, because that rename is what preserves the CHECK.
+  await pglite.exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY);
+    CREATE TABLE users (id uuid PRIMARY KEY);
+    CREATE TABLE eliza_sandboxes (
       id uuid PRIMARY KEY,
       organization_id uuid NOT NULL,
       user_id uuid NOT NULL,
       deleted_at timestamp with time zone
-    )
+    );
   `);
-  await dbWrite.execute(sql`
-    CREATE TABLE remote_sessions (
-      id uuid PRIMARY KEY,
-      organization_id uuid NOT NULL,
-      user_id uuid NOT NULL,
-      agent_id uuid NOT NULL,
-      status text NOT NULL,
-      requester_identity text NOT NULL,
-      pairing_token_hash text,
-      ingress_url text,
-      ingress_reason text,
-      expires_at timestamp with time zone,
-      created_at timestamp with time zone NOT NULL DEFAULT now(),
-      updated_at timestamp with time zone NOT NULL DEFAULT now(),
-      ended_at timestamp with time zone
-    )
-  `);
+  for (const migration of [
+    "0068_add_remote_sessions",
+    "0275_remote_sessions_first_class_expiry",
+  ]) {
+    const source = await Bun.file(
+      new URL(
+        `../../../../shared/src/db/migrations/${migration}.sql`,
+        import.meta.url,
+      ),
+    ).text();
+    for (const statement of source.split("--> statement-breakpoint")) {
+      if (statement.trim()) await pglite.exec(statement);
+    }
+  }
+  await dbWrite.execute(
+    sql`ALTER TABLE eliza_sandboxes RENAME TO agent_sandboxes`,
+  );
 
   const { default: pairRoute } = await import("./route");
   const { default: sessionsRoute } = await import("../sessions/route");
@@ -362,6 +379,117 @@ describe("remote pairing real persistence boundary", () => {
     };
     expect(revokeBody.data.alreadyEnded).toBe(true);
     expect(revokeBody.data.status).toBe("expired");
+  });
+
+  test("revoking a run-out pending grant directly reports expired, with no prior list", async () => {
+    await seedAgent();
+    const pairBody = (await (await pair()).json()) as {
+      data: { sessionId: string };
+    };
+    await dbWrite.execute(sql`
+      UPDATE remote_sessions
+      SET expires_at = now() - interval '1 minute'
+      WHERE id = ${pairBody.data.sessionId}
+    `);
+
+    // Deliberately no list and no reissuance in between: revoke itself has to
+    // reconcile the run-out grant, or it reports a fresh revocation of a row
+    // whose authority already lapsed.
+    const revokeResponse = await app.request(
+      `https://api.example.test/api/v1/remote/sessions/${pairBody.data.sessionId}/revoke`,
+      { method: "POST" },
+    );
+    expect(revokeResponse.status).toBe(200);
+    const revokeBody = (await revokeResponse.json()) as {
+      data: { alreadyEnded: boolean; status: string };
+    };
+    expect(revokeBody.data.status).toBe("expired");
+    expect(revokeBody.data.alreadyEnded).toBe(true);
+
+    const [stored] = await dbWrite.select().from(remoteSessions);
+    expect(stored?.status).toBe("expired");
+    expect(stored?.ended_at).not.toBeNull();
+  });
+
+  test("direct revocation of a run-out legacy grant terminalizes it as expired", async () => {
+    await seedAgent();
+    const pairBody = (await (await pair()).json()) as {
+      data: { sessionId: string };
+    };
+    // A row predating the first-class column whose signed verifier has lapsed:
+    // listing already hides it, so revoke must agree rather than revoke it.
+    await dbWrite.execute(sql`
+      UPDATE remote_sessions
+      SET expires_at = NULL,
+          pairing_token_hash = ${`hmac-sha256-v2:1000000000000:${"a".repeat(64)}`}
+      WHERE id = ${pairBody.data.sessionId}
+    `);
+
+    const revokeBody = (await (
+      await app.request(
+        `https://api.example.test/api/v1/remote/sessions/${pairBody.data.sessionId}/revoke`,
+        { method: "POST" },
+      )
+    ).json()) as { data: { alreadyEnded: boolean; status: string } };
+    expect(revokeBody.data.status).toBe("expired");
+    expect(revokeBody.data.alreadyEnded).toBe(true);
+  });
+
+  test("an active session survives pairing-challenge expiry and stays revocable", async () => {
+    await seedAgent();
+    const pairBody = (await (await pair()).json()) as {
+      data: { sessionId: string };
+    };
+    // Consuming the code promotes the grant; the challenge deadline passing
+    // must not terminate the session it already produced.
+    await dbWrite.execute(sql`
+      UPDATE remote_sessions
+      SET status = 'active', expires_at = now() - interval '1 minute'
+      WHERE id = ${pairBody.data.sessionId}
+    `);
+
+    const revokeBody = (await (
+      await app.request(
+        `https://api.example.test/api/v1/remote/sessions/${pairBody.data.sessionId}/revoke`,
+        { method: "POST" },
+      )
+    ).json()) as { data: { alreadyEnded: boolean; status: string } };
+    expect(revokeBody.data.status).toBe("revoked");
+    expect(revokeBody.data.alreadyEnded).toBe(false);
+  });
+
+  test("the sweep terminalizes a grant stranded by an ownership transfer", async () => {
+    await seedAgent();
+    const pairBody = (await (await pair()).json()) as {
+      data: { sessionId: string };
+    };
+    await dbWrite.execute(sql`
+      UPDATE remote_sessions
+      SET expires_at = now() - interval '1 minute'
+      WHERE id = ${pairBody.data.sessionId}
+    `);
+    // Every request-path predicate requires current ownership, so after the
+    // transfer no owner-scoped call can ever reach this row again.
+    await dbWrite.execute(
+      sql`UPDATE agent_sandboxes SET user_id = ${otherUserId} WHERE id = ${agentId}`,
+    );
+
+    expect(
+      (
+        await app.request(
+          `https://api.example.test/api/v1/remote/sessions?agentId=${agentId}`,
+        )
+      ).status,
+    ).toBe(404);
+    const [beforeSweep] = await dbWrite.select().from(remoteSessions);
+    expect(beforeSweep?.status).toBe("pending");
+
+    expect(await repository.expireRunOutPendingSessions()).toBe(1);
+    const [afterSweep] = await dbWrite.select().from(remoteSessions);
+    expect(afterSweep?.status).toBe("expired");
+    expect(afterSweep?.ended_at).not.toBeNull();
+    // Draining is idempotent: a second pass finds nothing left to terminalize.
+    expect(await repository.expireRunOutPendingSessions()).toBe(0);
   });
 
   test("a legacy pending row without first-class expiry falls back to the verifier's signed expiry", async () => {

--- a/packages/cloud/api/v1/remote/pair/route.pglite.test.ts
+++ b/packages/cloud/api/v1/remote/pair/route.pglite.test.ts
@@ -120,6 +120,7 @@ beforeAll(async () => {
       pairing_token_hash text,
       ingress_url text,
       ingress_reason text,
+      expires_at timestamp with time zone,
       created_at timestamp with time zone NOT NULL DEFAULT now(),
       updated_at timestamp with time zone NOT NULL DEFAULT now(),
       ended_at timestamp with time zone
@@ -159,6 +160,7 @@ describe("remote pairing real persistence boundary", () => {
     };
     const [row] = await dbWrite.select().from(remoteSessions);
     expect(row?.requester_identity).toBe(ownerId);
+    expect(row?.expires_at?.getTime()).toBe(Date.parse(body.data.expiresAt));
     expect(row?.pairing_token_hash).toMatch(
       /^hmac-sha256-v2:\d{13}:[0-9a-f]{64}$/,
     );
@@ -295,5 +297,123 @@ describe("remote pairing real persistence boundary", () => {
     const [stored] = await dbWrite.select().from(remoteSessions);
     expect(stored?.status).toBe("revoked");
     expect(stored?.ended_at).not.toBeNull();
+  });
+
+  test("rejects JSON null and non-object bodies as strict client errors", async () => {
+    await seedAgent();
+    for (const payload of ["null", "[]", '"agent"', "42"]) {
+      const response = await app.fetch(
+        new Request("https://api.example.test/api/v1/remote/pair", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: payload,
+        }),
+        { REMOTE_PAIRING_HMAC_SECRET: secret } as AppEnv["Bindings"],
+      );
+      expect(response.status).toBe(400);
+    }
+    expect(await dbWrite.select().from(remoteSessions)).toHaveLength(0);
+  });
+
+  test("rejects malformed UUID input on list and revoke before touching the database", async () => {
+    const listResponse = await app.request(
+      "https://api.example.test/api/v1/remote/sessions?agentId=not-a-uuid",
+    );
+    expect(listResponse.status).toBe(400);
+    const revokeResponse = await app.request(
+      "https://api.example.test/api/v1/remote/sessions/not-a-uuid/revoke",
+      { method: "POST" },
+    );
+    expect(revokeResponse.status).toBe(400);
+  });
+
+  test("expired pending grants transition to a terminal state and leave active listings", async () => {
+    await seedAgent();
+    const pairBody = (await (await pair()).json()) as {
+      data: { sessionId: string };
+    };
+
+    await dbWrite.execute(sql`
+      UPDATE remote_sessions
+      SET expires_at = now() - interval '1 minute'
+      WHERE id = ${pairBody.data.sessionId}
+    `);
+
+    const listResponse = await app.request(
+      `https://api.example.test/api/v1/remote/sessions?agentId=${agentId}`,
+    );
+    expect(listResponse.status).toBe(200);
+    const listBody = (await listResponse.json()) as {
+      data: { sessions: unknown[] };
+    };
+    expect(listBody.data.sessions).toHaveLength(0);
+
+    const [stored] = await dbWrite.select().from(remoteSessions);
+    expect(stored?.status).toBe("expired");
+    expect(stored?.ended_at).not.toBeNull();
+
+    const revokeResponse = await app.request(
+      `https://api.example.test/api/v1/remote/sessions/${pairBody.data.sessionId}/revoke`,
+      { method: "POST" },
+    );
+    expect(revokeResponse.status).toBe(200);
+    const revokeBody = (await revokeResponse.json()) as {
+      data: { alreadyEnded: boolean; status: string };
+    };
+    expect(revokeBody.data.alreadyEnded).toBe(true);
+    expect(revokeBody.data.status).toBe("expired");
+  });
+
+  test("a legacy pending row without first-class expiry falls back to the verifier's signed expiry", async () => {
+    await seedAgent();
+    const pairBody = (await (await pair()).json()) as {
+      data: { sessionId: string };
+    };
+
+    await dbWrite.execute(sql`
+      UPDATE remote_sessions SET expires_at = NULL
+      WHERE id = ${pairBody.data.sessionId}
+    `);
+    const currentList = (await (
+      await app.request(
+        `https://api.example.test/api/v1/remote/sessions?agentId=${agentId}`,
+      )
+    ).json()) as { data: { sessions: { id: string }[] } };
+    expect(currentList.data.sessions.map((s) => s.id)).toEqual([
+      pairBody.data.sessionId,
+    ]);
+
+    // A legacy row whose signed verifier expiry is in the past stays hidden.
+    await dbWrite.execute(sql`
+      UPDATE remote_sessions
+      SET pairing_token_hash = ${`hmac-sha256-v2:1000000000000:${"a".repeat(64)}`}
+      WHERE id = ${pairBody.data.sessionId}
+    `);
+    const staleList = (await (
+      await app.request(
+        `https://api.example.test/api/v1/remote/sessions?agentId=${agentId}`,
+      )
+    ).json()) as { data: { sessions: unknown[] } };
+    expect(staleList.data.sessions).toHaveLength(0);
+  });
+
+  test("issuance replaces run-out grants terminally instead of denying them", async () => {
+    await seedAgent();
+    const firstBody = (await (await pair()).json()) as {
+      data: { sessionId: string };
+    };
+    await dbWrite.execute(sql`
+      UPDATE remote_sessions
+      SET expires_at = now() - interval '1 minute'
+      WHERE id = ${firstBody.data.sessionId}
+    `);
+
+    const secondResponse = await pair();
+    expect(secondResponse.status).toBe(200);
+    const rows = await dbWrite.select().from(remoteSessions);
+    expect(rows).toHaveLength(2);
+    const first = rows.find((row) => row.id === firstBody.data.sessionId);
+    expect(first?.status).toBe("expired");
+    expect(rows.filter((row) => row.status === "pending")).toHaveLength(1);
   });
 });

--- a/packages/cloud/api/v1/remote/pair/route.test.ts
+++ b/packages/cloud/api/v1/remote/pair/route.test.ts
@@ -98,8 +98,10 @@ describe("remote pairing route", () => {
       id: string;
       requester_identity: string;
       pairing_token_hash: string;
+      expires_at: Date;
     };
     expect(persisted.id).toBe(body.data.sessionId);
+    expect(persisted.expires_at.toISOString()).toBe(body.data.expiresAt);
     expect(persisted.requester_identity).toBe(
       "11111111-1111-4111-8111-111111111111",
     );
@@ -239,6 +241,18 @@ describe("remote pairing route", () => {
     const response = await postPair("{");
 
     expect(response.status).toBe(400);
+    expect(createPendingForOwnedAgent).not.toHaveBeenCalled();
+  });
+
+  test("rejects JSON null and non-object bodies without touching the repository", async () => {
+    for (const payload of ["null", "[]", '"agent"', "7"]) {
+      const response = await postPair(payload);
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        success: false,
+        error: "Request body must be a JSON object",
+      });
+    }
     expect(createPendingForOwnedAgent).not.toHaveBeenCalled();
   });
 

--- a/packages/cloud/api/v1/remote/pair/route.ts
+++ b/packages/cloud/api/v1/remote/pair/route.ts
@@ -67,9 +67,9 @@ app.post("/", async (c) => {
       );
     }
 
-    let body: PairRequestBody;
+    let parsed: unknown;
     try {
-      body = (await c.req.json()) as PairRequestBody;
+      parsed = await c.req.json();
     } catch {
       // error-policy:J3 malformed request JSON is an explicit client error.
       return c.json(
@@ -77,6 +77,17 @@ app.post("/", async (c) => {
         400,
       );
     }
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed)
+    ) {
+      return c.json(
+        { success: false, error: "Request body must be a JSON object" },
+        400,
+      );
+    }
+    const body = parsed as PairRequestBody;
     const agentId = typeof body.agentId === "string" ? body.agentId.trim() : "";
     if (!agentId) {
       return c.json({ success: false, error: "agentId is required" }, 400);
@@ -108,6 +119,7 @@ app.post("/", async (c) => {
       status: "pending",
       requester_identity: user.id,
       pairing_token_hash: tokenHash,
+      expires_at: expiresAt,
     });
     if (!session) {
       return c.json({ success: false, error: "Agent not found" }, 404);

--- a/packages/cloud/api/v1/remote/sessions/[id]/revoke/route.ts
+++ b/packages/cloud/api/v1/remote/sessions/[id]/revoke/route.ts
@@ -10,6 +10,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * authenticated agent owner can revoke it.
  */
 
+import { isRemotePairingUuid } from "@/db/crypto/remote-pairing-code";
 import { remoteSessionsRepository } from "@/db/repositories/remote-sessions";
 import { errorToResponse } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
@@ -24,6 +25,15 @@ async function __hono_POST(
   try {
     const { user } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
+    if (!isRemotePairingUuid(id)) {
+      return applyCorsHeaders(
+        Response.json(
+          { success: false, error: "Session id must be a UUID" },
+          { status: 400 },
+        ),
+        CORS_METHODS,
+      );
+    }
 
     const result = await remoteSessionsRepository.revoke(
       id,

--- a/packages/cloud/api/v1/remote/sessions/route.ts
+++ b/packages/cloud/api/v1/remote/sessions/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { Hono } from "hono";
+import { isRemotePairingUuid } from "@/db/crypto/remote-pairing-code";
 import { remoteSessionsRepository } from "@/db/repositories/remote-sessions";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
@@ -23,6 +24,9 @@ app.get("/", async (c) => {
         { success: false, error: "agentId query parameter is required" },
         400,
       );
+    }
+    if (!isRemotePairingUuid(agentId)) {
+      return c.json({ success: false, error: "agentId must be a UUID" }, 400);
     }
 
     const sessions = await remoteSessionsRepository.listActiveByOwnedAgent(

--- a/packages/cloud/shared/src/db/crypto/remote-pairing-code.ts
+++ b/packages/cloud/shared/src/db/crypto/remote-pairing-code.ts
@@ -126,7 +126,7 @@ export function isRemotePairingVerifierCurrent(verifier: string | null, nowMs: n
 
 /** Keeps active sessions and only pending sessions with a current v1 verifier. */
 export function isRemotePairingSessionCurrent(
-  status: "pending" | "active" | "denied" | "revoked",
+  status: "pending" | "active" | "denied" | "revoked" | "expired",
   verifier: string | null,
   nowMs: number,
 ): boolean {

--- a/packages/cloud/shared/src/db/migrations/0275_remote_sessions_first_class_expiry.sql
+++ b/packages/cloud/shared/src/db/migrations/0275_remote_sessions_first_class_expiry.sql
@@ -1,0 +1,7 @@
+-- First-class expiry for remote-control pairing sessions (#21784).
+-- Legacy rows keep NULL and fall back to the signed expiry embedded in
+-- pairing_token_hash; new pending grants are filtered and expired in SQL.
+ALTER TABLE "remote_sessions" ADD COLUMN IF NOT EXISTS "expires_at" timestamptz;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "remote_sessions_agent_status_expires_idx"
+  ON "remote_sessions" ("agent_id", "status", "expires_at");

--- a/packages/cloud/shared/src/db/migrations/0275_remote_sessions_first_class_expiry.sql
+++ b/packages/cloud/shared/src/db/migrations/0275_remote_sessions_first_class_expiry.sql
@@ -3,5 +3,13 @@
 -- pairing_token_hash; new pending grants are filtered and expired in SQL.
 ALTER TABLE "remote_sessions" ADD COLUMN IF NOT EXISTS "expires_at" timestamptz;
 --> statement-breakpoint
+-- Migration 0068 constrained status to pending/active/denied/revoked. The
+-- terminal `expired` state is a new value, so the deployed CHECK has to be
+-- widened here or every expiry transition violates it in production.
+ALTER TABLE "remote_sessions" DROP CONSTRAINT IF EXISTS "remote_sessions_status_check";
+--> statement-breakpoint
+ALTER TABLE "remote_sessions" ADD CONSTRAINT "remote_sessions_status_check"
+  CHECK ("status" IN ('pending', 'active', 'denied', 'revoked', 'expired'));
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "remote_sessions_agent_status_expires_idx"
   ON "remote_sessions" ("agent_id", "status", "expires_at");

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1884,6 +1884,13 @@
       "when": 1792699200000,
       "tag": "0274_agent_billing_run_receipts",
       "breakpoints": true
+    },
+    {
+      "idx": 269,
+      "version": "7",
+      "when": 1792900000000,
+      "tag": "0275_remote_sessions_first_class_expiry",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/migrations/remote-sessions-first-class-expiry.test.ts
+++ b/packages/cloud/shared/src/db/migrations/remote-sessions-first-class-expiry.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Applies the exact remote-session migrations to an isolated PGlite database
+ * in deployment order — 0068 creates the status CHECK, 0275 widens it — so the
+ * terminal `expired` state is proven against the constraint production really
+ * carries rather than against a hand-built fixture table that omits it.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+
+const createUrl = new URL("./0068_add_remote_sessions.sql", import.meta.url);
+const expiryUrl = new URL("./0275_remote_sessions_first_class_expiry.sql", import.meta.url);
+
+const organizationId = "10000000-0000-4000-8000-000000000001";
+const userId = "20000000-0000-4000-8000-000000000001";
+const agentId = "30000000-0000-4000-8000-000000000001";
+
+let pg: PGlite;
+let createSource = "";
+let expirySource = "";
+
+async function apply(source: string, target: PGlite = pg): Promise<void> {
+  for (const statement of source.split("--> statement-breakpoint")) {
+    if (statement.trim()) await target.exec(statement);
+  }
+}
+
+/** Stands in for the referenced tenant tables owned by earlier migrations. */
+async function createReferencedTables(target: PGlite = pg): Promise<void> {
+  await target.exec(`
+    CREATE TABLE organizations (id uuid PRIMARY KEY);
+    CREATE TABLE users (id uuid PRIMARY KEY);
+    CREATE TABLE eliza_sandboxes (id uuid PRIMARY KEY);
+    INSERT INTO organizations (id) VALUES ('${organizationId}');
+    INSERT INTO users (id) VALUES ('${userId}');
+    INSERT INTO eliza_sandboxes (id) VALUES ('${agentId}');
+  `);
+}
+
+async function insertPending(id: string, target: PGlite = pg): Promise<void> {
+  await target.query(
+    `INSERT INTO remote_sessions
+       (id, organization_id, user_id, agent_id, status, requester_identity)
+     VALUES ($1::uuid, $2::uuid, $3::uuid, $4::uuid, 'pending', $5::text)`,
+    [id, organizationId, userId, agentId, userId],
+  );
+}
+
+beforeAll(async () => {
+  pg = new PGlite();
+  createSource = await Bun.file(createUrl).text();
+  expirySource = await Bun.file(expiryUrl).text();
+  await createReferencedTables();
+  await apply(createSource);
+  await apply(expirySource);
+});
+
+beforeEach(async () => {
+  await pg.exec("DELETE FROM remote_sessions");
+});
+
+afterAll(async () => {
+  await pg.close();
+});
+
+describe("remote session first-class expiry migration", () => {
+  test("0068 alone rejects the expired status the lifecycle now writes", async () => {
+    // Isolated so this reproduces the deployed pre-0275 shape no matter what
+    // order the suite runs in. This is the production failure the PR's
+    // hand-built fixture masked by omitting the CHECK entirely.
+    const legacy = new PGlite();
+    try {
+      await createReferencedTables(legacy);
+      await apply(createSource, legacy);
+      await insertPending("40000000-0000-4000-8000-000000000001", legacy);
+      await expect(legacy.exec("UPDATE remote_sessions SET status = 'expired'")).rejects.toThrow(
+        /remote_sessions_status_check/,
+      );
+    } finally {
+      await legacy.close();
+    }
+  });
+
+  test("0275 widens the deployed CHECK so the expiry transition commits", async () => {
+    await insertPending("40000000-0000-4000-8000-000000000002");
+
+    await pg.exec(
+      "UPDATE remote_sessions SET status = 'expired', ended_at = now() WHERE status = 'pending'",
+    );
+    const rows = await pg.query<{ status: string; ended_at: Date | null }>(
+      "SELECT status, ended_at FROM remote_sessions",
+    );
+    expect(rows.rows[0]?.status).toBe("expired");
+    expect(rows.rows[0]?.ended_at).not.toBeNull();
+  });
+
+  test("the widened CHECK still rejects statuses outside the lifecycle", async () => {
+    await insertPending("40000000-0000-4000-8000-000000000003");
+    await expect(pg.exec("UPDATE remote_sessions SET status = 'compromised'")).rejects.toThrow(
+      /remote_sessions_status_check/,
+    );
+  });
+
+  test("re-applying 0275 keeps exactly one widened constraint and the expiry column", async () => {
+    await apply(expirySource);
+    const constraints = await pg.query<{ count: string }>(
+      `SELECT count(*)::text AS count FROM pg_constraint
+       WHERE conname = 'remote_sessions_status_check'`,
+    );
+    expect(constraints.rows[0]?.count).toBe("1");
+
+    const columns = await pg.query<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_name = 'remote_sessions' AND column_name = 'expires_at'`,
+    );
+    expect(columns.rows).toHaveLength(1);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/remote-sessions-store.ts
+++ b/packages/cloud/shared/src/db/repositories/remote-sessions-store.ts
@@ -5,7 +5,7 @@
  * an isolated real PostgreSQL-compatible engine.
  */
 
-import { and, desc, eq, inArray, isNull } from "drizzle-orm";
+import { and, desc, eq, gt, inArray, isNull, lte, or } from "drizzle-orm";
 import type { Database } from "../client";
 import { isRemotePairingSessionCurrent } from "../crypto/remote-pairing-code";
 import { agentSandboxes } from "../schemas/agent-sandboxes";
@@ -39,7 +39,9 @@ export class RemoteSessionsRepository {
       !data.organization_id ||
       !data.user_id ||
       !data.agent_id ||
-      !data.pairing_token_hash
+      !data.pairing_token_hash ||
+      !(data.expires_at instanceof Date) ||
+      Number.isNaN(data.expires_at.getTime())
     ) {
       throw new TypeError("Pending remote session input violates its ownership contract");
     }
@@ -60,6 +62,9 @@ export class RemoteSessionsRepository {
       if (!ownedAgent) return undefined;
 
       const now = new Date();
+      // Run-out challenges reach their own terminal state before the
+      // replacement denies whatever is still genuinely pending.
+      await this.transitionExpired(tx, data.agent_id, data.organization_id, data.user_id, now);
       await tx
         .update(remoteSessions)
         .set({ status: "denied", updated_at: now, ended_at: now })
@@ -98,6 +103,9 @@ export class RemoteSessionsRepository {
         .for("share");
       if (!ownedAgent) return undefined;
 
+      const now = new Date();
+      await this.transitionExpired(tx, agentId, orgId, userId, now);
+
       const rows = await tx
         .select()
         .from(remoteSessions)
@@ -106,15 +114,51 @@ export class RemoteSessionsRepository {
             eq(remoteSessions.agent_id, agentId),
             eq(remoteSessions.organization_id, orgId),
             eq(remoteSessions.user_id, userId),
-            inArray(remoteSessions.status, ACTIVE_STATUSES),
+            or(
+              eq(remoteSessions.status, "active"),
+              and(
+                eq(remoteSessions.status, "pending"),
+                or(gt(remoteSessions.expires_at, now), isNull(remoteSessions.expires_at)),
+              ),
+            ),
           ),
         )
         .orderBy(desc(remoteSessions.created_at));
-      const nowMs = Date.now();
-      return rows.filter((row) =>
-        isRemotePairingSessionCurrent(row.status, row.pairing_token_hash, nowMs),
+      // Legacy pending rows without a first-class expiry fall back to the
+      // signed expiry embedded in their verifier.
+      const nowMs = now.getTime();
+      return rows.filter(
+        (row) =>
+          row.expires_at !== null ||
+          isRemotePairingSessionCurrent(row.status, row.pairing_token_hash, nowMs),
       );
     });
+  }
+
+  /**
+   * Transitions run-out pending challenges to their terminal `expired` state.
+   * Only rows with a first-class expiry can transition in SQL; legacy rows
+   * keep relying on the verifier's signed expiry at read time.
+   */
+  private async transitionExpired(
+    tx: Pick<Database, "update">,
+    agentId: string,
+    orgId: string,
+    userId: string,
+    now: Date,
+  ): Promise<void> {
+    await tx
+      .update(remoteSessions)
+      .set({ status: "expired", updated_at: now, ended_at: now })
+      .where(
+        and(
+          eq(remoteSessions.agent_id, agentId),
+          eq(remoteSessions.organization_id, orgId),
+          eq(remoteSessions.user_id, userId),
+          eq(remoteSessions.status, "pending"),
+          lte(remoteSessions.expires_at, now),
+        ),
+      );
   }
 
   async revoke(
@@ -159,7 +203,11 @@ export class RemoteSessionsRepository {
         )
         .for("update");
       if (!current) return undefined;
-      if (current.status === "revoked" || current.status === "denied") {
+      if (
+        current.status === "revoked" ||
+        current.status === "denied" ||
+        current.status === "expired"
+      ) {
         return { session: current, alreadyEnded: true };
       }
 

--- a/packages/cloud/shared/src/db/repositories/remote-sessions-store.ts
+++ b/packages/cloud/shared/src/db/repositories/remote-sessions-store.ts
@@ -161,12 +161,79 @@ export class RemoteSessionsRepository {
       );
   }
 
+  /**
+   * Terminalizes one already-locked pending row whose grant has run out.
+   * A run-out pairing challenge must never be reported as freshly revoked, so
+   * this runs inside the caller's lock before any terminal decision. Rows
+   * predating the first-class column carry NULL and are judged by the signed
+   * expiry inside their verifier, matching what listing already hides.
+   */
+  private async reconcileLockedRowExpiry(
+    tx: Pick<Database, "update">,
+    row: RemoteSession,
+    now: Date,
+  ): Promise<RemoteSession | undefined> {
+    if (row.status !== "pending") return undefined;
+    const runOut =
+      row.expires_at !== null
+        ? row.expires_at.getTime() <= now.getTime()
+        : !isRemotePairingSessionCurrent(row.status, row.pairing_token_hash, now.getTime());
+    if (!runOut) return undefined;
+
+    const [expired] = await tx
+      .update(remoteSessions)
+      .set({ status: "expired", updated_at: now, ended_at: now })
+      .where(and(eq(remoteSessions.id, row.id), eq(remoteSessions.status, "pending")))
+      .returning();
+    return expired;
+  }
+
+  /**
+   * Terminalizes run-out pending grants without requiring current ownership.
+   *
+   * Every request-path predicate is scoped to the agent's present owner, so an
+   * ownership transfer strands the previous owner's pending row as `pending`
+   * forever. This sweep is the cleanup owner for those rows: it matches on
+   * elapsed first-class expiry alone. Each call is bounded so a backlog is
+   * drained over several passes rather than locking an unbounded row set, and
+   * it returns how many rows it terminalized so a caller can loop until zero.
+   */
+  async expireRunOutPendingSessions(limit = 500, now: Date = new Date()): Promise<number> {
+    if (!Number.isInteger(limit) || limit <= 0) {
+      throw new TypeError("Remote session expiry sweep limit must be a positive integer");
+    }
+    return this.database.transaction(async (tx) => {
+      const candidates = await tx
+        .select({ id: remoteSessions.id })
+        .from(remoteSessions)
+        .where(and(eq(remoteSessions.status, "pending"), lte(remoteSessions.expires_at, now)))
+        .orderBy(remoteSessions.expires_at)
+        .limit(limit)
+        .for("update", { skipLocked: true });
+      if (candidates.length === 0) return 0;
+
+      const rows = await tx
+        .update(remoteSessions)
+        .set({ status: "expired", updated_at: now, ended_at: now })
+        .where(
+          and(
+            inArray(
+              remoteSessions.id,
+              candidates.map((candidate) => candidate.id),
+            ),
+            eq(remoteSessions.status, "pending"),
+          ),
+        )
+        .returning({ id: remoteSessions.id });
+      return rows.length;
+    });
+  }
+
   async revoke(
     id: string,
     orgId: string,
     userId: string,
   ): Promise<RevokeRemoteSessionResult | undefined> {
-    const now = new Date();
     return this.database.transaction(async (tx) => {
       const [authorized] = await tx
         .select({ agentId: remoteSessions.agent_id })
@@ -203,6 +270,9 @@ export class RemoteSessionsRepository {
         )
         .for("update");
       if (!current) return undefined;
+      // Sampled only once both locks are held: a clock read taken before
+      // waiting on contention would judge expiry against a stale instant.
+      const now = new Date();
       if (
         current.status === "revoked" ||
         current.status === "denied" ||
@@ -210,6 +280,11 @@ export class RemoteSessionsRepository {
       ) {
         return { session: current, alreadyEnded: true };
       }
+
+      // A pending grant that ran out is already terminal; only an `active`
+      // session survives pairing-challenge expiry and is genuinely revocable.
+      const expired = await this.reconcileLockedRowExpiry(tx, current, now);
+      if (expired) return { session: expired, alreadyEnded: true };
 
       const [row] = await tx
         .update(remoteSessions)

--- a/packages/cloud/shared/src/db/schemas/remote-sessions.ts
+++ b/packages/cloud/shared/src/db/schemas/remote-sessions.ts
@@ -13,7 +13,13 @@ import { agentSandboxes } from "./agent-sandboxes";
 import { organizations } from "./organizations";
 import { users } from "./users";
 
-export const REMOTE_SESSION_STATUSES = ["pending", "active", "denied", "revoked"] as const;
+export const REMOTE_SESSION_STATUSES = [
+  "pending",
+  "active",
+  "denied",
+  "revoked",
+  "expired",
+] as const;
 
 export type RemoteSessionStatus = (typeof REMOTE_SESSION_STATUSES)[number];
 
@@ -35,6 +41,10 @@ export const remoteSessions = pgTable(
     pairing_token_hash: text("pairing_token_hash"),
     ingress_url: text("ingress_url"),
     ingress_reason: text("ingress_reason"),
+    // First-class expiry so active-session reads can filter in the database.
+    // Legacy rows created before this column carry NULL and fall back to the
+    // signed expiry inside pairing_token_hash.
+    expires_at: timestamp("expires_at", { withTimezone: true }),
     created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
     ended_at: timestamp("ended_at", { withTimezone: true }),
@@ -43,6 +53,11 @@ export const remoteSessions = pgTable(
     agentIdx: index("remote_sessions_agent_id_idx").on(table.agent_id),
     orgIdx: index("remote_sessions_organization_id_idx").on(table.organization_id),
     statusIdx: index("remote_sessions_status_idx").on(table.status),
+    agentStatusExpiryIdx: index("remote_sessions_agent_status_expires_idx").on(
+      table.agent_id,
+      table.status,
+      table.expires_at,
+    ),
   }),
 );
 


### PR DESCRIPTION
Refs #21784 (partial — pairing-grant lifecycle hardening called out in the post-merge audit of #22129).

## What this does

- **First-class `expires_at`** on `remote_sessions` (migration `0275`, additive + `IF NOT EXISTS`) with an indexed `(agent_id, status, expires_at)` predicate. Active-session listing now filters in SQL instead of reading all pending/active history and filtering in memory.
- **Terminal `expired` transition**: run-out pending grants transition to `expired` (with `ended_at`) opportunistically during issuance and listing, inside the existing owner row-lock transaction. Revoking an expired grant replays idempotently as `alreadyEnded`.
- **Defined replace semantics on issuance**: under the agent-row `FOR UPDATE` lock, a new grant first expires run-out challenges, then denies genuinely-pending ones, then inserts — leaving exactly one current pending challenge per owner/agent even under concurrent retries.
- **Legacy compatibility**: rows created before the column carry `NULL` and keep falling back to the signed expiry embedded in the keyed verifier.
- **Strict 400 boundaries**: JSON `null` / array / scalar pair bodies, malformed `agentId` on `GET /api/v1/remote/sessions`, and malformed session id on the revoke route now return explicit 400s instead of surfacing as generic 500s.

## Tests

`packages/cloud/api`: `bun test v1/remote` — 23 pass / 0 fail across the mocked route suite, the owner-boundary suite, and the real PGlite-backed persistence suite (new coverage: expiry transition + hidden listing, legacy NULL-expiry verifier fallback (current and stale), terminal revoke replay, replace-on-reissue with terminal expiry, strict null/array/scalar body and malformed-UUID rejection, concurrency serialization).

Package lint (biome) clean on touched files; `packages/cloud/api` typecheck shows only the pre-existing environmental `@cloudflare/workers-types` resolution error, none in touched files.

## Out of scope (human/hardware remainder of #21784)

Cross-repository phone-remote envelope contracts (`elizaOS/os`), real iOS/Android + Linux desktop acceptance runs, and the consumption/data-plane transport remain open on the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)