### PR TITLE
fix(app): serve sitemap/robots and fail closed for unknown crawl endpoints

### DIFF
--- a/packages/app/functions/_middleware.ts
+++ b/packages/app/functions/_middleware.ts
@@ -30,6 +30,9 @@
 //   an edge-cached .js response has its browser TTL rewritten to the zone
 //   default (max-age=14400), which would delay SW update propagation by hours.
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import {
   canonicalCloudPathForLegacyDashboard,
   LANDING_AB_HOSTNAMES,
@@ -230,6 +233,48 @@ export const onRequest = async (
 
   if (url.pathname.startsWith(ASSETS_PREFIX)) {
     return serveAsset(context);
+  }
+
+  if (url.pathname === "/sitemap.xml" || url.pathname === "/robots.txt") {
+    const publicDir = join(
+      import.meta.dirname,
+      "..",
+      "public",
+    );
+    const fileName = url.pathname === "/sitemap.xml"
+      ? "sitemap.xml"
+      : "robots.txt";
+    try {
+      const body = readFileSync(join(publicDir, fileName), "utf8");
+      const contentType = fileName === "sitemap.xml"
+        ? "application/xml; charset=utf-8"
+        : "text/plain; charset=utf-8";
+      return new Response(body, {
+        status: 200,
+        headers: {
+          "Content-Type": contentType,
+          "Cache-Control": "no-cache",
+          "X-Content-Type-Options": "nosniff",
+        },
+      });
+    } catch {
+      // Fall through to SPA if the file is missing
+    }
+  }
+
+  if (
+    !isProtocolPath(url.pathname) &&
+    !url.pathname.startsWith(ASSETS_PREFIX) &&
+    (url.pathname.endsWith(".xml") || url.pathname.endsWith(".txt"))
+  ) {
+    return new Response("Not Found", {
+      status: 404,
+      headers: {
+        "Cache-Control": "no-store",
+        "Content-Type": "text/plain; charset=utf-8",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
   }
 
   const response = await context.next();

--- a/packages/app/functions/_middleware.ts
+++ b/packages/app/functions/_middleware.ts
@@ -30,14 +30,11 @@
 //   an edge-cached .js response has its browser TTL rewritten to the zone
 //   default (max-age=14400), which would delay SW update propagation by hours.
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-
 import {
   canonicalCloudPathForLegacyDashboard,
-  LANDING_AB_HOSTNAMES,
   classifyElizaHostname,
   ELIZA_DOMAIN_CONTRACTS,
+  LANDING_AB_HOSTNAMES,
 } from "@elizaos/shared/elizacloud/domain-contract";
 import { type PagesProxyEnv, proxyToApiWorker } from "./_proxy";
 
@@ -161,6 +158,46 @@ const serveAsset = async (context: MiddlewareContext): Promise<Response> => {
     : response;
 };
 
+// robots.txt and sitemap.xml ship as ordinary files in `public/`, so the Pages
+// static layer already serves their bytes through next(). The middleware only
+// has to keep them out of the fail-closed .txt/.xml 404 below and pin the
+// content type, because a crawler that receives the SPA's text/html for
+// robots.txt treats the whole site as uncrawlable. Reading the file off disk
+// here is not an option: Pages Functions run in workerd with no filesystem and
+// no nodejs_compat flag on this project, so a `node:fs` import fails to
+// resolve at deploy time.
+const CRAWL_ASSET_CONTENT_TYPES = new Map([
+  ["/robots.txt", "text/plain; charset=utf-8"],
+  ["/sitemap.xml", "application/xml; charset=utf-8"],
+]);
+
+const serveCrawlAsset = async (
+  context: MiddlewareContext,
+  contentType: string,
+): Promise<Response> => {
+  const response = await context.next();
+
+  // A static miss falls through to index.html. Serving that as robots.txt
+  // would advertise an HTML document as the crawl policy, so it fails closed
+  // and is loud enough to notice in Cloudflare's status metrics.
+  if (isSpaFallback(response) || !response.ok) {
+    return new Response("Not Found", {
+      status: 404,
+      headers: {
+        "Cache-Control": "no-store",
+        "Content-Type": "text/plain; charset=utf-8",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  }
+
+  const headers = new Headers(response.headers);
+  headers.set("Content-Type", contentType);
+  headers.set("Cache-Control", "no-cache");
+  headers.set("X-Content-Type-Options", "nosniff");
+  return new Response(response.body, { status: response.status, headers });
+};
+
 // The hosted-web SPA is embedded inside the Discord Activities and Telegram
 // Mini App iframes. The global `public/_headers` rule pins every response to
 // `X-Frame-Options: SAMEORIGIN` + CSP `frame-ancestors 'self'`, which denies
@@ -235,31 +272,11 @@ export const onRequest = async (
     return serveAsset(context);
   }
 
-  if (url.pathname === "/sitemap.xml" || url.pathname === "/robots.txt") {
-    const publicDir = join(
-      import.meta.dirname,
-      "..",
-      "public",
-    );
-    const fileName = url.pathname === "/sitemap.xml"
-      ? "sitemap.xml"
-      : "robots.txt";
-    try {
-      const body = readFileSync(join(publicDir, fileName), "utf8");
-      const contentType = fileName === "sitemap.xml"
-        ? "application/xml; charset=utf-8"
-        : "text/plain; charset=utf-8";
-      return new Response(body, {
-        status: 200,
-        headers: {
-          "Content-Type": contentType,
-          "Cache-Control": "no-cache",
-          "X-Content-Type-Options": "nosniff",
-        },
-      });
-    } catch {
-      // Fall through to SPA if the file is missing
-    }
+  // A single lookup decides both that this is a crawl asset and what type it
+  // must be served as, so the two can never drift apart.
+  const crawlAssetContentType = CRAWL_ASSET_CONTENT_TYPES.get(url.pathname);
+  if (crawlAssetContentType !== undefined) {
+    return serveCrawlAsset(context, crawlAssetContentType);
   }
 
   if (

--- a/packages/app/public/robots.txt
+++ b/packages/app/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /steward/
+Disallow: /.well-known/
+Disallow: /embed/
+Sitemap: https://eliza.app/sitemap.xml

--- a/packages/app/public/sitemap.xml
+++ b/packages/app/public/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://eliza.app/</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://eliza.app/downloads</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/packages/app/test/pages-middleware-serving.test.ts
+++ b/packages/app/test/pages-middleware-serving.test.ts
@@ -362,6 +362,76 @@ describe("unified host migration", () => {
     expect(response.status).toBe(503);
     expect(response.headers.get("Cache-Control")).toBe("no-store");
   });
+
+  it("serves static robots.txt with no-store cache and text/plain type", async () => {
+    const publicDir = join(import.meta.dirname, "..", "public");
+    writeFileSync(
+      join(publicDir, "robots.txt"),
+      "User-agent: *\nDisallow: /api/\nSitemap: https://eliza.app/sitemap.xml\n",
+      "utf8",
+    );
+
+    const response = await run(
+      new Request(`${ORIGIN}/robots.txt`),
+      async () => spaFallback(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/plain; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe("no-cache");
+    expect(await response.text()).toContain("Sitemap:");
+  });
+
+  it("serves static sitemap.xml with no-store cache and application/xml type", async () => {
+    const publicDir = join(import.meta.dirname, "..", "public");
+    writeFileSync(
+      join(publicDir, "sitemap.xml"),
+      '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>',
+      "utf8",
+    );
+
+    const response = await run(
+      new Request(`${ORIGIN}/sitemap.xml`),
+      async () => spaFallback(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "application/xml; charset=utf-8",
+    );
+    expect(response.headers.get("Cache-Control")).toBe("no-cache");
+    expect(await response.text()).toContain("<urlset");
+  });
+
+  it("returns 404 for unknown crawl endpoints instead of SPA HTML", async () => {
+    const response = await run(
+      new Request(`${ORIGIN}/bogus-crawl-endpoint.xml`),
+      async () => spaFallback(),
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/plain; charset=utf-8",
+    );
+    expect(await response.text()).toBe("Not Found");
+  });
+
+  it("returns 404 for unknown crawl .txt endpoints instead of SPA HTML", async () => {
+    const response = await run(
+      new Request(`${ORIGIN}/random-note.txt`),
+      async () => spaFallback(),
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/plain; charset=utf-8",
+    );
+    expect(await response.text()).toBe("Not Found");
+  });
 });
 
 describe("pages config files stay within Cloudflare Pages semantics", () => {

--- a/packages/app/test/pages-middleware-serving.test.ts
+++ b/packages/app/test/pages-middleware-serving.test.ts
@@ -33,6 +33,22 @@ const spaFallback = () =>
     },
   });
 
+// The Pages static layer serves `public/` bytes through next(); these tests
+// read the committed files and hand them back the way Cloudflare would, so the
+// assertions cover the real shipped robots/sitemap content without the suite
+// ever writing into the repository's public directory.
+const readPublicFile = (name: string): string =>
+  readFileSync(join(import.meta.dirname, "..", "public", name), "utf8");
+
+const staticFile = (body: string, contentType: string) =>
+  new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control": "public, max-age=14400",
+    },
+  });
+
 const assetHit = () =>
   new Response("export const chunk = 1;", {
     status: 200,
@@ -363,17 +379,9 @@ describe("unified host migration", () => {
     expect(response.headers.get("Cache-Control")).toBe("no-store");
   });
 
-  it("serves static robots.txt with no-store cache and text/plain type", async () => {
-    const publicDir = join(import.meta.dirname, "..", "public");
-    writeFileSync(
-      join(publicDir, "robots.txt"),
-      "User-agent: *\nDisallow: /api/\nSitemap: https://eliza.app/sitemap.xml\n",
-      "utf8",
-    );
-
-    const response = await run(
-      new Request(`${ORIGIN}/robots.txt`),
-      async () => spaFallback(),
+  it("serves the static robots.txt bytes with a pinned text/plain type", async () => {
+    const response = await run(new Request(`${ORIGIN}/robots.txt`), async () =>
+      staticFile(readPublicFile("robots.txt"), "text/plain"),
     );
 
     expect(response.status).toBe(200);
@@ -381,20 +389,13 @@ describe("unified host migration", () => {
       "text/plain; charset=utf-8",
     );
     expect(response.headers.get("Cache-Control")).toBe("no-cache");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(await response.text()).toContain("Sitemap:");
   });
 
-  it("serves static sitemap.xml with no-store cache and application/xml type", async () => {
-    const publicDir = join(import.meta.dirname, "..", "public");
-    writeFileSync(
-      join(publicDir, "sitemap.xml"),
-      '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>',
-      "utf8",
-    );
-
-    const response = await run(
-      new Request(`${ORIGIN}/sitemap.xml`),
-      async () => spaFallback(),
+  it("serves the static sitemap.xml bytes with a pinned xml type", async () => {
+    const response = await run(new Request(`${ORIGIN}/sitemap.xml`), async () =>
+      staticFile(readPublicFile("sitemap.xml"), "application/xml"),
     );
 
     expect(response.status).toBe(200);
@@ -403,6 +404,31 @@ describe("unified host migration", () => {
     );
     expect(response.headers.get("Cache-Control")).toBe("no-cache");
     expect(await response.text()).toContain("<urlset");
+  });
+
+  // A crawler that gets index.html for robots.txt reads it as a parse failure
+  // and falls back to crawling everything, so a missing file must 404 rather
+  // than pass the SPA shell through.
+  it("fails closed when the static layer misses robots.txt", async () => {
+    const response = await run(new Request(`${ORIGIN}/robots.txt`), async () =>
+      spaFallback(),
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/plain; charset=utf-8",
+    );
+    expect(await response.text()).toBe("Not Found");
+  });
+
+  it("fails closed when the static layer misses sitemap.xml", async () => {
+    const response = await run(new Request(`${ORIGIN}/sitemap.xml`), async () =>
+      spaFallback(),
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
   });
 
   it("returns 404 for unknown crawl endpoints instead of SPA HTML", async () => {


### PR DESCRIPTION
Closes #23476

Previously unknown `.xml`/`.txt` crawl endpoints returned SPA HTML. This branch adds explicit static serving for `sitemap.xml` and `robots.txt`, plus a fail-closed 404 for unknown crawl paths.

- `packages/app/public/sitemap.xml`
- `packages/app/public/robots.txt`
- `packages/app/functions/_middleware.ts`: host-agnostic static serving
- `packages/app/test/pages-middleware-serving.test.ts`: coverage for robots, sitemap, and 404 behavior