### PR TITLE
fix(core): reject invalid Markdown chunk limits

### DIFF
--- a/packages/core/src/markdown/chunk.chunkText.test.ts
+++ b/packages/core/src/markdown/chunk.chunkText.test.ts
@@ -9,11 +9,9 @@ import { describe, expect, it } from "vitest";
 import { chunkText } from "./chunk.ts";
 
 describe("chunkText", () => {
-	it("returns [] for empty and a single chunk within-limit / non-positive limit", () => {
+	it("returns [] for empty and a single chunk within the limit", () => {
 		expect(chunkText("", 10)).toEqual([]);
 		expect(chunkText("short", 10)).toEqual(["short"]);
-		expect(chunkText("anything", 0)).toEqual(["anything"]);
-		expect(chunkText("anything", -5)).toEqual(["anything"]);
 	});
 
 	it("splits long text into chunks each within the limit", () => {

--- a/packages/core/src/markdown/chunk.limit.test.ts
+++ b/packages/core/src/markdown/chunk.limit.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Public Markdown chunkers reject invalid resource limits before fast paths
+ * and preserve forward progress and UTF-16 integrity for valid tiny limits.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ElizaError } from "../errors.ts";
+import { MARKDOWN_CHUNK_LIMIT_INVALID } from "./chunk.ts";
+import {
+	chunkByParagraph,
+	chunkMarkdownIR,
+	chunkMarkdownText,
+	chunkText,
+	type MarkdownIR,
+} from "./index.ts";
+
+const CHUNKERS = [
+	{
+		name: "chunkText",
+		run: (text: string, limit: number) => chunkText(text, limit),
+	},
+	{
+		name: "chunkMarkdownText",
+		run: (text: string, limit: number) => chunkMarkdownText(text, limit),
+	},
+	{
+		name: "chunkByParagraph",
+		run: (text: string, limit: number) => chunkByParagraph(text, limit),
+	},
+	{
+		name: "chunkMarkdownIR",
+		run: (text: string, limit: number) =>
+			chunkMarkdownIR({ text, styles: [], links: [] }, limit),
+	},
+] as const;
+
+const INVALID_LIMITS = [
+	0,
+	-1,
+	0.5,
+	1.5,
+	Number.NaN,
+	Number.POSITIVE_INFINITY,
+	Number.NEGATIVE_INFINITY,
+	Number.MAX_SAFE_INTEGER + 1,
+] as const;
+
+describe("Markdown chunk limit validation", () => {
+	for (const chunker of CHUNKERS) {
+		it(`${chunker.name} rejects every invalid limit before empty and within-limit fast paths`, () => {
+			for (const text of ["", "short"]) {
+				for (const limit of INVALID_LIMITS) {
+					let thrown: unknown;
+					try {
+						chunker.run(text, limit);
+					} catch (error) {
+						thrown = error;
+					}
+					expect(thrown).toBeInstanceOf(ElizaError);
+					expect((thrown as ElizaError).code).toBe(
+						MARKDOWN_CHUNK_LIMIT_INVALID,
+					);
+					expect(
+						JSON.stringify((thrown as ElizaError).context).length,
+					).toBeLessThan(80);
+				}
+			}
+		});
+	}
+
+	it("preserves reconstruction, progress, and astral scalars at limits 1 and 2", () => {
+		const input = "😀x😀y";
+		for (const limit of [1, 2]) {
+			for (const chunker of [chunkText, chunkMarkdownText]) {
+				const chunks = chunker(input, limit);
+				expect(chunks.length).toBeGreaterThan(0);
+				expect(chunks.every((chunk) => chunk.length > 0)).toBe(true);
+				expect(chunks.join("")).toBe(input);
+				for (const chunk of chunks) {
+					expect(isWellFormed(chunk)).toBe(true);
+					expect(chunk.length).toBeLessThanOrEqual(limit === 1 ? 2 : limit);
+				}
+			}
+		}
+	});
+
+	it("keeps the public IR and fenced-markdown paths progressing at tiny limits", () => {
+		const ir: MarkdownIR = {
+			text: "😀abc",
+			styles: [{ start: 0, end: 5, style: "bold" }],
+			links: [],
+		};
+		const irChunks = chunkMarkdownIR(ir, 1);
+		expect(irChunks.map((chunk) => chunk.text).join("")).toBe(ir.text);
+		expect(irChunks.every((chunk) => chunk.text.length > 0)).toBe(true);
+
+		const fenced = chunkMarkdownText("```\n😀abc\n```", 1);
+		expect(fenced.length).toBeGreaterThan(0);
+		expect(fenced.every((chunk) => chunk.length > 0)).toBe(true);
+		expect(fenced.every(isWellFormed)).toBe(true);
+	});
+});
+
+function isWellFormed(value: string): boolean {
+	for (let index = 0; index < value.length; index += 1) {
+		const code = value.charCodeAt(index);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			const next = value.charCodeAt(index + 1);
+			if (!(next >= 0xdc00 && next <= 0xdfff)) {
+				return false;
+			}
+			index += 1;
+		} else if (code >= 0xdc00 && code <= 0xdfff) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/packages/core/src/markdown/chunk.ts
+++ b/packages/core/src/markdown/chunk.ts
@@ -1,10 +1,29 @@
 /** Splits Markdown text at fence, paragraph, and word-safe boundaries. */
 
+import { ElizaError } from "../errors.js";
 import {
 	findFenceSpanAt,
 	isSafeFenceBreak,
 	parseFenceSpans,
 } from "./fences.js";
+
+/** Stable classification for invalid public Markdown chunk limits. */
+export const MARKDOWN_CHUNK_LIMIT_INVALID = "MARKDOWN_CHUNK_LIMIT_INVALID";
+
+/**
+ * Reject limits that cannot guarantee finite forward progress before any
+ * empty/within-limit fast path can hide the invalid caller input.
+ */
+export function assertValidMarkdownChunkLimit(limit: number): void {
+	if (Number.isSafeInteger(limit) && limit > 0) {
+		return;
+	}
+
+	throw new ElizaError("Markdown chunk limit must be a positive safe integer", {
+		code: MARKDOWN_CHUNK_LIMIT_INVALID,
+		context: { limit: describeInvalidLimit(limit) },
+	});
+}
 
 /**
  * Split text into chunks of maximum length.
@@ -19,11 +38,9 @@ import {
  * @returns Array of text chunks
  */
 export function chunkText(text: string, limit: number): string[] {
+	assertValidMarkdownChunkLimit(limit);
 	if (!text) {
 		return [];
-	}
-	if (limit <= 0) {
-		return [text];
 	}
 	if (text.length <= limit) {
 		return [text];
@@ -88,11 +105,9 @@ export function chunkByParagraph(
 	limit: number,
 	opts?: { splitLongParagraphs?: boolean },
 ): string[] {
+	assertValidMarkdownChunkLimit(limit);
 	if (!text) {
 		return [];
-	}
-	if (limit <= 0) {
-		return [text];
 	}
 	const splitLongParagraphs = opts?.splitLongParagraphs !== false;
 
@@ -158,11 +173,9 @@ export function chunkByParagraph(
  * @returns Array of text chunks
  */
 export function chunkMarkdownText(text: string, limit: number): string[] {
+	assertValidMarkdownChunkLimit(limit);
 	if (!text) {
 		return [];
-	}
-	if (limit <= 0) {
-		return [text];
 	}
 	if (text.length <= limit) {
 		return [text];
@@ -360,4 +373,17 @@ function scanParenAwareBreakpoints(
 	}
 
 	return { lastNewline, lastWhitespace };
+}
+
+function describeInvalidLimit(limit: number): string {
+	if (Number.isNaN(limit)) {
+		return "NaN";
+	}
+	if (limit === Number.POSITIVE_INFINITY) {
+		return "+Infinity";
+	}
+	if (limit === Number.NEGATIVE_INFINITY) {
+		return "-Infinity";
+	}
+	return String(limit).slice(0, 32);
 }

--- a/packages/core/src/markdown/ir.ts
+++ b/packages/core/src/markdown/ir.ts
@@ -1,7 +1,7 @@
 /** Converts Markdown into text, style spans, and links for platform-independent rendering. */
 
 import MarkdownIt from "markdown-it";
-import { chunkText } from "./chunk.js";
+import { assertValidMarkdownChunkLimit, chunkText } from "./chunk.js";
 
 // ============================================================================
 // Types
@@ -960,10 +960,11 @@ export function markdownToIRWithMeta(
  * @returns Array of IR chunks
  */
 export function chunkMarkdownIR(ir: MarkdownIR, limit: number): MarkdownIR[] {
+	assertValidMarkdownChunkLimit(limit);
 	if (!ir.text) {
 		return [];
 	}
-	if (limit <= 0 || ir.text.length <= limit) {
+	if (ir.text.length <= limit) {
 		return [ir];
 	}
 


### PR DESCRIPTION
# Relates to

Closes #23334.

- [x] Targets `develop` and was rebased onto `origin/develop@210823b7d5366c014644fcefd3cfa0dc5439b92d` with zero conflicts.
- [ ] A full frozen install and root `bun run verify` still need an independent full-worktree run; the sparse-worktree limitation is recorded below.
- [x] The exact-head deterministic receipt below exercises the public behavior without requiring code inspection.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@48e5f5ce9bdc8c7bc3458b35b2c5e9bec61f06b0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@210823b7d5366c014644fcefd3cfa0dc5439b92d`; zero conflicts.
- [ ] Root verification is pending an independent full-worktree run; see Known gaps / failures.

# Risks

Low. The change tightens an invalid-input contract for four public Markdown chunking paths. Positive safe-integer behavior is unchanged and covered at the smallest valid limits, including astral Unicode and fenced Markdown.

# Background

## What does this PR do?

- Rejects zero, negative, fractional, non-finite, and unsafe-integer chunk limits with `ElizaError` code `MARKDOWN_CHUNK_LIMIT_INVALID`.
- Performs validation before empty and within-limit fast paths so invalid configuration cannot remain latent.
- Applies the same contract to `chunkText`, `chunkMarkdownText`, `chunkByParagraph`, and `chunkMarkdownIR`.
- Pins progress, reconstruction, fence, and surrogate-pair behavior at limits 1 and 2.

## What kind of change is this?

Bug fix (non-breaking for valid callers; malformed resource limits now fail closed).

# Documentation changes needed?

No public documentation change is needed; the exported JSDoc and adversarial contract tests define the tightened boundary.

# Testing

## Where should a reviewer start?

Run the new public-export contract test, then the two existing chunker suites:

```bash
node_modules/.bin/vitest run \
  packages/core/src/markdown/chunk.limit.test.ts \
  packages/core/src/markdown/chunk.chunkText.test.ts \
  packages/core/src/markdown/chunk.chunkMarkdownText.test.ts \
  --config packages/core/vitest.config.ts --maxWorkers=1
```

## Detailed testing steps

Exact head `99b7ec1d6712676f87802ef13ae1a605a393e62c`:

```text
Test Files  3 passed (3)
Tests       23 passed (23)
```

Also passed:

- scoped Biome on all four changed source/test files;
- strict standalone TypeScript validation for `errors.ts`, `fences.ts`, and `chunk.ts`;
- `git diff origin/develop...HEAD --check`;
- direct runtime probes covering 48 invalid fast-path calls, IR reconstruction, fenced limit-1 progress, and astral reconstruction.

# Evidence Gate

<!-- evidence-head:99b7ec1d6712676f87802ef13ae1a605a393e62c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - pure core text utility with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - pure core text utility with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or visual flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server process is involved; the exact-head deterministic execution receipt is included in Testing above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, model, prompt, provider, or action behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted domain artifact; output is the returned chunk array or typed error.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model path changes.

## Backend + frontend logs

The exact-head focused receipt is reproduced in Testing. There is no network boundary in this pure core utility.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice path.

## Known gaps / failures

- `bun run --cwd packages/core typecheck` was attempted in the sparse isolated worktree. It reached TypeScript and failed only because the borrowed partial dependency tree lacks existing core dependencies `ai`, `mammoth`, `unpdf`, `file-type`, and `@types/markdown-it`; it reported no diagnostic in the changed chunk-limit implementation. A full frozen install/typecheck/root verify is intentionally left for the independent review wave.
- The PR remains draft until that independent exact-head full-worktree validation and review are complete.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@48e5f5ce9bdc8c7bc3458b35b2c5e9bec61f06b0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-markdown-bound]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@48e5f5ce9bdc8c7bc3458b35b2c5e9bec61f06b0:packages/skills/skills/contribute-to-eliza"} -->
