### PR TITLE
fix(personal-assistant): keep surrogate pairs intact in creative draft source truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/creative-draft.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/creative-draft.surrogate.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Surrogate-safe truncation for creative-draft owner voice source (6000 cap).
+ * Verifies cap never splits an astral surrogate pair.
+ */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+const MAX_OWNER_SOURCE_CHARS = 6000;
+function truncate6000(text: string): string {
+  return truncateWellFormed(toWellFormedUnicode(text), MAX_OWNER_SOURCE_CHARS);
+}
+
+function isWellFormed(s: string): boolean {
+  const w = s as unknown as { isWellFormed?: () => boolean };
+  if (typeof w.isWellFormed === "function") return w.isWellFormed();
+  return toWellFormedUnicode(s) === s;
+}
+
+describe("creative-draft surrogate handling", () => {
+  it("6000 backs off at surrogate (5999+fox->5999)", () => {
+    const input = "a".repeat(5999) + "🦊" + "b".repeat(50);
+    const out = truncate6000(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(6000);
+    expect(out.length).toBe(5999);
+  });
+
+  it("6000 preserves fitting emoji (5998+fox intact)", () => {
+    const input = "a".repeat(5998) + "🦊";
+    const out = truncate6000(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out).toBe("a".repeat(5998) + "🦊");
+  });
+
+  it("short text passes through", () => {
+    const input = "short owner voice text";
+    const out = truncate6000(input);
+    expect(out).toBe(input);
+    expect(isWellFormed(out)).toBe(true);
+  });
+
+  it("sanitizes lone high surrogate", () => {
+    const lone =
+      `text ${String.fromCharCode(0xd800)} content ` + "a".repeat(7000);
+    const out = truncate6000(lone);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("�")).toBe(true);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/actions/creative-draft.ts
+++ b/plugins/plugin-personal-assistant/src/actions/creative-draft.ts
@@ -33,6 +33,8 @@ import {
   logger,
   ModelType,
   runWithTrajectoryPurpose,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import { hasLifeOpsAccess } from "../lifeops/access.js";
 import {
@@ -245,7 +247,10 @@ async function resolveOwnerVoiceSources(args: {
     if (!document.id || !text) continue;
     byId.set(document.id, {
       id: document.id,
-      text: text.slice(0, MAX_OWNER_SOURCE_CHARS),
+      text: truncateWellFormed(
+        toWellFormedUnicode(text),
+        MAX_OWNER_SOURCE_CHARS,
+      ),
       source: ownerVoiceSourceKind(document),
     });
     if (byId.size >= MAX_OWNER_VOICE_SOURCES) break;


### PR DESCRIPTION
Closes #23711

## Summary
- Fix `plugins/plugin-personal-assistant/src/actions/creative-draft.ts:248` `text.slice(0,6000)` (owner voice source for creative draft style card / LLM) to use `toWellFormedUnicode` + `truncateWellFormed` so the 6000 cap never splits an astral surrogate pair (e.g. 🦊) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict parsers reject. Lone surrogates sanitized to `�`.
- Preserve budget exactly (6000) via `truncateWellFormed(toWellFormedUnicode(text),6000)`.
- Same class as merged #23654 (owner-send 237/197), #23651 (website-block 1024) — identical pattern.

## What Changed
- `plugins/plugin-personal-assistant/src/actions/creative-draft.ts`: import `toWellFormedUnicode, truncateWellFormed`, 6000 source `truncateWellFormed(toWellFormedUnicode(text),6000)`.
- `plugins/plugin-personal-assistant/src/actions/creative-draft.surrogate.test.ts`: +~50 lines — 4 behavioral `isWellFormed()` tests: 5999+🦊→5999 backs off, fitting 5998+🦊 intact, short, lone `\ud800` sanitized.

## Exact-head evidence
Head: 9bc754e3ed4cd099011f2d30cd8970ad78414b74
Base: origin/develop@94175304cf6009f71d300689560fa764bd9f026c with zero conflicts

## Verification / Definition of Done
- [x] Targets develop, rebased onto origin/develop@94175304c zero conflicts
- [x] `bun install --frozen-lockfile` clean
- [x] `bunx biome check plugins/plugin-personal-assistant/src/actions/creative-draft.ts plugins/plugin-personal-assistant/src/actions/creative-draft.surrogate.test.ts` — no errors
- [x] `bunx vitest run plugins/plugin-personal-assistant/src/actions/creative-draft.surrogate.test.ts --reporter=verbose` — **4 passed, 0 failed**
- [x] `git diff --check` — no whitespace errors
- [x] Reviewer can confirm: `truncate6000("a".repeat(5999)+"🦊"+"b...")` → 5999 well-formed; `truncate6000("a".repeat(5998)+"🦊")` intact

## Evidence Gate

<!-- evidence-head:9bc754e3ed4cd099011f2d30cd8970ad78414b74 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; creative draft source is headless.

<!-- evidence-row:console-logs -->
- [x] N/A - `bunx vitest run` passes (4/4); no runtime console capture needed.

<!-- evidence-row:unit-tests -->
- [x] `bunx vitest run plugins/plugin-personal-assistant/src/actions/creative-draft.surrogate.test.ts --reporter=verbose` — 4 passed

<!-- evidence-row:static-analysis -->
- [x] `bunx biome check` — no errors

<!-- evidence-row:edge-cases -->
- [x] Backs off on high surrogate at 5999, preserves fitting emoji, short, sanitizes lone surrogate to `�`.

<!-- evidence-row:trajectory -->
- [x] N/A - not an agent trajectory change.

<!-- evidence-row:docs -->
- [x] N/A - bug fix, no docs change.

## Risks
Low. Isolated to creative draft owner voice source truncation (6000); preserves budget, no behavioral change for well-formed text.

## Provenance
- Base: `elizaOS/eliza@94175304c:packages/skills/skills/contribute-to-eliza`
- Head: `9bc754e3ed`

