### PR TITLE
fix(plugin-form): guard component data persistence against circular objects

### DIFF
--- a/plugins/plugin-form/src/service.ts
+++ b/plugins/plugin-form/src/service.ts
@@ -524,8 +524,7 @@ export class FormService extends Service {
    * Save a session
    */
   async saveSession(session: FormSession): Promise<void> {
-    session.updatedAt = Date.now();
-    await storageSaveSession(this.runtime, session);
+    await storageSaveSession(this.runtime, session, true);
   }
 
   // ============================================================================

--- a/plugins/plugin-form/src/storage.test.ts
+++ b/plugins/plugin-form/src/storage.test.ts
@@ -1,7 +1,7 @@
 /**
- * Tests the form-storage session scans: locating stale live form sessions and
- * those expiring within a requested window, ignoring unrelated components. Runs
- * against a stub component store, no live model.
+ * Exercises form component persistence and bounded snapshot construction.
+ * The deterministic runtime covers real storage and FormService entry points
+ * without external services.
  */
 import type {
   Component,
@@ -11,15 +11,24 @@ import type {
   UUID,
 } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { FormService } from "./service";
 import {
+  FORM_COMPONENT_DATA_UNBOUNDED,
   getExpiringSessions,
   getStaleSessions,
+  MAX_FORM_COMPONENT_DATA_BYTES,
+  MAX_FORM_COMPONENT_DATA_DEPTH,
+  MAX_FORM_COMPONENT_DATA_NODES,
   saveAutofillData,
   saveSession,
   saveSubmission,
   toComponentData,
 } from "./storage";
-import { FORM_SESSION_COMPONENT, type FormSession } from "./types";
+import {
+  FORM_SESSION_COMPONENT,
+  type FormSession,
+  type FormSubmission,
+} from "./types";
 
 const NOW = 1_700_000_000_000;
 const agentId = "00000000-0000-4000-8000-000000000201" as UUID;
@@ -183,96 +192,192 @@ describe("form storage session scans", () => {
   });
 });
 
