### PR TITLE
fix(agent): bound the connector-account metadata walks

### DIFF
--- a/packages/agent/src/api/blocked-object-keys.test.ts
+++ b/packages/agent/src/api/blocked-object-keys.test.ts
@@ -44,6 +44,39 @@ describe("blocked object key sanitization", () => {
     expect(hostile).toHaveProperty("prototype", "x");
   });
 
+  it("drops or redacts keys per the caller policy while still bounding the walk", () => {
+    const parsed = JSON.parse(
+      '{"keep":"yes","access_token":"sk-live","nested":{"drop_me":1,"keep":2},"__proto__":{"polluted":true}}',
+    ) as Record<string, unknown>;
+
+    const cleaned = cloneWithoutBlockedObjectKeys(parsed, {
+      keyAction: (key) =>
+        key === "access_token" || key === "drop_me" ? "drop" : "keep",
+    });
+    expect(cleaned).toEqual({ keep: "yes", nested: { keep: 2 } });
+
+    const redacted = cloneWithoutBlockedObjectKeys(parsed, {
+      keyAction: (key) => (key === "access_token" ? "redact" : "keep"),
+      redactedValue: "[REDACTED]",
+    });
+    expect(redacted).toEqual({
+      keep: "yes",
+      access_token: "[REDACTED]",
+      nested: { drop_me: 1, keep: 2 },
+    });
+
+    // The policy does not relax the bound.
+    let overDeep: unknown = "leaf";
+    for (let index = 0; index <= MAX_BLOCKED_OBJECT_DEPTH + 1; index += 1) {
+      overDeep = { a: overDeep };
+    }
+    expect(() =>
+      cloneWithoutBlockedObjectKeys(overDeep, { keyAction: () => "keep" }),
+    ).toThrowError(
+      expect.objectContaining({ code: BLOCKED_OBJECT_GRAPH_UNBOUNDED }),
+    );
+  });
+
   it("does not assign __proto__ while cloning hostile parsed JSON", () => {
     const hostile = JSON.parse(
       '{"__proto__":{"polluted":true},"nested":{"ok":true}}',

--- a/packages/agent/src/api/blocked-object-keys.ts
+++ b/packages/agent/src/api/blocked-object-keys.ts
@@ -152,10 +152,27 @@ function walkHasBlockedObjectKey(
   }
 }
 
+/**
+ * What the clone does with one own enumerable string key. Blocked keys are
+ * always dropped regardless of the policy; the policy only decides the fate of
+ * the keys this walk would otherwise have kept.
+ */
+export type BoundedCloneKeyAction = "keep" | "drop" | "redact";
+
+export interface BoundedCloneOptions {
+  /** Defaults to keeping every non-blocked key, i.e. the historical behaviour. */
+  keyAction?: (key: string) => BoundedCloneKeyAction;
+  /** Substituted for a key whose action is `"redact"`. */
+  redactedValue?: unknown;
+}
+
+const KEEP_EVERY_KEY: BoundedCloneOptions = {};
+
 function cloneWithoutBlockedObjectKeysWalk<T>(
   value: T,
   depth: number,
   ctx: BlockedObjectWalkContext,
+  options: BoundedCloneOptions,
   visitAlreadyReserved = false,
 ): T {
   if (depth > MAX_BLOCKED_OBJECT_DEPTH) {
@@ -182,6 +199,7 @@ function cloneWithoutBlockedObjectKeysWalk<T>(
           descriptor.value,
           depth + 1,
           ctx,
+          options,
           true,
         );
       }
@@ -193,12 +211,19 @@ function cloneWithoutBlockedObjectKeysWalk<T>(
     const out: Record<string, unknown> = {};
     for (const key of keys) {
       if (isBlockedObjectKey(key)) continue;
+      const action = options.keyAction?.(key) ?? "keep";
+      if (action === "drop") continue;
+      if (action === "redact") {
+        out[key] = options.redactedValue;
+        continue;
+      }
       const descriptor = Object.getOwnPropertyDescriptor(value, key);
       if (!descriptor || !("value" in descriptor)) continue;
       out[key] = cloneWithoutBlockedObjectKeysWalk(
         descriptor.value,
         depth + 1,
         ctx,
+        options,
         true,
       );
     }
@@ -227,9 +252,17 @@ export function hasBlockedObjectKeyDeep(value: unknown): boolean {
   }
 }
 
-export function cloneWithoutBlockedObjectKeys<T>(value: T): T {
-  return cloneWithoutBlockedObjectKeysWalk(value, 0, {
-    visits: 0,
-    visiting: new WeakSet<object>(),
-  });
+export function cloneWithoutBlockedObjectKeys<T>(
+  value: T,
+  options: BoundedCloneOptions = KEEP_EVERY_KEY,
+): T {
+  return cloneWithoutBlockedObjectKeysWalk(
+    value,
+    0,
+    {
+      visits: 0,
+      visiting: new WeakSet<object>(),
+    },
+    options,
+  );
 }

--- a/packages/agent/src/api/connector-account-routes.metadata-bounds.test.ts
+++ b/packages/agent/src/api/connector-account-routes.metadata-bounds.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Bounds coverage for the two metadata walks in connector-account-routes.ts
+ * against the REAL route handler and the REAL @elizaos/core connector-account
+ * manager (core is not mocked here; InMemoryDatabaseAdapter stands in for
+ * plugin-sql), modelled on the sibling connector-account-routes.durable.test.ts
+ * harness.
+ *
+ * `metadataSchema` is `z.record(z.string(), z.unknown())`, so a caller-supplied
+ * body may nest arbitrarily. `cleanMetadata` (write) and `redactAuditMetadata`
+ * (read) both used to recurse once per level with no depth cap, no visit
+ * budget and no cycle guard, and neither call site was inside a `try`. Stack
+ * exhaustion therefore escaped `handleConnectorAccountRoutes` entirely --
+ * neither `json()` nor `error()` ran, so no response was ever written. The read
+ * side fails the same way on an adapter-supplied audit row, whose `metadata`
+ * column no layer between the row and the redaction walk bounds.
+ *
+ * These tests pin the bounded behaviour: an over-budget write is rejected with
+ * a 400, an over-budget stored value is still served with an explicit marker,
+ * and honest nested metadata is untouched.
+ */
+import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  getConnectorAccountManager,
+  InMemoryDatabaseAdapter,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ConnectorAccountRouteContext,
+  handleConnectorAccountRoutes,
+} from "./connector-account-routes";
+
+type Captured = { status: number; body: unknown };
+
+const PROVIDER = "google";
+const ACCOUNT_ID = "3a899cd0-170f-4b3e-932e-46ec68119b35";
+
+/** Comfortably past the V8 recursion limit for these frames. */
+const OVERFLOW_DEPTH = 60_000;
+
+function deepChain(depth: number): Record<string, unknown> {
+  const root: Record<string, unknown> = {};
+  let cursor = root;
+  for (let index = 0; index < depth; index += 1) {
+    const next: Record<string, unknown> = {};
+    cursor.a = next;
+    cursor = next;
+  }
+  cursor.leaf = "end";
+  return root;
+}
+
+function createRuntime(adapter?: InMemoryDatabaseAdapter) {
+  return {
+    agentId: "00000000-0000-0000-0000-000000000001",
+    adapter,
+    getService: vi.fn(() => null),
+    getMessageConnectors: vi.fn(() => []),
+    getPostConnectors: vi.fn(() => []),
+    registerMessageConnector: vi.fn(),
+    registerPostConnector: vi.fn(),
+  };
+}
+
+function createContext(
+  runtime: ReturnType<typeof createRuntime>,
+  method: string,
+  pathname: string,
+  body?: unknown,
+): { ctx: ConnectorAccountRouteContext; captured: Captured } {
+  const captured: Captured = { status: 0, body: null };
+  const ctx: ConnectorAccountRouteContext = {
+    req: { url: pathname, on: vi.fn() } as unknown as IncomingMessage,
+    res: {
+      statusCode: 200,
+      setHeader: vi.fn(),
+      write: vi.fn(),
+      end: vi.fn(),
+    } as unknown as ServerResponse,
+    method,
+    pathname,
+    state: { runtime: runtime as never },
+    readJsonBody: (async () => body ?? {}) as never,
+    json: (_res, data, status = 200) => {
+      captured.status = status;
+      captured.body = data;
+    },
+    error: (_res, message, status = 500) => {
+      captured.status = status;
+      captured.body = { error: message };
+    },
+    authorize: vi.fn(async () => true),
+  };
+  return { ctx, captured };
+}
+
+async function newAdapter(): Promise<InMemoryDatabaseAdapter> {
+  const adapter = new InMemoryDatabaseAdapter();
+  await adapter.initialize();
+  return adapter;
+}
+
+describe("connector account metadata walk bounds (real route handler)", () => {
+  it("rejects an over-deep POST body with a 400 instead of escaping the handler", async () => {
+    const runtime = createRuntime(await newAdapter());
+    const pathname = `/api/connectors/${PROVIDER}/accounts`;
+    const { ctx, captured } = createContext(runtime, "POST", pathname, {
+      label: "deep",
+      metadata: { root: deepChain(OVERFLOW_DEPTH) },
+    });
+
+    const handled = await handleConnectorAccountRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(captured.status).toBe(400);
+    expect(String((captured.body as { error: string }).error)).toMatch(
+      /metadata/i,
+    );
+  });
+
+  it("rejects an over-deep PATCH body with a 400", async () => {
+    const adapter = await newAdapter();
+    const runtime = createRuntime(adapter);
+    const manager = getConnectorAccountManager(runtime as never);
+    await manager.upsertAccount(PROVIDER, {
+      id: ACCOUNT_ID,
+      provider: PROVIDER,
+      label: "user@example.com",
+      role: "OWNER",
+      accessGate: "open",
+      status: "connected",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      metadata: {},
+    } as never);
+
+    const pathname = `/api/connectors/${PROVIDER}/accounts/${ACCOUNT_ID}`;
+    const { ctx, captured } = createContext(runtime, "PATCH", pathname, {
+      metadata: { root: deepChain(OVERFLOW_DEPTH) },
+    });
+
+    const handled = await handleConnectorAccountRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(captured.status).toBe(400);
+  });
+
+  it("still serves audit events whose stored row metadata is over-deep, instead of 500ing the read", async () => {
+    // Audit rows come back from the adapter (`listConnectorAccountAuditEvents`
+    // or the raw SQL fallback); nothing between the row and the redaction walk
+    // bounds their `metadata` column.
+    const runtime = {
+      agentId: "00000000-0000-0000-0000-000000000001",
+      adapter: {
+        listConnectorAccountAuditEvents: async () => [
+          {
+            id: "evt-1",
+            accountId: "acct-1",
+            agentId: "00000000-0000-0000-0000-000000000001",
+            provider: PROVIDER,
+            actorId: null,
+            action: "connect",
+            outcome: "success",
+            metadata: { root: deepChain(OVERFLOW_DEPTH) },
+            createdAt: Date.now(),
+          },
+        ],
+      },
+      getService: vi.fn(() => null),
+      getMessageConnectors: vi.fn(() => []),
+      getPostConnectors: vi.fn(() => []),
+      registerMessageConnector: vi.fn(),
+      registerPostConnector: vi.fn(),
+    } as unknown as ReturnType<typeof createRuntime>;
+
+    const pathname = `/api/connectors/${PROVIDER}/audit/events`;
+    const { ctx, captured } = createContext(runtime, "GET", pathname);
+
+    const handled = await handleConnectorAccountRoutes(ctx);
+
+    expect(handled).toBe(true);
+    expect(captured.status).toBe(200);
+    const body = captured.body as { events: Array<{ metadata: unknown }> };
+    // Explicit marker, not a silently truncated object served as success.
+    expect(body.events[0]?.metadata).toBe("[UNBOUNDED]");
+  });
+
+  it("keeps honest nested metadata byte-for-byte on the write and read paths", async () => {
+    const adapter = await newAdapter();
+    const runtime = createRuntime(adapter);
+    const honest = {
+      handle: "user@example.com",
+      profile: {
+        display: "User",
+        tags: ["work", "personal"],
+        settings: {
+          notifications: { email: true, push: false },
+          quota: { daily: 100, nested: { deeper: { deepest: "ok" } } },
+        },
+      },
+      history: [{ at: 1, note: "created" }, { at: 2, note: "verified" }, null],
+      empty: {},
+      emptyList: [],
+      flag: false,
+      count: 0,
+    };
+
+    const createPath = `/api/connectors/${PROVIDER}/accounts`;
+    const create = createContext(runtime, "POST", createPath, {
+      label: "user@example.com",
+      metadata: honest,
+    });
+    expect(await handleConnectorAccountRoutes(create.ctx)).toBe(true);
+    expect(create.captured.status).toBe(201);
+
+    const created = create.captured.body as {
+      id: string;
+      metadata: Record<string, unknown>;
+    };
+    expect(created.metadata).toEqual(honest);
+
+    const readPath = `/api/connectors/${PROVIDER}/accounts/${created.id}`;
+    const read = createContext(runtime, "GET", readPath);
+    expect(await handleConnectorAccountRoutes(read.ctx)).toBe(true);
+    expect(read.captured.status).toBe(200);
+    expect((read.captured.body as { metadata: unknown }).metadata).toEqual(
+      honest,
+    );
+  });
+
+  it("still strips secret-shaped and client-reserved metadata keys on write", async () => {
+    const runtime = createRuntime(await newAdapter());
+    const createPath = `/api/connectors/${PROVIDER}/accounts`;
+    const create = createContext(runtime, "POST", createPath, {
+      label: "user@example.com",
+      metadata: {
+        keep: "yes",
+        access_token: "sk-should-not-persist",
+        ownerBindingId: "spoofed",
+        nested: { refresh_token: "nope", ok: 1 },
+      },
+    });
+
+    expect(await handleConnectorAccountRoutes(create.ctx)).toBe(true);
+    expect(create.captured.status).toBe(201);
+    const created = create.captured.body as {
+      metadata: Record<string, unknown>;
+    };
+    expect(created.metadata.keep).toBe("yes");
+    expect(created.metadata.access_token).toBeUndefined();
+    expect(created.metadata.ownerBindingId).toBeUndefined();
+    expect(created.metadata.nested).toEqual({ ok: 1 });
+  });
+
+  it("redacts secret-shaped keys on read without walking past the budget", async () => {
+    const adapter = await newAdapter();
+    const runtime = createRuntime(adapter);
+    const manager = getConnectorAccountManager(runtime as never);
+    await manager.upsertAccount(PROVIDER, {
+      id: ACCOUNT_ID,
+      provider: PROVIDER,
+      label: "user@example.com",
+      role: "OWNER",
+      accessGate: "open",
+      status: "connected",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      metadata: { keep: "yes", nested: { access_token: "leaked" } } as never,
+    } as never);
+
+    const pathname = `/api/connectors/${PROVIDER}/accounts/${ACCOUNT_ID}`;
+    const { ctx, captured } = createContext(runtime, "GET", pathname);
+    expect(await handleConnectorAccountRoutes(ctx)).toBe(true);
+    expect(captured.status).toBe(200);
+    const serialized = captured.body as { metadata: Record<string, unknown> };
+    expect(serialized.metadata.keep).toBe("yes");
+    expect(serialized.metadata.nested).toEqual({ access_token: "[REDACTED]" });
+  });
+});

--- a/packages/agent/src/api/connector-account-routes.ts
+++ b/packages/agent/src/api/connector-account-routes.ts
@@ -376,7 +376,7 @@ function redactAuditMetadata(value: unknown): unknown {
       redactedValue: AUDIT_REDACTED,
     });
   } catch (error) {
-    // error-policy:J3 metadata already at rest may exceed the walk budget (it
+    // error-policy:J4 metadata already at rest may exceed the walk budget (it
     // could have been written before this bound existed, or by an in-process
     // writer that does not pass through this route). Serve an explicit marker
     // so a single stored value cannot 500 every subsequent read; the reader is
@@ -760,6 +760,10 @@ export async function handleConnectorAccountRoutes(
       try {
         createPatch = accountPatchFromBody(parsed.data);
       } catch (err) {
+        // error-policy:J1 route boundary — an over-budget caller body becomes a
+        // 400 rather than escaping the handler with no response written. Any
+        // other error is rethrown, so this narrows one shape rather than
+        // swallowing the class.
         if (!isUnboundedMetadataGraph(err)) throw err;
         error(res, UNBOUNDED_METADATA_MESSAGE, 400);
         return true;
@@ -810,6 +814,9 @@ export async function handleConnectorAccountRoutes(
         try {
           patch = accountPatchFromBody(parsed.data, existing.metadata);
         } catch (err) {
+          // error-policy:J1 route boundary — same translation as the POST path
+          // above; an over-budget patch body becomes a 400 and every other
+          // error is rethrown.
           if (!isUnboundedMetadataGraph(err)) throw err;
           error(res, UNBOUNDED_METADATA_MESSAGE, 400);
           return true;

--- a/packages/agent/src/api/connector-account-routes.ts
+++ b/packages/agent/src/api/connector-account-routes.ts
@@ -19,6 +19,7 @@ import {
   type ConnectorAccountStatus,
   type ConnectorOAuthFlow,
   DEFAULT_PRIVACY_LEVEL,
+  ElizaError,
   getConnectorAccountManager,
   isPrivacyLevel,
   type Metadata,
@@ -29,9 +30,13 @@ import {
 } from "@elizaos/shared";
 import type { infer as ZodInfer } from "zod";
 import * as zod from "zod";
+import {
+  BLOCKED_OBJECT_GRAPH_UNBOUNDED,
+  cloneWithoutBlockedObjectKeys,
+  isBlockedObjectKey,
+} from "./blocked-object-keys.ts";
 import { resolveDirectRequestOrigin } from "./request-origin.ts";
 import { decodePathComponent } from "./server-helpers.ts";
-import { isBlockedObjectKey } from "./server-helpers-config.ts";
 
 const z = (zod as typeof zod & { z?: typeof zod }).z ?? zod;
 
@@ -81,6 +86,10 @@ const confirmationSchema = z
   })
   .optional();
 const AUDIT_REDACTED = "[REDACTED]";
+/** Served in place of stored metadata whose graph exceeds the bounded walk. */
+const AUDIT_UNBOUNDED = "[UNBOUNDED]";
+const UNBOUNDED_METADATA_MESSAGE =
+  "Connector account metadata exceeds the bounded walk budget";
 const AUDIT_SECRET_KEY_PATTERN =
   /(access|refresh|id)?_?token|secret|password|credential|authorization|cookie|code[_-]?verifier|codeVerifier|client[_-]?secret|api_?key|private_?key|oauth_?code|state/i;
 const CLIENT_RESERVED_METADATA_KEYS = new Set([
@@ -327,25 +336,22 @@ function isClientReservedMetadataKey(key: string): boolean {
   return CLIENT_RESERVED_METADATA_KEYS.has(normalizeMetadataKey(key));
 }
 
+/**
+ * `metadataSchema` is `z.record(z.string(), z.unknown())`, so a caller-supplied
+ * connector-account body may nest arbitrarily. Both metadata walks therefore
+ * run on the shared bounded walker exported by `./blocked-object-keys.ts`
+ * (depth cap, node budget, path-local WeakSet cycle guard, descriptor-only
+ * reflection, typed `BLOCKED_OBJECT_GRAPH_UNBOUNDED` failure) rather than
+ * recursing once per nesting level. Blocked keys are dropped by the walker
+ * itself; the key policies below carry the connector-specific rules.
+ */
 function cleanMetadataValue(value: unknown): unknown {
-  if (value === null || value === undefined) return value;
-  if (Array.isArray(value)) {
-    return value.map((item) => cleanMetadataValue(item));
-  }
-  if (typeof value !== "object") return value;
-
-  const cleaned: Record<string, unknown> = {};
-  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
-    if (
-      isBlockedObjectKey(key) ||
-      AUDIT_SECRET_KEY_PATTERN.test(key) ||
-      isClientReservedMetadataKey(key)
-    ) {
-      continue;
-    }
-    cleaned[key] = cleanMetadataValue(item);
-  }
-  return cleaned;
+  return cloneWithoutBlockedObjectKeys(value, {
+    keyAction: (key) =>
+      AUDIT_SECRET_KEY_PATTERN.test(key) || isClientReservedMetadataKey(key)
+        ? "drop"
+        : "keep",
+  });
 }
 
 function cleanMetadata(value: unknown): Metadata | undefined {
@@ -356,19 +362,28 @@ function cleanMetadata(value: unknown): Metadata | undefined {
   return cleaned as Metadata;
 }
 
-function redactAuditMetadata(value: unknown): unknown {
-  if (value === null || value === undefined) return value;
-  if (Array.isArray(value))
-    return value.map((item) => redactAuditMetadata(item));
-  if (typeof value !== "object") return value;
+function isUnboundedMetadataGraph(error: unknown): boolean {
+  return (
+    error instanceof ElizaError && error.code === BLOCKED_OBJECT_GRAPH_UNBOUNDED
+  );
+}
 
-  const redacted: Record<string, unknown> = {};
-  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
-    redacted[key] = AUDIT_SECRET_KEY_PATTERN.test(key)
-      ? AUDIT_REDACTED
-      : redactAuditMetadata(item);
+function redactAuditMetadata(value: unknown): unknown {
+  try {
+    return cloneWithoutBlockedObjectKeys(value, {
+      keyAction: (key) =>
+        AUDIT_SECRET_KEY_PATTERN.test(key) ? "redact" : "keep",
+      redactedValue: AUDIT_REDACTED,
+    });
+  } catch (error) {
+    // error-policy:J3 metadata already at rest may exceed the walk budget (it
+    // could have been written before this bound existed, or by an in-process
+    // writer that does not pass through this route). Serve an explicit marker
+    // so a single stored value cannot 500 every subsequent read; the reader is
+    // told the value was withheld rather than handed a silent truncation.
+    if (!isUnboundedMetadataGraph(error)) throw error;
+    return AUDIT_UNBOUNDED;
   }
-  return redacted;
 }
 
 function accountPatchFromBody(
@@ -741,8 +756,16 @@ export async function handleConnectorAccountRoutes(
         error(res, "Privacy escalation requires confirmation", 403);
         return true;
       }
+      let createPatch: ConnectorAccountPatch;
+      try {
+        createPatch = accountPatchFromBody(parsed.data);
+      } catch (err) {
+        if (!isUnboundedMetadataGraph(err)) throw err;
+        error(res, UNBOUNDED_METADATA_MESSAGE, 400);
+        return true;
+      }
       const account = await manager.createAccount(provider, {
-        ...accountPatchFromBody(parsed.data),
+        ...createPatch,
         ...(parsed.data.id ? { id: parsed.data.id } : {}),
       } as ConnectorAccountPatch);
       json(res, serializeAccount(account), 201);
@@ -783,7 +806,14 @@ export async function handleConnectorAccountRoutes(
           error(res, "Connector account not found", 404);
           return true;
         }
-        const patch = accountPatchFromBody(parsed.data, existing.metadata);
+        let patch: ConnectorAccountPatch;
+        try {
+          patch = accountPatchFromBody(parsed.data, existing.metadata);
+        } catch (err) {
+          if (!isUnboundedMetadataGraph(err)) throw err;
+          error(res, UNBOUNDED_METADATA_MESSAGE, 400);
+          return true;
+        }
         if (
           requiresOwnerRoleConfirmation(existing, patch.role) &&
           !hasOwnerRoleConfirmation(parsed.data.confirmation)


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #23805 (owning issue, filed for this head, carrying both origin
reproductions verbatim).

Context: #23156 landed the shared bounded connector JSON projection at the
**storage** layer and #22973 pinned its in-memory adapter parity. Neither covers
the two walks fixed here, which run in the **route** — one before storage sees
the body, one after storage has already returned.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      (`3850758df657e222d82d6f63db77ae1d6d0b3938`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` @ `3850758df657e222d82d6f63db77ae1d6d0b3938`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. One production file changes behaviour (`connector-account-routes.ts`); the
second (`blocked-object-keys.ts`) gains an **optional** parameter whose default
is byte-equivalent to today's behaviour, so its existing chat-route and
config-route callers are untouched.

The one axis worth a reviewer's attention is over-rejection, and it is bounded
by arithmetic rather than by judgement: the route bound is depth 32 / 100k
nodes, while `packages/core/src/database/connector-json.ts` already rejects
connector-account metadata at **depth 16 / 2048 nodes** on the storage write.
The new route bound is strictly looser than a bound this metadata must already
survive to be persisted at all, so no value that can round-trip today is newly
rejected. Two compatibility tests pin that directly.

Read-side behaviour change worth naming: `redactAuditMetadata` now also drops
prototype-pollution keys (`__proto__`, `constructor`, `prototype`, `$include`),
because the shared walker drops them. Previously the read path assigned
`redacted["__proto__"] = …` onto an object literal. The write path already
stripped those keys, so nothing this route can store is affected.

# Background

## What does this PR do?

Both connector-account metadata walks in
`packages/agent/src/api/connector-account-routes.ts` recursed once per nesting
level with **no depth cap, no visit budget, no cycle guard, and no enclosing
`try`**:

- **Write** — `cleanMetadata` → `cleanMetadataValue`, reached from
  `POST /api/connectors/:provider/accounts` and the sibling `PATCH`.
- **Read** — `redactAuditMetadata`, run on every `serializeAccount`,
  `serializeFlow`, and `serializeAuditEvent`.

`metadataSchema` is `z.record(z.string(), z.unknown()).optional()`: it validates
the key type only and never constrains the graph shape, so a caller-supplied
body may nest arbitrarily. Depth is cheap — `{"a":{"a":…` costs ~6 bytes per
level, so 1 MB of body buys ~170k levels while V8 exhausts the stack at ~10k.

The resulting throw escaped `handleConnectorAccountRoutes` entirely: neither the
route's `json()` nor its `error()` callback ran, so **no response was ever
written**. Both directions are reproduced against `origin/develop` below.

**The fix reuses the bounded walker this package already exports, rather than
adding a second one.** `packages/agent/src/api/blocked-object-keys.ts` already
provides `cloneWithoutBlockedObjectKeys` with the exact shape this needs — a
depth cap, a node budget charged before allocation, a path-local `WeakSet` cycle
guard that still permits honest DAGs, descriptor-only reflection so no getter or
`Proxy` trap ever executes, and a typed `BLOCKED_OBJECT_GRAPH_UNBOUNDED`
`ElizaError`. `connector-account-routes.ts` already imports `isBlockedObjectKey`
from that same walker (via `server-helpers-config.ts`, which re-exports it).

That walker gains one optional parameter: a per-key policy returning
`"keep" | "drop" | "redact"`, plus the value to substitute when redacting.
Blocked keys are still dropped by the walker itself and the bound is untouched;
omitting the option reproduces today's behaviour exactly. The two connector
rules — drop secret-shaped and client-reserved keys on write; redact
secret-shaped keys on read — then ride on the shared walk instead of a
divergent copy of it.

At the route boundary:

- **Write:** an over-budget body is a caller error, so both `accountPatchFromBody`
  call sites catch the typed failure and answer `400 "Connector account metadata
  exceeds the bounded walk budget"`. (The OAuth-start call site already sat
  inside a `try` that answers 400.)
- **Read:** metadata already at rest must not 500 the read, so
  `redactAuditMetadata` catches the typed failure and serves an explicit
  `"[UNBOUNDED]"` marker — the reader is told the value was withheld rather than
  handed a silent truncation dressed up as success. This mirrors the sentinel
  policy `connector-json.ts` already uses for over-budget audit branches.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/connector-account-routes.metadata-bounds.test.ts`. It
drives the **real** `handleConnectorAccountRoutes` against the **real**
`@elizaos/core` connector-account manager (core is not mocked; the harness is
the one already in `connector-account-routes.durable.test.ts`). Six cases:

1. over-deep `POST` body → `400`, handler returns normally;
2. over-deep `PATCH` body → `400`;
3. `GET /audit/events` on an adapter row with over-deep `metadata` → `200` with
   the explicit marker, instead of an unhandled throw;
4. **compatibility** — realistic nested metadata (nested objects, arrays,
   `null` inside an array, empty object, empty array, `false`, `0`) is returned
   `toEqual` the input on both the write response and the read-back;
5. **compatibility** — secret-shaped and client-reserved keys are still stripped
   on write, at the top level and nested;
6. **compatibility** — secret-shaped keys are still redacted to `[REDACTED]` on
   read.

## Detailed testing steps

```
git checkout fix/bound-connector-account-metadata-walks
bun install --frozen-lockfile
(cd packages/core && node ../shared/scripts/generate-keywords.mjs)
bunx vitest run --root packages/agent \
  src/api/connector-account-routes.metadata-bounds.test.ts \
  src/api/blocked-object-keys.test.ts \
  src/api/connector-account-routes.durable.test.ts \
  src/api/connector-account-routes.test.ts \
  src/api/connector-routes.test.ts \
  src/api/server-helpers.test.ts
bun run --cwd packages/agent typecheck
bunx @biomejs/biome check packages/agent/src/api/blocked-object-keys.ts \
  packages/agent/src/api/blocked-object-keys.test.ts \
  packages/agent/src/api/connector-account-routes.ts \
  packages/agent/src/api/connector-account-routes.metadata-bounds.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:83ef650c5a18b79319b8abee86b509be710aea2f -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend route module and its tests; no rendered UI surface in the diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend route module and its tests; no rendered UI surface in the diff.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.

<!-- evidence-row:backend-logs -->
- [x] The route handler's own throw and response state, captured from the real handler on unmodified `origin/develop` @ `ceb82a4703273ffee12e43ff6cf246f3f4d8bfeb`:

```text
WRITE  POST /api/connectors/google/accounts  body.metadata.root = <60,000-deep object>
THROWN: TypeError: undefined is not a function
    at cleanMetadataValue (packages/agent/src/api/connector-account-routes.ts:340:7)
    at cleanMetadataValue (packages/agent/src/api/connector-account-routes.ts:346:20)
    at cleanMetadataValue (packages/agent/src/api/connector-account-routes.ts:346:20)
CAPTURED: {"status":0,"body":null}

READ   GET /api/connectors/google/audit/events  row.metadata = <60,000-deep object>
THROWN: RangeError: Maximum call stack size exceeded
    at Object.entries (<anonymous>)
    at redactAuditMetadata (packages/agent/src/api/connector-account-routes.ts:366:36)
    at redactAuditMetadata (packages/agent/src/api/connector-account-routes.ts:369:9)
CAPTURED: {"status":0,"wroteBody":false}

status 0 / body null == neither json() nor error() was ever called.
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Origin reproduction, load-bearing revert check, focused suite, typecheck control diff, and lint at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
head: 83ef650c5a18b79319b8abee86b509be710aea2f
rebase base: 3850758df657e222d82d6f63db77ae1d6d0b3938 (origin/develop)
reproduction base: ceb82a4703273ffee12e43ff6cf246f3f4d8bfeb (origin/develop when the
  probe ran; connector-account-routes.ts and blocked-object-keys.ts are
  byte-identical between the two bases -
  `git diff ceb82a47 3850758d -- packages/agent/src/api/connector-account-routes.ts`
  is empty)

=== 1. ORIGIN REPRODUCTION (production files at develop; probe catches the throw) ===

Harness: the real handleConnectorAccountRoutes + the real @elizaos/core
connector-account manager, copied from connector-account-routes.durable.test.ts.
`json`/`error` write into a record initialised to {status: 0, body: null}, so
"status 0 / body null" proves neither responder was ever called.

WRITE - POST /api/connectors/google/accounts
        body { label: "x", metadata: { root: <60,000-deep object> } }

THROWN: TypeError: undefined is not a function
FIRST FRAMES:
    at cleanMetadataValue (packages/agent/src/api/connector-account-routes.ts:340:7)
    at cleanMetadataValue (packages/agent/src/api/connector-account-routes.ts:346:20)
    at cleanMetadataValue (packages/agent/src/api/connector-account-routes.ts:346:20)
CAPTURED: {"status":0,"body":null}

READ  - GET /api/connectors/google/audit/events
        adapter.listConnectorAccountAuditEvents returns one event whose
        metadata is a 60,000-deep object

THROWN: RangeError: Maximum call stack size exceeded
FIRST FRAMES:
    at Object.entries (<anonymous>)
    at redactAuditMetadata (packages/agent/src/api/connector-account-routes.ts:366:36)
    at redactAuditMetadata (packages/agent/src/api/connector-account-routes.ts:369:9)
CAPTURED: {"status":0,"wroteBody":false}

(The error class is engine-dependent - bun/vitest raises TypeError at the frame
boundary, node raises RangeError. Either way it is an unhandled throw out of the
route handler with no response written.)

=== 2. LOAD-BEARING REVERT CHECK (copy-aside, never `git stash`) ===

Production files reverted to develop, both test files kept:

$ bunx vitest run src/api/connector-account-routes.metadata-bounds.test.ts \
                  src/api/blocked-object-keys.test.ts
 Test Files  2 failed (2)
      Tests  4 failed | 16 passed (20)

 FAIL  blocked-object-keys.test.ts > drops or redacts keys per the caller policy while still bounding the walk
 FAIL  connector-account-routes.metadata-bounds.test.ts > rejects an over-deep POST body with a 400 instead of escaping the handler
 FAIL  connector-account-routes.metadata-bounds.test.ts > rejects an over-deep PATCH body with a 400
 FAIL  connector-account-routes.metadata-bounds.test.ts > still serves audit events whose stored row metadata is over-deep, instead of 500ing the read

Fix restored -> green (below). The tests fail for the reported reason, not for a
harness artifact: the two route failures carry the RangeError/TypeError stacks
inside cleanMetadataValue and redactAuditMetadata respectively.

=== 3. FOCUSED SUITE AT THIS HEAD ===

$ bunx vitest run --root packages/agent \
    src/api/connector-account-routes.metadata-bounds.test.ts \
    src/api/blocked-object-keys.test.ts \
    src/api/connector-account-routes.durable.test.ts \
    src/api/connector-account-routes.test.ts \
    src/api/connector-routes.test.ts \
    src/api/server-helpers.test.ts
 Test Files  6 passed (6)
      Tests  61 passed (61)
exit 0

(The last four files are the existing coverage for every caller of the walker I
changed - connector-account routes, connector routes, and server-helpers - so
the default-behaviour claim is executed, not asserted.)

=== 4. TYPECHECK, AGAINST AN UNTOUCHED CONTROL ===

$ bun run --cwd packages/agent typecheck        # branch
  31 `error TS` lines
$ bun run --cwd packages/agent typecheck        # same tree, my 4 files reverted/removed
  31 `error TS` lines
$ diff <(sort branch) <(sort control)
  (no output)

The branch adds ZERO typecheck errors. All 31 are pre-existing unbuilt-plugin
module-resolution failures on develop (@elizaos/plugin-wallet/diagnostic,
@elizaos/cloud-routing, @elizaos/plugin-video, ...) plus pre-existing implicit-any
findings in unrelated test files.

=== 5. LINT ===

$ bunx @biomejs/biome check <the 4 touched files>
Checked 4 files in 58ms. No fixes applied.
exit 0

=== 6. OVER-REJECTION BOUND (why no live value regresses) ===

route bound   (this PR)            : MAX_BLOCKED_OBJECT_DEPTH = 32,   MAX_BLOCKED_OBJECT_NODES = 100_000
storage bound (already on develop) : MAX_CONNECTOR_JSON_DEPTH = 16,   MAX_CONNECTOR_JSON_NODES = 2_048

packages/core/src/database/connector-json.ts throws
ConnectorJsonUnboundedError("depth") on the storage write for anything past 16.
Confirmed by execution: a probe that tried to seed a deep account through
manager.upsertAccount failed there, not in the route. So every metadata graph the
route can newly reject was already unstorable.

=== 7. DIFF SHAPE ===

$ git diff --stat origin/develop...HEAD
 packages/agent/src/api/blocked-object-keys.test.ts |  33 +++
 packages/agent/src/api/blocked-object-keys.ts      |  43 +++-
 ...onnector-account-routes.metadata-bounds.test.ts | 278 +++++++++++++++++++++
 packages/agent/src/api/connector-account-routes.ts |  94 ++++---
 4 files changed, 411 insertions(+), 37 deletions(-)
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed. This is an
HTTP route walk bound.

## Backend + frontend logs

Backend: the origin-reproduction block in the domain receipt above is the real
code path firing - it is the route handler's own throw and its own (absent)
response, captured from the real handler on unmodified `develop`.

Frontend: N/A - no browser hop in this unit.

## Screenshots (before / after) + video walkthrough

N/A - backend route module and its tests; no rendered UI surface in the diff.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

- Root `bun run verify` was **not** run on this head. `verify` is a monorepo-wide
  gate and this machine's tree cannot complete it (the pre-existing unbuilt-plugin
  module-resolution errors listed in section 4 are on `develop` itself), so a
  root-wide run here would report failures that have nothing to do with this diff.
  The package-scoped suite, the typecheck **control diff**, and lint above were all
  executed and are the proof; the control diff is the specific evidence that this
  PR adds no new error.
- Hosted CI check-runs: none on this head. Fork branches on this repository do not
  schedule check-runs; that is repo steady state, not a skipped gate.
- Fork cannot upload `pr-evidence` release assets, so the domain receipt is inline.
- **Scope correction, stated plainly.** The read-side defect was first described to
  me as "stored account metadata makes every subsequent GET 500". I could **not**
  reproduce that through the account manager, because `connector-json.ts` already
  rejects account metadata at depth 16 on the storage write. The read-side instance
  I did reproduce is the audit-events route, whose adapter rows are not re-validated
  by that projection. The read fix is still in this PR because it is the same walk
  over the same shape of data and splitting it would leave half the unit unfixed -
  but the honest claim is "one reproduced read path plus defence in depth", not
  "every account read 500s".
- `redactAuditMetadata` now drops prototype-pollution keys on read as a side effect
  of using the shared walker (see **Risks**). Nothing this route can store carries
  them, since the write path already stripped them.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-connmeta-23805]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JDHDXPVT1VPR2SZSZECP4Q","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T15:02:57.719Z","completed_at":"2026-08-21T15:04:27.884Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T15:02:58.085Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"fa5ca1d0e61f3022aa477b9ef56230b67c74659c862a36c3333981a2fd0124d3","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"96322f72-a4d0-4e85-a0f6-b636d0091a93","object_id":"sha256:fa5ca1d0e61f3022aa477b9ef56230b67c74659c862a36c3333981a2fd0124d3","sha256":"fa5ca1d0e61f3022aa477b9ef56230b67c74659c862a36c3333981a2fd0124d3"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"I0GLmofaAzXHpJqTx4_dDK6REQ-YCOM7QRCVe7J-f2AcmkoL93glUh136c7EE15K83fzEnnBWnMXkc9gK8ldBw"}} -->
