### PR TITLE
fix(maps): bind results to provider attribution generation

### DIFF
--- a/plugins/plugin-maps/src/capabilities.ts
+++ b/plugins/plugin-maps/src/capabilities.ts
@@ -10,13 +10,15 @@ const PROVIDER_PARAM = {
   pattern: "^[a-zA-Z0-9][a-zA-Z0-9_-]*$",
 } as const;
 
+const PROVIDER_GENERATION_PARAM = {
+  type: "integer",
+  description:
+    "Exact adapter-registration generation that produced the result.",
+  minimum: 1,
+  maximum: Number.MAX_SAFE_INTEGER,
+} as const;
+
 export const MAPS_VIEW_CAPABILITIES: ViewCapability[] = [
-  {
-    id: "maps-describe-providers",
-    description:
-      "Read registered provider identities and adapter-owned attribution metadata.",
-    params: {},
-  },
   {
     id: "maps-search-places",
     description:
@@ -31,6 +33,7 @@ export const MAPS_VIEW_CAPABILITIES: ViewCapability[] = [
         pattern: "\\S",
       },
       provider: PROVIDER_PARAM,
+      providerGeneration: PROVIDER_GENERATION_PARAM,
       cursor: {
         type: "string",
         description: "Opaque next-page cursor from the preceding result.",
@@ -58,6 +61,7 @@ export const MAPS_VIEW_CAPABILITIES: ViewCapability[] = [
         maxLength: 512,
       },
       provider: PROVIDER_PARAM,
+      providerGeneration: PROVIDER_GENERATION_PARAM,
     },
   },
   {
@@ -82,6 +86,7 @@ export const MAPS_VIEW_CAPABILITIES: ViewCapability[] = [
         enum: ["drive", "walk", "bicycle", "transit"],
       },
       provider: PROVIDER_PARAM,
+      providerGeneration: PROVIDER_GENERATION_PARAM,
     },
   },
 ];

--- a/plugins/plugin-maps/src/components/MapsView.test.tsx
+++ b/plugins/plugin-maps/src/components/MapsView.test.tsx
@@ -16,7 +16,15 @@ import {
   mapsTestActionNotices,
   resetMapsTestActionNotices,
 } from "../../test/shims/ui-state.js";
-import type { PlacePage, PlaceRef, RoutePlan, TravelMode } from "../types.js";
+import type {
+  MapsPlacePageResult,
+  MapsPlaceResult,
+  MapsProviderDescription,
+  MapsRouteResult,
+  PlaceRef,
+  RoutePlan,
+  TravelMode,
+} from "../types.js";
 import { MapsView } from "./MapsView.js";
 import type { MapsViewTransport } from "./maps-view-data.js";
 
@@ -53,6 +61,34 @@ const PLAZA = place(
 );
 const PIER = place("pier-7", "Pier 7", ["landmark"], 37.8, -122.394);
 
