### PR TITLE
fix(agent-orchestrator): keep surrogate pairs intact in prompts, summaries, and evidence

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/agent-orchestrator-surrogate.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/agent-orchestrator-surrogate.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Verifies that string truncation across agent-orchestrator components
+ * (spawn acks, completion summaries, failure reasons, activity summaries,
+ * tool outputs, and evidence strings) never splits UTF-16 surrogate pairs
+ * and sanitizes lone surrogates before output.
+ */
+
+import { describe, expect, it } from "vitest";
+import { extractFailureReason } from "../../src/evaluators/sub-agent-failure.js";
+import {
+  buildSpawnAckUserPrompt,
+  extractCompletionSummary,
+  sanitizeSpawnAck,
+} from "../../src/index.js";
+import {
+  buildEvidenceStringFromInput,
+  clamp,
+} from "../../src/services/completion-evidence.js";
+
+describe("agent-orchestrator surrogate safety", () => {
+  describe("buildSpawnAckUserPrompt", () => {
+    it("never splits surrogate pairs at the 400 char truncation boundary", () => {
+      // 396 'a's + 🦊 (2 UTF-16 code units) + 50 'b's = 448 chars
+      const task = `${"a".repeat(396)}🦊${"b".repeat(50)}`;
+      const prompt = buildSpawnAckUserPrompt(task);
+      expect(prompt.isWellFormed()).toBe(true);
+      expect(prompt).toContain(`${"a".repeat(396)}…`);
+    });
+
+    it("sanitizes lone surrogates", () => {
+      const task = `task with bad surrogate ${String.fromCharCode(0xd800)} content`;
+      const prompt = buildSpawnAckUserPrompt(task);
+      expect(prompt.isWellFormed()).toBe(true);
+      expect(prompt).toContain("\uFFFD");
+    });
+  });
+
+  describe("sanitizeSpawnAck", () => {
+    it("never splits surrogate pairs at the SPAWN_ACK_MAX_CHARS boundary", () => {
+      // SPAWN_ACK_MAX_CHARS is 120.
+      // 118 'a's + 🦊 (2 code units) + 20 'b's = 140 chars
+      const ack = `${"a".repeat(118)}🦊${"b".repeat(20)}`;
+      const sanitized = sanitizeSpawnAck(ack);
+      expect(sanitized.isWellFormed()).toBe(true);
+      expect(sanitized).toBe(`${"a".repeat(118)}…`);
+      expect(sanitized.length).toBe(119);
+    });
+
+    it("sanitizes lone surrogates and preserves fitting emoji", () => {
+      const ack = `I'm starting the task 🚀 ${String.fromCharCode(0xd800)}`;
+      const sanitized = sanitizeSpawnAck(ack);
+      expect(sanitized.isWellFormed()).toBe(true);
+      expect(sanitized).toContain("🚀");
+      expect(sanitized).toContain("\uFFFD");
+    });
+  });
+
+  describe("extractCompletionSummary", () => {
+    it("never splits surrogate pairs at the 300 char truncation boundary", () => {
+      // 296 'a's + 🦊 (2 code units) + 50 'b's = 348 chars
+      const raw = `${"a".repeat(296)}🦊${"b".repeat(50)}`;
+      const summary = extractCompletionSummary(raw);
+      expect(summary.isWellFormed()).toBe(true);
+      expect(summary).toBe(`${"a".repeat(296)}…`);
+    });
+
+    it("handles lone surrogates cleanly", () => {
+      const raw = `Completed task with ${String.fromCharCode(0xd83d)} item`;
+      const summary = extractCompletionSummary(raw);
+      expect(summary.isWellFormed()).toBe(true);
+      expect(summary).toContain("\uFFFD");
+    });
+  });
+
+  describe("extractFailureReason", () => {
+    it("never splits surrogate pairs at the 160 char truncation boundary", () => {
+      // 156 'a's + 🦊 (2 code units) + 30 'b's
+      const errorOutput = `Error occurred: ${"a".repeat(156)}🦊${"b".repeat(30)}`;
+      const reason = extractFailureReason(errorOutput);
+      expect(reason.isWellFormed()).toBe(true);
+      expect(reason.length).toBeLessThanOrEqual(158);
+    });
+  });
+
+  describe("completion-evidence clamp and assembly", () => {
+    it("never splits surrogate pairs at the clamp boundary", () => {
+      const text = `${"a".repeat(99)}🦊${"b".repeat(20)}`;
+      const clamped = clamp(text, 100);
+      expect(clamped.isWellFormed()).toBe(true);
+      expect(clamped).toContain(`${"a".repeat(99)}\n… [truncated]`);
+    });
+
+    it("preserves well-formed Unicode in buildEvidenceStringFromInput", () => {
+      const input = {
+        fallbackSummary: "done 🚀",
+        deliverable: `${"x".repeat(100)} 🦊 ${"y".repeat(100)}`,
+        finalReply: `Fixed everything ✨ ${String.fromCharCode(0xd800)}`,
+      };
+      const evidence = buildEvidenceStringFromInput(input);
+      expect(evidence.isWellFormed()).toBe(true);
+      expect(evidence).toContain("🦊");
+      expect(evidence).toContain("✨");
+      expect(evidence).toContain("\uFFFD");
+    });
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -26,6 +26,8 @@ import {
   looksLikeBareLinkShare,
   MESSAGE_SOURCE_SUB_AGENT,
   stringToUuid,
+  toWellFormedUnicode,
+  truncateWellFormed,
   unwrapUserMessageText,
   userReferenceLogView,
 } from "@elizaos/core";
@@ -328,7 +330,8 @@ function parseAgentPrefix(
 
 function labelFrom(task: string, index: number): string {
   const cleaned = task.replace(/\s+/g, " ").trim();
-  return cleaned ? cleaned.slice(0, 80) : `task-${index + 1}`;
+  const wellFormed = toWellFormedUnicode(cleaned);
+  return wellFormed ? truncateWellFormed(wellFormed, 80) : `task-${index + 1}`;
 }
 
 function objectValue(value: unknown): Record<string, unknown> | undefined {
@@ -1888,7 +1891,7 @@ async function runSpawnAgent(
     const labelParam = pickString(params, content, "label");
     const label = labelParam
       ? userReferenceLogView(labelParam)
-      : task.slice(0, 80);
+      : truncateWellFormed(toWellFormedUnicode(task), 80);
     const originConnectorMessageId = connectorMessageIdFromMemory(
       message,
       content,
@@ -4139,7 +4142,11 @@ async function handleIssueAction(
           };
         }
         const issue = await service.getIssue(repo, issueNumber);
-        const issueText = `Issue #${issue.number}: ${issue.title} [${issue.state}]\n\n${issue.body.slice(0, ISSUE_BODY_MAX_CHARS)}\n\nLabels: ${issue.labels.join(", ") || "none"}\n${issue.url}`;
+        const issueBody = truncateWellFormed(
+          toWellFormedUnicode(issue.body),
+          ISSUE_BODY_MAX_CHARS,
+        );
+        const issueText = `Issue #${issue.number}: ${issue.title} [${issue.state}]\n\n${issueBody}\n\nLabels: ${issue.labels.join(", ") || "none"}\n${issue.url}`;
         return {
           success: true,
           text: issueText,
@@ -4300,7 +4307,10 @@ async function runManageIssues(
   // Unwrapped: bulk-issue extraction and action/repo inference read this as
   // the user's request; a raw envelope read would mint GitHub issues out of
   // security-notice lines (and the slice could truncate the real payload).
-  const text = requestText(message).slice(0, ISSUE_BODY_MAX_CHARS);
+  const text = truncateWellFormed(
+    toWellFormedUnicode(requestText(message)),
+    ISSUE_BODY_MAX_CHARS,
+  );
 
   const topLevelAction = textValue(params.action) ?? textValue(content.action);
   const normalizedTopLevelAction = topLevelAction

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts
@@ -14,6 +14,8 @@ import {
   type MessageHandlerResult,
   type ResponseHandlerEvaluator,
   SIMPLE_CONTEXT_ID,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import {
   completionHasVerificationFailure,
@@ -105,10 +107,9 @@ function isTerminalSubAgentFailure(message: Memory): boolean {
 
 // Trim the router's error narration to a single short, user-readable clause:
 // drop leading label/emoji/quote annotations and skip bare internal codes.
-function shortReason(body: string): string {
-  const firstLine = body
-    .replace(/\r\n/g, "\n")
-    .split("\n")
+export function extractFailureReason(errorOutput: string): string {
+  const lines = errorOutput.replace(/\r\n/g, "\n").split("\n");
+  const firstLine = lines
     .map((line) =>
       line
         .replace(/^[\s>*•-]+/, "")
@@ -117,14 +118,16 @@ function shortReason(body: string): string {
     )
     .find((line) => line.length > 0 && /\s/.test(line));
   if (!firstLine) return "";
-  // First sentence only, with trailing sentence punctuation stripped so the
-  // reply template's own period doesn't double up ("timed out.. Want me…").
   const clause = firstLine
     .split(/(?<=[.!?])\s/)[0]
     .replace(/[.!?]+$/, "")
     .trim();
-  return clause.length > 160 ? `${clause.slice(0, 157)}…` : clause;
+  const wellFormed = toWellFormedUnicode(clause);
+  return wellFormed.length > 160
+    ? `${truncateWellFormed(wellFormed, 157)}…`
+    : wellFormed;
 }
+const shortReason = extractFailureReason;
 
 function buildFailureReply(label: string, reason: string): string {
   const what = label ? `the "${label}" task` : "that task";

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -25,6 +25,8 @@ import {
   ModelType,
   promoteSubactionsToActions,
   requireConfirmedSendHandlerDelivery,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 
 // Register coding-agent HTTP routes with the runtime route registry.
@@ -853,7 +855,11 @@ export function buildSpawnAckSystemPrompt(character: Character): string {
 export function buildSpawnAckUserPrompt(task: string): string {
   const trimmed = task.trim();
   const what = trimmed.length > 0 ? trimmed : "the task they just gave you";
-  const clipped = what.length > 400 ? `${what.slice(0, 397)}…` : what;
+  const wellFormed = toWellFormedUnicode(what);
+  const clipped =
+    wellFormed.length > 400
+      ? `${truncateWellFormed(wellFormed, 397)}…`
+      : wellFormed;
   return `The task you're starting:\n${clipped}\n\nYour one-line acknowledgement:`;
 }
 
@@ -898,9 +904,10 @@ export function sanitizeSpawnAck(raw: string): string {
   }
   cleaned = cleaned.replace(/\s{2,}/g, " ").trim();
   if (!cleaned) return "";
-  return cleaned.length > SPAWN_ACK_MAX_CHARS
-    ? `${cleaned.slice(0, SPAWN_ACK_MAX_CHARS - 1).trimEnd()}…`
-    : cleaned;
+  const wellFormed = toWellFormedUnicode(cleaned);
+  return wellFormed.length > SPAWN_ACK_MAX_CHARS
+    ? `${truncateWellFormed(wellFormed, SPAWN_ACK_MAX_CHARS - 1).trimEnd()}…`
+    : wellFormed;
 }
 
 function stripToolTranscripts(raw: string): string {
@@ -940,7 +947,10 @@ export function extractCompletionSummary(raw: string): string {
     .filter((l) => l.length > 0 && !l.startsWith("[Tool:"));
   const last = lines[lines.length - 1] ?? "";
   if (!last) return "done";
-  return last.length > 300 ? `${last.slice(0, 297).trimEnd()}…` : last;
+  const wellFormed = toWellFormedUnicode(last);
+  return wellFormed.length > 300
+    ? `${truncateWellFormed(wellFormed, 297).trimEnd()}…`
+    : wellFormed;
 }
 
 /**
@@ -1021,8 +1031,12 @@ function formatToolCallForHuman(tc: AcpToolCall | undefined): string {
     const parts = p.split("/").filter(Boolean);
     return parts.length > 2 ? `…/${parts.slice(-2).join("/")}` : p;
   };
-  const trimCmd = (c: string): string =>
-    c.length > 80 ? `${c.slice(0, 77)}...` : c;
+  const trimCmd = (c: string): string => {
+    const wellFormed = toWellFormedUnicode(c);
+    return wellFormed.length > 80
+      ? `${truncateWellFormed(wellFormed, 77)}...`
+      : wellFormed;
+  };
   // Heuristic: pick a noun based on title/kind, then attach the most
   // informative arg.
   const noun = (() => {
@@ -1404,7 +1418,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         const prevSummary = lastHeartbeatSummary.get(sessionId);
         if (prevSummary && norm(prevSummary) === norm(trimmedSummary)) return;
         lastHeartbeatSummary.set(sessionId, trimmedSummary);
-        const text = `⏳ [${label}] ${trimmedSummary.length > 200 ? `${trimmedSummary.slice(0, 197)}...` : trimmedSummary}`;
+        const wellFormedSummary = toWellFormedUnicode(trimmedSummary);
+        const text = `⏳ [${label}] ${wellFormedSummary.length > 200 ? `${truncateWellFormed(wellFormedSummary, 197)}...` : wellFormedSummary}`;
         lastHeartbeatPostAt.set(sessionId, now);
         await emitProgress(sessionId, { source, roomId }, text, label);
       } catch {
@@ -2050,7 +2065,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
     // duplicates the final summary the response evaluator builds. A 800-char
     // window fits short tables and a few bullet points; longer dumps get
     // truncated and the canonical version lands via the summary.
-    const text = `💬 [${label}] ${trimmed.length > 800 ? `${trimmed.slice(0, 793)}…[+]` : trimmed}`;
+    const wellFormed = toWellFormedUnicode(trimmed);
+    const text = `💬 [${label}] ${wellFormed.length > 800 ? `${truncateWellFormed(wellFormed, 793)}…[+]` : wellFormed}`;
     // Reset heartbeat clock — message just posted, no need for a status
     // tick within the next heartbeat interval.
     lastHeartbeatPostAt.set(sessionId, Date.now());

--- a/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
@@ -5,12 +5,14 @@
  * spend-capped, or round-trip-capped session to resolve.
  */
 
-import type {
-  IAgentRuntime,
-  Memory,
-  Provider,
-  Service,
-  State,
+import {
+  type IAgentRuntime,
+  type Memory,
+  type Provider,
+  type Service,
+  type State,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import { getAcpService } from "../actions/common.js";
 import { TASK_WATCHDOG_SERVICE_TYPE } from "../services/task-watchdog-service.js";
@@ -491,8 +493,10 @@ function summarizeOutputTail(raw: string): string {
     );
   const last = lines.slice(-3).join(" / ");
   if (!last) return "";
-  // Truncate to keep the provider compact in the planner context.
-  return last.length > 120 ? `${last.slice(0, 117)}...` : last;
+  const wellFormed = toWellFormedUnicode(last);
+  return wellFormed.length > 120
+    ? `${truncateWellFormed(wellFormed, 117)}...`
+    : wellFormed;
 }
 
 function labelOf(session: SessionInfo): string {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -40,6 +40,8 @@ import {
   type IAgentRuntime,
   Service,
   TRACE_ENV,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import { isAndroidMobile } from "@elizaos/shared";
 import { getHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
@@ -5408,10 +5410,11 @@ function captureTerminalToolOutput(
   const key = `${toolCall.id}\0${output}`;
   if (capturedToolOutputs.has(key)) return undefined;
   capturedToolOutputs.add(key);
+  const wellFormed = toWellFormedUnicode(output);
   const truncated =
-    output.length > MAX_CAPTURED_TOOL_OUTPUT_CHARS
-      ? `${output.slice(0, MAX_CAPTURED_TOOL_OUTPUT_CHARS)}\n[tool output truncated]`
-      : output;
+    wellFormed.length > MAX_CAPTURED_TOOL_OUTPUT_CHARS
+      ? `${truncateWellFormed(wellFormed, MAX_CAPTURED_TOOL_OUTPUT_CHARS)}\n[tool output truncated]`
+      : wellFormed;
   const title = toolCall.title?.trim() || "tool output";
   return `[tool output: ${title}]\n${truncated}\n${TOOL_OUTPUT_END_MARKER}`;
 }
@@ -5475,7 +5478,10 @@ function execRecordOutputTail(record: Record<string, unknown>): string {
     .filter((entry) => entry.length > 0);
   if (candidates.length === 0) return "";
   const joined = candidates.join("\n").trim();
-  return joined.length > 200 ? `${joined.slice(0, 200)}…` : joined;
+  const wellFormed = toWellFormedUnicode(joined);
+  return wellFormed.length > 200
+    ? `${truncateWellFormed(wellFormed, 200)}…`
+    : wellFormed;
 }
 
 function parseJsonRecord(text: string): Record<string, unknown> | undefined {
@@ -5548,7 +5554,7 @@ function capStderr(text: string): string {
 }
 
 function preview(text: string): string {
-  return text.replace(/\s+/g, " ").slice(0, 80);
+  return truncateWellFormed(toWellFormedUnicode(text.replace(/\s+/g, " ")), 80);
 }
 
 function errorMessage(err: unknown): string {

--- a/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
@@ -31,6 +31,7 @@
  * @module services/completion-evidence
  */
 
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type { WorkspaceChangeSet } from "./workspace-diff.js";
 
 /** One recorded signal (a durable event or sub-agent message) the assembler
@@ -173,14 +174,16 @@ export function appendCompletionEvidenceSection(
   }
   if (addition.length >= MAX_EVIDENCE_CHARS) {
     const marker = "\n… [truncated]";
-    return `${addition.slice(0, MAX_EVIDENCE_CHARS - marker.length)}${marker}`;
+    const wellFormedAddition = toWellFormedUnicode(addition);
+    return `${truncateWellFormed(wellFormedAddition, MAX_EVIDENCE_CHARS - marker.length)}${marker}`;
   }
   const marker = "\n… [evidence truncated]";
   const available = Math.max(
     0,
     MAX_EVIDENCE_CHARS - addition.length - separator.length - marker.length,
   );
-  return `${base.slice(0, available)}${marker}${separator}${addition}`;
+  const wellFormedBase = toWellFormedUnicode(base);
+  return `${truncateWellFormed(wellFormedBase, available)}${marker}${separator}${addition}`;
 }
 
 /**
@@ -203,10 +206,11 @@ function isLoopbackUrl(value: string): boolean {
   }
 }
 
-function clamp(text: string, max: number): string {
+export function clamp(text: string, max: number): string {
   const trimmed = text.trim();
-  if (trimmed.length <= max) return trimmed;
-  return `${trimmed.slice(0, max)}\n… [truncated]`;
+  const wellFormed = toWellFormedUnicode(trimmed);
+  if (wellFormed.length <= max) return wellFormed;
+  return `${truncateWellFormed(wellFormed, max)}\n… [truncated]`;
 }
 
 /** Markers that class a signal as TEST output (vitest/jest run, suite result). */
@@ -545,9 +549,10 @@ export function buildCompletionEvidenceString(
   }
 
   const assembled = sections.join("\n\n");
-  return assembled.length > MAX_EVIDENCE_CHARS
-    ? `${assembled.slice(0, MAX_EVIDENCE_CHARS)}\n… [evidence truncated]`
-    : assembled;
+  const wellFormed = toWellFormedUnicode(assembled);
+  return wellFormed.length > MAX_EVIDENCE_CHARS
+    ? `${truncateWellFormed(wellFormed, MAX_EVIDENCE_CHARS)}\n… [evidence truncated]`
+    : wellFormed;
 }
 
 /**

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -40,6 +40,8 @@ import {
   Service,
   TRACE_ENV,
   type TrajectoryUsageRollup,
+  toWellFormedUnicode,
+  truncateWellFormed,
   type UUID,
 } from "@elizaos/core";
 import {
@@ -626,7 +628,10 @@ function readAttemptReflections(
 }
 
 function truncate(text: string, max = 2000): string {
-  return text.length > max ? `${text.slice(0, max)}…` : text;
+  const wellFormed = toWellFormedUnicode(text);
+  return wellFormed.length > max
+    ? `${truncateWellFormed(wellFormed, max)}…`
+    : wellFormed;
 }
 
 /**


### PR DESCRIPTION
Fixes #23590

## Summary

- Fix string-capping and preview helpers across `plugins/plugin-agent-orchestrator` (`buildSpawnAckUserPrompt`, `sanitizeSpawnAck`, `extractCompletionSummary`, `extractFailureReason`, `summarizeActivity`, `labelFrom`, `clamp`, `buildEvidenceStringFromInput`, `buildCapturedToolOutputEnvelope`, `execRecordOutputTail`, `preview`, and task `truncate`) to use `toWellFormedUnicode` + `truncateWellFormed` from `@elizaos/core` so capping prompts, acknowledgements, tool output tails, and completion evidence never splits an astral surrogate pair (e.g. 🦊 `\uD83E\uDD8A`) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict provider JSON (Cerebras/serde `wrong_api_format`) rejects with HTTP 400.
- Add deterministic `isWellFormed()` unit tests in `plugins/plugin-agent-orchestrator/__tests__/unit/agent-orchestrator-surrogate.test.ts`: emoji at truncation boundaries (396 'a' + 🦊, 118 'a' + 🦊, 296 'a' + 🦊, 156 'a' + 🦊, 99 'a' + 🦊), lone `\ud800` → `\ufffd`, and fitting emojis under cap.

Same class as approved #23241 (slack `formatting`), #23227 (telegram `splitTelegramText`), #23277 (agent `grounded-action-reply`), #23284 (shared `transcriptPreview`), #23441 (notes `noteLine`), #23448 (instagram `truncateComment`), #23472 (core `replyContext`), #23479 (agent `workspace-provider`), #23488 (discord `messaging`), #23491 (core `readErrorBodySnippet`), #23505 (agent-skills `truncateEvidence`/descriptions), and #23586 (personal-assistant `clip`).

## Changes

| File | Change |
|------|--------|
| `plugins/plugin-agent-orchestrator/src/index.ts` | Surrogate-safe `buildSpawnAckUserPrompt`, `sanitizeSpawnAck`, `extractCompletionSummary`, `trimCmd`, progress heartbeat & narration flush |
| `plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts` | Export and use surrogate-safe `extractFailureReason` |
| `plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts` | Surrogate-safe `summarizeActivity` |
| `plugins/plugin-agent-orchestrator/src/actions/tasks.ts` | Surrogate-safe `labelFrom`, label fallback, issue body, and request text truncation |
| `plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts` | Surrogate-safe `appendEvidence`, export `clamp`, and `buildEvidenceStringFromInput` |
| `plugins/plugin-agent-orchestrator/src/services/acp-service.ts` | Surrogate-safe `buildCapturedToolOutputEnvelope`, `execRecordOutputTail`, and `preview` |
| `plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts` | Surrogate-safe task log/summary `truncate` |
| `plugins/plugin-agent-orchestrator/__tests__/unit/agent-orchestrator-surrogate.test.ts` | +106 lines — 9 unit tests verifying surrogate boundary backoff, lone surrogate sanitization, and fitting emojis across components |

## Verification

- Rebased onto `origin/develop` — zero conflicts
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/` — 8 files clean (62ms, no fixes applied)
- `bunx vitest run __tests__/unit/agent-orchestrator-surrogate.test.ts` — **9 passed, 0 failed**
- `bun run --cwd packages/core typecheck` — 0 errors
- `git show 6d8c941f4a3b8a800e05255f62b9d71422bab4c1` verifies surrogate-safe wiring across all 8 files

## Evidence Gate

<!-- evidence-head:6d8c941f4a3b8a800e05255f62b9d71422bab4c1 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; agent orchestrator prompts, summaries, and evidence strings are headless prompt/event assembly.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; same as before.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior is proven by deterministic surrogate unit tests.

<!-- evidence-row:backend-logs -->
- [x] Real surrogate-aware paths exercised via Vitest:

```log
$ vitest run __tests__/unit/agent-orchestrator-surrogate.test.ts
 Test Files  1 passed (1)
      Tests  9 passed (9)
   Start at  17:55:19
   Duration  3.39s
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved; orchestrator sub-agent event streaming is backend-only.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model delegation change beyond string hygiene; no live-model trajectory to link (deterministic truncation unit coverage).

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = surrogate-safe spawn acks, completion evidence, and failure reason strings, proven by deterministic unit tests:

```log
each test asserts .isWellFormed() === true
boundary: "a".repeat(396) + "🦊" + "b".repeat(50) → "a".repeat(396) + "…" (backoff, not lone \uD83E)
boundary: "a".repeat(118) + "🦊" + "b".repeat(20) → "a".repeat(118) + "…"
boundary: "a".repeat(296) + "🦊" + "b".repeat(50) → "a".repeat(296) + "…"
lone: "task with bad surrogate \ud800 content" → "\ufffd"
fitting: "I'm starting the task 🚀" → kept intact
all pass; without fix the boundaries emit lone \uD83E and fail isWellFormed()
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface; no OCR text to review.

# Risks

Low — localized string hygiene in `@elizaos/plugin-agent-orchestrator`. Preserves standard max lengths and ellipsis suffixes while eliminating split surrogates.

# Background

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-agent-orchestrator/src/index.ts`, `plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts`, and `plugins/plugin-agent-orchestrator/__tests__/unit/agent-orchestrator-surrogate.test.ts`.

## Detailed testing steps

- `bunx vitest run plugins/plugin-agent-orchestrator/__tests__/unit/agent-orchestrator-surrogate.test.ts` — expect 9/9 passed
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/index.ts plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts plugins/plugin-agent-orchestrator/__tests__/unit/agent-orchestrator-surrogate.test.ts` — expect clean

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c276ccf007dd8f1e6102b8d5799b5ec6109394ef:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@c276ccf007dd8f1e6102b8d5799b5ec6109394ef:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — agent-orchestrator]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@c276ccf007dd8f1e6102b8d5799b5ec6109394ef:packages/skills/skills/contribute-to-eliza"} -->
