### PR TITLE
fix(personal-assistant): keep surrogate pairs intact in background planner error truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/background-planner.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/background-planner.surrogate.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Surrogate-safe truncation for background-planner error output (200 cap).
+ * Verifies cap never splits an astral surrogate pair.
+ */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+function truncate200(raw: string): string {
+  return truncateWellFormed(toWellFormedUnicode(raw), 200);
+}
+
+function isWellFormed(s: string): boolean {
+  const w = s as unknown as { isWellFormed?: () => boolean };
+  if (typeof w.isWellFormed === "function") return w.isWellFormed();
+  return toWellFormedUnicode(s) === s;
+}
+
+describe("background-planner surrogate handling", () => {
+  it("200 backs off at surrogate (199+fox->199)", () => {
+    const input = "a".repeat(199) + "🦊" + "b".repeat(50);
+    const out = truncate200(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(200);
+    expect(out.length).toBe(199);
+  });
+
+  it("200 preserves fitting emoji (198+fox intact)", () => {
+    const input = "a".repeat(198) + "🦊";
+    const out = truncate200(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out).toBe("a".repeat(198) + "🦊");
+  });
+
+  it("short raw passes through", () => {
+    const input = "short output";
+    const out = truncate200(input);
+    expect(out).toBe(input);
+    expect(isWellFormed(out)).toBe(true);
+  });
+
+  it("sanitizes lone high surrogate", () => {
+    const lone =
+      `output ${String.fromCharCode(0xd800)} text ` + "a".repeat(300);
+    const out = truncate200(lone);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("�")).toBe(true);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/background-planner.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/background-planner.ts
@@ -82,6 +82,8 @@ import {
   ModelType,
   parseJsonModelRecord,
   runWithTrajectoryPurpose,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import type {
   ApprovalAction,
@@ -548,7 +550,7 @@ export async function planJob(
   if (!parsed) {
     throw new BackgroundPlannerError(
       jobContext.jobKind,
-      `planner returned unparsable output: ${raw.slice(0, 200)}`,
+      `planner returned unparsable output: ${truncateWellFormed(toWellFormedUnicode(raw), 200)}`,
     );
   }
 


### PR DESCRIPTION
Closes #23730

## Summary
- Fix `plugins/plugin-personal-assistant/src/lifeops/background-planner.ts:551` `raw.slice(0,200)` (unparsable LLM output in `BackgroundPlannerError`) to use `toWellFormedUnicode` + `truncateWellFormed` so the 200 cap never splits an astral surrogate pair (e.g. 🦊) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict parsers reject. Lone surrogates sanitized to `�`.
- Preserve budget exactly (200) via `truncateWellFormed(toWellFormedUnicode(raw),200)`.
- Same class as #23728 (owner-policy-writes 200), #23724 (candidate-sources 59) — identical pattern.

## What Changed
- `plugins/plugin-personal-assistant/src/lifeops/background-planner.ts`: import `toWellFormedUnicode, truncateWellFormed`, 200 raw `truncateWellFormed(toWellFormedUnicode(raw),200)`.
- `plugins/plugin-personal-assistant/src/lifeops/background-planner.surrogate.test.ts`: +~49 lines — 4 behavioral `isWellFormed()` tests: 199+🦊→199 backs off, fitting 198+🦊 intact, short, lone `\ud800` sanitized.

## Exact-head evidence
Head: a8752cf105a5a411c490b380aa08842ee18abd30
Base: origin/develop@aeae937584d6a1d0825b2474498046ad18f848f6 with zero conflicts

## Verification / Definition of Done
- [x] Targets develop, rebased onto origin/develop@aeae937584 zero conflicts
- [x] `bun install --frozen-lockfile` clean
- [x] `bunx biome check plugins/plugin-personal-assistant/src/lifeops/background-planner.ts plugins/plugin-personal-assistant/src/lifeops/background-planner.surrogate.test.ts` — no errors
- [x] `bunx vitest run plugins/plugin-personal-assistant/src/lifeops/background-planner.surrogate.test.ts --reporter=verbose` — **4 passed, 0 failed**
- [x] `git diff --check` — no whitespace errors
- [x] Reviewer can confirm: `truncate200("a".repeat(199)+"🦊"+"b...")` → 199 well-formed; `truncate200("a".repeat(198)+"🦊")` intact

## Evidence Gate

<!-- evidence-head:a8752cf105a5a411c490b380aa08842ee18abd30 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; background planner error is headless.

<!-- evidence-row:console-logs -->
- [x] N/A - `bunx vitest run` passes (4/4); no runtime console capture needed.

<!-- evidence-row:unit-tests -->
- [x] `bunx vitest run plugins/plugin-personal-assistant/src/lifeops/background-planner.surrogate.test.ts --reporter=verbose` — 4 passed

<!-- evidence-row:static-analysis -->
- [x] `bunx biome check` — no errors

<!-- evidence-row:edge-cases -->
- [x] Backs off on high surrogate at 199, preserves fitting emoji, short, sanitizes lone surrogate.

<!-- evidence-row:trajectory -->
- [x] N/A - not an agent trajectory change.

<!-- evidence-row:docs -->
- [x] N/A - bug fix, no docs change.

## Risks
Low. Isolated to background planner error truncation (200); preserves budget, no behavioral change for well-formed text.

## Provenance
- Base: `elizaOS/eliza@aeae937584:packages/skills/skills/contribute-to-eliza`
- Head: `a8752cf105`

