### PR TITLE
fix(cloud): fail-closed environment placement and a tailnet path-outage alarm

### DIFF
--- a/packages/cloud/shared/src/db/repositories/docker-nodes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/docker-nodes.test.ts
@@ -102,6 +102,27 @@ describe("DockerNodesRepository environment guard", () => {
     expect(sql).toContain("= ''");
   });
 
+  test("findPlaceable fails closed: an unlabeled node is not a placement target", async () => {
+    const { DockerNodesRepository } = await import("./docker-nodes");
+
+    await new DockerNodesRepository().findPlaceable();
+
+    if (!capturedWhere) throw new Error("findPlaceable did not build a where clause");
+    const query = new PgDialect().sqlToQuery(capturedWhere);
+    const sql = query.sql.toLowerCase();
+    // Strict equality against the deployment environment only. The historic
+    // fail-open arm — COALESCE(metadata->>'environment','') = '' — let a
+    // staging host registered in the production DB take production placements
+    // (elizaOS/eliza#22547); its shape must never come back to a placement
+    // query.
+    expect(sql).toContain("->>'environment'");
+    expect(query.params).toContain("staging");
+    expect(sql).not.toMatch(/coalesce\([^)]*->>\s*'environment'/);
+    // Exactly one reference: the strict equality. The fail-open form carried
+    // two (the COALESCE('' ) arm plus the OR match arm).
+    expect(sql.match(/->>'environment'/g)?.length).toBe(1);
+  });
+
   test("setEmbeddingSidecarHealth merges into metadata instead of replacing it", async () => {
     const { DockerNodesRepository } = await import("./docker-nodes");
 
@@ -161,6 +182,11 @@ describe("DockerNodesRepository environment guard", () => {
     expect(sql).toContain("metadata");
     expect(sql).toContain("->>'environment'");
     expect(sql).toContain("capacityprovisional");
+    // Placement predicate: fail closed, no unlabeled-row escape hatch.
+    const query = new PgDialect().sqlToQuery(capturedWhere);
+    expect(query.params).toContain("staging");
+    expect(sql).not.toMatch(/coalesce\([^)]*->>\s*'environment'/);
+    expect(sql.match(/->>'environment'/g)?.length).toBe(1);
   });
 
   test("reconcileProvisionalCapacity consumes the provisional marker atomically", async () => {

--- a/packages/cloud/shared/src/db/repositories/docker-nodes.ts
+++ b/packages/cloud/shared/src/db/repositories/docker-nodes.ts
@@ -133,9 +133,28 @@ export function stampDockerNodeEnvironmentMetadata(
   return { ...base, environment };
 }
 
-function currentEnvironmentPredicate() {
+/**
+ * Environment guard for node reads, split by consequence.
+ *
+ * `placement` fails CLOSED: with ENVIRONMENT set, only rows explicitly stamped
+ * with the same environment are eligible. An unlabeled row must never receive
+ * a placement — treating '' as "matches everything" is how a staging box
+ * registered in the production DB became a production placement target
+ * (elizaOS/eliza#22547), and deleting such a row leaves the gate open for the
+ * next one. Live fleets must therefore carry `metadata.environment`; the
+ * onboarding, bootstrap-callback, and admin-register paths all stamp it via
+ * {@link stampDockerNodeEnvironmentMetadata}.
+ *
+ * `operational` stays inclusive of unlabeled rows so health checks, disk
+ * monitoring, and the orphan reconciler keep watching legacy nodes, while
+ * still excluding rows stamped for a DIFFERENT environment.
+ */
+function currentEnvironmentPredicate(scope: "placement" | "operational") {
   const environment = currentDeploymentEnvironment();
   if (!environment) return sql`TRUE`;
+  if (scope === "placement") {
+    return sql`${dockerNodes.metadata}->>'environment' = ${environment}`;
+  }
   return sql`(
     COALESCE(${dockerNodes.metadata}->>'environment', '') = ''
     OR ${dockerNodes.metadata}->>'environment' = ${environment}
@@ -169,7 +188,7 @@ export class DockerNodesRepository {
     return dbRead
       .select()
       .from(dockerNodes)
-      .where(and(eq(dockerNodes.enabled, true), currentEnvironmentPredicate()))
+      .where(and(eq(dockerNodes.enabled, true), currentEnvironmentPredicate("operational")))
       .orderBy(asc(dockerNodes.node_id));
   }
 
@@ -189,7 +208,7 @@ export class DockerNodesRepository {
           eq(dockerNodes.enabled, true),
           eq(dockerNodes.placement_state, PLACEABLE_NODE_STATE),
           capacityAttestedPredicate(),
-          currentEnvironmentPredicate(),
+          currentEnvironmentPredicate("placement"),
         ),
       )
       .orderBy(asc(dockerNodes.node_id));
@@ -223,7 +242,7 @@ export class DockerNodesRepository {
           eq(dockerNodes.placement_state, PLACEABLE_NODE_STATE),
           eq(dockerNodes.status, "healthy"),
           capacityAttestedPredicate(),
-          currentEnvironmentPredicate(),
+          currentEnvironmentPredicate("placement"),
           sql`${dockerNodes.allocated_count} < ${dockerNodes.capacity}`,
         ),
       )

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -95,6 +95,7 @@ import {
   resolveStewardTenantCredentials,
   type StewardTenantCredentials,
 } from "./steward-tenant-config";
+import { tailnetPathMonitor } from "./tailnet-path-monitor";
 
 // ---------------------------------------------------------------------------
 // Exported metadata type for strongly-typed provider metadata
@@ -2649,6 +2650,10 @@ export class DockerSandboxProvider implements SandboxProvider {
           logger.info(
             `[docker-sandbox] Tailnet health probe passed for ${meta.containerName} (${healthUrl})`,
           );
+          await tailnetPathMonitor.record({
+            containerName: meta.containerName,
+            outcome: "passed",
+          });
           return true;
         }
         logger.debug(
@@ -2670,6 +2675,13 @@ export class DockerSandboxProvider implements SandboxProvider {
     logger.warn(
       `[docker-sandbox] Tailnet health check timed out after ${HEALTH_CHECK_TIMEOUT_MS / 1000}s for ${meta.containerName} (${healthUrl})`,
     );
+    // A run of these across distinct containers is the severed-path signature
+    // (headscale ACL regression); the monitor pages ops instead of letting the
+    // outage hide inside per-container provisioning retries.
+    await tailnetPathMonitor.record({
+      containerName: meta.containerName,
+      outcome: "timed_out",
+    });
     return false;
   }
 

--- a/packages/cloud/shared/src/lib/services/tailnet-path-monitor.test.ts
+++ b/packages/cloud/shared/src/lib/services/tailnet-path-monitor.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Exercises the tailnet path-outage detector's alarm, throttle, and recovery
+ * logic deterministically with injected alert and clock deps (no network).
+ */
+import { describe, expect, test } from "bun:test";
+import type { DaemonHealthAlert } from "./provisioning-worker-health-monitor";
+import {
+  TAILNET_ALARM_CONSECUTIVE_TIMEOUTS,
+  TAILNET_ALARM_DEDUP_KEY,
+  TAILNET_ALARM_MIN_DISTINCT_CONTAINERS,
+  TAILNET_ALARM_REALERT_MS,
+  TailnetPathMonitor,
+} from "./tailnet-path-monitor";
+
+function makeMonitor(startMs = 1_000_000) {
+  const alerts: DaemonHealthAlert[] = [];
+  let nowMs = startMs;
+  const monitor = new TailnetPathMonitor({
+    alert: async (alert) => {
+      alerts.push(alert);
+    },
+    now: () => nowMs,
+  });
+  return {
+    monitor,
+    alerts,
+    advance(ms: number) {
+      nowMs += ms;
+    },
+  };
+}
+
+describe("TailnetPathMonitor", () => {
+  test("fires once the timeout run spans enough distinct containers", async () => {
+    const { monitor, alerts } = makeMonitor();
+
+    await monitor.record({ containerName: "agent-a", outcome: "timed_out" });
+    await monitor.record({ containerName: "agent-a", outcome: "timed_out" });
+    expect(alerts).toHaveLength(0);
+    expect(monitor.active).toBe(false);
+
+    await monitor.record({ containerName: "agent-b", outcome: "timed_out" });
+    expect(alerts).toHaveLength(1);
+    expect(monitor.active).toBe(true);
+    expect(alerts[0].dedupKey).toBe(TAILNET_ALARM_DEDUP_KEY);
+    expect(alerts[0].details.code).toBe("TAILNET_AGENT_PATH_UNREACHABLE");
+    expect(alerts[0].details.consecutiveTimeouts).toBe(TAILNET_ALARM_CONSECUTIVE_TIMEOUTS);
+    expect(alerts[0].details.distinctContainers).toEqual(["agent-a", "agent-b"]);
+  });
+
+  test("a single sick container never fires the path alarm", async () => {
+    const { monitor, alerts } = makeMonitor();
+
+    for (let i = 0; i < TAILNET_ALARM_CONSECUTIVE_TIMEOUTS * 3; i++) {
+      await monitor.record({ containerName: "agent-only", outcome: "timed_out" });
+    }
+    expect(TAILNET_ALARM_MIN_DISTINCT_CONTAINERS).toBeGreaterThan(1);
+    expect(alerts).toHaveLength(0);
+    expect(monitor.active).toBe(false);
+  });
+
+  test("throttles re-alerts while the outage persists, then re-fires after the window", async () => {
+    const { monitor, alerts, advance } = makeMonitor();
+
+    await monitor.record({ containerName: "agent-a", outcome: "timed_out" });
+    await monitor.record({ containerName: "agent-b", outcome: "timed_out" });
+    await monitor.record({ containerName: "agent-c", outcome: "timed_out" });
+    expect(alerts).toHaveLength(1);
+
+    advance(TAILNET_ALARM_REALERT_MS - 1);
+    await monitor.record({ containerName: "agent-d", outcome: "timed_out" });
+    expect(alerts).toHaveLength(1);
+
+    advance(1);
+    await monitor.record({ containerName: "agent-e", outcome: "timed_out" });
+    expect(alerts).toHaveLength(2);
+  });
+
+  test("a pass resets the run and clears the alarm; the next outage pages again", async () => {
+    const { monitor, alerts } = makeMonitor();
+
+    await monitor.record({ containerName: "agent-a", outcome: "timed_out" });
+    await monitor.record({ containerName: "agent-b", outcome: "timed_out" });
+    await monitor.record({ containerName: "agent-c", outcome: "timed_out" });
+    expect(monitor.active).toBe(true);
+
+    await monitor.record({ containerName: "agent-a", outcome: "passed" });
+    expect(monitor.active).toBe(false);
+
+    // Interleaved passes keep it quiet: retries during a healthy path.
+    await monitor.record({ containerName: "agent-b", outcome: "timed_out" });
+    await monitor.record({ containerName: "agent-c", outcome: "timed_out" });
+    await monitor.record({ containerName: "agent-d", outcome: "passed" });
+    expect(alerts).toHaveLength(1);
+
+    // A fresh outage pages immediately even inside the old throttle window.
+    await monitor.record({ containerName: "agent-a", outcome: "timed_out" });
+    await monitor.record({ containerName: "agent-b", outcome: "timed_out" });
+    await monitor.record({ containerName: "agent-c", outcome: "timed_out" });
+    expect(alerts).toHaveLength(2);
+  });
+
+  test("a throwing alert channel never propagates into the probe loop", async () => {
+    let nowMs = 0;
+    const monitor = new TailnetPathMonitor({
+      alert: async () => {
+        throw new Error("pagerduty down");
+      },
+      now: () => nowMs++,
+    });
+
+    await monitor.record({ containerName: "agent-a", outcome: "timed_out" });
+    await monitor.record({ containerName: "agent-b", outcome: "timed_out" });
+    await expect(
+      monitor.record({ containerName: "agent-c", outcome: "timed_out" }),
+    ).resolves.toBeUndefined();
+    expect(monitor.active).toBe(true);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/tailnet-path-monitor.ts
+++ b/packages/cloud/shared/src/lib/services/tailnet-path-monitor.ts
@@ -1,0 +1,136 @@
+/**
+ * Detects a control-plane→agent tailnet path outage from the provisioning
+ * daemon's own health-probe stream and makes it loud.
+ *
+ * The 2026-08-18 headscale ACL regression turned EVERY tailnet health probe
+ * into a 360 s timeout for a day and a half without a single alert: each probe
+ * failure looked like one slow container, provisioning retried, and nobody was
+ * paged (elizaOS/eliza#22547 proof 7). One sick container cannot distinguish
+ * itself from a severed path, but a run of consecutive timeouts across
+ * DISTINCT containers with zero passes in between can — that is the signature
+ * this monitor alarms on.
+ *
+ * The daemon (docker-sandbox-provider) reports every terminal probe outcome
+ * here; the monitor fires the shared provisioning ops alert channels
+ * (structured error log always; Slack/PagerDuty when configured) under its own
+ * PagerDuty dedup key, re-alerts on a throttle while the outage persists, and
+ * logs recovery on the first subsequent pass.
+ */
+
+import { logger } from "../utils/logger";
+import {
+  type DaemonHealthAlert,
+  sendProvisioningWorkerAlert,
+} from "./provisioning-worker-health-monitor";
+
+/** Consecutive terminal probe timeouts required before the path alarm fires. */
+export const TAILNET_ALARM_CONSECUTIVE_TIMEOUTS = 3;
+
+/**
+ * Distinct containers that must be represented in the timeout run. A single
+ * container timing out repeatedly is a sick agent, not a severed path.
+ */
+export const TAILNET_ALARM_MIN_DISTINCT_CONTAINERS = 2;
+
+/** Re-alert cadence while the outage persists (one PagerDuty incident via dedup). */
+export const TAILNET_ALARM_REALERT_MS = 30 * 60_000;
+
+/** PagerDuty dedup key: keeps this a separate incident from the daemon heartbeat. */
+export const TAILNET_ALARM_DEDUP_KEY = "tailnet-agent-path-unreachable";
+
+export interface TailnetProbeOutcome {
+  containerName: string;
+  outcome: "passed" | "timed_out";
+}
+
+/**
+ * Sliding outage detector over terminal tailnet probe outcomes. One instance
+ * lives per daemon process; tests construct their own with injected deps.
+ */
+export class TailnetPathMonitor {
+  private consecutiveTimeouts = 0;
+  private readonly timedOutContainers = new Set<string>();
+  private firstTimeoutAtMs: number | null = null;
+  private lastAlertAtMs: number | null = null;
+  private alarmActive = false;
+
+  constructor(
+    private readonly deps: {
+      alert?: (alert: DaemonHealthAlert) => Promise<void>;
+      now?: () => number;
+    } = {},
+  ) {}
+
+  /** True while the path-outage condition currently holds. */
+  get active(): boolean {
+    return this.alarmActive;
+  }
+
+  /**
+   * Record one terminal probe outcome. Never throws: an alerting failure must
+   * not take down the provisioning loop that observed it.
+   */
+  async record(probe: TailnetProbeOutcome): Promise<void> {
+    const now = (this.deps.now ?? Date.now)();
+    if (probe.outcome === "passed") {
+      if (this.alarmActive) {
+        logger.info("[TailnetPathMonitor] Tailnet agent path recovered", {
+          containerName: probe.containerName,
+          consecutiveTimeouts: this.consecutiveTimeouts,
+          outageStartedAt:
+            this.firstTimeoutAtMs === null ? null : new Date(this.firstTimeoutAtMs).toISOString(),
+        });
+      }
+      this.consecutiveTimeouts = 0;
+      this.timedOutContainers.clear();
+      this.firstTimeoutAtMs = null;
+      this.lastAlertAtMs = null;
+      this.alarmActive = false;
+      return;
+    }
+
+    this.consecutiveTimeouts += 1;
+    this.timedOutContainers.add(probe.containerName);
+    if (this.firstTimeoutAtMs === null) this.firstTimeoutAtMs = now;
+
+    const conditionMet =
+      this.consecutiveTimeouts >= TAILNET_ALARM_CONSECUTIVE_TIMEOUTS &&
+      this.timedOutContainers.size >= TAILNET_ALARM_MIN_DISTINCT_CONTAINERS;
+    if (!conditionMet) return;
+
+    const due = this.lastAlertAtMs === null || now - this.lastAlertAtMs >= TAILNET_ALARM_REALERT_MS;
+    this.alarmActive = true;
+    if (!due) return;
+    this.lastAlertAtMs = now;
+
+    try {
+      await (this.deps.alert ?? sendProvisioningWorkerAlert)({
+        title: "Control-plane → agent tailnet path appears down",
+        message:
+          `${this.consecutiveTimeouts} consecutive tailnet health probes timed out across ` +
+          `${this.timedOutContainers.size} distinct containers with zero passes in between. ` +
+          "This is the signature of a severed headscale path (e.g. an ACL dropping " +
+          "tag:eliza-proxy → tag:agent), not one sick agent. Check the control plane's " +
+          "netmap and the deployed /etc/headscale/acl.hujson before restarting anything.",
+        details: {
+          code: "TAILNET_AGENT_PATH_UNREACHABLE",
+          consecutiveTimeouts: this.consecutiveTimeouts,
+          distinctContainers: [...this.timedOutContainers].slice(0, 10),
+          firstTimeoutAt:
+            this.firstTimeoutAtMs === null ? null : new Date(this.firstTimeoutAtMs).toISOString(),
+        },
+        dedupKey: TAILNET_ALARM_DEDUP_KEY,
+      });
+    } catch (error) {
+      // error-policy:J7 alert delivery is diagnostics; the probe loop that
+      // observed the outage must keep running (the structured error log inside
+      // sendProvisioningWorkerAlert already fired before any channel send).
+      logger.warn("[TailnetPathMonitor] Failed to dispatch tailnet path alert", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+/** Process-wide monitor used by the daemon's sandbox provider. */
+export const tailnetPathMonitor = new TailnetPathMonitor();


### PR DESCRIPTION
Fixes #22547

The ACL rule itself already landed (#22617 for staging, #22664 for production), and the issue's own recheck comment confirms points 1/2/6/8 are green in production. What did **not** land is the pair of defects the issue calls out as the reason the outage was both *possible* and *invisible*. This PR closes those two, which are the only parts of GOAL A that are codeable rather than fleet operations.

## 1. Placement environment guard fails closed (proof 9)

`currentEnvironmentPredicate()` (`docker-nodes.ts`) carried a fail-open arm:

```sql
COALESCE(metadata->>'environment', '') = ''   -- matches EVERY unlabeled row
OR metadata->>'environment' = $environment
```

No `docker_nodes` row carries `metadata.environment`, so with `ENVIRONMENT` set the guard admitted the entire table — which is how a staging host registered in the production DB stood as a production placement target. As the issue notes, deleting the offending row leaves the gate open for the next one, so the fix is the predicate.

The predicate now takes a `scope`:

- **`placement`** (`findPlaceable`, `findLeastLoaded`) — strict equality only. An unlabeled row is **not** a placement target.
- **`operational`** (`findEnabled`) — keeps the inclusive form deliberately, because health checks, disk monitoring, allocated-count sync, and the orphan reconciler must keep watching a legacy node. Rows stamped for a *different* environment are still excluded.

Live fleets must therefore carry the stamp. They already do on every write path: `stampDockerNodeEnvironmentMetadata` is applied by the admin register route, the bootstrap-callback route, and `onboard-docker-node.ts`.

**A/B against the predicate (the proof-9 requirement).** Reverting `docker-nodes.ts` to the `origin/develop` version and rerunning the *new* test file:

```
== new tests against develop's fail-open predicate ==
(fail) findPlaceable fails closed: an unlabeled node is not a placement target
(fail) findLeastLoaded applies the same environment guard to schedulable capacity
 5 pass, 2 fail

== same tests against this branch ==
 7 pass, 0 fail
```

Worth flagging for the reviewer: the first draft of that assertion passed against **both** versions, because drizzle renders the column qualified (`"docker_nodes"."metadata"`) and my substring never matched. The A/B is what caught it. The assertion now counts `->>'environment'` occurrences — the fail-open form emits two (the COALESCE arm and the OR arm), the fail-closed form exactly one — so it cannot silently pass again.

## 2. The missing alarm (proof 7)

Every tailnet health probe became a 360 s timeout for a day and a half and nobody was paged. Each individual failure was indistinguishable from one slow container, provisioning retried, and the outage hid inside per-container retry noise.

`tailnet-path-monitor.ts` alarms on the signature that a single sick agent *cannot* produce: a run of consecutive terminal probe timeouts spanning **distinct containers** with zero passes in between. On that condition it fires the shared provisioning ops alert channels (structured error log always, Slack/PagerDuty when configured) under its own dedup key — `tailnet-agent-path-unreachable`, separate from the daemon-heartbeat incident — re-alerts on a 30-minute throttle while the outage persists, and logs recovery on the first subsequent pass. It is wired into both terminal outcomes of the daemon's `pollTailnetHealth`.

The alert message names the actual first move (check the control plane's netmap and the deployed `/etc/headscale/acl.hujson`) and, per the issue's explicit warning, does not suggest restarting `tailscaled`.

Tests cover: firing on the distinct-container run; **not** firing for one container timing out indefinitely; the re-alert throttle at the boundary (`REALERT_MS - 1` quiet, `REALERT_MS` fires); a pass resetting the run so interleaved retries stay quiet while a fresh outage still pages immediately; and a throwing alert channel never propagating into the probe loop (`// error-policy:J7`).

## Test results

```
packages/cloud/shared
  bun test src/lib/services/tailnet-path-monitor.test.ts
  bun test src/db/repositories/docker-nodes.test.ts
    12 pass, 0 fail, 63 expect() calls

  bun test docker-sandbox            166 pass, 0 fail
  bun test provisioning-worker-health-monitor.test.ts    11 pass, 0 fail
  bun test __tests__/docker-sandbox-health-fallback.test.ts    4 pass, 0 fail

  bun run typecheck                  clean for all touched files
  biome check (5 touched files)      clean
```

**Pre-existing failure, disclosed:** `docker-node-manager-health-disable.test.ts` has 3 failures (`3 pass / 3 fail`). Verified pre-existing by reverting `docker-nodes.ts` to `origin/develop` and rerunning — identical `3 pass / 3 fail`. Not caused by, and not addressed by, this PR.

## Human-only remainder

This PR cannot close #22547 on its own. Proofs 3, 4, and 5 require operations against the live fleet that an agent must not perform:

- **Proof 3** — provision a *new* dedicated agent and show `https://<agent-uuid>.cloud.eliza.app/api/health` returning 200 from outside the network.
- **Proof 4** — that agent answering a chat message, with the transcript and the server-side row. The issue is explicit that with zero live dedicated agents this is the hard part, not a formality.
- **Proof 5** — a warm-pool sandbox with `pool_ready_at` set, confirming the pool converges post-ACL. If it does not, that is a second defect.
- **Proof 7, live half** — this PR supplies the alarm and its unit proof; demonstrating it firing end to end requires reproducing the condition against the real fleet and showing the notification arrive in a channel a human reads. `PROVISIONING_ALERT_SLACK_WEBHOOK` / `PROVISIONING_ALERT_PAGERDUTY_KEY` must be present in the daemon environment for the channel fan-out — the structured error log fires regardless.

**Before removing any `docker_nodes` row on the strength of this change:** the fail-closed predicate now excludes unlabeled rows from placement, so a live production node that was never stamped will stop receiving placements on deploy. Confirm the production fleet carries `metadata.environment` before rollout. The staging row the issue names reads *"re-added 2026-08-05 by sol; shares box with 23 GH Actions CI runners"* — the issue says ask sol, and this PR does not touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
