### PR TITLE
fix(agent): bound the role-gate metadata dedup key walk

### DIFF
--- a/packages/agent/src/runtime/plugin-role-gating.metadata-key-bound.test.ts
+++ b/packages/agent/src/runtime/plugin-role-gating.metadata-key-bound.test.ts
@@ -1,0 +1,256 @@
+/**
+ * The role-check dedup key is derived from `message.metadata`, the
+ * connector-stamped identity blob `resolveEntityRole` consumes as live
+ * connector identity (`roles.ts` `getConnectorMetadataFromMemory`). Nothing
+ * bounds its nesting — `MemoryMetadata`'s `CustomMetadata` arm is
+ * `[key: string]: MetadataValue`, and `agent-event-bridge.ts` reads
+ * `metadata.discord` / `metadata.origin` / `metadata.session` / `metadata.sender`
+ * as whatever platform payload the connector stamped.
+ *
+ * Key derivation runs BEFORE the role check, inside every gated provider's
+ * wrapped `get()`. So an over-deep or cyclic metadata blob does not fail one
+ * provider — it throws out of every role-gated provider for that turn, and
+ * `AgentRuntime.composeState` drops each of them, silently emptying the
+ * owner's own sensitive context.
+ *
+ * These tests pin the bound and, just as importantly, pin that the key does
+ * not move for metadata the live path accepts today.
+ */
+import type {
+  IAgentRuntime,
+  Memory,
+  Plugin,
+  Provider,
+  State,
+} from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const rolesMock = vi.hoisted(() => ({
+  checkSenderRole: vi.fn(),
+}));
+
+vi.mock("./roles.ts", () => rolesMock);
+
+import { applyPluginRoleGating } from "./plugin-role-gating.ts";
+
+const runtime = {
+  agentId: "11111111-1111-1111-1111-111111111111",
+} as IAgentRuntime;
+
+function message(metadata: unknown): Memory {
+  return {
+    id: "22222222-2222-2222-2222-222222222222",
+    entityId: "33333333-3333-3333-3333-333333333333",
+    roomId: "44444444-4444-4444-4444-444444444444",
+    content: { text: "hi", source: "discord" },
+    metadata,
+  } as Memory;
+}
+
+function gatedProvider(name: string, minRole: string): Provider {
+  return {
+    name,
+    roleGate: { minRole },
+    get: vi.fn(async () => ({ text: `${name}: visible` })),
+  } as unknown as Provider;
+}
+
+function gate(providers: Provider[]): Provider[] {
+  applyPluginRoleGating([{ name: "test-plugin", providers } as Plugin]);
+  return providers;
+}
+
+/** `{ a: { a: { ... } } }`, `levels` containers deep. */
+function nest(levels: number): Record<string, unknown> {
+  let node: Record<string, unknown> = { leaf: "x" };
+  for (let index = 0; index < levels; index += 1) {
+    node = { a: node };
+  }
+  return node;
+}
+
+/**
+ * Deep enough to exhaust the stack in an unbounded recursive walk, and far
+ * below any transport limit: `{"a":` is six bytes per level, so this whole
+ * blob is well under 100 KB.
+ */
+const OVERFLOW_DEPTH = 12_000;
+
+describe("role-gate dedup key — bounded metadata walk", () => {
+  beforeEach(() => {
+    rolesMock.checkSenderRole.mockReset();
+    rolesMock.checkSenderRole.mockResolvedValue({
+      role: "ADMIN",
+      isOwner: false,
+      isAdmin: true,
+    });
+  });
+
+  it("still gates when connector metadata nests past the stack limit", async () => {
+    const [provider] = gate([gatedProvider("SECRETS_STATUS", "ADMIN")]);
+
+    const result = await provider.get?.(
+      runtime,
+      message({ discord: { userId: "u1" }, payload: nest(OVERFLOW_DEPTH) }),
+      {} as State,
+    );
+
+    // The gate must still decide, not throw out of composeState.
+    expect(result).toEqual({ text: "SECRETS_STATUS: visible" });
+    expect(rolesMock.checkSenderRole).toHaveBeenCalledTimes(1);
+  });
+
+  it("withholds from a caller below minRole even with over-deep metadata", async () => {
+    rolesMock.checkSenderRole.mockResolvedValue({
+      role: "USER",
+      isOwner: false,
+      isAdmin: false,
+    });
+    const [provider] = gate([gatedProvider("SECRETS_STATUS", "ADMIN")]);
+
+    const result = await provider.get?.(
+      runtime,
+      message({ payload: nest(OVERFLOW_DEPTH) }),
+      {} as State,
+    );
+
+    // Over-budget metadata must not become a way to skip the gate.
+    expect(result).toEqual({ text: "" });
+  });
+
+  it("still gates when connector metadata contains a cycle", async () => {
+    const cyclic: Record<string, unknown> = { discord: { userId: "u1" } };
+    cyclic.self = cyclic;
+    const [provider] = gate([gatedProvider("SECRETS_STATUS", "ADMIN")]);
+
+    const result = await provider.get?.(runtime, message(cyclic), {} as State);
+
+    expect(result).toEqual({ text: "SECRETS_STATUS: visible" });
+  });
+
+  it("still gates when metadata carries an enumerable accessor", async () => {
+    const hostile = {
+      discord: { userId: "u1" },
+    } as Record<string, unknown>;
+    Object.defineProperty(hostile, "trap", {
+      enumerable: true,
+      get() {
+        throw new Error("accessor must not run on the gate path");
+      },
+    });
+    const [provider] = gate([gatedProvider("SECRETS_STATUS", "ADMIN")]);
+
+    const result = await provider.get?.(runtime, message(hostile), {} as State);
+
+    expect(result).toEqual({ text: "SECRETS_STATUS: visible" });
+  });
+});
+
+/**
+ * Compatibility. The dedup key's whole observable contract is "two messages
+ * coalesce iff their keys are equal", so these pin that the key relation over
+ * ordinary connector metadata is exactly what it was before the bound: equal
+ * structures still share one role check, different structures still get their
+ * own. A key that moved would silently split or merge live role decisions.
+ */
+const EQUIVALENT_METADATA_PAIRS: Array<[string, unknown, unknown]> = [
+  [
+    "key order",
+    { discord: { userId: "u1", name: "a" }, type: "message" },
+    { type: "message", discord: { name: "a", userId: "u1" } },
+  ],
+  [
+    "nested arrays and nulls",
+    { origin: { ids: [1, null, "x"], nested: { deep: [{ k: false }] } } },
+    { origin: { nested: { deep: [{ k: false }] }, ids: [1, null, "x"] } },
+  ],
+  [
+    "unicode and empty containers",
+    { telegram: { name: "日本 🎌", tags: [], extra: {} } },
+    { telegram: { extra: {}, tags: [], name: "日本 🎌" } },
+  ],
+  [
+    "non-finite and signed-zero numbers",
+    { m: { a: Number.NaN, b: Number.POSITIVE_INFINITY, c: -0 } },
+    { m: { c: -0, b: Number.POSITIVE_INFINITY, a: Number.NaN } },
+  ],
+  [
+    "sparse array holes",
+    // biome-ignore lint/suspicious/noSparseArray: the hole is the fixture.
+    { m: [, 1, , 2] },
+    // biome-ignore lint/suspicious/noSparseArray: the hole is the fixture.
+    { m: [, 1, , 2] },
+  ],
+  [
+    "repeated (non-cyclic) reference — an honest DAG",
+    (() => {
+      const shared = { userId: "u1" };
+      return { discord: shared, mirror: shared };
+    })(),
+    (() => {
+      const shared = { userId: "u1" };
+      return { mirror: shared, discord: shared };
+    })(),
+  ],
+  ["absent metadata", undefined, undefined],
+  ["null metadata", null, null],
+  ["depth at the ceiling", { m: nest(24) }, { m: nest(24) }],
+];
+
+const DISTINCT_METADATA_PAIRS: Array<[string, unknown, unknown]> = [
+  [
+    "different connector user id",
+    { discord: { userId: "u1" } },
+    { discord: { userId: "u2" } },
+  ],
+  ["different value type", { m: "1" }, { m: 1 }],
+  ["different array order", { m: [1, 2] }, { m: [2, 1] }],
+  ["added key", { m: { a: 1 } }, { m: { a: 1, b: 2 } }],
+  ["absent vs empty", undefined, {}],
+];
+
+describe("role-gate dedup key — no over-rejection, no key drift", () => {
+  beforeEach(() => {
+    rolesMock.checkSenderRole.mockReset();
+  });
+
+  /** Two concurrent gated providers share one role check iff the keys match. */
+  async function roleChecksFor(first: unknown, second: unknown) {
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    rolesMock.checkSenderRole.mockImplementation(async () => {
+      await held;
+      return { role: "ADMIN", isOwner: false, isAdmin: true };
+    });
+    const providers = gate([
+      gatedProvider("SECRETS_STATUS", "ADMIN"),
+      gatedProvider("MISSING_SECRETS", "ADMIN"),
+    ]);
+    const pending = Promise.all([
+      providers[0].get?.(runtime, message(first), {} as State),
+      providers[1].get?.(runtime, message(second), {} as State),
+    ]);
+    await Promise.resolve();
+    release();
+    const results = await pending;
+    expect(results).toEqual([
+      { text: "SECRETS_STATUS: visible" },
+      { text: "MISSING_SECRETS: visible" },
+    ]);
+    return rolesMock.checkSenderRole.mock.calls.length;
+  }
+
+  for (const [label, first, second] of EQUIVALENT_METADATA_PAIRS) {
+    it(`coalesces equivalent metadata: ${label}`, async () => {
+      expect(await roleChecksFor(first, second)).toBe(1);
+    });
+  }
+
+  for (const [label, first, second] of DISTINCT_METADATA_PAIRS) {
+    it(`separates distinct metadata: ${label}`, async () => {
+      expect(await roleChecksFor(first, second)).toBe(2);
+    });
+  }
+});

