### PR TITLE
fix(cloud): fence container lifecycle job admission

### DIFF
--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -1,4 +1,7 @@
-// Persists jobs records for cloud services through the shared DB boundary.
+/**
+ * Persists background-job state, execution generations, and renewable leases
+ * through the primary and read-intent cloud database boundaries.
+ */
 import { randomUUID } from "node:crypto";
 import { and, desc, eq, inArray, lt, type SQL, sql } from "drizzle-orm";
 import {
@@ -72,6 +75,9 @@ export const JOB_EXECUTION_RECOVERY_GRACE_MS = 30_000;
 
 /** Atomic result of attempting to renew one claimed execution generation. */
 export type ExecutionLeaseRenewal = "renewed" | "settled" | "lost";
+
+/** Outcome of terminally rejecting one exact claimed execution generation. */
+export type ClaimedExecutionRejection = "rejected" | "already-terminal" | "stale" | "lost";
 
 const SETTLED_JOB_STATUSES = new Set(["completed", "failed", "cancelled"]);
 
@@ -988,6 +994,107 @@ export class JobsRepository {
       )
       .limit(1);
     if (!owned) throw new StaleJobExecutionError(claimedJob.id);
+  }
+
+  /**
+   * Terminally rejects an invalid claimed execution before it can acquire a
+   * resource fence. The exact generation and live owner lease are the only
+   * authority; no dependent-row callback or sandbox mutation participates in
+   * this pre-dispatch transition.
+   *
+   * A same-generation terminal row is classified before its lease is read so
+   * a retry after an ambiguous commit acknowledgement reconstructs success
+   * without incrementing attempts twice.
+   */
+  async rejectClaimedExecution(
+    claimedJob: Job,
+    error: string,
+    ownerId: string,
+  ): Promise<ClaimedExecutionRejection> {
+    const generation = requireExecutionGeneration(claimedJob);
+    if (!ownerId) {
+      throw new Error(`Execution owner is required to reject claimed job ${claimedJob.id}`);
+    }
+    const payload = await prepareJobPayload({ error }, claimedJob);
+
+    return await dbWrite.transaction(async (tx) => {
+      const [current] = await tx
+        .select({
+          status: jobs.status,
+          executionGeneration: jobs.execution_generation,
+          executionQuiescedAt: jobs.execution_quiesced_at,
+        })
+        .from(jobs)
+        .where(eq(jobs.id, claimedJob.id))
+        .for("update")
+        .limit(1);
+      if (!current) return "lost";
+      if (current.executionGeneration !== generation) return "stale";
+      if (SETTLED_JOB_STATUSES.has(current.status)) return "already-terminal";
+      if (current.status !== "in_progress" || current.executionQuiescedAt !== null) {
+        return "stale";
+      }
+
+      const [lease] = await tx
+        .select({ jobId: jobExecutionLeases.job_id })
+        .from(jobExecutionLeases)
+        .where(
+          and(
+            eq(jobExecutionLeases.job_id, claimedJob.id),
+            eq(jobExecutionLeases.execution_generation, generation),
+            eq(jobExecutionLeases.owner_id, ownerId),
+            sql`${jobExecutionLeases.expires_at} > NOW()`,
+          ),
+        )
+        .for("update")
+        .limit(1);
+      if (!lease) return "lost";
+
+      const settledAt = new Date();
+      const [rejected] = await tx
+        .update(jobs)
+        .set({
+          status: "failed",
+          ...payload,
+          attempts: sql`${jobs.attempts} + 1`,
+          completed_at: settledAt,
+          execution_quiesced_at: settledAt,
+          updated_at: settledAt,
+        })
+        .where(
+          and(
+            eq(jobs.id, claimedJob.id),
+            eq(jobs.status, "in_progress"),
+            eq(jobs.execution_generation, generation),
+            sql`${jobs.execution_quiesced_at} IS NULL`,
+            sql`EXISTS (
+              SELECT 1
+              FROM ${jobExecutionLeases}
+              WHERE ${jobExecutionLeases.job_id} = ${claimedJob.id}
+                AND ${jobExecutionLeases.execution_generation} = ${generation}
+                AND ${jobExecutionLeases.owner_id} = ${ownerId}
+                AND ${jobExecutionLeases.expires_at} > NOW()
+            )`,
+          ),
+        )
+        .returning({ id: jobs.id });
+      if (!rejected) return "lost";
+
+      const [deletedLease] = await tx
+        .delete(jobExecutionLeases)
+        .where(
+          and(
+            eq(jobExecutionLeases.job_id, claimedJob.id),
+            eq(jobExecutionLeases.execution_generation, generation),
+            eq(jobExecutionLeases.owner_id, ownerId),
+          ),
+        )
+        .returning({ jobId: jobExecutionLeases.job_id });
+      if (!deletedLease) {
+        throw new Error(`Rejected job ${claimedJob.id} lost its exact execution lease`);
+      }
+      return "rejected";
+    });
   }
 
   /**

--- a/packages/cloud/shared/src/lib/services/provisioning-job-types.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-job-types.test.ts
@@ -19,12 +19,14 @@ import {
   APPS_JOB_TYPES,
   COLD_BOOT_JOB_TYPES,
   COLD_BOOT_STALE_JOB_THRESHOLD_MS,
+  CONTAINER_BACKED_TARGET_AGENT_JOB_TYPES,
   EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES,
   JOB_TYPES,
   ORPHAN_PENDING_THRESHOLD_MS,
   PROVISIONING_RECONCILIATION_BATCH_SIZE,
   PROVISIONING_STATUS_OWNER_JOB_TYPES,
   type ProvisioningJobType,
+  requiresContainerBackedTarget,
   resolveJobTypesForLanes,
   STUCK_PROVISIONING_RECONCILIATION_GRACE_MS,
   STUCK_PROVISIONING_THRESHOLD_MS,
@@ -60,6 +62,39 @@ describe("provisioning status ownership", () => {
     expect(PROVISIONING_STATUS_OWNER_JOB_TYPES.has(JOB_TYPES.AGENT_UPGRADE)).toBe(false);
     expect(PROVISIONING_STATUS_OWNER_JOB_TYPES.has(JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE)).toBe(false);
     expect(PROVISIONING_STATUS_OWNER_JOB_TYPES.has(JOB_TYPES.AGENT_DOWNGRADE)).toBe(false);
+  });
+});
+
+describe("container-backed target admission", () => {
+  test("derives the worker and enqueue classification from lifecycle metadata", () => {
+    expect([...CONTAINER_BACKED_TARGET_AGENT_JOB_TYPES]).toEqual(
+      AGENT_LIFECYCLE_JOB_METADATA.filter(({ requiresContainerBackedTarget }) =>
+        Boolean(requiresContainerBackedTarget),
+      ).map(({ type }) => type),
+    );
+  });
+
+  test("requires a container for exactly the eleven container lifecycle operations", () => {
+    const required = [
+      JOB_TYPES.AGENT_PROVISION,
+      JOB_TYPES.AGENT_SUSPEND,
+      JOB_TYPES.AGENT_RESUME,
+      JOB_TYPES.AGENT_SLEEP,
+      JOB_TYPES.AGENT_WAKE,
+      JOB_TYPES.AGENT_RESTART,
+      JOB_TYPES.AGENT_UPGRADE,
+      JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE,
+      JOB_TYPES.AGENT_DOWNGRADE,
+      JOB_TYPES.AGENT_LOGS,
+      JOB_TYPES.AGENT_SNAPSHOT,
+    ];
+
+    expect(new Set(CONTAINER_BACKED_TARGET_AGENT_JOB_TYPES)).toEqual(new Set(required));
+    for (const jobType of required) {
+      expect(requiresContainerBackedTarget(jobType)).toBe(true);
+    }
+    expect(requiresContainerBackedTarget(JOB_TYPES.AGENT_MESSAGE)).toBe(false);
+    expect(requiresContainerBackedTarget(JOB_TYPES.AGENT_DELETE)).toBe(false);
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/provisioning-job-types.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-job-types.ts
@@ -1,4 +1,7 @@
-// Coordinates cloud service provisioning job types behavior behind route handlers.
+/**
+ * Defines provisioning job wire values and the canonical lifecycle metadata
+ * consumed by enqueue admission, workers, recovery, and daemon lane routing.
+ */
 export const JOB_TYPES = {
   AGENT_PROVISION: "agent_provision",
   AGENT_DELETE: "agent_delete",
@@ -109,6 +112,7 @@ interface AgentLifecycleJobMetadata {
   exclusive: boolean;
   coldBoot: boolean;
   ownsProvisioningStatus: boolean;
+  requiresContainerBackedTarget: boolean;
 }
 
 export const AGENT_LIFECYCLE_JOB_METADATA = [
@@ -117,78 +121,91 @@ export const AGENT_LIFECYCLE_JOB_METADATA = [
     exclusive: true,
     coldBoot: true,
     ownsProvisioningStatus: true,
+    requiresContainerBackedTarget: true,
   },
   {
     type: JOB_TYPES.AGENT_DELETE,
     exclusive: true,
     coldBoot: false,
     ownsProvisioningStatus: false,
+    requiresContainerBackedTarget: false,
   },
   {
     type: JOB_TYPES.AGENT_SUSPEND,
     exclusive: true,
     coldBoot: false,
     ownsProvisioningStatus: false,
+    requiresContainerBackedTarget: true,
   },
   {
     type: JOB_TYPES.AGENT_RESUME,
     exclusive: true,
     coldBoot: true,
     ownsProvisioningStatus: true,
+    requiresContainerBackedTarget: true,
   },
   {
     type: JOB_TYPES.AGENT_RESTART,
     exclusive: true,
     coldBoot: true,
     ownsProvisioningStatus: true,
+    requiresContainerBackedTarget: true,
   },
   {
     type: JOB_TYPES.AGENT_LOGS,
     exclusive: false,
     coldBoot: false,
     ownsProvisioningStatus: false,
+    requiresContainerBackedTarget: true,
   },
   {
     type: JOB_TYPES.AGENT_MESSAGE,
     exclusive: false,
     coldBoot: false,
     ownsProvisioningStatus: false,
+    requiresContainerBackedTarget: false,
   },
   {
     type: JOB_TYPES.AGENT_SNAPSHOT,
     exclusive: false,
     coldBoot: false,
     ownsProvisioningStatus: false,
+    requiresContainerBackedTarget: true,
   },
   {
     type: JOB_TYPES.AGENT_UPGRADE,
     exclusive: true,
     coldBoot: true,
     ownsProvisioningStatus: false,
+    requiresContainerBackedTarget: true,
   },
   {
     type: JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE,
     exclusive: true,
     coldBoot: true,
     ownsProvisioningStatus: false,
+    requiresContainerBackedTarget: true,
   },
   {
     type: JOB_TYPES.AGENT_DOWNGRADE,
     exclusive: true,
     coldBoot: true,
     ownsProvisioningStatus: false,
+    requiresContainerBackedTarget: true,
   },
   {
     type: JOB_TYPES.AGENT_SLEEP,
     exclusive: true,
     coldBoot: false,
     ownsProvisioningStatus: false,
+    requiresContainerBackedTarget: true,
   },
   {
     type: JOB_TYPES.AGENT_WAKE,
     exclusive: true,
     coldBoot: true,
     ownsProvisioningStatus: true,
+    requiresContainerBackedTarget: true,
   },
 ] as const satisfies readonly AgentLifecycleJobMetadata[];
 
@@ -230,6 +247,22 @@ export const PROVISIONING_STATUS_OWNER_JOB_TYPES: ReadonlySet<ProvisioningJobTyp
     ({ type }) => type,
   ),
 );
