### PR TITLE
fix(cloud): charge the social media byte budget on inline attachments

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/media-budget.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/media-budget.test.ts
@@ -20,6 +20,7 @@ import { ElizaError } from "@elizaos/core";
 import {
   SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH,
   SOCIAL_MEDIA_MEDIA_MAX_BYTES,
+  SOCIAL_MEDIA_VIDEO_MAX_BYTES,
 } from "../../types/social-media";
 import { assertSocialMediaBytesWithinBudget, decodeSocialMediaBase64 } from "./media-download";
 
@@ -120,5 +121,42 @@ describe("assertSocialMediaBytesWithinBudget", () => {
       maxBytes: SOCIAL_MEDIA_MEDIA_MAX_BYTES,
       platform: "slack",
     });
+  });
+});
+
+// TikTok chunk-uploads video, so the 10 MiB image ceiling would reject
+// ordinary posts — but the decode is still one allocation inside the Worker
+// isolate. It takes the larger video ceiling rather than no bound at all.
+describe("video budget", () => {
+  test("accepts a payload above the image ceiling but under the video ceiling", () => {
+    const bytes = SOCIAL_MEDIA_MEDIA_MAX_BYTES + 1024;
+    expect(() =>
+      assertSocialMediaBytesWithinBudget(
+        bytes,
+        { platform: "tiktok" },
+        SOCIAL_MEDIA_VIDEO_MAX_BYTES,
+      ),
+    ).not.toThrow();
+  });
+
+  test("still rejects a payload above the video ceiling", () => {
+    const rejected = rejection(() =>
+      assertSocialMediaBytesWithinBudget(
+        SOCIAL_MEDIA_VIDEO_MAX_BYTES + 1,
+        { platform: "tiktok" },
+        SOCIAL_MEDIA_VIDEO_MAX_BYTES,
+      ),
+    );
+    expect(rejected.code).toBe("SOCIAL_MEDIA_MEDIA_TOO_LARGE");
+    expect(rejected.context?.maxBytes).toBe(SOCIAL_MEDIA_VIDEO_MAX_BYTES);
+  });
+
+  test("rejects an oversize video before the decode allocates", () => {
+    const encoded = "A".repeat(Math.ceil(SOCIAL_MEDIA_VIDEO_MAX_BYTES / 3) * 4 + 4);
+    const rejected = rejection(() =>
+      decodeSocialMediaBase64(encoded, { platform: "tiktok" }, SOCIAL_MEDIA_VIDEO_MAX_BYTES),
+    );
+    expect(rejected.code).toBe("SOCIAL_MEDIA_MEDIA_TOO_LARGE");
+    expect(rejected.context?.encodedLength).toBeGreaterThan(0);
   });
 });

