### PR TITLE
fix(cloud): require explicit agent execution tiers

### DIFF
--- a/packages/cloud/api/__tests__/compat-agent-credit-gate.test.ts
+++ b/packages/cloud/api/__tests__/compat-agent-credit-gate.test.ts
@@ -1,4 +1,5 @@
-// Exercises cloud API tests compat agent credit gate.test behavior with deterministic Worker route fixtures.
+/** Exercises compat agent credit and placement gates with deterministic Worker fixtures. */
+
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
 
@@ -95,6 +96,7 @@ const createAgent = mock(
     organizationId: string;
     userId: string;
     agentName: string;
+    executionTier: "shared" | "dedicated-always";
     maxNonTerminalAgents?: number;
   }) => ({
     agent: createdSandboxRow,
@@ -450,6 +452,7 @@ describe("compat agent create credit + quota gate (elizaOS/eliza#11678)", () => 
       organizationId: "org-1",
       userId: "user-1",
       agentName: "Agent One",
+      executionTier: "shared",
       maxNonTerminalAgents: 20,
     });
     // Compat stays multi-agent-per-org: the reuse guard must remain OFF.
@@ -462,6 +465,24 @@ describe("compat agent create credit + quota gate (elizaOS/eliza#11678)", () => 
       (standardCreateCall[0] as Record<string, unknown>)
         .reuseExistingNonTerminal,
     ).toBeUndefined();
+  });
+
+  test("uses an explicit Dedicated tier before compat auto-provision enqueues compute", async () => {
+    checkAgentCreditGate.mockResolvedValue({
+      allowed: true,
+      balance: 5,
+      error: "",
+    });
+
+    const response = await app.fetch(createRequest(), {
+      WAIFU_AUTO_PROVISION: "true",
+    });
+
+    expect(response.status).toBe(202);
+    expect(createAgent).toHaveBeenCalledTimes(1);
+    expect(createAgent.mock.calls[0]?.[0]).toMatchObject({
+      executionTier: "dedicated-always",
+    });
   });
 
   test("maps AgentQuotaExceededError from a standard-auth create to 429", async () => {

--- a/packages/cloud/api/compat/agents/route.ts
+++ b/packages/cloud/api/compat/agents/route.ts
@@ -193,6 +193,10 @@ app.post("/", async (c) => {
         agentName: parsed.data.agentName,
         agentConfig: sanitizedConfig,
         environmentVars: parsed.data.environmentVars,
+        // Compat remains container-free unless this deployment explicitly
+        // owns eager provisioning. Never let the persistence default choose
+        // Shared for a request that will immediately enqueue container work.
+        executionTier: autoProvision ? "dedicated-always" : "shared",
         maxNonTerminalAgents,
       });
     } catch (error) {

--- a/packages/cloud/api/v1/agents/route.test.ts
+++ b/packages/cloud/api/v1/agents/route.test.ts
@@ -1,4 +1,5 @@
-// Exercises cloud API v1 agents route.test behavior with deterministic Worker route fixtures.
+/** Exercises service-agent creation through deterministic Worker route fixtures. */
+
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const requireServiceKey = mock(async () => ({
@@ -289,6 +290,7 @@ describe("service agent provisioning route", () => {
         organizationId: "agent-wallet-org",
         userId: "agent-wallet-user",
         dockerImage: "registry.example.test/waifu-agent:latest",
+        executionTier: "custom",
         agentConfig: expect.objectContaining({
           waifuAgentId: "waifu-smoke-agent",
           account: expect.objectContaining({
@@ -400,9 +402,6 @@ describe("service agent provisioning route", () => {
             primaryWalletAddress: "0x0000000000000000000000000000000000000001",
             chainType: "evm",
           },
-          container: {
-            image: "registry.example.test/waifu-agent:latest",
-          },
         }),
       }),
       { WAIFU_SERVICE_KEY: "svc" },
@@ -417,6 +416,12 @@ describe("service agent provisioning route", () => {
       bridgeUrl: "https://runtime.example.test",
       status: "running",
     });
+    expect(createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dockerImage: undefined,
+        executionTier: "dedicated-always",
+      }),
+    );
     expect(enqueueAgentProvision).not.toHaveBeenCalled();
   });
 

--- a/packages/cloud/api/v1/agents/route.ts
+++ b/packages/cloud/api/v1/agents/route.ts
@@ -34,6 +34,7 @@ import {
   checkProvisioningWorkerHealth,
   provisioningWorkerFailureBody,
 } from "@/lib/services/provisioning-worker-health";
+import { getAgentTier } from "@/lib/services/shared-runtime/agent-tier";
 import { findOrCreateUserByWalletAddress } from "@/lib/services/wallet-signup";
 import { SIGNUP_CREDIT_POLICY } from "@/lib/signup-credits";
 import { isUniqueConstraintError } from "@/lib/utils/db-errors";
@@ -463,6 +464,12 @@ app.post("/", async (c) => {
           ELIZA_UI_ENABLE: "true",
         },
         dockerImage: p.container?.image,
+        executionTier: getAgentTier({
+          dockerImage: p.container?.image,
+          // This API always provisions immediately, including when it uses the
+          // managed image rather than a caller-supplied custom image.
+          alwaysOn: true,
+        }),
       }));
     } catch (createErr) {
       try {

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.test.ts
@@ -697,6 +697,7 @@ describe("createTierUpgradeTargetWithProvision — durable single-flight boundar
           organizationId: ORG_RACE_CREATE,
           userId: USER_A,
           agentName: "ordinary-create",
+          executionTier: "shared",
           maxNonTerminalAgents: 1,
         }),
       ]);

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
@@ -191,6 +191,41 @@ afterEach(() => {
   resetTx();
 });
 
