### PR TITLE
fix(ui): make audit-public-api see wildcard subpath exports

### DIFF
--- a/packages/ui/scripts/audit-public-api.mjs
+++ b/packages/ui/scripts/audit-public-api.mjs
@@ -1,9 +1,21 @@
 /**
- * Freezes the root package exports so compatibility work can shrink the public
- * API deliberately without allowing accidental additions or removals in CI.
+ * Freezes the public API surface so compatibility work can shrink it
+ * deliberately, without allowing accidental additions or removals in CI.
+ *
+ * Two distinct surfaces are frozen. The root barrel (`src/index.ts`) is
+ * checked via the TypeScript checker, same as before. Wildcard subpath
+ * exports (e.g. `./cloud/*`, `./components/*` in package.json `exports`) are
+ * a SEPARATE public surface: every source file the build emits under the
+ * corresponding `dist/<prefix>/...` path is importable from outside this
+ * package as `@elizaos/ui/<prefix>/<path>`, whether or not anything inside
+ * the monorepo currently imports it. An in-repo importer search finds zero
+ * hits for such a file and makes deleting it look free — it is not, because
+ * an external deep-importer can still reach it. Walking the exports map is
+ * the only way to see this surface; `checker.getExportsOfModule` on
+ * `src/index.ts` never will.
  */
 
-import { readFile, writeFile } from "node:fs/promises";
+import { readdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
@@ -15,7 +27,9 @@ const updateBaseline = process.argv.includes("--update-baseline");
 const configPath = resolve(packageRoot, "tsconfig.json");
 const config = ts.readConfigFile(configPath, ts.sys.readFile);
 if (config.error) {
-  throw new Error(ts.flattenDiagnosticMessageText(config.error.messageText, "\n"));
+  throw new Error(
+    ts.flattenDiagnosticMessageText(config.error.messageText, "\n"),
+  );
 }
 const parsed = ts.parseJsonConfigFileContent(
   config.config,
@@ -34,9 +48,10 @@ if (!moduleSymbol) throw new Error("Could not resolve the root module symbol");
 const api = checker
   .getExportsOfModule(moduleSymbol)
   .map((symbol) => {
-    const resolved = symbol.flags & ts.SymbolFlags.Alias
-      ? checker.getAliasedSymbol(symbol)
-      : symbol;
+    const resolved =
+      symbol.flags & ts.SymbolFlags.Alias
+        ? checker.getAliasedSymbol(symbol)
+        : symbol;
     const declaration = resolved.declarations?.[0];
     const source = declaration?.getSourceFile().fileName;
     return {
@@ -48,10 +63,100 @@ const api = checker
   })
   .sort((left, right) => left.name.localeCompare(right.name));
 
-const report = { exports: api, count: api.length };
+// Wildcard subpath entry points: every `"./<prefix>/*"` key in package.json
+// `exports` whose target lands under `dist/` (not a `.css` passthrough) turns
+// every non-test, non-story source file under `src/<prefix>/**` into a
+// resolvable `@elizaos/ui/<prefix>/<path>` module, because the build (`tsc
+// -p tsconfig.build.json`, include: ["src"]) emits one output file per source
+// file with no dead-code elimination at the package boundary.
+const SOURCE_EXTENSIONS = [".tsx", ".ts"];
+const EXCLUDED_SUFFIXES = [
+  ".test.ts",
+  ".test.tsx",
+  ".stories.ts",
+  ".stories.tsx",
+  ".d.ts",
+];
+
+async function collectSourceFiles(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const dirent of entries) {
+    const full = resolve(dir, dirent.name);
+    if (dirent.isDirectory()) {
+      out.push(...(await collectSourceFiles(full)));
+      continue;
+    }
+    if (!dirent.isFile()) continue;
+    if (!SOURCE_EXTENSIONS.some((ext) => dirent.name.endsWith(ext))) continue;
+    if (EXCLUDED_SUFFIXES.some((suffix) => dirent.name.endsWith(suffix)))
+      continue;
+    out.push(full);
+  }
+  return out;
+}
+
+function stripSourceExtension(filePath) {
+  for (const ext of SOURCE_EXTENSIONS) {
+    if (filePath.endsWith(ext)) return filePath.slice(0, -ext.length);
+  }
+  return filePath;
+}
+
+const pkgJson = JSON.parse(
+  await readFile(resolve(packageRoot, "package.json"), "utf8"),
+);
+const exportsMap = pkgJson.exports ?? {};
+
+const wildcardPrefixes = Object.entries(exportsMap)
+  .filter(([key, value]) => {
+    if (!key.endsWith("/*") || key.endsWith(".css")) return false;
+    const target =
+      typeof value === "string" ? value : (value.import ?? value.default ?? "");
+    return (
+      typeof target === "string" &&
+      target.startsWith("./dist/") &&
+      target.endsWith(".js")
+    );
+  })
+  .map(([key]) => key.slice(2, -2)); // "./cloud/*" -> "cloud"
+
+const subpathExports = [];
+for (const prefix of wildcardPrefixes) {
+  const dir = resolve(packageRoot, "src", prefix);
+  const files = await collectSourceFiles(dir);
+  for (const file of files) {
+    const relFromSrc = relative(resolve(packageRoot, "src"), file).replaceAll(
+      "\\",
+      "/",
+    );
+    subpathExports.push({
+      specifier: `@elizaos/ui/${stripSourceExtension(relFromSrc)}`,
+      source: relative(packageRoot, file).replaceAll("\\", "/"),
+    });
+  }
+}
+subpathExports.sort((left, right) =>
+  left.specifier.localeCompare(right.specifier),
+);
+
+const report = {
+  exports: api,
+  count: api.length,
+  subpathExports,
+  subpathCount: subpathExports.length,
+};
+
 if (updateBaseline) {
   await writeFile(baselinePath, `${JSON.stringify(report, null, 2)}\n`);
-  console.log(`Updated public API baseline (${api.length} root exports).`);
+  console.log(
+    `Updated public API baseline (${api.length} root exports, ${subpathExports.length} subpath entry points).`,
+  );
   process.exit(0);
 }
 
@@ -69,18 +174,55 @@ if (currentText !== baselineText) {
     (entry) =>
       previous.has(entry.name) && previous.get(entry.name) !== entry.source,
   );
+
+  const previousSubpaths = new Map(
+    (baseline.subpathExports ?? []).map((entry) => [
+      entry.specifier,
+      entry.source,
+    ]),
+  );
+  const currentSubpaths = new Map(
+    subpathExports.map((entry) => [entry.specifier, entry.source]),
+  );
+  const addedSubpaths = subpathExports.filter(
+    (entry) => !previousSubpaths.has(entry.specifier),
+  );
+  const removedSubpaths = (baseline.subpathExports ?? []).filter(
+    (entry) => !currentSubpaths.has(entry.specifier),
+  );
+  const movedSubpaths = subpathExports.filter(
+    (entry) =>
+      previousSubpaths.has(entry.specifier) &&
+      previousSubpaths.get(entry.specifier) !== entry.source,
+  );
+
   throw new Error(
     [
-      "Root public API changed. Prefer an explicit subpath; update the baseline only for an intentional compatibility decision.",
-      added.length ? `Added: ${added.map((entry) => entry.name).join(", ")}` : "",
-      removed.length
-        ? `Removed: ${removed.map((entry) => entry.name).join(", ")}`
+      "Public API changed. Prefer an explicit subpath; update the baseline only for an intentional compatibility decision.",
+      added.length
+        ? `Root added: ${added.map((entry) => entry.name).join(", ")}`
         : "",
-      moved.length ? `Moved: ${moved.map((entry) => entry.name).join(", ")}` : "",
+      removed.length
+        ? `Root removed: ${removed.map((entry) => entry.name).join(", ")}`
+        : "",
+      moved.length
+        ? `Root moved: ${moved.map((entry) => entry.name).join(", ")}`
+        : "",
+      addedSubpaths.length
+        ? `Subpath added: ${addedSubpaths.map((entry) => entry.specifier).join(", ")}`
+        : "",
+      removedSubpaths.length
+        ? `Subpath removed: ${removedSubpaths.map((entry) => entry.specifier).join(", ")}`
+        : "",
+      movedSubpaths.length
+        ? `Subpath moved: ${movedSubpaths.map((entry) => entry.specifier).join(", ")}`
+        : "",
     ]
       .filter(Boolean)
       .join("\n"),
   );
 }
 
-console.log(`Public API matches baseline (${api.length} root exports).`);
+console.log(
+  `Public API matches baseline (${api.length} root exports, ${subpathExports.length} subpath entry points).`,
+);

--- a/packages/ui/scripts/public-api-baseline.json
+++ b/packages/ui/scripts/public-api-baseline.json
@@ -573,5 +573,5564 @@
       "source": "src/components/ui/message-scroller.tsx"
     }
   ],
