### PR TITLE
fix(ui): report zero trajectory lines for absent prompt text

### DIFF
--- a/packages/ui/src/components/pages/TrajectoryDetailView.test.ts
+++ b/packages/ui/src/components/pages/TrajectoryDetailView.test.ts
@@ -1,5 +1,15 @@
+/**
+ * Covers the trajectory detail view's sparse-record text normalization and the
+ * line-count metadata derived from it. The harness is deterministic: the
+ * exported pure helpers are called directly, with no runtime, network, or DOM
+ * rendering involved, so a missing prompt must never fabricate a line count.
+ */
+
 import { describe, expect, it } from "vitest";
-import { normalizeTrajectoryCallText } from "./TrajectoryDetailView";
+import {
+  countTrajectoryTextLines,
+  normalizeTrajectoryCallText,
+} from "./TrajectoryDetailView";
 
 describe("normalizeTrajectoryCallText", () => {
   it("keeps sparse trajectory calls renderable", () => {
@@ -20,5 +30,45 @@ describe("normalizeTrajectoryCallText", () => {
         { role: "user", content: "open notes" },
       ]),
     ).toContain('"content": "open notes"');
+  });
+
+  it("serializes falsy non-null payloads instead of dropping them", () => {
+    expect(normalizeTrajectoryCallText(false)).toBe("false");
+    expect(normalizeTrajectoryCallText(0)).toBe("0");
+    expect(normalizeTrajectoryCallText(undefined, false, "later")).toBe(
+      "false",
+    );
+  });
+});
+
+describe("countTrajectoryTextLines", () => {
+  it("reports zero lines for absent or empty trajectory text", () => {
+    expect(countTrajectoryTextLines(undefined)).toBe(0);
+    expect(countTrajectoryTextLines(null)).toBe(0);
+    expect(countTrajectoryTextLines("")).toBe(0);
+    expect(countTrajectoryTextLines("   \n\t  ")).toBe(0);
+    expect(
+      countTrajectoryTextLines(normalizeTrajectoryCallText(undefined, null)),
+    ).toBe(0);
+  });
+
+  it("counts real lines truthfully", () => {
+    expect(countTrajectoryTextLines("one line")).toBe(1);
+    expect(countTrajectoryTextLines("first\nsecond\nthird")).toBe(3);
+    expect(countTrajectoryTextLines("trailing\n")).toBe(2);
+  });
+
+  it("counts normalized falsy and structured fallbacks", () => {
+    expect(countTrajectoryTextLines(normalizeTrajectoryCallText(false))).toBe(
+      1,
+    );
+    expect(countTrajectoryTextLines(normalizeTrajectoryCallText(0))).toBe(1);
+    expect(
+      countTrajectoryTextLines(
+        normalizeTrajectoryCallText(undefined, [
+          { role: "user", content: "open notes" },
+        ]),
+      ),
+    ).toBeGreaterThan(1);
   });
 });

--- a/packages/ui/src/components/pages/TrajectoryDetailView.tsx
+++ b/packages/ui/src/components/pages/TrajectoryDetailView.tsx
@@ -157,6 +157,18 @@ export function normalizeTrajectoryCallText(...candidates: unknown[]): string {
   return "";
 }
 
