### PR TITLE
fix(core): build the revision copy without Array#with

### DIFF
--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -920,8 +920,15 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		this.memoriesById.set(String(params.documentId), replacement);
 		for (const [key, list] of this.memoriesByRoom) {
 			const index = list.findIndex((memory) => memory.id === params.documentId);
-			if (index >= 0)
-				this.memoriesByRoom.set(key, list.with(index, replacement));
+			// Copy-on-write so a concurrent reader holding the old array still sees a
+			// coherent generation. Built by hand rather than with Array#with: core is
+			// consumed by packages that target ES2022, where that method's lib
+			// declaration is absent and the workspace typecheck fails.
+			if (index >= 0) {
+				const next = list.slice();
+				next[index] = replacement;
+				this.memoriesByRoom.set(key, next);
+			}
 		}
 		for (const fragment of params.fragments) {
 			this.memoriesById.set(String(fragment.id), fragment);


### PR DESCRIPTION
# Relates to

Refs #16021. Fix-forward for a workspace typecheck break introduced by #23365.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from latest `origin/develop`; zero conflicts.

# Risks

Low. One expression rewritten to an equivalent copy; no behavior change.

# Background

## What does this PR do?

`replaceDocumentRevision` in `packages/core/src/database/inMemoryAdapter.ts` used `Array.prototype.with`, an ES2023 method. `packages/agent/tsconfig.json` sets `"target": "ES2022"` and no explicit `lib`, so TypeScript resolves its lib to ES2022, where that method has no declaration:

```
../core/src/database/inMemoryAdapter.ts(924,39): error TS2550: Property 'with' does not exist on type 'Memory[]'.
```

That breaks `bun run --cwd packages/agent typecheck` on develop today. This builds the copy-on-write array by hand (`slice()` then index assignment) so the code is independent of any consumer's target, and records the constraint in a comment so the method is not reintroduced.

## What kind of change is this?

Bug fix (build/typecheck regression).

# Testing

`plugins/plugin-inmemorydb` `document-list.test.ts` at this head: **7/7 passed** — the suite that covers `replaceDocumentRevision`'s atomic swap and read barrier.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - in-memory adapter internals, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - in-memory adapter internals, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - the failure is a compile-time diagnostic, quoted above; the test receipt covers runtime behavior.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/prompt/action behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - document revision rows are asserted directly by the suite above.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [core-inmemory]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza"} -->
