### PR TITLE
feat(shared): add typed capability handoffs

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -78,7 +78,8 @@ describe("Shared turn AgentRuntime boundary", () => {
         channel: { type: ChannelType.DM, source: "shared-runtime" },
       },
     });
-    expect(JSON.stringify(runtimeInputs[0])).toContain("Shared runtime boundaries");
+    expect(JSON.stringify(runtimeInputs[0])).toContain("Shared runtime capabilities");
+    expect(JSON.stringify(runtimeInputs[0])).toContain("prerequisites:");
   });
 
   test("preserves server-owned voice execution semantics", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -35,6 +35,12 @@ import type { MobilePushMessage } from "../../mobile-push/types";
 import { CEREBRAS_DEFAULT_TEXT_SMALL_MODEL } from "../../models/catalog";
 import { hasLanguageModelProviderConfigured } from "../../providers/language-model";
 import {
+  buildSharedCapabilityCatalog,
+  formatSharedCapabilityCatalogForPrompt,
+  type SharedCapabilityFlags,
+  sharedCapabilityTransportForSource,
+} from "./shared-capability-catalog";
+import {
   resolveSharedCapabilityIntent,
   type SharedCapabilityResolution,
   type SharedCapabilityWall,
@@ -291,7 +297,7 @@ export function resolveSharedAgentTurnModel(preferred?: string): string | null {
  */
 function buildSharedRuntimeSystem(
   character: SharedAgentCharacter,
-  capabilities: { webSearch: boolean; reminders: boolean; todos: boolean; media: boolean },
+  capabilities: SharedCapabilityFlags,
   recallContext?: string,
   blockedCapabilities: SharedCapabilityWall[] = [],
   requiredAction?: "REMINDERS" | "TODO",
@@ -299,24 +305,11 @@ function buildSharedRuntimeSystem(
   const parts: string[] = [];
   const system = replaceNameTokens(character.system ?? "", character.name).trim();
   if (system) parts.push(system);
+  const catalog = buildSharedCapabilityCatalog(capabilities);
   parts.push(
-    "Shared runtime boundaries:\n" +
-      (capabilities.webSearch
-        ? "- You can converse, reason, draft, help the user plan, and use WEB_SEARCH for current public information.\n" +
-          "- WEB_SEARCH reads public results only; it does not operate websites, access accounts, submit forms, or make changes.\n"
-        : "- You can converse, reason, draft, and help the user plan; public web search is unavailable for this turn.\n") +
-      (capabilities.reminders
-        ? "- REMINDERS can create, list, snooze, complete, and dismiss reminders delivered to this private chat.\n"
-        : "- Reminders are unavailable on this transport.\n") +
-      (capabilities.todos
-        ? "- TODO can create, list, update, complete, cancel, and delete this account's persistent checklist.\n"
-        : "- Persistent todos are unavailable on this chat path.\n") +
-      (capabilities.media
-        ? "- GENERATE_MEDIA can create one organization-credit-funded image and return its public artifact URL.\n"
-        : "- Image generation is unavailable on this chat path.\n") +
-      "- You have no connected accounts, calendar, calling, arbitrary messaging, purchasing, notes store, shell, filesystem, browser control, or code execution in this runtime.\n" +
+    `Shared runtime capabilities:\n${formatSharedCapabilityCatalogForPrompt(catalog)}\n` +
       "- Never claim that you performed, scheduled, sent, booked, bought, saved, opened, or changed anything unless a registered action returned a successful result for that exact effect.\n" +
-      "- When an ambiguous follow-up asks you to execute a prior external action, explain the actual limitation naturally and offer useful planning or drafting help.",
+      "- When setup is needed, preserve the user's intent, offer the smallest valid handoff, and continue useful planning or drafting now.",
   );
   if (blockedCapabilities.length) {
     parts.push(
@@ -500,6 +493,7 @@ export async function runSharedAgentTurn(
               reminders: remindersEnabled,
               todos: todosEnabled,
               media: actionsEnabled && Boolean(execution.media),
+              transport: sharedCapabilityTransportForSource(execution.channel.source),
             },
             input.recallContext,
             capabilityWall ? [capabilityWall] : blockedSecondary,
@@ -583,6 +577,7 @@ export async function runSharedAgentTurnStream(
               reminders: remindersEnabled,
               todos: todosEnabled,
               media: actionsEnabled && Boolean(execution.media),
+              transport: sharedCapabilityTransportForSource(execution.channel.source),
             },
             input.recallContext,
             capabilityWall ? [capabilityWall] : blockedSecondary,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-catalog.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-catalog.test.ts
@@ -1,0 +1,67 @@
+/** Tests the capability catalog against actual Shared service combinations. */
+
+import { describe, expect, test } from "bun:test";
+import { findAgentCapability } from "@elizaos/shared";
+import {
+  buildSharedCapabilityCatalog,
+  formatSharedCapabilityCatalogForPrompt,
+  sharedCapabilityTransportForSource,
+} from "./shared-capability-catalog.js";
+
+describe("Shared capability catalog", () => {
+  test("derives optional capability availability from injected services", () => {
+    const catalog = buildSharedCapabilityCatalog({
+      webSearch: true,
+      reminders: true,
+      todos: false,
+      media: false,
+      transport: "sms",
+    });
+    expect(findAgentCapability(catalog, "reminders")?.availability).toBe("available");
+    expect(findAgentCapability(catalog, "todos")?.availability).toBe("unavailable");
+    expect(findAgentCapability(catalog, "reminders")?.transports).toEqual(["sms"]);
+  });
+
+  test("marks private integrations as personal-workspace capabilities", () => {
+    const catalog = buildSharedCapabilityCatalog({
+      webSearch: true,
+      reminders: false,
+      todos: false,
+      media: false,
+    });
+    expect(findAgentCapability(catalog, "calendar")).toMatchObject({
+      availability: "needs_workspace",
+      requiredTier: "personal",
+      nextAction: "upgrade_workspace",
+      requiresConfirmation: true,
+    });
+  });
+
+  test("gives the model detailed truthful setup and safety context", () => {
+    const catalog = buildSharedCapabilityCatalog({
+      webSearch: true,
+      reminders: false,
+      todos: false,
+      media: false,
+      transport: "web",
+    });
+
+    const text = formatSharedCapabilityCatalogForPrompt(catalog);
+    expect(text).toContain("Capability tier: shared. Transport: web.");
+    expect(text).toContain("Calendar (calendar)");
+    expect(text).toContain("examples: Check tomorrow; Schedule a meeting");
+    expect(text).toContain("prerequisites: Personal workspace, Connect calendar");
+    expect(text).toContain("consequence: consequential");
+    expect(text).toContain("confirmation: required before effect");
+    expect(text).toContain("next: upgrade workspace");
+    expect(text).toContain("Public web research (web-search); availability: available");
+  });
+
+  test("projects only trusted channel-source categories", () => {
+    expect(sharedCapabilityTransportForSource("gateway-discord")).toBe("discord");
+    expect(sharedCapabilityTransportForSource("twilio-sms")).toBe("sms");
+    expect(sharedCapabilityTransportForSource("twilio-voice")).toBe("voice");
+    expect(sharedCapabilityTransportForSource("client-chat")).toBe("app");
+    expect(sharedCapabilityTransportForSource("unrecognized")).toBe("api");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-catalog.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-catalog.ts
@@ -1,0 +1,321 @@
+/**
+ * Builds Shared's capability catalog from the services actually injected for
+ * this turn, keeping prompts, refusal routing, and client handoffs consistent.
+ */
+
+import type {
+  AgentCapabilityCatalog,
+  AgentCapabilityConsequence,
+  AgentCapabilityDescriptor,
+  AgentCapabilityId,
+  AgentCapabilityNextAction,
+  AgentCapabilityTransport,
+} from "@elizaos/shared";
+
+export interface SharedCapabilityFlags {
+  webSearch: boolean;
+  reminders: boolean;
+  todos: boolean;
+  media: boolean;
+  transport?: AgentCapabilityTransport;
+}
+
+/** Map only trusted server-owned channel sources into catalog transports. */
+export function sharedCapabilityTransportForSource(
+  source: string | undefined,
+): AgentCapabilityTransport {
+  const normalized = source?.toLowerCase() ?? "";
+  if (normalized.includes("discord")) return "discord";
+  if (normalized.includes("telegram")) return "telegram";
+  if (normalized.includes("voice")) return "voice";
+  if (
+    normalized.includes("twilio") ||
+    normalized.includes("blooio") ||
+    normalized.includes("sms")
+  ) {
+    return "sms";
+  }
+  if (normalized.includes("client") || normalized.includes("app")) return "app";
+  if (normalized.includes("web")) return "web";
+  return "api";
+}
+
+const ALL_TRANSPORTS: readonly AgentCapabilityTransport[] = [
+  "app",
+  "web",
+  "sms",
+  "voice",
+  "discord",
+  "telegram",
+  "api",
+];
+
+interface CapabilityDefinition {
+  id: AgentCapabilityId;
+  label: string;
+  examples: readonly string[];
+  consequence: AgentCapabilityConsequence;
+  requiresConfirmation: boolean;
+  nextAction: AgentCapabilityNextAction;
+  connection?: string;
+}
+
+const ALWAYS_AVAILABLE: readonly CapabilityDefinition[] = [
+  {
+    id: "conversation",
+    label: "Conversation and planning",
+    examples: ["Make a plan", "Think through a decision"],
+    consequence: "read_only",
+    requiresConfirmation: false,
+    nextAction: "none",
+  },
+  {
+    id: "drafting",
+    label: "Writing and drafting",
+    examples: ["Draft an email", "Rewrite a note"],
+    consequence: "read_only",
+    requiresConfirmation: false,
+    nextAction: "none",
+  },
+];
+
+const PERSONAL_CAPABILITIES: readonly CapabilityDefinition[] = [
+  {
+    id: "calendar",
+    label: "Calendar",
+    examples: ["Check tomorrow", "Schedule a meeting"],
+    consequence: "consequential",
+    requiresConfirmation: true,
+    nextAction: "upgrade_workspace",
+    connection: "calendar",
+  },
+  {
+    id: "bookings",
+    label: "Bookings",
+    examples: ["Reserve dinner", "Book travel"],
+    consequence: "consequential",
+    requiresConfirmation: true,
+    nextAction: "upgrade_workspace",
+  },
+  {
+    id: "communications",
+    label: "Email, calls, and messages",
+    examples: ["Send an email", "Text a contact"],
+    consequence: "consequential",
+    requiresConfirmation: true,
+    nextAction: "upgrade_workspace",
+    connection: "communications",
+  },
+  {
+    id: "purchases",
+    label: "Purchases",
+    examples: ["Order groceries", "Buy tickets"],
+    consequence: "consequential",
+    requiresConfirmation: true,
+    nextAction: "upgrade_workspace",
+  },
+  {
+    id: "notes",
+    label: "Persistent notes",
+    examples: ["Save a note", "Find my notes"],
+    consequence: "reversible_write",
+    requiresConfirmation: false,
+    nextAction: "upgrade_workspace",
+  },
+  {
+    id: "cloud-apps",
+    label: "Connected apps",
+    examples: ["Search Gmail", "Read Google Drive"],
+    consequence: "consequential",
+    requiresConfirmation: true,
+    nextAction: "upgrade_workspace",
+    connection: "external account",
+  },
+  {
+    id: "coding-runtime",
+    label: "Coding workspace",
+    examples: ["Edit a repository", "Run tests"],
+    consequence: "reversible_write",
+    requiresConfirmation: false,
+    nextAction: "upgrade_workspace",
+  },
+  {
+    id: "shell",
+    label: "Shell",
+    examples: ["Run a command"],
+    consequence: "consequential",
+    requiresConfirmation: true,
+    nextAction: "upgrade_workspace",
+  },
+  {
+    id: "filesystem",
+    label: "Files",
+    examples: ["Read a file", "Edit a document"],
+    consequence: "reversible_write",
+    requiresConfirmation: false,
+    nextAction: "upgrade_workspace",
+  },
+  {
+    id: "browser-control",
+    label: "Browser control",
+    examples: ["Open a page", "Fill a form"],
+    consequence: "consequential",
+    requiresConfirmation: true,
+    nextAction: "upgrade_workspace",
+  },
+  {
+    id: "profile-memory",
+    label: "Personal profile and preferences",
+    examples: ["Remember my location", "Remember how I work"],
+    consequence: "reversible_write",
+    requiresConfirmation: false,
+    nextAction: "upgrade_workspace",
+  },
+];
+
+function availableCapability(
+  definition: CapabilityDefinition,
+  transport: AgentCapabilityTransport,
+): AgentCapabilityDescriptor {
+  return {
+    ...definition,
+    availability: "available",
+    currentTier: "shared",
+    requiredTier: "shared",
+    transports: [transport],
+    prerequisites: [],
+    nextAction: "none",
+  };
+}
+
+function optionalSharedCapability(
+  definition: CapabilityDefinition,
+  available: boolean,
+  transport: AgentCapabilityTransport,
+): AgentCapabilityDescriptor {
+  return available
+    ? availableCapability(definition, transport)
+    : {
+        ...definition,
+        availability: "unavailable",
+        currentTier: "shared",
+        requiredTier: "shared",
+        transports: [transport],
+        prerequisites: [],
+        nextAction: "retry",
+      };
+}
+
+/** Build the truthful per-turn catalog from host-attested runtime services. */
+export function buildSharedCapabilityCatalog(flags: SharedCapabilityFlags): AgentCapabilityCatalog {
+  const transport = flags.transport ?? "api";
+  const optional: Array<[CapabilityDefinition, boolean]> = [
+    [
+      {
+        id: "web-search",
+        label: "Public web research",
+        examples: ["Find current public information"],
+        consequence: "read_only",
+        requiresConfirmation: false,
+        nextAction: "retry",
+      },
+      flags.webSearch,
+    ],
+    [
+      {
+        id: "reminders",
+        label: "Reminders",
+        examples: ["Remind me tomorrow"],
+        consequence: "reversible_write",
+        requiresConfirmation: false,
+        nextAction: "retry",
+      },
+      flags.reminders,
+    ],
+    [
+      {
+        id: "todos",
+        label: "Todos",
+        examples: ["Add this to my list"],
+        consequence: "reversible_write",
+        requiresConfirmation: false,
+        nextAction: "retry",
+      },
+      flags.todos,
+    ],
+    [
+      {
+        id: "image-generation",
+        label: "Image generation",
+        examples: ["Create an image"],
+        consequence: "read_only",
+        requiresConfirmation: false,
+        nextAction: "retry",
+      },
+      flags.media,
+    ],
+  ];
+  const personal = PERSONAL_CAPABILITIES.map<AgentCapabilityDescriptor>((definition) => ({
+    ...definition,
+    availability: "needs_workspace",
+    currentTier: "shared",
+    requiredTier: "personal",
+    transports: ALL_TRANSPORTS,
+    prerequisites: [
+      {
+        kind: "workspace",
+        id: "personal",
+        label: "Personal workspace",
+      },
+      ...(definition.connection
+        ? [
+            {
+              kind: "connection" as const,
+              id: definition.connection,
+              label: `Connect ${definition.connection}`,
+            },
+          ]
+        : []),
+    ],
+  }));
+  return {
+    version: 1,
+    tier: "shared",
+    transport,
+    capabilities: [
+      ...ALWAYS_AVAILABLE.map((definition) => availableCapability(definition, transport)),
+      ...optional.map(([definition, available]) =>
+        optionalSharedCapability(definition, available, transport),
+      ),
+      ...personal,
+    ],
+  };
+}
+
+function humanize(value: string): string {
+  return value.replaceAll("_", " ");
+}
+
+/** Detailed model-facing projection of the same typed catalog used by gates. */
+export function formatSharedCapabilityCatalogForPrompt(catalog: AgentCapabilityCatalog): string {
+  const capabilities = catalog.capabilities.map((capability) => {
+    const prerequisites = capability.prerequisites.length
+      ? capability.prerequisites.map((item) => item.label).join(", ")
+      : "none";
+    return [
+      `- ${capability.label} (${capability.id})`,
+      `availability: ${humanize(capability.availability)}`,
+      `tier: ${capability.currentTier} -> ${capability.requiredTier}`,
+      `examples: ${capability.examples.join("; ")}`,
+      `prerequisites: ${prerequisites}`,
+      `consequence: ${humanize(capability.consequence)}`,
+      `confirmation: ${capability.requiresConfirmation ? "required before effect" : "not required"}`,
+      `next: ${humanize(capability.nextAction)}`,
+    ].join("; ");
+  });
+  return [
+    `Capability tier: ${catalog.tier}. Transport: ${catalog.transport}.`,
+    ...capabilities,
+    "Offer only the smallest next setup step needed for the user's request.",
+  ].join("\n");
+}

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  capabilityWallActionResult,
   resolveSharedCapabilityIntent,
   resolveSharedCapabilityWall,
 } from "./shared-capability-wall";
@@ -197,5 +198,59 @@ describe("Shared capability wall", () => {
       primary: expect.objectContaining({ capability: "todos" }),
       blockedSecondary: [],
     });
+  });
+
+  test("returns a bounded, review-only personal workspace handoff", () => {
+    const wall = resolveSharedCapabilityWall("email Bob the itinerary");
+    expect(wall).not.toBeNull();
+
+    const result = capabilityWallActionResult(wall!, {
+      agentId: "agent/with spaces",
+      originalIntent: "email Bob the itinerary",
+      clientMessageId: "client-123",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        actionName: "DEDICATED_CAPABILITY_REQUIRED",
+        success: false,
+        values: expect.objectContaining({
+          automatic: false,
+          capabilityHandoff: expect.objectContaining({
+            version: 1,
+            kind: "capability_handoff",
+            capabilityId: "communications",
+            requiresConfirmation: true,
+            cta: {
+              label: "Set up personal workspace",
+              href: "/cloud/agents/agent%2Fwith%20spaces",
+            },
+            continuation: {
+              originalIntent: "email Bob the itinerary",
+              clientMessageId: "client-123",
+            },
+          }),
+        }),
+      }),
+    );
+  });
+
+  test("bounds untrusted continuation fields before returning the handoff", () => {
+    const wall = resolveSharedCapabilityWall("open the browser");
+    expect(wall).not.toBeNull();
+    const handoff = capabilityWallActionResult(wall!, {
+      originalIntent: `  ${"a".repeat(4_100)}  `,
+      clientMessageId: `  ${"b".repeat(140)}  `,
+    }).values.capabilityHandoff;
+    expect(handoff.continuation?.originalIntent).toHaveLength(4_000);
+    expect(handoff.continuation?.clientMessageId).toHaveLength(128);
+  });
+
+  test("never invents continuation data when the transport did not provide it", () => {
+    const wall = resolveSharedCapabilityWall("open the browser");
+    expect(wall).not.toBeNull();
+    const handoff = capabilityWallActionResult(wall!).values.capabilityHandoff;
+    expect(handoff.continuation).toBeUndefined();
+    expect(handoff.cta.href).toBe("/cloud/agents");
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
@@ -1,4 +1,6 @@
-/** Keeps Shared honest when a request requires stateful tools or device control. */
+/** Keeps Shared honest and returns a resumable setup handoff for unavailable work. */
+
+import type { CapabilityHandoffRequest } from "@elizaos/shared";
 
 export type SharedDedicatedCapability =
   | "calendar"
@@ -236,7 +238,44 @@ export function resolveSharedCapabilityIntent(
   };
 }
 
-export function capabilityWallActionResult(wall: SharedCapabilityWall) {
+export function capabilityWallActionResult(
+  wall: SharedCapabilityWall,
+  context: {
+    agentId?: string;
+    originalIntent?: string;
+    clientMessageId?: string;
+  } = {},
+) {
+  const originalIntent = context.originalIntent?.trim().slice(0, 4_000) || undefined;
+  const clientMessageId = context.clientMessageId?.trim().slice(0, 128) || undefined;
+  const handoff: CapabilityHandoffRequest = {
+    version: 1,
+    kind: "capability_handoff",
+    capabilityId: wall.capability,
+    label: wall.label,
+    availability: "needs_workspace",
+    reason: wall.constraint,
+    currentTier: "shared",
+    requiredTier: "personal",
+    nextAction: "upgrade_workspace",
+    // This receipt offers a paid-workspace setup flow; it never authorizes
+    // setup or the original capability request automatically.
+    requiresConfirmation: true,
+    cta: {
+      label: "Set up personal workspace",
+      href: context.agentId
+        ? `/cloud/agents/${encodeURIComponent(context.agentId)}`
+        : "/cloud/agents",
+    },
+    ...(originalIntent || clientMessageId
+      ? {
+          continuation: {
+            ...(originalIntent ? { originalIntent } : {}),
+            ...(clientMessageId ? { clientMessageId } : {}),
+          },
+        }
+      : {}),
+  };
   return {
     actionName: "DEDICATED_CAPABILITY_REQUIRED" as const,
     success: false as const,
@@ -247,6 +286,7 @@ export function capabilityWallActionResult(wall: SharedCapabilityWall) {
       requiredExecutionTier: "dedicated-always" as const,
       automatic: false as const,
       source: "agent" as const,
+      capabilityHandoff: handoff,
     },
   };
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -38,6 +38,7 @@ import {
 import { createSharedRemindersEdgePlugin } from "@elizaos/plugin-scheduling/edge";
 import { createTodosEdgePlugin } from "@elizaos/plugin-todos/edge";
 import { webSearchEdgeAction, webSearchEdgePlugin } from "@elizaos/plugin-web-search/edge";
+import type { AgentCapabilityTransport } from "@elizaos/shared";
 import {
   generateText,
   type JSONSchema7,
@@ -59,6 +60,7 @@ import type {
   SharedTurnMessage,
 } from "./run-shared-agent-turn";
 import { appendSharedInput, appendSharedTurn } from "./run-shared-agent-turn";
+import { sharedCapabilityTransportForSource } from "./shared-capability-catalog";
 import {
   createSharedRuntimeCapabilitiesPlugin,
   REQUEST_DEDICATED_UPGRADE_ACTION,
@@ -232,6 +234,7 @@ function createRuntime(options: {
   adapter: InMemoryDatabaseAdapter;
   character: RunSharedAgentTurnInput["character"];
   modelPlugin: Plugin;
+  transport?: AgentCapabilityTransport;
   mediaPlugin?: Plugin;
   reminderPlugin?: Plugin;
   todoPlugin?: Plugin;
@@ -242,6 +245,7 @@ function createRuntime(options: {
     reminders: options.actionsEnabled && Boolean(options.reminderPlugin),
     todos: options.actionsEnabled && Boolean(options.todoPlugin),
     media: options.actionsEnabled && Boolean(options.mediaPlugin),
+    transport: options.transport,
   });
   return new AgentRuntime({
     agentId: options.agentId ?? stringToUuid(options.agentKey),
@@ -687,6 +691,7 @@ async function executeMeasuredSharedElizaRuntimeTurn(
     adapter,
     character: input.character,
     modelPlugin,
+    transport: sharedCapabilityTransportForSource(input.execution.channel.source),
     mediaPlugin,
     reminderPlugin,
     todoPlugin,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-capabilities.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-capabilities.test.ts
@@ -39,24 +39,39 @@ describe("Shared runtime capability components", () => {
     expect(result.data).toMatchObject({
       runtimeMode: "shared",
       available: [
-        "conversation and reasoning",
-        "conversation memory",
-        "public web search",
-        "private reminders",
+        "Conversation and planning",
+        "Writing and drafting",
+        "Public web research",
+        "Reminders",
       ],
+      agentCapabilityCatalog: expect.objectContaining({ version: 1, tier: "shared" }),
       canActivateDedicatedWithoutConfirmation: false,
     });
     expect(result.text).toContain(REQUEST_DEDICATED_UPGRADE_ACTION);
+    expect(result.text).toContain("prerequisites:");
+    expect(result.text).toContain("confirmation:");
   });
 
   test("returns a structured review handoff for an in-character continuation", async () => {
-    const action = createRequestDedicatedUpgradeAction("personal:user/1");
+    const action = createRequestDedicatedUpgradeAction({
+      agentId: "personal:user/1",
+      webSearch: true,
+      reminders: false,
+      todos: false,
+      media: false,
+      transport: "app",
+    });
     const delivered: string[] = [];
     const result = await action.handler(
       {} as never,
-      {} as never,
+      {
+        content: {
+          text: "run tests in my repository",
+          chatIdempotency: { clientMessageId: "client-1" },
+        },
+      } as never,
       undefined,
-      { parameters: { capability: "coding" } },
+      { parameters: { capabilityId: "coding-runtime" } },
       async (content) => {
         delivered.push(content.text ?? "");
         return [];
@@ -68,6 +83,13 @@ describe("Shared runtime capability components", () => {
       upgradePath: "/cloud/agents/personal%3Auser%2F1",
       mutationPerformed: false,
       requiresUserConfirmation: true,
+      capabilityHandoff: expect.objectContaining({
+        capabilityId: "coding-runtime",
+        continuation: {
+          originalIntent: "run tests in my repository",
+          clientMessageId: "client-1",
+        },
+      }),
     });
     expect(result.text).toContain("no mutation or charge was performed");
     expect(delivered).toEqual([]);

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-capabilities.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-capabilities.ts
@@ -14,6 +14,17 @@ import type {
   ProviderResult,
   State,
 } from "@elizaos/core/edge";
+import {
+  type AgentCapabilityDescriptor,
+  type AgentCapabilityId,
+  type AgentCapabilityTransport,
+  type CapabilityHandoffRequest,
+  findAgentCapability,
+} from "@elizaos/shared";
+import {
+  buildSharedCapabilityCatalog,
+  formatSharedCapabilityCatalogForPrompt,
+} from "./shared-capability-catalog";
 
 export const SHARED_RUNTIME_CAPABILITIES_PROVIDER = "SHARED_RUNTIME_CAPABILITIES";
 export const REQUEST_DEDICATED_UPGRADE_ACTION = "REQUEST_DEDICATED_UPGRADE";
@@ -70,26 +81,8 @@ export interface SharedRuntimeCapabilityOptions {
   reminders: boolean;
   todos: boolean;
   media: boolean;
+  transport?: AgentCapabilityTransport;
 }
-
-function availableCapabilities(options: SharedRuntimeCapabilityOptions): string[] {
-  return [
-    "conversation and reasoning",
-    "conversation memory",
-    ...(options.webSearch ? ["public web search"] : []),
-    ...(options.reminders ? ["private reminders"] : []),
-    ...(options.todos ? ["persistent todos"] : []),
-    ...(options.media ? ["image generation"] : []),
-  ];
-}
-
-const DEDICATED_CAPABILITIES = [
-  "coding and sub-agents",
-  "shell and filesystem",
-  "browser or computer control",
-  "connected private accounts",
-  "arbitrary outbound communications",
-] as const;
 
 export function createSharedRuntimeCapabilitiesProvider(
   options: SharedRuntimeCapabilityOptions,
@@ -102,26 +95,83 @@ export function createSharedRuntimeCapabilitiesProvider(
     cacheScope: "turn",
     roleGate: { minRole: "GUEST" },
     get: async (): Promise<ProviderResult> => {
-      const available = availableCapabilities(options);
+      const catalog = buildSharedCapabilityCatalog(options);
+      const available = catalog.capabilities
+        .filter((capability) => capability.availability === "available")
+        .map((capability) => capability.label);
+      const dedicatedRequired = catalog.capabilities
+        .filter((capability) => capability.requiredTier === "personal")
+        .map((capability) => capability.label);
       return {
         text: [
           "# Runtime capabilities",
           "",
-          "This agent is running on Shared, stateless edge compute.",
-          `Available now: ${available.join(", ")}.`,
-          `Dedicated required: ${DEDICATED_CAPABILITIES.join(", ")}.`,
+          formatSharedCapabilityCatalogForPrompt(catalog),
           `Use ${REQUEST_DEDICATED_UPGRADE_ACTION} only when the user asks to review upgrading for a capability Shared cannot perform. It opens a review flow and never starts paid compute by itself.`,
         ].join("\n"),
+        values: {
+          capabilityTier: catalog.tier,
+          capabilityTransport: catalog.transport,
+        },
         data: {
           runtimeMode: "shared",
           agentId: options.agentId,
           available,
-          dedicatedRequired: [...DEDICATED_CAPABILITIES],
+          dedicatedRequired,
+          agentCapabilityCatalog: catalog,
           canRequestDedicatedReview: true,
           canActivateDedicatedWithoutConfirmation: false,
         },
       };
     },
+  };
+}
+
+function boundedString(value: unknown, maximum: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  return normalized ? normalized.slice(0, maximum) : undefined;
+}
+
+function handoffFor(
+  options: SharedRuntimeCapabilityOptions,
+  capability: AgentCapabilityDescriptor,
+  message: Memory,
+): CapabilityHandoffRequest {
+  if (capability.availability === "available") {
+    throw new Error(`Capability ${capability.id} does not need setup`);
+  }
+  const originalIntent = boundedString(message.content?.text, 4_000);
+  const idempotency = message.content?.chatIdempotency;
+  const clientMessageId =
+    idempotency && typeof idempotency === "object" && "clientMessageId" in idempotency
+      ? boundedString(idempotency.clientMessageId, 128)
+      : undefined;
+  return {
+    version: 1,
+    kind: "capability_handoff",
+    capabilityId: capability.id,
+    label: capability.label,
+    availability: capability.availability,
+    reason: `${capability.label} needs setup before it can be used safely.`,
+    currentTier: capability.currentTier,
+    requiredTier: capability.requiredTier,
+    nextAction: capability.nextAction === "none" ? "retry" : capability.nextAction,
+    // A workspace upgrade is itself consequential even when the requested
+    // capability (for example research) would not require confirmation.
+    requiresConfirmation: true,
+    cta: {
+      label: "Set up personal workspace",
+      href: `/cloud/agents/${encodeURIComponent(options.agentId)}`,
+    },
+    ...(originalIntent || clientMessageId
+      ? {
+          continuation: {
+            ...(originalIntent ? { originalIntent } : {}),
+            ...(clientMessageId ? { clientMessageId } : {}),
+          },
+        }
+      : {}),
   };
 }
 
@@ -133,7 +183,13 @@ function readParameters(options: unknown): Record<string, unknown> {
     : record;
 }
 
-export function createRequestDedicatedUpgradeAction(agentId: string): Action {
+export function createRequestDedicatedUpgradeAction(
+  options: SharedRuntimeCapabilityOptions,
+): Action {
+  const catalog = buildSharedCapabilityCatalog(options);
+  const dedicatedIds = catalog.capabilities
+    .filter((capability) => capability.requiredTier === "personal")
+    .map((capability) => capability.id);
   return {
     name: REQUEST_DEDICATED_UPGRADE_ACTION,
     similes: ["UPGRADE_AGENT", "ENABLE_ADVANCED_CAPABILITIES", "GET_DEDICATED"],
@@ -145,39 +201,48 @@ export function createRequestDedicatedUpgradeAction(agentId: string): Action {
       "Return the explicit review link for moving this Shared agent to Dedicated when the user asks for coding, shell, browser control, connected accounts, or another unavailable advanced capability. After this action, explain the result naturally in the agent's voice. This action does not purchase, provision, or activate anything.",
     parameters: [
       {
-        name: "capability",
-        description: "The unavailable capability that motivated the user's upgrade request.",
-        required: false,
-        schema: { type: "string", maxLength: 160 },
+        name: "capabilityId",
+        description: "The unavailable capability id from the runtime capability provider.",
+        required: true,
+        schema: { type: "string", enum: dedicatedIds },
       },
     ],
     validate: async () => true,
     handler: async (
       _runtime: IAgentRuntime,
-      _message: Memory,
+      message: Memory,
       _state?: State,
       handlerOptions?: unknown,
       _callback?: HandlerCallback,
     ): Promise<ActionResult> => {
       const parameters = readParameters(handlerOptions);
-      const capability =
-        typeof parameters.capability === "string" && parameters.capability.trim()
-          ? parameters.capability.trim().slice(0, 160)
-          : "advanced capabilities";
-      const upgradePath = `/cloud/agents/${encodeURIComponent(agentId)}`;
+      const capabilityId = boundedString(parameters.capabilityId, 64) as
+        | AgentCapabilityId
+        | undefined;
+      const capability = capabilityId ? findAgentCapability(catalog, capabilityId) : undefined;
+      if (!capability || capability.availability === "available") {
+        return {
+          success: false,
+          text: "The requested capability does not need a personal-workspace handoff.",
+          error: new Error("Unknown or already available capability"),
+        };
+      }
+      const capabilityHandoff = handoffFor(options, capability, message);
       // This is a structured tool receipt, not end-user copy. The normal
       // post-action model continuation turns it into an in-character response.
-      const text = `Dedicated review available for ${capability} at ${upgradePath}; no mutation or charge was performed and explicit user confirmation is required.`;
+      const text = `Personal-workspace review is available for ${capability.label}; no mutation or charge was performed.`;
       return {
         success: true,
         text,
         data: {
           actionName: REQUEST_DEDICATED_UPGRADE_ACTION,
-          capability,
-          upgradePath,
+          capabilityId: capability.id,
+          capabilityHandoff,
+          upgradePath: capabilityHandoff.cta.href,
           mutationPerformed: false,
           requiresUserConfirmation: true,
         },
+        values: { capabilityHandoff },
       };
     },
   };
@@ -190,6 +255,6 @@ export function createSharedRuntimeCapabilitiesPlugin(
     name: "shared-runtime-capabilities",
     description: "Shared runtime capability context and safe Dedicated review handoff.",
     providers: [createSharedRuntimeCapabilitiesProvider(options)],
-    actions: [createRequestDedicatedUpgradeAction(options.agentId)],
+    actions: [createRequestDedicatedUpgradeAction(options)],
   };
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -839,6 +839,9 @@ describe("SharedRuntimeChatService", () => {
     expect(body).toContain(JSON.stringify(expectedTodoActionResult));
     expect(body).toContain('"actionName":"DEDICATED_CAPABILITY_REQUIRED"');
     expect(body).toContain('"capability":"communications"');
+    expect(body).toContain('"kind":"capability_handoff"');
+    expect(body).toContain('"originalIntent":"hello"');
+    expect(body).toContain(`/cloud/agents/${encodeURIComponent(agent.id)}`);
     expect(memoryPairs).toEqual([
       expect.objectContaining({
         assistantReply: "Created: [ ] Buy milk\n\nI can't initiate a separate email.",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -216,11 +216,14 @@ function turnActionResults(
     RunSharedAgentTurnResult,
     "actionResults" | "capabilityWall" | "blockedSecondaryCapabilities"
   >,
+  context: { agentId: string; originalIntent: string; clientMessageId?: string },
 ): unknown[] | undefined {
   const results: unknown[] = [...(turn.actionResults ?? [])];
-  if (turn.capabilityWall) results.push(capabilityWallActionResult(turn.capabilityWall));
+  if (turn.capabilityWall) {
+    results.push(capabilityWallActionResult(turn.capabilityWall, context));
+  }
   for (const wall of turn.blockedSecondaryCapabilities ?? []) {
-    results.push(capabilityWallActionResult(wall));
+    results.push(capabilityWallActionResult(wall, context));
   }
   return results.length ? results : undefined;
 }
@@ -1388,7 +1391,11 @@ export class SharedRuntimeChatService {
     let turnIsProvablyFree = false;
     try {
       turnIsProvablyFree = turn.degraded || isProviderFreeTurn(turn);
-      const actionResults = turnActionResults(turn);
+      const actionResults = turnActionResults(turn, {
+        agentId: agent.id,
+        originalIntent: text,
+        ...(claimKey ? { clientMessageId: claimKey } : {}),
+      });
       const result: SharedTurnTerminalResult = {
         text: turn.reply,
         ...(turn.responded === false ? { responded: false } : {}),
@@ -1808,10 +1815,17 @@ export class SharedRuntimeChatService {
               );
               continue;
             }
-            const actionResults = turnActionResults({
-              ...turn,
-              ...(part.actionResults?.length ? { actionResults: part.actionResults } : {}),
-            });
+            const actionResults = turnActionResults(
+              {
+                ...turn,
+                ...(part.actionResults?.length ? { actionResults: part.actionResults } : {}),
+              },
+              {
+                agentId: agent.id,
+                originalIntent: text,
+                ...(claimKey ? { clientMessageId: claimKey } : {}),
+              },
+            );
             await finalizeMessages(finalReply, false, async () => {
               // Durable claim completion before the done frame: a lost/dropped
               // terminal frame replays this result on retry instead of

--- a/packages/shared/src/capability-catalog.test.ts
+++ b/packages/shared/src/capability-catalog.test.ts
@@ -1,0 +1,60 @@
+/** Unit tests for the runtime-neutral capability catalog projection. */
+
+import { describe, expect, it } from "vitest";
+import {
+  type AgentCapabilityCatalog,
+  findAgentCapability,
+  formatAgentCapabilityCatalog,
+} from "./capability-catalog.js";
+
+const catalog: AgentCapabilityCatalog = {
+  version: 1,
+  tier: "shared",
+  transport: "web",
+  capabilities: [
+    {
+      id: "web-search",
+      label: "Public web research",
+      examples: ["Find current information"],
+      availability: "available",
+      currentTier: "shared",
+      requiredTier: "shared",
+      transports: ["web"],
+      prerequisites: [],
+      consequence: "read_only",
+      requiresConfirmation: false,
+      nextAction: "none",
+    },
+    {
+      id: "calendar",
+      label: "Calendar",
+      examples: ["Check tomorrow"],
+      availability: "needs_workspace",
+      currentTier: "shared",
+      requiredTier: "personal",
+      transports: ["web"],
+      prerequisites: [
+        { kind: "workspace", id: "personal", label: "Personal workspace" },
+      ],
+      consequence: "consequential",
+      requiresConfirmation: true,
+      nextAction: "upgrade_workspace",
+    },
+  ],
+};
+
+describe("capability catalog", () => {
+  it("finds structured capability state", () => {
+    expect(findAgentCapability(catalog, "calendar")).toMatchObject({
+      availability: "needs_workspace",
+      requiredTier: "personal",
+    });
+  });
+
+  it("projects only concise availability context", () => {
+    const text = formatAgentCapabilityCatalog(catalog);
+    expect(text).toContain("Available now: Public web research.");
+    expect(text).toContain("Calendar (needs workspace)");
+    expect(text).not.toContain("Check tomorrow");
+  });
+});

--- a/packages/shared/src/capability-catalog.ts
+++ b/packages/shared/src/capability-catalog.ts
@@ -1,0 +1,134 @@
+/**
+ * Cross-runtime capability contracts keep agent prompts, safety gates, and UI
+ * handoffs aligned without importing a server or renderer implementation.
+ */
+
+export type AgentExecutionTier = "shared" | "personal";
+
+export type AgentCapabilityAvailability =
+  | "available"
+  | "needs_account"
+  | "needs_workspace"
+  | "needs_connection"
+  | "needs_permission"
+  | "provisioning"
+  | "unavailable";
+
+export type AgentCapabilityConsequence =
+  | "read_only"
+  | "reversible_write"
+  | "consequential";
+
+export type AgentCapabilityNextAction =
+  | "none"
+  | "sign_up"
+  | "upgrade_workspace"
+  | "connect_account"
+  | "request_permission"
+  | "wait_for_provisioning"
+  | "retry";
+
+export type AgentCapabilityId =
+  | "conversation"
+  | "drafting"
+  | "web-search"
+  | "reminders"
+  | "todos"
+  | "image-generation"
+  | "calendar"
+  | "bookings"
+  | "communications"
+  | "purchases"
+  | "notes"
+  | "cloud-apps"
+  | "coding-runtime"
+  | "shell"
+  | "filesystem"
+  | "browser-control"
+  | "profile-memory";
+
+export type AgentCapabilityTransport =
+  | "app"
+  | "web"
+  | "sms"
+  | "voice"
+  | "discord"
+  | "telegram"
+  | "api";
+
+export interface AgentCapabilityPrerequisite {
+  kind: "account" | "workspace" | "connection" | "permission";
+  id: string;
+  label: string;
+}
+
+export interface AgentCapabilityDescriptor {
+  id: AgentCapabilityId;
+  label: string;
+  examples: readonly string[];
+  availability: AgentCapabilityAvailability;
+  currentTier: AgentExecutionTier;
+  requiredTier: AgentExecutionTier;
+  transports: readonly AgentCapabilityTransport[];
+  prerequisites: readonly AgentCapabilityPrerequisite[];
+  consequence: AgentCapabilityConsequence;
+  requiresConfirmation: boolean;
+  nextAction: AgentCapabilityNextAction;
+}
+
+export interface AgentCapabilityCatalog {
+  version: 1;
+  tier: AgentExecutionTier;
+  transport: AgentCapabilityTransport;
+  capabilities: readonly AgentCapabilityDescriptor[];
+}
+
+export interface CapabilityHandoffRequest {
+  version: 1;
+  kind: "capability_handoff";
+  capabilityId: AgentCapabilityId;
+  label: string;
+  availability: Exclude<AgentCapabilityAvailability, "available">;
+  reason: string;
+  currentTier: AgentExecutionTier;
+  requiredTier: AgentExecutionTier;
+  nextAction: Exclude<AgentCapabilityNextAction, "none">;
+  requiresConfirmation: boolean;
+  cta: {
+    label: string;
+    href: string;
+  };
+  continuation?: {
+    clientMessageId?: string;
+    originalIntent?: string;
+  };
+}
+
+/** Find one capability without making callers duplicate catalog traversal. */
+export function findAgentCapability(
+  catalog: AgentCapabilityCatalog,
+  id: AgentCapabilityId,
+): AgentCapabilityDescriptor | undefined {
+  return catalog.capabilities.find((capability) => capability.id === id);
+}
+
+/** Compact prompt projection; the structured catalog remains authoritative. */
+export function formatAgentCapabilityCatalog(
+  catalog: AgentCapabilityCatalog,
+): string {
+  const available = catalog.capabilities
+    .filter((capability) => capability.availability === "available")
+    .map((capability) => capability.label);
+  const gated = catalog.capabilities
+    .filter((capability) => capability.availability !== "available")
+    .map(
+      (capability) =>
+        `${capability.label} (${capability.availability.replaceAll("_", " ")})`,
+    );
+  return [
+    `Capability tier: ${catalog.tier}. Transport: ${catalog.transport}.`,
+    `Available now: ${available.join(", ") || "none"}.`,
+    `Needs setup: ${gated.join(", ") || "none"}.`,
+    "Offer the smallest valid setup step only when it unlocks the user's request.",
+  ].join("\n");
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,6 +23,7 @@ export * from "./apps/index.js";
 export * from "./automation-node-contributors.js";
 // Awareness + themes barrels
 export * from "./awareness/index.js";
+export * from "./capability-catalog.js";
 export * from "./character-presets.characters.js";
 export * from "./character-presets.js";
 // Chat-upload limits — the single source of truth for the attachment caps and


### PR DESCRIPTION
# Relates to

#22309

This is the first narrow replacement for closed monolith #22350. It adds the Shared/server contract only; it intentionally does not add UI auto-resume, provisioning, OAuth, or billing behavior.

## What changed

- Adds one typed capability catalog shared by prompts, gates, action receipts, and future clients.
- Projects per-turn availability, tier, transport, examples, prerequisites, consequence, confirmation, and smallest next action.
- Adds a structured, bounded CapabilityHandoffRequest for capabilities that need a personal workspace.
- Preserves exact original intent and client message identity when the trusted transport supplies them.
- Keeps handoffs review-only: no purchase, provisioning, connection, charge, or original action executes automatically.
- Preserves the existing useful-substitute model path and truthful effect-receipt boundary.

## Safety invariants

- Workspace setup always requires explicit user confirmation.
- Continuation fields are trimmed and bounded to 4,000/128 characters.
- Agent IDs are URL-encoded; transport comes only from the server-owned channel source.
- Unknown/already-available capability IDs fail without a handoff.
- Existing action effects still require successful registered-action receipts.

## Exact-head validation

Head: 6cccd9ebeecf8c726d8a544cca90e33faa486837 (rebased onto current develop before publication)

- 125 focused tests passed, 0 failed, 354 assertions.
- packages/shared typecheck passed.
- packages/cloud/shared typecheck passed.
- Biome on all 14 changed files passed.
- git diff --check passed.
- bun run verify was executed and stopped at the pre-existing check:i18n gate. A detached clean origin/develop@8737a653e34f reproduces the same missing-English-key/orphan-translation failure; this patch changes no locale or UI files.

## Evidence

- UI screenshots/video/OCR: N/A — no renderer is changed in this slice.
- Live OAuth/workspace/provider evidence: N/A — this slice performs no OAuth, provisioning, billing, or provider call.
- Live-model trajectory: still required before ready-for-review because this changes model-facing capability context.
- The dependent UI continuation and authoritative lifecycle outbox remain separate follow-up PRs.

Keep draft until independent review and live-model behavior evidence are attached.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: OpenAI / gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [onboarding-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->
