### PR TITLE
fix(plugin-form): revalidate finalized session snapshots before persistence

### DIFF
--- a/plugins/plugin-form/src/storage.test.ts
+++ b/plugins/plugin-form/src/storage.test.ts
@@ -380,4 +380,66 @@ describe("form persistence staging", () => {
     expect(getter).not.toHaveBeenCalled();
     expectNoPersistence(runtime);
   });
+
+  it("revalidates the exact byte-limit snapshot after FormService adds updatedAt", async () => {
+    const runtime = makePersistenceRuntime();
+    const service = (await FormService.start(
+      runtime as unknown as IAgentRuntime,
+    )) as FormService;
+    const session = makeSession("byte-limit") as FormSession &
+      Record<string, unknown>;
+    delete session.updatedAt;
+    session.meta = { padding: "" };
+    const encoder = new TextEncoder();
+    const emptyBytes = encoder.encode(
+      JSON.stringify(toComponentData(session)),
+    ).byteLength;
+    (session.meta as Record<string, JsonValue>).padding = "x".repeat(
+      MAX_FORM_COMPONENT_DATA_BYTES - emptyBytes,
+    );
+    expect(
+      encoder.encode(JSON.stringify(toComponentData(session))).byteLength,
+    ).toBe(MAX_FORM_COMPONENT_DATA_BYTES);
+
+    await expect(service.saveSession(session)).rejects.toMatchObject({
+      code: FORM_COMPONENT_DATA_UNBOUNDED,
+      context: expect.objectContaining({ reason: "bytes" }),
+    });
+    expectNoPersistence(runtime);
+  });
+
+  it("revalidates the exact node-limit snapshot after FormService adds updatedAt", async () => {
+    const runtime = makePersistenceRuntime();
+    const service = (await FormService.start(
+      runtime as unknown as IAgentRuntime,
+    )) as FormService;
+    const session = makeSession("node-limit") as FormSession &
+      Record<string, unknown>;
+    delete session.updatedAt;
+    let accepted = 0;
+    let rejected = MAX_FORM_COMPONENT_DATA_NODES;
+    while (accepted + 1 < rejected) {
+      const candidate = Math.floor((accepted + rejected) / 2);
+      session.history = new Array(candidate);
+      try {
+        toComponentData(session);
+        accepted = candidate;
+      } catch {
+        rejected = candidate;
+      }
+    }
+    session.history = new Array(accepted);
+    expect(() => toComponentData(session)).not.toThrow();
+    session.history = new Array(accepted + 1);
+    expect(() => toComponentData(session)).toThrow(
+      expect.objectContaining({ code: FORM_COMPONENT_DATA_UNBOUNDED }),
+    );
+    session.history = new Array(accepted);
+
+    await expect(service.saveSession(session)).rejects.toMatchObject({
+      code: FORM_COMPONENT_DATA_UNBOUNDED,
+      context: expect.objectContaining({ reason: "nodes" }),
+    });
+    expectNoPersistence(runtime);
+  });
 });

--- a/plugins/plugin-form/src/storage.ts
+++ b/plugins/plugin-form/src/storage.ts
@@ -88,7 +88,9 @@ const resolveComponentContext = async (
   return { roomId: runtime.agentId, worldId: runtime.agentId };
 };
 
