### PR TITLE
fix(plugin-inmemorydb): preserve public vector storage contract

### DIFF
--- a/plugins/plugin-inmemorydb/package.json
+++ b/plugins/plugin-inmemorydb/package.json
@@ -57,7 +57,7 @@
   },
   "scripts": {
     "dev": "bun run build.ts --watch",
-    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.contract.json",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist .turbo .turbo-tsconfig.json *.tsbuildinfo",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",

--- a/plugins/plugin-inmemorydb/tsconfig.contract.json
+++ b/plugins/plugin-inmemorydb/tsconfig.contract.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["./types.ts", "./vector-storage-contract.test.ts"],
+  "exclude": []
+}

--- a/plugins/plugin-inmemorydb/types.ts
+++ b/plugins/plugin-inmemorydb/types.ts
@@ -31,20 +31,6 @@ export interface IVectorStorage {
   add(id: string, vector: number[]): Promise<void>;
   remove(id: string): Promise<void>;
   search(query: number[], k: number, threshold?: number): Promise<VectorSearchResult[]>;
-  /**
-   * Exhaustive nearest-neighbor scan over every indexed vector, ordered by
-   * ascending cosine distance. Unlike `search`, which navigates the
-   * approximate HNSW graph and may omit reachable-but-unvisited nodes, this
-   * considers the entire index so callers that apply their own scope filter
-   * afterwards get the true "top K among eligible" set instead of a global
-   * top-K that can be starved by closer out-of-scope vectors.
-   */
-  searchExact(
-    query: number[],
-    k: number,
-    threshold?: number,
-    eligibleIds?: ReadonlySet<string>
-  ): Promise<VectorSearchResult[]>;
   clear(): Promise<void>;
 }
 

--- a/plugins/plugin-inmemorydb/vector-storage-contract.test.ts
+++ b/plugins/plugin-inmemorydb/vector-storage-contract.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Compile-time compatibility coverage for the public vector-storage contract.
+ * A third-party implementation of the documented approximate-index surface
+ * must remain valid without adopting EphemeralHNSW-specific exact search.
+ */
+import { describe, expect, it } from "vitest";
+import type { IVectorStorage } from "./types";
+
+const thirdPartyVectorStorage = {
+  async init(_dimension: number): Promise<void> {},
+  async add(_id: string, _vector: number[]): Promise<void> {},
+  async remove(_id: string): Promise<void> {},
+  async search(_query: number[], _k: number, _threshold?: number) {
+    return [];
+  },
+  async clear(): Promise<void> {},
+} satisfies IVectorStorage;
+
+describe("IVectorStorage public compatibility", () => {
+  it("accepts an existing approximate-only third-party implementation", async () => {
+    await expect(thirdPartyVectorStorage.search([1, 0], 1)).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
# Relates to

Fixes #23405.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and the owning package gates were run after sync. Root `bun run verify` reaches an unrelated current-`develop` i18n inventory failure documented below.
- [x] A reviewer can confirm the contract from the compile-time compatibility regression and exact-head package receipts below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@1a70ab06914a2e81f5d542adafe3919fb3697f98:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `5923db821fd0cf77554ce1d004733a57f868598c`; zero conflicts.
- [ ] `bun run verify` passes post-sync. It stops at the unrelated repository-wide i18n inventory failure described below.

# Risks

Low. This narrows a public TypeScript interface back to its pre-#23415 contract while retaining the concrete `EphemeralHNSW.searchExact` method used internally by the adapter.

# Background

## What does this PR do?

The merged #23415 repair made `searchExact` mandatory on the publicly exported `IVectorStorage` interface. That unnecessarily broke third-party vector storage implementations even though the adapter owns a concrete `EphemeralHNSW` instance.

This corrective removes the mandatory interface member, keeps the concrete exact-search implementation, and adds a compile-time structural compatibility regression proving an existing minimal third-party implementation remains assignable.

## What kind of change is this?

Bug fix (non-breaking compatibility repair).

# Documentation changes needed?

No. The change restores the documented public extension contract.

# Testing

## Where should a reviewer start?

- `plugins/plugin-inmemorydb/vector-storage-contract.test.ts`
- `plugins/plugin-inmemorydb/src/vector-storage.ts`

## Detailed testing steps

Exact head `1a70ab06914a2e81f5d542adafe3919fb3697f98`:

- `bun run --cwd plugins/plugin-inmemorydb typecheck` — PASS
- `bun run --cwd plugins/plugin-inmemorydb lint` — PASS, 29 files, no fixes
- `bun run --cwd plugins/plugin-inmemorydb test` — PASS, 13 files / 63 tests
- `bun run --cwd plugins/plugin-inmemorydb build` — PASS, Node/browser/declarations
- `git diff --check origin/develop...HEAD` — PASS

# Evidence Gate

<!-- evidence-head:1a70ab06914a2e81f5d542adafe3919fb3697f98 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - public TypeScript contract repair with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - public TypeScript contract repair with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow or visual behavior changes
<!-- evidence-row:backend-logs -->
- [ ] N/A - no runtime backend path changes; the regression is compile-time API compatibility
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface or network request changes
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, provider, or agent behavior changes
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the exact contract artifact is the compile-time structural compatibility test
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered text or UI surface changes

# Evidence Details

## Known gaps / failures

`bun run verify` reaches the current-`develop` repository-wide `check:i18n` failure before aggregate package gates. It reports 998–1,016 missing source keys across non-English locales and seven missing English keys in unrelated UI connector-capability files. This PR touches only the plugin-inmemorydb public vector interface and its compile-time regression; its owning typecheck, lint, complete package tests, build, and diff-check all pass on the exact head.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@1a70ab06914a2e81f5d542adafe3919fb3697f98:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@1a70ab06914a2e81f5d542adafe3919fb3697f98:packages/skills/skills/contribute-to-eliza"} -->

