### PR TITLE
fix(agent): add ES2024 lib so native isWellFormed assertions typecheck

### DIFF
--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",


### PR DESCRIPTION
Follow-up to #23501 and #23479.

## Summary
Both merged PRs added test assertions using native `String.prototype.isWellFormed()`, but `packages/agent/tsconfig.json` pinned `target: ES2022` without a `lib`, so `bun run --cwd packages/agent typecheck` failed with 8 `TS2550` errors (5 in `src/api/interactions-routes.test.ts`, 3 in `src/providers/workspace-provider.test.ts`). This adds `\"lib\": [\"ES2024\", \"DOM\", \"DOM.Iterable\"]`, matching `tsconfig.base.json`, so the natives typecheck; Bun already executes them at runtime.

## Verification
- `bun run --cwd packages/agent typecheck` error diff before/after: exactly the 8 `isWellFormed` TS2550 errors removed, zero new errors.
- `bunx vitest run packages/agent/src/api/interactions-routes.test.ts packages/agent/src/providers/workspace-provider.test.ts` — 33 passed, 0 failed.