### PR TITLE
fix(plugin-browser): bound the desktop workspace diff page fetches

### DIFF
--- a/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-diff-deadline.test.ts
+++ b/plugins/plugin-browser/src/workspace/__tests__/browser-workspace-diff-deadline.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Deadline tests for browser workspace page fetches.
+ *
+ * The desktop `diff url` subaction fetches two caller-supplied page URLs with
+ * the raw page fetch. Every other hop in the workspace is bounded — the bridge
+ * transport (`browser-workspace-desktop.ts` `requestBrowserWorkspace`) and the
+ * tracked page fetch used by the web backend of the *same* subaction both carry
+ * `AbortSignal.timeout(DEFAULT_TIMEOUT_MS)`. These tests pin that the desktop
+ * hops are bounded too, that a caller abort still wins over the deadline, and
+ * that ordinary fast responses are untouched.
+ *
+ * Every assertion runs against a real never-answering TCP socket, not a stub:
+ * a fake `fetch` that never settles is indistinguishable from a slow one, and
+ * the test runner's own timeout does not interrupt an in-flight `fetch`, so
+ * each wait is raced against an explicit watchdog instead.
+ */
+
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { executeBrowserWorkspaceCommand } from "../browser-workspace.js";
+import {
+  browserWorkspaceBoundedPageFetch,
+  DEFAULT_TIMEOUT_MS,
+} from "../browser-workspace-helpers.js";
+import { fetchBrowserWorkspaceTrackedResponse } from "../browser-workspace-network.js";
+import { getBrowserWorkspaceRuntimeState } from "../browser-workspace-state.js";
+
+type Watchdog<T> = { value: T | "STILL-PENDING"; elapsedMs: number };
+
+/** Race a promise against a watchdog so a never-settling fetch fails instead of hanging the suite. */
+async function raceWatchdog<T>(
+  work: Promise<T>,
+  watchdogMs: number,
+): Promise<Watchdog<{ ok: true; value: T } | { ok: false; error: unknown }>> {
+  const startedAt = Date.now();
+  let timer: NodeJS.Timeout | undefined;
+  const watchdog = new Promise<"STILL-PENDING">((resolve) => {
+    timer = setTimeout(() => resolve("STILL-PENDING"), watchdogMs);
+  });
+  try {
+    const settled = await Promise.race([
+      work.then(
+        (value) => ({ ok: true as const, value }),
+        (error) => ({ ok: false as const, error }),
+      ),
+      watchdog,
+    ]);
+    return { elapsedMs: Date.now() - startedAt, value: settled };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function errorName(error: unknown): string {
+  return error instanceof Error ? error.name : String(error);
+}
+
+/** Cause-aware: `fetch` wraps an abort reason in a TypeError on some runtimes. */
+function abortReasonName(error: unknown): string {
+  if (error instanceof Error && error.cause instanceof Error) {
+    return error.cause.name;
+  }
+  return errorName(error);
+}
+
+let blackhole: http.Server;
+let blackholeUrl: string;
+let fastServer: http.Server;
+let fastUrl: string;
+let bridge: http.Server;
+let bridgeEnv: NodeJS.ProcessEnv;
+
+async function listen(server: http.Server): Promise<string> {
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+beforeAll(async () => {
+  // Accepts the connection, reads the request, and never writes a response.
+  blackhole = http.createServer(() => {});
+  blackholeUrl = `${await listen(blackhole)}/never`;
+
+  fastServer = http.createServer((_request, response) => {
+    response.writeHead(200, { "Content-Type": "text/html" });
+    response.end("<html><body>ok</body></html>");
+  });
+  fastUrl = `${await listen(fastServer)}/fast`;
+
+  // Minimal desktop bridge: the diff path resolves a snapshot through `/eval`.
+  bridge = http.createServer((request, response) => {
+    request.resume();
+    request.on("end", () => {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      if (/\/tabs\/[^/]+\/eval$/.test(request.url ?? "")) {
+        response.end(
+          JSON.stringify({
+            result: {
+              capturedAt: "2026-01-01T00:00:00.000Z",
+              html: "<html></html>",
+              text: "",
+              title: "tab",
+              url: "https://example.invalid/",
+            },
+          }),
+        );
+        return;
+      }
+      response.end(JSON.stringify({ tabs: [] }));
+    });
+  });
+  const bridgeUrl = await listen(bridge);
+  bridgeEnv = { ELIZA_BROWSER_WORKSPACE_URL: bridgeUrl };
+});
+
+afterAll(async () => {
+  await Promise.all(
+    [blackhole, fastServer, bridge].map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.closeAllConnections?.();
+          server.close(() => resolve());
+        }),
+    ),
+  );
+});
+
+describe("browserWorkspaceBoundedPageFetch", () => {
+  it("aborts a never-answering socket with a TimeoutError", async () => {
+    const outcome = await raceWatchdog(
+      browserWorkspaceBoundedPageFetch(blackholeUrl, {}, 300),
+      3_000,
+    );
+
+    expect(outcome.value).not.toBe("STILL-PENDING");
+    const settled = outcome.value as { ok: boolean; error?: unknown };
+    expect(settled.ok).toBe(false);
+    // Specifically the deadline, so dropping the caller signal cannot pass this.
+    expect(abortReasonName(settled.error)).toBe("TimeoutError");
+    expect(outcome.elapsedMs).toBeLessThan(3_000);
+  });
+
+  it("lets a caller abort win over the deadline instead of over-rejecting", async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 150);
+
+    const outcome = await raceWatchdog(
+      browserWorkspaceBoundedPageFetch(
+        blackholeUrl,
+        { signal: controller.signal },
+        30_000,
+      ),
+      5_000,
+    );
+
+    expect(outcome.value).not.toBe("STILL-PENDING");
+    const settled = outcome.value as { ok: boolean; error?: unknown };
+    expect(settled.ok).toBe(false);
+    expect(abortReasonName(settled.error)).toBe("AbortError");
+    expect(outcome.elapsedMs).toBeLessThan(5_000);
+  });
+
+  it("leaves an ordinary fast response untouched", async () => {
+    const response = await browserWorkspaceBoundedPageFetch(fastUrl, {}, 5_000);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("ok");
+  });
+});
+
+describe("fetchBrowserWorkspaceTrackedResponse", () => {
+  it(
+    "keeps the hop deadline when the caller also supplies a signal",
+    async () => {
+      const state = getBrowserWorkspaceRuntimeState("web", "tracked-deadline");
+      // A caller controller that never fires: on the `??` form this replaced the
+      // deadline outright, so the hop had no bound at all.
+      const controller = new AbortController();
+
+      const outcome = await raceWatchdog(
+        fetchBrowserWorkspaceTrackedResponse(
+          state,
+          blackholeUrl,
+          { signal: controller.signal },
+          "document",
+        ),
+        DEFAULT_TIMEOUT_MS + 8_000,
+      );
+
+      expect(outcome.value).not.toBe("STILL-PENDING");
+      const settled = outcome.value as { ok: boolean; error?: unknown };
+      expect(settled.ok).toBe(false);
+      expect(abortReasonName(settled.error)).toBe("TimeoutError");
+      expect(controller.signal.aborted).toBe(false);
+    },
+    DEFAULT_TIMEOUT_MS + 20_000,
+  );
+});
+
+describe("desktop browser workspace diff url", () => {
+  it(
+    "does not hang forever on a never-answering page",
+    async () => {
+      const outcome = await raceWatchdog(
+        executeBrowserWorkspaceCommand(
+          {
+            diffAction: "url",
+            id: "tab-1",
+            secondaryUrl: blackholeUrl,
+            subaction: "diff",
+            url: blackholeUrl,
+          },
+          bridgeEnv,
+        ),
+        DEFAULT_TIMEOUT_MS + 8_000,
+      );
+
+      expect(outcome.value).not.toBe("STILL-PENDING");
+      const settled = outcome.value as { ok: boolean; error?: unknown };
+      expect(settled.ok).toBe(false);
+      expect(abortReasonName(settled.error)).toBe("TimeoutError");
+    },
+    DEFAULT_TIMEOUT_MS + 20_000,
+  );
+
+  it("still returns a diff for pages that answer", async () => {
+    const result = await executeBrowserWorkspaceCommand(
+      {
+        diffAction: "url",
+        id: "tab-1",
+        secondaryUrl: fastUrl,
+        subaction: "diff",
+        url: fastUrl,
+      },
+      bridgeEnv,
+    );
+
+    expect(result.mode).toBe("desktop");
+    expect(result.subaction).toBe("diff");
+    expect(result.value).toBeDefined();
+  }, 30_000);
+});

