### PR TITLE
registry: add elizaos-plugin-livetennis (mid-flight abort fix, v0.1.2)

### DIFF
--- a/packages/registry/entries/third-party/elizaos-plugin-livetennis.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-livetennis.json
@@ -1,0 +1,15 @@
+{
+  "package": "elizaos-plugin-livetennis",
+  "repository": "github:livetennisapi/elizaos-plugin-livetennis",
+  "kind": "plugin",
+  "description": "Live tennis scores, upcoming fixtures, and player search for elizaOS agents via the Live Tennis API \u2014 ATP, WTA, Challenger, ITF and juniors. FREE-tier endpoints only, with honest per-action tier errors.",
+  "homepage": "https://livetennisapi.com",
+  "version": "0.1.2",
+  "tags": [
+    "tennis",
+    "sports",
+    "live-scores",
+    "fixtures",
+    "rankings"
+  ]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1421,6 +1421,51 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "elizaos-plugin-livetennis": {
+      "git": {
+        "repo": "livetennisapi/elizaos-plugin-livetennis",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "elizaos-plugin-livetennis",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.2"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Live tennis scores, upcoming fixtures, and player search for elizaOS agents via the Live Tennis API — ATP, WTA, Challenger, ITF and juniors. FREE-tier endpoints only, with honest per-action tier errors.",
+      "homepage": "https://livetennisapi.com",
+      "topics": [
+        "tennis",
+        "sports",
+        "live-scores",
+        "fixtures",
+        "rankings"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "elizaos-plugin-neynar-search": {
       "git": {
         "repo": "xavier-arosemena/elizaos-plugin-neynar-search",


### PR DESCRIPTION
Re-opening the registry listing for **elizaos-plugin-livetennis** after addressing the codex-review on #22030 (which I closed to force-push cleanly; GitHub wouldn't let me re-open it).

**The review's blocker is fixed.** The finding was correct: on a *mid-flight* abort, the client wrapped the aborted fetch as a `LiveTennisApiError`, and the provider then returned a **successful empty** `ProviderResult` with `liveTennisError: "network_error"` — misclassifying a cancelled turn and preventing the runtime's `PROVIDER_COMPOSITION_ABORTED` path.

**0.1.2 (published to npm) fixes it:**
- `client.ts`: an aborted fetch (caller signal **or** the request timeout) now **re-throws the abort identity** (`signal.reason` when present) instead of wrapping it. New exported `isAbortError()`.
- The match-context provider's `catch` **re-throws an abort** (rather than `reportFailure`), so a mid-flight cancellation propagates as a **rejection**.
- Two new tests assert the provider **rejects** with the AbortError / `signal.reason` on a mid-flight abort (not resolves a diagnostic). Full suite: typecheck + tsup build + **34 vitest tests green**.

**Registry PR contents (2 files, rebased onto current `develop`):**
- entry `version` → **0.1.2**
- `generated-registry.json` regenerated via `bun run src/generate.ts` — `validate`: **48 third-party entries passed**.

The npm 0.1.2 tarball is built from tag `v0.1.2` on `livetennisapi/elizaos-plugin-livetennis`. Disclosure: vendor-authored (I run the Live Tennis API), free-tier, self-gated. Thanks for the genuinely useful review — the abort-identity catch was right.