### PR TITLE
fix(cloud): keep container secrets off process argv

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-container-provider.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-container-provider.test.ts
@@ -1,4 +1,4 @@
-// Exercises app container provider behavior with deterministic cloud-shared lib fixtures.
+/** Exercises app container orchestration with a deterministic in-process SSH seam. */
 import { describe, expect, test } from "bun:test";
 import {
   AppContainerProvider,
@@ -34,19 +34,24 @@ const INPUT: CreateContainerInput = {
 
 function recordingSsh(create = "containerid-abc123") {
   const calls: string[] = [];
+  const stdinCalls: Array<{ command: string; input: string | Buffer }> = [];
   const ssh: AppContainerSsh = {
     async exec(command) {
       calls.push(command);
-      if (command.startsWith("docker create")) return create;
       return "";
     },
+    async execStdin(command, input) {
+      calls.push(command);
+      stdinCalls.push({ command, input });
+      return create;
+    },
   };
-  return { calls, ssh };
+  return { calls, ssh, stdinCalls };
 }
 
 describe("AppContainerProvider.provision", () => {
   test("ensures the --internal network, creates, starts, and returns the id", async () => {
-    const { calls, ssh } = recordingSsh();
+    const { calls, ssh, stdinCalls } = recordingSsh();
     const provider = new AppContainerProvider({
       ssh,
       nodeId: "node-1",
@@ -64,17 +69,107 @@ describe("AppContainerProvider.provision", () => {
     expect(result.hostPort).toBe(49001);
     expect(result.network).toMatch(/^app-net-/);
 
-    // network ensured first; a docker-ps probe runs for collision-safe ports
-    expect(calls[0]).toContain("docker network create --driver bridge --internal");
-    expect(calls.some((c) => c.startsWith("docker ps"))).toBe(true);
-    const createCmd = calls.find((c) => c.startsWith("docker create")) ?? "";
+    // The collision probe is read-only; the network remains the first remote
+    // mutation, followed by stale-name cleanup and the stdin-backed create.
+    const psIndex = calls.findIndex((c) => c.startsWith("docker ps"));
+    const networkIndex = calls.findIndex((c) =>
+      c.includes("docker network create --driver bridge --internal"),
+    );
+    const removeIndex = calls.indexOf("docker rm -f 'app-nubilio'");
+    const createIndex = calls.findIndex((c) => c.includes("docker create"));
+    expect(psIndex).toBeGreaterThanOrEqual(0);
+    expect(networkIndex).toBeGreaterThan(psIndex);
+    expect(removeIndex).toBeGreaterThan(networkIndex);
+    expect(createIndex).toBeGreaterThan(removeIndex);
+    const createCmd = stdinCalls[0]?.command ?? "";
+    const createInput = String(stdinCalls[0]?.input ?? "");
     expect(createCmd).toContain("--cap-drop=ALL");
     // Host port is bound to loopback only (ingress/proxy reaches it via
     // 127.0.0.1 on the node) — never exposed on the node's public interface.
     expect(createCmd).toContain("-p 127.0.0.1:49001:3000");
-    expect(createCmd).toContain("HTTP_PROXY=http://egress-gw:3128");
+    expect(createCmd).not.toContain("HTTP_PROXY");
+    expect(createCmd).not.toContain("http://egress-gw:3128");
+    expect(createInput).toContain("HTTP_PROXY=http://egress-gw:3128");
     expect(createCmd).not.toContain("NET_ADMIN");
     expect(calls).toContain("docker start 'app-nubilio'");
+  });
+
+  test("preserves multiline and large app environment through stdin", async () => {
+    const { calls, ssh, stdinCalls } = recordingSsh();
+    const provider = new AppContainerProvider({
+      ssh,
+      nodeId: "node-1",
+      allocateHostPort: async () => 49001,
+    });
+    const pem = "-----BEGIN CERTIFICATE-----\nline one\nline two\n-----END CERTIFICATE-----\n";
+    const large = "x".repeat(70 * 1024);
+
+    await provider.provision({
+      appId: APP_ID,
+      containerName: "app-nubilio",
+      input: { ...INPUT, environmentVars: { TLS_CERT: pem, LARGE_CONFIG: large } },
+    });
+
+    const create = stdinCalls[0];
+    expect(create).toBeDefined();
+    expect(create?.command).not.toContain("TLS_CERT");
+    expect(create?.command).not.toContain(pem);
+    expect(create?.command).not.toContain(large);
+    expect(String(create?.input)).toContain(pem);
+    expect(String(create?.input)).toContain(large);
+    expect(calls).toContain("docker start 'app-nubilio'");
+  });
+
+  test("rejects an impossible app environment before allocation or remote IO", async () => {
+    const { calls, ssh } = recordingSsh();
+    let allocations = 0;
+    const provider = new AppContainerProvider({
+      ssh,
+      nodeId: "node-1",
+      allocateHostPort: async () => {
+        allocations += 1;
+        return 49001;
+      },
+    });
+
+    await expect(
+      provider.provision({
+        appId: APP_ID,
+        containerName: "app-nubilio",
+        input: { ...INPUT, environmentVars: { OVERSIZED: "x".repeat(121 * 1024) } },
+      }),
+    ).rejects.toThrow(/process entry limit/);
+
+    expect(calls).toEqual([]);
+    expect(allocations).toBe(0);
+  });
+
+  test("validates the rewritten DSN before creating the network or ambassador", async () => {
+    const { calls, ssh } = recordingSsh();
+    const provider = new AppContainerProvider({
+      ssh,
+      nodeId: "node-1",
+      allocateHostPort: async () => 49001,
+    });
+    const dsnPrefix = "postgresql://app:";
+    const dsnSuffix = "@x:5432/db";
+    const entryLimit = 120 * 1024;
+    const paddingLength =
+      entryLimit -
+      Buffer.byteLength("DATABASE_URL=") -
+      Buffer.byteLength(dsnPrefix) -
+      Buffer.byteLength(dsnSuffix);
+    const boundaryDsn = `${dsnPrefix}${"p".repeat(paddingLength)}${dsnSuffix}`;
+
+    await expect(
+      provider.provision({
+        appId: APP_ID,
+        containerName: "app-nubilio",
+        input: { ...INPUT, environmentVars: { DATABASE_URL: boundaryDsn } },
+      }),
+    ).rejects.toThrow(/process entry limit/);
+
+    expect(calls).toEqual([]);
   });
 
   test("removes any stale container by name BEFORE docker create (redeploy self-heal)", async () => {
@@ -92,7 +187,7 @@ describe("AppContainerProvider.provision", () => {
     });
 
     const rmIdx = calls.indexOf("docker rm -f 'app-nubilio'");
-    const createIdx = calls.findIndex((c) => c.startsWith("docker create"));
+    const createIdx = calls.findIndex((c) => c.includes("docker create"));
     // The idempotent `docker rm -f <name>` is issued, and it precedes the create
     // so the deterministic `app-<slug>` name is free (no 'name already in use').
     expect(rmIdx).toBeGreaterThanOrEqual(0);
@@ -107,8 +202,11 @@ describe("AppContainerProvider.provision", () => {
         calls.push(command);
         if (command === "docker rm -f 'app-nubilio'") throw new Error("rm failed");
         if (command.startsWith("docker inspect")) throw new Error("No such container");
-        if (command.startsWith("docker create")) return "cid";
         return "";
+      },
+      async execStdin(command) {
+        calls.push(command);
+        return "cid";
       },
     };
     const provider = new AppContainerProvider({
@@ -123,7 +221,7 @@ describe("AppContainerProvider.provision", () => {
     });
     // rm failed, but inspect proved the name absent before create continued.
     expect(result.containerId).toBe("cid");
-    expect(calls.some((c) => c.startsWith("docker create"))).toBe(true);
+    expect(calls.some((c) => c.includes("docker create"))).toBe(true);
   });
 
   test("an uninspectable pre-clean target blocks provisioning", async () => {
@@ -132,6 +230,9 @@ describe("AppContainerProvider.provision", () => {
         if (command.startsWith("docker rm -f")) throw new Error("ssh write failed");
         if (command.startsWith("docker inspect")) throw new Error("ssh read failed");
         return "";
+      },
+      async execStdin() {
+        return "cid";
       },
     };
     const provider = new AppContainerProvider({
@@ -152,8 +253,10 @@ describe("AppContainerProvider.provision", () => {
     const ssh = {
       async exec(command: string) {
         if (command.startsWith("docker ps")) return "0.0.0.0:30000->3000/tcp, :::30000->3000/tcp";
-        if (command.startsWith("docker create")) return "cid";
         return "";
+      },
+      async execStdin() {
+        return "cid";
       },
     };
     const provider = new AppContainerProvider({
@@ -175,9 +278,12 @@ describe("AppContainerProvider.provision", () => {
     const ssh: AppContainerSsh = {
       async exec(command) {
         calls.push(command);
-        if (command.startsWith("docker create")) return "cid";
         if (command.startsWith("docker start")) throw new Error("start failed");
         return "";
+      },
+      async execStdin(command) {
+        calls.push(command);
+        return "cid";
       },
     };
     const provider = new AppContainerProvider({
@@ -193,7 +299,7 @@ describe("AppContainerProvider.provision", () => {
   });
 
   test("provision with DATABASE_URL + POSTGRES_URL stands up the ambassador + rewrites BOTH", async () => {
-    const { calls, ssh } = recordingSsh();
+    const { calls, ssh, stdinCalls } = recordingSsh();
     const provider = new AppContainerProvider({
       ssh,
       nodeId: "node-1",
@@ -219,15 +325,19 @@ describe("AppContainerProvider.provision", () => {
     expect(joined).toContain("'TCP-LISTEN:5432,fork,reuseaddr'");
     expect(joined).toMatch(/docker network connect 'app-net-\S+' 'app-db-111111112222'/);
     // the app container's DSN host is rewritten to the ambassador (creds/db/params kept)
-    const createCmd = calls.find((c) => c.startsWith("docker create")) ?? "";
-    expect(createCmd).toContain(
-      "DATABASE_URL=postgresql://app_x:p%40ss@app-db-111111112222:5432/db_app_x?sslmode=require",
+    const createCmd = stdinCalls[0]?.command ?? "";
+    const createInput = String(stdinCalls[0]?.input ?? "");
+    expect(createCmd).not.toContain("DATABASE_URL");
+    expect(createCmd).not.toContain("POSTGRES_URL");
+    expect(createCmd).not.toContain("p%40ss");
+    expect(createInput).toContain(
+      "DATABASE_URL='postgresql://app_x:p%40ss@app-db-111111112222:5432/db_app_x?sslmode=require'",
     );
-    expect(createCmd).toContain(
-      "POSTGRES_URL=postgresql://app_x:p%40ss@app-db-111111112222:5432/db_app_x?sslmode=require",
+    expect(createInput).toContain(
+      "POSTGRES_URL='postgresql://app_x:p%40ss@app-db-111111112222:5432/db_app_x?sslmode=require'",
     );
     // neither var still points at the real cluster host (both rewritten to the ambassador)
-    expect(createCmd).not.toContain("@10.43.0.10:5432");
+    expect(createInput).not.toContain("@10.43.0.10:5432");
   });
 
   test("lifecycle verbs issue the expected docker commands", async () => {

--- a/packages/cloud/shared/src/lib/services/__tests__/app-docker-cmd.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-docker-cmd.test.ts
@@ -1,4 +1,4 @@
-// Exercises app docker cmd behavior with deterministic cloud-shared lib fixtures.
+/** Exercises the deterministic app Docker stdin plan without reaching Docker or SSH. */
 import { describe, expect, test } from "bun:test";
 import { buildAppDockerCreateCmd } from "../app-docker-cmd";
 import type { CreateContainerInput } from "../containers/hetzner-client/types";
@@ -33,13 +33,13 @@ function build(over: Partial<CreateContainerInput> = {}, egress?: string) {
 
 describe("buildAppDockerCreateCmd", () => {
   test("puts the container on its own --internal app network", () => {
-    const cmd = build();
+    const { command: cmd } = build();
     expect(cmd).toMatch(/--network 'app-net-[a-z0-9]+'/);
     expect(cmd).not.toContain("containers-isolated");
   });
 
   test("hardens the container and NEVER uses the agent escapes", () => {
-    const cmd = build();
+    const { command: cmd } = build();
     expect(cmd).toContain("--cap-drop=ALL");
     expect(cmd).toContain("no-new-privileges");
     expect(cmd).toContain("--pids-limit=512");
@@ -52,14 +52,14 @@ describe("buildAppDockerCreateCmd", () => {
   });
 
   test("maps the host port, sets memory, and runs the requested image", () => {
-    const cmd = build();
+    const { command: cmd } = build();
     expect(cmd).toContain("-p 127.0.0.1:49001:3000");
     expect(cmd).toContain("--memory '512m'");
     expect(cmd).toContain("'ghcr.io/nubs/nubilio:latest'");
   });
 
   test("publishes ONLY to loopback so the port is not reachable across the private network", () => {
-    const cmd = build();
+    const { command: cmd } = build();
     // The published mapping must be loopback-scoped, never a bare/0.0.0.0 bind
     // (a bare `-p host:container` binds 0.0.0.0 -> cross-tenant ingress bypass).
     expect(cmd).toContain("-p 127.0.0.1:49001:3000");
@@ -69,29 +69,62 @@ describe("buildAppDockerCreateCmd", () => {
 
   test("caps CPU and pins swap to the memory limit (untrusted-tenant DoS guards)", () => {
     // 1024 ECS units = 1 full vCPU.
-    expect(build()).toContain("--cpus 1");
+    expect(build().command).toContain("--cpus 1");
     // Fractional + multi-vCPU allocations convert cleanly.
-    expect(build({ cpu: 512 })).toContain("--cpus 0.5");
-    expect(build({ cpu: 2048 })).toContain("--cpus 2");
+    expect(build({ cpu: 512 }).command).toContain("--cpus 0.5");
+    expect(build({ cpu: 2048 }).command).toContain("--cpus 2");
     // Swap pinned to the memory limit (no swap escape of the --memory ceiling).
-    expect(build()).toContain("--memory-swap '512m'");
+    expect(build().command).toContain("--memory-swap '512m'");
   });
 
-  test("never auto-injects DATABASE_URL, but forwards a caller-supplied one", () => {
-    expect(build()).not.toContain("DATABASE_URL");
+  test("never auto-injects DATABASE_URL and keeps a caller DSN off argv", () => {
+    expect(build().command).not.toContain("DATABASE_URL");
     const dsn = "postgresql://app_x:pw@apps-cluster-1/db_app_x?sslmode=require";
     const withDb = build({ environmentVars: { DATABASE_URL: dsn } });
-    expect(withDb).toContain(`-e ${"'"}DATABASE_URL=${dsn}${"'"}`);
+    expect(withDb.command).toContain('--env-file "$env_file"');
+    expect(withDb.command).not.toContain("DATABASE_URL");
+    expect(withDb.command).not.toContain(dsn);
+    expect(withDb.input).toContain("DATABASE_URL");
+    expect(withDb.input).toContain(dsn);
+  });
+
+  test("keeps arbitrary caller keys and values out of Docker argv", () => {
+    const key = "CUSTOM_API_TOKEN";
+    const value = "app-secret-argv-sentinel";
+    const transport = build({ environmentVars: { [key]: value } });
+
+    expect(transport.command).not.toContain(key);
+    expect(transport.command).not.toContain(value);
+    expect(transport.input).toContain(key);
+    expect(transport.input).toContain(value);
   });
 
   test("routes egress through the proxy when one is given", () => {
-    const cmd = build({}, "http://egress-gw:3128");
-    expect(cmd).toContain("HTTP_PROXY=http://egress-gw:3128");
-    expect(cmd).toContain("HTTPS_PROXY=http://egress-gw:3128");
+    const transport = build({}, "http://egress-gw:3128");
+    expect(transport.command).not.toContain("HTTP_PROXY");
+    expect(transport.command).not.toContain("http://egress-gw:3128");
+    expect(transport.input).toContain("HTTP_PROXY=http://egress-gw:3128");
+    expect(transport.input).toContain("HTTPS_PROXY=http://egress-gw:3128");
+  });
+
+  test("preserves caller PORT precedence while infrastructure egress wins", () => {
+    const transport = build(
+      {
+        environmentVars: {
+          PORT: "4444",
+          HTTP_PROXY: "http://caller-proxy:9999",
+        },
+      },
+      "http://egress-gw:3128",
+    );
+
+    expect(transport.input).toContain("PORT='4444'");
+    expect(transport.input).not.toContain("http://caller-proxy:9999");
+    expect(transport.input).toContain("HTTP_PROXY=http://egress-gw:3128");
   });
 
   test("honors a custom container port and health path", () => {
-    const cmd = build({ port: 8080, healthCheckPath: "/healthz" });
+    const { command: cmd } = build({ port: 8080, healthCheckPath: "/healthz" });
     expect(cmd).toContain("-p 127.0.0.1:49001:8080");
     expect(cmd).toContain("localhost:8080/healthz");
   });

--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-steward-secret-transport.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-steward-secret-transport.test.ts
@@ -1,0 +1,612 @@
+/**
+ * Pins DockerSandboxProvider's secret-bearing SSH transports. The harness
+ * captures commands/stdin and executes safe remote parsers locally; it never
+ * reaches a real Docker node or Steward deployment.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { spawn, spawnSync } from "node:child_process";
+import { chmod, mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildRegisterAgentWithStewardRequest,
+  buildSignedDeleteAgentRequest,
+  buildStewardRefreshLoopScript,
+  deregisterAgentWithSteward,
+  registerAgentWithSteward,
+  startStewardRefreshSidecar,
+  writeManagedElizaRuntimeConfig,
+} from "../docker-sandbox-provider";
+import type { DockerSSHClient } from "../docker-ssh";
+
+const PLATFORM_KEY_SENTINEL = "platform-key-sentinel-23804";
+const SIGNING_SECRET_SENTINEL = "signing-secret-sentinel-23804";
+const TENANT_KEY_SENTINEL = "tenant-key-sentinel-23804";
+const CLOUD_API_KEY_SENTINEL = "cloud-api-key-sentinel-23804";
+const REFRESH_SERVICE_TOKEN_SENTINEL = "refresh-service-token-sentinel-23804";
+const RUN_REAL_DOCKER = process.env.ELIZA_DOCKER_ENV_STDIN_REAL === "1";
+const MANAGED_ENV_KEYS = [
+  "STEWARD_API_URL",
+  "STEWARD_PLATFORM_KEY",
+  "STEWARD_PLATFORM_KEYS",
+  "STEWARD_REQUEST_SIGNING_SECRET",
+  "STEWARD_REQUEST_SIGNING_SECRETS",
+] as const;
+const savedEnv = Object.fromEntries(MANAGED_ENV_KEYS.map((key) => [key, process.env[key]]));
+
+interface CommandResult {
+  code: number | null;
+  stderr: string;
+  stdout: string;
+}
+
+function restoreEnv(): void {
+  for (const key of MANAGED_ENV_KEYS) {
+    const saved = savedEnv[key];
+    if (saved === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = saved;
+    }
+  }
+}
+
+function configureStewardSecrets(baseUrl = "https://steward.invalid.example"): void {
+  process.env.STEWARD_API_URL = baseUrl;
+  process.env.STEWARD_PLATFORM_KEY = PLATFORM_KEY_SENTINEL;
+  delete process.env.STEWARD_PLATFORM_KEYS;
+  process.env.STEWARD_REQUEST_SIGNING_SECRET = SIGNING_SECRET_SENTINEL;
+  delete process.env.STEWARD_REQUEST_SIGNING_SECRETS;
+}
+
+function decodeJsonFrame(input: string): {
+  end: string;
+  header: string;
+  payload: Record<string, unknown>;
+} {
+  const parts = input.split("\n");
+  expect(parts).toHaveLength(4);
+  expect(parts[3]).toBe("");
+  return {
+    header: parts[0],
+    payload: JSON.parse(Buffer.from(parts[1], "base64").toString("utf8")) as Record<
+      string,
+      unknown
+    >,
+    end: parts[2],
+  };
+}
+
+function runRemoteCommand(command: string, input: string | Buffer): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("/bin/sh", ["-c", command], { stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk.toString()));
+    child.stderr.on("data", (chunk) => (stderr += chunk.toString()));
+    child.once("error", reject);
+    child.once("close", (code) => resolve({ code, stderr, stdout }));
+    child.stdin.end(input);
+  });
+}
+
+function executingSsh(): DockerSSHClient {
+  return {
+    execStdin: async (command: string, input: string | Buffer) => {
+      const result = await runRemoteCommand(command, input);
+      if (result.code !== 0) {
+        throw new Error(`${result.stderr}${result.stdout}`.trim());
+      }
+      return result.stdout;
+    },
+  } as unknown as DockerSSHClient;
+}
+
+async function listen(
+  handler: (request: IncomingMessage, response: ServerResponse) => void,
+): Promise<{ close: () => Promise<void>; url: string }> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("test HTTP server did not expose a TCP address");
+  }
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+function finishRequest(request: IncomingMessage, callback: () => void): void {
+  request.resume();
+  request.once("end", callback);
+}
+
+function expectCommandHasNoAuthMaterial(
+  command: string,
+  headerSets: Array<Record<string, string>>,
+): void {
+  expect(command).not.toContain("X-Steward-Platform-Key");
+  expect(command).not.toContain("x-steward-signature");
+  for (const secret of [PLATFORM_KEY_SENTINEL, SIGNING_SECRET_SENTINEL, TENANT_KEY_SENTINEL]) {
+    expect(command).not.toContain(secret);
+    expect(command).not.toContain(Buffer.from(secret).toString("base64"));
+  }
+  for (const headers of headerSets) {
+    for (const [name, value] of Object.entries(headers)) {
+      if (name.toLowerCase().startsWith("x-steward-") && value) {
+        expect(command).not.toContain(value);
+      }
+    }
+  }
+}
+
+afterEach(() => {
+  restoreEnv();
+  mock.restore();
+});
+
+describe("DockerSandboxProvider Steward stdin transport (#23804)", () => {
+  test("registers with platform and signed headers only in versioned stdin", async () => {
+    configureStewardSecrets();
+    let capturedCommand = "";
+    let capturedInput = "";
+    const execStdin = mock(async (command: string, input: string | Buffer) => {
+      capturedCommand = command;
+      capturedInput = String(input);
+      return JSON.stringify({ token: "registered-agent-token" });
+    });
+    const ssh = { execStdin } as unknown as DockerSSHClient;
+
+    const token = await registerAgentWithSteward(
+      ssh,
+      "agent-23804",
+      "Secret transport sentinel",
+      "tenant-23804",
+      TENANT_KEY_SENTINEL,
+    );
+
+    expect(token).toBe("registered-agent-token");
+    expect(execStdin).toHaveBeenCalledTimes(1);
+    const frame = decodeJsonFrame(capturedInput);
+    expect(frame.header).toBe("ELIZA_STEWARD_SSH_STDIN_V1:steward-agent-register");
+    expect(frame.end).toBe("ELIZA_STEWARD_SSH_STDIN_END");
+    const agentHeaders = frame.payload.agentHeaders as Record<string, string>;
+    const tokenHeaders = frame.payload.tokenHeaders as Record<string, string>;
+    expect(agentHeaders["X-Steward-Platform-Key"]).toBe(PLATFORM_KEY_SENTINEL);
+    expect(tokenHeaders["X-Steward-Platform-Key"]).toBe(PLATFORM_KEY_SENTINEL);
+    expect(agentHeaders["x-steward-signature"]).toStartWith("v1=");
+    expect(tokenHeaders["x-steward-signature"]).toStartWith("v1=");
+    expectCommandHasNoAuthMaterial(capturedCommand, [agentHeaders, tokenHeaders]);
+  });
+
+  test("deregisters with platform and signed headers only in versioned stdin", async () => {
+    configureStewardSecrets();
+    let capturedCommand = "";
+    let capturedInput = "";
+    const execStdin = mock(async (command: string, input: string | Buffer) => {
+      capturedCommand = command;
+      capturedInput = String(input);
+      return "";
+    });
+    const ssh = { execStdin } as unknown as DockerSSHClient;
+
+    await deregisterAgentWithSteward(ssh, "agent-23804", {
+      tenantId: "tenant-23804",
+      apiKey: TENANT_KEY_SENTINEL,
+    });
+
+    expect(execStdin).toHaveBeenCalledTimes(1);
+    const frame = decodeJsonFrame(capturedInput);
+    expect(frame.header).toBe("ELIZA_STEWARD_SSH_STDIN_V1:steward-agent-delete");
+    expect(frame.end).toBe("ELIZA_STEWARD_SSH_STDIN_END");
+    const headers = frame.payload.headers as Record<string, string>;
+    expect(headers["X-Steward-Platform-Key"]).toBe(PLATFORM_KEY_SENTINEL);
+    expect(headers["x-steward-signature"]).toStartWith("v1=");
+    expectCommandHasNoAuthMaterial(capturedCommand, [headers]);
+  });
+
+  test("rejects malformed or oversized frames without reflecting received bytes", async () => {
+    configureStewardSecrets();
+    const request = await buildRegisterAgentWithStewardRequest(
+      "agent-23804",
+      "Secret transport sentinel",
+      "tenant-23804",
+      TENANT_KEY_SENTINEL,
+    );
+    const malformedInputs = [
+      request.input.slice(0, -"ELIZA_STEWARD_SSH_STDIN_END\n".length),
+      `${request.input}raw-error-sentinel-${PLATFORM_KEY_SENTINEL}`,
+    ];
+
+    for (const input of malformedInputs) {
+      const result = await runRemoteCommand(request.command, input);
+      expect(result.code).toBe(64);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain("Invalid Steward stdin payload");
+      expect(result.stderr).not.toContain(PLATFORM_KEY_SENTINEL);
+      expect(result.stderr).not.toContain(SIGNING_SECRET_SENTINEL);
+    }
+
+    process.env.STEWARD_PLATFORM_KEY = "x".repeat(300 * 1024);
+    delete process.env.STEWARD_REQUEST_SIGNING_SECRET;
+    await expect(
+      buildSignedDeleteAgentRequest("agent-23804", { tenantId: "tenant-23804" }),
+    ).rejects.toThrow("Invalid Steward stdin payload size");
+  });
+
+  test("executes register and delete successfully without placing auth in the command", async () => {
+    const observations: Array<{ method: string; path: string; platformKey: string | undefined }> =
+      [];
+    const server = await listen((request, response) => {
+      finishRequest(request, () => {
+        observations.push({
+          method: request.method ?? "",
+          path: request.url ?? "",
+          platformKey: request.headers["x-steward-platform-key"] as string | undefined,
+        });
+        if (request.method === "DELETE") {
+          response.writeHead(204);
+          response.end();
+          return;
+        }
+        response.writeHead(201, { "content-type": "application/json" });
+        response.end(
+          request.url?.endsWith("/token") ? JSON.stringify({ token: "live-token" }) : "{}",
+        );
+      });
+    });
+
+    try {
+      configureStewardSecrets(server.url);
+      const ssh = executingSsh();
+      const token = await registerAgentWithSteward(
+        ssh,
+        "agent-23804",
+        "Secret transport sentinel",
+        "tenant-23804",
+        TENANT_KEY_SENTINEL,
+      );
+      expect(token).toBe("live-token");
+      await deregisterAgentWithSteward(ssh, "agent-23804", {
+        tenantId: "tenant-23804",
+        apiKey: TENANT_KEY_SENTINEL,
+      });
+      expect(observations).toEqual([
+        {
+          method: "POST",
+          path: "/platform/tenants/tenant-23804/agents",
+          platformKey: PLATFORM_KEY_SENTINEL,
+        },
+        {
+          method: "POST",
+          path: "/platform/tenants/tenant-23804/agents/agent-23804/token",
+          platformKey: PLATFORM_KEY_SENTINEL,
+        },
+        {
+          method: "DELETE",
+          path: "/platform/tenants/tenant-23804/agents/agent-23804",
+          platformKey: PLATFORM_KEY_SENTINEL,
+        },
+      ]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("refuses redirects for register and delete without following credentials", async () => {
+    let redirectHits = 0;
+    let sinkHits = 0;
+    const sink = await listen((request, response) => {
+      finishRequest(request, () => {
+        sinkHits += 1;
+        response.writeHead(201, { "content-type": "application/json" });
+        response.end(JSON.stringify({ token: "redirect-must-not-succeed" }));
+      });
+    });
+    const redirector = await listen((request, response) => {
+      finishRequest(request, () => {
+        redirectHits += 1;
+        response.writeHead(302, { location: `${sink.url}/capture` });
+        response.end();
+      });
+    });
+
+    try {
+      configureStewardSecrets(redirector.url);
+      const ssh = executingSsh();
+      await expect(
+        registerAgentWithSteward(
+          ssh,
+          "agent-redirect-23804",
+          "Redirect sentinel",
+          "tenant-23804",
+          TENANT_KEY_SENTINEL,
+        ),
+      ).rejects.toThrow(/status 302/);
+      await expect(
+        deregisterAgentWithSteward(ssh, "agent-redirect-23804", {
+          tenantId: "tenant-23804",
+          apiKey: TENANT_KEY_SENTINEL,
+        }),
+      ).rejects.toThrow(/status 302/);
+      expect(redirectHits).toBe(2);
+      expect(sinkHits).toBe(0);
+    } finally {
+      await Promise.all([redirector.close(), sink.close()]);
+    }
+  });
+
+  test("does not reflect Steward error bodies into loggable errors", async () => {
+    let reflectedHeaderValues: string[] = [];
+    const server = await listen((request, response) => {
+      finishRequest(request, () => {
+        reflectedHeaderValues = Object.entries(request.headers)
+          .filter(([name]) => name.startsWith("x-steward-"))
+          .flatMap(([, value]) => (Array.isArray(value) ? value : value ? [value] : []));
+        response.writeHead(500, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({
+            reflectedHeaderValues,
+            rawSecrets: [PLATFORM_KEY_SENTINEL, SIGNING_SECRET_SENTINEL, TENANT_KEY_SENTINEL],
+          }),
+        );
+      });
+    });
+
+    try {
+      configureStewardSecrets(server.url);
+      const ssh = executingSsh();
+      let loggableError = "";
+      try {
+        await registerAgentWithSteward(
+          ssh,
+          "agent-reflection-23804",
+          "Reflection sentinel",
+          "tenant-23804",
+          TENANT_KEY_SENTINEL,
+        );
+      } catch (error) {
+        loggableError = error instanceof Error ? error.message : String(error);
+      }
+      expect(loggableError).toContain("status 500");
+      for (const value of [
+        PLATFORM_KEY_SENTINEL,
+        SIGNING_SECRET_SENTINEL,
+        TENANT_KEY_SENTINEL,
+        ...reflectedHeaderValues,
+      ]) {
+        expect(loggableError).not.toContain(value);
+      }
+
+      await expect(
+        deregisterAgentWithSteward(ssh, "agent-reflection-23804", {
+          tenantId: "tenant-23804",
+          apiKey: TENANT_KEY_SENTINEL,
+        }),
+      ).rejects.toThrow(/status 500/);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe("DockerSandboxProvider remaining secret stdin transports (#23804)", () => {
+  const managedEnvironment = {
+    ELIZAOS_CLOUD_API_KEY: CLOUD_API_KEY_SENTINEL,
+    ELIZAOS_CLOUD_BASE_URL: "https://api.example.invalid/api/v1",
+    ELIZA_CLOUD_AGENT_ID: "agent-23804",
+  };
+
+  test("writes host eliza.json through stdin and preserves runtime-readable metadata", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "eliza-23804-config-"));
+    const volumePath = join(temporaryRoot, "agent-volume");
+    try {
+      await writeManagedElizaRuntimeConfig(
+        executingSsh(),
+        { kind: "host-volume", volumePath },
+        managedEnvironment,
+      );
+
+      const configPath = join(volumePath, "eliza", "eliza.json");
+      const configBytes = await readFile(configPath, "utf8");
+      expect(JSON.parse(configBytes)).toMatchObject({
+        cloud: { apiKey: CLOUD_API_KEY_SENTINEL },
+      });
+      expect((await stat(configPath)).mode & 0o777).toBe(0o644);
+
+      await chmod(configPath, 0o640);
+      const existingMetadata = await stat(configPath);
+      await writeManagedElizaRuntimeConfig(
+        executingSsh(),
+        { kind: "host-volume", volumePath },
+        { ...managedEnvironment, ELIZAOS_CLOUD_API_KEY: "replacement-cloud-key" },
+      );
+      const replacedMetadata = await stat(configPath);
+      expect(replacedMetadata.mode & 0o777).toBe(0o640);
+      expect(replacedMetadata.uid).toBe(existingMetadata.uid);
+      expect(replacedMetadata.gid).toBe(existingMetadata.gid);
+      expect(JSON.parse(await readFile(configPath, "utf8"))).toMatchObject({
+        cloud: { apiKey: "replacement-cloud-key" },
+      });
+    } finally {
+      await rm(temporaryRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("writes container eliza.json without secret or reversible encoding in argv", async () => {
+    let capturedCommand = "";
+    let capturedInput = "";
+    const exec = mock(async () => {
+      throw new Error("secret-bearing config must not use exec");
+    });
+    const execStdin = mock(async (command: string, input: string | Buffer) => {
+      capturedCommand = command;
+      capturedInput = String(input);
+      return "";
+    });
+    const ssh = { exec, execStdin } as unknown as DockerSSHClient;
+
+    await writeManagedElizaRuntimeConfig(
+      ssh,
+      { kind: "container", containerName: "agent-23804" },
+      managedEnvironment,
+    );
+
+    expect(exec).not.toHaveBeenCalled();
+    expect(execStdin).toHaveBeenCalledTimes(1);
+    expect(capturedCommand).toContain("docker exec -i");
+    expect(capturedCommand).not.toContain(CLOUD_API_KEY_SENTINEL);
+    expect(capturedCommand).not.toContain(Buffer.from(CLOUD_API_KEY_SENTINEL).toString("base64"));
+    expect(JSON.parse(capturedInput)).toMatchObject({
+      cloud: { apiKey: CLOUD_API_KEY_SENTINEL },
+    });
+  });
+
+  test("starts Steward refresh with its service token only on stdin", async () => {
+    let capturedCommand = "";
+    let capturedInput = "";
+    const exec = mock(async () => {
+      throw new Error("Steward refresh must not use exec");
+    });
+    const execStdin = mock(async (command: string, input: string | Buffer) => {
+      capturedCommand = command;
+      capturedInput = String(input);
+      return "";
+    });
+    const ssh = { exec, execStdin } as unknown as DockerSSHClient;
+
+    await startStewardRefreshSidecar(
+      ssh,
+      "agent-23804",
+      "agent-id-23804",
+      REFRESH_SERVICE_TOKEN_SENTINEL,
+    );
+
+    expect(exec).not.toHaveBeenCalled();
+    expect(execStdin).toHaveBeenCalledTimes(1);
+    expect(capturedInput).toBe(REFRESH_SERVICE_TOKEN_SENTINEL);
+    expect(capturedCommand).toContain("docker exec -i");
+    expect(capturedCommand).toContain("docker exec -d");
+    expect(capturedCommand).toContain('-H @"$auth_header_file"');
+    expect(capturedCommand).toContain("/tmp/eliza-steward-refresh-service-token");
+    expect(capturedCommand).not.toContain("/app/data/steward-refresh");
+    expect(capturedCommand).toContain("trap cleanup_refresh_files EXIT");
+    expect(capturedCommand).not.toContain(REFRESH_SERVICE_TOKEN_SENTINEL);
+    expect(capturedCommand).not.toContain(
+      Buffer.from(REFRESH_SERVICE_TOKEN_SENTINEL).toString("base64"),
+    );
+  });
+
+  test("keeps the detached Steward refresh loop valid POSIX shell", () => {
+    const script = buildStewardRefreshLoopScript("agent-id-23804");
+    const syntax = spawnSync("/bin/sh", ["-n", "-c", script], { encoding: "utf8" });
+
+    expect(syntax.status).toBe(0);
+    expect(syntax.stderr).toBe("");
+    expect(script).not.toContain("do;");
+    expect(script).not.toContain("then;");
+    expect(script).not.toContain("else;");
+  });
+
+  test("rejects unsafe Steward refresh tokens before SSH mutation", async () => {
+    const execStdin = mock(async () => "");
+    const ssh = { execStdin } as unknown as DockerSSHClient;
+
+    for (const token of ["", "line-one\nline-two", "x".repeat(8 * 1024 + 1)]) {
+      await expect(
+        startStewardRefreshSidecar(ssh, "agent-23804", "agent-id-23804", token),
+      ).rejects.toThrow("Invalid Steward refresh service token stdin payload");
+    }
+    expect(execStdin).not.toHaveBeenCalled();
+  });
+});
+
+describe.skipIf(!RUN_REAL_DOCKER)(
+  "DockerSandboxProvider Steward refresh — real Docker opt-in (#23804)",
+  () => {
+    test("starts the exact detached loop and removes transient bearer files", async () => {
+      const containerName = `eliza-steward-refresh-proof-23804-${process.pid}`;
+      const docker = (args: string[], input?: string) =>
+        spawnSync("docker", args, {
+          encoding: "utf8",
+          input,
+          maxBuffer: 4 * 1024 * 1024,
+        });
+
+      try {
+        docker(["rm", "-f", containerName]);
+        const started = docker([
+          "run",
+          "-d",
+          "--rm",
+          "--name",
+          containerName,
+          "alpine:3.23",
+          "/bin/sleep",
+          "300",
+        ]);
+        expect(started.status, started.stderr).toBe(0);
+
+        const curlStub = docker(
+          [
+            "exec",
+            "-i",
+            containerName,
+            "sh",
+            "-c",
+            "cat > /usr/local/bin/curl && chmod 755 /usr/local/bin/curl",
+          ],
+          "#!/bin/sh\nprintf '%s\\n' '{\"token\":\"jwt-from-refresh\"}'\n",
+        );
+        expect(curlStub.status, curlStub.stderr).toBe(0);
+        const sleepStub = docker(
+          [
+            "exec",
+            "-i",
+            containerName,
+            "sh",
+            "-c",
+            "cat > /usr/local/bin/sleep && chmod 755 /usr/local/bin/sleep && mkdir -p /app/data",
+          ],
+          "#!/bin/sh\nexit 7\n",
+        );
+        expect(sleepStub.status, sleepStub.stderr).toBe(0);
+
+        await startStewardRefreshSidecar(
+          executingSsh(),
+          containerName,
+          "agent-id-23804",
+          REFRESH_SERVICE_TOKEN_SENTINEL,
+        );
+
+        let proof = docker(["exec", containerName, "false"]);
+        for (let attempt = 0; attempt < 200; attempt++) {
+          proof = docker([
+            "exec",
+            containerName,
+            "sh",
+            "-c",
+            [
+              "test -f /app/data/steward.jwt",
+              "test ! -e /tmp/eliza-steward-refresh-service-token",
+              "test ! -e /tmp/eliza-steward-refresh-authorization.header",
+              'test "$(stat -c %a /app/data/steward.jwt)" = 600',
+              "cat /app/data/steward.jwt",
+            ].join(" && "),
+          ]);
+          if (proof.status === 0) break;
+          await Bun.sleep(10);
+        }
+
+        expect(proof.status, `${proof.stderr}${proof.stdout}`).toBe(0);
+        expect(proof.stdout).toBe("jwt-from-refresh");
+      } finally {
+        docker(["rm", "-f", containerName]);
+      }
+    }, 30_000);
+  },
+);

--- a/packages/cloud/shared/src/lib/services/app-container-provider.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-provider.ts
@@ -3,7 +3,7 @@
  * that runs an isolated user container on a node. It composes the pure builders
  * (network ensure + docker-create + isolation flags) and drives them over an
  * injected SSH seam, so the orchestration is unit-testable with a fake SSH and
- * the real `ssh.exec` is the only IO.
+ * arbitrary environment bytes cross the real transport only via stdin.
  *
  * Deliberately NOT a subclass of DockerSandboxProvider and NOT coupled to the
  * `containers` table here — recording the row is the job executor's concern
@@ -20,7 +20,7 @@ import {
   parseDsnEndpoint,
   rewriteDsnToAmbassador,
 } from "./app-db-ambassador";
-import { buildAppDockerCreateCmd } from "./app-docker-cmd";
+import { buildAppDockerCreateCmd, validateAppDockerEnvironment } from "./app-docker-cmd";
 import { appNetworkName, buildEnsureAppNetworkCmd } from "./app-network-utils";
 import type { CreateContainerInput } from "./containers/hetzner-client/types";
 import { shellQuote } from "./docker-sandbox-utils";
@@ -28,6 +28,7 @@ import { shellQuote } from "./docker-sandbox-utils";
 /** Minimal SSH seam — runs a command on the target node and returns stdout. */
 export interface AppContainerSsh {
   exec(command: string, timeoutMs?: number): Promise<string>;
+  execStdin(command: string, input: Buffer | string, timeoutMs?: number): Promise<string>;
 }
 
 export interface AppContainerProviderDeps {
@@ -146,27 +147,10 @@ export class AppContainerProvider {
   /** Ensure the per-app `--internal` network, create the container, start it. */
   async provision(params: ProvisionAppContainerParams): Promise<ProvisionedAppContainer> {
     const network = appNetworkName(params.appId);
-    await this.deps.ssh.exec(buildEnsureAppNetworkCmd(network));
-
-    // DB ambassador: the app is on an `--internal` net (no egress at all), so it
-    // can't reach its tenant DB directly. Stand up a per-app socat forwarder on
-    // the app net that reaches ONLY the tenant DB, and point the app's
-    // DATABASE_URL at it. The app keeps zero general egress; REVOKE-CONNECT still
-    // isolates the actual database. No DSN -> no ambassador (nothing to reach).
     let input = params.input;
     const dsn = input.environmentVars?.DATABASE_URL;
     const endpoint = dsn ? parseDsnEndpoint(dsn) : null;
     if (dsn && endpoint) {
-      const cmds = buildEnsureAmbassadorCmds({
-        appId: params.appId,
-        network,
-        db: endpoint,
-        egressNetwork: this.deps.dbEgressNetwork,
-        image: this.deps.ambassadorImage,
-      });
-      for (const cmd of cmds) {
-        await this.deps.ssh.exec(cmd);
-      }
       // Rewrite EVERY injected DSN var (DATABASE_URL + POSTGRES_URL) to the
       // ambassador host. They carry the same tenant DSN; an un-rewritten
       // POSTGRES_URL would point at the real cluster host, which is unreachable
@@ -179,6 +163,10 @@ export class AppContainerProvider {
       }
       input = { ...input, environmentVars: rewritten };
     }
+
+    // Validate the exact post-rewrite frame before port allocation or any
+    // remote mutation. Rewriting a DSN can itself cross a transport bound.
+    validateAppDockerEnvironment(input, this.deps.egressProxyUrl);
 
     // Collision-safe host port: avoid ports already published on the node. The
     // `docker ps` probe is best-effort — on failure we fall back to the blind
@@ -198,7 +186,7 @@ export class AppContainerProvider {
     for (let attempt = 0; attempt < 20 && usedPorts.has(hostPort); attempt++) {
       hostPort = await this.deps.allocateHostPort();
     }
-    const createCmd = buildAppDockerCreateCmd({
+    const createTransport = buildAppDockerCreateCmd({
       appId: params.appId,
       containerName: params.containerName,
       input,
@@ -207,6 +195,28 @@ export class AppContainerProvider {
       pidsLimit: this.deps.pidsLimit,
     });
 
+    // Build the complete stdin plan before the first SSH mutation, then preserve
+    // the existing network -> ambassador -> stale-container -> create order.
+    await this.deps.ssh.exec(buildEnsureAppNetworkCmd(network));
+
+    // DB ambassador: the app is on an `--internal` net (no egress at all), so it
+    // can't reach its tenant DB directly. Stand up a per-app socat forwarder on
+    // the app net that reaches ONLY the tenant DB, and point the app's
+    // DATABASE_URL at it. The app keeps zero general egress; REVOKE-CONNECT still
+    // isolates the actual database. No DSN -> no ambassador (nothing to reach).
+    if (endpoint) {
+      const cmds = buildEnsureAmbassadorCmds({
+        appId: params.appId,
+        network,
+        db: endpoint,
+        egressNetwork: this.deps.dbEgressNetwork,
+        image: this.deps.ambassadorImage,
+      });
+      for (const cmd of cmds) {
+        await this.deps.ssh.exec(cmd);
+      }
+    }
+
     // A redeploy reuses the deterministic `app-<slug>`
     // name, so a still-present container from a prior deploy makes `docker
     // create --name` fail with 'name already in use'. Remove it first (no-op when
@@ -214,7 +224,11 @@ export class AppContainerProvider {
     // regardless of which deploy route enqueued this provision.
     await this.removeContainerAndConfirmAbsent(params.containerName);
 
-    const stdout = await this.deps.ssh.exec(createCmd);
+    const stdout = await this.deps.ssh.execStdin(
+      createTransport.command,
+      createTransport.input,
+      60_000,
+    );
     const containerId = (this.deps.extractContainerId ?? defaultExtractContainerId)(stdout);
     await this.deps.ssh.exec(`docker start ${shellQuote(params.containerName)}`);
 

--- a/packages/cloud/shared/src/lib/services/app-docker-cmd.ts
+++ b/packages/cloud/shared/src/lib/services/app-docker-cmd.ts
@@ -7,8 +7,9 @@
  * NET_ADMIN/tun). Reads no ambient env: any `DATABASE_URL` is the caller's
  * per-tenant DSN passed via `environmentVars`, never sourced here.
  *
- * Pure string assembly so the exact run posture is a unit-testable contract;
- * the real `ssh.exec` of this command lives in the (impure) provider.
+ * Pure transport-plan assembly keeps the exact run posture unit-testable while
+ * arbitrary environment bytes travel only on stdin; the impure provider owns
+ * the corresponding `ssh.execStdin` call.
  */
 
 import {
@@ -17,7 +18,12 @@ import {
   buildAppEgressEnv,
 } from "./app-network-utils";
 import type { CreateContainerInput } from "./containers/hetzner-client/types";
-import { shellQuote } from "./docker-sandbox-utils";
+import {
+  buildDockerEnvFileStdinTransport,
+  type DockerEnvFileStdinTransport,
+  shellQuote,
+  validateDockerEnvFileStdinEnvironment,
+} from "./docker-sandbox-utils";
 
 export interface BuildAppDockerCmdParams {
   appId: string;
@@ -35,56 +41,71 @@ function appHealthCmd(port: number, path: string): string {
   return `curl -fsS http://localhost:${port}${path} || exit 1`;
 }
 
-/** Build the `docker create` command for an isolated app container. */
-export function buildAppDockerCreateCmd(params: BuildAppDockerCmdParams): string {
-  const { input } = params;
-  const network = appNetworkName(params.appId);
-  const security = buildAppContainerSecurityFlags({ pidsLimit: params.pidsLimit });
-  const egress = params.egressProxyUrl ? buildAppEgressEnv(params.egressProxyUrl) : {};
-
+function buildAppDockerEnvironment(
+  input: CreateContainerInput,
+  egressProxyUrl?: string,
+): Record<string, string> {
+  const egress = egressProxyUrl ? buildAppEgressEnv(egressProxyUrl) : {};
   // Default PORT, then caller env (may override PORT), then infra egress (wins).
-  const allEnv: Record<string, string> = {
+  return {
     PORT: String(input.port),
     ...input.environmentVars,
     ...egress,
   };
-  const envFlags = Object.entries(allEnv)
-    .map(([key, value]) => `-e ${shellQuote(`${key}=${value}`)}`)
-    .join(" ");
+}
 
-  return [
-    "docker create",
-    `--name ${shellQuote(params.containerName)}`,
-    "--restart unless-stopped",
-    `--network ${shellQuote(network)}`,
-    ...security,
-    `--health-cmd ${shellQuote(appHealthCmd(input.port, input.healthCheckPath ?? "/health"))}`,
-    "--health-interval 10s",
-    "--health-timeout 5s",
-    "--health-start-period 15s",
-    "--health-retries 6",
-    ...(input.memoryMb
-      ? [
-          `--memory ${shellQuote(`${Math.ceil(input.memoryMb)}m`)}`,
-          // Pin swap to the memory limit (i.e. no swap) so an untrusted image
-          // can't escape the --memory ceiling via swap on the shared node.
-          `--memory-swap ${shellQuote(`${Math.ceil(input.memoryMb)}m`)}`,
-        ]
-      : []),
-    // Hard CPU cap. `cpu` is ECS-style units (1024 = 1 vCPU), the same unit
-    // docker's --cpus takes once divided. Without this an untrusted tenant image
-    // can pin every core on the shared node and starve every co-tenant app (a
-    // cross-tenant availability break) — the dedicated-vCPU node sizing alone
-    // does NOT prevent in-node CPU theft.
-    ...(input.cpu > 0 ? [`--cpus ${input.cpu / 1024}`] : []),
-    // Publish to loopback only: the node-local Caddy reverse-proxies to
-    // 127.0.0.1:hostPort, so the port must NOT be reachable across the shared
-    // private network (binding 0.0.0.0 would let any other node/container hit
-    // this tenant's app directly — a cross-tenant ingress bypass).
-    `-p 127.0.0.1:${params.hostPort}:${input.port}`,
-    envFlags,
-    shellQuote(input.image),
-  ]
-    .filter((part) => part.length > 0)
-    .join(" ");
+/** Validate the exact environment frame before the provider mutates remote state. */
+export function validateAppDockerEnvironment(
+  input: CreateContainerInput,
+  egressProxyUrl?: string,
+): void {
+  validateDockerEnvFileStdinEnvironment(buildAppDockerEnvironment(input, egressProxyUrl));
+}
+
+/** Build the stdin-backed `docker create` plan for an isolated app container. */
+export function buildAppDockerCreateCmd(
+  params: BuildAppDockerCmdParams,
+): DockerEnvFileStdinTransport {
+  const { input } = params;
+  const network = appNetworkName(params.appId);
+  const security = buildAppContainerSecurityFlags({ pidsLimit: params.pidsLimit });
+  const allEnv = buildAppDockerEnvironment(input, params.egressProxyUrl);
+
+  return buildDockerEnvFileStdinTransport(allEnv, (envFilePath) =>
+    [
+      "docker create",
+      `--name ${shellQuote(params.containerName)}`,
+      "--restart unless-stopped",
+      `--network ${shellQuote(network)}`,
+      ...security,
+      `--health-cmd ${shellQuote(appHealthCmd(input.port, input.healthCheckPath ?? "/health"))}`,
+      "--health-interval 10s",
+      "--health-timeout 5s",
+      "--health-start-period 15s",
+      "--health-retries 6",
+      ...(input.memoryMb
+        ? [
+            `--memory ${shellQuote(`${Math.ceil(input.memoryMb)}m`)}`,
+            // Pin swap to the memory limit (i.e. no swap) so an untrusted image
+            // can't escape the --memory ceiling via swap on the shared node.
+            `--memory-swap ${shellQuote(`${Math.ceil(input.memoryMb)}m`)}`,
+          ]
+        : []),
+      // Hard CPU cap. `cpu` is ECS-style units (1024 = 1 vCPU), the same unit
+      // docker's --cpus takes once divided. Without this an untrusted tenant image
+      // can pin every core on the shared node and starve every co-tenant app (a
+      // cross-tenant availability break) — the dedicated-vCPU node sizing alone
+      // does NOT prevent in-node CPU theft.
+      ...(input.cpu > 0 ? [`--cpus ${input.cpu / 1024}`] : []),
+      // Publish to loopback only: the node-local Caddy reverse-proxies to
+      // 127.0.0.1:hostPort, so the port must NOT be reachable across the shared
+      // private network (binding 0.0.0.0 would let any other node/container hit
+      // this tenant's app directly — a cross-tenant ingress bypass).
+      `-p 127.0.0.1:${params.hostPort}:${input.port}`,
+      `--env-file ${envFilePath}`,
+      shellQuote(input.image),
+    ]
+      .filter((part) => part.length > 0)
+      .join(" "),
+  );
 }

--- a/packages/cloud/shared/src/lib/services/container-executor-deps.ts
+++ b/packages/cloud/shared/src/lib/services/container-executor-deps.ts
@@ -136,7 +136,8 @@ function makeNodeSsh(): AppContainerSsh {
 function makeBuilderSsh(host: string): AppContainerSsh {
   const keyB64 = containersEnv.sshKey();
   const privateKey = keyB64 ? Buffer.from(keyB64, "base64") : undefined;
-  // DockerSSHClient.exec(command, timeoutMs?) IS the AppContainerSsh shape.
+  // Keep both command paths on the pooled client: arbitrary container env is
+  // delivered only through execStdin, never interpolated into exec argv.
   const client = privateKey
     ? new DockerSSHClient({ hostname: host, username: containersEnv.sshUser(), privateKey })
     : new DockerSSHClient({
@@ -144,7 +145,10 @@ function makeBuilderSsh(host: string): AppContainerSsh {
         username: containersEnv.sshUser(),
         privateKeyPath: containersEnv.sshKeyPath(),
       });
-  return { exec: (command, timeoutMs) => client.exec(command, timeoutMs) };
+  return {
+    exec: (command, timeoutMs) => client.exec(command, timeoutMs),
+    execStdin: (command, input, timeoutMs) => client.execStdin(command, input, timeoutMs),
+  };
 }
 
 /** Parse the docker node id from the first `CONTAINERS_DOCKER_NODES` seed entry. */

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.error-policy.test.ts
@@ -1,9 +1,8 @@
-// Pins the fail-closed error policy of HetznerContainersClient: an authoritative
-// host-teardown failure (the un-caught `docker rm -f`) must PROPAGATE and leave
-// the control-plane row intact, while a best-effort `docker stop` failure and a
-// legitimately-empty list stay distinct from an internal failure. Harness is a
-// deterministic in-process fake (mocked repositories + SSH client); no live
-// Hetzner node or DB is reached.
+/**
+ * Pins Hetzner container lifecycle and stdin-environment boundaries with
+ * deterministic repository, scheduler, registry, and SSH fakes. No live node,
+ * provider, or database is reached.
+ */
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // bun runs cloud-shared test files in one process and `mock.module` overrides
@@ -11,15 +10,23 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 // afterAll so these stubs never leak into sibling files.
 import * as realContainersRepo from "../../../../db/repositories/containers";
 import * as realDockerNodesRepo from "../../../../db/repositories/docker-nodes";
+import * as realDockerNodeManager from "../../docker-node-manager";
+import * as realDockerPortAllocation from "../../docker-port-allocation";
+import { buildDockerEnvFileStdinTransport } from "../../docker-sandbox-utils";
 import * as realDockerSsh from "../../docker-ssh";
 import * as realHetznerVolumes from "../hetzner-volumes";
 import * as realMetadata from "./metadata";
+import * as realRegistry from "./registry";
+import { type CreateContainerInput, HetznerClientError } from "./types";
 
 const realContainersRepoSnap = { ...realContainersRepo };
 const realDockerNodesRepoSnap = { ...realDockerNodesRepo };
+const realDockerNodeManagerSnap = { ...realDockerNodeManager };
+const realDockerPortAllocationSnap = { ...realDockerPortAllocation };
 const realHetznerVolumesSnap = { ...realHetznerVolumes };
 const realDockerSshSnap = { ...realDockerSsh };
 const realMetadataSnap = { ...realMetadata };
+const realRegistrySnap = { ...realRegistry };
 
 const findById = mock(async (_id: string, _org: string): Promise<unknown> => null);
 const listByOrganization = mock(async (_org: string): Promise<unknown[]> => []);
@@ -27,6 +34,7 @@ const deleteRow = mock(async (_id: string, _org: string): Promise<void> => {});
 const tryReleaseNodeSlot = mock(async (): Promise<void> => {});
 const updateRow = mock(async (): Promise<unknown> => null);
 const updateStatus = mock(async (): Promise<void> => {});
+const prepareFundedRestart = mock(async (): Promise<void> => {});
 const createWithProjectIntentAndQuotaCheck = mock(
   async (): Promise<unknown> => ({
     container: ROW,
@@ -37,9 +45,17 @@ const createWithProjectIntentAndQuotaCheck = mock(
 const readMetadata = mock((_row: unknown): unknown => null);
 
 const execMock = mock(async (_cmd: string, _timeout?: number): Promise<string> => "");
-const fakeSsh = { exec: execMock, execStream: mock(async () => {}) };
+const execStdinMock = mock(
+  async (_cmd: string, _input: Buffer | string, _timeout?: number): Promise<string> => "",
+);
+const fakeSsh = { exec: execMock, execStdin: execStdinMock, execStream: mock(async () => {}) };
 const getClient = mock(() => fakeSsh);
 const findByNodeId = mock(async (_id: string): Promise<unknown> => null);
+const incrementAllocated = mock(async (_id: string): Promise<void> => {});
+const getAvailableNode = mock(async (): Promise<unknown> => null);
+const getUsedDockerHostPorts = mock(async (): Promise<Set<number>> => new Set());
+const ensureRegistryAccess = mock(async (): Promise<void> => {});
+const readPulledImageDigest = mock(async (): Promise<string | undefined> => undefined);
 const getOrCreateProjectVolume = mock(
   async (): Promise<unknown> => ({
     id: 11,
@@ -58,6 +74,7 @@ mock.module("../../../../db/repositories/containers", () => ({
     tryReleaseNodeSlot,
     update: updateRow,
     updateStatus,
+    prepareFundedRestart,
     createWithProjectIntentAndQuotaCheck,
   },
 }));
@@ -67,7 +84,21 @@ mock.module("../../../../db/repositories/docker-nodes", () => ({
   dockerNodesRepository: {
     ...realDockerNodesRepo.dockerNodesRepository,
     findByNodeId,
+    incrementAllocated,
   },
+}));
+
+mock.module("../../docker-node-manager", () => ({
+  ...realDockerNodeManager,
+  dockerNodeManager: {
+    ...realDockerNodeManager.dockerNodeManager,
+    getAvailableNode,
+  },
+}));
+
+mock.module("../../docker-port-allocation", () => ({
+  ...realDockerPortAllocation,
+  getUsedDockerHostPorts,
 }));
 
 mock.module("../hetzner-volumes", () => ({
@@ -84,6 +115,12 @@ mock.module("../../docker-ssh", () => ({
 mock.module("./metadata", () => ({
   ...realMetadata,
   readMetadata,
+}));
+
+mock.module("./registry", () => ({
+  ...realRegistry,
+  ensureRegistryAccess,
+  readPulledImageDigest,
 }));
 
 const { getHetznerContainersClient } = await import("./client");
@@ -103,6 +140,14 @@ const ROW = {
   name: "existing",
   project_name: "project-one",
   organization_id: "org1",
+  user_id: "user1",
+  image_tag: "ghcr.io/elizaos/eliza:stable",
+  port: 3000,
+  desired_count: 1,
+  cpu: 1024,
+  memory: 512,
+  environment_vars: {},
+  health_check_path: "/health",
   hcloud_volume_id: null,
   lifecycle_revision: 7,
   status: "running",
@@ -113,12 +158,54 @@ const ROW = {
   updated_at: new Date("2026-08-20T12:00:00.000Z"),
 };
 
+const NODE = {
+  node_id: "node-create",
+  hostname: "10.0.0.2",
+  ssh_port: 22,
+  ssh_user: "root",
+  host_key_fingerprint: null,
+};
+
+const NEW_CONTAINER_INPUT: CreateContainerInput = {
+  name: "stdin-env",
+  projectName: "project-stdin-env",
+  organizationId: "org1",
+  userId: "user1",
+  image: "ghcr.io/elizaos/eliza:stable",
+  port: 3000,
+  desiredCount: 1,
+  cpu: 1024,
+  memoryMb: 1024,
+};
+const TEST_PRIVATE_KEY_HEADER = ["-----BEGIN", "PRIVATE", "KEY-----"].join(" ");
+
+function expectedEnvironmentFrame(environment: Readonly<Record<string, string>>): string {
+  return buildDockerEnvFileStdinTransport(environment, () => "true").input;
+}
+
+function dockerCreateCommands(): string[] {
+  return execStdinMock.mock.calls.map((call) => call[0]);
+}
+
+function assertSecretsAbsentFromCommands(secrets: readonly string[]): void {
+  const commands = [...execMock.mock.calls.map((call) => call[0]), ...dockerCreateCommands()];
+  for (const command of commands) {
+    expect(command).not.toMatch(/(?:^|\s)-e(?:\s|$)/);
+    for (const secret of secrets) {
+      if (secret.length > 0) expect(command).not.toContain(secret);
+    }
+  }
+}
+
 afterAll(() => {
   mock.module("../../../../db/repositories/containers", () => realContainersRepoSnap);
   mock.module("../../../../db/repositories/docker-nodes", () => realDockerNodesRepoSnap);
+  mock.module("../../docker-node-manager", () => realDockerNodeManagerSnap);
+  mock.module("../../docker-port-allocation", () => realDockerPortAllocationSnap);
   mock.module("../hetzner-volumes", () => realHetznerVolumesSnap);
   mock.module("../../docker-ssh", () => realDockerSshSnap);
   mock.module("./metadata", () => realMetadataSnap);
+  mock.module("./registry", () => realRegistrySnap);
 });
 
 beforeEach(() => {
@@ -129,11 +216,18 @@ beforeEach(() => {
     tryReleaseNodeSlot,
     updateRow,
     updateStatus,
+    prepareFundedRestart,
     createWithProjectIntentAndQuotaCheck,
     readMetadata,
     execMock,
+    execStdinMock,
     getClient,
     findByNodeId,
+    incrementAllocated,
+    getAvailableNode,
+    getUsedDockerHostPorts,
+    ensureRegistryAccess,
+    readPulledImageDigest,
     getOrCreateProjectVolume,
   ]) {
     m.mockReset();
@@ -144,14 +238,21 @@ beforeEach(() => {
   tryReleaseNodeSlot.mockResolvedValue(undefined);
   updateRow.mockResolvedValue(null);
   updateStatus.mockResolvedValue(undefined);
+  prepareFundedRestart.mockResolvedValue(undefined);
   createWithProjectIntentAndQuotaCheck.mockResolvedValue({
     container: ROW,
     created: false,
   });
   readMetadata.mockReturnValue(META);
   execMock.mockResolvedValue("");
+  execStdinMock.mockResolvedValue("");
   getClient.mockReturnValue(fakeSsh);
   findByNodeId.mockResolvedValue(null);
+  incrementAllocated.mockResolvedValue(undefined);
+  getAvailableNode.mockResolvedValue(NODE);
+  getUsedDockerHostPorts.mockResolvedValue(new Set());
+  ensureRegistryAccess.mockResolvedValue(undefined);
+  readPulledImageDigest.mockResolvedValue(undefined);
   getOrCreateProjectVolume.mockResolvedValue({ id: 11, location: { name: "fsn1" } });
   volumesAvailable = false;
 });
@@ -207,6 +308,221 @@ describe("createContainer — primary project intent", () => {
     expect(updateStatus).toHaveBeenCalledWith("ct1", "failed", "volume preflight unavailable");
     expect(getClient).not.toHaveBeenCalled();
     expect(execMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("createContainer — stdin-only environment transport", () => {
+  test("a newly admitted intent keeps multiline and 70 KiB values off every command", async () => {
+    const privateKey = `${TEST_PRIVATE_KEY_HEADER}\nline one with 'quotes'\nline two\n-----END PRIVATE KEY-----\n`;
+    const largeSecret = `seventy-kib-secret:${"x".repeat(70 * 1024)}`;
+    const environmentVars = {
+      APP_SECRET: "new-intent-secret-sentinel",
+      PRIVATE_KEY: privateKey,
+      LARGE_SECRET: largeSecret,
+    };
+    createWithProjectIntentAndQuotaCheck.mockResolvedValue({
+      container: { ...ROW, environment_vars: environmentVars },
+      created: true,
+    });
+
+    const client = getHetznerContainersClient();
+    await expect(
+      client.createContainer({ ...NEW_CONTAINER_INPUT, environmentVars }),
+    ).resolves.toMatchObject({ id: "ct1" });
+
+    expect(createWithProjectIntentAndQuotaCheck).toHaveBeenCalledTimes(1);
+    expect(createWithProjectIntentAndQuotaCheck.mock.calls[0]?.[0]).toMatchObject({
+      environment_vars: environmentVars,
+    });
+    expect(execStdinMock).toHaveBeenCalledTimes(1);
+    const [command, input, timeout] = execStdinMock.mock.calls[0]!;
+    expect(command).toContain("docker create");
+    expect(command).toContain('--env-file "$env_file"');
+    expect(input).toBe(expectedEnvironmentFrame(environmentVars));
+    expect(input).toContain(TEST_PRIVATE_KEY_HEADER);
+    expect(input).toContain("line two\n-----END PRIVATE KEY-----");
+    expect(input).toContain(largeSecret);
+    expect(Buffer.byteLength(input)).toBeGreaterThan(70 * 1024);
+    expect(timeout).toBe(60_000);
+    assertSecretsAbsentFromCommands(Object.values(environmentVars));
+    for (const key of Object.keys(environmentVars)) expect(command).not.toContain(key);
+  });
+
+  test("a host-port collision retries with byte-identical stdin and a distinct port", async () => {
+    const environmentVars = {
+      API_TOKEN: "collision-secret-sentinel",
+      PRIVATE_KEY: "first line\nsecond line\n",
+    };
+    createWithProjectIntentAndQuotaCheck.mockResolvedValue({
+      container: { ...ROW, environment_vars: environmentVars },
+      created: true,
+    });
+    execStdinMock.mockImplementation(async () => {
+      if (execStdinMock.mock.calls.length === 1) {
+        throw new Error("Bind for 0.0.0.0 failed: port is already allocated");
+      }
+      return "";
+    });
+
+    const client = getHetznerContainersClient();
+    await expect(
+      client.createContainer({ ...NEW_CONTAINER_INPUT, environmentVars }),
+    ).resolves.toMatchObject({ id: "ct1" });
+
+    expect(execStdinMock).toHaveBeenCalledTimes(2);
+    const firstCommand = execStdinMock.mock.calls[0]![0];
+    const secondCommand = execStdinMock.mock.calls[1]![0];
+    const firstInput = execStdinMock.mock.calls[0]![1];
+    const secondInput = execStdinMock.mock.calls[1]![1];
+    expect(firstInput).toBe(expectedEnvironmentFrame(environmentVars));
+    expect(secondInput).toBe(firstInput);
+    expect(Buffer.from(secondInput)).toEqual(Buffer.from(firstInput));
+
+    const firstPort = firstCommand.match(/\s-p (\d+):3000(?:\s|$)/)?.[1];
+    const secondPort = secondCommand.match(/\s-p (\d+):3000(?:\s|$)/)?.[1];
+    expect(firstPort).toMatch(/^\d+$/);
+    expect(secondPort).toMatch(/^\d+$/);
+    expect(secondPort).not.toBe(firstPort);
+    expect(
+      execMock.mock.calls.filter(([command]) => command.includes("docker network inspect")),
+    ).toHaveLength(2);
+    assertSecretsAbsentFromCommands(Object.values(environmentVars));
+  });
+
+  test("NUL and oversized values are rejected before intent admission, node selection, or SSH", async () => {
+    const invalidEnvironments = [
+      { PRIVATE_KEY: "nul-secret\0must-not-travel" },
+      { LARGE_SECRET: `oversized-secret:${"x".repeat(121 * 1024)}` },
+    ];
+    const client = getHetznerContainersClient();
+
+    for (const environmentVars of invalidEnvironments) {
+      let rejection: unknown;
+      try {
+        await client.createContainer({ ...NEW_CONTAINER_INPUT, environmentVars });
+      } catch (error) {
+        rejection = error;
+      }
+      expect(rejection).toBeInstanceOf(HetznerClientError);
+      expect(rejection).toMatchObject({ code: "invalid_input" });
+    }
+
+    expect(createWithProjectIntentAndQuotaCheck).not.toHaveBeenCalled();
+    expect(getAvailableNode).not.toHaveBeenCalled();
+    expect(getUsedDockerHostPorts).not.toHaveBeenCalled();
+    expect(getClient).not.toHaveBeenCalled();
+    expect(execMock).not.toHaveBeenCalled();
+    expect(execStdinMock).not.toHaveBeenCalled();
+    expect(updateRow).not.toHaveBeenCalled();
+    expect(updateStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe("setEnv — validate before mutation and recreate through stdin", () => {
+  test("rejects invalid frames before funding state, lookup, stop, rm, or SSH", async () => {
+    const client = getHetznerContainersClient();
+    const invalidEnvironments = [
+      { PRIVATE_KEY: "nul-secret\0must-not-travel" },
+      { LARGE_SECRET: `oversized-secret:${"x".repeat(121 * 1024)}` },
+    ];
+
+    for (const environmentVars of invalidEnvironments) {
+      let rejection: unknown;
+      try {
+        await client.setEnv("ct1", "org1", environmentVars);
+      } catch (error) {
+        rejection = error;
+      }
+      expect(rejection).toBeInstanceOf(HetznerClientError);
+      expect(rejection).toMatchObject({ code: "invalid_input" });
+    }
+
+    expect(prepareFundedRestart).not.toHaveBeenCalled();
+    expect(findById).not.toHaveBeenCalled();
+    expect(findByNodeId).not.toHaveBeenCalled();
+    expect(getClient).not.toHaveBeenCalled();
+    expect(execMock).not.toHaveBeenCalled();
+    expect(execStdinMock).not.toHaveBeenCalled();
+    expect(updateRow).not.toHaveBeenCalled();
+  });
+
+  test("orders stop, rm, network, stdin create, start, then persists the exact environment", async () => {
+    const environmentVars = {
+      API_TOKEN: "set-env-secret-sentinel",
+      PRIVATE_KEY: "-----BEGIN KEY-----\nmultiline\n-----END KEY-----\n",
+      EMPTY: "",
+    };
+    const events: string[] = [];
+    prepareFundedRestart.mockImplementation(async () => {
+      events.push("funded");
+    });
+    execMock.mockImplementation(async (command: string) => {
+      if (command.includes("docker stop")) events.push("stop");
+      else if (command.includes("docker rm -f")) events.push("rm");
+      else if (command.includes("docker network inspect")) events.push("network");
+      else if (command.includes("docker start")) events.push("start");
+      return "";
+    });
+    execStdinMock.mockImplementation(async () => {
+      events.push("stdin-create");
+      return "";
+    });
+    updateRow.mockImplementation(async () => {
+      events.push("persist");
+      return null;
+    });
+
+    const client = getHetznerContainersClient();
+    await expect(client.setEnv("ct1", "org1", environmentVars)).resolves.toMatchObject({
+      id: "ct1",
+    });
+
+    expect(events).toEqual(["funded", "stop", "rm", "network", "stdin-create", "start", "persist"]);
+    expect(prepareFundedRestart).toHaveBeenCalledWith("ct1", "org1", expect.any(Date));
+    expect(execStdinMock).toHaveBeenCalledTimes(1);
+    const [command, input, timeout] = execStdinMock.mock.calls[0]!;
+    expect(command).toContain("docker create");
+    expect(command).toContain('--env-file "$env_file"');
+    expect(input).toBe(expectedEnvironmentFrame(environmentVars));
+    expect(timeout).toBe(60_000);
+    expect(updateRow).toHaveBeenCalledWith(
+      "ct1",
+      "org1",
+      expect.objectContaining({
+        environment_vars: environmentVars,
+        status: "deploying",
+      }),
+    );
+    assertSecretsAbsentFromCommands(Object.values(environmentVars));
+    for (const key of Object.keys(environmentVars)) expect(command).not.toContain(key);
+  });
+
+  test("a remote create error can quote its command without disclosing stdin secrets", async () => {
+    const environmentVars = {
+      API_TOKEN: "set-env-error-secret-sentinel",
+      PRIVATE_KEY: "error-path-line-one\nerror-path-line-two\n",
+    };
+    execStdinMock.mockImplementation(async (command: string) => {
+      throw new Error(`remote create rejected command: ${command}`);
+    });
+
+    const client = getHetznerContainersClient();
+    let rejection: unknown;
+    try {
+      await client.setEnv("ct1", "org1", environmentVars);
+    } catch (error) {
+      rejection = error;
+    }
+
+    expect(rejection).toBeInstanceOf(Error);
+    const rejectionText = String(rejection);
+    expect(rejectionText).toContain("remote create rejected command");
+    for (const [key, secret] of Object.entries(environmentVars)) {
+      expect(rejectionText).not.toContain(key);
+      expect(rejectionText).not.toContain(secret);
+    }
+    assertSecretsAbsentFromCommands(Object.values(environmentVars));
+    expect(updateRow).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-client/client.ts
@@ -21,8 +21,10 @@ import { dockerNodeManager } from "../../docker-node-manager";
 import { getUsedDockerHostPorts } from "../../docker-port-allocation";
 import {
   allocatePort,
+  buildDockerEnvFileStdinTransport,
   buildEnsureNetworkCmd,
   shellQuote,
+  validateDockerEnvFileStdinEnvironment,
   WEBUI_PORT_MAX,
   WEBUI_PORT_MIN,
 } from "../../docker-sandbox-utils";
@@ -43,7 +45,6 @@ import {
   derivePublicHostname,
   deriveVolumePath,
   validateContainerMountPath,
-  validateEnvKey,
 } from "./paths";
 import { buildContainerPortPublishFlag } from "./port-publish";
 import { ensureRegistryAccess, readPulledImageDigest } from "./registry";
@@ -75,6 +76,20 @@ function cpuUnitsToDockerCpus(cpuUnits: number): string {
   return (Math.round(vcpus * 1000) / 1000).toString();
 }
 
+function validateContainerEnvironment(environment: Readonly<Record<string, string>>): void {
+  try {
+    validateDockerEnvFileStdinEnvironment(environment);
+  } catch (error) {
+    // error-policy:J2 boundary translation — the public Hetzner route maps
+    // invalid_input to 400, so transport validation must not escape as a 500.
+    throw new HetznerClientError(
+      "invalid_input",
+      `Invalid container environment: ${error instanceof Error ? error.message : String(error)}`,
+      error,
+    );
+  }
+}
+
 export class HetznerContainersClient {
   // ----------------------------------------------------------------------
   // CRUD
@@ -98,9 +113,7 @@ export class HetznerContainersClient {
         `desiredCount must be 1; multi-replica containers are not supported on the Hetzner-Docker pool.`,
       );
     }
-    if (input.environmentVars) {
-      for (const key of Object.keys(input.environmentVars)) validateEnvKey(key);
-    }
+    validateContainerEnvironment(input.environmentVars ?? {});
     const volumeMountPath = validateContainerMountPath(input.volumeMountPath);
 
     // 1. Pre-create the DB row in `pending` so the rest of the flow has an id.
@@ -267,33 +280,36 @@ export class HetznerContainersClient {
         bootstrapStats = await hydrateBootstrapSource(ssh, volumePath, input.bootstrapSource);
       }
 
-      const envFlags = Object.entries(input.environmentVars ?? {})
-        .map(([k, v]) => `-e ${shellQuote(`${k}=${v}`)}`)
-        .join(" ");
-
       let hostPort: number | undefined;
       const maxPortAttempts = 5;
       for (let attempt = 1; attempt <= maxPortAttempts; attempt++) {
-        hostPort = allocatePort(WEBUI_PORT_MIN, WEBUI_PORT_MAX, usedPorts);
-        const dockerCreateCmd = [
-          "docker create",
-          `--name ${shellQuote(containerName)}`,
-          "--restart unless-stopped",
-          `--network ${shellQuote(DEFAULT_NODE_NETWORK)}`,
-          `--cpus ${cpuUnitsToDockerCpus(input.cpu)}`,
-          `--memory ${input.memoryMb}m`,
-          ...buildAppContainerSecurityFlags(),
-          ...(volumePath ? [`-v ${shellQuote(volumePath)}:${shellQuote(volumeMountPath)}`] : []),
-          buildContainerPortPublishFlag(hostPort, input.port),
-          envFlags,
-          shellQuote(input.image),
-        ]
-          .filter((part) => part.length > 0)
-          .join(" ");
+        const candidateHostPort = allocatePort(WEBUI_PORT_MIN, WEBUI_PORT_MAX, usedPorts);
+        hostPort = candidateHostPort;
+        const createTransport = buildDockerEnvFileStdinTransport(
+          input.environmentVars ?? {},
+          (envFilePath) =>
+            [
+              "docker create",
+              `--name ${shellQuote(containerName)}`,
+              "--restart unless-stopped",
+              `--network ${shellQuote(DEFAULT_NODE_NETWORK)}`,
+              `--cpus ${cpuUnitsToDockerCpus(input.cpu)}`,
+              `--memory ${input.memoryMb}m`,
+              ...buildAppContainerSecurityFlags(),
+              ...(volumePath
+                ? [`-v ${shellQuote(volumePath)}:${shellQuote(volumeMountPath)}`]
+                : []),
+              buildContainerPortPublishFlag(candidateHostPort, input.port),
+              `--env-file ${envFilePath}`,
+              shellQuote(input.image),
+            ]
+              .filter((part) => part.length > 0)
+              .join(" "),
+        );
 
         try {
           await ssh.exec(buildEnsureNetworkCmd(DEFAULT_NODE_NETWORK), 30_000);
-          await ssh.exec(dockerCreateCmd, 60_000);
+          await ssh.execStdin(createTransport.command, createTransport.input, 60_000);
           break;
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
@@ -707,10 +723,35 @@ export class HetznerContainersClient {
     organizationId: string,
     environmentVars: Record<string, string>,
   ): Promise<ContainerSummary> {
-    for (const key of Object.keys(environmentVars)) validateEnvKey(key);
+    // Validate the complete frame before funding state or the existing
+    // container is touched. Invalid input must not turn setEnv into a
+    // destructive stop/remove followed by an impossible replacement.
+    validateContainerEnvironment(environmentVars);
     await containersRepository.prepareFundedRestart(containerId, organizationId, new Date());
     const row = await this.requireRowWithMeta(containerId, organizationId);
     const { meta } = row;
+
+    const createTransport = buildDockerEnvFileStdinTransport(environmentVars, (envFilePath) =>
+      [
+        "docker create",
+        `--name ${shellQuote(meta.containerName)}`,
+        "--restart unless-stopped",
+        `--network ${shellQuote(DEFAULT_NODE_NETWORK)}`,
+        `--cpus ${cpuUnitsToDockerCpus(row.row.cpu)}`,
+        `--memory ${row.row.memory}m`,
+        ...buildAppContainerSecurityFlags(),
+        ...(meta.volumePath
+          ? [
+              `-v ${shellQuote(meta.volumePath)}:${shellQuote(meta.volumeMountPath ?? DEFAULT_VOLUME_MOUNT_PATH)}`,
+            ]
+          : []),
+        buildContainerPortPublishFlag(meta.hostPort, meta.containerPort),
+        `--env-file ${envFilePath}`,
+        shellQuote(meta.image),
+      ]
+        .filter(Boolean)
+        .join(" "),
+    );
 
     await this.execOnNode(meta, async (ssh) => {
       // error-policy:J6 best-effort stop before the authoritative rm -f below;
@@ -725,33 +766,8 @@ export class HetznerContainersClient {
         );
       await ssh.exec(`docker rm -f ${shellQuote(meta.containerName)}`, 30_000);
 
-      const envFlags = Object.entries(environmentVars)
-        .map(([k, v]) => `-e ${shellQuote(`${k}=${v}`)}`)
-        .join(" ");
-
       await ssh.exec(buildEnsureNetworkCmd(DEFAULT_NODE_NETWORK), 30_000);
-      await ssh.exec(
-        [
-          "docker create",
-          `--name ${shellQuote(meta.containerName)}`,
-          "--restart unless-stopped",
-          `--network ${shellQuote(DEFAULT_NODE_NETWORK)}`,
-          `--cpus ${cpuUnitsToDockerCpus(row.row.cpu)}`,
-          `--memory ${row.row.memory}m`,
-          ...buildAppContainerSecurityFlags(),
-          ...(meta.volumePath
-            ? [
-                `-v ${shellQuote(meta.volumePath)}:${shellQuote(meta.volumeMountPath ?? DEFAULT_VOLUME_MOUNT_PATH)}`,
-              ]
-            : []),
-          buildContainerPortPublishFlag(meta.hostPort, meta.containerPort),
-          envFlags,
-          shellQuote(meta.image),
-        ]
-          .filter(Boolean)
-          .join(" "),
-        60_000,
-      );
+      await ssh.execStdin(createTransport.command, createTransport.input, 60_000);
       await ssh.exec(`docker start ${shellQuote(meta.containerName)}`, 60_000);
     });
 

--- a/packages/cloud/shared/src/lib/services/docker-env-file-stdin-transport.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-env-file-stdin-transport.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Exercises the generic Docker env-file stdin transport through the exact
+ * production builder and a real local `/bin/sh` execution boundary.
+ */
+import { describe, expect, test } from "bun:test";
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildDockerEnvFileStdinTransport,
+  shellQuote,
+  validateDockerEnvFileStdinEnvironment,
+} from "./docker-sandbox-utils";
+
+interface ShellResult {
+  code: number | null;
+  output: string;
+}
+
+const RUN_REAL_DOCKER = process.env.ELIZA_DOCKER_ENV_STDIN_REAL === "1";
+const TEST_PRIVATE_KEY_HEADER = ["-----BEGIN", "PRIVATE", "KEY-----"].join(" ");
+
+async function runShell(
+  command: string,
+  input: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ShellResult> {
+  return new Promise<ShellResult>((resolve, reject) => {
+    const child = spawn("/bin/sh", ["-c", command], { env });
+    let output = "";
+    child.stdout.on("data", (chunk) => (output += chunk.toString()));
+    child.stderr.on("data", (chunk) => (output += chunk.toString()));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, output }));
+    child.stdin.end(input);
+  });
+}
+
+function makeTemporaryDirectory(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+describe("generic Docker env-file stdin transport", () => {
+  test("keeps arbitrary keys and values out of command argv", () => {
+    const environment = Object.fromEntries([
+      ["ARGV_SENTINEL_KEY", "argv-sentinel-value with spaces = and 'quotes'"],
+      ["DATABASE_URL", "postgresql://user:argv-sentinel-password@example.invalid/app"],
+      ["__proto__", "prototype-key-is-data"],
+    ]);
+    const transport = buildDockerEnvFileStdinTransport(environment, (envFilePath) =>
+      ["docker create", `--env-file ${envFilePath}`, "image:latest"].join(" "),
+    );
+
+    expect(transport.command).toContain('--env-file "$env_file"');
+    expect(transport.command).not.toContain(" -e ");
+    for (const [key, value] of Object.entries(environment)) {
+      expect(transport.command).not.toContain(key);
+      expect(transport.command).not.toContain(value);
+      expect(transport.input).toContain(`export ${key}=${shellQuote(value)}`);
+    }
+    expect(transport.input).not.toContain("ELIZA_VAULT_PASSPHRASE");
+  });
+
+  test("round-trips multiline, trailing LF, quotes, Unicode, empty, and 70 KiB values", async () => {
+    const temporaryDirectory = makeTemporaryDirectory("eliza-env-roundtrip-");
+    try {
+      const environment = {
+        PEM: `${TEST_PRIVATE_KEY_HEADER}\nline with ' quote\tand tab\n-----END-----\n`,
+        QUOTED: " leading = 'quotes' \\slashes\\ and trailing ",
+        UNICODE: "clé-🧪-東京",
+        EMPTY: "",
+        LARGE: "x".repeat(70 * 1024),
+      };
+      const outputPaths = Object.fromEntries(
+        Object.keys(environment).map((key) => [key, join(temporaryDirectory, `${key}.out`)]),
+      );
+      const capturedEnvPath = join(temporaryDirectory, "captured.env");
+      const transport = buildDockerEnvFileStdinTransport(
+        environment,
+        (envFilePath) =>
+          [
+            `test "$(find ${envFilePath} -prune -perm 0600 -print)" = ${envFilePath}`,
+            ...Object.entries(outputPaths).map(
+              ([key, outputPath]) => `printf '%s' "$${key}" > ${shellQuote(outputPath)}`,
+            ),
+            `cp ${envFilePath} ${shellQuote(capturedEnvPath)}`,
+          ].join("; "),
+        { temporaryDirectory },
+      );
+
+      expect(transport.command).not.toContain(environment.PEM);
+      expect(transport.command).not.toContain(environment.LARGE);
+      const result = await runShell(transport.command, transport.input);
+
+      expect(result).toEqual({ code: 0, output: "" });
+      for (const [key, value] of Object.entries(environment)) {
+        expect(readFileSync(outputPaths[key]!, "utf8")).toBe(value);
+      }
+      expect(readFileSync(capturedEnvPath, "utf8")).toBe(
+        `${Object.keys(environment).join("\n")}\n`,
+      );
+      expect(readdirSync(temporaryDirectory).sort()).toEqual(
+        [...Object.keys(environment).map((key) => `${key}.out`), "captured.env"].sort(),
+      );
+    } finally {
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps Docker and shell control variables out of the wrapper process environment", async () => {
+    const temporaryDirectory = makeTemporaryDirectory("eliza-control-env-");
+    try {
+      const dockerHost = "tcp://caller-must-not-steer-docker.invalid:2375";
+      const httpProxy = "http://container-only-proxy.invalid:3128";
+      const capturedEnvPath = join(temporaryDirectory, "captured.env");
+      const capturedProcessPath = join(temporaryDirectory, "captured.process");
+      const transport = buildDockerEnvFileStdinTransport(
+        { DOCKER_HOST: dockerHost, HTTP_PROXY: httpProxy },
+        (envFilePath) =>
+          [
+            `cp ${envFilePath} ${shellQuote(capturedEnvPath)}`,
+            `printf '%s\n%s' "\${DOCKER_HOST-unset}" "\${HTTP_PROXY-unset}" > ${shellQuote(capturedProcessPath)}`,
+          ].join("; "),
+        { temporaryDirectory },
+      );
+      const cleanEnvironment = Object.fromEntries(
+        Object.entries(process.env).filter(
+          ([key]) => key !== "DOCKER_HOST" && key !== "HTTP_PROXY",
+        ),
+      );
+
+      expect(transport.input).not.toContain("export DOCKER_HOST=");
+      expect(transport.input).not.toContain("export HTTP_PROXY=");
+      const result = await runShell(transport.command, transport.input, cleanEnvironment);
+
+      expect(result).toEqual({ code: 0, output: "" });
+      expect(readFileSync(capturedEnvPath, "utf8")).toBe(
+        `DOCKER_HOST=${dockerHost}\nHTTP_PROXY=${httpProxy}\n`,
+      );
+      expect(readFileSync(capturedProcessPath, "utf8")).toBe("unset\nunset");
+      expect(readdirSync(temporaryDirectory).sort()).toEqual(["captured.env", "captured.process"]);
+    } finally {
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test("uses mode 0600 and cleans temporary files after success and failure", async () => {
+    for (const dockerResult of ["true", "false"]) {
+      const temporaryDirectory = makeTemporaryDirectory("eliza-env-cleanup-");
+      try {
+        const capturedEnvPath = join(temporaryDirectory, "captured.env");
+        const transport = buildDockerEnvFileStdinTransport(
+          { API_TOKEN: "stdin-only-sentinel" },
+          (envFilePath) =>
+            [
+              `test "$(find ${envFilePath} -prune -perm 0600 -print)" = ${envFilePath}`,
+              `cp ${envFilePath} ${shellQuote(capturedEnvPath)}`,
+              dockerResult,
+            ].join("; "),
+          { temporaryDirectory },
+        );
+
+        const result = await runShell(transport.command, transport.input);
+
+        expect(result.code === 0).toBe(dockerResult === "true");
+        expect(result.output).toBe("");
+        expect(readFileSync(capturedEnvPath, "utf8")).toBe("API_TOKEN\n");
+        expect(readdirSync(temporaryDirectory)).toEqual(["captured.env"]);
+      } finally {
+        rmSync(temporaryDirectory, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("rejects impossible environments before building a remote command", () => {
+    expect(() => validateDockerEnvFileStdinEnvironment({ PRIVATE_KEY: "nul\0value" })).toThrow(
+      /contains NUL/,
+    );
+    expect(() =>
+      buildDockerEnvFileStdinTransport({ PRIVATE_KEY: "x".repeat(121 * 1024) }, () => "true"),
+    ).toThrow(/process entry limit/);
+    expect(() =>
+      buildDockerEnvFileStdinTransport(
+        {
+          A: "a".repeat(90 * 1024),
+          B: "b".repeat(90 * 1024),
+          C: "c".repeat(90 * 1024),
+        },
+        () => "true",
+      ),
+    ).toThrow(/transport limit/);
+    expect(() =>
+      buildDockerEnvFileStdinTransport({ DOCKER_HOST: "line1\nline2" }, () => "true"),
+    ).toThrow(/must be single-line/);
+    expect(() =>
+      buildDockerEnvFileStdinTransport({ QUOTE_HEAVY: "'".repeat(60 * 1024) }, () => "true"),
+    ).toThrow(/environment frame exceeds/);
+    for (const key of ["env_file", "env_frame_file", "env_end_file"]) {
+      expect(() => buildDockerEnvFileStdinTransport({ [key]: "collision" }, () => "true")).toThrow(
+        /reserved by the Docker stdin transport/,
+      );
+    }
+    expect(() => buildDockerEnvFileStdinTransport({}, () => "")).toThrow(/non-empty command/);
+  });
+
+  test("fails closed and cleans up truncated, corrupt, oversized, or overlong frames", async () => {
+    const temporaryDirectory = makeTemporaryDirectory("eliza-invalid-frame-");
+    try {
+      const shouldNotRun = join(temporaryDirectory, "should-not-run");
+      const transport = buildDockerEnvFileStdinTransport(
+        { API_TOKEN: "must-not-echo" },
+        () => `touch ${shellQuote(shouldNotRun)}`,
+        { temporaryDirectory },
+      );
+      const invalidInputs = [
+        transport.input.slice(0, -10),
+        transport.input.replace(
+          "ELIZA_DOCKER_ENV_FILE_STDIN_V1_END",
+          "ELIZA_DOCKER_ENV_FILE_STDIN_V1_BAD",
+        ),
+        `${transport.input}x`,
+        "ELIZA_DOCKER_ENV_FILE_STDIN_V1 262145\n",
+      ];
+
+      for (const input of invalidInputs) {
+        const result = await runShell(transport.command, input);
+        expect(result.code).not.toBe(0);
+        expect(result.output).toBe("");
+        expect(result.output).not.toContain("must-not-echo");
+        expect(existsSync(shouldNotRun)).toBe(false);
+        expect(readdirSync(temporaryDirectory)).toEqual([]);
+      }
+    } finally {
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test("cleans temporary files when the remote command is interrupted", async () => {
+    const temporaryDirectory = makeTemporaryDirectory("eliza-signal-env-");
+    const readyPath = join(temporaryDirectory, "ready");
+    const transport = buildDockerEnvFileStdinTransport(
+      { API_TOKEN: "stdin-only-sentinel" },
+      () => `touch ${shellQuote(readyPath)}; sleep 30`,
+      { temporaryDirectory },
+    );
+    const child = spawn("/bin/sh", ["-c", transport.command], { detached: true });
+    child.stdin.end(transport.input);
+
+    try {
+      for (let attempt = 0; attempt < 200 && !existsSync(readyPath); attempt++) {
+        await Bun.sleep(10);
+      }
+      expect(existsSync(readyPath)).toBe(true);
+      expect(readdirSync(temporaryDirectory).length).toBeGreaterThan(1);
+
+      const closePromise = new Promise<void>((resolve) => child.on("close", () => resolve()));
+      process.kill(-child.pid!, "SIGTERM");
+      await closePromise;
+
+      expect(readdirSync(temporaryDirectory)).toEqual(["ready"]);
+    } finally {
+      try {
+        process.kill(-child.pid!, "SIGKILL");
+      } catch {
+        // The process group already exited after the handled signal.
+      }
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  }, 10_000);
+});
+
+describe.skipIf(!RUN_REAL_DOCKER)(
+  "generic Docker env-file stdin transport — real Docker opt-in (#23804)",
+  () => {
+    test("round-trips the exact production plan through a disposable container", () => {
+      const temporaryDirectory = makeTemporaryDirectory("eliza-real-docker-env-");
+      const containerName = `eliza-env-proof-23804-${process.pid}`;
+      const environment = {
+        EMPTY: "",
+        QUOTED: " leading = 'quotes' \\slashes\\ and trailing ",
+        UNICODE: "clé-🧪-東京",
+        PEM: `${TEST_PRIVATE_KEY_HEADER}\nline with ' quote\tand tab\n-----END PRIVATE KEY-----\n`,
+        LARGE: "x".repeat(70 * 1024),
+        DOCKER_HOST: "tcp://container-only.invalid:2375",
+        HTTP_PROXY: " http://container-only.invalid:3128 ",
+      };
+      const docker = (...args: string[]) =>
+        spawnSync("docker", args, { encoding: "utf8", maxBuffer: 4 * 1024 * 1024 });
+
+      try {
+        docker("rm", "-f", containerName);
+        const transport = buildDockerEnvFileStdinTransport(
+          environment,
+          (envFilePath) =>
+            [
+              `test "$(find ${envFilePath} -prune -perm 0600 -print)" = ${envFilePath} &&`,
+              "docker create",
+              `--name ${shellQuote(containerName)}`,
+              `--env-file ${envFilePath}`,
+              shellQuote("alpine:3.23"),
+              "env",
+            ].join(" "),
+          { temporaryDirectory },
+        );
+
+        expect(transport.command).not.toContain(" -e ");
+        for (const [key, value] of Object.entries(environment)) {
+          expect(transport.command).not.toContain(key);
+          if (value.length > 0) expect(transport.command).not.toContain(value);
+        }
+
+        const created = spawnSync("/bin/sh", ["-c", transport.command], {
+          input: transport.input,
+          encoding: "utf8",
+          maxBuffer: 4 * 1024 * 1024,
+        });
+        expect(created.status, `${created.stderr}${created.stdout}`).toBe(0);
+        expect(readdirSync(temporaryDirectory)).toEqual([]);
+
+        const inspected = docker("inspect", "--format", "{{json .Config.Env}}", containerName);
+        expect(inspected.status, inspected.stderr).toBe(0);
+        const entries = JSON.parse(inspected.stdout.trim()) as string[];
+        const actual = new Map(
+          entries.map((entry) => {
+            const separator = entry.indexOf("=");
+            return [entry.slice(0, separator), entry.slice(separator + 1)];
+          }),
+        );
+        for (const [key, expected] of Object.entries(environment)) {
+          expect(actual.get(key)).toBe(expected);
+        }
+      } finally {
+        docker("rm", "-f", containerName);
+        rmSync(temporaryDirectory, { recursive: true, force: true });
+      }
+    }, 30_000);
+  },
+);

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -237,6 +237,171 @@ function resolveStewardContainerEnvUrl(): string {
 }
 
 const STEWARD_JWT_FILE = "/app/data/steward.jwt";
+const STEWARD_REFRESH_SERVICE_TOKEN_FILE = "/tmp/eliza-steward-refresh-service-token";
+const STEWARD_REFRESH_AUTH_HEADER_FILE = "/tmp/eliza-steward-refresh-authorization.header";
+const MAX_STEWARD_REFRESH_SERVICE_TOKEN_BYTES = 8 * 1024;
+const MAX_MANAGED_ELIZA_RUNTIME_CONFIG_BYTES = 256 * 1024;
+const STEWARD_SSH_STDIN_FRAME_VERSION = "ELIZA_STEWARD_SSH_STDIN_V1";
+const STEWARD_SSH_STDIN_FRAME_END = "ELIZA_STEWARD_SSH_STDIN_END";
+const MAX_STEWARD_SSH_STDIN_PAYLOAD_BYTES = 256 * 1024;
+const MAX_STEWARD_SSH_STDIN_BASE64_BYTES = Math.ceil(MAX_STEWARD_SSH_STDIN_PAYLOAD_BYTES / 3) * 4;
+
+type StewardSshStdinPurpose = "steward-agent-delete" | "steward-agent-register";
+
+/** A static remote command paired with sensitive bytes transported only on stdin. */
+export interface StewardSshStdinRequest {
+  command: string;
+  input: string;
+}
+
+type ManagedElizaRuntimeConfigTarget =
+  | { kind: "container"; containerName: string }
+  | { kind: "host-volume"; volumePath: string };
+
+function buildAtomicStdinFileWriteScript(
+  directory: string,
+  destination: string,
+  options: { mode?: "0600" | "0644"; preserveExistingMetadata?: boolean } = {},
+): string {
+  const mode = options.mode ?? "0600";
+  const prepareTemporaryFile = options.preserveExistingMetadata
+    ? [
+        // Preserve an existing runtime-owned inode's uid/gid/mode. For the first
+        // pre-seed, 0644 retains the historical readability needed before the
+        // image entrypoint drops from root to `agent`.
+        `if test -e "$destination"; then cp -p "$destination" "$temporary_file"; else : > "$temporary_file"; chmod ${mode} "$temporary_file"; fi`,
+      ]
+    : [': > "$temporary_file"', `chmod ${mode} "$temporary_file"`];
+  return [
+    "set -eu",
+    "umask 077",
+    `destination=${shellQuote(destination)}`,
+    'temporary_file="${destination}.tmp.$$"',
+    "trap 'rm -f \"$temporary_file\"' EXIT",
+    "trap 'exit 129' HUP",
+    "trap 'exit 130' INT",
+    "trap 'exit 143' TERM",
+    `mkdir -p ${shellQuote(directory)}`,
+    ...prepareTemporaryFile,
+    'cat > "$temporary_file"',
+    'mv -f "$temporary_file" "$destination"',
+    "trap - EXIT HUP INT TERM",
+  ].join("; ");
+}
+
+function serializeManagedElizaRuntimeConfig(allEnv: Record<string, string | undefined>): string {
+  const serialized = JSON.stringify(buildManagedElizaRuntimeConfig(allEnv));
+  const payloadBytes = Buffer.byteLength(serialized, "utf8");
+  if (payloadBytes === 0 || payloadBytes > MAX_MANAGED_ELIZA_RUNTIME_CONFIG_BYTES) {
+    throw new Error("[docker-sandbox] Invalid managed eliza.json stdin payload size");
+  }
+  return serialized;
+}
+
+function buildManagedElizaRuntimeConfigWriteRequest(
+  target: ManagedElizaRuntimeConfigTarget,
+  allEnv: Record<string, string | undefined>,
+): StewardSshStdinRequest {
+  const input = serializeManagedElizaRuntimeConfig(allEnv);
+  if (target.kind === "host-volume") {
+    const directory = `${target.volumePath}/eliza`;
+    return {
+      command: buildAtomicStdinFileWriteScript(directory, `${directory}/eliza.json`, {
+        mode: "0644",
+        preserveExistingMetadata: true,
+      }),
+      input,
+    };
+  }
+
+  const writeScript = buildAtomicStdinFileWriteScript("/root/.eliza", "/root/.eliza/eliza.json", {
+    mode: "0644",
+    preserveExistingMetadata: true,
+  });
+  return {
+    command: `docker exec -i ${shellQuote(target.containerName)} sh -c ${shellQuote(writeScript)}`,
+    input,
+  };
+}
+
+/** Write secret-bearing managed runtime config through SSH stdin, never command argv. */
+export async function writeManagedElizaRuntimeConfig(
+  ssh: DockerSSHClient,
+  target: ManagedElizaRuntimeConfigTarget,
+  allEnv: Record<string, string | undefined>,
+): Promise<void> {
+  const request = buildManagedElizaRuntimeConfigWriteRequest(target, allEnv);
+  await ssh.execStdin(request.command, request.input, DOCKER_CMD_TIMEOUT_MS);
+}
+
+function stewardSshStdinFrameHeader(purpose: StewardSshStdinPurpose): string {
+  return `${STEWARD_SSH_STDIN_FRAME_VERSION}:${purpose}`;
+}
+
+function encodeStewardSshStdinFrame(purpose: StewardSshStdinPurpose, payload: string): string {
+  const payloadBytes = Buffer.byteLength(payload, "utf8");
+  if (payloadBytes === 0 || payloadBytes > MAX_STEWARD_SSH_STDIN_PAYLOAD_BYTES) {
+    throw new Error("[docker-sandbox] Invalid Steward stdin payload size");
+  }
+  if (payload.includes("\0")) {
+    throw new Error("[docker-sandbox] Invalid NUL byte in Steward stdin payload");
+  }
+  const encoded = Buffer.from(payload, "utf8").toString("base64");
+  return `${stewardSshStdinFrameHeader(purpose)}\n${encoded}\n${STEWARD_SSH_STDIN_FRAME_END}\n`;
+}
+
+/**
+ * Build an operation-specific Python command which validates a bounded,
+ * versioned stdin frame before parsing its JSON payload. Invalid input produces
+ * only a fixed diagnostic and received bytes are never reflected to stderr.
+ */
+function buildStewardFramedPythonCommand(
+  purpose: StewardSshStdinPurpose,
+  operationBody: string,
+): string {
+  const maxFrameBytes = MAX_STEWARD_SSH_STDIN_BASE64_BYTES + 256;
+  const parser = `import base64
+import json
+import sys
+
+MAX_FRAME_BYTES = ${maxFrameBytes}
+EXPECTED_HEADER = ${JSON.stringify(stewardSshStdinFrameHeader(purpose))}
+EXPECTED_END = ${JSON.stringify(STEWARD_SSH_STDIN_FRAME_END)}
+
+
+def invalid_stdin():
+    print("[docker-sandbox] Invalid Steward stdin payload", file=sys.stderr)
+    raise SystemExit(64)
+
+
+raw_frame = sys.stdin.buffer.read(MAX_FRAME_BYTES + 1)
+if not raw_frame or len(raw_frame) > MAX_FRAME_BYTES:
+    invalid_stdin()
+
+frame_parts = raw_frame.split(b"\\n")
+if len(frame_parts) != 4 or frame_parts[3] != b"":
+    invalid_stdin()
+if frame_parts[0] != EXPECTED_HEADER.encode("ascii") or frame_parts[2] != EXPECTED_END.encode("ascii"):
+    invalid_stdin()
+if not frame_parts[1] or len(frame_parts[1]) > ${MAX_STEWARD_SSH_STDIN_BASE64_BYTES}:
+    invalid_stdin()
+
+try:
+    raw_payload_bytes = base64.b64decode(frame_parts[1], validate=True)
+    if base64.b64encode(raw_payload_bytes) != frame_parts[1]:
+        invalid_stdin()
+    if not raw_payload_bytes or len(raw_payload_bytes) > ${MAX_STEWARD_SSH_STDIN_PAYLOAD_BYTES}:
+        invalid_stdin()
+    payload = json.loads(
+        raw_payload_bytes.decode("utf-8"),
+        parse_constant=lambda _value: (_ for _ in ()).throw(ValueError()),
+    )
+except Exception:
+    invalid_stdin()
+
+${operationBody}`;
+  return `python3 -c ${shellQuote(parser)}`;
+}
 
 export function resolveDockerSandboxImage(
   dockerImage?: string,
@@ -486,19 +651,39 @@ export function shouldCleanupHeadscaleVpn(
   return headscaleVpnEnabled(env) && hasConfiguredValue(registeredNodeName);
 }
 
-function buildStewardRefreshCommand(
-  containerName: string,
-  agentId: string,
-  serviceToken: string,
-): string {
-  const refreshScript = [
+function validateStewardRefreshServiceToken(serviceToken: string): void {
+  const payloadBytes = Buffer.byteLength(serviceToken, "utf8");
+  if (
+    payloadBytes === 0 ||
+    payloadBytes > MAX_STEWARD_REFRESH_SERVICE_TOKEN_BYTES ||
+    /[\0\r\n]/.test(serviceToken)
+  ) {
+    throw new Error("[docker-sandbox] Invalid Steward refresh service token stdin payload");
+  }
+}
+
+/** Build the credential-free in-container loop; exported for exact shell syntax proof. */
+export function buildStewardRefreshLoopScript(agentId: string): string {
+  return [
     "set -eu",
     `agent_id=${shellQuote(agentId)}`,
     `refresh_url=${shellQuote(resolveStewardRefreshUrl())}`,
     `jwt_file=${shellQuote(STEWARD_JWT_FILE)}`,
-    `service_token=${shellQuote(serviceToken)}`,
+    `service_token_file=${shellQuote(STEWARD_REFRESH_SERVICE_TOKEN_FILE)}`,
+    `auth_header_file=${shellQuote(STEWARD_REFRESH_AUTH_HEADER_FILE)}`,
+    'cleanup_refresh_files() { rm -f "$service_token_file" "$auth_header_file"; }',
+    "trap cleanup_refresh_files EXIT",
+    "trap 'exit 129' HUP",
+    "trap 'exit 130' INT",
+    "trap 'exit 143' TERM",
+    'service_token=$(cat "$service_token_file")',
+    "umask 077",
+    'printf "authorization: Bearer %s\\n" "$service_token" > "$auth_header_file"',
+    'chmod 600 "$auth_header_file"',
+    "unset service_token",
+    'rm -f "$service_token_file"',
     "while true; do",
-    '  response=$(curl -fsS -X POST "$refresh_url" -H "content-type: application/json" -H "authorization: Bearer $service_token" --data "{\\"agentId\\":\\"$agent_id\\",\\"ttl\\":900}" || true)',
+    '  response=$(curl -fsS -X POST "$refresh_url" -H "content-type: application/json" -H @"$auth_header_file" --data "{\\"agentId\\":\\"$agent_id\\",\\"ttl\\":900}" || true)',
     '  token=$(printf "%s" "$response" | sed -n "s/.*\\"token\\"[[:space:]]*:[[:space:]]*\\"\\([^\\"]*\\)\\".*/\\1/p")',
     '  if [ -n "$token" ]; then',
     "    umask 077",
@@ -509,9 +694,47 @@ function buildStewardRefreshCommand(
     "  fi",
     "  sleep 600",
     "done",
-  ].join("; ");
+  ].join("\n");
+}
 
-  return `docker exec -d ${shellQuote(containerName)} sh -lc ${shellQuote(refreshScript)}`;
+function buildStewardRefreshRequest(
+  containerName: string,
+  agentId: string,
+  serviceToken: string,
+): StewardSshStdinRequest {
+  validateStewardRefreshServiceToken(serviceToken);
+  const tokenWriteScript = buildAtomicStdinFileWriteScript(
+    "/tmp",
+    STEWARD_REFRESH_SERVICE_TOKEN_FILE,
+  );
+  const cleanupScript = `rm -f ${shellQuote(STEWARD_REFRESH_SERVICE_TOKEN_FILE)} ${shellQuote(
+    STEWARD_REFRESH_AUTH_HEADER_FILE,
+  )}`;
+  const refreshScript = buildStewardRefreshLoopScript(agentId);
+
+  return {
+    command: [
+      "set -eu",
+      `docker exec -i ${shellQuote(containerName)} sh -c ${shellQuote(tokenWriteScript)}`,
+      `if ! docker exec -d ${shellQuote(containerName)} sh -lc ${shellQuote(
+        refreshScript,
+      )}; then docker exec ${shellQuote(containerName)} sh -c ${shellQuote(
+        cleanupScript,
+      )} >/dev/null 2>&1 || true; exit 1; fi`,
+    ].join("; "),
+    input: serviceToken,
+  };
+}
+
+/** Start Steward refresh with its service token transported only through SSH stdin. */
+export async function startStewardRefreshSidecar(
+  ssh: DockerSSHClient,
+  containerName: string,
+  agentId: string,
+  serviceToken: string,
+): Promise<void> {
+  const request = buildStewardRefreshRequest(containerName, agentId, serviceToken);
+  await ssh.execStdin(request.command, request.input, DOCKER_CMD_TIMEOUT_MS);
 }
 
 function buildStewardPluginInstallCommand(containerName: string): string {
@@ -756,7 +979,7 @@ function buildPlatformAgentPath(tenantId: string, agentId?: string): string {
   return agentId ? `${base}/${encodeURIComponent(agentId)}` : base;
 }
 
-// Best-effort `curl -X DELETE` against Steward's platform agent endpoint for
+// Best-effort DELETE against Steward's platform agent endpoint for
 // deletion paths (failed container create, missing Headscale registration).
 // Uses the platform-key path so the daemon authenticates as a platform
 // operator instead of impersonating a tenant owner session — Steward's
@@ -765,18 +988,18 @@ function buildPlatformAgentPath(tenantId: string, agentId?: string): string {
 // path `/platform/tenants/:id/agents/:id` is exactly what Steward exposes
 // for this case (scope `platform:agent:delete`). Without signing the call
 // 401s and the agent record stays around as a ghost, blocking retries.
-async function buildSignedDeleteAgentCurl(
+export async function buildSignedDeleteAgentRequest(
   agentId: string,
   stewardTenant: StewardTenantCredentials,
-): Promise<string> {
+): Promise<StewardSshStdinRequest> {
   const path = buildPlatformAgentPath(stewardTenant.tenantId, agentId);
-  const url = `${resolveStewardHostUrl()}${path}`;
   const platformKey = resolveStewardPlatformKey();
   const signingSecret = resolveStewardRequestSigningSecret(stewardTenant.apiKey);
-  const flags = [
-    `-H ${shellQuote(`X-Steward-Tenant: ${stewardTenant.tenantId}`)}`,
-    ...(platformKey ? [`-H ${shellQuote(`X-Steward-Platform-Key: ${platformKey}`)}`] : []),
-  ];
+  const headers: Record<string, string> = {
+    "User-Agent": "eliza-cloud-provisioner/1.0",
+    "X-Steward-Tenant": stewardTenant.tenantId,
+    ...(platformKey ? { "X-Steward-Platform-Key": platformKey } : {}),
+  };
   if (signingSecret !== undefined) {
     const signed = await buildStewardSignedHeaders({
       method: "DELETE",
@@ -786,11 +1009,76 @@ async function buildSignedDeleteAgentCurl(
       ...(platformKey === undefined ? {} : { platformKey }),
       signingSecret,
     });
-    for (const [name, value] of Object.entries(signed)) {
-      flags.push(`-H ${shellQuote(`${name}: ${value}`)}`);
-    }
+    Object.assign(headers, signed);
   }
-  return `curl -s -X DELETE ${flags.join(" ")} ${shellQuote(url)} || true`;
+
+  const operationBody = `import urllib.error
+import urllib.request
+
+EXPECTED_KEYS = {"baseUrl", "headers", "path"}
+if type(payload) is not dict or set(payload) != EXPECTED_KEYS:
+    invalid_stdin()
+if any(type(payload[key]) is not str for key in ("baseUrl", "path")):
+    invalid_stdin()
+if type(payload["headers"]) is not dict or len(payload["headers"]) > 32:
+    invalid_stdin()
+
+base_url = payload["baseUrl"]
+path = payload["path"]
+if not base_url.startswith(("http://", "https://")) or any(char in base_url for char in "\\r\\n\\0"):
+    invalid_stdin()
+if not path.startswith("/") or any(char in path for char in "\\r\\n\\0"):
+    invalid_stdin()
+
+headers = {}
+allowed_header_name = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-"
+for name, value in payload["headers"].items():
+    if type(name) is not str or type(value) is not str:
+        invalid_stdin()
+    if not name or any(char not in allowed_header_name for char in name):
+        invalid_stdin()
+    if len(value) > 8192 or any(char in value for char in "\\r\\n\\0"):
+        invalid_stdin()
+    headers[name] = value
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, file_pointer, code, message, response_headers, new_url):
+        return None
+
+
+opener = urllib.request.build_opener(NoRedirect())
+try:
+    request = urllib.request.Request(f"{base_url}{path}", headers=headers, method="DELETE")
+    with opener.open(request, timeout=15) as response:
+        response.read(1)
+except urllib.error.HTTPError as error:
+    status = error.code
+    error.close()
+    print(f"[docker-sandbox] Steward agent delete failed with status {status}", file=sys.stderr)
+    raise SystemExit(69)
+except Exception:
+    # The lifecycle callers retain best-effort cleanup semantics by catching
+    # this fixed diagnostic; never reflect response bodies, headers, or input.
+    print("[docker-sandbox] Steward agent delete request failed", file=sys.stderr)
+    raise SystemExit(69)`;
+
+  return {
+    command: buildStewardFramedPythonCommand("steward-agent-delete", operationBody),
+    input: encodeStewardSshStdinFrame(
+      "steward-agent-delete",
+      JSON.stringify({ baseUrl: resolveStewardHostUrl(), headers, path }),
+    ),
+  };
+}
+
+export async function deregisterAgentWithSteward(
+  ssh: DockerSSHClient,
+  agentId: string,
+  stewardTenant: StewardTenantCredentials,
+): Promise<void> {
+  const request = await buildSignedDeleteAgentRequest(agentId, stewardTenant);
+  await ssh.execStdin(request.command, request.input, DOCKER_CMD_TIMEOUT_MS);
 }
 
 async function buildStewardSignedHeaders(params: {
@@ -815,8 +1103,8 @@ async function buildStewardSignedHeaders(params: {
   );
   const out: Record<string, string> = {};
   headers.forEach((value, name) => {
-    // Strip tenant/platform-key — the caller injects them via curl flag or
-    // Python shim. Avoid double-injection.
+    // Strip tenant/platform-key — the caller adds them once to the framed
+    // stdin header map. Avoid double-injection into the outbound request.
     if (name === "x-steward-tenant" || name === "x-steward-platform-key") {
       return;
     }
@@ -825,13 +1113,12 @@ async function buildStewardSignedHeaders(params: {
   return out;
 }
 
-async function registerAgentWithSteward(
-  ssh: DockerSSHClient,
+export async function buildRegisterAgentWithStewardRequest(
   agentId: string,
   agentName: string,
   tenantId: string,
   apiKey?: string,
-): Promise<string> {
+): Promise<StewardSshStdinRequest> {
   // The tenant-scoped POST /agents compatibility route requires a session-jwt with
   // owner|admin role (Steward `requireTenantAdminSession`), which a daemon
   // cannot satisfy. Switch to the platform-key path Steward exposes for
@@ -874,58 +1161,140 @@ async function registerAgentWithSteward(
           signingSecret,
         });
 
-  const script = `python3 - <<'PY'
-import json
-import sys
-import urllib.error
+  const commonHeaders = {
+    "Content-Type": "application/json",
+    "User-Agent": "eliza-cloud-provisioner/1.0",
+    "X-Steward-Tenant": tenantId,
+    ...(platformKey ? { "X-Steward-Platform-Key": platformKey } : {}),
+  };
+  const operationBody = `import urllib.error
 import urllib.request
 
-base_url = ${JSON.stringify(resolveStewardHostUrl())}
-platform_key = ${JSON.stringify(platformKey ?? "")}
-tenant_id = ${JSON.stringify(tenantId)}
-agent_path = ${JSON.stringify(agentPath)}
-token_path = ${JSON.stringify(tokenPath)}
-agent_body = ${JSON.stringify(agentBody)}
-token_body = ${JSON.stringify(tokenBody)}
-agent_signed_headers = ${JSON.stringify(agentSignedHeaders)}
-token_signed_headers = ${JSON.stringify(tokenSignedHeaders)}
+EXPECTED_KEYS = {
+    "agentBody",
+    "agentHeaders",
+    "agentPath",
+    "baseUrl",
+    "tokenBody",
+    "tokenHeaders",
+    "tokenPath",
+}
+if type(payload) is not dict or set(payload) != EXPECTED_KEYS:
+    invalid_stdin()
+if any(
+    type(payload[key]) is not str
+    for key in ("agentBody", "agentPath", "baseUrl", "tokenBody", "tokenPath")
+):
+    invalid_stdin()
+if any(type(payload[key]) is not dict for key in ("agentHeaders", "tokenHeaders")):
+    invalid_stdin()
+
+base_url = payload["baseUrl"]
+agent_path = payload["agentPath"]
+token_path = payload["tokenPath"]
+if not base_url.startswith(("http://", "https://")) or any(char in base_url for char in "\\r\\n\\0"):
+    invalid_stdin()
+for path in (agent_path, token_path):
+    if not path.startswith("/") or any(char in path for char in "\\r\\n\\0"):
+        invalid_stdin()
+for body_text in (payload["agentBody"], payload["tokenBody"]):
+    try:
+        body_value = json.loads(body_text)
+    except (TypeError, ValueError):
+        invalid_stdin()
+    if type(body_value) is not dict:
+        invalid_stdin()
 
 
-def post(path, body_text, signed_headers):
-    headers = {"Content-Type": "application/json", "User-Agent": "eliza-cloud-provisioner/1.0"}
-    if tenant_id:
-        headers["X-Steward-Tenant"] = tenant_id
-    if platform_key:
-        headers["X-Steward-Platform-Key"] = platform_key
-    headers.update(signed_headers)
-    req = urllib.request.Request(
+def validated_headers(value):
+    if len(value) > 32:
+        invalid_stdin()
+    result = {}
+    allowed_header_name = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-"
+    for name, header_value in value.items():
+        if type(name) is not str or type(header_value) is not str:
+            invalid_stdin()
+        if not name or any(char not in allowed_header_name for char in name):
+            invalid_stdin()
+        if len(header_value) > 8192 or any(char in header_value for char in "\\r\\n\\0"):
+            invalid_stdin()
+        result[name] = header_value
+    return result
+
+
+agent_headers = validated_headers(payload["agentHeaders"])
+token_headers = validated_headers(payload["tokenHeaders"])
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, file_pointer, code, message, response_headers, new_url):
+        return None
+
+
+opener = urllib.request.build_opener(NoRedirect())
+
+
+def post(path, body_text, headers, capture_body):
+    request = urllib.request.Request(
         f"{base_url}{path}",
         data=body_text.encode("utf-8"),
         headers=headers,
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=15) as response:
-            return response.status, response.read().decode("utf-8")
+        with opener.open(request, timeout=15) as response:
+            response_body = response.read(65537) if capture_body else b""
+            return response.status, response_body
     except urllib.error.HTTPError as error:
-        return error.code, error.read().decode("utf-8")
+        status = error.code
+        error.close()
+        return status, b""
+    except Exception:
+        print("[docker-sandbox] Steward request failed", file=sys.stderr)
+        raise SystemExit(69)
 
 
-status, body = post(agent_path, agent_body, agent_signed_headers)
+status, _body = post(agent_path, payload["agentBody"], agent_headers, False)
 if status not in (200, 201, 202, 400, 409):
-    print(body, file=sys.stderr)
     raise SystemExit(f"Steward agent registration failed with status {status}")
-# 400/409 = agent already exists, continue to token minting
+# 400/409 = agent already exists, continue to token minting.
 
-status, body = post(token_path, token_body, token_signed_headers)
+status, body = post(token_path, payload["tokenBody"], token_headers, True)
 if status not in (200, 201):
-    print(body, file=sys.stderr)
     raise SystemExit(f"Steward token mint failed with status {status}")
+if len(body) > 65536:
+    raise SystemExit("Steward token response exceeded the bounded size")
+try:
+    print(body.decode("utf-8"))
+except UnicodeDecodeError:
+    raise SystemExit("Steward token response was not UTF-8")`;
 
-print(body)
-PY`;
+  return {
+    command: buildStewardFramedPythonCommand("steward-agent-register", operationBody),
+    input: encodeStewardSshStdinFrame(
+      "steward-agent-register",
+      JSON.stringify({
+        agentBody,
+        agentHeaders: { ...commonHeaders, ...agentSignedHeaders },
+        agentPath,
+        baseUrl: resolveStewardHostUrl(),
+        tokenBody,
+        tokenHeaders: { ...commonHeaders, ...tokenSignedHeaders },
+        tokenPath,
+      }),
+    ),
+  };
+}
 
-  const rawToken = await ssh.exec(script, DOCKER_CMD_TIMEOUT_MS);
+export async function registerAgentWithSteward(
+  ssh: DockerSSHClient,
+  agentId: string,
+  agentName: string,
+  tenantId: string,
+  apiKey?: string,
+): Promise<string> {
+  const request = await buildRegisterAgentWithStewardRequest(agentId, agentName, tenantId, apiKey);
+  const rawToken = await ssh.execStdin(request.command, request.input, DOCKER_CMD_TIMEOUT_MS);
   return extractStewardToken(rawToken);
 }
 
@@ -1632,16 +2001,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       // stays as a fallback (and overwrites with identical content).
       try {
         if (allEnv.ELIZAOS_CLOUD_BASE_URL) {
-          const preSeed = Buffer.from(
-            JSON.stringify(buildManagedElizaRuntimeConfig(allEnv)),
-            "utf-8",
-          ).toString("base64");
-          await ssh.exec(
-            `mkdir -p ${shellQuote(`${volumePath}/eliza`)} && printf %s ${shellQuote(
-              preSeed,
-            )} | base64 -d > ${shellQuote(`${volumePath}/eliza/eliza.json`)}`,
-            DOCKER_CMD_TIMEOUT_MS,
-          );
+          await writeManagedElizaRuntimeConfig(ssh, { kind: "host-volume", volumePath }, allEnv);
           logger.info(`[docker-sandbox] Pre-seeded eliza.json on host volume for ${containerName}`);
         }
       } catch (preSeedErr) {
@@ -1670,10 +2030,7 @@ export class DockerSandboxProvider implements SandboxProvider {
 
       if (stewardJwt && stewardRefreshServiceToken) {
         try {
-          await ssh.exec(
-            buildStewardRefreshCommand(containerName, agentId, stewardRefreshServiceToken),
-            DOCKER_CMD_TIMEOUT_MS,
-          );
+          await startStewardRefreshSidecar(ssh, containerName, agentId, stewardRefreshServiceToken);
           logger.info(`[docker-sandbox] Steward JWT refresh sidecar started in ${containerName}`);
         } catch (refreshErr) {
           logger.warn(
@@ -1696,15 +2053,7 @@ export class DockerSandboxProvider implements SandboxProvider {
               "https://api-staging.eliza.app/api/v1 for staging, https://api.eliza.app/api/v1 for prod).",
           );
         }
-        const elizaConfig = JSON.stringify(buildManagedElizaRuntimeConfig(allEnv));
-        // Base64-encode the JSON before passing it through the shell so an
-        // apiKey/baseUrl containing single quotes can't break out of the
-        // outer sh -c quoting or inject commands on the remote host.
-        const encodedConfig = Buffer.from(elizaConfig, "utf-8").toString("base64");
-        const writeCmd = `docker exec ${shellQuote(containerName)} sh -c ${shellQuote(
-          `mkdir -p /root/.eliza && printf %s ${shellQuote(encodedConfig)} | base64 -d > /root/.eliza/eliza.json`,
-        )}`;
-        await ssh.exec(writeCmd, DOCKER_CMD_TIMEOUT_MS);
+        await writeManagedElizaRuntimeConfig(ssh, { kind: "container", containerName }, allEnv);
         logger.info(`[docker-sandbox] Cloud config written to eliza.json in ${containerName}`);
       } catch (configErr) {
         logger.warn(
@@ -1718,10 +2067,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       // Best-effort Steward deregistration — the agent was registered but the
       // container failed to start, so the Steward record is deleted here.
       try {
-        await ssh.exec(
-          await buildSignedDeleteAgentCurl(agentId, stewardTenant),
-          DOCKER_CMD_TIMEOUT_MS,
-        );
+        await deregisterAgentWithSteward(ssh, agentId, stewardTenant);
         logger.info(`[docker-sandbox] Cleaned up Steward agent ${agentId} after container failure`);
       } catch (cleanupErr) {
         logger.warn(
@@ -1899,8 +2245,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         containerName,
         nodeId,
       });
-      await ssh
-        .exec(await buildSignedDeleteAgentCurl(agentId, stewardTenant), DOCKER_CMD_TIMEOUT_MS)
+      await deregisterAgentWithSteward(ssh, agentId, stewardTenant)
         .then(() => {
           logger.info(
             `[docker-sandbox] Cleaned up Steward agent ${agentId} after missing Headscale registration`,

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-utils.ts
@@ -288,7 +288,246 @@ export interface DockerContainerEnvTransport {
   secretInput: string;
 }
 
+export interface DockerEnvFileStdinTransport {
+  /** Shell command whose environment-related argv contains only the temporary env-file path. */
+  command: string;
+  /** Versioned, bounded frame that must be delivered through an stdin-capable executor. */
+  input: string;
+}
+
+export interface DockerEnvFileStdinTransportOptions {
+  /** Override for isolated tests; production callers use restrictive files under `/tmp`. */
+  temporaryDirectory?: string;
+}
+
 const CONTAINER_SECRET_ENV_STDIN_SENTINEL = "ELIZA_SECRET_ENV_STDIN_V1_END";
+const DOCKER_ENV_FILE_STDIN_VERSION = "ELIZA_DOCKER_ENV_FILE_STDIN_V1";
+const DOCKER_ENV_FILE_STDIN_END = "ELIZA_DOCKER_ENV_FILE_STDIN_V1_END";
+const DOCKER_ENV_FILE_STDIN_LENGTH_DIGITS = 6;
+const DOCKER_ENV_FILE_STDIN_HEADER_BYTES = Buffer.byteLength(
+  `${DOCKER_ENV_FILE_STDIN_VERSION} ${"0".repeat(DOCKER_ENV_FILE_STDIN_LENGTH_DIGITS)}\n`,
+);
+const DOCKER_ENV_FILE_STDIN_END_BYTES = Buffer.byteLength(`${DOCKER_ENV_FILE_STDIN_END}\n`);
+const MAX_DOCKER_ENV_TRANSPORT_BYTES = 256 * 1024;
+const MAX_DOCKER_PROCESS_ENV_ENTRY_BYTES = 120 * 1024;
+const MAX_DOCKER_ENV_FILE_LINE_BYTES = 60 * 1024;
+const RESERVED_DOCKER_ENV_TRANSPORT_KEYS = new Set(["env_file", "env_frame_file", "env_end_file"]);
+const DOCKER_CLIENT_CONTROL_ENV_KEYS = new Set([
+  "ALL_PROXY",
+  "BASHOPTS",
+  "BASH_ENV",
+  "CDPATH",
+  "ENV",
+  "EUID",
+  "GLOBIGNORE",
+  "HOME",
+  "HTTPS_PROXY",
+  "HTTP_PROXY",
+  "IFS",
+  "LANG",
+  "LINENO",
+  "LOGNAME",
+  "NO_PROXY",
+  "OLDPWD",
+  "OPTARG",
+  "OPTIND",
+  "PATH",
+  "POSIXLY_CORRECT",
+  "PPID",
+  "PROMPT_COMMAND",
+  "PS1",
+  "PS2",
+  "PS3",
+  "PS4",
+  "PWD",
+  "RANDOM",
+  "SECONDS",
+  "SHELL",
+  "SHELLOPTS",
+  "SHLVL",
+  "SSH_AUTH_SOCK",
+  "SSL_CERT_DIR",
+  "SSL_CERT_FILE",
+  "TEMP",
+  "TMP",
+  "TMPDIR",
+  "UID",
+  "USER",
+  "_",
+  "all_proxy",
+  "http_proxy",
+  "https_proxy",
+  "no_proxy",
+]);
+
+function isDockerClientControlEnvKey(key: string): boolean {
+  if (
+    /^(?:DOCKER_|LD_|DYLD_|XDG_|LC_|MALLOC_)/.test(key) ||
+    /^(?:GODEBUG|GOMAXPROCS|GOMEMLIMIT|GOTRACEBACK)$/.test(key)
+  ) {
+    return true;
+  }
+  return DOCKER_CLIENT_CONTROL_ENV_KEYS.has(key);
+}
+
+interface DockerEnvironmentPartition {
+  processEnvironment: Record<string, string>;
+  envFileBody: string;
+}
+
+/**
+ * Partition an arbitrary container environment without allowing it to steer
+ * the shell wrapper or Docker client. Ordinary values are exported only so a
+ * key-only env-file entry can copy them into the container. Docker/shell
+ * control variables remain explicit env-file records and never reach the
+ * provisioning process environment.
+ */
+function partitionDockerEnvironment(
+  environment: Readonly<Record<string, string>>,
+): DockerEnvironmentPartition {
+  // A valid POSIX env key may be `__proto__`; a null-prototype record keeps it
+  // as data instead of invoking Object.prototype's legacy setter.
+  const processEnvironment = Object.create(null) as Record<string, string>;
+  const envFileLines: string[] = [];
+  let rawBytes = 0;
+
+  for (const [key, value] of Object.entries(environment)) {
+    validateEnvKey(key);
+    if (RESERVED_DOCKER_ENV_TRANSPORT_KEYS.has(key)) {
+      throw new Error(`Environment variable "${key}" is reserved by the Docker stdin transport.`);
+    }
+    if (value.includes("\0")) {
+      throw new Error(`Invalid environment variable value for key "${key}": contains NUL.`);
+    }
+
+    const entryBytes = Buffer.byteLength(`${key}=${value}`);
+    if (entryBytes > MAX_DOCKER_PROCESS_ENV_ENTRY_BYTES) {
+      throw new Error(
+        `Environment variable "${key}" exceeds the ${MAX_DOCKER_PROCESS_ENV_ENTRY_BYTES}-byte process entry limit.`,
+      );
+    }
+    rawBytes += entryBytes + 1;
+    if (rawBytes > MAX_DOCKER_ENV_TRANSPORT_BYTES) {
+      throw new Error(
+        `Container environment exceeds the ${MAX_DOCKER_ENV_TRANSPORT_BYTES}-byte transport limit.`,
+      );
+    }
+
+    if (isDockerClientControlEnvKey(key)) {
+      if (value.includes("\n") || value.includes("\r")) {
+        throw new Error(
+          `Docker client control variable "${key}" must be single-line so it cannot alter the provisioning client.`,
+        );
+      }
+      if (entryBytes > MAX_DOCKER_ENV_FILE_LINE_BYTES) {
+        throw new Error(
+          `Docker client control variable "${key}" exceeds the ${MAX_DOCKER_ENV_FILE_LINE_BYTES}-byte env-file line limit.`,
+        );
+      }
+      envFileLines.push(`${key}=${value}`);
+      continue;
+    }
+
+    processEnvironment[key] = value;
+    envFileLines.push(key);
+  }
+
+  return {
+    processEnvironment,
+    envFileBody: envFileLines.length > 0 ? `${envFileLines.join("\n")}\n` : "",
+  };
+}
+
+function buildDockerEnvironmentFrame(environment: Readonly<Record<string, string>>): string {
+  const partition = partitionDockerEnvironment(environment);
+  const exportLines = Object.entries(partition.processEnvironment).map(
+    ([key, value]) => `export ${key}=${shellQuote(value)}`,
+  );
+  const envScript = [
+    ...exportLines,
+    `printf '%s' ${shellQuote(partition.envFileBody)} > "$env_file"`,
+  ].join("\n");
+  const framedScript = `${envScript}\n`;
+  const framedScriptBytes = Buffer.byteLength(framedScript);
+  if (framedScriptBytes > MAX_DOCKER_ENV_TRANSPORT_BYTES) {
+    throw new Error(
+      `Container environment frame exceeds the ${MAX_DOCKER_ENV_TRANSPORT_BYTES}-byte transport limit.`,
+    );
+  }
+  const encodedLength = String(framedScriptBytes).padStart(
+    DOCKER_ENV_FILE_STDIN_LENGTH_DIGITS,
+    "0",
+  );
+  return `${DOCKER_ENV_FILE_STDIN_VERSION} ${encodedLength}\n${framedScript}${DOCKER_ENV_FILE_STDIN_END}\n`;
+}
+
+/** Validate the exact bounded stdin frame before callers mutate container state. */
+export function validateDockerEnvFileStdinEnvironment(
+  environment: Readonly<Record<string, string>>,
+): void {
+  buildDockerEnvironmentFrame(environment);
+}
+
+/**
+ * Build a one-shot, stdin-only Docker environment transport. The remote shell
+ * accepts exactly one bounded frame, creates restrictive temporary files,
+ * verifies the terminal sentinel and EOF, and removes every file on success,
+ * failure, timeout-driven HUP, or another handled signal.
+ */
+export function buildDockerEnvFileStdinTransport(
+  environment: Readonly<Record<string, string>>,
+  buildDockerCommand: (envFilePath: string) => string,
+  options: DockerEnvFileStdinTransportOptions = {},
+): DockerEnvFileStdinTransport {
+  const input = buildDockerEnvironmentFrame(environment);
+  const temporaryDirectory = options.temporaryDirectory ?? "/tmp";
+  validateVolumePath(temporaryDirectory);
+
+  const envFrameTemplate = shellQuote(`${temporaryDirectory}/eliza-docker-env-frame.XXXXXX`);
+  const envFileTemplate = shellQuote(`${temporaryDirectory}/eliza-docker-env.XXXXXX`);
+  const envEndFileTemplate = shellQuote(`${temporaryDirectory}/eliza-docker-env-end.XXXXXX`);
+  const dockerCommand = buildDockerCommand('"$env_file"');
+  if (!dockerCommand.trim()) {
+    throw new Error("Docker env-file stdin transport requires a non-empty command.");
+  }
+
+  return {
+    input,
+    command: [
+      "set -eu",
+      "env_frame_file=",
+      "env_file=",
+      "env_end_file=",
+      'cleanup_env_files() { test -z "$env_frame_file" || rm -f "$env_frame_file"; test -z "$env_end_file" || rm -f "$env_end_file"; test -z "$env_file" || rm -f "$env_file"; }',
+      "trap cleanup_env_files EXIT",
+      "trap 'exit 1' HUP INT TERM",
+      "umask 077",
+      `env_frame_file=$(mktemp ${envFrameTemplate})`,
+      `env_file=$(mktemp ${envFileTemplate})`,
+      `env_end_file=$(mktemp ${envEndFileTemplate})`,
+      'chmod 600 "$env_frame_file" "$env_end_file" "$env_file"',
+      `dd bs=1 count=${DOCKER_ENV_FILE_STDIN_HEADER_BYTES} of="$env_frame_file" status=none`,
+      `test "$(wc -c < "$env_frame_file" | tr -d ' ')" = ${DOCKER_ENV_FILE_STDIN_HEADER_BYTES}`,
+      'env_header=$(cat "$env_frame_file")',
+      `case "$env_header" in ${shellQuote(`${DOCKER_ENV_FILE_STDIN_VERSION} `)}??????) ;; *) exit 44 ;; esac`,
+      `env_length_padded=\${env_header#${DOCKER_ENV_FILE_STDIN_VERSION} }`,
+      "case \"$env_length_padded\" in ''|*[!0-9]*) exit 44 ;; esac",
+      "env_length=$(printf %s \"$env_length_padded\" | sed 's/^0*//')",
+      'test -n "$env_length" || env_length=0',
+      `test "$env_length" -le ${MAX_DOCKER_ENV_TRANSPORT_BYTES}`,
+      'if test "$env_length" -gt 0; then dd bs=1 count="$env_length" of="$env_frame_file" status=none; else : > "$env_frame_file"; fi',
+      "env_actual_length=$(wc -c < \"$env_frame_file\" | tr -d ' ')",
+      'test "$env_actual_length" = "$env_length"',
+      `dd bs=1 count=${DOCKER_ENV_FILE_STDIN_END_BYTES} of="$env_end_file" status=none`,
+      `test "$(wc -c < "$env_end_file" | tr -d ' ')" = ${DOCKER_ENV_FILE_STDIN_END_BYTES}`,
+      `test "$(cat "$env_end_file")" = ${shellQuote(DOCKER_ENV_FILE_STDIN_END)}`,
+      "test \"$(dd bs=1 count=1 status=none | wc -c | tr -d ' ')\" = 0",
+      '. "$env_frame_file"',
+      'chmod 600 "$env_file"',
+      dockerCommand,
+    ].join("; "),
+  };
+}
 
 /** Split validated container env into visible flags and stdin-only entries. */
 export function buildDockerContainerEnvTransport(


### PR DESCRIPTION
# Relates to

Fixes #23804. Parent epic: #20726 (Sandboxes V3, chantier 0).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated blockers are recorded below.
- [x] A reviewer can confirm the change works without reading the code from the exact-head tests and real disposable-Docker evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d54e2abd97aa8a62776b996a3094b034b11eabf7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `d54e2abd97aa8a62776b996a3094b034b11eabf7`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact unrelated i18n blocker is documented in **Known gaps / failures**.

# Risks

Medium. This changes remote Docker command construction for App, Hetzner, and Steward paths. Failure is deliberately fail-closed before allocation/destructive mutation, frames are bounded, temporary files are `0600`, and signal/error cleanup is covered. Rollback is a revert of the three commits in this PR; there are no migrations, feature flags, or deployment changes.

# Background

## What does this PR do?

- Adds one bounded, versioned stdin transport that materializes a restrictive temporary Docker env file without putting caller keys or values in process argv.
- Moves App and Hetzner create/recreate environment payloads to `execStdin`, preserving DSN rewrite, port retry, and environment precedence.
- Moves Steward register/delete headers, runtime `eliza.json`, and refresh-service credentials to bounded stdin-backed files, rejects redirects/reflected bodies, and makes deregistration failure observable.
- Preserves runtime config ownership/mode and removes all transient files after success, failure, truncation, and signals.

## What kind of change is this?

Bug fix (non-breaking security hardening).

# Documentation changes needed?

No project documentation change is needed: the public API and operator configuration remain unchanged.

# Testing

## Where should a reviewer start?

Start with `docker-env-file-stdin-transport.test.ts` and `docker-sandbox-steward-secret-transport.test.ts`, then inspect the App and Hetzner caller tests. They exercise the production builders/callers with deterministic sentinel credentials and real shell/Docker execution.

## Detailed testing steps

Using pinned Bun `1.3.14` / Node `24.15.0`:

```bash
mise exec -- bun install --frozen-lockfile
mise exec -- bun run --cwd packages/cloud/shared lint:check
mise exec -- bun test --isolate \
  src/lib/services/docker-sandbox-utils.test.ts \
  src/lib/services/docker-env-file-stdin-transport.test.ts \
  src/lib/services/__tests__/app-docker-cmd.test.ts \
  src/lib/services/__tests__/app-container-provider.test.ts \
  src/lib/services/containers/hetzner-client/client.error-policy.test.ts \
  src/lib/services/__tests__/docker-sandbox-steward-secret-transport.test.ts
ELIZA_DOCKER_ENV_STDIN_REAL=1 mise exec -- bun test --isolate \
  src/lib/services/docker-env-file-stdin-transport.test.ts \
  src/lib/services/__tests__/docker-sandbox-steward-secret-transport.test.ts
```

For the adjacent regression lane, run the two exact App files, `docker-sandbox-*.test.ts`, `containers/hetzner-client/*.test.ts`, and the two Docker transport/utils files. Expected result at this head: `374 pass`, `2 skip`, `0 fail`.

# Evidence Gate

<!-- evidence-head:602de603b183fb9b13f96993df1618b1e08a4660 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - backend-only command transport; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - backend-only command transport; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - no interactive or rendered user flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - local exact-head test and Docker execution summaries are included in Evidence Details; no live service was called
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend code or request surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain state is changed; command-vs-stdin, mode, round-trip, and cleanup assertions are automated tests
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

- `bun install --frozen-lockfile`: exit `0`, no lockfile changes.
- Focused production builders/callers: exit `0`, `108 pass`, `2 skip`, `0 fail`, `725` assertions.
- Real disposable Docker transport/refresh: exit `0`, `20 pass`, `0 fail`, `200` assertions.
- Adjacent App-container/Docker-sandbox/Hetzner regression lane: exit `0`, `374 pass`, `2 skip`, `0 fail`, `1376` assertions across `23` files.
- `packages/cloud/shared` lint: exit `0`, `2236` files checked, no fixes.
- `git diff --check origin/develop...HEAD`: exit `0`.
- Two independent read-only reviews (security and regression) reported no remaining concrete finding after the follow-up fixes.

Frontend logs: N/A - no frontend change.

## Screenshots (before / after) + video walkthrough

N/A - backend-only transport hardening.

### Before

N/A - no UI.

### After

N/A - no UI.

### Walkthrough video

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

- `mise exec -- bun run verify`: exit `1` before reaching the changed package because root `check:i18n` reports seven missing English connector-account keys and existing locale gaps in unrelated UI files. None of those files is in this diff.
- `mise exec -- bun run --cwd packages/cloud/shared typecheck`: exit `1` only at unchanged `src/lib/services/shared-runtime/conversation-coordinator.ts:241` (`URL | RequestInfo` passed to `string | URL`). The file is byte-identical to `origin/develop` and absent from this diff.
- The full `packages/cloud/shared` test runner reaches the existing `app-credits-ledger.test.ts` PGlite harness failure (`relation \"credit_transactions\" does not exist`). Running that unrelated file alone reproduces four failures; the strictly scoped 23-file regression lane is green.
- A linked-workspace build reached the repository's existing npm-shim incompatibility after producing the required local dependency artifacts. No generated artifact is included in this PR.
- No live staging/production call was made and no real credential was used. Real local Docker execution covers the transport boundary without expanding operational scope.

# Deploy Notes

No special deployment steps. No migration or configuration change.

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@d54e2abd97aa8a62776b996a3094b034b11eabf7:packages/skills/skills/contribute-to-eliza"} -->

