### PR TITLE
feat(core): wire audience-admission policy core into DisclosureGate (split-disclosure PR2)

### DIFF
--- a/packages/core/src/access-control/audience-disclosure.test.ts
+++ b/packages/core/src/access-control/audience-disclosure.test.ts
@@ -23,6 +23,8 @@ import type {
 import { ChannelType } from "../types";
 import { resolveArtifactDisclosure } from "./artifact-disclosure";
 import {
+	attestedAudienceViewerResolver,
+	audienceAdmissionGateFailure,
 	type DisclosureLevel,
 	type DisclosureSubject,
 	disclosureSubjectRecord,
@@ -406,5 +408,135 @@ describe("resolver failures are distinguishable from denials", () => {
 
 		expect(admission.level).toBe("none");
 		expect(admission.resolverFailureEntityIds).toEqual([]);
+	});
+});
+
+/**
+ * Gate-wiring proof (split-disclosure PR2): the `audience_admission` gate
+ * consults the min-over-members policy core over the ATTESTED audience, with
+ * the per-viewer resolver derived ONLY from the attestation (agent self-read /
+ * canonical owner / bare-USER rest). This is the seam PR1 anticipated; the
+ * pre-wiring gate had no `audience_admission` variant and never called
+ * `resolveAudienceAdmission`, so these assertions fail without the wiring.
+ */
+describe("audience_admission gate wiring", () => {
+	function attestHarness(type: ChannelType, participants: UUID[]) {
+		return {
+			agentId: AGENT,
+			getRoom: vi.fn(async (roomId: UUID) =>
+				roomId === ROOM
+					? ({ id: ROOM, agentId: AGENT, type, source: "test" } as Room)
+					: null,
+			),
+			getParticipantsForRoom: vi.fn(async () => [...participants]),
+			getSetting: vi.fn((key: string) =>
+				key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER : undefined,
+			),
+			reportError: vi.fn(),
+			logger: {
+				debug: vi.fn(),
+				info: vi.fn(),
+				warn: vi.fn(),
+				error: vi.fn(),
+			},
+		} as unknown as IAgentRuntime;
+	}
+
+	function gateTurn(actor: UUID): Memory {
+		return {
+			id: "66666666-6666-6666-6666-666666666666" as UUID,
+			entityId: actor,
+			agentId: AGENT,
+			roomId: ROOM,
+			content: { text: "surface owner-private artifact", source: "discord" },
+		} as Memory;
+	}
+
+	async function attestGate(
+		type: ChannelType,
+		participants: UUID[],
+		actor: UUID,
+	): Promise<TrustedDeliveryAudience> {
+		const runtime = attestHarness(type, participants);
+		const msg = gateTurn(actor);
+		await attestDeliveryAudienceFromCanonicalRoom(runtime, msg, {
+			nowMs: 1_000,
+		});
+		const audience = getTrustedDeliveryAudience(msg);
+		if (!audience) throw new Error("attestation did not bind");
+		return audience;
+	}
+
+	it("admits an owner-private subject only in the two-party owner DM (undefined failure)", async () => {
+		const audience = await attestGate(ChannelType.DM, [OWNER, AGENT], OWNER);
+		expect(
+			audienceAdmissionGateFailure(OWNER_PRIVATE_SUBJECT, audience),
+		).toBeUndefined();
+	});
+
+	it("denies when an ungranted third member is in the room, naming the capped level", async () => {
+		const audience = await attestGate(
+			ChannelType.GROUP,
+			[OWNER, AGENT, GUEST],
+			OWNER,
+		);
+		const failure = audienceAdmissionGateFailure(
+			OWNER_PRIVATE_SUBJECT,
+			audience,
+		);
+		expect(failure).toContain("Audience-admission disclosure denied");
+		expect(failure).toContain("capped at none");
+		expect(failure).toContain("1 member");
+	});
+
+	it("a full grant to the third member lifts the gate to admitted", async () => {
+		const audience = await attestGate(
+			ChannelType.GROUP,
+			[OWNER, AGENT, GUEST],
+			OWNER,
+		);
+		const granted: DisclosureSubject = {
+			...OWNER_PRIVATE_SUBJECT,
+			grants: [{ entityId: GUEST, mode: "full" }],
+		};
+		expect(audienceAdmissionGateFailure(granted, audience)).toBeUndefined();
+	});
+
+	it("a redacted grant caps the room below full → gate denies (fail closed)", async () => {
+		const audience = await attestGate(
+			ChannelType.GROUP,
+			[OWNER, AGENT, GUEST],
+			OWNER,
+		);
+		const redacted: DisclosureSubject = {
+			...OWNER_PRIVATE_SUBJECT,
+			grants: [{ entityId: GUEST, mode: "redacted" }],
+		};
+		expect(audienceAdmissionGateFailure(redacted, audience)).toContain(
+			"capped at redacted",
+		);
+	});
+
+	it("missing attestation fails closed with missing_attestation", () => {
+		expect(
+			audienceAdmissionGateFailure(OWNER_PRIVATE_SUBJECT, undefined),
+		).toContain("missing_attestation");
+	});
+
+	it("the resolver derives roles from the attestation, not caller fields", async () => {
+		const audience = await attestGate(
+			ChannelType.GROUP,
+			[OWNER, AGENT, GUEST],
+			OWNER,
+		);
+		const resolve = attestedAudienceViewerResolver(
+			OWNER_PRIVATE_SUBJECT,
+			audience,
+		);
+		// Owner is the attested canonicalOwnerEntityId → full; the guest is a bare
+		// USER against an owner-private subject → none; the agent self-reads full.
+		expect(resolve(OWNER)).toBe("full");
+		expect(resolve(GUEST)).toBe("none");
+		expect(resolve(AGENT)).toBe("full");
 	});
 });

