### PR TITLE
fix(shared): bound the agent-backup canonical JSON walk

### DIFF
--- a/packages/agent/src/services/agent-backup.canonicalize-bound.test.ts
+++ b/packages/agent/src/services/agent-backup.canonicalize-bound.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Fail-closed canonical walk for the agent-backup integrity gate.
+ *
+ * `assertManifest` canonicalizes `manifest.integrity.componentHashes` — file
+ * content read straight out of a stored backup — and
+ * `decryptLocalBackupEnvelope` canonicalizes the decrypted snapshot BEFORE
+ * `assertManifest` has validated its shape. On origin develop the sorted-key
+ * recursion behind `stableJson` carried no depth counter, no node budget and no
+ * cycle guard, so a deep or cyclic payload `RangeError`ed the very check whose
+ * job is to reject a malformed backup: the restore had no reachable error path.
+ * It now fails closed with a typed `ElizaError`, and honest manifests keep the
+ * hashes they already had.
+ */
+import { ElizaError } from "@elizaos/core";
+import { CANONICAL_JSON_UNBOUNDED } from "@elizaos/shared/canonical-json";
+import { describe, expect, it } from "vitest";
+import { restoreAgentSnapshot } from "./agent-backup.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+const COMPONENT = { sha256: "0".repeat(64), size: 0 };
+
+function snapshotWith(componentHashes: unknown): unknown {
+  return {
+    memories: [],
+    config: {},
+    workspaceFiles: {},
+    manifest: {
+      format: "elizaos.agent-backup",
+      schemaVersion: 1,
+      agentId: AGENT_ID,
+      components: {
+        database: { ...COMPONENT, kind: "pglite-files" },
+        media: COMPONENT,
+        vault: COMPONENT,
+        character: COMPONENT,
+        stateFiles: COMPONENT,
+      },
+      integrity: { componentHashes },
+    },
+  };
+}
+
+function deepChain(levels: number): unknown {
+  let node: Record<string, unknown> = {};
+  const root = node;
+  for (let i = 0; i < levels; i += 1) {
+    const next: Record<string, unknown> = {};
+    node.next = next;
+    node = next;
+  }
+  return root;
+}
+
+const runtime = { agentId: AGENT_ID } as never;
+
+async function expectUnbounded(componentHashes: unknown): Promise<void> {
+  let caught: unknown;
+  let threw = false;
+  try {
+    await restoreAgentSnapshot(runtime, snapshotWith(componentHashes) as never);
+  } catch (error) {
+    threw = true;
+    caught = error;
+  }
+  expect(threw).toBe(true);
+  expect(caught).toBeInstanceOf(ElizaError);
+  expect(caught).not.toBeInstanceOf(RangeError);
+  expect((caught as ElizaError).code).toBe(CANONICAL_JSON_UNBOUNDED);
+}
+
+describe("agent backup manifest hashing is bounded", () => {
+  it("fails closed on a 60k-deep componentHashes instead of RangeError", async () => {
+    await expectUnbounded(deepChain(60_000));
+  });
+
+  it("fails closed on a cyclic componentHashes instead of RangeError", async () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    await expectUnbounded(cyclic);
+  });
+
+  it("still rejects an honest-but-inconsistent manifest the way it always did", async () => {
+    // The bound must not change what a well-formed backup does: this is the
+    // ordinary hash-index mismatch, not a walk-budget failure.
+    await expect(
+      restoreAgentSnapshot(runtime, snapshotWith({ database: "x" }) as never),
+    ).rejects.toThrow("Backup manifest component hash index is inconsistent");
+  });
+
+  it("accepts a consistent component hash index, so honest bytes are unchanged", async () => {
+    const consistent = {
+      database: COMPONENT.sha256,
+      media: COMPONENT.sha256,
+      vault: COMPONENT.sha256,
+      character: COMPONENT.sha256,
+      stateFiles: COMPONENT.sha256,
+    };
+    // Past the manifest gate the restore fails on infrastructure, never on the
+    // canonical walk — that is the point: the integrity check now returns a
+    // verdict instead of overflowing.
+    await expect(
+      restoreAgentSnapshot(runtime, snapshotWith(consistent) as never),
+    ).rejects.not.toThrow(
+      "Backup manifest component hash index is inconsistent",
+    );
+  });
+});

--- a/packages/agent/src/services/agent-backup.ts
+++ b/packages/agent/src/services/agent-backup.ts
@@ -17,6 +17,10 @@ import type { AgentRuntime, IAgentRuntime } from "@elizaos/core";
 import { ElizaError, logger } from "@elizaos/core";
 import { createKmsClient, systemKey } from "@elizaos/core/security/kms";
 import { MAX_RESTORABLE_AGENT_BACKUP_BYTES } from "@elizaos/shared/agent-backup-limits";
