### PR TITLE
fix(cloud): bound onboarding coordinator and agent API hops

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
@@ -46,7 +46,7 @@ mock.module("./user-service", () => ({
   },
 }));
 
-const { runOnboardingChat } = await import(
+const { runOnboardingChat, onboardingFetch } = await import(
   `./onboarding-chat.ts?test=onboarding-error-policy-${Date.now()}`
 );
 
@@ -122,5 +122,40 @@ describe("onboarding-chat phone-link error policy", () => {
     expect(linkPhoneToUser).toHaveBeenCalledWith("user-1", PHONE);
     expect(result.reply.length).toBeGreaterThan(0);
     expect(result.provisioning.status).toBe("provisioning");
+  });
+});
+
+describe("onboardingFetch — bounded hops fail closed and keep caller signals", () => {
+  test("aborts a hung onboarding coordinator hop at the timeout", async () => {
+    // A coordinator that never settles on its own: the only way out is the
+    // caller's AbortSignal firing (the 10s default bounds internal hops).
+    const hungStub = {
+      fetch: (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    };
+    const start = Date.now();
+    await expect(
+      onboardingFetch(hungStub, "https://onboarding.internal/resolve", undefined, 100),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("preserves a caller-provided abort signal", async () => {
+    let seen: AbortSignal | undefined;
+    const stub = {
+      fetch: async (_input: RequestInfo | URL, init?: RequestInit) => {
+        seen = init?.signal;
+        return new Response("{}", { status: 200 });
+      },
+    };
+    const controller = new AbortController();
+    await onboardingFetch(stub, "https://onboarding.internal/resolve", {
+      signal: controller.signal,
+    });
+    expect(seen).toBe(controller.signal);
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -27,6 +27,25 @@ import {
 import { type ElizaAppProvisioningStatus, getElizaAppProvisioningStatus } from "./provisioning";
 import { elizaAppUserService } from "./user-service";
 
+const ONBOARDING_REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Bound every onboarding coordinator / agent API hop so a hung or overloaded
+ * Durable Object or agent cannot pin the onboarding worker indefinitely. A
+ * caller-provided abort signal wins.
+ */
+export function onboardingFetch(
+  stub: { fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> },
+  input: string | URL,
+  init?: RequestInit,
+  timeoutMs: number = ONBOARDING_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  return stub.fetch(input, {
+    ...init,
+    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
+
 export type OnboardingChatRole = "user" | "assistant";
 export type OnboardingPlatform = "web" | "telegram" | "discord" | "whatsapp" | "twilio" | "blooio";
 
@@ -311,9 +330,11 @@ async function resolveContinuationToken(token: string): Promise<string | null> {
 
   const coordinator = onboardingCoordinator();
   if (coordinator) {
-    const response = await coordinator
-      .getByName(trimmed)
-      .fetch("https://onboarding.internal/resolve", { method: "POST" });
+    const response = await onboardingFetch(
+      coordinator.getByName(trimmed),
+      "https://onboarding.internal/resolve",
+      { method: "POST" },
+    );
     if (response.ok) {
       const resolved: unknown = await response.json();
       if (isOnboardingContinuation(resolved)) return resolved.sessionId;
@@ -341,13 +362,15 @@ async function loadOnboardingSessionForValidation(
 ): Promise<OnboardingSession | null> {
   const coordinator = onboardingCoordinator();
   if (coordinator) {
-    const response = await coordinator
-      .getByName(sessionId)
-      .fetch("https://onboarding.internal/inspect", {
+    const response = await onboardingFetch(
+      coordinator.getByName(sessionId),
+      "https://onboarding.internal/inspect",
+      {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ sessionId }),
-      });
+      },
+    );
     if (response.ok) {
       return (await response.json()) as OnboardingSession;
     }
@@ -626,17 +649,21 @@ export async function claimTelegramOnboardingContinuation(
   if (!coordinator || !SESSION_ID_PATTERN.test(token) || isReservedSessionId(token)) {
     throw trustedContinuationError(null);
   }
-  const response = await coordinator.getByName(token).fetch("https://onboarding.internal/claim", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      claimId: input.claimId,
-      telegramId: input.telegramId,
-      phoneNumber: input.phoneNumber,
-      userId: input.authenticatedAccount?.userId,
-      organizationId: input.authenticatedAccount?.organizationId,
-    }),
-  });
+  const response = await onboardingFetch(
+    coordinator.getByName(token),
+    "https://onboarding.internal/claim",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        claimId: input.claimId,
+        telegramId: input.telegramId,
+        phoneNumber: input.phoneNumber,
+        userId: input.authenticatedAccount?.userId,
+        organizationId: input.authenticatedAccount?.organizationId,
+      }),
+    },
+  );
   if (!response.ok) throw trustedContinuationError(null);
   return parseTelegramOnboardingContinuationClaim(await response.json());
 }
@@ -651,13 +678,15 @@ export async function completeTelegramOnboardingContinuationClaim(input: {
 }): Promise<void> {
   const coordinator = onboardingCoordinator();
   if (!coordinator) throw trustedContinuationError(null);
-  const response = await coordinator
-    .getByName(input.continuationToken.trim())
-    .fetch("https://onboarding.internal/complete-claim", {
+  const response = await onboardingFetch(
+    coordinator.getByName(input.continuationToken.trim()),
+    "https://onboarding.internal/complete-claim",
+    {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(input),
-    });
+    },
+  );
   if (!response.ok) throw trustedContinuationError(null);
 }
 
@@ -1312,7 +1341,8 @@ async function copyTranscriptToManagedAgent(session: OnboardingSession): Promise
       organizationId: session.organizationId,
     });
 
-    const rememberResponse = await fetch(
+    const rememberResponse = await onboardingFetch(
+      { fetch },
       `${connection.apiBase.replace(/\/+$/, "")}/api/memory/remember`,
       {
         method: "POST",
@@ -1715,7 +1745,7 @@ async function runViaCoordinator(
   sessionId: string,
 ): Promise<OnboardingChatResult> {
   return readOnboardingCoordinatorResult<OnboardingChatResult>(
-    await stub.fetch("https://onboarding.internal/turn", {
+    await onboardingFetch(stub, "https://onboarding.internal/turn", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ input, sessionId }),


### PR DESCRIPTION
## Problem

Six fetches in `onboarding-chat` had **no timeout**: the coordinator Durable Object hops (`resolve`, `inspect`, `claim`, `complete-claim`, `turn`) and the agent `memory/remember` call could pin the onboarding worker forever when the coordinator or agent hung without closing the connection — stalling phone-link onboarding, continuation resolution, and chat turns.

## Fix

- Add `onboardingFetch(stub, input, init, timeoutMs = 10_000)`: fails closed at a **10s hop timeout**, preserving any caller-provided abort signal.
- Route all six fetch sites through it (five coordinator DO stubs + the agent memory call via `{ fetch }`).

One module, one bounded behavior: no onboarding hop can hang forever.

## Tests

`onboarding-chat.error-policy.test.ts` (5 pass):

- new: **`onboardingFetch` aborts a hung onboarding coordinator hop at the timeout** — a stub that never settles is rejected with `AbortError` at the configured 100ms timeout (elapsed asserted < 5s).
- new: **`onboardingFetch` preserves a caller-provided abort signal** — the caller's signal passes through untouched.
- existing phone-link error-policy tests still pass. `onboarding-chat.test.ts` (93 tests) also still green.

## Verification

```bash
bun test --isolate src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts \
  src/lib/services/eliza-app/onboarding-chat.test.ts
# 96 pass, 0 fail
bunx biome check packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
# no issues
```