--- a/packages/core/src/access-control/audience-disclosure.ts
+++ b/packages/core/src/access-control/audience-disclosure.ts
@@ -42,27 +42,28 @@
  * `decisionFromAudience` allows (see the parity tests).
  */
 import type { TrustedDeliveryAudience } from "../security/trusted-delivery-audience";
-import type { ArtifactShareGrant, MemoryScope, UUID } from "../types";
+import type {
+	AccessContext,
+	DisclosureSubject,
+	MemoryScope,
+	UUID,
+} from "../types";
 import type {
 	ArtifactDisclosure,
 	ArtifactDisclosureRecord,
 } from "./artifact-disclosure";
+import { resolveArtifactDisclosure } from "./artifact-disclosure";
+
+// The subject shape lives in the types layer so the `DisclosureGate` contract
+// (also in the types layer) can reference it without a barrel cycle. Re-export
+// it here so this module's original public surface is unchanged.
+export type { DisclosureSubject } from "../types";
 
 /**
  * The universal disclosure level. Deliberately the SAME type as the artifact
  * read-side answer — one vocabulary, no parallel enum to drift.
  */
 export type DisclosureLevel = ArtifactDisclosure;
-
-/** What a sensitive span/surface requires of each viewer. */
-export interface DisclosureSubject {
-	/** Stored visibility scope; `owner-private` is the fail-closed default. */
-	scope: MemoryScope;
-	/** Entity the subject is scoped to (owner/speaker), for entity-scoped tiers. */
-	scopedEntityId?: UUID;
-	/** Explicit per-entity grants; a grant beats the ladder in both directions. */
-	grants?: readonly ArtifactShareGrant[];
-}
 
 /** The admission decision for one subject over one attested audience. */
 export interface AudienceAdmission {
@@ -235,4 +236,69 @@ export function resolveAudienceAdmission(
 		blockingEntityIds: Object.freeze(blocking),
 		resolverFailureEntityIds: Object.freeze(resolverFailures),
 	});
