### PR TITLE
fix(agent): keep surrogate pairs intact in the remaining trajectory-internals truncations

### DIFF
--- a/packages/agent/src/runtime/trajectory-internals.surrogate.test.ts
+++ b/packages/agent/src/runtime/trajectory-internals.surrogate.test.ts
@@ -1,95 +1,240 @@
 /**
- * Surrogate-safe truncation for trajectory-internals (100000/500 caps).
- * Verifies clamps never split an astral surrogate pair.
+ * Surrogate-safe truncation for trajectory-internals.
+ *
+ * These tests drive the REAL exported helpers from `trajectory-internals.ts`.
+ * The previous revision of this file re-declared the clamps locally and never
+ * imported the module under test, so every production truncation site in it
+ * could be replaced by a raw `.slice()` while the suite stayed green.
  */
 
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { createHash } from "node:crypto";
+import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
+import { TRAJECTORY_STEP_SCRIPT_MAX_CHARS } from "../types/trajectory.ts";
+import {
+  capScriptForPersistence,
+  extractInsightsFromResponse,
+  flushObservationBuffer,
+  pushChatExchange,
+  truncateField,
+  truncateRecord,
+} from "./trajectory-internals.ts";
 
-const RESPONSE_LIMIT = 100_000;
-const EXCHANGE_LIMIT = 500;
-
-function clampResponse(text: string): string {
-  return truncateWellFormed(toWellFormedUnicode(text), RESPONSE_LIMIT);
-}
-
-function clampExchange(text: string): string {
-  return truncateWellFormed(toWellFormedUnicode(text), EXCHANGE_LIMIT);
-}
+const FOX = "🦊";
+const HIGH = String.fromCharCode(0xd800);
+const LOW = String.fromCharCode(0xdc00);
 
 function isWellFormed(value: string): boolean {
   const maybe = value as unknown as { isWellFormed?: () => boolean };
   if (typeof maybe.isWellFormed === "function") return maybe.isWellFormed();
-  return toWellFormedUnicode(value) === value;
+  return !/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+    value,
+  );
 }
 
