### PR TITLE
fix(documents): replace fragment revisions atomically

### DIFF
--- a/packages/cloud/test-mocks/test/provider-contract/whatsapp-cloud-webhook.contract.test.ts
+++ b/packages/cloud/test-mocks/test/provider-contract/whatsapp-cloud-webhook.contract.test.ts
@@ -72,7 +72,7 @@ function createWebhookRuntime(): IAgentRuntime {
       return true;
     },
     adapter: {
-      documentListQueryCapability: 2,
+      documentListQueryCapability: 3,
       getDocument: async ({ documentId }: { documentId: UUID }) =>
         memoryStore.get(String(documentId)) ?? null,
       compareAndSwapDocument: async ({

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -29,6 +29,7 @@ import type {
 	DocumentListQueryParams,
 	DocumentListQueryResult,
 	DocumentMutationResult,
+	DocumentRevisionReplaceParams,
 	Entity,
 	GetConnectorAccountCredentialRefParams,
 	GetConnectorAccountParams,
@@ -115,9 +116,9 @@ export abstract class DatabaseAdapter<DB extends object = object>
 {
 	/**
 	 * Exact document-store contract implemented by every first-class adapter.
-	 * Version 2 adds canonical lookup/search authorization and CAS mutations.
+	 * Version 3 adds atomic parent-and-fragment revision replacement.
 	 */
-	abstract readonly documentListQueryCapability: 2;
+	abstract readonly documentListQueryCapability: 3;
 
 	abstract queryDocuments(
 		params: DocumentListQueryParams,
@@ -131,6 +132,10 @@ export abstract class DatabaseAdapter<DB extends object = object>
 
 	abstract compareAndSwapDocument(
 		params: DocumentCompareAndSwapParams,
+	): Promise<DocumentMutationResult>;
+
+	abstract replaceDocumentRevision(
+		params: DocumentRevisionReplaceParams,
 	): Promise<DocumentMutationResult>;
 
 	abstract deleteDocumentWithSnapshot(

--- a/packages/core/src/database/document-list-query.test.ts
+++ b/packages/core/src/database/document-list-query.test.ts
@@ -119,7 +119,7 @@ describe("document-list capability contract", () => {
 		const adapter = new InMemoryDatabaseAdapter();
 		Object.defineProperty(adapter, "documentListQueryCapability", {
 			configurable: true,
-			value: 3,
+			value: 4,
 		});
 		const queryDocuments = vi.spyOn(adapter, "queryDocuments");
 
@@ -128,8 +128,8 @@ describe("document-list capability contract", () => {
 		).rejects.toMatchObject({
 			code: "DOCUMENT_STORE_CAPABILITY_REQUIRED",
 			context: expect.objectContaining({
-				expectedVersion: 2,
-				advertisedVersion: 3,
+				expectedVersion: 3,
+				advertisedVersion: 4,
 			}),
 		});
 		expect(queryDocuments).not.toHaveBeenCalled();

--- a/packages/core/src/database/document-list-query.ts
+++ b/packages/core/src/database/document-list-query.ts
@@ -12,13 +12,14 @@ import {
 	type DocumentListQueryResult,
 	type DocumentMutationSnapshot,
 	type DocumentRequesterContext,
+	type DocumentRevisionReplaceParams,
 	type IDatabaseAdapter,
 	type Memory,
 	MemoryType,
 	type UUID,
 } from "../types";
 
-export const DOCUMENT_LIST_QUERY_CAPABILITY_VERSION = 2 as const;
+export const DOCUMENT_LIST_QUERY_CAPABILITY_VERSION = 3 as const;
 export const DOCUMENT_LIST_MAX_LIMIT = 100;
 export const DOCUMENT_LIST_MAX_OFFSET = 10_000;
 export const DOCUMENT_LIST_MAX_QUERY_LENGTH = 512;
@@ -27,6 +28,7 @@ export const DOCUMENT_LIST_MAX_TAG_LENGTH = 128;
 export const DOCUMENT_LIST_MAX_REQUESTER_ROOMS = 1_000;
 export const DOCUMENT_LIST_MAX_PINNED_PAGES =
 	Math.floor(DOCUMENT_LIST_MAX_OFFSET / DOCUMENT_LIST_MAX_LIMIT) + 1;
+export const DOCUMENT_REVISION_MAX_FRAGMENTS = 10_000;
 
 export interface DocumentListQueryCapableAdapter {
 	readonly documentListQueryCapability: typeof DOCUMENT_LIST_QUERY_CAPABILITY_VERSION;
@@ -329,6 +331,82 @@ export function readDocumentMutationSnapshot(
 		...(scopedToEntityId ? { scopedToEntityId } : {}),
 		...(addedBy ? { addedBy } : {}),
 	};
+}
+
+/** Rejects malformed revision batches before an adapter begins a transaction. */
+export function validateDocumentRevisionReplacement(
+	params: DocumentRevisionReplaceParams,
+): void {
+	validateDocumentRequesterContext(params);
+	const replacement = params.replacement;
+	const replacementMetadata = replacement.metadata as
+		| Record<string, unknown>
+		| undefined;
+	const revision = replacementMetadata?.documentRevision;
+	const replacementSnapshot = readDocumentMutationSnapshot(replacement);
+	const invalid = (
+		reason: string,
+		context: Record<string, unknown> = {},
+	): never => {
+		throw new ElizaError("Invalid atomic document revision replacement", {
+			code: "DOCUMENT_MUTATION_INVALID_REPLACEMENT",
+			context: { documentId: params.documentId, reason, ...context },
+		});
+	};
+	if (
+		replacement.id !== params.documentId ||
+		replacement.agentId !== params.agentId ||
+		replacementMetadata?.type !== MemoryType.DOCUMENT ||
+		replacementMetadata.documentId !== params.documentId ||
+		typeof replacement.content.text !== "string" ||
+		revision !== params.expected.revision + 1 ||
+		!replacementSnapshot ||
+		replacementSnapshot.scope !== params.expected.scope ||
+		replacementSnapshot.roomId !== params.expected.roomId ||
+		replacementSnapshot.entityId !== params.expected.entityId ||
+		replacementSnapshot.scopedToEntityId !== params.expected.scopedToEntityId ||
+		replacementSnapshot.addedBy !== params.expected.addedBy ||
+		replacementSnapshot.ingestionAttemptId !==
+			params.expected.ingestionAttemptId ||
+		replacementSnapshot.ingestionState !== params.expected.ingestionState
+	) {
+		invalid("parent identity or revision does not match the mutation");
+	}
+	if (params.fragments.length > DOCUMENT_REVISION_MAX_FRAGMENTS) {
+		invalid("fragment batch exceeds the supported bound", {
+			fragmentCount: params.fragments.length,
+		});
+	}
+	const ids = new Set<string>();
+	for (let index = 0; index < params.fragments.length; index++) {
+		const fragment = params.fragments[index];
+		const fragmentId = fragment.id;
+		const metadata = fragment.metadata as Record<string, unknown> | undefined;
+		if (
+			!isUuid(fragmentId) ||
+			fragmentId === params.documentId ||
+			(typeof fragmentId === "string" && ids.has(fragmentId)) ||
+			fragment.agentId !== replacement.agentId ||
+			fragment.roomId !== replacement.roomId ||
+			fragment.worldId !== replacement.worldId ||
+			fragment.entityId !== replacement.entityId ||
+			metadata?.type !== MemoryType.FRAGMENT ||
+			metadata.documentId !== params.documentId ||
+			metadata.documentRevision !== revision ||
+			metadata.position !== index ||
+			typeof fragment.content.text !== "string" ||
+			(fragment.embedding !== undefined &&
+				(!Array.isArray(fragment.embedding) ||
+					fragment.embedding.length === 0 ||
+					fragment.embedding.some((value) => !Number.isFinite(value))))
+		) {
+			invalid("fragment is not a complete member of the replacement revision", {
+				fragmentIndex: index,
+				fragmentId,
+			});
+		}
+		ids.add(fragmentId as UUID);
+	}
 }
 
 /** Canonical read decision shared by list, lookup, and fragment search. */
@@ -882,6 +960,7 @@ export function hasDocumentListQueryCapability(
 		getDocument?: unknown;
 		queryDocumentFragments?: unknown;
 		compareAndSwapDocument?: unknown;
+		replaceDocumentRevision?: unknown;
 		deleteDocumentWithSnapshot?: unknown;
 	};
 	return (
@@ -891,6 +970,7 @@ export function hasDocumentListQueryCapability(
 		typeof candidate.getDocument === "function" &&
 		typeof candidate.queryDocumentFragments === "function" &&
 		typeof candidate.compareAndSwapDocument === "function" &&
+		typeof candidate.replaceDocumentRevision === "function" &&
 		typeof candidate.deleteDocumentWithSnapshot === "function"
 	);
 }
@@ -902,7 +982,7 @@ function requireDocumentListQueryCapability(adapter: IDatabaseAdapter): void {
 		queryDocuments?: unknown;
 	};
 	throw new ElizaError(
-		"Database adapter must implement document-store capability v2; migrate by adding authorized list, lookup, fragment search, CAS update, and CAS delete methods",
+		"Database adapter must implement document-store capability v3; migrate by adding authorized list, lookup, fragment search, atomic revision replacement, CAS update, and CAS delete methods",
 		{
 			code: "DOCUMENT_STORE_CAPABILITY_REQUIRED",
 			context: {
@@ -911,7 +991,7 @@ function requireDocumentListQueryCapability(adapter: IDatabaseAdapter): void {
 				advertisedVersion: candidate.documentListQueryCapability,
 				hasQueryMethod: typeof candidate.queryDocuments === "function",
 				migrationGuide:
-					"Implement IDatabaseAdapter documentListQueryCapability=2 and all document-store methods; no compatibility scan is supported.",
+					"Implement IDatabaseAdapter documentListQueryCapability=3 and all document-store methods, including replaceDocumentRevision; no compatibility scan is supported.",
 			},
 			severity: "fatal",
 		},

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -41,6 +41,7 @@ import type {
 	DocumentListQueryParams,
 	DocumentListQueryResult,
 	DocumentMutationResult,
+	DocumentRevisionReplaceParams,
 	EntitiesForRoomsResult,
 	Entity,
 	GetConnectorAccountCredentialRefParams,
@@ -91,6 +92,7 @@ import {
 	isDocumentVisibleToRequester,
 	queryDocumentFragmentsInMemory,
 	queryDocumentsInMemory,
+	validateDocumentRevisionReplacement,
 } from "./document-list-query";
 
 function asUuid(id: string): UUID {
@@ -873,6 +875,66 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		return updated
 			? { status: "updated", document: updated }
 			: { status: "conflict" };
+	}
+
+	async replaceDocumentRevision(
+		params: DocumentRevisionReplaceParams,
+	): Promise<DocumentMutationResult> {
+		validateDocumentRevisionReplacement(params);
+		const existing = this.memoriesById.get(String(params.documentId));
+		if (!existing || existing.agentId !== params.agentId) {
+			return { status: "not_found" };
+		}
+		if (!documentMutationSnapshotMatches(existing, params.expected)) {
+			return { status: "conflict" };
+		}
+		if (!canRequesterMutateDocument(existing, params)) {
+			return { status: "forbidden" };
+		}
+		const oldFragmentIds = new Set(
+			Array.from(this.memoriesById.values())
+				.filter(
+					(memory) =>
+						memory.agentId === params.agentId &&
+						memory.metadata?.type === MemoryType.FRAGMENT &&
+						memory.metadata.documentId === params.documentId,
+				)
+				.map((memory) => String(memory.id)),
+		);
+		for (const fragment of params.fragments) {
+			if (
+				this.memoriesById.has(String(fragment.id)) &&
+				!oldFragmentIds.has(String(fragment.id))
+			) {
+				throw new ElizaError("Atomic document fragment id already exists", {
+					code: "DOCUMENT_FRAGMENT_ID_CONFLICT",
+					context: { documentId: params.documentId, fragmentId: fragment.id },
+				});
+			}
+		}
+		for (const id of oldFragmentIds) this.memoriesById.delete(id);
+		for (const [key, list] of this.memoriesByRoom) {
+			this.memoriesByRoom.set(
+				key,
+				list.filter((memory) => !oldFragmentIds.has(String(memory.id))),
+			);
+		}
+		const replacement = { ...params.replacement, id: params.documentId };
+		this.memoriesById.set(String(params.documentId), replacement);
+		for (const [key, list] of this.memoriesByRoom) {
+			const index = list.findIndex((memory) => memory.id === params.documentId);
+			if (index >= 0)
+				this.memoriesByRoom.set(key, list.with(index, replacement));
+		}
+		for (const fragment of params.fragments) {
+			this.memoriesById.set(String(fragment.id), fragment);
+			const key = roomTableKey("document_fragments", fragment.roomId);
+			this.memoriesByRoom.set(key, [
+				...(this.memoriesByRoom.get(key) ?? []),
+				fragment,
+			]);
+		}
+		return { status: "updated", document: replacement };
 	}
 
 	async deleteDocumentWithSnapshot(

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -902,12 +902,9 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 				.map((memory) => String(memory.id)),
 		);
 		for (const fragment of params.fragments) {
-			if (
-				this.memoriesById.has(String(fragment.id)) &&
-				!oldFragmentIds.has(String(fragment.id))
-			) {
+			if (this.memoriesById.has(String(fragment.id))) {
 				throw new ElizaError("Atomic document fragment id already exists", {
-					code: "DOCUMENT_FRAGMENT_ID_CONFLICT",
+					code: "DOCUMENT_REVISION_FRAGMENT_ID_CONFLICT",
 					context: { documentId: params.documentId, fragmentId: fragment.id },
 				});
 			}

--- a/packages/core/src/features/documents/provider-pinned.test.ts
+++ b/packages/core/src/features/documents/provider-pinned.test.ts
@@ -41,11 +41,12 @@ function runtimeWithDocumentQuery(
 	return {
 		agentId,
 		adapter: {
-			documentListQueryCapability: 2,
+			documentListQueryCapability: 3,
 			queryDocuments,
 			queryDocumentFragments: vi.fn(async () => []),
 			getDocument: vi.fn(async () => null),
 			compareAndSwapDocument: vi.fn(async () => ({ status: "ok" })),
+			replaceDocumentRevision: vi.fn(async () => ({ status: "ok" })),
 			deleteDocumentWithSnapshot: vi.fn(async () => ({ status: "ok" })),
 		},
 		getMemories: vi.fn(async () => []),
@@ -218,11 +219,12 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 		const runtime = {
 			agentId,
 			adapter: {
-				documentListQueryCapability: 2,
+				documentListQueryCapability: 3,
 				queryDocuments: queryDocumentsMock,
 				queryDocumentFragments: vi.fn(async () => []),
 				getDocument: vi.fn(async () => null),
 				compareAndSwapDocument: vi.fn(async () => ({ status: "ok" })),
+				replaceDocumentRevision: vi.fn(async () => ({ status: "ok" })),
 				deleteDocumentWithSnapshot: vi.fn(async () => ({ status: "ok" })),
 			},
 			getMemories: vi.fn(async () => []),
@@ -272,11 +274,12 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 		const runtime = {
 			agentId,
 			adapter: {
-				documentListQueryCapability: 2,
+				documentListQueryCapability: 3,
 				queryDocuments: queryDocumentsMock,
 				queryDocumentFragments: vi.fn(async () => []),
 				getDocument: vi.fn(async () => null),
 				compareAndSwapDocument: vi.fn(async () => ({ status: "ok" })),
+				replaceDocumentRevision: vi.fn(async () => ({ status: "ok" })),
 				deleteDocumentWithSnapshot: vi.fn(async () => ({ status: "ok" })),
 			},
 			getMemories: vi.fn(async () => []),

--- a/packages/core/src/features/documents/service-authorization.real.test.ts
+++ b/packages/core/src/features/documents/service-authorization.real.test.ts
@@ -13,6 +13,7 @@ import {
 	ChannelType,
 	type Memory,
 	MemoryType,
+	ModelType,
 	type State,
 	type UUID,
 } from "../../types/index.ts";
@@ -29,9 +30,14 @@ const DELETE_DOCUMENT_ID = "f4300000-0000-4000-8000-000000000005" as UUID;
 const VISIBLE_DOCUMENT_ID = "f4300000-0000-4000-8000-000000000009" as UUID;
 const HIDDEN_USER_DOCUMENT_ID = "f4300000-0000-4000-8000-000000000010" as UUID;
 const FOREIGN_DOCUMENT_ID = "f4300000-0000-4000-8000-000000000011" as UUID;
+const ATOMIC_UPDATE_DOCUMENT_ID =
+	"f4300000-0000-4000-8000-000000000016" as UUID;
+const FAILED_UPDATE_DOCUMENT_ID =
+	"f4300000-0000-4000-8000-000000000018" as UUID;
 
 let runtime: AgentRuntime;
 let cleanup: () => Promise<void>;
+let failEmbedding = false;
 
 function message(): Memory {
 	return {
@@ -248,6 +254,120 @@ describe("DocumentService requester authorization", () => {
 		} finally {
 			getService.mockRestore();
 		}
+	});
+
+	it("keeps the complete old revision when replacement embedding fails", async () => {
+		const embed = async () => {
+			if (failEmbedding) throw new Error("injected update embedding failure");
+			return Array.from({ length: 384 }, (_, index) => (index % 11) / 10);
+		};
+		runtime.registerModel(
+			ModelType.TEXT_EMBEDDING,
+			async () => embed(),
+			"atomic-update-test",
+			1_000,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_EMBEDDING_BATCH,
+			async (_runtime, params: { texts?: string[] }) =>
+				Promise.all((params.texts ?? []).map(() => embed())),
+			"atomic-update-test",
+			1_000,
+		);
+		const original = userPrivateDocument(
+			FAILED_UPDATE_DOCUMENT_ID,
+			"Failure original body",
+		);
+		const oldFragmentId = "f4300000-0000-4000-8000-000000000019" as UUID;
+		await runtime.createMemories([
+			{ memory: original, tableName: "documents" },
+			{
+				memory: documentFragment(
+					original,
+					"Failure old fragment",
+					oldFragmentId,
+				),
+				tableName: "document_fragments",
+			},
+		]);
+		failEmbedding = true;
+		try {
+			await expect(
+				new DocumentService(runtime).updateDocument({
+					documentId: FAILED_UPDATE_DOCUMENT_ID,
+					content: "Replacement that must not become visible",
+					message: message(),
+				}),
+			).rejects.toThrow("injected update embedding failure");
+		} finally {
+			failEmbedding = false;
+		}
+		await expect(
+			runtime.adapter.getMemoryById(FAILED_UPDATE_DOCUMENT_ID),
+		).resolves.toMatchObject({
+			content: { text: "Failure original body" },
+			metadata: { documentRevision: 0 },
+		});
+		await expect(
+			runtime.adapter.getMemoryById(oldFragmentId),
+		).resolves.toMatchObject({ content: { text: "Failure old fragment" } });
+	});
+
+	it("commits a parent and its replacement fragments as one revision", async () => {
+		const original = userPrivateDocument(
+			ATOMIC_UPDATE_DOCUMENT_ID,
+			"Atomic original body",
+		);
+		const oldFragmentId = "f4300000-0000-4000-8000-000000000017" as UUID;
+		await runtime.createMemories([
+			{ memory: original, tableName: "documents" },
+			{
+				memory: documentFragment(
+					original,
+					"Atomic old fragment",
+					oldFragmentId,
+				),
+				tableName: "document_fragments",
+			},
+		]);
+		const service = new DocumentService(runtime);
+		await expect(
+			service.updateDocument({
+				documentId: ATOMIC_UPDATE_DOCUMENT_ID,
+				content: "Atomic replacement body",
+				message: message(),
+			}),
+		).resolves.toMatchObject({ fragmentCount: 1 });
+
+		const context = {
+			agentId: runtime.agentId,
+			requesterEntityId: USER_ID,
+			requesterRoomIds: [ROOM_ID],
+			requesterRole: "USER" as const,
+		};
+		const parent = await runtime.adapter.getDocument({
+			...context,
+			documentId: ATOMIC_UPDATE_DOCUMENT_ID,
+		});
+		const fragments = await runtime.adapter.queryDocumentFragments({
+			...context,
+			limit: 100,
+		});
+		const replacementFragments = fragments.filter(
+			(fragment) => fragment.metadata?.documentId === ATOMIC_UPDATE_DOCUMENT_ID,
+		);
+		expect(parent).toMatchObject({
+			content: { text: "Atomic replacement body" },
+			metadata: { documentRevision: 1 },
+		});
+		expect(replacementFragments).toHaveLength(1);
+		expect(replacementFragments[0]).toMatchObject({
+			content: { text: "Atomic replacement body" },
+			metadata: { documentRevision: 1, position: 0 },
+		});
+		await expect(
+			runtime.adapter.getMemoryById(oldFragmentId),
+		).resolves.toBeNull();
 	});
 
 	it("denies same-turn update and delete after room membership is revoked", async () => {

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -2307,11 +2307,6 @@ export class DocumentService extends Service {
 			metadata: updatedMetadata,
 			createdAt: existingDocument.createdAt,
 		};
-		// Stage the complete replacement generation BEFORE touching the parent.
-		// Fragments inherit documentRevision R+1 from updatedMetadata while the
-		// parent still publishes revision R, and the adapter's fragment reader
-		// joins on matching fragment/parent documentRevision, so staged fragments
-		// stay invisible to concurrent readers until the CAS commit below.
 		const fragments = await this.splitAndCreateFragments(
 			{
 				id: options.documentId,
@@ -2322,43 +2317,19 @@ export class DocumentService extends Service {
 			200,
 			{
 				roomId: existingDocument.roomId,
-				worldId: existingDocument.worldId ?? this.runtime.agentId,
+				worldId: existingDocument.worldId,
 				entityId: existingDocument.entityId,
 			},
 		);
-		try {
-			await this.processDocumentFragmentsBatched(fragments, {
-				continueOnError: false,
-			});
-		} catch (stagingError) {
-			// error-policy:J2 Discard the partially staged (reader-invisible)
-			// generation, then rethrow with document identity; the committed
-			// revision R parent and its fragments are untouched.
-			await this.discardStagedFragments(options.documentId, fragments);
-			throw new ElizaError(
-				`Failed to stage replacement fragments for document ${options.documentId}`,
-				{
-					code: "DOCUMENT_UPDATE_STAGING_FAILED",
-					context: {
-						documentId: options.documentId,
-						stagedFragmentCount: fragments.length,
-					},
-					cause: stagingError,
-				},
-			);
-		}
-
-		// The single-statement compare-and-swap is the atomic commit point on
-		// real SQL adapters: it flips the parent from revision R to R+1, which
-		// simultaneously hides the old generation and exposes the staged one.
-		const mutation = await this.runtime.adapter.compareAndSwapDocument({
+		await this.prepareDocumentFragmentEmbeddings(fragments);
+		const mutation = await this.runtime.adapter.replaceDocumentRevision({
 			...requestContext,
 			documentId: options.documentId,
 			expected: snapshot,
 			replacement,
+			fragments,
 		});
 		if (mutation.status !== "updated") {
-			await this.discardStagedFragments(options.documentId, fragments);
 			throw new ElizaError("Document authorization changed before update", {
 				code:
 					mutation.status === "forbidden"
@@ -2370,94 +2341,58 @@ export class DocumentService extends Service {
 			});
 		}
 
-		await this.removeSupersededFragments(options.documentId, fragments, {
-			roomId: existingDocument.roomId,
-		});
-
 		return {
 			documentId: options.documentId,
 			fragmentCount: fragments.length,
 		};
 	}
 
-	/**
-	 * Delete a staged-but-never-committed fragment generation. Callers invoke
-	 * this only while the parent still publishes the prior revision, so every
-	 * row removed here was reader-invisible; any row this pass fails to delete
-	 * stays invisible and is swept by the next successful update's
-	 * {@link removeSupersededFragments} pass.
-	 */
-	private async discardStagedFragments(
-		documentId: UUID,
+	/** Stages every embedding before the atomic parent/fragment replacement. */
+	private async prepareDocumentFragmentEmbeddings(
 		fragments: Memory[],
 	): Promise<void> {
-		for (const fragment of fragments) {
-			if (typeof fragment.id !== "string") continue;
+		if (fragments.length === 0 || !hasDocumentEmbeddingModel(this.runtime))
+			return;
+		const batchModel = this.runtime.getModel(ModelType.TEXT_EMBEDDING_BATCH);
+		if (batchModel) {
 			try {
-				await this.runtime.deleteMemory(fragment.id as UUID);
-			} catch (cleanupError) {
-				// error-policy:J7 Discard is best effort and must not mask the
-				// staging or CAS failure being propagated; the leftover row is
-				// reader-invisible (revision mismatch) and swept later.
+				const texts = fragments.map((fragment) => {
+					if (typeof fragment.content.text !== "string") {
+						throw new Error("Document fragment is missing text");
+					}
+					return fragment.content.text;
+				});
+				const vectors = await this.runtime.useModel(
+					ModelType.TEXT_EMBEDDING_BATCH,
+					{ texts },
+				);
+				if (
+					!Array.isArray(vectors) ||
+					vectors.length !== fragments.length ||
+					vectors.some(
+						(vector) => !Array.isArray(vector) || vector.length === 0,
+					)
+				) {
+					throw new Error(
+						"Batch embedding returned an incomplete fragment set",
+					);
+				}
+				for (let index = 0; index < fragments.length; index++) {
+					fragments[index].embedding = vectors[index];
+				}
+				return;
+			} catch (error) {
+				// error-policy:J4 The serial embedding provider is the documented
+				// fallback, and no storage mutation has happened at this point.
 				this.runtime.reportError(
-					"DocumentService.discardStagedFragments",
-					cleanupError instanceof Error
-						? cleanupError
-						: new Error(String(cleanupError)),
-					{ documentId, fragmentId: fragment.id },
+					"DocumentService.stageBatchFragmentEmbedding",
+					error,
+					{ fragmentCount: fragments.length },
 				);
 			}
 		}
-	}
-
-	/**
-	 * Remove every fragment of a document that is not part of the just-committed
-	 * generation. Runs only after the parent CAS commit, so every row deleted
-	 * here is already invisible to readers (its documentRevision no longer
-	 * matches the parent); failure is storage garbage, not data exposure.
-	 */
-	private async removeSupersededFragments(
-		documentId: UUID,
-		committedFragments: Memory[],
-		scope: { roomId: UUID },
-	): Promise<void> {
-		const committedIds = new Set(
-			committedFragments
-				.map((fragment) => fragment.id)
-				.filter((id): id is UUID => typeof id === "string"),
-		);
-		try {
-			const existingFragments = await this.runtime.getMemories({
-				tableName: DOCUMENT_FRAGMENTS_TABLE,
-				agentId: this.runtime.agentId,
-				roomId: scope.roomId,
-				count: 10_000,
-			});
-			for (const fragment of existingFragments) {
-				const metadata = fragment.metadata as
-					| Record<string, unknown>
-					| undefined;
-				if (
-					!this.isDocumentFragmentMemory(fragment) ||
-					metadata?.documentId !== documentId ||
-					typeof fragment.id !== "string" ||
-					committedIds.has(fragment.id as UUID)
-				) {
-					continue;
-				}
-				await this.runtime.deleteMemory(fragment.id as UUID);
-			}
-		} catch (cleanupError) {
-			// error-policy:J7 The update already committed; superseded rows are
-			// reader-invisible and the next successful update sweeps them again,
-			// so cleanup failure is reported instead of failing the update.
-			this.runtime.reportError(
-				"DocumentService.removeSupersededFragments",
-				cleanupError instanceof Error
-					? cleanupError
-					: new Error(String(cleanupError)),
-				{ documentId },
-			);
+		for (const fragment of fragments) {
+			await this.runtime.addEmbeddingToMemory(fragment);
 		}
 	}
 
@@ -2745,7 +2680,7 @@ export class DocumentService extends Service {
 		document: StoredDocument,
 		targetTokens: number,
 		overlap: number,
-		scope: { roomId: UUID; worldId: UUID; entityId: UUID },
+		scope: { roomId: UUID; worldId?: UUID; entityId: UUID },
 	): Promise<Memory[]> {
 		if (!document.content.text) {
 			return [];

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -2317,7 +2317,10 @@ export class DocumentService extends Service {
 			200,
 			{
 				roomId: existingDocument.roomId,
-				worldId: existingDocument.worldId,
+				// Original ingestion coerces fragment worldId to the agent id when the
+				// parent document has none; replacement fragments must match or they
+				// fall out of worldId-scoped retrieval that still sees the old ones.
+				worldId: existingDocument.worldId ?? this.runtime.agentId,
 				entityId: existingDocument.entityId,
 			},
 		);

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -135,7 +135,12 @@ export interface DocumentCompareAndSwapParams extends DocumentRequesterContext {
 	replacement: Memory;
 }
 
-/** Atomic replacement of a document parent and its complete fragment revision. */
+/**
+ * Atomic replacement of a document parent and its complete fragment revision.
+ * Replacement fragment IDs must be fresh; adapters reject IDs from the
+ * committed generation so secondary indexes and asynchronous replicas can
+ * preserve the old revision until the parent commit point advances.
+ */
 export interface DocumentRevisionReplaceParams
 	extends DocumentCompareAndSwapParams {
 	fragments: Memory[];

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -135,6 +135,12 @@ export interface DocumentCompareAndSwapParams extends DocumentRequesterContext {
 	replacement: Memory;
 }
 
+/** Atomic replacement of a document parent and its complete fragment revision. */
+export interface DocumentRevisionReplaceParams
+	extends DocumentCompareAndSwapParams {
+	fragments: Memory[];
+}
+
 /** Compare-and-swap document deletion under canonical mutation policy. */
 export interface DocumentDeleteParams extends DocumentRequesterContext {
 	documentId: UUID;
@@ -1101,13 +1107,13 @@ export interface IDatabaseAdapter<DB extends object = object> {
 	}): Promise<Memory[]>;
 
 	/**
-	 * Required native document-store contract. Version 2 covers canonical
-	 * visibility for list/lookup/search plus compare-and-swap mutation. Adapter
-	 * authors migrating from version 1 must implement all five methods; there is
+	 * Required native document-store contract. Version 3 covers canonical
+	 * visibility for list/lookup/search plus atomic revision replacement. Adapter
+	 * authors migrating from version 2 must implement all six methods; there is
 	 * deliberately no bounded compatibility scan because it cannot preserve
 	 * authorization, counts, or pagination guarantees.
 	 */
-	readonly documentListQueryCapability: 2;
+	readonly documentListQueryCapability: 3;
 	queryDocuments(
 		params: DocumentListQueryParams,
 	): Promise<DocumentListQueryResult>;
@@ -1117,6 +1123,9 @@ export interface IDatabaseAdapter<DB extends object = object> {
 	): Promise<Memory[]>;
 	compareAndSwapDocument(
 		params: DocumentCompareAndSwapParams,
+	): Promise<DocumentMutationResult>;
+	replaceDocumentRevision(
+		params: DocumentRevisionReplaceParams,
 	): Promise<DocumentMutationResult>;
 	deleteDocumentWithSnapshot(
 		params: DocumentDeleteParams,

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -555,6 +555,7 @@ type RuntimeDatabaseAdapterSurface = Omit<
 	| "getDocument"
 	| "queryDocumentFragments"
 	| "compareAndSwapDocument"
+	| "replaceDocumentRevision"
 	| "deleteDocumentWithSnapshot"
 >;
 

--- a/plugins/plugin-inmemorydb/README.md
+++ b/plugins/plugin-inmemorydb/README.md
@@ -7,7 +7,8 @@ Intended for tests, stateless deployments, prototyping, and scenarios where zero
 Custom `IStorage` implementations must provide `applyBatch` to support document
 updates. The adapter fails closed when that primitive is absent because a
 parent document and all fragments of its new revision must become visible
-together.
+together. Replacement fragment IDs must be fresh and cannot reuse IDs from the
+committed generation.
 
 ## Installation
 

--- a/plugins/plugin-inmemorydb/README.md
+++ b/plugins/plugin-inmemorydb/README.md
@@ -4,6 +4,11 @@ A pure in-memory, ephemeral database adapter for elizaOS. All data is completely
 
 Intended for tests, stateless deployments, prototyping, and scenarios where zero setup and zero persistence are the goal. Not suitable for production agents that need to remember past interactions.
 
+Custom `IStorage` implementations must provide `applyBatch` to support document
+updates. The adapter fails closed when that primitive is absent because a
+parent document and all fragments of its new revision must become visible
+together.
+
 ## Installation
 
 ```bash

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -1079,24 +1079,26 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     entityId?: UUID;
     accessContext?: AccessContext;
   }): Promise<Memory[]> {
-    const threshold = params.match_threshold ?? 0.5;
-    const limit = params.count ?? params.limit ?? 10;
+    return this.withDocumentMutationLock(async () => {
+      const threshold = params.match_threshold ?? 0.5;
+      const limit = params.count ?? params.limit ?? 10;
 
-    const results = await this.vectorIndex.search(params.embedding, limit * 2, threshold);
+      const results = await this.vectorIndex.search(params.embedding, limit * 2, threshold);
 
-    const memories: Memory[] = [];
-    for (const result of results) {
-      const memory = await this.storage.get<StoredMemory>(COLLECTIONS.MEMORIES, result.id);
-      if (!memory) continue;
-      if (params.tableName && storedMemoryTableName(memory) !== params.tableName) continue;
-      if (params.roomId && memory.roomId !== params.roomId) continue;
-      if (params.worldId && memory.worldId !== params.worldId) continue;
-      if (params.entityId && memory.entityId !== params.entityId) continue;
-      if (params.unique && !memory.unique) continue;
-      memories.push({ ...toMemory(memory), similarity: result.similarity });
-    }
+      const memories: Memory[] = [];
+      for (const result of results) {
+        const memory = await this.storage.get<StoredMemory>(COLLECTIONS.MEMORIES, result.id);
+        if (!memory) continue;
+        if (params.tableName && storedMemoryTableName(memory) !== params.tableName) continue;
+        if (params.roomId && memory.roomId !== params.roomId) continue;
+        if (params.worldId && memory.worldId !== params.worldId) continue;
+        if (params.entityId && memory.entityId !== params.entityId) continue;
+        if (params.unique && !memory.unique) continue;
+        memories.push({ ...toMemory(memory), similarity: result.similarity });
+      }
 
-    return memories.slice(0, limit);
+      return memories.slice(0, limit);
+    });
   }
 
   async createMemories(

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -782,13 +782,12 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       const oldIds = oldFragments
         .map(({ id }) => id)
         .filter((id): id is string => typeof id === "string");
-      const oldIdSet = new Set(oldIds);
       for (const fragment of params.fragments) {
         const collision = await this.storage.get<StoredMemory>(
           COLLECTIONS.MEMORIES,
           fragment.id as UUID
         );
-        if (collision && !oldIdSet.has(fragment.id as UUID)) {
+        if (collision) {
           throw new ElizaError("Atomic document fragment id already exists", {
             code: "DOCUMENT_REVISION_FRAGMENT_ID_CONFLICT",
             context: { documentId: params.documentId, fragmentId: fragment.id },

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -30,6 +30,7 @@ import {
   type DocumentListQueryParams,
   type DocumentListQueryResult,
   type DocumentMutationResult,
+  type DocumentRevisionReplaceParams,
   documentMutationSnapshotMatches,
   ElizaError,
   type EntitiesForRoomsResult,
@@ -64,6 +65,7 @@ import {
   rankMessageSearch,
   type Task,
   type UUID,
+  validateDocumentRevisionReplacement,
   validateQueryEntitiesPagination,
   type World,
   withinCreatedAtWindow,
@@ -738,6 +740,101 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
         metadata: params.replacement.metadata,
       };
       await this.storage.set(COLLECTIONS.MEMORIES, params.documentId, replacement);
+      return { status: "updated", document: toMemory(replacement) };
+    });
+  }
+
+  async replaceDocumentRevision(
+    params: DocumentRevisionReplaceParams
+  ): Promise<DocumentMutationResult> {
+    validateDocumentRevisionReplacement(params);
+    return this.withDocumentMutationLock(async () => {
+      const stored = await this.storage.get<StoredMemory>(COLLECTIONS.MEMORIES, params.documentId);
+      if (
+        !stored ||
+        storedMemoryTableName(stored) !== "documents" ||
+        stored.agentId !== params.agentId
+      ) {
+        return { status: "not_found" };
+      }
+      const existing = toMemory(stored);
+      if (!documentMutationSnapshotMatches(existing, params.expected)) {
+        return { status: "conflict" };
+      }
+      if (!isDocumentVisibleToRequester(existing, params)) return { status: "not_found" };
+      if (!canRequesterMutateDocument(existing, params)) return { status: "forbidden" };
+      if (!this.storage.applyBatch) {
+        throw new ElizaError(
+          "The configured in-memory storage cannot atomically replace documents",
+          {
+            code: "DOCUMENT_REVISION_ATOMIC_STORAGE_REQUIRED",
+            context: { documentId: params.documentId },
+          }
+        );
+      }
+      const oldFragments = await this.storage.getWhere<StoredMemory>(
+        COLLECTIONS.MEMORIES,
+        (memory) =>
+          memory.agentId === params.agentId &&
+          memory.metadata?.type === MemoryType.FRAGMENT &&
+          memory.metadata.documentId === params.documentId
+      );
+      const oldIds = oldFragments
+        .map(({ id }) => id)
+        .filter((id): id is string => typeof id === "string");
+      const oldIdSet = new Set(oldIds);
+      for (const fragment of params.fragments) {
+        const collision = await this.storage.get<StoredMemory>(
+          COLLECTIONS.MEMORIES,
+          fragment.id as UUID
+        );
+        if (collision && !oldIdSet.has(fragment.id as UUID)) {
+          throw new ElizaError("Atomic document fragment id already exists", {
+            code: "DOCUMENT_REVISION_FRAGMENT_ID_CONFLICT",
+            context: { documentId: params.documentId, fragmentId: fragment.id },
+          });
+        }
+      }
+      const replacement: StoredMemory = {
+        ...stored,
+        ...params.replacement,
+        id: params.documentId,
+        tableName: "documents",
+        agentId: params.agentId,
+      };
+      const newFragments: StoredMemory[] = params.fragments.map((fragment) => ({
+        ...fragment,
+        id: fragment.id,
+        tableName: "document_fragments",
+        agentId: params.agentId,
+        createdAt: fragment.createdAt ?? Date.now(),
+      }));
+      const indexedNewIds: string[] = [];
+      try {
+        for (const fragment of newFragments) {
+          if (!fragment.embedding || fragment.embedding.length === 0) continue;
+          await this.vectorIndex.add(fragment.id as string, fragment.embedding);
+          indexedNewIds.push(fragment.id as string);
+        }
+        await this.storage.applyBatch({
+          collection: COLLECTIONS.MEMORIES,
+          deletes: oldIds,
+          sets: [
+            { id: params.documentId, data: replacement },
+            ...newFragments.map((data) => ({ id: data.id as string, data })),
+          ],
+        });
+      } catch (error) {
+        // error-policy:J2 Staged vector entries are not a committed revision;
+        // remove them before surfacing the storage/vector failure.
+        await Promise.all(indexedNewIds.map((id) => this.vectorIndex.remove(id)));
+        throw new ElizaError("Failed to stage an atomic document revision", {
+          code: "DOCUMENT_REVISION_STAGE_FAILED",
+          context: { documentId: params.documentId },
+          cause: error,
+        });
+      }
+      await Promise.all(oldIds.map((id) => this.vectorIndex.remove(id)));
       return { status: "updated", document: toMemory(replacement) };
     });
   }

--- a/plugins/plugin-inmemorydb/document-list.test.ts
+++ b/plugins/plugin-inmemorydb/document-list.test.ts
@@ -12,7 +12,7 @@ import {
   readDocumentMutationSnapshot,
   type UUID,
 } from "@elizaos/core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "./adapter";
 import { MemoryStorage } from "./storage-memory";
 
@@ -20,6 +20,37 @@ const AGENT_ID = "50000000-0000-0000-0000-000000000001" as UUID;
 const REQUESTER_ID = "50000000-0000-0000-0000-000000000002" as UUID;
 const ROOM_A = "50000000-0000-0000-0000-000000000003" as UUID;
 const ROOM_B = "50000000-0000-0000-0000-000000000004" as UUID;
+
+class BlockingBatchStorage extends MemoryStorage {
+  readonly batchStarted: Promise<void>;
+  private markBatchStarted!: () => void;
+  private releaseBatch!: () => void;
+  private readonly batchRelease: Promise<void>;
+
+  constructor() {
+    super();
+    this.batchStarted = new Promise((resolve) => {
+      this.markBatchStarted = resolve;
+    });
+    this.batchRelease = new Promise((resolve) => {
+      this.releaseBatch = resolve;
+    });
+  }
+
+  release(): void {
+    this.releaseBatch();
+  }
+
+  override async applyBatch(batch: {
+    collection: string;
+    deletes: string[];
+    sets: Array<{ id: string; data: unknown }>;
+  }): Promise<void> {
+    this.markBatchStarted();
+    await this.batchRelease;
+    await super.applyBatch(batch);
+  }
+}
 
 function memory(
   index: number,
@@ -355,5 +386,80 @@ describe("InMemoryDatabaseAdapter document list capability", () => {
         }),
       ]
     );
+  });
+
+  it("does not expose staged revision vectors before the storage swap", async () => {
+    const storage = new BlockingBatchStorage();
+    const adapter = new InMemoryDatabaseAdapter(storage, AGENT_ID);
+    await adapter.initialize();
+    const vectorSearch = vi.spyOn(
+      (
+        adapter as unknown as {
+          vectorIndex: {
+            search: (embedding: number[], limit: number, threshold: number) => Promise<unknown[]>;
+          };
+        }
+      ).vectorIndex,
+      "search"
+    );
+    const original = memory(10, ROOM_A, { documentRevision: 0 });
+    const oldFragment = {
+      ...memory(11, ROOM_A),
+      content: { text: "old searchable fragment" },
+      embedding: [0, 1, ...Array.from({ length: 382 }, () => 0)],
+      metadata: {
+        type: MemoryType.FRAGMENT,
+        documentId: original.id,
+        documentRevision: 0,
+        position: 0,
+      },
+    };
+    await adapter.createMemories([
+      { memory: original, tableName: "documents" },
+      { memory: oldFragment, tableName: "document_fragments" },
+    ]);
+    const expected = readDocumentMutationSnapshot(original);
+    if (!expected) throw new Error("Expected a valid document mutation snapshot");
+    const replacement = {
+      ...original,
+      content: { text: "new body" },
+      metadata: { ...original.metadata, documentRevision: 1 },
+    };
+    const newFragment = {
+      ...oldFragment,
+      id: memory(12, ROOM_A).id,
+      content: { text: "new searchable fragment" },
+      embedding: [1, ...Array.from({ length: 383 }, () => 0)],
+      metadata: { ...oldFragment.metadata, documentRevision: 1 },
+    };
+
+    const replacementPromise = adapter.replaceDocumentRevision({
+      agentId: AGENT_ID,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [],
+      requesterRole: "OWNER",
+      documentId: original.id,
+      expected,
+      replacement,
+      fragments: [newFragment],
+    });
+    await storage.batchStarted;
+    const readPromise = adapter.searchMemories({
+      tableName: "document_fragments",
+      embedding: newFragment.embedding,
+      match_threshold: 0.9,
+      limit: 1,
+    });
+    expect(vectorSearch).not.toHaveBeenCalled();
+
+    storage.release();
+    await expect(replacementPromise).resolves.toMatchObject({ status: "updated" });
+    await expect(readPromise).resolves.toEqual([
+      expect.objectContaining({
+        id: newFragment.id,
+        content: { text: "new searchable fragment" },
+      }),
+    ]);
+    expect(vectorSearch).toHaveBeenCalledOnce();
   });
 });

--- a/plugins/plugin-inmemorydb/document-list.test.ts
+++ b/plugins/plugin-inmemorydb/document-list.test.ts
@@ -294,4 +294,66 @@ describe("InMemoryDatabaseAdapter document list capability", () => {
     ).resolves.toEqual({ status: "conflict" });
     await expect(adapter.getMemoriesByIds([original.id], "documents")).resolves.toHaveLength(1);
   });
+
+  it("atomically replaces a parent and its complete fragment generation", async () => {
+    const adapter = new InMemoryDatabaseAdapter(new MemoryStorage(), AGENT_ID);
+    await adapter.initialize();
+    const original = memory(1, ROOM_A, { documentRevision: 0 });
+    const oldFragment = {
+      ...memory(2, ROOM_A),
+      content: { text: "old fragment" },
+      metadata: {
+        type: MemoryType.FRAGMENT,
+        documentId: original.id,
+        documentRevision: 0,
+        position: 0,
+      },
+    };
+    await adapter.createMemories([
+      { memory: original, tableName: "documents" },
+      { memory: oldFragment, tableName: "document_fragments" },
+    ]);
+    const expected = readDocumentMutationSnapshot(original);
+    if (!expected) throw new Error("Expected a valid document mutation snapshot");
+    const replacement = {
+      ...original,
+      content: { text: "new body" },
+      metadata: { ...original.metadata, documentRevision: 1 },
+    };
+    const newFragment = {
+      ...oldFragment,
+      id: memory(3, ROOM_A).id,
+      content: { text: "new fragment" },
+      metadata: { ...oldFragment.metadata, documentRevision: 1 },
+    };
+    await expect(
+      adapter.replaceDocumentRevision({
+        agentId: AGENT_ID,
+        requesterEntityId: REQUESTER_ID,
+        requesterRoomIds: [],
+        requesterRole: "OWNER",
+        documentId: original.id,
+        expected,
+        replacement,
+        fragments: [newFragment],
+      })
+    ).resolves.toMatchObject({ status: "updated" });
+    await expect(adapter.getMemoriesByIds([oldFragment.id], "document_fragments")).resolves.toEqual(
+      []
+    );
+    await expect(adapter.getMemoriesByIds([original.id], "documents")).resolves.toEqual([
+      expect.objectContaining({
+        content: { text: "new body" },
+        metadata: expect.objectContaining({ documentRevision: 1 }),
+      }),
+    ]);
+    await expect(adapter.getMemoriesByIds([newFragment.id], "document_fragments")).resolves.toEqual(
+      [
+        expect.objectContaining({
+          content: { text: "new fragment" },
+          metadata: expect.objectContaining({ documentRevision: 1 }),
+        }),
+      ]
+    );
+  });
 });

--- a/plugins/plugin-inmemorydb/document-list.test.ts
+++ b/plugins/plugin-inmemorydb/document-list.test.ts
@@ -388,6 +388,74 @@ describe("InMemoryDatabaseAdapter document list capability", () => {
     );
   });
 
+  it("rejects reused fragment ids without corrupting the committed vector", async () => {
+    const storage = new MemoryStorage();
+    const adapter = new InMemoryDatabaseAdapter(storage, AGENT_ID);
+    await adapter.initialize();
+    const original = memory(20, ROOM_A, { documentRevision: 0 });
+    const oldEmbedding = [1, ...Array.from({ length: 383 }, () => 0)];
+    const oldFragment = {
+      ...memory(21, ROOM_A),
+      content: { text: "old searchable fragment" },
+      embedding: oldEmbedding,
+      metadata: {
+        type: MemoryType.FRAGMENT,
+        documentId: original.id,
+        documentRevision: 0,
+        position: 0,
+      },
+    };
+    await adapter.createMemories([
+      { memory: original, tableName: "documents" },
+      { memory: oldFragment, tableName: "document_fragments" },
+    ]);
+    const expected = readDocumentMutationSnapshot(original);
+    if (!expected) throw new Error("Expected a valid document mutation snapshot");
+    const replacement = {
+      ...original,
+      content: { text: "new body" },
+      metadata: { ...original.metadata, documentRevision: 1 },
+    };
+    const reusedFragment = {
+      ...oldFragment,
+      content: { text: "new fragment with reused id" },
+      embedding: [0, 1, ...Array.from({ length: 382 }, () => 0)],
+      metadata: { ...oldFragment.metadata, documentRevision: 1 },
+    };
+
+    await expect(
+      adapter.replaceDocumentRevision({
+        agentId: AGENT_ID,
+        requesterEntityId: REQUESTER_ID,
+        requesterRoomIds: [],
+        requesterRole: "OWNER",
+        documentId: original.id,
+        expected,
+        replacement,
+        fragments: [reusedFragment],
+      })
+    ).rejects.toMatchObject({ code: "DOCUMENT_REVISION_FRAGMENT_ID_CONFLICT" });
+    await expect(
+      adapter.searchMemories({
+        tableName: "document_fragments",
+        embedding: oldEmbedding,
+        match_threshold: 0.99,
+        limit: 1,
+      })
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: oldFragment.id,
+        content: { text: "old searchable fragment" },
+      }),
+    ]);
+    await expect(adapter.getMemoriesByIds([original.id], "documents")).resolves.toEqual([
+      expect.objectContaining({
+        content: { text: original.content.text },
+        metadata: expect.objectContaining({ documentRevision: 0 }),
+      }),
+    ]);
+  });
+
   it("does not expose staged revision vectors before the storage swap", async () => {
     const storage = new BlockingBatchStorage();
     const adapter = new InMemoryDatabaseAdapter(storage, AGENT_ID);

--- a/plugins/plugin-inmemorydb/storage-memory.ts
+++ b/plugins/plugin-inmemorydb/storage-memory.ts
@@ -108,4 +108,16 @@ export class MemoryStorage implements IStorage {
     this.assertReady();
     this.collections.clear();
   }
+
+  async applyBatch(batch: {
+    collection: string;
+    deletes: string[];
+    sets: Array<{ id: string; data: unknown }>;
+  }): Promise<void> {
+    const current = this.getCollection(batch.collection);
+    const replacement = new Map(current);
+    for (const id of batch.deletes) replacement.delete(id);
+    for (const { id, data } of batch.sets) replacement.set(id, data);
+    this.collections.set(batch.collection, replacement);
+  }
 }

--- a/plugins/plugin-inmemorydb/types.ts
+++ b/plugins/plugin-inmemorydb/types.ts
@@ -18,6 +18,12 @@ export interface IStorage {
     predicate?: (item: T) => boolean
   ): Promise<number>;
   clear(): Promise<void>;
+  /** Applies one collection mutation without exposing intermediate state. */
+  applyBatch?(batch: {
+    collection: string;
+    deletes: string[];
+    sets: Array<{ id: string; data: unknown }>;
+  }): Promise<void>;
 }
 
 export interface IVectorStorage {

--- a/plugins/plugin-maps/src/store.ts
+++ b/plugins/plugin-maps/src/store.ts
@@ -148,7 +148,8 @@ async function ensureNamespace(runtime: IAgentRuntime): Promise<void> {
 
 function assertCasStorage(runtime: IAgentRuntime): void {
   if (
-    runtime.adapter.documentListQueryCapability !== 2 ||
+    !Number.isInteger(runtime.adapter.documentListQueryCapability) ||
+    runtime.adapter.documentListQueryCapability < 2 ||
     typeof runtime.adapter.getDocument !== "function" ||
     typeof runtime.adapter.compareAndSwapDocument !== "function"
   ) {

--- a/plugins/plugin-sql/src/__tests__/integration/document-list-query.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/document-list-query.real.test.ts
@@ -747,6 +747,60 @@ describe("document list query (real SQL parity)", () => {
     });
   });
 
+  it("rejects replacement fragment ids from the committed generation", async () => {
+    const original = document(10, { metadata: { documentRevision: 0 } });
+    const oldFragment = {
+      ...document(11),
+      id: v4() as UUID,
+      content: { text: "old fragment" },
+      metadata: {
+        type: MemoryType.FRAGMENT,
+        documentId: original.id,
+        documentRevision: 0,
+        position: 0,
+      },
+    };
+    await adapter.createMemories([
+      { memory: original, tableName: "documents" },
+      { memory: oldFragment, tableName: "document_fragments" },
+    ]);
+    const context = {
+      agentId,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [roomId],
+      requesterRole: "OWNER" as const,
+    };
+    const snapshot = readDocumentMutationSnapshot(original)!;
+    const replacement = {
+      ...original,
+      content: { text: "new body" },
+      metadata: { ...original.metadata, documentRevision: 1 },
+    };
+    const reusedFragment = {
+      ...oldFragment,
+      content: { text: "new fragment with reused id" },
+      metadata: { ...oldFragment.metadata, documentRevision: 1 },
+    };
+
+    await expect(
+      adapter.replaceDocumentRevision({
+        ...context,
+        documentId: original.id!,
+        expected: snapshot,
+        replacement,
+        fragments: [reusedFragment],
+      })
+    ).rejects.toMatchObject({ code: "DOCUMENT_REVISION_FRAGMENT_ID_CONFLICT" });
+    await expect(adapter.getMemoryById(original.id!)).resolves.toMatchObject({
+      content: { text: "Document body 10" },
+      metadata: { documentRevision: 0 },
+    });
+    await expect(adapter.getMemoryById(oldFragment.id!)).resolves.toMatchObject({
+      content: { text: "old fragment" },
+      metadata: { documentRevision: 0 },
+    });
+  });
+
   it("serializes competing revisions and exposes one complete winning generation", async () => {
     const original = document(1, { metadata: { documentRevision: 0 } });
     const oldFragment = {

--- a/plugins/plugin-sql/src/__tests__/integration/document-list-query.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/document-list-query.real.test.ts
@@ -687,6 +687,139 @@ describe("document list query (real SQL parity)", () => {
     await expect(adapter.getMemoryById(original.id!)).resolves.not.toBeNull();
   });
 
+  it("rolls back a complete revision when a staged fragment cannot be inserted", async () => {
+    const original = document(1, { metadata: { documentRevision: 0 } });
+    const oldFragment = {
+      ...document(2),
+      id: v4() as UUID,
+      content: { text: "old fragment" },
+      metadata: {
+        type: MemoryType.FRAGMENT,
+        documentId: original.id,
+        documentRevision: 0,
+        position: 0,
+      },
+    };
+    const collision = document(3);
+    await adapter.createMemories([
+      { memory: original, tableName: "documents" },
+      { memory: oldFragment, tableName: "document_fragments" },
+      { memory: collision, tableName: "documents" },
+    ]);
+    const context = {
+      agentId,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [roomId],
+      requesterRole: "OWNER" as const,
+    };
+    const snapshot = readDocumentMutationSnapshot(original)!;
+    const replacement = {
+      ...original,
+      content: { text: "new body" },
+      metadata: { ...original.metadata, documentRevision: 1 },
+    };
+    const conflictingFragment = {
+      ...oldFragment,
+      id: collision.id,
+      content: { text: "new fragment" },
+      metadata: { ...oldFragment.metadata, documentRevision: 1 },
+    };
+
+    await expect(
+      adapter.replaceDocumentRevision({
+        ...context,
+        documentId: original.id!,
+        expected: snapshot,
+        replacement,
+        fragments: [conflictingFragment],
+      })
+    ).rejects.toMatchObject({ code: "DOCUMENT_REVISION_FRAGMENT_ID_CONFLICT" });
+
+    await expect(adapter.getMemoryById(original.id!)).resolves.toMatchObject({
+      content: { text: "Document body 1" },
+      metadata: { documentRevision: 0 },
+    });
+    await expect(adapter.getMemoryById(oldFragment.id!)).resolves.toMatchObject({
+      content: { text: "old fragment" },
+    });
+    await expect(adapter.getMemoryById(collision.id!)).resolves.toMatchObject({
+      metadata: { type: MemoryType.DOCUMENT },
+    });
+  });
+
+  it("serializes competing revisions and exposes one complete winning generation", async () => {
+    const original = document(1, { metadata: { documentRevision: 0 } });
+    const oldFragment = {
+      ...original,
+      id: v4() as UUID,
+      content: { text: "old fragment" },
+      metadata: {
+        type: MemoryType.FRAGMENT,
+        documentId: original.id,
+        documentRevision: 0,
+        position: 0,
+      },
+    };
+    await adapter.createMemories([
+      { memory: original, tableName: "documents" },
+      { memory: oldFragment, tableName: "document_fragments" },
+    ]);
+    const context = {
+      agentId,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [roomId],
+      requesterRole: "OWNER" as const,
+    };
+    const snapshot = readDocumentMutationSnapshot(original)!;
+    const revision = (label: string) => {
+      const fragmentId = v4() as UUID;
+      return {
+        ...context,
+        documentId: original.id!,
+        expected: snapshot,
+        replacement: {
+          ...original,
+          content: { text: `${label} body` },
+          metadata: { ...original.metadata, documentRevision: 1 },
+        },
+        fragments: [
+          {
+            ...original,
+            id: fragmentId,
+            content: { text: `${label} fragment` },
+            metadata: {
+              type: MemoryType.FRAGMENT,
+              documentId: original.id,
+              documentRevision: 1,
+              position: 0,
+            },
+          },
+        ],
+      };
+    };
+    const observations = Promise.all(
+      Array.from({ length: 12 }, () => adapter.queryDocumentFragments({ ...context, limit: 10 }))
+    );
+    const [left, right, observed] = await Promise.all([
+      adapter.replaceDocumentRevision(revision("left")),
+      adapter.replaceDocumentRevision(revision("right")),
+      observations,
+    ]);
+    expect([left.status, right.status].sort()).toEqual(["conflict", "updated"]);
+    const parent = await adapter.getDocument({ ...context, documentId: original.id! });
+    const fragments = await adapter.queryDocumentFragments({ ...context, limit: 10 });
+    expect(parent?.metadata?.documentRevision).toBe(1);
+    expect(fragments).toHaveLength(1);
+    expect(fragments[0]?.metadata?.documentRevision).toBe(1);
+    expect(fragments[0]?.content.text).toBe(
+      `${String(parent?.content.text).split(" ")[0]} fragment`
+    );
+    for (const snapshotFragments of observed) {
+      expect(snapshotFragments).toHaveLength(1);
+      expect([0, 1]).toContain(snapshotFragments[0]?.metadata?.documentRevision);
+    }
+  });
+
   it("installs the evidence-backed portable-token index", async () => {
     const db = adapter.getDatabase() as DrizzleDatabase;
     const result = await db.execute(sql`

--- a/plugins/plugin-sql/src/__tests__/pglite-adapter-liveness.test.ts
+++ b/plugins/plugin-sql/src/__tests__/pglite-adapter-liveness.test.ts
@@ -5,7 +5,12 @@
  * SQL tables.
  */
 
-import type { UUID } from "@elizaos/core";
+import {
+  type DocumentRevisionReplaceParams,
+  type Memory,
+  MemoryType,
+  type UUID,
+} from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BaseDrizzleAdapter } from "../base";
 import { PgliteDatabaseAdapter } from "../pglite/adapter";
@@ -17,6 +22,8 @@ const worldId = "00000000-0000-4000-8000-000000000004" as UUID;
 const memoryId = "00000000-0000-4000-8000-000000000005" as UUID;
 const relationshipId = "00000000-0000-4000-8000-000000000006" as UUID;
 const taskId = "00000000-0000-4000-8000-000000000007" as UUID;
+const documentId = "00000000-0000-4000-8000-000000000008" as UUID;
+const fragmentId = "00000000-0000-4000-8000-000000000009" as UUID;
 
 function makeAdapter() {
   const rawConnection = {
@@ -44,6 +51,7 @@ function makeAdapter() {
     ensureSync: vi.fn(async () => undefined),
     getConnection: vi.fn(() => rawConnection),
     getDataDir: vi.fn(() => "/tmp/pglite-test"),
+    getWriteBack: vi.fn(() => null),
     initialize: vi.fn(async () => undefined),
     isInitialized: vi.fn(() => true),
     isShuttingDown: vi.fn(() => false),
@@ -201,5 +209,78 @@ describe("PgliteDatabaseAdapter liveness", () => {
         ["tasks", "insert"],
       ])
     );
+  });
+
+  it("notifies a complete document revision only after the local commit", async () => {
+    const { adapter, manager } = makeAdapter();
+    manager.getWriteBack.mockReturnValue({} as never);
+    const replacement: Memory = {
+      id: documentId,
+      agentId,
+      entityId,
+      roomId,
+      worldId,
+      content: { text: "new body" },
+      metadata: {
+        type: MemoryType.DOCUMENT,
+        documentId,
+        documentRevision: 1,
+        scope: "global",
+      },
+    };
+    const fragment: Memory = {
+      ...replacement,
+      id: fragmentId,
+      content: { text: "new fragment" },
+      metadata: {
+        type: MemoryType.FRAGMENT,
+        documentId,
+        documentRevision: 1,
+        position: 0,
+      },
+    };
+    const params: DocumentRevisionReplaceParams = {
+      agentId,
+      requesterEntityId: entityId,
+      requesterRoomIds: [roomId],
+      requesterRole: "OWNER",
+      documentId,
+      expected: {
+        scope: "global",
+        roomId,
+        entityId,
+        revision: 0,
+      },
+      replacement,
+      fragments: [fragment],
+    };
+    const replace = vi
+      .spyOn(BaseDrizzleAdapter.prototype, "replaceDocumentRevision")
+      .mockResolvedValue({
+        status: "updated",
+        document: replacement,
+        removedFragmentIds: [memoryId],
+      });
+
+    await expect(adapter.replaceDocumentRevision(params)).resolves.toMatchObject({
+      status: "updated",
+    });
+
+    expect(replace).toHaveBeenCalledWith(params);
+    expect(manager.notifyWrite.mock.calls).toEqual([
+      ["memories", "upsert", expect.objectContaining({ id: fragmentId })],
+      ["memories", "upsert", expect.objectContaining({ id: documentId })],
+      ["memories", "delete", { id: memoryId }],
+    ]);
+    expect(replace.mock.invocationCallOrder[0]).toBeLessThan(
+      manager.notifyWrite.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY
+    );
+
+    manager.notifyWrite.mockClear();
+    replace.mockResolvedValueOnce({ status: "conflict" });
+    await expect(adapter.replaceDocumentRevision(params)).resolves.toEqual({
+      status: "conflict",
+    });
+    expect(manager.notifyWrite).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -2269,7 +2269,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
 
   async replaceDocumentRevision(
     params: DocumentRevisionReplaceParams
-  ): Promise<DocumentMutationResult> {
+  ): Promise<DocumentMutationResult & { removedFragmentIds?: UUID[] }> {
     validateDocumentRevisionReplacement(params);
     this.validateMemoryBatchEmbeddings(
       params.fragments.map((memory) => ({ memory, tableName: "document_fragments" }))
@@ -2352,7 +2352,11 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           context: { documentId: params.documentId, updated: updated.length },
         });
       }
-      return { status: "updated", document: memoryFromRow(updated[0]) };
+      return {
+        status: "updated",
+        document: memoryFromRow(updated[0]),
+        removedFragmentIds: oldFragments.map(({ id }) => id),
+      };
     });
   }
 

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -35,6 +35,7 @@ import {
   type DocumentListQueryParams,
   type DocumentListQueryResult,
   type DocumentMutationResult,
+  type DocumentRevisionReplaceParams,
   decryptedCharacter,
   documentMutationSnapshotMatches,
   documentRoleHasGlobalVisibility,
@@ -80,6 +81,7 @@ import {
   validateDocumentFragmentQueryParams,
   validateDocumentListQueryParams,
   validateDocumentRequesterContext,
+  validateDocumentRevisionReplacement,
   validateQueryEntitiesPagination,
   type World,
 } from "@elizaos/core";
@@ -2265,6 +2267,95 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     });
   }
 
+  async replaceDocumentRevision(
+    params: DocumentRevisionReplaceParams
+  ): Promise<DocumentMutationResult> {
+    validateDocumentRevisionReplacement(params);
+    this.validateMemoryBatchEmbeddings(
+      params.fragments.map((memory) => ({ memory, tableName: "document_fragments" }))
+    );
+    const entityContext = documentRoleHasGlobalVisibility(params.requesterRole)
+      ? params.agentId
+      : params.requesterEntityId;
+    return this.withEntityContext(entityContext, async (tx) => {
+      const rows = await tx
+        .select()
+        .from(memoryTable)
+        .where(and(...this.documentStorageConditions(params)))
+        .for("update")
+        .limit(1);
+      const row = rows[0];
+      if (!row) return { status: "not_found" };
+      const existing = memoryFromRow(row);
+      if (!documentMutationSnapshotMatches(existing, params.expected)) {
+        return { status: "conflict" };
+      }
+      if (!canRequesterMutateDocument(existing, params)) return { status: "forbidden" };
+
+      const oldFragments = await tx
+        .select({ id: memoryTable.id })
+        .from(memoryTable)
+        .where(
+          and(
+            eq(memoryTable.type, "document_fragments"),
+            eq(memoryTable.agentId, params.agentId),
+            sql`${memoryTable.metadata}->>'type' = 'fragment'`,
+            sql`${memoryTable.metadata}->>'documentId' = ${params.documentId}`
+          )
+        );
+      if (oldFragments.length > 0) {
+        const deleted = await tx
+          .delete(memoryTable)
+          .where(
+            inArray(
+              memoryTable.id,
+              oldFragments.map(({ id }) => id)
+            )
+          )
+          .returning();
+        if (deleted.length !== oldFragments.length) {
+          throw new ElizaError("Atomic document replacement did not delete every old fragment", {
+            code: "DOCUMENT_REVISION_DELETE_INCOMPLETE",
+            context: {
+              documentId: params.documentId,
+              expected: oldFragments.length,
+              deleted: deleted.length,
+            },
+          });
+        }
+      }
+      for (const fragment of params.fragments) {
+        await this.insertMemoryInTransaction(
+          tx,
+          fragment,
+          "document_fragments",
+          fragment.id as UUID,
+          true
+        );
+      }
+      const replacement = params.replacement;
+      const updated = await tx
+        .update(memoryTable)
+        .set({
+          content: replacement.content,
+          entityId: replacement.entityId,
+          roomId: replacement.roomId,
+          worldId: replacement.worldId,
+          unique: replacement.unique ?? row.unique,
+          metadata: replacement.metadata ?? {},
+        })
+        .where(eq(memoryTable.id, params.documentId))
+        .returning();
+      if (updated.length !== 1) {
+        throw new ElizaError("Atomic document replacement did not update its parent", {
+          code: "DOCUMENT_REVISION_PARENT_UPDATE_INCOMPLETE",
+          context: { documentId: params.documentId, updated: updated.length },
+        });
+      }
+      return { status: "updated", document: memoryFromRow(updated[0]) };
+    });
+  }
+
   async deleteDocumentWithSnapshot(params: DocumentDeleteParams): Promise<DocumentMutationResult> {
     validateDocumentRequesterContext(params);
     const entityContext = documentRoleHasGlobalVisibility(params.requesterRole)
@@ -3585,7 +3676,8 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     tx: DrizzleDatabase,
     memory: Memory & { metadata?: MemoryMetadata },
     tableName: string,
-    memoryId: UUID
+    memoryId: UUID,
+    requireInserted = false
   ): Promise<void> {
     // Ensure we always pass a JSON string to the SQL bind parameter; if we pass an
     // object directly PG sees `[object Object]` and fails the `::jsonb` cast.
@@ -3615,6 +3707,12 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       .returning();
 
     if (inserted.length === 0) {
+      if (requireInserted) {
+        throw new ElizaError("Atomic memory insert collided with an existing id", {
+          code: "DOCUMENT_REVISION_FRAGMENT_ID_CONFLICT",
+          context: { memoryId },
+        });
+      }
       return;
     }
 

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -2303,6 +2303,14 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
             sql`${memoryTable.metadata}->>'documentId' = ${params.documentId}`
           )
         );
+      const oldFragmentIds = new Set(oldFragments.map(({ id }) => String(id)));
+      const reusedFragment = params.fragments.find(({ id }) => oldFragmentIds.has(String(id)));
+      if (reusedFragment) {
+        throw new ElizaError("Atomic document fragment id already exists", {
+          code: "DOCUMENT_REVISION_FRAGMENT_ID_CONFLICT",
+          context: { documentId: params.documentId, fragmentId: reusedFragment.id },
+        });
+      }
       if (oldFragments.length > 0) {
         const deleted = await tx
           .delete(memoryTable)

--- a/plugins/plugin-sql/src/pglite/adapter.ts
+++ b/plugins/plugin-sql/src/pglite/adapter.ts
@@ -9,6 +9,8 @@
 import type { PGlite } from "@electric-sql/pglite";
 import {
   type Agent,
+  type DocumentMutationResult,
+  type DocumentRevisionReplaceParams,
   type Entity,
   logger,
   type Memory,
@@ -172,6 +174,35 @@ export class PgliteDatabaseAdapter extends BaseDrizzleAdapter {
   // WriteBackService (Pattern 1 — Online Writes) can forward the change to the
   // cloud API. The row payload contains at minimum the primary key(s); for
   // inserts and upserts it includes the full data the caller provided.
+
+  async replaceDocumentRevision(
+    params: DocumentRevisionReplaceParams
+  ): Promise<DocumentMutationResult> {
+    const writeBackEnabled = this.manager.getWriteBack() !== null;
+    const result = await super.replaceDocumentRevision(params);
+    if (result.status !== "updated" || !writeBackEnabled) return result;
+
+    // Stage the new generation before advancing the parent revision. Remote
+    // readers therefore see either the complete old generation or the
+    // complete new one when asynchronous Electric write-back catches up.
+    for (const fragment of params.fragments) {
+      this.manager.notifyWrite("memories", "upsert", {
+        ...fragment,
+        id: fragment.id,
+      } as Record<string, unknown>);
+    }
+    this.manager.notifyWrite("memories", "upsert", {
+      ...params.replacement,
+      id: params.documentId,
+    } as Record<string, unknown>);
+    const replacementIds = new Set(params.fragments.map(({ id }) => String(id)));
+    for (const id of result.removedFragmentIds ?? []) {
+      if (!replacementIds.has(String(id))) {
+        this.manager.notifyWrite("memories", "delete", { id });
+      }
+    }
+    return result;
+  }
 
   async createAgent(agent: Agent): Promise<boolean> {
     const ok = await super.createAgent(agent);

--- a/plugins/plugin-whatsapp/__tests__/webhook-account-idempotency.test.ts
+++ b/plugins/plugin-whatsapp/__tests__/webhook-account-idempotency.test.ts
@@ -129,7 +129,7 @@ function makeRuntimeWithStore(
 				store.updateMemory(memory),
 		),
 		adapter: {
-			documentListQueryCapability: 2,
+			documentListQueryCapability: 3,
 			getDocument: vi.fn(async ({ documentId }: { documentId: UUID }) =>
 				store.getMemoryById(documentId),
 			),

--- a/plugins/plugin-whatsapp/src/inbound-claim.ts
+++ b/plugins/plugin-whatsapp/src/inbound-claim.ts
@@ -167,7 +167,8 @@ async function readClaimDocument(runtime: IAgentRuntime, claimId: UUID): Promise
 function assertClaimStorage(runtime: IAgentRuntime): void {
   const adapter = runtime.adapter;
   if (
-    adapter?.documentListQueryCapability !== 2 ||
+    !Number.isInteger(adapter?.documentListQueryCapability) ||
+    adapter.documentListQueryCapability < 2 ||
     typeof adapter.getDocument !== "function" ||
     typeof adapter.compareAndSwapDocument !== "function" ||
     typeof runtime.createMemory !== "function"


### PR DESCRIPTION
# Relates to

Refs #16021

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2b7c8fcd22692e3d11175689a029e4858d0f1d56:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased on `origin/develop` at `acf51a6eb977b3ebb493d7638ee11f41917c893a`.
- [x] The final sync added only unrelated `plugin-x` files; every affected blob
      is byte-identical to the independently exercised tree.

# Risks

Medium. This raises the first-party document-store capability to v3 and makes
custom adapters fail closed until they implement atomic revision replacement.
Replacement fragment IDs must also be fresh: reusing a committed fragment ID
is rejected before any secondary-index or SQL mutation, which preserves the old
generation across rollback and asynchronous PGlite write-back.

# Background

## What does this PR do?

- stages and validates every replacement fragment and embedding before storage
  publication;
- atomically row-locks the SQL parent, verifies the expected revision/scope,
  replaces the complete fragment generation, and updates the parent in one real
  Drizzle transaction;
- gives in-memory adapters serialized copy/swap semantics and gates vector
  readers on the same document mutation barrier;
- rejects IDs from the committed fragment generation before staging, preventing
  failed in-memory edits from deleting the old vector and preventing a
  zero-fragment PGlite write-back window;
- publishes PGlite/Electric write-back notifications only after the winning
  local transaction commits, using the exact removed fragment IDs;
- preserves the complete old revision on embedding, insert, delete, collision,
  or competing-writer failure; and
- accepts WhatsApp idempotency adapters with the canonical v2+ method surface
  instead of rejecting every new v3 adapter by exact version equality.

The already-landed create-path ingestion state machine is unchanged. This PR
corrects and completes the consolidated `updateDocument` residual from #16021.

## What kind of change is this?

Bug fix (non-breaking for first-party adapters; intentionally fail-closed for
incomplete custom document adapters and reused replacement fragment IDs).

# Testing

## Where should a reviewer start?

Start at `DocumentService.updateDocument`, then follow
`replaceDocumentRevision` into `plugins/plugin-sql/src/base.ts` and
`plugins/plugin-inmemorydb/adapter.ts`. Review the committed-ID rejection and
retrieval regression before the normal copy/swap path.

## Exact-head verification

The affected tree at `2b7c8fcd22692e3d11175689a029e4858d0f1d56`
passed in a fresh network-disabled bwrap sandbox with an isolated home and
read-only dependency cache:

- core real-PGlite document service suite: 4/4;
- in-memory document atomicity/vector suite: 7/7;
- real-PGlite rollback, committed-ID rejection, and competing-writer cases: 3/3;
- PGlite post-commit write-back/liveness suite: 4/4;
- WhatsApp webhook idempotency suite: 20/20;
- signed production WhatsApp route contract: 1/1, 23 assertions;
- core, plugin-sql, plugin-inmemorydb, and plugin-whatsapp typechecks;
- core Node build including declarations;
- changed-file Biome (17 applicable files) and `git diff --check`.

The broader real-SQL parity file reached 16 passing tests and the same unrelated
existing entity-isolation parity failure documented before this correction;
one performance case is intentionally skipped by the suite. The cloud test-mock
typecheck could not resolve the sparse sandbox's cloud-shared dependency graph,
although the changed production-route contract passed. This host exposes Bun
1.3.13 and Node 25.2.1 rather than the repository-pinned Bun 1.3.14 and Node
24.15.0, so hosted checks must rerun the gates with the pinned toolchain.

# Evidence Gate

<!-- evidence-head:2b7c8fcd22692e3d11175689a029e4858d0f1d56 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI flow changes.
<!-- evidence-row:backend-logs -->
- [ ] N/A - live API/Postgres logs remain required before final delivery.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changes.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - a live embedding ingestion/edit trajectory remains required;
      deterministic embedding handlers cover the local failure matrix only.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - attach manually inspected before/after Postgres rows plus vector/BM25
      retrieval from a live API edit before final delivery.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Known residual evidence

Keep this PR draft. It still needs independent review of the reviewer-authored
repair, hosted checks on the pinned toolchain, real PostgreSQL fault/concurrency
proof, and the credentialed live embedding/API artifacts listed above. The
author of the correction has not approved or merged it.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@2b7c8fcd22692e3d11175689a029e4858d0f1d56:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-23365]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@2b7c8fcd22692e3d11175689a029e4858d0f1d56:packages/skills/skills/contribute-to-eliza"} -->
