### PR TITLE
fix(cloud): make the warm-claim character push surrogate-safe

### DIFF
--- a/packages/cloud/shared/src/lib/services/warm-claim-character-push.test.ts
+++ b/packages/cloud/shared/src/lib/services/warm-claim-character-push.test.ts
@@ -178,3 +178,132 @@ describe("mergeWarmClaimEnvironmentVars", () => {
     });
   });
 });
+
+/**
+ * The payload crosses an HTTP boundary as `JSON.stringify(payload)` and the
+ * container applies it to the live runtime, persists it via `updateAgent`
+ * metadata and journals it to character history. So every projected string has
+ * to be well-formed UTF-16 by the time it leaves this builder: a lone surrogate
+ * survives JSON (it is escaped as `\ud83d`) and only turns into a permanent
+ * U+FFFD when the container UTF-8 encodes it for storage, and it throws
+ * `URIError` in any downstream that re-encodes it into a URI. [sol-warmpool]
+ */
+describe("buildWarmClaimCharacterPayload — surrogate-safe projection", () => {
+  const ROCKET = "🚀"; // U+1F680, one surrogate pair (2 UTF-16 code units)
+
+  test("a cap landing mid-pair backs off one code unit instead of splitting it", () => {
+    const payload = buildWarmClaimCharacterPayload({
+      name: `${"a".repeat(99)}${ROCKET}`, // 101 units, NAME_MAX = 100
+      username: `${"u".repeat(49)}${ROCKET}`, // 51 units, USERNAME_MAX = 50
+      system: `${"s".repeat(9999)}${ROCKET}`, // 10001 units, SYSTEM_MAX = 10000
+      adjectives: [`${"j".repeat(99)}${ROCKET}`], // 101 units, LIST_ITEM_MAX = 100
+      topics: [`${"t".repeat(99)}${ROCKET}`],
+    }) as {
+      name: string;
+      username: string;
+      system: string;
+      adjectives: string[];
+      topics: string[];
+    } | null;
+
+    expect(payload).not.toBeNull();
+    if (!payload) return;
+
+    expect(payload.name).toBe("a".repeat(99));
+    expect(payload.username).toBe("u".repeat(49));
+    expect(payload.system).toBe("s".repeat(9999));
+    expect(payload.adjectives[0]).toBe("j".repeat(99));
+    expect(payload.topics[0]).toBe("t".repeat(99));
+
+    for (const value of [
+      payload.name,
+      payload.username,
+      payload.system,
+      payload.adjectives[0],
+      payload.topics[0],
+    ]) {
+      expect(value.isWellFormed()).toBe(true);
+      // The whole point: no unpaired half rides onto the wire.
+      expect(value.endsWith("\ud83d")).toBe(false);
+    }
+  });
+
+  test("a lone surrogate already in agent_config is normalised, not forwarded", () => {
+    const payload = buildWarmClaimCharacterPayload({
+      name: "agent\ud83d",
+      username: "\udc00user",
+      system: "sys\ud83dtem",
+      bio: "bio\ud83d",
+      topics: ["topic\ud83d"],
+      style: { all: ["style\ud83d"] },
+      postExamples: ["post\ud83d"],
+      messageExamples: [
+        {
+          examples: [
+            { name: "who\ud83d", content: { text: "what\ud83d", actions: ["REPLY\ud83d"] } },
+          ],
+        },
+      ],
+    });
+
+    expect(payload).not.toBeNull();
+    if (!payload) return;
+
+    const strings: string[] = [];
+    const collect = (value: unknown): void => {
+      if (typeof value === "string") strings.push(value);
+      else if (Array.isArray(value)) for (const item of value) collect(item);
+      else if (value && typeof value === "object")
+        for (const item of Object.values(value)) collect(item);
+    };
+    collect(payload);
+
+    expect(strings.length).toBeGreaterThan(0);
+    for (const value of strings) {
+      expect(value.isWellFormed()).toBe(true);
+    }
+    expect(payload.name).toBe("agent�");
+    expect(payload.username).toBe("�user");
+    expect(payload.system).toBe("sys�tem");
+  });
+
+  test("the projected name survives the wire and the container's UTF-8 persist", () => {
+    const payload = buildWarmClaimCharacterPayload({
+      name: `${"a".repeat(99)}${ROCKET}`,
+    }) as { name: string } | null;
+    expect(payload).not.toBeNull();
+    if (!payload) return;
+
+    // What `pushClaimedWarmContainerCharacter` puts on the wire, and what the
+    // container gets back out of it before storing it.
+    const received = JSON.parse(JSON.stringify(payload)) as { name: string };
+    const persisted = Buffer.from(received.name, "utf8").toString("utf8");
+    expect(persisted).toBe(payload.name);
+    expect(persisted.includes("�")).toBe(false);
+    // Any downstream that re-encodes the stored name into a URI must not throw.
+    expect(() => encodeURIComponent(persisted)).not.toThrow();
+  });
+
+  test("ASCII and BMP values under and at the cap are unchanged", () => {
+    const config = {
+      name: "Nyx",
+      username: "nyx",
+      system: "You are Nyx. 漢字 кириллица é ☃",
+      bio: ["Nyx is a night owl. 漢字"],
+      adjectives: ["nocturnal", "é".repeat(100)],
+      topics: ["astronomy"],
+      style: { all: ["terse ☃"] },
+      postExamples: ["hello 漢字"],
+    };
+    expect(buildWarmClaimCharacterPayload(config)).toEqual({
+      name: "Nyx",
+      username: "nyx",
+      system: "You are Nyx. 漢字 кириллица é ☃",
+      bio: ["Nyx is a night owl. 漢字"],
+      adjectives: ["nocturnal", "é".repeat(100)],
+      topics: ["astronomy"],
+      style: { all: ["terse ☃"] },
+      postExamples: ["hello 漢字"],
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/warm-claim-character-push.ts
+++ b/packages/cloud/shared/src/lib/services/warm-claim-character-push.ts
@@ -22,9 +22,11 @@
  *     secrets, connectors, knowledge — is dropped; secrets must NEVER ride
  *     along on this call anyway);
  *   - length caps mirrored from the schema (name 100, username 50,
- *     system 10000, adjective/topic items 100) via slice, so an oversized
- *     field degrades to a truncated push instead of a 422 that would forfeit
- *     the whole character;
+ *     system 10000, adjective/topic items 100), so an oversized field degrades
+ *     to a truncated push instead of a 422 that would forfeit the whole
+ *     character. The cut is surrogate-safe (`truncateWellFormed`) and every
+ *     projected string is normalised with `toWellFormedUnicode`, because this
+ *     payload is persisted by the container — see `capWellFormed` below;
  *   - messageExamples are included ONLY when they already match the strict
  *     `[{ examples: [{ name, content: { text, actions? } }] }]` group form
  *     (extra content keys are stripped); the legacy `[[{user,content}]]` form
@@ -33,6 +35,8 @@
  * Returns null when there is no name to push (no config name and no
  * agent_name), in which case the caller skips the push entirely.
  */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 import { applyRemoteDockerRuntimeMode } from "./remote-docker-runtime-mode";
 
@@ -88,11 +92,36 @@ const LIST_ITEM_MAX = 100;
 /** Bounded timeout for the post-claim character push HTTP call. */
 export const WARM_CLAIM_CHARACTER_PUSH_TIMEOUT_MS = 10_000;
 
+/**
+ * Every string that leaves this builder crosses an HTTP boundary as
+ * `JSON.stringify(payload)` and is then applied to the live runtime, persisted
+ * via `updateAgent` metadata and journaled to character history. `agent_config`
+ * is a loose user-supplied blob, so a value can already carry a lone surrogate;
+ * and the schema caps below are `slice()`d by UTF-16 code unit, which splits an
+ * astral character (emoji, CJK ext-B, most non-BMP scripts) whose surrogate
+ * pair straddles the cap. Either way the container receives an ill-formed
+ * string that becomes a permanent U+FFFD the moment it is UTF-8 encoded for
+ * storage, and that throws `URIError` in any downstream that re-encodes it into
+ * a URI.
+ *
+ * `toWellFormedUnicode` + `truncateWellFormed` are core's shared primitives for
+ * exactly this (`packages/core/src/utils/well-formed.ts`), already used on the
+ * same shape by `packages/cloud/services/agent-server/src/agent-manager.ts:90`
+ * and `plugin-cloud-bootstrap/providers/action-state.ts:21`. Truncation still
+ * happens at the same cap — the boundary just backs off one code unit rather
+ * than cutting a pair in half — so no value the schema accepts today is
+ * rejected.
+ */
+function capWellFormed(value: string, max?: number): string {
+  const wellFormed = toWellFormedUnicode(value);
+  return max === undefined ? wellFormed : truncateWellFormed(wellFormed, max);
+}
+
 function cleanStringArray(value: unknown, itemMax?: number): string[] | undefined {
   if (!Array.isArray(value)) return undefined;
   const items = value
     .filter((v): v is string => typeof v === "string" && v.trim().length > 0)
-    .map((v) => (itemMax !== undefined ? v.slice(0, itemMax) : v));
+    .map((v) => capWellFormed(v, itemMax));
   return items.length > 0 ? items : undefined;
 }
 
@@ -126,8 +155,13 @@ function sanitizeMessageExampleGroups(value: unknown): MessageExampleGroup[] | u
         ? rawActions.filter((a): a is string => typeof a === "string" && a.length > 0)
         : undefined;
       examples.push({
-        name,
-        content: { text, ...(actions && actions.length > 0 ? { actions } : {}) },
+        name: capWellFormed(name),
+        content: {
+          text: capWellFormed(text),
+          ...(actions && actions.length > 0
+            ? { actions: actions.map((a) => capWellFormed(a)) }
+            : {}),
+        },
       });
     }
     groups.push({ examples });
@@ -155,18 +189,18 @@ export function buildWarmClaimCharacterPayload(
       : (agentName?.trim() ?? "");
   if (!name) return null;
 
-  const payload: Record<string, unknown> = { name: name.slice(0, NAME_MAX) };
+  const payload: Record<string, unknown> = { name: capWellFormed(name, NAME_MAX) };
 
   if (typeof config.username === "string" && config.username.trim()) {
-    payload.username = config.username.trim().slice(0, USERNAME_MAX);
+    payload.username = capWellFormed(config.username.trim(), USERNAME_MAX);
   }
   if (typeof config.system === "string" && config.system.trim()) {
-    payload.system = config.system.slice(0, SYSTEM_MAX);
+    payload.system = capWellFormed(config.system, SYSTEM_MAX);
   }
 
   const bio =
     typeof config.bio === "string" && config.bio.trim()
-      ? [config.bio]
+      ? [capWellFormed(config.bio)]
       : cleanStringArray(config.bio);
   if (bio) payload.bio = bio;
 


### PR DESCRIPTION
# Relates to

Fixes #23864

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (branched off `3cfde651ae70db8e7276846ad5f15f4bf27120fe`).
- [x] `bun install` was run after sync. `bun run verify` was **not** run
      monorepo-wide — see **Known gaps / failures**; the focused suites, the
      package typecheck against an untouched control, a 20 000-case differential
      compatibility corpus, and biome on both touched files were run and are
      recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after real-socket transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched off the latest `origin/develop` (`3cfde651ae70`); zero conflicts.
- [ ] `bun run verify` post-sync — not run monorepo-wide; the exact scope that
      was run, and why the wider run was skipped, is in **Known gaps / failures**.

# Risks

**Low.** One helper and four call sites inside a single exported builder, reusing
core's already-merged `toWellFormedUnicode` / `truncateWellFormed` rather than
introducing a truncator. The caps do not move. The only outputs that change are
the ones that were ill-formed UTF-16, and that is proved over a 20 000-case
differential corpus rather than argued — every ASCII and BMP case is
byte-identical to `origin/develop`, with zero over-rejections.

# Background

## What does this PR do?

`buildWarmClaimCharacterPayload`
(`packages/cloud/shared/src/lib/services/warm-claim-character-push.ts`) projects a
claimed sandbox row's loose, user-supplied `agent_config` down to the shape the
container's strict `PUT /api/character` accepts, capping the text fields so an
oversized value "degrades to a truncated push instead of a 422" (its own
docblock). The caps are applied with `String.prototype.slice()`, which counts
**UTF-16 code units**, so a cap landing between the two halves of an astral
character ships an **unpaired surrogate**. A lone surrogate already present in
`agent_config` is forwarded for the same reason.

| file:line | field | cap |
|---|---|---|
| `warm-claim-character-push.ts:158` | `name` | `NAME_MAX = 100` |
| `warm-claim-character-push.ts:161` | `username` | `USERNAME_MAX = 50` |
| `warm-claim-character-push.ts:164` | `system` | `SYSTEM_MAX = 10_000` |
| `warm-claim-character-push.ts:95` (`cleanStringArray`) | `adjectives` / `topics` items | `LIST_ITEM_MAX = 100` |

## Why this is not cosmetic

The payload is not rendered — it is **persisted by another service**.

`ElizaSandboxService.pushClaimedWarmContainerCharacter`
(`eliza-sandbox.ts:4801-4812`) sends it as `JSON.stringify(payload)` to the
claimed container, reached from the two live provisioning routes
`api/v1/eliza/agents/route.ts:617` and
`api/v1/eliza/agents/[agentId]/provision/route.ts:225`. Per the receiving route's
docblock the container then applies the values to the live runtime, "persists
them to the agent's DB (`updateAgent` metadata) and journals character history".

`JSON.stringify` **escapes** a lone surrogate (`\ud83d`) rather than failing, so
nothing in the chain reports a problem:

1. the push returns **HTTP 200** and is recorded as a successful claim;
2. the container parses the escape straight back into a lone surrogate;
3. the corruption materialises only when that string is UTF-8 encoded for
   storage — as a **permanent U+FFFD** on the agent's name / system /
   adjectives, which no later push can undo because the source blob was fine;
4. `encodeURIComponent` on the stored value throws
   `URIError: String contained an illegal UTF-16 sequence.`

A user whose agent name ends on an emoji at the cap boundary silently gets a
mojibake agent after a warm-pool claim.

## The fix, and why it is not a new mechanism

`packages/core/src/utils/well-formed.ts` already exports the two primitives this
needs, and the same pairing is already applied to the same shape elsewhere in
`packages/cloud`:

- `packages/cloud/services/agent-server/src/agent-manager.ts:90-92`
- `packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/providers/action-state.ts:21-24`

So the diff adds one local helper that composes them, and routes the projected
strings through it:

```ts
function capWellFormed(value: string, max?: number): string {
  const wellFormed = toWellFormedUnicode(value);
  return max === undefined ? wellFormed : truncateWellFormed(wellFormed, max);
}
```

`packages/cloud/shared` already declares `"@elizaos/core": "workspace:*"`, so the
dependency edge is the existing one — no new package relationship is created.

## No over-rejection — proved, not asserted

This is the part worth checking hardest, because the agent's `CharacterSchema`
(`packages/agent/src/config/character-schema.ts`) caps the same fields at the
same numbers, and narrowing them would start 422-ing pushes that succeed today.

- **The caps do not move.** `truncateWellFormed` cuts at `maxLength` and backs
  off by exactly one code unit only when position `maxLength - 1` is a high
  surrogate whose low half sits at `maxLength`. The pre-existing suite case that
  asserts `name.length === 100`, `username.length === 50`,
  `system.length === 10_000`, `adjectives[0].length === 100` uses ASCII inputs
  and passes **unchanged**.
- **A 20 000-case differential corpus** ran the `origin/develop` builder —
  extracted with `git show origin/develop:<path>`, never hand-copied — against
  this branch's builder over the same inputs, comparing `JSON.stringify` output
  byte for byte. Every ASCII case (4 926) and every BMP case (5 191) is
  byte-identical. Zero cases turn a payload into `null`, drop a key, or shorten a
  value by more than the one code unit the boundary back-off costs.
- The `astral` arm's inputs are constructed **well-formed by code point**, so the
  only way a lone surrogate can appear in its `origin/develop` output is the
  production cap cutting a pair in half — which is what the 2 465 differing cases
  are.

## Do the existing sibling tests assert the defect?

**No** — worth stating explicitly, because sibling suites in this family
sometimes do. `warm-claim-character-push.test.ts` on `origin/develop` pins the
caps at `:85-88` with pure-ASCII inputs (`"N".repeat(300)` etc.), so it constrains
the cap *length* and never the cut *boundary*. All ten pre-existing cases pass
byte-identically on this branch; none had to be changed.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The module's own
docblock, which described the caps as plain `slice`, is corrected in this diff.

# Testing

## Where should a reviewer start?

`capWellFormed` and its four call sites, then the new
`buildWarmClaimCharacterPayload — surrogate-safe projection` block in the suite.

## Detailed testing steps

```bash
git fetch origin develop && git checkout <this branch>
bun install
node packages/shared/scripts/generate-keywords.mjs   # see Known gaps
bun test --cwd packages/cloud/shared \
  src/lib/services/warm-claim-character-push.test.ts \
  src/lib/services/default-agent-character.test.ts
```

### 1. Origin reproduction — the real pre-fix builder, a real socket

The `origin/develop` builder was extracted with
`git show origin/develop:packages/cloud/shared/src/lib/services/warm-claim-character-push.ts`
and driven against a real `http.createServer` standing in for the claimed
container's `PUT /api/character`. Inputs are one code unit over each cap, ending
on `🚀` (U+1F680).

```
$ bun run origin-repro-warmclaim-mine26.ts

buildWarmClaimCharacterPayload output on origin/develop:
  name      len=  100 isWellFormed=false tail="a\ud83d"
  username  len=   50 isWellFormed=false tail="u\ud83d"
  system    len=10000 isWellFormed=false tail="s\ud83d"
  adjective len=  100 isWellFormed=false tail="j\ud83d"

what the claimed container's PUT /api/character receives:
  name isWellFormed=false tail="a\ud83d"
  after the container UTF-8 encodes it for updateAgent/history: tail="a�" corrupted=true
  encodeURIComponent(name): THROWS URIError: String contained an illegal UTF-16 sequence.

PUT /api/character -> HTTP 200 (the push reports success)
```

The `HTTP 200` line is the point: nothing in the chain surfaces the corruption.

### 2. AFTER — the suites

```
$ bun test --cwd packages/cloud/shared \
    src/lib/services/warm-claim-character-push.test.ts \
    src/lib/services/default-agent-character.test.ts
bun test v1.3.14 (0d9b296a)

 25 pass
 0 fail
 114 expect() calls
Ran 25 tests across 2 files. [1013.00ms]
```

### 3. Load-bearing check

The production file was reverted to its `origin/develop` body by **copy-aside**
(never `git stash`, which is repo-global on this clone), the new suite was run
against it, and the file was restored.

```
===== REVERT warm-claim-character-push.ts -> origin/develop body, new tests kept
Expected: "aaaa…aaa"          (99 units)
Received: "aaaa…aaa\ud83d"    (100 units, unpaired high surrogate)
(fail) surrogate-safe projection > a cap landing mid-pair backs off one code unit instead of splitting it

expect(value.isWellFormed()).toBe(true)  ->  Received: false
(fail) surrogate-safe projection > a lone surrogate already in agent_config is normalised, not forwarded

expect(persisted).toBe(payload.name)     ->  U+FFFD vs the unpaired half
(fail) surrogate-safe projection > the projected name survives the wire and the container's UTF-8 persist

 11 pass
 3 fail
Ran 14 tests across 1 file. [22.00ms]

===== RESTORE
 14 pass
 0 fail
 54 expect() calls
Ran 14 tests across 1 file. [1243.00ms]
```

The fourth new case — the ASCII/BMP no-change compatibility assertion — is among
the 11 that stay green on the reverted file, which is correct: it exists to catch
a fix that changes values it should not touch.

### 4. Compatibility corpus — 20 000 cases, `git show` origin vs this branch

```
$ bun run compat-warmclaim-mine26.ts

cases: 20000
  ascii   total= 4926  byte-identical= 4926  differing=    0
  bmp     total= 5191  byte-identical= 5191  differing=    0
  astral  total= 4932  byte-identical= 2467  differing= 2465
  lone    total= 4951  byte-identical=  262  differing= 4689
over-rejections (null / dropped key / over-truncated): 0
ORIGIN payloads carrying a lone surrogate: 7154
BRANCH payloads carrying a lone surrogate: 0

split-cut boundary (input is well-formed, only the cap splits the pair):
  name      ORIGIN len=100 wellFormed=false | BRANCH len=99 wellFormed=true
  username  ORIGIN len=50 wellFormed=false | BRANCH len=49 wellFormed=true
  system    ORIGIN len=10000 wellFormed=false | BRANCH len=9999 wellFormed=true
  adjective ORIGIN len=100 wellFormed=false | BRANCH len=99 wellFormed=true
```

`over-rejections: 0` is the compatibility claim, measured: across 20 000 payloads
the branch never returns `null` where origin returned an object, never drops a
key, and never shortens a value by more than the single code unit.

### 5. Typecheck — zero errors added, measured against an untouched control

```
$ bun run --cwd packages/cloud/shared typecheck        # this branch
src/lib/services/shared-runtime/conversation-coordinator.ts(241,85): error TS2345: …
1 error

# control: the same tree with both touched files restored to origin/develop
$ bun run --cwd packages/cloud/shared typecheck
src/lib/services/shared-runtime/conversation-coordinator.ts(241,85): error TS2345: …
1 error
```

Identical. The single error is pre-existing, in a file this PR does not touch.

### 6. Biome

```
$ bunx @biomejs/biome check \
    packages/cloud/shared/src/lib/services/warm-claim-character-push.ts \
    packages/cloud/shared/src/lib/services/warm-claim-character-push.test.ts
Checked 2 files in 34ms. No fixes applied.
```

# Evidence Gate

<!-- evidence-head:674a644c561733219d304c42ddc5e43643ac8662 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only change to one Cloud service module; no rendered UI surface is touched by this diff.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only change to one Cloud service module; no rendered UI surface is touched by this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the observable behaviour is whether the pushed character string is well-formed on the wire and after storage, shown as before/after transcripts in Testing above.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — pasted below (the
      real `origin/develop` builder driven against a real `http.createServer`,
      then the real suites on this branch).

<details><summary>BEFORE — <code>origin/develop</code> builder, real socket</summary>

```
buildWarmClaimCharacterPayload output on origin/develop:
  name      len=  100 isWellFormed=false tail="a\ud83d"
  username  len=   50 isWellFormed=false tail="u\ud83d"
  system    len=10000 isWellFormed=false tail="s\ud83d"
  adjective len=  100 isWellFormed=false tail="j\ud83d"

what the claimed container's PUT /api/character receives:
  name isWellFormed=false tail="a\ud83d"
  after the container UTF-8 encodes it for updateAgent/history: tail="a�" corrupted=true
  encodeURIComponent(name): THROWS URIError: String contained an illegal UTF-16 sequence.

PUT /api/character -> HTTP 200 (the push reports success)
```

</details>

<details><summary>AFTER — this branch, same driver</summary>

```
$ bun test --cwd packages/cloud/shared \
    src/lib/services/warm-claim-character-push.test.ts \
    src/lib/services/default-agent-character.test.ts
bun test v1.3.14 (0d9b296a)

 25 pass
 0 fail
 114 expect() calls
Ran 25 tests across 2 files. [1013.00ms]

split-cut boundary (input is well-formed, only the cap splits the pair):
  name      ORIGIN len=100 wellFormed=false | BRANCH len=99 wellFormed=true
  username  ORIGIN len=50 wellFormed=false | BRANCH len=49 wellFormed=true
  system    ORIGIN len=10000 wellFormed=false | BRANCH len=9999 wellFormed=true
  adjective ORIGIN len=100 wellFormed=false | BRANCH len=99 wellFormed=true
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path; this module runs server-side in Cloud only.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behaviour changes; this is a string-projection boundary on an internal HTTP push.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the artifact is the pushed character payload itself — the
      exact `PUT /api/character` request body, and the `agent_name` value the
      container ends up storing from it.
  <details><summary>The wire body and the stored <code>agent_name</code>, before and after</summary>

  ```
  $ bun run artifact-warmclaim-mine26.ts

  ORIGIN PUT /api/character body (last 60 bytes):
    jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj\ud83d"]}
    sha256=4d806160982d0fd2610ff55ae875a1a81fed62b979e8af70712ba64384d96052
    agent_name as the container stores it (last 4): "aaa�"
  BRANCH PUT /api/character body (last 60 bytes):
    jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj"]}
    sha256=113316fc0097b5630702e9c90c11fedc9614a5ea3745ef71ddd95431ea57f174
    agent_name as the container stores it (last 4): "aaaa"
  ```

  </details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behaviour changes.`

## Backend + frontend logs

Backend: inline in **Testing → 1, 2, 3, 4** (the real `origin/develop` builder
extracted by `git show` and driven against a real
`http.createServer`, the real suites, the copy-aside revert arm, and the
20 000-case differential corpus).

Frontend: `N/A - server-side module.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT, or omnivoice surface.`

## Known gaps / failures

- **`bun run verify` was not run monorepo-wide.** It builds and tests the whole
  repository and is far beyond the blast radius of one Cloud service module. What
  was run instead, and passed, is recorded above: the two focused suites
  (25 pass / 0 fail), the copy-aside revert arm, the 20 000-case differential
  compatibility corpus, the `@elizaos/cloud-shared` typecheck against an
  untouched control, and biome on both touched files.
- **The uncapped projected strings are normalised too, and that is a deliberate
  scope call.** `bio`, `style.*`, `postExamples` and the `messageExamples` text /
  name / action strings carry no cap, so no split can occur there — but they land
  in the same persisted payload, and a lone surrogate that arrives in
  `agent_config` corrupts them by exactly the same UTF-8 mechanism. Normalising
  only the capped half would have left the identical defect reachable through the
  other fields. The corpus above covers all of them.
- **The reproduction harness and the differential corpus are not part of this
  diff.** They are standalone scripts that import a `git show origin/develop`
  sidecar; the sidecar was deleted before committing. The permanent regression
  coverage is the four new suite cases.
- **`packages/core/src/i18n/generated/validation-keyword-data.ts` had to be
  generated** in the fresh worktree
  (`node packages/shared/scripts/generate-keywords.mjs`) before anything under
  `packages/cloud/shared` would import `@elizaos/core`. It is a gitignored build
  artifact and is not in this diff.
- **Hosted CI checks do not run on this PR.** I contribute from a fork without
  push access to `elizaOS/eliza`, so no hosted check will report here. Every
  result above was produced locally and is reproducible with the commands given.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-mine-warmclaim]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JKJHXE0E1ETYGPBGR9FV5N","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T16:48:26.030Z","completed_at":"2026-08-21T16:49:35.877Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T16:48:27.477Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"2628125255c75b7a35cf46d5713171207b28abdc43a3503a3186d4c4eb002168","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"70180596-7ad3-4c34-9424-ec8d6a648701","object_id":"sha256:2628125255c75b7a35cf46d5713171207b28abdc43a3503a3186d4c4eb002168","sha256":"2628125255c75b7a35cf46d5713171207b28abdc43a3503a3186d4c4eb002168"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"BVOkDfz4sZr2JP39QNpzbAd4Ox26FpEgmr1tp1UsvVInDXwnstnbJa8UkMaYBPaB30wx92RCDFntxZ-V7YswCQ"}} -->
