### PR TITLE
fix(cloud): bound PayPal REST hops in the agent connector

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-paypal-connector.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-paypal-connector.test.ts
@@ -1,0 +1,46 @@
+// Pins the bounded-delivery contract of the agent → PayPal connector: every
+// REST hop fails closed at the connector timeout instead of pinning the
+// worker forever, and a caller-provided abort signal wins.
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { paypalFetch } from "./agent-paypal-connector";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("paypalFetch — bounded hops fail closed and keep caller signals", () => {
+  test("aborts a hung PayPal API hop at the timeout", async () => {
+    // An API that never settles on its own: the only way out is the caller's
+    // AbortSignal firing (the 30s default bounds OAuth / identity / reports).
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as typeof fetch;
+
+    const start = Date.now();
+    await expect(
+      paypalFetch("https://api-m.paypal.com/v1/oauth2/token", undefined, 100),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("preserves a caller-provided abort signal", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen = init?.signal;
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const controller = new AbortController();
+    await paypalFetch("https://api-m.paypal.com/v1/oauth2/token", {
+      signal: controller.signal,
+    });
+    expect(seen).toBe(controller.signal);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-paypal-connector.ts
+++ b/packages/cloud/shared/src/lib/services/agent-paypal-connector.ts
@@ -23,6 +23,23 @@
 const PAYPAL_LIVE_HOST = "https://api-m.paypal.com";
 const PAYPAL_SANDBOX_HOST = "https://api-m.sandbox.paypal.com";
 
+const PAYPAL_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Bound every PayPal REST hop so a hung or rate-limited API cannot pin the
+ * connector worker indefinitely. A caller-provided abort signal wins.
+ */
+export function paypalFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = PAYPAL_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
+
 export class AgentPaypalConnectorError extends Error {
   readonly status: number;
   constructor(status: number, message: string) {
@@ -126,7 +143,7 @@ async function paypalTokenRequest(
   const credentials = Buffer.from(`${config.clientId}:${config.secret}`, "utf-8").toString(
     "base64",
   );
-  const response = await fetch(`${config.host}/v1/oauth2/token`, {
+  const response = await paypalFetch(`${config.host}/v1/oauth2/token`, {
     method: "POST",
     headers: {
       Authorization: `Basic ${credentials}`,
@@ -210,12 +227,15 @@ export interface PaypalIdentity {
 
 export async function getPaypalIdentity(args: { accessToken: string }): Promise<PaypalIdentity> {
   const config = requireConfig();
-  const response = await fetch(`${config.host}/v1/identity/oauth2/userinfo?schema=paypalv1.1`, {
-    headers: {
-      Authorization: `Bearer ${args.accessToken}`,
-      Accept: "application/json",
+  const response = await paypalFetch(
+    `${config.host}/v1/identity/oauth2/userinfo?schema=paypalv1.1`,
+    {
+      headers: {
+        Authorization: `Bearer ${args.accessToken}`,
+        Accept: "application/json",
+      },
     },
-  });
+  );
   if (!response.ok) {
     throw new AgentPaypalConnectorError(
       response.status,
@@ -286,12 +306,15 @@ export async function searchPaypalTransactions(
     page_size: "100",
     page: String(Math.max(1, request.page ?? 1)),
   });
-  const response = await fetch(`${config.host}/v1/reporting/transactions?${params.toString()}`, {
-    headers: {
-      Authorization: `Bearer ${request.accessToken}`,
-      Accept: "application/json",
+  const response = await paypalFetch(
+    `${config.host}/v1/reporting/transactions?${params.toString()}`,
+    {
+      headers: {
+        Authorization: `Bearer ${request.accessToken}`,
+        Accept: "application/json",
+      },
     },
-  });
+  );
   if (response.status === 403) {
     // The most common error: user authorized but they're a personal-tier
     // account without Reporting API access. Surface a specific message so


### PR DESCRIPTION
## Problem

Every agent → PayPal connector fetch had **no timeout**: the OAuth token, identity `userinfo`, and transaction-report hops could pin the connector worker forever when the API hung without closing the connection.

## Fix

- Add `paypalFetch(input, init, timeoutMs = 30_000)`: fails closed at a **30s hop timeout**, preserving any caller-provided abort signal.
- Route all three fetch sites through it.

One module, one bounded behavior: no PayPal connector hop can hang forever.

## Tests

New `agent-paypal-connector.test.ts` (2 pass):

- **`paypalFetch` aborts a hung PayPal API hop at the timeout** — a fetch that never settles is rejected with `AbortError` at the configured 100ms timeout (elapsed asserted < 5s).
- **`paypalFetch` preserves a caller-provided abort signal** — the caller's signal passes through untouched.

## Verification

```bash
bun test --isolate src/lib/services/agent-paypal-connector.test.ts
# 2 pass, 0 fail
bunx biome check packages/cloud/shared/src/lib/services/agent-paypal-connector.ts
# no issues
```