+import {
+  AGENT_BACKUP_CANONICAL_JSON,
+  stableJsonString,
+} from "@elizaos/shared/canonical-json";
 import type { ElizaConfig } from "../config/config.ts";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.ts";
 import {
@@ -366,20 +370,22 @@ function getLocalBackupKmsClient(): ReturnType<typeof createKmsClient> {
   return localBackupKmsClient;
 }
 
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize);
-  if (value && typeof value === "object") {
-    const out: JsonRecord = {};
-    for (const key of Object.keys(value as JsonRecord).sort()) {
-      out[key] = canonicalize((value as JsonRecord)[key]);
-    }
-    return out;
-  }
-  return value;
-}
-
+/**
+ * Deterministic JSON with recursively sorted object keys — the bytes every
+ * backup integrity hash is taken over.
+ *
+ * Bounded, because both directions run it on content the process does not
+ * control. `assertManifest` canonicalizes `manifest.integrity.componentHashes`
+ * straight out of a stored backup file, and `decryptLocalBackupEnvelope`
+ * canonicalizes the decrypted snapshot BEFORE `assertManifest` has validated
+ * its shape — so the unbounded sorted-key recursion this replaces made the
+ * integrity gate itself `RangeError` on a deep or cyclic payload, leaving a
+ * restore with no reachable error path rather than a clean rejection.
+ * Canonical bytes are unchanged for every payload that hashed before, so
+ * already-written `stateSha256` envelopes stay verifiable.
+ */
 function stableJson(value: unknown): string {
-  return JSON.stringify(canonicalize(value));
+  return stableJsonString(value, AGENT_BACKUP_CANONICAL_JSON);
 }
 
 function sha256Bytes(bytes: Buffer | string): string {

--- a/packages/agent/src/services/agent-export.ts
+++ b/packages/agent/src/services/agent-export.ts
@@ -36,6 +36,12 @@ import type {
   World,
 } from "@elizaos/core";
 import { ElizaError, type ElizaErrorOptions, logger } from "@elizaos/core";
+import {
+  type CanonicalJsonOptions,
+  canonicalJsonString,
+  isCanonicalJsonArray,
+  readCanonicalArrayLength,
+} from "@elizaos/shared/canonical-json";
 import * as zod from "zod";
 import {
   isStoredMediaUrl,
@@ -230,18 +236,17 @@ export class AgentExportError extends ElizaError {
   }
 }
 
-type CanonicalizeWalkContext = {
-  visits: number;
-  visiting: WeakSet<object>;
-};
-
+/**
+ * Rejection hook for the shared walk, so `AgentExportError` (and its
+ * `AGENT_EXPORT_CANONICALIZE_UNBOUNDED` code) stays what export/import callers
+ * catch. Context is deliberately structural only (never a reflected property
+ * name): the walk runs on attacker-supplied import payloads and the error
+ * surfaces in API responses and logs.
+ */
 function failCanonicalizeUnbounded(
   context: Record<string, unknown>,
   cause?: unknown,
 ): never {
-  // Context is deliberately structural only (never a reflected property name):
-  // the walk runs on attacker-supplied import payloads and the error surfaces
-  // in API responses and logs.
   throw new AgentExportError(
     "Export payload exceeds the canonicalize walk budget",
     {
@@ -253,175 +258,24 @@ function failCanonicalizeUnbounded(
   );
 }
 
-function reserveCanonicalizeVisits(
-  ctx: CanonicalizeWalkContext,
-  count: number,
-): void {
-  if (count > MAX_AGENT_EXPORT_CANONICALIZE_NODES - ctx.visits) {
-    failCanonicalizeUnbounded({
-      visits: ctx.visits + count,
-      maxNodes: MAX_AGENT_EXPORT_CANONICALIZE_NODES,
-    });
-  }
-  ctx.visits += count;
-}
-
-function enterCanonicalizeContainer(
-  value: object,
-  ctx: CanonicalizeWalkContext,
-): void {
-  if (ctx.visiting.has(value)) {
-    failCanonicalizeUnbounded({ cycle: true });
-  }
-  ctx.visiting.add(value);
-}
-
-function inspectCanonicalize<T>(operation: string, inspect: () => T): T {
-  try {
-    return inspect();
-  } catch (cause) {
-    // error-policy:J2 Proxy inspection failures wrap with cause as unbounded.
-    failCanonicalizeUnbounded({ inspection: operation }, cause);
-  }
-}
-
-function isCanonicalizeArray(value: object): boolean {
-  return inspectCanonicalize("isArray", () => Array.isArray(value));
-}
-
 /**
- * Reads `length` off an array exactly once, as an own data descriptor, so a
- * Proxy cannot serve a different value to a second reader. Callers that also
- * need the length (e.g. a manifest `count`) must reuse the returned number
- * rather than calling this again.
+ * `sparseArrayHoles: "omit"` keeps the empty-slot rendering
+ * `array.map(canonicalize).join(",")` published before the walk was bounded —
+ * export manifests already carry digests taken over those bytes.
+ *
+ * No `maxOutputChars`: an import payload is already capped upstream by
+ * {@link MAX_IMPORT_DECOMPRESSED_BYTES}, and an export payload is this
+ * process's own rows.
  */
-function ownArrayLength(value: object): number {
-  const descriptor = inspectCanonicalize("getOwnPropertyDescriptor", () =>
-    Object.getOwnPropertyDescriptor(value, "length"),
-  );
-  if (descriptor && !("value" in descriptor)) {
-    failCanonicalizeUnbounded({ accessor: true, property: "length" });
-  }
-  if (
-    !descriptor ||
-    typeof descriptor.value !== "number" ||
-    !Number.isSafeInteger(descriptor.value) ||
-    descriptor.value < 0
-  ) {
-    failCanonicalizeUnbounded({ invalidArrayLength: true });
-  }
-  return descriptor.value as number;
-}
-
-type CanonicalizeDataSnapshot = {
-  key: string;
-  value: unknown;
+const EXPORT_CANONICAL_JSON: CanonicalJsonOptions = {
+  maxDepth: MAX_AGENT_EXPORT_CANONICALIZE_DEPTH,
+  maxNodes: MAX_AGENT_EXPORT_CANONICALIZE_NODES,
+  sparseArrayHoles: "omit",
+  onUnbounded: failCanonicalizeUnbounded,
 };
 
-/**
- * One getOwnPropertyDescriptor per key (prevents Proxy descriptor drift), with
- * the object's breadth charged to the node budget BEFORE any descriptor trap
- * runs, before the snapshot array is allocated and before the O(n log n) sort.
- * A hostile wide object or `ownKeys` Proxy is rejected on the key list alone.
- * The reservation covers every child, so the walks below run with
- * `visitAlreadyReserved`.
- */
-function ownEnumerableDataSnapshot(
-  value: object,
-  ctx: CanonicalizeWalkContext,
-): CanonicalizeDataSnapshot[] {
-  const keys = inspectCanonicalize("ownKeys", () => Reflect.ownKeys(value));
-  reserveCanonicalizeVisits(ctx, keys.length);
-  const snapshot: CanonicalizeDataSnapshot[] = [];
-  for (const key of keys) {
-    if (typeof key !== "string") continue;
-    const descriptor = inspectCanonicalize("getOwnPropertyDescriptor", () =>
-      Object.getOwnPropertyDescriptor(value, key),
-    );
-    if (!descriptor?.enumerable) continue;
-    if (!("value" in descriptor)) {
-      failCanonicalizeUnbounded({ accessor: true, container: "object" });
-    }
-    if (descriptor.value === undefined) continue;
-    snapshot.push({ key, value: descriptor.value });
-  }
-  snapshot.sort((left, right) =>
-    left.key < right.key ? -1 : left.key > right.key ? 1 : 0,
-  );
-  return snapshot;
-}
-
-function canonicalizeWalk(
-  value: unknown,
-  depth: number,
-  ctx: CanonicalizeWalkContext,
-  visitAlreadyReserved = false,
-  /**
-   * Array length already read by the caller (root only). Reusing it keeps the
-   * digest and the manifest `count` on one immutable snapshot.
-   */
-  knownArrayLength?: number,
-): string {
-  if (depth > MAX_AGENT_EXPORT_CANONICALIZE_DEPTH) {
-    failCanonicalizeUnbounded({
-      depth,
-      max: MAX_AGENT_EXPORT_CANONICALIZE_DEPTH,
-    });
-  }
-  if (!visitAlreadyReserved) reserveCanonicalizeVisits(ctx, 1);
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value ?? null);
-  }
-
-  enterCanonicalizeContainer(value, ctx);
-  try {
-    if (isCanonicalizeArray(value)) {
-      const length = knownArrayLength ?? ownArrayLength(value);
-      reserveCanonicalizeVisits(ctx, length);
-      // String-build so inherited Array.prototype index accessors cannot
-      // trap assignment into a preallocated parts array.
-      let body = "";
-      for (let index = 0; index < length; index += 1) {
-        if (index > 0) body += ",";
-        const descriptor = inspectCanonicalize("getOwnPropertyDescriptor", () =>
-          Object.getOwnPropertyDescriptor(value, String(index)),
-        );
-        if (!descriptor) {
-          // Sparse hole: keep the prior map()+join() empty-slot string.
-          continue;
-        }
-        if (!("value" in descriptor)) {
-          failCanonicalizeUnbounded({
-            accessor: true,
-            container: "array",
-            index,
-          });
-        }
-        body += canonicalizeWalk(descriptor.value, depth + 1, ctx, true);
-      }
-      return `[${body}]`;
-    }
-
-    const snapshot = ownEnumerableDataSnapshot(value, ctx);
-    return `{${snapshot
-      .map(
-        (entry) =>
-          `${JSON.stringify(entry.key)}:${canonicalizeWalk(entry.value, depth + 1, ctx, true)}`,
-      )
-      .join(",")}}`;
-  } finally {
-    ctx.visiting.delete(value);
-  }
-}
-
 function canonicalizeRoot(value: unknown, knownArrayLength?: number): string {
-  return canonicalizeWalk(
-    value,
-    0,
-    { visits: 0, visiting: new WeakSet<object>() },
-    false,
-    knownArrayLength,
-  );
+  return canonicalJsonString(value, EXPORT_CANONICAL_JSON, knownArrayLength);
 }
 
 export function canonicalize(value: unknown): string {
@@ -439,12 +293,12 @@ export function digestCollection(items: unknown[]): AgentExportComponentDigest {
   if (
     items != null &&
     typeof items === "object" &&
-    isCanonicalizeArray(items)
+    isCanonicalJsonArray(items, EXPORT_CANONICAL_JSON)
   ) {
     // One `length` descriptor read feeds BOTH the canonical bytes and `count`.
     // Reading it twice let a legal Array Proxy drift (or throw) between the two
     // reads and publish a digest and a count taken from different snapshots.
-    const length = ownArrayLength(items);
+    const length = readCanonicalArrayLength(items, EXPORT_CANONICAL_JSON);
     return {
       sha256: sha256Hex(canonicalizeRoot(items, length)),
       count: length,

--- a/packages/cloud/shared/src/lib/services/agent-backup-diff.canonicalize-bound.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-diff.canonicalize-bound.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Fail-closed canonical walk for incremental-backup state hashing.
+ *
+ * Origin develop `RangeError`ed `computeStateHash` and `diffBackupState` on a
+ * deep or cyclic `state.config` — agent- and plugin-controlled content — because
+ * the sorted-key recursion behind `stableStringify` had no depth counter, no
+ * node budget and no cycle guard. It now fails closed with a typed
+ * `ElizaError` / `CANONICAL_JSON_UNBOUNDED`, and every state that hashed before
+ * still hashes to the same digest.
+ */
+import { createHash } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
+import { CANONICAL_JSON_UNBOUNDED } from "@elizaos/shared/canonical-json";
+import { describe, expect, test } from "vitest";
+import { computeStateHash, diffBackupState, emptyBackupState } from "./agent-backup-diff";
+
+/** The unbounded body this file used to carry, kept as the hash oracle. */
+function legacyCanonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(legacyCanonicalize);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      out[key] = legacyCanonicalize((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function legacyStateHash(state: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(legacyCanonicalize(state)))
+    .digest("hex");
+}
+
+function deepChain(levels: number): unknown {
+  let node: Record<string, unknown> = {};
+  const root = node;
+  for (let i = 0; i < levels; i += 1) {
+    const next: Record<string, unknown> = {};
+    node.next = next;
+    node = next;
+  }
+  return root;
+}
+
+function expectUnbounded(fn: () => unknown): void {
+  let caught: unknown;
+  let threw = false;
+  try {
+    fn();
+  } catch (error) {
+    threw = true;
+    caught = error;
+  }
+  expect(threw).toBe(true);
+  expect(caught).toBeInstanceOf(ElizaError);
+  expect(caught).not.toBeInstanceOf(RangeError);
+  expect((caught as ElizaError).code).toBe(CANONICAL_JSON_UNBOUNDED);
+}
+
+function stateWithConfig(config: Record<string, unknown>) {
+  const state = emptyBackupState();
+  Object.assign(state.config, config);
+  return state;
+}
+
+describe("bounded state hashing", () => {
+  test("computeStateHash fails closed on a 60k-deep config", () => {
+    expectUnbounded(() => computeStateHash(stateWithConfig({ deep: deepChain(60_000) })));
+  });
+
+  test("computeStateHash fails closed on a cyclic config", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expectUnbounded(() => computeStateHash(stateWithConfig({ cyclic })));
+  });
+
+  test("diffBackupState fails closed on a deep or cyclic config value", () => {
+    const base = stateWithConfig({ deep: { shallow: true }, cyclic: { shallow: true } });
+    expectUnbounded(() => diffBackupState(base, stateWithConfig({ deep: deepChain(60_000) })));
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expectUnbounded(() => diffBackupState(base, stateWithConfig({ cyclic })));
+  });
+
+  test("honest states keep the digest they already had", () => {
+    const shared = { b: 1, a: [1, 2, { deep: true }] };
+    const honest = {
+      memories: [
+        { role: "user", text: "hi 🦊", timestamp: 1 },
+        { role: "assistant", text: "hello", timestamp: 2 },
+      ],
+      config: {
+        zeta: 1,
+        // An honest shared reference (DAG): the same object down two branches
+        // is not a cycle and must still hash exactly as it did before.
+        x: shared,
+        y: shared,
+        nested: { a: { b: { c: [1, null, "two", true] } } },
+        empty: {},
+        nul: null,
+      },
+      workspaceFiles: { "b.txt": "second", "a.txt": "first" },
+    };
+    expect(computeStateHash(honest)).toBe(legacyStateHash(honest));
+  });
+
+  test("a deeply-nested but finite honest config still hashes, unchanged", () => {
+    let value: unknown = "leaf";
+    for (let i = 0; i < 40; i += 1) value = { level: value };
+    const state = stateWithConfig({ plugin: value });
+    expect(computeStateHash(state)).toBe(legacyStateHash(state));
+  });
+
+  test("key insertion order still does not change the digest", () => {
+    const left = stateWithConfig({ a: 1, b: { x: 1, y: 2 } });
+    const right = stateWithConfig({ b: { y: 2, x: 1 }, a: 1 });
+    expect(computeStateHash(left)).toBe(computeStateHash(right));
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-backup-diff.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-diff.ts
@@ -24,6 +24,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { AGENT_BACKUP_CANONICAL_JSON, stableJsonString } from "@elizaos/shared/canonical-json";
 import type {
   AgentBackupDeltaData,
   AgentBackupPlainStateData,
@@ -75,21 +76,16 @@ export function emptyBackupState(): AgentBackupStateData {
 /**
  * Deterministic JSON with recursively sorted object keys. Used so two states
  * that differ only in key insertion order hash and compare equal.
+ *
+ * `state.config` and `state.memories` are agent- and plugin-controlled, so the
+ * walk is bounded: the sorted-key recursion this replaces carried no depth
+ * counter, no node budget and no cycle guard, and `RangeError`ed
+ * `computeStateHash`/`diffBackupState` on a deep or cyclic config instead of
+ * rejecting it. Canonical bytes are unchanged for every state that hashed
+ * before, so stored `content_hash` values stay valid.
  */
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize);
-  if (value && typeof value === "object") {
-    const sorted: Record<string, unknown> = {};
-    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-      sorted[key] = canonicalize((value as Record<string, unknown>)[key]);
-    }
-    return sorted;
-  }
-  return value;
-}
-
 function stableStringify(value: unknown): string {
-  return JSON.stringify(canonicalize(value));
+  return stableJsonString(value, AGENT_BACKUP_CANONICAL_JSON);
 }
 
 function valuesEqual(a: unknown, b: unknown): boolean {
@@ -349,4 +345,4 @@ export function selectPrunableBackupIds(nodes: BackupChainNode[], keep: number):
   return newestFirst.filter((n) => !keepSet.has(n.id)).map((n) => n.id);
 }
 
-export const __testing = { canonicalize, stableStringify, sharedMemoryPrefix, EMPTY_STATE };
+export const __testing = { stableStringify, sharedMemoryPrefix, EMPTY_STATE };

--- a/packages/cloud/shared/src/lib/services/agent-backup-verifier.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-verifier.ts
@@ -42,13 +42,16 @@
  *
  * Manifest hashing here intentionally mirrors the producer in
  * `packages/agent/src/services/agent-backup.ts` (canonical sorted-key JSON →
- * sha256). Cloud-shared cannot import that package, so the canonicalization is
- * reimplemented; if the producer's hash shapes change, this verifier must
- * change in lockstep or the fleet will page with hash-mismatch failures.
+ * sha256). Cloud-shared cannot import that package, so both sides now call the
+ * one bounded walk in `@elizaos/shared/canonical-json` instead of keeping two
+ * copies of the recursion in sync; if the producer's hash shapes change, this
+ * verifier must still change in lockstep or the fleet will page with
+ * hash-mismatch failures.
  */
 
 import { createHash } from "node:crypto";
 import { ElizaError } from "@elizaos/core";
+import { AGENT_BACKUP_CANONICAL_JSON, stableJsonString } from "@elizaos/shared/canonical-json";
 import { and, desc, eq, isNotNull, isNull, lt, or, type SQL, sql } from "drizzle-orm";
 import {
   decryptAgentBackupStateData,
@@ -333,24 +336,20 @@ function classifyChainError(error: unknown): BackupVerificationFailure | null {
 
 type JsonRecord = Record<string, unknown>;
 
-function canonicalize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalize);
-  if (value && typeof value === "object") {
-    const out: JsonRecord = {};
-    for (const key of Object.keys(value as JsonRecord).sort()) {
-      out[key] = canonicalize((value as JsonRecord)[key]);
-    }
-    return out;
-  }
-  return value;
-}
-
 function sha256Bytes(bytes: Buffer | string): string {
   return createHash("sha256").update(bytes).digest("hex");
 }
 
+/**
+ * Bounded canonical hash of stored-backup content. `manifest.integrity`
+ * and the file-set entries are read straight out of a stored backup, so the
+ * unbounded sorted-key recursion this replaces could `RangeError` the whole
+ * `runBackupVerificationCycle` daemon pass on one malformed row instead of
+ * stamping that row as unverifiable. Canonical bytes are unchanged for every
+ * manifest that hashed before.
+ */
 function sha256Json(value: unknown): string {
-  return sha256Bytes(JSON.stringify(canonicalize(value)));
+  return sha256Bytes(stableJsonString(value, AGENT_BACKUP_CANONICAL_JSON));
 }
 
 function verifyFileEntry(label: string, entry: AgentBackupFileEntry, mismatches: string[]): void {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -193,6 +193,16 @@
       "import": "./dist/platform/native-library-policy.js",
       "default": "./dist/platform/native-library-policy.js"
     },
+    "./canonical-json": {
+      "types": "./dist/canonical-json.d.ts",
+      "eliza-source": {
+        "types": "./src/canonical-json.ts",
+        "import": "./src/canonical-json.ts",
+        "default": "./src/canonical-json.ts"
+      },
+      "import": "./dist/canonical-json.js",
+      "default": "./dist/canonical-json.js"
+    },
     "./character-presets": {
       "types": "./dist/character-presets.d.ts",
       "eliza-source": {

--- a/packages/shared/src/canonical-json.test.ts
+++ b/packages/shared/src/canonical-json.test.ts
@@ -1,0 +1,383 @@
+/**
+ * The shared bounded canonical-JSON walk.
+ *
+ * Two obligations, and the second one is the reason this file is long:
+ *   1. deep / cyclic / hostile payloads fail closed with a typed error instead
+ *      of `RangeError`ing an integrity gate; and
+ *   2. every payload the unbounded predecessors accepted still produces the
+ *      SAME canonical bytes. A backup state that hashed one way yesterday and
+ *      another way today would silently invalidate the backups already stored
+ *      for it, so compatibility is pinned differentially against a verbatim
+ *      copy of the recursion this module replaces.
+ */
+import { ElizaError } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_BACKUP_CANONICAL_JSON,
+  CANONICAL_JSON_UNBOUNDED,
+  type CanonicalJsonOptions,
+  canonicalJsonString,
+  failCanonicalJsonUnbounded,
+  readCanonicalArrayLength,
+  stableJsonString,
+} from "./canonical-json.js";
+
+/**
+ * The exact unbounded body that shipped in agent-backup.ts,
+ * agent-backup-diff.ts and agent-backup-verifier.ts, kept here as the
+ * compatibility oracle. `JSON.stringify(legacyCanonicalize(v))` is the byte
+ * sequence every already-stored backup hash was taken over.
+ */
+function legacyCanonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(legacyCanonicalize);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      out[key] = legacyCanonicalize((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function legacyStableJson(value: unknown): string {
+  return JSON.stringify(legacyCanonicalize(value));
+}
+
+const OPTIONS = AGENT_BACKUP_CANONICAL_JSON;
+
+function expectUnbounded(fn: () => unknown): ElizaError {
+  let caught: unknown;
+  let threw = false;
+  try {
+    fn();
+  } catch (error) {
+    threw = true;
+    caught = error;
+  }
+  expect(threw).toBe(true);
+  expect(caught).toBeInstanceOf(ElizaError);
+  expect(caught).not.toBeInstanceOf(RangeError);
+  expect((caught as ElizaError).code).toBe(CANONICAL_JSON_UNBOUNDED);
+  return caught as ElizaError;
+}
+
+function nest(depth: number): unknown {
+  let value: unknown = 1;
+  for (let i = 0; i < depth; i += 1) value = { a: value };
+  return value;
+}
+
+/** An honest backup state, deep enough to be interesting but finite. */
+function honestState(depth: number) {
+  return {
+    memories: [
+      { role: "user", text: "hi 🦊", timestamp: 1 },
+      { role: "assistant", text: "hello", timestamp: 2 },
+    ],
+    config: {
+      zeta: 1,
+      alpha: { nested: nest(depth), list: [1, "two", null, true] },
+      beta: null,
+      unicode: "sur\u{1F98A}rogate éè",
+    },
+    workspaceFiles: { "b.txt": "second", "a.txt": "first" },
+  };
+}
+
+describe("canonical JSON compatibility with the unbounded predecessor", () => {
+  const corpus: Array<[string, unknown]> = [
+    ["null", null],
+    ["number", 42],
+    ["negative zero", -0],
+    ["non-finite number", Number.NaN],
+    ["infinity", Number.POSITIVE_INFINITY],
+    ["string with quotes and newlines", 'a"b\nc\\d'],
+    ["astral string", "🦊🦊"],
+    ["boolean", true],
+    ["empty object", {}],
+    ["empty array", []],
+    ["flat object out of key order", { b: 1, a: 2, C: 3, "": 4 }],
+    ["nested arrays", [[1, [2, [3, [4]]]], []]],
+    ["array of objects", [{ b: 1, a: 2 }, { z: [1, 2] }]],
+    ["undefined-valued key", { a: 1, b: undefined }],
+    ["function-valued key", { a: 1, b: () => 1 }],
+    ["symbol-valued key", { a: 1, b: Symbol("s") }],
+    ["undefined array slot", [1, undefined, 3]],
+    ["function array slot", [1, () => 1, 3]],
+    ["null array slot", [1, null, 3]],
+    ["symbol key", { a: 1, [Symbol("s")]: 2 }],
+    ["Date value", { at: new Date(0) }],
+    ["Map value", { m: new Map([["a", 1]]) }],
+    ["Set value", { s: new Set([1, 2]) }],
+    [
+      "null-prototype object",
+      Object.assign(Object.create(null), { b: 1, a: 2 }),
+    ],
+    ["honest backup state", honestState(4)],
+    ["deep but finite state (depth 55)", honestState(50)],
+    [
+      "wide object",
+      Object.fromEntries(
+        Array.from({ length: 2_000 }, (_v, i) => [
+          `k${(2_000 - i).toString(36)}`,
+          i,
+        ]),
+      ),
+    ],
+    [
+      "long memory log",
+      {
+        memories: Array.from({ length: 5_000 }, (_v, i) => ({
+          role: i % 2 ? "user" : "assistant",
+          text: `m${i}`,
+          timestamp: i,
+        })),
+        config: {},
+        workspaceFiles: {},
+      },
+    ],
+  ];
+
+  for (const [label, value] of corpus) {
+    it(`emits identical canonical bytes: ${label}`, () => {
+      expect(stableJsonString(value, OPTIONS)).toBe(legacyStableJson(value));
+    });
+  }
+
+  it("keeps a non-enumerable own property out of the digest, as before", () => {
+    const value: Record<string, unknown> = { a: 1 };
+    Object.defineProperty(value, "hidden", { value: 2, enumerable: false });
+    expect(stableJsonString(value, OPTIONS)).toBe(legacyStableJson(value));
+    expect(stableJsonString(value, OPTIONS)).toBe('{"a":1}');
+  });
+
+  it("preserves the sparse-hole rendering of JSON.stringify", () => {
+    const sparse = [1];
+    sparse[2] = 3;
+    expect(stableJsonString(sparse, OPTIONS)).toBe(legacyStableJson(sparse));
+    expect(stableJsonString(sparse, OPTIONS)).toBe("[1,null,3]");
+  });
+
+  it("keeps undefined at the root undefined, so absent != null stays true", () => {
+    // The differ compares stableJson(a) === stableJson(b); collapsing an
+    // absent value onto "null" would stop reporting a null -> absent change.
+    expect(stableJsonString(undefined, OPTIONS)).toBe(
+      legacyStableJson(undefined),
+    );
+    expect(stableJsonString(undefined, OPTIONS)).toBeUndefined();
+    expect(stableJsonString(null, OPTIONS)).toBe("null");
+  });
+
+  it("hashes key-order permutations of one state identically", () => {
+    const left = { config: { a: 1, b: 2 }, memories: [], workspaceFiles: {} };
+    const right = { memories: [], workspaceFiles: {}, config: { b: 2, a: 1 } };
+    expect(stableJsonString(left, OPTIONS)).toBe(
+      stableJsonString(right, OPTIONS),
+    );
+  });
+
+  it("preserves an honest shared reference (DAG), not just rejecting cycles", () => {
+    // Reviewers have caught the difference twice: `seen`-forever rejects a DAG
+    // the live path accepts today. `visiting` is path-local, so this must hash
+    // exactly as the unbounded walk did.
+    const shared = { b: 1, a: [1, 2, { deep: true }] };
+    const dag = { config: { x: shared, y: shared, z: { again: shared } } };
+    expect(stableJsonString(dag, OPTIONS)).toBe(legacyStableJson(dag));
+  });
+
+  it("preserves a shared reference repeated inside one array", () => {
+    const shared = { a: 1 };
+    const value = [shared, shared, shared];
+    expect(stableJsonString(value, OPTIONS)).toBe(legacyStableJson(value));
+    expect(stableJsonString(value, OPTIONS)).toBe('[{"a":1},{"a":1},{"a":1}]');
+  });
+
+  it("accepts a state nested one level under the depth ceiling", () => {
+    const atLimit = nest(OPTIONS.maxDepth);
+    expect(stableJsonString(atLimit, OPTIONS)).toBe(legacyStableJson(atLimit));
+  });
+});
+
+describe("canonical JSON fail-closed bounds", () => {
+  it("fails closed on a cyclic graph instead of RangeError", () => {
+    const cyclic: Record<string, unknown> = { id: "state" };
+    cyclic.self = cyclic;
+    const error = expectUnbounded(() => stableJsonString(cyclic, OPTIONS));
+    expect(error.context).toEqual({ cycle: true });
+    expect(error.severity).toBe("fatal");
+  });
+
+  it("fails closed on an over-deep nest before the walk RangeErrors", () => {
+    const error = expectUnbounded(() =>
+      stableJsonString(nest(OPTIONS.maxDepth + 8), OPTIONS),
+    );
+    expect(error.context).toMatchObject({ max: OPTIONS.maxDepth });
+  });
+
+  it("fails closed after JSON.parse accepts a 20k-deep payload", () => {
+    const raw = `${'{"a":'.repeat(20_000)}1${"}".repeat(20_000)}`;
+    const parsed = JSON.parse(raw) as unknown;
+    expectUnbounded(() => stableJsonString(parsed, OPTIONS));
+  });
+
+  it("bounds an exponential shared-reference expansion on output chars", () => {
+    // Path-local cycle detection is correct and keeps DAGs honest, but a
+    // 40-level doubling graph is a few hundred bytes of input that flattens to
+    // a terabyte of canonical text. The output budget is what stops it.
+    let node: Record<string, unknown> = { leaf: "0123456789" };
+    for (let i = 0; i < 40; i += 1) node = { a: node, b: node };
+    const error = expectUnbounded(() =>
+      stableJsonString(node, {
+        ...OPTIONS,
+        maxDepth: 128,
+        maxOutputChars: 1_000_000,
+      }),
+    );
+    expect(error.context).toMatchObject({ maxOutputChars: 1_000_000 });
+  });
+
+  it("never invokes an enumerable getter", () => {
+    const hostile: Record<string, unknown> = {};
+    Object.defineProperty(hostile, "secret", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw new Error("GETTER_INVOKED");
+      },
+    });
+    const error = expectUnbounded(() =>
+      stableJsonString({ config: hostile }, OPTIONS),
+    );
+    expect(String(error)).not.toContain("GETTER_INVOKED");
+  });
+
+  it("never echoes an attacker-controlled property name in error context", () => {
+    const hostile: Record<string, unknown> = {};
+    Object.defineProperty(hostile, "AWS_SECRET_ACCESS_KEY", {
+      enumerable: true,
+      configurable: true,
+      get: () => "leaked",
+    });
+    const error = expectUnbounded(() => stableJsonString(hostile, OPTIONS));
+    expect(error.context).toEqual({ accessor: true, container: "object" });
+    expect(JSON.stringify(error.context ?? {})).not.toContain(
+      "AWS_SECRET_ACCESS_KEY",
+    );
+    expect(error.message).not.toContain("AWS_SECRET_ACCESS_KEY");
+  });
+
+  it("charges a wide object's breadth before any descriptor read or sort", () => {
+    const options: CanonicalJsonOptions = { ...OPTIONS, maxNodes: 1_000 };
+    const keys = Array.from({ length: 1_001 }, (_v, i) => `k${i}`);
+    let descriptorReads = 0;
+    const wide = new Proxy(
+      {},
+      {
+        ownKeys: () => keys,
+        getOwnPropertyDescriptor: () => {
+          descriptorReads += 1;
+          return {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            value: 1,
+          };
+        },
+      },
+    );
+    const error = expectUnbounded(() => stableJsonString(wide, options));
+    expect(descriptorReads).toBe(0);
+    expect(error.context).toEqual({ visits: 1_002, maxNodes: 1_000 });
+  });
+
+  it("fails closed on a huge sparse length before allocating the join", () => {
+    const options: CanonicalJsonOptions = { ...OPTIONS, maxNodes: 1_000 };
+    const sparse: unknown[] = [];
+    sparse.length = 1_001;
+    expectUnbounded(() => stableJsonString(sparse, options));
+  });
+
+  it("wraps a revoked Proxy as a typed rejection, preserving the cause", () => {
+    const pair = Proxy.revocable({ a: 1 }, {});
+    pair.revoke();
+    const error = expectUnbounded(() => stableJsonString(pair.proxy, OPTIONS));
+    expect(error.cause).toBeInstanceOf(TypeError);
+    expect(error.context).toEqual({ inspection: "isArray" });
+  });
+
+  it("keeps honest canonical bytes for an ordinary Proxy", () => {
+    expect(stableJsonString(new Proxy({ b: 1, a: 2 }, {}), OPTIONS)).toBe(
+      '{"a":2,"b":1}',
+    );
+    expect(stableJsonString(new Proxy([2, 1], {}), OPTIONS)).toBe("[2,1]");
+  });
+
+  it("reads one object descriptor snapshot so Proxy drift cannot change bytes", () => {
+    let reads = 0;
+    const drifted = new Proxy(
+      { a: 1 },
+      {
+        ownKeys: () => ["a"],
+        getOwnPropertyDescriptor: () => {
+          reads += 1;
+          if (reads === 1) {
+            return {
+              configurable: true,
+              enumerable: true,
+              writable: true,
+              value: 1,
+            };
+          }
+          throw new Error("DESCRIPTOR_DRIFT");
+        },
+      },
+    );
+    expect(stableJsonString(drifted, OPTIONS)).toBe('{"a":1}');
+    expect(reads).toBe(1);
+  });
+
+  it("reads an array length exactly once for a caller that also publishes it", () => {
+    const items = [{ id: "a" }, { id: "b" }];
+    let lengthReads = 0;
+    const counted = new Proxy(items, {
+      getOwnPropertyDescriptor(target, key) {
+        if (key === "length") lengthReads += 1;
+        return Object.getOwnPropertyDescriptor(target, key);
+      },
+    });
+    const length = readCanonicalArrayLength(counted, OPTIONS);
+    expect(length).toBe(2);
+    expect(lengthReads).toBe(1);
+    expect(canonicalJsonString(counted, OPTIONS, length)).toBe(
+      canonicalJsonString(items, OPTIONS),
+    );
+    expect(lengthReads).toBe(1);
+  });
+
+  it("renders a sparse hole per the call site's declared policy", () => {
+    const sparse = [1];
+    sparse[2] = 3;
+    const omit: CanonicalJsonOptions = { ...OPTIONS, sparseArrayHoles: "omit" };
+    expect(canonicalJsonString(sparse, omit)).toBe("[1,,3]");
+    expect(canonicalJsonString(sparse, OPTIONS)).toBe("[1,null,3]");
+  });
+
+  it("routes rejections through a call site's own error type", () => {
+    class DomainError extends ElizaError {}
+    const options: CanonicalJsonOptions = {
+      ...OPTIONS,
+      onUnbounded: (context, cause) => {
+        throw new DomainError("domain", {
+          code: "DOMAIN_UNBOUNDED",
+          context,
+          cause,
+        });
+      },
+    };
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(() => canonicalJsonString(cyclic, options)).toThrow(DomainError);
+    expect(typeof failCanonicalJsonUnbounded).toBe("function");
+  });
+});

--- a/packages/shared/src/canonical-json.ts
+++ b/packages/shared/src/canonical-json.ts
@@ -1,0 +1,380 @@
+/**
+ * One bounded canonical-JSON walk for every integrity digest in the monorepo.
+ *
+ * Canonical JSON — recursively key-sorted, `undefined`-dropping — is what makes
+ * a content hash reproducible across a serialize → store → `JSON.parse`
+ * round-trip regardless of in-memory key ordering. Four hand-rolled copies of
+ * the same six-line recursion existed:
+ *
+ *   - `packages/agent/src/services/agent-export.ts` (bounded by #23127)
+ *   - `packages/agent/src/services/agent-backup.ts`
+ *   - `packages/cloud/shared/src/lib/services/agent-backup-diff.ts`
+ *   - `packages/cloud/shared/src/lib/services/agent-backup-verifier.ts`
+ *
+ * Only the export copy was ever bounded. The three backup copies still recursed
+ * with no depth counter, no node budget and no cycle guard, so a deep or cyclic
+ * payload `RangeError`ed the integrity gate instead of rejecting it. This module
+ * is that bounded walk, lifted out of `agent-export.ts` unchanged and
+ * parameterized on the two things the call sites legitimately disagree about:
+ * the budgets, and how a sparse array hole is rendered.
+ *
+ * Guarantees the call sites depend on:
+ *   - Output is byte-identical to the unbounded predecessor for every input the
+ *     predecessor accepted, with `sparseArrayHoles` selecting that site's
+ *     historical hole rendering. Existing stored digests stay valid.
+ *   - Descriptor-only reflection: `Reflect.ownKeys` plus exactly one
+ *     `getOwnPropertyDescriptor` per key. An enumerable getter is never
+ *     invoked, and a Proxy cannot serve two different descriptors to two reads.
+ *   - Breadth is charged to the node budget BEFORE any descriptor trap runs,
+ *     before the snapshot array is allocated and before the O(n log n) sort.
+ *   - Cycle detection is PATH-LOCAL (`visiting` is popped in a `finally`), so an
+ *     honest shared reference — the same object reached twice down two
+ *     different branches, i.e. a DAG — still canonicalizes exactly as it always
+ *     did. Only a true ancestor cycle fails closed.
+ *   - Every rejection is a typed error carrying a machine-classifiable `code`,
+ *     structural-only `context` (never a reflected property name: the walk runs
+ *     on attacker-supplied payloads and the error reaches logs and API
+ *     responses) and a preserved `cause`.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import { MAX_RESTORABLE_AGENT_BACKUP_BYTES } from "./agent-backup-limits.js";
+
+/** Classification for a canonical walk that refused to keep going. */
+export const CANONICAL_JSON_UNBOUNDED = "CANONICAL_JSON_UNBOUNDED";
+
+/**
+ * Rejection hook. Call sites with their own domain error type (export/import
+ * failures are `AgentExportError`) pass their own so callers keep catching what
+ * they always caught; everything else uses {@link failCanonicalJsonUnbounded}.
+ */
+export type CanonicalJsonUnbounded = (
+  context: Record<string, unknown>,
+  cause?: unknown,
+) => never;
+
+export type CanonicalJsonOptions = {
+  /** Rejected strictly above this. Honest documents are a handful deep. */
+  maxDepth: number;
+  /** Node ceiling across the whole walk, including sparse array slots. */
+  maxNodes: number;
+  /**
+   * Optional ceiling on the number of characters the canonical form may emit.
+   * A cycle guard that is path-local (as it must be, to keep honest DAGs
+   * hashing unchanged) still lets a shared-reference graph expand
+   * exponentially when it is flattened to a tree; this is the budget that
+   * bounds that expansion in output terms rather than input terms. Omit it at
+   * a call site whose payload size is already capped upstream.
+   */
+  maxOutputChars?: number;
+  /**
+   * How a sparse array hole is rendered. `"omit"` reproduces
+   * `array.map(fn).join(",")` (an empty slot); `"null"` reproduces
+   * `JSON.stringify`, which renders a hole as `null`. Both are historical
+   * behaviours in this repo and both are load-bearing for already-stored
+   * digests, so the caller must say which one it is preserving.
+   */
+  sparseArrayHoles: "omit" | "null";
+  /** Typed rejection for this call site. */
+  onUnbounded: CanonicalJsonUnbounded;
+};
+
+/** Default typed rejection: an {@link ElizaError} with a fatal severity. */
+export const failCanonicalJsonUnbounded: CanonicalJsonUnbounded = (
+  context,
+  cause,
+) => {
+  throw new ElizaError("Payload exceeds the canonical JSON walk budget", {
+    code: CANONICAL_JSON_UNBOUNDED,
+    cause,
+    context,
+    severity: "fatal",
+  });
+};
+
+/**
+ * Budgets for the agent-backup integrity digests.
+ *
+ * `maxDepth` matches the export walk's 64: an honest backup state — config
+ * record, memory log, workspace file map, manifest — is a handful of objects
+ * deep, while a decrypted or stored payload can still be legal JSON nested
+ * deeply enough to overflow the stack.
+ *
+ * The node and output ceilings are pinned to
+ * {@link MAX_RESTORABLE_AGENT_BACKUP_BYTES} rather than to a smaller round
+ * number on purpose: every JSON node costs at least one character in the
+ * canonical form, so NO state the restore path is willing to accept can reach
+ * either ceiling. That makes them unreachable by honest data by construction —
+ * the point that matters, because a state that newly failed to hash would
+ * invalidate the backups already stored for it — while still bounding the
+ * shared-reference expansion that has no wire-size bound at all.
+ */
+export const AGENT_BACKUP_CANONICAL_JSON: CanonicalJsonOptions = {
+  maxDepth: 64,
+  maxNodes: MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+  maxOutputChars: MAX_RESTORABLE_AGENT_BACKUP_BYTES,
+  sparseArrayHoles: "null",
+  onUnbounded: failCanonicalJsonUnbounded,
+};
+
+type CanonicalWalkContext = {
+  visits: number;
+  emitted: number;
+  visiting: WeakSet<object>;
+  options: CanonicalJsonOptions;
+};
+
+function newWalkContext(options: CanonicalJsonOptions): CanonicalWalkContext {
+  return { visits: 0, emitted: 0, visiting: new WeakSet<object>(), options };
+}
+
+function reserveVisits(ctx: CanonicalWalkContext, count: number): void {
+  if (count > ctx.options.maxNodes - ctx.visits) {
+    ctx.options.onUnbounded({
+      visits: ctx.visits + count,
+      maxNodes: ctx.options.maxNodes,
+    });
+  }
+  ctx.visits += count;
+}
+
+function reserveOutput(ctx: CanonicalWalkContext, count: number): void {
+  const max = ctx.options.maxOutputChars;
+  if (max === undefined) return;
+  if (count > max - ctx.emitted) {
+    ctx.options.onUnbounded({
+      emitted: ctx.emitted + count,
+      maxOutputChars: max,
+    });
+  }
+  ctx.emitted += count;
+}
+
+function emit(ctx: CanonicalWalkContext, text: string): string {
+  reserveOutput(ctx, text.length);
+  return text;
+}
+
+function enterContainer(value: object, ctx: CanonicalWalkContext): void {
+  if (ctx.visiting.has(value)) ctx.options.onUnbounded({ cycle: true });
+  ctx.visiting.add(value);
+}
+
+function inspect<T>(
+  ctx: CanonicalWalkContext,
+  operation: string,
+  read: () => T,
+): T {
+  try {
+    return read();
+  } catch (cause) {
+    // error-policy:J2 Proxy inspection failures wrap with cause as unbounded.
+    ctx.options.onUnbounded({ inspection: operation }, cause);
+  }
+}
+
+function isCanonicalArray(value: object, ctx: CanonicalWalkContext): boolean {
+  return inspect(ctx, "isArray", () => Array.isArray(value));
+}
+
+/**
+ * Reads `length` off an array exactly once, as an own data descriptor, so a
+ * Proxy cannot serve a different value to a second reader. Callers that also
+ * need the length (e.g. a manifest `count`) must reuse the returned number
+ * rather than calling this again.
+ */
+function ownArrayLengthWith(value: object, ctx: CanonicalWalkContext): number {
+  const descriptor = inspect(ctx, "getOwnPropertyDescriptor", () =>
+    Object.getOwnPropertyDescriptor(value, "length"),
+  );
+  if (descriptor && !("value" in descriptor)) {
+    ctx.options.onUnbounded({ accessor: true, property: "length" });
+  }
+  if (
+    !descriptor ||
+    typeof descriptor.value !== "number" ||
+    !Number.isSafeInteger(descriptor.value) ||
+    descriptor.value < 0
+  ) {
+    ctx.options.onUnbounded({ invalidArrayLength: true });
+  }
+  return descriptor.value as number;
+}
+
+/**
+ * One immutable `length` read for a caller that must publish a digest and a
+ * count taken from the same snapshot. Pass the result back in as
+ * `knownArrayLength`.
+ */
+export function readCanonicalArrayLength(
+  value: object,
+  options: CanonicalJsonOptions,
+): number {
+  return ownArrayLengthWith(value, newWalkContext(options));
+}
+
+/** @see readCanonicalArrayLength */
+export function isCanonicalJsonArray(
+  value: object,
+  options: CanonicalJsonOptions,
+): boolean {
+  return isCanonicalArray(value, newWalkContext(options));
+}
+
+/**
+ * Values `JSON.stringify` renders as nothing at all: dropped from an object,
+ * `null` inside an array. The sorted-key recursions this replaces all deferred
+ * to `JSON.stringify` for exactly this, so reproducing it is what keeps their
+ * canonical bytes unchanged.
+ */
+function isJsonInvisible(value: unknown): boolean {
+  return (
+    value === undefined ||
+    typeof value === "function" ||
+    typeof value === "symbol"
+  );
+}
+
+type DataSnapshot = { key: string; value: unknown };
+
+/**
+ * One getOwnPropertyDescriptor per key (prevents Proxy descriptor drift), with
+ * the object's breadth charged to the node budget BEFORE any descriptor trap
+ * runs, before the snapshot array is allocated and before the O(n log n) sort.
+ * A hostile wide object or `ownKeys` Proxy is rejected on the key list alone.
+ * The reservation covers every child, so the walks below run with
+ * `visitAlreadyReserved`.
+ */
+function ownEnumerableDataSnapshot(
+  value: object,
+  ctx: CanonicalWalkContext,
+): DataSnapshot[] {
+  const keys = inspect(ctx, "ownKeys", () => Reflect.ownKeys(value));
+  reserveVisits(ctx, keys.length);
+  const snapshot: DataSnapshot[] = [];
+  for (const key of keys) {
+    if (typeof key !== "string") continue;
+    const descriptor = inspect(ctx, "getOwnPropertyDescriptor", () =>
+      Object.getOwnPropertyDescriptor(value, key),
+    );
+    if (!descriptor?.enumerable) continue;
+    if (!("value" in descriptor)) {
+      ctx.options.onUnbounded({ accessor: true, container: "object" });
+    }
+    if (isJsonInvisible(descriptor.value)) continue;
+    snapshot.push({ key, value: descriptor.value });
+  }
+  snapshot.sort((left, right) =>
+    left.key < right.key ? -1 : left.key > right.key ? 1 : 0,
+  );
+  return snapshot;
+}
+
+function canonicalWalk(
+  value: unknown,
+  depth: number,
+  ctx: CanonicalWalkContext,
+  visitAlreadyReserved = false,
+  /**
+   * Array length already read by the caller (root only). Reusing it keeps the
+   * digest and any published `count` on one immutable snapshot.
+   */
+  knownArrayLength?: number,
+): string {
+  if (depth > ctx.options.maxDepth) {
+    ctx.options.onUnbounded({ depth, max: ctx.options.maxDepth });
+  }
+  if (!visitAlreadyReserved) reserveVisits(ctx, 1);
+  if (value === null || typeof value !== "object") {
+    // Object keys carrying these were already dropped by the snapshot; reaching
+    // one here means an array slot, which `JSON.stringify` renders as `null`.
+    if (isJsonInvisible(value)) return emit(ctx, "null");
+    return emit(ctx, JSON.stringify(value));
+  }
+
+  enterContainer(value, ctx);
+  try {
+    if (isCanonicalArray(value, ctx)) {
+      const length = knownArrayLength ?? ownArrayLengthWith(value, ctx);
+      reserveVisits(ctx, length);
+      // String-build so inherited Array.prototype index accessors cannot
+      // trap assignment into a preallocated parts array.
+      let body = "";
+      for (let index = 0; index < length; index += 1) {
+        if (index > 0) body += emit(ctx, ",");
+        const descriptor = inspect(ctx, "getOwnPropertyDescriptor", () =>
+          Object.getOwnPropertyDescriptor(value, String(index)),
+        );
+        if (!descriptor) {
+          // Sparse hole: whichever empty-slot rendering this call site has
+          // already published digests for.
+          if (ctx.options.sparseArrayHoles === "null")
+            body += emit(ctx, "null");
+          continue;
+        }
+        if (!("value" in descriptor)) {
+          ctx.options.onUnbounded({
+            accessor: true,
+            container: "array",
+            index,
+          });
+        }
+        body += canonicalWalk(descriptor.value, depth + 1, ctx, true);
+      }
+      return `${emit(ctx, "[")}${body}${emit(ctx, "]")}`;
+    }
+
+    const snapshot = ownEnumerableDataSnapshot(value, ctx);
+    let body = "";
+    for (let index = 0; index < snapshot.length; index += 1) {
+      if (index > 0) body += emit(ctx, ",");
+      const entry = snapshot[index] as DataSnapshot;
+      body += emit(ctx, `${JSON.stringify(entry.key)}:`);
+      body += canonicalWalk(entry.value, depth + 1, ctx, true);
+    }
+    return `${emit(ctx, "{")}${body}${emit(ctx, "}")}`;
+  } finally {
+    ctx.visiting.delete(value);
+  }
+}
+
+/**
+ * Canonical JSON text for `value`, bounded by `options`.
+ *
+ * Mirrors `JSON.stringify` for every value the unbounded predecessors reached:
+ * keys sorted, `undefined`-valued object keys dropped, `undefined` array slots
+ * rendered `null`, non-plain objects (`Date`, `Map`, `Set`) rendered from their
+ * own enumerable string keys — which is exactly what the sorted-key recursion
+ * they replace already did.
+ */
+export function canonicalJsonString(
+  value: unknown,
+  options: CanonicalJsonOptions,
+  knownArrayLength?: number,
+): string {
+  return canonicalWalk(
+    value,
+    0,
+    newWalkContext(options),
+    false,
+    knownArrayLength,
+  );
+}
+
+/**
+ * `JSON.stringify`-faithful wrapper for the call sites that spelled this
+ * `JSON.stringify(canonicalize(value))`.
+ *
+ * `JSON.stringify(undefined)` is `undefined`, not `"null"`, and callers such as
+ * the backup differ rely on that to tell an absent config value apart from a
+ * `null` one (same for a bare function or symbol at the root). Its declared return type is `string` for the same reason
+ * `JSON.stringify`'s most-used overload is: every call site here passes a
+ * defined value, and widening it would ripple through unrelated signatures.
+ */
+export function stableJsonString(
+  value: unknown,
+  options: CanonicalJsonOptions,
+): string {
+  if (isJsonInvisible(value)) return undefined as unknown as string;
+  return canonicalJsonString(value, options);
+}


### PR DESCRIPTION
# Relates to

Fixes #23814. Successor to #23127 (merged), which bounded the fourth copy of
this same walk in `agent-export.ts` and left the three backup copies as they
were.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      (`ceb82a4703273ffee12e43ff6cf246f3f4d8bfeb`) with zero conflicts.
- [x] Focused suites, per-package `typecheck` against an untouched control, and
      biome were run; the monorepo-wide `bun run verify` was not (see
      **Known gaps / failures**).
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after reproduction output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched off `origin/develop` @ `ceb82a4703273ffee12e43ff6cf246f3f4d8bfeb`;
      zero conflicts.
- [ ] `bun run verify` not run post-sync — the exact blocker is recorded in
      **Known gaps / failures** below.

# Risks

**Low–medium.** The change is confined to how canonical JSON bytes are produced
for backup integrity hashes; it adds no new behaviour to any caller.

The one risk worth naming explicitly is **hash compatibility**: these bytes feed
`stateSha256`, `content_hash` and `manifest.integrity`, so a payload that
canonicalized one way before and another way after would silently invalidate the
backups already stored for it. That is treated as the primary correctness
obligation, not an afterthought — see *Detailed testing steps*, where the new
walk is pinned differentially against a verbatim copy of the recursion it
replaces across a 28-case corpus (including `Date`/`Map`/`Set`, sparse arrays,
`undefined`/function/symbol values, null-prototype objects, non-enumerable
properties, unicode, wide objects, a 5 000-entry memory log and honest shared
references), and every existing backup and export suite still passes unchanged.

`agent-export.ts` is re-pointed at the shared walk rather than left as a fourth
copy; its own 17-test bound suite from #23127 passes untouched, which is the
proof that its published digests did not move.

# Background

## What does this PR do?

The sorted-key `canonicalize()` behind every agent-backup integrity hash was
duplicated **character-for-character in three files** and bounded in none of
them — no depth counter, no node budget, no cycle guard:

| call site | reached through | input |
| --- | --- | --- |
| `packages/cloud/shared/.../agent-backup-diff.ts:79` | `computeStateHash`, `diffBackupState` | agent- and plugin-controlled `state.config` / `state.memories` |
| `packages/agent/src/services/agent-backup.ts:369` | `assertManifest` (from the exported `restoreAgentSnapshot`), `decryptLocalBackupEnvelope` | `manifest.integrity.componentHashes` read out of a stored backup; the decrypted snapshot |
| `packages/cloud/shared/.../agent-backup-verifier.ts:336` | `verifyManifestIntegrity` → `runBackupVerificationCycle` | stored-backup manifest content |

So a deep or cyclic payload raised `RangeError: Maximum call stack size
exceeded` from **inside** the check whose job is to reject it. On the local
restore path that is the sharper version: `decryptLocalBackupEnvelope` computes
`sha256Json(snapshot)` **before** `assertManifest(snapshot)` has validated the
shape, so a malformed backup overflows the integrity gate instead of being
refused by it.

This PR lifts the already-merged bounded walk from `agent-export.ts` (#23127)
into `@elizaos/shared/canonical-json`, parameterized on the only two things the
call sites legitimately disagree about — the budgets, and how a sparse array
hole is rendered — and routes **all four** call sites through it. One shared
implementation replaces four; the net diff removes more lines than it adds
outside the new module.

The walk keeps every property #23127 was reviewed for:

- **descriptor-only reflection** — `Reflect.ownKeys` plus exactly one
  `getOwnPropertyDescriptor` per key; an enumerable getter is never invoked and
  a `Proxy` cannot serve two different descriptors to two reads;
- **breadth charged before allocation** — a wide object or hostile `ownKeys`
  trap is rejected on the key list alone, before any descriptor read, before the
  snapshot array, before the `O(n log n)` sort;
- **path-local cycle detection** — `visiting` is popped in a `finally`, so an
  honest shared reference (a DAG) still hashes exactly as it did; only a true
  ancestor cycle fails closed;
- **typed rejection** — `ElizaError` with `code: CANONICAL_JSON_UNBOUNDED`,
  structural-only `context` (never a reflected property name — this runs on
  attacker-supplied payloads and the error reaches logs and API responses) and a
  preserved `cause`. `agent-export` keeps throwing its own `AgentExportError`
  with the same `AGENT_EXPORT_CANONICALIZE_UNBOUNDED` code, via an
  `onUnbounded` hook, so nothing that catches it today changes.

It adds one budget #23127 did not have: an optional **output-character
ceiling**. Path-local cycle detection is required for DAG compatibility, but a
shared-reference graph still expands exponentially when flattened to a tree —
40 doubling levels is a few hundred bytes of input and a terabyte of canonical
text. Depth and node budgets do not bound that; an output budget does.

Budget choices for the backup sites are deliberately **unreachable by honest
data**: `maxDepth: 64` (the export walk's value), and node/output ceilings
pinned to `MAX_RESTORABLE_AGENT_BACKUP_BYTES`. Every JSON node costs at least
one character in the canonical form, so no state the restore path is willing to
accept can reach either ceiling — which is the property that matters here,
because over-rejecting a legitimate state would break the backups already
stored for it.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue), plus the de-duplication that
makes the fix a single logical unit instead of three near-identical patches.

# Documentation changes needed?

My changes do not require a change to the project documentation. The new module
carries its own rationale in its header comment, and the two behavioural
contracts a future caller can get wrong (`sparseArrayHoles`, and why the budgets
are pinned to the restore ceiling) are documented on the options themselves.

# Testing

## Where should a reviewer start?

`packages/shared/src/canonical-json.test.ts` — specifically the
`canonical JSON compatibility with the unbounded predecessor` block. It keeps a
verbatim copy of the recursion this PR deletes and asserts byte-identical output
across the corpus. That block failing is what "this PR broke existing backups"
would look like.

Then `packages/cloud/shared/src/lib/services/agent-backup-diff.canonicalize-bound.test.ts`
and `packages/agent/src/services/agent-backup.canonicalize-bound.test.ts` for the
live crash → typed rejection at each site.

## Detailed testing steps

### 1. Reproduction on origin `develop` (before the fix)

Checked out `origin/develop` @ `ceb82a4703273ffee12e43ff6cf246f3f4d8bfeb`, real
modules, no mocks.

`agent-backup-diff.ts` (`bun run`, importing `computeStateHash` /
`diffBackupState` / `emptyBackupState` by path):

```text
computeStateHash(deep 60k):     CRASH RangeError: Maximum call stack size exceeded.
computeStateHash(cyclic):       CRASH RangeError: Maximum call stack size exceeded.
diffBackupState(deep 60k):      CRASH RangeError: Maximum call stack size exceeded.
diffBackupState(cyclic):        CRASH RangeError: Maximum call stack size exceeded.
computeStateHash(honest DAG):   OK 6f50203da7b3071f
```

`agent-backup.ts`, driven through the **exported** `restoreAgentSnapshot` →
`assertManifest` integrity gate with attacker-shaped
`manifest.integrity.componentHashes`:

```text
restoreAgentSnapshot(componentHashes deep 60k): RangeError: Maximum call stack size exceeded.
restoreAgentSnapshot(componentHashes cyclic):   RangeError: Maximum call stack size exceeded.
restoreAgentSnapshot(honest componentHashes):   Error: Backup manifest component hash index is inconsistent
```

The honest case already produces the typed rejection; only the malformed ones
overflow — i.e. the gate works except on exactly the inputs it exists for.

### 2. The same scripts after the fix

```text
computeStateHash(deep 60k):     CRASH ElizaError: Payload exceeds the canonical JSON walk budget
computeStateHash(cyclic):       CRASH ElizaError: Payload exceeds the canonical JSON walk budget
diffBackupState(deep 60k):      CRASH ElizaError: Payload exceeds the canonical JSON walk budget
diffBackupState(cyclic):        CRASH ElizaError: Payload exceeds the canonical JSON walk budget
computeStateHash(honest DAG):   OK 6f50203da7b3071f      <- byte-identical digest

restoreAgentSnapshot(componentHashes deep 60k): ElizaError: Payload exceeds the canonical JSON walk budget
restoreAgentSnapshot(componentHashes cyclic):   ElizaError: Payload exceeds the canonical JSON walk budget
restoreAgentSnapshot(honest componentHashes):   Error: Backup manifest component hash index is inconsistent
```

The honest-DAG digest prefix is unchanged (`6f50203da7b3071f`) and the honest
manifest still gets its ordinary domain error, not a walk-budget error.

### 3. No over-rejection (the compatibility obligation)

`packages/shared/src/canonical-json.test.ts` asserts
`stableJsonString(v, AGENT_BACKUP_CANONICAL_JSON) === JSON.stringify(legacyCanonicalize(v))`
for a 28-case corpus, where `legacyCanonicalize` is a verbatim copy of the
deleted recursion. Named cases include `Date`/`Map`/`Set` values,
null-prototype objects, symbol keys, non-enumerable own properties,
`undefined`/function/symbol values in both object and array position, sparse
holes, negative zero, `NaN`/`Infinity`, astral strings, a 2 000-key wide object,
a 5 000-entry memory log, a depth-55 honest state, an object reached down three
branches (a DAG), and the same object repeated inside one array.

`agent-backup-diff.canonicalize-bound.test.ts` repeats the check at the site
level against a locally recomputed **sha256 of the legacy canonical bytes**, so
`computeStateHash` itself is pinned, not just the string helper.

### 4. Load-bearing check (revert-by-copy-aside, never `git stash`)

The three modified sources were copied aside and restored to their `develop`
contents; the new tests were re-run and **fail**; the sources were restored and
they pass again.

```text
# fix reverted
bun test src/lib/services/agent-backup-diff.canonicalize-bound.test.ts
  -> 3 pass, 3 fail   (RangeError: Maximum call stack size exceeded at agent-backup-diff.ts:84)

vitest run src/services/agent-backup.canonicalize-bound.test.ts
  -> 2 passed | 2 failed
     AssertionError: expected RangeError: Maximum call stack size excee… to be an instance of ElizaError

# fix restored
bun test agent-backup-diff.test.ts agent-backup-diff.canonicalize-bound.test.ts
  -> 39 pass, 0 fail
vitest run <6 agent export/backup suites>
  -> 6 passed (6) | 71 passed (71)
```

### 5. Suites, typecheck and lint

```text
packages/shared     node ../scripts/run-vitest.mjs run --config ./vitest.config.ts src/canonical-json.test.ts
                    -> Test Files 1 passed (1) | Tests 49 passed (49)

packages/cloud/shared
                    bun test src/lib/services/agent-backup-diff.test.ts \
                             src/lib/services/agent-backup-diff.canonicalize-bound.test.ts
                    -> 39 pass, 0 fail, 62 expect() calls

packages/agent      vitest run agent-export.canonicalize-bound / agent-export.roundtrip /
                                agent-export.media / agent-export.password /
                                agent-backup / agent-backup.canonicalize-bound
                    -> Test Files 6 passed (6) | Tests 71 passed (71)
```

`typecheck`, each compared against the same command on an untouched control tree
(the branch's own changes reverted), so the added-error count is stated rather
than guessed:

```text
packages/shared        control 1 pre-existing error   branch 1   -> +0
packages/agent         control 10 pre-existing errors branch 10  -> +0
packages/cloud/shared  control 2 pre-existing errors  branch 2   -> +0
```

None of the pre-existing errors is in a file this PR touches
(`todo-cutover.ts`, `chat-routes.ts`, `registry-routes.ts`,
`optional-plugin-imports.generated.ts`, `character-history.test.ts`,
`push-schema-for-tests.ts`, `conversation-coordinator.ts`, and two absent
optional plugin packages).

```text
bunx @biomejs/biome check <the 8 touched files>
  -> Checked 8 files in 77ms. No fixes applied.
```

# Evidence Gate

<!-- evidence-head:fffe651bacdd603096aacddd774827066e9e7488 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface. The diff is three service modules plus one new pure
      module in packages/shared; nothing rendered changes.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface, as above.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow. The observable behaviour is an uncaught
      RangeError becoming a typed ElizaError, shown as command output in
      Detailed testing steps sections 1 and 2.`
<!-- evidence-row:backend-logs -->
- [x] Real code-path output, same scripts against `origin/develop` and against
      this branch, importing the real modules (these are pure hash helpers, so
      they throw rather than emit `[ClassName]` logger lines):

      ```text
      # origin/develop ceb82a4703273ffee12e43ff6cf246f3f4d8bfeb
      computeStateHash(deep 60k):     CRASH RangeError: Maximum call stack size exceeded.
      computeStateHash(cyclic):       CRASH RangeError: Maximum call stack size exceeded.
      diffBackupState(deep 60k):      CRASH RangeError: Maximum call stack size exceeded.
      diffBackupState(cyclic):        CRASH RangeError: Maximum call stack size exceeded.
      restoreAgentSnapshot(componentHashes deep 60k): RangeError: Maximum call stack size exceeded.
      restoreAgentSnapshot(componentHashes cyclic):   RangeError: Maximum call stack size exceeded.

      # this branch fffe651bacdd603096aacddd774827066e9e7488
      computeStateHash(deep 60k):     CRASH ElizaError: Payload exceeds the canonical JSON walk budget
      computeStateHash(cyclic):       CRASH ElizaError: Payload exceeds the canonical JSON walk budget
      diffBackupState(deep 60k):      CRASH ElizaError: Payload exceeds the canonical JSON walk budget
      diffBackupState(cyclic):        CRASH ElizaError: Payload exceeds the canonical JSON walk budget
      restoreAgentSnapshot(componentHashes deep 60k): ElizaError: Payload exceeds the canonical JSON walk budget
      restoreAgentSnapshot(componentHashes cyclic):   ElizaError: Payload exceeds the canonical JSON walk budget
      ```
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response is involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt or model behaviour changes. No
      model is called anywhere on this diff.`
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifacts on this path are the backup digests themselves. The
      honest state and the honest manifest keep exactly the results they had
      before, on both trees:

      ```text
      # origin/develop ceb82a4703273ffee12e43ff6cf246f3f4d8bfeb
      computeStateHash(honest DAG):                  OK 6f50203da7b3071f
      restoreAgentSnapshot(honest componentHashes):  Error: Backup manifest component hash index is inconsistent

      # this branch fffe651bacdd603096aacddd774827066e9e7488
      computeStateHash(honest DAG):                  OK 6f50203da7b3071f
      restoreAgentSnapshot(honest componentHashes):  Error: Backup manifest component hash index is inconsistent

      # digest compatibility pinned in-suite against a recomputed sha256 of the
      # legacy canonical bytes, plus the 28-case byte-identity corpus
      bun test agent-backup-diff.test.ts agent-backup-diff.canonicalize-bound.test.ts -> 39 pass, 0 fail
      vitest run packages/shared src/canonical-json.test.ts                           -> 49 passed
      ```
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface on this diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - this diff contains no agent/action/provider/prompt/model change; no
scenario exercises it and a live-model run would prove nothing about a JSON
canonicalizer.`

## Backend + frontend logs

Backend: see **Detailed testing steps** §1 and §2 — the before/after output of
the two reproduction scripts against the real modules, plus the suite output in
§4 and §5.

Frontend: `N/A - no frontend surface.`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface.`

### After

`N/A - no UI surface.`

### Walkthrough video

`N/A - no user-facing flow; the behaviour change is an error type, shown as
command output above.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT or omnivoice surface on this diff.`

## Known gaps / failures

1. **`bun run verify` (monorepo-wide) was not run.** This is a fork checkout
   with a shared, partially stale install; the full verify pipeline builds every
   package and does not complete in this environment. What was run instead is
   listed with real output in §4 and §5: the focused suites for all three
   affected packages, `typecheck` per package against an untouched control, and
   biome on every touched file. Hosted CI does not run on fork PRs for this
   repo, so no hosted check is claimed either.

2. **`packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts`
   could not be executed locally, on this branch or on `develop`.** Its import
   graph reaches `plugins/plugin-sql`, which imports `redactConnectorJsonAudit`
   from `@elizaos/core`; that symbol is not exported from any `@elizaos/core`
   barrel at this head, so the suite aborts before collection:

   ```text
   SyntaxError: Export named 'redactConnectorJsonAudit' not found in module
     .../packages/core/dist/node/index.node.js
   ```

   Confirmed identical with this PR's changes reverted, so it is pre-existing
   and unrelated. The verifier's `sha256Json` change is therefore covered by the
   shared module's 49-test suite (same code path, same options object) and by
   `packages/cloud/shared` `typecheck`, not by its own suite. Flagging it rather
   than claiming a run I did not get.

3. **`decryptLocalBackupEnvelope` still hashes before `assertManifest`
   validates.** This PR deliberately does not reorder those two statements. With
   the walk bounded, both orderings now produce a typed, catchable error instead
   of an overflow, and `assertManifest` itself canonicalizes attacker-supplied
   `componentHashes`, so reordering would not remove the untrusted-input hash —
   it would only change which error a malformed backup reports. That is a
   separate behavioural decision and does not belong in a bounding fix.

4. **`agent-export.ts`'s budgets are unchanged** (`maxNodes: 100_000`, no output
   ceiling), and its sparse-hole rendering stays `"omit"`. Both are what #23127
   published digests against; changing either here would move export digests for
   no reason connected to this bug.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JEP4CAFEVDCQDJSK93YEPC","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T15:23:00.363Z","completed_at":"2026-08-21T15:24:31.540Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T15:23:00.961Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"4fa2db1f475a92faf37fc789c3227228ddafce066b63501238875dc5235db143","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"469b1050-4361-4b9d-bff4-6d7ddf68aa30","object_id":"sha256:4fa2db1f475a92faf37fc789c3227228ddafce066b63501238875dc5235db143","sha256":"4fa2db1f475a92faf37fc789c3227228ddafce066b63501238875dc5235db143"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"qXM_7oIa2vYIz2VWNp9sNtQ0hye3kBQMK3vQNKiLnA4v0tfCcgHjeuaS3BxI4lAB246S608sGN8mIytBLMg8Bw"}} -->
