### PR TITLE
fix(personal-assistant): keep surrogate pairs intact in cross-channel context truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/providers/cross-channel-context.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/providers/cross-channel-context.surrogate.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Surrogate-safe truncation for cross-channel-context provider (180 cap).
+ * Verifies cap never splits an astral surrogate pair.
+ */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+function truncate180(hitText: string): string {
+  return truncateWellFormed(
+    toWellFormedUnicode(hitText.replace(/\s+/g, " ").trim()),
+    180,
+  );
+}
+
+function isWellFormed(s: string): boolean {
+  const w = s as unknown as { isWellFormed?: () => boolean };
+  if (typeof w.isWellFormed === "function") return w.isWellFormed();
+  return toWellFormedUnicode(s) === s;
+}
+
+describe("cross-channel-context surrogate handling", () => {
+  it("180 backs off at surrogate (179+fox->179)", () => {
+    const input = "a".repeat(179) + "🦊" + "b".repeat(50);
+    const out = truncate180(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(180);
+    expect(out.length).toBe(179);
+  });
+
+  it("180 preserves fitting emoji (178+fox intact)", () => {
+    const input = "a".repeat(178) + "🦊";
+    const out = truncate180(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out).toBe("a".repeat(178) + "🦊");
+  });
+
+  it("trims and normalizes whitespace before truncation", () => {
+    const input = "  hello   world  ";
+    const out = truncate180(input);
+    expect(out).toBe("hello world");
+  });
+
+  it("sanitizes lone high surrogate", () => {
+    const lone =
+      `text ${String.fromCharCode(0xd800)} content ` + "a".repeat(500);
+    const out = truncate180(lone);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("�")).toBe(true);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/providers/cross-channel-context.ts
+++ b/plugins/plugin-personal-assistant/src/providers/cross-channel-context.ts
@@ -24,6 +24,7 @@ import type {
   State,
   UUID,
 } from "@elizaos/core";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   CROSS_CHANNEL_SEARCH_CHANNELS,
   type CrossChannelSearchChannel,
@@ -155,7 +156,10 @@ function compactHit(
     speaker: hit.speaker,
     ...(hit.subject ? { subject: hit.subject } : {}),
     text: redactTextForEgress(
-      hit.text.replace(/\s+/g, " ").trim().slice(0, 180),
+      truncateWellFormed(
+        toWellFormedUnicode(hit.text.replace(/\s+/g, " ").trim()),
+        180,
+      ),
       {
         context: egressContext,
         dataClass: "body",


### PR DESCRIPTION
Closes #23645

## Summary
- Fix `plugins/plugin-personal-assistant/src/providers/cross-channel-context.ts:158` `hit.text.replace(/\s+/g," ").trim().slice(0,180)` (injected into LLM context before egress redaction) to use `toWellFormedUnicode` + `truncateWellFormed` so the 180 cap never splits an astral surrogate pair (e.g. 🦊) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict parsers reject. Lone surrogates sanitized to `�`.
- Preserve budget exactly (180) via `truncateWellFormed(toWellFormedUnicode(hit.text.replace(/\s+/g," ").trim()),180)`.
- Same class as merged #23618 (scheduling-handler), #23630 (bill-extraction), #23632 (household) and open #23640 (autofill), #23643 (google-delegates) — identical pattern.

## What Changed
- `plugins/plugin-personal-assistant/src/providers/cross-channel-context.ts`: import `toWellFormedUnicode, truncateWellFormed`, 180 hit text `truncateWellFormed(toWellFormedUnicode(hit.text.replace(/\s+/g," ").trim()),180)`.
- `plugins/plugin-personal-assistant/src/providers/cross-channel-context.surrogate.test.ts`: +~51 lines — 4 behavioral `isWellFormed()` tests: 179+🦊→179 backs off, fitting 178+🦊 intact, whitespace normalization, lone `\ud800` sanitized.

## Exact-head evidence
Head: 0ebce9be13e8a7c2c9d3200bceeb6fa23a2063a4
Base: origin/develop@3d0558d12cd17d72efb9903cca5a37807387e625 with zero conflicts

## Verification / Definition of Done
- [x] Targets develop, rebased onto origin/develop@3d0558d12c zero conflicts
- [x] `bun install --frozen-lockfile` clean
- [x] `bunx biome check plugins/plugin-personal-assistant/src/providers/cross-channel-context.ts plugins/plugin-personal-assistant/src/providers/cross-channel-context.surrogate.test.ts` — no errors
- [x] `bunx vitest run plugins/plugin-personal-assistant/src/providers/cross-channel-context.surrogate.test.ts --reporter=verbose` — **4 passed, 0 failed**
- [x] `git diff --check` — no whitespace errors
- [x] Reviewer can confirm: `truncate180("a".repeat(179)+"🦊"+"b...")` → 179 well-formed; `truncate180("a".repeat(178)+"🦊")` intact

## Evidence Gate

<!-- evidence-head:0ebce9be13e8a7c2c9d3200bceeb6fa23a2063a4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; cross-channel context provider is headless.

<!-- evidence-row:console-logs -->
- [x] N/A - `bunx vitest run` passes (4/4); no runtime console capture needed.

<!-- evidence-row:unit-tests -->
- [x] `bunx vitest run plugins/plugin-personal-assistant/src/providers/cross-channel-context.surrogate.test.ts --reporter=verbose` — 4 passed

<!-- evidence-row:static-analysis -->
- [x] `bunx biome check` — no errors

<!-- evidence-row:edge-cases -->
- [x] Backs off on high surrogate at 179, preserves fitting emoji, whitespace normalization, sanitizes lone surrogate to `�`.

<!-- evidence-row:trajectory -->
- [x] N/A - not an agent trajectory change.

<!-- evidence-row:docs -->
- [x] N/A - bug fix, no docs change.

## Risks
Low. Isolated to cross-channel hit text truncation (180); preserves budget, no behavioral change for well-formed text.

## Provenance
- Base: `elizaOS/eliza@3d0558d12c:packages/skills/skills/contribute-to-eliza`
- Head: `0ebce9be13`

