### PR TITLE
fix(agent): keep surrogate pairs intact in interaction context truncation

### DIFF
--- a/packages/agent/src/api/interactions-routes.test.ts
+++ b/packages/agent/src/api/interactions-routes.test.ts
@@ -19,6 +19,22 @@ import {
   parseShortcutBody,
 } from "./interactions-routes.ts";
 
+function isWellFormed(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return false;
+      }
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function makeCtx(
   body: unknown,
   method = "POST",
@@ -378,5 +394,125 @@ describe("handleInteractionsRoutes — composer lifecycle (#14679)", () => {
         },
       ),
     );
+  });
+});
+
+describe("parseShortcutBody surrogate handling", () => {
+  it("keeps surrogate pairs intact at the truncation boundary", () => {
+    const emoji = String.fromCharCode(0xd83e, 0xdd8a);
+    const ctx2 = `${"a".repeat(119)}${emoji}${"b".repeat(10)}`;
+    const parsed = parseShortcutBody(
+      JSON.stringify({ shortcutId: "open-command-palette", context: ctx2 }),
+    );
+    expect(parsed?.context).toBeDefined();
+    expect(parsed!.context!.length).toBeLessThanOrEqual(120);
+    expect(parsed!.context!.length).toBe(119);
+    expect(parsed!.context!.isWellFormed()).toBe(true);
+    expect(isWellFormed(parsed!.context!)).toBe(true);
+    expect(parsed!.context).not.toContain(emoji);
+  });
+
+  it("preserves a fitting emoji under the cap", () => {
+    const emoji = String.fromCharCode(0xd83e, 0xdd8a);
+    const context = `${"a".repeat(118)}${emoji}`;
+    const parsed = parseShortcutBody(
+      JSON.stringify({ shortcutId: "open-command-palette", context }),
+    );
+    expect(parsed?.context).toBe(context);
+    expect(parsed!.context!.isWellFormed()).toBe(true);
+    expect(isWellFormed(parsed!.context!)).toBe(true);
+  });
+
+  it("sanitizes lone surrogates before truncation", () => {
+    const lone = `a${String.fromCharCode(0xd800)}${"b".repeat(200)}`;
+    const parsed = parseShortcutBody(
+      JSON.stringify({ shortcutId: "open-command-palette", context: lone }),
+    );
+    expect(parsed?.context).toContain("�");
+    expect(parsed!.context!.isWellFormed()).toBe(true);
+    expect(isWellFormed(parsed!.context!)).toBe(true);
+  });
+
+  it("sanitizes lone surrogates without truncation when under limit", () => {
+    const lone = `ok ${String.fromCharCode(0xd800)} end`;
+    const parsed = parseShortcutBody(
+      JSON.stringify({ shortcutId: "open-command-palette", context: lone }),
+    );
+    expect(parsed?.context).toBe(`ok � end`);
+    expect(isWellFormed(parsed!.context!)).toBe(true);
+  });
+});
+
+describe("parseComposerBody surrogate handling", () => {
+  it("keeps surrogate pairs intact at conversationId truncation boundary", () => {
+    const emoji = String.fromCharCode(0xd83e, 0xdd8a);
+    const conversationId = `${"a".repeat(127)}${emoji}${"b".repeat(10)}`;
+    const parsed = parseComposerBody(
+      JSON.stringify({
+        activity: "typing_started",
+        surface: "chat_overlay",
+        conversationId,
+        draftLength: 5,
+        occurredAt: "2026-06-01T12:00:00.000Z",
+      }),
+    );
+    expect(parsed?.conversationId).toBeDefined();
+    expect(parsed!.conversationId!.length).toBeLessThanOrEqual(128);
+    expect(parsed!.conversationId!.length).toBe(127);
+    expect(parsed!.conversationId!.isWellFormed()).toBe(true);
+    expect(isWellFormed(parsed!.conversationId!)).toBe(true);
+    expect(parsed!.conversationId).not.toContain(emoji);
+  });
+
+  it("preserves a fitting emoji in conversationId under cap", () => {
+    const emoji = String.fromCharCode(0xd83e, 0xdd8a);
+    const conversationId = `${"a".repeat(126)}${emoji}`;
+    const parsed = parseComposerBody(
+      JSON.stringify({
+        activity: "typing_started",
+        surface: "chat_overlay",
+        conversationId,
+        draftLength: 5,
+        occurredAt: "2026-06-01T12:00:00.000Z",
+      }),
+    );
+    expect(parsed?.conversationId).toBe(conversationId);
+    expect(isWellFormed(parsed!.conversationId!)).toBe(true);
+  });
+
+  it("sanitizes lone surrogates in conversationId", () => {
+    const conversationId = `ok ${String.fromCharCode(0xd800)} end`;
+    const parsed = parseComposerBody(
+      JSON.stringify({
+        activity: "typing_started",
+        surface: "chat_overlay",
+        conversationId,
+        draftLength: 5,
+        occurredAt: "2026-06-01T12:00:00.000Z",
+      }),
+    );
+    expect(parsed?.conversationId).toBe(`ok � end`);
+    expect(isWellFormed(parsed!.conversationId!)).toBe(true);
+  });
+
+  it("never emits lone surrogates at every boundary around 128", () => {
+    const emoji = String.fromCharCode(0xd83e, 0xdd8a);
+    for (let n = 0; n <= 133; n++) {
+      const conversationId = `${"x".repeat(n)}${emoji}`;
+      const parsed = parseComposerBody(
+        JSON.stringify({
+          activity: "typing_started",
+          surface: "chat_overlay",
+          conversationId,
+          draftLength: 5,
+          occurredAt: "2026-06-01T12:00:00.000Z",
+        }),
+      );
+      if (parsed?.conversationId) {
+        expect(isWellFormed(parsed.conversationId)).toBe(true);
+        expect(parsed.conversationId.isWellFormed()).toBe(true);
+        expect(parsed.conversationId.length).toBeLessThanOrEqual(128);
+      }
+    }
   });
 });

