### PR TITLE
fix(plugin-google-workspace): unfold folded RFC 5322 address headers before parsing

### DIFF
--- a/plugins/plugin-google-workspace/src/gmail-address-fold.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-address-fold.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression tests proving RFC 5322 §2.2.3 folded address headers (CRLF + WSP
+ * continuations) parse identically to their unfolded spelling on both the
+ * `getMessage`/`searchMessages` path via `mapMessage` and the rich triage path
+ * via `mapRichMessage`/`getGmailMessageDetail`. Before unfolding, a fold
+ * between the display name and the angle-addr defeated `parseMailbox`'s
+ * single-line regex and the whole mailbox was silently dropped (`Unknown
+ * sender` on the rich path); a fold inside a quoted string or quoted local
+ * part embedded the literal line break into the parsed value. Uses the real
+ * `GoogleGmailClient` with a stubbed client factory returning fixed
+ * `messages.get` payloads; deterministic, no network.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { GoogleApiClientFactory } from "./client-factory.js";
+import { GoogleGmailClient } from "./gmail.js";
+
+function clientReturning(data: Record<string, unknown>): GoogleGmailClient {
+  const get = vi.fn().mockResolvedValue({ data });
+  const factory = {
+    gmail: vi.fn().mockResolvedValue({ users: { messages: { get } } }),
+  } as unknown as GoogleApiClientFactory;
+  return new GoogleGmailClient(factory);
+}
+
+function messageWithHeaders(
+  headers: Array<{ name: string; value: string }>
+): Record<string, unknown> {
+  return {
+    id: "m1",
+    threadId: "t1",
+    snippet: "hi",
+    labelIds: ["INBOX"],
+    internalDate: "0",
+    payload: { headers },
+  };
+}
+
+describe("mapMessage folded (RFC 5322 2.2.3) address headers", () => {
+  it("parses a folded From display name identically to the unfolded spelling", async () => {
+    const client = clientReturning(
+      messageWithHeaders([
+        { name: "From", value: "Jane Smith\r\n <jane@corp.com>" },
+        { name: "To", value: "me@corp.com" },
+      ])
+    );
+    const msg = await client.getMessage({ accountId: "a1", messageId: "m1" });
+    expect(msg.from).toEqual({ email: "jane@corp.com", name: "Jane Smith" });
+  });
+
+  it("parses a folded To list with display names into distinct addresses", async () => {
+    const client = clientReturning(
+      messageWithHeaders([
+        { name: "From", value: "sender@corp.com" },
+        {
+          name: "To",
+          value: "Jane Smith\r\n <jane@corp.com>, Bob\r\n Doe <bob@x.com>",
+        },
+        { name: "Cc", value: "Carol\r\n <carol@y.com>" },
+        { name: "Reply-To", value: "Reply Desk\r\n <replies@corp.com>" },
+      ])
+    );
+    const msg = await client.getMessage({ accountId: "a1", messageId: "m1" });
+    expect(msg.to).toEqual([
+      { email: "jane@corp.com", name: "Jane Smith" },
+      { email: "bob@x.com", name: "Bob Doe" },
+    ]);
+    expect(msg.cc).toEqual([{ email: "carol@y.com", name: "Carol" }]);
+    expect(msg.replyTo).toEqual({ email: "replies@corp.com", name: "Reply Desk" });
+  });
+
+  it("keeps a folded quoted display name without embedding the line break", async () => {
+    const client = clientReturning(
+      messageWithHeaders([
+        { name: "From", value: "sender@corp.com" },
+        { name: "To", value: '"Doe,\r\n Jane" <jane@corp.com>' },
+      ])
+    );
+    const msg = await client.getMessage({ accountId: "a1", messageId: "m1" });
+    expect(msg.to).toEqual([{ email: "jane@corp.com", name: "Doe, Jane" }]);
+  });
+
+  it("preserves a folded quoted local part", async () => {
+    const client = clientReturning(
+      messageWithHeaders([
+        { name: "From", value: "sender@corp.com" },
+        { name: "To", value: '"weird\r\n name"@example.com' },
+      ])
+    );
+    const msg = await client.getMessage({ accountId: "a1", messageId: "m1" });
+    expect(msg.to).toEqual([{ email: '"weird name"@example.com' }]);
+  });
+
+  it("unfolds LF-only continuations the same way as CRLF folds", async () => {
+    const client = clientReturning(
+      messageWithHeaders([
+        { name: "From", value: "Jane Smith\n <jane@corp.com>" },
+        { name: "To", value: "me@corp.com" },
+      ])
+    );
+    const msg = await client.getMessage({ accountId: "a1", messageId: "m1" });
+    expect(msg.from).toEqual({ email: "jane@corp.com", name: "Jane Smith" });
+  });
+
+  it("still fails closed on a fold inside an addr-spec domain", async () => {
+    const client = clientReturning(
+      messageWithHeaders([
+        { name: "From", value: "sender@corp.com" },
+        { name: "To", value: "<jane@\r\n corp.com>" },
+      ])
+    );
+    const msg = await client.getMessage({ accountId: "a1", messageId: "m1" });
+    expect(msg.to).toEqual([]);
+  });
+});
+
+describe("mapRichMessage folded address headers", () => {
+  it("resolves a folded rich-path From to the real sender, not 'Unknown sender'", async () => {
+    const client = clientReturning(
+      messageWithHeaders([
+        { name: "From", value: "Jane Smith\r\n <jane@corp.com>" },
+        { name: "To", value: "me@corp.com" },
+      ])
+    );
+    const detail = await client.getGmailMessageDetail({ accountId: "a1", messageId: "m1" });
+    expect(detail?.message.from).toBe("Jane Smith");
+    expect(detail?.message.fromEmail).toBe("jane@corp.com");
+  });
+
+  it("keeps folded To display names on the rich path", async () => {
+    const client = clientReturning(
+      messageWithHeaders([
+        { name: "From", value: "sender@corp.com" },
+        { name: "To", value: "Jane Smith\r\n <jane@corp.com>, bob@x.com" },
+      ])
+    );
+    const detail = await client.getGmailMessageDetail({ accountId: "a1", messageId: "m1" });
+    expect(detail?.message.to).toEqual(["jane@corp.com", "bob@x.com"]);
+  });
+});

