### PR TITLE
fix(agent): bind cookie auth to trusted CORS and CSRF boundaries

### DIFF
--- a/packages/agent/src/api/server-cookie-cors-boundary.real-server.test.ts
+++ b/packages/agent/src/api/server-cookie-cors-boundary.real-server.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Real HTTP-server coverage for the cookie/CORS authority split. The host
+ * session seam is deterministic, while requests traverse the production host,
+ * CORS, preflight, and coarse-auth pipeline over an ephemeral TCP listener.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  _resetAgentHostBridge,
+  defaultAgentHostBridge,
+  setAgentHostBridge,
+} from "../runtime/host-bridge.ts";
+import { startApiServer } from "./server.ts";
+
+type ApiServer = Awaited<ReturnType<typeof startApiServer>>;
+
+const TRUSTED_ORIGIN = "https://trusted.example";
+const HOSTILE_ORIGIN = "https://hostile.example";
+const REMOTE_HEADERS = { "x-forwarded-for": "203.0.113.10" } as const;
+const touchedEnv = [
+  "ELIZA_ALLOWED_ORIGINS",
+  "ELIZA_API_BIND_HOST",
+  "ELIZA_API_PORT",
+  "ELIZA_API_TOKEN",
+  "ELIZA_CLOUD_PROVISIONED",
+  "ELIZA_CONFIG_PATH",
+  "ELIZA_PERSIST_CONFIG_PATH",
+  "ELIZA_PORT",
+  "ELIZA_REQUIRE_LOCAL_AUTH",
+  "ELIZA_STATE_DIR",
+] as const;
+
+let api: ApiServer | null = null;
+let stateDir: string | null = null;
+const originalEnv = new Map<string, string | undefined>();
+
+function restoreEnvironment(): void {
+  for (const key of touchedEnv) {
+    const original = originalEnv.get(key);
+    if (original === undefined) delete process.env[key];
+    else process.env[key] = original;
+  }
+  originalEnv.clear();
+}
+
+beforeEach(async () => {
+  for (const key of touchedEnv) originalEnv.set(key, process.env[key]);
+  stateDir = await mkdtemp(path.join(tmpdir(), "eliza-cookie-cors-"));
+  process.env.ELIZA_STATE_DIR = stateDir;
+  process.env.ELIZA_CONFIG_PATH = path.join(stateDir, "eliza.json");
+  process.env.ELIZA_PERSIST_CONFIG_PATH = path.join(stateDir, "eliza.json");
+  process.env.ELIZA_API_BIND_HOST = "127.0.0.1";
+  process.env.ELIZA_CLOUD_PROVISIONED = "1";
+  process.env.ELIZA_ALLOWED_ORIGINS = TRUSTED_ORIGIN;
+  delete process.env.ELIZA_API_TOKEN;
+  delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
+
+  setAgentHostBridge({
+    ...defaultAgentHostBridge,
+    resolveHttpRequestAuthorization: async (req, _runtime, options) => {
+      const authorization =
+        typeof req.headers.authorization === "string"
+          ? req.headers.authorization
+          : "";
+      if (authorization === "Bearer explicit-session") {
+        return { ok: true, role: "OWNER", identityId: "owner" };
+      }
+      if (!options.allowCookieAuth) return { ok: false, role: "NONE" };
+      const cookie =
+        typeof req.headers.cookie === "string" ? req.headers.cookie : "";
+      if (!cookie.includes("eliza_session=browser-session")) {
+        return { ok: false, role: "NONE" };
+      }
+      const method = (req.method ?? "GET").toUpperCase();
+      if (
+        ["POST", "PUT", "PATCH", "DELETE"].includes(method) &&
+        req.headers["x-eliza-csrf"] !== "valid-csrf"
+      ) {
+        return { ok: false, role: "NONE" };
+      }
+      return { ok: true, role: "OWNER", identityId: "owner" };
+    },
+  });
+
+  api = await startApiServer({
+    port: 0,
+    skipDeferredStartupWork: true,
+  });
+}, 30_000);
+
+afterEach(async () => {
+  await api?.close();
+  api = null;
+  _resetAgentHostBridge();
+  if (stateDir) await rm(stateDir, { recursive: true, force: true });
+  stateDir = null;
+  restoreEnvironment();
+}, 30_000);
+
+function endpoint(): string {
+  if (!api) throw new Error("test server is not running");
+  return `http://127.0.0.1:${api.port}/api/cors-auth-probe`;
+}
+
+function browserHeaders(
+  origin: string,
+  extra: Record<string, string> = {},
+): Record<string, string> {
+  return { ...REMOTE_HEADERS, Origin: origin, ...extra };
+}
+
+describe("cookie authentication follows credentialed CORS trust", () => {
+  it("accepts trusted cookie reads but ignores the same cookie from a reflected origin", async () => {
+    const trusted = await fetch(endpoint(), {
+      headers: browserHeaders(TRUSTED_ORIGIN, {
+        Cookie: "eliza_session=browser-session",
+      }),
+    });
+    expect(trusted.status).toBe(404);
+    expect(trusted.headers.get("access-control-allow-credentials")).toBe(
+      "true",
+    );
+
+    const hostile = await fetch(endpoint(), {
+      headers: browserHeaders(HOSTILE_ORIGIN, {
+        Cookie: "eliza_session=browser-session",
+      }),
+    });
+    expect(hostile.status).toBe(401);
+    expect(hostile.headers.get("access-control-allow-origin")).toBe(
+      HOSTILE_ORIGIN,
+    );
+    expect(hostile.headers.get("access-control-allow-credentials")).toBeNull();
+  });
+
+  it("requires CSRF for a trusted simple cookie mutation", async () => {
+    const missingCsrf = await fetch(endpoint(), {
+      method: "POST",
+      headers: browserHeaders(TRUSTED_ORIGIN, {
+        "Content-Type": "text/plain",
+        Cookie: "eliza_session=browser-session",
+      }),
+      body: "mutation",
+    });
+    expect(missingCsrf.status).toBe(401);
+
+    const withCsrf = await fetch(endpoint(), {
+      method: "POST",
+      headers: browserHeaders(TRUSTED_ORIGIN, {
+        "Content-Type": "text/plain",
+        Cookie: "eliza_session=browser-session",
+        "X-Eliza-CSRF": "valid-csrf",
+      }),
+      body: "mutation",
+    });
+    expect(withCsrf.status).toBe(404);
+  });
+
+  it("keeps hostile reflected origins bearer-only for simple mutations", async () => {
+    const cookieOnly = await fetch(endpoint(), {
+      method: "POST",
+      headers: browserHeaders(HOSTILE_ORIGIN, {
+        "Content-Type": "text/plain",
+        Cookie: "eliza_session=browser-session",
+        "X-Eliza-CSRF": "valid-csrf",
+      }),
+      body: "mutation",
+    });
+    expect(cookieOnly.status).toBe(401);
+
+    const bearer = await fetch(endpoint(), {
+      method: "POST",
+      headers: browserHeaders(HOSTILE_ORIGIN, {
+        Authorization: "Bearer explicit-session",
+        "Content-Type": "text/plain",
+        Cookie: "eliza_session=browser-session",
+      }),
+      body: "mutation",
+    });
+    expect(bearer.status).toBe(404);
+    expect(bearer.headers.get("access-control-allow-credentials")).toBeNull();
+  });
+
+  it("answers trusted and hostile preflights without granting hostile credentials", async () => {
+    const preflight = async (origin: string) =>
+      fetch(endpoint(), {
+        method: "OPTIONS",
+        headers: browserHeaders(origin, {
+          "Access-Control-Request-Headers": "x-eliza-csrf",
+          "Access-Control-Request-Method": "POST",
+        }),
+      });
+
+    const trusted = await preflight(TRUSTED_ORIGIN);
+    expect(trusted.status).toBe(204);
+    expect(trusted.headers.get("access-control-allow-credentials")).toBe(
+      "true",
+    );
+    expect(
+      trusted.headers.get("access-control-allow-headers")?.toLowerCase(),
+    ).toContain("x-eliza-csrf");
+
+    const hostile = await preflight(HOSTILE_ORIGIN);
+    expect(hostile.status).toBe(204);
+    expect(hostile.headers.get("access-control-allow-origin")).toBe(
+      HOSTILE_ORIGIN,
+    );
+    expect(hostile.headers.get("access-control-allow-credentials")).toBeNull();
+  });
+});

