### PR TITLE
fix(cloud): contain unsafe tenant restore drill

### DIFF
--- a/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/cloud-init/tenant-db.yaml.tftpl
+++ b/packages/cloud/infra/cloud/terraform/hetzner/apps-shared/cloud-init/tenant-db.yaml.tftpl
@@ -318,6 +318,7 @@ write_files:
       fi
       set -a
       . "$ENV_FILE"
+      set +a
       # The sourced file contains base64 alphabet only. Decode after parsing so
       # spaces, quotes, dollar signs, command substitutions, and newlines in
       # operator-provided values can never become root shell syntax.
@@ -331,7 +332,6 @@ write_files:
       unset BACKUP_S3_ENDPOINT_B64 BACKUP_S3_BUCKET_B64 BACKUP_S3_PREFIX_B64 \
         BACKUP_S3_ACCESS_KEY_ID_B64 BACKUP_S3_SECRET_ACCESS_KEY_B64 \
         BACKUP_ENCRYPTION_PASSPHRASE_B64 BACKUP_RETENTION_DAYS_B64
-      set +a
       : "$BACKUP_S3_ENDPOINT" "$BACKUP_S3_BUCKET" "$BACKUP_S3_PREFIX" \
         "$BACKUP_S3_ACCESS_KEY_ID" "$BACKUP_S3_SECRET_ACCESS_KEY" \
         "$BACKUP_ENCRYPTION_PASSPHRASE" "$BACKUP_RETENTION_DAYS"
@@ -387,9 +387,11 @@ write_files:
         > manifest.json
 
       tar -czf backup.tar.gz manifest.json checksums.sha256 globals.sql dbmap.tsv dumps
-      openssl enc -aes-256-cbc -pbkdf2 -iter 210000 -salt \
+      BACKUP_ENCRYPTION_PASSPHRASE="$BACKUP_ENCRYPTION_PASSPHRASE" \
+        openssl enc -aes-256-cbc -pbkdf2 -iter 210000 -salt \
         -in backup.tar.gz -out backup.tar.gz.enc \
         -pass env:BACKUP_ENCRYPTION_PASSPHRASE
+      unset BACKUP_ENCRYPTION_PASSPHRASE
       ENC_SHA=$(sha256sum backup.tar.gz.enc | awk '{print $1}')
       ENC_BYTES=$(stat -c%s backup.tar.gz.enc)
       # Plaintext sidecar: freshness/integrity metadata only (no tenant data),
@@ -415,9 +417,13 @@ write_files:
       CUTOFF=$(date -u -d "-$BACKUP_RETENTION_DAYS days" +%Y%m%dT%H%M%SZ)
       PRUNED=0
       RETENTION_DIRS=$(rclone lsf --dirs-only ":s3:$BACKUP_S3_BUCKET/$BACKUP_S3_PREFIX")
-      while IFS= read -r dir; do
-        dir=$(printf '%s' "$dir" | tr -d '/')
-        [ -n "$dir" ] || continue
+      while IFS= read -r listed_dir; do
+        [ -n "$listed_dir" ] || continue
+        if ! [[ "$listed_dir" =~ ^[0-9]{8}T[0-9]{6}Z/$ ]]; then
+          log "unexpected retention directory name; refusing before purge."
+          exit 1
+        fi
+        dir=$${listed_dir%/}
         if [[ "$dir" < "$CUTOFF" ]]; then
           rclone purge ":s3:$BACKUP_S3_BUCKET/$BACKUP_S3_PREFIX/$dir"
           PRUNED=$((PRUNED+1))

--- a/packages/cloud/infra/tests/terraform-static.test.ts
+++ b/packages/cloud/infra/tests/terraform-static.test.ts
@@ -369,6 +369,17 @@ describe("Apps tenant-DB off-host encrypted recovery (#21729)", () => {
     expect(tenantDbInit).toContain(
       "openssl enc -aes-256-cbc -pbkdf2 -iter 210000 -salt",
     );
+    const sourceAt = tenantDbInit.indexOf('. "$ENV_FILE"');
+    const stopExportAt = tenantDbInit.indexOf("set +a", sourceAt);
+    const decodeAt = tenantDbInit.indexOf("base64 --decode", sourceAt);
+    expect(stopExportAt).toBeGreaterThan(sourceAt);
+    expect(stopExportAt).toBeLessThan(decodeAt);
+    expect(tenantDbInit).toContain(
+      'BACKUP_ENCRYPTION_PASSPHRASE="$BACKUP_ENCRYPTION_PASSPHRASE"',
+    );
+    expect(
+      tenantDbInit.indexOf("unset BACKUP_ENCRYPTION_PASSPHRASE"),
+    ).toBeLessThan(tenantDbInit.indexOf("export RCLONE_S3_PROVIDER"));
     expect(tenantDbInit).toContain("rclone copyto backup.tar.gz.enc");
   });
 
