### PR TITLE
fix(cloud): bind container-delete reconciliation to the job row's tenant

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/container-delete-job-reconciler.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-delete-job-reconciler.integration.test.ts
@@ -2,8 +2,12 @@
  * Exercises the legacy CONTAINER_DELETE reconciler against real in-process
  * Postgres semantics (PGlite): classification of persisted payloads, dry-run
  * write-freedom, the two status-guarded apply transitions, idempotent
- * re-application, and concurrent double-apply safety. Integration-backed; no
- * mocks stand in for the system under test.
+ * re-application, and concurrent double-apply safety. Also pins the tenant
+ * boundary: a payload naming an organization other than the jobs row's own
+ * `organization_id` must never be requeued, must enumerate no foreign-tenant
+ * container rows, and must leave foreign state untransitioned.
+ * Integration-backed; no mocks stand in for the system under test, and a
+ * failed PGlite setup fails the suite rather than skipping it.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
@@ -22,20 +26,28 @@ const JOB_ORG_ONLY_FAILED = "00000000-0000-4000-8000-000000415821";
 const JOB_ORG_ONLY_NO_ROWS = "00000000-0000-4000-8000-000000515821";
 const JOB_UNRECOVERABLE_PENDING = "00000000-0000-4000-8000-000000615821";
 const JOB_UNRECOVERABLE_FAILED = "00000000-0000-4000-8000-000000715821";
+/** Owned by ORG_B but the payload names ORG_A, which has deleting rows. */
+const JOB_FOREIGN_TENANT_FAILED = "00000000-0000-4000-8000-000000815821";
+const JOB_FOREIGN_TENANT_PENDING = "00000000-0000-4000-8000-000000915821";
+/** Payload organization is a nonblank string that is not a canonical UUID. */
+const JOB_MALFORMED_ORG_FAILED = "00000000-0000-4000-8000-000001015821";
 
 let dbWrite: typeof import("../../../db/client").dbWrite;
 let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
 let reconcileContainerDeleteJobs: typeof import("../container-delete-job-reconciler").reconcileContainerDeleteJobs;
 let UNRECOVERABLE_DELETE_JOB_ERROR: string;
