### PR TITLE
fix(cloud): clamp the social-media Retry-After sleep budget

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/rate-limit.retry-after-clamp.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/rate-limit.retry-after-clamp.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Pins the `Retry-After` sleep budget in the social-media `withRetry` transport
+ * boundary. The header comes from the remote platform, so an unbounded value
+ * reaches `setTimeout` directly and fails in two opposite directions:
+ *
+ *  - `Retry-After: 86400` (legal HTTP) parks the publishing worker for 24h per
+ *    attempt with the request still open.
+ *  - `setTimeout` silently coerces any delay above 2^31-1 ms to 1ms, so
+ *    `Retry-After: 999999999` INVERTS the backoff — the larger the pause the
+ *    provider asks for, the faster the whole retry ladder is burned through.
+ *
+ * The clamp must therefore have both a floor and a ceiling, and the ceiling has
+ * to sit below `setTimeout`'s 32-bit range or it reproduces the inversion. It
+ * must also leave ordinary values (seconds, `0`, the HTTP-date form) and the
+ * value reported on the typed `RateLimitError` exactly as they are today.
+ *
+ * The logger is mocked to read back the wait actually chosen; the real
+ * `withRetry` control flow runs and `fn` is injected, so there is no network.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const warn = mock(() => undefined);
+
+mock.module("../../utils/logger", () => ({
+  logger: { warn, info: () => {}, error: () => {}, debug: () => {} },
+}));
+
+const { withRetry, clampRateLimitWaitMs, MAX_RATE_LIMIT_WAIT_MS } = await import("./rate-limit");
+
+/** The largest delay `setTimeout` accepts before coercing it to 1ms. */
+const SET_TIMEOUT_MAX_MS = 2 ** 31 - 1;
+
+afterEach(() => {
+  mock.restore();
+});
+
+beforeEach(() => {
+  warn.mockClear();
+});
+
+const rateLimited = (retryAfter: string) => async () =>
+  new Response("", { status: 429, headers: { "retry-after": retryAfter } });
+const parseJson = async (response: Response) => response.json();
+
+/** The `waiting <n>ms` figure the retry loop actually handed to `sleep`. */
+function loggedWaitMs(): number {
+  const message = String((warn.mock.calls[0] as unknown as string[])?.[0] ?? "");
+  const matched = /waiting (-?\d+)ms/.exec(message);
+  if (!matched) throw new Error(`no wait logged; saw: ${message}`);
+  return Number(matched[1]);
+}
+
+describe("clampRateLimitWaitMs — the ceiling has to clear setTimeout's 32-bit range", () => {
+  it("never yields a delay setTimeout would silently coerce to 1ms", () => {
+    // Guard the guard: the cap itself must be inside the range it protects.
+    expect(MAX_RATE_LIMIT_WAIT_MS).toBeLessThanOrEqual(SET_TIMEOUT_MAX_MS);
+    expect(MAX_RATE_LIMIT_WAIT_MS).toBeGreaterThan(0);
+
+    // 2_147_484s is the first whole-second Retry-After that overflows.
+    for (const seconds of [2_147_484, 999_999_999, Number.MAX_SAFE_INTEGER]) {
+      const unclamped = seconds * 1000;
+      expect(unclamped).toBeGreaterThan(SET_TIMEOUT_MAX_MS); // origin really does overflow
+      expect(clampRateLimitWaitMs(unclamped)).toBeLessThanOrEqual(SET_TIMEOUT_MAX_MS);
+      expect(clampRateLimitWaitMs(unclamped)).toBe(MAX_RATE_LIMIT_WAIT_MS);
+    }
+  });
+
+  it("caps a long-but-in-range wait instead of parking the worker for a day", () => {
+    expect(clampRateLimitWaitMs(86_400 * 1000)).toBe(MAX_RATE_LIMIT_WAIT_MS);
+    expect(clampRateLimitWaitMs(MAX_RATE_LIMIT_WAIT_MS + 1)).toBe(MAX_RATE_LIMIT_WAIT_MS);
+  });
+
+  it("floors negatives at zero and treats a non-finite wait as the maximum, not as zero", () => {
+    expect(clampRateLimitWaitMs(-1000)).toBe(0);
+    expect(clampRateLimitWaitMs(Number.NEGATIVE_INFINITY)).toBe(MAX_RATE_LIMIT_WAIT_MS);
+    expect(clampRateLimitWaitMs(Number.POSITIVE_INFINITY)).toBe(MAX_RATE_LIMIT_WAIT_MS);
+    expect(clampRateLimitWaitMs(Number.NaN)).toBe(MAX_RATE_LIMIT_WAIT_MS);
+  });
+
+  it("leaves every ordinary wait exactly as it is today (no over-rejection)", () => {
+    for (const ms of [0, 1, 1000, 5000, 30_000, MAX_RATE_LIMIT_WAIT_MS]) {
+      expect(clampRateLimitWaitMs(ms)).toBe(ms);
+    }
+  });
+});
+
+describe("withRetry — the clamp is on the path that feeds setTimeout", () => {
+  it("does not collapse an overflowing Retry-After into an instant retry storm", async () => {
+    const started = Date.now();
+    let settled = false;
+    void withRetry(rateLimited("999999999"), parseJson, {
+      platform: "twitter",
+      maxRetries: 1,
+      baseDelayMs: 1000,
+    }).then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Unclamped this is sleep(999999999000) -> coerced to 1ms, so the whole
+    // ladder is exhausted in single-digit milliseconds.
+    expect(settled).toBe(false);
+    expect(Date.now() - started).toBeGreaterThanOrEqual(100);
+    expect(loggedWaitMs()).toBe(MAX_RATE_LIMIT_WAIT_MS);
+    expect(loggedWaitMs()).toBeLessThanOrEqual(SET_TIMEOUT_MAX_MS);
+  });
+
+  it("caps a 24h Retry-After yet still reports the provider's real value", async () => {
+    const error = await withRetry(rateLimited("86400"), parseJson, {
+      platform: "twitter",
+      maxRetries: 0,
+      baseDelayMs: 1000,
+    }).catch((thrown) => thrown);
+
+    // The typed error keeps the unclamped seconds so callers can reschedule.
+    expect(error).toMatchObject({ rateLimited: true, platform: "twitter", retryAfter: 86400 });
+  });
+
+  it("bounds the exponential fallback used when no Retry-After is sent", () => {
+    expect(clampRateLimitWaitMs(1000 * 2 ** 40)).toBe(MAX_RATE_LIMIT_WAIT_MS);
+  });
+});
+
+describe("withRetry — values the live path accepts today are untouched", () => {
+  it("still honours a short numeric Retry-After and recovers", async () => {
+    const started = Date.now();
+    let call = 0;
+    const fn = async () => {
+      call += 1;
+      return call === 1
+        ? new Response("", { status: 429, headers: { "retry-after": "1" } })
+        : new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+
+    await expect(
+      withRetry(fn, async (r) => (await r.json()) as { ok: boolean }, {
+        platform: "twitter",
+        maxRetries: 1,
+        baseDelayMs: 1000,
+      }),
+    ).resolves.toEqual({ data: { ok: true } });
+
+    expect(loggedWaitMs()).toBe(1000);
+    expect(Date.now() - started).toBeGreaterThanOrEqual(900);
+  });
+
+  it("still preserves Retry-After: 0 as an immediate retry (#20116)", async () => {
+    let call = 0;
+    const fn = async () => {
+      call += 1;
+      return call === 1
+        ? new Response("", { status: 429, headers: { "retry-after": "0" } })
+        : new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+
+    await expect(
+      withRetry(fn, async (r) => (await r.json()) as { ok: boolean }, {
+        platform: "twitter",
+        maxRetries: 1,
+        baseDelayMs: 100,
+      }),
+    ).resolves.toEqual({ data: { ok: true } });
+    expect(warn).toHaveBeenCalledWith("[twitter] Rate limited, waiting 0ms before retry 1/1");
+  });
+
+  it("still parses the HTTP-date form of Retry-After", async () => {
+    const fiveSecondsOut = new Date(Date.now() + 5000).toUTCString();
+    const error = await withRetry(rateLimited(fiveSecondsOut), parseJson, {
+      platform: "bluesky",
+      maxRetries: 0,
+      baseDelayMs: 1000,
+    }).catch((thrown) => thrown);
+
+    expect(error).toMatchObject({ rateLimited: true, platform: "bluesky" });
+    expect(error.retryAfter).toBeGreaterThan(0);
+    expect(error.retryAfter).toBeLessThanOrEqual(5);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/rate-limit.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/rate-limit.ts
@@ -39,6 +39,45 @@ const PLATFORM_RATE_LIMITS: Record<
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+/**
+ * Upper bound on how long a single `withRetry` attempt will hold the caller
+ * waiting on a provider-supplied `Retry-After`. Both bounds are load-bearing,
+ * and both are reachable from a response header we do not control:
+ *
+ * - **No upper bound** parks the publishing worker for as long as the provider
+ *   asks. `Retry-After: 86400` is legal HTTP and pins one attempt for 24h; with
+ *   the default `maxRetries = 3` that is four days on one open request.
+ * - **`setTimeout` coerces any delay above 2^31-1 ms to 1ms** (Node/Bun emit
+ *   `TimeoutOverflowWarning`), so an unclamped wait *inverts* the backoff: the
+ *   larger the pause the provider asks for, the faster we retry it.
+ *   `Retry-After: 999999999` exhausts the whole retry ladder in milliseconds.
+ *   This cap is well below 2^31-1, so no wait computed here can reach that
+ *   coercion.
+ * - **No lower bound** lets `Retry-After: -1` reach `setTimeout` as a negative
+ *   delay (`TimeoutNegativeWarning`), which it also coerces to 1ms.
+ *
+ * Not reusing `PROVIDER_MAX_BACKOFF_DELAY_MS` (8s, `lib/providers/_http.ts`):
+ * that constant is exported so the stale-reservation sweep can derive its grace
+ * window from the *LLM provider* ladder, and 8s is far below what social
+ * platforms legitimately ask for. The clamp shape here is the same as that
+ * module's `computeBackoffMs`.
+ */
+export const MAX_RATE_LIMIT_WAIT_MS = 60_000;
+
+/**
+ * Keep a retry wait inside `[0, MAX_RATE_LIMIT_WAIT_MS]` before it reaches
+ * `setTimeout`. A non-finite wait clamps to the maximum rather than to zero, so
+ * a malformed value slows us down instead of turning into a retry storm.
+ *
+ * The value parsed off the header is deliberately NOT clamped at the source: it
+ * is still reported verbatim on the typed `RateLimitError` so callers can
+ * schedule against what the provider actually said (see #20116).
+ */
+export function clampRateLimitWaitMs(waitMs: number): number {
+  if (!Number.isFinite(waitMs)) return MAX_RATE_LIMIT_WAIT_MS;
+  return Math.min(Math.max(waitMs, 0), MAX_RATE_LIMIT_WAIT_MS);
+}
+
 function parseRetryAfter(response: Response): number | undefined {
   const header = response.headers.get("retry-after");
   if (!header) return undefined;
@@ -77,7 +116,7 @@ export async function withRetry<T>(
 
       if (isRateLimitResponse(response)) {
         const retryAfter = parseRetryAfter(response);
-        const waitMs = retryAfter ?? baseDelayMs * 2 ** attempt;
+        const waitMs = clampRateLimitWaitMs(retryAfter ?? baseDelayMs * 2 ** attempt);
 
         if (attempt < maxRetries) {
           logger.warn(
@@ -110,7 +149,7 @@ export async function withRetry<T>(
       if ((error as RateLimitError).rateLimited) throw error;
 
       if (attempt < maxRetries) {
-        const delayMs = baseDelayMs * 2 ** attempt;
+        const delayMs = clampRateLimitWaitMs(baseDelayMs * 2 ** attempt);
         logger.warn(`[${platform}] Request failed, retrying in ${delayMs}ms: ${lastError.message}`);
         await sleep(delayMs);
       }


### PR DESCRIPTION
# Relates to

Fixes #23797

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (branched off `f4ee83bf9a94a9339f9eea32e1eb80d0838aac3c`).
- [x] `bun install` was run after sync. `bun run verify` was **not** run
      monorepo-wide — see **Known gaps / failures**; the focused suite, the
      package typecheck and biome were all run and are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after `withRetry` traces below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched off the latest `origin/develop` (`f4ee83bf9a94`); zero conflicts.
- [ ] `bun run verify` post-sync — not run monorepo-wide; the exact scope that
      was run, and why the wider run was skipped, is in **Known gaps / failures**.

# Risks

**Low.** One module, two call sites, one new exported pure helper. The clamp is
applied only where a wait reaches `setTimeout`; nothing that a caller observes
changes for any value the live path accepts today, and the value reported on the
typed `RateLimitError` is deliberately left untouched (see *No over-rejection*).

# Background

## What does this PR do?

`packages/cloud/shared/src/lib/services/social-media/rate-limit.ts` takes the
remote platform's `Retry-After` header and hands it straight to `setTimeout` as
a sleep budget, with **no ceiling and no floor**. This PR clamps that wait into
`[0, MAX_RATE_LIMIT_WAIT_MS]` at the point it reaches the timer.

### Lead with the inversion, because that is the sharp end

`setTimeout` cannot represent a delay above `2^31-1` ms. Node and Bun **silently
coerce anything larger to 1 ms** and emit `TimeoutOverflowWarning`. So on
`develop` today, *the larger the pause the provider asks for, the faster we
retry it*:

```
TimeoutOverflowWarning: 999999999000 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
      at sleep (.../social-media/rate-limit.ts:40:31)
      at withRetry (.../social-media/rate-limit.ts:86:17)
```

`Retry-After: 999999999` asks for ~11 574 days. The default ladder
(`maxRetries = 3`) burns **all three retries in 6 ms** and hammers the provider
four times back to back, while the log says we are waiting 999 999 999 000 ms.
The guard does the exact opposite of its purpose at the extreme, and the trigger
is a response header we do not control — any provider bug, hostile upstream, or
misconfiguration reaches it. The threshold is `Retry-After: 2147484` (~24.9
days).

The second, blunter failure is the one you would expect: there is no upper clamp
at all, so `Retry-After: 86400` (entirely legal HTTP) **parks the publishing
worker for 24 h per attempt**, four attempts deep, with nothing to cancel it.
And there is no floor, so `Retry-After: -1` reaches `setTimeout` as `-1000`
(`TimeoutNegativeWarning`).

`withRetry` is the shared transport boundary for **all 11 social platforms**
(`PLATFORM_RATE_LIMITS`, `rate-limit.ts:23-38`), so this sits on every outbound
publish and read hop for twitter, bluesky, discord, telegram, slack, reddit,
facebook, instagram, tiktok, linkedin and mastodon.

### The repo already has the correct shape one directory over

`packages/cloud/shared/src/lib/providers/_http.ts:85-96` (`computeBackoffMs`)
reads the same header and clamps both ends against
`PROVIDER_MAX_BACKOFF_DELAY_MS`. The social-media sibling has neither bound.
This PR uses that module's clamp shape.

I did **not** reuse `PROVIDER_MAX_BACKOFF_DELAY_MS` itself. It is 8 s, and it is
exported specifically so the stale-reservation sweep can derive its grace window
from the *LLM provider* retry ladder (`_http.ts:51-58`, #11683). Coupling the
social ladder to it would both entangle two unrelated subsystems and clamp far
below what social platforms legitimately ask for. `MAX_RATE_LIMIT_WAIT_MS` is
60 s: worst case one `withRetry` call now holds for 3 min instead of 4 days,
and it is ~36 000× below the `2^31-1` coercion threshold.

### The shape of the fix

```ts
export const MAX_RATE_LIMIT_WAIT_MS = 60_000;

export function clampRateLimitWaitMs(waitMs: number): number {
  if (!Number.isFinite(waitMs)) return MAX_RATE_LIMIT_WAIT_MS;
  return Math.min(Math.max(waitMs, 0), MAX_RATE_LIMIT_WAIT_MS);
}
```

applied at the two places a wait reaches `sleep()` — the 429 path
(`retryAfter ?? baseDelayMs * 2 ** attempt`) and the transient-error path
(`baseDelayMs * 2 ** attempt`) — so the module-wide invariant is *every* delay
handed to `setTimeout` is finite, non-negative, and inside the 32-bit range. A
non-finite wait clamps to the **maximum**, not to zero, so a malformed value
slows us down rather than becoming a retry storm.

The ceiling is the load-bearing half and it is asserted as such: a fix that
merely caps "at 24h" while still passing a value above `2^31-1` to `setTimeout`
reproduces the inversion, so the test pins `MAX_RATE_LIMIT_WAIT_MS <= 2^31-1`
directly (mutation C below proves that assertion fires).

### No over-rejection — proved, not asserted

This is the part I want a reviewer to check hardest, because it is where this
family of PRs gets caught.

- **The value reported to callers is not clamped.** `parseRetryAfter` is
  untouched; the clamp lives at the sleep site. A 429 exhaustion still throws the
  typed `RateLimitError` carrying the provider's real value
  (`retryAfter: 86400`, not `60`), so callers can still schedule against what the
  provider actually said. #20116 established that this function's numeric edges
  are load-bearing, and nothing about them moves here.
- **`Retry-After: 0` still means an immediate retry** (#20116) — pinned by an
  assertion on the exact existing log line, and the pre-existing
  `rate-limit.error-policy.test.ts` case for it still passes unchanged.
- **A few seconds still waits those seconds** — `Retry-After: 1` measured at
  1001 ms end to end, recovering to `{ data: { ok: true } }`.
- **The HTTP-date form still parses** — a date 5 s out still yields a
  `RateLimitError` with `0 < retryAfter <= 5`.
- `clampRateLimitWaitMs(ms) === ms` is asserted for every ordinary value
  `0, 1, 1000, 5000, 30_000, 60_000`.

Nothing is silently truncated and served as success: the clamped figure is what
the existing `logger.warn` line reports, so the log and the timer agree.

No new error type was introduced. The module already has a typed, fail-closed
`RateLimitError` with platform and `retryAfter` context, and this change
preserves it exactly rather than adding a competing one.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The rationale
(both bounds, the `2^31-1` coercion, and why `PROVIDER_MAX_BACKOFF_DELAY_MS` is
not reused) is documented on the constant itself.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/social-media/rate-limit.retry-after-clamp.test.ts`,
then the 4-line behavioural diff in `rate-limit.ts`.

## Detailed testing steps

```bash
git fetch origin develop && git checkout <this branch>
bun install
cd packages/cloud/shared
bun test src/lib/services/social-media/rate-limit.retry-after-clamp.test.ts
bun test src/lib/services/social-media/rate-limit.error-policy.test.ts
```

### 1. Origin reproduction — BEFORE (unmodified `origin/develop` `f4ee83bf9a94`)

A temporary `bun:test` file placed next to the module (logger mocked, `fn`
injected, no network) driving the **real exported `withRetry`**. It is not part
of this diff; it exists only to produce this output.

```
$ bun test src/lib/services/social-media/zz-origin-repro.test.ts

TimeoutOverflowWarning: 999999999000 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
      at sleep (.../social-media/rate-limit.ts:40:31)
      at withRetry (.../social-media/rate-limit.ts:86:17)
   [x3, one per retry]

TimeoutNegativeWarning: -1000 is a negative number.
Timeout duration was set to 1.
      at sleep (.../social-media/rate-limit.ts:40:31)
      at withRetry (.../social-media/rate-limit.ts:86:17)

===== ORIGIN REPRODUCTION =====
A. Retry-After: 86400      -> log: "[twitter] Rate limited, waiting 86400000ms before retry 1/3"
                              withRetry STILL PENDING after 3002ms (settled=false) — worker held 24.00h per attempt, 4 attempts
B. Retry-After: 999999999  -> log: "[twitter] Rate limited, waiting 999999999000ms before retry 1/3"
                              waits requested: 3 x 999999999000ms (11574 days each)
                              ACTUAL wall clock to exhaust all 3 retries: 6ms
                              setTimeout coerced every wait to 1ms -> the LARGER the provider's backoff, the FASTER we hammer it (rateLimited=true)
C. Retry-After: -1         -> sleep(-1000) fired immediately; 3 retries in 4ms (rateLimited=true)
D. Retry-After: 1 (CONTROL)-> waited 1001ms then recovered: {"data":{"ok":true}}
===============================

 4 pass
 0 fail
Ran 4 tests across 1 file. [4.51s]
```

Both failures are measured, not argued: **A** is the 24 h pin (still pending at
3 s, log confirms an 86 400 000 ms sleep). **B** is the inversion — three
requested waits of 11 574 days each, exhausted in **6 ms** of wall clock.

### 2. AFTER — the new suite

```
$ bun test src/lib/services/social-media/rate-limit.retry-after-clamp.test.ts
bun test v1.3.14 (0d9b296a)

 10 pass
 0 fail
 37 expect() calls
Ran 10 tests across 1 file. [1207.00ms]
```

### 3. Load-bearing check — the test fails without the fix, three ways

Reverted by copy-aside (never `git stash`), restored after each arm.

**A. Full revert to the origin file** (`git show HEAD:…/rate-limit.ts > rate-limit.ts`):

```
 4 pass
 6 fail

(fail) withRetry — the clamp is on the path that feeds setTimeout > does not
       collapse an overflowing Retry-After into an instant retry storm [104.09ms]
       expect(received).toBe(expected)   Expected: false   Received: true
(fail) … > bounds the exponential fallback used when no Retry-After is sent
       TypeError: clampRateLimitWaitMs is not a function
```

The first failure is the inversion itself, behaviourally: on origin `withRetry`
has already settled 100 ms in, because every wait collapsed to 1 ms.

**B. Ceiling removed, floor kept** (`return Math.max(waitMs, 0);`) — the precise
mutation a "just floor the negative" fix would be:

```
 6 pass
 4 fail

(fail) withRetry — … > does not collapse an overflowing Retry-After into an instant retry storm [105.69ms]
(fail) … > bounds the exponential fallback used when no Retry-After is sent
       Expected: 60000   Received: 1099511627776000
```

**C. Ceiling present but above `2^31-1`** (`MAX_RATE_LIMIT_WAIT_MS = 30 * 24 * 60 * 60 * 1000`
= 2 592 000 000 ms) — the "cap it at some large number and move on" fix that
*still* overflows `setTimeout`:

```
 7 pass
 3 fail

(fail) clampRateLimitWaitMs — the ceiling has to clear setTimeout's 32-bit range >
       never yields a delay setTimeout would silently coerce to 1ms
       Expected: <= 2147483647   Received: 2592000000
(fail) withRetry — … > does not collapse an overflowing Retry-After into an instant retry storm [101.31ms]
```

Mutation C is the one that matters for this defect: the suite catches the
overflow inversion *specifically*, not merely the 24 h case. A 7-day cap
(604 800 000 ms, still under `2^31-1`) is correctly **not** flagged by that
assertion — only the `2^31-1` violation is.

### 4. Pre-existing suite, unchanged

```
$ bun test src/lib/services/social-media/rate-limit.error-policy.test.ts
 9 pass
 0 fail
 15 expect() calls
```

Including its two `Retry-After: 0` cases, untouched.

# Evidence Gate

<!-- evidence-head:f763e246180634e40a7b8430f3ff03e6b40de557 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only change to a Cloud service module; no rendered UI surface is touched by this diff.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only change to a Cloud service module; no rendered UI surface is touched by this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the observable behaviour is a timer bound, shown as before/after wall-clock measurements in Testing above.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — pasted below (the
      structured `logger.warn` lines emitted by the real `withRetry`, plus the
      runtime's own timer warnings naming `rate-limit.ts:40` and `:86`).

<details><summary>BEFORE — unmodified <code>origin/develop</code> f4ee83bf9a94, real <code>withRetry</code> driven by <code>bun test</code></summary>

```
TimeoutOverflowWarning: 999999999000 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
      at new Promise (1:11)
      at sleep (.../packages/cloud/shared/src/lib/services/social-media/rate-limit.ts:40:31)
      at withRetry (.../packages/cloud/shared/src/lib/services/social-media/rate-limit.ts:86:17)

TimeoutOverflowWarning: 999999999000 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
      at sleep (.../social-media/rate-limit.ts:40:31)
      at withRetry (.../social-media/rate-limit.ts:86:17)

TimeoutOverflowWarning: 999999999000 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
      at sleep (.../social-media/rate-limit.ts:40:31)
      at withRetry (.../social-media/rate-limit.ts:86:17)

TimeoutNegativeWarning: -1000 is a negative number.
Timeout duration was set to 1.
      at sleep (.../social-media/rate-limit.ts:40:31)
      at withRetry (.../social-media/rate-limit.ts:86:17)

===== ORIGIN REPRODUCTION =====
A. Retry-After: 86400      -> log: "[twitter] Rate limited, waiting 86400000ms before retry 1/3"
                              withRetry STILL PENDING after 3002ms (settled=false) — worker held 24.00h per attempt, 4 attempts
B. Retry-After: 999999999  -> log: "[twitter] Rate limited, waiting 999999999000ms before retry 1/3"
                              waits requested: 3 x 999999999000ms (11574 days each)
                              ACTUAL wall clock to exhaust all 3 retries: 6ms
                              setTimeout coerced every wait to 1ms -> the LARGER the provider's backoff, the FASTER we hammer it (rateLimited=true)
C. Retry-After: -1         -> sleep(-1000) fired immediately; 3 retries in 4ms (rateLimited=true)
D. Retry-After: 1 (CONTROL)-> waited 1001ms then recovered: {"data":{"ok":true}}
===============================

 4 pass
 0 fail
Ran 4 tests across 1 file. [4.51s]
```

</details>

<details><summary>AFTER — this branch, same module, same driver</summary>

```
$ bun test src/lib/services/social-media/rate-limit.retry-after-clamp.test.ts
bun test v1.3.14 (0d9b296a)

 10 pass
 0 fail
 37 expect() calls
Ran 10 tests across 1 file. [1207.00ms]
```

No `TimeoutOverflowWarning` and no `TimeoutNegativeWarning` are emitted: every
wait handed to `setTimeout` is now finite, non-negative, and <= 60000ms. The
logged figure and the timer agree, so `[twitter] Rate limited, waiting 60000ms
before retry 1/1` is what an overflowing `Retry-After` now produces, in place of
`waiting 999999999000ms` followed by an immediate retry.

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path; this module runs server-side in Cloud only.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behaviour changes; this is an HTTP retry timer bound.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB rows, memories, scheduled tasks, on-chain output, or generated files are produced or altered.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behaviour changes.`

## Backend + frontend logs

Backend: inline in **Testing → 1** (structured `logger.warn` lines from the real
`withRetry`, plus the runtime's own `TimeoutOverflowWarning` /
`TimeoutNegativeWarning` frames naming `rate-limit.ts:40` and `:86`).

Frontend: `N/A - server-side module.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT, or omnivoice surface.`

## Known gaps / failures

- **`bun run verify` was not run monorepo-wide.** It builds and tests the whole
  repo and is far beyond the blast radius of a 4-line change in one Cloud
  service module. What was run instead, and passed, is recorded above and below:
  the new focused suite, the pre-existing `rate-limit.error-policy.test.ts`, the
  `@elizaos/cloud-shared` typecheck against an untouched control, and biome on
  both touched files.
- **Hosted CI checks do not run on this PR.** I contribute from a fork without
  push access to `elizaOS/eliza`, so no hosted check will report here. Every
  result above was produced locally and is reproducible with the commands given.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-mine-23797]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JCZJFQKYW9Z9WD7PQARJKB","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T14:53:12.567Z","completed_at":"2026-08-21T15:02:59.820Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T14:53:13.839Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"41155955a068625b0e6feaa7ad2bf78e6b67d008e46c672874d9407f32be2aae","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"16af3fdb-868d-4624-8a2b-7fbca735f67f","object_id":"sha256:41155955a068625b0e6feaa7ad2bf78e6b67d008e46c672874d9407f32be2aae","sha256":"41155955a068625b0e6feaa7ad2bf78e6b67d008e46c672874d9407f32be2aae"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"UmGeJgSCeEdOQeRi7sG-BAJXq83Lxl4neKspIQqcrkyWv67jg-qimVOzhsyTC0MXElmFcRPLMr5GWamyc2o-AA"}} -->
