### PR TITLE
fix(agent): reject proxies before cache reflection

### DIFF
--- a/packages/agent/src/runtime/tool-call-cache-wrapper.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache-wrapper.test.ts
@@ -177,6 +177,54 @@ describe("wrapActionWithCache", () => {
     expect(calls()).toBe(2);
   });
 
+  it("does not cache a proxied field or run its reflection traps", async () => {
+    const cache = createToolCallCacheFromConfig({ diskRoot: tempRoot });
+    if (!cache) throw new Error("cache must be enabled");
+    const trapCalls = {
+      get: 0,
+      getOwnPropertyDescriptor: 0,
+      getPrototypeOf: 0,
+      ownKeys: 0,
+    };
+    const { action, calls } = makeFakeAction("web_search", () => ({
+      success: true,
+      data: new Proxy(
+        { payload: "value" },
+        {
+          get() {
+            trapCalls.get += 1;
+            throw new TypeError("hostile get trap");
+          },
+          getOwnPropertyDescriptor() {
+            trapCalls.getOwnPropertyDescriptor += 1;
+            throw new TypeError("hostile descriptor trap");
+          },
+          getPrototypeOf() {
+            trapCalls.getPrototypeOf += 1;
+            throw new TypeError("hostile prototype trap");
+          },
+          ownKeys() {
+            trapCalls.ownKeys += 1;
+            throw new TypeError("hostile ownKeys trap");
+          },
+        },
+      ),
+    }));
+    const wrapped = wrapActionWithCache(action, cache, { diskRoot: tempRoot });
+    const options = { parameters: { q: "hostile-proxy" } };
+
+    await wrapped.handler({} as never, {} as never, undefined, options);
+    await wrapped.handler({} as never, {} as never, undefined, options);
+
+    expect(calls()).toBe(2);
+    expect(trapCalls).toEqual({
+      get: 0,
+      getOwnPropertyDescriptor: 0,
+      getPrototypeOf: 0,
+      ownKeys: 0,
+    });
+  });
+
   it("createToolCallCacheFromConfig returns null when disabled", () => {
     const cache = createToolCallCacheFromConfig({ enabled: false });
     expect(cache).toBeNull();

--- a/packages/agent/src/runtime/tool-call-cache/bounded-walk.ts
+++ b/packages/agent/src/runtime/tool-call-cache/bounded-walk.ts
@@ -15,15 +15,17 @@
  *     rejected without allocating a values array.
  *   - Property values are read from data descriptors only. An accessor
  *     (getter/setter) property is rejected outright, so no user getter and no
- *     Proxy `get` trap is ever invoked.
- *   - Every reflection call is guarded. A revoked or throwing Proxy surfaces
- *     as a `reflection` rejection instead of leaking a raw `TypeError` onto
- *     the caller's success path.
+ *     user property getter is ever invoked.
+ *   - Proxies are rejected with Node's trap-free Proxy detector before any
+ *     JavaScript reflection runs. Guarded reflection calls then keep unusual
+ *     non-Proxy objects from leaking raw errors onto the caller's success path.
  *   - Depth, node count, aggregate key width, per-string length and aggregate
  *     bytes are all budgeted, and the budget is shared across the whole walk.
  *   - Cycle detection is path-local (`seen.delete` on container exit) so valid
  *     DAGs / repeated references are preserved; only true cycles reject.
  */
+
+import { types as nodeUtilTypes } from "node:util";
 
 export interface BoundedWalkLimits {
   /** Maximum container nesting. Depth 0 is the root value. */
@@ -65,7 +67,7 @@ export type BoundedWalkRejection =
   | "keys"
   /** Node budget exhausted. */
   | "nodes"
-  /** A reflection call threw (revoked/hostile Proxy). */
+  /** Reflection was unsafe (including any Proxy) or a reflection call threw. */
   | "reflection"
   /** A single string leaf exceeded the per-string cap. */
   | "string-length"
@@ -116,10 +118,16 @@ type ContainerShape =
 
 /**
  * Classify a container and report its width without reading any property
- * value. Every reflection call is guarded so a revoked Proxy rejects rather
- * than throwing.
+ * value. Proxies are rejected before reflection, and every subsequent
+ * reflection call is guarded so unusual host objects reject rather than throw.
  */
 function describeContainer(value: object): ContainerShape {
+  // `util.types.isProxy` inspects the engine object directly and never invokes
+  // user traps, including for revoked proxies.
+  if (nodeUtilTypes.isProxy(value)) {
+    return { kind: "reject", reason: "reflection" };
+  }
+
   let isArray: boolean;
   try {
     isArray = Array.isArray(value);

--- a/packages/agent/src/runtime/tool-call-cache/cache.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/cache.test.ts
@@ -649,8 +649,13 @@ describe("ToolCallCache", () => {
     expect(getterCalls).toBe(0);
   });
 
-  it("returns a reflection-hostile proxy uncached without running its get trap", async () => {
-    let getTrapCalls = 0;
+  it("returns a proxy uncached without running any reflection trap", async () => {
+    const trapCalls = {
+      get: 0,
+      getOwnPropertyDescriptor: 0,
+      getPrototypeOf: 0,
+      ownKeys: 0,
+    };
     // Wrapped in a plain object: a bare proxy as a resolved promise value
     // would trip the runtime's own `then` lookup before the cache sees it.
     const makeHostile = (): unknown => ({
@@ -658,11 +663,20 @@ describe("ToolCallCache", () => {
       nested: new Proxy(
         { payload: "value" },
         {
-          get(target, property, receiver) {
-            getTrapCalls += 1;
-            return Reflect.get(target, property, receiver);
+          get() {
+            trapCalls.get += 1;
+            throw new TypeError("hostile get trap");
+          },
+          getOwnPropertyDescriptor() {
+            trapCalls.getOwnPropertyDescriptor += 1;
+            throw new TypeError("hostile descriptor trap");
+          },
+          getPrototypeOf() {
+            trapCalls.getPrototypeOf += 1;
+            throw new TypeError("hostile prototype trap");
           },
           ownKeys() {
+            trapCalls.ownKeys += 1;
             throw new TypeError("hostile ownKeys trap");
           },
         },
@@ -670,7 +684,12 @@ describe("ToolCallCache", () => {
     });
     expect(isCacheableToolOutput(makeHostile())).toBe(false);
     await expectUncacheableOnEveryRoute("hostile-proxy", makeHostile);
-    expect(getTrapCalls).toBe(0);
+    expect(trapCalls).toEqual({
+      get: 0,
+      getOwnPropertyDescriptor: 0,
+      getPrototypeOf: 0,
+      ownKeys: 0,
+    });
   });
 
   it("returns a revoked proxy uncached instead of leaking a raw TypeError", async () => {

--- a/packages/agent/src/runtime/tool-call-cache/redact.test.ts
+++ b/packages/agent/src/runtime/tool-call-cache/redact.test.ts
@@ -179,6 +179,49 @@ describe("defaultPrivacyRedactor", () => {
     expect(isRedactionDegraded(out)).toBe(true);
   });
 
+  it("marks a proxy degraded without running any reflection trap", () => {
+    const trapCalls = {
+      get: 0,
+      getOwnPropertyDescriptor: 0,
+      getPrototypeOf: 0,
+      ownKeys: 0,
+    };
+    const hostile = new Proxy(
+      { payload: "value" },
+      {
+        get() {
+          trapCalls.get += 1;
+          throw new TypeError("hostile get trap");
+        },
+        getOwnPropertyDescriptor() {
+          trapCalls.getOwnPropertyDescriptor += 1;
+          throw new TypeError("hostile descriptor trap");
+        },
+        getPrototypeOf() {
+          trapCalls.getPrototypeOf += 1;
+          throw new TypeError("hostile prototype trap");
+        },
+        ownKeys() {
+          trapCalls.ownKeys += 1;
+          throw new TypeError("hostile ownKeys trap");
+        },
+      },
+    );
+
+    const out = defaultPrivacyRedactor({ nested: hostile });
+
+    expect((out as Record<string, unknown>).nested).toBe(
+      REDACT_BUDGET_SENTINEL,
+    );
+    expect(isRedactionDegraded(out)).toBe(true);
+    expect(trapCalls).toEqual({
+      get: 0,
+      getOwnPropertyDescriptor: 0,
+      getPrototypeOf: 0,
+      ownKeys: 0,
+    });
+  });
+
   it("bounds an oversize string leaf", () => {
     const huge = "a".repeat(4_000_001);
     expect(defaultPrivacyRedactor({ blob: huge })).toEqual({


### PR DESCRIPTION
# Relates to

Fixes #23397

Definition of Done: full standard in CONTRIBUTING.md.

- [x] This PR targets develop and is rebased onto origin/develop at 9bc6d456677dc9cb73c9e89d2a216c8cf0315910 with zero conflicts.
- [ ] bun install and bun run verify were run after sync; the current shared-host blocker is recorded below.
- [x] A reviewer can confirm the changed contract from the focused regression evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: OpenAI/gpt-5
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@9bc6d456677dc9cb73c9e89d2a216c8cf0315910:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto origin/develop at 9bc6d456677dc9cb73c9e89d2a216c8cf0315910; zero conflicts.
- [ ] bun run verify is pending for the exact shared-host limitation below.

# Risks

Low. The behavior change rejects Proxy objects earlier than before, using the Node engine trap-free detector. Plain objects and arrays retain their existing bounded traversal behavior. Proxy outputs were already treated as degraded or uncacheable; this closes side effects during that rejection.

# Background

## What does this PR do?

It rejects Proxy values at the shared bounded-walker boundary before Array.isArray, prototype inspection, key enumeration, or descriptor lookup can invoke user-controlled reflection hooks. It also adds zero-trap regressions through cache validation, direct set, default run, lenient run, privacy redaction, and the action wrapper.

## What kind of change is this?

Bug fix (non-breaking hardening of an existing rejection path).

# Documentation changes needed?

N/A - the maintained source header now states the corrected hostile-input contract; no public API or user workflow changes.

# Testing

## Where should a reviewer start?

Start with packages/agent/src/runtime/tool-call-cache/bounded-walk.ts and the hostile-Proxy tests in cache.test.ts, redact.test.ts, and tool-call-cache-wrapper.test.ts.

## Detailed testing steps

At exact commit a670bd39186b2dd155d53a54ed841bf08dd64a11:

- Focused Vitest cache/redactor/wrapper suites: 3 files passed, 62 tests passed.
- Biome check on all four changed files: passed.
- git diff --check: passed.
- The new fixtures arm get, getPrototypeOf, ownKeys, and getOwnPropertyDescriptor hooks; all counters remain zero across every route.

# Evidence Gate

<!-- evidence-head:a670bd39186b2dd155d53a54ed841bf08dd64a11 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - this is a deterministic in-process object-walk boundary with no backend transport.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, provider, planner, or action semantics change; only cache output validation hardening.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduler, wallet, file, or other domain artifact changes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changes.

## Backend + frontend logs

N/A - the executable evidence is the deterministic zero-trap regression matrix above.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT changes.

## Known gaps / failures

- The owning package typecheck was started after the exact rebase and stopped after several minutes with no diagnostics. The shared machine currently has numerous unrelated TypeScript processes running for over an hour and saturating CPU, so this is recorded as an environmental non-result, not a pass.
- bun install and root bun run verify were not started in the dirty shared checkout while those unrelated validation processes are active. Hosted checks and a clean-worktree verification remain required before merge.
- The focused Vitest run used a temporary source-boundary test configuration because the sparse review worktree does not contain built workspace artifacts. Those temporary harness files were removed and are not in the diff.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@9bc6d456677dc9cb73c9e89d2a216c8cf0315910:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
-- [codex/root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@9bc6d456677dc9cb73c9e89d2a216c8cf0315910:packages/skills/skills/contribute-to-eliza"} -->