### PR TITLE
fix(core): carry failure provenance onto the repeated-failure trajectory limit

### DIFF
--- a/packages/core/src/runtime/limits.test.ts
+++ b/packages/core/src/runtime/limits.test.ts
@@ -153,3 +153,56 @@ describe("countRepeatedFailures / assertRepeatedFailureLimit", () => {
 		}
 	});
 });
+
+describe("repeated-failure provenance", () => {
+	// classifyStructuredFailureCause (services/message/fallback-reply.ts) reads
+	// error.failureProvenance?.kind to tell the user *why* a tool kept failing.
+	// The field has to survive the throw or that reader silently degrades every
+	// repeated-failure abort to generic planner exhaustion.
+	const persistenceFailure = {
+		success: false as const,
+		toolName: "SAVE_MEMORY",
+		error: "datastore unreachable",
+		failureProvenance: {
+			kind: "persistence_error" as const,
+			boundary: "persistence" as const,
+			code: "ACTION_PERSISTENCE_FAILED",
+			retryable: true,
+		},
+	};
+
+	it("carries the underlying failure provenance onto the thrown limit", () => {
+		expect(() =>
+			assertRepeatedFailureLimit({
+				failures: [persistenceFailure, persistenceFailure],
+				latestFailure: persistenceFailure,
+				maxRepeatedFailures: 1,
+			}),
+		).toThrow(TrajectoryLimitExceeded);
+
+		try {
+			assertRepeatedFailureLimit({
+				failures: [persistenceFailure, persistenceFailure],
+				latestFailure: persistenceFailure,
+				maxRepeatedFailures: 1,
+			});
+		} catch (e) {
+			expect((e as TrajectoryLimitExceeded).failureProvenance?.kind).toBe(
+				"persistence_error",
+			);
+		}
+	});
+
+	it("leaves provenance undefined when the failure carries none", () => {
+		try {
+			const bare = { success: false as const, toolName: "X", error: "boom" };
+			assertRepeatedFailureLimit({
+				failures: [bare, bare],
+				latestFailure: bare,
+				maxRepeatedFailures: 1,
+			});
+		} catch (e) {
+			expect((e as TrajectoryLimitExceeded).failureProvenance).toBeUndefined();
+		}
+	});
+});

--- a/packages/core/src/runtime/limits.ts
+++ b/packages/core/src/runtime/limits.ts
@@ -1,3 +1,4 @@
+import type { ActionFailureProvenance } from "../types/action-failure";
 import { truncateWellFormed } from "../utils/well-formed";
 
 /**
@@ -153,12 +154,19 @@ export class TrajectoryLimitExceeded extends Error {
 	readonly kind: TrajectoryLimitKind;
 	readonly max: number;
 	readonly observed: number;
+	/**
+	 * Present only for `repeated_failures`, where the underlying tool failure
+	 * has a structured cause worth surfacing. Consumed by
+	 * `classifyStructuredFailureCause` in `services/message/fallback-reply.ts`.
+	 */
+	readonly failureProvenance?: ActionFailureProvenance;
 
 	constructor(params: {
 		kind: TrajectoryLimitKind;
 		max: number;
 		observed: number;
 		message?: string;
+		failureProvenance?: ActionFailureProvenance;
 	}) {
 		super(
 			params.message ??
@@ -168,6 +176,9 @@ export class TrajectoryLimitExceeded extends Error {
 		this.kind = params.kind;
 		this.max = params.max;
 		this.observed = params.observed;
+		if (params.failureProvenance !== undefined) {
+			this.failureProvenance = params.failureProvenance;
+		}
 	}
 }
 
@@ -198,6 +209,13 @@ export interface FailureLike {
 	error?: unknown;
 	success?: boolean;
 	repeatKey?: string;
+	/**
+	 * Structured cause carried up from the settled `ActionResult`. When a
+	 * repeated-failure abort is raised, this is what lets the fallback reply
+	 * say *why* the tool kept failing (a dead datastore, say) rather than
+	 * reporting generic planner exhaustion.
+	 */
+	failureProvenance?: ActionFailureProvenance;
 }
 
 export function getFailureSignature(failure: FailureLike): string | null {
@@ -260,6 +278,7 @@ export function assertRepeatedFailureLimit(params: {
 			message: `Repeated tool failure limit exceeded for ${getFailureSignature(
 				params.latestFailure,
 			)}`,
+			failureProvenance: params.latestFailure.failureProvenance,
 		});
 	}
 }


### PR DESCRIPTION
## Problem

**`packages/core` does not compile on `develop`.**

```
packages/core/src/services/message/fallback-reply.ts(353,18): error TS2339:
  Property 'failureProvenance' does not exist on type 'TrajectoryLimitExceeded'.
```

`bun run build:core` aborts on it, and because it aborts mid-`tsc` it leaves a partial `packages/core/dist/**/*.d.ts` tree behind — which then makes Bun resolve `@elizaos/core` to a broken declaration file, so the failure spreads to unrelated packages as a confusing resolution error rather than an obvious type error. Two independent workstreams hit this today and both had to hand-delete the partial dist to make progress.

## Cause

The reader was landed without the producer. `classifyStructuredFailureCause` does:

```ts
case "repeated_failures":
  return error.failureProvenance?.kind ?? "planner_exhaustion";
```

but `TrajectoryLimitExceeded` (`packages/core/src/runtime/limits.ts:152`) declares only `kind`, `max`, and `observed`. Nothing ever set `failureProvenance`, and nothing declared it.

The intent is legible from the surrounding types and is worth preserving rather than deleting the read: `StructuredFailureCause` is exactly `ActionFailureProvenance["kind"]` plus `planner_exhaustion` and `transient`, and `execute-planned-tool-call.test.ts:151` already asserts that a *thrown* value carries `failureProvenance`. So the design is that a repeated-failure abort reports **why** the tool kept failing — a dead datastore is `persistence_error`, not generic planner exhaustion. That distinction is the difference between telling a user their request is retryable and telling them the system is degraded.

## Fix

Plumb the provenance from the settled `ActionResult` through to the throw:

- `FailureLike` gains an optional `failureProvenance?: ActionFailureProvenance`.
- `TrajectoryLimitExceeded` declares and assigns it.
- `assertRepeatedFailureLimit` passes `params.latestFailure.failureProvenance` at the throw site.

Deleting the read would have been the smaller diff, but it would have silently discarded a real signal that the rest of the type graph is built to carry.

## Evidence

`tsc --noEmit -p packages/core/tsconfig.json`, counting errors in `fallback-reply.ts`:

```
=== BEFORE (develop) ===
1
=== AFTER (fix) ===
0
```

The three remaining repo-wide errors are the ungenerated `i18n/generated/validation-keyword-data.ts` artifact, unrelated and pre-existing.

`packages/core` `limits.test.ts`: **16/16 pass** (14 existing + 2 new). The new cases pin both directions — that provenance survives the throw, and that it stays `undefined` when the underlying failure carries none, so a future change cannot start fabricating a cause.

Biome clean.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [pr-finisher]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza"} -->