### PR TITLE
fix(cloud): bound Reddit REST hops in the social-media provider

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/providers/reddit.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/reddit.error-policy.test.ts
@@ -37,7 +37,7 @@ mock.module("../rate-limit", () => ({
   isRateLimitResponse: (r: Response) => r.status === 429,
 }));
 
-const { redditProvider } = await import("./reddit");
+const { redditProvider, redditFetch } = await import("./reddit");
 
 const creds = {
   apiKey: "client-id",
@@ -150,5 +150,38 @@ describe("redditProvider.getAccountAnalytics — fail closed", () => {
 
     const err = await rejects(redditProvider.getAccountAnalytics!(creds));
     expect(err.message).toContain("503");
+  });
+});
+
+describe("redditFetch — bounded hops fail closed and keep caller signals", () => {
+  test("aborts a hung Reddit API hop at the timeout", async () => {
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as typeof fetch;
+
+    const start = Date.now();
+    await expect(redditFetch("https://oauth.reddit.com/api/v1/me", undefined, 100)).rejects.toThrow(
+      /aborted/i,
+    );
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("preserves a caller-provided abort signal", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen = init?.signal;
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const controller = new AbortController();
+    await redditFetch("https://oauth.reddit.com/api/v1/me", {
+      signal: controller.signal,
+    });
+    expect(seen).toBe(controller.signal);
   });
 });

--- a/packages/cloud/shared/src/lib/services/social-media/providers/reddit.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/reddit.ts
@@ -18,6 +18,23 @@ import { withRetry } from "../rate-limit";
 const REDDIT_API_BASE = "https://oauth.reddit.com";
 const REDDIT_AUTH_BASE = "https://www.reddit.com/api/v1";
 
+const REDDIT_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Bound every Reddit REST hop so a hung or rate-limited API cannot pin the
+ * publishing worker indefinitely. A caller-provided abort signal wins.
+ */
+export function redditFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = REDDIT_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
+
 interface RedditToken {
   access_token: string;
   token_type: string;
@@ -55,7 +72,7 @@ async function getAccessToken(
 
   const { data } = await withRetry<RedditToken>(
     () =>
-      fetch(`${REDDIT_AUTH_BASE}/access_token`, {
+      redditFetch(`${REDDIT_AUTH_BASE}/access_token`, {
         method: "POST",
         headers: {
           Authorization: `Basic ${auth}`,
@@ -91,7 +108,7 @@ async function redditApiRequest<T>(
 
   const { data } = await withRetry<T>(
     () =>
-      fetch(url, {
+      redditFetch(url, {
         ...options,
         headers: {
           Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
## Problem

Every Reddit fetch had **no timeout**: the OAuth access-token call and the API request helper could pin the publishing worker forever when the API hung without closing the connection.

## Fix

- Add `redditFetch(input, init, timeoutMs = 30_000)`: fails closed at a **30s hop timeout**, preserving any caller-provided abort signal.
- Route both fetch sites through it.

## Tests

`reddit.error-policy.test.ts` (8 pass): new hung-hop abort test (100ms timeout, elapsed < 5s) + caller-signal preservation test; existing error-policy tests still pass.

```bash
bun test --isolate src/lib/services/social-media/providers/reddit.error-policy.test.ts
# 8 pass, 0 fail
```