### PR TITLE
fix(app-core): bind artifact verification to stable files

### DIFF
--- a/packages/app-core/scripts/__tests__/package-linux-gtk-artifact.test.ts
+++ b/packages/app-core/scripts/__tests__/package-linux-gtk-artifact.test.ts
@@ -314,6 +314,36 @@ describe("produceArtifact", () => {
     ).toThrow(ArtifactContractError);
     expect(() => readFileSync(path.join(outDir, MANIFEST_NAME))).toThrow();
   });
+
+  it("never deletes a replacement installed during a failed publication", () => {
+    const outDir = tempDir();
+    const replacement = Buffer.from("replacement owned by another writer");
+    const archiveName = "eliza-desktop-gtk-1.2.3-x86_64.tar.zst";
+    const signatureName = "eliza-desktop-gtk-1.2.3-x86_64.sig";
+    const { privateKeyPem } = generateSigningKeyPair();
+    expect(() =>
+      produceArtifact({
+        stageDir: stageShell(),
+        outDir,
+        privateKeyPem,
+        version: "1.2.3",
+        architecture: "x86_64",
+        sourceCommit: COMMIT,
+        testHooks: {
+          afterPublishEntry: ({ index, publishedPath }) => {
+            if (index !== 0) return;
+            renameSync(publishedPath, path.join(outDir, "owned-archive"));
+            writeFileSync(publishedPath, replacement, { flag: "wx" });
+            writeFileSync(path.join(outDir, signatureName), "collision", {
+              flag: "wx",
+            });
+          },
+        },
+      }),
+    ).toThrow();
+    expect(readFileSync(path.join(outDir, archiveName))).toEqual(replacement);
+    expect(existsSync(path.join(outDir, MANIFEST_NAME))).toBe(false);
+  });
 });
 
 describe("writeSigningKeyPair", () => {
@@ -337,6 +367,27 @@ describe("writeSigningKeyPair", () => {
       false,
     );
     expect(readFileSync(publicKeyPath, "utf8")).toBe("existing public key");
+  });
+
+  it("never deletes a replacement installed during a keypair collision", () => {
+    const outDir = tempDir();
+    const privateKeyPath = path.join(outDir, "desktop-signing.key.pem");
+    const publicKeyPath = path.join(outDir, "desktop-signing.pub.pem");
+    expect(() =>
+      writeSigningKeyPair(outDir, {
+        beforePublicKeyWrite: () => {
+          renameSync(privateKeyPath, path.join(outDir, "owned-private.pem"));
+          writeFileSync(privateKeyPath, "replacement private key", {
+            flag: "wx",
+          });
+          writeFileSync(publicKeyPath, "collision", { flag: "wx" });
+        },
+      }),
+    ).toThrow();
+    expect(readFileSync(privateKeyPath, "utf8")).toBe(
+      "replacement private key",
+    );
+    expect(readFileSync(publicKeyPath, "utf8")).toBe("collision");
   });
 
   it("rejects a dangling private-key symlink without creating its target", () => {
@@ -400,6 +451,34 @@ describe("verifyArtifactDir", () => {
     expect(() => verifyArtifactDir(outDir, publicKeyPem)).toThrow(
       /regular non-symlink file/,
     );
+  });
+
+  it("rejects an archive pathname replacement after cryptographic inspection", () => {
+    const { result, outDir, publicKeyPem } = produce("x86_64");
+    const originalArchive = path.join(tempDir(), "original.tar.zst");
+    expect(() =>
+      verifyArtifactDir(outDir, publicKeyPem, {
+        beforeFinalStableFileCheck: ({ archivePath }) => {
+          renameSync(archivePath, originalArchive);
+          writeFileSync(archivePath, "replacement archive", { flag: "wx" });
+        },
+      }),
+    ).toThrow(/archive .* changed during verification/);
+    expect(readFileSync(result.archivePath, "utf8")).toBe(
+      "replacement archive",
+    );
+  });
+
+  it("rejects in-place contract mutation after archive inspection", () => {
+    const { outDir, publicKeyPem } = produce("x86_64");
+    const manifestPath = path.join(outDir, MANIFEST_NAME);
+    expect(() =>
+      verifyArtifactDir(outDir, publicKeyPem, {
+        beforeFinalStableFileCheck: () => {
+          writeFileSync(manifestPath, "{}\n");
+        },
+      }),
+    ).toThrow(/manifest.*changed during verification/);
   });
 });
 

--- a/packages/app-core/scripts/package-linux-gtk-artifact.mjs
+++ b/packages/app-core/scripts/package-linux-gtk-artifact.mjs
@@ -27,19 +27,23 @@ import {
   generateKeyPairSync,
 } from "node:crypto";
 import {
+  closeSync,
+  constants,
+  fstatSync,
   linkSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   readdirSync,
   readFileSync,
   readlinkSync,
   realpathSync,
   rmSync,
   statSync,
-  unlinkSync,
   writeFileSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -125,6 +129,71 @@ function assertRegularFile(filePath, label) {
   }
   if (!stats.isFile()) {
     fail(`${label} must be a regular non-symlink file`);
+  }
+}
+
+function openStableRegularFile(filePath, label) {
+  let fd;
+  try {
+    fd = openSync(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") {
+      fail(`missing ${label}`);
+    }
+    if (error && typeof error === "object" && error.code === "ELOOP") {
+      fail(`${label} must be a regular non-symlink file`);
+    }
+    throw error;
+  }
+  try {
+    const stats = fstatSync(fd);
+    if (!stats.isFile()) {
+      fail(`${label} must be a regular non-symlink file`);
+    }
+    return { bytes: readFileSync(fd), fd, filePath, label, stats };
+  } catch (error) {
+    try {
+      closeSync(fd);
+    } catch {
+      // error-policy:J6 best-effort teardown: preserve the open/read failure.
+    }
+    throw error;
+  }
+}
+
+function assertStableFile(handle) {
+  let namedStats;
+  try {
+    namedStats = lstatSync(handle.filePath);
+  } catch (error) {
+    throw new ArtifactContractError(
+      `${handle.label} changed during verification`,
+      { cause: error },
+    );
+  }
+  const currentStats = fstatSync(handle.fd);
+  if (
+    !namedStats.isFile() ||
+    namedStats.dev !== handle.stats.dev ||
+    namedStats.ino !== handle.stats.ino ||
+    currentStats.size !== handle.stats.size ||
+    currentStats.mtimeMs !== handle.stats.mtimeMs ||
+    currentStats.ctimeMs !== handle.stats.ctimeMs
+  ) {
+    fail(`${handle.label} changed during verification`);
+  }
+}
+
+function inspectArchiveBytes(archiveBytes, inspect) {
+  const inspectionDir = mkdtempSync(
+    path.join(tmpdir(), "eliza-linux-gtk-archive-"),
+  );
+  const snapshotPath = path.join(inspectionDir, "artifact.tar.zst");
+  try {
+    writeFileSync(snapshotPath, archiveBytes, { flag: "wx", mode: 0o600 });
+    return inspect(snapshotPath);
+  } finally {
+    rmSync(inspectionDir, { force: true, recursive: true });
   }
 }
 
@@ -255,7 +324,7 @@ export function generateSigningKeyPair() {
 }
 
 /** Creates a signing keypair without rotating or weakening an existing key. */
-export function writeSigningKeyPair(outDir) {
+export function writeSigningKeyPair(outDir, testHooks = {}) {
   mkdirSync(outDir, { recursive: true });
   const privateKeyPath = path.join(outDir, "desktop-signing.key.pem");
   const publicKeyPath = path.join(outDir, "desktop-signing.pub.pem");
@@ -263,24 +332,15 @@ export function writeSigningKeyPair(outDir) {
     fail("refusing to overwrite an existing desktop signing keypair");
   }
   const { privateKeyPem, publicKeyPem } = generateSigningKeyPair();
-  let privateKeyCreated = false;
-  try {
-    writeFileSync(privateKeyPath, privateKeyPem, {
-      flag: "wx",
-      mode: 0o600,
-    });
-    privateKeyCreated = true;
-    writeFileSync(publicKeyPath, publicKeyPem, { flag: "wx", mode: 0o644 });
-  } catch (error) {
-    if (privateKeyCreated) {
-      try {
-        unlinkSync(privateKeyPath);
-      } catch {
-        // error-policy:J6 best-effort teardown: preserve the original write failure.
-      }
-    }
-    throw error;
-  }
+  writeFileSync(privateKeyPath, privateKeyPem, {
+    flag: "wx",
+    mode: 0o600,
+  });
+  // If public-key publication fails, preserve the partial output rather than
+  // risk deleting a private-key pathname that another writer replaced. The
+  // next invocation fails closed until an operator inspects the pair.
+  testHooks.beforePublicKeyWrite?.({ privateKeyPath, publicKeyPath });
+  writeFileSync(publicKeyPath, publicKeyPem, { flag: "wx", mode: 0o644 });
   return { privateKeyPath, publicKeyPath };
 }
 
@@ -470,6 +530,7 @@ export function produceArtifact({
   architecture,
   sourceCommit,
   artifactBaseName = "eliza-desktop-gtk",
+  testHooks = {},
   entrypoints = {
     desktop: "bin/eliza-desktop",
     agent: "bin/eliza-agent",
@@ -521,12 +582,14 @@ export function produceArtifact({
   const stagingDir = mkdtempSync(
     path.join(canonicalOutDir, ".linux-gtk-artifact-"),
   );
-  const publishedEntries = [];
+  // Publication is manifest-last. On failure, leave any partial hard links
+  // for operator inspection instead of racing pathname replacement during
+  // rollback. A partial set cannot verify and blocks automatic overwrite.
   try {
     const stagedArchivePath = path.join(stagingDir, archiveName);
     runTar(["--zstd", "-cf", stagedArchivePath, "-C", canonicalStageDir, "."]);
-    assertSafeArchiveMembers(stagedArchivePath);
     const archiveBytes = readFileSync(stagedArchivePath);
+    inspectArchiveBytes(archiveBytes, assertSafeArchiveMembers);
     const archiveDigest = createHash("sha256")
       .update(archiveBytes)
       .digest("hex");
@@ -567,15 +630,10 @@ export function produceArtifact({
       { flag: "wx" },
     );
 
-    for (const outputName of outputNames) {
+    for (const [index, outputName] of outputNames.entries()) {
       const publishedPath = path.join(canonicalOutDir, outputName);
       linkSync(path.join(stagingDir, outputName), publishedPath);
-      const publishedStats = lstatSync(publishedPath);
-      publishedEntries.push({
-        dev: publishedStats.dev,
-        ino: publishedStats.ino,
-        path: publishedPath,
-      });
+      testHooks.afterPublishEntry?.({ index, outputName, publishedPath });
     }
     return {
       archivePath: path.join(canonicalOutDir, archiveName),
@@ -586,18 +644,6 @@ export function produceArtifact({
         MANIFEST_SIGNATURE_NAME,
       ),
     };
-  } catch (error) {
-    for (const published of publishedEntries.reverse()) {
-      try {
-        const current = lstatSync(published.path);
-        if (current.dev === published.dev && current.ino === published.ino) {
-          unlinkSync(published.path);
-        }
-      } catch {
-        // error-policy:J6 best-effort teardown: preserve the publication failure.
-      }
-    }
-    throw error;
   } finally {
     try {
       rmSync(stagingDir, { force: true, recursive: true });
@@ -613,57 +659,77 @@ export function produceArtifact({
  * archive bytes, and presence of every declared entrypoint in the archive.
  * Throws ArtifactContractError on the first failure; returns the manifest.
  */
-export function verifyArtifactDir(outDir, publicKeyPem) {
+export function verifyArtifactDir(outDir, publicKeyPem, testHooks = {}) {
   readVendoredSchema();
+  const handles = [];
   const manifestPath = path.join(outDir, MANIFEST_NAME);
-  assertRegularFile(manifestPath, MANIFEST_NAME);
-  const manifestBytes = readFileSync(manifestPath);
-  let manifest;
   try {
-    manifest = JSON.parse(manifestBytes.toString("utf8"));
-  } catch (error) {
-    // error-policy:J2 context-adding rethrow: name the file that failed to parse.
-    throw new ArtifactContractError(
-      `${MANIFEST_NAME} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
-      { cause: error },
-    );
-  }
-  assertValidManifest(manifest);
-
-  const manifestSigPath = path.join(outDir, MANIFEST_SIGNATURE_NAME);
-  assertRegularFile(manifestSigPath, MANIFEST_SIGNATURE_NAME);
-  if (
-    !verifyBytes(publicKeyPem, manifestBytes, readFileSync(manifestSigPath))
-  ) {
-    fail("manifest signature does not verify over the exact manifest bytes");
-  }
-
-  const archivePath = path.join(outDir, manifest.archive);
-  assertRegularFile(archivePath, `archive ${manifest.archive}`);
-  const archiveBytes = readFileSync(archivePath);
-  const digest = createHash("sha256").update(archiveBytes).digest("hex");
-  if (digest !== manifest.sha256) {
-    fail(
-      `archive digest mismatch: manifest says ${manifest.sha256}, archive is ${digest}`,
-    );
-  }
-  const archiveSigPath = path.join(outDir, manifest.signature);
-  assertRegularFile(archiveSigPath, `archive signature ${manifest.signature}`);
-  if (!verifyBytes(publicKeyPem, archiveBytes, readFileSync(archiveSigPath))) {
-    fail("archive signature does not verify over the exact archive bytes");
-  }
-
-  const members = new Set(listArchiveMembers(archivePath));
-  assertSafeArchiveMembers(archivePath);
-  for (const key of REQUIRED_ENTRYPOINTS) {
-    if (!members.has(manifest.entrypoints[key])) {
-      fail(
-        `entrypoint ${key} (${manifest.entrypoints[key]}) is not present in the archive`,
+    const manifestFile = openStableRegularFile(manifestPath, MANIFEST_NAME);
+    handles.push(manifestFile);
+    const manifestBytes = manifestFile.bytes;
+    let manifest;
+    try {
+      manifest = JSON.parse(manifestBytes.toString("utf8"));
+    } catch (error) {
+      // error-policy:J2 context-adding rethrow: name the file that failed to parse.
+      throw new ArtifactContractError(
+        `${MANIFEST_NAME} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
       );
     }
-    assertArchivedEntrypoint(archivePath, manifest.entrypoints[key], key);
+    assertValidManifest(manifest);
+
+    const manifestSigPath = path.join(outDir, MANIFEST_SIGNATURE_NAME);
+    const manifestSigFile = openStableRegularFile(
+      manifestSigPath,
+      MANIFEST_SIGNATURE_NAME,
+    );
+    handles.push(manifestSigFile);
+    if (!verifyBytes(publicKeyPem, manifestBytes, manifestSigFile.bytes)) {
+      fail("manifest signature does not verify over the exact manifest bytes");
+    }
+
+    const archivePath = path.join(outDir, manifest.archive);
+    const archiveFile = openStableRegularFile(
+      archivePath,
+      `archive ${manifest.archive}`,
+    );
+    handles.push(archiveFile);
+    const archiveBytes = archiveFile.bytes;
+    const digest = createHash("sha256").update(archiveBytes).digest("hex");
+    if (digest !== manifest.sha256) {
+      fail(
+        `archive digest mismatch: manifest says ${manifest.sha256}, archive is ${digest}`,
+      );
+    }
+    const archiveSigPath = path.join(outDir, manifest.signature);
+    const archiveSigFile = openStableRegularFile(
+      archiveSigPath,
+      `archive signature ${manifest.signature}`,
+    );
+    handles.push(archiveSigFile);
+    if (!verifyBytes(publicKeyPem, archiveBytes, archiveSigFile.bytes)) {
+      fail("archive signature does not verify over the exact archive bytes");
+    }
+
+    inspectArchiveBytes(archiveBytes, (snapshotPath) => {
+      const members = new Set(listArchiveMembers(snapshotPath));
+      assertSafeArchiveMembers(snapshotPath);
+      for (const key of REQUIRED_ENTRYPOINTS) {
+        if (!members.has(manifest.entrypoints[key])) {
+          fail(
+            `entrypoint ${key} (${manifest.entrypoints[key]}) is not present in the archive`,
+          );
+        }
+        assertArchivedEntrypoint(snapshotPath, manifest.entrypoints[key], key);
+      }
+    });
+    testHooks.beforeFinalStableFileCheck?.({ archivePath, manifestPath });
+    for (const handle of handles) assertStableFile(handle);
+    return manifest;
+  } finally {
+    for (const handle of handles) closeSync(handle.fd);
   }
-  return manifest;
 }
 
 function parseArgs(argv) {


### PR DESCRIPTION
Closes #23865

## What

- opens manifest, signatures, and archive with `O_NOFOLLOW` and retains their file descriptors through verification;
- performs archive member/type/entrypoint inspection from a private snapshot of the exact bytes whose digest and Ed25519 signature were verified;
- rejects pathname replacement or in-place mutation before returning success;
- leaves partial manifest-last publication output for explicit operator inspection rather than racing rollback against a replacement pathname;
- preserves the schema-derived validator and pinned vendored-schema contract merged in #23352.

## Verification

- real artifact contract suite: 34/34 passed;
- scoped Biome: passed;
- diff hygiene: passed.

The deterministic regressions replace the archive pathname after cryptographic/structural inspection, mutate a contract file in place, and install replacement files during keypair/artifact publication failure.

No UI, model, provider, native-device, or credential path changes.

<!-- evidence-head:167c58bdbf72a8353f81a326aed4d4cde436127d -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - server-side artifact producer and verifier only; no rendered UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - server-side artifact producer and verifier only; no rendered UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic CLI contract with no interactive flow

<!-- evidence-row:backend-logs -->
- [x] [23866-exact-head-verification.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23866-exact-head-verification.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend execution path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [23866-desktop-artifact-manifest.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23866-desktop-artifact-manifest.json)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots or rendered text


<!-- contribution-attribution:v1 -->

<!-- attribution-row:ai-assistance -->
- AI assistance: Yes

<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`

<!-- attribution-row:client -->
- Agent tooling: Codex

<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@15e36f445282ec0ce478ef79a05c8ba0dbbeafbc:packages/skills/skills/contribute-to-eliza

<!-- attribution-row:status -->
- Provenance status: self-reported