### PR TITLE
fix(core): keep surrogate pairs intact in setup progress text truncation

### DIFF
--- a/packages/core/src/providers/setup-progress.test.ts
+++ b/packages/core/src/providers/setup-progress.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for setup-progress provider and surrogate-safe truncateSetupProgressText helper.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	MAX_SETUP_OUTPUT_LENGTH,
+	truncateSetupProgressText,
+} from "./setup-progress";
+
+function isWellFormed(value: string): boolean {
+	for (let index = 0; index < value.length; index += 1) {
+		const codeUnit = value.charCodeAt(index);
+		if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+			const next = value.charCodeAt(index + 1);
+			if (!(next >= 0xdc00 && next <= 0xdfff)) {
+				return false;
+			}
+			index += 1;
+		} else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+			return false;
+		}
+	}
+	return true;
+}
+
+describe("truncateSetupProgressText well-formed Unicode boundaries", () => {
+	it("keeps surrogate pairs intact when truncating progress text at boundary", () => {
+		const budget = MAX_SETUP_OUTPUT_LENGTH - 3;
+		const text = `${"a".repeat(budget - 1)}🦊${"b".repeat(50)}`;
+		const out = truncateSetupProgressText(text);
+		expect(out.length).toBeLessThanOrEqual(MAX_SETUP_OUTPUT_LENGTH);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.endsWith("...")).toBe(true);
+		expect(out).not.toContain("\uD83E");
+	});
+
+	it("preserves fitting emoji without truncation", () => {
+		const text = `${"a".repeat(100)}🦊`;
+		const out = truncateSetupProgressText(text);
+		expect(out).toBe(text);
+		expect(isWellFormed(out)).toBe(true);
+	});
+
+	it("sanitizes lone surrogates before truncation", () => {
+		const lone = `setup \uD800 ${"b".repeat(6000)}`;
+		const out = truncateSetupProgressText(lone);
+		expect(out).toContain("\uFFFD");
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.length).toBeLessThanOrEqual(MAX_SETUP_OUTPUT_LENGTH);
+	});
+
+	it("sanitizes lone surrogates without truncation when fitting under limit", () => {
+		const lone = "setup progress \uD800 current";
+		const out = truncateSetupProgressText(lone);
+		expect(out).toBe("setup progress \uFFFD current");
+		expect(isWellFormed(out)).toBe(true);
+	});
+});

--- a/packages/core/src/providers/setup-progress.ts
+++ b/packages/core/src/providers/setup-progress.ts
@@ -22,6 +22,10 @@ import {
 	type SetupContext,
 	SetupStep,
 } from "../types/setup";
+import {
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "../utils/well-formed.ts";
 
 export const MAX_SETUP_OUTPUT_LENGTH = 5000;
 const MAX_SETUP_ERRORS = 8;
@@ -178,9 +182,12 @@ ${context.completedSteps.map((step) => `- ${SETUP_STEP_LABELS[step]}`).join("\n"
 }
 
 export function truncateSetupProgressText(text: string): string {
-	return text.length > MAX_SETUP_OUTPUT_LENGTH
-		? `${text.slice(0, MAX_SETUP_OUTPUT_LENGTH - 3)}...`
-		: text;
+	const wellFormed = toWellFormedUnicode(text);
+	if (wellFormed.length <= MAX_SETUP_OUTPUT_LENGTH) {
+		return wellFormed;
+	}
+	const budget = Math.max(0, MAX_SETUP_OUTPUT_LENGTH - 3);
+	return `${truncateWellFormed(wellFormed, budget)}...`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix `packages/core/src/providers/setup-progress.ts:180` `truncateSetupProgressText` to use `toWellFormedUnicode` + `truncateWellFormed` so capping setup progress prompt output (`MAX_SETUP_OUTPUT_LENGTH=5000`) never splits an astral surrogate pair (e.g. 🦊 `\uD83E\uDD8A`) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict JSON parsers (Cerebras, OpenAI, Anthropic) reject with HTTP 400 `wrong_api_format`.
- Preserves the 3-character ellipsis budget reserve (`MAX_SETUP_OUTPUT_LENGTH - 3` + `...`) and sanitizes lone surrogates to `` even when under the cap.
- Adds dedicated unit tests in `packages/core/src/providers/setup-progress.test.ts`.

Same class as approved #23241 (slack `formatting`), #23227 (telegram `splitTelegramText`), #23277 (agent `grounded-action-reply`), #23284 (shared `transcripts`), #23472 (core `replyContext`), #23479 (agent `workspace-provider`).

## Changes

| File | Change |
|------|--------|
| `packages/core/src/providers/setup-progress.ts` | Import `toWellFormedUnicode`/`truncateWellFormed`, rewrite `truncateSetupProgressText` to sanitize + well-formed truncate |
| `packages/core/src/providers/setup-progress.test.ts` | +60 lines — 4 tests: surrogate boundary at 5,000, fitting emoji, lone surrogate sanitization before truncation and under limit |

## Verification

- Rebased onto `origin/develop@2fab6054d2` — zero conflicts
- `bunx biome check packages/core/src/providers/setup-progress.ts packages/core/src/providers/setup-progress.test.ts` — 2 files clean, 0 errors
- `bunx vitest run packages/core/src/providers/setup-progress.test.ts packages/core/src/truncation-suffix-reserve-2.test.ts` — **10 passed, 0 failed**
- `bun --cwd packages/core typecheck` — passed (0 errors)

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - core provider prompt logic with no UI changes.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - verified by deterministic surrogate unit tests.

<!-- evidence-row:backend-logs -->
- [x] Real surrogate-aware clamp paths exercised via Vitest:

```log
bunx vitest run packages/core/src/providers/setup-progress.test.ts packages/core/src/truncation-suffix-reserve-2.test.ts
vitest v4.1.10
 Test Files  2 passed (2)
      Tests  10 passed (10)
   Duration  467ms
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - server-side core framework logic.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic truncation unit coverage.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = surrogate-safe setup progress prompt rendering.

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Risks

Low — localized string truncation in `truncateSetupProgressText` using existing core well-formed primitives.

# Background

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/providers/setup-progress.ts:180-188` and `packages/core/src/providers/setup-progress.test.ts:25-60`.

## Detailed testing steps

- `bunx vitest run packages/core/src/providers/setup-progress.test.ts`
- `bunx biome check packages/core/src/providers/setup-progress.ts packages/core/src/providers/setup-progress.test.ts`
- `bun --cwd packages/core typecheck`

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — core]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza"} -->