### PR TITLE
fix(agent): close signing-policy rate-limit reservation race

### DIFF
--- a/packages/agent/src/services/remote-signing-service.test.ts
+++ b/packages/agent/src/services/remote-signing-service.test.ts
@@ -3,13 +3,23 @@
  * construct when the TEE boot gate blocks secrets and re-attests TEE evidence on
  * every sign when a policy demands it. Deterministic harness — vi-mocked signer
  * backend and evidence provider over in-memory boot-gate state; no real TEE.
+ *
+ * Also covers RemoteSigningService's rate-limit reservation lifecycle
+ * end-to-end (not just the underlying SigningPolicyEvaluator in isolation):
+ * concurrent submissions racing for a one-slot budget, and every path that
+ * must release an unconsumed reservation (rejection, expiry, sign failure).
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createTeeGatedRemoteSigningService,
+  RemoteSigningService,
   type SignerBackend,
 } from "./remote-signing-service.ts";
-import type { SigningRequest } from "./signing-policy.ts";
+import {
+  createDefaultPolicy,
+  type SigningPolicy,
+  type SigningRequest,
+} from "./signing-policy.ts";
 import type { TeeBootGate } from "./tee-boot-gate.ts";
 import {
   clearTeeBootGateState,
@@ -135,5 +145,132 @@ describe("createTeeGatedRemoteSigningService", () => {
         teePolicy: attestingPolicy,
       }),
     ).toThrow(/no evidenceProvider/);
