### PR TITLE
fix(cloud): bound Google Ads REST hops in the ad provider

### DIFF
--- a/packages/cloud/shared/src/lib/services/advertising/providers/google.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/google.error-policy.test.ts
@@ -9,7 +9,7 @@ mock.module("../../../utils/logger", () => ({
   logger: { info() {}, warn() {}, error() {}, debug() {} },
 }));
 
-const { googleAdsProvider } = await import("./google");
+const { googleAdsProvider, googleAdsFetch } = await import("./google");
 
 const originalFetch = globalThis.fetch;
 const credentials = { accessToken: "token" };
@@ -121,5 +121,44 @@ describe("googleAdsProvider.getCampaignMetrics money-path distinctness", () => {
       success: true,
       metrics: { spend: 0, impressions: 0, clicks: 0, conversions: 0 },
     });
+  });
+});
+
+describe("googleAdsFetch — bounded hops fail closed and keep caller signals", () => {
+  test("aborts a hung Google Ads API hop at the timeout", async () => {
+    // An API that never settles on its own: the only way out is the caller's
+    // AbortSignal firing (the 30s default bounds every ads / upload hop).
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as unknown as typeof fetch;
+
+    const start = Date.now();
+    await expect(
+      googleAdsFetch(
+        "https://googleads.googleapis.com/v24/customers:listAccessibleCustomers",
+        undefined,
+        100,
+      ),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("preserves a caller-provided abort signal", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen = init?.signal;
+      return jsonResponse({ resourceNames: [] });
+    }) as unknown as typeof fetch;
+
+    const controller = new AbortController();
+    await googleAdsFetch("https://googleads.googleapis.com/v24/customers:listAccessibleCustomers", {
+      signal: controller.signal,
+    });
+    expect(seen).toBe(controller.signal);
   });
 });

--- a/packages/cloud/shared/src/lib/services/advertising/providers/google.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/google.ts
@@ -22,6 +22,23 @@ const GOOGLE_ADS_API_VERSION = process.env.GOOGLE_ADS_API_VERSION || "v24";
 const GOOGLE_ADS_BASE_URL = `https://googleads.googleapis.com/${GOOGLE_ADS_API_VERSION}`;
 const GOOGLE_ADS_RESUMABLE_UPLOAD_BASE_URL = `https://googleads.googleapis.com/resumable/upload/${GOOGLE_ADS_API_VERSION}`;
 
+const GOOGLE_ADS_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Bound every Google Ads REST hop so a hung or rate-limited API cannot pin the
+ * ad-provider worker indefinitely. A caller-provided abort signal wins.
+ */
+export function googleAdsFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = GOOGLE_ADS_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
+
 interface GoogleAdsError {
   error?: {
     code: number;
@@ -46,7 +63,7 @@ async function googleAdsRequest<T>(
 ): Promise<T> {
   const url = `${GOOGLE_ADS_BASE_URL}/customers/${customerId}${endpoint}`;
 
-  const response = await fetch(url, {
+  const response = await googleAdsFetch(url, {
     ...options,
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -221,12 +238,15 @@ export const googleAdsProvider: AdProvider = {
     }
 
     // List accessible customers to validate token
-    const response = await fetch(`${GOOGLE_ADS_BASE_URL}/customers:listAccessibleCustomers`, {
-      headers: {
-        Authorization: `Bearer ${credentials.accessToken}`,
-        "developer-token": process.env.GOOGLE_ADS_DEVELOPER_TOKEN,
+    const response = await googleAdsFetch(
+      `${GOOGLE_ADS_BASE_URL}/customers:listAccessibleCustomers`,
+      {
+        headers: {
+          Authorization: `Bearer ${credentials.accessToken}`,
+          "developer-token": process.env.GOOGLE_ADS_DEVELOPER_TOKEN,
+        },
       },
-    });
+    );
 
     if (!response.ok) {
       return {
@@ -250,7 +270,7 @@ export const googleAdsProvider: AdProvider = {
     refreshToken?: string;
     expiresAt?: Date;
   }> {
-    const response = await fetch("https://oauth2.googleapis.com/token", {
+    const response = await googleAdsFetch("https://oauth2.googleapis.com/token", {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: new URLSearchParams({
@@ -281,12 +301,15 @@ export const googleAdsProvider: AdProvider = {
   async listAdAccounts(
     credentials: AdAccountCredentials,
   ): Promise<Array<{ id: string; name: string }>> {
-    const response = await fetch(`${GOOGLE_ADS_BASE_URL}/customers:listAccessibleCustomers`, {
-      headers: {
-        Authorization: `Bearer ${credentials.accessToken}`,
-        "developer-token": process.env.GOOGLE_ADS_DEVELOPER_TOKEN || "",
+    const response = await googleAdsFetch(
+      `${GOOGLE_ADS_BASE_URL}/customers:listAccessibleCustomers`,
+      {
+        headers: {
+          Authorization: `Bearer ${credentials.accessToken}`,
+          "developer-token": process.env.GOOGLE_ADS_DEVELOPER_TOKEN || "",
+        },
       },
-    });
+    );
 
     if (!response.ok) {
       throw new Error("Failed to list Google Ads accounts");
@@ -699,7 +722,7 @@ export const googleAdsProvider: AdProvider = {
           "X-Goog-Upload-Header-Content-Length": String(downloaded.bytes.byteLength),
           "X-Goog-Upload-Header-Content-Type": downloaded.contentType,
         };
-        const startResponse = await fetch(
+        const startResponse = await googleAdsFetch(
           `${GOOGLE_ADS_RESUMABLE_UPLOAD_BASE_URL}/customers/${accountId}/youTubeVideoUploads:create`,
           {
             method: "POST",
@@ -727,7 +750,7 @@ export const googleAdsProvider: AdProvider = {
           downloaded.bytes.byteOffset,
           downloaded.bytes.byteOffset + downloaded.bytes.byteLength,
         ) as ArrayBuffer;
-        const finalizeResponse = await fetch(uploadUrl, {
+        const finalizeResponse = await googleAdsFetch(uploadUrl, {
           method: "PUT",
           headers: {
             Authorization: `Bearer ${credentials.accessToken}`,


### PR DESCRIPTION
## Problem

Every Google Ads fetch had **no timeout**: the shared `googleAdsRequest` helper, credential token validation, account listing, OAuth token refresh, and the resumable YouTube upload **start / finalize** hops could pin the ad-provider worker forever when the API hung without closing the connection. Ad campaign creation, media uploads, and metrics reads all stall.

## Fix

- Add `googleAdsFetch(input, init, timeoutMs = 30_000)`: fails closed at a **30s hop timeout**, preserving any caller-provided abort signal.
- Route all six fetch sites through it (API request helper, both `listAccessibleCustomers` calls, OAuth token refresh, resumable upload start + finalize).

One module, one bounded behavior: no Google Ads hop can hang forever.

## Tests

`google.error-policy.test.ts` (8 pass):

- new: **`googleAdsFetch` aborts a hung Google Ads API hop at the timeout** — a fetch that never settles is rejected with `AbortError` at the configured 100ms timeout (elapsed asserted < 5s).
- new: **`googleAdsFetch` preserves a caller-provided abort signal** — the caller's signal passes through untouched.
- existing error-surfacing tests (empty-vs-failure distinctness, zeroed metrics) all still pass.

## Verification

```bash
bun test --isolate src/lib/services/advertising/providers/google.error-policy.test.ts
# 8 pass, 0 fail
bunx biome check packages/cloud/shared/src/lib/services/advertising/providers/google.ts
# no issues
```
