### PR TITLE
fix(cloud): type deletion job fixture data

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-delete-shared-fallback.test.ts
@@ -32,10 +32,21 @@ type CancelAgentDeletionResult =
 const cancelAgentDeletion = mock(
   async (): Promise<CancelAgentDeletionResult> => ({ success: true }),
 );
-const enqueueAgentDeleteOnce = mock(async () => ({
-  created: true,
-  job: { id: "delete-job-1", status: "pending" },
-}));
+type EnqueueAgentDeleteOnceResult = {
+  created: boolean;
+  job: {
+    id: string;
+    status: string;
+    data?: Record<string, unknown>;
+  };
+};
+
+const enqueueAgentDeleteOnce = mock(
+  async (): Promise<EnqueueAgentDeleteOnceResult> => ({
+    created: true,
+    job: { id: "delete-job-1", status: "pending" },
+  }),
+);
 const triggerImmediate = mock(async () => undefined);
 
 const loggerInfo = mock(() => undefined);


### PR DESCRIPTION
## Summary
- widen the mocked deletion-job result to its exercised optional `data` payload
- unblock the Cloud API Worker release typecheck without changing runtime code

## Verification
- focused deletion lifecycle suite: 17 passed
- Biome: clean
- `git diff --check`: clean
- failing `TS2353` fixture errors no longer reproduce