### PR TITLE
fix(cloud): compose the hop deadline with caller abort signals in four wrappers

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/alerts.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/alerts.test.ts
@@ -1,6 +1,7 @@
 // Pins the bounded-delivery contract of the cloud alert senders: every
 // webhook / API hop fails closed at the alert timeout instead of pinning the
-// alert worker forever, and a caller-provided abort signal wins.
+// alert worker forever, and a caller-provided signal is composed with that
+// deadline rather than replacing it.
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { alertFetch } from "./alerts";
 
@@ -30,7 +31,7 @@ describe("alertFetch — bounded hops fail closed and keep caller signals", () =
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
-  test("preserves a caller-provided abort signal", async () => {
+  test("composes a caller-provided abort signal with the deadline", async () => {
     let seen: AbortSignal | undefined;
     globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
       seen = init?.signal;
@@ -41,6 +42,66 @@ describe("alertFetch — bounded hops fail closed and keep caller signals", () =
     await alertFetch("https://hooks.example/alert", {
       signal: controller.signal,
     });
-    expect(seen).toBe(controller.signal);
+    // The wrapper owns the deadline, so the transport receives a composition of
+    // the caller signal and that deadline, never the caller object itself.
+    expect(seen).not.toBe(controller.signal);
+    expect(seen?.aborted).toBe(false);
+  });
+
+  test("still aborts at the deadline when the caller signal never fires", async () => {
+    // Regression: the wrapper used to read `init?.signal ?? AbortSignal.timeout(ms)`,
+    // so any caller signal REPLACED the deadline. A request-scoped controller
+    // that outlives this hop and is never aborted then left the hop unbounded —
+    // it stayed hung well past 10x the declared deadline against a real
+    // non-responding socket.
+    // Mirrors real fetch: the only way out is the signal firing, and the
+    // rejection carries the signal's own reason, so the assertion below can
+    // tell the wrapper's deadline (TimeoutError) from any other abort.
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              init.signal?.reason ?? new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    ) as typeof fetch;
+
+    const caller = new AbortController();
+    // Raced against a watchdog rather than awaited directly: an unbounded hop
+    // never settles, so a regression has to surface as a failed assertion here
+    // and not as a hung test file.
+    const outcome = await Promise.race([
+      alertFetch("https://hooks.example/alert", { signal: caller.signal }, 100).then(
+        () => "resolved",
+        (error: Error) => `aborted:${error.name}`,
+      ),
+      new Promise<string>((resolve) => setTimeout(() => resolve("STILL-HUNG"), 1_000)),
+    ]);
+    expect(outcome).toBe("aborted:TimeoutError");
+    expect(caller.signal.aborted).toBe(false);
+  });
+
+  test("still lets the caller abort early, ahead of the deadline", async () => {
+    // No over-rejection: composing must not cost the caller its own cancellation.
+    // Mirrors real fetch: the only way out is the signal firing, and the
+    // rejection carries the signal's own reason, so the assertion below can
+    // tell the wrapper's deadline (TimeoutError) from any other abort.
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              init.signal?.reason ?? new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    ) as typeof fetch;
+
+    const caller = new AbortController();
+    const pending = alertFetch("https://hooks.example/alert", { signal: caller.signal }, 60_000);
+    caller.abort();
+    await expect(pending).rejects.toThrow(/aborted/i);
   });
 });

--- a/packages/cloud/shared/src/lib/services/social-media/alerts.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/alerts.ts
@@ -5,17 +5,20 @@ const ALERT_REQUEST_TIMEOUT_MS = 15_000;
 
 /**
  * Bound every alert delivery hop so a hung or rate-limited webhook / API
- * cannot pin the alert worker indefinitely. A caller-provided abort signal
- * wins.
+ * cannot pin the alert worker indefinitely.
+ * A caller-provided signal is composed with the deadline rather than
+ * replacing it — a caller that cancels still aborts early, and a caller
+ * whose signal never fires still cannot outlive the bound.
  */
 export function alertFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
   timeoutMs: number = ALERT_REQUEST_TIMEOUT_MS,
 ): Promise<Response> {
+  const deadline = AbortSignal.timeout(timeoutMs);
   return fetch(input, {
     ...init,
-    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+    signal: init?.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
   });
 }
 

