### PR TITLE
fix(ui): keep surrogate pairs intact in bug report field truncation

### DIFF
--- a/packages/ui/src/components/shell/BugReportModal.test.ts
+++ b/packages/ui/src/components/shell/BugReportModal.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression for BugReportModal strip surrogate safety + tag stripping.
+ */
+
+import { toWellFormedUnicode } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { stripBugReportField } from "./BugReportModal";
+
+function isWellFormed(value: string): boolean {
+  if (!value) return true;
+  const maybe = value as unknown as { isWellFormed?: () => boolean };
+  if (typeof maybe.isWellFormed === "function") return maybe.isWellFormed();
+  return toWellFormedUnicode(value) === value;
+}
+
+describe("stripBugReportField well-formed", () => {
+  it("keeps surrogate pairs intact at 10k boundary", () => {
+    const fox = "🦊";
+    const text = `${"a".repeat(9999)}${fox}${"b".repeat(20)}`;
+    const out = stripBugReportField(text, 10_000);
+    expect(isWellFormed(out)).toBe(true);
+    expect(() => JSON.stringify(out)).not.toThrow();
+    expect(out).toBe("a".repeat(9999));
+  });
+
+  it("preserves fitting emoji under cap and strips tags", () => {
+    const fox = "🦊";
+    const text = `${"a".repeat(100)}${fox} <b>hi</b>`;
+    const out = stripBugReportField(text, 10_000);
+    expect(out).toContain(fox);
+    expect(out).not.toContain("<b>");
+    expect(isWellFormed(out)).toBe(true);
+  });
+
+  it("caps at 200 boundary for environment field with fox", () => {
+    const fox = "🦊";
+    const text = `${"a".repeat(199)}${fox}${"b".repeat(20)}`;
+    const out = stripBugReportField(text, 200);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(200);
+    expect(out).toBe("a".repeat(199));
+  });
+
+  it("sanitizes lone high surrogate before truncation", () => {
+    const lone = `msg ${String.fromCharCode(0xd800)} ${"x".repeat(11_000)}`;
+    const out = stripBugReportField(lone, 10_000);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("�")).toBe(true);
+    expect(out.includes(String.fromCharCode(0xd800))).toBe(false);
+  });
+
+  it("sanitizes lone low surrogate before truncation", () => {
+    const lone = `msg ${String.fromCharCode(0xdc00)} ${"x".repeat(11_000)}`;
+    const out = stripBugReportField(lone, 10_000);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("�")).toBe(true);
+  });
+
+  it("strips nested tags and stays well-formed", () => {
+    const fox = "🦊";
+    const text = `<div>${"a".repeat(50)}${fox}</div><scr<script>ipt>alert(1)</scr<script>ipt>`;
+    const out = stripBugReportField(text, 10_000);
+    expect(out).not.toContain("<div>");
+    expect(out).not.toContain("</div>");
+    expect(out).not.toContain("<script>");
+    expect(isWellFormed(out)).toBe(true);
+    expect(out).toContain(fox);
+  });
+
+  it("sweep 0..30 offsets at 200 all well-formed", () => {
+    const fox = "🦊";
+    for (let n = 0; n <= 30; n++) {
+      const text = `${"a".repeat(n)}${fox}${"b".repeat(500)}`;
+      const out = stripBugReportField(text, 200);
+      expect(isWellFormed(out)).toBe(true);
+      expect(out.length).toBeLessThanOrEqual(200);
+      expect(() => JSON.stringify(out)).not.toThrow();
+    }
+  });
+
+  it("sweep at 10k with lone surrogate in input stays well-formed", () => {
+    for (let n = 0; n <= 30; n++) {
+      const text = `${"a".repeat(n)}${String.fromCharCode(0xd800)}${"b".repeat(11_000)}`;
+      const out = stripBugReportField(text, 10_000);
+      expect(isWellFormed(out)).toBe(true);
+      expect(out.length).toBeLessThanOrEqual(10_000);
+    }
+  });
+
+  it("caps at 50k for logs with fox boundary", () => {
+    const fox = "🦊";
+    const text = `${"a".repeat(49_999)}${fox}${"b".repeat(20)}`;
+    const out = stripBugReportField(text, 50_000);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(50_000);
+    expect(out).toBe("a".repeat(49_999));
+  });
+});

