### PR TITLE
fix(notes): keep surrogate pairs intact in note line truncation

### DIFF
--- a/plugins/plugin-notes/src/provider.test.ts
+++ b/plugins/plugin-notes/src/provider.test.ts
@@ -262,4 +262,62 @@ describe("SAVED_NOTES provider", () => {
     expect(text).toContain("(truncated)");
     expect(text.length).toBeLessThan(1_000);
   });
+
+  it("keeps UTF-16 surrogate pairs intact when truncating a note line to 400", () => {
+    const body = `${"a".repeat(382)}🦊${"b".repeat(100)}`;
+    const text = renderSavedNotesText([
+      {
+        id: "note-emoji-boundary",
+        title: "x",
+        body,
+        color: "yellow",
+        createdAt: "2026-08-14T12:00:00.000Z",
+        updatedAt: "2026-08-14T12:00:00.000Z",
+      },
+    ]);
+    const noteLine = text.split("\n").find((line) => line.startsWith("- x"));
+    expect(noteLine).toBeDefined();
+    if (noteLine) {
+      expect(noteLine.isWellFormed()).toBe(true);
+      expect(noteLine.length).toBeLessThanOrEqual(402);
+    }
+    expect(noteLine).not.toContain("🦊");
+    expect(noteLine).toContain("(truncated)");
+  });
+
+  it("sanitizes lone surrogates in a note before truncation", () => {
+    const text = renderSavedNotesText([
+      {
+        id: "note-lone",
+        title: "a\ud800bc",
+        body: "",
+        color: "yellow",
+        createdAt: "2026-08-14T12:00:00.000Z",
+        updatedAt: "2026-08-14T12:00:00.000Z",
+      },
+    ]);
+    expect(text).toContain("a\ufffdbc");
+    expect(text.isWellFormed()).toBe(true);
+  });
+
+  it("preserves an emoji that fits entirely under the 400 cap", () => {
+    const body = `${"a".repeat(10)}🦊`;
+    const text = renderSavedNotesText([
+      {
+        id: "note-fitting",
+        title: "t",
+        body,
+        color: "yellow",
+        createdAt: "2026-08-14T12:00:00.000Z",
+        updatedAt: "2026-08-14T12:00:00.000Z",
+      },
+    ]);
+    expect(text).toContain("🦊");
+    expect(text.isWellFormed()).toBe(true);
+    const noteLine = text.split("\n").find((line) => line.startsWith("- t"));
+    expect(noteLine).toBeDefined();
+    if (noteLine) {
+      expect(noteLine.isWellFormed()).toBe(true);
+    }
+  });
 });

--- a/plugins/plugin-notes/src/provider.ts
+++ b/plugins/plugin-notes/src/provider.ts
@@ -13,12 +13,14 @@
  * deleted note cannot linger here the way a mirrored memory record would.
  */
 
