### PR TITLE
fix(core): keep surrogate pairs intact in reflection prompt rendering

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.surrogate.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.surrogate.test.ts
@@ -1,0 +1,53 @@
+/** Surrogate safety for boundRender in reflection-items.ts. */
+import { describe, expect, test } from "vitest";
+import { boundRender } from "./reflection-items.ts";
+
+function isWellFormed(value: string): boolean {
+	if (!value) return true;
+	const maybe = value as unknown as { isWellFormed?: () => boolean };
+	if (typeof maybe.isWellFormed === "function") return maybe.isWellFormed();
+	return true;
+}
+
+describe("reflection-items boundRender surrogate safety", () => {
+	test("emoji at boundary before suffix backs off without lone surrogate", () => {
+		const fox = "🦊";
+		const input = `${"a".repeat(15)}${fox}${"b".repeat(20)}`;
+		const out = boundRender(input, 25);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.endsWith("…[truncated]")).toBe(true);
+		expect(() => JSON.stringify({ out })).not.toThrow();
+	});
+
+	test("fitting text with emoji untouched", () => {
+		const fox = "🦊";
+		const input = `Short ${fox} text`;
+		const out = boundRender(input, 50);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out).toBe(input);
+	});
+
+	test("lone high surrogate in text sanitized safely", () => {
+		const badInput = `Bad \ud800 in reflection text ${"x".repeat(100)}`;
+		const out = boundRender(badInput, 30);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.includes("\ud800")).toBe(false);
+	});
+
+	test("very small maxChars budget truncates suffix safely", () => {
+		expect(boundRender("some long text", 0)).toBe("");
+		expect(boundRender("some long text", 1)).toBe("…");
+		expect(boundRender("some long text", 5)).toBe("…[tru");
+	});
+
+	test("sweep offsets around max budget all stay well-formed", () => {
+		const fox = "🦊";
+		for (let offset = -5; offset <= 5; offset++) {
+			const n = 30 + offset;
+			const input = `${"a".repeat(n)}${fox}${"b".repeat(20)}`;
+			const out = boundRender(input, 35);
+			expect(isWellFormed(out)).toBe(true);
+			expect(() => JSON.stringify({ out })).not.toThrow();
+		}
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
@@ -47,7 +47,10 @@ import type {
 import { MemoryType } from "../../../types/memory.ts";
 import type { JsonValue } from "../../../types/primitives.ts";
 import { isSyntheticConversationArtifactMemory } from "../../../utils/synthetic-conversation-artifact.ts";
-import { truncateWellFormed } from "../../../utils/well-formed.ts";
+import {
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "../../../utils/well-formed.ts";
 import {
 	buildFactKeywordsForStorage,
 	buildFactSearchText,
@@ -445,11 +448,13 @@ export const REFLECTION_ENTITY_LIMIT = 50;
 // dominate the prompt.
 const ENTITY_NAMES_RENDER_MAX_CHARS = 240;
 
-function boundRender(text: string, maxChars: number): string {
-	if (text.length <= maxChars) return text;
+export function boundRender(text: string, maxChars: number): string {
+	const wellFormed = toWellFormedUnicode(text);
+	if (wellFormed.length <= maxChars) return wellFormed;
 	const suffix = "…[truncated]";
-	if (maxChars <= suffix.length) return suffix.slice(0, maxChars);
-	return `${truncateWellFormed(text, maxChars - suffix.length)}${suffix}`;
+	if (maxChars <= suffix.length)
+		return truncateWellFormed(suffix, Math.max(0, maxChars));
+	return `${truncateWellFormed(wellFormed, maxChars - suffix.length)}${suffix}`;
 }
 
 function boundReflectionEntities(params: {


### PR DESCRIPTION
## Summary

- Fix `packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts:451,452` (`boundRender`) to use `toWellFormedUnicode` + `truncateWellFormed` so rendering bounded reflection context text into reflection evaluator prompts never splits an astral surrogate pair (e.g. 🦊) before the suffix delimiter.
- Add 5 `isWellFormed()` tests in `packages/core/src/features/advanced-capabilities/evaluators/reflection-items.surrogate.test.ts`: boundary backoff before suffix, fitting text with emoji, lone high surrogate sanitization, small budget suffix truncation, sweep offsets.

Same class as approved #23604, #23602, #23599, #23598 — identical `toWellFormedUnicode` → `truncateWellFormed` pattern.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts` | Import `toWellFormedUnicode` from `../../../utils/well-formed.ts`, sanitize input text and bound suffix with `truncateWellFormed` in `boundRender` |
| `packages/core/src/features/advanced-capabilities/evaluators/reflection-items.surrogate.test.ts` | +58 lines — 5 tests: boundary backoff, fitting emoji, lone high sanitization, small budget, sweep offsets well-formed |

## Verification

- Rebased onto `origin/develop@59caf74936` — zero conflicts
- `bunx biome check` — 2 files clean
- `bunx vitest run packages/core/src/features/advanced-capabilities/evaluators/reflection-items.surrogate.test.ts --config packages/core/vitest.config.ts` — **5 passed, 0 failed** (1 file)
- `git show HEAD:packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts` verifies surrogate-safe prompt rendering

## Evidence Gate

<!-- evidence-head:c099bc21ddf1cc3ef2cb44eafe047a10f283134c -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface; reflection evaluator is headless core post-response analyzer.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface; same as before.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior is proven by deterministic surrogate unit tests.

<!-- evidence-row:backend-logs -->
- [x] Real surrogate-aware clamp paths exercised via Vitest:

```log
bunx vitest run packages/core/src/features/advanced-capabilities/evaluators/reflection-items.surrogate.test.ts --config packages/core/vitest.config.ts
vitest v4.1.10
 Test Files  1 passed (1)
      Tests  5 passed (5)
   Duration  94ms
 5 new isWellFormed() cases: boundary backoff, fitting emoji, lone high, small budget, sweep offsets all well-formed
Ran 5 tests across 1 file.
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved; reflection evaluators run in core Node runtime.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model delegation change beyond string hygiene.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact = surrogate-safe bounded reflection prompt strings, proven by 5 deterministic tests:

```log
each test asserts .isWellFormed() === true
boundary before suffix: "a".repeat(15) + "🦊" + ... + "…[truncated]" -> well-formed without lone surrogate
fitting emoji: "Short 🦊 text" -> exact match kept intact well-formed
sweep offsets: all stay well-formed
all 5 pass without emitting lone surrogates
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface; no OCR text to review.

# Risks

Low — defensive string hygiene in reflection context prompt rendering. Standard across core; atomic churn.

# Background

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts:50,448` (import + boundRender) and `packages/core/src/features/advanced-capabilities/evaluators/reflection-items.surrogate.test.ts` (5 new cases).

## Detailed testing steps

- `bunx vitest run packages/core/src/features/advanced-capabilities/evaluators/reflection-items.surrogate.test.ts --config packages/core/vitest.config.ts` — expect 5 pass
- `bunx biome check packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts packages/core/src/features/advanced-capabilities/evaluators/reflection-items.surrogate.test.ts` — expect `Checked 2 files … No fixes applied.`

# Deploy Notes

None.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@59caf74936:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@59caf74936:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — core]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@59caf74936:packages/skills/skills/contribute-to-eliza"} -->
