### PR TITLE
fix(core): fail soft on facts whose timestamp is outside the Date range

### DIFF
--- a/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
@@ -665,3 +665,109 @@ describe("factsProvider provenance attribution", () => {
 		expect(result.data.facts).toEqual([privateOwnerFact]);
 	});
 });
+
+describe("factsProvider out-of-range timestamps", () => {
+	// A microsecond-precision `createdAt` from a connector passes
+	// `Number.isFinite` but falls outside the ±8.64e15 Date range, so
+	// `new Date(ts).toISOString()` throws `RangeError: Invalid time value`.
+	// That escaped `formatSince` and surfaced as FACTS_PROVIDER_READ_FAILED,
+	// dropping every fact for the turn instead of one unreadable date.
+	const MICROSECOND_TIMESTAMP = 1.7e18;
+
+	it("renders a current fact whose createdAt is outside the Date range", async () => {
+		const runtime = makeRuntime({
+			recentMessages: [memory("msg-1", "where am I working from now?")],
+			facts: [
+				memory(
+					"fact-1",
+					"the user is working from Lisbon",
+					{
+						kind: "current",
+						category: "location",
+						confidence: 0.9,
+						keywords: ["working", "lisbon"],
+					},
+					MICROSECOND_TIMESTAMP,
+				),
+			],
+		});
+
+		const result = await factsProvider.get(
+			runtime,
+			memory("msg-current", "where am I working from now?"),
+			{ values: {}, data: {}, text: "" },
+		);
+
+		expect(result.text).toContain("the user is working from Lisbon");
+		expect(result.text).toContain("since unknown");
+	});
+
+	it("keeps readable facts when one row carries an unreadable timestamp", async () => {
+		const runtime = makeRuntime({
+			recentMessages: [memory("msg-1", "remind me where I am working")],
+			facts: [
+				memory(
+					"fact-bad",
+					"the user is working from Lisbon",
+					{
+						kind: "current",
+						category: "location",
+						confidence: 0.9,
+						keywords: ["working", "lisbon"],
+					},
+					MICROSECOND_TIMESTAMP,
+				),
+				memory(
+					"fact-good",
+					"the user is working from Porto on Fridays",
+					{
+						kind: "current",
+						category: "location",
+						confidence: 0.9,
+						keywords: ["working", "porto"],
+					},
+					Date.now(),
+				),
+			],
+		});
+
+		const result = await factsProvider.get(
+			runtime,
+			memory("msg-current", "remind me where I am working"),
+			{ values: {}, data: {}, text: "" },
+		);
+
+		expect(result.text).toContain("the user is working from Porto on Fridays");
+		expect(result.text).toContain("the user is working from Lisbon");
+	});
+
+	// 8.64e15 is the largest value `Date` can represent. One millisecond past it
+	// is the first input that `Number.isFinite` accepts and `Date` cannot.
+	it("treats a timestamp one millisecond past the Date range as unknown", async () => {
+		const runtime = makeRuntime({
+			recentMessages: [memory("msg-1", "what is my current setup")],
+			facts: [
+				memory(
+					"fact-1",
+					"the user is running the beta setup",
+					{
+						kind: "current",
+						category: "status",
+						confidence: 0.9,
+						keywords: ["running", "beta", "setup"],
+					},
+					8.64e15 + 1,
+				),
+			],
+		});
+
+		const result = await factsProvider.get(
+			runtime,
+			memory("msg-current", "what is my current setup"),
+			{ values: {}, data: {}, text: "" },
+		);
+
+		expect(result.text).toContain("the user is running the beta setup");
+		expect(result.text).toContain("since unknown");
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/providers/facts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.ts
@@ -113,15 +113,24 @@ function readFactKind(memory: Memory): FactKind {
  * back to `createdAt` so legacy facts and current facts that omit
  * `valid_at` still rank consistently.
  */
+function isRenderableTimestamp(value: number): boolean {
+	// Match packages/core/src/utils/time-format.ts: construct the Date first and
+	// require a finite getTime(). `Number.isFinite` alone admits values outside
+	// the ±8.64e15 Date range — a microsecond-precision timestamp from a
+	// connector, say — which then throws `RangeError: Invalid time value` from
+	// `toISOString()` and takes the whole provider down with it.
+	return Number.isFinite(new Date(value).getTime());
+}
+
 function readEffectiveTimestampMs(memory: Memory): number | null {
 	const validAt = readFactMetadata(memory).validAt;
 	if (typeof validAt === "string") {
 		const parsed = Date.parse(validAt);
-		if (Number.isFinite(parsed)) return parsed;
+		if (isRenderableTimestamp(parsed)) return parsed;
 	}
 	if (
 		typeof memory.createdAt === "number" &&
-		Number.isFinite(memory.createdAt)
+		isRenderableTimestamp(memory.createdAt)
 	) {
 		return memory.createdAt;
 	}


### PR DESCRIPTION
# Relates to

No linked issue. Found during a queue-cleared repository audit (no open
`mission-ready` issue was available) and reproduced locally before any change.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Two-line guard change in one module-private helper plus a new comment. The
only behavioural difference is for timestamps `Date` cannot represent: those
previously threw and now resolve to `null`, which the existing `null` paths
already handle. Ranking is unchanged — both call sites already treated a `null`
timestamp as age zero, and an out-of-range future timestamp already produced
`ageMs = 0` through `Math.max(0, nowMs - ts)`. No schema, export, or contract
change.

# Background

## What does this PR do?

`readEffectiveTimestampMs` guarded `createdAt` with `Number.isFinite`, which
also accepts values outside the ±8.64e15 millisecond range `Date` can
represent. A microsecond-precision timestamp from a connector (a common unit
mix-up) passes that guard:

```
Number.isFinite(1.7e18)      -> true      (guard passes)
new Date(1.7e18).getTime()   -> NaN       (not representable)
new Date(1.7e18).toISOString() -> RangeError: Invalid time value
```

`formatSince` calls `new Date(ts).toISOString()` and runs for every `current`
fact via `formatCurrentLine`. The `RangeError` escapes `factsProvider.get` and
is rethrown as `ElizaError` `FACTS_PROVIDER_READ_FAILED`, so **one unreadable
row dropped every fact for that turn** rather than one date label.

The fix mirrors the guard the sibling `packages/core/src/utils/time-format.ts`
already uses and documents for exactly this case: construct the `Date` first
and require a finite `getTime()`. Out-of-range timestamps now render
`since unknown`, and readable facts on the same turn survive.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`readEffectiveTimestampMs` and the new `isRenderableTimestamp` helper in
`packages/core/src/features/advanced-capabilities/providers/facts.ts`, then the
`factsProvider out-of-range timestamps` block appended to
`packages/core/src/features/advanced-capabilities/providers/facts.test.ts`.

## Detailed testing steps

```bash
bun run --cwd packages/core test -- src/features/advanced-capabilities/providers/facts.test.ts
```

Three new cases, driven through the public `factsProvider.get` with the file's
existing deterministic runtime mock (no live model, no DB):

1. a `current` fact whose `createdAt` is a microsecond timestamp renders and
   shows `since unknown` instead of throwing;
2. a readable fact on the same turn still renders when a sibling row carries an
   unreadable timestamp — this is the regression that dropped all facts;
3. the exact boundary: `8.64e15 + 1`, the first value `Number.isFinite` accepts
   and `Date` cannot.

Verified red before green — against unpatched `facts.ts` all three fail with
`Caused by: RangeError: Invalid time value` (3 failed | 19 passed); with the fix
the suite is 22/22.

# Evidence Gate

<!-- evidence-head:69d65c3a07723ccbda38e6df14ef4e353c543f7a -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no UI surface; the change is a
      module-private timestamp guard in a prompt-context provider and renders no
      rendered component.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no UI surface; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the observable behaviour is
      provider text asserted directly by the unit tests above.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: test output below shows the real code path — the unpatched
      run surfaces the actual `RangeError` through the provider's error boundary.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path is touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - the changed path performs no model call. It is
      a pure date-formatting guard; the provider mock in this suite asserts the
      no-embeddings invariant by throwing on useModel, so a live run would
      exercise nothing this diff changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the rendered provider text is asserted inline in the
      tests (`since unknown`, and both facts present on the mixed-row case).
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Backend logs

Red — against unpatched `facts.ts` at this branch point:

<details>
<summary>3 failed | 19 passed (22)</summary>

```
 × renders a current fact whose createdAt is outside the Date range
 × keeps readable facts when one row carries an unreadable timestamp
 × treats a timestamp one millisecond past the Date range as unknown
⎯⎯⎯ Failed Tests 3 ⎯⎯⎯
Caused by: RangeError: Invalid time value
Caused by: RangeError: Invalid time value
Caused by: RangeError: Invalid time value
 Tests  3 failed | 19 passed (22)
```

</details>

Green — with the fix, at `69d65c3a07723ccbda38e6df14ef4e353c543f7a`:

<details>
<summary>22 passed (22)</summary>

```
 RUN  v4.1.10 packages/core
 Test Files  1 passed (1)
      Tests  22 passed (22)
```

</details>

Biome on both changed files:

```
Checked 2 files. No fixes applied.
```

## Screenshots (before / after) + video walkthrough

`N/A - no UI surface is touched by this diff.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, or STT path is touched.`

## Known gaps / failures

- **`bun run verify` was not run in full.** The focused package lane
  (`packages/core` advanced-capabilities providers, 22 tests) and the Biome gate
  were run instead, both after the final rebase. The full repository verify is a
  long multi-package lane and was not completed in this environment; the diff
  touches one core module and its colocated test, and no export, schema, or
  contract changed. Happy to attach a full run if a maintainer wants it before
  merge.
- Every `N/A` evidence row above is a non-UI, non-model code path; reasons are
  recorded inline on each row rather than left blank.
- The signed contribution receipt footer is not yet appended. It is pending
  completion of the run-receipt trace step and will be added to this description
  in a follow-up edit; the self-reported provenance rows above are complete in
  the meantime.