-  "count": 143
+  "count": 143,
+  "subpathExports": [
+    {
+      "specifier": "@elizaos/ui/agent-surface/__e2e__/fixture",
+      "source": "src/agent-surface/__e2e__/fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/agent-surface/__e2e__/real-view-fixture",
+      "source": "src/agent-surface/__e2e__/real-view-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/agent-surface/__e2e__/teardown-fixture",
+      "source": "src/agent-surface/__e2e__/teardown-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/agent-surface/AgentElementOverlay",
+      "source": "src/agent-surface/AgentElementOverlay.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/agent-surface/AgentSurfaceContext",
+      "source": "src/agent-surface/AgentSurfaceContext.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/agent-surface/AgentSurfaceContext.hooks",
+      "source": "src/agent-surface/AgentSurfaceContext.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/agent-surface/capabilities",
+      "source": "src/agent-surface/capabilities.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/agent-surface/components",
+      "source": "src/agent-surface/components.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/agent-surface/element-reporter",
+      "source": "src/agent-surface/element-reporter.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/agent-surface/element-reporter.hooks",
+      "source": "src/agent-surface/element-reporter.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/agent-surface/index",
+      "source": "src/agent-surface/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/agent-surface/registry",
+      "source": "src/agent-surface/registry.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/agent-surface/sensitive",
+      "source": "src/agent-surface/sensitive.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/agent-surface/types",
+      "source": "src/agent-surface/types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/agent-surface/useAgentElement",
+      "source": "src/agent-surface/useAgentElement.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/android-native-agent-transport",
+      "source": "src/api/android-native-agent-transport.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/app-shell-capabilities",
+      "source": "src/api/app-shell-capabilities.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/auth-client",
+      "source": "src/api/auth-client.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/auth/csrf-cookie",
+      "source": "src/api/auth/csrf-cookie.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/auth/sessions",
+      "source": "src/api/auth/sessions.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/browser-contracts",
+      "source": "src/api/browser-contracts.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client",
+      "source": "src/api/client.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-accounts",
+      "source": "src/api/client-accounts.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-agent",
+      "source": "src/api/client-agent.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-agent-accounts",
+      "source": "src/api/client-agent-accounts.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-agent-accounts-validator",
+      "source": "src/api/client-agent-accounts-validator.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-agent-connector-accounts",
+      "source": "src/api/client-agent-connector-accounts.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-agent-consumer-keys",
+      "source": "src/api/client-agent-consumer-keys.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-approvals",
+      "source": "src/api/client-approvals.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-automations",
+      "source": "src/api/client-automations.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-background",
+      "source": "src/api/client-background.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-base",
+      "source": "src/api/client-base.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-browser-bridge",
+      "source": "src/api/client-browser-bridge.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-browser-workspace",
+      "source": "src/api/client-browser-workspace.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-chat",
+      "source": "src/api/client-chat.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-cloud",
+      "source": "src/api/client-cloud.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-computeruse",
+      "source": "src/api/client-computeruse.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-files",
+      "source": "src/api/client-files.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-imessage",
+      "source": "src/api/client-imessage.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-local-inference",
+      "source": "src/api/client-local-inference.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-meetings",
+      "source": "src/api/client-meetings.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-notifications",
+      "source": "src/api/client-notifications.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-orchestrator-widgets",
+      "source": "src/api/client-orchestrator-widgets.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-scheduled-tasks",
+      "source": "src/api/client-scheduled-tasks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-skills",
+      "source": "src/api/client-skills.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-transcripts",
+      "source": "src/api/client-transcripts.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-types",
+      "source": "src/api/client-types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-types-character",
+      "source": "src/api/client-types-character.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-types-chat",
+      "source": "src/api/client-types-chat.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-types-cloud",
+      "source": "src/api/client-types-cloud.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-types-commands",
+      "source": "src/api/client-types-commands.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-types-config",
+      "source": "src/api/client-types-config.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-types-core",
+      "source": "src/api/client-types-core.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-types-experience",
+      "source": "src/api/client-types-experience.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-types-relationships",
+      "source": "src/api/client-types-relationships.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-types-steward",
+      "source": "src/api/client-types-steward.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-types-wallet",
+      "source": "src/api/client-types-wallet.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-vault",
+      "source": "src/api/client-vault.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-voice-models",
+      "source": "src/api/client-voice-models.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-voice-profiles",
+      "source": "src/api/client-voice-profiles.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-wallet",
+      "source": "src/api/client-wallet.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/client-workflow",
+      "source": "src/api/client-workflow.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/credit-gate-error",
+      "source": "src/api/credit-gate-error.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/csrf-client",
+      "source": "src/api/csrf-client.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/desktop-external-api-base",
+      "source": "src/api/desktop-external-api-base.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/desktop-http-transport",
+      "source": "src/api/desktop-http-transport.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/desktop-local-agent-transport",
+      "source": "src/api/desktop-local-agent-transport.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/direct-cloud-endpoints",
+      "source": "src/api/direct-cloud-endpoints.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/i18n-locale-client",
+      "source": "src/api/i18n-locale-client.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/index",
+      "source": "src/api/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/ios-local-agent-kernel",
+      "source": "src/api/ios-local-agent-kernel.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/ios-local-agent-mobile-policy",
+      "source": "src/api/ios-local-agent-mobile-policy.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/ios-local-agent-transport",
+      "source": "src/api/ios-local-agent-transport.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/ios-streaming-agent-plugin",
+      "source": "src/api/ios-streaming-agent-plugin.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/ittp-agent-transport",
+      "source": "src/api/ittp-agent-transport.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/native-agent-stream",
+      "source": "src/api/native-agent-stream.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/native-cloud-http-transport",
+      "source": "src/api/native-cloud-http-transport.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/request-timeout",
+      "source": "src/api/request-timeout.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/response",
+      "source": "src/api/response.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/runtime-mode-client",
+      "source": "src/api/runtime-mode-client.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/timeout-signal",
+      "source": "src/api/timeout-signal.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/transport",
+      "source": "src/api/transport.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/api/workflow-surface-routing",
+      "source": "src/api/workflow-surface-routing.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/bridge/capacitor-bridge",
+      "source": "src/bridge/capacitor-bridge.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/bridge/electrobun-rpc",
+      "source": "src/bridge/electrobun-rpc.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/bridge/electrobun-runtime",
+      "source": "src/bridge/electrobun-runtime.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/bridge/eliza-window-bridge",
+      "source": "src/bridge/eliza-window-bridge.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/bridge/gateway-discovery",
+      "source": "src/bridge/gateway-discovery.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/bridge/index",
+      "source": "src/bridge/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/bridge/native-notifications",
+      "source": "src/bridge/native-notifications.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/bridge/native-plugins",
+      "source": "src/bridge/native-plugins.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/bridge/plugin-bridge",
+      "source": "src/bridge/plugin-bridge.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/bridge/storage-bridge",
+      "source": "src/bridge/storage-bridge.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/analytics/cost-alerts",
+      "source": "src/cloud-ui/components/analytics/cost-alerts.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/analytics/cost-insights-card",
+      "source": "src/cloud-ui/components/analytics/cost-insights-card.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/analytics/export-button",
+      "source": "src/cloud-ui/components/analytics/export-button.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/analytics/index",
+      "source": "src/cloud-ui/components/analytics/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/api-key-empty-state",
+      "source": "src/cloud-ui/components/api-key-empty-state.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/auth/authorize-content",
+      "source": "src/cloud-ui/components/auth/authorize-content.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/auth/authorize-return",
+      "source": "src/cloud-ui/components/auth/authorize-return.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/brand-button",
+      "source": "src/cloud-ui/components/brand/brand-button.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/brand-card",
+      "source": "src/cloud-ui/components/brand/brand-card.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/brand-tabs",
+      "source": "src/cloud-ui/components/brand/brand-tabs.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/brand-tabs-responsive",
+      "source": "src/cloud-ui/components/brand/brand-tabs-responsive.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/corner-brackets",
+      "source": "src/cloud-ui/components/brand/corner-brackets.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/dashboard-section",
+      "source": "src/cloud-ui/components/brand/dashboard-section.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/dashboard-stat-card",
+      "source": "src/cloud-ui/components/brand/dashboard-stat-card.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/eliza-cloud-lockup",
+      "source": "src/cloud-ui/components/brand/eliza-cloud-lockup.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/eliza-logo",
+      "source": "src/cloud-ui/components/brand/eliza-logo.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/hud-container",
+      "source": "src/cloud-ui/components/brand/hud-container.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/index",
+      "source": "src/cloud-ui/components/brand/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/key-metrics-grid",
+      "source": "src/cloud-ui/components/brand/key-metrics-grid.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/lock-on-button",
+      "source": "src/cloud-ui/components/brand/lock-on-button.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/lock-on-button.variants",
+      "source": "src/cloud-ui/components/brand/lock-on-button.variants.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/mini-stat-card",
+      "source": "src/cloud-ui/components/brand/mini-stat-card.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/prompt-card",
+      "source": "src/cloud-ui/components/brand/prompt-card.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/brand/section-header",
+      "source": "src/cloud-ui/components/brand/section-header.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/bulk/bulk-select",
+      "source": "src/cloud-ui/components/bulk/bulk-select.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/code/code-display",
+      "source": "src/cloud-ui/components/code/code-display.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/code/index",
+      "source": "src/cloud-ui/components/code/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/code/monaco-editor-skeleton",
+      "source": "src/cloud-ui/components/code/monaco-editor-skeleton.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/code/prism-light",
+      "source": "src/cloud-ui/components/code/prism-light.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/connection-card",
+      "source": "src/cloud-ui/components/connection-card.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/dashboard/cloud-dashboard-components",
+      "source": "src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/dashboard/dashboard-route-error",
+      "source": "src/cloud-ui/components/dashboard/dashboard-route-error.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/dashboard/dashboard-route-error.helpers",
+      "source": "src/cloud-ui/components/dashboard/dashboard-route-error.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/dashboard/route-placeholders",
+      "source": "src/cloud-ui/components/dashboard/route-placeholders.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/data-list/api-keys-table",
+      "source": "src/cloud-ui/components/data-list/api-keys-table.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/data-list/apps-list-view",
+      "source": "src/cloud-ui/components/data-list/apps-list-view.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/data-list/dashboard-data-list",
+      "source": "src/cloud-ui/components/data-list/dashboard-data-list.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/data-list/dashboard-table-skeleton",
+      "source": "src/cloud-ui/components/data-list/dashboard-table-skeleton.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/data-list/data-list-empty-state",
+      "source": "src/cloud-ui/components/data-list/data-list-empty-state.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/data-list/index",
+      "source": "src/cloud-ui/components/data-list/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/data-list/list-action-menu",
+      "source": "src/cloud-ui/components/data-list/list-action-menu.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/docs/api-parameter-select",
+      "source": "src/cloud-ui/components/docs/api-parameter-select.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/docs/api-route-explorer-client",
+      "source": "src/cloud-ui/components/docs/api-route-explorer-client.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/docs/docs-layout",
+      "source": "src/cloud-ui/components/docs/docs-layout.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/docs/docs-types",
+      "source": "src/cloud-ui/components/docs/docs-types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/docs/endpoint-card",
+      "source": "src/cloud-ui/components/docs/endpoint-card.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/docs/index",
+      "source": "src/cloud-ui/components/docs/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/docs/llms-txt-badge",
+      "source": "src/cloud-ui/components/docs/llms-txt-badge.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/docs/mdx-components",
+      "source": "src/cloud-ui/components/docs/mdx-components.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/docs/openapi-viewer",
+      "source": "src/cloud-ui/components/docs/openapi-viewer.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/drawer",
+      "source": "src/cloud-ui/components/drawer.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/icons",
+      "source": "src/cloud-ui/components/icons.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/layout/dashboard-header",
+      "source": "src/cloud-ui/components/layout/dashboard-header.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/layout/dashboard-page",
+      "source": "src/cloud-ui/components/layout/dashboard-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/layout/dashboard-route-page",
+      "source": "src/cloud-ui/components/layout/dashboard-route-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/layout/dashboard-shell",
+      "source": "src/cloud-ui/components/layout/dashboard-shell.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/layout/dashboard-sidebar",
+      "source": "src/cloud-ui/components/layout/dashboard-sidebar.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/layout/dashboard-sidebar-item",
+      "source": "src/cloud-ui/components/layout/dashboard-sidebar-item.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/layout/dashboard-sidebar-section",
+      "source": "src/cloud-ui/components/layout/dashboard-sidebar-section.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/layout/dashboard-sidebar-types",
+      "source": "src/cloud-ui/components/layout/dashboard-sidebar-types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/layout/index",
+      "source": "src/cloud-ui/components/layout/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/layout/page-header-context",
+      "source": "src/cloud-ui/components/layout/page-header-context.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/layout/page-header-context.hooks",
+      "source": "src/cloud-ui/components/layout/page-header-context.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/layout/page-transition",
+      "source": "src/cloud-ui/components/layout/page-transition.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/log-viewer",
+      "source": "src/cloud-ui/components/log-viewer.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/monetization/animated-counter",
+      "source": "src/cloud-ui/components/monetization/animated-counter.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/monetization/earnings-simulator",
+      "source": "src/cloud-ui/components/monetization/earnings-simulator.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/monetization/index",
+      "source": "src/cloud-ui/components/monetization/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/monetization/milestone-progress",
+      "source": "src/cloud-ui/components/monetization/milestone-progress.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/monetization/revenue-flow-diagram",
+      "source": "src/cloud-ui/components/monetization/revenue-flow-diagram.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/navigation-progress",
+      "source": "src/cloud-ui/components/navigation-progress.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/primitives",
+      "source": "src/cloud-ui/components/primitives.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/product-switcher",
+      "source": "src/cloud-ui/components/product-switcher.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/promotion/promote-app-dialog",
+      "source": "src/cloud-ui/components/promotion/promote-app-dialog.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/promotion/social-connection-hint",
+      "source": "src/cloud-ui/components/promotion/social-connection-hint.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/resizable",
+      "source": "src/cloud-ui/components/resizable.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/share/index",
+      "source": "src/cloud-ui/components/share/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/share/share-buttons",
+      "source": "src/cloud-ui/components/share/share-buttons.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/sonner",
+      "source": "src/cloud-ui/components/sonner.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/spotlight",
+      "source": "src/cloud-ui/components/spotlight.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/theme/index",
+      "source": "src/cloud-ui/components/theme/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/theme/theme-provider",
+      "source": "src/cloud-ui/components/theme/theme-provider.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/theme/theme-provider.hooks",
+      "source": "src/cloud-ui/components/theme/theme-provider.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/theme/theme-toggle",
+      "source": "src/cloud-ui/components/theme/theme-toggle.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/timeline",
+      "source": "src/cloud-ui/components/timeline.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/voice/audio-utils",
+      "source": "src/cloud-ui/components/voice/audio-utils.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/voice/index",
+      "source": "src/cloud-ui/components/voice/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/voice/types",
+      "source": "src/cloud-ui/components/voice/types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/voice/use-audio-player",
+      "source": "src/cloud-ui/components/voice/use-audio-player.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/voice/use-audio-recorder",
+      "source": "src/cloud-ui/components/voice/use-audio-recorder.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/voice/voice-audio-player",
+      "source": "src/cloud-ui/components/voice/voice-audio-player.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/voice/voice-empty-state",
+      "source": "src/cloud-ui/components/voice/voice-empty-state.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/voice/voice-status-badge",
+      "source": "src/cloud-ui/components/voice/voice-status-badge.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/components/voice/voice-status-badge.helpers",
+      "source": "src/cloud-ui/components/voice/voice-status-badge.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/index",
+      "source": "src/cloud-ui/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/lib/utils",
+      "source": "src/cloud-ui/lib/utils.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/runtime/dynamic",
+      "source": "src/cloud-ui/runtime/dynamic.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/runtime/image",
+      "source": "src/cloud-ui/runtime/image.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/runtime/navigation",
+      "source": "src/cloud-ui/runtime/navigation.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/runtime/render-telemetry",
+      "source": "src/cloud-ui/runtime/render-telemetry.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/types/chat-media",
+      "source": "src/cloud-ui/types/chat-media.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud-ui/types/cloud-api",
+      "source": "src/cloud-ui/types/cloud-api.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/__e2e__/optional-wallet-peer-stub",
+      "source": "src/cloud/__e2e__/optional-wallet-peer-stub.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/__e2e__/slop-removal-fixture",
+      "source": "src/cloud/__e2e__/slop-removal-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/AccountPage",
+      "source": "src/cloud/account-security/AccountPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/AccountSurface",
+      "source": "src/cloud/account-security/AccountSurface.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/components/account-details",
+      "source": "src/cloud/account-security/components/account-details.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/components/account-page-client",
+      "source": "src/cloud/account-security/components/account-page-client.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/components/active-sessions-panel",
+      "source": "src/cloud/account-security/components/active-sessions-panel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/components/api-keys-link",
+      "source": "src/cloud/account-security/components/api-keys-link.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/components/incident-report-panel",
+      "source": "src/cloud/account-security/components/incident-report-panel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/components/mfa-panel",
+      "source": "src/cloud/account-security/components/mfa-panel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/components/plugin-permissions-link",
+      "source": "src/cloud/account-security/components/plugin-permissions-link.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/components/plugin-permissions-page-client",
+      "source": "src/cloud/account-security/components/plugin-permissions-page-client.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/components/privacy-panel",
+      "source": "src/cloud/account-security/components/privacy-panel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/components/profile-form",
+      "source": "src/cloud/account-security/components/profile-form.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/components/recent-audit-events",
+      "source": "src/cloud/account-security/components/recent-audit-events.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/data/audit-client",
+      "source": "src/cloud/account-security/data/audit-client.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/data/consent-store",
+      "source": "src/cloud/account-security/data/consent-store.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/data/user",
+      "source": "src/cloud/account-security/data/user.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/PermissionsPage",
+      "source": "src/cloud/account-security/PermissionsPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/PermissionsSurface",
+      "source": "src/cloud/account-security/PermissionsSurface.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/routes",
+      "source": "src/cloud/account-security/routes.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/SecurityMovedRoute",
+      "source": "src/cloud/account-security/SecurityMovedRoute.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/account-security/SecuritySurface",
+      "source": "src/cloud/account-security/SecuritySurface.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/admin/AdminGate",
+      "source": "src/cloud/admin/AdminGate.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/admin/data/use-admin-gate",
+      "source": "src/cloud/admin/data/use-admin-gate.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/admin/index",
+      "source": "src/cloud/admin/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/admin/ModerationPage",
+      "source": "src/cloud/admin/ModerationPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/admin/RedemptionsPage",
+      "source": "src/cloud/admin/RedemptionsPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/admin/RpcStatusPage",
+      "source": "src/cloud/admin/RpcStatusPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/analytics/_components/analytics-page-client",
+      "source": "src/cloud/analytics/_components/analytics-page-client.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/analytics/_components/filters",
+      "source": "src/cloud/analytics/_components/filters.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/analytics/_components/model-breakdown",
+      "source": "src/cloud/analytics/_components/model-breakdown.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/analytics/_components/projections-chart",
+      "source": "src/cloud/analytics/_components/projections-chart.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/analytics/_components/provider-breakdown",
+      "source": "src/cloud/analytics/_components/provider-breakdown.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/analytics/_components/usage-chart",
+      "source": "src/cloud/analytics/_components/usage-chart.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/analytics/index",
+      "source": "src/cloud/analytics/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/analytics/lib/analytics-data",
+      "source": "src/cloud/analytics/lib/analytics-data.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/analytics/lib/format",
+      "source": "src/cloud/analytics/lib/format.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/analytics/lib/time-range",
+      "source": "src/cloud/analytics/lib/time-range.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/analytics/Page",
+      "source": "src/cloud/analytics/Page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/api-explorer/api-tester",
+      "source": "src/cloud/api-explorer/api-tester.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/api-explorer/ApiExplorerPage",
+      "source": "src/cloud/api-explorer/ApiExplorerPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/api-explorer/auth-manager",
+      "source": "src/cloud/api-explorer/auth-manager.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/api-explorer/index",
+      "source": "src/cloud/api-explorer/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/api-explorer/toast",
+      "source": "src/cloud/api-explorer/toast.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/api-explorer/use-explorer-api-key",
+      "source": "src/cloud/api-explorer/use-explorer-api-key.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/api-keys/ApiKeysPage",
+      "source": "src/cloud/api-keys/ApiKeysPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/api-keys/ApiKeysSurface",
+      "source": "src/cloud/api-keys/ApiKeysSurface.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/api-keys/ApiKeysView",
+      "source": "src/cloud/api-keys/ApiKeysView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/api-keys/copy-api-key",
+      "source": "src/cloud/api-keys/copy-api-key.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/api-keys/routes",
+      "source": "src/cloud/api-keys/routes.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/api-keys/use-api-keys",
+      "source": "src/cloud/api-keys/use-api-keys.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/app-mode/app-mode",
+      "source": "src/cloud/app-mode/app-mode.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/app-mode/AppModeEntryRoute",
+      "source": "src/cloud/app-mode/AppModeEntryRoute.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/app-mode/use-personal-entry",
+      "source": "src/cloud/app-mode/use-personal-entry.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/__e2e__/cloud-api-test-server",
+      "source": "src/cloud/applications/__e2e__/cloud-api-test-server.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/__e2e__/frontend-hosting-fixture",
+      "source": "src/cloud/applications/__e2e__/frontend-hosting-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/ApplicationDetailPage",
+      "source": "src/cloud/applications/ApplicationDetailPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/ApplicationsPage",
+      "source": "src/cloud/applications/ApplicationsPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/AppsMovedRoute",
+      "source": "src/cloud/applications/AppsMovedRoute.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/components/app-analytics",
+      "source": "src/cloud/applications/components/app-analytics.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/components/app-details-tabs",
+      "source": "src/cloud/applications/components/app-details-tabs.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/components/app-domains",
+      "source": "src/cloud/applications/components/app-domains.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/components/app-earnings-dashboard",
+      "source": "src/cloud/applications/components/app-earnings-dashboard.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/components/app-frontend-hosting",
+      "source": "src/cloud/applications/components/app-frontend-hosting.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/components/app-monetization-settings",
+      "source": "src/cloud/applications/components/app-monetization-settings.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/components/app-overview",
+      "source": "src/cloud/applications/components/app-overview.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/components/app-promote",
+      "source": "src/cloud/applications/components/app-promote.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/components/app-settings",
+      "source": "src/cloud/applications/components/app-settings.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/components/app-users",
+      "source": "src/cloud/applications/components/app-users.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/components/apps-table",
+      "source": "src/cloud/applications/components/apps-table.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/components/BuyDomainCard",
+      "source": "src/cloud/applications/components/BuyDomainCard.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/components/single-app-page-wrapper",
+      "source": "src/cloud/applications/components/single-app-page-wrapper.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/components/withdraw-dialog",
+      "source": "src/cloud/applications/components/withdraw-dialog.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/index",
+      "source": "src/cloud/applications/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/lib/apps",
+      "source": "src/cloud/applications/lib/apps.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/lib/frontend-hosting",
+      "source": "src/cloud/applications/lib/frontend-hosting.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/lib/native-cloud-nav",
+      "source": "src/cloud/applications/lib/native-cloud-nav.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/lib/one-time-app-api-key",
+      "source": "src/cloud/applications/lib/one-time-app-api-key.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/lib/utils",
+      "source": "src/cloud/applications/lib/utils.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/NativeAppsStudio",
+      "source": "src/cloud/applications/NativeAppsStudio.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/register-moved-routes",
+      "source": "src/cloud/applications/register-moved-routes.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/applications/WebAppsStudio",
+      "source": "src/cloud/applications/WebAppsStudio.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/approvals/ApprovalsRoute",
+      "source": "src/cloud/approvals/ApprovalsRoute.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/approvals/components/approvals-tab",
+      "source": "src/cloud/approvals/components/approvals-tab.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/approvals/components/ballots-tab",
+      "source": "src/cloud/approvals/components/ballots-tab.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/approvals/components/sensitive-tab",
+      "source": "src/cloud/approvals/components/sensitive-tab.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/approvals/components/status-badge",
+      "source": "src/cloud/approvals/components/status-badge.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/approvals/index",
+      "source": "src/cloud/approvals/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/approvals/lib/approvals",
+      "source": "src/cloud/approvals/lib/approvals.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/approvals/lib/wallet-sign",
+      "source": "src/cloud/approvals/lib/wallet-sign.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/auth/cloud-auth-complete-signal",
+      "source": "src/cloud/auth/cloud-auth-complete-signal.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing-console",
+      "source": "src/cloud/billing-console.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing/BillingPage",
+      "source": "src/cloud/billing/BillingPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing/BillingSection",
+      "source": "src/cloud/billing/BillingSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing/BillingSuccessPage",
+      "source": "src/cloud/billing/BillingSuccessPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing/components/auto-top-up-card",
+      "source": "src/cloud/billing/components/auto-top-up-card.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing/components/billing-tab",
+      "source": "src/cloud/billing/components/billing-tab.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing/components/direct-crypto-credit-card",
+      "source": "src/cloud/billing/components/direct-crypto-credit-card.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing/components/invoice-detail-client",
+      "source": "src/cloud/billing/components/invoice-detail-client.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing/components/payment-waiting-overlay",
+      "source": "src/cloud/billing/components/payment-waiting-overlay.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing/components/success-client",
+      "source": "src/cloud/billing/components/success-client.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing/data/billing-data",
+      "source": "src/cloud/billing/data/billing-data.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing/InvoiceDetailPage",
+      "source": "src/cloud/billing/InvoiceDetailPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing/routes",
+      "source": "src/cloud/billing/routes.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing/types",
+      "source": "src/cloud/billing/types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing/wallet/ConditionalWalletProviders",
+      "source": "src/cloud/billing/wallet/ConditionalWalletProviders.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing/wallet/steward-wallet-providers",
+      "source": "src/cloud/billing/wallet/steward-wallet-providers.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/billing/wallet/wallet-connect-project-id",
+      "source": "src/cloud/billing/wallet/wallet-connect-project-id.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/connectors/blooio-connection",
+      "source": "src/cloud/connectors/blooio-connection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/connectors/CloudConnectorsSection",
+      "source": "src/cloud/connectors/CloudConnectorsSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/connectors/CloudConnectorsUpsell",
+      "source": "src/cloud/connectors/CloudConnectorsUpsell.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/connectors/ConnectorsPage",
+      "source": "src/cloud/connectors/ConnectorsPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/connectors/discord-gateway-connection",
+      "source": "src/cloud/connectors/discord-gateway-connection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/connectors/google-connection",
+      "source": "src/cloud/connectors/google-connection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/connectors/index",
+      "source": "src/cloud/connectors/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/connectors/microsoft-connection",
+      "source": "src/cloud/connectors/microsoft-connection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/connectors/oauth-connection",
+      "source": "src/cloud/connectors/oauth-connection.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/connectors/routes",
+      "source": "src/cloud/connectors/routes.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/connectors/telegram-connection",
+      "source": "src/cloud/connectors/telegram-connection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/connectors/twilio-connection",
+      "source": "src/cloud/connectors/twilio-connection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/connectors/use-connection-status",
+      "source": "src/cloud/connectors/use-connection-status.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/connectors/whatsapp-connection",
+      "source": "src/cloud/connectors/whatsapp-connection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/handoff/cloud-handoff-supervisor",
+      "source": "src/cloud/handoff/cloud-handoff-supervisor.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/handoff/conversation-handoff",
+      "source": "src/cloud/handoff/conversation-handoff.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/handoff/pending-handoff-store",
+      "source": "src/cloud/handoff/pending-handoff-store.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/handoff/resume-pending-handoff",
+      "source": "src/cloud/handoff/resume-pending-handoff.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/handoff/run-cloud-agent-handoff",
+      "source": "src/cloud/handoff/run-cloud-agent-handoff.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/handoff/silent-repoint",
+      "source": "src/cloud/handoff/silent-repoint.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/handoff/start-tier-upgrade",
+      "source": "src/cloud/handoff/start-tier-upgrade.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/home/DashboardHomePage",
+      "source": "src/cloud/home/DashboardHomePage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/home/routes",
+      "source": "src/cloud/home/routes.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/AgentDetailPage",
+      "source": "src/cloud/instances/AgentDetailPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/AgentsPage",
+      "source": "src/cloud/instances/AgentsPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/components/agent-actions",
+      "source": "src/cloud/instances/components/agent-actions.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/components/agent-card",
+      "source": "src/cloud/instances/components/agent-card.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/components/agent-cost-badge",
+      "source": "src/cloud/instances/components/agent-cost-badge.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/components/character-filters",
+      "source": "src/cloud/instances/components/character-filters.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/components/character-library-grid",
+      "source": "src/cloud/instances/components/character-library-grid.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/components/eliza-agent-pricing-banner",
+      "source": "src/cloud/instances/components/eliza-agent-pricing-banner.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/components/eliza-agents-table",
+      "source": "src/cloud/instances/components/eliza-agents-table.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/components/eliza-connect-button",
+      "source": "src/cloud/instances/components/eliza-connect-button.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/components/empty-state",
+      "source": "src/cloud/instances/components/empty-state.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/components/my-agents",
+      "source": "src/cloud/instances/components/my-agents.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/components/types",
+      "source": "src/cloud/instances/components/types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/index",
+      "source": "src/cloud/instances/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/lib/agent-type",
+      "source": "src/cloud/instances/lib/agent-type.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/lib/data/credits",
+      "source": "src/cloud/instances/lib/data/credits.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/lib/data/eliza-agents",
+      "source": "src/cloud/instances/lib/data/eliza-agents.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/lib/i18n",
+      "source": "src/cloud/instances/lib/i18n.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/lib/open-web-ui",
+      "source": "src/cloud/instances/lib/open-web-ui.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/lib/sandbox-status",
+      "source": "src/cloud/instances/lib/sandbox-status.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/lib/use-job-poller",
+      "source": "src/cloud/instances/lib/use-job-poller.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/lib/use-sandbox-status-poll",
+      "source": "src/cloud/instances/lib/use-sandbox-status-poll.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/instances/MyAgentsPage",
+      "source": "src/cloud/instances/MyAgentsPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/join/GetStartedPage",
+      "source": "src/cloud/join/GetStartedPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/join/index",
+      "source": "src/cloud/join/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/join/JoinPage",
+      "source": "src/cloud/join/JoinPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/join/lib/apex-app-handoff",
+      "source": "src/cloud/join/lib/apex-app-handoff.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/join/lib/onboarding-continuation",
+      "source": "src/cloud/join/lib/onboarding-continuation.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/join/lib/resolve-cloud-connection",
+      "source": "src/cloud/join/lib/resolve-cloud-connection.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/join/lib/run-join-flow",
+      "source": "src/cloud/join/lib/run-join-flow.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/join/lib/use-join-session",
+      "source": "src/cloud/join/lib/use-join-session.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/join/register",
+      "source": "src/cloud/join/register.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/lib/api-client",
+      "source": "src/cloud/lib/api-client.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/lib/auth-query",
+      "source": "src/cloud/lib/auth-query.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/lib/cloud-api-key-token",
+      "source": "src/cloud/lib/cloud-api-key-token.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/lib/format-usd",
+      "source": "src/cloud/lib/format-usd.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/lib/jwt",
+      "source": "src/cloud/lib/jwt.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/lib/navigation-url",
+      "source": "src/cloud/lib/navigation-url.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/lib/query-client",
+      "source": "src/cloud/lib/query-client.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/lib/steward-session",
+      "source": "src/cloud/lib/steward-session.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/lib/use-document-title",
+      "source": "src/cloud/lib/use-document-title.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/lib/use-session-auth",
+      "source": "src/cloud/lib/use-session-auth.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/managed-cloud-runtime",
+      "source": "src/cloud/managed-cloud-runtime.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/mcps/index",
+      "source": "src/cloud/mcps/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/mcps/lib/api-types",
+      "source": "src/cloud/mcps/lib/api-types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/mcps/lib/mcp-mutations",
+      "source": "src/cloud/mcps/lib/mcp-mutations.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/mcps/lib/test-connection",
+      "source": "src/cloud/mcps/lib/test-connection.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/mcps/lib/use-mcps",
+      "source": "src/cloud/mcps/lib/use-mcps.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/mcps/McpDetailDrawer",
+      "source": "src/cloud/mcps/McpDetailDrawer.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/mcps/McpEditorDialog",
+      "source": "src/cloud/mcps/McpEditorDialog.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/mcps/McpsRoute",
+      "source": "src/cloud/mcps/McpsRoute.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/mcps/McpsSection",
+      "source": "src/cloud/mcps/McpsSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/mcps/McpsView",
+      "source": "src/cloud/mcps/McpsView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/monetization/affiliates/AffiliatesPageClient",
+      "source": "src/cloud/monetization/affiliates/AffiliatesPageClient.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/monetization/affiliates/AffiliatesSurface",
+      "source": "src/cloud/monetization/affiliates/AffiliatesSurface.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/monetization/affiliates/referral-me",
+      "source": "src/cloud/monetization/affiliates/referral-me.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/monetization/affiliates/use-dashboard-referral-me",
+      "source": "src/cloud/monetization/affiliates/use-dashboard-referral-me.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/monetization/earnings/EarningsPageClient",
+      "source": "src/cloud/monetization/earnings/EarningsPageClient.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/monetization/earnings/EarningsSurface",
+      "source": "src/cloud/monetization/earnings/EarningsSurface.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/monetization/earnings/redemption-client-contract",
+      "source": "src/cloud/monetization/earnings/redemption-client-contract.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/monetization/lib/clipboard",
+      "source": "src/cloud/monetization/lib/clipboard.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/monetization/MonetizationPage",
+      "source": "src/cloud/monetization/MonetizationPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/monetization/MonetizationSection",
+      "source": "src/cloud/monetization/MonetizationSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/monetization/routes",
+      "source": "src/cloud/monetization/routes.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/organization/__e2e__/credentials-fixture",
+      "source": "src/cloud/organization/__e2e__/credentials-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/organization/contribute-credential-dialog",
+      "source": "src/cloud/organization/contribute-credential-dialog.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/organization/credentials-list",
+      "source": "src/cloud/organization/credentials-list.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/organization/credentials-tab",
+      "source": "src/cloud/organization/credentials-tab.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/organization/data/cloud-org-types",
+      "source": "src/cloud/organization/data/cloud-org-types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/organization/data/use-credentials",
+      "source": "src/cloud/organization/data/use-credentials.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/organization/data/use-organization",
+      "source": "src/cloud/organization/data/use-organization.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/organization/invite-member-dialog",
+      "source": "src/cloud/organization/invite-member-dialog.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/organization/members-list",
+      "source": "src/cloud/organization/members-list.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/organization/members-tab",
+      "source": "src/cloud/organization/members-tab.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/organization/organization-general-tab",
+      "source": "src/cloud/organization/organization-general-tab.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/organization/organization-tab",
+      "source": "src/cloud/organization/organization-tab.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/organization/OrganizationPage",
+      "source": "src/cloud/organization/OrganizationPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/organization/OrganizationSection",
+      "source": "src/cloud/organization/OrganizationSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/organization/pending-invites-list",
+      "source": "src/cloud/organization/pending-invites-list.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/organization/routes",
+      "source": "src/cloud/organization/routes.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/private-cloud-registration",
+      "source": "src/cloud/private-cloud-registration.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/index",
+      "source": "src/cloud/public-pages/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/lib/error-message",
+      "source": "src/cloud/public-pages/lib/error-message.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/lib/login-return-to",
+      "source": "src/cloud/public-pages/lib/login-return-to.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/lib/oidc-continue",
+      "source": "src/cloud/public-pages/lib/oidc-continue.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/lib/steward-email-login",
+      "source": "src/cloud/public-pages/lib/steward-email-login.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/lib/steward-email-login-complete",
+      "source": "src/cloud/public-pages/lib/steward-email-login-complete.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/lib/steward-oauth-url",
+      "source": "src/cloud/public-pages/lib/steward-oauth-url.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/lib/steward-session",
+      "source": "src/cloud/public-pages/lib/steward-session.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/lib/use-page-title",
+      "source": "src/cloud/public-pages/lib/use-page-title.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/app-auth/app-authorize-page",
+      "source": "src/cloud/public-pages/pages/app-auth/app-authorize-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/approve/approval-page",
+      "source": "src/cloud/public-pages/pages/approve/approval-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/auth/auth-error-page",
+      "source": "src/cloud/public-pages/pages/auth/auth-error-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/auth/auth-success-page",
+      "source": "src/cloud/public-pages/pages/auth/auth-success-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/auth/cli-login-page",
+      "source": "src/cloud/public-pages/pages/auth/cli-login-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/auth/email-callback-page",
+      "source": "src/cloud/public-pages/pages/auth/email-callback-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/ballot/ballot-page",
+      "source": "src/cloud/public-pages/pages/ballot/ballot-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/bsc-page",
+      "source": "src/cloud/public-pages/pages/bsc-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/chat/public-chat-page",
+      "source": "src/cloud/public-pages/pages/chat/public-chat-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/invite/invite-accept-page",
+      "source": "src/cloud/public-pages/pages/invite/invite-accept-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/legal/privacy-policy-page",
+      "source": "src/cloud/public-pages/pages/legal/privacy-policy-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/legal/terms-of-service-page",
+      "source": "src/cloud/public-pages/pages/legal/terms-of-service-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/login/login-page",
+      "source": "src/cloud/public-pages/pages/login/login-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/login/login-section-skeleton",
+      "source": "src/cloud/public-pages/pages/login/login-section-skeleton.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/login/passkey-capability",
+      "source": "src/cloud/public-pages/pages/login/passkey-capability.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/login/steward-login-section",
+      "source": "src/cloud/public-pages/pages/login/steward-login-section.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/login/wallet-buttons",
+      "source": "src/cloud/public-pages/pages/login/wallet-buttons.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/oidc/oidc-continue-page",
+      "source": "src/cloud/public-pages/pages/oidc/oidc-continue-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/payment/app-charge-page",
+      "source": "src/cloud/public-pages/pages/payment/app-charge-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/payment/payment-navigation",
+      "source": "src/cloud/public-pages/pages/payment/payment-navigation.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/payment/payment-request-page",
+      "source": "src/cloud/public-pages/pages/payment/payment-request-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/payment/payment-success-page",
+      "source": "src/cloud/public-pages/pages/payment/payment-success-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/pages/sensitive-requests/sensitive-request-page",
+      "source": "src/cloud/public-pages/pages/sensitive-requests/sensitive-request-page.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/public-pages/register",
+      "source": "src/cloud/public-pages/register.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/register-all",
+      "source": "src/cloud/register-all.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/register-all-sync",
+      "source": "src/cloud/register-all-sync.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/register-managed-cloud-page",
+      "source": "src/cloud/register-managed-cloud-page.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/register-public",
+      "source": "src/cloud/register-public.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/settings/applications-entry",
+      "source": "src/cloud/settings/applications-entry.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/settings/cloud-settings-group",
+      "source": "src/cloud/settings/cloud-settings-group.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/settings/CloudSettingsSectionShell",
+      "source": "src/cloud/settings/CloudSettingsSectionShell.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/settings/index",
+      "source": "src/cloud/settings/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/settings/register-cloud-settings",
+      "source": "src/cloud/settings/register-cloud-settings.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/settings/sections",
+      "source": "src/cloud/settings/sections.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/shell/apex-host",
+      "source": "src/cloud/shell/apex-host.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/shell/cloud-route-registry",
+      "source": "src/cloud/shell/cloud-route-registry.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/shell/CloudAccountMenu",
+      "source": "src/cloud/shell/CloudAccountMenu.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/shell/CloudI18nProvider",
+      "source": "src/cloud/shell/CloudI18nProvider.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/shell/CloudRouteErrorBoundary",
+      "source": "src/cloud/shell/CloudRouteErrorBoundary.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/shell/CloudRouterShell",
+      "source": "src/cloud/shell/CloudRouterShell.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/shell/console-surfaces",
+      "source": "src/cloud/shell/console-surfaces.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/shell/ConsolePage",
+      "source": "src/cloud/shell/ConsolePage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/shell/ManagedCloudPage",
+      "source": "src/cloud/shell/ManagedCloudPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/shell/steward-config",
+      "source": "src/cloud/shell/steward-config.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/shell/steward-url",
+      "source": "src/cloud/shell/steward-url.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/shell/StewardProvider",
+      "source": "src/cloud/shell/StewardProvider.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/shell/StewardProviderRuntime",
+      "source": "src/cloud/shell/StewardProviderRuntime.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/shell/StewardProviderShared",
+      "source": "src/cloud/shell/StewardProviderShared.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/sso-bridge/sso-bridge",
+      "source": "src/cloud/sso-bridge/sso-bridge.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/cloud/sso-bridge/SsoBridgeRoute",
+      "source": "src/cloud/sso-bridge/SsoBridgeRoute.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/account-eligibility",
+      "source": "src/components/accounts/account-eligibility.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/account-provider-options",
+      "source": "src/components/accounts/account-provider-options.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/account-table-model",
+      "source": "src/components/accounts/account-table-model.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/AccountCard",
+      "source": "src/components/accounts/AccountCard.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/AccountCommandTable",
+      "source": "src/components/accounts/AccountCommandTable.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/AccountList",
+      "source": "src/components/accounts/AccountList.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/AccountManagementPanel",
+      "source": "src/components/accounts/AccountManagementPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/AddAccountDialog",
+      "source": "src/components/accounts/AddAccountDialog.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/ConsumerKeyPanel",
+      "source": "src/components/accounts/ConsumerKeyPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/EditableAccountLabel",
+      "source": "src/components/accounts/EditableAccountLabel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/provider-icons",
+      "source": "src/components/accounts/provider-icons.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/ProviderAccountRow",
+      "source": "src/components/accounts/ProviderAccountRow.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/ProviderPicker",
+      "source": "src/components/accounts/ProviderPicker.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/reset-time",
+      "source": "src/components/accounts/reset-time.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/RotationStrategyPicker",
+      "source": "src/components/accounts/RotationStrategyPicker.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/subscription-oauth-mode",
+      "source": "src/components/accounts/subscription-oauth-mode.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/accounts/subscription-oauth-state",
+      "source": "src/components/accounts/subscription-oauth-state.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/app-identity",
+      "source": "src/components/apps/app-identity.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/app-identity.helpers",
+      "source": "src/components/apps/app-identity.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/apps-cache",
+      "source": "src/components/apps/apps-cache.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/AppsCatalogGrid",
+      "source": "src/components/apps/AppsCatalogGrid.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/AppsSidebar",
+      "source": "src/components/apps/AppsSidebar.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/AppWindowRenderer",
+      "source": "src/components/apps/AppWindowRenderer.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/AppWindowRenderer.helpers",
+      "source": "src/components/apps/AppWindowRenderer.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/catalog-loader",
+      "source": "src/components/apps/catalog-loader.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/EmbeddedAppViewer",
+      "source": "src/components/apps/EmbeddedAppViewer.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/extensions/registry",
+      "source": "src/components/apps/extensions/registry.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/extensions/surface",
+      "source": "src/components/apps/extensions/surface.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/extensions/surface.helpers",
+      "source": "src/components/apps/extensions/surface.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/extensions/types",
+      "source": "src/components/apps/extensions/types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/FullscreenView",
+      "source": "src/components/apps/FullscreenView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/FullscreenView.helpers",
+      "source": "src/components/apps/FullscreenView.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/GameViewOverlay",
+      "source": "src/components/apps/GameViewOverlay.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/helpers",
+      "source": "src/components/apps/helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/home-grid-apps",
+      "source": "src/components/apps/home-grid-apps.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/internal-tool-apps",
+      "source": "src/components/apps/internal-tool-apps.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/load-apps-catalog",
+      "source": "src/components/apps/load-apps-catalog.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/overlay-app-api",
+      "source": "src/components/apps/overlay-app-api.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/overlay-app-registry",
+      "source": "src/components/apps/overlay-app-registry.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/provenance",
+      "source": "src/components/apps/provenance.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/run-attention",
+      "source": "src/components/apps/run-attention.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/RunningAppsRow",
+      "source": "src/components/apps/RunningAppsRow.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/useRegistryCatalog",
+      "source": "src/components/apps/useRegistryCatalog.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/apps/viewer-auth",
+      "source": "src/components/apps/viewer-auth.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/auth/AgentAuthGateSurface",
+      "source": "src/components/auth/AgentAuthGateSurface.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/auth/CloudPairRelay",
+      "source": "src/components/auth/CloudPairRelay.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/auth/LoginView",
+      "source": "src/components/auth/LoginView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/brand/eliza-mark",
+      "source": "src/components/brand/eliza-mark.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/browser/browser-session-policy",
+      "source": "src/components/browser/browser-session-policy.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/browser/BrowserSessionPolicyPanel",
+      "source": "src/components/browser/BrowserSessionPolicyPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/browser/index",
+      "source": "src/components/browser/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/character-editor-helpers",
+      "source": "src/components/character/character-editor-helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/character-greeting",
+      "source": "src/components/character/character-greeting.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/character-hub-helpers",
+      "source": "src/components/character/character-hub-helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/character-hub-types",
+      "source": "src/components/character/character-hub-types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/character-voice-config",
+      "source": "src/components/character/character-voice-config.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/character-voice-persistence",
+      "source": "src/components/character/character-voice-persistence.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/CharacterEditor",
+      "source": "src/components/character/CharacterEditor.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/CharacterEditorPanels",
+      "source": "src/components/character/CharacterEditorPanels.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/CharacterExperienceView",
+      "source": "src/components/character/CharacterExperienceView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/CharacterExperienceWorkspace",
+      "source": "src/components/character/CharacterExperienceWorkspace.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/CharacterHubView",
+      "source": "src/components/character/CharacterHubView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/CharacterLearnedSkillsSection",
+      "source": "src/components/character/CharacterLearnedSkillsSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/CharacterPersonalityTimeline",
+      "source": "src/components/character/CharacterPersonalityTimeline.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/CharacterRoster",
+      "source": "src/components/character/CharacterRoster.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/CharacterRoster.helpers",
+      "source": "src/components/character/CharacterRoster.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/CharacterSectionNav",
+      "source": "src/components/character/CharacterSectionNav.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/CharacterSkillsView",
+      "source": "src/components/character/CharacterSkillsView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/character/MusicLibraryCharacterWidget",
+      "source": "src/components/character/MusicLibraryCharacterWidget.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/__e2e__/activity-feedback-fixture",
+      "source": "src/components/chat/__e2e__/activity-feedback-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/AccountConnectBlock",
+      "source": "src/components/chat/AccountConnectBlock.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/AccountRequiredCard",
+      "source": "src/components/chat/AccountRequiredCard.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/AgentActivityBox",
+      "source": "src/components/chat/AgentActivityBox.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/AppsSection",
+      "source": "src/components/chat/AppsSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/chat-source-registration",
+      "source": "src/components/chat/chat-source-registration.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/ChatWidgetHarness",
+      "source": "src/components/chat/ChatWidgetHarness.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/connector-send-as",
+      "source": "src/components/chat/connector-send-as.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/ConnectorAccountPicker",
+      "source": "src/components/chat/ConnectorAccountPicker.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/inline-connector-modes",
+      "source": "src/components/chat/inline-connector-modes.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/InlineWidgetText",
+      "source": "src/components/chat/InlineWidgetText.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/message-background-parser",
+      "source": "src/components/chat/message-background-parser.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/message-checklist-parser",
+      "source": "src/components/chat/message-checklist-parser.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/message-choice-parser",
+      "source": "src/components/chat/message-choice-parser.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/message-followups-parser",
+      "source": "src/components/chat/message-followups-parser.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/message-form-parser",
+      "source": "src/components/chat/message-form-parser.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/message-parser-helpers",
+      "source": "src/components/chat/message-parser-helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/message-parser-incremental",
+      "source": "src/components/chat/message-parser-incremental.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/message-search/MessageSearchPanel",
+      "source": "src/components/chat/message-search/MessageSearchPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/message-task-parser",
+      "source": "src/components/chat/message-task-parser.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/message-workflow-parser",
+      "source": "src/components/chat/message-workflow-parser.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/MessageAttachments",
+      "source": "src/components/chat/MessageAttachments.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/MessageContent",
+      "source": "src/components/chat/MessageContent.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/SaveCommandModal",
+      "source": "src/components/chat/SaveCommandModal.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/TasksEventsPanel",
+      "source": "src/components/chat/TasksEventsPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/ThinkingBlock",
+      "source": "src/components/chat/ThinkingBlock.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/TranscriptViewerOverlay",
+      "source": "src/components/chat/TranscriptViewerOverlay.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/use-parsed-segments",
+      "source": "src/components/chat/use-parsed-segments.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/__e2e__/deslop-walkthrough-fixture",
+      "source": "src/components/chat/widgets/__e2e__/deslop-walkthrough-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/__e2e__/orchestrator-accounts-fixture",
+      "source": "src/components/chat/widgets/__e2e__/orchestrator-accounts-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/__e2e__/task-pipeline-fixture",
+      "source": "src/components/chat/widgets/__e2e__/task-pipeline-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/__e2e__/wallet-widget-fixture",
+      "source": "src/components/chat/widgets/__e2e__/wallet-widget-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/agent-orchestrator",
+      "source": "src/components/chat/widgets/agent-orchestrator.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/agent-orchestrator-accounts-view",
+      "source": "src/components/chat/widgets/agent-orchestrator-accounts-view.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/agent-orchestrator-room-view",
+      "source": "src/components/chat/widgets/agent-orchestrator-room-view.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/agent-provisioning",
+      "source": "src/components/chat/widgets/agent-provisioning.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/background-widget",
+      "source": "src/components/chat/widgets/background-widget.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/browser-launch-widget",
+      "source": "src/components/chat/widgets/browser-launch-widget.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/browser-status",
+      "source": "src/components/chat/widgets/browser-status.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/browser-status.helpers",
+      "source": "src/components/chat/widgets/browser-status.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/calendar-countdown",
+      "source": "src/components/chat/widgets/calendar-countdown.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/calendar-upcoming",
+      "source": "src/components/chat/widgets/calendar-upcoming.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/chat-widget-shell",
+      "source": "src/components/chat/widgets/chat-widget-shell.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/ChoiceWidget",
+      "source": "src/components/chat/widgets/ChoiceWidget.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/followups",
+      "source": "src/components/chat/widgets/followups.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/form-request",
+      "source": "src/components/chat/widgets/form-request.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/goals-attention",
+      "source": "src/components/chat/widgets/goals-attention.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/goals-attention-data",
+      "source": "src/components/chat/widgets/goals-attention-data.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/health-sleep",
+      "source": "src/components/chat/widgets/health-sleep.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/home-widget-card",
+      "source": "src/components/chat/widgets/home-widget-card.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/inline-builtins",
+      "source": "src/components/chat/widgets/inline-builtins.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/inline-registry",
+      "source": "src/components/chat/widgets/inline-registry.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/model-download",
+      "source": "src/components/chat/widgets/model-download.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/music-player",
+      "source": "src/components/chat/widgets/music-player.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/music-player.helpers",
+      "source": "src/components/chat/widgets/music-player.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/needs-attention",
+      "source": "src/components/chat/widgets/needs-attention.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/orchestrator-grilling-card",
+      "source": "src/components/chat/widgets/orchestrator-grilling-card.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/orchestrator-task-widget",
+      "source": "src/components/chat/widgets/orchestrator-task-widget.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/shared",
+      "source": "src/components/chat/widgets/shared.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/task-pipeline",
+      "source": "src/components/chat/widgets/task-pipeline.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/task-widget",
+      "source": "src/components/chat/widgets/task-widget.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/today-todos-data",
+      "source": "src/components/chat/widgets/today-todos-data.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/todo",
+      "source": "src/components/chat/widgets/todo.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/topic-chips-bar",
+      "source": "src/components/chat/widgets/topic-chips-bar.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/topic-grouped-transcript",
+      "source": "src/components/chat/widgets/topic-grouped-transcript.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/types",
+      "source": "src/components/chat/widgets/types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/use-inline-widget-context",
+      "source": "src/components/chat/widgets/use-inline-widget-context.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/wallet-balance",
+      "source": "src/components/chat/widgets/wallet-balance.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/wallet-price-holdings",
+      "source": "src/components/chat/widgets/wallet-price-holdings.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/widget-equality",
+      "source": "src/components/chat/widgets/widget-equality.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/widgets/workflow-steps",
+      "source": "src/components/chat/widgets/workflow-steps.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/WidgetVisibilityPanel",
+      "source": "src/components/chat/WidgetVisibilityPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/chat/WidgetVisibilityPanel.helpers",
+      "source": "src/components/chat/WidgetVisibilityPanel.helpers.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/cloud/CloudSourceControls",
+      "source": "src/components/cloud/CloudSourceControls.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/cloud/CloudStatusBadge",
+      "source": "src/components/cloud/CloudStatusBadge.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/cloud/StripeEmbeddedCheckout",
+      "source": "src/components/cloud/StripeEmbeddedCheckout.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/cockpit/cockpit-modes",
+      "source": "src/components/cockpit/cockpit-modes.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/cockpit/CockpitModePicker",
+      "source": "src/components/cockpit/CockpitModePicker.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/cockpit/CockpitNewSessionForm",
+      "source": "src/components/cockpit/CockpitNewSessionForm.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/cockpit/CockpitTierToggle",
+      "source": "src/components/cockpit/CockpitTierToggle.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/cockpit/CockpitView",
+      "source": "src/components/cockpit/CockpitView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/cockpit/index",
+      "source": "src/components/cockpit/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/cockpit/MyRuntimesContainer",
+      "source": "src/components/cockpit/MyRuntimesContainer.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/cockpit/MyRuntimesSection",
+      "source": "src/components/cockpit/MyRuntimesSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/__e2e__/divider-drag-perf-fixture",
+      "source": "src/components/composites/__e2e__/divider-drag-perf-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/__e2e__/resize-handles-fixture",
+      "source": "src/components/composites/__e2e__/resize-handles-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat-search-hint",
+      "source": "src/components/composites/chat-search-hint.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/chat-attachment-strip",
+      "source": "src/components/composites/chat/chat-attachment-strip.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/chat-bubble",
+      "source": "src/components/composites/chat/chat-bubble.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/chat-composer",
+      "source": "src/components/composites/chat/chat-composer.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/chat-composer-shell",
+      "source": "src/components/composites/chat/chat-composer-shell.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/chat-conversation-item",
+      "source": "src/components/composites/chat/chat-conversation-item.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/chat-conversation-rename-dialog",
+      "source": "src/components/composites/chat/chat-conversation-rename-dialog.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/chat-empty-state",
+      "source": "src/components/composites/chat/chat-empty-state.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/chat-message",
+      "source": "src/components/composites/chat/chat-message.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/chat-message-actions",
+      "source": "src/components/composites/chat/chat-message-actions.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/chat-reply-pill",
+      "source": "src/components/composites/chat/chat-reply-pill.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/chat-source",
+      "source": "src/components/composites/chat/chat-source.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/chat-source.helpers",
+      "source": "src/components/composites/chat/chat-source.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/chat-thread-layout",
+      "source": "src/components/composites/chat/chat-thread-layout.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/chat-transcript",
+      "source": "src/components/composites/chat/chat-transcript.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/chat-types",
+      "source": "src/components/composites/chat/chat-types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/chat-typing-indicator",
+      "source": "src/components/composites/chat/chat-typing-indicator.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/ChatVoiceStatusBar",
+      "source": "src/components/composites/chat/ChatVoiceStatusBar.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/ContinuousChatToggle",
+      "source": "src/components/composites/chat/ContinuousChatToggle.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/permission-card",
+      "source": "src/components/composites/chat/permission-card.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/permission-card.helpers",
+      "source": "src/components/composites/chat/permission-card.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/permission-card.render",
+      "source": "src/components/composites/chat/permission-card.render.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/chat/pstn-call-button",
+      "source": "src/components/composites/chat/pstn-call-button.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/code/DiffReviewPanel",
+      "source": "src/components/composites/code/DiffReviewPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/code/index",
+      "source": "src/components/composites/code/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/OwnerBadge",
+      "source": "src/components/composites/OwnerBadge.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/page-panel/index",
+      "source": "src/components/composites/page-panel/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/page-panel/page-panel-collapsible-section",
+      "source": "src/components/composites/page-panel/page-panel-collapsible-section.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/page-panel/page-panel-empty",
+      "source": "src/components/composites/page-panel/page-panel-empty.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/page-panel/page-panel-feature-empty",
+      "source": "src/components/composites/page-panel/page-panel-feature-empty.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/page-panel/page-panel-frame",
+      "source": "src/components/composites/page-panel/page-panel-frame.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/page-panel/page-panel-header",
+      "source": "src/components/composites/page-panel/page-panel-header.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/page-panel/page-panel-loading",
+      "source": "src/components/composites/page-panel/page-panel-loading.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/page-panel/page-panel-root",
+      "source": "src/components/composites/page-panel/page-panel-root.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/page-panel/page-panel-toolbar",
+      "source": "src/components/composites/page-panel/page-panel-toolbar.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/page-panel/page-panel-types",
+      "source": "src/components/composites/page-panel/page-panel-types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/search/index",
+      "source": "src/components/composites/search/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/search/searchbar",
+      "source": "src/components/composites/search/searchbar.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/sidebar/index",
+      "source": "src/components/composites/sidebar/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/sidebar/nav-active",
+      "source": "src/components/composites/sidebar/nav-active.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/sidebar/sidebar-auto-rail",
+      "source": "src/components/composites/sidebar/sidebar-auto-rail.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/sidebar/sidebar-body",
+      "source": "src/components/composites/sidebar/sidebar-body.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/sidebar/sidebar-collapsed-rail",
+      "source": "src/components/composites/sidebar/sidebar-collapsed-rail.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/sidebar/sidebar-content",
+      "source": "src/components/composites/sidebar/sidebar-content.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/sidebar/sidebar-header",
+      "source": "src/components/composites/sidebar/sidebar-header.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/sidebar/sidebar-header-stack",
+      "source": "src/components/composites/sidebar/sidebar-header-stack.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/sidebar/sidebar-panel",
+      "source": "src/components/composites/sidebar/sidebar-panel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/sidebar/sidebar-root",
+      "source": "src/components/composites/sidebar/sidebar-root.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/sidebar/sidebar-scroll-region",
+      "source": "src/components/composites/sidebar/sidebar-scroll-region.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/sidebar/sidebar-types",
+      "source": "src/components/composites/sidebar/sidebar-types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/skills/skill-sidebar-item",
+      "source": "src/components/composites/skills/skill-sidebar-item.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/trajectories/trajectory-cache-stats",
+      "source": "src/components/composites/trajectories/trajectory-cache-stats.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/trajectories/trajectory-code-block",
+      "source": "src/components/composites/trajectories/trajectory-code-block.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/trajectories/trajectory-context-diff-list",
+      "source": "src/components/composites/trajectories/trajectory-context-diff-list.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/trajectories/trajectory-event-timeline",
+      "source": "src/components/composites/trajectories/trajectory-event-timeline.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/trajectories/trajectory-llm-call-card",
+      "source": "src/components/composites/trajectories/trajectory-llm-call-card.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/trajectories/trajectory-pipeline-graph",
+      "source": "src/components/composites/trajectories/trajectory-pipeline-graph.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/composites/trajectories/trajectory-sidebar-item",
+      "source": "src/components/composites/trajectories/trajectory-sidebar-item.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/config-ui/config-control-primitives",
+      "source": "src/components/config-ui/config-control-primitives.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/config-ui/config-control-primitives.helpers",
+      "source": "src/components/config-ui/config-control-primitives.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/config-ui/config-field",
+      "source": "src/components/config-ui/config-field.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/config-ui/config-field.helpers",
+      "source": "src/components/config-ui/config-field.helpers.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/config-ui/config-renderer",
+      "source": "src/components/config-ui/config-renderer.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/config-ui/config-renderer.helpers",
+      "source": "src/components/config-ui/config-renderer.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/config-ui/index",
+      "source": "src/components/config-ui/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/config-ui/ui-renderer",
+      "source": "src/components/config-ui/ui-renderer.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/config-ui/ui-renderer.helpers",
+      "source": "src/components/config-ui/ui-renderer.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/BlueBubblesCloudGatewayPanel",
+      "source": "src/components/connectors/BlueBubblesCloudGatewayPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/BlueBubblesStatusPanel",
+      "source": "src/components/connectors/BlueBubblesStatusPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/connector-account-options",
+      "source": "src/components/connectors/connector-account-options.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/connector-channel-mode",
+      "source": "src/components/connectors/connector-channel-mode.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/connector-mode-registry",
+      "source": "src/components/connectors/connector-mode-registry.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/connector-setup-panel-registry",
+      "source": "src/components/connectors/connector-setup-panel-registry.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/connector-ui-groups",
+      "source": "src/components/connectors/connector-ui-groups.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/ConnectorAccountAuditList",
+      "source": "src/components/connectors/ConnectorAccountAuditList.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/ConnectorAccountCard",
+      "source": "src/components/connectors/ConnectorAccountCard.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/ConnectorAccountList",
+      "source": "src/components/connectors/ConnectorAccountList.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/ConnectorAccountPrivacySelector",
+      "source": "src/components/connectors/ConnectorAccountPrivacySelector.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/ConnectorAccountPurposeSelector",
+      "source": "src/components/connectors/ConnectorAccountPurposeSelector.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/ConnectorAccountSetupScope",
+      "source": "src/components/connectors/ConnectorAccountSetupScope.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/ConnectorChannelModeSwitch",
+      "source": "src/components/connectors/ConnectorChannelModeSwitch.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/ConnectorModeSelector",
+      "source": "src/components/connectors/ConnectorModeSelector.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/ConnectorModeSelector.helpers",
+      "source": "src/components/connectors/ConnectorModeSelector.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/ConnectorModeSelector.hooks",
+      "source": "src/components/connectors/ConnectorModeSelector.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/ConnectorOAuthCapabilityPicker",
+      "source": "src/components/connectors/ConnectorOAuthCapabilityPicker.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/ConnectorQrPairingOverlay",
+      "source": "src/components/connectors/ConnectorQrPairingOverlay.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/ConnectorSetupPanel",
+      "source": "src/components/connectors/ConnectorSetupPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/ConnectorSetupPanel.helpers",
+      "source": "src/components/connectors/ConnectorSetupPanel.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/DiscordLocalConnectorPanel",
+      "source": "src/components/connectors/DiscordLocalConnectorPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/IMessageStatusPanel",
+      "source": "src/components/connectors/IMessageStatusPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/OwnerAgentConnectorSetupPanel",
+      "source": "src/components/connectors/OwnerAgentConnectorSetupPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/SignalQrOverlay",
+      "source": "src/components/connectors/SignalQrOverlay.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/TelegramAccountConnectorPanel",
+      "source": "src/components/connectors/TelegramAccountConnectorPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/TelegramBotSetupPanel",
+      "source": "src/components/connectors/TelegramBotSetupPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/connectors/WhatsAppQrOverlay",
+      "source": "src/components/connectors/WhatsAppQrOverlay.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/conversations/brand-icons",
+      "source": "src/components/conversations/brand-icons.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/conversations/conversation-sidebar-model",
+      "source": "src/components/conversations/conversation-sidebar-model.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/conversations/conversation-utils",
+      "source": "src/components/conversations/conversation-utils.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/conversations/ConversationRenameDialog",
+      "source": "src/components/conversations/ConversationRenameDialog.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/conversations/ConversationsSidebar",
+      "source": "src/components/conversations/ConversationsSidebar.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/custom-actions/custom-action-form",
+      "source": "src/components/custom-actions/custom-action-form.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/custom-actions/CustomActionEditor",
+      "source": "src/components/custom-actions/CustomActionEditor.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/custom-actions/CustomActionsPanel",
+      "source": "src/components/custom-actions/CustomActionsPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/custom-actions/CustomActionsView",
+      "source": "src/components/custom-actions/CustomActionsView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/desktop/DesktopTabBar",
+      "source": "src/components/desktop/DesktopTabBar.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/index",
+      "source": "src/components/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/ActiveModelBar",
+      "source": "src/components/local-inference/ActiveModelBar.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/DeviceBridgeStatus",
+      "source": "src/components/local-inference/DeviceBridgeStatus.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/DevicesPanel",
+      "source": "src/components/local-inference/DevicesPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/DownloadProgress",
+      "source": "src/components/local-inference/DownloadProgress.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/DownloadQueue",
+      "source": "src/components/local-inference/DownloadQueue.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/FirstRunOffer",
+      "source": "src/components/local-inference/FirstRunOffer.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/HardwareBadge",
+      "source": "src/components/local-inference/HardwareBadge.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/hub-utils",
+      "source": "src/components/local-inference/hub-utils.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/LocalInferencePanel",
+      "source": "src/components/local-inference/LocalInferencePanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/ModelCard",
+      "source": "src/components/local-inference/ModelCard.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/ModelHubView",
+      "source": "src/components/local-inference/ModelHubView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/ModelUpdatesPanel",
+      "source": "src/components/local-inference/ModelUpdatesPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/ProvidersList",
+      "source": "src/components/local-inference/ProvidersList.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/RoutingMatrix",
+      "source": "src/components/local-inference/RoutingMatrix.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/runtime-class-ui",
+      "source": "src/components/local-inference/runtime-class-ui.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/slot-metadata",
+      "source": "src/components/local-inference/slot-metadata.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/SlotAssignments",
+      "source": "src/components/local-inference/SlotAssignments.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/useDeviceBridgeStatus",
+      "source": "src/components/local-inference/useDeviceBridgeStatus.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/local-inference/useHomeModelStatus",
+      "source": "src/components/local-inference/useHomeModelStatus.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/__e2e__/background-fixture",
+      "source": "src/components/pages/__e2e__/background-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/__e2e__/browser-surface-error-api-stub",
+      "source": "src/components/pages/__e2e__/browser-surface-error-api-stub.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/__e2e__/browser-surface-error-fixture",
+      "source": "src/components/pages/__e2e__/browser-surface-error-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/__e2e__/browser-surface-error-hook-stub",
+      "source": "src/components/pages/__e2e__/browser-surface-error-hook-stub.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/__e2e__/browser-surface-error-state-stub",
+      "source": "src/components/pages/__e2e__/browser-surface-error-state-stub.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/__e2e__/chat-infinite-scroll-fixture",
+      "source": "src/components/pages/__e2e__/chat-infinite-scroll-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/__e2e__/connectors-fixture",
+      "source": "src/components/pages/__e2e__/connectors-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/__e2e__/connectors-fixture-api-stub",
+      "source": "src/components/pages/__e2e__/connectors-fixture-api-stub.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/__e2e__/connectors-fixture-state-stub",
+      "source": "src/components/pages/__e2e__/connectors-fixture-state-stub.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/__e2e__/launcher-fixture",
+      "source": "src/components/pages/__e2e__/launcher-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/__e2e__/settings-fixture",
+      "source": "src/components/pages/__e2e__/settings-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/__e2e__/settings-fixture-state-stub",
+      "source": "src/components/pages/__e2e__/settings-fixture-state-stub.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/__e2e__/suggestions-bundle",
+      "source": "src/components/pages/__e2e__/suggestions-bundle.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/__e2e__/suggestions-fixture",
+      "source": "src/components/pages/__e2e__/suggestions-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/AppRouteNotFound",
+      "source": "src/components/pages/AppRouteNotFound.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/AppsPageView",
+      "source": "src/components/pages/AppsPageView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/AutomationsFeed",
+      "source": "src/components/pages/AutomationsFeed.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/background-image",
+      "source": "src/components/pages/background-image.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/BackgroundView",
+      "source": "src/components/pages/BackgroundView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/browser-wallet-consent-format",
+      "source": "src/components/pages/browser-wallet-consent-format.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/browser-workspace-wallet",
+      "source": "src/components/pages/browser-workspace-wallet.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/BrowserTabSwitcher",
+      "source": "src/components/pages/BrowserTabSwitcher.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/BrowserWorkspaceView",
+      "source": "src/components/pages/BrowserWorkspaceView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/CameraPageView",
+      "source": "src/components/pages/CameraPageView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/chat-view-hooks",
+      "source": "src/components/pages/chat-view-hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/chat-view-voice-mic",
+      "source": "src/components/pages/chat-view-voice-mic.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/ChatView",
+      "source": "src/components/pages/ChatView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/ChatView.terminal-focus",
+      "source": "src/components/pages/ChatView.terminal-focus.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/cloud-dashboard-utils",
+      "source": "src/components/pages/cloud-dashboard-utils.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/config-page-sections",
+      "source": "src/components/pages/config-page-sections.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/config-page-sections.helpers",
+      "source": "src/components/pages/config-page-sections.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/ConfigPageView",
+      "source": "src/components/pages/ConfigPageView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/database-utils",
+      "source": "src/components/pages/database-utils.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/DatabasePageView",
+      "source": "src/components/pages/DatabasePageView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/DatabaseView",
+      "source": "src/components/pages/DatabaseView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/documents-detail",
+      "source": "src/components/pages/documents-detail.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/documents-detail.helpers",
+      "source": "src/components/pages/documents-detail.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/documents-upload",
+      "source": "src/components/pages/documents-upload.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/documents-upload.helpers",
+      "source": "src/components/pages/documents-upload.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/DocumentsView",
+      "source": "src/components/pages/DocumentsView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/ElizaCloudDashboard",
+      "source": "src/components/pages/ElizaCloudDashboard.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/ElizaOsAppsView",
+      "source": "src/components/pages/ElizaOsAppsView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/FilesView",
+      "source": "src/components/pages/FilesView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/GeneratedViewHero",
+      "source": "src/components/pages/GeneratedViewHero.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/knowledge-media-format",
+      "source": "src/components/pages/knowledge-media-format.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/KnowledgeView",
+      "source": "src/components/pages/KnowledgeView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/Launcher",
+      "source": "src/components/pages/Launcher.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/launcher-curation",
+      "source": "src/components/pages/launcher-curation.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/LauncherSurface",
+      "source": "src/components/pages/LauncherSurface.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/LogsView",
+      "source": "src/components/pages/LogsView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/MediaGalleryView",
+      "source": "src/components/pages/MediaGalleryView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/MemoryDetailPanel",
+      "source": "src/components/pages/MemoryDetailPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/MemoryViewerView",
+      "source": "src/components/pages/MemoryViewerView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/MyAppsView",
+      "source": "src/components/pages/MyAppsView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/page-scoped-conversations",
+      "source": "src/components/pages/page-scoped-conversations.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/PendantTranscriptView",
+      "source": "src/components/pages/PendantTranscriptView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/plugin-list-utils",
+      "source": "src/components/pages/plugin-list-utils.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/plugin-view-connectors",
+      "source": "src/components/pages/plugin-view-connectors.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/plugin-view-dialogs",
+      "source": "src/components/pages/plugin-view-dialogs.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/plugin-view-modal",
+      "source": "src/components/pages/plugin-view-modal.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/PluginCard",
+      "source": "src/components/pages/PluginCard.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/PluginConfigForm",
+      "source": "src/components/pages/PluginConfigForm.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/PluginsPageView",
+      "source": "src/components/pages/PluginsPageView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/PluginsView",
+      "source": "src/components/pages/PluginsView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/PluginVisual",
+      "source": "src/components/pages/PluginVisual.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/relationships/relationships-utils",
+      "source": "src/components/pages/relationships/relationships-utils.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/relationships/RelationshipsActivityFeed",
+      "source": "src/components/pages/relationships/RelationshipsActivityFeed.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/relationships/RelationshipsCandidateMergesPanel",
+      "source": "src/components/pages/relationships/RelationshipsCandidateMergesPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/relationships/RelationshipsPersonPanels",
+      "source": "src/components/pages/relationships/RelationshipsPersonPanels.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/relationships/RelationshipsSidebar",
+      "source": "src/components/pages/relationships/RelationshipsSidebar.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/relationships/RelationshipsWorkspaceView",
+      "source": "src/components/pages/relationships/RelationshipsWorkspaceView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/RelationshipsGraphPanel",
+      "source": "src/components/pages/RelationshipsGraphPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/RelationshipsIdentityCluster",
+      "source": "src/components/pages/RelationshipsIdentityCluster.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/RelationshipsView",
+      "source": "src/components/pages/RelationshipsView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/ReleaseCenterView",
+      "source": "src/components/pages/ReleaseCenterView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/RuntimeView",
+      "source": "src/components/pages/RuntimeView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/ScheduledTaskEditor",
+      "source": "src/components/pages/ScheduledTaskEditor.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/SecretsView",
+      "source": "src/components/pages/SecretsView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/SettingsView",
+      "source": "src/components/pages/SettingsView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/skill-detail-panel",
+      "source": "src/components/pages/skill-detail-panel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/skill-installer",
+      "source": "src/components/pages/skill-installer.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/SkillsView",
+      "source": "src/components/pages/SkillsView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/SqlEditorPanel",
+      "source": "src/components/pages/SqlEditorPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/StreamView",
+      "source": "src/components/pages/StreamView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/TaskEditor",
+      "source": "src/components/pages/TaskEditor.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/TasksPageView",
+      "source": "src/components/pages/TasksPageView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/TrajectoriesView",
+      "source": "src/components/pages/TrajectoriesView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/TrajectoryDetailView",
+      "source": "src/components/pages/TrajectoryDetailView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/trigger-form-utils",
+      "source": "src/components/pages/trigger-form-utils.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/TriggerForm",
+      "source": "src/components/pages/TriggerForm.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/TriggersView",
+      "source": "src/components/pages/TriggersView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/useBrowserWorkspaceWalletBridge",
+      "source": "src/components/pages/useBrowserWorkspaceWalletBridge.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/vector-browser-utils",
+      "source": "src/components/pages/vector-browser-utils.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/WalletSectionNav",
+      "source": "src/components/pages/WalletSectionNav.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/workflow-action-handoff",
+      "source": "src/components/pages/workflow-action-handoff.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/workflow-canvas-graph",
+      "source": "src/components/pages/workflow-canvas-graph.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/workflow-graph-events",
+      "source": "src/components/pages/workflow-graph-events.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/WorkflowCanvas",
+      "source": "src/components/pages/WorkflowCanvas.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/WorkflowEditor",
+      "source": "src/components/pages/WorkflowEditor.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/pages/WorkflowTriggerPanel",
+      "source": "src/components/pages/WorkflowTriggerPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/permissions/__e2e__/permission-priming-fixture",
+      "source": "src/components/permissions/__e2e__/permission-priming-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/permissions/permission-priming",
+      "source": "src/components/permissions/permission-priming.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/permissions/PermissionIcon",
+      "source": "src/components/permissions/PermissionIcon.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/permissions/PermissionPrimingModal",
+      "source": "src/components/permissions/PermissionPrimingModal.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/permissions/PermissionPrimingOverlay",
+      "source": "src/components/permissions/PermissionPrimingOverlay.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/permissions/PermissionRecoveryCallout",
+      "source": "src/components/permissions/PermissionRecoveryCallout.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/permissions/StreamingPermissions",
+      "source": "src/components/permissions/StreamingPermissions.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/permissions/use-permission-priming",
+      "source": "src/components/permissions/use-permission-priming.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/plugins/showcase-data",
+      "source": "src/components/plugins/showcase-data.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/primitives/index",
+      "source": "src/components/primitives/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/RedactedBadge",
+      "source": "src/components/RedactedBadge.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/release-center/sections",
+      "source": "src/components/release-center/sections.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/release-center/shared",
+      "source": "src/components/release-center/shared.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/release-center/shared.helpers",
+      "source": "src/components/release-center/shared.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/release-center/types",
+      "source": "src/components/release-center/types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/RoleGate",
+      "source": "src/components/RoleGate.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/AdvancedSection",
+      "source": "src/components/settings/AdvancedSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/AdvancedToggle",
+      "source": "src/components/settings/AdvancedToggle.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/AdvancedToggle.hooks",
+      "source": "src/components/settings/AdvancedToggle.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/ApiKeyConfig",
+      "source": "src/components/settings/ApiKeyConfig.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/appearance-primitives.helpers",
+      "source": "src/components/settings/appearance-primitives.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/AppearanceSettingsSection",
+      "source": "src/components/settings/AppearanceSettingsSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/AppPermissionsSection",
+      "source": "src/components/settings/AppPermissionsSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/AppsManagementSection",
+      "source": "src/components/settings/AppsManagementSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/BackgroundSettingsControls",
+      "source": "src/components/settings/BackgroundSettingsControls.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/BackgroundSettingsSection",
+      "source": "src/components/settings/BackgroundSettingsSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/CapabilitiesSection",
+      "source": "src/components/settings/CapabilitiesSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/ChatHotkeySettingsGroup",
+      "source": "src/components/settings/ChatHotkeySettingsGroup.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/cloud-model-schema",
+      "source": "src/components/settings/cloud-model-schema.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/CloudAgentsSection",
+      "source": "src/components/settings/CloudAgentsSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/CloudOverviewSection",
+      "source": "src/components/settings/CloudOverviewSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/ConnectorsSection",
+      "source": "src/components/settings/ConnectorsSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/DesktopSettingsNavigation",
+      "source": "src/components/settings/DesktopSettingsNavigation.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/DesktopWorkspaceDisplay",
+      "source": "src/components/settings/DesktopWorkspaceDisplay.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/DesktopWorkspaceDisplay.hooks",
+      "source": "src/components/settings/DesktopWorkspaceDisplay.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/DesktopWorkspaceSection",
+      "source": "src/components/settings/DesktopWorkspaceSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/IdentitySettingsSection",
+      "source": "src/components/settings/IdentitySettingsSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/IntelligenceServingSummary",
+      "source": "src/components/settings/IntelligenceServingSummary.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/LoadedPacksList",
+      "source": "src/components/settings/LoadedPacksList.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/ModelConfigurationPanel",
+      "source": "src/components/settings/ModelConfigurationPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/PendantSettingsCard",
+      "source": "src/components/settings/PendantSettingsCard.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/permission-controls",
+      "source": "src/components/settings/permission-controls.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/permission-controls.hooks",
+      "source": "src/components/settings/permission-controls.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/permission-types",
+      "source": "src/components/settings/permission-types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/PermissionsCombinedSection",
+      "source": "src/components/settings/PermissionsCombinedSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/PermissionsSection",
+      "source": "src/components/settings/PermissionsSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/ProviderCard",
+      "source": "src/components/settings/ProviderCard.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/ProviderPanels",
+      "source": "src/components/settings/ProviderPanels.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/ProviderRoutingPanel",
+      "source": "src/components/settings/ProviderRoutingPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/ProviderSwitcher",
+      "source": "src/components/settings/ProviderSwitcher.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/resolveServingAxes",
+      "source": "src/components/settings/resolveServingAxes.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/RuntimeSettingsSection",
+      "source": "src/components/settings/RuntimeSettingsSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/SecretsManagerSection",
+      "source": "src/components/settings/SecretsManagerSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/SecuritySettingsSection",
+      "source": "src/components/settings/SecuritySettingsSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/settings-agent-rows",
+      "source": "src/components/settings/settings-agent-rows.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/settings-control-primitives",
+      "source": "src/components/settings/settings-control-primitives.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/settings-control-primitives.hooks",
+      "source": "src/components/settings/settings-control-primitives.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/settings-layout",
+      "source": "src/components/settings/settings-layout.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/settings-route",
+      "source": "src/components/settings/settings-route.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/settings-section-meta",
+      "source": "src/components/settings/settings-section-meta.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/settings-section-registry",
+      "source": "src/components/settings/settings-section-registry.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/settings-section-tokens",
+      "source": "src/components/settings/settings-section-tokens.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/settings-sections",
+      "source": "src/components/settings/settings-sections.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/SettingsHubList",
+      "source": "src/components/settings/SettingsHubList.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/SubscriptionStatus",
+      "source": "src/components/settings/SubscriptionStatus.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/useCloudModelConfig",
+      "source": "src/components/settings/useCloudModelConfig.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/useDesktopWindowControls",
+      "source": "src/components/settings/useDesktopWindowControls.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/useModelConfiguration",
+      "source": "src/components/settings/useModelConfiguration.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/useProviderBootstrap",
+      "source": "src/components/settings/useProviderBootstrap.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/useProviderEntries",
+      "source": "src/components/settings/useProviderEntries.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/useProviderSelection",
+      "source": "src/components/settings/useProviderSelection.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/useServingAxes",
+      "source": "src/components/settings/useServingAxes.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/vault-tabs/LoginsTab",
+      "source": "src/components/settings/vault-tabs/LoginsTab.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/vault-tabs/OverviewTab",
+      "source": "src/components/settings/vault-tabs/OverviewTab.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/vault-tabs/RoutingTab",
+      "source": "src/components/settings/vault-tabs/RoutingTab.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/vault-tabs/SecretsTab",
+      "source": "src/components/settings/vault-tabs/SecretsTab.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/vault-tabs/types",
+      "source": "src/components/settings/vault-tabs/types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/VaultInventoryPanel",
+      "source": "src/components/settings/VaultInventoryPanel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/VoiceConfigView",
+      "source": "src/components/settings/VoiceConfigView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/VoiceConfigView.helpers",
+      "source": "src/components/settings/VoiceConfigView.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/VoiceProfileSection",
+      "source": "src/components/settings/VoiceProfileSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/VoiceSection",
+      "source": "src/components/settings/VoiceSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/VoiceSection.helpers",
+      "source": "src/components/settings/VoiceSection.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/VoiceSectionMount",
+      "source": "src/components/settings/VoiceSectionMount.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/VoiceTierBanner",
+      "source": "src/components/settings/VoiceTierBanner.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/VoiceTierBanner.helpers",
+      "source": "src/components/settings/VoiceTierBanner.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/WalletKeysSection",
+      "source": "src/components/settings/WalletKeysSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/WalletRpcSection",
+      "source": "src/components/settings/WalletRpcSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/settings/WebPushSettingsSection",
+      "source": "src/components/settings/WebPushSettingsSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/setup/BootstrapStep",
+      "source": "src/components/setup/BootstrapStep.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/setup/setup-classes",
+      "source": "src/components/setup/setup-classes.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/setup/setup-form-primitives",
+      "source": "src/components/setup/setup-form-primitives.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/setup/setup-step-chrome",
+      "source": "src/components/setup/setup-step-chrome.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shared/AppPageSidebar",
+      "source": "src/components/shared/AppPageSidebar.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shared/CollapsibleSidebarSection",
+      "source": "src/components/shared/CollapsibleSidebarSection.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shared/confirm-delete-control",
+      "source": "src/components/shared/confirm-delete-control.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shared/LanguageDropdown",
+      "source": "src/components/shared/LanguageDropdown.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shared/LanguageDropdown.helpers",
+      "source": "src/components/shared/LanguageDropdown.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shared/SectionNav",
+      "source": "src/components/shared/SectionNav.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shared/ThemeToggle",
+      "source": "src/components/shared/ThemeToggle.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shared/ViewHeader",
+      "source": "src/components/shared/ViewHeader.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shared/ViewHeaderSidebarTrigger",
+      "source": "src/components/shared/ViewHeaderSidebarTrigger.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/bottombar-fixture",
+      "source": "src/components/shell/__e2e__/bottombar-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/chat-ambient-fixture",
+      "source": "src/components/shell/__e2e__/chat-ambient-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/chat-sheet-fixture",
+      "source": "src/components/shell/__e2e__/chat-sheet-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/chatux-gesture-fixture",
+      "source": "src/components/shell/__e2e__/chatux-gesture-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/fused-wake-integration-fixture",
+      "source": "src/components/shell/__e2e__/fused-wake-integration-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/home-locale-fixture",
+      "source": "src/components/shell/__e2e__/home-locale-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/home-screen-fixture",
+      "source": "src/components/shell/__e2e__/home-screen-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/home-screen-fixture.activity-stub",
+      "source": "src/components/shell/__e2e__/home-screen-fixture.activity-stub.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/home-screen-fixture.api-stub",
+      "source": "src/components/shell/__e2e__/home-screen-fixture.api-stub.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/home-screen-fixture.auth-stub",
+      "source": "src/components/shell/__e2e__/home-screen-fixture.auth-stub.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/home-screen-fixture.catalog-stub",
+      "source": "src/components/shell/__e2e__/home-screen-fixture.catalog-stub.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/home-screen-fixture.core-stub",
+      "source": "src/components/shell/__e2e__/home-screen-fixture.core-stub.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/home-screen-fixture.docvis-stub",
+      "source": "src/components/shell/__e2e__/home-screen-fixture.docvis-stub.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/home-screen-fixture.platform-stub",
+      "source": "src/components/shell/__e2e__/home-screen-fixture.platform-stub.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/home-screen-fixture.view-kinds-stub",
+      "source": "src/components/shell/__e2e__/home-screen-fixture.view-kinds-stub.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/home-screen-fixture.views-stub",
+      "source": "src/components/shell/__e2e__/home-screen-fixture.views-stub.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/notifications-center-fixture",
+      "source": "src/components/shell/__e2e__/notifications-center-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/perf-gate-fixture",
+      "source": "src/components/shell/__e2e__/perf-gate-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/warming-absorption-fixture",
+      "source": "src/components/shell/__e2e__/warming-absorption-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/__e2e__/warmup-eviction-fixture",
+      "source": "src/components/shell/__e2e__/warmup-eviction-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/AssistantOverlay",
+      "source": "src/components/shell/AssistantOverlay.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/BugReportModal",
+      "source": "src/components/shell/BugReportModal.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/BuildBadge",
+      "source": "src/components/shell/BuildBadge.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/chat-overlay-motion",
+      "source": "src/components/shell/chat-overlay-motion.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/chat-overlay-transcript",
+      "source": "src/components/shell/chat-overlay-transcript.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/chat-overlay-window-bounds",
+      "source": "src/components/shell/chat-overlay-window-bounds.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/chat-panel-layout",
+      "source": "src/components/shell/chat-panel-layout.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/ChatOverlay",
+      "source": "src/components/shell/ChatOverlay.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/ChatSurface",
+      "source": "src/components/shell/ChatSurface.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/CommandPalette",
+      "source": "src/components/shell/CommandPalette.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/ComputerUseApprovalOverlay",
+      "source": "src/components/shell/ComputerUseApprovalOverlay.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/ConnectionLostOverlay",
+      "source": "src/components/shell/ConnectionLostOverlay.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/conversation-nav",
+      "source": "src/components/shell/conversation-nav.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/DefaultHomeWidgets",
+      "source": "src/components/shell/DefaultHomeWidgets.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/DynamicPluginFallback",
+      "source": "src/components/shell/DynamicPluginFallback.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/FirstSessionSwipeHint",
+      "source": "src/components/shell/FirstSessionSwipeHint.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/glass-composer",
+      "source": "src/components/shell/glass-composer.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/glass-composer.helpers",
+      "source": "src/components/shell/glass-composer.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/home-pill-wave",
+      "source": "src/components/shell/home-pill-wave.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/HomeLauncherSurface",
+      "source": "src/components/shell/HomeLauncherSurface.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/HomePill",
+      "source": "src/components/shell/HomePill.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/HomeScreen",
+      "source": "src/components/shell/HomeScreen.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/KioskViewCanvas",
+      "source": "src/components/shell/KioskViewCanvas.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/liquid-glass",
+      "source": "src/components/shell/liquid-glass.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/LoadingScreen",
+      "source": "src/components/shell/LoadingScreen.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/notification-shade-content",
+      "source": "src/components/shell/notification-shade-content.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/notification-shade-gesture-policy",
+      "source": "src/components/shell/notification-shade-gesture-policy.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/notification-shade-presentation",
+      "source": "src/components/shell/notification-shade-presentation.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/notifications-boot",
+      "source": "src/components/shell/notifications-boot.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/NotificationsHomeCenter",
+      "source": "src/components/shell/NotificationsHomeCenter.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/PagerEdgeButtons",
+      "source": "src/components/shell/PagerEdgeButtons.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/pairing-command",
+      "source": "src/components/shell/pairing-command.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/PairingCommandHint",
+      "source": "src/components/shell/PairingCommandHint.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/PairingView",
+      "source": "src/components/shell/PairingView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/press-latch",
+      "source": "src/components/shell/press-latch.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/RelativeTime",
+      "source": "src/components/shell/RelativeTime.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/RestartBanner",
+      "source": "src/components/shell/RestartBanner.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/shell-auth-gate",
+      "source": "src/components/shell/shell-auth-gate.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/shell-controller-sync/__tests__/fixtures",
+      "source": "src/components/shell/shell-controller-sync/__tests__/fixtures.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/shell-controller-sync/apply-command",
+      "source": "src/components/shell/shell-controller-sync/apply-command.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/shell-controller-sync/electrobun-transport",
+      "source": "src/components/shell/shell-controller-sync/electrobun-transport.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/shell-controller-sync/follower-controller",
+      "source": "src/components/shell/shell-controller-sync/follower-controller.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/shell-controller-sync/protocol",
+      "source": "src/components/shell/shell-controller-sync/protocol.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/shell-controller-sync/snapshot",
+      "source": "src/components/shell/shell-controller-sync/snapshot.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/shell-controller-sync/useOsIntentRouting",
+      "source": "src/components/shell/shell-controller-sync/useOsIntentRouting.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/shell-controller-sync/useShellControllerSync",
+      "source": "src/components/shell/shell-controller-sync/useShellControllerSync.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/shell-state",
+      "source": "src/components/shell/shell-state.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/ShellControllerContext",
+      "source": "src/components/shell/ShellControllerContext.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/ShellControllerContext.hooks",
+      "source": "src/components/shell/ShellControllerContext.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/ShellOverlays",
+      "source": "src/components/shell/ShellOverlays.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/ShortcutsOverlay",
+      "source": "src/components/shell/ShortcutsOverlay.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/SlashCommandMenu",
+      "source": "src/components/shell/SlashCommandMenu.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/startup-shell-types",
+      "source": "src/components/shell/startup-shell-types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/StartupFailureView",
+      "source": "src/components/shell/StartupFailureView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/StartupScreen",
+      "source": "src/components/shell/StartupScreen.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/StartupShell",
+      "source": "src/components/shell/StartupShell.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/SystemWarningBanner",
+      "source": "src/components/shell/SystemWarningBanner.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/topic-element",
+      "source": "src/components/shell/topic-element.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/topic-grouping",
+      "source": "src/components/shell/topic-grouping.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/TopicChipsBar",
+      "source": "src/components/shell/TopicChipsBar.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/TopicGroup",
+      "source": "src/components/shell/TopicGroup.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/TrayLauncher",
+      "source": "src/components/shell/TrayLauncher.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/use-pull-gesture",
+      "source": "src/components/shell/use-pull-gesture.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/useBarSurfaceWindows",
+      "source": "src/components/shell/useBarSurfaceWindows.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/useKioskViewSurfaces",
+      "source": "src/components/shell/useKioskViewSurfaces.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/useShellAuthGate",
+      "source": "src/components/shell/useShellAuthGate.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/useShellController",
+      "source": "src/components/shell/useShellController.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/useShellVoiceOutput",
+      "source": "src/components/shell/useShellVoiceOutput.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/VoiceCaptureHud",
+      "source": "src/components/shell/VoiceCaptureHud.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/shell/wallpaper-idiom",
+      "source": "src/components/shell/wallpaper-idiom.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ShellModalityProvider",
+      "source": "src/components/ShellModalityProvider.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ShellRoleProvider",
+      "source": "src/components/ShellRoleProvider.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/stream/helpers",
+      "source": "src/components/stream/helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/stream/popout-url",
+      "source": "src/components/stream/popout-url.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/stream/StatusBar",
+      "source": "src/components/stream/StatusBar.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/tool-events/chat-tool-events",
+      "source": "src/components/tool-events/chat-tool-events.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/tool-events/ToolCallEventLog",
+      "source": "src/components/tool-events/ToolCallEventLog.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/tool-events/ToolCallEventLog.helpers",
+      "source": "src/components/tool-events/ToolCallEventLog.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/transcripts/LiveMeetingPage",
+      "source": "src/components/transcripts/LiveMeetingPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/transcripts/LiveMeetingPane",
+      "source": "src/components/transcripts/LiveMeetingPane.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/transcripts/meeting-live",
+      "source": "src/components/transcripts/meeting-live.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/transcripts/MeetingJoinBar",
+      "source": "src/components/transcripts/MeetingJoinBar.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/transcripts/SpeakerNameAttributionBadge",
+      "source": "src/components/transcripts/SpeakerNameAttributionBadge.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/transcripts/transcript-story-fixtures",
+      "source": "src/components/transcripts/transcript-story-fixtures.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/transcripts/TranscriptBody",
+      "source": "src/components/transcripts/TranscriptBody.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/transcripts/TranscriptPlayer",
+      "source": "src/components/transcripts/TranscriptPlayer.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/transcripts/TranscriptsPage",
+      "source": "src/components/transcripts/TranscriptsPage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/transcripts/TranscriptsView",
+      "source": "src/components/transcripts/TranscriptsView.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/transcripts/useAudioElement",
+      "source": "src/components/transcripts/useAudioElement.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/accordion",
+      "source": "src/components/ui/accordion.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/admin-dialog",
+      "source": "src/components/ui/admin-dialog.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/alert",
+      "source": "src/components/ui/alert.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/alert-dialog",
+      "source": "src/components/ui/alert-dialog.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/attachment",
+      "source": "src/components/ui/attachment.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/avatar",
+      "source": "src/components/ui/avatar.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/badge",
+      "source": "src/components/ui/badge.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/banner",
+      "source": "src/components/ui/banner.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/button",
+      "source": "src/components/ui/button.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/calendar",
+      "source": "src/components/ui/calendar.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/card",
+      "source": "src/components/ui/card.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/carousel",
+      "source": "src/components/ui/carousel.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/chart",
+      "source": "src/components/ui/chart.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/checkbox",
+      "source": "src/components/ui/checkbox.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/code-block",
+      "source": "src/components/ui/code-block.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/collapsible",
+      "source": "src/components/ui/collapsible.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/confirm-delete",
+      "source": "src/components/ui/confirm-delete.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/confirm-dialog",
+      "source": "src/components/ui/confirm-dialog.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/confirm-dialog.hooks",
+      "source": "src/components/ui/confirm-dialog.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/connection-status",
+      "source": "src/components/ui/connection-status.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/copy-button",
+      "source": "src/components/ui/copy-button.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/dialog",
+      "source": "src/components/ui/dialog.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/dropdown-menu",
+      "source": "src/components/ui/dropdown-menu.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/empty-state",
+      "source": "src/components/ui/empty-state.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/error-boundary",
+      "source": "src/components/ui/error-boundary.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/field",
+      "source": "src/components/ui/field.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/field-switch",
+      "source": "src/components/ui/field-switch.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/form",
+      "source": "src/components/ui/form.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/form-select",
+      "source": "src/components/ui/form-select.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/grid",
+      "source": "src/components/ui/grid.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/hover-card",
+      "source": "src/components/ui/hover-card.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/input",
+      "source": "src/components/ui/input.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/input-group",
+      "source": "src/components/ui/input-group.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/label",
+      "source": "src/components/ui/label.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/marker",
+      "source": "src/components/ui/marker.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/message",
+      "source": "src/components/ui/message.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/message-scroller",
+      "source": "src/components/ui/message-scroller.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/new-action-button",
+      "source": "src/components/ui/new-action-button.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/pagination",
+      "source": "src/components/ui/pagination.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/popover",
+      "source": "src/components/ui/popover.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/progress",
+      "source": "src/components/ui/progress.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/save-footer",
+      "source": "src/components/ui/save-footer.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/scroll-area",
+      "source": "src/components/ui/scroll-area.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/segmented-control",
+      "source": "src/components/ui/segmented-control.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/select",
+      "source": "src/components/ui/select.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/separator",
+      "source": "src/components/ui/separator.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/settings-controls",
+      "source": "src/components/ui/settings-controls.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/skeleton",
+      "source": "src/components/ui/skeleton.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/skeleton-layouts",
+      "source": "src/components/ui/skeleton-layouts.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/slider",
+      "source": "src/components/ui/slider.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/spinner",
+      "source": "src/components/ui/spinner.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/stack",
+      "source": "src/components/ui/stack.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/status-badge",
+      "source": "src/components/ui/status-badge.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/status-badge.helpers",
+      "source": "src/components/ui/status-badge.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/switch",
+      "source": "src/components/ui/switch.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/table",
+      "source": "src/components/ui/table.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/tabs",
+      "source": "src/components/ui/tabs.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/tag-editor",
+      "source": "src/components/ui/tag-editor.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/textarea",
+      "source": "src/components/ui/textarea.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/toggle",
+      "source": "src/components/ui/toggle.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/tooltip",
+      "source": "src/components/ui/tooltip.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/tooltip-extended",
+      "source": "src/components/ui/tooltip-extended.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/ui/typography",
+      "source": "src/components/ui/typography.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/__e2e__/view-lifecycle-fixture",
+      "source": "src/components/views/__e2e__/view-lifecycle-fixture.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/device-control-interact",
+      "source": "src/components/views/device-control-interact.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/DynamicViewLoader",
+      "source": "src/components/views/DynamicViewLoader.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/KeepAliveViewHost",
+      "source": "src/components/views/KeepAliveViewHost.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/sandbox-policy",
+      "source": "src/components/views/sandbox-policy.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/sandbox-probe-view",
+      "source": "src/components/views/sandbox-probe-view.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/sandboxed-view-broker",
+      "source": "src/components/views/sandboxed-view-broker.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/SandboxedViewFrame",
+      "source": "src/components/views/SandboxedViewFrame.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/ShellViewAgentSurface",
+      "source": "src/components/views/ShellViewAgentSurface.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/view-capability-broker",
+      "source": "src/components/views/view-capability-broker.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/view-icon-aliases",
+      "source": "src/components/views/view-icon-aliases.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/view-icons.generated",
+      "source": "src/components/views/view-icons.generated.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/view-interact-registry",
+      "source": "src/components/views/view-interact-registry.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/ViewErrorBoundary",
+      "source": "src/components/views/ViewErrorBoundary.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/ViewIcon",
+      "source": "src/components/views/ViewIcon.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/ViewStatusStates",
+      "source": "src/components/views/ViewStatusStates.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/ViewTelemetryProfiler",
+      "source": "src/components/views/ViewTelemetryProfiler.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/views/ViewTileImage",
+      "source": "src/components/views/ViewTileImage.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/components/workspace/AppWorkspaceChrome",
+      "source": "src/components/workspace/AppWorkspaceChrome.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/adopt-remote-first-run",
+      "source": "src/first-run/adopt-remote-first-run.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/auto-download-recommended",
+      "source": "src/first-run/auto-download-recommended.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/boot-recovery-channel",
+      "source": "src/first-run/boot-recovery-channel.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/clear-first-run-transcript",
+      "source": "src/first-run/clear-first-run-transcript.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/cloud-login-wait-deadline",
+      "source": "src/first-run/cloud-login-wait-deadline.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/deep-link-handler",
+      "source": "src/first-run/deep-link-handler.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/device-ram-gate",
+      "source": "src/first-run/device-ram-gate.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/device-ram-tier",
+      "source": "src/first-run/device-ram-tier.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/ensure-store-build-workspace-folder",
+      "source": "src/first-run/ensure-store-build-workspace-folder.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/first-run",
+      "source": "src/first-run/first-run.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/first-run-action-channel",
+      "source": "src/first-run/first-run-action-channel.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/first-run-cloud-resume",
+      "source": "src/first-run/first-run-cloud-resume.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/first-run-config",
+      "source": "src/first-run/first-run-config.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/first-run-finish",
+      "source": "src/first-run/first-run-finish.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/first-run-greeting",
+      "source": "src/first-run/first-run-greeting.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/first-run-runtime-flag",
+      "source": "src/first-run/first-run-runtime-flag.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/local-agent-token",
+      "source": "src/first-run/local-agent-token.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/mobile-runtime-mode",
+      "source": "src/first-run/mobile-runtime-mode.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/model-action-channel",
+      "source": "src/first-run/model-action-channel.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/pre-seed-local-runtime",
+      "source": "src/first-run/pre-seed-local-runtime.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/probe-local-agent",
+      "source": "src/first-run/probe-local-agent.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/reconcile-mobile-runtime-mode",
+      "source": "src/first-run/reconcile-mobile-runtime-mode.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/reload-into-first-run-runtime",
+      "source": "src/first-run/reload-into-first-run-runtime.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/revert-local-runtime-commitment",
+      "source": "src/first-run/revert-local-runtime-commitment.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/runtime-target",
+      "source": "src/first-run/runtime-target.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/use-boot-recovery-conductor",
+      "source": "src/first-run/use-boot-recovery-conductor.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/use-first-run-conductor",
+      "source": "src/first-run/use-first-run-conductor.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/use-microphone-permission",
+      "source": "src/first-run/use-microphone-permission.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/first-run/use-model-status-conductor",
+      "source": "src/first-run/use-model-status-conductor.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/android-runtime",
+      "source": "src/platform/android-runtime.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/aosp-user-agent",
+      "source": "src/platform/aosp-user-agent.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/app-shell-mode",
+      "source": "src/platform/app-shell-mode.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/assistant-launch-payload",
+      "source": "src/platform/assistant-launch-payload.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/browser-launch",
+      "source": "src/platform/browser-launch.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/cloud-preference-patch",
+      "source": "src/platform/cloud-preference-patch.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/desktop-permissions-client",
+      "source": "src/platform/desktop-permissions-client.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/e2e-wallet",
+      "source": "src/platform/e2e-wallet.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/empty-node-module",
+      "source": "src/platform/empty-node-module.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/first-run-reset",
+      "source": "src/platform/first-run-reset.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/index",
+      "source": "src/platform/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/init",
+      "source": "src/platform/init.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/ios-runtime",
+      "source": "src/platform/ios-runtime.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/is-native-server",
+      "source": "src/platform/is-native-server.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/mobile-permissions-client",
+      "source": "src/platform/mobile-permissions-client.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/onboarding-replay",
+      "source": "src/platform/onboarding-replay.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/platform-guards",
+      "source": "src/platform/platform-guards.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/renderer-services",
+      "source": "src/platform/renderer-services.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/standalone-bottom-reclaim",
+      "source": "src/platform/standalone-bottom-reclaim.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/types",
+      "source": "src/platform/types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/vite-dev-ui-shell",
+      "source": "src/platform/vite-dev-ui-shell.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/platform/window-shell",
+      "source": "src/platform/window-shell.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/app-updates/update-policy",
+      "source": "src/services/app-updates/update-policy.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/active-model",
+      "source": "src/services/local-inference/active-model.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/assignments",
+      "source": "src/services/local-inference/assignments.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/bundled-models",
+      "source": "src/services/local-inference/bundled-models.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/catalog",
+      "source": "src/services/local-inference/catalog.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/catalog-policy",
+      "source": "src/services/local-inference/catalog-policy.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/custom-search",
+      "source": "src/services/local-inference/custom-search.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/device-bridge",
+      "source": "src/services/local-inference/device-bridge.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/disk-space",
+      "source": "src/services/local-inference/disk-space.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/downloader",
+      "source": "src/services/local-inference/downloader.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/engine",
+      "source": "src/services/local-inference/engine.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/external-scanner",
+      "source": "src/services/local-inference/external-scanner.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/handler-registry",
+      "source": "src/services/local-inference/handler-registry.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/hardware",
+      "source": "src/services/local-inference/hardware.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/hf-search",
+      "source": "src/services/local-inference/hf-search.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/home-model-status",
+      "source": "src/services/local-inference/home-model-status.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/index",
+      "source": "src/services/local-inference/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/load-args",
+      "source": "src/services/local-inference/load-args.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/manifest",
+      "source": "src/services/local-inference/manifest.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/paths",
+      "source": "src/services/local-inference/paths.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/readiness",
+      "source": "src/services/local-inference/readiness.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/recommendation",
+      "source": "src/services/local-inference/recommendation.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/registry",
+      "source": "src/services/local-inference/registry.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/resource-snapshot-bridge",
+      "source": "src/services/local-inference/resource-snapshot-bridge.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/routing-preferences",
+      "source": "src/services/local-inference/routing-preferences.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/service",
+      "source": "src/services/local-inference/service.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/token-tree",
+      "source": "src/services/local-inference/token-tree.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/tokenizer-client",
+      "source": "src/services/local-inference/tokenizer-client.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/types",
+      "source": "src/services/local-inference/types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/services/local-inference/verify",
+      "source": "src/services/local-inference/verify.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/slots/task-coordinator-slots",
+      "source": "src/slots/task-coordinator-slots.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/slots/task-coordinator-slots.helpers",
+      "source": "src/slots/task-coordinator-slots.helpers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/action-notice",
+      "source": "src/state/action-notice.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/active-server-credential",
+      "source": "src/state/active-server-credential.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/agent-profile-connection",
+      "source": "src/state/agent-profile-connection.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/agent-profile-types",
+      "source": "src/state/agent-profile-types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/agent-profiles",
+      "source": "src/state/agent-profiles.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/agent-runtime-target",
+      "source": "src/state/agent-runtime-target.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/agent-session-recovery",
+      "source": "src/state/agent-session-recovery.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/agent-session-recovery-runner",
+      "source": "src/state/agent-session-recovery-runner.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/agent-startup-timing",
+      "source": "src/state/agent-startup-timing.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/app-store",
+      "source": "src/state/app-store.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/AppContext",
+      "source": "src/state/AppContext.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/state/AppContext.hooks",
+      "source": "src/state/AppContext.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/autonomy",
+      "source": "src/state/autonomy.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/background-history",
+      "source": "src/state/background-history.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/bounded-view-lru",
+      "source": "src/state/bounded-view-lru.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/chat-conversation-guards",
+      "source": "src/state/chat-conversation-guards.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/chat-send-failures",
+      "source": "src/state/chat-send-failures.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/chat-view-routing",
+      "source": "src/state/chat-view-routing.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/ChatComposerContext.hooks",
+      "source": "src/state/ChatComposerContext.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/ChatTurnStatusContext.hooks",
+      "source": "src/state/ChatTurnStatusContext.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/cloud-login-launch",
+      "source": "src/state/cloud-login-launch.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/cloud-pair-token",
+      "source": "src/state/cloud-pair-token.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/cloud-session-refresh-for-repair",
+      "source": "src/state/cloud-session-refresh-for-repair.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/cloud-siwe-login",
+      "source": "src/state/cloud-siwe-login.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/cloud-steward-login",
+      "source": "src/state/cloud-steward-login.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/complete-reset-local-state-after-wipe",
+      "source": "src/state/complete-reset-local-state-after-wipe.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/config-readers",
+      "source": "src/state/config-readers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/continuous-chat-mode",
+      "source": "src/state/continuous-chat-mode.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/conversation-message-filter",
+      "source": "src/state/conversation-message-filter.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/ConversationMessagesContext.hooks",
+      "source": "src/state/ConversationMessagesContext.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/dedicated-cloud-agent-error",
+      "source": "src/state/dedicated-cloud-agent-error.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/desktop-tray-launcher",
+      "source": "src/state/desktop-tray-launcher.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/first-run-bootstrap",
+      "source": "src/state/first-run-bootstrap.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/greeting-dedupe",
+      "source": "src/state/greeting-dedupe.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/handle-reset-applied-from-main",
+      "source": "src/state/handle-reset-applied-from-main.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/heap-pressure-monitor",
+      "source": "src/state/heap-pressure-monitor.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/index",
+      "source": "src/state/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/internal",
+      "source": "src/state/internal.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/load-older-conversation-messages",
+      "source": "src/state/load-older-conversation-messages.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/notifications/category-icon",
+      "source": "src/state/notifications/category-icon.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/state/notifications/navigate-deep-link",
+      "source": "src/state/notifications/navigate-deep-link.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/notifications/notification-store",
+      "source": "src/state/notifications/notification-store.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/notifications/push-registration",
+      "source": "src/state/notifications/push-registration.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/notifications/useWebPush",
+      "source": "src/state/notifications/useWebPush.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/notifications/web-push-subscription",
+      "source": "src/state/notifications/web-push-subscription.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/ocr-bridge",
+      "source": "src/state/ocr-bridge.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/parsers",
+      "source": "src/state/parsers.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/pending-chat-turns",
+      "source": "src/state/pending-chat-turns.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/persistence",
+      "source": "src/state/persistence.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/private-network-host",
+      "source": "src/state/private-network-host.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/PtySessionsContext.hooks",
+      "source": "src/state/PtySessionsContext.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/rail-gesture-store",
+      "source": "src/state/rail-gesture-store.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/runtime-url-trust",
+      "source": "src/state/runtime-url-trust.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/screen-capture-bridge",
+      "source": "src/state/screen-capture-bridge.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/setup-resume",
+      "source": "src/state/setup-resume.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/shared-cloud-account-binding",
+      "source": "src/state/shared-cloud-account-binding.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/shell-routing",
+      "source": "src/state/shell-routing.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/shell-surface-store",
+      "source": "src/state/shell-surface-store.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/startup-coordinator",
+      "source": "src/state/startup-coordinator.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/startup-first-run-options",
+      "source": "src/state/startup-first-run-options.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/startup-phase-hydrate",
+      "source": "src/state/startup-phase-hydrate.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/startup-phase-poll",
+      "source": "src/state/startup-phase-poll.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/startup-phase-restore",
+      "source": "src/state/startup-phase-restore.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/startup-phase-runtime",
+      "source": "src/state/startup-phase-runtime.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/startup-probe",
+      "source": "src/state/startup-probe.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/startup-telemetry",
+      "source": "src/state/startup-telemetry.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/startup-timing-policy",
+      "source": "src/state/startup-timing-policy.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/streaming-render-cadence",
+      "source": "src/state/streaming-render-cadence.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/switch-runtime",
+      "source": "src/state/switch-runtime.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/task-activity-store",
+      "source": "src/state/task-activity-store.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/top-level-auth-gate",
+      "source": "src/state/top-level-auth-gate.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/TranslationContext.hooks",
+      "source": "src/state/TranslationContext.hooks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/TranslationProvider",
+      "source": "src/state/TranslationProvider.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/state/types",
+      "source": "src/state/types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/ui-preferences",
+      "source": "src/state/ui-preferences.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/use-startup-shell-controller",
+      "source": "src/state/use-startup-shell-controller.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useApp",
+      "source": "src/state/useApp.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useAppLifecycleEvents",
+      "source": "src/state/useAppLifecycleEvents.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useAppProviderEffects",
+      "source": "src/state/useAppProviderEffects.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useAppShellState",
+      "source": "src/state/useAppShellState.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useBackgroundConfig",
+      "source": "src/state/useBackgroundConfig.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useCharacterState",
+      "source": "src/state/useCharacterState.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useChatCallbacks",
+      "source": "src/state/useChatCallbacks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useChatLifecycle",
+      "source": "src/state/useChatLifecycle.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useChatOverlayHotkey",
+      "source": "src/state/useChatOverlayHotkey.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useChatSend",
+      "source": "src/state/useChatSend.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useChatState",
+      "source": "src/state/useChatState.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useCloudState",
+      "source": "src/state/useCloudState.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useContentPack",
+      "source": "src/state/useContentPack.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useDataLoaders",
+      "source": "src/state/useDataLoaders.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useDeveloperMode",
+      "source": "src/state/useDeveloperMode.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useDisplayPreferences",
+      "source": "src/state/useDisplayPreferences.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useExportImportState",
+      "source": "src/state/useExportImportState.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useFirstRunCallbacks",
+      "source": "src/state/useFirstRunCallbacks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useFirstRunState",
+      "source": "src/state/useFirstRunState.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useLifecycleState",
+      "source": "src/state/useLifecycleState.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useLogsState",
+      "source": "src/state/useLogsState.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useMiscUiState",
+      "source": "src/state/useMiscUiState.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useNavigationState",
+      "source": "src/state/useNavigationState.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/usePairingState",
+      "source": "src/state/usePairingState.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/usePluginsSkillsState",
+      "source": "src/state/usePluginsSkillsState.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/usePreviewMode",
+      "source": "src/state/usePreviewMode.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/user-background-catalog",
+      "source": "src/state/user-background-catalog.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useResyncReconcile",
+      "source": "src/state/useResyncReconcile.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useStartupCoordinator",
+      "source": "src/state/useStartupCoordinator.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useStreamingText",
+      "source": "src/state/useStreamingText.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useTabSync",
+      "source": "src/state/useTabSync.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useTriggersState",
+      "source": "src/state/useTriggersState.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useViewKinds",
+      "source": "src/state/useViewKinds.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useViewLifecycle",
+      "source": "src/state/useViewLifecycle.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/useWalletState",
+      "source": "src/state/useWalletState.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/view-chat-binding",
+      "source": "src/state/view-chat-binding.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/view-lifecycle",
+      "source": "src/state/view-lifecycle.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/view-lifecycle-context",
+      "source": "src/state/view-lifecycle-context.tsx"
+    },
+    {
+      "specifier": "@elizaos/ui/state/view-lifecycle-types",
+      "source": "src/state/view-lifecycle-types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/state/vrm",
+      "source": "src/state/vrm.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/asset-url",
+      "source": "src/utils/asset-url.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/attachment-url",
+      "source": "src/utils/attachment-url.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/automation-feed-filter",
+      "source": "src/utils/automation-feed-filter.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/browser-tab-kit-types",
+      "source": "src/utils/browser-tab-kit-types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/browser-tabs-renderer-registry",
+      "source": "src/utils/browser-tabs-renderer-registry.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/character-message-examples",
+      "source": "src/utils/character-message-examples.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/chunk-load-recovery",
+      "source": "src/utils/chunk-load-recovery.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/clipboard",
+      "source": "src/utils/clipboard.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/cloud-agent-base",
+      "source": "src/utils/cloud-agent-base.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/cloud-status",
+      "source": "src/utils/cloud-status.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/cron-format",
+      "source": "src/utils/cron-format.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/desktop-bug-report",
+      "source": "src/utils/desktop-bug-report.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/desktop-dialogs",
+      "source": "src/utils/desktop-dialogs.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/desktop-workspace",
+      "source": "src/utils/desktop-workspace.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/documents-upload-image",
+      "source": "src/utils/documents-upload-image.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/download-share",
+      "source": "src/utils/download-share.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/eliza-cloud-model-route",
+      "source": "src/utils/eliza-cloud-model-route.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/eliza-globals",
+      "source": "src/utils/eliza-globals.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/env",
+      "source": "src/utils/env.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/errors",
+      "source": "src/utils/errors.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/event-source",
+      "source": "src/utils/event-source.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/fetch-with-deadline",
+      "source": "src/utils/fetch-with-deadline.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/format",
+      "source": "src/utils/format.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/globals",
+      "source": "src/utils/globals.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/host-capabilities",
+      "source": "src/utils/host-capabilities.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/image-attachment",
+      "source": "src/utils/image-attachment.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/index",
+      "source": "src/utils/index.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/labels",
+      "source": "src/utils/labels.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/log-prefix",
+      "source": "src/utils/log-prefix.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/merge-unified-tasks",
+      "source": "src/utils/merge-unified-tasks.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/name-tokens",
+      "source": "src/utils/name-tokens.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/namespace-defaults",
+      "source": "src/utils/namespace-defaults.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/navigation-url",
+      "source": "src/utils/navigation-url.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/openExternalUrl",
+      "source": "src/utils/openExternalUrl.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/owner-name",
+      "source": "src/utils/owner-name.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/rate-limiter",
+      "source": "src/utils/rate-limiter.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/renderer-diagnostics",
+      "source": "src/utils/renderer-diagnostics.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/scheduled-task-to-automation",
+      "source": "src/utils/scheduled-task-to-automation.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/serialise",
+      "source": "src/utils/serialise.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/sql-compat",
+      "source": "src/utils/sql-compat.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/streaming-text",
+      "source": "src/utils/streaming-text.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/subscription-auth",
+      "source": "src/utils/subscription-auth.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/trajectory-format",
+      "source": "src/utils/trajectory-format.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/transient-fetch",
+      "source": "src/utils/transient-fetch.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/tts-debug",
+      "source": "src/utils/tts-debug.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/voice-capture-debug",
+      "source": "src/utils/voice-capture-debug.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/utils/with-timeout",
+      "source": "src/utils/with-timeout.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/views/view-event-bus",
+      "source": "src/views/view-event-bus.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/views/view-event-types",
+      "source": "src/views/view-event-types.ts"
+    },
+    {
+      "specifier": "@elizaos/ui/views/view-interact-protocol",
+      "source": "src/views/view-interact-protocol.ts"
+    }
+  ],
+  "subpathCount": 1389
 }


