### PR TITLE
fix(core): keep surrogate pairs intact in reply context truncation

### DIFF
--- a/packages/core/src/features/basic-capabilities/providers/replyContext.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/replyContext.test.ts
@@ -10,9 +10,29 @@
 import { describe, expect, it, vi } from "vitest";
 import type { IAgentRuntime, Memory, UUID } from "../../../types/index.ts";
 import {
+	MAX_REPLY_TARGET_SNIPPET_CHARS,
+	MAX_REPLY_WINDOW_MESSAGE_CHARS,
 	REPLY_CONTEXT_WINDOW_RADIUS,
 	replyContextProvider,
+	truncateSingleLine,
+	withBoundedText,
 } from "./replyContext.ts";
+
+function isWellFormed(value: string): boolean {
+	for (let index = 0; index < value.length; index += 1) {
+		const codeUnit = value.charCodeAt(index);
+		if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+			const next = value.charCodeAt(index + 1);
+			if (!(next >= 0xdc00 && next <= 0xdfff)) {
+				return false;
+			}
+			index += 1;
+		} else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+			return false;
+		}
+	}
+	return true;
+}
 
 const AGENT_ID = "00000000-0000-0000-0000-000000000001" as UUID;
 const ROOM_ID = "00000000-0000-0000-0000-000000000002" as UUID;
@@ -232,5 +252,88 @@ describe("replyContextProvider", () => {
 		);
 
 		expect(result.text).toBe("");
+	});
+});
+
+describe("truncateSingleLine", () => {
+	it("keeps surrogate pairs intact at the max-1 boundary", () => {
+		const text = `hello${"🦊"}world`;
+		const at7 = truncateSingleLine(text, 7);
+		expect(at7).toBe("hello…");
+		expect(isWellFormed(at7)).toBe(true);
+		expect(at7.length).toBeLessThanOrEqual(7);
+		const at8 = truncateSingleLine(text, 8);
+		expect(at8).toBe("hello🦊…");
+		expect(isWellFormed(at8)).toBe(true);
+		expect(at8.length).toBeLessThanOrEqual(8);
+	});
+
+	it("sanitizes lone surrogates before truncation", () => {
+		const lone = `a\uD800bcdef`;
+		const truncated = truncateSingleLine(lone, 4);
+		expect(truncated).toBe(`a�b…`);
+		expect(isWellFormed(truncated)).toBe(true);
+	});
+
+	it("sanitizes lone surrogate without truncation", () => {
+		const lone = `a\uD800bc`;
+		const out = truncateSingleLine(lone, 10);
+		expect(out).toBe(`a�bc`);
+		expect(isWellFormed(out)).toBe(true);
+	});
+
+	it("collapses whitespace and trims before well-formed check", () => {
+		const text = `  hello   \n  world  `;
+		const out = truncateSingleLine(text, 20);
+		expect(out).toBe("hello world");
+		expect(isWellFormed(out)).toBe(true);
+	});
+
+	it("honors the 300-char reply target cap and never emits lone surrogates", () => {
+		const emoji = "🦊";
+		const long =
+			`a`.repeat(MAX_REPLY_TARGET_SNIPPET_CHARS - 1) + emoji + `b`.repeat(10);
+		const out = truncateSingleLine(long, MAX_REPLY_TARGET_SNIPPET_CHARS);
+		expect(out.length).toBeLessThanOrEqual(MAX_REPLY_TARGET_SNIPPET_CHARS);
+		expect(out.endsWith("…")).toBe(true);
+		expect(isWellFormed(out)).toBe(true);
+	});
+});
+
+describe("withBoundedText", () => {
+	it("keeps surrogate pairs intact at the 1000-char window cap", () => {
+		const emoji = "🦊";
+		const text =
+			`a`.repeat(MAX_REPLY_WINDOW_MESSAGE_CHARS - 1) + emoji + `tail`;
+		const bounded = withBoundedText(mem("m1", USER_ID, text, 100));
+		const out = bounded.content.text as string;
+		expect(out.length).toBeLessThanOrEqual(MAX_REPLY_WINDOW_MESSAGE_CHARS);
+		expect(out.endsWith("…")).toBe(true);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out).not.toContain("\uD83E");
+	});
+
+	it("sanitizes lone surrogates in window text", () => {
+		const lone = `x\uD800` + `y`.repeat(2000);
+		const bounded = withBoundedText(mem("m2", USER_ID, lone, 200));
+		const out = bounded.content.text as string;
+		expect(out).toContain("�");
+		expect(isWellFormed(out)).toBe(true);
+	});
+
+	it("returns same reference when already well-formed and under limit", () => {
+		const text = "short well-formed";
+		const memory = mem("m3", USER_ID, text, 300);
+		const bounded = withBoundedText(memory);
+		expect(bounded).toBe(memory);
+	});
+
+	it("returns new memory with sanitized text when lone surrogate present under limit", () => {
+		const lone = `ok \uD800 end`;
+		const memory = mem("m4", USER_ID, lone, 400);
+		const bounded = withBoundedText(memory);
+		expect(bounded).not.toBe(memory);
+		expect(bounded.content.text).toBe(`ok � end`);
+		expect(isWellFormed(bounded.content.text as string)).toBe(true);
 	});
 });

