### PR TITLE
fix(agent): keep surrogate pairs intact in dynamic skill provider truncation

### DIFF
--- a/packages/agent/src/providers/skill-provider.test.ts
+++ b/packages/agent/src/providers/skill-provider.test.ts
@@ -140,6 +140,9 @@ describe("createDynamicSkillProvider instructions well-formed Unicode", () => {
       {} as never,
     );
 
+    if (typeof result.text !== "string") {
+      throw new Error("expected provider result text to be a string");
+    }
     expect(isWellFormed(result.text)).toBe(true);
     expect(result.text).toContain(
       "[truncated — use USE_SKILL for full instructions]",

--- a/packages/agent/src/providers/skill-provider.test.ts
+++ b/packages/agent/src/providers/skill-provider.test.ts
@@ -3,7 +3,23 @@
  * an unrelated prior topic to keep injecting its instructions.
  */
 import { describe, expect, it } from "vitest";
-import { createDynamicSkillProvider } from "./skill-provider.ts";
+import { createDynamicSkillProvider, truncateDesc } from "./skill-provider.ts";
+
+function isWellFormed(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return false;
+      }
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
 
 const skills = [
   {
@@ -67,5 +83,66 @@ describe("dynamic skill current-turn relevance", () => {
 
     expect(result.values?.activeSkill).toBe("eliza-cloud");
     expect(result.text).toContain("## Active Skill: Eliza Cloud");
+  });
+});
+
+describe("truncateDesc well-formed Unicode boundaries", () => {
+  it("keeps surrogate pairs intact when truncating description at boundary", () => {
+    const max = 80;
+    const budget = max - 3;
+    const text = `${"a".repeat(budget - 1)}🦊${"b".repeat(50)}`;
+    const out = truncateDesc(text, max);
+    expect(out.length).toBeLessThanOrEqual(max);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.endsWith("...")).toBe(true);
+  });
+
+  it("preserves fitting emoji under limit", () => {
+    const text = `${"a".repeat(70)}🦊`;
+    const out = truncateDesc(text, 80);
+    expect(out).toBe(text);
+    expect(isWellFormed(out)).toBe(true);
+  });
+
+  it("sanitizes lone surrogates before truncation", () => {
+    const lone = `a\uD800${"b".repeat(100)}`;
+    const out = truncateDesc(lone, 80);
+    expect(out).toContain("");
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(80);
+  });
+});
+
+describe("createDynamicSkillProvider instructions well-formed Unicode", () => {
+  it("keeps surrogate pairs intact when truncating active skill instructions", async () => {
+    const longBody = `${"a".repeat(1999)}🦊${"b".repeat(50)}`;
+    const customRuntime = {
+      getService: () => ({
+        getLoadedSkills: () => [
+          {
+            slug: "test-skill",
+            name: "Test Skill",
+            description: "A test skill for instructions truncation",
+          },
+        ],
+        getSkillInstructions: () => ({
+          slug: "test-skill",
+          body: longBody,
+          estimatedTokens: 500,
+        }),
+      }),
+    };
+
+    const provider = createDynamicSkillProvider();
+    const result = await provider.get(
+      customRuntime as never,
+      { content: { text: "test-skill instructions" } } as never,
+      {} as never,
+    );
+
+    expect(isWellFormed(result.text)).toBe(true);
+    expect(result.text).toContain(
+      "[truncated — use USE_SKILL for full instructions]",
+    );
   });
 });

--- a/packages/agent/src/providers/skill-provider.ts
+++ b/packages/agent/src/providers/skill-provider.ts
@@ -13,13 +13,15 @@
  *   - Strong:    Full instructions of #1 match, capped at 2000 chars
  */
 
-import type {
-  IAgentRuntime,
-  Memory,
-  Provider,
-  ProviderResult,
-  Service,
-  State,
+import {
+  type IAgentRuntime,
+  type Memory,
+  type Provider,
+  type ProviderResult,
+  type Service,
+  type State,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 
 // ── Stopwords ────────────────────────────────────────────────────────────────
@@ -283,9 +285,12 @@ function scoreQuery(index: BM25Index, queryText: string): ScoredSkill[] {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function truncateDesc(desc: string, maxLen: number): string {
-  if (desc.length <= maxLen) return desc;
-  return `${desc.substring(0, maxLen - 3)}...`;
+export function truncateDesc(desc: string, maxLen: number): string {
+  const wellFormed = toWellFormedUnicode(desc);
+  if (wellFormed.length <= maxLen) return wellFormed;
+  if (maxLen <= 3) return truncateWellFormed(wellFormed, maxLen);
+  const budget = Math.max(0, maxLen - 3);
+  return `${truncateWellFormed(wellFormed, budget)}...`;
 }
 
 // ── Thresholds ───────────────────────────────────────────────────────────────
@@ -391,10 +396,11 @@ export function createDynamicSkillProvider(): Provider {
         const instructions = service.getSkillInstructions(topMatch.slug);
         let body = "";
         if (instructions?.body) {
+          const wellFormed = toWellFormedUnicode(instructions.body);
           body =
-            instructions.body.length > MAX_INSTRUCTION_CHARS
-              ? `${instructions.body.substring(0, MAX_INSTRUCTION_CHARS)}\n\n...[truncated — use USE_SKILL for full instructions]`
-              : instructions.body;
+            wellFormed.length > MAX_INSTRUCTION_CHARS
+              ? `${truncateWellFormed(wellFormed, MAX_INSTRUCTION_CHARS)}\n\n...[truncated — use USE_SKILL for full instructions]`
+              : wellFormed;
         }
 
         const otherMatches =
@@ -420,6 +426,8 @@ export function createDynamicSkillProvider(): Provider {
           },
         };
       } catch (error) {
+        // error-policy:J4 user-facing degrade — skill matching failure falls back
+        // to a clean empty result rather than aborting the turn.
         return {
           text: "",
           values: { skillMatchTier: "error" as never },


### PR DESCRIPTION
## Summary

- Fix `packages/agent/src/providers/skill-provider.ts` `truncateDesc` and active skill instructions truncation to use `toWellFormedUnicode` + `truncateWellFormed` so capping descriptions (80) and instructions (`MAX_INSTRUCTION_CHARS` 2,000) never splits an astral surrogate pair (e.g. 🦊 `\uD83E\uDD8A`) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict model JSON parsers (Cerebras, OpenAI, Anthropic) reject with HTTP 400 `wrong_api_format`.
- Export `truncateDesc` for deterministic unit testing.
- Annotate `catch` block in `createDynamicSkillProvider().get()` with `// error-policy:J4 user-facing degrade` to comply with repository error policy.
- Add deterministic `isWellFormed()` test coverage for description and instruction truncation boundaries.

Same class as approved #23241 (slack `formatting`), #23227 (telegram `splitTelegramText`), #23277 (agent `grounded-action-reply`), #23284 (shared `transcripts`), #23472 (core `replyContext`), #23479 (agent `workspace-provider`).

## Changes

| File | Change |
|------|--------|
| `packages/agent/src/providers/skill-provider.ts` | Import `toWellFormedUnicode`/`truncateWellFormed`, sanitize + well-formed truncate in `truncateDesc` and active skill instructions, annotate error policy |
| `packages/agent/src/providers/skill-provider.test.ts` | +63 lines — 4 tests: surrogate boundary in `truncateDesc`, fitting emoji, lone surrogate sanitization, and active skill instruction truncation boundary |

## Verification

- Rebased onto `origin/develop@2fab6054d2` — zero conflicts
- `bunx biome check packages/agent/src/providers/skill-provider.ts packages/agent/src/providers/skill-provider.test.ts` — 2 files clean, 0 errors
- `bunx vitest run packages/agent/src/providers/skill-provider.test.ts` — **6 passed, 0 failed**

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - prompt provider logic for agent runtime with no UI surface.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - verified by deterministic surrogate unit tests.

<!-- evidence-row:backend-logs -->
- [x] Real surrogate-aware provider paths exercised via Vitest:

```log
bunx vitest run packages/agent/src/providers/skill-provider.test.ts
vitest v4.1.5
 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  195ms
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - server-side agent provider.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic unit test coverage.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = surrogate-safe dynamic skill prompt injection.

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Risks

Low — localized string truncation and error-policy comment in `packages/agent/src/providers/skill-provider.ts`.

# Background

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/providers/skill-provider.ts:285-300`, `packages/agent/src/providers/skill-provider.ts:392-402`, and `packages/agent/src/providers/skill-provider.test.ts:70-135`.

## Detailed testing steps

- `bunx vitest run packages/agent/src/providers/skill-provider.test.ts`
- `bunx biome check packages/agent/src/providers/skill-provider.ts packages/agent/src/providers/skill-provider.test.ts`

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza"} -->