### PR TITLE
fix(cloud): bound remaining Discord REST hops

### DIFF
--- a/packages/cloud/shared/src/lib/services/discord-automation/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/index.error-policy.test.ts
@@ -12,6 +12,12 @@ process.env.DISCORD_BOT_TOKEN = "test-bot-token";
 const channelUpsert = mock(async () => {});
 const guildUpsert = mock(async () => {});
 
+// This suite exercises Discord transport and persistence policy. Keep the
+// unrelated Core Unicode helper hermetic so the focused test does not require
+// a built @elizaos/core workspace package.
+mock.module("@elizaos/core", () => ({
+  truncateWellFormed: (value: string, maxUnits: number) => value.slice(0, maxUnits),
+}));
 mock.module("../../../db/repositories/discord-channels", () => ({
   discordChannelsRepository: {
     upsert: channelUpsert,
@@ -43,6 +49,23 @@ function jsonResponse(body: unknown, init?: { ok?: boolean; status?: number }): 
     json: async () => body,
     text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
   } as unknown as Response;
+}
+
+function hungResponse(
+  init?: RequestInit,
+  onSignal?: (signal: AbortSignal | undefined) => void,
+): Promise<Response> {
+  onSignal?.(init?.signal);
+  return new Promise<Response>((_resolve, reject) => {
+    const guard = setTimeout(
+      () => reject(new Error("test guard elapsed before Discord deadline")),
+      2_000,
+    );
+    init?.signal?.addEventListener("abort", () => {
+      clearTimeout(guard);
+      reject(new DOMException("The operation was aborted.", "AbortError"));
+    });
+  });
 }
 
 beforeEach(() => {
@@ -159,13 +182,8 @@ describe("discordFetch — bounded hops fail closed and keep caller signals", ()
   it("aborts a hung Discord API hop at the timeout", async () => {
     // A Discord API that never settles on its own: the only way out is the
     // caller's AbortSignal firing (the 25s default matches the send path).
-    globalThis.fetch = mock(
-      (_input: RequestInfo | URL, init?: RequestInit) =>
-        new Promise<Response>((_resolve, reject) => {
-          init?.signal?.addEventListener("abort", () => {
-            reject(new DOMException("The operation was aborted.", "AbortError"));
-          });
-        }),
+    globalThis.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) =>
+      hungResponse(init),
     ) as unknown as typeof fetch;
 
     const start = Date.now();
@@ -177,14 +195,10 @@ describe("discordFetch — bounded hops fail closed and keep caller signals", ()
 
   it("propagates a caller abort through the composed signal", async () => {
     let seen: AbortSignal | undefined;
-    globalThis.fetch = mock(
-      (_input: RequestInfo | URL, init?: RequestInit) =>
-        new Promise<Response>((_resolve, reject) => {
-          seen = init?.signal;
-          init?.signal?.addEventListener("abort", () => {
-            reject(new DOMException("The operation was aborted.", "AbortError"));
-          });
-        }),
+    globalThis.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) =>
+      hungResponse(init, (signal) => {
+        seen = signal;
+      }),
     ) as unknown as typeof fetch;
 
     const controller = new AbortController();
@@ -201,24 +215,30 @@ describe("discordFetch — bounded hops fail closed and keep caller signals", ()
   it("keeps the hop deadline when the caller signal never aborts", async () => {
     // The caller signal must not replace the bound: a caller holding a signal
     // it never fires would otherwise pin the worker forever.
-    globalThis.fetch = mock(
-      (_input: RequestInfo | URL, init?: RequestInit) =>
-        new Promise<Response>((_resolve, reject) => {
-          init?.signal?.addEventListener("abort", () => {
-            reject(new DOMException("The operation was aborted.", "AbortError"));
-          });
-        }),
+    globalThis.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) =>
+      hungResponse(init),
     ) as unknown as typeof fetch;
 
     const never = new AbortController();
     const start = Date.now();
     await expect(
-      discordFetch(
-        "https://discord.com/api/v10/users/@me",
-        { signal: never.signal },
-        100,
-      ),
+      discordFetch("https://discord.com/api/v10/users/@me", { signal: never.signal }, 100),
     ).rejects.toThrow(/aborted/i);
     expect(Date.now() - start).toBeLessThan(5_000);
+  });
+});
+
+describe("sendMessage — shared Discord deadline boundary", () => {
+  it("passes the shared deadline signal to the message transport", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen = init?.signal;
+      return jsonResponse({ id: "message-1" });
+    }) as unknown as typeof fetch;
+
+    const result = await discordAutomationService.sendMessage("channel-1", "hello");
+
+    expect(result).toEqual({ success: true, messageId: "message-1" });
+    expect(seen).toBeInstanceOf(AbortSignal);
   });
 });

--- a/packages/cloud/shared/src/lib/services/discord-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/index.ts
@@ -8,6 +8,7 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { discordChannelsRepository } from "../../../db/repositories/discord-channels";
 import { discordGuildsRepository } from "../../../db/repositories/discord-guilds";
+import { discordFetch } from "../../utils/discord-api";
 import {
   DISCORD_RATE_LIMITS,
   getGuildIconUrl,
@@ -28,28 +29,7 @@ import type {
 const DISCORD_API_BASE = "https://discord.com/api/v10";
 const _DISCORD_CDN_BASE = "https://cdn.discordapp.com";
 
-const DISCORD_REQUEST_TIMEOUT_MS = 25_000;
-
-/**
- * Bound every Discord REST hop so a hung or rate-limited Discord API cannot
- * pin the calling worker indefinitely. Matches the 25s bound the message-send
- * path already applies. A caller-provided signal is composed with the hop
- * deadline rather than replacing it: a caller that cancels still aborts early,
- * and a caller whose signal never fires still cannot outlive the bound.
- */
-export function discordFetch(
-  input: RequestInfo | URL,
-  init?: RequestInit,
-  timeoutMs: number = DISCORD_REQUEST_TIMEOUT_MS,
-): Promise<Response> {
-  const deadline = AbortSignal.timeout(timeoutMs);
-  return fetch(input, {
-    ...init,
-    signal: init?.signal
-      ? AbortSignal.any([init.signal, deadline])
-      : deadline,
-  });
-}
+export { discordFetch };
 
 // Required environment variables
 const DISCORD_CLIENT_ID = process.env.DISCORD_CLIENT_ID;
@@ -601,19 +581,14 @@ class DiscordAutomationService {
           if (options?.components) body.components = options.components;
         }
 
-        const response = await Promise.race([
-          fetch(`${DISCORD_API_BASE}/channels/${channelId}/messages`, {
-            method: "POST",
-            headers: {
-              Authorization: `Bot ${DISCORD_BOT_TOKEN}`,
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify(body),
-          }),
-          new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error("Discord API timeout")), 25_000),
-          ),
-        ]);
+        const response = await discordFetch(`${DISCORD_API_BASE}/channels/${channelId}/messages`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bot ${DISCORD_BOT_TOKEN}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        });
 
         if (!response.ok) {
           const error = await response.text();

--- a/packages/cloud/shared/src/lib/services/eliza-app/discord-auth.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/discord-auth.error-policy.test.ts
@@ -6,7 +6,15 @@
 // Deterministic: real exported service driven through a mocked global fetch.
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { logger } from "../../utils/logger";
-import { discordAuthService } from "./discord-auth";
+
+// The brand catalog only supplies an unrelated app URL default here. Mock it
+// so this focused OAuth boundary test remains hermetic without a built
+// @elizaos/shared workspace package.
+mock.module("@elizaos/shared/brand", () => ({
+  EXTERNAL_URLS: { app: "https://app.example.com" },
+}));
+
+const { discordAuthService } = await import("./discord-auth");
 
 const REDIRECT_URI = "https://app.example.com/auth/discord/callback";
 const OK_USER = {
@@ -22,8 +30,9 @@ type FetchHandlers = {
   user?: () => Response | Promise<Response>;
 };
 
-function installFetch(handlers: FetchHandlers) {
-  globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+function installFetch(handlers: FetchHandlers, signals?: AbortSignal[]) {
+  globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (init?.signal) signals?.push(init.signal);
     const url = typeof input === "string" ? input : input.toString();
     if (url.includes("/oauth2/token")) {
       if (!handlers.token) throw new Error("unexpected token fetch");
@@ -148,10 +157,14 @@ describe("verifyOAuthCode — internal failure throws (distinct from null)", () 
 
 describe("verifyOAuthCode — happy path (proves the success branch is real)", () => {
   test("valid token + valid human user -> DiscordUserData", async () => {
-    installFetch({
-      token: () => new Response(JSON.stringify({ access_token: "tok" }), { status: 200 }),
-      user: () => new Response(JSON.stringify(OK_USER), { status: 200 }),
-    });
+    const signals: AbortSignal[] = [];
+    installFetch(
+      {
+        token: () => new Response(JSON.stringify({ access_token: "tok" }), { status: 200 }),
+        user: () => new Response(JSON.stringify(OK_USER), { status: 200 }),
+      },
+      signals,
+    );
     const result = await discordAuthService.verifyOAuthCode("good-code", REDIRECT_URI);
     expect(result).toEqual({
       id: OK_USER.id,
@@ -159,5 +172,7 @@ describe("verifyOAuthCode — happy path (proves the success branch is real)", (
       global_name: OK_USER.global_name,
       avatar: OK_USER.avatar,
     });
+    expect(signals).toHaveLength(2);
+    expect(signals.every((signal) => signal instanceof AbortSignal)).toBe(true);
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-app/discord-auth.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/discord-auth.ts
@@ -5,6 +5,7 @@
  * See: https://discord.com/developers/docs/topics/oauth2
  */
 
+import { discordFetch } from "../../utils/discord-api";
 import { logger } from "../../utils/logger";
 import { elizaAppConfig } from "./config";
 
@@ -70,7 +71,7 @@ class DiscordAuthService {
     }
 
     // Step 1: Exchange the authorization code for an access token.
-    const tokenResponse = await fetch(`${DISCORD_API_BASE}/oauth2/token`, {
+    const tokenResponse = await discordFetch(`${DISCORD_API_BASE}/oauth2/token`, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -114,7 +115,7 @@ class DiscordAuthService {
     // Step 2: Fetch the user profile with the access token. We now hold a valid
     // token, so any failure here is internal (transport/Discord/protocol) — never
     // a user-supplied-code problem — and must surface, not degrade to "invalid code".
-    const userResponse = await fetch(`${DISCORD_API_BASE}/users/@me`, {
+    const userResponse = await discordFetch(`${DISCORD_API_BASE}/users/@me`, {
       headers: {
         Authorization: `Bearer ${tokenData.access_token}`,
       },

--- a/packages/cloud/shared/src/lib/services/social-media/providers/discord.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/discord.error-policy.test.ts
@@ -29,6 +29,19 @@ const BOT_CREDS = { botToken: "bot-token", channelId: "chan-1" } as never;
 const BOT_CREDS_NO_CHANNEL = { botToken: "bot-token" } as never;
 const CONTENT = { text: "hello world" } as never;
 
+function hungResponse(init?: RequestInit): Promise<Response> {
+  return new Promise<Response>((_resolve, reject) => {
+    const guard = realSetTimeout(
+      () => reject(new Error("test guard elapsed before Discord deadline")),
+      2_000,
+    );
+    init?.signal?.addEventListener("abort", () => {
+      clearTimeout(guard);
+      reject(new DOMException("The operation was aborted.", "AbortError"));
+    });
+  });
+}
+
 beforeEach(() => {
   // Collapse exponential-backoff sleeps so a failing request exhausts its retries and rejects
   // without waiting out the real delays.
@@ -117,13 +130,8 @@ describe("discordProvider error policy", () => {
 
 describe("discordApiFetch — bounded hops fail closed and keep caller signals", () => {
   it("aborts a hung Discord API hop at the timeout", async () => {
-    globalThis.fetch = mock(
-      (_input: RequestInfo | URL, init?: RequestInit) =>
-        new Promise<Response>((_resolve, reject) => {
-          init?.signal?.addEventListener("abort", () => {
-            reject(new DOMException("The operation was aborted.", "AbortError"));
-          });
-        }),
+    globalThis.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) =>
+      hungResponse(init),
     ) as typeof fetch;
 
     const start = Date.now();
@@ -133,7 +141,7 @@ describe("discordApiFetch — bounded hops fail closed and keep caller signals",
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
-  it("preserves a caller-provided abort signal", async () => {
+  it("composes a caller-provided abort signal with the deadline", async () => {
     let seen: AbortSignal | undefined;
     globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
       seen = init?.signal;
@@ -144,6 +152,22 @@ describe("discordApiFetch — bounded hops fail closed and keep caller signals",
     await discordApiFetch("https://discord.com/api/v10/channels/1/messages", {
       signal: controller.signal,
     });
-    expect(seen).toBe(controller.signal);
+    expect(seen).toBeDefined();
+    expect(seen).not.toBe(controller.signal);
+  });
+
+  it("keeps the deadline when a caller signal never aborts", async () => {
+    globalThis.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) =>
+      hungResponse(init),
+    ) as typeof fetch;
+    const never = new AbortController();
+
+    await expect(
+      discordApiFetch(
+        "https://discord.com/api/v10/channels/1/messages",
+        { signal: never.signal },
+        100,
+      ),
+    ).rejects.toThrow(/aborted/i);
   });
 });

--- a/packages/cloud/shared/src/lib/services/social-media/providers/discord.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/discord.ts
@@ -9,27 +9,16 @@ import type {
   SocialCredentials,
   SocialMediaProvider,
 } from "../../../types/social-media";
-import { DISCORD_API_BASE, discordBotHeaders } from "../../../utils/discord-api";
+import {
+  DISCORD_API_BASE,
+  discordFetch as discordApiFetch,
+  discordBotHeaders,
+} from "../../../utils/discord-api";
 import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
 import { withRetry } from "../rate-limit";
 
-const DISCORD_REQUEST_TIMEOUT_MS = 30_000;
-
-/**
- * Bound every Discord bot / webhook hop so a hung or rate-limited API cannot
- * pin the publishing worker indefinitely. A caller-provided abort signal wins.
- */
-export function discordApiFetch(
-  input: RequestInfo | URL,
-  init?: RequestInit,
-  timeoutMs: number = DISCORD_REQUEST_TIMEOUT_MS,
-): Promise<Response> {
-  return fetch(input, {
-    ...init,
-    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
-  });
-}
+export { discordApiFetch };
 
 interface DiscordMessage {
   id: string;

--- a/packages/cloud/shared/src/lib/utils/discord-api.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/utils/discord-api.error-policy.test.ts
@@ -1,0 +1,101 @@
+// Pins the shared Discord REST deadline contract. Every caller keeps its own
+// cancellation signal, but a caller that never aborts cannot disable the
+// owned per-hop deadline. The bot/bearer helpers must use this same boundary.
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+const { discordBearerApiRequest, discordBotApiRequest, discordFetch } = await import(
+  "./discord-api"
+);
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function installHungFetch(): void {
+  globalThis.fetch = mock(
+    (_input: RequestInfo | URL, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        const guard = setTimeout(
+          () => reject(new Error("test guard elapsed before Discord deadline")),
+          2_000,
+        );
+        init?.signal?.addEventListener("abort", () => {
+          clearTimeout(guard);
+          reject(new DOMException("The operation was aborted.", "AbortError"));
+        });
+      }),
+  ) as typeof fetch;
+}
+
+describe("discordFetch", () => {
+  it("aborts a hung Discord hop at the owned deadline", async () => {
+    installHungFetch();
+
+    await expect(
+      discordFetch("https://discord.com/api/v10/users/@me", undefined, 100),
+    ).rejects.toThrow(/aborted/i);
+  });
+
+  it("propagates caller cancellation through a composed signal", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          seen = init?.signal;
+          const guard = setTimeout(
+            () => reject(new Error("test guard elapsed before caller abort")),
+            2_000,
+          );
+          init?.signal?.addEventListener("abort", () => {
+            clearTimeout(guard);
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as typeof fetch;
+
+    const controller = new AbortController();
+    const pending = discordFetch(
+      "https://discord.com/api/v10/users/@me",
+      { signal: controller.signal },
+      60_000,
+    );
+    controller.abort();
+
+    await expect(pending).rejects.toThrow(/aborted/i);
+    expect(seen).toBeDefined();
+    expect(seen).not.toBe(controller.signal);
+  });
+
+  it("keeps the deadline when a caller signal never aborts", async () => {
+    installHungFetch();
+    const never = new AbortController();
+
+    await expect(
+      discordFetch("https://discord.com/api/v10/users/@me", { signal: never.signal }, 100),
+    ).rejects.toThrow(/aborted/i);
+  });
+
+  it("routes bot and bearer helpers through the composed boundary", async () => {
+    const signals: AbortSignal[] = [];
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.signal) signals.push(init.signal);
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    const never = new AbortController();
+
+    await discordBotApiRequest("/users/@me", "bot", {
+      signal: never.signal,
+    });
+    await discordBearerApiRequest("/users/@me", "bearer", {
+      signal: never.signal,
+    });
+
+    expect(signals).toHaveLength(2);
+    expect(signals.every((signal) => signal !== never.signal)).toBe(true);
+  });
+});

--- a/packages/cloud/shared/src/lib/utils/discord-api.ts
+++ b/packages/cloud/shared/src/lib/utils/discord-api.ts
@@ -6,6 +6,25 @@
  */
 
 export const DISCORD_API_BASE = "https://discord.com/api/v10";
+export const DISCORD_REQUEST_TIMEOUT_MS = 25_000;
+
+/**
+ * Bound every Discord REST hop while preserving caller cancellation.
+ *
+ * A caller signal is composed with the owned deadline rather than replacing
+ * it, so a never-aborted caller signal cannot disable the operation bound.
+ */
+export function discordFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = DISCORD_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  const deadline = AbortSignal.timeout(timeoutMs);
+  return fetch(input, {
+    ...init,
+    signal: init?.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
+  });
+}
 
 /**
  * Create Discord Bot authorization header
@@ -57,7 +76,7 @@ export async function discordBotApiRequest<T>(
   botToken: string,
   options: RequestInit = {},
 ): Promise<T> {
-  const response = await fetch(`${DISCORD_API_BASE}${endpoint}`, {
+  const response = await discordFetch(`${DISCORD_API_BASE}${endpoint}`, {
     ...options,
     headers: {
       ...discordBotHeaders(botToken),
@@ -83,7 +102,7 @@ export async function discordBearerApiRequest<T>(
   accessToken: string,
   options: RequestInit = {},
 ): Promise<T> {
-  const response = await fetch(`${DISCORD_API_BASE}${endpoint}`, {
+  const response = await discordFetch(`${DISCORD_API_BASE}${endpoint}`, {
     ...options,
     headers: {
       ...discordBearerHeaders(accessToken),


### PR DESCRIPTION
# Relates to

Fixes #23521.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@62b8954f7d0febbee986d30bb3afc0623fa794e3:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@62b8954f7d0febbee986d30bb3afc0623fa794e3`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. This centralizes Discord REST transport policy inside Cloud shared and changes
the social provider's default bound from 30 seconds to the existing Cloud Discord
automation bound of 25 seconds. Timeout and caller-abort failures continue to
propagate through each caller's existing error boundary.

# Background

## What does this PR do?

- Adds one shared `discordFetch` primitive with an owned 25-second deadline.
- Composes caller cancellation with that deadline, so a never-aborted caller signal
  cannot silently disable the operation bound.
- Routes bot/bearer helpers, Discord automation sends, eliza-app OAuth token/profile
  hops, and social-media Discord calls through the same boundary.
- Preserves the automation and social modules' existing helper exports for callers.
- Adds production-path regressions for deadline expiry, caller cancellation,
  never-aborted signals, both OAuth hops, and message sending.

## What kind of change is this?

Bug fix (non-breaking change).

# Documentation changes needed?

No. This is an internal Cloud shared transport-policy consolidation; no public user
workflow or configuration key changes.

# Testing

## Where should a reviewer start?

Start at `packages/cloud/shared/src/lib/utils/discord-api.ts`, then inspect the four
focused error-policy suites.

## Detailed testing steps

On exact head `329ae3b5c405f05b02a77c65dddba1861bded6d2` after the final rebase:

```text
bun 1.3.14 test <four focused Discord suites>
31 pass, 0 fail, 59 expect() calls

@biomejs/biome 2.5.8 check <eight changed files>
Checked 8 files. No fixes applied.

git diff --check origin/develop...HEAD
exit 0
```

The focused suites are:

- `src/lib/utils/discord-api.error-policy.test.ts`
- `src/lib/services/discord-automation/index.error-policy.test.ts`
- `src/lib/services/eliza-app/discord-auth.error-policy.test.ts`
- `src/lib/services/social-media/providers/discord.error-policy.test.ts`

# Evidence Gate

<!-- evidence-head:329ae3b5c405f05b02a77c65dddba1861bded6d2 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only Cloud shared TypeScript; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only Cloud shared TypeScript; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or rendered user flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - live Discord logs require external credentials; 31 credential-free production-service tests cover timeout, cancellation, success, and error paths.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser request path changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action-selection, or LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database row, file, wallet, audio, or other domain artifact is created.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, action-selection, or LLM behavior changed.

## Backend + frontend logs

Backend live-service log: N/A - no disposable Discord credential was available or
authorized. The focused test run drives the real exported helpers/services with a
mocked network boundary and proves timeout, caller-abort, success, and error paths.

Frontend log: N/A - no frontend code changed.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI or interactive flow changed.

## Audio / voice walkthrough

N/A - no voice, audio, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- `bun install`, package-wide typecheck, and root `bun run verify` were not run in
  the intentionally sparse worktree because the monorepo dependency graph is not
  installed there. Hosted CI is required for those gates.
- No live Discord request was made: that would require an external credential and
  network authorization. The deterministic focused suites exercise the real service
  code with only the HTTP boundary mocked.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@62b8954f7d0febbee986d30bb3afc0623fa794e3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [startrack3r-cloud-discord-deadline-23521]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@62b8954f7d0febbee986d30bb3afc0623fa794e3:packages/skills/skills/contribute-to-eliza"} -->

