### PR TITLE
fix(core): keep surrogate pairs intact in document label and reference log truncation

### DIFF
--- a/packages/core/src/features/documents/naming.test.ts
+++ b/packages/core/src/features/documents/naming.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for document naming helpers and surrogate-safe truncateDocumentLabel.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	createDocumentNoteFilename,
+	DOCUMENT_TITLE_MAX_LENGTH,
+	deriveDocumentTitle,
+	stripDocumentFilenameExtension,
+	truncateDocumentLabel,
+} from "./naming.ts";
+
+function isWellFormed(value: string): boolean {
+	for (let index = 0; index < value.length; index += 1) {
+		const codeUnit = value.charCodeAt(index);
+		if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+			const next = value.charCodeAt(index + 1);
+			if (!(next >= 0xdc00 && next <= 0xdfff)) {
+				return false;
+			}
+			index += 1;
+		} else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+			return false;
+		}
+	}
+	return true;
+}
+
+describe("truncateDocumentLabel well-formed Unicode boundaries", () => {
+	it("keeps surrogate pairs intact when truncating at 80-char boundary", () => {
+		const budget = DOCUMENT_TITLE_MAX_LENGTH - 1; // 79
+		const text = `${"a".repeat(budget - 1)}🦊${"b".repeat(50)}`;
+		const out = truncateDocumentLabel(text);
+		expect(out.length).toBeLessThanOrEqual(DOCUMENT_TITLE_MAX_LENGTH);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.endsWith("…")).toBe(true);
+		expect(out).not.toContain("\uD83E");
+	});
+
+	it("preserves fitting emoji under limit", () => {
+		const text = `${"a".repeat(70)}🦊`;
+		const out = truncateDocumentLabel(text);
+		expect(out).toBe(text);
+		expect(isWellFormed(out)).toBe(true);
+	});
+
+	it("sanitizes lone surrogates before truncation", () => {
+		const lone = `title \uD800 ${"b".repeat(200)}`;
+		const out = truncateDocumentLabel(lone);
+		expect(out).toContain("\uFFFD");
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.length).toBeLessThanOrEqual(DOCUMENT_TITLE_MAX_LENGTH);
+	});
+
+	it("deriveDocumentTitle uses surrogate-safe truncation on heading line", () => {
+		const budget = DOCUMENT_TITLE_MAX_LENGTH - 1;
+		const content = `# ${"a".repeat(budget - 1)}🦊${"b".repeat(50)}\n\nBody content.`;
+		const title = deriveDocumentTitle(content);
+		expect(title.length).toBeLessThanOrEqual(DOCUMENT_TITLE_MAX_LENGTH);
+		expect(isWellFormed(title)).toBe(true);
+		expect(title.endsWith("…")).toBe(true);
+	});
+
+	it("handles filenames and extensions properly", () => {
+		expect(stripDocumentFilenameExtension("report.final.pdf")).toBe(
+			"report.final",
+		);
+		expect(createDocumentNoteFilename("My Note & Plan!")).toBe(
+			"my-note-plan.txt",
+		);
+	});
+});

--- a/packages/core/src/features/documents/naming.ts
+++ b/packages/core/src/features/documents/naming.ts
@@ -6,12 +6,20 @@
  * `utils.ts` re-exports these, so existing import sites keep working.
  */
 
