### PR TITLE
fix(core): restore failure-signature normalization dropped by #23734

### DIFF
--- a/packages/core/src/runtime/limits.surrogate.test.ts
+++ b/packages/core/src/runtime/limits.surrogate.test.ts
@@ -2,59 +2,80 @@
  * Regression for limits surrogate-safe truncation (240).
  */
 
-import { toWellFormedUnicode, truncateWellFormed } from "../utils/well-formed.ts";
 import { describe, expect, it } from "vitest";
+
+import { toWellFormedUnicode, truncateWellFormed } from "../utils/well-formed";
+import { getFailureSignature } from "./limits";
 
 const LIMITS_TRUNCATE = 240;
 
 function clampLimits(text: string): string {
-  const wellFormed = toWellFormedUnicode(text ?? "");
-  return truncateWellFormed(wellFormed, LIMITS_TRUNCATE);
+	const wellFormed = toWellFormedUnicode(text ?? "");
+	return truncateWellFormed(wellFormed, LIMITS_TRUNCATE);
 }
 
 function isWellFormed(s: string): boolean {
-  const w = s as unknown as { isWellFormed?: () => boolean };
-  if (typeof w.isWellFormed === "function") return w.isWellFormed();
-  return toWellFormedUnicode(s) === s;
+	const w = s as unknown as { isWellFormed?: () => boolean };
+	if (typeof w.isWellFormed === "function") return w.isWellFormed();
+	return toWellFormedUnicode(s) === s;
 }
 
 describe("limits well-formed", () => {
-  it("backs off astral at 240 boundary (239+fox->239)", () => {
-    const fox = "🦊";
-    const input = `${"a".repeat(239)}${fox}${"b".repeat(20)}`;
-    const out = clampLimits(input);
-    expect(isWellFormed(out)).toBe(true);
-    expect(out.length).toBe(239);
-    expect(out).toBe("a".repeat(239));
-  });
+	it("backs off astral at 240 boundary (239+fox->239)", () => {
+		const fox = "🦊";
+		const input = `${"a".repeat(239)}${fox}${"b".repeat(20)}`;
+		const out = clampLimits(input);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.length).toBe(239);
+		expect(out).toBe("a".repeat(239));
+	});
 
-  it("preserves fitting astral at 240 (238+fox intact)", () => {
-    const fox = "🦊";
-    const input = `${"a".repeat(238)}${fox}`;
-    const out = clampLimits(input);
-    expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe(input);
-    expect(out.length).toBe(240);
-  });
+	it("preserves fitting astral at 240 (238+fox intact)", () => {
+		const fox = "🦊";
+		const input = `${"a".repeat(238)}${fox}`;
+		const out = clampLimits(input);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out).toBe(input);
+		expect(out.length).toBe(240);
+	});
 
-  it("sanitizes lone high surrogate", () => {
-    const lone = `err ${String.fromCharCode(0xd800)} text`;
-    const out = clampLimits(`${lone}${"x".repeat(300)}`);
-    expect(isWellFormed(out)).toBe(true);
-    expect(out.includes("�")).toBe(true);
-  });
+	it("sanitizes lone high surrogate", () => {
+		const lone = `err ${String.fromCharCode(0xd800)} text`;
+		const out = clampLimits(`${lone}${"x".repeat(300)}`);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.includes("�")).toBe(true);
+	});
 
-  it("short passthrough", () => {
-    expect(clampLimits("short error")).toBe("short error");
-  });
+	it("short passthrough", () => {
+		expect(clampLimits("short error")).toBe("short error");
+	});
 
-  it("sweep around 240 well-formed", () => {
-    const fox = "🦊";
-    for (let n = 235; n <= 245; n++) {
-      const input = `${"x".repeat(n)}${fox}${"y".repeat(20)}`;
-      const out = clampLimits(input);
-      expect(isWellFormed(out)).toBe(true);
-      expect(out.length).toBeLessThanOrEqual(240);
-    }
-  });
+	it("sweep around 240 well-formed", () => {
+		const fox = "🦊";
+		for (let n = 235; n <= 245; n++) {
+			const input = `${"x".repeat(n)}${fox}${"y".repeat(20)}`;
+			const out = clampLimits(input);
+			expect(isWellFormed(out)).toBe(true);
+			expect(out.length).toBeLessThanOrEqual(240);
+		}
+	});
+});
+
+describe("getFailureSignature normalizes pre-existing lone surrogates", () => {
+	// truncateWellFormed only guards the cut boundary. A lone surrogate that is
+	// already sitting in the provider's error text — well short of 240 chars —
+	// survives truncation untouched, so the normalization pass is what repairs
+	// it. Dropping toWellFormedUnicode leaves the existing boundary tests green,
+	// which is how that regression got through once already.
+	it("repairs a lone surrogate far from the truncation boundary", () => {
+		const signature = getFailureSignature({
+			success: false,
+			toolName: "WEB_FETCH",
+			error: `upstream said \uD800 and stopped`,
+		});
+
+		expect(signature).not.toBeNull();
+		expect(signature as string).toBe(toWellFormedUnicode(signature as string));
+		expect((signature as string).includes("\uD800")).toBe(false);
+	});
 });

