### PR TITLE
fix(cloud): bound alert delivery hops in the social-media alerts service

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/alerts.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/alerts.test.ts
@@ -1,0 +1,46 @@
+// Pins the bounded-delivery contract of the cloud alert senders: every
+// webhook / API hop fails closed at the alert timeout instead of pinning the
+// alert worker forever, and a caller-provided abort signal wins.
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { alertFetch } from "./alerts";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("alertFetch — bounded hops fail closed and keep caller signals", () => {
+  test("aborts a hung webhook hop at the timeout", async () => {
+    // A webhook that never settles on its own: the only way out is the
+    // caller's AbortSignal firing (the 15s default bounds every sender).
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as typeof fetch;
+
+    const start = Date.now();
+    await expect(alertFetch("https://hooks.example/alert", undefined, 100)).rejects.toThrow(
+      /aborted/i,
+    );
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("preserves a caller-provided abort signal", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen = init?.signal;
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+
+    const controller = new AbortController();
+    await alertFetch("https://hooks.example/alert", {
+      signal: controller.signal,
+    });
+    expect(seen).toBe(controller.signal);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/alerts.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/alerts.ts
@@ -1,6 +1,24 @@
 // Coordinates cloud service alerts behavior behind route handlers.
 import { logger } from "../../utils/logger";
 
+const ALERT_REQUEST_TIMEOUT_MS = 15_000;
+
+/**
+ * Bound every alert delivery hop so a hung or rate-limited webhook / API
+ * cannot pin the alert worker indefinitely. A caller-provided abort signal
+ * wins.
+ */
+export function alertFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = ALERT_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
+
 type AlertSeverity = "critical" | "high" | "medium" | "low";
 
 interface AlertPayload {
@@ -20,7 +38,7 @@ const SEVERITY_COLORS: Record<AlertSeverity, { hex: string; emoji: string }> = {
 async function sendDiscordAlert(webhookUrl: string, payload: AlertPayload): Promise<void> {
   const { hex, emoji } = SEVERITY_COLORS[payload.severity];
 
-  await fetch(webhookUrl, {
+  await alertFetch(webhookUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -48,7 +66,7 @@ async function sendDiscordAlert(webhookUrl: string, payload: AlertPayload): Prom
 async function sendSlackAlert(webhookUrl: string, payload: AlertPayload): Promise<void> {
   const { emoji } = SEVERITY_COLORS[payload.severity];
 
-  await fetch(webhookUrl, {
+  await alertFetch(webhookUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -93,7 +111,7 @@ async function sendTelegramAlert(
     ...(payload.platforms?.length ? ["", `Platforms: ${payload.platforms.join(", ")}`] : []),
   ].join("\n");
 
-  await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
+  await alertFetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ chat_id: chatId, text, parse_mode: "Markdown" }),
@@ -114,7 +132,7 @@ async function sendWhatsAppAlert(
     ...(payload.platforms?.length ? ["", `Platforms: ${payload.platforms.join(", ")}`] : []),
   ].join("\n");
 
-  await fetch(apiUrl, {
+  await alertFetch(apiUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
## Problem

Every alert-sender fetch had **no timeout**: the Discord webhook, Slack webhook, Telegram `sendMessage`, and generic API hops could pin the alert worker forever when the destination hung without closing the connection.

## Fix

- Add `alertFetch(input, init, timeoutMs = 15_000)`: fails closed at a **15s hop timeout**, preserving any caller-provided abort signal.
- Route all four fetch sites through it.

One module, one bounded behavior: no alert delivery hop can hang forever.

## Tests

New `alerts.test.ts` (2 pass):

- **`alertFetch` aborts a hung webhook hop at the timeout** — a fetch that never settles is rejected with `AbortError` at the configured 100ms timeout (elapsed asserted < 5s).
- **`alertFetch` preserves a caller-provided abort signal** — the caller's signal passes through untouched.

## Verification

```bash
bun test --isolate src/lib/services/social-media/alerts.test.ts
# 2 pass, 0 fail
bunx biome check packages/cloud/shared/src/lib/services/social-media/alerts.ts
# no issues
```
