### PR TITLE
fix(cloud): make the dedicated-fleet liveness question askable

### DIFF
--- a/packages/cloud/api/v1/cron/provisioning-worker-health/route.test.ts
+++ b/packages/cloud/api/v1/cron/provisioning-worker-health/route.test.ts
@@ -9,12 +9,19 @@
  *   - global `fetch`, so we can capture the outbound ops-channel alert without
  *     POSTing to a real Slack webhook;
  *   - the shared-DB heartbeat write, whose repository is outside this route's
- *     health/alert contract and must not initialize persistent PGlite here.
+ *     health/alert contract and must not initialize persistent PGlite here;
+ *   - the dedicated-fleet census/jobs repositories, which would otherwise open
+ *     a real database — the fleet monitor's own logic runs for real.
  *
  * Asserts the dead-alert gap is closed: when the daemon heartbeat is
  * absent or stale, the route returns `healthy:false` AND the alert callback
  * actually fires (structured error log + Slack channel POST). The healthy path
  * stays silent, and an invalid cron secret is rejected before any check runs.
+ *
+ * Also asserts the failure-isolation boundary (#22548): the two monitors are
+ * independent questions sharing a schedule, so a rejection in either one must
+ * NOT prevent the other from running and alerting, while the cron still
+ * answers with a structured failure.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -54,6 +61,28 @@ mock.module("@/lib/services/cloud-api-db-heartbeat", () => ({
   writeCloudApiDbHeartbeat,
 }));
 
+// The fleet monitor's own logic runs for real; only its two data sources are
+// stubbed so no database is opened. `summarizeDedicatedFleet` returns the real
+// grouped tier/status census shape.
+type FleetCensusRow = { execution_tier: string; status: string; count: number };
+let fleetCensus: FleetCensusRow[] = [];
+let fleetCensusError: Error | null = null;
+const summarizeDedicatedFleet = mock(async (): Promise<FleetCensusRow[]> => {
+  if (fleetCensusError) throw fleetCensusError;
+  return fleetCensus;
+});
+const summarizeOutcomesByTypeSince = mock(
+  async (): Promise<Array<{ status: string; count: number }>> => [],
+);
+
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: { summarizeDedicatedFleet },
+}));
+
+mock.module("@/db/repositories/jobs", () => ({
+  jobsRepository: { summarizeOutcomesByTypeSince },
+}));
+
 mock.module("@/lib/utils/logger", () => ({
   logger: {
     info: mock(() => undefined),
@@ -86,6 +115,10 @@ beforeEach(() => {
   writeCloudApiDbHeartbeat.mockClear();
   fetchMock.mockClear();
   fetchCalls.length = 0;
+  summarizeDedicatedFleet.mockClear();
+  summarizeOutcomesByTypeSince.mockClear();
+  fleetCensus = [];
+  fleetCensusError = null;
   process.env.PROVISIONING_ALERT_SLACK_WEBHOOK = SLACK_WEBHOOK;
   delete process.env.PROVISIONING_ALERT_PAGERDUTY_KEY;
   globalThis.fetch = fetchMock as unknown as typeof fetch;
@@ -183,10 +216,119 @@ describe("provisioning-worker-health cron route", () => {
     expect(fetchCalls.some((c) => c.url === SLACK_WEBHOOK)).toBe(false);
   });
 
-  test("invalid cron secret -> rejected before the gate is ever read", async () => {
+  test("invalid cron secret -> rejected before either monitor is ever run", async () => {
     const response = await hitCron("wrong-secret");
     expect(response.status).toBeGreaterThanOrEqual(400);
     expect(checkProvisioningWorkerHealth).not.toHaveBeenCalled();
     expect(writeCloudApiDbHeartbeat).not.toHaveBeenCalled();
+    expect(summarizeDedicatedFleet).not.toHaveBeenCalled();
+  });
+
+  // #22548 blocker 2: the monitors are independent questions on a shared
+  // schedule. Sequencing them meant one unhealthy monitoring dependency
+  // silenced the other — the exact silence this cron exists to prevent.
+  test("the fleet alert still fires when the sibling heartbeat monitor REJECTS", async () => {
+    checkProvisioningWorkerHealth.mockRejectedValueOnce(
+      new Error("redis gate unreachable"),
+    );
+    fleetCensus = [
+      { execution_tier: "dedicated-always", status: "error", count: 26 },
+    ];
+
+    const response = await hitCron();
+
+    // The fleet census ran despite the sibling rejection...
+    expect(summarizeDedicatedFleet).toHaveBeenCalledTimes(1);
+    // ...and its alert actually reached the ops channel.
+    const slackPost = fetchCalls.find((c) => c.url === SLACK_WEBHOOK);
+    expect(slackPost).toBeDefined();
+    expect(JSON.stringify(slackPost?.body)).toContain(
+      "Dedicated agent fleet is unreachable",
+    );
+
+    // The cron still answers with a structured failure naming the dead monitor.
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as {
+      success: boolean;
+      code: string;
+      monitors: {
+        heartbeat: { ok: boolean; error?: string };
+        fleet: { ok: boolean };
+      };
+      fleet: { unreachable: boolean } | null;
+    };
+    expect(body.success).toBe(false);
+    expect(body.code).toBe("cron_monitor_failed");
+    expect(body.monitors.heartbeat.ok).toBe(false);
+    expect(body.monitors.heartbeat.error).toContain("redis gate unreachable");
+    expect(body.monitors.fleet.ok).toBe(true);
+    expect(body.fleet?.unreachable).toBe(true);
+  });
+
+  test("the heartbeat alert still fires when the fleet census REJECTS", async () => {
+    checkProvisioningWorkerHealth.mockResolvedValueOnce({
+      ok: false,
+      required: true,
+      status: 503,
+      code: "PROVISIONING_WORKER_UNHEALTHY",
+      error:
+        "Provisioning worker has not reported a heartbeat in the last 60 seconds.",
+    });
+    fleetCensusError = new Error("fleet census query failed");
+
+    const response = await hitCron();
+
+    const slackPost = fetchCalls.find((c) => c.url === SLACK_WEBHOOK);
+    expect(slackPost).toBeDefined();
+    expect(JSON.stringify(slackPost?.body)).toContain(
+      "Provisioning worker is unhealthy",
+    );
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as {
+      code: string;
+      healthy: boolean;
+      monitors: {
+        heartbeat: { ok: boolean };
+        fleet: { ok: boolean; error?: string };
+      };
+      fleet: unknown;
+    };
+    expect(body.code).toBe("cron_monitor_failed");
+    // The healthy monitor's answer is preserved, not discarded.
+    expect(body.healthy).toBe(false);
+    expect(body.monitors.heartbeat.ok).toBe(true);
+    expect(body.monitors.fleet.ok).toBe(false);
+    expect(body.monitors.fleet.error).toContain("fleet census query failed");
+    expect(body.fleet).toBeNull();
+  });
+
+  // #22548 blocker 1, at the route boundary: a fleet of healthy sleeping
+  // dedicated-lazy agents has rows but nothing running, and must stay silent.
+  test("a fleet of sleeping dedicated-lazy agents does NOT page", async () => {
+    checkProvisioningWorkerHealth.mockResolvedValueOnce({
+      ok: true,
+      required: true,
+      lastHeartbeatAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+    fleetCensus = [
+      { execution_tier: "dedicated-lazy", status: "sleeping", count: 40 },
+      { execution_tier: "dedicated-lazy", status: "stopped", count: 5 },
+    ];
+
+    const response = await hitCron();
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      fleet: {
+        fleetTotal: number;
+        expectedReachableTotal: number;
+        unreachable: boolean;
+      };
+    };
+    expect(body.fleet.fleetTotal).toBe(45);
+    expect(body.fleet.expectedReachableTotal).toBe(0);
+    expect(body.fleet.unreachable).toBe(false);
+    expect(fetchCalls.some((c) => c.url === SLACK_WEBHOOK)).toBe(false);
   });
 });

--- a/packages/cloud/api/v1/cron/provisioning-worker-health/route.ts
+++ b/packages/cloud/api/v1/cron/provisioning-worker-health/route.ts
@@ -10,44 +10,113 @@
  * exist and none is serving" is invisible to the heartbeat sweep (which
  * iterates only running rows), so this cron asks it explicitly and publishes
  * provisioning success measured on the jobs ledger in its response and logs.
+ *
+ * The two monitors are INDEPENDENT questions that merely share a schedule, so
+ * they are settled independently: a Redis outage in the heartbeat gate, or a
+ * database outage in the fleet census, must not silence the sibling monitor —
+ * that would recreate the exact silence this cron exists to prevent, at the
+ * exact moment one monitoring dependency is unhealthy. Each failure is logged
+ * under its own scope and the cron still answers with a structured failure so
+ * the schedule itself is visibly red.
+ *
  * Protected by CRON_SECRET; supports GET (Workers cron trigger) and POST (manual hits).
  */
 
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireCronSecret } from "@/lib/auth/workers-hono-auth";
-import { monitorDedicatedFleetLiveness } from "@/lib/services/dedicated-fleet-liveness";
+import {
+  type DedicatedFleetLiveness,
+  monitorDedicatedFleetLiveness,
+} from "@/lib/services/dedicated-fleet-liveness";
 import { monitorProvisioningWorkerHealth } from "@/lib/services/provisioning-worker-health-monitor";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 async function runProvisioningWorkerHealthCheck(c: AppContext) {
   try {
     requireCronSecret(c);
-
-    const { healthy, stale, health } = await monitorProvisioningWorkerHealth();
-    const fleet = await monitorDedicatedFleetLiveness();
-
-    logger.info("[Provisioning Worker Health Cron] Heartbeat check completed", {
-      healthy,
-      stale,
-      required: health.required,
-      fleetTotal: fleet.fleetTotal,
-      fleetRunning: fleet.fleetRunning,
-      fleetUnreachable: fleet.unreachable,
-      provisionSuccessRate: fleet.provisionSuccessRate,
-    });
-
-    return c.json({ healthy, stale, health, fleet });
   } catch (error) {
-    logger.error(
-      "[Provisioning Worker Health Cron] Failed:",
-      error instanceof Error ? error.message : String(error),
-    );
+    // error-policy:J1 transport boundary — an unauthenticated cron hit is a
+    // structured 4xx, and neither monitor may run.
     return failureResponse(c, error);
   }
+
+  const [heartbeatResult, fleetResult] = await Promise.allSettled([
+    monitorProvisioningWorkerHealth(),
+    monitorDedicatedFleetLiveness(),
+  ]);
+
+  const failures: string[] = [];
+
+  if (heartbeatResult.status === "rejected") {
+    failures.push("provisioning-worker-heartbeat");
+    logger.error(
+      "[Provisioning Worker Health Cron] Heartbeat monitor failed:",
+      describe(heartbeatResult.reason),
+    );
+  }
+  if (fleetResult.status === "rejected") {
+    failures.push("dedicated-fleet-liveness");
+    logger.error(
+      "[Provisioning Worker Health Cron] Dedicated-fleet liveness monitor failed:",
+      describe(fleetResult.reason),
+    );
+  }
+
+  const fleet: DedicatedFleetLiveness | null =
+    fleetResult.status === "fulfilled" ? fleetResult.value : null;
+  const heartbeat =
+    heartbeatResult.status === "fulfilled" ? heartbeatResult.value : null;
+
+  logger.info("[Provisioning Worker Health Cron] Monitors settled", {
+    heartbeatOk: heartbeatResult.status === "fulfilled",
+    fleetOk: fleetResult.status === "fulfilled",
+    healthy: heartbeat?.healthy ?? null,
+    stale: heartbeat?.stale ?? null,
+    required: heartbeat?.health.required ?? null,
+    fleetExpectedReachable: fleet?.expectedReachableTotal ?? null,
+    fleetExpectedReachableRunning: fleet?.expectedReachableRunning ?? null,
+    fleetUnreachable: fleet?.unreachable ?? null,
+    fleetOffContract: fleet?.offContractTotal ?? null,
+    provisionSuccessRate: fleet?.provisionSuccessRate ?? null,
+  });
+
+  const monitors = {
+    heartbeat:
+      heartbeatResult.status === "fulfilled"
+        ? { ok: true as const }
+        : { ok: false as const, error: describe(heartbeatResult.reason) },
+    fleet:
+      fleetResult.status === "fulfilled"
+        ? { ok: true as const }
+        : { ok: false as const, error: describe(fleetResult.reason) },
+  };
+
+  // `!heartbeat` is implied by a non-empty `failures`; it is spelled out so the
+  // destructure below is narrowed by control flow rather than by an assertion.
+  if (failures.length > 0 || !heartbeat) {
+    return c.json(
+      {
+        success: false,
+        error: `Cron monitor(s) failed: ${failures.join(", ")}`,
+        code: "cron_monitor_failed" as const,
+        monitors,
+        ...(heartbeat ?? {}),
+        fleet,
+      },
+      500,
+    );
+  }
+
+  const { healthy, stale, health } = heartbeat;
+  return c.json({ healthy, stale, health, fleet, monitors });
 }
 
 app.get("/", runProvisioningWorkerHealthCheck);

--- a/packages/cloud/api/v1/cron/provisioning-worker-health/route.ts
+++ b/packages/cloud/api/v1/cron/provisioning-worker-health/route.ts
@@ -5,12 +5,18 @@
  * The daemon cannot page about its own death, so this runs separately on the
  * Worker. Schedule: every minute (registered in CRON_FANOUT for "* * * * *"
  * alongside health-check and deployment-monitor).
+ *
+ * Also runs the dedicated-fleet liveness monitor (#22548): "dedicated agents
+ * exist and none is serving" is invisible to the heartbeat sweep (which
+ * iterates only running rows), so this cron asks it explicitly and publishes
+ * provisioning success measured on the jobs ledger in its response and logs.
  * Protected by CRON_SECRET; supports GET (Workers cron trigger) and POST (manual hits).
  */
 
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireCronSecret } from "@/lib/auth/workers-hono-auth";
+import { monitorDedicatedFleetLiveness } from "@/lib/services/dedicated-fleet-liveness";
 import { monitorProvisioningWorkerHealth } from "@/lib/services/provisioning-worker-health-monitor";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
@@ -22,14 +28,19 @@ async function runProvisioningWorkerHealthCheck(c: AppContext) {
     requireCronSecret(c);
 
     const { healthy, stale, health } = await monitorProvisioningWorkerHealth();
+    const fleet = await monitorDedicatedFleetLiveness();
 
     logger.info("[Provisioning Worker Health Cron] Heartbeat check completed", {
       healthy,
       stale,
       required: health.required,
+      fleetTotal: fleet.fleetTotal,
+      fleetRunning: fleet.fleetRunning,
+      fleetUnreachable: fleet.unreachable,
+      provisionSuccessRate: fleet.provisionSuccessRate,
     });
 
-    return c.json({ healthy, stale, health });
+    return c.json({ healthy, stale, health, fleet });
   } catch (error) {
     logger.error(
       "[Provisioning Worker Health Cron] Failed:",

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -58,6 +58,12 @@ __filename = '"/worker.js"'
 [observability]
 enabled = true
 
+# Querying these logs after the fact: the Observability query API silently caps
+# results (~50 events) with NO truncation signal — one wide query over a
+# multi-minute window can cover only its last seconds and look complete. Slice
+# the window (~5s slices) and aggregate before asserting absence or measuring a
+# rate (#22548). Same caveat is documented in scripts/admin/cf-tail.sh.
+
 # Logs and traces are configured separately. Keep logs complete for production
 # diagnostics while sampling distributed traces to bound storage volume.
 [observability.logs]

--- a/packages/cloud/scripts/admin/cf-tail.sh
+++ b/packages/cloud/scripts/admin/cf-tail.sh
@@ -3,6 +3,13 @@
 #   bash packages/cloud/scripts/admin/cf-tail.sh             -> production
 #   bash packages/cloud/scripts/admin/cf-tail.sh staging     -> staging
 #   bash packages/cloud/scripts/admin/cf-tail.sh pr-123      -> PR preview Worker
+#
+# WARNING — Workers Observability query truncation (#22548): the historical
+# query API silently caps results (~50 events) with NO truncation signal. A
+# single wide query over a multi-minute window can return only the last few
+# seconds and look complete; the same window queried in ~5-second slices
+# returns orders of magnitude more events. Never conclude "no events" (or
+# measure a rate) from one wide query — slice the window and sum the slices.
 set -eu
 
 ENV="${1:-prod}"

--- a/packages/cloud/shared/src/db/repositories/agent-backup-scheduler.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-scheduler.ts
@@ -180,6 +180,13 @@ function activeBackupLanes(activeStates: SQL): SQL {
  * authority. Before the first scheduled proof, activation completion starts
  * the exposure clock. A protected-but-not-yet-reconciled operation is excluded
  * only when the same strict manifest-v3 evidence used by reconciliation exists.
+ *
+ * `activation_phase` is RETAINED (not removed) as this gate's admission
+ * evidence, and the backup consequence of it never being written is explicit
+ * here rather than silent: a running dedicated row whose activation authority
+ * is incomplete is not eligible for capture, so it is counted as overdue
+ * immediately and stays visible in this number instead of dropping out of
+ * scheduling unobserved (#22548).
  */
 export async function countOverdueAgentBackupSchedules(): Promise<number> {
   const protectedStates = sql.join(

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -37,14 +37,17 @@ let selectRowBatches: unknown[][] = [];
 function chainableRows(): unknown[] & {
   limit: () => unknown[];
   orderBy: () => unknown[] & { limit: () => unknown[]; orderBy: () => unknown[] };
+  groupBy: () => unknown[];
 } {
   const sourceRows = selectRowBatches.length > 0 ? selectRowBatches.shift() : selectRows;
   const rows = [...(sourceRows ?? [])] as unknown[] & {
     limit: () => unknown[];
     orderBy: () => unknown[] & { limit: () => unknown[]; orderBy: () => unknown[] };
+    groupBy: () => unknown[];
   };
   rows.limit = () => rows;
   rows.orderBy = () => rows;
+  rows.groupBy = () => rows;
   return rows;
 }
 
@@ -280,6 +283,35 @@ describe("AgentSandboxesRepository", () => {
     // eq/ne bind their operands, so the values land in `params`, not the SQL.
     expect(query.params).toContain("running");
     expect(query.params).toContain("shared");
+    // #22548: soft-deleted rows and unclaimed warm-pool rows must never be
+    // dialed — both guards are present, matching the sibling predicates.
+    expect(sql).toContain("deleted_at");
+    expect(sql).toContain("pool_status");
+    expect((sql.match(/is null/g) ?? []).length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("dedicated fleet census covers every status of the non-deleted dedicated fleet (#22548)", async () => {
+    capturedWhere = undefined;
+
+    const { AgentSandboxesRepository } = await import("./agent-sandboxes");
+
+    await new AgentSandboxesRepository().summarizeDedicatedFleet();
+
+    if (!capturedWhere) throw new Error("summarizeDedicatedFleet did not build a where clause");
+    const query = new PgDialect().sqlToQuery(capturedWhere);
+    const sql = query.sql.toLowerCase();
+    // The census must NOT filter on status: the whole point is to see a fleet
+    // whose every row sits in `error`, which the heartbeat sweep cannot.
+    expect(sql).not.toContain('"status"');
+    expect(query.params).not.toContain("running");
+    // Shared-tier rows are container-free by design and excluded.
+    expect(sql).toContain("execution_tier");
+    expect(sql).toContain("<>");
+    expect(query.params).toContain("shared");
+    // Deleted and warm-pool rows are not tenant-serving fleet.
+    expect(sql).toContain("deleted_at");
+    expect(sql).toContain("pool_status");
+    expect((sql.match(/is null/g) ?? []).length).toBeGreaterThanOrEqual(2);
   });
 
   test("heartbeat writeback is fenced to the exact running generation and loses to deletion", async () => {

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -34,20 +34,25 @@ const ensureAgentSandboxSchema = mock(async () => {});
 let selectRows: unknown[] = [];
 let selectRowBatches: unknown[][] = [];
 
+let capturedGroupBy: unknown[] = [];
+
 function chainableRows(): unknown[] & {
   limit: () => unknown[];
   orderBy: () => unknown[] & { limit: () => unknown[]; orderBy: () => unknown[] };
-  groupBy: () => unknown[];
+  groupBy: (...columns: unknown[]) => unknown[];
 } {
   const sourceRows = selectRowBatches.length > 0 ? selectRowBatches.shift() : selectRows;
   const rows = [...(sourceRows ?? [])] as unknown[] & {
     limit: () => unknown[];
     orderBy: () => unknown[] & { limit: () => unknown[]; orderBy: () => unknown[] };
-    groupBy: () => unknown[];
+    groupBy: (...columns: unknown[]) => unknown[];
   };
   rows.limit = () => rows;
   rows.orderBy = () => rows;
-  rows.groupBy = () => rows;
+  rows.groupBy = (...columns: unknown[]) => {
+    capturedGroupBy = columns;
+    return rows;
+  };
   return rows;
 }
 
@@ -290,8 +295,10 @@ describe("AgentSandboxesRepository", () => {
     expect((sql.match(/is null/g) ?? []).length).toBeGreaterThanOrEqual(2);
   });
 
-  test("dedicated fleet census covers every status of the non-deleted dedicated fleet (#22548)", async () => {
+  test("dedicated fleet census groups by tier AND status over the container-backed fleet (#22548)", async () => {
     capturedWhere = undefined;
+    capturedGroupBy = [];
+    select.mockClear();
 
     const { AgentSandboxesRepository } = await import("./agent-sandboxes");
 
@@ -300,18 +307,39 @@ describe("AgentSandboxesRepository", () => {
     if (!capturedWhere) throw new Error("summarizeDedicatedFleet did not build a where clause");
     const query = new PgDialect().sqlToQuery(capturedWhere);
     const sql = query.sql.toLowerCase();
-    // The census must NOT filter on status: the whole point is to see a fleet
-    // whose every row sits in `error`, which the heartbeat sweep cannot.
+
+    // The census must NOT filter on status: the caller applies the serving
+    // contract, and it needs the off-state counts (sleeping/stopped) to tell
+    // "no agents exist" from "all are asleep". A fleet whose every row sits in
+    // `error` — invisible to the heartbeat sweep — must still be counted.
     expect(sql).not.toContain('"status"');
     expect(query.params).not.toContain("running");
-    // Shared-tier rows are container-free by design and excluded.
+
+    // The tier filter is an explicit allowlist, not `<> 'shared'`, so a tier
+    // added later cannot silently enroll itself in the paging census.
     expect(sql).toContain("execution_tier");
-    expect(sql).toContain("<>");
-    expect(query.params).toContain("shared");
+    expect(sql).toContain("in (");
+    expect(sql).not.toContain("<>");
+    expect(query.params).toContain("dedicated-lazy");
+    expect(query.params).toContain("dedicated-always");
+    expect(query.params).toContain("custom");
+    expect(query.params).not.toContain("shared");
+
     // Deleted and warm-pool rows are not tenant-serving fleet.
     expect(sql).toContain("deleted_at");
     expect(sql).toContain("pool_status");
     expect((sql.match(/is null/g) ?? []).length).toBeGreaterThanOrEqual(2);
+
+    // Tier must be both projected and grouped: a status-only census cannot
+    // distinguish a sleeping lazy agent (fine) from a sleeping always-on one.
+    const lastSelectArgs = select.mock.calls.at(-1) as unknown as unknown[] | undefined;
+    const projection = lastSelectArgs?.[0] as Record<string, unknown> | undefined;
+    expect(Object.keys(projection ?? {})).toEqual(
+      expect.arrayContaining(["execution_tier", "status", "count"]),
+    );
+    expect(capturedGroupBy).toHaveLength(2);
+    const groupedNames = capturedGroupBy.map((column) => (column as { name?: string }).name);
+    expect(groupedNames).toEqual(expect.arrayContaining(["execution_tier", "status"]));
   });
 
   test("heartbeat writeback is fenced to the exact running generation and loses to deletion", async () => {

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -499,6 +499,11 @@ export class AgentSandboxesRepository {
    * (node_id / container_name are NULL by design), so there is nothing to
    * dial over the Headscale tunnel — heartbeating them only ever fails and
    * spams the logs. Only dedicated/custom tiers have a real container.
+   *
+   * Soft-deleted rows and unclaimed warm-pool rows are excluded like the
+   * sibling predicates in this file: neither belongs to a tenant-serving
+   * agent, so dialing them wastes cycles and pollutes heartbeat telemetry
+   * (#22548).
    */
   async listRunning(): Promise<Array<{ id: string; organization_id: string }>> {
     return dbRead
@@ -508,8 +513,40 @@ export class AgentSandboxesRepository {
       })
       .from(agentSandboxes)
       .where(
-        and(eq(agentSandboxes.status, "running"), ne(agentSandboxes.execution_tier, "shared")),
+        and(
+          eq(agentSandboxes.status, "running"),
+          ne(agentSandboxes.execution_tier, "shared"),
+          isNull(agentSandboxes.deleted_at),
+          isNull(agentSandboxes.pool_status),
+        ),
       );
+  }
+
+  /**
+   * Status census of the dedicated (non-shared) tenant fleet, for the
+   * fleet-liveness monitor (#22548). Counts every non-deleted, non-warm-pool
+   * dedicated row grouped by status so a caller can answer "do dedicated
+   * agents exist that should be reachable and are not?" — a question the
+   * heartbeat sweep structurally cannot ask, because a fleet whose every row
+   * sits in `error` gives it nothing to iterate and it reports healthy by
+   * having nothing to say.
+   */
+  async summarizeDedicatedFleet(): Promise<Array<{ status: string; count: number }>> {
+    await ensureAgentSandboxSchema();
+    return dbRead
+      .select({
+        status: agentSandboxes.status,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(agentSandboxes)
+      .where(
+        and(
+          ne(agentSandboxes.execution_tier, "shared"),
+          isNull(agentSandboxes.deleted_at),
+          isNull(agentSandboxes.pool_status),
+        ),
+      )
+      .groupBy(agentSandboxes.status);
   }
 
   /**

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -68,6 +68,7 @@ import {
   type AgentSandboxStatus,
   agentSandboxBackups,
   agentSandboxes,
+  CONTAINER_BACKED_EXECUTION_TIERS,
   type NewAgentSandbox,
   type NewAgentSandboxBackup,
   type StoredAgentSandboxBackup,
@@ -523,30 +524,45 @@ export class AgentSandboxesRepository {
   }
 
   /**
-   * Status census of the dedicated (non-shared) tenant fleet, for the
-   * fleet-liveness monitor (#22548). Counts every non-deleted, non-warm-pool
-   * dedicated row grouped by status so a caller can answer "do dedicated
-   * agents exist that should be reachable and are not?" — a question the
-   * heartbeat sweep structurally cannot ask, because a fleet whose every row
-   * sits in `error` gives it nothing to iterate and it reports healthy by
-   * having nothing to say.
+   * Tier x status census of the container-backed tenant fleet, for the
+   * fleet-liveness monitor (#22548). Grouping by BOTH keys is the point: the
+   * monitor cannot decide whether a row "should be reachable right now" from
+   * its status alone, because the tiers carry different serving contracts —
+   * `dedicated-lazy` is allowed to sleep, `dedicated-always`/`custom` are not.
+   * The caller applies that contract with `isFleetRowExpectedReachable`.
+   *
+   * The tier filter is an explicit allowlist rather than `<> 'shared'` so a
+   * tier added later cannot silently join the paging census: shared rows are
+   * container-free by design, and any new tier must state its own serving
+   * contract before it can raise a fleet alarm. Soft-deleted rows and
+   * unclaimed warm-pool rows are excluded because neither belongs to a
+   * tenant-serving agent.
+   *
+   * Status is deliberately NOT filtered here: the monitor needs the off-state
+   * counts (`sleeping`, `stopped`, ...) to report the whole fleet picture
+   * alongside the alarm, and a fleet whose every row sits in `error` — the
+   * exact shape the heartbeat sweep cannot see, since it iterates only
+   * `running` rows — must still appear in the census.
    */
-  async summarizeDedicatedFleet(): Promise<Array<{ status: string; count: number }>> {
+  async summarizeDedicatedFleet(): Promise<
+    Array<{ execution_tier: string; status: string; count: number }>
+  > {
     await ensureAgentSandboxSchema();
     return dbRead
       .select({
+        execution_tier: agentSandboxes.execution_tier,
         status: agentSandboxes.status,
         count: sql<number>`count(*)::int`,
       })
       .from(agentSandboxes)
       .where(
         and(
-          ne(agentSandboxes.execution_tier, "shared"),
+          inArray(agentSandboxes.execution_tier, [...CONTAINER_BACKED_EXECUTION_TIERS]),
           isNull(agentSandboxes.deleted_at),
           isNull(agentSandboxes.pool_status),
         ),
       )
-      .groupBy(agentSandboxes.status);
+      .groupBy(agentSandboxes.execution_tier, agentSandboxes.status);
   }
 
   /**

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -1931,6 +1931,24 @@ export class JobsRepository {
       .limit(1);
     return rows[0]?.created_at ?? null;
   }
+
+  /**
+   * Outcome census of jobs of `type` created since `since`, grouped by
+   * status. Powers the fleet-liveness monitor's provisioning success rate
+   * (#22548): provisioning health is measured on the `jobs` ledger itself
+   * (`type='agent_provision'`), not on sandbox `status`, which is written at
+   * INSERT and therefore cannot testify to provisioning success.
+   */
+  async summarizeOutcomesByTypeSince(
+    type: string,
+    since: Date,
+  ): Promise<Array<{ status: string; count: number }>> {
+    return dbRead
+      .select({ status: jobs.status, count: sql<number>`count(*)::int` })
+      .from(jobs)
+      .where(and(eq(jobs.type, type), sql`${jobs.created_at} >= ${since}`))
+      .groupBy(jobs.status);
+  }
 }
 
 // Singleton instance

--- a/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
@@ -113,6 +113,18 @@ export type AgentBillingStatus = "active" | "warning" | "suspended" | "shutdown_
  * have containers. See services/shared-runtime/agent-tier.ts for derivation.
  */
 export type AgentExecutionTier = "shared" | "dedicated-lazy" | "dedicated-always" | "custom";
+
+/**
+ * Tiers that own a real container. Every tier except "shared" is here today,
+ * but the list is an explicit allowlist rather than a "not shared" test so
+ * that adding a tier is a deliberate decision at each container-scoped query
+ * (heartbeat dialing, fleet liveness) instead of a silent enrollment.
+ */
+export const CONTAINER_BACKED_EXECUTION_TIERS = [
+  "dedicated-lazy",
+  "dedicated-always",
+  "custom",
+] as const satisfies readonly AgentExecutionTier[];
 export type WarmClaimCredentialState = "pending" | "attested" | "ready" | "failed";
 export type AgentActivationPurpose = "provision" | "wake" | "restore" | "fresh_boot";
 export type AgentActivationPhase =

--- a/packages/cloud/shared/src/lib/services/__tests__/dedicated-fleet-liveness.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/dedicated-fleet-liveness.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit coverage for the dedicated-fleet liveness monitor (#22548): the alarm
+ * shape "dedicated agents exist and none is serving", the jobs-ledger
+ * provisioning success rate, and the no-data-is-not-100% rule. Deterministic:
+ * repositories and the alert channel are injected; no database.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  DEDICATED_FLEET_UNREACHABLE_DEDUP_KEY,
+  monitorDedicatedFleetLiveness,
+  PROVISION_SUCCESS_WINDOW_MS,
+} from "../dedicated-fleet-liveness";
+import type { DaemonHealthAlert } from "../provisioning-worker-health-monitor";
+
+function harness(overrides: {
+  fleet?: Array<{ status: string; count: number }>;
+  jobs?: Array<{ status: string; count: number }>;
+}) {
+  const alerts: DaemonHealthAlert[] = [];
+  const sinceSeen: Date[] = [];
+  const nowMs = Date.parse("2026-08-20T12:00:00.000Z");
+  const run = () =>
+    monitorDedicatedFleetLiveness({
+      summarizeFleet: async () => overrides.fleet ?? [],
+      summarizeProvisionJobs: async (since) => {
+        sinceSeen.push(since);
+        return overrides.jobs ?? [];
+      },
+      alert: (a) => {
+        alerts.push(a);
+      },
+      now: () => nowMs,
+    });
+  return { run, alerts, sinceSeen, nowMs };
+}
+
+describe("monitorDedicatedFleetLiveness", () => {
+  test("alerts when dedicated agents exist and none is running (the 36h-outage shape)", async () => {
+    const h = harness({ fleet: [{ status: "error", count: 26 }] });
+    const result = await h.run();
+
+    expect(result.unreachable).toBe(true);
+    expect(result.fleetTotal).toBe(26);
+    expect(result.fleetRunning).toBe(0);
+    expect(h.alerts).toHaveLength(1);
+    const alert = h.alerts[0];
+    if (!alert) throw new Error("expected an alert");
+    expect(alert.dedupKey).toBe(DEDICATED_FLEET_UNREACHABLE_DEDUP_KEY);
+    expect(alert.details.code).toBe("DEDICATED_FLEET_UNREACHABLE");
+    expect(alert.details.fleetTotal).toBe(26);
+  });
+
+  test("stays quiet while at least one dedicated agent serves", async () => {
+    const h = harness({
+      fleet: [
+        { status: "error", count: 25 },
+        { status: "running", count: 1 },
+      ],
+    });
+    const result = await h.run();
+
+    expect(result.unreachable).toBe(false);
+    expect(result.fleetRunning).toBe(1);
+    expect(h.alerts).toHaveLength(0);
+  });
+
+  test("an empty dedicated fleet is not an outage", async () => {
+    const h = harness({ fleet: [] });
+    const result = await h.run();
+
+    expect(result.unreachable).toBe(false);
+    expect(result.fleetTotal).toBe(0);
+    expect(h.alerts).toHaveLength(0);
+  });
+
+  test("provisioning success is measured on the jobs ledger over the trailing window", async () => {
+    const h = harness({
+      fleet: [{ status: "running", count: 3 }],
+      jobs: [
+        { status: "completed", count: 6 },
+        { status: "failed", count: 2 },
+        { status: "in_progress", count: 1 },
+      ],
+    });
+    const result = await h.run();
+
+    expect(result.provisionCompleted).toBe(6);
+    expect(result.provisionFailed).toBe(2);
+    expect(result.provisionSuccessRate).toBe(0.75);
+    expect(result.provisionJobsByStatus.in_progress).toBe(1);
+    // The window must be anchored to the injected clock, not the wall clock.
+    expect(h.sinceSeen[0]?.getTime()).toBe(h.nowMs - PROVISION_SUCCESS_WINDOW_MS);
+  });
+
+  test("no settled provision jobs yields null success rate, not a healthy-looking 100%", async () => {
+    const h = harness({
+      fleet: [{ status: "running", count: 1 }],
+      jobs: [{ status: "in_progress", count: 2 }],
+    });
+    const result = await h.run();
+
+    expect(result.provisionSuccessRate).toBeNull();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/dedicated-fleet-liveness.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/dedicated-fleet-liveness.test.ts
@@ -1,19 +1,50 @@
 /**
- * Unit coverage for the dedicated-fleet liveness monitor (#22548): the alarm
- * shape "dedicated agents exist and none is serving", the jobs-ledger
- * provisioning success rate, and the no-data-is-not-100% rule. Deterministic:
- * repositories and the alert channel are injected; no database.
+ * Unit coverage for the dedicated-fleet liveness monitor (#22548): the serving
+ * contract that decides which (tier, lifecycle) rows may raise the alarm, the
+ * alarm shape "agents that should be reachable exist and none is serving", the
+ * jobs-ledger provisioning success rate, and the no-data-is-not-100% rule.
+ * Deterministic: repositories and the alert channel are injected; no database.
+ * The repository-level SQL contract this consumes is proven separately in
+ * `db/repositories/agent-sandboxes.test.ts`.
  */
 import { describe, expect, test } from "bun:test";
+import type { AgentExecutionTier, AgentSandboxStatus } from "../../../db/schemas/agent-sandboxes";
 import {
   DEDICATED_FLEET_UNREACHABLE_DEDUP_KEY,
+  type FleetCensusRow,
+  isFleetRowExpectedReachable,
   monitorDedicatedFleetLiveness,
   PROVISION_SUCCESS_WINDOW_MS,
 } from "../dedicated-fleet-liveness";
 import type { DaemonHealthAlert } from "../provisioning-worker-health-monitor";
 
+const ALL_TIERS: AgentExecutionTier[] = ["shared", "dedicated-lazy", "dedicated-always", "custom"];
+
+const ALL_STATUSES: AgentSandboxStatus[] = [
+  "pending",
+  "provisioning",
+  "running",
+  "stopped",
+  "sleeping",
+  "disconnected",
+  "error",
+  "deletion_pending",
+  "deletion_failed",
+];
+
+/** The statuses in which a row asserts that a live container should exist. */
+const REACHABLE_STATUSES = new Set<string>(["running", "disconnected", "error"]);
+
+function row(
+  execution_tier: AgentExecutionTier,
+  status: AgentSandboxStatus,
+  count: number,
+): FleetCensusRow {
+  return { execution_tier, status, count };
+}
+
 function harness(overrides: {
-  fleet?: Array<{ status: string; count: number }>;
+  fleet?: FleetCensusRow[];
   jobs?: Array<{ status: string; count: number }>;
 }) {
   const alerts: DaemonHealthAlert[] = [];
@@ -34,33 +65,108 @@ function harness(overrides: {
   return { run, alerts, sinceSeen, nowMs };
 }
 
+describe("isFleetRowExpectedReachable", () => {
+  test("the serving contract is exhaustive over every tier x lifecycle pair", () => {
+    for (const tier of ALL_TIERS) {
+      for (const status of ALL_STATUSES) {
+        const expected = tier !== "shared" && REACHABLE_STATUSES.has(status);
+        expect({ tier, status, live: isFleetRowExpectedReachable(tier, status) }).toEqual({
+          tier,
+          status,
+          live: expected,
+        });
+      }
+    }
+  });
+
+  test("a sleeping dedicated-lazy agent is contractually off, not unreachable", () => {
+    expect(isFleetRowExpectedReachable("dedicated-lazy", "sleeping")).toBe(false);
+    expect(isFleetRowExpectedReachable("dedicated-lazy", "stopped")).toBe(false);
+    // But once woken it holds a live container like any other tier.
+    expect(isFleetRowExpectedReachable("dedicated-lazy", "running")).toBe(true);
+    expect(isFleetRowExpectedReachable("dedicated-lazy", "error")).toBe(true);
+  });
+
+  test("an unknown tier cannot enroll itself in the paging census", () => {
+    expect(isFleetRowExpectedReachable("dedicated-burst", "error")).toBe(false);
+  });
+});
+
 describe("monitorDedicatedFleetLiveness", () => {
-  test("alerts when dedicated agents exist and none is running (the 36h-outage shape)", async () => {
-    const h = harness({ fleet: [{ status: "error", count: 26 }] });
+  test("alerts when agents that should be reachable exist and none is running (the 36h-outage shape)", async () => {
+    const h = harness({ fleet: [row("dedicated-always", "error", 26)] });
     const result = await h.run();
 
     expect(result.unreachable).toBe(true);
-    expect(result.fleetTotal).toBe(26);
-    expect(result.fleetRunning).toBe(0);
+    expect(result.expectedReachableTotal).toBe(26);
+    expect(result.expectedReachableRunning).toBe(0);
     expect(h.alerts).toHaveLength(1);
     const alert = h.alerts[0];
     if (!alert) throw new Error("expected an alert");
     expect(alert.dedupKey).toBe(DEDICATED_FLEET_UNREACHABLE_DEDUP_KEY);
     expect(alert.details.code).toBe("DEDICATED_FLEET_UNREACHABLE");
-    expect(alert.details.fleetTotal).toBe(26);
+    expect(alert.details.expectedReachableTotal).toBe(26);
   });
 
-  test("stays quiet while at least one dedicated agent serves", async () => {
+  test("a fleet of healthy SLEEPING dedicated-lazy agents never pages", async () => {
+    const h = harness({
+      fleet: [row("dedicated-lazy", "sleeping", 40), row("dedicated-lazy", "stopped", 5)],
+    });
+    const result = await h.run();
+
+    // The rows exist and none is `running` — the old predicate paged here.
+    expect(result.fleetTotal).toBe(45);
+    expect(result.expectedReachableTotal).toBe(0);
+    expect(result.offContractTotal).toBe(45);
+    expect(result.unreachable).toBe(false);
+    expect(h.alerts).toHaveLength(0);
+  });
+
+  test("stopped, deletion-bound, and not-yet-provisioned rows are all off-contract", async () => {
     const h = harness({
       fleet: [
-        { status: "error", count: 25 },
-        { status: "running", count: 1 },
+        row("dedicated-always", "stopped", 3),
+        row("custom", "deletion_pending", 2),
+        row("custom", "deletion_failed", 1),
+        row("dedicated-always", "pending", 4),
+        row("dedicated-always", "provisioning", 6),
       ],
     });
     const result = await h.run();
 
+    expect(result.fleetTotal).toBe(16);
+    expect(result.expectedReachableTotal).toBe(0);
     expect(result.unreachable).toBe(false);
-    expect(result.fleetRunning).toBe(1);
+    expect(h.alerts).toHaveLength(0);
+  });
+
+  test("an always-on fleet in error pages even while lazy agents sleep healthily beside it", async () => {
+    const h = harness({
+      fleet: [
+        row("dedicated-lazy", "sleeping", 100),
+        row("dedicated-always", "error", 4),
+        row("custom", "disconnected", 2),
+      ],
+    });
+    const result = await h.run();
+
+    expect(result.unreachable).toBe(true);
+    expect(result.expectedReachableTotal).toBe(6);
+    expect(result.offContractTotal).toBe(100);
+    expect(result.fleetByTierStatus["dedicated-lazy:sleeping"]).toBe(100);
+    expect(h.alerts).toHaveLength(1);
+    // The operator must be able to see the sleeping majority is NOT the alarm.
+    expect(h.alerts[0]?.details.offContractTotal).toBe(100);
+  });
+
+  test("one serving row anywhere in the live census silences the alarm", async () => {
+    const h = harness({
+      fleet: [row("dedicated-always", "error", 25), row("dedicated-lazy", "running", 1)],
+    });
+    const result = await h.run();
+
+    expect(result.unreachable).toBe(false);
+    expect(result.expectedReachableRunning).toBe(1);
     expect(h.alerts).toHaveLength(0);
   });
 
@@ -70,12 +176,13 @@ describe("monitorDedicatedFleetLiveness", () => {
 
     expect(result.unreachable).toBe(false);
     expect(result.fleetTotal).toBe(0);
+    expect(result.expectedReachableTotal).toBe(0);
     expect(h.alerts).toHaveLength(0);
   });
 
   test("provisioning success is measured on the jobs ledger over the trailing window", async () => {
     const h = harness({
-      fleet: [{ status: "running", count: 3 }],
+      fleet: [row("dedicated-always", "running", 3)],
       jobs: [
         { status: "completed", count: 6 },
         { status: "failed", count: 2 },
@@ -94,11 +201,23 @@ describe("monitorDedicatedFleetLiveness", () => {
 
   test("no settled provision jobs yields null success rate, not a healthy-looking 100%", async () => {
     const h = harness({
-      fleet: [{ status: "running", count: 1 }],
+      fleet: [row("dedicated-always", "running", 1)],
       jobs: [{ status: "in_progress", count: 2 }],
     });
     const result = await h.run();
 
     expect(result.provisionSuccessRate).toBeNull();
+  });
+
+  test("a census failure propagates instead of reporting a fabricated healthy fleet", async () => {
+    await expect(
+      monitorDedicatedFleetLiveness({
+        summarizeFleet: async () => {
+          throw new Error("census query failed");
+        },
+        summarizeProvisionJobs: async () => [],
+        alert: () => {},
+      }),
+    ).rejects.toThrow("census query failed");
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/provision-duration-estimate.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/provision-duration-estimate.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Guards the user-facing provisioning duration estimate against drifting
+ * below the real health-check budget again (#22548): the old flat 90s
+ * estimate assumed a 60s health check against docker-sandbox-provider's real
+ * 360s timeout, so users were told an in-budget job was "still in progress
+ * after 362s". Deterministic constant assertions; no I/O.
+ */
+import { expect, test } from "bun:test";
+import { HEALTH_CHECK_TIMEOUT_MS } from "../docker-sandbox-provider";
+import {
+  CONTAINER_HEALTH_CHECK_BUDGET_MS,
+  CONTAINER_LIFECYCLE_ESTIMATED_DURATION_MS,
+} from "../provisioning-jobs";
+
+test("provisioning-jobs' mirrored health budget equals docker-sandbox-provider's timeout", () => {
+  // provisioning-jobs cannot import docker-sandbox-provider (node-only deps
+  // in the Worker bundle), so it mirrors the value; this pins the mirror.
+  expect(CONTAINER_HEALTH_CHECK_BUDGET_MS).toBe(HEALTH_CHECK_TIMEOUT_MS);
+});
+
+test("the user-facing lifecycle estimate covers the full health-check budget", () => {
+  expect(CONTAINER_LIFECYCLE_ESTIMATED_DURATION_MS).toBeGreaterThanOrEqual(HEALTH_CHECK_TIMEOUT_MS);
+});

--- a/packages/cloud/shared/src/lib/services/dedicated-fleet-liveness.ts
+++ b/packages/cloud/shared/src/lib/services/dedicated-fleet-liveness.ts
@@ -1,0 +1,124 @@
+/**
+ * Dedicated-fleet liveness monitor: answers on a schedule the question no
+ * other sweep asks — "do dedicated agents exist that should be reachable and
+ * are not?" (#22548). The heartbeat cycle iterates only `running` dedicated
+ * rows, so a fleet whose every row sits in `error` gives it nothing to
+ * iterate and it reports healthy by having nothing to say; a 36-hour total
+ * outage of the dedicated product produced silence that way. This monitor
+ * looks at the whole non-deleted dedicated census instead and alerts when
+ * the fleet is non-empty with zero rows serving.
+ *
+ * It also publishes provisioning success measured on the `jobs` ledger
+ * (`type='agent_provision'`) rather than on sandbox `status`, which is
+ * written at INSERT and cannot testify to provisioning success. Invoked
+ * every minute from the Worker cron alongside the provisioning-worker
+ * heartbeat monitor; alert fan-out reuses the provisioning ops channels
+ * with its own PagerDuty dedup key so a sustained outage is one incident.
+ */
+
+import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
+import { jobsRepository } from "../../db/repositories/jobs";
+import { JOB_TYPES } from "./provisioning-job-types";
+import {
+  type DaemonHealthAlert,
+  sendProvisioningWorkerAlert,
+} from "./provisioning-worker-health-monitor";
+
+/** PagerDuty dedup key: one incident per unreachable-fleet episode. */
+export const DEDICATED_FLEET_UNREACHABLE_DEDUP_KEY = "dedicated-fleet-unreachable";
+
+/** Window over which provisioning success is measured on the jobs ledger. */
+export const PROVISION_SUCCESS_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export interface DedicatedFleetLiveness {
+  /** Non-deleted, non-warm-pool dedicated rows, total and by status. */
+  fleetTotal: number;
+  fleetRunning: number;
+  fleetByStatus: Record<string, number>;
+  /** True when dedicated agents exist and none is serving — the alarm shape. */
+  unreachable: boolean;
+  /** agent_provision job outcomes in the trailing window, by status. */
+  provisionWindowMs: number;
+  provisionJobsByStatus: Record<string, number>;
+  provisionCompleted: number;
+  provisionFailed: number;
+  /**
+   * completed / (completed + failed) over the window; null when no
+   * agent_provision job settled in the window (no data is not 100%).
+   */
+  provisionSuccessRate: number | null;
+}
+
+function toStatusCounts(rows: Array<{ status: string; count: number }>): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const row of rows) counts[row.status] = row.count;
+  return counts;
+}
+
+/**
+ * Compute the liveness DTO and alert when the fleet is unreachable.
+ * `deps` are injectable for tests; production uses the real repositories,
+ * the shared provisioning ops alert channels, and the wall clock.
+ */
+export async function monitorDedicatedFleetLiveness(
+  deps: {
+    summarizeFleet?: () => Promise<Array<{ status: string; count: number }>>;
+    summarizeProvisionJobs?: (since: Date) => Promise<Array<{ status: string; count: number }>>;
+    alert?: (alert: DaemonHealthAlert) => void | Promise<void>;
+    now?: () => number;
+  } = {},
+): Promise<DedicatedFleetLiveness> {
+  const summarizeFleet =
+    deps.summarizeFleet ?? (() => agentSandboxesRepository.summarizeDedicatedFleet());
+  const summarizeProvisionJobs =
+    deps.summarizeProvisionJobs ??
+    ((since: Date) =>
+      jobsRepository.summarizeOutcomesByTypeSince(JOB_TYPES.AGENT_PROVISION, since));
+  const alert = deps.alert ?? sendProvisioningWorkerAlert;
+  const nowMs = (deps.now ?? Date.now)();
+
+  const since = new Date(nowMs - PROVISION_SUCCESS_WINDOW_MS);
+  const [fleetRows, jobRows] = await Promise.all([summarizeFleet(), summarizeProvisionJobs(since)]);
+
+  const fleetByStatus = toStatusCounts(fleetRows);
+  const fleetTotal = Object.values(fleetByStatus).reduce((sum, n) => sum + n, 0);
+  const fleetRunning = fleetByStatus.running ?? 0;
+  const unreachable = fleetTotal > 0 && fleetRunning === 0;
+
+  const provisionJobsByStatus = toStatusCounts(jobRows);
+  const provisionCompleted = provisionJobsByStatus.completed ?? 0;
+  const provisionFailed = provisionJobsByStatus.failed ?? 0;
+  const settled = provisionCompleted + provisionFailed;
+  const provisionSuccessRate = settled > 0 ? provisionCompleted / settled : null;
+
+  if (unreachable) {
+    await alert({
+      title: "Dedicated agent fleet is unreachable",
+      message:
+        `${fleetTotal} dedicated agent${fleetTotal === 1 ? "" : "s"} exist and NONE is running — ` +
+        "every paid dedicated agent is currently unreachable. The heartbeat sweep iterates only " +
+        "running rows, so it cannot see this condition; treat it as a product outage, not noise.",
+      details: {
+        code: "DEDICATED_FLEET_UNREACHABLE",
+        fleetTotal,
+        fleetByStatus,
+        provisionSuccessRate,
+        provisionJobsByStatus,
+        provisionWindowMs: PROVISION_SUCCESS_WINDOW_MS,
+      },
+      dedupKey: DEDICATED_FLEET_UNREACHABLE_DEDUP_KEY,
+    });
+  }
+
+  return {
+    fleetTotal,
+    fleetRunning,
+    fleetByStatus,
+    unreachable,
+    provisionWindowMs: PROVISION_SUCCESS_WINDOW_MS,
+    provisionJobsByStatus,
+    provisionCompleted,
+    provisionFailed,
+    provisionSuccessRate,
+  };
+}

--- a/packages/cloud/shared/src/lib/services/dedicated-fleet-liveness.ts
+++ b/packages/cloud/shared/src/lib/services/dedicated-fleet-liveness.ts
@@ -4,9 +4,15 @@
  * are not?" (#22548). The heartbeat cycle iterates only `running` dedicated
  * rows, so a fleet whose every row sits in `error` gives it nothing to
  * iterate and it reports healthy by having nothing to say; a 36-hour total
- * outage of the dedicated product produced silence that way. This monitor
- * looks at the whole non-deleted dedicated census instead and alerts when
- * the fleet is non-empty with zero rows serving.
+ * outage of the dedicated product produced silence that way.
+ *
+ * "Should be reachable" is a contract, not a status string. The census this
+ * monitor pages on is scoped by BOTH axes — the tier's serving contract and
+ * the row's lifecycle state — because `dedicated-lazy` is explicitly allowed
+ * to sleep and `stopped`/`sleeping`/`deletion_*` rows are off on purpose. A
+ * fleet of healthy sleeping lazy agents must never page. Rows outside the
+ * expected-reachable census are still counted and reported, so the alert and
+ * the cron log carry the whole fleet picture, but they cannot raise the alarm.
  *
  * It also publishes provisioning success measured on the `jobs` ledger
  * (`type='agent_provision'`) rather than on sandbox `status`, which is
@@ -18,6 +24,7 @@
 
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { jobsRepository } from "../../db/repositories/jobs";
+import type { AgentExecutionTier, AgentSandboxStatus } from "../../db/schemas/agent-sandboxes";
 import { JOB_TYPES } from "./provisioning-job-types";
 import {
   type DaemonHealthAlert,
@@ -30,12 +37,82 @@ export const DEDICATED_FLEET_UNREACHABLE_DEDUP_KEY = "dedicated-fleet-unreachabl
 /** Window over which provisioning success is measured on the jobs ledger. */
 export const PROVISION_SUCCESS_WINDOW_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Lifecycle states in which a container-backed row asserts that a live
+ * container should exist right now:
+ *   running       — serving; the only state that satisfies the assertion.
+ *   disconnected  — was serving, tunnel dropped; should be reachable, is not.
+ *   error         — was meant to be up and failed; the 36h-outage shape.
+ *
+ * Everything else is deliberately excluded and can never raise the alarm:
+ * `sleeping`/`stopped` are contractual off-states (scale-to-zero, suspend,
+ * billing shutdown), `pending`/`provisioning` are not-yet-live, and
+ * `deletion_pending`/`deletion_failed` are on their way out — an operator
+ * already owns those, and a fleet of them is not an outage.
+ */
+export const FLEET_EXPECTED_REACHABLE_STATUSES = [
+  "running",
+  "disconnected",
+  "error",
+] as const satisfies readonly AgentSandboxStatus[];
+
+/**
+ * Tiers whose rows may raise the fleet alarm. `shared` is container-free and
+ * never enters the census at all (the repository query excludes it).
+ *
+ * `dedicated-lazy` is included but is NOT thereby claimed to be always-on:
+ * its right to sleep is enforced by the lifecycle axis above, which drops
+ * every sleeping/stopped lazy row from the census. A lazy row only counts
+ * once it has been woken and is therefore asserting a live container —
+ * exactly the state in which its unreachability is a real user-facing
+ * failure. `dedicated-always` and `custom` carry standing serving authority
+ * and count whenever they make the same assertion.
+ */
+export const FLEET_ALARM_TIERS = [
+  "dedicated-lazy",
+  "dedicated-always",
+  "custom",
+] as const satisfies readonly AgentExecutionTier[];
+
+/** One grouped census row as returned by the repository. */
+export interface FleetCensusRow {
+  execution_tier: string;
+  status: string;
+  count: number;
+}
+
+/**
+ * True when a row of this tier and lifecycle state is contractually supposed
+ * to be reachable at this instant. This is the whole liveness contract: the
+ * alarm counts only rows for which it answers true, so a fleet that is merely
+ * asleep, suspended, or being deleted cannot page.
+ */
+export function isFleetRowExpectedReachable(executionTier: string, status: string): boolean {
+  return (
+    (FLEET_ALARM_TIERS as readonly string[]).includes(executionTier) &&
+    (FLEET_EXPECTED_REACHABLE_STATUSES as readonly string[]).includes(status)
+  );
+}
+
 export interface DedicatedFleetLiveness {
-  /** Non-deleted, non-warm-pool dedicated rows, total and by status. */
+  /**
+   * Rows that should be reachable right now: container-backed tiers in a
+   * lifecycle state asserting a live container. This is the census the alarm
+   * is computed on.
+   */
+  expectedReachableTotal: number;
+  expectedReachableRunning: number;
+  expectedReachableByStatus: Record<string, number>;
+  /**
+   * Every non-deleted, non-warm-pool container-backed row, including the
+   * contractual off-states excluded from the alarm census. Reported for
+   * context so an operator can tell "no agents exist" from "all are asleep".
+   */
   fleetTotal: number;
-  fleetRunning: number;
-  fleetByStatus: Record<string, number>;
-  /** True when dedicated agents exist and none is serving — the alarm shape. */
+  fleetByTierStatus: Record<string, number>;
+  /** Rows that exist but are contractually off, and therefore not an alarm. */
+  offContractTotal: number;
+  /** True when agents that should be reachable exist and none is serving. */
   unreachable: boolean;
   /** agent_provision job outcomes in the trailing window, by status. */
   provisionWindowMs: number;
@@ -51,7 +128,7 @@ export interface DedicatedFleetLiveness {
 
 function toStatusCounts(rows: Array<{ status: string; count: number }>): Record<string, number> {
   const counts: Record<string, number> = {};
-  for (const row of rows) counts[row.status] = row.count;
+  for (const row of rows) counts[row.status] = (counts[row.status] ?? 0) + row.count;
   return counts;
 }
 
@@ -62,7 +139,7 @@ function toStatusCounts(rows: Array<{ status: string; count: number }>): Record<
  */
 export async function monitorDedicatedFleetLiveness(
   deps: {
-    summarizeFleet?: () => Promise<Array<{ status: string; count: number }>>;
+    summarizeFleet?: () => Promise<FleetCensusRow[]>;
     summarizeProvisionJobs?: (since: Date) => Promise<Array<{ status: string; count: number }>>;
     alert?: (alert: DaemonHealthAlert) => void | Promise<void>;
     now?: () => number;
@@ -78,12 +155,31 @@ export async function monitorDedicatedFleetLiveness(
   const nowMs = (deps.now ?? Date.now)();
 
   const since = new Date(nowMs - PROVISION_SUCCESS_WINDOW_MS);
-  const [fleetRows, jobRows] = await Promise.all([summarizeFleet(), summarizeProvisionJobs(since)]);
+  const [censusRows, jobRows] = await Promise.all([
+    summarizeFleet(),
+    summarizeProvisionJobs(since),
+  ]);
 
-  const fleetByStatus = toStatusCounts(fleetRows);
-  const fleetTotal = Object.values(fleetByStatus).reduce((sum, n) => sum + n, 0);
-  const fleetRunning = fleetByStatus.running ?? 0;
-  const unreachable = fleetTotal > 0 && fleetRunning === 0;
+  const fleetByTierStatus: Record<string, number> = {};
+  const expectedReachable: Array<{ status: string; count: number }> = [];
+  let fleetTotal = 0;
+  for (const row of censusRows) {
+    const key = `${row.execution_tier}:${row.status}`;
+    fleetByTierStatus[key] = (fleetByTierStatus[key] ?? 0) + row.count;
+    fleetTotal += row.count;
+    if (isFleetRowExpectedReachable(row.execution_tier, row.status)) {
+      expectedReachable.push({ status: row.status, count: row.count });
+    }
+  }
+
+  const expectedReachableByStatus = toStatusCounts(expectedReachable);
+  const expectedReachableTotal = Object.values(expectedReachableByStatus).reduce(
+    (sum, n) => sum + n,
+    0,
+  );
+  const expectedReachableRunning = expectedReachableByStatus.running ?? 0;
+  const offContractTotal = fleetTotal - expectedReachableTotal;
+  const unreachable = expectedReachableTotal > 0 && expectedReachableRunning === 0;
 
   const provisionJobsByStatus = toStatusCounts(jobRows);
   const provisionCompleted = provisionJobsByStatus.completed ?? 0;
@@ -95,13 +191,19 @@ export async function monitorDedicatedFleetLiveness(
     await alert({
       title: "Dedicated agent fleet is unreachable",
       message:
-        `${fleetTotal} dedicated agent${fleetTotal === 1 ? "" : "s"} exist and NONE is running — ` +
-        "every paid dedicated agent is currently unreachable. The heartbeat sweep iterates only " +
-        "running rows, so it cannot see this condition; treat it as a product outage, not noise.",
+        `${expectedReachableTotal} dedicated agent${expectedReachableTotal === 1 ? "" : "s"} ` +
+        "should be reachable right now and NONE is running — every dedicated agent that is " +
+        "contractually live is currently unreachable. The heartbeat sweep iterates only running " +
+        "rows, so it cannot see this condition; treat it as a product outage, not noise. " +
+        `${offContractTotal} further row(s) are contractually off (asleep/suspended/deleting) ` +
+        "and are excluded from this count.",
       details: {
         code: "DEDICATED_FLEET_UNREACHABLE",
+        expectedReachableTotal,
+        expectedReachableByStatus,
         fleetTotal,
-        fleetByStatus,
+        fleetByTierStatus,
+        offContractTotal,
         provisionSuccessRate,
         provisionJobsByStatus,
         provisionWindowMs: PROVISION_SUCCESS_WINDOW_MS,
@@ -111,9 +213,12 @@ export async function monitorDedicatedFleetLiveness(
   }
 
   return {
+    expectedReachableTotal,
+    expectedReachableRunning,
+    expectedReachableByStatus,
     fleetTotal,
-    fleetRunning,
-    fleetByStatus,
+    fleetByTierStatus,
+    offContractTotal,
     unreachable,
     provisionWindowMs: PROVISION_SUCCESS_WINDOW_MS,
     provisionJobsByStatus,

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -1068,6 +1068,25 @@ const SETTLEMENT_RETRY_MAX_MS = 5_000;
 const UNREACHABLE_BRIDGE_SENTINEL = "http://127.0.0.1:65535";
 
 /**
+ * Health-check budget a container lifecycle job may legitimately spend
+ * waiting for `/api/health`. Mirrors docker-sandbox-provider's
+ * `HEALTH_CHECK_TIMEOUT_MS` (360s) WITHOUT importing it — that module drags
+ * node-only deps (ssh2) into the Worker bundle. A guarding test
+ * (`provision-duration-estimate.test.ts`) asserts the two stay equal.
+ */
+export const CONTAINER_HEALTH_CHECK_BUDGET_MS = 360_000;
+
+/**
+ * User-facing duration estimate for container lifecycle jobs (provision /
+ * restart / restore / fresh-boot). The old flat 90s estimate assumed a 60s
+ * health check against the real 360s budget, so users were told a healthy
+ * in-budget job was "still in progress after 362s" (#22548). Estimate the
+ * real worst case: DB assignment + docker pull/run (~30s) + full health
+ * budget.
+ */
+export const CONTAINER_LIFECYCLE_ESTIMATED_DURATION_MS = 30_000 + CONTAINER_HEALTH_CHECK_BUDGET_MS;
+
+/**
  * Per-job execution timeout for the `withTimeout(executeJob(job), …)` wrap,
  * BY JOB TYPE (#10919).
  *
@@ -1656,8 +1675,7 @@ export class ProvisioningJobService {
       userId: params.userId,
       webhookUrl: params.webhookUrl,
       maxAttempts: 3,
-      // DB assignment + Docker pull/run (10-30s) + health check (up to 60s)
-      estimatedDurationMs: 90_000,
+      estimatedDurationMs: CONTAINER_LIFECYCLE_ESTIMATED_DURATION_MS,
       logName: "agent_provision",
       validateSandbox:
         expected !== undefined
@@ -2067,9 +2085,9 @@ export class ProvisioningJobService {
       userId: params.userId,
       webhookUrl: params.webhookUrl,
       maxAttempts: 3,
-      // docker start is ~5s on the fast path, full re-provision is ~60s.
-      // Budget the long path so the UI doesn't show a stuck estimate.
-      estimatedDurationMs: 90_000,
+      // docker start is ~5s on the fast path; budget the full re-provision
+      // path so the UI doesn't show a stuck estimate.
+      estimatedDurationMs: CONTAINER_LIFECYCLE_ESTIMATED_DURATION_MS,
       logName: "agent_resume",
       beforeInsert: async (tx) => {
         const supersededAt = new Date();
@@ -2156,8 +2174,8 @@ export class ProvisioningJobService {
       userId: params.userId,
       webhookUrl: params.webhookUrl,
       maxAttempts: 3,
-      // Fresh provision (~60-90s) + state restore.
-      estimatedDurationMs: 90_000,
+      // Fresh provision + state restore.
+      estimatedDurationMs: CONTAINER_LIFECYCLE_ESTIMATED_DURATION_MS,
       logName: "agent_wake",
       // Reusing an in-flight wake keeps ITS params and drops the caller's. A
       // bare retry ("wake me") may ride whatever is already running, but a
@@ -2229,8 +2247,8 @@ export class ProvisioningJobService {
       userId: params.userId,
       webhookUrl: params.webhookUrl,
       maxAttempts: 3,
-      // shutdown ~5s + provision ~60s; budget the long path.
-      estimatedDurationMs: 90_000,
+      // shutdown ~5s + full provision; budget the long path.
+      estimatedDurationMs: CONTAINER_LIFECYCLE_ESTIMATED_DURATION_MS,
       logName: "agent_restart",
     });
   }
@@ -2288,7 +2306,7 @@ export class ProvisioningJobService {
           organizationId: candidate.organization_id,
           userId: candidate.user_id,
           maxAttempts: 3,
-          estimatedDurationMs: 90_000,
+          estimatedDurationMs: CONTAINER_LIFECYCLE_ESTIMATED_DURATION_MS,
           logName: "legacy_warm_claim_recovery",
           mutuallyExclusiveJobTypes: [
             ...ADMIN_CANARY_CONFLICTING_JOB_TYPES,
@@ -2374,7 +2392,7 @@ export class ProvisioningJobService {
           organizationId: candidate.organization_id,
           userId: candidate.user_id,
           maxAttempts: 3,
-          estimatedDurationMs: 90_000,
+          estimatedDurationMs: CONTAINER_LIFECYCLE_ESTIMATED_DURATION_MS,
           logName: "stranded_warm_claim_recovery",
           mutuallyExclusiveJobTypes: [
             ...ADMIN_CANARY_CONFLICTING_JOB_TYPES,


### PR DESCRIPTION
Progresses #22548

## What this changes

**1. The missing monitor (`packages/cloud/shared/src/lib/services/dedicated-fleet-liveness.ts`).**
`listRunning()` is NOT widened — its `ne(execution_tier,'shared')` exclusion is deliberate and stays. The gap was that nothing asked *"do dedicated agents exist that should be reachable and are not?"*. The new `monitorDedicatedFleetLiveness()` takes a status census of the whole non-deleted, non-warm-pool dedicated fleet (`summarizeDedicatedFleet()`), and alerts when the fleet is non-empty with **zero** rows running — exactly the 26-rows-all-in-`error` shape that produced 36 hours of silence. It runs on the existing per-minute `/api/v1/cron/provisioning-worker-health` Worker cron, and fans out through the established provisioning ops channels (`sendProvisioningWorkerAlert`) under its own PagerDuty dedup key so a sustained outage is one incident, not one per tick.

**2. Provisioning success measured on jobs.** `jobsRepository.summarizeOutcomesByTypeSince('agent_provision', since)` gives a 24h `completed/(completed+failed)` rate, published in the cron's JSON response and its structured log line — i.e. where people quote it. No settled job in the window yields `null`, not a healthy-looking 100%.

**3. Predicate hygiene on `listRunning()`.** Added the `deleted_at IS NULL` and `pool_status IS NULL` guards that thirteen sibling predicates in the same file already carry; soft-deleted and unclaimed warm-pool rows are no longer heartbeated. The shared-tier exclusion is untouched and its existing guard test still passes.

**4. The duration-estimate lie.** `estimatedDurationMs: 90_000` (commented "health check up to 60s") is replaced everywhere by `CONTAINER_LIFECYCLE_ESTIMATED_DURATION_MS`, derived from the real 360 s health budget. `provision-duration-estimate.test.ts` pins the mirrored constant to `docker-sandbox-provider`'s `HEALTH_CHECK_TIMEOUT_MS`, so it fails if either drifts. (The "after 3 attempts" string was already fixed in #22619 and is guarded by its own tests in `eliza-sandbox.test.ts`; the 503 substring-matching is GOAL B's.)

**5. `activation_phase`: retained, consequence stated.** Kept as the backup scheduler's admission evidence, with the consequence documented at the gate: a running dedicated row without complete activation authority is not capture-eligible, so `countOverdueAgentBackupSchedules()` counts it as overdue immediately rather than letting it drop out of scheduling unobserved.

**6. Observability truncation.** The silent ~50-event cap (no truncation signal) is documented in `scripts/admin/cf-tail.sh` and in `api/wrangler.toml`'s `[observability]` block — the two places an engineer is standing when they query those logs. Slice the window, sum the slices; never conclude absence from one wide query.

## Tests

`bun test` in `packages/cloud/shared`, focused set — **40 pass / 0 fail**:
- `__tests__/dedicated-fleet-liveness.test.ts` (new): alerts on the all-error fleet; silent with one server running; empty fleet is not an outage; jobs-ledger rate over an injected clock window; no-data → `null`.
- `__tests__/provision-duration-estimate.test.ts` (new): estimate covers the health budget; mirrored constant equals the provider timeout.
- `db/repositories/agent-sandboxes.test.ts` (extended): the census must NOT filter on status (the whole point) and must carry the deleted/pool guards; existing `listRunning` shared-exclusion guard extended with the two new NULL guards.
- Plus `jobs.test.ts` and `provisioning-worker-health-monitor.test.ts` re-run clean.

Lint and typecheck clean for `packages/cloud/shared` and `packages/cloud/api`. Five failures in `provisioning-jobs-*.test.ts` (`agent-downgrade`, `execute-dispatch`, `recovery`) reproduce on this branch from error-stringification/UUID-matcher drift unrelated to these constants-only edits to that file.

## Human-only remainder

Proof 4 of the DoD — *reproduce the unreachable-fleet condition and show the alarm arriving* — needs production/staging fleet access this PR cannot reach: flip the dedicated rows to a non-running status in staging (or point the monitor at a snapshot of the 26-row prod state), hit the cron with `CRON_SECRET`, and capture the PagerDuty incident + Slack message + the `DEDICATED_FLEET_UNREACHABLE` structured log. `PROVISIONING_ALERT_SLACK_WEBHOOK` / `PROVISIONING_ALERT_PAGERDUTY_KEY` must be set in the target environment for the channel fan-out; the structured error log fires regardless. The wedged agent host (41,352 consecutive `Cannot fork` failures) and the never-ready warm pool are GOAL A's fixes — this monitor answers only the fleet-wide "none is serving" question about them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

