### PR TITLE
fix(personal-assistant): keep surrogate pairs intact in room policy directive truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/providers/room-policy.surrogate.test.ts
+++ b/plugins/plugin-personal-assistant/src/providers/room-policy.surrogate.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { truncateWellFormed, toWellFormedUnicode } from "@elizaos/core";
+
+const ONE_LINE_MAX = 240;
+
+function buildDirective(status: {
+  enteredAt?: string | null;
+  reason?: string | null;
+  resumeOn?: { kind?: string } | null;
+}): string {
+  const resumePhrase = status.resumeOn?.kind
+    ? `the resume condition fires (${status.resumeOn.kind})`
+    : "the resume condition fires";
+  return (
+    `This room is in handoff mode (since ${status.enteredAt ?? "earlier"}; reason: ${status.reason ?? "n/a"}). ` +
+    `Do not respond unless ${resumePhrase}. Stay silent — defer to the human participants.`
+  );
+}
+
+describe("room-policy surrogate truncation", () => {
+  it("does not split surrogate pairs at ONE_LINE_MAX", () => {
+    const directive = buildDirective({
+      enteredAt: "earlier",
+      reason: `a`.repeat(200) + "🦊" + `b`.repeat(100),
+    });
+    const text = truncateWellFormed(toWellFormedUnicode(directive), ONE_LINE_MAX);
+    const isWellFormed = (value: string) =>
+      (value as unknown as { isWellFormed(): boolean }).isWellFormed?.() ?? true;
+    expect(isWellFormed(text)).toBe(true);
+    expect(text.length).toBeLessThanOrEqual(ONE_LINE_MAX);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/providers/room-policy.ts
+++ b/plugins/plugin-personal-assistant/src/providers/room-policy.ts
@@ -19,7 +19,11 @@ import type {
   ProviderResult,
   State,
 } from "@elizaos/core";
-import { logger } from "@elizaos/core";
+import {
+  logger,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import {
   describeResumeCondition,
   resolveHandoffStore,
@@ -88,7 +92,7 @@ export const roomPolicyProvider: Provider = {
     const directive =
       `This room is in handoff mode (since ${status.enteredAt ?? "earlier"}; reason: ${status.reason ?? "n/a"}). ` +
       `Do not respond unless ${resumePhrase}. Stay silent — defer to the human participants.`;
-    const text = directive.slice(0, ONE_LINE_MAX);
+    const text = truncateWellFormed(toWellFormedUnicode(directive), ONE_LINE_MAX);
     return {
       text,
       values: {


### PR DESCRIPTION
Closes #23732

Room-policy handoff directive now sanitizes lone surrogates and truncates
at 240 via truncateWellFormed(toWellFormedUnicode(...),240).

- plugins/plugin-personal-assistant/src/providers/room-policy.ts
- plugins/plugin-personal-assistant/src/providers/room-policy.surrogate.test.ts: regression coverage