### PR TITLE
fix(ci): restore fail-closed PR and merge-queue admission

### DIFF
--- a/.github/rulesets/required-branches.json
+++ b/.github/rulesets/required-branches.json
@@ -13,11 +13,10 @@
     { "type": "deletion" },
     { "type": "non_fast_forward" },
     { "type": "required_linear_history" },
-    { "type": "required_signatures" },
     {
       "type": "pull_request",
       "parameters": {
-        "allowed_merge_methods": ["merge", "squash", "rebase"],
+        "allowed_merge_methods": ["squash", "rebase"],
         "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": false,
         "require_last_push_approval": true,

--- a/.github/rulesets/required-branches.json
+++ b/.github/rulesets/required-branches.json
@@ -1,0 +1,37 @@
+{
+  "name": "required-main-and-develop",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/develop", "refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_linear_history" },
+    { "type": "required_signatures" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "allowed_merge_methods": ["merge", "squash", "rebase"],
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [{ "context": "All Tests Passed" }],
+        "strict_required_status_checks_policy": true
+      }
+    }
+  ]
+}

--- a/.github/rulesets/required-branches.json
+++ b/.github/rulesets/required-branches.json
@@ -19,7 +19,7 @@
       "parameters": {
         "allowed_merge_methods": ["merge", "squash", "rebase"],
         "dismiss_stale_reviews_on_push": true,
-        "require_code_owner_review": true,
+        "require_code_owner_review": false,
         "require_last_push_approval": true,
         "required_approving_review_count": 1,
         "required_review_thread_resolution": true

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -75,7 +75,8 @@ fixture, research, example, and documentation trees are excluded.
 Several branch-scoped and path-scoped workflows run alongside the canonical CI
 gate for specific surfaces. This list is non-exhaustive; other specialized
 gates such as `cloud-tests.yml`, `chat-shell-gestures.yml`, and the `pr.yaml`
-title check cover narrower contracts. None replaces the `CI / Required` status.
+title check cover narrower contracts. None replaces the required
+`All Tests Passed` aggregate.
 Representative examples:
 
 - `develop-pr.yml` is called from canonical `ci.yml` for `develop`-targeted PRs

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,7 +24,18 @@ create or update that exact ruleset. `repository-ruleset-drift.yml` performs the
 same semantic readback on a schedule, by manual dispatch, and through the
 `repository_ruleset_drift` external repository-dispatch event. A green readback
 proves configuration parity only; owner audit-log review plus red/green and
-direct-push canaries remain required after an authorized apply.
+direct-push canaries remain required after an authorized apply. Scheduled and
+external readback requires an owner-provisioned
+`REPOSITORY_RULESET_READ_TOKEN` Actions secret with repository
+`Administration: read`; the workflow-scoped `GITHUB_TOKEN` cannot request
+that repository permission and is never used for this readback.
+
+The manifest intentionally keeps Code Owner review disabled while
+`.github/CODEOWNERS` names placeholder teams. An organization owner must
+replace every placeholder, verify each team exists and can review the covered
+paths, then submit a separate reviewed manifest change enabling Code Owner
+review. The current ruleset still requires one approval, last-push approval,
+and review-thread resolution.
 
 `nightly.yml` calls the same CI workflow once per day and adds macOS and Windows
 core smoke tests. It never publishes packages or creates releases.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -37,6 +37,15 @@ paths, then submit a separate reviewed manifest change enabling Code Owner
 review. The current ruleset still requires one approval, last-push approval,
 and review-thread resolution.
 
+The manifest allows squash and rebase only: linear history rejects merge commits.
+Required-signature enforcement is deferred because GitHub cannot generally
+produce a signed web squash for an external contributor unless the merger is
+also the pull-request author, while rebase admission requires every source
+commit to be signed. An owner may propose signature enforcement separately only
+after proving contributor-safe signed squash/rebase canaries; ordinary approval,
+last-push approval, thread resolution, status checks, linear history, and the
+force-push/deletion bans remain active here.
+
 `nightly.yml` calls the same CI workflow once per day and adds macOS and Windows
 core smoke tests. It never publishes packages or creates releases.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,18 +6,25 @@ runners, environments, and a concise job graph.
 
 ## Required validation
 
-`merge-candidate-biome.yml` is the pre-merge admission gate. GitHub's merge
-queue synthesizes its checkout SHA from the current `develop` tip and the
-queued pull requests, then the workflow runs the repository-pinned full lint
-and format contracts on that exact tree. Branch rules must require the stable
-`Merge Candidate Biome / Candidate tree` check for the queue to block a bad
-candidate; post-merge workflows remain health checks rather than admission.
+`ci.yml` is the canonical pull-request, merge-queue, and `develop` branch-health
+workflow. Pull requests targeting `develop` or `main` and every `merge_group`
+candidate run the same fail-closed job graph. Branch rules require only its stable
+`CI / All Tests Passed` aggregate, which succeeds only when every mandatory lane
+succeeds; individual lane names may evolve without silently weakening admission.
 
-`ci.yml` is the canonical post-merge branch-health workflow for `develop`. It
-classifies changed paths, runs repository quality checks, affected tests,
-deterministic smoke tests, a path-scoped Android release AAB audit, and a
-diff-scoped secret scan. Its stable `CI / Required` job diagnoses the integrated
-branch; it does not replace the merge-candidate admission check above.
+`merge-candidate-biome.yml` remains a defense-in-depth merge-queue check of
+GitHub's synthesized candidate tree. It runs the repository-pinned full lint and
+format contracts, but it is not a separately required context because canonical
+CI already covers those contracts and publishes the single admission aggregate.
+
+`.github/rulesets/required-branches.json` is the reviewed no-bypass ruleset
+manifest for `develop` and `main`. `scripts/security/apply-branch-protection.sh`
+is read-only by default (`--check`) and requires explicit `--apply` authority to
+create or update that exact ruleset. `repository-ruleset-drift.yml` performs the
+same semantic readback on a schedule, by manual dispatch, and through the
+`repository_ruleset_drift` external repository-dispatch event. A green readback
+proves configuration parity only; owner audit-log review plus red/green and
+direct-push canaries remain required after an authorized apply.
 
 `nightly.yml` calls the same CI workflow once per day and adds macOS and Windows
 core smoke tests. It never publishes packages or creates releases.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,16 @@
-# This workflow is the canonical develop branch-health validation entry point.
-# Pull requests intentionally do not run repository workflows; develop validates
-# the integrated tree after merge.
+# This workflow is the canonical required merge-candidate and develop branch-health
+# validation entry point. Every pull request and merge-group candidate publishes
+# the stable fail-closed `CI / All Tests Passed` admission context.
 name: CI
 
 on:
+  pull_request:
+    branches: [develop, main]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   push:
     branches: [develop]
+  merge_group:
+    types: [checks_requested]
   workflow_call:
   workflow_dispatch:
 
@@ -14,8 +19,8 @@ on:
 # branch health can never be read on demand. Give workflow_dispatch its own
 # run-scoped identity — the same shape test.yml already uses.
 concurrency:
-  group: ci-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'push' }}
+  group: ci-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push' }}
 
 permissions:
   contents: read
