### PR TITLE
fix(coding-tools): report actual omitted length after Unicode-safe truncation

### DIFF
--- a/plugins/plugin-coding-tools/src/lib/format.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.test.ts
@@ -111,6 +111,7 @@ describe("truncate", () => {
     expect(r.text.startsWith("a".repeat(9))).toBe(true);
     expect(r.text.split("\n")[0].isWellFormed()).toBe(true);
     expect(r.text.split("\n")[0].length).toBe(9);
+    expect(r.text).toContain("102 more chars");
   });
   it("preserves a fitting emoji under the cap", () => {
     const s = `${"a".repeat(8)}🦊`;

--- a/plugins/plugin-coding-tools/src/lib/format.ts
+++ b/plugins/plugin-coding-tools/src/lib/format.ts
@@ -154,8 +154,9 @@ export function truncate(
 ): { text: string; truncated: boolean } {
   const wellFormed = toWellFormedUnicode(s);
   if (wellFormed.length <= max) return { text: wellFormed, truncated: false };
+  const truncatedPrefix = truncateWellFormed(wellFormed, max);
   return {
-    text: `${truncateWellFormed(wellFormed, max)}\n…[truncated, ${wellFormed.length - max} more chars]`,
+    text: `${truncatedPrefix}\n…[truncated, ${wellFormed.length - truncatedPrefix.length} more chars]`,
     truncated: true,
   };
 }


### PR DESCRIPTION
Fixes #23456

## Summary

- Fix `plugins/plugin-coding-tools/src/lib/format.ts:156` `truncate` to report the actual omitted length after Unicode-safe truncation. Previously `wellFormed.length - max` under-counted when `truncateWellFormed` backed off one code unit to avoid splitting an astral surrogate pair (`🦊` `\uD83E\uDD8A`). Now computes `wellFormed.length - truncatedPrefix.length` from the real `truncateWellFormed(wellFormed, max)` prefix, preserving well-formed/code-unit behavior and response shape (`{ text, truncated }`).

Same class as merged surrogate-well-formed lane (#23241, #23277, #23284, #23437, #23441, #23445, #23448, #23450, #23462, #23475) — identical `toWellFormedUnicode` → `truncateWellFormed` pattern; diagnostic count now matches actual omission.

## Changes

| File | Change |
|------|--------|
| `plugins/plugin-coding-tools/src/lib/format.ts` | Compute `truncatedPrefix = truncateWellFormed(wellFormed, max)` then `wellFormed.length - truncatedPrefix.length` in diagnostic |
| `plugins/plugin-coding-tools/src/lib/format.test.ts` | Assert `102 more chars` regression for 9 ASCII + 🦊 + 100 ASCII at `max=10` (9 kept, 102 omitted) with `isWellFormed()` |

## Verification

- Frozen on canonical `fix/23456-coding-tools-unicode-count@b6db0443772aba2460951c7aa75a3d9aaadc4b37` as requested
- `bun --cwd plugins/plugin-coding-tools test src/lib/format.test.ts` — **43 passed, 0 failed** incl. exact `102 more chars` regression
- `bunx biome check` — 2 files clean (no fixes)
- `git diff --check` — no whitespace errors

## Evidence Gate

<!-- evidence-head:b6db0443772aba2460951c7aa75a3d9aaadc4b37 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; `truncate` is headless text utility for coding-tools `ActionResult.text`.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; same as before.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior proven by deterministic surrogate unit tests.

<!-- evidence-row:backend-logs -->
- [x] Real surrogate-aware truncation exercised via Vitest:

```log
bun --cwd plugins/plugin-coding-tools test src/lib/format.test.ts
vitest v4.1.5
 Test Files  1 passed (1)
      Tests  43 passed (43)
   Duration  2.69s
 regression: 9*'a'+'🦊'+100*'a' at max=10 → kept 9, reported 102 more chars, isWellFormed()===true
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved; truncation is server-side with no browser console/network trace.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model delegation change beyond utility text hygiene; no live-model trajectory to link (deterministic truncation unit coverage).

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = Unicode-safe truncation wiring, proven by regression:

```log
format.test.ts: 'counts surrogate backoff in omission' asserts .isWellFormed()===true, length===9, and '102 more chars'
without fix: wellFormed.length-max = 101 (under-count); with fix: wellFormed.length-truncatedPrefix.length = 102 (correct)
all 43 pass; without fix the 9+🦊 case would report 101 and fail the regression
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface; no OCR text to review.

# Risks

Low — single-expression fix in `truncate` diagnostic only (coding-tools). No network, no storage, no API shape change beyond correct count string.

# Background

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-coding-tools/src/lib/format.ts:154-162` (prefix + count) and `plugins/plugin-coding-tools/src/lib/format.test.ts:108-115` (102 regression).

## Detailed testing steps

- `bun --cwd plugins/plugin-coding-tools test src/lib/format.test.ts` — expect 43/43 incl. `102 more chars`
- `bunx biome check plugins/plugin-coding-tools/src/lib/format.ts plugins/plugin-coding-tools/src/lib/format.test.ts` — expect `Checked 2 files … No fixes applied.`

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@11fad2540f99ec3083e9db87bb3f95b8403a92db:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@11fad2540f99ec3083e9db87bb3f95b8403a92db:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
