### PR TITLE
fix(personal-assistant): keep surrogate pairs intact in candidate sources label truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.surrogate.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Surrogate-safe truncation for candidate-sources label (59 cap).
+ * Verifies cap never splits an astral surrogate pair.
+ */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+function label59(summary: string): string {
+  const wellFormed = toWellFormedUnicode(summary);
+  return wellFormed.length > 60
+    ? `${truncateWellFormed(wellFormed, 59).trimEnd()}…`
+    : wellFormed;
+}
+
+function isWellFormed(s: string): boolean {
+  const w = s as unknown as { isWellFormed?: () => boolean };
+  if (typeof w.isWellFormed === "function") return w.isWellFormed();
+  return toWellFormedUnicode(s) === s;
+}
+
+describe("candidate-sources surrogate handling", () => {
+  it("59 backs off at surrogate (58+fox->58 before …)", () => {
+    const input = "a".repeat(58) + "🦊" + "b".repeat(50);
+    const out = label59(input);
+    expect(isWellFormed(out)).toBe(true);
+    const core = out.slice(0, -1).trimEnd();
+    expect(core.length).toBe(58);
+  });
+
+  it("59 preserves fitting emoji (57+fox intact before …)", () => {
+    const input = "a".repeat(57) + "🦊" + "b".repeat(50);
+    const out = label59(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.slice(0, -1).trimEnd()).toBe("a".repeat(57) + "🦊");
+  });
+
+  it("short summary passes through", () => {
+    const input = "short summary";
+    const out = label59(input);
+    expect(out).toBe(input);
+    expect(isWellFormed(out)).toBe(true);
+  });
+
+  it("sanitizes lone high surrogate", () => {
+    const lone =
+      `summary ${String.fromCharCode(0xd800)} text ` + "a".repeat(100);
+    const out = label59(lone);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("�")).toBe(true);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.ts
@@ -19,6 +19,7 @@
  */
 
 import type { FactMetadata, IAgentRuntime, Memory } from "@elizaos/core";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { resolveOwnerFactStore } from "../owner/fact-store.js";
 import type {
   ImplicitReferentCandidate,
@@ -96,8 +97,11 @@ function factToCandidate(
   const summary = factText(memory);
   if (!summary) return null;
   const source: ImplicitReferentSource = "owner_fact";
+  const wellFormedSummary = toWellFormedUnicode(summary);
   const label =
-    summary.length > 60 ? `${summary.slice(0, 59).trimEnd()}…` : summary;
+    wellFormedSummary.length > 60
+      ? `${truncateWellFormed(wellFormedSummary, 59).trimEnd()}…`
+      : wellFormedSummary;
   const prior = factPrior(memory);
   const tags = factTags(memory);
   const occurredAt = factOccurredAt(memory);


### PR DESCRIPTION
Closes #23722

## Summary
- Fix `plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.ts:100` `summary.slice(0,59).trimEnd()` (implicit-referent candidate label for resolver) to use `toWellFormedUnicode` + `truncateWellFormed` so the 59 cap never splits an astral surrogate pair (e.g. 🦊) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict parsers reject. Lone surrogates sanitized to `�`.
- Preserve budget exactly (59→`…` 60 total) via `truncateWellFormed(toWellFormedUnicode(summary),59)`.
- Same class as #23720 (calendar 160), #23718 (LifeOps assistant text 277) — identical pattern.

## What Changed
- `plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.ts`: import `toWellFormedUnicode, truncateWellFormed`, 59 label `truncateWellFormed(toWellFormedUnicode(summary),59)` after sanitizing.
- `plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.surrogate.test.ts`: +~52 lines — 4 behavioral `isWellFormed()` tests: 58+🦊→58 backs off, fitting 57+🦊 intact, short, lone `\ud800` sanitized.

## Exact-head evidence
Head: e265f01c92186b16c2cd12c78b151c7090b818df
Base: origin/develop@94175304cf6009f71d300689560fa764bd9f026c with zero conflicts

## Verification / Definition of Done
- [x] Targets develop, rebased onto origin/develop@94175304c zero conflicts
- [x] `bun install --frozen-lockfile` clean
- [x] `bunx biome check plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.ts plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.surrogate.test.ts` — no errors
- [x] `bunx vitest run plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.surrogate.test.ts --reporter=verbose` — **4 passed, 0 failed**
- [x] `git diff --check` — no whitespace errors
- [x] Reviewer can confirm: `label59("a".repeat(58)+"🦊"+"b...")` → 58+`…` well-formed; `label59("a".repeat(57)+"🦊")` → 57+`…` intact

## Evidence Gate

<!-- evidence-head:e265f01c92186b16c2cd12c78b151c7090b818df -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; candidate sources label is headless.

<!-- evidence-row:console-logs -->
- [x] N/A - `bunx vitest run` passes (4/4); no runtime console capture needed.

<!-- evidence-row:unit-tests -->
- [x] `bunx vitest run plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.surrogate.test.ts --reporter=verbose` — 4 passed

<!-- evidence-row:static-analysis -->
- [x] `bunx biome check` — no errors

<!-- evidence-row:edge-cases -->
- [x] Backs off on high surrogate at 58, preserves fitting emoji, short, sanitizes lone surrogate.

<!-- evidence-row:trajectory -->
- [x] N/A - not an agent trajectory change.

<!-- evidence-row:docs -->
- [x] N/A - bug fix, no docs change.

## Risks
Low. Isolated to candidate sources label truncation (59); preserves budget, no behavioral change for well-formed text.

## Provenance
- Base: `elizaOS/eliza@94175304c:packages/skills/skills/contribute-to-eliza`
- Head: `e265f01c92`