@@ -539,8 +544,8 @@ jobs:
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.sha }}
         run: |
           set -euo pipefail
           if [ -n "$BASE_SHA" ] && [ "$BASE_SHA" != "0000000000000000000000000000000000000000" ]; then
@@ -578,7 +583,7 @@ jobs:
             --log-opts "$range"
 
   required:
-    name: Required
+    name: All Tests Passed
     if: always()
     needs:
       [

--- a/.github/workflows/repository-ruleset-drift.yml
+++ b/.github/workflows/repository-ruleset-drift.yml
@@ -29,7 +29,16 @@ jobs:
           persist-credentials: false
           submodules: false
 
+      - name: Require the Administration-read credential
+        env:
+          GH_TOKEN: ${{ secrets.REPOSITORY_RULESET_READ_TOKEN }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::REPOSITORY_RULESET_READ_TOKEN is required with repository Administration: read permission"
+            exit 1
+          fi
+
       - name: Compare live ruleset with the reviewed manifest
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.REPOSITORY_RULESET_READ_TOKEN }}
         run: ./scripts/security/apply-branch-protection.sh --check --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/repository-ruleset-drift.yml
+++ b/.github/workflows/repository-ruleset-drift.yml
@@ -1,0 +1,35 @@
+# Performs semantic readback of the canonical repository ruleset. The workflow
+# never applies settings; an owner must authorize and run the separate mutation
+# mode after reviewing the exact manifest.
+name: Repository Ruleset Drift
+
+on:
+  schedule:
+    - cron: "23 */6 * * *"
+  workflow_dispatch:
+  repository_dispatch:
+    types: [repository_ruleset_drift]
+
+concurrency:
+  group: repository-ruleset-drift
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  readback:
+    name: Ruleset readback
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: develop
+          persist-credentials: false
+          submodules: false
+
+      - name: Compare live ruleset with the reviewed manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/security/apply-branch-protection.sh --check --repo "$GITHUB_REPOSITORY"

--- a/packages/app/docs/E2E_LIVE_COVERAGE.md
+++ b/packages/app/docs/E2E_LIVE_COVERAGE.md
@@ -8,11 +8,11 @@ feature.
 `.github/workflows/ci.yml` is the canonical required pull-request workflow. Its
 `Tests` and `Smoke` jobs call the repository-level package sweeps and
 deterministic E2E suite. Path classification can skip unaffected groups, while
-the stable `Required` job remains the only status intended for branch
-protection. Specialized branch-scoped and path-scoped PR gates such as
+the stable `All Tests Passed` aggregate remains the only status intended for
+branch protection. Specialized branch-scoped and path-scoped PR gates such as
 `develop-pr.yml`, `quality.yml`, `scenario-pr.yml`, `ui-e2e-gate.yml`,
 `ui-fixture-e2e.yml`, and `gitleaks.yml` run alongside it for specific
-surfaces; none replaces the `CI / Required` status.
+surfaces; none replaces the required `All Tests Passed` aggregate.
 
 The pull-request lane is credential-free. It uses deterministic model fixtures,
 local services, and checked-in browser fixtures. A test that requires a hosted

--- a/packages/docs/build-and-release.md
+++ b/packages/docs/build-and-release.md
@@ -8,7 +8,7 @@ description: "How the monorepo validates builds and publishes an explicit npm re
 The repository has one pull-request workflow and one release workflow:
 
 - `.github/workflows/ci.yml` validates every pull request and protected-branch
-  push. Its stable `CI / Required` job is the only required status.
+  push. Its stable `All Tests Passed` aggregate is the only required status.
 - `.github/workflows/release.yaml` is manually dispatched from the exact tip of
   `develop`. It builds one immutable package cohort, publishes those tarballs to
   npm, verifies the registry, and only then creates the exact Git tag and GitHub

