### PR TITLE
fix(scheduling): validate the scheduled-task edit payload like its sibling snooze verb

### DIFF
--- a/plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts
+++ b/plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts
@@ -494,4 +494,164 @@ describe("scheduled-tasks REST handler", () => {
       expect.arrayContaining(["weekend_skip", "quiet_hours"]),
     );
   });
+
+  describe("POST /:id/edit validates the body like its sibling snooze verb", () => {
+    const BASE_INPUT = {
+      kind: "reminder",
+      promptInstructions: "drink water",
+      trigger: { kind: "manual" },
+      priority: "low",
+      respectsGlobalPause: true,
+      source: "user_chat",
+      createdBy: "tester",
+      ownerVisible: true,
+    } as const;
+
+    async function seed(): Promise<{
+      runner: ScheduledTaskRunnerHandle;
+      handler: (ctx: SchedulingRouteContext) => Promise<boolean>;
+      task: ScheduledTask;
+    }> {
+      const runner = makeRunner();
+      const handler = makeScheduledTasksRouteHandler({
+        resolveRunner: async () => runner,
+      });
+      const { ctx, res } = buildCtx({
+        method: "POST",
+        pathname: "/api/lifeops/scheduled-tasks",
+        body: BASE_INPUT,
+      });
+      await handler(ctx);
+      expect(res.statusCode).toBe(201);
+      return {
+        runner,
+        handler,
+        task: JSON.parse(res.body ?? "{}").task as ScheduledTask,
+      };
+    }
+
+    async function edit(
+      handler: (ctx: SchedulingRouteContext) => Promise<boolean>,
+      taskId: string,
+      body: unknown,
+    ): Promise<MockResponse> {
+      const { ctx, res } = buildCtx({
+        method: "POST",
+        pathname: `/api/lifeops/scheduled-tasks/${taskId}/edit`,
+        body,
+      });
+      await handler(ctx);
+      return res;
+    }
+
+    it("still accepts every editable ScheduledTaskInput field (no over-rejection)", async () => {
+      const { runner, handler, task } = await seed();
+      const fullPatch = {
+        kind: "checkin",
+        promptInstructions: "updated text",
+        contextRequest: {
+          includeOwnerFacts: ["timezone"],
+          includeEventPayload: true,
+        },
+        trigger: { kind: "interval", everyMinutes: 30 },
+        priority: "high",
+        shouldFire: { compose: "all", gates: [{ kind: "quiet_hours" }] },
+        completionCheck: {
+          kind: "user_acknowledged",
+          followupAfterMinutes: 10,
+        },
+        escalation: { steps: [{ delayMinutes: 5, channelKey: "chat" }] },
+        output: { destination: "in_app_card" },
+        pipeline: { onComplete: [] },
+        subject: { kind: "self", id: "owner" },
+        idempotencyKey: "idem-1",
+        respectsGlobalPause: false,
+        source: "plugin",
+        createdBy: "someone-else",
+        ownerVisible: false,
+        metadata: { note: "kept" },
+        executionProfile: "bg-light-30s",
+      };
+      const res = await edit(handler, task.taskId, fullPatch);
+      expect(res.statusCode).toBe(200);
+      const persisted = (await runner.list()).find(
+        (t) => t.taskId === task.taskId,
+      );
+      for (const [key, value] of Object.entries(fullPatch)) {
+        if (key === "metadata") continue;
+        expect(persisted?.[key as keyof ScheduledTask]).toEqual(value);
+      }
+      expect(persisted?.metadata?.note).toBe("kept");
+    });
+
+    it("returns 400 (not 500) for a malformed trigger", async () => {
+      const { runner, handler, task } = await seed();
+      const res = await edit(
+        handler,
+        task.taskId,
+        JSON.parse('{"trigger":null}'),
+      );
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toContain("invalid edit payload");
+      const persisted = (await runner.list()).find(
+        (t) => t.taskId === task.taskId,
+      );
+      expect(persisted?.trigger).toEqual({ kind: "manual" });
+    });
+
+    it("rejects wrong-typed fields the create path already rejects, leaving the task untouched", async () => {
+      const { runner, handler, task } = await seed();
+      const res = await edit(
+        handler,
+        task.taskId,
+        JSON.parse(
+          '{"kind":12345,"priority":{"$ne":1},"ownerVisible":"yes","createdBy":null}',
+        ),
+      );
+      expect(res.statusCode).toBe(400);
+      const persisted = (await runner.list()).find(
+        (t) => t.taskId === task.taskId,
+      );
+      expect(persisted?.kind).toBe("reminder");
+      expect(persisted?.priority).toBe("low");
+      expect(persisted?.ownerVisible).toBe(true);
+      expect(persisted?.createdBy).toBe("tester");
+    });
+
+    it("rejects an unknown field instead of silently dropping it", async () => {
+      const { handler, task } = await seed();
+      const res = await edit(handler, task.taskId, { whatever: "junk" });
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toContain("whatever");
+    });
+
+    it("does not re-parent the task when the body carries an own __proto__ key", async () => {
+      const { runner, handler, task } = await seed();
+      const body = JSON.parse(
+        '{"promptInstructions":"edited","__proto__":{"isAdmin":true}}',
+      );
+      expect(Object.hasOwn(body, "__proto__")).toBe(true);
+      const res = await edit(handler, task.taskId, body);
+      expect(res.statusCode).toBe(409);
+      expect(res.body).toContain("edit: __proto__ is read-only");
+      const persisted = (await runner.list()).find(
+        (t) => t.taskId === task.taskId,
+      );
+      expect(Object.getPrototypeOf(persisted)).toBe(Object.prototype);
+      expect((persisted as unknown as { isAdmin?: unknown }).isAdmin).toBe(
+        undefined,
+      );
+      expect(({} as { isAdmin?: unknown }).isAdmin).toBe(undefined);
+      expect(persisted?.promptInstructions).toBe("drink water");
+    });
+
+    it("keeps the 409 read-only contract for the server-managed keys", async () => {
+      const { handler, task } = await seed();
+      for (const key of ["taskId", "state"] as const) {
+        const res = await edit(handler, task.taskId, { [key]: "anything" });
+        expect(res.statusCode).toBe(409);
+        expect(res.body).toContain(`edit: ${key} is read-only`);
+      }
+    });
+  });
 });