+}
+
+/**
+ * Build the per-viewer resolver a gate must use over an ATTESTED audience,
+ * derived ONLY from the attestation — never from caller-supplied role fields.
+ * Each member's `AccessContext` is minted from the census: the attested
+ * `agentEntityId` is the agent self-read, the attested `canonicalOwnerEntityId`
+ * is the sole OWNER, and every other participant is a bare USER (no role, no
+ * `isOwner`) so the artifact scope ladder fails closed. The resolver then runs
+ * `resolveArtifactDisclosure` over `disclosureSubjectRecord(subject)`, so gate
+ * admission inherits the exact artifact tier order (agent/OWNER full → grant
+ * beats ladder both directions → owner-private fails closed) with zero I/O.
+ */
+export function attestedAudienceViewerResolver(
+	subject: DisclosureSubject,
+	audience: TrustedDeliveryAudience,
+): (entityId: UUID) => DisclosureLevel {
+	const record = disclosureSubjectRecord(subject);
+	const agentId = audience.agentEntityId;
+	const ownerId = audience.canonicalOwnerEntityId;
+	return (entityId) => {
+		const ctx: AccessContext =
+			ownerId !== null && entityId === ownerId
+				? { requesterEntityId: entityId, role: "OWNER", isOwner: true }
+				: { requesterEntityId: entityId };
+		return resolveArtifactDisclosure(record, ctx, agentId);
+	};
+}
+
+/**
+ * Gate-side evaluation of the `audience_admission` disclosure policy: the
+ * component is admitted only when the ATTESTED audience as a whole earns FULL
+ * disclosure for `subject`. Returns `undefined` when admitted, or a
+ * human-readable failure reason (mirroring `disclosureGateFailure`'s contract)
+ * when the room caps below full — the reason names the capped level and the
+ * count of blocking members so the denial is diagnosable without leaking who.
+ *
+ * Fail-closed by construction: a missing/unattested audience is passed straight
+ * to `resolveAudienceAdmission`, which returns `none` for unusable evidence;
+ * one ungranted non-agent member caps the room. This never widens access
+ * relative to the owner-exclusive gate — an owner-private grant-free subject
+ * admits full only in the degenerate two-party owner DM.
+ */
+export function audienceAdmissionGateFailure(
+	subject: DisclosureSubject,
+	audience: TrustedDeliveryAudience | undefined,
+): string | undefined {
+	if (!audience) {
+		return "Audience-admission disclosure denied: missing_attestation";
+	}
+	const admission = resolveAudienceAdmission(
+		subject,
+		audience,
+		attestedAudienceViewerResolver(subject, audience),
+	);
+	if (admission.level === "full") return undefined;
+	// Surface a broken viewer lookup distinctly from a deliberate deny (PR1
+	// follow-up recorded it on the admission for exactly this caller): a resolver
+	// failure means the gate could not evaluate the room, not that policy denied
+	// it — either way access is capped, but the reason must not read as a settled
+	// policy decision.
+	if (admission.resolverFailureEntityIds.length > 0) {
+		return `Audience-admission disclosure denied: viewer resolution failed for ${admission.resolverFailureEntityIds.length} member(s) (capped at ${admission.level})`;
+	}
+	return `Audience-admission disclosure denied: capped at ${admission.level} by ${admission.blockingEntityIds.length} member(s)`;
 }

--- a/packages/core/src/runtime/action-gate.test.ts
+++ b/packages/core/src/runtime/action-gate.test.ts
@@ -3,6 +3,12 @@
  * `actionGateFailure`) — synthetic in-process actions, no live model or DB.
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	attestDeliveryAudienceFromCanonicalRoom,
+	getTrustedDeliveryAudience,
+} from "../security/trusted-delivery-audience";
+import type { IAgentRuntime, Room, UUID } from "../types";
+import { ChannelType } from "../types";
 import type { Action } from "../types/components";
 import type { AgentContext, RoleGateRole } from "../types/contexts";
 import type { Memory } from "../types/memory";