+
+/**
+ * Agent jobs whose target must own a dedicated container. This explicit
+ * metadata-derived set deliberately leaves shared-runtime message delivery
+ * and logical deletion available without enrolling future job types by
+ * default.
+ */
+export const CONTAINER_BACKED_TARGET_AGENT_JOB_TYPES: ReadonlySet<ProvisioningJobType> = new Set(
+  AGENT_LIFECYCLE_JOB_METADATA.filter(({ requiresContainerBackedTarget }) =>
+    Boolean(requiresContainerBackedTarget),
+  ).map(({ type }) => type),
+);
+
+export function requiresContainerBackedTarget(jobType: string): boolean {
+  return CONTAINER_BACKED_TARGET_AGENT_JOB_TYPES.has(jobType as ProvisioningJobType);
+}
 
 export const DEFAULT_STALE_JOB_THRESHOLD_MS = 5 * 60 * 1000;
 export const COLD_BOOT_STALE_JOB_THRESHOLD_MS = 15 * 60 * 1000;

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-container-tier-guard.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-container-tier-guard.pglite.test.ts
@@ -1,0 +1,521 @@
+/**
+ * Exercises container-tier admission and pre-dispatch rejection against real
+ * PGlite state. The harness drives the lifecycle enqueue transaction, worker
+ * claim/lease path, locked sandbox authority read, and exact terminal
+ * settlement; only the final resource handler is replaced with an explicit
+ * completion callback for the two shared-runtime exemptions.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { and, eq, sql } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../db/client";
+import { jobsRepository } from "../../db/repositories/jobs";
+import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import { jobExecutionLeases } from "../../db/schemas/job-execution-leases";
+import type { Job } from "../../db/schemas/jobs";
+import { jobs } from "../../db/schemas/jobs";
+import { organizations } from "../../db/schemas/organizations";
+import { users } from "../../db/schemas/users";
+import { PROVISIONING_JOB_TEST_TABLES } from "./__tests__/tier-upgrade-pglite-schema";
+import { JOB_TYPES, type ProvisioningJobType } from "./provisioning-job-types";
+import { ProvisioningJobService } from "./provisioning-jobs";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
+const PGLITE_TIMEOUT = 300_000;
+const OWNER_ID = "00000000-0000-4000-8000-000000229470";
+const OTHER_OWNER_ID = "00000000-0000-4000-8000-000000229471";
+const OTHER_GENERATION = "00000000-0000-4000-8000-000000229472";
+const REQUIRED_JOB_TYPES = [
+  JOB_TYPES.AGENT_PROVISION,
+  JOB_TYPES.AGENT_SUSPEND,
+  JOB_TYPES.AGENT_RESUME,
+  JOB_TYPES.AGENT_SLEEP,
+  JOB_TYPES.AGENT_WAKE,
+  JOB_TYPES.AGENT_RESTART,
+  JOB_TYPES.AGENT_UPGRADE,
+  JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE,
+  JOB_TYPES.AGENT_DOWNGRADE,
+  JOB_TYPES.AGENT_LOGS,
+  JOB_TYPES.AGENT_SNAPSHOT,
+] as const satisfies readonly ProvisioningJobType[];
+
+let pgliteReady = true;
+let sequence = 0;
+
+function unique(prefix: string): string {
+  sequence += 1;
+  return `${prefix}-${sequence}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedOwner(): Promise<{ organizationId: string; userId: string }> {
+  const [organization] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Container Tier Guard", slug: unique("tier-guard") })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ organization_id: organization.id, steward_user_id: unique("steward") })
+    .returning();
+  return { organizationId: organization.id, userId: user.id };
+}
+
+async function seedSandbox(executionTier: string): Promise<{
+  agentId: string;
+  organizationId: string;
+  userId: string;
+}> {
+  const owner = await seedOwner();
+  const [sandbox] = await dbWrite
+    .insert(agentSandboxes)
+    .values({
+      organization_id: owner.organizationId,
+      user_id: owner.userId,
+      agent_name: unique("agent"),
+      execution_tier: executionTier as never,
+      status: "running",
+    })
+    .returning();
+  return { agentId: sandbox.id, ...owner };
+}
+
+function agentJobData(
+  type: ProvisioningJobType,
+  identity: { agentId: string; organizationId: string; userId: string },
+): Record<string, unknown> {
+  const common = {
+    agentId: identity.agentId,
+    organizationId: identity.organizationId,
+    userId: identity.userId,
+  };
+  switch (type) {
+    case JOB_TYPES.AGENT_PROVISION:
+      return { ...common, agentName: "Tier Guard Agent" };
+    case JOB_TYPES.AGENT_DELETE:
+      return common;
+    case JOB_TYPES.AGENT_SUSPEND:
+      return { ...common, authorization: "user_request" };
+    case JOB_TYPES.AGENT_RESUME:
+    case JOB_TYPES.AGENT_SLEEP:
+      return common;
+    case JOB_TYPES.AGENT_WAKE:
+      return { ...common, forceFreshBoot: false };
+    case JOB_TYPES.AGENT_RESTART:
+      return { ...common, stateLossAcknowledged: false };
+    case JOB_TYPES.AGENT_UPGRADE:
+      return {
+        ...common,
+        dockerImage: "ghcr.io/elizaos/eliza:develop",
+        fromDigest: null,
+        toDigest: `sha256:${"b".repeat(64)}`,
+      };
+    case JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE:
+      return {
+        ...common,
+        operation: "upgrade",
+        rolloutId: crypto.randomUUID(),
+        actorUserId: identity.userId,
+        targetOwnerUserId: identity.userId,
+        decisionAt: new Date().toISOString(),
+        sourceImage: "ghcr.io/elizaos/eliza:develop",
+        sourceDigest: `sha256:${"a".repeat(64)}`,
+        targetImage: `ghcr.io/elizaos/eliza-demo@sha256:${"b".repeat(64)}`,
+        targetDigest: `sha256:${"b".repeat(64)}`,
+      };
+    case JOB_TYPES.AGENT_DOWNGRADE:
+      return {
+        ...common,
+        dockerImage: "ghcr.io/elizaos/eliza:develop",
+        fromDigest: `sha256:${"b".repeat(64)}`,
+      };
+    case JOB_TYPES.AGENT_LOGS:
+      return { ...common, tail: 100 };
+    case JOB_TYPES.AGENT_MESSAGE:
+      return { ...common, text: "hello", nonce: crypto.randomUUID() };
+    case JOB_TYPES.AGENT_SNAPSHOT:
+      return { ...common, snapshotType: "manual" };
+    default:
+      throw new Error(`Unsupported agent job fixture type ${type}`);
+  }
+}
+
+async function seedPendingAgentJob(
+  type: ProvisioningJobType,
+  identity: { agentId: string; organizationId: string; userId: string },
+  data = agentJobData(type, identity),
+): Promise<Job> {
+  const [job] = await dbWrite
+    .insert(jobs)
+    .values({
+      type,
+      status: "pending",
+      data,
+      data_storage: "inline",
+      agent_id: identity.agentId,
+      organization_id: identity.organizationId,
+      user_id: identity.userId,
+      max_attempts: 1,
+    })
+    .returning();
+  return job;
+}
+
+async function claim(job: Job, ownerId = OWNER_ID): Promise<Job> {
+  const [claimed] = await jobsRepository.claimPendingJobs({
+    type: job.type,
+    organizationId: job.organization_id,
+    limit: 1,
+    executionOwnerId: ownerId,
+    executionLeaseMs: 60_000,
+  });
+  if (!claimed) throw new Error(`Job ${job.id} was not claimed`);
+  return claimed;
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    return;
+  }
+  try {
+    for (const ddl of PROVISIONING_JOB_TEST_TABLES) {
+      await dbWrite.execute(sql.raw(ddl));
+    }
+  } catch {
+    pgliteReady = false;
+  }
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  expect(pgliteReady).toBe(true);
+  process.env.ELIZA_SNAPSHOT_JOBS_ENABLED = "true";
+  await dbWrite.delete(jobExecutionLeases);
+  await dbWrite.delete(jobs);
+  await dbWrite.delete(agentSandboxes);
+});
+
+afterAll(async () => {
+  delete process.env.ELIZA_SNAPSHOT_JOBS_ENABLED;
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("container-backed enqueue admission", () => {
+  test("admits a dedicated provision and rejects Shared before insert or reuse", async () => {
+    const service = new ProvisioningJobService();
+    const dedicated = await seedSandbox("dedicated-lazy");
+    const first = await service.enqueueAgentProvisionOnce({
+      ...dedicated,
+      agentName: "Dedicated Agent",
+    });
+    expect(first).toMatchObject({ created: true, job: { status: "pending" } });
+
+    await dbWrite
+      .update(agentSandboxes)
+      .set({ execution_tier: "shared" })
+      .where(eq(agentSandboxes.id, dedicated.agentId));
+    await expect(
+      service.enqueueAgentProvisionOnce({ ...dedicated, agentName: "Dedicated Agent" }),
+    ).rejects.toMatchObject({ status: 409, code: "session_not_ready" });
+    const active = await dbWrite
+      .select()
+      .from(jobs)
+      .where(and(eq(jobs.agent_id, dedicated.agentId), eq(jobs.type, JOB_TYPES.AGENT_PROVISION)));
+    expect(active).toHaveLength(1);
+    expect(active[0]).toMatchObject({ id: first.job.id, status: "pending" });
+
+    const shared = await seedSandbox("shared");
+    await expect(
+      dbWrite.transaction((tx) =>
+        service.enqueueAgentProvisionOnceInTx(tx, {
+          ...shared,
+          agentName: "Shared Agent",
+        }),
+      ),
+    ).rejects.toMatchObject({ status: 409, code: "session_not_ready" });
+    const sharedJobs = await dbWrite.select().from(jobs).where(eq(jobs.agent_id, shared.agentId));
+    expect(sharedJobs).toHaveLength(0);
+  });
+});
+
+describe("worker container-tier and identity preflight", () => {
+  test(
+    "terminally rejects all eleven Shared container jobs before handlers and remains idempotent",
+    async () => {
+      const shared = await seedSandbox("shared");
+      for (const type of REQUIRED_JOB_TYPES) {
+        await seedPendingAgentJob(type, shared);
+      }
+      const before = await dbWrite
+        .select({
+          status: agentSandboxes.status,
+          executionTier: agentSandboxes.execution_tier,
+          error: agentSandboxes.error_message,
+          lifecycleJobId: agentSandboxes.lifecycle_job_id,
+          lifecycleGeneration: agentSandboxes.lifecycle_execution_generation,
+          lifecycleRevision: agentSandboxes.lifecycle_revision,
+        })
+        .from(agentSandboxes)
+        .where(eq(agentSandboxes.id, shared.agentId));
+      const handlerCalls: string[] = [];
+      const service = new ProvisioningJobService({
+        executionOwnerId: OWNER_ID,
+        executeJob: async (job) => {
+          handlerCalls.push(job.type);
+        },
+      });
+      const ordinaryFailure = spyOn(jobsRepository, "incrementAttempt");
+      try {
+        const result = await service.processPendingJobs(1, { jobTypes: REQUIRED_JOB_TYPES });
+        expect(result).toMatchObject({ claimed: 11, succeeded: 0, retried: 0, failed: 11 });
+        expect(result.errors).toHaveLength(11);
+        expect(handlerCalls).toEqual([]);
+        expect(ordinaryFailure).not.toHaveBeenCalled();
+
+        const rejected = await dbWrite
+          .select()
+          .from(jobs)
+          .where(eq(jobs.organization_id, shared.organizationId));
+        expect(rejected).toHaveLength(11);
+        for (const row of rejected) {
+          expect(row).toMatchObject({
+            status: "failed",
+            attempts: 1,
+            execution_quiesced_at: expect.anything(),
+            completed_at: expect.anything(),
+          });
+          expect(row.error).toContain(CONTAINER_BACKED_TARGET_REQUIRED_MESSAGE_FOR_TEST);
+        }
+        const [misaligned] = await dbWrite
+          .select({ count: sql<number>`count(*)::int` })
+          .from(jobs)
+          .where(
+            and(
+              eq(jobs.organization_id, shared.organizationId),
+              sql`(
+                ${jobs.completed_at} IS DISTINCT FROM ${jobs.execution_quiesced_at}
+                OR ${jobs.completed_at} IS DISTINCT FROM ${jobs.updated_at}
+              )`,
+            ),
+          );
+        expect(misaligned?.count).toBe(0);
+        expect(await dbWrite.select().from(jobExecutionLeases)).toHaveLength(0);
+
+        const after = await dbWrite
+          .select({
+            status: agentSandboxes.status,
+            executionTier: agentSandboxes.execution_tier,
+            error: agentSandboxes.error_message,
+            lifecycleJobId: agentSandboxes.lifecycle_job_id,
+            lifecycleGeneration: agentSandboxes.lifecycle_execution_generation,
+            lifecycleRevision: agentSandboxes.lifecycle_revision,
+          })
+          .from(agentSandboxes)
+          .where(eq(agentSandboxes.id, shared.agentId));
+        expect(after).toEqual(before);
+
+        const secondPass = await service.processPendingJobs(1, { jobTypes: REQUIRED_JOB_TYPES });
+        expect(secondPass).toMatchObject({ claimed: 0, succeeded: 0, retried: 0, failed: 0 });
+        const afterReplay = await dbWrite
+          .select({ attempts: jobs.attempts })
+          .from(jobs)
+          .where(eq(jobs.organization_id, shared.organizationId));
+        expect(new Set(afterReplay.map(({ attempts }) => attempts))).toEqual(new Set([1]));
+      } finally {
+        ordinaryFailure.mockRestore();
+      }
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test("rejects forged payload identity before a dedicated target handler", async () => {
+    const dedicated = await seedSandbox("dedicated-always");
+    const forged = {
+      ...agentJobData(JOB_TYPES.AGENT_LOGS, dedicated),
+      agentId: crypto.randomUUID(),
+    };
+    await seedPendingAgentJob(JOB_TYPES.AGENT_LOGS, dedicated, forged);
+    let handlerCalls = 0;
+    const service = new ProvisioningJobService({
+      executionOwnerId: OWNER_ID,
+      executeJob: async () => {
+        handlerCalls += 1;
+      },
+    });
+
+    const result = await service.processPendingJobs(1, { jobTypes: [JOB_TYPES.AGENT_LOGS] });
+
+    expect(result).toMatchObject({ claimed: 1, succeeded: 0, failed: 1 });
+    expect(handlerCalls).toBe(0);
+    const [rejected] = await dbWrite.select().from(jobs);
+    expect(rejected).toMatchObject({ status: "failed", attempts: 1 });
+    expect(rejected.error).toContain("identity does not match indexed columns");
+    const [sandbox] = await dbWrite
+      .select({ status: agentSandboxes.status, error: agentSandboxes.error_message })
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, dedicated.agentId));
+    expect(sandbox).toEqual({ status: "running", error: null });
+  });
+
+  test("fails closed when a container-required target row disappeared before dispatch", async () => {
+    const owner = await seedOwner();
+    const missing = { agentId: crypto.randomUUID(), ...owner };
+    await seedPendingAgentJob(JOB_TYPES.AGENT_LOGS, missing);
+    let handlerCalls = 0;
+    const service = new ProvisioningJobService({
+      executionOwnerId: OWNER_ID,
+      executeJob: async () => {
+        handlerCalls += 1;
+      },
+    });
+
+    const result = await service.processPendingJobs(1, { jobTypes: [JOB_TYPES.AGENT_LOGS] });
+
+    expect(result).toMatchObject({ claimed: 1, succeeded: 0, failed: 1 });
+    expect(handlerCalls).toBe(0);
+    const [rejected] = await dbWrite.select().from(jobs);
+    expect(rejected).toMatchObject({ status: "failed", attempts: 1 });
+    expect(rejected.error).toContain(CONTAINER_BACKED_TARGET_REQUIRED_MESSAGE_FOR_TEST);
+    expect(await dbWrite.select().from(agentSandboxes)).toHaveLength(0);
+  });
+
+  test("allows Shared message delivery and logical deletion through the common preflight", async () => {
+    const shared = await seedSandbox("shared");
+    await seedPendingAgentJob(JOB_TYPES.AGENT_MESSAGE, shared);
+    await seedPendingAgentJob(JOB_TYPES.AGENT_DELETE, shared);
+    const handlerCalls: string[] = [];
+    const service = new ProvisioningJobService({
+      executionOwnerId: OWNER_ID,
+      executeJob: async (job) => {
+        handlerCalls.push(job.type);
+        await jobsRepository.settleExecution(
+          job,
+          "completed",
+          { completed_at: new Date() },
+          OWNER_ID,
+        );
+      },
+    });
+
+    const result = await service.processPendingJobs(1, {
+      jobTypes: [JOB_TYPES.AGENT_MESSAGE, JOB_TYPES.AGENT_DELETE],
+    });
+
+    expect(result).toMatchObject({ claimed: 2, succeeded: 2, failed: 0 });
+    expect(new Set(handlerCalls)).toEqual(
+      new Set([JOB_TYPES.AGENT_MESSAGE, JOB_TYPES.AGENT_DELETE]),
+    );
+    const completed = await dbWrite.select().from(jobs);
+    expect(completed.map(({ status }) => status)).toEqual(["completed", "completed"]);
+  });
+});
+
+describe("jobsRepository.rejectClaimedExecution", () => {
+  test("rejects once, reconstructs an ambiguous acknowledgement, and stops lease renewal", async () => {
+    const shared = await seedSandbox("shared");
+    const pending = await seedPendingAgentJob(JOB_TYPES.AGENT_MESSAGE, shared);
+    const claimed = await claim(pending);
+
+    expect(await jobsRepository.rejectClaimedExecution(claimed, "invalid target", OWNER_ID)).toBe(
+      "rejected",
+    );
+    expect(await jobsRepository.rejectClaimedExecution(claimed, "invalid target", OWNER_ID)).toBe(
+      "already-terminal",
+    );
+    expect(await jobsRepository.renewExecutionLease(claimed, OWNER_ID)).toBe("settled");
+
+    const [persisted] = await dbWrite.select().from(jobs).where(eq(jobs.id, claimed.id));
+    expect(persisted).toMatchObject({ status: "failed", attempts: 1, error: "invalid target" });
+    const [misaligned] = await dbWrite
+      .select({ count: sql<number>`count(*)::int` })
+      .from(jobs)
+      .where(
+        and(
+          eq(jobs.id, claimed.id),
+          sql`(
+            ${jobs.completed_at} IS DISTINCT FROM ${jobs.execution_quiesced_at}
+            OR ${jobs.completed_at} IS DISTINCT FROM ${jobs.updated_at}
+          )`,
+        ),
+      );
+    expect(misaligned?.count).toBe(0);
+    expect(await dbWrite.select().from(jobExecutionLeases)).toHaveLength(0);
+  });
+
+  test("classifies terminal, stale, missing, wrong-owner, and expired authority without mutation", async () => {
+    const shared = await seedSandbox("shared");
+
+    const terminalClaim = await claim(
+      await seedPendingAgentJob(JOB_TYPES.AGENT_MESSAGE, shared),
+      OWNER_ID,
+    );
+    await dbWrite
+      .update(jobs)
+      .set({ status: "completed", completed_at: new Date(), execution_quiesced_at: new Date() })
+      .where(eq(jobs.id, terminalClaim.id));
+    await dbWrite.delete(jobExecutionLeases).where(eq(jobExecutionLeases.job_id, terminalClaim.id));
+    expect(
+      await jobsRepository.rejectClaimedExecution(terminalClaim, "must not replace", OWNER_ID),
+    ).toBe("already-terminal");
+
+    const staleClaim = await claim(await seedPendingAgentJob(JOB_TYPES.AGENT_MESSAGE, shared));
+    await dbWrite
+      .update(jobs)
+      .set({ execution_generation: OTHER_GENERATION })
+      .where(eq(jobs.id, staleClaim.id));
+    expect(await jobsRepository.rejectClaimedExecution(staleClaim, "stale", OWNER_ID)).toBe(
+      "stale",
+    );
+
+    const wrongOwnerClaim = await claim(await seedPendingAgentJob(JOB_TYPES.AGENT_MESSAGE, shared));
+    expect(
+      await jobsRepository.rejectClaimedExecution(wrongOwnerClaim, "wrong owner", OTHER_OWNER_ID),
+    ).toBe("lost");
+
+    const expiredClaim = await claim(await seedPendingAgentJob(JOB_TYPES.AGENT_MESSAGE, shared));
+    await dbWrite
+      .update(jobExecutionLeases)
+      .set({ expires_at: new Date(0) })
+      .where(eq(jobExecutionLeases.job_id, expiredClaim.id));
+    expect(await jobsRepository.rejectClaimedExecution(expiredClaim, "expired", OWNER_ID)).toBe(
+      "lost",
+    );
+
+    const missingClaim = await claim(await seedPendingAgentJob(JOB_TYPES.AGENT_MESSAGE, shared));
+    await dbWrite.delete(jobExecutionLeases).where(eq(jobExecutionLeases.job_id, missingClaim.id));
+    await dbWrite.delete(jobs).where(eq(jobs.id, missingClaim.id));
+    expect(await jobsRepository.rejectClaimedExecution(missingClaim, "missing", OWNER_ID)).toBe(
+      "lost",
+    );
+
+    const rows = await dbWrite.select().from(jobs);
+    expect(rows.find(({ id }) => id === terminalClaim.id)).toMatchObject({
+      status: "completed",
+      attempts: 0,
+      error: null,
+    });
+    expect(rows.find(({ id }) => id === staleClaim.id)).toMatchObject({
+      status: "in_progress",
+      attempts: 0,
+      error: null,
+    });
+    expect(rows.find(({ id }) => id === wrongOwnerClaim.id)).toMatchObject({
+      status: "in_progress",
+      attempts: 0,
+      error: null,
+    });
+    expect(rows.find(({ id }) => id === expiredClaim.id)).toMatchObject({
+      status: "in_progress",
+      attempts: 0,
+      error: null,
+    });
+  });
+});
+
+const CONTAINER_BACKED_TARGET_REQUIRED_MESSAGE_FOR_TEST =
+  "Agent job requires a container-backed execution tier";

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-lifecycle.test.ts
@@ -95,6 +95,7 @@ function makeJob(type: ProvisioningJobType, extraData: Record<string, unknown> =
       organizationId: ORG,
       userId: USER,
       agentName: "Test Agent",
+      ...(type === JOB_TYPES.AGENT_SUSPEND ? { authorization: "user_request" } : {}),
       ...extraData,
     },
     data_storage: "inline",
@@ -132,6 +133,15 @@ function makeJob(type: ProvisioningJobType, extraData: Record<string, unknown> =
  */
 function withClaimedJob(type: ProvisioningJobType, extraData: Record<string, unknown> = {}) {
   const job = makeJob(type, extraData);
+  // These handler-policy cases model a target disappearing only after a
+  // successful common preflight. Missing-target rejection itself is exercised
+  // against real PGlite state in provisioning-jobs-container-tier-guard.
+  const preflightSpy = spyOn(
+    provisioningJobService as unknown as {
+      assertNoConflictingLifecycleExecution(job: Job): Promise<void>;
+    },
+    "assertNoConflictingLifecycleExecution",
+  ).mockResolvedValue(undefined);
   const claimSpy = spyOn(jobsRepository, "claimPendingJobs").mockImplementation(
     async (f: { type: string }) => (f.type === type ? [job] : []),
   );
@@ -156,6 +166,7 @@ function withClaimedJob(type: ProvisioningJobType, extraData: Record<string, unk
     incrementSpy,
     retryLaterSpy,
     restore() {
+      preflightSpy.mockRestore();
       claimSpy.mockRestore();
       recoverSpy.mockRestore();
       assertLeaseSpy.mockRestore();

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-execute-dispatch.test.ts
@@ -46,6 +46,7 @@ function makeJob(
       organizationId: ORG,
       userId: USER,
       agentName: "Test Agent",
+      ...(type === JOB_TYPES.AGENT_SUSPEND ? { authorization: "user_request" } : {}),
       ...extraData,
     },
     data_storage: "inline",

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-lease-heartbeat.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-lease-heartbeat.test.ts
@@ -68,6 +68,12 @@ function claimedJob(type: ProvisioningJobType = JOB_TYPES.AGENT_LOGS): Job {
 function stubLaneClaim(job: Job | undefined) {
   const claim = spyOn(jobsRepository, "claimPendingJobs").mockResolvedValue(job ? [job] : []);
   spyOn(jobsRepository, "recoverStaleJobs").mockResolvedValue(EMPTY_RECOVERY);
+  spyOn(
+    ProvisioningJobService.prototype as unknown as {
+      assertNoConflictingLifecycleExecution(job: Job): Promise<void>;
+    },
+    "assertNoConflictingLifecycleExecution",
+  ).mockResolvedValue(undefined);
   return claim;
 }
 

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
@@ -94,6 +94,7 @@ async function seedSandbox(opts: SeedOpts = {}): Promise<string> {
       // Default to a due, reachable, user-owned running row so each test only
       // has to flip the one field it is exercising out of eligibility.
       status: (opts.status ?? "running") as never,
+      execution_tier: "dedicated-lazy",
       bridge_url: opts.bridgeUrl === undefined ? REACHABLE_BRIDGE : opts.bridgeUrl,
       pool_status: (opts.poolStatus ?? null) as never,
       last_backup_at: opts.lastBackupAt ?? null,
@@ -319,7 +320,7 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
         user_id: userId,
         agent_name: uniq("agent"),
         status: (opts.status ?? "running") as never,
-        execution_tier: (opts.executionTier ?? "shared") as never,
+        execution_tier: (opts.executionTier ?? "dedicated-lazy") as never,
         bridge_url: REACHABLE_BRIDGE,
         last_heartbeat_at: opts.lastHeartbeatAt ?? null,
       })

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-wake-enqueue.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-wake-enqueue.test.ts
@@ -69,6 +69,7 @@ async function seedSleepingAgent(): Promise<{
       user_id: user.id,
       agent_name: uniq("agent"),
       status: "sleeping",
+      execution_tier: "dedicated-lazy",
     })
     .returning();
   return { agentId: sandbox.id, organizationId: org.id, userId: user.id };

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -52,6 +52,7 @@ import {
   type AgentSandboxPoolStatus,
   type AgentSandboxStatus,
   agentSandboxes,
+  CONTAINER_BACKED_EXECUTION_TIERS,
   UPGRADE_FAILURE_TARGET_MARKER_PREFIX,
   WARM_POOL_ORG_ID,
 } from "../../db/schemas/agent-sandboxes";
@@ -105,12 +106,14 @@ import {
 } from "./eliza-sandbox";
 import { finalizeJobErrorText, jobErrorSummary, jobErrorText } from "./job-error-text";
 import {
+  AGENT_JOB_TYPES,
   COLD_BOOT_JOB_TYPES,
   COLD_BOOT_STALE_JOB_THRESHOLD_MS,
   DEFAULT_STALE_JOB_THRESHOLD_MS,
   EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES,
   JOB_TYPES,
   type ProvisioningJobType,
+  requiresContainerBackedTarget,
 } from "./provisioning-job-types";
 import { sendProvisioningWorkerAlert } from "./provisioning-worker-health-monitor";
 import {
@@ -135,6 +138,38 @@ function safeErrorKind<T extends Error>(
     // error-policy:J3 hostile thrown value; treat it as an ordinary failure so
     // the job still reaches its durable retry/failure transition.
     return false;
+  }
+}
+
+const CONTAINER_BACKED_TARGET_REQUIRED_MESSAGE =
+  "Agent job requires a container-backed execution tier";
+
+function isContainerBackedExecutionTier(tier: AgentExecutionTier): boolean {
+  return (CONTAINER_BACKED_EXECUTION_TIERS as readonly AgentExecutionTier[]).includes(tier);
+}
+
+/** Domain rejection that must terminate the exact claim without ordinary retry handling. */
+class RejectedAgentExecutionError extends ElizaError {
+  override readonly name = "RejectedAgentExecutionError";
+
+  constructor(
+    message: string,
+    context: {
+      jobId: string;
+      jobType: string;
+      columnAgentId: string | null;
+      columnOrganizationId: string;
+      payloadAgentId?: string | null;
+      payloadOrganizationId?: string | null;
+      executionTier?: string;
+      cause?: string;
+    },
+  ) {
+    super(message, {
+      code: "PROVISIONING_JOB_TARGET_REJECTED",
+      context,
+      severity: "fatal",
+    });
   }
 }
 
@@ -1563,6 +1598,17 @@ export class ProvisioningJobService {
           jobType: opts.jobType,
         },
       });
