### PR TITLE
fix(plugin-cli-inference): bound prompt flattening against hostile tool payloads

### DIFF
--- a/plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Load-bearing regression pins for the bounded tool-payload walk in
+ * `src/prompt-flatten.ts`.
+ *
+ * These import the REAL production symbols (`contentToText`, `flattenPrompt`
+ * and the exported markers) — no copy of the implementation lives in this file,
+ * so deleting or weakening any guard turns the suite red.
+ *
+ * Two halves:
+ *  1. Hostile payloads that threw uncaught out of `flattenPrompt` before the
+ *     fix (`RangeError: Maximum call stack size exceeded` on a deep array, a
+ *     deep `.content` chain and a self-referential `.content`; `TypeError:
+ *     Converting circular structure to JSON` on a cyclic object and on cyclic
+ *     tool-call arguments) now flatten to a bounded marker.
+ *  2. Ordinary payloads still flatten byte-identically — the guard must not
+ *     reject anything the live path accepts today.
+ */
+import type { ChatMessage, ChatMessageContentPart } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  contentToText,
+  flattenPrompt,
+  TOOL_PAYLOAD_BUDGET_MARKER,
+  TOOL_PAYLOAD_CYCLE_MARKER,
+  TOOL_PAYLOAD_DEPTH_MARKER,
+} from "../src/prompt-flatten";
+
+const toolResult = (output: unknown): ChatMessageContentPart =>
+  ({ type: "tool-result", toolName: "WEB_FETCH", output }) as unknown as ChatMessageContentPart;
+const toolCall = (input: unknown): ChatMessageContentPart =>
+  ({ type: "tool-call", toolName: "WEB_FETCH", input }) as unknown as ChatMessageContentPart;
+
+/** Deep enough that the old recursive walk blew the stack. */
+const DEEP = 60_000;
+
+describe("toolOutputToText — hostile tool payloads no longer throw", () => {
+  it("bounds a deep array tool output instead of overflowing the stack", () => {
+    const deepArray = JSON.parse(`${"[".repeat(DEEP)}1${"]".repeat(DEEP)}`);
+    const text = contentToText([toolResult(deepArray)]);
+    expect(text).toContain(TOOL_PAYLOAD_DEPTH_MARKER);
+  });
+
+  it("bounds a deep `.content` chain instead of overflowing the stack", () => {
+    let nested: unknown = { text: "leaf" };
+    for (let i = 0; i < DEEP; i += 1) nested = { content: nested };
+    const text = contentToText([toolResult(nested)]);
+    expect(text).toContain(TOOL_PAYLOAD_DEPTH_MARKER);
+  });
+
+  it("cuts a self-referential `.content` back-edge instead of recursing forever", () => {
+    const selfReferential: Record<string, unknown> = {};
+    selfReferential.content = selfReferential;
+    const text = contentToText([toolResult(selfReferential)]);
+    expect(text).toContain(TOOL_PAYLOAD_CYCLE_MARKER);
+  });
+
+  it("serializes a cyclic tool output instead of throwing from JSON.stringify", () => {
+    const cyclic: Record<string, unknown> = { a: 1 };
+    cyclic.self = cyclic;
+    const text = contentToText([toolResult(cyclic)]);
+    expect(text).toContain('"a":1');
+    expect(text).toContain(TOOL_PAYLOAD_CYCLE_MARKER);
+  });
+
+  it("bounds the AI-SDK `{type:'json',value}` tool-result shape", () => {
+    // The shape emitted by plugins/plugin-openai/models/text.ts and
+    // plugins/plugin-zerollama/utils/ai-sdk-wire.ts: `value` is parsed remote
+    // JSON of arbitrary depth, with no string fast-path in the walk.
+    const deepJson = JSON.parse(`${'{"a":'.repeat(DEEP)}1${"}".repeat(DEEP)}`);
+    const text = contentToText([toolResult({ type: "json", value: deepJson })]);
+    expect(text).toContain(TOOL_PAYLOAD_DEPTH_MARKER);
+  });
+
+  it("bounds cyclic tool-call arguments carried in the content array", () => {
+    const cyclic: Record<string, unknown> = { q: 1 };
+    cyclic.self = cyclic;
+    const text = contentToText([toolCall(cyclic)]);
+    expect(text).toContain(TOOL_PAYLOAD_CYCLE_MARKER);
+  });
+
+  it("bounds cyclic arguments carried on `message.toolCalls`", () => {
+    const cyclic: Record<string, unknown> = { q: 1 };
+    cyclic.self = cyclic;
+    const { body } = flattenPrompt({
+      messages: [
+        {
+          role: "assistant",
+          content: "narrating",
+          toolCalls: [{ name: "WEB_FETCH", arguments: cyclic }],
+        } as unknown as ChatMessage,
+      ],
+    });
+    expect(body).toContain(TOOL_PAYLOAD_CYCLE_MARKER);
+  });
+
+  it("charges container width so a very wide payload cannot exhaust the walk", () => {
+    const wide = { rows: Array.from({ length: 200_000 }, (_, i) => i) };
+    const text = contentToText([toolResult(wide)]);
+    expect(text).toContain(TOOL_PAYLOAD_BUDGET_MARKER);
+  });
+
+  it("keeps the rest of the turn alive when one part is poisoned", () => {
+    // The whole point: a poisoned part is replayed on every later generation of
+    // the turn, so it must degrade to a marker rather than kill the flatten.
+    const selfReferential: Record<string, unknown> = {};
+    selfReferential.content = selfReferential;
+    const { system, body } = flattenPrompt({
+      system: "ROOT",
+      messages: [
+        { role: "user", content: "turn 1" },
+        { role: "tool", content: [toolResult(selfReferential)] } as unknown as ChatMessage,
+        { role: "user", content: "turn 2" },
+      ],
+    });
+    expect(system).toContain("ROOT");
+    expect(body).toContain("turn 1");
+    expect(body).toContain("turn 2");
+    expect(body).toContain(TOOL_PAYLOAD_CYCLE_MARKER);
+  });
+
+  it("never invokes an accessor on an untrusted payload", () => {
+    let invoked = 0;
+    const trap = {};
+    Object.defineProperty(trap, "value", {
+      enumerable: true,
+      get() {
+        invoked += 1;
+        return "pwned";
+      },
+    });
+    const text = contentToText([toolResult(trap)]);
+    expect(invoked).toBe(0);
+    expect(text).not.toContain("pwned");
+  });
+});
+
+describe("toolOutputToText — no over-rejection of ordinary payloads", () => {
+  it("passes through the shapes the live path already accepts, unchanged", () => {
+    expect(contentToText([toolResult("plain fetched text")])).toBe(
+      "[tool_result WEB_FETCH: plain fetched text]"
+    );
+    expect(contentToText([toolResult({ type: "text", value: "hello" })])).toBe(
+      "[tool_result WEB_FETCH: hello]"
+    );
+    expect(contentToText([toolResult({ text: "from .text" })])).toBe(
+      "[tool_result WEB_FETCH: from .text]"
+    );
+    expect(contentToText([toolResult([{ type: "text", value: "a" }, "b"])])).toBe(
+      "[tool_result WEB_FETCH: a\nb]"
+    );
+    expect(contentToText([toolResult({ content: [{ type: "text", value: "n" }] })])).toBe(
+      "[tool_result WEB_FETCH: n]"
+    );
+    expect(contentToText([toolResult({ status: 200, items: ["x", "y"] })])).toBe(
+      '[tool_result WEB_FETCH: {"status":200,"items":["x","y"]}]'
+    );
+    expect(contentToText([toolCall({ url: "https://e.com" })])).toBe(
+      '[tool_call WEB_FETCH {"url":"https://e.com"}]'
+    );
+  });
+
+  it("renders scalars, dates and dropped members exactly as JSON.stringify does", () => {
+    const payload = {
+      a: null,
+      b: true,
+      c: 1.5,
+      d: -0,
+      e: 1e21,
+      f: undefined,
+      g: new Date("2026-08-21T12:00:00.000Z"),
+      h: [1, undefined, 3],
+      i: "héllo 🚀 世界",
+    };
+    expect(contentToText([toolResult(payload)])).toBe(
+      `[tool_result WEB_FETCH: ${JSON.stringify(payload)}]`
+    );
+  });
+
+  it("preserves an honest DAG rather than reporting the second reference as a cycle", () => {
+    const shared = { id: "u1", tier: "pro" };
+    expect(contentToText([toolResult({ a: shared, b: shared })])).toBe(
+      '[tool_result WEB_FETCH: {"a":{"id":"u1","tier":"pro"},"b":{"id":"u1","tier":"pro"}}]'
+    );
+  });
+
+  it("keeps a large single tool output whole", () => {
+    const body = "x".repeat(2 * 1024 * 1024);
+    expect(contentToText([toolResult({ type: "text", value: body })])).toBe(
+      `[tool_result WEB_FETCH: ${body}]`
+    );
+  });
+
+  it("keeps an honestly deep (but in-budget) payload whole", () => {
+    let nested: unknown = { leaf: true };
+    for (let i = 0; i < 40; i += 1) nested = { child: nested };
+    expect(contentToText([toolResult(nested)])).toBe(
+      `[tool_result WEB_FETCH: ${JSON.stringify(nested)}]`
+    );
+  });
+});

