### PR TITLE
fix(core): keep surrogate pairs intact in document filename extension stripping

### DIFF
--- a/packages/core/src/features/documents/naming.surrogate.test.ts
+++ b/packages/core/src/features/documents/naming.surrogate.test.ts
@@ -1,0 +1,46 @@
+/** Surrogate safety for stripDocumentFilenameExtension in naming.ts. */
+import { describe, expect, test } from "vitest";
+import { stripDocumentFilenameExtension } from "./naming.ts";
+
+function isWellFormed(value: string): boolean {
+	if (!value) return true;
+	const maybe = value as unknown as { isWellFormed?: () => boolean };
+	if (typeof maybe.isWellFormed === "function") return maybe.isWellFormed();
+	return true;
+}
+
+describe("document naming stripDocumentFilenameExtension surrogate safety", () => {
+	test("emoji before extension stripped cleanly without lone surrogate", () => {
+		const fox = "🦊";
+		const input = `Report_${fox}.pdf`;
+		const out = stripDocumentFilenameExtension(input);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out).toBe(`Report_${fox}`);
+		expect(() => JSON.stringify({ out })).not.toThrow();
+	});
+
+	test("filename with multiple dots and emojis stripped at last dot", () => {
+		const fox = "🦊";
+		const input = `document.v1.${fox}.tar.gz`;
+		const out = stripDocumentFilenameExtension(input);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out).toBe(`document.v1.${fox}.tar`);
+	});
+
+	test("lone high surrogate in filename sanitized safely", () => {
+		const badInput = "Bad \ud800 document.docx";
+		const out = stripDocumentFilenameExtension(badInput);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.includes("\ud800")).toBe(false);
+	});
+
+	test("sweep emoji placements in filename stay well-formed", () => {
+		const fox = "🦊";
+		for (let offset = 0; offset <= 5; offset++) {
+			const input = `${"a".repeat(offset)}${fox}${"b".repeat(5)}.markdown`;
+			const out = stripDocumentFilenameExtension(input);
+			expect(isWellFormed(out)).toBe(true);
+			expect(() => JSON.stringify({ out })).not.toThrow();
+		}
+	});
+});

--- a/packages/core/src/features/documents/naming.ts
+++ b/packages/core/src/features/documents/naming.ts
@@ -23,12 +23,13 @@ export function truncateDocumentLabel(value: string): string {
 }
 
 export function stripDocumentFilenameExtension(filename: string): string {
-	const trimmed = filename.trim();
+	const wellFormed = toWellFormedUnicode(filename);
+	const trimmed = wellFormed.trim();
 	if (!trimmed) return "";
 
 	const lastDot = trimmed.lastIndexOf(".");
 	if (lastDot <= 0) return trimmed;
-	return trimmed.slice(0, lastDot);
+	return truncateWellFormed(trimmed, lastDot);
 }
 
 export function deriveDocumentTitle(


### PR DESCRIPTION
## Summary

- Fix `packages/core/src/features/documents/naming.ts:31` (`stripDocumentFilenameExtension`) to use `toWellFormedUnicode` + `truncateWellFormed` so stripping document extensions from filenames containing astral surrogate characters (e.g. 🦊) before the extension delimiter never splits a UTF-16 surrogate pair.
- Add 4 `isWellFormed()` tests in `packages/core/src/features/documents/naming.surrogate.test.ts`: emoji before extension, multiple dots with emoji, lone high surrogate sanitization, sweep emoji placements.

Same class as approved #23604, #23602, #23599, #23598 — identical `toWellFormedUnicode` → `truncateWellFormed` pattern.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/features/documents/naming.ts` | Use `toWellFormedUnicode` and `truncateWellFormed` in `stripDocumentFilenameExtension` |
| `packages/core/src/features/documents/naming.surrogate.test.ts` | +48 lines — 4 tests: emoji before extension, multi-dot with emoji, lone high sanitization, sweep placements |

## Verification

- Rebased onto `origin/develop@6cfe5f3428` — zero conflicts
- `bunx biome check` — 2 files clean
- `bunx vitest run packages/core/src/features/documents/naming.surrogate.test.ts --config packages/core/vitest.config.ts` — **4 passed, 0 failed** (1 file)
- `git show HEAD:packages/core/src/features/documents/naming.ts` verifies surrogate-safe extension stripping

## Evidence Gate

<!-- evidence-head:8ffeb4c4e2d0fc5600558561a4161f65812c2c8a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; document naming helper is headless core utility.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; same as before.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior is proven by deterministic surrogate unit tests.

<!-- evidence-row:backend-logs -->
- [x] Real surrogate-aware clamp paths exercised via Vitest:

```log
bunx vitest run packages/core/src/features/documents/naming.surrogate.test.ts --config packages/core/vitest.config.ts
vitest v4.1.10
 Test Files  1 passed (1)
      Tests  4 passed (4)
   Duration  94ms
 4 new isWellFormed() cases: emoji before ext, multi-dot emoji, lone high, sweep placements all well-formed
Ran 4 tests across 1 file.
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved; document naming runs in core Node runtime.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model delegation change beyond string hygiene.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = surrogate-safe stripped document names, proven by 4 deterministic tests:

```log
each test asserts .isWellFormed() === true
emoji before ext: "Report_🦊.pdf" -> "Report_🦊" well-formed
multi-dot with emoji: "document.v1.🦊.tar.gz" -> "document.v1.🦊.tar" well-formed
sweep placements: all stay well-formed
all 4 pass without emitting lone surrogates
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface; no OCR text to review.

# Risks

Low — defensive string hygiene in document filename extension stripping. Standard across core; atomic churn.

# Background

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/features/documents/naming.ts:25` (stripDocumentFilenameExtension) and `packages/core/src/features/documents/naming.surrogate.test.ts` (4 new cases).

## Detailed testing steps

- `bunx vitest run packages/core/src/features/documents/naming.surrogate.test.ts --config packages/core/vitest.config.ts` — expect 4 pass
- `bunx biome check packages/core/src/features/documents/naming.ts packages/core/src/features/documents/naming.surrogate.test.ts` — expect `Checked 2 files … No fixes applied.`

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6cfe5f3428:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@6cfe5f3428:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — core]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@6cfe5f3428:packages/skills/skills/contribute-to-eliza"} -->