--- a/packages/core/src/runtime/limits.ts
+++ b/packages/core/src/runtime/limits.ts
@@ -1,6 +1,3 @@
-import type { ActionFailureProvenance } from "../types/action-failure";
-import { truncateWellFormed } from "../utils/well-formed";
-
 /**
  * Bounds and guard functions for the planner chaining loop: the
  * `ChainingLoopConfig` limit contract (max tool calls, repeated-failure and
@@ -8,6 +5,9 @@ import { truncateWellFormed } from "../utils/well-formed";
  * `TrajectoryLimitExceeded` error, and the assert/count helpers that stop a
  * runaway or stuck planner from burning a turn.
  */
+import type { ActionFailureProvenance } from "../types/action-failure";
+import { toWellFormedUnicode, truncateWellFormed } from "../utils/well-formed";
+
 export interface ChainingLoopConfig {
 	/** Maximum tool calls executed during one planner loop. */
 	maxToolCalls: number;
@@ -232,8 +232,11 @@ export function getFailureSignature(failure: FailureLike): string | null {
 				: failure.error == null
 					? "failed"
 					: JSON.stringify(failure.error);
+	// Normalize before truncating: toWellFormedUnicode repairs lone surrogates
+	// already present in the raw provider error, and truncateWellFormed keeps
+	// the 240-char cut off a pair boundary. Truncation alone fixes only the cut.
 	const normalizedError = truncateWellFormed(
-		rawError.trim().replace(/\s+/g, " "),
+		toWellFormedUnicode(rawError.trim().replace(/\s+/g, " ")),
 		240,
 	);
 	return `${toolName}:${normalizedError}`;


### PR DESCRIPTION
Repairs a regression **I introduced** in #23734, reported by @standujar in #23756 / #23739. Credit for catching it goes there; this lands the remaining half.

## What happened

When I rebuilt #23734 onto current `develop`, its branch was stale, so I reconstructed it — and copied `packages/core/src/runtime/limits.ts` wholesale from the old branch head instead of applying just its hunk. That silently reverted everything `develop` had landed in that file since the branch point:

- the `toWellFormedUnicode` normalization in `getFailureSignature` (#23699),
- `failureProvenance` on `TrajectoryLimitExceeded` and `FailureLike`,
- the file-header-before-imports ordering.

Copying a whole file across a rebase cannot merge — it can only overwrite. The diff *looked* like the intended one-line change because I compared it against the branch it came from rather than against the file it was replacing.

## Correcting the record on #23767

I opened #23767 to fix the resulting `packages/core` build break and diagnosed it there as "the reader was landed without the producer." **That was wrong.** The producer existed on `develop`; my own merge deleted it a few commits earlier. The fix in #23767 is correct and stands, but its stated cause was not, and anyone reading it would draw the wrong conclusion about how the field went missing.

## What this PR restores

`failureProvenance` is already back via #23767, so what remains is the normalization pass and the header ordering:

```ts
const normalizedError = truncateWellFormed(
  toWellFormedUnicode(rawError.trim().replace(/\s+/g, " ")),
  240,
);
```

`truncateWellFormed` only guards the 240-character cut. A lone surrogate already sitting in the provider's error text — well short of the boundary — passes straight through it. The two do different jobs, and only one of them was left.

## Why no test caught it

This is the part worth keeping. `limits.surrogate.test.ts` does not call `getFailureSignature`; it declares a local `clampLimits` that reimplements the same composition and asserts against that. So it verifies that `truncateWellFormed(toWellFormedUnicode(x), 240)` behaves — which is true no matter what the production function does. All five cases stayed green straight through the revert.

The added case calls the real exported function and asserts on a lone surrogate placed far from the boundary, where truncation cannot mask the missing normalization:

```
--- WITHOUT normalization ---
  × repairs a lone surrogate far from the truncation boundary
  1 failed | 5 passed
--- WITH normalization ---
  22 passed (limits.surrogate.test.ts + limits.test.ts)
```

The five pre-existing cases pass in both columns. That gap between them is the whole lesson: a test that reimplements its subject reports on the reimplementation.

Biome clean.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [pr-finisher]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza"} -->