### PR TITLE
fix(telegram): bound reaction callback replies

### DIFF
--- a/plugins/plugin-telegram/src/messageManager.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.test.ts
@@ -56,6 +56,45 @@ function createManager() {
   };
 }
 
+async function captureReactionCallback() {
+  const emitEvent = vi.fn();
+  const reply = vi.fn(async (text: string) => ({
+    message_id: 100,
+    date: 1_700_000_000,
+    text,
+    chat: { id: 123, type: "private" },
+  }));
+  const manager = new MessageManager(
+    {} as never,
+    { agentId: "agent-1", emitEvent } as unknown as IAgentRuntime,
+  );
+
+  await manager.handleReaction({
+    from: { id: 42, first_name: "Ada", is_bot: false },
+    chat: { id: 123, type: "private" },
+    update: {
+      message_reaction: {
+        chat: { id: 123, type: "private" },
+        message_id: 99,
+        date: 1,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: "👍" }],
+      },
+    },
+    reply,
+  } as never);
+
+  expect(emitEvent).toHaveBeenCalledTimes(2);
+  const payload = emitEvent.mock.calls[0]?.[1] as
+    | { callback?: (content: { text?: string }) => Promise<unknown> }
+    | undefined;
+  expect(payload?.callback).toBeTypeOf("function");
+  if (!payload?.callback) {
+    throw new Error("expected the reaction event to expose its reply callback");
+  }
+  return { callback: payload.callback, reply };
+}
+
 describe("MessageManager long message splitting", () => {
   it("sends interaction-only replies with fallback text and inline keyboard", async () => {
     const { manager, sendMessage } = createManager();
@@ -490,6 +529,33 @@ describe("MessageManager malformed payload handling", () => {
 
     expect(emitEvent).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["lone high surrogate", `before\ud800after`, "before�after"],
+    ["lone low surrogate", `before\udc00after`, "before�after"],
+    ["exact 4096-unit text", `${"a".repeat(4094)}🦊`, `${"a".repeat(4094)}🦊`],
+    ["4097-unit text", "a".repeat(4097), "a".repeat(4096)],
+    [
+      "astral character crossing the cap",
+      `${"a".repeat(4095)}🦊tail`,
+      "a".repeat(4095),
+    ],
+  ])(
+    "normalizes the reaction callback wire reply for %s",
+    async (_label, input, expected) => {
+      const { callback, reply } = await captureReactionCallback();
+
+      await callback({ text: input });
+
+      expect(reply).toHaveBeenCalledTimes(1);
+      const wireText = reply.mock.calls[0]?.[0];
+      // This observes the production callback argument, so restoring the raw
+      // `ctx.reply(content.text)` path breaks the malformed/over-limit cases.
+      expect(wireText).toBe(expected);
+      expect(wireText?.length).toBeLessThanOrEqual(4096);
+      expect(wireText?.isWellFormed()).toBe(true);
+    },
+  );
 
   it("rejects missing chat context when sending media", async () => {
     const manager = new MessageManager(

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -33,6 +33,7 @@ import {
   type ResolvedAttachmentBytes,
   resolveAttachmentBytes,
   ServiceType,
+  toWellFormedUnicode,
   truncateWellFormed,
   type UUID,
 } from "@elizaos/core";
@@ -2319,8 +2320,10 @@ export class MessageManager {
       // Create callback for handling reaction responses
       const callback: HandlerCallback = async (content: Content) => {
         try {
-          // Add null check for content.text
-          const replyText = content.text ?? "";
+          const replyText = truncateWellFormed(
+            toWellFormedUnicode(content.text ?? ""),
+            MAX_MESSAGE_LENGTH,
+          );
           const sentMessage = await ctx.reply(replyText);
           const responseMemory: Memory = {
             id: createUniqueUuid(


### PR DESCRIPTION
# Relates to

Closes #23765.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      baseline failure is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      focused Vitest artifact and reproduction steps below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@f556c9003007c0423fac0755729228d1221542b2:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@680e0a9d385d329e340411440902ff9c5e51866a`; zero conflicts.
- [x] `bun run verify` was run post-sync. It stops at the pre-existing i18n gate
      failure reproduced on pristine `origin/develop`; details are below.

# Risks

Low. The change is limited to the reaction-event callback's outbound text. It
normalizes lone UTF-16 surrogates and truncates at Telegram's existing 4096-unit
limit. It intentionally does not change navigation, command replies, or the
plugin's chunking policy.

# Background

## What does this PR do?

Routes agent-generated reaction callback replies through the shared
`toWellFormedUnicode` and `truncateWellFormed(..., 4096)` helpers before
`ctx.reply`. Production-path regression tests cover lone high/low surrogates,
the exact cap, cap + 1, and an astral character crossing the cap.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores the already documented Telegram output boundary contract and
does not add or change a user-facing option.

# Testing

## Where should a reviewer start?

`plugins/plugin-telegram/src/messageManager.ts`, in the callback created by
`handleReaction`, then the table-driven regression in
`plugins/plugin-telegram/src/messageManager.test.ts`.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-telegram test
bun run --cwd plugins/plugin-telegram typecheck
bun run --cwd plugins/plugin-telegram build
bun run --cwd plugins/plugin-telegram lint:check
```

Observed post-rebase:

- plugin tests: 24 files, 238 tests passed;
- focused `messageManager.test.ts`: 33 tests passed, including all five new boundary cases;
- typecheck: passed;
- build: passed;
- Biome lint: passed;
- `git diff --check`: passed.

# Evidence Gate

<!-- evidence-head:9bbc4ef44e3e0c0b9d36414ae1ac2e4c434b78b9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a headless Telegram transport-boundary fix with no visual flow.
<!-- evidence-row:backend-logs -->
- [x] [23818-23765-telegram-message-manager-vitest.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23818-23765-telegram-message-manager-vitest.json)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, console, or network request changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory schema, schedule, wallet, generated media, or other domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - the change sanitizes and bounds already-produced text at the Telegram wire
boundary; it does not alter LLM behavior.

## Backend + frontend logs

The focused machine-readable Vitest report is attached in the evidence row. The
test invokes the actual callback emitted by `handleReaction` and inspects the
actual argument delivered to `ctx.reply`; restoring the raw reply makes four of
the five boundary rows fail.

Frontend logs: N/A - no frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT path changed.

## Known gaps / failures

- `bun run verify` stops at `check:i18n`: `en.json` is missing seven connector
  account keys and non-English locale files are missing hundreds of existing
  keys. The same failure was reproduced in a temporary pristine worktree at
  `origin/develop@680e0a9d385d329e340411440902ff9c5e51866a`; that baseline worktree
  was deleted immediately.
- The filtered Turbo typecheck's Core prebuild reached its package-contract step
  but the local mise installation caused Node to parse mise's shell `npm` wrapper
  (`SyntaxError: Unexpected identifier 'pipefail'`). After Core's artifacts were
  produced and `@elizaos/plugin-commands` was built, the owning plugin's direct
  `tsc --noEmit -p tsconfig.json` passed. This is local toolchain plumbing, not a
  source failure.
- No live Telegram credential/network call was used. The regression instead
  traverses the real `handleReaction` callback seam with a mocked wire boundary.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@f556c9003007c0423fac0755729228d1221542b2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [/root/issue23765-telegram-reaction]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@f556c9003007c0423fac0755729228d1221542b2:packages/skills/skills/contribute-to-eliza"} -->