@@ -187,5 +193,100 @@ describe("canActionRun — contextGate", () => {
 		expect(
 			canActionRun(coding, ctx({ activeContexts: ["coding" as AgentContext] })),
 		).toBe(true);
+	});
+});
+
+/**
+ * Gate-routing proof (split-disclosure PR2): the unified action gate routes the
+ * `audience_admission` disclosure variant through the min-over-members policy
+ * over the ATTESTED audience. The pre-wiring gate had no such variant and
+ * `disclosureGateFailure` returned undefined for anything but `owner_exclusive`
+ * — so a component carrying this policy would have been ALLOWED into a group
+ * room (a leak). These assertions fail without the wiring and pass with it.
+ */
+describe("actionGateRejection — audience_admission disclosure variant", () => {
+	const OWNER = "11111111-1111-1111-1111-111111111111" as UUID;
+	const AGENT = "22222222-2222-2222-2222-222222222222" as UUID;
+	const GUEST = "33333333-3333-3333-3333-333333333333" as UUID;
+	const ROOM = "44444444-4444-4444-4444-444444444444" as UUID;
+
+	function attestRuntime(type: ChannelType, participants: UUID[]) {
+		return {
+			agentId: AGENT,
+			getRoom: async (roomId: UUID) =>
+				roomId === ROOM
+					? ({ id: ROOM, agentId: AGENT, type, source: "test" } as Room)
+					: null,
+			getParticipantsForRoom: async () => [...participants],
+			getSetting: (key: string) =>
+				key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER : undefined,
+			reportError: () => {},
+			logger: {
+				debug: () => {},
+				info: () => {},
+				warn: () => {},
+				error: () => {},
+			},
+		} as unknown as IAgentRuntime;
+	}
+
+	async function attestedTurn(
+		type: ChannelType,
+		participants: UUID[],
+	): Promise<Memory> {
+		const msg = {
+			id: "66666666-6666-6666-6666-666666666666" as UUID,
+			entityId: OWNER,
+			agentId: AGENT,
+			roomId: ROOM,
+			content: { text: "surface owner-private artifact", source: "discord" },
+		} as Memory;
+		await attestDeliveryAudienceFromCanonicalRoom(
+			attestRuntime(type, participants),
+			msg,
+			{ nowMs: 1_000 },
+		);
+		if (!getTrustedDeliveryAudience(msg)) {
+			throw new Error("attestation did not bind");
+		}
+		return msg;
+	}
+
+	const gated = action({
+		name: "OWNER_ARTIFACT",
+		disclosureGate: {
+			require: "audience_admission",
+			subject: { scope: "owner-private", scopedEntityId: OWNER },
+		},
+	});
+
+	it("allows the component in a two-party owner DM", async () => {
+		const message = await attestedTurn(ChannelType.DM, [OWNER, AGENT]);
+		expect(canActionRun(gated, ctx({ message, userRoles: ["OWNER"] }))).toBe(
+			true,
+		);
+	});
+
+	it("denies the component when an ungranted third member is present", async () => {
+		const message = await attestedTurn(ChannelType.GROUP, [
+			OWNER,
+			AGENT,
+			GUEST,
+		]);
+		const rej = actionGateRejection(
+			gated,
+			ctx({ message, userRoles: ["OWNER"] }),
+		);
+		expect(rej?.kind).toBe("disclosure");
+		expect(rej?.reason).toContain("Audience-admission disclosure denied");
+	});
+
+	it("denies fail-closed when the turn carries no attestation", () => {
+		const rej = actionGateRejection(
+			gated,
+			ctx({ message: userTurn, userRoles: ["OWNER"] }),
+		);
+		expect(rej?.kind).toBe("disclosure");
+		expect(rej?.reason).toContain("missing_attestation");
 	});
 });

--- a/packages/core/src/runtime/action-gate.ts
+++ b/packages/core/src/runtime/action-gate.ts
@@ -5,7 +5,11 @@
  * top-level role gate in a fixed precedence.
  */
 
-import { disclosureGateFailure } from "../security/trusted-delivery-audience";
+import { audienceAdmissionGateFailure } from "../access-control/audience-disclosure";
+import {
+	disclosureGateFailure,
+	getTrustedDeliveryAudience,
+} from "../security/trusted-delivery-audience";
 import type { Action } from "../types/components";
 import type { AgentContext, RoleGate, RoleGateRole } from "../types/contexts";
 import type { Memory } from "../types/memory";
@@ -90,10 +94,14 @@ export function actionGateRejection(
 		};
 	}
 
