### PR TITLE
fix(personal-assistant): keep surrogate pairs intact in background planner error truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/background-planner.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/background-planner.surrogate.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { planJob, BackgroundPlannerError } from "./background-planner.ts";
+
+const isWellFormed = (value: string) =>
+  (value as unknown as { isWellFormed(): boolean }).isWellFormed?.() ?? true;
+
+describe("background-planner surrogate truncation", () => {
+  it("surrogate-safe truncates unparsable planner output", async () => {
+    const runtime = {
+      useModel: async () =>
+        `${"a".repeat(199)}🦊${"b".repeat(200)}`,
+    } as any;
+
+    await expect(
+      planJob(runtime, {
+        jobKind: "TEST" as any,
+        channel: "test",
+        prompt: "x",
+      }),
+    ).rejects.toThrow((err: BackgroundPlannerError) => {
+      const message = err.message;
+      expect(isWellFormed(message)).toBe(true);
+      expect(message.length).toBeLessThanOrEqual(220);
+      return true;
+    });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/background-planner.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/background-planner.ts
@@ -82,6 +82,8 @@ import {
   ModelType,
   parseJsonModelRecord,
   runWithTrajectoryPurpose,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import type {
   ApprovalAction,
@@ -548,7 +550,7 @@ export async function planJob(
   if (!parsed) {
     throw new BackgroundPlannerError(
       jobContext.jobKind,
-      `planner returned unparsable output: ${raw.slice(0, 200)}`,
+      `planner returned unparsable output: ${truncateWellFormed(toWellFormedUnicode(raw), 200)}`,
     );
   }
 


### PR DESCRIPTION
Closes #23730

Background-planner unparsable-output error now sanitizes lone surrogates
and truncates at 200 via truncateWellFormed(toWellFormedUnicode(...),200).

- plugins/plugin-personal-assistant/src/lifeops/background-planner.ts
- plugins/plugin-personal-assistant/src/lifeops/background-planner.surrogate.test.ts: regression coverage