### PR TITLE
fix(core): keep surrogate pairs intact in direct action heuristics identifier unwrapping

### DIFF
--- a/packages/core/src/services/message/direct-action-heuristics.surrogate.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.surrogate.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression for direct-action-heuristics unwrapPlannerIdentifier surrogate safety.
+ */
+
+import { describe, expect, it } from "vitest";
+import { unwrapPlannerIdentifier } from "./direct-action-heuristics.ts";
+
+function isWellFormed(v: string): boolean {
+	if (!v) return true;
+	if (
+		typeof (v as unknown as { isWellFormed?: () => boolean }).isWellFormed ===
+		"function"
+	)
+		return (v as unknown as { isWellFormed: () => boolean }).isWellFormed();
+	for (let i = 0; i < v.length; i++) {
+		const c = v.charCodeAt(i);
+		if (c >= 0xd800 && c <= 0xdbff) {
+			const n = v.charCodeAt(i + 1);
+			if (!(n >= 0xdc00 && n <= 0xdfff)) return false;
+			i++;
+		} else if (c >= 0xdc00 && c <= 0xdfff) return false;
+	}
+	return true;
+}
+
+describe("direct-action-heuristics unwrapPlannerIdentifier surrogate safety", () => {
+	it("keeps surrogate pair intact at 10,000-char boundary", () => {
+		const fox = String.fromCharCode(0xd83e, 0xdd8a);
+		const input = `${"a".repeat(9999)}${fox}${"b".repeat(50)}`;
+		const out = unwrapPlannerIdentifier(input);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.length).toBe(9999);
+		expect(out).not.toContain("\uD83E");
+	});
+
+	it("unwraps XML tag identifiers correctly", () => {
+		expect(unwrapPlannerIdentifier("<SEND_MESSAGE>")).toBe("SEND_MESSAGE");
+		expect(unwrapPlannerIdentifier('"SEND_MESSAGE"')).toBe("SEND_MESSAGE");
+	});
+
+	it("sanitizes lone surrogate in raw planner token", () => {
+		const lone = `planner ${String.fromCharCode(0xd800)} action ${"a".repeat(20000)}`;
+		const out = unwrapPlannerIdentifier(lone);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.includes("\uFFFD")).toBe(true);
+		expect(out.length).toBeLessThanOrEqual(10_000);
+	});
+});

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -10,6 +10,10 @@
 import { isReservedNonToolActionName } from "../../action-names";
 import type { Action } from "../../types/components";
 import { trimEndCharacters } from "../../utils/string-boundaries";
+import {
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "../../utils/well-formed.ts";
 
 export interface DirectActionInferenceHooks {
 	looksLikeCodingWorkRequest?: (text: string) => boolean;
@@ -18,8 +22,12 @@ export interface DirectActionInferenceHooks {
 	) => string | undefined;
 }
 
-function unwrapPlannerIdentifier(value: string): string {
-	const safe = value.length > 10_000 ? value.slice(0, 10_000) : value;
+export function unwrapPlannerIdentifier(value: string): string {
+	const wellFormed = toWellFormedUnicode(value);
+	const safe =
+		wellFormed.length > 10_000
+			? truncateWellFormed(wellFormed, 10_000)
+			: wellFormed;
 	const trimmed = safe
 		.trim()
 		.replace(/^(?:[-*]|\d+[.)])\s+/, "")


### PR DESCRIPTION
### Summary
Keep surrogate pairs intact and sanitize lone surrogates in `unwrapPlannerIdentifier` (`direct-action-heuristics.ts`).

### Root Cause
`unwrapPlannerIdentifier` in `packages/core/src/services/message/direct-action-heuristics.ts` previously capped planner identifier strings using `value.slice(0, 10_000)` without UTF-16 code point validation. When a long token crossed the 10,000-character boundary in the middle of a surrogate pair, it produced an invalid lone surrogate.

### Solution
- Use `toWellFormedUnicode` on raw planner identifier strings.
- Use `truncateWellFormed` to enforce the 10,000 character limit without bisecting surrogate pairs.
- Added deterministic surrogate regression unit tests for `unwrapPlannerIdentifier`.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — fix(core)]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza"} -->