### PR TITLE
fix(personal-assistant): keep surrogate pairs intact in website block candidate truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/website-block.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/website-block.surrogate.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Surrogate-safe truncation for website-block candidate normalization (1024 cap).
+ * Verifies cap never splits an astral surrogate pair.
+ */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+function truncate1024(item: string): string {
+  return truncateWellFormed(toWellFormedUnicode(item.trim()), 1024);
+}
+
+function isWellFormed(s: string): boolean {
+  const w = s as unknown as { isWellFormed?: () => boolean };
+  if (typeof w.isWellFormed === "function") return w.isWellFormed();
+  return toWellFormedUnicode(s) === s;
+}
+
+describe("website-block surrogate handling", () => {
+  it("1024 backs off at surrogate (1023+fox->1023)", () => {
+    const input = "a".repeat(1023) + "🦊" + "b".repeat(50);
+    const out = truncate1024(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(1024);
+    expect(out.length).toBe(1023);
+  });
+
+  it("1024 preserves fitting emoji (1022+fox intact)", () => {
+    const input = "a".repeat(1022) + "🦊";
+    const out = truncate1024(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out).toBe("a".repeat(1022) + "🦊");
+  });
+
+  it("trims before truncation", () => {
+    const input = "  hello world  ";
+    const out = truncate1024(input);
+    expect(out).toBe("hello world");
+  });
+
+  it("sanitizes lone high surrogate", () => {
+    const lone =
+      `site ${String.fromCharCode(0xd800)} example ` + "a".repeat(2000);
+    const out = truncate1024(lone);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("�")).toBe(true);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/actions/website-block.ts
+++ b/plugins/plugin-personal-assistant/src/actions/website-block.ts
@@ -18,6 +18,8 @@ import {
   resolveActionArgs,
   runWithTrajectoryPurpose,
   type SubactionsMap,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import {
   formatWebsiteList,
@@ -169,7 +171,9 @@ function normalizeWebsiteCandidates(value: unknown): string[] {
     ...new Set(
       values
         .filter((item): item is string => typeof item === "string")
-        .map((item) => item.trim().slice(0, 1024))
+        .map((item) =>
+          truncateWellFormed(toWellFormedUnicode(item.trim()), 1024),
+        )
         .map((item) => item.replace(/^[[\]'"]{1,32}|[[\]'"]{1,32}$/g, ""))
         .filter((item) => item.length > 0),
     ),


### PR DESCRIPTION
Closes #23650

## Summary
- Fix `plugins/plugin-personal-assistant/src/actions/website-block.ts:172` `item.trim().slice(0,1024)` (website block candidate normalization before set dedup) to use `toWellFormedUnicode` + `truncateWellFormed` so the 1024 cap never splits an astral surrogate pair (e.g. 🦊) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict parsers reject. Lone surrogates sanitized to `�`.
- Preserve budget exactly (1024) via `truncateWellFormed(toWellFormedUnicode(item.trim()),1024)`.
- Same class as merged #23640 (autofill 500), #23643 (google-delegates 240), #23647 (cross-channel 180) — identical pattern.

## What Changed
- `plugins/plugin-personal-assistant/src/actions/website-block.ts`: import `toWellFormedUnicode, truncateWellFormed`, 1024 candidate `truncateWellFormed(toWellFormedUnicode(item.trim()),1024)`.
- `plugins/plugin-personal-assistant/src/actions/website-block.surrogate.test.ts`: +~48 lines — 4 behavioral `isWellFormed()` tests: 1023+🦊→1023 backs off, fitting 1022+🦊 intact, trim, lone `\ud800` sanitized.

## Exact-head evidence
Head: 727a4a340844934d404e018e46280e46eeb7f6e5
Base: origin/develop@3d0558d12cd17d72efb9903cca5a37807387e625 with zero conflicts

## Verification / Definition of Done
- [x] Targets develop, rebased onto origin/develop@3d0558d12c zero conflicts
- [x] `bun install --frozen-lockfile` clean
- [x] `bunx biome check plugins/plugin-personal-assistant/src/actions/website-block.ts plugins/plugin-personal-assistant/src/actions/website-block.surrogate.test.ts` — no errors
- [x] `bunx vitest run plugins/plugin-personal-assistant/src/actions/website-block.surrogate.test.ts --reporter=verbose` — **4 passed, 0 failed**
- [x] `git diff --check` — no whitespace errors
- [x] Reviewer can confirm: `truncate1024("a".repeat(1023)+"🦊"+"b...")` → 1023 well-formed; `truncate1024("a".repeat(1022)+"🦊")` intact

## Evidence Gate

<!-- evidence-head:727a4a340844934d404e018e46280e46eeb7f6e5 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; website block candidate is headless.

<!-- evidence-row:console-logs -->
- [x] N/A - `bunx vitest run` passes (4/4); no runtime console capture needed.

<!-- evidence-row:unit-tests -->
- [x] `bunx vitest run plugins/plugin-personal-assistant/src/actions/website-block.surrogate.test.ts --reporter=verbose` — 4 passed

<!-- evidence-row:static-analysis -->
- [x] `bunx biome check` — no errors

<!-- evidence-row:edge-cases -->
- [x] Backs off on high surrogate at 1023, preserves fitting emoji, trim, sanitizes lone surrogate to `�`.

<!-- evidence-row:trajectory -->
- [x] N/A - not an agent trajectory change.

<!-- evidence-row:docs -->
- [x] N/A - bug fix, no docs change.

## Risks
Low. Isolated to website block candidate truncation (1024); preserves budget, no behavioral change for well-formed text.

## Provenance
- Base: `elizaOS/eliza@3d0558d12c:packages/skills/skills/contribute-to-eliza`
- Head: `727a4a3408`