--- a/plugins/plugin-cli-inference/src/prompt-flatten.ts
+++ b/plugins/plugin-cli-inference/src/prompt-flatten.ts
@@ -22,20 +22,203 @@ export interface FlattenedPrompt {
   body: string;
 }
 
-/** Pull readable text out of a tool-result part's `output` (shape varies by
- * provider: `{type:"text",value}`, a bare string, or an array of such parts). */
-function toolOutputToText(output: unknown): string {
-  if (output == null) return "";
-  if (typeof output === "string") return output;
-  if (Array.isArray(output)) return output.map(toolOutputToText).filter(Boolean).join("\n");
-  if (typeof output === "object") {
-    const o = output as { value?: unknown; text?: unknown; content?: unknown };
-    if (typeof o.value === "string") return o.value;
-    if (typeof o.text === "string") return o.text;
-    if (o.content != null) return toolOutputToText(o.content);
-    return JSON.stringify(output);
+/**
+ * Bounded-walk budget for untrusted tool payloads.
+ *
+ * A tool part's `output`/`input` is raw remote data — a WEB_FETCH body, an MCP
+ * tool result, model-authored tool arguments. The walk below used to be
+ * unbounded and unguarded, so a deep or cyclic payload threw `RangeError:
+ * Maximum call stack size exceeded` (deep array, deep `.content` chain,
+ * self-referential `.content`) or `TypeError: Converting circular structure to
+ * JSON` straight out of `flattenPrompt`. Because the planner's message array
+ * grows append-only across iterations
+ * (`packages/core/src/runtime/planner-loop.ts` "grows append-only across
+ * planner iterations"), every later CLI-backed generation that replays the turn
+ * re-walks the same part and throws again — one poisoned tool result is a
+ * persistent failure, not a single failed call.
+ *
+ * The contract mirrors core's own bounded flatten (`flattenTextValues` in
+ * `packages/core/src/utils/text-normalize.ts`):
+ *  - a depth ceiling far above any honest payload;
+ *  - node and character ceilings, so a wide graph is bounded too, not just a
+ *    deep one, with container width charged BEFORE any element is allocated;
+ *  - a PATH-LOCAL ancestor set (added on descent, removed in `finally`), so a
+ *    real back-edge is cut while an honest DAG — the same cached object
+ *    referenced twice in one result — still flattens in full;
+ *  - descriptor-only reflection, so no attacker-supplied getter or `toJSON`
+ *    ever executes while we render a prompt;
+ *  - an explicit in-band marker rather than a throw. Throwing would preserve
+ *    the exact failure this guards against: one bad part bricking every later
+ *    replay of the turn. The marker is visible to the model and in the
+ *    transcript, so nothing is silently dropped.
+ *
+ * Nothing inside the budget changes shape: every payload the old walk accepted
+ * still flattens to byte-identical text.
+ */
+const MAX_TOOL_PAYLOAD_DEPTH = 64;
+const MAX_TOOL_PAYLOAD_NODES = 100_000;
+const MAX_TOOL_PAYLOAD_CHARS = 4 * 1024 * 1024;
+
+/** Emitted in place of a subtree that is deeper than the ceiling. */
+export const TOOL_PAYLOAD_DEPTH_MARKER = `[tool payload omitted: deeper than ${MAX_TOOL_PAYLOAD_DEPTH}]`;
+/** Emitted in place of a back-edge (a value that is its own ancestor). */
+export const TOOL_PAYLOAD_CYCLE_MARKER = "[tool payload omitted: cycle]";
+/** Emitted once the node or character budget for one part is spent. */
+export const TOOL_PAYLOAD_BUDGET_MARKER = "[tool payload omitted: over budget]";
+
+interface PayloadBudget {
+  nodes: number;
+  chars: number;
+  /** Path-local, NOT visit-global: honest DAGs keep flattening in full. */
+  ancestors: Set<object>;
+}
+
+/** One budget per tool part, so a large part never starves its siblings. */
+function newPayloadBudget(): PayloadBudget {
+  return { nodes: 0, chars: 0, ancestors: new Set<object>() };
+}
+
+/**
+ * Charge produced text against the character budget. The check runs before the
+ * charge, so the first (possibly very large) string always comes back whole —
+ * a single 10 MB WEB_FETCH body flattens exactly as it does today.
+ */
+function chargeChars(budget: PayloadBudget, text: string): string {
+  if (budget.chars > MAX_TOOL_PAYLOAD_CHARS) return TOOL_PAYLOAD_BUDGET_MARKER;
+  budget.chars += text.length;
+  return text;
+}
+
+/** Charge container width before allocating anything for its elements. */
+function chargeWidth(budget: PayloadBudget, width: number): boolean {
+  budget.nodes += width;
+  return budget.nodes <= MAX_TOOL_PAYLOAD_NODES;
+}
+
+/**
+ * Own data property, or `undefined`. Accessors are reported as absent and are
+ * never invoked — an attacker-supplied getter must not run during prompt
+ * flattening. Inherited members are not consulted; every producer of these
+ * shapes (`JSON.parse`, object literals in the provider normalizers) emits own
+ * data properties.
+ */
+function ownDataProperty(target: object, key: string): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(target, key);
+  return descriptor && "value" in descriptor ? descriptor.value : undefined;
+}
+
+type JsonSafe = string | number | boolean | null | JsonSafe[] | { [key: string]: JsonSafe };
+
+/**
+ * Bounded, descriptor-only projection to a JSON-safe value. Structurally
+ * identical to the input for anything within budget — same keys, same insertion
+ * order, same scalar rendering as `JSON.stringify` — so serializing the result
+ * is byte-identical to serializing the original. Cycles, over-deep subtrees and
+ * over-budget graphs become markers instead of throwing, and `bigint` becomes
+ * its decimal string instead of throwing `TypeError`.
+ */
+function toBoundedJsonValue(
+  value: unknown,
+  budget: PayloadBudget,
+  depth: number
+): JsonSafe | undefined {
+  if (value === null) return null;
+  const kind = typeof value;
+  if (kind === "string") return value as string;
+  if (kind === "number") return Number.isFinite(value as number) ? (value as number) : null;
+  if (kind === "boolean") return value as boolean;
+  if (kind === "bigint") return (value as bigint).toString();
+  if (kind !== "object") return undefined; // undefined / function / symbol: dropped, as today
+  const object = value as object;
+  if (object instanceof Date) {
+    const time = object.getTime();
+    return Number.isNaN(time) ? null : object.toISOString();
   }
-  return String(output);
+  if (depth >= MAX_TOOL_PAYLOAD_DEPTH) return TOOL_PAYLOAD_DEPTH_MARKER;
+  if (budget.ancestors.has(object)) return TOOL_PAYLOAD_CYCLE_MARKER;
+  if (Array.isArray(object)) {
+    if (!chargeWidth(budget, object.length)) return TOOL_PAYLOAD_BUDGET_MARKER;
+    budget.ancestors.add(object);
+    try {
+      const items: JsonSafe[] = [];
+      for (let index = 0; index < object.length; index += 1) {
+        items.push(toBoundedJsonValue(object[index], budget, depth + 1) ?? null);
+      }
+      return items;
+    } finally {
+      budget.ancestors.delete(object);
+    }
+  }
+  // Own enumerable string keys, in insertion order — the exact set and order
+  // `JSON.stringify` would serialize, read without invoking anything.
+  const keys = Object.keys(object);
+  if (!chargeWidth(budget, keys.length)) return TOOL_PAYLOAD_BUDGET_MARKER;
+  budget.ancestors.add(object);
+  try {
+    const projected: Record<string, JsonSafe> = {};
+    for (const key of keys) {
+      const descriptor = Object.getOwnPropertyDescriptor(object, key);
+      if (!descriptor || !("value" in descriptor)) continue;
+      const nested = toBoundedJsonValue(descriptor.value, budget, depth + 1);
+      if (nested !== undefined) projected[key] = nested;
+    }
+    return projected;
+  } finally {
+    budget.ancestors.delete(object);
+  }
+}
+
+/** `JSON.stringify` for untrusted tool payloads: bounded and fail-closed. */
+function stringifyToolPayload(value: unknown, budget: PayloadBudget, depth: number): string {
+  const bounded = toBoundedJsonValue(value, budget, depth);
+  if (bounded === undefined) return "";
+  return JSON.stringify(bounded) ?? "";
+}
+
+/** Pull readable text out of a tool-result part's `output` (shape varies by
+ * provider: `{type:"text",value}`, a bare string, or an array of such parts).
+ * Bounded per {@link newPayloadBudget}: the payload is untrusted remote data. */
+function toolOutputToText(
+  output: unknown,
+  budget: PayloadBudget = newPayloadBudget(),
+  depth = 0
+): string {
+  if (output == null) return "";
+  if (typeof output === "string") return chargeChars(budget, output);
+  if (typeof output !== "object") return chargeChars(budget, String(output));
+  if (depth >= MAX_TOOL_PAYLOAD_DEPTH) return TOOL_PAYLOAD_DEPTH_MARKER;
+  if (budget.ancestors.has(output)) return TOOL_PAYLOAD_CYCLE_MARKER;
+  if (Array.isArray(output)) {
+    if (!chargeWidth(budget, output.length)) return TOOL_PAYLOAD_BUDGET_MARKER;
+    budget.ancestors.add(output);
+    try {
+      const parts: string[] = [];
+      for (let index = 0; index < output.length; index += 1) {
+        const text = toolOutputToText(output[index], budget, depth + 1);
+        if (text) parts.push(text);
+      }
+      return parts.join("\n");
+    } finally {
+      budget.ancestors.delete(output);
+    }
+  }
+  if (!chargeWidth(budget, 1)) return TOOL_PAYLOAD_BUDGET_MARKER;
+  budget.ancestors.add(output);
+  try {
+    const value = ownDataProperty(output, "value");
+    if (typeof value === "string") return chargeChars(budget, value);
+    const text = ownDataProperty(output, "text");
+    if (typeof text === "string") return chargeChars(budget, text);
+    const content = ownDataProperty(output, "content");
+    if (content != null) return toolOutputToText(content, budget, depth + 1);
+  } finally {
+    budget.ancestors.delete(output);
+  }
+  // Terminal serialization runs AFTER `output` leaves the ancestor path, so the
+  // projection below treats it as a fresh root rather than as a back-edge onto
+  // itself. This is exactly what "path-local" buys: an honest value is never
+  // mistaken for a cycle.
+  return chargeChars(budget, stringifyToolPayload(output, budget, depth));
 }
 
 /**
@@ -64,7 +247,10 @@ export function contentToText(content: ChatMessage["content"]): string {
         output?: unknown;
       };
       if (p.type === "tool-call" || p.type === "tool_call") {
-        const args = typeof p.input === "string" ? p.input : JSON.stringify(p.input ?? {});
+        const args =
+          typeof p.input === "string"
+            ? p.input
+            : stringifyToolPayload(p.input ?? {}, newPayloadBudget(), 0);
         return `[tool_call ${p.toolName ?? "tool"} ${args}]`;
       }
       if (p.type === "tool-result" || p.type === "tool_result") {
@@ -89,7 +275,7 @@ function renderMessage(message: ChatMessage): string {
           const args =
             typeof call.arguments === "string"
               ? call.arguments
-              : JSON.stringify(call.arguments ?? {});
+              : stringifyToolPayload(call.arguments ?? {}, newPayloadBudget(), 0);
           return `[tool_call ${call.name} ${args}]`;
         })
       : [];


### PR DESCRIPTION
# Relates to

Closes #23826.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
      Branched directly off `3850758df657e222d82d6f63db77ae1d6d0b3938`.
- [x] `bun install` was run after sync. `bun run verify` was **not** run in full —
      see **Known gaps / failures** for the exact reason and for the focused
      checks run instead.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — not run; the exact blocker and the
      focused checks used instead are documented in **Known gaps / failures**.

# Risks

**Low.** One plugin-side module, `plugins/plugin-cli-inference/src/prompt-flatten.ts`,
plus one new test file. No API shape changes, no new dependency, no core change.

The one behavioural risk that matters here is **over-rejection** — a guard that
refuses payloads the live path accepts today. That is measured, not asserted:
a 30-case corpus of ordinary tool payloads was run through the origin module and
the patched module and compared byte for byte, `identical=30 differing=0` (see
**Evidence Details**). Three deliberate, documented narrowings remain, all of
them the point of the change: an attacker-supplied `get value()` accessor is no
longer invoked, a non-`Date` `toJSON()` is no longer invoked, and a `value` /
`text` / `content` member inherited from a prototype is no longer consulted.
JSON-parsed payloads and every in-repo producer of these shapes emit own data
properties, so none of the three is reachable from an honest payload.

# Background

## What does this PR do?

`toolOutputToText` (`prompt-flatten.ts:27-38`) walked the raw `output` of a
`tool-result` content part with no depth cap, no cycle guard, no width or byte
budget and no `try/catch`, and handed its tail case to a bare `JSON.stringify`.
That payload is untrusted remote data — a `WEB_FETCH` body, an MCP tool result,
model-authored tool arguments. Four distinct uncaught throws escaped it, and the
tool-**call** half of the same file (`contentToText:67`, `renderMessage:92`) had
the same bare-`JSON.stringify` exposure.

This PR bounds that walk. The contract is copied from core's own bounded flatten
of untrusted nested values, `flattenTextValues` in
`packages/core/src/utils/text-normalize.ts`:

- a depth ceiling (`64`, the same ceiling `MAX_TEXT_NORMALIZE_DEPTH` uses);
- node and character budgets, so a **wide** graph is bounded too and not only a
  deep one, with **container width charged before any element is allocated**;
- a **path-local** ancestor set — added on descent, removed in `finally` — so a
  real back-edge is cut while an honest DAG (the same cached object referenced
  twice in one result) still flattens in full;
- **descriptor-only reflection**: `Object.keys` + `getOwnPropertyDescriptor`, an
  accessor is reported as absent and never invoked, and no `toJSON` other than
  `Date`'s runs. Nothing attacker-supplied executes while we render a prompt;
- an explicit **in-band marker** for the offending subtree rather than an
  exception. This one is deliberate and is argued below.

Both bare `JSON.stringify` call sites now go through the same bounded,
descriptor-only projection, which also removes a fifth uncaught throw
(`TypeError` on a `bigint` member).

## Why a marker and not a typed `ElizaError`

The failure being fixed is *persistence*: `packages/core/src/runtime/planner-loop.ts:1837`
documents that the message array "grows append-only across planner iterations",
and `flattenPrompt` re-walks every part of that array on every call. A part that
throws once therefore throws on every later CLI-backed generation that replays
the turn — the agent does not recover by retrying. Throwing a typed error
instead of a `RangeError` would keep that property exactly. The marker keeps the
turn alive, is visible to the model and in the transcript, and is exported
(`TOOL_PAYLOAD_DEPTH_MARKER`, `TOOL_PAYLOAD_CYCLE_MARKER`,
`TOOL_PAYLOAD_BUDGET_MARKER`) so callers and tests can detect it. Nothing is
silently dropped.

## Why this walker and not one of the three the repo already ships

Stated explicitly because "do not write a fourth walker" is the right instinct:

| Candidate | Why not |
| --- | --- |
| `cloneWithoutBlockedObjectKeys` (`packages/agent/src/api/blocked-object-keys.ts`) | Lives in `packages/agent`. `plugins/plugin-cli-inference/package.json` declares `@elizaos/core` as its only peer/dev dependency; the plugin cannot import `packages/agent`. |
| `redactDeep` (`packages/agent/src/api/server-helpers-config.ts`) | Same package barrier, and welded to redaction semantics. |
| `sanitizeTrajectoryJsonValue` (`packages/core/src/services/trajectory-json.ts`) | In core, but **not on the `@elizaos/core` public export surface** (`index.node.ts` re-exports `./trajectory-utils`, not `./services/trajectory-json`), and welded to trajectory-**row** persistence budgets: 64 KiB per-string truncation and a 1 MiB output budget with `__trajectoryTruncated` markers. Applying those to a prompt would silently rewrite ordinary large tool output — exactly the over-rejection this PR is measured against. |
| `flattenTextValues` (`packages/core/src/utils/text-normalize.ts`) | **The contract used here.** It cannot be called directly because its output shape is `key: value` text fragments, not this function's output shape, but its budget axes, its path-local `ancestors` set with `finally { delete }`, and its ceiling values are what this change mirrors. |

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The new budget
and every deliberate narrowing are documented in the module docblock.

# Testing

## Where should a reviewer start?

`plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts`. It
imports the real `contentToText` / `flattenPrompt` / marker symbols — there is no
copy of the implementation in the test file — and is split in two halves: hostile
payloads that used to throw, and ordinary payloads that must still flatten
unchanged.

## Detailed testing steps

```bash
bun install
bun run --cwd packages/core build          # the plugin's vitest alias resolves @elizaos/core to its dist
bun run --cwd plugins/plugin-cli-inference test
bun run --cwd plugins/plugin-cli-inference typecheck
bunx @biomejs/biome check plugins/plugin-cli-inference/src/prompt-flatten.ts \
     plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:ae26f4867749768d277bdd12faf40d10ae851ec2 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no UI surface; this changes one prompt-flattening helper in plugins/plugin-cli-inference, and the diff touches no .tsx/.css/.svg.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no UI surface; see the row above.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the observable behaviour is a library function's return value, captured as command output below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: the real code path firing end to end — the shipped
      `prompt-flatten.ts` module driven through its public `contentToText` /
      `flattenPrompt` entry points, before and after, plus the package suite.

```
$ node --experimental-strip-types origin-repro-promptflatten.mjs   # BEFORE, at 3850758df657
A deep array tool output               -> RangeError: Maximum call stack size exceeded
B deep .content chain                  -> RangeError: Maximum call stack size exceeded
C self-referential .content            -> RangeError: Maximum call stack size exceeded
D cyclic object (JSON.stringify)       -> TypeError: Converting circular structure to JSON
E {type:json,value:<deep parsed JSON>} -> RangeError: Maximum call stack size exceeded
F tool-call input, cyclic              -> TypeError: Converting circular structure to JSON
G flattenPrompt whole turn             -> RangeError: Maximum call stack size exceeded

$ node --experimental-strip-types origin-repro-promptflatten.mjs   # AFTER, at ae26f4867749
A deep array tool output               -> OK (63 chars)
B deep .content chain                  -> OK (63 chars)
C self-referential .content            -> OK (54 chars)
D cyclic object (JSON.stringify)       -> OK (71 chars)
E {type:json,value:<deep parsed JSON>} -> OK (467 chars)
F tool-call input, cyclic              -> OK (68 chars)
G flattenPrompt whole turn             -> OK (95 chars)

$ bun run --cwd plugins/plugin-cli-inference test
 RUN  v4.1.10 /…/plugins/plugin-cli-inference
 Test Files  8 passed (8)
      Tests  153 passed (153)
```

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend surface is involved.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - we are a fork contributor without access to a live provider account for the scenario runner in this environment, and the change is deterministic and fully covered by the unit evidence below. Attaching a fabricated report would be worse than this row.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the compatibility corpus — 30 ordinary tool payloads
      flattened through the origin module and through the patched module and
      compared byte for byte. Full listing under **Evidence Details**; the
      decisive rows and the verdict are pasted here.

```
$ node --experimental-strip-types compat-promptflatten.mjs
identical  plain JSON object                (207 bytes)
identical  JSON with nulls/bools/nums       (201 bytes)
identical  JSON with unicode + emoji        (209 bytes)
identical  JSON with Date                   (185 bytes)
identical  JSON with undefined member       (165 bytes)
identical  honest DAG (shared ref twice)    (227 bytes)
identical  deeply-but-honestly nested 40    (643 bytes)
identical  5000-row wide payload            (240440 bytes)
identical  big 2MB string body              (2097315 bytes)
identical  assistant message.toolCalls      (111 bytes)

corpus=30 identical=30 differing=0
```

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Origin reproduction (before) — on `3850758df657e222d82d6f63db77ae1d6d0b3938`

The script imports the **real production module**. Its only import is
`import type … from "@elizaos/core"`, which Node's type stripping erases, so the
shipped body runs unmodified; the payloads go in through the public
`contentToText` / `flattenPrompt` entry points.

```
$ node --experimental-strip-types origin-repro-promptflatten.mjs
A deep array tool output               -> RangeError: Maximum call stack size exceeded
B deep .content chain                  -> RangeError: Maximum call stack size exceeded
C self-referential .content            -> RangeError: Maximum call stack size exceeded
D cyclic object (JSON.stringify)       -> TypeError: Converting circular structure to JSON
E {type:json,value:<deep parsed JSON>} -> RangeError: Maximum call stack size exceeded
F tool-call input, cyclic              -> TypeError: Converting circular structure to JSON
G flattenPrompt whole turn             -> RangeError: Maximum call stack size exceeded
```

- **A** is `JSON.parse("[".repeat(60000) + "1" + "]".repeat(60000))` — a value a
  remote response can produce and `JSON.parse` accepts, but the walk at `:29`
  cannot traverse.
- **B/C** exercise the `.content` unwrap the function performs itself at `:34`.
- **D/F** are the bare `JSON.stringify` at `:35` and `:67`.
- **E** is the AI-SDK `{ type: "json", value: <parsed remote JSON> }` tool-result
  shape emitted by `plugins/plugin-openai/models/text.ts:1043-1047` and
  `plugins/plugin-zerollama/utils/ai-sdk-wire.ts:152-158`. `value` is a parsed
  remote document and has no string fast-path in the walk, so it lands directly
  on the unguarded `JSON.stringify`.
- **G** is the blast radius: one poisoned part takes down the entire
  `flattenPrompt` call, including the healthy user turns before and after it.

## Same script against the patched module (after)

```
$ node --experimental-strip-types origin-repro-promptflatten.mjs
A deep array tool output               -> OK (63 chars)
B deep .content chain                  -> OK (63 chars)
C self-referential .content            -> OK (54 chars)
D cyclic object (JSON.stringify)       -> OK (71 chars)
E {type:json,value:<deep parsed JSON>} -> OK (467 chars)
F tool-call input, cyclic              -> OK (68 chars)
G flattenPrompt whole turn             -> OK (95 chars)
```

## Reachability and replay, stated honestly

`flattenPrompt` is the entry point for the `claude-cli`, `claude-sdk`,
`codex-cli-exec` and `codex-sdk` backends
(`plugins/plugin-cli-inference/index.ts:456,477,505`, `src/claude-cli.ts:188`,
`src/codex-cli-exec.ts:176`), and `contentToText` is additionally consumed by
`src/clean-routing-planner.ts:98`.

**Replay is real and documented in core.** `packages/core/src/runtime/planner-loop.ts:1837`
— "This grows append-only across planner iterations so the base prefix remains
byte-identical" — and `packages/core/src/runtime/planner-rendering.ts:116` for
`trajectoryStepsToMessages`. `flattenPrompt` re-walks every part on every call,
so a value that throws once throws on every subsequent generation that replays
the turn.

**What the core planner path does today, so no one over-reads the above.** On
that path the payload is bounded *upstream* before it reaches this function:
`planner-rendering.ts:172` pre-renders tool results to
`{ type: "text", value: <string> }`, and `projectToolDiagnosticArgs` masks
tool-call arguments at depth 8
(`packages/core/src/security/tool-diagnostics.ts:31,120`). So the planner is
protected today by two invariants this function neither enforces nor can see. The
throws above are reached from callers that hand `useModel` raw tool-result parts —
the AI-SDK `{type:"json",value}` normalizers cited under **E**, and any direct
`useModel({ messages })` caller. That is the defect: an exported prompt-flattening
helper documented to accept provider-shaped payloads ("shape varies by provider",
`:25-26`) has no guard of its own and depends on invariants it cannot check.

## Load-bearing check (revert → red → restore → green)

Reverted by copy-aside — never `git stash`, which is repo-global on this clone.

```
$ cp <patched> /tmp/prompt-flatten.FIXED.ts
$ cp <origin body from `git show 3850758df657:…`> plugins/plugin-cli-inference/src/prompt-flatten.ts
$ bunx vitest run --config ./vitest.config.ts __tests__/prompt-flatten-bounded.test.ts
 FAIL  … > bounds a deep array tool output instead of overflowing the stack
RangeError: Maximum call stack size exceeded
 FAIL  … > bounds a deep `.content` chain instead of overflowing the stack
 FAIL  … > cuts a self-referential `.content` back-edge instead of recursing forever
 FAIL  … > keeps the rest of the turn alive when one part is poisoned
RangeError: Maximum call stack size exceeded
 FAIL  … > serializes a cyclic tool output instead of throwing from JSON.stringify
TypeError: Converting circular structure to JSON
 FAIL  … > bounds the AI-SDK `{type:'json',value}` tool-result shape
RangeError: Maximum call stack size exceeded
 FAIL  … > bounds cyclic tool-call arguments carried in the content array
TypeError: Converting circular structure to JSON
 FAIL  … > bounds cyclic arguments carried on `message.toolCalls`
TypeError: Converting circular structure to JSON
 FAIL  … > charges container width so a very wide payload cannot exhaust the walk
 FAIL  … > never invokes an accessor on an untrusted payload
      Tests  10 failed | 5 passed (15)

$ cp /tmp/prompt-flatten.FIXED.ts plugins/plugin-cli-inference/src/prompt-flatten.ts
$ bunx vitest run --config ./vitest.config.ts __tests__/prompt-flatten-bounded.test.ts
      Tests  15 passed (15)
```

The 5 that pass on the origin body are the no-over-rejection half; they are meant
to pass on both sides.

## Compatibility corpus — no over-rejection (`identical=30 differing=0`)

30 ordinary tool payloads flattened through the **origin** module (extracted with
`git show 3850758df657:plugins/plugin-cli-inference/src/prompt-flatten.ts`) and
through the **patched** module, compared byte for byte.

<details><summary><code>node --experimental-strip-types compat-promptflatten.mjs</code></summary>

```
identical  bare string output               (166 bytes)
identical  {type:text,value}                (159 bytes)
identical  {text}                           (164 bytes)
identical  array of text parts              (155 bytes)
identical  array with empty entries         (152 bytes)
identical  .content unwrap                  (154 bytes)
identical  .content nested 10 deep          (152 bytes)
identical  {type:json,value} object         (201 bytes)
identical  plain JSON object                (207 bytes)
identical  JSON with nulls/bools/nums       (201 bytes)
identical  JSON with unicode + emoji        (209 bytes)
identical  JSON with Date                   (185 bytes)
identical  JSON with undefined member       (165 bytes)
identical  array holding undefined          (167 bytes)
identical  empty object                     (150 bytes)
identical  empty array                      (106 bytes)
identical  number output                    (150 bytes)
identical  boolean output                   (152 bytes)
identical  null output                      (106 bytes)
identical  honest DAG (shared ref twice)    (227 bytes)
identical  deeply-but-honestly nested 40    (643 bytes)
identical  5000-row wide payload            (240440 bytes)
identical  big 2MB string body              (2097315 bytes)
identical  tool-call object input           (196 bytes)
identical  tool-call string input           (172 bytes)
identical  tool-call empty input            (147 bytes)
identical  call+result pair                 (188 bytes)
identical  assistant message.toolCalls      (111 bytes)
identical  unknown part type                (106 bytes)
identical  output with only whitespace      (151 bytes)

corpus=30 identical=30 differing=0
```

</details>

Three of those cases are the ones reviewers usually ask about on this family:
`honest DAG (shared ref twice)` proves the cycle guard is path-local and does not
collapse a legitimate repeated reference; `5000-row wide payload` (240 KB, 20 000
nodes) proves the node budget does not clip ordinary width; `big 2MB string body`
proves the character budget checks before it charges, so a single large tool
output still comes back whole.

## Suites, typecheck, lint

```
$ bun run --cwd plugins/plugin-cli-inference test
 Test Files  8 passed (8)
      Tests  153 passed (153)

$ bun run --cwd plugins/plugin-cli-inference typecheck
$ tsc --noEmit -p tsconfig.json
(no output — 0 errors)

$ bunx @biomejs/biome check plugins/plugin-cli-inference/src/prompt-flatten.ts \
       plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts
Checked 2 files in 84ms. No fixes applied.
```

Before `packages/core` was built, 5 of the 8 files in this package failed to
import `@elizaos/core` (the package's `vitest.config.ts` aliases it to
`packages/core/dist/node/index.node.js`). That is pre-existing and unrelated:
with this PR's two files reverted by copy-aside, the same command reports the
same `5 failed | 2 passed` files. After `bun run --cwd packages/core build`, all
8 files pass.

## Known gaps / failures

- **`bun run verify` not run.** The full monorepo verification is a multi-hour
  build on this machine and the operator caps compute for this lane. Focused
  equivalents were run and are pasted above: the complete
  `plugins/plugin-cli-inference` vitest suite (153 tests), the package
  `typecheck` (0 errors), and biome on both touched files. The diff is confined
  to one plugin module and one new test file in the same package.
- **Real-LLM trajectory: `N/A`.** No live provider account is available to this
  fork-contributor environment for `packages/scenario-runner`, and the change is
  deterministic. The behaviour it would demonstrate is captured by the before/
  after runs of the real module above.
- **Hosted CI checks do not run on this PR.** We are a fork contributor without
  push access to `elizaOS/eliza`; no hosted check result is claimed anywhere in
  this body.
- **Deliberate, documented narrowings** (all listed under **Risks**): an
  attacker-supplied `get value()` accessor is no longer invoked; a non-`Date`
  `toJSON()` is no longer invoked; a `value` / `text` / `content` member
  inherited from a prototype is no longer consulted. Each one is a case where
  the old code would execute or read attacker-controlled machinery during prompt
  rendering. None is reachable from a `JSON.parse`d payload or from any in-repo
  producer of these shapes, and the 30-case corpus contains no such value.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251-promptflatten]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JFSR3R14NJSFV0V26AWH4N","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T15:42:27.448Z","completed_at":"2026-08-21T15:45:34.207Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T15:42:28.046Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"38ed103568fd2dd82eaf6cfca2b7b60f8a88d0e98ccaf210b98bf835608486d8","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"cb1fe1d3-a917-441d-a186-eafa1a76bac6","object_id":"sha256:38ed103568fd2dd82eaf6cfca2b7b60f8a88d0e98ccaf210b98bf835608486d8","sha256":"38ed103568fd2dd82eaf6cfca2b7b60f8a88d0e98ccaf210b98bf835608486d8"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"oNdMXTdl_3jXp5vsblgLGAL8XbfQ9pStQJJl2bodR9IEbwyCN4dMsUzR9ID5eJYJHz7MQEF7shEOYE6eDQrqCA"}} -->
