### PR TITLE
fix(core): keep surrogate pairs intact in fallback reply credit scan clamp

### DIFF
--- a/packages/core/src/services/message/fallback-reply-clamp.surrogate.test.ts
+++ b/packages/core/src/services/message/fallback-reply-clamp.surrogate.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression for fallback-reply clampForScan surrogate safety (10,000).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	clampForScan,
+	isInsufficientCreditsMessage,
+} from "./fallback-reply.ts";
+
+function isWellFormed(v: string): boolean {
+	if (!v) return true;
+	if (
+		typeof (v as unknown as { isWellFormed?: () => boolean }).isWellFormed ===
+		"function"
+	)
+		return (v as unknown as { isWellFormed: () => boolean }).isWellFormed();
+	for (let i = 0; i < v.length; i++) {
+		const c = v.charCodeAt(i);
+		if (c >= 0xd800 && c <= 0xdbff) {
+			const n = v.charCodeAt(i + 1);
+			if (!(n >= 0xdc00 && n <= 0xdfff)) return false;
+			i++;
+		} else if (c >= 0xdc00 && c <= 0xdfff) return false;
+	}
+	return true;
+}
+
+describe("fallback-reply clampForScan surrogate safety", () => {
+	it("keeps surrogate pair intact at 10,000-char boundary", () => {
+		const fox = String.fromCharCode(0xd83e, 0xdd8a);
+		const input = `${"a".repeat(9999)}${fox}${"b".repeat(50)}`;
+		const out = clampForScan(input);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.length).toBe(9999);
+		expect(out).not.toContain("\uD83E");
+	});
+
+	it("detects billing error with emoji cleanly", () => {
+		const fox = String.fromCharCode(0xd83e, 0xdd8a);
+		expect(
+			isInsufficientCreditsMessage(`Error ${fox}: insufficient_quota`),
+		).toBe(true);
+	});
+
+	it("sanitizes lone surrogate in error payload", () => {
+		const lone = `error ${String.fromCharCode(0xd800)} ${"a".repeat(20000)}`;
+		const out = clampForScan(lone);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.includes("\uFFFD")).toBe(true);
+		expect(out.length).toBeLessThanOrEqual(10_000);
+	});
+});

--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -18,6 +18,10 @@ import {
 	stripPairedTagBlocks,
 	stripUnclosedTagSuffix,
 } from "../../utils/reasoning-tags";
+import {
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "../../utils/well-formed.ts";
 
 type ErrorWithStatus = {
 	code?: unknown;
@@ -184,8 +188,11 @@ const BILLING_KEYWORDS_RE =
 
 /** Cap a value before running a regex scan so a pathological provider payload
  *  cannot turn a substring match into a catastrophic-backtracking DoS. */
-function clampForScan(value: string): string {
-	return value.length > 10_000 ? value.slice(0, 10_000) : value;
+export function clampForScan(value: string): string {
+	const wellFormed = toWellFormedUnicode(value);
+	return wellFormed.length > 10_000
+		? truncateWellFormed(wellFormed, 10_000)
+		: wellFormed;
 }
 
 export function isInsufficientCreditsMessage(message: string): boolean {


### PR DESCRIPTION
### Summary
Keep surrogate pairs intact and sanitize lone surrogates in fallback reply error message clamping (`clampForScan`).

### Root Cause
`clampForScan` in `packages/core/src/services/message/fallback-reply.ts` previously used `value.slice(0, 10_000)` to guard against regex DoS when checking for provider quota/billing failure signatures. If an error payload had a multi-byte UTF-16 character across index 9,999/10,000, raw slicing left an invalid lone high surrogate before testing against the billing regex pattern.

### Solution
- Use `toWellFormedUnicode` on input error messages.
- Use `truncateWellFormed` to enforce the 10,000 character limit without slicing surrogate pairs.
- Added deterministic surrogate regression unit tests for `clampForScan`.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — fix(core)]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza"} -->