+const PROVIDER: MapsProviderDescription = {
+  id: "fixture_maps",
+  attribution: "Map data © Fixture Maps",
+  generation: 1,
+};
+
+function pageResult(
+  places: PlaceRef[],
+  nextCursor: string | null = null,
+  provider: MapsProviderDescription = PROVIDER,
+): MapsPlacePageResult {
+  return { page: { places, nextCursor }, provider };
+}
+
+function placeResult(
+  place: PlaceRef | null,
+  provider: MapsProviderDescription = PROVIDER,
+): MapsPlaceResult {
+  return { place, provider };
+}
+
+function routeResult(
+  value: RoutePlan,
+  provider: MapsProviderDescription = PROVIDER,
+): MapsRouteResult {
+  return { route: value, provider };
+}
+
 function route(mode: TravelMode): RoutePlan {
   return {
     provider: "fixture_maps",
@@ -68,15 +104,11 @@ function route(mode: TravelMode): RoutePlan {
 
 function transport(over: Partial<MapsViewTransport> = {}): MapsViewTransport {
   return {
-    describeProviders: vi.fn(async () => [
-      {
-        id: "fixture_maps",
-        attribution: "Map data © Fixture Maps",
-      },
-    ]),
-    search: vi.fn(async () => ({ places: [FERRY, PLAZA], nextCursor: null })),
-    getPlace: vi.fn(async (value) => value),
-    planRoute: vi.fn(async (_origin, _destination, mode) => route(mode)),
+    search: vi.fn(async () => pageResult([FERRY, PLAZA])),
+    getPlace: vi.fn(async (value) => placeResult(value)),
+    planRoute: vi.fn(async (_origin, _destination, mode) =>
+      routeResult(route(mode)),
+    ),
     ...over,
   };
 }
@@ -124,63 +156,42 @@ describe("MapsView", () => {
     expect(screen.getByText("Embarcadero Plaza")).toBeTruthy();
   });
 
-  it("loads provider metadata after provider-backed results become available", async () => {
-    let providerReady = false;
-    const describeProviders = vi.fn(async () =>
-      providerReady
-        ? [{ id: "fixture_maps", attribution: "Late legal attribution" }]
-        : [],
-    );
-    const user = userEvent.setup();
-    render(
-      <MapsView
-        transport={transport({
-          describeProviders,
-          search: vi.fn(async () => {
-            providerReady = true;
-            return { places: [FERRY], nextCursor: null };
+  it("swaps successful replacement results and attribution as one generation", async () => {
+    const replacementProvider = {
+      ...PROVIDER,
+      attribution: "Replacement legal attribution",
+      generation: 2,
+    };
+    let resolveReplacement: ((result: MapsPlacePageResult) => void) | undefined;
+    const search = vi
+      .fn<MapsViewTransport["search"]>()
+      .mockResolvedValueOnce(pageResult([FERRY]))
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveReplacement = resolve;
           }),
-        })}
-        online
-      />,
-    );
-
-    expect(describeProviders).not.toHaveBeenCalled();
-    await searchFor(user, "waterfront");
-    expect(await screen.findByText("Late legal attribution")).toBeTruthy();
-    expect(describeProviders).toHaveBeenCalledTimes(1);
-  });
-
-  it("retries failed metadata after a successful repeat search", async () => {
-    const describeProviders = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("metadata temporarily unavailable"))
-      .mockResolvedValueOnce([
-        { id: "fixture_maps", attribution: "Recovered legal attribution" },
-      ]);
+      );
     const user = userEvent.setup();
-    render(<MapsView transport={transport({ describeProviders })} online />);
+    render(<MapsView transport={transport({ search })} online />);
 
-    await searchFor(user, "waterfront");
-    expect(
-      await screen.findByText("Legal attribution unavailable for fixture_maps"),
-    ).toBeTruthy();
+    await searchFor(user, "first");
+    expect(await screen.findByText(PROVIDER.attribution ?? "")).toBeTruthy();
 
-    await searchFor(user, "waterfront");
-    expect(await screen.findByText("Recovered legal attribution")).toBeTruthy();
-    expect(describeProviders).toHaveBeenCalledTimes(2);
+    await searchFor(user, "second");
+    expect(screen.getByText(PROVIDER.attribution ?? "")).toBeTruthy();
+    resolveReplacement?.(pageResult([PIER], null, replacementProvider));
+
+    expect((await screen.findAllByText("Pier 7")).length).toBeGreaterThan(0);
+    expect(screen.getByText("Replacement legal attribution")).toBeTruthy();
+    expect(screen.queryByText(PROVIDER.attribution ?? "")).toBeNull();
   });
 
   it("keeps prior results and attribution coherent while a replacement search is pending, and after it fails", async () => {
-    const describeProviders = vi.fn<
-      NonNullable<MapsViewTransport["describeProviders"]>
-    >(async () => [
-      { id: "fixture_maps", attribution: "Current legal attribution" },
-    ]);
     let rejectReplacementSearch: ((reason: unknown) => void) | undefined;
     const search = vi
       .fn<MapsViewTransport["search"]>()
-      .mockResolvedValueOnce({ places: [FERRY], nextCursor: null })
+      .mockResolvedValueOnce(pageResult([FERRY]))
       .mockImplementationOnce(
         () =>
           new Promise((_resolve, reject) => {
@@ -188,16 +199,13 @@ describe("MapsView", () => {
           }),
       );
     const user = userEvent.setup();
-    render(
-      <MapsView transport={transport({ describeProviders, search })} online />,
-    );
+    render(<MapsView transport={transport({ search })} online />);
 
     await searchFor(user, "first");
     expect(
       (await screen.findAllByText("Ferry Building")).length,
     ).toBeGreaterThan(0);
-    expect(await screen.findByText("Current legal attribution")).toBeTruthy();
-    await waitFor(() => expect(describeProviders).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(PROVIDER.attribution ?? "")).toBeTruthy();
 
     await searchFor(user, "second");
     // The replacement search is still in flight: the places list shows its
@@ -205,9 +213,8 @@ describe("MapsView", () => {
     // the still-unchanged `places`/`providers` state, not by search phase —
     // must keep showing the prior search's legal notice untouched, never a
     // stripped/mismatched "unavailable" placeholder.
-    expect(screen.getByText("Current legal attribution")).toBeTruthy();
+    expect(screen.getByText(PROVIDER.attribution ?? "")).toBeTruthy();
     expect(screen.queryByText(/attribution unavailable/i)).toBeNull();
-    expect(describeProviders).toHaveBeenCalledTimes(1);
 
     rejectReplacementSearch?.(new Error("search backend unavailable"));
     await screen.findByText("search backend unavailable");
@@ -218,9 +225,8 @@ describe("MapsView", () => {
     expect(
       (await screen.findAllByText("Ferry Building")).length,
     ).toBeGreaterThan(0);
-    expect(screen.getByText("Current legal attribution")).toBeTruthy();
+    expect(screen.getByText(PROVIDER.attribution ?? "")).toBeTruthy();
     expect(screen.queryByText(/attribution unavailable/i)).toBeNull();
-    expect(describeProviders).toHaveBeenCalledTimes(1);
   });
 
   it("explicitly reports unavailable legal attribution", async () => {
@@ -228,9 +234,9 @@ describe("MapsView", () => {
     render(
       <MapsView
         transport={transport({
-          describeProviders: vi.fn(async () => [
-            { id: "fixture_maps", attribution: null },
-          ]),
+          search: vi.fn(async () =>
+            pageResult([FERRY], null, { ...PROVIDER, attribution: null }),
+          ),
         })}
         online
       />,
@@ -241,29 +247,6 @@ describe("MapsView", () => {
       await screen.findByText("Legal attribution unavailable for fixture_maps"),
     ).toBeTruthy();
   });
-
-  it.each([
-    ["unsupported", undefined],
-    [
-      "failed",
-      vi.fn(async () => {
-        throw new Error("provider metadata unavailable");
-      }),
-    ],
-  ] as const)(
-    "degrades explicitly when provider metadata is %s",
-    async (_state, describeProviders) => {
-      const user = userEvent.setup();
-      render(<MapsView transport={transport({ describeProviders })} online />);
-
-      await searchFor(user, "waterfront");
-      expect(
-        await screen.findByText(
-          "Legal attribution unavailable for fixture_maps",
-        ),
-      ).toBeTruthy();
-    },
-  );
 
   it("gives every rendered control a unique collision-safe agent id", async () => {
     const collisionPlaces = [
@@ -277,8 +260,7 @@ describe("MapsView", () => {
       <MapsView
         transport={transport({
           search: vi.fn(async () => ({
-            places: collisionPlaces,
-            nextCursor: null,
+            ...pageResult(collisionPlaces),
           })),
         })}
         online
@@ -376,8 +358,8 @@ describe("MapsView", () => {
     const user = userEvent.setup();
     const search = vi
       .fn<MapsViewTransport["search"]>()
-      .mockResolvedValueOnce({ places: [FERRY, PLAZA], nextCursor: "page-2" })
-      .mockResolvedValueOnce({ places: [PLAZA, PIER, PIER], nextCursor: null });
+      .mockResolvedValueOnce(pageResult([FERRY, PLAZA], "page-2"))
+      .mockResolvedValueOnce(pageResult([PLAZA, PIER, PIER]));
     render(<MapsView transport={transport({ search })} online />);
 
     await searchFor(user, "waterfront");
@@ -394,6 +376,7 @@ describe("MapsView", () => {
       "waterfront",
       expect.any(AbortSignal),
       "page-2",
+      PROVIDER,
     );
     expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
   });
@@ -401,12 +384,12 @@ describe("MapsView", () => {
   it("keeps the newest result when searches resolve out of order", async () => {
     const pending = new Map<
       string,
-      { resolve: (value: { places: PlaceRef[]; nextCursor: null }) => void }
+      { resolve: (value: MapsPlacePageResult) => void }
     >();
     const fake = transport({
       search: vi.fn<MapsViewTransport["search"]>(
         (query) =>
-          new Promise<PlacePage>((resolve) => {
+          new Promise<MapsPlacePageResult>((resolve) => {
             pending.set(query, { resolve });
           }),
       ),
@@ -416,31 +399,31 @@ describe("MapsView", () => {
 
     await searchFor(user, "first");
     await searchFor(user, "second");
-    pending.get("second")?.resolve({ places: [PLAZA], nextCursor: null });
+    pending.get("second")?.resolve(pageResult([PLAZA]));
     expect(
       (await screen.findAllByText("Embarcadero Plaza")).length,
     ).toBeGreaterThan(0);
-    pending.get("first")?.resolve({ places: [FERRY], nextCursor: null });
+    pending.get("first")?.resolve(pageResult([FERRY]));
     await Promise.resolve();
     expect(screen.queryByText("Ferry Building")).toBeNull();
   });
 
   it("ignores an old place detail after a new search even when transport ignores abort", async () => {
-    let resolveOldDetail: ((value: PlaceRef) => void) | undefined;
+    let resolveOldDetail: ((value: MapsPlaceResult) => void) | undefined;
     let oldDetailSignal: AbortSignal | undefined;
     const staleDetail = { ...PLAZA, name: "Stale Plaza Detail" };
     const fake = transport({
       search: vi.fn<MapsViewTransport["search"]>(async (query) => ({
-        places: query === "new search" ? [PIER] : [FERRY, PLAZA],
-        nextCursor: null,
+        ...pageResult(query === "new search" ? [PIER] : [FERRY, PLAZA]),
       })),
-      getPlace: vi.fn<MapsViewTransport["getPlace"]>((value, signal) =>
-        value.providerPlaceId === PLAZA.providerPlaceId
-          ? new Promise<PlaceRef>((resolve) => {
-              oldDetailSignal = signal;
-              resolveOldDetail = resolve;
-            })
-          : Promise.resolve(value),
+      getPlace: vi.fn<MapsViewTransport["getPlace"]>(
+        (value, provider, signal) =>
+          value.providerPlaceId === PLAZA.providerPlaceId
+            ? new Promise<MapsPlaceResult>((resolve) => {
+                oldDetailSignal = signal;
+                resolveOldDetail = resolve;
+              })
+            : Promise.resolve(placeResult(value, provider)),
       ),
     });
     const user = userEvent.setup();
@@ -463,7 +446,7 @@ describe("MapsView", () => {
     expect(oldDetailSignal?.aborted).toBe(true);
     expect(await screen.findByRole("heading", { name: "Pier 7" })).toBeTruthy();
     await act(async () => {
-      resolveOldDetail?.(staleDetail);
+      resolveOldDetail?.(placeResult(staleDetail));
       await Promise.resolve();
     });
 
@@ -476,16 +459,15 @@ describe("MapsView", () => {
       destination: PlaceRef;
       mode: TravelMode;
       signal?: AbortSignal;
-      resolve: (value: RoutePlan) => void;
+      resolve: (value: MapsRouteResult) => void;
     }> = [];
     const fake = transport({
       search: vi.fn(async () => ({
-        places: [FERRY, PLAZA, PIER],
-        nextCursor: null,
+        ...pageResult([FERRY, PLAZA, PIER]),
       })),
       planRoute: vi.fn<MapsViewTransport["planRoute"]>(
-        (_origin, destination, mode, signal) =>
-          new Promise<RoutePlan>((resolve) => {
+        (_origin, destination, mode, _provider, signal) =>
+          new Promise<MapsRouteResult>((resolve) => {
             pendingRoutes.push({ destination, mode, signal, resolve });
           }),
       ),
@@ -529,16 +511,18 @@ describe("MapsView", () => {
         for (const pending of pendingRoutes.filter(
           ({ destination }) => destination.providerPlaceId === destinationId,
         )) {
-          pending.resolve({
-            provider: "fixture_maps",
-            routeId: `${destinationId}-${pending.mode}`,
-            origin: FERRY,
-            destination: pending.destination,
-            travelMode: pending.mode,
-            distanceMeters,
-            durationSeconds: 300,
-            warnings: [],
-          });
+          pending.resolve(
+            routeResult({
+              provider: "fixture_maps",
+              routeId: `${destinationId}-${pending.mode}`,
+              origin: FERRY,
+              destination: pending.destination,
+              travelMode: pending.mode,
+              distanceMeters,
+              durationSeconds: 300,
+              warnings: [],
+            }),
+          );
         }
         await Promise.resolve();
       });
@@ -560,8 +544,7 @@ describe("MapsView", () => {
   it("clears a stale route error when a new search starts", async () => {
     const fake = transport({
       search: vi.fn<MapsViewTransport["search"]>(async (query) => ({
-        places: query === "new search" ? [PIER] : [FERRY, PLAZA],
-        nextCursor: null,
+        ...pageResult(query === "new search" ? [PIER] : [FERRY, PLAZA]),
       })),
       planRoute: vi.fn(async () => {
         throw new Error("Old route failure");
@@ -591,7 +574,7 @@ describe("MapsView", () => {
     const fake = transport({
       search: vi.fn<MapsViewTransport["search"]>(
         () =>
-          new Promise<PlacePage>((_resolve, reject) => {
+          new Promise<MapsPlacePageResult>((_resolve, reject) => {
             rejectSearch = reject;
           }),
       ),

--- a/plugins/plugin-maps/src/components/MapsView.tsx
+++ b/plugins/plugin-maps/src/components/MapsView.tsx
@@ -64,6 +64,12 @@ function agentIdPart(value: string): string {
 
 type Phase = "idle" | "searching" | "ready" | "error";
 
+interface PlaceResultGeneration {
+  places: PlaceRef[];
+  nextCursor: string | null;
+  provider: MapsProviderDescription | null;
+}
+
 function readChatSheetOpen(): boolean {
   return (
     document
@@ -574,8 +580,12 @@ export function MapsView({
   const [lastQuery, setLastQuery] = useState("");
   const [phase, setPhase] = useState<Phase>("idle");
   const [error, setError] = useState<string | null>(null);
-  const [places, setPlaces] = useState<PlaceRef[]>([]);
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [placeResult, setPlaceResult] = useState<PlaceResultGeneration>({
+    places: [],
+    nextCursor: null,
+    provider: null,
+  });
+  const { places, nextCursor } = placeResult;
   const [pageBusy, setPageBusy] = useState(false);
   const [selected, setSelected] = useState<PlaceRef | null>(null);
   const [origin, setOrigin] = useState<PlaceRef | null>(null);
@@ -584,15 +594,13 @@ export function MapsView({
   const [activeRouteId, setActiveRouteId] = useState<string | null>(null);
   const [routeBusy, setRouteBusy] = useState(false);
   const [routeError, setRouteError] = useState<string | null>(null);
-  const [providers, setProviders] = useState<MapsProviderDescription[]>([]);
-  const [providerMetadataRevision, setProviderMetadataRevision] = useState(0);
+  const providers = placeResult.provider ? [placeResult.provider] : [];
   const [isOnline, setIsOnline] = useState(
     online ?? (typeof navigator === "undefined" ? true : navigator.onLine),
   );
   const searchRequest = useRef<AbortController | null>(null);
   const detailRequest = useRef<AbortController | null>(null);
   const routeRequest = useRef<AbortController | null>(null);
-  const providerMetadataRequest = useRef<AbortController | null>(null);
   const detailRequestGeneration = useRef(0);
   const routeRequestGeneration = useRef(0);
   const attributionProviderIds = useMemo(
@@ -604,10 +612,6 @@ export function MapsView({
     ],
     [places, routes],
   );
-  const attributionProviderKey = attributionProviderIds.join("\0");
-  const providerMetadataRequestKey = attributionProviderKey
-    ? `${attributionProviderKey}\0${providerMetadataRevision}`
-    : "";
 
   const invalidateRouteOperation = useCallback(() => {
     routeRequestGeneration.current += 1;
@@ -633,33 +637,6 @@ export function MapsView({
       window.removeEventListener("offline", update);
     };
   }, [online]);
-
-  useEffect(() => {
-    providerMetadataRequest.current?.abort();
-    providerMetadataRequest.current = null;
-    if (!providerMetadataRequestKey || !transport.describeProviders) {
-      setProviders([]);
-      return;
-    }
-    const controller = new AbortController();
-    providerMetadataRequest.current = controller;
-    void transport
-      .describeProviders(controller.signal)
-      .then((descriptions) => {
-        if (!controller.signal.aborted) setProviders(descriptions);
-      })
-      // error-policy:J4 Missing provider metadata is rendered as an explicit
-      // attribution-unavailable state for each provider returned by a search.
-      .catch((_cause: unknown) => {
-        if (!controller.signal.aborted) setProviders([]);
-      });
-    return () => {
-      controller.abort();
-      if (providerMetadataRequest.current === controller) {
-        providerMetadataRequest.current = null;
-      }
-    };
-  }, [providerMetadataRequestKey, transport]);
 
   useEffect(
     () => () => {
@@ -708,8 +685,6 @@ export function MapsView({
     async (requested: string) => {
       const normalized = requested.trim();
       if (!normalized) {
-        providerMetadataRequest.current?.abort();
-        providerMetadataRequest.current = null;
         searchRequest.current?.abort();
         detailRequestGeneration.current += 1;
         detailRequest.current?.abort();
@@ -717,11 +692,9 @@ export function MapsView({
         invalidateRouteOperation();
         setPhase("idle");
         setError(null);
-        setPlaces([]);
-        setNextCursor(null);
+        setPlaceResult({ places: [], nextCursor: null, provider: null });
         setSelected(null);
         setCategory("all");
-        setProviders([]);
         return;
       }
       if (normalized.length > 500) return;
@@ -741,24 +714,28 @@ export function MapsView({
       searchRequest.current = controller;
       setPhase("searching");
       setError(null);
-      // Leave `places`/`providers` untouched while this replacement search is
+      // Leave the prior result generation untouched while this replacement is
       // pending: the previously rendered results and their attribution are
-      // still the correct, coherent state for what's on screen. The provider
-      // metadata effect below only refetches once new places actually commit
-      // (via the revision bump on success), so a failed replacement never
-      // strips attribution from results that are still displayed.
+      // still the correct, coherent state for what's on screen. A successful
+      // broker response contains both the new page and
+      // its captured provider description, so the UI swaps them atomically.
       setLastQuery(normalized);
       try {
-        const page = await transport.search(normalized, controller.signal);
+        const result = await transport.search(normalized, controller.signal);
         if (controller.signal.aborted || searchRequest.current !== controller)
           return;
-        setPlaces(page.places);
-        setNextCursor(page.nextCursor);
-        setSelected(page.places[0] ?? null);
+        if (
+          placeResult.provider &&
+          (placeResult.provider.id !== result.provider.id ||
+            placeResult.provider.generation !== result.provider.generation)
+        ) {
+          setOrigin(null);
+        }
+        setPlaceResult({ ...result.page, provider: result.provider });
+        setSelected(result.page.places[0] ?? null);
         setCategory("all");
         setRoutes([]);
         setActiveRouteId(null);
-        setProviderMetadataRevision((revision) => revision + 1);
         setPhase("ready");
       } catch (cause) {
         if (controller.signal.aborted) return;
@@ -773,7 +750,13 @@ export function MapsView({
         if (searchRequest.current === controller) searchRequest.current = null;
       }
     },
-    [invalidateRouteOperation, isOnline, places.length, transport],
+    [
+      invalidateRouteOperation,
+      isOnline,
+      places.length,
+      placeResult.provider,
+      transport,
+    ],
   );
 
   const loadNextPage = useCallback(async () => {
@@ -788,22 +771,37 @@ export function MapsView({
         lastQuery,
         controller.signal,
         nextCursor,
+        placeResult.provider ?? undefined,
       );
       if (controller.signal.aborted) return;
-      setPlaces((current) => {
+      if (
+        !placeResult.provider ||
+        page.provider.id !== placeResult.provider.id ||
+        page.provider.generation !== placeResult.provider.generation
+      ) {
+        throw new Error(
+          "Maps pagination returned a different provider generation.",
+        );
+      }
+      setPlaceResult((current) => {
         const seen = new Set(
-          current.map((place) => `${place.provider}:${place.providerPlaceId}`),
+          current.places.map(
+            (place) => `${place.provider}:${place.providerPlaceId}`,
+          ),
         );
         const added: PlaceRef[] = [];
-        for (const place of page.places) {
+        for (const place of page.page.places) {
           const key = `${place.provider}:${place.providerPlaceId}`;
           if (seen.has(key)) continue;
           seen.add(key);
           added.push(place);
         }
-        return [...current, ...added];
+        return {
+          places: [...current.places, ...added],
+          nextCursor: page.page.nextCursor,
+          provider: page.provider,
+        };
       });
-      setNextCursor(page.nextCursor);
     } catch (cause) {
       if (controller.signal.aborted) return;
       // error-policy:J4 pagination failures preserve prior visible places.
@@ -816,7 +814,14 @@ export function MapsView({
       if (searchRequest.current === controller) searchRequest.current = null;
       if (!controller.signal.aborted) setPageBusy(false);
     }
-  }, [isOnline, lastQuery, nextCursor, pageBusy, transport]);
+  }, [
+    isOnline,
+    lastQuery,
+    nextCursor,
+    pageBusy,
+    placeResult.provider,
+    transport,
+  ]);
 
   const submitSearch = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
@@ -828,17 +833,18 @@ export function MapsView({
 
   const selectPlace = useCallback(
     (place: PlaceRef) => {
+      const provider = placeResult.provider;
       detailRequestGeneration.current += 1;
       const detailGeneration = detailRequestGeneration.current;
       detailRequest.current?.abort();
       detailRequest.current = null;
       invalidateRouteOperation();
       setSelected(place);
-      if (!isOnline) return;
+      if (!isOnline || !provider) return;
       const controller = new AbortController();
       detailRequest.current = controller;
       void transport
-        .getPlace(place, controller.signal)
+        .getPlace(place, provider, controller.signal)
         .then((detail) => {
           if (
             controller.signal.aborted ||
@@ -846,7 +852,15 @@ export function MapsView({
             detailRequestGeneration.current !== detailGeneration
           )
             return;
-          if (detail) setSelected(detail);
+          if (
+            detail.provider.id !== provider.id ||
+            detail.provider.generation !== provider.generation
+          ) {
+            throw new Error(
+              "Maps detail returned a different provider generation.",
+            );
+          }
+          if (detail.place) setSelected(detail.place);
         })
         // error-policy:J4 the normalized search result remains visible while
         // a failed optional detail enrichment is announced.
@@ -871,11 +885,12 @@ export function MapsView({
             detailRequest.current = null;
         });
     },
-    [invalidateRouteOperation, isOnline, transport],
+    [invalidateRouteOperation, isOnline, placeResult.provider, transport],
   );
 
   const planRoutes = useCallback(async () => {
-    if (!origin || !selected || routeBusy) return;
+    const provider = placeResult.provider;
+    if (!origin || !selected || !provider || routeBusy) return;
     if (
       origin.provider === selected.provider &&
       origin.providerPlaceId === selected.providerPlaceId
@@ -898,7 +913,13 @@ export function MapsView({
     try {
       const outcomes = await Promise.allSettled(
         TRAVEL_MODES.map((mode) =>
-          transport.planRoute(origin, selected, mode, controller.signal),
+          transport.planRoute(
+            origin,
+            selected,
+            mode,
+            provider,
+            controller.signal,
+          ),
         ),
       );
       if (
@@ -920,8 +941,20 @@ export function MapsView({
           new Error("No route alternatives are available.")
         );
       }
-      setRoutes(available);
-      setActiveRouteId(available[0]?.routeId ?? null);
+      if (
+        available.some(
+          (result) =>
+            result.provider.id !== provider.id ||
+            result.provider.generation !== provider.generation,
+        )
+      ) {
+        throw new Error(
+          "Maps routes returned a different provider generation.",
+        );
+      }
+      const routes = available.map((result) => result.route);
+      setRoutes(routes);
+      setActiveRouteId(routes[0]?.routeId ?? null);
     } catch (cause) {
       if (
         controller.signal.aborted ||
@@ -944,7 +977,7 @@ export function MapsView({
         setRouteBusy(false);
       }
     }
-  }, [isOnline, origin, routeBusy, selected, transport]);
+  }, [isOnline, origin, placeResult.provider, routeBusy, selected, transport]);
 
   const handoff = useCallback(
     (action: "MAPS_SAVE" | "MAPS_SHARE" | "MAPS_NAVIGATE") => {

--- a/plugins/plugin-maps/src/components/maps-view-data.test.ts
+++ b/plugins/plugin-maps/src/components/maps-view-data.test.ts
@@ -17,6 +17,12 @@ const PLACE = {
   categories: ["landmark"],
 };
 
+const PROVIDER = {
+  id: "fixture_maps",
+  attribution: "Map data © Fixture Maps",
+  generation: 7,
+};
+
 function response(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -24,85 +30,27 @@ function response(body: unknown, status = 200): Response {
   });
 }
 
-function providerMetadataResponse(providers: unknown): Response {
-  return response({
-    requestId: "maps-provider-request",
-    success: true,
-    result: {
-      success: true,
-      data: { providers },
-    },
-  });
-}
-
 describe("mapsViewTransport", () => {
   beforeEach(() => fetchWithCsrf.mockReset());
 
-  it("validates adapter-owned provider attribution metadata", async () => {
-    fetchWithCsrf.mockResolvedValueOnce(
-      providerMetadataResponse([
-        {
-          id: "fixture_maps",
-          attribution: "  Map data © Fixture Maps  ",
-        },
-      ]),
-    );
-
-    await expect(mapsViewTransport.describeProviders?.()).resolves.toEqual([
-      {
-        id: "fixture_maps",
-        attribution: "Map data © Fixture Maps",
-      },
-    ]);
-
-    fetchWithCsrf.mockResolvedValueOnce(
-      providerMetadataResponse([
-        {
-          id: "fixture_maps",
-          attribution: "x".repeat(501),
-        },
-      ]),
-    );
-    await expect(mapsViewTransport.describeProviders?.()).rejects.toThrow();
-  });
-
-  it.each([
-    ["blank attribution", [{ id: "fixture_maps", attribution: "   " }]],
-    ["invalid provider id", [{ id: "fixture maps", attribution: null }]],
-    [
-      "duplicate provider id",
-      [
-        { id: "fixture_maps", attribution: null },
-        { id: "fixture_maps", attribution: "Duplicate" },
-      ],
-    ],
-    [
-      "too many providers",
-      Array.from({ length: 33 }, (_, index) => ({
-        id: `fixture_${index}`,
-        attribution: null,
-      })),
-    ],
-  ])("rejects %s in provider metadata", async (_case, providers) => {
-    fetchWithCsrf.mockResolvedValueOnce(providerMetadataResponse(providers));
-    await expect(mapsViewTransport.describeProviders?.()).rejects.toThrow();
-  });
-
-  it("validates a successful search broker envelope", async () => {
+  it("validates a successful search page and its captured provider generation", async () => {
     fetchWithCsrf.mockResolvedValue(
       response({
         requestId: "maps-request-1",
         success: true,
         result: {
           success: true,
-          data: { places: [PLACE], nextCursor: null },
+          data: {
+            page: { places: [PLACE], nextCursor: null },
+            provider: PROVIDER,
+          },
         },
       }),
     );
 
     await expect(mapsViewTransport.search("ferry")).resolves.toEqual({
-      places: [PLACE],
-      nextCursor: null,
+      page: { places: [PLACE], nextCursor: null },
+      provider: PROVIDER,
     });
     expect(fetchWithCsrf).toHaveBeenCalledWith(
       "/api/views/maps/interact",
@@ -124,10 +72,13 @@ describe("mapsViewTransport", () => {
         result: {
           success: true,
           data: {
-            places: [
-              { ...PLACE, coordinates: { latitude: 900, longitude: 0 } },
-            ],
-            nextCursor: null,
+            page: {
+              places: [
+                { ...PLACE, coordinates: { latitude: 900, longitude: 0 } },
+              ],
+              nextCursor: null,
+            },
+            provider: PROVIDER,
           },
         },
       }),
@@ -158,7 +109,7 @@ describe("mapsViewTransport", () => {
     );
   });
 
-  it("forwards opaque cursors and surfaces expired or revoked authorization", async () => {
+  it("forwards opaque cursors with the exact provider generation", async () => {
     fetchWithCsrf.mockResolvedValueOnce(
       response({ error: { message: "Maps authorization expired." } }, 401),
     );
@@ -170,7 +121,7 @@ describe("mapsViewTransport", () => {
       response({ error: { message: "Maps authorization revoked." } }, 403),
     );
     await expect(
-      mapsViewTransport.search("museum", undefined, "opaque-page-2"),
+      mapsViewTransport.search("museum", undefined, "opaque-page-2", PROVIDER),
     ).rejects.toThrow("Maps authorization revoked.");
     expect(fetchWithCsrf).toHaveBeenLastCalledWith(
       "/api/views/maps/interact",
@@ -181,6 +132,8 @@ describe("mapsViewTransport", () => {
             query: "museum",
             limit: 24,
             cursor: "opaque-page-2",
+            provider: "fixture_maps",
+            providerGeneration: 7,
           },
         }),
       }),

--- a/plugins/plugin-maps/src/components/maps-view-data.ts
+++ b/plugins/plugin-maps/src/components/maps-view-data.ts
@@ -2,14 +2,14 @@
 
 import { fetchWithCsrf } from "@elizaos/ui/api/csrf-client";
 import {
+  type MapsPlacePageResult,
+  type MapsPlaceResult,
   type MapsProviderDescription,
-  mapsProviderDescriptionsSchema,
-  type PlacePage,
+  type MapsRouteResult,
+  mapsPlacePageResultSchema,
+  mapsPlaceResultSchema,
+  mapsRouteResultSchema,
   type PlaceRef,
-  placePageSchema,
-  placeRefSchema,
-  type RoutePlan,
-  routePlanSchema,
   type TravelMode,
 } from "../types.js";
 
@@ -23,20 +23,24 @@ interface BrokerEnvelope {
 }
 
 export interface MapsViewTransport {
-  /** Optional for host/test transports; absence renders attribution unavailable. */
-  describeProviders?(signal?: AbortSignal): Promise<MapsProviderDescription[]>;
   search(
     query: string,
     signal?: AbortSignal,
     cursor?: string,
-  ): Promise<PlacePage>;
-  getPlace(place: PlaceRef, signal?: AbortSignal): Promise<PlaceRef | null>;
+    provider?: MapsProviderDescription,
+  ): Promise<MapsPlacePageResult>;
+  getPlace(
+    place: PlaceRef,
+    provider: MapsProviderDescription,
+    signal?: AbortSignal,
+  ): Promise<MapsPlaceResult>;
   planRoute(
     origin: PlaceRef,
     destination: PlaceRef,
     travelMode: TravelMode,
+    provider: MapsProviderDescription,
     signal?: AbortSignal,
-  ): Promise<RoutePlan>;
+  ): Promise<MapsRouteResult>;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -104,38 +108,51 @@ async function invoke(
 }
 
 export const mapsViewTransport: MapsViewTransport = {
-  async describeProviders(signal) {
-    const value = await invoke("maps-describe-providers", {}, signal);
-    if (!isRecord(value)) {
-      throw new Error("Maps returned invalid provider metadata.");
-    }
-    return mapsProviderDescriptionsSchema.parse(value.providers);
-  },
-  async search(query, signal, cursor) {
-    return placePageSchema.parse(
+  async search(query, signal, cursor, provider) {
+    return mapsPlacePageResultSchema.parse(
       await invoke(
         "maps-search-places",
-        { query, limit: 24, ...(cursor ? { cursor } : {}) },
+        {
+          query,
+          limit: 24,
+          ...(cursor ? { cursor } : {}),
+          ...(provider
+            ? {
+                provider: provider.id,
+                providerGeneration: provider.generation,
+              }
+            : {}),
+        },
         signal,
       ),
     );
   },
-  async getPlace(place, signal) {
-    const value = await invoke(
-      "maps-get-place",
-      { placeId: place.providerPlaceId, provider: place.provider },
-      signal,
+  async getPlace(place, provider, signal) {
+    return mapsPlaceResultSchema.parse(
+      await invoke(
+        "maps-get-place",
+        {
+          placeId: place.providerPlaceId,
+          provider: provider.id,
+          providerGeneration: provider.generation,
+        },
+        signal,
+      ),
     );
-    if (!isRecord(value)) throw new Error("Maps returned invalid place data.");
-    return value.place === null ? null : placeRefSchema.parse(value.place);
   },
-  async planRoute(origin, destination, travelMode, signal) {
-    const value = await invoke(
-      "maps-plan-route",
-      { origin, destination, travelMode, provider: destination.provider },
-      signal,
+  async planRoute(origin, destination, travelMode, provider, signal) {
+    return mapsRouteResultSchema.parse(
+      await invoke(
+        "maps-plan-route",
+        {
+          origin,
+          destination,
+          travelMode,
+          provider: provider.id,
+          providerGeneration: provider.generation,
+        },
+        signal,
+      ),
     );
-    if (!isRecord(value)) throw new Error("Maps returned invalid route data.");
-    return routePlanSchema.parse(value.route);
   },
 };

--- a/plugins/plugin-maps/src/errors.ts
+++ b/plugins/plugin-maps/src/errors.ts
@@ -5,6 +5,7 @@ import { ElizaError } from "@elizaos/core";
 export type MapsErrorCode =
   | "MAPS_INVALID_INPUT"
   | "MAPS_PROVIDER_UNAVAILABLE"
+  | "MAPS_PROVIDER_CHANGED"
   | "MAPS_NOT_FOUND"
   | "MAPS_AUTH_EXPIRED"
   | "MAPS_AUTH_REVOKED"

--- a/plugins/plugin-maps/src/interact.test.ts
+++ b/plugins/plugin-maps/src/interact.test.ts
@@ -67,20 +67,6 @@ describe("Maps view serverInteract", () => {
     const { runtime, adapter } = harness();
 
     await expect(
-      serverInteract("maps-describe-providers", {}, { runtime }),
-    ).resolves.toMatchObject({
-      success: true,
-      data: {
-        providers: [
-          {
-            id: "fixture_maps",
-            attribution: "Map data © Fixture Maps",
-          },
-        ],
-      },
-    });
-
-    await expect(
       serverInteract(
         "maps-search-places",
         { query: " waterfront ", limit: 12 },
@@ -88,7 +74,14 @@ describe("Maps view serverInteract", () => {
       ),
     ).resolves.toMatchObject({
       success: true,
-      data: { places: [ORIGIN, DESTINATION], nextCursor: null },
+      data: {
+        page: { places: [ORIGIN, DESTINATION], nextCursor: null },
+        provider: {
+          id: "fixture_maps",
+          attribution: "Map data © Fixture Maps",
+          generation: 1,
+        },
+      },
     });
     expect(adapter.searchPlaces).toHaveBeenCalledWith({
       query: "waterfront",
@@ -101,7 +94,13 @@ describe("Maps view serverInteract", () => {
         { placeId: ORIGIN.providerPlaceId, provider: ORIGIN.provider },
         { runtime },
       ),
-    ).resolves.toMatchObject({ success: true, data: { place: ORIGIN } });
+    ).resolves.toMatchObject({
+      success: true,
+      data: {
+        place: ORIGIN,
+        provider: { id: "fixture_maps", generation: 1 },
+      },
+    });
 
     await expect(
       serverInteract(
@@ -109,7 +108,13 @@ describe("Maps view serverInteract", () => {
         { origin: ORIGIN, destination: DESTINATION, travelMode: "walk" },
         { runtime },
       ),
-    ).resolves.toMatchObject({ success: true, data: { route: ROUTE } });
+    ).resolves.toMatchObject({
+      success: true,
+      data: {
+        route: ROUTE,
+        provider: { id: "fixture_maps", generation: 1 },
+      },
+    });
   });
 
   it("returns typed invalid-input and provider failures", async () => {

--- a/plugins/plugin-maps/src/interact.ts
+++ b/plugins/plugin-maps/src/interact.ts
@@ -5,6 +5,7 @@ import { ZodError } from "zod";
 import { MapsError } from "./errors.js";
 import { getMapsService } from "./service.js";
 import {
+  mapsProviderGenerationSchema,
   mapsProviderIdSchema,
   placeRefSchema,
   placeSearchRequestSchema,
@@ -81,14 +82,12 @@ export async function serverInteract(
       values.provider === undefined
         ? undefined
         : mapsProviderIdSchema.parse(requiredText(values.provider, "provider"));
+    const providerGeneration =
+      values.providerGeneration === undefined
+        ? undefined
+        : mapsProviderGenerationSchema.parse(values.providerGeneration);
     const service = getMapsService(context.runtime);
     switch (capability) {
-      case "maps-describe-providers":
-        return {
-          success: true,
-          text: "Loaded maps provider metadata.",
-          data: { providers: service.describeProviders() },
-        };
       case "maps-search-places": {
         const request = placeSearchRequestSchema.parse({
           query: requiredText(values.query, "query"),
@@ -97,24 +96,31 @@ export async function serverInteract(
             : {}),
           ...(typeof values.limit === "number" ? { limit: values.limit } : {}),
         });
-        const page = await service.searchPlaces(request, provider);
-        return {
-          success: true,
-          text: page.places.length
-            ? `Found ${page.places.length} place${page.places.length === 1 ? "" : "s"}.`
-            : "No matching places were found.",
-          data: page,
-        };
-      }
-      case "maps-get-place": {
-        const place = await service.getPlace(
-          requiredText(values.placeId, "place id"),
+        const result = await service.searchPlacesResult(
+          request,
           provider,
+          providerGeneration,
         );
         return {
           success: true,
-          text: place ? `Found ${place.name}.` : "No matching place was found.",
-          data: { place },
+          text: result.page.places.length
+            ? `Found ${result.page.places.length} place${result.page.places.length === 1 ? "" : "s"}.`
+            : "No matching places were found.",
+          data: result,
+        };
+      }
+      case "maps-get-place": {
+        const result = await service.getPlaceResult(
+          requiredText(values.placeId, "place id"),
+          provider,
+          providerGeneration,
+        );
+        return {
+          success: true,
+          text: result.place
+            ? `Found ${result.place.name}.`
+            : "No matching place was found.",
+          data: result,
         };
       }
       case "maps-plan-route": {
@@ -123,11 +129,15 @@ export async function serverInteract(
           destination: placeRefSchema.parse(values.destination),
           travelMode: values.travelMode,
         });
-        const route = await service.planRoute(request, provider);
+        const result = await service.planRouteResult(
+          request,
+          provider,
+          providerGeneration,
+        );
         return {
           success: true,
-          text: `Planned a ${route.travelMode} route.`,
-          data: { route },
+          text: `Planned a ${result.route.travelMode} route.`,
+          data: result,
         };
       }
       default:

--- a/plugins/plugin-maps/src/maps.test.ts
+++ b/plugins/plugin-maps/src/maps.test.ts
@@ -24,7 +24,11 @@ import {
   MAX_SAVED_PLACE_STATE_BYTES,
   MAX_SAVED_PLACES_PER_OWNER,
 } from "./store.js";
-import { MAX_MAPS_PROVIDER_ID_LENGTH, MAX_MAPS_PROVIDERS } from "./types.js";
+import {
+  MAX_MAPS_PROVIDER_ID_LENGTH,
+  MAX_MAPS_PROVIDERS,
+  type PlacePage,
+} from "./types.js";
 
 const AGENT_ID = "11111111-1111-4111-a111-111111111111" as UUID;
 const OWNER_ID = "22222222-2222-4222-a222-222222222222" as UUID;
@@ -303,10 +307,11 @@ describe("MapsService and MAPS action", () => {
     expect(() =>
       opaqueService.registerAdapter({ ...adapter, attribution: " " }),
     ).toThrow(expect.objectContaining({ code: "MAPS_INVALID_INPUT" }));
-    expect(opaqueService.describeProviders()).toEqual([
+    expect(opaqueService.describeProviders([adapter.id])).toEqual([
       {
         id: adapter.id,
         attribution: null,
+        generation: 1,
       },
     ]);
   });
@@ -320,30 +325,33 @@ describe("MapsService and MAPS action", () => {
     attributionService.registerAdapter(mutableAdapter, true);
 
     mutableAdapter.attribution = "x".repeat(501);
-    const description = attributionService.describeProviders();
+    const description = attributionService.describeProviders([adapter.id]);
     expect(description).toEqual([
       {
         id: adapter.id,
         attribution: "Map data © Contract Maps",
+        generation: 1,
       },
     ]);
 
     (description[0] as { attribution: string | null }).attribution =
       "caller mutation";
-    expect(attributionService.describeProviders()[0]?.attribution).toBe(
-      "Map data © Contract Maps",
-    );
+    expect(
+      attributionService.describeProviders([adapter.id])[0]?.attribution,
+    ).toBe("Map data © Contract Maps");
 
     attributionService.registerAdapter({
       ...adapter,
       attribution: "Updated legal notice",
     });
-    expect(attributionService.describeProviders()[0]?.attribution).toBe(
-      "Updated legal notice",
-    );
+    expect(attributionService.describeProviders([adapter.id])[0]).toEqual({
+      id: adapter.id,
+      attribution: "Updated legal notice",
+      generation: 2,
+    });
   });
 
-  it("keeps registration unlimited but bounds the describeProviders DTO", () => {
+  it("keeps registration unlimited and resolves a 33rd default provider exactly", async () => {
     const boundedService = new MapsService(runtime);
     expect(() =>
       boundedService.registerAdapter({
@@ -359,36 +367,89 @@ describe("MapsService and MAPS action", () => {
         connectionId: `conn_${String(index).padStart(16, "0")}`,
       });
     }
-    expect(boundedService.describeProviders()).toHaveLength(MAX_MAPS_PROVIDERS);
-
-    // Registration itself has no cap: the 33rd adapter registers successfully
-    // and remains reachable for search/route/save; only the browser-facing
-    // describeProviders() DTO is bounded, at the describe boundary.
+    const overflowId = "one_provider_too_many";
     expect(() =>
-      boundedService.registerAdapter({
-        ...adapter,
-        id: "one_provider_too_many",
-        connectionId: "conn_overflow00000000",
-      }),
+      boundedService.registerAdapter(
+        {
+          ...adapter,
+          id: overflowId,
+          connectionId: "conn_overflow00000000",
+          attribution: "Overflow legal attribution",
+          async searchPlaces() {
+            return {
+              places: [{ ...home, provider: overflowId }],
+              nextCursor: null,
+            };
+          },
+        },
+        true,
+      ),
     ).not.toThrow();
     expect(boundedService.listAdapters()).toHaveLength(MAX_MAPS_PROVIDERS + 1);
-    expect(boundedService.describeProviders()).toHaveLength(MAX_MAPS_PROVIDERS);
-    expect(
-      boundedService
-        .describeProviders()
-        .some((provider) => provider.id === "one_provider_too_many"),
-    ).toBe(false);
+    expect(boundedService.describeProviders([overflowId])).toEqual([
+      {
+        id: overflowId,
+        attribution: "Overflow legal attribution",
+        generation: MAX_MAPS_PROVIDERS + 1,
+      },
+    ]);
+    await expect(
+      boundedService.searchPlacesResult({ query: "default" }),
+    ).resolves.toMatchObject({
+      page: { places: [{ provider: overflowId }] },
+      provider: {
+        id: overflowId,
+        attribution: "Overflow legal attribution",
+        generation: MAX_MAPS_PROVIDERS + 1,
+      },
+    });
+  });
 
-    boundedService.registerAdapter({
+  it("binds an in-flight result to the adapter generation that started it", async () => {
+    let resolveSearch: ((page: PlacePage) => void) | undefined;
+    const generationService = new MapsService(runtime);
+    generationService.registerAdapter(
+      {
+        ...adapter,
+        attribution: "Original legal attribution",
+        searchPlaces: vi.fn(
+          () =>
+            new Promise<
+              Awaited<ReturnType<MapsProviderAdapter["searchPlaces"]>>
+            >((resolve) => {
+              resolveSearch = resolve;
+            }),
+        ),
+      },
+      true,
+    );
+
+    const inFlight = generationService.searchPlacesResult({ query: "old" });
+    generationService.registerAdapter({
       ...adapter,
-      id: "provider_0",
-      connectionId: "conn_replacement000000",
-      attribution: "Replacement attribution",
+      attribution: "Replacement legal attribution",
     });
-    expect(boundedService.describeProviders()[0]).toEqual({
-      id: "provider_0",
-      attribution: "Replacement attribution",
+    resolveSearch?.({ places: [home], nextCursor: null });
+
+    await expect(inFlight).resolves.toMatchObject({
+      provider: {
+        id: adapter.id,
+        attribution: "Original legal attribution",
+        generation: 1,
+      },
     });
+    await expect(
+      generationService.searchPlacesResult({ query: "new" }),
+    ).resolves.toMatchObject({
+      provider: {
+        id: adapter.id,
+        attribution: "Replacement legal attribution",
+        generation: 2,
+      },
+    });
+    await expect(
+      generationService.searchPlacesResult({ query: "stale" }, adapter.id, 1),
+    ).rejects.toMatchObject({ code: "MAPS_PROVIDER_CHANGED" });
   });
 
   it("validates public store UUIDs before creating persistence namespaces", async () => {

--- a/plugins/plugin-maps/src/service.ts
+++ b/plugins/plugin-maps/src/service.ts
@@ -7,10 +7,14 @@ import { MapsError } from "./errors.js";
 import { RuntimeSavedPlaceStore, type SavedPlaceStore } from "./store.js";
 import {
   coordinatesSchema,
-  MAX_MAPS_PROVIDERS,
+  MAX_MAPS_PROVIDER_GENERATION,
+  type MapsPlacePageResult,
+  type MapsPlaceResult,
   type MapsProviderDescription,
+  type MapsRouteResult,
   mapsAttributionSchema,
   mapsProviderIdSchema,
+  mapsProviderIdsSchema,
   type PlacePage,
   type PlaceRef,
   type PlaceSearchRequest,
@@ -32,6 +36,11 @@ export interface MapsHandoff {
   kind: "share" | "navigate";
   uri: string;
   place: PlaceRef;
+}
+
+interface RegisteredMapsProvider {
+  adapter: MapsProviderAdapter;
+  description: MapsProviderDescription;
 }
 
 function validated<T>(
@@ -127,11 +136,8 @@ export class MapsService extends Service {
   override capabilityDescription =
     "Provider-neutral place search, route planning, durable saved places, sharing, and navigation handoffs.";
 
-  private readonly adapters = new Map<string, MapsProviderAdapter>();
-  private readonly providerDescriptions = new Map<
-    string,
-    MapsProviderDescription
-  >();
+  private readonly providers = new Map<string, RegisteredMapsProvider>();
+  private providerGeneration = 0;
   private defaultAdapterId: string | null = null;
   private readonly store: SavedPlaceStore;
 
@@ -145,8 +151,7 @@ export class MapsService extends Service {
   }
 
   override async stop(): Promise<void> {
-    this.adapters.clear();
-    this.providerDescriptions.clear();
+    this.providers.clear();
     this.defaultAdapterId = null;
   }
 
@@ -171,58 +176,79 @@ export class MapsService extends Service {
         cause: attribution.error,
       });
     }
-    this.adapters.set(providerId.data, adapter);
-    this.providerDescriptions.set(providerId.data, {
-      id: providerId.data,
-      attribution: attribution?.data ?? null,
+    if (this.providerGeneration >= MAX_MAPS_PROVIDER_GENERATION) {
+      throw new MapsError("Maps provider generation capacity is exhausted.", {
+        code: "MAPS_PROVIDER_UNAVAILABLE",
+      });
+    }
+    this.providerGeneration += 1;
+    this.providers.set(providerId.data, {
+      adapter,
+      description: {
+        id: providerId.data,
+        attribution: attribution?.data ?? null,
+        generation: this.providerGeneration,
+      },
     });
     if (makeDefault || this.defaultAdapterId === null)
       this.defaultAdapterId = providerId.data;
   }
 
   unregisterAdapter(adapterId: string): void {
-    this.adapters.delete(adapterId);
-    this.providerDescriptions.delete(adapterId);
+    this.providers.delete(adapterId);
     if (this.defaultAdapterId === adapterId) {
-      this.defaultAdapterId = this.adapters.keys().next().value ?? null;
+      this.defaultAdapterId = this.providers.keys().next().value ?? null;
     }
   }
 
   listAdapters(): readonly string[] {
-    return [...this.adapters.keys()];
+    return [...this.providers.keys()];
   }
 
   /**
-   * Describes registered providers without exposing credentials or endpoints.
-   * Registration itself stays unlimited; the DTO returned to the view/broker
-   * boundary is bounded here at MAX_MAPS_PROVIDERS so the browser-facing
-   * schema (`mapsProviderDescriptionsSchema`) can never be handed a payload
-   * it will reject.
+   * Describes only the exact bounded provider ids requested by a consumer.
+   * Result-producing providers cannot disappear behind registration order.
    */
-  describeProviders(): readonly MapsProviderDescription[] {
-    return [...this.providerDescriptions.values()]
-      .slice(0, MAX_MAPS_PROVIDERS)
-      .map((provider) => ({
-        id: provider.id,
-        attribution: provider.attribution,
-      }));
+  describeProviders(providerIds: readonly string[]): MapsProviderDescription[] {
+    const ids = validated(
+      mapsProviderIdsSchema,
+      providerIds,
+      "Maps provider description lookup is invalid.",
+    );
+    return ids.flatMap((id) => {
+      const provider = this.providers.get(id);
+      return provider ? [this.copyDescription(provider.description)] : [];
+    });
   }
 
   async searchPlaces(
     request: PlaceSearchRequest,
     provider?: string,
   ): Promise<PlacePage> {
-    const adapter = this.adapter(provider);
+    return (await this.searchPlacesResult(request, provider)).page;
+  }
+
+  async searchPlacesResult(
+    request: PlaceSearchRequest,
+    provider?: string,
+    expectedGeneration?: number,
+  ): Promise<MapsPlacePageResult> {
+    const registration = this.provider(provider, expectedGeneration);
+    const { adapter } = registration;
     const page = validated(
       placePageSchema,
       await adapter.searchPlaces(validatedSearchRequest(request)),
       "Maps provider returned an invalid place page.",
     );
-    return {
+    const normalizedPage = {
       ...page,
       places: page.places.map((place) =>
         assertProviderPlace(place, adapter, "place search result"),
       ),
+    };
+    return {
+      page: normalizedPage,
+      provider: this.copyDescription(registration.description),
     };
   }
 
@@ -230,21 +256,42 @@ export class MapsService extends Service {
     providerPlaceId: string,
     provider?: string,
   ): Promise<PlaceRef | null> {
-    const adapter = this.adapter(provider);
+    return (await this.getPlaceResult(providerPlaceId, provider)).place;
+  }
+
+  async getPlaceResult(
+    providerPlaceId: string,
+    provider?: string,
+    expectedGeneration?: number,
+  ): Promise<MapsPlaceResult> {
+    const registration = this.provider(provider, expectedGeneration);
+    const { adapter } = registration;
     if (!providerPlaceId || providerPlaceId.length > 512) {
       throw new MapsError("Place id is invalid.", {
         code: "MAPS_INVALID_INPUT",
       });
     }
     const place = await adapter.getPlace(providerPlaceId);
-    return place ? assertProviderPlace(place, adapter, "place detail") : null;
+    return {
+      place: place ? assertProviderPlace(place, adapter, "place detail") : null,
+      provider: this.copyDescription(registration.description),
+    };
   }
 
   async planRoute(
     request: RoutePlanRequest,
     provider?: string,
   ): Promise<RoutePlan> {
-    const adapter = this.adapter(provider);
+    return (await this.planRouteResult(request, provider)).route;
+  }
+
+  async planRouteResult(
+    request: RoutePlanRequest,
+    provider?: string,
+    expectedGeneration?: number,
+  ): Promise<MapsRouteResult> {
+    const registration = this.provider(provider, expectedGeneration);
+    const { adapter } = registration;
     const normalized = {
       origin: validated(
         placeRefSchema,
@@ -355,7 +402,10 @@ export class MapsService extends Service {
         },
       );
     }
-    return route;
+    return {
+      route,
+      provider: this.copyDescription(registration.description),
+    };
   }
 
   async savePlace(request: SavePlaceRequest): Promise<SavePlaceResult> {
@@ -419,16 +469,41 @@ export class MapsService extends Service {
     };
   }
 
-  private adapter(provider?: string): MapsProviderAdapter {
+  private provider(
+    provider?: string,
+    expectedGeneration?: number,
+  ): RegisteredMapsProvider {
     const id = provider?.trim() || this.defaultAdapterId;
-    const adapter = id ? this.adapters.get(id) : undefined;
-    if (!adapter) {
+    const registration = id ? this.providers.get(id) : undefined;
+    if (!registration) {
       throw new MapsError("No maps provider adapter is available.", {
         code: "MAPS_PROVIDER_UNAVAILABLE",
         context: { requestedProvider: provider ?? null },
       });
     }
-    return adapter;
+    if (
+      expectedGeneration !== undefined &&
+      registration.description.generation !== expectedGeneration
+    ) {
+      throw new MapsError(
+        "The maps provider changed after these results loaded. Search again before continuing.",
+        {
+          code: "MAPS_PROVIDER_CHANGED",
+          context: {
+            providerId: id,
+            expectedGeneration,
+            actualGeneration: registration.description.generation,
+          },
+        },
+      );
+    }
+    return registration;
+  }
+
+  private copyDescription(
+    description: MapsProviderDescription,
+  ): MapsProviderDescription {
+    return { ...description };
   }
 }
 

--- a/plugins/plugin-maps/src/types.ts
+++ b/plugins/plugin-maps/src/types.ts
@@ -8,6 +8,7 @@ const opaqueText = (max: number) => z.string().min(1).max(max);
 export const MAX_MAPS_PROVIDERS = 32;
 export const MAX_MAPS_PROVIDER_ID_LENGTH = 64;
 export const MAX_MAPS_ATTRIBUTION_LENGTH = 500;
+export const MAX_MAPS_PROVIDER_GENERATION = Number.MAX_SAFE_INTEGER;
 
 /** Validates the canonical identity used to join adapter and browser metadata. */
 export const mapsProviderIdSchema = z
@@ -24,12 +25,26 @@ export const mapsAttributionSchema = z
   .min(1);
 
 /** Couples one canonical provider id to legal text or explicit unavailability. */
+export const mapsProviderGenerationSchema = z
+  .number()
+  .int()
+  .positive()
+  .max(MAX_MAPS_PROVIDER_GENERATION);
+
 export const mapsProviderDescriptionSchema = z
   .object({
     id: mapsProviderIdSchema,
     attribution: mapsAttributionSchema.nullable(),
+    generation: mapsProviderGenerationSchema,
   })
   .strict();
+
+export const mapsProviderIdsSchema = z
+  .array(mapsProviderIdSchema)
+  .max(MAX_MAPS_PROVIDERS)
+  .refine((providers) => new Set(providers).size === providers.length, {
+    message: "Maps provider lookup ids must be unique.",
+  });
 
 export const mapsProviderDescriptionsSchema = z
   .array(mapsProviderDescriptionSchema)
@@ -108,6 +123,45 @@ export const placePageSchema = z
   })
   .strict();
 
+/** Binds one page to the exact adapter registration that generated it. */
+export const mapsPlacePageResultSchema = z
+  .object({
+    page: placePageSchema,
+    provider: mapsProviderDescriptionSchema,
+  })
+  .strict()
+  .refine(
+    (result) =>
+      result.page.places.every(
+        (place) => place.provider === result.provider.id,
+      ),
+    { message: "Maps page provider binding does not match its places." },
+  );
+
+/** Binds one detail read to the exact adapter registration that generated it. */
+export const mapsPlaceResultSchema = z
+  .object({
+    place: placeRefSchema.nullable(),
+    provider: mapsProviderDescriptionSchema,
+  })
+  .strict()
+  .refine(
+    (result) =>
+      result.place === null || result.place.provider === result.provider.id,
+    { message: "Maps detail provider binding does not match its place." },
+  );
+
+/** Binds one route to the exact adapter registration that generated it. */
+export const mapsRouteResultSchema = z
+  .object({
+    route: routePlanSchema,
+    provider: mapsProviderDescriptionSchema,
+  })
+  .strict()
+  .refine((result) => result.route.provider === result.provider.id, {
+    message: "Maps route provider binding does not match its route.",
+  });
+
 export const placeSearchRequestSchema = z
   .object({
     query: boundedText(500),
@@ -135,6 +189,9 @@ export type TravelMode = z.infer<typeof travelModeSchema>;
 export type RoutePlan = z.infer<typeof routePlanSchema>;
 export type SavedPlace = z.infer<typeof savedPlaceSchema>;
 export type PlacePage = z.infer<typeof placePageSchema>;
+export type MapsPlacePageResult = z.infer<typeof mapsPlacePageResultSchema>;
+export type MapsPlaceResult = z.infer<typeof mapsPlaceResultSchema>;
+export type MapsRouteResult = z.infer<typeof mapsRouteResultSchema>;
 
 export interface PlaceSearchRequest {
   query: string;


### PR DESCRIPTION
## Summary

Fix-forward for merged #23422. Results and legal attribution now come from the same immutable provider registration generation, and consumers fence follow-up operations against provider replacement.

- return page/place/route data with the exact captured provider description and generation
- atomically swap result data and attribution in the Maps UI
- reject stale pagination/detail/route continuations with `MAPS_PROVIDER_CHANGED`
- replace insertion-order truncation with bounded exact provider-ID lookup
- cover in-flight replacement, stale-generation rejection, the 33rd/default provider, and pending/failed/successful replacement behavior

## Validation

Pinned Bun 1.3.14 and Node 24.15.0:

- affected Maps service/interact/broker/UI suites: 47/47 pass
- plugin-maps Biome: 33 files clean
- `git diff --check`: pass

Broader package validation remains blocked in this isolated checkout by unbuilt `@elizaos/plugin-sql` and `@elizaos/ui` workspace artifacts. Keep this PR draft until exact-head hosted checks and independent review are green.

Refs #23422