--- a/plugins/plugin-google-workspace/src/gmail-address-fold.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail-address-fold.test.ts
@@ -111,6 +111,41 @@ describe("mapMessage folded (RFC 5322 2.2.3) address headers", () => {
     const msg = await client.getMessage({ accountId: "a1", messageId: "m1" });
     expect(msg.to).toEqual([]);
   });
+
+  it("treats a line break without a WSP continuation as malformed, not a fold", async () => {
+    const client = clientReturning(
+      messageWithHeaders([
+        { name: "From", value: "sender@corp.com" },
+        { name: "To", value: "a@x.com\r\nb@y.com" },
+      ])
+    );
+    const msg = await client.getMessage({ accountId: "a1", messageId: "m1" });
+    expect(msg.to).toEqual([]);
+  });
+
+  it("drops a mailbox whose angle-addr is split by a bare line break", async () => {
+    const client = clientReturning(
+      messageWithHeaders([
+        { name: "From", value: "Jane\r\n<jane@corp.com>" },
+        { name: "To", value: "me@corp.com" },
+      ])
+    );
+    const msg = await client.getMessage({ accountId: "a1", messageId: "m1" });
+    expect(msg.from).toBeUndefined();
+  });
+
+  it("unfolds tab continuations and consecutive obs-folds", async () => {
+    const client = clientReturning(
+      messageWithHeaders([
+        { name: "From", value: "sender@corp.com" },
+        { name: "To", value: "Jane\r\n\t Smith\r\n <jane@corp.com>" },
+      ])
+    );
+    const msg = await client.getMessage({ accountId: "a1", messageId: "m1" });
+    // Unfolding removes only the CRLF; the retained WSP (tab, space) stays in
+    // the display name, matching the unfolded spelling with the same runs.
+    expect(msg.to).toEqual([{ email: "jane@corp.com", name: "Jane\t Smith" }]);
+  });
 });
 
 describe("mapRichMessage folded address headers", () => {

--- a/plugins/plugin-google-workspace/src/gmail.ts
+++ b/plugins/plugin-google-workspace/src/gmail.ts
@@ -746,6 +746,16 @@ function splitAddressList(value: string): string[] {
     return [];
   }
 
+  // RFC 5322 2.2.3 folds long header lines as CRLF followed by WSP; the
+  // continuation is part of the same logical value, not a structural break.
+  // Unfold before scanning so a fold between a display name and its angle-addr
+  // (or inside a quoted string) cannot split the mailbox: `parseMailbox`'s
+  // address regex does not cross line breaks, so an unfolded fold silently
+  // dropped the whole mailbox. Only CRLF/LF directly followed by space or tab
+  // is a fold; a bare line break elsewhere stays malformed and fails closed
+  // below.
+  value = value.replace(/\r?\n(?=[ \t])/g, "");
+
   const tokens: string[] = [];
   let current = "";
   let inQuote = false;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Fixes #23442

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3` (implementation) + `CC Zai/opus` (RepoPrompt CE independent review agent)
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. One-line, deletion-only preprocessing step inside `splitAddressList` in a
single plugin. The unfold removes CRLF/LF **only** when immediately followed by
WSP (RFC 5322 §2.2.3 obs-fold); every other line break survives and still fails
closed downstream (`isPlausibleEmailAddress` rejects whitespace). Unfolding
happens after the 512 KiB size bound and only ever shortens the string, so no
parser bound is loosened; deletion cannot manufacture commas, so recipient
counts cannot inflate. Previously-accepted unfolded inputs are untouched (the
replace is the identity when no fold sequence is present).

# Background

## What does this PR do?

Gmail folds long address headers as CRLF + WSP continuations (RFC 5322
§2.2.3). The address-list scanner introduced by #23386 never unfolded them, so
a fold between a display name and its angle-addr (e.g. `Jane Smith\r\n
<jane@corp.com>`) defeated `parseMailbox`'s single-line regex
(`^(.*?)<([^<>]+)>\s*$` — `.` cannot cross `\r`/`\n`) and the whole mailbox was
silently dropped: `From` degraded to `Unknown sender` on the rich triage path
and the recipient vanished from `To`/`Cc`/`Reply-To` on both read paths. A fold
inside a quoted string or quoted local part embedded the literal line break
into the parsed value.

The fix unfolds at `splitAddressList` entry, after the size bound:
`value = value.replace(/\r?\n(?=[ \t])/g, "")` — remove the line break, keep
the WSP, exactly per RFC 5322 §2.2.3 ("unfolding is accomplished by simply
removing any CRLF that is immediately followed by WSP"). A bare line break not
followed by WSP stays malformed and fails closed.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-google-workspace/src/gmail-address-fold.test.ts` — 11
deterministic tests using the real `GoogleGmailClient` with a stubbed client
factory (same harness as the #23386 regression suite), covering both read paths
(`getMessage` via `mapMessage`, `getGmailMessageDetail` via `mapRichMessage`).

## Detailed testing steps

Red control (proves the tests bite): at pristine `origin/develop` in an
isolated worktree, 7 of the 8 original tests fail — folded `From` yields
`Unknown sender`, folded `To`/`Cc`/`Reply-To` mailboxes are dropped, folded
quoted names/local parts are mangled. With the fix: 11/11 pass.

```bash
bun install --frozen-lockfile
node packages/shared/scripts/generate-keywords.mjs   # fresh-worktree artifact
bun run --cwd packages/core build                    # plugin typecheck dep
cd plugins/plugin-google-workspace
npx vitest run          # 317/317 (306 pre-existing + 11 new)
bun run typecheck       # tsc --noEmit clean
bun run lint:check      # biome clean
```

Test classes pinned:
- folded From/To/Cc/Reply-To with display names parse identically to the
  unfolded spelling on `mapMessage` and `mapRichMessage` (CRLF and LF-only);
- folded quoted display name and folded quoted local part preserved
  (`"weird\r\n name"@example.com` → `"weird name"@example.com`);
- fail-closed preserved: fold inside an addr-spec domain (`<jane@\r\n
  corp.com>` → `to: []`), **bare line break without WSP is not a fold**
  (`a@x.com\r\nb@y.com` → `to: []`; `Jane\r\n<jane@corp.com>` → `from`
  dropped) — the lookahead is the entire fail-closed boundary of this diff and
  these pin it;
- tab continuation and consecutive obs-folds unfold with RFC-exact WSP
  retention (`Jane\r\n\t Smith\r\n <jane@corp.com>` → name `"Jane\t Smith"`).

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:b9923e69a3ffd07fdca364ed4a4ce238daf9ffce -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - headless parser fix in a server-side plugin; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - headless parser fix in a server-side plugin; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - headless parser fix in a server-side plugin; no user flow to record.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no live server path; inline vitest transcript in PR body covers the full real code path (317/317 at head b9923e69a3, red control 7/8 fail on pristine develop)

<details>
<summary>vitest run — plugin-google-workspace at head b9923e69a3 (post-rebase)</summary>

```
$ npx vitest run
 RUN  v4.1.10 /private/tmp/pr-23442/plugins/plugin-google-workspace

 Test Files  26 passed (26)
      Tests  317 passed (317)
   Start at  04:03:11
   Duration  6.01s

Red control (same tests, pristine origin/develop@4d6789b41c before the fix):
 Test Files  1 failed (1)
      Tests  7 failed | 1 passed (8)   [original 8-test battery]
 - folded From -> "Unknown sender" (rich path)
 - folded To list dropped folded mailboxes -> only unfolded recipient survived
 - folded Cc / Reply-To dropped
 - folded quoted display name mangled
 - folded quoted local part dropped
```
</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface; plugin runs server-side (`"runtime": "node"`).
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model change; MIME header parsing only.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - deterministic parser change; the parsed `GoogleEmailAddress` DTOs
      are asserted directly by the suite (no DB/network/external artifacts).
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change; MIME header parsing only.

## Backend + frontend logs

N/A (frontend); backend evidence is the inline vitest transcript above — the
real `GoogleGmailClient` code path (`mapMessage`/`mapRichMessage` →
`parseEmailAddresses` → `splitAddressList` → `parseMailbox`) exercised end to
end with folded headers at the exact head.

## Screenshots (before / after) + video walkthrough

N/A - headless parser fix in a server-side plugin; no rendered UI surface.

### Before

### After

### Walkthrough video

N/A - no user flow to record.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT surface touched.

## Known gaps / failures

- Root `bun run verify` fails at `@elizaos/app#lint:check` with a **pre-existing
  biome format violation in `packages/app/scripts/lib/android-capture.test.mjs`**,
  committed by the current `origin/develop` tip itself (`4d6789b41c`, #23408 —
  `mkdtempSync` call wrapped across lines vs biome's single-line expectation).
  Reproduced on a clean worktree at the develop tip before this branch's
  changes; this PR touches only `plugins/plugin-google-workspace` and cannot
  affect that file. All 140 other verify tasks that ran before the failure
  passed (17 completed before abort). The owning package's full gates pass:
  317/317 tests, `tsc --noEmit` clean, biome check + format clean.
- Not a blocker for this PR; the app lint failure needs a one-off
  `biome format` fix on develop.

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes/t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza"} -->