-const DOCUMENT_TITLE_MAX_LENGTH = 80;
+import {
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "../../utils/well-formed.ts";
 
-function truncateDocumentLabel(value: string): string {
-	return value.length > DOCUMENT_TITLE_MAX_LENGTH
-		? `${value.slice(0, DOCUMENT_TITLE_MAX_LENGTH - 1).trimEnd()}…`
-		: value;
+export const DOCUMENT_TITLE_MAX_LENGTH = 80;
+
+export function truncateDocumentLabel(value: string): string {
+	const wellFormed = toWellFormedUnicode(value);
+	if (wellFormed.length <= DOCUMENT_TITLE_MAX_LENGTH) {
+		return wellFormed;
+	}
+	const budget = Math.max(0, DOCUMENT_TITLE_MAX_LENGTH - 1);
+	return `${truncateWellFormed(wellFormed, budget).trimEnd()}…`;
 }
 
 export function stripDocumentFilenameExtension(filename: string): string {

--- a/packages/core/src/utils/reference-echo.test.ts
+++ b/packages/core/src/utils/reference-echo.test.ts
@@ -133,4 +133,21 @@ describe("userReferenceLogView", () => {
 		expect(clamped.endsWith("…")).toBe(true);
 		expect(clamped.slice(0, 119)).toBe("b".repeat(119));
 	});
+
+	it("keeps surrogate pairs intact when truncating at 120-char boundary", () => {
+		const text = `${"a".repeat(118)}🦊${"b".repeat(50)}`;
+		const clamped = userReferenceLogView(text);
+		expect(clamped.length).toBeLessThanOrEqual(120);
+		expect(clamped.isWellFormed?.() ?? true).toBe(true);
+		expect(clamped.endsWith("…")).toBe(true);
+		expect(clamped).not.toContain("\uD83E");
+	});
+
+	it("sanitizes lone surrogates before clamping", () => {
+		const lone = `bad \uD800 ${"c".repeat(200)}`;
+		const clamped = userReferenceLogView(lone);
+		expect(clamped).toContain("\uFFFD");
+		expect(clamped.isWellFormed?.() ?? true).toBe(true);
+		expect(clamped.length).toBeLessThanOrEqual(120);
+	});
 });

--- a/packages/core/src/utils/reference-echo.ts
+++ b/packages/core/src/utils/reference-echo.ts
@@ -9,6 +9,8 @@
  * single-line strings, a rendered prompt never is.
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "./well-formed.ts";
+
 /**
  * Render a reference for user-facing text: quoted only when it is name-shaped
  * (non-empty, single line, ≤64 chars), otherwise the neutral `fallback` noun.
@@ -32,6 +34,9 @@ export function describeUserReference(
  */
 export function userReferenceLogView(reference: string): string {
 	const safeRef = typeof reference === "string" ? reference : "";
-	const collapsed = safeRef.replace(/\s+/g, " ").trim();
-	return collapsed.length > 120 ? `${collapsed.slice(0, 119)}…` : collapsed;
+	const collapsed = toWellFormedUnicode(safeRef.replace(/\s+/g, " ").trim());
+	if (collapsed.length <= 120) {
+		return collapsed;
+	}
+	return `${truncateWellFormed(collapsed, 119).trimEnd()}…`;
 }


### PR DESCRIPTION
## Summary

- Fix `packages/core/src/features/documents/naming.ts:11` `truncateDocumentLabel` and `packages/core/src/utils/reference-echo.ts:33` `userReferenceLogView` to use `toWellFormedUnicode` + `truncateWellFormed` so capping document labels (80) and log reference views (120) never splits an astral surrogate pair (e.g. 🦊 `\uD83E\uDD8A`) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict JSON parsers (Cerebras, OpenAI, Anthropic) reject with HTTP 400 `wrong_api_format`.
- Preserves the 1-character suffix budget reserve (`80 - 1` + `…`, `120 - 1` + `…`) and sanitizes lone surrogates to ``.
- Exports `DOCUMENT_TITLE_MAX_LENGTH` and `truncateDocumentLabel` for direct unit testing.
- Adds dedicated unit tests in `packages/core/src/features/documents/naming.test.ts` and expands `packages/core/src/utils/reference-echo.test.ts`.

Same class as approved #23241 (slack `formatting`), #23227 (telegram `splitTelegramText`), #23277 (agent `grounded-action-reply`), #23284 (shared `transcripts`), #23472 (core `replyContext`), #23479 (agent `workspace-provider`).

## Changes

| File | Change |
|------|--------|
| `packages/core/src/features/documents/naming.ts` | Import `toWellFormedUnicode`/`truncateWellFormed`, rewrite `truncateDocumentLabel` to sanitize + well-formed truncate |
| `packages/core/src/features/documents/naming.test.ts` | +74 lines — 5 tests: surrogate boundary at 80, fitting emoji, lone surrogate sanitization, heading derivation, filename normalization |
| `packages/core/src/utils/reference-echo.ts` | Import `toWellFormedUnicode`/`truncateWellFormed`, sanitize collapsed reference in `userReferenceLogView` |
| `packages/core/src/utils/reference-echo.test.ts` | +17 lines — 2 tests: surrogate boundary at 120, lone surrogate sanitization |

## Verification

- Rebased onto `origin/develop@2fab6054d2` — zero conflicts
- `bunx biome check packages/core/src/features/documents/naming.ts packages/core/src/features/documents/naming.test.ts packages/core/src/utils/reference-echo.ts packages/core/src/utils/reference-echo.test.ts` — 4 files clean, 0 errors
- `bunx vitest run packages/core/src/features/documents/naming.test.ts packages/core/src/utils/reference-echo.test.ts packages/core/src/truncation-suffix-reserve-2.test.ts` — **27 passed, 0 failed**
- `bun --cwd packages/core typecheck` — passed (0 errors)

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - core document naming and reference echo logic with no UI changes.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - verified by deterministic surrogate unit tests.

<!-- evidence-row:backend-logs -->
- [x] Real surrogate-aware clamp paths exercised via Vitest:

```log
bunx vitest run packages/core/src/features/documents/naming.test.ts packages/core/src/utils/reference-echo.test.ts packages/core/src/truncation-suffix-reserve-2.test.ts
vitest v4.1.10
 Test Files  3 passed (3)
      Tests  27 passed (27)
   Duration  559ms
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - server-side core framework logic.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic truncation unit coverage.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = surrogate-safe document label naming and reference echo logging.

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Risks

Low — localized string truncation in `truncateDocumentLabel` and `userReferenceLogView` using existing core well-formed primitives.

# Background

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/features/documents/naming.ts:9-25`, `packages/core/src/utils/reference-echo.ts:30-38`, and test files.

## Detailed testing steps

- `bunx vitest run packages/core/src/features/documents/naming.test.ts packages/core/src/utils/reference-echo.test.ts`
- `bunx biome check packages/core/src/features/documents/naming.ts packages/core/src/features/documents/naming.test.ts packages/core/src/utils/reference-echo.ts packages/core/src/utils/reference-echo.test.ts`
- `bun --cwd packages/core typecheck`

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — core]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza"} -->