-const isFormSession = (data: JsonValue | object): data is FormSession => {
+const isFormSessionIdentity = (
+  data: JsonValue | object,
+): data is FormSession => {
   if (!isRecord(data)) return false;
   return (
     typeof data.id === "string" &&
@@ -97,6 +99,11 @@ const isFormSession = (data: JsonValue | object): data is FormSession => {
     typeof data.roomId === "string"
   );
 };
+
+const isFormSession = (data: JsonValue | object): data is FormSession =>
+  isFormSessionIdentity(data) &&
+  typeof data.updatedAt === "number" &&
+  Number.isFinite(data.updatedAt);
 
 const isLiveSession = (session: FormSession): boolean => !isExpired(session);
 
@@ -625,12 +632,16 @@ export async function saveSession(
   session: FormSession,
   refreshUpdatedAt = false,
 ): Promise<void> {
-  const componentData = toComponentData(session);
+  const stagedSession = toComponentData(session);
+  if (!isFormSessionIdentity(stagedSession)) {
+    failComponentData("session-shape");
+  }
+  if (refreshUpdatedAt) stagedSession.updatedAt = Date.now();
+  const componentData = toComponentData(stagedSession);
   if (!isFormSession(componentData)) {
     failComponentData("session-shape");
   }
   const persistedSession = componentData;
-  if (refreshUpdatedAt) persistedSession.updatedAt = Date.now();
   const componentType = sessionComponentType(
     persistedSession.roomId,
     persistedSession.id,


### PR DESCRIPTION
Fixes #23460

## Summary

- Fix `plugins/plugin-form/src/storage.ts:625-647` `saveSession` to revalidate the finalized inert session after `FormService` adds `updatedAt`. Previously the bounded snapshot (`toComponentData`) was staged and validated, then `updatedAt` was mutated in-place without re-accounting—so a session at the exact 1 MiB UTF-8 or 100,000-node bound could cross the limit after validation and a session missing `updatedAt` could be made superficially valid.
- Now finalizes `stagedSession = toComponentData(session)`, validates identity, optionally sets `updatedAt`, then re-serializes `componentData = toComponentData(stagedSession)` as the terminal bounded snapshot; `isFormSession` now requires finite numeric `updatedAt`. Preserves descriptor/accessor/proxy/cycle behavior from #23439.

Same class as #23439 follow-up; unbounded sessions are rejected as typed `FORM_COMPONENT_DATA_UNBOUNDED` before any component lookup/write.

## Changes

| File | Change |
|------|--------|
| `plugins/plugin-form/src/storage.ts` | Stage inert session, validate identity, finalize `updatedAt` before terminal `toComponentData`; require `Number.isFinite(updatedAt)` in `isFormSession` |
| `plugins/plugin-form/src/storage.test.ts` | +62 lines — 2 real `FormService.saveSession` regressions: exact-byte (1 MiB) and exact-node (100k) snapshots with deleted `updatedAt` prove `FORM_COMPONENT_DATA_UNBOUNDED` (`bytes`/`nodes`) and zero storage writes |

## Verification

- Frozen on canonical `lalalune/eliza:fix/form-storage-final-snapshot-bound@2cccdff234d6918a4a8516464dbb42d24184ddda` (rebased on `origin/develop@79f770508c`) as requested
- `bun --cwd plugins/plugin-form test src/storage.test.ts` — **17 passed, 0 failed** incl. 2 new zero-storage `FORM_COMPONENT_DATA_UNBOUNDED` regressions
- `bunx biome check` — 2 files clean (no fixes)
- `git diff --check` — no whitespace errors
- `plugin-form` full `typecheck` is blocked on `develop` by unrelated `shared/config-catalog` exports (`isSafeUntrustedRegexPattern`) — same on `79f770508c` and `11fad2540f`; touched `storage.ts` compiles and `tsc` on that file shows no new errors

## Evidence Gate

<!-- evidence-head:2cccdff234d6918a4a8516464dbb42d24184ddda -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; `FormService.saveSession` is headless storage persistence with typed error handling.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; same as before.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior proven by deterministic storage unit tests (byte/node bounds, zero writes).

<!-- evidence-row:backend-logs -->
- [x] Real bounded-persistence paths exercised via Vitest (zero-storage regressions):

```log
bun --cwd plugins/plugin-form test src/storage.test.ts
vitest v4.1.5
 Test Files  1 passed (1)
      Tests  17 passed (17)
   Duration  2.74s
 2 new cases: exact 1 MiB bytes and 100k nodes after updatedAt → FORM_COMPONENT_DATA_UNBOUNDED (bytes/nodes), zero persistence writes
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved; persistence is server-side storage provider with no browser trace.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model delegation change beyond storage validation; no live-model trajectory to link (deterministic unit coverage).

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = bounded session snapshot validation, proven by 2 regressions + zero-write guard:

```log
each new test deletes session.updatedAt, crafts exact-limit snapshot (bytes=1MiB via TextEncoder, nodes=100k via history array binary search)
calls FormService.saveSession, expects rejects.toMatchObject({code: FORM_COMPONENT_DATA_UNBOUNDED, context: {reason: 'bytes'|'nodes'}})
and expectNoPersistence(runtime) — zero storage writes
without fix the exact-limit cases pass validation then cross bound after updatedAt; with fix both correctly reject before component write
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface; no OCR text to review.

# Risks

Low — narrow storage validation order fix in `saveSession` only (`+17/-3` in `storage.ts`). No new dependencies, no schema migration, no component type changes; typed `FORM_COMPONENT_DATA_UNBOUNDED` is already the caller-observed contract.

# Background

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-form/src/storage.ts:88-110` (`isFormSessionIdentity`/`isFormSession` + finite `updatedAt`) and `plugins/plugin-form/src/storage.ts:625-650` (`saveSession` staging → finalize → revalidate) and `plugins/plugin-form/src/storage.test.ts:383-445` (2 new FormService regressions).

## Detailed testing steps

- `bun --cwd plugins/plugin-form test src/storage.test.ts` — expect 17/17 incl. 2 new `revalidates the exact …` cases
- `bunx biome check plugins/plugin-form/src/storage.ts plugins/plugin-form/src/storage.test.ts` — expect `Checked 2 files … No fixes applied.`

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@11fad2540f99ec3083e9db87bb3f95b8403a92db:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@11fad2540f99ec3083e9db87bb3f95b8403a92db:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
