### PR TITLE
fix(app): isolate build subprocess export conditions

### DIFF
--- a/packages/app/scripts/lib/playwright-node-options.mjs
+++ b/packages/app/scripts/lib/playwright-node-options.mjs
@@ -1,7 +1,7 @@
 /**
- * Normalizes Node options inherited by Playwright and its child build processes.
- * Source-conditioned workspace exports must travel through every child
- * process. Playwright owns TypeScript transformation for its test graph.
+ * Normalizes Node export conditions at the Playwright process boundary.
+ * Playwright owns TypeScript transformation for its source graph, while build
+ * children must resolve the packages they verify through published exports.
  */
 
 const SOURCE_CONDITION = "--conditions=eliza-source";
@@ -17,4 +17,23 @@ export function withElizaSourceNodeOptions(value) {
   }
 
   return options.join(" ");
+}
+
+export function withoutElizaSourceNodeOptions(value) {
+  const options =
+    typeof value === "string" && value.trim().length > 0
+      ? value.trim().split(/\s+/)
+      : [];
+
+  return options
+    .filter((option, index) => {
+      if (option === SOURCE_CONDITION) return false;
+      if (option === "--conditions" && options[index + 1] === "eliza-source") {
+        return false;
+      }
+      return !(
+        option === "eliza-source" && options[index - 1] === "--conditions"
+      );
+    })
+    .join(" ");
 }

--- a/packages/app/scripts/lib/playwright-node-options.test.ts
+++ b/packages/app/scripts/lib/playwright-node-options.test.ts
@@ -1,5 +1,12 @@
+/**
+ * Deterministically verifies the Node export-condition boundary between the
+ * Playwright collector and its package-building subprocesses.
+ */
 import { describe, expect, it } from "bun:test";
