### PR TITLE
fix(agent): keep surrogate pairs intact in bug report input sanitization

### DIFF
--- a/packages/agent/src/api/bug-report-routes.surrogate.test.ts
+++ b/packages/agent/src/api/bug-report-routes.surrogate.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression for bug-report input sanitization surrogate safety.
+ */
+
+import { describe, expect, it } from "vitest";
+import { sanitize } from "./bug-report-routes.ts";
+
+function isWellFormed(v: string): boolean {
+  if (!v) return true;
+  if (
+    typeof (v as unknown as { isWellFormed?: () => boolean }).isWellFormed ===
+    "function"
+  )
+    return (v as unknown as { isWellFormed: () => boolean }).isWellFormed();
+  for (let i = 0; i < v.length; i++) {
+    const c = v.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const n = v.charCodeAt(i + 1);
+      if (!(n >= 0xdc00 && n <= 0xdfff)) return false;
+      i++;
+    } else if (c >= 0xdc00 && c <= 0xdfff) return false;
+  }
+  return true;
+}
+
+describe("bug-report sanitize surrogate safety", () => {
+  it("keeps surrogate pair intact at custom maxLen boundary", () => {
+    const maxLen = 100;
+    const fox = String.fromCharCode(0xd83e, 0xdd8a);
+    const input = `${"a".repeat(99)}${fox}${"b".repeat(50)}`;
+    const out = sanitize(input, maxLen);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBe(99);
+  });
+
+  it("preserves HTML stripped content with emojis safely", () => {
+    const fox = String.fromCharCode(0xd83e, 0xdd8a);
+    const input = `<div>Crash report ${fox} error</div>`;
+    const out = sanitize(input, 10_000);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out).toBe(`Crash report ${fox} error`);
+  });
+
+  it("sanitizes lone surrogate in report body", () => {
+    const lone = `stack ${String.fromCharCode(0xd800)} trace ${"a".repeat(200)}`;
+    const out = sanitize(lone, 100);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("\uFFFD")).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(100);
+  });
+});

--- a/packages/agent/src/api/bug-report-routes.ts
+++ b/packages/agent/src/api/bug-report-routes.ts
@@ -8,7 +8,12 @@
  * opens itself.
  */
 import os from "node:os";
-import { logger, type RouteRequestContext } from "@elizaos/core";
+import {
+  logger,
+  type RouteRequestContext,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import { PostBugReportRequestSchema } from "@elizaos/shared";
 
 export const DEFAULT_BUG_REPORT_REPO = "elizaOS/eliza";
@@ -128,14 +133,21 @@ interface BugReportBody {
 }
 
 export function sanitize(input: string, maxLen = 10_000): string {
-  const clipped = input.length > maxLen ? input.slice(0, maxLen) : input;
+  const wellFormed = toWellFormedUnicode(input);
+  const clipped =
+    wellFormed.length > maxLen
+      ? truncateWellFormed(wellFormed, maxLen)
+      : wellFormed;
   let prev = clipped;
   let next = prev.replace(/<[^<>]{0,1024}>/g, "");
   while (next !== prev) {
     prev = next;
     next = prev.replace(/<[^<>]{0,1024}>/g, "");
   }
-  return next.replace(/[<>]/g, "").slice(0, maxLen);
+  const cleaned = next.replace(/[<>]/g, "");
+  return cleaned.length > maxLen
+    ? truncateWellFormed(cleaned, maxLen)
+    : cleaned;
 }
 
 function redactSecrets(input: string, maxLen = 10_000): string {


### PR DESCRIPTION
### Summary
Keep surrogate pairs intact and sanitize lone surrogates in bug report input sanitization (`sanitize`).

### Root Cause
When user bug reports, error stack traces, or diagnostic payloads containing multi-byte UTF-16 code units (e.g. emoji or supplementary symbols) were sanitized, `input.slice(0, maxLen)` and `next.slice(0, maxLen)` could bisect a surrogate pair at the boundary. This created invalid lone surrogates in generated GitHub issues or remote intake requests.

### Solution
- Use `toWellFormedUnicode` on input text to sanitize lone surrogates.
- Use `truncateWellFormed` to enforce the length cap without splitting code points.
- Added deterministic surrogate regression unit tests for `sanitize`.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — fix(agent)]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza"} -->