### PR TITLE
fix(app): preserve deep-link ack and FIFO authority

### DIFF
--- a/packages/app/src/mobile-lifecycle.ts
+++ b/packages/app/src/mobile-lifecycle.ts
@@ -101,12 +101,34 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
     }
     const result = ctx.handleDeepLink(trimmed);
     if (result && typeof (result as Promise<boolean>).then === "function") {
-      void (result as Promise<boolean>).then((applied) => {
-        if (!applied) return;
-        const queued = pendingDeepLinkAcknowledgements.get(trimmed);
-        pendingDeepLinkAcknowledgements.delete(trimmed);
-        for (const acknowledge of queued ?? []) acknowledge();
-      });
+      // Record every asynchronous application attempt, including one first
+      // observed through Capacitor getLaunchUrl without an acknowledgement.
+      // A concurrent DeepLinkBuffer peek of the same URL must queue behind this
+      // promise instead of mistaking the missing callback list for completion.
+      if (!pendingDeepLinkAcknowledgements.has(trimmed)) {
+        pendingDeepLinkAcknowledgements.set(trimmed, []);
+      }
+      void (result as Promise<boolean>)
+        .then((applied) => {
+          if (!applied) {
+            pendingDeepLinkAcknowledgements.delete(trimmed);
+            handledDeepLinks.delete(trimmed);
+            return;
+          }
+          const queued = pendingDeepLinkAcknowledgements.get(trimmed);
+          pendingDeepLinkAcknowledgements.delete(trimmed);
+          for (const acknowledge of queued ?? []) acknowledge();
+        })
+        .catch((error) => {
+          // error-policy:J1 the native lifecycle boundary translates a rejected
+          // renderer application into retained-buffer retry authority.
+          pendingDeepLinkAcknowledgements.delete(trimmed);
+          handledDeepLinks.delete(trimmed);
+          console.warn(
+            `${ctx.logPrefix} Deep-link navigation application failed:`,
+            error instanceof Error ? error.message : error,
+          );
+        });
       return;
     }
     const queued = pendingDeepLinkAcknowledgements.get(trimmed);

--- a/packages/app/test/mobile-lifecycle.test.ts
+++ b/packages/app/test/mobile-lifecycle.test.ts
@@ -553,6 +553,59 @@ describe("createMobileLifecycle — app lifecycle", () => {
     );
   });
 
