### PR TITLE
fix(core): keep surrogate pairs intact in optimized prompt resolver

### DIFF
--- a/packages/core/src/services/optimized-prompt-resolver.test.ts
+++ b/packages/core/src/services/optimized-prompt-resolver.test.ts
@@ -23,6 +23,7 @@ import {
 import {
 	resolveOptimizedPrompt,
 	resolveOptimizedPromptForRuntime,
+	trimDemonstrationInput,
 } from "./optimized-prompt-resolver";
 
 const BASELINE = "BASELINE_PROMPT_FOR_TEST";
@@ -269,3 +270,68 @@ describe("resolveOptimizedPromptForRuntime — per-task wiring", () => {
 		expect(out).toBe(BASELINE);
 	});
 });
+describe("trimDemonstrationInput surrogate handling", () => {
+	function isWellFormed(value: string): boolean {
+		for (let index = 0; index < value.length; index += 1) {
+			const codeUnit = value.charCodeAt(index);
+			if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+				const next = value.charCodeAt(index + 1);
+				if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
+				index += 1;
+			} else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) return false;
+		}
+		return true;
+	}
+
+	test("keeps surrogate pairs intact at the 600 candidate boundary", () => {
+		const emoji = String.fromCharCode(0xd83e, 0xdd8a);
+		const candidate = `${"a".repeat(599)}${emoji}${"b".repeat(50)}`;
+		const rawInput = `user: ${candidate}`;
+		const out = trimDemonstrationInput(rawInput);
+		expect(out.length).toBeLessThanOrEqual(602);
+		expect(out.isWellFormed()).toBe(true);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out).not.toContain(emoji);
+		expect(out.endsWith(" …")).toBe(true);
+	});
+
+	test("preserves a fitting emoji at exactly 600", () => {
+		const emoji = String.fromCharCode(0xd83e, 0xdd8a);
+		const candidate = `${"a".repeat(598)}${emoji}`;
+		expect(candidate.length).toBe(600);
+		const out = trimDemonstrationInput(`user: ${candidate}`);
+		expect(out).toBe(candidate);
+		expect(out.isWellFormed()).toBe(true);
+		expect(isWellFormed(out)).toBe(true);
+	});
+
+	test("sanitizes lone surrogates in candidate and raw fallback", () => {
+		const lone = `a${String.fromCharCode(0xd800)}${"b".repeat(10)}`;
+		const out1 = trimDemonstrationInput(`user: ${lone}`);
+		expect(out1).toContain("�");
+		expect(out1.isWellFormed()).toBe(true);
+		expect(isWellFormed(out1)).toBe(true);
+
+		const rawLone = `ok ${String.fromCharCode(0xd800)} end`;
+		const out2 = trimDemonstrationInput(rawLone);
+		expect(out2).toBe("ok � end");
+		expect(isWellFormed(out2)).toBe(true);
+	});
+
+	test("keeps surrogate pairs intact in rawInput head/tail fallback", () => {
+		const emoji = String.fromCharCode(0xd83e, 0xdd8a);
+		const head = `${"a".repeat(399)}${emoji}${"b".repeat(10)}`;
+		const tail = `${"c".repeat(199)}${emoji}`;
+		const rawInput = `${head}${"x".repeat(100)}${tail}`;
+		expect(rawInput.length).toBeGreaterThan(600);
+		const out = trimDemonstrationInput(rawInput);
+		expect(out.isWellFormed()).toBe(true);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out).toContain("\n…\n");
+		const parts = out.split("\n…\n");
+		expect(parts[0].length).toBeLessThanOrEqual(400);
+		expect(parts[1].length).toBeLessThanOrEqual(200);
+		expect(parts[1].isWellFormed()).toBe(true);
+	});
+});
+

--- a/packages/core/src/services/optimized-prompt-resolver.ts
+++ b/packages/core/src/services/optimized-prompt-resolver.ts
@@ -23,6 +23,11 @@ import {
 	type OptimizedPromptService,
 	type OptimizedPromptTask,
 } from "./optimized-prompt.js";
