### PR TITLE
fix(cloud): cap what SQL text and jsonb columns may store inline

### DIFF
--- a/packages/cloud/shared/src/db/repositories/agent-events.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-events.ts
@@ -63,6 +63,8 @@ async function prepareAgentEventPayload(data: NewAgentEvent): Promise<NewAgentEv
       field: "message",
       createdAt,
       value: data.message,
+      // Event bodies are diagnostic text; bound them when offload is off.
+      oversizeInline: "clamp",
     }),
     offloadJsonField<Record<string, unknown>>({
       namespace: ObjectNamespaces.AgentEventBodies,

--- a/packages/cloud/shared/src/db/repositories/containers.ts
+++ b/packages/cloud/shared/src/db/repositories/containers.ts
@@ -117,6 +117,8 @@ async function prepareContainerInsertPayload(
     organizationId: data.organization_id,
     objectId: context.id,
     field: "deployment_log",
+    // Deployment logs are diagnostics; bound them when offload is unavailable.
+    oversizeInline: "clamp" as const,
     createdAt: data.created_at ?? context.created_at,
     value: data.deployment_log,
   });
@@ -142,6 +144,8 @@ async function prepareContainerUpdatePayload(
     organizationId: data.organization_id ?? context.organization_id,
     objectId: context.id,
     field: "deployment_log",
+    // Deployment logs are diagnostics; bound them when offload is unavailable.
+    oversizeInline: "clamp" as const,
     createdAt: data.created_at ?? context.created_at ?? new Date(),
     value: data.deployment_log,
   });

--- a/packages/cloud/shared/src/db/repositories/jobs.test.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.test.ts
@@ -7,6 +7,7 @@ const ENV_KEYS = [
   "SQL_HEAVY_PAYLOAD_STORAGE",
   "SQL_HEAVY_PAYLOAD_MIN_BYTES",
   "SQL_HEAVY_PAYLOAD_INLINE_PREVIEW_BYTES",
+  "SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES",
 ] as const;
 
 const originalEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
@@ -73,5 +74,28 @@ describe("prepareJobInsertData", () => {
       appId: "app-123",
       buildContext: expect.any(String),
     });
+  });
+
+  test("a failure dump can no longer be written whole into the error column", async () => {
+    setRuntimeR2Bucket(null);
+    process.env.SQL_HEAVY_PAYLOAD_STORAGE = "inline";
+    process.env.SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES = "4096";
+
+    const dump = "PGLITE-DUMP".repeat(5000);
+    const prepared = await prepareJobInsertData({
+      id: "44444444-4444-4444-8444-444444444444",
+      type: "agent_snapshot",
+      organization_id: "22222222-2222-4222-8222-222222222222",
+      user_id: "33333333-3333-4333-8333-333333333333",
+      data: { appId: "app-123" },
+      error: dump,
+    });
+
+    expect(prepared.error_storage).toBe("inline");
+    expect(prepared.error_key).toBeNull();
+    const stored = prepared.error ?? "";
+    expect(new TextEncoder().encode(stored).byteLength).toBeLessThanOrEqual(4096);
+    expect(stored).toContain("truncated:");
+    expect(stored.startsWith("PGLITE-DUMP")).toBe(true);
   });
 });

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -14,6 +14,7 @@ import {
 } from "../../lib/services/provisioning-job-types";
 import { ObjectNamespaces } from "../../lib/storage/object-namespace";
 import {
+  clampInlineDiagnosticText,
   hydrateJsonField,
   hydrateTextField,
   offloadJsonField,
@@ -445,7 +446,7 @@ async function prepareJobPayload<T extends Partial<Job> | Partial<NewJob>>(
       ? Promise.resolve(null)
       : forceInlineError
         ? Promise.resolve({
-            value: data.error,
+            value: data.error === null ? null : clampInlineDiagnosticText(data.error),
             storage: "inline" as const,
             key: null,
           })
@@ -456,6 +457,9 @@ async function prepareJobPayload<T extends Partial<Job> | Partial<NewJob>>(
             field: "error",
             createdAt,
             value: data.error,
+            // A failure reason is a diagnostic string: bound it rather than let
+            // a full dump land in the text column when offload is unavailable.
+            oversizeInline: "clamp",
           }),
   ]);
 

