### PR TITLE
fix(cloud): bound proactive-greeting coordinator hops

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-proactive-greeting.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-proactive-greeting.test.ts
@@ -8,6 +8,7 @@ import {
   clearLocalGreetingQueue,
   drainDiscordProactiveGreetings,
   enqueueDiscordProactiveGreeting,
+  greetingFetch,
   peekLocalGreetingQueue,
 } from "./onboarding-proactive-greeting";
 
@@ -65,5 +66,38 @@ describe("local proactive greeting queue", () => {
         { sessionId, leaseId: leased[0]?.leaseId ?? "" },
       ]),
     ).toBe(1);
+  });
+});
+
+describe("greetingFetch — bounded hops fail closed and keep caller signals", () => {
+  test("aborts a hung coordinator hop at the timeout", async () => {
+    const hungStub = {
+      fetch: (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    };
+    const start = Date.now();
+    await expect(
+      greetingFetch(hungStub, "https://onboarding.internal/enqueue-greeting", undefined, 100),
+    ).rejects.toThrow(/aborted/i);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("preserves a caller-provided abort signal", async () => {
+    let seen: AbortSignal | undefined;
+    const stub = {
+      fetch: async (_input: RequestInfo | URL, init?: RequestInit) => {
+        seen = init?.signal;
+        return new Response("{}", { status: 200 });
+      },
+    };
+    const controller = new AbortController();
+    await greetingFetch(stub, "https://onboarding.internal/enqueue-greeting", {
+      signal: controller.signal,
+    });
+    expect(seen).toBe(controller.signal);
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-proactive-greeting.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-proactive-greeting.ts
@@ -36,6 +36,25 @@ import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-
 import { getCloudBinding, hasCloudBindingsContext } from "../../runtime/cloud-bindings";
 import { logger } from "../../utils/logger";
 
+const GREETING_REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Bound every onboarding coordinator hop so a hung or overloaded Durable
+ * Object cannot pin the greeting worker indefinitely. A caller-provided abort
+ * signal wins.
+ */
+export function greetingFetch(
+  stub: { fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> },
+  input: string | URL,
+  init?: RequestInit,
+  timeoutMs: number = GREETING_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  return stub.fetch(input, {
+    ...init,
+    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
+
 export interface ProactiveGreetingEntry {
   /** Platform-scoped onboarding session id (`platform:discord:<userId>`). */
   sessionId: string;
@@ -148,13 +167,15 @@ export async function enqueueDiscordProactiveGreeting(
   try {
     const coordinator = greetingCoordinator();
     if (coordinator) {
-      const response = await coordinator
-        .getByName(DISCORD_GREETING_QUEUE_NAME)
-        .fetch("https://onboarding.internal/enqueue-greeting", {
+      const response = await greetingFetch(
+        coordinator.getByName(DISCORD_GREETING_QUEUE_NAME),
+        "https://onboarding.internal/enqueue-greeting",
+        {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify(entry),
-        });
+        },
+      );
       if (!response.ok) {
         throw new Error(`greeting enqueue failed (${response.status})`);
       }
@@ -182,13 +203,15 @@ export async function enqueueDiscordProactiveGreeting(
 export async function drainDiscordProactiveGreetings(): Promise<LeasedProactiveGreetingEntry[]> {
   const coordinator = greetingCoordinator();
   if (coordinator) {
-    const response = await coordinator
-      .getByName(DISCORD_GREETING_QUEUE_NAME)
-      .fetch("https://onboarding.internal/drain-greetings", {
+    const response = await greetingFetch(
+      coordinator.getByName(DISCORD_GREETING_QUEUE_NAME),
+      "https://onboarding.internal/drain-greetings",
+      {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ limit: MAX_GREETING_DRAIN }),
-      });
+      },
+    );
     if (!response.ok) {
       throw new Error(`greeting drain failed (${response.status})`);
     }
@@ -230,13 +253,15 @@ export async function acknowledgeDiscordProactiveGreetings(
 ): Promise<number> {
   const coordinator = greetingCoordinator();
   if (coordinator) {
-    const response = await coordinator
-      .getByName(DISCORD_GREETING_QUEUE_NAME)
-      .fetch("https://onboarding.internal/ack-greetings", {
+    const response = await greetingFetch(
+      coordinator.getByName(DISCORD_GREETING_QUEUE_NAME),
+      "https://onboarding.internal/ack-greetings",
+      {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ acknowledgements }),
-      });
+      },
+    );
     if (!response.ok) {
       throw new Error(`greeting acknowledgement failed (${response.status})`);
     }


### PR DESCRIPTION
## Problem

Every proactive-greeting coordinator fetch had **no timeout**: enqueue, drain, and ack hops could pin the greeting worker forever when the coordinator Durable Object hung without closing the connection.

## Fix

- Add `greetingFetch(stub, input, init, timeoutMs = 10_000)`: fails closed at a **10s hop timeout** (matching the onboarding coordinator bound), preserving any caller-provided abort signal.
- Route all three fetch sites through it.

## Tests

`onboarding-proactive-greeting.test.ts` (4 pass): new hung-hop abort test (100ms timeout, elapsed < 5s) + caller-signal preservation test; existing queue-semantics tests still pass.

```bash
bun test --isolate src/lib/services/eliza-app/onboarding-proactive-greeting.test.ts
# 4 pass, 0 fail
```