### PR TITLE
fix(app): validate Android update throttle timestamps

### DIFF
--- a/packages/app/src/android-update-checker.test.ts
+++ b/packages/app/src/android-update-checker.test.ts
@@ -180,6 +180,52 @@ describe("AndroidUpdateChecker.check()", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("checks for updates when the last-check timestamp is malformed", async () => {
+    mockDeviceInfo("android");
+    vi.stubEnv("VITE_ANDROID_BUILD_VARIANT", "sideload");
+    mockAppInfo("1.0.10", "10");
+    localStorage.setItem(
+      "elizaos_android_update_last_check",
+      "not-a-timestamp",
+    );
+
+    const manifest = makeManifest(10);
+    const fetchMock = setFetchMock(
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => manifest,
+      } as Response),
+    );
+
+    const result = await AndroidUpdateChecker.check("stable");
+
+    expect(result).not.toBeNull();
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it("checks for updates when the last-check timestamp is in the future", async () => {
+    mockDeviceInfo("android");
+    vi.stubEnv("VITE_ANDROID_BUILD_VARIANT", "sideload");
+    mockAppInfo("1.0.10", "10");
+    localStorage.setItem(
+      "elizaos_android_update_last_check",
+      String(Date.now() + 60 * 60 * 1000),
+    );
+
+    const manifest = makeManifest(10);
+    const fetchMock = setFetchMock(
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => manifest,
+      } as Response),
+    );
+
+    const result = await AndroidUpdateChecker.check("stable");
+
+    expect(result).not.toBeNull();
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
   it("fetches correct stable manifest URL", async () => {
     mockDeviceInfo("android");
     vi.stubEnv("VITE_ANDROID_BUILD_VARIANT", "sideload");

--- a/packages/app/src/android-update-checker.ts
+++ b/packages/app/src/android-update-checker.ts
@@ -62,8 +62,11 @@ export const AndroidUpdateChecker = {
 
       const lastCheck = localStorage.getItem(LAST_CHECK_KEY);
       if (lastCheck !== null) {
-        const elapsed = Date.now() - parseInt(lastCheck, 10);
-        if (elapsed < CHECK_INTERVAL_MS) return null;
+        const lastCheckTimestamp = Number(lastCheck);
+        if (Number.isFinite(lastCheckTimestamp)) {
+          const elapsed = Date.now() - lastCheckTimestamp;
+          if (elapsed >= 0 && elapsed < CHECK_INTERVAL_MS) return null;
+        }
       }
 
       const manifestUrl = MANIFEST_URLS[channel];


### PR DESCRIPTION
## Summary- validate the persisted Android update throttle timestamp before using it- treat malformed and future timestamps as stale- add focused coverage for valid, malformed, and future timestamp behaviorCloses #23557## Validation- Focused Vitest: passed, 10/10- Biome: passed- git diff --check: passed- App typecheck: attempted, but blocked by unrelated existing missing workspace modules and viem/wagmi/redemption errors; typecheck did not pass## ProvenanceProvider: OpenAI; Model: Fable; Client: Postman Agent Mode