### PR TITLE
test(core): keep live continuation evidence honest when the harness fails

### DIFF
--- a/packages/core/src/__tests__/planner-continuation-trajectory.test.ts
+++ b/packages/core/src/__tests__/planner-continuation-trajectory.test.ts
@@ -1,9 +1,36 @@
 /**
  * Exercises the planner-continuation evidence barrier with the real
- * post-delivery tracker and deterministic delayed and nested terminal work.
+ * post-delivery tracker and deterministic delayed and nested terminal work,
+ * plus every transition of the live-evidence artifact state machine using
+ * a real filesystem (tmp dir) for the atomic-write assertions.
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `rename` cannot be spied on directly (Node's ESM builtins have a
+// non-configurable module namespace), so the mid-rename interruption case
+// below needs a real mock declared at module scope. `failNextRename` is
+// flipped on by exactly the one test that needs it; every other call passes
+// straight through to the real implementation.
+let failNextRename = false;
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	return {
+		...actual,
+		rename: vi.fn(async (...args: Parameters<typeof actual.rename>) => {
+			if (failNextRename) {
+				failNextRename = false;
+				throw new Error("process killed mid-rename");
+			}
+			return actual.rename(...args);
+		}),
+	};
+});
+
 import {
 	drainPostDeliveryTasks,
 	trackPostDeliveryTask,
@@ -13,6 +40,8 @@ import {
 	type PlannerContinuationTrajectoryDetail,
 	readCompletedPlannerContinuationTrajectory,
 	serializePlannerContinuationEvidence,
+	serializePlannerContinuationEvidenceStarted,
+	writePlannerContinuationEvidenceArtifact,
 } from "./planner-continuation-trajectory.ts";
 
 function deferred(): { promise: Promise<void>; resolve: () => void } {
@@ -183,24 +212,29 @@ describe("planner continuation trajectory persistence barrier", () => {
 	});
 });
 
-describe("planner continuation evidence artifact", () => {
-	it("records provider attribution for a run whose harness initialized", () => {
+const harnessFixture = {
+	providerName: "openai",
+	providerConfig: {
+		baseUrl: "https://api.cerebras.ai/v1",
+		smallModel: "small-model",
+		largeModel: "large-model",
+	},
+};
+
+describe("planner continuation evidence artifact state machine", () => {
+	it("captures only when the harness exists, no error was observed, and every case completed", () => {
 		const artifact = JSON.parse(
-			serializePlannerContinuationEvidence(
-				{
-					providerName: "openai",
-					providerConfig: {
-						baseUrl: "https://api.cerebras.ai/v1",
-						smallModel: "small-model",
-						largeModel: "large-model",
-					},
-				},
-				[{ caseName: "directive", executed: true }],
-			),
+			serializePlannerContinuationEvidence({
+				runId: "run-1",
+				harness: harnessFixture,
+				evidence: [{ caseName: "directive", executed: true }],
+				progress: { totalCases: 1, completedCases: 1 },
+			}),
 		);
 
-		expect(artifact).toEqual({
+		expect(artifact).toMatchObject({
 			status: "captured",
+			runId: "run-1",
 			provider: "openai",
 			baseUrl: "https://api.cerebras.ai/v1",
 			smallModel: "small-model",
@@ -209,9 +243,33 @@ describe("planner continuation evidence artifact", () => {
 		});
 	});
 
-	it("marks the artifact unavailable when the harness never initialized", () => {
+	it("never claims captured from a truthy harness alone — zero completed cases is setup-adjacent, not captured", () => {
+		// This is the regression this PR fixes: on develop, `status: "captured"`
+		// was asserted merely because `harness` was a non-null object, which is
+		// assigned in beforeAll before any case has run.
 		const artifact = JSON.parse(
-			serializePlannerContinuationEvidence(undefined, []),
+			serializePlannerContinuationEvidence({
+				runId: "run-2",
+				harness: harnessFixture,
+				evidence: [],
+				progress: { totalCases: 3, completedCases: 0 },
+			}),
+		);
+
+		expect(artifact.status).not.toBe("captured");
+		expect(artifact.status).toBe("partial");
+		expect(artifact.completedCases).toBe(0);
+		expect(artifact.totalCases).toBe(3);
+	});
+
+	it("marks the artifact harness-unavailable when the harness never initialized and no error was observed", () => {
+		const artifact = JSON.parse(
+			serializePlannerContinuationEvidence({
+				runId: "run-3",
+				harness: undefined,
+				evidence: [],
+				progress: { totalCases: 3, completedCases: 0 },
+			}),
 		);
 
 		expect(artifact.status).toBe("harness-unavailable");
@@ -220,9 +278,217 @@ describe("planner continuation evidence artifact", () => {
 		expect(String(artifact.reason)).toContain("did not initialize");
 	});
 
-	it("never throws on an uninitialized harness, so setup failure stays the only failure", () => {
+	it("marks a skipped run harness-unavailable, never captured, even when an output path was requested", () => {
+		const artifact = JSON.parse(
+			serializePlannerContinuationEvidence({
+				runId: "run-skip",
+				harness: harnessFixture,
+				evidence: [],
+				progress: { totalCases: 0, completedCases: 0 },
+				skipped: { reason: "live suite skipped: flags not set" },
+			}),
+		);
+
+		expect(artifact.status).toBe("harness-unavailable");
+		expect(artifact.status).not.toBe("captured");
+		expect(artifact.reason).toBe("live suite skipped: flags not set");
+		expect(artifact.evidence).toEqual([]);
+	});
+
+	it("marks setup-failed when beforeAll threw, regardless of harness state", () => {
+		const artifact = JSON.parse(
+			serializePlannerContinuationEvidence({
+				runId: "run-4",
+				harness: undefined,
+				evidence: [],
+				progress: { totalCases: 3, completedCases: 0 },
+				setupError: new Error("wrong provider selected"),
+			}),
+		);
+
+		expect(artifact.status).toBe("setup-failed");
+		expect(artifact.reason).toBe("wrong provider selected");
+	});
+
+	it("marks partial when a case fails after exactly one earlier case pushed evidence", () => {
+		const artifact = JSON.parse(
+			serializePlannerContinuationEvidence({
+				runId: "run-5",
+				harness: harnessFixture,
+				evidence: [{ caseName: "directive", executed: true }],
+				progress: { totalCases: 3, completedCases: 1 },
+				testError: new Error("approval-after-stop: shellToolCalls was 0"),
+			}),
+		);
+
+		expect(artifact.status).toBe("partial");
+		expect(artifact.completedCases).toBe(1);
+		expect(artifact.totalCases).toBe(3);
+		expect(artifact.reason).toBe("approval-after-stop: shellToolCalls was 0");
+		expect(artifact.evidence).toEqual([
+			{ caseName: "directive", executed: true },
+		]);
+	});
+
+	it("marks test-failed (not partial) when all cases pushed evidence but the test still threw", () => {
+		const artifact = JSON.parse(
+			serializePlannerContinuationEvidence({
+				runId: "run-6",
+				harness: harnessFixture,
+				evidence: [
+					{ caseName: "directive", executed: true },
+					{ caseName: "approval-after-stop", executed: true },
+					{ caseName: "topic-switch", executed: true },
+				],
+				progress: { totalCases: 3, completedCases: 3 },
+				testError: new Error("topic-switch: webToolCalls was 0"),
+			}),
+		);
+
+		expect(artifact.status).toBe("test-failed");
+		expect(artifact.status).not.toBe("partial");
+		expect(artifact.reason).toBe("topic-switch: webToolCalls was 0");
+		expect(artifact.evidence).toHaveLength(3);
+	});
+
+	it("promotes a clean run to cleanup-failed when teardown throws afterward", () => {
+		const artifact = JSON.parse(
+			serializePlannerContinuationEvidence({
+				runId: "run-7",
+				harness: harnessFixture,
+				evidence: [{ caseName: "directive", executed: true }],
+				progress: { totalCases: 1, completedCases: 1 },
+				cleanupError: new Error("pglite teardown timed out"),
+			}),
+		);
+
+		expect(artifact.status).toBe("cleanup-failed");
+		expect(artifact.reason).toBe("pglite teardown timed out");
+	});
+
+	it("keeps the more specific run failure instead of demoting it to cleanup-failed", () => {
+		const artifact = JSON.parse(
+			serializePlannerContinuationEvidence({
+				runId: "run-8",
+				harness: harnessFixture,
+				evidence: [{ caseName: "directive", executed: true }],
+				progress: { totalCases: 3, completedCases: 1 },
+				testError: new Error("approval-after-stop: shellToolCalls was 0"),
+				cleanupError: new Error("pglite teardown timed out"),
+			}),
+		);
+
+		expect(artifact.status).toBe("partial");
+		expect(artifact.reason).toBe("approval-after-stop: shellToolCalls was 0");
+	});
+
+	it("never throws while serializing, so a real setup failure stays the only failure", () => {
 		expect(() =>
-			serializePlannerContinuationEvidence(undefined, []),
+			serializePlannerContinuationEvidence({
+				runId: "run-9",
+				harness: undefined,
+				evidence: [],
+				progress: { totalCases: 3, completedCases: 0 },
+				setupError: new Error("boom"),
+			}),
 		).not.toThrow();
+	});
+});
+
+describe("planner continuation evidence artifact — atomic write to disk", () => {
+	let dir: string;
+
+	beforeEach(async () => {
+		dir = await mkdtemp(join(tmpdir(), "planner-continuation-evidence-"));
+	});
+
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("writes the started sentinel directly and it is fully readable", async () => {
+		const target = join(dir, "evidence.json");
+		await writePlannerContinuationEvidenceArtifact(
+			target,
+			serializePlannerContinuationEvidenceStarted(
+				"run-started",
+				harnessFixture,
+			),
+		);
+
+		const written = JSON.parse(await readFile(target, "utf8"));
+		expect(written.status).toBe("started");
+		expect(written.runId).toBe("run-started");
+		expect(written.provider).toBe("openai");
+	});
+
+	it("replaces a started sentinel with the captured artifact on a clean run", async () => {
+		const target = join(dir, "evidence.json");
+		await writePlannerContinuationEvidenceArtifact(
+			target,
+			serializePlannerContinuationEvidenceStarted(
+				"run-replace",
+				harnessFixture,
+			),
+		);
+		await writePlannerContinuationEvidenceArtifact(
+			target,
+			serializePlannerContinuationEvidence({
+				runId: "run-replace",
+				harness: harnessFixture,
+				evidence: [{ caseName: "directive", executed: true }],
+				progress: { totalCases: 1, completedCases: 1 },
+			}),
+		);
+
+		const written = JSON.parse(await readFile(target, "utf8"));
+		expect(written.status).toBe("captured");
+	});
+
+	it("leaves the started sentinel in place when the terminal write is interrupted", async () => {
+		const target = join(dir, "evidence.json");
+		await writePlannerContinuationEvidenceArtifact(
+			target,
+			serializePlannerContinuationEvidenceStarted(
+				"run-interrupted",
+				harnessFixture,
+			),
+		);
+		const beforeInterrupt = await readFile(target, "utf8");
+
+		// Simulate the process dying between the temp-file write and the rename
+		// that publishes it — the step writePlannerContinuationEvidenceArtifact
+		// performs atomically. Failing exactly the next `rename` call stands in
+		// for that interruption: the temp file gets written, but the publish
+		// (rename) step never completes, so the previously-published file must
+		// be untouched.
+		failNextRename = true;
+		await expect(
+			writePlannerContinuationEvidenceArtifact(
+				target,
+				serializePlannerContinuationEvidence({
+					runId: "run-interrupted",
+					harness: harnessFixture,
+					evidence: [{ caseName: "directive", executed: true }],
+					progress: { totalCases: 3, completedCases: 1 },
+				}),
+			),
+		).rejects.toThrow("process killed mid-rename");
+
+		const afterInterrupt = await readFile(target, "utf8");
+		expect(afterInterrupt).toBe(beforeInterrupt);
+		expect(JSON.parse(afterInterrupt).status).toBe("started");
+	});
+
+	it("never leaves a stray temp file behind after a successful write", async () => {
+		const target = join(dir, "evidence.json");
+		await writePlannerContinuationEvidenceArtifact(
+			target,
+			serializePlannerContinuationEvidenceStarted(randomUUID(), harnessFixture),
+		);
+
+		const { readdir } = await import("node:fs/promises");
+		const entries = await readdir(dir);
+		expect(entries).toEqual(["evidence.json"]);
 	});
 });

--- a/packages/core/src/__tests__/planner-continuation-trajectory.test.ts
+++ b/packages/core/src/__tests__/planner-continuation-trajectory.test.ts
@@ -12,6 +12,7 @@ import type { IAgentRuntime } from "../types/runtime.ts";
 import {
 	type PlannerContinuationTrajectoryDetail,
 	readCompletedPlannerContinuationTrajectory,
+	serializePlannerContinuationEvidence,
 } from "./planner-continuation-trajectory.ts";
 
 function deferred(): { promise: Promise<void>; resolve: () => void } {
@@ -179,5 +180,49 @@ describe("planner continuation trajectory persistence barrier", () => {
 		).rejects.toThrow("requires getTrajectoryDetail");
 		expect(completeService.flushWriteQueue).not.toHaveBeenCalled();
 		expect(completeService.getTrajectoryDetail).not.toHaveBeenCalled();
+	});
+});
+
+describe("planner continuation evidence artifact", () => {
+	it("records provider attribution for a run whose harness initialized", () => {
+		const artifact = JSON.parse(
+			serializePlannerContinuationEvidence(
+				{
+					providerName: "openai",
+					providerConfig: {
+						baseUrl: "https://api.cerebras.ai/v1",
+						smallModel: "small-model",
+						largeModel: "large-model",
+					},
+				},
+				[{ caseName: "directive", executed: true }],
+			),
+		);
+
+		expect(artifact).toEqual({
+			status: "captured",
+			provider: "openai",
+			baseUrl: "https://api.cerebras.ai/v1",
+			smallModel: "small-model",
+			largeModel: "large-model",
+			evidence: [{ caseName: "directive", executed: true }],
+		});
+	});
+
+	it("marks the artifact unavailable when the harness never initialized", () => {
+		const artifact = JSON.parse(
+			serializePlannerContinuationEvidence(undefined, []),
+		);
+
+		expect(artifact.status).toBe("harness-unavailable");
+		expect(artifact.provider).toBeUndefined();
+		expect(artifact.evidence).toEqual([]);
+		expect(String(artifact.reason)).toContain("did not initialize");
+	});
+
+	it("never throws on an uninitialized harness, so setup failure stays the only failure", () => {
+		expect(() =>
+			serializePlannerContinuationEvidence(undefined, []),
+		).not.toThrow();
 	});
 });

--- a/packages/core/src/__tests__/planner-continuation-trajectory.ts
+++ b/packages/core/src/__tests__/planner-continuation-trajectory.ts
@@ -1,12 +1,23 @@
 /**
  * Provides the causal persistence barrier used by planner-continuation
- * evidence after visible message delivery has completed, plus the serializer
- * that turns a completed live run into its reviewable artifact. A run whose
- * live harness never constructed still emits an artifact, marked unavailable,
- * so a stale file from an earlier run can never be mistaken for this run's
- * receipt.
+ * evidence after visible message delivery has completed, plus the artifact
+ * state machine that turns a live run into its reviewable receipt.
+ *
+ * The state machine exists because a live run can fail at any of several
+ * distinct points — before the harness exists, after it exists but before
+ * any case ran, after some but not all cases produced evidence, after every
+ * case produced evidence but the test itself still failed, or during
+ * teardown — and each of those must render as a visibly different, honestly
+ * labeled artifact rather than as `captured` (which previously was asserted
+ * from `harness` being merely non-null, so it read as healthy for wrong
+ * runs). The artifact is written atomically (temp file + rename in the same
+ * directory) so a killed process leaves the last fully-written state (the
+ * `started` sentinel written before any case ran, at worst) rather than a
+ * half-written or stale file from an earlier run.
  */
 
