### PR TITLE
fix(cloud): bind container delete execution to job tenant

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-job-executors.test.ts
@@ -88,7 +88,19 @@ function fakeProvider(over: Partial<Record<keyof AppContainerProvider, unknown>>
   return { calls, provider };
 }
 
-const job = (data: unknown) => ({ id: "job-1", data });
+const job = (data: unknown, organizationId?: string) => {
+  const payloadOrganizationId =
+    typeof data === "object" &&
+    data !== null &&
+    typeof Reflect.get(data, "organizationId") === "string"
+      ? (Reflect.get(data, "organizationId") as string)
+      : "org-1";
+  return {
+    id: "job-1",
+    data,
+    organization_id: organizationId ?? payloadOrganizationId,
+  };
+};
 
 describe("executeContainerProvision", () => {
   test("builds input from the row, provisions, and marks running", async () => {
@@ -506,6 +518,48 @@ describe("executeContainerDelete / restart / logs", () => {
       }),
     ).rejects.toThrow("does not own");
     expect(calls).toEqual([]);
+  });
+
+  test("rejects an organization-only payload before a foreign tenant lookup", async () => {
+    const { events, store } = fakeStore();
+    const lookedUpOrganizations: string[] = [];
+    store.findDeletingByOrganization = async (organizationId) => {
+      lookedUpOrganizations.push(organizationId);
+      return [ROW];
+    };
+    const { calls, provider } = fakeProvider();
+
+    await expect(
+      executeContainerDelete(job({ organizationId: "org-foreign" }, "org-owner"), {
+        provider,
+        store,
+      }),
+    ).rejects.toMatchObject({ code: "CONTAINER_DELETE_PAYLOAD_ORGANIZATION_MISMATCH" });
+
+    expect(lookedUpOrganizations).toEqual([]);
+    expect(calls).toEqual([]);
+    expect(events).toEqual([]);
+  });
+
+  test("rejects a codec-valid payload when its tenant differs from the job row", async () => {
+    const { events, store } = fakeStore();
+    let containerRead = false;
+    store.getById = async () => {
+      containerRead = true;
+      return ROW;
+    };
+    const { calls, provider } = fakeProvider();
+
+    await expect(
+      executeContainerDelete(
+        job({ containerId: "container-1", organizationId: "org-foreign" }, "org-owner"),
+        { provider, store },
+      ),
+    ).rejects.toMatchObject({ code: "CONTAINER_DELETE_PAYLOAD_ORGANIZATION_MISMATCH" });
+
+    expect(containerRead).toBe(false);
+    expect(calls).toEqual([]);
+    expect(events).toEqual([]);
   });
 
   test("restart restarts by container name", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/container-job-service.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-job-service.test.ts
@@ -103,6 +103,7 @@ describe("dispatchContainerJob", () => {
         {
           id: "j",
           type,
+          organization_id: "org-1",
           data: { containerId: "container-1", organizationId: "org-1", userId: "user-1" },
         },
         deps,
@@ -114,7 +115,10 @@ describe("dispatchContainerJob", () => {
   test("throws on a non-container job type", async () => {
     const { deps } = fakeDeps();
     await expect(
-      dispatchContainerJob({ id: "j", type: JOB_TYPES.AGENT_PROVISION, data: {} }, deps),
+      dispatchContainerJob(
+        { id: "j", type: JOB_TYPES.AGENT_PROVISION, organization_id: "org-1", data: {} },
+        deps,
+      ),
     ).rejects.toThrow("Not a container job type");
   });
 });

--- a/packages/cloud/shared/src/lib/services/container-job-executors.ts
+++ b/packages/cloud/shared/src/lib/services/container-job-executors.ts
@@ -277,9 +277,10 @@ export async function executeContainerProvision(
 }
 
 export async function executeContainerDelete(
-  job: JobLike,
+  job: JobLike & { organization_id: string },
   deps: ContainerExecutorDeps,
 ): Promise<void> {
+  const organizationId = authoritativeDeleteOrganizationId(job);
   let targets: Array<{
     id: string;
     organizationId: string;
@@ -287,7 +288,7 @@ export async function executeContainerDelete(
   }>;
   if (isContainerDeleteJobData(job.data)) {
     const row = await deps.store.getById(job.data.containerId);
-    if (row && row.organizationId !== job.data.organizationId) {
+    if (row && row.organizationId !== organizationId) {
       throw new ElizaError(
         `Container delete job ${job.id} organization does not own ${job.data.containerId}`,
         {
@@ -295,16 +296,15 @@ export async function executeContainerDelete(
           context: {
             jobId: job.id,
             containerId: job.data.containerId,
-            jobOrganizationId: job.data.organizationId,
+            jobOrganizationId: organizationId,
             containerOrganizationId: row.organizationId,
           },
           severity: "fatal",
         },
       );
     }
-    targets = [{ id: job.data.containerId, organizationId: job.data.organizationId, row }];
+    targets = [{ id: job.data.containerId, organizationId, row }];
   } else {
-    const organizationId = recoverableDeleteOrganizationId(job);
     const rows = await deps.store.findDeletingByOrganization(organizationId);
     targets = rows.map((row) => ({ id: row.id, organizationId, row }));
     logger.warn("[ContainerExecutor] recovering malformed container delete job", {
@@ -355,15 +355,40 @@ export async function executeContainerDelete(
   }
 }
 
-function recoverableDeleteOrganizationId(job: JobLike): string {
+/**
+ * Bind every delete scope to the jobs row before any container lookup or
+ * provider mutation. The JSON payload is input; `organization_id` is durable
+ * queue authority. This guard also covers workers racing the operator
+ * reconciler and any future producer that bypasses that reconciler.
+ */
+function authoritativeDeleteOrganizationId(job: JobLike & { organization_id: string }): string {
+  let payloadOrganizationId: string;
   if (typeof job.data !== "object" || job.data === null) {
-    return readContainerDeleteJobData(job).organizationId;
+    payloadOrganizationId = readContainerDeleteJobData(job).organizationId;
+  } else {
+    const candidate = Reflect.get(job.data, "organizationId");
+    if (typeof candidate !== "string" || candidate.trim().length === 0) {
+      payloadOrganizationId = readContainerDeleteJobData(job).organizationId;
+    } else {
+      payloadOrganizationId = candidate;
+    }
   }
-  const organizationId = Reflect.get(job.data, "organizationId");
-  if (typeof organizationId !== "string" || organizationId.trim().length === 0) {
-    return readContainerDeleteJobData(job).organizationId;
+
+  if (payloadOrganizationId.toLowerCase() !== job.organization_id.toLowerCase()) {
+    throw new ElizaError(
+      `Container delete job ${job.id} payload organization does not match its owner`,
+      {
+        code: "CONTAINER_DELETE_PAYLOAD_ORGANIZATION_MISMATCH",
+        context: {
+          jobId: job.id,
+          jobOrganizationId: job.organization_id,
+          payloadOrganizationId,
+        },
+        severity: "fatal",
+      },
+    );
   }
-  return organizationId;
+  return job.organization_id;
 }
 
 export async function executeContainerRestart(

--- a/packages/cloud/shared/src/lib/services/container-job-service.ts
+++ b/packages/cloud/shared/src/lib/services/container-job-service.ts
@@ -45,7 +45,7 @@ export function isContainerJobType(type: string): boolean {
 
 /** Route a CONTAINER_* job to its executor. */
 export async function dispatchContainerJob(
-  job: JobLike & { type: string },
+  job: JobLike & { type: string; organization_id: string },
   deps: ContainerExecutorDeps,
 ): Promise<void> {
   switch (job.type) {


### PR DESCRIPTION
Refs #15821
Fixes the remaining executor boundary after merged #23423.

## Why

#23423 correctly fences its operator reconciliation path, but a worker can claim the same durable job first. The irreversible delete executor still accepted the tenant from the payload even though the durable job row supplies the authoritative organization.

This follow-up requires the job owner at dispatch, compares the payload tenant to that authority before any lookup/provider/store mutation, and uses the durable owner for every scoped lookup and terminal write.

Security-sensitive reproduction detail is tracked privately.

## Exact correction validation

Correction commit before the conflict-free rebase: `216074a756f152ef47b03d4caadff69e574b35c3`
Current rebased head: `87938ce930a51`
Base: `84bbd770c78e0`

- pinned Bun 1.3.14 focused executor/service: 40/40 PASS, 95 assertions
- negative org-only and codec-valid mismatch cases prove zero lookup/provider/DB transition
- Biome on four changed files: PASS
- git diff --check: PASS
- the rebase had no overlap in the four correction files

The full PGlite reconciler lane was not claimed locally because the sparse review environment lacked its plugin workspace dependencies. Keep draft until exact-head hosted Cloud/PGlite checks and independent review are green.