### PR TITLE
fix(agent): escape regex metacharacters in plugin discovery prefixLabel

### DIFF
--- a/packages/agent/src/api/plugin-discovery-helpers.prefix-label.test.ts
+++ b/packages/agent/src/api/plugin-discovery-helpers.prefix-label.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Tests for prefixLabel with regex special character suffixes.
+ */
+
+import { describe, expect, it } from "vitest";
+import { prefixLabel } from "./plugin-discovery-helpers.ts";
+
+describe("prefixLabel regex safety", () => {
+  it("strips ordinary suffixes correctly", () => {
+    expect(prefixLabel("anthropic_api_key", "_api_key")).toBe("Anthropic");
+    expect(prefixLabel("openai_key", "_key")).toBe("Openai");
+  });
+
+  it("handles suffixes containing regex special characters without crashing or misinterpreting", () => {
+    expect(prefixLabel("config.json", ".json")).toBe("Config");
+    expect(prefixLabel("service+prod", "+prod")).toBe("Service");
+    expect(prefixLabel("key(secret)", "(secret)")).toBe("Key");
+    expect(prefixLabel("target[0]", "[0]")).toBe("Target");
+    expect(prefixLabel("special$val", "$val")).toBe("Special");
+  });
+
+  it("falls back to key when nothing remains after stripping", () => {
+    expect(prefixLabel("_api_key", "_api_key")).toBe("_api_key");
+  });
+});

--- a/packages/agent/src/api/plugin-discovery-helpers.ts
+++ b/packages/agent/src/api/plugin-discovery-helpers.ts
@@ -649,7 +649,10 @@ export function inferDescription(key: string): string {
 
 /** Extract the plugin/service prefix label from a key by removing a known suffix. */
 export function prefixLabel(key: string, suffix: string): string {
-  const raw = key.replace(new RegExp(`${suffix}$`, "i"), "").replace(/_+$/, "");
+  const escapedSuffix = suffix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const raw = key
+    .replace(new RegExp(`${escapedSuffix}$`, "i"), "")
+    .replace(/_+$/, "");
   if (!raw) return key;
   return raw
     .split("_")


### PR DESCRIPTION
### Summary
Escape regular expression metacharacters in plugin discovery `prefixLabel` when stripping suffixes.

### Root Cause
`prefixLabel` previously constructed dynamic regular expressions directly via `new RegExp(`${suffix}$`, "i")` without escaping `suffix`. When suffixes contained regex metacharacters (such as `.`, `$`, `+`, `(`, `)`, `[`, `]`), `RegExp` threw a `SyntaxError` or matched regex patterns rather than literal string suffixes.

### Solution
- Escape all special regex metacharacters in `suffix` before creating the RegExp instance.
- Added comprehensive unit tests for `prefixLabel` covering suffixes with special regex characters (`.json`, `+prod`, `(secret)`, `[0]`, `$val`).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — fix(agent)]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza"} -->