### PR TITLE
fix(core): key image-description cache by SHA-256 instead of 32-bit FNV-1a

### DIFF
--- a/packages/core/src/media/image-description-cache.test.ts
+++ b/packages/core/src/media/image-description-cache.test.ts
@@ -47,7 +47,19 @@ describe("imageDescriptionCacheKey", () => {
 		expect(imageDescriptionCacheKey("a")).not.toBe(
 			imageDescriptionCacheKey("b"),
 		);
-		expect(imageDescriptionCacheKey("x")).toMatch(/^img-desc:v1:[a-f0-9]{8}$/);
+		expect(imageDescriptionCacheKey("x")).toMatch(/^img-desc:v2:[a-f0-9]{64}$/);
+	});
+
+	// Regression for the 32-bit FNV-1a key: these two real-world-shaped URLs
+	// collided under `img-desc:v1:62b0a0eb`, so the second image was served
+	// the first image's cached description forever.
+	it("separates URLs that collided under the 32-bit v1 key", () => {
+		const urlA = "https://cdn.example.com/media/539599.jpg";
+		const urlB = "https://cdn.example.com/media/722382.jpg";
+		expect(imageDescriptionCacheKey(urlA)).not.toBe(
+			imageDescriptionCacheKey(urlB),
+		);
+		expect(imageDescriptionCacheKey(urlA)).toMatch(/^img-desc:v2:/);
 	});
 });
 
@@ -132,6 +144,28 @@ describe("describeImageCached", () => {
 		const { runtime, useModel } = fakeRuntime({});
 		expect(await describeImageCached(runtime, "  ", "p")).toBeNull();
 		expect(useModel).not.toHaveBeenCalled();
+	});
+
+	// End-to-end regression for #23680: a description cached for one URL must
+	// never be served for a different URL that shared the old 32-bit key.
+	it("never serves image A's description for its former v1 collision partner", async () => {
+		const urlA = "https://cdn.example.com/media/539599.jpg";
+		const urlB = "https://cdn.example.com/media/722382.jpg";
+		const useModel = vi.fn(
+			async (_modelType: unknown, params: { imageUrl: string }) =>
+				params.imageUrl === urlA
+					? '{"title":"A tabby cat","description":"a cat on a windowsill"}'
+					: '{"title":"City skyline","description":"a skyline at dusk"}',
+		);
+		const { runtime } = fakeRuntime({ useModel });
+
+		const describedA = await describeImageCached(runtime, urlA, "p");
+		const describedB = await describeImageCached(runtime, urlB, "p");
+
+		expect(describedA?.title).toBe("A tabby cat");
+		expect(describedB?.title).toBe("City skyline");
+		// Both were real misses: no cross-contamination through the cache.
+		expect(useModel).toHaveBeenCalledTimes(2);
 	});
 });
 

--- a/packages/core/src/media/image-description-cache.ts
+++ b/packages/core/src/media/image-description-cache.ts
@@ -11,6 +11,7 @@
  */
 import type { IAgentRuntime } from "../types/index.ts";
 import { ModelType } from "../types/index.ts";
