### PR TITLE
fix(telegram): keep surrogate pairs intact in command description clamp

### DIFF
--- a/plugins/plugin-telegram/src/command-registration.test.ts
+++ b/plugins/plugin-telegram/src/command-registration.test.ts
@@ -160,6 +160,53 @@ describe("buildTelegramCommandDescriptors", () => {
     expect(commands.some((c) => c.target.kind === "agent")).toBe(true);
     expect(commands.some((c) => c.target.kind === "navigate")).toBe(true);
   });
+
+  it("keeps UTF-16 surrogate pairs intact when clamping description to 256", () => {
+    const emojiDesc = `${"a".repeat(255)}🦊${"b".repeat(100)}`;
+    pluginCommandsMock.getConnectorCommands.mockReturnValueOnce([
+      {
+        name: "emoji_desc",
+        description: emojiDesc,
+        target: { kind: "agent" },
+      },
+    ]);
+    const [descriptor] = buildTelegramCommandDescriptors();
+    expect(descriptor).toBeDefined();
+    expect(descriptor.description.isWellFormed()).toBe(true);
+    expect(descriptor.description.length).toBeLessThanOrEqual(256);
+    expect(descriptor.description.length).toBe(255);
+    expect(descriptor.description).toBe("a".repeat(255));
+  });
+
+  it("sanitizes lone surrogates in description before clamping", () => {
+    const loneDesc = "a\ud800bc";
+    pluginCommandsMock.getConnectorCommands.mockReturnValueOnce([
+      {
+        name: "lone_desc",
+        description: loneDesc,
+        target: { kind: "agent" },
+      },
+    ]);
+    const [descriptor] = buildTelegramCommandDescriptors();
+    expect(descriptor).toBeDefined();
+    expect(descriptor.description).toBe("a\ufffdbc");
+    expect(descriptor.description.isWellFormed()).toBe(true);
+  });
+
+  it("preserves an emoji that fits entirely under the 256 cap", () => {
+    const fittingDesc = `${"a".repeat(254)}🦊`;
+    pluginCommandsMock.getConnectorCommands.mockReturnValueOnce([
+      {
+        name: "fitting_desc",
+        description: fittingDesc,
+        target: { kind: "agent" },
+      },
+    ]);
+    const [descriptor] = buildTelegramCommandDescriptors();
+    expect(descriptor.description).toBe(fittingDesc);
+    expect(descriptor.description.isWellFormed()).toBe(true);
+    expect(descriptor.description.length).toBe(256);
+  });
 });
 
 describe("registerTelegramCommandHandlers", () => {

--- a/plugins/plugin-telegram/src/command-registration.ts
+++ b/plugins/plugin-telegram/src/command-registration.ts
@@ -43,6 +43,8 @@ import {
   type IAgentRuntime,
   logger,
   type Memory,
+  toWellFormedUnicode,
+  truncateWellFormed,
   type UUID,
 } from "@elizaos/core";
 import {
@@ -109,8 +111,11 @@ function sanitizeCommandName(name: string): string | null {
 
 /** Clamp a description to Telegram's limit; a description is always required. */
 function clampDescription(description: string): string {
-  const trimmed = description.trim();
-  return trimmed.slice(0, TELEGRAM_COMMAND_DESCRIPTION_MAX);
+  const wellFormed = toWellFormedUnicode(description.trim());
+  if (wellFormed.length <= TELEGRAM_COMMAND_DESCRIPTION_MAX) {
+    return wellFormed;
+  }
+  return truncateWellFormed(wellFormed, TELEGRAM_COMMAND_DESCRIPTION_MAX);
 }
 
 /**


### PR DESCRIPTION
Fixes #23436

## Summary

- Fix `plugins/plugin-telegram/src/command-registration.ts:111` `clampDescription` to use `toWellFormedUnicode` + `truncateWellFormed` so clamping to `TELEGRAM_COMMAND_DESCRIPTION_MAX=256` never splits an astral surrogate pair (e.g. 🦊 `\uD83E\uDD8A`) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and Telegram Bot API's `setMyCommands` strict JSON rejects. Preserves `trim()` + `length<=256` + `isWellFormed()` and adds deterministic coverage.
- Add 3 `isWellFormed()` tests in `plugins/plugin-telegram/src/command-registration.test.ts`: emoji at 255/256 boundary (255 'a' + 🦊 → 255 'a' after backoff, not lone surrogate), lone `\ud800`→`\ufffd`, and fitting 254 'a' + 🦊 → 256 exact.

Same class as approved #23241 (slack `formatting.ts:550`), #23227 (telegram `handler.ts:99` `splitTelegramText`), #23277 (agent `grounded-action-reply.ts:40`), #23284 (shared `transcripts.ts:380`) — identical `toWellFormedUnicode` → `truncateWellFormed` pattern; command descriptions are sent via `bot.telegram.setMyCommands` JSON body.

## Changes

| File | Change |
|------|--------|
| `plugins/plugin-telegram/src/command-registration.ts` | Import `toWellFormedUnicode`/`truncateWellFormed`, rewrite `clampDescription` to sanitize + well-formed truncate |
| `plugins/plugin-telegram/src/command-registration.test.ts` | +47 lines — 3 tests: surrogate boundary (255), lone surrogate sanitization, fitting emoji at 256 |

## Verification

- Rebased onto `origin/develop@9f3887c0f7` (fix/homepage #23265) — zero conflicts
- `bunx biome check` — 2 files clean (9ms, no fixes)
- `bun --cwd plugins/plugin-telegram test` — **222 passed, 0 failed** (23 files) incl. 3 new `isWellFormed()` cases
- `bun --cwd plugins/plugin-telegram typecheck` — passed (0), `git diff --check` — clean
- `git show 54adb8ad31c345e9ab477fd0e70f712d8c37a100:plugins/plugin-telegram/src/command-registration.ts` verifies import + `wellFormed` early return + `truncateWellFormed(wellFormed,256)`

## Evidence Gate

<!-- evidence-head:54adb8ad31c345e9ab477fd0e70f712d8c37a100 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; Telegram command description clamp is headless text truncation for `setMyCommands` JSON payload.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; same as before.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior is proven by deterministic surrogate unit tests.

<!-- evidence-row:backend-logs -->
- [x] Real surrogate-aware clamp paths exercised via Vitest (vitest runner):

```log
bun --cwd plugins/plugin-telegram test
vitest v4.1.5
 Test Files  23 passed (23)
      Tests  222 passed (222)
   Duration  2.90s (1.18s tests)
 3 new isWellFormed() cases: 255+'🦊'→255, lone '\ud800'→'\ufffd', 254+'🦊'→256
Ran 222 tests across 23 files.
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved; command registration is server-side Telegram boot with no browser console/network trace.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model delegation change beyond command-string hygiene; no live-model trajectory to link (deterministic truncation unit coverage).

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = surrogate-safe description wiring, proven by 3 deterministic tests:

```log
each test asserts .isWellFormed() === true and length <=256
boundary: "a".repeat(255)+"🦊"+"b".repeat(100) → "a".repeat(255) (backoff high surrogate)
lone: "a\ud800bc" → "a\ufffdbc"
fitting: "a".repeat(254)+"🦊" → 256 exact, kept intact
all 3 pass; without fix the 255+🦊 case would emit lone \uD83E and fail isWellFormed()
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface; no OCR text to review.

# Risks

Low — single-function hygiene in Telegram command description clamp (`clampDescription` only). No handler semantics, no `setMyCommands` semantics, no storage. Narrow import of two well-formed helpers already used by slack/telegram/agent/shared precedents; atomic `+54/-2` churn.

# Background

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-telegram/src/command-registration.ts:40-119` (import + `clampDescription`) and `plugins/plugin-telegram/src/command-registration.test.ts:164-209` (3 new cases).

## Detailed testing steps

- `bun --cwd plugins/plugin-telegram test -- src/command-registration.test.ts` — expect 8 pass incl. 3 new `isWellFormed()`
- `bun --cwd plugins/plugin-telegram test` — expect 222/222
- `bunx biome check plugins/plugin-telegram/src/command-registration.ts plugins/plugin-telegram/src/command-registration.test.ts` — expect `Checked 2 files … No fixes applied.`

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@9f3887c0f740491c4fc3c017f8b8d23f40d5712e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@9f3887c0f740491c4fc3c017f8b8d23f40d5712e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — telegram]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@9f3887c0f740491c4fc3c017f8b8d23f40d5712e:packages/skills/skills/contribute-to-eliza"} -->