+  });
+});
+
+function ratePolicy(overrides: Partial<SigningPolicy> = {}): SigningPolicy {
+  return {
+    ...createDefaultPolicy(),
+    maxTransactionsPerHour: 1,
+    maxTransactionsPerDay: 10,
+    ...overrides,
+  };
+}
+
+function rateRequest(overrides: Partial<SigningRequest> = {}): SigningRequest {
+  return {
+    requestId: "req-1",
+    chainId: 1,
+    to: "0x0000000000000000000000000000000000000001",
+    value: "0",
+    data: "0x",
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("RemoteSigningService rate-limit reservation lifecycle", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("admits exactly one of two concurrent submissions against a limit of 1", async () => {
+    const signer = signerBackend();
+    const service = new RemoteSigningService({
+      signer,
+      policy: ratePolicy(),
+    });
+
+    // Both submissions start before either has recorded a reservation —
+    // submitSigningRequest's check-and-reserve runs synchronously via
+    // tryReserve() before the first `await` (signTransaction), so this
+    // reproduces the interleaving a concurrent-caller race depends on.
+    const [a, b] = await Promise.all([
+      service.submitSigningRequest(rateRequest({ requestId: "race-a" })),
+      service.submitSigningRequest(rateRequest({ requestId: "race-b" })),
+    ]);
+
+    const results = [a, b];
+    expect(results.filter((r) => r.success)).toHaveLength(1);
+    const rejected = results.find((r) => !r.success);
+    expect(rejected?.policyDecision.matchedRule).toBe("rate_limit_hourly");
+    expect(signer.signTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("frees the slot on human rejection so a later request is admitted", async () => {
+    const signer = signerBackend();
+    const service = new RemoteSigningService({
+      signer,
+      policy: ratePolicy({ requireHumanConfirmation: true }),
+    });
+
+    const first = await service.submitSigningRequest(
+      rateRequest({ requestId: "needs-approval" }),
+    );
+    expect(first.success).toBe(false);
+    expect(first.policyDecision.requiresHumanConfirmation).toBe(true);
+
+    // A second submission is rejected by the hourly limit while the first
+    // reservation is still held pending human confirmation.
+    const blocked = await service.submitSigningRequest(
+      rateRequest({ requestId: "blocked-while-pending" }),
+    );
+    expect(blocked.policyDecision.matchedRule).toBe("rate_limit_hourly");
+
+    const rejected = service.rejectRequest("needs-approval");
+    expect(rejected).toBe(true);
+
+    const after = await service.submitSigningRequest(
+      rateRequest({ requestId: "after-rejection" }),
+    );
+    // The policy still requires human confirmation for every request, so
+    // this can't reach success:true — the reservation freeing itself is
+    // proven by getting past the rate limit (matchedRule "allowed") instead
+    // of "rate_limit_hourly".
+    expect(after.policyDecision.matchedRule).toBe("allowed");
+  });
+
+  it("frees the slot on approval expiry so a later request is admitted", async () => {
+    const signer = signerBackend();
+    const now = Date.parse("2026-08-20T00:00:00Z");
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const service = new RemoteSigningService({
+      signer,
+      policy: ratePolicy({ requireHumanConfirmation: true }),
+      approvalTimeoutMs: 1000,
+    });
+
+    await service.submitSigningRequest(
+      rateRequest({ requestId: "expires-soon" }),
+    );
+
+    vi.spyOn(Date, "now").mockImplementation(() => now + 2000);
+    const approveResult = await service.approveRequest("expires-soon");
+    expect(approveResult.error).toBe("Approval expired");
+
+    const after = await service.submitSigningRequest(
+      rateRequest({ requestId: "after-expiry" }),
+    );
+    expect(after.policyDecision.matchedRule).toBe("allowed");
+  });
+
+  it("frees the slot when the signer itself fails", async () => {
+    const signer = signerBackend();
+    signer.signTransaction.mockRejectedValueOnce(new Error("signer offline"));
+    const service = new RemoteSigningService({
+      signer,
+      policy: ratePolicy(),
+    });
+
+    const failed = await service.submitSigningRequest(
+      rateRequest({ requestId: "sign-fails" }),
+    );
+    expect(failed.success).toBe(false);
+    expect(failed.error).toMatch(/Signing failed/);
+
+    const retry = await service.submitSigningRequest(
+      rateRequest({ requestId: "sign-fails" }),
+    );
+    expect(retry.success).toBe(true);
   });
 });

--- a/packages/agent/src/services/remote-signing-service.ts
+++ b/packages/agent/src/services/remote-signing-service.ts
@@ -75,8 +75,13 @@ export class RemoteSigningService {
   }
 
   async submitSigningRequest(request: SigningRequest): Promise<SigningResult> {
-    // Evaluate policy
-    const decision = this.policyEvaluator.evaluate(request);
+    // Atomically check-and-reserve: a plain evaluate() followed by a later
+    // recordRequest() left a TOCTOU window where two concurrent submissions
+    // could both pass a maxTransactionsPerHour: 1 policy before either
+    // recorded (#23228). tryReserve() closes it; every path below that
+    // abandons an allowed-but-unconsumed reservation must call
+    // policyEvaluator.release(request.requestId) to return the slot.
+    const decision = this.policyEvaluator.tryReserve(request);
 
     this.auditLog?.record({
       type: "signing_request_submitted",
@@ -153,6 +158,7 @@ export class RemoteSigningService {
     // Check expiration
     if (Date.now() > approval.expiresAt) {
       this.pendingApprovals.delete(requestId);
+      this.policyEvaluator.release(requestId);
       return {
         success: false,
         error: "Approval expired",
@@ -171,6 +177,10 @@ export class RemoteSigningService {
     this.pendingApprovals.delete(requestId);
 
     if (existed) {
+      // The reservation tryReserve() made at submit time is never going to
+      // be consumed by a sign now — return the rate-limit slot and replay
+      // marker to the pool.
+      this.policyEvaluator.release(requestId);
       this.auditLog?.record({
         type: "signing_request_rejected",
         summary: `Human rejected request ${requestId}`,
@@ -188,6 +198,7 @@ export class RemoteSigningService {
     for (const [id, approval] of this.pendingApprovals) {
       if (now > approval.expiresAt) {
         this.pendingApprovals.delete(id);
+        this.policyEvaluator.release(id);
       }
     }
     return [...this.pendingApprovals.values()];
@@ -228,8 +239,10 @@ export class RemoteSigningService {
       }
       const signedTx = await this.signer.signTransaction(unsigned);
 
-      // Record for replay protection and rate limiting
-      this.policyEvaluator.recordRequest(request.requestId);
+      // Replay protection + rate limiting were already reserved atomically
+      // by tryReserve() before this method was called; the reservation is
+      // now consumed by a real signed transaction, so there is nothing left
+      // to record here.
 
       this.auditLog?.record({
         type: "signing_request_approved",
@@ -251,6 +264,11 @@ export class RemoteSigningService {
       };
     } catch (err) {
       const errorMsg = String(err);
+
+      // The reservation was never consumed by a real signature — return the
+      // slot and replay marker so a legitimate retry isn't blocked by a
+      // failed attempt (#23228).
+      this.policyEvaluator.release(request.requestId);
 
       this.auditLog?.record({
         type: "signing_request_rejected",

--- a/packages/agent/src/services/signing-policy.test.ts
+++ b/packages/agent/src/services/signing-policy.test.ts
@@ -108,7 +108,12 @@ describe("SigningPolicyEvaluator", () => {
     const evaluator = new SigningPolicyEvaluator(input);
 
     input.deniedContracts.push("0x0000000000000000000000000000000000000001");
-    evaluator.getPolicy().allowedMethodSelectors.length = 0;
+    // getPolicy() now returns a frozen snapshot: a mutation attempt throws
+    // immediately instead of silently succeeding on a copy that has no
+    // effect on future decisions (#23228).
+    expect(() => {
+      evaluator.getPolicy().allowedMethodSelectors.length = 0;
+    }).toThrow();
 
     expect(
       evaluator.evaluate(createRequest({ data: "0x12345678" })),
@@ -182,5 +187,50 @@ describe("SigningPolicyEvaluator", () => {
     expect(
       evaluator.evaluate(createRequest({ requestId: "candidate" })),
     ).toMatchObject({ allowed: true, matchedRule: "allowed" });
+  });
+
+  it("closes the evaluate/recordRequest TOCTOU race: exactly one of two concurrent reservations succeeds at a limit of 1", async () => {
+    const evaluator = new SigningPolicyEvaluator(
+      createPolicy({ maxTransactionsPerHour: 1, maxTransactionsPerDay: 1 }),
+    );
+
+    // Two "submissions" that each do their own check-and-reserve with no
+    // knowledge of the other. With the old evaluate()+recordRequest() split,
+    // both checks could run (and both pass) before either recordRequest()
+    // executed. tryReserve() performs the check and the record in one
+    // synchronous call, so the second call always observes the first's
+    // reservation, however the two calls get interleaved by the scheduler.
+    const results = await Promise.all([
+      Promise.resolve().then(() =>
+        evaluator.tryReserve(createRequest({ requestId: "concurrent-a" })),
+      ),
+      Promise.resolve().then(() =>
+        evaluator.tryReserve(createRequest({ requestId: "concurrent-b" })),
+      ),
+    ]);
+
+    expect(results.filter((r) => r.allowed)).toHaveLength(1);
+    expect(results.map((r) => r.matchedRule).sort()).toEqual(
+      ["allowed", "rate_limit_hourly"].sort(),
+    );
+  });
+
+  it("release() undoes a reservation so a later request can take the freed slot", () => {
+    const evaluator = new SigningPolicyEvaluator(
+      createPolicy({ maxTransactionsPerHour: 1, maxTransactionsPerDay: 1 }),
+    );
+
+    expect(
+      evaluator.tryReserve(createRequest({ requestId: "req-1" })).allowed,
+    ).toBe(true);
+    expect(
+      evaluator.tryReserve(createRequest({ requestId: "req-2" })),
+    ).toMatchObject({ matchedRule: "rate_limit_hourly" });
+
+    evaluator.release("req-1");
+
+    expect(
+      evaluator.tryReserve(createRequest({ requestId: "req-2" })).allowed,
+    ).toBe(true);
   });
 });

--- a/packages/agent/src/services/signing-policy.ts
+++ b/packages/agent/src/services/signing-policy.ts
@@ -74,8 +74,21 @@ export class SigningPolicyEvaluator {
     this.policy = clonePolicy(policy);
   }
 
+  /**
+   * `clonePolicy()` already isolates callers from the live arrays; freezing
+   * the snapshot additionally makes a mutation attempt throw immediately
+   * (in strict-mode/ESM code) rather than silently succeed on a copy that
+   * happens to have no effect — surfacing the caller bug instead of masking
+   * it (#23228).
+   */
   getPolicy(): SigningPolicy {
-    return clonePolicy(this.policy);
+    const snapshot = clonePolicy(this.policy);
+    for (const value of Object.values(snapshot)) {
+      if (Array.isArray(value)) {
+        Object.freeze(value);
+      }
+    }
+    return Object.freeze(snapshot);
   }
 
   evaluate(request: SigningRequest): PolicyDecision {
@@ -260,5 +273,38 @@ export class SigningPolicyEvaluator {
         this.processedRequestIds.delete(id);
       }
     }
+  }
+
+  /**
+   * Atomically evaluates `request` and, when the policy allows it, reserves
+   * the rate-limit slot and replay marker in the same synchronous step as
+   * the check. A separate `evaluate()` then later `recordRequest()` call is
+   * a TOCTOU race: two concurrent submissions can both call `evaluate()`
+   * (e.g. both observe 0/1 hourly) before either has recorded, so both pass
+   * a `maxTransactionsPerHour: 1` policy (#23228). JS execution is
+   * single-threaded, so doing the check and the record with no `await`
+   * between them — as this method does — makes the pair uninterruptible: no
+   * other `tryReserve` call can run in between and observe stale state.
+   * `evaluate()`/`recordRequest()` stay as separate primitives, unchanged,
+   * for read-only previews and for tests that seed history directly.
+   *
+   * The caller owns the reservation once this returns `allowed: true`; call
+   * `release(request.requestId)` on every path where the reservation is not
+   * consumed by an actual signed transaction — a failed sign, a rejected or
+   * expired human-confirmation request — or the slot and replay marker are
+   * gone from the pool forever.
+   */
+  tryReserve(request: SigningRequest): PolicyDecision {
+    const decision = this.evaluate(request);
+    if (decision.allowed) {
+      this.recordRequest(request.requestId);
+    }
+    return decision;
+  }
+
+  /** Undo a reservation made by `tryReserve()` that the caller did not follow through on. */
+  release(requestId: string): void {
+    this.processedRequestIds.delete(requestId);
+    this.requestLog = this.requestLog.filter((r) => r.requestId !== requestId);
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #23326 ("fix(agent): harden signing policy boundaries"), which
merged into `develop` as [`d281421ed`](https://github.com/elizaOS/eliza/commit/d281421ed4f08e79bbfbc0bb0bbe0225ce196c15).

That PR was reviewed for three defects in `packages/agent/src/services/signing-policy.ts`:

1. The method-selector regex was unanchored at the end (`0x12345678zz` matched as a valid selector).
2. `evaluate()` and `recordRequest()` were two separate calls — a TOCTOU race where two concurrent submissions could both pass a `maxTransactionsPerHour: 1` check before either recorded.
3. `getPolicy()` returned a shallow clone, sharing array references with the live policy.

**By the time #23326 merged, a second commit inside that PR ("fix(agent): validate whole calldata and isolate policy arrays") had already fixed defects 1 and 3** — the selector regex is now whole-payload-anchored (`/^0x[0-9a-f]{8}(?:[0-9a-f]{2})*$/i`) and `getPolicy()`/`updatePolicy()`/the constructor all deep-copy policy arrays via `clonePolicy()`. **Defect 2, the reservation race, was never addressed and shipped to `develop` live** — this PR closes it.

## The three defects, as they existed when #23326 merged

1. **Selector regex bypass** — already fixed on `develop`. No change needed; verified the existing `/^0x[0-9a-f]{8}(?:[0-9a-f]{2})*$/i` rule (whole 4-byte selector + whole trailing byte pairs, anchored to end-of-string) correctly rejects `0x12345678zz`, odd-length payloads, and accepts a bare `0x12345678` selector. Existing test coverage for this in `signing-policy.test.ts` (`it.each` over `0x1`, `0x1234`, `0x1234567`, `0x1234567g`, `12345678`, `0x123456789`, `0x12345678zz`) is untouched by this PR.

2. **TOCTOU race between `evaluate()` and `recordRequest()`** — **fixed here.** Added `SigningPolicyEvaluator.tryReserve(request)`, which performs the policy check and the rate-limit/replay record in a single synchronous call. Because JS execution is single-threaded, doing the check and the record with no `await` between them makes the pair uninterruptible — no concurrent `tryReserve()` call can run in between and observe stale state. Added `release(requestId)` to return an unconsumed reservation to the pool. `evaluate()`/`recordRequest()` are unchanged and still exported for other callers and for tests that seed history directly.

   **Caller rewiring (the part that actually closes the production race):** `remote-signing-service.ts`'s `submitSigningRequest()` now calls `tryReserve()` instead of `evaluate()`. Every path that abandons an allowed-but-unconsumed reservation calls `release(requestId)`:
   - `rejectRequest()` — human rejects a pending approval.
   - `approveRequest()`'s expiry check, and `getPendingApprovals()`'s expiry sweep — approval times out.
   - `executeSign()`'s `catch` block — the signer itself throws.

   Policy rejection needs no release, since `tryReserve()` never reserves when `decision.allowed` is `false`. `executeSign()` no longer calls `recordRequest()` on success — the reservation was already made at submit time and is simply left in place (consumed) once a signature is produced.

3. **`getPolicy()` shallow clone** — already fixed on `develop` via `clonePolicy()` (deep-copies every array field). This PR goes one step further: `getPolicy()` now also `Object.freeze()`s the returned snapshot (each array and the top-level object), so a mutation attempt throws immediately instead of silently succeeding on a copy that has no effect on future decisions.

## Tests

`packages/agent/src/services/signing-policy.test.ts` (evaluator-level):
- `closes the evaluate/recordRequest TOCTOU race: exactly one of two concurrent reservations succeeds at a limit of 1` — drives two `tryReserve()` calls through `Promise.all`/microtask interleaving against `maxTransactionsPerHour: 1`, asserts exactly one is `allowed`.
- `release() undoes a reservation so a later request can take the freed slot`.
- Updated `is immune to mutation of caller-held and returned policy arrays` to assert the frozen snapshot throws on mutation instead of expecting a silent no-op.

`packages/agent/src/services/remote-signing-service.test.ts` (service-level, driving the race through the real caller, not just the policy object):
- `admits exactly one of two concurrent submissions against a limit of 1` — two concurrent `submitSigningRequest()` calls, asserts exactly one `success: true` and the signer backend was invoked exactly once.
- `frees the slot on human rejection so a later request is admitted`.
- `frees the slot on approval expiry so a later request is admitted`.
- `frees the slot when the signer itself fails` — retries the same `requestId` after a signer error and confirms it's admitted.

### Exact counts

```
$ bunx vitest run src/services/signing-policy.test.ts
 Test Files  1 passed (1)
      Tests  17 passed (17)

$ bunx vitest run src/services/remote-signing-service.test.ts
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

Both together: **26/26 passed.** `tsc --noEmit` on the package: clean, no errors in either changed file.

### Red-before proof

Stashed only the two source files (`signing-policy.ts`, `remote-signing-service.ts`), keeping the new/updated test files, and re-ran both suites against the pre-fix (current-`develop`) source:

```
 ❯ src/services/remote-signing-service.test.ts (9 tests | 2 failed)
     × admits exactly one of two concurrent submissions against a limit of 1
       AssertionError: expected [ { success: true, … }, … ] to have a length of 1 but got 2
     × frees the slot on human rejection so a later request is admitted
 ❯ src/services/signing-policy.test.ts (17 tests | 3 failed)
     × is immune to mutation of caller-held and returned policy arrays
     × closes the evaluate/recordRequest TOCTOU race: exactly one of two concurrent reservations succeeds at a limit of 1
       TypeError: evaluator.tryReserve is not a function
     × release() undoes a reservation so a later request can take the freed slot
       TypeError: evaluator.tryReserve is not a function

 Test Files  2 failed (2)
      Tests  5 failed | 21 passed (26)
```

The concurrency test at the service level is the load-bearing one: pre-fix, both concurrent submissions succeed (`2` admitted instead of `1`) against a one-per-hour policy — that's the live bypass. Restoring the fix brings all 26 back to green.

## Evidence

This is a pure server-side policy/service change with deterministic Vitest coverage (no UI surface, no live-model path) — the repo's frontend/screenshot/trajectory evidence requirements are N/A. The red-before/green-after test output above is the functional proof: exact assertions that fail against the pre-fix code and pass against the fix.

---

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [pr-finisher]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza"} -->
