### PR TITLE
fix(personal-assistant): keep surrogate pairs intact in google plugin delegates snippet truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.surrogate.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Surrogate-safe truncation for google-plugin-delegates snippet (240 cap).
+ * Verifies cap never splits an astral surrogate pair.
+ */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+function truncate240(bodyText: string | undefined): string {
+  return bodyText ? truncateWellFormed(toWellFormedUnicode(bodyText), 240) : "";
+}
+
+function isWellFormed(s: string): boolean {
+  const w = s as unknown as { isWellFormed?: () => boolean };
+  if (typeof w.isWellFormed === "function") return w.isWellFormed();
+  return toWellFormedUnicode(s) === s;
+}
+
+describe("google-plugin-delegates snippet surrogate handling", () => {
+  it("240 backs off at surrogate (239+fox->239)", () => {
+    const input = "a".repeat(239) + "🦊" + "b".repeat(50);
+    const out = truncate240(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(240);
+    expect(out.length).toBe(239);
+  });
+
+  it("240 preserves fitting emoji (238+fox intact)", () => {
+    const input = "a".repeat(238) + "🦊";
+    const out = truncate240(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out).toBe("a".repeat(238) + "🦊");
+  });
+
+  it("short bodyText passes through", () => {
+    const input = "short body";
+    const out = truncate240(input);
+    expect(out).toBe(input);
+    expect(isWellFormed(out)).toBe(true);
+  });
+
+  it("sanitizes lone high surrogate", () => {
+    const lone = `body ${String.fromCharCode(0xd800)} text ` + "a".repeat(500);
+    const out = truncate240(lone);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("�")).toBe(true);
+  });
+
+  it("undefined bodyText returns empty", () => {
+    expect(truncate240(undefined)).toBe("");
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.ts
@@ -9,6 +9,8 @@ import {
   getConnectorAccountManager,
   type IAgentRuntime,
   type Metadata,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import type {
   GoogleDriveFile,
@@ -493,7 +495,11 @@ export function lifeOpsGmailMessageFromGoogle(args: {
     replyTo: message.replyTo?.email ?? null,
     to: (message.to ?? []).map((item: GoogleEmailAddress) => item.email),
     cc: (message.cc ?? []).map((item: GoogleEmailAddress) => item.email),
-    snippet: message.snippet ?? message.bodyText?.slice(0, 240) ?? "",
+    snippet:
+      message.snippet ??
+      (message.bodyText
+        ? truncateWellFormed(toWellFormedUnicode(message.bodyText), 240)
+        : ""),
     receivedAt,
     isUnread: labels.includes("UNREAD"),
     isImportant: labels.includes("IMPORTANT"),


### PR DESCRIPTION
Closes #23642

## Summary
- Fix `plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.ts:496` `message.bodyText?.slice(0,240)` fallback for Gmail snippet to use `toWellFormedUnicode` + `truncateWellFormed` so the 240 cap never splits an astral surrogate pair (e.g. 🦊) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict parsers reject. Lone surrogates sanitized to `�`.
- Preserve budget exactly (240) via `truncateWellFormed(toWellFormedUnicode(message.bodyText),240)` when `bodyText` exists, else `""`.
- Same class as merged #23618 (scheduling-handler), #23630 (bill-extraction), #23632 (household) and open #23640 (autofill) — identical pattern.

## What Changed
- `plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.ts`: import `toWellFormedUnicode, truncateWellFormed`, 240 snippet `truncateWellFormed(toWellFormedUnicode(message.bodyText),240)` when bodyText present.
- `plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.surrogate.test.ts`: +~52 lines — 5 behavioral `isWellFormed()` tests: 239+🦊→239 backs off, fitting 238+🦊 intact, short, lone `\ud800` sanitized, undefined→"".

## Exact-head evidence
Head: a8ecf577b3b5465e2a41190b95218ca0f7b53b54
Base: origin/develop@3d0558d12cd17d72efb9903cca5a37807387e625 with zero conflicts

## Verification / Definition of Done
- [x] Targets develop, rebased onto origin/develop@3d0558d12c zero conflicts
- [x] `bun install --frozen-lockfile` clean
- [x] `bunx biome check plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.ts plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.surrogate.test.ts` — no errors
- [x] `bunx vitest run plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.surrogate.test.ts --reporter=verbose` — **5 passed, 0 failed**
- [x] `git diff --check` — no whitespace errors
- [x] Reviewer can confirm: `truncate240("a".repeat(239)+"🦊"+"b...")` → 239 well-formed; `truncate240("a".repeat(238)+"🦊")` intact

## Evidence Gate

<!-- evidence-head:a8ecf577b3b5465e2a41190b95218ca0f7b53b54 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; Gmail snippet delegation is headless.

<!-- evidence-row:console-logs -->
- [x] N/A - `bunx vitest run` passes (5/5); no runtime console capture needed.

<!-- evidence-row:unit-tests -->
- [x] `bunx vitest run plugins/plugin-personal-assistant/src/lifeops/google-plugin-delegates.surrogate.test.ts --reporter=verbose` — 5 passed

<!-- evidence-row:static-analysis -->
- [x] `bunx biome check` — no errors

<!-- evidence-row:edge-cases -->
- [x] Backs off on high surrogate at 239, preserves fitting emoji, sanitizes lone surrogate to `�`, undefined→"".

<!-- evidence-row:trajectory -->
- [x] N/A - not an agent trajectory change.

<!-- evidence-row:docs -->
- [x] N/A - bug fix, no docs change.

## Risks
Low. Isolated to Gmail snippet fallback truncation; preserves 240 cap, no behavioral change for well-formed text.

## Provenance
- Base: `elizaOS/eliza@3d0558d12c:packages/skills/skills/contribute-to-eliza`
- Head: `a8ecf577b3`

