### PR TITLE
fix(plugin-elizacloud): retry partial voice catalog outages

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/unit/cloud-voice-catalog.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/cloud-voice-catalog.test.ts
@@ -434,6 +434,39 @@ describe("fetchCloudVoiceCatalog", () => {
     }
   });
 
+  it("reports a total outage once per backoff window, not once per caller", async () => {
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    try {
+      const { client, calls } = makeFakeClient({
+        premadeError: new Error("premade down"),
+        userError: new Error("user down"),
+      });
+      setCloudVoiceClientFactoryForTesting(() => client);
+      const runtime = makeRuntime();
+
+      await fetchCloudVoiceCatalog(runtime);
+      await fetchCloudVoiceCatalog(runtime);
+      await fetchCloudVoiceCatalog(runtime);
+
+      // The backoff shields upstream from the retries, and the outage report
+      // is a diagnostic about the outage, not about each caller that noticed
+      // it — three reads inside one window must not become three reports.
+      expect(calls).toEqual({ premade: 1, user: 1 });
+      expect(runtime.reportError).toHaveBeenCalledTimes(1);
+
+      // A window later the endpoints are retried, so the still-live outage is
+      // reported again — the diagnostic stays alive rather than going silent.
+      vi.advanceTimersByTime(31_000);
+      await fetchCloudVoiceCatalog(runtime);
+      expect(calls).toEqual({ premade: 2, user: 2 });
+      expect(runtime.reportError).toHaveBeenCalledTimes(2);
+    } finally {
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it("caches a genuine empty catalog when both endpoints succeed", async () => {
     const { client, calls } = makeFakeClient({ premade: [], user: [] });
     setCloudVoiceClientFactoryForTesting(() => client);

--- a/plugins/plugin-elizacloud/__tests__/unit/cloud-voice-catalog.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/cloud-voice-catalog.test.ts
@@ -398,20 +398,40 @@ describe("fetchCloudVoiceCatalog", () => {
     warnSpy.mockRestore();
   });
 
-  it("caches a partial success while one endpoint is unavailable", async () => {
-    const { client, calls } = makeFakeClient({
-      premade: [{ voice_id: "available-voice", name: "Available" }],
-      userError: new Error("user endpoint down"),
-    });
-    setCloudVoiceClientFactoryForTesting(() => client);
+  it("keeps a healthy endpoint cached while retrying a failed endpoint after the short backoff", async () => {
+    vi.useFakeTimers();
+    try {
+      const partial = makeFakeClient({
+        premade: [{ voice_id: "available-voice", name: "Available" }],
+        userError: new Error("user endpoint down"),
+      });
+      const recovered = makeFakeClient({
+        premade: [{ voice_id: "should-not-refetch", name: "Unexpected" }],
+        user: [{ voice_id: "new-clone", name: "New Clone" }],
+      });
+      let currentClient = partial.client;
+      setCloudVoiceClientFactoryForTesting(() => currentClient);
 
-    const runtime = makeRuntime();
-    const first = await fetchCloudVoiceCatalog(runtime);
-    const second = await fetchCloudVoiceCatalog(runtime);
+      const runtime = makeRuntime();
+      const first = await fetchCloudVoiceCatalog(runtime);
+      expect(first.map((voice) => voice.id)).toEqual(["available-voice"]);
 
-    expect(first.map((voice) => voice.id)).toEqual(["available-voice"]);
-    expect(second).toBe(first);
-    expect(calls).toEqual({ premade: 1, user: 1 });
+      currentClient = recovered.client;
+      vi.advanceTimersByTime(29_000);
+      const backedOff = await fetchCloudVoiceCatalog(runtime);
+      expect(backedOff.map((voice) => voice.id)).toEqual(["available-voice"]);
+      expect(partial.calls).toEqual({ premade: 1, user: 1 });
+      expect(recovered.calls).toEqual({ premade: 0, user: 0 });
+
+      vi.advanceTimersByTime(2_000);
+      const afterRecovery = await fetchCloudVoiceCatalog(runtime);
+      expect(afterRecovery.map((voice) => voice.id)).toEqual(["new-clone", "available-voice"]);
+      // The healthy premade result keeps its 1h success TTL; only the failed
+      // user endpoint is retried after the 30s backoff.
+      expect(recovered.calls).toEqual({ premade: 0, user: 1 });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("caches a genuine empty catalog when both endpoints succeed", async () => {

--- a/plugins/plugin-elizacloud/src/cloud-voice-catalog.ts
+++ b/plugins/plugin-elizacloud/src/cloud-voice-catalog.ts
@@ -247,19 +247,26 @@ function endpointCacheKey(
   return `${catalogKey}|${endpoint}`;
 }
 
+/**
+ * `attempted` distinguishes a fresh upstream failure from a remembered one.
+ * The outage report is a diagnostic about the outage, not about each caller
+ * that observed it, so only a pass that actually reached upstream may report.
+ */
+type EndpointLoadResult = EndpointVoiceResult & { attempted: boolean };
+
 async function loadEndpointVoices(
   runtime: IAgentRuntime,
   catalogKey: string,
   endpoint: "premade" | "user"
-): Promise<EndpointVoiceResult> {
+): Promise<EndpointLoadResult> {
   const key = endpointCacheKey(catalogKey, endpoint);
   const cached = cache.get(key);
   const age = cached ? Date.now() - cached.fetchedAt : Number.POSITIVE_INFINITY;
   if (cached?.kind === "success" && age < CACHE_TTL_MS) {
-    return { ok: true, voices: cached.voices };
+    return { ok: true, voices: cached.voices, attempted: false };
   }
   if (cached?.kind === "failure" && age < FAILURE_TTL_MS) {
-    return { ok: false, voices: [] };
+    return { ok: false, voices: [], attempted: false };
   }
 
   const result = await fetchEndpointVoices(runtime, endpoint);
@@ -269,7 +276,7 @@ async function loadEndpointVoices(
       ? { kind: "success", fetchedAt: Date.now(), voices: result.voices }
       : { kind: "failure", fetchedAt: Date.now() }
   );
-  return result;
+  return { ...result, attempted: true };
 }
 
 /**
@@ -325,7 +332,10 @@ export async function fetchCloudVoiceCatalog(
 
     // Total outage: both endpoint caches carry short-lived failure entries;
     // surface it observably (error-policy: "not loaded" must never read as
-    // "empty").
+    // "empty"). Reads served entirely from those failure entries stay silent —
+    // the next expiry re-attempts and re-reports, so a persistent outage keeps
+    // producing one diagnostic per backoff window instead of one per caller.
+    if (!premade.attempted && !user.attempted) return merged;
     runtime.reportError(
       "cloud-voice-catalog",
       new Error("cloud voice catalog: both premade and user endpoints failed"),

--- a/plugins/plugin-elizacloud/src/cloud-voice-catalog.ts
+++ b/plugins/plugin-elizacloud/src/cloud-voice-catalog.ts
@@ -75,7 +75,7 @@ export function setCloudVoiceClientFactoryForTesting(
   }
 }
 
-type CacheEntry =
+type EndpointCacheEntry =
   | { kind: "success"; fetchedAt: number; voices: CloudVoiceCatalogEntry[] }
   | { kind: "failure"; fetchedAt: number };
 
@@ -83,8 +83,14 @@ type EndpointVoiceResult =
   | { ok: true; voices: CloudVoiceCatalogEntry[] }
   | { ok: false; voices: [] };
 
-/** Module-level cache. Keyed by `${baseUrl}|${apiKey}`. */
-const cache = new Map<string, CacheEntry>();
+/** Module-level endpoint cache. Keyed by `${baseUrl}|${apiKey}|${endpoint}`. */
+const cache = new Map<string, EndpointCacheEntry>();
+
+/** Combined catalog cache used only when both endpoint reads succeeded. */
+const catalogCache = new Map<
+  string,
+  { fetchedAt: number; voices: CloudVoiceCatalogEntry[] }
+>();
 
 /**
  * Module-level singleflight. Keyed the same as {@link cache}; holds the
@@ -100,6 +106,7 @@ const inflight = new Map<string, Promise<CloudVoiceCatalogEntry[]>>();
  */
 export function resetCloudVoiceCatalogCacheForTesting(): void {
   cache.clear();
+  catalogCache.clear();
   inflight.clear();
 }
 
@@ -233,6 +240,38 @@ async function fetchEndpointVoices(
   }
 }
 
+function endpointCacheKey(
+  catalogKey: string,
+  endpoint: "premade" | "user"
+): string {
+  return `${catalogKey}|${endpoint}`;
+}
+
+async function loadEndpointVoices(
+  runtime: IAgentRuntime,
+  catalogKey: string,
+  endpoint: "premade" | "user"
+): Promise<EndpointVoiceResult> {
+  const key = endpointCacheKey(catalogKey, endpoint);
+  const cached = cache.get(key);
+  const age = cached ? Date.now() - cached.fetchedAt : Number.POSITIVE_INFINITY;
+  if (cached?.kind === "success" && age < CACHE_TTL_MS) {
+    return { ok: true, voices: cached.voices };
+  }
+  if (cached?.kind === "failure" && age < FAILURE_TTL_MS) {
+    return { ok: false, voices: [] };
+  }
+
+  const result = await fetchEndpointVoices(runtime, endpoint);
+  cache.set(
+    key,
+    result.ok
+      ? { kind: "success", fetchedAt: Date.now(), voices: result.voices }
+      : { kind: "failure", fetchedAt: Date.now() }
+  );
+  return result;
+}
+
 /**
  * Fetch the user-visible voice catalog from Eliza Cloud (premade + cloned).
  *
@@ -243,13 +282,12 @@ async function fetchEndpointVoices(
  *     capability-only mode too).
  *   - Both upstream endpoints fail (network, auth, etc.).
  *
- * Results are cached for {@link CACHE_TTL_MS} per runtime. Subsequent calls
- * within that window are served from memory. A total outage (both endpoints
- * fail) is remembered for {@link FAILURE_TTL_MS} instead — long enough to
- * shield upstream from a thundering herd of retries, short enough to pick up
- * a real recovery quickly — and is reported via `runtime.reportError` so the
- * outage is observable rather than indistinguishable from a genuinely empty
- * catalog.
+ * Successful endpoint results are cached independently for
+ * {@link CACHE_TTL_MS}; endpoint failures use {@link FAILURE_TTL_MS}. This
+ * keeps a healthy premade catalog warm while retrying a failed user-voice
+ * endpoint quickly instead of hiding newly available clones for an hour. A
+ * total outage is reported via `runtime.reportError` so it remains observable
+ * rather than indistinguishable from a genuinely empty catalog.
  */
 export async function fetchCloudVoiceCatalog(
   runtime: IAgentRuntime,
@@ -258,19 +296,13 @@ export async function fetchCloudVoiceCatalog(
     return [];
   }
   const key = cacheKeyFor(runtime);
-  const now = Date.now();
-  const cached = cache.get(key);
-  if (cached) {
-    if (cached.kind === "success" && now - cached.fetchedAt < CACHE_TTL_MS) {
-      return cached.voices;
-    }
-    if (cached.kind === "failure" && now - cached.fetchedAt < FAILURE_TTL_MS) {
-      return [];
-    }
+  const combined = catalogCache.get(key);
+  if (combined && Date.now() - combined.fetchedAt < CACHE_TTL_MS) {
+    return combined.voices;
   }
 
-  // Concurrent callers during a miss or a remembered outage share this one
-  // upstream fetch pair instead of each firing their own (singleflight).
+  // Concurrent callers during a miss or an endpoint retry share this one
+  // catalog load instead of racing the per-endpoint cache checks.
   const existing = inflight.get(key);
   if (existing) {
     return existing;
@@ -278,23 +310,22 @@ export async function fetchCloudVoiceCatalog(
 
   const promise = (async (): Promise<CloudVoiceCatalogEntry[]> => {
     const [premade, user] = await Promise.all([
-      fetchEndpointVoices(runtime, "premade"),
-      fetchEndpointVoices(runtime, "user"),
+      loadEndpointVoices(runtime, key, "premade"),
+      loadEndpointVoices(runtime, key, "user"),
     ]);
 
     // User voices first so cloned voices appear before the shared premade
     // list — most users care about their own clones.
     const merged = dedupeById([...user.voices, ...premade.voices]);
-    if (premade.ok || user.ok) {
-      cache.set(key, { kind: "success", fetchedAt: Date.now(), voices: merged });
+    if (premade.ok && user.ok) {
+      catalogCache.set(key, { fetchedAt: Date.now(), voices: merged });
       return merged;
     }
+    if (premade.ok || user.ok) return merged;
 
-    // Total outage: both endpoints failed. Never cache this as a genuine
-    // empty catalog — record a short-lived failure entry instead and surface
-    // the outage observably (error-policy: "not loaded" must never read as
+    // Total outage: both endpoint caches carry short-lived failure entries;
+    // surface it observably (error-policy: "not loaded" must never read as
     // "empty").
-    cache.set(key, { kind: "failure", fetchedAt: Date.now() });
     runtime.reportError(
       "cloud-voice-catalog",
       new Error("cloud voice catalog: both premade and user endpoints failed"),


### PR DESCRIPTION
# Relates to

Fixes #23325.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and the owning package gates were run after sync. Root `bun run verify` reaches an unrelated current-`develop` i18n inventory failure documented below.
- [x] A reviewer can confirm the retry/cache behavior from the exact-head deterministic endpoint-failure regression and package receipts below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@f11c4163b9c7aa1d4f0c4d6aa8b8e2d9fb19596f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `5923db821fd0cf77554ce1d004733a57f868598c`; zero conflicts.
- [ ] `bun run verify` passes post-sync. It stops at the unrelated repository-wide i18n inventory failure described below.

# Risks

Low. The change affects only voice-catalog cache timing. Successful endpoint responses retain the one-hour TTL; endpoint failures use a bounded 30-second backoff and existing catalog-level singleflight remains in place.

# Background

## What does this PR do?

The merged #23406 repair added catalog singleflight and a short total-outage backoff, but it still cached a partially successful catalog for one hour. If the premade endpoint succeeded while the user-voice endpoint failed, recovered or newly cloned user voices stayed hidden for the full success TTL.

This corrective gives each endpoint its own success/failure cache state: one-hour success caching, 30-second failure backoff, and selective retry of only the failed endpoint. A recovered user endpoint becomes visible after the short backoff without refetching the healthy premade endpoint.

## What kind of change is this?

Bug fix (partial-outage cache recovery).

# Documentation changes needed?

No. The external catalog contract is unchanged.

# Testing

## Where should a reviewer start?

- `plugins/plugin-elizacloud/src/cloud-voice-catalog.ts`
- `plugins/plugin-elizacloud/__tests__/unit/cloud-voice-catalog.test.ts`

## Detailed testing steps

Exact head `f11c4163b9c7aa1d4f0c4d6aa8b8e2d9fb19596f`:

- `bun run --cwd plugins/plugin-elizacloud typecheck` — PASS
- `bun run --cwd plugins/plugin-elizacloud lint` — PASS, 64 files, no fixes
- focused Vitest voice-catalog lane — PASS, 1 file / 15 tests
- `bun run --cwd plugins/plugin-elizacloud build` — PASS, Node/browser/CJS/subpaths/views/declarations
- `git diff --check origin/develop...HEAD` — PASS

# Evidence Gate

<!-- evidence-head:f11c4163b9c7aa1d4f0c4d6aa8b8e2d9fb19596f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend voice-catalog cache behavior with no rendered UI change
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend voice-catalog cache behavior with no rendered UI change
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-interface flow changes
<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic injected-fetch regression exercises success, outage backoff, and recovery without a credentialed external provider call
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request or state contract changes
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, or agent-planning behavior changes
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent artifact; exact cache-call counts and recovered catalog output are asserted in the focused test
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered text or UI surface changes

# Evidence Details

## Known gaps / failures

`bun run verify` reaches the current-`develop` repository-wide `check:i18n` failure before aggregate package gates. It reports 998–1,016 missing source keys across non-English locales and seven missing English keys in unrelated UI connector-capability files. This PR touches only the plugin-elizacloud voice catalog and its deterministic tests; its owning typecheck, lint, focused recovery lane, complete package build, and diff-check all pass on the exact head.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@f11c4163b9c7aa1d4f0c4d6aa8b8e2d9fb19596f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@f11c4163b9c7aa1d4f0c4d6aa8b8e2d9fb19596f:packages/skills/skills/contribute-to-eliza"} -->


