### PR TITLE
fix(cloud): bound LinkedIn REST hops in the ad provider

### DIFF
--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.error-policy.test.ts
@@ -14,8 +14,8 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 async function loadProvider() {
-  const { linkedinAdsProvider } = await import("./linkedin");
-  return linkedinAdsProvider;
+  const { linkedinAdsProvider, linkedinFetch } = await import("./linkedin");
+  return { provider: linkedinAdsProvider, linkedinFetch };
 }
 
 const credentials = { accessToken: "linkedin-token" };
@@ -31,7 +31,7 @@ describe("linkedinAdsProvider.validateCredentials error policy", () => {
       throw new Error("network unreachable");
     }) as typeof fetch;
 
-    const result = await (await loadProvider()).validateCredentials(credentials);
+    const result = await (await loadProvider()).provider.validateCredentials(credentials);
 
     expect(result.valid).toBe(false);
     expect(result.error).toBe("network unreachable");
@@ -44,7 +44,7 @@ describe("linkedinAdsProvider.validateCredentials error policy", () => {
       jsonResponse({ message: "Invalid access token" }, 401),
     ) as typeof fetch;
 
-    const result = await (await loadProvider()).validateCredentials(credentials);
+    const result = await (await loadProvider()).provider.validateCredentials(credentials);
 
     expect(result.valid).toBe(false);
     expect(result.error).toBe("Invalid access token");
@@ -54,7 +54,7 @@ describe("linkedinAdsProvider.validateCredentials error policy", () => {
   test("a successful fetch with zero accounts is the DISTINCT legitimately-empty result", async () => {
     globalThis.fetch = mock(async () => jsonResponse({ elements: [] })) as typeof fetch;
 
-    const result = await (await loadProvider()).validateCredentials(credentials);
+    const result = await (await loadProvider()).provider.validateCredentials(credentials);
 
     expect(result).toEqual({ valid: false, error: EMPTY_ERROR });
   });
@@ -64,12 +64,49 @@ describe("linkedinAdsProvider.validateCredentials error policy", () => {
       jsonResponse({ elements: [{ id: 507404993, name: "Dunder Mifflin Account" }] }),
     ) as typeof fetch;
 
-    const result = await (await loadProvider()).validateCredentials(credentials);
+    const result = await (await loadProvider()).provider.validateCredentials(credentials);
 
     expect(result).toEqual({
       valid: true,
       accountId: "507404993",
       accountName: "Dunder Mifflin Account",
     });
+  });
+});
+
+describe("linkedinFetch — bounded hops fail closed and keep caller signals", () => {
+  test("aborts a hung LinkedIn API hop at the timeout", async () => {
+    // An API that never settles on its own: the only way out is the caller's
+    // AbortSignal firing (the 30s default bounds every ads / upload hop).
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as typeof fetch;
+
+    const start = Date.now();
+    const { linkedinFetch } = await loadProvider();
+    await expect(
+      linkedinFetch("https://api.linkedin.com/rest/adAccountsV2", undefined, 100),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("preserves a caller-provided abort signal", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen = init?.signal;
+      return jsonResponse({ elements: [] });
+    }) as typeof fetch;
+
+    const { linkedinFetch } = await loadProvider();
+    const controller = new AbortController();
+    await linkedinFetch("https://api.linkedin.com/rest/adAccountsV2", {
+      signal: controller.signal,
+    });
+    expect(seen).toBe(controller.signal);
   });
 });

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
@@ -27,6 +27,23 @@ const LINKEDIN_OAUTH_TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken"
 // (LinkedIn requires at least one location facet on every campaign).
 const LINKEDIN_WORLDWIDE_GEO = "urn:li:geo:92000000";
 
+const LINKEDIN_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Bound every LinkedIn REST hop so a hung or rate-limited API cannot pin the
+ * ad-provider worker indefinitely. A caller-provided abort signal wins.
+ */
+export function linkedinFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = LINKEDIN_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
+
 function linkedinVersion(): string {
   return process.env.LINKEDIN_ADS_API_VERSION ?? "202606";
 }
@@ -107,7 +124,7 @@ async function linkedinRequest<T>(
   options: RequestInit & { rawQuery?: string } = {},
 ): Promise<LinkedInRequestResult<T>> {
   const url = `${LINKEDIN_API_BASE_URL}${endpoint}${options.rawQuery ? `?${options.rawQuery}` : ""}`;
-  const response = await fetch(url, {
+  const response = await linkedinFetch(url, {
     ...options,
     headers: {
       Authorization: `Bearer ${credentials.accessToken}`,
@@ -459,7 +476,7 @@ export const linkedinAdsProvider: AdProvider = {
     if (!clientId || !clientSecret) {
       throw new Error("LinkedIn Ads client credentials are not configured");
     }
-    const response = await fetch(LINKEDIN_OAUTH_TOKEN_URL, {
+    const response = await linkedinFetch(LINKEDIN_OAUTH_TOKEN_URL, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: new URLSearchParams({
@@ -757,7 +774,7 @@ export const linkedinAdsProvider: AdProvider = {
         if (!uploadUrl || !imageUrn) {
           throw new Error("LinkedIn image upload initialization returned no upload URL");
         }
-        const upload = await fetch(uploadUrl, {
+        const upload = await linkedinFetch(uploadUrl, {
           method: "PUT",
           headers: { Authorization: `Bearer ${credentials.accessToken}` },
           body: bytes,
@@ -792,7 +809,7 @@ export const linkedinAdsProvider: AdProvider = {
       }
       const uploadedPartIds: string[] = [];
       for (const instruction of instructions) {
-        const part = await fetch(instruction.uploadUrl, {
+        const part = await linkedinFetch(instruction.uploadUrl, {
           method: "PUT",
           headers: { Authorization: `Bearer ${credentials.accessToken}` },
           body: bytes.slice(instruction.firstByte, instruction.lastByte + 1),


### PR DESCRIPTION
## Problem

Every LinkedIn Ads fetch had **no timeout**: the shared `linkedinRequest` helper, the OAuth token refresh, and the image / video upload `PUT` hops could pin the ad-provider worker forever when the API hung without closing the connection. Ad account validation, campaign management, and media uploads all stall.

## Fix

- Add `linkedinFetch(input, init, timeoutMs = 30_000)`: fails closed at a **30s hop timeout**, preserving any caller-provided abort signal.
- Route all four fetch sites through it (API request helper, OAuth refresh, image upload PUT, video part upload PUT).

One module, one bounded behavior: no LinkedIn Ads hop can hang forever.

## Tests

`linkedin.error-policy.test.ts` (6 pass):

- new: **`linkedinFetch` aborts a hung LinkedIn API hop at the timeout** — a fetch that never settles is rejected with `AbortError` at the configured 100ms timeout (elapsed asserted < 5s).
- new: **`linkedinFetch` preserves a caller-provided abort signal** — the caller's signal passes through untouched.
- existing credential-validation error-policy tests still pass.

## Verification

```bash
bun test --isolate src/lib/services/advertising/providers/linkedin.error-policy.test.ts
# 6 pass, 0 fail
bunx biome check packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
# no issues
```
