### PR TITLE
fix(telegram): bound settings navigation replies

### DIFF
--- a/plugins/plugin-telegram/src/command-registration.test.ts
+++ b/plugins/plugin-telegram/src/command-registration.test.ts
@@ -273,6 +273,57 @@ describe("registerTelegramCommandHandlers", () => {
     expect(reply.mock.calls[0]?.[0]).toContain("settings");
     expect(reply.mock.calls[0]?.[0]).toContain("Eliza app");
   });
+
+  it.each([
+    [
+      "a lone high surrogate",
+      "before\ud800after",
+      "Open settings → before�after in the Eliza app.",
+    ],
+    [
+      "a lone low surrogate",
+      "before\udc00after",
+      "Open settings → before�after in the Eliza app.",
+    ],
+    [
+      "an exact-cap reply",
+      "a".repeat(4062),
+      `Open settings → ${"a".repeat(4062)} in the Eliza app.`,
+    ],
+    [
+      "a cap-plus-one reply",
+      "a".repeat(4063),
+      `Open settings → ${"a".repeat(4063)} in the Eliza app`,
+    ],
+    [
+      "an astral character crossing the cap",
+      `${"a".repeat(4079)}🦊tail`,
+      `Open settings → ${"a".repeat(4079)}`,
+    ],
+    [
+      "a hostile over-limit raw argument",
+      "a".repeat(5000),
+      `Open settings → ${"a".repeat(4080)}`,
+    ],
+  ])(
+    "normalizes the /settings wire reply for %s",
+    async (_label, section, expected) => {
+      const { handlers } = registerHandlers();
+      const settingsHandler = handlers.get("settings");
+      expect(settingsHandler).toBeDefined();
+      const { ctx, reply } = makeCtx(`/settings ${section}`);
+
+      await settingsHandler?.(ctx);
+
+      expect(reply).toHaveBeenCalledTimes(1);
+      const wireText = reply.mock.calls[0]?.[0];
+      // Observe the production handler's actual wire argument: restoring the
+      // raw describeNavigation reply breaks the malformed/over-limit cases.
+      expect(wireText).toBe(expected);
+      expect(wireText?.length).toBeLessThanOrEqual(4096);
+      expect(wireText?.isWellFormed()).toBe(true);
+    },
+  );
 });
 
 describe("Telegram Mini App launch command", () => {

--- a/plugins/plugin-telegram/src/command-registration.ts
+++ b/plugins/plugin-telegram/src/command-registration.ts
@@ -341,9 +341,14 @@ function buildCommandHandler(
       let sectionLabel: string | undefined;
       if (command.name === "settings") {
         const raw = firstCommandArg(messageText(ctx));
-        if (raw) sectionLabel = resolveSettingsSection(raw) ?? raw;
+        if (raw) {
+          sectionLabel =
+            resolveSettingsSection(raw) ?? truncateTelegramCommandReply(raw);
+        }
       }
-      await ctx.reply(describeNavigation(command, sectionLabel));
+      await ctx.reply(
+        truncateTelegramCommandReply(describeNavigation(command, sectionLabel)),
+      );
       return;
     }
 


### PR DESCRIPTION
# Relates to

Closes #23766.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      baseline failure is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      focused Vitest artifact and reproduction steps below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@f556c9003007c0423fac0755729228d1221542b2:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@d54e2abd97aa8a62776b996a3094b034b11eabf7`; zero conflicts.
- [x] `bun run verify` was run post-sync. It stops at the pre-existing i18n gate
      failure reproduced on pristine `origin/develop`; details are below.

# Risks

Low. The change is limited to navigate-command text sent by Telegram. Unknown
`/settings` section arguments are normalized and bounded, then the complete
navigation reply is normalized and bounded again at the wire. It does not alter
authorization, destination resolution, command routing, or chunking policy.

# Background

## What does this PR do?

Reuses `truncateTelegramCommandReply` for both the raw `/settings` fallback and
the final `describeNavigation(...)` result before `ctx.reply`. Production-handler
regressions cover lone high/low surrogates, exact cap, cap + 1, an astral
character crossing the cap, and a hostile 5,000-unit raw argument.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores the existing Telegram output-boundary contract and does not
add or change a user-facing option.

# Testing

## Where should a reviewer start?

`plugins/plugin-telegram/src/command-registration.ts`, in the navigate branch of
the registered command handler, then the table-driven production-handler test in
`plugins/plugin-telegram/src/command-registration.test.ts`.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-telegram test
bun run --cwd plugins/plugin-telegram typecheck
bun run --cwd plugins/plugin-telegram build
bun run --cwd plugins/plugin-telegram lint:check
```

Observed post-rebase:

- plugin tests: 24 files, 239 tests passed;
- focused `command-registration.test.ts`: 22 tests passed, including all six new boundary cases;
- typecheck: passed;
- build: passed;
- Biome lint: passed;
- `git diff --check`: passed.

# Evidence Gate

<!-- evidence-head:cda65ffedec1e1a6fe3047cfc40c253bc87fd646 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a headless Telegram transport-boundary fix with no visual flow.
<!-- evidence-row:backend-logs -->
- [x] [23830-23766-telegram-command-registration-vitest.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23830-23766-telegram-command-registration-vitest.json)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, console, or network request changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory schema, schedule, wallet, generated media, or other domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - the change sanitizes and bounds text at the Telegram wire boundary; it
does not alter LLM behavior.

## Backend + frontend logs

The focused machine-readable Vitest report is attached in the evidence row. The
test invokes the actual `/settings` handler registered by the production bridge
and inspects the actual argument delivered to `ctx.reply`; restoring the raw
reply breaks the malformed and over-limit cases.

Frontend logs: N/A - no frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT path changed.

## Known gaps / failures

- `bun run verify` stops at `check:i18n`: `en.json` is missing seven connector
  account keys and non-English locale files are missing hundreds of existing
  keys. The same failure was reproduced in a temporary pristine worktree at
  `origin/develop@d54e2abd97aa8a62776b996a3094b034b11eabf7`; that baseline worktree
  was deleted immediately.
- No live Telegram credential/network call was used. The regression instead
  traverses the real registered handler with a mocked wire boundary.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@f556c9003007c0423fac0755729228d1221542b2:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [/root/issue23766-telegram-settings]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@f556c9003007c0423fac0755729228d1221542b2:packages/skills/skills/contribute-to-eliza"} -->

