### PR TITLE
fix(cloud): keep Twilio migration test append-safe

### DIFF
--- a/packages/cloud/shared/src/db/twilio-call-opening-context-migration.test.ts
+++ b/packages/cloud/shared/src/db/twilio-call-opening-context-migration.test.ts
@@ -54,7 +54,10 @@ describe("0281 Twilio call opening context", () => {
       await readFile(new URL("meta/_journal.json", migrationsUrl), "utf8"),
     ) as { entries: Array<{ idx: number; tag: string }> };
     const filenames = await readdir(migrationsUrl);
-    const entry = journal.entries.at(-1);
+    const entryIndex = journal.entries.findIndex(
+      ({ tag }) => tag === "0281_twilio_call_opening_context",
+    );
+    const entry = journal.entries[entryIndex];
 
     expect(entry).toEqual({
       idx: 275,
@@ -63,6 +66,9 @@ describe("0281 Twilio call opening context", () => {
       tag: "0281_twilio_call_opening_context",
       breakpoints: true,
     });
+    expect(journal.entries[entryIndex - 1]?.tag).toBe(
+      "0280_mobile_app_auth_credential_tombstone_trigger",
+    );
     expect(new Set(journal.entries.map(({ idx }) => idx)).size).toBe(journal.entries.length);
     expect(new Set(journal.entries.map(({ tag }) => tag)).size).toBe(journal.entries.length);
     expect(filenames.filter((filename) => filename.startsWith("0281_"))).toEqual([


### PR DESCRIPTION
# Relates to

Closes #23871.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and the owning package checks were run after sync; the exact unrelated root-gate blocker is recorded below.
- [x] A reviewer can confirm the migration invariant from the focused test output.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@15d98478444b31b802f4ea411b9c2268621f0a78:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `15d98478444b31b802f4ea411b9c2268621f0a78`; zero conflicts.
- [x] Cloud-shared typecheck and focused checks pass. Root verify reaches an unrelated pre-existing i18n failure documented below.

# Risks

Low. Test-only change: the migration remains append-only and no SQL, schema, journal entry, or runtime behavior changes.

# Background

## What does this PR do?

Finds migration `0281_twilio_call_opening_context` by its immutable tag instead of requiring it to remain the last journal entry. It preserves the exact identity, predecessor, unique index/tag, filename, and delayed-history idempotency assertions.

## What kind of change is this?

Bug fix (test-only, non-breaking).

# Documentation changes needed?

No documentation change is needed.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/db/twilio-call-opening-context-migration.test.ts`

## Detailed testing steps

- `bun run --cwd packages/cloud/shared typecheck`
- `bun --cwd=/private/tmp/eliza-voice-6a1 --config=/private/tmp/bunfig-no-coverage.toml test packages/cloud/shared/src/db/twilio-call-opening-context-migration.test.ts` — 3 pass, 0 fail, 19 assertions.
- `bunx @biomejs/biome check packages/cloud/shared/src/db/twilio-call-opening-context-migration.test.ts`

# Evidence Gate

<!-- evidence-head:96ab7c8b9fe70f4d723e2b9a4263d820ef1717d3 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend test-only change; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend test-only change; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend test-only change; no visual flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic migration-contract test; no deployed runtime path changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no migration artifact changed; the existing journal and SQL are read and verified by the passing test.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Known gaps / failures

Root `bun run verify` stops at the pre-existing `check:i18n` gate because current `develop` is missing seven English `connectoraccount.*` keys introduced by unrelated UI changes. The owning package typecheck and focused migration checks pass.

AI provider/model: openai / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@15d98478444b31b802f4ea411b9c2268621f0a78:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@15d98478444b31b802f4ea411b9c2268621f0a78:packages/skills/skills/contribute-to-eliza"} -->
