### PR TITLE
fix(app): replay cold-boot navigation intents

### DIFF
--- a/packages/app/src/deep-link-handler.test.ts
+++ b/packages/app/src/deep-link-handler.test.ts
@@ -9,7 +9,10 @@
  * untrusted or unconfigured hosts are ignored. Runs under jsdom with `window`,
  * `location.hash`, and event listeners; dispatch seams are `vi.fn()` spies.
  */
-import { CONNECT_EVENT, NAVIGATE_VIEW_EVENT } from "@elizaos/ui/events";
+import {
+  CONNECT_EVENT,
+  listenForNavigateViewRequests,
+} from "@elizaos/ui/events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createDeepLinkHandler,
@@ -135,15 +138,28 @@ describe("createDeepLinkHandler — top-level-surface navigation intents", () =>
   it("dispatches on the eliza:navigate:view bus by default (no injected seam)", () => {
     const { handle } = makeHandler({ dispatchNavigationIntent: undefined });
     const seen: unknown[] = [];
-    const onNavigate = (event: Event) => {
-      seen.push((event as CustomEvent).detail);
-    };
-    window.addEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
+    const stop = listenForNavigateViewRequests((event) => {
+      seen.push(event.detail);
+    });
     try {
       handle("elizaos://apps/deploy");
     } finally {
-      window.removeEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
+      stop();
     }
+    expect(seen).toEqual([{ viewId: "cloud-apps", viewPath: "/cloud-apps" }]);
+    expect(window.location.hash).toBe("");
+  });
+
+  it("replays a default native dispatch that arrives before shell registration", () => {
+    const { handle } = makeHandler({ dispatchNavigationIntent: undefined });
+    handle("elizaos://apps/deploy");
+
+    const seen: unknown[] = [];
+    const stop = listenForNavigateViewRequests((event) => {
+      seen.push(event.detail);
+    });
+    stop();
+
     expect(seen).toEqual([{ viewId: "cloud-apps", viewPath: "/cloud-apps" }]);
     expect(window.location.hash).toBe("");
   });

--- a/packages/app/src/deep-link-handler.ts
+++ b/packages/app/src/deep-link-handler.ts
@@ -11,8 +11,8 @@
  */
 
 import {
-  createNavigateViewEvent,
   dispatchConnectRequest,
+  dispatchNavigateViewRequest,
   dispatchOpenNotificationCenter,
 } from "@elizaos/ui/events";
 import { routeFirstRunDeepLink } from "@elizaos/ui/first-run/deep-link-handler";
@@ -60,7 +60,7 @@ export interface DeepLinkHandlerContext {
 function defaultDispatchNavigationIntent(
   intent: DeepLinkNavigationIntent,
 ): void {
-  window.dispatchEvent(createNavigateViewEvent(intent));
+  dispatchNavigateViewRequest(intent);
 }
 
 /** True for an `https://<trusted-host>/<path>` universal/App link. */

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -2186,7 +2186,14 @@ async function handleAuthCallbackDeepLink(
   );
 }
 
-function handleDeepLink(url: string): void {
+/**
+ * Returns `void` for every branch except the top-level-surface navigation
+ * intent, which returns the `dispatchNavigateViewRequest` promise so a caller
+ * that needs to know the intent actually LANDED (not merely enqueued) — today
+ * `mobile-lifecycle.ts`, gating its Android deep-link-buffer acknowledgement —
+ * can await it instead of acking on dispatch alone.
+ */
+function handleDeepLink(url: string): undefined | Promise<boolean> {
   const firstRunRemote = parseFirstRunRemoteConnectDeepLink(
     url,
     APP_URL_SCHEME,
@@ -2245,8 +2252,7 @@ function handleDeepLink(url: string): void {
   // from the hash directly.)
   const navigationIntent = resolveDeepLinkNavigationIntent(path);
   if (navigationIntent) {
-    dispatchDeepLinkNavigation(navigationIntent);
-    return;
+    return dispatchDeepLinkNavigation(navigationIntent);
   }
 
   const assistantLaunchHashRoute = buildAssistantLaunchHashRoute(
@@ -2379,8 +2385,10 @@ function setHashRoute(route: string, params: URLSearchParams): void {
  * the rest of the app uses; a raw `window.location.hash` write does not open a
  * tab on the mobile/Capacitor entrypoint (see `resolveDeepLinkNavigationIntent`).
  */
-function dispatchDeepLinkNavigation(intent: DeepLinkNavigationIntent): void {
-  dispatchNavigateViewRequest(intent);
+function dispatchDeepLinkNavigation(
+  intent: DeepLinkNavigationIntent,
+): Promise<boolean> {
+  return dispatchNavigateViewRequest(intent);
 }
 
 async function initializeDesktopShell(): Promise<void> {
@@ -2586,7 +2594,7 @@ async function initializeDesktopShell(): Promise<void> {
       if (typeof url !== "string" || url.trim().length === 0) {
         return;
       }
-      handleDeepLink(url);
+      void handleDeepLink(url);
     },
   });
 }

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -93,9 +93,9 @@ import {
 import {
   AGENT_READY_EVENT,
   COMMAND_PALETTE_EVENT,
-  createNavigateViewEvent,
   dispatchAppEvent,
   dispatchConnectRequest,
+  dispatchNavigateViewRequest,
   MOBILE_RUNTIME_MODE_CHANGED_EVENT,
   PUSH_TO_TALK_HOLD_EVENT,
   PUSH_TO_TALK_TOGGLE_EVENT,
@@ -2380,7 +2380,7 @@ function setHashRoute(route: string, params: URLSearchParams): void {
  * tab on the mobile/Capacitor entrypoint (see `resolveDeepLinkNavigationIntent`).
  */
 function dispatchDeepLinkNavigation(intent: DeepLinkNavigationIntent): void {
-  window.dispatchEvent(createNavigateViewEvent(intent));
+  dispatchNavigateViewRequest(intent);
 }
 
 async function initializeDesktopShell(): Promise<void> {

--- a/packages/app/src/mobile-lifecycle.ts
+++ b/packages/app/src/mobile-lifecycle.ts
@@ -26,7 +26,14 @@ export interface MobileLifecycleContext {
   isIOS: boolean;
   isAndroid: boolean;
   logPrefix: string;
-  handleDeepLink: (url: string) => void;
+  /**
+   * Most deep-link routes finish synchronously; the top-level-surface
+   * navigation-intent route returns a promise that resolves once the intent
+   * actually landed in the shell (not merely enqueued). `initializeDeepLinks`
+   * awaits it before acknowledging the Android buffer — see
+   * `acknowledgeBufferedUrl` below.
+   */
+  handleDeepLink: (url: string) => undefined | Promise<boolean>;
   androidDeepLinkBuffer?: AndroidDeepLinkBuffer;
 }
 
@@ -63,6 +70,49 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
   let networkStatusListenerRegistered = false;
   const handledDeepLinks = new Set<string>();
   const pendingDeepLinks = new Map<string, Array<() => void>>();
+  // Acknowledgements queued behind a URL's IN-FLIGHT `ctx.handleDeepLink`
+  // outcome. Android's cold-launch replay polls the still-unacked buffer
+  // every second for up to 15s, redelivering the same URL while the shell is
+  // still applying the first attempt; those redeliveries must queue here
+  // rather than fire immediately, or the "ack only after applied" guarantee
+  // below is defeated by the second poll instead of the first.
+  const pendingDeepLinkAcknowledgements = new Map<string, Array<() => void>>();
+
+  // Runs `ctx.handleDeepLink` and only fires the queued acknowledgements once
+  // the intent is confirmed APPLIED. Synchronous routes (everything except
+  // the top-level-surface navigation intent) return `void`/non-promise and ack
+  // immediately, matching prior behavior. The navigation-intent route returns
+  // a promise from `dispatchNavigateViewRequest`
+  // (packages/ui/src/events/index.ts) that only resolves `true` once the
+  // canonical App listener actually claims + applies it — never on enqueue
+  // alone — so a renderer reload/crash between dispatch and the App mount
+  // effect can no longer tell Android the intent was delivered when it wasn't
+  // (#23350). Shared by `captureDeepLinkOnce` and the ready-flush in
+  // `initializeAppLifecycle`, the two sites that first hand a URL to
+  // `ctx.handleDeepLink`.
+  const applyDeepLink = (
+    trimmed: string,
+    acknowledgements: Array<() => void>,
+  ): void => {
+    if (acknowledgements.length > 0) {
+      const queued = pendingDeepLinkAcknowledgements.get(trimmed) ?? [];
+      queued.push(...acknowledgements);
+      pendingDeepLinkAcknowledgements.set(trimmed, queued);
+    }
+    const result = ctx.handleDeepLink(trimmed);
+    if (result && typeof (result as Promise<boolean>).then === "function") {
+      void (result as Promise<boolean>).then((applied) => {
+        if (!applied) return;
+        const queued = pendingDeepLinkAcknowledgements.get(trimmed);
+        pendingDeepLinkAcknowledgements.delete(trimmed);
+        for (const acknowledge of queued ?? []) acknowledge();
+      });
+      return;
+    }
+    const queued = pendingDeepLinkAcknowledgements.get(trimmed);
+    pendingDeepLinkAcknowledgements.delete(trimmed);
+    for (const acknowledge of queued ?? []) acknowledge();
+  };
 
   function logNativePluginUnavailable(
     pluginName: string,
@@ -147,7 +197,19 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
       if (!trimmed) return false;
       if (handledDeepLinks.has(trimmed)) {
         if (deepLinkHandlingReady) {
-          acknowledge?.();
+          if (!acknowledge) return false;
+          const inFlight = pendingDeepLinkAcknowledgements.get(trimmed);
+          if (inFlight) {
+            // First attempt hasn't resolved "applied" yet — queue behind it
+            // instead of confirming delivery this poll never earned.
+            inFlight.push(acknowledge);
+          } else {
+            // No in-flight record: the first attempt already applied (and
+            // cleared) or this URL was never gated on a promise. Either way
+            // this redelivery is a genuine duplicate of an already-delivered
+            // intent — ack it.
+            acknowledge();
+          }
         } else if (acknowledge) {
           pendingDeepLinks.get(trimmed)?.push(acknowledge);
         }
@@ -155,8 +217,7 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
       }
       handledDeepLinks.add(trimmed);
       if (deepLinkHandlingReady) {
-        ctx.handleDeepLink(trimmed);
-        acknowledge?.();
+        applyDeepLink(trimmed, acknowledge ? [acknowledge] : []);
       } else {
         pendingDeepLinks.set(trimmed, acknowledge ? [acknowledge] : []);
       }
@@ -225,8 +286,7 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
     if (!deepLinkHandlingReady) {
       deepLinkHandlingReady = true;
       for (const [url, acknowledgements] of pendingDeepLinks) {
-        ctx.handleDeepLink(url);
-        for (const acknowledge of acknowledgements) acknowledge();
+        applyDeepLink(url, acknowledgements);
       }
       pendingDeepLinks.clear();
     }

--- a/packages/app/test/mobile-lifecycle.test.ts
+++ b/packages/app/test/mobile-lifecycle.test.ts
@@ -447,6 +447,112 @@ describe("createMobileLifecycle — app lifecycle", () => {
     );
   });
 
+  it("defers the Android ack until handleDeepLink's returned promise resolves applied=true (#23350)", async () => {
+    // Regression: `ctx.handleDeepLink` used to be treated as complete the
+    // instant it returned, so `acknowledgePendingUrl` fired even though the
+    // navigation intent it dispatched was still only enqueued, not yet
+    // claimed by the App shell. A renderer reload/crash in that window lost
+    // the intent while Android had already been told it was delivered.
+    const url = "elizaos://apps/deploy";
+    const deepLinkBuffer = makeDeepLinkBuffer(url);
+    let resolveApplied: ((applied: boolean) => void) | undefined;
+    const ctx = makeContext({
+      androidDeepLinkBuffer: deepLinkBuffer.bridge,
+      handleDeepLink: vi.fn(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveApplied = resolve;
+          }),
+      ),
+    });
+    const lifecycle = createMobileLifecycle(ctx);
+
+    lifecycle.initializeDeepLinks();
+    await vi.waitFor(() =>
+      expect(deepLinkBuffer.bridge.peekPendingUrl).toHaveBeenCalled(),
+    );
+    lifecycle.initializeAppLifecycle();
+
+    expect(ctx.handleDeepLink).toHaveBeenCalledOnce();
+    // The intent is dispatched, but nothing has confirmed it landed yet —
+    // acknowledging now would be the exact bug this test guards against.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(deepLinkBuffer.bridge.acknowledgePendingUrl).not.toHaveBeenCalled();
+
+    // Simulate the App shell's canonical listener claiming + applying it.
+    resolveApplied?.(true);
+    await vi.waitFor(() =>
+      expect(deepLinkBuffer.bridge.acknowledgePendingUrl).toHaveBeenCalledWith({
+        url,
+      }),
+    );
+  });
+
+  it("never acknowledges Android when handleDeepLink's promise resolves applied=false (dropped/never claimed)", async () => {
+    const url = "elizaos://apps/deploy";
+    const deepLinkBuffer = makeDeepLinkBuffer(url);
+    const ctx = makeContext({
+      androidDeepLinkBuffer: deepLinkBuffer.bridge,
+      handleDeepLink: vi.fn(() => Promise.resolve(false)),
+    });
+    const lifecycle = createMobileLifecycle(ctx);
+
+    lifecycle.initializeDeepLinks();
+    await vi.waitFor(() =>
+      expect(deepLinkBuffer.bridge.peekPendingUrl).toHaveBeenCalled(),
+    );
+    lifecycle.initializeAppLifecycle();
+
+    expect(ctx.handleDeepLink).toHaveBeenCalledOnce();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    // Never applied (e.g. every listener declined, or it overflowed the
+    // replay bound) — the native buffer must stay unacknowledged so a fresh
+    // process can pick the intent back up.
+    expect(deepLinkBuffer.bridge.acknowledgePendingUrl).not.toHaveBeenCalled();
+  });
+
+  it("queues an in-flight redelivery's ack behind the original attempt instead of confirming it early", async () => {
+    // Android's cold-launch replay polls the unacked buffer every second
+    // for up to 15s. A poll landing while the FIRST attempt is still
+    // in-flight must not let that second poll's ack fire ahead of — or
+    // instead of — the real "applied" confirmation.
+    vi.useFakeTimers();
+    const url = "elizaos://apps/deploy";
+    const deepLinkBuffer = makeDeepLinkBuffer(url);
+    let resolveApplied: ((applied: boolean) => void) | undefined;
+    let callCount = 0;
+    const ctx = makeContext({
+      androidDeepLinkBuffer: deepLinkBuffer.bridge,
+      handleDeepLink: vi.fn(() => {
+        callCount += 1;
+        return new Promise<boolean>((resolve) => {
+          resolveApplied = resolve;
+        });
+      }),
+    });
+    const lifecycle = createMobileLifecycle(ctx);
+
+    lifecycle.initializeAppLifecycle();
+    // A poll redelivers the same still-unacked URL while the first attempt
+    // is in-flight.
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    // handleDeepLink is only invoked once per URL — the redelivery reuses
+    // the first attempt's outcome rather than re-dispatching.
+    expect(callCount).toBe(1);
+    expect(deepLinkBuffer.bridge.acknowledgePendingUrl).not.toHaveBeenCalled();
+
+    resolveApplied?.(true);
+    await vi.waitFor(() =>
+      expect(deepLinkBuffer.bridge.acknowledgePendingUrl).toHaveBeenCalledWith({
+        url,
+      }),
+    );
+  });
+
   it("acknowledges a native replay duplicate after appUrlOpen already routed it", async () => {
     vi.useFakeTimers();
     const url = "elizaos://chat/replayed";

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -137,7 +137,7 @@ import {
   FOCUS_CONNECTOR_EVENT,
   type FocusConnectorEventDetail,
   listenForConnectRequests,
-  NAVIGATE_VIEW_EVENT,
+  listenForNavigateViewRequests,
   PUSH_TO_TALK_HOLD_EVENT,
   PUSH_TO_TALK_TOGGLE_EVENT,
   type PushToTalkHoldDetail,
@@ -2790,9 +2790,7 @@ function AppContent() {
         markCompletedActionNavigationHandled(event, detail);
       }
     };
-    window.addEventListener(NAVIGATE_VIEW_EVENT, handleNavigateView);
-    return () =>
-      window.removeEventListener(NAVIGATE_VIEW_EVENT, handleNavigateView);
+    return listenForNavigateViewRequests(handleNavigateView);
   }, [
     setTab,
     availableViewsForDesktopTabs,

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2770,7 +2770,12 @@ function AppContent() {
     // deep-links a section. Route it through the same settings state the
     // slash-command path uses (initialSection + #hash) instead of the generic
     // path nav, which would drop the requested section.
-    const handleNavigateView = (event: Event) => {
+    // Returns whether the request was actually applied — this is the
+    // canonical, single-owner handler `listenForNavigateViewRequests` claims
+    // the intent for, so an accurate `true`/`false` here (not just "was
+    // invoked") is what lets a cold-boot Android deep link only get
+    // acknowledged once its navigation genuinely landed (see events/index.ts).
+    const handleNavigateView = (event: Event): boolean => {
       const detail = (event as CustomEvent<NavigateViewDetail>).detail;
       if (
         detail?.subview &&
@@ -2784,11 +2789,13 @@ function AppContent() {
         setSettingsNavigateSequence((sequence) => sequence + 1);
         setTab("settings");
         markCompletedActionNavigationHandled(event, detail);
-        return;
+        return true;
       }
-      if (baseHandler(event)) {
+      const handled = baseHandler(event);
+      if (handled) {
         markCompletedActionNavigationHandled(event, detail);
       }
+      return handled;
     };
     return listenForNavigateViewRequests(handleNavigateView);
   }, [

--- a/packages/ui/src/events/index.ts
+++ b/packages/ui/src/events/index.ts
@@ -10,6 +10,7 @@
  * `dispatchAppEvent` / `dispatchWindowEvent` accept them.
  */
 
+import { logger } from "@elizaos/logger";
 import {
   CONNECT_EVENT,
   createNavigateViewEvent,
@@ -332,10 +333,29 @@ export function listenForConnectRequests(
   return () => document.removeEventListener(CONNECT_EVENT, handle);
 }
 
-type NavigateViewRequestListener = (event: NavigateViewEvent) => void;
+// A listener reports whether it actually APPLIED the request by returning
+// `true`/`void`; returning `false` (or throwing) means "not applied" so the
+// intent stays eligible for a later-mounting or retried listener instead of
+// being permanently consumed by whichever subscriber happened to mount first.
+type NavigateViewRequestListener = (
+  event: NavigateViewEvent,
+) => boolean | undefined;
+
+interface NavigateViewRequestClaim {
+  claimed: boolean;
+  /** Durably consumes the request: unqueues it and resolves its dispatch promise `true`. */
+  commit: () => void;
+}
 
 const MAX_PENDING_NAVIGATE_VIEW_REQUESTS = 16;
-const navigateViewRequestClaims = new WeakMap<object, () => boolean>();
+const navigateViewRequestClaims = new WeakMap<
+  object,
+  NavigateViewRequestClaim
+>();
+const navigateViewRequestResolvers = new WeakMap<
+  object,
+  (applied: boolean) => void
+>();
 const pendingNavigateViewRequests: NavigateViewDetail[] = [];
 
 function emitNavigateViewRequest(detail: NavigateViewDetail): void {
@@ -343,33 +363,73 @@ function emitNavigateViewRequest(detail: NavigateViewDetail): void {
   window.dispatchEvent(createNavigateViewEvent(detail));
 }
 
+function dropOldestPendingNavigateViewRequest(): void {
+  const dropped = pendingNavigateViewRequests.shift();
+  if (!dropped) return;
+  // error-policy:J4 bounded FIFO — an OS can deliver intents faster than a
+  // listener claims them (or none ever mounts); silently dropping one here
+  // used to be indistinguishable from a healthy delivery. Surface it, and
+  // resolve the dispatcher's promise `false` so a caller gating a native ack
+  // on "applied" (mobile-lifecycle's Android intent buffer) never
+  // acknowledges a request this store just discarded.
+  logger.warn(
+    { viewId: dropped.viewId, viewPath: dropped.viewPath },
+    `[navigate-view-request] dropped oldest pending request past the ${MAX_PENDING_NAVIGATE_VIEW_REQUESTS}-item bound`,
+  );
+  navigateViewRequestResolvers.get(dropped)?.(false);
+  navigateViewRequestResolvers.delete(dropped);
+  navigateViewRequestClaims.delete(dropped);
+}
+
 /**
- * Dispatches a native navigation intent without losing it during cold boot.
- * Requests remain pending until one shell listener claims them; the bounded
- * FIFO preserves ordering when an OS delivers several intents before mount.
+ * Dispatches a native navigation intent without losing it during cold boot,
+ * and resolves only once some listener has actually APPLIED it — never
+ * merely enqueued it. `mobile-lifecycle.ts` (via `main.tsx`'s `handleDeepLink`)
+ * awaits this before acknowledging the Android deep-link buffer: acking on
+ * enqueue would tell Android the intent was delivered even though the queue
+ * below is in-memory only, so a renderer reload/crash between dispatch and
+ * the App mount effect can still lose it. The bounded FIFO preserves ordering
+ * when an OS delivers several intents before mount.
  */
-export function dispatchNavigateViewRequest(detail: NavigateViewDetail): void {
-  if (typeof window === "undefined") return;
-  let claimed = false;
+export function dispatchNavigateViewRequest(
+  detail: NavigateViewDetail,
+): Promise<boolean> {
+  if (typeof window === "undefined") return Promise.resolve(false);
   const request: NavigateViewDetail = { ...detail };
-  navigateViewRequestClaims.set(request, () => {
-    if (claimed) return false;
-    claimed = true;
-    const pendingIndex = pendingNavigateViewRequests.indexOf(request);
-    if (pendingIndex >= 0) pendingNavigateViewRequests.splice(pendingIndex, 1);
-    return true;
+  const applied = new Promise<boolean>((resolve) => {
+    navigateViewRequestResolvers.set(request, resolve);
   });
+  const claim: NavigateViewRequestClaim = {
+    claimed: false,
+    commit: () => {
+      claim.claimed = true;
+      const pendingIndex = pendingNavigateViewRequests.indexOf(request);
+      if (pendingIndex >= 0)
+        pendingNavigateViewRequests.splice(pendingIndex, 1);
+      navigateViewRequestResolvers.get(request)?.(true);
+      navigateViewRequestResolvers.delete(request);
+    },
+  };
+  navigateViewRequestClaims.set(request, claim);
   pendingNavigateViewRequests.push(request);
   if (pendingNavigateViewRequests.length > MAX_PENDING_NAVIGATE_VIEW_REQUESTS) {
-    pendingNavigateViewRequests.shift();
+    dropOldestPendingNavigateViewRequest();
   }
   emitNavigateViewRequest(request);
+  return applied;
 }
 
 /**
  * Subscribes to navigation events and synchronously replays unclaimed native
- * intents. Raw legacy CustomEvents still pass through without entering the
- * replay queue.
+ * intents. A request is claimed — durably removed from the replay queue, with
+ * its `dispatchNavigateViewRequest` promise resolved `true` — only after the
+ * listener call returns without throwing and without returning `false`.
+ * `window.dispatchEvent` invokes every attached listener regardless of an
+ * earlier one throwing, so a listener that throws, no-ops, or unmounts before
+ * applying the intent leaves it unclaimed for the next attached listener (or
+ * the next mount's replay) rather than permanently stealing it. Raw legacy
+ * CustomEvents outside this helper (no registered claim) still pass through
+ * without entering the replay queue.
  */
 export function listenForNavigateViewRequests(
   listener: NavigateViewRequestListener,
@@ -379,8 +439,20 @@ export function listenForNavigateViewRequests(
     const detail = (event as CustomEvent<unknown>).detail;
     if (!detail || typeof detail !== "object" || Array.isArray(detail)) return;
     const claim = navigateViewRequestClaims.get(detail);
-    if (claim && !claim()) return;
-    listener(event as NavigateViewEvent);
+    if (claim?.claimed) return;
+    let applied: boolean;
+    try {
+      applied = listener(event as NavigateViewEvent) !== false;
+    } catch (error) {
+      // error-policy:J4 one subscriber's failure must not steal the intent
+      // from the next attached listener or a later mount's replay.
+      logger.warn(
+        { error },
+        "[navigate-view-request] listener threw while applying a navigation intent; leaving it unclaimed for retry",
+      );
+      return;
+    }
+    if (applied) claim?.commit();
   };
 
   window.addEventListener(NAVIGATE_VIEW_EVENT, handle);

--- a/packages/ui/src/events/index.ts
+++ b/packages/ui/src/events/index.ts
@@ -12,6 +12,10 @@
 
 import {
   CONNECT_EVENT,
+  createNavigateViewEvent,
+  NAVIGATE_VIEW_EVENT,
+  type NavigateViewDetail,
+  type NavigateViewEvent,
   type ElizaDocumentEventName as SharedDocumentEventName,
   type ElizaWindowEventName as SharedWindowEventName,
 } from "@elizaos/shared/events";
@@ -326,6 +330,64 @@ export function listenForConnectRequests(
     }
   });
   return () => document.removeEventListener(CONNECT_EVENT, handle);
+}
+
+type NavigateViewRequestListener = (event: NavigateViewEvent) => void;
+
+const MAX_PENDING_NAVIGATE_VIEW_REQUESTS = 16;
+const navigateViewRequestClaims = new WeakMap<object, () => boolean>();
+const pendingNavigateViewRequests: NavigateViewDetail[] = [];
+
+function emitNavigateViewRequest(detail: NavigateViewDetail): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(createNavigateViewEvent(detail));
+}
+
+/**
+ * Dispatches a native navigation intent without losing it during cold boot.
+ * Requests remain pending until one shell listener claims them; the bounded
+ * FIFO preserves ordering when an OS delivers several intents before mount.
+ */
+export function dispatchNavigateViewRequest(detail: NavigateViewDetail): void {
+  if (typeof window === "undefined") return;
+  let claimed = false;
+  const request: NavigateViewDetail = { ...detail };
+  navigateViewRequestClaims.set(request, () => {
+    if (claimed) return false;
+    claimed = true;
+    const pendingIndex = pendingNavigateViewRequests.indexOf(request);
+    if (pendingIndex >= 0) pendingNavigateViewRequests.splice(pendingIndex, 1);
+    return true;
+  });
+  pendingNavigateViewRequests.push(request);
+  if (pendingNavigateViewRequests.length > MAX_PENDING_NAVIGATE_VIEW_REQUESTS) {
+    pendingNavigateViewRequests.shift();
+  }
+  emitNavigateViewRequest(request);
+}
+
+/**
+ * Subscribes to navigation events and synchronously replays unclaimed native
+ * intents. Raw legacy CustomEvents still pass through without entering the
+ * replay queue.
+ */
+export function listenForNavigateViewRequests(
+  listener: NavigateViewRequestListener,
+): () => void {
+  if (typeof window === "undefined") return () => {};
+  const handle = (event: Event): void => {
+    const detail = (event as CustomEvent<unknown>).detail;
+    if (!detail || typeof detail !== "object" || Array.isArray(detail)) return;
+    const claim = navigateViewRequestClaims.get(detail);
+    if (claim && !claim()) return;
+    listener(event as NavigateViewEvent);
+  };
+
+  window.addEventListener(NAVIGATE_VIEW_EVENT, handle);
+  for (const request of [...pendingNavigateViewRequests]) {
+    emitNavigateViewRequest(request);
+  }
+  return () => window.removeEventListener(NAVIGATE_VIEW_EVENT, handle);
 }
 
 /** Dispatch a typed custom event on `window`. */

--- a/packages/ui/src/events/navigate-view-request.test.ts
+++ b/packages/ui/src/events/navigate-view-request.test.ts
@@ -1,7 +1,14 @@
-/** Tests the bounded native-navigation replay boundary with real DOM events. */
+/**
+ * Tests the bounded native-navigation replay boundary with real DOM events,
+ * plus the single-owner claim contract (#23350): a listener only consumes a
+ * request after reporting it actually APPLIED it, `dispatchNavigateViewRequest`
+ * only resolves `true` on that same confirmation, and a dropped-for-overflow
+ * request is observable rather than silently discarded.
+ */
 // @vitest-environment jsdom
 
-import { afterEach, describe, expect, it } from "vitest";
+import { logger } from "@elizaos/logger";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   dispatchNavigateViewRequest,
   listenForNavigateViewRequests,
@@ -57,5 +64,167 @@ describe("native navigate-view requests", () => {
     );
 
     expect(received).toEqual(["/wallet", "/connectors"]);
+  });
+
+  it("does not resolve the dispatch promise until a listener actually applies the request (ack-gating contract)", async () => {
+    let resolvedApplied: boolean | undefined;
+    const applied = dispatchNavigateViewRequest({ viewPath: "/apps/deploy" });
+    applied.then((value) => {
+      resolvedApplied = value;
+    });
+
+    // Nothing has mounted yet — enqueuing alone must never resolve the
+    // promise a caller (mobile-lifecycle) uses to gate a native ack.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolvedApplied).toBeUndefined();
+
+    cleanups.push(listenForNavigateViewRequests(() => {}));
+    expect(await applied).toBe(true);
+    expect(resolvedApplied).toBe(true);
+  });
+
+  it("leaves the dispatch promise pending (not falsely resolved) while a listener declines to apply", async () => {
+    let settled: boolean | undefined;
+    let firstCalls = 0;
+    const applied = dispatchNavigateViewRequest({
+      viewPath: "/wallet-decline",
+    });
+    void applied.then((value) => {
+      settled = value;
+    });
+
+    cleanups.push(
+      listenForNavigateViewRequests(() => {
+        firstCalls += 1;
+        return false;
+      }),
+    );
+    expect(firstCalls).toBeGreaterThanOrEqual(1);
+
+    // Declining is not the same as failing: the promise must stay pending
+    // (never settle `false`) so a later-mounting listener still has a
+    // legitimate chance to apply it — only an actual drop (overflow) or a
+    // genuine claim settles it.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(settled).toBeUndefined();
+
+    const secondReceived: Array<string | null | undefined> = [];
+    cleanups.push(
+      listenForNavigateViewRequests((event) => {
+        secondReceived.push(event.detail.viewPath);
+      }),
+    );
+    expect(secondReceived).toEqual(["/wallet-decline"]);
+    expect(await applied).toBe(true);
+  });
+
+  it("multi-listener ownership race: a throwing first listener must not steal the intent from the second", () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    try {
+      let firstThrew = 0;
+      cleanups.push(
+        listenForNavigateViewRequests(() => {
+          firstThrew += 1;
+          throw new Error("boom: first listener explodes on mount");
+        }),
+      );
+      const secondReceived: Array<string | null | undefined> = [];
+      cleanups.push(
+        listenForNavigateViewRequests((event) => {
+          secondReceived.push(event.detail.viewPath);
+        }),
+      );
+
+      const applied = dispatchNavigateViewRequest({
+        viewPath: "/connectors-throw-race",
+      });
+
+      // Both listeners saw the dispatch (real DOM dispatchEvent semantics: one
+      // listener throwing does not stop the next attached listener), but only
+      // the second — the one that actually applied it — gets credit; the
+      // throw is surfaced via a warning, never silently swallowed.
+      expect(firstThrew).toBeGreaterThanOrEqual(1);
+      expect(secondReceived).toEqual(["/connectors-throw-race"]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.any(Error) }),
+        expect.stringContaining("listener threw"),
+      );
+      return applied.then((value) => {
+        expect(value).toBe(true);
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("multi-listener ownership race: a no-op/unmounted first listener does not permanently consume the intent", () => {
+    const secondReceived: Array<string | null | undefined> = [];
+    cleanups.push(
+      // Mounts first, but declines to apply (e.g. it decided the intent isn't
+      // its concern) — must not block the canonical listener behind it.
+      listenForNavigateViewRequests(() => false),
+    );
+    cleanups.push(
+      listenForNavigateViewRequests((event) => {
+        secondReceived.push(event.detail.viewPath);
+      }),
+    );
+
+    dispatchNavigateViewRequest({ viewPath: "/settings" });
+    expect(secondReceived).toEqual(["/settings"]);
+  });
+
+  it("reentrant/concurrent dispatch preserves delivery order under a single canonical listener", () => {
+    const received: Array<string | null | undefined> = [];
+    const stop = listenForNavigateViewRequests((event) => {
+      received.push(event.detail.viewPath);
+      // Dispatch a second intent from inside the listener — a plausible
+      // real-world reentrant case (a handler that itself triggers another
+      // navigation) — and confirm it queues/delivers after the current one
+      // rather than interleaving or being dropped.
+      if (event.detail.viewPath === "/wallet") {
+        dispatchNavigateViewRequest({ viewPath: "/connectors" });
+      }
+    });
+    cleanups.push(stop);
+
+    dispatchNavigateViewRequest({ viewPath: "/wallet" });
+    expect(received).toEqual(["/wallet", "/connectors"]);
+  });
+
+  it("overflow: dropping the oldest pending request past the bound is observable and resolves its promise false", async () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    try {
+      const applied: Array<Promise<boolean>> = [];
+      // No listener mounted — every dispatch stays queued until the 16-item
+      // bound forces the oldest out.
+      for (let i = 0; i < 17; i += 1) {
+        applied.push(
+          dispatchNavigateViewRequest({ viewPath: `/overflow-${i}` }),
+        );
+      }
+
+      expect(await applied[0]).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ viewPath: "/overflow-0" }),
+        expect.stringContaining("dropped oldest pending request"),
+      );
+
+      // The surviving 16 requests (index 1..16) still replay in order to a
+      // listener that mounts afterward.
+      const received: Array<string | null | undefined> = [];
+      cleanups.push(
+        listenForNavigateViewRequests((event) => {
+          received.push(event.detail.viewPath);
+        }),
+      );
+      expect(received).toEqual(
+        Array.from({ length: 16 }, (_, i) => `/overflow-${i + 1}`),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/ui/src/events/navigate-view-request.test.ts
+++ b/packages/ui/src/events/navigate-view-request.test.ts
@@ -1,0 +1,61 @@
+/** Tests the bounded native-navigation replay boundary with real DOM events. */
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  dispatchNavigateViewRequest,
+  listenForNavigateViewRequests,
+} from "./index";
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) cleanup();
+});
+
+describe("native navigate-view requests", () => {
+  it("replays a pre-listener request exactly once", () => {
+    dispatchNavigateViewRequest({ viewPath: "/apps/deploy" });
+    const received: Array<string | null | undefined> = [];
+    cleanups.push(
+      listenForNavigateViewRequests((event) => {
+        received.push(event.detail.viewPath);
+      }),
+    );
+
+    expect(received).toEqual(["/apps/deploy"]);
+  });
+
+  it("delivers a post-listener request without a later stale replay", () => {
+    const received: Array<string | null | undefined> = [];
+    const firstCleanup = listenForNavigateViewRequests((event) => {
+      received.push(event.detail.viewPath);
+    });
+    cleanups.push(firstCleanup);
+
+    dispatchNavigateViewRequest({ viewPath: "/settings" });
+    expect(received).toEqual(["/settings"]);
+
+    firstCleanup();
+    cleanups.pop();
+    cleanups.push(
+      listenForNavigateViewRequests((event) => {
+        received.push(event.detail.viewPath);
+      }),
+    );
+    expect(received).toEqual(["/settings"]);
+  });
+
+  it("replays multiple cold-boot intents in delivery order", () => {
+    dispatchNavigateViewRequest({ viewPath: "/wallet" });
+    dispatchNavigateViewRequest({ viewPath: "/connectors" });
+    const received: Array<string | null | undefined> = [];
+    cleanups.push(
+      listenForNavigateViewRequests((event) => {
+        received.push(event.detail.viewPath);
+      }),
+    );
+
+    expect(received).toEqual(["/wallet", "/connectors"]);
+  });
+});


### PR DESCRIPTION
# Relates to

Fixes #23350.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto live `develop@5d412662d335fda557a31a338193068e6ccffdd1`.
- [ ] Full install, root verify, and visual evidence remain pending as recorded below.
- [x] Deterministic real-DOM and production bridge tests prove the queue and exactly-once behavior.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@46b3faa2fe58c860b41197fb13b1cf1fcfca4095:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto live `develop@5d412662d335fda557a31a338193068e6ccffdd1`; zero conflicts.
- [ ] `bun run verify` remains blocked by the incomplete borrowed workspace dependency tree.

# Risks

Low-to-medium. This changes only native deep-link delivery timing. Ordinary UI and agent-authored `eliza:navigate:view` events retain their one-shot behavior.

# Background

## What does this PR do?

- Adds a bounded FIFO for native top-level navigation intents.
- Lets the shell atomically claim and synchronously replay pending cold-boot intents.
- Removes claimed intents immediately, preventing stale replay across remounts.
- Routes both native dispatch bridges through the same authority while keeping legacy raw CustomEvents compatible.
- Covers pre-listener, post-listener, ordered cold-boot, default real bridge, and existing App routing behavior.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No public API or operator configuration changes. The exported event helper is documented at its definition.

# Testing

## Where should a reviewer start?

`packages/ui/src/events/navigate-view-request.test.ts` and the default-dispatch cases in `packages/app/src/deep-link-handler.test.ts`.

## Detailed testing steps

```text
packages/ui event boundary: 2 files / 6 tests passed
packages/app deep-link bridge: 1 file / 14 tests passed
packages/ui App navigation wiring: 2 files / 29 tests passed
Biome on all 6 touched files: passed
git diff --check: passed
```

# Evidence Gate

<!-- evidence-head:46b3faa2fe58c860b41197fb13b1cf1fcfca4095 -->

<!-- evidence-row:before-screenshots -->
- [ ] Pending exact-head app capture. No pixels intentionally changed, but the repository's `.tsx` evidence rule still requires the artifact.
<!-- evidence-row:after-screenshots -->
- [ ] Pending exact-head app capture for the same unchanged visual surfaces.
<!-- evidence-row:walkthrough-video -->
- [ ] Pending cold-boot deep-link walkthrough recording.
<!-- evidence-row:backend-logs -->
- [ ] N/A - renderer/native event bridge only; no backend path changes.
<!-- evidence-row:frontend-logs -->
- [x] Exact-head deterministic DOM/bridge/App test summaries are inlined above; immutable uploaded log pending.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, or provider behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Exact navigation detail arrays and exactly-once assertions are produced by the focused tests.
<!-- evidence-row:ocr-review -->
- [ ] Pending with the required app capture.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic native event delivery only.

## Backend + frontend logs

Backend: N/A - no backend path.

Frontend: final rebased head passed 49 focused tests across the real DOM event boundary, production deep-link dispatcher, and App listener wiring. No navigation detail was duplicated or replayed after claim.

## Screenshots (before / after) + video walkthrough

Pending. `bun run --cwd packages/app audit:app` was attempted twice. All 21 plugin view bundles built, but capture stopped in the pre-capture core package smoke because the borrowed dependency tree's packed core import points at absent `src/client-public.ts`. This PR remains draft until exact-head visual evidence is captured in a complete install.

## Audio / voice walkthrough

N/A - no audio or voice surface.

## Known gaps / failures

- UI typecheck reached only unrelated missing workspace exports such as `@elizaos/core/edge`, `@elizaos/plugin-scheduling/edge`, and `@elizaos/plugin-todos/edge`; no touched-file diagnostic was emitted.
- App audit was attempted with pinned Node 24.15.0 and TypeScript 6.0.3. All 21 plugin view bundles built, but core's package smoke failed because the borrowed install resolves an absent packaged `src/client-public.ts`.
- Full `bun install`, root `bun run verify`, screenshots, video, OCR, and immutable evidence-log upload remain required before ready-for-review.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@46b3faa2fe58c860b41197fb13b1cf1fcfca4095:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@46b3faa2fe58c860b41197fb13b1cf1fcfca4095:packages/skills/skills/contribute-to-eliza"} -->

