### PR TITLE
feat(cloud): read-only credit-pack reconciliation audit command (#22963 AC1)

### DIFF
--- a/packages/cloud/scripts/admin/audit-credit-packs.proof.test.ts
+++ b/packages/cloud/scripts/admin/audit-credit-packs.proof.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Proof harness for audit-credit-packs.ts (#22963): applies the real migration
+ * journal to a temp PGlite store, seeds packs via a SUBPROCESS (fresh module
+ * cache per store — the in-process client is cached across tests), and runs
+ * the audit as a subprocess with a hermetic environment.
+ * Run: bun test packages/cloud/scripts/admin/audit-credit-packs.proof.test.ts
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const SCRIPT = `${import.meta.dir}/audit-credit-packs.ts`;
+const SEED_HELPER = `${import.meta.dir}/audit-credit-packs.seed.ts`;
+
+/** Hermetic child env: no inherited .env, keys stripped. */
+function childEnv(dbUrl: string, extra: Record<string, string> = {}) {
+  return {
+    PATH: process.env.PATH ?? "",
+    HOME: process.env.HOME ?? "",
+    DATABASE_URL: dbUrl,
+    DISABLE_LOCAL_PGLITE_FALLBACK: "1",
+    ...extra,
+  };
+}
+
+async function freshDb(): Promise<{ dir: string; url: string }> {
+  const dir = await mkdtemp(`${tmpdir()}/22963-audit-`);
+  const url = `pglite://${dir}`;
+  const proc = Bun.spawnSync([process.execPath, "run", "db:migrate"], {
+    cwd: `${import.meta.dir}/../../shared`,
+    env: { ...childEnv(url) },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (proc.exitCode !== 0) {
+    throw new Error(`migrate failed: ${proc.stderr.toString().slice(-400)}`);
+  }
+  return { dir, url };
+}
+
+/** Seed in a fresh process so the db client binds to THIS test's store. */
+async function seed(url: string, rows: Array<Record<string, unknown>>) {
+  const file = path.join(await mkdtemp(`${tmpdir()}/22963-seed-`), "rows.json");
+  await writeFile(file, JSON.stringify(rows));
+  const proc = Bun.spawnSync([process.execPath, SEED_HELPER, url, file], {
+    env: childEnv(url),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (proc.exitCode !== 0) {
+    throw new Error(`seed failed: ${proc.stderr.toString().slice(-400)}`);
+  }
+}
+
+function runAudit(env: Record<string, string>, cwd: string) {
+  const out = Bun.spawnSync([process.execPath, SCRIPT, "--json"], {
+    env,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return { exitCode: out.exitCode, stdout: out.stdout.toString() };
+}
+
+describe("audit-credit-packs classification (#22963)", () => {
+  test("empty catalogue: clean summary, empty packs array", async () => {
+    const { dir, url } = await freshDb();
+    try {
+      const r = runAudit(childEnv(url), dir);
+      expect(r.exitCode).toBe(0);
+      const parsed = JSON.parse(r.stdout);
+      expect(parsed.packs).toEqual([]);
+      expect(parsed.summary).toBe("No credit packs exist in the database.");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("no Stripe key: DB-active => UNKNOWN (not ERRONEOUS), DB-inactive => DEPRECATED", async () => {
+    const { dir, url } = await freshDb();
+    try {
+      await seed(url, [
+        {
+          name: "Small Pack",
+          credits: "5.00",
+          price_cents: 4999,
+          stripe_price_id: "price_a",
+          stripe_product_id: "prod_a",
+          is_active: true,
+          sort_order: 1,
+        },
+        {
+          name: "Medium Pack",
+          credits: "15.00",
+          price_cents: 12999,
+          stripe_price_id: "price_b",
+          stripe_product_id: "prod_b",
+          is_active: false,
+          sort_order: 2,
+        },
+      ]);
+      const r = runAudit(childEnv(url), dir);
+      expect(r.exitCode).toBe(0);
+      const parsed = JSON.parse(r.stdout);
+      const small = parsed.packs.find(
+        (p: { name: string }) => p.name === "Small Pack",
+      );
+      const medium = parsed.packs.find(
+        (p: { name: string }) => p.name === "Medium Pack",
+      );
+      expect(small.classification).toBe("UNKNOWN");
+      expect(small.reasons.join(" ")).toContain("unverifiable");
+      expect(medium.classification).toBe("DEPRECATED");
+      // Economics is a NOTE (AC2 decision), never a classification override.
+      expect(small.economicsNote).toContain("product approval");
+      expect(small.impliedUsdPerCredit).toBeCloseTo(9.998, 2);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("deployment currency guard: non-USD STRIPE_CURRENCY => ERRONEOUS", async () => {
+    const { dir, url } = await freshDb();
+    try {
+      await seed(url, [
+        {
+          name: "Small Pack",
+          credits: "5.00",
+          price_cents: 4999,
+          stripe_price_id: "price_a",
+          stripe_product_id: "prod_a",
+          is_active: true,
+          sort_order: 1,
+        },
+      ]);
+      const r = runAudit(childEnv(url, { STRIPE_CURRENCY: "eur" }), dir);
+      expect(r.exitCode).toBe(0);
+      const parsed = JSON.parse(r.stdout);
+      expect(parsed.packs[0].classification).toBe("ERRONEOUS");
+      expect(parsed.packs[0].reasons.join(" ")).toContain(
+        "deployment currency guard",
+      );
+      expect(parsed.summary.deploymentCurrencyUsd).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("deployment currency guard sticks: non-USD + DB-inactive stays ERRONEOUS (not overwritten)", async () => {
+    const { dir, url } = await freshDb();
+    try {
+      await seed(url, [
+        {
+          name: "Medium Pack",
+          credits: "15.00",
+          price_cents: 12999,
+          stripe_price_id: "price_b",
+          stripe_product_id: "prod_b",
+          is_active: false,
+          sort_order: 2,
+        },
+      ]);
+      const r = runAudit(childEnv(url, { STRIPE_CURRENCY: "eur" }), dir);
+      expect(r.exitCode).toBe(0);
+      const parsed = JSON.parse(r.stdout);
+      expect(parsed.packs[0].classification).toBe("ERRONEOUS");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("seededWiringMatches is null when the seeder env var is unset", async () => {
+    const { dir, url } = await freshDb();
+    try {
+      await seed(url, [
+        {
+          name: "Small Pack",
+          credits: "5.00",
+          price_cents: 4999,
+          stripe_price_id: "price_a",
+          stripe_product_id: "prod_a",
+          is_active: false,
+          sort_order: 1,
+        },
+      ]);
+      const r = runAudit(childEnv(url), dir);
+      const parsed = JSON.parse(r.stdout);
+      expect(parsed.packs[0].seededWiringMatches).toBeNull();
+      expect(parsed.packs[0].classification).toBe("DEPRECATED");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cloud/scripts/admin/audit-credit-packs.seed.ts
+++ b/packages/cloud/scripts/admin/audit-credit-packs.seed.ts
@@ -1,0 +1,21 @@
+/**
+ * Seed helper for audit-credit-packs.proof.test.ts — inserts rows into the
+ * PGlite store at argv[2] from the JSON rows file at argv[3]. Runs as its own
+ * process so the db client binds to the target store, not a cached one.
+ */
+const [dbUrl, rowsFile] = process.argv.slice(2);
+if (!dbUrl || !rowsFile) {
+  console.error("usage: audit-credit-packs.seed.ts <DATABASE_URL> <rows.json>");
+  process.exit(2);
+}
+process.env.DATABASE_URL = dbUrl;
+process.env.DISABLE_LOCAL_PGLITE_FALLBACK = "1";
+
+const rows = JSON.parse(await Bun.file(rowsFile).text());
+const { db } = await import("../../shared/src/db/client");
+const { creditPacks } = await import(
+  "../../shared/src/db/schemas/credit-packs"
+);
+await db.insert(creditPacks).values(rows);
+console.log(`seeded ${rows.length} pack(s)`);
+process.exit(0);

--- a/packages/cloud/scripts/admin/audit-credit-packs.ts
+++ b/packages/cloud/scripts/admin/audit-credit-packs.ts
@@ -1,0 +1,320 @@
+/**
+ * Read-only credit-pack reconciliation audit (#22963).
+ *
+ * Classifies every seeded credit pack as ACTIVE / DEPRECATED / ERRONEOUS /
+ * UNKNOWN using server state and read-only Stripe retrievals — no charges, no
+ * writes, no provider mutation. Produces the exact data the product owner
+ * needs for the retain/remove/reprice decision (issue AC1-AC2).
+ *
+ * Classification rules mirror the LIVE checkout verification seam
+ * (packages/cloud/api/stripe/create-checkout-session/route.ts):
+ * a pack can only be purchased when the deployment currency is USD, its
+ * Stripe price exists, is active, is USD, one-off (non-recurring), and its
+ * unit_amount equals the DB price_cents. Anything else cannot be bought
+ * through the live path.
+ *
+ * Provider uncertainty (missing credentials, auth/permission/rate-limit/
+ * transient errors) is reported as UNKNOWN — never conflated with pack
+ * defects. Only Stripe's explicit missing-resource response means a stale
+ * price id.
+ *
+ * Usage:
+ *   bun packages/cloud/scripts/admin/audit-credit-packs.ts [--json]
+ *
+ * Reads DATABASE_URL + STRIPE_SECRET_KEY (+ STRIPE_CURRENCY and optional
+ * per-pack STRIPE_*_PACK_* env vars to cross-check the seeder's wiring) from
+ * .env/.env.local, same loading convention as seed-credit-packs.ts.
+ */
+import { loadEnvFiles } from "./local-dev-helpers";
+
+// In --json mode the script's stdout is machine-parsed; silence dotenv banners.
+if (process.argv.includes("--json")) {
+  const origLog = console.log;
+  const origInfo = console.info;
+  console.log = (...a: unknown[]) => process.stderr.write(`${a.join(" ")}\n`);
+  console.info = (...a: unknown[]) => process.stderr.write(`${a.join(" ")}\n`);
+  loadEnvFiles([".env", { path: ".env.local", override: true }]);
+  console.log = origLog;
+  console.info = origInfo;
+} else {
+  loadEnvFiles([".env", { path: ".env.local", override: true }]);
+}
+
+type Classification = "ACTIVE" | "DEPRECATED" | "ERRONEOUS" | "UNKNOWN";
+
+/** Provider-side per-price read result, separating defect from uncertainty. */
+type PriceRead =
+  | {
+      kind: "ok";
+      active: boolean;
+      usd: boolean;
+      oneOff: boolean;
+      amountMatchesDb: boolean;
+    }
+  | { kind: "missing" }
+  | { kind: "provider-error"; errorType: string };
+
+interface PackAudit {
+  id: string;
+  name: string;
+  dbActive: boolean;
+  credits: number;
+  priceCents: number;
+  impliedUsdPerCredit: number | null;
+  customPathUsdPerCredit: number; // live custom top-up economics: 1 credit = $1
+  economicsNote: string | null;
+  stripePriceId: string | null;
+  stripeChecks: PriceRead | null;
+  deploymentCurrencyUsd: boolean | null;
+  seededWiringMatches: boolean | null;
+  classification: Classification;
+  reasons: string[];
+}
+
+function readStripePrice(
+  stripe: {
+    prices: {
+      retrieve: (id: string) => Promise<{
+        active: boolean;
+        currency: string;
+        recurring: unknown;
+        unit_amount: number | null;
+      }>;
+    };
+  },
+  priceId: string,
+  priceCents: number,
+): Promise<PriceRead> {
+  return stripe.prices.retrieve(priceId).then(
+    (price) => ({
+      kind: "ok" as const,
+      active: price.active,
+      usd: price.currency.toLowerCase() === "usd",
+      oneOff: !price.recurring,
+      amountMatchesDb: price.unit_amount === priceCents,
+    }),
+    (error: unknown) => {
+      const err = error as { type?: string; code?: string };
+      // error-policy:J1 Stripe's resource-missing boundary is the ONLY signal
+      // that the price id is stale (stripe-customer-authority.ts precedent).
+      // StripeInvalidRequestError alone covers invalid requests generally.
+      if (err.code === "resource_missing") {
+        return { kind: "missing" as const };
+      }
+      // Auth, permission, rate-limit, and transient failures are operator
+      // uncertainty, not pack defects; the audit must not fabricate a
+      // classification from them.
+      return {
+        kind: "provider-error" as const,
+        errorType: err.type ?? err.code ?? "unknown",
+      };
+    },
+  );
+}
+
+async function main() {
+  const asJson = process.argv.includes("--json");
+
+  const [{ db }, { creditPacks }, { requireStripe, isStripeConfigured }] =
+    await Promise.all([
+      import("../../shared/src/db/client"),
+      import("../../shared/src/db/schemas/credit-packs"),
+      import("../../shared/src/lib/stripe"),
+    ]);
+
+  const packs = await db.select().from(creditPacks);
+  const deploymentCurrencyUsd =
+    // biome-ignore lint/suspicious/noUndeclaredEnvVars: standalone admin script run manually with bun; outside Turbo task caching.
+    (process.env.STRIPE_CURRENCY || "usd").trim().toLowerCase() === "usd";
+  if (packs.length === 0) {
+    const empty = {
+      summary: "No credit packs exist in the database.",
+      packs: [] as PackAudit[],
+      note: "The seed script has never been run against this environment; the credit_packs table is empty and only the custom-amount path ($1-$1000, 1:1 credits) is sellable.",
+    };
+    console.log(asJson ? JSON.stringify(empty, null, 2) : empty.summary);
+    return;
+  }
+
+  const stripe = isStripeConfigured() ? requireStripe() : null;
+  if (!stripe) {
+    // Without provider credentials the audit cannot certify anything; warn
+    // loudly and classify DB-active packs UNKNOWN below.
+    console.error(
+      "WARNING: STRIPE_SECRET_KEY is not configured — provider state cannot be verified; DB-active packs will report UNKNOWN.",
+    );
+  }
+
+  // The seeder's expected wiring, for cross-checking which env vars seeded rows.
+  const expectedWiring: Array<[string, string | undefined]> = [
+    // biome-ignore lint/suspicious/noUndeclaredEnvVars: standalone admin script run manually with bun; outside Turbo task caching.
+    ["Small Pack", process.env.STRIPE_SMALL_PACK_PRICE_ID],
+    // biome-ignore lint/suspicious/noUndeclaredEnvVars: standalone admin script run manually with bun; outside Turbo task caching.
+    ["Medium Pack", process.env.STRIPE_MEDIUM_PACK_PRICE_ID],
+    // biome-ignore lint/suspicious/noUndeclaredEnvVars: standalone admin script run manually with bun; outside Turbo task caching.
+    ["Large Pack", process.env.STRIPE_LARGE_PACK_PRICE_ID],
+  ];
+
+  const results: PackAudit[] = [];
+  for (const pack of packs) {
+    const reasons: string[] = [];
+    let classification: Classification = "ACTIVE";
+
+    const credits = Number(pack.credits);
+    const priceUsd = pack.price_cents / 100;
+    const impliedUsdPerCredit = credits > 0 ? priceUsd / credits : null;
+    const economicsNote =
+      impliedUsdPerCredit !== null && impliedUsdPerCredit !== 1
+        ? `Purchasable economics diverge from the live custom path: $${impliedUsdPerCredit.toFixed(2)} per credit vs $1.00 — retain/reprice decision belongs to product approval (AC2)`
+        : null;
+
+    const wiring = expectedWiring.find(([n]) => n === pack.name);
+    const seededWiringMatches = wiring
+      ? wiring[1] === undefined
+        ? null // env var unset — nothing to compare against
+        : wiring[1] === pack.stripe_price_id
+      : null;
+
+    if (!deploymentCurrencyUsd) {
+      reasons.push(
+        "STRIPE_CURRENCY is not usd — the live checkout rejects ALL credit-pack purchases with 503 (deployment currency guard)",
+      );
+      classification = "ERRONEOUS";
+    }
+
+    let stripeChecks: PriceRead | null = null;
+    if (stripe) {
+      stripeChecks = await readStripePrice(
+        stripe,
+        pack.stripe_price_id,
+        pack.price_cents,
+      );
+      if (stripeChecks.kind === "ok") {
+        const purchasable =
+          stripeChecks.active &&
+          stripeChecks.usd &&
+          stripeChecks.oneOff &&
+          stripeChecks.amountMatchesDb;
+        if (!pack.is_active) {
+          if (classification !== "ERRONEOUS") classification = "DEPRECATED";
+          reasons.push(
+            purchasable
+              ? "DB-inactive but the Stripe price is still live — consider archiving the price in Stripe when the catalogue decision lands"
+              : "DB-inactive; not purchasable through the live path",
+          );
+        } else if (classification !== "ERRONEOUS") {
+          if (!purchasable) {
+            classification = "ERRONEOUS";
+            if (!stripeChecks.active)
+              reasons.push("Stripe price is archived/inactive");
+            if (!stripeChecks.usd)
+              reasons.push("Stripe price is non-USD currency");
+            if (!stripeChecks.oneOff)
+              reasons.push(
+                "Stripe price is recurring — live path only accepts one-off prices",
+              );
+            if (!stripeChecks.amountMatchesDb)
+              reasons.push(
+                "Stripe unit_amount disagrees with DB price_cents — checkout would 503",
+              );
+          }
+        }
+      } else if (stripeChecks.kind === "missing") {
+        if (pack.is_active) {
+          classification = "ERRONEOUS";
+          reasons.push("Stripe price does not exist (stale/unseeded price id)");
+        } else if (classification !== "ERRONEOUS") {
+          classification = "DEPRECATED";
+          reasons.push("DB-inactive and the Stripe price no longer exists");
+        }
+      } else {
+        // provider-error: never a pack defect — but a prior deployment-currency
+        // ERRONEOUS verdict stands (the pack is unsellable regardless of
+        // provider state).
+        if (classification !== "ERRONEOUS") {
+          classification = "UNKNOWN";
+        }
+        reasons.push(
+          `Provider state unverifiable (Stripe error type: ${stripeChecks.errorType}) — classify after resolving provider access`,
+        );
+      }
+    } else if (!stripe && pack.is_active) {
+      if (classification !== "ERRONEOUS") {
+        classification = "UNKNOWN";
+      }
+      reasons.push(
+        "STRIPE_SECRET_KEY not configured — provider state unverifiable",
+      );
+    } else if (!stripe && !pack.is_active && classification !== "ERRONEOUS") {
+      classification = "DEPRECATED";
+      reasons.push("DB-inactive");
+    }
+
+    if (seededWiringMatches === false) {
+      reasons.push(
+        "stripe_price_id does not match the seeder's STRIPE_*_PACK_PRICE_ID env wiring for this pack name",
+      );
+    }
+    if (economicsNote) reasons.push(economicsNote);
+
+    results.push({
+      id: pack.id,
+      name: pack.name,
+      dbActive: pack.is_active,
+      credits,
+      priceCents: pack.price_cents,
+      impliedUsdPerCredit,
+      customPathUsdPerCredit: 1,
+      economicsNote,
+      stripePriceId: pack.stripe_price_id,
+      stripeChecks,
+      deploymentCurrencyUsd,
+      seededWiringMatches,
+      classification,
+      reasons,
+    });
+  }
+
+  const summary = {
+    total: results.length,
+    active: results.filter((r) => r.classification === "ACTIVE").length,
+    deprecated: results.filter((r) => r.classification === "DEPRECATED").length,
+    erroneous: results.filter((r) => r.classification === "ERRONEOUS").length,
+    unknown: results.filter((r) => r.classification === "UNKNOWN").length,
+    liveCustomPath: { minUsd: 1, maxUsd: 1000, usdPerCredit: 1 },
+    deploymentCurrencyUsd,
+  };
+
+  if (asJson) {
+    console.log(JSON.stringify({ summary, packs: results }, null, 2));
+    return;
+  }
+
+  console.log("\n=== Credit-pack reconciliation audit (#22963) ===\n");
+  console.log(`Live custom-amount path: $1-$1000, 1 credit = $1.00\n`);
+  for (const r of results) {
+    console.log(`${r.classification.padEnd(10)} ${r.name}`);
+    console.log(
+      `  credits=$${r.credits.toFixed(2)}  price=$${(r.priceCents / 100).toFixed(2)}  implied=$${r.impliedUsdPerCredit?.toFixed(2) ?? "?"}/credit  dbActive=${r.dbActive}`,
+    );
+    if (r.stripeChecks?.kind === "ok") {
+      console.log(
+        `  stripe: active=${r.stripeChecks.active} usd=${r.stripeChecks.usd} oneOff=${r.stripeChecks.oneOff} amountMatchesDb=${r.stripeChecks.amountMatchesDb}`,
+      );
+    } else if (r.stripeChecks) {
+      console.log(`  stripe: ${r.stripeChecks.kind}`);
+    }
+    for (const reason of r.reasons) console.log(`  - ${reason}`);
+    console.log();
+  }
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+// error-policy:J1 process-boundary translation — the CLI exits non-zero with
+// the failure reason; never swallow.
+main()
+  .then(() => process.exit(0))
+  .catch((error: unknown) => {
+    console.error("Audit failed:", error);
+    process.exit(1);
+  });


### PR DESCRIPTION
# Relates to

Implements AC1 of #22963 (the reconciliation-tooling slice; claim comment: https://github.com/elizaOS/eliza/issues/22963#issuecomment-5372898027). AC2 (product approval of retained prices/minimums) explicitly remains with the product owner — this PR produces the exact data for that decision.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` (3cfde651ae7) with zero conflicts.
- [x] Focused verification lanes were run after sync.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3` (implementation) + `CC Zai/gpt-5.6-sol` (RepoPrompt CE review, 4 rounds — see Testing)
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent` / `RepoPrompt CE`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` (3cfde651ae7); zero conflicts.

# Risks

**None at runtime.** A new standalone admin script, run manually with bun; not imported by any package, not in any CI lane, not on any request path. Read-only by construction: one DB `select` + Stripe `prices.retrieve`; no charges, no writes, no provider mutation.

# Background

## What does this PR do?

Issue AC1: *"Confirm whether legacy packs are active, deprecated, or erroneous using server/provider identifiers without a real charge."*

**Verified live state first** (direct reads at develop): the pack path is fully wired — `create-checkout-session` resolves `creditPackId` through the durable `stripe-checkout-orders` service with a live price-verification seam, and the queue settlement handles `purchase_type=credit_pack` end to end — but **zero UI surfaces offer packs**, and the only seeder (`seed-credit-packs.ts`) grants $5 of credit for $49.99 charged (~10x off the live custom path's $1-per-credit economics).

`audit-credit-packs.ts` gives the product owner the AC1 classification with **zero charges**:

- **ACTIVE** — purchasable through the live path under exactly the checkout seam's own rules (price retrievable + active + USD + one-off + `unit_amount === price_cents` + deployment `STRIPE_CURRENCY` is USD).
- **DEPRECATED** — DB-inactive.
- **ERRONEOUS** — a live-path defect (stale price id per Stripe's explicit `resource_missing` boundary; archived/non-USD/recurring/amount-mismatched price; non-USD deployment currency — route parity, sticky across all branches).
- **UNKNOWN** — provider uncertainty (no Stripe key; auth/permission/rate-limit/transient errors). The audit never fabricates a classification from provider degradation.

Economics divergence (e.g. the seeder's 9.998x) is reported as a per-pack **note** for the AC2 decision, never a classification override. Unset seeder env wiring reports `null` (unverifiable), never a false mismatch. `--json` emits machine-readable output.

## What kind of change is this?

Features (non-breaking change which adds functionality) — a read-only operator tool.

# Documentation changes needed?

My changes do not require a change to the project documentation — the script's header documents usage; admin scripts are not in the public docs.

# Testing

## Where should a reviewer start?

`audit-credit-packs.proof.test.ts` — 5/5 green. Then the audit script's classification table.

## Detailed testing steps

The proof harness applies the **real migration journal** to a temp PGlite store (subprocess `db:migrate`), seeds packs via a subprocess (fresh db-client binding per store), and runs the audit as a subprocess with a **hermetic environment** (scratch env + temp cwd containing no `.env`/`.env.local`):

```
$ bun test packages/cloud/scripts/admin/audit-credit-packs.proof.test.ts
 5 pass / 0 fail
   - empty catalogue → clean summary, empty array
   - no Stripe key → DB-active is UNKNOWN (not ERRONEOUS); DB-inactive is DEPRECATED
   - non-USD STRIPE_CURRENCY → ERRONEOUS for all packs (deployment guard parity)
   - currency verdict is sticky: non-USD + DB-inactive stays ERRONEOUS
   - unset seeder wiring → seededWiringMatches null, no false mismatch
   - 9.998x economics delta surfaced as a note (impliedUsdPerCredit pinned)
```

Honest gap: the Stripe-live branches (`prices.retrieve` success shapes, `resource_missing`, provider-error typing) require network + credentials and are not exercised by the hermetic suite; the branches were reviewed byte-level by the independent reviewer instead.

**Independent review (4 rounds, pre-push, gpt-5.6-sol):** round 1 REQUEST_CHANGES (6 findings: provider-uncertainty misclassified as ERRONEOUS, non-hermetic proof, missing deployment-currency guard, invented 50% economics threshold, false wiring mismatch on unset env, error-policy violations). Round 2 REQUEST_CHANGES (5 more: `.env.local override:true` cwd hole, overbroad `StripeInvalidRequestError` ⇒ missing, overwritable currency verdict, wrong J-categories, stale commit metadata). Round 3 caught that two of round 2's fixes had silently failed to apply. Round 4 **APPROVE**, byte-verified at head `129e4438af0`: resource_missing-only detection, sticky currency verdict, clean annotations, hermetic cwd, 5/5 proof.

# Evidence Gate

<!-- evidence-head:129e4438af00214a0d7543dbd5c1730ea5639908 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CLI operator tool; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - CLI operator tool; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - CLI operator tool; no rendered UI surface.
<!-- evidence-row:backend-logs -->
- [ ] N/A - not a server code path; the executable proof is the 5/5 hermetic proof battery pasted in Testing (real migrations, real classification runs).
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or agent code touched.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the domain artifact is the audit's own JSON output, pinned by the proof assertions (classifications, economics delta, wiring null-ness); no production DB rows are read or written by the tests.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/prompt/provider/agent changes.

## Backend + frontend logs

N/A - CLI tool; proof output in Testing.

## Screenshots (before / after) + video walkthrough

N/A - CLI tool.

### Before

### After

### Walkthrough video

## Audio / voice walkthrough

N/A.

## Known gaps / failures

None for this diff's scope. Stripe-live branches untestable hermetically (documented above).

# Database changes

None — read-only.

# Deployment instructions

None. Manual operator tool: `bun packages/cloud/scripts/admin/audit-credit-packs.ts [--json]`.

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->