--- a/packages/agent/src/runtime/plugin-role-gating.ts
+++ b/packages/agent/src/runtime/plugin-role-gating.ts
@@ -25,6 +25,8 @@ import type {
 } from "@elizaos/core";
 import { logger, satisfiesRoleGate } from "@elizaos/core";
 
+import { tryCanonicalizeJson } from "./tool-call-cache/key.ts";
+
 // ---------------------------------------------------------------------------
 // Sensitivity classification
 // ---------------------------------------------------------------------------
@@ -92,28 +94,44 @@ function loadCheckSenderRole() {
   return roleCheckLoader;
 }
 
-function stableStringify(value: unknown): string {
-  if (value === undefined) {
-    return "undefined";
-  }
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value) ?? String(value);
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
-  }
-  const record = value as Record<string, unknown>;
-  return `{${Object.keys(record)
-    .sort()
-    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
-    .join(",")}}`;
-}
-
-function liveRoleMetadataKey(message: Memory): string {
+/**
+ * Canonical dedup key for the live connector metadata this message's role
+ * decision depends on, or `null` when the metadata cannot be canonicalized
+ * within budget.
+ *
+ * `message.metadata` is the connector-stamped identity blob (`roles.ts`
+ * `getConnectorMetadataFromMemory`) and nothing bounds its nesting:
+ * `MemoryMetadata`'s `CustomMetadata` arm is `[key: string]: MetadataValue`,
+ * and `agent-event-bridge.ts` reads whatever platform payload a connector
+ * stamped under `metadata.discord` / `.origin` / `.session` / `.sender`. The
+ * previous key was built by a local unbounded recursive walk, so an over-deep
+ * or cyclic blob RangeError'd here — before the role check, inside every gated
+ * provider's wrapped `get()`, so composeState dropped ALL of them and the
+ * owner's own sensitive context silently went empty. An enumerable getter in
+ * metadata also ran on this path, which a cache key cannot tolerate anyway
+ * (it makes the key non-deterministic).
+ *
+ * `tryCanonicalizeJson` is the repo's bounded canonical-TEXT walk, already
+ * merged and already used for exactly this job on the other untrusted cache
+ * boundary in this package (`tool-call-cache/key.ts`, #23428): depth, node,
+ * width, per-string and aggregate-byte budgets charged before allocation;
+ * path-local cycle detection so an honest DAG still canonicalizes;
+ * descriptor-only reflection so no getter or Proxy trap runs. Its text is
+ * byte-identical to the unbounded canonicalizer it replaced for every value
+ * within budget, so live keys do not move.
+ *
+ * A rejection is NOT a role decision. The caller falls back to the uncached
+ * path it already has for messages with no entity/room, so an out-of-budget
+ * blob costs one extra role lookup and can never change, skip, or reuse a
+ * gate result.
+ */
+function liveRoleMetadataKey(message: Memory): string | null {
   const source =
     typeof message.content.source === "string" ? message.content.source : "";
   const metadata = (message as Memory & { metadata?: unknown }).metadata;
-  return stableStringify({ metadata, source });
+  const canonical = tryCanonicalizeJson({ metadata, source });
+  if (!canonical.ok || canonical.canonical === undefined) return null;
+  return canonical.canonical;
 }
 
 async function fetchSenderRole(
@@ -131,13 +149,15 @@ async function getCachedSenderRole(
 ): Promise<RoleCheckValue> {
   const entityId = message.entityId;
   const roomId = message.roomId;
-  if (!entityId || !roomId) {
+  const metadataKey = liveRoleMetadataKey(message);
+  // No dedup key means no dedup — never a skipped or reused gate decision.
+  if (!entityId || !roomId || metadataKey === null) {
     const checkSenderRole = await loadCheckSenderRole();
     const fresh = await checkSenderRole(runtime, message);
     return fresh ? { role: fresh.role } : null;
   }
 
-  const key = `${runtime.agentId}|${entityId}|${roomId}|${liveRoleMetadataKey(message)}`;
+  const key = `${runtime.agentId}|${entityId}|${roomId}|${metadataKey}`;
   let roleCheckInflight = roleCheckInflightByRuntime.get(runtime);
   if (!roleCheckInflight) {
     roleCheckInflight = new Map();


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #23843 (owning issue, filed for this work, carrying the origin
reproduction verbatim and the same scope limits stated below).

Context: #23428 built the bounded canonical cache-key walk this PR adopts, and
#23809 landed the same "reuse the bounded walker your neighbour already
exports" repair on the connector-account routes in this package. This is the
third call site in `packages/agent` with an unbounded walk over untrusted
input — and, unlike the other two, it sits on the provider **authorization**
path. It is a reuse, not a new walker: the local one is deleted.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop`
      (`a3e45ac538fbd79e4682e3b505f5eb77e3b65d34`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` @ `a3e45ac538fbd79e4682e3b505f5eb77e3b65d34`; zero conflicts.
      Neither `plugin-role-gating.ts` nor `runtime/tool-call-cache/` changed
      between the reproduction base `680e0a9d385d` and this base
      (`git diff 680e0a9d385d a3e45ac538fbd -- <both paths>` is empty), so the
      reproduction below still describes this base exactly.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low, and the one axis that matters — **key drift** — is proved by execution
rather than argued.

The dedup key's whole contract is "two messages coalesce iff their keys are
equal". If the key text moved, every cached role decision would silently split
or merge. So the compatibility check is not a sample: the **origin**
`liveRoleMetadataKey` was extracted verbatim from `origin/develop` with
`git show` (never hand-copied) and compared **byte for byte** against the
replacement over a 34-shape corpus and 20,000 randomized JSON metadata graphs.
**0 keys moved** in either. Section 3 of the domain receipt has the transcript.

Byte-identity is not a coincidence — `tool-call-cache/key.ts` was written to be
byte-identical to the same unbounded canonicalizer shape, and both walks emit
sorted own-enumerable-string keys, `undefined` as the literal token inside an
object, holes as empty inside an array, and non-finite numbers as `null`. It
holds for **every JSON-shaped value**, which is the only shape a connector
payload can have after `JSON.parse`: JSON has no `undefined`, no functions, no
symbols, no bigint, no getters, no proxies and no cycles.

Where behaviour *does* change, it changes to "do not dedup", never to a
different role:

| Metadata shape | Before | After |
| --- | --- | --- |
| over-deep / cyclic / >100k nodes | `RangeError` out of every gated provider | no dedup key → one uncached role lookup, gate decides normally |
| enumerable getter | the getter **ran** during key derivation | rejected before `[[Get]]` → no dedup, gate decides normally |
| `Proxy` | traps ran | rejected via `util.types.isProxy` → no dedup |
| `bigint` leaf | raw `TypeError` from `JSON.stringify` | rejected → no dedup |
| function / symbol leaf | key included `String(fn)` | rejected or emitted as `undefined` → at worst two such messages share a key |

A rejection is **not** a role decision. `getCachedSenderRole` falls through to
the uncached path it already had for messages with no entity/room, so the worst
case is one extra `checkSenderRole` — never a skipped, reused, or altered gate
result. That is pinned by the second bound test, which asserts a below-`minRole`
caller is still withheld from when its metadata is over-deep.

# Background

## What does this PR do?

`packages/agent/src/runtime/plugin-role-gating.ts` derived the in-flight
role-check dedup key from `message.metadata` with a **local unbounded
recursive** `stableStringify`: no depth cap, no node budget, no cycle guard, no
enclosing `try`, and property values read through `[[Get]]`, so an enumerable
accessor in metadata executed on the gate path.

The key is derived **before** the role check, inside every gated provider's
wrapped `get()`. So an over-deep or cyclic blob does not fail one provider — it
throws out of **every** role-gated provider for the turn.
`AgentRuntime.composeState` catches it (`packages/core/src/runtime.ts:5169`)
and drops the provider, so the legitimate OWNER/ADMIN silently receives an
empty `SECRETS_STATUS` / `ACTIVE_WORKSPACE_CONTEXT` / wallet context with no
signal. Reproduced against unmodified `develop` below; the stack is the whole
finding in four frames.

`message.metadata` is the connector-stamped identity blob the role resolver
itself consumes (`roles.ts:284` `getConnectorMetadataFromMemory`, reached from
`checkSenderRole:1015`) — the dedup key hashes exactly the security-relevant
input. Nothing bounds its nesting: `MemoryMetadata`'s `CustomMetadata` arm is
`[key: string]: MetadataValue` (`types/memory.ts:443`), and
`services/agent-event-bridge.ts:215-300` reads whatever platform payload a
connector stamped under `metadata.discord` / `.origin` / `.session` /
`.sender`. Depth is cheap: `{"a":{"a":…` is ~6 bytes per level and V8 exhausts
the stack at ~10k, so the reproduction payload is under 100 KB.

**The fix reuses this package's already-merged bounded canonicalizer rather
than adding a fifth copy of the walk.**
`packages/agent/src/runtime/tool-call-cache/key.ts` exports
`tryCanonicalizeJson`, built for exactly this job on the other untrusted
cache-key boundary in `packages/agent/src/runtime/` (#23428): depth, node,
width, per-string and aggregate-byte budgets **charged before allocation**;
path-local cycle detection (`seen.delete` on container exit) so an honest DAG
still canonicalizes; descriptor-only reflection so no getter or `Proxy` trap
ever runs; a typed rejection instead of a partial result; and no silent
truncation. Its own module doc states its text is byte-identical to the
unbounded canonicalizer it replaced for every value within budget — section 3
proves that holds for this call site too.

The 16-line local `stableStringify` is deleted. Net: **−16 / +1** lines of
walk logic in the production file.

### Alternatives considered, and why not

- **`packages/core/src/services/trajectory-json.ts`** — rejected outright. It
  is a lossy *sanitizer*: it truncates and substitutes markers. Under a cache
  key that would silently merge distinct metadata into one role decision.
- **`cloneWithoutBlockedObjectKeys`** (`packages/agent/src/api/blocked-object-keys.ts`,
  the walker #23809 adopted) — bounded and correct, but it returns a **copy in
  own-key order**. A dedup key needs canonical **sorted text**, and
  `JSON.stringify` of that copy is not the same text (it drops the `undefined`
  token inside objects). Using it would mean a bounded clone plus a second full
  walk to stringify — two walks of untrusted input, and the key would move.
  `tool-call-cache/key.ts` documents this exact trade-off against its own
  sibling `boundedWalk` for the same reason.
- **`packages/shared/src/canonical-json.ts`** — does not exist on `develop`
  (it is proposed in open PR #23817, which this branch cannot depend on). If
  that lands, this call site is a one-import follow-up.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

## Scope, stated honestly

This is a **runtime robustness / availability** defect on an authorization
path. I am **not** claiming an authorization bypass, and I checked for one:

- The throw is **fail-closed**. `provider.get` rejects before `originalGet` is
  called and `composeState` drops the provider, so no gated content leaks. The
  damage is that the gate silently degrades for the *legitimate* caller.
- I looked specifically for a **key collision → wrong role decision** and did
  not find a reachable one, so this PR does not claim it. The role decision
  depends only on `metadata[source]`'s flat string fields
  (`hasConnectorStableIdentity`, `roles.ts:260`), which the walk represents
  losslessly for JSON-shaped metadata; the map is in-flight only
  (`roleCheckInflight.delete(key)` in `.finally`) and keyed by
  `agentId|entityId|roomId`, so a collision would additionally need two
  concurrent same-sender same-room messages. Prototype-chain and getter-backed
  identity fields *can* collapse under the old walk, but that is not a shape
  `JSON.parse` can produce.
- **Reachability is the connector-plugin contract, not an in-repo HTTP route.**
  The in-repo chat path (`readChatRequestPayload` → `buildUserMessages`) puts
  client metadata on `content.metadata`, which `roles.ts:808` explicitly
  refuses to trust and which the dedup key does not read. `message.metadata` is
  written by connector plugins outside this repository (`core/src/connectors.ts:17`
  documents the `metadata[source]` contract; `agent-event-bridge.ts` consumes
  it). So I could not stand up an unauthenticated in-repo HTTP reproduction,
  and I do not claim one. The unbounded walk on the gate path is reproduced
  through the real module either way.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/runtime/plugin-role-gating.metadata-key-bound.test.ts`. It
drives the **real** `applyPluginRoleGating` and the **real** wrapped
`provider.get`; only `./roles.ts` is mocked, exactly as the existing
`plugin-role-gating.test.ts` does, so the role decision is deterministic and
the metadata walk is the only thing under test. 18 tests:

**4 bound tests** (these are the load-bearing ones — all four fail on `develop`)

1. over-deep metadata, caller at `minRole` → provider still returns its content
   and `checkSenderRole` is called exactly once;
2. over-deep metadata, caller **below** `minRole` → still withheld (`{text:""}`)
   — an unrepresentable blob must not become a way past the gate;
3. cyclic metadata → gate still decides;
4. metadata carrying an **enumerable accessor** whose getter throws → gate still
   decides, i.e. the getter never runs.

**14 compatibility tests** (all pass on `develop` too — that is the point)

Two gated providers run concurrently on two *separate* metadata objects and the
test asserts the number of `checkSenderRole` calls, so it observes the key
relation directly: 1 call ⇒ same key, 2 calls ⇒ different keys.

- 9 pairs that must still coalesce: key-order permutation, nested arrays with
  `null`, unicode, non-finite and signed-zero numbers, sparse array holes, an
  honest DAG (repeated non-cyclic reference), absent metadata, `null` metadata,
  depth at the ceiling.
- 5 pairs that must still separate: different connector user id, `"1"` vs `1`,
  array order, an added key, absent vs `{}`.

## Detailed testing steps

```
git checkout fix/bound-role-gate-metadata-key
bun install --frozen-lockfile
(cd packages/core && node ../shared/scripts/generate-keywords.mjs)
bunx vitest run --root packages/agent \
  src/runtime/plugin-role-gating.metadata-key-bound.test.ts \
  src/runtime/plugin-role-gating.test.ts \
  src/runtime/plugin-role-gating-chokepoint.test.ts \
  src/runtime/plugin-role-gating-registration.test.ts \
  src/runtime/plugin-role-gating.guest-history.test.ts \
  src/runtime/tool-call-cache
bun run --cwd packages/agent typecheck
bunx @biomejs/biome check \
  packages/agent/src/runtime/plugin-role-gating.ts \
  packages/agent/src/runtime/plugin-role-gating.metadata-key-bound.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:2f3115a232edccef02253793a8d994b1d00b52cd -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - runtime gating module and its tests; no rendered UI surface in the diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - runtime gating module and its tests; no rendered UI surface in the diff.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.

<!-- evidence-row:backend-logs -->
- [x] The gate's own throw, captured from the real wrapped `provider.get` on unmodified `origin/develop` @ `680e0a9d385d329e340411440902ff9c5e51866a`:

```text
 FAIL  ... > still gates when connector metadata nests past the stack limit
RangeError: Maximum call stack size exceeded
 ❯ src/runtime/plugin-role-gating.ts:108:27
    106|   return `{${Object.keys(record)
    107|     .sort()
    108|     .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key…
       |                           ^
    109|     .join(",")}}`;
 ❯ stableStringify src/runtime/plugin-role-gating.ts:108:6
 ❯ src/runtime/plugin-role-gating.ts:108:45
 ❯ stableStringify src/runtime/plugin-role-gating.ts:108:6

 FAIL  ... > still gates when metadata carries an enumerable accessor
Error: accessor must not run on the gate path
 ❯ Object.get [as trap] src/runtime/plugin-role-gating.metadata-key-bound.test.ts:138:15
 ❯ src/runtime/plugin-role-gating.ts:108:61
 ❯ stableStringify src/runtime/plugin-role-gating.ts:108:6
 ❯ liveRoleMetadataKey src/runtime/plugin-role-gating.ts:116:10
 ❯ getCachedSenderRole src/runtime/plugin-role-gating.ts:140:59
 ❯ Object.provider.get src/runtime/plugin-role-gating.ts:182:25
```

The second stack is the finding in four frames: `provider.get` →
`getCachedSenderRole` → `liveRoleMetadataKey` → `stableStringify`. Its first
frame is the test's own getter, which the walk executed — the gate never
reaches `checkSenderRole`.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model *behaviour* changed; this is a cache-key derivation bound. (A device-signed private-trace receipt for this run is finalized in the footer below.)

<!-- evidence-row:domain-artifacts -->
- [x] Origin reproduction, byte-for-byte key-compatibility proof against the origin implementation, load-bearing revert check, focused suite, typecheck control diff, and lint — all at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
head:            2f3115a232edccef02253793a8d994b1d00b52cd
rebase base:     a3e45ac538fbd79e4682e3b505f5eb77e3b65d34 (origin/develop)
reproduction base: 680e0a9d385d329e340411440902ff9c5e51866a (origin/develop when the
  probes ran). `git diff 680e0a9d385d a3e45ac538fbd --
  packages/agent/src/runtime/plugin-role-gating.ts
  packages/agent/src/runtime/tool-call-cache/` is EMPTY, so the reproduction
  describes the rebase base exactly.

=== 1. ORIGIN REPRODUCTION (production file at develop; real module, real wrapped get) ===

$ bunx vitest run src/runtime/plugin-role-gating.metadata-key-bound.test.ts

 ❯ src/runtime/plugin-role-gating.metadata-key-bound.test.ts (18 tests | 4 failed)
     × still gates when connector metadata nests past the stack limit 4ms
     × withholds from a caller below minRole even with over-deep metadata 1ms
     × still gates when connector metadata contains a cycle 2ms
     × still gates when metadata carries an enumerable accessor 1ms

 Test Files  1 failed (1)
      Tests  4 failed | 14 passed (18)
exit 1

(Stacks in the backend-logs row above. The 14 that PASS here are the
compatibility tests — they are the before-side of the no-key-drift claim.)

=== 2. AFTER THE FIX, SAME FILE ===

$ bunx vitest run src/runtime/plugin-role-gating.metadata-key-bound.test.ts
 Test Files  1 passed (1)
      Tests  18 passed (18)
exit 0

=== 3. KEY COMPATIBILITY — BYTE FOR BYTE, AGAINST THE REAL ORIGIN CODE ===

The origin `liveRoleMetadataKey` was NOT hand-copied. It was extracted verbatim:

  $ git show origin/develop:packages/agent/src/runtime/plugin-role-gating.ts \
      > src/runtime/__origin-role-gating-probe.ts
  $ printf '\nexport { liveRoleMetadataKey as originLiveRoleMetadataKey };\n' \
      >> src/runtime/__origin-role-gating-probe.ts

and compared against the bounded replacement over (a) a hand-built corpus of
connector metadata shapes and (b) randomized JSON-shaped metadata:

$ bun run src/runtime/__key-compat-probe.ts
corpus entries:            34
byte-identical keys:       34
keys that moved:           0
randomized JSON metadata:  20000
byte-identical keys:       20000
keys that moved:           0
exit=0

Corpus shapes: absent/null/empty metadata; discord, telegram and legacy-flat
`fromId`/`entityName` identity blobs; the agent-event-bridge
origin/session/delivery/sender shape; the pendant stamped metadata;
`createMessageMemory`'s own default; nested arrays with `null`; unicode +
astral + escapes; empty containers; NaN / ±Infinity / -0; 1e21, 5e-324,
MAX_SAFE_INTEGER; sparse array holes; nested arrays-of-arrays; a repeated
(non-cyclic) reference; `Date`; `Map`/`Set`; a class instance; a non-enumerable
own property; a symbol-keyed property; two key-order permutations; keys needing
JSON escapes; depth 24; a 5,000-key object; a 200,000-char string; array /
string / number / boolean metadata roots; non-string and absent `content.source`.

Both probe files were deleted after the run; `git status --porcelain` on this
head shows only the two intended paths.

=== 4. LOAD-BEARING REVERT CHECK (copy-aside, never `git stash`) ===

Production file reverted to develop with the test file kept:

$ git show origin/develop:packages/agent/src/runtime/plugin-role-gating.ts \
    > packages/agent/src/runtime/plugin-role-gating.ts
$ bunx vitest run src/runtime/plugin-role-gating.metadata-key-bound.test.ts
     × still gates when connector metadata nests past the stack limit 4ms
     × withholds from a caller below minRole even with over-deep metadata 1ms
     × still gates when connector metadata contains a cycle 2ms
     × still gates when metadata carries an enumerable accessor 1ms
 Test Files  1 failed (1)
      Tests  4 failed | 14 passed (18)

Fix restored from the copy-aside:
$ bunx vitest run src/runtime/plugin-role-gating.metadata-key-bound.test.ts
 Test Files  1 passed (1)
      Tests  18 passed (18)

The four fail for the reported reason, not a harness artifact: each carries the
RangeError (or, for the accessor case, the throwing getter's own Error)
inside `stableStringify`.

=== 5. FOCUSED SUITE AT THIS HEAD ===

$ bunx vitest run --root packages/agent \
    src/runtime/plugin-role-gating.metadata-key-bound.test.ts \
    src/runtime/plugin-role-gating.test.ts \
    src/runtime/plugin-role-gating-chokepoint.test.ts \
    src/runtime/plugin-role-gating-registration.test.ts \
    src/runtime/plugin-role-gating.guest-history.test.ts \
    src/runtime/tool-call-cache
 Test Files  9 passed (9)
      Tests  152 passed (152)
exit 0

(All four pre-existing role-gating suites plus the whole tool-call-cache suite —
the module I now depend on — so both sides of the new import are executed.)

=== 6. TYPECHECK, AGAINST AN UNTOUCHED CONTROL ===

$ bun run --cwd packages/agent typecheck        # branch
  31 `error TS` lines
$ bun run --cwd packages/agent typecheck        # same tree, my 2 files reverted/removed
  31 `error TS` lines
$ diff <(sort control) <(sort branch)
  (no output)  -> IDENTICAL-ERROR-SETS

The branch adds ZERO typecheck errors. All 31 are pre-existing unbuilt-plugin
module-resolution failures on develop (@elizaos/plugin-wallet/diagnostic,
@elizaos/cloud-routing, @elizaos/plugin-video, @elizaos/plugin-notes/plugin, ...)
plus pre-existing implicit-any findings in unrelated test files.

=== 7. LINT ===

$ bunx biome check packages/agent/src/runtime/plugin-role-gating.ts \
                   packages/agent/src/runtime/plugin-role-gating.metadata-key-bound.test.ts
Checked 2 files in 20ms. No fixes applied.
exit 0

=== 8. DIFF SHAPE ===

$ git diff --stat origin/develop...HEAD
 .../plugin-role-gating.metadata-key-bound.test.ts  | 256 +++++++++++++++++++++
 packages/agent/src/runtime/plugin-role-gating.ts   |  62 +++--
 2 files changed, 297 insertions(+), 21 deletions(-)

The production file's walk logic goes from 16 lines to 1 call; the rest of its
delta is the doc comment explaining the trust boundary and the fallback.
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behaviour changed. This is a
cache-key derivation bound inside the provider role gate; the gate's decision
inputs and outputs are unchanged, which sections 3 and 5 of the domain receipt
demonstrate. A device-signed, trace-finalized private-trace receipt for this run
is in the footer.

## Backend + frontend logs

Backend: the origin-reproduction block in the **backend-logs** row is the real
code path firing — the real `applyPluginRoleGating`-wrapped `provider.get`
throwing out of `stableStringify` on unmodified `develop`, with the four-frame
stack from the provider down to the walk.

Frontend: N/A - no browser hop in this unit.

## Screenshots (before / after) + video walkthrough

N/A - runtime module and its tests; no rendered UI surface in the diff.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

- **No unauthenticated in-repo HTTP reproduction, and I do not claim one.**
  `message.metadata` is written by connector plugins that live outside this
  repository. The in-repo chat route puts client metadata on
  `content.metadata`, which role resolution deliberately ignores
  (`roles.ts:808`). The reproduction above is through the real gating module,
  not through a route. Reviewers should read the impact as "connector payload
  or in-process producer", not "any HTTP caller".
- **No authorization-bypass claim.** The throw is fail-closed and I could not
  find a reachable key collision that changes a role decision (reasoning in
  **Scope, stated honestly**). Filing that as a stated gap rather than as a
  finding is deliberate: the reachable defect is the unbounded walk.
- Root `bun run verify` was **not** run on this head. `verify` is a
  monorepo-wide gate and this tree cannot complete it — the 31 unbuilt-plugin
  module-resolution errors in section 6 are on `develop` itself — so a root run
  here would report failures unrelated to this diff. The package-scoped suite,
  the typecheck **control diff**, and lint above were executed and are the
  proof; the control diff is the specific evidence that this PR adds no new
  error.
- Hosted CI check-runs: none on this head. Fork branches on this repository do
  not schedule check-runs; that is repo steady state, not a skipped gate.
- Fork cannot upload `pr-evidence` release assets, so the domain receipt is
  inline.
- The bound is `tool-call-cache/key.ts`'s `CACHE_KEY_LIMITS` (depth 32, 100k
  nodes, 100k aggregate width, 4M chars per string, 16M bytes) rather than a
  new constant, so the two untrusted cache-key boundaries in `packages/agent`
  cannot drift apart. If a reviewer wants a tighter, metadata-specific ceiling,
  `tryCanonicalizeJson` already accepts a `Partial<CanonicalizeLimits>` and it
  is a one-line change — I left it at the shared budget deliberately, because a
  narrower bound is the only way this PR could newly reject a live value.
- If #23817 lands `packages/shared/src/canonical-json.ts`, this call site
  should move to it. It is a one-import follow-up, not a reason to hold this.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-rolegate-23843]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JH5TT33RDGAYD84R2TEQ3C","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T16:06:32.003Z","completed_at":"2026-08-21T16:08:13.801Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T16:06:32.335Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"4ee5b6111585d8403f2e26c0534e01f3afe46df3187fb687dd07fd9bb2eaaf6b","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"aa15cb1b-e703-4baa-8c40-b9bb75d83320","object_id":"sha256:4ee5b6111585d8403f2e26c0534e01f3afe46df3187fb687dd07fd9bb2eaaf6b","sha256":"4ee5b6111585d8403f2e26c0534e01f3afe46df3187fb687dd07fd9bb2eaaf6b"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"Awb-YsQFd6qZYcMwFbQHcMk8FNEVurFoX--GN46cgvLTAeRWVYAStFDKhQ0u8zCK5ztVwH9O_jGvrBTRaAVpDQ"}} -->
