### PR TITLE
feat(core): within-turn fact linking — semantic union in FACTS + evidence-driven turn-cache invalidation

### DIFF
--- a/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
@@ -784,6 +784,9 @@ describe("factsProvider out-of-range timestamps", () => {
 
 		expect(result.text).toContain("the user is running the beta setup");
 		expect(result.text).toContain("since unknown");
+	});
+});
+
 /**
  * The factlink gap (2026-08-21): the fact "Connor (c-node) is a Zcash core
  * dev" shares ZERO non-stopword tokens with a "convent / season 3 / grove"

--- a/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
@@ -6,10 +6,13 @@
  * intact for bot/bridge senders — relays carry real human questions — that the
  * always-on standing-preferences lane gate is structural (extractor-assigned
  * `category: "preference"` + sender ownership + prior) so reply/domain-shaped
- * text under a non-preference category never leaks into the lane, and that the
- * provider never requests embeddings. Uses a hand-built deterministic
- * runtime mock — no live model, no DB — whose `useModel` throws to enforce the
- * no-embeddings invariant.
+ * text under a non-preference category never leaks into the lane, and that
+ * the always-on semantic lane unions in lexically-disjoint-but-related facts
+ * (local embedding + bounded fact-table search) while degrading to pure
+ * lexical retrieval when the embedding model is unavailable or the canonical
+ * embedding capability is disabled. Uses a hand-built deterministic runtime
+ * mock — no live model, no DB; `useModel` throws unless the test provides
+ * semantic results, enforcing that embedding failure never breaks retrieval.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { IAgentRuntime, Memory, UUID } from "../../../types/index.ts";
@@ -44,9 +47,16 @@ function makeRuntime(args: {
 	entityFacts?: Memory[];
 	recentMessages?: Memory[];
 	canonicalEmbeddingsDisabled?: boolean;
+	/**
+	 * Semantic-lane results returned by `searchMemories`. When set, `useModel`
+	 * returns a deterministic local embedding instead of throwing. Entries
+	 * should carry a `similarity` value the provider's floor can filter on.
+	 */
+	semanticFacts?: Memory[];
 }): IAgentRuntime & {
 	getMemories: ReturnType<typeof vi.fn>;
 	useModel: ReturnType<typeof vi.fn>;
+	searchMemories: ReturnType<typeof vi.fn>;
 } {
 	const runtime = {
 		agentId,
@@ -69,6 +79,7 @@ function makeRuntime(args: {
 				return [];
 			},
 		),
+		searchMemories: vi.fn(async () => args.semanticFacts ?? []),
 		getSetting: vi.fn((key: string) =>
 			key === "ELIZA_CANONICAL_EMBEDDINGS_ENABLED" &&
 			args.canonicalEmbeddingsDisabled
@@ -76,12 +87,14 @@ function makeRuntime(args: {
 				: undefined,
 		),
 		useModel: vi.fn(async () => {
-			throw new Error("FACTS provider must not request embeddings");
+			if (args.semanticFacts) return [0.1, 0.2, 0.3];
+			throw new Error("local embedding model unavailable");
 		}),
 	};
 	return runtime as unknown as IAgentRuntime & {
 		getMemories: ReturnType<typeof vi.fn>;
 		useModel: ReturnType<typeof vi.fn>;
+		searchMemories: ReturnType<typeof vi.fn>;
 	};
 }
 
@@ -90,7 +103,7 @@ describe("factsProvider keyword retrieval", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("retrieves matching facts with BM25 keywords without calling embeddings", async () => {
+	it("retrieves matching facts with BM25 keywords, degrading past an unavailable embedding model", async () => {
 		const runtime = makeRuntime({
 			recentMessages: [memory("msg-1", "Berlin keeps coming up today")],
 			facts: [
@@ -117,7 +130,9 @@ describe("factsProvider keyword retrieval", () => {
 			{ values: {}, data: {}, text: "" },
 		);
 
-		expect(runtime.useModel).not.toHaveBeenCalled();
+		// The semantic lane attempted a LOCAL embedding, failed, and lexical
+		// retrieval still delivered — embedding failure must never break recall.
+		expect(runtime.useModel).toHaveBeenCalled();
 		expect(runtime.getMemories).toHaveBeenCalledWith(
 			expect.objectContaining({ tableName: "facts", count: 120 }),
 		);
@@ -769,5 +784,169 @@ describe("factsProvider out-of-range timestamps", () => {
 
 		expect(result.text).toContain("the user is running the beta setup");
 		expect(result.text).toContain("since unknown");
+/**
+ * The factlink gap (2026-08-21): the fact "Connor (c-node) is a Zcash core
+ * dev" shares ZERO non-stopword tokens with a "convent / season 3 / grove"
+ * query, and because OTHER facts in the pool DID keyword-match ("convent"),
+ * the old total-miss-gated widen never ran — the related fact was
+ * structurally unreachable. These tests replay that shape.
+ */
+describe("factsProvider semantic union (Grove/Zcash replay)", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// Durable like the live incident's convent facts: they fill the durable
+	// slots via lexical match, so the durable direct-recall fallback (which
+	// only fires on an EMPTY durable ranking) never rescues the Zcash fact.
+	const conventFact = memory(
+		"fact-convent",
+		"The Grove originated at the Convent in Greenpoint during season 1",
+		{
+			kind: "durable",
+			category: "project",
+			confidence: 0.9,
+			keywords: ["grove", "convent", "greenpoint", "season"],
+		},
+	);
+	const zcashFact = memory(
+		"fact-zcash",
+		"Learned Connor (c-node) is a Zcash core dev at the 2026-08-19 bar night",
+		{
+			kind: "durable",
+			category: "relationship",
+			confidence: 0.85,
+			keywords: ["connor", "c-node", "zcash", "core", "dev"],
+		},
+	);
+	const groveQuery = memory(
+		"msg-grove",
+		"wait we're in season 3... grov3.net... look at this from season 1",
+		{ source: "discord" },
+	);
+
+	it("BEFORE-shape: lexical-only retrieval drops the Zcash fact when other facts keyword-match", async () => {
+		// No semanticFacts -> embedding model throws -> pure lexical path,
+		// which is exactly the pre-fix behavior for this pool.
+		const runtime = makeRuntime({ facts: [conventFact, zcashFact] });
+
+		const result = await factsProvider.get(runtime, groveQuery, {
+			values: {},
+			data: {},
+			text: "",
+		});
+
+		expect(result.text).toContain("Grove originated at the Convent");
+		expect(result.text).not.toContain("Zcash");
+	});
+
+	it("AFTER: the semantic lane unions the lexically-disjoint Zcash fact into the output", async () => {
+		const semanticZcash: Memory = { ...zcashFact, similarity: 0.62 };
+		const runtime = makeRuntime({
+			facts: [conventFact, zcashFact],
+			semanticFacts: [semanticZcash],
+		});
+
+		const result = await factsProvider.get(runtime, groveQuery, {
+			values: {},
+			data: {},
+			text: "",
+		});
+
+		// Lexical winners keep their place AND the semantic hit surfaces.
+		expect(result.text).toContain("Grove originated at the Convent");
+		expect(result.text).toContain("Zcash");
+		expect(runtime.useModel).toHaveBeenCalledTimes(1);
+		expect(runtime.searchMemories).toHaveBeenCalledWith(
+			expect.objectContaining({ tableName: "facts", count: 8 }),
+		);
+	});
+
+	it("drops semantic hits below the similarity floor", async () => {
+		const weakHit: Memory = { ...zcashFact, similarity: 0.2 };
+		const runtime = makeRuntime({
+			facts: [conventFact],
+			semanticFacts: [weakHit],
+		});
+
+		const result = await factsProvider.get(runtime, groveQuery, {
+			values: {},
+			data: {},
+			text: "",
+		});
+
+		expect(result.text).not.toContain("Zcash");
+	});
+
+	it("never embeds when the canonical embedding capability is disabled", async () => {
+		const runtime = makeRuntime({
+			canonicalEmbeddingsDisabled: true,
+			facts: [conventFact, zcashFact],
+			semanticFacts: [{ ...zcashFact, similarity: 0.9 }],
+		});
+
+		const result = await factsProvider.get(runtime, groveQuery, {
+			values: {},
+			data: {},
+			text: "",
+		});
+
+		expect(runtime.useModel).not.toHaveBeenCalled();
+		expect(runtime.searchMemories).not.toHaveBeenCalled();
+		expect(result.text).toContain("Grove originated at the Convent");
+	});
+
+	it("folds in-turn attachment text into the retrieval query so page content contributes tokens", async () => {
+		// The attachment carries the literal token "ZCash" (the grov3.net page
+		// text) — with evidence folded into the query, plain BM25 now matches
+		// the stored fact even with the embedding model unavailable.
+		const groveWithAttachment: Memory = {
+			...groveQuery,
+			content: {
+				...groveQuery.content,
+				attachments: [
+					{
+						id: "att-grove",
+						url: "https://grov3.net",
+						title: "the grove",
+						text: "Pillar IV Private Communication: FlashNet node, TorDash, ZCash infra",
+					},
+				],
+			},
+		} as Memory;
+		const runtime = makeRuntime({ facts: [conventFact, zcashFact] });
+
+		const result = await factsProvider.get(runtime, groveWithAttachment, {
+			values: {},
+			data: {},
+			text: "",
+		});
+
+		expect(result.text).toContain("Zcash core dev");
+	});
+
+	it("folds prior in-turn action-result text into the retrieval query", async () => {
+		const runtime = makeRuntime({ facts: [conventFact, zcashFact] });
+		const stateWithActionResult = {
+			values: {},
+			data: {
+				actionResults: [
+					{
+						success: true,
+						text: "Read grov3.net: Pillar IV Private Communication — FlashNet node, TorDash, ZCash infra",
+						data: { actionName: "ATTACHMENT" },
+					},
+				],
+			},
+			text: "",
+		};
+
+		const result = await factsProvider.get(
+			runtime,
+			groveQuery,
+			stateWithActionResult as never,
+		);
+
+		expect(result.text).toContain("Zcash core dev");
 	});
 });

--- a/packages/core/src/features/advanced-capabilities/providers/facts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.ts
@@ -10,9 +10,17 @@
  * header; room-pool facts about other participants render under a neutral
  * room header, so relay/webhook turns keep room recall without the room's
  * facts being misattributed to the bridge sender.
- * Retrieval deliberately avoids vector search so relevance is computed from the
- * fact's own words and extracted keywords; a keyword-miss on durable facts
- * falls back to the highest-prior candidates so direct recall still works.
+ * Lexical BM25 stays the primary lane, but it is no longer the only one: a
+ * bounded semantic lane (local gte-small embedding of the query, one embed
+ * call plus the same bounded fact-table searches the old total-miss widen
+ * path used) is ALWAYS unioned in, so facts that are meaning-related but
+ * lexically disjoint from the query ("Connor is a Zcash core dev" vs a
+ * "convent/season/grove" turn) still surface. In-turn evidence text — the
+ * current message's attachment/link-preview text and any action results
+ * already on the composed state — contributes query tokens too, so content
+ * the agent just read participates in retrieval within the same turn.
+ * A keyword-miss on durable facts still falls back to the highest-prior
+ * candidates so direct recall works.
  * Sender-owned `preference` facts get a separate bounded always-on lane
  * because standing preferences should be visible on every turn even with zero
  * lexical overlap ("brief replies" never BM25-matches "what's next?"); the
@@ -62,6 +70,18 @@ const DEFAULT_FACT_CONFIDENCE = 0.6;
  */
 const CANDIDATE_POOL_PER_SEARCH = 120;
 const TOP_PER_KIND = 6;
+/**
+ * Bounded always-on semantic lane. Embedding-lane hits enter on similarity
+ * alone (the lexical score>0 filter does not apply to them), capped per kind
+ * so the union can never flood the prompt. The floor keeps junk matches out
+ * while staying well under relevant-conversations' 0.7 (which the factlink
+ * diagnosis showed is too strict for cross-topic fact clusters).
+ */
+const SEMANTIC_LANE_LIMIT = 3;
+const SEMANTIC_SEARCH_COUNT = 8;
+const SEMANTIC_SIMILARITY_FLOOR = 0.45;
+/** Cap on in-turn evidence text folded into the retrieval query. */
+const EVIDENCE_TEXT_CHAR_CAP = 4000;
 const PRIVATE_FACT_PRIVACY_CLASSES = new Set([
 	"private",
 	"sensitive",
@@ -283,6 +303,71 @@ function mergeAlwaysIncludedFacts(
 	return dedupeById([...alwaysIncluded, ...ranked]).slice(0, max);
 }
 
+/**
+ * Textual evidence the agent already possesses THIS turn, beyond the message
+ * text itself: attachment/link-preview text and descriptions on the current
+ * message, and the textual results of actions that already ran (present on
+ * the composed state's actionResults when the provider re-runs after a
+ * planner tool — e.g. an ATTACHMENT page read). Folded into the retrieval
+ * query so in-turn-acquired content contributes query tokens within the same
+ * turn. Bounded by EVIDENCE_TEXT_CHAR_CAP; keyword extraction downstream
+ * caps the final query size regardless.
+ */
+function collectTurnEvidenceText(
+	runtime: IAgentRuntime,
+	message: Memory,
+	state: State,
+): string {
+	const parts: string[] = [];
+	for (const attachment of message.content.attachments ?? []) {
+		if (typeof attachment.title === "string") parts.push(attachment.title);
+		if (typeof attachment.description === "string") {
+			parts.push(attachment.description);
+		}
+		if (typeof attachment.text === "string") parts.push(attachment.text);
+	}
+	const pushResultText = (result: unknown): void => {
+		if (!result || typeof result !== "object") return;
+		const record = result as Record<string, unknown>;
+		if (typeof record.text === "string") parts.push(record.text);
+		if (typeof record.userFacingText === "string") {
+			parts.push(record.userFacingText);
+		}
+		const data = record.data;
+		if (data && typeof data === "object" && !Array.isArray(data)) {
+			const content = (data as Record<string, unknown>).content;
+			if (typeof content === "string") parts.push(content);
+		}
+	};
+	const actionResults = state?.data?.actionResults;
+	if (Array.isArray(actionResults)) {
+		for (const result of actionResults) pushResultText(result);
+	}
+	// The composed state a provider receives is the runtime's cached turn
+	// state, which does not always carry actionResults (callers enrich a COPY
+	// via withActionResultsForPrompt). The per-turn scratch entry is the
+	// durable in-memory record of what already ran this turn — an in-process
+	// Map read, never a DB call.
+	if (
+		typeof runtime.getActionResults === "function" &&
+		typeof message.id === "string" &&
+		message.id
+	) {
+		try {
+			for (const result of runtime.getActionResults(message.id)) {
+				pushResultText(result);
+			}
+		} catch {
+			// Scratch-state read is best-effort; evidence enrichment must never
+			// fail the provider.
+		}
+	}
+	const joined = parts.filter((part) => part.trim().length > 0).join("\n");
+	return joined.length > EVIDENCE_TEXT_CHAR_CAP
+		? joined.slice(0, EVIDENCE_TEXT_CHAR_CAP)
+		: joined;
+}
+
 function formatDurableLine(memory: Memory): string {
 	const text = memory.content.text ?? "";
 	if (!text) return "";
@@ -331,7 +416,7 @@ const factsProvider: Provider = {
 	get: async (
 		runtime: IAgentRuntime,
 		message: Memory,
-		_state: State,
+		state: State,
 	): Promise<ProviderResult> => {
 		try {
 			const recentMessagesPromise = runtime.getMemories({
@@ -360,9 +445,16 @@ const factsProvider: Provider = {
 			}
 			lastMessageLines.reverse();
 			const last5Messages = lastMessageLines.join("\n");
+			// In-turn evidence: attachment/link-preview text on the current message
+			// and textual results of actions that already ran this turn. Folding it
+			// into the query means content the agent just read (an ATTACHMENT page
+			// read whose text says "ZCash infra") contributes retrieval tokens
+			// WITHIN the same turn instead of being invisible to fact recall.
+			const evidenceText = collectTurnEvidenceText(runtime, message, state);
 			const queryText = buildFactQueryText(
 				message.content.text ?? "",
 				last5Messages,
+				evidenceText,
 			);
 
 			if (!queryText) {
@@ -411,23 +503,27 @@ const factsProvider: Provider = {
 			let dedupedPool = dedupeById([...roomFacts, ...entityFacts]).filter(
 				(memory) => !minimizePrivateFacts || !isMarkedPrivateFact(memory),
 			);
-			// Bounded-pool blindness guard: both pools are RECENCY-fetched, so a
-			// fact older than the last CANDIDATE_POOL_PER_SEARCH extractions per
-			// scope is invisible to ranking no matter how directly the user asks
-			// for it (observed live: "whats my keyboard budget" fabricated an
-			// answer while the extracted "$150 max" fact sat in the store, pushed
-			// out of the recent pool by heavy room traffic). When keyword scoring
-			// finds NOTHING relevant in the recency pools, widen once with an
-			// embedding search over the same room/entity scopes and merge the
-			// hits — ranking stays local and keyword-based over the widened pool.
-			// Gated to genuine misses so ordinary turns pay no embedding cost;
-			// any failure degrades to the recency pools.
-			const poolHasKeywordHit = scoreFactKeywordRelevance(
-				queryText,
-				dedupedPool,
-			).some((entry) => entry.relevance > 0);
+			// Semantic lane (always-on, bounded, local-only). Previously the
+			// embedding widen fired ONLY on a total keyword miss, so a query with
+			// ANY lexical hit ("convent" matching convent facts) never widened —
+			// and cross-topic facts sharing zero tokens with the query ("Connor is
+			// a Zcash core dev" on a grove/convent turn) stayed invisible no
+			// matter how related they were. Now: one LOCAL embedding of the query
+			// (gte-small class, ~50ms; never a cloud embedding — the capability
+			// gate below is the same one the old widen honored) plus the same
+			// bounded fact-table searches the widen path already ran. The hits
+			// serve two roles:
+			//   1. pool widening — merged into the candidate pool so BM25 can
+			//      rank older-than-recency-pool facts (the keyboard-budget case);
+			//   2. similarity admission — the top hits above a similarity floor
+			//      are unioned into the ranked output on similarity alone, capped
+			//      at SEMANTIC_LANE_LIMIT per kind, so lexically-disjoint-but-
+			//      related facts surface (the c-node/Zcash case).
+			// Any failure degrades to pure lexical retrieval while staying
+			// observable. No new hot-path DB shape: these are the exact adapter
+			// calls the total-miss widen already made.
+			let semanticHits: Memory[] = [];
 			if (
-				!poolHasKeywordHit &&
 				!(
 					typeof runtime.getSetting === "function" &&
 					isCanonicalModelCapabilityDisabled(runtime, ModelType.TEXT_EMBEDDING)
@@ -444,7 +540,7 @@ const factsProvider: Provider = {
 								tableName: "facts",
 								roomId: message.roomId,
 								worldId: message.worldId,
-								count: 12,
+								count: SEMANTIC_SEARCH_COUNT,
 								unique: false,
 							}),
 							...relatedEntityIds.map((entityId) =>
@@ -452,30 +548,42 @@ const factsProvider: Provider = {
 									embedding,
 									tableName: "facts",
 									entityId,
-									count: 12,
+									count: SEMANTIC_SEARCH_COUNT,
 									unique: false,
 								}),
 							),
 						]);
-						dedupedPool = dedupeById([
-							...dedupedPool,
+						const searched = dedupeById([
 							...searchedRoom,
 							...searchedEntities.flat(),
 						]).filter(
 							(memory) => !minimizePrivateFacts || !isMarkedPrivateFact(memory),
 						);
+						semanticHits = searched
+							.filter(
+								(memory) =>
+									typeof memory.similarity === "number" &&
+									memory.similarity >= SEMANTIC_SIMILARITY_FLOOR,
+							)
+							.sort(
+								(left, right) =>
+									(right.similarity ?? 0) - (left.similarity ?? 0),
+							);
+						dedupedPool = dedupeById([...dedupedPool, ...searched]);
 					}
 				} catch (error) {
-					// error-policy:J4 the widened pool is an optional recall upgrade;
-					// an unavailable embedding model or search degrades to the
-					// recency pools while staying observable.
-					runtime.reportError?.("FactsProvider.poolWiden", error, {
+					// error-policy:J4 the semantic lane is an optional recall upgrade;
+					// an unavailable embedding model or search degrades to pure
+					// lexical retrieval while staying observable.
+					runtime.reportError?.("FactsProvider.semanticLane", error, {
 						roomId: message.roomId,
 					});
 				}
 			}
 			const { durable: durableCandidates, current: currentCandidates } =
 				partitionByKind(dedupedPool);
+			const { durable: semanticDurable, current: semanticCurrent } =
+				partitionByKind(semanticHits);
 
 			const nowMs = Date.now();
 			const senderEntityIds = new Set<string>(relatedEntityIds);
@@ -509,6 +617,16 @@ const factsProvider: Provider = {
 					)
 					.slice(0, TOP_PER_KIND);
 			}
+			// Semantic-lane admission: the top embedding hits enter on similarity
+			// alone — the lexical score>0 filter does not gate them — bounded per
+			// kind so the union can never exceed the existing prompt caps by more
+			// than SEMANTIC_LANE_LIMIT rows per kind. BM25-ranked facts keep
+			// their order; semantic-only facts append after them.
+			durableFacts = mergeAlwaysIncludedFacts(
+				durableFacts,
+				semanticDurable.slice(0, SEMANTIC_LANE_LIMIT),
+				TOP_PER_KIND + SEMANTIC_LANE_LIMIT,
+			);
 			const preferenceLane = topByPrior(
 				durableCandidates.filter(
 					(memory) => isAboutSender(memory) && isPreferenceFact(memory),
@@ -520,14 +638,18 @@ const factsProvider: Provider = {
 			durableFacts = mergeAlwaysIncludedFacts(
 				preferenceLane,
 				durableFacts,
-				TOP_PER_KIND + PREFERENCE_LANE_LIMIT,
+				TOP_PER_KIND + PREFERENCE_LANE_LIMIT + SEMANTIC_LANE_LIMIT,
 			);
-			const currentFacts = rankByKeywordScore(
-				currentCandidates,
-				"current",
-				queryText,
-				nowMs,
-			).slice(0, TOP_PER_KIND);
+			const currentFacts = mergeAlwaysIncludedFacts(
+				rankByKeywordScore(
+					currentCandidates,
+					"current",
+					queryText,
+					nowMs,
+				).slice(0, TOP_PER_KIND),
+				semanticCurrent.slice(0, SEMANTIC_LANE_LIMIT),
+				TOP_PER_KIND + SEMANTIC_LANE_LIMIT,
+			);
 			const allFacts = [...durableFacts, ...currentFacts];
 
 			if (allFacts.length === 0) {

--- a/packages/core/src/features/advanced-capabilities/providers/facts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.ts
@@ -357,9 +357,15 @@ function collectTurnEvidenceText(
 			for (const result of runtime.getActionResults(message.id)) {
 				pushResultText(result);
 			}
-		} catch {
-			// Scratch-state read is best-effort; evidence enrichment must never
-			// fail the provider.
+		} catch (error) {
+			// error-policy:J7 the scratch-state read is a diagnostics-grade
+			// enrichment; losing it degrades recall for one turn but must not
+			// fail the provider. Reported rather than swallowed so a
+			// consistently broken accessor surfaces instead of looking like a
+			// turn that simply had no prior action results.
+			runtime.reportError?.("FactsProvider.turnEvidence", error, {
+				messageId: message.id,
+			});
 		}
 	}
 	const joined = parts.filter((part) => part.trim().length > 0).join("\n");

--- a/packages/core/src/services/message.evidence-cache-invalidation.test.ts
+++ b/packages/core/src/services/message.evidence-cache-invalidation.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Within-turn freshness for retrieval providers: when a planner action settles
+ * carrying substantive new text (an ATTACHMENT page read, a WEB_FETCH body),
+ * the FACTS and relevant-conversations entries must be evicted from the
+ * turn's cached provider state so the next composeState re-runs retrieval
+ * with the new evidence tokens in scope. Diagnosed live 2026-08-21: an
+ * ATTACHMENT read injected page text containing "ZCash" — the token that
+ * would have BM25-matched a stored fact — but compose #2 logged
+ * `provider-cache:FACTS cacheHit:true` and reused the pre-attachment output.
+ */
+import { describe, expect, it } from "vitest";
+import type {
+	ActionResult,
+	IAgentRuntime,
+	Memory,
+	State,
+	UUID,
+} from "../types/index.ts";
+import { __invalidateEvidenceSensitiveProviderCacheForTests } from "./message.ts";
+
+const messageId = "00000000-0000-0000-0000-0000000000e1" as UUID;
+const roomId = "00000000-0000-0000-0000-0000000000e2" as UUID;
+
+function makeMessage(): Memory {
+	return {
+		id: messageId,
+		entityId: "00000000-0000-0000-0000-0000000000e3" as UUID,
+		roomId,
+		content: { text: "wait we're in season 3... grov3.net" },
+	} as Memory;
+}
+
+function makeRuntimeWithCachedProviders(providers: Record<string, unknown>): {
+	runtime: IAgentRuntime;
+	cachedProviders: Record<string, unknown>;
+} {
+	const cachedState = {
+		values: {},
+		data: { providers },
+		text: "",
+	} as unknown as State;
+	const stateCache = new Map<string, State>([[messageId, cachedState]]);
+	const runtime = { stateCache } as unknown as IAgentRuntime;
+	return { runtime, cachedProviders: providers };
+}
+
+const longEvidence =
+	"Pillar IV Private Communication: FlashNet node, TorDash, ZCash infra. ".repeat(
+		5,
+	);
+
+describe("invalidateEvidenceSensitiveProviderCache", () => {
+	it("evicts FACTS and relevant-conversations when an action adds substantive text", () => {
+		const { runtime, cachedProviders } = makeRuntimeWithCachedProviders({
+			FACTS: { text: "stale pre-attachment facts" },
+			"relevant-conversations": { text: "stale snippets" },
+			CURRENT_TIME: { text: "clock" },
+		});
+		const result: ActionResult = {
+			success: true,
+			text: longEvidence,
+			data: { actionName: "ATTACHMENT" },
+		};
+
+		__invalidateEvidenceSensitiveProviderCacheForTests(
+			runtime,
+			makeMessage(),
+			result,
+		);
+
+		expect(cachedProviders).not.toHaveProperty("FACTS");
+		expect(cachedProviders).not.toHaveProperty("relevant-conversations");
+		// Unrelated providers keep their cached entries.
+		expect(cachedProviders).toHaveProperty("CURRENT_TIME");
+	});
+
+	it("counts data.content toward the evidence threshold (ATTACHMENT stores page text there)", () => {
+		const { runtime, cachedProviders } = makeRuntimeWithCachedProviders({
+			FACTS: { text: "stale" },
+		});
+		const result: ActionResult = {
+			success: true,
+			text: "ok",
+			data: { actionName: "ATTACHMENT", content: longEvidence },
+		};
+
+		__invalidateEvidenceSensitiveProviderCacheForTests(
+			runtime,
+			makeMessage(),
+			result,
+		);
+
+		expect(cachedProviders).not.toHaveProperty("FACTS");
+	});
+
+	it("leaves the cache intact for terse control results", () => {
+		const { runtime, cachedProviders } = makeRuntimeWithCachedProviders({
+			FACTS: { text: "still fresh enough" },
+		});
+		const result: ActionResult = {
+			success: true,
+			text: "ok",
+			data: { actionName: "IGNORE" },
+		};
+
+		__invalidateEvidenceSensitiveProviderCacheForTests(
+			runtime,
+			makeMessage(),
+			result,
+		);
+
+		expect(cachedProviders).toHaveProperty("FACTS");
+	});
+
+	it("is a no-op when the message has no id or no cached state", () => {
+		const { runtime } = makeRuntimeWithCachedProviders({});
+		const noIdMessage = { ...makeMessage(), id: undefined } as Memory;
+		const result: ActionResult = { success: true, text: longEvidence };
+
+		expect(() =>
+			__invalidateEvidenceSensitiveProviderCacheForTests(
+				runtime,
+				noIdMessage,
+				result,
+			),
+		).not.toThrow();
+
+		const emptyRuntime = {
+			stateCache: new Map<string, State>(),
+		} as unknown as IAgentRuntime;
+		expect(() =>
+			__invalidateEvidenceSensitiveProviderCacheForTests(
+				emptyRuntime,
+				makeMessage(),
+				result,
+			),
+		).not.toThrow();
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -7083,6 +7083,77 @@ export function __buildV5ExecutorContextForTests(
 	return buildV5ExecutorContext(args);
 }
 
+/**
+ * Providers whose output is a retrieval over the turn's query text, so their
+ * turn-cached result goes stale the moment an action introduces new textual
+ * evidence mid-turn (an ATTACHMENT page read, a WEB_FETCH body). Names, not
+ * references: the agent-side relevant-conversations provider registers by
+ * name and core never imports it.
+ */
+const EVIDENCE_SENSITIVE_PROVIDER_NAMES = [
+	"FACTS",
+	"relevant-conversations",
+] as const;
+
+/**
+ * Minimum characters of new action-result text that count as "new textual
+ * evidence". Filters out terse control results (REPLY echoes, IGNORE, status
+ * one-liners) so ordinary tool turns do not pay the re-retrieval cost.
+ */
+const EVIDENCE_INVALIDATION_MIN_CHARS = 200;
+
+function actionResultEvidenceTextLength(result: ActionResult): number {
+	let length = 0;
+	if (typeof result.text === "string") length += result.text.length;
+	if (typeof result.userFacingText === "string") {
+		length += result.userFacingText.length;
+	}
+	const content = (result.data as Record<string, unknown> | undefined)?.content;
+	if (typeof content === "string") length += content.length;
+	return length;
+}
+
+/**
+ * Within-turn freshness for retrieval providers (the c-node/Zcash gap): when
+ * an action settles carrying substantive new text, evict the FACTS and
+ * relevant-conversations entries from the turn's cached provider state so the
+ * NEXT composeState — planner recompose with maximum reuse, the REPLY
+ * action's compose, a continuation compose — re-runs retrieval with the new
+ * evidence tokens in scope instead of reusing the pre-action output
+ * (`provider-cache:FACTS cacheHit:true` was exactly how "ZCash" on a
+ * just-read page never reached fact recall in the same turn). Eviction only;
+ * nothing recomputes until a caller actually composes again, and the re-runs
+ * are ~tens of ms against multi-second model calls.
+ */
+function invalidateEvidenceSensitiveProviderCache(
+	runtime: IAgentRuntime,
+	message: Memory,
+	result: ActionResult,
+): void {
+	if (!message.id) return;
+	if (
+		actionResultEvidenceTextLength(result) < EVIDENCE_INVALIDATION_MIN_CHARS
+	) {
+		return;
+	}
+	const cached = runtime.stateCache?.get?.(message.id);
+	const providers = cached?.data?.providers as
+		| Record<string, unknown>
+		| undefined;
+	if (!providers || typeof providers !== "object") return;
+	for (const name of EVIDENCE_SENSITIVE_PROVIDER_NAMES) {
+		if (name in providers) delete providers[name];
+	}
+}
+
+export function __invalidateEvidenceSensitiveProviderCacheForTests(
+	runtime: IAgentRuntime,
+	message: Memory,
+	result: ActionResult,
+): void {
+	invalidateEvidenceSensitiveProviderCache(runtime, message, result);
+}
+
 async function executeV5PlannedToolCall(
 	args: ExecuteV5PlannedToolCallParams,
 ): Promise<PlannerToolResult> {
@@ -7173,6 +7244,11 @@ async function executeV5PlannedToolCall(
 		executorCtx,
 		toolCall,
 		{ ...(args.executorOptions ?? {}), actions: executionActions },
+	);
+	invalidateEvidenceSensitiveProviderCache(
+		args.runtime,
+		args.executorCtx.message,
+		rawActionResult,
 	);
 	const actionResult = projectActionResultForClipboard(
 		action,


### PR DESCRIPTION
## Principle

Whatever information the agent possesses or acquires during a turn must reach the model's context WITHIN that same turn. This is the FACTS-provider analog of the pinned-knowledge work in #22184: there, standing docs bypass relevance gating deterministically; here, dynamic in-turn evidence and semantically-related facts bypass the lexical-relevance cutoff that was structurally hiding them.

## The live failure (2026-08-21, diagnosed read-only)

Stored fact: `Connor (c-node) is a Zcash core dev` (extracted correctly, on time). A later turn asked about grov3.net (convent/season-3 framing); mid-turn an ATTACHMENT action read the page, whose text literally says "ZCash infra". The reply recited the page's pillars with zero connection to the stored fact. Two mechanisms:

1. **BM25 score>0 cutoff + total-miss-gated widen.** The Zcash fact shares zero non-stopword tokens with the query. Because OTHER facts in the pool DID keyword-match ("convent"), `poolHasKeywordHit` was true and the embedding widen never ran. The related-but-lexically-disjoint cluster case is exactly the case the total-miss gate cannot catch.
2. **Turn-cache staleness.** FACTS and relevant-conversations are `cacheScope:"turn"`. compose #2 after the attachment read logged `provider-cache:FACTS cacheHit:true` — the one moment lexical retrieval could have matched "ZCash", it was never re-consulted.

## Changes

### FACTS provider (`providers/facts.ts`)
- **Always-on bounded semantic lane**: one LOCAL embedding of the query (same `useModel(TEXT_EMBEDDING)` + canonical-capability gate the old widen path used — never cloud) plus the same bounded `searchMemories` fact-table searches. Hits ≥ 0.45 similarity union into the ranked output on similarity alone, capped at **3 per kind** (durable/current). The full search result also widens the BM25 candidate pool, preserving the existing keyboard-budget rescue for older-than-recency-pool facts.
- **In-turn evidence in the query**: attachment/link-preview text on the current message, `actionResults` on the composed state, and the runtime's per-turn action-results scratch entry (in-process Map read) contribute query tokens, capped at 4000 chars before keyword extraction.
- All failures degrade to pure lexical retrieval, reported via `reportError`.

### Turn-cache invalidation (`services/message.ts`)
- After `executePlannedToolCall` settles inside `executeV5PlannedToolCall`, if the result carries ≥200 chars of text (`text` + `userFacingText` + `data.content`), the FACTS and relevant-conversations entries are deleted from the turn's cached provider state (`stateCache`). The next composeState (planner recompose with max reuse, REPLY compose, continuation) re-runs those providers with the new tokens in scope. Eviction only — nothing recomputes eagerly. Cost when it fires: ~45ms + ~27ms provider re-runs against 8–20s model calls.
- Terse control results (REPLY echoes, IGNORE) don't trigger it.

## Invariants (Shaw's)
- **Local embeddings only**: the lane goes through the exact `useModel(TEXT_EMBEDDING)` path the total-miss widen already used, still behind `isCanonicalModelCapabilityDisabled`. No cloud embedding, no new model dependency.
- **No new DB shape on the chat hot path**: the `searchMemories` calls are byte-for-byte the adapter calls the widen path already made (count 12→8), now unconditional instead of miss-gated. Worst-case added cost per turn ≈ one local embed (~50ms class) + bounded vector searches that previously ran on miss turns anyway. Cache invalidation adds zero DB work (in-memory Map delete).
- Prompt caps: union bounded by `TOP_PER_KIND + SEMANTIC_LANE_LIMIT` (+ preference lane), so at most 3 extra rows per kind.

## Proof (bidirectional, in-repo)
`facts.test.ts` replays the exact incident shape:
- **BEFORE-shape** (embedding unavailable → pure lexical, the pre-fix behavior): convent fact surfaces, `Zcash` **absent** ✓
- **AFTER** (semantic lane active): convent fact keeps its place AND `Zcash` **present**; asserts exactly one local embed + bounded `searchMemories` ✓
- Similarity floor drops weak hits ✓; capability-disabled runtimes never embed and never search ✓
- Attachment text folded into the query makes plain BM25 match the Zcash fact even with no embedding model ✓; same for prior in-turn action-result text ✓

`message.evidence-cache-invalidation.test.ts`: eviction of FACTS + relevant-conversations on a substantive result, `data.content` counted (ATTACHMENT stores page text there), no-op for terse results, no-throw on missing id/state.

## Validation
- `bunx tsc --noEmit` (packages/core): clean
- Targeted vitest: facts.test.ts 25/25, evidence-cache 4/4, fact-keywords 3/3, planner-provider-selection 13/13, preserved-tool-result + processAttachments 38/38, turn-read-coalescing + provider-io-concurrency + fact-write-dedupe 30/30
- Biome clean on touched files
- Not run: full-repo suite (sparse worktree, borrowed deps — same constraint documented in #22184). Live scratch-room replay against sol-dev planned as post-review validation before any deploy.

## Scope
FACTS provider + its turn-cache path only. Does NOT touch the DOCUMENTS provider or anything from #22184. **Do not merge — Shadow reviews first (changes core retrieval behavior for every agent).**