### PR TITLE
fix(cloud): bound Vertex AI tuning REST hops

### DIFF
--- a/packages/cloud/shared/src/lib/services/vertex-tuning.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/vertex-tuning.error-policy.test.ts
@@ -5,7 +5,7 @@
  * global fetch is mocked and restored per test.
  */
 import { afterEach, describe, expect, test } from "bun:test";
-import { getTuningJobStatus, listTuningJobs } from "./vertex-tuning";
+import { getTuningJobStatus, listTuningJobs, vertexTuningFetch } from "./vertex-tuning";
 
 const realFetch = globalThis.fetch;
 
@@ -65,5 +65,39 @@ describe("getTuningJobStatus — internal failure propagates", () => {
     const result = await getTuningJobStatus(job.name, "token");
     expect(result.state).toBe("JOB_STATE_SUCCEEDED");
     expect(result.tunedModelDisplayName).toBe("tuned-x");
+  });
+});
+
+describe("vertexTuningFetch — bounded hops fail closed and keep caller signals", () => {
+  test("aborts a hung Vertex AI API hop at the timeout", async () => {
+    // An API that never settles on its own: the only way out is the caller's
+    // AbortSignal firing (the 30s default bounds every tuning hop).
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      return await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      });
+    }) as typeof fetch;
+
+    const start = Date.now();
+    await expect(
+      vertexTuningFetch("https://aiplatform.googleapis.com/v1/jobs/x", undefined, 100),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("preserves a caller-provided abort signal", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen = init?.signal;
+      return new Response(JSON.stringify({ tuningJobs: [] }), { status: 200 });
+    }) as typeof fetch;
+
+    const controller = new AbortController();
+    await vertexTuningFetch("https://aiplatform.googleapis.com/v1/jobs/x", {
+      signal: controller.signal,
+    });
+    expect(seen).toBe(controller.signal);
   });
 });

--- a/packages/cloud/shared/src/lib/services/vertex-tuning.ts
+++ b/packages/cloud/shared/src/lib/services/vertex-tuning.ts
@@ -5,6 +5,23 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
+const VERTEX_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Bound every Vertex AI REST hop so a hung or rate-limited API cannot pin the
+ * tuning worker indefinitely. A caller-provided abort signal wins.
+ */
+export function vertexTuningFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = VERTEX_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
+
 export interface VertexTuningConfig {
   projectId: string;
   region?: string;
@@ -172,7 +189,7 @@ export async function uploadToGCS(
   const content = await readFile(localPath);
   const uploadUrl = `https://storage.googleapis.com/upload/storage/v1/b/${bucket}/o?uploadType=media&name=${encodeURIComponent(objectName)}`;
 
-  const response = await fetch(uploadUrl, {
+  const response = await vertexTuningFetch(uploadUrl, {
     method: "POST",
     headers: {
       authorization: `Bearer ${accessToken}`,
@@ -216,7 +233,7 @@ export async function createTuningJob(config: VertexTuningConfig): Promise<Creat
   };
   const sourceModel = `publishers/google/models/${modelMap[config.baseModel] ?? config.baseModel}`;
 
-  const response = await fetch(
+  const response = await vertexTuningFetch(
     `https://${region}-aiplatform.googleapis.com/v1/projects/${config.projectId}/locations/${region}/tuningJobs`,
     {
       method: "POST",
@@ -262,7 +279,7 @@ export async function listTuningJobs(
   accessToken?: string,
 ): Promise<TuningJob[]> {
   const token = await getAccessToken(accessToken);
-  const response = await fetch(
+  const response = await vertexTuningFetch(
     `https://${region}-aiplatform.googleapis.com/v1/projects/${projectId}/locations/${region}/tuningJobs`,
     {
       headers: { authorization: `Bearer ${token}` },
@@ -282,7 +299,7 @@ export async function getTuningJobStatus(
   accessToken?: string,
 ): Promise<TuningJob> {
   const token = await getAccessToken(accessToken);
-  const response = await fetch(`https://aiplatform.googleapis.com/v1/${jobName}`, {
+  const response = await vertexTuningFetch(`https://aiplatform.googleapis.com/v1/${jobName}`, {
     headers: { authorization: `Bearer ${token}` },
   });
 


### PR DESCRIPTION
## Problem

Every Vertex AI tuning fetch had **no timeout**: the GCS media upload, tuning-job create, job list, and job status hops could pin the tuning worker forever when the API hung without closing the connection.

## Fix

- Add `vertexTuningFetch(input, init, timeoutMs = 30_000)`: fails closed at a **30s hop timeout**, preserving any caller-provided abort signal.
- Route all four fetch sites through it.

One module, one bounded behavior: no Vertex tuning hop can hang forever.

## Tests

`vertex-tuning.error-policy.test.ts` (7 pass):

- new: **`vertexTuningFetch` aborts a hung Vertex AI API hop at the timeout** — a fetch that never settles is rejected with `AbortError` at the configured 100ms timeout (elapsed asserted < 5s).
- new: **`vertexTuningFetch` preserves a caller-provided abort signal**.
- existing tuning transport error-policy tests still pass.

## Verification

```bash
bun test --isolate src/lib/services/vertex-tuning.error-policy.test.ts
# 7 pass, 0 fail
bunx biome check packages/cloud/shared/src/lib/services/vertex-tuning.ts
# no issues
```
