### PR TITLE
fix(ci): let develop push verification terminate

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,6 +11,10 @@ workflow. Pull requests targeting `develop` or `main` and every `merge_group`
 candidate run the same fail-closed job graph. Branch rules require only its stable
 `CI / All Tests Passed` aggregate, which succeeds only when every mandatory lane
 succeeds; individual lane names may evolve without silently weakening admission.
+Manual diagnostics use independent concurrency groups, PR and merge candidates
+supersede stale runs, and `develop` pushes share a never-cancelled terminal group.
+GitHub's default single-pending queue therefore lets the running push finish while
+retaining only the newest waiting tip instead of accumulating every merge-wave run.
 
 `merge-candidate-biome.yml` remains a defense-in-depth merge-queue check of
 GitHub's synthesized candidate tree. It runs the repository-pinned full lint and
@@ -50,9 +54,10 @@ force-push/deletion bans remain active here.
 core smoke tests. It never publishes packages or creates releases.
 
 `develop-health.yml` is the canonical uncontended trunk-health lane (#19181).
-Push-triggered develop runs supersede each other during merge waves, so this
-lane runs the repository verify gate on the live develop tip four times a day
-(and on manual dispatch) from a single hosted runner, in a fixed
+Pending push-triggered develop runs can still supersede each other during merge
+waves and hosted capacity can delay their start. This lane independently runs
+the repository verify gate on the live develop tip four times a day (and on
+manual dispatch) from a single hosted runner, in a fixed
 never-cancelled concurrency group, and publishes the outcome as a
 `develop-health` commit status on the exact SHA it measured. A missing status
 means no measurement concluded; a red status means develop is actually red —

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,16 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# A manual run is a diagnostic: it must not share the push ref group, or a
-# develop push storm parks it `pending` forever and then supersedes it, so
-# branch health can never be read on demand. Give workflow_dispatch its own
-# run-scoped identity — the same shape test.yml already uses.
+# Manual diagnostics keep a run-scoped identity, while PR and merge-queue runs
+# still supersede stale work. A develop push uses a stable terminal-v2 group
+# with the default single-pending queue: the running verification finishes and
+# GitHub retains only the newest waiting tip. The versioned group also avoids
+# inheriting the pre-fix ci-refs/heads/develop run that can remain retained.
+# Do not add queue: max here; it is incompatible with cancellable PR/merge
+# events and would retain every merge-wave push instead of only the latest.
 concurrency:
-  group: ci-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'push' }}
+  group: ci-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'push' && format('terminal-v2-{0}', github.ref) || github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
 
 permissions:
   contents: read

