### PR TITLE
fix(core): keep surrogate pairs intact in trajectory evaluator prompt and response formatting

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.surrogate.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.surrogate.test.ts
@@ -1,0 +1,129 @@
+/** Surrogate safety for formatTrajectoryForPrompt: userPrompt and response truncation must never emit lone surrogates. */
+import { describe, expect, test } from "vitest";
+import {
+	formatTrajectoryForPrompt,
+	type SkillTrajectory,
+} from "./trajectory-evaluator-utils.ts";
+
+function isWellFormed(value: string): boolean {
+	if (!value) return true;
+	const maybe = value as unknown as { isWellFormed?: () => boolean };
+	if (typeof maybe.isWellFormed === "function") return maybe.isWellFormed();
+	return true;
+}
+
+describe("formatTrajectoryForPrompt surrogate safety", () => {
+	test("emoji at 599 boundary backs off to 599 without lone surrogate at 600 cap in userPrompt", () => {
+		const traj: SkillTrajectory = {
+			trajectoryId: "traj-1",
+			agentId: "agent-1",
+			startTime: Date.now(),
+			steps: [
+				{
+					timestamp: Date.now(),
+					llmCalls: [
+						{
+							userPrompt: `${"a".repeat(599)}🦊${"b".repeat(50)}`,
+							purpose: "planning",
+						},
+					],
+				},
+			],
+		};
+		const out = formatTrajectoryForPrompt(traj);
+		expect(isWellFormed(out)).toBe(true);
+		expect(() => JSON.stringify({ prompt: out })).not.toThrow();
+		expect(out.includes("USER:")).toBe(true);
+	});
+
+	test("fitting emoji ending at 600 kept intact in response", () => {
+		const traj: SkillTrajectory = {
+			trajectoryId: "traj-2",
+			agentId: "agent-1",
+			startTime: Date.now(),
+			steps: [
+				{
+					timestamp: Date.now(),
+					llmCalls: [
+						{
+							response: `${"a".repeat(598)}🦊`,
+							purpose: "execution",
+						},
+					],
+				},
+			],
+		};
+		const out = formatTrajectoryForPrompt(traj);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.includes("🦊")).toBe(true);
+	});
+
+	test("short prompt with emoji passes through untouched", () => {
+		const traj: SkillTrajectory = {
+			trajectoryId: "traj-3",
+			agentId: "agent-1",
+			startTime: Date.now(),
+			steps: [
+				{
+					timestamp: Date.now(),
+					llmCalls: [
+						{
+							userPrompt: "Help me find a fox 🦊",
+							response: "Found the fox 🦊!",
+						},
+					],
+				},
+			],
+		};
+		const out = formatTrajectoryForPrompt(traj);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.includes("Help me find a fox 🦊")).toBe(true);
+		expect(out.includes("Found the fox 🦊!")).toBe(true);
+	});
+
+	test("lone high surrogate is sanitized before truncation", () => {
+		const traj: SkillTrajectory = {
+			trajectoryId: "traj-4",
+			agentId: "agent-1",
+			startTime: Date.now(),
+			steps: [
+				{
+					timestamp: Date.now(),
+					llmCalls: [
+						{
+							userPrompt: `bad \ud800 surrogate ${"x".repeat(700)}`,
+						},
+					],
+				},
+			],
+		};
+		const out = formatTrajectoryForPrompt(traj);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.includes("\ud800")).toBe(false);
+	});
+
+	test("sweep 595..605 emoji offsets at 600 cap all stay well-formed", () => {
+		const fox = "🦊";
+		for (let n = 595; n <= 605; n++) {
+			const traj: SkillTrajectory = {
+				trajectoryId: `traj-sweep-${n}`,
+				agentId: "agent-1",
+				startTime: Date.now(),
+				steps: [
+					{
+						timestamp: Date.now(),
+						llmCalls: [
+							{
+								userPrompt: `${"a".repeat(n)}${fox}${"b".repeat(50)}`,
+								response: `${"c".repeat(n)}${fox}${"d".repeat(50)}`,
+							},
+						],
+					},
+				],
+			};
+			const out = formatTrajectoryForPrompt(traj);
+			expect(isWellFormed(out)).toBe(true);
+			expect(() => JSON.stringify({ prompt: out })).not.toThrow();
+		}
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.ts
@@ -7,6 +7,10 @@
  * truncated) into the digest fed to the extraction model.
  */
 import type { IAgentRuntime } from "../../../types/index.ts";
+import {
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "../../../utils/well-formed.ts";
 
 export interface SkillTrajectoryLlmCall {
 	systemPrompt?: string;
@@ -111,10 +115,14 @@ export function formatTrajectoryForPrompt(
 			const purpose = call.purpose ?? call.actionType ?? "step";
 			lines.push(`[${purpose}]`);
 			if (call.userPrompt) {
-				lines.push(`USER: ${call.userPrompt.slice(0, 600)}`);
+				lines.push(
+					`USER: ${truncateWellFormed(toWellFormedUnicode(call.userPrompt), 600)}`,
+				);
 			}
 			if (call.response) {
-				lines.push(`AGENT: ${call.response.slice(0, 600)}`);
+				lines.push(
+					`AGENT: ${truncateWellFormed(toWellFormedUnicode(call.response), 600)}`,
+				);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Fix `packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.ts:114,117` (`formatTrajectoryForPrompt` 600) to use `toWellFormedUnicode` + `truncateWellFormed` so trajectory step prompt and response digest formatting never splits an astral surrogate pair (e.g. 🦊) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict extraction models reject.
- Add 5 `isWellFormed()` tests in `packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.surrogate.test.ts`: 599+🦊 backoff at 600, fitting 598+🦊, short prompt/response, lone high sanitization, sweep 595..605 at 600 well-formed.

Same class as approved #23604, #23602, #23599, #23598 — identical `toWellFormedUnicode` → `truncateWellFormed` pattern.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.ts` | Import `toWellFormedUnicode`/`truncateWellFormed` from `../../../utils/well-formed.ts`, sanitize `userPrompt` and `response` with `toWellFormedUnicode` then well-formed truncate at `600` |
| `packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.surrogate.test.ts` | +128 lines — 5 tests: 599+🦊 backoff, fitting, short, lone high, sweep 595..605 at 600 well-formed |

## Verification

- Rebased onto `origin/develop@c276ccf007dd` — zero conflicts
- `bunx biome check` — 2 files clean
- `bunx vitest run packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.surrogate.test.ts --config packages/core/vitest.config.ts` — **5 passed, 0 failed** (1 file)
- `git show HEAD:packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.ts` verifies import + `toWellFormedUnicode` + `truncateWellFormed(..., 600)`

## Evidence Gate

<!-- evidence-head:3d0558d12cd17d72efb9903cca5a37807387e625 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; trajectory evaluator utils are headless core helpers.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; same as before.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior is proven by deterministic surrogate unit tests.

<!-- evidence-row:backend-logs -->
- [x] Real surrogate-aware clamp paths exercised via Vitest:

```log
bunx vitest run packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.surrogate.test.ts --config packages/core/vitest.config.ts
vitest v4.1.10
 Test Files  1 passed (1)
      Tests  5 passed (5)
   Duration  102ms
 5 new isWellFormed() cases: 599+'🦊'→599 backoff at 600, fitting 598+🦊, short, sweep 595..605 at 600 all well-formed
Ran 5 tests across 1 file.
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved; trajectory evaluator runs in core Node runtime.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model delegation change beyond string hygiene.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = surrogate-safe formatted trajectory prompt, proven by 5 deterministic tests:

```log
each test asserts .isWellFormed() === true
boundary 600: "a".repeat(599)+"🦊"+... → 599 (backoff high surrogate at 600) well-formed
fitting 600: "a".repeat(598)+"🦊" → 600 exact, kept intact well-formed
sweep 595..605 at 600: each n+"🦊"+... at 600 → all well-formed
all 5 pass; without fix the 599+🦊 case would emit lone \uD83D and fail isWellFormed()
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface; no OCR text to review.

# Risks

Low — defensive string formatting in trajectory prompt digest (600 limit). Narrow import of helpers standard across core; atomic churn.

# Background

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.ts:10,114,117` (import + 600 clamp) and `packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.surrogate.test.ts` (5 new cases).

## Detailed testing steps

- `bunx vitest run packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.surrogate.test.ts --config packages/core/vitest.config.ts` — expect 5 pass
- `bunx biome check packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.ts packages/core/src/features/advanced-capabilities/evaluators/trajectory-evaluator-utils.surrogate.test.ts` — expect `Checked 2 files … No fixes applied.`

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c276ccf007dd546ada22cc37178a07d3d7c76aed6c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@c276ccf007dd546ada22cc37178a07d3d7c76aed6c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — core]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@c276ccf007dd546ada22cc37178a07d3d7c76aed6c:packages/skills/skills/contribute-to-eliza"} -->
