### PR TITLE
test(core): publish continuation evidence after cleanup

### DIFF
--- a/packages/core/src/__tests__/planner-continuation-trajectory.test.ts
+++ b/packages/core/src/__tests__/planner-continuation-trajectory.test.ts
@@ -37,6 +37,7 @@ import {
 } from "../services/post-delivery-task-tracker.ts";
 import type { IAgentRuntime } from "../types/runtime.ts";
 import {
+	finalizePlannerContinuationEvidence,
 	type PlannerContinuationTrajectoryDetail,
 	readCompletedPlannerContinuationTrajectory,
 	serializePlannerContinuationEvidence,
@@ -490,5 +491,49 @@ describe("planner continuation evidence artifact — atomic write to disk", () =
 		const { readdir } = await import("node:fs/promises");
 		const entries = await readdir(dir);
 		expect(entries).toEqual(["evidence.json"]);
+	});
+});
+
+describe("planner continuation evidence finalization", () => {
+	const cleanOutcome = {
+		runId: "run-finalize",
+		harness: harnessFixture,
+		evidence: [{ caseName: "directive", executed: true }],
+		progress: { totalCases: 1, completedCases: 1 },
+	};
+
+	it("does not publish captured until cleanup completes", async () => {
+		const cleanupGate = deferred();
+		const published: string[] = [];
+		const pending = finalizePlannerContinuationEvidence(
+			cleanOutcome,
+			() => cleanupGate.promise,
+			async (body) => {
+				published.push(body);
+			},
+		);
+
+		await Promise.resolve();
+		expect(published).toEqual([]);
+		cleanupGate.resolve();
+		await pending;
+		expect(JSON.parse(published[0] ?? "{}").status).toBe("captured");
+	});
+
+	it("publishes cleanup-failed once and keeps teardown red", async () => {
+		const published: string[] = [];
+		await expect(
+			finalizePlannerContinuationEvidence(
+				cleanOutcome,
+				async () => {
+					throw new Error("cleanup failed");
+				},
+				async (body) => {
+					published.push(body);
+				},
+			),
+		).rejects.toThrow("cleanup failed");
+		expect(published).toHaveLength(1);
+		expect(JSON.parse(published[0] ?? "{}").status).toBe("cleanup-failed");
 	});
 });

--- a/packages/core/src/__tests__/planner-continuation-trajectory.ts
+++ b/packages/core/src/__tests__/planner-continuation-trajectory.ts
@@ -303,3 +303,28 @@ export async function writePlannerContinuationEvidenceArtifact(
 	await writeFile(tmpPath, body);
 	await rename(tmpPath, path);
 }
+
+/**
+ * Finish teardown before publishing a terminal artifact. Publishing
+ * `captured` first would leave a false-success receipt if teardown hung or the
+ * process was killed before a later cleanup-failed rewrite.
+ */
+export async function finalizePlannerContinuationEvidence(
+	outcome: PlannerContinuationEvidenceOutcome,
+	cleanup: () => Promise<void>,
+	publish: (body: string) => Promise<void>,
+): Promise<void> {
+	let cleanupError: unknown;
+	try {
+		await cleanup();
+	} catch (error) {
+		// error-policy:J1 The live-test boundary records this teardown failure in
+		// the terminal artifact and then rethrows it to keep the lane red.
+		cleanupError = error;
+	}
+
+	await publish(
+		serializePlannerContinuationEvidence({ ...outcome, cleanupError }),
+	);
+	if (cleanupError !== undefined) throw cleanupError;
+}

--- a/packages/core/src/__tests__/planner-continuation.live.test.ts
+++ b/packages/core/src/__tests__/planner-continuation.live.test.ts
@@ -19,6 +19,7 @@ import {
 	type RealTestRuntimeResult,
 } from "../testing/index.ts";
 import {
+	finalizePlannerContinuationEvidence,
 	type PlannerContinuationRunProgress,
 	readCompletedPlannerContinuationTrajectory,
 	serializePlannerContinuationEvidence,
@@ -150,44 +151,15 @@ liveDescribe("planner continuation — live Cerebras message loop", () => {
 	}, 180_000);
 
 	afterAll(async () => {
-		if (evidencePath) {
-			await writePlannerContinuationEvidenceArtifact(
-				evidencePath,
-				serializePlannerContinuationEvidence({
-					runId,
-					harness,
-					evidence,
-					progress,
-					setupError,
-					testError,
-				}),
-			);
-		}
-		try {
-			await harness?.cleanup();
-		} catch (cleanupError) {
-			// A would-be `captured` run whose teardown then fails is downgraded to
-			// `cleanup-failed` so the artifact does not read as a fully clean run;
-			// a run that already failed on its own terms keeps that more specific
-			// status instead of being overwritten by the later teardown failure —
-			// this is the same "don't let a second failure mask the first" defect
-			// this file exists to fix, just one step later in the sequence.
-			if (evidencePath) {
-				await writePlannerContinuationEvidenceArtifact(
-					evidencePath,
-					serializePlannerContinuationEvidence({
-						runId,
-						harness,
-						evidence,
-						progress,
-						setupError,
-						testError,
-						cleanupError,
-					}),
-				);
-			}
-			throw cleanupError;
-		}
+		await finalizePlannerContinuationEvidence(
+			{ runId, harness, evidence, progress, setupError, testError },
+			async () => harness?.cleanup(),
+			async (body) => {
+				if (evidencePath) {
+					await writePlannerContinuationEvidenceArtifact(evidencePath, body);
+				}
+			},
+		);
 	});
 
 	async function runTurn(params: {


### PR DESCRIPTION
## Summary

Fix-forward for merged #23400. The new evidence state machine wrote a terminal `captured` artifact before runtime cleanup, then attempted to rewrite it only if cleanup threw. A process kill or teardown hang in that window could therefore leave a false success receipt.

This change:

- completes cleanup before publishing any terminal artifact
- publishes exactly one terminal state (`captured`, the earlier run failure, or `cleanup-failed`)
- leaves the prior `started` sentinel intact if teardown hangs or the process is interrupted
- rethrows cleanup failure after recording it so the lane remains red

## Validation

Pinned Bun 1.3.14 / repository Vitest:

- planner continuation trajectory suite: 21/21 pass
- Biome on all three changed files: pass
- `git diff --check`: pass

Core typecheck was attempted with pinned Node 24.15.0 but this isolated checkout lacks several existing workspace/third-party modules (`@elizaos/cloud-routing`, `ai`, `mammoth`, `unpdf`, `dotenv`, `@noble/ciphers`). Keep draft until exact-head hosted checks, independent review, and the real Cerebras/PGlite live run are green.

Refs #23400
Refs #22845
