### PR TITLE
fix(workflow): scope trigger ancestry to each execution

### DIFF
--- a/packages/agent/src/triggers/runtime.test.ts
+++ b/packages/agent/src/triggers/runtime.test.ts
@@ -1418,23 +1418,30 @@ describe("runtime event trigger bridge", () => {
     // emit to a later round (the previous shape here) inverts that, and made
     // this test pass against a chain guard that never fired in production.
     let runSeq = 0;
-    const execute = vi.fn(async (workflowId: string) => {
-      runSeq += 1;
-      const runId = `run-${runSeq}`;
-      // Bound the harness itself so a genuinely unbounded chain fails the
-      // assertion below instead of hanging the suite.
-      if (runSeq <= 30) {
-        await handle.runtime.emitEvent("workflow_run_event", {
-          event: {
-            id: `${runId}:1`,
-            runId,
-            workflowId,
-            type: "NodeFinished",
-          },
-        } as never);
-      }
-      return { ok: true as const, executionId: runId };
-    });
+    const execute = vi.fn(
+      async (
+        workflowId: string,
+        _triggerData: Record<string, unknown>,
+        options?: { triggerChainDepth?: number },
+      ) => {
+        runSeq += 1;
+        const runId = `run-${runSeq}`;
+        // Bound the harness itself so a genuinely unbounded chain fails the
+        // assertion below instead of hanging the suite.
+        if (runSeq <= 30) {
+          await handle.runtime.emitEvent("workflow_run_event", {
+            event: {
+              id: `${runId}:1`,
+              runId,
+              workflowId,
+              type: "NodeFinished",
+            },
+            triggerChainDepth: options?.triggerChainDepth,
+          } as never);
+        }
+        return { ok: true as const, executionId: runId };
+      },
+    );
     (
       handle.runtime.getService("WORKFLOW_DISPATCH") as unknown as {
         execute: typeof execute;
@@ -1459,9 +1466,24 @@ describe("runtime event trigger bridge", () => {
       5, // MAX_EVENT_TRIGGER_CHAIN_DEPTH (4) + the seed hop
     );
     expect(execute.mock.calls.length).toBeGreaterThan(0);
+
+    // An ancestry limit belongs to one execution chain, not the workflow id.
+    // A later external event for the same workflow must still be eligible.
+    const priorCalls = execute.mock.calls.length;
+    handle.setTasks([aToB]);
+    await handle.runtime.emitEvent("workflow_run_event", {
+      event: {
+        id: "later:1",
+        runId: "run-later",
+        workflowId: "wf-a",
+        type: "NodeFinished",
+      },
+    } as never);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(execute.mock.calls.length).toBe(priorCalls + 1);
   });
 
-  it("cuts off a saved trigger that exceeds the sustained dispatch ceiling", async () => {
+  it("dispatches more than sixty distinct valid events without loss", async () => {
     const target = makeTriggerTask(
       {
         triggerType: "event",
@@ -1485,14 +1507,14 @@ describe("runtime event trigger bridge", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
 
-    expect(handle.dispatchCalls).toHaveLength(60);
+    expect(handle.dispatchCalls).toHaveLength(65);
     expect(
       handle.reportedErrors.filter(
         (entry) =>
           (entry.error as { code?: string }).code ===
           "TRIGGER_EVENT_DISPATCH_RATE_EXCEEDED",
       ),
-    ).toHaveLength(1);
+    ).toHaveLength(0);
   });
 
   it("reads the task store once per event instead of once per tag set", async () => {

--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -28,7 +28,6 @@ import type {
   UUID,
 } from "@elizaos/core";
 import {
-  ElizaError,
   inspectSendHandlerResult,
   MESSAGE_SOURCE_TRIGGER_PROMPT,
   registerRuntimeManagedInternalActor,
@@ -61,20 +60,10 @@ const RUNTIME_TRIGGER_EVENT_KINDS = [WORKFLOW_RUN_EVENT] as const;
  * How many trigger hops a single originating run may cause. A workflow started
  * by an event trigger emits its own run events, so a mutually referential
  * configuration (A triggers B, B triggers A) would otherwise never quiesce.
- * Ancestry is tracked by run id, so the chain stops after this many hops.
+ * The native workflow service carries the current depth on every emitted run
+ * event, so independent executions of the same workflow never share ancestry.
  */
 const MAX_EVENT_TRIGGER_CHAIN_DEPTH = 4;
-/** Upper bound on remembered run-id ancestry entries per runtime. */
-const MAX_EVENT_TRIGGER_CHAIN_ENTRIES = 1024;
-/**
- * Long-run dispatch ceiling per saved trigger. The predecessor app-core bridge
- * enforced a one-second floor between fires, which silently dropped distinct
- * legitimate events arriving in a burst. This keeps the same sustained ceiling
- * without the burst loss: bursts of distinct events all fire, but a runaway
- * fan-out is cut off and reported instead of compounding.
- */
-const EVENT_DISPATCH_WINDOW_MS = 60_000;
-const MAX_EVENT_DISPATCHES_PER_WINDOW = 60;
 const eventBridgeRegistrations = new WeakSet<IAgentRuntime>();
 const eventDispatchQueues = new WeakMap<
   IAgentRuntime,
@@ -82,21 +71,6 @@ const eventDispatchQueues = new WeakMap<
 >();
 /** Discovery queries shared by every event observed in the same event-loop turn. */
 const eventDiscoveryBatches = new WeakMap<IAgentRuntime, Promise<Task[]>>();
-/** Run id -> number of trigger hops between an external event and that run. */
-const eventTriggerChainDepths = new WeakMap<
-  IAgentRuntime,
-  Map<string, number>
->();
-interface EventDispatchWindow {
-  windowStart: number;
-  count: number;
-  reported: boolean;
-}
-const eventDispatchWindows = new WeakMap<
-  IAgentRuntime,
-  Map<string, EventDispatchWindow>
->();
-
 const DEFAULT_MAX_ACTIVE_TRIGGERS = 100;
 
 interface TriggerMetricsState {
@@ -112,6 +86,8 @@ export interface TriggerExecutionOptions {
   event?: {
     kind: string;
     payload?: Record<string, unknown>;
+    /** Trigger hops already carried by the workflow execution that emitted it. */
+    triggerChainDepth?: number;
   };
 }
 
@@ -303,6 +279,7 @@ export function getTriggerLimit(runtime?: IAgentRuntime): number {
 interface WorkflowDispatchOptionsLike {
   triggerData?: Record<string, unknown>;
   idempotencyKey?: string;
+  triggerChainDepth?: number;
 }
 
 interface WorkflowDispatchServiceLike {
@@ -451,6 +428,9 @@ async function dispatchWorkflow(
     : {};
   const result = await svc.execute(trigger.workflowId, payload, {
     idempotencyKey,
+    ...(event?.triggerChainDepth !== undefined
+      ? { triggerChainDepth: event.triggerChainDepth }
+      : {}),
   });
   return result.ok
     ? {
@@ -1073,74 +1053,13 @@ function discoverEventTriggerTasks(runtime: IAgentRuntime): Promise<Task[]> {
   return batch;
 }
 
-/** Trigger hops between an external event and the run that emitted `runId`. */
-// Ancestry is keyed on the WORKFLOW id, not the run id. Keying on the run id
-// could never work: WORKFLOW_DISPATCH awaits executeWorkflow, and a run emits
-// every one of its events before that promise resolves — so the child's events
-// were always dispatched before its depth was recorded, and readChainDepth
-// returned 0 forever. The workflow id is known before dispatch, so recording
-// against it actually bounds the chain.
-function readChainDepth(runtime: IAgentRuntime, workflowId?: string): number {
-  if (!workflowId) return 0;
-  return eventTriggerChainDepths.get(runtime)?.get(workflowId) ?? 0;
-}
-
-function recordChainDepth(
-  runtime: IAgentRuntime,
-  workflowId: string,
-  depth: number,
-): void {
-  const depths =
-    eventTriggerChainDepths.get(runtime) ?? new Map<string, number>();
-  eventTriggerChainDepths.set(runtime, depths);
-  // Keep the deepest observed depth for this workflow: a later shallower hop
-  // must not reset a chain that has already gone deep.
-  depths.set(workflowId, Math.max(depths.get(workflowId) ?? 0, depth));
-  // Insertion-ordered eviction keeps ancestry bounded for long-lived hosts.
-  while (depths.size > MAX_EVENT_TRIGGER_CHAIN_ENTRIES) {
-    const oldest = depths.keys().next();
-    if (oldest.done) break;
-    depths.delete(oldest.value);
-  }
-}
-
-/**
- * Consume one dispatch slot for a saved trigger, returning false once the
- * sustained ceiling is reached so a runaway configuration stops compounding.
- */
-function admitTriggerDispatch(
-  runtime: IAgentRuntime,
-  triggerId: string,
-  eventKind: string,
-): boolean {
-  const windows =
-    eventDispatchWindows.get(runtime) ?? new Map<string, EventDispatchWindow>();
-  eventDispatchWindows.set(runtime, windows);
-  const now = Date.now();
-  const window = windows.get(triggerId);
-  if (!window || now - window.windowStart >= EVENT_DISPATCH_WINDOW_MS) {
-    windows.set(triggerId, { windowStart: now, count: 1, reported: false });
-    return true;
-  }
-  if (window.count < MAX_EVENT_DISPATCHES_PER_WINDOW) {
-    window.count += 1;
-    return true;
-  }
-  if (!window.reported) {
-    window.reported = true;
-    runtime.reportError(
-      "TriggerRuntime.eventDispatch",
-      new ElizaError(
-        `Event trigger ${triggerId} exceeded ${MAX_EVENT_DISPATCHES_PER_WINDOW} dispatches per minute; further events are dropped until the window rolls`,
-        {
-          code: "TRIGGER_EVENT_DISPATCH_RATE_EXCEEDED",
-          context: { triggerId, eventKind },
-        },
-      ),
-      { triggerId, eventKind },
-    );
-  }
-  return false;
+function readChainDepth(payload: Record<string, unknown>): number {
+  const candidate = payload.triggerChainDepth;
+  return typeof candidate === "number" &&
+    Number.isSafeInteger(candidate) &&
+    candidate >= 0
+    ? candidate
+    : 0;
 }
 
 /**
@@ -1156,7 +1075,7 @@ export async function dispatchRuntimeEventTriggers(
   const nestedEvent = readNestedRunEvent(payload);
   const sourceWorkflowId = readNestedString(nestedEvent?.workflowId);
   const sourceRunId = readNestedString(nestedEvent?.runId);
-  const chainDepth = readChainDepth(runtime, sourceWorkflowId);
+  const chainDepth = readChainDepth(payload);
   if (chainDepth >= MAX_EVENT_TRIGGER_CHAIN_DEPTH) {
     // The emitting run was itself started by a trigger chain that has already
     // reached its hop limit. Continuing would let a mutually referential
@@ -1224,38 +1143,19 @@ export async function dispatchRuntimeEventTriggers(
           const currentTask = await runtime.getTask(taskId);
           if (!currentTask) return;
           const currentTrigger = readTriggerConfig(currentTask);
-          // Evaluate the filter BEFORE consuming a dispatch slot. A workflow
-          // emitting NodeStarted/NodeFinished for every node would otherwise
-          // burn the whole per-minute ceiling on events that were never going
-          // to fire, and drop the one the trigger actually exists for.
           if (
             currentTrigger?.triggerType === "event" &&
             !eventFilterMatches(currentTrigger.eventFilter, payload)
           ) {
             return;
           }
-          if (
-            currentTrigger &&
-            !admitTriggerDispatch(runtime, currentTrigger.triggerId, eventKind)
-          ) {
-            return;
-          }
-          // Recorded BEFORE dispatch: the target workflow emits its events
-          // inside executeTriggerTask, so anything written afterwards arrives
-          // too late to bound the next hop.
-          if (
-            currentTrigger?.kind === "workflow" &&
-            currentTrigger.workflowId
-          ) {
-            recordChainDepth(
-              runtime,
-              currentTrigger.workflowId,
-              chainDepth + 1,
-            );
-          }
           await executeTriggerTask(runtime, currentTask, {
             source: "event",
-            event: { kind: eventKind, payload },
+            event: {
+              kind: eventKind,
+              payload,
+              triggerChainDepth: chainDepth + 1,
+            },
           });
         } catch (error) {
           // error-policy:J7 one trigger's persistence/dispatch failure must not

--- a/plugins/plugin-workflow/__tests__/unit/embedded-workflow-lifecycle.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/embedded-workflow-lifecycle.test.ts
@@ -75,6 +75,7 @@ async function harness() {
     );
   `);
   const tasks: Task[] = [];
+  const emittedEvents: Array<{ type: string; payload: unknown }> = [];
   const runtime = {
     agentId: '00000000-0000-4000-8000-000000000001' as UUID,
     db: drizzle(client, { schema }),
@@ -90,13 +91,16 @@ async function harness() {
       const index = tasks.findIndex((task) => task.id === id);
       if (index >= 0) tasks.splice(index, 1);
     },
-    emitEvent: async () => {},
+    emitEvent: async (type: string, payload: unknown) => {
+      emittedEvents.push({ type, payload });
+    },
   } as unknown as IAgentRuntime;
   return {
     service: await EmbeddedWorkflowService.start(runtime),
     tasks,
     client,
     runtime,
+    emittedEvents,
   };
 }
 
@@ -342,7 +346,7 @@ describe('embedded native workflow lifecycle', () => {
   }, 15_000);
 
   test('persists authoritative pending approval details from Smithers events', async () => {
-    const { service, client, runtime } = await harness();
+    const { service, client, runtime, emittedEvents } = await harness();
     const workflow = await service.createWorkflow({
       ...definition('Approval'),
       id: 'approval',
@@ -360,6 +364,7 @@ describe('embedded native workflow lifecycle', () => {
       input: {},
       events: [],
       approvals: [],
+      triggerChainDepth: 3,
     };
     await client.query(
       `INSERT INTO workflow.embedded_executions
@@ -418,5 +423,9 @@ describe('embedded native workflow lifecycle', () => {
         requestedAt: '2026-08-16T00:00:01.000Z',
       },
     ]);
+    expect(emittedEvents.at(-1)).toMatchObject({
+      type: 'workflow_run_event',
+      payload: { triggerChainDepth: 3 },
+    });
   }, 15_000);
 });

--- a/plugins/plugin-workflow/__tests__/unit/workflow-dispatch.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-dispatch.test.ts
@@ -13,7 +13,11 @@ function makeEmbeddedService() {
     executeWorkflow: mock(
       async (
         workflowId: string,
-        options: { triggerData: Record<string, unknown>; idempotencyKey?: string }
+        options: {
+          triggerData: Record<string, unknown>;
+          idempotencyKey?: string;
+          triggerChainDepth?: number;
+        }
       ) => ({ id: `${workflowId}:${options.idempotencyKey ?? 'fresh'}` })
     ),
     findExecutionByIdempotencyKey: mock(async () => null as { id?: string } | null),
@@ -49,13 +53,18 @@ describe('workflow dispatch service', () => {
     const dispatch = createWorkflowDispatchService(makeRuntime(embedded) as never);
 
     await expect(
-      dispatch.execute(' workflow-1 ', { source: 'schedule' }, { idempotencyKey: 'tick-1' })
+      dispatch.execute(
+        ' workflow-1 ',
+        { source: 'schedule' },
+        { idempotencyKey: 'tick-1', triggerChainDepth: 3 }
+      )
     ).resolves.toEqual({ ok: true, executionId: 'workflow-1:tick-1' });
     expect(embedded.findExecutionByIdempotencyKey).toHaveBeenCalledWith('workflow-1', 'tick-1');
     expect(embedded.executeWorkflow).toHaveBeenCalledWith('workflow-1', {
       mode: 'trigger',
       triggerData: { source: 'schedule' },
       idempotencyKey: 'tick-1',
+      triggerChainDepth: 3,
     });
   });
 

--- a/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
+++ b/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
@@ -61,6 +61,8 @@ export interface ExecuteWorkflowOptions {
   triggerData?: Record<string, unknown>;
   idempotencyKey?: string;
   throwOnError?: boolean;
+  /** Trigger hops inherited by events emitted from this execution. */
+  triggerChainDepth?: number;
 }
 
 type RunListener = (event: WorkflowRunEvent) => void;
@@ -539,6 +541,9 @@ export class EmbeddedWorkflowService extends Service {
       events: [],
       approvals: [],
       ...(options.idempotencyKey ? { idempotencyKey: options.idempotencyKey } : {}),
+      ...(options.triggerChainDepth !== undefined
+        ? { triggerChainDepth: options.triggerChainDepth }
+        : {}),
     };
     await this.saveExecution(pending);
     const controller = new AbortController();
@@ -647,7 +652,13 @@ export class EmbeddedWorkflowService extends Service {
     }
     await this.saveExecution(execution);
     for (const listener of this.listeners.get(execution.id) ?? []) listener(event);
-    await this.runtime.emitEvent(WORKFLOW_RUN_EVENT, { runtime: this.runtime, event } as never);
+    await this.runtime.emitEvent(WORKFLOW_RUN_EVENT, {
+      runtime: this.runtime,
+      event,
+      ...(execution.triggerChainDepth !== undefined
+        ? { triggerChainDepth: execution.triggerChainDepth }
+        : {}),
+    } as never);
   }
 
   subscribe(runId: string, listener: RunListener): () => void {

--- a/plugins/plugin-workflow/src/services/workflow-dispatch.ts
+++ b/plugins/plugin-workflow/src/services/workflow-dispatch.ts
@@ -50,6 +50,8 @@ export interface WorkflowDispatchResult {
 export interface WorkflowDispatchOptions {
   triggerData?: Record<string, unknown>;
   idempotencyKey?: string;
+  /** Trigger ancestry copied onto events emitted by this execution. */
+  triggerChainDepth?: number;
 }
 
 export interface WorkflowDispatchService {
@@ -155,14 +157,20 @@ export function createWorkflowDispatchService(runtime: IAgentRuntime): WorkflowD
           return result.ok ? { ...result, dedup: true } : result;
         }
 
-        const promise = runDispatch(service, id, triggerData, idempotencyKey).finally(() => {
+        const promise = runDispatch(
+          service,
+          id,
+          triggerData,
+          idempotencyKey,
+          options.triggerChainDepth
+        ).finally(() => {
           inflight.delete(inflightKey);
         });
         inflight.set(inflightKey, promise);
         return promise;
       }
 
-      return runDispatch(service, id, triggerData, undefined);
+      return runDispatch(service, id, triggerData, undefined, options.triggerChainDepth);
     },
   };
 }
@@ -171,13 +179,15 @@ async function runDispatch(
   service: EmbeddedWorkflowService,
   workflowId: string,
   triggerData: Record<string, unknown>,
-  idempotencyKey: string | undefined
+  idempotencyKey: string | undefined,
+  triggerChainDepth: number | undefined
 ): Promise<WorkflowDispatchResult> {
   try {
     const execution = await service.executeWorkflow(workflowId, {
       mode: 'trigger',
       triggerData,
       idempotencyKey,
+      ...(triggerChainDepth !== undefined ? { triggerChainDepth } : {}),
     });
     return execution.id ? { ok: true, executionId: execution.id } : { ok: true };
   } catch (err) {

--- a/plugins/plugin-workflow/src/types/index.ts
+++ b/plugins/plugin-workflow/src/types/index.ts
@@ -171,6 +171,8 @@ export interface WorkflowExecution {
   events?: WorkflowRunEvent[];
   approvals?: WorkflowApproval[];
   idempotencyKey?: string;
+  /** Internal ancestry carried across native workflow-trigger executions. */
+  triggerChainDepth?: number;
 }
 
 export interface WorkflowCreationResult {


### PR DESCRIPTION
# Relates to

Refs #22575.

Corrective follow-up to merged PR #22790. The merged head keyed trigger ancestry permanently by workflow ID and deliberately dropped distinct events after 60 dispatches per minute. That made one bounded cycle poison later independent runs and violated the durable event contract.

## What changed

- Carries `triggerChainDepth` through `WORKFLOW_DISPATCH`, the native Smithers execution record, and the emitted `workflow_run_event`.
- Resets ancestry naturally for each independent external/manual execution.
- Preserves the four-hop cycle bound for mutually referential saved triggers.
- Removes the lossy per-minute dispatch gate; durable native event identity and dispatch idempotency remain the replay boundary.
- Adds adversarial coverage for production event ordering, a fresh run after a bounded cycle, 65 distinct rapid events, typed dispatch propagation, and real-PGlite event emission.

## Exact-head validation

Exact head: `7e8bf9ca31159a3d5a253c88fb0ba654af0bf110`  
Base: `2f9011038d0dc7640bfa878bba3b841f59bfbb50`

- Nested LifeOps dispatch regression: 9/9 passed; verifies the in-tree `dispatch_workflow` caller advances inherited ancestry through the typed third argument.
- Agent trigger runtime: 45/45 passed on the original source-complete head; the rebased direct Bun lane reconfirmed the new cycle/throughput cases while 13 unrelated Vitest-only helper cases require the configured Vitest harness.
- Workflow dispatch plus real-PGlite lifecycle: 12/12 passed, 50 assertions.
- plugin-workflow typecheck and build: passed.
- Biome for all 11 changed files and `git diff --check`: passed.
- Real local Chromium Smithers journey: 1/1 passed in 2.0 minutes after rebuilding plugin views, core, and shared. It created, triggered, inspected, reloaded, and persisted the workflow through the real local API and real PGlite-backed native service.
- `packages/app audit:app`: 222/223 passed before this source-only corrective patch. All workflow captures passed. The only failure was the pre-existing untouched mobile-landscape minimalism ratchet for `builtin-plugins`, `builtin-runtime`, and `builtin-background`.

The seven original corrective blobs and the four existing real-browser bridge/journey blobs were byte-identical between the tested updated #22790 tree and this corrective commit's `develop` parent. The only relevant range difference was the lockfile; no package involved in this correction changed dependency declarations.

## Risk

Medium: production runtime events can start workflows. The correction narrows recursion state to one typed execution chain and removes an undocumented lossy policy. The exact real-browser run plus unit/PGlite adversarial tests cover the changed boundary.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8e5e0ff034704511e777527a4d0f02440a00940f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Evidence Gate

<!-- evidence-head:7e8bf9ca31159a3d5a253c88fb0ba654af0bf110 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no production UI or styling changed; this corrects the runtime event contract.
<!-- evidence-row:after-screenshots -->
- [x] ![real Chromium final workflow state](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22575-7eb18d7b-chromium.png)
<!-- evidence-row:walkthrough-video -->
- [x] [real Chromium workflow walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22575-7eb18d7b-chromium.webm)
<!-- evidence-row:backend-logs -->
- [x] [real local API and Smithers backend log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22575-7eb18d7b-backend.log)
<!-- evidence-row:frontend-logs -->
- [x] [22575-7eb18d7b-frontend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22575-7eb18d7b-frontend.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic workflow/event routing only; no provider, prompt, planner, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [22575-7eb18d7b-evidence.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/22575-7eb18d7b-evidence.txt)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no production UI pixels changed; the final recorded frame was manually inspected.

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex Desktop  
Contribution skill revision: elizaOS/eliza@8e5e0ff034704511e777527a4d0f02440a00940f:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@8e5e0ff034704511e777527a4d0f02440a00940f:packages/skills/skills/contribute-to-eliza"} -->