--- a/packages/core/src/features/basic-capabilities/providers/replyContext.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/replyContext.test.ts
@@ -256,16 +256,17 @@ describe("replyContextProvider", () => {
 });
 
 describe("truncateSingleLine", () => {
-	it("keeps surrogate pairs intact at the max-1 boundary", () => {
-		const text = `hello${"🦊"}world`;
-		const at7 = truncateSingleLine(text, 7);
-		expect(at7).toBe("hello…");
-		expect(isWellFormed(at7)).toBe(true);
-		expect(at7.length).toBeLessThanOrEqual(7);
-		const at8 = truncateSingleLine(text, 8);
-		expect(at8).toBe("hello🦊…");
-		expect(isWellFormed(at8)).toBe(true);
-		expect(at8.length).toBeLessThanOrEqual(8);
+	it("keeps surrogate pairs intact at exact and max-plus-one bounds", () => {
+		const exact = "hello🦊";
+		expect(exact.length).toBe(7);
+		expect(truncateSingleLine(exact, 7)).toBe(exact);
+
+		const maxPlusOne = `${exact}b`;
+		expect(maxPlusOne.length).toBe(8);
+		const truncated = truncateSingleLine(maxPlusOne, 7);
+		expect(truncated).toBe("hello…");
+		expect(isWellFormed(truncated)).toBe(true);
+		expect(truncated.length).toBeLessThanOrEqual(7);
 	});
 
 	it("sanitizes lone surrogates before truncation", () => {
@@ -275,11 +276,12 @@ describe("truncateSingleLine", () => {
 		expect(isWellFormed(truncated)).toBe(true);
 	});
 
-	it("sanitizes lone surrogate without truncation", () => {
-		const lone = `a\uD800bc`;
-		const out = truncateSingleLine(lone, 10);
-		expect(out).toBe(`a�bc`);
-		expect(isWellFormed(out)).toBe(true);
+	it("sanitizes either lone surrogate half without truncation", () => {
+		for (const lone of [`a\uD800bc`, `a\uDC00bc`]) {
+			const out = truncateSingleLine(lone, 10);
+			expect(out).toBe(`a�bc`);
+			expect(isWellFormed(out)).toBe(true);
+		}
 	});
 
 	it("collapses whitespace and trims before well-formed check", () => {
@@ -301,11 +303,15 @@ describe("truncateSingleLine", () => {
 });
 
 describe("withBoundedText", () => {
-	it("keeps surrogate pairs intact at the 1000-char window cap", () => {
-		const emoji = "🦊";
-		const text =
-			`a`.repeat(MAX_REPLY_WINDOW_MESSAGE_CHARS - 1) + emoji + `tail`;
-		const bounded = withBoundedText(mem("m1", USER_ID, text, 100));
+	it("keeps surrogate pairs intact at exact and max-plus-one window bounds", () => {
+		const exact = `${`a`.repeat(MAX_REPLY_WINDOW_MESSAGE_CHARS - 2)}🦊`;
+		const exactMemory = mem("m0", USER_ID, exact, 99);
+		expect(exact.length).toBe(MAX_REPLY_WINDOW_MESSAGE_CHARS);
+		expect(withBoundedText(exactMemory)).toBe(exactMemory);
+
+		const maxPlusOne = `${exact}b`;
+		expect(maxPlusOne.length).toBe(MAX_REPLY_WINDOW_MESSAGE_CHARS + 1);
+		const bounded = withBoundedText(mem("m1", USER_ID, maxPlusOne, 100));
 		const out = bounded.content.text as string;
 		expect(out.length).toBeLessThanOrEqual(MAX_REPLY_WINDOW_MESSAGE_CHARS);
 		expect(out.endsWith("…")).toBe(true);
@@ -314,7 +320,7 @@ describe("withBoundedText", () => {
 	});
 
 	it("sanitizes lone surrogates in window text", () => {
-		const lone = `x\uD800` + `y`.repeat(2000);
+		const lone = `x\uD800${`y`.repeat(2000)}`;
 		const bounded = withBoundedText(mem("m2", USER_ID, lone, 200));
 		const out = bounded.content.text as string;
 		expect(out).toContain("�");

--- a/packages/core/src/features/basic-capabilities/providers/replyContext.ts
+++ b/packages/core/src/features/basic-capabilities/providers/replyContext.ts
@@ -27,6 +27,10 @@ import type {
 	ProviderResult,
 	UUID,
 } from "../../../types/index.ts";
+import {
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "../../../utils/well-formed.ts";
 import { addHeader, formatMessages, validateUuid } from "../../../utils.ts";
 
 /** Turns fetched on EACH side of the replied-to message. */
@@ -50,20 +54,33 @@ function memoryText(memory: Memory): string {
 
 export function truncateSingleLine(text: string, maxChars: number): string {
 	const collapsed = text.replace(/\s+/g, " ").trim();
-	return collapsed.length > maxChars
-		? `${collapsed.slice(0, maxChars - 1)}…`
-		: collapsed;
+	const wellFormed = toWellFormedUnicode(collapsed);
+	if (wellFormed.length <= maxChars) {
+		return wellFormed;
+	}
+	const budget = Math.max(0, maxChars - 1);
+	return `${truncateWellFormed(wellFormed, budget).trimEnd()}…`;
 }
 
 /** Cap a window turn's text so one giant pasted message can't blow up the prompt. */
 export function withBoundedText(memory: Memory): Memory {
 	const text = memoryText(memory);
-	if (text.length <= MAX_REPLY_WINDOW_MESSAGE_CHARS) return memory;
+	const wellFormed = toWellFormedUnicode(text);
+	if (wellFormed.length <= MAX_REPLY_WINDOW_MESSAGE_CHARS) {
+		if (wellFormed !== text) {
+			return {
+				...memory,
+				content: { ...memory.content, text: wellFormed },
+			};
+		}
+		return memory;
+	}
+	const budget = Math.max(0, MAX_REPLY_WINDOW_MESSAGE_CHARS - 1);
 	return {
 		...memory,
 		content: {
 			...memory.content,
-			text: `${text.slice(0, MAX_REPLY_WINDOW_MESSAGE_CHARS - 1)}…`,
+			text: `${truncateWellFormed(wellFormed, budget).trimEnd()}…`,
 		},
 	};
 }


### PR DESCRIPTION
Closes #23473

## Summary
- Fix `packages/core/src/features/basic-capabilities/providers/replyContext.ts:53` `truncateSingleLine` and `packages/core/src/features/basic-capabilities/providers/replyContext.ts:64` `withBoundedText` to use `toWellFormedUnicode` + `truncateWellFormed` so capping at `MAX_REPLY_TARGET_SNIPPET_CHARS` (300) and `MAX_REPLY_WINDOW_MESSAGE_CHARS` (1000) never splits an astral surrogate pair (e.g. 🦊 `\uD83E\uDD8A`) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict provider parsers reject (HTTP 400 `wrong_api_format`). Preserves `trimEnd()` + `…` semantics (`budget = max(0, max-1)`) and sanitizes pre-existing lone surrogates to `�` even when under limit.
- `withBoundedText` now sanitizes lone surrogates even when under the 1000-char cap (returns new `Memory` with `wellFormed` text) and otherwise preserves reference identity for well-formed short text.

Same class as merged #23284 (shared `transcriptPreview`), #23277 (agent `grounded-action-reply`), #23241 (slack `formatting`), #23227 (telegram `splitTelegramText`) — identical `toWellFormedUnicode` → `truncateWellFormed` → `…` pattern; reply context text is injected into the provider prompt (`# Replied-To Message Context`), so ill-formed text poisons the model JSON body.

## What Changed
- `packages/core/src/features/basic-capabilities/providers/replyContext.ts`: import `toWellFormedUnicode`/`truncateWellFormed`, rewrite `truncateSingleLine` to sanitize + well-formed budget + ellipsis, rewrite `withBoundedText` to sanitize + well-formed budget + ellipsis with reference-preservation.
- `packages/core/src/features/basic-capabilities/providers/replyContext.test.ts`: +103 lines — 9 tests: exact and max-plus-one split-pair boundaries at 7 and 1000 code units, both lone surrogate halves `a\ud800` → `a�b…` / `a�bc`, whitespace collapse, 300-char cap, window cap 1000-char emoji boundary, lone surrogate in window, reference identity, sanitized new reference.

## Exact-head evidence
Head: 9143b7ae617aadbf792064a20058a939d211d978
Base: origin/develop@84a1586c3b4c2b4bc00755e684bf7804fe27bd19 with zero conflicts

## Verification / Definition of Done
- [x] Targets develop, rebased onto origin/develop@3d295c9e82 zero conflicts
- [x] `bun install --frozen-lockfile` clean (no lockfile churn)
- [x] `bun test packages/core/src/features/basic-capabilities/providers/replyContext.test.ts` — **14 pass, 0 fail** (5 existing + 9 new `isWellFormed()` assertions)
- [x] `bunx biome check packages/core/src/features/basic-capabilities/providers/replyContext.ts packages/core/src/features/basic-capabilities/providers/replyContext.test.ts` — checked 2 files, no fixes (1 unsafe optional)
- [x] `bun --cwd packages/core typecheck` — pass (generated keyword data)
- [x] Reviewer can confirm from automated tests / negative control: without fix `truncateSingleLine("hello🦊world",7)` emits lone `\uD83E` and `isWellFormed()===false`; with fix emits `hello…` and `isWellFormed()===true`

## Evidence Gate

<!-- evidence-head:9143b7ae617aadbf792064a20058a939d211d978 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - headless core provider; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [x] N/A - headless core provider; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic provider formatting with no interactive flow.

<!-- evidence-row:backend-logs -->
- [x] Exact-head focused Vitest and core typecheck passed:

```log
RUN v4.1.10 packages/core
Test Files  1 passed (1) — replyContext.test.ts
Tests  14 passed (14), including exact and max-plus-one Unicode bounds
core typecheck: generated keyword data and tsc --noEmit completed successfully
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic prompt-context hygiene; no model delegation changed.

<!-- evidence-row:domain-artifacts -->
- [x] Deterministic provider artifacts inspected directly:

```text
truncateSingleLine exact 7 code units: hello🦊 remains unchanged
truncateSingleLine max-plus-one: hello🦊b becomes hello… without a lone half
withBoundedText exact 1000 preserves identity; max-plus-one remains well formed
both pre-existing lone surrogate halves normalize to U+FFFD
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@84a1586c3b4c2b4bc00755e684bf7804fe27bd19:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@84a1586c3b4c2b4bc00755e684bf7804fe27bd19:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — core]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@84a1586c3b4c2b4bc00755e684bf7804fe27bd19:packages/skills/skills/contribute-to-eliza"} -->