### PR TITLE
fix(cloud): bound Discord bot / webhook hops in the social-media provider

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/providers/discord.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/discord.error-policy.test.ts
@@ -116,7 +116,7 @@ describe("discordProvider error policy", () => {
 });
 
 describe("discordApiFetch — bounded hops fail closed and keep caller signals", () => {
-  test("aborts a hung Discord API hop at the timeout", async () => {
+  it("aborts a hung Discord API hop at the timeout", async () => {
     globalThis.fetch = mock(
       (_input: RequestInfo | URL, init?: RequestInit) =>
         new Promise<Response>((_resolve, reject) => {
@@ -133,7 +133,7 @@ describe("discordApiFetch — bounded hops fail closed and keep caller signals",
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
-  test("preserves a caller-provided abort signal", async () => {
+  it("preserves a caller-provided abort signal", async () => {
     let seen: AbortSignal | undefined;
     globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
       seen = init?.signal;

--- a/packages/cloud/shared/src/lib/services/social-media/providers/discord.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/discord.error-policy.test.ts
@@ -12,7 +12,7 @@ mock.module("../../../utils/logger", () => ({
   logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },
 }));
 
-const { discordProvider } = await import("./discord");
+const { discordProvider, discordApiFetch } = await import("./discord");
 
 const realFetch = globalThis.fetch;
 const realSetTimeout = globalThis.setTimeout;
@@ -112,5 +112,38 @@ describe("discordProvider error policy", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("Unknown Message");
+  });
+});
+
+describe("discordApiFetch — bounded hops fail closed and keep caller signals", () => {
+  test("aborts a hung Discord API hop at the timeout", async () => {
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as typeof fetch;
+
+    const start = Date.now();
+    await expect(
+      discordApiFetch("https://discord.com/api/v10/channels/1/messages", undefined, 100),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("preserves a caller-provided abort signal", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen = init?.signal;
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const controller = new AbortController();
+    await discordApiFetch("https://discord.com/api/v10/channels/1/messages", {
+      signal: controller.signal,
+    });
+    expect(seen).toBe(controller.signal);
   });
 });

--- a/packages/cloud/shared/src/lib/services/social-media/providers/discord.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/discord.ts
@@ -14,6 +14,23 @@ import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
 import { withRetry } from "../rate-limit";
 
+const DISCORD_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Bound every Discord bot / webhook hop so a hung or rate-limited API cannot
+ * pin the publishing worker indefinitely. A caller-provided abort signal wins.
+ */
+export function discordApiFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = DISCORD_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
+
 interface DiscordMessage {
   id: string;
   channel_id: string;
@@ -48,7 +65,7 @@ async function discordApiRequest<T>(
 ): Promise<T> {
   const { data } = await withRetry<T>(
     () =>
-      fetch(`${DISCORD_API_BASE}${endpoint}`, {
+      discordApiFetch(`${DISCORD_API_BASE}${endpoint}`, {
         ...options,
         headers: {
           ...discordBotHeaders(botToken),
@@ -69,7 +86,7 @@ async function webhookRequest<T>(webhookUrl: string, payload: Record<string, unk
   const url = webhookUrl.includes("?") ? `${webhookUrl}&wait=true` : `${webhookUrl}?wait=true`;
   const { data } = await withRetry<T>(
     () =>
-      fetch(url, {
+      discordApiFetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -91,7 +108,7 @@ export const discordProvider: SocialMediaProvider = {
     // Webhook validation
     if (credentials.webhookUrl) {
       try {
-        const response = await fetch(credentials.webhookUrl);
+        const response = await discordApiFetch(credentials.webhookUrl);
         if (!response.ok) {
           return { valid: false, error: "Invalid webhook URL" };
         }


### PR DESCRIPTION
## Problem

Every Discord fetch had **no timeout**: the bot API request helper, webhook delivery, and webhook validation could pin the publishing worker forever when the API hung without closing the connection.

## Fix

- Add `discordApiFetch(input, init, timeoutMs = 30_000)`: fails closed at a **30s hop timeout**, preserving any caller-provided abort signal.
- Route all three fetch sites through it.

## Tests

`discord.error-policy.test.ts` (8 pass): new hung-hop abort test (100ms timeout, elapsed < 5s) + caller-signal preservation test; existing error-policy tests still pass.

```bash
bun test --isolate src/lib/services/social-media/providers/discord.error-policy.test.ts
# 8 pass, 0 fail
```