### PR TITLE
fix(plugin-zai): reject exotic provider option records

### DIFF
--- a/plugins/plugin-zai/__tests__/text-params.test.ts
+++ b/plugins/plugin-zai/__tests__/text-params.test.ts
@@ -277,13 +277,20 @@ describe("z.ai text parameter resolution", () => {
       const handlers = await import("../models/text");
       const handler = handlers[handlerName];
 
-      await expect(
-        handler(runtime as never, {
-          prompt: "hello",
-          providerOptions: { agentName: "keep", bad: 1n } as never,
-        })
-      ).rejects.toMatchObject({ code: "ZAI_PROVIDER_OPTIONS_UNBOUNDED" });
+      for (const providerOptions of [
+        { agentName: "keep", bad: 1n },
+        new Date(0),
+        { nested: new Map([["enabled", true]]) },
+      ]) {
+        await expect(
+          handler(runtime as never, {
+            prompt: "hello",
+            providerOptions: providerOptions as never,
+          })
+        ).rejects.toMatchObject({ code: "ZAI_PROVIDER_OPTIONS_UNBOUNDED" });
+      }
 
+      expect(createOpenAICompatibleMock).not.toHaveBeenCalled();
       expect(generateTextMock).not.toHaveBeenCalled();
     }
   );

--- a/plugins/plugin-zai/__tests__/zai-provider-options.test.ts
+++ b/plugins/plugin-zai/__tests__/zai-provider-options.test.ts
@@ -21,6 +21,10 @@ function nestArray(depth: number): unknown {
 }
 
 describe("readProviderOptions", () => {
+  class CustomOptions {
+    enabled = true;
+  }
+
   it("preserves root and nested __proto__ keys as inert own data", () => {
     const nested = Object.fromEntries([["__proto__", { nested: true }]]);
     const input = Object.fromEntries([
@@ -53,6 +57,36 @@ describe("readProviderOptions", () => {
     });
     for (const invalid of [null, ["not", "a", "record"], "scalar"]) {
       expect(() => readProviderOptions(invalid)).toThrow(
+        expect.objectContaining({ code: ZAI_PROVIDER_OPTIONS_UNBOUNDED })
+      );
+    }
+  });
+
+  it("accepts root and nested null-prototype records and copies them to inert records", () => {
+    const nested = Object.assign(Object.create(null) as Record<string, unknown>, {
+      effort: "high",
+    });
+    const root = Object.assign(Object.create(null) as Record<string, unknown>, {
+      agentName: "eliza",
+      zai: nested,
+    });
+
+    const copied = readProviderOptions(root);
+
+    expect(copied).toEqual({ agentName: "eliza", zai: { effort: "high" } });
+    expect(Object.getPrototypeOf(copied)).toBe(Object.prototype);
+    expect(Object.getPrototypeOf(copied.zai as object)).toBe(Object.prototype);
+  });
+
+  it.each([
+    ["Date", () => new Date(0)],
+    ["Map", () => new Map([["enabled", true]])],
+    ["Set", () => new Set(["enabled"])],
+    ["class instance", () => new CustomOptions()],
+    ["custom prototype", () => Object.create({ inherited: true })],
+  ])("rejects %s values at root and nested record boundaries", (_name, makeValue) => {
+    for (const candidate of [makeValue(), { nested: makeValue() }]) {
+      expect(() => readProviderOptions(candidate)).toThrow(
         expect.objectContaining({ code: ZAI_PROVIDER_OPTIONS_UNBOUNDED })
       );
     }
@@ -164,5 +198,29 @@ describe("readProviderOptions", () => {
     expect(() => readProviderOptions(hostile)).toThrow(
       expect.objectContaining({ code: ZAI_PROVIDER_OPTIONS_UNBOUNDED })
     );
+  });
+
+  it("translates hostile and revoked prototype reflection at root and nested boundaries", () => {
+    const hostile = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error("prototype reflection trap");
+        },
+      }
+    );
+    const revoked = Proxy.revocable({}, {});
+    revoked.revoke();
+
+    for (const candidate of [
+      hostile,
+      { nested: hostile },
+      revoked.proxy,
+      { nested: revoked.proxy },
+    ]) {
+      expect(() => readProviderOptions(candidate)).toThrow(
+        expect.objectContaining({ code: ZAI_PROVIDER_OPTIONS_UNBOUNDED })
+      );
+    }
   });
 });

--- a/plugins/plugin-zai/models/zai-provider-options.ts
+++ b/plugins/plugin-zai/models/zai-provider-options.ts
@@ -68,6 +68,16 @@ function isArrayRecord(value: unknown): value is unknown[] {
   return inspectRecord("isArray", () => Array.isArray(value));
 }
 
+function assertPlainRecord(value: object): void {
+  const prototype = inspectRecord("getPrototypeOf", () => Object.getPrototypeOf(value));
+  // Null-prototype records are an explicitly supported JSON-record shape. The
+  // copier still returns an ordinary inert data record, so neither input shape
+  // can carry custom prototype behavior across the provider boundary.
+  if (prototype !== Object.prototype && prototype !== null) {
+    failUnbounded({ invalidRecordPrototype: true });
+  }
+}
+
 function newWalkContext(): WalkContext {
   return {
     visits: 0,
@@ -143,6 +153,7 @@ function readProviderOptionValue(
       return out;
     }
 
+    assertPlainRecord(value);
     const keys = inspectRecord("ownKeys", () => Reflect.ownKeys(value));
     reserve(ctx, keys.length);
     const record: { [key: string]: ProviderOptionValue | undefined } = {};


### PR DESCRIPTION
# Relates to

Fixes #23329.

- [x] This PR targets `develop` and was rebased onto live `origin/develop` at `210823b7d5366c014644fcefd3cfa0dc5439b92d` with zero conflicts.
- [ ] `bun install` and root `bun run verify` are deferred while this remains a draft; exact package gates are recorded below.
- [x] A reviewer can confirm the changed boundary from the deterministic production-path tests and receipt below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@210823b7d5366c014644fcefd3cfa0dc5439b92d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto live `develop` immediately before exact-head validation and push; zero conflicts.
- [ ] Root `bun run verify` is deferred to ready-for-review after the independent review wave.

# Risks

Low. The change only narrows the accepted z.ai `providerOptions` object shapes. Ordinary and null-prototype JSON records remain accepted; custom-prototype objects now fail with the existing typed boundary error before client creation.

# Background

## What does this PR do?

It validates every non-array provider-options object with a trap-safe prototype read. Only ordinary records and null-prototype records are accepted. Date, Map, Set, class instances, custom prototypes, and reflection failures reject with `ZAI_PROVIDER_OPTIONS_UNBOUNDED` before the z.ai client or model dispatcher is called.

## What kind of change is this?

Bug fix (non-breaking hardening of malformed provider options).

# Documentation changes needed?

No public documentation change is required. The supported null-prototype policy is documented beside the production validator and pinned by tests.

# Testing

## Where should a reviewer start?

- `plugins/plugin-zai/models/zai-provider-options.ts`
- `plugins/plugin-zai/__tests__/zai-provider-options.test.ts`
- `plugins/plugin-zai/__tests__/text-params.test.ts`

## Detailed testing steps

At exact head `77f87f9791c7a4e6f498ba827d5516d15942d283` (the three PR-owned blobs are byte-identical to the tested implementation commit; the receipt records both blob sets):

```text
bun run --cwd plugins/plugin-zai test
  7 files passed; 56 tests passed

bun run --cwd plugins/plugin-zai typecheck
  passed

bun run --cwd plugins/plugin-zai lint:check
  Checked 21 files; no fixes applied

bun run --cwd plugins/plugin-zai build
  Node, browser, Node CJS, and TypeScript declaration builds passed
```

The focused production-boundary subset also passed 29/29 tests after the final rebase.

# Evidence Gate

<!-- evidence-head:77f87f9791c7a4e6f498ba827d5516d15942d283 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - this is a non-visual typed input boundary.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - malformed inputs are rejected before client creation or any backend/provider request.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend behavior or network request is involved.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - acceptance requires proof of pre-dispatch rejection; making a model call would contradict the boundary under test.
<!-- evidence-row:domain-artifacts -->
- [x] [23359-zai-provider-options-77f87f-receipt.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23359-zai-provider-options-77f87f-receipt.json)
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered UI surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - invalid provider options must fail before client creation and model dispatch; no live provider secret is required or used.

## Backend + frontend logs

N/A - the changed path is a synchronous dependency-injected validation boundary. The exact test receipt above is the applicable execution record.

## Screenshots (before / after) + video walkthrough

N/A - no UI files or rendered behavior changed.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT path changed.

## Known gaps / failures

- Root `bun install` and `bun run verify` remain for the ready-for-review wave; this draft used the pinned Bun 1.3.14 toolchain and an existing current dependency installation because the shared host is under active disk pressure.
- Hosted Quality and independent review are intentionally pending while the PR is draft.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@210823b7d5366c014644fcefd3cfa0dc5439b92d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-zai-exotic-options]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@210823b7d5366c014644fcefd3cfa0dc5439b92d:packages/skills/skills/contribute-to-eliza"} -->