--- a/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.error-policy.test.ts
@@ -146,7 +146,7 @@ describe("blueskyFetch — bounded hops fail closed and keep caller signals", ()
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
-  it("preserves a caller-provided abort signal", async () => {
+  it("composes a caller-provided abort signal with the deadline", async () => {
     let seen: AbortSignal | undefined;
     globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
       seen = init?.signal;
@@ -157,6 +157,76 @@ describe("blueskyFetch — bounded hops fail closed and keep caller signals", ()
     await blueskyFetch("https://bsky.social/xrpc/com.atproto.server.createSession", {
       signal: controller.signal,
     });
-    expect(seen).toBe(controller.signal);
+    // The wrapper owns the deadline, so the transport receives a composition of
+    // the caller signal and that deadline, never the caller object itself.
+    expect(seen).not.toBe(controller.signal);
+    expect(seen?.aborted).toBe(false);
+  });
+
+  it("still aborts at the deadline when the caller signal never fires", async () => {
+    // Regression: the wrapper used to read `init?.signal ?? AbortSignal.timeout(ms)`,
+    // so any caller signal REPLACED the deadline. A request-scoped controller
+    // that outlives this hop and is never aborted then left the hop unbounded —
+    // it stayed hung well past 10x the declared deadline against a real
+    // non-responding socket.
+    // Mirrors real fetch: the only way out is the signal firing, and the
+    // rejection carries the signal's own reason, so the assertion below can
+    // tell the wrapper's deadline (TimeoutError) from any other abort.
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              init.signal?.reason ?? new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    ) as typeof fetch;
+
+    const caller = new AbortController();
+    // Raced against a watchdog rather than awaited directly: an unbounded hop
+    // never settles, so a regression has to surface as a failed assertion here
+    // and not as a hung test file.
+    const outcome = await Promise.race([
+      blueskyFetch(
+        "https://bsky.social/xrpc/com.atproto.server.createSession",
+        { signal: caller.signal },
+        100,
+      ).then(
+        () => "resolved",
+        (error: Error) => `aborted:${error.name}`,
+      ),
+      // `realSetTimeout`: this file's beforeEach collapses `globalThis.setTimeout`
+      // to fire synchronously so retry backoff does not slow the suite.
+      new Promise<string>((resolve) => realSetTimeout(() => resolve("STILL-HUNG"), 1_000)),
+    ]);
+    expect(outcome).toBe("aborted:TimeoutError");
+    expect(caller.signal.aborted).toBe(false);
+  });
+
+  it("still lets the caller abort early, ahead of the deadline", async () => {
+    // No over-rejection: composing must not cost the caller its own cancellation.
+    // Mirrors real fetch: the only way out is the signal firing, and the
+    // rejection carries the signal's own reason, so the assertion below can
+    // tell the wrapper's deadline (TimeoutError) from any other abort.
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              init.signal?.reason ?? new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    ) as typeof fetch;
+
+    const caller = new AbortController();
+    const pending = blueskyFetch(
+      "https://bsky.social/xrpc/com.atproto.server.createSession",
+      { signal: caller.signal },
+      60_000,
+    );
+    caller.abort();
+    await expect(pending).rejects.toThrow(/aborted/i);
   });
 });

--- a/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/bluesky.ts
@@ -27,16 +27,20 @@ const BLUESKY_REQUEST_TIMEOUT_MS = 30_000;
 
 /**
  * Bound every Bluesky / AT Protocol hop so a hung or rate-limited API cannot
- * pin the publishing worker indefinitely. A caller-provided abort signal wins.
+ * pin the publishing worker indefinitely.
+ * A caller-provided signal is composed with the deadline rather than
+ * replacing it — a caller that cancels still aborts early, and a caller
+ * whose signal never fires still cannot outlive the bound.
  */
 export function blueskyFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
   timeoutMs: number = BLUESKY_REQUEST_TIMEOUT_MS,
 ): Promise<Response> {
+  const deadline = AbortSignal.timeout(timeoutMs);
   return fetch(input, {
     ...init,
-    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+    signal: init?.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
   });
 }
 

