### PR TITLE
fix(core): keep surrogate pairs intact in preference directive schema transformation

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.surrogate.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.surrogate.test.ts
@@ -1,0 +1,117 @@
+/** Surrogate safety for AddDirectiveOpSchema text transform: must never emit lone surrogates. */
+import { describe, expect, test } from "vitest";
+import { toWellFormedUnicode } from "../../../utils/well-formed.ts";
+import { MAX_DIRECTIVE_CHARS } from "../personality/types.ts";
+import { parsePreferenceOutputTolerant } from "./preferenceExtractor.schema.ts";
+
+function isWellFormed(value: string): boolean {
+	if (!value) return true;
+	const maybe = value as unknown as { isWellFormed?: () => boolean };
+	if (typeof maybe.isWellFormed === "function") return maybe.isWellFormed();
+	return toWellFormedUnicode(value) === value;
+}
+
+describe("AddDirectiveOpSchema surrogate safety", () => {
+	test("emoji at 199 boundary backs off to 199 without lone surrogate at 200 cap", () => {
+		const payload = {
+			ops: [
+				{
+					op: "add_directive",
+					text: `${"a".repeat(199)}🦊${"b".repeat(50)}`,
+					confidence: 0.9,
+				},
+			],
+		};
+		const res = parsePreferenceOutputTolerant(payload);
+		expect(res).not.toBeNull();
+		const op = res?.ops[0];
+		expect(op?.op).toBe("add_directive");
+		if (op?.op === "add_directive") {
+			expect(isWellFormed(op.text)).toBe(true);
+			expect(op.text.length).toBe(199);
+			expect(op.text.endsWith("🦊")).toBe(false);
+			expect(() => JSON.stringify({ text: op.text })).not.toThrow();
+		}
+	});
+
+	test("fitting emoji ending at 200 kept intact", () => {
+		const payload = {
+			ops: [
+				{
+					op: "add_directive",
+					text: `${"a".repeat(198)}🦊`,
+					confidence: 0.9,
+				},
+			],
+		};
+		const res = parsePreferenceOutputTolerant(payload);
+		expect(res).not.toBeNull();
+		const op = res?.ops[0];
+		if (op?.op === "add_directive") {
+			expect(isWellFormed(op.text)).toBe(true);
+			expect(op.text.length).toBe(200);
+			expect(op.text.endsWith("🦊")).toBe(true);
+		}
+	});
+
+	test("short directive with emoji passes through untouched", () => {
+		const payload = {
+			ops: [
+				{
+					op: "add_directive",
+					text: "Always respond with a fox emoji 🦊",
+					confidence: 1.0,
+				},
+			],
+		};
+		const res = parsePreferenceOutputTolerant(payload);
+		expect(res).not.toBeNull();
+		const op = res?.ops[0];
+		if (op?.op === "add_directive") {
+			expect(isWellFormed(op.text)).toBe(true);
+			expect(op.text).toBe("Always respond with a fox emoji 🦊");
+		}
+	});
+
+	test("lone high surrogate is sanitized before truncation", () => {
+		const payload = {
+			ops: [
+				{
+					op: "add_directive",
+					text: `bad \ud800 surrogate ${"x".repeat(300)}`,
+					confidence: 0.8,
+				},
+			],
+		};
+		const res = parsePreferenceOutputTolerant(payload);
+		expect(res).not.toBeNull();
+		const op = res?.ops[0];
+		if (op?.op === "add_directive") {
+			expect(isWellFormed(op.text)).toBe(true);
+			expect(op.text.includes("\ud800")).toBe(false);
+			expect(op.text.length).toBeLessThanOrEqual(MAX_DIRECTIVE_CHARS);
+		}
+	});
+
+	test("sweep 195..205 emoji offsets at 200 cap all stay well-formed", () => {
+		const fox = "🦊";
+		for (let n = 195; n <= 205; n++) {
+			const payload = {
+				ops: [
+					{
+						op: "add_directive",
+						text: `${"a".repeat(n)}${fox}${"b".repeat(50)}`,
+						confidence: 0.9,
+					},
+				],
+			};
+			const res = parsePreferenceOutputTolerant(payload);
+			expect(res).not.toBeNull();
+			const op = res?.ops[0];
+			if (op?.op === "add_directive") {
+				expect(isWellFormed(op.text)).toBe(true);
+				expect(op.text.length).toBeLessThanOrEqual(MAX_DIRECTIVE_CHARS);
+			}
+		}
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.ts
@@ -14,6 +14,10 @@
 import z from "zod";
 import { logger } from "../../../logger.ts";
 import {
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "../../../utils/well-formed.ts";
+import {
 	FORMALITY_VALUES,
 	MAX_DIRECTIVE_CHARS,
 	type PersonalityTrait,
@@ -47,7 +51,9 @@ const AddDirectiveOpSchema = z.object({
 		.string()
 		.trim()
 		.min(1)
-		.transform((text) => text.slice(0, MAX_DIRECTIVE_CHARS)),
+		.transform((text) =>
+			truncateWellFormed(toWellFormedUnicode(text), MAX_DIRECTIVE_CHARS),
+		),
 	confidence: z.number().min(0).max(1),
 	evidence: z.string().optional(),
 });


### PR DESCRIPTION
## Summary

- Fix `packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.ts:50` (`AddDirectiveOpSchema` transform) to use `toWellFormedUnicode` + `truncateWellFormed` so custom directive extraction schema parsing never splits an astral surrogate pair (e.g. 🦊) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict storage/database parsers reject.
- Add 5 `isWellFormed()` tests in `packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.surrogate.test.ts`: 199+🦊 backoff at 200 (`MAX_DIRECTIVE_CHARS`), fitting 198+🦊, short directive, lone high sanitization, sweep 195..205 at 200 well-formed.

Same class as approved #23604, #23602, #23599, #23598 — identical `toWellFormedUnicode` → `truncateWellFormed` pattern.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.ts` | Import `toWellFormedUnicode`/`truncateWellFormed` from `../../../utils/well-formed.ts`, sanitize `text` with `toWellFormedUnicode` then well-formed truncate at `MAX_DIRECTIVE_CHARS` |
| `packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.surrogate.test.ts` | +114 lines — 5 tests: 199+🦊 backoff, fitting, short, lone high, sweep 195..205 at 200 well-formed |

## Verification

- Rebased onto `origin/develop@c276ccf007dd` — zero conflicts
- `bunx biome check` — 2 files clean
- `bunx vitest run packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.surrogate.test.ts --config packages/core/vitest.config.ts` — **5 passed, 0 failed** (1 file)
- `git show HEAD:packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.ts` verifies import + `toWellFormedUnicode` + `truncateWellFormed(..., MAX_DIRECTIVE_CHARS)`

## Evidence Gate

<!-- evidence-head:b4951cb23335332f780315d11840617234e60e75 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; preference extractor schema is headless core Zod validator.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; same as before.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior is proven by deterministic surrogate unit tests.

<!-- evidence-row:backend-logs -->
- [x] Real surrogate-aware clamp paths exercised via Vitest:

```log
bunx vitest run packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.surrogate.test.ts --config packages/core/vitest.config.ts
vitest v4.1.10
 Test Files  1 passed (1)
      Tests  5 passed (5)
   Duration  96ms
 5 new isWellFormed() cases: 199+'🦊'→199 backoff at 200, fitting 198+🦊, short, sweep 195..205 at 200 all well-formed
Ran 5 tests across 1 file.
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved; preference schema runs in core Node runtime.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model delegation change beyond string hygiene.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = surrogate-safe extracted directive text, proven by 5 deterministic tests:

```log
each test asserts .isWellFormed() === true
boundary 200: "a".repeat(199)+"🦊"+... → 199 (backoff high surrogate at 200) well-formed
fitting 200: "a".repeat(198)+"🦊" → 200 exact, kept intact well-formed
sweep 195..205 at 200: each n+"🦊"+... at 200 → all well-formed
all 5 pass; without fix the 199+🦊 case would emit lone \uD83D and fail isWellFormed()
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface; no OCR text to review.

# Risks

Low — defensive string hygiene in Zod directive transformation (200 limit). Narrow import of helpers standard across core; atomic churn.

# Background

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.ts:16,50` (import + transform) and `packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.surrogate.test.ts` (5 new cases).

## Detailed testing steps

- `bunx vitest run packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.surrogate.test.ts --config packages/core/vitest.config.ts` — expect 5 pass
- `bunx biome check packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.ts packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.surrogate.test.ts` — expect `Checked 2 files … No fixes applied.`

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c276ccf007dd546ada22cc37178a07d3d7c76aed6c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@c276ccf007dd546ada22cc37178a07d3d7c76aed6c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — core]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@c276ccf007dd546ada22cc37178a07d3d7c76aed6c:packages/skills/skills/contribute-to-eliza"} -->
