### PR TITLE
fix(cloud): bound X/Twitter REST hops in the social-media provider

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/providers/twitter.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/twitter.error-policy.test.ts
@@ -45,7 +45,7 @@ mock.module("../rate-limit", () => ({
   },
 }));
 
-const { twitterProvider } = await import("./twitter");
+const { twitterProvider, twitterFetch } = await import("./twitter");
 
 const CREDS = { accessToken: "tok" } as SocialCredentials;
 
@@ -180,5 +180,40 @@ describe("twitterProvider J1 boundaries — upstream failure becomes a structure
     const result = await twitterProvider.deletePost?.(CREDS, "post-1");
     expect(result?.success).toBe(false);
     expect(result?.error).toContain("not found");
+  });
+});
+
+describe("twitterFetch — bounded hops fail closed and keep caller signals", () => {
+  it("aborts a hung X/Twitter API hop at the timeout", async () => {
+    // An API that never settles on its own: the only way out is the caller's
+    // AbortSignal firing (the 30s default bounds every media-upload hop).
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as unknown as typeof fetch;
+
+    const start = Date.now();
+    await expect(
+      twitterFetch("https://upload.twitter.com/media/upload.json", undefined, 100),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  it("preserves a caller-provided abort signal", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen = init?.signal;
+      return okJson({ media_id_string: "m1" });
+    }) as unknown as typeof fetch;
+
+    const controller = new AbortController();
+    await twitterFetch("https://upload.twitter.com/media/upload.json", {
+      signal: controller.signal,
+    });
+    expect(seen).toBe(controller.signal);
   });
 });

--- a/packages/cloud/shared/src/lib/services/social-media/providers/twitter.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/twitter.ts
@@ -15,6 +15,23 @@ import { TWITTER_API_BASE, TWITTER_UPLOAD_BASE } from "../../../utils/twitter-ap
 import { downloadSocialMediaBytes } from "../media-download";
 import { withRetry } from "../rate-limit";
 
+const TWITTER_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Bound every X/Twitter REST hop so a hung or rate-limited API cannot pin the
+ * publishing worker indefinitely. A caller-provided abort signal wins.
+ */
+export function twitterFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = TWITTER_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
+
 // Wrapped with retry logic for social media provider
 async function twitterApiRequest<T>(
   endpoint: string,
@@ -24,7 +41,7 @@ async function twitterApiRequest<T>(
   const url = endpoint.startsWith("http") ? endpoint : `${TWITTER_API_BASE}${endpoint}`;
   const { data } = await withRetry<T>(
     () =>
-      fetch(url, {
+      twitterFetch(url, {
         ...options,
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -57,7 +74,7 @@ async function uploadMedia(accessToken: string, media: MediaAttachment): Promise
     formData.append("media_data", mediaData.toString("base64"));
     formData.append("media_category", mediaType);
 
-    const response = await fetch(`${TWITTER_UPLOAD_BASE}/media/upload.json`, {
+    const response = await twitterFetch(`${TWITTER_UPLOAD_BASE}/media/upload.json`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -82,10 +99,13 @@ async function uploadMedia(accessToken: string, media: MediaAttachment): Promise
     media_category: mediaType,
   });
 
-  const initResponse = await fetch(`${TWITTER_UPLOAD_BASE}/media/upload.json?${initParams}`, {
-    method: "POST",
-    headers: { Authorization: `Bearer ${accessToken}` },
-  });
+  const initResponse = await twitterFetch(
+    `${TWITTER_UPLOAD_BASE}/media/upload.json?${initParams}`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${accessToken}` },
+    },
+  );
 
   if (!initResponse.ok) {
     throw new Error("Media upload INIT failed");
@@ -108,11 +128,14 @@ async function uploadMedia(accessToken: string, media: MediaAttachment): Promise
     const chunkBytes = Uint8Array.from(chunk);
     formData.append("media", new Blob([chunkBytes]));
 
-    const appendResponse = await fetch(`${TWITTER_UPLOAD_BASE}/media/upload.json?${appendParams}`, {
-      method: "POST",
-      headers: { Authorization: `Bearer ${accessToken}` },
-      body: formData,
-    });
+    const appendResponse = await twitterFetch(
+      `${TWITTER_UPLOAD_BASE}/media/upload.json?${appendParams}`,
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${accessToken}` },
+        body: formData,
+      },
+    );
 
     if (!appendResponse.ok) {
       throw new Error(`Media upload APPEND failed at segment ${segmentIndex}`);
@@ -125,7 +148,7 @@ async function uploadMedia(accessToken: string, media: MediaAttachment): Promise
     media_id: mediaId,
   });
 
-  const finalizeResponse = await fetch(
+  const finalizeResponse = await twitterFetch(
     `${TWITTER_UPLOAD_BASE}/media/upload.json?${finalizeParams}`,
     {
       method: "POST",
@@ -159,9 +182,12 @@ async function waitForProcessing(
       media_id: mediaId,
     });
 
-    const response = await fetch(`${TWITTER_UPLOAD_BASE}/media/upload.json?${statusParams}`, {
-      headers: { Authorization: `Bearer ${accessToken}` },
-    });
+    const response = await twitterFetch(
+      `${TWITTER_UPLOAD_BASE}/media/upload.json?${statusParams}`,
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+    );
 
     const data = (await response.json()) as {
       processing_info?: {


### PR DESCRIPTION
## Problem

Every X/Twitter fetch in the social-media provider had **no timeout**: the general API request (`twitterApiRequest`, inside `withRetry` — a hung fetch never settles so the retry loop can't even fire) and the whole media-upload pipeline (image upload, video INIT, per-segment APPEND, FINALIZE, and STATUS polling). A hung or rate-limited X API pins the publishing worker forever, so posts with media can stall indefinitely.

## Fix

- Add `twitterFetch(input, init, timeoutMs = 30_000)`: fails closed at a **30s hop timeout**, preserving any caller-provided abort signal.
- Route all six fetch sites through it — including the `withRetry` callback, so **each retry attempt is individually bounded** (worst case: 3 bounded attempts instead of infinite hang).

One module, one bounded behavior: no X/Twitter hop in the publishing path can hang forever.

## Tests

`twitter.error-policy.test.ts` (11 pass):

- new: **`twitterFetch` aborts a hung X/Twitter API hop at the timeout** — a fetch that never settles is rejected with `AbortError` at the configured 100ms timeout (elapsed asserted < 5s).
- new: **`twitterFetch` preserves a caller-provided abort signal** — the caller's signal passes through untouched.
- existing error-policy tests (structured failure DTOs, credentials validation, delete) all still pass.

## Verification

```bash
bun test --isolate src/lib/services/social-media/providers/twitter.error-policy.test.ts
# 11 pass, 0 fail
bunx biome check packages/cloud/shared/src/lib/services/social-media/providers/twitter.ts
# no issues
```
