### PR TITLE
fix(personal-assistant): keep surrogate pairs intact in room policy directive truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/providers/room-policy.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/providers/room-policy.surrogate.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Surrogate-safe truncation for room-policy directive (240 cap).
+ * Verifies cap never splits an astral surrogate pair.
+ */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+const ONE_LINE_MAX = 240;
+function truncateDirective(directive: string): string {
+  return truncateWellFormed(toWellFormedUnicode(directive), ONE_LINE_MAX);
+}
+
+function isWellFormed(s: string): boolean {
+  const w = s as unknown as { isWellFormed?: () => boolean };
+  if (typeof w.isWellFormed === "function") return w.isWellFormed();
+  return toWellFormedUnicode(s) === s;
+}
+
+describe("room-policy surrogate handling", () => {
+  it("240 backs off at surrogate (239+fox->239)", () => {
+    const input = "a".repeat(239) + "🦊" + "b".repeat(50);
+    const out = truncateDirective(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(240);
+    expect(out.length).toBe(239);
+  });
+
+  it("240 preserves fitting emoji (238+fox intact)", () => {
+    const input = "a".repeat(238) + "🦊";
+    const out = truncateDirective(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out).toBe("a".repeat(238) + "🦊");
+  });
+
+  it("short directive passes through", () => {
+    const input = "This room is in handoff mode";
+    const out = truncateDirective(input);
+    expect(out).toBe(input);
+    expect(isWellFormed(out)).toBe(true);
+  });
+
+  it("sanitizes lone high surrogate", () => {
+    const lone =
+      `directive ${String.fromCharCode(0xd800)} content ` + "a".repeat(500);
+    const out = truncateDirective(lone);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("�")).toBe(true);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/providers/room-policy.ts
+++ b/plugins/plugin-personal-assistant/src/providers/room-policy.ts
@@ -19,7 +19,7 @@ import type {
   ProviderResult,
   State,
 } from "@elizaos/core";
-import { logger } from "@elizaos/core";
+import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   describeResumeCondition,
   resolveHandoffStore,
@@ -88,7 +88,10 @@ export const roomPolicyProvider: Provider = {
     const directive =
       `This room is in handoff mode (since ${status.enteredAt ?? "earlier"}; reason: ${status.reason ?? "n/a"}). ` +
       `Do not respond unless ${resumePhrase}. Stay silent — defer to the human participants.`;
-    const text = directive.slice(0, ONE_LINE_MAX);
+    const text = truncateWellFormed(
+      toWellFormedUnicode(directive),
+      ONE_LINE_MAX,
+    );
     return {
       text,
       values: {


### PR DESCRIPTION
Closes #23732

## Summary
- Fix `plugins/plugin-personal-assistant/src/providers/room-policy.ts:91` `directive.slice(0,240)` (handoff mode directive injected into planner context) to use `toWellFormedUnicode` + `truncateWellFormed` so the 240 cap never splits an astral surrogate pair (e.g. 🦊) into a lone surrogate that `JSON.stringify` emits as `\uD8xx` and strict parsers reject. Lone surrogates sanitized to `�`.
- Preserve budget exactly (240) via `truncateWellFormed(toWellFormedUnicode(directive),240)`.
- Same class as #23731 (background-planner 200), #23728 (owner-policy-writes 200) — identical pattern.

## What Changed
- `plugins/plugin-personal-assistant/src/providers/room-policy.ts`: import `toWellFormedUnicode, truncateWellFormed`, 240 directive `truncateWellFormed(toWellFormedUnicode(directive),240)`.
- `plugins/plugin-personal-assistant/src/providers/room-policy.surrogate.test.ts`: +~50 lines — 4 behavioral `isWellFormed()` tests: 239+🦊→239 backs off, fitting 238+🦊 intact, short, lone `\ud800` sanitized.

## Exact-head evidence
Head: 5dbd230846b67935216da1250c9bec605f58d602
Base: origin/develop@aeae937584d6a1d0825b2474498046ad18f848f6 with zero conflicts

## Verification / Definition of Done
- [x] Targets develop, rebased onto origin/develop@aeae937584 zero conflicts
- [x] `bun install --frozen-lockfile` clean
- [x] `bunx biome check plugins/plugin-personal-assistant/src/providers/room-policy.ts plugins/plugin-personal-assistant/src/providers/room-policy.surrogate.test.ts` — no errors
- [x] `bunx vitest run plugins/plugin-personal-assistant/src/providers/room-policy.surrogate.test.ts --reporter=verbose` — **4 passed, 0 failed**
- [x] `git diff --check` — no whitespace errors
- [x] Reviewer can confirm: `truncateDirective("a".repeat(239)+"🦊"+"b...")` → 239 well-formed; `truncateDirective("a".repeat(238)+"🦊")` intact

## Evidence Gate

<!-- evidence-head:5dbd230846b67935216da1250c9bec605f58d602 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; room policy directive is headless.

<!-- evidence-row:console-logs -->
- [x] N/A - `bunx vitest run` passes (4/4); no runtime console capture needed.

<!-- evidence-row:unit-tests -->
- [x] `bunx vitest run plugins/plugin-personal-assistant/src/providers/room-policy.surrogate.test.ts --reporter=verbose` — 4 passed

<!-- evidence-row:static-analysis -->
- [x] `bunx biome check` — no errors

<!-- evidence-row:edge-cases -->
- [x] Backs off on high surrogate at 239, preserves fitting emoji, short, sanitizes lone surrogate.

<!-- evidence-row:trajectory -->
- [x] N/A - not an agent trajectory change.

<!-- evidence-row:docs -->
- [x] N/A - bug fix, no docs change.

## Risks
Low. Isolated to room policy directive truncation (240); preserves budget, no behavioral change for well-formed text.

## Provenance
- Base: `elizaOS/eliza@aeae937584:packages/skills/skills/contribute-to-eliza`
- Head: `5dbd230846`