+  it("does not ack when getLaunchUrl starts applying before the buffer reports the same URL", async () => {
+    const url = "elizaos://apps/deploy";
+    capacitorAppMock.__setLaunchUrl({ url });
+    const deepLinkBuffer = makeDeepLinkBuffer(url);
+    let resolveApplied: ((applied: boolean) => void) | undefined;
+    const ctx = makeContext({
+      androidDeepLinkBuffer: deepLinkBuffer.bridge,
+      handleDeepLink: vi.fn(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveApplied = resolve;
+          }),
+      ),
+    });
+
+    createMobileLifecycle(ctx).initializeAppLifecycle();
+    await vi.waitFor(() => expect(ctx.handleDeepLink).toHaveBeenCalledOnce());
+    await vi.waitFor(() =>
+      expect(deepLinkBuffer.bridge.peekPendingUrl).toHaveBeenCalled(),
+    );
+    expect(deepLinkBuffer.bridge.acknowledgePendingUrl).not.toHaveBeenCalled();
+
+    resolveApplied?.(true);
+    await vi.waitFor(() =>
+      expect(deepLinkBuffer.bridge.acknowledgePendingUrl).toHaveBeenCalledWith({
+        url,
+      }),
+    );
+  });
+
+  it("retries a buffered URL after an application attempt resolves false", async () => {
+    vi.useFakeTimers();
+    const url = "elizaos://apps/deploy";
+    const deepLinkBuffer = makeDeepLinkBuffer(url);
+    const ctx = makeContext({
+      androidDeepLinkBuffer: deepLinkBuffer.bridge,
+      handleDeepLink: vi
+        .fn<MobileLifecycleContext["handleDeepLink"]>()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true),
+    });
+
+    createMobileLifecycle(ctx).initializeAppLifecycle();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(ctx.handleDeepLink).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() =>
+      expect(deepLinkBuffer.bridge.acknowledgePendingUrl).toHaveBeenCalledWith({
+        url,
+      }),
+    );
+  });
+
   it("acknowledges a native replay duplicate after appUrlOpen already routed it", async () => {
     vi.useFakeTimers();
     const url = "elizaos://chat/replayed";

--- a/packages/ui/src/events/index.ts
+++ b/packages/ui/src/events/index.ts
@@ -357,10 +357,27 @@ const navigateViewRequestResolvers = new WeakMap<
   (applied: boolean) => void
 >();
 const pendingNavigateViewRequests: NavigateViewDetail[] = [];
+let drainingNavigateViewRequests = false;
 
 function emitNavigateViewRequest(detail: NavigateViewDetail): void {
   if (typeof window === "undefined") return;
   window.dispatchEvent(createNavigateViewEvent(detail));
+}
+
+function drainNavigateViewRequests(): void {
+  if (drainingNavigateViewRequests || typeof window === "undefined") return;
+  drainingNavigateViewRequests = true;
+  try {
+    while (pendingNavigateViewRequests.length > 0) {
+      const request = pendingNavigateViewRequests[0];
+      emitNavigateViewRequest(request);
+      // Every attached listener declined or threw. Preserve strict FIFO: a
+      // later request cannot overtake this one while it is still unclaimed.
+      if (pendingNavigateViewRequests[0] === request) break;
+    }
+  } finally {
+    drainingNavigateViewRequests = false;
+  }
 }
 
 function dropOldestPendingNavigateViewRequest(): void {
@@ -415,7 +432,7 @@ export function dispatchNavigateViewRequest(
   if (pendingNavigateViewRequests.length > MAX_PENDING_NAVIGATE_VIEW_REQUESTS) {
     dropOldestPendingNavigateViewRequest();
   }
-  emitNavigateViewRequest(request);
+  drainNavigateViewRequests();
   return applied;
 }
 
@@ -456,9 +473,7 @@ export function listenForNavigateViewRequests(
   };
 
   window.addEventListener(NAVIGATE_VIEW_EVENT, handle);
-  for (const request of [...pendingNavigateViewRequests]) {
-    emitNavigateViewRequest(request);
-  }
+  drainNavigateViewRequests();
   return () => window.removeEventListener(NAVIGATE_VIEW_EVENT, handle);
 }
 

--- a/packages/ui/src/events/navigate-view-request.test.ts
+++ b/packages/ui/src/events/navigate-view-request.test.ts
@@ -194,6 +194,22 @@ describe("native navigate-view requests", () => {
     expect(received).toEqual(["/wallet", "/connectors"]);
   });
 
+  it("does not let a reentrant dispatch overtake an already-queued cold-boot intent", () => {
+    dispatchNavigateViewRequest({ viewPath: "/wallet" });
+    dispatchNavigateViewRequest({ viewPath: "/settings" });
+    const received: Array<string | null | undefined> = [];
+    cleanups.push(
+      listenForNavigateViewRequests((event) => {
+        received.push(event.detail.viewPath);
+        if (event.detail.viewPath === "/wallet") {
+          dispatchNavigateViewRequest({ viewPath: "/connectors" });
+        }
+      }),
+    );
+
+    expect(received).toEqual(["/wallet", "/settings", "/connectors"]);
+  });
+
   it("overflow: dropping the oldest pending request past the bound is observable and resolves its promise false", async () => {
     const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
     try {


### PR DESCRIPTION
## Summary

Fix-forward for the remaining cold-boot navigation races in merged #23403.

- Records every asynchronous navigation attempt, including launch-URL delivery without an initial native-buffer ACK callback.
- Queues a matching durable-buffer ACK behind the actual in-flight apply result.
- Clears handled/in-flight state after false or rejection so the persisted native URL can be retried in-process.
- Serializes the owned navigate-view drain so reentrant arrivals cannot overtake older cold-queued requests.

## Validation

Exact commit: `e2694117e89f0132c2b8cefd9db0f84a36d8a56d`, rebased onto `develop@11fad2540f99ec3083e9db87bb3f95b8403a92db`.

Pinned validation:

- UI navigate-view tests: 10/10 passed on Bun 1.3.14
- app mobile-lifecycle tests: 30/30 passed on Node 24.15.0
- UI and app typechecks completed without diagnostics before the final conflict-free rebase
- changed-file Biome: passed
- diff check: passed

New regressions cover launch URL winning before durable-buffer peek, false-result redelivery without renderer restart, and cold-queued A/B with reentrant C preserving A/B/C order.

Keep draft until exact-head hosted gates, package typechecks, independent review, and real Android cold-boot capture are green.