--- a/packages/scripts/__tests__/repository-ruleset-contract.test.ts
+++ b/packages/scripts/__tests__/repository-ruleset-contract.test.ts
@@ -67,6 +67,7 @@ describe("repository ruleset contract", () => {
     );
     expect(codeowners).toContain("are PLACEHOLDERS");
     expect(pullRequest.parameters).toMatchObject({
+      allowed_merge_methods: ["squash", "rebase"],
       dismiss_stale_reviews_on_push: true,
       require_code_owner_review: false,
       require_last_push_approval: true,
@@ -82,16 +83,14 @@ describe("repository ruleset contract", () => {
       strict_required_status_checks_policy: true,
     });
     expect(
-      manifest.rules.map((rule: Record<string, any>) => rule.type),
-    ).toEqual(
-      expect.arrayContaining([
-        "deletion",
-        "non_fast_forward",
-        "pull_request",
-        "required_linear_history",
-        "required_signatures",
-      ]),
-    );
+      manifest.rules.map((rule: Record<string, any>) => rule.type).sort(),
+    ).toEqual([
+      "deletion",
+      "non_fast_forward",
+      "pull_request",
+      "required_linear_history",
+      "required_status_checks",
+    ]);
   });
 
   test("keeps mutation explicit and semantic readback as the default", () => {

--- a/packages/scripts/__tests__/repository-ruleset-contract.test.ts
+++ b/packages/scripts/__tests__/repository-ruleset-contract.test.ts
@@ -1,0 +1,105 @@
+/** Proves the canonical CI aggregate, no-bypass ruleset manifest, and read-only drift workflow remain one fail-closed repository contract. */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const read = (path: string) => readFileSync(join(REPO_ROOT, path), "utf8");
+const ci = Bun.YAML.parse(read(".github/workflows/ci.yml")) as Record<
+  string,
+  any
+>;
+const drift = Bun.YAML.parse(
+  read(".github/workflows/repository-ruleset-drift.yml"),
+) as Record<string, any>;
+const manifest = JSON.parse(
+  read(".github/rulesets/required-branches.json"),
+) as Record<string, any>;
+const helper = read("scripts/security/apply-branch-protection.sh");
+
+describe("repository ruleset contract", () => {
+  test("publishes one stable fail-closed aggregate for PR and merge candidates", () => {
+    expect(ci.on.pull_request).toEqual({
+      branches: ["develop", "main"],
+      types: [
+        "opened",
+        "synchronize",
+        "reopened",
+        "ready_for_review",
+        "labeled",
+        "unlabeled",
+      ],
+    });
+    expect(ci.on.merge_group).toEqual({ types: ["checks_requested"] });
+    expect(ci.jobs.required.name).toBe("All Tests Passed");
+    expect(ci.jobs.required.if).toBe("always()");
+    expect(ci.jobs.required.needs).toEqual([
+      "changes",
+      "quality",
+      "tests",
+      "tests_server",
+      "tests_client",
+      "tests_plugins",
+      "smoke",
+      "smoke_lanes",
+      "android_aab",
+      "secrets",
+    ]);
+    expect(ci.jobs.required.steps[0].run).toContain(
+      'if [ "$result" != "success" ]',
+    );
+  });
+
+  test("requires the aggregate on main and develop without bypass actors", () => {
+    expect(manifest.enforcement).toBe("active");
+    expect(manifest.target).toBe("branch");
+    expect(manifest.bypass_actors).toEqual([]);
+    expect(manifest.conditions.ref_name).toEqual({
+      include: ["refs/heads/develop", "refs/heads/main"],
+      exclude: [],
+    });
+    const status = manifest.rules.find(
+      (rule: Record<string, any>) => rule.type === "required_status_checks",
+    );
+    expect(status.parameters).toEqual({
+      do_not_enforce_on_create: true,
+      required_status_checks: [{ context: "All Tests Passed" }],
+      strict_required_status_checks_policy: true,
+    });
+    expect(
+      manifest.rules.map((rule: Record<string, any>) => rule.type),
+    ).toEqual(
+      expect.arrayContaining([
+        "deletion",
+        "non_fast_forward",
+        "pull_request",
+        "required_linear_history",
+        "required_signatures",
+      ]),
+    );
+  });
+
+  test("keeps mutation explicit and semantic readback as the default", () => {
+    expect(helper).toContain('MODE="check"');
+    expect(helper).toContain('--apply) MODE="apply"');
+    expect(helper).toContain("repos/$REPO/rulesets");
+    expect(helper).not.toContain("/branches/${branch}/protection");
+    expect(helper).toContain("repository ruleset drift detected");
+  });
+
+  test("runs readback on schedule, manual request, and external dispatch", () => {
+    expect(Object.keys(drift.on).sort()).toEqual([
+      "repository_dispatch",
+      "schedule",
+      "workflow_dispatch",
+    ]);
+    expect(drift.on.repository_dispatch.types).toEqual([
+      "repository_ruleset_drift",
+    ]);
+    expect(drift.permissions).toEqual({ contents: "read" });
+    expect(drift.jobs.readback.steps.at(-1).run).toContain("--check");
+    expect(drift.jobs.readback.steps.at(-1).run).not.toContain("--apply");
+  });
+});

--- a/packages/scripts/__tests__/repository-ruleset-contract.test.ts
+++ b/packages/scripts/__tests__/repository-ruleset-contract.test.ts
@@ -18,6 +18,8 @@ const manifest = JSON.parse(
   read(".github/rulesets/required-branches.json"),
 ) as Record<string, any>;
 const helper = read("scripts/security/apply-branch-protection.sh");
+const codeowners = read(".github/CODEOWNERS");
+const driftSource = read(".github/workflows/repository-ruleset-drift.yml");
 
 describe("repository ruleset contract", () => {
   test("publishes one stable fail-closed aggregate for PR and merge candidates", () => {
@@ -60,6 +62,17 @@ describe("repository ruleset contract", () => {
       include: ["refs/heads/develop", "refs/heads/main"],
       exclude: [],
     });
+    const pullRequest = manifest.rules.find(
+      (rule: Record<string, any>) => rule.type === "pull_request",
+    );
+    expect(codeowners).toContain("are PLACEHOLDERS");
+    expect(pullRequest.parameters).toMatchObject({
+      dismiss_stale_reviews_on_push: true,
+      require_code_owner_review: false,
+      require_last_push_approval: true,
+      required_approving_review_count: 1,
+      required_review_thread_resolution: true,
+    });
     const status = manifest.rules.find(
       (rule: Record<string, any>) => rule.type === "required_status_checks",
     );
@@ -99,7 +112,20 @@ describe("repository ruleset contract", () => {
       "repository_ruleset_drift",
     ]);
     expect(drift.permissions).toEqual({ contents: "read" });
-    expect(drift.jobs.readback.steps.at(-1).run).toContain("--check");
-    expect(drift.jobs.readback.steps.at(-1).run).not.toContain("--apply");
+    expect(driftSource).not.toContain("github.token");
+    const credential = drift.jobs.readback.steps.find(
+      (step: Record<string, any>) =>
+        step.name === "Require the Administration-read credential",
+    );
+    expect(credential.env.GH_TOKEN).toBe(
+      "${{ secrets.REPOSITORY_RULESET_READ_TOKEN }}",
+    );
+    expect(credential.run).toContain('if [ -z "${GH_TOKEN:-}" ]');
+    const readback = drift.jobs.readback.steps.at(-1);
+    expect(readback.env.GH_TOKEN).toBe(
+      "${{ secrets.REPOSITORY_RULESET_READ_TOKEN }}",
+    );
+    expect(readback.run).toContain("--check");
+    expect(readback.run).not.toContain("--apply");
   });
 });

--- a/packages/scripts/__tests__/workflow-trigger-policy.test.ts
+++ b/packages/scripts/__tests__/workflow-trigger-policy.test.ts
@@ -1,4 +1,4 @@
-/** Exercises the repository policy that excludes pull-request workflow runs, reserves merge-queue admission, and restricts branch pushes to develop. */
+/** Exercises the policy that permits one canonical PR/merge aggregate, reserves other PR-adjacent triggers, and restricts branch pushes to develop. */
 
 import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -13,9 +13,8 @@ function buildRepo(workflows: Record<string, string>): string {
   const root = mkdtempSync(join(tmpdir(), "workflow-trigger-policy-"));
   const directory = join(root, ".github", "workflows");
   mkdirSync(directory, { recursive: true });
-  for (const [name, source] of Object.entries(workflows)) {
+  for (const [name, source] of Object.entries(workflows))
     writeFileSync(join(directory, name), source);
-  }
   return root;
 }
 
@@ -29,6 +28,18 @@ function validateFixture(
     rmSync(root, { recursive: true, force: true });
   }
 }
+
+const canonicalCi = `name: CI
+on:
+  pull_request:
+    branches: [develop, main]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  push:
+    branches: [develop]
+  merge_group:
+    types: [checks_requested]
+jobs: {}
+`;
 
 describe("workflow trigger policy", () => {
   test("accepts develop pushes alongside manual and scheduled operations", () => {
@@ -61,7 +72,6 @@ jobs: {}
   });
 
   test.each([
-    "pull_request",
     "pull_request_target",
     "issue_comment",
     "pull_request_review",
@@ -74,15 +84,57 @@ jobs: {}
     ).toThrow(/forbidden pull-request event trigger/);
   });
 
-  test("reserves merge_group for the candidate Biome workflow", () => {
+  test("reserves pull_request for the canonical CI workflow", () => {
     expect(() =>
       validateFixture(
-        `on:\n  push:\n    branches: [develop]\n  merge_group:\njobs: {}\n`,
+        "on:\n  push:\n    branches: [develop]\n  pull_request:\n    branches: [develop, main]\n    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]\njobs: {}\n",
       ),
-    ).toThrow(/merge_group is reserved for merge-candidate-biome\.yml/);
+    ).toThrow(/pull_request is reserved for ci\.yml/);
+  });
 
+  test("accepts the exact canonical PR and merge-group aggregate", () => {
+    const root = buildRepo({ "ci.yml": canonicalCi });
+    try {
+      expect(validateWorkflowTriggerPolicy(root)).toEqual({
+        developPushWorkflows: 1,
+        files: 1,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("fails closed when canonical CI loses either admission trigger", () => {
+    const variants = [
+      canonicalCi.replace(
+        /  pull_request:\n    branches: \[develop, main\]\n    types: \[opened, synchronize, reopened, ready_for_review, labeled, unlabeled\]\n/,
+        "",
+      ),
+      canonicalCi.replace(
+        /  merge_group:\n    types: \[checks_requested\]\n/,
+        "",
+      ),
+    ];
+    for (const workflow of variants) {
+      const root = buildRepo({ "ci.yml": workflow });
+      try {
+        expect(() => validateWorkflowTriggerPolicy(root)).toThrow(
+          /canonical (pull_request|merge_group) trigger is absent or invalid/,
+        );
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("reserves merge_group for canonical CI and candidate Biome", () => {
+    expect(() =>
+      validateFixture(
+        `on:\n  push:\n    branches: [develop]\n  merge_group:\n    types: [checks_requested]\njobs: {}\n`,
+      ),
+    ).toThrow(/merge_group is reserved/);
     const root = buildRepo({
-      "develop.yml": `on:\n  push:\n    branches: [develop]\njobs: {}\n`,
+      "ci.yml": canonicalCi,
       "merge-candidate-biome.yml": `on:\n  merge_group:\n    types: [checks_requested]\njobs: {}\n`,
     });
     try {
@@ -109,7 +161,7 @@ jobs: {}
     }
   });
 
-  test("the checked-in workflow set has no PR triggers or non-develop branch pushes", () => {
+  test("the checked-in workflows expose only the canonical aggregate and develop pushes", () => {
     const result = validateWorkflowTriggerPolicy(REAL_REPO_ROOT);
     expect(result.files).toBeGreaterThan(40);
     expect(result.developPushWorkflows).toBeGreaterThan(15);

--- a/packages/scripts/workflow-trigger-policy.mjs
+++ b/packages/scripts/workflow-trigger-policy.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
- * Enforces develop-only automated branch workflows and rejects pull-request
- * event triggers. The credential-free merge-candidate Biome gate is the sole
- * exception because it checks GitHub's synthesized queue tree before landing.
+ * Enforces develop-only automated pushes and one canonical pull-request and
+ * merge-group aggregate. Other PR-adjacent triggers remain forbidden; the
+ * merge-candidate Biome workflow may retain its defense-in-depth queue check.
  */
 
 import { readdirSync, readFileSync } from "node:fs";
@@ -12,13 +12,24 @@ import { parseDocument } from "yaml";
 
 const FORBIDDEN_EVENTS = new Set([
   "issue_comment",
-  "pull_request",
   "pull_request_review",
   "pull_request_review_comment",
   "pull_request_target",
 ]);
-
-const MERGE_GROUP_WORKFLOW = "merge-candidate-biome.yml";
+const CANONICAL_ADMISSION_WORKFLOW = "ci.yml";
+const MERGE_GROUP_WORKFLOWS = new Set([
+  CANONICAL_ADMISSION_WORKFLOW,
+  "merge-candidate-biome.yml",
+]);
+const REQUIRED_PR_BRANCHES = ["develop", "main"];
+const REQUIRED_PR_TYPES = [
+  "labeled",
+  "opened",
+  "ready_for_review",
+  "reopened",
+  "synchronize",
+  "unlabeled",
+];
 
 function triggerEntries(value) {
   if (typeof value === "string") return [[value, null]];
@@ -33,11 +44,20 @@ function stringList(value) {
   return [];
 }
 
+function sameStrings(actual, expected) {
+  return (
+    JSON.stringify([...actual].sort()) === JSON.stringify([...expected].sort())
+  );
+}
+
 export function validateWorkflowTriggerPolicy(repoRoot) {
   const workflowsDir = path.join(repoRoot, ".github", "workflows");
   const failures = [];
   let files = 0;
   let developPushWorkflows = 0;
+  let sawCanonicalWorkflow = false;
+  let sawCanonicalPullRequest = false;
+  let sawCanonicalMergeGroup = false;
 
   for (const name of readdirSync(workflowsDir).sort()) {
     if (!name.endsWith(".yml") && !name.endsWith(".yaml")) continue;
@@ -53,26 +73,60 @@ export function validateWorkflowTriggerPolicy(repoRoot) {
 
     const workflow = document.toJS();
     const entries = triggerEntries(workflow?.on);
+    if (name === CANONICAL_ADMISSION_WORKFLOW) sawCanonicalWorkflow = true;
+
     for (const [eventName, config] of entries) {
-      if (eventName === "merge_group" && name !== MERGE_GROUP_WORKFLOW) {
-        failures.push(
-          `${name}: merge_group is reserved for ${MERGE_GROUP_WORKFLOW}`,
-        );
-      }
       if (FORBIDDEN_EVENTS.has(eventName)) {
         failures.push(
           `${name}: forbidden pull-request event trigger: ${eventName}`,
         );
       }
-      if (eventName !== "push") continue;
 
+      if (eventName === "pull_request") {
+        if (name !== CANONICAL_ADMISSION_WORKFLOW) {
+          failures.push(
+            `${name}: pull_request is reserved for ${CANONICAL_ADMISSION_WORKFLOW}`,
+          );
+          continue;
+        }
+        const branches = stringList(config?.branches);
+        const types = stringList(config?.types);
+        if (
+          !sameStrings(branches, REQUIRED_PR_BRANCHES) ||
+          !sameStrings(types, REQUIRED_PR_TYPES)
+        ) {
+          failures.push(
+            `${name}: pull_request must target ${JSON.stringify(REQUIRED_PR_BRANCHES)} with types ${JSON.stringify(REQUIRED_PR_TYPES)}`,
+          );
+          continue;
+        }
+        sawCanonicalPullRequest = true;
+      }
+
+      if (eventName === "merge_group") {
+        if (!MERGE_GROUP_WORKFLOWS.has(name)) {
+          failures.push(
+            `${name}: merge_group is reserved for ${[...MERGE_GROUP_WORKFLOWS].join(" and ")}`,
+          );
+          continue;
+        }
+        if (!sameStrings(stringList(config?.types), ["checks_requested"])) {
+          failures.push(
+            `${name}: merge_group types must be exactly [\"checks_requested\"]`,
+          );
+          continue;
+        }
+        if (name === CANONICAL_ADMISSION_WORKFLOW)
+          sawCanonicalMergeGroup = true;
+      }
+
+      if (eventName !== "push") continue;
       if (!config || typeof config !== "object") {
         failures.push(
           `${name}: push must be branch-filtered to develop (tag-only release pushes are allowed)`,
         );
         continue;
       }
-
       const branches = stringList(config.branches);
       const tags = stringList(config.tags);
       const hasBranchIgnore = stringList(config["branches-ignore"]).length > 0;
@@ -93,18 +147,26 @@ export function validateWorkflowTriggerPolicy(repoRoot) {
   }
 
   if (files === 0) failures.push("No workflow files were found.");
-  if (developPushWorkflows === 0) {
+  if (developPushWorkflows === 0)
     failures.push("No develop push workflows were found.");
+  if (sawCanonicalWorkflow && !sawCanonicalPullRequest) {
+    failures.push(
+      `${CANONICAL_ADMISSION_WORKFLOW}: canonical pull_request trigger is absent or invalid`,
+    );
+  }
+  if (sawCanonicalWorkflow && !sawCanonicalMergeGroup) {
+    failures.push(
+      `${CANONICAL_ADMISSION_WORKFLOW}: canonical merge_group trigger is absent or invalid`,
+    );
   }
   if (failures.length > 0) {
     throw new Error(
       [
-        "GitHub workflow triggers must not run for pull requests, merge_group is reserved for the candidate Biome gate, and automated branch pushes must target develop only:",
+        "GitHub workflow triggers must expose only the canonical PR/merge aggregate, reserve other PR-adjacent events, and target automated branch pushes to develop:",
         ...failures,
       ].join("\n"),
     );
   }
-
   return { developPushWorkflows, files };
 }
 

--- a/scripts/security/apply-branch-protection.sh
+++ b/scripts/security/apply-branch-protection.sh
@@ -1,146 +1,149 @@
 #!/usr/bin/env bash
-# apply-branch-protection.sh
-#
-# Idempotently applies branch-protection rules to `main` and `develop` on the
-# elizaOS repositories. Required for SOC2 CC8.1 (change management)
-# and CC6.1 (logical access).
-#
-# Required token scopes:
-#   - `admin:org`  (to read team membership for required reviewers)
-#   - `repo`       (to write branch protection)
-# Or a fine-grained PAT with "Administration: write" on the target repos.
-#
-# Usage:
-#   GH_TOKEN=ghp_xxx ./scripts/security/apply-branch-protection.sh
-#   ./scripts/security/apply-branch-protection.sh --repo elizaos/eliza --branches main,develop
-#
-# Pre-flight checks: requires `gh` CLI authenticated with sufficient scopes.
+# Reconciles the reviewed no-bypass repository ruleset for main and develop.
+# The default mode is a read-only semantic drift check; mutation requires the
+# explicit --apply flag and repository Administration permission.
 
 set -euo pipefail
 
-REPOS=("elizaos/eliza")
-BRANCHES=("main" "develop")
-
-# Required status checks. These must match job NAMES (not workflow names) that
-# run on PRs to the protected branch. Update as workflows evolve.
-REQUIRED_CHECKS=(
-  "typecheck"
-  "test"
-  "gitleaks"
-)
-# Optional checks — added if known to exist; CI publish/container scans live
-# in different workflows on different repos, so we keep this list short and
-# tighten per-repo via overrides below if needed.
-OPTIONAL_CHECKS=(
-  "container-scan"
-)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MANIFEST="$REPO_ROOT/.github/rulesets/required-branches.json"
+REPO="${GITHUB_REPOSITORY:-elizaOS/eliza}"
+MODE="check"
 
 usage() {
-  cat <<EOF
-Usage: $0 [--repo OWNER/NAME] [--branches BR1,BR2] [--dry-run]
+  cat <<EOF_USAGE
+Usage: $0 [--repo OWNER/NAME] [--manifest PATH] [--check|--dry-run|--apply]
 
-Applies branch protection rules to the configured repos and branches.
-Without --repo / --branches, defaults are: ${REPOS[*]} / ${BRANCHES[*]}.
-EOF
+Checks the canonical repository ruleset by default. --dry-run prints the exact
+reviewed payload without contacting GitHub. --apply creates or updates only the
+named ruleset and then performs the same semantic readback.
+EOF_USAGE
 }
 
-DRY_RUN=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --repo)     REPOS=("$2"); shift 2 ;;
-    --branches) IFS=',' read -ra BRANCHES <<< "$2"; shift 2 ;;
-    --dry-run)  DRY_RUN=1; shift ;;
-    -h|--help)  usage; exit 0 ;;
-    *) echo "Unknown arg: $1" >&2; usage; exit 2 ;;
+    --repo) REPO="$2"; shift 2 ;;
+    --manifest) MANIFEST="$2"; shift 2 ;;
+    --check) MODE="check"; shift ;;
+    --dry-run) MODE="dry-run"; shift ;;
+    --apply) MODE="apply"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown argument: $1" >&2; usage >&2; exit 2 ;;
   esac
 done
 
+if [[ ! "$REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  echo "error: --repo must be OWNER/NAME" >&2
+  exit 2
+fi
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "error: ruleset manifest not found: $MANIFEST" >&2
+  exit 1
+fi
+
+manifest_json="$(node -e '
+  const fs = require("node:fs");
+  const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  if (value.target !== "branch" || !value.name) throw new Error("manifest must name a branch ruleset");
+  process.stdout.write(JSON.stringify(value));
+' "$MANIFEST")"
+ruleset_name="$(printf '%s' "$manifest_json" | node -e '
+  let source = "";
+  process.stdin.on("data", (chunk) => (source += chunk));
+  process.stdin.on("end", () => process.stdout.write(JSON.parse(source).name));
+')"
+
+if [[ "$MODE" == "dry-run" ]]; then
+  printf '%s\n' "$manifest_json"
+  exit 0
+fi
+
 if ! command -v gh >/dev/null 2>&1; then
-  echo "error: gh CLI not found. Install from https://cli.github.com/" >&2
+  echo "error: gh CLI is required for ruleset readback" >&2
   exit 1
 fi
 if ! gh auth status >/dev/null 2>&1; then
-  echo "error: gh not authenticated. Run 'gh auth login' or set GH_TOKEN." >&2
+  echo "error: gh is not authenticated; set GH_TOKEN or run gh auth login" >&2
   exit 1
 fi
 
-# Build the JSON payload. We require code-owner review and at least one
-# approving review. Status checks are required and must be up-to-date. Force
-# pushes and deletions are denied. Signed commits and linear history are
-# required. Conversation resolution required.
-build_payload() {
-  local contexts_json
-  contexts_json=$(printf '"%s",' "${REQUIRED_CHECKS[@]}")
-  contexts_json="[${contexts_json%,}]"
+list_json="$(gh api "repos/$REPO/rulesets?includes_parents=false")"
+ruleset_ids="$(printf '%s' "$list_json" | node -e '
+  let source = "";
+  const name = process.argv[1];
+  process.stdin.on("data", (chunk) => (source += chunk));
+  process.stdin.on("end", () => {
+    const ids = JSON.parse(source).filter((item) => item.name === name).map((item) => item.id);
+    process.stdout.write(ids.join("\n"));
+  });
+' "$ruleset_name")"
+ruleset_count="$(printf '%s\n' "$ruleset_ids" | sed '/^$/d' | wc -l | tr -d ' ')"
+if [[ "$ruleset_count" -gt 1 ]]; then
+  echo "error: multiple repository rulesets are named '$ruleset_name'; refusing ambiguous reconciliation" >&2
+  exit 1
+fi
+ruleset_id="$(printf '%s\n' "$ruleset_ids" | sed -n '1p')"
 
-  cat <<JSON
-{
-  "required_status_checks": {
-    "strict": true,
-    "contexts": ${contexts_json}
-  },
-  "enforce_admins": true,
-  "required_pull_request_reviews": {
-    "dismiss_stale_reviews": true,
-    "require_code_owner_reviews": true,
-    "required_approving_review_count": 1,
-    "require_last_push_approval": true
-  },
-  "restrictions": null,
-  "required_linear_history": true,
-  "allow_force_pushes": false,
-  "allow_deletions": false,
-  "required_conversation_resolution": true,
-  "lock_branch": false,
-  "allow_fork_syncing": false,
-  "required_signatures": true
-}
-JSON
-}
-
-apply_one() {
-  local repo="$1" branch="$2"
-  echo "==> ${repo}@${branch}"
-  local payload
-  payload=$(build_payload)
-  if [[ "$DRY_RUN" -eq 1 ]]; then
-    echo "$payload"
-    return 0
+if [[ "$MODE" == "apply" ]]; then
+  if [[ -n "$ruleset_id" ]]; then
+    gh api -X PUT "repos/$REPO/rulesets/$ruleset_id" --input "$MANIFEST" >/dev/null
+    echo "updated ruleset $ruleset_name ($ruleset_id)"
+  else
+    created_json="$(gh api -X POST "repos/$REPO/rulesets" --input "$MANIFEST")"
+    ruleset_id="$(printf '%s' "$created_json" | node -e '
+      let source = "";
+      process.stdin.on("data", (chunk) => (source += chunk));
+      process.stdin.on("end", () => process.stdout.write(String(JSON.parse(source).id)));
+    ')"
+    echo "created ruleset $ruleset_name ($ruleset_id)"
   fi
-  # PUT /repos/{owner}/{repo}/branches/{branch}/protection
-  echo "$payload" \
-    | gh api -X PUT "repos/${repo}/branches/${branch}/protection" \
-        -H "Accept: application/vnd.github+json" \
-        --input - \
-    > /dev/null
-  # Signed commits is a separate endpoint historically; the unified payload
-  # above already includes required_signatures, but enforce explicitly too
-  # so older gh API versions still set it.
-  gh api -X POST "repos/${repo}/branches/${branch}/protection/required_signatures" \
-        -H "Accept: application/vnd.github+json" \
-    > /dev/null 2>&1 || true
-  echo "    ok"
-}
+fi
 
-main() {
-  for repo in "${REPOS[@]}"; do
-    for branch in "${BRANCHES[@]}"; do
-      if gh api "repos/${repo}/branches/${branch}" >/dev/null 2>&1; then
-        apply_one "$repo" "$branch"
-      else
-        echo "==> ${repo}@${branch} — branch not found, skipping"
-      fi
-    done
-  done
+if [[ -z "$ruleset_id" ]]; then
+  echo "error: required repository ruleset '$ruleset_name' is absent" >&2
+  exit 1
+fi
 
-  cat <<EOF
-
-Done. Verify in the GitHub UI:
-  https://github.com/<owner>/<repo>/settings/branches
-
-Optional checks (not required by this script but recommended once they exist):
-$(printf '  - %s\n' "${OPTIONAL_CHECKS[@]}")
-EOF
-}
-
-main "$@"
+actual_json="$(gh api "repos/$REPO/rulesets/$ruleset_id")"
+printf '%s' "$actual_json" | node -e '
+  const fs = require("node:fs");
+  const expected = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  let source = "";
+  process.stdin.on("data", (chunk) => (source += chunk));
+  process.stdin.on("end", () => {
+    const actual = JSON.parse(source);
+    const pick = (template, value) => {
+      if (Array.isArray(template)) {
+        if (!Array.isArray(value)) return value;
+        return template.map((entry, index) => pick(entry, value[index]));
+      }
+      if (template && typeof template === "object") {
+        return Object.fromEntries(Object.keys(template).map((key) => [key, pick(template[key], value?.[key])]));
+      }
+      return value;
+    };
+    const expectedTypes = expected.rules.map((rule) => rule.type).sort();
+    const actualTypes = actual.rules.map((rule) => rule.type).sort();
+    const projected = {
+      ...pick({
+        name: expected.name,
+        target: expected.target,
+        enforcement: expected.enforcement,
+        bypass_actors: expected.bypass_actors,
+        conditions: expected.conditions,
+      }, actual),
+      rules: expected.rules.map((rule) => {
+        const matches = actual.rules.filter((candidate) => candidate.type === rule.type);
+        if (matches.length !== 1) return { type: rule.type, count: matches.length };
+        return pick(rule, matches[0]);
+      }),
+    };
+    if (JSON.stringify(expectedTypes) !== JSON.stringify(actualTypes) || JSON.stringify(projected) !== JSON.stringify(expected)) {
+      console.error(`error: repository ruleset drift detected for ${expected.name}`);
+      console.error(JSON.stringify({ expected, actual: projected }, null, 2));
+      process.exit(1);
+    }
+    console.log(`ruleset readback passed: ${expected.name}`);
+  });
+' "$MANIFEST"


### PR DESCRIPTION
# Relates to

Refs #13306. This PR intentionally does not close the issue: repository-owner ruleset application, audit-log attribution, and hosted/local/admin canaries remain outstanding.

- [x] This PR targets `develop`. Head `13de70af8aba25e979c0dd9be7a4ae186fe20141` is rebased directly onto current `develop@acf51a6eb977b3ebb493d7638ee11f41917c893a`; the predecessor `c5200e84` series and final series are 4/4 `=` by range-diff.
- [ ] Complete post-sync install/root verification. Focused exact-head contracts, workflow-trigger audit, dry-run manifest validation, actionlint parity, and clean-worktree verification passed; `bun install` and root `bun run verify` remain pending.
- [ ] A reviewer can confirm the change works without reading the code. The declarative contract is inspectable, but hosted PR/merge-group results and owner canaries remain pending.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@210823b7d5366c014644fcefd3cfa0dc5439b92d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Head `13de70af8aba25e979c0dd9be7a4ae186fe20141` is rebased onto current `develop@acf51a6eb977b3ebb493d7638ee11f41917c893a`; exact range-diff from predecessor `c5200e84` is 4/4 `=`.
- [ ] Root `bun run verify` passes post-sync. Focused exact-head reruns, trigger audit, helper dry-run, actionlint parity, and diff/status checks are green; `bun install` and root verification remain pending before approval or merge.

# Risks

Large operational risk if misconfigured: a missing required context can deadlock merges, while an under-scoped ruleset can permit unsafe landings. This draft separates source from owner-only application, defaults the helper to read-only `--check`, requires literal `All Tests Passed`, and performs no repository-settings mutation.

# Background

## What does this PR do?

- Restores canonical CI on pull requests targeting `develop`/`main` and every `merge_group` candidate.
- Renames the existing fail-closed aggregate job to the stable literal `All Tests Passed` context and adds merge-group base/head handling to the gitleaks range.
- Replaces stale `typecheck`/`test`/`gitleaks` protection assumptions with one reviewed no-bypass repository-ruleset manifest for `develop` and `main`.
- Makes the compatibility helper read-only by default, with explicit `--apply`, exact-name ambiguity refusal, and semantic live readback.
- Adds scheduled, manual, and external `repository_dispatch` drift readback without settings-write permission.
- Pins the topology with deterministic contract tests and updates workflow documentation.

## What kind of change is this?

Bug fix and security/operations hardening.

# Documentation changes needed?

Documentation changed in `.github/workflows/README.md` to define the single required aggregate, declarative ruleset, safe application boundary, and readback paths.

# Testing

## Where should a reviewer start?

1. `.github/workflows/ci.yml`
2. `.github/rulesets/required-branches.json`
3. `scripts/security/apply-branch-protection.sh`
4. `packages/scripts/__tests__/repository-ruleset-contract.test.ts`
5. `packages/scripts/__tests__/workflow-trigger-policy.test.ts`

## Detailed testing steps

Exact-head validation at `13de70af8aba25e979c0dd9be7a4ae186fe20141` on parent/current `develop@acf51a6eb977b3ebb493d7638ee11f41917c893a` from an isolated checkout:

- Range-diff from predecessor `c5200e84`: 4/4 `=`.

```text
bun test packages/scripts/__tests__/workflow-trigger-policy.test.ts packages/scripts/__tests__/repository-ruleset-contract.test.ts
  PASS — 17/17 tests, 45 expects
bun run audit:workflow-triggers
  PASS — verified 58 workflows and 18 develop push surfaces
./scripts/security/apply-branch-protection.sh --dry-run
  PASS — JSON parsed and matched exactly five rule types:
  deletion, non_fast_forward, pull_request, required_linear_history,
  required_status_checks
actionlint (base/head normalized comparison)
  BASELINE — base 1/1 and head 1/1 have identical normalized SC2034 output;
  no new actionlint diagnostic
git diff --check && git status --short --branch
  PASS — diff and isolated checkout status clean
```

`bun install` and root `bun run verify` were not run and remain pending. Hosted exact-head PR and manual checks must still confirm the exact check-run context is `All Tests Passed`; merge-group and organization-owner apply/readback canaries also remain pending. Do not run `--apply` until hosted evidence is green and an organization owner approves the settings change.

# Evidence Gate

<!-- evidence-head:13de70af8aba25e979c0dd9be7a4ae186fe20141 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - repository workflow and ruleset source only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - repository workflow and ruleset source only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - no user-facing visual flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no application backend path; hosted check suites remain pending.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, prompt, action, model, or provider behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: declarative `.github/rulesets/required-branches.json` and exact Git tree `d8c2c801c158110a140b000696b953645bb6f31e`; no live settings changed.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered UI.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - repository control-plane source only. Authoritative runtime evidence remains the hosted PR/merge-group suites and owner-performed post-apply readback/canaries.

## Screenshots (before / after) + video walkthrough

N/A - no visual surface.

## Audio / voice walkthrough

N/A - no audio/voice surface.

## Known gaps / failures

- Rebased exact-head focused evidence is green: workflow-trigger and ruleset contracts passed 17/17 with 45 expects; the trigger audit verified 58 workflows and 18 develop push surfaces; dry-run JSON matched the exact five rule types; base/head actionlint retained the identical normalized 1/1 SC2034 baseline; and diff/status checks were clean.
- Rebase and exact-head restamp are complete at `13de70af8aba25e979c0dd9be7a4ae186fe20141` on `develop@acf51a6eb977b3ebb493d7638ee11f41917c893a`; range-diff from predecessor `c5200e84` is 4/4 `=`.
- Hosted exact-head PR/manual checks, merge-group context proof, `bun install`, root `bun run verify`, and organization-owner apply/readback canaries remain pending. Focused contracts, trigger audit, dry-run JSON validation, actionlint parity, and diff/status verification are complete.
- No workflow was manually dispatched and no ruleset/branch-protection setting was applied.
- Scheduled/external readback intentionally fails until an owner provisions `REPOSITORY_RULESET_READ_TOKEN` with repository `Administration: read`; workflow-scoped `github.token` is not used.
- Code Owner review intentionally remains disabled because every `@elizaos/*` entry in `.github/CODEOWNERS` is explicitly a placeholder. An owner must replace and verify those teams before a separate reviewed enablement.
- Required-signature enforcement is deferred: it conflicts with contributor-safe web squash/rebase behavior. The manifest allows only squash and rebase under linear history; an owner must prove signed contributor canaries before proposing signature enforcement.
- #13306 remains open until an authorized owner applies the reviewed ruleset, identifies the deleting actor from audit logs, and attaches live readback, red/green required-check, and rejected direct-push canaries.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop / multi-agent
Contribution skill revision: elizaOS/eliza@210823b7d5366c014644fcefd3cfa0dc5439b92d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-13306-ruleset-prerequisite]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop / multi-agent","skill_revision":"elizaOS/eliza@210823b7d5366c014644fcefd3cfa0dc5439b92d:packages/skills/skills/contribute-to-eliza"} -->

