### PR TITLE
fix(canvas): preserve layers across attach lifecycle

### DIFF
--- a/plugins/plugin-native-canvas/src/web.test.ts
+++ b/plugins/plugin-native-canvas/src/web.test.ts
@@ -162,6 +162,88 @@ describe("CanvasWeb validation", () => {
   );
 });
 
+describe("CanvasWeb attachment lifecycle", () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+      createContextStub(),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("composites a layer created before the base canvas is attached", async () => {
+    const canvas = new CanvasWeb();
+    const { canvasId } = await canvas.create({
+      size: { width: 10, height: 10 },
+    });
+    await canvas.createLayer({
+      canvasId,
+      layer: { visible: true, opacity: 1, zIndex: 1 },
+    });
+    const host = document.createElement("div");
+
+    await canvas.attach({ canvasId, element: host });
+
+    expect(host.querySelectorAll("canvas")).toHaveLength(2);
+  });
+
+  it("composites a layer created after the base canvas is attached", async () => {
+    const canvas = new CanvasWeb();
+    const { canvasId } = await canvas.create({
+      size: { width: 10, height: 10 },
+    });
+    const host = document.createElement("div");
+    await canvas.attach({ canvasId, element: host });
+
+    await canvas.createLayer({
+      canvasId,
+      layer: { visible: true, opacity: 1, zIndex: 1 },
+    });
+
+    expect(host.querySelectorAll("canvas")).toHaveLength(2);
+  });
+
+  it("removes the base canvas and every layer when detached", async () => {
+    const canvas = new CanvasWeb();
+    const { canvasId } = await canvas.create({
+      size: { width: 10, height: 10 },
+    });
+    const host = document.createElement("div");
+    await canvas.attach({ canvasId, element: host });
+    await canvas.createLayer({
+      canvasId,
+      layer: { visible: true, opacity: 1, zIndex: 1 },
+    });
+
+    await canvas.detach({ canvasId });
+
+    expect(host.querySelectorAll("canvas")).toHaveLength(0);
+  });
+
+  it("reattaches the base canvas and retained layers into a new host", async () => {
+    const canvas = new CanvasWeb();
+    const { canvasId } = await canvas.create({
+      size: { width: 10, height: 10 },
+    });
+    const firstHost = document.createElement("div");
+    const secondHost = document.createElement("div");
+    await canvas.attach({ canvasId, element: firstHost });
+    await canvas.createLayer({
+      canvasId,
+      layer: { visible: true, opacity: 1, zIndex: 1 },
+    });
+
+    await canvas.detach({ canvasId });
+    await canvas.attach({ canvasId, element: secondHost });
+
+    expect(firstHost.querySelectorAll("canvas")).toHaveLength(0);
+    expect(secondHost.querySelectorAll("canvas")).toHaveLength(2);
+  });
+});
+
 describe("CanvasWeb eval message source", () => {
   afterEach(() => {
     document.body.innerHTML = "";

--- a/plugins/plugin-native-canvas/src/web.ts
+++ b/plugins/plugin-native-canvas/src/web.ts
@@ -236,7 +236,11 @@ export class CanvasWeb extends WebPlugin {
     const managed = this.canvases.get(options.canvasId);
     if (!managed) throw new Error("Canvas not found");
 
-    assertAttachElement(options.element).appendChild(managed.canvas);
+    const element = assertAttachElement(options.element);
+    element.appendChild(managed.canvas);
+    for (const layer of managed.layers.values()) {
+      element.appendChild(layer.canvas);
+    }
     this.setupTouchHandlers(managed);
   }
 
@@ -244,6 +248,9 @@ export class CanvasWeb extends WebPlugin {
     const managed = this.canvases.get(options.canvasId);
     if (!managed) throw new Error("Canvas not found");
 
+    for (const layer of managed.layers.values()) {
+      layer.canvas.remove();
+    }
     managed.canvas.remove();
   }
 


### PR DESCRIPTION
# Relates to

Fixes #23454.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@3d0558d12cd17d72efb9903cca5a37807387e625:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@3d0558d12cd17d72efb9903cca5a37807387e625`; zero conflicts.
- [x] `bun run verify` was attempted on the exact head; the current-develop
      blocker is recorded in **Known gaps / failures** below.

# Risks

Low. The browser reference implementation now treats every tracked layer canvas
as part of the base canvas's DOM lifecycle. Existing attached-layer behavior,
insertion order, CSS z-index compositing, touch-handler setup, native bridges,
and the public API are unchanged.

# Background

## What does this PR do?

- Appends layers created before `attach()` when the base canvas enters a host.
- Removes all layer canvases alongside the base canvas during `detach()`.
- Preserves tracked layers across detach/re-attach into a different host.
- Adds real jsdom regressions for both layer-creation orderings, cleanup, and
  reattachment.

## What kind of change is this?

Bug fix (non-breaking change).

# Documentation changes needed?

No. The existing README already documents create-layer-before-attach as the
primary flow; this change makes the browser implementation honor that contract.

# Testing

## Where should a reviewer start?

Start with `plugins/plugin-native-canvas/src/web.test.ts` under
`CanvasWeb attachment lifecycle`, then inspect the small `attach()` / `detach()`
loops in `src/web.ts`.

## Detailed testing steps

Exact head: `eb9238f2b5b993b702fa54f4dccef8b957e1fb88`.

```text
Pre-fix control (new tests with production loops removed):
1 file failed; 3 failed, 28 passed
  - layer created before attach: host had 1 canvas, expected 2
  - detach: host retained 1 layer canvas, expected 0
  - reattach: old/new hosts had 1/1 canvases, expected 0/2

Final focused web suite:
1 file passed; 31 passed, 0 failed

Final full package suite:
3 files passed; 40 passed, 0 failed

Plugin typecheck:
tsc --noEmit -p tsconfig.json
exit 0

Changed-file Biome:
Checked 2 files. No fixes applied.

Package build:
dist/esm/index.js -> dist/plugin.js, dist/plugin.cjs.js
created successfully

git diff --check origin/develop...HEAD
exit 0
```

# Evidence Gate

<!-- evidence-head:eb9238f2b5b993b702fa54f4dccef8b957e1fb88 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - opt-in canvas library has no repository-owned host page for this lifecycle; a screenshot would require an invented wrapper rather than the real changed boundary.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - the authoritative artifact is the exact DOM ownership matrix below, not pixels from a synthetic host.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no repository-owned interactive route exercises this opt-in Capacitor plugin.
<!-- evidence-row:backend-logs -->
- [ ] N/A - browser-only DOM lifecycle; no backend service or request path changed.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no console/network transition is involved; real jsdom host-node counts are recorded below.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, model, or LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database row, file, wallet, audio, or persisted domain artifact is created; the in-memory DOM matrix is inline below.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no text or rendered application surface changed.

# Evidence Details

## DOM ownership artifact

The real `CanvasWeb` implementation was driven in jsdom with only the unavailable
2D context stubbed:

| Lifecycle | Pre-fix host canvas count | Final host canvas count |
| --- | --- | --- |
| create layer, then attach | `1` (base only) | `2` (base + layer) |
| attach, then create layer | `2` | `2` |
| detach after attached layer | `1` (orphan layer) | `0` |
| detach and attach into new host | old/new = `1/1` | old/new = `0/2` |

The pre-fix control fails exactly the three repaired lifecycle cases. The final
implementation passes those cases and all 40 package tests.

## Real LLM-call trajectory

N/A - no model, prompt, action-selection, or LLM behavior changed.

## Backend + frontend logs

N/A - the changed boundary is synchronous browser DOM ownership with no network,
backend, console, or storage path. The exact node-count artifact above exercises
the real production class.

## Screenshots (before / after) + video walkthrough

N/A - the plugin is an opt-in library with no repository-owned integration page.
Creating a bespoke evidence page would test a synthetic consumer rather than add
information beyond the real DOM ownership assertions.

## Audio / voice walkthrough

N/A - no voice, audio, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- Exact-head root `bun run verify` stops at the first current-`develop` gate:
  `packages/cloud/test-mocks: CLAUDE.md and AGENTS.md differ`. This branch changes
  neither guide; the native-canvas package tests, typecheck, build, changed-file
  Biome, and diff-check all pass after the final rebase.
- Dependencies were installed with pinned Bun 1.3.14 and lifecycle scripts
  disabled; the lockfile and manifests are unchanged.
- No Cargo command was run because no Rust source or build surface changed.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@3d0558d12cd17d72efb9903cca5a37807387e625:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [startrack3r-native-canvas-attach-23454]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@3d0558d12cd17d72efb9903cca5a37807387e625:packages/skills/skills/contribute-to-eliza"} -->