--- a/packages/cloud/shared/src/lib/services/social-media/providers/slack.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/slack.error-policy.test.ts
@@ -197,7 +197,7 @@ describe("slackFetch — bounded hops fail closed and keep caller signals", () =
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
-  test("preserves a caller-provided abort signal", async () => {
+  test("composes a caller-provided abort signal with the deadline", async () => {
     let seen: AbortSignal | undefined;
     globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
       seen = init?.signal;
@@ -208,6 +208,70 @@ describe("slackFetch — bounded hops fail closed and keep caller signals", () =
     await slackFetch("https://slack.com/api/chat.postMessage", {
       signal: controller.signal,
     });
-    expect(seen).toBe(controller.signal);
+    // The wrapper owns the deadline, so the transport receives a composition of
+    // the caller signal and that deadline, never the caller object itself.
+    expect(seen).not.toBe(controller.signal);
+    expect(seen?.aborted).toBe(false);
+  });
+
+  test("still aborts at the deadline when the caller signal never fires", async () => {
+    // Regression: the wrapper used to read `init?.signal ?? AbortSignal.timeout(ms)`,
+    // so any caller signal REPLACED the deadline. A request-scoped controller
+    // that outlives this hop and is never aborted then left the hop unbounded —
+    // it stayed hung well past 10x the declared deadline against a real
+    // non-responding socket.
+    // Mirrors real fetch: the only way out is the signal firing, and the
+    // rejection carries the signal's own reason, so the assertion below can
+    // tell the wrapper's deadline (TimeoutError) from any other abort.
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              init.signal?.reason ?? new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    ) as typeof fetch;
+
+    const caller = new AbortController();
+    // Raced against a watchdog rather than awaited directly: an unbounded hop
+    // never settles, so a regression has to surface as a failed assertion here
+    // and not as a hung test file.
+    const outcome = await Promise.race([
+      slackFetch("https://slack.com/api/chat.postMessage", { signal: caller.signal }, 100).then(
+        () => "resolved",
+        (error: Error) => `aborted:${error.name}`,
+      ),
+      new Promise<string>((resolve) => setTimeout(() => resolve("STILL-HUNG"), 1_000)),
+    ]);
+    expect(outcome).toBe("aborted:TimeoutError");
+    expect(caller.signal.aborted).toBe(false);
+  });
+
+  test("still lets the caller abort early, ahead of the deadline", async () => {
+    // No over-rejection: composing must not cost the caller its own cancellation.
+    // Mirrors real fetch: the only way out is the signal firing, and the
+    // rejection carries the signal's own reason, so the assertion below can
+    // tell the wrapper's deadline (TimeoutError) from any other abort.
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(
+              init.signal?.reason ?? new DOMException("The operation was aborted.", "AbortError"),
+            );
+          });
+        }),
+    ) as typeof fetch;
+
+    const caller = new AbortController();
+    const pending = slackFetch(
+      "https://slack.com/api/chat.postMessage",
+      { signal: caller.signal },
+      60_000,
+    );
+    caller.abort();
+    await expect(pending).rejects.toThrow(/aborted/i);
   });
 });

--- a/packages/cloud/shared/src/lib/services/social-media/providers/slack.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/slack.ts
@@ -22,16 +22,20 @@ const SLACK_REQUEST_TIMEOUT_MS = 30_000;
 
 /**
  * Bound every Slack hop so a hung or rate-limited API cannot pin the
- * publishing worker indefinitely. A caller-provided abort signal wins.
+ * publishing worker indefinitely.
+ * A caller-provided signal is composed with the deadline rather than
+ * replacing it — a caller that cancels still aborts early, and a caller
+ * whose signal never fires still cannot outlive the bound.
  */
 export function slackFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
   timeoutMs: number = SLACK_REQUEST_TIMEOUT_MS,
 ): Promise<Response> {
+  const deadline = AbortSignal.timeout(timeoutMs);
   return fetch(input, {
     ...init,
-    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+    signal: init?.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
   });
 }
 