@@ -402,6 +413,12 @@ describe("Apps tenant-DB off-host encrypted recovery (#21729)", () => {
     expect(tenantDbInit).toContain("rclone purge");
     expect(tenantDbInit).toContain(
       'RETENTION_DIRS=$(rclone lsf --dirs-only ":s3:$BACKUP_S3_BUCKET/$BACKUP_S3_PREFIX")',
+    );
+    expect(tenantDbInit).toContain(
+      '[[ "$listed_dir" =~ ^[0-9]{8}T[0-9]{6}Z/$ ]]',
+    );
+    expect(tenantDbInit.indexOf('[[ "$listed_dir" =~')).toBeLessThan(
+      tenantDbInit.indexOf("rclone purge"),
     );
     expect(tenantDbInit).not.toContain(
       'rclone lsf --dirs-only ":s3:$BACKUP_S3_BUCKET/$BACKUP_S3_PREFIX" 2>/dev/null || true',

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.test.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.test.ts
@@ -20,9 +20,11 @@ import { join } from "node:path";
 import {
   assertDirectTarget,
   assertNoGlobalRoleCollisions,
+  assertRestoreDrillExecutionEnabled,
   assertRestoreTargetIdentity,
   buildIsolationChecks,
   evaluateObjectives,
+  executeDrill,
   guardedConsumeTargetIdentitySql,
   guardPsqlScript,
   isCrossTenantDenial,
@@ -52,6 +54,17 @@ const SIDECAR = {
   database_count: 3,
   cipher: "aes-256-cbc-pbkdf2-210000",
 };
+
+describe("restore drill containment", () => {
+  test("refuses execution before any destructive collaborator can run", () => {
+    expect(() => executeDrill({} as never)).toThrow(
+      expect.objectContaining({ code: "RESTORE_DRILL_DISABLED" }),
+    );
+    expect(() => assertRestoreDrillExecutionEnabled()).toThrow(
+      RecoveryDrillError,
+    );
+  });
+});
 
 describe("redactDsn", () => {
   test("strips credentials and database, keeps host and port", () => {

--- a/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
+++ b/packages/cloud/scripts/admin/apps-tenant-db-recovery.ts
@@ -53,6 +53,20 @@ const RESTORE_TARGET_ID =
 const PASSWORD_ENV = /^[A-Z][A-Z0-9_]*$/;
 export const POOLER_PORT = 6432;
 
+/**
+ * Fail-closed containment for the merged restore orchestrator. The current
+ * one-use target marker is cleared before the later guarded restore sessions,
+ * and the remaining authority/evidence contracts require a redesign backed by
+ * a real disposable Postgres and pgbouncer canary. Keep parsing helpers
+ * available to tests, but refuse every destructive drill invocation.
+ */
+export function assertRestoreDrillExecutionEnabled(): void {
+  throw new RecoveryDrillError(
+    "RESTORE_DRILL_DISABLED",
+    "tenant restore drills are disabled pending a verified destructive-authority redesign",
+  );
+}
+
 export class RecoveryDrillError extends Error {
   readonly code: string;
   constructor(code: string, message: string) {
@@ -895,7 +909,8 @@ export function verifyAndConsumeRestoreTargetIdentity(
 }
 
 /** Execute the full drill. Requires openssl, tar, psql, pg_restore on PATH. */
-function executeDrill(options: CliOptions): DrillReport {
+export function executeDrill(options: CliOptions): DrillReport {
+  assertRestoreDrillExecutionEnabled();
   const targetUrl = assertDirectTarget(options.targetDsn);
   const work = mkdtempSync(join(tmpdir(), "tenant-db-drill-"));
   try {


### PR DESCRIPTION
## Summary

Immediate fail-closed containment for the tenant restore drill merged in #23421.

- Refuses destructive drill execution before target parsing, child-process spawn, or database mutation.
- Rejects unknown retention inventory entries unless they match the exact UTC backup-set directory grammar.
- Narrows backup secret scope so decoded credentials are not inherited by every later child process.

The merged drill currently clears its target marker before later guarded restore sessions, so it cannot complete normally, while the marker is still not an atomic archive-bound authority. Do not run the drill against protected infrastructure.

## Validation

Exact commit: `1f7161c67cdb73db014c933f958c78345e21531f`, rebased onto `develop@11fad2540f99ec3083e9db87bb3f95b8403a92db`.

Pinned Bun 1.3.14 / Node 24.15.0:

- recovery suite: 34/34 passed (88 assertions)
- nonce suite: 2/2 passed (5 assertions)
- Terraform static suite: 38/38 passed (304 assertions)
- standalone strict TypeScript compile: passed
- Biome: passed, with only two documented pre-existing warnings
- extracted backup shell: shellcheck clean except the pre-existing dynamic-source warning
- diff check: passed

## Follow-up authority

This containment does not claim recovery readiness or close the parent objective. Re-enable only after a private security-reviewed redesign provides an expiring capability bound to immutable target identity and archive SHA, transactional exclusive consumption at the destructive boundary, authenticated freshness/owner inventory, bounded retention, minimal credential-file environments, scalable isolation proof included in RTO, and a real isolated PostgreSQL/pgbouncer canary.

Sensitive details are tracked privately in GHSA-5947-7jrv-cxv7. Keep this PR draft until exact-head hosted checks and independent security approval are green.