### PR TITLE
fix(security): make product regex boundaries linear

### DIFF
--- a/packages/app-core/platforms/electrobun/scripts/bench-cloud-login.mjs
+++ b/packages/app-core/platforms/electrobun/scripts/bench-cloud-login.mjs
@@ -25,6 +25,7 @@
  *   --poll-interval MS  Milliseconds between polls (default 2000)
  *   --no-cors-check     Skip the CORS preflight check
  */
+import crypto from "node:crypto";
 
 // ─── Arg parsing ─────────────────────────────────────────────────────────────
 
@@ -59,7 +60,9 @@ function parseArgs(argv) {
         break;
       case "--help":
       case "-h":
-        console.log(`Usage: bun run bench:cloud-login [--rounds N] [--api-base URL] [--web-base URL] [--poll-rounds N] [--poll-interval MS] [--no-cors-check]`);
+        console.log(
+          `Usage: bun run bench:cloud-login [--rounds N] [--api-base URL] [--web-base URL] [--poll-rounds N] [--poll-interval MS] [--no-cors-check]`,
+        );
         process.exit(0);
     }
   }
@@ -137,7 +140,7 @@ async function runLoginFlow(round) {
 
   // Step 1: Create CLI session
   const sessionPayload = JSON.stringify({
-    sessionId: `bench-${Date.now()}-${round}-${Math.random().toString(36).slice(2, 8)}`,
+    sessionId: `bench-${round}-${crypto.randomUUID()}`,
   });
 
   const createResult = await timedFetch(
@@ -251,8 +254,13 @@ async function main() {
   console.log(`API base:       ${config.apiBase}`);
   console.log(`Web base:       ${config.webBase}`);
   console.log(`Rounds:         ${config.rounds}`);
-  console.log(`Poll rounds:    ${config.pollRounds} (interval: ${config.pollIntervalMs}ms)`);
-  const runtimeName = typeof Bun !== "undefined" ? `Bun ${Bun.version}` : `Node ${process.version}`;
+  console.log(
+    `Poll rounds:    ${config.pollRounds} (interval: ${config.pollIntervalMs}ms)`,
+  );
+  const runtimeName =
+    typeof Bun !== "undefined"
+      ? `Bun ${Bun.version}`
+      : `Node ${process.version}`;
   console.log(`Runtime:        ${runtimeName}`);
   console.log(`Timestamp:      ${new Date().toISOString()}`);
   console.log("=".repeat(80));
@@ -294,9 +302,7 @@ async function main() {
         : r.error
           ? `ERR: ${r.error}`
           : `${r.status}`;
-      console.log(
-        `  ${r.label}`,
-      );
+      console.log(`  ${r.label}`);
       console.log(
         `    status: ${status}  time: ${fmtMs(r.totalMs)}  ttfb: ${r.ttfbMs ? fmtMs(r.ttfbMs) : "n/a"}`,
       );
@@ -379,7 +385,9 @@ async function main() {
     `   TOTAL estimated e2e:            ~${(totalEstimate / 1000).toFixed(1)}s`,
   );
   console.log();
-  console.log(`   API-only overhead (no user):   ${fmtMs(createMs + pollLoopMs)}`);
+  console.log(
+    `   API-only overhead (no user):   ${fmtMs(createMs + pollLoopMs)}`,
+  );
   console.log(
     `   User-dependent latency:         ~${((browserOpenMs + userAuthMs + tokenPersistMs) / 1000).toFixed(1)}s`,
   );
@@ -391,8 +399,12 @@ async function main() {
   console.log(
     `\nCreate:  [${createSamples.map((s) => s.toFixed(1)).join(", ")}] ms`,
   );
-  console.log(`Poll:    [${pollSamples.map((s) => s.toFixed(1)).join(", ")}] ms`);
-  console.log(`Flow:    [${flowSamples.map((s) => s.toFixed(1)).join(", ")}] ms`);
+  console.log(
+    `Poll:    [${pollSamples.map((s) => s.toFixed(1)).join(", ")}] ms`,
+  );
+  console.log(
+    `Flow:    [${flowSamples.map((s) => s.toFixed(1)).join(", ")}] ms`,
+  );
 
   console.log("\nDone.");
 }

--- a/packages/app-core/platforms/electrobun/src/bench-cloud-login.contract.test.ts
+++ b/packages/app-core/platforms/electrobun/src/bench-cloud-login.contract.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Guards the desktop cloud-login benchmark's posted session identifier.
+ * This source contract is deterministic and does not contact the cloud API.
+ */
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const benchmarkSource = readFileSync(
+  new URL("../scripts/bench-cloud-login.mjs", import.meta.url),
+  "utf8",
+);
+
+describe("cloud-login benchmark session identity", () => {
+  it("uses cryptographic UUIDs without a Math.random downgrade", () => {
+    expect(benchmarkSource).toContain('import crypto from "node:crypto"');
+    expect(benchmarkSource).toContain("crypto.randomUUID()");
+    expect(benchmarkSource).not.toContain("Math.random");
+  });
+});

--- a/packages/app-core/src/api/ios-local-agent-transport.test.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.test.ts
@@ -503,12 +503,16 @@ describe("iOS local agent transport bridge", () => {
         key === "eliza:mobile-runtime-mode" ? "local" : null,
     });
 
-    const { isIosInProcessLocalAgentUrl } = await import(
-      "./ios-local-agent-transport"
-    );
+    const { isIosInProcessLocalAgentBase, isIosInProcessLocalAgentUrl } =
+      await import("./ios-local-agent-transport");
 
     expect(
       isIosInProcessLocalAgentUrl("http://127.0.0.1:31337/api/health"),
+    ).toBe(true);
+    expect(
+      isIosInProcessLocalAgentBase(
+        `http://127.0.0.1:31337${"/".repeat(100_000)}`,
+      ),
     ).toBe(true);
   });
 

--- a/packages/app-core/src/api/ios-local-agent-transport.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.ts
@@ -497,9 +497,9 @@ export function isIosInProcessLocalAgentBase(
   baseUrl: string | null | undefined,
 ): boolean {
   if (!baseUrl) return false;
-  return isIosInProcessLocalAgentUrl(
-    `${baseUrl.replace(/\/+$/, "")}/api/health`,
-  );
+  let end = baseUrl.length;
+  while (end > 0 && baseUrl.charCodeAt(end - 1) === 47) end--;
+  return isIosInProcessLocalAgentUrl(`${baseUrl.slice(0, end)}/api/health`);
 }
 
 function isSafeLocalPath(path: string): boolean {

--- a/packages/app-core/src/diagnostics/integration-observability.test.ts
+++ b/packages/app-core/src/diagnostics/integration-observability.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Deterministic unit coverage for integration-boundary telemetry emission and
+ * adversarial token normalization. The logger and clock are injected; no live
+ * integration or network service is used.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { createIntegrationTelemetrySpan } from "./integration-observability";
+
+describe("createIntegrationTelemetrySpan", () => {
+  it("collapses and trims 100k invalid token separators in linear time", () => {
+    const warn = vi.fn();
+    const span = createIntegrationTelemetrySpan(
+      { boundary: "cloud", operation: "request" },
+      { now: () => 10, sink: { info: vi.fn(), warn } },
+    );
+
+    span.failure({
+      errorKind: `${"_".repeat(100_000)}Provider${"_".repeat(100_000)}Failure${"_".repeat(100_000)}`,
+    });
+
+    expect(warn).toHaveBeenCalledOnce();
+    const event = JSON.parse(
+      String(warn.mock.calls[0]?.[0]).slice("[integration] ".length),
+    );
+    expect(event.errorKind).toBe("provider_failure");
+  });
+});

--- a/packages/app-core/src/diagnostics/integration-observability.ts
+++ b/packages/app-core/src/diagnostics/integration-observability.ts
@@ -76,9 +76,26 @@ function inferErrorKind(error: unknown): string | undefined {
 
 function sanitizeToken(value: string | undefined): string | undefined {
   if (!value) return undefined;
-  const token = value.toLowerCase().replace(/[^a-z0-9_-]/g, "_");
-  const normalized = token.replace(/_+/g, "_").replace(/^_+|_+$/g, "");
-  return normalized ? normalized.slice(0, 64) : undefined;
+  const lower = value.toLowerCase();
+  let normalized = "";
+  let pendingUnderscore = false;
+  for (let index = 0; index < lower.length; index++) {
+    const code = lower.charCodeAt(index);
+    const isAllowed =
+      (code >= 48 && code <= 57) || (code >= 97 && code <= 122) || code === 45;
+    if (!isAllowed) {
+      if (normalized.length > 0) pendingUnderscore = true;
+      continue;
+    }
+    if (pendingUnderscore) {
+      normalized += "_";
+      if (normalized.length === 64) break;
+      pendingUnderscore = false;
+    }
+    normalized += lower[index];
+    if (normalized.length === 64) break;
+  }
+  return normalized || undefined;
 }
 
 function emitEvent(

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -876,6 +876,20 @@ describe("cloud-api worker entrypoint", () => {
     ).toBeNull();
   });
 
+  test("normalizes a 100k-dot configured hostname without pathological matching", () => {
+    const agentId = "e06bb509-6c52-4c33-a9f7-66addc43e8c8";
+    const env = {
+      ELIZA_CLOUD_AGENT_BASE_DOMAIN: `cloud.eliza.app${".".repeat(100_000)}`,
+    };
+
+    expect(
+      getGeneratedAgentId(
+        new URL(`https://${agentId}.cloud.eliza.app/api/health`),
+        env,
+      ),
+    ).toBe(agentId);
+  });
+
   test("proxies canonical staging marketing to the unified Pages develop branch", () => {
     const target = getFrontendAliasProxyTarget(
       new URL("https://staging.eliza.app/dashboard?tab=agents"),

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -635,7 +635,11 @@ function healthResponse(env: AppEnv["Bindings"]): Response {
 }
 
 function normalizeHostname(hostname: string | undefined): string | null {
-  const normalized = hostname?.trim().toLowerCase().replace(/\.+$/, "");
+  const value = hostname?.trim().toLowerCase();
+  if (!value) return null;
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 46) end--;
+  const normalized = value.slice(0, end);
   return normalized || null;
 }
 

--- a/packages/cloud/api/src/steward/public-paths.ts
+++ b/packages/cloud/api/src/steward/public-paths.ts
@@ -13,8 +13,14 @@
  *
  * OPTIONS preflight for these paths is also eligible for the thin shell.
  */
+function removeTrailingSlashes(pathname: string): string {
+  let end = pathname.length;
+  while (end > 0 && pathname.charCodeAt(end - 1) === 47) end--;
+  return end === 0 ? "/" : pathname.slice(0, end);
+}
+
 export function isThinStewardPublicPath(pathname: string): boolean {
-  const normalized = pathname.replace(/\/+$/, "") || "/";
+  const normalized = removeTrailingSlashes(pathname);
   return (
     normalized === "/steward/auth/providers" ||
     normalized === "/steward/tenants/config"
@@ -52,7 +58,7 @@ export function isThinStewardPublicPath(pathname: string): boolean {
  * payments) stay on the full app.
  */
 export function isThinStewardEmailAuthPath(pathname: string): boolean {
-  const normalized = pathname.replace(/\/+$/, "") || "/";
+  const normalized = removeTrailingSlashes(pathname);
   return (
     normalized === "/steward/auth/email/send" ||
     normalized === "/steward/auth/email/code/verify" ||

--- a/packages/cloud/api/src/steward/thin-app.test.ts
+++ b/packages/cloud/api/src/steward/thin-app.test.ts
@@ -74,6 +74,9 @@ describe("isThinStewardPublicPath", () => {
     expect(isThinStewardPublicPath("/steward/auth/email/send")).toBe(false);
     expect(isThinStewardPublicPath("/steward/auth/nonce")).toBe(false);
     expect(isThinStewardPublicPath("/api/v1/oauth/providers")).toBe(false);
+    expect(
+      isThinStewardPublicPath(`/steward/auth/providers${"/".repeat(100_000)}`),
+    ).toBe(true);
   });
 });
 
@@ -90,6 +93,11 @@ describe("isThinStewardEmailAuthPath", () => {
       false,
     );
     expect(isThinStewardEmailAuthPath("/steward/vault/keys")).toBe(false);
+    expect(
+      isThinStewardEmailAuthPath(
+        `/steward/auth/email/send${"/".repeat(100_000)}`,
+      ),
+    ).toBe(true);
     expect(isThinStewardEmailAuthPath("/steward/auth/passkey/register")).toBe(
       false,
     );

--- a/packages/cloud/routing/src/resolve.test.ts
+++ b/packages/cloud/routing/src/resolve.test.ts
@@ -139,6 +139,22 @@ describe("cloud routing helpers", () => {
     });
   });
 
+  it("normalizes 100k boundary slashes in linear time", () => {
+    const slashes = "/".repeat(100_000);
+    const settings = runtime({
+      ELIZAOS_CLOUD_API_KEY: "cloud-secret",
+      ELIZAOS_CLOUD_ENABLED: true,
+      ELIZAOS_CLOUD_BASE_URL: `https://cloud.example.com/api/v1${slashes}`,
+    });
+
+    expect(
+      cloudServiceApisBaseUrl(settings, `${slashes}media${slashes}`),
+    ).toEqual({
+      baseUrl: "https://cloud.example.com/api/v1/apis/media",
+      headers: { Authorization: "Bearer cloud-secret" },
+    });
+  });
+
   it.each([
     "../admin",
     "media/../../billing",

--- a/packages/cloud/routing/src/resolve.ts
+++ b/packages/cloud/routing/src/resolve.ts
@@ -50,7 +50,9 @@ export function cloudServiceApisBaseUrl(
 }
 
 function stripTrailingSlashes(url: string): string {
-  return url.replace(/\/+$/, "");
+  let end = url.length;
+  while (end > 0 && url.charCodeAt(end - 1) === 47) end--;
+  return url.slice(0, end);
 }
 
 function normalizeCloudBaseUrl(rawUrl: string): string | null {
@@ -73,7 +75,12 @@ function normalizeCloudBaseUrl(rawUrl: string): string | null {
 }
 
 function normalizeServiceName(service: string): string | null {
-  const trimmed = service.trim().replace(/^\/+|\/+$/g, "");
+  const value = service.trim();
+  let start = 0;
+  let end = value.length;
+  while (start < end && value.charCodeAt(start) === 47) start++;
+  while (end > start && value.charCodeAt(end - 1) === 47) end--;
+  const trimmed = value.slice(start, end);
   if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
     return null;
   }

--- a/packages/cloud/sdk/src/app-auth.test.ts
+++ b/packages/cloud/sdk/src/app-auth.test.ts
@@ -22,4 +22,17 @@ describe("buildAppAuthorizeUrl", () => {
     );
     expect(url.searchParams.get("state")).toBe("csrf-value");
   });
+
+  it("normalizes 100k trailing base-url slashes", () => {
+    const url = new URL(
+      buildAppAuthorizeUrl({
+        appId: "app_123",
+        redirectUri: "https://example.app/auth/callback",
+        baseUrl: `https://elizacloud.ai${"/".repeat(100_000)}`,
+      }),
+    );
+
+    expect(url.origin).toBe("https://elizacloud.ai");
+    expect(url.pathname).toBe(APP_AUTHORIZE_PATH);
+  });
 });

--- a/packages/cloud/sdk/src/app-auth.ts
+++ b/packages/cloud/sdk/src/app-auth.ts
@@ -16,7 +16,9 @@ export interface BuildAppAuthorizeUrlOptions {
 }
 
 function trimTrailingSlash(value: string): string {
-  return value.replace(/\/+$/, "");
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end--;
+  return value.slice(0, end);
 }
 
 export function buildAppAuthorizeUrl({

--- a/packages/cloud/sdk/src/client.test.ts
+++ b/packages/cloud/sdk/src/client.test.ts
@@ -328,6 +328,14 @@ describe("ElizaCloudClient.createContainer wire contract", () => {
 });
 
 describe("ElizaCloudClient path parameter encoding", () => {
+  it("normalizes 100k trailing API base-url slashes", () => {
+    const client = new ElizaCloudClient({
+      apiBaseUrl: `https://api.eliza.app/api/v1${"/".repeat(100_000)}`,
+    });
+
+    expect(client.apiBaseUrl).toBe("https://api.eliza.app/api/v1");
+  });
+
   it("percent-encodes path parameters that contain slashes, query markers, and fragments", async () => {
     const { client, requests } = createClientRecorder();
 
@@ -349,6 +357,22 @@ describe("ElizaCloudClient path parameter encoding", () => {
         skipAuth: true,
       }),
     ).toThrow("Missing path parameter: sessionId");
+  });
+
+  it("leaves 100k unmatched template openers unchanged without backtracking", async () => {
+    const { client, requests } = createClientRecorder();
+    const unmatched = "{".repeat(100_000);
+
+    await client.callEndpoint("GET", `/api/literal/${unmatched}`, {
+      pathParams: { unused: "value" },
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(
+      decodeURIComponent(new URL(requests[0]?.url ?? "").pathname).endsWith(
+        unmatched,
+      ),
+    ).toBe(true);
   });
 });
 

--- a/packages/cloud/sdk/src/client.ts
+++ b/packages/cloud/sdk/src/client.ts
@@ -158,7 +158,9 @@ import {
 } from "./types.js";
 
 function trimTrailingSlash(value: string): string {
-  return value.replace(/\/+$/, "");
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end--;
+  return value.slice(0, end);
 }
 
 function normalizeBaseUrl(value: string | undefined, fallback: string): string {
@@ -260,13 +262,30 @@ function withPathParams(
   params?: Record<string, string | number>,
 ): string {
   if (!params) return path;
-  return path.replace(/\{([^}]+)\}/g, (_match, key: string) => {
+  let cursor = 0;
+  let searchFrom = 0;
+  const output: string[] = [];
+  while (searchFrom < path.length) {
+    const open = path.indexOf("{", searchFrom);
+    if (open === -1) break;
+    const close = path.indexOf("}", open + 1);
+    if (close === -1) break;
+    if (close === open + 1) {
+      searchFrom = open + 1;
+      continue;
+    }
+    const key = path.slice(open + 1, close);
     const value = params[key];
     if (value === undefined) {
       throw new Error(`Missing path parameter: ${key}`);
     }
-    return encodePathParam(value);
-  });
+    output.push(path.slice(cursor, open), encodePathParam(value));
+    cursor = close + 1;
+    searchFrom = cursor;
+  }
+  if (output.length === 0) return path;
+  output.push(path.slice(cursor));
+  return output.join("");
 }
 
 function createCliLoginRequestId(): string {

--- a/packages/cloud/sdk/src/http.test.ts
+++ b/packages/cloud/sdk/src/http.test.ts
@@ -23,6 +23,18 @@ function okFetch(
 }
 
 describe("ElizaCloudHttpClient auth headers", () => {
+  it("normalizes 100k trailing base-url slashes", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const client = new ElizaCloudHttpClient({
+      baseUrl: `https://cloud.test/root${"/".repeat(100_000)}`,
+      fetchImpl: okFetch(calls),
+    });
+
+    await client.requestRaw("GET", "/api/test");
+
+    expect(calls[0]?.url).toBe("https://cloud.test/root/api/test");
+  });
+
   it("serializes hostile query values without dropping falsey values or inventing path segments", async () => {
     const calls: Array<{ url: string; init: RequestInit }> = [];
     const client = new ElizaCloudHttpClient({

--- a/packages/cloud/sdk/src/http.ts
+++ b/packages/cloud/sdk/src/http.ts
@@ -17,7 +17,9 @@ import {
 } from "./types.js";
 
 function trimTrailingSlash(value: string): string {
-  return value.replace(/\/+$/, "");
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end--;
+  return value.slice(0, end);
 }
 
 function ensureLeadingSlash(value: string): string {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-failurekind.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-failurekind.test.ts
@@ -26,6 +26,16 @@ type MessageSender = {
   bridgeMessageSend(rec: AgentSandbox, rpc: BridgeRequest): Promise<BridgeResponse>;
 };
 
+type HostParserInternals = {
+  buildBridgeNoReplyFallbackText(params: Record<string, unknown>): string | null;
+  fetchCanonicalConversationApi(
+    rec: AgentSandbox,
+    path: string,
+    init: RequestInit,
+    canonicalBridgeBase: unknown,
+  ): Promise<Response>;
+};
+
 const rec = {
   id: "sandbox-1",
   bridge_url: "http://sandbox.test",
@@ -128,6 +138,52 @@ function installNativeBridgeFetchStub(result: Record<string, unknown>): string[]
 const realFetch = globalThis.fetch;
 afterEach(() => {
   globalThis.fetch = realFetch;
+});
+
+describe("ElizaSandboxService linear bridge boundary parsing", () => {
+  test("parses an exact-words directive after 100k spaces", () => {
+    const host = new ElizaSandboxService() as unknown as HostParserInternals;
+
+    expect(
+      host.buildBridgeNoReplyFallbackText({
+        text: `Please reply with exact words${" ".repeat(100_000)}: "pong"`,
+      }),
+    ).toBe("pong");
+  });
+
+  test("parses a reply-with directive after 100k spaces", () => {
+    const host = new ElizaSandboxService() as unknown as HostParserInternals;
+
+    expect(
+      host.buildBridgeNoReplyFallbackText({
+        text: `Please reply${" ".repeat(100_000)}briefly with "pong"`,
+      }),
+    ).toBe("pong");
+  });
+
+  test("normalizes 100k canonical bridge URL slashes before exact comparison", async () => {
+    const host = new ElizaSandboxService() as unknown as HostParserInternals &
+      Record<string, unknown>;
+    const fetchAgentTarget = async (_rec: AgentSandbox, target: { url: string }) =>
+      Response.json({ url: target.url });
+    Object.assign(host, { fetchAgentTarget });
+    const slashes = "/".repeat(100_000);
+    const localRecord = {
+      ...rec,
+      bridge_url: `http://127.0.0.1:31337${slashes}`,
+    };
+
+    const response = await host.fetchCanonicalConversationApi(
+      localRecord,
+      "/api/conversations/conv-1/messages",
+      {},
+      `http://127.0.0.1:31337${slashes}`,
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      url: "http://127.0.0.1:31337/api/conversations/conv-1/messages",
+    });
+  });
 });
 
 describe("ElizaSandboxService native bridge failureKind propagation", () => {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -3899,11 +3899,16 @@ export class ElizaSandboxService {
     init: RequestInit,
     canonicalBridgeBase: unknown,
   ): Promise<Response> {
+    const trimTrailingSlashes = (value: string): string => {
+      let end = value.length;
+      while (end > 0 && value.charCodeAt(end - 1) === 47) end--;
+      return value.slice(0, end);
+    };
     const requestedBase =
       typeof canonicalBridgeBase === "string"
-        ? canonicalBridgeBase.trim().replace(/\/+$/, "")
+        ? trimTrailingSlashes(canonicalBridgeBase.trim())
         : null;
-    const storedBase = rec.bridge_url?.trim().replace(/\/+$/, "") ?? null;
+    const storedBase = rec.bridge_url ? trimTrailingSlashes(rec.bridge_url.trim()) : null;
     if (requestedBase && requestedBase === storedBase) {
       const url = new URL(requestedBase);
       const isLoopback =
@@ -6115,11 +6120,74 @@ export class ElizaSandboxService {
     const text = typeof params.text === "string" ? params.text.trim() : "";
     if (!text) return null;
 
-    const exactWords =
-      /\bexact words?\s*:\s*["']?(.+?)["']?\s*$/i.exec(text) ??
-      /\breply\s+(?:briefly\s+)?with\s+["']([^"']+)["']/i.exec(text);
-    if (exactWords?.[1]?.trim()) {
-      return exactWords[1].trim();
+    const lower = text.toLowerCase();
+    let searchFrom = 0;
+    while (searchFrom < lower.length) {
+      const start = lower.indexOf("exact word", searchFrom);
+      if (start === -1) break;
+      searchFrom = start + 1;
+      const preceding = start > 0 ? lower.charCodeAt(start - 1) : 0;
+      const precededByWord =
+        (preceding >= 48 && preceding <= 57) ||
+        (preceding >= 97 && preceding <= 122) ||
+        preceding === 95;
+      if (precededByWord) continue;
+
+      let cursor = start + "exact word".length;
+      if (lower.charCodeAt(cursor) === 115) cursor++;
+      while (cursor < lower.length && /\s/.test(lower[cursor] ?? "")) cursor++;
+      if (lower.charCodeAt(cursor) !== 58) continue;
+      cursor++;
+      while (cursor < text.length && /\s/.test(text[cursor] ?? "")) cursor++;
+
+      let end = text.length;
+      while (end > cursor && /\s/.test(text[end - 1] ?? "")) end--;
+      if (cursor < end && (text[cursor] === '"' || text[cursor] === "'")) cursor++;
+      if (cursor < end && (text[end - 1] === '"' || text[end - 1] === "'")) end--;
+      const exact = text.slice(cursor, end).trim();
+      if (exact && !exact.includes("\n") && !exact.includes("\r")) return exact;
+    }
+
+    searchFrom = 0;
+    while (searchFrom < lower.length) {
+      const start = lower.indexOf("reply", searchFrom);
+      if (start === -1) break;
+      searchFrom = start + 1;
+      const preceding = start > 0 ? lower.charCodeAt(start - 1) : 0;
+      const precededByWord =
+        (preceding >= 48 && preceding <= 57) ||
+        (preceding >= 97 && preceding <= 122) ||
+        preceding === 95;
+      if (precededByWord) continue;
+
+      let cursor = start + "reply".length;
+      const whitespaceStart = cursor;
+      while (cursor < lower.length && /\s/.test(lower[cursor] ?? "")) cursor++;
+      if (cursor === whitespaceStart) continue;
+      if (lower.startsWith("briefly", cursor)) {
+        cursor += "briefly".length;
+        const brieflyWhitespaceStart = cursor;
+        while (cursor < lower.length && /\s/.test(lower[cursor] ?? "")) cursor++;
+        if (cursor === brieflyWhitespaceStart) continue;
+      }
+      if (!lower.startsWith("with", cursor)) continue;
+      cursor += "with".length;
+      const withWhitespaceStart = cursor;
+      while (cursor < lower.length && /\s/.test(lower[cursor] ?? "")) cursor++;
+      if (cursor === withWhitespaceStart) continue;
+      const quote = text[cursor];
+      if (quote !== '"' && quote !== "'") continue;
+      const singleQuoteClose = text.indexOf("'", cursor + 1);
+      const doubleQuoteClose = text.indexOf('"', cursor + 1);
+      const close =
+        singleQuoteClose === -1
+          ? doubleQuoteClose
+          : doubleQuoteClose === -1
+            ? singleQuoteClose
+            : Math.min(singleQuoteClose, doubleQuoteClose);
+      if (close === -1) continue;
+      const reply = text.slice(cursor + 1, close).trim();
+      if (reply) return reply;
     }
 
     return "Agent runtime is online, but no model response was produced before the cloud bridge timeout.";

--- a/packages/ui/src/api/client-cloud-steward-token.test.ts
+++ b/packages/ui/src/api/client-cloud-steward-token.test.ts
@@ -138,6 +138,12 @@ describe("resolveDirectCloudWebBase / resolveDirectCloudAuthApiBase", () => {
     );
   });
 
+  it("trims a 100k trailing slash run without changing the prefix", () => {
+    expect(
+      resolveDirectCloudWebBase(`https://example.com${"/".repeat(100_000)}`),
+    ).toBe("https://example.com");
+  });
+
   it("falls back to the raw input for an unparseable base", () => {
     expect(resolveDirectCloudWebBase("not a url")).toBe("not a url");
   });

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -77,6 +77,7 @@ import {
   DIRECT_ELIZA_CLOUD_API_BY_HOST,
   resolveDirectCloudAuthApiBase,
   resolveDirectCloudWebBase,
+  stripTrailingSlashes,
 } from "./direct-cloud-endpoints";
 import { createTimeoutSignal, isTimeoutAbortError } from "./timeout-signal";
 import { fetchAgentTransport } from "./transport";
@@ -3412,11 +3413,10 @@ export function resolveCloudAgentApiBase(args: {
   /** Resolved direct-cloud origin — required to derive from `agentId`. */
   cloudApiBase?: string | null;
 }): string {
-  const stripTrailingSlash = (u: string): string => u.replace(/\/+$/, "");
   const candidate =
-    args.webUiUrl?.trim() || stripTrailingSlash(args.bridgeUrl ?? "");
+    args.webUiUrl?.trim() || stripTrailingSlashes(args.bridgeUrl ?? "");
   const normalized = candidate
-    ? normalizeDirectCloudSharedAgentApiBase(stripTrailingSlash(candidate))
+    ? normalizeDirectCloudSharedAgentApiBase(stripTrailingSlashes(candidate))
     : "";
   // A server URL that is missing/blank, or collapsed to the agent-id-less Eliza
   // Cloud collection (`.../api/v1/eliza/agents`), is unusable — every `/api/*`
@@ -3441,7 +3441,7 @@ function resolveDirectCloudAgentBridgeUrl(
   cloudApiBase: string,
   agentId: string,
 ): string {
-  return `${cloudApiBase.replace(/\/+$/, "")}/api/v1/eliza/agents/${encodeURIComponent(agentId)}/bridge`;
+  return `${stripTrailingSlashes(cloudApiBase)}/api/v1/eliza/agents/${encodeURIComponent(agentId)}/bridge`;
 }
 
 function resolveDedicatedCloudAgentApiBase(args: {
@@ -3569,7 +3569,7 @@ ElizaClient.prototype.provisionCloudSandbox = async (options) => {
     // fallback for callers that explicitly allow shared runtime.
     const sharedWebUiUrl =
       immediateWebUiUrl ??
-      `${resolvedCloudApiBase.replace(/\/+$/, "")}/api/v1/eliza/agents/${encodeURIComponent(agentId)}`;
+      `${stripTrailingSlashes(resolvedCloudApiBase)}/api/v1/eliza/agents/${encodeURIComponent(agentId)}`;
     return {
       bridgeUrl: resolveDirectCloudAgentBridgeUrl(
         resolvedCloudApiBase,

--- a/packages/ui/src/api/direct-cloud-endpoints.ts
+++ b/packages/ui/src/api/direct-cloud-endpoints.ts
@@ -103,8 +103,15 @@ const DIRECT_ELIZA_CLOUD_APP_BY_HOST = new Map([
   ),
 ]);
 
+/** Removes one trailing slash run with a single scan and allocation. */
+export function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end -= 1;
+  return end === value.length ? value : value.slice(0, end);
+}
+
 export function resolveDirectCloudWebBase(cloudBase: string): string {
-  const normalized = cloudBase.replace(/\/+$/, "");
+  const normalized = stripTrailingSlashes(cloudBase);
   try {
     const host = new URL(normalized).hostname.toLowerCase();
     return DIRECT_ELIZA_CLOUD_WEB_BY_HOST.get(host) ?? normalized;
@@ -117,7 +124,7 @@ export function resolveDirectCloudWebBase(cloudBase: string): string {
 
 /** Resolve the browser origin that owns authenticated Cloud management. */
 export function resolveDirectCloudAppBase(cloudBase: string): string {
-  const normalized = cloudBase.replace(/\/+$/, "");
+  const normalized = stripTrailingSlashes(cloudBase);
   try {
     const host = new URL(normalized).hostname.toLowerCase();
     return DIRECT_ELIZA_CLOUD_APP_BY_HOST.get(host) ?? normalized;
@@ -129,7 +136,7 @@ export function resolveDirectCloudAppBase(cloudBase: string): string {
 }
 
 export function resolveDirectCloudAuthApiBase(cloudBase: string): string {
-  const normalized = cloudBase.replace(/\/+$/, "");
+  const normalized = stripTrailingSlashes(cloudBase);
   try {
     const host = new URL(normalized).hostname.toLowerCase();
     return DIRECT_ELIZA_CLOUD_API_BY_HOST.get(host) ?? normalized;

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/polynomial-edge-runs.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/polynomial-edge-runs.test.ts
@@ -1,5 +1,6 @@
 /** Exercises linear-time public sanitizers with adversarial 100k-character runs. */
 import { describe, expect, it } from "vitest";
+import { extractBulkItems } from "../../src/actions/tasks.ts";
 import { sanitizePlannerText } from "../../src/index.ts";
 import { normalizeClaudeAcpModelId } from "../../src/services/acp-service.ts";
 import { redactCodingMemoryText } from "../../src/services/curated-coding-memory.ts";
@@ -32,5 +33,13 @@ describe("polynomial edge-run regressions", () => {
     const result = sanitizePlannerText(`restart${" ".repeat(100_000)}acpx.`);
     expect(result).toContain("self-heals");
     expect(result).not.toContain("acpx");
+  });
+
+  it("does not treat decimal versions as numbered issue markers", () => {
+    expect(extractBulkItems("release 1.2 works with runtime 3.4")).toEqual([]);
+    expect(extractBulkItems("1. first issue 2. second issue")).toEqual([
+      { title: "first issue" },
+      { title: "second issue" },
+    ]);
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/polynomial-edge-runs.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/polynomial-edge-runs.test.ts
@@ -13,7 +13,7 @@ describe("polynomial edge-run regressions", () => {
       normalizeRepositoryInput(
         `https://github.com/elizaOS/eliza${"/".repeat(100_000)}`,
       ),
-    ).toBe("https://github.com/elizaOS/eliza");
+    ).toBe("https://github.com/elizaOS/eliza.git");
     expect(
       stripToolTranscript(`[tool output:${"[tool output:".repeat(10_000)}`),
     ).toBe("");

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/polynomial-edge-runs.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/polynomial-edge-runs.test.ts
@@ -1,0 +1,36 @@
+/** Exercises linear-time public sanitizers with adversarial 100k-character runs. */
+import { describe, expect, it } from "vitest";
+import { sanitizePlannerText } from "../../src/index.ts";
+import { normalizeClaudeAcpModelId } from "../../src/services/acp-service.ts";
+import { redactCodingMemoryText } from "../../src/services/curated-coding-memory.ts";
+import { normalizeRepositoryInput } from "../../src/services/repo-input.ts";
+import { stripToolTranscript } from "../../src/services/transcript-sanitizer.ts";
+import { parseOwnerRepo } from "../../src/services/workspace-github.ts";
+
+describe("polynomial edge-run regressions", () => {
+  it("handles 100k trailing delimiters and unterminated envelopes", () => {
+    expect(
+      normalizeRepositoryInput(
+        `https://github.com/elizaOS/eliza${"/".repeat(100_000)}`,
+      ),
+    ).toBe("https://github.com/elizaOS/eliza");
+    expect(
+      stripToolTranscript(`[tool output:${"[tool output:".repeat(10_000)}`),
+    ).toBe("");
+    expect(() => parseOwnerRepo(`#${"#".repeat(100_000)}`)).toThrow();
+  });
+
+  it("redacts large key blocks and strips repeated model suffixes", () => {
+    const key = `-----BEGIN PRIVATE KEY-----${"A".repeat(100_000)}-----END PRIVATE KEY-----`;
+    expect(redactCodingMemoryText(key)).toBe("[REDACTED]");
+    expect(
+      normalizeClaudeAcpModelId(`claude${" [123ms]".repeat(10_000)}`),
+    ).toBe("claude");
+  });
+
+  it("filters forbidden recovery prose with a 100k whitespace run", () => {
+    const result = sanitizePlannerText(`restart${" ".repeat(100_000)}acpx.`);
+    expect(result).toContain("self-heals");
+    expect(result).not.toContain("acpx");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sanitize-planner-text.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sanitize-planner-text.test.ts
@@ -33,6 +33,21 @@ describe("sanitizePlannerText", () => {
     expect(out).toBe(SELF_HEAL);
   });
 
+  it("strips plural 'manually clear your sessions' phrases", () => {
+    const out = sanitizePlannerText("Please manually clear your sessions.");
+    expect(out).toBe(SELF_HEAL);
+  });
+
+  it("strips 'kickoff acpx' phrases", () => {
+    const out = sanitizePlannerText("Kickoff acpx again.");
+    expect(out).toBe(SELF_HEAL);
+  });
+
+  it("strips 'kick-off acpx' phrases", () => {
+    const out = sanitizePlannerText("Kick-off acpx again.");
+    expect(out).toBe(SELF_HEAL);
+  });
+
   it("strips daemon-restart phrases", () => {
     const out = sanitizePlannerText("The daemon isn't accepting requests.");
     expect(out).toBe(SELF_HEAL);

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -3877,7 +3877,7 @@ function formatGitHubAuthPrompt(
   );
 }
 
-function extractBulkItems(
+export function extractBulkItems(
   text: string,
 ): Array<{ title: string; body?: string }> {
   if (!text) return [];
@@ -3903,6 +3903,10 @@ function extractBulkItems(
       continue;
     }
     let contentStart = digitEnd + 1;
+    if (text[contentStart]?.trim() !== "") {
+      cursor += 1;
+      continue;
+    }
     while (contentStart < text.length && text[contentStart]?.trim() === "") {
       contentStart += 1;
     }

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -3882,12 +3882,37 @@ function extractBulkItems(
 ): Array<{ title: string; body?: string }> {
   if (!text) return [];
 
-  const numberedPattern =
-    /(?:^|\s)(\d+)[).:-]\s*(.+?)(?=(?:\s+\d+[).:-]\s)|$)/gs;
   const items: Array<{ title: string; body?: string }> = [];
-
-  for (const match of text.matchAll(numberedPattern)) {
-    const raw = match[2].trim();
+  const markers: Array<{ start: number; contentStart: number }> = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    if (cursor > 0 && text[cursor - 1]?.trim() !== "") {
+      cursor += 1;
+      continue;
+    }
+    let digitEnd = cursor;
+    while (
+      digitEnd < text.length &&
+      (text[digitEnd] ?? "") >= "0" &&
+      (text[digitEnd] ?? "") <= "9"
+    ) {
+      digitEnd += 1;
+    }
+    if (digitEnd === cursor || !").:-".includes(text[digitEnd] ?? "")) {
+      cursor += 1;
+      continue;
+    }
+    let contentStart = digitEnd + 1;
+    while (contentStart < text.length && text[contentStart]?.trim() === "") {
+      contentStart += 1;
+    }
+    markers.push({ start: cursor, contentStart });
+    cursor = contentStart;
+  }
+  for (const [index, marker] of markers.entries()) {
+    const raw = text
+      .slice(marker.contentStart, markers[index + 1]?.start ?? text.length)
+      .trim();
     if (raw.length > 0) {
       items.push({ title: raw });
     }
@@ -3895,10 +3920,12 @@ function extractBulkItems(
 
   if (items.length >= 2) return items;
 
-  const bulletPattern = /(?:^|\n)\s*[-*•]\s+(.+)/g;
   const bulletItems: Array<{ title: string; body?: string }> = [];
-  for (const match of text.matchAll(bulletPattern)) {
-    const raw = match[1].trim();
+  for (const line of text.split("\n")) {
+    const candidate = line.trimStart();
+    if (!"-*•".includes(candidate[0] ?? "")) continue;
+    if (candidate.length < 2 || candidate[1]?.trim() !== "") continue;
+    const raw = candidate.slice(2).trim();
     if (raw.length > 0) {
       bulletItems.push({ title: raw });
     }

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -581,6 +581,8 @@ function isForbiddenCleanupSentence(sentence: string): boolean {
     containsWord(lower, "reboot") ||
     containsWord(lower, "bounce") ||
     containsWord(lower, "kick") ||
+    containsWord(lower, "kickoff") ||
+    containsWord(lower, "kick-off") ||
     lower.includes("not accepting") ||
     lower.includes("isn't accepting") ||
     lower.includes("isnt accepting");
@@ -591,7 +593,10 @@ function isForbiddenCleanupSentence(sentence: string): boolean {
     containsWord(lower, "clean") ||
     containsWord(lower, "wipe");
   if (clears && lower.includes("stale session")) return true;
-  return lower.includes("manually clear") && containsWord(lower, "session");
+  return (
+    lower.includes("manually clear") &&
+    (containsWord(lower, "session") || containsWord(lower, "sessions"))
+  );
 }
 
 function stripForbiddenCleanupSentences(text: string): string {

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -557,16 +557,80 @@ export function createAgentOrchestratorPlugin(): Plugin {
 // memory rewriting lands upstream, intercept user-facing text and replace
 // the teardown-retry phrases with the canonical self-heal recovery line so
 // the user never sees instructions to do something the runtime already does.
-const FORBIDDEN_CLEANUP_PATTERNS: RegExp[] = [
-  /[^.!?\n]*\b(restart|kick(?:[\s-]?off)?|bounce)[^.!?\n]*\bacpx[^.!?\n]*[.!?]?/gi,
-  /[^.!?\n]*\bacpx[^.!?\n]*\b(restart|reboot|not\s+accepting|isn'?t\s+accepting)[^.!?\n]*[.!?]?/gi,
-  /[^.!?\n]*\b(clear|clean|wipe)[^.!?\n]*\bstale\s+sessions?[^.!?\n]*[.!?]?/gi,
-  /[^.!?\n]*\bmanually\s+clear[^.!?\n]*\bsessions?[^.!?\n]*[.!?]?/gi,
-  /[^.!?\n]*\bdaemon\b[^.!?\n]*\b(restart|reboot|not\s+accepting|isn'?t\s+accepting)[^.!?\n]*[.!?]?/gi,
-];
-
 const SELF_HEAL_REPLACEMENT =
   "(Sub-agent state self-heals; respawning a fresh one automatically.)";
+
+function containsWord(value: string, word: string): boolean {
+  let cursor = 0;
+  while (cursor < value.length) {
+    const index = value.indexOf(word, cursor);
+    if (index < 0) return false;
+    const before = value[index - 1] ?? " ";
+    const after = value[index + word.length] ?? " ";
+    const isWord = (character: string): boolean => /[a-z0-9_]/.test(character);
+    if (!isWord(before) && !isWord(after)) return true;
+    cursor = index + 1;
+  }
+  return false;
+}
+
+function isForbiddenCleanupSentence(sentence: string): boolean {
+  const lower = sentence.toLowerCase();
+  const hasRecoveryVerb =
+    containsWord(lower, "restart") ||
+    containsWord(lower, "reboot") ||
+    containsWord(lower, "bounce") ||
+    containsWord(lower, "kick") ||
+    lower.includes("not accepting") ||
+    lower.includes("isn't accepting") ||
+    lower.includes("isnt accepting");
+  if (containsWord(lower, "acpx") && hasRecoveryVerb) return true;
+  if (containsWord(lower, "daemon") && hasRecoveryVerb) return true;
+  const clears =
+    containsWord(lower, "clear") ||
+    containsWord(lower, "clean") ||
+    containsWord(lower, "wipe");
+  if (clears && lower.includes("stale session")) return true;
+  return lower.includes("manually clear") && containsWord(lower, "session");
+}
+
+function stripForbiddenCleanupSentences(text: string): string {
+  const out: string[] = [];
+  let segmentStart = 0;
+  for (let index = 0; index <= text.length; index += 1) {
+    const character = text[index];
+    const boundary =
+      index === text.length ||
+      character === "." ||
+      character === "!" ||
+      character === "?" ||
+      character === "\n";
+    if (!boundary) continue;
+    const includePunctuation = character !== "\n" && index < text.length;
+    const segmentEnd = index + (includePunctuation ? 1 : 0);
+    const segment = text.slice(segmentStart, segmentEnd);
+    if (!isForbiddenCleanupSentence(segment)) out.push(segment);
+    if (character === "\n") out.push("\n");
+    segmentStart = index + 1;
+  }
+  return out.join("");
+}
+
+function collapseWhitespaceRuns(text: string): string {
+  const out: string[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    if (text[cursor]?.trim() !== "") {
+      out.push(text[cursor] ?? "");
+      cursor += 1;
+      continue;
+    }
+    const start = cursor;
+    while (cursor < text.length && text[cursor]?.trim() === "") cursor += 1;
+    out.push(cursor - start >= 2 ? " " : (text[start] ?? ""));
+  }
+  return out.join("");
+}
 
 /**
  * Strip the `<emoji> [label] ` prefix from a progress line so it reads
@@ -699,12 +763,9 @@ export function plannerAlreadyAckedSpawn(
 // Exported for unit tests; not part of the plugin's public API contract.
 export function sanitizePlannerText(text: string): string {
   if (!text) return text;
-  let cleaned = text;
-  for (const pattern of FORBIDDEN_CLEANUP_PATTERNS) {
-    cleaned = cleaned.replace(pattern, "");
-  }
+  let cleaned = stripForbiddenCleanupSentences(text);
   if (cleaned === text) return text;
-  cleaned = cleaned.replace(/\s{2,}/g, " ").trim();
+  cleaned = collapseWhitespaceRuns(cleaned).trim();
   return cleaned.length > 0
     ? `${cleaned} ${SELF_HEAL_REPLACEMENT}`
     : SELF_HEAL_REPLACEMENT;

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -361,10 +361,34 @@ function findExecutableOnPath(name: string): string | undefined {
 export function normalizeClaudeAcpModelId(
   model: string | undefined,
 ): string | undefined {
-  const normalized = model
-    ?.trim()
-    .replace(/(?:\s*\[[0-9]+[a-zA-Z]+\])+$/u, "")
-    .trim();
+  const value = model?.trim();
+  if (!value) return undefined;
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "]") {
+    const tokenStart = value.lastIndexOf("[", end - 1);
+    if (tokenStart < 0) break;
+    const token = value.slice(tokenStart + 1, end - 1);
+    let cursor = 0;
+    while (
+      cursor < token.length &&
+      (token[cursor] ?? "") >= "0" &&
+      (token[cursor] ?? "") <= "9"
+    ) {
+      cursor += 1;
+    }
+    const digitEnd = cursor;
+    while (
+      cursor < token.length &&
+      (((token[cursor] ?? "") >= "A" && (token[cursor] ?? "") <= "Z") ||
+        ((token[cursor] ?? "") >= "a" && (token[cursor] ?? "") <= "z"))
+    ) {
+      cursor += 1;
+    }
+    if (digitEnd === 0 || cursor === digitEnd || cursor !== token.length) break;
+    end = tokenStart;
+    while (end > 0 && value[end - 1]?.trim() === "") end -= 1;
+  }
+  const normalized = value.slice(0, end).trim();
   return normalized || undefined;
 }
 

--- a/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
@@ -262,10 +262,28 @@ function isCloudDeployTarget(config: AppDeployConfig): boolean {
 }
 
 function extractViewPluginSourceDir(task: string): string | undefined {
+  const lowerTask = task.toLowerCase();
+  const extractAfter = (
+    marker: string,
+    terminators: readonly string[],
+  ): string | undefined => {
+    const markerStart = lowerTask.indexOf(marker);
+    if (markerStart < 0) return undefined;
+    let valueStart = markerStart + marker.length;
+    while (valueStart < task.length && task[valueStart]?.trim() === "") {
+      valueStart += 1;
+    }
+    if (valueStart === markerStart + marker.length) return undefined;
+    let valueEnd = task.length;
+    for (const terminator of terminators) {
+      const candidate = lowerTask.indexOf(terminator.toLowerCase(), valueStart);
+      if (candidate >= 0 && candidate < valueEnd) valueEnd = candidate;
+    }
+    return task.slice(valueStart, valueEnd).trim() || undefined;
+  };
   return (
-    task
-      .match(/plugin source directory is\s+(.+?)(?:\. It|\n|$)/i)?.[1]
-      ?.trim() ?? task.match(/source lives in\s+(.+?)(?:\.|\n|$)/i)?.[1]?.trim()
+    extractAfter("plugin source directory is", [". it", "\n"]) ??
+    extractAfter("source lives in", [".", "\n"])
   );
 }
 

--- a/plugins/plugin-agent-orchestrator/src/services/completion-envelope.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-envelope.ts
@@ -100,20 +100,35 @@ export type CompletionEnvelopeParse =
   | { present: true; ok: true; envelope: CompletionEnvelope }
   | { present: true; ok: false; errors: string[] };
 
-const FENCED_JSON_RE = /```json\s*\n([\s\S]*?)```/gi;
-
 function isStringArray(v: unknown): v is string[] {
   return Array.isArray(v) && v.every((x) => typeof x === "string");
 }
 
 function extractJsonCandidate(text: string): string | null {
   // Prefer the LAST fenced ```json block (the completion envelope comes last).
-  let match: RegExpExecArray | null;
   let last: string | null = null;
-  FENCED_JSON_RE.lastIndex = 0;
-  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
-  while ((match = FENCED_JSON_RE.exec(text)) !== null) {
-    last = match[1]?.trim() ?? null;
+  const lowerText = text.toLowerCase();
+  let cursor = 0;
+  while (cursor < text.length) {
+    const opener = lowerText.indexOf("```json", cursor);
+    if (opener < 0) break;
+    let bodyStart = opener + 7;
+    while (bodyStart < text.length && text[bodyStart] !== "\n") {
+      if (text[bodyStart]?.trim() !== "") {
+        bodyStart = opener + 1;
+        break;
+      }
+      bodyStart += 1;
+    }
+    if (bodyStart === opener + 1 || text[bodyStart] !== "\n") {
+      cursor = opener + 1;
+      continue;
+    }
+    bodyStart += 1;
+    const closer = text.indexOf("```", bodyStart);
+    if (closer < 0) break;
+    last = text.slice(bodyStart, closer).trim() || null;
+    cursor = closer + 3;
   }
   if (last) return last;
   // No fence: only treat the whole message as JSON when it clearly looks like

--- a/plugins/plugin-agent-orchestrator/src/services/curated-coding-memory.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/curated-coding-memory.ts
@@ -250,14 +250,35 @@ const SECRET_PATTERNS: RegExp[] = [
   /\bsk-[A-Za-z0-9_-]{20,}\b/g,
   /\bAKIA[A-Z0-9]{16}\b/g,
   /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
-  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
   /\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|password|credential)\s*[:=]\s*["']?[^"'\s,;]+/gi,
   /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
   /\b(?:\+?\d[\d .()-]{8,}\d)\b/g,
 ];
 
+function redactPrivateKeys(input: string): string {
+  const begin = "-----BEGIN ";
+  const end = "-----END ";
+  const keySuffix = "PRIVATE KEY-----";
+  const fragments: string[] = [];
+  let cursor = 0;
+  while (cursor < input.length) {
+    const blockStart = input.indexOf(begin, cursor);
+    if (blockStart < 0) break;
+    const headerEnd = input.indexOf(keySuffix, blockStart + begin.length);
+    if (headerEnd < 0) break;
+    const blockFooter = input.indexOf(end, headerEnd + keySuffix.length);
+    if (blockFooter < 0) break;
+    const footerEnd = input.indexOf(keySuffix, blockFooter + end.length);
+    if (footerEnd < 0) break;
+    fragments.push(input.slice(cursor, blockStart), "[REDACTED]");
+    cursor = footerEnd + keySuffix.length;
+  }
+  fragments.push(input.slice(cursor));
+  return fragments.join("");
+}
+
 export function redactCodingMemoryText(input: string): string {
-  let text = input;
+  let text = redactPrivateKeys(input);
   for (const pattern of SECRET_PATTERNS) {
     text = text.replace(pattern, "[REDACTED]");
   }

--- a/plugins/plugin-agent-orchestrator/src/services/lane-planner.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/lane-planner.ts
@@ -113,10 +113,14 @@ export function collisionProviderFromWorkspaceService(
 }
 
 function normalizePath(raw: string): string | undefined {
-  const trimmed = raw
-    .trim()
-    .replace(/^['"`([{<]+/, "")
-    .replace(/['"`)\]}>.,;:]+$/, "");
+  const value = raw.trim();
+  const leading = "'\"`([{<";
+  const trailing = "'\"`)]}>.,;:";
+  let start = 0;
+  let end = value.length;
+  while (start < end && leading.includes(value[start] ?? "")) start += 1;
+  while (end > start && trailing.includes(value[end - 1] ?? "")) end -= 1;
+  const trimmed = value.slice(start, end);
   if (!trimmed || trimmed === "." || trimmed === "/") return undefined;
   if (trimmed.includes("..")) return undefined;
   if (/^(?:https?:|file:)/i.test(trimmed)) return undefined;

--- a/plugins/plugin-agent-orchestrator/src/services/repo-input.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/repo-input.ts
@@ -18,9 +18,16 @@ function stripGitSuffix(value: string): string {
   return value.replace(/\.git$/i, "");
 }
 
+function stripSlashEdges(value: string): string {
+  let start = 0;
+  let end = value.length;
+  while (start < end && value.charCodeAt(start) === 47) start += 1;
+  while (end > start && value.charCodeAt(end - 1) === 47) end -= 1;
+  return value.slice(start, end);
+}
+
 function normalizePathSegments(pathname: string): string[] {
-  return pathname
-    .replace(/^\/+|\/+$/g, "")
+  return stripSlashEdges(pathname)
     .split("/")
     .map((segment) => segment.trim())
     .filter(Boolean);

--- a/plugins/plugin-agent-orchestrator/src/services/repo-input.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/repo-input.ts
@@ -40,7 +40,10 @@ export function normalizeRepositoryInput(repo: string): string {
     return trimmed;
   }
 
-  const withoutTrailingSlash = trimmed.replace(/\/+$/, "");
+  let end = trimmed.length;
+  while (end > 0 && trimmed.charCodeAt(end - 1) === 47) end -= 1;
+  const withoutTrailingSlash =
+    end === trimmed.length ? trimmed : trimmed.slice(0, end);
 
   if (/^https?:\/\//i.test(withoutTrailingSlash)) {
     try {

--- a/plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/transcript-sanitizer.ts
@@ -37,17 +37,32 @@ export const DEFAULT_MAX_RELAY_CHARS = 2000;
  */
 export function stripToolTranscript(text: string): string {
   if (!text) return "";
-  return (
-    text
-      // Well-formed and empty-title blocks (non-greedy body up to the fence).
-      .replace(/\[tool output:[^\]]*\][\s\S]*?\[\/tool output\]/g, "")
-      // Unterminated trailing block: dangling opener with no closing fence.
-      // Only fires if a `[tool output:` marker remains AFTER the pass above,
-      // which means it was never closed — strip it to end of string.
-      .replace(/\[tool output:[\s\S]*$/g, "")
-      .replace(/\n{3,}/g, "\n\n")
-      .trim()
-  );
+  const opener = "[tool output:";
+  const closer = "[/tool output]";
+  const fragments: string[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    const blockStart = text.indexOf(opener, cursor);
+    if (blockStart < 0) break;
+    const titleEnd = text.indexOf("]", blockStart + opener.length);
+    if (titleEnd < 0) {
+      fragments.push(text.slice(cursor, blockStart));
+      cursor = text.length;
+      break;
+    }
+    const blockEnd = text.indexOf(closer, titleEnd + 1);
+    fragments.push(text.slice(cursor, blockStart));
+    if (blockEnd < 0) {
+      cursor = text.length;
+      break;
+    }
+    cursor = blockEnd + closer.length;
+  }
+  fragments.push(text.slice(cursor));
+  return fragments
+    .join("")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
 }
 
 /**

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-github.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-github.ts
@@ -64,11 +64,14 @@ export function parseOwnerRepo(repo: string): {
 } {
   // Handle URLs like https://github.com/owner/repo or owner/repo. GitHub
   // repository names may contain dots, so do not use a dot as a delimiter.
-  const normalized = repo
-    .trim()
-    .replace(/^https?:\/\/github\.com\//i, "")
-    .replace(/[?#].*$/, "")
-    .replace(/\.git$/, "");
+  const withoutHost = repo.trim().replace(/^https?:\/\/github\.com\//i, "");
+  const query = withoutHost.indexOf("?");
+  const fragment = withoutHost.indexOf("#");
+  const suffixStart =
+    query < 0 ? fragment : fragment < 0 ? query : Math.min(query, fragment);
+  const normalized = (
+    suffixStart < 0 ? withoutHost : withoutHost.slice(0, suffixStart)
+  ).replace(/\.git$/, "");
   const parts = normalized.split("/");
   if (
     parts.length !== 2 ||

--- a/plugins/plugin-agent-orchestrator/vitest.config.ts
+++ b/plugins/plugin-agent-orchestrator/vitest.config.ts
@@ -21,6 +21,11 @@ export default defineConfig({
         "../../packages/auth/src/index.ts",
         import.meta.url,
       ).pathname,
+      // The auth source alias pulls in @elizaos/vault, which resolves only
+      // through its built dist; pin it to source for clean-checkout runs.
+      "@elizaos/vault": fileURLToPath(
+        new URL("../../packages/vault/src/index.ts", import.meta.url),
+      ),
       "@elizaos/shared": fileURLToPath(
         new URL("./__tests__/shared-runtime-env.ts", import.meta.url),
       ),

--- a/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
+++ b/plugins/plugin-anthropic-proxy/src/proxy/process-body.ts
@@ -53,6 +53,37 @@ export interface ProcessBodyResult {
   };
 }
 
+function stripThinkingParameters(value: string): {
+  value: string;
+  count: number;
+} {
+  const marker = '"thinking":';
+  const out: string[] = [];
+  let cursor = 0;
+  let count = 0;
+  while (cursor < value.length) {
+    const keyStart = value.indexOf(marker, cursor);
+    if (keyStart < 0) break;
+    let objectStart = keyStart + marker.length;
+    while (objectStart < value.length && value[objectStart]?.trim() === "") {
+      objectStart += 1;
+    }
+    if (value[objectStart] !== "{") {
+      out.push(value.slice(cursor, keyStart + 1));
+      cursor = keyStart + 1;
+      continue;
+    }
+    const objectEnd = value.indexOf("}", objectStart + 1);
+    if (objectEnd < 0) break;
+    const removalStart = keyStart > cursor && value[keyStart - 1] === "," ? keyStart - 1 : keyStart;
+    out.push(value.slice(cursor, removalStart));
+    cursor = objectEnd + 1;
+    count += 1;
+  }
+  out.push(value.slice(cursor));
+  return { value: out.join(""), count };
+}
+
 function insertTopLevelField(body: string, field: string): string {
   if (!body.startsWith("{")) return `{${field}}`;
 
@@ -229,12 +260,9 @@ export function processBody(bodyStr: string, config: ProcessBodyConfig): Process
   let thinkingBlocksStripped = 0;
   let thinkingParamsStripped = 0;
   if (config.stripThinkingBlocks !== false) {
-    const thinkingParamRegex = /,?"thinking":\s*\{[^}]*\}/g;
-    const thinkingMatches = m.match(thinkingParamRegex);
-    if (thinkingMatches) {
-      m = m.replace(thinkingParamRegex, "");
-      thinkingParamsStripped = thinkingMatches.length;
-    }
+    const strippedThinkingParameters = stripThinkingParameters(m);
+    m = strippedThinkingParameters.value;
+    thinkingParamsStripped = strippedThinkingParameters.count;
     const msgsIdx2 = m.indexOf('"messages":[');
     if (msgsIdx2 !== -1) {
       for (const marker of ['{"type":"thinking"', '{"type":"redacted_thinking"']) {

--- a/plugins/plugin-app-control/src/actions/agent-switch.test.ts
+++ b/plugins/plugin-app-control/src/actions/agent-switch.test.ts
@@ -55,6 +55,10 @@ describe("inferAgentSwitchProfile", () => {
 		expect(inferAgentSwitchProfile("hello")).toBeNull();
 		expect(inferAgentSwitchProfile("")).toBeNull();
 	});
+
+	it("scans a 100k non-matching request without regex backtracking", () => {
+		expect(inferAgentSwitchProfile(`switch ${"x".repeat(100_000)}`)).toBeNull();
+	});
 });
 
 describe("AGENT_SWITCH handler", () => {

--- a/plugins/plugin-app-control/src/actions/agent-switch.ts
+++ b/plugins/plugin-app-control/src/actions/agent-switch.ts
@@ -85,6 +85,45 @@ const SWITCH_VERB_RE = /\b(switch|use|change|connect|move|go|activate)\b/i;
 const AGENT_NOUN_RE =
 	/\b(agent|runtime|backend|profile|instance|server|node)\b/i;
 
+function wordSpans(
+	value: string,
+): Array<{ value: string; start: number; end: number }> {
+	const spans: Array<{ value: string; start: number; end: number }> = [];
+	let cursor = 0;
+	while (cursor < value.length) {
+		const code = value.charCodeAt(cursor);
+		const isWord =
+			(code >= 48 && code <= 57) ||
+			(code >= 65 && code <= 90) ||
+			code === 95 ||
+			(code >= 97 && code <= 122);
+		if (!isWord) {
+			cursor += 1;
+			continue;
+		}
+		const start = cursor;
+		while (cursor < value.length) {
+			const next = value.charCodeAt(cursor);
+			if (
+				!(
+					(next >= 48 && next <= 57) ||
+					(next >= 65 && next <= 90) ||
+					next === 95 ||
+					(next >= 97 && next <= 122)
+				)
+			)
+				break;
+			cursor += 1;
+		}
+		spans.push({
+			value: value.slice(start, cursor).toLowerCase(),
+			start,
+			end: cursor,
+		});
+	}
+	return spans;
+}
+
 /**
  * Extract the target profile from an explicit option or the message. Returns
  * null when no profile is named — AGENT_SWITCH never picks a profile blindly.
@@ -107,18 +146,66 @@ export function inferAgentSwitchProfile(
 	// Pull the phrase after the agent/runtime noun: "switch to my cloud agent"
 	// → "cloud"; "use the laptop runtime" → "laptop". The shell resolves this
 	// fuzzy label against the profile registry (id or label).
-	const match =
-		/\b(?:switch|use|change|connect|move|go|activate)\b\s+(?:to\s+|over\s+to\s+)?(?:the\s+|my\s+)?(.+?)\s+(?:agent|runtime|backend|profile|instance|server|node)\b/i.exec(
-			trimmed,
-		);
-	const label = match?.[1]?.trim();
+	const spans = wordSpans(trimmed);
+	const verbs = new Set([
+		"switch",
+		"use",
+		"change",
+		"connect",
+		"move",
+		"go",
+		"activate",
+	]);
+	const nouns = new Set([
+		"agent",
+		"runtime",
+		"backend",
+		"profile",
+		"instance",
+		"server",
+		"node",
+	]);
+	const verbIndex = spans.findIndex((span) => verbs.has(span.value));
+	let labelStartIndex = verbIndex + 1;
+	if (
+		spans[labelStartIndex]?.value === "over" &&
+		spans[labelStartIndex + 1]?.value === "to"
+	) {
+		labelStartIndex += 2;
+	} else if (spans[labelStartIndex]?.value === "to") {
+		labelStartIndex += 1;
+	}
+	if (
+		spans[labelStartIndex]?.value === "the" ||
+		spans[labelStartIndex]?.value === "my"
+	) {
+		labelStartIndex += 1;
+	}
+	const nounIndex = spans.findIndex(
+		(span, index) => index > labelStartIndex && nouns.has(span.value),
+	);
+	const labelStartSpan = spans[labelStartIndex];
+	const nounSpan = spans[nounIndex];
+	const label =
+		verbIndex >= 0 && nounIndex > labelStartIndex && labelStartSpan && nounSpan
+			? trimmed.slice(labelStartSpan.start, nounSpan.start).trim()
+			: undefined;
 	if (label && label.length > 0 && label.toLowerCase() !== "another") {
 		return label;
 	}
 	// "switch agent to X" / "switch to the X runtime" fallback: the phrase after
 	// "to".
-	const toMatch = /\bto\s+(?:the\s+|my\s+)?(.+?)\s*$/i.exec(trimmed);
-	const toLabel = toMatch?.[1]
+	const toIndex = spans.findIndex((span) => span.value === "to");
+	let fallbackStart = toIndex + 1;
+	if (
+		spans[fallbackStart]?.value === "the" ||
+		spans[fallbackStart]?.value === "my"
+	)
+		fallbackStart += 1;
+	const fallbackSpan = spans[fallbackStart];
+	const toLabel = (
+		toIndex >= 0 && fallbackSpan ? trimmed.slice(fallbackSpan.start) : undefined
+	)
 		?.replace(/\b(agent|runtime|backend|profile|instance|server|node)\b/gi, "")
 		.trim();
 	return toLabel && toLabel.length > 0 ? toLabel : null;

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -1536,12 +1536,48 @@ function deriveParamsFromIntent(
 }
 
 function extractIntentTitle(intent: string): string | null {
-	const titled =
-		/\btitled?\s+["']?(.+?)(?:["']?\s+\b(?:with|on|at|for)\b|["']?$)/i.exec(
-			intent,
-		);
-	if (titled?.[1]?.trim()) {
-		return titled[1].trim();
+	const lower = intent.toLowerCase();
+	let markerEnd = -1;
+	for (const marker of ["titled", "title"]) {
+		let cursor = 0;
+		while (cursor < lower.length) {
+			const start = lower.indexOf(marker, cursor);
+			if (start < 0) break;
+			const before = lower[start - 1] ?? " ";
+			const after = lower[start + marker.length] ?? " ";
+			if (!/[a-z0-9_]/.test(before) && after.trim() === "") {
+				markerEnd = start + marker.length;
+				break;
+			}
+			cursor = start + 1;
+		}
+		if (markerEnd >= 0) break;
+	}
+	if (markerEnd >= 0) {
+		let titleStart = markerEnd;
+		while (titleStart < intent.length && intent[titleStart]?.trim() === "")
+			titleStart += 1;
+		if (intent[titleStart] === '"' || intent[titleStart] === "'")
+			titleStart += 1;
+		let titleEnd = intent.length;
+		for (const delimiter of ["with", "on", "at", "for"]) {
+			let cursor = titleStart;
+			while (cursor < lower.length) {
+				const start = lower.indexOf(delimiter, cursor);
+				if (start < 0) break;
+				const before = intent[start - 1] ?? "";
+				const after = intent[start + delimiter.length] ?? " ";
+				if (before.trim() === "" && !/[a-z0-9_]/.test(after)) {
+					titleEnd = Math.min(titleEnd, start);
+					break;
+				}
+				cursor = start + 1;
+			}
+		}
+		let title = intent.slice(titleStart, titleEnd).trim();
+		if (title.endsWith('"') || title.endsWith("'"))
+			title = title.slice(0, -1).trimEnd();
+		if (title) return title;
 	}
 	const quoted = /["']([^"']{1,160})["']/.exec(intent);
 	return quoted?.[1]?.trim() ?? null;

--- a/plugins/plugin-browser/src/workspace/browser-workspace-errors.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-errors.ts
@@ -96,7 +96,11 @@ export function classifyBrowserWorkspaceErrorCode(
   if (/rejected invalid URL|only supports http\/https/i.test(message)) {
     return "invalid_url";
   }
-  if (/\(404\)|Tab .+ was not found/i.test(message)) {
+  const lowerMessage = message.toLowerCase();
+  const tabPrefix = lowerMessage.indexOf("tab ");
+  const tabSuffix =
+    tabPrefix < 0 ? -1 : lowerMessage.indexOf(" was not found", tabPrefix + 4);
+  if (message.includes("(404)") || tabSuffix > tabPrefix + 4) {
     return "tab_not_found";
   }
   if (/requires a current tab/i.test(message)) {

--- a/plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts
@@ -98,13 +98,15 @@ function normalizeConnectorBrowserWorkspaceSegment(
   value: string,
   fieldName: string,
 ): string {
-  const normalized = value
+  const slug = value
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .replace(/-{2,}/g, "-")
-    .slice(0, 64);
+    .replace(/[^a-z0-9]+/g, "-");
+  let start = 0;
+  let end = slug.length;
+  while (start < end && slug.charCodeAt(start) === 45) start += 1;
+  while (end > start && slug.charCodeAt(end - 1) === 45) end -= 1;
+  const normalized = slug.slice(start, end).slice(0, 64);
   if (!normalized) {
     throw new Error(`Eliza browser connector session requires ${fieldName}.`);
   }

--- a/plugins/plugin-calendar/src/actions/conflict-detect.offset.test.ts
+++ b/plugins/plugin-calendar/src/actions/conflict-detect.offset.test.ts
@@ -1,0 +1,27 @@
+/** Deterministic coverage for conflict-detect timestamp offset validation. */
+
+import { describe, expect, it } from "vitest";
+import { hasExplicitOffset } from "./conflict-detect.js";
+
+describe("hasExplicitOffset", () => {
+  it.each([
+    "2026-01-01T10:00:00Z",
+    "2026-01-01t10:00:00z",
+    "2026-01-01t10:00:00Z",
+    "2026-01-01T10:00:00z",
+    "2026-01-01t10:00:00+05:30",
+    "2026-01-01t10:00:00-0800",
+  ])("accepts RFC 3339 timestamp with explicit offset: %s", (value) => {
+    expect(hasExplicitOffset(value)).toBe(true);
+  });
+
+  it.each([
+    "2026-01-01T10:00:00",
+    "2026-01-01t10:00:00",
+    "2026-01-01",
+    "2026-01-01T",
+    "10:00:00Z",
+  ])("rejects timestamp without explicit offset: %s", (value) => {
+    expect(hasExplicitOffset(value)).toBe(false);
+  });
+});

--- a/plugins/plugin-calendar/src/actions/conflict-detect.ts
+++ b/plugins/plugin-calendar/src/actions/conflict-detect.ts
@@ -432,7 +432,25 @@ function resolveSubaction(
 }
 
 function hasExplicitOffset(value: string): boolean {
-  return /T.+(?:Z|[+-]\d{2}:?\d{2})$/i.test(value);
+  const timeSeparator = value.indexOf("T");
+  if (timeSeparator < 0 || timeSeparator >= value.length - 1) return false;
+  if (value.endsWith("Z") || value.endsWith("z")) {
+    return value.length - 1 > timeSeparator + 1;
+  }
+  const compactStart = value.length - 5;
+  const colonStart = value.length - 6;
+  const offsetStart = value[colonStart + 3] === ":" ? colonStart : compactStart;
+  if (offsetStart <= timeSeparator + 1) return false;
+  const sign = value[offsetStart];
+  if (sign !== "+" && sign !== "-") return false;
+  const digits =
+    offsetStart === colonStart
+      ? `${value.slice(offsetStart + 1, offsetStart + 3)}${value.slice(offsetStart + 4)}`
+      : value.slice(offsetStart + 1);
+  return (
+    digits.length === 4 &&
+    [...digits].every((digit) => digit >= "0" && digit <= "9")
+  );
 }
 
 function validInstantRange(range: ConflictRange): boolean {

--- a/plugins/plugin-calendar/src/actions/conflict-detect.ts
+++ b/plugins/plugin-calendar/src/actions/conflict-detect.ts
@@ -431,8 +431,10 @@ function resolveSubaction(
   );
 }
 
-function hasExplicitOffset(value: string): boolean {
-  const timeSeparator = value.indexOf("T");
+// Exported for unit tests; not a public API.
+export function hasExplicitOffset(value: string): boolean {
+  // RFC 3339 permits a lowercase time separator (`2026-01-01t10:00:00z`).
+  const timeSeparator = value.toUpperCase().indexOf("T");
   if (timeSeparator < 0 || timeSeparator >= value.length - 1) return false;
   if (value.endsWith("Z") || value.endsWith("z")) {
     return value.length - 1 > timeSeparator + 1;

--- a/plugins/plugin-calendar/src/service/availability.test.ts
+++ b/plugins/plugin-calendar/src/service/availability.test.ts
@@ -402,6 +402,27 @@ describe("evaluateCalendarAvailability", () => {
     expect(repeatedHour.conflicts).toHaveLength(0);
   });
 
+  it("accepts RFC 3339 lowercase time separators and offsets", () => {
+    const evaluation = evaluateCalendarAvailability({
+      range: UTC_DAY,
+      timeZone: "UTC",
+      sources: [
+        source([
+          event("lower-z", "2026-05-11t09:00:00z", "2026-05-11t10:00:00z"),
+          event(
+            "lower-offset",
+            "2026-05-11t14:30:00+05:30",
+            "2026-05-11t15:30:00+05:30",
+          ),
+        ]),
+      ],
+    });
+    // Both events resolve to 09:00-10:00 UTC, so parsing both yields one
+    // overlap conflict instead of an "explicit offset" rejection.
+    expect(evaluation.checkedEvents).toBe(2);
+    expect(evaluation.conflicts).toHaveLength(1);
+  });
+
   it("rejects an offset-less local timestamp instead of guessing through a DST fold", () => {
     expect(() =>
       evaluateCalendarAvailability({

--- a/plugins/plugin-calendar/src/service/availability.ts
+++ b/plugins/plugin-calendar/src/service/availability.ts
@@ -180,8 +180,29 @@ const DEFAULT_POLICY: Required<CalendarAvailabilityPolicy> = {
   allDay: "block",
 };
 
-const EXPLICIT_OFFSET_PATTERN = /T.+(?:Z|[+-]\d{2}:?\d{2})$/i;
 const LOCAL_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+function hasExplicitOffset(value: string): boolean {
+  const timeSeparator = value.indexOf("T");
+  if (timeSeparator < 0 || timeSeparator >= value.length - 1) return false;
+  if (value.endsWith("Z") || value.endsWith("z")) {
+    return value.length - 1 > timeSeparator + 1;
+  }
+  const compactStart = value.length - 5;
+  const colonStart = value.length - 6;
+  const offsetStart = value[colonStart + 3] === ":" ? colonStart : compactStart;
+  if (offsetStart <= timeSeparator + 1) return false;
+  const sign = value[offsetStart];
+  if (sign !== "+" && sign !== "-") return false;
+  const digits =
+    offsetStart === colonStart
+      ? `${value.slice(offsetStart + 1, offsetStart + 3)}${value.slice(offsetStart + 4)}`
+      : value.slice(offsetStart + 1);
+  return (
+    digits.length === 4 &&
+    [...digits].every((digit) => digit >= "0" && digit <= "9")
+  );
+}
 
 function invalidAvailabilityInput(
   message: string,
@@ -195,7 +216,7 @@ function invalidAvailabilityInput(
 }
 
 function parseInstant(value: string, field: string, eventId?: string): number {
-  if (!EXPLICIT_OFFSET_PATTERN.test(value)) {
+  if (!hasExplicitOffset(value)) {
     return invalidAvailabilityInput(
       `${field} must be an RFC 3339 instant with an explicit offset.`,
       { field, value, ...(eventId ? { eventId } : {}) },

--- a/plugins/plugin-calendar/src/service/availability.ts
+++ b/plugins/plugin-calendar/src/service/availability.ts
@@ -183,7 +183,8 @@ const DEFAULT_POLICY: Required<CalendarAvailabilityPolicy> = {
 const LOCAL_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
 
 function hasExplicitOffset(value: string): boolean {
-  const timeSeparator = value.indexOf("T");
+  // RFC 3339 permits a lowercase time separator (`2026-01-01t10:00:00z`).
+  const timeSeparator = value.toUpperCase().indexOf("T");
   if (timeSeparator < 0 || timeSeparator >= value.length - 1) return false;
   if (value.endsWith("Z") || value.endsWith("z")) {
     return value.length - 1 > timeSeparator + 1;

--- a/plugins/plugin-cloud-apps/src/reachability.ts
+++ b/plugins/plugin-cloud-apps/src/reachability.ts
@@ -45,7 +45,9 @@ const globalFetchLike: FetchLike | undefined =
 
 /** Append `/health` (or another path) to a base URL, collapsing slashes. */
 export function healthUrl(base: string, path = "/health"): string {
-  const trimmedBase = base.replace(/\/+$/, "");
+  let end = base.length;
+  while (end > 0 && base.charCodeAt(end - 1) === 47) end -= 1;
+  const trimmedBase = end === base.length ? base : base.slice(0, end);
   const trimmedPath = path.startsWith("/") ? path : `/${path}`;
   return `${trimmedBase}${trimmedPath}`;
 }

--- a/plugins/plugin-codex-cli/src/codex-backend.ts
+++ b/plugins/plugin-codex-cli/src/codex-backend.ts
@@ -530,7 +530,9 @@ async function consumeResponseStream(
 }
 
 function stripTrailingSlash(value: string): string {
-  return value.replace(/\/+$/, "");
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end -= 1;
+  return end === value.length ? value : value.slice(0, end);
 }
 
 function validateBaseUrl(value: string): string {

--- a/plugins/plugin-coding-tools/src/shell/services/shellService.ts
+++ b/plugins/plugin-coding-tools/src/shell/services/shellService.ts
@@ -1868,11 +1868,19 @@ export class ShellService extends Service {
         target: this.resolvePath(parts[1], cwd),
       });
     } else if (cmd === "echo" && command.includes(">")) {
-      const match = command.match(/>\s*([^\s]+)$/);
-      if (match) {
+      const redirect = command.lastIndexOf(">");
+      let targetStart = redirect + 1;
+      while (
+        targetStart < command.length &&
+        command[targetStart]?.trim() === ""
+      ) {
+        targetStart += 1;
+      }
+      const target = command.slice(targetStart);
+      if (target && ![...target].some((character) => character.trim() === "")) {
         operations.push({
           type: "write" as FileOperationType,
-          target: this.resolvePath(match[1], cwd),
+          target: this.resolvePath(target, cwd),
         });
       }
     } else if (cmd === "mkdir" && parts.length > 1) {

--- a/plugins/plugin-computeruse/src/__tests__/brain.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/brain.test.ts
@@ -119,6 +119,12 @@ describe("parseBrainOutput", () => {
     expect(out.proposed_action.kind).toBe("wait");
   });
 
+  it("rejects a 100k unterminated fence without backtracking", () => {
+    expect(() =>
+      parseBrainOutput(`\`\`\`json\n${"x".repeat(100_000)}`),
+    ).toThrow(BrainParseError);
+  });
+
   it("tolerates leading prose before the first brace", () => {
     const raw =
       "Sure! Here's the JSON: " +

--- a/plugins/plugin-computeruse/src/actor/brain.ts
+++ b/plugins/plugin-computeruse/src/actor/brain.ts
@@ -543,17 +543,30 @@ export function brainPromptFor(
   ].join("\n");
 }
 
-const FENCE_RE = /```(?:json)?\s*([\s\S]*?)\s*```/i;
+function extractFencedBrainBody(value: string): string | null {
+  const opener = value.indexOf("```");
+  if (opener < 0) return null;
+  let bodyStart = opener + 3;
+  if (value.slice(bodyStart, bodyStart + 4).toLowerCase() === "json") {
+    bodyStart += 4;
+  }
+  while (bodyStart < value.length && value[bodyStart]?.trim() === "") {
+    bodyStart += 1;
+  }
+  const closer = value.indexOf("```", bodyStart);
+  if (closer < 0) return null;
+  let bodyEnd = closer;
+  while (bodyEnd > bodyStart && value[bodyEnd - 1]?.trim() === "") {
+    bodyEnd -= 1;
+  }
+  return value.slice(bodyStart, bodyEnd);
+}
 
 export function parseBrainOutput(raw: string): BrainOutput {
   const trimmed = raw.trim();
   let body = trimmed;
-  const fenceMatch = FENCE_RE.exec(trimmed);
-  if (fenceMatch) {
-    const fencedBody = fenceMatch[1];
-    if (fencedBody === undefined) {
-      throw new BrainParseError("Brain response markdown fence was empty", raw);
-    }
+  const fencedBody = extractFencedBrainBody(trimmed);
+  if (fencedBody !== null) {
     body = fencedBody.trim();
   }
   // Allow a leading prose paragraph by snipping to the first `{`.

--- a/plugins/plugin-discord/allowlist.ts
+++ b/plugins/plugin-discord/allowlist.ts
@@ -58,12 +58,16 @@ export interface DiscordChannelConfigResolved {
  * Converts to lowercase, removes special characters, replaces spaces with dashes
  */
 export function normalizeDiscordSlug(value: string): string {
-	return value
+	const slug = value
 		.trim()
 		.toLowerCase()
 		.replace(/^#/, "")
-		.replace(/[^a-z0-9]+/g, "-")
-		.replace(/^-+|-+$/g, "");
+		.replace(/[^a-z0-9]+/g, "-");
+	let start = 0;
+	let end = slug.length;
+	while (start < end && slug.charCodeAt(start) === 45) start += 1;
+	while (end > start && slug.charCodeAt(end - 1) === 45) end -= 1;
+	return slug.slice(start, end);
 }
 
 /**

--- a/plugins/plugin-elizacloud/src/cloud/lifeops-schedule-sync-client.ts
+++ b/plugins/plugin-elizacloud/src/cloud/lifeops-schedule-sync-client.ts
@@ -10,6 +10,12 @@ import type {
 
 const LIFEOPS_SCHEDULE_REQUEST_TIMEOUT_MS = 20_000;
 
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end -= 1;
+  return end === value.length ? value : value.slice(0, end);
+}
+
 export class LifeOpsScheduleSyncClientError extends Error {
   constructor(
     public readonly status: number,
@@ -70,7 +76,7 @@ export function resolveLifeOpsScheduleSyncConfig(
     return {
       configured: true,
       mode: "remote",
-      baseUrl: remoteApiBase.replace(/\/+$/, ""),
+      baseUrl: stripTrailingSlashes(remoteApiBase),
       accessToken:
         normalizeLifeOpsScheduleSyncSecret(config.remoteAccessToken) ??
         normalizeLifeOpsScheduleSyncSecret(process.env.ELIZA_REMOTE_ACCESS_TOKEN),

--- a/plugins/plugin-finances/src/services/subscriptions-service.ts
+++ b/plugins/plugin-finances/src/services/subscriptions-service.ts
@@ -330,11 +330,15 @@ function normalizeSubscriptionLookup(value: string): string {
 }
 
 function slugifySubscriptionValue(value: string): string {
-  return value
+  const slug = value
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "");
+    .replace(/[^a-z0-9]+/g, "_");
+  let start = 0;
+  let end = slug.length;
+  while (start < end && slug.charCodeAt(start) === 95) start += 1;
+  while (end > start && slug.charCodeAt(end - 1) === 95) end -= 1;
+  return slug.slice(start, end);
 }
 
 function guessCadence(

--- a/plugins/plugin-github/src/connector-credential-refs.ts
+++ b/plugins/plugin-github/src/connector-credential-refs.ts
@@ -539,10 +539,12 @@ function buildConnectorCredentialVaultRef(params: {
 }
 
 function normalizeVaultSegment(value: string): string {
-  const normalized = value
-    .trim()
-    .replace(/[^a-zA-Z0-9_-]+/g, "_")
-    .replace(/^_+|_+$/g, "");
+  const slug = value.trim().replace(/[^a-zA-Z0-9_-]+/g, "_");
+  let start = 0;
+  let end = slug.length;
+  while (start < end && slug.charCodeAt(start) === 95) start += 1;
+  while (end > start && slug.charCodeAt(end - 1) === 95) end -= 1;
+  const normalized = slug.slice(start, end);
   return (normalized || "unknown").slice(0, 64);
 }
 

--- a/plugins/plugin-google-workspace/src/connector-credential-refs.ts
+++ b/plugins/plugin-google-workspace/src/connector-credential-refs.ts
@@ -374,10 +374,12 @@ function buildConnectorCredentialVaultRef(params: {
 }
 
 function normalizeVaultSegment(value: string): string {
-  const normalized = value
-    .trim()
-    .replace(/[^a-zA-Z0-9_-]+/g, "_")
-    .replace(/^_+|_+$/g, "");
+  const slug = value.trim().replace(/[^a-zA-Z0-9_-]+/g, "_");
+  let start = 0;
+  let end = slug.length;
+  while (start < end && slug.charCodeAt(start) === 95) start += 1;
+  while (end > start && slug.charCodeAt(end - 1) === 95) end -= 1;
+  const normalized = slug.slice(start, end);
   return (normalized || "unknown").slice(0, 64);
 }
 

--- a/plugins/plugin-imessage/src/types.test.ts
+++ b/plugins/plugin-imessage/src/types.test.ts
@@ -13,7 +13,14 @@
 
 import { toWellFormedUnicode } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import { splitMessageForIMessage } from "./types";
+import { isEmail, splitMessageForIMessage } from "./types";
+
+describe("isEmail", () => {
+  it("validates a 100k local part without polynomial backtracking", () => {
+    expect(isEmail(`${"a".repeat(100_000)}@example.com`)).toBe(true);
+    expect(isEmail(`${"a".repeat(100_000)}@example`)).toBe(false);
+  });
+});
 
 function expectWellFormedLosslessRejoin(text: string, maxLength: number) {
   const chunks = splitMessageForIMessage(text, maxLength);

--- a/plugins/plugin-imessage/src/types.ts
+++ b/plugins/plugin-imessage/src/types.ts
@@ -216,7 +216,16 @@ export function isPhoneNumber(input: string): boolean {
  * Check if a string looks like an email
  */
 export function isEmail(input: string): boolean {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(input);
+  const at = input.indexOf("@");
+  if (at <= 0 || at !== input.lastIndexOf("@")) return false;
+  const dot = input.indexOf(".", at + 2);
+  if (dot < 0 || dot === input.length - 1) return false;
+  for (let index = 0; index < input.length; index += 1) {
+    const character = input[index];
+    if (character === "@") continue;
+    if (character?.trim() === "") return false;
+  }
+  return true;
 }
 
 /**

--- a/plugins/plugin-inbox/src/inbox/aggregate.ts
+++ b/plugins/plugin-inbox/src/inbox/aggregate.ts
@@ -61,11 +61,27 @@ const PHONE_BACKED_INBOX_CHANNELS = new Set<LifeOpsInboxChannel>([
   "sms",
   "whatsapp",
 ]);
-const SUBJECT_REPLY_PREFIX = /^(?:\s*(?:re|fwd|fw)\s*:\s*)+/i;
 const MISSED_REPLY_GAP_MS = 24 * 60 * 60 * 1000;
 const MISSED_MIN_PRIORITY = 50;
 
 export type InboxChatType = "dm" | "group" | "channel";
+
+function stripSubjectReplyPrefixes(value: string): string {
+  let cursor = 0;
+  while (cursor < value.length) {
+    let prefixStart = cursor;
+    while (prefixStart < value.length && value[prefixStart]?.trim() === "") {
+      prefixStart += 1;
+    }
+    const colon = value.indexOf(":", prefixStart);
+    if (colon < 0) break;
+    const marker = value.slice(prefixStart, colon).trim().toLowerCase();
+    if (marker !== "re" && marker !== "fw" && marker !== "fwd") break;
+    cursor = colon + 1;
+    while (cursor < value.length && value[cursor]?.trim() === "") cursor += 1;
+  }
+  return value.slice(cursor);
+}
 
 export function normalizeInboxChannel(
   source: string | null | undefined,
@@ -127,13 +143,11 @@ function deriveThreadId(
     return message.xConversationId;
   }
   if (channel === "gmail") {
-    const subject = message.channelName
-      .replace(/^Email from\s+/i, "")
-      .replace(SUBJECT_REPLY_PREFIX, "")
-      .trim();
+    const subject = message.channelName.replace(/^Email from\s+/i, "").trim();
+    const normalizedSubject = stripSubjectReplyPrefixes(subject).trim();
     const fromKey =
       message.senderEmail?.trim().toLowerCase() ?? message.senderName;
-    return `gmail:${fromKey}:${subject || externalId}`;
+    return `gmail:${fromKey}:${normalizedSubject || externalId}`;
   }
   if (message.roomId) {
     return message.roomId;

--- a/plugins/plugin-inbox/src/inbox/email-address.test.ts
+++ b/plugins/plugin-inbox/src/inbox/email-address.test.ts
@@ -21,4 +21,35 @@ describe("linear inbox token scanners", () => {
       ),
     ).toBe("hello");
   });
+
+  it("prefers the RFC 5322 angle-addr over email-like display-name tokens", () => {
+    expect(
+      extractAsciiEmailAddress("displayed@wrong.example <real@sender.example>"),
+    ).toBe("real@sender.example");
+    expect(
+      extractLooseEmailAddress("displayed@wrong.example <real@sender.example>"),
+    ).toBe("real@sender.example");
+    expect(
+      extractAsciiEmailAddress(
+        '"quoted display displayed@wrong.example" <real@sender.example>',
+      ),
+    ).toBe("real@sender.example");
+    expect(
+      extractLooseEmailAddress(
+        '"quoted display displayed@wrong.example" <real@sender.example>',
+      ),
+    ).toBe("real@sender.example");
+  });
+
+  it("falls back to the leftmost token when no angle-addr is present", () => {
+    expect(extractAsciiEmailAddress("plain@sender.example rest")).toBe(
+      "plain@sender.example",
+    );
+    expect(extractAsciiEmailAddress("Name <not-an-address> a@b.example")).toBe(
+      "a@b.example",
+    );
+    expect(extractLooseEmailAddress("plain@sender.example rest")).toBe(
+      "plain@sender.example",
+    );
+  });
 });

--- a/plugins/plugin-inbox/src/inbox/email-address.test.ts
+++ b/plugins/plugin-inbox/src/inbox/email-address.test.ts
@@ -1,0 +1,24 @@
+/** Proves sender-address scanners remain bounded on adversarial long headers. */
+import { describe, expect, it } from "vitest";
+import {
+  extractAsciiEmailAddress,
+  extractLooseEmailAddress,
+} from "./email-address.ts";
+import { normalizeGeneratedGmailReplyDraftBody } from "./gmail-normalize.ts";
+
+describe("linear inbox token scanners", () => {
+  it("handles 100k address and think-tag runs", () => {
+    const noise = "<".repeat(100_000);
+    expect(extractAsciiEmailAddress(`${noise}User.Name+tag@example.com`)).toBe(
+      "user.name+tag@example.com",
+    );
+    expect(
+      extractLooseEmailAddress(`${"@".repeat(100_000)}valid@example.com`),
+    ).toBe("valid@example.com");
+    expect(
+      normalizeGeneratedGmailReplyDraftBody(
+        `<think>${"x".repeat(100_000)}</think>hello`,
+      ),
+    ).toBe("hello");
+  });
+});

--- a/plugins/plugin-inbox/src/inbox/email-address.ts
+++ b/plugins/plugin-inbox/src/inbox/email-address.ts
@@ -27,7 +27,37 @@ function isAsciiDomainCharacter(character: string): boolean {
   );
 }
 
+/**
+ * RFC 5322 puts the authoritative address in the angle-addr (`<...>`), while
+ * the display name before it is attacker-controlled free text. Scanning
+ * angle spans first keeps `displayed@wrong.example <real@sender.example>`
+ * resolving to the real sender instead of the spoofed display token.
+ */
+function extractFromAngleSpans(
+  value: string,
+  extractToken: (span: string) => string | null,
+): string | null {
+  let searchFrom = 0;
+  while (searchFrom < value.length) {
+    const open = value.indexOf("<", searchFrom);
+    if (open < 0) return null;
+    const close = value.indexOf(">", open + 1);
+    if (close < 0) return null;
+    const address = extractToken(value.slice(open + 1, close));
+    if (address) return address;
+    searchFrom = close + 1;
+  }
+  return null;
+}
+
 export function extractAsciiEmailAddress(value: string): string | null {
+  return (
+    extractFromAngleSpans(value, extractAsciiEmailToken) ??
+    extractAsciiEmailToken(value)
+  );
+}
+
+function extractAsciiEmailToken(value: string): string | null {
   let searchFrom = 0;
   while (searchFrom < value.length) {
     const at = value.indexOf("@", searchFrom);
@@ -62,6 +92,13 @@ function isLooseAddressCharacter(character: string): boolean {
 }
 
 export function extractLooseEmailAddress(value: string): string | null {
+  return (
+    extractFromAngleSpans(value, extractLooseEmailToken) ??
+    extractLooseEmailToken(value)
+  );
+}
+
+function extractLooseEmailToken(value: string): string | null {
   let searchFrom = 0;
   while (searchFrom < value.length) {
     const at = value.indexOf("@", searchFrom);

--- a/plugins/plugin-inbox/src/inbox/email-address.ts
+++ b/plugins/plugin-inbox/src/inbox/email-address.ts
@@ -1,0 +1,88 @@
+/**
+ * Extracts email-like address tokens with monotonic scans so hostile sender
+ * headers cannot trigger regex retry storms.
+ */
+
+function isAsciiLetterOrDigit(character: string): boolean {
+  const code = character.charCodeAt(0);
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122)
+  );
+}
+
+function isAsciiLetter(character: string): boolean {
+  const code = character.charCodeAt(0);
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+}
+
+function isAsciiLocalCharacter(character: string): boolean {
+  return isAsciiLetterOrDigit(character) || "._%+-".includes(character);
+}
+
+function isAsciiDomainCharacter(character: string): boolean {
+  return (
+    isAsciiLetterOrDigit(character) || character === "." || character === "-"
+  );
+}
+
+export function extractAsciiEmailAddress(value: string): string | null {
+  let searchFrom = 0;
+  while (searchFrom < value.length) {
+    const at = value.indexOf("@", searchFrom);
+    if (at < 0) return null;
+    let start = at;
+    while (start > 0 && isAsciiLocalCharacter(value[start - 1] ?? ""))
+      start -= 1;
+    let end = at + 1;
+    while (end < value.length && isAsciiDomainCharacter(value[end] ?? ""))
+      end += 1;
+    const domain = value.slice(at + 1, end);
+    const dot = domain.lastIndexOf(".");
+    if (
+      start < at &&
+      dot > 0 &&
+      domain.length - dot - 1 >= 2 &&
+      [...domain.slice(dot + 1)].every(isAsciiLetter)
+    ) {
+      return value.slice(start, end).toLowerCase();
+    }
+    searchFrom = at + 1;
+  }
+  return null;
+}
+
+function isLooseAddressCharacter(character: string): boolean {
+  return (
+    character !== "@" &&
+    !"<>()\"';,".includes(character) &&
+    character.trim() !== ""
+  );
+}
+
+export function extractLooseEmailAddress(value: string): string | null {
+  let searchFrom = 0;
+  while (searchFrom < value.length) {
+    const at = value.indexOf("@", searchFrom);
+    if (at < 0) return null;
+    let start = at;
+    while (start > 0 && isLooseAddressCharacter(value[start - 1] ?? ""))
+      start -= 1;
+    let end = at + 1;
+    while (end < value.length && isLooseAddressCharacter(value[end] ?? ""))
+      end += 1;
+    const candidate = value.slice(start, end);
+    const domain = candidate.slice(candidate.indexOf("@") + 1);
+    if (
+      start < at &&
+      domain.includes(".") &&
+      !domain.startsWith(".") &&
+      !domain.endsWith(".")
+    ) {
+      return candidate.toLowerCase();
+    }
+    searchFrom = at + 1;
+  }
+  return null;
+}

--- a/plugins/plugin-inbox/src/inbox/email-curation.ts
+++ b/plugins/plugin-inbox/src/inbox/email-curation.ts
@@ -8,6 +8,8 @@
  * connector or runtime dependency. Consumed by the inbox triage flow and
  * exposed at the `@elizaos/plugin-inbox/inbox/email-curation` subpath.
  */
+import { extractAsciiEmailAddress } from "./email-address.ts";
+
 export type EmailCurationAction = "save" | "archive" | "delete" | "review";
 
 export type EmailCurationMode = "body_semantic" | "metadata_degraded";
@@ -373,10 +375,7 @@ function normalizeWhitespace(value: string): string {
 function normalizeAddress(value: string | null | undefined): string | null {
   const raw = value?.trim();
   if (!raw) return null;
-  const angleMatch = raw.match(/<([^>]+)>/);
-  const candidate = (angleMatch?.[1] ?? raw).trim().toLowerCase();
-  const emailMatch = candidate.match(/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i);
-  return emailMatch?.[0]?.toLowerCase() ?? null;
+  return extractAsciiEmailAddress(raw);
 }
 
 function localPart(address: string | null): string | null {

--- a/plugins/plugin-inbox/src/inbox/gmail-normalize.ts
+++ b/plugins/plugin-inbox/src/inbox/gmail-normalize.ts
@@ -39,6 +39,7 @@ import {
   normalizeOptionalString,
   requireNonEmptyString,
 } from "@elizaos/shared";
+import { extractLooseEmailAddress } from "./email-address.ts";
 
 export type SyncedGoogleGmailMessageSummary = Omit<
   LifeOpsGmailMessageSummary,
@@ -192,17 +193,7 @@ export function extractNormalizedEmailAddress(value: string): string | null {
   if (!trimmed) {
     return null;
   }
-  const angleMatch = trimmed.match(/<\s*([^<>\s@]+@[^<>\s@]+)\s*>/u);
-  const rawCandidate =
-    angleMatch?.[1] ??
-    trimmed.match(/([^\s<>()"';,]+@[^\s<>()"';,]+)/u)?.[1] ??
-    trimmed;
-  const normalized = rawCandidate
-    .trim()
-    .replace(/^["']+|["']+$/g, "")
-    .replace(/[>;,\s]+$/g, "")
-    .toLowerCase();
-  return /^[^@\s]+@[^@\s]+\.[^@\s]+$/u.test(normalized) ? normalized : null;
+  return extractLooseEmailAddress(trimmed);
 }
 
 export function normalizeOptionalMessageIdArray(
@@ -1262,7 +1253,19 @@ export function buildFallbackGmailReplyDraftBody(args: {
 export function normalizeGeneratedGmailReplyDraftBody(
   value: string,
 ): string | null {
-  const withoutThink = value.replace(/<think>[\s\S]*?<\/think>/gi, " ").trim();
+  const lowerValue = value.toLowerCase();
+  const fragments: string[] = [];
+  let cursor = 0;
+  while (cursor < value.length) {
+    const opener = lowerValue.indexOf("<think>", cursor);
+    if (opener < 0) break;
+    const closer = lowerValue.indexOf("</think>", opener + 7);
+    if (closer < 0) break;
+    fragments.push(value.slice(cursor, opener), " ");
+    cursor = closer + 8;
+  }
+  fragments.push(value.slice(cursor));
+  const withoutThink = fragments.join("").trim();
   if (!withoutThink) {
     return null;
   }

--- a/plugins/plugin-inbox/src/inbox/service.ts
+++ b/plugins/plugin-inbox/src/inbox/service.ts
@@ -25,6 +25,7 @@ import type {
 import { logger, ServiceType } from "@elizaos/core";
 import type { EntityResolveCandidate } from "@elizaos/shared";
 import { loadInboxTriageConfig } from "./config.ts";
+import { extractAsciiEmailAddress } from "./email-address.ts";
 import {
   type CurationDecision,
   curateEmailCandidates,
@@ -68,10 +69,7 @@ function normalizeSenderEmail(
 ): string | null {
   const raw = candidate.fromEmail ?? candidate.from;
   if (!raw) return null;
-  const angle = raw.match(/<([^>]+)>/);
-  const value = (angle?.[1] ?? raw).trim().toLowerCase();
-  const email = value.match(/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i);
-  return email?.[0]?.toLowerCase() ?? null;
+  return extractAsciiEmailAddress(raw);
 }
 
 /**

--- a/plugins/plugin-local-inference/src/actions/identify-speaker.ts
+++ b/plugins/plugin-local-inference/src/actions/identify-speaker.ts
@@ -64,7 +64,9 @@ export function extractSpeakerName(text: string): string | null {
 	for (const pattern of SPEAKER_NAME_PATTERNS) {
 		const m = pattern.exec(text);
 		if (m?.[1]) {
-			const cleaned = m[1].replace(/[.,;:!?]+$/, "").trim();
+			let end = m[1].length;
+			while (end > 0 && ".,;:!?".includes(m[1][end - 1] ?? "")) end -= 1;
+			const cleaned = m[1].slice(0, end).trim();
 			if (cleaned.length > 0) return cleaned;
 		}
 	}

--- a/plugins/plugin-local-inference/src/services/local-model-lifecycle-matrix.ts
+++ b/plugins/plugin-local-inference/src/services/local-model-lifecycle-matrix.ts
@@ -338,8 +338,29 @@ function knownGapFor(
 }
 
 function bundleRelativeFileFor(model: CatalogModel, file: string): string {
-	const cleanFile = file.replace(/^\/+/, "");
-	const cleanPrefix = model.hfPathPrefix?.replace(/^\/+|\/+$/g, "");
+	let fileStart = 0;
+	while (fileStart < file.length && file.charCodeAt(fileStart) === 47) {
+		fileStart += 1;
+	}
+	const cleanFile = fileStart === 0 ? file : file.slice(fileStart);
+	const rawPrefix = model.hfPathPrefix;
+	let prefixStart = 0;
+	let prefixEnd = rawPrefix?.length ?? 0;
+	while (
+		rawPrefix &&
+		prefixStart < prefixEnd &&
+		rawPrefix.charCodeAt(prefixStart) === 47
+	) {
+		prefixStart += 1;
+	}
+	while (
+		rawPrefix &&
+		prefixEnd > prefixStart &&
+		rawPrefix.charCodeAt(prefixEnd - 1) === 47
+	) {
+		prefixEnd -= 1;
+	}
+	const cleanPrefix = rawPrefix?.slice(prefixStart, prefixEnd);
 	if (cleanPrefix && cleanFile.startsWith(`${cleanPrefix}/`)) {
 		return cleanFile.slice(cleanPrefix.length + 1);
 	}

--- a/plugins/plugin-matrix/src/types.ts
+++ b/plugins/plugin-matrix/src/types.ts
@@ -274,8 +274,8 @@ export function getMatrixLocalpart(matrixId: string): string {
  * Extract the server part from a Matrix ID.
  */
 export function getMatrixServerpart(matrixId: string): string {
-  const match = matrixId.match(/:(.+)$/);
-  return match ? match[1] : "";
+  const separator = matrixId.indexOf(":");
+  return separator >= 0 ? matrixId.slice(separator + 1) : "";
 }
 
 /**

--- a/plugins/plugin-pdf/services/pdf.ts
+++ b/plugins/plugin-pdf/services/pdf.ts
@@ -291,7 +291,8 @@ export class PdfService extends Service {
 
     return filtered
       .replace(/[^\S\r\n]+/g, " ")
-      .replace(/[ \t]+(\r?\n)/g, "$1")
+      .replaceAll(" \r\n", "\r\n")
+      .replaceAll(" \n", "\n")
       .trim();
   }
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/commitments/ledger.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/commitments/ledger.ts
@@ -195,7 +195,9 @@ function firstCommitmentSentence(text: string): string | null {
     if (!sentence) continue;
     if (!COMMITMENT_RE.test(sentence)) continue;
     if (SPECULATIVE_RE.test(sentence)) continue;
-    return sentence.replace(/[.!?]+$/, "");
+    let end = sentence.length;
+    while (end > 0 && ".!?".includes(sentence[end - 1] ?? "")) end -= 1;
+    return sentence.slice(0, end);
   }
   return null;
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/household/inbound-approval.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/household/inbound-approval.ts
@@ -43,9 +43,62 @@ const DIRECT_CHAT_TYPES = new Set(["direct", "dm", "private"]);
 // Requiring the entire trimmed body to be the taught command preserves
 // whitespace-only client decoration without treating prose, signatures, or
 // reflowed history as approval intent.
-const APPROVAL_COMMAND_MESSAGE =
-  /^\s*(approve|reject)\s+household\s+approval\s+([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})(?:\s*[:—-]\s*(.{1,500}))?\s*$/iu;
 const MESSAGE_LINE_BREAK = /[\n\v\f\r\u0085\u2028\u2029]/u;
+
+function parseApprovalCommand(
+  value: string,
+): HouseholdInboundApprovalCommand | null {
+  let cursor = 0;
+  const readWord = (): string => {
+    const start = cursor;
+    while (cursor < value.length && value[cursor]?.trim() !== "") cursor += 1;
+    return value.slice(start, cursor);
+  };
+  const skipWhitespace = (): boolean => {
+    const start = cursor;
+    while (cursor < value.length && value[cursor]?.trim() === "") cursor += 1;
+    return cursor > start;
+  };
+  const decision = readWord().toLowerCase();
+  if ((decision !== "approve" && decision !== "reject") || !skipWhitespace())
+    return null;
+  if (readWord().toLowerCase() !== "household" || !skipWhitespace())
+    return null;
+  if (readWord().toLowerCase() !== "approval" || !skipWhitespace()) return null;
+  const requestId = value.slice(cursor, cursor + 36);
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      requestId,
+    )
+  )
+    return null;
+  cursor += requestId.length;
+  if (
+    cursor < value.length &&
+    value[cursor]?.trim() !== "" &&
+    value[cursor] !== ":" &&
+    value[cursor] !== "—" &&
+    value[cursor] !== "-"
+  ) {
+    return null;
+  }
+  skipWhitespace();
+  let reason: string | null = null;
+  if (cursor < value.length) {
+    if (value[cursor] !== ":" && value[cursor] !== "—" && value[cursor] !== "-")
+      return null;
+    cursor += 1;
+    skipWhitespace();
+    reason = value.slice(cursor).trimEnd();
+    if (reason.length < 1 || reason.length > 500) return null;
+    cursor = value.length;
+  }
+  return {
+    decision,
+    approvalRequestId: requestId.toLowerCase(),
+    reason,
+  };
+}
 
 export type HouseholdInboundApprovalDecision = "approve" | "reject";
 
@@ -180,18 +233,9 @@ export function parseHouseholdInboundApprovalCommand(
 ): HouseholdInboundApprovalCommand | null {
   const meaningfulText = text.trim();
   if (MESSAGE_LINE_BREAK.test(meaningfulText)) return null;
-  const match = APPROVAL_COMMAND_MESSAGE.exec(meaningfulText);
+  const match = parseApprovalCommand(meaningfulText);
   if (!match) return null;
-  const decision = match[1]?.toLowerCase();
-  const approvalRequestId = match[2]?.toLowerCase();
-  if ((decision !== "approve" && decision !== "reject") || !approvalRequestId) {
-    return null;
-  }
-  return {
-    decision,
-    approvalRequestId,
-    reason: match[3]?.trim() || null,
-  };
+  return match;
 }
 
 /**

--- a/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/index.ts
@@ -96,21 +96,130 @@ export interface MeetingGhostAnalysis {
 // the speaker + a commitment verb ("will send the plan by Friday"), not on a
 // literal "Action:" prefix a human would never say aloud. The prefixed forms
 // are still accepted for transcripts that carry structured annotations.
-const DECISION_PREFIX_RE =
-  /^(?:decision|decided|we decided|decision is)\s*[:-]\s*(.+)$/i;
-// A leading "we/the team decided (to)? X" spoken sentence.
-const SPOKEN_DECISION_RE =
-  /^(?:we|the team|everyone|the group)\s+(?:agreed|decided|settled|concluded)\s+(?:that\s+|to\s+|on\s+)?(?<body>.+?)[.;]?$/i;
-const COMMITMENT_PREFIX_RE =
-  /^(?:action|commitment|follow-up)\s*[:-]\s*(?<body>.+)$/i;
-// "Mira will send the deck by Friday" / "Ben is taking the calendar update"
-const NAMED_COMMITMENT_RE =
-  /^(?<who>[A-Z][A-Za-z .'-]{1,60}?)\s+(?:will|to|owns|is taking|committed to|is going to|can)\s+(?<what>.+?)(?:\s+by\s+(?<due>[^.;]+))?[.;]?$/;
-// First-person, who = the speaker. Requires an explicit commitment verb
-// ("I will…", "I'll…", "we can…", "I am going to…") so a bare first-person
-// remark ("I think…") is not mistaken for an action item.
-const SPEAKER_COMMITMENT_RE =
-  /^(?:i|we)\s*(?:'ll\s+|will\s+|can\s+|am going to\s+|are going to\s+)(?<what>.+?)(?:\s+by\s+(?<due>[^.;]+))?[.;]?$/i;
+function stripOneTerminalPunctuation(value: string): string {
+  const last = value[value.length - 1];
+  return last === "." || last === ";" ? value.slice(0, -1) : value;
+}
+
+function extractStructuredBody(
+  value: string,
+  prefixes: readonly string[],
+): string | null {
+  const lower = value.toLowerCase();
+  for (const prefix of prefixes) {
+    if (!lower.startsWith(prefix)) continue;
+    let cursor = prefix.length;
+    while (cursor < value.length && value[cursor]?.trim() === "") cursor += 1;
+    if (value[cursor] !== ":" && value[cursor] !== "-") continue;
+    cursor += 1;
+    while (cursor < value.length && value[cursor]?.trim() === "") cursor += 1;
+    return value.slice(cursor) || null;
+  }
+  return null;
+}
+
+function extractSpokenDecision(value: string): string | null {
+  const lower = value.toLowerCase();
+  for (const subject of ["we", "the team", "everyone", "the group"]) {
+    if (!lower.startsWith(`${subject} `)) continue;
+    let cursor = subject.length + 1;
+    const verb = ["agreed", "decided", "settled", "concluded"].find(
+      (candidate) => lower.startsWith(`${candidate} `, cursor),
+    );
+    if (!verb) continue;
+    cursor += verb.length + 1;
+    for (const connector of ["that ", "to ", "on "]) {
+      if (lower.startsWith(connector, cursor)) {
+        cursor += connector.length;
+        break;
+      }
+    }
+    return stripOneTerminalPunctuation(value.slice(cursor)) || null;
+  }
+  return null;
+}
+
+function splitCommitmentDue(value: string): {
+  what: string;
+  due: string | null;
+} {
+  const unpunctuated = stripOneTerminalPunctuation(value);
+  const separator = unpunctuated.toLowerCase().indexOf(" by ");
+  if (separator < 0) return { what: unpunctuated, due: null };
+  const due = unpunctuated.slice(separator + 4);
+  if (due.includes(".") || due.includes(";")) {
+    return { what: unpunctuated, due: null };
+  }
+  return {
+    what: unpunctuated.slice(0, separator),
+    due,
+  };
+}
+
+function parseNamedCommitment(value: string): {
+  who: string;
+  what: string;
+  due: string | null;
+} | null {
+  const lower = value.toLowerCase();
+  const verbs = [
+    "is going to",
+    "committed to",
+    "is taking",
+    "will",
+    "owns",
+    "can",
+    "to",
+  ];
+  let earliest:
+    | { markerStart: number; marker: string; verbIndex: number }
+    | undefined;
+  for (const [verbIndex, verb] of verbs.entries()) {
+    const marker = ` ${verb} `;
+    const markerStart = lower.indexOf(marker);
+    if (markerStart < 1) continue;
+    if (
+      !earliest ||
+      markerStart < earliest.markerStart ||
+      (markerStart === earliest.markerStart && verbIndex < earliest.verbIndex)
+    ) {
+      earliest = { markerStart, marker, verbIndex };
+    }
+  }
+  if (!earliest) return null;
+  const who = value.slice(0, earliest.markerStart);
+  if (who.length < 2 || who.length > 61 || !/[A-Z]/.test(who[0] ?? ""))
+    return null;
+  if ([...who].some((character) => !/[A-Za-z .'-]/.test(character)))
+    return null;
+  const split = splitCommitmentDue(
+    value.slice(earliest.markerStart + earliest.marker.length),
+  );
+  return split.what ? { who, ...split } : null;
+}
+
+function parseSpeakerCommitment(value: string): {
+  what: string;
+  due: string | null;
+} | null {
+  const lower = value.toLowerCase();
+  for (const subject of ["i", "we"]) {
+    if (!lower.startsWith(subject)) continue;
+    let cursor = subject.length;
+    while (cursor < value.length && value[cursor]?.trim() === "") cursor += 1;
+    const verb = [
+      "'ll ",
+      "will ",
+      "can ",
+      "am going to ",
+      "are going to ",
+    ].find((candidate) => lower.startsWith(candidate, cursor));
+    if (!verb) continue;
+    const split = splitCommitmentDue(value.slice(cursor + verb.length));
+    if (split.what) return split;
+  }
+  return null;
+}
 
 const WEEKDAYS = new Map([
   ["sunday", 0],
@@ -177,8 +286,13 @@ function parseDecision(
 ): MeetingGhostDecision | null {
   const text = compact(segment.text);
   const decision =
-    text.match(DECISION_PREFIX_RE)?.[1] ??
-    text.match(SPOKEN_DECISION_RE)?.groups?.body ??
+    extractStructuredBody(text, [
+      "decision",
+      "decided",
+      "we decided",
+      "decision is",
+    ]) ??
+    extractSpokenDecision(text) ??
     null;
   const compacted = decision ? compact(decision) : "";
   if (!compacted) return null;
@@ -195,21 +309,23 @@ function parseCommitmentBody(text: string): {
   what: string;
   dueText: string | null;
 } | null {
-  const body = text.match(COMMITMENT_PREFIX_RE)?.groups?.body ?? text;
-  const named = compact(body).match(NAMED_COMMITMENT_RE);
-  if (named?.groups?.what) {
+  const body =
+    extractStructuredBody(text, ["action", "commitment", "follow-up"]) ?? text;
+  const compactedBody = compact(body);
+  const named = parseNamedCommitment(compactedBody);
+  if (named?.what) {
     return {
-      who: compact(named.groups.who ?? ""),
-      what: compact(named.groups.what),
-      dueText: named.groups.due ? compact(named.groups.due) : null,
+      who: compact(named.who),
+      what: compact(named.what),
+      dueText: named.due ? compact(named.due) : null,
     };
   }
-  const speaker = compact(body).match(SPEAKER_COMMITMENT_RE);
-  if (speaker?.groups?.what) {
+  const speaker = parseSpeakerCommitment(compactedBody);
+  if (speaker?.what) {
     return {
       who: null,
-      what: compact(speaker.groups.what),
-      dueText: speaker.groups.due ? compact(speaker.groups.due) : null,
+      what: compact(speaker.what),
+      dueText: speaker.due ? compact(speaker.due) : null,
     };
   }
   return null;

--- a/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/index.ts
@@ -206,7 +206,9 @@ function parseSpeakerCommitment(value: string): {
   for (const subject of ["i", "we"]) {
     if (!lower.startsWith(subject)) continue;
     let cursor = subject.length;
+    const wordBoundary = cursor;
     while (cursor < value.length && value[cursor]?.trim() === "") cursor += 1;
+    const hasWhitespaceBoundary = cursor > wordBoundary;
     const verb = [
       "'ll ",
       "will ",
@@ -214,7 +216,7 @@ function parseSpeakerCommitment(value: string): {
       "am going to ",
       "are going to ",
     ].find((candidate) => lower.startsWith(candidate, cursor));
-    if (!verb) continue;
+    if (!verb || (!hasWhitespaceBoundary && verb !== "'ll ")) continue;
     const split = splitCommitmentDue(value.slice(cursor + verb.length));
     if (split.what) return split;
   }

--- a/plugins/plugin-personal-assistant/test/meeting-ghost.test.ts
+++ b/plugins/plugin-personal-assistant/test/meeting-ghost.test.ts
@@ -322,4 +322,29 @@ describe("meeting ghost transcript analysis", () => {
     expect(analysis.calendarIntents).toHaveLength(0);
     expect(analysis.digestLines).toHaveLength(0);
   });
+
+  it("requires a word boundary before first-person commitment verbs", () => {
+    const analysis = analyzeMeetingGhostTranscript({
+      owner: {
+        ownerUserId: "owner-1",
+        ownerDisplayName: "Shaw",
+        requestedBy: "meeting-ghost",
+        careAbouts: [],
+        calendarId: "primary",
+        approvalExpiresAt,
+      },
+      transcript: {
+        meetingId: "joined-subject-words",
+        title: "Standup",
+        startedAt: "2026-07-06T16:00:00.000Z",
+        attendees: [{ name: "Mira", email: "mira@example.com" }],
+        segments: [
+          seg("Mira", 0, "iwill send the plan tomorrow"),
+          seg("Mira", 5_000, "wewill update the calendar tomorrow"),
+        ],
+      },
+    });
+
+    expect(analysis.commitments).toHaveLength(0);
+  });
 });

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
@@ -61,6 +61,8 @@ describe("explicit Shared reminder relative delay", () => {
 
   it.each([
     'Use the example "remind me in 2 minutes" in the documentation.',
+    'Don\'t say "remind me in 5 minutes" yet.',
+    'It\'s just an example: "remind me in 5 minutes".',
     "For example: remind me in 2 minutes.",
     "Remind me tomorrow to stretch for five minutes.",
     "Remind me at 3pm to check in with the team for 30 minutes.",

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
@@ -75,10 +75,35 @@ interface DelayCandidate {
 }
 
 function maskQuotedText(text: string): string {
-  return text.replace(
-    /"[^"\n]*"|'[^'\n]*'|`[^`\n]*`|“[^”\n]*”|‘[^’\n]*’/g,
-    (match) => " ".repeat(match.length),
-  );
+  const closingQuote = new Map([
+    ['"', '"'],
+    ["'", "'"],
+    ["`", "`"],
+    ["“", "”"],
+    ["‘", "’"],
+  ]);
+  const out: string[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    const closer = closingQuote.get(text[cursor] ?? "");
+    if (!closer) {
+      out.push(text[cursor] ?? "");
+      cursor += 1;
+      continue;
+    }
+    let end = cursor + 1;
+    while (end < text.length && text[end] !== "\n" && text[end] !== closer) {
+      end += 1;
+    }
+    if (text[end] === closer) {
+      out.push(" ".repeat(end - cursor + 1));
+      cursor = end + 1;
+      continue;
+    }
+    out.push(text.slice(cursor, end));
+    cursor = end;
+  }
+  return out.join("");
 }
 
 function candidateIsExample(text: string, index: number): boolean {

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
@@ -100,8 +100,10 @@ function maskQuotedText(text: string): string {
       cursor = end + 1;
       continue;
     }
-    out.push(text.slice(cursor, end));
-    cursor = end;
+    // Unmatched opener (e.g. a contraction apostrophe): emit just the opener
+    // and rescan from the next char so a later quoted span is still masked.
+    out.push(text[cursor] ?? "");
+    cursor += 1;
   }
   return out.join("");
 }

--- a/plugins/plugin-slack/src/connector-credential-refs.ts
+++ b/plugins/plugin-slack/src/connector-credential-refs.ts
@@ -311,10 +311,12 @@ function buildConnectorCredentialVaultRef(params: {
 }
 
 function normalizeVaultSegment(value: string): string {
-  const normalized = value
-    .trim()
-    .replace(/[^a-zA-Z0-9_-]+/g, "_")
-    .replace(/^_+|_+$/g, "");
+  const slug = value.trim().replace(/[^a-zA-Z0-9_-]+/g, "_");
+  let start = 0;
+  let end = slug.length;
+  while (start < end && slug.charCodeAt(start) === 95) start += 1;
+  while (end > start && slug.charCodeAt(end - 1) === 95) end -= 1;
+  const normalized = slug.slice(start, end);
   return (normalized || "unknown").slice(0, 64);
 }
 

--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -33,6 +33,11 @@ describe("escapeSlackMrkdwn", () => {
     expect(escapeSlackMrkdwn("a & b < c > d")).toBe("a &amp; b &lt; c &gt; d");
     expect(escapeSlackMrkdwn("plain text")).toBe("plain text");
   });
+
+  it("handles a 100k unterminated Slack control run in one pass", () => {
+    const adversarial = `<${"a".repeat(100_000)}`;
+    expect(escapeSlackMrkdwn(adversarial)).toBe(`&lt;${"a".repeat(100_000)}`);
+  });
 });
 
 describe("markdownToSlackMrkdwn", () => {
@@ -41,6 +46,11 @@ describe("markdownToSlackMrkdwn", () => {
     expect(markdownToSlackMrkdwn("*italic*")).toBe("_italic_");
     expect(markdownToSlackMrkdwn("~~struck~~")).toBe("~struck~");
     expect(markdownToSlackMrkdwn("")).toBe("");
+  });
+
+  it("handles a 100k unterminated code fence without backtracking", () => {
+    const adversarial = `\`\`\`json\n${"x".repeat(100_000)}`;
+    expect(markdownToSlackMrkdwn(adversarial)).toContain("x".repeat(100_000));
   });
 });
 

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -30,8 +30,6 @@ function escapeSlackMrkdwnSegment(text: string): string {
     .replace(/>/g, "&gt;");
 }
 
-const SLACK_ANGLE_TOKEN_RE = /<[^>\n]+>/g;
-
 /**
  * Checks if an angle-bracket token is an allowed Slack format
  */
@@ -60,25 +58,28 @@ function escapeSlackMrkdwnContent(text: string): string {
     return text;
   }
 
-  SLACK_ANGLE_TOKEN_RE.lastIndex = 0;
   const out: string[] = [];
-  let lastIndex = 0;
-
-  for (
-    let match = SLACK_ANGLE_TOKEN_RE.exec(text);
-    match;
-    match = SLACK_ANGLE_TOKEN_RE.exec(text)
-  ) {
-    const matchIndex = match.index;
-    out.push(escapeSlackMrkdwnSegment(text.slice(lastIndex, matchIndex)));
-    const token = match[0] ?? "";
+  let cursor = 0;
+  while (cursor < text.length) {
+    const tokenStart = text.indexOf("<", cursor);
+    if (tokenStart < 0) break;
+    out.push(escapeSlackMrkdwnSegment(text.slice(cursor, tokenStart)));
+    const lineEnd = text.indexOf("\n", tokenStart + 1);
+    const tokenEnd = text.indexOf(">", tokenStart + 1);
+    if (tokenEnd < 0 || (lineEnd >= 0 && lineEnd < tokenEnd)) {
+      const plainEnd = lineEnd < 0 ? text.length : lineEnd + 1;
+      out.push(escapeSlackMrkdwnSegment(text.slice(tokenStart, plainEnd)));
+      cursor = plainEnd;
+      continue;
+    }
+    const token = text.slice(tokenStart, tokenEnd + 1);
     out.push(
       isAllowedSlackAngleToken(token) ? token : escapeSlackMrkdwnSegment(token),
     );
-    lastIndex = matchIndex + token.length;
+    cursor = tokenEnd + 1;
   }
 
-  out.push(escapeSlackMrkdwnSegment(text.slice(lastIndex)));
+  out.push(escapeSlackMrkdwnSegment(text.slice(cursor)));
   return out.join("");
 }
 
@@ -137,7 +138,35 @@ function convertStrikethrough(text: string): string {
  */
 function convertCodeBlocks(text: string): string {
   // Slack code blocks don't support language hints in the same way
-  return text.replace(/```(\w*)\n?([\s\S]*?)```/g, "```\n$2```");
+  const out: string[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    const opener = text.indexOf("```", cursor);
+    if (opener < 0) break;
+    let bodyStart = opener + 3;
+    while (bodyStart < text.length) {
+      const code = text.charCodeAt(bodyStart);
+      const isWord =
+        (code >= 48 && code <= 57) ||
+        (code >= 65 && code <= 90) ||
+        code === 95 ||
+        (code >= 97 && code <= 122);
+      if (!isWord) break;
+      bodyStart += 1;
+    }
+    if (text[bodyStart] === "\n") bodyStart += 1;
+    const closer = text.indexOf("```", bodyStart);
+    if (closer < 0) break;
+    out.push(
+      text.slice(cursor, opener),
+      "```\n",
+      text.slice(bodyStart, closer),
+      "```",
+    );
+    cursor = closer + 3;
+  }
+  out.push(text.slice(cursor));
+  return out.join("");
 }
 
 /**

--- a/plugins/plugin-slack/src/policy.ts
+++ b/plugins/plugin-slack/src/policy.ts
@@ -657,12 +657,16 @@ export class SlackAccountPolicyResolver {
 }
 
 export function normalizeSlackSlug(value: string): string {
-  return value
+  const slug = value
     .trim()
     .toLowerCase()
     .replace(/^[#@]/, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+    .replace(/[^a-z0-9]+/g, "-");
+  let start = 0;
+  let end = slug.length;
+  while (start < end && slug.charCodeAt(start) === 45) start += 1;
+  while (end > start && slug.charCodeAt(end - 1) === 45) end -= 1;
+  return slug.slice(start, end);
 }
 
 export function isSlackChannelIdKey(key: string): boolean {

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -288,6 +288,15 @@ function isValidSlackEmojiName(emoji: string): boolean {
   return /^[A-Za-z0-9_+-]+(::skin-tone-[2-6])?$/.test(emoji);
 }
 
+function normalizeSlackEmojiName(emoji: string): string {
+  const value = emoji.trim();
+  let start = 0;
+  let end = value.length;
+  while (start < end && value.charCodeAt(start) === 58) start += 1;
+  while (end > start && value.charCodeAt(end - 1) === 58) end -= 1;
+  return value.slice(start, end);
+}
+
 function isUnknownRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
@@ -3310,7 +3319,9 @@ export class SlackService extends Service implements ISlackService {
       params,
     );
     const messageTs = params.messageTs ?? params.messageId;
-    const emoji = params.emoji?.trim().replace(/^:+|:+$/g, "");
+    const emoji = params.emoji
+      ? normalizeSlackEmojiName(params.emoji)
+      : undefined;
     if (
       !messageTs ||
       !isValidMessageTs(messageTs) ||
@@ -3728,7 +3739,7 @@ export class SlackService extends Service implements ISlackService {
     }
 
     // Remove colons if present
-    const cleanEmoji = emoji.trim().replace(/^:+|:+$/g, "");
+    const cleanEmoji = normalizeSlackEmojiName(emoji);
     if (
       !isValidChannelId(channelId) ||
       !isValidMessageTs(messageTs) ||
@@ -3758,7 +3769,7 @@ export class SlackService extends Service implements ISlackService {
       throw new Error("Slack client not initialized");
     }
 
-    const cleanEmoji = emoji.trim().replace(/^:+|:+$/g, "");
+    const cleanEmoji = normalizeSlackEmojiName(emoji);
     if (
       !isValidChannelId(channelId) ||
       !isValidMessageTs(messageTs) ||

--- a/plugins/plugin-sql/src/connector-credential-store.ts
+++ b/plugins/plugin-sql/src/connector-credential-store.ts
@@ -92,9 +92,11 @@ export function createConnectorCredentialStore(
 }
 
 function normalizeVaultSegment(value: string): string {
-  const normalized = value
-    .trim()
-    .replace(/[^a-zA-Z0-9_-]+/g, "_")
-    .replace(/^_+|_+$/g, "");
+  const slug = value.trim().replace(/[^a-zA-Z0-9_-]+/g, "_");
+  let start = 0;
+  let end = slug.length;
+  while (start < end && slug.charCodeAt(start) === 95) start += 1;
+  while (end > start && slug.charCodeAt(end - 1) === 95) end -= 1;
+  const normalized = slug.slice(start, end);
   return (normalized || "unknown").slice(0, 64);
 }

--- a/plugins/plugin-trajectory-logger/src/phases.ts
+++ b/plugins/plugin-trajectory-logger/src/phases.ts
@@ -60,10 +60,14 @@ export function extractShouldRespondDecision(
 ): { decision: string; reasoning?: string } | null {
   const text = call.response.trim();
   if (!text) return null;
-  const m = text.match(/\{[\s\S]*\}/);
-  if (m) {
+  const objectStart = text.indexOf("{");
+  const objectEnd = text.lastIndexOf("}");
+  if (objectStart >= 0 && objectEnd >= objectStart) {
     try {
-      const obj = JSON.parse(m[0]) as Record<string, unknown>;
+      const obj = JSON.parse(text.slice(objectStart, objectEnd + 1)) as Record<
+        string,
+        unknown
+      >;
       const a = obj.action ?? obj.decision ?? obj.shouldRespond;
       if (typeof a === "string" && a.length > 0) {
         const r = obj.reasoning ?? obj.rationale;

--- a/plugins/plugin-wallet/src/sdk/identity/uaid.ts
+++ b/plugins/plugin-wallet/src/sdk/identity/uaid.ts
@@ -153,10 +153,11 @@ export class UAIDResolver {
   private readonly cache = new Map<string, CacheEntry>();
 
   constructor(config: UAIDResolverConfig = {}) {
-    this.brokerUrl = (config.brokerUrl ?? DEFAULT_BROKER_URL).replace(
-      /\/+$/,
-      "",
-    );
+    const brokerUrl = config.brokerUrl ?? DEFAULT_BROKER_URL;
+    let end = brokerUrl.length;
+    while (end > 0 && brokerUrl.charCodeAt(end - 1) === 47) end -= 1;
+    this.brokerUrl =
+      end === brokerUrl.length ? brokerUrl : brokerUrl.slice(0, end);
     this.apiKey = config.apiKey;
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.cacheTtlMs = config.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;

--- a/plugins/plugin-x/src/connector-credential-refs.ts
+++ b/plugins/plugin-x/src/connector-credential-refs.ts
@@ -611,10 +611,12 @@ function buildConnectorCredentialVaultRef(params: {
 }
 
 function normalizeVaultSegment(value: string): string {
-  const normalized = value
-    .trim()
-    .replace(/[^a-zA-Z0-9_-]+/g, "_")
-    .replace(/^_+|_+$/g, "");
+  const slug = value.trim().replace(/[^a-zA-Z0-9_-]+/g, "_");
+  let start = 0;
+  let end = slug.length;
+  while (start < end && slug.charCodeAt(start) === 95) start += 1;
+  while (end > start && slug.charCodeAt(end - 1) === 95) end -= 1;
+  const normalized = slug.slice(start, end);
   return (normalized || "unknown").slice(0, 64);
 }
 


### PR DESCRIPTION
## Summary

- replace polynomial regular-expression boundaries across Cloud, app-core, UI, and product plugins with deterministic cursor scans
- preserve URL, slug, email, Markdown, scheduling, transcript, approval, and meeting-parser behavior while removing retry-heavy matching
- centralize the repeated inbox email scan and add adversarial 100,000-character regressions at the highest-risk public boundaries
- keep CodeQL scheduled/manual only; this change does not add CodeQL to pull-request workflows or required checks

This fixes CodeQL alerts #803, #812, #813, #814, #815, #816, #817, #818, #819, #820, #821, #822, #823, #824, #825, #869, #870, #871, #872, #873, #874, #875, #876, #877, #878, #879, #880, #881, #882, #883, #884, #885, #886, #887, #888, #889, #898, #899, #900, #901, #902, #903, #904, #905, #906, #907, #908, #909, #910, #911, #912, #913, #914, #915, #916, #917, #918, #919, #920, #921, #922, #924, #925, #926, #934, #935, #936, #937, #938, #939, #940, #941, #943, #944, #981, #982, #983, #984, #985, #986, and branch-scan alert #1099 tracked in #22087.

## Verification

Exact head: `5b515464f40fdbfb685c2d3f63b715a9d647d9ba`

- cloud routing focused suite: 62/62 passed
- cloud SDK focused suite: 87 passed, 19 live-only skips
- post-review polynomial boundary suite: 4/4 passed
- cloud SDK focused suites: 44/44 passed
- cloud routing and SDK typechecks passed
- all 74 changed TypeScript/JavaScript files passed Biome
- `git diff --check origin/develop...HEAD` passed
- focused cloud API and cloud-shared batches passed before the final base-only rebase (1/1 and 11/11 respectively); exact-head reruns are locally blocked by the sparse install missing `@noble/hashes/sha2.js`
- app-core and several plugin suites stall during module transformation in this disk-constrained sparse worktree; hosted exact-head CI and CodeQL are required before merge
- adversarial regressions cover 100k slash, dot, quote, whitespace, Markdown-fence, address, key-block, and delimiter runs

Independent source review is complete; it repaired joined-word meeting commitments and decimal bulk-item parsing. Hosted gates remain required before merge.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@5b515464f40fdbfb685c2d3f63b715a9d647d9ba:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@5b515464f40fdbfb685c2d3f63b715a9d647d9ba:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-codeql]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5b515464f40fdbfb685c2d3f63b715a9d647d9ba:packages/skills/skills/contribute-to-eliza"} -->

## Evidence Gate

<!-- evidence-head:5b515464f40fdbfb685c2d3f63b715a9d647d9ba -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered product pixels or layout changed in this parser-hardening change.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered product pixels or layout changed in this parser-hardening change.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no product interaction flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - focused parser-boundary test results are documented above; no protected backend was mutated.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no rendered frontend state or browser-network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no production prompt, model selection, or model-output behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact adversarial parser contracts are the domain artifacts for this source-only hardening change.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no product pixels changed.

