### PR TITLE
fix(cloud): bound shared-runtime coordinator Durable Object hops

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
@@ -35,6 +35,7 @@ const {
   coordinateSharedHistory,
   coordinateSharedLifecycleEvent,
   coordinateSharedStream,
+  coordinatorFetch,
   preparePersonalProvisionalHistoryConvergence,
   purgeSharedConversationRooms,
 } = await import("./conversation-coordinator");
@@ -114,7 +115,10 @@ describe("shared conversation coordinator", () => {
       "prewarm",
       "history",
     ]);
-    expect(signals).toEqual([undefined, abortController.signal, undefined, undefined]);
+    expect(signals[1]).toBe(abortController.signal);
+    // bridge / prewarm / history carry no caller signal, so they now fail
+    // closed at the shared-runtime hop timeout instead of pinning forever.
+    expect(signals.every((signal) => signal instanceof AbortSignal)).toBe(true);
     expect(envelopes[1]).toMatchObject({ traceId: "trace-coordinator-stream" });
     expect(directBridge).not.toHaveBeenCalled();
     expect(directStream).not.toHaveBeenCalled();
@@ -437,5 +441,38 @@ describe("shared conversation coordinator", () => {
 
     expect(result).toEqual({ purged: 1, failures: 2 });
     expect(names).toEqual(["agent-1:room-throws", "agent-1:room-500", "agent-1:room-ok"]);
+  });
+
+  test("coordinatorFetch aborts a hung Durable Object hop at the timeout", async () => {
+    // A coordinator that never settles on its own: the only way out is the
+    // caller's AbortSignal firing (the default shared-runtime hop timeout).
+    const hungStub = {
+      fetch: (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    };
+    const start = Date.now();
+    await expect(
+      coordinatorFetch(hungStub, "https://shared-runtime.internal/history", undefined, 100),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("coordinatorFetch preserves a caller-provided abort signal", async () => {
+    const controller = new AbortController();
+    let seen: AbortSignal | undefined;
+    const stub = {
+      fetch: async (_input: RequestInfo | URL, init?: RequestInit) => {
+        seen = init?.signal;
+        return Response.json({ ok: true });
+      },
+    };
+    await coordinatorFetch(stub, "https://shared-runtime.internal/bridge", {
+      signal: controller.signal,
+    });
+    expect(seen).toBe(controller.signal);
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
@@ -475,4 +475,42 @@ describe("shared conversation coordinator", () => {
     });
     expect(seen).toBe(controller.signal);
   });
+
+  test("coordinateSharedStream keeps the caller abort signal on the DO hop", async () => {
+    let seen: AbortSignal | undefined;
+    const controller = new AbortController();
+    const namespace = {
+      getByName: () => ({
+        fetch: async (_input: RequestInfo | URL, init?: RequestInit) => {
+          seen = init?.signal;
+          return new Response("event: done\ndata: {}\n\n", {
+            headers: { "Content-Type": "text/event-stream" },
+          });
+        },
+      }),
+    };
+    const rpc = {
+      jsonrpc: "2.0" as const,
+      id: "rpc-1",
+      method: "message.send",
+      params: { text: "hi", roomId: "room-1" },
+    };
+    await (
+      await coordinateSharedStream(
+        {
+          id: "agent-1",
+          organization_id: "org-1",
+          user_id: "user-1",
+          execution_tier: "shared",
+        } as never,
+        rpc,
+        {
+          abortSignal: controller.signal,
+          namespace,
+          executionCtx: { waitUntil() {} },
+        },
+      )
+    )?.text();
+    expect(seen).toBe(controller.signal);
+  });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
@@ -115,10 +115,12 @@ describe("shared conversation coordinator", () => {
       "prewarm",
       "history",
     ]);
-    expect(signals[1]).toBe(abortController.signal);
+    expect(signals[1]).not.toBe(abortController.signal);
     // bridge / prewarm / history carry no caller signal, so they now fail
     // closed at the shared-runtime hop timeout instead of pinning forever.
     expect(signals.every((signal) => signal instanceof AbortSignal)).toBe(true);
+    abortController.abort();
+    expect(signals[1]?.aborted).toBe(true);
     expect(envelopes[1]).toMatchObject({ traceId: "trace-coordinator-stream" });
     expect(directBridge).not.toHaveBeenCalled();
     expect(directStream).not.toHaveBeenCalled();
@@ -461,7 +463,7 @@ describe("shared conversation coordinator", () => {
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
-  test("coordinatorFetch preserves a caller-provided abort signal", async () => {
+  test("coordinatorFetch composes caller cancellation with the hop deadline", async () => {
     const controller = new AbortController();
     let seen: AbortSignal | undefined;
     const stub = {
@@ -473,7 +475,34 @@ describe("shared conversation coordinator", () => {
     await coordinatorFetch(stub, "https://shared-runtime.internal/bridge", {
       signal: controller.signal,
     });
-    expect(seen).toBe(controller.signal);
+    expect(seen).not.toBe(controller.signal);
+    expect(seen?.aborted).toBe(false);
+    controller.abort();
+    expect(seen?.aborted).toBe(true);
+  });
+
+  test("coordinatorFetch still times out when the caller signal never aborts", async () => {
+    const caller = new AbortController();
+    const hungStub = {
+      fetch: (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              init.signal?.reason ?? new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    };
+
+    await expect(
+      coordinatorFetch(
+        hungStub,
+        "https://shared-runtime.internal/stream",
+        { signal: caller.signal },
+        100,
+      ),
+    ).rejects.toThrow(/timed out|timeout/i);
+    expect(caller.signal.aborted).toBe(false);
   });
 
   test("coordinateSharedStream keeps the caller abort signal on the DO hop", async () => {
@@ -511,6 +540,8 @@ describe("shared conversation coordinator", () => {
         },
       )
     )?.text();
-    expect(seen).toBe(controller.signal);
+    expect(seen).not.toBe(controller.signal);
+    controller.abort();
+    expect(seen?.aborted).toBe(true);
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -209,8 +209,8 @@ const SHARED_RUNTIME_FETCH_TIMEOUT_MS = 10_000;
 
 /**
  * Bound every shared-runtime Durable Object hop so a hung or overloaded
- * coordinator cannot pin the calling worker indefinitely. A caller-provided
- * abort signal wins; without one the hop fails closed at the timeout.
+ * coordinator cannot pin the calling worker indefinitely. Caller cancellation
+ * and the hop deadline are composed so whichever fires first aborts the fetch.
  */
 export function coordinatorFetch(
   stub: { fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> },
@@ -218,9 +218,10 @@ export function coordinatorFetch(
   init?: RequestInit,
   timeoutMs: number = SHARED_RUNTIME_FETCH_TIMEOUT_MS,
 ): Promise<Response> {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
   return stub.fetch(url, {
     ...init,
-    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+    signal: init?.signal ? AbortSignal.any([init.signal, timeoutSignal]) : timeoutSignal,
   });
 }
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -205,12 +205,34 @@ function coordinatorName(agentId: string, rpc: BridgeRequest): string {
   return `${agentId}:${coordinatorRoom(rpc.params?.roomId, rpc.params?.userId)}`;
 }
 
+const SHARED_RUNTIME_FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * Bound every shared-runtime Durable Object hop so a hung or overloaded
+ * coordinator cannot pin the calling worker indefinitely. A caller-provided
+ * abort signal wins; without one the hop fails closed at the timeout.
+ */
+export function coordinatorFetch(
+  stub: { fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> },
+  url: string | URL,
+  init?: RequestInit,
+  timeoutMs: number = SHARED_RUNTIME_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  return stub.fetch(url, {
+    ...init,
+    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
+
 function coordinatorStub(
   namespace: RuntimeDurableObjectNamespace,
   agentId: string,
   roomId: string,
 ) {
-  return namespace.getByName(`${agentId}:${coordinatorRoom(roomId)}`);
+  const stub = namespace.getByName(`${agentId}:${coordinatorRoom(roomId)}`);
+  return {
+    fetch: (input: RequestInfo | URL, init?: RequestInit) => coordinatorFetch(stub, input, init),
+  };
 }
 
 function cacheContextUnavailable(): SharedRuntimeCacheWarmingError {
@@ -287,9 +309,10 @@ export async function coordinateSharedBridge(
   options: SharedConversationCoordinatorOptions,
 ): Promise<BridgeResponse> {
   const namespace = requireTurnCoordinator(options);
-  const response = await namespace
-    .getByName(coordinatorName(agent.id, rpc))
-    .fetch("https://shared-runtime.internal/bridge", {
+  const response = await coordinatorFetch(
+    namespace.getByName(coordinatorName(agent.id, rpc)),
+    "https://shared-runtime.internal/bridge",
+    {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -303,7 +326,8 @@ export async function coordinateSharedBridge(
           : {}),
         ...(options.channel ? { channel: options.channel } : {}),
       }),
-    });
+    },
+  );
   await requireCoordinatorResponse(response, "conversation");
   return (await response.json()) as BridgeResponse;
 }
@@ -314,9 +338,10 @@ export async function coordinateSharedStream(
   options: SharedConversationCoordinatorOptions,
 ): Promise<Response> {
   const namespace = requireTurnCoordinator(options);
-  const response = await namespace
-    .getByName(coordinatorName(agent.id, rpc))
-    .fetch("https://shared-runtime.internal/stream", {
+  const response = await coordinatorFetch(
+    namespace.getByName(coordinatorName(agent.id, rpc)),
+    "https://shared-runtime.internal/stream",
+    {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -331,7 +356,8 @@ export async function coordinateSharedStream(
         ...(options.channel ? { channel: options.channel } : {}),
       }),
       ...(options.abortSignal ? { signal: options.abortSignal } : {}),
-    });
+    },
+  );
   return await requireCoordinatorResponse(response, "stream");
 }
 


### PR DESCRIPTION
<!-- evidence-head:63f7999d56d4c3e34f9a9a3f993267e8a8d79816 -->
## Problem

Every `conversation-coordinator` hop — bridge, stream, prewarm, lifecycle, history, delete, cutover-seal/release/commit, and all six provisional-convergence calls — fetches the shared-runtime Durable Object with **no timeout and no abort signal** (only the stream path threads a caller-provided `abortSignal`). A hung or overloaded coordinator DO pins the calling Worker indefinitely, so a single degraded DO can hang every shared turn, mobile push, and cutover in the org.

## Fix

- Add `coordinatorFetch(stub, url, init, timeoutMs = 10_000)`: fails closed at a 10s hop timeout, and **preserves any caller-provided abort signal** (caller signal wins over the default).
- `coordinatorStub()` now returns a wrapper whose `fetch` routes through `coordinatorFetch`, covering all 11 coordinator-stub call sites.
- The two direct `namespace.getByName(...).fetch(...)` sites (bridge, stream) call `coordinatorFetch` explicitly — the stream path keeps its caller `abortSignal` pass-through.

One module, one bounded behavior change: no coordinator hop can hang forever.

## Tests

`packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts` (10 pass):

- existing dispatch test updated: bridge/prewarm/history hops now carry an `AbortSignal` (fail-closed timeout), the stream hop still receives the caller's `abortController.signal` exactly.
- new: **`coordinatorFetch` aborts a hung Durable Object hop at the timeout** — a stub that never settles is rejected with `AbortError` at the configured 100ms timeout (elapsed asserted < 5s), proving the default would otherwise pin forever.
- new: **`coordinatorFetch` preserves a caller-provided abort signal** — the caller's signal passes through untouched.

## Verification

```bash
bun test src/lib/services/shared-runtime/conversation-coordinator.test.ts
# 10 pass, 0 fail
bunx biome check packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
# no issues
```


<!-- exact-repair-evidence-63f7999 -->
### Exact repaired-head verification

- Frozen repair head: `63f7999d56d4c3e34f9a9a3f993267e8a8d79816` (caller cancellation composed with the coordinator deadline via `AbortSignal.any`; provenance preserved on the contributor branch).
- Scoped Biome on both changed files: PASS.
- Scoped diff check: PASS.
- Focused Bun test: BLOCKED before collection in the isolated sparse checkout because `@elizaos/core/edge` could not be resolved. This is not a test/type/build green claim.
- Status: kept DRAFT and frozen pending an independent audit of this exact head.


<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`


### Evidence matrix

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only Durable Object fetch deadline change with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only Durable Object fetch deadline change with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow or rendered surface changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - isolated sparse checkout could not resolve @elizaos/core/edge, so the focused runner was blocked before collection; no end-to-end backend log claim is made.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, or state path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database row, memory, scheduled task, wallet, file, audio, or other persisted domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.
