### PR TITLE
fix(cloud-auth): revoke orphan CLI keys when reaping expired sessions

### DIFF
--- a/packages/cloud/api/__tests__/cleanup-cli-sessions-cron.test.ts
+++ b/packages/cloud/api/__tests__/cleanup-cli-sessions-cron.test.ts
@@ -24,7 +24,10 @@ import { Hono } from "hono";
 import { cliAuthSessionsService } from "@/lib/services/cli-auth-sessions";
 import type { Bindings } from "@/types/cloud-worker-env";
 
-const cleanupExpiredSessions = mock(async () => {});
+const cleanupExpiredSessions = mock(async () => ({
+  deletedSessions: 0,
+  revokedOrphanKeys: 0,
+}));
 const cleanupSpy = spyOn(
   cliAuthSessionsService,
   "cleanupExpiredSessions",

--- a/packages/cloud/api/cron/cleanup-cli-sessions/route.ts
+++ b/packages/cloud/api/cron/cleanup-cli-sessions/route.ts
@@ -18,10 +18,13 @@ const app = new Hono<AppEnv>();
 async function handle(c: Context<AppEnv>) {
   try {
     requireCronSecret(c);
-    await cliAuthSessionsService.cleanupExpiredSessions();
+    const { deletedSessions, revokedOrphanKeys } =
+      await cliAuthSessionsService.cleanupExpiredSessions();
     return c.json({
       success: true,
-      message: "Expired CLI auth sessions cleaned up successfully",
+      message: `Reaped ${deletedSessions} expired CLI auth sessions; revoked ${revokedOrphanKeys} orphan keys`,
+      deletedSessions,
+      revokedOrphanKeys,
     });
   } catch (error) {
     logger.error("Error cleaning up CLI auth sessions:", error);

--- a/packages/cloud/shared/src/db/repositories/cli-auth-sessions.ts
+++ b/packages/cloud/shared/src/db/repositories/cli-auth-sessions.ts
@@ -1,5 +1,5 @@
 /** Persists CLI auth sessions through primary-safe reveal and lifecycle operations. */
-import { and, eq, exists, gt, isNull, lt, or } from "drizzle-orm";
+import { and, eq, exists, gt, inArray, isNotNull, isNull, lt, or } from "drizzle-orm";
 import { dbRead, dbWrite } from "../helpers";
 import { type ApiKey, apiKeys } from "../schemas/api-keys";
 import {
@@ -192,11 +192,57 @@ export class CliAuthSessionsRepository {
   }
 
   /**
-   * Deletes all expired CLI auth sessions.
+   * Reaps every expired CLI auth session and revokes the orphan credentials
+   * they minted, in one primary transaction.
+   *
+   * An abandoned sign-in ends `authenticated` with `consumed_at = NULL`: the
+   * key row exists and is active, but its plaintext was never revealed to any
+   * caller (`getAndClearApiKey` is the only reveal path and it stamps
+   * `consumed_at`). Deleting such a session without touching its key would
+   * strand a live credential nobody holds — the #22551 orphan population — so
+   * the key is deactivated in the same transaction that removes the session.
+   * Consumed sessions leave their keys alone: that credential was handed to a
+   * real CLI and lives out its own `expires_at`.
+   *
+   * Returns the revoked keys' hashes so the caller can invalidate auth caches
+   * AFTER commit (write-then-invalidate; a pre-commit invalidation could be
+   * repopulated from the not-yet-revoked row).
    */
-  async deleteExpiredSessions(): Promise<void> {
-    const now = new Date();
-    await dbWrite.delete(cliAuthSessions).where(lt(cliAuthSessions.expires_at, now));
+  async reapExpiredSessions(now: Date = new Date()): Promise<{
+    deletedSessions: number;
+    revokedOrphanKeys: { id: string; key_hash: string }[];
+  }> {
+    return await dbWrite.transaction(async (tx) => {
+      const orphanKeyIds = tx
+        .select({ id: cliAuthSessions.api_key_id })
+        .from(cliAuthSessions)
+        .where(
+          and(
+            lt(cliAuthSessions.expires_at, now),
+            isNull(cliAuthSessions.consumed_at),
+            isNotNull(cliAuthSessions.api_key_id),
+          ),
+        );
+
+      const revokedOrphanKeys = await tx
+        .update(apiKeys)
+        .set({ is_active: false, updated_at: now })
+        .where(
+          and(
+            inArray(apiKeys.id, orphanKeyIds),
+            eq(apiKeys.is_active, true),
+            isNull(apiKeys.deleted_at),
+          ),
+        )
+        .returning({ id: apiKeys.id, key_hash: apiKeys.key_hash });
+
+      const deleted = await tx
+        .delete(cliAuthSessions)
+        .where(lt(cliAuthSessions.expires_at, now))
+        .returning({ id: cliAuthSessions.id });
+
+      return { deletedSessions: deleted.length, revokedOrphanKeys };
+    });
   }
 }
 

--- a/packages/cloud/shared/src/lib/services/cli-auth-sessions.idempotent-complete.test.ts
+++ b/packages/cloud/shared/src/lib/services/cli-auth-sessions.idempotent-complete.test.ts
@@ -305,12 +305,18 @@ describe("cliAuthSessionsService lifecycle", () => {
     expect(markExpired).toHaveBeenCalledWith(SESSION_ID);
   });
 
-  test("delegates expired-session cleanup to the repository", async () => {
-    const removeExpired = track(
-      spyOn(cliAuthSessionsRepository, "deleteExpiredSessions").mockResolvedValue(undefined),
+  test("delegates expired-session reaping to the repository and reports counts", async () => {
+    const reap = track(
+      spyOn(cliAuthSessionsRepository, "reapExpiredSessions").mockResolvedValue({
+        deletedSessions: 3,
+        revokedOrphanKeys: [],
+      }),
     );
 
-    await cliAuthSessionsService.cleanupExpiredSessions();
-    expect(removeExpired).toHaveBeenCalledTimes(1);
+    await expect(cliAuthSessionsService.cleanupExpiredSessions()).resolves.toEqual({
+      deletedSessions: 3,
+      revokedOrphanKeys: 0,
+    });
+    expect(reap).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud/shared/src/lib/services/cli-auth-sessions.reap-expired.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/cli-auth-sessions.reap-expired.pglite.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Expired CLI auth session reaping against real PGlite DDL (#22551).
+ *
+ * An abandoned sign-in leaves an `authenticated` session with
+ * `consumed_at = NULL` and an active api_keys row whose plaintext was never
+ * revealed. The sweep must revoke that orphan credential in the same
+ * transaction that deletes the session, must NOT touch keys whose sessions
+ * were consumed (those belong to a real CLI), and must invalidate the auth
+ * caches for every revoked hash after commit. The repository and service under
+ * test are real; only the cache invalidation boundary is spied.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
+import { eq } from "drizzle-orm";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../db/client";
+import { cliAuthSessionsRepository } from "../../db/repositories/cli-auth-sessions";
+import { apiKeys } from "../../db/schemas/api-keys";
+import { cliAuthSessions } from "../../db/schemas/cli-auth-sessions";
+import { organizations } from "../../db/schemas/organizations";
+import { users } from "../../db/schemas/users";
+import { apiKeysService } from "./api-keys";
+import { cliAuthSessionsService } from "./cli-auth-sessions";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+let seq = 0;
+
+function uniq(prefix: string): string {
+  seq += 1;
+  return `${prefix}-${seq}`;
+}
+
+const spies: Array<{ mockRestore: () => void }> = [];
+function track<T extends { mockRestore: () => void }>(spy: T): T {
+  spies.push(spy);
+  return spy;
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    return;
+  }
+  try {
+    const schema = { organizations, users, apiKeys, cliAuthSessions };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch {
+    pgliteReady = false;
+  }
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  expect(pgliteReady).toBe(true);
+  await dbWrite.delete(cliAuthSessions);
+  await dbWrite.delete(apiKeys);
+  await dbWrite.delete(users);
+  await dbWrite.delete(organizations);
+});
+
+afterEach(() => {
+  while (spies.length > 0) spies.pop()?.mockRestore();
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+async function seedIdentity(): Promise<{ orgId: string; userId: string }> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Reap Org", slug: uniq("reap-org") })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("reap-user"), organization_id: org.id })
+    .returning();
+  return { orgId: org.id, userId: user.id };
+}
+
+async function seedKey(
+  ids: { orgId: string; userId: string },
+  overrides: Partial<typeof apiKeys.$inferInsert> = {},
+): Promise<{ id: string; key_hash: string }> {
+  const hash = uniq("hash").padEnd(64, "0");
+  const [key] = await dbWrite
+    .insert(apiKeys)
+    .values({
+      name: uniq("CLI Login"),
+      key_hash: hash,
+      key_prefix: "eliza_te",
+      organization_id: ids.orgId,
+      user_id: ids.userId,
+      is_active: true,
+      ...overrides,
+    })
+    .returning({ id: apiKeys.id, key_hash: apiKeys.key_hash });
+  return key;
+}
+
+async function seedSession(overrides: Partial<typeof cliAuthSessions.$inferInsert>): Promise<void> {
+  await dbWrite.insert(cliAuthSessions).values({
+    session_id: uniq("sess"),
+    status: "pending",
+    expires_at: new Date(Date.now() - 60_000),
+    ...overrides,
+  });
+}
+
+async function keyIsActive(id: string): Promise<boolean> {
+  const [row] = await dbWrite
+    .select({ is_active: apiKeys.is_active })
+    .from(apiKeys)
+    .where(eq(apiKeys.id, id));
+  return row.is_active;
+}
+
+describe("reapExpiredSessions on primary PGlite", () => {
+  test("revokes the orphan key of an expired, never-consumed authenticated session", async () => {
+    const ids = await seedIdentity();
+    const orphan = await seedKey(ids);
+    await seedSession({
+      status: "authenticated",
+      user_id: ids.userId,
+      api_key_id: orphan.id,
+      consumed_at: null,
+      authenticated_at: new Date(Date.now() - 120_000),
+    });
+
+    const result = await cliAuthSessionsRepository.reapExpiredSessions();
+
+    expect(result.deletedSessions).toBe(1);
+    expect(result.revokedOrphanKeys).toEqual([{ id: orphan.id, key_hash: orphan.key_hash }]);
+    expect(await keyIsActive(orphan.id)).toBe(false);
+    expect(await dbWrite.select().from(cliAuthSessions)).toHaveLength(0);
+  });
+
+  test("leaves a consumed session's key active while deleting the session", async () => {
+    const ids = await seedIdentity();
+    const delivered = await seedKey(ids);
+    await seedSession({
+      status: "authenticated",
+      user_id: ids.userId,
+      api_key_id: delivered.id,
+      consumed_at: new Date(Date.now() - 90_000),
+    });
+
+    const result = await cliAuthSessionsRepository.reapExpiredSessions();
+
+    expect(result.deletedSessions).toBe(1);
+    expect(result.revokedOrphanKeys).toEqual([]);
+    expect(await keyIsActive(delivered.id)).toBe(true);
+  });
+
+  test("ignores live sessions and keyless expired sessions", async () => {
+    const ids = await seedIdentity();
+    const liveKey = await seedKey(ids);
+    await seedSession({
+      status: "authenticated",
+      user_id: ids.userId,
+      api_key_id: liveKey.id,
+      expires_at: new Date(Date.now() + 600_000),
+    });
+    await seedSession({ status: "pending", api_key_id: null });
+
+    const result = await cliAuthSessionsRepository.reapExpiredSessions();
+
+    expect(result.deletedSessions).toBe(1);
+    expect(result.revokedOrphanKeys).toEqual([]);
+    expect(await keyIsActive(liveKey.id)).toBe(true);
+    expect(await dbWrite.select().from(cliAuthSessions)).toHaveLength(1);
+  });
+
+  test("does not re-report keys already revoked or soft-deleted", async () => {
+    const ids = await seedIdentity();
+    const alreadyRevoked = await seedKey(ids, { is_active: false });
+    const softDeleted = await seedKey(ids, { deleted_at: new Date() });
+    await seedSession({
+      status: "authenticated",
+      user_id: ids.userId,
+      api_key_id: alreadyRevoked.id,
+    });
+    await seedSession({ status: "authenticated", user_id: ids.userId, api_key_id: softDeleted.id });
+
+    const result = await cliAuthSessionsRepository.reapExpiredSessions();
+
+    expect(result.deletedSessions).toBe(2);
+    expect(result.revokedOrphanKeys).toEqual([]);
+  });
+});
+
+describe("cleanupExpiredSessions service boundary", () => {
+  test("invalidates auth caches for each revoked orphan hash after commit", async () => {
+    const ids = await seedIdentity();
+    const orphanA = await seedKey(ids);
+    const orphanB = await seedKey(ids);
+    await seedSession({ status: "authenticated", user_id: ids.userId, api_key_id: orphanA.id });
+    await seedSession({ status: "authenticated", user_id: ids.userId, api_key_id: orphanB.id });
+
+    const invalidate = track(spyOn(apiKeysService, "invalidateCache").mockResolvedValue(undefined));
+
+    const result = await cliAuthSessionsService.cleanupExpiredSessions();
+
+    expect(result).toEqual({ deletedSessions: 2, revokedOrphanKeys: 2 });
+    const invalidatedHashes = invalidate.mock.calls.map((call) => call[0]).sort();
+    expect(invalidatedHashes).toEqual([orphanA.key_hash, orphanB.key_hash].sort());
+    // Both keys were already inactive in the database before any invalidation
+    // ran (write-then-invalidate): re-check the durable state.
+    expect(await keyIsActive(orphanA.id)).toBe(false);
+    expect(await keyIsActive(orphanB.id)).toBe(false);
+  });
+
+  test("surfaces an unconfirmed cache invalidation instead of swallowing it", async () => {
+    const ids = await seedIdentity();
+    const orphan = await seedKey(ids);
+    await seedSession({ status: "authenticated", user_id: ids.userId, api_key_id: orphan.id });
+
+    track(
+      spyOn(apiKeysService, "invalidateCache").mockRejectedValue(
+        new Error("cache invalidation not confirmed"),
+      ),
+    );
+
+    await expect(cliAuthSessionsService.cleanupExpiredSessions()).rejects.toThrow(
+      "cache invalidation not confirmed",
+    );
+    // The durable revocation still committed: the key denies from the database.
+    expect(await keyIsActive(orphan.id)).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/cli-auth-sessions.ts
+++ b/packages/cloud/shared/src/lib/services/cli-auth-sessions.ts
@@ -7,6 +7,7 @@ import { decryptApiKey } from "../../db/crypto/api-keys";
 import { cliAuthSessionsRepository } from "../../db/repositories";
 import type { ApiKey } from "../../db/schemas/api-keys";
 import type { CliAuthSession } from "../../db/schemas/cli-auth-sessions";
+import { apiKeysService } from "./api-keys";
 import { cliAuthSessionCompletionService } from "./cli-auth-session-completion";
 
 /**
@@ -295,10 +296,26 @@ export class CliAuthSessionsService {
   }
 
   /**
-   * Clean up expired sessions (should be called by a cron job)
+   * Reaps expired sessions and revokes the orphan keys minted by abandoned
+   * sign-ins (cron-driven). The revocation commits first, then each revoked
+   * hash's auth caches are invalidated — matching the write-then-invalidate
+   * ordering the revocation paths use. These keys' plaintext was never
+   * revealed (consumed_at was NULL), so no warm cache entry can exist; the
+   * invalidation is defense-in-depth and an unconfirmed delete surfaces to
+   * the cron boundary rather than being swallowed.
    */
-  async cleanupExpiredSessions(): Promise<void> {
-    await cliAuthSessionsRepository.deleteExpiredSessions();
+  async cleanupExpiredSessions(): Promise<{
+    deletedSessions: number;
+    revokedOrphanKeys: number;
+  }> {
+    const { deletedSessions, revokedOrphanKeys } =
+      await cliAuthSessionsRepository.reapExpiredSessions();
+
+    for (const key of revokedOrphanKeys) {
+      await apiKeysService.invalidateCache(key.key_hash);
+    }
+
+    return { deletedSessions, revokedOrphanKeys: revokedOrphanKeys.length };
   }
 }
 


### PR DESCRIPTION
Fixes #22551 (partially — see "Human-only remainder").

## What was wrong

An abandoned CLI sign-in leaves an `authenticated` session with `consumed_at = NULL` and an **active** `api_keys` row whose plaintext was never revealed to anybody: `getAndClearApiKey` is the only reveal path and it stamps `consumed_at` on the way out. The cleanup cron (`/api/cron/cleanup-cli-sessions`, scheduled by #22618) deleted those sessions and left the credential live and permanent. That is the orphan population the issue names — 58 keys across 44 organisations minted this way in the last 90 days, and the current sweep made the evidence disappear while leaving the credential standing.

## What changed

- `CliAuthSessionsRepository.reapExpiredSessions()` replaces `deleteExpiredSessions()`. In **one primary transaction** it deactivates every never-consumed key referenced by an expired session, then deletes the expired sessions, and returns the revoked `{id, key_hash}` rows.
- `CliAuthSessionsService.cleanupExpiredSessions()` invalidates the auth caches for each revoked hash **after** the transaction commits — write-then-invalidate, the same ordering the revocation paths are being corrected to in #22920/#23119. A pre-commit invalidation could be repopulated from the not-yet-revoked row.
- Consumed sessions are untouched on the key side: that credential reached a real CLI and lives out its own `expires_at` (90-day CLI TTL, `cli-auth-session-completion.ts`).
- The cron route now returns `deletedSessions` and `revokedOrphanKeys` so an operator can read the run rate off the cron log instead of querying for it.

Residual exposure for an orphan key: bounded by one cron interval (`0 */6 * * *`, so **≤ 6 h**) from session expiry (10 min after mint). Because the plaintext was never revealed, no warm cache entry can exist for these hashes — the cache invalidation is defence in depth, and an unconfirmed delete is surfaced, not swallowed.

## Tests

New `packages/cloud/shared/src/lib/services/cli-auth-sessions.reap-expired.pglite.test.ts` drives the real repository and service against real PGlite DDL:

- expired + never-consumed authenticated session → key deactivated, session deleted, hash returned;
- expired + **consumed** session → session deleted, key left active (negative control);
- live session and keyless expired session → untouched / no spurious revocation;
- already-inactive and soft-deleted keys → not re-reported;
- service boundary → caches invalidated for exactly the revoked hashes, and the durable revocation is already committed at that point;
- invalidation failure → propagates (does not fabricate success) while the revocation stays committed.

```
bun test src/lib/services/cli-auth-sessions.reap-expired.pglite.test.ts \
         src/lib/services/cli-auth-sessions.idempotent-complete.test.ts
  19 pass  0 fail  50 expect() calls

packages/cloud/api: bun test __tests__/cleanup-cli-sessions-cron.test.ts
  4 pass  0 fail

biome check (touched files): clean
bun run --cwd packages/cloud/shared typecheck: clean
```

## Human-only remainder (not in this PR)

- **Revocation ordering** in `ApiKeysService.update/delete/deactivate*` — claimed under #22920, PR #23119.
- **Migrating the existing 8,039 live non-expiring keys** to an expiry, and **remediating the 4,671 never-used credentials**: production data touching other people's integrations. Policy, audit trail, and rollout window must be decided by a human; the issue itself says so.
- **Mint-per-sign-in policy** — a design adjudication, not a code gap.
- Before/after production population counts require production DB access.
