### PR TITLE
fix(coding-tools): keep surrogate pairs intact in WEB_FETCH truncation

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/web-fetch.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.test.ts
@@ -192,6 +192,56 @@ describe("coding-tools WEB_FETCH", () => {
     });
   });
 
+  it("keeps surrogate pairs intact when truncating large responses", async () => {
+    const text = `${"a".repeat(7_999)}🦊${"b".repeat(100)}`;
+    usePinnedRoutes({
+      "https://public.example.test/emoji.txt": new Response(text, {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+    });
+    const result = await runFetch({
+      url: "https://public.example.test/emoji.txt",
+    });
+    expect(result.success).toBe(true);
+    const truncated = (result.text ?? "").split("\n")[0];
+    expect(truncated.isWellFormed()).toBe(true);
+    expect(truncated.length).toBeLessThanOrEqual(8_000);
+    expect(truncated).toBe("a".repeat(7_999));
+  });
+
+  it("preserves a fitting emoji under the truncation cap", async () => {
+    const text = `${"a".repeat(100)}🦊`;
+    usePinnedRoutes({
+      "https://public.example.test/fitting.txt": new Response(text, {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+    });
+    const result = await runFetch({
+      url: "https://public.example.test/fitting.txt",
+    });
+    expect(result.success).toBe(true);
+    expect(result.text).toBe(text);
+    expect(result.text?.isWellFormed()).toBe(true);
+  });
+
+  it("sanitizes lone surrogates in fetched text", async () => {
+    const text = "a\ud800bc";
+    usePinnedRoutes({
+      "https://public.example.test/lone.txt": new Response(text, {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+    });
+    const result = await runFetch({
+      url: "https://public.example.test/lone.txt",
+    });
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("a\ufffdbc");
+    expect(result.text?.isWellFormed()).toBe(true);
+  });
+
   it("surfaces timeout-style fetch errors honestly", async () => {
     __setWebHttpLookupFnForTests(async () => [
       { address: PUBLIC_IP, family: 4 },

--- a/plugins/plugin-coding-tools/src/actions/web-fetch.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.ts
@@ -12,7 +12,11 @@ import type {
   Memory,
   State,
 } from "@elizaos/core";
-import { stripHtmlRawTextElements } from "@elizaos/core";
+import {
+  stripHtmlRawTextElements,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import {
   failureToActionResult,
   readStringParam,
@@ -210,10 +214,11 @@ export const webFetchAction: Action = {
         response.contentType,
         extract,
       );
+      const wellFormed = toWellFormedUnicode(extracted.value);
       const value =
-        extracted.value.length > WEB_FETCH_RESULT_CHARS
-          ? `${extracted.value.slice(0, WEB_FETCH_RESULT_CHARS)}\n[truncated]`
-          : extracted.value;
+        wellFormed.length > WEB_FETCH_RESULT_CHARS
+          ? `${truncateWellFormed(wellFormed, WEB_FETCH_RESULT_CHARS)}\n[truncated]`
+          : wellFormed;
       return successActionResult(value, {
         action: "WEB_FETCH",
         url,
@@ -222,7 +227,7 @@ export const webFetchAction: Action = {
         content_type: response.contentType,
         kind: extracted.kind,
         truncated:
-          response.truncated || extracted.value.length > WEB_FETCH_RESULT_CHARS,
+          response.truncated || wellFormed.length > WEB_FETCH_RESULT_CHARS,
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
Fixes #23474

## Summary

- Fix `plugins/plugin-coding-tools/src/actions/web-fetch.ts:215` `WEB_FETCH` to use `toWellFormedUnicode` + `truncateWellFormed` so capping to `WEB_FETCH_RESULT_CHARS=8000` never splits an astral surrogate pair (e.g. 🦊 `\uD83E\uDD8A`) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict JSON consumers reject. Handles under-cap sanitization (`\ud800`→`\ufffd`) and preserves `wellFormed.length` for `truncated` flag.

Same class as approved #23241 (slack), #23227 (telegram), #23277 (agent), #23284 (shared), #23437 (telegram clamp), #23441 (notes), #23445 (zerollama), #23448 (instagram), #23450 (coding-tools truncate), #23462 (coding-tools compactSummary) — identical `toWellFormedUnicode` → `truncateWellFormed` pattern; `WEB_FETCH` value is returned as `ActionResult.text`.

## Changes

| File | Change |
|------|--------|
| `plugins/plugin-coding-tools/src/actions/web-fetch.ts` | Import `toWellFormedUnicode`/`truncateWellFormed`, rewrite handler to sanitize `extracted.value` then `truncateWellFormed(wellFormed, 8000)` |
| `plugins/plugin-coding-tools/src/actions/web-fetch.test.ts` | +42 lines — 3 tests: boundary 🦊→7999, fitting emoji, lone `\ud800`→`\ufffd` with `isWellFormed()` |

## Verification

- Rebased onto `origin/develop@0fdf9c512e` — zero conflicts
- `bunx biome check` — 2 files clean (no fixes)
- `bun --cwd plugins/plugin-coding-tools test src/actions/web-fetch.test.ts` — **19 passed, 0 failed** incl. 3 new `isWellFormed()` cases (was 16)
- `git show 43775a8178a10eb7693fa6a2d56b1e761b4a27a9:plugins/plugin-coding-tools/src/actions/web-fetch.ts` verifies import + `wellFormed` + `truncateWellFormed`

## Evidence Gate

<!-- evidence-head:43775a8178a10eb7693fa6a2d56b1e761b4a27a9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; `WEB_FETCH` is headless text truncation for `ActionResult.text`.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; same as before.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior is proven by deterministic surrogate unit tests.

<!-- evidence-row:backend-logs -->
- [x] Real surrogate-aware WEB_FETCH paths exercised via Vitest:

```log
bun --cwd plugins/plugin-coding-tools test src/actions/web-fetch.test.ts
vitest v4.1.5
 Test Files  1 passed (1)
      Tests  19 passed (19)
   Duration  2.43s (9ms tests)
 3 new isWellFormed() cases: 7999+'🦊'→7999, fitting 100+'🦊', lone '\ud800'
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved; truncate is server-side with no browser console/network trace.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model delegation change beyond handler text hygiene; no live-model trajectory to link (deterministic truncation unit coverage).

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = surrogate-safe WEB_FETCH wiring, proven by 3 deterministic tests:

```log
each test asserts .isWellFormed() === true and length <=8000
boundary: "a".repeat(7999)+"🦊"+"b".repeat(100) at 8000 → "a".repeat(7999) + "\n[truncated]" (backoff)
fitting: "a".repeat(100)+"🦊" at 8000 → kept intact
lone: "a\ud800bc" → "a\ufffdbc" well-formed without truncation flag
all 3 pass; without fix the 7999+🦊 case would emit lone \uD83E and fail isWellFormed()
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface; no OCR text to review.

# Risks

Low — single-function hygiene in `WEB_FETCH` handler only (coding-tools). No network guard, no SSRF, no HTML extraction logic change. Narrow import of two well-formed helpers already used by 10 precedents; atomic `+60/-5` churn.

# Background

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-coding-tools/src/actions/web-fetch.ts:12-20` (import + handler) and `plugins/plugin-coding-tools/src/actions/web-fetch.test.ts:195-245` (3 new cases).

## Detailed testing steps

- `bun --cwd plugins/plugin-coding-tools test src/actions/web-fetch.test.ts` — expect 19/19 incl. 3 new `isWellFormed()`
- `bunx biome check plugins/plugin-coding-tools/src/actions/web-fetch.ts plugins/plugin-coding-tools/src/actions/web-fetch.test.ts` — expect `Checked 2 files … No fixes applied.`

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@0fdf9c512ee41b46f707cd9b8d17375b072eae9:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@0fdf9c512ee41b46f707cd9b8d17375b072eae9:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — coding-tools]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@0fdf9c512ee41b46f707cd9b8d17375b072eae9:packages/skills/skills/contribute-to-eliza"} -->
