### PR TITLE
fix(core): normalize bounded planner repeat keys

### DIFF
--- a/packages/core/src/runtime/limits.surrogate.test.ts
+++ b/packages/core/src/runtime/limits.surrogate.test.ts
@@ -5,7 +5,11 @@
 import { describe, expect, it } from "vitest";
 
 import { toWellFormedUnicode, truncateWellFormed } from "../utils/well-formed";
-import { getFailureSignature } from "./limits";
+import {
+	countRepeatedFailures,
+	type FailureLike,
+	getFailureSignature,
+} from "./limits";
 
 const LIMITS_TRUNCATE = 240;
 
@@ -18,6 +22,15 @@ function isWellFormed(s: string): boolean {
 	const w = s as unknown as { isWellFormed?: () => boolean };
 	if (typeof w.isWellFormed === "function") return w.isWellFormed();
 	return toWellFormedUnicode(s) === s;
+}
+
+function failure(repeatKey: string): FailureLike {
+	return {
+		toolName: "WEB_FETCH",
+		error: "ETIMEDOUT",
+		success: false,
+		repeatKey,
+	};
 }
 
 describe("limits well-formed", () => {
@@ -77,5 +90,21 @@ describe("getFailureSignature normalizes pre-existing lone surrogates", () => {
 		expect(signature).not.toBeNull();
 		expect(signature as string).toBe(toWellFormedUnicode(signature as string));
 		expect((signature as string).includes("\uD800")).toBe(false);
+	});
+});
+
+describe("repeat-key comparison normalizes malformed UTF-16", () => {
+	it("normalizes astral repeat keys before comparing their bounded prefix", () => {
+		const grinning = failure(`${"x".repeat(239)}😀-one`);
+		const fox = failure(`${"x".repeat(239)}🦊-two`);
+
+		expect(countRepeatedFailures([grinning, fox], grinning)).toBe(2);
+	});
+
+	it("normalizes lone surrogates before comparing repeat keys", () => {
+		const malformed = failure(`key-${String.fromCharCode(0xd800)}`);
+		const repaired = failure("key-�");
+
+		expect(countRepeatedFailures([malformed, repaired], repaired)).toBe(2);
 	});
 });

--- a/packages/core/src/runtime/limits.ts
+++ b/packages/core/src/runtime/limits.ts
@@ -264,7 +264,9 @@ function getFailureComparisonKey(failure: FailureLike): string | null {
 	const signature = getFailureSignature(failure);
 	if (!signature) return null;
 	const repeatKey = failure.repeatKey?.trim();
-	return repeatKey ? `${signature}:${repeatKey.slice(0, 240)}` : signature;
+	return repeatKey
+		? `${signature}:${truncateWellFormed(toWellFormedUnicode(repeatKey), 240)}`
+		: signature;
 }
 
 export function assertRepeatedFailureLimit(params: {


### PR DESCRIPTION
# Relates to

Fixes #23739.

#23767 restored action-failure provenance and #23778 restored error-signature normalization after this PR opened. This rebased diff now contains only the remaining #23734 regression: repeat keys were still truncated with raw `.slice(0, 240)` and could retain malformed UTF-16.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated i18n blocker is recorded below.
- [x] A reviewer can confirm the change from the production-path regression tests and command evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@bec56dcd1d0a4c9e9d1248e594dca0cf66348ec7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `59caf749366fb38b2f4b794d8370ee4267a4a8f0`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact unrelated `check:i18n` blocker is documented in **Known gaps / failures**.

# Risks

Low. Well-formed repeat keys keep the same 240-code-unit bound. The only changed cases are malformed lone surrogates and astral characters straddling the boundary; both are normalized and truncated without leaving an unpaired surrogate.

# Background

## What does this PR do?

- Normalizes `repeatKey` with `toWellFormedUnicode` before applying `truncateWellFormed`.
- Adds production-path tests through `countRepeatedFailures` for both an astral boundary and a pre-existing lone surrogate.
- Leaves the independently merged provenance and error-signature repairs untouched.

## What kind of change is this?

Bug fix (non-breaking repair of the final planner-limit contract lost in #23734).

# Documentation changes needed?

No. This is an internal normalization boundary with no public API or workflow documentation change.

# Testing

## Where should a reviewer start?

Run `limits.surrogate.test.ts`, then inspect the four-line production diff in `getFailureComparisonKey`.

## Detailed testing steps

```bash
bun install --frozen-lockfile
mise exec node@24.15.0 -- bun run --cwd packages/core test -- src/runtime/limits.test.ts src/runtime/limits.surrogate.test.ts src/services/__tests__/failure-reply-prompt.test.ts
mise exec node@24.15.0 -- bunx biome check packages/core/src/runtime/limits.ts packages/core/src/runtime/limits.surrogate.test.ts
mise exec node@24.15.0 -- bun run --cwd packages/core typecheck
mise exec node@24.15.0 -- bun run --cwd packages/core build:node
mise exec node@24.15.0 -- bun run --cwd packages/core build
mise exec node@24.15.0 -- bun run verify
```

Observed at exact head:

- Focused Vitest: 3 files, 54 tests passed.
- Biome: 2 changed files checked, no fixes required.
- Core typecheck: passed.
- Core Node build: passed.
- Core Node/browser/edge/testing build plus packed-consumer verification: passed. A temporary PATH shim pointed the repository's npm resolver at Node 24's real `npm-cli.js`, because the local mise `npm` executable is a Bash wrapper.
- Repository verify: reached `check:i18n` and failed on existing translation debt outside this diff; details below.

# Evidence Gate

<!-- evidence-head:bec56dcd1d0a4c9e9d1248e594dca0cf66348ec7 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface is changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface is changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic Core runtime normalization; no visual user flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no service boundary or logging path changes; production-path unit tests exercise the exported comparison guard.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend or network path is changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, model, provider, action selection, or LLM call path changes; deterministic repeat-key handling only.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - affected values are in-memory bounded strings asserted directly by regression tests.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface is changed.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic planner-limit key normalization only; no LLM call contract changes.

## Backend + frontend logs

N/A - no server process, request, persistence, frontend, or network behavior is involved. The focused test output above is the applicable executable evidence.

## Screenshots (before / after) + video walkthrough

N/A - no UI files or visual surfaces are touched.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice path is touched.

## Known gaps / failures

`mise exec node@24.15.0 -- bun run verify` fails in the pre-existing `check:i18n` stage before the monorepo typecheck/lint stages. At this base it reports seven missing English connector-account keys and 943-1016 source-used keys across each non-English locale (plus the existing translation fallback inventory). None of those UI/i18n files are in this two-file Core diff. Focused Biome, Core typecheck, both required Core builds, packed-consumer verification, and all 54 relevant tests pass after the final rebase.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@bec56dcd1d0a4c9e9d1248e594dca0cf66348ec7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [/root/pr23734-limits-repair]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@bec56dcd1d0a4c9e9d1248e594dca0cf66348ec7:packages/skills/skills/contribute-to-eliza"} -->