--- a/packages/agent/src/api/server-helpers-auth.ts
+++ b/packages/agent/src/api/server-helpers-auth.ts
@@ -31,6 +31,8 @@ const LOCAL_ORIGIN_RE =
   /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\]|\[0:0:0:0:0:0:0:1\])(:\d+)?$/i;
 const APP_ORIGIN_RE =
   /^(capacitor|capacitor-electron|app|tauri|file|electrobun):\/\/.*$/i;
+const CREDENTIALED_APP_ORIGIN_RE =
+  /^(capacitor|capacitor-electron|app|tauri|electrobun):\/\/.*$/i;
 
 export const CORS_ALLOWED_HEADERS = [
   "Content-Type",
@@ -148,17 +150,21 @@ export function resolveCorsOrigin(origin?: string): string | null {
  * binds may reflect an origin for explicit bearer-token clients, but ambient
  * cookies are enabled only for configured or app-owned origin classes.
  */
-function isCredentialedCorsOrigin(origin: string | undefined): boolean {
+export function isCredentialedCorsOrigin(origin: string | undefined): boolean {
   if (!origin) return false;
   const trimmed = origin.trim();
-  if (!trimmed || trimmed === "null" || trimmed === "file://") return false;
+  if (!trimmed || trimmed === "null" || trimmed.startsWith("file:")) {
+    return false;
+  }
 
   const configuredOrigin = resolveAllowedOrigins(process.env).find(
     (allowedOrigin) => allowedOrigin === trimmed,
   );
   if (configuredOrigin) return true;
 
-  return LOCAL_ORIGIN_RE.test(trimmed) || APP_ORIGIN_RE.test(trimmed);
+  return (
+    LOCAL_ORIGIN_RE.test(trimmed) || CREDENTIALED_APP_ORIGIN_RE.test(trimmed)
+  );
 }
 
 function isBrowserCompanionExtensionOrigin(

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -1320,6 +1320,7 @@ import {
   isAllowedHost as _isAllowedHost,
   isAuthorized as _isAuthorized,
   isBoundaryRoleAuthorized as _isBoundaryRoleAuthorized,
+  isCredentialedCorsOrigin as _isCredentialedCorsOrigin,
   isServerTokenAuthorized as _isServerTokenAuthorized,
   isSharedTerminalClientId as _isSharedTerminalClientId,
   isTrustedLocalRequest as _isTrustedLocalRequest,
@@ -1368,6 +1369,7 @@ const isAuthorized = _isAuthorized;
 const resolveBoundaryRole = _resolveBoundaryRole;
 const isTrustedLocalRequest = _isTrustedLocalRequest;
 const isBoundaryRoleAuthorized = _isBoundaryRoleAuthorized;
+const isCredentialedCorsOrigin = _isCredentialedCorsOrigin;
 const isServerTokenAuthorized = _isServerTokenAuthorized;
 const ensureApiTokenForBindHost = _ensureApiTokenForBindHost;
 const normalizeWsClientId = _normalizeWsClientId;
@@ -1571,6 +1573,13 @@ async function handleRequest(
   // the port (LAN/wildcard bind) read the owner's cloud userId, organizationId,
   // and live credit balance (W1-010).
   const isAuthProtectedPath = isAuthProtectedRoute(pathname);
+  const requestOrigin =
+    typeof req.headers.origin === "string" ? req.headers.origin : undefined;
+  // A same-origin navigation commonly omits Origin. When an Origin is present,
+  // ambient cookie authority is available only to the narrower credentialed
+  // CORS trust set; arbitrary reflected origins remain bearer-only.
+  const allowHostCookieAuth =
+    requestOrigin === undefined || isCredentialedCorsOrigin(requestOrigin);
   let hostSessionAuthorization: AgentHttpRequestAuthorization = {
     ok: false,
     role: "NONE",
@@ -1586,12 +1595,16 @@ async function handleRequest(
         hostSessionAuthorization = await resolveAuthorization(
           req,
           state.runtime,
+          { allowCookieAuth: allowHostCookieAuth },
         );
         return hostSessionAuthorization;
       }
       const authorize = bridge.isHttpRequestAuthorized;
+      // A legacy boolean-only bridge cannot separate cookie from bearer
+      // authority. Do not consult it for an explicitly untrusted origin;
+      // standalone bearer schemes are evaluated by the normal server gates.
       const authorized =
-        typeof authorize === "function"
+        allowHostCookieAuth && typeof authorize === "function"
           ? await authorize(req, state.runtime)
           : false;
       // Legacy boolean-only hosts can still pass the coarse request gate, but

--- a/packages/agent/src/runtime/host-bridge.ts
+++ b/packages/agent/src/runtime/host-bridge.ts
@@ -47,6 +47,16 @@ export interface AgentHttpRequestAuthorization {
   principal?: string;
 }
 
+/** Browser-bound authority the agent permits an embedding host to consider. */
+export interface AgentHttpRequestAuthorizationOptions {
+  /**
+   * False when an explicit request Origin is outside the credentialed CORS
+   * trust set. Hosts must then ignore ambient cookies while retaining explicit
+   * bearer-token authentication.
+   */
+  allowCookieAuth: boolean;
+}
+
 /** Public (digest-free) consumer-key record surfaced to the owner dashboard. */
 export interface AccountPoolConsumerKeySummary {
   id: string;
@@ -129,6 +139,7 @@ export interface AgentHostBridge {
   resolveHttpRequestAuthorization?(
     req: HttpIncomingMessage,
     runtime: AgentRuntime | null,
+    options: AgentHttpRequestAuthorizationOptions,
   ): Promise<AgentHttpRequestAuthorization> | AgentHttpRequestAuthorization;
   /**
    * Cloud-SSO popup handoff (`GET /pair?token=…`). Owned by the host; a

--- a/packages/agent/test/api/server-helpers-auth.test.ts
+++ b/packages/agent/test/api/server-helpers-auth.test.ts
@@ -125,6 +125,24 @@ describe("applyCors", () => {
     expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
   });
 
+  it("never grants ambient credentials to file origins", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    const res = new HeaderCapture();
+
+    expect(
+      applyCors(
+        requestWithOrigin("file:///tmp/index.html"),
+        res,
+        "/api/status",
+      ),
+    ).toBe(true);
+
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe(
+      "file:///tmp/index.html",
+    );
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBeUndefined();
+  });
+
   it("allows waifu token-page iframe ancestors when hosted chat JWT auth is enabled", () => {
     process.env.WAIFU_CHAT_ACCESS_JWT_SECRET = "waifu-secret";
     const res = new HeaderCapture();

--- a/packages/app-core/src/api/__tests__/ensure-route-min-role.test.ts
+++ b/packages/app-core/src/api/__tests__/ensure-route-min-role.test.ts
@@ -194,6 +194,51 @@ describe("ensureRouteMinRole", () => {
     });
   });
 
+  it("ignores ambient cookies when the caller origin is not trusted", async () => {
+    mocks.findActiveSession.mockResolvedValue(makeSession());
+    mocks.findIdentity.mockResolvedValue(makeIdentity("owner"));
+    const req = makeReq({ headers: { cookie: "eliza_session=owner-session" } });
+
+    await expect(
+      resolveAuthorizedRouteRole(req, {
+        state: STATE_WITH_DB,
+        allowCookieAuth: false,
+      }),
+    ).resolves.toEqual({ ok: false, status: 401, reason: "Unauthorized" });
+    expect(mocks.findActiveSession).not.toHaveBeenCalled();
+    expect(mocks.verifyCsrfToken).not.toHaveBeenCalled();
+  });
+
+  it("keeps explicit bearer sessions available when cookie auth is disabled", async () => {
+    mocks.findActiveSession.mockResolvedValue(makeSession());
+    mocks.findIdentity.mockResolvedValue(makeIdentity("owner"));
+    const req = makeReq({
+      method: "POST",
+      headers: {
+        authorization: "Bearer bearer-session",
+        cookie: "eliza_session=ambient-session",
+      },
+    });
+
+    await expect(
+      resolveAuthorizedRouteRole(req, {
+        state: STATE_WITH_DB,
+        allowCookieAuth: false,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      role: "OWNER",
+      identityId: "identity-id",
+    });
+    expect(mocks.findActiveSession).toHaveBeenCalledTimes(1);
+    expect(mocks.findActiveSession).toHaveBeenCalledWith(
+      expect.anything(),
+      "bearer-session",
+      undefined,
+    );
+    expect(mocks.verifyCsrfToken).not.toHaveBeenCalled();
+  });
+
   it("rejects a machine session from OWNER routes", async () => {
     mocks.findActiveSession.mockResolvedValue(
       makeSession({ id: "machine-session", kind: "machine" }),

--- a/packages/app-core/src/api/auth.ts
+++ b/packages/app-core/src/api/auth.ts
@@ -402,6 +402,7 @@ type AuthorizedRouteRoleOptions =
   | {
       state: CompatStateLike;
       store?: never;
+      allowCookieAuth?: boolean;
       skipCsrf?: boolean;
       now?: number;
       readSetting?: never;
@@ -409,6 +410,7 @@ type AuthorizedRouteRoleOptions =
   | {
       store: AuthStore;
       state?: never;
+      allowCookieAuth?: boolean;
       skipCsrf?: boolean;
       now?: number;
       readSetting?: (key: string) => unknown;
@@ -481,7 +483,10 @@ export async function resolveAuthorizedRouteRole(
   const method = (req.method ?? "GET").toUpperCase();
   const csrfRequired = !options.skipCsrf && CSRF_REQUIRED_METHODS.has(method);
 
-  const sessionCookie = readCookie(req, SESSION_COOKIE_NAME);
+  const sessionCookie =
+    options.allowCookieAuth === false
+      ? null
+      : readCookie(req, SESSION_COOKIE_NAME);
   if (sessionCookie) {
     const session = await findActiveSession(
       store,

--- a/packages/app-core/src/runtime/agent-host-bridge-cookie-cors.test.ts
+++ b/packages/app-core/src/runtime/agent-host-bridge-cookie-cors.test.ts
@@ -1,0 +1,209 @@
+/**
+ * End-to-end coverage for the cookie/CORS authority split across the
+ * agent → app-core host-bridge seam.
+ *
+ * The agent-side suite
+ * (`packages/agent/src/api/server-cookie-cors-boundary.real-server.test.ts`)
+ * drives real TCP but substitutes a deterministic `resolveHttpRequestAuthorization`,
+ * so the cross-package plumbing this file covers — the real bridge installed by
+ * `installAgentHostBridge()`, the real `resolveAuthorizedRouteRole`, and the
+ * real session/CSRF cookie and header names — was previously only verified by
+ * inspection. Sessions come from a real PGlite-backed `AuthStore`: an untrusted
+ * origin must lose the ambient cookie while explicit bearer auth survives, and
+ * cookie mutations must still present a valid CSRF token.
+ */
+
+import fs from "node:fs";
+import * as http from "node:http";
+import { Socket } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import {
+  _resetAgentHostBridge,
+  getAgentHostBridge,
+} from "@elizaos/agent/runtime/host-bridge";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createBrowserSession,
+  createMachineSession,
+  CSRF_HEADER_NAME,
+  SESSION_COOKIE_NAME,
+} from "../api/auth/sessions";
+import { _resetAuthRateLimiter } from "../api/auth.ts";
+import { AuthStore, type DrizzleDatabase } from "../services/auth-store";
+import { installAgentHostBridge } from "./install-agent-host-bridge";
+
+interface AdapterWithDb {
+  db?: unknown;
+  initialize?: () => Promise<void>;
+  init?: () => Promise<void>;
+  close?: () => Promise<void>;
+}
+
+interface SqlPluginModule {
+  createDatabaseAdapter: (
+    cfg: { dataDir: string },
+    id: `${string}-${string}-${string}-${string}-${string}`,
+  ) => unknown;
+  DatabaseMigrationService: new () => {
+    initializeWithDatabase: (db: unknown) => Promise<void>;
+    discoverAndRegisterPluginSchemas: (plugins: unknown[]) => void;
+    runAllPluginMigrations: () => Promise<void>;
+  };
+  plugin: unknown;
+}
+
+interface Harness {
+  store: AuthStore;
+  runtime: { adapter: { db: DrizzleDatabase } };
+  cleanup: () => Promise<void>;
+}
+
+async function open(): Promise<Harness> {
+  const {
+    createDatabaseAdapter,
+    DatabaseMigrationService,
+    plugin: sqlPlugin,
+  } = (await import("@elizaos/plugin-sql")) as SqlPluginModule;
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-bridge-cors-"));
+  const adapter = createDatabaseAdapter(
+    { dataDir },
+    "00000000-0000-0000-0000-000000000001",
+  ) as AdapterWithDb;
+  if (typeof adapter.initialize === "function") await adapter.initialize();
+  else if (typeof adapter.init === "function") await adapter.init();
+  if (!adapter.db) throw new Error("test harness: adapter has no .db");
+  const db = adapter.db as DrizzleDatabase;
+  const migrations = new DatabaseMigrationService();
+  await migrations.initializeWithDatabase(db);
+  migrations.discoverAndRegisterPluginSchemas([sqlPlugin]);
+  await migrations.runAllPluginMigrations();
+  return {
+    store: new AuthStore(db),
+    runtime: { adapter: { db } },
+    cleanup: async () => {
+      await adapter.close?.();
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    },
+  };
+}
+
+/**
+ * A request that looks remote: `resolveAuthorizedRouteRole` short-circuits to
+ * OWNER for trusted loopback callers, which would mask the cookie boundary.
+ */
+function request(
+  method: string,
+  headers: Record<string, string>,
+): http.IncomingMessage {
+  const socket = new Socket();
+  Object.defineProperty(socket, "remoteAddress", { value: "203.0.113.10" });
+  const req = new http.IncomingMessage(socket);
+  req.method = method;
+  for (const [name, value] of Object.entries(headers)) {
+    req.headers[name.toLowerCase()] = value;
+  }
+  return req;
+}
+
+let harness: Harness | null = null;
+
+beforeEach(async () => {
+  _resetAuthRateLimiter();
+  harness = await open();
+  installAgentHostBridge();
+}, 60_000);
+
+afterEach(async () => {
+  _resetAgentHostBridge();
+  _resetAuthRateLimiter();
+  await harness?.cleanup();
+  harness = null;
+});
+
+describe("installed host bridge binds cookie auth to credentialed CORS trust", () => {
+  async function resolve(
+    method: string,
+    headers: Record<string, string>,
+    allowCookieAuth: boolean,
+  ) {
+    const bridge = getAgentHostBridge();
+    if (!bridge.resolveHttpRequestAuthorization) {
+      throw new Error("installed bridge exposes no authorization resolver");
+    }
+    return bridge.resolveHttpRequestAuthorization(
+      request(method, headers),
+      harness?.runtime as never,
+      { allowCookieAuth },
+    );
+  }
+
+  it("accepts a real session cookie only when the origin may carry credentials", async () => {
+    if (!harness) throw new Error("harness");
+    const identity = await harness.store.createIdentity({
+      id: "owner-identity",
+      kind: "owner",
+      displayName: "Owner",
+      createdAt: Date.now(),
+      passwordHash: null,
+    });
+    const { session } = await createBrowserSession(harness.store, {
+      identityId: identity.id,
+    });
+    const cookie = `${SESSION_COOKIE_NAME}=${session.id}`;
+
+    await expect(resolve("GET", { cookie }, true)).resolves.toMatchObject({
+      ok: true,
+      role: "OWNER",
+    });
+    await expect(resolve("GET", { cookie }, false)).resolves.toMatchObject({
+      ok: false,
+      role: "NONE",
+    });
+  }, 60_000);
+
+  it("keeps explicit bearer auth working from an untrusted origin", async () => {
+    if (!harness) throw new Error("harness");
+    const identity = await harness.store.createIdentity({
+      id: "owner-identity",
+      kind: "owner",
+      displayName: "Owner",
+      createdAt: Date.now(),
+      passwordHash: null,
+    });
+    const { session } = await createMachineSession(harness.store, {
+      identityId: identity.id,
+      scopes: [],
+    });
+
+    await expect(
+      resolve("GET", { authorization: `Bearer ${session.id}` }, false),
+    ).resolves.toMatchObject({ ok: true, role: "OWNER" });
+  }, 60_000);
+
+  it("still requires a valid CSRF token for a trusted cookie mutation", async () => {
+    if (!harness) throw new Error("harness");
+    const identity = await harness.store.createIdentity({
+      id: "owner-identity",
+      kind: "owner",
+      displayName: "Owner",
+      createdAt: Date.now(),
+      passwordHash: null,
+    });
+    const { session, csrfToken } = await createBrowserSession(harness.store, {
+      identityId: identity.id,
+    });
+    const cookie = `${SESSION_COOKIE_NAME}=${session.id}`;
+
+    await expect(resolve("POST", { cookie }, true)).resolves.toMatchObject({
+      ok: false,
+      role: "NONE",
+    });
+    await expect(
+      resolve("POST", { cookie, [CSRF_HEADER_NAME]: "not-the-token" }, true),
+    ).resolves.toMatchObject({ ok: false, role: "NONE" });
+    await expect(
+      resolve("POST", { cookie, [CSRF_HEADER_NAME]: csrfToken }, true),
+    ).resolves.toMatchObject({ ok: true, role: "OWNER" });
+  }, 60_000);
+});

--- a/packages/app-core/src/runtime/install-agent-host-bridge.ts
+++ b/packages/app-core/src/runtime/install-agent-host-bridge.ts
@@ -44,13 +44,9 @@ let installed = false;
 export function installAgentHostBridge(): void {
   const resolveHttpRequestAuthorization: NonNullable<
     AgentHostBridge["resolveHttpRequestAuthorization"]
-  > = async (req, runtime) => {
+  > = async (req, runtime, options) => {
     const resolved = await resolveAuthorizedRouteRole(req, {
-      // Agent-owned legacy mutations predate app-core's CSRF header and the
-      // web client does not attach it to that surface. These requests have
-      // already passed the server's strict Origin/CORS gate; validate the
-      // host session here without imposing the compat-route CSRF contract.
-      skipCsrf: true,
+      allowCookieAuth: options.allowCookieAuth,
       state: {
         current: runtime,
       },
@@ -88,7 +84,11 @@ export function installAgentHostBridge(): void {
     handleCloudPairRoute,
     resolveHttpRequestAuthorization,
     isHttpRequestAuthorized: async (req, runtime) =>
-      (await resolveHttpRequestAuthorization(req, runtime)).ok,
+      (
+        await resolveHttpRequestAuthorization(req, runtime, {
+          allowCookieAuth: true,
+        })
+      ).ok,
   };
   setAgentHostBridge(bridge);
   installed = true;

--- a/packages/ui/src/api/auth/csrf-cookie.ts
+++ b/packages/ui/src/api/auth/csrf-cookie.ts
@@ -1,0 +1,22 @@
+/** Reads the browser session's readable CSRF companion cookie. */
+
+import { CSRF_COOKIE_NAME } from "./sessions";
+
+/** Return the decoded token, or null for absent and malformed cookie values. */
+export function readCsrfTokenFromCookie(): string | null {
+  if (typeof document === "undefined") return null;
+  const prefix = `${CSRF_COOKIE_NAME}=`;
+  for (const part of document.cookie.split(";")) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(prefix)) {
+      try {
+        return decodeURIComponent(trimmed.slice(prefix.length));
+      } catch {
+        // error-policy:J3 untrusted cookie values — a malformed percent-escape
+        // is an absent CSRF token, not a client crash.
+        return null;
+      }
+    }
+  }
+  return null;
+}

--- a/packages/ui/src/api/client-base-csrf.test.ts
+++ b/packages/ui/src/api/client-base-csrf.test.ts
@@ -1,0 +1,73 @@
+/** Verifies the canonical API client carries cookie-session CSRF on mutations. */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setBootConfig } from "../config/boot-config";
+import { ElizaClient } from "./client-base";
+import type { AgentRequestTransport } from "./transport";
+
+function makeClient(baseUrl = "https://agent.example") {
+  const request = vi.fn<AgentRequestTransport["request"]>(
+    async () =>
+      new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+  );
+  const client = new ElizaClient(baseUrl, null);
+  client.setRequestTransport({ request });
+  return { client, request };
+}
+
+describe("ElizaClient browser-session request auth", () => {
+  const originalDocument = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "document",
+  );
+
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: { cookie: "eliza_csrf=csrf-token" },
+    });
+  });
+
+  afterEach(() => {
+    if (originalDocument) {
+      Object.defineProperty(globalThis, "document", originalDocument);
+    } else {
+      Reflect.deleteProperty(globalThis, "document");
+    }
+    vi.clearAllMocks();
+  });
+
+  it("mirrors CSRF and includes cookies on ordinary agent mutations", async () => {
+    const { client, request } = makeClient();
+
+    await client.fetch("/api/settings", { method: "PATCH" });
+
+    const init = request.mock.calls[0]?.[1];
+    expect(init?.credentials).toBe("include");
+    expect(new Headers(init?.headers).get("x-eliza-csrf")).toBe("csrf-token");
+  });
+
+  it("does not attach CSRF to reads", async () => {
+    const { client, request } = makeClient();
+
+    await client.fetch("/api/status");
+
+    const init = request.mock.calls[0]?.[1];
+    expect(init?.credentials).toBe("include");
+    expect(new Headers(init?.headers).has("x-eliza-csrf")).toBe(false);
+  });
+
+  it("omits both cookie credentials and CSRF on dedicated agents", async () => {
+    const { client, request } = makeClient("https://agent-123.cloud.eliza.app");
+
+    await client.fetch("/api/settings", { method: "PATCH" });
+
+    const init = request.mock.calls[0]?.[1];
+    expect(init?.credentials).toBe("omit");
+    expect(new Headers(init?.headers).has("x-eliza-csrf")).toBe(false);
+  });
+});

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -54,6 +54,8 @@ import {
   mergeStreamingText,
 } from "../utils/streaming-text";
 import { androidNativeAgentTransportForUrl } from "./android-native-agent-transport";
+import { readCsrfTokenFromCookie } from "./auth/csrf-cookie";
+import { CSRF_HEADER_NAME } from "./auth/sessions";
 import type {
   AccountConnectRequest,
   ChatActionResultSummary,
@@ -98,6 +100,7 @@ const REPLAYABLE_WS_EVENT_TYPES: ReadonlySet<string> = new Set([
   SHELL_NAVIGATE_VIEW_WS_EVENT,
 ]);
 const WS_EVENT_BACKLOG_LIMIT = 8;
+const CSRF_REQUIRED_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 type StreamChatEvent = {
   type?: string;
@@ -1735,6 +1738,7 @@ export class ElizaClient {
     requestAttempt: number,
   ): RequestInit {
     const isDedicatedCloudRequest = isDedicatedCloudAgentBase(requestUrl);
+    const method = (init?.method ?? "GET").toUpperCase();
     const headers: Record<string, string> = {
       ...(!isDedicatedCloudRequest
         ? { "X-ElizaOS-Client-Id": this.clientId }
@@ -1745,6 +1749,17 @@ export class ElizaClient {
         : {}),
       ...requestHeadersToRecord(init?.headers),
     };
+    const hasCsrfHeader = Object.keys(headers).some(
+      (name) => name.toLowerCase() === CSRF_HEADER_NAME,
+    );
+    if (
+      !isDedicatedCloudRequest &&
+      !hasCsrfHeader &&
+      CSRF_REQUIRED_METHODS.has(method)
+    ) {
+      const csrfToken = readCsrfTokenFromCookie();
+      if (csrfToken) headers[CSRF_HEADER_NAME] = csrfToken;
+    }
     const correlation = headers[SHARED_TURN_CORRELATION_HEADER];
     if (correlation) {
       headers[SHARED_TURN_ATTEMPT_HEADER] = String(requestAttempt);
@@ -1758,6 +1773,9 @@ export class ElizaClient {
     }
     return {
       ...init,
+      credentials: isDedicatedCloudRequest
+        ? "omit"
+        : (init?.credentials ?? "include"),
       signal: abortController.signal,
       headers,
     };

--- a/packages/ui/src/api/csrf-client.ts
+++ b/packages/ui/src/api/csrf-client.ts
@@ -18,7 +18,8 @@ import { hydrateAndroidLocalAgentTokenForUrl } from "../first-run/local-agent-to
 import { resolveApiUrl } from "../utils/asset-url";
 import { isDedicatedCloudAgentBase } from "../utils/cloud-agent-base";
 import { androidNativeAgentTransportForUrl } from "./android-native-agent-transport";
-import { CSRF_COOKIE_NAME, CSRF_HEADER_NAME } from "./auth/sessions";
+import { readCsrfTokenFromCookie } from "./auth/csrf-cookie";
+import { CSRF_HEADER_NAME } from "./auth/sessions";
 import { desktopHttpTransportForUrl } from "./desktop-http-transport";
 import { desktopLocalAgentTransportForUrl } from "./desktop-local-agent-transport";
 import { iosInProcessAgentTransportForUrl } from "./ios-local-agent-transport";
@@ -26,27 +27,7 @@ import { nativeCloudHttpTransportForUrl } from "./native-cloud-http-transport";
 import { defaultFetchTimeoutMs } from "./request-timeout";
 import { type AgentRequestContext, fetchAgentTransport } from "./transport";
 
-/**
- * Reads the current CSRF token from `document.cookie`.
- * Returns null when the cookie is absent (no active session).
- */
-export function readCsrfTokenFromCookie(): string | null {
-  if (typeof document === "undefined") return null;
-  const prefix = `${CSRF_COOKIE_NAME}=`;
-  for (const part of document.cookie.split(";")) {
-    const trimmed = part.trim();
-    if (trimmed.startsWith(prefix)) {
-      try {
-        return decodeURIComponent(trimmed.slice(prefix.length));
-      } catch {
-        // error-policy:J3 untrusted cookie values — a malformed percent-escape
-        // is an absent CSRF token, not a client crash.
-        return null;
-      }
-    }
-  }
-  return null;
-}
+export { readCsrfTokenFromCookie } from "./auth/csrf-cookie";
 
 const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "DELETE", "PATCH"]);
 


### PR DESCRIPTION
## Summary

Fixes #23383. Security-sensitive corrective follow-up to merged #23189.

- Makes reflected/untrusted origins bearer-only.
- Disables host cookie authentication outside credentialed canonical origins.
- Restores CSRF enforcement on legacy app-core agent mutations.
- Updates the canonical UI client to send the CSRF token.
- Rejects file/non-web origins.
- Adds real TCP tests for trusted/hostile reads, simple cookie mutation, bearer-only access, and preflight behavior.

## Verification

Exact head: `9bf031050b4161ee79085c1db1d9b7548373e4b3`, rebased onto `develop@16cbebf500d4ec798f516c1cf0fac56694585bf9`.

Pinned Bun 1.3.14 evidence:

- real TCP CORS/auth matrix: 4/4 passed
- auth helper: 25/25 passed
- app-core authorization/bridge: 12/12 passed before the final conflict-free two-commit rebase
- UI client CSRF: 3/3 passed
- changed-file Biome and diff-check: passed

## Known gaps

- Broad agent/app-core/UI typechecks were attempted but remained CPU-active for approximately 40 minutes without diagnostics and were stopped; no green package-wide typecheck is claimed.
- No protected deployment or production cookie/session was mutated.
- Keep draft until exact-head hosted checks and a non-author security review are green.

## Evidence Gate

<!-- evidence-head:9bf031050b4161ee79085c1db1d9b7548373e4b3 -->

- Screenshots/video/OCR: N/A — transport authorization only; no rendered pixels changed.
- Backend/domain artifact: deterministic real TCP request/response matrix above.
- Frontend logs: canonical UI client regression above.
- LLM trajectory: N/A — no model/prompt/action behavior changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
- AI assistance: yes
- Model: OpenAI GPT-5.6
- Client: Codex Desktop
- Status: self-reported


<!-- evidence-row:before-screenshots -->
- [x] N/A - transport authorization only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - transport authorization only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic request boundary with no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head real TCP CORS/auth matrix passed 4/4.
<!-- evidence-row:frontend-logs -->
- [x] Exact-head canonical UI CSRF client regression passed 3/3.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Real TCP tests inspect trusted and hostile cookie/bearer request outcomes and preflights.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text.
