### PR TITLE
fix(notes): restore plugin-notes typecheck under the ES2023 lib

### DIFF
--- a/plugins/plugin-notes/src/provider.test.ts
+++ b/plugins/plugin-notes/src/provider.test.ts
@@ -20,6 +20,7 @@ import {
   type Provider,
   type State,
   stringToUuid,
+  toWellFormedUnicode,
 } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -29,6 +30,13 @@ import { NOTES_SERVICE_TYPE, NotesService } from "./service.js";
 import { NotesStore } from "./store.js";
 import type { StickyNote } from "./types.js";
 import { parseNoteContent } from "./validation.js";
+
+/**
+ * `String.prototype.isWellFormed` is ES2024 and the workspace compiles against
+ * the ES2023 lib, so assert well-formedness through the core helper instead.
+ */
+const isWellFormedText = (value: string): boolean =>
+  toWellFormedUnicode(value) === value;
 
 const temporaryDirectories: string[] = [];
 const testRuntimes: AgentRuntime[] = [];
@@ -278,7 +286,7 @@ describe("SAVED_NOTES provider", () => {
     const noteLine = text.split("\n").find((line) => line.startsWith("- x"));
     expect(noteLine).toBeDefined();
     if (noteLine) {
-      expect(noteLine.isWellFormed()).toBe(true);
+      expect(isWellFormedText(noteLine)).toBe(true);
       expect(noteLine.length).toBeLessThanOrEqual(402);
     }
     expect(noteLine).not.toContain("🦊");
@@ -297,7 +305,7 @@ describe("SAVED_NOTES provider", () => {
       },
     ]);
     expect(text).toContain("a\ufffdbc");
-    expect(text.isWellFormed()).toBe(true);
+    expect(isWellFormedText(text)).toBe(true);
   });
 
   it("preserves an emoji that fits entirely under the 400 cap", () => {
@@ -313,11 +321,11 @@ describe("SAVED_NOTES provider", () => {
       },
     ]);
     expect(text).toContain("🦊");
-    expect(text.isWellFormed()).toBe(true);
+    expect(isWellFormedText(text)).toBe(true);
     const noteLine = text.split("\n").find((line) => line.startsWith("- t"));
     expect(noteLine).toBeDefined();
     if (noteLine) {
-      expect(noteLine.isWellFormed()).toBe(true);
+      expect(isWellFormedText(noteLine)).toBe(true);
     }
   });
 });


### PR DESCRIPTION
## Problem

`bun run --cwd plugins/plugin-notes typecheck` currently **fails on develop**:

```
src/provider.test.ts(281,23): error TS2550: Property 'isWellFormed' does not exist on type 'string'.
src/provider.test.ts(300,17): error TS2550: ...
src/provider.test.ts(316,17): error TS2550: ...
src/provider.test.ts(320,23): error TS2550: ...
```

PR #23441 added provider tests that call `String.prototype.isWellFormed`, which is **ES2024**. The workspace root tsconfig sets `"lib": ["ES2023", "DOM", "DOM.Iterable"]`, and `plugins/plugin-notes/tsconfig.json` includes `src/**/*.ts` — so the test file is typechecked and the build breaks.

Sibling PRs #23437 (telegram) and #23445 (zerollama) used the same assertion but escape the failure only because their tsconfigs exclude test files.

## Fix

Assert well-formedness through the core `toWellFormedUnicode` helper instead. This is the feature-detected path that `packages/core/src/utils/well-formed.ts` already documents for exactly this reason — it reads `String.prototype.isWellFormed` behind a cast precisely because the lib target does not declare it.

Assertion behaviour is unchanged: `toWellFormedUnicode(value) === value` is true iff the string is well-formed.

## Verification

Run in a clean worktree off develop (`bun install`, generated keyword sources materialized):

| Gate | Before | After |
| --- | --- | --- |
| `typecheck` (TS2550 count) | 4 | **0** |
| `typecheck` (errors in `src/`) | 4 | **0** |
| `test` | 96 passed | **96 passed (10 files)** |
| `biome check` on the changed file | — | **clean** |

The remaining `TS2307: Cannot find module '@elizaos/shared'` diagnostics are pre-existing unbuilt-workspace-dependency noise, present identically before and after this change and unrelated to plugin-notes.

Refs #23440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)