### PR TITLE
fix(coding-tools): keep surrogate pairs intact in truncate

### DIFF
--- a/plugins/plugin-coding-tools/src/lib/format.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.test.ts
@@ -104,6 +104,40 @@ describe("truncate", () => {
     expect(r.text.startsWith("abcd")).toBe(true);
     expect(r.text).toContain("6 more chars");
   });
+  it("keeps UTF-16 surrogate pairs intact at the truncation boundary", () => {
+    const s = `${"a".repeat(9)}🦊${"b".repeat(100)}`;
+    const r = truncate(s, 10);
+    expect(r.truncated).toBe(true);
+    expect(r.text.startsWith("a".repeat(9))).toBe(true);
+    expect(r.text.split("\n")[0].isWellFormed()).toBe(true);
+    expect(r.text.split("\n")[0].length).toBe(9);
+  });
+  it("preserves a fitting emoji under the cap", () => {
+    const s = `${"a".repeat(8)}🦊`;
+    const r = truncate(s, 10);
+    expect(r.truncated).toBe(false);
+    expect(r.text).toBe(s);
+    expect(r.text.isWellFormed()).toBe(true);
+  });
+  it("sanitizes lone surrogates before truncating", () => {
+    const s = "a\ud800bcdef";
+    const r = truncate(s, 4);
+    expect(r.text.split("\n")[0]).toBe("a\ufffdbc");
+    expect(r.text.split("\n")[0].isWellFormed()).toBe(true);
+  });
+  it("sanitizes lone surrogates without truncation when under the cap", () => {
+    const s = "a\ud800bc";
+    const r = truncate(s, 10);
+    expect(r.truncated).toBe(false);
+    expect(r.text).toBe("a\ufffdbc");
+    expect(r.text.isWellFormed()).toBe(true);
+  });
+  it("returns empty well-formed text when max is 0", () => {
+    const r = truncate("hello", 0);
+    expect(r.truncated).toBe(true);
+    expect(r.text.split("\n")[0]).toBe("");
+    expect(r.text.split("\n")[0].isWellFormed()).toBe(true);
+  });
 });
 
 describe("readPositiveIntSetting", () => {

--- a/plugins/plugin-coding-tools/src/lib/format.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.ts
@@ -6,6 +6,7 @@
  * success/failure shape identical.
  */
 import type { ActionResult, IAgentRuntime } from "@elizaos/core";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   type ActionResultData,
   FAILURE_TEXT_PREFIX,
@@ -151,9 +152,10 @@ export function truncate(
   s: string,
   max: number,
 ): { text: string; truncated: boolean } {
-  if (s.length <= max) return { text: s, truncated: false };
+  const wellFormed = toWellFormedUnicode(s);
+  if (wellFormed.length <= max) return { text: wellFormed, truncated: false };
   return {
-    text: `${s.slice(0, max)}\n…[truncated, ${s.length - max} more chars]`,
+    text: `${truncateWellFormed(wellFormed, max)}\n…[truncated, ${wellFormed.length - max} more chars]`,
     truncated: true,
   };
 }


### PR DESCRIPTION
Fixes #23450

## Summary

- Fix `plugins/plugin-coding-tools/src/lib/format.ts:156` `truncate` to use `toWellFormedUnicode` + `truncateWellFormed` so capping to `max` never splits an astral surrogate pair (e.g. 🦊 `\uD83E\uDD8A`) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict JSON consumers reject. Handles under-cap sanitization (`\ud800`→`\ufffd`) and preserves `wellFormed.length` in suffix count.

Same class as approved #23241 (slack), #23227 (telegram), #23277 (agent), #23284 (shared), #23437 (telegram clamp), #23441 (notes), #23445 (zerollama), #23448 (instagram) — identical `toWellFormedUnicode` → `truncateWellFormed` pattern; `truncate` output is returned as `ActionResult.text` via `POST /api/*`.

## Changes

| File | Change |
|------|--------|
| `plugins/plugin-coding-tools/src/lib/format.ts` | Import `toWellFormedUnicode`/`truncateWellFormed`, rewrite `truncate` to sanitize + well-formed truncate; suffix uses `wellFormed.length` |
| `plugins/plugin-coding-tools/src/lib/format.test.ts` | +34 lines — 5 tests: string boundary 🦊→9, fitting emoji, lone `\ud800`→`\ufffd` with/without truncation, max 0 |

## Verification

- Rebased onto `origin/develop@9f3887c0f7` — zero conflicts
- `bunx biome check` — 2 files clean (no fixes)
- `bun --cwd plugins/plugin-coding-tools test src/lib/format.test.ts` — **43 passed, 0 failed** incl. 5 new `isWellFormed()` cases (was 38)
- `git show b00979a7436cd3cec0d4925504bf7917d9efce91:plugins/plugin-coding-tools/src/lib/format.ts` verifies import + `wellFormed` early return + `truncateWellFormed`

## Evidence Gate

<!-- evidence-head:b00979a7436cd3cec0d4925504bf7917d9efce91 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; `truncate` is headless text truncation for `ActionResult.text` callback.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; same as before.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior is proven by deterministic surrogate unit tests.

<!-- evidence-row:backend-logs -->
- [x] Real surrogate-aware truncate paths exercised via Vitest:

```log
bun --cwd plugins/plugin-coding-tools test src/lib/format.test.ts
vitest v4.1.5
 Test Files  1 passed (1)
      Tests  43 passed (43)
   Duration  2.61s (4ms tests)
 5 new isWellFormed() cases: 9+'🦊'→9, fitting 8+'🦊', lone '\ud800', max 0
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved; truncate is server-side with no browser console/network trace.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model delegation change beyond ActionResult text hygiene; no live-model trajectory to link (deterministic truncation unit coverage).

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = surrogate-safe ActionResult wiring, proven by 5 deterministic tests:

```log
each test asserts .isWellFormed() === true and length <=max
boundary: "a".repeat(9)+"🦊"+"b".repeat(100) at 10 → "a".repeat(9) (backoff) + suffix
fitting: "a".repeat(8)+"🦊" at 10 → kept intact, truncated:false
lone: "a\ud800bcdef" at 4 → "a\ufffdbc" + suffix, "a\ud800bc" at 10 → "a\ufffdbc"
max 0 → "" + suffix
all 5 pass; without fix the 9+🦊 case would emit lone \uD83E and fail isWellFormed()
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface; no OCR text to review.

# Risks

Low — single-function hygiene in `truncate` only (coding-tools ActionResult). No shell, no destructive gate, no path logic. Narrow import of two well-formed helpers already used by 8 precedents; atomic `+38/-2` churn.

# Background

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-coding-tools/src/lib/format.ts:7-20` (import + `truncate`) and `plugins/plugin-coding-tools/src/lib/format.test.ts:18-55` (5 new cases).

## Detailed testing steps

- `bun --cwd plugins/plugin-coding-tools test src/lib/format.test.ts` — expect 43/43 incl. 5 new `isWellFormed()`
- `bunx biome check plugins/plugin-coding-tools/src/lib/format.ts plugins/plugin-coding-tools/src/lib/format.test.ts` — expect `Checked 2 files … No fixes applied.`

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@9f3887c0f7cdd537a9b50c886e261a392671a050:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@9f3887c0f7cdd537a9b50c886e261a392671a050:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — coding-tools]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@9f3887c0f7cdd537a9b50c886e261a392671a050:packages/skills/skills/contribute-to-eliza"} -->