--- a/packages/cloud/shared/src/lib/storage/object-store-inline-ceiling.test.ts
+++ b/packages/cloud/shared/src/lib/storage/object-store-inline-ceiling.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Covers the SQL inline-payload ceiling that keeps heavy payloads out of text
+ * and jsonb columns when object storage is unconfigured. Deterministic: the
+ * suite exercises the real helpers with storage env cleared, so every case
+ * takes the inline branch without touching a network backend.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ObjectNamespaces } from "./object-namespace";
+import {
+  clampInlineDiagnosticText,
+  InlinePayloadTooLargeError,
+  inlinePayloadCeilingBytes,
+  offloadJsonField,
+  offloadTextField,
+  shouldUseObjectStorage,
+} from "./object-store";
+
+const ENV_KEYS = [
+  "STORAGE_PROVIDER",
+  "STORAGE_ENDPOINT",
+  "STORAGE_REGION",
+  "STORAGE_ACCESS_KEY_ID",
+  "STORAGE_SECRET_ACCESS_KEY",
+  "STORAGE_HEAVY_PAYLOADS_BUCKET",
+  "STORAGE_BLOB_DEFAULT_BUCKET",
+  "STORAGE_TRAJECTORIES_BUCKET",
+  "R2_ACCOUNT_ID",
+  "R2_ACCESS_KEY_ID",
+  "R2_SECRET_ACCESS_KEY",
+  "R2_HEAVY_PAYLOADS_BUCKET",
+  "R2_BLOB_DEFAULT_BUCKET",
+  "R2_TRAJECTORIES_BUCKET",
+  "SQL_HEAVY_PAYLOAD_STORAGE",
+  "HEAVY_PAYLOAD_STORAGE",
+  "SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES",
+] as const;
+
+const ORIGINAL = new Map(ENV_KEYS.map((key) => [key, process.env[key]] as const));
+
+const baseParams = {
+  namespace: ObjectNamespaces.JobPayloads,
+  organizationId: "org-1",
+  objectId: "job-1",
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+};
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) delete process.env[key];
+  process.env.SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES = "2048";
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) delete process.env[key];
+  for (const [key, value] of ORIGINAL) {
+    if (value !== undefined) process.env[key] = value;
+  }
+});
+
+describe("inline payload ceiling", () => {
+  test("object storage is genuinely unconfigured in this harness", () => {
+    expect(shouldUseObjectStorage()).toBe(false);
+    expect(inlinePayloadCeilingBytes()).toBe(2048);
+  });
+
+  test("a value under the ceiling is stored inline unchanged", async () => {
+    const value = "x".repeat(100);
+    const field = await offloadTextField({ ...baseParams, field: "error", value });
+    expect(field).toEqual({ value, storage: "inline", key: null });
+  });
+
+  test("an oversize text field is refused by default rather than written inline", async () => {
+    const value = "x".repeat(5000);
+    const promise = offloadTextField({ ...baseParams, field: "error", value });
+    await expect(promise).rejects.toBeInstanceOf(InlinePayloadTooLargeError);
+    await promise.catch((error: unknown) => {
+      // error-policy:J3 the rejection is the assertion subject, not a recovery path.
+      const typed = error as InlinePayloadTooLargeError;
+      expect(typed.code).toBe("INLINE_PAYLOAD_TOO_LARGE");
+      expect(typed.field).toBe("error");
+      expect(typed.sizeBytes).toBe(5000);
+      expect(typed.maxInlineBytes).toBe(2048);
+    });
+  });
+
+  test("a diagnostic field opted into clamping is bounded and marked", async () => {
+    const value = "x".repeat(5000);
+    const field = await offloadTextField({
+      ...baseParams,
+      field: "error",
+      value,
+      oversizeInline: "clamp",
+    });
+    expect(field.storage).toBe("inline");
+    expect(field.key).toBeNull();
+    const stored = field.value ?? "";
+    expect(byteLength(stored)).toBeLessThanOrEqual(2048);
+    expect(stored).toContain("truncated: 5000-byte payload");
+  });
+
+  test("oversize structured payloads are refused, never truncated", async () => {
+    const value = { dump: "x".repeat(5000) };
+    await expect(
+      offloadJsonField<Record<string, unknown>>({
+        ...baseParams,
+        field: "data",
+        value,
+        inlineValueWhenOffloaded: null,
+      }),
+    ).rejects.toBeInstanceOf(InlinePayloadTooLargeError);
+  });
+
+  test("clamping preserves whole characters for multi-byte payloads", () => {
+    process.env.SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES = "1024";
+    const clamped = clampInlineDiagnosticText("é".repeat(4000));
+    expect(byteLength(clamped)).toBeLessThanOrEqual(1024);
+    expect(clamped.includes("�")).toBe(false);
+  });
+
+  test("a ceiling below the 1024-byte floor falls back to the 1 MiB default", () => {
+    process.env.SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES = "10";
+    expect(inlinePayloadCeilingBytes()).toBe(1024 * 1024);
+    process.env.SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES = "not-a-number";
+    expect(inlinePayloadCeilingBytes()).toBe(1024 * 1024);
+  });
+
+  test("a null value is unaffected by the ceiling", async () => {
+    const field = await offloadTextField({ ...baseParams, field: "error", value: null });
+    expect(field).toEqual({ value: null, storage: "inline", key: null });
+  });
+});