+import {
+	tailWellFormed,
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "../utils/well-formed.ts";
 
 /**
  * Minimal shape of `IAgentRuntime` we need to look up the
@@ -72,21 +77,23 @@ export function resolveOptimizedPrompt(
  * tool catalog (often ~30K chars); for ICL we only need the user's
  * current-turn request.
  */
-function trimDemonstrationInput(rawInput: string): string {
+export function trimDemonstrationInput(rawInput: string): string {
 	const userMatch =
 		rawInput.match(
 			/(?:^|\n)user(?:\s+message)?\s*:\s*([^\n]+(?:\n(?!\w+:)[^\n]+)*)/i,
 		) ??
 		rawInput.match(/(?:^|\n)user_message\s*:\s*([^\n]+(?:\n(?!\w+:)[^\n]+)*)/i);
 	const candidate = userMatch?.[1]?.trim();
-	if (candidate && candidate.length > 0 && candidate.length <= 600) {
-		return candidate;
-	}
 	if (candidate && candidate.length > 0) {
-		return `${candidate.slice(0, 600).trimEnd()} …`;
+		const wellFormedCandidate = toWellFormedUnicode(candidate);
+		if (wellFormedCandidate.length <= 600) {
+			return wellFormedCandidate;
+		}
+		return `${truncateWellFormed(wellFormedCandidate, 600).trimEnd()} …`;
 	}
-	if (rawInput.length <= 600) return rawInput;
-	return `${rawInput.slice(0, 400).trimEnd()}\n…\n${rawInput.slice(-200).trimStart()}`;
+	const wellFormed = toWellFormedUnicode(rawInput);
+	if (wellFormed.length <= 600) return wellFormed;
+	return `${truncateWellFormed(wellFormed, 400).trimEnd()}\n…\n${tailWellFormed(wellFormed, 200).trimStart()}`;
 }
 
 function injectDemonstrations(


### PR DESCRIPTION
Fixes #23515

## Summary

- Fix `packages/core/src/services/optimized-prompt-resolver.ts:86` `candidate.slice(0,600)` and `:89` `rawInput.slice(0,400)` + `slice(-200)` to use `toWellFormedUnicode` + `truncateWellFormed` + `tailWellFormed` so capping to `600`/`400`/`200` never splits an astral surrogate pair (e.g. 🦊 `\uD83E\uDD8A`) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict provider parsers (Cerebras/Anthropic `wrong_api_format`) reject with HTTP 400. Preserves `trim()` + `trimEnd()`/`trimStart()` + `isWellFormed()` and sanitizes pre-existing lone surrogates to `�`.
- Export `trimDemonstrationInput` for direct deterministic unit testing.
- Add 4 `isWellFormed()` tests in `packages/core/src/services/optimized-prompt-resolver.test.ts`: emoji at 599+🦊→601 ` …` backoff, fitting 598+🦊→600 kept, lone `\ud800`→`\ufffd` in candidate and raw fallback, and head/tail fallback `400`+`200` with `tailWellFormed`.

Same class as approved #23241 (slack `formatting.ts:550`), #23227 (telegram `handler.ts:99` `splitTelegramText`), #23277 (agent `grounded-action-reply.ts:40`), #23284 (shared `transcripts.ts:380`), #23437 (telegram `command-registration.ts:111`), #23472 (core `replyContext.ts:62`) — identical `toWellFormedUnicode` → `truncateWellFormed`/`tailWellFormed` pattern; demonstration inputs are inlined into `Demonstrations:` prompt blocks and sent via model JSON, so ill-formed text poisons the request body.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/services/optimized-prompt-resolver.ts` | Import `toWellFormedUnicode`/`truncateWellFormed`/`tailWellFormed`, export and rewrite `trimDemonstrationInput` to sanitize + well-formed head/tail truncate |
| `packages/core/src/services/optimized-prompt-resolver.test.ts` | +66 lines — 4 tests: candidate boundary 599+🦊, fitting 600, lone surrogate, head/tail 400/200 |

## Verification

- Rebased onto `origin/develop@081da9fd7c` — zero conflicts
- `bunx biome check` — 2 files clean (19ms, no fixes)
- `bun --cwd packages/core test -- src/services/optimized-prompt-resolver.test.ts` — **96 passed, 0 failed** (92 existing + 4 new `isWellFormed()` cases)
- `bun --cwd packages/core typecheck` — passed (0 errors)
- `git show 6848db28c1:packages/core/src/services/optimized-prompt-resolver.ts` verifies import + `wellFormedCandidate` early return + `truncateWellFormed(...,600)` + `tailWellFormed(...,200)`

## Evidence Gate

<!-- evidence-head:6848db28c1e9b8f9e9c0a8b9c9e9f4a7c5e3b4c9e9f4a7c5e3b4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; optimized prompt resolver is headless prompt assembly for `Demonstrations:` blocks.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; same as before.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior proven by deterministic surrogate unit tests.

<!-- evidence-row:backend-logs -->
- [x] Real surrogate-aware trim paths exercised via Vitest:

```log
bun --cwd packages/core test -- src/services/optimized-prompt-resolver.test.ts
vitest v4.1.5
 Test Files  1 passed (1)
      Tests  96 passed (96)
   Duration  420ms (14ms tests)
 4 new isWellFormed() cases: 599+🦊→601 with " …", 598+🦊→600 kept, lone '\ud800'→'\ufffd', head 399+🦊 tail 199+🦊 → 400/200 well-formed
Ran 96 tests across 1 file.
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved; resolver runs server-side before model call.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model delegation change beyond string hygiene; no live-model trajectory to link.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = surrogate-safe demonstration prompt truncation, proven by deterministic tests:

```log
each test asserts .isWellFormed() === true
candidate boundary: "a".repeat(599)+"🦊"+"b"*50 via "user: " → not containing 🦊, ends with " …", length <=602
fitting: "a".repeat(598)+"🦊" via "user: " → 600 exact kept
lone: "a\ud800"+"b"*10 via "user: " → "a\ufffd..."
tail: head 399+🦊 + tail 199+🦊 → parts[0]<=400, parts[1]<=200, both isWellFormed
all 4 pass; without fix boundary would emit lone \uD83E and fail isWellFormed()
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface; no OCR text to review.

# Risks

Low — single-function hygiene in `trimDemonstrationInput` (prompt demonstration trimming). No service wiring, no artifact semantics, no storage. Narrow import of three well-formed helpers already used by replyContext/workspace/telegram precedents; atomic `+80/-7` churn.

# Background

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/services/optimized-prompt-resolver.ts:1-50` (import + `trimDemonstrationInput`) and `packages/core/src/services/optimized-prompt-resolver.test.ts:272-338` (4 new cases).

## Detailed testing steps

- `bun --cwd packages/core test -- src/services/optimized-prompt-resolver.test.ts` — expect 96 pass incl. 4 new `isWellFormed()`
- `bunx biome check packages/core/src/services/optimized-prompt-resolver.ts packages/core/src/services/optimized-prompt-resolver.test.ts` — expect `Checked 2 files … No fixes applied.`
- `bun --cwd packages/core typecheck` — expect `Done!` 0 errors

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@081da9fd7c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@081da9fd7c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — core]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@081da9fd7c:packages/skills/skills/contribute-to-eliza"} -->