--- a/plugins/plugin-scheduling/src/routes/scheduled-tasks.ts
+++ b/plugins/plugin-scheduling/src/routes/scheduled-tasks.ts
@@ -22,11 +22,13 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   ChannelKeyError,
+  SCHEDULED_TASK_EDIT_READONLY_KEYS,
   type ScheduledTask,
   type ScheduledTaskFireResult,
   type ScheduledTaskRunnerHandle,
 } from "../scheduled-task/index.js";
 import {
+  scheduledTaskEditPayloadSchema,
   scheduledTaskFilterSchema,
   scheduledTaskInputSchema,
   scheduledTaskSnoozePayloadSchema,
@@ -498,6 +500,39 @@ async function handleScheduledTasks(
             error(
               res,
               `invalid snooze payload: ${parsed.error.issues.map((i) => i.message).join("; ")}`,
+              400,
+            );
+            return true;
+          }
+          payload = parsed.data;
+        } else if (verb === "edit") {
+          // `applyEdit` merges this body onto the live task with
+          // `Object.assign`, so it needs the same edge validation `snooze`
+          // already gets. Unvalidated, a caller writes wrong-typed fields
+          // straight into a persisted `ScheduledTask` — and `{"trigger":null}`
+          // crashes `computeNextFireAt` into a 500 instead of the 400 this
+          // boundary promises for malformed input. A `JSON.parse`-produced own
+          // `"__proto__"` key additionally re-parents the task object, because
+          // `Object.assign` writes through `[[Set]]`.
+          const raw = (body ?? {}) as Record<string, unknown>;
+          // Refuse the read-only keys up front, with the runner's own message
+          // and the 409 the boundary already documents for a read-only field.
+          // Zod reports neither: `.strict()` skips `__proto__`, and the two
+          // server-managed keys would degrade to a generic unknown-key 400.
+          const readOnly = SCHEDULED_TASK_EDIT_READONLY_KEYS.find((key) =>
+            Object.hasOwn(raw, key),
+          );
+          if (readOnly) {
+            error(res, `edit: ${readOnly} is read-only`, 409);
+            return true;
+          }
+          const parsed = scheduledTaskEditPayloadSchema.safeParse(raw);
+          if (!parsed.success) {
+            error(
+              res,
+              `invalid edit payload: ${parsed.error.issues
+                .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+                .join("; ")}`,
               400,
             );
             return true;

--- a/plugins/plugin-scheduling/src/scheduled-task/index.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/index.ts
@@ -131,6 +131,7 @@ export {
 } from "./runner-service.js";
 export {
   isScheduledTask,
+  scheduledTaskEditPayloadSchema,
   scheduledTaskFilterSchema,
   scheduledTaskInputSchema,
   scheduledTaskSchema,
@@ -221,6 +222,7 @@ export type {
 export {
   APPROVAL_DEFAULT_FOLLOWUP_AFTER_MINUTES,
   DEFAULT_TASK_EXECUTION_PROFILE,
+  SCHEDULED_TASK_EDIT_READONLY_KEYS,
   TASK_EXECUTION_PROFILES,
 } from "./types.js";
 export {

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
@@ -660,6 +660,46 @@ describe("ScheduledTaskRunner — every verb", () => {
     ).rejects.toThrow(/read-only/);
   });
 
+  it("edit refuses an own __proto__ key instead of re-parenting the task", async () => {
+    const h = makeHarness();
+    const task = await h.runner.schedule(baseInput());
+    // `JSON.parse` is the only way to build a real own "__proto__" data
+    // property — an object literal would invoke the setter instead.
+    const payload = JSON.parse(
+      '{"promptInstructions":"edited","__proto__":{"isAdmin":true}}',
+    );
+    expect(Object.hasOwn(payload, "__proto__")).toBe(true);
+    await expect(
+      h.runner.apply(
+        task.taskId,
+        "edit",
+        payload as Parameters<ScheduledTaskRunnerHandle["apply"]>[2],
+      ),
+    ).rejects.toThrow(/__proto__ is read-only/);
+    const persisted = (await h.runner.list()).find(
+      (t) => t.taskId === task.taskId,
+    );
+    expect(Object.getPrototypeOf(persisted)).toBe(Object.prototype);
+    expect((persisted as unknown as { isAdmin?: unknown }).isAdmin).toBe(
+      undefined,
+    );
+    expect(({} as { isAdmin?: unknown }).isAdmin).toBe(undefined);
+    expect(persisted?.promptInstructions).toBe(task.promptInstructions);
+  });
+
+  it("edit still accepts an ordinary patch after the __proto__ guard", async () => {
+    const h = makeHarness();
+    const task = await h.runner.schedule(baseInput());
+    const edited = await h.runner.apply(task.taskId, "edit", {
+      priority: "high",
+      metadata: { note: "kept" },
+      executionProfile: "bg-light-30s",
+    });
+    expect(edited.priority).toBe("high");
+    expect(edited.metadata?.note).toBe("kept");
+    expect(edited.executionProfile).toBe("bg-light-30s");
+  });
+
   it("reopen brings a terminal task back inside the 24h window", async () => {
     const h = makeHarness("2026-05-09T12:00:00.000Z");
     const task = await h.runner.schedule(baseInput());

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -49,6 +49,7 @@ import {
   type GateEvaluationContext,
   type GlobalPauseView,
   type OwnerFactsView,
+  SCHEDULED_TASK_EDIT_READONLY_KEYS,
   type ScheduledTask,
   type ScheduledTaskApplyResult,
   type ScheduledTaskFilter,
@@ -1372,11 +1373,14 @@ export function createScheduledTaskRunner(
     payload: Partial<Omit<ScheduledTask, "taskId" | "state">> | undefined,
   ): Promise<ScheduledTask> {
     if (!payload) return task;
-    // Cannot edit through state — that's what verbs are for.
-    const banned: Array<keyof ScheduledTask> = ["taskId", "state"];
-    for (const key of banned) {
-      if (key in (payload as Record<string, unknown>)) {
-        throw new Error(`edit: ${String(key)} is read-only`);
+    // Cannot edit through state — that's what verbs are for — and cannot edit
+    // through `__proto__`, which `Object.assign` would route to
+    // `Object.prototype`'s setter (see SCHEDULED_TASK_EDIT_READONLY_KEYS).
+    // `Object.hasOwn`, not `in`: `"__proto__" in payload` is true for every
+    // ordinary object.
+    for (const key of SCHEDULED_TASK_EDIT_READONLY_KEYS) {
+      if (Object.hasOwn(payload as Record<string, unknown>, key)) {
+        throw new Error(`edit: ${key} is read-only`);
       }
     }
     Object.assign(task, payload);

--- a/plugins/plugin-scheduling/src/scheduled-task/schema.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/schema.ts
@@ -9,7 +9,7 @@
  */
 
 import { z } from "zod";
-import type { ScheduledTask } from "./types.js";
+import { type ScheduledTask, TASK_EXECUTION_PROFILES } from "./types.js";
 
 const isoString = z
   .string()
@@ -215,6 +215,10 @@ const scheduledTaskInputBaseSchema = z.object({
   createdBy: z.string().min(1),
   ownerVisible: z.boolean(),
   metadata: z.record(z.string(), z.unknown()).optional(),
+  // `ScheduledTaskInput` carries this field, `validation.ts` checks it and the
+  // store persists it to `execution_profile` — the Zod layer was the only one
+  // that dropped it, so a caller's requested profile was silently discarded.
+  executionProfile: z.enum(TASK_EXECUTION_PROFILES).optional(),
 });
 
 export const scheduledTaskInputSchema = scheduledTaskInputBaseSchema;
@@ -269,6 +273,25 @@ export const scheduledTaskSnoozePayloadSchema = z
     (v) => typeof v.minutes === "number" || typeof v.untilIso === "string",
     "snooze: provide minutes or untilIso",
   );
+
+/**
+ * Payload accepted by `apply("edit")` at the REST boundary.
+ *
+ * `applyEdit` does `Object.assign(task, payload)` onto the live domain object,
+ * so the body has to be validated the same way the sibling `snooze` verb's is
+ * — an unvalidated body writes wrong-typed fields straight into a persisted
+ * `ScheduledTask` (which the create path rejects with 400), and a
+ * `JSON.parse`-produced own `"__proto__"` key re-parents the object because
+ * `Object.assign` assigns through `[[Set]]`.
+ *
+ * Every field of `ScheduledTaskInput` stays settable — this is the create
+ * schema made partial, nothing narrower. It is `.strict()` so a key that is
+ * not part of the task contract is reported to the caller instead of being
+ * silently dropped.
+ */
+export const scheduledTaskEditPayloadSchema = scheduledTaskInputBaseSchema
+  .partial()
+  .strict();
 
 export const scheduledTaskFilterSchema = z.object({
   kind: scheduledTaskKindSchema.optional(),

--- a/plugins/plugin-scheduling/src/scheduled-task/types.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/types.ts
@@ -313,6 +313,24 @@ export interface ScheduledTask {
  */
 export type ScheduledTaskInput = Omit<ScheduledTask, "taskId" | "state">;
 
+/**
+ * Keys `apply("edit")` refuses outright, checked with `Object.hasOwn` before
+ * anything merges onto the task.
+ *
+ * `taskId` and `state` are server-managed — the verbs own the state machine.
+ * `__proto__` is refused for a different reason: `applyEdit` merges the patch
+ * with `Object.assign`, which writes through `[[Set]]`, so a
+ * `JSON.parse`-produced own `"__proto__"` key reaches `Object.prototype`'s
+ * setter and re-parents the task instead of adding a field. Zod's `.strict()`
+ * does not report that key as unrecognized, so this explicit list is what makes
+ * the refusal visible to the caller rather than a silent drop.
+ */
+export const SCHEDULED_TASK_EDIT_READONLY_KEYS = [
+  "taskId",
+  "state",
+  "__proto__",
+] as const;
+
 export type ScheduledTaskRef = string | ScheduledTask;
 export type EventFilter = unknown; // typed via EventKindRegistry per kind
 export type GateParams = unknown; // typed via TaskGateRegistry per kind


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #23825 (owning issue, filed for this head, carrying the origin
reproduction verbatim).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched off the latest `origin/develop`
      (`3850758df657e222d82d6f63db77ae1d6d0b3938`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched off `origin/develop` @ `3850758df657e222d82d6f63db77ae1d6d0b3938`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low, and the risk axis worth a reviewer's attention is over-rejection — so it is
pinned by tests rather than argued.

The new `edit` schema is `scheduledTaskInputBaseSchema.partial().strict()`. It
is literally the create schema made partial: **every field a caller can set
through `edit` today is still settable**, and a test drives all sixteen of them
through the real route in one patch and reads them back off the persisted task.

Three behaviour changes are deliberate and named:

1. **`executionProfile` is added to `scheduledTaskInputBaseSchema`.** It is a
   field of `ScheduledTaskInput`; `validation.ts` validates it
   (`TASK_EXECUTION_PROFILES`) and `store.ts` persists it to the
   `execution_profile` column — the Zod layer was the only one that dropped it,
   so a caller's requested profile was already being silently discarded on
   create. Leaving it out would have made the new edit validation over-reject a
   field the store round-trips, which is the one thing this change must not do.
2. **An unknown key on `edit` is now a 400 instead of being written onto the
   in-memory task.** Nothing supported is lost: the SQL store writes named
   columns only, so an unknown key never survived a real persist anyway. The
   caller is now told, rather than silently ignored.
3. **`__proto__` in the body is now a 409 `edit: __proto__ is read-only`**,
   joining `taskId` and `state`. Zod's `.strict()` does not report `__proto__`
   as an unrecognized key, so naming it explicitly is what makes the refusal
   visible instead of a silent drop.

`taskId` / `state` keep their existing **409** answer with the runner's exact
message — the boundary already documents "editing a read-only field" as a 409,
and `.strict()` alone would have degraded it to a generic unknown-key 400.

No in-repo HTTP client calls this endpoint (`grep` for the path finds only the
route registration and its tests), and the in-repo `runner.apply(id, "edit", …)`
callers pass typed objects that carry none of the three refused keys.

# Background

## What does this PR do?

Every verb on the scheduled-tasks REST surface shares one dispatch block in
`plugins/plugin-scheduling/src/routes/scheduled-tasks.ts`. One of them — `snooze`
— validates its body before handing it to the runner:

```ts
if (verb === "snooze") {
  const parsed = scheduledTaskSnoozePayloadSchema.safeParse(body ?? {});
  if (!parsed.success) { error(res, `invalid snooze payload: …`, 400); return true; }
  payload = parsed.data;
}
```

`edit` did not. Its raw parsed JSON body went straight to `applyEdit`
(`plugins/plugin-scheduling/src/scheduled-task/runner.ts`), which merges it onto
the live domain object and persists the result:

```ts
const banned: Array<keyof ScheduledTask> = ["taskId", "state"];
for (const key of banned) { … }
Object.assign(task, payload);   // unvalidated body
await persist(task);
```

`banned` covers the two server-managed keys and nothing else, and no other layer
type-checks the patch — `validateScheduledTaskInput` runs on `schedule()`, not
on `apply("edit")`. **This is not a new policy; it is the pattern the sibling
verb one `if`-branch away already uses.**

Three consequences, all reproduced against unmodified `origin/develop` through
the real route handler (transcript below):

- **500 on a malformed field.** `{"trigger":null}` reaches `persist →
  resolveNextFireAt → computeNextFireAt`, which does `switch (trigger.kind)`.
  The `TypeError` escapes to `classifyRunnerError`, which — correctly — refuses
  to mask a runtime failure and answers **500**. The same file documents the
  intended contract two functions up: *"malformed task input → 400 (J3
  sanitized-input boundary)"*.
- **Wrong-typed fields persist.** `{"kind":12345,"priority":{"$ne":1},
  "ownerVisible":"yes","createdBy":null,"whatever":"junk"}` returns **200** and
  every value lands in the stored `ScheduledTask`. The create path rejects that
  exact body with a 400, so `edit` was a bypass of the schema the same resource
  is created under; the SQL store then writes those values into typed columns.
- **`__proto__` re-parents the live task.** `Object.assign` writes through
  `[[Set]]`, so a `JSON.parse`-produced own `"__proto__"` key hits
  `Object.prototype`'s setter.

**Scoping the `__proto__` half honestly, because it is the half that invites
overclaiming.** It re-parents the object the runner returns mid-request —
`getPrototypeOf(task) !== Object.prototype`, injected members readable off it —
and nothing more. `Object.prototype` is **not** globally polluted (the
assignment is per-object), and the store's `structuredClone` on `upsert` drops
the foreign prototype, so the *persisted* record is clean. I probed this
specifically rather than asserting it; the measurement is in the transcript. The
500 and the persisted wrong-typed fields are the material defects. `__proto__`
is fixed because the same one-line validation fixes it, not because it is the
headline.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

## Where should a reviewer start?

`plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts`, the new
`POST /:id/edit validates the body like its sibling snooze verb` block. It drives
the **real** `makeScheduledTasksRouteHandler` against the **real** runner and
store, using the harness already in that file. Six cases:

1. **compatibility** — a patch setting all sixteen `ScheduledTaskInput` fields
   returns 200 and every value is read back off the persisted task;
2. `{"trigger":null}` → **400**, and the stored trigger is unchanged;
3. wrong-typed `kind` / `priority` / `ownerVisible` / `createdBy` → **400**, and
   all four stored values are unchanged;
4. an unknown key → **400** naming the key, not a silent drop;
5. an own `__proto__` key → **409**, `getPrototypeOf(persisted) ===
   Object.prototype`, `Object.prototype` unpolluted, and the sibling field in the
   same body not applied;
6. **compatibility** — `taskId` and `state` still answer **409** with
   `edit: <key> is read-only`.

Plus two in `plugins/plugin-scheduling/src/scheduled-task/runner.test.ts` for
non-route callers of `runner.apply`: the `__proto__` refusal, and an ordinary
patch (including `executionProfile`) still applying after the new guard.

## Detailed testing steps

```
git checkout fix/validate-scheduled-task-edit-payload
bun install --frozen-lockfile
bunx vitest run --root plugins/plugin-scheduling \
  src/routes/scheduled-tasks.test.ts \
  src/scheduled-task/runner.test.ts
bun run --cwd plugins/plugin-scheduling typecheck
bunx @biomejs/biome check plugins/plugin-scheduling/src/routes/scheduled-tasks.ts \
  plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts \
  plugins/plugin-scheduling/src/scheduled-task/schema.ts \
  plugins/plugin-scheduling/src/scheduled-task/types.ts \
  plugins/plugin-scheduling/src/scheduled-task/index.ts \
  plugins/plugin-scheduling/src/scheduled-task/runner.ts \
  plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:17d460e21505ea0ba15df5fe52eed5f7bc7f11c9 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend route + runner modules and their tests; no rendered UI surface in the diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend route + runner modules and their tests; no rendered UI surface in the diff.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.

<!-- evidence-row:backend-logs -->
- [x] The route handler's own responses on unmodified `origin/develop` @ `3850758df657e222d82d6f63db77ae1d6d0b3938`, captured from the real `makeScheduledTasksRouteHandler`:

```text
A: status = 200
A: getPrototypeOf(task) === Object.prototype -> false
A: task.isAdmin -> true task.pwned -> 1
A: persisted proto === Object.prototype -> true | persisted.isAdmin -> undefined
A: Object.prototype.isAdmin (global) -> undefined
B: status = 500 body = {"error":"Cannot read properties of null (reading 'kind')"}
C: status = 200
C: persisted = {"taskId":"st_mt33lw4k_17gcuec6","kind":12345,"promptInstructions":"drink water",
    "trigger":{"kind":"manual"},"priority":{"$ne":1},"respectsGlobalPause":true,
    "source":"user_chat","createdBy":null,"ownerVisible":"yes",
    "metadata":{"schedulingCreationReceipt":{...}},
    "state":{"status":"scheduled","followupCount":0},"whatever":"junk"}
D: status = 400 body = {"error":"invalid snooze payload: Invalid input: expected number, received string"}
```

A = `{"promptInstructions":"edited","__proto__":{"isAdmin":true,"pwned":1}}` on `/edit`.
B = `{"trigger":null}` on `/edit`.
C = wrong-typed + unknown fields on `/edit`.
D = the **sibling `snooze` verb** on the same handler answering 400 for the same class of body.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed. This is an HTTP request-body validator.

<!-- evidence-row:domain-artifacts -->
- [x] Origin reproduction, post-fix reproduction, load-bearing revert check, focused + whole-package suites against an untouched control, typecheck control diff, and lint at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
head:        17d460e21505ea0ba15df5fe52eed5f7bc7f11c9
base:        3850758df657e222d82d6f63db77ae1d6d0b3938 (origin/develop, fetched 2026-08-21)
worktree:    a dedicated detached worktree at that base; the primary was never dirtied.

=== 1. ORIGIN REPRODUCTION (production files at develop) ===

Probe: a throwaway test file next to the existing route tests, reusing that
file's own harness (real makeScheduledTasksRouteHandler, real
createScheduledTaskRunner, real createInMemoryScheduledTaskStore). Every body is
built with JSON.parse so "__proto__" is a genuine own data property, not the
setter an object literal would invoke.

$ cd plugins/plugin-scheduling && vitest run src/routes/zz-origin-probe.test.ts \
    --reporter=verbose --disable-console-intercept

A: status = 200
A: getPrototypeOf(task) === Object.prototype -> false
A: task.isAdmin -> true task.pwned -> 1
A: persisted proto === Object.prototype -> true | persisted.isAdmin -> undefined
A: Object.prototype.isAdmin (global) -> undefined
B: status = 500 body = {"error":"Cannot read properties of null (reading 'kind')"}
C: status = 200
C: persisted = {"taskId":"st_mt33lw4k_17gcuec6","kind":12345,"promptInstructions":"drink water",
    "trigger":{"kind":"manual"},"priority":{"$ne":1},"respectsGlobalPause":true,
    "source":"user_chat","createdBy":null,"ownerVisible":"yes","metadata":{...},
    "state":{"status":"scheduled","followupCount":0},"whatever":"junk"}
D: status = 400 body = {"error":"invalid snooze payload: Invalid input: expected number, received string"}

Read A carefully: the live task IS re-parented, the PERSISTED task is NOT, and
Object.prototype is NOT globally polluted. I measured all three rather than
assuming the first implies the others, because the store's structuredClone is
exactly the kind of thing that quietly narrows this class of finding.

Two further probes I ran and am NOT claiming, for completeness:
  - an edit-persisted bad cron trigger poisoning a later tick: the probe hit the
    environment's stale @elizaos/core/edge dist (see Known gaps), so it proves
    nothing. Not used.
  - unregistered gate / completion-check kinds written through edit: the fire
    path handles them gracefully (`{"kind":"skipped","reason":"not_registered:
    unknown gate kind: not_registered"}`). No defect there; stated so it is not
    re-walked.

=== 2. SAME PROBE, AFTER THE FIX ===

A: status = 409 ... getPrototypeOf(task) === Object.prototype -> true
                    task.isAdmin -> undefined
B: status = 400 {"error":"invalid edit payload: trigger: Invalid input: expected object, received null"}
C: status = 400 ; persisted task byte-unchanged from creation
D: status = 400 (unchanged - the sibling verb was already correct)

(The probe file was deleted before committing; it is not in the diff. The six
committed route tests assert the same facts.)

=== 3. LOAD-BEARING REVERT CHECK (copy-aside, never `git stash`) ===

Production files reverted to develop, both test files kept:

$ vitest run src/routes/scheduled-tasks.test.ts src/scheduled-task/runner.test.ts
 Test Files  2 failed (2)
      Tests  10 failed | 86 passed (96)

 FAIL routes/scheduled-tasks.test.ts > ... > returns 400 (not 500) for a malformed trigger
 FAIL routes/scheduled-tasks.test.ts > ... > rejects wrong-typed fields the create path already rejects, leaving the task untouched
 FAIL routes/scheduled-tasks.test.ts > ... > rejects an unknown field instead of silently dropping it
 FAIL routes/scheduled-tasks.test.ts > ... > does not re-parent the task when the body carries an own __proto__ key
 FAIL scheduled-task/runner.test.ts  > ... > edit refuses an own __proto__ key instead of re-parenting the task
 (+ the 5 pre-existing environment failures listed in section 5)

5 of the 8 new tests are killed by reverting the fix. The other 3 are the
compatibility guards (full sixteen-field patch; taskId/state still 409; an
ordinary patch still applies) - those pass on BOTH sides by design, which is
what makes them compatibility guards rather than defect pins. Fix restored -> green.

=== 4. FOCUSED SUITE AT THIS HEAD, AGAINST AN UNTOUCHED CONTROL ===

$ vitest run src/routes/scheduled-tasks.test.ts src/scheduled-task/runner.test.ts
  branch : Tests  5 failed | 91 passed (96)
  control: Tests  5 failed | 83 passed (88)      # same tree, my 5 src files reverted

Same 5 failures on both sides (section 5). +8 passing = the 8 new tests.

$ vitest run                                     # the WHOLE plugin-scheduling package
  branch : Test Files 11 failed | 22 passed (33) ; Tests 42 failed | 492 passed (534)
  control: Test Files 11 failed | 22 passed (33) ; Tests 42 failed | 484 passed (526)
$ diff <(grep '^ FAIL' control.log | sort) <(grep '^ FAIL' branch.log | sort)
  (no output)  ->  FAILURE SETS IDENTICAL

The whole-package run is the specific evidence that adding executionProfile to
the shared create schema did not disturb any other consumer of it.

$ node scripts/proof-run.mjs run --repo <worktree> <branch> \
    bash -c 'cd plugins/plugin-scheduling && vitest run src/routes/scheduled-tasks.test.ts'
 Test Files  1 passed (1)
      Tests  22 passed (22)
proof-run: recorded PROOF for 17d460e21 (exit 0)

=== 5. THE 42 PRE-EXISTING FAILURES ===

All are `TypeError: computeNextCronRunAtMs is not a function` /
`stableStringify is not a function` out of `@elizaos/core/edge`, in
dst-boundaries / due / next-fire-at / recurrence-refire / event-bridge - files
this PR does not touch. They are an environment artifact: this worktree links the
monorepo's prebuilt node_modules, and that `@elizaos/core` dist predates those
edge exports. They reproduce identically on the untouched control, which is why
the control diff rather than a green run is the evidence here.

=== 6. TYPECHECK, AGAINST AN UNTOUCHED CONTROL ===

$ tsc --noEmit -p plugins/plugin-scheduling/tsconfig.json
  branch : 22 `error TS` lines
  control: 22 `error TS` lines
$ diff control.txt branch.txt
  (no output)  ->  the branch adds ZERO typecheck errors.

All 22 are the same stale-dist module-resolution errors as section 5, plus two
missing generated i18n keyword files.

=== 7. LINT ===

$ biome check <the 7 touched files>
Checked 7 files in 37ms. No fixes applied.
exit 0

=== 8. DIFF SHAPE ===

$ git diff --stat origin/develop...HEAD
 .../src/routes/scheduled-tasks.test.ts             | 160 +++++++++++++++++++++
 .../src/routes/scheduled-tasks.ts                  |  35 +++++
 .../plugin-scheduling/src/scheduled-task/index.ts  |   2 +
 .../src/scheduled-task/runner.test.ts              |  40 ++++++
 .../plugin-scheduling/src/scheduled-task/runner.ts |  14 +-
 .../plugin-scheduling/src/scheduled-task/schema.ts |  25 +++-
 .../plugin-scheduling/src/scheduled-task/types.ts  |  18 +++
 7 files changed, 288 insertions(+), 6 deletions(-)

SCHEDULED_TASK_EDIT_READONLY_KEYS lives in types.ts, not schema.ts, so runner.ts
gains no new import edge into the zod module.
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed. This is an
HTTP request-body validator on a REST route.

## Backend + frontend logs

Backend: the origin-reproduction block in the domain receipt is the real route
handler's own responses on unmodified `develop` - its status codes and its error
strings, captured through `makeScheduledTasksRouteHandler`, not a hand-called
inner function.

Frontend: N/A - no browser hop in this unit.

## Screenshots (before / after) + video walkthrough

N/A - backend route and runner modules and their tests; no rendered UI surface in
the diff.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

- Root `bun run verify` was **not** run on this head. It is a monorepo-wide gate
  and this tree cannot complete it: the worktree links the monorepo's prebuilt
  `node_modules`, whose `@elizaos/core` dist predates the `edge` exports
  `plugin-scheduling` imports, so 42 tests and 22 typecheck lines fail on
  **unmodified `develop`** here. The package suite, the whole-package control
  diff, the typecheck control diff and lint above were all executed, and the
  control diffs are the specific evidence that this PR adds nothing new.
- Hosted CI check-runs: none on this head. Fork branches on this repository do
  not schedule check-runs; that is repo steady state, not a skipped gate.
- Fork cannot upload `pr-evidence` release assets, so the domain receipt is inline.
- **Scope correction, stated plainly.** This target was handed to me as
  "prototype pollution re-parents the *persisted* `ScheduledTask`". That is not
  what happens, and I am not going to file it that way. The persisted record is
  clean, because the store `structuredClone`s on `upsert`, and
  `Object.prototype` is never globally polluted. What I did reproduce is the
  500, the wrong-typed fields that genuinely do persist, and a live domain
  object re-parented mid-request. Those are the claims this PR makes.
- The whole-package run covers `plugin-scheduling`. `@elizaos/plugin-personal-assistant`
  re-exports these schemas for back-compat; I did **not** run PA's suite (it needs
  a built core in this tree, same blocker as above). The change is additive to the
  create schema (one optional field) and adds a new export, so no PA re-export
  breaks, but that is reasoning, not an executed run - flagging it rather than
  letting it pass silently.
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-mine-23825]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JFS2470QS3F0DEYQ7FA5PW","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T15:42:04.935Z","completed_at":"2026-08-21T15:43:07.278Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T15:42:05.576Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"53cc04fb65664d318b7e2d066eed27115141d0ebcd6773fbde33c5eafc1ec6ef","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"478275b3-e949-4a66-a5c9-cdcfb3bdc606","object_id":"sha256:53cc04fb65664d318b7e2d066eed27115141d0ebcd6773fbde33c5eafc1ec6ef","sha256":"53cc04fb65664d318b7e2d066eed27115141d0ebcd6773fbde33c5eafc1ec6ef"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"PN3ln1SBQft8o8r1JGoo7sXH2pFmPUgvoPfrLQ-HUfwg2-tS8Hf-thh8Pn4NAaGqSOOKUxJhnM_myfaG2JhPCw"}} -->