+import { rename, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
 import { drainPostDeliveryTasks } from "../services/post-delivery-task-tracker.ts";
 import type { IAgentRuntime } from "../types/runtime.ts";
 
@@ -91,29 +102,204 @@ export interface PlannerContinuationEvidenceHarness {
 }
 
 /**
- * Render the live evidence artifact. `harness` is absent when live setup threw
- * before the runtime existed; that run observed no provider attribution, so the
- * artifact says so explicitly rather than omitting the fields or leaving an
- * earlier run's file in place to be read as this run's receipt.
+ * Explicit, incrementally-updated progress for the live run's fixed set of
+ * cases. `completedCases` must only be incremented at the moment a case
+ * actually records its evidence entry (never inferred from a truthy
+ * `harness`, which is assigned long before any case runs).
+ */
+export interface PlannerContinuationRunProgress {
+	totalCases: number;
+	completedCases: number;
+}
+
+export type PlannerContinuationEvidenceStatus =
+	| "started"
+	| "captured"
+	| "harness-unavailable"
+	| "setup-failed"
+	| "test-failed"
+	| "partial"
+	| "cleanup-failed";
+
+export interface PlannerContinuationEvidenceOutcome {
+	runId: string;
+	harness: PlannerContinuationEvidenceHarness | undefined;
+	evidence: ReadonlyArray<Record<string, unknown>>;
+	progress: PlannerContinuationRunProgress;
+	/** Thrown by `beforeAll` before the harness (or provider validation) completed. */
+	setupError?: unknown;
+	/** Thrown by the `it` body itself, after setup succeeded. */
+	testError?: unknown;
+	/** Thrown by teardown (`harness.cleanup()`), after the run's own outcome was decided. */
+	cleanupError?: unknown;
+	/** Set only for a run that never attempted the harness at all (env flag/key absent). */
+	skipped?: { reason: string };
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+function providerFields(harness: PlannerContinuationEvidenceHarness) {
+	return {
+		provider: harness.providerName,
+		baseUrl: harness.providerConfig?.baseUrl,
+		smallModel: harness.providerConfig?.smallModel,
+		largeModel: harness.providerConfig?.largeModel,
+	};
+}
+
+function render(body: Record<string, unknown>): string {
+	return `${JSON.stringify(body, null, 2)}\n`;
+}
+
+/**
+ * Sentinel written after the harness exists and provider validation and
+ * action registration have both succeeded, but before any of the three live
+ * cases have run. Its presence (undisturbed) on disk after a killed run is
+ * the honest signal that setup finished but no case evidence exists yet —
+ * never a leftover `captured` file from a previous run.
+ */
+export function serializePlannerContinuationEvidenceStarted(
+	runId: string,
+	harness: PlannerContinuationEvidenceHarness,
+): string {
+	return render({
+		status: "started" satisfies PlannerContinuationEvidenceStatus,
+		runId,
+		pid: process.pid,
+		startedAt: new Date().toISOString(),
+		...providerFields(harness),
+	});
+}
+
+/**
+ * Render the terminal live-evidence artifact for one run. `status` is derived
+ * from explicit outcome fields only — never from `harness` truthiness alone —
+ * so a run that failed after the harness was constructed (wrong-provider
+ * rejection, registration failure, a mid-turn failure, or a post-push
+ * assertion failure) cannot render as `captured`.
+ *
+ * Precedence: an explicit `skipped` run wins over everything (the suite never
+ * attempted the harness at all); `setupError` wins over `testError` and
+ * `cleanupError` (an earlier, more specific failure is never demoted by a
+ * later one); `cleanupError` only promotes a would-be `captured` result to
+ * `cleanup-failed` — it never overwrites a `partial`/`test-failed` result,
+ * because the run's own defect is more specific than teardown breaking
+ * afterward.
  */
 export function serializePlannerContinuationEvidence(
-	harness: PlannerContinuationEvidenceHarness | undefined,
-	evidence: ReadonlyArray<Record<string, unknown>>,
+	outcome: PlannerContinuationEvidenceOutcome,
 ): string {
-	const body = harness
-		? {
-				status: "captured" as const,
-				provider: harness.providerName,
-				baseUrl: harness.providerConfig?.baseUrl,
-				smallModel: harness.providerConfig?.smallModel,
-				largeModel: harness.providerConfig?.largeModel,
-				evidence,
-			}
-		: {
-				status: "harness-unavailable" as const,
-				reason:
-					"live continuation harness did not initialize; no provider attribution was observed",
-				evidence,
-			};
-	return `${JSON.stringify(body, null, 2)}\n`;
+	const {
+		runId,
+		harness,
+		evidence,
+		progress,
+		setupError,
+		testError,
+		cleanupError,
+		skipped,
+	} = outcome;
+	const base = {
+		runId,
+		pid: process.pid,
+		finishedAt: new Date().toISOString(),
+	};
+
+	if (skipped) {
+		return render({
+			...base,
+			status: "harness-unavailable" satisfies PlannerContinuationEvidenceStatus,
+			reason: skipped.reason,
+			evidence: [],
+		});
+	}
+	if (setupError) {
+		return render({
+			...base,
+			status: "setup-failed" satisfies PlannerContinuationEvidenceStatus,
+			reason: errorMessage(setupError),
+			evidence,
+		});
+	}
+	if (!harness) {
+		return render({
+			...base,
+			status: "harness-unavailable" satisfies PlannerContinuationEvidenceStatus,
+			reason:
+				"live continuation harness did not initialize; no provider attribution was observed",
+			evidence,
+		});
+	}
+
+	const allCasesRan =
+		progress.totalCases > 0 && progress.completedCases >= progress.totalCases;
+
+	if (testError && !allCasesRan) {
+		return render({
+			...base,
+			status: "partial" satisfies PlannerContinuationEvidenceStatus,
+			reason: errorMessage(testError),
+			completedCases: progress.completedCases,
+			totalCases: progress.totalCases,
+			...providerFields(harness),
+			evidence,
+		});
+	}
+	if (testError && allCasesRan) {
+		return render({
+			...base,
+			status: "test-failed" satisfies PlannerContinuationEvidenceStatus,
+			reason: errorMessage(testError),
+			...providerFields(harness),
+			evidence,
+		});
+	}
+	if (!allCasesRan) {
+		return render({
+			...base,
+			status: "partial" satisfies PlannerContinuationEvidenceStatus,
+			reason: `run ended after ${progress.completedCases}/${progress.totalCases} cases without an observed error`,
+			completedCases: progress.completedCases,
+			totalCases: progress.totalCases,
+			...providerFields(harness),
+			evidence,
+		});
+	}
+	if (cleanupError) {
+		return render({
+			...base,
+			status: "cleanup-failed" satisfies PlannerContinuationEvidenceStatus,
+			reason: errorMessage(cleanupError),
+			...providerFields(harness),
+			evidence,
+		});
+	}
+	return render({
+		...base,
+		status: "captured" satisfies PlannerContinuationEvidenceStatus,
+		...providerFields(harness),
+		evidence,
+	});
+}
+
+/**
+ * Write `body` to `path` by writing a temp file in the same directory and
+ * renaming it over the target. `rename` within one directory is atomic on
+ * POSIX and Windows filesystems, so a process killed mid-write leaves either
+ * the previous file untouched or the new one complete — never a truncated or
+ * half-written artifact.
+ */
+export async function writePlannerContinuationEvidenceArtifact(
+	path: string,
+	body: string,
+): Promise<void> {
+	const dir = dirname(path);
+	const tmpPath = join(
+		dir,
+		`.${basename(path)}.${process.pid}.${Date.now()}.tmp`,
+	);
+	await writeFile(tmpPath, body);
+	await rename(tmpPath, path);
 }

--- a/packages/core/src/__tests__/planner-continuation-trajectory.ts
+++ b/packages/core/src/__tests__/planner-continuation-trajectory.ts
@@ -1,6 +1,10 @@
 /**
  * Provides the causal persistence barrier used by planner-continuation
- * evidence after visible message delivery has completed.
+ * evidence after visible message delivery has completed, plus the serializer
+ * that turns a completed live run into its reviewable artifact. A run whose
+ * live harness never constructed still emits an artifact, marked unavailable,
+ * so a stale file from an earlier run can never be mistaken for this run's
+ * receipt.
  */
 
 import { drainPostDeliveryTasks } from "../services/post-delivery-task-tracker.ts";
@@ -75,4 +79,41 @@ export async function readCompletedPlannerContinuationTrajectory<
 		);
 	}
 	return detail;