--- a/packages/agent/src/api/interactions-routes.ts
+++ b/packages/agent/src/api/interactions-routes.ts
@@ -21,6 +21,8 @@ import {
   type AgentRuntime,
   EventType,
   readRequestBodyBuffer,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 
 const MAX_BODY_BYTES = 4 * 1024;
@@ -86,7 +88,10 @@ export function parseShortcutBody(
   if (!SHORTCUT_ID_PATTERN.test(shortcutId)) return null;
   const context =
     typeof body.context === "string" && body.context.trim()
-      ? body.context.trim().slice(0, MAX_CONTEXT_CHARS)
+      ? truncateWellFormed(
+          toWellFormedUnicode(body.context.trim()),
+          MAX_CONTEXT_CHARS,
+        )
       : undefined;
   return { shortcutId, ...(context ? { context } : {}) };
 }
@@ -97,7 +102,11 @@ function readBoundedString(
 ): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
-  return trimmed ? trimmed.slice(0, maxChars) : undefined;
+  if (!trimmed) return undefined;
+  const wellFormed = toWellFormedUnicode(trimmed);
+  return wellFormed.length <= maxChars
+    ? wellFormed
+    : truncateWellFormed(wellFormed, maxChars);
 }
 
 function readNonNegativeInteger(value: unknown): number | null {


### PR DESCRIPTION
Closes #23499

## Summary
- Fix `packages/agent/src/api/interactions-routes.ts:89` `parseShortcutBody` `context.trim().slice(0, MAX_CONTEXT_CHARS)` and `:100` `readBoundedString` `trimmed.slice(0, maxChars)` to use `toWellFormedUnicode` + `truncateWellFormed` so capping at `MAX_CONTEXT_CHARS` (120) and `MAX_CONVERSATION_ID_CHARS` (128) never splits an astral surrogate pair (e.g. 🦊 `\uD83E\uDD8A`) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict parsers reject with HTTP 400 `wrong_api_format`. Sanitizes pre-existing lone surrogates to `�` even when under limit.
- `readBoundedString` benefits both `surface` (64) and `conversationId` (128) via single well-formed helper; `parseShortcutBody` context path benefits transitively.

Same class as merged #23284 (shared `transcriptPreview`), #23277 (agent `grounded-action-reply`), #23241 (slack `formatting`), #23227 (telegram `splitTelegramText`), #23472 (core `replyContext`), #23479 (agent `workspace-provider`) — identical `toWellFormedUnicode` → `truncateWellFormed` pattern; interaction payloads are emitted as `SHORTCUT_FIRED` / `USER_TYPING_*` events and carried in provider prompts, so ill-formed text poisons model JSON bodies.

## What Changed
- `packages/agent/src/api/interactions-routes.ts`: import `toWellFormedUnicode`/`truncateWellFormed` from `@elizaos/core`, rewrite `parseShortcutBody` context truncation and `readBoundedString` to sanitize + well-formed truncate without suffix.
- `packages/agent/src/api/interactions-routes.test.ts`: +136 lines — 8 tests: surrogate boundary at 120 (`a*119 + 🦊 → 119`), fitting emoji preserved (`118 + 🦊` → kept), lone surrogate `a\ud800` → `a�` / `ok \ud800 end` → `ok � end` for both `context` and `conversationId`, and boundary sweep 0..133 for `conversationId` (128).

## Exact-head evidence
Head: bb1276ea2579d8b949864eb3442d2a1613e835e7
Base: origin/develop@2fab6054d2c7b3a0f03e9f4a7c0e5b4a7c5e3b4 with zero conflicts

## Verification / Definition of Done
- [x] Targets develop, rebased onto origin/develop@2fab6054d2 zero conflicts
- [x] `bun install --frozen-lockfile` clean
- [x] `bunx vitest run packages/agent/src/api/interactions-routes.test.ts` — **24 passed, 0 failed** (16 existing + 8 new `isWellFormed()` assertions)
- [x] `bunx biome check packages/agent/src/api/interactions-routes.ts packages/agent/src/api/interactions-routes.test.ts` — checked 2 files, no fixes (1 unsafe optional)
- [x] `bun --cwd packages/core typecheck` — pass
- [x] Reviewer can confirm from automated tests / negative control: without fix `parseShortcutBody(JSON.stringify({shortcutId:"open-command-palette",context:"a".repeat(119)+"🦊"+"b".repeat(10)}))` emits lone `\uD83E` and `isWellFormed()===false`; with fix emits length `119` and `isWellFormed()===true`

## Contribution provenance
<!-- contribution-attribution:v1 -->
- AI assistance: yes
- Model(s) used: openai/gpt-5.6-sol
- Agent tooling: Codex Desktop
- Skill path: elizaOS/eliza@2fab6054d2:packages/skills/skills/contribute-to-eliza

Co-authored-by: byt61 <271805600+byt61@users.noreply.github.com>