--- a/packages/cloud/shared/src/lib/services/vertex-tuning.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/vertex-tuning.error-policy.test.ts
@@ -87,7 +87,7 @@ describe("vertexTuningFetch — bounded hops fail closed and keep caller signals
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
-  test("preserves a caller-provided abort signal", async () => {
+  test("composes a caller-provided abort signal with the deadline", async () => {
     let seen: AbortSignal | undefined;
     globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
       seen = init?.signal;
@@ -98,6 +98,72 @@ describe("vertexTuningFetch — bounded hops fail closed and keep caller signals
     await vertexTuningFetch("https://aiplatform.googleapis.com/v1/jobs/x", {
       signal: controller.signal,
     });
-    expect(seen).toBe(controller.signal);
+    // The wrapper owns the deadline, so the transport receives a composition of
+    // the caller signal and that deadline, never the caller object itself.
+    expect(seen).not.toBe(controller.signal);
+    expect(seen?.aborted).toBe(false);
+  });
+
+  test("still aborts at the deadline when the caller signal never fires", async () => {
+    // Regression: the wrapper used to read `init?.signal ?? AbortSignal.timeout(ms)`,
+    // so any caller signal REPLACED the deadline. A request-scoped controller
+    // that outlives this hop and is never aborted then left the hop unbounded —
+    // it stayed hung well past 10x the declared deadline against a real
+    // non-responding socket.
+    // Mirrors real fetch: the only way out is the signal firing, and the
+    // rejection carries the signal's own reason, so the assertion below can
+    // tell the wrapper's deadline (TimeoutError) from any other abort.
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      return await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(
+            init.signal?.reason ?? new DOMException("The operation was aborted.", "AbortError"),
+          );
+        });
+      });
+    }) as typeof fetch;
+
+    const caller = new AbortController();
+    // Raced against a watchdog rather than awaited directly: an unbounded hop
+    // never settles, so a regression has to surface as a failed assertion here
+    // and not as a hung test file.
+    const outcome = await Promise.race([
+      vertexTuningFetch(
+        "https://aiplatform.googleapis.com/v1/jobs/x",
+        { signal: caller.signal },
+        100,
+      ).then(
+        () => "resolved",
+        (error: Error) => `aborted:${error.name}`,
+      ),
+      new Promise<string>((resolve) => setTimeout(() => resolve("STILL-HUNG"), 1_000)),
+    ]);
+    expect(outcome).toBe("aborted:TimeoutError");
+    expect(caller.signal.aborted).toBe(false);
+  });
+
+  test("still lets the caller abort early, ahead of the deadline", async () => {
+    // No over-rejection: composing must not cost the caller its own cancellation.
+    // Mirrors real fetch: the only way out is the signal firing, and the
+    // rejection carries the signal's own reason, so the assertion below can
+    // tell the wrapper's deadline (TimeoutError) from any other abort.
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      return await new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(
+            init.signal?.reason ?? new DOMException("The operation was aborted.", "AbortError"),
+          );
+        });
+      });
+    }) as typeof fetch;
+
+    const caller = new AbortController();
+    const pending = vertexTuningFetch(
+      "https://aiplatform.googleapis.com/v1/jobs/x",
+      { signal: caller.signal },
+      60_000,
+    );
+    caller.abort();
+    await expect(pending).rejects.toThrow(/aborted/i);
   });
 });

