### PR TITLE
chore(cloud): sync test-mocks AGENTS.md with CLAUDE.md to unblock the Quality lane

### DIFF
--- a/packages/cloud/test-mocks/AGENTS.md
+++ b/packages/cloud/test-mocks/AGENTS.md
@@ -23,6 +23,8 @@ exits.
   returns `{ url, port, store, stop, tick, processDbBackedJobs, cleanupStuck }`.
   Also exports `buildControlPlaneApp`, `ControlPlaneStore`, and the
   `Job`/`JobStatus`/`JobType`/`Sandbox`/`SandboxStatus` types.
+- `src/steward/` (export `./steward`) — stateful loopback mock for authenticated
+  Steward platform-user deactivation and deletion calls used by account lifecycle E2E.
 - `src/fetch-server.ts` — shared `startFetchServer(fetch, opts)`; uses
   `Bun.serve` when running under Bun, falls back to a `node:http` adapter
   otherwise.


### PR DESCRIPTION
## Problem

`bun run check:agents-claude` **fails on `develop` itself**:

```
[assert-agents-claude-identical] FAIL
- packages/cloud/test-mocks: CLAUDE.md and AGENTS.md differ; author CLAUDE.md, then copy it to AGENTS.md
```

Because it is part of the Quality lane, this makes that lane red on **every open PR**, regardless of what the PR changes. I found it while reviewing #22674, whose Quality failure turned out to be entirely this and nothing to do with the PR — which is the real cost of a repo-wide red gate: it stops carrying information, and reviewers learn to skim past a failure that might one day be genuine.

## Cause

`AGENTS.md` was missing the two lines `CLAUDE.md` has for the Steward mock:

```
- `src/steward/` (export `./steward`) — stateful loopback mock for authenticated
  Steward platform-user deactivation and deletion calls used by account lifecycle E2E.
```

## Fix

`CLAUDE.md` is authoritative per the repo rule ("author `CLAUDE.md`, then copy it to `AGENTS.md`"), so `AGENTS.md` is synced to it rather than the difference being split.

I verified the drifted content is accurate before propagating it rather than assuming the newer file was right — `packages/cloud/test-mocks/src/steward/index.ts` exists, and `package.json:11` maps `"./steward": "./src/steward/index.ts"`. So `CLAUDE.md` was the correct side and `AGENTS.md` was simply stale.

## Evidence

Before (on `develop`): `FAIL`, as quoted above.

After:

```
[assert-agents-claude-identical] PASS: 159 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.
```

Documentation-only; no source, test, or build input is touched.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [pr-finisher]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza"} -->