### PR TITLE
fix(cloud): preserve coordinator Request inputs

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
@@ -497,6 +497,24 @@ describe("shared conversation coordinator", () => {
     expect(seen?.aborted).toBe(true);
   });
 
+  test("coordinatorFetch preserves Request inputs through the deadline wrapper", async () => {
+    const request = new Request("https://shared-runtime.internal/bridge", {
+      method: "POST",
+      body: "{}",
+    });
+    let seenInput: RequestInfo | URL | undefined;
+    const stub = {
+      fetch: async (input: RequestInfo | URL) => {
+        seenInput = input;
+        return Response.json({ ok: true });
+      },
+    };
+
+    await coordinatorFetch(stub, request);
+
+    expect(seenInput).toBe(request);
+  });
+
   test("coordinatorFetch still times out when the caller signal never aborts", async () => {
     const caller = new AbortController();
     const hungStub = {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -220,12 +220,12 @@ const SHARED_RUNTIME_FETCH_TIMEOUT_MS = 10_000;
  */
 export function coordinatorFetch(
   stub: { fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> },
-  url: string | URL,
+  input: RequestInfo | URL,
   init?: RequestInit,
   timeoutMs: number = SHARED_RUNTIME_FETCH_TIMEOUT_MS,
 ): Promise<Response> {
   const timeoutSignal = AbortSignal.timeout(timeoutMs);
-  return stub.fetch(url, {
+  return stub.fetch(input, {
     ...init,
     signal: init?.signal ? AbortSignal.any([init.signal, timeoutSignal]) : timeoutSignal,
   });


### PR DESCRIPTION
# Relates to

Closes #23875.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync; focused install/build/typecheck/test evidence is recorded below while the root gate runs.
- [x] A reviewer can confirm the change from the regression test and command output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d29920dad3273d6911f569733f0d3d9693971e4b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `d29920dad3273d6911f569733f0d3d9693971e4b`; zero conflicts.
- [ ] Root `bun run verify` reaches an unrelated pre-existing i18n failure; package typecheck and focused checks pass.

# Risks

Low. The production helper already accepts Fetch API `RequestInfo | URL`; this restores that same public contract through its deadline wrapper and adds a `Request` regression test.

# Background

## What does this PR do?

Preserves `Request` objects through the shared-runtime Durable Object deadline wrapper. This fixes the exact `develop` package typecheck failure without changing cancellation or timeout behavior.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is needed; this restores the declared Fetch API contract.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts`

## Detailed testing steps

- `bun run --cwd packages/cloud/shared typecheck`
- `bun --cwd=/private/tmp test /private/tmp/eliza-coordinator-request-input/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts` — 14 pass, 0 fail, 47 assertions.
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts`

# Evidence Gate

<!-- evidence-head:77568c98cadab8f0b98e26195a45c83077dca685 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend TypeScript contract only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend TypeScript contract only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend TypeScript contract only; no visual flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic compile-time contract and unit test; no deployed route behavior changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or planner behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted domain artifact; the artifact is the passing typecheck and regression test.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Known gaps / failures

No focused failures. Root `bun run verify` stops at the pre-existing `check:i18n` gate because current `develop` is missing seven English `connectoraccount.*` keys introduced by unrelated UI changes; this PR does not touch UI or locale catalogs.

AI provider/model: openai / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@d29920dad3273d6911f569733f0d3d9693971e4b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@d29920dad3273d6911f569733f0d3d9693971e4b:packages/skills/skills/contribute-to-eliza"} -->