-let databaseReady = true;
+let ORGANIZATION_MISMATCH_DELETE_JOB_ERROR: string;
 
 beforeAll(async () => {
-  try {
-    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
-    ({ reconcileContainerDeleteJobs, UNRECOVERABLE_DELETE_JOB_ERROR } = await import(
-      "../container-delete-job-reconciler"
-    ));
-    await dbWrite.execute(`
+  // No try/catch: a broken PGlite harness must fail this suite loudly rather
+  // than let every test return early and report a fabricated pass.
+  ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+  ({
+    reconcileContainerDeleteJobs,
+    UNRECOVERABLE_DELETE_JOB_ERROR,
+    ORGANIZATION_MISMATCH_DELETE_JOB_ERROR,
+  } = await import("../container-delete-job-reconciler"));
+  await dbWrite.execute(`
       CREATE TABLE IF NOT EXISTS containers (
         id uuid PRIMARY KEY,
         organization_id uuid NOT NULL,
@@ -44,7 +56,7 @@ beforeAll(async () => {
         updated_at timestamp NOT NULL DEFAULT now()
       );
     `);
-    await dbWrite.execute(`
+  await dbWrite.execute(`
       CREATE TABLE IF NOT EXISTS jobs (
         id uuid PRIMARY KEY,
         type text NOT NULL,
@@ -60,10 +72,6 @@ beforeAll(async () => {
         updated_at timestamp NOT NULL DEFAULT now()
       );
     `);
-  } catch (error) {
-    databaseReady = false;
-    console.warn("[container-delete-job-reconciler-test] PGlite setup failed", error);
-  }
 }, TIMEOUT);
 
 afterAll(async () => {
@@ -89,7 +97,13 @@ async function seed(): Promise<void> {
       ('${JOB_UNRECOVERABLE_PENDING}', 'container_delete', 'pending',
        '{"containerId":""}'::jsonb, 0, '${ORG_B}', NULL),
       ('${JOB_UNRECOVERABLE_FAILED}', 'container_delete', 'failed',
-       '{}'::jsonb, 3, '${ORG_B}', 'Invalid container delete job data')
+       '{}'::jsonb, 3, '${ORG_B}', 'Invalid container delete job data'),
+      ('${JOB_FOREIGN_TENANT_FAILED}', 'container_delete', 'failed',
+       '{"organizationId":"${ORG_A}"}'::jsonb, 3, '${ORG_B}', 'Invalid container delete job data'),
+      ('${JOB_FOREIGN_TENANT_PENDING}', 'container_delete', 'pending',
+       '{"organizationId":"${ORG_A}"}'::jsonb, 0, '${ORG_B}', NULL),
+      ('${JOB_MALFORMED_ORG_FAILED}', 'container_delete', 'failed',
+       '{"organizationId":"not-a-uuid"}'::jsonb, 3, '${ORG_B}', 'Invalid container delete job data')
   `);
 }
 
@@ -102,19 +116,18 @@ async function jobRow(id: string): Promise<{ status: string; error: string | nul
 
 describe("container-delete job reconciler (PGlite integration)", () => {
   beforeEach(async () => {
-    if (!databaseReady) return;
     await seed();
   });
 
   test(
     "dry run classifies every row and writes nothing",
     async () => {
-      if (!databaseReady) return;
       const report = await reconcileContainerDeleteJobs(dbWrite);
       expect(report.dryRun).toBe(true);
-      expect(report.scannedJobs).toBe(5);
+      expect(report.scannedJobs).toBe(8);
       expect(report.validJobs).toBe(1);
       expect(report.recoverableJobs).toBe(2);
+      expect(report.organizationMismatchJobs).toBe(3);
       expect(report.unrecoverableJobs).toBe(2);
       expect(report.requeuedJobs).toBe(0);
       expect(report.markedFailedJobs).toBe(0);
@@ -138,10 +151,10 @@ describe("container-delete job reconciler (PGlite integration)", () => {
   test(
     "apply performs only the two guarded transitions and is idempotent",
     async () => {
-      if (!databaseReady) return;
       const first = await reconcileContainerDeleteJobs(dbWrite, { apply: true });
       expect(first.requeuedJobs).toBe(1);
-      expect(first.markedFailedJobs).toBe(1);
+      // The unrecoverable pending row plus the foreign-tenant pending row.
+      expect(first.markedFailedJobs).toBe(2);
 
       const requeued = await jobRow(JOB_ORG_ONLY_FAILED);
       expect(requeued.status).toBe("pending");
@@ -165,13 +178,12 @@ describe("container-delete job reconciler (PGlite integration)", () => {
   test(
     "concurrent apply runs never double-transition a row",
     async () => {
-      if (!databaseReady) return;
       const [a, b] = await Promise.all([
         reconcileContainerDeleteJobs(dbWrite, { apply: true }),
         reconcileContainerDeleteJobs(dbWrite, { apply: true }),
       ]);
       expect(a.requeuedJobs + b.requeuedJobs).toBe(1);
-      expect(a.markedFailedJobs + b.markedFailedJobs).toBe(1);
+      expect(a.markedFailedJobs + b.markedFailedJobs).toBe(2);
       expect((await jobRow(JOB_ORG_ONLY_FAILED)).status).toBe("pending");
       expect((await jobRow(JOB_UNRECOVERABLE_PENDING)).status).toBe("failed");
     },
@@ -181,7 +193,6 @@ describe("container-delete job reconciler (PGlite integration)", () => {
   test(
     "requeued organization-only row satisfies the executor's recovery contract",
     async () => {
-      if (!databaseReady) return;
       await reconcileContainerDeleteJobs(dbWrite, { apply: true });
       const { isContainerDeleteJobData } = await import("../container-jobs-data");
       const result = await dbWrite.execute(
@@ -193,6 +204,56 @@ describe("container-delete job reconciler (PGlite integration)", () => {
       expect(isContainerDeleteJobData(data)).toBe(false);
       const organizationId = Reflect.get(data as object, "organizationId");
       expect(organizationId).toBe(ORG_A);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "a payload naming a foreign tenant is never requeued and leaks no foreign rows",
+    async () => {
+      const report = await reconcileContainerDeleteJobs(dbWrite, { apply: true });
+      const byId = new Map(report.entries.map((entry) => [entry.jobId, entry]));
+
+      // ORG_B owns both rows; the payload claims ORG_A, which owns CONTAINER_A.
+      for (const jobId of [JOB_FOREIGN_TENANT_FAILED, JOB_FOREIGN_TENANT_PENDING]) {
+        const entry = byId.get(jobId);
+        expect(entry?.classification).toBe("organization-mismatch");
+        expect(entry?.ownerOrganizationId).toBe(ORG_B);
+        expect(entry?.payloadOrganizationMatchesOwner).toBe(false);
+        // The inventory is scoped to the authoritative owner, so ORG_A's
+        // deleting container is never enumerated under an ORG_B job.
+        expect(entry?.deletingContainerIds).toEqual([]);
+        expect(entry?.plannedAction).not.toBe("requeue");
+      }
+
+      // Zero foreign-tenant state transition: the failed row stays failed, and
+      // the pending row is fail-closed rather than handed to a worker.
+      expect((await jobRow(JOB_FOREIGN_TENANT_FAILED)).status).toBe("failed");
+      const fenced = await jobRow(JOB_FOREIGN_TENANT_PENDING);
+      expect(fenced.status).toBe("failed");
+      expect(fenced.error).toBe(ORGANIZATION_MISMATCH_DELETE_JOB_ERROR);
+
+      // ORG_A's container is untouched by ORG_B's reconciliation.
+      const container = await dbWrite.execute(
+        `SELECT status FROM containers WHERE id = '${CONTAINER_A}'`,
+      );
+      expect((container as { rows: Array<{ status: string }> }).rows[0].status).toBe("deleting");
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "a non-UUID payload organization is fail-closed and does not abort the run",
+    async () => {
+      const report = await reconcileContainerDeleteJobs(dbWrite, { apply: true });
+      const entry = report.entries.find((e) => e.jobId === JOB_MALFORMED_ORG_FAILED);
+      expect(entry?.classification).toBe("organization-mismatch");
+      expect(entry?.plannedAction).toBe("none");
+      expect(entry?.payloadOrganizationMatchesOwner).toBe(false);
+      // The run still scanned and reconciled every other row.
+      expect(report.scannedJobs).toBe(8);
+      expect(report.requeuedJobs).toBe(1);
+      expect((await jobRow(JOB_MALFORMED_ORG_FAILED)).status).toBe("failed");
     },
     TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/container-delete-job-reconciler.ts
+++ b/packages/cloud/shared/src/lib/services/container-delete-job-reconciler.ts
@@ -8,6 +8,17 @@
  * organization-only row that still has `deleting` container rows to consume,
  * and terminally fail a pending row whose payload can never identify an owner.
  *
+ * Tenant authority comes from the jobs row's own `organization_id` column, not
+ * from the payload. The executor's recovery branch derives its delete scope
+ * from `data.organizationId` with only a nonblank-string check, so requeueing a
+ * row whose payload names a different tenant would hand one organization's
+ * `deleting` containers to another organization's job. Every payload
+ * organization is therefore required to be a canonical UUID equal to the
+ * persisted owner; anything else is classified `organization-mismatch` and
+ * fails closed — never requeued — and the `deleting` inventory is always scoped
+ * to the authoritative owner so a corrupt payload cannot enumerate a foreign
+ * tenant's rows.
+ *
  * Every mutation is guarded on the status the classification observed, so
  * concurrent daemons or a second reconciler run cannot double-apply a
  * transition; the report counts only rows this run actually changed. The
@@ -28,6 +39,7 @@ export type ReconcilerDatabase = Pick<typeof dbWrite, "select" | "update">;
 export type ContainerDeleteJobClassification =
   | "valid"
   | "recoverable-organization-only"
+  | "organization-mismatch"
   | "unrecoverable";
 
 export type ContainerDeleteJobPlannedAction = "none" | "requeue" | "mark-failed";
@@ -40,8 +52,12 @@ export interface ContainerDeleteJobInventoryEntry {
   maxAttempts: number;
   createdAt: string;
   classification: ContainerDeleteJobClassification;
+  /** Authoritative owner from the jobs row; the only tenant scope trusted. */
+  ownerOrganizationId: string;
   /** Present when the payload carried a usable owning organization. */
   organizationId: string | null;
+  /** Whether the payload organization is a canonical UUID equal to the owner. */
+  payloadOrganizationMatchesOwner: boolean;
   /** Present only when the payload passed the canonical codec. */
   containerId: string | null;
   /** For organization-only rows: ids of that org's `deleting` container rows. */
@@ -60,6 +76,8 @@ export interface ContainerDeleteJobReconciliationReport {
   scannedJobs: number;
   validJobs: number;
   recoverableJobs: number;
+  /** Payload named a tenant that is not the row's authoritative owner. */
+  organizationMismatchJobs: number;
   unrecoverableJobs: number;
   requeuedJobs: number;
   markedFailedJobs: number;
@@ -73,8 +91,17 @@ export const UNRECOVERABLE_DELETE_JOB_ERROR =
   "reconciler (#15821). Any live container is swept by the orphan reconciler " +
   "using its immutable host id.";
 
+/** Error text stamped on pending rows whose payload names a foreign tenant. */
+export const ORGANIZATION_MISMATCH_DELETE_JOB_ERROR =
+  "CONTAINER_DELETE_PAYLOAD_ORGANIZATION_MISMATCH: legacy job payload names an " +
+  "organization that is not this job row's owner; terminally failed by the " +
+  "container-delete reconciler (#15821) so no worker can consume it into a " +
+  "foreign tenant. Escalate to an operator.";
+
 /** Statuses that are already settled and must never be touched. */
 const TERMINAL_JOB_STATUSES = new Set(["completed", "failed", "cancelled"]);
+
+const CANONICAL_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function readOrganizationId(data: unknown): string | null {
   if (typeof data !== "object" || data === null) return null;
@@ -84,10 +111,35 @@ function readOrganizationId(data: unknown): string | null {
     : null;
 }
 
-/** Classify one persisted payload through the executor's own codec. */
-export function classifyContainerDeleteJobData(data: unknown): ContainerDeleteJobClassification {
+/**
+ * Classify one persisted payload against the row's authoritative owner.
+ *
+ * `ownerOrganizationId` is the jobs row's own `organization_id` column. A
+ * payload organization is only trusted when it is a canonical UUID equal to
+ * that owner, because the executor's recovery branch turns the payload value
+ * directly into a cross-tenant delete scope.
+ */
+export function classifyContainerDeleteJobData(
+  data: unknown,
+  ownerOrganizationId: string,
+): ContainerDeleteJobClassification {
+  const payloadOrganizationId = readOrganizationId(data);
+  if (
+    payloadOrganizationId !== null &&
+    !organizationMatchesOwner(payloadOrganizationId, ownerOrganizationId)
+  ) {
+    return "organization-mismatch";
+  }
   if (isContainerDeleteJobData(data)) return "valid";
-  return readOrganizationId(data) === null ? "unrecoverable" : "recoverable-organization-only";
+  return payloadOrganizationId === null ? "unrecoverable" : "recoverable-organization-only";
+}
+
+function organizationMatchesOwner(
+  payloadOrganizationId: string,
+  ownerOrganizationId: string,
+): boolean {
+  if (!CANONICAL_UUID.test(payloadOrganizationId)) return false;
+  return payloadOrganizationId.toLowerCase() === ownerOrganizationId.toLowerCase();
 }
 
 interface ScannedJobRow {
@@ -109,7 +161,7 @@ function planEntry(
   row: ScannedJobRow,
   deletingRows: Array<{ id: string; hasHostId: boolean }>,
 ): PlannedEntry {
-  const classification = classifyContainerDeleteJobData(row.data);
+  const classification = classifyContainerDeleteJobData(row.data, row.organization_id);
   const payloadOrganizationId = readOrganizationId(row.data);
   const base: ContainerDeleteJobInventoryEntry = {
     jobId: row.id,
@@ -118,7 +170,11 @@ function planEntry(
     maxAttempts: row.max_attempts,
     createdAt: row.created_at.toISOString(),
     classification,
+    ownerOrganizationId: row.organization_id,
     organizationId: payloadOrganizationId,
+    payloadOrganizationMatchesOwner:
+      payloadOrganizationId !== null &&
+      organizationMatchesOwner(payloadOrganizationId, row.organization_id),
     containerId:
       classification === "valid" &&
       typeof row.data === "object" &&
@@ -135,6 +191,21 @@ function planEntry(
 
   if (classification === "valid") {
     base.reason = "payload passes the canonical codec; normal worker path owns it";
+    return { entry: base, guardStatus: null };
+  }
+  if (classification === "organization-mismatch") {
+    // Fail closed: the executor's recovery branch would take its delete scope
+    // straight from this payload, so a pending row is actively dangerous.
+    if (row.status === "pending") {
+      base.plannedAction = "mark-failed";
+      base.reason =
+        "payload names an organization that is not this row's owner; terminally " +
+        "fail so no worker can consume it into a foreign tenant";
+      return { entry: base, guardStatus: "pending" };
+    }
+    base.reason =
+      `payload organization is not the row owner (status ${row.status}); ` +
+      "never requeued — escalate to an operator";
     return { entry: base, guardStatus: null };
   }
   if (TERMINAL_JOB_STATUSES.has(row.status) && row.status !== "failed") {
@@ -192,11 +263,16 @@ export async function reconcileContainerDeleteJobs(
     .where(eq(jobs.type, JOB_TYPES.CONTAINER_DELETE))
     .orderBy(jobs.created_at)) as ScannedJobRow[];
 
+  // Scope the deleting-container lookup to each row's authoritative owner. A
+  // corrupt payload must never widen this set to a foreign tenant, so the
+  // payload organization is not consulted here at all.
   const organizationIds = new Set<string>();
   for (const row of rows) {
-    if (classifyContainerDeleteJobData(row.data) === "recoverable-organization-only") {
-      const organizationId = readOrganizationId(row.data);
-      if (organizationId) organizationIds.add(organizationId);
+    if (
+      classifyContainerDeleteJobData(row.data, row.organization_id) ===
+      "recoverable-organization-only"
+    ) {
+      organizationIds.add(row.organization_id);
     }
   }
 
@@ -227,6 +303,7 @@ export async function reconcileContainerDeleteJobs(
     scannedJobs: rows.length,
     validJobs: 0,
     recoverableJobs: 0,
+    organizationMismatchJobs: 0,
     unrecoverableJobs: 0,
     requeuedJobs: 0,
     markedFailedJobs: 0,
@@ -234,15 +311,25 @@ export async function reconcileContainerDeleteJobs(
   };
 
   for (const row of rows) {
-    const organizationId = readOrganizationId(row.data);
-    const deletingRows = organizationId ? (deletingByOrganization.get(organizationId) ?? []) : [];
+    const deletingRows = deletingByOrganization.get(row.organization_id) ?? [];
     const { entry, guardStatus } = planEntry(row, deletingRows);
     if (entry.classification === "valid") report.validJobs += 1;
     else if (entry.classification === "recoverable-organization-only") report.recoverableJobs += 1;
+    else if (entry.classification === "organization-mismatch") report.organizationMismatchJobs += 1;
     else report.unrecoverableJobs += 1;
 
     if (apply && guardStatus !== null && entry.plannedAction !== "none") {
-      const changed = await applyTransition(db, row.id, entry.plannedAction, guardStatus);
+      const failureError =
+        entry.classification === "organization-mismatch"
+          ? ORGANIZATION_MISMATCH_DELETE_JOB_ERROR
+          : UNRECOVERABLE_DELETE_JOB_ERROR;
+      const changed = await applyTransition(
+        db,
+        row.id,
+        entry.plannedAction,
+        guardStatus,
+        failureError,
+      );
       entry.applied = changed;
       if (changed && entry.plannedAction === "requeue") report.requeuedJobs += 1;
       if (changed && entry.plannedAction === "mark-failed") report.markedFailedJobs += 1;
@@ -257,6 +344,7 @@ async function applyTransition(
   jobId: string,
   action: Exclude<ContainerDeleteJobPlannedAction, "none">,
   guardStatus: string,
+  failureError: string,
 ): Promise<boolean> {
   const values =
     action === "requeue"
@@ -269,7 +357,7 @@ async function applyTransition(
         }
       : {
           status: "failed" as const,
-          error: UNRECOVERABLE_DELETE_JOB_ERROR,
+          error: failureError,
           completed_at: new Date(),
           updated_at: new Date(),
         };


### PR DESCRIPTION
Follow-up to #22906 (merged), which landed the `#15821` operator reconciler. It addresses the tenant-binding blocker raised in review on that PR before it merged.

## The defect (on `develop` today)

`container-delete-job-reconciler.ts` derived its recovery scope from the persisted payload's `organizationId` using only a nonblank-string check. The jobs row's authoritative `organization_id` was selected in the query and never compared to it.

That matters because the executor's recovery branch (`container-job-executors.ts`) turns the *same* payload value straight into a delete scope:

```ts
const organizationId = recoverableDeleteOrganizationId(job); // payload, nonblank-string only
const rows = await deps.store.findDeletingByOrganization(organizationId);
```

The codec-valid path is tenant-guarded (`CONTAINER_DELETE_ORGANIZATION_MISMATCH`), but this recovery path is not. So requeueing an organization-only row whose payload names a *different* tenant hands one organization's `deleting` containers to another organization's job.

Confirmed empirically against the pre-fix code on real PGlite — a row owned by `ORG_B` whose payload named `ORG_A`:

```
classification:      "recoverable-organization-only"
organizationId:      ORG_A            <- payload, not the owner
deletingContainerIds:[CONTAINER_A]    <- ORG_A's row, enumerated under an ORG_B job
plannedAction:       "requeue"
applied:             true             <- status after: pending
```

Two problems in one: cross-tenant inventory disclosure in the operator report, and arming the executor's unguarded recovery branch to delete a foreign tenant's containers.

Secondarily, a nonblank non-UUID payload organization (e.g. `"not-a-uuid"`) reached `inArray(containers.organization_id, ...)` against a `uuid` column, so a single corrupt legacy row aborted the entire reconciliation run.

## The fix

Tenant authority now comes from the jobs row, never the payload:

- A payload organization is trusted only when it is a canonical UUID **equal to** the persisted owner. Anything else classifies as the new `organization-mismatch` and **fails closed** — never requeued.
- A `pending` mismatch row is terminally failed with `CONTAINER_DELETE_PAYLOAD_ORGANIZATION_MISMATCH`, so no worker can consume it into a foreign tenant. Non-pending mismatch rows are reported for operator escalation and left untouched.
- The `deleting` container lookup is scoped to the authoritative owner, so a corrupt payload can neither enumerate nor transition foreign rows.
- Because the scope key is now the `uuid` column itself, the non-UUID abort is structurally gone.
- Entries gain `ownerOrganizationId` and `payloadOrganizationMatchesOwner`; the report gains `organizationMismatchJobs`. Still ids/counts only — safe to paste as sanitized evidence.

Dry-run default, single-row status-guarded `UPDATE ... RETURNING`, idempotency, and concurrent-apply behavior are unchanged.

## Test-integrity fix

The suite's `beforeAll` wrapped PGlite setup in a `try/catch` that set `databaseReady = false`, and every test began `if (!databaseReady) return;`. When the harness could not resolve its DB module, the suite reported **4 pass / 0 fail** having executed zero assertions against zero database. That is a fabricated pass, and it happened on the first run here. The `try/catch` and the early returns are removed — a broken harness now fails loudly.

## Verification

Real in-process Postgres (PGlite), no mocks for the system under test:

- `container-delete-job-reconciler.integration.test.ts` — **6 pass / 0 fail, 74 assertions**, at this branch head rebased on current `develop`. Two new cases:
  - a payload naming a foreign tenant is never requeued, enumerates no foreign container rows, is fail-closed when pending, and leaves `ORG_A`'s container `deleting` (zero foreign-tenant state transition);
  - a non-UUID payload organization is fail-closed and does not abort the run.
- Neighboring suites green at the pre-rebase head: `container-job-executors`, `container-job-service`, `container-jobs-data`, `container-delete-job-reconciler` — **50 pass / 0 fail**.
- `biome check` clean; `tsc --noEmit` reports no errors in the touched files.

## Note on the executor

This fences the reconciler, which is the component that would *create* the cross-tenant requeue. `recoverableDeleteOrganizationId` in `container-job-executors.ts` still trusts `data.organizationId` without comparing it to the job row's owner, so any other producer of an organization-only payload retains the same hazard. That is a separate change to a path already on `develop` and is left out of this scope deliberately — worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)