-import { withElizaSourceNodeOptions } from "./playwright-node-options.mjs";
+import {
+  withElizaSourceNodeOptions,
+  withoutElizaSourceNodeOptions,
+} from "./playwright-node-options.mjs";
 
 describe("withElizaSourceNodeOptions", () => {
   it("adds the source condition", () => {
@@ -17,5 +24,33 @@ describe("withElizaSourceNodeOptions", () => {
   it("is idempotent", () => {
     const options = "--trace-warnings --conditions=eliza-source";
     expect(withElizaSourceNodeOptions(options)).toBe(options);
+  });
+});
+
+describe("withoutElizaSourceNodeOptions", () => {
+  it("removes the source condition without inventing another option", () => {
+    expect(withoutElizaSourceNodeOptions("--conditions=eliza-source")).toBe("");
+  });
+
+  it("preserves unrelated options and conditions", () => {
+    expect(
+      withoutElizaSourceNodeOptions(
+        "--trace-warnings --conditions=eliza-source --conditions=production --max-old-space-size=4096",
+      ),
+    ).toBe(
+      "--trace-warnings --conditions=production --max-old-space-size=4096",
+    );
+  });
+
+  it("removes the space-separated source condition form", () => {
+    expect(
+      withoutElizaSourceNodeOptions(
+        "--conditions production --conditions eliza-source --trace-warnings",
+      ),
+    ).toBe("--conditions production --trace-warnings");
+  });
+
+  it("accepts a missing Node options value", () => {
+    expect(withoutElizaSourceNodeOptions(undefined)).toBe("");
   });
 });

--- a/packages/app/scripts/run-ui-playwright.mjs
+++ b/packages/app/scripts/run-ui-playwright.mjs
@@ -13,7 +13,10 @@ import {
   auditProjectsRequestedByArgs,
   writeAuditProjectPropagation,
 } from "./lib/playwright-audit-projects.mjs";
-import { withElizaSourceNodeOptions } from "./lib/playwright-node-options.mjs";
+import {
+  withElizaSourceNodeOptions,
+  withoutElizaSourceNodeOptions,
+} from "./lib/playwright-node-options.mjs";
 import {
   resolveExecutableFromPath,
   resolvePlaywrightNodeRuntime,
@@ -402,7 +405,10 @@ if (
     [path.join(repoRoot, "packages", "scripts", "build-views.mjs")],
     {
       cwd: repoRoot,
-      env,
+      env: {
+        ...env,
+        NODE_OPTIONS: withoutElizaSourceNodeOptions(env.NODE_OPTIONS),
+      },
       stdio: "inherit",
     },
   );
@@ -438,7 +444,10 @@ if (
     ],
     {
       cwd: repoRoot,
-      env,
+      env: {
+        ...env,
+        NODE_OPTIONS: withoutElizaSourceNodeOptions(env.NODE_OPTIONS),
+      },
       stdio: "inherit",
     },
   );


### PR DESCRIPTION
# Relates to

Closes #23401.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change only removes the `eliza-source` export condition from the two build subprocess environments launched before Playwright. Playwright collection retains the condition, and unrelated `NODE_OPTIONS` tokens are preserved.

# Background

## What does this PR do?

Keeps Playwright's source-conditioned TypeScript collection environment from leaking into plugin-view and shared/core package builds. Packed consumers now resolve built distribution exports instead of source-only paths that are absent from the package tarball.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is needed. The helper's file-level contract and regression tests document the process boundary.

# Testing

## Where should a reviewer start?

Start with `packages/app/scripts/lib/playwright-node-options.test.ts`, then inspect the two sanitized build spawns in `packages/app/scripts/run-ui-playwright.mjs`.

## Detailed testing steps

```bash
bun test packages/app/scripts/lib/playwright-node-options.test.ts \
  packages/app/scripts/playwright-audit-projects.test.mjs \
  packages/app/scripts/playwright-test-match.test.mjs \
  packages/app/scripts/run-ui-playwright-node-resolution.test.mjs

bunx biome check \
  packages/app/scripts/lib/playwright-node-options.mjs \
  packages/app/scripts/lib/playwright-node-options.test.ts \
  packages/app/scripts/run-ui-playwright.mjs
```

Expected focused result: 24 pass, 1 environment-gated host probe skip, 0 fail; 28 assertions. The NODE_OPTIONS helper reports 100% line and function coverage.

# Evidence Gate

Evidence matches commit `6f1ddf3895f265d77fae6124d8b0bc18be6392a9`.
<!-- evidence-head:6f1ddf3895f265d77fae6124d8b0bc18be6392a9 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-rendered Node subprocess script change; no UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-rendered Node subprocess script change; no UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible flow or pixel change
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend service path; direct child-process and packed-consumer proof is in the PR body
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request, response, or state transition changes
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - focused test and packed-package verification output is in the PR body
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or text change

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior is changed.

## Backend + frontend logs

N/A - the affected boundary is a local Node subprocess environment. Direct evidence:

```text
Parent NODE_OPTIONS: --trace-warnings --conditions=eliza-source --conditions=production
Spawned Node 24 child NODE_OPTIONS: --trace-warnings --conditions=production
```

Canonical app audit reached and passed the affected packed-package contract:

```text
Packed @elizaos/core/edge declarations and runtime import verified
Packed Node, browser-condition, and exact-flat Vite consumers verified
```

## Screenshots (before / after) + video walkthrough

N/A - the diff contains only test and Node runner scripts; no rendered component, style, or asset changes.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice behavior changed.

## Known gaps / failures

- `bun install` was not rerun because the lockfile and dependency declarations are unchanged; the isolated worktree reused the existing lockfile-compatible dependency tree.
- Post-rebase root `bun run verify` was attempted. `check:agents-claude` and `check:biome-version` passed, then the existing repository-wide `check:i18n` gate failed on unrelated missing translation keys (including seven English capability-UI keys and existing secondary-locale gaps). None references the three changed files.
- Package-wide Biome reports existing errors in unrelated app tests/configuration and generated aesthetic-audit output. Biome passes on all three changed files.
- The canonical app audit passed every affected build and packed-consumer assertion. Its later live renderer capture was constrained by missing package-local dependency links in the isolated worktree; no rendered UI behavior is changed by this PR.
- No Cargo command was run.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: codex
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [otakucomrade-23401-app-audit-env]
<!-- slop-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0HVNF7KD6YC8R1WJ6MH3X4Q","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T09:50:35.763Z","completed_at":"2026-08-21T10:29:10.978Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T09:50:37.839Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"f1875bc27be69c4411a43bfaf9c1b1bfe69e75aec74e87d8662057259ba5df70","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"9fcc8e06-708e-418c-b9d6-52c502af88e9","object_id":"sha256:f1875bc27be69c4411a43bfaf9c1b1bfe69e75aec74e87d8662057259ba5df70","sha256":"f1875bc27be69c4411a43bfaf9c1b1bfe69e75aec74e87d8662057259ba5df70"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAflM8PoTR9ODo1eyirHaPX5A5wyYTcz--adY0c87h5N0","device_key_id":"38ff88641eac1ef721754364b87c73e2df36dc2b4dac70d9efab272041f0340c","device_signature":"VxCfHSu1nfMQgg2sO1fR3Tis4sYsK5T1BuJvw4AvkIs7y986TRoswCtC_d5M-cQ0dtp8ZLRhTe98WYNeEmRzBQ"}} -->

