### PR TITLE
fix(cloud): restore develop workflow contracts

### DIFF
--- a/packages/cloud/api/v1/user/wallets/provision/route.json.test.ts
+++ b/packages/cloud/api/v1/user/wallets/provision/route.json.test.ts
@@ -151,10 +151,10 @@ describe("POST /api/v1/user/wallets/provision JSON body", () => {
   });
 
   test("preserves non-syntax request decoding failures as server errors", async () => {
-    const originalJson = HonoRequest.prototype.json;
-    HonoRequest.prototype.json = mock(async () => {
+    const originalText = HonoRequest.prototype.text;
+    HonoRequest.prototype.text = mock(async () => {
       throw new Error("request stream failed");
-    }) as typeof HonoRequest.prototype.json;
+    }) as typeof HonoRequest.prototype.text;
 
     try {
       const res = await post(JSON.stringify(validBody));
@@ -162,7 +162,7 @@ describe("POST /api/v1/user/wallets/provision JSON body", () => {
       expect(provisionServerWallet).not.toHaveBeenCalled();
       expect(failureResponse).toHaveBeenCalled();
     } finally {
-      HonoRequest.prototype.json = originalJson;
+      HonoRequest.prototype.text = originalText;
     }
   });
 

--- a/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
@@ -89,6 +89,7 @@ describe("managed dedicated live-smoke workflow contract", () => {
       "all",
       "app",
       "scenarios",
+      "live-information",
       "cloud",
       "voice",
       "dedicated",


### PR DESCRIPTION
# Relates to

Relates to #22842.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c25bef09cc494c4e2a3185ff757e1d8f70ffc199:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `8737a653e34ff0f5d3a39e591c30cbf4848a9ae2`; zero conflicts.
- [ ] `bun run verify` passes post-sync. The exact host blocker is documented below.

# Risks

Low. This changes test contracts only: the request-decoding failure seam now patches the method production calls, and the managed live-smoke option inventory now includes the shipped `live-information` suite.

# Background

## What does this PR do?

- Repairs the wallet-provision decoder regression from Cloud Tests run 32447713091 by patching `HonoRequest.prototype.text`, matching the production decoder.
- Repairs the managed-dedicated workflow contract expectation by including the current `live-information` dispatch option.

Other failures from the same develop wave were absorbed upstream before publication: #23379 fixed Cloud CF delete mock typing, #23413 fixed Worker core-stub exports, #23424 fixed Cloud formatting and stale control-plane expectations, and #23367 fixed the UI fixture browser graph.

## What kind of change is this?

Bug fixes (non-breaking test-contract corrections).

# Documentation changes needed?

No. These tests now reflect existing production and workflow contracts.

# Testing

## Where should a reviewer start?

- `packages/cloud/api/v1/user/wallets/provision/route.json.test.ts`
- `packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts`

## Detailed testing steps

```text
bun test packages/cloud/api/v1/user/wallets/provision/route.json.test.ts packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
13 pass, 0 fail, 111 expect() calls

bunx @biomejs/biome check packages/cloud/api/v1/user/wallets/provision/route.json.test.ts packages/cloud/scripts/admin/managed-dedicated-canary-workflow.test.ts
Checked 2 files. No fixes applied.

git diff --check
exit 0
```

# Evidence Gate

<!-- evidence-head:c25bef09cc494c4e2a3185ff757e1d8f70ffc199 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic test-contract corrections have no deployed backend runtime path.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain state or persisted artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changed.

## Backend + frontend logs

Backend: exact focused test output is included in Testing. Frontend: N/A, no frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - test-only change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

`bun run verify` could not be completed in the sparse isolated checkout: expanding the full 46k-file worktree remained blocked in Git materialization for more than eight minutes on the saturated shared host and was interrupted cleanly. The exact affected tests and Biome checks pass after the final rebase; hosted develop/PR gates remain the broad acceptance hold.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@c25bef09cc494c4e2a3185ff757e1d8f70ffc199:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-develop-ci]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@c25bef09cc494c4e2a3185ff757e1d8f70ffc199:packages/skills/skills/contribute-to-eliza"} -->
