### PR TITLE
fix(cloud): bound Atlas Cloud video-generation REST hops

### DIFF
--- a/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.test.ts
+++ b/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   atlasCloudVideoProvider,
+  atlasFetch,
   buildAtlasVideoInput,
   firstAtlasVideoOutput,
   generateAtlasCloudVideo,
@@ -227,5 +228,37 @@ describe("Atlas Cloud video provider", () => {
       state: "failed",
       error: "Atlas Cloud does not know request missing",
     });
+  });
+});
+
+describe("atlasFetch — bounded hops fail closed and keep caller signals", () => {
+  test("aborts a hung Atlas Cloud API hop at the timeout", async () => {
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      return await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      });
+    }) as typeof fetch;
+
+    const start = Date.now();
+    await expect(
+      atlasFetch("https://api.atlascloud.ai/api/v1/model/generateVideo", undefined, 100),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("preserves a caller-provided abort signal", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen = init?.signal;
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const controller = new AbortController();
+    await atlasFetch("https://api.atlascloud.ai/api/v1/model/generateVideo", {
+      signal: controller.signal,
+    });
+    expect(seen).toBe(controller.signal);
   });
 });

--- a/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.ts
+++ b/packages/cloud/shared/src/lib/providers/video/atlascloud-video-generation.ts
@@ -11,6 +11,23 @@ import type {
 
 const ATLAS_POLL_INTERVAL_MS = 2_000;
 const ATLAS_POLL_TIMEOUT_MS = 180_000;
+const ATLAS_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Bound every Atlas Cloud REST hop so a hung or rate-limited API cannot pin
+ * the video-generation worker indefinitely. A caller-provided abort signal
+ * wins.
+ */
+export function atlasFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = ATLAS_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
 
 function atlasBaseUrl(request: VideoGenerationRequest): string {
   return (request.apiKeys.ATLASCLOUD_BASE_URL || "https://api.atlascloud.ai").replace(/\/+$/, "");
@@ -107,7 +124,7 @@ export async function generateAtlasCloudVideo(
 
   const baseUrl = atlasBaseUrl(request);
   const authHeader = { authorization: `Bearer ${apiKey}` };
-  const submitResponse = await fetch(`${baseUrl}/api/v1/model/generateVideo`, {
+  const submitResponse = await atlasFetch(`${baseUrl}/api/v1/model/generateVideo`, {
     method: "POST",
     headers: { ...authHeader, "content-type": "application/json" },
     body: JSON.stringify(buildAtlasVideoInput(request)),
@@ -138,7 +155,7 @@ export async function generateAtlasCloudVideo(
   while (Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, ATLAS_POLL_INTERVAL_MS));
 
-    const pollResponse = await fetch(pollUrl, { headers: authHeader });
+    const pollResponse = await atlasFetch(pollUrl, { headers: authHeader });
     const pollPayload = (await pollResponse.json().catch(() => ({}))) as Record<string, unknown>;
     if (!pollResponse.ok) {
       throw new Error(`Atlas prediction poll failed: ${pollResponse.status}`);
@@ -175,7 +192,7 @@ export async function getAtlasCloudVideoJobStatus(
     /\/+$/,
     "",
   );
-  const response = await fetch(`${baseUrl}/api/v1/model/prediction/${req.requestId}`, {
+  const response = await atlasFetch(`${baseUrl}/api/v1/model/prediction/${req.requestId}`, {
     headers: { authorization: `Bearer ${apiKey}` },
   });
   const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;


### PR DESCRIPTION
## Problem

Every Atlas Cloud fetch had **no timeout**: the generateVideo submit, prediction poll, and job-status hops could pin the video-generation worker forever when the API hung without closing the connection.

## Fix

- Add `atlasFetch(input, init, timeoutMs = 30_000)`: fails closed at a **30s hop timeout**, preserving any caller-provided abort signal.
- Route all three fetch sites through it.

## Tests

`atlascloud-video-generation.test.ts` (10 pass): new hung-hop abort test (100ms timeout, elapsed < 5s) + caller-signal preservation test; existing video-generation tests still pass.

```bash
bun test --isolate src/lib/providers/video/atlascloud-video-generation.test.ts
# 10 pass, 0 fail
```