### PR TITLE
fix(core): index empty string fields as zero-length BM25 docs

### DIFF
--- a/packages/core/src/__tests__/runtime-rerank-memories.test.ts
+++ b/packages/core/src/__tests__/runtime-rerank-memories.test.ts
@@ -34,4 +34,21 @@ describe("AgentRuntime.rerankMemories", () => {
 
 		expect(reranked).toEqual([keywordMatch, semanticOnly, attachmentOnly]);
 	});
+
+	it("does not throw when an attachment-only memory carries an empty text field", async () => {
+		const runtime = new AgentRuntime({
+			character: { name: "rerank-memory-test" } as Character,
+		});
+
+		const keywordMatch = memory("keyword-match", "automobile purchase receipt");
+		const emptyText = memory("empty-text", "");
+
+		const reranked = await runtime.rerankMemories("automobile purchase", [
+			keywordMatch,
+			emptyText,
+		]);
+
+		expect(reranked[0]).toBe(keywordMatch);
+		expect(reranked).toContain(emptyText);
+	});
 });

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -103,3 +103,29 @@ describe("BM25.search result ordering", () => {
 		expect(results[0].score).toBe(results[1].score);
 	});
 });
+
+describe("BM25 empty string fields", () => {
+	// Attachment-only memories carry `content.text === ""` into rerankMemories;
+	// the tokenizer rejects falsy input, so empty fields must index as
+	// zero-length docs instead of aborting the whole index build.
+	const docs = [
+		{ title: "11111111-1111-4111-8111-111111111111", content: "" },
+		{ title: "22222222-2222-4222-8222-222222222222", content: "hello world" },
+	];
+
+	it("indexes documents containing empty string fields without throwing", () => {
+		const bm25 = new BM25(docs);
+		expect(bm25.search("hello", 10).map((r) => r.index)).toEqual([1]);
+	});
+
+	it("treats whitespace-only fields as zero-length documents", () => {
+		const bm25 = new BM25([{ content: "   " }, { content: "signal" }]);
+		expect(bm25.search("signal", 10).map((r) => r.index)).toEqual([1]);
+	});
+
+	it("accepts incremental addDocument with empty string fields", async () => {
+		const bm25 = new BM25([{ content: "seed document" }]);
+		await bm25.addDocument({ content: "", body: "later arrival" });
+		expect(bm25.search("arrival", 10).map((r) => r.index)).toEqual([1]);
+	});
+});

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -1221,7 +1221,7 @@ export class BM25 {
 			// Iterate through fields of the document
 			for (const field in doc) {
 				const content = doc[field];
-				if (typeof content !== "string") continue; // Skip non-string fields
+				if (typeof content !== "string" || !content) continue; // Skip non-string and empty fields: the tokenizer rejects falsy input, so an empty field must contribute zero length and zero terms instead of throwing
 
 				const fieldBoost = this.fieldBoosts[field] || 1;
 				const { tokens } = this.tokenizer.tokenize(content);
@@ -1524,7 +1524,7 @@ export class BM25 {
 		// --- Process Fields and Tokens ---
 		for (const field in doc) {
 			const content = doc[field];
-			if (typeof content !== "string") continue;
+			if (typeof content !== "string" || !content) continue;
 
 			const fieldBoost = this.fieldBoosts[field] || 1;
 			const { tokens } = this.tokenizer.tokenize(content);


### PR DESCRIPTION
# Relates to

Fixes #23664 — `BM25` rerank crashes on empty-content memories (`"Input text cannot be null or empty"`).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

> `bun install` was rerun after sync; `bun run verify` cannot pass on the current
> base because `develop` HEAD itself fails `packages/core` typecheck for an
> unrelated reason — exact command and error documented under **Known gaps /
> failures** below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `opencode/x-preview-f-free`
<!-- attribution-row:client -->
- Agent tooling: `opencode`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza/SKILL.md`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
      Rebased onto `485efb8bd1` immediately before pushing; focused tests and lint rerun post-sync.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** The change only widens an indexing guard from "skip non-string fields"
to "skip non-string *or falsy* string fields" at the two BM25 index sites.
Previously such input aborted index construction with a throw; it now indexes a
zero-length document, which is strictly more work completed and cannot affect
scoring of other documents. The tokenizer's public contract is unchanged —
direct `tokenize("")` callers still get the same error. Blast radius is limited
to `processDocuments`, `addDocument`, and their single runtime caller
(`rerankMemories`). No schema, DTO, API, or persisted-state changes.

# Background

## What does this PR do?

Makes BM25 indexing tolerate documents whose string fields are empty strings,
so one attachment-only memory (`content.text === ""`) no longer aborts the
whole query-reranked semantic recall in `AgentRuntime.searchMemories`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

## Why are we doing this?

`Tokenizer.tokenize` throws `"Input text cannot be null or empty"` on falsy
input. `BM25.processDocuments` and `BM25.addDocument` tokenize every string
field unconditionally, and `AgentRuntime.rerankMemories` feeds candidate
memories' `content.text` straight into that constructor. Message memories that
carry attachments without a caption routinely have `content.text === ""`, so a
single such memory in the vector-search candidate set made the entire reranked
search throw instead of returning results. Verified live on `develop` before
filing the issue; duplicate search over open issues and PRs found none.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/search.test.ts` → `describe("BM25 empty string fields")`, and
the new case in `packages/core/src/__tests__/runtime-rerank-memories.test.ts`.

## Detailed testing steps

None beyond automated tests; repro is two commands:

1. On unpatched `develop` (`3d0558d12c`), build an index containing one
   document with an empty string field:
   `new BM25([{ title: "...", content: "" }, { title: "...", content: "hello world" }])`
   → throws `Error: Input text cannot be null or empty`.
2. On this branch the same constructor succeeds and `search("hello")` returns
   exactly the non-empty document.

Automated coverage added:

- `new BM25([{ content: "" }, ...])` indexes; search hits only the non-empty doc
- whitespace-only field (`"   "`) behaves as a zero-length document
- incremental `addDocument({ content: "", ... })` does not throw and stays searchable
- real `AgentRuntime.rerankMemories("automobile purchase", [keywordMatch, memoryWithText("")])`
  ranks without throwing (drives the actual runtime path, not a mock)

Commands run on the final synced head:

```bash
bun run --cwd packages/core test -- src/search.test.ts src/__tests__/runtime-rerank-memories.test.ts
# Test Files  2 passed (2)
# Tests       11 passed (11)

bunx biome check packages/core/src/search.ts packages/core/src/search.test.ts packages/core/src/__tests__/runtime-rerank-memories.test.ts
# Checked 3 files in 45ms. No fixes applied.
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:1ef3b5a4c9a3d1b5add4499724bb30f00aeaeec7 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      `N/A - no rendered UI surface is touched; before terminal capture attached under Screenshots below.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      `N/A - no rendered UI surface is touched; after terminal capture attached under Screenshots below.`
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
      `N/A - two-command library-level repro; before/after terminal captures plus automated tests demonstrate the behavior change.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
      `N/A - in-process BM25 indexing emits no logger lines; real AgentRuntime.rerankMemories path exercised by runtime-rerank-memories.test.ts (real runtime, no mock of the system under test).`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
      `N/A - no frontend surface is touched by this change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
      `N/A - deterministic lexical (BM25) reranker; no model call involved, so no trajectory exists.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
      `N/A - pure in-memory index behavior change; this path produces no persisted domain state.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.
      `N/A - change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - the changed path is a deterministic lexical (BM25) reranker; no model
call is involved, so there is no trajectory to record.`

## Backend + frontend logs

Backend: `N/A - the defect and fix are entirely inside in-process library code
(`BM25` indexing) that emits no logger lines; the real runtime path is exercised
by `runtime-rerank-memories.test.ts`, which drives a real `AgentRuntime` with no
mock in place of the system under test.`

Frontend: `N/A - no frontend surface is touched by this change.`

Repro output captured at both heads (terminal screenshots also attached below):

Before — unpatched `develop` at `3d0558d12c`:

```
THROWS: Input text cannot be null or empty
```

After — this branch at `1ef3b5a4c9`:

```
index ok, search: 1
```

<details>
<summary>Focused vitest run (post-sync head)</summary>

```
 RUN  v4.1.10

 Test Files  2 passed (2)
      Tests  11 passed (11)
   Start at  18:07:57
   Duration  7.08s
```

</details>

## Screenshots (before / after) + video walkthrough

No UI surface is affected; terminal captures serve as before/after proof.

### Before and After

<img width="1920" height="614" alt="image" src="https://github.com/user-attachments/assets/7ddd7424-ffcb-4120-a208-871c9b590bf9" />

# Domain artifacts

`N/A - pure in-memory index behavior change; no database rows, memories on
disk, scheduled tasks, wallet/on-chain output, or generated files are produced
by this path.`

# Known gaps / failures

Two failures reproduce on **unpatched `develop` HEAD** and are unrelated to
this PR (both verified via `git stash` on a clean checkout):

1. `bun run --cwd packages/core typecheck` fails at base commit `485efb8bd1`:
   commit `ec5f919572` (#23582) calls `truncateWellFormed(...)` /
   `toWellFormedUnicode(...)` at `packages/core/src/runtime.ts:9336-9337`
   without importing them:
   ```
   src/runtime.ts(9336,27): error TS2304: Cannot find name 'truncateWellFormed'.
   src/runtime.ts(9337,8): error TS2304: Cannot find name 'toWellFormedUnicode'.
   ```
   This blocks the repository-wide `bun run verify` gate for every contributor;
   this PR keeps its diff scoped to the issue and records the blocker here
   rather than bundling an unrelated fix.
2. `src/runtime/__tests__/action-retrieval.test.ts > uses recent conversation
   for continuation-shaped current turns` fails identically with the stash
   applied (expects `TASKS` matched by `bm25`, receives `SHELL` matched by
   `keyword`). Not caused by this branch; untouched by it.
