### PR TITLE
fix(core): keep surrogate pairs intact in action parameter array split capping

### DIFF
--- a/packages/core/src/actions-param-array.surrogate.test.ts
+++ b/packages/core/src/actions-param-array.surrogate.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression for action parameter array split capping surrogate safety (10,000).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "./utils/well-formed.ts";
+
+const SAFE_SPLIT_LIMIT = 10_000;
+
+function splitParamArray(trimmed: string): string[] {
+	const wellFormedTrimmed = toWellFormedUnicode(trimmed);
+	const safeTrimmed =
+		wellFormedTrimmed.length > SAFE_SPLIT_LIMIT
+			? truncateWellFormed(wellFormedTrimmed, SAFE_SPLIT_LIMIT)
+			: wellFormedTrimmed;
+	return safeTrimmed
+		.split(/\|\||,|\n/)
+		.map((entry) => entry.trim())
+		.filter((entry) => entry.length > 0);
+}
+
+function isWellFormed(v: string): boolean {
+	if (!v) return true;
+	if (
+		typeof (v as unknown as { isWellFormed?: () => boolean }).isWellFormed ===
+		"function"
+	)
+		return (v as unknown as { isWellFormed: () => boolean }).isWellFormed();
+	for (let i = 0; i < v.length; i++) {
+		const c = v.charCodeAt(i);
+		if (c >= 0xd800 && c <= 0xdbff) {
+			const n = v.charCodeAt(i + 1);
+			if (!(n >= 0xdc00 && n <= 0xdfff)) return false;
+			i++;
+		} else if (c >= 0xdc00 && c <= 0xdfff) return false;
+	}
+	return true;
+}
+
+describe("action param array split surrogate safety", () => {
+	it("keeps surrogate pair intact at 10,000-char boundary", () => {
+		const fox = String.fromCharCode(0xd83e, 0xdd8a);
+		const input = `${"a".repeat(9999)}${fox},item2,item3`;
+		const out = splitParamArray(input);
+		expect(out.length).toBeGreaterThan(0);
+		for (const item of out) {
+			expect(isWellFormed(item)).toBe(true);
+		}
+	});
+
+	it("preserves multiple emoji array entries under limit", () => {
+		const fox = String.fromCharCode(0xd83e, 0xdd8a);
+		const input = `tag1,${fox},tag3,${fox} 🦊`;
+		const out = splitParamArray(input);
+		expect(out).toEqual(["tag1", fox, "tag3", `${fox} 🦊`]);
+		for (const item of out) {
+			expect(isWellFormed(item)).toBe(true);
+		}
+	});
+
+	it("sanitizes lone surrogate before splitting", () => {
+		const lone = `item1,${String.fromCharCode(0xd800)},${"b".repeat(20000)}`;
+		const out = splitParamArray(lone);
+		for (const item of out) {
+			expect(isWellFormed(item)).toBe(true);
+		}
+		expect(out[1]).toBe("\uFFFD");
+	});
+});

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -37,6 +37,10 @@ import {
 	getDeterministicNames,
 } from "./utils/deterministic";
 import { compressPromptDescription } from "./utils/prompt-compression";
+import {
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "./utils/well-formed.ts";
 
 export {
 	type ExtractorPipelineResult,
@@ -496,10 +500,11 @@ function coerceActionParamValue(
 	}
 
 	const SAFE_SPLIT_LIMIT = 10_000;
+	const wellFormedTrimmed = toWellFormedUnicode(trimmed);
 	const safeTrimmed =
-		trimmed.length > SAFE_SPLIT_LIMIT
-			? trimmed.slice(0, SAFE_SPLIT_LIMIT)
-			: trimmed;
+		wellFormedTrimmed.length > SAFE_SPLIT_LIMIT
+			? truncateWellFormed(wellFormedTrimmed, SAFE_SPLIT_LIMIT)
+			: wellFormedTrimmed;
 	const splitValues = safeTrimmed
 		.split(/\|\||,|\n/)
 		.map((entry) => entry.trim())


### PR DESCRIPTION
### Summary
Keep surrogate pairs intact and sanitize lone surrogates in core action parameter array split capping (`parseActionParamsArray`).

### Root Cause
When array action parameters represented as delimited strings were normalized and capped via `trimmed.slice(0, SAFE_SPLIT_LIMIT)` at 10,000 characters, the cut could split across a surrogate pair boundary. This produced invalid lone surrogates in parsed action argument lists passed to action handlers.

### Solution
- Use `toWellFormedUnicode` on input parameters before capping.
- Use `truncateWellFormed` to enforce the 10,000 character limit without bisecting code points.
- Added deterministic surrogate regression unit tests for delimited action parameter splitting.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — fix(core)]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza"} -->