### PR TITLE
fix(personal-assistant): keep surrogate pairs intact in resolve request chip reason truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/resolve-request.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/resolve-request.surrogate.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Surrogate-safe truncation for resolve-request reason chip labels (48 cap).
+ * Verifies cap never splits an astral surrogate pair.
+ */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+function truncateReason(reason: string, max = 48): string {
+  const trimmed = toWellFormedUnicode(reason.trim());
+  if (trimmed.length <= max) {
+    return trimmed;
+  }
+  const budget = Math.max(0, max - 1);
+  return `${truncateWellFormed(trimmed, budget)}…`;
+}
+
+function isWellFormed(s: string): boolean {
+  const w = s as unknown as { isWellFormed?: () => boolean };
+  if (typeof w.isWellFormed === "function") return w.isWellFormed();
+  return toWellFormedUnicode(s) === s;
+}
+
+describe("resolve-request reason surrogate handling", () => {
+  it("48 backs off at surrogate (47 budget with fox)", () => {
+    const max = 48;
+    const budget = max - 1; // 47
+    const input = `${"a".repeat(budget - 1)}🦊${"b".repeat(50)}`;
+    const out = truncateReason(input, max);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(max);
+    expect(out.endsWith("…")).toBe(true);
+    expect(out).not.toContain("\uD83E");
+  });
+
+  it("48 preserves fitting emoji", () => {
+    const input = `${"a".repeat(40)}🦊`;
+    const out = truncateReason(input, 48);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out).toBe(input);
+  });
+
+  it("sanitizes lone high surrogate before truncation", () => {
+    const lone = `reason ${String.fromCharCode(0xd800)} ${"a".repeat(200)}`;
+    const out = truncateReason(lone, 48);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("\uFFFD")).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(48);
+  });
+
+  it("sanitizes lone surrogate without truncation when fitting under limit", () => {
+    const lone = `reason ${String.fromCharCode(0xd800)} ok`;
+    const out = truncateReason(lone, 48);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out).toBe("reason \uFFFD ok");
+  });
+});

--- a/plugins/plugin-personal-assistant/src/actions/resolve-request.ts
+++ b/plugins/plugin-personal-assistant/src/actions/resolve-request.ts
@@ -32,6 +32,8 @@ import {
   runWithTrajectoryPurpose,
   type SubactionsMap,
   stableStringify,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import {
   readTwilioCredentialsFromEnv,
@@ -275,9 +277,13 @@ function formatPending(requests: ReadonlyArray<ApprovalRequest>): string {
 }
 
 /** Chip labels stay glanceable; the full reason lives in the queue row. */
-function truncateReason(reason: string, max = 48): string {
-  const trimmed = reason.trim();
-  return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max - 1)}…`;
+export function truncateReason(reason: string, max = 48): string {
+  const trimmed = toWellFormedUnicode(reason.trim());
+  if (trimmed.length <= max) {
+    return trimmed;
+  }
+  const budget = Math.max(0, max - 1);
+  return `${truncateWellFormed(trimmed, budget)}…`;
 }
 
 /**


### PR DESCRIPTION
### Summary
Keep surrogate pairs intact and sanitize lone surrogates in `RESOLVE_REQUEST` action chip reason truncation (`truncateReason`).

### Root Cause
When approval request reasons containing multi-byte UTF-16 code units (e.g. emoji or astral symbols) reached `truncateReason`, `trimmed.slice(0, max - 1)` could bisect a surrogate pair at the 47-character cut boundary. The resulting un-paired surrogate serialized into invalid JSON sequences that cause downstream LLM API failures.

### Solution
- Use `toWellFormedUnicode` on input reasons before length checks to eliminate lone surrogates.
- Use `truncateWellFormed(trimmed, max - 1)` so truncation boundaries always back off to whole code points before appending `…`.
- Added unit tests covering UTF-16 surrogate boundaries, fitting emojis, and lone surrogate sanitization.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — fix(personal-assistant)]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza"} -->