### PR TITLE
fix(core): cut the evaluator prompt tail on a surrogate boundary

### DIFF
--- a/packages/core/src/services/evaluator.middle-surrogate.test.ts
+++ b/packages/core/src/services/evaluator.middle-surrogate.test.ts
@@ -1,110 +1,143 @@
-/** Surrogate safety for evaluator prompt truncation helpers (truncateHeadForPrompt and trimHeadAndTailForPrompt). */
-import { describe, expect, test } from "vitest";
-import {
-	toWellFormedUnicode,
-	truncateWellFormed,
-} from "../utils/well-formed.ts";
+/**
+ * Regression for the head-and-tail truncation of an oversized evaluator section
+ * (`trimHeadAndTailForPrompt`).
+ *
+ * Evaluator sections keep their extraction rules (head) and the newest context
+ * (tail), so the assembled prompt carries two independent cut points. Both are
+ * driven here through the real `EvaluatorService.run` and asserted on the
+ * string handed to `useModel`, since that is the value a provider serializes.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter";
+import { AgentRuntime } from "../runtime";
+import type { Character, Memory } from "../types";
+import { EVALUATOR_PROMPT_MAX_CHARS, EvaluatorService } from "./evaluator";
 
-const EVALUATOR_PROMPT_TRUNCATION_MARKER = "\n...[truncated]...\n";
+const FOX = "\u{1F98A}";
+const TRUNCATION_MARKER = "[... truncated; kept latest tail ...]";
 
 function isWellFormed(value: string): boolean {
-	if (!value) return true;
-	const maybe = value as unknown as { isWellFormed?: () => boolean };
-	if (typeof maybe.isWellFormed === "function") return maybe.isWellFormed();
-	return toWellFormedUnicode(value) === value;
+	const native = value as unknown as { isWellFormed?: () => boolean };
+	if (typeof native.isWellFormed === "function") return native.isWellFormed();
+	for (let i = 0; i < value.length; i++) {
+		const code = value.charCodeAt(i);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			const next = value.charCodeAt(i + 1);
+			if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
+			i++;
+		} else if (code >= 0xdc00 && code <= 0xdfff) return false;
+	}
+	return true;
 }
 
-function truncateHeadForPromptMock(text: string, maxChars: number): string {
-	if (maxChars <= 0) return "";
-	const wellFormed = toWellFormedUnicode(text);
-	if (wellFormed.length <= maxChars) return wellFormed;
-	if (maxChars <= EVALUATOR_PROMPT_TRUNCATION_MARKER.length) {
-		return EVALUATOR_PROMPT_TRUNCATION_MARKER.slice(0, maxChars);
-	}
-	const tailChars = maxChars - EVALUATOR_PROMPT_TRUNCATION_MARKER.length;
-	let tailStart = wellFormed.length - tailChars;
-	if (
-		tailStart > 0 &&
-		wellFormed.charCodeAt(tailStart - 1) >= 0xd800 &&
-		wellFormed.charCodeAt(tailStart - 1) <= 0xdbff &&
-		wellFormed.charCodeAt(tailStart) >= 0xdc00 &&
-		wellFormed.charCodeAt(tailStart) <= 0xdfff
-	) {
-		tailStart += 1;
-	}
-	return `${EVALUATOR_PROMPT_TRUNCATION_MARKER}${wellFormed.slice(tailStart)}`;
+function makeRuntime(): AgentRuntime {
+	const runtime = new AgentRuntime({
+		character: {
+			name: "EvaluatorMiddleAgent",
+			bio: "test",
+			settings: {},
+		} as Character,
+		adapter: new InMemoryDatabaseAdapter(),
+		logLevel: "fatal",
+	});
+	runtime.evaluators.length = 0;
+	runtime.composeState = vi.fn(async () => ({
+		values: {},
+		data: {},
+		text: "",
+	}));
+	runtime.emitEvent = vi.fn(async () => {});
+	return runtime;
 }
 
-function trimHeadAndTailForPromptMock(text: string, maxChars: number): string {
-	if (maxChars <= 0) return "";
-	const wellFormed = toWellFormedUnicode(text);
-	if (wellFormed.length <= maxChars) return wellFormed;
-	if (maxChars <= EVALUATOR_PROMPT_TRUNCATION_MARKER.length) {
-		return EVALUATOR_PROMPT_TRUNCATION_MARKER.slice(0, maxChars);
-	}
-	const contentBudget = maxChars - EVALUATOR_PROMPT_TRUNCATION_MARKER.length;
-	const headBudget = Math.ceil(contentBudget / 3);
-	const tailBudget = contentBudget - headBudget;
-	const head = truncateWellFormed(wellFormed, headBudget);
-	let tail = "";
-	if (tailBudget > 0) {
-		let tailStart = wellFormed.length - tailBudget;
-		if (
-			tailStart > 0 &&
-			wellFormed.charCodeAt(tailStart - 1) >= 0xd800 &&
-			wellFormed.charCodeAt(tailStart - 1) <= 0xdbff &&
-			wellFormed.charCodeAt(tailStart) >= 0xdc00 &&
-			wellFormed.charCodeAt(tailStart) <= 0xdfff
-		) {
-			tailStart += 1;
+function makeMessage(): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000001" as Memory["id"],
+		entityId: "00000000-0000-0000-0000-000000000002" as Memory["entityId"],
+		roomId: "00000000-0000-0000-0000-000000000003" as Memory["roomId"],
+		content: { text: "hello", source: "test" },
+	} as Memory;
+}
+
+/**
+ * Runs one turn whose single evaluator section is `body`. `descriptionPad`
+ * shifts both section cut points by one character per added byte, which is what
+ * moves them across a surrogate boundary.
+ */
+async function sectionPromptFor(
+	body: string,
+	descriptionPad = 0,
+): Promise<string> {
+	const runtime = makeRuntime();
+	runtime.registerEvaluator({
+		name: "alpha",
+		description: `alpha section${".".repeat(descriptionPad)}`,
+		schema: {
+			type: "object",
+			properties: { ok: { type: "boolean" } },
+			required: ["ok"],
+		},
+		shouldRun: async () => true,
+		prompt: () => body,
+		parse: (output) => output as never,
+		processors: [
+			{ name: "storeAlpha", process: async () => ({ success: true }) },
+		],
+	});
+	let captured: string | undefined;
+	runtime.useModel = vi.fn(async (_modelType, params) => {
+		captured = String(params.messages?.[0]?.content ?? "");
+		return { alpha: { ok: true } };
+	}) as AgentRuntime["useModel"];
+	const result = await new EvaluatorService(runtime).run(makeMessage(), {
+		values: {},
+		data: {},
+		text: "",
+	});
+	expect(result.errors).toEqual([]);
+	expect(captured).toBeDefined();
+	return captured as string;
+}
+
+describe("evaluator section head-and-tail truncation is surrogate-safe", () => {
+	it("never emits a lone surrogate at either cut across parities", async () => {
+		const body = FOX.repeat(EVALUATOR_PROMPT_MAX_CHARS);
+		const illFormed: number[] = [];
+		for (let pad = 0; pad < 8; pad++) {
+			const prompt = await sectionPromptFor(body, pad);
+			expect(prompt).toContain(TRUNCATION_MARKER);
+			expect(prompt.length).toBeLessThanOrEqual(EVALUATOR_PROMPT_MAX_CHARS);
+			if (!isWellFormed(prompt)) illFormed.push(pad);
 		}
-		tail = wellFormed.slice(tailStart);
-	}
-	return `${head}${EVALUATOR_PROMPT_TRUNCATION_MARKER}${tail}`;
-}
+		expect(illFormed).toEqual([]);
+	}, 60_000);
 
