### PR TITLE
fix(core): keep surrogate pairs intact in action state thought truncation

### DIFF
--- a/packages/core/src/features/basic-capabilities/providers/actionState.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/actionState.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for the ACTION_STATE provider and truncateThought well-formed
+ * Unicode truncation guarantees.
+ */
+
+import { describe, expect, it } from "vitest";
+import { MAX_THOUGHT_CHARS, truncateThought } from "./actionState.ts";
+
+function isWellFormed(value: string): boolean {
+	for (let index = 0; index < value.length; index += 1) {
+		const codeUnit = value.charCodeAt(index);
+		if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+			const next = value.charCodeAt(index + 1);
+			if (!(next >= 0xdc00 && next <= 0xdfff)) {
+				return false;
+			}
+			index += 1;
+		} else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+			return false;
+		}
+	}
+	return true;
+}
+
+describe("truncateThought well-formed Unicode boundaries", () => {
+	it("keeps surrogate pairs intact at exact boundary", () => {
+		const budget = MAX_THOUGHT_CHARS - 1;
+		const text = `${"a".repeat(budget - 1)}🦊${"b".repeat(50)}`;
+		const out = truncateThought(text);
+		expect(out.length).toBeLessThanOrEqual(MAX_THOUGHT_CHARS);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.endsWith("…")).toBe(true);
+		expect(out).not.toContain("\uD83E");
+	});
+
+	it("preserves fitting emoji under limit", () => {
+		const text = `${"a".repeat(100)}🦊`;
+		const out = truncateThought(text);
+		expect(out).toBe(text);
+		expect(isWellFormed(out)).toBe(true);
+	});
+
+	it("sanitizes lone surrogates before truncation", () => {
+		const lone = `a\uD800${"b".repeat(3000)}`;
+		const out = truncateThought(lone);
+		expect(out).toContain("\uFFFD");
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.length).toBeLessThanOrEqual(MAX_THOUGHT_CHARS);
+	});
+
+	it("sanitizes lone surrogates without truncation when under limit", () => {
+		const lone = `thought \uD800 test`;
+		const out = truncateThought(lone);
+		expect(out).toBe("thought \uFFFD test");
+		expect(isWellFormed(out)).toBe(true);
+	});
+});

--- a/packages/core/src/features/basic-capabilities/providers/actionState.ts
+++ b/packages/core/src/features/basic-capabilities/providers/actionState.ts
@@ -27,6 +27,10 @@ import {
 	truncateMiddle,
 } from "../../../utils/action-results.js";
 import { sliceToFitBudget } from "../../../utils/slice-to-fit-budget.js";
+import {
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "../../../utils/well-formed.ts";
 import { addHeader } from "../../../utils.ts";
 
 // Get text content from centralized specs
@@ -36,9 +40,12 @@ const MAX_RUNS = 3;
 export const MAX_THOUGHT_CHARS = 2000;
 
 export function truncateThought(thought: string): string {
-	return thought.length > MAX_THOUGHT_CHARS
-		? `${thought.slice(0, MAX_THOUGHT_CHARS - 1)}…`
-		: thought;
+	const wellFormed = toWellFormedUnicode(thought);
+	if (wellFormed.length <= MAX_THOUGHT_CHARS) {
+		return wellFormed;
+	}
+	const budget = Math.max(0, MAX_THOUGHT_CHARS - 1);
+	return `${truncateWellFormed(wellFormed, budget).trimEnd()}…`;
 }
 
 type WorkingMemoryEntry = {


### PR DESCRIPTION
## Summary

- Fix `packages/core/src/features/basic-capabilities/providers/actionState.ts:38` `truncateThought` to use `toWellFormedUnicode` + `truncateWellFormed` so capping action thoughts to `MAX_THOUGHT_CHARS=2000` never splits an astral surrogate pair (e.g. 🦊 `\uD83E\uDD8A`) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict JSON parsers (Cerebras, OpenAI, Anthropic) reject with HTTP 400 `wrong_api_format`.
- Preserves the 1-character suffix budget reserve (`MAX_THOUGHT_CHARS - 1` + `…`) and sanitizes pre-existing lone surrogates to `` even when under the cap.
- Adds dedicated unit tests in `packages/core/src/features/basic-capabilities/providers/actionState.test.ts`.

Same class as approved #23241 (slack `formatting`), #23227 (telegram `splitTelegramText`), #23277 (agent `grounded-action-reply`), #23284 (shared `transcripts`), #23472 (core `replyContext`), #23479 (agent `workspace-provider`).

## Changes

| File | Change |
|------|--------|
| `packages/core/src/features/basic-capabilities/providers/actionState.ts` | Import `toWellFormedUnicode`/`truncateWellFormed`, rewrite `truncateThought` to sanitize + well-formed truncate |
| `packages/core/src/features/basic-capabilities/providers/actionState.test.ts` | +58 lines — 4 tests: surrogate boundary at 2,000, fitting emoji, lone surrogate sanitization before truncation and under limit |

## Verification

- Rebased onto `origin/develop@2fab6054d2` — zero conflicts
- `bunx biome check packages/core/src/features/basic-capabilities/providers/actionState.ts packages/core/src/features/basic-capabilities/providers/actionState.test.ts` — 2 files clean, 0 errors
- `bunx vitest run packages/core/src/features/basic-capabilities/providers/actionState.test.ts packages/core/src/truncation-suffix-reserve-2.test.ts` — **10 passed, 0 failed**
- `bun --cwd packages/core typecheck` — passed (0 errors)

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - core provider prompt logic with no UI changes.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - verified by deterministic surrogate unit tests.

<!-- evidence-row:backend-logs -->
- [x] Real surrogate-aware clamp paths exercised via Vitest:

```log
bunx vitest run packages/core/src/features/basic-capabilities/providers/actionState.test.ts packages/core/src/truncation-suffix-reserve-2.test.ts
vitest v4.1.10
 Test Files  2 passed (2)
      Tests  10 passed (10)
   Duration  540ms
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - server-side core framework logic.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic truncation unit coverage.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = surrogate-safe action state thought prompt rendering.

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Risks

Low — localized string truncation in `truncateThought` helper using existing core well-formed primitives.

# Background

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/features/basic-capabilities/providers/actionState.ts:35-45` and `packages/core/src/features/basic-capabilities/providers/actionState.test.ts:25-60`.

## Detailed testing steps

- `bunx vitest run packages/core/src/features/basic-capabilities/providers/actionState.test.ts packages/core/src/truncation-suffix-reserve-2.test.ts`
- `bunx biome check packages/core/src/features/basic-capabilities/providers/actionState.ts packages/core/src/features/basic-capabilities/providers/actionState.test.ts`
- `bun --cwd packages/core typecheck`

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — core]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza"} -->