### PR TITLE
fix(telegram): persist delivered reaction text

### DIFF
--- a/plugins/plugin-telegram/src/messageManager.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.test.ts
@@ -9,7 +9,12 @@
  * carry `telegram-file:<file_id>`, the token-bearing Bot API URL stays inside
  * the fetch path, and model handlers receive bytes, never the URL.
  */
-import { type IAgentRuntime, logger } from "@elizaos/core";
+import {
+  type Content,
+  type IAgentRuntime,
+  logger,
+  type Memory,
+} from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { MediaType, MessageManager } from "./messageManager";
 
@@ -86,7 +91,7 @@ async function captureReactionCallback() {
 
   expect(emitEvent).toHaveBeenCalledTimes(2);
   const payload = emitEvent.mock.calls[0]?.[1] as
-    | { callback?: (content: { text?: string }) => Promise<unknown> }
+    | { callback?: (content: Content) => Promise<Memory[]> }
     | undefined;
   expect(payload?.callback).toBeTypeOf("function");
   if (!payload?.callback) {
@@ -541,11 +546,15 @@ describe("MessageManager malformed payload handling", () => {
       "a".repeat(4095),
     ],
   ])(
-    "normalizes the reaction callback wire reply for %s",
+    "keeps the reaction callback wire reply and returned memory aligned for %s",
     async (_label, input, expected) => {
       const { callback, reply } = await captureReactionCallback();
 
-      await callback({ text: input });
+      const memories = await callback({
+        text: input,
+        action: "REPLY",
+        data: { marker: "preserved" },
+      });
 
       expect(reply).toHaveBeenCalledTimes(1);
       const wireText = reply.mock.calls[0]?.[0];
@@ -554,6 +563,16 @@ describe("MessageManager malformed payload handling", () => {
       expect(wireText).toBe(expected);
       expect(wireText?.length).toBeLessThanOrEqual(4096);
       expect(wireText?.isWellFormed()).toBe(true);
+
+      expect(memories).toHaveLength(1);
+      const memoryContent = memories[0]?.content;
+      expect(memoryContent?.text).toBe(wireText);
+      expect(memoryContent?.text?.length).toBeLessThanOrEqual(4096);
+      expect(memoryContent?.text?.isWellFormed()).toBe(true);
+      expect(memoryContent?.action).toBe("REPLY");
+      expect(memoryContent?.data).toEqual({ marker: "preserved" });
+      expect(memoryContent?.inReplyTo).toBeDefined();
+      expect(memoryContent?.metadata).toEqual({ accountId: "default" });
     },
   );
 

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -2338,6 +2338,7 @@ export class MessageManager {
             roomId,
             content: {
               ...content,
+              text: sentMessage.text,
               inReplyTo: reactionId,
               metadata: { accountId: this.accountId },
             },


### PR DESCRIPTION
# Relates to

Closes #23839.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop@c11c55961c6b945d4f1b22f3d3eb22af6836f91a` with zero conflicts.
- [x] Installed the pinned Bun 1.3.14 dependency closure with lifecycle scripts disabled, then ran the owning package's full test, typecheck, lint, and build gates on the rebased head.
- [x] The production-path table and mutation receipt below let a reviewer verify the behavior without inferring it from the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c11c55961c6b945d4f1b22f3d3eb22af6836f91a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@c11c55961c6b945d4f1b22f3d3eb22af6836f91a`; zero conflicts.
- [ ] Root `bun run verify` was not run in the manifest-only sparse worktree. The complete owning-package matrix and the exact bounded gap are recorded below.

# Risks

Low. One production field now records the authoritative text returned by Telegram instead of the pre-wire input. Existing action/data fields, reply linkage, and account metadata are preserved and asserted. No routing, chunking, command, navigation, credential, or network behavior changes.

# Background

## What does this PR do?

#23818 correctly normalized and bounded reaction-callback text before `ctx.reply`, but the callback's returned `Memory` still spread the original `content.text`. The visible message and durable delivery record therefore diverged for every malformed or truncated input:

- a 4,097-unit response stored the unsent 4,097th unit;
- an astral character crossing the cap stored the unsent emoji and tail;
- lone surrogates remained malformed in memory after Telegram received the replacement character.

Other Telegram persistence paths already write `sentMessage.text`. This follow-up applies the same rule to reaction callbacks and strengthens the existing five-row production-path table so every row asserts wire/memory equality, the 4,096-unit ceiling, well-formed Unicode, and preservation of non-text content/linkage metadata.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores the existing delivery-memory contract and adds no option or user-facing workflow.

# Testing

## Where should a reviewer start?

`plugins/plugin-telegram/src/messageManager.test.ts`, in the five-row reaction callback table, then the single `text: sentMessage.text` assignment in `messageManager.ts`.

## Detailed testing steps

Pinned runtime and install:

```text
bun 1.3.14
bun install --frozen-lockfile --ignore-scripts --filter @elizaos/plugin-telegram
```

Exact rebased head `fb2dd0bd655fe9096b90be425ebd6c9eadd3a2e8`:

```text
$ bun run --cwd plugins/plugin-telegram test
Test Files  24 passed (24)
Tests       244 passed (244)

$ bun run --cwd plugins/plugin-telegram test -- src/messageManager.test.ts
Test Files  1 passed (1)
Tests       33 passed (33)

$ bun run --cwd plugins/plugin-telegram typecheck
$ tsc --noEmit -p tsconfig.json
# exit 0

$ bun run --cwd plugins/plugin-telegram lint:check
Checked 62 files in 84ms. No fixes applied.

$ bun run --cwd plugins/plugin-telegram build
ESM build success; declaration emit exit 0.

$ git diff --check origin/develop...HEAD
# exit 0
```

### Load-bearing mutation

I temporarily removed only `text: sentMessage.text` while leaving the new tests in place:

```text
Test Files  1 failed (1)
Tests       4 failed | 29 passed (33)

failed rows:
- lone high surrogate
- lone low surrogate
- 4097-unit text
- astral character crossing the cap
```

The exact-cap row stayed green because no transformation is required. Restoring the production line returned the focused suite to 33/33 and the full package to 244/244.

# Evidence Gate

<!-- evidence-head:fb2dd0bd655fe9096b90be425ebd6c9eadd3a2e8 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - headless Telegram connector callback; no rendered UI surface changes.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - headless Telegram connector callback; no rendered UI surface changes.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no visual flow. The observable output is the wire argument and returned Memory, asserted together in the production-path test.`
<!-- evidence-row:backend-logs -->
- [x] Full/focused Vitest, mutation, typecheck, lint, and build receipts are pasted in Testing above.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend code or browser request changes.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model, prompt, action-selection, or provider behavior changes; the callback receives already-produced content.`
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact is the returned `Memory`: all five rows assert `memory.content.text === ctx.reply argument`, bounded/well-formed text, retained action/data, reply linkage, and account metadata.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no visual text surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - this is a deterministic post-generation Telegram delivery boundary. A live model call would not exercise additional behavior.`

## Backend + frontend logs

Backend receipts are inline in **Testing**. Frontend is N/A.

## Screenshots (before / after) + video walkthrough

N/A - no rendered surface.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT path.

## Known gaps / failures

- Root `bun run verify` was not run because this implementation deliberately used a manifest-only sparse worktree to avoid materializing the repository's entire dependency surface. The owning Telegram package's full tests, typecheck, read-only lint, and build all passed after the final rebase.
- No live Telegram credential was used. The test invokes the real callback emitted by `handleReaction`, mocks only the Telegram wire boundary, and inspects both its actual argument and returned production `Memory`.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@c11c55961c6b945d4f1b22f3d3eb22af6836f91a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — issue-23839]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@c11c55961c6b945d4f1b22f3d3eb22af6836f91a:packages/skills/skills/contribute-to-eliza"} -->