-describe("toComponentData & circular structure tolerance", () => {
+describe("bounded form component data", () => {
   it("serializes normal plain objects cleanly", () => {
     const data = { id: "123", name: "test", count: 42, active: true };
     expect(toComponentData(data)).toEqual(data);
   });
 
-  it("fails closed on circular structures without throwing", () => {
+  it("duplicates honest shared references without treating them as cycles", () => {
+    const shared = { answer: 42 };
+    expect(toComponentData({ first: shared, second: shared })).toEqual({
+      first: { answer: 42 },
+      second: { answer: 42 },
+    });
+  });
+
+  it("rejects circular structures with a typed failure", () => {
     const circular: Record<string, unknown> = {
       id: "123",
       title: "form",
     };
     circular.self = circular;
 
-    const sanitized = toComponentData(circular);
-    expect(sanitized).toEqual({ id: "123", title: "form" });
+    expect(() => toComponentData(circular)).toThrow(
+      expect.objectContaining({ code: FORM_COMPONENT_DATA_UNBOUNDED }),
+    );
   });
 
-  it("fails closed on throwing getters without throwing", () => {
-    const throwingObj = {
-      id: "valid",
-      get boom() {
-        throw new Error("trap");
-      },
+  it("rejects accessors without invoking them", () => {
+    const getter = vi.fn(() => "secret");
+    const value = { id: "valid" } as Record<string, unknown>;
+    Object.defineProperty(value, "secret", { enumerable: true, get: getter });
+
+    expect(() => toComponentData(value)).toThrow(
+      expect.objectContaining({ code: FORM_COMPONENT_DATA_UNBOUNDED }),
+    );
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  it("wraps revoked proxy reflection failures with their cause", () => {
+    const { proxy, revoke } = Proxy.revocable({}, {});
+    revoke();
+    let failure: unknown;
+    try {
+      toComponentData(proxy);
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toEqual(
+      expect.objectContaining({ code: FORM_COMPONENT_DATA_UNBOUNDED }),
+    );
+    expect((failure as Error).cause).toBeInstanceOf(TypeError);
+  });
+
+  it("accepts the exact depth limit and rejects the next level", () => {
+    const nested = (depth: number): Record<string, unknown> => {
+      let value: Record<string, unknown> = {};
+      for (let index = 0; index < depth; index += 1) value = { child: value };
+      return value;
     };
-
-    const sanitized = toComponentData(throwingObj);
-    expect(sanitized).toEqual({ id: "valid" });
+    expect(() =>
+      toComponentData(nested(MAX_FORM_COMPONENT_DATA_DEPTH)),
+    ).not.toThrow();
+    expect(() =>
+      toComponentData(nested(MAX_FORM_COMPONENT_DATA_DEPTH + 1)),
+    ).toThrow(expect.objectContaining({ code: FORM_COMPONENT_DATA_UNBOUNDED }));
   });
 
-  it("safely persists sessions with circular properties", async () => {
-    const createComponent = vi.fn(async () => undefined);
-    const getComponent = vi.fn(async () => null);
-    const getRoom = vi.fn(async () => ({ id: roomId, worldId: agentId }));
-    const runtime = {
-      agentId,
-      createComponent,
-      getComponent,
-      getRoom,
-    } as unknown as IAgentRuntime;
+  it("accounts for sparse array slots at the exact node limit", () => {
+    expect(() =>
+      toComponentData({ values: new Array(MAX_FORM_COMPONENT_DATA_NODES - 2) }),
+    ).not.toThrow();
+    expect(() =>
+      toComponentData({ values: new Array(MAX_FORM_COMPONENT_DATA_NODES - 1) }),
+    ).toThrow(expect.objectContaining({ code: FORM_COMPONENT_DATA_UNBOUNDED }));
+  });
+
+  it("enforces the UTF-8 byte limit at exact and max-plus-one", () => {
+    const structuralBytes = 14;
+    const exact = "é".repeat(
+      (MAX_FORM_COMPONENT_DATA_BYTES - structuralBytes) / 2,
+    );
+    expect(() => toComponentData({ payload: exact })).not.toThrow();
+    expect(() => toComponentData({ payload: `${exact}é` })).toThrow(
+      expect.objectContaining({ code: FORM_COMPONENT_DATA_UNBOUNDED }),
+    );
+  });
+
+  it("preserves an own __proto__ key without mutating the result prototype", () => {
+    const value: Record<string, unknown> = {};
+    Object.defineProperty(value, "__proto__", {
+      enumerable: true,
+      value: { polluted: true },
+    });
+    const data = toComponentData(value);
+    expect(Object.getPrototypeOf(data)).toBeNull();
+    expect(Object.hasOwn(data, "__proto__")).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(data, "__proto__")?.value).toEqual({
+      polluted: true,
+    });
+  });
+});
+
+function makePersistenceRuntime() {
+  return {
+    agentId,
+    createComponent: vi.fn(async () => undefined),
+    updateComponent: vi.fn(async () => undefined),
+    deleteComponent: vi.fn(async () => undefined),
+    getComponent: vi.fn(async () => null),
+    getRoom: vi.fn(async () => ({ id: roomId, worldId: agentId })),
+  };
+}
+
+function expectNoPersistence(
+  runtime: ReturnType<typeof makePersistenceRuntime>,
+) {
+  expect(runtime.getComponent).not.toHaveBeenCalled();
+  expect(runtime.getRoom).not.toHaveBeenCalled();
+  expect(runtime.createComponent).not.toHaveBeenCalled();
+  expect(runtime.updateComponent).not.toHaveBeenCalled();
+  expect(runtime.deleteComponent).not.toHaveBeenCalled();
+}
+
+describe("form persistence staging", () => {
+  it("rejects a circular session before any runtime call", async () => {
+    const runtime = makePersistenceRuntime();
 
     const session = makeSession("cyclic-session");
     (session.fields as Record<string, unknown>).cycle = session;
 
-    await expect(saveSession(runtime, session)).resolves.toBeUndefined();
-    expect(createComponent).toHaveBeenCalledTimes(1);
-    const saved = createComponent.mock.calls[0][0];
-    expect(saved.data.id).toBe("cyclic-session");
-    expect(saved.data.fields).toBeDefined();
+    await expect(
+      saveSession(runtime as unknown as IAgentRuntime, session),
+    ).rejects.toMatchObject({ code: FORM_COMPONENT_DATA_UNBOUNDED });
+    expectNoPersistence(runtime);
   });
 
-  it("safely persists submissions with circular data", async () => {
-    const createComponent = vi.fn(async () => undefined);
-    const getRoom = vi.fn(async () => ({ id: roomId, worldId: agentId }));
-    const runtime = {
-      agentId,
-      createComponent,
-      getRoom,
-    } as unknown as IAgentRuntime;
+  it("rejects a circular submission before any runtime call", async () => {
+    const runtime = makePersistenceRuntime();
 
     const submission: FormSubmission = {
       id: "sub-1",
       formId: "feedback",
       formVersion: 1,
+      sessionId: "session-1",
       entityId,
       submittedAt: NOW,
       values: { comments: "great" },
     };
     (submission.values as Record<string, unknown>).cycle = submission;
 
-    await expect(saveSubmission(runtime, submission)).resolves.toBeUndefined();
-    expect(createComponent).toHaveBeenCalledTimes(1);
+    await expect(
+      saveSubmission(runtime as unknown as IAgentRuntime, submission),
+    ).rejects.toMatchObject({ code: FORM_COMPONENT_DATA_UNBOUNDED });
+    expectNoPersistence(runtime);
   });
 
-  it("safely persists autofill data with circular values", async () => {
-    const createComponent = vi.fn(async () => undefined);
-    const getComponent = vi.fn(async () => null);
-    const getRoom = vi.fn(async () => ({ id: roomId, worldId: agentId }));
-    const runtime = {
-      agentId,
-      createComponent,
-      getComponent,
-      getRoom,
-    } as unknown as IAgentRuntime;
+  it("rejects circular autofill values before any runtime call", async () => {
+    const runtime = makePersistenceRuntime();
 
     const values: Record<string, JsonValue> = { name: "Alice" };
     (values as Record<string, unknown>).cycle = values;
 
     await expect(
-      saveAutofillData(runtime, entityId, "feedback", values),
-    ).resolves.toBeUndefined();
-    expect(createComponent).toHaveBeenCalledTimes(1);
+      saveAutofillData(
+        runtime as unknown as IAgentRuntime,
+        entityId,
+        "feedback",
+        values,
+      ),
+    ).rejects.toMatchObject({ code: FORM_COMPONENT_DATA_UNBOUNDED });
+    expectNoPersistence(runtime);
+  });
+
+  it("rejects an accessor through the real FormService without dispatch", async () => {
+    const runtime = makePersistenceRuntime();
+    const service = (await FormService.start(
+      runtime as unknown as IAgentRuntime,
+    )) as FormService;
+    const session = makeSession("service-session") as FormSession &
+      Record<string, unknown>;
+    const getter = vi.fn(() => "secret");
+    Object.defineProperty(session, "secret", { enumerable: true, get: getter });
+
+    await expect(service.saveSession(session)).rejects.toMatchObject({
+      code: FORM_COMPONENT_DATA_UNBOUNDED,
+    });
+    expect(getter).not.toHaveBeenCalled();
+    expectNoPersistence(runtime);
   });
 });

--- a/plugins/plugin-form/src/storage.test.ts
+++ b/plugins/plugin-form/src/storage.test.ts
@@ -11,7 +11,14 @@ import type {
   UUID,
 } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getExpiringSessions, getStaleSessions } from "./storage";
+import {
+  getExpiringSessions,
+  getStaleSessions,
+  saveAutofillData,
+  saveSession,
+  saveSubmission,
+  toComponentData,
+} from "./storage";
 import { FORM_SESSION_COMPONENT, type FormSession } from "./types";
 
 const NOW = 1_700_000_000_000;
@@ -173,5 +180,99 @@ describe("form storage session scans", () => {
       "expiring",
       "stashed",
     ]);
+  });
+});
+
+describe("toComponentData & circular structure tolerance", () => {
+  it("serializes normal plain objects cleanly", () => {
+    const data = { id: "123", name: "test", count: 42, active: true };
+    expect(toComponentData(data)).toEqual(data);
+  });
+
+  it("fails closed on circular structures without throwing", () => {
+    const circular: Record<string, unknown> = {
+      id: "123",
+      title: "form",
+    };
+    circular.self = circular;
+
+    const sanitized = toComponentData(circular);
+    expect(sanitized).toEqual({ id: "123", title: "form" });
+  });
+
+  it("fails closed on throwing getters without throwing", () => {
+    const throwingObj = {
+      id: "valid",
+      get boom() {
+        throw new Error("trap");
+      },
+    };
+
+    const sanitized = toComponentData(throwingObj);
+    expect(sanitized).toEqual({ id: "valid" });
+  });
+
+  it("safely persists sessions with circular properties", async () => {
+    const createComponent = vi.fn(async () => undefined);
+    const getComponent = vi.fn(async () => null);
+    const getRoom = vi.fn(async () => ({ id: roomId, worldId: agentId }));
+    const runtime = {
+      agentId,
+      createComponent,
+      getComponent,
+      getRoom,
+    } as unknown as IAgentRuntime;
+
+    const session = makeSession("cyclic-session");
+    (session.fields as Record<string, unknown>).cycle = session;
+
+    await expect(saveSession(runtime, session)).resolves.toBeUndefined();
+    expect(createComponent).toHaveBeenCalledTimes(1);
+    const saved = createComponent.mock.calls[0][0];
+    expect(saved.data.id).toBe("cyclic-session");
+    expect(saved.data.fields).toBeDefined();
+  });
+
+  it("safely persists submissions with circular data", async () => {
+    const createComponent = vi.fn(async () => undefined);
+    const getRoom = vi.fn(async () => ({ id: roomId, worldId: agentId }));
+    const runtime = {
+      agentId,
+      createComponent,
+      getRoom,
+    } as unknown as IAgentRuntime;
+
+    const submission: FormSubmission = {
+      id: "sub-1",
+      formId: "feedback",
+      formVersion: 1,
+      entityId,
+      submittedAt: NOW,
+      values: { comments: "great" },
+    };
+    (submission.values as Record<string, unknown>).cycle = submission;
+
+    await expect(saveSubmission(runtime, submission)).resolves.toBeUndefined();
+    expect(createComponent).toHaveBeenCalledTimes(1);
+  });
+
+  it("safely persists autofill data with circular values", async () => {
+    const createComponent = vi.fn(async () => undefined);
+    const getComponent = vi.fn(async () => null);
+    const getRoom = vi.fn(async () => ({ id: roomId, worldId: agentId }));
+    const runtime = {
+      agentId,
+      createComponent,
+      getComponent,
+      getRoom,
+    } as unknown as IAgentRuntime;
+
+    const values: Record<string, JsonValue> = { name: "Alice" };
+    (values as Record<string, unknown>).cycle = values;
+
+    await expect(
+      saveAutofillData(runtime, entityId, "feedback", values),
+    ).resolves.toBeUndefined();
+    expect(createComponent).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/plugin-form/src/storage.ts
+++ b/plugins/plugin-form/src/storage.ts
@@ -94,6 +94,61 @@ const isFormSession = (data: JsonValue | object): data is FormSession => {
 
 const isLiveSession = (session: FormSession): boolean => !isExpired(session);
 
+function toComponentValue(
+  value: unknown,
+  seen = new WeakSet<object>(),
+): JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (typeof value !== "object") {
+    return null;
+  }
+  if (seen.has(value)) {
+    return null;
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.map((item) => toComponentValue(item, seen));
+  }
+  const obj: Record<string, JsonValue> = {};
+  for (const k of Object.keys(value)) {
+    try {
+      const val = (value as Record<string, unknown>)[k];
+      if (typeof val === "object" && val !== null && seen.has(val)) {
+        continue;
+      }
+      const serialized = toComponentValue(val, seen);
+      if (serialized !== undefined) {
+        obj[k] = serialized;
+      }
+    } catch {
+      // error-policy:J3 drop throwing properties.
+    }
+  }
+  return obj;
+}
+
+/**
+ * Safely serialize data into plain JSON component data, guarding against
+ * circular structures and non-serializable objects.
+ */
+export function toComponentData<T extends object>(
+  value: T,
+): Record<string, JsonValue> {
+  try {
+    return JSON.parse(JSON.stringify(value)) as Record<string, JsonValue>;
+  } catch {
+    // error-policy:J3 untrusted form payload may contain circular references or invalid JSON values; fail closed to sanitized record.
+    return (toComponentValue(value) as Record<string, JsonValue>) ?? {};
+  }
+}
+
 /**
  * Build the component type (natural key suffix) for a session.
  *
@@ -403,7 +458,7 @@ export async function saveSession(
     type: componentType,
     createdAt: existing?.createdAt || Date.now(),
     // Store session as component data
-    data: JSON.parse(JSON.stringify(session)) as Record<string, JsonValue>,
+    data: toComponentData(session),
   };
 
   if (existing) {
@@ -479,7 +534,7 @@ export async function saveSubmission(
     sourceEntityId: runtime.agentId,
     type: componentType,
     createdAt: submission.submittedAt,
-    data: JSON.parse(JSON.stringify(submission)) as Record<string, JsonValue>,
+    data: toComponentData(submission),
   };
 
   await runtime.createComponent(component);
@@ -623,7 +678,7 @@ export async function saveAutofillData(
     sourceEntityId: runtime.agentId,
     type: componentType,
     createdAt: existing?.createdAt || Date.now(),
-    data: JSON.parse(JSON.stringify(data)) as Record<string, JsonValue>,
+    data: toComponentData(data),
   };
 
   if (existing) {

--- a/plugins/plugin-form/src/storage.ts
+++ b/plugins/plugin-form/src/storage.ts
@@ -56,7 +56,13 @@
  * operational queries.
  */
 
-import type { Component, IAgentRuntime, JsonValue, UUID } from "@elizaos/core";
+import {
+  type Component,
+  ElizaError,
+  type IAgentRuntime,
+  type JsonValue,
+  type UUID,
+} from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 import { isExpired, isExpiringSoon } from "./ttl";
 import type { FormAutofillData, FormSession, FormSubmission } from "./types";
@@ -94,44 +100,215 @@ const isFormSession = (data: JsonValue | object): data is FormSession => {
 
 const isLiveSession = (session: FormSession): boolean => !isExpired(session);
 
+export const MAX_FORM_COMPONENT_DATA_DEPTH = 64;
+export const MAX_FORM_COMPONENT_DATA_NODES = 100_000;
+export const MAX_FORM_COMPONENT_DATA_BYTES = 1024 * 1024;
+export const FORM_COMPONENT_DATA_UNBOUNDED = "FORM_COMPONENT_DATA_UNBOUNDED";
+
+const OMIT_COMPONENT_VALUE = Symbol("omit-component-value");
+type ComponentValue = JsonValue | typeof OMIT_COMPONENT_VALUE;
+type ComponentWalk = {
+  bytes: number;
+  nodes: number;
+  visiting: WeakSet<object>;
+};
+
+function failComponentData(
+  reason: string,
+  context: Record<string, unknown> = {},
+  cause?: unknown,
+): never {
+  throw new ElizaError("Form component data is not bounded JSON", {
+    code: FORM_COMPONENT_DATA_UNBOUNDED,
+    context: { reason, ...context },
+    cause,
+  });
+}
+
+function inspectComponentData<T>(operation: string, inspect: () => T): T {
+  try {
+    return inspect();
+  } catch (cause) {
+    // error-policy:J2 Preserve hostile reflection failures at the persistence boundary.
+    failComponentData("reflection", { operation }, cause);
+  }
+}
+
+function reserveNodes(walk: ComponentWalk, count = 1): void {
+  if (count > MAX_FORM_COMPONENT_DATA_NODES - walk.nodes) {
+    failComponentData("nodes", {
+      maxNodes: MAX_FORM_COMPONENT_DATA_NODES,
+      nodes: walk.nodes + count,
+    });
+  }
+  walk.nodes += count;
+}
+
+function reserveBytes(walk: ComponentWalk, count: number): void {
+  if (count > MAX_FORM_COMPONENT_DATA_BYTES - walk.bytes) {
+    failComponentData("bytes", {
+      maxBytes: MAX_FORM_COMPONENT_DATA_BYTES,
+      bytes: walk.bytes + count,
+    });
+  }
+  walk.bytes += count;
+}
+
+function jsonStringBytes(value: string): number {
+  if (value.length > MAX_FORM_COMPONENT_DATA_BYTES) {
+    failComponentData("bytes", {
+      maxBytes: MAX_FORM_COMPONENT_DATA_BYTES,
+      minimumBytes: value.length,
+    });
+  }
+  const encoded = JSON.stringify(value);
+  return new TextEncoder().encode(encoded).byteLength;
+}
+
+function defineComponentProperty(
+  target: Record<string, JsonValue>,
+  key: string,
+  value: JsonValue,
+): void {
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+}
+
 function toComponentValue(
   value: unknown,
-  seen = new WeakSet<object>(),
-): JsonValue {
-  if (
-    value === null ||
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return value;
+  walk: ComponentWalk,
+  depth: number,
+  arrayElement = false,
+): ComponentValue {
+  if (depth > MAX_FORM_COMPONENT_DATA_DEPTH) {
+    failComponentData("depth", {
+      depth,
+      maxDepth: MAX_FORM_COMPONENT_DATA_DEPTH,
+    });
   }
-  if (typeof value !== "object") {
+  reserveNodes(walk);
+
+  if (value === null) {
+    reserveBytes(walk, 4);
     return null;
   }
-  if (seen.has(value)) {
-    return null;
+  switch (typeof value) {
+    case "string":
+      reserveBytes(walk, jsonStringBytes(value));
+      return value;
+    case "boolean":
+      reserveBytes(walk, value ? 4 : 5);
+      return value;
+    case "number": {
+      if (!Number.isFinite(value)) {
+        reserveBytes(walk, 4);
+        return null;
+      }
+      reserveBytes(walk, String(value).length);
+      return value;
+    }
+    case "undefined":
+    case "function":
+    case "symbol":
+      if (arrayElement) {
+        reserveBytes(walk, 4);
+        return null;
+      }
+      return OMIT_COMPONENT_VALUE;
+    case "bigint":
+      failComponentData("unsupported", { type: "bigint" });
   }
-  seen.add(value);
-  if (Array.isArray(value)) {
-    return value.map((item) => toComponentValue(item, seen));
+
+  if (walk.visiting.has(value)) {
+    failComponentData("cycle");
   }
-  const obj: Record<string, JsonValue> = {};
-  for (const k of Object.keys(value)) {
-    try {
-      const val = (value as Record<string, unknown>)[k];
-      if (typeof val === "object" && val !== null && seen.has(val)) {
+  walk.visiting.add(value);
+  try {
+    const isArray = inspectComponentData("Array.isArray", () =>
+      Array.isArray(value),
+    );
+    if (isArray) {
+      const lengthDescriptor = inspectComponentData("array.length", () =>
+        Object.getOwnPropertyDescriptor(value, "length"),
+      );
+      const length = lengthDescriptor?.value;
+      if (!Number.isSafeInteger(length) || length < 0) {
+        failComponentData("array-length");
+      }
+      if (length > MAX_FORM_COMPONENT_DATA_NODES - walk.nodes) {
+        failComponentData("nodes", {
+          maxNodes: MAX_FORM_COMPONENT_DATA_NODES,
+          nodes: walk.nodes + length,
+        });
+      }
+      const result: JsonValue[] = new Array(length);
+      reserveBytes(walk, 2 + Math.max(0, length - 1));
+      for (let index = 0; index < length; index += 1) {
+        const descriptor = inspectComponentData(`array[${index}]`, () =>
+          Object.getOwnPropertyDescriptor(value, String(index)),
+        );
+        if (!descriptor) {
+          reserveNodes(walk);
+          reserveBytes(walk, 4);
+          result[index] = null;
+          continue;
+        }
+        if (!("value" in descriptor)) {
+          failComponentData("accessor", { key: String(index) });
+        }
+        const item = toComponentValue(descriptor.value, walk, depth + 1, true);
+        result[index] = item === OMIT_COMPONENT_VALUE ? null : item;
+      }
+      return result;
+    }
+
+    const prototype = inspectComponentData("Object.getPrototypeOf", () =>
+      Object.getPrototypeOf(value),
+    );
+    if (prototype !== null && prototype !== Object.prototype) {
+      failComponentData("unsupported", { type: "non-plain-object" });
+    }
+    const keys = inspectComponentData("Reflect.ownKeys", () =>
+      Reflect.ownKeys(value),
+    );
+    if (keys.length > MAX_FORM_COMPONENT_DATA_NODES - walk.nodes) {
+      failComponentData("nodes", {
+        maxNodes: MAX_FORM_COMPONENT_DATA_NODES,
+        nodes: walk.nodes + keys.length,
+      });
+    }
+    const result: Record<string, JsonValue> = Object.create(null);
+    reserveBytes(walk, 2);
+    let properties = 0;
+    for (const key of keys) {
+      if (typeof key !== "string") {
+        reserveNodes(walk);
         continue;
       }
-      const serialized = toComponentValue(val, seen);
-      if (serialized !== undefined) {
-        obj[k] = serialized;
+      const descriptor = inspectComponentData(`object.${key}`, () =>
+        Object.getOwnPropertyDescriptor(value, key),
+      );
+      if (!descriptor?.enumerable) {
+        reserveNodes(walk);
+        continue;
       }
-    } catch {
-      // error-policy:J3 drop throwing properties.
+      if (!("value" in descriptor)) {
+        failComponentData("accessor", { key });
+      }
+      const child = toComponentValue(descriptor.value, walk, depth + 1);
+      if (child === OMIT_COMPONENT_VALUE) continue;
+      reserveBytes(walk, jsonStringBytes(key) + 1 + (properties > 0 ? 1 : 0));
+      defineComponentProperty(result, key, child);
+      properties += 1;
     }
+    return result;
+  } finally {
+    walk.visiting.delete(value);
   }
-  return obj;
 }
 
 /**
@@ -141,12 +318,16 @@ function toComponentValue(
 export function toComponentData<T extends object>(
   value: T,
 ): Record<string, JsonValue> {
-  try {
-    return JSON.parse(JSON.stringify(value)) as Record<string, JsonValue>;
-  } catch {
-    // error-policy:J3 untrusted form payload may contain circular references or invalid JSON values; fail closed to sanitized record.
-    return (toComponentValue(value) as Record<string, JsonValue>) ?? {};
+  const walk: ComponentWalk = {
+    bytes: 0,
+    nodes: 0,
+    visiting: new WeakSet(),
+  };
+  const data = toComponentValue(value, walk, 0);
+  if (data === OMIT_COMPONENT_VALUE || Array.isArray(data) || !isRecord(data)) {
+    failComponentData("root");
   }
+  return data;
 }
 
 /**
@@ -437,28 +618,45 @@ export async function getSessionById(
  *
  * @param runtime - Agent runtime for database access
  * @param session - Session to save
+ * @param refreshUpdatedAt - Refresh the timestamp on the inert staged snapshot
  */
 export async function saveSession(
   runtime: IAgentRuntime,
   session: FormSession,
+  refreshUpdatedAt = false,
 ): Promise<void> {
-  const componentType = sessionComponentType(session.roomId, session.id);
-  const existing = await runtime.getComponent(session.entityId, componentType);
-  const context = await resolveComponentContext(runtime, session.roomId);
+  const componentData = toComponentData(session);
+  if (!isFormSession(componentData)) {
+    failComponentData("session-shape");
+  }
+  const persistedSession = componentData;
+  if (refreshUpdatedAt) persistedSession.updatedAt = Date.now();
+  const componentType = sessionComponentType(
+    persistedSession.roomId,
+    persistedSession.id,
+  );
+  const existing = await runtime.getComponent(
+    persistedSession.entityId,
+    componentType,
+  );
+  const context = await resolveComponentContext(
+    runtime,
+    persistedSession.roomId,
+  );
   const resolvedWorldId = existing?.worldId ?? context.worldId;
 
   const component: Component = {
     id: existing?.id || (uuidv4() as UUID),
-    entityId: session.entityId,
+    entityId: persistedSession.entityId,
     agentId: runtime.agentId,
-    roomId: session.roomId,
+    roomId: persistedSession.roomId,
     // WHY preserve worldId: Avoids breaking existing component relationships
     worldId: resolvedWorldId,
     sourceEntityId: runtime.agentId,
     type: componentType,
     createdAt: existing?.createdAt || Date.now(),
     // Store session as component data
-    data: toComponentData(session),
+    data: componentData,
   };
 
   if (existing) {
@@ -469,7 +667,7 @@ export async function saveSession(
 
   // Retire any pre-upgrade room-only component for this session so the stale
   // `active` row cannot shadow the freshly written session-id key.
-  await retireLegacySessionComponent(runtime, session);
+  await retireLegacySessionComponent(runtime, persistedSession);
 }
 
 /**
@@ -520,21 +718,26 @@ export async function saveSubmission(
   runtime: IAgentRuntime,
   submission: FormSubmission,
 ): Promise<void> {
+  const componentData = toComponentData(submission);
+  if (!isFormSubmission(componentData)) {
+    failComponentData("submission-shape");
+  }
+  const persistedSubmission = componentData;
   // Use a unique component type per submission
   // WHY: Allows multiple submissions per form
-  const componentType = `${FORM_SUBMISSION_COMPONENT}:${submission.formId}:${submission.id}`;
+  const componentType = `${FORM_SUBMISSION_COMPONENT}:${persistedSubmission.formId}:${persistedSubmission.id}`;
   const context = await resolveComponentContext(runtime);
 
   const component: Component = {
     id: uuidv4() as UUID,
-    entityId: submission.entityId,
+    entityId: persistedSubmission.entityId,
     agentId: runtime.agentId,
     roomId: context.roomId,
     worldId: context.worldId,
     sourceEntityId: runtime.agentId,
     type: componentType,
-    createdAt: submission.submittedAt,
-    data: toComponentData(submission),
+    createdAt: persistedSubmission.submittedAt,
+    data: componentData,
   };
 
   await runtime.createComponent(component);
@@ -658,16 +861,18 @@ export async function saveAutofillData(
   formId: string,
   values: Record<string, JsonValue>,
 ): Promise<void> {
+  const componentData = toComponentData({
+    formId,
+    values,
+    updatedAt: Date.now(),
+  });
+  if (!isFormAutofillData(componentData)) {
+    failComponentData("autofill-shape");
+  }
   const componentType = `${FORM_AUTOFILL_COMPONENT}:${formId}`;
   const existing = await runtime.getComponent(entityId, componentType);
   const context = await resolveComponentContext(runtime);
   const resolvedWorldId = existing?.worldId ?? context.worldId;
-
-  const data: FormAutofillData = {
-    formId,
-    values,
-    updatedAt: Date.now(),
-  };
 
   const component: Component = {
     id: existing?.id || (uuidv4() as UUID),
@@ -678,7 +883,7 @@ export async function saveAutofillData(
     sourceEntityId: runtime.agentId,
     type: componentType,
     createdAt: existing?.createdAt || Date.now(),
-    data: toComponentData(data),
+    data: componentData,
   };
 
   if (existing) {


### PR DESCRIPTION
## Summary
- Bound form component snapshots to depth 64, 100,000 nodes, and 1 MiB of exact UTF-8 JSON.
- Traverse own data descriptors without invoking getters or `toJSON`; reject accessors, revoked proxies, cycles, non-plain objects, and over-budget graphs with typed `FORM_COMPONENT_DATA_UNBOUNDED`.
- Preserve ordinary JSON behavior, honest shared references, sparse-array semantics, and inert `__proto__` keys.
- Stage and validate the complete snapshot before any component lookup/write in session, submission, and autofill persistence; the real `FormService.saveSession` entry point uses the same boundary.

## Verification

Frozen exact head: `61e723234a7070c741f638c328c6928f1c7cea96`

- New adversarial assertions: 13/13 passed under pinned Bun 1.3.14 (DAG, getter zero-call, revoked proxy cause, cycle, exact/max+1 depth/nodes/UTF-8 bytes, `__proto__`, and zero-dispatch real storage/FormService paths). The repository-wide Bun coverage reporter hung after printing all passing assertions and was bounded.
- `bun run --cwd plugins/plugin-form typecheck`: passed before the final base-only rebase; the exact-head rerun is environment-blocked because the shared sparse dependency dist predates the new `@elizaos/shared/config/config-catalog` export. The three repaired source blobs are unchanged by the rebase.
- `tsc6 --noCheck -p plugins/plugin-form/tsconfig.build.json`: passed before the final base-only rebase.
- Biome on the three touched files: passed at exact head.
- `git diff --check origin/develop HEAD`: passed.
- JavaScript build is environment-blocked because `tsup` is absent from the sparse dependency installation.

This is a material maintainer repair and remains draft pending independent exact-head audit.