### PR TITLE
fix(core): restore EOF as a raw-text tag-name delimiter

### DIFF
--- a/packages/core/src/utils/html-raw-text.test.ts
+++ b/packages/core/src/utils/html-raw-text.test.ts
@@ -105,6 +105,17 @@ describe("stripHtmlRawTextElements", () => {
 		).toBe("before after");
 	});
 
+	it.each(["text<script", "text<style"])(
+		"treats end of input as an opening tag-name delimiter, matching eof-in-tag",
+		(markup) => {
+			expect(stripHtmlRawTextElements(markup)).toBe("text ");
+		},
+	);
+
+	it("strips through EOF when a closing tag name abuts end of input", () => {
+		expect(stripHtmlRawTextElements("a<script>bad</script")).toBe("a ");
+	});
+
 	it.each(["<script>hidden", "<style data-x='>' hidden"])(
 		"removes an unclosed raw-text element through EOF",
 		(markup) => {

--- a/packages/core/src/utils/html-raw-text.ts
+++ b/packages/core/src/utils/html-raw-text.ts
@@ -2,9 +2,12 @@
  * Removes HTML script and style elements with a bounded tokenizer pass.
  *
  * An appropriate HTML raw-text end-tag name transitions only on ASCII
- * whitespace, a slash, or `>`. Regex-based filters routinely accept broader
- * punctuation lookalikes or miss parser-accepted trailing material, exposing
- * raw script/style bodies as visible text after a later generic tag strip.
+ * whitespace, a slash, `>`, or end of input. Regex-based filters routinely
+ * accept broader punctuation lookalikes or miss parser-accepted trailing
+ * material, exposing raw script/style bodies as visible text after a later
+ * generic tag strip. End of input stays a delimiter: the WHATWG tokenizer's
+ * eof-in-tag path emits nothing for a buffered `<script` at EOF, so treating
+ * EOF as a delimiter (and stripping through end of input) matches browsers.
  */
 
 const RAW_TEXT_TAGS = ["script", "style"] as const;
@@ -35,9 +38,10 @@ function matchesAsciiCaseInsensitive(
 
 function isTagNameDelimiter(character: string | undefined): boolean {
 	return (
+		character === undefined ||
 		character === ">" ||
 		character === "/" ||
-		(character !== undefined && isAsciiWhitespace(character))
+		isAsciiWhitespace(character)
 	);
 }
 


### PR DESCRIPTION
# Relates to

Refs #23307. Fix-forward for a regression introduced by the #23373 merge.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from latest `origin/develop`; zero conflicts.

# Risks

Low. One predicate widened back to its pre-#23373 form; all 38 scanner tests (including #23363's escape-state suite and #23373's punctuation-lookalike suite) pass.

# Background

## What does this PR do?

#23373 removed end-of-input from `isTagNameDelimiter`. Its punctuation-lookalike hardening was already satisfied by the consolidated scanner (every lookalike test in that PR passes on the pre-#23373 code unchanged); the delimiter narrowing was its only behavioral delta, and it is a fidelity regression: for an opening tag name abutting EOF (`text<script`), the WHATWG tokenizer's eof-in-tag path emits nothing for the buffered tag, so the pre-#23373 strip-through-EOF matched browsers while the narrowed predicate leaks the literal `<script` text into visible output. For closing tags at EOF the two behave identically.

This restores the EOF pseudo-delimiter, documents the invariant in the file header, and pins the EOF-abutting opening- and closing-tag cases with tests. It composes with the #23363 escape-state machine (an EOF-delimited closing name still closes at end of input, which strips through EOF either way).

## What kind of change is this?

Bug fix (regression fix-forward).

# Testing

`packages/core` scanner suite at this head: 38/38 passed (`bunx vitest run src/utils/html-raw-text.test.ts`), covering the #23363 escape-state cases, the #23373 punctuation-lookalike cases, and the two new EOF cases.

# Evidence Gate

<!-- evidence-head:63b6477bd3495cdc2ee7975d7548cab73424ec5f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend text-extraction boundary with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend text-extraction boundary with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic parser utility; direct test receipt above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - extraction preprocessing only.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - visible-text output asserted directly in the suite.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [core-raw-text]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza"} -->

