### PR TITLE
fix(cloud): bound Discord REST hops in the automation service

### DIFF
--- a/packages/cloud/shared/src/lib/services/discord-automation/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/index.error-policy.test.ts
@@ -30,7 +30,7 @@ mock.module("../../utils/logger", () => ({
   logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
 }));
 
-const { discordAutomationService } = await import("./index");
+const { discordAutomationService, discordFetch } = await import("./index");
 
 const realFetch = globalThis.fetch;
 
@@ -152,5 +152,40 @@ describe("handleBotOAuthCallback — J6 best-effort: channel cache-warm failure 
     expect(result.guildId).toBe(guildId);
     // The guild was persisted even though channel warm-up threw.
     expect(guildUpsert).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("discordFetch — bounded hops fail closed and keep caller signals", () => {
+  it("aborts a hung Discord API hop at the timeout", async () => {
+    // A Discord API that never settles on its own: the only way out is the
+    // caller's AbortSignal firing (the 25s default matches the send path).
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as unknown as typeof fetch;
+
+    const start = Date.now();
+    await expect(
+      discordFetch("https://discord.com/api/v10/guilds/g1", undefined, 100),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  it("preserves a caller-provided abort signal", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen = init?.signal;
+      return jsonResponse({ ok: true });
+    }) as unknown as typeof fetch;
+
+    const controller = new AbortController();
+    await discordFetch("https://discord.com/api/v10/users/@me", {
+      signal: controller.signal,
+    });
+    expect(seen).toBe(controller.signal);
   });
 });

--- a/packages/cloud/shared/src/lib/services/discord-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/index.ts
@@ -28,6 +28,24 @@ import type {
 const DISCORD_API_BASE = "https://discord.com/api/v10";
 const _DISCORD_CDN_BASE = "https://cdn.discordapp.com";
 
+const DISCORD_REQUEST_TIMEOUT_MS = 25_000;
+
+/**
+ * Bound every Discord REST hop so a hung or rate-limited Discord API cannot
+ * pin the calling worker indefinitely. Matches the 25s bound the message-send
+ * path already applies; a caller-provided abort signal wins.
+ */
+export function discordFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = DISCORD_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
+
 // Required environment variables
 const DISCORD_CLIENT_ID = process.env.DISCORD_CLIENT_ID;
 const DISCORD_CLIENT_SECRET = process.env.DISCORD_CLIENT_SECRET;
@@ -161,7 +179,7 @@ class DiscordAutomationService {
 
     let tokenData: DiscordTokenResponse;
     try {
-      const tokenResponse = await fetch(`${DISCORD_API_BASE}/oauth2/token`, {
+      const tokenResponse = await discordFetch(`${DISCORD_API_BASE}/oauth2/token`, {
         method: "POST",
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
@@ -201,12 +219,12 @@ class DiscordAutomationService {
 
     try {
       const [userResponse, guildsResponse] = await Promise.all([
-        fetch(`${DISCORD_API_BASE}/users/@me`, {
+        discordFetch(`${DISCORD_API_BASE}/users/@me`, {
           headers: {
             Authorization: `Bearer ${tokenData.access_token}`,
           },
         }),
-        fetch(`${DISCORD_API_BASE}/users/@me/guilds`, {
+        discordFetch(`${DISCORD_API_BASE}/users/@me/guilds`, {
           headers: {
             Authorization: `Bearer ${tokenData.access_token}`,
           },
@@ -304,7 +322,7 @@ class DiscordAutomationService {
       }
 
       // Fetch guild info using bot token
-      const guildResponse = await fetch(`${DISCORD_API_BASE}/guilds/${args.guildId}`, {
+      const guildResponse = await discordFetch(`${DISCORD_API_BASE}/guilds/${args.guildId}`, {
         headers: {
           Authorization: `Bot ${DISCORD_BOT_TOKEN}`,
         },
@@ -397,7 +415,7 @@ class DiscordAutomationService {
     }
 
     try {
-      const response = await fetch(`${DISCORD_API_BASE}/guilds/${guildId}/members/@me`, {
+      const response = await discordFetch(`${DISCORD_API_BASE}/guilds/${guildId}/members/@me`, {
         method: "PATCH",
         headers: {
           Authorization: `Bot ${DISCORD_BOT_TOKEN}`,
@@ -500,7 +518,7 @@ class DiscordAutomationService {
       throw new Error("[Discord] Cannot refresh channels: bot token not configured");
     }
 
-    const response = await fetch(`${DISCORD_API_BASE}/guilds/${guildId}/channels`, {
+    const response = await discordFetch(`${DISCORD_API_BASE}/guilds/${guildId}/channels`, {
       headers: {
         Authorization: `Bot ${DISCORD_BOT_TOKEN}`,
       },
@@ -666,7 +684,7 @@ class DiscordAutomationService {
 
     try {
       // Try to leave the guild via API
-      const response = await fetch(`${DISCORD_API_BASE}/users/@me/guilds/${guildId}`, {
+      const response = await discordFetch(`${DISCORD_API_BASE}/users/@me/guilds/${guildId}`, {
         method: "DELETE",
         headers: {
           Authorization: `Bot ${DISCORD_BOT_TOKEN}`,
@@ -720,7 +738,7 @@ class DiscordAutomationService {
     if (!DISCORD_BOT_TOKEN) return false;
 
     try {
-      const response = await fetch(`${DISCORD_API_BASE}/channels/${channelId}`, {
+      const response = await discordFetch(`${DISCORD_API_BASE}/channels/${channelId}`, {
         headers: {
           Authorization: `Bot ${DISCORD_BOT_TOKEN}`,
         },


### PR DESCRIPTION
## Problem

Eight of the nine Discord REST fetches in `discord-automation` had **no timeout at all**: OAuth token exchange, user/guild identity lookup, guild info, member PATCH, channel listing, guild leave, and channel delete. A hung or rate-limited Discord API (connection never closes) pins the calling Worker indefinitely — the bot-add OAuth flow, channel refresh, and guild-leave paths all stall.

The message-send path was already bounded (`Promise.race` + 25s) — the other eight hops just never got the same treatment.

## Fix

- Add `discordFetch(input, init, timeoutMs = 25_000)`: fails closed at a **25s hop timeout, matching the bound the message-send path already applies**, and preserves any caller-provided abort signal.
- Route all eight unbounded hops through it. The message-send path keeps its existing 25s `Promise.race` bound (unchanged behavior).

One module, one bounded behavior: no Discord REST hop in the automation service can hang forever.

## Tests

`index.error-policy.test.ts` (7 pass):

- new: **`discordFetch` aborts a hung Discord API hop at the timeout** — a fetch that never settles is rejected with `AbortError` at the configured 100ms timeout (elapsed asserted < 5s).
- new: **`discordFetch` preserves a caller-provided abort signal** — the caller's signal passes through untouched.
- existing error-policy tests (fail-closed propagation, designed-empty guild, bot-add best-effort) all still pass.

## Verification

```bash
bun test --isolate src/lib/services/discord-automation/index.error-policy.test.ts
# 7 pass, 0 fail
bunx biome check packages/cloud/shared/src/lib/services/discord-automation/
# no issues
```
