### PR TITLE
fix(cloud): bound Bluesky / AT Protocol hops in the social-media provider

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.error-policy.test.ts
@@ -129,7 +129,7 @@ describe("blueskyProvider analytics error policy", () => {
 });
 
 describe("blueskyFetch — bounded hops fail closed and keep caller signals", () => {
-  test("aborts a hung Bluesky API hop at the timeout", async () => {
+  it("aborts a hung Bluesky API hop at the timeout", async () => {
     globalThis.fetch = mock(
       (_input: RequestInfo | URL, init?: RequestInit) =>
         new Promise<Response>((_resolve, reject) => {
@@ -146,7 +146,7 @@ describe("blueskyFetch — bounded hops fail closed and keep caller signals", ()
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
-  test("preserves a caller-provided abort signal", async () => {
+  it("preserves a caller-provided abort signal", async () => {
     let seen: AbortSignal | undefined;
     globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
       seen = init?.signal;

--- a/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.error-policy.test.ts
@@ -9,7 +9,7 @@ mock.module("../../../utils/logger", () => ({
   logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
 }));
 
-const { blueskyProvider } = await import("./bluesky");
+const { blueskyProvider, blueskyFetch } = await import("./bluesky");
 
 const realFetch = globalThis.fetch;
 const realSetTimeout = globalThis.setTimeout;
@@ -125,5 +125,38 @@ describe("blueskyProvider analytics error policy", () => {
     }) as typeof fetch;
 
     await expect(blueskyProvider.getAccountAnalytics?.(CREDS)).rejects.toThrow();
+  });
+});
+
+describe("blueskyFetch — bounded hops fail closed and keep caller signals", () => {
+  test("aborts a hung Bluesky API hop at the timeout", async () => {
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as typeof fetch;
+
+    const start = Date.now();
+    await expect(
+      blueskyFetch("https://bsky.social/xrpc/com.atproto.server.createSession", undefined, 100),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("preserves a caller-provided abort signal", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen = init?.signal;
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const controller = new AbortController();
+    await blueskyFetch("https://bsky.social/xrpc/com.atproto.server.createSession", {
+      signal: controller.signal,
+    });
+    expect(seen).toBe(controller.signal);
   });
 });

--- a/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.ts
@@ -19,6 +19,23 @@ import { withRetry } from "../rate-limit";
 
 const BLUESKY_SERVICE = "https://bsky.social";
 
+const BLUESKY_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Bound every Bluesky / AT Protocol hop so a hung or rate-limited API cannot
+ * pin the publishing worker indefinitely. A caller-provided abort signal wins.
+ */
+export function blueskyFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = BLUESKY_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
+
 interface BskySession {
   did: string;
   handle: string;
@@ -44,7 +61,7 @@ interface BskyFacet {
 async function createSession(handle: string, appPassword: string): Promise<BskySession> {
   const { data } = await withRetry<BskySession>(
     () =>
-      fetch(`${BLUESKY_SERVICE}/xrpc/com.atproto.server.createSession`, {
+      blueskyFetch(`${BLUESKY_SERVICE}/xrpc/com.atproto.server.createSession`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ identifier: handle, password: appPassword }),
@@ -66,7 +83,7 @@ async function bskyApiRequest<T>(
 ): Promise<T> {
   const { data } = await withRetry<T>(
     () =>
-      fetch(`${BLUESKY_SERVICE}/xrpc/${endpoint}`, {
+      blueskyFetch(`${BLUESKY_SERVICE}/xrpc/${endpoint}`, {
         ...options,
         headers: {
           Authorization: `Bearer ${accessJwt}`,
@@ -96,7 +113,7 @@ async function uploadBlob(
     size: number;
   };
 }> {
-  const response = await fetch(`${BLUESKY_SERVICE}/xrpc/com.atproto.repo.uploadBlob`, {
+  const response = await blueskyFetch(`${BLUESKY_SERVICE}/xrpc/com.atproto.repo.uploadBlob`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${accessJwt}`,


### PR DESCRIPTION
## Problem

Every Bluesky fetch had **no timeout**: session creation, the xrpc request helper, and blob upload could pin the publishing worker forever when the API hung without closing the connection.

## Fix

- Add `blueskyFetch(input, init, timeoutMs = 30_000)`: fails closed at a **30s hop timeout**, preserving any caller-provided abort signal.
- Route all three fetch sites through it.

## Tests

`bluesky.error-policy.test.ts` (11 pass): new hung-hop abort test (100ms timeout, elapsed < 5s) + caller-signal preservation test; existing error-policy tests still pass.

```bash
bun test --isolate src/lib/services/social-media/providers/bluesky.error-policy.test.ts
# 11 pass, 0 fail
```