--- a/packages/cloud/shared/src/lib/services/vertex-tuning.ts
+++ b/packages/cloud/shared/src/lib/services/vertex-tuning.ts
@@ -9,16 +9,20 @@ const VERTEX_REQUEST_TIMEOUT_MS = 30_000;
 
 /**
  * Bound every Vertex AI REST hop so a hung or rate-limited API cannot pin the
- * tuning worker indefinitely. A caller-provided abort signal wins.
+ * tuning worker indefinitely.
+ * A caller-provided signal is composed with the deadline rather than
+ * replacing it — a caller that cancels still aborts early, and a caller
+ * whose signal never fires still cannot outlive the bound.
  */
 export function vertexTuningFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
   timeoutMs: number = VERTEX_REQUEST_TIMEOUT_MS,
 ): Promise<Response> {
+  const deadline = AbortSignal.timeout(timeoutMs);
   return fetch(input, {
     ...init,
-    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+    signal: init?.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
   });
 }
 


### PR DESCRIPTION
# Relates to

Fixes #23819

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (branched off `680e0a9d385d329e340411440902ff9c5e51866a`).
- [x] `bun install` was run after sync. `bun run verify` was **not** run
      monorepo-wide — see **Known gaps / failures**; the four focused suites, the
      package typecheck against an untouched control, and biome on all eight
      touched files were run and are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after real-socket measurements below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched off the latest `origin/develop` (`680e0a9d385d`); zero conflicts.
- [ ] `bun run verify` post-sync — not run monorepo-wide; the exact scope that
      was run, and why the wider run was skipped, is in **Known gaps / failures**.

# Risks

**Low.** Four one-line behavioural changes, each replacing `??` with the
`AbortSignal.any` composition this repository already merged for the sibling
wrappers. Nothing an ordinary caller observes changes: a call with no signal is
byte-identical in behaviour, a fast call is unaffected, and a caller that aborts
early still aborts early — all three are asserted, not argued (see *No
over-rejection*).

# Background

## What does this PR do?

Four `packages/cloud` fetch wrappers say in their own docblocks that a
caller-supplied `AbortSignal` is honoured *on top of* the wrapper's hop
deadline, and then implement the opposite:

```ts
signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
```

`??` short-circuits, so when the caller passes a signal the deadline object is
**never constructed**. A caller holding a request-scoped `AbortController` that
outlives the hop — the normal shape for a Cloud request handler — silently
removes the only bound the wrapper exists to provide.

| file:line | wrapper | declared bound |
|---|---|---|
| `services/social-media/providers/bluesky.ts:35` | `blueskyFetch` | 30 s |
| `services/social-media/providers/slack.ts:30` | `slackFetch` | 30 s |
| `services/social-media/alerts.ts:18` | `alertFetch` | 15 s |
| `services/vertex-tuning.ts:21` | `vertexTuningFetch` | 30 s |

This is two defects on one line, and both are worth stating.

The **behavioural** defect is an unbounded outbound hop: a hung upstream pins
the publishing worker (bluesky, slack), the alert worker (alerts), or the tuning
worker (vertex-tuning) with nothing to cancel it. The bluesky and slack hops sit
under `withRetry` (`social-media/rate-limit.ts`, `maxRetries = 3`), so one hung
instance is held four times over.

The **documentation** defect is that each wrapper's comment states a contract the
code does not implement. A reader auditing whether these hops are bounded reads
"A caller-provided abort signal wins" directly above `??` and concludes,
reasonably and wrongly, that they are. The comments now describe what the code
does, using the wording already merged on `services/seo.ts:26-31`.

## Why these four, and why one PR

These four are the exact residue of a repair this repository has already
accepted, twice.

- **#23517** (bluesky), **#23518** (slack), **#23510** (alerts) and **#23508**
  (vertex-tuning) introduced these wrappers with the `??` shape.
- **#23480** (discord), **#23695** (reddit) and **#23677** (six providers) then
  merged the compose follow-up, replacing `??` with an `AbortSignal.any`
  composition.

That follow-up did not reach these four. Their siblings in the same directory —
`providers/reddit.ts:32-35`, `providers/twitter.ts:29-32`,
`providers/tiktok.ts:32-35`, `utils/discord-api.ts:22-25` — already read the
composed form on `develop` today. So this is one logical unit: the same defect,
in the same family, closed with the same shape the maintainers already merged
three times. Filing it as four one-line PRs would be split-only work.

No new mechanism is introduced. The composition is copied verbatim from the
merged siblings rather than reinvented:

```ts
const deadline = AbortSignal.timeout(timeoutMs);
return fetch(input, {
  ...init,
  signal: init?.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
});
```

## The existing tests pinned the defect

Each of the four already had a sibling test asserting

```ts
expect(seen).toBe(controller.signal);
```

— i.e. the suite *required* the transport to receive the caller signal
unwrapped, which is exactly the broken behaviour. The repaired sibling
(`providers/reddit.error-policy.test.ts`) asserts `not.toBe`. These four could
not be fixed without correcting their tests, and as written those tests would
have rejected the accepted fix. This PR brings them onto the reddit shape and
adds the two cases that were missing.

## No over-rejection — proved, not asserted

This is the part worth checking hardest.

- **An early caller abort still wins.** Each suite has a case that calls the
  wrapper with a 60 s deadline, aborts the caller's controller immediately, and
  asserts the hop rejects. Composition must not cost the caller its
  cancellation.
- **Ordinary fast calls are unaffected.** The pre-existing "returns a normal
  response" case in each suite is untouched and still passes; the composed
  signal is asserted `aborted === false` on the successful path.
- **A call with no caller signal is unchanged.** The pre-existing "aborts a hung
  hop at the timeout" case in each suite passes with the same timing, and the
  real-socket control below measures it at 302 ms against a 300 ms deadline.
- **`caller.signal.aborted` stays `false`** when the deadline is what fired, so
  a caller can still distinguish its own cancellation from the hop timing out.
- The regression test asserts the abort reason is specifically a
  **`TimeoutError`**, not merely "something aborted" — a fix that dropped the
  caller signal instead of composing would abort too, and would not be caught by
  a weaker assertion.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue), plus the code-comment
correction described above.

# Documentation changes needed?

My changes do not require a change to the project documentation. The four
docblocks that were wrong are corrected in this diff.

# Testing

## Where should a reviewer start?

The four-line behavioural diff, then any one of the four suites — they are
identical in shape.

## Detailed testing steps

```bash
git fetch origin develop && git checkout <this branch>
bun install
bun run --cwd packages/cloud/shared test \
  src/lib/services/social-media/alerts.test.ts \
  src/lib/services/vertex-tuning.error-policy.test.ts \
  src/lib/services/social-media/providers/bluesky.error-policy.test.ts \
  src/lib/services/social-media/providers/slack.error-policy.test.ts
```

### 1. Origin reproduction — a real non-responding socket, no mocks

A real `http.createServer` that accepts the connection and never answers. The
declared deadline is 300 ms; the harness gives up at 3000 ms, ten times the
bound. Both arms import the **real exported wrappers**: the `ORIGIN` arm from
sidecar copies produced by `git show origin/develop:<file>` byte for byte, the
`FIXED` arm from this branch. The third column is the no-caller-signal control,
which this patch does not change.

```
$ WT=<worktree> bun repro-origin-compose-mine.ts

server: real http.createServer that never responds @ http://127.0.0.1:60315/hop
declared deadline 300ms; harness gives up at 3000ms (10x)

blueskyFetch       ORIGIN  3003ms -> STILL-HUNG   FIXED   302ms -> aborted:TimeoutError (no-signal control   303ms -> aborted:TimeoutError)
slackFetch         ORIGIN  3001ms -> STILL-HUNG   FIXED   301ms -> aborted:TimeoutError (no-signal control   302ms -> aborted:TimeoutError)
alertFetch         ORIGIN  3001ms -> STILL-HUNG   FIXED   303ms -> aborted:TimeoutError (no-signal control   302ms -> aborted:TimeoutError)
vertexTuningFetch  ORIGIN  3002ms -> STILL-HUNG   FIXED   303ms -> aborted:TimeoutError (no-signal control   302ms -> aborted:TimeoutError)
```

`STILL-HUNG` is not "slow" — it is the harness abandoning a hop that had no
deadline at all. The caller's controller in that run is never aborted, which is
precisely the case the `??` throws the deadline away for.

### 2. AFTER — the four suites

```
$ bun run --cwd packages/cloud/shared test \
    src/lib/services/social-media/alerts.test.ts \
    src/lib/services/vertex-tuning.error-policy.test.ts \
    src/lib/services/social-media/providers/bluesky.error-policy.test.ts \
    src/lib/services/social-media/providers/slack.error-policy.test.ts
bun test v1.3.14 (0d9b296a)

 33 pass
 0 fail
 64 expect() calls
Ran 33 tests across 4 files. [13.62s]
```

### 3. Load-bearing check — per call site, not per PR

Each production file was reverted **individually** to its `origin/develop` body
by copy-aside (never `git stash`), only that file's own suite was run, and the
file was restored before the next arm. A fix that only worked in aggregate would
show up here as a suite that stays green while its own wrapper is broken.

```
===== REVERT social-media/providers/bluesky.ts -> bun test providers/bluesky.error-policy.test.ts
(fail) blueskyFetch — … > composes a caller-provided abort signal with the deadline [0.36ms]
(fail) blueskyFetch — … > still aborts at the deadline when the caller signal never fires [1006.80ms]
 7 pass  2 fail   Ran 9 tests across 1 file.

===== REVERT social-media/providers/slack.ts -> bun test providers/slack.error-policy.test.ts
(fail) slackFetch — … > composes a caller-provided abort signal with the deadline [0.31ms]
(fail) slackFetch — … > still aborts at the deadline when the caller signal never fires [1003.69ms]
 9 pass  2 fail   Ran 11 tests across 1 file.

===== REVERT social-media/alerts.ts -> bun test social-media/alerts.test.ts
(fail) alertFetch — … > composes a caller-provided abort signal with the deadline [0.35ms]
(fail) alertFetch — … > still aborts at the deadline when the caller signal never fires [1003.21ms]
 2 pass  2 fail   Ran 4 tests across 1 file.

===== REVERT vertex-tuning.ts -> bun test vertex-tuning.error-policy.test.ts
(fail) vertexTuningFetch — … > composes a caller-provided abort signal with the deadline [0.35ms]
(fail) vertexTuningFetch — … > still aborts at the deadline when the caller signal never fires [1003.76ms]
 7 pass  2 fail   Ran 9 tests across 1 file.
```

Four call sites, four independent failures, and in every arm the *other* cases
in that suite stay green — the reverted behaviour is caught specifically.

Note the `~1004ms` figure on the deadline case: that assertion is written as a
race against a 1 s watchdog rather than a bare `await`, because an unbounded hop
never settles. A regression therefore surfaces as
`expect("STILL-HUNG").toBe("aborted:TimeoutError")` in about a second instead of
hanging the test file until the runner's own timeout. That was measured, not
assumed — the first draft of this test did hang.

### 4. Typecheck — zero errors added, measured against an untouched control

```
$ bun run --cwd packages/cloud/shared typecheck        # this branch
src/lib/services/shared-runtime/conversation-coordinator.ts(241,85): error TS2345: …
1 error

# control: the same tree with all eight touched files restored to origin/develop
$ bun run --cwd packages/cloud/shared typecheck
src/lib/services/shared-runtime/conversation-coordinator.ts(241,85): error TS2345: …
1 error
```

Identical. The single error is pre-existing, in a file this PR does not touch.

### 5. Biome

```
$ biome check <the 8 touched files>
Checked 8 files in 22ms. No fixes applied.
```

# Evidence Gate

<!-- evidence-head:ab88e5bd737ed21bda2c55e103f93f1d8f927571 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only change to four Cloud service modules; no rendered UI surface is touched by this diff.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only change to four Cloud service modules; no rendered UI surface is touched by this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the observable behaviour is whether an outbound hop terminates, shown as before/after wall-clock measurements against a real socket in Testing above.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — pasted below (the
      real exported wrappers driven against a real `http.createServer`, and the
      four real suites).

<details><summary>BEFORE — <code>origin/develop</code> bodies, real socket, caller signal present</summary>

```
server: real http.createServer that never responds @ http://127.0.0.1:60315/hop
declared deadline 300ms; harness gives up at 3000ms (10x)

blueskyFetch       ORIGIN  3003ms -> STILL-HUNG
slackFetch         ORIGIN  3001ms -> STILL-HUNG
alertFetch         ORIGIN  3001ms -> STILL-HUNG
vertexTuningFetch  ORIGIN  3002ms -> STILL-HUNG
```

</details>

<details><summary>AFTER — this branch, same socket, same driver</summary>

```
blueskyFetch       FIXED   302ms -> aborted:TimeoutError   (no-signal control 303ms -> aborted:TimeoutError)
slackFetch         FIXED   301ms -> aborted:TimeoutError   (no-signal control 302ms -> aborted:TimeoutError)
alertFetch         FIXED   303ms -> aborted:TimeoutError   (no-signal control 302ms -> aborted:TimeoutError)
vertexTuningFetch  FIXED   303ms -> aborted:TimeoutError   (no-signal control 302ms -> aborted:TimeoutError)

$ bun run --cwd packages/cloud/shared test <the four suites>
 33 pass
 0 fail
 64 expect() calls
Ran 33 tests across 4 files. [13.62s]
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path; these modules run server-side in Cloud only.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behaviour changes; this is an HTTP hop deadline composition.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB rows, memories, scheduled tasks, on-chain output, or generated files are produced or altered.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behaviour changes.`

## Backend + frontend logs

Backend: inline in **Testing → 1, 2, 3** (the real exported wrappers driven
against a real non-responding `http.createServer`, plus the four real suites and
the four per-call-site revert arms).

Frontend: `N/A - server-side modules.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT, or omnivoice surface.`

## Known gaps / failures

- **`bun run verify` was not run monorepo-wide.** It builds and tests the whole
  repository and is far beyond the blast radius of four one-line changes in four
  Cloud service modules. What was run instead, and passed, is recorded above: the
  four focused suites (33 pass / 0 fail), the four per-call-site revert arms, the
  `@elizaos/cloud-shared` typecheck against an untouched control, and biome on
  all eight touched files.
- **The repro harness is not part of this diff.** It is a standalone script that
  imports the real wrappers plus `git show origin/develop` sidecar copies; the
  sidecars were deleted before committing. The permanent regression coverage is
  the four suites.
- **`packages/core/src/i18n/generated/validation-keyword-data.ts` had to be
  generated** in the fresh worktree (`node packages/shared/scripts/generate-keywords.mjs`)
  before anything under `packages/cloud/shared` would import. It is a gitignored
  build artifact and is not in this diff.
- **Hosted CI checks do not run on this PR.** I contribute from a fork without
  push access to `elizaOS/eliza`, so no hosted check will report here. Every
  result above was produced locally and is reproducible with the commands given.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-mine-compose-deadlines]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JENEG9PQHXZ0VMYBRS7M7A","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T15:22:37.961Z","completed_at":"2026-08-21T15:38:19.860Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T15:22:38.924Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a91fbcad4853dc0151bc5211056c2c19294f3860aa808c4923e6159e9d132aa9","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"59452464-62f6-4676-b767-f9ffe150b856","object_id":"sha256:a91fbcad4853dc0151bc5211056c2c19294f3860aa808c4923e6159e9d132aa9","sha256":"a91fbcad4853dc0151bc5211056c2c19294f3860aa808c4923e6159e9d132aa9"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"jeuhBjJ5nt5kzfq9wWR9GncqGPW5b3HRTQBrQLxXC78P3eL_gqBDGNG1OxA64xNe6C7Th5PBKs9JGl42UCugBg"}} -->
