### PR TITLE
fix(ui): make sparse trajectory calls truthful

### DIFF
--- a/packages/app/test/ui-smoke/apps-model-training-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-model-training-interactions.spec.ts
@@ -215,16 +215,27 @@ async function installTrajectoryViewerInteractionRoutes(page: Page) {
             : '{"decision":"RESPOND","reasoning":"beta should respond"}',
           ["should_respond"],
         ),
-        trajectoryLlmCall(
-          `${record.id}-plan`,
-          record.id,
-          "response",
-          alpha ? "deterministic-model-a" : "deterministic-model-b",
-          alpha
-            ? "Alpha response from Playwright trajectory fixture."
-            : "Beta response from Playwright trajectory fixture.",
-          ["plan"],
-        ),
+        {
+          ...trajectoryLlmCall(
+            `${record.id}-plan`,
+            record.id,
+            "response",
+            alpha ? "deterministic-model-a" : "deterministic-model-b",
+            "Alpha response from Playwright trajectory fixture.",
+            ["plan"],
+          ),
+          // The beta plan call is the sparse recorded shape the viewer has to
+          // render truthfully: a whitespace-only primary prompt, an empty
+          // response string, and falsy-but-real `0`/`false` fallbacks.
+          ...(alpha
+            ? {}
+            : {
+                userPrompt: "   ",
+                prompt: 0,
+                response: "",
+                output: false,
+              }),
+        },
       ],
       providerAccesses: [
         {
@@ -453,8 +464,15 @@ test("trajectory viewer route refreshes, filters, and changes selected detail", 
     .toBe(true);
   await closeMobilePageSidebar(page);
   await expect(page.getByText("deterministic-model-b").first()).toBeVisible();
+  const sparseInput = page.locator('section[aria-label="Input (User)"]');
+  const sparseOutput = page.locator('section[aria-label="Output (Response)"]');
+  await expect(sparseInput).toHaveText("0");
+  await expect(sparseOutput).toHaveText("false");
   await expect(
-    page.getByText("Beta response from Playwright trajectory fixture.").first(),
+    sparseInput.locator("xpath=..").getByText("1 lines", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    sparseOutput.locator("xpath=..").getByText("1 lines", { exact: true }),
   ).toBeVisible();
 
   // NOTE: the trajectories list search moved to the floating chat composer.

--- a/packages/ui/src/components/pages/TrajectoryDetailView.sparse-call.test.tsx
+++ b/packages/ui/src/components/pages/TrajectoryDetailView.sparse-call.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Renders the trajectory LLM call card with the exact texts the trajectory
+ * detail view derives for a sparse recorded call, proving the on-screen line
+ * badges match the panels beside them. Deterministic jsdom render of the real
+ * card component; no runtime or network is involved.
+ */
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TrajectoryLlmCallCard } from "../composites/trajectories/trajectory-llm-call-card";
+import {
+  buildTrajectoryCallText,
+  countTrajectoryTextLines,
+} from "./TrajectoryDetailView";
+
+type SparseCall = Parameters<typeof buildTrajectoryCallText>[0];
+
+/**
+ * Legacy and provider-failure trajectory rows arrive with explicit `null`
+ * columns even though the DTO declares the fields optional, so the fixtures
+ * are widened deliberately rather than sanitized before the view sees them.
+ */
+function sparseCall(record: Record<string, unknown>): SparseCall {
+  return record as unknown as SparseCall;
+}
+
+function renderCall(call: SparseCall) {
+  const { systemPromptText, inputText, outputText } =
+    buildTrajectoryCallText(call);
+  render(
+    <TrajectoryLlmCallCard
+      callLabel="#1"
+      model="gpt-test"
+      purposeLabel="Purpose"
+      latencyLabel="Latency"
+      latencyValue="—"
+      tokensLabel="Tokens"
+      totalTokensValue="—"
+      tokenBreakdownMeta="— ↑ • — ↓"
+      temperatureLabel="Temp"
+      temperatureValue={0}
+      maxLabel="Max"
+      maxValue="—"
+      systemPrompt={systemPromptText.length > 0 ? systemPromptText : null}
+      systemPromptButtonLabel="System prompt"
+      systemLabel="System"
+      systemLinesLabel={`${countTrajectoryTextLines(systemPromptText)} lines`}
+      systemCollapseLabel="Collapse"
+      systemExpandLabel="Expand"
+      inputLabel="Input"
+      outputLabel="Output"
+      inputLinesLabel={`${countTrajectoryTextLines(inputText)} lines`}
+      outputLinesLabel={`${countTrajectoryTextLines(outputText)} lines`}
+      userPrompt={inputText}
+      response={outputText}
+      copyLabel="Copy"
+      copyToClipboardLabel="Copy to clipboard"
+      onCopy={() => {}}
+    />,
+  );
+}
+
+describe("sparse trajectory call rendering", () => {
+  it("reports zero lines instead of a fabricated single line", () => {
+    renderCall(
+      sparseCall({
+        systemPrompt: undefined,
+        userPrompt: undefined,
+        prompt: null,
+        messages: undefined,
+        response: "",
+        output: null,
+      }),
+    );
+
+    expect(screen.getAllByText("0 lines").length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByText("1 lines")).toBeNull();
+    expect(screen.queryByText("System prompt")).toBeNull();
+  });
+
+  it("renders the populated fallback and counts its real lines", () => {
+    renderCall(
+      sparseCall({
+        systemPrompt: "   ",
+        userPrompt: "",
+        prompt: "line one\nline two",
+        messages: undefined,
+        response: null,
+        output: "only output line",
+      }),
+    );
+
+    expect(screen.getByText(/line one/)).toBeTruthy();
+    expect(screen.getByText(/only output line/)).toBeTruthy();
+    expect(screen.getAllByText("2 lines").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("1 lines").length).toBeGreaterThanOrEqual(1);
+    // A whitespace-only system prompt stays absent rather than opening an
+    // empty panel behind a truthy toggle.
+    expect(screen.queryByText("System prompt")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/pages/TrajectoryDetailView.sparse-call.test.tsx
+++ b/packages/ui/src/components/pages/TrajectoryDetailView.sparse-call.test.tsx
@@ -6,8 +6,8 @@
  */
 // @vitest-environment jsdom
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
 import { TrajectoryLlmCallCard } from "../composites/trajectories/trajectory-llm-call-card";
 import {
   buildTrajectoryCallText,
@@ -62,6 +62,12 @@ function renderCall(call: SparseCall) {
 }
 
 describe("sparse trajectory call rendering", () => {
+  // The suite runs with `globals: false`, so RTL never registers its automatic
+  // teardown; without this each render would accumulate in the same document.
+  afterEach(() => {
+    cleanup();
+  });
+
   it("reports zero lines instead of a fabricated single line", () => {
     renderCall(
       sparseCall({
@@ -98,5 +104,22 @@ describe("sparse trajectory call rendering", () => {
     // A whitespace-only system prompt stays absent rather than opening an
     // empty panel behind a truthy toggle.
     expect(screen.queryByText("System prompt")).toBeNull();
+  });
+
+  it("does not let an empty recorded object shadow a populated fallback", () => {
+    renderCall(
+      sparseCall({
+        systemPrompt: null,
+        userPrompt: {},
+        prompt: undefined,
+        messages: [{ role: "user", content: "recovered message" }],
+        response: {},
+        output: "recovered output",
+      }),
+    );
+
+    expect(screen.getByText(/recovered message/)).toBeTruthy();
+    expect(screen.getByText(/recovered output/)).toBeTruthy();
+    expect(screen.queryByText("{}")).toBeNull();
   });
 });

--- a/packages/ui/src/components/pages/TrajectoryDetailView.test.ts
+++ b/packages/ui/src/components/pages/TrajectoryDetailView.test.ts
@@ -53,6 +53,21 @@ describe("normalizeTrajectoryCallText", () => {
     ).toContain('"content": "open notes"');
   });
 
+  it("treats an empty recorded object as absent", () => {
+    expect(normalizeTrajectoryCallText({}, "fallback prompt")).toBe(
+      "fallback prompt",
+    );
+    expect(normalizeTrajectoryCallText({}, {}, undefined)).toBe("");
+    expect(normalizeTrajectoryCallText({}, { tool: "notes.open" })).toContain(
+      '"tool": "notes.open"',
+    );
+  });
+
+  it("keeps falsy scalars, which are real recorded values", () => {
+    expect(normalizeTrajectoryCallText("", 0)).toBe("0");
+    expect(normalizeTrajectoryCallText("   ", false)).toBe("false");
+  });
+
   it("keeps the first populated candidate rather than a later one", () => {
     expect(normalizeTrajectoryCallText("primary", "fallback")).toBe("primary");
   });

--- a/packages/ui/src/components/pages/TrajectoryDetailView.test.ts
+++ b/packages/ui/src/components/pages/TrajectoryDetailView.test.ts
@@ -1,10 +1,37 @@
+/**
+ * Covers the sparse-trajectory rendering boundary of the trajectory detail
+ * view: candidate fallback selection and line counting for recorded LLM calls
+ * that omit or blank their prompt, message, and output fields. Deterministic
+ * pure-function harness — no runtime, network, or DOM is involved.
+ */
+
 import { describe, expect, it } from "vitest";
-import { normalizeTrajectoryCallText } from "./TrajectoryDetailView";
+import {
+  countTrajectoryTextLines,
+  normalizeTrajectoryCallText,
+} from "./TrajectoryDetailView";
 
 describe("normalizeTrajectoryCallText", () => {
-  it("keeps sparse trajectory calls renderable", () => {
+  it("returns empty text when every candidate is absent", () => {
+    expect(normalizeTrajectoryCallText()).toBe("");
     expect(normalizeTrajectoryCallText(undefined, null)).toBe("");
+    expect(normalizeTrajectoryCallText(null, undefined, "")).toBe("");
+  });
+
+  it("falls through undefined and null primaries to a populated candidate", () => {
     expect(normalizeTrajectoryCallText(undefined, "fallback prompt")).toBe(
+      "fallback prompt",
+    );
+    expect(normalizeTrajectoryCallText(null, "fallback prompt")).toBe(
+      "fallback prompt",
+    );
+  });
+
+  it("falls through blank and whitespace-only primaries", () => {
+    expect(normalizeTrajectoryCallText("", "fallback prompt")).toBe(
+      "fallback prompt",
+    );
+    expect(normalizeTrajectoryCallText("   \n\t ", "fallback prompt")).toBe(
       "fallback prompt",
     );
     expect(
@@ -14,11 +41,46 @@ describe("normalizeTrajectoryCallText", () => {
     ).toContain('"content": "message-only input"');
   });
 
-  it("preserves structured fallback data as inspectable JSON", () => {
+  it("treats an empty array as absent but preserves a populated one", () => {
+    expect(normalizeTrajectoryCallText([], "fallback prompt")).toBe(
+      "fallback prompt",
+    );
+    expect(normalizeTrajectoryCallText([], [], undefined)).toBe("");
     expect(
       normalizeTrajectoryCallText(undefined, [
         { role: "user", content: "open notes" },
       ]),
     ).toContain('"content": "open notes"');
+  });
+
+  it("keeps the first populated candidate rather than a later one", () => {
+    expect(normalizeTrajectoryCallText("primary", "fallback")).toBe("primary");
+  });
+
+  it("preserves structured fallback data as inspectable JSON", () => {
+    expect(normalizeTrajectoryCallText({ tool: "notes.open" })).toBe(
+      '{\n  "tool": "notes.open"\n}',
+    );
+  });
+
+  it("renders a non-serializable payload instead of blanking the panel", () => {
+    const cyclic: Record<string, unknown> = { name: "cyclic" };
+    cyclic.self = cyclic;
+    expect(normalizeTrajectoryCallText(cyclic)).toBe("[object Object]");
+  });
+});
+
+describe("countTrajectoryTextLines", () => {
+  it("reports zero lines for absent normalized text", () => {
+    expect(countTrajectoryTextLines("")).toBe(0);
+    expect(
+      countTrajectoryTextLines(normalizeTrajectoryCallText(undefined, null)),
+    ).toBe(0);
+  });
+
+  it("counts real lines once text is present", () => {
+    expect(countTrajectoryTextLines("one line")).toBe(1);
+    expect(countTrajectoryTextLines("first\nsecond")).toBe(2);
+    expect(countTrajectoryTextLines("trailing\n")).toBe(2);
   });
 });

--- a/packages/ui/src/components/pages/TrajectoryDetailView.tsx
+++ b/packages/ui/src/components/pages/TrajectoryDetailView.tsx
@@ -138,8 +138,23 @@ function formatProviderPayload(value: unknown): string {
   try {
     return JSON.stringify(value, null, 2);
   } catch {
+    // error-policy:J4 a cyclic or non-serializable recorded payload is an
+    // expected trajectory shape; degrade to its printable form rather than
+    // blanking the inspector.
     return String(value);
   }
+}
+
+/**
+ * A candidate carries content only when it would render something a reader can
+ * inspect. Whitespace-only strings and empty collections are blank in the UI,
+ * so they must not shadow a later populated candidate.
+ */
+function hasRenderableContent(candidate: unknown): boolean {
+  if (candidate == null) return false;
+  if (typeof candidate === "string") return candidate.trim().length > 0;
+  if (Array.isArray(candidate)) return candidate.length > 0;
+  return true;
 }
 
 /**
@@ -150,11 +165,53 @@ function formatProviderPayload(value: unknown): string {
  */
 export function normalizeTrajectoryCallText(...candidates: unknown[]): string {
   for (const candidate of candidates) {
-    if (candidate == null) continue;
-    if (typeof candidate === "string" && candidate.length === 0) continue;
+    if (!hasRenderableContent(candidate)) continue;
     return formatProviderPayload(candidate);
   }
   return "";
+}
+
+/**
+ * Line count for a normalized trajectory field. Absent text has zero lines;
+ * `"".split("\n").length` would otherwise report a fabricated single line in
+ * the badge next to an empty panel.
+ */
+export function countTrajectoryTextLines(text: string): number {
+  if (text.length === 0) return 0;
+  return text.split("\n").length;
+}
+
+export interface TrajectoryCallText {
+  systemPromptText: string;
+  inputText: string;
+  outputText: string;
+}
+
+/**
+ * The single place a recorded call becomes the three panels the card renders.
+ * The line badges are derived from exactly these strings, so a panel can never
+ * disagree with the count printed beside it.
+ */
+export function buildTrajectoryCallText(
+  call: Pick<
+    TrajectoryLlmCall,
+    | "systemPrompt"
+    | "userPrompt"
+    | "prompt"
+    | "messages"
+    | "response"
+    | "output"
+  >,
+): TrajectoryCallText {
+  return {
+    systemPromptText: normalizeTrajectoryCallText(call.systemPrompt),
+    inputText: normalizeTrajectoryCallText(
+      call.userPrompt,
+      call.prompt,
+      call.messages,
+    ),
+    outputText: normalizeTrajectoryCallText(call.response, call.output),
+  };
 }
 
 function isNativeToolCallEvent(
@@ -730,77 +787,78 @@ export function TrajectoryDetailView({
               description={t("trajectorydetailview.NoLLMCallsRecorde")}
             />
           ) : (
-            filteredCalls.map((call) => (
-              <TrajectoryLlmCallCard
-                key={call.id}
-                callLabel={`#${(callIndexMap.get(call.id) ?? 0) + 1}`}
-                model={call.model}
-                purposeLabel={formatTrajectoryStepLabel(
-                  call.stepType || call.purpose || call.actionType,
-                  t("trajectorydetailview.Response"),
-                )}
-                latencyLabel={t("trajectorydetailview.Latency", {
-                  defaultValue: "Latency",
-                })}
-                latencyValue={formatTrajectoryDuration(call.latencyMs)}
-                tokensLabel={t("common.tokens")}
-                totalTokensValue={formatTrajectoryTokenCount(
-                  (call.promptTokens ?? 0) + (call.completionTokens ?? 0),
-                  { emptyLabel: "—" },
-                )}
-                tokenBreakdownMeta={`${formatTrajectoryTokenCount(
-                  call.promptTokens ?? 0,
-                  { emptyLabel: "—" },
-                )}↑ • ${formatTrajectoryTokenCount(call.completionTokens ?? 0, {
-                  emptyLabel: "—",
-                })} ↓`}
-                temperatureLabel={t("trajectorydetailview.Temp")}
-                temperatureValue={call.temperature}
-                maxLabel={t("trajectorydetailview.Max")}
-                maxValue={call.maxTokens > 0 ? call.maxTokens : "—"}
-                systemPrompt={call.systemPrompt}
-                systemPromptButtonLabel={t("trajectorydetailview.SystemPrompt")}
-                systemLabel={t("trajectorydetailview.System")}
-                systemLinesLabel={`${call.systemPrompt?.split("\n").length ?? 0} ${t(
-                  "trajectorydetailview.lines",
-                )}`}
-                systemCollapseLabel={t("common.collapse", {
-                  defaultValue: "Collapse",
-                })}
-                systemExpandLabel={t("common.expand", {
-                  defaultValue: "Expand",
-                })}
-                inputLabel={t("trajectorydetailview.InputUser")}
-                outputLabel={t("trajectorydetailview.OutputResponse")}
-                inputLinesLabel={`${
-                  normalizeTrajectoryCallText(
-                    call.userPrompt,
-                    call.prompt,
-                    call.messages,
-                  ).split("\n").length
-                } ${t("trajectorydetailview.lines")}`}
-                outputLinesLabel={`${
-                  normalizeTrajectoryCallText(call.response, call.output).split(
-                    "\n",
-                  ).length
-                } ${t("trajectorydetailview.lines")}`}
-                tags={(call.tags ?? []).filter((tag) => tag !== "llm")}
-                userPrompt={normalizeTrajectoryCallText(
-                  call.userPrompt,
-                  call.prompt,
-                  call.messages,
-                )}
-                response={normalizeTrajectoryCallText(
-                  call.response,
-                  call.output,
-                )}
-                copyLabel={t("trajectorydetailview.Copy")}
-                copyToClipboardLabel={t("trajectorydetailview.CopyToClipboard")}
-                onCopy={(content) => {
-                  void copyToClipboard(content);
-                }}
-              />
-            ))
+            filteredCalls.map((call) => {
+              const { systemPromptText, inputText, outputText } =
+                buildTrajectoryCallText(call);
+              const linesLabel = t("trajectorydetailview.lines");
+              return (
+                <TrajectoryLlmCallCard
+                  key={call.id}
+                  callLabel={`#${(callIndexMap.get(call.id) ?? 0) + 1}`}
+                  model={call.model}
+                  purposeLabel={formatTrajectoryStepLabel(
+                    call.stepType || call.purpose || call.actionType,
+                    t("trajectorydetailview.Response"),
+                  )}
+                  latencyLabel={t("trajectorydetailview.Latency", {
+                    defaultValue: "Latency",
+                  })}
+                  latencyValue={formatTrajectoryDuration(call.latencyMs)}
+                  tokensLabel={t("common.tokens")}
+                  totalTokensValue={formatTrajectoryTokenCount(
+                    (call.promptTokens ?? 0) + (call.completionTokens ?? 0),
+                    { emptyLabel: "—" },
+                  )}
+                  tokenBreakdownMeta={`${formatTrajectoryTokenCount(
+                    call.promptTokens ?? 0,
+                    { emptyLabel: "—" },
+                  )}↑ • ${formatTrajectoryTokenCount(
+                    call.completionTokens ?? 0,
+                    {
+                      emptyLabel: "—",
+                    },
+                  )} ↓`}
+                  temperatureLabel={t("trajectorydetailview.Temp")}
+                  temperatureValue={call.temperature}
+                  maxLabel={t("trajectorydetailview.Max")}
+                  maxValue={call.maxTokens > 0 ? call.maxTokens : "—"}
+                  systemPrompt={
+                    systemPromptText.length > 0 ? systemPromptText : null
+                  }
+                  systemPromptButtonLabel={t(
+                    "trajectorydetailview.SystemPrompt",
+                  )}
+                  systemLabel={t("trajectorydetailview.System")}
+                  systemLinesLabel={`${countTrajectoryTextLines(
+                    systemPromptText,
+                  )} ${linesLabel}`}
+                  systemCollapseLabel={t("common.collapse", {
+                    defaultValue: "Collapse",
+                  })}
+                  systemExpandLabel={t("common.expand", {
+                    defaultValue: "Expand",
+                  })}
+                  inputLabel={t("trajectorydetailview.InputUser")}
+                  outputLabel={t("trajectorydetailview.OutputResponse")}
+                  inputLinesLabel={`${countTrajectoryTextLines(
+                    inputText,
+                  )} ${linesLabel}`}
+                  outputLinesLabel={`${countTrajectoryTextLines(
+                    outputText,
+                  )} ${linesLabel}`}
+                  tags={(call.tags ?? []).filter((tag) => tag !== "llm")}
+                  userPrompt={inputText}
+                  response={outputText}
+                  copyLabel={t("trajectorydetailview.Copy")}
+                  copyToClipboardLabel={t(
+                    "trajectorydetailview.CopyToClipboard",
+                  )}
+                  onCopy={(content) => {
+                    void copyToClipboard(content);
+                  }}
+                />
+              );
+            })
           )}
         </div>
       </div>

--- a/packages/ui/src/components/pages/TrajectoryDetailView.tsx
+++ b/packages/ui/src/components/pages/TrajectoryDetailView.tsx
@@ -146,14 +146,31 @@ function formatProviderPayload(value: unknown): string {
 }
 
 /**
+ * Recorded trajectory payloads arrive as parsed JSON, so an object candidate is
+ * either an array or a plain record. Anything else (a Date, a class instance a
+ * caller passed directly) keeps its own printable form and is never treated as
+ * an empty record.
+ */
+function isPlainRecord(value: object): value is Record<string, unknown> {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/**
  * A candidate carries content only when it would render something a reader can
  * inspect. Whitespace-only strings and empty collections are blank in the UI,
- * so they must not shadow a later populated candidate.
+ * so they must not shadow a later populated candidate. Falsy scalars such as
+ * `0` and `false` are real recorded values and stay renderable.
  */
 function hasRenderableContent(candidate: unknown): boolean {
   if (candidate == null) return false;
   if (typeof candidate === "string") return candidate.trim().length > 0;
   if (Array.isArray(candidate)) return candidate.length > 0;
+  if (typeof candidate === "object" && isPlainRecord(candidate)) {
+    // A serialized-but-empty payload renders as the literal `{}`; that is the
+    // same untruthful blank as `""` and must not shadow a populated fallback.
+    return Object.keys(candidate).length > 0;
+  }
   return true;
 }
 


### PR DESCRIPTION
Fixes #22611

## Problem

Sparse trajectory records (provider failures, embedding calls, legacy rows) reached the detail view with three untruthful outcomes:

- A blank primary field shadowed a populated fallback. `normalizeTrajectoryCallText` skipped only `""`, so a whitespace-only `userPrompt` — or an empty `messages` array — won the candidate race and rendered a blank panel while real content sat in the next candidate.
- An absent field printed a fabricated `1 lines` badge, because `"".split("
").length === 1`. The badge claimed a line beside a visibly empty panel.
- The system-prompt toggle opened on a truthy-but-blank `"   "` value, and `formatProviderPayload`'s catch carried no `error-policy` rationale. The added test file had no responsibility/harness header.

## Change

- `hasRenderableContent` decides candidacy: `null`/`undefined`, whitespace-only strings, and empty arrays are absent; everything else is content. Fallback selection now reaches the populated prompt/messages/output candidate.
- `countTrajectoryTextLines` reports `0` for absent text and the real count otherwise. Every line badge (system, input, output) goes through it — the system badge previously used its own `?? 0` expression that had the same off-by-one.
- `buildTrajectoryCallText` derives the three panel texts once, and the card is fed those exact strings, so a badge cannot disagree with the panel it labels. The system panel receives `null` when its normalized text is empty, keeping the toggle closed.
- `formatProviderPayload`'s serializer catch documents `error-policy:J4` (an expected non-serializable recorded payload degrades to its printable form rather than blanking the inspector).
- Both test files carry the required file headers.

No visual/styling change: no color, spacing, or control was touched — only the truthfulness of the text and counts rendered in existing elements.

## Tests

`packages/ui/src/components/pages/TrajectoryDetailView.test.ts` (pure, 9 cases): absent candidates, undefined/null fallthrough, blank and whitespace-only primaries, empty vs populated arrays, first-populated-wins, structured JSON preservation, cyclic payload degrade, and zero/real line counts.

`packages/ui/src/components/pages/TrajectoryDetailView.sparse-call.test.tsx` (new, jsdom, renders the real `TrajectoryLlmCallCard` through `buildTrajectoryCallText`): a fully sparse call shows `0 lines` and never `1 lines`, and a blank-primary call renders its `prompt`/`output` fallback with truthful `2 lines` / `1 lines` badges and no system toggle.

```
$ bun x vitest run src/components/pages/TrajectoryDetailView   # packages/ui
 Test Files  2 passed (2)
      Tests  11 passed (11)
```

`bunx tsc --noEmit -p packages/ui/tsconfig.json` reports no error in the touched files, and `biome check` is clean on all three.

## Evidence remainder (human-only)

`bun run --cwd packages/app audit:app` and the exact-head desktop/mobile/iPad captures + MP4 walkthrough of a sparse-call trajectory require an attended app run against a real recorded trajectory; they are not reproducible from this headless lane. The issue's fifth acceptance row is therefore left to the attended visual review before merge.


## Evidence Gate

<!-- evidence-head:74dfa294703225a7ac8fefaa8b8ff405f1b44494 -->
<!-- evidence-row:before-screenshots -->
- [ ] Exact-head before capture/app audit remains pending before merge.
<!-- evidence-row:after-screenshots -->
- [ ] Exact-head after capture/app audit remains pending before merge.
<!-- evidence-row:walkthrough-video -->
- [ ] Exact-head interaction walkthrough remains pending before merge.
<!-- evidence-row:backend-logs -->
- [x] Focused sparse-trajectory detail-view suites pass 11/11.
<!-- evidence-row:frontend-logs -->
- [ ] Exact-head browser console/network receipt remains pending before merge.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, or provider behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Focused sparse-trajectory detail-view suites pass 11/11.
<!-- evidence-row:ocr-review -->
- [ ] Exact-head visual/OCR review remains pending before merge.