--- a/packages/scripts/__tests__/ci-workflow-concurrency.test.ts
+++ b/packages/scripts/__tests__/ci-workflow-concurrency.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Pins the canonical CI event-specific concurrency contract. This deterministic
+ * check protects terminal develop health without weakening stale PR or merge
+ * queue cancellation and without creating an unbounded push backlog.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const workflowPath = join(repoRoot, ".github", "workflows", "ci.yml");
+const workflow = Bun.YAML.parse(readFileSync(workflowPath, "utf8")) as {
+  concurrency?: {
+    group?: string;
+    "cancel-in-progress"?: string | boolean;
+    queue?: string;
+  };
+};
+
+describe("ci.yml concurrency contract", () => {
+  const concurrency = workflow.concurrency;
+  const group = concurrency?.group ?? "";
+
+  test("gives every manual diagnostic an independent run-scoped group", () => {
+    expect(group).toContain(
+      "github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id)",
+    );
+  });
+
+  test("supersedes pull-request runs by pull-request number", () => {
+    expect(group).toContain(
+      "github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number)",
+    );
+  });
+
+  test("supersedes merge-group runs by their stable candidate ref", () => {
+    expect(group).not.toContain("github.event_name == 'merge_group'");
+    expect(group).toContain("|| github.ref || github.run_id");
+  });
+
+  test("lets one develop push finish while retaining only the newest pending tip", () => {
+    expect(group).toContain(
+      "github.event_name == 'push' && format('terminal-v2-{0}', github.ref)",
+    );
+    expect(group).not.toContain("format('terminal-v2-{0}', github.run_id)");
+    expect(group).not.toContain("format('terminal-v2-{0}', github.sha)");
+    expect(concurrency?.queue).toBeUndefined();
+  });
+
+  test("cancels only stale pull-request and merge-group work", () => {
+    expect(concurrency?.["cancel-in-progress"]).toBe(
+      `\${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}`,
+    );
+  });
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #19181. This is the bounded repository-only canonical-CI scheduling fix; it does not close the broader runner-fleet or branch-policy issue.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto `origin/develop@c803f19a739eb21a30a437b0da0e27637249e9bb` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync; the exact inherited `verify` blocker is recorded below.
- [x] A reviewer can confirm the scheduling contract from the deterministic workflow tests, workflow inventory audit, actionlint result, and independent exact-head review below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2d2411ef8cbe924e0068ac17f89dc0edf23ba0af:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@c803f19a739eb21a30a437b0da0e27637249e9bb`; zero conflicts and one commit ahead at publication.
- [x] The exact unrelated `bun run verify` blocker is documented in **Known gaps / failures**.

# Risks

Medium. This changes scheduling for the canonical CI workflow on `develop` pushes. An in-progress terminal verification now finishes while GitHub retains only the newest pending tip, so the latest merge-wave tip can wait behind one running verification but cannot build an unbounded backlog. Pull-request and merge-group cancellation, manual-run isolation, the job graph, and the stable required aggregate remain unchanged.

No repository ruleset, branch protection, runner fleet, infrastructure, deployment, release, secret, or production service was changed.

# Background

## What does this PR do?

- Gives `develop` push runs a versioned stable concurrency group with `cancel-in-progress: false`, allowing one terminal verification to conclude instead of cancelling every in-flight run during merge waves.
- Preserves independent run-scoped manual diagnostics and stale-run cancellation for pull requests and merge-queue candidates.
- Relies on GitHub's default one-running/one-pending concurrency behavior so only the newest waiting `develop` tip is retained; it deliberately does not add `queue: max`.
- Adds a deterministic regression test for the event-specific concurrency contract and updates the workflow documentation to describe the resulting terminal signal.

## What kind of change is this?

Bug fix (non-breaking CI scheduling change).

# Documentation changes needed?

Yes. `.github/workflows/README.md` now documents manual, PR/merge-candidate, and `develop` push concurrency behavior plus the independent `develop-health` lane.

# Testing

## Where should a reviewer start?

1. `.github/workflows/ci.yml`
2. `packages/scripts/__tests__/ci-workflow-concurrency.test.ts`
3. `.github/workflows/README.md`

## Detailed testing steps

- `bun install --frozen-lockfile` with Bun 1.3.14: passed after the final rebase; no lockfile or worktree changes.
- Six focused workflow-contract suites: **34/34 passed** on exact head.
- Independent exact-head review: **21/21 focused tests passed; no P0/P1/P2 findings**.
- `bun run audit:workflow-triggers`: passed; verified **60 workflows** and **18 develop-push surfaces**.
- `actionlint -ignore 'SC2034' .github/workflows/ci.yml`: passed. Plain actionlint reports only the same inherited SC2034 warning as `origin/develop`, outside this diff.
- `bunx biome check packages/scripts/__tests__/ci-workflow-concurrency.test.ts`: passed with no fixes.
- `git diff --check origin/develop...HEAD`: passed; exact-head worktree clean.
- `bun run verify`: reached `check:i18n` and stopped on the inherited repository baseline documented below.

# Evidence Gate

<!-- evidence-head:2d2411ef8cbe924e0068ac17f89dc0edf23ba0af -->

This patch has no rendered UI, backend request path, database, provider, model, or deploy surface. Deterministic workflow parsing and policy tests exercise the changed scheduling contract.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface is changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface is changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or rendered user flow is changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - this is repository CI orchestration, not a backend runtime code path.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, request, or state transition is changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent action, prompt, model, or LLM behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, provider, wallet, generated file, or domain artifact is changed.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text is changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM behavior is changed.

## Backend + frontend logs

N/A - no application backend or frontend path is changed. The exact YAML contract is parsed and asserted locally, and the PR/explicit-dispatch Actions runs are the live GitHub scheduling evidence.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface is changed.

## Audio / voice walkthrough

N/A - no audio, voice, TTS, or STT behavior is changed.

## Known gaps / failures

- `bun run verify` reaches `check:i18n` and stops on the inherited repository baseline: seven missing English `connectoraccount.*` keys plus the existing broad non-English translation gaps. This patch changes no UI or locale file.
- Plain `actionlint .github/workflows/ci.yml` reports inherited SC2034 at the shell block now at line 619; the same warning is present on `origin/develop` (line 616 before this patch). Actionlint passes when that one pre-existing ShellCheck warning is ignored.
- No ruleset/branch-protection mutation, runner-fleet operation, infrastructure change, deployment, release, or production action was performed. Those remain outside this PR's scope.

# Deploy notes

No deployment step is required. The scheduling behavior takes effect when the workflow change lands. Repository owners may evaluate runner-fleet and ruleset changes separately under #19181; this PR does not perform them.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@2d2411ef8cbe924e0068ac17f89dc0edf23ba0af:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [billing-v3-ci-terminal]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@2d2411ef8cbe924e0068ac17f89dc0edf23ba0af:packages/skills/skills/contribute-to-eliza"} -->




