### PR TITLE
fix(cloud): widen delete job mock result shape

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts
@@ -32,10 +32,20 @@ type CancelAgentDeletionResult =
 const cancelAgentDeletion = mock(
   async (): Promise<CancelAgentDeletionResult> => ({ success: true }),
 );
-const enqueueAgentDeleteOnce = mock(async () => ({
-  created: true,
-  job: { id: "delete-job-1", status: "pending" },
-}));
+type EnqueueAgentDeleteOnceResult = {
+  created: boolean;
+  job: {
+    id: string;
+    status: string;
+    data?: Record<string, unknown>;
+  };
+};
+const enqueueAgentDeleteOnce = mock(
+  async (): Promise<EnqueueAgentDeleteOnceResult> => ({
+    created: true,
+    job: { id: "delete-job-1", status: "pending" },
+  }),
+);
 const triggerImmediate = mock(async () => undefined);
 
 const loggerInfo = mock(() => undefined);


### PR DESCRIPTION
Closes #23377.

The new state-loss acknowledgement tests legitimately reuse an enqueue result containing persisted `job.data`, but Bun inferred the mock from the initial `{ id, status }` return. This gives the test double an explicit result shape with optional `data` and does not alter production behavior or assertions.

## Verification

- reproduced from canonical staging run 32446584435: `__tests__/eliza-agents-delete-shared-fallback.test.ts(271,9)` and `(296,53)` TS2353
- `bun run --cwd packages/cloud/api typecheck` — passed
- Wrangler production dry-run Worker bundle — passed (24,545.71 KiB / gzip 5,835.24 KiB)
- exact one-commit child of current develop `16cbebf500d4ec798f516c1cf0fac56694585bf9`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Attribution status: self-reported
— [codex-cloud-release-repair]