-describe("trajectory-internals well-formed", () => {
-  it("100k backs off astral at boundary (99999+fox->99999)", () => {
-    const fox = "🦊";
-    const input = `${"a".repeat(99_999)}${fox}${"b".repeat(20)}`;
-    const out = clampResponse(input);
-    expect(isWellFormed(out)).toBe(true);
-    expect(out.length).toBe(99_999);
-    expect(out).toBe("a".repeat(99_999));
-    expect(() => JSON.stringify(out)).not.toThrow();
-  });
-
-  it("100k preserves fitting astral (99998+fox intact)", () => {
-    const fox = "🦊";
-    const input = `${"a".repeat(99_998)}${fox}`;
-    const out = clampResponse(input);
-    expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe(input);
-    expect(out.length).toBe(100_000);
-  });
-
-  it("500 backs off astral at boundary (499+fox->499)", () => {
-    const fox = "🦊";
-    const input = `${"a".repeat(499)}${fox}${"b".repeat(20)}`;
-    const out = clampExchange(input);
-    expect(isWellFormed(out)).toBe(true);
-    expect(out.length).toBe(499);
-    expect(out).toBe("a".repeat(499));
-  });
-
-  it("500 preserves fitting astral (498+fox intact)", () => {
-    const fox = "🦊";
-    const input = `${"a".repeat(498)}${fox}`;
-    const out = clampExchange(input);
-    expect(isWellFormed(out)).toBe(true);
-    expect(out).toBe(input);
-    expect(out.length).toBe(500);
-  });
-
-  it("sanitizes lone high surrogate", () => {
-    const lone = `hi ${String.fromCharCode(0xd800)} world ${"a".repeat(600)}`;
-    const out = clampExchange(lone);
-    expect(isWellFormed(out)).toBe(true);
-    expect(out.includes("�")).toBe(true);
-    expect(() => JSON.stringify(out)).not.toThrow();
-  });
-
-  it("sanitizes lone low surrogate", () => {
-    const lone = `hi ${String.fromCharCode(0xdc00)} world ${"a".repeat(600)}`;
-    const out = clampResponse(lone);
-    expect(isWellFormed(out)).toBe(true);
-    expect(out.includes("�")).toBe(true);
-  });
-
-  it("short passthrough remains well-formed", () => {
-    expect(clampResponse("short")).toBe("short");
-    expect(clampExchange("short")).toBe("short");
-    expect(isWellFormed(clampResponse("short"))).toBe(true);
-  });
-
-  it("sweep 0..30 at 500 well-formed and JSON-safe", () => {
-    const fox = "🦊";
-    for (let n = 0; n <= 30; n++) {
-      const input = `${"a".repeat(470 + n)}${fox}${"b".repeat(40)}`;
-      const out = clampExchange(input);
+describe("truncateField", () => {
+  it("keeps the head cut well-formed across every astral offset", () => {
+    for (let n = 0; n <= 8; n++) {
+      const input = `${"a".repeat(496 + n)}${FOX}${"b".repeat(3000)}`;
+      const out = truncateField(input, 500);
       expect(isWellFormed(out)).toBe(true);
-      expect(out.length).toBeLessThanOrEqual(500);
       expect(() => JSON.stringify(out)).not.toThrow();
     }
+  });
+
+  it("keeps the tail cut well-formed across every astral offset", () => {
+    for (let n = 0; n <= 8; n++) {
+      const input = `${"a".repeat(3000)}${FOX}${"b".repeat(496 + n)}`;
+      const out = truncateField(input, 500);
+      expect(isWellFormed(out)).toBe(true);
+      expect(() => JSON.stringify(out)).not.toThrow();
+    }
+  });
+
+  it("splits neither end when a pair straddles both boundaries at once", () => {
+    const input = `${"a".repeat(499)}${FOX}${"b".repeat(2000)}${FOX}${"c".repeat(499)}`;
+    const out = truncateField(input, 500);
+    expect(isWellFormed(out)).toBe(true);
+    // Head backs off to 499 "a"; tail backs off to 499 "c".
+    expect(out.startsWith(`${"a".repeat(499)}\n`)).toBe(true);
+    expect(out.endsWith(`\n${"c".repeat(499)}`)).toBe(true);
+  });
+
+  it("reports a truthful removed-character count after a back-off", () => {
+    const input = `${"a".repeat(499)}${FOX}${"b".repeat(2000)}${FOX}${"c".repeat(499)}`;
+    const out = truncateField(input, 500);
+    const removed = Number(/truncated (\d+) chars/.exec(out)?.[1]);
+    const kept = out.length - `\n[...truncated ${removed} chars...]\n`.length;
+    expect(kept + removed).toBe(input.length);
+  });
+
+  it("is byte-identical to a raw head/tail slice for ASCII input", () => {
+    const input = `${"a".repeat(700)}${"b".repeat(700)}`;
+    const legacy = `${input.slice(0, 500)}\n[...truncated ${input.length - 1000} chars...]\n${input.slice(-500)}`;
+    expect(truncateField(input, 500)).toBe(legacy);
+  });
+
+  it("is byte-identical to a raw head/tail slice for BMP input", () => {
+    const input = `${"é".repeat(700)}${"漢".repeat(700)}`;
+    const legacy = `${input.slice(0, 500)}\n[...truncated ${input.length - 1000} chars...]\n${input.slice(-500)}`;
+    expect(truncateField(input, 500)).toBe(legacy);
+  });
+
+  it("returns short input unchanged", () => {
+    expect(truncateField("short", 500)).toBe("short");
+    expect(truncateField(`ok ${FOX}`, 500)).toBe(`ok ${FOX}`);
+  });
+
+  it("preserves an astral pair that fits inside the head budget", () => {
+    const input = `${"a".repeat(498)}${FOX}${"b".repeat(3000)}`;
+    const out = truncateField(input, 500);
+    expect(out.startsWith(`${"a".repeat(498)}${FOX}\n`)).toBe(true);
+  });
+
+  it("repairs a pre-existing lone surrogate instead of persisting it", () => {
+    const input = `hi ${HIGH} there${"a".repeat(2000)}`;
+    const out = truncateField(input, 500);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("�")).toBe(true);
+    expect(isWellFormed(truncateField(`lo ${LOW} there`, 500))).toBe(true);
+  });
+});
+
+describe("truncateRecord", () => {
+  it("emits a well-formed serialized payload at every astral offset", () => {
+    for (let n = 0; n <= 8; n++) {
+      const obj = { k: `${"x".repeat(490 + n)}${FOX}${"y".repeat(3000)}` };
+      const out = truncateRecord(obj, 500) as { _truncated: string };
+      expect(isWellFormed(out._truncated)).toBe(true);
+      expect(() => JSON.parse(JSON.stringify(out))).not.toThrow();
+    }
+  });
+
+  it("returns the original object when it fits", () => {
+    const obj = { k: "small" };
+    expect(truncateRecord(obj, 500)).toBe(obj);
+  });
+});
+
+describe("capScriptForPersistence", () => {
+  it("never stores a lone surrogate at the 4096 cap", () => {
+    for (let n = 0; n <= 8; n++) {
+      const script = `${"a".repeat(TRAJECTORY_STEP_SCRIPT_MAX_CHARS - 4 + n)}${FOX}${"b".repeat(500)}`;
+      const capped = capScriptForPersistence(script);
+      expect(isWellFormed(capped.script)).toBe(true);
+      // steps_json is a raw JSON.stringify of the step list — a split pair
+      // would be written to the row as a \uD8xx escape.
+      expect(JSON.stringify(capped.script)).not.toMatch(
+        /\\ud[89ab][0-9a-f]{2}/i,
+      );
+    }
+  });
+
+  it("stores a genuine prefix of the hashed source", () => {
+    const script = `${"a".repeat(TRAJECTORY_STEP_SCRIPT_MAX_CHARS - 1)}${FOX}${"b".repeat(500)}`;
+    const capped = capScriptForPersistence(script);
+    expect(script.startsWith(capped.script)).toBe(true);
+    expect(capped.scriptHash).toBe(
+      createHash("sha256").update(script, "utf8").digest("hex"),
+    );
+  });
+
+  it("caps ASCII scripts at exactly the documented character budget", () => {
+    const script = "a".repeat(TRAJECTORY_STEP_SCRIPT_MAX_CHARS + 100);
+    const capped = capScriptForPersistence(script);
+    expect(capped.script).toBe(
+      script.slice(0, TRAJECTORY_STEP_SCRIPT_MAX_CHARS),
+    );
+    expect(capped.script.length).toBe(TRAJECTORY_STEP_SCRIPT_MAX_CHARS);
+  });
+
+  it("passes a script under the cap through untouched and unhashed", () => {
+    const script = `console.log("${FOX}")`;
+    const capped = capScriptForPersistence(script);
+    expect(capped.script).toBe(script);
+    expect(capped.scriptHash).toBeUndefined();
+  });
+});
+
+describe("extractInsightsFromResponse", () => {
+  it("does not split an astral pair at the 100k response clamp", () => {
+    // Lay a DECISION line so the 100_000 clamp lands between the two halves
+    // of FOX: a raw slice yields an insight ending in a lone high surrogate.
+    let response = `${"a".repeat(99_000)}\nDECISION: `;
+    response += "b".repeat(99_999 - response.length);
+    response += `${FOX}\n`;
+    const insights = extractInsightsFromResponse(response, "turn-complete");
+    expect(insights).toHaveLength(1);
+    for (const insight of insights) {
+      expect(isWellFormed(insight)).toBe(true);
+      expect(() => JSON.stringify(insight)).not.toThrow();
+    }
+  });
+
+  it("returns ASCII decisions unchanged", () => {
+    expect(
+      extractInsightsFromResponse("DECISION: ship it\n", "coordination"),
+    ).toEqual(["ship it"]);
+  });
+});
+
+describe("flushObservationBuffer", () => {
+  function stubRuntime(
+    modelOutput: string,
+    seenPrompts: string[] = [],
+  ): IAgentRuntime {
+    return {
+      agentId: "00000000-0000-0000-0000-000000000001",
+      adapter: { db: { execute: async () => ({ rows: [] }) } },
+      useModel: async (_type: unknown, params: { prompt: string }) => {
+        seenPrompts.push(params.prompt);
+        return modelOutput;
+      },
+    } as unknown as IAgentRuntime;
+  }
+
+  it("clamps buffered exchanges into a well-formed extraction prompt", async () => {
+    const seenPrompts: string[] = [];
+    const runtime = stubRuntime(JSON.stringify(["ok"]), seenPrompts);
+    pushChatExchange(runtime, {
+      userPrompt: `${"u".repeat(499)}${FOX}${"v".repeat(200)}`,
+      response: `${"r".repeat(499)}${FOX}${"s".repeat(200)}`,
+      trajectoryId: "00000000-0000-0000-0000-0000000000cc",
+      timestamp: Date.now(),
+    });
+    await flushObservationBuffer(runtime);
+    expect(seenPrompts).toHaveLength(1);
+    expect(isWellFormed(seenPrompts[0] as string)).toBe(true);
+    expect(() => JSON.stringify(seenPrompts[0])).not.toThrow();
+  });
+
+  it("clamps model-authored observations without splitting an astral pair", async () => {
+    const observation = `${"o".repeat(149)}${FOX}${"p".repeat(200)}`;
+    const runtime = stubRuntime(JSON.stringify([observation]));
+    pushChatExchange(runtime, {
+      userPrompt: `ask ${FOX}`,
+      response: `reply ${FOX}`,
+      trajectoryId: "00000000-0000-0000-0000-0000000000aa",
+      timestamp: Date.now(),
+    });
+    const observations = await flushObservationBuffer(runtime);
+    expect(observations).toHaveLength(1);
+    const only = observations[0] as string;
+    expect(isWellFormed(only)).toBe(true);
+    expect(only.length).toBeLessThanOrEqual(150);
+    expect(() => JSON.stringify(only)).not.toThrow();
+  });
+
+  it("leaves ASCII observations clamped exactly as before", async () => {
+    const observation = "o".repeat(300);
+    const runtime = stubRuntime(JSON.stringify([observation]));
+    pushChatExchange(runtime, {
+      userPrompt: "ask",
+      response: "reply",
+      trajectoryId: "00000000-0000-0000-0000-0000000000bb",
+      timestamp: Date.now(),
+    });
+    const observations = await flushObservationBuffer(runtime);
+    expect(observations).toEqual([observation.slice(0, 150)]);
   });
 });

--- a/packages/agent/src/runtime/trajectory-internals.ts
+++ b/packages/agent/src/runtime/trajectory-internals.ts
@@ -26,6 +26,7 @@ import {
   resolveStateDir,
   resolveTrajectoryGate,
   sanitizeTrajectoryJsonObject,
+  tailWellFormed,
   toWellFormedUnicode,
   truncateWellFormed,
 } from "@elizaos/core";
@@ -439,13 +440,30 @@ export function normalizeTrajectoryMetadata(
 
 const DEFAULT_TRUNCATE_LIMIT = 500;
 
+/**
+ * Head+tail preview of an over-long field. BOTH cuts land at an arbitrary
+ * UTF-16 index, so both must back off a surrogate pair: `truncateWellFormed`
+ * guards the head and `tailWellFormed` guards the tail. A raw `.slice()` here
+ * split an astral character in half and persisted a lone surrogate into the
+ * trajectory row (#23688 fixed the two clamps in this module that had callers
+ * at the time; these helpers were left raw).
+ *
+ * `removed` is derived from the retained halves rather than from `limit * 2`
+ * so the reported count stays truthful when a boundary backs off by one code
+ * unit. ASCII and BMP input is unaffected: neither guard moves a boundary that
+ * does not split a pair, so the output is byte-identical to the previous
+ * implementation.
+ */
 export function truncateField(
   value: string,
   limit = DEFAULT_TRUNCATE_LIMIT,
 ): string {
-  if (value.length <= limit * 2) return value;
-  const removed = value.length - limit * 2;
-  return `${value.slice(0, limit)}\n[...truncated ${removed} chars...]\n${value.slice(-limit)}`;
+  const wellFormed = toWellFormedUnicode(value);
+  if (wellFormed.length <= limit * 2) return wellFormed;
+  const head = truncateWellFormed(wellFormed, limit);
+  const tail = tailWellFormed(wellFormed, limit);
+  const removed = wellFormed.length - head.length - tail.length;
+  return `${head}\n[...truncated ${removed} chars...]\n${tail}`;
 }
 
 export function truncateRecord(
@@ -466,6 +484,16 @@ export function truncateRecord(
  * source exceeds `TRAJECTORY_STEP_SCRIPT_MAX_CHARS`, returns a truncated
  * prefix together with the sha256 hex digest of the full source so callers
  * can store the digest alongside.
+ *
+ * The prefix is cut with `truncateWellFormed`, not a raw `.slice()`: this
+ * value is the ONLY step field that bypasses `sanitizeTrajectoryJsonObject`
+ * (`normalizeStepForPersistence` destructures `script` out of the sanitized
+ * scalars), so a split surrogate pair is written straight into the
+ * `steps_json` blob as a `\uD8xx` escape instead of being repaired downstream.
+ *
+ * Pre-existing lone surrogates in `script` are deliberately preserved rather
+ * than replaced: `scriptHash` is the digest of the raw full source, and the
+ * stored value must stay a genuine prefix of the bytes that were hashed.
  */
 export function capScriptForPersistence(script: string): {
   script: string;
@@ -476,7 +504,7 @@ export function capScriptForPersistence(script: string): {
   }
   const scriptHash = createHash("sha256").update(script, "utf8").digest("hex");
   return {
-    script: script.slice(0, TRAJECTORY_STEP_SCRIPT_MAX_CHARS),
+    script: truncateWellFormed(script, TRAJECTORY_STEP_SCRIPT_MAX_CHARS),
     scriptHash,
   };
 }
@@ -661,7 +689,12 @@ export async function flushObservationBuffer(
 
     const observations = parsed
       .filter((s: unknown) => typeof s === "string" && s.length > 0)
-      .map((s: string) => s.slice(0, 150)) as string[];
+      // Model-authored observation text is persisted into trajectory
+      // metadata; the 150-char clamp must not split an astral pair (same
+      // guard as the exchange clamp above).
+      .map((s: string) =>
+        truncateWellFormed(toWellFormedUnicode(s), 150),
+      ) as string[];
 
     if (observations.length === 0) return [];
 


### PR DESCRIPTION
# Relates to

Closes #23810.

Successor to merged #23688 (byt61), which fixed two clamps in this exact file
and shipped `trajectory-internals.surrogate.test.ts` next to them. That test
file never imports the module under test, so the three raw `.slice()`
truncations #23688 did not reach were left unpinned and still broken. This PR
is the remainder that fix missed.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker. — see **Known gaps /
      failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts. Branched
      off `ceb82a4703273ffee12e43ff6cf246f3f4d8bfeb`, then rebased onto
      `96d373a4388e5b9b149a0f509f43627244925c7d` (head at push time). The focused
      suite and biome were re-run after the rebase and re-recorded at
      `11320c128543de5566bf50670c4457bc76d8eb79`.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below. — documented there.

# Risks

**Low.** Two functions and one `.map()` callback in a single file. No signature,
no return shape, and no schema changes. The only observable difference is that a
truncation boundary that would have landed between the two halves of a surrogate
pair now backs off by one code unit.

Compatibility is asserted directly rather than argued — ASCII and BMP text
truncates **byte-identically** to the previous implementation:

```ts
it("is byte-identical to a raw head/tail slice for ASCII input", () => {
  const input = `${"a".repeat(700)}${"b".repeat(700)}`;
  const legacy = `${input.slice(0, 500)}\n[...truncated ${input.length - 1000} chars...]\n${input.slice(-500)}`;
  expect(truncateField(input, 500)).toBe(legacy);
});

it("is byte-identical to a raw head/tail slice for BMP input", () => {
  const input = `${"é".repeat(700)}${"漢".repeat(700)}`;   // same assertion
});

it("caps ASCII scripts at exactly the documented character budget", () => {
  const script = "a".repeat(TRAJECTORY_STEP_SCRIPT_MAX_CHARS + 100);
  expect(capScriptForPersistence(script).script)
    .toBe(script.slice(0, TRAJECTORY_STEP_SCRIPT_MAX_CHARS));
});

it("leaves ASCII observations clamped exactly as before", async () => {
  expect(observations).toEqual([observation.slice(0, 150)]);
});
```

Nothing is rejected that the live path accepts today: `truncateWellFormed`,
`tailWellFormed`, and `toWellFormedUnicode` are total functions with no error
path. There is no new failure mode and no new typed error.

# Background

## What does this PR do?

Routes the three remaining raw `.slice()` truncations in
`packages/agent/src/runtime/trajectory-internals.ts` through the in-repo
well-formed helpers, and rewrites the module's surrogate test file so it drives
the real exports instead of local copies.

| Line | Before | Path it corrupts |
| --- | --- | --- |
| `:448` `truncateField` | `` `${value.slice(0, limit)}…${value.slice(-limit)}` `` — raw slice at **both** ends | `truncateRecord` (`:457`) funnels `JSON.stringify(obj)` through it; both are re-exported from `trajectory-persistence.ts` as the module's public helper surface |
| `:479` `capScriptForPersistence` | `script.slice(0, TRAJECTORY_STEP_SCRIPT_MAX_CHARS)` | called at `:3697` to build `legacySteps` → `JSON.stringify(legacySteps)` → the `steps_json` column |
| `:664` `flushObservationBuffer` | `.map((s: string) => s.slice(0, 150))` | model-authored observation strings persisted into `trajectory.metadata.observations` |

`:479` is the load-bearing one. `script` is the **only** step field that
`normalizeStepForPersistence` destructures *out* of the sanitizing path:

```ts
// trajectory-internals.ts:3562-3639
const { llmCalls, providerAccesses, childSteps, usedSkills, skillInvocations,
        semanticStages, script, ...scalarFields } = step;
const boundedScalars = sanitizeTrajectoryJsonObject(scalarFields);
...
...(script !== undefined ? { script } : {}),   // never sanitized
```

Every other persisted field passes through `sanitizeTrajectoryJsonObject`, whose
`truncateTrajectoryString` applies `toWellFormedUnicode`. `script` does not — so
a pair split at 4096 is serialized into the row as a `\uD8xx` escape with nothing
downstream to repair it. `well-formed.ts`'s own module docstring names that
escape as the thing strict provider JSON parsers reject with HTTP 400.

`:664` is 36 lines below the exchange clamp #23688 *did* fix, inside the same
function.

The fix reuses the helpers the repo already standardised on
(`truncateWellFormed`, `tailWellFormed`, `toWellFormedUnicode` from
`packages/core/src/utils/well-formed.ts`) — no new truncator is introduced.
`tailWellFormed` is the existing tail-side dual already used by
`planner-rendering.ts`, `planner-loop.ts`, `optimized-prompt-resolver.ts`, and
`action-results.ts`.

Two deliberate details:

1. `truncateField` now derives `removed` from the retained halves
   (`wellFormed.length - head.length - tail.length`) instead of `limit * 2`, so
   the reported count stays truthful after a back-off. For ASCII this is the
   same number as before.
2. `capScriptForPersistence` uses `truncateWellFormed` **without**
   `toWellFormedUnicode`. `scriptHash` is the digest of the raw full source, so
   the stored value must remain a genuine prefix of the bytes that were hashed;
   sanitizing pre-existing lone surrogates there would break that invariant.
   A test pins it: `expect(script.startsWith(capped.script)).toBe(true)`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The two
affected function docstrings were updated in-place to state why each guard is
there.

# Testing

## Where should a reviewer start?

`packages/agent/src/runtime/trajectory-internals.surrogate.test.ts`. It now
imports `truncateField`, `truncateRecord`, `capScriptForPersistence`,
`extractInsightsFromResponse`, `flushObservationBuffer`, and `pushChatExchange`
from `./trajectory-internals.ts` and drives the real production path — including
`flushObservationBuffer` end to end against a stub runtime, so the `:664` clamp
is exercised through the actual function rather than a re-declaration.

## Detailed testing steps

### 1. Reproduction on unmodified `origin/develop` (`ceb82a4703273ffee12e43ff6cf246f3f4d8bfeb`)

`packages/agent/src/runtime/zz-origin-probe.test.ts` (scratch file, not
committed):

```ts
import { createHash } from "node:crypto";
import { capScriptForPersistence, truncateField, truncateRecord } from "./trajectory-internals.ts";
const wf = (s: string) => (s as unknown as { isWellFormed(): boolean }).isWellFormed();

it("truncateField head and tail keep surrogate pairs intact", () => {
  const input = `${"a".repeat(499)}🦊${"b".repeat(2000)}🦊${"c".repeat(499)}`;
  expect(wf(truncateField(input, 500))).toBe(true);
});
it("capScriptForPersistence keeps the stored script well-formed", () => {
  expect(wf(capScriptForPersistence(`${"a".repeat(4095)}🦊${"b".repeat(500)}`).script)).toBe(true);
});
```

```
$ cd packages/agent && ../../node_modules/.bin/vitest run src/runtime/zz-origin-probe.test.ts

 FAIL  src/runtime/zz-origin-probe.test.ts > origin reproduction > truncateField head and tail keep surrogate pairs intact
 AssertionError: expected false to be true // Object.is equality
 ❯ src/runtime/zz-origin-probe.test.ts:17:21

 FAIL  src/runtime/zz-origin-probe.test.ts > origin reproduction > capScriptForPersistence keeps the stored script well-formed
 AssertionError: expected false to be true // Object.is equality
 ❯ src/runtime/zz-origin-probe.test.ts:29:28

 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

### 2. Why a green suite means nothing here (executed, not asserted)

The merged `trajectory-internals.surrogate.test.ts` imports only
`toWellFormedUnicode` / `truncateWellFormed` from `@elizaos/core` and
re-declares `clampResponse` / `clampExchange` locally. It never references
`trajectory-internals.ts`.

I mutated **both** guards #23688 itself added — `truncateWellFormed(toWellFormedUnicode(response), 100_000)`
→ `response.slice(0, 100_000)`, and the exchange clamp → `e.userPrompt.slice(0, 500)` /
`e.response.slice(0, 500)` — and ran the merged test file unchanged:

```
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

**0 of 2 mutations killed.** The production lines that file claims to cover are
100 % deletable while it stays green. That is why these three sites survived.

Re-running the **same two mutations** against the test file in this PR:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  … > extractInsightsFromResponse > does not split an astral pair at the 100k response clamp
 FAIL  … > flushObservationBuffer > clamps buffered exchanges into a well-formed extraction prompt
 Test Files  1 failed (1)
      Tests  2 failed | 18 passed (20)
```

**2 of 2 killed.** The rewritten file also pins #23688's own guards, which were
previously unpinned.

### 3. Load-bearing check for THIS fix (copy-aside revert, not `git stash`)

Production file reverted to `origin/develop`, new test file kept:

```
$ git checkout -- packages/agent/src/runtime/trajectory-internals.ts
$ cd packages/agent && ../../node_modules/.bin/vitest run src/runtime/trajectory-internals.surrogate.test.ts

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 7 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  … > truncateField > keeps the head cut well-formed across every astral offset
 FAIL  … > truncateField > keeps the tail cut well-formed across every astral offset
 FAIL  … > truncateField > splits neither end when a pair straddles both boundaries at once
 FAIL  … > truncateField > repairs a pre-existing lone surrogate instead of persisting it
 FAIL  … > truncateRecord > emits a well-formed serialized payload at every astral offset
 FAIL  … > capScriptForPersistence > never stores a lone surrogate at the 4096 cap
 FAIL  … > flushObservationBuffer > clamps model-authored observations without splitting an astral pair

 Test Files  1 failed (1)
      Tests  7 failed | 13 passed (20)
```

Fix restored:

```
$ cd packages/agent && ../../node_modules/.bin/vitest run src/runtime/trajectory-internals.surrogate.test.ts

 Test Files  1 passed (1)
      Tests  20 passed (20)
   Duration  9.54s
```

Every one of the three production sites has at least one test that fails without
it.

### 4. Package-scoped suite

```
$ cd packages/agent && ../../node_modules/.bin/vitest run src/runtime/ --reporter=dot

 Test Files  3 failed | 103 passed (106)
      Tests  3 failed | 1059 passed (1062)
   Duration  403.20s
```

The 3 failures are pre-existing and unrelated — verified by re-running those
exact files with **both of my files reverted to `origin/develop`**:

```
$ git checkout -- packages/agent/src/runtime/trajectory-internals.ts packages/agent/src/runtime/trajectory-internals.surrogate.test.ts
$ cd packages/agent && ../../node_modules/.bin/vitest run src/runtime/mobile-dns.test.ts \
    src/runtime/plugin-resolver-staging-cache.test.ts src/runtime/plugin-resolver.test.ts --reporter=dot

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/runtime/mobile-dns.test.ts > mobile DNS fetch decode budget > forwards malformed compressed-body failures to the consumer
 FAIL  src/runtime/plugin-resolver-staging-cache.test.ts > content-keyed staging cache > two real processes racing to stage the same plugin converge on one dir
 FAIL  src/runtime/plugin-resolver.test.ts > resolvePlugins manifest discovery > loads a host-manifest readiness plugin in blocking only
 Test Files  3 failed (3)
      Tests  3 failed | 22 passed (25)
```

Identical set, identical names, on the untouched control.

### 5. Typecheck against an untouched control

```
$ bun run --cwd packages/agent typecheck   # branch
793 × "error TS"

$ git checkout -- <both files> && bun run --cwd packages/agent typecheck   # control
793 × "error TS"

$ diff <(sort tc-control.txt) <(sort tc-branch.txt) && echo IDENTICAL
IDENTICAL
```

**Zero typecheck errors added**, and zero of the 793 mention either touched
file (`grep -c trajectory-internals` → `0`). The 793 are all
`TS2307: Cannot find module 'drizzle-orm' / '@aws-sdk/*' / 'redis' / …` from
optional deps absent in this checkout — they reproduce byte-for-byte on the
control.

### 6. Lint

```
$ ./node_modules/.bin/biome check packages/agent/src/runtime/trajectory-internals.ts \
    packages/agent/src/runtime/trajectory-internals.surrogate.test.ts
Checked 2 files in 784ms. No fixes applied.
```

# Evidence Gate

<!-- evidence-head:11320c128543de5566bf50670c4457bc76d8eb79 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no rendered UI surface; the diff is two functions and one .map() callback in packages/agent/src/runtime/trajectory-internals.ts plus its test file.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no rendered UI surface; see above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; the observable behaviour is a truncation boundary, demonstrated by the executed test output in Testing §3.`
<!-- evidence-row:backend-logs -->
- [x] The real code path firing end to end, captured from
      `vitest run src/runtime/trajectory-internals.surrogate.test.ts --reporter=verbose`
      at `11320c128543de5566bf50670c4457bc76d8eb79`. `flushObservationBuffer` is
      driven as the exported function against a stub runtime, so the `:664`
      clamp and the extraction prompt handed to `runtime.useModel` are both
      exercised through the production path:

  ```
   ✓ trajectory-internals.surrogate.test.ts > truncateField > keeps the head cut well-formed across every astral offset 2ms
   ✓ trajectory-internals.surrogate.test.ts > truncateField > keeps the tail cut well-formed across every astral offset 0ms
   ✓ trajectory-internals.surrogate.test.ts > truncateField > splits neither end when a pair straddles both boundaries at once 0ms
   ✓ trajectory-internals.surrogate.test.ts > truncateField > reports a truthful removed-character count after a back-off 0ms
   ✓ trajectory-internals.surrogate.test.ts > truncateField > is byte-identical to a raw head/tail slice for ASCII input 0ms
   ✓ trajectory-internals.surrogate.test.ts > truncateField > is byte-identical to a raw head/tail slice for BMP input 0ms
   ✓ trajectory-internals.surrogate.test.ts > truncateField > returns short input unchanged 0ms
   ✓ trajectory-internals.surrogate.test.ts > truncateField > preserves an astral pair that fits inside the head budget 0ms
   ✓ trajectory-internals.surrogate.test.ts > truncateField > repairs a pre-existing lone surrogate instead of persisting it 0ms
   ✓ trajectory-internals.surrogate.test.ts > truncateRecord > emits a well-formed serialized payload at every astral offset 1ms
   ✓ trajectory-internals.surrogate.test.ts > truncateRecord > returns the original object when it fits 0ms
   ✓ trajectory-internals.surrogate.test.ts > capScriptForPersistence > never stores a lone surrogate at the 4096 cap 1ms
   ✓ trajectory-internals.surrogate.test.ts > capScriptForPersistence > stores a genuine prefix of the hashed source 0ms
   ✓ trajectory-internals.surrogate.test.ts > capScriptForPersistence > caps ASCII scripts at exactly the documented character budget 0ms
   ✓ trajectory-internals.surrogate.test.ts > capScriptForPersistence > passes a script under the cap through untouched and unhashed 0ms
   ✓ trajectory-internals.surrogate.test.ts > extractInsightsFromResponse > does not split an astral pair at the 100k response clamp 1ms
   ✓ trajectory-internals.surrogate.test.ts > extractInsightsFromResponse > returns ASCII decisions unchanged 0ms
   ✓ trajectory-internals.surrogate.test.ts > flushObservationBuffer > clamps buffered exchanges into a well-formed extraction prompt 3ms
   ✓ trajectory-internals.surrogate.test.ts > flushObservationBuffer > clamps model-authored observations without splitting an astral pair 0ms
   ✓ trajectory-internals.surrogate.test.ts > flushObservationBuffer > leaves ASCII observations clamped exactly as before 0ms
   Test Files  1 passed (1)
        Tests  20 passed (20)
  ```
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response or state change is involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no prompt, model, provider or action selection is changed. The clamp under test is applied to model output AFTER the call returns; a live-model run would add no information the deterministic reproduction in Testing §1 and §3 does not already carry, and elizaOS/eliza CI does not run on fork PRs from contributors without write access, so a scenario-runner report could not be reproduced by the reviewer from this PR.`
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact is the persisted row content itself. A driver script
      (`bun run domain-artifact.ts`, not committed) builds the exact
      `JSON.stringify(legacySteps)` payload that `saveTrajectory` writes into
      the `steps_json` column, for
      `script = "a".repeat(4095) + "\u{1F98A}" + "b".repeat(500)`, and runs it
      first against `origin/develop` and then against this branch:

  ```
  # BEFORE — origin/develop (script.slice(0, TRAJECTORY_STEP_SCRIPT_MAX_CHARS))
  script length (chars): 4096
  scriptHash: 589d647a24a75e724949db49757e4124f4e981320e04b02d8a918f6ebc346554
  stored prefix is a genuine prefix of the hashed source: true
  steps_json contains a lone-surrogate escape: true
  steps_json round-trips through JSON.parse well-formed: false
  truncateField preview well-formed: false
  truncateField marker: [...truncated 2002 chars...]

  # AFTER — this branch (truncateWellFormed / tailWellFormed)
  script length (chars): 4095
  scriptHash: 589d647a24a75e724949db49757e4124f4e981320e04b02d8a918f6ebc346554
  stored prefix is a genuine prefix of the hashed source: true
  steps_json contains a lone-surrogate escape: false
  steps_json round-trips through JSON.parse well-formed: true
  truncateField preview well-formed: true
  truncateField marker: [...truncated 2004 chars...]
  ```

  The `scriptHash` is unchanged (it is the digest of the full source, as
  documented), the stored value is still a genuine prefix of the hashed bytes,
  and the `\uD8xx` escape that `origin/develop` writes into the row is gone.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface in this diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - see the llm-trajectory row above.` No prompt, model, provider, or action
selection changes in this diff.

## Backend + frontend logs

Frontend: `N/A - no frontend surface.`

Backend: the exported `flushObservationBuffer` path, driven end to end.

<details>
<summary>The two <code>flushObservationBuffer</code> tests and their assertions</summary>

```ts
function stubRuntime(modelOutput: string, seenPrompts: string[] = []): IAgentRuntime {
  return {
    agentId: "00000000-0000-0000-0000-000000000001",
    adapter: { db: { execute: async () => ({ rows: [] }) } },
    useModel: async (_type: unknown, params: { prompt: string }) => {
      seenPrompts.push(params.prompt);
      return modelOutput;
    },
  } as unknown as IAgentRuntime;
}

it("clamps model-authored observations without splitting an astral pair", async () => {
  const observation = `${"o".repeat(149)}🦊${"p".repeat(200)}`;
  const runtime = stubRuntime(JSON.stringify([observation]));
  pushChatExchange(runtime, { userPrompt: "ask 🦊", response: "reply 🦊",
    trajectoryId: "…aa", timestamp: Date.now() });
  const observations = await flushObservationBuffer(runtime);
  expect(isWellFormed(observations[0] as string)).toBe(true);   // FAILS on origin
  expect((observations[0] as string).length).toBeLessThanOrEqual(150);
});
```

Run against `origin/develop`'s production file:

```
 FAIL  … > flushObservationBuffer > clamps model-authored observations without splitting an astral pair
 AssertionError: expected false to be true // Object.is equality
 ❯ src/runtime/trajectory-internals.surrogate.test.ts:191:32
```

Run against this branch: passes, together with the ASCII-parity assertion
`expect(observations).toEqual([observation.slice(0, 150)])`.

</details>

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no rendered UI surface in this diff.`

### After

`N/A - no rendered UI surface in this diff.`

### Walkthrough video

`N/A - no user-facing flow; the behaviour change is a truncation boundary, shown by the executed test output above.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT, or omnivoice surface in this diff.`

## Known gaps / failures

1. **`bun run verify` was not run.** It builds and tests the whole monorepo and
   is not runnable in this checkout: `bun run --cwd packages/agent typecheck`
   already reports 793 pre-existing `TS2307: Cannot find module` errors for
   optional dependencies (`drizzle-orm`, `@aws-sdk/client-s3`, `redis`,
   `@upstash/redis`, `decimal.js`, `@noble/hashes`) that are absent here. Those
   793 reproduce **identically** on the untouched control, so they are an
   environment property, not a regression — the executed diff is in
   **Testing §5**. What was run instead: the focused suite for the touched
   module (20/20), the whole `packages/agent/src/runtime` suite (1059 passed,
   3 pre-existing failures proven on the control), the package typecheck against
   a control, and biome on both touched files.

2. **3 pre-existing failures in `packages/agent/src/runtime`** —
   `mobile-dns.test.ts`, `plugin-resolver-staging-cache.test.ts`,
   `plugin-resolver.test.ts`. Reproduced with both of my files reverted; see
   **Testing §4** for the executed control run. Unrelated to this diff.

3. **No hosted CI checks on this PR.** I contribute from a fork without write
   access to `elizaOS/eliza`, so upstream workflows do not run and
   `requested_reviewers` is unavailable. Every result above is from a local run
   whose exact command and output are quoted.

4. **`capScriptForPersistence` does not change the `scriptHash` contract.**
   The digest remains the sha256 of the **full** source, per the function's
   existing docstring, and is therefore not re-derivable from the truncated
   stored prefix. That is deliberate and unchanged: `scriptHash` is what
   identifies the original, and the canonical `trajectory_steps.script` column
   stores the uncapped source. This PR only guarantees that the stored legacy
   prefix is a *well-formed* prefix of the hashed bytes. Flagging it explicitly
   so a reviewer does not read the untouched line as an oversight.

5. **`truncateField` / `truncateRecord` have no in-repo caller today.** They are
   exported from `trajectory-internals.ts` and re-exported from
   `trajectory-persistence.ts` under the header
   *"Internal helpers (exported for testing / advanced consumers)"*. The live
   in-repo paths in this PR are `capScriptForPersistence` (`:3697` → `steps_json`)
   and `flushObservationBuffer` (`:664` → `metadata.observations`). Stated
   plainly rather than implied.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-mine-traj-int]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JC0MHQS05BAYN7FA2B885R","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T14:36:18.871Z","completed_at":"2026-08-21T15:11:42.496Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T14:36:20.110Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"45fd6a03dbca978fa60a1ca3a3fc466371a7c66311dcf88dbae533adec5fa115","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"a1e607c5-acc8-498d-a7f0-4f00376d3f54","object_id":"sha256:45fd6a03dbca978fa60a1ca3a3fc466371a7c66311dcf88dbae533adec5fa115","sha256":"45fd6a03dbca978fa60a1ca3a3fc466371a7c66311dcf88dbae533adec5fa115"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"K3s6weV2QrqUEj4IaINB-Cf00NKELk4GlsdDzsF0t0U87izUwC1xuiWSF3ojTDnGlYXOAZyDDPfHMr9IQ2dJDQ"}} -->