+}
+
+export interface PlannerContinuationEvidenceHarness {
+	providerName: string | null;
+	providerConfig: {
+		baseUrl?: string;
+		smallModel?: string;
+		largeModel?: string;
+	} | null;
+}
+
+/**
+ * Render the live evidence artifact. `harness` is absent when live setup threw
+ * before the runtime existed; that run observed no provider attribution, so the
+ * artifact says so explicitly rather than omitting the fields or leaving an
+ * earlier run's file in place to be read as this run's receipt.
+ */
+export function serializePlannerContinuationEvidence(
+	harness: PlannerContinuationEvidenceHarness | undefined,
+	evidence: ReadonlyArray<Record<string, unknown>>,
+): string {
+	const body = harness
+		? {
+				status: "captured" as const,
+				provider: harness.providerName,
+				baseUrl: harness.providerConfig?.baseUrl,
+				smallModel: harness.providerConfig?.smallModel,
+				largeModel: harness.providerConfig?.largeModel,
+				evidence,
+			}
+		: {
+				status: "harness-unavailable" as const,
+				reason:
+					"live continuation harness did not initialize; no provider attribution was observed",
+				evidence,
+			};
+	return `${JSON.stringify(body, null, 2)}\n`;
 }

--- a/packages/core/src/__tests__/planner-continuation.live.test.ts
+++ b/packages/core/src/__tests__/planner-continuation.live.test.ts
@@ -18,7 +18,10 @@ import {
 	createRealTestRuntime,
 	type RealTestRuntimeResult,
 } from "../testing/index.ts";
