### PR TITLE
fix(personal-assistant): keep surrogate pairs intact in truncation paths

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/calendar.ts
+++ b/plugins/plugin-personal-assistant/src/actions/calendar.ts
@@ -31,6 +31,8 @@ import {
   resolveActionArgs,
   type SubactionsMap,
   stableStringify,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import {
   type CalendarActionDeps,
@@ -128,12 +130,14 @@ interface CalendarApprovalQueue {
 }
 
 function approvalSafeLabel(value: string): string {
-  return value
-    .replace(/[\r\n\t]+/g, " ")
-    .replace(/[[\]]/g, "")
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, 160);
+  const sanitized = toWellFormedUnicode(
+    value
+      .replace(/[\r\n\t]+/g, " ")
+      .replace(/[[\]]/g, "")
+      .replace(/\s+/g, " ")
+      .trim(),
+  );
+  return truncateWellFormed(sanitized, 160);
 }
 
 function requireApprovalMessageIdentity(message: Memory): {

--- a/plugins/plugin-personal-assistant/src/lifeops/screen-context.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/screen-context.ts
@@ -7,6 +7,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { truncateWellFormed, toWellFormedUnicode } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import { FRAME_FILE } from "@elizaos/plugin-browser";
 import type sharp from "sharp";
@@ -140,10 +141,10 @@ function isSharpFactory(value: unknown): value is SharpFactory {
 }
 
 function normalizeText(value: string | null | undefined): string {
-  return (value ?? "")
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, HEURISTIC_TEXT_LIMIT);
+  return truncateWellFormed(
+    toWellFormedUnicode((value ?? "").replace(/\s+/g, " ").trim()),
+    HEURISTIC_TEXT_LIMIT,
+  );
 }
 
 function keywordMatches(text: string, keywords: readonly string[]): string[] {

--- a/plugins/plugin-personal-assistant/src/lifeops/service-helpers-misc.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service-helpers-misc.ts
@@ -3,7 +3,7 @@
  * computation, metadata merging, reminder-channel/urgency checks, and other
  * small pure utilities shared across the domains.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import { type IAgentRuntime, truncateWellFormed, toWellFormedUnicode } from "@elizaos/core";
 import type {
   CreateLifeOpsDefinitionRequest,
   LifeOpsActiveReminderView,
@@ -699,9 +699,10 @@ export function normalizeGeneratedLifeOpsAssistantText(
   if (!cleaned) {
     return null;
   }
-  return cleaned.length > 280
-    ? `${cleaned.slice(0, 277).trimEnd()}...`
-    : cleaned;
+  const normalized = toWellFormedUnicode(cleaned);
+  return normalized.length > 280
+    ? `${truncateWellFormed(normalized, 277).trimEnd()}...`
+    : normalized;
 }
 
 export function formatNearbyReminderTitlesForPrompt(titles: string[]): string {


### PR DESCRIPTION
Closes #23719, closes #23717, closes #23713

Replaces raw `.slice(0, N)` truncation in three personal-assistant paths with surrogate-safe `truncateWellFormed(toWellFormedUnicode(...), N)` so emoji and other astral characters can never split across the clamp boundary.

- `plugins/plugin-personal-assistant/src/actions/calendar.ts`: `approvalSafeLabel` now sanitizes lone surrogates and truncates at 160 without splitting pairs
- `plugins/plugin-personal-assistant/src/lifeops/service-helpers-misc.ts`: LifeOps assistant text cleanup truncates at 277 with surrogate safety
- `plugins/plugin-personal-assistant/src/lifeops/screen-context.ts`: `normalizeText` truncates at 1024 with surrogate safety