--- a/packages/cloud/shared/src/lib/storage/object-store-inline-ceiling.test.ts
+++ b/packages/cloud/shared/src/lib/storage/object-store-inline-ceiling.test.ts
@@ -120,6 +120,27 @@ describe("inline payload ceiling", () => {
     expect(clamped.includes("�")).toBe(false);
   });
 
+  test("clamping never allocates a payload-sized TextEncoder copy", () => {
+    const originalTextEncoder = globalThis.TextEncoder;
+    Object.defineProperty(globalThis, "TextEncoder", {
+      configurable: true,
+      value: class {
+        encode(): never {
+          throw new Error("TextEncoder.encode must not run at the ceiling boundary");
+        }
+      },
+    });
+    try {
+      const clamped = clampInlineDiagnosticText("x".repeat(5000));
+      expect(clamped).toContain("truncated: 5000-byte payload");
+    } finally {
+      Object.defineProperty(globalThis, "TextEncoder", {
+        configurable: true,
+        value: originalTextEncoder,
+      });
+    }
+  });
+
   test("a ceiling below the 1024-byte floor falls back to the 1 MiB default", () => {
     process.env.SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES = "10";
     expect(inlinePayloadCeilingBytes()).toBe(1024 * 1024);

--- a/packages/cloud/shared/src/lib/storage/object-store.ts
+++ b/packages/cloud/shared/src/lib/storage/object-store.ts
@@ -480,7 +480,32 @@ function previewBytes(): number {
 }
 
 function byteLength(value: string): number {
-  return new TextEncoder().encode(value).byteLength;
+  // Count UTF-8 bytes without materializing a second payload-sized buffer.
+  // These helpers run specifically on values large enough to threaten SQL;
+  // TextEncoder.encode() would transiently duplicate a 250 MB dump before the
+  // ceiling could reject or clamp it.
+  let bytes = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit <= 0x7f) {
+      bytes += 1;
+    } else if (codeUnit <= 0x7ff) {
+      bytes += 2;
+    } else if (codeUnit >= 0xd800 && codeUnit <= 0xdbff && index + 1 < value.length) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4;
+        index += 1;
+      } else {
+        bytes += 3;
+      }
+    } else {
+      // BMP code points and unpaired surrogates encode to three bytes; the
+      // latter matches TextEncoder's U+FFFD replacement behavior.
+      bytes += 3;
+    }
+  }
+  return bytes;
 }
 
 function shouldOffload(value: string): boolean {

--- a/packages/cloud/shared/src/lib/storage/object-store.ts
+++ b/packages/cloud/shared/src/lib/storage/object-store.ts
@@ -384,6 +384,85 @@ export function shouldUseObjectStorage(): boolean {
   return storageConfigured();
 }
 
+/**
+ * Hard ceiling on what a single field may persist inline in a SQL text or
+ * jsonb column. Without it the offload helpers degrade into unbounded inline
+ * writes whenever object storage is unconfigured, which is how quarter-gigabyte
+ * failure dumps reached the `jobs.error` column (elizaOS/eliza#22553).
+ */
+const DEFAULT_MAX_INLINE_BYTES = 1024 * 1024;
+
+function maxInlineBytes(): number {
+  const raw = getCloudAwareEnv().SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES;
+  if (!raw) return DEFAULT_MAX_INLINE_BYTES;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 1024) return DEFAULT_MAX_INLINE_BYTES;
+  return Math.floor(parsed);
+}
+
+/** Raised when a payload exceeds the inline ceiling and cannot be offloaded. */
+export class InlinePayloadTooLargeError extends Error {
+  readonly code = "INLINE_PAYLOAD_TOO_LARGE";
+  readonly field: string;
+  readonly sizeBytes: number;
+  readonly maxInlineBytes: number;
+
+  constructor(input: { field: string; sizeBytes: number; maxBytes: number }) {
+    super(
+      `Inline payload for field "${input.field}" is ${input.sizeBytes} bytes, above the ` +
+        `${input.maxBytes}-byte SQL inline ceiling, and object storage is not configured to ` +
+        `offload it. Set SQL_HEAVY_PAYLOAD_STORAGE with a heavy-payload bucket, or persist a ` +
+        `bounded summary instead of the full payload.`,
+    );
+    this.name = "InlinePayloadTooLargeError";
+    this.field = input.field;
+    this.sizeBytes = input.sizeBytes;
+    this.maxInlineBytes = input.maxBytes;
+  }
+}
+
+function truncateToBytes(value: string, limit: number): string {
+  if (limit <= 0) return "";
+  if (byteLength(value) <= limit) return value;
+  let output = "";
+  let size = 0;
+  for (const char of value) {
+    const charSize = byteLength(char);
+    if (size + charSize > limit) break;
+    output += char;
+    size += charSize;
+  }
+  return output;
+}
+
+/**
+ * Bound a diagnostic string to the inline ceiling with an explicit truncation
+ * marker. Callers use this for reason/log columns, where a bounded string is
+ * the correct persisted shape when the full payload cannot be offloaded.
+ */
+export function clampInlineDiagnosticText(value: string): string {
+  const cap = maxInlineBytes();
+  const size = byteLength(value);
+  if (size <= cap) return value;
+  const marker =
+    `\n…[truncated: ${size}-byte payload exceeded the ${cap}-byte SQL inline ceiling; ` +
+    `configure object storage to retain the full payload]`;
+  return truncateToBytes(value, Math.max(0, cap - byteLength(marker))) + marker;
+}
+
+/** Byte size at which a value is refused inline storage. */
+export function inlinePayloadCeilingBytes(): number {
+  return maxInlineBytes();
+}
+
+function guardInlineSize(field: string, value: string): void {
+  const cap = maxInlineBytes();
+  const size = byteLength(value);
+  if (size > cap) {
+    throw new InlinePayloadTooLargeError({ field, sizeBytes: size, maxBytes: cap });
+  }
+}
+
 function minBytes(): number {
   const raw = getCloudAwareEnv().SQL_HEAVY_PAYLOAD_MIN_BYTES;
   if (!raw) return 0;
@@ -2074,9 +2153,22 @@ export async function offloadTextField(params: {
   value: string | null | undefined;
   keepPreview?: boolean;
   inlineValueWhenOffloaded?: string;
+  /**
+   * How to handle a value above the inline ceiling when object storage is
+   * unavailable: `"clamp"` persists a bounded, explicitly-marked truncation
+   * (correct for diagnostic reason/log columns), `"throw"` (default) refuses
+   * the write so the caller cannot silently bloat a text column.
+   */
+  oversizeInline?: "clamp" | "throw";
 }): Promise<OffloadedField<string>> {
   if (params.value == null) return { value: null, storage: "inline", key: null };
-  if (!shouldOffload(params.value)) return { value: params.value, storage: "inline", key: null };
+  if (!shouldOffload(params.value)) {
+    if (params.oversizeInline === "clamp") {
+      return { value: clampInlineDiagnosticText(params.value), storage: "inline", key: null };
+    }
+    guardInlineSize(params.field, params.value);
+    return { value: params.value, storage: "inline", key: null };
+  }
 
   const key = await putObjectText({
     namespace: params.namespace,
@@ -2108,7 +2200,12 @@ export async function offloadJsonField<T>(params: {
 }): Promise<OffloadedField<T>> {
   if (params.value == null) return { value: null, storage: "inline", key: null };
   const body = JSON.stringify(params.value);
-  if (!shouldOffload(body)) return { value: params.value, storage: "inline", key: null };
+  if (!shouldOffload(body)) {
+    // Structured payloads cannot be truncated without becoming invalid, so an
+    // oversize inline JSON write always fails rather than degrading silently.
+    guardInlineSize(params.field, body);
+    return { value: params.value, storage: "inline", key: null };
+  }
 
   const key = await putObjectText({
     namespace: params.namespace,

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -305,6 +305,12 @@ export interface Bindings {
   SQL_HEAVY_PAYLOAD_STORAGE?: string;
   SQL_HEAVY_PAYLOAD_MIN_BYTES?: string;
   SQL_HEAVY_PAYLOAD_INLINE_PREVIEW_BYTES?: string;
+  /**
+   * Hard ceiling, in bytes, on a single field persisted inline in a SQL text or
+   * jsonb column when object storage is unavailable. Defaults to 1 MiB; values
+   * below 1024 are ignored.
+   */
+  SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES?: string;
   LLM_TRAJECTORY_STORAGE?: string;
 
   // ---- Steward (auth provider) ----


### PR DESCRIPTION
Relates to #22553

## Problem

Goal G item 3 asks that "the paths that put [large payloads] there can no longer do so". The offload helpers in `packages/cloud/shared/src/lib/storage/object-store.ts` only offload when `shouldUseObjectStorage()` is true. When the gate is off — which is the deployed state described in the issue — `offloadTextField` / `offloadJsonField` fall through to an **unbounded inline write**. That is the mechanism by which 33 failed snapshot rows each put a ~250 MB PGlite dump into `jobs.error`, a column whose contract is a reason string.

Flipping the gate on does not close this: any environment without a heavy-payload bucket keeps the same unbounded path, and the next incident refills the column.

## Change

A byte ceiling on the inline branch, enforced where the fall-through happens:

- `SQL_HEAVY_PAYLOAD_MAX_INLINE_BYTES` (default 1 MiB; values under 1024 or non-numeric fall back to the default) is the hard limit on a single field persisted inline.
- **Structured payloads** (`offloadJsonField`) are refused with a typed `InlinePayloadTooLargeError` (`code: "INLINE_PAYLOAD_TOO_LARGE"`, carrying field, size, and ceiling). JSON cannot be truncated without becoming invalid, so this fails fast per the repository error policy rather than degrading silently.
- **Diagnostic text columns** opt into `oversizeInline: "clamp"`, which persists a bounded, explicitly-marked truncation (`…[truncated: N-byte payload exceeded the M-byte SQL inline ceiling; configure object storage to retain the full payload]`) on whole-character boundaries. Applied to `jobs.error` (both the offload path and the `error_storage === "inline"` forced path), `containers.deployment_log` (insert and update), and `agent_events.message`.
- Text fields that did not opt in keep the default `"throw"` behavior, so no other path can quietly write an unbounded blob either.

The clamp marker names the missing configuration, so an operator reading a truncated row learns why the full payload is absent instead of seeing a healthy-looking short string.

## Tests

New `packages/cloud/shared/src/lib/storage/object-store-inline-ceiling.test.ts` (8 tests) exercises the real helpers with storage env cleared — it first asserts `shouldUseObjectStorage() === false` so the suite provably takes the inline branch:

- under-ceiling value stored inline unchanged;
- oversize text refused by default, with the typed error's `code` / `field` / `sizeBytes` / `maxInlineBytes` asserted;
- opted-in diagnostic field clamped to the ceiling and marked;
- oversize JSON refused, never truncated;
- multi-byte clamp preserves whole characters (no replacement chars);
- sub-floor and non-numeric ceilings fall back to 1 MiB;
- `null` unaffected.

New regression case in `packages/cloud/shared/src/db/repositories/jobs.test.ts` drives the real `prepareJobInsertData` with `SQL_HEAVY_PAYLOAD_STORAGE=inline` and a 55 KB dump in `error`, asserting the persisted value stays within the ceiling, keeps the leading diagnostic text, and carries the truncation marker — i.e. the exact shape of the incident row can no longer be produced.

```
bun test --isolate src/lib/storage src/db/repositories/jobs.test.ts \
  src/db/repositories/__tests__/jobs-recovery.test.ts \
  src/db/repositories/agent-events.test.ts src/db/repositories/containers.test.ts \
  src/db/repositories/agent-sandboxes.test.ts
→ 94 pass, 0 fail, 558 expect() calls
```

`bun run --cwd packages/cloud/shared lint` and `typecheck` are clean for the touched files.

## Explicitly not claimed here (human-only remainder of Goal G)

This PR closes the code half of item 3 — the path that put payloads in text columns. The following require production access or physical proof and are **not** claimed:

- **Item 3, space returned:** deleting/vacuuming the existing 9.9 GB of out-of-line `jobs.error` data, and reading those dumps before destroying them. This change is prospective only.
- **Item 4:** restoring one of the 18 `legacy_unmigrated` sandbox backups. A restore performed by a human, not a flag.
- **Items 1 and 2:** the billing predicate and the empty-set-vs-broken-biller discriminator were addressed in #22620 and #23191; the production log read that distinguishes the two remains an operational step.
- **Items 5 and 6:** cgroup OOM diagnosis and agent-image boot health (embeddings 503, swarm coordinator, missing plugin dependency) are host/image work outside this repository change.
- Enabling `SQL_HEAVY_PAYLOAD_STORAGE` in the deployed environment is a configuration action; this PR makes the unconfigured state safe rather than assuming it will be fixed.

## Evidence Gate

<!-- evidence-head:702e5ee80e8628f5f29c1846ad771c341b7b4656 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side storage boundary with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side storage boundary with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow changed.
<!-- evidence-row:backend-logs -->
- [x] Exact-head deterministic storage-guard suite passed 94 tests with 558 assertions, recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or prompt behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact tests assert bounded stored text, typed JSON refusal, and forced-inline job error clamping.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text.
