### PR TITLE
fix(core): bound the Stage-1 planner tool-argument canonicalizer

### DIFF
--- a/packages/core/src/services/message.tool-argument-bounds.test.ts
+++ b/packages/core/src/services/message.tool-argument-bounds.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Stage-1 tool-argument parsing is an untrusted-model boundary
+ * (`error-policy:J3 planner output is untrusted model input`). A planner that
+ * emits the HANDLE_RESPONSE arguments as a duplicated object stream drives the
+ * duplicated-stream recovery in `parseToolArgumentsString`, which canonicalizes
+ * each recovered fragment before comparing them.
+ *
+ * That canonicalizer must be bounded, and it must fail rather than truncate:
+ *   - an over-nested fragment becomes the documented "malformed" signal so the
+ *     Stage-1 recovery chain runs, never a `RangeError` that escapes
+ *     `runV5MessageRuntimeStage1` and ends the turn;
+ *   - two DIFFERENT over-budget fragments must never compare equal, which is
+ *     what a lossy normalizer would produce;
+ *   - every stream the live path accepts today still recovers unchanged.
+ *
+ * `getStage1RetryReason` is the exported Stage-1 entry point that reaches the
+ * parser (`message.ts` calls it on the raw completion before parsing), so these
+ * assertions run the real production path with no test-only surface.
+ */
+import { describe, expect, it } from "vitest";
+import { HANDLE_RESPONSE_TOOL_NAME } from "../actions/to-tool";
+import type { GenerateTextResult } from "../types/index";
+import { getStage1RetryReason } from "./message";
+
+function nestedObjectJson(depth: number, leaf = "1"): string {
+	return `${'{"a":'.repeat(depth)}${leaf}${"}".repeat(depth)}`;
+}
+
+/** A weak model narrating the same tool call twice, as concatenated objects. */
+function duplicatedStream(objectText: string): string {
+	return `${objectText}${objectText}`;
+}
+
+function rawWithToolArguments(argumentsText: string): GenerateTextResult {
+	return {
+		toolCalls: [{ name: HANDLE_RESPONSE_TOOL_NAME, arguments: argumentsText }],
+	} as unknown as GenerateTextResult;
+}
+
+/** A realistic HANDLE_RESPONSE arguments object, emitted twice by the model. */
+const WELL_FORMED_ARGUMENTS = JSON.stringify({
+	shouldRespond: true,
+	replyText: "Here is the summary you asked for.",
+	thought: "The user wants a recap; answer directly.",
+	contexts: [
+		{ name: "RECENT_MESSAGES", reason: "transcript" },
+		{ name: "ENTITIES", reason: "who is speaking" },
+	],
+	plan: { reply: "Here is the summary you asked for.", actions: ["REPLY"] },
+});
+
+describe("Stage-1 tool-argument canonicalization bounds", () => {
+	it("classifies an over-nested duplicated stream instead of overflowing", () => {
+		const argumentsText = duplicatedStream(nestedObjectJson(50_000));
+		// Well inside an ordinary completion: ~586 KiB of model output.
+		expect(argumentsText.length).toBeLessThan(1_000_000);
+		expect(getStage1RetryReason(rawWithToolArguments(argumentsText))).toBe(
+			"malformed HANDLE_RESPONSE tool call",
+		);
+	});
+
+	it("does not compare two DIFFERENT over-budget fragments as equal", () => {
+		// A lossy normalizer collapses both tails to the same marker and would
+		// accept this stream as a repeat of one object. It is not one.
+		const argumentsText = `${nestedObjectJson(50_000, '"LEFT"')}${nestedObjectJson(
+			50_000,
+			'"RIGHT"',
+		)}`;
+		expect(getStage1RetryReason(rawWithToolArguments(argumentsText))).toBe(
+			"malformed HANDLE_RESPONSE tool call",
+		);
+	});
+
+	it("still recovers an ordinary duplicated HANDLE_RESPONSE stream", () => {
+		expect(
+			getStage1RetryReason(
+				rawWithToolArguments(duplicatedStream(WELL_FORMED_ARGUMENTS)),
+			),
+		).toBeNull();
+	});
+
+	it("still recovers when the repeat differs only in key order", () => {
+		const argumentsText = `${JSON.stringify({
+			shouldRespond: true,
+			replyText: "ok",
+		})}${JSON.stringify({ replyText: "ok", shouldRespond: true })}`;
+		expect(
+			getStage1RetryReason(rawWithToolArguments(argumentsText)),
+		).toBeNull();
+	});
+
+	it("still rejects a duplicated stream whose fragments genuinely differ", () => {
+		const argumentsText = `${JSON.stringify({
+			shouldRespond: true,
+			replyText: "one",
+		})}${JSON.stringify({ shouldRespond: true, replyText: "two" })}`;
+		expect(getStage1RetryReason(rawWithToolArguments(argumentsText))).toBe(
+			"malformed HANDLE_RESPONSE tool call",
+		);
+	});
+
+	it("accepts nesting up to the depth budget and rejects one level past it", () => {
+		// The recovered fragment is the walk root at depth 0, so 32 nested objects
+		// is the deepest accepted shape.
+		const atBudget = `{"shouldRespond":true,"replyText":${JSON.stringify(
+			"x",
+		)},"d":${nestedObjectJson(30)}}`;
+		expect(
+			getStage1RetryReason(rawWithToolArguments(duplicatedStream(atBudget))),
+		).toBeNull();
+
+		const pastBudget = `{"shouldRespond":true,"replyText":${JSON.stringify(
+			"x",
+		)},"d":${nestedObjectJson(32)}}`;
+		expect(
+			getStage1RetryReason(rawWithToolArguments(duplicatedStream(pastBudget))),
+		).toBe("malformed HANDLE_RESPONSE tool call");
+	});
+
+	it("charges array width, so an over-wide fragment is declined not walked", () => {
+		const wide = `{"shouldRespond":true,"contexts":[${Array.from(
+			{ length: 25_000 },
+			(_, index) => index,
+		).join(",")}]}`;
+		expect(
+			getStage1RetryReason(rawWithToolArguments(duplicatedStream(wide))),
+		).toBe("malformed HANDLE_RESPONSE tool call");
+
+		// Well under the node budget still recovers — the cap is a real budget,
+		// not a blanket rejection of wide planner output. (Width is charged once
+		// up front and once per visited element, matching `connector-json.ts`.)
+		const narrow = `{"shouldRespond":true,"contexts":[${Array.from(
+			{ length: 8_000 },
+			(_, index) => index,
+		).join(",")}]}`;
+		expect(
+			getStage1RetryReason(rawWithToolArguments(duplicatedStream(narrow))),
+		).toBeNull();
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -5328,6 +5328,10 @@ function canonicalOwnDescriptor(
 	try {
 		return Object.getOwnPropertyDescriptor(value, key);
 	} catch (error) {
+		// error-policy:J2 a hostile or revoked Proxy can make
+		// getOwnPropertyDescriptor throw; rethrow as the typed unbounded
+		// failure with the original preserved as `cause`, so the caller sees
+		// one failure shape rather than a raw reflection error.
 		failCanonicalJsonUnbounded("reflection", { key: String(key) }, error);
 	}
 }
@@ -5347,6 +5351,9 @@ function canonicalOwnEntries(
 	try {
 		keys = Reflect.ownKeys(value);
 	} catch (error) {
+		// error-policy:J2 same shape as the descriptor read above — a revoked
+		// Proxy makes Reflect.ownKeys throw, and it is rethrown as the typed
+		// unbounded failure with the original as `cause`.
 		failCanonicalJsonUnbounded("reflection", {}, error);
 	}
 	// Width is charged before the entry array is allocated.

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -5244,21 +5244,211 @@ export async function renderMessageHandlerStablePrefix(
 		.join("\n\n");
 }
 
-function canonicalJsonValue(value: unknown): string {
+/**
+ * Budget for the Stage-1 duplicated-stream canonicalizer. The values walked
+ * here are `JSON.parse` products of planner output — `error-policy:J3 planner
+ * output is untrusted model input` — so the walk is bounded the way
+ * `database/connector-json.ts` bounds connector JSON: a depth cap, a node
+ * budget charged BEFORE any per-child allocation, an output-size budget, and a
+ * path-local cycle guard that still accepts an honest DAG.
+ *
+ * Overflow is a typed failure, never a truncated canonical form. A lossy
+ * normalizer (`services/trajectory-json.ts` replaces an over-depth branch with
+ * `"[MaxDepth]"`) cannot back this comparison: two DIFFERENT over-budget
+ * fragments would canonicalize to the same string and the equality check below
+ * would accept a stream the model never actually repeated.
+ */
+const MAX_TOOL_ARGUMENT_CANONICAL_DEPTH = 32;
+const MAX_TOOL_ARGUMENT_CANONICAL_NODES = 20_000;
+const MAX_TOOL_ARGUMENT_CANONICAL_OUTPUT_CHARS = 4 * 1024 * 1024;
+const TOOL_ARGUMENT_CANONICAL_UNBOUNDED = "TOOL_ARGUMENT_CANONICAL_UNBOUNDED";
+
+type CanonicalJsonOverflowReason =
+	| "accessor"
+	| "chars"
+	| "cycle"
+	| "depth"
+	| "nodes"
+	| "reflection";
+
+type CanonicalJsonState = {
+	nodes: number;
+	chars: number;
+	readonly visiting: WeakSet<object>;
+};
+
+function createCanonicalJsonState(): CanonicalJsonState {
+	return { nodes: 0, chars: 0, visiting: new WeakSet<object>() };
+}
+
+function failCanonicalJsonUnbounded(
+	reason: CanonicalJsonOverflowReason,
+	context: Record<string, unknown> = {},
+	cause?: unknown,
+): never {
+	throw new ElizaError(`planner tool arguments are unbounded (${reason})`, {
+		code: TOOL_ARGUMENT_CANONICAL_UNBOUNDED,
+		severity: "ephemeral",
+		context: {
+			reason,
+			maxDepth: MAX_TOOL_ARGUMENT_CANONICAL_DEPTH,
+			maxNodes: MAX_TOOL_ARGUMENT_CANONICAL_NODES,
+			maxOutputChars: MAX_TOOL_ARGUMENT_CANONICAL_OUTPUT_CHARS,
+			...context,
+		},
+		...(cause !== undefined ? { cause } : {}),
+	});
+}
+
+function isCanonicalJsonUnboundedError(error: unknown): boolean {
+	return (
+		error instanceof ElizaError &&
+		error.code === TOOL_ARGUMENT_CANONICAL_UNBOUNDED
+	);
+}
+
+function chargeCanonicalNodes(state: CanonicalJsonState, count: number): void {
+	state.nodes += count;
+	if (state.nodes > MAX_TOOL_ARGUMENT_CANONICAL_NODES) {
+		failCanonicalJsonUnbounded("nodes", { nodes: state.nodes });
+	}
+}
+
+function chargeCanonicalChars(state: CanonicalJsonState, count: number): void {
+	state.chars += count;
+	if (state.chars > MAX_TOOL_ARGUMENT_CANONICAL_OUTPUT_CHARS) {
+		failCanonicalJsonUnbounded("chars", { chars: state.chars });
+	}
+}
+
+function canonicalOwnDescriptor(
+	value: object,
+	key: PropertyKey,
+): PropertyDescriptor | undefined {
+	try {
+		return Object.getOwnPropertyDescriptor(value, key);
+	} catch (error) {
+		failCanonicalJsonUnbounded("reflection", { key: String(key) }, error);
+	}
+}
+
+/**
+ * Own enumerable string-keyed data properties, read through descriptors only —
+ * a getter is never invoked and a Proxy `get` trap never runs on untrusted
+ * input. A `JSON.parse` product carries only data properties, so this selects
+ * exactly the same keys `Object.entries` did for every value the live path
+ * accepts today.
+ */
+function canonicalOwnEntries(
+	value: object,
+	state: CanonicalJsonState,
+): Array<[string, unknown]> {
+	let keys: readonly PropertyKey[];
+	try {
+		keys = Reflect.ownKeys(value);
+	} catch (error) {
+		failCanonicalJsonUnbounded("reflection", {}, error);
+	}
+	// Width is charged before the entry array is allocated.
+	chargeCanonicalNodes(state, keys.length);
+	const entries: Array<[string, unknown]> = [];
+	for (const key of keys) {
+		if (typeof key !== "string") continue;
+		const descriptor = canonicalOwnDescriptor(value, key);
+		if (!descriptor?.enumerable) continue;
+		if (!("value" in descriptor)) {
+			failCanonicalJsonUnbounded("accessor", { key });
+		}
+		entries.push([key, descriptor.value]);
+	}
+	return entries;
+}
+
+function canonicalArrayLength(
+	value: object,
+	state: CanonicalJsonState,
+): number {
+	const descriptor = canonicalOwnDescriptor(value, "length");
+	if (
+		!descriptor ||
+		!("value" in descriptor) ||
+		typeof descriptor.value !== "number" ||
+		!Number.isSafeInteger(descriptor.value) ||
+		descriptor.value < 0
+	) {
+		failCanonicalJsonUnbounded("reflection", { field: "length" });
+	}
+	// Width is charged before the element array is allocated.
+	chargeCanonicalNodes(state, descriptor.value);
+	return descriptor.value;
+}
+
+function canonicalJsonValue(
+	value: unknown,
+	state: CanonicalJsonState,
+	depth: number,
+): string {
+	chargeCanonicalNodes(state, 1);
 	if (Array.isArray(value)) {
-		return `[${value.map(canonicalJsonValue).join(",")}]`;
+		if (depth >= MAX_TOOL_ARGUMENT_CANONICAL_DEPTH) {
+			failCanonicalJsonUnbounded("depth", { depth });
+		}
+		// Path-local: a repeated sibling reference (an honest DAG) still
+		// canonicalizes; only a reference back into the current path is a cycle.
+		if (state.visiting.has(value)) {
+			failCanonicalJsonUnbounded("cycle", { depth });
+		}
+		const length = canonicalArrayLength(value, state);
+		chargeCanonicalChars(state, 2 + Math.max(0, length - 1));
+		state.visiting.add(value);
+		try {
+			const parts: string[] = [];
+			for (let index = 0; index < length; index += 1) {
+				const descriptor = canonicalOwnDescriptor(value, String(index));
+				if (!descriptor) {
+					// A hole: `Array.prototype.map` skipped it and `join` rendered it
+					// as the empty string. Preserved byte-for-byte.
+					parts.push("");
+					continue;
+				}
+				if (!("value" in descriptor)) {
+					failCanonicalJsonUnbounded("accessor", { index });
+				}
+				parts.push(canonicalJsonValue(descriptor.value, state, depth + 1));
+			}
+			return `[${parts.join(",")}]`;
+		} finally {
+			state.visiting.delete(value);
+		}
 	}
 	if (value && typeof value === "object") {
-		const entries = Object.entries(value as Record<string, unknown>).sort(
-			([left], [right]) => left.localeCompare(right),
-		);
-		return `{${entries
-			.map(
-				([key, entry]) => `${JSON.stringify(key)}:${canonicalJsonValue(entry)}`,
-			)
-			.join(",")}}`;
+		if (depth >= MAX_TOOL_ARGUMENT_CANONICAL_DEPTH) {
+			failCanonicalJsonUnbounded("depth", { depth });
+		}
+		if (state.visiting.has(value)) {
+			failCanonicalJsonUnbounded("cycle", { depth });
+		}
+		const entries = canonicalOwnEntries(value, state);
+		chargeCanonicalChars(state, 2 + Math.max(0, entries.length - 1));
+		entries.sort(([left], [right]) => left.localeCompare(right));
+		state.visiting.add(value);
+		try {
+			const parts: string[] = [];
+			for (const [key, entry] of entries) {
+				const encodedKey = JSON.stringify(key);
+				chargeCanonicalChars(state, encodedKey.length + 1);
+				parts.push(
+					`${encodedKey}:${canonicalJsonValue(entry, state, depth + 1)}`,
+				);
+			}
+			return `{${parts.join(",")}}`;
+		} finally {
+			state.visiting.delete(value);
+		}
 	}
-	return JSON.stringify(value) ?? "undefined";
+	const encoded = JSON.stringify(value) ?? "undefined";
+	chargeCanonicalChars(state, encoded.length);
+	return encoded;
 }
 
 function parseToolArgumentsString(
@@ -5305,8 +5495,27 @@ function parseToolArgumentsString(
 	}
 
 	const [first, ...rest] = parsedObjects as Record<string, unknown>[];
-	const canonical = canonicalJsonValue(first);
-	if (rest.some((entry) => canonicalJsonValue(entry) !== canonical)) {
+	try {
+		// A fresh budget per fragment: one fragment must never exhaust the budget
+		// of the next, or the comparison would depend on stream position.
+		const canonical = canonicalJsonValue(first, createCanonicalJsonState(), 0);
+		if (
+			rest.some(
+				(entry) =>
+					canonicalJsonValue(entry, createCanonicalJsonState(), 0) !==
+					canonical,
+			)
+		) {
+			return null;
+		}
+	} catch (error) {
+		if (!isCanonicalJsonUnboundedError(error)) throw error;
+		// error-policy:J3 an over-budget fragment is untrusted model input. The
+		// duplicated-stream recovery declines it through the documented `null`
+		// failure signal — Stage 1 then classifies the tool call as malformed and
+		// runs its recovery chain — instead of exhausting the stack inside
+		// `runV5MessageRuntimeStage1`, whose only catch rethrows to the message
+		// boundary and ends the turn.
 		return null;
 	}
 	return first;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #23837.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      (`680e0a9d385d329e340411440902ff9c5e51866a`, fetched 2026-08-21 21:05 IST)
      with zero conflicts.
- [x] `bun install --frozen-lockfile` was run after sync. `bun run verify` was
      NOT run monorepo-wide; the focused equivalents are recorded below and the
      one unrelated blocker is in **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop` @ `680e0a9d385d329e340411440902ff9c5e51866a`; zero conflicts.
- [ ] `bun run verify` monorepo-wide — not run; see **Known gaps / failures**.

# Risks

**Low.** One private function in `packages/core/src/services/message.ts` gains a
budget; its single caller converts the new typed overflow into the `null` value
that caller already documents as its failure signal. No exported surface, no
schema, no storage format changes.

The only behavioural risk is over-rejection — declining a stream the live path
accepts today. That is measured, not asserted: 250 019 values across the entire
`JSON.parse` domain canonicalize **byte-identically** before and after, with
zero over-budget declines (corpus below).

# Background

## What does this PR do?

`packages/core/src/services/message.ts:5247` `canonicalJsonValue` recursed over
arrays and objects with **no depth cap, no node budget, no output budget and no
cycle guard** — over data the file itself classifies as untrusted:

```
// error-policy:J3 planner output is untrusted model input; a single-object
// parse miss continues to the explicit duplicated-stream recovery below.
```

That recovery, `parseToolArgumentsString` (`:5308`/`:5309`), is the only caller.

**Reachability, from an exported Stage-1 entry point:**

```
getStage1RetryReason(raw)                       exported, message.ts:6644
  -> extractHandleResponseToolArguments(raw)    message.ts:10470
  -> parseToolArguments(entry.arguments)        message.ts:5315
  -> parseToolArgumentsString(value)            message.ts:5264
  -> canonicalJsonValue(first)                  message.ts:5308  <-- unbounded
```

`runV5MessageRuntimeStage1` calls `getStage1RetryReason` on the raw completion
at `message.ts:8231`, before any parse. The walk is also reached from
`parseMessageHandlerNativeToolCall` (`:6754`) and `extractMessageHandlerToolCalls`
(`:10252`).

**Nothing upstream bounds it.** `extractJsonObjects`
(`packages/core/src/runtime/json-output.ts:73`) is an iterative brace-depth scan
with no nesting bound, and `JSON.parse` is iterative in both engines this repo
runs on — so it produces exactly the object graph the recursive walker cannot
handle. Measured:

```
$ node probe-depth.mjs
depth=1000   bytes=6001     JSON.parse=OK canonical=OK
depth=5000   bytes=30001    JSON.parse=OK canonical=RangeError: Maximum call stack size exceeded
depth=200000 bytes=1200001  JSON.parse=OK canonical=RangeError: Maximum call stack size exceeded

$ bun probe-depth.mjs
depth=5000   bytes=30001    JSON.parse=OK canonical=OK
depth=20000  bytes=120001   JSON.parse=OK canonical=RangeError: Maximum call stack size exceeded.
```

~30 KiB (node) / ~120 KiB (bun) of model output is enough. That is well inside
an ordinary completion.

**Why the throw matters.** `parseMessageHandlerModelOutput`'s docstring says
"Returning `null` is the failure signal; callers route those to the
structured-failure reply path", and Stage 1 has a full recovery chain behind it
(retry classification, truncation recovery, planner fallback, structured-failure
reply). A `RangeError` bypasses all of it: `runV5MessageRuntimeStage1`'s only
function-level catch (`message.ts:10143`) sets `endStatus = "errored"` and
rethrows to the message boundary, so the turn dies instead of degrading.

**The fix.** Bound the walk the way `packages/core/src/database/connector-json.ts`
already bounds connector JSON in this same package:

- depth cap (32),
- node budget (20 000) **charged before any per-child allocation** — array width
  is read from the `length` descriptor and charged before the element array is
  built; object width is charged before the entry array is built,
- output budget (4 MiB of canonical characters), charged per structural
  character, per encoded key and per encoded leaf,
- **path-local** cycle detection (`WeakSet` add on enter / delete in `finally`),
  so an honest DAG — the same object referenced by two siblings — still
  canonicalizes,
- **descriptor-only reflection**: `Reflect.ownKeys` + `getOwnPropertyDescriptor`,
  data descriptors only, so no getter and no Proxy `get` trap ever runs on
  untrusted input; an accessor fails typed rather than being invoked,
- a typed `ElizaError` (`code: TOOL_ARGUMENT_CANONICAL_UNBOUNDED`,
  `severity: "ephemeral"`, `context: { reason, maxDepth, maxNodes,
  maxOutputChars, ... }`) which `parseToolArgumentsString` catches and converts
  into the documented `null`. Any other error still propagates.

**Overflow fails; it does not truncate.** This is load-bearing, not stylistic.
`canonicalJsonValue` exists only to compare fragments for equality. A lossy
normalizer would collapse two *different* over-budget fragments to the same
string, and the equality check would then accept a stream the model never
actually repeated. Executed proof that the obvious in-repo normalizer has that
property:

```
$ bunx vitest run src/services/scratch-lossy.test.ts --reporter=verbose   # scratch file, since deleted
left : {"a":{"a":…{"a":"[MaxDepth]"}…}}
right: {"a":{"a":…{"a":"[MaxDepth]"}…}}
 ✓ collapses two DIFFERENT over-budget objects to the same value
```

(`sanitizeTrajectoryJsonValue(deep(30, "LEFT"))` and
`sanitizeTrajectoryJsonValue(deep(30, "RIGHT"))` are byte-identical.)

### Why this walker and not one of the existing ones

The reviewer question on every PR in this family is "why not reuse a blessed
walker". Each candidate, and why:

| Candidate | Verdict |
|---|---|
| `packages/core/src/services/trajectory-json.ts` `sanitizeTrajectoryJsonValue` | **Rejected, with executed evidence** (above). It is a *lossy* normalizer for persistence — over-depth becomes `"[MaxDepth]"`, over-budget becomes a `__trajectoryTruncated` marker. Backing an equality comparison with it turns a stack overflow into silent acceptance of mismatched tool arguments, which is strictly worse than the bug being fixed. |
| `packages/agent/src/api/blocked-object-keys.ts` `cloneWithoutBlockedObjectKeys` (the walker adopted in #23809) | **Not importable.** It lives in `packages/agent`, which depends on `packages/core`; core cannot import from agent. It is also welded to prototype-pollution key filtering. |
| `packages/agent/src/api/server-helpers-config.ts` `redactDeep` | Same package-direction problem, and welded to redaction semantics (it rewrites values to `[REDACTED]`), which again destroys the equality property. |
| `packages/core/src/database/connector-json.ts` `cloneConnectorJsonValue` | The right *shape*, and in the right package — this PR mirrors it constant-for-constant and comment-for-comment. Not called directly because it is welded to connector-account semantics: its docstring is "Clone a JSON value for adapter read isolation", its constants are `MAX_CONNECTOR_JSON_*`, and its typed failure reads `connector account JSON is unbounded`, which is wrong and confusing text to surface from the message service. Its `MAX_CONNECTOR_JSON_STRING_BYTES = 64 KiB` per-string cap would also over-reject a long `replyText`. |
| `packages/core/src/utils/deterministic.ts` `stableStringify` | Would be the natural delegate, but it is **itself unbounded** today (`sortStable` recurses with no cap) and is owned by #23736 / #23751. Out of scope here; this PR does not touch it. |

So: no fourth walker was invented — the existing in-package budget is applied to
the existing in-place walker, whose canonical output is preserved exactly.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/services/message.tool-argument-bounds.test.ts`. It drives the
**exported** `getStage1RetryReason` — the real production entry point — with a
duplicated HANDLE_RESPONSE tool-argument stream. No test-only surface was added
to `message.ts`.

## Detailed testing steps

```bash
git fetch origin develop && git checkout 53c9189002547fbcf05959e14e59e42a09974832
bun install --frozen-lockfile
cd packages/core && node ../shared/scripts/generate-keywords.mjs
bunx vitest run src/services/message.tool-argument-bounds.test.ts
```

**Origin reproduction — clean `origin/develop` @ `680e0a9d385d`, before any fix:**

```
 RUN  v4.1.10 …/packages/core

 ❯ src/services/message.tool-argument-bounds.test.ts (1 test | 1 failed) 29ms
     × classifies an over-nested duplicated stream instead of overflowing 29ms

 FAIL  src/services/message.tool-argument-bounds.test.ts
RangeError: Maximum call stack size exceeded
 ❯ canonicalJsonValue src/services/message.ts:5256:5
    5254|   );
    5255|   return `{${entries
    5256|    .map(
       |     ^
    5257|     ([key, entry]) => `${JSON.stringify(key)}:${canonicalJsonValue(ent…
    5258|    )
 ❯ src/services/message.ts:5257:49
 ❯ canonicalJsonValue src/services/message.ts:5256:5
 ❯ src/services/message.ts:5257:49

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

The input is 586 002 characters — a duplicated 50 000-deep object stream, well
inside an ordinary completion.

**After the fix, same command:**

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

**Load-bearing check (copy-aside revert, not `git stash`).** `message.ts` was
copied aside, reverted with `git checkout -- packages/core/src/services/message.ts`
(the new test file is untracked and survived), the suite re-run, then the file
restored from the copy:

```
# fix reverted, test file untouched
     × classifies an over-nested duplicated stream instead of overflowing 32ms
     × does not compare two DIFFERENT over-budget fragments as equal 22ms
     × accepts nesting up to the depth budget and rejects one level past it 2ms
     × charges array width, so an over-wide fragment is declined not walked 8ms
      Tests  4 failed | 3 passed (7)

# fix restored
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

The 3 that pass on both sides are the no-over-rejection assertions — by
construction they must, and they are what proves the budget did not break the
live path.

**Compatibility corpus — no over-rejection, byte-identical output.** The pre-fix
and post-fix implementations, transcribed verbatim from this diff, run over the
whole input domain (`JSON.parse` products): 250 000 seeded pseudo-random JSON
values (depth ≤ 6; leaves covering every JSON type, non-finite-free numbers,
empty string, escapes, astral pairs, a lone surrogate; keys covering
`localeCompare`-vs-code-unit disagreements — `a`/`B`/`_x`/`Z`/`ä`/`á`/`тест`/`日本`,
integer-like keys, the empty key, keys needing escaping), plus realistic
HANDLE_RESPONSE argument objects, boundary depths 1/5/15/30/31, and five raw
JSON texts whose parsed form cannot be built from an object literal
(`{"__proto__":{…}}`, `{"constructor":…}`, `{"toString":1,…}`):

```
$ node canonical-corpus.mjs
corpus values           : 250019
in-budget, compared     : 250019
declined as over-budget : 0
byte-identical          : 250019
MISMATCHES              : 0
exit=0
```

**Focused suites at the pushed head `53c9189002547fbcf05959e14e59e42a09974832`**
(recorded through the proof recorder):

```
$ bunx vitest run src/services/message.tool-argument-bounds.test.ts \
    src/services/message.stage1-retry.test.ts \
    src/runtime/__tests__/json-output.test.ts \
    src/database/connector-json.test.ts
 Test Files  4 passed (4)
      Tests  53 passed (53)
```

```
$ bunx vitest run src/services/
 Test Files  1 failed | 70 passed (71)
      Tests  1119 passed (1119)
```

(the one failure is a collection error present on clean `develop` too — see
**Known gaps / failures**).

```
$ bun run --cwd packages/core typecheck
$ node ../shared/scripts/generate-keywords.mjs && tsc --noEmit -p ./tsconfig.json
exit 0   —   0 lines matching "error TS"
```

```
$ bunx biome check packages/core/src/services/message.ts \
    packages/core/src/services/message.tool-argument-bounds.test.ts
Checked 2 files in 2s. No fixes applied.
exit 0
```

# Evidence Gate

<!-- evidence-head:53c9189002547fbcf05959e14e59e42a09974832 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; the change is one private function in a core service and its single caller.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; the change is one private function in a core service and its single caller.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-visible flow; the observable behaviour is a Stage-1 classification result, asserted in the attached test.`
<!-- evidence-row:backend-logs -->
- [x] Real code path firing end to end — the exported `getStage1RetryReason`
      through `parseToolArgumentsString` into `canonicalJsonValue`, before and
      after the fix at the pushed head:

<details>
<summary>vitest transcript — clean <code>origin/develop</code> @ <code>680e0a9d385d</code>, then the same command at <code>53c9189002547fbcf05959e14e59e42a09974832</code></summary>

```
 RUN  v4.1.10 /Volumes/thescoho_1TB/.../packages/core

 ❯ src/services/message.tool-argument-bounds.test.ts (1 test | 1 failed) 29ms
     × classifies an over-nested duplicated stream instead of overflowing 29ms

 FAIL  src/services/message.tool-argument-bounds.test.ts > Stage-1 tool-argument canonicalization bounds > classifies an over-nested duplicated stream instead of overflowing
RangeError: Maximum call stack size exceeded
 ❯ canonicalJsonValue src/services/message.ts:5256:5
    5254|   );
    5255|   return `{${entries
    5256|    .map(
       |     ^
    5257|     ([key, entry]) => `${JSON.stringify(key)}:${canonicalJsonValue(ent…
    5258|    )
 ❯ src/services/message.ts:5257:49
 ❯ canonicalJsonValue src/services/message.ts:5256:5
 ❯ src/services/message.ts:5257:49
 ❯ canonicalJsonValue src/services/message.ts:5256:5

 Test Files  1 failed (1)
      Tests  1 failed (1)
   Duration  2.13s

--- with the fix applied, same command ---

 RUN  v4.1.10 /Volumes/thescoho_1TB/.../packages/core

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Duration  28.83s

--- load-bearing: fix reverted by copy-aside, test file untouched ---

     × classifies an over-nested duplicated stream instead of overflowing 32ms
     × does not compare two DIFFERENT over-budget fragments as equal 22ms
     × accepts nesting up to the depth budget and rejects one level past it 2ms
     × charges array width, so an over-wide fragment is declined not walked 8ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
      Tests  4 failed | 3 passed (7)

--- fix restored from the copy-aside ---

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response is involved; the input is a model completion inside the core message service.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - a real live-model run cannot be steered to emit a 50 000-deep duplicated tool-argument stream on demand. The deterministic reproduction above drives the identical exported code path with the exact bytes a model would have to produce, which is stronger evidence for this defect than a sampled live run.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the compatibility corpus (no over-rejection), the
      engine-depth probe (nothing upstream bounds the walk), and the executed
      demonstration that the in-repo lossy normalizer cannot back this
      comparison:

<details>
<summary>corpus + probe + lossy-normalizer transcripts</summary>

```
$ node canonical-corpus.mjs      # pre-fix vs post-fix canonicalizer, JSON.parse domain
corpus values           : 250019
in-budget, compared     : 250019
declined as over-budget : 0
byte-identical          : 250019
MISMATCHES              : 0
exit=0

$ node probe-depth.mjs           # V8
depth=1000   bytes=6001     JSON.parse=OK canonical=OK
depth=5000   bytes=30001    JSON.parse=OK canonical=RangeError: Maximum call stack size exceeded
depth=200000 bytes=1200001  JSON.parse=OK canonical=RangeError: Maximum call stack size exceeded

$ bun probe-depth.mjs            # JavaScriptCore
depth=5000   bytes=30001    JSON.parse=OK canonical=OK
depth=20000  bytes=120001   JSON.parse=OK canonical=RangeError: Maximum call stack size exceeded.

$ bunx vitest run src/services/scratch-lossy.test.ts --reporter=verbose   # scratch, since deleted
left : {"a":{"a":{"a":…{"a":"[MaxDepth]"}…}}}
right: {"a":{"a":{"a":…{"a":"[MaxDepth]"}…}}}
 ✓ collapses two DIFFERENT over-budget objects to the same value
      Tests  1 passed (1)
```

</details>
<!-- evidence-row:ocr-review -->
- [x] `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - see the llm-trajectory row above. This is a deterministic parser defect
reached from an exported function; the scenario runner cannot make a live model
emit the required 50 000-deep duplicated object stream, and a sampled live run
would not exercise the branch at all.`

## Backend + frontend logs

Backend: the vitest output under **Detailed testing steps** (pre-fix stack
frames naming `canonicalJsonValue src/services/message.ts:5256:5`; post-fix
7/7 pass). Frontend: `N/A - no frontend surface.`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface.`

### After

`N/A - no UI surface.`

### Walkthrough video

`N/A - no UI surface.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface is touched.`

## Known gaps / failures

1. **`bun run verify` was not run monorepo-wide.** Focused equivalents were run
   instead and are pasted above: `packages/core` typecheck (exit 0, zero `error
   TS` lines), biome on both touched files (exit 0), the full
   `packages/core/src/services/` suite (1119 passed), and the targeted suites
   through the proof recorder. Not a blocker: the diff is two files in one
   package with no exported-surface change.

2. **`src/services/message.side-effect-claim.test.ts` fails to collect.**
   `Error: Failed to resolve entry for package "@elizaos/cloud-routing"` — an
   unbuilt workspace package, not a test failure (`Tests  no tests`). Verified
   **pre-existing** by reverting `message.ts` to `develop` and re-running that
   file alone: identical error. Not a blocker; unrelated to this diff.

3. **`src/__tests__/message-runtime-stage1.test.ts` has one pre-existing
   failure** (`does not re-add generic inferred actions after an evaluator
   clears the candidate route` — `expected [...] to not include 'SHELL'`). Run
   on clean `develop` @ `680e0a9d385d` it is `1 failed | 161 passed`; run on
   this branch it is `1 failed | 161 passed`. Unchanged by this PR, so not
   fixed here.

4. **No hosted CI results are claimed.** This PR comes from a fork
   (`ss251/eliza`) without upstream write access, so hosted checks do not run
   for it and the reviewer-requested-review API is unavailable. Every result
   above is from a local run whose command line is shown.

5. **One deliberate behaviour change beyond the budget.** A property whose own
   descriptor is an *accessor* now fails typed (declining the recovery) instead
   of having its getter invoked, and a Proxy's `get` trap is never reached. A
   `JSON.parse` product — the only thing that reaches this function — has
   neither, which is why the 250 019-value corpus is byte-identical; the
   hardening is for the untrusted boundary, stated here so it is not read as an
   oversight.

6. **The `localeCompare` key sort at the old `:5253` was left alone.** It is
   locale-dependent, but both sides of this comparison are canonicalized in the
   same process with the same comparator and the output is never persisted or
   hashed, so it is not the `#23736` defect and changing it here would be
   unrelated churn.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-mine-canonjson]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JGRB8XQW96HWEJQX2DMDXS","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T15:59:10.109Z","completed_at":"2026-08-21T16:05:10.703Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T15:59:11.368Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"ad773849b7b1a1a984a8021f1e197b124012b878f6ddd3030c69a861f5b9821e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b37c00ec-2936-427a-8c55-be9e5290d506","object_id":"sha256:ad773849b7b1a1a984a8021f1e197b124012b878f6ddd3030c69a861f5b9821e","sha256":"ad773849b7b1a1a984a8021f1e197b124012b878f6ddd3030c69a861f5b9821e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"1WV2wu9WIKfSsGS8QF0dFRYZP62tj6Q448d7UGdyVIFp-ShM23IxfE1G3olWHF8tFJcau9gCF7xewUJBTEQ0AQ"}} -->
