### PR TITLE
fix(security): make product input scanners linear

### DIFF
--- a/packages/app-core/platforms/electrobun/scripts/bench-cloud-login.mjs
+++ b/packages/app-core/platforms/electrobun/scripts/bench-cloud-login.mjs
@@ -25,6 +25,7 @@
  *   --poll-interval MS  Milliseconds between polls (default 2000)
  *   --no-cors-check     Skip the CORS preflight check
  */
+import crypto from "node:crypto";
 
 // ─── Arg parsing ─────────────────────────────────────────────────────────────
 
@@ -137,7 +138,7 @@ async function runLoginFlow(round) {
 
   // Step 1: Create CLI session
   const sessionPayload = JSON.stringify({
-    sessionId: `bench-${Date.now()}-${round}-${Math.random().toString(36).slice(2, 8)}`,
+    sessionId: `bench-${round}-${crypto.randomUUID()}`,
   });
 
   const createResult = await timedFetch(

--- a/packages/app-core/platforms/electrobun/scripts/bench-cloud-login.mjs
+++ b/packages/app-core/platforms/electrobun/scripts/bench-cloud-login.mjs
@@ -60,7 +60,9 @@ function parseArgs(argv) {
         break;
       case "--help":
       case "-h":
-        console.log(`Usage: bun run bench:cloud-login [--rounds N] [--api-base URL] [--web-base URL] [--poll-rounds N] [--poll-interval MS] [--no-cors-check]`);
+        console.log(
+          `Usage: bun run bench:cloud-login [--rounds N] [--api-base URL] [--web-base URL] [--poll-rounds N] [--poll-interval MS] [--no-cors-check]`,
+        );
         process.exit(0);
     }
   }
@@ -252,8 +254,13 @@ async function main() {
   console.log(`API base:       ${config.apiBase}`);
   console.log(`Web base:       ${config.webBase}`);
   console.log(`Rounds:         ${config.rounds}`);
-  console.log(`Poll rounds:    ${config.pollRounds} (interval: ${config.pollIntervalMs}ms)`);
-  const runtimeName = typeof Bun !== "undefined" ? `Bun ${Bun.version}` : `Node ${process.version}`;
+  console.log(
+    `Poll rounds:    ${config.pollRounds} (interval: ${config.pollIntervalMs}ms)`,
+  );
+  const runtimeName =
+    typeof Bun !== "undefined"
+      ? `Bun ${Bun.version}`
+      : `Node ${process.version}`;
   console.log(`Runtime:        ${runtimeName}`);
   console.log(`Timestamp:      ${new Date().toISOString()}`);
   console.log("=".repeat(80));
@@ -295,9 +302,7 @@ async function main() {
         : r.error
           ? `ERR: ${r.error}`
           : `${r.status}`;
-      console.log(
-        `  ${r.label}`,
-      );
+      console.log(`  ${r.label}`);
       console.log(
         `    status: ${status}  time: ${fmtMs(r.totalMs)}  ttfb: ${r.ttfbMs ? fmtMs(r.ttfbMs) : "n/a"}`,
       );
@@ -380,7 +385,9 @@ async function main() {
     `   TOTAL estimated e2e:            ~${(totalEstimate / 1000).toFixed(1)}s`,
   );
   console.log();
-  console.log(`   API-only overhead (no user):   ${fmtMs(createMs + pollLoopMs)}`);
+  console.log(
+    `   API-only overhead (no user):   ${fmtMs(createMs + pollLoopMs)}`,
+  );
   console.log(
     `   User-dependent latency:         ~${((browserOpenMs + userAuthMs + tokenPersistMs) / 1000).toFixed(1)}s`,
   );
@@ -392,8 +399,12 @@ async function main() {
   console.log(
     `\nCreate:  [${createSamples.map((s) => s.toFixed(1)).join(", ")}] ms`,
   );
-  console.log(`Poll:    [${pollSamples.map((s) => s.toFixed(1)).join(", ")}] ms`);
-  console.log(`Flow:    [${flowSamples.map((s) => s.toFixed(1)).join(", ")}] ms`);
+  console.log(
+    `Poll:    [${pollSamples.map((s) => s.toFixed(1)).join(", ")}] ms`,
+  );
+  console.log(
+    `Flow:    [${flowSamples.map((s) => s.toFixed(1)).join(", ")}] ms`,
+  );
 
   console.log("\nDone.");
 }

--- a/packages/app-core/platforms/electrobun/src/bench-cloud-login.contract.test.ts
+++ b/packages/app-core/platforms/electrobun/src/bench-cloud-login.contract.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Guards the desktop cloud-login benchmark's posted session identifier.
+ * This source contract is deterministic and does not contact the cloud API.
+ */
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const benchmarkSource = readFileSync(
+  new URL("../scripts/bench-cloud-login.mjs", import.meta.url),
+  "utf8",
+);
+
+describe("cloud-login benchmark session identity", () => {
+  it("uses cryptographic UUIDs without a Math.random downgrade", () => {
+    expect(benchmarkSource).toContain('import crypto from "node:crypto"');
+    expect(benchmarkSource).toContain("crypto.randomUUID()");
+    expect(benchmarkSource).not.toContain("Math.random");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-envelope.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-envelope.test.ts
@@ -132,6 +132,12 @@ describe("parseCompletionEnvelope (#8895)", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("handles an adversarial amount of fence whitespace without backtracking", () => {
+    const input = `\`\`\`json${" \n\t".repeat(40_000)}${JSON.stringify(validEnvelope())}\n\`\`\``;
+    const res = parseCompletionEnvelope(input);
+    expect(res.ok).toBe(true);
+  });
+
   it("accepts a bare JSON object with no fence", () => {
     const res = parseCompletionEnvelope(JSON.stringify(validEnvelope()));
     expect(res.ok).toBe(true);

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-envelope.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-envelope.test.ts
@@ -138,6 +138,11 @@ describe("parseCompletionEnvelope (#8895)", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("keeps original offsets when a Unicode prefix expands under lowercase", () => {
+    const res = parseCompletionEnvelope(`İ prefix\n${fenced(validEnvelope())}`);
+    expect(res.ok).toBe(true);
+  });
+
   it("accepts a bare JSON object with no fence", () => {
     const res = parseCompletionEnvelope(JSON.stringify(validEnvelope()));
     expect(res.ok).toBe(true);

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/transcript-sanitizer.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/transcript-sanitizer.test.ts
@@ -83,6 +83,11 @@ describe("stripToolTranscript", () => {
   it("returns empty string for empty input", () => {
     expect(stripToolTranscript("")).toBe("");
   });
+
+  it("strips a long malformed opener tail without rescanning it", () => {
+    const input = `keep\n${"[tool output:".repeat(40_000)}`;
+    expect(stripToolTranscript(input)).toBe("keep");
+  });
 });
 
 describe("elideLongBlocks", () => {

--- a/plugins/plugin-agent-orchestrator/src/services/completion-envelope.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-envelope.ts
@@ -104,13 +104,29 @@ function isStringArray(v: unknown): v is string[] {
   return Array.isArray(v) && v.every((x) => typeof x === "string");
 }
 
+function findAsciiCaseInsensitive(
+  text: string,
+  lowerNeedle: string,
+  from: number,
+): number {
+  const lastStart = text.length - lowerNeedle.length;
+  outer: for (let start = from; start <= lastStart; start++) {
+    for (let offset = 0; offset < lowerNeedle.length; offset++) {
+      const code = text.charCodeAt(start + offset);
+      const folded = code >= 65 && code <= 90 ? code + 32 : code;
+      if (folded !== lowerNeedle.charCodeAt(offset)) continue outer;
+    }
+    return start;
+  }
+  return -1;
+}
+
 function extractJsonCandidate(text: string): string | null {
   // Prefer the LAST fenced ```json block (the completion envelope comes last).
   let last: string | null = null;
-  const lower = text.toLowerCase();
   let cursor = 0;
   while (cursor < text.length) {
-    const start = lower.indexOf("```json", cursor);
+    const start = findAsciiCaseInsensitive(text, "```json", cursor);
     if (start < 0) break;
     let bodyStart = start + 7;
     let sawLineFeed = false;

--- a/plugins/plugin-agent-orchestrator/src/services/completion-envelope.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-envelope.ts
@@ -100,20 +100,32 @@ export type CompletionEnvelopeParse =
   | { present: true; ok: true; envelope: CompletionEnvelope }
   | { present: true; ok: false; errors: string[] };
 
-const FENCED_JSON_RE = /```json\s*\n([\s\S]*?)```/gi;
-
 function isStringArray(v: unknown): v is string[] {
   return Array.isArray(v) && v.every((x) => typeof x === "string");
 }
 
 function extractJsonCandidate(text: string): string | null {
   // Prefer the LAST fenced ```json block (the completion envelope comes last).
-  let match: RegExpExecArray | null;
   let last: string | null = null;
-  FENCED_JSON_RE.lastIndex = 0;
-  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
-  while ((match = FENCED_JSON_RE.exec(text)) !== null) {
-    last = match[1]?.trim() ?? null;
+  const lower = text.toLowerCase();
+  let cursor = 0;
+  while (cursor < text.length) {
+    const start = lower.indexOf("```json", cursor);
+    if (start < 0) break;
+    let bodyStart = start + 7;
+    let sawLineFeed = false;
+    while (bodyStart < text.length && /\s/.test(text[bodyStart] ?? "")) {
+      if (text[bodyStart] === "\n") sawLineFeed = true;
+      bodyStart++;
+    }
+    if (!sawLineFeed) {
+      cursor = start + 7;
+      continue;
+    }
+    const end = text.indexOf("```", bodyStart);
+    if (end < 0) break;
+    last = text.slice(bodyStart, end).trim() || null;
+    cursor = end + 3;
   }
   if (last) return last;
   // No fence: only treat the whole message as JSON when it clearly looks like

--- a/plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts
@@ -37,17 +37,26 @@ export const DEFAULT_MAX_RELAY_CHARS = 2000;
  */
 export function stripToolTranscript(text: string): string {
   if (!text) return "";
-  return (
-    text
-      // Well-formed and empty-title blocks (non-greedy body up to the fence).
-      .replace(/\[tool output:[^\]]*\][\s\S]*?\[\/tool output\]/g, "")
-      // Unterminated trailing block: dangling opener with no closing fence.
-      // Only fires if a `[tool output:` marker remains AFTER the pass above,
-      // which means it was never closed — strip it to end of string.
-      .replace(/\[tool output:[\s\S]*$/g, "")
-      .replace(/\n{3,}/g, "\n\n")
-      .trim()
-  );
+  const opener = "[tool output:";
+  const chunks: string[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    const start = text.indexOf(opener, cursor);
+    if (start < 0) {
+      chunks.push(text.slice(cursor));
+      break;
+    }
+    chunks.push(text.slice(cursor, start));
+    const titleEnd = text.indexOf("]", start + opener.length);
+    if (titleEnd < 0) break;
+    const end = text.indexOf(TOOL_OUTPUT_END_MARKER, titleEnd + 1);
+    if (end < 0) break;
+    cursor = end + TOOL_OUTPUT_END_MARKER.length;
+  }
+  return chunks
+    .join("")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
 }
 
 /**

--- a/plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts
@@ -88,19 +88,27 @@ describe("processBody edge handling", () => {
     expect(JSON.stringify(parsed)).not.toContain("hidden");
   });
 
-  it("strips a large collection of thinking fields without regex rescans", () => {
-    const thinking = Array.from({ length: 20_000 }, (_, index) => ({
-      thinking: { index },
-      visible: index,
-    }));
-    const { parsed, stats } = parseProcessed({ messages: [], items: thinking });
-    expect(stats.thinkingParamsStripped).toBe(20_000);
-    expect(JSON.stringify(parsed)).not.toContain('"thinking"');
+  it("strips only the top-level thinking config and preserves nested application data", () => {
+    const nestedThinking = [
+      { thinking: "tool input field" },
+      { thinking: ["domain", "values"] },
+      { thinking: { approved: true } },
+    ];
+    const { parsed, stats } = parseProcessed({
+      thinking: { type: "enabled", budget_tokens: 1024 },
+      messages: [{ role: "user", content: "hello" }],
+      toolInput: nestedThinking,
+    });
+
+    expect(stats.thinkingParamsStripped).toBe(1);
+    expect(parsed).not.toHaveProperty("thinking");
+    expect(parsed.toolInput).toEqual(nestedThinking);
   });
 
   it("fails closed when a sanitized deeply nested body cannot be serialized", () => {
     const depth = 100_000;
-    const body = `${'{"nested":'.repeat(depth)}{"thinking":{"enabled":true}}${"}".repeat(depth)}`;
+    const nested = `${'{"nested":'.repeat(depth)}{}${"}".repeat(depth)}`;
+    const body = `{"thinking":{"enabled":true},"payload":${nested}}`;
     expect(() => processBody(body, baseConfig)).toThrow();
   });
 });

--- a/plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts
@@ -87,4 +87,14 @@ describe("processBody edge handling", () => {
     ]);
     expect(JSON.stringify(parsed)).not.toContain("hidden");
   });
+
+  it("strips a large collection of thinking fields without regex rescans", () => {
+    const thinking = Array.from({ length: 20_000 }, (_, index) => ({
+      thinking: { index },
+      visible: index,
+    }));
+    const { parsed, stats } = parseProcessed({ messages: [], items: thinking });
+    expect(stats.thinkingParamsStripped).toBe(20_000);
+    expect(JSON.stringify(parsed)).not.toContain('"thinking"');
+  });
 });

--- a/plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts
+++ b/plugins/plugin-anthropic-proxy/__tests__/process-body.edge.test.ts
@@ -97,4 +97,10 @@ describe("processBody edge handling", () => {
     expect(stats.thinkingParamsStripped).toBe(20_000);
     expect(JSON.stringify(parsed)).not.toContain('"thinking"');
   });
+
+  it("fails closed when a sanitized deeply nested body cannot be serialized", () => {
+    const depth = 100_000;
+    const body = `${'{"nested":'.repeat(depth)}{"thinking":{"enabled":true}}${"}".repeat(depth)}`;
+    expect(() => processBody(body, baseConfig)).toThrow();
+  });
 });

--- a/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
@@ -229,21 +229,34 @@ export function processBody(bodyStr: string, config: ProcessBodyConfig): Process
   let thinkingBlocksStripped = 0;
   let thinkingParamsStripped = 0;
   if (config.stripThinkingBlocks !== false) {
+    let parsedThinkingBody: unknown;
+    let parsedThinkingBodyOk = false;
     try {
-      const parsed = JSON.parse(m) as unknown;
-      const pending: unknown[] = [parsed];
+      parsedThinkingBody = JSON.parse(m) as unknown;
+      parsedThinkingBodyOk = true;
+    } catch {
+      // error-policy:J3 malformed upstream JSON remains explicit input for later validation.
+    }
+    if (parsedThinkingBodyOk) {
+      let strippedParams = 0;
+      const pending: unknown[] = [parsedThinkingBody];
       while (pending.length > 0) {
         const value = pending.pop();
         if (!value || typeof value !== "object") continue;
         if (!Array.isArray(value) && Object.hasOwn(value, "thinking")) {
           delete (value as Record<string, unknown>).thinking;
-          thinkingParamsStripped++;
+          strippedParams++;
         }
         for (const nested of Object.values(value)) pending.push(nested);
       }
-      if (thinkingParamsStripped > 0) m = JSON.stringify(parsed);
-    } catch {
-      // error-policy:J3 malformed upstream JSON remains explicit input for later validation.
+      if (strippedParams > 0) {
+        const sanitized = JSON.stringify(parsedThinkingBody);
+        if (sanitized === undefined) {
+          throw new TypeError("Sanitized Anthropic request body is not JSON");
+        }
+        m = sanitized;
+        thinkingParamsStripped = strippedParams;
+      }
     }
     const msgsIdx2 = m.indexOf('"messages":[');
     if (msgsIdx2 !== -1) {

--- a/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
@@ -229,11 +229,21 @@ export function processBody(bodyStr: string, config: ProcessBodyConfig): Process
   let thinkingBlocksStripped = 0;
   let thinkingParamsStripped = 0;
   if (config.stripThinkingBlocks !== false) {
-    const thinkingParamRegex = /,?"thinking":\s*\{[^}]*\}/g;
-    const thinkingMatches = m.match(thinkingParamRegex);
-    if (thinkingMatches) {
-      m = m.replace(thinkingParamRegex, "");
-      thinkingParamsStripped = thinkingMatches.length;
+    try {
+      const parsed = JSON.parse(m) as unknown;
+      const pending: unknown[] = [parsed];
+      while (pending.length > 0) {
+        const value = pending.pop();
+        if (!value || typeof value !== "object") continue;
+        if (!Array.isArray(value) && Object.hasOwn(value, "thinking")) {
+          delete (value as Record<string, unknown>).thinking;
+          thinkingParamsStripped++;
+        }
+        for (const nested of Object.values(value)) pending.push(nested);
+      }
+      if (thinkingParamsStripped > 0) m = JSON.stringify(parsed);
+    } catch {
+      // error-policy:J3 malformed upstream JSON remains explicit input for later validation.
     }
     const msgsIdx2 = m.indexOf('"messages":[');
     if (msgsIdx2 !== -1) {

--- a/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
@@ -237,26 +237,20 @@ export function processBody(bodyStr: string, config: ProcessBodyConfig): Process
     } catch {
       // error-policy:J3 malformed upstream JSON remains explicit input for later validation.
     }
-    if (parsedThinkingBodyOk) {
-      let strippedParams = 0;
-      const pending: unknown[] = [parsedThinkingBody];
-      while (pending.length > 0) {
-        const value = pending.pop();
-        if (!value || typeof value !== "object") continue;
-        if (!Array.isArray(value) && Object.hasOwn(value, "thinking")) {
-          delete (value as Record<string, unknown>).thinking;
-          strippedParams++;
-        }
-        for (const nested of Object.values(value)) pending.push(nested);
+    if (
+      parsedThinkingBodyOk &&
+      parsedThinkingBody !== null &&
+      typeof parsedThinkingBody === "object" &&
+      !Array.isArray(parsedThinkingBody) &&
+      Object.hasOwn(parsedThinkingBody, "thinking")
+    ) {
+      delete (parsedThinkingBody as Record<string, unknown>).thinking;
+      const sanitized = JSON.stringify(parsedThinkingBody);
+      if (sanitized === undefined) {
+        throw new TypeError("Sanitized Anthropic request body is not JSON");
       }
-      if (strippedParams > 0) {
-        const sanitized = JSON.stringify(parsedThinkingBody);
-        if (sanitized === undefined) {
-          throw new TypeError("Sanitized Anthropic request body is not JSON");
-        }
-        m = sanitized;
-        thinkingParamsStripped = strippedParams;
-      }
+      m = sanitized;
+      thinkingParamsStripped = 1;
     }
     const msgsIdx2 = m.indexOf('"messages":[');
     if (msgsIdx2 !== -1) {

--- a/plugins/plugin-inbox/src/inbox/gmail-normalize.test.ts
+++ b/plugins/plugin-inbox/src/inbox/gmail-normalize.test.ts
@@ -54,6 +54,12 @@ describe("normalizeGeneratedGmailReplyDraftBody", () => {
       "Visible",
     );
   });
+
+  it("keeps original offsets when a Unicode prefix expands under lowercase", () => {
+    expect(
+      normalizeGeneratedGmailReplyDraftBody("İ<think>secret</think>Visible"),
+    ).toBe("İ Visible");
+  });
 });
 
 describe("splitMailboxLikeList", () => {

--- a/plugins/plugin-inbox/src/inbox/gmail-normalize.test.ts
+++ b/plugins/plugin-inbox/src/inbox/gmail-normalize.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractNormalizedEmailAddress,
   filterGmailMessagesBySearch,
+  normalizeGeneratedGmailReplyDraftBody,
   normalizeGmailSearchQueryMatches,
   normalizeOptionalGmailLabelIdArray,
   normalizeOptionalMessageIdArray,
@@ -34,6 +35,24 @@ describe("extractNormalizedEmailAddress", () => {
     expect(extractNormalizedEmailAddress("not an email")).toBeNull();
     expect(extractNormalizedEmailAddress("missing@domain")).toBeNull();
     expect(extractNormalizedEmailAddress("")).toBeNull();
+  });
+
+  it("scans adversarial punctuation and angle brackets in one pass", () => {
+    expect(extractNormalizedEmailAddress(`${"!".repeat(50_000)}a@b.com`)).toBe(
+      `${"!".repeat(50_000)}a@b.com`,
+    );
+    expect(extractNormalizedEmailAddress(`${"<".repeat(50_000)}a@b.com>`)).toBe(
+      "a@b.com",
+    );
+  });
+});
+
+describe("normalizeGeneratedGmailReplyDraftBody", () => {
+  it("removes repeated thinking blocks while preserving visible prose", () => {
+    const thinking = "<think>hidden</think>".repeat(20_000);
+    expect(normalizeGeneratedGmailReplyDraftBody(`${thinking}Visible`)).toBe(
+      "Visible",
+    );
   });
 });
 

--- a/plugins/plugin-inbox/src/inbox/gmail-normalize.ts
+++ b/plugins/plugin-inbox/src/inbox/gmail-normalize.ts
@@ -1295,14 +1295,28 @@ export function buildFallbackGmailReplyDraftBody(args: {
 export function normalizeGeneratedGmailReplyDraftBody(
   value: string,
 ): string | null {
-  const lower = value.toLowerCase();
+  const findAsciiCaseInsensitive = (
+    lowerNeedle: string,
+    from: number,
+  ): number => {
+    const lastStart = value.length - lowerNeedle.length;
+    outer: for (let start = from; start <= lastStart; start++) {
+      for (let offset = 0; offset < lowerNeedle.length; offset++) {
+        const code = value.charCodeAt(start + offset);
+        const folded = code >= 65 && code <= 90 ? code + 32 : code;
+        if (folded !== lowerNeedle.charCodeAt(offset)) continue outer;
+      }
+      return start;
+    }
+    return -1;
+  };
   const chunks: string[] = [];
   let cursor = 0;
   while (cursor < value.length) {
-    const start = lower.indexOf("<think>", cursor);
+    const start = findAsciiCaseInsensitive("<think>", cursor);
     if (start < 0) break;
     chunks.push(value.slice(cursor, start), " ");
-    const end = lower.indexOf("</think>", start + 7);
+    const end = findAsciiCaseInsensitive("</think>", start + 7);
     if (end < 0) {
       cursor = value.length;
       break;

--- a/plugins/plugin-inbox/src/inbox/gmail-normalize.ts
+++ b/plugins/plugin-inbox/src/inbox/gmail-normalize.ts
@@ -192,11 +192,44 @@ export function extractNormalizedEmailAddress(value: string): string | null {
   if (!trimmed) {
     return null;
   }
-  const angleMatch = trimmed.match(/<\s*([^<>\s@]+@[^<>\s@]+)\s*>/u);
-  const rawCandidate =
-    angleMatch?.[1] ??
-    trimmed.match(/([^\s<>()"';,]+@[^\s<>()"';,]+)/u)?.[1] ??
-    trimmed;
+  const isAddressCharacter = (character: string): boolean =>
+    !/\s/u.test(character) && !`<>()"';,`.includes(character);
+  const isSyntacticAddressToken = (candidate: string): boolean => {
+    const at = candidate.indexOf("@");
+    return at > 0 && at < candidate.length - 1;
+  };
+  let angleCandidate: string | null = null;
+  let angleStart = -1;
+  let tokenCandidate: string | null = null;
+  let tokenStart = -1;
+  for (let index = 0; index <= trimmed.length; index++) {
+    const character = trimmed[index];
+    if (character && isAddressCharacter(character)) {
+      if (tokenStart < 0) tokenStart = index;
+    } else if (tokenStart >= 0) {
+      const token = trimmed.slice(tokenStart, index);
+      if (isSyntacticAddressToken(token)) {
+        tokenCandidate ??= token;
+      }
+      tokenStart = -1;
+    }
+
+    if (character === "<") {
+      angleStart = index;
+    } else if (character === ">" && angleStart >= 0) {
+      const inside = trimmed.slice(angleStart + 1, index).trim();
+      if (
+        isSyntacticAddressToken(inside) &&
+        inside.length > 0 &&
+        Array.from(inside).every(isAddressCharacter)
+      ) {
+        angleCandidate = inside;
+        break;
+      }
+      angleStart = -1;
+    }
+  }
+  const rawCandidate = angleCandidate ?? tokenCandidate ?? trimmed;
   const normalized = rawCandidate
     .trim()
     .replace(/^["']+|["']+$/g, "")
@@ -1262,7 +1295,22 @@ export function buildFallbackGmailReplyDraftBody(args: {
 export function normalizeGeneratedGmailReplyDraftBody(
   value: string,
 ): string | null {
-  const withoutThink = value.replace(/<think>[\s\S]*?<\/think>/gi, " ").trim();
+  const lower = value.toLowerCase();
+  const chunks: string[] = [];
+  let cursor = 0;
+  while (cursor < value.length) {
+    const start = lower.indexOf("<think>", cursor);
+    if (start < 0) break;
+    chunks.push(value.slice(cursor, start), " ");
+    const end = lower.indexOf("</think>", start + 7);
+    if (end < 0) {
+      cursor = value.length;
+      break;
+    }
+    cursor = end + 8;
+  }
+  chunks.push(value.slice(cursor));
+  const withoutThink = chunks.join("").trim();
   if (!withoutThink) {
     return null;
   }

--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -33,6 +33,10 @@ describe("escapeSlackMrkdwn", () => {
     expect(escapeSlackMrkdwn("a & b < c > d")).toBe("a &amp; b &lt; c &gt; d");
     expect(escapeSlackMrkdwn("plain text")).toBe("plain text");
   });
+
+  it("escapes a long run of unmatched angle brackets linearly", () => {
+    expect(escapeSlackMrkdwn("<".repeat(50_000))).toBe("&lt;".repeat(50_000));
+  });
 });
 
 describe("markdownToSlackMrkdwn", () => {
@@ -41,6 +45,13 @@ describe("markdownToSlackMrkdwn", () => {
     expect(markdownToSlackMrkdwn("*italic*")).toBe("_italic_");
     expect(markdownToSlackMrkdwn("~~struck~~")).toBe("~struck~");
     expect(markdownToSlackMrkdwn("")).toBe("");
+  });
+
+  it("preserves fenced code with a long language tag", () => {
+    const language = `ts${"a".repeat(50_000)}`;
+    expect(
+      markdownToSlackMrkdwn(`\`\`\`${language}\nconst x = 1;\n\`\`\``),
+    ).toBe("```\nconst x = 1;\n```");
   });
 });
 

--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -37,6 +37,10 @@ describe("escapeSlackMrkdwn", () => {
   it("escapes a long run of unmatched angle brackets linearly", () => {
     expect(escapeSlackMrkdwn("<".repeat(50_000))).toBe("&lt;".repeat(50_000));
   });
+
+  it("fully escapes a nested token that could otherwise forge a mention", () => {
+    expect(escapeSlackMrkdwn("<<@U1>")).toBe("&lt;&lt;@U1&gt;");
+  });
 });
 
 describe("markdownToSlackMrkdwn", () => {

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -61,30 +61,33 @@ function escapeSlackMrkdwnContent(text: string): string {
   const out: string[] = [];
   let plainStart = 0;
   let tokenStart = -1;
+  let tokenMalformed = false;
   for (let index = 0; index < text.length; index++) {
     const character = text[index];
     if (tokenStart < 0) {
       if (character === "<") {
         out.push(escapeSlackMrkdwnSegment(text.slice(plainStart, index)));
         tokenStart = index;
+        tokenMalformed = false;
       }
       continue;
     }
     if (character === "<") {
-      out.push(escapeSlackMrkdwnSegment(text.slice(tokenStart, index)));
-      tokenStart = index;
+      tokenMalformed = true;
     } else if (character === "\n") {
       out.push(escapeSlackMrkdwnSegment(text.slice(tokenStart, index + 1)));
       tokenStart = -1;
+      tokenMalformed = false;
       plainStart = index + 1;
     } else if (character === ">") {
       const token = text.slice(tokenStart, index + 1);
       out.push(
-        isAllowedSlackAngleToken(token)
+        !tokenMalformed && isAllowedSlackAngleToken(token)
           ? token
           : escapeSlackMrkdwnSegment(token),
       );
       tokenStart = -1;
+      tokenMalformed = false;
       plainStart = index + 1;
     }
   }

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -30,8 +30,6 @@ function escapeSlackMrkdwnSegment(text: string): string {
     .replace(/>/g, "&gt;");
 }
 
-const SLACK_ANGLE_TOKEN_RE = /<[^>\n]+>/g;
-
 /**
  * Checks if an angle-bracket token is an allowed Slack format
  */
@@ -60,25 +58,41 @@ function escapeSlackMrkdwnContent(text: string): string {
     return text;
   }
 
-  SLACK_ANGLE_TOKEN_RE.lastIndex = 0;
   const out: string[] = [];
-  let lastIndex = 0;
-
-  for (
-    let match = SLACK_ANGLE_TOKEN_RE.exec(text);
-    match;
-    match = SLACK_ANGLE_TOKEN_RE.exec(text)
-  ) {
-    const matchIndex = match.index;
-    out.push(escapeSlackMrkdwnSegment(text.slice(lastIndex, matchIndex)));
-    const token = match[0] ?? "";
-    out.push(
-      isAllowedSlackAngleToken(token) ? token : escapeSlackMrkdwnSegment(token),
-    );
-    lastIndex = matchIndex + token.length;
+  let plainStart = 0;
+  let tokenStart = -1;
+  for (let index = 0; index < text.length; index++) {
+    const character = text[index];
+    if (tokenStart < 0) {
+      if (character === "<") {
+        out.push(escapeSlackMrkdwnSegment(text.slice(plainStart, index)));
+        tokenStart = index;
+      }
+      continue;
+    }
+    if (character === "<") {
+      out.push(escapeSlackMrkdwnSegment(text.slice(tokenStart, index)));
+      tokenStart = index;
+    } else if (character === "\n") {
+      out.push(escapeSlackMrkdwnSegment(text.slice(tokenStart, index + 1)));
+      tokenStart = -1;
+      plainStart = index + 1;
+    } else if (character === ">") {
+      const token = text.slice(tokenStart, index + 1);
+      out.push(
+        isAllowedSlackAngleToken(token)
+          ? token
+          : escapeSlackMrkdwnSegment(token),
+      );
+      tokenStart = -1;
+      plainStart = index + 1;
+    }
   }
-
-  out.push(escapeSlackMrkdwnSegment(text.slice(lastIndex)));
+  out.push(
+    escapeSlackMrkdwnSegment(
+      text.slice(tokenStart >= 0 ? tokenStart : plainStart),
+    ),
+  );
   return out.join("");
 }
 
@@ -136,8 +150,31 @@ function convertStrikethrough(text: string): string {
  * Converts markdown code blocks to Slack mrkdwn
  */
 function convertCodeBlocks(text: string): string {
-  // Slack code blocks don't support language hints in the same way
-  return text.replace(/```(\w*)\n?([\s\S]*?)```/g, "```\n$2```");
+  const output: string[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    const start = text.indexOf("```", cursor);
+    if (start < 0) break;
+    const end = text.indexOf("```", start + 3);
+    if (end < 0) break;
+    output.push(text.slice(cursor, start), "```\n");
+    let bodyStart = start + 3;
+    while (bodyStart < end) {
+      const code = text.charCodeAt(bodyStart);
+      const isLanguageCharacter =
+        (code >= 48 && code <= 57) ||
+        (code >= 65 && code <= 90) ||
+        code === 95 ||
+        (code >= 97 && code <= 122);
+      if (!isLanguageCharacter) break;
+      bodyStart++;
+    }
+    if (text[bodyStart] === "\n") bodyStart++;
+    output.push(text.slice(bodyStart, end), "```");
+    cursor = end + 3;
+  }
+  output.push(text.slice(cursor));
+  return output.join("");
 }
 
 /**

--- a/plugins/plugin-trajectory-logger/src/phases.ts
+++ b/plugins/plugin-trajectory-logger/src/phases.ts
@@ -60,10 +60,29 @@ export function extractShouldRespondDecision(
 ): { decision: string; reasoning?: string } | null {
   const text = call.response.trim();
   if (!text) return null;
-  const m = text.match(/\{[\s\S]*\}/);
-  if (m) {
+  const start = text.indexOf("{");
+  let candidate: string | null = null;
+  if (start >= 0) {
+    let depth = 0;
+    let quoted = false;
+    for (let index = start; index < text.length; index++) {
+      const char = text[index];
+      if (quoted) {
+        if (char === "\\") index++;
+        else if (char === '"') quoted = false;
+        continue;
+      }
+      if (char === '"') quoted = true;
+      else if (char === "{") depth++;
+      else if (char === "}" && --depth === 0) {
+        candidate = text.slice(start, index + 1);
+        break;
+      }
+    }
+  }
+  if (candidate) {
     try {
-      const obj = JSON.parse(m[0]) as Record<string, unknown>;
+      const obj = JSON.parse(candidate) as Record<string, unknown>;
       const a = obj.action ?? obj.decision ?? obj.shouldRespond;
       if (typeof a === "string" && a.length > 0) {
         const r = obj.reasoning ?? obj.rationale;

--- a/plugins/plugin-trajectory-logger/test/phases.test.ts
+++ b/plugins/plugin-trajectory-logger/test/phases.test.ts
@@ -169,4 +169,11 @@ describe("extractShouldRespondDecision", () => {
       extractShouldRespondDecision(makeLlmCall({ response: "lorem ipsum" })),
     ).toBeNull();
   });
+
+  it("handles deeply repeated opening braces without regex backtracking", () => {
+    const out = extractShouldRespondDecision(
+      makeLlmCall({ response: `${"{".repeat(50_000)} RESPOND` }),
+    );
+    expect(out).toEqual({ decision: "RESPOND" });
+  });
 });


### PR DESCRIPTION
## Summary

- replace polynomial regular expressions at product input boundaries with deterministic scanners for completion envelopes, tool transcripts, Anthropic thinking data, Gmail addresses/drafts, Slack tokens/code fences, and trajectory decisions
- preserve parser behavior while bounding adversarial repeated delimiters and whitespace to linear work
- replace the Electrobun cloud-login benchmark's posted CLI-session identifier with `crypto.randomUUID()`
- add large adversarial regressions and a source contract that forbids a `Math.random` downgrade

This fixes CodeQL alerts #816, #817, #820, #879, #880, #881, #887, #903, #908, #910, #911, and #1098 tracked in #22087 without adding CodeQL to pull-request workflows.

## Verification

- original focused matrix: 156 tests passed across 6 parser test files
- post-review exact-head matrix: 50 tests passed across completion-envelope, transcript, Anthropic proxy, trajectory, and Electrobun contract suites
- independent review found and repaired Unicode offset corruption, nested Slack mention activation, and misleading thinking-strip accounting; the adversarial regressions pass at the current head
- exact-head Electrobun benchmark contract: 1 test passed
- `@elizaos/plugin-anthropic-proxy` typecheck passed
- all 13 changed TypeScript/test files passed Biome; benchmark script passed `node --check`
- `git diff --check origin/develop...HEAD` passed
- package typechecks for orchestrator, inbox, Slack, trajectory logger, and Electrobun were blocked by existing sparse-worktree missing optional/workspace modules (`ai`, `mammoth`, `unpdf`, `file-type`, `git-workspace-service`, Slack/Google/Capacitor/Electrobun and wallet dependencies); no diagnostic points to a changed file

Independent source review is complete; hosted gates remain required before merge.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@3b238dda93d016d77ae53c6c37b13bd84f4c891e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@3b238dda93d016d77ae53c6c37b13bd84f4c891e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-codeql]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@3b238dda93d016d77ae53c6c37b13bd84f4c891e:packages/skills/skills/contribute-to-eliza"} -->

## Evidence Gate

<!-- evidence-head:3b238dda93d016d77ae53c6c37b13bd84f4c891e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered product pixels or layout changed in this parser and benchmark hardening change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered product pixels or layout changed in this parser and benchmark hardening change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no product interaction flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - exact parser and benchmark contract tests are documented in the PR; no protected backend was mutated.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no rendered frontend state or browser-network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no production prompt or model selection changed; parsing semantics are pinned by deterministic tests.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - exact adversarial parser contracts and the benchmark source contract are documented in the PR.
<!-- evidence-row:ocr-review -->
- [x] N/A - no product pixels changed.



