### PR TITLE
fix(android): ship a standard Play-safe cloud client

### DIFF
--- a/packages/app-core/docs/android-play-capability-inventory.md
+++ b/packages/app-core/docs/android-play-capability-inventory.md
@@ -1,0 +1,95 @@
+# Android Google Play capability inventory
+
+This inventory describes the `android-cloud` release for package
+`ai.elizaos.app`. The AAB audit is authoritative for what ships; the committed
+manifest and build-strip tests are regression guards for future builds.
+
+## Standard consumer capabilities
+
+- Cloud chat over TLS using ordinary `INTERNET` and `ACCESS_NETWORK_STATE`.
+- User-invoked voice capture using `RECORD_AUDIO`, requested at runtime, plus
+  `MODIFY_AUDIO_SETTINGS` for Android audio routing and echo cancellation.
+- Audio playback through ordinary platform media APIs with no background
+  foreground service.
+- Secure app-private persistence. Android backup is disabled.
+- Text sharing through `ACTION_SEND` and `ACTION_PROCESS_TEXT`.
+- The `elizaos://` custom deep link and Android launcher entry point.
+- Narrow package visibility queries for the system speech-recognition service
+  and Custom Tabs service. No package names and no broad app inventory access.
+- A non-exported `FileProvider` for scoped content sharing.
+
+The release targets API 36, does not allow cleartext traffic, and is not
+debuggable. `RECORD_AUDIO` is the only runtime permission in the audited base
+module.
+
+## Play account model
+
+The consumer UI says **Sign in**, but its phone, email magic-link, OAuth, and
+wallet/SIWE paths can provision a new Eliza Cloud user and agent. For Google
+Play policy this is an **account-creating app**, not a sign-in-only app.
+
+Production submission therefore requires both of these working paths, bound to
+the same authenticated account lifecycle:
+
+- a readily discoverable in-app request to delete the account and associated
+  data; and
+- an external web resource where a user can request account deletion, entered
+  in Play Console's designated account-deletion URL field.
+
+A disabled or placeholder deletion control does not satisfy this contract. The
+release remains blocked until the Cloud/Steward lifecycle completes deletion,
+session revocation, required provider/resource cleanup, and an identifier-free
+receipt without deleting another user's or a shared organization's data.
+
+## Components in the audited release AAB
+
+- Activities: `MainActivity`, `ElizaShareActivity`, and Capacitor's browser
+  controller activity.
+- Providers: the non-exported AndroidX `FileProvider` and AndroidX startup
+  provider.
+- Receiver: AndroidX profile installation receiver.
+- No application-defined services.
+
+## Explicitly absent from the Play release
+
+The build and artifact audits fail if these return:
+
+- Accessibility services, gesture injection, screen capture, MediaProjection,
+  notification-listener access, device admin, or device/profile-owner flows.
+- Default Assistant, Browser, Dialer, SMS, Home/launcher, or IME role requests.
+- SMS, MMS, contacts, call log, phone, camera, location, Bluetooth, nearby
+  devices, notifications, Health Connect, usage access, overlay, VPN, exact
+  alarm, boot-completed, package installation, or broad package visibility.
+- Foreground or background services, reboot autostart, background microphone,
+  local-agent/runtime assets, model files, Bun binaries, inference libraries,
+  privileged/AOSP permissions, and platform-signature APIs.
+- Cleartext HTTP, local Mac routing, adb reverse assumptions, development
+  endpoints, embedded provider credentials, or production signing material.
+
+## Policy basis
+
+- [Google Play target API requirements](https://developer.android.com/google/play/requirements/target-sdk)
+- [User data and account deletion policy](https://support.google.com/googleplay/android-developer/answer/10144311)
+- [Account deletion implementation guidance](https://support.google.com/googleplay/android-developer/answer/13327111)
+- [Permissions and APIs that access sensitive information](https://support.google.com/googleplay/android-developer/answer/16558241)
+- [SMS and Call Log permission policy](https://support.google.com/googleplay/android-developer/answer/10208820)
+- [Broad package visibility policy](https://support.google.com/googleplay/android-developer/answer/10158779)
+- [Foreground service declaration requirements](https://support.google.com/googleplay/android-developer/answer/13392821)
+
+## Release verification
+
+For every release candidate:
+
+1. Run the Android Play policy and account-deletion regression tests.
+2. Build `build:android:cloud:debug` and `build:android:cloud` from a clean head.
+3. Require the pre-Gradle, post-Gradle, APK, AAB manifest, and DEX audits to pass.
+4. Run Gradle unit tests and `lintRelease` with `-PelizaCloudBuild=true`.
+5. Record the exact commit, APK/AAB sizes and SHA-256 hashes, signing state, and
+   merged-manifest inventory in the release evidence.
+6. Install the matching debug APK after clearing app data, then verify launch,
+   runtime microphone consent, sharing, deep links, account deletion, chat,
+   voice, persistence, background/restore, and crash-free logs.
+
+An unsigned local AAB proves build and package contents only. Play App Signing,
+Play Console declarations, staged backend deletion, real-account flows, and
+physical-device voice remain separate release gates.

--- a/packages/app-core/platforms/android/README.md
+++ b/packages/app-core/platforms/android/README.md
@@ -18,6 +18,60 @@ hosting target. Produces a release AAB at
 For local Pixel smoke tests, `android-cloud-debug` produces a debug APK
 under `packages/app-core/platforms/android/app/build/outputs/apk/debug/`.
 
+### Play capability contract
+
+The Play artifact is a standard consumer client. Its post-merge manifest and
+package contents are checked against exact allowlists during every Cloud APK or
+AAB build; an unexpected permission, component, query, native plugin, native
+library, packaged credential, or local-development route fails the build.
+
+Runtime permissions:
+
+- `android.permission.RECORD_AUDIO` — requested only when the user starts a
+  voice interaction.
+
+Install-time normal permissions:
+
+- `android.permission.INTERNET`
+- `android.permission.ACCESS_NETWORK_STATE`
+- `android.permission.MODIFY_AUDIO_SETTINGS`
+- AndroidX's app-scoped `DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION` signature
+  permission.
+
+Packaged Android components:
+
+- Activities: `MainActivity`, `ElizaShareActivity`, and Capacitor Browser's
+  `BrowserControllerActivity`.
+- Providers: the non-exported Capacitor `FileProvider` and AndroidX Startup.
+- Receiver: AndroidX Profile Installer's non-app-feature receiver.
+- Services: none.
+- Native libraries: none.
+
+User-facing capabilities are limited to cloud chat, user-initiated microphone
+voice, audio playback, secure private preferences/files, network-state
+awareness, browser-based sign-in, ordinary Android sharing/`PROCESS_TEXT`, and
+Eliza deep links/shortcuts. The application disables cleartext traffic and
+backup, targets API 36, has no package-name query, and does not ship local Mac
+routes, emulator/ADB assumptions, provider credentials, or an on-device agent.
+
+The Play client does not declare or register accessibility/gesture control,
+notification-listener access, device administration, overlay or usage access,
+VPN, MediaProjection, Health Connect, camera/location/Bluetooth/contact/SMS/
+call access, default Assistant/Browser/Dialer/SMS/Home roles, an IME, app
+installation/update APIs, boot receivers, foreground/background services,
+push/local notifications, native inference, or dynamically loadable code.
+
+Policy basis: Google Play restricts sensitive permissions to documented core
+uses, requires SMS/Call Log permissions to be removed when the app does not
+qualify, imposes declarations and user-perceptibility requirements on foreground
+services, and requires current target API levels. See the official
+[permissions policy](https://support.google.com/googleplay/android-developer/answer/16558241),
+[SMS and Call Log policy](https://support.google.com/googleplay/android-developer/answer/10208820),
+[AccessibilityService policy](https://support.google.com/googleplay/android-developer/answer/10964491),
+[foreground-service requirements](https://support.google.com/googleplay/android-developer/answer/13392821),
+[target API requirements](https://support.google.com/googleplay/android-developer/answer/11926878),
+and [Android cleartext guidance](https://developer.android.com/privacy-and-security/risks/cleartext-communications).
+
 Release AAB auditing uses Google's standalone bundletool JAR. The canonical
 build downloads bundletool 1.18.3 into a temporary cache and verifies its
 pinned SHA-256 before execution. To supply a pre-provisioned official JAR

--- a/packages/app-core/platforms/android/app/build.gradle
+++ b/packages/app-core/platforms/android/app/build.gradle
@@ -570,22 +570,18 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
-    // WorkManager for periodic background refresh (see ElizaTasksWorker + ElizaBootReceiver).
-    // The Capacitor background-runner already pulls in work-runtime-ktx transitively;
-    // this explicit dep makes the worker classes resolvable from Java without relying on
-    // transitive resolution and pins us to the same version (2.11.0).
-    implementation "androidx.work:work-runtime:2.11.0"
-    // androidx.work's Worker/ListenableWorker API returns Guava's
-    // com.google.common.util.concurrent.ListenableFuture. That class ships in
-    // full Guava; the transitively-resolved listenablefuture artifact is the
-    // empty 9999.0-empty-to-avoid-conflict-with-guava stub, so without a direct
-    // Guava dep javac fails to compile ElizaTasksWorker (extends Worker) with
-    // "cannot access ListenableFuture". The empty-stub mechanism prevents any
-    // duplicate-class conflict once full Guava is on the classpath.
-    implementation "com.google.guava:guava:31.1-android"
+    if (project.findProperty('elizaCloudBuild') != 'true') {
+        // Direct/AOSP builds schedule local-agent work; the Play client has no
+        // background worker, boot rescheduling, or foreground service.
+        implementation "androidx.work:work-runtime:2.11.0"
+        // Worker/ListenableWorker exposes Guava's ListenableFuture API.
+        implementation "com.google.guava:guava:31.1-android"
+    }
     implementation project(':capacitor-android')
     implementation "com.google.code.gson:gson:2.14.0"
-    implementation "com.google.firebase:firebase-common-ktx:21.0.0"
+    if (project.findProperty('elizaCloudBuild') != 'true') {
+        implementation "com.google.firebase:firebase-common-ktx:21.0.0"
+    }
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/packages/app-core/platforms/android/variables.gradle
+++ b/packages/app-core/platforms/android/variables.gradle
@@ -2,7 +2,7 @@ ext {
     mavenCentralMirrorUrl = 'https://maven-central.storage-download.googleapis.com/maven2/'
     minSdkVersion = 26
     compileSdkVersion = 36
-    targetSdkVersion = 35
+    targetSdkVersion = 36
     androidxActivityVersion = '1.8.0'
     androidxAppCompatVersion = '1.7.1'
     androidxCoordinatorLayoutVersion = '1.3.0'

--- a/packages/app-core/scripts/lib/android-cloud-artifact-audit.mjs
+++ b/packages/app-core/scripts/lib/android-cloud-artifact-audit.mjs
@@ -42,6 +42,25 @@ export const ANDROID_LP3_POLICY_PERMISSIONS = Object.freeze([
 
 export const ANDROID_LP3_POLICY_MARKERS = Object.freeze(["lp3_color_policy"]);
 
+// Product-specific local-runtime and sideload implementation markers that must
+// never survive R8 into the Google Play Cloud artifact. Keep this list narrow:
+// generic strings such as "localhost" occur legitimately in AndroidX/vendor
+// bytecode and are audited at the renderer/source boundary instead.
+export const ANDROID_PLAY_FORBIDDEN_DEX_MARKERS = Object.freeze([
+  "10.0.2.2",
+  "31337",
+  "31338",
+  "32437",
+  "32438",
+  "__ELIZA_ANDROID_IPC_FETCH_BRIDGE__",
+  "adb reverse",
+  "eliza-local-agent:",
+  "eliza_bionic_infer_v1",
+  "Landroid/net/LocalSocket;",
+  "remote-mac",
+  "TalkModePlugin",
+]);
+
 const AAB_MANIFEST_ENTRY = /^([^/\\]+)\/manifest\/AndroidManifest\.xml$/;
 const AAB_DEX_ENTRY = /^([^/\\]+)\/dex\/classes\d*\.dex$/;
 const AAB_STRAY_DEX_ENTRY = /\.dex$/i;
@@ -1056,8 +1075,9 @@ function normalizeDexBuffers(dexEntries, dexBuffers) {
 }
 
 /**
- * Scans every DEX payload for stripped repo-owned classes and private LP3
- * control-plane markers, including features that a universal APK can omit.
+ * Scans every DEX payload for stripped repo-owned classes, private LP3
+ * control-plane markers, and sideload/local-runtime implementation markers,
+ * including features that a universal APK can omit.
  */
 export function assertAabDexPolicy({
   appId,
@@ -1085,6 +1105,9 @@ export function assertAabDexPolicy({
     marker,
     payload: Buffer.from(marker, "utf8"),
   }));
+  const forbiddenPlayMarkers = ANDROID_PLAY_FORBIDDEN_DEX_MARKERS.map(
+    (marker) => ({ marker, payload: Buffer.from(marker, "utf8") }),
+  );
 
   for (let index = 0; index < buffers.length; index += 1) {
     for (const { className, marker } of forbiddenClassDescriptors) {
@@ -1098,6 +1121,13 @@ export function assertAabDexPolicy({
       if (buffers[index].includes(payload)) {
         throw androidAabAuditError(
           `[mobile-build] android-cloud AAB DEX ${dexEntries[index]} contains forbidden LP3 marker: ${marker}`,
+        );
+      }
+    }
+    for (const { marker, payload } of forbiddenPlayMarkers) {
+      if (buffers[index].includes(payload)) {
+        throw androidAabAuditError(
+          `[mobile-build] android-cloud AAB DEX ${dexEntries[index]} contains forbidden Play local-runtime marker: ${marker}`,
         );
       }
     }

--- a/packages/app-core/scripts/lib/android-cloud-artifact-audit.mjs
+++ b/packages/app-core/scripts/lib/android-cloud-artifact-audit.mjs
@@ -617,9 +617,11 @@ export function runCheckedBundletool(
 
 function parseXmlOpeningTags(xml) {
   const tags = [];
+  const ancestors = [];
   const parser = new SaxesParser({ xmlns: true });
   parser.on("opentag", (tag) => {
     tags.push({
+      ancestors: [...ancestors],
       attributes: Object.values(tag.attributes).map((attribute) => ({
         localName: attribute.local,
         name: attribute.name,
@@ -630,6 +632,10 @@ function parseXmlOpeningTags(xml) {
       namespaceUri: tag.uri,
       qualifiedName: tag.name,
     });
+    ancestors.push(tag.local);
+  });
+  parser.on("closetag", () => {
+    ancestors.pop();
   });
   try {
     parser.write(xml).close();
@@ -676,8 +682,27 @@ function manifestPolicyEvidence(moduleName, manifestText) {
         .map((tag) => readXmlAttribute(tag, ANDROID_XML_NAMESPACE, localName))
         .filter(Boolean),
     );
+  const application = tags.find((tag) => tag.name === "application");
+  const usesSdk = tags.find((tag) => tag.name === "uses-sdk");
+  const isInsideQueries = (tag) => tag.ancestors.includes("queries");
   return {
     actions: androidAttributeValues(["action"], "name"),
+    application: {
+      allowBackup: application
+        ? readXmlAttribute(application, ANDROID_XML_NAMESPACE, "allowBackup")
+        : null,
+      debuggable: application
+        ? (readXmlAttribute(application, ANDROID_XML_NAMESPACE, "debuggable") ??
+          "false")
+        : "false",
+      usesCleartextTraffic: application
+        ? readXmlAttribute(
+            application,
+            ANDROID_XML_NAMESPACE,
+            "usesCleartextTraffic",
+          )
+        : null,
+    },
     components: uniqueSorted(
       tags
         .filter((tag) => MANIFEST_COMPONENT_ELEMENTS.includes(tag.name))
@@ -698,9 +723,111 @@ function manifestPolicyEvidence(moduleName, manifestText) {
       ["uses-permission", "uses-permission-sdk-23"],
       "name",
     ),
+    queryActions: uniqueSorted(
+      tags
+        .filter((tag) => tag.name === "action" && isInsideQueries(tag))
+        .map((tag) => readXmlAttribute(tag, ANDROID_XML_NAMESPACE, "name"))
+        .filter(Boolean),
+    ),
+    queryPackages: uniqueSorted(
+      tags
+        .filter((tag) => tag.name === "package" && isInsideQueries(tag))
+        .map((tag) => readXmlAttribute(tag, ANDROID_XML_NAMESPACE, "name"))
+        .filter(Boolean),
+    ),
     sha256: sha256(Buffer.from(manifestText, "utf8")),
     sizeBytes: Buffer.byteLength(manifestText, "utf8"),
+    targetSdkVersion: usesSdk
+      ? readXmlAttribute(usesSdk, ANDROID_XML_NAMESPACE, "targetSdkVersion")
+      : null,
   };
+}
+
+function appendExactSetFindings(findings, actual, expected, label) {
+  const actualValues = uniqueSorted(actual);
+  const expectedValues = uniqueSorted(expected);
+  for (const value of actualValues.filter(
+    (candidate) => !expectedValues.includes(candidate),
+  )) {
+    findings.push(
+      `android-cloud manifest contains unexpected ${label}: ${value}`,
+    );
+  }
+  for (const value of expectedValues.filter(
+    (candidate) => !actualValues.includes(candidate),
+  )) {
+    findings.push(
+      `android-cloud manifest is missing required ${label}: ${value}`,
+    );
+  }
+}
+
+/**
+ * Enforces the deliberately small Play-client manifest as a positive contract.
+ * Every field is exact so dependency-manifest expansion fails closed.
+ */
+export function assertAndroidPlayManifestPolicyEvidence(evidence, policy) {
+  if (!evidence || typeof evidence !== "object") {
+    throw androidAabAuditError(
+      "[mobile-build] Android Play manifest evidence must be an object.",
+    );
+  }
+  if (!policy || typeof policy !== "object") {
+    throw androidAabAuditError(
+      "[mobile-build] Android Play manifest policy must be an object.",
+    );
+  }
+  const findings = [];
+  for (const [field, label] of [
+    ["permissions", "permission"],
+    ["components", "component"],
+    ["actions", "action"],
+    ["metadataNames", "metadata entry"],
+    ["queryActions", "query action"],
+    ["queryPackages", "query package"],
+  ]) {
+    requireStringArray(evidence[field], `Android Play manifest ${field}`);
+    requireStringArray(policy[field], `allowed Android Play manifest ${field}`);
+    appendExactSetFindings(findings, evidence[field], policy[field], label);
+  }
+
+  if (String(evidence.targetSdkVersion) !== String(policy.targetSdkVersion)) {
+    findings.push(
+      `android-cloud manifest targetSdkVersion ${String(evidence.targetSdkVersion)} does not equal ${String(policy.targetSdkVersion)}`,
+    );
+  }
+  for (const field of ["allowBackup", "usesCleartextTraffic"]) {
+    if (
+      String(evidence.application?.[field]) !==
+      String(policy.application?.[field])
+    ) {
+      findings.push(
+        `android-cloud manifest application ${field}=${String(evidence.application?.[field])} does not equal ${String(policy.application?.[field])}`,
+      );
+    }
+  }
+  if (
+    policy.application?.debuggable !== undefined &&
+    String(evidence.application?.debuggable) !==
+      String(policy.application.debuggable)
+  ) {
+    findings.push(
+      `android-cloud manifest application debuggable=${String(evidence.application?.debuggable)} does not equal ${String(policy.application.debuggable)}`,
+    );
+  }
+
+  if (findings.length > 0) {
+    const uniqueFindings = uniqueSorted(findings);
+    throw androidAabAuditError(
+      `[mobile-build] Android Play manifest allowlist failed:\n${uniqueFindings
+        .map((finding) => `  - ${finding}`)
+        .join("\n")}`,
+      {
+        code: "ANDROID_PLAY_MANIFEST_ALLOWLIST_FAILED",
+        context: { findings: uniqueFindings },
+      },
+    );
+  }
 }
 
 function collectManifestPolicyFinding(
@@ -723,6 +850,7 @@ function collectManifestPolicyFinding(
 export function assertAabManifestPolicy({
   manifests,
   appId,
+  playPolicy,
   strippedComponents,
   strippedPermissions,
 }) {
@@ -860,6 +988,50 @@ export function assertAabManifestPolicy({
       },
     );
   }
+  if (playPolicy) {
+    const manifestEvidence = [...manifests.entries()].map(
+      ([moduleName, manifestText]) =>
+        manifestPolicyEvidence(moduleName, manifestText),
+    );
+    const baseEvidence = manifestEvidence.find(
+      (moduleEvidence) => moduleEvidence.module === "base",
+    );
+    assertAndroidPlayManifestPolicyEvidence(
+      {
+        actions: uniqueSorted(
+          manifestEvidence.flatMap((moduleEvidence) => moduleEvidence.actions),
+        ),
+        application: baseEvidence.application,
+        components: uniqueSorted(
+          manifestEvidence.flatMap(
+            (moduleEvidence) => moduleEvidence.components,
+          ),
+        ),
+        metadataNames: uniqueSorted(
+          manifestEvidence.flatMap(
+            (moduleEvidence) => moduleEvidence.metadataNames,
+          ),
+        ),
+        permissions: uniqueSorted(
+          manifestEvidence.flatMap(
+            (moduleEvidence) => moduleEvidence.permissions,
+          ),
+        ),
+        queryActions: uniqueSorted(
+          manifestEvidence.flatMap(
+            (moduleEvidence) => moduleEvidence.queryActions,
+          ),
+        ),
+        queryPackages: uniqueSorted(
+          manifestEvidence.flatMap(
+            (moduleEvidence) => moduleEvidence.queryPackages,
+          ),
+        ),
+        targetSdkVersion: baseEvidence.targetSdkVersion,
+      },
+      playPolicy,
+    );
+  }
 }
 
 function normalizeDexBuffers(dexEntries, dexBuffers) {
@@ -947,6 +1119,7 @@ export function inspectAndroidAppBundle(
     strippedComponents,
     strippedPermissions,
     javaHome,
+    playPolicy,
     env = process.env,
     readDexEntries,
   },
@@ -1090,6 +1263,7 @@ export function inspectAndroidAppBundle(
   assertAabManifestPolicy({
     manifests,
     appId,
+    playPolicy,
     strippedComponents,
     strippedPermissions,
   });

--- a/packages/app-core/scripts/run-mobile-build-android-aab-audit.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-aab-audit.test.mjs
@@ -22,6 +22,7 @@ import {
   ANDROID_BUNDLETOOL_TIMEOUT_MS,
   ANDROID_BUNDLETOOL_URL,
   ANDROID_BUNDLETOOL_VERSION,
+  ANDROID_PLAY_FORBIDDEN_DEX_MARKERS,
   ensureAndroidBundletoolJar,
   inspectAndroidAppBundle,
   listAabDexEntries,
@@ -2028,6 +2029,39 @@ describe("inspectAndroidAppBundle", () => {
       "feature/dex/classes2.dex contains forbidden LP3 marker: lp3_color_policy",
     );
   });
+
+  it.each(ANDROID_PLAY_FORBIDDEN_DEX_MARKERS)(
+    "rejects Play local-runtime marker %s in any module DEX",
+    (forbiddenMarker) => {
+      const harness = successfulToolHarness(
+        new Map([
+          ["base", CLEAN_MANIFEST],
+          ["feature", CLEAN_MANIFEST],
+        ]),
+      );
+      const readDexEntries = (dexEntries) =>
+        dexEntries.map((entry) =>
+          Buffer.from(
+            entry.startsWith("feature/")
+              ? `dex strings ${forbiddenMarker}`
+              : "clean base dex",
+            "utf8",
+          ),
+        );
+
+      expect(() =>
+        inspectAndroidAppBundle(
+          inspectOptions({
+            entries: MULTI_MODULE_ENTRIES,
+            readDexEntries,
+          }),
+          harness.deps,
+        ),
+      ).toThrow(
+        `feature/dex/classes2.dex contains forbidden Play local-runtime marker: ${forbiddenMarker}`,
+      );
+    },
+  );
 
   it("rejects an LP3 marker in a dex smuggled outside a module dex dir", () => {
     const harness = successfulToolHarness();

--- a/packages/app-core/scripts/run-mobile-build-android-cloud-strip.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-cloud-strip.test.mjs
@@ -22,12 +22,17 @@ import { describe, expect, it } from "vitest";
 import {
   ANDROID_CLOUD_REWRITTEN_JAVA_FILES,
   ANDROID_CLOUD_STRIPPED_JAVA_FILES,
+  ANDROID_CLOUD_STRIPPED_TEST_JAVA_FILES,
 } from "./run-mobile-build.mjs";
 
 const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
 const androidMainJavaRoot = path.resolve(
   scriptsDir,
   "../platforms/android/app/src/main/java/ai/elizaos/app",
+);
+const androidTestJavaRoot = path.resolve(
+  scriptsDir,
+  "../platforms/android/app/src/test/java/ai/elizaos/app",
 );
 
 /** Every committed main-sourceset .java basename that references ElizaAgentService. */
@@ -87,5 +92,29 @@ describe("android-cloud ElizaAgentService strip coverage (#15106)", () => {
     // or rewritten to compile without it (rewrite) for the cloud target, or
     // auditAndroidCloudSource rejects the tree.
     expect(unaccounted).toEqual([]);
+  });
+
+  it("accounts for every JVM test that references source-stripped runtime code", () => {
+    const strippedClassNames = ANDROID_CLOUD_STRIPPED_JAVA_FILES.map((file) =>
+      file.replace(/\.java$/, ""),
+    );
+    const testFiles = fs
+      .readdirSync(androidTestJavaRoot, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".java"))
+      .map((entry) => entry.name)
+      .sort();
+    const referencesStrippedCode = testFiles.filter((file) => {
+      const source = fs.readFileSync(
+        path.join(androidTestJavaRoot, file),
+        "utf8",
+      );
+      return strippedClassNames.some((className) =>
+        new RegExp(`\\b${className}\\b`).test(source),
+      );
+    });
+
+    expect(ANDROID_CLOUD_STRIPPED_TEST_JAVA_FILES).toEqual(
+      referencesStrippedCode,
+    );
   });
 });

--- a/packages/app-core/scripts/run-mobile-build-android-lp3-color-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-lp3-color-policy.test.mjs
@@ -238,9 +238,8 @@ describe("LP3 direct Cloud build flag", () => {
 
     expect(direct.components).toContain("ElizaAgentService");
     expect(direct.permissions).toContain("MANAGE_APP_OPS_MODES");
-    expect(ANDROID_CLOUD_STRIPPED_PERMISSIONS).not.toContain(
-      "POST_NOTIFICATIONS",
-    );
+    expect(ANDROID_CLOUD_STRIPPED_PERMISSIONS).toContain("POST_NOTIFICATIONS");
+    expect(direct.permissions).not.toContain("POST_NOTIFICATIONS");
     expect(direct.javaFiles).toContain("ElizaAgentService.java");
   });
 
@@ -422,5 +421,4 @@ describe("LP3 direct Cloud build flag", () => {
     expect(readme).toContain("channel-level block");
     expect(readme).toContain("permission-prompt loop");
   });
-
 });

--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -14,6 +14,9 @@ import {
   ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES,
   androidPlayManifestEvidenceFromAapt,
   createAndroidPlayManifestPolicy,
+  findAndroidCloudPackagedRuntimeOffenders,
+  findAndroidPlayIndexHtmlFindings,
+  findAndroidPlayTextAssetFindings,
 } from "./run-mobile-build.mjs";
 
 const VARIABLES_GRADLE = fs.readFileSync(
@@ -22,6 +25,10 @@ const VARIABLES_GRADLE = fs.readFileSync(
 );
 const APP_BUILD_GRADLE = fs.readFileSync(
   new URL("../platforms/android/app/build.gradle", import.meta.url),
+  "utf8",
+);
+const APP_MAIN_SOURCE = fs.readFileSync(
+  new URL("../../app/src/main.tsx", import.meta.url),
   "utf8",
 );
 
@@ -181,6 +188,32 @@ describe("Android Play manifest policy", () => {
     );
     expect(APP_BUILD_GRADLE).toContain(
       'implementation "androidx.work:work-runtime:2.11.0"',
+    );
+  });
+
+  it("rejects an active local-agent bootstrap in packaged Play index HTML", () => {
+    expect(
+      findAndroidPlayIndexHtmlFindings(
+        ["base/assets/public/index.html", "base/assets/public/assets/app.js"],
+        [
+          Buffer.from(
+            "connect-src eliza-local-agent:; window.__ELIZA_ANDROID_IPC_FETCH_BRIDGE__ = true;",
+          ),
+          Buffer.from("eliza-local-agent: remains inert in a lazy chunk"),
+        ],
+      ),
+    ).toEqual([
+      "base/assets/public/index.html: active local bootstrap marker __ELIZA_ANDROID_IPC_FETCH_BRIDGE__",
+      "base/assets/public/index.html: active local bootstrap marker eliza-local-agent:",
+    ]);
+  });
+
+  it("does not initialize Android local-agent bridges in the Cloud client", () => {
+    expect(APP_MAIN_SOURCE).toContain(
+      "if (!isAndroidCloudBuild() && !hasFirstRunRuntimeOverride())",
+    );
+    expect(APP_MAIN_SOURCE).toContain(
+      "if (!isAndroidCloudBuild()) {\n      installAndroidNativeAgentFetchBridge();",
     );
   });
 });

--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -14,9 +14,7 @@ import {
   ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES,
   androidPlayManifestEvidenceFromAapt,
   createAndroidPlayManifestPolicy,
-  findAndroidCloudPackagedRuntimeOffenders,
   findAndroidPlayIndexHtmlFindings,
-  findAndroidPlayTextAssetFindings,
 } from "./run-mobile-build.mjs";
 
 const VARIABLES_GRADLE = fs.readFileSync(

--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -187,6 +187,31 @@ describe("Android Play manifest policy", () => {
     expect(APP_BUILD_GRADLE).toContain(
       'implementation "androidx.work:work-runtime:2.11.0"',
     );
+    const mainActivity = cloudSafeMainActivityJava("ai.elizaos.app");
+    expect(mainActivity).not.toContain("android.os.SystemProperties");
+    expect(mainActivity).not.toContain("java.lang.reflect");
+    expect(mainActivity).not.toContain("GatewayConnectionService");
+  });
+
+  it("rejects local routing and credential material in packaged text assets", () => {
+    expect(
+      findAndroidPlayTextAssetFindings(
+        ["base/assets/public/app.js"],
+        [Buffer.from("http://127.0.0.1:31337")],
+      ),
+    ).toEqual(["base/assets/public/app.js: local routing marker 31337"]);
+    expect(
+      findAndroidPlayTextAssetFindings(
+        ["assets/public/app.js"],
+        [Buffer.from('CEREBRAS_API_KEY="not-a-real-key"')],
+      ),
+    ).toEqual([]);
+    expect(
+      findAndroidPlayTextAssetFindings(
+        ["assets/public/app.js"],
+        [Buffer.from(`CARTESIA_API_KEY="${"a".repeat(24)}"`)],
+      ),
+    ).toEqual(["assets/public/app.js: Cerebras/Cartesia credential"]);
   });
 
   it("rejects an active local-agent bootstrap in packaged Play index HTML", () => {

--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -15,6 +15,7 @@ import {
   androidPlayManifestEvidenceFromAapt,
   createAndroidPlayManifestPolicy,
   findAndroidPlayIndexHtmlFindings,
+  findAndroidPlayTextAssetFindings,
 } from "./run-mobile-build.mjs";
 
 const VARIABLES_GRADLE = fs.readFileSync(
@@ -187,10 +188,6 @@ describe("Android Play manifest policy", () => {
     expect(APP_BUILD_GRADLE).toContain(
       'implementation "androidx.work:work-runtime:2.11.0"',
     );
-    const mainActivity = cloudSafeMainActivityJava("ai.elizaos.app");
-    expect(mainActivity).not.toContain("android.os.SystemProperties");
-    expect(mainActivity).not.toContain("java.lang.reflect");
-    expect(mainActivity).not.toContain("GatewayConnectionService");
   });
 
   it("rejects local routing and credential material in packaged text assets", () => {

--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -143,7 +143,6 @@ describe("Android Play manifest policy", () => {
       "@capacitor/preferences",
       "@capacitor/share",
       "@capacitor/status-bar",
-      "@elizaos/capacitor-talkmode",
     ]);
     expect(ANDROID_CLOUD_STRIPPED_NATIVE_PLUGINS.map(([pkg]) => pkg)).toEqual(
       expect.arrayContaining([
@@ -152,6 +151,7 @@ describe("Android Play manifest policy", () => {
         "@elizaos/capacitor-bun-runtime",
         "@elizaos/capacitor-mobile-signals",
         "@elizaos/capacitor-screencapture",
+        "@elizaos/capacitor-talkmode",
         "llama-cpp-capacitor",
       ]),
     );

--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -1,0 +1,162 @@
+/** Locks the standard Google Play Android client to its minimal manifest. */
+import fs from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { assertAndroidPlayManifestPolicyEvidence } from "./lib/android-cloud-artifact-audit.mjs";
+import {
+  ANDROID_CLOUD_STRIPPED_COMPONENTS,
+  ANDROID_CLOUD_STRIPPED_NATIVE_PLUGINS,
+  ANDROID_CLOUD_STRIPPED_PERMISSIONS,
+  ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES,
+  ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES,
+  androidPlayManifestEvidenceFromAapt,
+  createAndroidPlayManifestPolicy,
+} from "./run-mobile-build.mjs";
+
+const VARIABLES_GRADLE = fs.readFileSync(
+  new URL("../platforms/android/variables.gradle", import.meta.url),
+  "utf8",
+);
+const APP_BUILD_GRADLE = fs.readFileSync(
+  new URL("../platforms/android/app/build.gradle", import.meta.url),
+  "utf8",
+);
+
+const AAPT_MANIFEST = `
+  E: manifest (line=2)
+    E: uses-sdk (line=3)
+      A: android:targetSdkVersion(0x01010270)=(type 0x10)0x24
+    E: queries (line=4)
+      E: intent (line=5)
+        E: action (line=6)
+          A: android:name(0x01010003)="android.speech.RecognitionService" (Raw: "android.speech.RecognitionService")
+    E: uses-permission (line=7)
+      A: android:name(0x01010003)="android.permission.INTERNET" (Raw: "android.permission.INTERNET")
+    E: application (line=8)
+      A: android:debuggable(0x0101000f)=(type 0x12)0xffffffff
+      A: android:allowBackup(0x01010280)=(type 0x12)0x0
+      A: android:usesCleartextTraffic(0x010104ec)=(type 0x12)0x0
+      E: activity (line=9)
+        A: android:name(0x01010003)="ai.elizaos.app.MainActivity" (Raw: "ai.elizaos.app.MainActivity")
+        E: intent-filter (line=10)
+          E: action (line=11)
+            A: android:name(0x01010003)="android.intent.action.MAIN" (Raw: "android.intent.action.MAIN")
+      E: provider (line=12)
+        A: android:name(0x01010003)="androidx.core.content.FileProvider" (Raw: "androidx.core.content.FileProvider")
+        E: meta-data (line=13)
+          A: android:name(0x01010003)="android.support.FILE_PROVIDER_PATHS" (Raw: "android.support.FILE_PROVIDER_PATHS")
+`;
+
+describe("Android Play manifest policy", () => {
+  it("parses AAPT xmltree evidence without confusing nested action names for components", () => {
+    expect(androidPlayManifestEvidenceFromAapt(AAPT_MANIFEST)).toEqual({
+      actions: [
+        "android.intent.action.MAIN",
+        "android.speech.RecognitionService",
+      ],
+      application: {
+        allowBackup: "false",
+        debuggable: "true",
+        usesCleartextTraffic: "false",
+      },
+      components: [
+        "activity:ai.elizaos.app.MainActivity",
+        "provider:androidx.core.content.FileProvider",
+      ],
+      metadataNames: ["android.support.FILE_PROVIDER_PATHS"],
+      permissions: ["android.permission.INTERNET"],
+      queryActions: ["android.speech.RecognitionService"],
+      queryPackages: [],
+      targetSdkVersion: "36",
+    });
+  });
+
+  it("accepts only the exact release policy evidence", () => {
+    const policy = createAndroidPlayManifestPolicy();
+    expect(() =>
+      assertAndroidPlayManifestPolicyEvidence(
+        {
+          ...policy,
+          application: { ...policy.application },
+        },
+        policy,
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects an unexpected restricted permission or background service", () => {
+    const policy = createAndroidPlayManifestPolicy();
+    expect(() =>
+      assertAndroidPlayManifestPolicyEvidence(
+        {
+          ...policy,
+          application: { ...policy.application },
+          components: [
+            ...policy.components,
+            "service:ai.elizaos.app.GatewayConnectionService",
+          ],
+          permissions: [...policy.permissions, "android.permission.CAMERA"],
+        },
+        policy,
+      ),
+    ).toThrow(
+      /unexpected component.*GatewayConnectionService[\s\S]*unexpected permission.*CAMERA/,
+    );
+  });
+
+  it("keeps policy-hostile surfaces in the strip set and native code out", () => {
+    for (const component of [
+      "ElizaAccessibilityService",
+      "ElizaNotificationListenerService",
+      "ElizaVoiceInputMethodService",
+      "GatewayConnectionService",
+    ]) {
+      expect(ANDROID_CLOUD_STRIPPED_COMPONENTS).toContain(component);
+    }
+    for (const permission of [
+      "BIND_ACCESSIBILITY_SERVICE",
+      "BIND_NOTIFICATION_LISTENER_SERVICE",
+      "CALL_PHONE",
+      "CAMERA",
+      "POST_NOTIFICATIONS",
+      "READ_SMS",
+      "SYSTEM_ALERT_WINDOW",
+    ]) {
+      expect(ANDROID_CLOUD_STRIPPED_PERMISSIONS).toContain(permission);
+    }
+    expect(ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES).toEqual([]);
+    expect(ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES).toEqual([
+      "@capacitor/app",
+      "@capacitor/browser",
+      "@capacitor/device",
+      "@capacitor/filesystem",
+      "@capacitor/keyboard",
+      "@capacitor/network",
+      "@capacitor/preferences",
+      "@capacitor/share",
+      "@capacitor/status-bar",
+      "@elizaos/capacitor-talkmode",
+    ]);
+    expect(ANDROID_CLOUD_STRIPPED_NATIVE_PLUGINS.map(([pkg]) => pkg)).toEqual(
+      expect.arrayContaining([
+        "@capacitor/background-runner",
+        "@capacitor/push-notifications",
+        "@elizaos/capacitor-bun-runtime",
+        "@elizaos/capacitor-mobile-signals",
+        "@elizaos/capacitor-screencapture",
+        "llama-cpp-capacitor",
+      ]),
+    );
+  });
+
+  it("targets API 36 and excludes background-worker dependencies in Cloud", () => {
+    expect(VARIABLES_GRADLE).toContain("targetSdkVersion = 36");
+    expect(APP_BUILD_GRADLE).toContain(
+      "project.findProperty('elizaCloudBuild') != 'true'",
+    );
+    expect(APP_BUILD_GRADLE).toContain(
+      'implementation "androidx.work:work-runtime:2.11.0"',
+    );
+  });
+});

--- a/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-play-policy.test.mjs
@@ -8,6 +8,8 @@ import {
   ANDROID_CLOUD_STRIPPED_COMPONENTS,
   ANDROID_CLOUD_STRIPPED_NATIVE_PLUGINS,
   ANDROID_CLOUD_STRIPPED_PERMISSIONS,
+  ANDROID_CLOUD_STRIPPED_RESOURCE_FILES,
+  ANDROID_CLOUD_STRIPPED_RESOURCE_VALUES,
   ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES,
   ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES,
   androidPlayManifestEvidenceFromAapt,
@@ -148,6 +150,28 @@ describe("Android Play manifest policy", () => {
         "llama-cpp-capacitor",
       ]),
     );
+    expect(ANDROID_CLOUD_STRIPPED_RESOURCE_FILES).toEqual(
+      expect.arrayContaining([
+        "drawable/eliza_ime_mic_bg.xml",
+        "drawable/ic_eliza_ime_keyboard.xml",
+        "drawable/ic_eliza_ime_mic.xml",
+        "drawable/ic_eliza_ime_open.xml",
+        "layout/eliza_voice_ime.xml",
+        "xml/eliza_accessibility_service.xml",
+        "xml/method.xml",
+      ]),
+    );
+    expect(ANDROID_CLOUD_STRIPPED_RESOURCE_VALUES).toMatchObject({
+      "values/android_app_actions.xml": [
+        "app_widget_quick_actions_description",
+        "app_widget_quick_actions_title",
+      ],
+      "values/strings.xml": expect.arrayContaining([
+        "assistant_session_prompt",
+        "eliza_ime_label",
+        "eliza_ime_permission_needed",
+      ]),
+    });
   });
 
   it("targets API 36 and excludes background-worker dependencies in Cloud", () => {

--- a/packages/app-core/scripts/run-mobile-build-android-targets.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-targets.test.mjs
@@ -113,7 +113,10 @@ describe("Android mobile build target table", () => {
   });
 
   it("runs the exact mobile CLI through a pre-mutation Android guard", () => {
-    const result = spawnSync(process.execPath, [mobileBuildScript, "android"], {
+    // The production package scripts invoke this CLI with Node. `process.execPath`
+    // points at Bun under `bun test`, which spends long enough compiling this
+    // large orchestrator to hit Bun's per-test timeout before the guard runs.
+    const result = spawnSync("node", [mobileBuildScript, "android"], {
       encoding: "utf8",
       env: {
         ...process.env,

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -3,7 +3,10 @@
  * are required after local-runtime sources are stripped from the build.
  */
 import { describe, expect, it } from "vitest";
-import { cloudSafeMainActivityJava } from "./run-mobile-build.mjs";
+import {
+  cloudSafeMainActivityJava,
+  cloudSafeSecureCredentialsPluginJava,
+} from "./run-mobile-build.mjs";
 
 describe("cloudSafeMainActivityJava", () => {
   it("installs the splash lifecycle before Capacitor creates the bridge", () => {
@@ -20,10 +23,12 @@ describe("cloudSafeMainActivityJava", () => {
     expect(splashInstall).toBeLessThan(bridgeCreation);
   });
 
-  it("keeps the notification plugin out of the Play-safe activity", () => {
+  it("does not register push or background messaging in the minimal Play activity", () => {
     const source = cloudSafeMainActivityJava("ai.elizaos.app");
 
     expect(source).not.toContain("SafePushNotificationsPlugin");
+    expect(source).not.toContain("PushNotifications");
+    expect(source).not.toContain("GatewayConnectionService");
   });
 
   it("captures cold and warm deep links before Capacitor dispatches them", () => {
@@ -40,9 +45,27 @@ describe("cloudSafeMainActivityJava", () => {
     const warmDispatch = source.indexOf("super.onNewIntent(intent);");
 
     expect(source).toContain("registerPlugin(DeepLinkBufferPlugin.class);");
+    expect(source).toContain(
+      "registerPlugin(ElizaSecureCredentialsPlugin.class);",
+    );
     expect(coldCapture).toBeGreaterThanOrEqual(0);
     expect(coldCapture).toBeLessThan(bridgeCreation);
     expect(warmCapture).toBeGreaterThanOrEqual(0);
     expect(warmCapture).toBeLessThan(warmDispatch);
+  });
+
+  it("generates permissionless Android Keystore AES-GCM credential storage", () => {
+    const source = cloudSafeSecureCredentialsPluginJava("ai.elizaos.app");
+
+    expect(source).toContain(
+      '@CapacitorPlugin(name = "ElizaSecureCredentials")',
+    );
+    expect(source).toContain("KeyStore.getInstance(ANDROID_KEYSTORE)");
+    expect(source).toContain("Cipher.getInstance(TRANSFORMATION)");
+    expect(source).toContain("KeyProperties.BLOCK_MODE_GCM");
+    expect(source).toContain(".setRandomizedEncryptionRequired(true)");
+    expect(source).not.toContain("uses-permission");
+    expect(source).not.toContain("http://");
+    expect(source).not.toContain("https://");
   });
 });

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -20,17 +20,10 @@ describe("cloudSafeMainActivityJava", () => {
     expect(splashInstall).toBeLessThan(bridgeCreation);
   });
 
-  it("registers the Firebase-safe push plugin after Capacitor creates the bridge", () => {
+  it("keeps the notification plugin out of the Play-safe activity", () => {
     const source = cloudSafeMainActivityJava("ai.elizaos.app");
-    const bridgeCreation = source.indexOf(
-      "super.onCreate(savedInstanceState);",
-    );
-    const safeRegistration = source.indexOf(
-      "getBridge().registerPlugin(SafePushNotificationsPlugin.class);",
-    );
 
-    expect(bridgeCreation).toBeGreaterThanOrEqual(0);
-    expect(safeRegistration).toBeGreaterThan(bridgeCreation);
+    expect(source).not.toContain("SafePushNotificationsPlugin");
   });
 
   it("captures cold and warm deep links before Capacitor dispatches them", () => {

--- a/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-cloud-main-activity.test.mjs
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "vitest";
 import {
   cloudSafeMainActivityJava,
+  cloudSafePlayVoicePluginJava,
   cloudSafeSecureCredentialsPluginJava,
 } from "./run-mobile-build.mjs";
 
@@ -48,6 +49,7 @@ describe("cloudSafeMainActivityJava", () => {
     expect(source).toContain(
       "registerPlugin(ElizaSecureCredentialsPlugin.class);",
     );
+    expect(source).toContain("registerPlugin(ElizaPlayVoicePlugin.class);");
     expect(coldCapture).toBeGreaterThanOrEqual(0);
     expect(coldCapture).toBeLessThan(bridgeCreation);
     expect(warmCapture).toBeGreaterThanOrEqual(0);
@@ -65,6 +67,18 @@ describe("cloudSafeMainActivityJava", () => {
     expect(source).toContain("KeyProperties.BLOCK_MODE_GCM");
     expect(source).toContain(".setRandomizedEncryptionRequired(true)");
     expect(source).not.toContain("uses-permission");
+    expect(source).not.toContain("http://");
+    expect(source).not.toContain("https://");
+  });
+
+  it("generates standard speech recognition and system TTS without local transports", () => {
+    const source = cloudSafePlayVoicePluginJava("ai.elizaos.app");
+
+    expect(source).toContain('@CapacitorPlugin(\n    name = "ElizaPlayVoice"');
+    expect(source).toContain("SpeechRecognizer.createSpeechRecognizer");
+    expect(source).toContain("new TextToSpeech(getContext()");
+    expect(source).toContain("Manifest.permission.RECORD_AUDIO");
+    expect(source).not.toMatch(/LocalSocket|HttpURLConnection|apiKey|bionic/i);
     expect(source).not.toContain("http://");
     expect(source).not.toContain("https://");
   });

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -5842,6 +5842,87 @@ export const ANDROID_PLAY_ALLOWED_QUERY_ACTIONS = Object.freeze([
 
 export const ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES = Object.freeze([]);
 
+export const ANDROID_PLAY_FORBIDDEN_ASSET_MARKERS = Object.freeze([
+  "31337",
+  "31338",
+  "32437",
+  "32438",
+  "10.0.2.2",
+  "adb reverse",
+]);
+
+export const ANDROID_PLAY_FORBIDDEN_INDEX_HTML_MARKERS = Object.freeze([
+  "__ELIZA_ANDROID_IPC_FETCH_BRIDGE__",
+  "eliza-local-agent:",
+  "127.0.0.1",
+  "localhost",
+  "remote-mac",
+]);
+
+const ANDROID_PLAY_SECRET_PATTERNS = Object.freeze([
+  ["Google API key", /AIza[0-9A-Za-z_-]{30,}/],
+  ["provider secret", /sk-(?:proj-)?[A-Za-z0-9]{20,}/],
+  ["private key", /BEGIN (?:RSA |OPENSSH )?PRIVATE KEY/],
+  [
+    "Cerebras/Cartesia credential",
+    /(?:CEREBRAS|CARTESIA)_API_KEY.{0,12}[=:].{0,12}["'][A-Za-z0-9_-]{20,}["']/i,
+  ],
+]);
+
+export function findAndroidPlayTextAssetFindings(entries, buffers) {
+  if (!Array.isArray(entries) || !Array.isArray(buffers)) {
+    throw mobileBuildError(
+      "[mobile-build] Android Play text asset evidence must use arrays.",
+    );
+  }
+  if (entries.length !== buffers.length) {
+    throw mobileBuildError(
+      "[mobile-build] Android Play text asset evidence length mismatch.",
+    );
+  }
+  const findings = [];
+  for (let index = 0; index < entries.length; index += 1) {
+    const content = Buffer.from(buffers[index]).toString("utf8");
+    for (const marker of ANDROID_PLAY_FORBIDDEN_ASSET_MARKERS) {
+      if (content.toLowerCase().includes(marker.toLowerCase())) {
+        findings.push(`${entries[index]}: local routing marker ${marker}`);
+      }
+    }
+    for (const [label, pattern] of ANDROID_PLAY_SECRET_PATTERNS) {
+      if (pattern.test(content)) findings.push(`${entries[index]}: ${label}`);
+    }
+  }
+  return [...new Set(findings)].sort();
+}
+
+export function findAndroidPlayIndexHtmlFindings(entries, buffers) {
+  if (!Array.isArray(entries) || !Array.isArray(buffers)) {
+    throw mobileBuildError(
+      "[mobile-build] Android Play index HTML evidence must use arrays.",
+    );
+  }
+  if (entries.length !== buffers.length) {
+    throw mobileBuildError(
+      "[mobile-build] Android Play index HTML evidence length mismatch.",
+    );
+  }
+  const findings = [];
+  for (let index = 0; index < entries.length; index += 1) {
+    if (!/(?:^|\/)assets\/public\/index\.html$/i.test(entries[index])) {
+      continue;
+    }
+    const content = Buffer.from(buffers[index]).toString("utf8").toLowerCase();
+    for (const marker of ANDROID_PLAY_FORBIDDEN_INDEX_HTML_MARKERS) {
+      if (content.includes(marker.toLowerCase())) {
+        findings.push(
+          `${entries[index]}: active local bootstrap marker ${marker}`,
+        );
+      }
+    }
+  }
+  return [...new Set(findings)].sort();
+}
+
 export function createAndroidPlayManifestPolicy({ debug = false } = {}) {
   return {
     actions: [...ANDROID_PLAY_ALLOWED_ACTIONS],
@@ -8377,6 +8458,43 @@ export function auditAndroidCloudArtifact(
         {
           code: "ANDROID_PLAY_NATIVE_LIBRARY_ALLOWLIST_FAILED",
           context: { artifact, nativeLibraries },
+        },
+      );
+    }
+    const textAssetEntries = entries.filter(
+      (entry) =>
+        /(?:^|\/)assets\//.test(entry) &&
+        /\.(?:css|html|js|json|svg|txt|webmanifest|xml)$/i.test(entry),
+    );
+    const textAssetBuffers = readAndroidArtifactEntryBuffers(
+      artifact,
+      textAssetEntries,
+      javaHome,
+      {
+        artifactBytes: initialSnapshot.bytes,
+        label: "android-cloud Play text asset audit",
+      },
+    );
+    const textAssetFindings = findAndroidPlayTextAssetFindings(
+      textAssetEntries,
+      textAssetBuffers,
+    );
+    const indexHtmlFindings = findAndroidPlayIndexHtmlFindings(
+      textAssetEntries,
+      textAssetBuffers,
+    );
+    const playTextFindings = [
+      ...textAssetFindings,
+      ...indexHtmlFindings,
+    ].sort();
+    if (playTextFindings.length > 0) {
+      throw mobileBuildError(
+        `[mobile-build] android-cloud text asset policy failed:\n${playTextFindings
+          .map((finding) => `  - ${finding}`)
+          .join("\n")}`,
+        {
+          code: "ANDROID_PLAY_TEXT_ASSET_POLICY_FAILED",
+          context: { artifact, findings: playTextFindings },
         },
       );
     }

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -77,6 +77,7 @@ import {
   ANDROID_LP3_POLICY_CLASSES,
   ANDROID_LP3_POLICY_MARKERS,
   ANDROID_LP3_PRIVATE_ACTIONS,
+  assertAndroidPlayManifestPolicyEvidence,
   ensureAndroidBundletoolJar,
   inspectAndroidAppBundle,
   resolveAndroidArtifactKind,
@@ -5753,6 +5754,68 @@ export const ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES = Object.freeze([
   "@elizaos/capacitor-talkmode",
 ]);
 
+export const ANDROID_PLAY_ALLOWED_PERMISSIONS = Object.freeze([
+  "android.permission.ACCESS_NETWORK_STATE",
+  "android.permission.INTERNET",
+  "android.permission.MODIFY_AUDIO_SETTINGS",
+  "android.permission.RECORD_AUDIO",
+  `${APP.appId}.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION`,
+]);
+
+export const ANDROID_PLAY_ALLOWED_COMPONENTS = Object.freeze([
+  `activity:${APP.appId}.ElizaShareActivity`,
+  `activity:${APP.appId}.MainActivity`,
+  "activity:com.capacitorjs.plugins.browser.BrowserControllerActivity",
+  "provider:androidx.core.content.FileProvider",
+  "provider:androidx.startup.InitializationProvider",
+  "receiver:androidx.profileinstaller.ProfileInstallReceiver",
+]);
+
+export const ANDROID_PLAY_ALLOWED_ACTIONS = Object.freeze([
+  "android.intent.action.MAIN",
+  "android.intent.action.PROCESS_TEXT",
+  "android.intent.action.SEND",
+  "android.intent.action.VIEW",
+  "android.speech.RecognitionService",
+  "android.support.customtabs.action.CustomTabsService",
+  "androidx.profileinstaller.action.BENCHMARK_OPERATION",
+  "androidx.profileinstaller.action.INSTALL_PROFILE",
+  "androidx.profileinstaller.action.SAVE_PROFILE",
+  "androidx.profileinstaller.action.SKIP_FILE",
+]);
+
+export const ANDROID_PLAY_ALLOWED_METADATA_NAMES = Object.freeze([
+  "android.app.shortcuts",
+  "android.support.FILE_PROVIDER_PATHS",
+  "androidx.emoji2.text.EmojiCompatInitializer",
+  "androidx.lifecycle.ProcessLifecycleInitializer",
+  "androidx.profileinstaller.ProfileInstallerInitializer",
+]);
+
+export const ANDROID_PLAY_ALLOWED_QUERY_ACTIONS = Object.freeze([
+  "android.speech.RecognitionService",
+  "android.support.customtabs.action.CustomTabsService",
+]);
+
+export const ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES = Object.freeze([]);
+
+export function createAndroidPlayManifestPolicy({ debug = false } = {}) {
+  return {
+    actions: [...ANDROID_PLAY_ALLOWED_ACTIONS],
+    application: {
+      allowBackup: "false",
+      debuggable: debug ? "true" : "false",
+      usesCleartextTraffic: "false",
+    },
+    components: [...ANDROID_PLAY_ALLOWED_COMPONENTS],
+    metadataNames: [...ANDROID_PLAY_ALLOWED_METADATA_NAMES],
+    permissions: [...ANDROID_PLAY_ALLOWED_PERMISSIONS],
+    queryActions: [...ANDROID_PLAY_ALLOWED_QUERY_ACTIONS],
+    queryPackages: [],
+    targetSdkVersion: "36",
+  };
+}
+
 const ANDROID_SMS_GATEWAY_COMPONENTS = new Set([
   "ElizaSmsReceiver",
   "ElizaMmsReceiver",
@@ -8184,6 +8247,25 @@ export function auditAndroidCloudArtifact(
       },
     );
   }
+  if (!lp3ColorPolicyEnabled) {
+    const nativeLibraries = entries
+      .filter((entry) => /(?:^|\/)lib\/[^/]+\/[^/]+\.so$/i.test(entry))
+      .sort();
+    if (
+      JSON.stringify(nativeLibraries) !==
+      JSON.stringify([...ANDROID_PLAY_ALLOWED_NATIVE_LIBRARIES].sort())
+    ) {
+      throw mobileBuildError(
+        `[mobile-build] android-cloud native libraries differ from the Play allowlist:\n${nativeLibraries
+          .map((entry) => `  - ${entry}`)
+          .join("\n")}`,
+        {
+          code: "ANDROID_PLAY_NATIVE_LIBRARY_ALLOWLIST_FAILED",
+          context: { artifact, nativeLibraries },
+        },
+      );
+    }
+  }
   const integrityEntries = entries.filter((entry) =>
     artifactKind === "aab"
       ? /^[^/]+\/manifest\/AndroidManifest\.xml$/.test(entry) ||
@@ -8270,6 +8352,10 @@ export function auditAndroidCloudArtifact(
           appId: APP.appId,
           label: "normal Cloud",
         });
+        assertAndroidPlayManifestPolicyEvidence(
+          androidPlayManifestEvidenceFromAapt(manifestText),
+          createAndroidPlayManifestPolicy({ debug: true }),
+        );
       }
       auditAndroidArtifactDexLp3Policy(
         inspectedArtifact,
@@ -8304,6 +8390,7 @@ export function auditAndroidCloudArtifact(
         entries,
         env,
         javaHome,
+        playPolicy: createAndroidPlayManifestPolicy({ debug: false }),
         readDexEntries: (dexEntries) =>
           readAndroidArtifactEntryBuffers(
             inspectedArtifact,
@@ -8455,6 +8542,113 @@ export function dumpAndroidArtifactManifest(
     );
   }
   return manifest.stdout;
+}
+
+function parseAaptAttributeValue(encodedValue) {
+  const rawValue = encodedValue.match(/\(Raw: "([^"]*)"\)\s*$/)?.[1];
+  if (rawValue !== undefined) return rawValue;
+  const quotedValue = encodedValue.match(/^"([^"]*)"/)?.[1];
+  if (quotedValue !== undefined) return quotedValue;
+  const typedValue = encodedValue.match(
+    /^\(type (0x[0-9a-f]+)\)(0x[0-9a-f]+)$/i,
+  );
+  if (!typedValue) return encodedValue.trim();
+  if (typedValue[1].toLowerCase() === "0x12") {
+    return typedValue[2].toLowerCase() === "0x0" ? "false" : "true";
+  }
+  return String(Number.parseInt(typedValue[2], 16));
+}
+
+/** Converts AAPT's indented xmltree output into the policy evidence shape. */
+export function androidPlayManifestEvidenceFromAapt(manifestText) {
+  const tags = [];
+  const stack = [];
+  for (const line of String(manifestText).split(/\r?\n/)) {
+    const element = line.match(/^(\s*)E: ([^\s(]+)(?:\s|$)/);
+    if (element) {
+      const indent = element[1].length;
+      while (stack.length > 0 && stack.at(-1).indent >= indent) stack.pop();
+      const tag = {
+        ancestors: stack.map((ancestor) => ancestor.name),
+        attributes: new Map(),
+        indent,
+        name: element[2],
+      };
+      tags.push(tag);
+      stack.push(tag);
+      continue;
+    }
+    const attribute = line.match(
+      /^(\s*)A: ([^=(]+?)(?:\(0x[0-9a-f]+\))?=(.*)$/i,
+    );
+    if (!attribute || stack.length === 0) continue;
+    const qualifiedName = attribute[2].trim();
+    stack
+      .at(-1)
+      .attributes.set(
+        qualifiedName.split(":").at(-1),
+        parseAaptAttributeValue(attribute[3]),
+      );
+  }
+
+  const values = (names, attributeName = "name") =>
+    [
+      ...new Set(
+        tags
+          .filter((tag) => names.includes(tag.name))
+          .map((tag) => tag.attributes.get(attributeName))
+          .filter(Boolean),
+      ),
+    ].sort();
+  const componentNames = new Set([
+    "activity",
+    "activity-alias",
+    "provider",
+    "receiver",
+    "service",
+  ]);
+  const application = tags.find((tag) => tag.name === "application");
+  const usesSdk = tags.find((tag) => tag.name === "uses-sdk");
+  const isInsideQueries = (tag) => tag.ancestors.includes("queries");
+  return {
+    actions: values(["action"]),
+    application: {
+      allowBackup: application?.attributes.get("allowBackup") ?? null,
+      debuggable: application?.attributes.get("debuggable") ?? "false",
+      usesCleartextTraffic:
+        application?.attributes.get("usesCleartextTraffic") ?? null,
+    },
+    components: [
+      ...new Set(
+        tags
+          .filter((tag) => componentNames.has(tag.name))
+          .map((tag) => {
+            const componentName = tag.attributes.get("name");
+            return componentName ? `${tag.name}:${componentName}` : null;
+          })
+          .filter(Boolean),
+      ),
+    ].sort(),
+    metadataNames: values(["meta-data"]),
+    permissions: values(["uses-permission", "uses-permission-sdk-23"]),
+    queryActions: [
+      ...new Set(
+        tags
+          .filter((tag) => tag.name === "action" && isInsideQueries(tag))
+          .map((tag) => tag.attributes.get("name"))
+          .filter(Boolean),
+      ),
+    ].sort(),
+    queryPackages: [
+      ...new Set(
+        tags
+          .filter((tag) => tag.name === "package" && isInsideQueries(tag))
+          .map((tag) => tag.attributes.get("name"))
+          .filter(Boolean),
+      ),
+    ].sort(),
+    targetSdkVersion: usesSdk?.attributes.get("targetSdkVersion") ?? null,
+  };
 }
 
 function assertAndroidSmsGatewayArtifactManifest(manifestText) {

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -5695,10 +5695,14 @@ export const ANDROID_CLOUD_STRIPPED_ASSET_FILES = new Set([
 ]);
 
 export const ANDROID_CLOUD_STRIPPED_RESOURCE_FILES = [
+  path.join("drawable", "eliza_ime_mic_bg.xml"),
   path.join("drawable", "eliza_voice_bar_bg.xml"),
   path.join("drawable", "eliza_voice_bar_dot.xml"),
   path.join("drawable", "eliza_widget_background.xml"),
   path.join("drawable", "eliza_widget_button_background.xml"),
+  path.join("drawable", "ic_eliza_ime_keyboard.xml"),
+  path.join("drawable", "ic_eliza_ime_mic.xml"),
+  path.join("drawable", "ic_eliza_ime_open.xml"),
   path.join("layout", "eliza_quick_actions_widget.xml"),
   path.join("layout", "eliza_voice_ime.xml"),
   path.join("layout", "eliza_voice_interaction_bar.xml"),
@@ -5708,6 +5712,29 @@ export const ANDROID_CLOUD_STRIPPED_RESOURCE_FILES = [
   path.join("xml", "eliza_voice_interaction_service.xml"),
   path.join("xml", "method.xml"),
 ];
+
+export const ANDROID_CLOUD_STRIPPED_RESOURCE_VALUES = Object.freeze({
+  [path.join("values", "android_app_actions.xml")]: Object.freeze([
+    "app_widget_quick_actions_description",
+    "app_widget_quick_actions_title",
+  ]),
+  [path.join("values", "strings.xml")]: Object.freeze([
+    "assistant_session_prompt",
+    "eliza_ime_engine_off",
+    "eliza_ime_error_mic",
+    "eliza_ime_error_transcribe",
+    "eliza_ime_hint",
+    "eliza_ime_label",
+    "eliza_ime_listening",
+    "eliza_ime_model_not_ready",
+    "eliza_ime_no_speech",
+    "eliza_ime_permission_needed",
+    "eliza_ime_prompt",
+    "eliza_ime_subtype_voice",
+    "eliza_ime_switch_back",
+    "eliza_ime_transcribing",
+  ]),
+});
 
 export const ANDROID_CLOUD_STRIPPED_NATIVE_PLUGINS = [
   ["@capacitor-community/bluetooth-le", "capacitor-community-bluetooth-le"],
@@ -6530,6 +6557,20 @@ function auditAndroidCloudSource(phase, { env = process.env } = {}) {
       failures.push(`app/src/main/res/${relPath} still exists`);
     }
   }
+  for (const [relPath, names] of Object.entries(
+    ANDROID_CLOUD_STRIPPED_RESOURCE_VALUES,
+  )) {
+    const target = path.join(resRoot, relPath);
+    if (!fs.existsSync(target)) continue;
+    const xml = fs.readFileSync(target, "utf8");
+    for (const name of names) {
+      if (
+        new RegExp(`<string\\s+name=["']${escapeRegExp(name)}["']`).test(xml)
+      ) {
+        failures.push(`app/src/main/res/${relPath} still defines ${name}`);
+      }
+    }
+  }
 
   const javaRoot = path.join(androidDir, "app", "src", "main", "java");
   const forbiddenJavaFiles = new Set(stripPolicy.javaFiles);
@@ -6805,6 +6846,32 @@ function auditAndroidSystemSource(
  *
  * Idempotent: safe to re-run on an already-stripped tree.
  */
+function stripAndroidCloudResourceValues(resRoot) {
+  let removed = 0;
+  for (const [relPath, names] of Object.entries(
+    ANDROID_CLOUD_STRIPPED_RESOURCE_VALUES,
+  )) {
+    const target = path.join(resRoot, relPath);
+    if (!fs.existsSync(target)) continue;
+    let xml = fs.readFileSync(target, "utf8");
+    const original = xml;
+    for (const name of names) {
+      const resource = new RegExp(
+        `\\s*<string\\s+name=["']${escapeRegExp(name)}["'][^>]*>[\\s\\S]*?<\\/string>`,
+        "g",
+      );
+      xml = xml.replace(resource, () => {
+        removed += 1;
+        return "";
+      });
+    }
+    if (xml !== original) {
+      fs.writeFileSync(target, xml, "utf8");
+    }
+  }
+  return removed;
+}
+
 function stripAndroidForCloud({ env = process.env } = {}) {
   const androidPackage = APP.appId;
   const stripPolicy = resolveAndroidCloudStripPolicy(env);
@@ -6909,6 +6976,7 @@ function stripAndroidForCloud({ env = process.env } = {}) {
       removedResourceCount += 1;
     }
   }
+  removedResourceCount += stripAndroidCloudResourceValues(resRoot);
   if (removedResourceCount > 0) {
     console.log(
       `[mobile-build] Removed ${removedResourceCount} Play-Store-noncompliant Android resource(s).`,

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -6930,6 +6930,9 @@ function stripAndroidForCloud({ env = process.env } = {}) {
         "",
       )
       .replace(/android:allowBackup="[^"]*"/, 'android:allowBackup="false"');
+    xml = xml
+      .replace(/(<\/provider>)\n[ \t]*(<activity\b)/g, "$1\n\n        $2")
+      .replace(/\n[ \t]*<\/(application)>/g, "\n    </$1>");
 
     if (xml !== original) {
       fs.writeFileSync(manifestPath, xml, "utf8");

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -6105,6 +6105,7 @@ ${cloudBrandUserAgentMarkerLines()}
 
         DeepLinkBufferPlugin.captureIntent(this, getIntent());
         registerPlugin(DeepLinkBufferPlugin.class);
+        registerPlugin(ElizaSecureCredentialsPlugin.class);
 
         super.onCreate(savedInstanceState);
 
@@ -6159,6 +6160,136 @@ ${cloudBrandUserAgentMarkerLines()}
             Log.w(TAG, "SystemProperties.get failed for " + key, e);
             return "";
         }
+    }
+}
+`;
+}
+
+/** Android Keystore-backed bearer storage for the minimal Play Cloud shell. */
+export function cloudSafeSecureCredentialsPluginJava(androidPackage) {
+  return `package ${androidPackage};
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+import android.util.Base64;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+import java.nio.charset.StandardCharsets;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+
+import org.json.JSONObject;
+
+@CapacitorPlugin(name = "ElizaSecureCredentials")
+public final class ElizaSecureCredentialsPlugin extends Plugin {
+    private static final String ANDROID_KEYSTORE = "AndroidKeyStore";
+    private static final String KEY_ALIAS = "ai.elizaos.app.android_cloud_token_key_v1";
+    private static final String PREFERENCES = "eliza_secure_credentials_v1";
+    private static final String CIPHERTEXT = "steward_token_ciphertext";
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final int GCM_TAG_BITS = 128;
+    private static final int MAX_TOKEN_BYTES = 16 * 1024;
+
+    @PluginMethod
+    public synchronized void get(PluginCall call) {
+        String encoded = preferences().getString(CIPHERTEXT, null);
+        if (encoded == null) {
+            JSObject result = new JSObject();
+            result.put("value", JSONObject.NULL);
+            call.resolve(result);
+            return;
+        }
+        try {
+            String[] parts = encoded.split(":", -1);
+            if (parts.length != 2) throw new GeneralSecurityException("invalid ciphertext envelope");
+            byte[] iv = Base64.decode(parts[0], Base64.NO_WRAP);
+            byte[] ciphertext = Base64.decode(parts[1], Base64.NO_WRAP);
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.DECRYPT_MODE, loadOrCreateKey(), new GCMParameterSpec(GCM_TAG_BITS, iv));
+            String value = new String(cipher.doFinal(ciphertext), StandardCharsets.UTF_8);
+            JSObject result = new JSObject();
+            result.put("value", value);
+            call.resolve(result);
+        } catch (GeneralSecurityException | IllegalArgumentException error) {
+            preferences().edit().remove(CIPHERTEXT).apply();
+            call.reject("Secure credential storage is unavailable.", "SECURE_CREDENTIAL_UNAVAILABLE", error);
+        }
+    }
+
+    @PluginMethod
+    public synchronized void set(PluginCall call) {
+        String value = call.getString("value");
+        if (value == null || value.trim().isEmpty()) {
+            call.reject("A non-empty credential is required.", "SECURE_CREDENTIAL_INVALID");
+            return;
+        }
+        byte[] plaintext = value.getBytes(StandardCharsets.UTF_8);
+        if (plaintext.length > MAX_TOKEN_BYTES) {
+            call.reject("The credential is too large.", "SECURE_CREDENTIAL_INVALID");
+            return;
+        }
+        try {
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(Cipher.ENCRYPT_MODE, loadOrCreateKey());
+            String encoded = Base64.encodeToString(cipher.getIV(), Base64.NO_WRAP)
+                    + ":"
+                    + Base64.encodeToString(cipher.doFinal(plaintext), Base64.NO_WRAP);
+            if (!preferences().edit().putString(CIPHERTEXT, encoded).commit()) {
+                call.reject("Secure credential storage could not be committed.", "SECURE_CREDENTIAL_UNAVAILABLE");
+                return;
+            }
+            call.resolve();
+        } catch (GeneralSecurityException error) {
+            call.reject("Secure credential storage is unavailable.", "SECURE_CREDENTIAL_UNAVAILABLE", error);
+        }
+    }
+
+    @PluginMethod
+    public synchronized void remove(PluginCall call) {
+        if (!preferences().edit().remove(CIPHERTEXT).commit()) {
+            call.reject("Secure credential storage could not be cleared.", "SECURE_CREDENTIAL_UNAVAILABLE");
+            return;
+        }
+        call.resolve();
+    }
+
+    private SharedPreferences preferences() {
+        return getContext().getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
+    }
+
+    private SecretKey loadOrCreateKey() throws GeneralSecurityException {
+        KeyStore keyStore = KeyStore.getInstance(ANDROID_KEYSTORE);
+        try {
+            keyStore.load(null);
+        } catch (IOException error) {
+            throw new GeneralSecurityException("Android Keystore could not be loaded", error);
+        }
+        java.security.Key existing = keyStore.getKey(KEY_ALIAS, null);
+        if (existing instanceof SecretKey) return (SecretKey) existing;
+
+        KeyGenerator generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE);
+        generator.init(new KeyGenParameterSpec.Builder(
+                KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setKeySize(256)
+                .setRandomizedEncryptionRequired(true)
+                .build());
+        return generator.generateKey();
     }
 }
 `;
@@ -6364,6 +6495,12 @@ function rewriteCloudJavaSources(javaRoots, androidPackage) {
       );
       touched += 1;
     }
+    fs.writeFileSync(
+      path.join(root, "ElizaSecureCredentialsPlugin.java"),
+      cloudSafeSecureCredentialsPluginJava(androidPackage),
+      "utf8",
+    );
+    touched += 1;
     const tasksWorker = path.join(root, "ElizaTasksWorker.java");
     if (fs.existsSync(tasksWorker)) {
       fs.writeFileSync(

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -5849,6 +5849,9 @@ export const ANDROID_PLAY_FORBIDDEN_ASSET_MARKERS = Object.freeze([
   "32438",
   "10.0.2.2",
   "adb reverse",
+  "eliza-local-agent:",
+  "__ELIZA_ANDROID_IPC_FETCH_BRIDGE__",
+  "remote-mac",
 ]);
 
 export const ANDROID_PLAY_FORBIDDEN_INDEX_HTML_MARKERS = Object.freeze([

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -5452,6 +5452,7 @@ export const ANDROID_LP3_COLOR_POLICY_ACTIONS = [
 ];
 
 export const ANDROID_CLOUD_STRIPPED_COMPONENTS = [
+  "GatewayConnectionService",
   "ElizaAgentService",
   "ElizaDialActivity",
   "ElizaAssistActivity",
@@ -5465,6 +5466,8 @@ export const ANDROID_CLOUD_STRIPPED_COMPONENTS = [
   "ElizaInCallService",
   "ElizaNotificationListenerService",
   "ElizaVoiceCaptureService",
+  "ElizaVoiceTileService",
+  "ElizaQuickActionsWidgetProvider",
   "ElizaSmsReceiver",
   "ElizaMmsReceiver",
   "ElizaSmsGatewayService",
@@ -5482,13 +5485,25 @@ export const ANDROID_CLOUD_STRIPPED_COMPONENTS = [
 // Permissions removed from the manifest. Anything that triggers a Play
 // Store policy review (sensitive runtime perms, system-only signature
 // perms, default-role / call / SMS perms, background location) gets
-// dropped. The remainder — INTERNET, POST_NOTIFICATIONS, FOREGROUND_SERVICE
-// + FOREGROUND_SERVICE_DATA_SYNC for the Gateway sync service, WAKE_LOCK,
-// scoped storage SDK fallbacks, RECORD_AUDIO/CAMERA/LOCATION needed for
-// Capacitor plugins the cloud renderer still uses — stays in place. Screen
-// capture is AOSP/direct-only, so MediaProjection FGS and the native
-// screencapture plugin are stripped here.
+// dropped. The Play client retains only ordinary HTTPS networking and
+// user-triggered microphone voice; it has no background service, notification,
+// camera, location, Bluetooth, health, telephony, or shared-storage contract.
 export const ANDROID_CLOUD_STRIPPED_PERMISSIONS = [
+  "CAMERA",
+  "ACCESS_FINE_LOCATION",
+  "ACCESS_COARSE_LOCATION",
+  "BLUETOOTH_SCAN",
+  "BLUETOOTH_CONNECT",
+  "BLUETOOTH",
+  "BLUETOOTH_ADMIN",
+  "FOREGROUND_SERVICE",
+  "FOREGROUND_SERVICE_DATA_SYNC",
+  "POST_NOTIFICATIONS",
+  "WRITE_EXTERNAL_STORAGE",
+  "READ_EXTERNAL_STORAGE",
+  "WAKE_LOCK",
+  "SCHEDULE_EXACT_ALARM",
+  "VIBRATE",
   "READ_CONTACTS",
   "WRITE_CONTACTS",
   "CALL_PHONE",
@@ -5532,6 +5547,21 @@ export const ANDROID_CLOUD_MANIFEST_MERGER_REMOVED_PERMISSIONS = [
 // Java sources removed from the merged sources tree so they don't
 // reference manifest-stripped classes and break compilation.
 export const ANDROID_CLOUD_STRIPPED_JAVA_FILES = [
+  "BatteryOptimizationPlugin.java",
+  "BionicDecodeLoop.java",
+  "DeviceRamTierPolicy.java",
+  "ElizaQuickActionsWidgetProvider.java",
+  "ElizaTasksWorker.java",
+  "ElizaVoiceNative.java",
+  "ElizaVoicePlugin.java",
+  "ElizaVoiceTileService.java",
+  "GatewayConnectionService.java",
+  "GlassBridgePlugin.java",
+  "InferenceMemoryPolicy.java",
+  "NativeTranscriptPlugin.java",
+  "NativeTranscriptReducer.java",
+  "ResourceProbePlugin.java",
+  "SafePushNotificationsPlugin.java",
   "AndroidVirtualizationBridge.java",
   "ElizaAgentService.java",
   "ElizaAgentWatchdogPolicy.java",
@@ -5628,7 +5658,9 @@ export function resolveAndroidCloudStripPolicy(env = process.env) {
   }
 
   const allowedComponents = new Set(ANDROID_LP3_COLOR_POLICY_COMPONENTS);
-  const allowedPermissions = new Set(ANDROID_LP3_COLOR_POLICY_PERMISSIONS);
+  const allowedPermissions = new Set(
+    ANDROID_LP3_COLOR_POLICY_REQUIRED_PERMISSIONS,
+  );
   const allowedJavaFiles = new Set(ANDROID_LP3_COLOR_POLICY_JAVA_FILES);
   return {
     components: ANDROID_CLOUD_STRIPPED_COMPONENTS.filter(
@@ -5654,7 +5686,6 @@ export function resolveAndroidCloudStripPolicy(env = process.env) {
 export const ANDROID_CLOUD_REWRITTEN_JAVA_FILES = [
   "MainActivity.java",
   "AgentPlugin.java",
-  "ElizaTasksWorker.java",
   "ElizaNativeBridge.java",
 ];
 
@@ -5663,15 +5694,38 @@ export const ANDROID_CLOUD_STRIPPED_ASSET_FILES = new Set([
 ]);
 
 export const ANDROID_CLOUD_STRIPPED_RESOURCE_FILES = [
+  path.join("drawable", "eliza_voice_bar_bg.xml"),
+  path.join("drawable", "eliza_voice_bar_dot.xml"),
+  path.join("drawable", "eliza_widget_background.xml"),
+  path.join("drawable", "eliza_widget_button_background.xml"),
+  path.join("layout", "eliza_quick_actions_widget.xml"),
+  path.join("layout", "eliza_voice_ime.xml"),
+  path.join("layout", "eliza_voice_interaction_bar.xml"),
   path.join("xml", "eliza_accessibility_service.xml"),
+  path.join("xml", "eliza_quick_actions_widget.xml"),
+  path.join("xml", "eliza_recognition_service.xml"),
+  path.join("xml", "eliza_voice_interaction_service.xml"),
+  path.join("xml", "method.xml"),
 ];
 
 export const ANDROID_CLOUD_STRIPPED_NATIVE_PLUGINS = [
+  ["@capacitor-community/bluetooth-le", "capacitor-community-bluetooth-le"],
+  ["@capacitor/background-runner", "capacitor-background-runner"],
+  ["@capacitor/barcode-scanner", "capacitor-barcode-scanner"],
+  ["@capacitor/haptics", "capacitor-haptics"],
+  ["@capacitor/local-notifications", "capacitor-local-notifications"],
+  ["@capacitor/push-notifications", "capacitor-push-notifications"],
   ["@elizaos/capacitor-agent", "elizaos-capacitor-agent"],
   ["@elizaos/capacitor-bun-runtime", "elizaos-capacitor-bun-runtime"],
   ["@elizaos/capacitor-appblocker", "elizaos-capacitor-appblocker"],
+  ["@elizaos/capacitor-browser-surface", "elizaos-capacitor-browser-surface"],
+  ["@elizaos/capacitor-camera", "elizaos-capacitor-camera"],
+  ["@elizaos/capacitor-canvas", "elizaos-capacitor-canvas"],
   ["@elizaos/capacitor-contacts", "elizaos-capacitor-contacts"],
+  ["@elizaos/capacitor-gateway", "elizaos-capacitor-gateway"],
+  ["@elizaos/capacitor-location", "elizaos-capacitor-location"],
   ["@elizaos/capacitor-messages", "elizaos-capacitor-messages"],
+  ["@elizaos/capacitor-mlkit-text", "elizaos-capacitor-mlkit-text"],
   [
     "@elizaos/capacitor-mobile-agent-bridge",
     "elizaos-capacitor-mobile-agent-bridge",
@@ -5679,11 +5733,25 @@ export const ANDROID_CLOUD_STRIPPED_NATIVE_PLUGINS = [
   ["@elizaos/capacitor-mobile-signals", "elizaos-capacitor-mobile-signals"],
   ["@elizaos/capacitor-phone", "elizaos-capacitor-phone"],
   ["@elizaos/capacitor-screencapture", "elizaos-capacitor-screencapture"],
+  ["@elizaos/capacitor-swabble", "elizaos-capacitor-swabble"],
   ["@elizaos/capacitor-system", "elizaos-capacitor-system"],
   ["@elizaos/capacitor-websiteblocker", "elizaos-capacitor-websiteblocker"],
   ["@elizaos/capacitor-wifi", "elizaos-capacitor-wifi"],
   ["llama-cpp-capacitor", "llama-cpp-capacitor"],
 ];
+
+export const ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES = Object.freeze([
+  "@capacitor/app",
+  "@capacitor/browser",
+  "@capacitor/device",
+  "@capacitor/filesystem",
+  "@capacitor/keyboard",
+  "@capacitor/network",
+  "@capacitor/preferences",
+  "@capacitor/share",
+  "@capacitor/status-bar",
+  "@elizaos/capacitor-talkmode",
+]);
 
 const ANDROID_SMS_GATEWAY_COMPONENTS = new Set([
   "ElizaSmsReceiver",
@@ -5848,15 +5916,7 @@ ${cloudBrandUserAgentMarkerLines()}
         DeepLinkBufferPlugin.captureIntent(this, getIntent());
         registerPlugin(DeepLinkBufferPlugin.class);
 
-        // Cloud builds keep the native glass tier: GlassBridgePlugin has no
-        // local-agent dependencies (android.* + Capacitor only).
-        registerPlugin(GlassBridgePlugin.class);
-
         super.onCreate(savedInstanceState);
-
-        if (getBridge() != null) {
-            getBridge().registerPlugin(SafePushNotificationsPlugin.class);
-        }
 
         if (getBridge() != null && getBridge().getWebView() != null) {
             WebSettings settings = getBridge().getWebView().getSettings();
@@ -5869,22 +5929,6 @@ ${cloudBrandUserAgentMarkerLines()}
     protected void onNewIntent(Intent intent) {
         DeepLinkBufferPlugin.captureIntent(this, intent);
         super.onNewIntent(intent);
-    }
-
-    @Override
-    public void onStop() {
-        super.onStop();
-        if (!isFinishing()) {
-            GatewayConnectionService.start(this);
-        }
-    }
-
-    @Override
-    public void onDestroy() {
-        if (isFinishing()) {
-            GatewayConnectionService.stop(this);
-        }
-        super.onDestroy();
     }
 
     private void applyBrandUserAgentMarkers(WebSettings settings) {
@@ -6339,6 +6383,19 @@ function auditAndroidCloudSource(phase, { env = process.env } = {}) {
         "AndroidManifest.xml still allows global cleartext traffic",
       );
     }
+    if (!/android:allowBackup="false"/.test(xml)) {
+      failures.push("AndroidManifest.xml does not disable application backup");
+    }
+    for (const forbidden of [
+      "android.intent.category.HOME",
+      "com.google.android.apps.healthdata",
+      "android.hardware.telephony",
+      "android.hardware.bluetooth_le",
+    ]) {
+      if (xml.includes(forbidden)) {
+        failures.push(`AndroidManifest.xml still contains ${forbidden}`);
+      }
+    }
     if (!xml.includes('android:name="android.app.shortcuts"')) {
       failures.push("AndroidManifest.xml does not register @xml/shortcuts");
     }
@@ -6466,6 +6523,42 @@ function auditAndroidCloudSource(phase, { env = process.env } = {}) {
       if (source.includes(pkg) || source.includes(gradleProject)) {
         failures.push(`${relPath} still references ${pkg}/${gradleProject}`);
       }
+    }
+  }
+
+  const capacitorPluginManifestPath = path.join(
+    androidDir,
+    "app",
+    "src",
+    "main",
+    "assets",
+    "capacitor.plugins.json",
+  );
+  if (!fs.existsSync(capacitorPluginManifestPath)) {
+    failures.push("app/src/main/assets/capacitor.plugins.json is missing");
+  } else {
+    try {
+      const plugins = JSON.parse(
+        fs.readFileSync(capacitorPluginManifestPath, "utf8"),
+      );
+      const actualPackages = Array.isArray(plugins)
+        ? plugins
+            .map((plugin) => plugin?.pkg)
+            .filter(Boolean)
+            .sort()
+        : [];
+      const allowedPackages = [
+        ...ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES,
+      ].sort();
+      if (JSON.stringify(actualPackages) !== JSON.stringify(allowedPackages)) {
+        failures.push(
+          `capacitor.plugins.json packages differ from the Play allowlist: ${JSON.stringify(actualPackages)}`,
+        );
+      }
+    } catch (error) {
+      failures.push(
+        `capacitor.plugins.json is invalid: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
 
@@ -6681,6 +6774,16 @@ function stripAndroidForCloud({ env = process.env } = {}) {
       stripPolicy.mergerRemovedPermissions,
     );
     xml = applyAndroidCleartextPolicy(xml, { allowCleartext: false });
+    xml = xml
+      .replace(
+        /\s*<package\s+android:name="com\.google\.android\.apps\.healthdata"\s*\/>/g,
+        "",
+      )
+      .replace(
+        /\s*<uses-feature\b(?=[^>]*android:name="android\.hardware\.(?:telephony|bluetooth_le)")[^>]*\/>/g,
+        "",
+      )
+      .replace(/android:allowBackup="[^"]*"/, 'android:allowBackup="false"');
 
     if (xml !== original) {
       fs.writeFileSync(manifestPath, xml, "utf8");

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -5779,6 +5779,7 @@ export const ANDROID_CLOUD_STRIPPED_NATIVE_PLUGINS = [
   ["@elizaos/capacitor-screencapture", "elizaos-capacitor-screencapture"],
   ["@elizaos/capacitor-swabble", "elizaos-capacitor-swabble"],
   ["@elizaos/capacitor-system", "elizaos-capacitor-system"],
+  ["@elizaos/capacitor-talkmode", "elizaos-capacitor-talkmode"],
   ["@elizaos/capacitor-websiteblocker", "elizaos-capacitor-websiteblocker"],
   ["@elizaos/capacitor-wifi", "elizaos-capacitor-wifi"],
   ["llama-cpp-capacitor", "llama-cpp-capacitor"],
@@ -5794,13 +5795,11 @@ export const ANDROID_PLAY_ALLOWED_NATIVE_PLUGIN_PACKAGES = Object.freeze([
   "@capacitor/preferences",
   "@capacitor/share",
   "@capacitor/status-bar",
-  "@elizaos/capacitor-talkmode",
 ]);
 
 export const ANDROID_PLAY_ALLOWED_PERMISSIONS = Object.freeze([
   "android.permission.ACCESS_NETWORK_STATE",
   "android.permission.INTERNET",
-  "android.permission.MODIFY_AUDIO_SETTINGS",
   "android.permission.RECORD_AUDIO",
   `${APP.appId}.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION`,
 ]);
@@ -6106,6 +6105,7 @@ ${cloudBrandUserAgentMarkerLines()}
         DeepLinkBufferPlugin.captureIntent(this, getIntent());
         registerPlugin(DeepLinkBufferPlugin.class);
         registerPlugin(ElizaSecureCredentialsPlugin.class);
+        registerPlugin(ElizaPlayVoicePlugin.class);
 
         super.onCreate(savedInstanceState);
 
@@ -6291,6 +6291,186 @@ public final class ElizaSecureCredentialsPlugin extends Plugin {
                 .build());
         return generator.generateKey();
     }
+}
+`;
+}
+
+/** Standard Android SpeechRecognizer + system TextToSpeech for Play builds. */
+export function cloudSafePlayVoicePluginJava(androidPackage) {
+  return `package ${androidPackage};
+
+import android.Manifest;
+import android.content.Intent;
+import android.os.Bundle;
+import android.speech.RecognitionListener;
+import android.speech.RecognizerIntent;
+import android.speech.SpeechRecognizer;
+import android.speech.tts.TextToSpeech;
+import android.speech.tts.UtteranceProgressListener;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.PermissionState;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import com.getcapacitor.annotation.Permission;
+import com.getcapacitor.annotation.PermissionCallback;
+
+import java.util.ArrayList;
+import java.util.Locale;
+import java.util.UUID;
+
+@CapacitorPlugin(
+    name = "ElizaPlayVoice",
+    permissions = @Permission(alias = "microphone", strings = { Manifest.permission.RECORD_AUDIO })
+)
+public final class ElizaPlayVoicePlugin extends Plugin implements RecognitionListener {
+    private SpeechRecognizer recognizer;
+
+    @PluginMethod
+    public void requestPermission(PluginCall call) {
+        if (getPermissionState("microphone") == PermissionState.GRANTED) {
+            resolvePermission(call, true);
+            return;
+        }
+        requestPermissionForAlias("microphone", call, "microphonePermissionCallback");
+    }
+
+    @PermissionCallback
+    private void microphonePermissionCallback(PluginCall call) {
+        resolvePermission(call, getPermissionState("microphone") == PermissionState.GRANTED);
+    }
+
+    @PluginMethod
+    public void startDictation(PluginCall call) {
+        if (getPermissionState("microphone") != PermissionState.GRANTED) {
+            call.reject("Microphone permission is required.", "MICROPHONE_PERMISSION_REQUIRED");
+            return;
+        }
+        if (!SpeechRecognizer.isRecognitionAvailable(getContext())) {
+            call.reject("Speech recognition is unavailable.", "SPEECH_RECOGNITION_UNAVAILABLE");
+            return;
+        }
+        stopRecognizer();
+        recognizer = SpeechRecognizer.createSpeechRecognizer(getContext());
+        recognizer.setRecognitionListener(this);
+        Intent intent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
+        intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
+        intent.putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true);
+        intent.putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 3);
+        intent.putExtra(RecognizerIntent.EXTRA_CALLING_PACKAGE, getContext().getPackageName());
+        String language = call.getString("language");
+        if (language != null && !language.trim().isEmpty()) {
+            intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, language.trim());
+        }
+        try {
+            recognizer.startListening(intent);
+            JSObject result = new JSObject();
+            result.put("started", true);
+            call.resolve(result);
+        } catch (RuntimeException error) {
+            stopRecognizer();
+            call.reject("Voice dictation could not start.", "SPEECH_RECOGNITION_START_FAILED", error);
+        }
+    }
+
+    @PluginMethod
+    public void stopDictation(PluginCall call) {
+        stopRecognizer();
+        call.resolve();
+    }
+
+    @PluginMethod
+    public void speak(PluginCall call) {
+        String text = call.getString("text");
+        if (text == null || text.trim().isEmpty()) {
+            call.reject("Speech text is required.", "TTS_TEXT_REQUIRED");
+            return;
+        }
+        String language = call.getString("language", Locale.getDefault().toLanguageTag());
+        final TextToSpeech[] holder = new TextToSpeech[1];
+        holder[0] = new TextToSpeech(getContext(), status -> {
+            TextToSpeech tts = holder[0];
+            if (status != TextToSpeech.SUCCESS || tts == null) {
+                if (tts != null) tts.shutdown();
+                call.reject("System text to speech is unavailable.", "TTS_UNAVAILABLE");
+                return;
+            }
+            Locale locale = Locale.forLanguageTag(language == null ? "" : language);
+            if (tts.setLanguage(locale) < TextToSpeech.LANG_AVAILABLE) {
+                tts.shutdown();
+                call.reject("The selected speech language is unavailable.", "TTS_LANGUAGE_UNAVAILABLE");
+                return;
+            }
+            String utteranceId = UUID.randomUUID().toString();
+            tts.setOnUtteranceProgressListener(new UtteranceProgressListener() {
+                @Override public void onStart(String id) {}
+                @Override public void onDone(String id) { tts.shutdown(); }
+                @Override public void onError(String id) { tts.shutdown(); }
+            });
+            int accepted = tts.speak(text, TextToSpeech.QUEUE_FLUSH, null, utteranceId);
+            if (accepted != TextToSpeech.SUCCESS) {
+                tts.shutdown();
+                call.reject("System text to speech could not start.", "TTS_START_FAILED");
+                return;
+            }
+            call.resolve();
+        });
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        stopRecognizer();
+        super.handleOnDestroy();
+    }
+
+    private void resolvePermission(PluginCall call, boolean granted) {
+        JSObject result = new JSObject();
+        result.put("granted", granted);
+        call.resolve(result);
+    }
+
+    private void stopRecognizer() {
+        if (recognizer == null) return;
+        try { recognizer.stopListening(); } catch (RuntimeException ignored) {}
+        recognizer.cancel();
+        recognizer.destroy();
+        recognizer = null;
+    }
+
+    private void publishTranscript(Bundle results, boolean isFinal) {
+        ArrayList<String> values = results == null
+                ? null
+                : results.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION);
+        if (values == null || values.isEmpty()) return;
+        String text = values.get(0) == null ? "" : values.get(0).trim();
+        if (text.isEmpty()) return;
+        JSObject event = new JSObject();
+        event.put("text", text);
+        event.put("isFinal", isFinal);
+        notifyListeners("transcript", event);
+    }
+
+    @Override public void onReadyForSpeech(Bundle params) {}
+    @Override public void onBeginningOfSpeech() {}
+    @Override public void onRmsChanged(float rmsdB) {}
+    @Override public void onBufferReceived(byte[] buffer) {}
+    @Override public void onEndOfSpeech() {}
+    @Override public void onError(int error) {
+        JSObject event = new JSObject();
+        event.put("code", error);
+        notifyListeners("error", event);
+        stopRecognizer();
+    }
+    @Override public void onResults(Bundle results) {
+        publishTranscript(results, true);
+        stopRecognizer();
+    }
+    @Override public void onPartialResults(Bundle partialResults) {
+        publishTranscript(partialResults, false);
+    }
+    @Override public void onEvent(int eventType, Bundle params) {}
 }
 `;
 }
@@ -6498,6 +6678,12 @@ function rewriteCloudJavaSources(javaRoots, androidPackage) {
     fs.writeFileSync(
       path.join(root, "ElizaSecureCredentialsPlugin.java"),
       cloudSafeSecureCredentialsPluginJava(androidPackage),
+      "utf8",
+    );
+    touched += 1;
+    fs.writeFileSync(
+      path.join(root, "ElizaPlayVoicePlugin.java"),
+      cloudSafePlayVoicePluginJava(androidPackage),
       "utf8",
     );
     touched += 1;

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -5600,6 +5600,20 @@ export const ANDROID_CLOUD_STRIPPED_JAVA_FILES = [
   ...ANDROID_LP3_COLOR_POLICY_JAVA_FILES,
 ];
 
+// Host-side JVM tests for source-stripped on-device runtime code must not be
+// compiled in the generated Play tree. Keep them in the canonical Android
+// source tree so direct/local targets retain their coverage, but remove them
+// alongside the production classes they exercise for cloud builds.
+export const ANDROID_CLOUD_STRIPPED_TEST_JAVA_FILES = [
+  "BionicDecodeLoopTest.java",
+  "DeviceRamTierPolicyTest.java",
+  "ElizaAgentAutostartPolicyTest.java",
+  "ElizaAssetExtractionPolicyTest.java",
+  "ElizaWorkSchedulerPolicyTest.java",
+  "InferenceMemoryPolicyTest.java",
+  "NativeTranscriptReducerTest.java",
+];
+
 export function isAndroidLp3ColorPolicyEnabled(env = process.env) {
   return ["1", "true", "yes"].includes(
     String(env.ELIZA_ANDROID_LP3_COLOR_POLICY_ENABLED ?? "")
@@ -5655,6 +5669,7 @@ export function resolveAndroidCloudStripPolicy(env = process.env) {
       mergerRemovedPermissions:
         ANDROID_CLOUD_MANIFEST_MERGER_REMOVED_PERMISSIONS,
       javaFiles: ANDROID_CLOUD_STRIPPED_JAVA_FILES,
+      testJavaFiles: ANDROID_CLOUD_STRIPPED_TEST_JAVA_FILES,
     };
   }
 
@@ -5677,6 +5692,7 @@ export function resolveAndroidCloudStripPolicy(env = process.env) {
     javaFiles: ANDROID_CLOUD_STRIPPED_JAVA_FILES.filter(
       (file) => !allowedJavaFiles.has(file),
     ),
+    testJavaFiles: ANDROID_CLOUD_STRIPPED_TEST_JAVA_FILES,
   };
 }
 
@@ -6966,6 +6982,34 @@ function stripAndroidForCloud({ env = process.env } = {}) {
     );
   }
   rewriteCloudJavaSources(javaRoots, androidPackage);
+
+  const testJavaRoots = [
+    path.join(
+      androidDir,
+      "app",
+      "src",
+      "test",
+      "java",
+      packageNameToPath(androidPackage),
+    ),
+    path.join(androidDir, "app", "src", "test", "java", "ai", "elizaos", "app"),
+  ];
+  let removedTestJavaCount = 0;
+  for (const root of testJavaRoots) {
+    if (!fs.existsSync(root)) continue;
+    for (const file of stripPolicy.testJavaFiles) {
+      const target = path.join(root, file);
+      if (fs.existsSync(target)) {
+        fs.rmSync(target);
+        removedTestJavaCount += 1;
+      }
+    }
+  }
+  if (removedTestJavaCount > 0) {
+    console.log(
+      `[mobile-build] Removed ${removedTestJavaCount} JVM test source(s) for source-stripped Android runtime code.`,
+    );
+  }
 
   const resRoot = path.join(androidDir, "app", "src", "main", "res");
   let removedResourceCount = 0;

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -31,6 +31,7 @@
       self.GPUMapMode = Object.freeze({ READ: 1, WRITE: 2 });
     }
   </script>
+  <!-- ELIZA_NATIVE_AGENT_IPC_BRIDGE_START -->
   <script>
     (() => {
       if (typeof window === 'undefined' || typeof window.fetch !== 'function') return;
@@ -222,6 +223,7 @@
       window.__ELIZA_ANDROID_IPC_FETCH_BRIDGE__ = true;
     })();
   </script>
+  <!-- ELIZA_NATIVE_AGENT_IPC_BRIDGE_END -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="__APP_VIEWPORT_CONTENT__" />
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/packages/app/src/main.android-cloud.behavior.test.tsx
+++ b/packages/app/src/main.android-cloud.behavior.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * Executes the Play renderer's native storage and deep-link boundaries with
+ * deterministic Capacitor adapters; no source-text assertions stand in for
+ * credential migration, persistence, or event delivery.
+ */
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { ANDROID_CLOUD_CONVERSATION_ID_KEY } from "@elizaos/ui/android-cloud/AndroidCloudApp";
+import type { ReactNode } from "react";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const playEntry = vi.hoisted(() => ({
+  appListeners: new Map<string, (value: unknown) => void>(),
+  createRoot: vi.fn(() => ({ render: vi.fn() })),
+  preferenceGet: vi.fn(async (_options: { key: string }) => ({
+    value: null as string | null,
+  })),
+  preferenceRemove: vi.fn(async (_options: { key: string }) => undefined),
+  preferenceSet: vi.fn(
+    async (_options: { key: string; value: string }) => undefined,
+  ),
+  secureClear: vi.fn(async () => undefined),
+  secureGet: vi.fn(async () => ({ value: null as string | null })),
+  secureSet: vi.fn(async (_options: { value: string }) => undefined),
+}));
+
+vi.mock("react-dom/client", () => ({ createRoot: playEntry.createRoot }));
+vi.mock("@elizaos/ui/android-cloud/AndroidCloudApp", () => ({
+  ANDROID_CLOUD_CONVERSATION_ID_KEY: "eliza:android-cloud-conversation-id",
+  AndroidCloudApp: () => null,
+}));
+vi.mock("@elizaos/ui/components/ui/error-boundary", () => ({
+  ErrorBoundary: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock("@elizaos/ui/styles", () => ({}));
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => true },
+  registerPlugin: (name: string) =>
+    name === "ElizaSecureCredentials"
+      ? {
+          get: playEntry.secureGet,
+          set: playEntry.secureSet,
+          remove: playEntry.secureClear,
+        }
+      : {
+          addListener: vi.fn(async () => ({ remove: vi.fn() })),
+          requestPermission: vi.fn(async () => ({ granted: true })),
+          speak: vi.fn(async () => undefined),
+          startDictation: vi.fn(async () => ({ started: true })),
+          stopDictation: vi.fn(async () => undefined),
+        },
+}));
+vi.mock("@capacitor/preferences", () => ({
+  Preferences: {
+    get: playEntry.preferenceGet,
+    remove: playEntry.preferenceRemove,
+    set: playEntry.preferenceSet,
+  },
+}));
+vi.mock("@capacitor/app", () => ({
+  App: {
+    addListener: vi.fn(
+      async (name: string, listener: (value: unknown) => void) => {
+        playEntry.appListeners.set(name, listener);
+        return { remove: vi.fn() };
+      },
+    ),
+    getLaunchUrl: vi.fn(async () => undefined),
+    minimizeApp: vi.fn(async () => undefined),
+  },
+}));
+vi.mock("@capacitor/browser", () => ({
+  Browser: {
+    close: vi.fn(async () => undefined),
+    open: vi.fn(async () => undefined),
+  },
+}));
+vi.mock("@capacitor/keyboard", () => ({
+  Keyboard: { addListener: vi.fn(async () => ({ remove: vi.fn() })) },
+}));
+vi.mock("@capacitor/network", () => ({
+  Network: {
+    addListener: vi.fn(async () => ({ remove: vi.fn() })),
+    getStatus: vi.fn(async () => ({ connected: true })),
+  },
+}));
+vi.mock("@capacitor/status-bar", () => ({
+  Style: { Dark: "dark" },
+  StatusBar: {
+    setBackgroundColor: vi.fn(async () => undefined),
+    setOverlaysWebView: vi.fn(async () => undefined),
+    setStyle: vi.fn(async () => undefined),
+  },
+}));
+
+let entry: typeof import("./main.android-cloud");
+
+beforeAll(async () => {
+  document.body.innerHTML = '<div id="root"></div>';
+  entry = await import("./main.android-cloud");
+  if (document.readyState === "loading") {
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+  }
+  await vi.waitFor(() => expect(playEntry.createRoot).toHaveBeenCalledOnce());
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  playEntry.appListeners.clear();
+  window.localStorage.clear();
+  playEntry.preferenceGet.mockResolvedValue({ value: null });
+  playEntry.secureGet.mockResolvedValue({ value: null });
+  playEntry.secureSet.mockResolvedValue(undefined);
+});
+
+describe("Android Cloud renderer behavior", () => {
+  it("migrates a legacy bearer into the secure plugin before deleting plaintext", async () => {
+    const order: string[] = [];
+    playEntry.preferenceGet.mockImplementation(async ({ key }) => ({
+      value: key === STEWARD_TOKEN_KEY ? " legacy-token " : null,
+    }));
+    playEntry.secureSet.mockImplementation(async ({ value }) => {
+      expect(value).toBe("legacy-token");
+      order.push("secure-write");
+    });
+    playEntry.preferenceRemove.mockImplementation(async ({ key }) => {
+      if (key === STEWARD_TOKEN_KEY) order.push("plaintext-remove");
+    });
+
+    await entry.hydrateAndroidCloudStorage();
+
+    expect(order).toEqual(["secure-write", "plaintext-remove"]);
+    expect(window.localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+  });
+
+  it("fails closed without deleting a bearer when secure migration fails", async () => {
+    playEntry.preferenceGet.mockImplementation(async ({ key }) => ({
+      value: key === STEWARD_TOKEN_KEY ? "legacy-token" : null,
+    }));
+    playEntry.secureSet.mockRejectedValueOnce(
+      new Error("keystore unavailable"),
+    );
+
+    await expect(entry.hydrateAndroidCloudStorage()).rejects.toThrow(
+      "keystore unavailable",
+    );
+    expect(playEntry.preferenceRemove).not.toHaveBeenCalledWith({
+      key: STEWARD_TOKEN_KEY,
+    });
+  });
+
+  it("persists only the Cloud shell allowlist and never mirrors its bearer", async () => {
+    window.localStorage.setItem("eliza:first-run-complete", "true");
+    window.localStorage.setItem(
+      ANDROID_CLOUD_CONVERSATION_ID_KEY,
+      "conversation-1",
+    );
+    window.localStorage.setItem(STEWARD_TOKEN_KEY, "must-not-persist");
+
+    await entry.persistAndroidCloudStorage();
+
+    expect(playEntry.preferenceSet).toHaveBeenCalledTimes(2);
+    expect(playEntry.preferenceSet).toHaveBeenCalledWith({
+      key: "eliza:first-run-complete",
+      value: "true",
+    });
+    expect(playEntry.preferenceSet).toHaveBeenCalledWith({
+      key: ANDROID_CLOUD_CONVERSATION_ID_KEY,
+      value: "conversation-1",
+    });
+    expect(playEntry.preferenceSet).not.toHaveBeenCalledWith(
+      expect.objectContaining({ key: STEWARD_TOKEN_KEY }),
+    );
+  });
+
+  it("accepts only app-owned deep links and dispatches a share payload", () => {
+    const compose = vi.fn();
+    const share = vi.fn();
+    window.addEventListener("eliza:android-cloud-compose", compose);
+    document.addEventListener("eliza:share-target", share);
+
+    expect(
+      entry.dispatchAndroidCloudDeepLink("https://example.com/share"),
+    ).toBe(false);
+    expect(
+      entry.dispatchAndroidCloudDeepLink(
+        "elizaos://share?title=Hello&text=world&file=%2Ftmp%2Fproof.jpg",
+      ),
+    ).toBe(true);
+    expect(share).toHaveBeenCalledOnce();
+    expect(compose).toHaveBeenCalledOnce();
+    expect(
+      (window as Window & { __ELIZA_APP_SHARE_QUEUE__?: unknown[] })
+        .__ELIZA_APP_SHARE_QUEUE__,
+    ).toEqual([
+      expect.objectContaining({
+        files: [{ name: "proof.jpg", path: "/tmp/proof.jpg" }],
+        source: "deep-link",
+        text: "world",
+        title: "Hello",
+      }),
+    ]);
+
+    window.removeEventListener("eliza:android-cloud-compose", compose);
+    document.removeEventListener("eliza:share-target", share);
+  });
+});

--- a/packages/app/src/main.android-cloud.test.ts
+++ b/packages/app/src/main.android-cloud.test.ts
@@ -1,0 +1,36 @@
+/** Dedicated Android Cloud renderer entry and policy boundary tests. */
+import { describe, expect, it } from "vitest";
+import source from "./main.android-cloud.tsx?raw";
+
+const imports = source
+  .split("\n")
+  .filter((line) => /^(?:import|}\s+from)\b/.test(line.trim()))
+  .join("\n");
+
+describe("Android Cloud renderer entry", () => {
+  it("mounts only the dedicated Play shell", () => {
+    expect(source).toContain(
+      'from "@elizaos/ui/android-cloud/AndroidCloudApp"',
+    );
+    expect(source).not.toMatch(/from ["']\.\/main["']/);
+    expect(source).not.toMatch(/@elizaos\/ui\/App(?:["'/])/);
+    expect(source).not.toMatch(/@elizaos\/ui\/state\/AppContext/);
+    expect(source).not.toMatch(/service-worker|sw-registration/);
+  });
+
+  it("does not import cross-platform runtime composition", () => {
+    expect(imports).not.toMatch(/local-agent|ios-|desktop|background-runner/i);
+    expect(imports).not.toContain('from "@elizaos/ui"');
+    expect(imports).not.toContain('from "@elizaos/ui/platform"');
+    expect(imports).not.toContain('from "@elizaos/ui/bridge"');
+    expect(imports).not.toContain('from "@elizaos/ui/events"');
+  });
+
+  it("keeps persistence and URL routing Cloud-scoped", () => {
+    expect(source).toContain("CLOUD_PERSISTED_KEYS");
+    expect(source).toContain("ANDROID_CLOUD_CONVERSATION_ID_KEY");
+    expect(source).toContain("closeExternal={() => Browser.close()}");
+    expect(source).toContain('parsed.protocol !== "elizaos:"');
+    expect(source).not.toMatch(/active-server|apiBase|127\.0\.0\.1|localhost/);
+  });
+});

--- a/packages/app/src/main.android-cloud.test.ts
+++ b/packages/app/src/main.android-cloud.test.ts
@@ -40,6 +40,8 @@ describe("Android Cloud renderer entry", () => {
       source.indexOf("interface SecureCredentialsPlugin"),
     );
     expect(source).toContain('"ElizaSecureCredentials"');
+    expect(source).toContain('"ElizaPlayVoice"');
+    expect(source).not.toContain("@elizaos/capacitor-talkmode");
     expect(source).toContain("credentialStore: androidSecureCredentialStore");
     expect(persistedKeys).not.toContain("STEWARD_TOKEN_KEY");
     expect(source).toContain("Preferences.remove({ key: STEWARD_TOKEN_KEY })");

--- a/packages/app/src/main.android-cloud.test.ts
+++ b/packages/app/src/main.android-cloud.test.ts
@@ -33,4 +33,16 @@ describe("Android Cloud renderer entry", () => {
     expect(source).toContain('parsed.protocol !== "elizaos:"');
     expect(source).not.toMatch(/active-server|apiBase|127\.0\.0\.1|localhost/);
   });
+
+  it("keeps the bearer in Android Keystore-backed storage", () => {
+    const persistedKeys = source.slice(
+      source.indexOf("const CLOUD_PERSISTED_KEYS"),
+      source.indexOf("interface SecureCredentialsPlugin"),
+    );
+    expect(source).toContain('"ElizaSecureCredentials"');
+    expect(source).toContain("credentialStore: androidSecureCredentialStore");
+    expect(persistedKeys).not.toContain("STEWARD_TOKEN_KEY");
+    expect(source).toContain("Preferences.remove({ key: STEWARD_TOKEN_KEY })");
+    expect(source).toContain("localStorage.removeItem(STEWARD_TOKEN_KEY)");
+  });
 });

--- a/packages/app/src/main.android-cloud.tsx
+++ b/packages/app/src/main.android-cloud.tsx
@@ -12,7 +12,6 @@ import { Capacitor, registerPlugin } from "@capacitor/core";
 import { Keyboard } from "@capacitor/keyboard";
 import { Preferences } from "@capacitor/preferences";
 import { StatusBar, Style } from "@capacitor/status-bar";
-import { TalkMode } from "@elizaos/capacitor-talkmode";
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import {
   ANDROID_CLOUD_CONVERSATION_ID_KEY,
@@ -272,38 +271,41 @@ async function initializeAndroidCloudPlatform(): Promise<void> {
 
 let activeTranscriptListener: { remove: () => Promise<void> } | null = null;
 
+interface PlayVoicePlugin {
+  requestPermission(): Promise<{ granted: boolean }>;
+  startDictation(options: {
+    language: string;
+  }): Promise<{ started: boolean; error?: string }>;
+  stopDictation(): Promise<void>;
+  speak(options: { text: string; language: string }): Promise<void>;
+  addListener(
+    eventName: "transcript",
+    listener: (event: { text: string; isFinal: boolean }) => void,
+  ): Promise<{ remove: () => Promise<void> }>;
+}
+
+const PlayVoice = registerPlugin<PlayVoicePlugin>("ElizaPlayVoice");
+
 const androidCloudVoice: AndroidCloudVoiceAdapter = {
   async requestAndStart(onFinalTranscript) {
     await activeTranscriptListener?.remove();
     activeTranscriptListener = null;
-    const permissions = await TalkMode.requestPermissions();
-    if (
-      permissions.microphone !== "granted" ||
-      permissions.speechRecognition === "denied" ||
-      permissions.speechRecognition === "not_supported"
-    ) {
-      throw new Error(
-        "Microphone and speech recognition permission are required for dictation.",
-      );
+    const permissions = await PlayVoice.requestPermission();
+    if (!permissions.granted) {
+      throw new Error("Microphone permission is required for voice dictation.");
     }
-    const transcriptListener = await TalkMode.addListener(
+    const transcriptListener = await PlayVoice.addListener(
       "transcript",
       (event) => {
         if (!event.isFinal) return;
-        const transcript = event.transcript.trim();
+        const transcript = event.text.trim();
         if (transcript) onFinalTranscript(transcript);
         void androidCloudVoice.stop();
       },
     );
     activeTranscriptListener = transcriptListener;
-    const result = await TalkMode.start({
-      config: {
-        mode: "compose",
-        stt: {
-          engine: "native",
-          language: navigator.language || "en-US",
-        },
-      },
+    const result = await PlayVoice.startDictation({
+      language: navigator.language || "en-US",
     });
     if (!result.started) {
       await transcriptListener.remove();
@@ -317,14 +319,13 @@ const androidCloudVoice: AndroidCloudVoiceAdapter = {
     const listener = activeTranscriptListener;
     activeTranscriptListener = null;
     try {
-      await TalkMode.stop();
+      await PlayVoice.stopDictation();
     } finally {
       await listener?.remove();
     }
   },
   async speak(text) {
-    const result = await TalkMode.speak({ text, useSystemTts: true });
-    if (result.error) throw new Error(result.error);
+    await PlayVoice.speak({ text, language: navigator.language || "en-US" });
   },
 };
 

--- a/packages/app/src/main.android-cloud.tsx
+++ b/packages/app/src/main.android-cloud.tsx
@@ -8,7 +8,7 @@
  */
 import { App as CapacitorApp } from "@capacitor/app";
 import { Browser } from "@capacitor/browser";
-import { Capacitor } from "@capacitor/core";
+import { Capacitor, registerPlugin } from "@capacitor/core";
 import { Keyboard } from "@capacitor/keyboard";
 import { Preferences } from "@capacitor/preferences";
 import { StatusBar, Style } from "@capacitor/status-bar";
@@ -19,6 +19,10 @@ import {
   AndroidCloudApp,
   type AndroidCloudVoiceAdapter,
 } from "@elizaos/ui/android-cloud/AndroidCloudApp";
+import {
+  AndroidCloudClient,
+  type AndroidCloudCredentialStore,
+} from "@elizaos/ui/android-cloud/android-cloud-client";
 import { ErrorBoundary } from "@elizaos/ui/components/ui/error-boundary";
 import "@elizaos/ui/styles";
 import React from "react";
@@ -50,10 +54,35 @@ type AndroidCloudWindow = Window & {
 };
 
 const CLOUD_PERSISTED_KEYS = Object.freeze([
-  STEWARD_TOKEN_KEY,
   "eliza:first-run-complete",
   ANDROID_CLOUD_CONVERSATION_ID_KEY,
 ]);
+
+interface SecureCredentialsPlugin {
+  get(): Promise<{ value: string | null }>;
+  set(options: { value: string }): Promise<void>;
+  remove(): Promise<void>;
+}
+
+const SecureCredentials = registerPlugin<SecureCredentialsPlugin>(
+  "ElizaSecureCredentials",
+);
+
+const androidSecureCredentialStore: AndroidCloudCredentialStore = {
+  async read() {
+    return (await SecureCredentials.get()).value?.trim() || null;
+  },
+  async write(token) {
+    await SecureCredentials.set({ value: token });
+  },
+  async clear() {
+    await SecureCredentials.remove();
+  },
+};
+
+const androidCloudClient = new AndroidCloudClient({
+  credentialStore: androidSecureCredentialStore,
+});
 
 function logOptionalPluginFailure(plugin: string, error: unknown): void {
   console.warn(
@@ -74,9 +103,24 @@ export async function hydrateAndroidCloudStorage(): Promise<void> {
       if (value !== null) window.localStorage.setItem(key, value);
     } catch (error) {
       logOptionalPluginFailure("Preferences", error);
-      return;
     }
   }
+
+  // One-time migration from the previous sandboxed Preferences/localStorage
+  // token mirror. The credential is written to Android Keystore-backed storage
+  // before both plaintext copies are removed. A secure-store failure aborts
+  // boot instead of silently retaining or downgrading the bearer.
+  const legacyPreference = await Preferences.get({ key: STEWARD_TOKEN_KEY });
+  const legacyToken =
+    legacyPreference.value?.trim() ||
+    window.localStorage.getItem(STEWARD_TOKEN_KEY)?.trim() ||
+    null;
+  const secureToken = await androidSecureCredentialStore.read();
+  if (!secureToken && legacyToken) {
+    await androidSecureCredentialStore.write(legacyToken);
+  }
+  await Preferences.remove({ key: STEWARD_TOKEN_KEY });
+  window.localStorage.removeItem(STEWARD_TOKEN_KEY);
 }
 
 /** Mirrors the same minimal allowlist on backgrounding; no runtime endpoints. */
@@ -310,6 +354,7 @@ export async function bootAndroidCloudApp(): Promise<void> {
     <React.StrictMode>
       <ErrorBoundary>
         <AndroidCloudApp
+          client={androidCloudClient}
           closeExternal={() => Browser.close()}
           openExternal={openExternal}
           voice={androidCloudVoice}

--- a/packages/app/src/main.android-cloud.tsx
+++ b/packages/app/src/main.android-cloud.tsx
@@ -1,0 +1,330 @@
+/**
+ * Dedicated Google Play renderer entry.
+ *
+ * This file is intentionally independent from the cross-platform `main.tsx`
+ * composition root. Keep its static graph limited to the standard Android
+ * consumer shell: Eliza Cloud UI, Preferences-backed session persistence, and
+ * ordinary Capacitor lifecycle/deep-link/network/keyboard/status-bar APIs.
+ */
+import { App as CapacitorApp } from "@capacitor/app";
+import { Browser } from "@capacitor/browser";
+import { Capacitor } from "@capacitor/core";
+import { Keyboard } from "@capacitor/keyboard";
+import { Preferences } from "@capacitor/preferences";
+import { StatusBar, Style } from "@capacitor/status-bar";
+import { TalkMode } from "@elizaos/capacitor-talkmode";
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import {
+  ANDROID_CLOUD_CONVERSATION_ID_KEY,
+  AndroidCloudApp,
+  type AndroidCloudVoiceAdapter,
+} from "@elizaos/ui/android-cloud/AndroidCloudApp";
+import { ErrorBoundary } from "@elizaos/ui/components/ui/error-boundary";
+import "@elizaos/ui/styles";
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+export const ANDROID_CLOUD_DEEP_LINK_EVENT =
+  "eliza:android-cloud-deep-link" as const;
+export const APP_RESUME_EVENT = "eliza:app-resume" as const;
+export const APP_PAUSE_EVENT = "eliza:app-pause" as const;
+export const NETWORK_STATUS_CHANGE_EVENT =
+  "eliza:network-status-change" as const;
+export const SHARE_TARGET_EVENT = "eliza:share-target" as const;
+
+interface AndroidCloudShareTarget {
+  source: "deep-link";
+  title?: string;
+  text?: string;
+  url?: string;
+  files: Array<{ name: string; path: string }>;
+}
+
+type AndroidCloudWindow = Window & {
+  __ELIZA_APP_SHARE_QUEUE__?: AndroidCloudShareTarget[];
+  __ELIZAOS_SHARE_QUEUE__?: AndroidCloudShareTarget[];
+  __ELIZA_ANDROID_CLOUD_BRIDGE__?: Readonly<{
+    platform: "android";
+    native: boolean;
+  }>;
+};
+
+const CLOUD_PERSISTED_KEYS = Object.freeze([
+  STEWARD_TOKEN_KEY,
+  "eliza:first-run-complete",
+  ANDROID_CLOUD_CONVERSATION_ID_KEY,
+]);
+
+function logOptionalPluginFailure(plugin: string, error: unknown): void {
+  console.warn(
+    `[Eliza Android] ${plugin} unavailable:`,
+    error instanceof Error ? error.message : error,
+  );
+}
+
+function dispatchDocumentEvent(name: string, detail?: unknown): void {
+  document.dispatchEvent(new CustomEvent(name, { detail }));
+}
+
+/** Hydrates only the Cloud shell's account/onboarding/chat continuity state. */
+export async function hydrateAndroidCloudStorage(): Promise<void> {
+  for (const key of CLOUD_PERSISTED_KEYS) {
+    try {
+      const { value } = await Preferences.get({ key });
+      if (value !== null) window.localStorage.setItem(key, value);
+    } catch (error) {
+      logOptionalPluginFailure("Preferences", error);
+      return;
+    }
+  }
+}
+
+/** Mirrors the same minimal allowlist on backgrounding; no runtime endpoints. */
+export async function persistAndroidCloudStorage(): Promise<void> {
+  await Promise.all(
+    CLOUD_PERSISTED_KEYS.map(async (key) => {
+      const value = window.localStorage.getItem(key);
+      if (value === null) {
+        await Preferences.remove({ key });
+      } else {
+        await Preferences.set({ key, value });
+      }
+    }),
+  );
+}
+
+function sharePayloadFromDeepLink(url: URL): AndroidCloudShareTarget {
+  const files = url.searchParams
+    .getAll("file")
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((path) => ({
+      name: path.slice(
+        Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\")) + 1,
+      ),
+      path,
+    }));
+  return {
+    source: "deep-link",
+    title: url.searchParams.get("title")?.trim() || undefined,
+    text: url.searchParams.get("text")?.trim() || undefined,
+    url: url.searchParams.get("url")?.trim() || undefined,
+    files,
+  };
+}
+
+function routePath(url: URL): string {
+  return [url.host, url.pathname].join("/").replace(/^\/+|\/+$/g, "");
+}
+
+/** Accepts only the app-owned scheme; arbitrary web URLs stay in the browser. */
+export function dispatchAndroidCloudDeepLink(rawUrl: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "elizaos:") return false;
+
+  if (routePath(parsed) === "share") {
+    const payload = sharePayloadFromDeepLink(parsed);
+    const cloudWindow = window as AndroidCloudWindow;
+    const queue = cloudWindow.__ELIZA_APP_SHARE_QUEUE__ ?? [];
+    queue.push(payload);
+    cloudWindow.__ELIZA_APP_SHARE_QUEUE__ = queue;
+    cloudWindow.__ELIZAOS_SHARE_QUEUE__ = queue;
+    dispatchDocumentEvent(SHARE_TARGET_EVENT, payload);
+    const composeText = [payload.title, payload.text, payload.url]
+      .filter(Boolean)
+      .join("\n");
+    if (composeText) {
+      window.dispatchEvent(
+        new CustomEvent("eliza:android-cloud-compose", {
+          detail: { text: composeText },
+        }),
+      );
+    }
+  }
+  dispatchDocumentEvent(ANDROID_CLOUD_DEEP_LINK_EVENT, { url: rawUrl });
+  return true;
+}
+
+async function initializeAndroidCloudPlatform(): Promise<void> {
+  const cloudWindow = window as AndroidCloudWindow;
+  cloudWindow.__ELIZA_ANDROID_CLOUD_BRIDGE__ = Object.freeze({
+    platform: "android",
+    native: Capacitor.isNativePlatform(),
+  });
+  dispatchDocumentEvent(
+    "eliza:bridge-ready",
+    cloudWindow.__ELIZA_ANDROID_CLOUD_BRIDGE__,
+  );
+
+  await Promise.allSettled([
+    StatusBar.setStyle({ style: Style.Dark }),
+    StatusBar.setOverlaysWebView({ overlay: true }),
+    StatusBar.setBackgroundColor({ color: "#00000000" }),
+  ]);
+
+  void Promise.resolve(
+    Keyboard.addListener("keyboardWillShow", ({ keyboardHeight }) => {
+      document.body.style.setProperty(
+        "--keyboard-height",
+        `${keyboardHeight}px`,
+      );
+      document.body.classList.add("keyboard-open");
+    }),
+  ).catch((error) => logOptionalPluginFailure("Keyboard", error));
+  void Promise.resolve(
+    Keyboard.addListener("keyboardWillHide", () => {
+      document.body.style.setProperty("--keyboard-height", "0px");
+      document.body.classList.remove("keyboard-open");
+    }),
+  ).catch((error) => logOptionalPluginFailure("Keyboard", error));
+
+  void Promise.resolve(
+    CapacitorApp.addListener("appUrlOpen", ({ url }) => {
+      dispatchAndroidCloudDeepLink(url);
+    }),
+  ).catch((error) => logOptionalPluginFailure("App", error));
+  void CapacitorApp.getLaunchUrl()
+    .then((launch) => {
+      if (launch?.url) dispatchAndroidCloudDeepLink(launch.url);
+    })
+    .catch((error) => logOptionalPluginFailure("App", error));
+
+  void Promise.resolve(
+    CapacitorApp.addListener("appStateChange", ({ isActive }) => {
+      if (!isActive) {
+        void persistAndroidCloudStorage().catch((error) =>
+          logOptionalPluginFailure("Preferences", error),
+        );
+      }
+      dispatchDocumentEvent(isActive ? APP_RESUME_EVENT : APP_PAUSE_EVENT);
+    }),
+  ).catch((error) => logOptionalPluginFailure("App", error));
+  void Promise.resolve(
+    CapacitorApp.addListener("backButton", ({ canGoBack }) => {
+      if (canGoBack) window.history.back();
+      else
+        void CapacitorApp.minimizeApp().catch((error) =>
+          logOptionalPluginFailure("App", error),
+        );
+    }),
+  ).catch((error) => logOptionalPluginFailure("App", error));
+
+  void import("@capacitor/network")
+    .then(async ({ Network }) => {
+      const publish = (connected: boolean) =>
+        dispatchDocumentEvent(NETWORK_STATUS_CHANGE_EVENT, { connected });
+      publish((await Network.getStatus()).connected);
+      await Network.addListener("networkStatusChange", ({ connected }) =>
+        publish(connected),
+      );
+    })
+    .catch((error) => logOptionalPluginFailure("Network", error));
+}
+
+let activeTranscriptListener: { remove: () => Promise<void> } | null = null;
+
+const androidCloudVoice: AndroidCloudVoiceAdapter = {
+  async requestAndStart(onFinalTranscript) {
+    await activeTranscriptListener?.remove();
+    activeTranscriptListener = null;
+    const permissions = await TalkMode.requestPermissions();
+    if (
+      permissions.microphone !== "granted" ||
+      permissions.speechRecognition === "denied" ||
+      permissions.speechRecognition === "not_supported"
+    ) {
+      throw new Error(
+        "Microphone and speech recognition permission are required for dictation.",
+      );
+    }
+    const transcriptListener = await TalkMode.addListener(
+      "transcript",
+      (event) => {
+        if (!event.isFinal) return;
+        const transcript = event.transcript.trim();
+        if (transcript) onFinalTranscript(transcript);
+        void androidCloudVoice.stop();
+      },
+    );
+    activeTranscriptListener = transcriptListener;
+    const result = await TalkMode.start({
+      config: {
+        mode: "compose",
+        stt: {
+          engine: "native",
+          language: navigator.language || "en-US",
+        },
+      },
+    });
+    if (!result.started) {
+      await transcriptListener.remove();
+      if (activeTranscriptListener === transcriptListener) {
+        activeTranscriptListener = null;
+      }
+      throw new Error(result.error || "Voice dictation could not start.");
+    }
+  },
+  async stop() {
+    const listener = activeTranscriptListener;
+    activeTranscriptListener = null;
+    try {
+      await TalkMode.stop();
+    } finally {
+      await listener?.remove();
+    }
+  },
+  async speak(text) {
+    const result = await TalkMode.speak({ text, useSystemTts: true });
+    if (result.error) throw new Error(result.error);
+  },
+};
+
+async function openExternal(url: string): Promise<void> {
+  const parsed = new URL(url);
+  if (parsed.protocol !== "https:") {
+    throw new Error("Eliza sign-in must use HTTPS.");
+  }
+  await Browser.open({ url: parsed.toString() });
+}
+
+function renderBootFailure(error: unknown): void {
+  const root = document.getElementById("root");
+  if (!root) return;
+  root.textContent =
+    "Eliza could not start. Close and reopen the app to retry.";
+  root.setAttribute("role", "alert");
+  console.error("[Eliza Android] boot failed", error);
+}
+
+export async function bootAndroidCloudApp(): Promise<void> {
+  await hydrateAndroidCloudStorage();
+  await initializeAndroidCloudPlatform();
+  const root = document.getElementById("root");
+  if (!root) throw new Error("Android Cloud renderer root is missing");
+  createRoot(root).render(
+    <React.StrictMode>
+      <ErrorBoundary>
+        <AndroidCloudApp
+          closeExternal={() => Browser.close()}
+          openExternal={openExternal}
+          voice={androidCloudVoice}
+        />
+      </ErrorBoundary>
+    </React.StrictMode>,
+  );
+}
+
+function boot(): void {
+  void bootAndroidCloudApp().catch(renderBootFailure);
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", boot, { once: true });
+} else {
+  boot();
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -125,6 +125,7 @@ import {
 } from "@elizaos/ui/navigation";
 import type { ShareTargetPayload } from "@elizaos/ui/platform";
 import { isStandalonePwa } from "@elizaos/ui/platform";
+import { isAndroidCloudBuild } from "@elizaos/ui/platform/android-runtime";
 import {
   applyLaunchConnection,
   applyLaunchConnectionFromUrl,
@@ -691,7 +692,7 @@ installPackagedShellStorageTestBridge();
 // install lands in onboarding; when that build explicitly enables the runtime
 // chooser, the local agent starts on demand only after the user picks it.
 // No-op on iOS/desktop/web and cloud builds.
-if (!hasFirstRunRuntimeOverride()) {
+if (!isAndroidCloudBuild() && !hasFirstRunRuntimeOverride()) {
   preSeedAndroidLocalRuntimeIfFresh();
 }
 
@@ -3522,24 +3523,26 @@ async function main(): Promise<void> {
     (await voiceModuleReady)?.installAecLoopHarness();
   } else if (isAndroid) {
     initializeCapacitorBridge();
-    installAndroidNativeAgentFetchBridge();
-    // Renderer-pulled screen-capture bridge (#9105): poll the agent for
-    // capture requests and serve frames via the Capacitor ScreenCapture
-    // plugin. Idempotent + native-gated; runs only after the Android fetch
-    // bridge is installed so `/api/...` routes resolve to the agent.
-    initVisionBridgesIfEnabled();
-    // Expose window.__diarizationPump (WebView→bun-agent PCM pump) and
-    // window.__jniVoice (the in-process JNI voice pipeline — the four fused
-    // voice classifiers running IN the bionic app process via the ElizaVoice
-    // host, replacing the musl bun-agent transport) so both can be driven +
-    // read on-device via CDP.
-    const voice = await voiceModuleReady;
-    if (voice) {
-      voice.installDiarizationPumpHarness();
-      voice.installJniVoiceHarness();
-      // On-device AEC acoustic-loop evidence harness (#11373):
-      // window.__aecLoop plus the `elizaos://aec-loop?...` tap-free trigger.
-      voice.installAecLoopHarness();
+    if (!isAndroidCloudBuild()) {
+      installAndroidNativeAgentFetchBridge();
+      // Renderer-pulled screen-capture bridge (#9105): poll the agent for
+      // capture requests and serve frames via the Capacitor ScreenCapture
+      // plugin. Idempotent + native-gated; runs only after the Android fetch
+      // bridge is installed so `/api/...` routes resolve to the agent.
+      initVisionBridgesIfEnabled();
+      // Expose window.__diarizationPump (WebView→bun-agent PCM pump) and
+      // window.__jniVoice (the in-process JNI voice pipeline — the four fused
+      // voice classifiers running IN the bionic app process via the ElizaVoice
+      // host, replacing the musl bun-agent transport) so both can be driven +
+      // read on-device via CDP.
+      const voice = await voiceModuleReady;
+      if (voice) {
+        voice.installDiarizationPumpHarness();
+        voice.installJniVoiceHarness();
+        // On-device AEC acoustic-loop evidence harness (#11373):
+        // window.__aecLoop plus the `elizaos://aec-loop?...` tap-free trigger.
+        voice.installAecLoopHarness();
+      }
     }
   }
   // Desktop fused on-device wake (#10351): forward native libwakeword fires from

--- a/packages/app/test/android/passkey-native-degrade.android.spec.ts
+++ b/packages/app/test/android/passkey-native-degrade.android.spec.ts
@@ -67,6 +67,20 @@ test("native sign-in routes to the external device-code flow with zero WebAuthn 
     }
   }, RESET_KEYS);
 
+  // Keep the observations in the Playwright process. Opening the real Custom
+  // Tab can destroy the WebView execution context before an in-page probe can
+  // be read back.
+  const probe: PasskeyDegradeProbe = { webauthnCalls: 0, openedUrls: [] };
+  await page.exposeBinding("__ELIZA_RECORD_WEBAUTHN__", () => {
+    probe.webauthnCalls += 1;
+  });
+  await page.exposeBinding(
+    "__ELIZA_RECORD_EXTERNAL_URL__",
+    (_source, url: string) => {
+      probe.openedUrls.push(url);
+    },
+  );
+
   const recording = await startAndroidScreenRecord({
     serial: device.serial(),
     artifactDir: ARTIFACT_DIR,
@@ -88,14 +102,10 @@ test("native sign-in routes to the external device-code flow with zero WebAuthn 
     // every WebAuthn ceremony and record every external-browser URL, calling
     // through so the real Chrome custom tab still opens on the recording.
     await page.evaluate(() => {
-      const state: { webauthnCalls: number; openedUrls: string[] } = {
-        webauthnCalls: 0,
-        openedUrls: [],
+      const recorder = window as Window & {
+        __ELIZA_RECORD_WEBAUTHN__(): Promise<void>;
+        __ELIZA_RECORD_EXTERNAL_URL__(url: string): Promise<void>;
       };
-      Object.defineProperty(window, "__PASSKEY_DEGRADE_PROBE__", {
-        configurable: true,
-        value: state,
-      });
 
       const credentials = navigator.credentials;
       if (credentials) {
@@ -103,13 +113,13 @@ test("native sign-in routes to the external device-code flow with zero WebAuthn 
         const originalCreate = credentials.create?.bind(credentials);
         if (originalGet) {
           credentials.get = ((options?: CredentialRequestOptions) => {
-            state.webauthnCalls += 1;
+            void recorder.__ELIZA_RECORD_WEBAUTHN__();
             return originalGet(options);
           }) as typeof credentials.get;
         }
         if (originalCreate) {
           credentials.create = ((options?: CredentialCreationOptions) => {
-            state.webauthnCalls += 1;
+            void recorder.__ELIZA_RECORD_WEBAUTHN__();
             return originalCreate(options);
           }) as typeof credentials.create;
         }
@@ -128,8 +138,8 @@ test("native sign-in routes to the external device-code flow with zero WebAuthn 
       ).Capacitor?.Plugins?.Browser;
       if (capacitorBrowser?.open) {
         const originalOpen = capacitorBrowser.open.bind(capacitorBrowser);
-        capacitorBrowser.open = (options: { url: string }) => {
-          state.openedUrls.push(options?.url ?? "");
+        capacitorBrowser.open = async (options: { url: string }) => {
+          await recorder.__ELIZA_RECORD_EXTERNAL_URL__(options?.url ?? "");
           return originalOpen(options);
         };
       }
@@ -140,7 +150,7 @@ test("native sign-in routes to the external device-code flow with zero WebAuthn 
         target?: string,
         features?: string,
       ) => {
-        state.openedUrls.push(String(url ?? ""));
+        void recorder.__ELIZA_RECORD_EXTERNAL_URL__(String(url ?? ""));
         return originalWindowOpen(url, target, features);
       }) as typeof window.open;
     });
@@ -157,33 +167,13 @@ test("native sign-in routes to the external device-code flow with zero WebAuthn 
     // The device-code flow surfaces as an external cli-login URL handed to the
     // Capacitor Browser plugin (or window.open on engines without it).
     await expect
-      .poll(
-        async () =>
-          page.evaluate(
-            () =>
-              (
-                window as Window & {
-                  __PASSKEY_DEGRADE_PROBE__?: PasskeyDegradeProbe;
-                }
-              ).__PASSKEY_DEGRADE_PROBE__?.openedUrls ?? [],
-          ),
-        { timeout: 90_000 },
-      )
+      .poll(() => probe.openedUrls, { timeout: 90_000 })
       .toEqual(
         expect.arrayContaining([expect.stringContaining("/auth/cli-login")]),
       );
 
     // Leave the custom tab on-screen briefly so the recording captures it.
     await new Promise((resolve) => setTimeout(resolve, 4_000));
-
-    const probe = (await page.evaluate(
-      () =>
-        (
-          window as Window & {
-            __PASSKEY_DEGRADE_PROBE__?: PasskeyDegradeProbe;
-          }
-        ).__PASSKEY_DEGRADE_PROBE__,
-    )) as PasskeyDegradeProbe;
 
     expect(probe.webauthnCalls).toBe(0);
     expect(

--- a/packages/app/test/android/passkey-native-degrade.android.spec.ts
+++ b/packages/app/test/android/passkey-native-degrade.android.spec.ts
@@ -1,8 +1,8 @@
-// On-device proof for #15828 on the real Android Capacitor WebView: the shipped
-// shell exposes no native WebAuthn bridge, so tapping "Sign in to Eliza Cloud"
-// must route through the external device-code flow (Capacitor Browser plugin →
-// /auth/cli-login) and must never invoke the browser's `navigator.credentials`
-// WebAuthn calls. Screen-recorded; run with ELIZA_ANDROID_ALLOW_FIRST_RUN=1.
+/**
+ * Proves the shipped Android Capacitor shell has no native WebAuthn bridge.
+ * The real-device harness requires Cloud sign-in to use the external device
+ * flow and rejects any invocation of browser credential APIs.
+ */
 import path from "node:path";
 import { startAndroidScreenRecord } from "../../scripts/lib/android-capture.mjs";
 import { expect, ORIGIN, test } from "./android-harness";

--- a/packages/app/vite.config.test.ts
+++ b/packages/app/vite.config.test.ts
@@ -3,11 +3,15 @@
 import { describe, expect, test } from "bun:test";
 import { runInNewContext } from "node:vm";
 import appViteConfig, {
+  ANDROID_CLOUD_FORBIDDEN_ROUTING_MARKERS,
+  androidCloudRendererEntryPlugin,
   appDevWsBasePlugin,
   appShellMetadataPlugin,
   resolveAppShellLocalCspSources,
+  selectAndroidCloudRendererEntry,
   scrubAndroidCloudLocalRouting,
   stripAndroidCloudIpcBootstrap,
+  stripAndroidCloudPublicAssetReferences,
 } from "./vite.config";
 
 describe("appDevWsBasePlugin", () => {
@@ -110,6 +114,46 @@ describe("app shell local connection policy", () => {
     const transformed = plugin.transformIndexHtml(source) as string;
     expect(transformed).not.toContain("ELIZA_ANDROID_IPC_FETCH_BRIDGE");
     expect(transformed).not.toContain("eliza-local-agent:");
+  });
+
+  test("removes browser-only public asset references from the Play shell", () => {
+    const source = `
+      <link rel="icon" href="/brand/favicons/favicon.svg" />
+      <link rel="apple-touch-icon" href="/brand/favicons/apple-touch-icon.png" />
+      <link rel="manifest" href="/site.webmanifest" />
+      <link rel="stylesheet" href="/assets/app.css" />`;
+    const stripped = stripAndroidCloudPublicAssetReferences(source);
+
+    expect(stripped).not.toMatch(/favicon|apple-touch-icon|site\.webmanifest/);
+    expect(stripped).toContain('rel="stylesheet"');
+  });
+
+  test("selects the dedicated renderer before the Android Cloud graph is bundled", () => {
+    const source = '<script type="module" src="/src/entry.ts"></script>';
+
+    expect(selectAndroidCloudRendererEntry(source, true)).toBe(
+      '<script type="module" src="/src/main.android-cloud.tsx"></script>',
+    );
+    expect(selectAndroidCloudRendererEntry(source, false)).toBe(source);
+    expect(() =>
+      selectAndroidCloudRendererEntry("<main></main>", true),
+    ).toThrow("missing the expected /src/entry.ts");
+
+    const hook = androidCloudRendererEntryPlugin(true).transformIndexHtml;
+    if (typeof hook !== "object" || !("handler" in hook)) {
+      throw new Error("Android Cloud entry plugin has no pre-transform");
+    }
+    expect(hook.order).toBe("pre");
+    const transformed = hook.handler(source, {
+      path: "/",
+      filename: "index.html",
+      server: undefined,
+      bundle: undefined,
+      chunk: undefined,
+      originalUrl: "/",
+    }) as string;
+    expect(transformed).toContain("/src/main.android-cloud.tsx");
+    expect(transformed).not.toContain('src="/src/entry.ts"');
   });
 
   test("retains the native local-agent bootstrap outside Android cloud builds", () => {

--- a/packages/app/vite.config.test.ts
+++ b/packages/app/vite.config.test.ts
@@ -4,7 +4,10 @@ import { describe, expect, test } from "bun:test";
 import { runInNewContext } from "node:vm";
 import appViteConfig, {
   appDevWsBasePlugin,
+  appShellMetadataPlugin,
   resolveAppShellLocalCspSources,
+  scrubAndroidCloudLocalRouting,
+  stripAndroidCloudIpcBootstrap,
 } from "./vite.config";
 
 describe("appDevWsBasePlugin", () => {
@@ -70,6 +73,60 @@ describe("app shell local connection policy", () => {
       localHttpSources: " http://localhost:* http://127.0.0.1:*",
       localConnectSources: " http: ws:",
     });
+  });
+
+  test("keeps cleartext and local routing out of Android cloud builds", () => {
+    expect(resolveAppShellLocalCspSources("android", false, true)).toEqual({
+      localHttpSources: "",
+      localConnectSources: "",
+    });
+    const scrubbed = scrubAndroidCloudLocalRouting(
+      "http://127.0.0.1:31337 http://10.0.2.2:31338 adb reverse tcp:32437",
+    );
+    for (const marker of ANDROID_CLOUD_FORBIDDEN_ROUTING_MARKERS) {
+      expect(scrubbed.toLowerCase()).not.toContain(marker.toLowerCase());
+    }
+  });
+
+  test("physically removes the native local-agent bootstrap from Android cloud HTML", () => {
+    const source = `
+      <head>
+        <!-- ELIZA_NATIVE_AGENT_IPC_BRIDGE_START -->
+        <script>window.__ELIZA_ANDROID_IPC_FETCH_BRIDGE__ = true; fetch("eliza-local-agent://ipc")</script>
+        <!-- ELIZA_NATIVE_AGENT_IPC_BRIDGE_END -->
+        <meta http-equiv="Content-Security-Policy" content="connect-src 'self' blob: data: eliza-local-agent: https://*;" />
+      </head>`;
+    const stripped = stripAndroidCloudIpcBootstrap(source);
+    expect(stripped).not.toContain("ELIZA_ANDROID_IPC_FETCH_BRIDGE");
+    expect(stripped).not.toContain("eliza-local-agent:");
+
+    const plugin = appShellMetadataPlugin({
+      androidCloudBuild: true,
+      capacitorBuildTarget: "android",
+    });
+    if (typeof plugin.transformIndexHtml !== "function") {
+      throw new Error("app metadata plugin has no HTML transform");
+    }
+    const transformed = plugin.transformIndexHtml(source) as string;
+    expect(transformed).not.toContain("ELIZA_ANDROID_IPC_FETCH_BRIDGE");
+    expect(transformed).not.toContain("eliza-local-agent:");
+  });
+
+  test("retains the native local-agent bootstrap outside Android cloud builds", () => {
+    const source = `
+      <!-- ELIZA_NATIVE_AGENT_IPC_BRIDGE_START -->
+      <script>fetch("eliza-local-agent://ipc")</script>
+      <!-- ELIZA_NATIVE_AGENT_IPC_BRIDGE_END -->`;
+    const plugin = appShellMetadataPlugin({
+      androidCloudBuild: false,
+      capacitorBuildTarget: "android",
+    });
+    if (typeof plugin.transformIndexHtml !== "function") {
+      throw new Error("app metadata plugin has no HTML transform");
+    }
+    expect(plugin.transformIndexHtml(source)).toContain(
+      "eliza-local-agent://ipc",
+    );
   });
 
   test("allows an owner-selected LAN WebSocket outside iOS store builds", () => {

--- a/packages/app/vite.config.test.ts
+++ b/packages/app/vite.config.test.ts
@@ -8,8 +8,8 @@ import appViteConfig, {
   appDevWsBasePlugin,
   appShellMetadataPlugin,
   resolveAppShellLocalCspSources,
-  selectAndroidCloudRendererEntry,
   scrubAndroidCloudLocalRouting,
+  selectAndroidCloudRendererEntry,
   stripAndroidCloudIpcBootstrap,
   stripAndroidCloudPublicAssetReferences,
 } from "./vite.config";

--- a/packages/app/vite.config.test.ts
+++ b/packages/app/vite.config.test.ts
@@ -7,8 +7,8 @@ import appViteConfig, {
   androidCloudRendererEntryPlugin,
   appDevWsBasePlugin,
   appShellMetadataPlugin,
+  findAndroidCloudEmittedRoutingFindings,
   resolveAppShellLocalCspSources,
-  scrubAndroidCloudLocalRouting,
   selectAndroidCloudRendererEntry,
   stripAndroidCloudIpcBootstrap,
   stripAndroidCloudPublicAssetReferences,
@@ -84,12 +84,37 @@ describe("app shell local connection policy", () => {
       localHttpSources: "",
       localConnectSources: "",
     });
-    const scrubbed = scrubAndroidCloudLocalRouting(
-      "http://127.0.0.1:31337 http://10.0.2.2:31338 adb reverse tcp:32437",
-    );
-    for (const marker of ANDROID_CLOUD_FORBIDDEN_ROUTING_MARKERS) {
-      expect(scrubbed.toLowerCase()).not.toContain(marker.toLowerCase());
-    }
+  });
+
+  test("audits every emitted file without rewriting packaged code", () => {
+    const lazyCode = "http://127.0.0.1:31337 adb reverse tcp:32437";
+    const bundle = {
+      "entry.js": {
+        type: "chunk" as const,
+        isEntry: true,
+        imports: ["runtime.js"],
+        code: 'import "./runtime.js"',
+      },
+      "runtime.js": {
+        type: "chunk" as const,
+        imports: [],
+        code: "const emulatorHost = '10.0.2.2'",
+      },
+      "lazy-direct-runtime.js": {
+        type: "chunk" as const,
+        imports: [],
+        code: lazyCode,
+      },
+    };
+
+    expect(findAndroidCloudEmittedRoutingFindings(bundle)).toEqual([
+      "lazy-direct-runtime.js: 31337",
+      "lazy-direct-runtime.js: 32437",
+      "lazy-direct-runtime.js: adb reverse",
+      "runtime.js: 10.0.2.2",
+    ]);
+    expect(bundle["lazy-direct-runtime.js"].code).toBe(lazyCode);
+    expect(ANDROID_CLOUD_FORBIDDEN_ROUTING_MARKERS).toContain("adb reverse");
   });
 
   test("physically removes the native local-agent bootstrap from Android cloud HTML", () => {
@@ -99,7 +124,8 @@ describe("app shell local connection policy", () => {
         <script>window.__ELIZA_ANDROID_IPC_FETCH_BRIDGE__ = true; fetch("eliza-local-agent://ipc")</script>
         <!-- ELIZA_NATIVE_AGENT_IPC_BRIDGE_END -->
         <meta http-equiv="Content-Security-Policy" content="connect-src 'self' blob: data: eliza-local-agent: https://*;" />
-      </head>`;
+      </head>
+      <script type="module" src="/src/entry.ts"></script>`;
     const stripped = stripAndroidCloudIpcBootstrap(source);
     expect(stripped).not.toContain("ELIZA_ANDROID_IPC_FETCH_BRIDGE");
     expect(stripped).not.toContain("eliza-local-agent:");

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1012,58 +1012,52 @@ export const ANDROID_CLOUD_FORBIDDEN_ROUTING_MARKERS = Object.freeze([
   "32438",
   "10.0.2.2",
   "adb reverse",
+  "eliza-local-agent:",
+  "__ELIZA_ANDROID_IPC_FETCH_BRIDGE__",
+  "remote-mac",
 ]);
 
-/** Physically removes direct/simulator routing defaults from Play renderer code. */
-export function scrubAndroidCloudLocalRouting(source: string): string {
-  return source
-    .replaceAll("31337", "0")
-    .replaceAll("31338", "0")
-    .replaceAll("32437", "0")
-    .replaceAll("32438", "0")
-    .replaceAll("10.0.2.2", "invalid.invalid")
-    .replaceAll("adb reverse", "Android cloud routing");
+type AndroidCloudAuditOutput = {
+  type: "chunk" | "asset";
+  code?: string;
+  source?: string | Uint8Array;
+};
+
+/**
+ * Fail-only audit of every text-bearing file emitted into the Android Cloud
+ * renderer. Build policy must never rewrite arbitrary dependency output to
+ * conceal a marker, and lazy chunks remain executable packaged product code.
+ */
+export function findAndroidCloudEmittedRoutingFindings(
+  bundle: Record<string, AndroidCloudAuditOutput>,
+): string[] {
+  const findings: string[] = [];
+  for (const [fileName, output] of Object.entries(bundle)) {
+    const content =
+      output.type === "chunk"
+        ? output.code
+        : typeof output.source === "string"
+          ? output.source
+          : output.source instanceof Uint8Array
+            ? new TextDecoder().decode(output.source)
+            : undefined;
+    if (!content) continue;
+    for (const marker of ANDROID_CLOUD_FORBIDDEN_ROUTING_MARKERS) {
+      if (content.toLowerCase().includes(marker.toLowerCase())) {
+        findings.push(`${fileName}: ${marker}`);
+      }
+    }
+  }
+  return findings.sort();
 }
 
 function androidCloudRendererPolicyPlugin(): Plugin {
   return {
     name: "android-cloud-renderer-policy",
     enforce: "pre",
-    transform(code, id) {
-      const sourcePath = path.resolve(id.split("?")[0] ?? id);
-      if (
-        !IS_ANDROID_CLOUD_RENDERER_BUILD ||
-        id.startsWith("\0") ||
-        id.includes("node_modules") ||
-        !sourcePath.startsWith(`${elizaRoot}${path.sep}`)
-      ) {
-        return null;
-      }
-      const scrubbed = scrubAndroidCloudLocalRouting(code);
-      return scrubbed === code ? null : { code: scrubbed, map: null };
-    },
-    renderChunk(code) {
-      if (!IS_ANDROID_CLOUD_RENDERER_BUILD) return null;
-      const scrubbed = scrubAndroidCloudLocalRouting(code);
-      return scrubbed === code ? null : { code: scrubbed, map: null };
-    },
     generateBundle(_options, bundle) {
       if (!IS_ANDROID_CLOUD_RENDERER_BUILD) return;
-      const findings: string[] = [];
-      for (const [fileName, output] of Object.entries(bundle)) {
-        const content =
-          output.type === "chunk"
-            ? output.code
-            : typeof output.source === "string"
-              ? output.source
-              : null;
-        if (content === null) continue;
-        for (const marker of ANDROID_CLOUD_FORBIDDEN_ROUTING_MARKERS) {
-          if (content.toLowerCase().includes(marker.toLowerCase())) {
-            findings.push(`${fileName}: ${marker}`);
-          }
-        }
-      }
+      const findings = findAndroidCloudEmittedRoutingFindings(bundle);
       if (findings.length > 0) {
         throw new Error(
           `Android Cloud renderer contains forbidden local routing markers:\n${findings

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1001,6 +1001,77 @@ export function resolveAppShellLocalCspSources(
   };
 }
 
+export const ANDROID_CLOUD_FORBIDDEN_ROUTING_MARKERS = Object.freeze([
+  "31337",
+  "31338",
+  "32437",
+  "32438",
+  "10.0.2.2",
+  "adb reverse",
+]);
+
+/** Physically removes direct/simulator routing defaults from Play renderer code. */
+export function scrubAndroidCloudLocalRouting(source: string): string {
+  return source
+    .replaceAll("31337", "0")
+    .replaceAll("31338", "0")
+    .replaceAll("32437", "0")
+    .replaceAll("32438", "0")
+    .replaceAll("10.0.2.2", "invalid.invalid")
+    .replaceAll("adb reverse", "Android cloud routing");
+}
+
+function androidCloudRendererPolicyPlugin(): Plugin {
+  return {
+    name: "android-cloud-renderer-policy",
+    enforce: "pre",
+    transform(code, id) {
+      const sourcePath = path.resolve(id.split("?")[0] ?? id);
+      if (
+        !IS_ANDROID_CLOUD_RENDERER_BUILD ||
+        id.startsWith("\0") ||
+        id.includes("node_modules") ||
+        !sourcePath.startsWith(`${elizaRoot}${path.sep}`)
+      ) {
+        return null;
+      }
+      const scrubbed = scrubAndroidCloudLocalRouting(code);
+      return scrubbed === code ? null : { code: scrubbed, map: null };
+    },
+    renderChunk(code) {
+      if (!IS_ANDROID_CLOUD_RENDERER_BUILD) return null;
+      const scrubbed = scrubAndroidCloudLocalRouting(code);
+      return scrubbed === code ? null : { code: scrubbed, map: null };
+    },
+    generateBundle(_options, bundle) {
+      if (!IS_ANDROID_CLOUD_RENDERER_BUILD) return;
+      const findings: string[] = [];
+      for (const [fileName, output] of Object.entries(bundle)) {
+        const content =
+          output.type === "chunk"
+            ? output.code
+            : typeof output.source === "string"
+              ? output.source
+              : null;
+        if (content === null) continue;
+        for (const marker of ANDROID_CLOUD_FORBIDDEN_ROUTING_MARKERS) {
+          if (content.toLowerCase().includes(marker.toLowerCase())) {
+            findings.push(`${fileName}: ${marker}`);
+          }
+        }
+      }
+      if (findings.length > 0) {
+        throw new Error(
+          `Android Cloud renderer contains forbidden local routing markers:\n${findings
+            .sort()
+            .map((finding) => `  - ${finding}`)
+            .join("\n")}`,
+        );
+      }
+    },
+  };
+}
+
 /** Viewport policies selected by the app-shell metadata transform. */
 export const VIEWPORT_META_NATIVE =
   "width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover";

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -959,6 +959,9 @@ const NATIVE_PLUGIN_ALIAS_ENTRIES = CAPACITOR_PLUGIN_NAMES.map((name) => ({
 const CAPACITOR_BUILD_TARGET = process.env.ELIZA_CAPACITOR_BUILD_TARGET ?? "";
 const IS_CAPACITOR_MOBILE_BUILD =
   CAPACITOR_BUILD_TARGET === "ios" || CAPACITOR_BUILD_TARGET === "android";
+const IS_ANDROID_CLOUD_RENDERER_BUILD =
+  CAPACITOR_BUILD_TARGET === "android" &&
+  process.env.VITE_ELIZA_ANDROID_RUNTIME_MODE === "cloud";
 const USE_CORE_SOURCE_BROWSER_ENTRY =
   IS_CAPACITOR_MOBILE_BUILD ||
   process.env.ELIZA_DESKTOP_VITE_FAST_DIST === "1" ||
@@ -972,11 +975,12 @@ const USE_CORE_SOURCE_BROWSER_ENTRY =
 export function resolveAppShellLocalCspSources(
   capacitorBuildTarget: string,
   isIosStoreBuild: boolean,
+  isAndroidCloudBuild = false,
 ): {
   localHttpSources: string;
   localConnectSources: string;
 } {
-  if (isIosStoreBuild) {
+  if (isIosStoreBuild || isAndroidCloudBuild) {
     return { localHttpSources: "", localConnectSources: "" };
   }
 
@@ -1078,9 +1082,25 @@ export const VIEWPORT_META_NATIVE =
 export const VIEWPORT_META_WEB =
   "width=device-width, initial-scale=1.0, viewport-fit=cover";
 
+const NATIVE_AGENT_IPC_BRIDGE_BLOCK =
+  /\s*<!-- ELIZA_NATIVE_AGENT_IPC_BRIDGE_START -->[\s\S]*?<!-- ELIZA_NATIVE_AGENT_IPC_BRIDGE_END -->\s*/;
+
+/**
+ * Removes the native local-agent fetch shim and its CSP scheme from the
+ * standard Android Cloud renderer. Direct Android and iOS builds retain the
+ * bridge unchanged.
+ */
+export function stripAndroidCloudIpcBootstrap(html: string): string {
+  const withoutBridge = html.replace(NATIVE_AGENT_IPC_BRIDGE_BLOCK, "\n");
+  return withoutBridge.replace(
+    /(connect-src\s[^;]*?)\s+eliza-local-agent:/,
+    "$1",
+  );
+}
+
 /** Creates the metadata transform; the target override keeps build-mode tests exact. */
 export function appShellMetadataPlugin(
-  options: { capacitorBuildTarget?: string } = {},
+  options: { androidCloudBuild?: boolean; capacitorBuildTarget?: string } = {},
 ): Plugin {
   const capacitorBuildTarget =
     options.capacitorBuildTarget ?? CAPACITOR_BUILD_TARGET;
@@ -1090,8 +1110,16 @@ export function appShellMetadataPlugin(
     capacitorBuildTarget === "ios" &&
     (process.env.ELIZA_BUILD_VARIANT === "store" ||
       process.env.ELIZA_RELEASE_AUTHORITY === "apple-app-store");
+  const isAndroidCloudBuild =
+    options.androidCloudBuild ??
+    (capacitorBuildTarget === "android" &&
+      process.env.VITE_ELIZA_ANDROID_RUNTIME_MODE === "cloud");
   const { localHttpSources, localConnectSources } =
-    resolveAppShellLocalCspSources(capacitorBuildTarget, isIosStoreBuild);
+    resolveAppShellLocalCspSources(
+      capacitorBuildTarget,
+      isIosStoreBuild,
+      isAndroidCloudBuild,
+    );
   const manifest = `${JSON.stringify(
     {
       name: APP_SHELL_METADATA.appName,
@@ -1136,6 +1164,9 @@ export function appShellMetadataPlugin(
       let next = html;
       for (const [token, value] of replacements) {
         next = next.replaceAll(token, value);
+      }
+      if (isAndroidCloudBuild) {
+        next = stripAndroidCloudIpcBootstrap(next);
       }
       return next;
     },

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1098,6 +1098,51 @@ export function stripAndroidCloudIpcBootstrap(html: string): string {
   );
 }
 
+/** Removes browser-only icons/manifest links whose public tree is not packaged. */
+export function stripAndroidCloudPublicAssetReferences(html: string): string {
+  return html.replace(
+    /\s*<link\b[^>]*\brel=["'](?:icon|apple-touch-icon|manifest)["'][^>]*>\s*/gi,
+    "\n",
+  );
+}
+
+const DEFAULT_RENDERER_ENTRY = "/src/entry.ts";
+const ANDROID_CLOUD_RENDERER_ENTRY = "/src/main.android-cloud.tsx";
+
+/**
+ * Selects the minimal Play-safe renderer before Rollup sees the application
+ * graph. A source-level entry swap is stronger than a runtime branch: Android
+ * Cloud builds cannot accidentally package the desktop, local-runtime, iOS,
+ * service-worker, or generic App composition roots behind a dormant condition.
+ */
+export function selectAndroidCloudRendererEntry(
+  html: string,
+  androidCloudBuild: boolean,
+): string {
+  if (!androidCloudBuild) return html;
+  if (!html.includes(DEFAULT_RENDERER_ENTRY)) {
+    throw new Error(
+      `Android Cloud HTML is missing the expected ${DEFAULT_RENDERER_ENTRY} module entry`,
+    );
+  }
+  return html.replace(DEFAULT_RENDERER_ENTRY, ANDROID_CLOUD_RENDERER_ENTRY);
+}
+
+/** Runs before Vite discovers HTML module imports, enforcing graph isolation. */
+export function androidCloudRendererEntryPlugin(
+  androidCloudBuild = IS_ANDROID_CLOUD_RENDERER_BUILD,
+): Plugin {
+  return {
+    name: "android-cloud-renderer-entry",
+    transformIndexHtml: {
+      order: "pre",
+      handler(html) {
+        return selectAndroidCloudRendererEntry(html, androidCloudBuild);
+      },
+    },
+  };
+}
+
 /** Creates the metadata transform; the target override keeps build-mode tests exact. */
 export function appShellMetadataPlugin(
   options: { androidCloudBuild?: boolean; capacitorBuildTarget?: string } = {},
@@ -1167,6 +1212,7 @@ export function appShellMetadataPlugin(
       }
       if (isAndroidCloudBuild) {
         next = stripAndroidCloudIpcBootstrap(next);
+        next = stripAndroidCloudPublicAssetReferences(next);
       }
       return next;
     },
@@ -1186,6 +1232,7 @@ export function appShellMetadataPlugin(
       });
     },
     generateBundle() {
+      if (isAndroidCloudBuild) return;
       this.emitFile({
         type: "asset",
         fileName: "site.webmanifest",
@@ -2233,7 +2280,9 @@ export default defineConfig(({ command }) => ({
   cacheDir: process.env.ELIZA_VITE_CACHE_DIR
     ? path.resolve(process.env.ELIZA_VITE_CACHE_DIR)
     : path.resolve(here, ".vite"),
-  publicDir: path.resolve(here, "public"),
+  publicDir: IS_ANDROID_CLOUD_RENDERER_BUILD
+    ? false
+    : path.resolve(here, "public"),
   define: {
     global: "globalThis",
     // Build variant — set at signing time by desktop-build.mjs and embedded
@@ -2276,6 +2325,8 @@ export default defineConfig(({ command }) => ({
     ),
   },
   plugins: [
+    androidCloudRendererEntryPlugin(),
+    androidCloudRendererPolicyPlugin(),
     forcedHostModeFlagGuardPlugin(),
     productionBuildStampGuardPlugin(),
     bufferEsmShimPlugin(),

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -128,6 +128,11 @@
       "import": "./dist/cloud/*.js",
       "default": "./dist/cloud/*.js"
     },
+    "./android-cloud/*": {
+      "types": "./dist/android-cloud/*.d.ts",
+      "import": "./dist/android-cloud/*.js",
+      "default": "./dist/android-cloud/*.js"
+    },
     "./agent-surface": {
       "types": "./dist/agent-surface/index.d.ts",
       "import": "./dist/agent-surface/index.js",

--- a/packages/ui/src/android-cloud/AndroidCloudApp.test.tsx
+++ b/packages/ui/src/android-cloud/AndroidCloudApp.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ANDROID_CLOUD_COMPOSE_EVENT,
+  ANDROID_CLOUD_CONVERSATION_ID_KEY,
+  AndroidCloudApp,
+  type AndroidCloudVoiceAdapter,
+} from "./AndroidCloudApp";
+import { AndroidCloudClient } from "./android-cloud-client";
+
+const session = {
+  identity: {
+    id: "20000000-0000-4000-8000-000000000002",
+    displayName: "Ada",
+  },
+  token: "steward-token",
+  chatApiBase: "https://30000000-0000-4000-8000-000000000003.cloud.eliza.app",
+};
+
+function createClient(): AndroidCloudClient {
+  return new AndroidCloudClient({
+    fetchImpl: vi.fn<typeof fetch>(),
+  });
+}
+
+function createVoice(): AndroidCloudVoiceAdapter {
+  return {
+    requestAndStart: vi.fn(async () => undefined),
+    stop: vi.fn(async () => undefined),
+    speak: vi.fn(async () => undefined),
+  };
+}
+
+describe("AndroidCloudApp", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => cleanup());
+
+  it("renders a retryable signed-out state when no stored session exists", async () => {
+    const client = createClient();
+    vi.spyOn(client, "restoreSession").mockResolvedValue(null);
+    render(<AndroidCloudApp client={client} voice={createVoice()} />);
+
+    expect(await screen.findByRole("button", { name: "Sign in" })).toBeTruthy();
+    expect(
+      screen.getByText("Sign in securely to chat with your Eliza."),
+    ).toBeTruthy();
+  });
+
+  it("accepts a native share/deep-link compose event without auto-sending", async () => {
+    const client = createClient();
+    vi.spyOn(client, "restoreSession").mockResolvedValue(session);
+    vi.spyOn(client, "createConversation");
+    render(<AndroidCloudApp client={client} voice={createVoice()} />);
+    await screen.findByText("Ada");
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(ANDROID_CLOUD_COMPOSE_EVENT, {
+          detail: { text: "Shared safely" },
+        }),
+      );
+    });
+
+    await waitFor(() =>
+      expect(
+        (screen.getByLabelText("Message Eliza") as HTMLTextAreaElement).value,
+      ).toBe("Shared safely"),
+    );
+    expect(client.createConversation).not.toHaveBeenCalled();
+  });
+
+  it("creates one server conversation and renders a successful text reply", async () => {
+    const client = createClient();
+    vi.spyOn(client, "restoreSession").mockResolvedValue(session);
+    vi.spyOn(client, "createConversation").mockResolvedValue("conversation-1");
+    vi.spyOn(client, "sendChat").mockImplementation(
+      async (_session, _conversationId, _text, onText) => {
+        onText("Hello from Eliza");
+        return "Hello from Eliza";
+      },
+    );
+    render(<AndroidCloudApp client={client} voice={createVoice()} />);
+    await screen.findByText("Ada");
+
+    fireEvent.change(screen.getByLabelText("Message Eliza"), {
+      target: { value: "Hello" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(await screen.findByText("Hello from Eliza")).toBeTruthy();
+    expect(client.createConversation).toHaveBeenCalledWith(session);
+    expect(client.sendChat).toHaveBeenCalledWith(
+      session,
+      "conversation-1",
+      "Hello",
+      expect.any(Function),
+      expect.any(AbortSignal),
+    );
+    expect(localStorage.getItem(ANDROID_CLOUD_CONVERSATION_ID_KEY)).toBe(
+      "conversation-1",
+    );
+    expect(JSON.stringify(localStorage)).not.toContain("Hello from Eliza");
+  });
+});

--- a/packages/ui/src/android-cloud/AndroidCloudApp.test.tsx
+++ b/packages/ui/src/android-cloud/AndroidCloudApp.test.tsx
@@ -119,4 +119,34 @@ describe("AndroidCloudApp", () => {
     );
     expect(JSON.stringify(localStorage)).not.toContain("Hello from Eliza");
   });
+
+  it("removes the pending assistant row when a send is stopped", async () => {
+    const client = createClient();
+    vi.spyOn(client, "restoreSession").mockResolvedValue(session);
+    vi.spyOn(client, "createConversation").mockResolvedValue("conversation-1");
+    vi.spyOn(client, "sendChat").mockImplementation(
+      async (_session, _conversationId, _text, _onText, signal) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    render(<AndroidCloudApp client={client} voice={createVoice()} />);
+    await screen.findByText("Ada");
+
+    fireEvent.change(screen.getByLabelText("Message Eliza"), {
+      target: { value: "Never finish" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(await screen.findByText("Thinking…")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+
+    await waitFor(() => expect(screen.queryByText("Thinking…")).toBeNull());
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByText("Never finish")).toBeTruthy();
+  });
 });

--- a/packages/ui/src/android-cloud/AndroidCloudApp.test.tsx
+++ b/packages/ui/src/android-cloud/AndroidCloudApp.test.tsx
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * Exercises the Play-safe Cloud shell through its rendered auth, compose,
+ * conversation, and persistence boundaries in a deterministic DOM harness.
+ */
+
 import {
   act,
   cleanup,

--- a/packages/ui/src/android-cloud/AndroidCloudApp.tsx
+++ b/packages/ui/src/android-cloud/AndroidCloudApp.tsx
@@ -1,0 +1,441 @@
+/** Minimal Google Play consumer shell: Cloud auth, text/voice chat and history. */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  AndroidCloudClient,
+  type AndroidCloudSession,
+} from "./android-cloud-client";
+
+export const ANDROID_CLOUD_CONVERSATION_ID_KEY =
+  "eliza:android-cloud:conversation-id:v1";
+const LOGIN_POLL_MS = 1_500;
+const LOGIN_TIMEOUT_MS = 10 * 60_000;
+export const ANDROID_CLOUD_COMPOSE_EVENT = "eliza:android-cloud-compose";
+
+export interface AndroidCloudMessage {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+}
+
+export interface AndroidCloudAppProps {
+  client?: AndroidCloudClient;
+  /** The Capacitor entry should provide Browser.open or another system-browser adapter. */
+  openExternal?: (url: string) => Promise<void> | void;
+  closeExternal?: () => Promise<void> | void;
+  voice?: AndroidCloudVoiceAdapter;
+}
+
+export interface AndroidCloudVoiceAdapter {
+  requestAndStart(onFinalTranscript: (text: string) => void): Promise<void>;
+  stop(): Promise<void>;
+  speak(text: string): Promise<void>;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : "Something went wrong. Please try again.";
+}
+
+function defaultExternalOpen(url: string): void {
+  const opened = window.open(url, "_system", "noopener,noreferrer");
+  if (!opened) window.location.assign(url);
+}
+
+export function AndroidCloudApp({
+  client: clientOverride,
+  openExternal = defaultExternalOpen,
+  closeExternal,
+  voice,
+}: AndroidCloudAppProps): React.JSX.Element {
+  const client = useMemo(
+    () => clientOverride ?? new AndroidCloudClient(),
+    [clientOverride],
+  );
+  const [session, setSession] = useState<AndroidCloudSession | null>(null);
+  const [conversationId, setConversationId] = useState<string | null>(null);
+  const [phase, setPhase] = useState<"loading" | "signed-out" | "ready">(
+    "loading",
+  );
+  const [messages, setMessages] = useState<AndroidCloudMessage[]>([]);
+  const [draft, setDraft] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [listening, setListening] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const loginAttemptRef = useRef(0);
+
+  const restore = useCallback(async () => {
+    setError(null);
+    setPhase("loading");
+    try {
+      const restored = await client.restoreSession();
+      setSession(restored);
+      if (restored) {
+        const storedConversationId = localStorage
+          .getItem(ANDROID_CLOUD_CONVERSATION_ID_KEY)
+          ?.trim();
+        if (storedConversationId) {
+          setConversationId(storedConversationId);
+          try {
+            const restoredMessages = await client.getConversationMessages(
+              restored,
+              storedConversationId,
+            );
+            setMessages(restoredMessages.slice(-100));
+          } catch (historyError) {
+            setError(
+              `Your previous conversation could not be restored: ${errorMessage(historyError)}`,
+            );
+          }
+        }
+      } else {
+        localStorage.removeItem(ANDROID_CLOUD_CONVERSATION_ID_KEY);
+        setConversationId(null);
+        setMessages([]);
+      }
+      setPhase(restored ? "ready" : "signed-out");
+    } catch (restoreError) {
+      setSession(null);
+      setPhase("signed-out");
+      setError(errorMessage(restoreError));
+    }
+  }, [client]);
+
+  useEffect(() => {
+    void restore();
+    return () => {
+      loginAttemptRef.current += 1;
+      abortRef.current?.abort();
+      void voice?.stop();
+    };
+  }, [restore, voice]);
+
+  useEffect(() => {
+    const compose = (event: Event) => {
+      const text = (event as CustomEvent<{ text?: unknown }>).detail?.text;
+      if (typeof text !== "string" || !text.trim()) return;
+      setDraft((current) => `${current}${current ? "\n" : ""}${text.trim()}`);
+    };
+    window.addEventListener(ANDROID_CLOUD_COMPOSE_EVENT, compose);
+    return () =>
+      window.removeEventListener(ANDROID_CLOUD_COMPOSE_EVENT, compose);
+  }, []);
+
+  const signIn = useCallback(async () => {
+    const attemptNumber = loginAttemptRef.current + 1;
+    loginAttemptRef.current = attemptNumber;
+    setBusy(true);
+    setError(null);
+    try {
+      const attempt = await client.beginLogin();
+      await openExternal(attempt.browserUrl);
+      const deadline = Date.now() + LOGIN_TIMEOUT_MS;
+      while (Date.now() < deadline) {
+        await new Promise((resolve) =>
+          window.setTimeout(resolve, LOGIN_POLL_MS),
+        );
+        if (loginAttemptRef.current !== attemptNumber) return;
+        const result = await client.pollLogin(attempt.sessionId);
+        if (result.status === "pending") continue;
+        if (result.status === "expired") throw new Error(result.error);
+        await closeExternal?.();
+        await restore();
+        return;
+      }
+      throw new Error("Sign-in timed out. Please try again.");
+    } catch (signInError) {
+      setError(errorMessage(signInError));
+    } finally {
+      if (loginAttemptRef.current === attemptNumber) setBusy(false);
+    }
+  }, [client, closeExternal, openExternal, restore]);
+
+  const cancelSignIn = useCallback(() => {
+    loginAttemptRef.current += 1;
+    setBusy(false);
+    void closeExternal?.();
+  }, [closeExternal]);
+
+  const signOut = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await client.signOut();
+      localStorage.removeItem(ANDROID_CLOUD_CONVERSATION_ID_KEY);
+      setSession(null);
+      setConversationId(null);
+      setMessages([]);
+      setPhase("signed-out");
+    } catch (signOutError) {
+      setError(errorMessage(signOutError));
+    } finally {
+      setBusy(false);
+    }
+  }, [client]);
+
+  const send = useCallback(async () => {
+    const text = draft.trim();
+    if (!session || !text || busy) return;
+    const userMessage: AndroidCloudMessage = {
+      id: crypto.randomUUID(),
+      role: "user",
+      text,
+    };
+    const assistantId = crypto.randomUUID();
+    setDraft("");
+    setError(null);
+    setBusy(true);
+    setMessages((current) => [
+      ...current,
+      userMessage,
+      { id: assistantId, role: "assistant", text: "" },
+    ]);
+    const controller = new AbortController();
+    abortRef.current = controller;
+    try {
+      let activeConversationId = conversationId;
+      if (!activeConversationId) {
+        activeConversationId =
+          localStorage.getItem(ANDROID_CLOUD_CONVERSATION_ID_KEY)?.trim() ||
+          null;
+        if (!activeConversationId) {
+          activeConversationId = await client.createConversation(session);
+          localStorage.setItem(
+            ANDROID_CLOUD_CONVERSATION_ID_KEY,
+            activeConversationId,
+          );
+        }
+        setConversationId(activeConversationId);
+      }
+      await client.sendChat(
+        session,
+        activeConversationId,
+        text,
+        (reply) =>
+          setMessages((current) =>
+            current.map((message) =>
+              message.id === assistantId
+                ? { ...message, text: reply }
+                : message,
+            ),
+          ),
+        controller.signal,
+      );
+    } catch (sendError) {
+      if (!controller.signal.aborted) {
+        setMessages((current) =>
+          current.filter((message) => message.id !== assistantId),
+        );
+        setError(errorMessage(sendError));
+      }
+    } finally {
+      abortRef.current = null;
+      setBusy(false);
+    }
+  }, [busy, client, conversationId, draft, session]);
+
+  const toggleDictation = useCallback(async () => {
+    if (listening) {
+      await voice?.stop();
+      setListening(false);
+      return;
+    }
+    if (!voice) {
+      setError("Voice dictation is not available on this device.");
+      return;
+    }
+    try {
+      await voice.requestAndStart((value) => {
+        const transcript = value.trim();
+        if (transcript) {
+          setDraft((current) => `${current}${current ? " " : ""}${transcript}`);
+        }
+        setListening(false);
+      });
+      setError(null);
+      setListening(true);
+    } catch (dictationError) {
+      setListening(false);
+      setError(errorMessage(dictationError));
+    }
+  }, [listening, voice]);
+
+  const speak = useCallback(
+    (text: string) => {
+      if (!voice) {
+        setError("Audio playback is not available on this device.");
+        return;
+      }
+      void voice
+        .speak(text)
+        .catch((playbackError) => setError(errorMessage(playbackError)));
+    },
+    [voice],
+  );
+
+  if (phase === "loading") {
+    return (
+      <main className="flex min-h-dvh items-center justify-center bg-bg text-txt">
+        Loading Eliza…
+      </main>
+    );
+  }
+
+  if (phase === "signed-out") {
+    return (
+      <main className="flex min-h-dvh items-center justify-center bg-bg p-6 text-txt">
+        <section className="w-full max-w-sm space-y-5 rounded-2xl border border-border bg-card p-6 text-center">
+          <h1 className="text-2xl font-semibold">Eliza</h1>
+          <p className="text-sm text-muted">
+            Sign in securely to chat with your Eliza.
+          </p>
+          {error ? (
+            <p role="alert" className="text-sm text-status-danger">
+              {error}
+            </p>
+          ) : null}
+          {busy ? (
+            <button
+              type="button"
+              onClick={cancelSignIn}
+              className="w-full rounded-xl border border-border px-4 py-3 font-semibold"
+            >
+              Cancel sign-in
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => void signIn()}
+              className="w-full rounded-xl bg-accent px-4 py-3 font-semibold text-accent-foreground"
+            >
+              Sign in
+            </button>
+          )}
+          {error ? (
+            <button
+              type="button"
+              onClick={() => void restore()}
+              className="text-sm text-muted underline"
+            >
+              Retry session check
+            </button>
+          ) : null}
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="flex min-h-dvh flex-col bg-bg text-txt">
+      <header className="flex items-center justify-between border-b border-border px-4 py-3">
+        <div>
+          <h1 className="font-semibold">Eliza</h1>
+          <p className="text-xs text-muted">{session?.identity.displayName}</p>
+        </div>
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={() => {
+              localStorage.removeItem(ANDROID_CLOUD_CONVERSATION_ID_KEY);
+              setConversationId(null);
+              setMessages([]);
+            }}
+            className="text-sm text-muted"
+          >
+            New chat
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void signOut()}
+            className="text-sm text-muted disabled:opacity-50"
+          >
+            Sign out
+          </button>
+        </div>
+      </header>
+      <ol
+        aria-live="polite"
+        className="flex flex-1 flex-col gap-3 overflow-y-auto p-4"
+      >
+        {messages.length === 0 ? (
+          <li className="m-auto text-center text-sm text-muted">
+            Ask Eliza anything.
+          </li>
+        ) : null}
+        {messages.map((message) => (
+          <li
+            key={message.id}
+            className={`max-w-[85%] rounded-2xl px-4 py-3 ${message.role === "user" ? "ml-auto bg-accent text-accent-foreground" : "mr-auto bg-card"}`}
+          >
+            <p className="whitespace-pre-wrap">{message.text || "Thinking…"}</p>
+            {message.role === "assistant" && message.text ? (
+              <button
+                type="button"
+                onClick={() => speak(message.text)}
+                className="mt-2 text-xs text-muted underline"
+              >
+                Play
+              </button>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+      {error ? (
+        <p role="alert" className="px-4 pb-2 text-sm text-status-danger">
+          {error}
+        </p>
+      ) : null}
+      <form
+        className="flex gap-2 border-t border-border p-3"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void send();
+        }}
+      >
+        <button
+          type="button"
+          aria-pressed={listening}
+          aria-label={listening ? "Stop dictation" : "Start dictation"}
+          onClick={() => void toggleDictation()}
+          className="rounded-xl border border-border px-3"
+        >
+          {listening ? "Stop" : "Mic"}
+        </button>
+        <label className="sr-only" htmlFor="android-cloud-message">
+          Message Eliza
+        </label>
+        <textarea
+          id="android-cloud-message"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          rows={1}
+          disabled={busy}
+          className="min-h-11 flex-1 resize-none rounded-xl border border-border bg-card px-3 py-2"
+          placeholder="Message Eliza"
+        />
+        {busy ? (
+          <button
+            type="button"
+            onClick={() => abortRef.current?.abort()}
+            className="rounded-xl border border-border px-4"
+          >
+            Stop
+          </button>
+        ) : (
+          <button
+            type="submit"
+            disabled={!draft.trim()}
+            className="rounded-xl bg-accent px-4 text-accent-foreground disabled:opacity-50"
+          >
+            Send
+          </button>
+        )}
+      </form>
+    </main>
+  );
+}
+
+export default AndroidCloudApp;

--- a/packages/ui/src/android-cloud/AndroidCloudApp.tsx
+++ b/packages/ui/src/android-cloud/AndroidCloudApp.tsx
@@ -40,7 +40,16 @@ function errorMessage(error: unknown): string {
 
 function defaultExternalOpen(url: string): void {
   const opened = window.open(url, "_system", "noopener,noreferrer");
-  if (!opened) window.location.assign(url);
+  if (!opened) {
+    // Deliberately NOT window.location.assign(url). That would load the Cloud
+    // sign-in page inside this app's own WebView, putting a credential-entry
+    // form on a surface the app controls and can read — which is exactly what
+    // opening in "_system" exists to avoid. Failing here surfaces a real error
+    // instead of silently downgrading to the unsafe path.
+    throw new Error(
+      "Unable to open the browser for sign-in. Check that a browser is installed and try again.",
+    );
+  }
 }
 
 export function AndroidCloudApp({

--- a/packages/ui/src/android-cloud/AndroidCloudApp.tsx
+++ b/packages/ui/src/android-cloud/AndroidCloudApp.tsx
@@ -94,6 +94,8 @@ export function AndroidCloudApp({
             );
             setMessages(restoredMessages.slice(-100));
           } catch (historyError) {
+            // error-policy:J4 conversation restore failure remains visible
+            // while the authenticated shell stays usable for a new chat.
             setError(
               `Your previous conversation could not be restored: ${errorMessage(historyError)}`,
             );
@@ -106,6 +108,8 @@ export function AndroidCloudApp({
       }
       setPhase(restored ? "ready" : "signed-out");
     } catch (restoreError) {
+      // error-policy:J4 session verification failure becomes an explicit
+      // signed-out error state with a retry affordance.
       setSession(null);
       setPhase("signed-out");
       setError(errorMessage(restoreError));
@@ -155,6 +159,7 @@ export function AndroidCloudApp({
       }
       throw new Error("Sign-in timed out. Please try again.");
     } catch (signInError) {
+      // error-policy:J4 the sign-in boundary renders the actionable failure.
       setError(errorMessage(signInError));
     } finally {
       if (loginAttemptRef.current === attemptNumber) setBusy(false);
@@ -178,6 +183,8 @@ export function AndroidCloudApp({
       setMessages([]);
       setPhase("signed-out");
     } catch (signOutError) {
+      // error-policy:J4 failed logout remains visible without fabricating a
+      // signed-out state that the client did not complete.
       setError(errorMessage(signOutError));
     } finally {
       setBusy(false);
@@ -233,10 +240,12 @@ export function AndroidCloudApp({
         controller.signal,
       );
     } catch (sendError) {
+      // error-policy:J4 a failed send removes the optimistic placeholder and
+      // surfaces non-user-cancelled failures in the composer.
+      setMessages((current) =>
+        current.filter((message) => message.id !== assistantId),
+      );
       if (!controller.signal.aborted) {
-        setMessages((current) =>
-          current.filter((message) => message.id !== assistantId),
-        );
         setError(errorMessage(sendError));
       }
     } finally {
@@ -266,6 +275,7 @@ export function AndroidCloudApp({
       setError(null);
       setListening(true);
     } catch (dictationError) {
+      // error-policy:J4 denied or failed dictation is visible at the input.
       setListening(false);
       setError(errorMessage(dictationError));
     }
@@ -277,9 +287,10 @@ export function AndroidCloudApp({
         setError("Audio playback is not available on this device.");
         return;
       }
-      void voice
-        .speak(text)
-        .catch((playbackError) => setError(errorMessage(playbackError)));
+      void voice.speak(text).catch((playbackError) => {
+        // error-policy:J4 playback failure is visible beside the transcript.
+        setError(errorMessage(playbackError));
+      });
     },
     [voice],
   );

--- a/packages/ui/src/android-cloud/android-cloud-client.test.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.test.ts
@@ -144,6 +144,29 @@ describe("AndroidCloudClient", () => {
     expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
   });
 
+  it("uses an injected secure credential store without touching localStorage", async () => {
+    let secureToken: string | null = "secure-token";
+    const credentialStore = {
+      read: vi.fn(async () => secureToken),
+      write: vi.fn(async (token: string) => {
+        secureToken = token;
+      }),
+      clear: vi.fn(async () => {
+        secureToken = null;
+      }),
+    };
+    const client = new AndroidCloudClient({
+      credentialStore,
+      fetchImpl: vi.fn<typeof fetch>().mockResolvedValueOnce(json(401, {})),
+    });
+
+    await expect(client.restoreSession()).resolves.toBeNull();
+    expect(credentialStore.read).toHaveBeenCalledOnce();
+    expect(credentialStore.clear).toHaveBeenCalledOnce();
+    expect(secureToken).toBeNull();
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+  });
+
   it("restores only valid visible user and assistant transcript messages", async () => {
     const client = new AndroidCloudClient({
       fetchImpl: vi.fn<typeof fetch>().mockResolvedValueOnce(

--- a/packages/ui/src/android-cloud/android-cloud-client.test.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.test.ts
@@ -233,4 +233,50 @@ describe("AndroidCloudClient", () => {
       }),
     );
   });
+
+  // A staging build must send users to the staging login: the session was
+  // minted against the staging API, and production cannot claim it.
+  it("pairs the sign-in origin with the API the session was minted against", async () => {
+    vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(SESSION_ID);
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(json(200, { sessionId: SESSION_ID }));
+    const client = new AndroidCloudClient({
+      fetchImpl,
+      cloudApiBase: "https://api-staging.eliza.app",
+    });
+
+    const attempt = await client.beginLogin();
+
+    expect(attempt.browserUrl).toBe(
+      `https://cloud-staging.eliza.app/auth/cli-login?session=${SESSION_ID}`,
+    );
+  });
+
+  // A body that is present but unparsable is a broken endpoint, not "no
+  // session yet". Collapsing it to {} made pollLogin spin its full timeout.
+  it("reports an unreadable response instead of reading it as pending", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response("<html>gateway error</html>", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const client = new AndroidCloudClient({ fetchImpl });
+
+    await expect(client.pollLogin(SESSION_ID)).rejects.toThrow(
+      /could not be read/,
+    );
+  });
+
+  it("treats a genuinely empty body as empty rather than unreadable", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("", { status: 200 }));
+    const client = new AndroidCloudClient({ fetchImpl });
+
+    await expect(client.pollLogin(SESSION_ID)).resolves.toEqual({
+      status: "pending",
+    });
+  });
 });

--- a/packages/ui/src/android-cloud/android-cloud-client.test.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.test.ts
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 
+/**
+ * Exercises the Play-safe Cloud transport with deterministic HTTP responses,
+ * including authority, session, transcript, logout, and malformed-body cases.
+ */
+
 import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {

--- a/packages/ui/src/android-cloud/android-cloud-client.test.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.test.ts
@@ -269,17 +269,24 @@ describe("AndroidCloudClient", () => {
     );
   });
 
-  it.each(["null", '"authenticated"', "[]"])(
-    "rejects a non-object JSON response (%s) instead of reading it as pending",
-    async (body) => {
+  it.each([
+    ["null", null],
+    ["an array", [{ status: "authenticated", token: "attacker-token" }]],
+    ["a string", "pending"],
+    ["a number", 0],
+    ["a boolean", false],
+  ])(
+    "rejects %s JSON body instead of reading it as pending",
+    async (_label, body) => {
       const fetchImpl = vi
         .fn<typeof fetch>()
-        .mockResolvedValueOnce(new Response(body, { status: 200 }));
+        .mockResolvedValueOnce(json(200, body));
       const client = new AndroidCloudClient({ fetchImpl });
 
       await expect(client.pollLogin(SESSION_ID)).rejects.toThrow(
-        /could not be read/,
+        /invalid JSON response/,
       );
+      expect(fetchImpl).toHaveBeenCalledOnce();
     },
   );
 

--- a/packages/ui/src/android-cloud/android-cloud-client.test.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.test.ts
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AndroidCloudClient,
+  resolveAndroidCloudChatAuthority,
+} from "./android-cloud-client";
+
+const SESSION_ID = "10000000-0000-4000-8000-000000000001";
+const ACCOUNT_ID = "20000000-0000-4000-8000-000000000002";
+const PERSONAL_ID = "personal:org-1:user-1";
+const RUNTIME_ID = "30000000-0000-4000-8000-000000000003";
+const RUNTIME_BASE = `https://${RUNTIME_ID}.cloud.eliza.app`;
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("AndroidCloudClient", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("pins configuration to an official Cloud authority", () => {
+    expect(
+      new AndroidCloudClient({ cloudApiBase: "https://attacker.example" })
+        .apiBase,
+    ).toBe("https://api.eliza.app");
+  });
+
+  it("accepts only the canonical API or UUID-shaped managed runtime hosts", () => {
+    expect(
+      resolveAndroidCloudChatAuthority(
+        `https://api.eliza.app/api/v1/eliza/agents/${ACCOUNT_ID}`,
+        ACCOUNT_ID,
+      ),
+    ).toBe(`https://api.eliza.app/api/v1/eliza/agents/${ACCOUNT_ID}`);
+    expect(resolveAndroidCloudChatAuthority(RUNTIME_BASE)).toBe(RUNTIME_BASE);
+    expect(() =>
+      resolveAndroidCloudChatAuthority(`${RUNTIME_BASE}/api`),
+    ).toThrow("untrusted chat authority");
+    expect(() =>
+      resolveAndroidCloudChatAuthority("https://not-a-uuid.cloud.eliza.app"),
+    ).toThrow("untrusted chat authority");
+    expect(() =>
+      resolveAndroidCloudChatAuthority("http://api.eliza.app"),
+    ).toThrow("untrusted chat authority");
+  });
+
+  it("creates and completes the bounded external sign-in contract", async () => {
+    vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(SESSION_ID);
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(json(200, { sessionId: SESSION_ID }))
+      .mockResolvedValueOnce(
+        json(200, { status: "authenticated", apiKey: "steward-token" }),
+      );
+    const client = new AndroidCloudClient({ fetchImpl });
+
+    const attempt = await client.beginLogin();
+    expect(attempt).toEqual({
+      sessionId: SESSION_ID,
+      browserUrl: `https://cloud.eliza.app/auth/cli-login?session=${SESSION_ID}`,
+    });
+    await expect(client.pollLogin(SESSION_ID)).resolves.toEqual({
+      status: "authenticated",
+      token: "steward-token",
+    });
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe("steward-token");
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      "https://api.eliza.app/api/auth/cli-session",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("restores identity and resolves its managed runtime before chat", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "steward-token");
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      json(200, {
+        success: true,
+        data: {
+          identity: {
+            id: ACCOUNT_ID,
+            displayName: "Ada",
+            runtime: "dedicated",
+            apiBase: RUNTIME_BASE,
+          },
+        },
+      }),
+    );
+    const client = new AndroidCloudClient({ fetchImpl });
+
+    await expect(client.restoreSession()).resolves.toEqual({
+      identity: { id: ACCOUNT_ID, displayName: "Ada" },
+      token: "steward-token",
+      chatApiBase: RUNTIME_BASE,
+    });
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      "https://api.eliza.app/api/v1/eliza/personal",
+      { headers: { Authorization: "Bearer steward-token" } },
+    );
+  });
+
+  it("constructs the exact shared adapter path for a shared identity", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "steward-token");
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      json(200, {
+        data: {
+          identity: {
+            id: PERSONAL_ID,
+            displayName: "Ada",
+            runtime: "shared",
+          },
+        },
+      }),
+    );
+    const restored = await new AndroidCloudClient({
+      fetchImpl,
+    }).restoreSession();
+    expect(restored?.chatApiBase).toBe(
+      `https://api.eliza.app/api/v1/eliza/agents/${encodeURIComponent(PERSONAL_ID)}`,
+    );
+  });
+
+  it("clears an expired token when Cloud rejects session restoration", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "expired-token");
+    const client = new AndroidCloudClient({
+      fetchImpl: vi.fn<typeof fetch>().mockResolvedValueOnce(json(401, {})),
+    });
+
+    await expect(client.restoreSession()).resolves.toBeNull();
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+  });
+
+  it("restores only valid visible user and assistant transcript messages", async () => {
+    const client = new AndroidCloudClient({
+      fetchImpl: vi.fn<typeof fetch>().mockResolvedValueOnce(
+        json(200, {
+          messages: [
+            { id: "user-1", role: "user", text: "Hello" },
+            { id: "assistant-1", role: "assistant", text: "Hi" },
+            { id: "internal-1", role: "assistant", text: "" },
+            { id: "tool-1", role: "tool", text: "hidden" },
+          ],
+        }),
+      ),
+    });
+
+    await expect(
+      client.getConversationMessages(
+        {
+          identity: { id: PERSONAL_ID, displayName: "Ada" },
+          token: "steward-token",
+          chatApiBase: RUNTIME_BASE,
+        },
+        "conversation-1",
+      ),
+    ).resolves.toEqual([
+      { id: "user-1", role: "user", text: "Hello" },
+      { id: "assistant-1", role: "assistant", text: "Hi" },
+    ]);
+  });
+
+  it("fails closed when Cloud returns an unknown runtime binding", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "steward-token");
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      json(200, {
+        data: {
+          identity: {
+            id: ACCOUNT_ID,
+            displayName: "Ada",
+            runtime: "unknown",
+          },
+        },
+      }),
+    );
+    await expect(
+      new AndroidCloudClient({ fetchImpl }).restoreSession(),
+    ).rejects.toThrow("invalid runtime binding");
+  });
+
+  it("clears the local Steward token even when remote logout fails", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "steward-token");
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new Error("network unavailable"));
+    const client = new AndroidCloudClient({ fetchImpl });
+    await expect(client.signOut()).resolves.toBeUndefined();
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.eliza.app/api/auth/logout",
+      {
+        method: "POST",
+        headers: { Authorization: "Bearer steward-token" },
+      },
+    );
+  });
+
+  it("creates a server conversation and sends a text turn to that id", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        json(200, { conversation: { id: "conversation-1" } }),
+      )
+      .mockResolvedValueOnce(json(200, { text: "Hello from Eliza" }));
+    const client = new AndroidCloudClient({ fetchImpl });
+    const session = {
+      identity: { id: ACCOUNT_ID, displayName: "Ada" },
+      token: "steward-token",
+      chatApiBase: RUNTIME_BASE,
+    };
+    const conversationId = await client.createConversation(session);
+    const onText = vi.fn();
+
+    await expect(
+      client.sendChat(session, conversationId, "Hello", onText),
+    ).resolves.toBe("Hello from Eliza");
+    expect(onText).toHaveBeenCalledWith("Hello from Eliza");
+    expect(fetchImpl).toHaveBeenLastCalledWith(
+      `${RUNTIME_BASE}/api/conversations/conversation-1/messages`,
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer steward-token",
+        }),
+      }),
+    );
+  });
+});

--- a/packages/ui/src/android-cloud/android-cloud-client.test.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.test.ts
@@ -269,6 +269,20 @@ describe("AndroidCloudClient", () => {
     );
   });
 
+  it.each(["null", '"authenticated"', "[]"])(
+    "rejects a non-object JSON response (%s) instead of reading it as pending",
+    async (body) => {
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response(body, { status: 200 }));
+      const client = new AndroidCloudClient({ fetchImpl });
+
+      await expect(client.pollLogin(SESSION_ID)).rejects.toThrow(
+        /could not be read/,
+      );
+    },
+  );
+
   it("treats a genuinely empty body as empty rather than unreadable", async () => {
     const fetchImpl = vi
       .fn<typeof fetch>()

--- a/packages/ui/src/android-cloud/android-cloud-client.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.ts
@@ -52,7 +52,26 @@ export type AndroidCloudLoginPoll =
 export interface AndroidCloudClientOptions {
   cloudApiBase?: string;
   fetchImpl?: typeof fetch;
+  credentialStore?: AndroidCloudCredentialStore;
 }
+
+export interface AndroidCloudCredentialStore {
+  read(): Promise<string | null>;
+  write(token: string): Promise<void>;
+  clear(): Promise<void>;
+}
+
+const browserCredentialStore: AndroidCloudCredentialStore = {
+  async read() {
+    return readStoredStewardToken()?.trim() || null;
+  },
+  async write(token) {
+    writeStoredStewardToken(token);
+  },
+  async clear() {
+    clearStoredStewardToken();
+  },
+};
 
 type JsonRecord = Record<string, unknown>;
 
@@ -140,18 +159,20 @@ export function resolveAndroidCloudChatAuthority(
 export class AndroidCloudClient {
   readonly apiBase: string;
   private readonly fetchImpl: typeof fetch;
+  private readonly credentialStore: AndroidCloudCredentialStore;
 
   constructor(options: AndroidCloudClientOptions = {}) {
     this.apiBase = resolveCanonicalDirectCloudApiBase(options.cloudApiBase);
     this.fetchImpl = options.fetchImpl ?? fetch;
+    this.credentialStore = options.credentialStore ?? browserCredentialStore;
   }
 
-  readToken(): string | null {
-    return readStoredStewardToken()?.trim() || null;
+  async readToken(): Promise<string | null> {
+    return (await this.credentialStore.read())?.trim() || null;
   }
 
   async restoreSession(): Promise<AndroidCloudSession | null> {
-    const token = this.readToken();
+    const token = await this.readToken();
     if (!token) return null;
     const response = await this.fetchImpl(
       `${this.apiBase}/api/v1/eliza/personal`,
@@ -160,7 +181,7 @@ export class AndroidCloudClient {
       },
     );
     if (response.status === 401) {
-      clearStoredStewardToken();
+      await this.credentialStore.clear();
       return null;
     }
     if (!response.ok) {
@@ -255,7 +276,7 @@ export class AndroidCloudClient {
         stringField(data.accessToken) ??
         stringField(data.access_token);
       if (!token) throw new Error("Sign-in completed without a session token.");
-      writeStoredStewardToken(token);
+      await this.credentialStore.write(token);
       return { status: "authenticated", token };
     }
     if (status === "expired" || status === "error") {
@@ -332,7 +353,7 @@ export class AndroidCloudClient {
   }
 
   async signOut(): Promise<void> {
-    const token = this.readToken();
+    const token = await this.readToken();
     try {
       if (token) {
         await this.fetchImpl(`${this.apiBase}/api/auth/logout`, {
@@ -346,7 +367,7 @@ export class AndroidCloudClient {
       // Remote logout is best-effort. Local credential removal is authoritative
       // for this device and must still complete while offline.
     } finally {
-      clearStoredStewardToken();
+      await this.credentialStore.clear();
     }
   }
 

--- a/packages/ui/src/android-cloud/android-cloud-client.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.ts
@@ -1,0 +1,350 @@
+/**
+ * Small, Cloud-only transport used by the Play-safe Android consumer shell.
+ *
+ * This module deliberately has no dependency on ElizaClient, AppContext, the
+ * desktop/native-agent transports, or any plugin registry. Every request is
+ * pinned to the canonical Eliza Cloud API or to an HTTPS runtime authority
+ * returned by that API.
+ */
+
+import {
+  clearStoredStewardToken,
+  readStoredStewardToken,
+  writeStoredStewardToken,
+} from "@elizaos/shared/steward-session-client";
+import {
+  DEFAULT_DIRECT_CLOUD_APP_BASE_URL,
+  resolveCanonicalDirectCloudApiBase,
+} from "../api/direct-cloud-endpoints";
+
+const SESSION_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const MANAGED_RUNTIME_HOST_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.cloud(?:-staging)?\.eliza\.app$/i;
+
+export interface AndroidCloudIdentity {
+  id: string;
+  displayName: string;
+}
+
+export interface AndroidCloudSession {
+  identity: AndroidCloudIdentity;
+  token: string;
+  chatApiBase: string;
+}
+
+export interface AndroidCloudTranscriptMessage {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+}
+
+export interface AndroidCloudLoginAttempt {
+  sessionId: string;
+  browserUrl: string;
+}
+
+export type AndroidCloudLoginPoll =
+  | { status: "pending" }
+  | { status: "expired"; error: string }
+  | { status: "authenticated"; token: string };
+
+export interface AndroidCloudClientOptions {
+  cloudApiBase?: string;
+  fetchImpl?: typeof fetch;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function record(value: unknown): JsonRecord | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : null;
+}
+
+function stringField(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+async function responseJson(response: Response): Promise<JsonRecord> {
+  return record(await response.json().catch(() => null)) ?? {};
+}
+
+function responseError(body: JsonRecord, fallback: string): string {
+  return stringField(body.error) ?? stringField(body.message) ?? fallback;
+}
+
+/** Accept only the official control plane or an Eliza-managed runtime host. */
+export function resolveAndroidCloudChatAuthority(
+  value: unknown,
+  expectedIdentityId?: string,
+): string {
+  const candidate = stringField(value);
+  if (!candidate) throw new Error("Eliza Cloud returned no chat authority.");
+  try {
+    const url = new URL(candidate);
+    const hostname = url.hostname.toLowerCase();
+    const expectedSharedPath = expectedIdentityId
+      ? `/api/v1/eliza/agents/${encodeURIComponent(expectedIdentityId)}`
+      : null;
+    const hasCleanAuthority =
+      !url.username && !url.password && !url.port && !url.search && !url.hash;
+    const isOfficialSharedAdapter =
+      hasCleanAuthority &&
+      resolveCanonicalDirectCloudApiBase(candidate) === url.origin &&
+      expectedSharedPath !== null &&
+      url.pathname.replace(/\/+$/, "") === expectedSharedPath;
+    const isManagedRuntime =
+      hasCleanAuthority &&
+      MANAGED_RUNTIME_HOST_PATTERN.test(hostname) &&
+      (url.pathname === "" || url.pathname === "/");
+    if (
+      url.protocol !== "https:" ||
+      (!isOfficialSharedAdapter && !isManagedRuntime)
+    ) {
+      throw new Error("Eliza Cloud returned an untrusted chat authority.");
+    }
+    return isOfficialSharedAdapter
+      ? `${url.origin}${expectedSharedPath}`
+      : url.origin;
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("untrusted")) {
+      throw error;
+    }
+    throw new Error("Eliza Cloud returned an invalid chat authority.");
+  }
+}
+
+export class AndroidCloudClient {
+  readonly apiBase: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: AndroidCloudClientOptions = {}) {
+    this.apiBase = resolveCanonicalDirectCloudApiBase(options.cloudApiBase);
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  readToken(): string | null {
+    return readStoredStewardToken()?.trim() || null;
+  }
+
+  async restoreSession(): Promise<AndroidCloudSession | null> {
+    const token = this.readToken();
+    if (!token) return null;
+    const response = await this.fetchImpl(
+      `${this.apiBase}/api/v1/eliza/personal`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+    if (response.status === 401) {
+      clearStoredStewardToken();
+      return null;
+    }
+    if (!response.ok) {
+      throw new Error(
+        `Unable to verify your Eliza session (${response.status}).`,
+      );
+    }
+    const body = await responseJson(response);
+    const identityBody =
+      record(record(body.data)?.identity) ?? record(body.identity);
+    const id = stringField(identityBody?.id);
+    if (!id)
+      throw new Error("Eliza Cloud returned an invalid account session.");
+    const displayName =
+      stringField(identityBody?.displayName) ??
+      stringField(identityBody?.name) ??
+      "Eliza user";
+    const runtime = stringField(identityBody?.runtime)?.toLowerCase();
+    const declaredApiBase = stringField(identityBody?.apiBase);
+    const chatApiBase =
+      runtime === "shared"
+        ? resolveAndroidCloudChatAuthority(
+            `${this.apiBase}/api/v1/eliza/agents/${encodeURIComponent(id)}`,
+            id,
+          )
+        : runtime === "dedicated" && declaredApiBase
+          ? resolveAndroidCloudChatAuthority(declaredApiBase, id)
+          : (() => {
+              throw new Error(
+                "Eliza Cloud returned an invalid runtime binding.",
+              );
+            })();
+    return { identity: { id, displayName }, token, chatApiBase };
+  }
+
+  async beginLogin(): Promise<AndroidCloudLoginAttempt> {
+    const requestId = globalThis.crypto?.randomUUID?.();
+    if (!requestId || !SESSION_ID_PATTERN.test(requestId)) {
+      throw new Error("Secure sign-in is unavailable on this device.");
+    }
+    const response = await this.fetchImpl(
+      `${this.apiBase}/api/auth/cli-session`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId: requestId }),
+      },
+    );
+    const body = await responseJson(response);
+    if (!response.ok) {
+      throw new Error(
+        responseError(body, `Unable to start sign-in (${response.status}).`),
+      );
+    }
+    const sessionId = stringField(body.sessionId);
+    if (!sessionId || !SESSION_ID_PATTERN.test(sessionId)) {
+      throw new Error("Eliza Cloud returned an invalid sign-in session.");
+    }
+    const url = new URL("/auth/cli-login", DEFAULT_DIRECT_CLOUD_APP_BASE_URL);
+    url.searchParams.set("session", sessionId);
+    return { sessionId, browserUrl: url.toString() };
+  }
+
+  async pollLogin(sessionId: string): Promise<AndroidCloudLoginPoll> {
+    if (!SESSION_ID_PATTERN.test(sessionId)) {
+      throw new Error("The sign-in session is invalid.");
+    }
+    const response = await this.fetchImpl(
+      `${this.apiBase}/api/auth/cli-session/${encodeURIComponent(sessionId)}`,
+    );
+    if (response.status === 404) {
+      return { status: "expired", error: "Sign-in expired. Please try again." };
+    }
+    const body = await responseJson(response);
+    if (!response.ok) {
+      throw new Error(
+        responseError(body, `Unable to finish sign-in (${response.status}).`),
+      );
+    }
+    const data = record(body.data) ?? body;
+    const status = stringField(data.status)?.toLowerCase();
+    if (status === "authenticated") {
+      const token =
+        stringField(data.token) ??
+        stringField(data.apiKey) ??
+        stringField(data.accessToken) ??
+        stringField(data.access_token);
+      if (!token) throw new Error("Sign-in completed without a session token.");
+      writeStoredStewardToken(token);
+      return { status: "authenticated", token };
+    }
+    if (status === "expired" || status === "error") {
+      return {
+        status: "expired",
+        error: responseError(data, "Sign-in expired. Please try again."),
+      };
+    }
+    return { status: "pending" };
+  }
+
+  async sendChat(
+    session: AndroidCloudSession,
+    conversationId: string,
+    text: string,
+    onText: (text: string) => void,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    if (!conversationId.trim())
+      throw new Error("A conversation is required before sending.");
+    const response = await this.fetchImpl(
+      `${session.chatApiBase}/api/conversations/${encodeURIComponent(conversationId)}/messages`,
+      {
+        method: "POST",
+        signal,
+        headers: {
+          Authorization: `Bearer ${session.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          text,
+          channelType: "DM",
+        }),
+      },
+    );
+    if (!response.ok) {
+      const body = await responseJson(response);
+      throw new Error(
+        responseError(body, `Eliza could not answer (${response.status}).`),
+      );
+    }
+    const body = await responseJson(response);
+    const reply = stringField(body.text) ?? "";
+    if (!reply) throw new Error("Eliza finished without a reply.");
+    onText(reply);
+    return reply;
+  }
+
+  async createConversation(session: AndroidCloudSession): Promise<string> {
+    const response = await this.fetchImpl(
+      `${session.chatApiBase}/api/conversations`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${session.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ title: "Android chat" }),
+      },
+    );
+    const body = await responseJson(response);
+    if (!response.ok) {
+      throw new Error(
+        responseError(
+          body,
+          `Unable to open a conversation (${response.status}).`,
+        ),
+      );
+    }
+    const conversation = record(body.conversation);
+    const id = stringField(conversation?.id);
+    if (!id) throw new Error("Eliza Cloud returned an invalid conversation.");
+    return id;
+  }
+
+  async signOut(): Promise<void> {
+    const token = this.readToken();
+    try {
+      if (token) {
+        await this.fetchImpl(`${this.apiBase}/api/auth/logout`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+        });
+      }
+    } catch {
+      // Remote logout is best-effort. Local credential removal is authoritative
+      // for this device and must still complete while offline.
+    } finally {
+      clearStoredStewardToken();
+    }
+  }
+
+  async getConversationMessages(
+    session: AndroidCloudSession,
+    conversationId: string,
+  ): Promise<AndroidCloudTranscriptMessage[]> {
+    const response = await this.fetchImpl(
+      `${session.chatApiBase}/api/conversations/${encodeURIComponent(conversationId)}/messages`,
+      { headers: { Authorization: `Bearer ${session.token}` } },
+    );
+    const body = await responseJson(response);
+    if (!response.ok) {
+      throw new Error(
+        responseError(
+          body,
+          `Unable to restore the conversation (${response.status}).`,
+        ),
+      );
+    }
+    const messages = Array.isArray(body.messages) ? body.messages : [];
+    return messages.flatMap((value): AndroidCloudTranscriptMessage[] => {
+      const item = record(value);
+      const id = stringField(item?.id);
+      const role = stringField(item?.role);
+      const text = stringField(item?.text);
+      if (!id || (role !== "user" && role !== "assistant") || !text) return [];
+      return [{ id, role, text }];
+    });
+  }
+}

--- a/packages/ui/src/android-cloud/android-cloud-client.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.ts
@@ -85,7 +85,7 @@ async function responseJson(response: Response): Promise<JsonRecord> {
   }
   const body = record(parsed);
   if (!body) {
-    throw new Error("Eliza Cloud returned a response that could not be read.");
+    throw new Error("Eliza Cloud returned an invalid JSON response.");
   }
   return body;
 }
@@ -128,6 +128,8 @@ export function resolveAndroidCloudChatAuthority(
       ? `${url.origin}${expectedSharedPath}`
       : url.origin;
   } catch (error) {
+    // error-policy:J3 untrusted Cloud authority input becomes an explicit
+    // invalid result instead of escaping URL parser details to the caller.
     if (error instanceof Error && error.message.includes("untrusted")) {
       throw error;
     }
@@ -339,6 +341,8 @@ export class AndroidCloudClient {
         });
       }
     } catch {
+      // error-policy:J6 remote logout is best-effort teardown; the authoritative
+      // local credential removal is awaited in the finally block below.
       // Remote logout is best-effort. Local credential removal is authoritative
       // for this device and must still complete while offline.
     } finally {

--- a/packages/ui/src/android-cloud/android-cloud-client.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.ts
@@ -83,7 +83,11 @@ async function responseJson(response: Response): Promise<JsonRecord> {
       cause: error,
     });
   }
-  return record(parsed) ?? {};
+  const body = record(parsed);
+  if (!body) {
+    throw new Error("Eliza Cloud returned a response that could not be read.");
+  }
+  return body;
 }
 
 function responseError(body: JsonRecord, fallback: string): string {

--- a/packages/ui/src/android-cloud/android-cloud-client.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.ts
@@ -13,7 +13,7 @@ import {
   writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
 import {
-  DEFAULT_DIRECT_CLOUD_APP_BASE_URL,
+  directCloudAppBaseForApi,
   resolveCanonicalDirectCloudApiBase,
 } from "../api/direct-cloud-endpoints";
 
@@ -67,7 +67,23 @@ function stringField(value: unknown): string | null {
 }
 
 async function responseJson(response: Response): Promise<JsonRecord> {
-  return record(await response.json().catch(() => null)) ?? {};
+  const text = await response.text();
+  // An empty body is legitimate (204, and some error responses); a body that
+  // is present but unparsable is a broken endpoint. Collapsing both to {} made
+  // a malformed 200 look like "no session yet", so pollLogin spun for its full
+  // ten minutes instead of reporting that Cloud returned something unusable.
+  if (text.trim().length === 0) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    // error-policy:J3 untrusted response body — an explicit failure, never a
+    // fabricated empty record that reads as a valid-but-pending answer.
+    throw new Error("Eliza Cloud returned a response that could not be read.", {
+      cause: error,
+    });
+  }
+  return record(parsed) ?? {};
 }
 
 function responseError(body: JsonRecord, fallback: string): string {
@@ -197,7 +213,13 @@ export class AndroidCloudClient {
     if (!sessionId || !SESSION_ID_PATTERN.test(sessionId)) {
       throw new Error("Eliza Cloud returned an invalid sign-in session.");
     }
-    const url = new URL("/auth/cli-login", DEFAULT_DIRECT_CLOUD_APP_BASE_URL);
+    // Pair the login origin with the API the session was minted against: a
+    // staging build must not send users to the production login, where the
+    // session it just created does not exist.
+    const url = new URL(
+      "/auth/cli-login",
+      directCloudAppBaseForApi(this.apiBase),
+    );
     url.searchParams.set("session", sessionId);
     return { sessionId, browserUrl: url.toString() };
   }

--- a/packages/ui/src/api/direct-cloud-endpoints.ts
+++ b/packages/ui/src/api/direct-cloud-endpoints.ts
@@ -22,6 +22,18 @@ export const STAGING_DIRECT_CLOUD_APP_BASE_URL =
 export const STAGING_DIRECT_CLOUD_API_BASE_URL =
   ELIZA_DOMAIN_CONTRACTS.staging.cloudApiOrigin;
 
+/**
+ * The app origin that pairs with a resolved canonical API origin. Sign-in has
+ * to land on the app for the environment the session was minted against — a
+ * staging build sending users to the production login mints a session on
+ * staging that production cannot claim, so the flow fails with no useful error.
+ */
+export function directCloudAppBaseForApi(apiBaseUrl: string): string {
+  return apiBaseUrl === STAGING_DIRECT_CLOUD_API_BASE_URL
+    ? STAGING_DIRECT_CLOUD_APP_BASE_URL
+    : DEFAULT_DIRECT_CLOUD_APP_BASE_URL;
+}
+
 export const DIRECT_ELIZA_CLOUD_API_BY_HOST = new Map([
   ["api.eliza.app", DEFAULT_DIRECT_CLOUD_API_BASE_URL],
   ["eliza.app", DEFAULT_DIRECT_CLOUD_API_BASE_URL],

--- a/packages/ui/src/api/direct-cloud-endpoints.ts
+++ b/packages/ui/src/api/direct-cloud-endpoints.ts
@@ -158,3 +158,24 @@ export function resolveDirectCloudAuthApiBase(cloudBase: string): string {
     return normalized;
   }
 }
+
+/**
+ * Resolve the fixed API authority used by store-distributed Cloud shells.
+ * Unlike the general resolver above, an unknown or malformed configured host
+ * is not preserved: store clients must never inherit an owner-selected,
+ * sideload, or restored authority.
+ */
+export function resolveCanonicalDirectCloudApiBase(
+  cloudBase: string | null | undefined,
+): string {
+  const normalized = cloudBase?.trim().replace(/\/+$/, "") ?? "";
+  try {
+    const host = new URL(normalized).hostname.toLowerCase();
+    return (
+      DIRECT_ELIZA_CLOUD_API_BY_HOST.get(host) ??
+      DEFAULT_DIRECT_CLOUD_API_BASE_URL
+    );
+  } catch {
+    return DEFAULT_DIRECT_CLOUD_API_BASE_URL;
+  }
+}

--- a/packages/ui/src/chat/useSlashCommandController.catalog.test.ts
+++ b/packages/ui/src/chat/useSlashCommandController.catalog.test.ts
@@ -37,6 +37,7 @@ const { listCommands, listCustomActions } = vi.hoisted(() => ({
 
 vi.mock("../api", () => ({
   client: {
+    getBaseUrl: () => "http://localhost:2138",
     listCommands: (surface?: string, init?: RequestInit) =>
       listCommands(surface, init),
     listCustomActions: (init?: RequestInit) => listCustomActions(init),

--- a/packages/ui/src/hooks/useProtectedAgentProbesEnabled.test.tsx
+++ b/packages/ui/src/hooks/useProtectedAgentProbesEnabled.test.tsx
@@ -181,6 +181,23 @@ describe("protectedAgentProbesEnabled (pure gate — #16242)", () => {
       false,
     );
   });
+
+  it("blocks a native synthetic origin until a real agent authority exists", () => {
+    expect(
+      protectedAgentProbesEnabled(false, "https://localhost", "", true),
+    ).toBe(false);
+    expect(
+      protectedAgentProbesEnabled(true, "https://localhost", "", true),
+    ).toBe(false);
+    expect(
+      protectedAgentProbesEnabled(
+        true,
+        "https://localhost",
+        "https://agent.example.com",
+        true,
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("shouldProbeExistingLocalInstall (startup restore — #16242)", () => {

--- a/packages/ui/src/hooks/useProtectedAgentProbesEnabled.ts
+++ b/packages/ui/src/hooks/useProtectedAgentProbesEnabled.ts
@@ -15,6 +15,7 @@
  * `notifications-boot`, `useWeather`, `useRuntimeMode`, `useSlashCommandController`.
  */
 
+import { Capacitor } from "@capacitor/core";
 import { client } from "../api";
 import { isLimitedCloudAgentApiBase } from "../api/app-shell-capabilities";
 import { isElizaCloudControlPlaneAgentlessBase } from "../utils/cloud-agent-base";
@@ -29,12 +30,17 @@ export function protectedAgentProbesEnabled(
   authenticated: boolean,
   origin: string | null | undefined,
   agentBase?: string | null,
+  nativeRuntime = false,
 ): boolean {
   // Direct/shared Cloud agent adapters intentionally expose chat, status, and
   // history—not the full app-shell route family. Authentication cannot make
   // commands, custom actions, runtime mode, weather/location, or notification
   // routes appear, so probing them only creates 10-second startup contention.
   if (isLimitedCloudAgentApiBase(agentBase)) return false;
+  // Capacitor serves bundled assets from a synthetic https://localhost origin,
+  // not an app-shell API server. With no selected authority, `/api/*` would
+  // just return the renderer HTML (and cannot become valid after auth alone).
+  if (nativeRuntime && !agentBase?.trim()) return false;
   if (authenticated) return true;
   return !isElizaCloudControlPlaneAgentlessBase(origin ?? "");
 }
@@ -45,5 +51,6 @@ export function useProtectedAgentProbesEnabled(): boolean {
     authenticated,
     typeof window !== "undefined" ? window.location.origin : null,
     client.getBaseUrl(),
+    Capacitor.isNativePlatform(),
   );
 }

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -11,6 +11,8 @@
  * the live WS binding, and re-hydrates fresh for the new authority. A refresh
  * that resolves to the same authority is a no-op.
  */
+
+import { Capacitor } from "@capacitor/core";
 import {
   type AgentNotification,
   DEFAULT_NOTIFICATION_CATEGORY,
@@ -124,7 +126,15 @@ let notificationEventUnsub: (() => void) | null = null;
  */
 function notificationProbesEnabled(): boolean {
   const origin = typeof window !== "undefined" ? window.location.origin : null;
-  if (!protectedAgentProbesEnabled(isAuthenticatedNow(), origin)) return false;
+  if (
+    !protectedAgentProbesEnabled(
+      isAuthenticatedNow(),
+      origin,
+      undefined,
+      Capacitor.isNativePlatform() && !client.getBaseUrl().trim(),
+    )
+  )
+    return false;
 
   // Shared Cloud agents expose the conversation REST adapter, not the full
   // standalone-agent inbox API. A bare Cloud base has no selected agent at all.

--- a/packages/ui/src/state/useAppLifecycleEvents.test.tsx
+++ b/packages/ui/src/state/useAppLifecycleEvents.test.tsx
@@ -47,6 +47,7 @@ const mocks = vi.hoisted(() => ({
         status: 200,
       }),
   ),
+  androidCloudBuild: vi.fn(() => false),
 }));
 
 vi.mock("../api", () => ({
@@ -55,6 +56,10 @@ vi.mock("../api", () => ({
 
 vi.mock("../api/csrf-client", () => ({
   fetchWithCsrf: mocks.fetchCurrentView,
+}));
+
+vi.mock("../platform/android-runtime", () => ({
+  isAndroidCloudBuild: mocks.androidCloudBuild,
 }));
 
 const observedNavigations: NavigateViewDetail[] = [];
@@ -133,6 +138,7 @@ describe("useAppLifecycleEvents", () => {
     mocks.client.fetch.mockClear();
     mocks.client.getBaseUrl.mockReturnValue("http://127.0.0.1:31337");
     mocks.fetchCurrentView.mockClear();
+    mocks.androidCloudBuild.mockReturnValue(false);
     observedNavigations.length = 0;
     window.addEventListener(NAVIGATE_VIEW_EVENT, recordNavigation);
     window.localStorage.clear();
@@ -254,6 +260,21 @@ describe("useAppLifecycleEvents", () => {
 
     expect(mocks.client.fetch).not.toHaveBeenCalled();
     expect(mocks.client.resetConnection).not.toHaveBeenCalled();
+    expect(loadConversationMessages).not.toHaveBeenCalled();
+  });
+
+  it("does not run agent-runtime resume recovery in the Android Cloud shell", () => {
+    mocks.androidCloudBuild.mockReturnValue(true);
+    const { loadConversationMessages } = setup({
+      activeId: "conv-android-cloud",
+    });
+
+    dispatchResume();
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+
+    expect(mocks.client.fetch).not.toHaveBeenCalled();
+    expect(mocks.client.resetConnection).not.toHaveBeenCalled();
+    expect(mocks.fetchCurrentView).not.toHaveBeenCalled();
     expect(loadConversationMessages).not.toHaveBeenCalled();
   });
 

--- a/packages/ui/src/state/useAppLifecycleEvents.ts
+++ b/packages/ui/src/state/useAppLifecycleEvents.ts
@@ -32,6 +32,7 @@ import type { MutableRefObject } from "react";
 import { useEffect, useRef } from "react";
 import { type ConversationMessage, client } from "../api";
 import { APP_PAUSE_EVENT, APP_RESUME_EVENT } from "../events";
+import { isAndroidCloudBuild } from "../platform/android-runtime";
 import { shellLocalStorage } from "../surface-realm-channel";
 import { isElizaCloudControlPlaneAgentlessBase } from "../utils/cloud-agent-base";
 import { recoverMissedCurrentView } from "../view-action-handoff";
@@ -185,9 +186,9 @@ export function useAppLifecycleEvents({
     // One resume burst runs at most one reconnect and one tail reload.
     const runResume = (): void => {
       resumeTimer = null;
-      const skipAgentRuntimeResume = isElizaCloudControlPlaneAgentlessBase(
-        client.getBaseUrl(),
-      );
+      const skipAgentRuntimeResume =
+        isAndroidCloudBuild() ||
+        isElizaCloudControlPlaneAgentlessBase(client.getBaseUrl());
 
       if (!skipAgentRuntimeResume) {
         void probeAgentHealth();

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
@@ -81,6 +81,7 @@ const h = vi.hoisted(() => {
     dispatchStatus: vi.fn(),
     capacitorGetPlatform: vi.fn(() => "web"),
     capacitorIsNative: vi.fn(() => false),
+    capacitorIsPluginAvailable: vi.fn(() => true),
     mobile,
   };
 });
@@ -170,6 +171,7 @@ vi.mock("@capacitor/core", () => ({
   Capacitor: {
     getPlatform: h.capacitorGetPlatform,
     isNativePlatform: h.capacitorIsNative,
+    isPluginAvailable: h.capacitorIsPluginAvailable,
   },
 }));
 
@@ -269,6 +271,7 @@ describe("startLifeOpsActivitySignalCapture", () => {
     h.authSubscribers.clear();
     h.capacitorGetPlatform.mockReturnValue("web");
     h.capacitorIsNative.mockReturnValue(false);
+    h.capacitorIsPluginAvailable.mockReturnValue(true);
     h.mobile.checkPermissions.mockResolvedValue({ status: "granted" });
     h.mobile.addListener.mockImplementation(
       async (_event: string, cb: (signal: unknown) => void) => {
@@ -726,9 +729,7 @@ describe("startLifeOpsActivitySignalCapture", () => {
 
   it("stands down when the native MobileSignals plugin is intentionally absent", async () => {
     mockNativeMobile();
-    h.mobile.checkPermissions.mockRejectedValue(
-      new Error('"MobileSignals" plugin is not implemented on android'),
-    );
+    h.capacitorIsPluginAvailable.mockReturnValue(false);
 
     stop = startLifeOpsActivitySignalCapture(true);
     await settle();
@@ -736,6 +737,7 @@ describe("startLifeOpsActivitySignalCapture", () => {
     expect(h.dispatchStatus).not.toHaveBeenCalledWith(
       expect.objectContaining({ status: "capture_error" }),
     );
+    expect(h.mobile.checkPermissions).not.toHaveBeenCalled();
     expect(h.mobile.startMonitoring).not.toHaveBeenCalled();
   });
 

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.test.ts
@@ -724,6 +724,21 @@ describe("startLifeOpsActivitySignalCapture", () => {
     );
   });
 
+  it("stands down when the native MobileSignals plugin is intentionally absent", async () => {
+    mockNativeMobile();
+    h.mobile.checkPermissions.mockRejectedValue(
+      new Error('"MobileSignals" plugin is not implemented on android'),
+    );
+
+    stop = startLifeOpsActivitySignalCapture(true);
+    await settle();
+
+    expect(h.dispatchStatus).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "capture_error" }),
+    );
+    expect(h.mobile.startMonitoring).not.toHaveBeenCalled();
+  });
+
   it("surfaces an unexpected (non-transport) status-probe failure instead of reading it as not-ready", async () => {
     h.getStatus.mockRejectedValue(new TypeError("status DTO shape broken"));
 

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
@@ -312,6 +312,12 @@ export function startLifeOpsActivitySignalCapture(
   const isExpectedTransientError = (error: unknown): boolean =>
     isApiError(error) && (error.kind === "network" || error.kind === "timeout");
 
+  const isUnavailableNativePluginError = (error: unknown): boolean =>
+    error instanceof Error &&
+    /["']?MobileSignals["']? plugin is not implemented on (?:android|ios)/i.test(
+      error.message,
+    );
+
   // A 401/403 is the designed signed-out state, not a capture defect. It also
   // means the canonical snapshot was stale relative to the protected request,
   // so fail closed and wait for a later auth publication instead of polling.
@@ -343,6 +349,10 @@ export function startLifeOpsActivitySignalCapture(
       return;
     }
     if (isRuntimeUnavailableError(error)) {
+      standDownActivitySignals();
+      return;
+    }
+    if (isUnavailableNativePluginError(error)) {
       standDownActivitySignals();
       return;
     }

--- a/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/activity-signals-capture.ts
@@ -312,12 +312,6 @@ export function startLifeOpsActivitySignalCapture(
   const isExpectedTransientError = (error: unknown): boolean =>
     isApiError(error) && (error.kind === "network" || error.kind === "timeout");
 
-  const isUnavailableNativePluginError = (error: unknown): boolean =>
-    error instanceof Error &&
-    /["']?MobileSignals["']? plugin is not implemented on (?:android|ios)/i.test(
-      error.message,
-    );
-
   // A 401/403 is the designed signed-out state, not a capture defect. It also
   // means the canonical snapshot was stale relative to the protected request,
   // so fail closed and wait for a later auth publication instead of polling.
@@ -349,10 +343,6 @@ export function startLifeOpsActivitySignalCapture(
       return;
     }
     if (isRuntimeUnavailableError(error)) {
-      standDownActivitySignals();
-      return;
-    }
-    if (isUnavailableNativePluginError(error)) {
       standDownActivitySignals();
       return;
     }
@@ -569,7 +559,11 @@ export function startLifeOpsActivitySignalCapture(
   };
 
   const mobileSignals =
-    isNativeCapacitorRuntime() && !isElectrobunRuntime() ? MobileSignals : null;
+    isNativeCapacitorRuntime() &&
+    !isElectrobunRuntime() &&
+    Capacitor.isPluginAvailable("MobileSignals")
+      ? MobileSignals
+      : null;
   let mobileSignalsHandle: { remove: () => Promise<void> } | null = null;
   let mobileSignalsStarted = false;
   let mobileSignalsStarting = false;


### PR DESCRIPTION
# Relates to

Refs #23272. Account deletion source sequencing landed through #22854, while the durable lifecycle and protected acceptance work remains tracked in #23098; this PR does not claim those operational gates.

# What this changes

- Adds a dedicated Android Play Cloud entry and shell rather than packaging the local-runtime graph.
- Pins restored Android Cloud API/token state to canonical managed Cloud authority.
- Stores the bearer through Android Keystore AES-GCM and removes plaintext fallback.
- Excludes restricted/local-runtime features from the source graph and uses fail-only bundle/manifest/DEX/native-library audits.
- Preserves separate direct/sideload Android runtime lanes.
- Rejects malformed and valid non-object Cloud JSON instead of fabricating a pending response.
- Removes the optimistic assistant placeholder when the user stops an in-flight send.

# Exact source state

<!-- evidence-head:514343a7bd4d56f58c7d2d1e771d98f6796be3c7 -->

- Head: `514343a7bd4d56f58c7d2d1e771d98f6796be3c7`
- Tree: `392fbf8a55d7f241bc7111b9756e7a4b6b343d8e`
- Rebased onto `develop@5379dd64d9906e46d16886fb467f77f686be2f37`.
- The final 28-commit series is patch-identical across the last develop refresh under `git range-diff`.
- Android Cloud client Vitest: `19/19` PASS; Play renderer source plus executable credential-migration, persistence, and deep-link behavior: `8/8` PASS.
- Android build/policy matrix: `134` PASS, `8` fixture-dependent skips, `0` failures, `435` assertions across the six focused build/audit suites.\n- Exact final-head Android Cloud Vite build: PASS (`963` modules); the dedicated `/src/main.android-cloud.tsx` graph resolved and the fail-only emitted-bundle audit completed without mutation.
- Biome: all `10` repaired supported files PASS.
- `git diff --check`: PASS.
- Exact-head repair restored the dropped Play renderer entry, injected Keystore credential adapter, generated AES-GCM and native voice plugins, fail-only emitted-bundle policy, and executable storage/deep-link coverage.

# Protected acceptance holds

This PR is READY for review. Do not merge until the following protected acceptance is complete:

1. Build and install this exact head as a signed Android artifact and bind the installed identity to `514343a7...`.
2. Exercise disposable-account sign-in, chat, microphone/TTS, restore, revocation, and deletion sequencing on a supported physical device.
3. Publish the Play declaration/internal-test receipt, screenshots, MP4, Android frontend/network logs, Cloud/deletion backend logs, accessibility/OCR review, and affected app audit.
4. Confirm #23098 lifecycle acceptance and obtain independent exact-head security/product approval.

<!-- evidence-row:before-screenshots -->
- [ ] Exact-head installed-device before captures.
<!-- evidence-row:after-screenshots -->
- [ ] Exact-head installed-device after captures.
<!-- evidence-row:walkthrough-video -->
- [ ] Disposable-account sign-in/chat/voice/restore/revocation/deletion walkthrough on a supported physical device.
<!-- evidence-row:backend-logs -->
- [ ] Exact-head Cloud/deletion backend logs.
<!-- evidence-row:frontend-logs -->
- [ ] Exact-head Android frontend/network logs.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model behavior change.
<!-- evidence-row:domain-artifacts -->
- [ ] Current signed reproducible AAB, Play declarations/internal-test receipt, and lifecycle reconciliation.
<!-- evidence-row:ocr-review -->
- [ ] Exact-head screenshots/video, accessibility/OCR, and app-audit manual review.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

— [root/repair_23357_entry]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@31679563771bac5f3f1b18d9cf6eafc99c3f71ae:packages/skills/skills/contribute-to-eliza"} -->