### PR TITLE
fix(cloud): fence warm-pool claims by target tier

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
@@ -6,7 +6,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { pushSchema } from "drizzle-kit/api";
 import { eq, sql } from "drizzle-orm";
-import { agentSandboxes } from "../../schemas/agent-sandboxes";
+import { agentSandboxes, WARM_POOL_ORG_ID, WARM_POOL_USER_ID } from "../../schemas/agent-sandboxes";
 import { apiKeys } from "../../schemas/api-keys";
 import { dockerNodes } from "../../schemas/docker-nodes";
 import { generations } from "../../schemas/generations";
@@ -113,7 +113,6 @@ async function seedPoolEntry(
   return repository.createPoolEntry({
     agent_name: `pool-${crypto.randomUUID().slice(0, 8)}`,
     status: "running",
-    execution_tier: "dedicated-always",
     database_status: "ready",
     sandbox_id: `sandbox-${crypto.randomUUID()}`,
     node_id: "node-1",
@@ -127,7 +126,9 @@ async function seedPoolEntry(
   });
 }
 
-async function seedUserAgent(): Promise<string> {
+async function seedUserAgent(
+  executionTier: "shared" | "dedicated-always" = "dedicated-always",
+): Promise<string> {
   const [row] = await dbWrite
     .insert(agentSandboxes)
     .values({
@@ -135,7 +136,7 @@ async function seedUserAgent(): Promise<string> {
       user_id: USER_ID,
       agent_name: `claim-${crypto.randomUUID().slice(0, 8)}`,
       status: "pending",
-      execution_tier: "dedicated-always",
+      execution_tier: executionTier,
       database_status: "none",
     })
     .returning({ id: agentSandboxes.id });
@@ -148,6 +149,10 @@ describe("one claimable-capacity predicate", () => {
     "counts, image inventory, and the claim transaction agree on the exact row",
     async () => {
       const valid = await seedPoolEntry();
+      expect(valid.execution_tier).toBe("dedicated-always");
+      expect(valid.billing_status).toBe("exempt");
+      expect(valid.last_billed_at).toBeNull();
+      expect(valid.hourly_rate).toBe("0.0000");
       await seedPoolEntry({ pool_ready_at: null });
       await seedPoolEntry({ bridge_url: null });
       await seedPoolEntry({ node_id: null });
@@ -184,6 +189,82 @@ describe("one claimable-capacity predicate", () => {
       expect(claimed?.warm_pool_row_id).toBe(valid.id);
       expect(claimed?.status).toBe("provisioning");
       expect(await repository.countUnclaimedPool({ image: IMAGE })).toBe(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a legacy Shared-tier pool source remains claimable by a Dedicated target",
+    async () => {
+      const [legacyPool] = await dbWrite
+        .insert(agentSandboxes)
+        .values({
+          organization_id: WARM_POOL_ORG_ID,
+          user_id: WARM_POOL_USER_ID,
+          agent_name: "legacy-shared-pool",
+          status: "running",
+          execution_tier: "shared",
+          billing_status: "exempt",
+          pool_status: "unclaimed",
+          pool_ready_at: new Date("2026-07-30T00:00:00.000Z"),
+          database_status: "ready",
+          database_uri: "postgres://legacy-pool",
+          sandbox_id: "legacy-pool-sandbox",
+          node_id: "legacy-pool-node",
+          container_name: "legacy-pool-container",
+          bridge_url: "http://100.64.0.20:3000",
+          health_url: healthUrl(),
+          docker_image: IMAGE,
+          image_digest: TARGET_DIGEST,
+        })
+        .returning();
+      if (!legacyPool) throw new Error("failed to seed legacy Shared pool row");
+      const userAgentId = await seedUserAgent();
+
+      const claimed = await repository.claimWarmContainer({
+        userAgentId,
+        organizationId: USER_ORG_ID,
+        image: IMAGE,
+        agentName: "legacy-source-claim",
+      });
+
+      expect(claimed?.warm_pool_row_id).toBe(legacyPool.id);
+      expect(claimed?.execution_tier).toBe("dedicated-always");
+      expect(claimed?.pool_status).toBeNull();
+      expect(claimed?.billing_status).toBe("active");
+      expect(claimed?.container_name).toBe(legacyPool.container_name);
+      expect(await repository.findById(legacyPool.id)).toBeUndefined();
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a Shared target cannot consume or inherit a ready pool container",
+    async () => {
+      const pool = await seedPoolEntry();
+      const sharedTargetId = await seedUserAgent("shared");
+
+      const claimed = await repository.claimWarmContainer({
+        userAgentId: sharedTargetId,
+        organizationId: USER_ORG_ID,
+        image: IMAGE,
+        agentName: "must-stay-shared",
+      });
+
+      expect(claimed).toBeNull();
+      expect(await repository.findById(pool.id)).toMatchObject({
+        id: pool.id,
+        pool_status: "unclaimed",
+        container_name: pool.container_name,
+      });
+      expect(await repository.findById(sharedTargetId)).toMatchObject({
+        id: sharedTargetId,
+        execution_tier: "shared",
+        status: "pending",
+        node_id: null,
+        container_name: null,
+        claimed_at: null,
+      });
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -74,6 +74,7 @@ const select = mock(() => ({ from: selectFrom }));
 type ExecuteResult = { rows: unknown[]; rowCount?: number };
 let executeHandler: (sqlText: string) => ExecuteResult = () => ({ rows: [] });
 let userRowForClaim: unknown;
+let warmClaimReadWhereClause: SQL | undefined;
 let warmClaimWhereClause: SQL | undefined;
 const warmClaimUpdateSet = mock((values: Record<string, unknown>) => {
   void values;
@@ -95,11 +96,14 @@ function makeTx() {
     }),
     select: mock(() => ({
       from: mock(() => ({
-        where: mock(() => ({
-          for: mock(() => ({
-            limit: mock(() => [userRowForClaim].filter(Boolean)),
-          })),
-        })),
+        where: mock((clause: SQL) => {
+          warmClaimReadWhereClause = clause;
+          return {
+            for: mock(() => ({
+              limit: mock(() => [userRowForClaim].filter(Boolean)),
+            })),
+          };
+        }),
       })),
     })),
     update: mock(() => ({
@@ -754,6 +758,7 @@ describe("AgentSandboxesRepository", () => {
         id: params.userAgentId,
         organization_id: params.organizationId,
         status: "pending",
+        execution_tier: "dedicated-always",
         database_status: null,
         database_uri: null,
         deletion_attempt_id: null,
@@ -769,6 +774,8 @@ describe("AgentSandboxesRepository", () => {
 
     beforeEach(() => {
       useTransactionMock = true;
+      warmClaimReadWhereClause = undefined;
+      warmClaimWhereClause = undefined;
     });
 
     afterEach(() => {
@@ -839,6 +846,7 @@ describe("AgentSandboxesRepository", () => {
         id: "pool-1",
         pool_status: "unclaimed",
         status: "running",
+        execution_tier: "shared",
         docker_image: IMAGE,
         image_digest: `sha256:${"a".repeat(64)}`,
         pool_ready_at: new Date("2026-07-07T11:00:00.000Z"),
@@ -899,13 +907,62 @@ describe("AgentSandboxesRepository", () => {
       // carries the id out of the transaction (#17066 review — the claimed
       // row's own id can never reach that key name).
       expect(result?.warm_pool_row_id).toBe("pool-1");
+      if (!warmClaimReadWhereClause) throw new Error("Warm claim did not guard its target read");
+      const readQuery = new PgDialect().sqlToQuery(warmClaimReadWhereClause);
+      expect(readQuery.sql.toLowerCase()).toContain("execution_tier");
+      expect(readQuery.sql.toLowerCase()).toContain("pool_status");
+      expect(readQuery.sql.toLowerCase()).toContain("deleted_at");
+      expect(readQuery.params).toEqual(
+        expect.arrayContaining(["dedicated-lazy", "dedicated-always", "custom"]),
+      );
+      expect(readQuery.params).not.toContain("shared");
       if (!warmClaimWhereClause) throw new Error("Warm claim did not build an update predicate");
-      const updateSql = new PgDialect().sqlToQuery(warmClaimWhereClause).sql.toLowerCase();
+      const updateQuery = new PgDialect().sqlToQuery(warmClaimWhereClause);
+      const updateSql = updateQuery.sql.toLowerCase();
       expect(updateSql).toContain("organization_id");
+      expect(updateSql).toContain("execution_tier");
+      expect(updateSql).toContain("pool_status");
+      expect(updateSql).toContain("deleted_at");
+      expect(updateQuery.params).toEqual(
+        expect.arrayContaining(["dedicated-lazy", "dedicated-always", "custom"]),
+      );
+      expect(updateQuery.params).not.toContain("shared");
       expect(updateSql).toContain("deletion_attempt_id");
       expect(updateSql).toContain("deletion_pending");
       expect(updateSql).toContain("deletion_failed");
       expect(updateSql).toContain("lifecycle_revision");
+    });
+
+    test("a Shared target is refused before any pool transfer", async () => {
+      userRowForClaim = { ...pendingUserRow(), execution_tier: "shared" };
+      warmClaimUpdateSet.mockClear();
+      warmClaimDeleteWhere.mockClear();
+      executeHandler = (sqlText: string) => {
+        if (sqlText.includes("FOR UPDATE SKIP LOCKED")) {
+          return {
+            rows: [
+              {
+                id: "legacy-shared-pool-source",
+                pool_status: "unclaimed",
+                status: "running",
+                execution_tier: "shared",
+                docker_image: IMAGE,
+                image_digest: `sha256:${"d".repeat(64)}`,
+                pool_ready_at: new Date("2026-07-07T11:00:00.000Z"),
+                node_id: "legacy-node",
+                container_name: "legacy-container",
+                bridge_url: "http://100.64.0.11:3000",
+              },
+            ],
+          };
+        }
+        return { rows: [] };
+      };
+
+      const { AgentSandboxesRepository } = await import("./agent-sandboxes");
+      await expect(new AgentSandboxesRepository().claimWarmContainer(params)).resolves.toBeNull();
+      expect(warmClaimUpdateSet).not.toHaveBeenCalled();
+      expect(warmClaimDeleteWhere).not.toHaveBeenCalled();
     });
 
     test("a stale lifecycle revision cannot consume a warm pool container", async () => {

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -1860,11 +1860,17 @@ export class AgentSandboxesRepository {
           and(
             eq(agentSandboxes.id, params.userAgentId),
             eq(agentSandboxes.organization_id, params.organizationId),
+            inArray(agentSandboxes.execution_tier, [...CONTAINER_BACKED_EXECUTION_TIERS]),
+            isNull(agentSandboxes.pool_status),
+            isNull(agentSandboxes.deleted_at),
           ),
         )
         .for("update")
         .limit(1);
       if (!userRow) return null;
+      if (!CONTAINER_BACKED_EXECUTION_TIERS.some((tier) => tier === userRow.execution_tier)) {
+        return null;
+      }
 
       // Pool claim is for fresh provisions only. If the user's row already
       // has a database, fall through to the existing provision flow which
@@ -1942,6 +1948,9 @@ export class AgentSandboxesRepository {
           and(
             eq(agentSandboxes.id, params.userAgentId),
             eq(agentSandboxes.organization_id, params.organizationId),
+            inArray(agentSandboxes.execution_tier, [...CONTAINER_BACKED_EXECUTION_TIERS]),
+            isNull(agentSandboxes.pool_status),
+            isNull(agentSandboxes.deleted_at),
             ...(params.expectedLifecycleRevision === undefined
               ? []
               : [eq(agentSandboxes.lifecycle_revision, params.expectedLifecycleRevision)]),
@@ -1964,7 +1973,18 @@ export class AgentSandboxesRepository {
 
   /** Insert a pool entry pre-bound to the sentinel pool org. */
   async createPoolEntry(
-    data: Omit<NewAgentSandbox, "organization_id" | "user_id" | "pool_status">,
+    data: Omit<
+      NewAgentSandbox,
+      | "organization_id"
+      | "user_id"
+      | "pool_status"
+      | "execution_tier"
+      | "billing_status"
+      | "last_billed_at"
+      | "hourly_rate"
+      | "shutdown_warning_sent_at"
+      | "scheduled_shutdown_at"
+    >,
   ): Promise<AgentSandbox> {
     await ensureAgentSandboxSchema();
     const [row] = await dbWrite
@@ -1974,6 +1994,17 @@ export class AgentSandboxesRepository {
         organization_id: WARM_POOL_ORG_ID,
         user_id: WARM_POOL_USER_ID,
         pool_status: "unclaimed",
+        // Pool placeholders own a real prewarmed container. Never inherit the
+        // schema's container-free Shared default at this creation seam.
+        execution_tier: "dedicated-always",
+        // The sentinel org owns capacity, not a customer subscription. Keep
+        // pool generations outside elapsed charging until a claim transfers
+        // infrastructure onto an already-container-backed user row.
+        billing_status: "exempt",
+        last_billed_at: null,
+        hourly_rate: "0.0000",
+        shutdown_warning_sent_at: null,
+        scheduled_shutdown_at: null,
       })
       .returning();
     if (!row) throw new Error("Failed to create warm pool entry");

--- a/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
@@ -1646,6 +1646,7 @@ describe("admin agent image rollout on primary PGlite", () => {
         user_id: seeded.actorUserId,
         agent_name: "Warm Claim Canary",
         status: "pending",
+        execution_tier: "dedicated-always",
       },
       {
         id: poolRowId,


### PR DESCRIPTION
# Relates to

Related to #22947. This is slice B of the remaining admission barriers; it does not close the issue.

- [x] This PR targets `develop` and is rebased onto `origin/develop` `a3e45ac538fbd79e4682e3b505f5eb77e3b65d34` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync; the exact unrelated `verify` blocker is recorded below and reproduced on clean `develop`.
- [x] A reviewer can confirm the change from the exact-head unit and isolated-PGlite evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/GPT-5.6`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` `a3e45ac538fbd79e4682e3b505f5eb77e3b65d34`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact unrelated i18n blocker is documented below and matches clean `develop` by key name.

# Risks

Low. The change is limited to warm-pool row creation and the atomic repository claim. The primary risk is refusing a legitimately container-backed target; positive Dedicated/custom allowlist coverage, the real PGlite transfer, and the retained legacy-Shared source case constrain that risk. No live data, migration, billing price, autoscaling, or deployment is changed.

# Background

## What does this PR do?

- Makes every newly created warm-pool placeholder explicitly `dedicated-always`, billing-exempt, zero-rate, and free of billing shutdown timestamps instead of inheriting the schema's container-free Shared default.
- Requires the claim target to be a non-deleted, user-owned row whose tier is in the canonical container-backed allowlist at both the locked read and final update CAS.
- Keeps a runtime allowlist check and never accepts a tier supplied by the caller.
- Deliberately leaves the pool-source predicate tier-agnostic, so historical slots stored as Shared remain claimable.
- Preserves the target row's tier and billing authority; source tier/billing fields are never copied.
- Makes the existing rollout fixture explicit about its Dedicated target.

Historical authors inventoried on the affected files: Derek Barnes, nubs, NubsCarson, Shaw, Sol, Stan, and standujar.

## What kind of change is this?

Bug fix (non-breaking admission and authority hardening).

# Documentation changes needed?

No project-documentation change is required. The repository comments and focused tests document the authority boundary; the later append-only billing-trigger migration remains a separate #22947 slice.

# Testing

## Where should a reviewer start?

Start with `AgentSandboxesRepository.claimWarmContainer` and `createPoolEntry` in `packages/cloud/shared/src/db/repositories/agent-sandboxes.ts`, then read the two new real-PGlite cases in `warm-pool-stranded-readiness.test.ts`.

## Detailed testing steps

Exact reviewed head: `3898765c9c5d8af151d0098b530aaca7df69daba` under Node `24.15.0` and Bun `1.3.14`.

- `bun install --frozen-lockfile` — exit 0.
- `bun test packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts` — 22 pass, 0 fail.
- `bun test packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts` — 16 pass, 0 fail against isolated PGlite.
- `bun test packages/cloud/shared/src/lib/services/containers/agent-warm-pool-creator.error-policy.test.ts` — 13 pass, 0 fail.
- Focused `admin-agent-image-rollout.pglite.test.ts` warm-claim case — 1 pass, 47 filtered, 0 fail.
- `bun run --cwd packages/cloud/shared lint:check` — 2,236 files checked, exit 0.
- Changed-file Biome and `git diff --check` — exit 0.
- Independent read-only review found one stale implicit-Shared rollout fixture; it is explicit in this head, and the focused PGlite case passes.

# Evidence Gate

<!-- evidence-head:3898765c9c5d8af151d0098b530aaca7df69daba -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - repository-only database authority change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - repository-only database authority change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible interaction or frontend flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend was changed; the real repository path is exercised against isolated PGlite at the exact head.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, request, or state changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent prompt, model, action, or provider behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the domain artifacts are ephemeral isolated-PGlite rows asserted directly by the 16-test repository suite; no persistent or live row was created.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM-call behavior changed.

## Backend + frontend logs

N/A - no deployed surface was mutated. Exact-head test output above records the repository and PGlite execution results.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- Full `admin-agent-image-rollout.pglite.test.ts`: 45 pass / 3 fail at this head. The same three tests fail by exact name on clean `develop` `2271e3b78750e19045a0b83c541d52da34d72158`: `post-cutover cleanup failure requeues immediately, then a scheduled claim converges exactly once`, `a chat 401 is durably failed while the independent canary still completes`, and `terminal execution failure retains actor, decision, error, and result timestamps`. The touched warm-claim case passes independently.
- Cloud-shared typecheck stops at `shared-runtime/conversation-coordinator.ts:241` (`URL | RequestInfo` is not assignable to `string | URL`), exactly reproduced on clean `develop`.
- Root `bun run verify` stops in `check:i18n` on the same seven missing English connector-account keys as clean `develop`: five `connectoraccount.capabilities.*` keys plus `connectoraccount.reconnect` and `connectoraccount.reconnectLabel`.
- `bun run build:core` generates the required local core artifacts, then the local mise Node install invokes its shell `npm` shim through Node during `npm pack` and exits on `set -euo pipefail`; the identical setup failure reproduces on clean `develop` and is unrelated to this diff.
- GitHub Actions are not used as acceptance evidence because repository concurrency currently leaves checks queued/cancelled; the evidence above is local at the exact head.

# Deploy Notes

No manual deploy and no live-data operation. This PR contains no migration; the append-only warm-pool billing-trigger migration remains a later #22947 slice.

AI provider/model: OpenAI / GPT-5.6
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-warm-claim-authority]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5.6","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
