### PR TITLE
fix(wallet): keep surrogate pairs intact and prevent length overflow in news formatter truncation

### DIFF
--- a/plugins/plugin-wallet/src/analytics/news/utils/formatters.surrogate.test.ts
+++ b/plugins/plugin-wallet/src/analytics/news/utils/formatters.surrogate.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Regression for plugin-wallet news formatter truncateText surrogate safety.
+ */
+
+import { describe, expect, it } from "vitest";
+import { truncateText } from "./formatters.ts";
+
+function isWellFormed(v: string): boolean {
+  if (!v) return true;
+  if (
+    typeof (v as unknown as { isWellFormed?: () => boolean }).isWellFormed ===
+    "function"
+  )
+    return (v as unknown as { isWellFormed: () => boolean }).isWellFormed();
+  for (let i = 0; i < v.length; i++) {
+    const c = v.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const n = v.charCodeAt(i + 1);
+      if (!(n >= 0xdc00 && n <= 0xdfff)) return false;
+      i++;
+    } else if (c >= 0xdc00 && c <= 0xdfff) return false;
+  }
+  return true;
+}
+
+describe("plugin-wallet truncateText surrogate safety", () => {
+  it("keeps surrogate pair intact at 200-char default limit", () => {
+    const fox = String.fromCharCode(0xd83e, 0xdd8a);
+    const input = `${"a".repeat(196)}${fox}${"b".repeat(50)}`;
+    const out = truncateText(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(200);
+    expect(out.endsWith("...")).toBe(true);
+    expect(out).not.toContain("\uD83E");
+  });
+
+  it("preserves fitting emoji under limit", () => {
+    const fox = String.fromCharCode(0xd83e, 0xdd8a);
+    const input = `Crypto news update ${fox}`;
+    const out = truncateText(input, 200);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out).toBe(input);
+  });
+
+  it("handles very short maxLength gracefully", () => {
+    expect(truncateText("hello world", 2)).toBe("..");
+    expect(truncateText("hello world", 3)).toBe("...");
+  });
+
+  it("sanitizes lone surrogate in news text", () => {
+    const lone = `news ${String.fromCharCode(0xd800)} item ${"a".repeat(300)}`;
+    const out = truncateText(lone, 100);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("\uFFFD")).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(100);
+  });
+});

--- a/plugins/plugin-wallet/src/analytics/news/utils/formatters.ts
+++ b/plugins/plugin-wallet/src/analytics/news/utils/formatters.ts
@@ -1,3 +1,5 @@
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+
 /**
  * Utility functions for formatting DeFi news data
  */
@@ -64,10 +66,14 @@ export function formatRelativeTime(timestamp: number | string): string {
  * Truncate text to a maximum length
  */
 export function truncateText(text: string, maxLength: number = 200): string {
-  if (text.length <= maxLength) {
-    return text;
+  const wellFormed = toWellFormedUnicode(text);
+  if (wellFormed.length <= maxLength) {
+    return wellFormed;
   }
-  return `${text.substring(0, maxLength)}...`;
+  if (maxLength <= 3) {
+    return "...".slice(0, maxLength);
+  }
+  return `${truncateWellFormed(wellFormed, maxLength - 3)}...`;
 }
 
 /**


### PR DESCRIPTION
### Summary
Keep surrogate pairs intact, prevent length cap overflow, and sanitize lone surrogates in wallet news formatter text truncation (`truncateText`).

### Root Cause
`truncateText` in `plugins/plugin-wallet` previously used `text.substring(0, maxLength) + "..."`. This caused two bugs:
1. Slicing at `maxLength` without checking code point boundaries could bisect a multi-byte UTF-16 surrogate pair, leaving an invalid lone surrogate.
2. Appending `"..."` to `text.substring(0, maxLength)` produced a string of length `maxLength + 3`, overflowing the intended character limit.

### Solution
- Use `toWellFormedUnicode` on input text.
- Use `truncateWellFormed(wellFormed, maxLength - 3) + "..."` so the final truncated output never exceeds `maxLength` and code points stay intact.
- Handle very short `maxLength <= 3` edge cases cleanly.
- Added deterministic surrogate regression unit tests for `truncateText`.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — fix(wallet)]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza"} -->