### PR TITLE
fix(cloud): bound the three un-deadlined OAuth token-refresh hops

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/token-refresh.hop-deadline.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/token-refresh.hop-deadline.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Pins the outbound deadline on the three OAuth token-refresh hops that shipped
+ * without one: `refreshMetaToken`, `refreshLinkedInToken` and `refreshTikTokToken`
+ * in `token-refresh.ts`. The fourth arm of the same `refreshToken` switch
+ * (twitter) already routes through `requestTwitterOAuth2Token`, which has carried
+ * `AbortSignal.timeout(TWITTER_OAUTH2_TOKEN_TIMEOUT_MS)` since it was written --
+ * the three hops here were the asymmetry.
+ *
+ * The hung arms are driven against a REAL `http.createServer` that accepts the
+ * socket and never writes a response, not a stubbed `fetch`. A stub can only show
+ * that a wrapper forwards a signal; only a real socket shows that the transport
+ * actually gives up.
+ *
+ * Every hung arm is a race against an explicit watchdog: the test-runner timeout
+ * does NOT interrupt a never-settling `fetch`, so an unbounded regression would
+ * hang the suite instead of failing it. Racing a watchdog turns that back into a
+ * plain assertion failure, and asserting the abort reason is specifically
+ * `TimeoutError` means a "just drop the caller signal" non-fix fails too.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, mock } from "bun:test";
+import http from "node:http";
+
+import type { SocialCredentials } from "../../types/social-media";
+import { refreshToken, tokenRefreshFetch } from "./token-refresh";
+
+const HOP_TIMEOUT_MS = 150;
+const WATCHDOG_MS = 5_000;
+
+let blackHole: http.Server;
+let blackHoleUrl: string;
+let responsive: http.Server;
+let responsiveUrl: string;
+
+function listen(server: http.Server): Promise<string> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as { port: number };
+      resolve(`http://127.0.0.1:${address.port}/`);
+    });
+  });
+}
+
+/**
+ * Resolve to the call's outcome, or to the sentinel if it is still pending after
+ * `WATCHDOG_MS`. Without this an un-deadlined hop never settles and the runner
+ * reports a hang rather than a failed expectation.
+ */
+async function raceWatchdog(pending: Promise<unknown>): Promise<string> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const watchdog = new Promise<string>((resolve) => {
+    timer = setTimeout(() => resolve("STILL-PENDING"), WATCHDOG_MS);
+  });
+  try {
+    return await Promise.race([
+      pending.then(
+        () => "resolved",
+        (error: unknown) => `rejected:${(error as Error).name}`,
+      ),
+      watchdog,
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+beforeAll(async () => {
+  blackHole = http.createServer(() => {
+    // Accept the request and never answer it.
+  });
+  blackHoleUrl = await listen(blackHole);
+
+  responsive = http.createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end('{"ok":true}');
+  });
+  responsiveUrl = await listen(responsive);
+});
+
+afterAll(() => {
+  blackHole.close();
+  responsive.close();
+});
+
+describe("tokenRefreshFetch bounds the OAuth refresh hop", () => {
+  it("aborts a hop against a peer that never answers", async () => {
+    const started = Date.now();
+    const outcome = await raceWatchdog(tokenRefreshFetch(blackHoleUrl, undefined, HOP_TIMEOUT_MS));
+
+    expect(outcome).toBe("rejected:TimeoutError");
+    expect(Date.now() - started).toBeLessThan(WATCHDOG_MS);
+  });
+
+  it("lets a caller-provided abort signal win with its own reason", async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(new Error("caller-cancelled")), 50);
+
+    // A 30s deadline that must NOT be what settles this call.
+    const pending = tokenRefreshFetch(blackHoleUrl, { signal: controller.signal }, 30_000);
+
+    await expect(pending).rejects.toThrow("caller-cancelled");
+  });
+
+  it("still aborts at the deadline when the caller signal never fires", async () => {
+    // Guards the `signal: init?.signal ?? deadline` non-fix: a request-scoped
+    // controller that outlives the hop would silently restore the unbounded wait.
+    const caller = new AbortController();
+    const started = Date.now();
+
+    const outcome = await raceWatchdog(
+      tokenRefreshFetch(blackHoleUrl, { signal: caller.signal }, HOP_TIMEOUT_MS),
+    );
+
+    expect(outcome).toBe("rejected:TimeoutError");
+    expect(caller.signal.aborted).toBe(false);
+    expect(Date.now() - started).toBeLessThan(WATCHDOG_MS);
+  });
+
+  it("leaves an ordinary fast hop unchanged", async () => {
+    const response = await tokenRefreshFetch(responsiveUrl);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('{"ok":true}');
+  });
+});
+
+/**
+ * The wrapper existing is not enough: each of the three refreshers has to route
+ * through it. This pins the request-side contract at the transport boundary, so a
+ * re-introduced bare `fetch()` in any of them fails here even though the wrapper
+ * itself is still correct.
+ */
+describe("every token-refresh hop routes through the bounded wrapper", () => {
+  const realFetch = globalThis.fetch;
+  const originalEnv = { ...process.env };
+
+  beforeAll(() => {
+    process.env.META_APP_ID = "app";
+    process.env.META_APP_SECRET = "secret";
+    process.env.LINKEDIN_CLIENT_ID = "cid";
+    process.env.LINKEDIN_CLIENT_SECRET = "csecret";
+    process.env.TIKTOK_CLIENT_KEY = "ckey";
+    process.env.TIKTOK_CLIENT_SECRET = "csecret";
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  const drives: Array<[string, () => Promise<unknown>]> = [
+    [
+      "meta (facebook/instagram)",
+      () =>
+        refreshToken("facebook", {
+          platform: "facebook",
+          accessToken: "tok",
+        } as SocialCredentials),
+    ],
+    [
+      "linkedin",
+      () =>
+        refreshToken("linkedin", {
+          platform: "linkedin",
+          accessToken: "tok",
+          refreshToken: "rtok",
+        } as SocialCredentials),
+    ],
+    [
+      "tiktok",
+      () =>
+        refreshToken("tiktok", {
+          platform: "tiktok",
+          accessToken: "tok",
+          refreshToken: "rtok",
+        } as SocialCredentials),
+    ],
+  ];
+
+  for (const [name, drive] of drives) {
+    it(`${name} hands the transport an abort signal`, async () => {
+      const seen: Array<AbortSignal | null | undefined> = [];
+      globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        seen.push(init?.signal);
+        return new Response(
+          JSON.stringify({ access_token: "new", refresh_token: "new-r", expires_in: 3600 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }) as unknown as typeof fetch;
+
+      const result = await drive();
+
+      expect(seen.length).toBeGreaterThan(0);
+      for (const signal of seen) {
+        expect(signal).toBeInstanceOf(AbortSignal);
+      }
+      // The refresh still returns its normal result: the deadline is additive.
+      expect((result as { accessToken: string }).accessToken).toBe("new");
+    });
+  }
+});

--- a/packages/cloud/shared/src/lib/services/social-media/token-refresh.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/token-refresh.ts
@@ -2,9 +2,42 @@
 import type { SocialCredentials, SocialPlatform } from "../../types/social-media";
 import { parseJsonErrorBody } from "../../utils/json-parsing";
 import { logger } from "../../utils/logger";
-import { requestTwitterOAuth2Token } from "../twitter-automation/oauth2-client";
+import {
+  requestTwitterOAuth2Token,
+  TWITTER_OAUTH2_TOKEN_TIMEOUT_MS,
+} from "../twitter-automation/oauth2-client";
 
 const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000; // Refresh 5 minutes before expiry
+
+/**
+ * Deadline for one outbound OAuth token-refresh hop.
+ *
+ * Pinned to the value the twitter arm of {@link refreshToken} already ships
+ * (`TWITTER_OAUTH2_TOKEN_TIMEOUT_MS`, 20 s) so the four arms of the same switch
+ * agree instead of only one of them terminating.
+ */
+const TOKEN_REFRESH_TIMEOUT_MS = TWITTER_OAUTH2_TOKEN_TIMEOUT_MS;
+
+/**
+ * Bound every outbound OAuth token-refresh hop so a hung provider IdP cannot pin
+ * the credential path indefinitely.
+ *
+ * A caller-provided signal is composed with the deadline rather than replacing
+ * it — a caller that cancels still aborts early, and a caller whose signal never
+ * fires still cannot outlive the bound. Same contract as `alertFetch`
+ * (`social-media/alerts.ts`) next door.
+ */
+export function tokenRefreshFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = TOKEN_REFRESH_TIMEOUT_MS,
+): Promise<Response> {
+  const deadline = AbortSignal.timeout(timeoutMs);
+  return fetch(input, {
+    ...init,
+    signal: init?.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
+  });
+}
 
 interface RefreshResult {
   accessToken: string;
@@ -59,7 +92,7 @@ async function refreshMetaToken(accessToken: string): Promise<RefreshResult> {
 
   if (!appId || !appSecret) throw new Error("META_APP_ID or META_APP_SECRET not configured");
 
-  const response = await fetch(
+  const response = await tokenRefreshFetch(
     `https://graph.facebook.com/v19.0/oauth/access_token?` +
       new URLSearchParams({
         grant_type: "fb_exchange_token",
@@ -88,7 +121,7 @@ async function refreshLinkedInToken(refreshToken: string): Promise<RefreshResult
   if (!clientId || !clientSecret)
     throw new Error("LINKEDIN_CLIENT_ID or LINKEDIN_CLIENT_SECRET not configured");
 
-  const response = await fetch("https://www.linkedin.com/oauth/v2/accessToken", {
+  const response = await tokenRefreshFetch("https://www.linkedin.com/oauth/v2/accessToken", {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({
@@ -123,7 +156,7 @@ async function refreshTikTokToken(refreshToken: string): Promise<RefreshResult> 
   if (!clientKey || !clientSecret)
     throw new Error("TIKTOK_CLIENT_KEY or TIKTOK_CLIENT_SECRET not configured");
 
-  const response = await fetch("https://open.tiktokapis.com/v2/oauth/token/", {
+  const response = await tokenRefreshFetch("https://open.tiktokapis.com/v2/oauth/token/", {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({


### PR DESCRIPTION
# Relates to

Fixes #23862

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (branched off `3cfde651ae70db8e7276846ad5f15f4bf27120fe`).
- [x] `bun install` was run after sync. `bun run verify` was **not** run
      monorepo-wide — see **Known gaps / failures**; the focused suite, the whole
      `social-media` directory measured against an untouched control, the package
      typecheck against an untouched control, and biome on both touched files
      were run and are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after real-socket measurements below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched off the latest `origin/develop` (`3cfde651ae70`); zero conflicts.
- [ ] `bun run verify` post-sync — not run monorepo-wide; the exact scope that
      was run, and why the wider run was skipped, is in **Known gaps / failures**.

# Risks

**Low.** One file gains one wrapper function copied from `alertFetch` next door,
and its three existing `fetch(` call sites are re-pointed at it. Nothing an
ordinary caller observes changes: a call with no signal now has a 20 s bound
where it previously had none, a fast call is unaffected, and a caller that aborts
early still aborts early with its own reason — the last two are asserted against
a real socket, not argued (see *No over-rejection*).

# Background

## What does this PR do?

Three of the four arms of `refreshToken` in
`packages/cloud/shared/src/lib/services/social-media/token-refresh.ts` call bare
`fetch()` with **no `signal` at all**:

| file:line | function | platform |
|---|---|---|
| `token-refresh.ts:62` | `refreshMetaToken` | `facebook`, `instagram` |
| `token-refresh.ts:91` | `refreshLinkedInToken` | `linkedin` |
| `token-refresh.ts:126` | `refreshTikTokToken` | `tiktok` |

A provider IdP that completes the TCP handshake and then never writes a response
pins `SocialMediaService.getCredentialsForPlatform` with nothing to cancel it.
This is not a slow call; there is no upper bound at all.

The file now carries the wrapper `alertFetch` already uses in this very
directory (`social-media/alerts.ts:13-23`), copied rather than reinvented:

```ts
export function tokenRefreshFetch(
  input: RequestInfo | URL,
  init?: RequestInit,
  timeoutMs: number = TOKEN_REFRESH_TIMEOUT_MS,
): Promise<Response> {
  const deadline = AbortSignal.timeout(timeoutMs);
  return fetch(input, {
    ...init,
    signal: init?.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
  });
}
```

…and all three call sites route through it. The deadline is composed with any
caller signal from the start, so this does not reintroduce the `??` defect that
#23822 closed in the four wrappers next door — and there is a dedicated
regression case for exactly that, proven load-bearing in step 5, Arm C.

## Why this one is an asymmetry, not just a leftover timeout

The **fourth** arm of the same `switch` is already bounded. `twitter` routes
through `requestTwitterOAuth2Token`
(`services/twitter-automation/oauth2-client.ts:90-95`), which has always passed
`signal: AbortSignal.timeout(TWITTER_OAUTH2_TOKEN_TIMEOUT_MS)` — 20 s. One arm
of `refreshToken` terminates; three do not.

So the constant here is not a new policy number. It **is**
`TWITTER_OAUTH2_TOKEN_TIMEOUT_MS`, imported:

```ts
const TOKEN_REFRESH_TIMEOUT_MS = TWITTER_OAUTH2_TOKEN_TIMEOUT_MS;
```

The four arms of the switch now agree by construction rather than by
coincidence, and a future change to the twitter budget moves all four together.

## Blast radius: the credit deduction is stranded, not just the request

`refreshToken` is awaited at `social-media/index.ts:145` inside
`getCredentialsForPlatform`. In `createPost`:

- `creditsService.deductCredits(...)` runs at `index.ts:332`, **before** the
  per-platform work;
- the per-platform work runs in `Promise.all` at `index.ts:341`;
- `creditsService.refundCredits(...)` for failed platforms runs at
  `index.ts:387`, **after** that `Promise.all` settles.

The per-platform `try/catch` is deliberately written to convert a thrown
credential error into a settled `{success:false}` so the refund runs — its own
`error-policy:J1` comment says exactly that. A hop that never settles is not a
thrown error: the `Promise.all` never resolves, so the refund at `:387` never
executes and the org stays charged for a post that never returns. One stalled
IdP is enough, because `Promise.all` waits for its slowest arm.

## Amplification: measured, and smaller than the sibling's — said plainly

#23849 reported that its per-attempt deadline still totals 127 s because
`withRetry(..., { maxRetries: 3 })` replays the hop four times. **That does not
apply here, and I am not claiming it does.** There is no `withRetry` anywhere on
the `getCredentialsForPlatform` path; `refreshToken` is a plain `await` at
`index.ts:145`. So the honest numbers are:

- before: **unbounded** per platform;
- after: **20 s** per platform, once, not multiplied;
- with N platforms in one `createPost`, the arms run concurrently in
  `Promise.all`, so the added worst case is 20 s total, not 20 s × N.

Measured end to end at the shipped constant in step 2 below (20 004 / 20 002 /
20 003 ms). What this buys is a bound where there was none. It does not make the
20 s wait free, and it does not add an operation-level budget — see
**Known gaps / failures**.

## Deliberate narrowings

Three claims a reviewer might expect here, and why they are **not** made:

- **No SSRF hardening.** #22579 ("guard social media SSRF with `safeFetch`") was
  **closed**, not merged. `safeFetch` is therefore deliberately not re-proposed
  for this surface; this PR changes deadlines only and twins nothing. All three
  destinations here are hardcoded vendor hosts anyway — unlike `mastodon` next
  door, none of them is configuration-supplied.
- **`refreshToken`'s signature is not widened.** The wrapper composes a
  caller-supplied signal, but `refreshToken(platform, credentials)` is not given
  a new `options.signal` parameter, because no live caller has a signal to pass:
  `getCredentialsForPlatform` takes none. That mirrors `alertFetch`, whose
  composition arm is likewise reachable only from tests today. Adding a
  parameter no caller can fill would be API surface without a user.
- **The twitter arm is untouched.** It is already bounded; re-routing it through
  the new wrapper would change nothing except the diff size.

## Relationship to #23849

#23849 (four social-media *provider* hops) confirmed these three lines and
explicitly held them out of scope in its Known gaps, calling folding them in "a
sweep rather than one defect". This PR is that follow-up: a different module, a
different failure surface (OAuth credential acquisition, not publishing), a
different amplification story (no retry ladder; a stranded credit deduction
instead), and a different constant with its own in-module justification. All
three lines were re-verified here from scratch rather than inherited — the origin
reproduction in step 1 was run on a clean `origin/develop` worktree.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The new wrapper
and the timeout constant each carry a docblock stating exactly what they do,
including the caller-signal composition and why the constant is the twitter one.

# Testing

## Where should a reviewer start?

`social-media/token-refresh.hop-deadline.test.ts`, then the 20-line wrapper at
the top of `token-refresh.ts`.

## Detailed testing steps

```bash
git fetch origin develop && git checkout <this branch>
bun install
node packages/shared/scripts/generate-keywords.mjs   # see Known gaps
bun run --cwd packages/cloud/shared test \
  src/lib/services/social-media/token-refresh.hop-deadline.test.ts
```

### 1. Origin reproduction — real exported `refreshToken`, real non-responding socket

A real `http.createServer` that accepts the request and never answers it. The
real exported `refreshToken` is driven against it and the runtime's own `fetch`
is the transport — no `fetch` stub, because a stub can only show that a signal is
forwarded, not that the transport actually gives up. The three refreshers
hardcode their hosts, so a shim rewrites only the destination and forwards `init`
— including the absent `signal` — verbatim to the real `fetch`.

Every arm is a race against a 45 s watchdog, because a test-runner timeout does
**not** interrupt a never-settling `fetch`; without the watchdog an unbounded hop
hangs the harness instead of failing it.

```
$ git rev-parse HEAD
3cfde651ae70db8e7276846ad5f15f4bf27120fe
$ git status --porcelain      # clean
$ WATCHDOG_MS=45000 bun run repro-tokenrefresh-mine.ts
black-hole peer: http://127.0.0.1:63214/   watchdog: 45000 ms
token-refresh.ts:62  refreshMetaToken     (facebook)  ->  STILL-PENDING  after 45003 ms   signal-handed-to-transport=undefined
token-refresh.ts:91  refreshLinkedInToken (linkedin)  ->  STILL-PENDING  after 45002 ms   signal-handed-to-transport=undefined
token-refresh.ts:126 refreshTikTokToken   (tiktok)  ->  STILL-PENDING  after 45003 ms   signal-handed-to-transport=undefined
```

Three of three. `STILL-PENDING` is the harness abandoning a hop that had no
deadline; `signal-handed-to-transport=undefined` is the cause.

### 2. AFTER — same socket, same driver, this branch, at the shipped constant

```
$ WATCHDOG_MS=45000 bun run repro-tokenrefresh-mine.ts
black-hole peer: http://127.0.0.1:49161/   watchdog: 45000 ms
token-refresh.ts:62  refreshMetaToken     (facebook)  ->  rejected:TimeoutError:The operation timed out.  after 20004 ms   signal-handed-to-transport=AbortSignal
token-refresh.ts:91  refreshLinkedInToken (linkedin)  ->  rejected:TimeoutError:The operation timed out.  after 20002 ms   signal-handed-to-transport=AbortSignal
token-refresh.ts:126 refreshTikTokToken   (tiktok)  ->  rejected:TimeoutError:The operation timed out.  after 20003 ms   signal-handed-to-transport=AbortSignal
```

Note these are the **real 20 s constant**, not a test override — the same value
the twitter arm has always used. There is no retry ladder here to multiply it.

### 3. No over-rejection — proved, not asserted

- **An early caller abort still wins, with its own reason.**
  `tokenRefreshFetch(blackhole, { signal }, 30_000)` with the caller aborting at
  50 ms rejects with `caller-cancelled`, not a `TimeoutError`. Composition must
  not cost the caller its cancellation. Pinned in the suite.
- **A caller signal that never fires does not disable the deadline.** The suite
  asserts a hop with a live, never-firing caller `AbortController` still rejects
  with `TimeoutError` and that `caller.signal.aborted === false`. This is the
  `signal: init?.signal ?? deadline` regression #23822 had to fix, and step 5
  Arm C shows this case is the one that catches it.
- **Ordinary fast calls are unchanged.** A responsive peer answers through the
  wrapper at the shipped default with status 200 and the body intact.
- **The refresh result is unchanged.** Each call-site case asserts the driven
  `refreshToken` still returns its normal `{ accessToken: "new" }` — the deadline
  is additive, not a behaviour change.
- **The whole `social-media` directory is unchanged apart from the added tests**
  — measured against an untouched control in step 6.
- The regression test asserts the abort reason is specifically a
  **`TimeoutError`**, not merely "something aborted", so a fix that dropped the
  caller signal instead of composing it would not slip past either.

### 4. AFTER — the focused suite

```
$ bun test src/lib/services/social-media/token-refresh.hop-deadline.test.ts \
           src/lib/services/social-media/token-refresh.expiry.test.ts
bun test v1.3.14 (0d9b296a)

 11 pass
 0 fail
 22 expect() calls
Ran 11 tests across 2 files. [1151.00ms]
```

### 5. Load-bearing check — three arms, each isolating one layer

Reverted by copy-aside, never `git stash`, and restored afterwards.

**Arm A — the deadline stripped from the wrapper, call sites left routed
(`return fetch(input, init)`):**

```
Expected: "rejected:TimeoutError"
Received: "STILL-PENDING"
(fail) tokenRefreshFetch bounds the OAuth refresh hop > aborts a hop against a peer that never answers [5002.29ms]
Expected: "rejected:TimeoutError"
Received: "STILL-PENDING"
(fail) tokenRefreshFetch bounds the OAuth refresh hop > still aborts at the deadline when the caller signal never fires [5002.31ms]
(fail) every token-refresh hop routes through the bounded wrapper > meta (facebook/instagram) hands the transport an abort signal [0.45ms]
(fail) every token-refresh hop routes through the bounded wrapper > linkedin hands the transport an abort signal [0.13ms]
(fail) every token-refresh hop routes through the bounded wrapper > tiktok hands the transport an abort signal [0.11ms]
 2 pass
 5 fail
Ran 7 tests across 1 file. [10.32s]
```

Note the `~5002ms` figures and the `STILL-PENDING` sentinel: those assertions are
written as a race against a 5 s watchdog rather than a bare `await`, precisely
because an unbounded hop never settles. A regression therefore surfaces as
`expect("STILL-PENDING").toBe("rejected:TimeoutError")` in about five seconds
instead of hanging CI until the runner's own timeout. That was measured, not
assumed.

**Arm B — the wrapper left correct, the three call sites reverted to bare
`fetch`:**

```
Expected constructor: [class AbortSignal extends EventTarget]
Received value: undefined
(fail) every token-refresh hop routes through the bounded wrapper > meta (facebook/instagram) hands the transport an abort signal [0.55ms]
(fail) every token-refresh hop routes through the bounded wrapper > linkedin hands the transport an abort signal [0.14ms]
(fail) every token-refresh hop routes through the bounded wrapper > tiktok hands the transport an abort signal [0.11ms]
 4 pass
 3 fail
Ran 7 tests across 1 file. [1201.00ms]
```

Only the call-site cases fail; the wrapper cases stay green. A wrapper that is
correct but unused would pass a wrapper-only test, which is why this arm exists.

**Arm C — the `??` non-fix (`signal: init?.signal ?? deadline`), everything else
correct:**

```
Expected: "rejected:TimeoutError"
Received: "STILL-PENDING"
(fail) tokenRefreshFetch bounds the OAuth refresh hop > still aborts at the deadline when the caller signal never fires [5002.49ms]
 6 pass
 1 fail
Ran 7 tests across 1 file. [5.45s]
```

Exactly one case fails, and it is the one written for this. The composition is
not decoration: replacing it with `??` is caught specifically.

**Restored:**

```
 7 pass
 0 fail
 17 expect() calls
Ran 7 tests across 1 file. [1199.00ms]
```

### 6. Whole-directory suite, branch vs untouched control

```
$ bun test src/lib/services/social-media/          # this branch
 152 pass   3 fail   4 errors   366 expect() calls
Ran 155 tests across 20 files. [101.52s]

# control: the same tree with token-refresh.ts restored to origin/develop
# and the new test file removed
$ bun test src/lib/services/social-media/
 145 pass   3 fail   4 errors   349 expect() calls
Ran 148 tests across 19 files. [65.87s]
```

+7 passing tests, **zero** new failures. The 3 failures are identical on both
sides and pre-existing; one of them is
`providers/tiktok.error-policy.test.ts:160` using `test` without importing it
from `bun:test`. Neither is touched by this diff.

### 7. Typecheck — zero errors added, measured against an untouched control

```
$ bun run --cwd packages/cloud/shared typecheck     # this branch
src/lib/services/shared-runtime/conversation-coordinator.ts(241,85): error TS2345: Argument of type 'URL | RequestInfo' is not assignable to parameter of type 'string | URL'.
  Type 'Request' is not assignable to type 'string | URL'.

# control: the same tree with token-refresh.ts restored to origin/develop
$ bun run --cwd packages/cloud/shared typecheck
src/lib/services/shared-runtime/conversation-coordinator.ts(241,85): error TS2345: Argument of type 'URL | RequestInfo' is not assignable to parameter of type 'string | URL'.
  Type 'Request' is not assignable to type 'string | URL'.
```

Identical. The single error is pre-existing, in a file this PR does not touch.

### 8. Biome

```
$ bunx @biomejs/biome check \
    packages/cloud/shared/src/lib/services/social-media/token-refresh.ts \
    packages/cloud/shared/src/lib/services/social-media/token-refresh.hop-deadline.test.ts
Checked 2 files in 27ms. No fixes applied.
```

# Evidence Gate

<!-- evidence-head:be01d59a8606b75afe9173080e4831215b52e206 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only change to one Cloud service module; no rendered UI surface is touched by this diff.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only change to one Cloud service module; no rendered UI surface is touched by this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the observable behaviour is whether an outbound hop terminates, shown as before/after wall-clock measurements against a real socket in Testing above.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — pasted below (the
      real exported `refreshToken` driven against a real `http.createServer`,
      plus the real suite and all three revert arms).

<details><summary>BEFORE — <code>origin/develop</code> 3cfde651ae70, real never-answering socket</summary>

```
black-hole peer: http://127.0.0.1:63214/   watchdog: 45000 ms
token-refresh.ts:62  refreshMetaToken     (facebook)  ->  STILL-PENDING  after 45003 ms   signal-handed-to-transport=undefined
token-refresh.ts:91  refreshLinkedInToken (linkedin)  ->  STILL-PENDING  after 45002 ms   signal-handed-to-transport=undefined
token-refresh.ts:126 refreshTikTokToken   (tiktok)  ->  STILL-PENDING  after 45003 ms   signal-handed-to-transport=undefined
```

</details>

<details><summary>AFTER — this branch, same socket, same driver, shipped 20 s constant</summary>

```
black-hole peer: http://127.0.0.1:49161/   watchdog: 45000 ms
token-refresh.ts:62  refreshMetaToken     (facebook)  ->  rejected:TimeoutError:The operation timed out.  after 20004 ms   signal-handed-to-transport=AbortSignal
token-refresh.ts:91  refreshLinkedInToken (linkedin)  ->  rejected:TimeoutError:The operation timed out.  after 20002 ms   signal-handed-to-transport=AbortSignal
token-refresh.ts:126 refreshTikTokToken   (tiktok)  ->  rejected:TimeoutError:The operation timed out.  after 20003 ms   signal-handed-to-transport=AbortSignal

$ bun test src/lib/services/social-media/token-refresh.hop-deadline.test.ts src/lib/services/social-media/token-refresh.expiry.test.ts
bun test v1.3.14 (0d9b296a)

 11 pass
 0 fail
 22 expect() calls
Ran 11 tests across 2 files. [1151.00ms]
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path; this module runs server-side in Cloud only.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behaviour changes; this is an HTTP hop deadline.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB rows, memories, scheduled tasks, on-chain output, or generated files are produced or altered.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behaviour changes.`

## Backend + frontend logs

Backend: inline in **Testing → 1, 2, 4, 5, 6** (the real exported `refreshToken`
driven against a real non-responding `http.createServer`, the real suite, all
three per-layer revert arms, and the whole-directory branch-vs-control run).

Frontend: `N/A - server-side module.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT, or omnivoice surface.`

## Known gaps / failures

- **The 20 s deadline is per hop, and there is no operation-level budget.**
  Unlike the provider hops in #23849 there is no retry ladder to multiply it —
  I checked, `getCredentialsForPlatform` has no `withRetry` — so 20 s per
  platform is the whole added cost, and concurrent `Promise.all` arms do not sum.
  But it is still a bound on one hop, not a budget for the whole `createPost`. A
  reviewer who wants an operation-level budget should say so; I did not add one,
  because that is a policy change none of the already-bounded siblings made.
- **No SSRF guard.** #22579 proposed `safeFetch` for exactly this surface and was
  **closed**, so re-proposing it here would twin a closed PR. Stated explicitly
  so the omission does not read as an oversight. Note all three hosts here are
  hardcoded vendor constants, so the SSRF argument that applies to `mastodon` in
  #23849 does not apply to this file at all.
- **`refreshToken`'s signature is not widened to take a caller signal.** The
  wrapper composes one if given, but no live caller has one. That arm is
  therefore exercised only by the suite today — exactly as `alertFetch`'s is.
  Called out so it does not look like dead code discovered later.
- **The stranded-credit-deduction claim is a code reading, not a measurement.**
  `index.ts:332` deducts before the `Promise.all` at `:341` and `:387` refunds
  after it, and the surrounding `error-policy:J1` comment states the intent. I
  did not stand up the credits service to observe the stranded row; the line
  references are given so a reviewer can check the ordering directly.
- **Existing sibling tests did NOT assert the defect here.** #23822 could not
  land without first correcting suites that asserted
  `expect(seen).toBe(controller.signal)`. I checked for the same trap across
  `packages/cloud/shared/src/**/*.test.ts`: every occurrence is already the
  corrected `not.toBe(...)` form, and nothing under `social-media/` asserts on
  `token-refresh`'s signal at all. **No existing test was modified by this PR.**
- **`bun run verify` was not run monorepo-wide.** It builds and tests the whole
  repository and is far beyond the blast radius of one Cloud service module.
  What was run instead, and passed, is recorded above.
- **`packages/core/src/i18n/generated/validation-keyword-data.ts` had to be
  generated** in the fresh worktree (`node packages/shared/scripts/generate-keywords.mjs`)
  before anything under `packages/cloud/shared` would import. It is a gitignored
  build artifact and is not in this diff.
- **The repro harness is not part of this diff.** It is a standalone script that
  imports the real `token-refresh` module. The permanent regression coverage is
  `social-media/token-refresh.hop-deadline.test.ts`.
- **Hosted CI checks do not run on this PR.** I contribute from a fork without
  push access to `elizaOS/eliza`, so no hosted check will report here. Every
  result above was produced locally and is reproducible with the commands given.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-mine-token-refresh]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JK5TSX8Y69GQZB64ZE4R32","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T16:41:29.149Z","completed_at":"2026-08-21T16:42:59.090Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T16:41:30.237Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"d41e18e75700306d55a1ceb81b153806c6dca38004bc1597d84c96be65d058ab","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"306ec15d-072d-437d-8c44-08c9fee4d38a","object_id":"sha256:d41e18e75700306d55a1ceb81b153806c6dca38004bc1597d84c96be65d058ab","sha256":"d41e18e75700306d55a1ceb81b153806c6dca38004bc1597d84c96be65d058ab"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"68jNVRtyvKzV4XA3Oxjj_1LuzFIw8OaRu3PBg0wvAYb2bZanmMIH9WHXosD2r6022Wr4WKq2qmXx4_HwMW5iAw"}} -->