-	const disclosureFailure = disclosureGateFailure(
-		action.disclosureGate,
-		ctx.message,
-	);
+	const gate = action.disclosureGate;
+	const disclosureFailure =
+		gate?.require === "audience_admission"
+			? audienceAdmissionGateFailure(
+					gate.subject,
+					getTrustedDeliveryAudience(ctx.message),
+				)
+			: disclosureGateFailure(gate, ctx.message);
 	if (disclosureFailure) {
 		return {
 			kind: "disclosure",

--- a/packages/core/src/security/trusted-delivery-audience.ts
+++ b/packages/core/src/security/trusted-delivery-audience.ts
@@ -766,12 +766,21 @@ export function trustedDeliveryAudienceCacheKey(message: Memory): string {
 		: "unattested";
 }
 
-/** Apply a component's non-overridable disclosure policy. */
+/**
+ * Apply a component's owner-exclusive disclosure policy.
+ *
+ * Scoped to the `owner_exclusive` gate variant only: the min-over-members
+ * `audience_admission` variant is evaluated in the access-control layer
+ * (`audienceAdmissionGateFailure`), which owns the value dependency on the
+ * policy core, so this security-layer function stays free of an access-control
+ * import cycle. A non-owner-exclusive gate is a no-op here (the action-gate
+ * routes it to the admission evaluator instead), never a mis-evaluation.
+ */
 export function disclosureGateFailure(
 	gate: DisclosureGate | undefined,
 	message: Memory | undefined,
 ): string | undefined {
-	if (!gate) return undefined;
+	if (gate?.require !== "owner_exclusive") return undefined;
 	const decision = evaluateOwnerExclusiveDisclosure(message);
 	if (decision.allowed) return undefined;
 	// A non-undefined return here IS a suppressed surface (the action-gate

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -14,7 +14,7 @@ import type {
 	RoleGate,
 } from "./contexts";
 import type { EffectReceipt } from "./effects";
-import type { Memory } from "./memory";
+import type { DisclosureSubject, Memory } from "./memory";
 import type { Content, JsonPrimitive, JsonValue } from "./primitives";
 import type { IAgentRuntime } from "./runtime";
 import type { ActionPlan, State } from "./state";
@@ -342,10 +342,20 @@ export const FOLLOW_UP_CAPABLE_ACTION_TAG = "follow-up-capable" as const;
  * Non-overridable policy for components whose prompt or result can contain
  * owner-private data. Unlike a role gate, this binds access to the attested
  * destination audience as well as the actor.
+ *
+ * Two forms, both fail-closed:
+ *  - `owner_exclusive` (the original, unchanged): the destination must be a
+ *    verified owner-only room — evaluated by `decisionFromAudience`.
+ *  - `audience_admission` (added with the min-over-members policy wiring): the
+ *    gate admits the component only when the ATTESTED delivery audience as a
+ *    whole earns full disclosure for `subject`, computed by
+ *    `resolveAudienceAdmission` over the same attested census. One ungranted
+ *    non-agent member caps the room, exactly like `owner_exclusive` is the
+ *    degenerate two-party-owner-DM case of this policy.
  */
-export interface DisclosureGate {
-	require: "owner_exclusive";
-}
+export type DisclosureGate =
+	| { require: "owner_exclusive" }
+	| { require: "audience_admission"; subject: DisclosureSubject };
 
 export interface Action {
 	/** Action name */

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -845,8 +845,16 @@ export interface Provider {
 	/** Optional role gate checked before including this provider. */
 	roleGate?: RoleGate;
 
-	/** Non-overridable destination-audience policy for sensitive context. */
-	disclosureGate?: DisclosureGate;
+	/**
+	 * Non-overridable destination-audience policy for sensitive context.
+	 *
+	 * Deliberately narrower than `Action.disclosureGate`: every provider
+	 * enforcement site in `runtime.ts` tests `require === "owner_exclusive"`
+	 * literally, so a provider declaring `audience_admission` would compose
+	 * into the prompt with NO enforcement at all. Widen this only in the same
+	 * change that wires the provider path.
+	 */
+	disclosureGate?: Extract<DisclosureGate, { require: "owner_exclusive" }>;
 
 	/** Child provider/action names exposed beneath this provider, if any. */
 	subActions?: string[];

--- a/packages/core/src/types/memory.ts
+++ b/packages/core/src/types/memory.ts
@@ -52,6 +52,26 @@ export interface ArtifactShareGrant {
 	grantedAtMs?: number;
 }
 
+/**
+ * What a sensitive span/surface requires of each viewer when a component's
+ * {@link DisclosureGate} runs the min-over-members audience-admission policy.
+ *
+ * The pure policy core (`resolveAudienceAdmission` in
+ * `access-control/audience-disclosure`) maps this onto the artifact-disclosure
+ * record via `disclosureSubjectRecord` so per-member evaluation inherits the
+ * exact `resolveArtifactDisclosure` tier order. It lives in the types layer (not
+ * access-control) so the {@link DisclosureGate} contract can reference it
+ * without the types barrel importing access-control (which would be a cycle).
+ */
+export interface DisclosureSubject {
+	/** Stored visibility scope; `owner-private` is the fail-closed default. */
+	scope: MemoryScope;
+	/** Entity the subject is scoped to (owner/speaker), for entity-scoped tiers. */
+	scopedEntityId?: UUID;
+	/** Explicit per-entity grants; a grant beats the ladder in both directions. */
+	grants?: readonly ArtifactShareGrant[];
+}
+
 /** Participant set captured at share time for room-scoped grants. */
 export interface ArtifactRoomSnapshot {
 	roomId: UUID;


### PR DESCRIPTION
Follow-up to #23813 (PR1, merged). PR1's pure min-over-members policy core + its `resolverFailureEntityIds` fix are already on `develop`, so this PR is a single clean gate-wiring commit on top.

## What
Wire `resolveAudienceAdmission` into `DisclosureGate`. Adds an `audience_admission` gate variant that admits a component only when the **attested** delivery audience as a whole earns full disclosure for its subject. `owner_exclusive` is byte-unchanged (still `decisionFromAudience`, still the degenerate two-party-owner-DM case of this policy).

## How (cycle-free layering)
- `DisclosureSubject` moves to the types layer (`types/memory.ts`) so the `DisclosureGate` contract can reference it without the types barrel importing access-control. `audience-disclosure` re-exports it, so PR1's public name is unchanged.
- `audienceAdmissionGateFailure` + `attestedAudienceViewerResolver` live in `access-control/audience-disclosure` (which already depends on `security` at value level). The viewer resolver is built **only from the attestation** (agent self-read / `canonicalOwnerEntityId` OWNER / bare-USER rest) and runs `resolveArtifactDisclosure` over `disclosureSubjectRecord(subject)` — no hand-rolled record shape, per PR1's design intent.
- `runtime/action-gate.ts` (downstream of both layers) is the single composition point: routes `audience_admission` to the access-control evaluator, leaves `owner_exclusive` on `disclosureGateFailure`. `disclosureGateFailure` now no-ops non-owner variants instead of mis-evaluating them.
- Surfaces PR1's `resolverFailureEntityIds` distinctly from a deliberate deny (a broken viewer lookup must not read as a settled policy decision).

## Fail-closed preserved
Missing/unattested audience → `none`; one ungranted non-agent member caps the room; a redacted grant caps below full and still denies. **No egress paths touched (PR3 scope).**

## Bidirectional proof
5 new gate-wiring tests (in `audience-disclosure.test` + `action-gate.test`) **FAIL** on a pre-wiring gate that never consults the policy core (deny/cap assertions receive `undefined` = the component would leak into a group room / unattested turn) and **PASS** with the wiring. Verified by temporarily neutering `audienceAdmissionGateFailure` to always return `undefined`: exactly those 5 fail, the other 31 pass; restore → all pass.

## Tests
- `access-control/` dir + `trusted-delivery-audience` (DisclosureGate suite) + `privacy-denial-reply`: **119/119 pass**.
- `audience-disclosure.test.ts`: 23 · `action-gate.test.ts`: 15.
- `bun run typecheck` clean · `biome check` clean.