-import type {
-  IAgentRuntime,
-  Memory,
-  Provider,
-  ProviderResult,
-  State,
+import {
+  type IAgentRuntime,
+  type Memory,
+  type Provider,
+  type ProviderResult,
+  type State,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 
 import { getNotesService } from "./service.js";
@@ -46,9 +48,13 @@ const UNAVAILABLE: ProviderResult = {
 function noteLine(note: StickyNote): string {
   const body = note.body.trim();
   const full = body.length > 0 ? `${note.title} — ${body}` : note.title;
-  return full.length > MAX_NOTE_LINE_LENGTH
-    ? `${full.slice(0, MAX_NOTE_LINE_LENGTH - "… (truncated)".length)}… (truncated)`
-    : full;
+  const wellFormed = toWellFormedUnicode(full);
+  if (wellFormed.length <= MAX_NOTE_LINE_LENGTH) {
+    return wellFormed;
+  }
+  const suffix = toWellFormedUnicode("… (truncated)");
+  const budget = Math.max(0, MAX_NOTE_LINE_LENGTH - suffix.length);
+  return `${truncateWellFormed(wellFormed, budget)}${suffix}`;
 }
 
 export function renderSavedNotesText(notes: readonly StickyNote[]): string {


### PR DESCRIPTION
Fixes #23440

## Summary

- Fix `plugins/plugin-notes/src/provider.ts:46` `noteLine` to use `toWellFormedUnicode` + `truncateWellFormed` so capping to `MAX_NOTE_LINE_LENGTH=400` never splits an astral surrogate pair (e.g. 🦊 `\uD83E\uDD8A`) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict provider JSON (Cerebras/serde `wrong_api_format`) rejects with HTTP 400. Preserves suffix sanitization (`… (truncated)` via `toWellFormedUnicode`) and `length<=400` (`budget = max(0,400-suffix.length)` → `truncateWellFormed` backoff).
- Add 3 deterministic `isWellFormed()` tests in `plugins/plugin-notes/src/provider.test.ts`: emoji at 387 budget boundary (382 'a' + 🦊 → backoff, not lone), lone `\ud800`→`\ufffd`, and fitting emoji under cap.

Same class as approved #23241 (slack `formatting.ts:550`), #23227 (telegram `handler.ts:99`), #23277 (agent `grounded-action-reply.ts:40`), #23284 (shared `transcripts.ts:380`), #23437 (telegram `command-registration.ts:111`) — identical `toWellFormedUnicode` → `truncateWellFormed` → suffix pattern; note line is rendered via `renderSavedNotesText` into `SAVED_NOTES` provider prompt.

## Changes

| File | Change |
|------|--------|
| `plugins/plugin-notes/src/provider.ts` | Import `toWellFormedUnicode`/`truncateWellFormed`, rewrite `noteLine` to sanitize + well-formed budget + suffix |
| `plugins/plugin-notes/src/provider.test.ts` | +58 lines — 3 tests: surrogate boundary (387), lone surrogate sanitization, fitting emoji |

## Verification

- Rebased onto `origin/develop@9f3887c0f7` (fix/homepage #23265) — zero conflicts
- `bunx biome check` — 2 files clean (7ms, no fixes)
- `bun --cwd plugins/plugin-notes test` — **96 passed, 0 failed** (10 files) incl. 3 new `isWellFormed()` cases (was 93)
- `git show 733f77b8e74f9c54acda0e9c488ded3f3ab0a0c8:plugins/plugin-notes/src/provider.ts` verifies import + `wellFormed` early return + `suffix toWellFormedUnicode` + `budget Math.max(0,400-suffix.length)` + `truncateWellFormed`

## Evidence Gate

<!-- evidence-head:733f77b8e74f9c54acda0e9c488ded3f3ab0a0c8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; notes provider line truncation is headless prompt text for `SAVED_NOTES` provider.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; same as before.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior is proven by deterministic surrogate unit tests.

<!-- evidence-row:backend-logs -->
- [x] Real surrogate-aware note line paths exercised via Vitest:

```log
bun --cwd plugins/plugin-notes test
vitest v4.1.5
 Test Files  10 passed (10)
      Tests  96 passed (96)
   Duration  6.54s (2.05s tests)
 3 new isWellFormed() cases: 382+'🦊' boundary→backoff, lone '\ud800'→'\ufffd', fitting emoji
Ran 96 tests across 10 files.
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved; notes rendering is server-side provider with no browser console/network trace.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model delegation change beyond note-string hygiene; no live-model trajectory to link (deterministic truncation unit coverage).

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = surrogate-safe note line wiring, proven by 3 deterministic tests:

```log
each test asserts .isWellFormed() === true
boundary: title "x" + "a".repeat(382)+"🦊"+"b".repeat(100) → "- x "+ "a".repeat(382) + "… (truncated)" (backoff, not 🦊, length<=402)
lone: "a\ud800bc" → "a\ufffdbc"
fitting: "a".repeat(10)+"🦊" → kept intact
all 3 pass; without fix the 382+🦊 case would emit lone \uD83E and fail isWellFormed()
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface; no OCR text to review.

# Risks

Low — single-function hygiene in notes provider (`noteLine` only). No provider semantics, no storage, no list truncation. Narrow import of two well-formed helpers already used by slack/telegram/agent/shared precedents; atomic `+73/-9` churn.

# Background

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-notes/src/provider.ts:16-58` (import + `noteLine`) and `plugins/plugin-notes/src/provider.test.ts:240-300` (3 new cases).

## Detailed testing steps

- `bun --cwd plugins/plugin-notes test` — expect 96/96 incl. 3 new `isWellFormed()`
- `bunx biome check plugins/plugin-notes/src/provider.ts plugins/plugin-notes/src/provider.test.ts` — expect `Checked 2 files … No fixes applied.`

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@9f3887c0f740491c4fc3c017f8b8d23f40d5712e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@9f3887c0f740491c4fc3c017f8b8d23f40d5712e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — notes]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@9f3887c0f740491c4fc3c017f8b8d23f40d5712e:packages/skills/skills/contribute-to-eliza"} -->