+import { createHash } from "../utils/crypto-compat";
 import { parseJSONObjectFromText } from "../utils.ts";
 
 export interface CachedImageDescription {
@@ -19,20 +20,15 @@ export interface CachedImageDescription {
 	text: string;
 }
 
-const CACHE_VERSION = "v1";
-
-/** Browser/edge-safe FNV-1a (no `node:crypto`) for the cache key. */
-function fnv1aHex(input: string): string {
-	let hash = 0x811c9dc5;
-	for (let i = 0; i < input.length; i++) {
-		hash ^= input.charCodeAt(i);
-		hash = Math.imul(hash, 0x01000193);
-	}
-	return (hash >>> 0).toString(16).padStart(8, "0");
-}
+const CACHE_VERSION = "v2";
 
 export function imageDescriptionCacheKey(imageUrl: string): string {
-	return `img-desc:${CACHE_VERSION}:${fnv1aHex(imageUrl)}`;
+	// SHA-256, not a truncated non-crypto hash: this key is a persistent
+	// content address across agents' cache namespaces, so a collision would
+	// permanently serve one image's description for a different image.
+	return `img-desc:${CACHE_VERSION}:${createHash("sha256")
+		.update(imageUrl)
+		.digest("hex")}`;
 }
 
 /** Coerce any IMAGE_DESCRIPTION model response into a uniform description shape. */


### PR DESCRIPTION
# Relates to

Fixes #23680 — image-description cache keys on a 32-bit hash; distinct images can permanently share one description.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `opencode/x-preview-f-free`
<!-- attribution-row:client -->
- Agent tooling: `opencode`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza/SKILL.md`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
      Rebased onto `94175304cf` immediately before pushing; focused tests, consumer tests, lint, and core typecheck rerun post-sync.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.
      Core typecheck passes on this head (the unrelated `runtime.ts` import break present earlier in the week was fixed upstream); focused and consumer test lanes pass; biome clean on changed files.

# Risks

**Low.** The change swaps the cache-key digest from 32-bit FNV-1a to full
SHA-256 and bumps `CACHE_VERSION` (`v1` → `v2`). Consequences:

- Existing cached descriptions become unreachable under the new namespace and
  are re-described once per image on next use. That is a one-time vision-model
  cost per image, bounded by normal describe traffic, and it is the only way to
  guarantee stale 32-bit-keyed entries can never be read.
- No API shape changes: `imageDescriptionCacheKey` keeps its signature and
  return type (string), `describeImageCached` / get / set semantics unchanged.
- Consumers (inbound attachment processing, `ATTACHMENT action=read`,
  working-memory attachment context, basic-capabilities helper,
  plugin-elizacloud image model) all go through the same helpers and need no
  edits.
- SHA-256 here is the same cross-platform `createHash` from
  `utils/crypto-compat.ts` already used for content addressing elsewhere in
  core, so browser/edge targets stay supported.

# Background

## What does this PR do?

Keys the shared image-description cache with a full SHA-256 hex digest of the
image URL instead of an 8-hex 32-bit FNV-1a truncation, so two distinct images
can no longer silently share one persisted description.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

## Why are we doing this?

The cache is content-addressed and persistent (`runtime.setCache`, no TTL). A
32-bit key space makes accidental collisions pass 1% probability near ~9,300
distinct images in one agent namespace, and collisions are trivial to craft —
a brute-force search over natural-looking URLs found
`https://cdn.example.com/media/539599.jpg` and
`https://cdn.example.com/media/722382.jpg` both hashing to
`img-desc:v1:62b0a0eb` in under a second. On a collision, the second image is
answered with the first image's cached vision description without a model
call, forever. Verified end-to-end through the exported functions on
`develop` before filing the issue; duplicate search found no prior report.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/media/image-description-cache.test.ts` — the updated key
format assertions plus the two new regression cases that use the real
colliding URL pair from the issue.

## Detailed testing steps

None beyond automated tests; repro is three commands per side:

1. On unpatched `develop` (`485efb8bd1`), call
   `imageDescriptionCacheKey` for both URLs above → identical key
   `img-desc:v1:62b0a0eb`; cache a description for URL A, then
   `getCachedImageDescription(runtime, urlB)` returns A's description as a hit.
2. On this branch the same script prints two distinct `img-desc:v2:<64 hex>`
   keys, and URL B is a cache miss (`undefined`) until it is described itself.
3. Focused suite:
   `bun run --cwd packages/core test -- src/media/image-description-cache.test.ts`

Automated coverage added:

- key format pinned to `img-desc:v2:<64 hex>` (was `img-desc:v1:<8 hex>`)
- the real colliding pair produces different keys
- end-to-end through `describeImageCached`: describing A then B calls the
  model twice and each URL gets its own description — no cross-contamination

Commands run on the final synced head:

```bash
bun run --cwd packages/core test -- src/media/image-description-cache.test.ts src/services/message.processAttachments.test.ts src/connectors/attachments.test.ts
# Test Files  3 passed (3)
# Tests       45 passed (45)

bunx biome check packages/core/src/media/image-description-cache.ts packages/core/src/media/image-description-cache.test.ts
# Checked 2 files in 20ms. No fixes applied.

bun run --cwd packages/core typecheck
# Done!
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:b769e2889e5453900e02b30ec0bb19c1811a2c51 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      `N/A - no rendered UI surface is touched; before terminal capture attached under Screenshots below.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - <reason>`.
      `N/A - no rendered UI surface is touched; after terminal capture attached under Screenshots below.`
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - <reason>`.
      `N/A - library-level repro with deterministic printed output; before/after terminal captures plus automated tests demonstrate the behavior change.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - <reason>`.
      `N/A - cache key derivation emits no logger lines; the real exported cache helpers are exercised directly by the repro script and by image-description-cache.test.ts.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked `N/A - <reason>`.
      `N/A - no frontend surface is touched by this change.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - <reason>`.
      `N/A - the defect is in cache key derivation, not in any model call; the fix does not change when the vision model runs except by eliminating false hits.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - <reason>`.
      `N/A - runtime cache entries are the only state touched; both keys and their contents are printed verbatim in the attached captures.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked
      `N/A - <reason>` when the change has no rendered visual surface.
      `N/A - change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - the changed path is cache key derivation; no model call is part of the
defect or the fix. The regression test proves both colliding URLs are real
model misses after the fix (useModel called twice).`

## Backend + frontend logs

Backend: `N/A - key derivation and cache reads/writes emit no structured log
lines; behavior is proven via direct exercise of the exported helpers
(repro captures below) and the focused vitest suite.`

Frontend: `N/A - no frontend surface is touched by this change.`

Repro output captured at both heads (terminal screenshots also attached below):

Before — unpatched `develop` at `485efb8bd1`:

```
keyA: img-desc:v1:62b0a0eb
keyB: img-desc:v1:62b0a0eb
SAME KEY: true
description served for B: A tabby cat
WRONG-IMAGE ANSWER: true
```

After — this branch:

```
keyA: img-desc:v2:98bebe495f7b4fc10d301e08857a37df571dae9bd15f65aef0d51b6033d89bc3
keyB: img-desc:v2:d2edf2e5afe4ea118d0c49a086376fa2a7fd8a6ca41371d565411449912907ae
SAME KEY: false
description served for B: undefined
WRONG-IMAGE ANSWER: false
```

<details>
<summary>Focused + consumer vitest run (final synced head)</summary>

```
 Test Files  3 passed (3)
      Tests  45 passed (45)
```

</details>

### Before and After

<img width="1920" height="969" alt="image" src="https://github.com/user-attachments/assets/2e8b48ba-cd87-4cdf-8995-a6c8bd70dae3" />

_Note: terminal captures were taken at `d8d618cad3`; the identical diff was
subsequently rebased onto `origin/develop` (`94175304cf`) with no behavior
change, and all automated checks were rerun on the final head._

# Known gaps / failures

None. All commands listed under Testing pass on the final synced head
(`b769e2889e`).