### PR DESCRIPTION
## Summary

`packages/ui/package.json` `exports` declares wildcard subpath entry points (`./cloud/*`, `./cloud-ui/*`, `./components/*`, `./api/*`, `./state/*`, `./agent-surface/*`, `./views/*`, `./bridge/*`, `./first-run/*`, `./platform/*`, `./slots/*`, `./utils/*`, `./services/*`). The build (`tsc -p tsconfig.build.json`, `include: ["src"]`) emits one `dist/<prefix>/...` output file per non-test, non-story source file under each prefix — with no dead-code elimination at the package boundary — so every one of those files is a genuine, externally-reachable public module (`@elizaos/ui/cloud/instances/components/docker-logs-viewer`, etc.), whether or not anything inside this monorepo imports it.

`packages/ui/scripts/audit-public-api.mjs` only ever checked `getExportsOfModule()` on `src/index.ts` — the root barrel. It had no visibility into this wildcard subpath surface at all. That is what let #23336 delete Cloud dashboard components (`docker-logs-viewer.tsx`, `account-limits-card.tsx`) with a clean in-repo-importer search: the deletion had zero in-repo importers, so it looked free, but the audit that should have caught a public-API narrowing structurally could not see this surface to begin with.

## What changed

- `audit-public-api.mjs` now also enumerates every `"./<prefix>/*" -> "./dist/<prefix>/*.js"` wildcard in `package.json` `exports`, resolves each back to its `src/<prefix>` source directory, and walks it (excluding `.test.ts(x)` / `.stories.ts(x)` / `.d.ts`, matching the build's own excludes) to produce public specifiers like `@elizaos/ui/cloud/billing/components/auto-top-up-card`.
- These are recorded in a new, separate `subpathExports` array in the baseline (`packages/ui/scripts/public-api-baseline.json`), diffed the same way as root exports — an added **or** removed subpath entry point fails the gate, same as a root export change.
- Root-export behavior, comparison logic, and the baseline's existing `exports` field are unchanged.
- `--update-baseline` regenerates both `exports` and `subpathExports`.

## Baseline diff summary

Regenerated against current `develop` (this repo already contains #23336's merged deletions):

- **143 root exports** — unchanged from before this PR.
- **1389 subpath entry points**, newly captured, spanning: `cloud` (272), `cloud-ui` (102), `components` (673), `api` (68), `state` (116), `first-run` (29), `services` (30), `platform` (22), `utils` (47), `agent-surface` (15), `bridge` (10), `views` (3), `slots` (2).
- `docker-logs-viewer` and `account-limits-card` are **already absent** from `develop` (#23336 merged before this branch), and correctly do not appear anywhere in the regenerated baseline. This PR does not restore them — it makes their removal (and any future one like it) visible to the gate.

## Proof the gate actually fails (step 3)

Temporarily removed `packages/ui/src/cloud/billing/components/auto-top-up-card.tsx` and reran the audit:

```
$ node scripts/audit-public-api.mjs
file:///.../packages/ui/scripts/audit-public-api.mjs:199
  throw new Error(
        ^

Error: Public API changed. Prefer an explicit subpath; update the baseline only for an intentional compatibility decision.
Subpath removed: @elizaos/ui/cloud/billing/components/auto-top-up-card
    at file:///.../packages/ui/scripts/audit-public-api.mjs:199:9

Node.js v22.4.1
EXIT CODE: 1
```

Also verified the added-file case (created a throwaway file under the same tree):

```
Error: Public API changed. ...
Subpath added: @elizaos/ui/cloud/billing/components/temp-added-file
EXIT: 1
```

File restored; audit clean again:

```
$ node scripts/audit-public-api.mjs
Public API matches baseline (143 root exports, 1389 subpath entry points).
EXIT CODE: 0
```

## Verification

- `node scripts/audit-public-api.mjs` — clean at final state (143 root / 1389 subpath).
- `biome check scripts/audit-public-api.mjs` — clean.
- No existing dedicated test file targets `audit-public-api.mjs`; none was removed or needed changes.

## Test plan

- [x] `node packages/ui/scripts/audit-public-api.mjs` exits 0 on the final tree
- [x] `node packages/ui/scripts/audit-public-api.mjs` exits 1 and names the entry point when a wildcard-subtree file is removed (proof above, file restored)
- [x] `node packages/ui/scripts/audit-public-api.mjs` exits 1 and names the entry point when a wildcard-subtree file is added (proof above, file removed)
- [x] `node packages/ui/scripts/audit-public-api.mjs --update-baseline` regenerates both `exports` and `subpathExports`
- [x] `biome check packages/ui/scripts/audit-public-api.mjs`

Follow-up to #23336.

---
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [pr-finisher]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza"} -->
