### PR TITLE
fix(cloud): compose the Discord hop deadline with caller signals

### DIFF
--- a/packages/cloud/shared/src/lib/services/discord-automation/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/index.error-policy.test.ts
@@ -175,17 +175,50 @@ describe("discordFetch — bounded hops fail closed and keep caller signals", ()
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
-  it("preserves a caller-provided abort signal", async () => {
+  it("propagates a caller abort through the composed signal", async () => {
     let seen: AbortSignal | undefined;
-    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      seen = init?.signal;
-      return jsonResponse({ ok: true });
-    }) as unknown as typeof fetch;
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          seen = init?.signal;
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as unknown as typeof fetch;
 
     const controller = new AbortController();
-    await discordFetch("https://discord.com/api/v10/users/@me", {
-      signal: controller.signal,
-    });
-    expect(seen).toBe(controller.signal);
+    const pending = discordFetch(
+      "https://discord.com/api/v10/users/@me",
+      { signal: controller.signal },
+      60_000,
+    );
+    controller.abort();
+    await expect(pending).rejects.toThrow(/aborted/i);
+    expect(seen).not.toBe(controller.signal);
+  });
+
+  it("keeps the hop deadline when the caller signal never aborts", async () => {
+    // The caller signal must not replace the bound: a caller holding a signal
+    // it never fires would otherwise pin the worker forever.
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as unknown as typeof fetch;
+
+    const never = new AbortController();
+    const start = Date.now();
+    await expect(
+      discordFetch(
+        "https://discord.com/api/v10/users/@me",
+        { signal: never.signal },
+        100,
+      ),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
   });
 });

--- a/packages/cloud/shared/src/lib/services/discord-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/index.ts
@@ -33,16 +33,21 @@ const DISCORD_REQUEST_TIMEOUT_MS = 25_000;
 /**
  * Bound every Discord REST hop so a hung or rate-limited Discord API cannot
  * pin the calling worker indefinitely. Matches the 25s bound the message-send
- * path already applies; a caller-provided abort signal wins.
+ * path already applies. A caller-provided signal is composed with the hop
+ * deadline rather than replacing it: a caller that cancels still aborts early,
+ * and a caller whose signal never fires still cannot outlive the bound.
  */
 export function discordFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
   timeoutMs: number = DISCORD_REQUEST_TIMEOUT_MS,
 ): Promise<Response> {
+  const deadline = AbortSignal.timeout(timeoutMs);
   return fetch(input, {
     ...init,
-    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+    signal: init?.signal
+      ? AbortSignal.any([init.signal, deadline])
+      : deadline,
   });
 }
 


### PR DESCRIPTION
# Relates to

Follow-up to #23446, completing the bounded-hop series (#23435 coordinator, #23471 Google Ads, #23461 X/Twitter).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from latest `origin/develop`; zero conflicts.

# Risks

Low. One signal expression; the bound and its call-site coverage are unchanged.

# Background

## What does this PR do?

`discordFetch` set `signal: init?.signal ?? AbortSignal.timeout(timeoutMs)`, so a caller-supplied signal *replaced* the hop deadline instead of joining it. No production caller passes one today, but the function is exported, and the first caller to pass a signal it never fires would silently lose the bound the wrapper exists to enforce. Both are now composed with `AbortSignal.any`, matching the form already merged for the shared-runtime coordinator (#23435) and applied to Google Ads (#23471) and X/Twitter (#23461), so the whole series is consistent.

The caller-signal test asserted the caller's signal object was passed through verbatim — exactly the behavior being removed — so it now asserts a caller abort still propagates through the composed signal, and a new test pins that a never-firing caller signal is still bounded.

## What kind of change is this?

Bug fix (hardening a bound that could be silently defeated).

# Testing

`packages/cloud` discord-automation error-policy suite at this head: **8/8 passed** (bun test), including the two rewritten/added signal tests.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side REST client, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side REST client, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - the timeout is asserted directly by the suite above against a never-resolving fetch.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/prompt/action behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain artifacts produced.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-hops]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza"} -->