-describe("evaluator prompt truncation surrogate safety", () => {
-	test("truncateHeadForPrompt handles emoji at tail boundary cleanly", () => {
-		const fox = "🦊";
-		const input = `${"a".repeat(100)}${fox}${"b".repeat(100)}`;
-		const out = truncateHeadForPromptMock(input, 50);
-		expect(isWellFormed(out)).toBe(true);
-		expect(out.startsWith(EVALUATOR_PROMPT_TRUNCATION_MARKER)).toBe(true);
-		expect(() => JSON.stringify({ prompt: out })).not.toThrow();
-	});
+	it("keeps the rules head and the newest tail of an oversized section", async () => {
+		const body = `HEAD_RULES_SENTINEL${FOX.repeat(
+			EVALUATOR_PROMPT_MAX_CHARS,
+		)}TAIL_CONTEXT_SENTINEL`;
+		const prompt = await sectionPromptFor(body);
+		expect(isWellFormed(prompt)).toBe(true);
+		expect(prompt).toContain("HEAD_RULES_SENTINEL");
+		expect(prompt).toContain("TAIL_CONTEXT_SENTINEL");
+		expect(prompt).toContain(TRUNCATION_MARKER);
+	}, 60_000);
 
-	test("trimHeadAndTailForPrompt handles emoji at head boundary without lone surrogate", () => {
-		const fox = "🦊";
-		const input = `${"a".repeat(10)}${fox}${"b".repeat(100)}`;
-		const out = trimHeadAndTailForPromptMock(input, 60);
-		expect(isWellFormed(out)).toBe(true);
-		expect(out.includes(EVALUATOR_PROMPT_TRUNCATION_MARKER)).toBe(true);
-		expect(() => JSON.stringify({ prompt: out })).not.toThrow();
-	});
+	it("serializes to a provider body with no lone-surrogate escape", async () => {
+		const prompt = await sectionPromptFor(
+			FOX.repeat(EVALUATOR_PROMPT_MAX_CHARS),
+			1,
+		);
+		const serialized = JSON.stringify({ messages: [{ content: prompt }] });
+		expect(/\\ud[89ab][0-9a-f]{2}(?!\\ud[c-f])/i.test(serialized)).toBe(false);
+		expect(JSON.parse(serialized).messages[0].content).toBe(prompt);
+	}, 60_000);
 
-	test("trimHeadAndTailForPrompt handles emoji at tail boundary without lone surrogate", () => {
-		const fox = "🦊";
-		const input = `${"a".repeat(100)}${fox}${"b".repeat(10)}`;
-		const out = trimHeadAndTailForPromptMock(input, 60);
-		expect(isWellFormed(out)).toBe(true);
-		expect(out.includes(EVALUATOR_PROMPT_TRUNCATION_MARKER)).toBe(true);
-		expect(() => JSON.stringify({ prompt: out })).not.toThrow();
-	});
-
-	test("short prompt with emoji passes through untouched", () => {
-		const input = "Short evaluator context with 🦊 emoji";
-		const out = trimHeadAndTailForPromptMock(input, 100);
-		expect(isWellFormed(out)).toBe(true);
-		expect(out).toBe(input);
-	});
-
-	test("sweep offsets for trimHeadAndTailForPrompt all stay well-formed", () => {
-		const fox = "🦊";
-		for (let n = 50; n <= 80; n++) {
-			const input = `${"a".repeat(n)}${fox}${"b".repeat(n)}`;
-			const out = trimHeadAndTailForPromptMock(input, 70);
-			expect(isWellFormed(out)).toBe(true);
-			expect(() => JSON.stringify({ prompt: out })).not.toThrow();
-		}
-	});
+	it("passes a short section through untouched", async () => {
+		const body = `Short evaluator section with ${FOX} emoji`;
+		const prompt = await sectionPromptFor(body);
+		expect(prompt).toContain(body);
+		expect(prompt).not.toContain(TRUNCATION_MARKER);
+		expect(isWellFormed(prompt)).toBe(true);
+	}, 60_000);
 });

