### PR TITLE
fix(cloud): bound Slack hops in the social-media provider

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/providers/slack.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/slack.error-policy.test.ts
@@ -57,7 +57,7 @@ mock.module("../rate-limit", () => ({
   isRateLimitResponse: (r: Response) => r.status === 429,
 }));
 
-const { slackProvider } = await import("./slack");
+const { slackProvider, slackFetch } = await import("./slack");
 
 const json = (body: unknown, status = 200): Response =>
   new Response(JSON.stringify(body), {
@@ -176,5 +176,38 @@ describe("slackProvider.createPost — designed failure vs success stay distingu
     expect(result.error).toContain("Channel ID required");
     // No outbound call happened — the queue was never touched.
     expect(fetchQueue.length).toBe(0);
+  });
+});
+
+describe("slackFetch — bounded hops fail closed and keep caller signals", () => {
+  test("aborts a hung Slack API hop at the timeout", async () => {
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as typeof fetch;
+
+    const start = Date.now();
+    await expect(
+      slackFetch("https://slack.com/api/chat.postMessage", undefined, 100),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("preserves a caller-provided abort signal", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen = init?.signal;
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const controller = new AbortController();
+    await slackFetch("https://slack.com/api/chat.postMessage", {
+      signal: controller.signal,
+    });
+    expect(seen).toBe(controller.signal);
   });
 });

--- a/packages/cloud/shared/src/lib/services/social-media/providers/slack.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/slack.ts
@@ -14,6 +14,23 @@ import { withRetry } from "../rate-limit";
 
 const SLACK_API_BASE = "https://slack.com/api";
 
+const SLACK_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Bound every Slack hop so a hung or rate-limited API cannot pin the
+ * publishing worker indefinitely. A caller-provided abort signal wins.
+ */
+export function slackFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = SLACK_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
+
 interface SlackResponse<_T = unknown> {
   ok: boolean;
   error?: string;
@@ -60,7 +77,7 @@ async function slackApiRequest<T>(
 ): Promise<T> {
   const { data } = await withRetry<SlackResponse<T>>(
     () =>
-      fetch(`${SLACK_API_BASE}/${method}`, {
+      slackFetch(`${SLACK_API_BASE}/${method}`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${botToken}`,
@@ -82,7 +99,7 @@ async function slackApiRequest<T>(
 }
 
 async function sendWebhook(webhookUrl: string, payload: Record<string, unknown>): Promise<void> {
-  const response = await fetch(webhookUrl, {
+  const response = await slackFetch(webhookUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
@@ -358,7 +375,7 @@ export const slackProvider: SocialMediaProvider = {
     formData.append("file", new Blob([fileBytes], { type: media.mimeType }), filename);
     formData.append("filename", filename);
 
-    const response = await fetch(`${SLACK_API_BASE}/files.upload`, {
+    const response = await slackFetch(`${SLACK_API_BASE}/files.upload`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${credentials.botToken}`,


### PR DESCRIPTION
## Problem

Every Slack fetch had **no timeout**: the API request helper, webhook delivery, and `files.upload` could pin the publishing worker forever when the API hung without closing the connection.

## Fix

- Add `slackFetch(input, init, timeoutMs = 30_000)`: fails closed at a **30s hop timeout**, preserving any caller-provided abort signal.
- Route all three fetch sites through it.

## Tests

`slack.error-policy.test.ts` (13 pass): new hung-hop abort test (100ms timeout, elapsed < 5s) + caller-signal preservation test; existing error-policy tests still pass.

```bash
bun test --isolate src/lib/services/social-media/providers/slack.error-policy.test.ts
# 13 pass, 0 fail
```