### PR TITLE
fix(maps): expose legal provider attribution safely

### DIFF
--- a/plugins/plugin-maps/src/adapter.ts
+++ b/plugins/plugin-maps/src/adapter.ts
@@ -30,6 +30,8 @@ export interface MapsProviderAdapter {
   readonly id: string;
   readonly connectionId: string;
   readonly supportsCrossProviderRoutes?: boolean;
+  /** Provider-mandated attribution text, or absent when none is available. */
+  readonly attribution?: string;
   searchPlaces(request: PlaceSearchRequest): Promise<PlacePage>;
   getPlace(providerPlaceId: string): Promise<PlaceRef | null>;
   planRoute(request: RoutePlanRequest): Promise<RoutePlan>;
@@ -42,6 +44,8 @@ export interface JsonMapsHttpAdapterOptions {
   credential?: string;
   timeoutMs?: number;
   responseByteLimit?: number;
+  /** Provider-mandated attribution text rendered by first-party Maps views. */
+  attribution?: string;
   /** Explicit transport seam for deterministic SSRF/adversarial tests only. */
   testTransport?: Pick<
     GuardedFetchOptions,
@@ -156,6 +160,7 @@ function providerError(response: Response, body: unknown): MapsError {
 export class JsonMapsHttpAdapter implements MapsProviderAdapter {
   readonly id: string;
   readonly connectionId: string;
+  readonly attribution?: string;
   private readonly baseOrigin: string;
   private readonly credential?: string;
   private readonly timeoutMs: number;
@@ -171,6 +176,14 @@ export class JsonMapsHttpAdapter implements MapsProviderAdapter {
     }
     if (!/^conn_[A-Za-z0-9_-]{16,}$/.test(options.connectionId)) {
       throw new MapsError("Maps adapter connection id must be opaque.", {
+        code: "MAPS_INVALID_INPUT",
+      });
+    }
+    if (
+      options.attribution !== undefined &&
+      (!options.attribution.trim() || options.attribution.length > 500)
+    ) {
+      throw new MapsError("Maps adapter attribution is invalid.", {
         code: "MAPS_INVALID_INPUT",
       });
     }
@@ -249,6 +262,7 @@ export class JsonMapsHttpAdapter implements MapsProviderAdapter {
     }
     this.id = options.id;
     this.connectionId = options.connectionId;
+    this.attribution = options.attribution?.trim();
     this.baseOrigin = baseUrl.origin;
     this.credential = options.credential;
     this.timeoutMs = timeoutMs;

--- a/plugins/plugin-maps/src/capabilities.ts
+++ b/plugins/plugin-maps/src/capabilities.ts
@@ -12,6 +12,12 @@ const PROVIDER_PARAM = {
 
 export const MAPS_VIEW_CAPABILITIES: ViewCapability[] = [
   {
+    id: "maps-describe-providers",
+    description:
+      "Read registered provider identities and adapter-owned attribution metadata.",
+    params: {},
+  },
+  {
     id: "maps-search-places",
     description:
       "Search registered maps providers for normalized places. This capability is read-only.",

--- a/plugins/plugin-maps/src/components/MapsView.test.tsx
+++ b/plugins/plugin-maps/src/components/MapsView.test.tsx
@@ -68,6 +68,12 @@ function route(mode: TravelMode): RoutePlan {
 
 function transport(over: Partial<MapsViewTransport> = {}): MapsViewTransport {
   return {
+    describeProviders: vi.fn(async () => [
+      {
+        id: "fixture_maps",
+        attribution: "Map data © Fixture Maps",
+      },
+    ]),
     search: vi.fn(async () => ({ places: [FERRY, PLAZA], nextCursor: null })),
     getPlace: vi.fn(async (value) => value),
     planRoute: vi.fn(async (_origin, _destination, mode) => route(mode)),
@@ -107,7 +113,7 @@ describe("MapsView", () => {
       (await screen.findAllByText("Ferry Building")).length,
     ).toBeGreaterThan(0);
     expect(screen.getByText("Embarcadero Plaza")).toBeTruthy();
-    expect(screen.getByText("Place data: fixture_maps")).toBeTruthy();
+    expect(await screen.findByText("Map data © Fixture Maps")).toBeTruthy();
 
     await user.click(screen.getByRole("button", { name: "park" }));
     expect(
@@ -117,6 +123,48 @@ describe("MapsView", () => {
     ).toBeNull();
     expect(screen.getByText("Embarcadero Plaza")).toBeTruthy();
   });
+
+  it("explicitly reports unavailable legal attribution", async () => {
+    const user = userEvent.setup();
+    render(
+      <MapsView
+        transport={transport({
+          describeProviders: vi.fn(async () => [
+            { id: "fixture_maps", attribution: null },
+          ]),
+        })}
+        online
+      />,
+    );
+
+    await searchFor(user, "waterfront");
+    expect(
+      await screen.findByText("Legal attribution unavailable for fixture_maps"),
+    ).toBeTruthy();
+  });
+
+  it.each([
+    ["unsupported", undefined],
+    [
+      "failed",
+      vi.fn(async () => {
+        throw new Error("provider metadata unavailable");
+      }),
+    ],
+  ] as const)(
+    "degrades explicitly when provider metadata is %s",
+    async (_state, describeProviders) => {
+      const user = userEvent.setup();
+      render(<MapsView transport={transport({ describeProviders })} online />);
+
+      await searchFor(user, "waterfront");
+      expect(
+        await screen.findByText(
+          "Legal attribution unavailable for fixture_maps",
+        ),
+      ).toBeTruthy();
+    },
+  );
 
   it("gives every rendered control a unique collision-safe agent id", async () => {
     const collisionPlaces = [
@@ -193,6 +241,12 @@ describe("MapsView", () => {
       document.querySelector('[data-agent-id="maps-route-walk"]'),
     ).toBeTruthy();
     expect(screen.getByText(/Route geometry is not drawn/)).toBeTruthy();
+    expect(screen.getByTestId("maps-bottom-overlays").className).toContain(
+      "pointer-events-none",
+    );
+    expect(screen.getByTestId("maps-schematic-label").className).toContain(
+      "pointer-events-none",
+    );
     expect(fake.planRoute).toHaveBeenCalledTimes(4);
 
     await user.click(screen.getByRole("button", { name: "Save" }));

--- a/plugins/plugin-maps/src/components/MapsView.tsx
+++ b/plugins/plugin-maps/src/components/MapsView.tsx
@@ -35,7 +35,11 @@ import {
   useState,
 } from "react";
 import type { PlaceRef, RoutePlan, TravelMode } from "../types.js";
-import { type MapsViewTransport, mapsViewTransport } from "./maps-view-data.js";
+import {
+  type MapsProviderDescription,
+  type MapsViewTransport,
+  mapsViewTransport,
+} from "./maps-view-data.js";
 
 const TRAVEL_MODES: readonly TravelMode[] = [
   "drive",
@@ -399,13 +403,33 @@ function projectPlaces(places: readonly PlaceRef[]) {
 
 interface MapPanelProps {
   places: readonly PlaceRef[];
+  attributionProviderIds: readonly string[];
+  providers: readonly MapsProviderDescription[];
   selected: PlaceRef | null;
   activeRoute: RoutePlan | null;
   onSelect: (place: PlaceRef) => void;
 }
 
-function MapPanel({ places, selected, activeRoute, onSelect }: MapPanelProps) {
+function MapPanel({
+  places,
+  attributionProviderIds,
+  providers,
+  selected,
+  activeRoute,
+  onSelect,
+}: MapPanelProps) {
   const points = useMemo(() => projectPlaces(places), [places]);
+  const providerAttribution = useMemo(() => {
+    const descriptions = new Map(
+      providers.map((provider) => [provider.id, provider]),
+    );
+    return attributionProviderIds
+      .map((providerId) => {
+        const attribution = descriptions.get(providerId)?.attribution;
+        return attribution ?? `Legal attribution unavailable for ${providerId}`;
+      })
+      .join(" · ");
+  }, [attributionProviderIds, providers]);
   return (
     <figure
       aria-labelledby="maps-canvas-title"
@@ -468,20 +492,34 @@ function MapPanel({ places, selected, activeRoute, onSelect }: MapPanelProps) {
           );
         })}
       </div>
-      <div className="absolute top-3 left-3 flex items-center gap-2 rounded-lg bg-bg/90 px-3 py-2 text-xs font-medium text-text shadow-sm backdrop-blur">
+      <div
+        data-testid="maps-schematic-label"
+        className="pointer-events-none absolute top-3 left-3 flex items-center gap-2 rounded-lg bg-bg/90 px-3 py-2 text-xs font-medium text-text shadow-sm backdrop-blur"
+      >
         <MapIcon aria-hidden="true" className="size-4 text-[#d94b00]" />
         Provider-neutral map
       </div>
-      {activeRoute ? (
-        <div className="absolute right-3 bottom-12 left-3 rounded-lg bg-bg/90 px-3 py-2 text-xs text-muted-foreground shadow-sm backdrop-blur">
-          Route geometry is not drawn in this provider-neutral schematic. Time
-          and distance remain provider-backed.
+      <div
+        data-testid="maps-bottom-overlays"
+        className="pointer-events-none absolute right-3 bottom-3 left-3 flex flex-col items-end gap-2"
+      >
+        {activeRoute ? (
+          <div
+            data-testid="maps-route-disclaimer"
+            className="w-full rounded-lg bg-bg/90 px-3 py-2 text-xs text-muted-foreground shadow-sm backdrop-blur"
+          >
+            Route geometry is not drawn in this provider-neutral schematic. Time
+            and distance remain provider-backed.
+          </div>
+        ) : null}
+        <div
+          data-testid="maps-provider-attribution"
+          className="max-w-full break-words rounded-md bg-bg/90 px-2 py-1 text-right text-[11px] text-muted-foreground shadow-sm"
+        >
+          {attributionProviderIds.length
+            ? providerAttribution
+            : "No provider data loaded"}
         </div>
-      ) : null}
-      <div className="absolute right-3 bottom-3 rounded-md bg-bg/90 px-2 py-1 text-[11px] text-muted-foreground shadow-sm">
-        {places.length
-          ? `Place data: ${[...new Set(places.map((place) => place.provider))].join(", ")}`
-          : "No provider data loaded"}
       </div>
     </figure>
   );
@@ -546,6 +584,7 @@ export function MapsView({
   const [activeRouteId, setActiveRouteId] = useState<string | null>(null);
   const [routeBusy, setRouteBusy] = useState(false);
   const [routeError, setRouteError] = useState<string | null>(null);
+  const [providers, setProviders] = useState<MapsProviderDescription[]>([]);
   const [isOnline, setIsOnline] = useState(
     online ?? (typeof navigator === "undefined" ? true : navigator.onLine),
   );
@@ -579,6 +618,25 @@ export function MapsView({
       window.removeEventListener("offline", update);
     };
   }, [online]);
+
+  useEffect(() => {
+    if (!transport.describeProviders) {
+      setProviders([]);
+      return;
+    }
+    const controller = new AbortController();
+    void transport
+      .describeProviders(controller.signal)
+      .then((descriptions) => {
+        if (!controller.signal.aborted) setProviders(descriptions);
+      })
+      // error-policy:J4 Missing provider metadata is rendered as an explicit
+      // attribution-unavailable state for each provider returned by a search.
+      .catch((_cause: unknown) => {
+        if (!controller.signal.aborted) setProviders([]);
+      });
+    return () => controller.abort();
+  }, [transport]);
 
   useEffect(
     () => () => {
@@ -623,6 +681,15 @@ export function MapsView({
     routes.find((route) => route.routeId === activeRouteId) ??
     routes[0] ??
     null;
+  const attributionProviderIds = useMemo(
+    () => [
+      ...new Set([
+        ...places.map((place) => place.provider),
+        ...routes.map((route) => route.provider),
+      ]),
+    ],
+    [places, routes],
+  );
 
   const runSearch = useCallback(
     async (requested: string) => {
@@ -1111,6 +1178,8 @@ export function MapsView({
 
           <MapPanel
             places={filteredPlaces}
+            attributionProviderIds={attributionProviderIds}
+            providers={providers}
             selected={selected}
             activeRoute={activeRoute}
             onSelect={selectPlace}

--- a/plugins/plugin-maps/src/components/maps-view-data.test.ts
+++ b/plugins/plugin-maps/src/components/maps-view-data.test.ts
@@ -27,6 +27,52 @@ function response(body: unknown, status = 200): Response {
 describe("mapsViewTransport", () => {
   beforeEach(() => fetchWithCsrf.mockReset());
 
+  it("validates adapter-owned provider attribution metadata", async () => {
+    fetchWithCsrf.mockResolvedValueOnce(
+      response({
+        requestId: "maps-provider-request",
+        success: true,
+        result: {
+          success: true,
+          data: {
+            providers: [
+              {
+                id: "fixture_maps",
+                attribution: "Map data © Fixture Maps",
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    await expect(mapsViewTransport.describeProviders?.()).resolves.toEqual([
+      {
+        id: "fixture_maps",
+        attribution: "Map data © Fixture Maps",
+      },
+    ]);
+
+    fetchWithCsrf.mockResolvedValueOnce(
+      response({
+        requestId: "maps-bad-provider-request",
+        success: true,
+        result: {
+          success: true,
+          data: {
+            providers: [
+              {
+                id: "fixture_maps",
+                attribution: "x".repeat(501),
+              },
+            ],
+          },
+        },
+      }),
+    );
+    await expect(mapsViewTransport.describeProviders?.()).rejects.toThrow();
+  });
+
   it("validates a successful search broker envelope", async () => {
     fetchWithCsrf.mockResolvedValue(
       response({

--- a/plugins/plugin-maps/src/components/maps-view-data.ts
+++ b/plugins/plugin-maps/src/components/maps-view-data.ts
@@ -1,6 +1,7 @@
 /** Validates browser responses from the authenticated Maps view broker. */
 
 import { fetchWithCsrf } from "@elizaos/ui/api/csrf-client";
+import { z } from "zod";
 import {
   type PlacePage,
   type PlaceRef,
@@ -11,6 +12,17 @@ import {
   type TravelMode,
 } from "../types.js";
 
+const mapsProviderDescriptionSchema = z
+  .object({
+    id: z.string().min(1).max(64),
+    attribution: z.string().min(1).max(500).nullable(),
+  })
+  .strict();
+
+export type MapsProviderDescription = z.infer<
+  typeof mapsProviderDescriptionSchema
+>;
+
 interface BrokerEnvelope {
   requestId: string;
   success: boolean;
@@ -19,6 +31,8 @@ interface BrokerEnvelope {
 }
 
 export interface MapsViewTransport {
+  /** Optional for host/test transports; absence renders attribution unavailable. */
+  describeProviders?(signal?: AbortSignal): Promise<MapsProviderDescription[]>;
   search(
     query: string,
     signal?: AbortSignal,
@@ -98,6 +112,16 @@ async function invoke(
 }
 
 export const mapsViewTransport: MapsViewTransport = {
+  async describeProviders(signal) {
+    const value = await invoke("maps-describe-providers", {}, signal);
+    if (!isRecord(value)) {
+      throw new Error("Maps returned invalid provider metadata.");
+    }
+    return z
+      .array(mapsProviderDescriptionSchema)
+      .max(32)
+      .parse(value.providers);
+  },
   async search(query, signal, cursor) {
     return placePageSchema.parse(
       await invoke(

--- a/plugins/plugin-maps/src/interact.test.ts
+++ b/plugins/plugin-maps/src/interact.test.ts
@@ -48,6 +48,7 @@ function harness(over: Partial<MapsProviderAdapter> = {}) {
   const adapter: MapsProviderAdapter = {
     id: "fixture_maps",
     connectionId: "conn_fixture_maps_0001",
+    attribution: "Map data © Fixture Maps",
     searchPlaces: vi.fn(async () => ({
       places: [ORIGIN, DESTINATION],
       nextCursor: null,
@@ -64,6 +65,20 @@ function harness(over: Partial<MapsProviderAdapter> = {}) {
 describe("Maps view serverInteract", () => {
   it("dispatches normalized search, detail, and route reads", async () => {
     const { runtime, adapter } = harness();
+
+    await expect(
+      serverInteract("maps-describe-providers", {}, { runtime }),
+    ).resolves.toMatchObject({
+      success: true,
+      data: {
+        providers: [
+          {
+            id: "fixture_maps",
+            attribution: "Map data © Fixture Maps",
+          },
+        ],
+      },
+    });
 
     await expect(
       serverInteract(

--- a/plugins/plugin-maps/src/interact.ts
+++ b/plugins/plugin-maps/src/interact.ts
@@ -89,6 +89,12 @@ export async function serverInteract(
         : providerIdSchema.parse(values.provider);
     const service = getMapsService(context.runtime);
     switch (capability) {
+      case "maps-describe-providers":
+        return {
+          success: true,
+          text: "Loaded maps provider metadata.",
+          data: { providers: service.describeProviders() },
+        };
       case "maps-search-places": {
         const request = placeSearchRequestSchema.parse({
           query: requiredText(values.query, "query"),

--- a/plugins/plugin-maps/src/maps.test.ts
+++ b/plugins/plugin-maps/src/maps.test.ts
@@ -299,6 +299,15 @@ describe("MapsService and MAPS action", () => {
     expect(() =>
       opaqueService.registerAdapter({ ...adapter, id: " invalid " }),
     ).toThrow(expect.objectContaining({ code: "MAPS_INVALID_INPUT" }));
+    expect(() =>
+      opaqueService.registerAdapter({ ...adapter, attribution: " " }),
+    ).toThrow(expect.objectContaining({ code: "MAPS_INVALID_INPUT" }));
+    expect(opaqueService.describeProviders()).toEqual([
+      {
+        id: adapter.id,
+        attribution: null,
+      },
+    ]);
   });
 
   it("validates public store UUIDs before creating persistence namespaces", async () => {

--- a/plugins/plugin-maps/src/service.ts
+++ b/plugins/plugin-maps/src/service.ts
@@ -23,6 +23,12 @@ import {
 
 export const MAPS_SERVICE_TYPE = "maps";
 
+export interface MapsProviderDescription {
+  id: string;
+  /** Provider-mandated attribution text, or null when the adapter has none. */
+  attribution: string | null;
+}
+
 export interface MapsHandoff {
   kind: "share" | "navigate";
   uri: string;
@@ -149,6 +155,14 @@ export class MapsService extends Service {
         code: "MAPS_INVALID_INPUT",
       });
     }
+    if (
+      adapter.attribution !== undefined &&
+      (!adapter.attribution.trim() || adapter.attribution.length > 500)
+    ) {
+      throw new MapsError("Maps adapter attribution is invalid.", {
+        code: "MAPS_INVALID_INPUT",
+      });
+    }
     this.adapters.set(adapter.id, adapter);
     if (makeDefault || this.defaultAdapterId === null)
       this.defaultAdapterId = adapter.id;
@@ -163,6 +177,14 @@ export class MapsService extends Service {
 
   listAdapters(): readonly string[] {
     return [...this.adapters.keys()];
+  }
+
+  /** Describes registered providers without exposing credentials or endpoints. */
+  describeProviders(): readonly MapsProviderDescription[] {
+    return [...this.adapters.values()].map((adapter) => ({
+      id: adapter.id,
+      attribution: adapter.attribution?.trim() || null,
+    }));
   }
 
   async searchPlaces(


### PR DESCRIPTION
## Summary

Fixes #23369. Corrective follow-up to merged #23177.

- Adds optional, adapter-owned legal attribution metadata.
- Preserves and validates it through the Maps service and provider-description broker.
- Adds a strict browser DTO with an explicit unavailable state instead of treating a provider ID as legal attribution.
- Renders attribution or a truthful unavailable fallback.
- Stacks/wraps informational notices and makes overlays pointer-transparent so edge markers remain interactive.

## Verification

Exact head: `ee6332f7cca5693e30731a92c96001504287fec5`.

Pinned Bun 1.3.14 / Node 24.15.0 evidence on the correction before the final conflict-free rebase:

- service + broker: 26/26 passed
- UI + DTO: 19/19 passed
- plugin-maps typecheck: passed
- plugin lint and diff-check: passed
- scoped production Maps view bundle: passed (84 modules)

After the final rebase, the DTO-only lane passed 5/5. The remaining focused runner invocation was environment-blocked by missing built `@elizaos/core` and `@elizaos/ui` exports in the borrowed sparse install; no assertion failed.

## Known gaps

- `packages/app audit:app` was attempted twice, but the isolated review environment failed before reaching Maps because plugin-contacts could not resolve an unbuilt `@elizaos/capacitor-contacts` artifact. No visual pass is claimed.
- Full package PGlite coverage remains blocked by unrelated/unbuilt plugin-sql dependencies in this worktree.
- Keep draft until exact-head hosted checks, a complete app visual audit of the Maps view, and a non-author review are green.

## Evidence Gate

<!-- evidence-head:ee6332f7cca5693e30731a92c96001504287fec5 -->

- Before/after screenshots: pending complete app audit.
- Walkthrough video: pending complete app audit.
- Backend logs: N/A — no backend deployment or protected system mutation.
- Frontend logs: focused deterministic UI/DTO tests above; browser audit pending.
- LLM trajectory: N/A — no prompt/model/action behavior changed.
- Domain artifacts: service/broker/DTO test receipts above.
- OCR review: pending complete app audit.

## Contribution provenance

<!-- contribution-attribution:v1 -->
- AI assistance: yes
- Model: OpenAI GPT-5.6
- Client: Codex Desktop
- Status: self-reported
