### PR TITLE
fix(agent): keep surrogate pairs intact in chat augmentation contextual document snippet truncation

### DIFF
--- a/packages/agent/src/api/chat-augmentation.surrogate.test.ts
+++ b/packages/agent/src/api/chat-augmentation.surrogate.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression for chat-augmentation document snippet truncation surrogate safety.
+ */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+const CHAT_DOCUMENTS_SNIPPET_MAX_CHARS = 1200;
+
+function formatDocumentSnippet(rawText: string): string {
+  const text = toWellFormedUnicode(rawText.trim());
+  return text.length > CHAT_DOCUMENTS_SNIPPET_MAX_CHARS
+    ? `${truncateWellFormed(text, CHAT_DOCUMENTS_SNIPPET_MAX_CHARS - 3)}...`
+    : text;
+}
+
+function isWellFormed(v: string): boolean {
+  if (!v) return true;
+  if (
+    typeof (v as unknown as { isWellFormed?: () => boolean }).isWellFormed ===
+    "function"
+  )
+    return (v as unknown as { isWellFormed: () => boolean }).isWellFormed();
+  for (let i = 0; i < v.length; i++) {
+    const c = v.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const n = v.charCodeAt(i + 1);
+      if (!(n >= 0xdc00 && n <= 0xdfff)) return false;
+      i++;
+    } else if (c >= 0xdc00 && c <= 0xdfff) return false;
+  }
+  return true;
+}
+
+describe("chat-augmentation snippet surrogate safety", () => {
+  it("keeps surrogate pair intact at 1197 boundary", () => {
+    const fox = String.fromCharCode(0xd83e, 0xdd8a);
+    const input = `${"a".repeat(1196)}${fox}${"b".repeat(50)}`;
+    const out = formatDocumentSnippet(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.endsWith("...")).toBe(true);
+    expect(out).not.toContain("\uD83E");
+  });
+
+  it("preserves fitting emoji under limit", () => {
+    const fox = String.fromCharCode(0xd83e, 0xdd8a);
+    const input = `document preview ${fox}`;
+    const out = formatDocumentSnippet(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out).toBe(input);
+  });
+
+  it("sanitizes lone surrogate in document excerpt", () => {
+    const lone = `doc ${String.fromCharCode(0xd800)} ${"a".repeat(2000)}`;
+    const out = formatDocumentSnippet(lone);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("\uFFFD")).toBe(true);
+  });
+});

--- a/packages/agent/src/api/chat-augmentation.ts
+++ b/packages/agent/src/api/chat-augmentation.ts
@@ -20,6 +20,8 @@ import {
   aliasRecallQuery,
   buildAccessContext,
   embedRecallQuery,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import { normalizeCharacterLanguage } from "@elizaos/shared";
 import { extractCompatTextContent } from "./compat-utils.ts";
@@ -438,10 +440,10 @@ export async function maybeAugmentChatMessageWithDocuments(
               metadata.title.trim().length > 0
             ? metadata.title.trim()
             : `source-${index + 1}`;
-      const text = (match.content.text ?? "").trim();
+      const text = toWellFormedUnicode((match.content.text ?? "").trim());
       const snippet =
         text.length > CHAT_DOCUMENTS_SNIPPET_MAX_CHARS
-          ? `${text.slice(0, CHAT_DOCUMENTS_SNIPPET_MAX_CHARS - 3)}...`
+          ? `${truncateWellFormed(text, CHAT_DOCUMENTS_SNIPPET_MAX_CHARS - 3)}...`
           : text;
       return [
         `<source title=${JSON.stringify(title)} similarity=${JSON.stringify(


### PR DESCRIPTION
### Summary
Keep surrogate pairs intact and sanitize lone surrogates in chat augmentation contextual document snippet truncation (`augmentWithContextualDocuments`).

### Root Cause
When document excerpts containing multi-byte UTF-16 code units (e.g. emoji or supplementary symbols) were formatted into prompt source snippets via `text.slice(0, CHAT_DOCUMENTS_SNIPPET_MAX_CHARS - 3)`, the slice could cut across a surrogate pair at the boundary. This injected invalid lone surrogates into the LLM system prompt context, triggering HTTP 400 rejection on strict JSON-validating inference endpoints (OpenAI, Anthropic, Cerebras).

### Solution
- Use `toWellFormedUnicode` on extracted document text.
- Use `truncateWellFormed(text, CHAT_DOCUMENTS_SNIPPET_MAX_CHARS - 3)` so truncation always respects code point boundaries.
- Added deterministic surrogate regression unit tests for document snippet formatting.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — fix(agent)]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza"} -->