### PR TITLE
fix(skills): keep surrogate pairs intact in skill command name truncation

### DIFF
--- a/packages/skills/src/formatter.ts
+++ b/packages/skills/src/formatter.ts
@@ -62,13 +62,17 @@ const SKILL_COMMAND_FALLBACK = "skill";
 const SKILL_COMMAND_DESCRIPTION_MAX_LENGTH = 100;
 
 function sanitizeSkillCommandName(raw: string): string {
-  const clamped = raw.length > 1024 ? raw.slice(0, 1024) : raw;
+  const wellFormed = toWellFormedUnicode(raw);
+  const clamped =
+    wellFormed.length > 1024
+      ? truncateWellFormed(wellFormed, 1024)
+      : wellFormed;
   const normalized = clamped
     .toLowerCase()
     .replace(/[^a-z0-9_]+/g, "_")
     .replace(/_+/g, "_")
     .replace(/^_+|_+$/g, "");
-  const trimmed = normalized.slice(0, SKILL_COMMAND_MAX_LENGTH);
+  const trimmed = truncateWellFormed(normalized, SKILL_COMMAND_MAX_LENGTH);
   return trimmed || SKILL_COMMAND_FALLBACK;
 }
 
@@ -82,7 +86,7 @@ function resolveUniqueSkillCommandName(
     }
     const suffix = `_${index}`;
     const maxBaseLength = Math.max(1, SKILL_COMMAND_MAX_LENGTH - suffix.length);
-    const trimmedBase = base.slice(0, maxBaseLength);
+    const trimmedBase = truncateWellFormed(base, maxBaseLength);
     const candidate = `${trimmedBase}${suffix}`;
     const candidateKey = candidate.toLowerCase();
     if (!used.has(candidateKey)) {

--- a/packages/skills/test/formatter.test.ts
+++ b/packages/skills/test/formatter.test.ts
@@ -281,3 +281,28 @@ describe("buildSkillCommandSpecs", () => {
     assert.strictEqual(specs[0].dispatch, undefined);
   });
 });
+
+describe("skill command name surrogate safety", () => {
+  it("does not split surrogate pairs in long skill names", () => {
+    // 30 ascii chars + 🦊 at the boundary of SKILL_COMMAND_MAX_LENGTH (32)
+    const longName = `${"a".repeat(30)}🦊${"b".repeat(10)}`;
+    const entries: SkillEntry[] = [
+      {
+        skill: { name: longName, description: "test" },
+        frontmatter: {},
+        metadata: {},
+        invocation: {},
+      },
+    ];
+    const specs = buildSkillCommandSpecs(entries);
+    const cmd = specs[0].command;
+    // no lone surrogate may survive truncation
+    for (const char of cmd) {
+      const code = char.charCodeAt(0);
+      assert.ok(
+        !(code >= 0xd800 && code <= 0xdfff),
+        `lone surrogate 0x${code.toString(16)} in command ${JSON.stringify(cmd)}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Problem
Skill command names use naive `slice(0,1024)` / `slice(0,32)` / `slice(0,maxBaseLength)` that split surrogate pairs, emitting lone surrogates.

## Fix
Replace with `toWellFormedUnicode` + `truncateWellFormed` (per #23437 pattern) in `packages/skills/src/formatter.ts`:
- `sanitizeSkillCommandName`: clamp 1024 and trim to `SKILL_COMMAND_MAX_LENGTH` without splitting pairs
- `resolveUniqueSkillCommandName`: base trim via `truncateWellFormed`

## Verification
- No bare `slice(0,` remains in formatter.ts
- Independent check: old `slice` splits 🦊 at boundary (broken=true), fixed path emits no lone surrogate
- Added regression test asserting no lone surrogate in truncated command names

Closes #23532

---
AI provider/model: deepseek-v4-flash
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza