### PR TITLE
fix(core): cut trajectory field caps on UTF-8 character boundaries

### DIFF
--- a/packages/core/src/runtime/trajectory-recorder.surrogate.test.ts
+++ b/packages/core/src/runtime/trajectory-recorder.surrogate.test.ts
@@ -1,76 +1,292 @@
-/** Surrogate safety for trajectory recorder string truncation: must never emit lone surrogates. */
-import { describe, expect, test } from "vitest";
+/**
+ * Unicode integrity for trajectory recorder truncation, pinned against the
+ * REAL exports of `./trajectory-recorder.ts` (this file previously re-declared
+ * a local copy of the call site, so the production lines were unpinned).
+ *
+ * Two distinct cuts are covered:
+ *  - `applyTrajectoryFieldCap` cuts on a **UTF-8 byte** budget. Decoding a raw
+ *    byte slice substitutes U+FFFD REPLACEMENT CHARACTER for a straddled
+ *    multi-byte sequence, so the cut must land on a character boundary.
+ *  - `truncateRecordString` (reached through `encodeTrajectoryFieldValue`)
+ *    cuts on a **UTF-16 code unit** budget and must not split a surrogate pair.
+ */
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
-	toWellFormedUnicode,
-	truncateWellFormed,
-} from "../utils/well-formed.ts";
+	applyTrajectoryFieldCap,
+	captureSkillInvocationIO,
+	captureToolStageIO,
+	createJsonFileTrajectoryRecorder,
+	encodeTrajectoryFieldValue,
+	type RecordedStage,
+	type RecordedTrajectory,
+} from "./trajectory-recorder.ts";
 
+const TRUNCATION_SUFFIX = "...[truncated]";
+const SUFFIX_BYTES = Buffer.byteLength(TRUNCATION_SUFFIX, "utf8");
+const REPLACEMENT_CHARACTER = "�";
 const RECORD_SANITIZE_MAX_STRING_CHARS = 64 * 1024;
-const RECORD_SANITIZE_TRUNCATION_SUFFIX = "...[truncated]";
+
+const FOX = "\u{1F98A}"; // U+1F98A, 4 UTF-8 bytes / 2 UTF-16 code units
+const YEN = "¥"; // 2 UTF-8 bytes
+const EURO = "€"; // 3 UTF-8 bytes
 
 function isWellFormed(value: string): boolean {
-	if (!value) return true;
-	const maybe = value as unknown as { isWellFormed?: () => boolean };
-	if (typeof maybe.isWellFormed === "function") return maybe.isWellFormed();
-	return toWellFormedUnicode(value) === value;
+	return (value as unknown as { isWellFormed(): boolean }).isWellFormed();
 }
 
-function truncateRecordStringMock(value: string): string {
-	const wellFormed = toWellFormedUnicode(value);
-	if (wellFormed.length <= RECORD_SANITIZE_MAX_STRING_CHARS) return wellFormed;
-	const previewLength = Math.max(
-		0,
-		RECORD_SANITIZE_MAX_STRING_CHARS - RECORD_SANITIZE_TRUNCATION_SUFFIX.length,
-	);
-	return `${truncateWellFormed(wellFormed, previewLength)}${RECORD_SANITIZE_TRUNCATION_SUFFIX}`;
-}
+describe("applyTrajectoryFieldCap byte-budget truncation", () => {
+	test("a straddled astral character is dropped, never decoded to U+FFFD", () => {
+		// cap 17 => 3-byte slice budget, which lands 3 bytes into a 4-byte fox.
+		const { value, marker } = applyTrajectoryFieldCap(
+			"output",
+			FOX.repeat(50),
+			17,
+		);
+		expect(value).toBe(TRUNCATION_SUFFIX);
+		expect(value).not.toContain(REPLACEMENT_CHARACTER);
+		expect(marker).toEqual({
+			field: "output",
+			originalBytes: 200,
+			capBytes: 17,
+		});
+	});
 
-describe("trajectory recorder string surrogate safety", () => {
+	test("offset x cap sweep never emits U+FFFD, never exceeds the cap, stays well-formed", () => {
+		const offending: string[] = [];
+		for (let prefix = 0; prefix < 8; prefix++) {
+			for (let cap = 15; cap < 120; cap++) {
+				const input = `${"a".repeat(prefix)}${FOX.repeat(50)}`;
+				const { value } = applyTrajectoryFieldCap("input", input, cap);
+				if (
+					value.includes(REPLACEMENT_CHARACTER) ||
+					Buffer.byteLength(value, "utf8") > cap ||
+					!isWellFormed(value)
+				) {
+					offending.push(`prefix=${prefix} cap=${cap}`);
+				}
+			}
+		}
+		expect(offending).toEqual([]);
+	});
+
+	test("a whole astral character that still fits is kept intact", () => {
+		// cap 18 => 4-byte slice budget: exactly one fox fits.
+		const { value } = applyTrajectoryFieldCap("output", FOX.repeat(50), 18);
+		expect(value).toBe(`${FOX}${TRUNCATION_SUFFIX}`);
+		expect(Buffer.byteLength(value, "utf8")).toBe(18);
+	});
+
+	test("ASCII caps to the exact byte budget (no over-rejection)", () => {
+		for (const cap of [15, 16, 64, 256, 1024]) {
+			const { value } = applyTrajectoryFieldCap(
+				"output",
+				"a".repeat(4096),
+				cap,
+			);
+			expect(value).toBe(
+				`${"a".repeat(cap - SUFFIX_BYTES)}${TRUNCATION_SUFFIX}`,
+			);
+			expect(Buffer.byteLength(value, "utf8")).toBe(cap);
+		}
+	});
+
+	test("2-byte and 3-byte BMP text keeps every character that fits", () => {
+		for (let cap = 15; cap < 120; cap++) {
+			const budget = cap - SUFFIX_BYTES;
+
+			const yen = applyTrajectoryFieldCap("output", YEN.repeat(200), cap).value;
+			expect(yen).toBe(
+				`${YEN.repeat(Math.floor(budget / 2))}${TRUNCATION_SUFFIX}`,
+			);
+
+			const euro = applyTrajectoryFieldCap(
+				"output",
+				EURO.repeat(200),
+				cap,
+			).value;
+			expect(euro).toBe(
+				`${EURO.repeat(Math.floor(budget / 3))}${TRUNCATION_SUFFIX}`,
+			);
+		}
+	});
+
+	test("under-cap values pass through byte-identically with no marker", () => {
+		const input = `mixed ${YEN}${EURO}${FOX} text`;
+		const { value, marker } = applyTrajectoryFieldCap("input", input, 1024);
+		expect(value).toBe(input);
+		expect(marker).toBeNull();
+	});
+
+	test("a pre-existing lone surrogate becomes exactly one U+FFFD (encoding), and the cap adds none", () => {
+		// Buffer encoding of a lone surrogate already yields U+FFFD; the cap must
+		// not manufacture a second one at the boundary.
+		const input = `\ud800${FOX.repeat(50)}`;
+		for (let cap = 15; cap < 120; cap++) {
+			const { value } = applyTrajectoryFieldCap("output", input, cap);
+			expect(isWellFormed(value)).toBe(true);
+			expect(Buffer.byteLength(value, "utf8")).toBeLessThanOrEqual(cap);
+			expect(value.split(REPLACEMENT_CHARACTER).length - 1).toBeLessThanOrEqual(
+				1,
+			);
+		}
+	});
+});
+
+describe("capture seams inherit the byte-cap guarantee", () => {
+	test("captureToolStageIO caps input/output/error without corrupting them", () => {
+		const captured = captureToolStageIO({
+			input: FOX.repeat(400),
+			output: FOX.repeat(400),
+			error: FOX.repeat(400),
+			capBytes: 129,
+		});
+		for (const field of [captured.input, captured.output, captured.errorText]) {
+			expect(field).toBeDefined();
+			expect(field).not.toContain(REPLACEMENT_CHARACTER);
+			expect(isWellFormed(field as string)).toBe(true);
+			expect(Buffer.byteLength(field as string, "utf8")).toBeLessThanOrEqual(
+				129,
+			);
+		}
+		expect(captured.truncated).toHaveLength(3);
+	});
+
+	test("captureSkillInvocationIO caps args/result without corrupting them", () => {
+		const captured = captureSkillInvocationIO({
+			args: FOX.repeat(400),
+			result: FOX.repeat(400),
+			capBytes: 133,
+		});
+		for (const field of [captured.args, captured.result]) {
+			expect(field).not.toContain(REPLACEMENT_CHARACTER);
+			expect(isWellFormed(field as string)).toBe(true);
+			expect(Buffer.byteLength(field as string, "utf8")).toBeLessThanOrEqual(
+				133,
+			);
+		}
+		expect(captured.truncated?.map((m) => m.field).sort()).toEqual([
+			"args",
+			"result",
+		]);
+	});
+});
+
+describe("persisted trajectory JSON on disk", () => {
+	let tmpDir: string;
+	const originalLogging = process.env.ELIZA_TRAJECTORY_LOGGING;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "trajectory-surrogate-"));
+		// The unified recording gate (#13775) defaults OFF under NODE_ENV=test.
+		process.env.ELIZA_TRAJECTORY_LOGGING = "1";
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+		if (originalLogging === undefined) {
+			delete process.env.ELIZA_TRAJECTORY_LOGGING;
+		} else {
+			process.env.ELIZA_TRAJECTORY_LOGGING = originalLogging;
+		}
+	});
+
+	test("a capped tool-stage output is written to the file without U+FFFD", async () => {
+		const recorder = createJsonFileTrajectoryRecorder({ rootDir: tmpDir });
+		const id = recorder.startTrajectory({
+			agentId: "agent-surrogate",
+			roomId: "room-1",
+			rootMessage: { id: "msg-1", text: `hello ${FOX}`, sender: "user-1" },
+		});
+		// 1024-byte cap => 1010-byte slice budget, which lands 3 bytes into the
+		// 252nd fox: exactly the boundary that used to decode to U+FFFD.
+		const io = captureToolStageIO({
+			output: `aaa${FOX.repeat(300)}`,
+			capBytes: 1024,
+		});
+		const stage: RecordedStage = {
+			stageId: "stage-tool-WEB_SEARCH-1",
+			kind: "tool",
+			startedAt: 1,
+			endedAt: 2,
+			latencyMs: 1,
+			tool: {
+				name: "WEB_SEARCH",
+				args: {},
+				result: {},
+				success: true,
+				durationMs: 1,
+				output: io.output,
+				truncated: io.truncated,
+			},
+		};
+		await recorder.recordStage(id, stage);
+		await recorder.endTrajectory(id, "finished");
+
+		const raw = await fs.readFile(
+			path.join(tmpDir, "agent-surrogate", `${id}.json`),
+			"utf8",
+		);
+		expect(raw).not.toContain(REPLACEMENT_CHARACTER);
+		const parsed = JSON.parse(raw) as RecordedTrajectory;
+		const persisted = parsed.stages[0]?.tool?.output as string;
+		expect(persisted).toBeDefined();
+		expect(persisted).not.toContain(REPLACEMENT_CHARACTER);
+		expect(isWellFormed(persisted)).toBe(true);
+		expect(persisted.endsWith(`${FOX}${TRUNCATION_SUFFIX}`)).toBe(true);
+		expect(Buffer.byteLength(persisted, "utf8")).toBeLessThanOrEqual(1024);
+	});
+});
+
+describe("record-string truncation via encodeTrajectoryFieldValue", () => {
 	const targetPreview =
-		RECORD_SANITIZE_MAX_STRING_CHARS - RECORD_SANITIZE_TRUNCATION_SUFFIX.length;
+		RECORD_SANITIZE_MAX_STRING_CHARS - TRUNCATION_SUFFIX.length;
 
-	test("emoji at preview boundary backs off without lone surrogate", () => {
-		const input = `${"a".repeat(targetPreview - 1)}🦊${"b".repeat(1000)}`;
-		const out = truncateRecordStringMock(input);
-		expect(isWellFormed(out)).toBe(true);
-		expect(out.endsWith(RECORD_SANITIZE_TRUNCATION_SUFFIX)).toBe(true);
-		expect(out.length).toBe(
-			targetPreview - 1 + RECORD_SANITIZE_TRUNCATION_SUFFIX.length,
+	/** The recorder's 64K code-unit record cap, exercised through a real export. */
+	function truncatedRecordString(value: string): string {
+		const encoded = encodeTrajectoryFieldValue({ record: value });
+		return (JSON.parse(encoded) as { record: string }).record;
+	}
+
+	test("emoji at the preview boundary backs off without a lone surrogate", () => {
+		const out = truncatedRecordString(
+			`${"a".repeat(targetPreview - 1)}${FOX}${"b".repeat(1000)}`,
 		);
-		expect(() => JSON.stringify({ record: out })).not.toThrow();
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.endsWith(TRUNCATION_SUFFIX)).toBe(true);
+		expect(out.length).toBe(targetPreview - 1 + TRUNCATION_SUFFIX.length);
 	});
 
-	test("fitting emoji ending at preview boundary kept intact", () => {
-		const input = `${"a".repeat(targetPreview - 2)}🦊${"b".repeat(1000)}`;
-		const out = truncateRecordStringMock(input);
-		expect(isWellFormed(out)).toBe(true);
-		expect(out.endsWith(RECORD_SANITIZE_TRUNCATION_SUFFIX)).toBe(true);
-		expect(out.length).toBe(
-			targetPreview + RECORD_SANITIZE_TRUNCATION_SUFFIX.length,
+	test("an emoji that ends exactly on the preview boundary is kept intact", () => {
+		const out = truncatedRecordString(
+			`${"a".repeat(targetPreview - 2)}${FOX}${"b".repeat(1000)}`,
 		);
-	});
-
-	test("short record string with emoji passes through untouched", () => {
-		const input = "Step execution log with fox 🦊 emoji";
-		const out = truncateRecordStringMock(input);
 		expect(isWellFormed(out)).toBe(true);
-		expect(out).toBe(input);
+		expect(out.length).toBe(targetPreview + TRUNCATION_SUFFIX.length);
+		expect(out.endsWith(`${FOX}${TRUNCATION_SUFFIX}`)).toBe(true);
 	});
 
-	test("lone high surrogate is sanitized before truncation", () => {
-		const input = `bad \ud800 surrogate ${"x".repeat(70000)}`;
-		const out = truncateRecordStringMock(input);
+	test("a short record string with an emoji passes through untouched", () => {
+		const input = `Step execution log with fox ${FOX} emoji`;
+		expect(truncatedRecordString(input)).toBe(input);
+	});
+
+	test("a lone high surrogate is sanitized before truncation", () => {
+		const out = truncatedRecordString(
+			`bad \ud800 surrogate ${"x".repeat(70000)}`,
+		);
 		expect(isWellFormed(out)).toBe(true);
 		expect(out.includes("\ud800")).toBe(false);
-		expect(out.endsWith(RECORD_SANITIZE_TRUNCATION_SUFFIX)).toBe(true);
+		expect(out.endsWith(TRUNCATION_SUFFIX)).toBe(true);
 	});
 
-	test("sweep offsets around 64KB cap all stay well-formed", () => {
-		const fox = "🦊";
+	test("sweep of offsets around the 64K cap all stay well-formed", () => {
 		for (let offset = -5; offset <= 5; offset++) {
-			const n = targetPreview + offset;
-			const input = `${"a".repeat(n)}${fox}${"b".repeat(1000)}`;
-			const out = truncateRecordStringMock(input);
+			const out = truncatedRecordString(
+				`${"a".repeat(targetPreview + offset)}${FOX}${"b".repeat(1000)}`,
+			);
 			expect(isWellFormed(out)).toBe(true);
 			expect(() => JSON.stringify({ record: out })).not.toThrow();
 		}

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -969,6 +969,14 @@ const DEFAULT_FIELD_CAP_BYTES = 64 * 1024;
 const TRUNCATION_SUFFIX = "...[truncated]";
 
 /**
+ * UTF-8 continuation bytes are `0b10xxxxxx`. A byte cut that lands on one is
+ * mid-character; see {@link applyTrajectoryFieldCap}.
+ */
+function isUtf8ContinuationByte(byte: number): boolean {
+	return (byte & 0xc0) === 0x80;
+}
+
+/**
  * Resolve the per-field byte cap for `input` / `output` / `errorText`. The
  * recorder uses this for action-step capture (M12). Override with
  * `ELIZA_TRAJECTORY_FIELD_CAP_BYTES`; values below 1KB or non-integer are
@@ -1006,6 +1014,9 @@ export function encodeTrajectoryFieldValue(value: unknown): string {
  * string and `null` marker when no truncation is needed, or the truncated
  * preview plus a structured marker when the cap was exceeded.
  *
+ * The cut always lands on a UTF-8 character boundary, so the preview never
+ * gains a U+FFFD REPLACEMENT CHARACTER that the recorded agent did not emit.
+ *
  * The marker is the caller's responsibility to attach to the stage (see
  * `captureToolStageIO`).
  */
@@ -1021,15 +1032,27 @@ export function applyTrajectoryFieldCap(
 	const suffixBytes = Buffer.byteLength(TRUNCATION_SUFFIX, "utf8");
 	const sliceBudget = Math.max(0, capBytes - suffixBytes);
 	const buffer = Buffer.from(value, "utf8");
-	let preview = buffer.subarray(0, sliceBudget).toString("utf8");
-	// `toString("utf8")` discards trailing partial code points, but the
-	// resulting string can still encode to slightly more bytes than the
-	// slice budget after concatenation. Trim defensively until it fits.
+	// Node's UTF-8 decoder does NOT drop a trailing partial sequence: it
+	// substitutes U+FFFD REPLACEMENT CHARACTER for it. Decoding a raw byte
+	// slice therefore writes a character the agent never emitted into the
+	// persisted trajectory, and the `RecordedTruncationMarker` below reports
+	// only byte counts, so the corruption is served as a successful capture.
+	// Back the cut off to the start of the straddled character first so the
+	// decode is lossless for everything that survives the cap.
+	let end = Math.min(sliceBudget, buffer.length);
+	while (end > 0 && isUtf8ContinuationByte(buffer[end] ?? 0)) {
+		end--;
+	}
+	let preview = buffer.subarray(0, end).toString("utf8");
+	// Defence in depth: the boundary back-off above already keeps the preview
+	// within `sliceBudget`, but if that invariant ever regresses, trim through
+	// `truncateWellFormed` so shrinking can never split a surrogate pair the
+	// way a bare `preview.slice(0, -1)` would.
 	while (
 		Buffer.byteLength(preview, "utf8") + suffixBytes > capBytes &&
 		preview.length > 0
 	) {
-		preview = preview.slice(0, -1);
+		preview = truncateWellFormed(preview, preview.length - 1);
 	}
 	return {
 		value: `${preview}${TRUNCATION_SUFFIX}`,


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #23820 (owning issue, filed for this head, carrying both origin
reproductions verbatim).

Context — this is **not** a member of today's lone-surrogate family and does not
overlap it. Those PRs fix UTF-16 `.slice()` cuts that split a surrogate pair.
This one fixes a **UTF-8 byte** cut whose decode inserts
`U+FFFD REPLACEMENT CHARACTER`, in a different package
(`packages/core/src/runtime/trajectory-recorder.ts`) and a different function.
`gh search prs "applyTrajectoryFieldCap"` returns 0 results; no open PR touches
this file.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched off the latest `origin/develop`
      (`96d373a4388e5b9b149a0f509f43627244925c7d`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched off `origin/develop` @ `96d373a4388e5b9b149a0f509f43627244925c7d`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low, and the one risk axis — over-rejection — is settled by execution rather
than by argument.

One production function changes behaviour. A differential sweep against the
verbatim pre-fix body over **2702** (text, cap) pairs of ASCII, Latin-1, CJK,
Cyrillic, Greek, Hebrew, Arabic and mixed-BMP text found **0** differences: this
change is byte-identical for every input that has no astral character straddling
the cut. Over 386 astral caps, **96** differ, and every one of those 96
differences is *exactly one U+FFFD removed* — nothing else moves. Full transcript
in the domain receipt.

The residual defensive trim loop below the cut is now unreachable (the boundary
back-off already guarantees the budget). It is kept, routed through the existing
`truncateWellFormed` helper rather than a raw `preview.slice(0, -1)`, so that if
the invariant above it ever regresses the trim cannot itself manufacture a lone
surrogate. It is stated here as defence in depth, not claimed as load-bearing.

# Background

## What does this PR do?

`applyTrajectoryFieldCap` (`packages/core/src/runtime/trajectory-recorder.ts:1012`)
caps the recorded-IO fields `input` / `output` / `errorText` / `args` / `result`
on a **UTF-8 byte** budget by slicing a `Buffer` and decoding the slice:

```ts
let preview = buffer.subarray(0, sliceBudget).toString("utf8");
// `toString("utf8")` discards trailing partial code points, but the
// resulting string can still encode to slightly more bytes than the
// slice budget after concatenation. Trim defensively until it fits.
```

**That comment is factually wrong about Node**, and the fix is only half the
change — correcting it is the other half. `Buffer.prototype.toString("utf8")`
does not discard a trailing partial sequence: it substitutes
`U+FFFD REPLACEMENT CHARACTER` for it. So when the byte cap lands inside a
multi-byte character, the persisted trajectory field silently gains a character
the recorded agent never emitted, and the attached `RecordedTruncationMarker`
reports only `originalBytes` / `capBytes` — nothing that says the preview was
corrupted. Silent corruption served as a successful capture.

The comment is worth calling out on its own: it is an assertion about runtime
behaviour, it is wrong, and it sits directly above the line it excuses. A future
reader auditing this function reads it, believes the decode is lossless, and
moves on. That is plausibly how this survived a day on which ~80 truncation PRs
landed in this repository.

Why the trim loop below did not save it: a 4-byte astral character cut with 3
bytes retained decodes to a single U+FFFD, which is itself 3 bytes — so the
preview fits the budget exactly and the loop never runs. (For 2- and 3-byte BMP
characters the substitution is *larger* than the bytes it replaced, the loop
fires, and the U+FFFD is removed by accident. That is why the defect is
astral-only, and why this change is byte-identical for BMP text.)

**The fix:** back the cut off to the start of the straddled character before
decoding — UTF-8 continuation bytes are `0b10xxxxxx` — so the decode is lossless
for everything that survives the cap. No new truncator is introduced; the
residual trim reuses the repository's existing `truncateWellFormed`.

## Reach

`captureToolStageIO` → `packages/core/src/runtime/planner-loop.ts:3434`
(`recordToolStage`) and `packages/core/src/services/message.ts:9439`;
`captureSkillInvocationIO` → the USE_SKILL seam. The capped strings are the
model- and tool-produced text a trajectory reviewer, a replay, or a downstream
training pipeline reads back as the agent's actual IO.

## Why nothing caught it

`packages/core/src/runtime/trajectory-recorder.surrogate.test.ts` never imported
the module it names — zero references to `trajectory-recorder` — and asserted
against a locally re-declared `truncateRecordStringMock` instead. That mock also
mirrors a *different* cut (`truncateRecordString`, code-unit budgeted, already
correct), so the byte-budgeted `applyTrajectoryFieldCap` had no coverage at all.
`__tests__/trajectory-recorder.test.ts` does import the real export, but its two
cap cases use `"a".repeat(2048)` and `"z".repeat(200_000)` — pure ASCII, which
can never straddle a byte boundary.

That file is rewritten here to drive the real exports, including one case that
records a capped tool stage through `createJsonFileTrajectoryRecorder` and reads
the persisted JSON back off disk.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The in-code
comment that misdescribed Node's decoder is corrected as part of the diff.

# Testing

## Where should a reviewer start?

`packages/core/src/runtime/trajectory-recorder.surrogate.test.ts` — 15 tests, all
against the real exports:

1. a straddled astral character is dropped, never decoded to U+FFFD;
2. an 8×105 offset/cap sweep: no U+FFFD, never over the cap, always well-formed;
3. a whole astral character that still fits is kept intact;
4. **compatibility** — ASCII caps to the exact byte budget at 5 cap values;
5. **compatibility** — 2-byte and 3-byte BMP text keeps every character that
   fits, asserted as an exact string at 105 cap values;
6. under-cap values pass through byte-identically with no marker;
7. a pre-existing lone surrogate yields at most one U+FFFD (from encoding), and
   the cap adds none;
8. `captureToolStageIO` / `captureSkillInvocationIO` inherit the guarantee;
9. **the persisted `<root>/<agentId>/<id>.json` file contains no U+FFFD**;
10. the five pre-existing record-string cases, re-pointed at the real
    `encodeTrajectoryFieldValue` export instead of the local mock.

## Detailed testing steps

```
git checkout fix/trajectory-recorder-field-cap-codepoints
bun install --frozen-lockfile
(cd packages/core && node ../shared/scripts/generate-keywords.mjs)
bunx vitest run --root packages/core \
  src/runtime/trajectory-recorder.surrogate.test.ts \
  src/runtime/__tests__/trajectory-recorder.test.ts
bunx vitest run --root packages/core src/runtime
bun run --cwd packages/core typecheck
bunx @biomejs/biome check packages/core/src/runtime/trajectory-recorder.ts \
  packages/core/src/runtime/trajectory-recorder.surrogate.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:546f8ffeead230be2dabf52b27fb3268109cb902 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - core runtime module and its unit tests; no rendered UI surface in the diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - core runtime module and its unit tests; no rendered UI surface in the diff.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.

<!-- evidence-row:backend-logs -->
- [x] The corrupted value as it lands in the persisted trajectory file, captured on unmodified `origin/develop` @ `96d373a4388e5b9b149a0f509f43627244925c7d` by driving the real `createJsonFileTrajectoryRecorder` through `captureToolStageIO` and reading the written JSON back off disk:

```text
PERSISTED tail (last 24 chars): "\udd8a🦊🦊🦊🦊�...[truncated]"
PERSISTED codepoints at tail:
  U+DD8A U+1F98A U+1F98A U+FFFD U+002E U+002E U+002E U+005B U+0074 U+0072
  U+0075 U+006E U+0063 U+0061 U+0074 U+0065 U+0064 U+005D
marker: [{"field":"output","originalBytes":1203,"capBytes":1024}]

AssertionError: expected true to be false   (persisted.includes("�"))
```

The U+FFFD is in the file, and the marker beside it reports two byte counts and
nothing about corruption.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed. This fixes how already-produced model/tool text is *recorded*; a real LLM call would not distinguish the two bodies (the defect needs an astral character straddling a specific byte offset, which is why the deterministic sweep below is the honest instrument).

<!-- evidence-row:domain-artifacts -->
- [x] Origin reproduction (helper + persisted file), differential compatibility sweep, load-bearing revert check, focused suite, package suite with an untouched control, typecheck, and lint at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
head: 546f8ffeead230be2dabf52b27fb3268109cb902
base: 96d373a4388e5b9b149a0f509f43627244925c7d (origin/develop; reproduction ran
      on this same base, unmodified)

=== 1. ORIGIN REPRODUCTION — HELPER LEVEL ===

Probe src/runtime/zz-probe.test.ts (removed before commit):
  for n in 0..7, cap in 20..79:
    applyTrajectoryFieldCap("input", "a"*n + "\u{1F98A}"*50, cap)

$ cd packages/core && ../../node_modules/.bin/vitest run src/runtime/zz-probe.test.ts
U+FFFD cases: 119; first: n=0 cap=21, n=0 cap=25, n=0 cap=29, n=0 cap=33,
                          n=0 cap=37, n=0 cap=41
AssertionError: expected [ 'n=0 cap=21', 'n=0 cap=25', …(117) ] to deeply equal []

 Test Files  1 failed (1)
      Tests  2 failed (2)

119 of 480 (offset, cap) pairs corrupt the value. The stride of 4 is the
signature: a 4-byte astral character whose first 3 bytes survive decodes to one
3-byte U+FFFD, which fits the budget exactly.

=== 2. ORIGIN REPRODUCTION — PERSISTED FIELD ON DISK ===

Same probe, second case: real createJsonFileTrajectoryRecorder({rootDir: tmp}),
startTrajectory -> captureToolStageIO({output: "aaa" + fox*300, capBytes: 1024})
-> recordStage(kind "tool") -> endTrajectory -> read <tmp>/agent-probe/<id>.json.

PERSISTED tail (last 24 chars): "\udd8a🦊🦊🦊🦊�...[truncated]"
PERSISTED codepoints at tail: … U+1F98A U+1F98A U+FFFD U+002E U+002E U+002E …
marker: [{"field":"output","originalBytes":1203,"capBytes":1024}]
AssertionError: expected true to be false

This is the persisted value, not the helper's return.

=== 3. NO OVER-REJECTION — DIFFERENTIAL SWEEP vs THE VERBATIM PRE-FIX BODY ===

Probe src/runtime/zz-compat.test.ts (removed before commit) holds a
character-for-character copy of the develop body and compares it against the
fixed export.

ASCII/BMP comparisons: 2702; differences: 0
astral checks: 1158; over-budget: 0; ill-formed: 0; new U+FFFD: 0
astral caps changed: 96 of 386
every change = exactly one U+FFFD removed (sample cap=17):
  "�...[truncated]" -> "...[truncated]"

Corpora: ASCII prose, ASCII JSON, Latin-1 ("café naïve façade Ünicode Straße"),
CJK, Cyrillic+Greek, Hebrew+Arabic, mixed BMP ("a£€あ"), caps 15..400.
Zero differences on every non-astral corpus. The ONLY behavioural change in the
whole cap surface is that a straddled astral character is dropped instead of
being replaced by U+FFFD.

=== 4. LOAD-BEARING REVERT CHECK (copy-aside; `git stash` never used) ===

A) fix in place
 Test Files  1 passed (1)
      Tests  15 passed (15)

B) trajectory-recorder.ts restored to the develop body byte-for-byte
   (`diff <(git show HEAD:…) <file>` empty), new test file kept:
 Test Files  1 failed (1)
      Tests  6 failed | 9 passed (15)

 × a straddled astral character is dropped, never decoded to U+FFFD
 × offset x cap sweep never emits U+FFFD, never exceeds the cap, stays well-formed
 × a pre-existing lone surrogate becomes exactly one U+FFFD (encoding), and the cap adds none
 × captureToolStageIO caps input/output/error without corrupting them
 × captureSkillInvocationIO caps args/result without corrupting them
 × a capped tool-stage output is written to the file without U+FFFD

C) fix restored
 Test Files  1 passed (1)
      Tests  15 passed (15)

The four compatibility cases (ASCII exact-budget, BMP exact-string, whole-astral
kept, under-cap passthrough) pass in BOTH directions — that is the intended
shape: they pin behaviour this PR must not change.

=== 5. THE OLD TEST FILE WAS INERT — PROVEN, NOT ASSERTED ===

$ git show HEAD:packages/core/src/runtime/trajectory-recorder.surrogate.test.ts \
    | grep -n 'from "'
6:} from "../utils/well-formed.ts";
$ git show HEAD:packages/core/src/runtime/trajectory-recorder.surrogate.test.ts \
    | grep -c "trajectory-recorder"
0

Zero references to the module under test. No change to trajectory-recorder.ts
could ever have failed it, so its green status was information-free.

=== 6. FOCUSED SUITE AT THIS HEAD ===

$ bunx vitest run --root packages/core \
    src/runtime/trajectory-recorder.surrogate.test.ts \
    src/runtime/__tests__/trajectory-recorder.test.ts
 Test Files  2 passed (2)
      Tests  70 passed (70)
exit 0

$ bunx vitest run --root packages/core \
    src/runtime/__tests__/trajectory-recorder.test.ts \
    src/runtime/trajectory-recorder.surrogate.test.ts \
    src/runtime-trajectory.surrogate.test.ts \
    src/services/trajectory-json.surrogate.test.ts
 Test Files  4 passed (4)
      Tests  83 passed (83)

=== 7. PACKAGE-SCOPED SUITE, WITH AN UNTOUCHED CONTROL ===

$ bunx vitest run --root packages/core src/runtime
 Test Files  2 failed | 114 passed (116)
      Tests  3 failed | 1624 passed (1627)

The 3 failures are PRE-EXISTING on develop. Control: both of my files restored
to their develop content in the same tree, same two files re-run:

 FAIL src/runtime/__tests__/action-retrieval.test.ts > uses recent conversation for continuation-shaped current turns
 FAIL src/runtime/__tests__/use-model-trajectory-dedupe.test.ts > keeps the provider record and suppresses only its generic duplicate
 FAIL src/runtime/__tests__/use-model-trajectory-dedupe.test.ts > isolates mixed concurrent calls under one parent trajectory
 Test Files  2 failed (2)
      Tests  3 failed | 67 passed (70)

Identical three failures, identical names, with none of this PR's code present.
They are model-dedupe / action-retrieval assertions unrelated to string capping.

=== 8. TYPECHECK ===

$ cd packages/core && ../../node_modules/.bin/tsc --noEmit -p tsconfig.json
exit 0   (zero diagnostics)

packages/core typechecks completely clean at this head, so "adds zero errors" is
exact rather than a control diff: the branch total is 0.

=== 9. LINT ===

$ ./node_modules/.bin/biome check \
    packages/core/src/runtime/trajectory-recorder.ts \
    packages/core/src/runtime/trajectory-recorder.surrogate.test.ts
Checked 2 files in 63ms. No fixes applied.
exit 0

=== 10. DIFF SHAPE ===

$ git diff --stat origin/develop...HEAD
 packages/core/src/runtime/trajectory-recorder.surrogate.test.ts | 271 ++++++++++++++-------
 packages/core/src/runtime/trajectory-recorder.ts                |  33 ++-
 2 files changed, 294 insertions(+), 55 deletions(-)

Production change is 33 lines in one function, of which 6 are the corrected
comment.
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed. This is the
*recording* of already-produced text. A live LLM call cannot serve as evidence
here because the defect requires an astral character to straddle one specific
byte offset; the deterministic 480-pair and 2702-pair sweeps in the domain
receipt are the honest instrument, and the persisted-file reproduction is the
real recorder writing a real file.

## Backend + frontend logs

Backend: sections 1 and 2 of the domain receipt are the real code path on
unmodified `develop` — the real recorder, the real capture seam, and the real
file it wrote.

Frontend: N/A - no browser hop in this unit.

## Screenshots (before / after) + video walkthrough

N/A - core runtime module and its unit tests; no rendered UI surface in the diff.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

- Root `bun run verify` was **not** run on this head. It is a monorepo-wide gate
  and this tree cannot complete it in a bounded time; the package-scoped suite in
  section 7 (1627 tests) with an untouched control, plus a clean `packages/core`
  typecheck and lint, are the proof offered instead.
- `packages/core`'s full suite was not run to completion (it exceeded the local
  time budget); the `src/runtime` subtree, which contains every consumer of the
  changed function inside this package, was run in full. Named plainly rather
  than reported as green.
- The three `src/runtime` failures in section 7 are pre-existing on `develop`,
  demonstrated by re-running the same two files with this PR's code removed. They
  are not fixed here and are out of scope.
- Hosted CI check-runs: none on this head. Fork branches on this repository do not
  schedule check-runs; that is repo steady state, not a skipped gate.
- Fork cannot upload `pr-evidence` release assets, so the domain receipt is inline.
- The residual defensive trim loop is now unreachable. It is retained (routed
  through `truncateWellFormed`) as defence in depth and is explicitly **not**
  claimed to be exercised by any test.
- Scope stated plainly: this fixes the byte-budget cut only. The sibling
  code-unit cut in the same file (`truncateRecordString`) was audited and is
  already correct; it gains real coverage here but no behaviour change.
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-trajrec]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JF6NHMF917QSD53E146B09","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T15:32:02.228Z","completed_at":"2026-08-21T15:33:50.578Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T15:32:03.203Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"cb40657d8e2945e7785652fa0678db565c3cb337c65cdeb824bd8980a14af3ed","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"271f7855-e686-43aa-9121-9d666aa06d59","object_id":"sha256:cb40657d8e2945e7785652fa0678db565c3cb337c65cdeb824bd8980a14af3ed","sha256":"cb40657d8e2945e7785652fa0678db565c3cb337c65cdeb824bd8980a14af3ed"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"2D0VyxLpsXIu_eNGma9SIm-0ncbMEdGAjl7tfJ7Iz3P6J91kCVvGZvbtJzanEwQ7OShvU626LkQwevdHSaSKDw"}} -->
