### PR TITLE
ci(cloud): gate production on approval environment

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -363,7 +363,7 @@ jobs:
     timeout-minutes: 2
     # Approval only. This job must not share a mutation concurrency group, or
     # a waiting reviewer holds the release lock (#18092).
-    environment: production
+    environment: production-approval
     steps:
       - name: Record production authorization
         run: echo "production environment authorized for this run"

--- a/packages/cloud/scripts/production-deploy-admission-lock.test.mjs
+++ b/packages/cloud/scripts/production-deploy-admission-lock.test.mjs
@@ -209,7 +209,7 @@ describe("committed Cloud CF workflow matches the policy", () => {
   test("production authorization is outside the release lock", () => {
     const authorize = jobBlock(cloudCf, "authorize-production");
     const release = jobBlock(cloudCf, "release");
-    expect(authorize).toContain("environment: production");
+    expect(authorize).toContain("environment: production-approval");
     expect(authorize).not.toContain("concurrency:");
     expect(release).toContain("uses: ./.github/workflows/cloud-cf-release.yml");
     expect(release).toContain("group: cloud-cf-release-v6-");

--- a/packages/scripts/__tests__/deploy-approval-concurrency-workflow.test.ts
+++ b/packages/scripts/__tests__/deploy-approval-concurrency-workflow.test.ts
@@ -70,7 +70,7 @@ describe("cloud-cf-deploy approval/concurrency topology (#18092)", () => {
   it("keeps production approval outside every mutation lock", () => {
     const approval = cfDeploy.jobs?.["authorize-production"];
     expect(approval).toBeDefined();
-    expect(approval?.environment).toBe("production");
+    expect(approval?.environment).toBe("production-approval");
     expect(approval?.concurrency).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary

- move the human production authorization job to the approval-only `production-approval` Environment
- retain `production` as the secret-bearing scope inside the serialized release workflow
- update the two exact topology contracts that pin the authorization Environment

## Live operator prerequisite

The Environment already exists and was read back through the GitHub API:

- required reviewers: `standujar`, `lalalune`, `NubsCarson`, `0xSolace` (one approval required by GitHub)
- `prevent_self_review: true`
- deployment branch policy: `main` only
- secrets: 0
- variables: 0

The existing `production` Environment is unchanged and retains its 35 secret names with no reviewer rule, preventing a second human wait inside the mutation lock.

## Exact change

- base: security-remediation head `27794dbe8123a582b3a49b92a8b842df44d82e7f` (#23796)
- head: `08746278b8d9592fa1746261371f9846bda8b0ad`
- 3 files, 3 insertions, 3 deletions
- no change to `needs`, `if`, concurrency, secret inheritance, or target-environment routing

## Validation

- `git diff --check`: pass
- parent review: GO
- independent exact-head read-only review: GO
- no repository code, install, build, or test executed while #23796 remains unmerged

This PR is intentionally stacked on #23796 so its visible diff contains only the three #18092 lines and its checkout does not contain the unauthorized runtime side effect. Retarget/rebase to `develop` only after #23796 lands.

No production approval, workflow dispatch, deployment, or secret value mutation was performed.

Fixes #18092