--- a/packages/ui/src/components/shell/BugReportModal.tsx
+++ b/packages/ui/src/components/shell/BugReportModal.tsx
@@ -5,6 +5,7 @@
  * client. On the Electrobun desktop it can additionally attach local diagnostics
  * — collected via `../../utils/desktop-bug-report` — and open the logs folder.
  */
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { logger } from "@elizaos/logger";
 import { ChevronRight } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -96,6 +97,23 @@ function normalizeHttpsResultUrl(url?: string): string | null {
     // only verifiable https links are shown to the reporter.
     return null;
   }
+}
+
+export function stripBugReportField(s: string, max = 10_000): string {
+  const wellFormed = toWellFormedUnicode(s);
+  const truncated =
+    wellFormed.length > max ? truncateWellFormed(wellFormed, max) : wellFormed;
+  // Iteratively strip `<...>` tags to defeat embedded `<scr<script>ipt>` patterns.
+  let out = truncated;
+  let prev: string;
+  do {
+    prev = out;
+    out = out.replace(/<[^>]*>/g, "");
+  } while (out !== prev);
+  const wellFormedOut = toWellFormedUnicode(out);
+  return wellFormedOut.length > max
+    ? truncateWellFormed(wellFormedOut, max)
+    : wellFormedOut;
 }
 
 export function BugReportModal() {
@@ -239,17 +257,7 @@ export function BugReportModal() {
   }, [buildDiagnosticsBlock, form.logs]);
 
   const formatMarkdown = useCallback((): string => {
-    const strip = (s: string, max = 10_000) => {
-      const truncated = s.length > max ? s.slice(0, max) : s;
-      // Iteratively strip `<...>` tags to defeat embedded `<scr<script>ipt>` patterns.
-      let out = truncated;
-      let prev: string;
-      do {
-        prev = out;
-        out = out.replace(/<[^>]*>/g, "");
-      } while (out !== prev);
-      return out.slice(0, max);
-    };
+    const strip = (s: string, max = 10_000) => stripBugReportField(s, max);
     const lines: string[] = [];
     lines.push(`### Description\n${strip(form.description)}`);
     lines.push(`\n### Steps to Reproduce\n${strip(form.stepsToReproduce)}`);


### PR DESCRIPTION
Refs #23536 — sibling precedent only; that issue is owned by merged PR #23537 and is **not** fixed by this PR.

> **Issue link corrected:** this body previously read `Fixes #23536`, which would have auto-closed the unrelated
> plugin-personal-assistant proactive-snippet issue on merge. This PR's actual scope is `packages/ui`
> BugReportModal field clamping. No issue currently tracks that scope.

## Summary

- Fix `packages/ui/src/components/shell/BugReportModal.tsx:242` `strip` (via exported `stripBugReportField`) to use `toWellFormedUnicode` + `truncateWellFormed` so clamping bug-report fields to `10_000` (description/steps/expected/actual), `200` (environment/nodeVersion/modelProvider), and `50_000` (logs) never splits an astral surrogate pair (e.g. 🦊 `🦊` `🦊`) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict JSON parsers reject. Preserves iterative `<...>` tag stripping with double well-formed truncate (pre- and post-strip) and adds deterministic coverage.
- Add 9 `isWellFormed()` tests in `packages/ui/src/components/shell/BugReportModal.test.ts`: 9999+🦊→9999 at 10k, fitting 100+🦊 tag strip, 199+🦊→199 at 200, lone high/low sanitization, nested `<div>/<script>` strip, sweep 0..30 at 200, sweep 0..30 at 10k lone, 49999+🦊→49999 at 50k.

Same class as approved #23488 (discord draft-chunking), #23491 (media fetch), #23535 (approval reason), #23537 (proactive snippet), #23546 (ttsDebugTextPreview), #23548 (cockpit deriveTitle), #23550 (subAgentCompletionRelayBody), #23553 (scenario-runner truncateText), #23562 (settings-debug), #23565 (browser-wallet consent) — identical `toWellFormedUnicode` → `truncateWellFormed` pattern; bug-report markdown is submitted via API client GitHub issue JSON wire and affects issue creation.

## Changes

| File | Change |
|------|--------|
| `packages/ui/src/components/shell/BugReportModal.tsx` | Import `toWellFormedUnicode`/`truncateWellFormed`, export `stripBugReportField(s,max)` with pre-sanitize + well-formed truncate, iterative tag strip, post-sanitize + second truncate; `formatMarkdown` delegates to helper |
| `packages/ui/src/components/shell/BugReportModal.test.ts` | +98 lines — 9 tests: 9999+🦊→9999 backed off, fitting 100+🦊 with tag, 199+🦊→199 at 200, lone high/low (`\ud800`/`\udc00`→`�`), nested `<div>/<script>` strip, sweep 0..30 at 200, sweep 0..30 at 10k lone, 49999+🦊→49999 at 50k |

## Verification

- Rebased onto `origin/develop@7a5541400e` — zero conflicts
- `bunx biome check` — 2 files clean (14ms, no fixes after --write)
- `bun run --cwd packages/ui test -- src/components/shell/BugReportModal.test.ts` — **9 passed, 0 failed** (1 file) incl. 9 new `isWellFormed()` cases
- `git show f136349660:packages/ui/src/components/shell/BugReportModal.tsx` verifies import + `stripBugReportField` double well-formed truncate + `formatMarkdown` delegation

## Evidence Gate

<!-- evidence-head:f136349660 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface change to dialog layout; bug-report field clamp is pure text sanitization for API markdown wire.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface change; same as before.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow change; behavior is proven by deterministic surrogate unit tests.

<!-- evidence-row:backend-logs -->
- [x] Real surrogate-aware clamp paths exercised via Vitest (vitest runner):

```log
bun run --cwd packages/ui test -- src/components/shell/BugReportModal.test.ts
vitest v4.1.10
 Test Files  1 passed (1)
      Tests  9 passed (9)
   Duration  4.82s
 9 new isWellFormed() cases: 9999+'🦊'→9999 backed off, fitting 100+🦊 with tag, 199+🦊→199 at 200, lone '\ud800'→'�', nested <div>/<script> strip, sweep 0..30 at 200, sweep 0..30 at 10k lone, 49999+🦊→49999 at 50k well-formed
Ran 9 tests across 1 file.
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - bug-report field formatter is pure helper with no browser console/network trace; wire text validity is proven via unit tests.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model delegation change beyond string hygiene; no live-model trajectory to link (deterministic truncation unit coverage).

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = surrogate-safe bug-report markdown, proven by 9 deterministic tests:

```log
each test asserts .isWellFormed() === true and JSON.stringify never throws
boundary 10k: "a".repeat(9999)+"🦊"+... → 9999 backed off well-formed (9999 < 10000, fox would need 10001)
fitting: "a".repeat(100)+"🦊 <b>hi</b>" → contains fox, no <b>, well-formed
boundary 200: "a".repeat(199)+"🦊"+... → 199 backed off well-formed (199 < 200, fox would need 201)
lone: "msg \ud800 ..." → "msg � ..." sanitized well-formed
nested: "<div>...🦊</div><scr<script>ipt>..." → no <div>/<script>, contains fox, well-formed
sweep 0..30 at 200: each n+"🦊"+... at 200 → all well-formed
sweep 0..30 at 10k lone: each n+"\ud800"+... at 10000 → all sanitized well-formed
boundary 50k: "a".repeat(49999)+"🦊"+... → 49999 well-formed
all 9 pass; without fix the 9999+🦊 and 199+🦊 cases would emit lone \uD83E and fail isWellFormed()
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface; no OCR text to review.

# Risks

Low — single-function hygiene in bug-report markdown clamp (`stripBugReportField` only). No API client, no GitHub issue routing, no desktop diagnostics. Narrow import of two well-formed helpers already used by discord/media-fetch/cockpit/proactive/scenario-runner/settings-debug/browser-wallet precedents; atomic `+117/-11` churn with double-truncate preserving existing tag-strip semantics.

# Background
N/A

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/shell/BugReportModal.tsx:8,102-118,260` (import + `stripBugReportField` + delegation) and `packages/ui/src/components/shell/BugReportModal.test.ts` (9 new cases).

## Detailed testing steps

- `bun run --cwd packages/ui test -- src/components/shell/BugReportModal.test.ts` — expect 9 pass incl. 9 new `isWellFormed()`
- `bunx biome check packages/ui/src/components/shell/BugReportModal.tsx packages/ui/src/components/shell/BugReportModal.test.ts` — expect `Checked 2 files … No fixes applied.`

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@7a5541400e3c4e3c3c3c3c3c3c3c3c3c3c3c3c3c3c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@7a5541400e3c4e3c3c3c3c3c3c3c3c3c3c3c3c3c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — ui]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@7a5541400e3c4e3c3c3c3c3c3c3c3c3c3c3c3c3c:packages/skills/skills/contribute-to-eliza"} -->