+/**
+ * Line counts are metadata a reader trusts, so an absent or whitespace-only
+ * prompt must report zero rather than the `1` that `"".split("\n")` yields.
+ * Only genuine text contributes a count; `false` and `0` arrive here already
+ * serialized by `normalizeTrajectoryCallText` and keep their truthful count.
+ */
+export function countTrajectoryTextLines(value: unknown): number {
+  if (typeof value !== "string") return 0;
+  if (value.trim().length === 0) return 0;
+  return value.split("\n").length;
+}
+
 function isNativeToolCallEvent(
   event: TrajectoryEvent,
 ): event is NativeToolCallEvent {
@@ -761,9 +773,9 @@ export function TrajectoryDetailView({
                 systemPrompt={call.systemPrompt}
                 systemPromptButtonLabel={t("trajectorydetailview.SystemPrompt")}
                 systemLabel={t("trajectorydetailview.System")}
-                systemLinesLabel={`${call.systemPrompt?.split("\n").length ?? 0} ${t(
-                  "trajectorydetailview.lines",
-                )}`}
+                systemLinesLabel={`${countTrajectoryTextLines(
+                  call.systemPrompt,
+                )} ${t("trajectorydetailview.lines")}`}
                 systemCollapseLabel={t("common.collapse", {
                   defaultValue: "Collapse",
                 })}
@@ -772,18 +784,16 @@ export function TrajectoryDetailView({
                 })}
                 inputLabel={t("trajectorydetailview.InputUser")}
                 outputLabel={t("trajectorydetailview.OutputResponse")}
-                inputLinesLabel={`${
+                inputLinesLabel={`${countTrajectoryTextLines(
                   normalizeTrajectoryCallText(
                     call.userPrompt,
                     call.prompt,
                     call.messages,
-                  ).split("\n").length
-                } ${t("trajectorydetailview.lines")}`}
-                outputLinesLabel={`${
-                  normalizeTrajectoryCallText(call.response, call.output).split(
-                    "\n",
-                  ).length
-                } ${t("trajectorydetailview.lines")}`}
+                  ),
+                )} ${t("trajectorydetailview.lines")}`}
+                outputLinesLabel={`${countTrajectoryTextLines(
+                  normalizeTrajectoryCallText(call.response, call.output),
+                )} ${t("trajectorydetailview.lines")}`}
                 tags={(call.tags ?? []).filter((tag) => tag !== "llm")}
                 userPrompt={normalizeTrajectoryCallText(
                   call.userPrompt,


### PR DESCRIPTION
Fixes #22601. Corrective follow-up to merged #22570.

## Problem

#22570 landed sparse trajectory rendering but the line-count labels still called `.split("\n").length` on the normalized string. `"".split("\n").length === 1`, so an absent, `null`, `undefined`, or empty system prompt / input / output rendered as `1 lines` — fabricated metadata in a diagnostic surface where the reader trusts the count. The `systemLinesLabel` `?? 0` guard only covered `undefined`, not the empty string. The new deterministic test file also lacked the repository-required prose responsibility header.

## Change

`packages/ui/src/components/pages/TrajectoryDetailView.tsx`

- adds exported `countTrajectoryTextLines(value: unknown): number` — non-strings and whitespace-only strings count zero; genuine text keeps `split("\n").length`;
- routes the system, input, and output line labels through it, replacing the three raw `.split("\n").length` sites.

Falsy-but-real payloads are unaffected: `normalizeTrajectoryCallText` already serializes `false` and `0` to `"false"` / `"0"`, which count as one line. Structured JSON fallbacks keep their true multiline counts.

`packages/ui/src/components/pages/TrajectoryDetailView.test.ts`

- adds the required deterministic-harness prose header (pure exported helpers, no runtime, network, or DOM);
- adds coverage for absent/`null`/empty/whitespace-only input reporting zero, truthful single/multi/trailing-newline counts, serialized `false`/`0`, and structured fallbacks.

## Scope note

This is trajectory line-count metadata only. Open draft PR #22627 covers the separate sparse-payload preservation work on the same view; this PR does not touch `normalizeTrajectoryCallText` or `formatProviderPayload`, so the two do not overlap in behavior.

## Verification

```
$ bun x vitest run src/components/pages/TrajectoryDetailView.test.ts   # packages/ui
 Test Files  1 passed (1)
      Tests  6 passed (6)

$ bun x @biomejs/biome check <both touched files>
Checked 2 files in 53ms. No fixes applied.

$ bun x tsc --noEmit -p tsconfig.json   # packages/ui
zero diagnostics for TrajectoryDetailView.{tsx,test.ts}
```

The `tsc` run reports pre-existing unrelated diagnostics (`stripe`, `ai`, `pg`, `lucide-react`, `unpdf` module resolution) caused by this isolated worktree's partial dependency install; none are in or caused by the touched files.

## Human-only remainder

Per the issue's own acceptance ("no broad app packaging is required because this is a deterministic text-metadata correction"), no visual evidence row applies. Not run here: the root `bun run verify` gate and `bun run --cwd packages/app audit:app`, which need a full workspace install this isolated worktree does not have. CI on the exact head covers the former.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: Claude Code

\n## Evidence Gate\n\n<!-- evidence-head:1487f96421f37b0d0446d9fe86dba1a6c987c7fe -->\n<!-- evidence-row:before-screenshots -->\n- [ ] Exact-head before capture/app audit remains pending before merge.\n<!-- evidence-row:after-screenshots -->\n- [ ] Exact-head after capture/app audit remains pending before merge.\n<!-- evidence-row:walkthrough-video -->\n- [ ] Exact-head interaction walkthrough remains pending before merge.\n<!-- evidence-row:backend-logs -->\n- [x] Focused trajectory detail-view suite passes 6/6.\n<!-- evidence-row:frontend-logs -->\n- [ ] Exact-head browser console/network receipt remains pending before merge.\n<!-- evidence-row:llm-trajectory -->\n- [x] N/A - no model, prompt, or provider behavior changed.\n<!-- evidence-row:domain-artifacts -->\n- [x] Focused trajectory detail-view suite passes 6/6.\n<!-- evidence-row:ocr-review -->\n- [ ] Exact-head visual/OCR review remains pending before merge.\n