### PR TITLE
fix(cloud): keep provisioning lifecycle polling live

### DIFF
--- a/packages/cloud/api/__tests__/elizaos-core-stub.test.ts
+++ b/packages/cloud/api/__tests__/elizaos-core-stub.test.ts
@@ -1,6 +1,9 @@
 /** Exercises Worker-safe core stub behavior with deterministic fixtures. */
 import { describe, expect, test } from "bun:test";
 
+import { stripHtmlRawTextElements as stripHtmlRawTextElementsFromCore } from "../../../core/src/utils/html-raw-text";
+import { toWellFormedUnicode as toWellFormedUnicodeFromCore } from "../../../core/src/utils/well-formed";
+
 import {
   DEFAULT_CEREBRAS_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL,
@@ -29,13 +32,35 @@ describe("elizaos-core Worker stub", () => {
     ).resolves.toBe("ok");
   });
 
-  test("re-exports canonical pure text sanitizers used by Worker consumers", () => {
-    expect(
-      stripHtmlRawTextElements(
-        "before<script><!--<script>hidden</script>still-hidden</script>after",
-      ),
-    ).toBe("before after");
-    expect(toWellFormedUnicode("before\ud83dafter")).toBe("before�after");
+  test("keeps Worker raw-text stripping in parity with core", () => {
+    const cases = [
+      "plain text",
+      "before<SCRIPT type='text/javascript'>hidden</SCRIPT >after",
+      'before<style media="screen > print">hidden</style/ >after',
+      "before<script><!--<script>hidden</script>still-hidden</script>after",
+      "before<script>unterminated",
+      "before<scripture>visible</scripture>after",
+    ];
+    for (const input of cases) {
+      expect(stripHtmlRawTextElements(input)).toBe(
+        stripHtmlRawTextElementsFromCore(input),
+      );
+    }
+  });
+
+  test("keeps Worker Unicode repair in parity with core", () => {
+    const cases = [
+      "plain text",
+      "before\ud83dafter",
+      "before\udc80after",
+      "valid pair 💀",
+      "\ud83d\udc80\ud83d",
+    ];
+    for (const input of cases) {
+      expect(toWellFormedUnicode(input)).toBe(
+        toWellFormedUnicodeFromCore(input),
+      );
+    }
   });
 
   test("strips document augmentation before Worker-side persistence", () => {

--- a/packages/homepage/src/lib/hooks/use-eliza-app-provisioning-chat.ts
+++ b/packages/homepage/src/lib/hooks/use-eliza-app-provisioning-chat.ts
@@ -111,6 +111,7 @@ export function useElizaAppProvisioningChat(
   );
   const stoppedRef = useRef(false);
   const pollStartRef = useRef<number | null>(null);
+  const hasAnnouncedReadyRef = useRef(false);
 
   const isReady = containerStatus === "running" && bridgeUrl !== null;
   const isDedicatedOff = containerStatus === "none";
@@ -176,6 +177,7 @@ export function useElizaAppProvisioningChat(
       setBridgeUrl(null);
       setMessages([WELCOME]);
       setIsLoading(false);
+      hasAnnouncedReadyRef.current = false;
       if (timeoutRef.current) {
         window.clearTimeout(timeoutRef.current);
         timeoutRef.current = null;
@@ -184,7 +186,7 @@ export function useElizaAppProvisioningChat(
   }, [onboardingSessionId]);
 
   useEffect(() => {
-    if (!active || isReady || isDedicatedOff || provisioningError) return;
+    if (!active || isDedicatedOff || provisioningError) return;
     stoppedRef.current = false;
     if (pollStartRef.current === null) pollStartRef.current = Date.now();
     generationRef.current += 1;
@@ -198,9 +200,8 @@ export function useElizaAppProvisioningChat(
         generation !== generationRef.current
       )
         return;
-      const elapsed = pollStartRef.current
-        ? Date.now() - pollStartRef.current
-        : 0;
+      if (pollStartRef.current === null) pollStartRef.current = Date.now();
+      const elapsed = Date.now() - pollStartRef.current;
       if (elapsed > POLL_DEADLINE_MS) {
         if (generation !== generationRef.current) return;
         stoppedRef.current = true;
@@ -234,17 +235,22 @@ export function useElizaAppProvisioningChat(
               newStatus === "running" ? (res.data.bridgeUrl ?? null) : null,
             );
             if (newStatus === "running" && res.data.bridgeUrl) {
-              stoppedRef.current = true;
-              setMessages((prev) => [
-                ...prev,
-                {
-                  id: uid(),
-                  role: "assistant",
-                  content:
-                    "Your AI space is ready! You can start chatting in full now.",
-                },
-              ]);
-              return;
+              pollStartRef.current = null;
+              // Multiple status requests can resolve together across an
+              // effect generation change. Claim the receipt synchronously so
+              // those responses still append exactly one ready handoff.
+              if (!hasAnnouncedReadyRef.current) {
+                hasAnnouncedReadyRef.current = true;
+                setMessages((prev) => [
+                  ...prev,
+                  {
+                    id: uid(),
+                    role: "assistant",
+                    content:
+                      "Your AI space is ready! You can start chatting in full now.",
+                  },
+                ]);
+              }
             }
             if (newStatus === "none") {
               stoppedRef.current = true;
@@ -287,8 +293,7 @@ export function useElizaAppProvisioningChat(
               provisioning?.status ?? containerStatusRef.current;
             applyOnboardingResponse(res.data);
             if (newStatus === "running" && provisioning?.bridgeUrl) {
-              stoppedRef.current = true;
-              return;
+              pollStartRef.current = null;
             }
             if (newStatus === "none") {
               stoppedRef.current = true;
@@ -338,7 +343,6 @@ export function useElizaAppProvisioningChat(
   }, [
     active,
     applyOnboardingResponse,
-    isReady,
     isDedicatedOff,
     onboardingSessionId,
     provisioningError,

--- a/packages/homepage/tests/provisioning-poll-hook.test.ts
+++ b/packages/homepage/tests/provisioning-poll-hook.test.ts
@@ -6,7 +6,9 @@
  * - the immediate (mount) request carries statusOnly:true with no message
  * - the 5-second retry carries statusOnly:true with no message
  * - the returned transcript has no poll-generated duplicate assistant replies
- * - cleanup (ready-state transition and unmount) stops further polling
+ * - polling observes canonical target changes after readiness
+ * - concurrent ready responses append one handoff receipt
+ * - cleanup on a terminal state or unmount stops further polling
  *
  * Uses jsdom (already a root devDependency) to provide the DOM React needs,
  * and controllable timer shims so tests advance the 5 s poll timeout
@@ -23,10 +25,13 @@ const fetchCalls: Array<{ url: string; method: string; body: unknown }> = [];
 // running until the test deliberately flips the status to "running".
 let nextStatus = "pending";
 let runningHasBridge = true;
+let runningAgentId = "agent-123";
+let runningBridgeUrl = "https://agent-123.example";
 let statusResponseSuccess = true;
 let releaseStatusResponse: (() => void) | null = null;
 let legacyStatusAgentId: string | null = null;
 let legacyStatusBridgeUrl: string | null = null;
+let legacyStatusResponseBarrier: Promise<void> | null = null;
 let legacyChatStatus = "running";
 let legacyChatAgentId: string | null = null;
 let legacyChatBridgeUrl: string | null = null;
@@ -64,6 +69,7 @@ const clientMock = {
     });
 
     if (url === "/api/eliza-app/provisioning-agent") {
+      await legacyStatusResponseBarrier;
       if (releaseStatusResponse) {
         await new Promise<void>((resolve) => {
           const release = releaseStatusResponse;
@@ -112,11 +118,8 @@ const clientMock = {
             : "Hi! I'm Eliza.",
           provisioning: {
             status: nextStatus,
-            agentId: isRunning ? "agent-123" : null,
-            bridgeUrl:
-              isRunning && runningHasBridge
-                ? "https://agent-123.example"
-                : null,
+            agentId: isRunning ? runningAgentId : null,
+            bridgeUrl: isRunning && runningHasBridge ? runningBridgeUrl : null,
           },
           messages: [
             {
@@ -187,6 +190,9 @@ async function tickPollTimers() {
   const timers = [...activeTimers];
   for (const timer of timers) {
     if (!timer.cleared) {
+      // Browser one-shot timers are no longer active once their callback
+      // begins; mirror that behavior before the callback schedules a retry.
+      activeTimers.delete(timer);
       await timer.callback();
     }
   }
@@ -262,10 +268,13 @@ describe("useElizaAppProvisioningChat — shared onboarding poll", () => {
     fetchCalls.length = 0;
     nextStatus = "pending";
     runningHasBridge = true;
+    runningAgentId = "agent-123";
+    runningBridgeUrl = "https://agent-123.example";
     statusResponseSuccess = true;
     releaseStatusResponse = null;
     legacyStatusAgentId = null;
     legacyStatusBridgeUrl = null;
+    legacyStatusResponseBarrier = null;
     legacyChatStatus = "running";
     legacyChatAgentId = null;
     legacyChatBridgeUrl = null;
@@ -336,7 +345,7 @@ describe("useElizaAppProvisioningChat — shared onboarding poll", () => {
     unmount();
   });
 
-  test("legacy chat clears a disappeared canonical target after polling stopped", async () => {
+  test("legacy chat clears a disappeared canonical target while polling continues", async () => {
     nextStatus = "running";
     legacyStatusAgentId = "agent-a";
     legacyStatusBridgeUrl = "https://agent-a.example";
@@ -347,7 +356,9 @@ describe("useElizaAppProvisioningChat — shared onboarding poll", () => {
     expect(getState().isReady).toBe(true);
     expect(getState().agentId).toBe("agent-a");
     expect(getState().bridgeUrl).toBe("https://agent-a.example");
-    expect([...activeTimers].filter((timer) => !timer.cleared)).toHaveLength(0);
+    expect(
+      [...activeTimers].filter((timer) => !timer.cleared).length,
+    ).toBeGreaterThanOrEqual(1);
 
     legacyChatStatus = "none";
     legacyChatAgentId = null;
@@ -514,7 +525,7 @@ describe("useElizaAppProvisioningChat — shared onboarding poll", () => {
     unmount();
   });
 
-  test("ready-state transition stops further polling", async () => {
+  test("shared onboarding replaces a ready target and clears a stale bridge", async () => {
     const { getState, unmount } = mountHook(
       true,
       "platform:blooio:+123****7890",
@@ -526,30 +537,109 @@ describe("useElizaAppProvisioningChat — shared onboarding poll", () => {
     // Flip the mock so the next response is provisioning=running with a bridgeUrl.
     nextStatus = "running";
 
-    // Fire the retry tick — the hook should see isReady and stop polling.
+    // Fire the retry tick — the hook should see the first ready target but
+    // keep its observation timer alive.
     await tickPollTimers();
     await waitForEffects(100);
 
     // The hook must have transitioned to ready.
     expect(getState().isReady).toBe(true);
 
-    // After the ready transition, the cleanup function should have cleared
-    // the timer. Verify no new calls arrive from further ticks.
-    const callsAfterReady = fetchCalls.filter(
-      (c) => c.url === "/api/eliza-app/onboarding/chat",
-    ).length;
+    expect(getState().agentId).toBe("agent-123");
+    expect(getState().bridgeUrl).toBe("https://agent-123.example");
 
-    // Even if we fire timers manually, cleared timers are skipped.
+    // The canonical session can move to a different running target while the
+    // page stays mounted. Change the mock identity and observe another poll.
+    runningAgentId = "agent-456";
+    runningBridgeUrl = "https://agent-456.example";
     await tickPollTimers();
     await waitForEffects(50);
 
-    const callsAfterExtraTick = fetchCalls.filter(
-      (c) => c.url === "/api/eliza-app/onboarding/chat",
-    ).length;
+    expect(getState().agentId).toBe("agent-456");
+    expect(getState().bridgeUrl).toBe("https://agent-456.example");
 
-    // No new calls should have arrived.
-    expect(callsAfterExtraTick).toBe(callsAfterReady);
+    nextStatus = "none";
+    await tickPollTimers();
+    await waitForEffects(50);
 
+    expect(getState().containerStatus).toBe("none");
+    expect(getState().agentId).toBeNull();
+    expect(getState().bridgeUrl).toBeNull();
+    expect(getState().isReady).toBe(false);
+    expect([...activeTimers].filter((timer) => !timer.cleared)).toHaveLength(0);
+
+    unmount();
+  });
+
+  test("legacy polling replaces a ready target and emits one ready receipt", async () => {
+    nextStatus = "running";
+    legacyStatusAgentId = "agent-a";
+    legacyStatusBridgeUrl = "https://agent-a.example";
+    const { getState, unmount } = mountHook(true, null);
+
+    await waitForEffects(150);
+
+    const readyCopy =
+      "Your AI space is ready! You can start chatting in full now.";
+    expect(getState().agentId).toBe("agent-a");
+    expect(
+      getState().messages.filter((message) => message.content === readyCopy),
+    ).toHaveLength(1);
+
+    legacyStatusAgentId = "agent-b";
+    legacyStatusBridgeUrl = "https://agent-b.example";
+    await tickPollTimers();
+    await waitForEffects(50);
+
+    expect(getState().agentId).toBe("agent-b");
+    expect(getState().bridgeUrl).toBe("https://agent-b.example");
+    expect(
+      getState().messages.filter((message) => message.content === readyCopy),
+    ).toHaveLength(1);
+
+    nextStatus = "none";
+    legacyStatusAgentId = null;
+    legacyStatusBridgeUrl = null;
+    await tickPollTimers();
+    await waitForEffects(50);
+
+    expect(getState().agentId).toBeNull();
+    expect(getState().bridgeUrl).toBeNull();
+    unmount();
+  });
+
+  test("concurrent legacy ready responses append one handoff receipt", async () => {
+    nextStatus = "pending";
+    let releaseBarrier: (() => void) | undefined;
+    legacyStatusResponseBarrier = new Promise<void>((resolve) => {
+      releaseBarrier = resolve;
+    });
+    const { getState, unmount } = mountHook(true, null);
+    await waitForEffects(50);
+
+    const firstPoll = fetchCalls.find(
+      (call) => call.url === "/api/eliza-app/provisioning-agent",
+    );
+    expect(firstPoll).toBeDefined();
+    const inFlight = capturedTimers[0]?.callback;
+    expect(inFlight).toBeUndefined();
+
+    nextStatus = "running";
+    legacyStatusAgentId = "agent-a";
+    legacyStatusBridgeUrl = "https://agent-a.example";
+    releaseBarrier?.();
+    await waitForEffects(150);
+
+    const timer = [...activeTimers][0];
+    expect(timer).toBeDefined();
+    await Promise.all([timer.callback(), timer.callback()]);
+    await waitForEffects(50);
+
+    const readyCopy =
+      "Your AI space is ready! You can start chatting in full now.";
+    expect(
+      getState().messages.filter((message) => message.content === readyCopy),
+    ).toHaveLength(1);
     unmount();
   });
 


### PR DESCRIPTION
# Relates to

Closes #23344.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact
      current-base-only `check:i18n` blocker is recorded below.
- [x] A reviewer can confirm the changed contract from the focused DOM hook
      suite, direct core/shim parity suite, production Worker dry-run, app
      production build, and real local onboarding-stack run below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@388a10abeb49801d59611afb43d250dcad4cb042:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `c722737178f39cd095bc8081eb4dbde6cb5bfb20`; zero conflicts.
- [x] `bun run verify` was run post-sync. It reaches the unchanged current-base
      `check:i18n` failure documented below; every owning and integration gate
      for this patch passes.

# Risks

Medium. The homepage now keeps its existing five-second lifecycle observation
poll active while a ready target is displayed, so a page left open continues
to generate status-only reads. Polling still stops on `none`, terminal failure,
the five-minute non-ready deadline, or unmount. The benefit is that canonical
target replacement and removal can no longer leave a stale handoff URL.

# Background

## What does this PR do?

- Keeps legacy and shared-onboarding lifecycle polling alive after the first
  `running` target with a bridge.
- Replaces target A with canonical target B on later status reads and clears a
  stale bridge when the target becomes `none`.
- Uses a synchronous one-shot claim so concurrent legacy ready responses append
  exactly one existing ready handoff receipt.
- Strengthens the recently merged Worker-shim fix with direct parity tests
  against core's raw-text and well-formed Unicode utilities.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores the lifecycle-observation behavior already specified by the
issue and does not change a public API or operator workflow.

# Testing

## Where should a reviewer start?

Start with `packages/homepage/tests/provisioning-poll-hook.test.ts`, especially
the shared A-to-B replacement, legacy A-to-B/clear, and concurrent receipt
cases. Then inspect the hook's ready branches and the direct Worker/core parity
cases.

## Detailed testing steps

On exact head `388a10abeb49801d59611afb43d250dcad4cb042`:

- `bun run --cwd packages/homepage typecheck && bun run --cwd packages/homepage test`
  - 175 general homepage tests + 18 provisioning hook tests pass.
- `bun test packages/cloud/api/__tests__/elizaos-core-stub.test.ts`
  - 13 pass, including direct core-vs-shim parity vectors.
- `bun run --cwd packages/cloud/api typecheck`
  - TypeScript passes and Wrangler production dry-run bundles successfully:
    24,715.27 KiB / gzip 5,915.88 KiB.
- `bun run --cwd packages/cloud/e2e test -- tests/onboarding-reprovision.spec.ts`
  - 2/2 pass against the real local PGlite + Wrangler Worker stack.
- `bun run --cwd packages/app build:web`
  - 9,247 modules transformed; chunk-safety and viewport verification pass.
- `bunx @biomejs/biome check <three touched files>` and `git diff --check`
  - pass.
- `bun run verify`
  - blocked at the pre-existing `check:i18n` gate; reproduced identically in a
    pristine detached worktree at base `c722737178f39cd095bc8081eb4dbde6cb5bfb20`.

# Evidence Gate

<!-- evidence-head:388a10abeb49801d59611afb43d250dcad4cb042 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered markup, styles, layout, or copy changes; the patch only
      changes the lifetime and replacement semantics of an existing hook.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered visual surface changed; the app production artifact
      was built and the state transitions are asserted in the DOM hook suite.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no new user interaction or rendered flow was introduced.
<!-- evidence-row:backend-logs -->
- [ ] N/A - exact-head local Wrangler/PGlite output is pasted in Evidence Details; this mock-backed local stack has no persistent external log sink.

  <details><summary>Exact-head local stack excerpt</summary>

  ```text
  [db:migrate] migrations complete; released migration lock
  [wrangler:info] GET /api/auth/siwe/nonce 200 OK
  [wrangler:info] POST /api/auth/siwe/verify 200 OK
  repeated reads expose a failed Dedicated row without re-arming it — passed
  a newer Shared row does not mask the Dedicated target or enqueue work — passed
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser component or network protocol changed; the deterministic
      jsdom hook suite records every GET/POST body and resulting client state.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this observation-only change creates no durable domain artifact;
      the real onboarding test proves it does not enqueue or re-arm compute.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text or visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing behavior changed.

## Backend + frontend logs

The exact-head real-stack run reported:

```text
[wrangler:info] GET /api/auth/siwe/nonce 200 OK
[wrangler:info] POST /api/auth/siwe/verify 200 OK
2 passed (1.4m)
```

The focused jsdom suite passed 18/18 and asserts the shared and legacy
request/response state transitions without depending on wall-clock waits.

## Screenshots (before / after) + video walkthrough

N/A - the diff contains no rendered component, style, asset, layout, or copy
change. The existing UI receives fresher canonical state from the same hook.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

`bun run verify` stops in the repository's current-base `check:i18n` gate. A
detached pristine worktree at exact base
`c722737178f39cd095bc8081eb4dbde6cb5bfb20` produces the same result: 11 English
keys used by unrelated `packages/ui` files are missing, and every translated
locale contains the same two orphaned keys. None of this PR's three files owns
or references those keys. All downstream owning gates were run separately and
pass as listed above.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@388a10abeb49801d59611afb43d250dcad4cb042:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@388a10abeb49801d59611afb43d250dcad4cb042:packages/skills/skills/contribute-to-eliza"} -->

