### PR TITLE
fix(cloud): close 4 defects in the connected-capability projection (#23157 follow-up)

### DIFF
--- a/packages/cloud/shared/src/lib/services/connected-capabilities/connected-capabilities.test.ts
+++ b/packages/cloud/shared/src/lib/services/connected-capabilities/connected-capabilities.test.ts
@@ -21,51 +21,24 @@ const ORG_B = "22222222-2222-4222-8222-222222222222";
 const NOW = new Date("2026-08-20T12:00:00.000Z");
 const PAST = new Date("2026-08-01T00:00:00.000Z");
 
+/**
+ * Row factories intentionally construct only the narrowed `Pick<>` shape the
+ * DB loader (`./index.ts`) actually selects — not the full Drizzle row. That
+ * narrowing IS the defect-1 fix: a factory that could still set
+ * `access_token_encrypted` or `platform_user_id_ciphertext` would let a
+ * secret column silently rejoin this contract. The "row shape" test below
+ * additionally asserts what the real loader's query requests, independent of
+ * these fixtures.
+ */
 function platformCredentialRow(overrides: Partial<PlatformCredentialRow>): PlatformCredentialRow {
   return {
     id: "33333333-3333-4333-8333-333333333331",
-    organization_id: ORG_A,
-    user_id: null,
-    app_id: null,
     platform: "gmail",
-    platform_user_id: "user-123",
     platform_username: "alice",
     platform_display_name: "Alice Example",
-    platform_avatar_url: null,
-    platform_email: "secret-alice@example.com",
     status: "active",
-    error_message: null,
-    access_token_secret_id: "44444444-4444-4444-8444-444444444441",
-    refresh_token_secret_id: null,
-    token_expires_at: null,
     scopes: ["gmail.readonly", "gmail.send"],
-    api_key_secret_id: null,
-    granted_permissions: [],
-    source_type: null,
-    source_context: null,
-    profile_data: null,
-    platform_user_id_ciphertext: "SECRET_CIPHERTEXT",
-    platform_user_id_nonce: null,
-    platform_user_id_auth_tag: null,
-    platform_user_id_kms_key_id: null,
-    platform_user_id_kms_key_version: null,
-    platform_email_ciphertext: null,
-    platform_email_nonce: null,
-    platform_email_auth_tag: null,
-    platform_email_kms_key_id: null,
-    platform_email_kms_key_version: null,
-    platform_display_name_ciphertext: null,
-    platform_display_name_nonce: null,
-    platform_display_name_auth_tag: null,
-    platform_display_name_kms_key_id: null,
-    platform_display_name_kms_key_version: null,
-    created_at: PAST,
-    linked_at: PAST,
     last_used_at: new Date("2026-08-19T09:30:00.000Z"),
-    last_refreshed_at: null,
-    expires_at: null,
-    revoked_at: null,
-    updated_at: PAST,
     deleted_at: null,
     ...overrides,
   };
@@ -74,20 +47,11 @@ function platformCredentialRow(overrides: Partial<PlatformCredentialRow>): Platf
 function vendorConnectionRow(overrides: Partial<VendorConnectionRow>): VendorConnectionRow {
   return {
     id: "33333333-3333-4333-8333-333333333332",
-    organization_id: ORG_A,
     vendor: "linear",
     label: "workspace",
-    access_token_encrypted: "SECRET_TOKEN",
-    refresh_token_encrypted: null,
-    encrypted_dek: "SECRET_DEK",
-    token_nonce: "SECRET_NONCE",
-    token_auth_tag: "SECRET_TAG",
-    encryption_key_id: "key-1",
+    hasRefreshToken: false,
     expires_at: null,
     scopes: ["read", "issues:create"],
-    connection_metadata: {},
-    created_at: PAST,
-    updated_at: PAST,
     deleted_at: null,
     ...overrides,
   };
@@ -96,28 +60,9 @@ function vendorConnectionRow(overrides: Partial<VendorConnectionRow>): VendorCon
 function discordConnectionRow(overrides: Partial<DiscordConnectionRow>): DiscordConnectionRow {
   return {
     id: "33333333-3333-4333-8333-333333333333",
-    organization_id: ORG_A,
-    character_id: null,
-    application_id: "app-1",
-    bot_user_id: "bot-1",
-    bot_token_encrypted: "SECRET_BOT_TOKEN",
-    encrypted_dek: "SECRET_DEK",
-    token_nonce: "SECRET_NONCE",
-    token_auth_tag: "SECRET_TAG",
-    encryption_key_id: "key-1",
-    assigned_pod: null,
     status: "connected",
-    error_message: null,
-    guild_count: 2,
-    events_received: 0,
-    events_routed: 0,
     last_heartbeat: new Date("2026-08-20T11:59:00.000Z"),
-    connected_at: PAST,
-    intents: 0,
     is_active: true,
-    metadata: null,
-    created_at: PAST,
-    updated_at: PAST,
     ...overrides,
   };
 }
@@ -125,24 +70,13 @@ function discordConnectionRow(overrides: Partial<DiscordConnectionRow>): Discord
 function phoneGatewayDeviceRow(overrides: Partial<PhoneGatewayDeviceRow>): PhoneGatewayDeviceRow {
   return {
     id: "33333333-3333-4333-8333-333333333334",
-    organization_id: ORG_A,
-    provider: "imessage",
-    phone_number: "+15555550100",
-    bridge_id: "default",
-    phone_account_id: null,
     phone_account_label: "Personal iPhone",
     friendly_name: null,
-    send_method: null,
-    cloud_webhook_url: null,
-    local_webhook_url: null,
     is_active: true,
     can_send_sms: true,
     can_receive_sms: true,
     can_send_imessage: false,
     can_receive_imessage: true,
-    metadata: "{}",
-    created_at: PAST,
-    updated_at: PAST,
     last_seen_at: new Date("2026-08-20T11:00:00.000Z"),
     ...overrides,
   };
@@ -201,9 +135,11 @@ describe("projectConnectedAccounts", () => {
     expect(byProvider.linear.mode).toBe("cloud");
     expect(byProvider.linear.capabilities).toEqual([
       { capabilityId: "linear/read", riskLevel: "R1", status: "available" },
+      // "issues:create" is a mutating scope that the old write-verb allowlist
+      // missed (defect 3); it must fail closed to R2, not default to R1.
       {
         capabilityId: "linear/issues:create",
-        riskLevel: "R1",
+        riskLevel: "R2",
         status: "available",
       },
     ]);
@@ -239,12 +175,14 @@ describe("projectConnectedAccounts", () => {
     ]);
   });
 
-  test("never leaks secret or identifying storage columns", async () => {
+  test("never leaks raw storage row IDs", async () => {
+    // Secret columns (tokens/ciphertext/DEKs/nonces) cannot appear here even
+    // in principle: the `Pick<>` row types these fixtures build don't carry
+    // those fields at all. This test covers the remaining identifying value —
+    // the raw row ID — is never serialized verbatim; the DB-loader test suite
+    // covers the query-shape half of the secret-column fix (defect 1).
     const accounts = await projectConnectedAccounts(fullRows(), NOW);
     const serialized = JSON.stringify(accounts);
-    expect(serialized).not.toContain("SECRET");
-    expect(serialized).not.toContain("secret-alice@example.com");
-    expect(serialized).not.toContain("+15555550100");
     expect(serialized).not.toContain("33333333-3333-4333-8333");
     for (const account of accounts) {
       expect(account.accountId).toMatch(/^ca_[0-9a-f]{32}$/);
@@ -294,7 +232,7 @@ describe("projectConnectedAccounts", () => {
     const rows = {
       ...emptyRows(),
       platformCredentials: [platformCredentialRow({ status: "revoked" })],
-      discordConnections: [discordConnectionRow({ status: "error", error_message: "boom" })],
+      discordConnections: [discordConnectionRow({ status: "error" })],
     };
     const accounts = await projectConnectedAccounts(rows, NOW);
     const revoked = accounts.find((a) => a.providerId === "gmail");
@@ -315,7 +253,7 @@ describe("projectConnectedAccounts", () => {
         vendorConnectionRow({
           id: "53333333-3333-4333-8333-333333333332",
           expires_at: PAST,
-          refresh_token_encrypted: "SECRET_REFRESH",
+          hasRefreshToken: true,
         }),
         vendorConnectionRow({
           id: "53333333-3333-4333-8333-333333333333",
@@ -358,6 +296,51 @@ describe("projectConnectedAccounts", () => {
     const accounts = await projectConnectedAccounts(rows, NOW);
     expect(accounts[0]?.capabilities).toEqual([
       { capabilityId: "linear/read", riskLevel: "R1", status: "available" },
+    ]);
+  });
+
+  test("unrecognized scope strings fail closed to elevated risk, not the low-risk default", async () => {
+    // "custom_scope" matches neither a known write verb nor a known
+    // read-only verb — an unrecognized scope must never under-classify its
+    // risk (defect 3).
+    const rows = {
+      ...emptyRows(),
+      vendorConnections: [vendorConnectionRow({ scopes: ["custom_scope"] })],
+    };
+    const accounts = await projectConnectedAccounts(rows, NOW);
+    expect(accounts[0]?.capabilities).toEqual([
+      { capabilityId: "linear/custom_scope", riskLevel: "R2", status: "available" },
+    ]);
+  });
+
+  test("a NULL/unrecorded scope set projects unsupported, not a live available grant", async () => {
+    // scopes: null means the grant set was never recorded — distinct from an
+    // explicitly-verified empty array — and must not read as a healthy,
+    // available base capability (defect 2). Mirrors the ungranted ->
+    // "unsupported" handling projectPhoneGatewayDevice already does for
+    // native device permissions.
+    const rows = {
+      ...emptyRows(),
+      platformCredentials: [platformCredentialRow({ scopes: null, status: "active" })],
+    };
+    const accounts = await projectConnectedAccounts(rows, NOW);
+    expect(accounts[0]?.status).toBe("connected");
+    expect(accounts[0]?.capabilities).toEqual([
+      { capabilityId: "gmail/connection", riskLevel: "R1", status: "unsupported" },
+    ]);
+  });
+
+  test("an explicitly empty scope array still projects an available base capability", async () => {
+    // Contrast case for the NULL test above: a verified-empty grant set ([])
+    // is not the same as an unrecorded one (null) and keeps its existing
+    // available-base-capability behavior.
+    const rows = {
+      ...emptyRows(),
+      platformCredentials: [platformCredentialRow({ scopes: [], status: "active" })],
+    };
+    const accounts = await projectConnectedAccounts(rows, NOW);
+    expect(accounts[0]?.capabilities).toEqual([
+      { capabilityId: "gmail/connection", riskLevel: "R1", status: "available" },
     ]);
   });
 });

--- a/packages/cloud/shared/src/lib/services/connected-capabilities/db-source-loader.test.ts
+++ b/packages/cloud/shared/src/lib/services/connected-capabilities/db-source-loader.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Contract tests for the DB-backed source loader in `./index.ts` — the half
+ * `connected-capabilities.test.ts` cannot exercise because it only ever sees
+ * already-loaded, already-narrowed in-memory rows. `dbRead` is replaced with a
+ * capturing double so these tests assert what the query actually requests
+ * (column names and the `.limit()` value reaching the query layer), not just
+ * the shape of a payload built from fixtures we control. That distinction is
+ * the whole point: the PR this file follows up on (#19883/#23157) claimed "no
+ * token/ciphertext is read" while the loader ran a bare `.select()`, and no
+ * existing test could have caught that because none inspected the query
+ * itself.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import * as realDbClient from "../../../db/client";
+
+// See oauth-service.error-policy.test.ts for why the real exports are
+// snapshotted and reinstalled in afterAll: mock.module patches the process-
+// global module registry and survives mock.restore(), so a later suite that
+// needs the real db/client (PGlite-backed) would otherwise inherit this stub.
+const realDbClientExports = { ...realDbClient };
+
+interface CapturedQuery {
+  columns: string[];
+  limit?: number;
+  orderByArgCount?: number;
+}
+
+let captured: CapturedQuery[];
+
+const notImplemented = () => {
+  throw new Error("db access not stubbed in db-source-loader test");
+};
+
+mock.module("../../../db/client", () => ({
+  dbRead: {
+    select: (fields: Record<string, unknown> = {}) => {
+      const entry: CapturedQuery = { columns: Object.keys(fields) };
+      captured.push(entry);
+      return {
+        from: () => ({
+          where: () => ({
+            orderBy: (...args: unknown[]) => {
+              entry.orderByArgCount = args.length;
+              return {
+                limit: (n: number) => {
+                  entry.limit = n;
+                  return Promise.resolve([]);
+                },
+              };
+            },
+          }),
+        }),
+      };
+    },
+  },
+  db: {},
+  dbWrite: {},
+  runWithDbCache: <T>(fn: () => T) => fn(),
+  runWithDbCacheAsync: <T>(fn: () => Promise<T>) => fn(),
+  withReadDb: notImplemented,
+  withWriteDb: notImplemented,
+  getDbConnectionInfo: notImplemented,
+  closeDatabaseConnectionsForTests: async () => {},
+  shouldSkipTlsVerification: () => false,
+  enforceTlsForRemote: notImplemented,
+}));
+
+const ORG_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("createDbSourceLoader — query shape (#19883 follow-up)", () => {
+  beforeEach(() => {
+    captured = [];
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  afterAll(() => {
+    mock.module("../../../db/client", () => realDbClientExports);
+  });
+
+  it("selects an explicit column list that excludes every secret-bearing column", async () => {
+    const { connectedCapabilitiesService } = await import("./index");
+    await connectedCapabilitiesService.list({ organizationId: ORG_ID, limit: 10, offset: 0 });
+
+    expect(captured).toHaveLength(4);
+    const [platformQuery, vendorQuery, discordQuery, phoneQuery] = captured;
+
+    // platform_credentials: no *_secret_id pointer, no *_ciphertext/_nonce/
+    // _auth_tag/_kms_* field for any of the three field-level-encrypted
+    // columns (platform_user_id, platform_email, platform_display_name).
+    expect(platformQuery?.columns).toEqual([
+      "id",
+      "platform",
+      "platform_display_name",
+      "platform_username",
+      "status",
+      "scopes",
+      "last_used_at",
+      "deleted_at",
+    ]);
+    for (const forbidden of [
+      "access_token_secret_id",
+      "refresh_token_secret_id",
+      "api_key_secret_id",
+      "platform_user_id_ciphertext",
+      "platform_user_id_nonce",
+      "platform_user_id_auth_tag",
+      "platform_email_ciphertext",
+      "platform_email_nonce",
+      "platform_display_name_ciphertext",
+      "platform_display_name_nonce",
+    ]) {
+      expect(platformQuery?.columns).not.toContain(forbidden);
+    }
+
+    // vendor_connections: no access/refresh token ciphertext, no DEK, no
+    // nonce/auth tag. Refresh-token presence is a computed boolean
+    // (`hasRefreshToken`), never the encrypted column itself.
+    expect(vendorQuery?.columns).toEqual([
+      "id",
+      "vendor",
+      "label",
+      "expires_at",
+      "scopes",
+      "deleted_at",
+      "hasRefreshToken",
+    ]);
+    for (const forbidden of [
+      "access_token_encrypted",
+      "refresh_token_encrypted",
+      "encrypted_dek",
+      "token_nonce",
+      "token_auth_tag",
+    ]) {
+      expect(vendorQuery?.columns).not.toContain(forbidden);
+    }
+
+    // discord_connections: no bot token ciphertext, DEK, nonce, or auth tag.
+    expect(discordQuery?.columns).toEqual(["id", "is_active", "status", "last_heartbeat"]);
+    for (const forbidden of [
+      "bot_token_encrypted",
+      "encrypted_dek",
+      "token_nonce",
+      "token_auth_tag",
+    ]) {
+      expect(discordQuery?.columns).not.toContain(forbidden);
+    }
+
+    // phone_gateway_devices carries no secret columns at all; still assert
+    // the explicit allowlist so a future column addition can't silently
+    // widen this read path.
+    expect(phoneQuery?.columns).toEqual([
+      "id",
+      "is_active",
+      "can_send_sms",
+      "can_receive_sms",
+      "can_send_imessage",
+      "can_receive_imessage",
+      "friendly_name",
+      "phone_account_label",
+      "last_seen_at",
+    ]);
+  });
+
+  it("bounds every source query with a fixed .limit(), independent of the requested page", async () => {
+    const { connectedCapabilitiesService, MAX_ROWS_PER_CONNECTED_CAPABILITY_SOURCE } = await import(
+      "./index"
+    );
+
+    // A tiny requested page must not shrink the query-layer bound, and the
+    // bound must not scale with offset either — it is a constant per source,
+    // not derived from the request.
+    await connectedCapabilitiesService.list({ organizationId: ORG_ID, limit: 1, offset: 500 });
+
+    expect(captured).toHaveLength(4);
+    for (const query of captured) {
+      expect(query.limit).toBe(MAX_ROWS_PER_CONNECTED_CAPABILITY_SOURCE);
+      // Deterministic ordering (created_at, id) backs the cap: the same two
+      // orderBy terms every time, so the same cap always returns the same
+      // top rows rather than an arbitrary DB-order-dependent slice.
+      expect(query.orderByArgCount).toBe(2);
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/connected-capabilities/index.ts
+++ b/packages/cloud/shared/src/lib/services/connected-capabilities/index.ts
@@ -2,9 +2,22 @@
  * DB-backed entry point for the connected-capability projection service: the
  * Drizzle source loader (each table read filtered by organization ID at the
  * SQL layer) and the process-wide singleton the Cloud API routes import.
+ *
+ * Each `.select()` below names an explicit column list — never a bare
+ * `.select()` — so a token, ciphertext, DEK, or nonce column can never enter
+ * Worker memory in the first place; `projection.ts`'s row types are the
+ * contract this loader must keep matching (#19883 follow-up). Vendor
+ * connections need to know only whether a refresh token exists, computed in
+ * SQL (`col IS NOT NULL`) rather than by reading the encrypted value.
+ *
+ * Every query also carries a hard `.limit()` ordered by `(created_at, id)`,
+ * so a request's cost — row fan-out, per-row account-id hashing, and the
+ * final cross-source sort in `service.ts` — is bounded by a constant
+ * independent of how many rows the organization has accumulated in any one
+ * source table, not by the requested page size.
  */
 
-import { eq } from "drizzle-orm";
+import { asc, eq, sql } from "drizzle-orm";
 import { dbRead } from "../../../db/client";
 import { discordConnections } from "../../../db/schemas/discord-connections";
 import { phoneGatewayDevices } from "../../../db/schemas/phone-gateway-devices";
@@ -14,26 +27,74 @@ import { ConnectedCapabilitiesService, type ConnectedCapabilitySourceLoader } fr
 
 export * from "./service";
 
+/**
+ * Per-table row cap for one connected-capability read. Chosen well above any
+ * real organization's connection count while still bounding worst-case cost
+ * to a fixed constant; raise it only alongside deliberate pagination-depth
+ * design, not as a quick unblock.
+ */
+export const MAX_ROWS_PER_CONNECTED_CAPABILITY_SOURCE = 1000;
+
 function createDbSourceLoader(): ConnectedCapabilitySourceLoader {
   return {
     async load(organizationId) {
       const [platform, vendor, discord, phone] = await Promise.all([
         dbRead
-          .select()
+          .select({
+            id: platformCredentials.id,
+            platform: platformCredentials.platform,
+            platform_display_name: platformCredentials.platform_display_name,
+            platform_username: platformCredentials.platform_username,
+            status: platformCredentials.status,
+            scopes: platformCredentials.scopes,
+            last_used_at: platformCredentials.last_used_at,
+            deleted_at: platformCredentials.deleted_at,
+          })
           .from(platformCredentials)
-          .where(eq(platformCredentials.organization_id, organizationId)),
+          .where(eq(platformCredentials.organization_id, organizationId))
+          .orderBy(asc(platformCredentials.created_at), asc(platformCredentials.id))
+          .limit(MAX_ROWS_PER_CONNECTED_CAPABILITY_SOURCE),
         dbRead
-          .select()
+          .select({
+            id: vendorConnections.id,
+            vendor: vendorConnections.vendor,
+            label: vendorConnections.label,
+            expires_at: vendorConnections.expires_at,
+            scopes: vendorConnections.scopes,
+            deleted_at: vendorConnections.deleted_at,
+            hasRefreshToken: sql<boolean>`${vendorConnections.refresh_token_encrypted} is not null`,
+          })
           .from(vendorConnections)
-          .where(eq(vendorConnections.organization_id, organizationId)),
+          .where(eq(vendorConnections.organization_id, organizationId))
+          .orderBy(asc(vendorConnections.created_at), asc(vendorConnections.id))
+          .limit(MAX_ROWS_PER_CONNECTED_CAPABILITY_SOURCE),
         dbRead
-          .select()
+          .select({
+            id: discordConnections.id,
+            is_active: discordConnections.is_active,
+            status: discordConnections.status,
+            last_heartbeat: discordConnections.last_heartbeat,
+          })
           .from(discordConnections)
-          .where(eq(discordConnections.organization_id, organizationId)),
+          .where(eq(discordConnections.organization_id, organizationId))
+          .orderBy(asc(discordConnections.created_at), asc(discordConnections.id))
+          .limit(MAX_ROWS_PER_CONNECTED_CAPABILITY_SOURCE),
         dbRead
-          .select()
+          .select({
+            id: phoneGatewayDevices.id,
+            is_active: phoneGatewayDevices.is_active,
+            can_send_sms: phoneGatewayDevices.can_send_sms,
+            can_receive_sms: phoneGatewayDevices.can_receive_sms,
+            can_send_imessage: phoneGatewayDevices.can_send_imessage,
+            can_receive_imessage: phoneGatewayDevices.can_receive_imessage,
+            friendly_name: phoneGatewayDevices.friendly_name,
+            phone_account_label: phoneGatewayDevices.phone_account_label,
+            last_seen_at: phoneGatewayDevices.last_seen_at,
+          })
           .from(phoneGatewayDevices)
-          .where(eq(phoneGatewayDevices.organization_id, organizationId)),
+          .where(eq(phoneGatewayDevices.organization_id, organizationId))
+          .orderBy(asc(phoneGatewayDevices.created_at), asc(phoneGatewayDevices.id))
+          .limit(MAX_ROWS_PER_CONNECTED_CAPABILITY_SOURCE),
       ]);
       return {
         platformCredentials: platform,

--- a/packages/cloud/shared/src/lib/services/connected-capabilities/projection.ts
+++ b/packages/cloud/shared/src/lib/services/connected-capabilities/projection.ts
@@ -24,10 +24,53 @@ import type { phoneGatewayDevices } from "../../../db/schemas/phone-gateway-devi
 import type { platformCredentials } from "../../../db/schemas/platform-credentials";
 import type { vendorConnections } from "../../../db/schemas/vendor-connections";
 
-export type PlatformCredentialRow = typeof platformCredentials.$inferSelect;
-export type VendorConnectionRow = typeof vendorConnections.$inferSelect;
-export type DiscordConnectionRow = typeof discordConnections.$inferSelect;
-export type PhoneGatewayDeviceRow = typeof phoneGatewayDevices.$inferSelect;
+/**
+ * Row shapes are `Pick`s of the Drizzle select model, not the full inferred
+ * row: they are the contract the DB loader's explicit column list (`./index.ts`)
+ * must satisfy, so a column can never rejoin this read path by falling out of
+ * sync with what the query actually selects (#19883 follow-up). No
+ * token/ciphertext/DEK/nonce column appears in any of them.
+ */
+export type PlatformCredentialRow = Pick<
+  typeof platformCredentials.$inferSelect,
+  | "id"
+  | "platform"
+  | "platform_display_name"
+  | "platform_username"
+  | "status"
+  | "scopes"
+  | "last_used_at"
+  | "deleted_at"
+>;
+
+/**
+ * `hasRefreshToken` replaces the raw `refresh_token_encrypted` column: the
+ * loader computes the null-check in SQL (`col IS NOT NULL`) so the ciphertext
+ * itself never crosses into Worker memory, only whether a refresh token row
+ * exists.
+ */
+export type VendorConnectionRow = Pick<
+  typeof vendorConnections.$inferSelect,
+  "id" | "vendor" | "label" | "expires_at" | "scopes" | "deleted_at"
+> & { hasRefreshToken: boolean };
+
+export type DiscordConnectionRow = Pick<
+  typeof discordConnections.$inferSelect,
+  "id" | "is_active" | "status" | "last_heartbeat"
+>;
+
+export type PhoneGatewayDeviceRow = Pick<
+  typeof phoneGatewayDevices.$inferSelect,
+  | "id"
+  | "is_active"
+  | "can_send_sms"
+  | "can_receive_sms"
+  | "can_send_imessage"
+  | "can_receive_imessage"
+  | "friendly_name"
+  | "phone_account_label"
+  | "last_seen_at"
+>;
 
 /** One organization's raw connection rows across every projected source table. */
 export interface ConnectedCapabilitySourceRows {
@@ -39,8 +82,17 @@ export interface ConnectedCapabilitySourceRows {
 
 const ACCOUNT_ID_PREFIX = "ca_";
 
-/** Scopes that can mutate remote state carry elevated (R2) risk. */
-const WRITE_SCOPE_PATTERN = /write|send|manage|admin|modify|compose|delete|post|publish|full|all/i;
+/**
+ * Only scopes affirmatively recognized as read-only carry the low (R1) risk
+ * classification; every other scope string — including one this pattern has
+ * never seen — defaults to elevated (R2). This is deliberately the inverse of
+ * a "flag known-dangerous verbs" pattern: a provider scope vocabulary this
+ * code doesn't recognize must fail closed to the higher-risk class rather
+ * than silently under-classify it (the earlier write-verb allowlist let scopes
+ * like `issues:create` — a mutating verb absent from its word list — default
+ * to R1).
+ */
+const READ_ONLY_SCOPE_PATTERN = /read|view|list|get|fetch/i;
 
 async function deriveAccountId(source: string, rowId: string): Promise<string> {
   const bytes = new TextEncoder().encode(`eliza-cloud/connected-capability\n${source}\n${rowId}`);
@@ -70,15 +122,34 @@ function unavailableCodeFor(
 
 /**
  * Project granted OAuth scopes into capability entries. Scope strings are
- * provider data, so risk is classified structurally: mutating verbs map to R2,
- * everything else to R1. A connection with no recorded scopes still exposes a
- * single base connection capability so it remains addressable.
+ * provider data, so risk is classified structurally: only scopes recognized
+ * as read-only map to R1, everything else fails closed to R2. A connection
+ * with no recorded scopes still exposes a single base connection capability
+ * so it remains addressable.
+ *
+ * `scopes === null`/`undefined` is a distinct, narrower case than `[]`: it
+ * means the grant set was never recorded (e.g. rows written before scope
+ * tracking existed), not that the connection was verified to hold zero
+ * scopes. Projecting that as a live `available` base capability would be an
+ * unknown-reads-as-healthy over-grant — the same failure mode
+ * `projectPhoneGatewayDevice` avoids for ungranted device permissions below —
+ * so an unrecorded scope set always projects as `unsupported`, never as a
+ * status derived from the (possibly "connected") account state.
  */
 function scopeCapabilities(
   providerId: string,
-  scopes: readonly string[],
+  scopes: readonly string[] | null | undefined,
   accountStatus: ConnectedAccountStatus,
 ): ConnectedAccountCapability[] {
+  if (scopes == null) {
+    return [
+      {
+        capabilityId: `${providerId}/connection`,
+        riskLevel: "R1",
+        status: "unsupported",
+      },
+    ];
+  }
   const status = unavailableCodeFor(accountStatus);
   const entries = new Map<string, ConnectedAccountCapability>();
   for (const scope of scopes) {
@@ -90,7 +161,7 @@ function scopeCapabilities(
     if (!entries.has(capabilityId)) {
       entries.set(capabilityId, {
         capabilityId,
-        riskLevel: WRITE_SCOPE_PATTERN.test(trimmed) ? "R2" : "R1",
+        riskLevel: READ_ONLY_SCOPE_PATTERN.test(trimmed) ? "R1" : "R2",
         status,
       });
     }
@@ -134,7 +205,7 @@ async function projectPlatformCredential(row: PlatformCredentialRow): Promise<Co
     mode: "cloud",
     status,
     displayName,
-    capabilities: scopeCapabilities(row.platform, row.scopes ?? [], status),
+    capabilities: scopeCapabilities(row.platform, row.scopes, status),
     lastUsedAt: isoOrNull(row.last_used_at),
   });
 }
@@ -144,7 +215,7 @@ function vendorConnectionStatus(row: VendorConnectionRow, now: Date): ConnectedA
     return "revoked";
   }
   const expired = row.expires_at !== null && row.expires_at.getTime() <= now.getTime();
-  if (expired && row.refresh_token_encrypted === null) {
+  if (expired && !row.hasRefreshToken) {
     return "reauth_required";
   }
   return "connected";
@@ -162,7 +233,7 @@ async function projectVendorConnection(
     mode: "cloud",
     status,
     displayName: row.label?.trim() || null,
-    capabilities: scopeCapabilities(row.vendor, row.scopes ?? [], status),
+    capabilities: scopeCapabilities(row.vendor, row.scopes, status),
     lastUsedAt: null,
   });
 }


### PR DESCRIPTION
## Summary

Follow-up to #23157 ("project managed connections into a shared capability API"), which **merged with four unaddressed review findings still live on `develop`**. Two reviews flagged them; this PR fixes them forward against `packages/cloud/shared/src/lib/services/connected-capabilities/index.ts` and `projection.ts` rather than reopening the merged PR.

## The four defects and their fixes

**1. Secret material was pulled into Worker memory.** `createDbSourceLoader` did a bare `.select()` on `platform_credentials` / `vendor_connections`, so encrypted tokens, DEKs, and nonces were read into memory — the PR body's "never reads token/ciphertext" claim wasn't actually true. Each of the four queries now names an explicit column list that excludes every secret-bearing column. `vendor_connections`' refresh-token presence is computed in SQL (`col IS NOT NULL`) rather than reading the ciphertext, exposed to the projector as `hasRefreshToken: boolean`. `projection.ts`'s row types (`PlatformCredentialRow`, `VendorConnectionRow`, `DiscordConnectionRow`, `PhoneGatewayDeviceRow`) are now `Pick<>`s of that same allowlist, so the query and the row type can't drift apart silently again.

**2. Unknown scopes read as available.** `scopeCapabilities` mapped a NULL/unrecorded `scopes` column to a live `available` capability — the "unknown reads as healthy" pattern the root `CLAUDE.md` bans, and here specifically an over-grant. Fixed by mirroring `projectPhoneGatewayDevice`'s existing ungranted → `unsupported` handling in the same file: an unrecorded scope set (`null`/`undefined`) now projects a single `unsupported` base capability, distinct from a verified-empty (`[]`) scope set, which keeps its existing `available` base-capability behavior.

**3. `WRITE_SCOPE_PATTERN` was fail-open.** Any scope string it didn't recognize as a write verb silently defaulted to the low-risk R1 classification — e.g. `issues:create` (a mutating scope) was never in its word list and defaulted to R1. Replaced with `READ_ONLY_SCOPE_PATTERN`: only scopes affirmatively recognized as read-only (`read|view|list|get|fetch`) get R1; everything else — including a scope this code has never seen — fails closed to R2.

**4. Unbounded per-request work.** Both list routes loaded every row for an organization across all four source tables, hashed every row into an account ID, and sorted the whole set before slicing to the requested page — cost scaled with total org row count, not page size. Each source query now carries a hard `.limit(MAX_ROWS_PER_CONNECTED_CAPABILITY_SOURCE)` (1000) ordered by `(created_at, id)`, bounding per-request cost to a fixed constant independent of table size while keeping ordering deterministic.

## Tests

- `connected-capabilities.test.ts`: **16 pass / 0 fail** (13 pre-existing tests updated for the narrowed row shapes + corrected `issues:create` risk classification; 3 new tests for defects 2 and 3 — unrecognized-scope fail-closed, NULL-scope unsupported, and the explicit-empty-array contrast case).
- New `db-source-loader.test.ts` (mocks `dbRead` with a capturing double, following the pattern in `oauth-service.error-policy.test.ts`): **2 pass / 0 fail** — asserts the actual column list each query requests (defect 1) and that `.limit()` reaches the query layer with the fixed bound (defect 4). This is the row-shape/query-shape assertion the original PR's tests never made — they only checked the serialized payload, which is why the bare `.select()` slipped through review.
- Route tests (`connected-accounts-hono.test.ts`, unaffected surface): **10 pass / 0 fail**.
- Combined package run: **18 pass / 0 fail, 80 expect() calls**.

## Red-before proof (defects 1–3)

Per the evidence bar: I stashed the source fix (`index.ts` + `projection.ts`, keeping the new/updated tests), ran the new/changed tests against pre-fix `develop` code, confirmed red, then restored the fix.

**Defect 1 + 4** (`db-source-loader.test.ts`, run against stashed/pre-fix `index.ts`):
```
TypeError: rows.platformCredentials.filter is not a function. (In 'rows.platformCredentials.filter((row) => row.deleted_at === null)', 'rows.platformCredentials.filter' is undefined)
      at projectConnectedAccounts (.../connected-capabilities/projection.ts:254:8)
      at async list (.../connected-capabilities/service.ts:69:33)
(fail) createDbSourceLoader — query shape (#19883 follow-up) > selects an explicit column list that excludes every secret-bearing column [159.71ms]
(fail) createDbSourceLoader — query shape (#19883 follow-up) > bounds every source query with a fixed .limit(), independent of the requested page
 0 pass
 2 fail
Ran 2 tests across 1 file.
```
(The pre-fix bare `.select().from().where(eq(...))` chain has no `.orderBy()`/`.limit()`, so the mock's `.where()` return value — a plain object, not a promise — was handed straight to `Promise.all` and never resolved to a row array, which is exactly the shape mismatch the fix corrects.)

**Defects 2 + 3** (`connected-capabilities.test.ts`, run against stashed/pre-fix `projection.ts`):
```
error: expect(received).toEqual(expected)
      "capabilityId": "linear/custom_scope",
-     "riskLevel": "R2",
+     "riskLevel": "R1",
(fail) projectConnectedAccounts > unrecognized scope strings fail closed to elevated risk, not the low-risk default

error: expect(received).toEqual(expected)
      "riskLevel": "R1",
-     "status": "unsupported",
+     "status": "available",
(fail) projectConnectedAccounts > a NULL/unrecorded scope set projects unsupported, not a live available grant

 2 fail
Ran 3 tests across 1 file.
```
(The third test in that run — "an explicitly empty scope array still projects an available base capability" — passed even pre-fix, as expected: it's the contrast case for defect 2, unaffected by either bug.)

After confirming red, the stash was popped and the full suite re-verified green (18/18).

## Verification

- `bun test packages/cloud/shared/src/lib/services/connected-capabilities/` → 18 pass / 0 fail
- `bun test packages/cloud/api/v1/connections/accounts/connected-accounts-hono.test.ts` → 10 pass / 0 fail
- `bun x biome check` on all touched files → clean
- `bun run --cwd packages/cloud/shared typecheck` → no errors in touched files (one pre-existing, unrelated error in `conversation-coordinator.ts`, not touched by this change)

Head SHA: `c9cc08053657b8cec09d2c6a931b8e89c414e245`

---

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [pr-finisher]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza"} -->