+    }
+
+    if (
+      requiresContainerBackedTarget(opts.jobType) &&
+      !isContainerBackedExecutionTier(sandbox.execution_tier)
+    ) {
+      throw new ApiError(
+        409,
+        "session_not_ready",
+        `${CONTAINER_BACKED_TARGET_REQUIRED_MESSAGE}: ${opts.jobType}`,
+      );
     }
 
     if (
@@ -3749,6 +3795,29 @@ export class ProvisioningJobService {
       : jobErrorText(err);
     result?.errors.push({ jobId: job.id, error: errorMsg });
 
+    if (safeErrorKind(err, RejectedAgentExecutionError)) {
+      const outcome = await this.retryOwnedWrite(job, "reject-agent-execution", () =>
+        jobsRepository.rejectClaimedExecution(job, errorMsg, this.executionOwnerId),
+      );
+      if (outcome === "rejected" || outcome === "already-terminal") {
+        if (result) result.failed++;
+        logger.warn("[provisioning-jobs] Rejected invalid agent execution before dispatch", {
+          jobId: job.id,
+          jobType: job.type,
+          outcome,
+          error: errorMsg,
+        });
+      } else {
+        logger.info("[provisioning-jobs] Invalid agent execution lost its exact claim", {
+          jobId: job.id,
+          jobType: job.type,
+          outcome,
+          error: errorMsg,
+        });
+      }
+      return;
+    }
+
     if (retryableTransportError) {
       const retrySnapshot = retryableTransportError.retrySnapshot;
       const onExhaustedInTx = this.buildPermanentFailureWriteback(retrySnapshot, errorMsg);
@@ -4184,51 +4253,101 @@ export class ProvisioningJobService {
     return (hydratedJob, error) => this.buildPermanentFailureWriteback(hydratedJob, error);
   }
 
-  private async assertNoConflictingLifecycleExecution(job: Job): Promise<void> {
-    if (
-      !EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES.includes(job.type as ProvisioningJobType) ||
-      !job.agent_id
-    ) {
-      return;
+  /** Parse and cross-check the duplicated agent identity before any handler runs. */
+  private assertAgentJobIdentity(
+    job: Job,
+  ): { agentId: string; organizationId: string } | undefined {
+    if (!AGENT_JOB_TYPES.includes(job.type as ProvisioningJobType)) return undefined;
+
+    const raw = job.data && typeof job.data === "object" ? job.data : undefined;
+    let identity: { agentId: string; organizationId: string };
+    try {
+      switch (job.type) {
+        case JOB_TYPES.AGENT_PROVISION:
+          identity = readAgentProvisionJobData(job);
+          break;
+        case JOB_TYPES.AGENT_DELETE:
+          identity = readAgentDeleteJobData(job);
+          break;
+        case JOB_TYPES.AGENT_SUSPEND:
+          identity = readAgentSuspendJobData(job);
+          break;
+        case JOB_TYPES.AGENT_RESUME:
+          identity = readAgentResumeJobData(job);
+          break;
+        case JOB_TYPES.AGENT_SLEEP:
+          identity = readAgentSleepJobData(job);
+          break;
+        case JOB_TYPES.AGENT_WAKE:
+          identity = readAgentWakeJobData(job);
+          break;
+        case JOB_TYPES.AGENT_RESTART:
+          identity = readAgentRestartJobData(job);
+          break;
+        case JOB_TYPES.AGENT_UPGRADE:
+          identity = readAgentUpgradeJobData(job);
+          break;
+        case JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE:
+          identity = readAdminCanaryImageJobData(job);
+          break;
+        case JOB_TYPES.AGENT_DOWNGRADE:
+          identity = readAgentDowngradeJobData(job);
+          break;
+        case JOB_TYPES.AGENT_LOGS:
+          identity = readAgentLogsJobData(job);
+          break;
+        case JOB_TYPES.AGENT_MESSAGE:
+          identity = readAgentMessageJobData(job);
+          break;
+        case JOB_TYPES.AGENT_SNAPSHOT:
+          identity = readAgentSnapshotJobData(job);
+          break;
+        default:
+          throw new Error(`No identity parser for agent job type ${job.type}`);
+      }
+    } catch (cause) {
+      throw new RejectedAgentExecutionError(`Invalid agent job payload for job ${job.id}`, {
+        jobId: job.id,
+        jobType: job.type,
+        columnAgentId: job.agent_id,
+        columnOrganizationId: job.organization_id,
+        payloadAgentId: typeof raw?.agentId === "string" ? raw.agentId : null,
+        payloadOrganizationId: typeof raw?.organizationId === "string" ? raw.organizationId : null,
+        cause: cause instanceof Error ? cause.message : String(cause),
+      });
     }
+
+    if (
+      identity.agentId.trim().length === 0 ||
+      identity.organizationId.trim().length === 0 ||
+      identity.agentId !== job.agent_id ||
+      identity.organizationId !== job.organization_id
+    ) {
+      throw new RejectedAgentExecutionError(
+        `Agent job identity does not match indexed columns for job ${job.id}`,
+        {
+          jobId: job.id,
+          jobType: job.type,
+          columnAgentId: job.agent_id,
+          columnOrganizationId: job.organization_id,
+          payloadAgentId: identity.agentId,
+          payloadOrganizationId: identity.organizationId,
+        },
+      );
+    }
+    return identity;
+  }
+
+  private async assertNoConflictingLifecycleExecution(job: Job): Promise<void> {
+    const identity = this.assertAgentJobIdentity(job);
+    if (!identity) return;
     if (!job.execution_generation) {
       throw new Error(`Claimed lifecycle job ${job.id} has no execution generation`);
     }
     await this.assertExecutionMutationLease(job);
     await dbWrite.transaction(async (tx) => {
       await configureElizaLifecycleTransaction(tx);
-      await tx.execute(elizaProvisionAdvisoryLockSql(job.organization_id, job.agent_id!));
-      const [conflict] = await tx
-        .select({ id: jobs.id, type: jobs.type, status: jobs.status })
-        .from(jobs)
-        .where(
-          and(
-            eq(jobs.organization_id, job.organization_id),
-            eq(jobs.agent_id, job.agent_id!),
-            inArray(jobs.type, EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES),
-            ne(jobs.id, job.id),
-            sql`${jobs.status} IN ('pending', 'in_progress')`,
-            // A manual suspend may be a durable follow-up to an already claimed
-            // billing suspend. Both executions serialize on the sandbox row in
-            // executeSuspend; treating them as a conflict would strand the
-            // unconditional follow-up behind the stale hydrated billing job.
-            or(ne(jobs.type, job.type), ne(jobs.type, JOB_TYPES.AGENT_SUSPEND)),
-          ),
-        )
-        .orderBy(desc(jobs.created_at))
-        .limit(1);
-      if (conflict) {
-        throw new ApiError(
-          409,
-          "session_not_ready",
-          `Agent ${job.agent_id} has conflicting ${conflict.type} job ${conflict.id}`,
-          {
-            conflictingJobId: conflict.id,
-            conflictingJobType: conflict.type,
-            conflictingJobStatus: conflict.status,
-          },
-        );
-      }
+      await tx.execute(elizaProvisionAdvisoryLockSql(identity.organizationId, identity.agentId));
       const [currentJob] = await tx
         .select({ id: jobs.id })
         .from(jobs)
@@ -4253,6 +4372,68 @@ export class ProvisioningJobService {
         throw new Error(`Lifecycle execution generation is no longer current: ${job.id}`);
       }
 
+      const [sandboxAuthority] = await tx
+        .select({ executionTier: agentSandboxes.execution_tier })
+        .from(agentSandboxes)
+        .where(
+          and(
+            eq(agentSandboxes.id, identity.agentId),
+            eq(agentSandboxes.organization_id, identity.organizationId),
+          ),
+        )
+        .for("update")
+        .limit(1);
+      if (
+        requiresContainerBackedTarget(job.type) &&
+        (!sandboxAuthority || !isContainerBackedExecutionTier(sandboxAuthority.executionTier))
+      ) {
+        throw new RejectedAgentExecutionError(
+          `${CONTAINER_BACKED_TARGET_REQUIRED_MESSAGE}: ${job.type}`,
+          {
+            jobId: job.id,
+            jobType: job.type,
+            columnAgentId: job.agent_id,
+            columnOrganizationId: job.organization_id,
+            payloadAgentId: identity.agentId,
+            payloadOrganizationId: identity.organizationId,
+            executionTier: sandboxAuthority?.executionTier ?? "missing",
+          },
+        );
+      }
+
+      if (!EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES.includes(job.type as ProvisioningJobType)) return;
+
+      const [conflict] = await tx
+        .select({ id: jobs.id, type: jobs.type, status: jobs.status })
+        .from(jobs)
+        .where(
+          and(
+            eq(jobs.organization_id, job.organization_id),
+            eq(jobs.agent_id, identity.agentId),
+            inArray(jobs.type, EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES),
+            ne(jobs.id, job.id),
+            sql`${jobs.status} IN ('pending', 'in_progress')`,
+            // A manual suspend may be a durable follow-up to an already claimed
+            // billing suspend. Both executions serialize on the sandbox row in
+            // executeSuspend; treating them as a conflict would strand the
+            // unconditional follow-up behind the stale hydrated billing job.
+            or(ne(jobs.type, job.type), ne(jobs.type, JOB_TYPES.AGENT_SUSPEND)),
+          ),
+        )
+        .orderBy(desc(jobs.created_at))
+        .limit(1);
+      if (conflict) {
+        throw new ApiError(
+          409,
+          "session_not_ready",
+          `Agent ${job.agent_id} has conflicting ${conflict.type} job ${conflict.id}`,
+          {
+            conflictingJobId: conflict.id,
+            conflictingJobType: conflict.type,
+            conflictingJobStatus: conflict.status,
+          },
+        );
+      }
       const [claimedSandbox] = await tx
         .update(agentSandboxes)
         .set({
@@ -4261,8 +4442,8 @@ export class ProvisioningJobService {
         })
         .where(
           and(
-            eq(agentSandboxes.id, job.agent_id!),
-            eq(agentSandboxes.organization_id, job.organization_id),
+            eq(agentSandboxes.id, identity.agentId),
+            eq(agentSandboxes.organization_id, identity.organizationId),
             or(
               isNull(agentSandboxes.lifecycle_execution_generation),
               and(
@@ -4279,8 +4460,8 @@ export class ProvisioningJobService {
           .from(agentSandboxes)
           .where(
             and(
-              eq(agentSandboxes.id, job.agent_id!),
-              eq(agentSandboxes.organization_id, job.organization_id),
+              eq(agentSandboxes.id, identity.agentId),
+              eq(agentSandboxes.organization_id, identity.organizationId),
             ),
           )
           .limit(1);

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -4306,6 +4306,10 @@ export class ProvisioningJobService {
           throw new Error(`No identity parser for agent job type ${job.type}`);
       }
     } catch (cause) {
+      // error-policy:J3 an unparseable job payload becomes an explicit terminal
+      // rejection, never a fake-valid identity. The cause is carried as a
+      // string rather than the Error so a malformed payload cannot smuggle a
+      // value into the persisted failure row.
       throw new RejectedAgentExecutionError(`Invalid agent job payload for job ${job.id}`, {
         jobId: job.id,
         jobType: job.type,


### PR DESCRIPTION
# Relates to

Related to #22947. This is slice C of the remaining admission barriers; it does not close the issue.

- [x] This PR targets `develop` and is rebased onto `origin/develop` `15e36f445282ec0ce478ef79a05c8ba0dbbeafbc` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync; exact unrelated blockers are recorded below and reproduced on clean `develop`.
- [x] A reviewer can confirm the change from the exact-head unit, real-PGlite, and independent-review evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/GPT-5.6`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` `15e36f445282ec0ce478ef79a05c8ba0dbbeafbc`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact unrelated i18n blocker is documented below and matches clean `develop` by key name.

# Risks

Medium. This changes admission and pre-dispatch settlement for every agent lifecycle job. A false rejection could stop a legitimate container operation; an overly broad exception could let Shared rows reach container services. The classification is explicit, the tier check uses the canonical allowlist, Shared message/delete are positive-tested exceptions, and the exact claim/lease settlement is exercised against real PGlite state. No provider call, migration, live row, billing price, autoscaling, route, or deployment changes.

# Background

## What does this PR do?

- Classifies exactly eleven agent lifecycle operations as requiring a container-backed target; Shared message delivery and logical deletion remain explicit exceptions.
- Rejects Shared, missing, unknown, or corrupt target authority inside the existing advisory-lock plus sandbox-row `FOR UPDATE` enqueue transaction, before conflict lookup, reuse, or insertion.
- Cross-checks payload agent/organization identity and revalidates the exact active generation, non-quiesced state, live owner lease, and locked target tier before any agent handler runs, including logs, snapshot, message, and delete.
- Keeps the existing conflict check and lifecycle resource fence after the common preflight for exclusive jobs only.
- Adds an idempotent pre-dispatch terminal rejection: job row lock first, same-generation terminal replay before lease lookup, exact live generation/owner lease, one failed transition, one attempt, identical terminal timestamps, and exact lease deletion. It never invokes lifecycle failure writeback or mutates the sandbox.

Historical authors inventoried on the affected seams: Bill Ding, byt61, ngngocnhan1997-hub, nothingxnowhere, NubsCarson, Shaw, Sol, Stan, and Tradi3.

## What kind of change is this?

Bug fix (non-breaking lifecycle admission and execution-authority hardening).

# Documentation changes needed?

No project-documentation change is required. Canonical metadata, invariant comments, and the focused tests document this boundary. Provider/service re-entry and the append-only migration remain separate #22947 slices.

# Testing

## Where should a reviewer start?

Start with `enqueueLifecycleJobInTx` and `assertNoConflictingLifecycleExecution` in `packages/cloud/shared/src/lib/services/provisioning-jobs.ts`, then `JobsRepository.rejectClaimedExecution`, and finally `provisioning-jobs-container-tier-guard.pglite.test.ts`.

## Detailed testing steps

Exact validated head: `66a05583c34a84f647589054e135718d05fc350d` under Node `24.15.0` and Bun `1.3.14`.

- `bun install --frozen-lockfile` — exit 0 after the final rebase.
- `provisioning-jobs-container-tier-guard.pglite.test.ts` — 7 pass, 0 fail, 73 assertions against real isolated PGlite state.
- `provisioning-job-types.test.ts` plus `provisioning-jobs-scheduled-backup-sentinel.test.ts` — 70 pass, 0 fail, 280 assertions.
- `provisioning-jobs-lease-heartbeat.test.ts` — 5 pass, 0 fail, 15 assertions.
- `provisioning-jobs-execute-dispatch.test.ts` — 54 pass, 0 fail, 282 assertions.
- `provisioning-jobs-wake-enqueue.test.ts` — 5 pass, 0 fail, 35 assertions.
- `bun run --cwd packages/cloud/shared lint:check` — 2,239 files checked, exit 0, no fixes applied.
- Changed-file Biome and `git diff --check` — exit 0.
- Independent read-only review on pre-rebase head `d684fe3b24c56305df18a3fa8c12fad518336338` found no P0-P2 blocker. The final rebase to `66a05583c34a84f647589054e135718d05fc350d` has the same stable patch-id and an equal range-diff; final-head review is recorded separately before merge.

# Evidence Gate

<!-- evidence-head:66a05583c34a84f647589054e135718d05fc350d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only lifecycle admission change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only lifecycle admission change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible interaction or frontend flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend was changed; the real enqueue, claim, lease, preflight, and settlement paths are exercised against isolated PGlite at the exact head.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, request, or state changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent prompt, model, action, or provider behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - domain artifacts are ephemeral isolated-PGlite job, lease, and sandbox rows asserted directly by the focused suite; no persistent or live row was created.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM-call behavior changed.

## Backend + frontend logs

N/A - no deployed surface was mutated. Exact-head test results above record execution through the real repository and PGlite paths.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- `provisioning-jobs-delete-lifecycle.test.ts`: 9 pass / 1 fail at this head. The remaining failure reproduces on clean `develop` `15e36f445282ec0ce478ef79a05c8ba0dbbeafbc` by exact name: `ProvisioningJobService — retryable readiness transport does not burn attempts > agent_provision retryable false-negative is requeued without terminal failure`. The baseline has an additional unrelated synthetic-suspend fixture failure; this PR makes that fixture explicit.
- `provisioning-jobs-agent-downgrade.test.ts`: 1 pass / 1 fail here and on the same clean `develop`, by exact name: `ProvisioningJobService agent_downgrade > treats rollback refusal as a failed attempt, not a silent no-op`.
- Cloud-shared typecheck stops at `shared-runtime/conversation-coordinator.ts:241` (`URL | RequestInfo` is not assignable to `string | URL`), exactly reproduced on the same clean `develop`.
- Root `bun run verify` stops in `check:i18n` on the same seven missing English connector-account keys as clean `develop`: five `connectoraccount.capabilities.*` keys plus `connectoraccount.reconnect` and `connectoraccount.reconnectLabel`.
- Root `bun run build:core` completes the core bundles and declarations, then both this head and clean `develop` stop in the local mise `npm` shell shim when Node parses `set -euo pipefail`; this is an environment-level packaging failure, not a source/build delta.
- GitHub Actions are not used as acceptance evidence because repository concurrency currently leaves checks queued/cancelled; evidence above is local at the exact head with real exit codes.

# Deploy Notes

No manual deploy and no live-data operation. This PR contains no migration and no provider/service re-entry guard; those remain later #22947 slices.

AI provider/model: OpenAI / GPT-5.6
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-enqueue-worker-tier]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5.6","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
