### PR TITLE
fix(cloud): compose the PayPal hop deadline with caller abort signals

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-paypal-connector.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-paypal-connector.test.ts
@@ -30,7 +30,11 @@ describe("paypalFetch — bounded hops fail closed and keep caller signals", () 
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
-  test("preserves a caller-provided abort signal", async () => {
+  // Asserting identity here is what kept the hop weak: `toBe(controller.signal)`
+  // is only true when the caller's signal REPLACED the deadline, which is the
+  // bug. The property worth pinning is that the caller's abort still
+  // propagates through the composed signal.
+  test("composes a caller-provided abort signal with the hop deadline", async () => {
     let seen: AbortSignal | undefined;
     globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
       seen = init?.signal;
@@ -41,6 +45,25 @@ describe("paypalFetch — bounded hops fail closed and keep caller signals", () 
     await paypalFetch("https://api-m.paypal.com/v1/oauth2/token", {
       signal: controller.signal,
     });
-    expect(seen).toBe(controller.signal);
+
+    expect(seen).toBeInstanceOf(AbortSignal);
+    expect(seen).not.toBe(controller.signal);
+    expect(seen?.aborted).toBe(false);
+  });
+
+  test("propagates a caller abort through the composed signal", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen = init?.signal;
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const controller = new AbortController();
+    await paypalFetch("https://api-m.paypal.com/v1/oauth2/token", {
+      signal: controller.signal,
+    });
+    controller.abort();
+
+    expect(seen?.aborted).toBe(true);
   });
 });

--- a/packages/cloud/shared/src/lib/services/agent-paypal-connector.ts
+++ b/packages/cloud/shared/src/lib/services/agent-paypal-connector.ts
@@ -34,9 +34,13 @@ export function paypalFetch(
   init?: RequestInit,
   timeoutMs: number = PAYPAL_REQUEST_TIMEOUT_MS,
 ): Promise<Response> {
+  // Compose rather than replace: `init?.signal ?? AbortSignal.timeout(...)`
+  // lets any caller that passes a signal silently drop the hop deadline, which
+  // is the failure this bound exists to prevent.
+  const deadline = AbortSignal.timeout(timeoutMs);
   return fetch(input, {
     ...init,
-    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+    signal: init?.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
   });
 }
 


### PR DESCRIPTION
## Problem

`agent-paypal-connector.ts` was the last hop in this series still using the weak form:

```ts
signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
```

`??` means a caller that supplies a signal **replaces** the deadline rather than joining it — so the bound this wrapper exists to provide silently disappears for exactly the callers most likely to have their own cancellation. #23822 fixed the other four hops (`alerts`, `bluesky`, `slack`, `vertex-tuning`); this one was left behind.

## Why it survived

Its test was asserting the bug:

```ts
test("preserves a caller-provided abort signal", async () => {
  ...
  expect(seen).toBe(controller.signal);
});
```

`toBe(controller.signal)` is only true when the caller's signal replaced the deadline. Composing the signal **breaks** that assertion, which made leaving the weakness the path of least resistance. This is the sixth instance of that exact pattern I've found across this series, and it is the mechanism by which the weak form kept passing review — the test looked like it was protecting caller cancellation when it was really pinning the missing bound.

## Fix

```ts
const deadline = AbortSignal.timeout(timeoutMs);
return fetch(input, {
  ...init,
  signal: init?.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
});
```

The test now pins the property that actually matters — that a caller abort still propagates through the composed signal — rather than signal identity:

- `composes a caller-provided abort signal with the hop deadline` — asserts the signal is an `AbortSignal`, is **not** the caller's, and is not already aborted.
- `propagates a caller abort through the composed signal` — asserts the caller's `abort()` still reaches it.

## Evidence

**3/3 pass.** Restoring the weak form fails the composition test:

```
(fail) composes a caller-provided abort signal with the hop deadline
 2 pass, 1 fail
```

So the new assertion is falsifiable in the direction that matters, where the one it replaced was falsifiable only in the wrong direction.

Biome clean.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [pr-finisher]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/eliza@7c4226d710c31571caaaf4472af5bc95bd75a274:packages/skills/skills/contribute-to-eliza"} -->