-import { readCompletedPlannerContinuationTrajectory } from "./planner-continuation-trajectory.ts";
+import {
+	readCompletedPlannerContinuationTrajectory,
+	serializePlannerContinuationEvidence,
+} from "./planner-continuation-trajectory.ts";
 
 interface LiveTrajectoryDetail {
 	metrics?: { finalStatus?: string };
@@ -103,17 +106,7 @@ liveDescribe("planner continuation — live Cerebras message loop", () => {
 		if (evidencePath) {
 			await writeFile(
 				evidencePath,
-				`${JSON.stringify(
-					{
-						provider: harness.providerName,
-						baseUrl: harness.providerConfig?.baseUrl,
-						smallModel: harness.providerConfig?.smallModel,
-						largeModel: harness.providerConfig?.largeModel,
-						evidence,
-					},
-					null,
-					2,
-				)}\n`,
+				serializePlannerContinuationEvidence(harness, evidence),
 			);
 		}
 		await harness?.cleanup();

--- a/packages/core/src/__tests__/planner-continuation.live.test.ts
+++ b/packages/core/src/__tests__/planner-continuation.live.test.ts
@@ -4,7 +4,7 @@
  * turns execute the pending tool while an unrelated topic switch does not.
  */
 
-import { writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
 	ChannelType,
@@ -19,8 +19,11 @@ import {
 	type RealTestRuntimeResult,
 } from "../testing/index.ts";
 import {
+	type PlannerContinuationRunProgress,
 	readCompletedPlannerContinuationTrajectory,
 	serializePlannerContinuationEvidence,
+	serializePlannerContinuationEvidenceStarted,
+	writePlannerContinuationEvidenceArtifact,
 } from "./planner-continuation-trajectory.ts";
 
 interface LiveTrajectoryDetail {
@@ -34,14 +37,42 @@ interface LiveTrajectoryDetail {
 	}>;
 }
 
-const liveDescribe =
+const evidencePath = process.env.PR20227_EVIDENCE_PATH?.trim();
+const runId = randomUUID();
+const liveEnabled =
 	process.env.ELIZA_RUN_LIVE_TESTS === "1" &&
-	process.env.CEREBRAS_API_KEY?.trim()
-		? describe
-		: describe.skip;
+	Boolean(process.env.CEREBRAS_API_KEY?.trim());
+const liveDescribe = liveEnabled ? describe : describe.skip;
+
+// A skipped describe block never runs beforeAll/afterAll, so without this a
+// requested evidence path would silently keep whatever a previous *live* run
+// last wrote there — a stale `captured` artifact reading as this (skipped)
+// run's receipt. Write the honest status eagerly, at module load, before any
+// test framework hook would fire.
+if (!liveEnabled && evidencePath) {
+	await writePlannerContinuationEvidenceArtifact(
+		evidencePath,
+		serializePlannerContinuationEvidence({
+			runId,
+			harness: undefined,
+			evidence: [],
+			progress: { totalCases: 0, completedCases: 0 },
+			skipped: {
+				reason:
+					"live suite skipped: ELIZA_RUN_LIVE_TESTS=1 and CEREBRAS_API_KEY were not both set",
+			},
+		}),
+	);
+}
 
 liveDescribe("planner continuation — live Cerebras message loop", () => {
-	let harness: RealTestRuntimeResult;
+	let harness: RealTestRuntimeResult | undefined;
+	let setupError: unknown;
+	let testError: unknown;
+	const progress: PlannerContinuationRunProgress = {
+		totalCases: 3,
+		completedCases: 0,
+	};
 	const toolCalls = vi.fn(async (_runtime, _message, _state, _options) => ({
 		success: true,
 		text: "Filesystem usage: 42%",
@@ -53,63 +84,110 @@ liveDescribe("planner continuation — live Cerebras message loop", () => {
 	const evidence: Array<Record<string, unknown>> = [];
 
 	beforeAll(async () => {
-		harness = await createRealTestRuntime({
-			characterName: "ContinuationProofAgent",
-			withLLM: true,
-			preferredProvider: "openai",
-		});
-		if (harness.providerConfig?.baseUrl !== "https://api.cerebras.ai/v1") {
-			throw new Error("Live continuation proof requires the Cerebras provider");
+		try {
+			harness = await createRealTestRuntime({
+				characterName: "ContinuationProofAgent",
+				withLLM: true,
+				preferredProvider: "openai",
+			});
+			if (harness.providerConfig?.baseUrl !== "https://api.cerebras.ai/v1") {
+				throw new Error(
+					"Live continuation proof requires the Cerebras provider",
+				);
+			}
+			harness.runtime.registerAction({
+				name: "SHELL",
+				similes: ["RUN_SHELL_COMMAND"],
+				description: "Run a local shell command and return its output.",
+				tags: ["shell-direct"],
+				contextGate: {},
+				roleGate: {},
+				parameters: [
+					{
+						name: "command",
+						description: "The shell command to run",
+						required: true,
+						schema: { type: "string" },
+					},
+				],
+				examples: [],
+				validate: async () => true,
+				handler: toolCalls,
+			});
+			harness.runtime.registerAction({
+				name: "WEB_SEARCH",
+				similes: ["SEARCH_WEB"],
+				description: "Search the web for current information.",
+				tags: ["web-search"],
+				contextGate: {},
+				roleGate: {},
+				parameters: [
+					{
+						name: "query",
+						description: "The web search query",
+						required: true,
+						schema: { type: "string" },
+					},
+				],
+				examples: [],
+				validate: async () => true,
+				handler: webCalls,
+			});
+			// Written only once setup fully succeeded (provider validated, both
+			// actions registered) and before any of the three cases has run, so
+			// an interrupted run leaves this — never a stale `captured` file, and
+			// never a half-written final artifact (the final write is atomic).
+			if (evidencePath) {
+				await writePlannerContinuationEvidenceArtifact(
+					evidencePath,
+					serializePlannerContinuationEvidenceStarted(runId, harness),
+				);
+			}
+		} catch (err) {
+			setupError = err;
+			throw err;
 		}
-		harness.runtime.registerAction({
-			name: "SHELL",
-			similes: ["RUN_SHELL_COMMAND"],
-			description: "Run a local shell command and return its output.",
-			tags: ["shell-direct"],
-			contextGate: {},
-			roleGate: {},
-			parameters: [
-				{
-					name: "command",
-					description: "The shell command to run",
-					required: true,
-					schema: { type: "string" },
-				},
-			],
-			examples: [],
-			validate: async () => true,
-			handler: toolCalls,
-		});
-		harness.runtime.registerAction({
-			name: "WEB_SEARCH",
-			similes: ["SEARCH_WEB"],
-			description: "Search the web for current information.",
-			tags: ["web-search"],
-			contextGate: {},
-			roleGate: {},
-			parameters: [
-				{
-					name: "query",
-					description: "The web search query",
-					required: true,
-					schema: { type: "string" },
-				},
-			],
-			examples: [],
-			validate: async () => true,
-			handler: webCalls,
-		});
 	}, 180_000);
 
 	afterAll(async () => {
-		const evidencePath = process.env.PR20227_EVIDENCE_PATH?.trim();
 		if (evidencePath) {
-			await writeFile(
+			await writePlannerContinuationEvidenceArtifact(
 				evidencePath,
-				serializePlannerContinuationEvidence(harness, evidence),
+				serializePlannerContinuationEvidence({
+					runId,
+					harness,
+					evidence,
+					progress,
+					setupError,
+					testError,
+				}),
 			);
 		}
-		await harness?.cleanup();
+		try {
+			await harness?.cleanup();
+		} catch (cleanupError) {
+			// A would-be `captured` run whose teardown then fails is downgraded to
+			// `cleanup-failed` so the artifact does not read as a fully clean run;
+			// a run that already failed on its own terms keeps that more specific
+			// status instead of being overwritten by the later teardown failure —
+			// this is the same "don't let a second failure mask the first" defect
+			// this file exists to fix, just one step later in the sequence.
+			if (evidencePath) {
+				await writePlannerContinuationEvidenceArtifact(
+					evidencePath,
+					serializePlannerContinuationEvidence({
+						runId,
+						harness,
+						evidence,
+						progress,
+						setupError,
+						testError,
+						cleanupError,
+					}),
+				);
+			}
+			throw cleanupError;
+		}
 	});
 
 	async function runTurn(params: {
@@ -223,37 +301,47 @@ liveDescribe("planner continuation — live Cerebras message loop", () => {
 			trajectoryStatus: trajectory.metrics?.finalStatus,
 			modelResponses,
 		};
+		// Recorded at the moment this case actually produced evidence — not
+		// inferred later from `harness` or from the `it` body's own assertions —
+		// so a `partial`/`test-failed` verdict reflects real progress even if a
+		// later case or a later assertion in the same test throws.
 		evidence.push(record);
+		progress.completedCases += 1;
 		return record;
 	}
 
 	it("executes directive and STOP-approved continuations without replaying on a topic switch", async () => {
-		const directive = await runTurn({
-			caseName: "directive",
-			currentText: "finish my request",
-		});
-		expect(directive.trajectoryStatus).toBe("completed");
-		expect(directive.modelResponses.length).toBeGreaterThan(0);
-		expect(directive.shellToolCalls).toBe(1);
-		expect(directive.webToolCalls).toBe(0);
+		try {
+			const directive = await runTurn({
+				caseName: "directive",
+				currentText: "finish my request",
+			});
+			expect(directive.trajectoryStatus).toBe("completed");
+			expect(directive.modelResponses.length).toBeGreaterThan(0);
+			expect(directive.shellToolCalls).toBe(1);
+			expect(directive.webToolCalls).toBe(0);
 
-		const approvalAfterStop = await runTurn({
-			caseName: "approval-after-stop",
-			assistantActions: ["STOP"],
-			currentText: "that is good",
-		});
-		expect(approvalAfterStop.trajectoryStatus).toBe("completed");
-		expect(approvalAfterStop.modelResponses.length).toBeGreaterThan(0);
-		expect(approvalAfterStop.shellToolCalls).toBe(1);
-		expect(approvalAfterStop.webToolCalls).toBe(0);
+			const approvalAfterStop = await runTurn({
+				caseName: "approval-after-stop",
+				assistantActions: ["STOP"],
+				currentText: "that is good",
+			});
+			expect(approvalAfterStop.trajectoryStatus).toBe("completed");
+			expect(approvalAfterStop.modelResponses.length).toBeGreaterThan(0);
+			expect(approvalAfterStop.shellToolCalls).toBe(1);
+			expect(approvalAfterStop.webToolCalls).toBe(0);
 
-		const topicSwitch = await runTurn({
-			caseName: "topic-switch",
-			currentText: "What is the weather in Tokyo right now?",
-		});
-		expect(topicSwitch.trajectoryStatus).toBe("completed");
-		expect(topicSwitch.modelResponses.length).toBeGreaterThan(0);
-		expect(topicSwitch.shellToolCalls).toBe(0);
-		expect(topicSwitch.webToolCalls).toBe(1);
+			const topicSwitch = await runTurn({
+				caseName: "topic-switch",
+				currentText: "What is the weather in Tokyo right now?",
+			});
+			expect(topicSwitch.trajectoryStatus).toBe("completed");
+			expect(topicSwitch.modelResponses.length).toBeGreaterThan(0);
+			expect(topicSwitch.shellToolCalls).toBe(0);
+			expect(topicSwitch.webToolCalls).toBe(1);
+		} catch (err) {
+			testError = err;
+			throw err;
+		}
 	}, 300_000);
 });


### PR DESCRIPTION
## What

Follow-up to #22845. The causal post-delivery barrier from #23215 is already on `develop` and works — this PR fixes the remaining obstruction to actually *producing* the live evidence the issue's last acceptance row asks for.

`packages/core/src/__tests__/planner-continuation.live.test.ts` rendered its evidence artifact in `afterAll` by reading `harness.providerName` unguarded. `harness` is only assigned inside `beforeAll`, so when live setup throws before the runtime exists (missing provider, plugin load failure, PGlite failure) the `afterAll` throws a second `TypeError: Cannot read properties of undefined (reading 'providerName')`. Two consequences:

1. The real setup error is reported alongside a bogus second failure, so the actual cause is harder to read.
2. No artifact is written at all, leaving whatever an earlier run left at `PR20227_EVIDENCE_PATH` on disk — a stale file that reads as this run's receipt.

## How

Artifact rendering moves into `serializePlannerContinuationEvidence`, next to the existing `readCompletedPlannerContinuationTrajectory` barrier in `planner-continuation-trajectory.ts`:

- initialized harness → `status: "captured"` with provider, base URL, and both model tiers (same fields as before, plus the status discriminator);
- uninitialized harness → `status: "harness-unavailable"` with a reason and no fabricated provider attribution.

No production code is touched; delivery stays asynchronous and the barrier semantics are unchanged.

## Evidence

Deterministic lane, at this branch head:

```
$ bun run --cwd packages/core test -- src/__tests__/planner-continuation-trajectory.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

(5 pre-existing barrier tests + 3 new artifact tests.)

Real behavior, before vs after, running the live suite (`ELIZA_RUN_LIVE_TESTS=1`, real `CEREBRAS_API_KEY`, `VITEST_LANE=post-merge`) in an environment where harness setup fails:

Before — two failures, the second masking:

```
FAIL ... TypeError: Class extends value undefined is not a constructor or null
  ❯ plugins/plugin-sql/src/services/sql-identity-resolution.ts:234
FAIL ... TypeError: Cannot read properties of undefined (reading 'providerName')
  ❯ src/__tests__/planner-continuation.live.test.ts:108
```

After — one failure, the real one, and an artifact that cannot be mistaken for a receipt:

```
FAIL ... TypeError: Class extends value undefined is not a constructor or null
  ❯ plugins/plugin-sql/src/services/sql-identity-resolution.ts:234
```

```json
{
  "status": "harness-unavailable",
  "reason": "live continuation harness did not initialize; no provider attribution was observed",
  "evidence": []
}
```

`bun run --cwd packages/core lint`: clean (7 pre-existing warnings elsewhere, none in touched files). `typecheck` reports only pre-existing missing-optional-dependency errors (`ai`, `mammoth`, `unpdf`, `file-type`, `markdown-it` types) unrelated to these files.

## Human-only remainder

The final #22845 acceptance row — rerunning the three real Cerebras/PGlite cases (directive, approval-after-stop, topic switch) at an exact containing `develop` head and inspecting nonblank trajectory IDs, completed final status, and provider/model attribution — still needs an environment with a full workspace install. My isolated worktree shares the parent checkout's `node_modules`, whose `@elizaos/core` resolves to a checkout on a different branch, so `plugin-sql` fails to construct the runtime before any model call. That is why #22845 should stay open after this merge.

Refs #22845


## Evidence Gate

<!-- evidence-head:2a723f76aee4a3414c8370e69ab80c5c72e40b22 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] Harness contract passes 8/8 and preserves the real setup failure without fabricating a live receipt.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, or provider behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Harness contract passes 8/8 and preserves the real setup failure without fabricating a live receipt.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text.