--- a/packages/core/src/services/evaluator.surrogate.test.ts
+++ b/packages/core/src/services/evaluator.surrogate.test.ts
@@ -1,25 +1,29 @@
 /**
- * Regression for evaluator service surrogate-safe truncation (500).
+ * Regression for the shared-context tail truncation of the merged evaluator
+ * prompt (`trimTailForPrompt`).
+ *
+ * These cases drive the real `EvaluatorService.run` and inspect the prompt
+ * handed to `useModel`, because that string is what a provider serializes. A
+ * negative slice taken at an arbitrary UTF-16 index can start on the low half
+ * of a surrogate pair; the lone surrogate then serializes as a `\uDCxx` escape
+ * that strict provider JSON parsers reject outright.
+ *
+ * The retained shared budget depends on how the fair-share allocator splits the
+ * remaining characters, so the boundary parity is swept rather than assumed.
  */
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter";
+import { AgentRuntime } from "../runtime";
+import type { Character, Memory } from "../types";
+import { EVALUATOR_PROMPT_MAX_CHARS, EvaluatorService } from "./evaluator";
 
-import { describe, expect, it } from "vitest";
-import {
-	toWellFormedUnicode,
-	truncateWellFormed,
-} from "../utils/well-formed.ts";
-
-const RAW_SECTION_LIMIT = 500;
-
-function clampRawSection(rawSection: unknown): string {
-	const text = typeof rawSection === "string" ? rawSection : JSON.stringify(rawSection) ?? "";
-	const wellFormed = toWellFormedUnicode(text);
-	return truncateWellFormed(wellFormed, RAW_SECTION_LIMIT);
-}
+const FOX = "\u{1F98A}";
+const REPLACEMENT_CHARACTER = "�";
+const TRUNCATION_MARKER = "[... truncated; kept latest tail ...]";
 
 function isWellFormed(value: string): boolean {
-	if (!value) return true;
-	const maybe = value as unknown as { isWellFormed?: () => boolean };
-	if (typeof maybe.isWellFormed === "function") return maybe.isWellFormed();
+	const native = value as unknown as { isWellFormed?: () => boolean };
+	if (typeof native.isWellFormed === "function") return native.isWellFormed();
 	for (let i = 0; i < value.length; i++) {
 		const code = value.charCodeAt(i);
 		if (code >= 0xd800 && code <= 0xdbff) {
@@ -31,52 +35,136 @@ function isWellFormed(value: string): boolean {
 	return true;
 }
 
-describe("evaluator service well-formed", () => {
-	it("backs off astral at 500 boundary (499+fox->499)", () => {
-		const fox = "🦊";
-		const input = `${"a".repeat(499)}${fox}${"b".repeat(20)}`;
-		const out = clampRawSection(input);
-		expect(isWellFormed(out)).toBe(true);
-		expect(out.length).toBe(499);
-		expect(out).toBe("a".repeat(499));
+function makeRuntime(): AgentRuntime {
+	const runtime = new AgentRuntime({
+		character: {
+			name: "EvaluatorSurrogateAgent",
+			bio: "test",
+			settings: {},
+		} as Character,
+		adapter: new InMemoryDatabaseAdapter(),
+		logLevel: "fatal",
 	});
+	runtime.evaluators.length = 0;
+	runtime.composeState = vi.fn(async () => ({
+		values: {},
+		data: {},
+		text: "",
+	}));
+	runtime.emitEvent = vi.fn(async () => {});
+	return runtime;
+}
 
-	it("preserves fitting astral at 500 (498+fox intact)", () => {
-		const fox = "🦊";
-		const input = `${"a".repeat(498)}${fox}`;
-		const out = clampRawSection(input);
-		expect(isWellFormed(out)).toBe(true);
-		expect(out).toBe(input);
-		expect(out.length).toBe(500);
+function makeMessage(text: string): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000001" as Memory["id"],
+		entityId: "00000000-0000-0000-0000-000000000002" as Memory["entityId"],
+		roomId: "00000000-0000-0000-0000-000000000003" as Memory["roomId"],
+		content: { text, source: "test" },
+	} as Memory;
+}
+
+/**
+ * Runs one turn and returns the prompt the model received. `messageText` shifts
+ * the fair-share split by one character per added byte, which is what moves the
+ * shared-context cut across a surrogate boundary.
+ */
+async function promptFor(
+	providerContext: string,
+	messageText = "hi",
+): Promise<string> {
+	const runtime = makeRuntime();
+	runtime.registerEvaluator({
+		name: "alpha",
+		description: "alpha section",
+		schema: {
+			type: "object",
+			properties: { ok: { type: "boolean" } },
+			required: ["ok"],
+		},
+		shouldRun: async () => true,
+		prompt: () => "Extract alpha.",
+		parse: (output) => output as never,
+		processors: [
+			{ name: "storeAlpha", process: async () => ({ success: true }) },
+		],
 	});
+	let captured: string | undefined;
+	runtime.useModel = vi.fn(async (_modelType, params) => {
+		captured = String(params.messages?.[0]?.content ?? "");
+		return { alpha: { ok: true } };
+	}) as AgentRuntime["useModel"];
+	const result = await new EvaluatorService(runtime).run(
+		makeMessage(messageText),
+		{ values: {}, data: {}, text: providerContext },
+	);
+	expect(result.errors).toEqual([]);
+	expect(captured).toBeDefined();
+	return captured as string;
+}
 
-	it("sanitizes lone high surrogate", () => {
-		const lone = `raw ${String.fromCharCode(0xd800)} section`;
-		const out = clampRawSection(`${lone}${"x".repeat(600)}`);
-		expect(isWellFormed(out)).toBe(true);
-		expect(out.includes("�")).toBe(true);
-	});
-
-	it("short passthrough", () => {
-		const out = clampRawSection("short section");
-		expect(out).toBe("short section");
-		expect(isWellFormed(out)).toBe(true);
-	});
-
-	it("stringifies object then clamps well-formed", () => {
-		const obj = { text: `a${"🦊".repeat(300)}` };
-		const out = clampRawSection(obj);
-		expect(isWellFormed(out)).toBe(true);
-		expect(out.length).toBeLessThanOrEqual(500);
-	});
-
-	it("sweep around 500 well-formed", () => {
-		const fox = "🦊";
-		for (let n = 495; n <= 505; n++) {
-			const input = `${"x".repeat(n)}${fox}${"y".repeat(20)}`;
-			const out = clampRawSection(input);
-			expect(isWellFormed(out)).toBe(true);
-			expect(out.length).toBeLessThanOrEqual(500);
+describe("evaluator shared-context tail truncation is surrogate-safe", () => {
+	it("never emits a lone surrogate across shared-budget parities", async () => {
+		const context = FOX.repeat(EVALUATOR_PROMPT_MAX_CHARS);
+		const illFormed: number[] = [];
+		for (let pad = 0; pad < 8; pad++) {
+			const prompt = await promptFor(context, `hi${"!".repeat(pad)}`);
+			expect(prompt).toContain(TRUNCATION_MARKER);
+			expect(prompt.length).toBeLessThanOrEqual(EVALUATOR_PROMPT_MAX_CHARS);
+			if (!isWellFormed(prompt)) illFormed.push(pad);
 		}
-	});
+		expect(illFormed).toEqual([]);
+	}, 60_000);
+
+	it("serializes to a provider body with no lone-surrogate escape", async () => {
+		const prompt = await promptFor(
+			FOX.repeat(EVALUATOR_PROMPT_MAX_CHARS),
+			"hi!",
+		);
+		const body = JSON.stringify({ messages: [{ content: prompt }] });
+		expect(/\\ud[89ab][0-9a-f]{2}(?!\\ud[c-f])/i.test(body)).toBe(false);
+		expect(JSON.parse(body).messages[0].content).toBe(prompt);
+	}, 60_000);
+
+	it("sanitizes a pre-existing lone surrogate instead of forwarding it", async () => {
+		const lone = String.fromCharCode(0xd83d);
+		const prompt = await promptFor(
+			`${lone}TAIL_SENTINEL${"z".repeat(EVALUATOR_PROMPT_MAX_CHARS)}${lone}END`,
+		);
+		expect(isWellFormed(prompt)).toBe(true);
+		expect(prompt).toContain(`${REPLACEMENT_CHARACTER}END`);
+	}, 60_000);
+
+	it("keeps ASCII shared context byte-identical to a plain tail slice", async () => {
+		// No over-rejection: for input the live path already accepts, the
+		// retained window must be exactly the trailing characters, unmodified.
+		const context = Array.from(
+			{ length: EVALUATOR_PROMPT_MAX_CHARS },
+			(_unused, index) => String.fromCharCode(0x41 + (index % 26)),
+		).join("");
+		const prompt = await promptFor(context);
+		expect(prompt).not.toContain(REPLACEMENT_CHARACTER);
+		const markerAt = prompt.indexOf(TRUNCATION_MARKER);
+		expect(markerAt).toBeGreaterThan(-1);
+		const sectionStart = prompt.indexOf("Provider context:\n");
+		expect(sectionStart).toBeGreaterThan(-1);
+		const sectionEnd = prompt.indexOf("\n\n## Active Evaluators");
+		expect(sectionEnd).toBeGreaterThan(sectionStart);
+		const rendered = prompt
+			.slice(sectionStart + "Provider context:\n".length, sectionEnd)
+			.replace(/\n+$/, "");
+		const retained = rendered.slice(
+			rendered.lastIndexOf(TRUNCATION_MARKER) + TRUNCATION_MARKER.length + 1,
+		);
+		expect(retained.length).toBeGreaterThan(1000);
+		expect(context.endsWith(retained)).toBe(true);
+	}, 60_000);
+
+	it("passes short well-formed context through untouched", async () => {
+		const context = `short evaluator context with ${FOX} emoji`;
+		const prompt = await promptFor(context);
+		expect(prompt).toContain(context);
+		expect(prompt).not.toContain(TRUNCATION_MARKER);
+		expect(isWellFormed(prompt)).toBe(true);
+	}, 60_000);
 });

--- a/packages/core/src/services/evaluator.ts
+++ b/packages/core/src/services/evaluator.ts
@@ -32,6 +32,7 @@ import { Service as BaseService } from "../types/service.ts";
 import { formatActionResultsForPrompt } from "../utils/action-results.ts";
 import { isObjectRecord as isRecord } from "../utils/type-guards.ts";
 import {
+	tailWellFormed,
 	toWellFormedUnicode,
 	truncateWellFormed,
 } from "../utils/well-formed.ts";
@@ -119,14 +120,25 @@ type BoundedPrompt = {
 	originalSectionChars: Record<string, number>;
 };
 
+/**
+ * Keeps the newest `maxChars` of `text` for the prompt. The cut is taken with
+ * {@link tailWellFormed} and the input is sanitized with
+ * {@link toWellFormedUnicode} first: a raw negative slice can start on the low
+ * half of a surrogate pair, and the resulting lone surrogate travels into the
+ * merged evaluator prompt and out to the model provider, where strict JSON
+ * parsers reject the request body outright. This mirrors the boundary handling
+ * {@link trimHeadAndTailForPrompt} already performs.
+ */
 function trimTailForPrompt(text: string, maxChars: number): string {
 	if (maxChars <= 0) return "";
-	if (text.length <= maxChars) return text;
+	const wellFormed = toWellFormedUnicode(text);
+	if (wellFormed.length <= maxChars) return wellFormed;
 	if (maxChars <= EVALUATOR_PROMPT_TRUNCATION_MARKER.length) {
 		return EVALUATOR_PROMPT_TRUNCATION_MARKER.slice(0, maxChars);
 	}
-	return `${EVALUATOR_PROMPT_TRUNCATION_MARKER}${text.slice(
-		-(maxChars - EVALUATOR_PROMPT_TRUNCATION_MARKER.length),
+	return `${EVALUATOR_PROMPT_TRUNCATION_MARKER}${tailWellFormed(
+		wellFormed,
+		maxChars - EVALUATOR_PROMPT_TRUNCATION_MARKER.length,
 	)}`;
 }
 
@@ -141,20 +153,7 @@ function trimHeadAndTailForPrompt(text: string, maxChars: number): string {
 	const headBudget = Math.ceil(contentBudget / 3);
 	const tailBudget = contentBudget - headBudget;
 	const head = truncateWellFormed(wellFormed, headBudget);
-	let tail = "";
-	if (tailBudget > 0) {
-		let tailStart = wellFormed.length - tailBudget;
-		if (
-			tailStart > 0 &&
-			wellFormed.charCodeAt(tailStart - 1) >= 0xd800 &&
-			wellFormed.charCodeAt(tailStart - 1) <= 0xdbff &&
-			wellFormed.charCodeAt(tailStart) >= 0xdc00 &&
-			wellFormed.charCodeAt(tailStart) <= 0xdfff
-		) {
-			tailStart += 1;
-		}
-		tail = wellFormed.slice(tailStart);
-	}
+	const tail = tailWellFormed(wellFormed, tailBudget);
 	return `${head}${EVALUATOR_PROMPT_TRUNCATION_MARKER}${tail}`;
 }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #23848 (owning issue, filed for this head, carrying the origin
reproduction verbatim).

Context — this is a **successor** to two merged PRs on this same file, not a
twin of either. #23649 (byt61) fixed the `rawSection` diagnostic at
`evaluator.ts:806`; #23703 (byt61) fixed `trimHeadAndTailForPrompt` at
`evaluator.ts:133`. Neither touched `trimTailForPrompt` eleven lines above,
which is what this PR fixes. `gh search prs "trimTailForPrompt"` returns 0
results and no open PR touches `packages/core/src/services/evaluator.ts`
(checked at filing time).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched off the latest `origin/develop`
      (`2271e3b78750e19045a0b83c541d52da34d72158`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched off `origin/develop` @ `2271e3b78750e19045a0b83c541d52da34d72158`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low, and the one risk axis — over-rejection — is settled by execution rather
than by argument.

One production helper changes behaviour. A differential digest sweep against the
verbatim pre-fix body, over nine end-to-end prompt builds covering ASCII and
BMP-only text (truncated and untruncated, shared-context and evaluator-section
paths), produced **9 of 9 identical SHA-256 digests**. There is no input without
an astral character straddling the cut for which this change alters a single
byte.

The second hunk is a pure dedup: `trimHeadAndTailForPrompt`'s hand-rolled tail
back-off — merged in #23703 — is replaced by the repository's existing
`tailWellFormed`, which implements exactly that back-off. It is included so the
two helpers in this file cannot drift apart again, and it is pinned by tests
here rather than left unverified.

# Background

## What does this PR do?

`trimTailForPrompt` (`packages/core/src/services/evaluator.ts:122`) keeps the
newest `maxChars` of a shared-context section with a raw negative slice:

```ts
return `${EVALUATOR_PROMPT_TRUNCATION_MARKER}${text.slice(
	-(maxChars - EVALUATOR_PROMPT_TRUNCATION_MARKER.length),
)}`;
```

When that cut lands between the two halves of a surrogate pair, the retained
tail begins with a **lone low surrogate**, and it travels into the merged
evaluator prompt that `EvaluatorService.run` hands to `useModel`.

The sibling helper eleven lines below, `trimHeadAndTailForPrompt`
(`evaluator.ts:133`), already sanitizes its input with `toWellFormedUnicode`
**and** backs its tail cut off a split pair — so the gap is an omission, not a
deliberate difference. This PR routes `trimTailForPrompt` through the same
existing helpers (`toWellFormedUnicode` + `tailWellFormed`), and replaces the
hand-rolled back-off in the sibling with `tailWellFormed` so both cuts are the
one implementation.

No new truncator is introduced.

## Impact

`packages/core/src/utils/well-formed.ts` documents the consequence in its own
header: a lone surrogate `JSON.stringify`s to a `\uD8xx`/`\uDCxx` escape that
strict provider JSON parsers reject with HTTP 400 (`wrong_api_format`). Only
`plugins/plugin-anthropic` and `plugins/plugin-openai` call
`deepToWellFormedUnicode` on the outbound body
(`grep -rl deepToWellFormedUnicode plugins`); every other model plugin forwards
the prompt as received. So depending on the configured provider, a post-turn
evaluation whose shared context is oversized either fails the request outright
or silently ships a corrupted context to the model.

## Reach

- `evaluator.ts:212` — `renderSharedContext`'s `part()` helper, applied to
  `latestMessage`, `responseTexts`, `actionResults` and `providerContext`. All
  four are model- or user-derived text, and truncation fires on any turn whose
  shared context exceeds its fair-share budget.
- `evaluator.ts:1033` — the defensive whole-prompt clamp against
  `EVALUATOR_PROMPT_MAX_CHARS`.

## Why nothing caught it

Both merged surrogate suites for this module are **inert** — neither imports
`./evaluator`:

```
$ grep -c "\./evaluator" packages/core/src/services/evaluator.surrogate.test.ts
0
$ grep -c "\./evaluator" packages/core/src/services/evaluator.middle-surrogate.test.ts
0
```

`evaluator.surrogate.test.ts` asserts against a local `clampRawSection` with a
500-character limit. `evaluator.middle-surrogate.test.ts` asserts against local
mocks, one of which (`truncateHeadForPromptMock`) models a
`truncateHeadForPrompt` that does not exist in the module, using a truncation
marker (`"\n...[truncated]...\n"`) that does not match the real one
(`"\n[... truncated; kept latest tail ...]\n"`).

Mutation proves it rather than asserting it: with three guards stripped out of
the *already-correct* `trimHeadAndTailForPrompt` on develop, both merged suites
still reported **11/11 passing — 0 of 3 mutations killed** (transcript in the
domain receipt). The same mutant fails 4 tests in the rewritten suites.

Both files are rewritten here to drive the real `EvaluatorService.run` and
assert on the string handed to `useModel`, which is the value a provider
serializes.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The new helper
docstring in the diff records why the cut must go through the well-formed
helpers.

# Testing

## Where should a reviewer start?

`packages/core/src/services/evaluator.surrogate.test.ts` — 5 tests, all against
the real `EvaluatorService`:

1. an eight-parity sweep of the fair-share split: the assembled prompt is never
   ill-formed (this is the origin reproduction, inverted);
2. the prompt serializes into a provider body with no lone-surrogate escape and
   round-trips through `JSON.parse`;
3. a pre-existing lone surrogate in the shared context is sanitized to U+FFFD
   rather than forwarded;
4. **compatibility** — for oversized ASCII context the retained window is
   exactly the trailing characters of the input, unmodified, with no U+FFFD;
5. short well-formed context passes through untouched with no marker.

`packages/core/src/services/evaluator.middle-surrogate.test.ts` — 4 tests
covering the evaluator-section head-and-tail path the same way (parity sweep,
head/tail sentinels both retained, provider-body serialization, short
passthrough).

## Detailed testing steps

```
git checkout fix/evaluator-prompt-tail-surrogate
bun install --frozen-lockfile
(cd packages/core && node ../shared/scripts/generate-keywords.mjs)
bunx vitest run --root packages/core \
  src/services/evaluator.surrogate.test.ts \
  src/services/evaluator.middle-surrogate.test.ts \
  src/services/evaluator.test.ts
bunx vitest run --root packages/core src/services
bun run --cwd packages/core typecheck
bunx @biomejs/biome check packages/core/src/services/evaluator.ts \
  packages/core/src/services/evaluator.surrogate.test.ts \
  packages/core/src/services/evaluator.middle-surrogate.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:f53032936729376c4ce09642163df1ec519a8048 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - core service module and its unit tests; no rendered UI surface in the diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - core service module and its unit tests; no rendered UI surface in the diff.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.

<!-- evidence-row:backend-logs -->
- [x] The ill-formed prompt as it leaves `EvaluatorService.run`, captured on unmodified `origin/develop` @ `2271e3b78750e19045a0b83c541d52da34d72158`. A probe registers a real evaluator, stubs `useModel`, and sweeps the fair-share split one character at a time so the tail cut walks across a surrogate boundary:

```text
n 0 len 119986 wf true
n 1 len 119986 wf false
n 2 len 119986 wf true
n 3 len 119986 wf false
n 4 len 119986 wf true
n 5 len 119986 wf false
n 6 len 119986 wf true
n 7 len 119986 wf false

AssertionError: expected [ 1, 3, 5, 7 ] to deeply equal []
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

`wf` is `String.prototype.isWellFormed()` on the exact string passed to
`useModel`. Half of the budget parities emit a lone surrogate into the model
request.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend console or network path in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt semantics, or model behavior changed. This fixes where an already-assembled prompt is *cut*; a real LLM call would not distinguish the two bodies, because the defect needs an astral character straddling one specific budget offset. The deterministic parity sweep above is the honest instrument, and it runs the real `EvaluatorService.run` with a real registered evaluator and a real `AgentRuntime` + `InMemoryDatabaseAdapter`.

<!-- evidence-row:domain-artifacts -->
- [x] Origin reproduction, inertness proven by grep-count and by mutation, load-bearing revert by copy-aside, differential no-over-rejection sweep, focused suite, package-subtree suite, typecheck, and lint at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
head: f53032936729376c4ce09642163df1ec519a8048
base: 2271e3b78750e19045a0b83c541d52da34d72158 (origin/develop; the reproduction
      ran on this same base, unmodified)

=== 1. ORIGIN REPRODUCTION — LIVE PATH ===

Probe src/services/zz-probe-eval.test.ts (removed before commit). It builds a
real AgentRuntime + InMemoryDatabaseAdapter, registers one evaluator, stubs
useModel to capture params.messages[0].content, and runs:

  state.text = "\u{1F98A}".repeat(EVALUATOR_PROMPT_MAX_CHARS)
  message.content.text = "hi" + "!".repeat(n)     for n in 0..7

$ cd packages/core && ../../node_modules/.bin/vitest run \
    src/services/zz-probe-eval.test.ts --reporter=verbose
n 0 len 119986 wf true
n 1 len 119986 wf false
n 2 len 119986 wf true
n 3 len 119986 wf false
n 4 len 119986 wf true
n 5 len 119986 wf false
n 6 len 119986 wf true
n 7 len 119986 wf false
   -> expected [ 1, 3, 5, 7 ] to deeply equal []
 Test Files  1 failed (1)
      Tests  1 failed (1)

The message text shifts the fair-share allocation by one character, which flips
the parity of the tail cut. Half the parities are ill-formed.

Same probe after the fix:
n 0 len 119986 wf true
n 1 len 119985 wf true
n 2 len 119986 wf true
n 3 len 119985 wf true
n 4 len 119986 wf true
n 5 len 119985 wf true
n 6 len 119986 wf true
n 7 len 119985 wf true
 Test Files  1 passed (1)

The odd parities lose exactly one code unit — the back-off — and nothing else.

=== 2. THE MERGED SURROGATE SUITES WERE INERT — PROVEN TWICE ===

(a) grep-count on the develop versions:

$ git show origin/develop:packages/core/src/services/evaluator.surrogate.test.ts \
    | grep -c "\./evaluator"
0
$ git show origin/develop:packages/core/src/services/evaluator.middle-surrogate.test.ts \
    | grep -c "\./evaluator"
0

Both import only "../utils/well-formed.ts". evaluator.surrogate.test.ts asserts
a local clampRawSection with a 500-char limit; evaluator.middle-surrogate.test.ts
declares two local re-implementations, one of them shaped around a
`truncateHeadForPrompt` that does not exist in evaluator.ts, with the marker "\n...[truncated]...\n" instead
of the real "\n[... truncated; kept latest tail ...]\n".

(b) mutation. On the ORIGIN evaluator.ts, three guards were stripped out of the
already-correct trimHeadAndTailForPrompt:
   M1  const wellFormed = toWellFormedUnicode(text)  ->  = text
   M2  truncateWellFormed(wellFormed, headBudget)    ->  wellFormed.slice(0, headBudget)
   M3  the tail surrogate back-off block             ->  wellFormed.slice(len - tailBudget)

$ ../../node_modules/.bin/vitest run \
    src/services/evaluator.surrogate.test.ts \
    src/services/evaluator.middle-surrogate.test.ts     # the MERGED versions
 Test Files  2 passed (2)
      Tests  11 passed (11)

0 of 3 mutations killed. The same mutant against the REWRITTEN suites:

     x never emits a lone surrogate at either cut across parities
     x keeps the rules head and the newest tail of an oversized section
     x never emits a lone surrogate across shared-budget parities
     x sanitizes a pre-existing lone surrogate instead of forwarding it
 Test Files  2 failed (2)
      Tests  4 failed | 5 passed (9)

3 of 3 killed. (Mutations reverted; the committed tree contains none of them.)

=== 3. LOAD-BEARING REVERT CHECK (copy-aside; `git stash` never used) ===

evaluator.ts restored to the develop body byte-for-byte, both rewritten test
files kept:

 FAIL evaluator.surrogate.test.ts > never emits a lone surrogate across shared-budget parities
      AssertionError: expected [ 1, 3, 5, 7 ] to deeply equal []
 FAIL evaluator.surrogate.test.ts > sanitizes a pre-existing lone surrogate instead of forwarding it
      AssertionError: expected false to be true
 Test Files  1 failed | 1 passed (2)
      Tests  2 failed | 7 passed (9)

Fix restored:
 Test Files  2 passed (2)
      Tests  9 passed (9)

Stated plainly: evaluator.middle-surrogate.test.ts PASSES against the origin
body, because the head-and-tail helper it covers was already correct (#23703).
It is not load-bearing for the production defect; it pins the tailWellFormed
dedup and replaces a local re-implementation of a function that does not exist
in the module. The load-bearing
half is evaluator.surrogate.test.ts, 2 of 5 tests.

=== 4. NO OVER-REJECTION — DIFFERENTIAL DIGEST SWEEP ===

A probe (removed before commit) builds nine end-to-end prompts and prints the
SHA-256 of the exact string handed to useModel: oversized ASCII shared context
at three fair-share parities, oversized BMP-only shared context at two, an
oversized ASCII evaluator section, an oversized BMP-only evaluator section, and
a short ASCII and a short accented-Latin context. The BMP corpus cycles
U+00E9 U+03B1 U+0416 U+4E2D U+20AC (accented Latin, Greek, Cyrillic, CJK, euro).

FIXED body:
COMPAT ascii-oversized-shared        len=119986 sha256=04922758fa50a3c12d32d2a292196068108aea2befbd6dbb0cc828f00c0c2eca
COMPAT ascii-oversized-shared-pad1   len=119986 sha256=46cebdec15735019ff4681151e6ebe28e38d79ec8db86ae5a04e8bd704910ea0
COMPAT ascii-oversized-shared-pad2   len=119986 sha256=e192b9744825d8e687846c36d3a141d66115e0fd8dcddbe291bc29ef51d7e8ac
COMPAT bmp-oversized-shared          len=119986 sha256=8655b13cf8baff522103a16bf948f288206295e3746244908740e725410482b1
COMPAT bmp-oversized-shared-pad1     len=119986 sha256=a4fd5b5e90fd76c89002d2efe929bd4a883384c9f4c3bcd6c7b5da2a9d073172
COMPAT ascii-oversized-section       len=119986 sha256=ec87ffc9a87a9a4d0ad3cdec8007704131f9973a458a54a830c9dababfc37504
COMPAT bmp-oversized-section         len=119986 sha256=f0435460b8a77f0fba6f3d1d9469b235d2b5c73cdab236ba924611c60a017873
COMPAT ascii-short                   len=722    sha256=c8f0f5994bbf3dc14f08774f49c1065905f04cfaeecae33a7714709a1f03a65b
COMPAT bmp-short                     len=731    sha256=beaf1d9778d7fd2595c5249cc5827ef139b8e6fad197e17ea62d8df1b4c0755d

ORIGIN body (same probe, verbatim develop evaluator.ts):
COMPAT ascii-oversized-shared        len=119986 sha256=04922758fa50a3c12d32d2a292196068108aea2befbd6dbb0cc828f00c0c2eca
COMPAT ascii-oversized-shared-pad1   len=119986 sha256=46cebdec15735019ff4681151e6ebe28e38d79ec8db86ae5a04e8bd704910ea0
COMPAT ascii-oversized-shared-pad2   len=119986 sha256=e192b9744825d8e687846c36d3a141d66115e0fd8dcddbe291bc29ef51d7e8ac
COMPAT bmp-oversized-shared          len=119986 sha256=8655b13cf8baff522103a16bf948f288206295e3746244908740e725410482b1
COMPAT bmp-oversized-shared-pad1     len=119986 sha256=a4fd5b5e90fd76c89002d2efe929bd4a883384c9f4c3bcd6c7b5da2a9d073172
COMPAT ascii-oversized-section       len=119986 sha256=ec87ffc9a87a9a4d0ad3cdec8007704131f9973a458a54a830c9dababfc37504
COMPAT bmp-oversized-section         len=119986 sha256=f0435460b8a77f0fba6f3d1d9469b235d2b5c73cdab236ba924611c60a017873
COMPAT ascii-short                   len=722    sha256=c8f0f5994bbf3dc14f08774f49c1065905f04cfaeecae33a7714709a1f03a65b
COMPAT bmp-short                     len=731    sha256=beaf1d9778d7fd2595c5249cc5827ef139b8e6fad197e17ea62d8df1b4c0755d

9 of 9 digests identical. Not a single byte moves for input with no astral
character straddling the cut.

=== 5. FOCUSED SUITE AT THIS HEAD ===

$ cd packages/core && ../../node_modules/.bin/vitest run \
    src/services/evaluator.surrogate.test.ts \
    src/services/evaluator.middle-surrogate.test.ts \
    src/services/evaluator.test.ts
 Test Files  3 passed (3)
      Tests  23 passed (23)
exit 0

That includes the pre-existing src/services/evaluator.test.ts (14 tests), which
covers the bounded-prompt assembly this change sits inside.

=== 6. PACKAGE SUBTREE SUITE ===

$ cd packages/core && ../../node_modules/.bin/vitest run src/services
 Test Files  1 failed | 69 passed (70)
      Tests  1110 passed | 191 skipped (1301)

The one failing FILE is src/services/message.side-effect-claim.test.ts, which
never imports evaluator. It fails at pglite bootstrap:

 FAIL src/services/message.side-effect-claim.test.ts
 TypeError: Cannot read properties of undefined (reading 'cleanup')
  ../../plugins/plugin-sql/src/index.node.ts:261:1
  createTestRuntime src/testing/pglite-runtime.ts:147:27

Control — the same file, run alone, with evaluator.ts restored to the develop
body byte-for-byte in the same tree:

 Test Files  1 failed (1)
      Tests  191 skipped (191)

Identical failure with none of this PR's production code present. It is a local
pglite/plugin-sql bootstrap problem in this checkout, not a regression, and it
is not fixed here.

=== 7. TYPECHECK ===

$ bun run --cwd packages/core typecheck
exit 0   (zero diagnostics)

packages/core typechecks completely clean at this head, so "adds zero errors" is
exact rather than a control diff: the branch total is 0.

=== 8. LINT ===

$ ./node_modules/.bin/biome check \
    packages/core/src/services/evaluator.ts \
    packages/core/src/services/evaluator.surrogate.test.ts \
    packages/core/src/services/evaluator.middle-surrogate.test.ts
Checked 3 files in 16ms. No fixes applied.
exit 0

=== 9. DIFF SHAPE ===

$ git diff --stat origin/develop...HEAD
 .../services/evaluator.middle-surrogate.test.ts    | 223 ++++++++++++---------
 .../core/src/services/evaluator.surrogate.test.ts  | 204 +++++++++++++------
 packages/core/src/services/evaluator.ts            |  33 ++-
 3 files changed, 290 insertions(+), 170 deletions(-)

Production change: one file, two helpers, 33 lines of which 8 are the new
docstring and 13 are the deleted hand-rolled back-off replaced by one call.

=== 10. NON-TWIN CHECK (run at filing time) ===

$ gh search prs --repo elizaOS/eliza "trimTailForPrompt"
(no results)
$ gh pr list --repo elizaOS/eliza --state open --author byt61
(no results)

Merged neighbours on this file, both by byt61, both leaving trimTailForPrompt
raw (diffs read, not assumed):
  #23649  rawSection diagnostic at evaluator.ts:806
  #23703  trimHeadAndTailForPrompt at evaluator.ts:133 (+ the inert
          evaluator.middle-surrogate.test.ts this PR rewrites)
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt semantics, or model behavior changed.
A live LLM call cannot serve as evidence here: the defect requires an astral
character to straddle one specific budget offset, so a real call would pass or
fail by luck. The deterministic parity sweep in the domain receipt is the honest
instrument, and it drives the real `EvaluatorService.run` against a real
`AgentRuntime` + `InMemoryDatabaseAdapter` with a real registered evaluator —
only the model call itself is stubbed, because the prompt handed to it *is* the
value under test.

## Backend + frontend logs

Backend: sections 1 and 4 of the domain receipt are the real code path — the
real evaluator service assembling the real prompt, first on unmodified
`develop` and then at this head.

Frontend: N/A - no browser hop in this unit.

## Screenshots (before / after) + video walkthrough

N/A - core service module and its unit tests; no rendered UI surface in the diff.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

- Root `bun run verify` was **not** run on this head. It is a monorepo-wide gate
  this tree cannot complete in a bounded time; the subtree suite in section 6,
  a clean `packages/core` typecheck, and lint are the proof offered instead.
- `packages/core`'s full suite was not run to completion. The `src/services`
  subtree, which contains the changed module and its consumers inside this
  package, was run in full.
- `evaluator.middle-surrogate.test.ts` passes against the pre-fix body and is
  therefore **not** load-bearing for the production defect — stated in section 3
  so its inclusion is not read as more than it is. It pins the `tailWellFormed`
  dedup and replaces a mock of a `truncateHeadForPrompt` that does not exist.
- The whole-prompt clamp at `evaluator.ts:1033` shares the fixed helper but is
  not driven end-to-end by a test: reaching it requires a base prompt over
  120 000 characters, which needs an absurd agent name or evaluator name and
  would be a contrived fixture. It is covered transitively by the helper, not by
  a dedicated case, and that is named here rather than implied.
- The claim that non-sanitizing providers reject the body with HTTP 400 is taken
  from `packages/core/src/utils/well-formed.ts`'s own header (Cerebras/serde,
  `wrong_api_format`); it was not reproduced against a live provider here. What
  *was* executed is that the ill-formed string reaches `useModel`, and that only
  `plugin-anthropic` and `plugin-openai` sanitize before the wire.
- Hosted CI check-runs: none on this head. Fork branches on this repository do
  not schedule check-runs; that is repo steady state, not a skipped gate.
- Fork cannot upload `pr-evidence` release assets, so the domain receipt is
  inline.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-eval-tail]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JHNCDZ6YZM2VQPR4H50AQV","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T16:15:01.567Z","completed_at":"2026-08-21T16:16:41.434Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T16:15:03.084Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"5467bfe701a96fac890f465d92c5da123affc4ea7f9f4ce6514a7c945c36c928","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"02a6096d-54a3-4397-8290-b247a8f815d1","object_id":"sha256:5467bfe701a96fac890f465d92c5da123affc4ea7f9f4ce6514a7c945c36c928","sha256":"5467bfe701a96fac890f465d92c5da123affc4ea7f9f4ce6514a7c945c36c928"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"a4QiTGQWE5vMuZU3FEx8n-0_I9ZNsi3K5YU-Td5MzC5sDq7zbVFTP_Vdre8pqbfxf0psLYvVPjdalmht5cZMDA"}} -->