+test("rejects an invalid execution tier before idempotency or persistence work", async () => {
+  const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+  const svc = new ElizaSandboxService();
+  const uncheckedCreateAgent = svc.createAgent.bind(svc) as unknown as (
+    params: Record<string, unknown>,
+  ) => Promise<unknown>;
+  const uncheckedCreateCodingContainerAgent = svc.createCodingContainerAgent.bind(
+    svc,
+  ) as unknown as (params: Record<string, unknown>) => Promise<unknown>;
+
+  existingRows = [baseRow()];
+  const base = {
+    organizationId: ORG_A,
+    userId: USER,
+    agentName: "invalid-placement",
+    reuseExistingNonTerminal: true,
+  };
+
+  await expect(uncheckedCreateAgent(base)).rejects.toThrow(
+    "createAgent requires an explicit valid executionTier",
+  );
+  await expect(
+    uncheckedCreateCodingContainerAgent({
+      ...base,
+      dockerImage: "ghcr.io/elizaos/tool:v1",
+      executionTier: "future-unclassified-tier",
+    }),
+  ).rejects.toThrow("createAgent requires an explicit valid executionTier");
+
+  expect(transaction).not.toHaveBeenCalled();
+  expect(txSelect).not.toHaveBeenCalled();
+  expect(txInsert).not.toHaveBeenCalled();
+  expect(txExecute).not.toHaveBeenCalled();
+});
+
 describe("ElizaSandboxService.createAgent — opt-in org reuse guard", () => {
   test("(a) two reuse-flagged creates for one org collapse to the same agent — 2nd is idempotent, no 2nd insert", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
@@ -202,6 +237,7 @@ describe("ElizaSandboxService.createAgent — opt-in org reuse guard", () => {
       organizationId: ORG_A,
       userId: USER,
       agentName: "alpha",
+      executionTier: "custom",
       dockerImage: "ghcr.io/elizaos/agent:latest",
       reuseExistingNonTerminal: true,
     });
@@ -216,6 +252,7 @@ describe("ElizaSandboxService.createAgent — opt-in org reuse guard", () => {
       organizationId: ORG_A,
       userId: USER,
       agentName: "alpha-retry",
+      executionTier: "custom",
       dockerImage: "ghcr.io/elizaos/agent:latest",
       reuseExistingNonTerminal: true,
     });
@@ -236,6 +273,7 @@ describe("ElizaSandboxService.createAgent — opt-in org reuse guard", () => {
       organizationId: ORG_B,
       userId: USER,
       agentName: "beta",
+      executionTier: "custom",
       dockerImage: "ghcr.io/elizaos/agent:latest",
       reuseExistingNonTerminal: true,
     });
@@ -255,6 +293,7 @@ describe("ElizaSandboxService.createAgent — opt-in org reuse guard", () => {
       organizationId: ORG_A,
       userId: USER,
       agentName: "gamma",
+      executionTier: "custom",
       dockerImage: "ghcr.io/elizaos/agent:latest",
       reuseExistingNonTerminal: true,
     });
@@ -285,6 +324,7 @@ describe("ElizaSandboxService.createAgent — opt-in org reuse guard", () => {
         organizationId: ORG_A,
         userId: USER,
         agentName: "no-reuse",
+        executionTier: "custom",
         dockerImage: "ghcr.io/elizaos/agent:latest",
       });
       expect(res.idempotent).toBe(false);
@@ -310,6 +350,7 @@ describe("ElizaSandboxService.createAgent — forceCreate per-org quota (#11023)
       organizationId: ORG_A,
       userId: USER,
       agentName: "forced-under-cap",
+      executionTier: "custom",
       dockerImage: "ghcr.io/elizaos/agent:latest",
       reuseExistingNonTerminal: false,
       maxNonTerminalAgents: 5,
@@ -347,6 +388,7 @@ describe("ElizaSandboxService.createAgent — forceCreate per-org quota (#11023)
         organizationId: ORG_A,
         userId: USER,
         agentName: "forced-at-cap",
+        executionTier: "custom",
         dockerImage: "ghcr.io/elizaos/agent:latest",
         reuseExistingNonTerminal: false,
         maxNonTerminalAgents: 5,
@@ -374,6 +416,7 @@ describe("ElizaSandboxService.createAgent — forceCreate per-org quota (#11023)
         organizationId: ORG_A,
         userId: USER,
         agentName: "waifu-launch",
+        executionTier: "custom",
         dockerImage: "ghcr.io/elizaos/agent:latest",
         reuseExistingNonTerminal: false,
         // maxNonTerminalAgents intentionally unset
@@ -401,6 +444,7 @@ describe("ElizaSandboxService.createCodingContainerAgent — same per-org quota 
       organizationId: ORG_A,
       userId: USER,
       agentName: "cc-under-cap",
+      executionTier: "custom",
       dockerImage: "ghcr.io/elizaos/tool:v1",
       maxNonTerminalAgents: 5,
     });
@@ -436,6 +480,7 @@ describe("ElizaSandboxService.createCodingContainerAgent — same per-org quota 
         organizationId: ORG_A,
         userId: USER,
         agentName: "cc-at-cap",
+        executionTier: "custom",
         dockerImage: "ghcr.io/elizaos/tool:v6",
         maxNonTerminalAgents: 5,
       }),
@@ -456,6 +501,7 @@ describe("ElizaSandboxService.createCodingContainerAgent — same per-org quota 
       organizationId: ORG_A,
       userId: USER,
       agentName: "cc-retry",
+      executionTier: "custom",
       dockerImage: "ghcr.io/elizaos/tool:v1",
       maxNonTerminalAgents: 5,
     });
@@ -474,6 +520,7 @@ describe("ElizaSandboxService.createCodingContainerAgent — same per-org quota 
       organizationId: ORG_A,
       userId: USER,
       agentName: "cc-uncapped",
+      executionTier: "custom",
       dockerImage: "ghcr.io/elizaos/tool:v9",
       // maxNonTerminalAgents intentionally unset
     });
@@ -501,6 +548,7 @@ describe("buildAgentSandboxInsertValues — the canonical insert builder (#15943
       environmentVars: { MY_FLAG: "on" },
       characterId: "55555555-5555-4555-8555-555555555555",
       dockerImage: "ghcr.io/elizaos/agent:latest",
+      executionTier: "custom" as const,
       reuseExistingNonTerminal: true,
     };
     existingRows = [];
@@ -530,9 +578,29 @@ describe("buildAgentSandboxInsertValues — the canonical insert builder (#15943
       organizationId: ORG_A,
       userId: USER,
       agentName: "shared-agent",
+      executionTier: "shared",
     });
     expect(shared.status).toBe("running");
     expect(shared.execution_tier).toBe("shared");
+  });
+
+  test("refuses a missing or unknown execution tier instead of defaulting to Shared", async () => {
+    const { buildAgentSandboxInsertValues } = await import("./eliza-sandbox.ts?actual");
+    const uncheckedBuilder = buildAgentSandboxInsertValues as unknown as (
+      params: Record<string, unknown>,
+    ) => unknown;
+    const base = {
+      organizationId: ORG_A,
+      userId: USER,
+      agentName: "placement-must-be-explicit",
+    };
+
+    expect(() => uncheckedBuilder(base)).toThrow(
+      "createAgent requires an explicit valid executionTier",
+    );
+    expect(() => uncheckedBuilder({ ...base, executionTier: "future-unclassified-tier" })).toThrow(
+      "createAgent requires an explicit valid executionTier",
+    );
   });
 
   test("reserved `__agent` config keys are stripped and characterId marks reuse-existing ownership", async () => {
@@ -542,6 +610,7 @@ describe("buildAgentSandboxInsertValues — the canonical insert builder (#15943
       organizationId: ORG_A,
       userId: USER,
       agentName: "sanitized",
+      executionTier: "shared",
       // A caller can never plant reattach/ownership markers — the builder
       // strips the whole reserved namespace; servers re-apply their own.
       agentConfig: { __agentUpgradedFrom: "forged", __agentManagedGithub: {}, keep: 1 },
@@ -567,6 +636,7 @@ describe("assertOrgAgentQuota — boundary at the cap (#15943)", () => {
       organizationId: ORG_A,
       userId: USER,
       agentName: "last-slot",
+      executionTier: "custom",
       dockerImage: "ghcr.io/elizaos/agent:latest",
       reuseExistingNonTerminal: false,
       maxNonTerminalAgents: 5,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-image-allowlist.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-image-allowlist.test.ts
@@ -115,6 +115,7 @@ describe("createAgent rejects a non-allowlisted image before provisioning (H1)",
           organizationId: "11111111-1111-1111-1111-111111111111",
           userId: "22222222-2222-2222-2222-222222222222",
           agentName: "evil",
+          executionTier: "custom",
           dockerImage: "docker.io/library/nginx:latest",
         }),
       ).rejects.toBeInstanceOf(AgentImageNotAllowedError);

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -777,6 +777,7 @@ describe("buildAgentSandboxInsertValues", () => {
       organizationId: "22222222-2222-4222-8222-222222222222",
       userId: "33333333-3333-4333-8333-333333333333",
       agentName: "bnancy",
+      executionTier: "shared" as const,
     };
 
     expect(

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -155,7 +155,12 @@ export interface CreateAgentParams {
   environmentVars?: Record<string, string>;
   characterId?: string;
   dockerImage?: string;
-  executionTier?: AgentExecutionTier;
+  /**
+   * Explicit placement authority for the new row. Callers must decide whether
+   * the agent is container-free Shared or owns dedicated/custom compute; the
+   * persistence seam must never make that product decision by default.
+   */
+  executionTier: AgentExecutionTier;
   /**
    * Opt-in idempotency for single-agent-per-org flows (e.g. the onboarding
    * `POST /api/v1/eliza/agents` path and the eliza-app provisioner). When set,
@@ -225,6 +230,28 @@ export class AgentQuotaExceededError extends Error {
   }
 }
 
+function assertAgentExecutionTier(
+  executionTier: unknown,
+): asserts executionTier is AgentExecutionTier {
+  if (
+    executionTier !== "shared" &&
+    executionTier !== "dedicated-lazy" &&
+    executionTier !== "dedicated-always" &&
+    executionTier !== "custom"
+  ) {
+    throw new ElizaError(
+      "createAgent requires an explicit valid executionTier; refusing to default placement",
+      {
+        code: "INVALID_AGENT_EXECUTION_TIER",
+        context: {
+          executionTier: typeof executionTier === "string" ? executionTier : null,
+          receivedType: typeof executionTier,
+        },
+      },
+    );
+  }
+}
+
 /**
  * Canonical value builder for a fresh `agent_sandboxes` insert. Every create
  * path — the sandbox service's own create/coding-container methods and the
@@ -240,8 +267,9 @@ export class AgentQuotaExceededError extends Error {
  * claim push, and the first-boot bootstrap agreeing on one persona.
  */
 export function buildAgentSandboxInsertValues(params: CreateAgentParams): NewAgentSandbox {
+  const executionTier = params.executionTier;
+  assertAgentExecutionTier(executionTier);
   const sanitizedConfig = stripReservedElizaConfigKeys(params.agentConfig);
-  const executionTier: AgentExecutionTier = params.executionTier ?? "shared";
   const agentConfig = params.characterId
     ? withReusedElizaCharacterOwnership(sanitizedConfig)
     : executionTier === "custom"
@@ -1490,6 +1518,7 @@ export class ElizaSandboxService {
     agent: AgentSandbox;
     idempotent: boolean;
   }> {
+    assertAgentExecutionTier(params.executionTier);
     // SECURITY (H1, #12230): gate a caller-supplied image against the managed-
     // agent allowlist BEFORE any DB write or provisioning. Throws
     // AgentImageNotAllowedError (→ 4xx at the route) so a non-allowlisted image
@@ -1595,9 +1624,9 @@ export class ElizaSandboxService {
     agent: AgentSandbox;
     idempotent: boolean;
   }> {
+    assertAgentExecutionTier(params.executionTier);
     const createParams: CreateAgentParams & { dockerImage: string } = {
       ...params,
-      executionTier: params.executionTier ?? "custom",
       // Coding-container env carries caller secrets (tokens, provider keys) —
       // encrypt them before the row is inserted (#11332).
       environmentVars: params.environmentVars


### PR DESCRIPTION
# Relates to

- Related admission slice of #22947. This PR does not close the parent issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`680e0a9d385d329e340411440902ff9c5e51866a`).
- [x] `bun install` and `bun run verify` were run after sync; the exact baseline-identical failures are recorded below.
- [x] A reviewer can confirm the changed contract from the exact-head commands and outputs below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/GPT-5.6`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `680e0a9d385d329e340411440902ff9c5e51866a`; zero conflicts.
- [x] `bun run verify` was run on exact head `bb461deba0854ae134feec6450b6c17c8c1c2034`; its unrelated, baseline-identical i18n blocker is documented below.

# Risks

Medium. This changes the placement authority supplied when an agent row is created. A wrong value can incorrectly allocate or exempt compute. The service now fails closed on missing/unknown tiers before idempotency, encryption, locking, or persistence; producer routes use the canonical tier classifier and focused tests cover Shared, Dedicated, and custom paths.

# Background

## What does this PR do?

- Makes `CreateAgentParams.executionTier` required and removes both silent persistence defaults (`shared` and coding-container `custom`).
- Rejects invalid runtime callers at the service boundary before any idempotent return or persistence-side work.
- Makes compat creation explicitly `shared` when container-free and `dedicated-always` when it immediately enqueues provisioning.
- Makes the legacy service-agent route use canonical `getAgentTier({ alwaysOn: true, dockerImage })`: managed image is `dedicated-always`; a supplied image is `custom`.
- Updates every affected fixture/caller with a semantically explicit tier.

Out of scope: warm-pool claim rules, queue admission/worker settlement, lifecycle/provider re-entry guards, and the append-only migration. Those remain separate #22947 slices.

## What kind of change is this?

Bug fix: fail-closed placement classification for agent creation.

## Author inventory

Affected-seam history was inventoried before implementation: Shaw, lalalune, NubsCarson, nubs, Stan, standujar, Sol, ngngocnhan1997-hub, felirami, moon, and Zorba the Buddhah.

# Documentation changes needed?

No project documentation change is required. The public service contract is documented inline at `CreateAgentParams`; no route or externally documented request shape changes.

# Testing

## Where should a reviewer start?

1. `packages/cloud/shared/src/lib/services/eliza-sandbox.ts` — required type plus fail-closed runtime assertion.
2. `packages/cloud/api/compat/agents/route.ts` — explicit Shared/Dedicated producer.
3. `packages/cloud/api/v1/agents/route.ts` — canonical managed/custom classifier.
4. The two focused route/service test files.

## Detailed testing steps

Toolchain for every listed command: Node `24.15.0`, Bun `1.3.14`.

```text
bun install --frozen-lockfile
exit 0

bun test packages/cloud/api/v1/agents/route.test.ts --reporter=dots --coverage-reporter=lcov
12 pass, 0 fail, exit 0

bun test packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts --reporter=dots --coverage-reporter=lcov
17 pass, 0 fail, exit 0

bun test packages/cloud/shared/src/lib/services/eliza-sandbox-image-allowlist.test.ts --reporter=dots --coverage-reporter=lcov
9 pass, 0 fail, exit 0

bun test packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.test.ts --reporter=dots --coverage-reporter=lcov
15 pass, 0 fail, exit 0

bunx @biomejs/biome check <the nine changed files>
9 files checked, no fixes, exit 0

bun run --cwd packages/cloud/shared lint:check
2,239 files checked, exit 0

git diff --check origin/develop
exit 0
```

# Evidence Gate

<!-- evidence-head:bb461deba0854ae134feec6450b6c17c8c1c2034 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-interface flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - this is an un-deployed creation-contract slice; exact-head route/service outputs above are the applicable evidence.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no migration or deployed DB row is part of this slice; deterministic exact-head contract tests exercise the tier values and fail-closed boundary.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior changes.

## Backend + frontend logs

Backend: N/A - no deployed backend mutation was authorized for this code-only slice. Exact-head test receipts are listed above.

Frontend: N/A - no frontend changes.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no voice/audio changes.

## Known gaps / failures

All comparisons below were repeated by exact test/error name against a clean worktree at current `origin/develop` `680e0a9d385d329e340411440902ff9c5e51866a`.

- `bun run verify` exits 1 at `check:i18n` on both PR head and clean `develop` (the same seven missing English connector-account keys plus existing locale gaps); the command stops before later verify stages.
- Cloud API typecheck exits 1 on both trees with the same two unrelated errors: `connected-accounts-hono.test.ts:50` (`organization_id` on `PlatformCredentialRow`) and `conversation-coordinator.ts:241` (`URL | RequestInfo` incompatibility).
- Cloud shared typecheck exits 1 on both trees with the same `conversation-coordinator.ts:241` error.
- Cloud API full lint exits 1 on both trees for the same import ordering in `v1/redemptions/route.ts`; changed-file Biome and cloud-shared full lint pass.
- Full compat suite: `11 pass, 1 fail` on PR head and the same named failure on clean `develop`: `allows funded compat resume and restart to reach sandbox operations` expects 200 and receives 500.
- Full `eliza-sandbox.test.ts`: `234 pass, 1 fail` on PR head and the same named failure on clean `develop`: `account deletion does not create a new backup of data being erased` expects `captureUnsupportedGeneration` while the implementation supplies `captureWaiverGeneration`.
- `bun run build:core` generated the required keyword/core outputs, then exited 1 in the local mise installation because its shell `npm` shim was invoked through Node during `npm pack`. The exact-head Bun tests above ran successfully after the generated core build output existed.

No CI conclusion is represented as proof; all evidence above is local at the exact PR head. No deployment, migration, fake composite E2E, or local-checkout receipt is claimed.

AI provider/model: OpenAI / GPT-5.6
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5.6","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
