### PR TITLE
fix(personal-assistant): keep surrogate pairs intact in autofill error detail truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/autofill.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/autofill.surrogate.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Surrogate-safe truncation for autofill device-bus error detail (500 cap).
+ * Verifies cap never splits an astral surrogate pair.
+ */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+function truncate500(text: string): string {
+  return truncateWellFormed(toWellFormedUnicode(text), 500);
+}
+
+function isWellFormed(s: string): boolean {
+  const w = s as unknown as { isWellFormed?: () => boolean };
+  if (typeof w.isWellFormed === "function") return w.isWellFormed();
+  return toWellFormedUnicode(s) === s;
+}
+
+describe("autofill surrogate handling", () => {
+  it("500 backs off at surrogate (499+fox->499)", () => {
+    const input = "a".repeat(499) + "🦊" + "b".repeat(50);
+    const out = truncate500(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(500);
+    expect(out.length).toBe(499);
+  });
+
+  it("500 preserves fitting emoji (498+fox intact)", () => {
+    const input = "a".repeat(498) + "🦊";
+    const out = truncate500(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out).toBe("a".repeat(498) + "🦊");
+  });
+
+  it("short detail passes through", () => {
+    const input = "short error detail";
+    const out = truncate500(input);
+    expect(out).toBe(input);
+    expect(isWellFormed(out)).toBe(true);
+  });
+
+  it("sanitizes lone high surrogate", () => {
+    const lone =
+      `error ${String.fromCharCode(0xd800)} details ` + "a".repeat(1000);
+    const out = truncate500(lone);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("�")).toBe(true);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/actions/autofill.ts
+++ b/plugins/plugin-personal-assistant/src/actions/autofill.ts
@@ -14,6 +14,8 @@ import {
   resolveActionArgs,
   type State,
   type SubactionsMap,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import {
   DEFAULT_AUTOFILL_WHITELIST,
@@ -209,7 +211,7 @@ async function dispatchToExtension(
     return {
       dispatched: false,
       via: "device-bus",
-      detail: text.slice(0, 500),
+      detail: truncateWellFormed(toWellFormedUnicode(text), 500),
     };
   }
   return { dispatched: true, via: "device-bus" };


### PR DESCRIPTION
Closes #23639

## Summary
- Fix `plugins/plugin-personal-assistant/src/actions/autofill.ts:212` `text.slice(0,500)` (device-bus error `detail` when `response.ok==false`) to use `toWellFormedUnicode` + `truncateWellFormed` so the 500 cap never splits an astral surrogate pair (e.g. 🦊) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict parsers reject. Lone surrogates sanitized to `�`.
- Preserve budget exactly (500) via `truncateWellFormed(toWellFormedUnicode(text),500)`.
- Same class as merged #23618 (scheduling-handler), #23578 (memories) — identical pattern.

## What Changed
- `plugins/plugin-personal-assistant/src/actions/autofill.ts`: import `toWellFormedUnicode, truncateWellFormed`, 500 detail `truncateWellFormed(toWellFormedUnicode(text),500)`.
- `plugins/plugin-personal-assistant/src/actions/autofill.surrogate.test.ts`: +~49 lines — 4 behavioral `isWellFormed()` tests: 499+🦊→499 backs off, fitting 498+🦊 intact, short, lone `\ud800` sanitized.

## Exact-head evidence
Head: c91cc8fa832389438aab9847b9a7d1108717bd62
Base: origin/develop@3d0558d12cd17d72efb9903cca5a37807387e625 with zero conflicts

## Verification / Definition of Done
- [x] Targets develop, rebased onto origin/develop@3d0558d12c zero conflicts
- [x] `bun install --frozen-lockfile` clean
- [x] `bunx biome check plugins/plugin-personal-assistant/src/actions/autofill.ts plugins/plugin-personal-assistant/src/actions/autofill.surrogate.test.ts` — no errors
- [x] `bunx vitest run plugins/plugin-personal-assistant/src/actions/autofill.surrogate.test.ts --reporter=verbose` — **4 passed, 0 failed**
- [x] `git diff --check` — no whitespace errors
- [x] Reviewer can confirm: `truncate500("a".repeat(499)+"🦊"+"b...")` → 499 well-formed; `truncate500("a".repeat(498)+"🦊")` intact

## Evidence Gate

<!-- evidence-head:c91cc8fa832389438aab9847b9a7d1108717bd62 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; device-bus error detail is headless.

<!-- evidence-row:console-logs -->
- [x] N/A - `bunx vitest run` passes (4/4); no runtime console capture needed.

<!-- evidence-row:unit-tests -->
- [x] `bunx vitest run plugins/plugin-personal-assistant/src/actions/autofill.surrogate.test.ts --reporter=verbose` — 4 passed

<!-- evidence-row:static-analysis -->
- [x] `bunx biome check` — no errors

<!-- evidence-row:edge-cases -->
- [x] Backs off on high surrogate at 499, preserves fitting emoji, sanitizes lone surrogate to `�`.

<!-- evidence-row:trajectory -->
- [x] N/A - not an agent trajectory change.

<!-- evidence-row:docs -->
- [x] N/A - bug fix, no docs change.

## Risks
Low. Isolated to device-bus error detail truncation; preserves 500 cap, no behavioral change for well-formed text.

## Provenance
- Base: `elizaOS/eliza@3d0558d12c:packages/skills/skills/contribute-to-eliza`
- Head: `c91cc8fa83`