--- a/plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-helpers.ts
@@ -27,6 +27,26 @@ export const DESKTOP_BRIDGE_UNAVAILABLE_MESSAGE =
   "Eliza browser workspace desktop bridge is unavailable.";
 export const browserWorkspacePageFetch = globalThis.fetch.bind(globalThis);
 
+/**
+ * Page fetch with a hop deadline, so a host that accepts the connection and
+ * never answers cannot pin a browser workspace command indefinitely.
+ *
+ * A caller-provided abort signal composes with the deadline rather than
+ * replacing it: the caller can still cancel early, and the bound still applies
+ * when the caller's signal never fires.
+ */
+export async function browserWorkspaceBoundedPageFetch(
+  url: string,
+  init: RequestInit = {},
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<Response> {
+  const deadline = AbortSignal.timeout(timeoutMs);
+  return browserWorkspacePageFetch(url, {
+    ...init,
+    signal: init.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
+  });
+}
+
 export function normalizeEnvValue(value: string | undefined): string | null {
   if (typeof value !== "string") {
     return null;

--- a/plugins/plugin-browser/src/workspace/browser-workspace-network.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-network.ts
@@ -2,10 +2,7 @@
  * Network interception and HAR helpers for browser workspace page loading.
  */
 
-import {
-  browserWorkspacePageFetch,
-  DEFAULT_TIMEOUT_MS,
-} from "./browser-workspace-helpers.js";
+import { browserWorkspaceBoundedPageFetch } from "./browser-workspace-helpers.js";
 import { getBrowserWorkspaceTimestamp } from "./browser-workspace-state.js";
 import type {
   BrowserWorkspaceNetworkRequestRecord,
@@ -160,11 +157,13 @@ export async function fetchBrowserWorkspaceTrackedResponse(
     );
   }
 
-  const response = await browserWorkspacePageFetch(url, {
+  // `browserWorkspaceBoundedPageFetch` composes any caller signal with the hop
+  // deadline; passing `init.signal` through unchanged would let a caller signal
+  // replace the deadline instead of adding to it.
+  const response = await browserWorkspaceBoundedPageFetch(url, {
     ...init,
     headers,
     redirect: init.redirect ?? "follow",
-    signal: init.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
   });
   let responseBody: string | null = null;
   if (resourceType !== "document") {

--- a/plugins/plugin-browser/src/workspace/browser-workspace.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace.ts
@@ -130,7 +130,7 @@ import {
   pushWebBrowserWorkspaceHistory,
 } from "./browser-workspace-forms.js";
 // ── Re-export network ────────────────────────────────────────────────
-import { browserWorkspacePageFetch } from "./browser-workspace-helpers.js";
+import { browserWorkspaceBoundedPageFetch } from "./browser-workspace-helpers.js";
 // ── Re-export jsdom ──────────────────────────────────────────────────
 import {
   createEmptyWebBrowserWorkspaceDom,
@@ -971,8 +971,10 @@ export async function executeBrowserWorkspaceCommand(
             "Eliza browser workspace diff url requires secondaryUrl.",
           );
         }
-        const left = await browserWorkspacePageFetch(leftUrl);
-        const right = await browserWorkspacePageFetch(rightUrl);
+        // Each hop carries its own deadline, matching the web backend of this
+        // same subaction, which routes both pages through the tracked fetch.
+        const left = await browserWorkspaceBoundedPageFetch(leftUrl);
+        const right = await browserWorkspaceBoundedPageFetch(rightUrl);
         return {
           mode: "desktop",
           subaction: command.subaction,


### PR DESCRIPTION
# Relates to

Fixes #23851

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (branched off `2271e3b78750e19045a0b83c541d52da34d72158`).
- [x] `bun install` was run after sync. `bun run verify` was **not** run
      monorepo-wide — see **Known gaps / failures**; the full `plugin-browser`
      workspace suite, the package typecheck against an untouched control, and
      biome on all four touched files were run and are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after real-socket measurements below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched off the latest `origin/develop` (`2271e3b78750`); zero conflicts.
- [ ] `bun run verify` post-sync — not run monorepo-wide; the exact scope that
      was run, and why the wider run was skipped, is in **Known gaps / failures**.

# Risks

**Low.** One new helper plus three call sites. Nothing an ordinary caller
observes changes: a page that answers is byte-identical, a caller that aborts
early still aborts early, and a call with no caller signal keeps the same 12 s
bound the rest of this feature already uses. All three are asserted, not argued
(see *No over-rejection*).

# Background

## What does this PR do?

The desktop `diff url` subaction fetches two caller-supplied page URLs with the
raw page fetch and **no `signal` at all**
(`plugins/plugin-browser/src/workspace/browser-workspace.ts:974-975` on
`develop`):

```ts
const left = await browserWorkspacePageFetch(leftUrl);
const right = await browserWorkspacePageFetch(rightUrl);
```

`browserWorkspacePageFetch` is `globalThis.fetch.bind(globalThis)`
(`browser-workspace-helpers.ts:28`) — a bare `fetch`, no wrapper, no deadline of
its own. A host that accepts the TCP connection and never writes a response pins
the browser workspace command handler for as long as the socket stays open, and
there is no caller signal on this path to cancel it with.

`leftUrl` / `rightUrl` come from `command.url` and `command.secondaryUrl` —
agent command parameters, not module constants.

## Why this is a hole and not a policy

Every other outbound hop in this feature is bounded, **including the same
subaction on the other backend**:

| hop | file:line on `develop` | deadline |
|---|---|---|
| desktop bridge transport | `browser-workspace-desktop.ts:98` | `AbortSignal.timeout(DEFAULT_TIMEOUT_MS)` |
| tracked page fetch | `browser-workspace-network.ts:167` | `AbortSignal.timeout(DEFAULT_TIMEOUT_MS)` |
| **web backend `diff url`** | `browser-workspace-web.ts:685,691` | bounded — routes both pages through the tracked fetch |
| **desktop backend `diff url`** | `browser-workspace.ts:974,975` | **none** |

The two blocks are otherwise the same code, down to the
`leftUrl` / `rightUrl` / `secondaryUrl` handling. `DEFAULT_TIMEOUT_MS` is
12 000 ms (`browser-workspace-helpers.ts:21`). The web backend gets it; the
desktop backend does not.

The two hops are sequential, so both are unbounded, and the body reads that
follow (`await left.text()`) are unbounded too.

## The second, narrower half — stated honestly

`browser-workspace-network.ts:167` reads

```ts
signal: init.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
```

`??` short-circuits, so when the caller passes a signal the deadline object is
never constructed — a caller signal **replaces** the bound instead of composing
with it. That is the shape this repository has already repaired several times
(#23480, #23677, #23695, #23822).

Being precise about what is and is not demonstrated here: **no in-repo caller of
`fetchBrowserWorkspaceTrackedResponse` currently passes a signal**, so this half
is a latent hole rather than an observed hang. I am not claiming otherwise. It
is included because it is one line in the same feature, it is the exact shape
the maintainers have already accepted, and the `dom.window.fetch` shim installed
at `browser-workspace-jsdom.ts:243-262` forwards a caller-supplied `init`
verbatim into this function — which is precisely the call that would drop the
deadline. It is covered by its own load-bearing test below rather than being
carried along untested.

## The fix

One bounded page-fetch helper, using the composition already merged in this
repository rather than a new mechanism:

```ts
export async function browserWorkspaceBoundedPageFetch(
  url: string,
  init: RequestInit = {},
  timeoutMs: number = DEFAULT_TIMEOUT_MS,
): Promise<Response> {
  const deadline = AbortSignal.timeout(timeoutMs);
  return browserWorkspacePageFetch(url, {
    ...init,
    signal: init.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
  });
}
```

Used at all three call sites. Each desktop diff hop gets its own deadline, which
is exactly what the web backend does — one fresh `AbortSignal.timeout` per
`fetchBrowserWorkspaceTrackedResponse` call — so the two backends now behave
identically rather than one being stricter than the other.

## Scope I deliberately did not take

Routing the desktop diff through `fetchBrowserWorkspaceTrackedResponse` would
also have bounded it, and would additionally have applied the workspace's
offline flag, network route table, injected headers and basic-auth credentials
to the desktop diff. That is a larger behavioural change than a missing
deadline, and it could reject calls that succeed today. This PR changes the
timeout behaviour only.

## No over-rejection — proved, not asserted

- **An early caller abort still wins.** A case aborts the caller's controller at
  150 ms against a 30 s deadline and asserts the rejection is an **`AbortError`**,
  not a `TimeoutError`. Composition must not cost the caller its cancellation.
- **Ordinary fast responses are unchanged.** A case fetches a real server that
  answers immediately and asserts `status === 200` and the body content.
- **`caller.signal.aborted` stays `false`** when the deadline is what fired, so a
  caller can still distinguish its own cancellation from the hop timing out.
- **The full existing workspace suite is untouched and still green** — 13 files,
  84 tests, 0 fail (that count includes this PR's 6 new cases; the other 78 are
  pre-existing).
- Every abort assertion names **`TimeoutError`** specifically, not merely "it
  aborted". A non-fix that dropped the caller signal instead of composing would
  also abort, and would not be caught by a weaker assertion.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`browser-workspace.ts:974-975` — two lines — then any one case in
`__tests__/browser-workspace-diff-deadline.test.ts`.

## Detailed testing steps

```bash
git fetch origin develop && git checkout <this branch>
bun install
node packages/shared/scripts/generate-keywords.mjs
bun run --cwd plugins/plugin-browser test src/workspace
```

### 1. Origin reproduction — a real non-answering socket, no mocks

A real `http.createServer` that accepts the connection and never writes a
response, a real minimal desktop bridge answering `POST /tabs/<id>/eval`, and
the **real exported `executeBrowserWorkspaceCommand`** driving the real desktop
`diff url` path. Run on `origin/develop` at `2271e3b78750`, unmodified:

```
$ bun run --cwd plugins/plugin-browser test src/workspace/__tests__/zz-origin-repro-diff.test.ts

stdout | ORIGIN REPRO: desktop diff url has no deadline
ORIGIN diff url after 30002ms -> STILL-HUNG

 × is still hung at 30s against a real never-answering socket 30005ms
AssertionError: expected 'STILL-HUNG' not to be 'STILL-HUNG'
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

`STILL-HUNG` is not "slow" — it is the harness abandoning a command that had no
deadline at all, at 2.5x the 12 s bound the *web* backend of the same subaction
enforces. Nothing in that run is stubbed: real sockets, real command dispatch.

### 2. AFTER — same driver, same sockets, this branch

```
$ bun run --cwd plugins/plugin-browser test src/workspace/__tests__/zz-origin-repro-diff.test.ts --reporter=verbose

ORIGIN diff url after 12018ms -> REJECTED:TimeoutError
 ✓ is still hung at 30s against a real never-answering socket 12019ms
      Tests  1 passed (1)
```

12 018 ms against the declared 12 000 ms `DEFAULT_TIMEOUT_MS`.

### 3. The permanent suite

```
$ bun run --cwd plugins/plugin-browser test src/workspace/__tests__/browser-workspace-diff-deadline.test.ts

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  25.65s
```

```
$ bun run --cwd plugins/plugin-browser test src/workspace

 Test Files  13 passed (13)
      Tests  84 passed (84)
   Duration  25.14s
```

### 4. Load-bearing check — per call site, not per PR

Each production file was reverted **individually** to its `origin/develop` body
by copy-aside (never `git stash`), the suite was run, and the file was restored
before the next arm. A fix that only worked in aggregate would show up here as a
suite that stays green while one call site is broken.

```
===== REVERT ARM 1: browser-workspace.ts -> origin/develop
     × does not hang forever on a never-answering page 20004ms
AssertionError: expected 'STILL-PENDING' not to be 'STILL-PENDING'
 Tests  1 failed | 5 passed (6)

===== REVERT ARM 2: browser-workspace-network.ts -> origin/develop
     × keeps the hop deadline when the caller also supplies a signal 20005ms
AssertionError: expected 'STILL-PENDING' not to be 'STILL-PENDING'
 Tests  1 failed | 5 passed (6)
```

Two call sites, two independent failures, each arm failing exactly the one case
that covers it while the other five stay green — including the "caller abort
still wins" and "fast response unchanged" cases, so neither revert is caught by
accident.

Note the `20004ms` figure: those assertions are written as a race against an
explicit watchdog rather than a bare `await`, because **the test runner's timeout
does not interrupt an in-flight `fetch`** — a naive deadline test on an unbounded
hop hangs the file instead of failing it. That was measured while writing this,
not assumed.

### 5. Typecheck — zero errors added, measured against an untouched control

```
$ bun run --cwd plugins/plugin-browser typecheck        # this branch
../../packages/core/src/cloud-routing.ts(12,8): error TS2307: Cannot find module '@elizaos/cloud-routing' …
../../packages/core/src/cloud-routing.ts(19,8): error TS2307: Cannot find module '@elizaos/cloud-routing' …
src/actions/browser-autofill-login.ts(52,8): error TS2307: Cannot find module '@elizaos/vault' …

# control: the same tree with all four touched files restored to origin/develop
$ bun run --cwd plugins/plugin-browser typecheck
../../packages/core/src/cloud-routing.ts(12,8): error TS2307: Cannot find module '@elizaos/cloud-routing' …
../../packages/core/src/cloud-routing.ts(19,8): error TS2307: Cannot find module '@elizaos/cloud-routing' …
src/actions/browser-autofill-login.ts(52,8): error TS2307: Cannot find module '@elizaos/vault' …
```

Identical. All three are pre-existing unbuilt-workspace module-resolution errors
in files this PR does not touch.

### 6. Biome

```
$ bunx @biomejs/biome check <the 4 touched files>
Checked 4 files in 67ms. No fixes applied.
```

# Evidence Gate

<!-- evidence-head:8eaf0922a8c94e74af77ef22bc1b49c73e76cb94 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only change to the browser workspace command layer; no rendered UI surface is touched by this diff.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only change to the browser workspace command layer; no rendered UI surface is touched by this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the observable behaviour is whether a workspace command terminates, shown as before/after wall-clock measurements against a real socket in Testing above.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — pasted below (the
      real exported `executeBrowserWorkspaceCommand` driven against a real
      `http.createServer` that never answers, plus the real suites).

<details><summary>BEFORE — <code>origin/develop</code> at <code>2271e3b78750</code>, real socket, real command dispatch</summary>

```
ORIGIN diff url after 30002ms -> STILL-HUNG

 × is still hung at 30s against a real never-answering socket 30005ms
AssertionError: expected 'STILL-HUNG' not to be 'STILL-HUNG'
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

</details>

<details><summary>AFTER — this branch, same socket, same driver</summary>

```
ORIGIN diff url after 12018ms -> REJECTED:TimeoutError
 ✓ is still hung at 30s against a real never-answering socket 12019ms
      Tests  1 passed (1)

$ bun run --cwd plugins/plugin-browser test src/workspace
 Test Files  13 passed (13)
      Tests  84 passed (84)
   Duration  25.14s
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path; these modules run in the agent process.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behaviour changes; this is an HTTP hop deadline.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB rows, memories, scheduled tasks, on-chain output, or generated files are produced or altered.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behaviour changes.`

## Backend + frontend logs

Backend: inline in **Testing → 1, 2, 3, 4** (the real exported command driven
against a real non-answering `http.createServer` and a real minimal bridge, plus
the full workspace suite and the two per-call-site revert arms).

Frontend: `N/A - agent-process modules.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT, or omnivoice surface.`

## Known gaps / failures

- **The `browser-workspace-network.ts` half is latent, not demonstrated.** As
  stated in Background: no in-repo caller of
  `fetchBrowserWorkspaceTrackedResponse` passes a signal today, so the `??` was
  a hole waiting for a caller rather than an observed hang. Its test drives the
  function directly with a caller-supplied controller. The **demonstrated** hang
  is the desktop `diff url` path.
- **The desktop `diff url` path requires `ELIZA_BROWSER_WORKSPACE_URL` to be
  set** (`isBrowserWorkspaceBridgeConfigured`). Without a bridge the command
  falls through to the web backend, which was already bounded. So this affects
  desktop-app deployments, not the web fallback.
- **The origin-reproduction test is not part of this diff.** It is a standalone
  file that imports only symbols present on `origin/develop`; it was deleted
  before committing. The permanent regression coverage is the six cases in
  `browser-workspace-diff-deadline.test.ts`.
- **`bun run verify` was not run monorepo-wide.** It builds and tests the whole
  repository and is far beyond the blast radius of one helper and three call
  sites in one plugin. What was run instead, and passed, is recorded above.
- **`packages/core/src/i18n/generated/validation-keyword-data.ts` had to be
  generated** in the fresh worktree
  (`node packages/shared/scripts/generate-keywords.mjs`). It is a gitignored
  build artifact and is not in this diff.
- **Hosted CI checks do not run on this PR.** I contribute from a fork without
  push access to `elizaOS/eliza`, so no hosted check will report here. Every
  result above was produced locally and is reproducible with the commands given.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-mine-browserdiff]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JHVWCBYRMH8G8TCV11RC8N","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T16:18:34.507Z","completed_at":"2026-08-21T16:20:30.671Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T16:18:35.452Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"364cdec7086ca56117bd0f8e689d40959efe773983bf94370b567eab544dcc04","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"b97f9489-2284-42a2-89e0-aff7343fee79","object_id":"sha256:364cdec7086ca56117bd0f8e689d40959efe773983bf94370b567eab544dcc04","sha256":"364cdec7086ca56117bd0f8e689d40959efe773983bf94370b567eab544dcc04"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"0eCXasug0u67hrVaTnM0uLTd0j74f6vYDXXTohMpPGQpV_xYNUEsRRUSV1ZlJg2i-IYApjzrj6yRWQU6wr9eCg"}} -->