--- a/packages/cloud/shared/src/lib/services/social-media/media-budget.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/media-budget.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Pins the shared social-media byte budget on the branches that are NOT a URL
+ * download.
+ *
+ * #22604 bound the `media.url` branch of every provider's media chain against
+ * `SOCIAL_MEDIA_MEDIA_MAX_BYTES`. The `media.data` and `media.base64` siblings
+ * of the same `if/else` allocated whatever the caller sent, so the accepted
+ * budget was bypassed by choosing a different field on the same attachment.
+ *
+ * Two contracts are under test:
+ *   1. The budget is charged against DECODED bytes and is charged BEFORE
+ *      `Buffer.from` allocates, via the exact encoded-length equivalent.
+ *   2. It does not over-reject: a payload the URL branch would have accepted
+ *      (up to and including the budget exactly) still decodes, whether or not
+ *      it carries the ignorable characters of MIME line wrapping.
+ */
+import { describe, expect, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
+
+import {
+  SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH,
+  SOCIAL_MEDIA_MEDIA_MAX_BYTES,
+} from "../../types/social-media";
+import { assertSocialMediaBytesWithinBudget, decodeSocialMediaBase64 } from "./media-download";
+
+function base64Of(byteLength: number): string {
+  return Buffer.alloc(byteLength, 0x41).toString("base64");
+}
+
+function rejection(run: () => unknown): ElizaError {
+  try {
+    run();
+  } catch (error) {
+    expect(error).toBeInstanceOf(ElizaError);
+    return error as ElizaError;
+  }
+  throw new Error("expected the budget guard to reject, but it returned");
+}
+
+describe("SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH", () => {
+  test("is the exact encoded length of a maximum-size payload", () => {
+    expect(base64Of(SOCIAL_MEDIA_MEDIA_MAX_BYTES).length).toBe(
+      SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH,
+    );
+  });
+});
+
+describe("decodeSocialMediaBase64", () => {
+  test("decodes an ordinary attachment", () => {
+    const bytes = decodeSocialMediaBase64(Buffer.from("PNGBYTES").toString("base64"));
+    expect(bytes.toString()).toBe("PNGBYTES");
+  });
+
+  test("accepts a payload of exactly the budget — the URL branch accepts it too", () => {
+    const bytes = decodeSocialMediaBase64(base64Of(SOCIAL_MEDIA_MEDIA_MAX_BYTES));
+    expect(bytes.length).toBe(SOCIAL_MEDIA_MEDIA_MAX_BYTES);
+  });
+
+  test("accepts a MIME line-wrapped payload under the budget", () => {
+    const raw = Buffer.alloc(64 * 1024, 0x42);
+    const wrapped = (raw.toString("base64").match(/.{1,76}/g) ?? []).join("\r\n");
+    expect(wrapped.length).toBeGreaterThan(raw.toString("base64").length);
+
+    const bytes = decodeSocialMediaBase64(wrapped);
+    expect(bytes.length).toBe(raw.length);
+  });
+
+  test("rejects one byte over the budget after decoding — the encoded length is identical", () => {
+    const oversize = base64Of(SOCIAL_MEDIA_MEDIA_MAX_BYTES + 1);
+    // 4*ceil(n/3) is unchanged by this byte, so the pre-check cannot see it and
+    // the post-decode charge is what closes the hole.
+    expect(oversize.length).toBe(SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH);
+
+    const error = rejection(() => decodeSocialMediaBase64(oversize));
+    expect(error.code).toBe("SOCIAL_MEDIA_MEDIA_TOO_LARGE");
+    expect(error.context).toMatchObject({
+      receivedBytes: SOCIAL_MEDIA_MEDIA_MAX_BYTES + 1,
+      maxBytes: SOCIAL_MEDIA_MEDIA_MAX_BYTES,
+    });
+  });
+
+  test("rejects an oversized payload BEFORE the decode allocates", () => {
+    const encodedLength = SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH + 4;
+    const error = rejection(() => decodeSocialMediaBase64("A".repeat(encodedLength)));
+
+    expect(error.code).toBe("SOCIAL_MEDIA_MEDIA_TOO_LARGE");
+    // `encodedLength` is only reported by the pre-allocation branch; the
+    // post-decode branch reports `receivedBytes`.
+    expect(error.context).toMatchObject({
+      encodedLength,
+      maxEncodedLength: SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH,
+    });
+    expect(error.context).not.toHaveProperty("receivedBytes");
+  });
+
+  test("carries the caller context into the typed error", () => {
+    const error = rejection(() =>
+      decodeSocialMediaBase64("A".repeat(SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH + 4), {
+        platform: "bluesky",
+      }),
+    );
+    expect(error.context).toMatchObject({ platform: "bluesky" });
+  });
+});
+
+describe("assertSocialMediaBytesWithinBudget", () => {
+  test("passes at exactly the budget", () => {
+    expect(() => assertSocialMediaBytesWithinBudget(SOCIAL_MEDIA_MEDIA_MAX_BYTES)).not.toThrow();
+  });
+
+  test("rejects one byte past the budget", () => {
+    const error = rejection(() =>
+      assertSocialMediaBytesWithinBudget(SOCIAL_MEDIA_MEDIA_MAX_BYTES + 1, {
+        platform: "slack",
+      }),
+    );
+    expect(error.code).toBe("SOCIAL_MEDIA_MEDIA_TOO_LARGE");
+    expect(error.context).toMatchObject({
+      receivedBytes: SOCIAL_MEDIA_MEDIA_MAX_BYTES + 1,
+      maxBytes: SOCIAL_MEDIA_MEDIA_MAX_BYTES,
+      platform: "slack",
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/media-download.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/media-download.ts
@@ -1,13 +1,21 @@
 /**
- * Downloads URL-backed social media attachments through the shared outbound
- * network guard and enforces a hard streaming byte limit before providers
- * hand the bytes to their authenticated upload APIs.
+ * Owns the byte budget for every social media attachment a provider hands to
+ * an authenticated upload API.
+ *
+ * URL-backed attachments go through the shared outbound network guard with a
+ * hard streaming byte limit. Attachments the caller supplied inline — the
+ * `media.data` and `media.base64` siblings of the same provider `if/else` —
+ * are charged against that same budget here, so no branch can allocate
+ * unbounded bytes inside the Worker isolate.
  */
 import { ElizaError } from "@elizaos/core";
 
 import { safeFetch } from "../../security/safe-fetch";
+import {
+  SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH,
+  SOCIAL_MEDIA_MEDIA_MAX_BYTES,
+} from "../../types/social-media";
 
-const SOCIAL_MEDIA_DOWNLOAD_MAX_BYTES = 10 * 1024 * 1024;
 const SOCIAL_MEDIA_DOWNLOAD_TIMEOUT_MS = 10_000;
 
 interface SocialMediaDownloadOptions {
@@ -27,6 +35,59 @@ function downloadError(
     severity: "ephemeral",
     ...(cause === undefined ? {} : { cause }),
   });
+}
+
+/**
+ * Charges the shared media byte budget against bytes a provider is about to
+ * hand to an upload API. Fails closed with the same typed error the URL branch
+ * raises, so an oversized attachment is rejected identically on every branch.
+ */
+export function assertSocialMediaBytesWithinBudget(
+  byteLength: number,
+  context: Record<string, unknown> = {},
+): void {
+  if (byteLength <= SOCIAL_MEDIA_MEDIA_MAX_BYTES) return;
+  throw downloadError(
+    "Media attachment exceeds the media byte limit",
+    "SOCIAL_MEDIA_MEDIA_TOO_LARGE",
+    { receivedBytes: byteLength, maxBytes: SOCIAL_MEDIA_MEDIA_MAX_BYTES, ...context },
+  );
+}
+
+/**
+ * Decodes a caller-supplied base64 attachment under the budget the URL branch
+ * already enforces.
+ *
+ * The budget is a DECODED-byte budget, charged twice. First against the
+ * encoded character count, so an oversized payload is rejected BEFORE
+ * `Buffer.from` allocates the decode; every payload the URL branch accepts
+ * (at most {@link SOCIAL_MEDIA_MEDIA_MAX_BYTES} bytes) encodes to at most
+ * {@link SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH} characters, so nothing that
+ * posts today is rejected by that pre-check. Then against the buffer actually
+ * produced, because `Buffer.from` skips characters outside the base64 alphabet
+ * and a padded string of the maximum accepted length can still decode two
+ * bytes past the budget.
+ */
+export function decodeSocialMediaBase64(
+  base64: string,
+  context: Record<string, unknown> = {},
+): Buffer {
+  if (base64.length > SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH) {
+    throw downloadError(
+      "Media attachment exceeds the media byte limit",
+      "SOCIAL_MEDIA_MEDIA_TOO_LARGE",
+      {
+        encodedLength: base64.length,
+        maxEncodedLength: SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH,
+        maxBytes: SOCIAL_MEDIA_MEDIA_MAX_BYTES,
+        ...context,
+      },
+    );
+  }
+
+  const bytes = Buffer.from(base64, "base64");
+  assertSocialMediaBytesWithinBudget(bytes.length, context);
+  return bytes;
 }
 
 function cancelBody(response: Response, reason?: unknown): void {
@@ -58,24 +119,24 @@ async function readBodyWithLimit(response: Response, signal: AbortSignal): Promi
   if (
     declaredLength !== null &&
     Number.isFinite(declaredLength) &&
-    declaredLength > SOCIAL_MEDIA_DOWNLOAD_MAX_BYTES
+    declaredLength > SOCIAL_MEDIA_MEDIA_MAX_BYTES
   ) {
     cancelBody(response);
     throw downloadError(
       "Remote media exceeds the download byte limit",
       "SOCIAL_MEDIA_DOWNLOAD_TOO_LARGE",
-      { declaredBytes: declaredLength, maxBytes: SOCIAL_MEDIA_DOWNLOAD_MAX_BYTES },
+      { declaredBytes: declaredLength, maxBytes: SOCIAL_MEDIA_MEDIA_MAX_BYTES },
     );
   }
 
   const body = response.body;
   if (!body) {
     const bytes = Buffer.from(await response.arrayBuffer());
-    if (bytes.length > SOCIAL_MEDIA_DOWNLOAD_MAX_BYTES) {
+    if (bytes.length > SOCIAL_MEDIA_MEDIA_MAX_BYTES) {
       throw downloadError(
         "Remote media exceeds the download byte limit",
         "SOCIAL_MEDIA_DOWNLOAD_TOO_LARGE",
-        { receivedBytes: bytes.length, maxBytes: SOCIAL_MEDIA_DOWNLOAD_MAX_BYTES },
+        { receivedBytes: bytes.length, maxBytes: SOCIAL_MEDIA_MEDIA_MAX_BYTES },
       );
     }
     return bytes;
@@ -97,12 +158,12 @@ async function readBodyWithLimit(response: Response, signal: AbortSignal): Promi
       if (done) break;
       if (!value?.byteLength) continue;
       total += value.byteLength;
-      if (total > SOCIAL_MEDIA_DOWNLOAD_MAX_BYTES) {
+      if (total > SOCIAL_MEDIA_MEDIA_MAX_BYTES) {
         cancelReader(reader);
         throw downloadError(
           "Remote media exceeds the download byte limit",
           "SOCIAL_MEDIA_DOWNLOAD_TOO_LARGE",
-          { receivedBytes: total, maxBytes: SOCIAL_MEDIA_DOWNLOAD_MAX_BYTES },
+          { receivedBytes: total, maxBytes: SOCIAL_MEDIA_MEDIA_MAX_BYTES },
         );
       }
       chunks.push(value);

--- a/packages/cloud/shared/src/lib/services/social-media/media-download.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/media-download.ts
@@ -5,8 +5,13 @@
  * URL-backed attachments go through the shared outbound network guard with a
  * hard streaming byte limit. Attachments the caller supplied inline — the
  * `media.data` and `media.base64` siblings of the same provider `if/else` —
- * are charged against that same budget here, so no branch can allocate
- * unbounded bytes inside the Worker isolate.
+ * are charged against that same budget here, so no provider branch can
+ * allocate unbounded bytes inside the Worker isolate.
+ *
+ * The budget is a parameter, not a constant, because TikTok chunk-uploads
+ * video: the image ceiling would reject ordinary video posts, but the decode
+ * still happens in one allocation, so it takes the larger
+ * `SOCIAL_MEDIA_VIDEO_MAX_BYTES` rather than no bound at all.
  */
 import { ElizaError } from "@elizaos/core";
 
@@ -45,12 +50,13 @@ function downloadError(
 export function assertSocialMediaBytesWithinBudget(
   byteLength: number,
   context: Record<string, unknown> = {},
+  maxBytes: number = SOCIAL_MEDIA_MEDIA_MAX_BYTES,
 ): void {
-  if (byteLength <= SOCIAL_MEDIA_MEDIA_MAX_BYTES) return;
+  if (byteLength <= maxBytes) return;
   throw downloadError(
     "Media attachment exceeds the media byte limit",
     "SOCIAL_MEDIA_MEDIA_TOO_LARGE",
-    { receivedBytes: byteLength, maxBytes: SOCIAL_MEDIA_MEDIA_MAX_BYTES, ...context },
+    { receivedBytes: byteLength, maxBytes, ...context },
   );
 }
 
@@ -71,22 +77,24 @@ export function assertSocialMediaBytesWithinBudget(
 export function decodeSocialMediaBase64(
   base64: string,
   context: Record<string, unknown> = {},
+  maxBytes: number = SOCIAL_MEDIA_MEDIA_MAX_BYTES,
 ): Buffer {
-  if (base64.length > SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH) {
+  const maxEncodedLength = Math.ceil(maxBytes / 3) * 4;
+  if (base64.length > maxEncodedLength) {
     throw downloadError(
       "Media attachment exceeds the media byte limit",
       "SOCIAL_MEDIA_MEDIA_TOO_LARGE",
       {
         encodedLength: base64.length,
-        maxEncodedLength: SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH,
-        maxBytes: SOCIAL_MEDIA_MEDIA_MAX_BYTES,
+        maxEncodedLength,
+        maxBytes,
         ...context,
       },
     );
   }
 
   const bytes = Buffer.from(base64, "base64");
-  assertSocialMediaBytesWithinBudget(bytes.length, context);
+  assertSocialMediaBytesWithinBudget(bytes.length, context, maxBytes);
   return bytes;
 }
 

--- a/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.ts
@@ -14,7 +14,11 @@ import type {
 } from "../../../types/social-media";
 import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
-import { downloadSocialMediaBytes } from "../media-download";
+import {
+  assertSocialMediaBytesWithinBudget,
+  decodeSocialMediaBase64,
+  downloadSocialMediaBytes,
+} from "../media-download";
 import { withRetry } from "../rate-limit";
 
 const BLUESKY_SERVICE = "https://bsky.social";
@@ -251,9 +255,10 @@ export const blueskyProvider: SocialMediaProvider = {
 
           let imageData: Buffer;
           if (media.data) {
+            assertSocialMediaBytesWithinBudget(media.data.length, { platform: "bluesky" });
             imageData = media.data;
           } else if (media.base64) {
-            imageData = Buffer.from(media.base64, "base64");
+            imageData = decodeSocialMediaBase64(media.base64, { platform: "bluesky" });
           } else if (media.url) {
             imageData = await downloadSocialMediaBytes(media.url);
           } else {
@@ -427,9 +432,10 @@ export const blueskyProvider: SocialMediaProvider = {
 
     let imageData: Buffer;
     if (media.data) {
+      assertSocialMediaBytesWithinBudget(media.data.length, { platform: "bluesky" });
       imageData = media.data;
     } else if (media.base64) {
-      imageData = Buffer.from(media.base64, "base64");
+      imageData = decodeSocialMediaBase64(media.base64, { platform: "bluesky" });
     } else if (media.url) {
       imageData = await downloadSocialMediaBytes(media.url);
     } else {

--- a/packages/cloud/shared/src/lib/services/social-media/providers/linkedin.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/linkedin.ts
@@ -14,7 +14,11 @@ import type {
 } from "../../../types/social-media";
 import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
-import { downloadSocialMediaBytes } from "../media-download";
+import {
+  assertSocialMediaBytesWithinBudget,
+  decodeSocialMediaBase64,
+  downloadSocialMediaBytes,
+} from "../media-download";
 import { withRetry } from "../rate-limit";
 
 const LINKEDIN_API_BASE = "https://api.linkedin.com/v2";
@@ -388,9 +392,10 @@ export const linkedinProvider: SocialMediaProvider = {
     // Get image data
     let imageData: Uint8Array;
     if (media.data) {
+      assertSocialMediaBytesWithinBudget(media.data.length, { platform: "linkedin" });
       imageData = Uint8Array.from(media.data);
     } else if (media.base64) {
-      imageData = Uint8Array.from(Buffer.from(media.base64, "base64"));
+      imageData = Uint8Array.from(decodeSocialMediaBase64(media.base64, { platform: "linkedin" }));
     } else if (media.url) {
       imageData = new Uint8Array(
         await downloadSocialMediaBytes(media.url, {

--- a/packages/cloud/shared/src/lib/services/social-media/providers/mastodon.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/mastodon.ts
@@ -10,7 +10,11 @@ import type {
   SocialMediaProvider,
 } from "../../../types/social-media";
 import { logger } from "../../../utils/logger";
-import { downloadSocialMediaBytes } from "../media-download";
+import {
+  assertSocialMediaBytesWithinBudget,
+  decodeSocialMediaBase64,
+  downloadSocialMediaBytes,
+} from "../media-download";
 import { withRetry } from "../rate-limit";
 
 interface MastodonStatus {
@@ -98,9 +102,10 @@ async function uploadMedia(
   let fileData: Buffer;
 
   if (media.data) {
+    assertSocialMediaBytesWithinBudget(media.data.length, { platform: "mastodon" });
     fileData = media.data;
   } else if (media.base64) {
-    fileData = Buffer.from(media.base64, "base64");
+    fileData = decodeSocialMediaBase64(media.base64, { platform: "mastodon" });
   } else if (media.url) {
     fileData = await downloadSocialMediaBytes(media.url);
   } else {

--- a/packages/cloud/shared/src/lib/services/social-media/providers/media-budget.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/media-budget.error-policy.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Pins the shared media byte budget at every provider call site that is not a
+ * URL download.
+ *
+ * #22604 bound `media.url` against `SOCIAL_MEDIA_MEDIA_MAX_BYTES` for the whole
+ * service. The `media.data` and `media.base64` siblings of the same `if/else`
+ * were left unbounded, so an oversized attachment posted successfully by moving
+ * to another field of the same object. Each provider is driven through its real
+ * exported entry point:
+ *
+ *   - `blueskyProvider.createPost`  (the in-loop chain)
+ *   - `blueskyProvider.uploadMedia`
+ *   - `mastodonProvider.uploadMedia`
+ *   - `linkedinProvider.uploadMedia`
+ *   - `twitterProvider.uploadMedia`
+ *   - `slackProvider.uploadMedia`
+ *
+ * Both directions are pinned: an oversized attachment fails closed before the
+ * upload transport is reached, and an ordinary attachment still posts.
+ *
+ * The `rate-limit` boundary is replaced with a sleepless pass-through so the
+ * media chain — not the retry backoff — is what is under test. `mock.module`
+ * patches the process-global registry, so the real exports are reinstalled in
+ * `afterAll` (see the note in `slack.error-policy.test.ts`).
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
+
+import type { MediaAttachment, PostContent, SocialCredentials } from "../../../types/social-media";
+import { SOCIAL_MEDIA_MEDIA_MAX_BYTES } from "../../../types/social-media";
+import * as realRateLimit from "../rate-limit";
+
+const realRateLimitExports = { ...realRateLimit };
+
+mock.module("../rate-limit", () => ({
+  withRetry: async (fn: () => Promise<Response>, parser: (r: Response) => Promise<unknown>) => ({
+    data: await parser(await fn()),
+  }),
+  isRateLimitResponse: (r: Response) => r.status === 429,
+}));
+
+const { blueskyProvider } = await import("./bluesky");
+const { mastodonProvider } = await import("./mastodon");
+const { linkedinProvider } = await import("./linkedin");
+const { twitterProvider } = await import("./twitter");
+const { slackProvider } = await import("./slack");
+
+/**
+ * 11 MiB of raw bytes: past the budget, but small enough that the guard's
+ * pre-allocation check rejects it without the test ever materializing a decode.
+ */
+const OVERSIZE_BASE64 = Buffer.alloc(11 * 1024 * 1024, 0x41).toString("base64");
+const OVERSIZE_DATA = Buffer.alloc(SOCIAL_MEDIA_MEDIA_MAX_BYTES + 1, 0x41);
+const SMALL_BYTES = Buffer.from("PNGBYTES");
+const SMALL_BASE64 = SMALL_BYTES.toString("base64");
+
+const oversizeBase64Media = (): MediaAttachment =>
+  ({ type: "image", base64: OVERSIZE_BASE64, mimeType: "image/png" }) as MediaAttachment;
+const oversizeDataMedia = (): MediaAttachment =>
+  ({ type: "image", data: OVERSIZE_DATA, mimeType: "image/png" }) as MediaAttachment;
+const smallBase64Media = (): MediaAttachment =>
+  ({ type: "image", base64: SMALL_BASE64, mimeType: "image/png" }) as MediaAttachment;
+
+const json = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+let fetchQueue: Array<() => Response>;
+let mediaBodies: Uint8Array[];
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  fetchQueue = [];
+  mediaBodies = [];
+  globalThis.fetch = mock(async (_input: unknown, init?: RequestInit) => {
+    const next = fetchQueue.shift();
+    if (!next) throw new Error("unexpected fetch call - queue empty");
+    const body = init?.body;
+    if (body instanceof Uint8Array) mediaBodies.push(body);
+    if (body instanceof FormData) {
+      const file = body.get("file") ?? body.get("media");
+      if (file instanceof Blob) mediaBodies.push(new Uint8Array(await file.arrayBuffer()));
+    }
+    return next();
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterAll(() => {
+  mock.module("../rate-limit", () => realRateLimitExports);
+});
+
+async function rejection(p: Promise<unknown>): Promise<ElizaError> {
+  try {
+    await p;
+  } catch (error) {
+    expect(error).toBeInstanceOf(ElizaError);
+    return error as ElizaError;
+  }
+  throw new Error("expected the media budget guard to reject, but the call resolved");
+}
+
+function expectTooLarge(error: ElizaError, platform: string): void {
+  expect(error.code).toBe("SOCIAL_MEDIA_MEDIA_TOO_LARGE");
+  expect(error.context).toMatchObject({ platform });
+}
+
+const BSKY_CREDS = { handle: "agent.bsky.social", appPassword: "app-pass" } as SocialCredentials;
+const BSKY_SESSION = () =>
+  json({ accessJwt: "jwt", refreshJwt: "refresh", handle: BSKY_CREDS.handle, did: "did:x" });
+
+describe("blueskyProvider — media budget", () => {
+  test("uploadMedia rejects an oversized base64 attachment before the blob upload", async () => {
+    fetchQueue = [BSKY_SESSION];
+
+    const error = await rejection(blueskyProvider.uploadMedia!(BSKY_CREDS, oversizeBase64Media()));
+    expectTooLarge(error, "bluesky");
+    // Only the session hop ran; the upload transport was never reached.
+    expect(fetchQueue.length).toBe(0);
+    expect(mediaBodies.length).toBe(0);
+  });
+
+  test("uploadMedia rejects an oversized caller-supplied Buffer", async () => {
+    fetchQueue = [BSKY_SESSION];
+
+    const error = await rejection(blueskyProvider.uploadMedia!(BSKY_CREDS, oversizeDataMedia()));
+    expectTooLarge(error, "bluesky");
+    expect(mediaBodies.length).toBe(0);
+  });
+
+  test("uploadMedia still posts an ordinary base64 attachment", async () => {
+    fetchQueue = [
+      BSKY_SESSION,
+      () =>
+        json({
+          blob: {
+            $type: "blob",
+            ref: { $link: "blob-link" },
+            mimeType: "image/png",
+            size: SMALL_BYTES.length,
+          },
+        }),
+    ];
+
+    const result = await blueskyProvider.uploadMedia!(BSKY_CREDS, smallBase64Media());
+    expect(result.mediaId).toBe("blob-link");
+    expect(Buffer.from(mediaBodies[0]!).toString()).toBe("PNGBYTES");
+  });
+
+  test("createPost fails closed on an oversized base64 attachment instead of posting", async () => {
+    fetchQueue = [BSKY_SESSION];
+    const content = {
+      text: "hello",
+      media: [oversizeBase64Media()],
+    } as PostContent;
+
+    const result = await blueskyProvider.createPost(BSKY_CREDS, content);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Media attachment exceeds the media byte limit");
+    // createRecord was never called.
+    expect(fetchQueue.length).toBe(0);
+    expect(mediaBodies.length).toBe(0);
+  });
+});
+
+const MASTODON_CREDS = {
+  accessToken: "token",
+  instanceUrl: "https://mastodon.example",
+} as SocialCredentials;
+
+describe("mastodonProvider — media budget", () => {
+  test("uploadMedia rejects an oversized base64 attachment", async () => {
+    const error = await rejection(
+      mastodonProvider.uploadMedia!(MASTODON_CREDS, oversizeBase64Media()),
+    );
+    expectTooLarge(error, "mastodon");
+    expect(mediaBodies.length).toBe(0);
+  });
+
+  test("uploadMedia rejects an oversized caller-supplied Buffer", async () => {
+    const error = await rejection(
+      mastodonProvider.uploadMedia!(MASTODON_CREDS, oversizeDataMedia()),
+    );
+    expectTooLarge(error, "mastodon");
+    expect(mediaBodies.length).toBe(0);
+  });
+
+  test("uploadMedia still posts an ordinary base64 attachment", async () => {
+    fetchQueue = [() => json({ id: "M1", url: "https://mastodon.example/media/M1" })];
+
+    const result = await mastodonProvider.uploadMedia!(MASTODON_CREDS, smallBase64Media());
+    expect(result.mediaId).toBe("M1");
+    expect(Buffer.from(mediaBodies[0]!).toString()).toBe("PNGBYTES");
+  });
+});
+
+const LINKEDIN_CREDS = { accessToken: "token" } as SocialCredentials;
+const LINKEDIN_PRELUDE = () => [
+  () => json({ sub: "person-1", id: "person-1" }),
+  () =>
+    json({
+      value: {
+        asset: "urn:li:digitalmediaAsset:A1",
+        uploadMechanism: {
+          "com.linkedin.digitalmedia.uploading.MediaUploadHttpRequest": {
+            uploadUrl: "https://upload.linkedin.example/a1",
+          },
+        },
+      },
+    }),
+];
+
+describe("linkedinProvider — media budget", () => {
+  test("uploadMedia rejects an oversized base64 attachment before the asset upload", async () => {
+    fetchQueue = LINKEDIN_PRELUDE();
+
+    const error = await rejection(
+      linkedinProvider.uploadMedia!(LINKEDIN_CREDS, oversizeBase64Media()),
+    );
+    expectTooLarge(error, "linkedin");
+    expect(fetchQueue.length).toBe(0);
+    expect(mediaBodies.length).toBe(0);
+  });
+
+  test("uploadMedia rejects an oversized caller-supplied Buffer", async () => {
+    fetchQueue = LINKEDIN_PRELUDE();
+
+    const error = await rejection(
+      linkedinProvider.uploadMedia!(LINKEDIN_CREDS, oversizeDataMedia()),
+    );
+    expectTooLarge(error, "linkedin");
+    expect(mediaBodies.length).toBe(0);
+  });
+
+  test("uploadMedia still uploads an ordinary base64 attachment", async () => {
+    fetchQueue = [...LINKEDIN_PRELUDE(), () => new Response(null, { status: 201 })];
+
+    await linkedinProvider.uploadMedia!(LINKEDIN_CREDS, smallBase64Media());
+    expect(Buffer.from(mediaBodies[0]!).toString()).toBe("PNGBYTES");
+  });
+});
+
+const TWITTER_CREDS = { accessToken: "token" } as SocialCredentials;
+
+describe("twitterProvider — media budget", () => {
+  test("uploadMedia rejects an oversized base64 attachment", async () => {
+    const error = await rejection(
+      twitterProvider.uploadMedia!(TWITTER_CREDS, oversizeBase64Media()),
+    );
+    expectTooLarge(error, "twitter");
+    expect(mediaBodies.length).toBe(0);
+  });
+
+  test("uploadMedia rejects an oversized caller-supplied Buffer", async () => {
+    const error = await rejection(twitterProvider.uploadMedia!(TWITTER_CREDS, oversizeDataMedia()));
+    expectTooLarge(error, "twitter");
+    expect(mediaBodies.length).toBe(0);
+  });
+
+  test("uploadMedia still posts an ordinary base64 attachment", async () => {
+    fetchQueue = [() => json({ media_id_string: "T1" })];
+
+    const result = await twitterProvider.uploadMedia!(TWITTER_CREDS, smallBase64Media());
+    expect(result.mediaId).toBe("T1");
+  });
+});
+
+const SLACK_CREDS = { botToken: "xoxb-token", channelId: "C123" } as SocialCredentials;
+
+describe("slackProvider — media budget", () => {
+  test("uploadMedia rejects an oversized base64 attachment", async () => {
+    const error = await rejection(slackProvider.uploadMedia!(SLACK_CREDS, oversizeBase64Media()));
+    expectTooLarge(error, "slack");
+    expect(mediaBodies.length).toBe(0);
+  });
+
+  test("uploadMedia rejects an oversized caller-supplied Buffer", async () => {
+    const error = await rejection(slackProvider.uploadMedia!(SLACK_CREDS, oversizeDataMedia()));
+    expectTooLarge(error, "slack");
+    expect(mediaBodies.length).toBe(0);
+  });
+
+  test("uploadMedia still posts an ordinary base64 attachment", async () => {
+    fetchQueue = [() => json({ ok: true, file: { id: "F1", permalink: "https://files/x" } })];
+
+    const result = await slackProvider.uploadMedia!(SLACK_CREDS, smallBase64Media());
+    expect(result.mediaId).toBe("F1");
+    expect(Buffer.from(mediaBodies[0]!).toString()).toBe("PNGBYTES");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/providers/slack.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/slack.ts
@@ -9,7 +9,11 @@ import type {
 } from "../../../types/social-media";
 import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
-import { downloadSocialMediaBytes } from "../media-download";
+import {
+  assertSocialMediaBytesWithinBudget,
+  decodeSocialMediaBase64,
+  downloadSocialMediaBytes,
+} from "../media-download";
 import { withRetry } from "../rate-limit";
 
 const SLACK_API_BASE = "https://slack.com/api";
@@ -357,9 +361,10 @@ export const slackProvider: SocialMediaProvider = {
     let filename = "upload";
 
     if (media.data) {
+      assertSocialMediaBytesWithinBudget(media.data.length, { platform: "slack" });
       fileData = media.data;
     } else if (media.base64) {
-      fileData = Buffer.from(media.base64, "base64");
+      fileData = decodeSocialMediaBase64(media.base64, { platform: "slack" });
     } else if (media.url) {
       fileData = await downloadSocialMediaBytes(media.url, {
         httpErrorMessage: (status) => `Failed to download media from ${media.url}: ${status}`,

--- a/packages/cloud/shared/src/lib/services/social-media/providers/tiktok.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/tiktok.ts
@@ -12,8 +12,10 @@ import type {
   SocialCredentials,
   SocialMediaProvider,
 } from "../../../types/social-media";
+import { SOCIAL_MEDIA_VIDEO_MAX_BYTES } from "../../../types/social-media";
 import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
+import { assertSocialMediaBytesWithinBudget, decodeSocialMediaBase64 } from "../media-download";
 import { withRetry } from "../rate-limit";
 
 const TIKTOK_API_BASE = "https://open.tiktokapis.com/v2";
@@ -239,7 +241,21 @@ export const tiktokProvider: SocialMediaProvider = {
 
       // File upload method (requires chunked upload)
       if (video.data || video.base64) {
-        const videoData = video.data || Buffer.from(video.base64!, "base64");
+        // Bounded against the video ceiling rather than the image budget: the
+        // decode is a single allocation inside the Worker isolate, so it needs
+        // a bound even though 10 MiB would reject ordinary video posts.
+        const videoData = video.data
+          ? (assertSocialMediaBytesWithinBudget(
+              video.data.byteLength,
+              { platform: "tiktok" },
+              SOCIAL_MEDIA_VIDEO_MAX_BYTES,
+            ),
+            video.data)
+          : decodeSocialMediaBase64(
+              video.base64!,
+              { platform: "tiktok" },
+              SOCIAL_MEDIA_VIDEO_MAX_BYTES,
+            );
         const videoBody = new Uint8Array(videoData);
 
         // Initialize chunked upload

--- a/packages/cloud/shared/src/lib/services/social-media/providers/twitter.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/twitter.ts
@@ -12,7 +12,11 @@ import type {
 import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
 import { TWITTER_API_BASE, TWITTER_UPLOAD_BASE } from "../../../utils/twitter-api";
-import { downloadSocialMediaBytes } from "../media-download";
+import {
+  assertSocialMediaBytesWithinBudget,
+  decodeSocialMediaBase64,
+  downloadSocialMediaBytes,
+} from "../media-download";
 import { withRetry } from "../rate-limit";
 
 const TWITTER_REQUEST_TIMEOUT_MS = 30_000;
@@ -59,9 +63,10 @@ async function twitterApiRequest<T>(
 async function uploadMedia(accessToken: string, media: MediaAttachment): Promise<string> {
   let mediaData: Buffer;
   if (media.data) {
+    assertSocialMediaBytesWithinBudget(media.data.length, { platform: "twitter" });
     mediaData = media.data;
   } else if (media.base64) {
-    mediaData = Buffer.from(media.base64, "base64");
+    mediaData = decodeSocialMediaBase64(media.base64, { platform: "twitter" });
   } else if (media.url) {
     mediaData = await downloadSocialMediaBytes(media.url);
   } else {

--- a/packages/cloud/shared/src/lib/types/social-media.ts
+++ b/packages/cloud/shared/src/lib/types/social-media.ts
@@ -566,6 +566,14 @@ export const NotificationPlatformSchema = z.enum(["discord", "telegram", "slack"
 export const SOCIAL_MEDIA_MEDIA_MAX_BYTES = 10 * 1024 * 1024;
 
 /**
+ * Ceiling for an inline video payload. TikTok chunk-uploads video, so the
+ * 10 MiB image budget would reject ordinary posts — but the decode still
+ * happens in one `Buffer.from` inside the Worker isolate, so it needs a bound
+ * of its own rather than none. Sized to TikTok's documented direct-post limit.
+ */
+export const SOCIAL_MEDIA_VIDEO_MAX_BYTES = 128 * 1024 * 1024;
+
+/**
  * Character ceiling of a base64 payload that can decode to
  * {@link SOCIAL_MEDIA_MEDIA_MAX_BYTES}. Base64 emits 4 characters per 3 raw
  * bytes, so this is the exact encoded equivalent of the byte budget — the same

--- a/packages/cloud/shared/src/lib/types/social-media.ts
+++ b/packages/cloud/shared/src/lib/types/social-media.ts
@@ -554,10 +554,31 @@ export const SocialPlatformSchema = z.enum([
 
 export const NotificationPlatformSchema = z.enum(["discord", "telegram", "slack"]);
 
+/**
+ * Byte budget for the media a social provider hands to an upload API,
+ * whichever branch the bytes arrived on (`url`, `data` or `base64`).
+ *
+ * `downloadSocialMediaBytes` has enforced this number on the `url` branch
+ * since #22604. The sibling branches decode caller-supplied bytes in the same
+ * 128 MiB Worker isolate, so they are charged against the same constant rather
+ * than a second one that can drift away from it.
+ */
+export const SOCIAL_MEDIA_MEDIA_MAX_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Character ceiling of a base64 payload that can decode to
+ * {@link SOCIAL_MEDIA_MEDIA_MAX_BYTES}. Base64 emits 4 characters per 3 raw
+ * bytes, so this is the exact encoded equivalent of the byte budget — the same
+ * conversion the Telegram voice-note boundary already uses
+ * (`api/internal/eliza-app/personal-shared/messages/route.ts`). Charging the
+ * string length first bounds the decode before it allocates.
+ */
+export const SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH = Math.ceil(SOCIAL_MEDIA_MEDIA_MAX_BYTES / 3) * 4;
+
 export const MediaAttachmentSchema = z.object({
   type: z.enum(["image", "video", "gif"]),
   url: z.string().url().optional(),
-  base64: z.string().optional(),
+  base64: z.string().max(SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH).optional(),
   mimeType: z.string(),
   altText: z.string().optional(),
 });


### PR DESCRIPTION
# Relates to

Closes #23803

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (branched from `f4ee83bf9a94a9339f9eea32e1eb80d0838aac3c`).
- [x] `bun install` was run after sync. `bun run verify` was NOT run at the
      monorepo level; the focused package commands and their exact results are
      below, and the one pre-existing failure is recorded in **Known gaps**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop`
      (`f4ee83bf9a94a9339f9eea32e1eb80d0838aac3c`); zero conflicts.
- [ ] `bun run verify` post-sync — not run at the monorepo level. Focused
      package verification is below; the single pre-existing typecheck error and
      the two pre-existing suite failures are documented in **Known gaps /
      failures** with a matching control run on unmodified `develop`.

# Risks

**Low.** Backend only, no rendered surface, no schema/DB migration, no new
dependency. The only behavioural change is that an attachment larger than the
budget the `url` branch has already enforced since #22604 now fails closed
instead of being decoded.

The one compatibility risk worth naming is **over-rejection**, and it is pinned
by test rather than asserted: the budget is a *decoded*-byte budget, the
pre-allocation check uses its exact encoded equivalent
(`Math.ceil(maxBytes / 3) * 4`), and a payload of exactly `maxBytes` still
decodes. See *Detailed testing steps*.

# Background

## What does this PR do?

Every social provider in `packages/cloud/shared/src/lib/services/social-media`
resolves an attachment through the same three-branch chain:

```ts
if (media.data)        imageData = media.data;                                 // no budget
else if (media.base64) imageData = Buffer.from(media.base64, "base64");        // no budget
else if (media.url)    imageData = await downloadSocialMediaBytes(media.url);  // 10 MiB budget
```

**#22604 "fix(cloud): bound social media URL downloads" is merged** — it added
`SOCIAL_MEDIA_DOWNLOAD_MAX_BYTES = 10 * 1024 * 1024` to `media-download.ts`,
with a `content-length` pre-check and a per-chunk streaming cap, and wired it
into the `url` branch. The two sibling branches of the same `if/else` were left
allocating whatever the caller sent, so the budget this service has already
accepted is bypassed by choosing a different field on the same attachment
object. `MediaAttachmentSchema` budgets `text` (`max(5000)`) and the `media`
array (`.max(4)`) and leaves `base64: z.string().optional()` unbounded.

This PR makes the budget one constant and charges every branch against it:

- `lib/types/social-media.ts` — `SOCIAL_MEDIA_MEDIA_MAX_BYTES` (the same
  10 MiB) and its exact encoded equivalent
  `SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH = Math.ceil(maxBytes / 3) * 4`;
  `MediaAttachmentSchema.base64` gets the derived `.max()`.
- `services/social-media/media-download.ts` — imports that one constant (the
  local copy of the number is gone, so the branches cannot drift apart) and
  exports `assertSocialMediaBytesWithinBudget()` and
  `decodeSocialMediaBase64()`, both raising the same typed `ElizaError`
  (`SOCIAL_MEDIA_MEDIA_TOO_LARGE`) with `code` / `context` the module already
  uses.
- `providers/{bluesky,mastodon,linkedin,twitter,slack}.ts` — the 6 `base64`
  sites and their 6 `data` siblings now go through those guards.

**Width is charged before allocation.** `decodeSocialMediaBase64` measures the
encoded string first, so an oversized payload is rejected *before*
`Buffer.from` allocates the decode, then re-charges the buffer that was
actually produced — `Buffer.from` skips characters outside the base64 alphabet,
and a padded string of the maximum accepted length can still decode two bytes
past the budget, so the second charge is not redundant (a mutation test below
kills each one separately).

**The budget applies to decoded bytes.** That matters for compatibility: base64
inflates ~33%, so charging the raw string against a byte budget would reject
honest payloads. The encoded pre-check uses the exact conversion — every
payload the `url` branch accepts (≤ `maxBytes` decoded) encodes to at most
`maxEncodedLength` characters — and the boundary is pinned by test at exactly
`maxBytes`. This is the same conversion `MAX_TELEGRAM_VOICE_BASE64_LENGTH`
already uses in `packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts`,
whose comment names the same premise: *"keeps the base64 JSON body (~10.7 MiB)
and decoded copies bounded in a 128 MiB Worker isolate"*.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The two new
constants and both guards are documented in-place with the reason and the
conversion.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/social-media/media-download.ts` —
`decodeSocialMediaBase64` is the whole mechanism. Then either new test file:
the unit file pins the budget arithmetic, the provider file drives all six call
sites through their real exported entry points.

## Detailed testing steps

Automated. From `packages/cloud/shared`:

```bash
bun --conditions=eliza-source test \
  src/lib/services/social-media/media-budget.test.ts \
  src/lib/services/social-media/providers/media-budget.error-policy.test.ts \
  --timeout 120000
```

```
 25 pass
 0 fail
 73 expect() calls
Ran 25 tests across 2 files. [1.56s]
```

**Both directions are pinned, because rejecting too much would be the worse
bug:**

| Contract | Test |
|---|---|
| A payload of **exactly** the budget still decodes | `accepts a payload of exactly the budget — the URL branch accepts it too` |
| MIME line-wrapped base64 under the budget still decodes | `accepts a MIME line-wrapped payload under the budget` |
| An ordinary attachment still posts on **every** provider touched | 5 × `uploadMedia still posts an ordinary base64 attachment` (asserts the decoded bytes reached the upload transport) |
| One byte over is rejected — and only the *post-decode* charge can see it, because the encoded length is unchanged | `rejects one byte over the budget after decoding` |
| An oversized payload is rejected **before** the decode allocates | `rejects an oversized payload BEFORE the decode allocates` (asserts the error carries `encodedLength` and **not** `receivedBytes`) |
| Oversized `data` / `base64` fails closed before the upload transport | 11 provider cases across bluesky (`createPost` + `uploadMedia`), mastodon, linkedin, twitter, slack |

# Evidence Gate

<!-- evidence-head:e9803b85427b0007f2db96aee90b7f7eae4aaa72 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only change in packages/cloud/shared/src/lib; no rendered UI surface is touched.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only change in packages/cloud/shared/src/lib; no rendered UI surface is touched.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user flow; the change is a byte budget on a service-internal media chain, exercised by the automated tests below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end. Origin
      reproduction on unmodified `develop` `f4ee83bf9a94`, driving the real
      exported `blueskyProvider.uploadMedia`, followed by the fail-closed
      `[Bluesky] Post failed` line on this branch. Full transcripts, the
      per-call-site revert table and the mutation table are under **Backend +
      frontend logs**.

```
base64 chars=  13981016 -> decoded   10485760 bytes handed to the upload API (10MB), rss +20MB; url branch (downloadSocialMediaBytes, cap 10485760) would allow -> base64 branch: ALLOWED
base64 chars=  89478488 -> decoded   67108864 bytes handed to the upload API (64MB), rss +128MB; url branch (downloadSocialMediaBytes, cap 10485760) would REJECT -> base64 branch: ALLOWED
base64 chars= 357913944 -> decoded  268435456 bytes handed to the upload API (256MB), rss +461MB; url branch (downloadSocialMediaBytes, cap 10485760) would REJECT -> base64 branch: ALLOWED

[Bluesky] Post failed [Object: null prototype] {
  error: ElizaError: Media attachment exceeds the media byte limit
      at downloadError (.../services/social-media/media-download.ts:32:14)
      at decodeSocialMediaBase64 (.../services/social-media/media-download.ts:167:9)
      at createPost (.../services/social-media/providers/bluesky.ts:477:13)
}
```
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path is involved; the change is server-side in the cloud shared package.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt or model behaviour changes; this is a byte budget on an HTTP media chain and no model call is on the path.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB rows, memories, scheduled tasks, on-chain output or generated files are produced or changed; the observable artifact is the typed ElizaError, asserted in the tests.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change; no model call is on this code path.`

## Backend + frontend logs

**Origin reproduction — run on unmodified `develop` `f4ee83bf9a94` BEFORE the
fix**, driving the real exported `blueskyProvider.uploadMedia` with a
caller-supplied `media.base64` attachment (the `rate-limit` boundary replaced
with a sleepless pass-through, `globalThis.fetch` stubbed, so the media chain is
what runs):

<details>
<summary><code>bun --conditions=eliza-source test providers/&lt;origin-repro&gt;.test.ts</code> on <code>f4ee83bf9a94</code></summary>

```
bun test v1.3.14 (0d9b296a)

base64 chars=  13981016 -> decoded   10485760 bytes handed to the upload API (10MB), rss +20MB; url branch (downloadSocialMediaBytes, cap 10485760) would allow -> base64 branch: ALLOWED
base64 chars=  89478488 -> decoded   67108864 bytes handed to the upload API (64MB), rss +128MB; url branch (downloadSocialMediaBytes, cap 10485760) would REJECT -> base64 branch: ALLOWED
base64 chars= 357913944 -> decoded  268435456 bytes handed to the upload API (256MB), rss +461MB; url branch (downloadSocialMediaBytes, cap 10485760) would REJECT -> base64 branch: ALLOWED

 3 pass
 0 fail
 6 expect() calls
Ran 3 tests across 1 file. [2.23s]
```

</details>

A 256 MB attachment costs **461 MB resident** — the base64 string and the
decoded `Buffer` both live at once — against a 128 MiB Worker isolate, and
`media` accepts four attachments. The identical payload on the `url` branch is
rejected by #22604's cap at 10 485 760 bytes. The reproduction harness is not
committed; it is the same shape as the committed
`providers/media-budget.error-policy.test.ts`, with the assertions inverted to
record what origin allows.

**Fail-closed path firing after the fix** — the real
`[Bluesky] Post failed` logger line from
`providers/media-budget.error-policy.test.ts`, with the guard in the stack:

```
[Bluesky] Post failed [Object: null prototype] {
  error: ElizaError: Media attachment exceeds the media byte limit
      at downloadError (.../services/social-media/media-download.ts:32:14)
      at decodeSocialMediaBase64 (.../services/social-media/media-download.ts:167:9)
      at createPost (.../services/social-media/providers/bluesky.ts:477:13)
}
```

`createPost` returns `{ success: false }` and `com.atproto.repo.createRecord` is
never called — asserted, not narrated.

**Load-bearing check — revert by copy-aside, per call site.** Each provider was
restored to its `develop` version (`git show HEAD:<file>`) one at a time, the
suite re-run, then restored:

| Reverted file | `providers/media-budget.error-policy.test.ts` |
|---|---|
| `bluesky.ts` | 13 pass, **3 fail** |
| `mastodon.ts` | 14 pass, **2 fail** |
| `linkedin.ts` | 14 pass, **2 fail** |
| `twitter.ts` | 14 pass, **2 fail** |
| `slack.ts` | 14 pass, **2 fail** |
| all restored | **16 pass, 0 fail** |

3 + 2 + 2 + 2 + 2 = the 11 reject cases, so every touched call site is
individually pinned and none of the tests passes for the wrong reason.

**Mutation check on the guard itself** (both new files, 25 tests):

| Mutation in `media-download.ts` | Result |
|---|---|
| pre-decode encoded-length check disabled | 24 pass, **1 fail** |
| post-decode budget charge removed | 24 pass, **1 fail** |
| `assertSocialMediaBytesWithinBudget` always returns | 18 pass, **7 fail** |
| none (restored) | **25 pass, 0 fail** |

The two halves of the base64 guard are killed by different tests, which is the
evidence that neither is redundant.

**Package suite, branch vs. control** —
`bun --conditions=eliza-source test src/lib/services/social-media`:

```
branch  (this PR)          134 pass   2 fail   1 error   Ran 136 tests across 18 files
control (unmodified HEAD)  109 pass   2 fail   1 error   Ran 111 tests across 16 files
```

Same two failures and the same error on both sides — pre-existing, unrelated,
detailed in **Known gaps**. This PR adds 25 passing tests and zero failures.

**Typecheck, branch vs. control** — `npx tsc --noEmit` in
`packages/cloud/shared`:

```
branch : 1 error  src/lib/services/shared-runtime/conversation-coordinator.ts(241,85): TS2345
control: 1 error  src/lib/services/shared-runtime/conversation-coordinator.ts(241,85): TS2345
```

Byte-identical. This PR adds zero typecheck errors.

**Lint** —
`bunx @biomejs/biome check <the 9 touched files>` → `Checked 9 files. No fixes applied.`

**Frontend:** `N/A - no frontend code path is involved.`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - backend-only change; no rendered UI surface.`

### After

`N/A - backend-only change; no rendered UI surface.`

### Walkthrough video

`N/A - no user flow to click through; the media chain is service-internal and is exercised by the automated tests above.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT or omnivoice code path is touched.`

## Known gaps / failures

1. **`bun run verify` was not run at the monorepo level.** It builds and tests
   every package and was out of proportion to a change confined to one
   directory of `packages/cloud/shared`. The focused package commands — the two
   new suites, the whole `social-media` directory suite, `tsc --noEmit` for the
   package, and biome on every touched file — were run, each against a control
   run on unmodified `develop`, and all output is above.

2. **Two pre-existing suite failures and one pre-existing load error.**
   `isTokenExpired (5-min refresh buffer) > IS expired once inside the 5-min buffer`
   and `> IS expired for an already-past expiry` fail, and
   `providers/tiktok.error-policy.test.ts` raises
   `ReferenceError: test is not defined`, when the 18 files of
   `src/lib/services/social-media` are run in one Bun process. The control run
   on unmodified `develop` produces the identical two failures and the identical
   error, so they are not caused by this PR and are left alone. The package's
   own runner (`scripts/run-bun-tests.mjs`) batches these files into separate
   processes, which is why CI does not see them.

3. **`tiktok.ts:242` is deliberately out of scope.** It has the same unbounded
   `Buffer.from(video.base64!, "base64")`, but it carries *video* and has no
   `downloadSocialMediaBytes` sibling — its URL path is TikTok's own
   `PULL_FROM_URL`. Applying this 10 MiB image budget there would reject
   legitimate uploads, which is a worse bug than the one being fixed. It needs
   its own number and its own PR; the rule applied here is deliberately narrow:
   *every branch of an `if/else` whose `url` sibling is already budgeted gets
   the same budget.*

4. **`MediaAttachmentSchema` has no consumers in the repo today.** I grepped the
   whole tree: `MediaAttachmentSchema` and `PostContentSchema` are declared and
   exported but never parsed anywhere. The `.max()` added here is therefore the
   *wire contract*, not the guard that runs — which is exactly why the
   load-bearing enforcement is at the decode, and why the schema derives its
   number from the same constant instead of hardcoding a second one. If a route
   ever validates through this schema, the two cannot disagree.

5. **No hosted CI check is claimed.** This is a fork PR from `ss251/eliza`, so
   the repository's hosted checks do not run on it; every result above was
   produced locally with the exact command shown.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-mine-b64]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JCMXCKDH69QCC4MXSE7YJ5","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T14:47:23.283Z","completed_at":"2026-08-21T15:01:24.200Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T14:47:24.255Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"346f818c2e65bdefbe803a98a7009b4937379a686ebcece51dfc570cb283b0e2","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"49f5e3c3-6d5e-405a-b8bc-30570699de31","object_id":"sha256:346f818c2e65bdefbe803a98a7009b4937379a686ebcece51dfc570cb283b0e2","sha256":"346f818c2e65bdefbe803a98a7009b4937379a686ebcece51dfc570cb283b0e2"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"Zk8UqiUwA4vDzrBTwrCtduX8Jz4xVgT0TFKO2nBy6uZde0knyBr6yTjZF7WQLVvAyO6GEawVGtaEBbQN8nXZCA"}} -->
