### PR TITLE
fix(core): close quoted-key and Google-token redaction bypasses, add a leak audit that can actually fail

### DIFF
--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -85,6 +85,41 @@ describe("redactSensitiveText (pattern detection)", () => {
 		expect(redactSensitiveText(benign)).toBe(benign);
 	});
 
+	it("masks a quoted credential key the ENV-style row cannot reach", () => {
+		// The ENV-style assignment pattern requires the key's word boundary to be
+		// followed immediately by `=`/`:`; a quoted key's closing quote always
+		// intervenes, so `{"api_key": "..."}` matched nothing before this fix.
+		// Assembled at runtime so no scannable secret-shaped literal sits in
+		// source (gitleaks/push-protection).
+		const value = ["sk", "_live_51H8xQ2LmNpQrStUv"].join("");
+		for (const [key, quote] of [
+			["api_key", '"'],
+			["api-key", '"'],
+			["api_key", "'"],
+		] as const) {
+			const body = `${quote}${key}${quote}: ${quote}${value}${quote}`;
+			const out = redactSensitiveText(`{${body}}`);
+			expect(out, `${key} (${quote})`).not.toContain(value);
+		}
+		// A prefixed name vocabulary still requires the separator before the
+		// credential word — "monkey" must not fold into "key".
+		const benign = '{"context_monkey": "banana bread"}';
+		expect(redactSensitiveText(benign)).toBe(benign);
+	});
+
+	it("masks Google OAuth refresh and access tokens", () => {
+		// `1//0...` (refresh) and `ya29....` (access) both survive a
+		// `\b`-anchored alphanumeric pattern because `1//` opens with a digit
+		// followed by slashes, which `\b` does not separate from what precedes
+		// it. Assembled at runtime per the fixture convention above.
+		const refreshToken = ["1//0", "AbCdEfGhIjKlMnOpQrStUvWxYz1234567890"].join("");
+		const accessToken = ["ya29.", "AbCdEfGhIjKlMnOpQrStUvWxYz1234-5678_90"].join("");
+		for (const token of [refreshToken, accessToken]) {
+			const out = redactSensitiveText(`token endpoint returned ${token} in the body`);
+			expect(out, token).not.toContain(token);
+		}
+	});
+
 	it("redacts credentials embedded in URI userinfo", () => {
 		const httpsUrl = "https://admin:hunter2hunter2@host.example.com/private";
 		const postgresUrl =

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -35,6 +35,21 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
 	String.raw`\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASSPHRASE|MNEMONIC|SEED|CREDENTIAL)\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1`,
 	// JSON fields.
 	String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|access_token|refreshToken|refresh_token|mnemonic|seedPhrase|passphrase|privateKey|credential|clientSecret|client_secret|sessionKey|session_key|authToken|auth_token|botToken|bot_token|connectionString|connection_string|webhookUrl|webhook_url)"\s*:\s*"([^"]+)"`,
+	// Quoted credential keys with arbitrary naming. The ENV-style row above
+	// requires the key's word boundary to be followed immediately by `=`/`:`,
+	// which a quoted key never is — the closing quote intervenes — so
+	// `{"api_key": "…"}` matched nothing at all. Serialized provider error
+	// bodies are exactly this shape, and they are the payloads most likely to
+	// be logged verbatim, so the blind spot pointed at the highest-risk input.
+	// The name vocabulary is open-ended: an optional separator-terminated
+	// prefix followed by a credential word, which keeps ordinary words that
+	// merely end in one ("monkey", "turkey") from matching because they have no
+	// separator before the suffix. Both quote styles are accepted so JS/Python
+	// reprs are covered alongside JSON. The prefix repeat is capped at 8
+	// segments (real key names never nest that deep) rather than left
+	// unbounded, keeping worst-case matching linear in input length instead of
+	// letting the engine explore every possible split of a long benign run.
+	String.raw`(["'])(?:[A-Za-z0-9]+[_.\-]){0,8}(?:api[_.\-]?key|access[_.\-]?token|refresh[_.\-]?token|auth[_.\-]?token|bot[_.\-]?token|session[_.\-]?key|private[_.\-]?key|client[_.\-]?secret|seed[_.\-]?phrase|passphrase|password|passwd|mnemonic|credential|secret|token|key)\1\s*[:=]\s*(["'])([^"'\\]+)\2`,
 	// CLI flags (space-separated and --flag=value forms).
 	String.raw`--(?:api[-_]?key|token|secret|password|passwd)(?:\s+|=)(["']?)([^\s"']+)\1`,
 	// Authorization credentials are either one token68 value or a complete
@@ -85,6 +100,13 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
 	String.raw`\b(pplx-[A-Za-z0-9_-]{10,})\b`,
 	String.raw`\b(npm_[A-Za-z0-9]{10,})\b`,
 	String.raw`\b(\d{6,}:[A-Za-z0-9_-]{20,})\b`,
+	// Google OAuth credentials. Refresh tokens (`1//0…`) and access tokens
+	// (`ya29.…`) carry no key name when echoed by a token-endpoint error body,
+	// and neither shape survives a `\b`-anchored alphanumeric pattern: `1//`
+	// opens with a digit followed by slashes. Case-sensitive `ya29.` avoids
+	// folding unrelated prose.
+	String.raw`/(1\/\/[A-Za-z0-9_\-]{10,})/g`,
+	String.raw`/\b(ya29\.[A-Za-z0-9_\-.]{10,})/g`,
 ];
 
 /**

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -724,6 +724,33 @@ describe("secret redaction", () => {
     }
   });
 
+  it("scrubs a quoted credential key the ENV-style row cannot reach", () => {
+    // Mirrors core's redact.test.ts case: the ENV-style pattern requires
+    // `=`/`:` immediately after the key's word boundary, which a quoted
+    // key's closing quote always intervenes on. Fixture assembled at
+    // runtime so no scannable secret-shaped literal sits in source.
+    const logger = redactLogger();
+    const value = ["sk", "_live_51H8xQ2LmNpQrStUv"].join("");
+    logger.info(
+      { payload: `{"api_key": "${value}"}` },
+      "ctx",
+    );
+    expect(recentLogs()).not.toContain(value);
+  });
+
+  it("scrubs Google OAuth refresh and access tokens from string values", () => {
+    const logger = redactLogger();
+    const refreshToken = ["1//0", "AbCdEfGhIjKlMnOpQrStUvWxYz1234567890"].join("");
+    const accessToken = ["ya29.", "AbCdEfGhIjKlMnOpQrStUvWxYz1234-5678_90"].join("");
+    logger.info(
+      { payload: `token endpoint returned ${refreshToken} and ${accessToken}` },
+      "ctx",
+    );
+    const logs = recentLogs();
+    expect(logs).not.toContain(refreshToken);
+    expect(logs).not.toContain(accessToken);
+  });
+
   it("scrubs credential patterns from the Error headline message (W5-026)", () => {
     const logger = redactLogger();
     logger.error(

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -467,6 +467,10 @@ const SENSITIVE_TEXT_PATTERNS: readonly string[] = [
   String.raw`\b[A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASSPHRASE|MNEMONIC|SEED|CREDENTIAL)\b\s*[=:]\s*(["']?)([^\s"'\\]+)\1`,
   // JSON fields.
   String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|access_token|refreshToken|refresh_token|mnemonic|seedPhrase|passphrase|privateKey|credential|clientSecret|client_secret|sessionKey|session_key|authToken|auth_token|botToken|bot_token|connectionString|connection_string|webhookUrl|webhook_url)"\s*:\s*"([^"]+)"`,
+  // Quoted credential keys with arbitrary naming — a closing quote sits where
+  // the ENV-style row expects `=`/`:`, so `{"api_key": "…"}` matched nothing.
+  // See core for the full rationale.
+  String.raw`(["'])(?:[A-Za-z0-9]+[_.\-]){0,8}(?:api[_.\-]?key|access[_.\-]?token|refresh[_.\-]?token|auth[_.\-]?token|bot[_.\-]?token|session[_.\-]?key|private[_.\-]?key|client[_.\-]?secret|seed[_.\-]?phrase|passphrase|password|passwd|mnemonic|credential|secret|token|key)\1\s*[:=]\s*(["'])([^"'\\]+)\2`,
   // CLI flags (space-separated and --flag=value forms).
   String.raw`--(?:api[-_]?key|token|secret|password|passwd)(?:\s+|=)(["']?)([^\s"']+)\1`,
   // Authorization headers (see core for the full grammar rationale: Basic
@@ -500,6 +504,10 @@ const SENSITIVE_TEXT_PATTERNS: readonly string[] = [
   String.raw`\b(pplx-[A-Za-z0-9_-]{10,})\b`,
   String.raw`\b(npm_[A-Za-z0-9]{10,})\b`,
   String.raw`\b(\d{6,}:[A-Za-z0-9_-]{20,})\b`,
+  // Google OAuth refresh (`1//0…`) and access (`ya29.…`) tokens; neither shape
+  // survives a `\b`-anchored alphanumeric pattern.
+  String.raw`/(1\/\/[A-Za-z0-9_\-]{10,})/g`,
+  String.raw`/\b(ya29\.[A-Za-z0-9_\-.]{10,})/g`,
 ];
 
 function parseSensitiveTextPattern(raw: string): RegExp | null {

--- a/plugins/plugin-agent-orchestrator/src/__tests__/curated-coding-memory.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/curated-coding-memory.test.ts
@@ -240,6 +240,46 @@ describe("curated coding memory", () => {
     );
   });
 
+  it("redacts token formats the retired local denylist missed", () => {
+    // Fixtures assembled at runtime so secret scanners do not flag them.
+    // Each row defeated the previous hand-maintained pattern list; the notes
+    // file is injected as coding context, so a miss here is a live credential
+    // handed to a future sub-agent. See issue #23419.
+    const cases: Array<[string, string]> = [
+      ["stripe live", ["sk", "_live_51H8xQ2LmNpQrStUv"].join("")],
+      [
+        "github fine-grained pat",
+        ["github", "_pat_11ABCDE0Y0aBcDeFgHiJkLmNoPqRsTuVwXyZ012345"].join(""),
+      ],
+      [
+        "slack app token",
+        ["xapp", "-1-A01B2C3D4-1234567890-abcdefabcdef"].join(""),
+      ],
+    ];
+    for (const [label, fixture] of cases) {
+      const redacted = redactCodingMemoryText(`Decision: used ${fixture} here`);
+      expect(redacted, label).not.toContain(fixture);
+    }
+  });
+
+  it("redacts a quoted credential inside a serialized provider error body", () => {
+    // The shape a provider error `detail` actually carries. The retired
+    // pattern's value class excluded quotes, so it matched nothing at all.
+    const fixture = ["sk", "_live_9ZyXwVuTsRqPoNmL"].join("");
+    const body = JSON.stringify({ error: "auth_failed", api_key: fixture });
+    expect(redactCodingMemoryText(body)).not.toContain(fixture);
+  });
+
+  it("does not maintain a local credential pattern list", async () => {
+    // Structural: a second hand-maintained denylist is how this drifted in the
+    // first place. Credential shapes must come from the canonical core set.
+    const source = await readFile(
+      join(import.meta.dirname, "../services/curated-coding-memory.ts"),
+      "utf8",
+    );
+    expect(source).toContain("getDefaultRedactPatterns");
+  });
+
   it("dedupes similar notes and merges provenance", async () => {
     const workdir = await tempWorkspace();
     try {

--- a/plugins/plugin-agent-orchestrator/src/services/curated-coding-memory.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/curated-coding-memory.ts
@@ -20,7 +20,7 @@ import {
 } from "node:fs/promises";
 import { homedir, hostname } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import type { IAgentRuntime } from "@elizaos/core";
+import { getDefaultRedactPatterns, type IAgentRuntime } from "@elizaos/core";
 import type {
   OrchestratorTaskDocument,
   OrchestratorTaskMessage,
@@ -245,12 +245,27 @@ function provenanceFor(doc: OrchestratorTaskDocument): string[] {
   return values.filter((value): value is string => Boolean(value));
 }
 
-const SECRET_PATTERNS: RegExp[] = [
-  /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g,
-  /\bsk-[A-Za-z0-9_-]{20,}\b/g,
-  /\bAKIA[A-Z0-9]{16}\b/g,
-  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
-  /\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|password|credential)\s*[:=]\s*["']?[^"'\s,;]+/gi,
+/**
+ * Credential shapes come from `@elizaos/core`'s canonical set rather than a
+ * local copy. A second hand-maintained denylist drifts the moment a provider
+ * introduces a format, and a miss here writes a live credential into a notes
+ * file that is later injected as coding context. Unlike core's diagnostic
+ * masking, the whole match is removed: a persisted read-model has no use for
+ * the surviving affixes that make a log line debuggable.
+ */
+const CREDENTIAL_PATTERNS: readonly RegExp[] = getDefaultRedactPatterns()
+  .map((raw) => {
+    const wrapped = raw.match(/^\/(.+)\/([gimsuy]*)$/);
+    if (wrapped) {
+      const flags = wrapped[2].includes("g") ? wrapped[2] : `${wrapped[2]}g`;
+      return new RegExp(wrapped[1], flags);
+    }
+    return new RegExp(raw, "gi");
+  })
+  .filter((pattern): pattern is RegExp => Boolean(pattern));
+
+/** Contact details that are personal data rather than credential shapes. */
+const CONTACT_PATTERNS: readonly RegExp[] = [
   /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
   /\b(?:\+?\d[\d .()-]{8,}\d)\b/g,
 ];
@@ -278,8 +293,15 @@ function redactPrivateKeys(input: string): string {
 }
 
 export function redactCodingMemoryText(input: string): string {
+  // Private keys are stripped by index-based scanning, not a `[\s\S]+?`
+  // regex, so an unterminated/huge PEM block can't push this onto the
+  // ReDoS-hardening backlog's radar (core's equivalent pattern is still run
+  // below as a defense-in-depth backstop, but it never sees a real block).
   let text = redactPrivateKeys(input);
-  for (const pattern of SECRET_PATTERNS) {
+  for (const pattern of CREDENTIAL_PATTERNS) {
+    text = text.replace(pattern, "[REDACTED]");
+  }
+  for (const pattern of CONTACT_PATTERNS) {
     text = text.replace(pattern, "[REDACTED]");
   }
   return text.replace(/\s+/g, " ").trim();


### PR DESCRIPTION
Refs #23419.

## Scope, honestly

The module #23419 describes — `packages/cloud/shared/src/lib/integrations/reliability.ts`, `SECRET_PATTERNS`, `redactIntegrationDiagnostics`, `findSecretLeaksInPayload`, the `redaction-audit` scenario — **does not exist on `develop`**. PR #23202 was closed unmerged and nothing from it landed. There is no integration-telemetry read-model here to fix, so this PR does not invent one.

What it does instead: the issue's two defect classes are **live elsewhere on `develop`**, and this fixes them there.

I ran the nine-row bypass table against the real live redactors before changing anything. `@elizaos/core`'s canonical `redactSensitiveText` already covered most rows (it is a much more mature module than the one #23202 introduced), but two genuine bypasses survived, and the orchestrator plugin carried its own stale copy that reproduced the original defect wholesale.

## Defect 1 — quoted credential keys (issue Cause 1)

Measured on `origin/develop`:

| input | before | after |
|---|---|---|
| `{"api_key": "AbCd1234EfGh"}` | **unchanged** | `{"api_key": "***"}` |
| `{"api-key": "AbCd1234EfGh"}` | **unchanged** | `{"api-key": "***"}` |
| `{'secret': 'AbCd1234EfGh'}` | **unchanged** | `{'secret': '***'}` |

The ENV-style assignment row requires the key's `\b` to be followed immediately by `\s*[=:]`. A quoted key never is — the closing quote intervenes — so the alternative dies and the pattern matches **nothing at all**. The JSON-field row only covered a hardcoded name list that has no `api_key`, no `api-key`, and no single-quoted form.

This is the same root cause the issue identifies, and it points at the same worst-case input: a serialized provider error body is exactly this shape, and it is the payload most likely to be logged verbatim.

The new row accepts an open-ended key vocabulary in both quote styles. A separator is required before the credential word, so ordinary words ending in one (`"monkey"`) do not fold into the shape — there is a test for that.

## Defect 2 — Google OAuth tokens (issue Cause 2)

| input | before | after |
|---|---|---|
| `google refresh 1//0gL9AbCdEfGh-XyZ` | **unchanged** | `google refresh 1//0gL…-XyZ` |
| `ya29.a0AfH6SMBx-abcdefghijklmnop` | **unchanged** | `ya29.a…mnop` |

Neither survives a `\b`-anchored alphanumeric pattern (`1//` opens with a digit followed by slashes). The other stale prefixes the issue lists — `sk_live_`, `github_pat_`, `xapp-`, `Authorization: Basic` — were already covered in core; I verified each rather than assuming.

Both new rows are mirrored into `@elizaos/logger`, which keeps a hand-synced copy. Core's existing parity test enforces this and caught the drift when I only edited one side.

## Defect 3 (structural) — an audit that can actually fail

This is the part of the issue that generalizes beyond any one module, so it is addressed as a reusable primitive: `packages/core/src/security/secret-leak-audit.ts`.

An audit built from the redactor's own pattern list is a tautology — every substring it can find has, by construction, already been replaced before it runs. `findSecretLeaks` shares **no pattern source** with `redact.ts` and is strictly broader:

- shape-generic detectors that enumerate no provider prefix (any `prefix_body` token, any credential-named assignment, any `Authorization` value) — these fire on formats that do not exist yet;
- a Shannon-entropy detector, where the redactor is explicitly enumerative and entropy-free.

Findings carry only masked previews, so an audit report cannot become the leak it was written to catch.

**Negative control** (the acceptance criterion that matters most):

```ts
const UNHANDLED_SECRET = "7Qk4Zr9WmT2xVb8NcJ5hLpY3dGs6Fa1E";

it("confirms the redactor deliberately leaves the control secret intact", () => {
  expect(redactSensitiveText(UNHANDLED_SECRET)).toBe(UNHANDLED_SECRET);
});

it("reports the control secret as a leak", () => {
  const findings = findSecretLeaks(redactSensitiveText(UNHANDLED_SECRET));
  expect(findings.length).toBeGreaterThan(0);
  expect(findings[0].category).toBe("high-entropy");
});
```

A bare high-entropy token with no key name, no assignment context, and no known prefix is a shape the redactor deliberately does not handle. The first test pins that this is real (not an accident that could silently drift), the second proves the audit sees it anyway. Two further tests assert the sources stay independent: no import of `redact.js`, and no pattern string from `getDefaultRedactPatterns()` appears in the audit source.

Because it over-reports by design (a commit SHA reads as high-entropy), the module header states plainly that it is an auditing instrument and must not gate production writes.

## Defect 4 (denylist drift) — the live duplicate

`plugins/plugin-agent-orchestrator/src/services/curated-coding-memory.ts` kept its own hand-maintained `SECRET_PATTERNS`. It was missing `sk_live_`, `github_pat_`, `xapp-`, and `Basic`, and its key=value row had the identical quote-excluding value class — the exact defect from the issue, on a live path. This writes into a `NOTES.eliza.md` file that is later **injected as coding context for sub-agents**, so a miss hands a live credential to a future agent.

It now sources credential shapes from core's canonical set and keeps only contact-detail (email/phone) patterns locally. It removes the whole match rather than masking: a persisted read-model has no use for the surviving affixes that make a log line debuggable.

This is the issue's "prefer typed/bounded over a denylist" recommendation applied as far as it goes here — one denylist instead of two is a real reduction, but it is still a denylist. The issue's stronger recommendation (closed `code` union, bounded `detail`) belongs to the read-model that does not exist yet; I have not simulated it.

## Tests

```
packages/core     src/security        37 files, 586 passed
packages/core     redact + audit      82 passed  (23 new)
packages/logger                       58 passed  (parity enforced)
plugin-agent-orchestrator  curated-coding-memory  14 passed  (3 new)
```

Lint (biome) clean on all seven touched files. ReDoS checked on the new nested-quantifier row — flat across `ab_`×10…160 and 10KB of prose, no backtracking blowup.

## What this PR does not claim

- It does **not** resolve #23419. The read-model, its typed `code`/`detail` contract, and the ingest-boundary validation the issue asks for have no code to attach to on `develop`. Those criteria remain open for whenever the dashboard is rebuilt — and `findSecretLeaks` is now available so that rework's audit can be non-vacuous from day one.
- It does **not** touch the #23202 closure grounds (durable cross-isolate storage, real telemetry producers).
- One test row is thinner than I wanted: the orchestrator plugin resolves `@elizaos/core` through the shared workspace symlink, so it exercises the installed core rather than this branch's source. The Google `1//` row is therefore asserted in core's own test (which does run against this source) rather than duplicated in the plugin suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
