### PR TITLE
fix(cloud): preserve Request cancellation through coordinator deadlines

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
@@ -498,14 +498,18 @@ describe("shared conversation coordinator", () => {
   });
 
   test("coordinatorFetch preserves Request inputs through the deadline wrapper", async () => {
+    const controller = new AbortController();
     const request = new Request("https://shared-runtime.internal/bridge", {
       method: "POST",
       body: "{}",
+      signal: controller.signal,
     });
     let seenInput: RequestInfo | URL | undefined;
+    let seenSignal: AbortSignal | undefined;
     const stub = {
-      fetch: async (input: RequestInfo | URL) => {
+      fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
         seenInput = input;
+        seenSignal = init?.signal ?? undefined;
         return Response.json({ ok: true });
       },
     };
@@ -513,6 +517,32 @@ describe("shared conversation coordinator", () => {
     await coordinatorFetch(stub, request);
 
     expect(seenInput).toBe(request);
+    expect(seenSignal).not.toBe(controller.signal);
+    expect(seenSignal?.aborted).toBe(false);
+    controller.abort();
+    expect(seenSignal?.aborted).toBe(true);
+  });
+
+  test("an explicit init signal overrides a Request-carried signal", async () => {
+    const requestController = new AbortController();
+    const initController = new AbortController();
+    const request = new Request("https://shared-runtime.internal/bridge", {
+      signal: requestController.signal,
+    });
+    let seenSignal: AbortSignal | undefined;
+    const stub = {
+      fetch: async (_input: RequestInfo | URL, init?: RequestInit) => {
+        seenSignal = init?.signal ?? undefined;
+        return Response.json({ ok: true });
+      },
+    };
+
+    await coordinatorFetch(stub, request, { signal: initController.signal });
+
+    requestController.abort();
+    expect(seenSignal?.aborted).toBe(false);
+    initController.abort();
+    expect(seenSignal?.aborted).toBe(true);
   });
 
   test("coordinatorFetch still times out when the caller signal never aborts", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -225,9 +225,10 @@ export function coordinatorFetch(
   timeoutMs: number = SHARED_RUNTIME_FETCH_TIMEOUT_MS,
 ): Promise<Response> {
   const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const callerSignal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
   return stub.fetch(input, {
     ...init,
-    signal: init?.signal ? AbortSignal.any([init.signal, timeoutSignal]) : timeoutSignal,
+    signal: callerSignal ? AbortSignal.any([callerSignal, timeoutSignal]) : timeoutSignal,
   });
 }
 


### PR DESCRIPTION
# Relates to

Fixes #23883

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`a08bac7f4cce8152079c279b17b131fa986cc816`).
- [x] `bun install --frozen-lockfile --ignore-scripts` was run after sync. The
      exact unrelated `bun run verify` blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      deterministic production-boundary transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@15d98478444b31b802f4ea411b9c2268621f0a78:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@a08bac7f4cce8152079c279b17b131fa986cc816`; zero conflicts.
- [x] The exact unrelated root-verify blocker is documented below.

# Risks

Low. The change only selects the caller cancellation signal that is composed
with the existing coordinator deadline. An explicit `init.signal` retains
precedence; otherwise a `Request`'s own signal is preserved.

# Background

## What does this PR do?

`coordinatorFetch` accepts `RequestInfo | URL`, but after #23879 it only
composed `init.signal` with the hop timeout. Passing a `Request` directly
therefore replaced the Request-carried cancellation signal with the timeout.

This patch selects `init.signal` first and otherwise uses `Request.signal`, then
composes that selected signal with the existing deadline. The regression tests
cover direct Request cancellation and explicit-init precedence.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores Fetch cancellation semantics at an internal Cloud boundary;
there is no user-facing configuration or API documentation change.

# Testing

## Where should a reviewer start?

- `packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts`
- The two `coordinatorFetch` Request-signal cases in
  `conversation-coordinator.test.ts`

## Detailed testing steps

Exact head: `3dc28f6e92b34d9395ac7af1a1616a4ce6aa0c32`

1. `bun install --frozen-lockfile --ignore-scripts` — pass, 3,593 installs / 3,878 packages, no changes.
2. `bun run --cwd packages/cloud/shared typecheck` — pass.
3. `bun x @biomejs/biome check <two changed files>` — pass, 2 files checked, no fixes.
4. `git diff --check origin/develop...HEAD` — pass.
5. Production-boundary Bun probe importing the real `coordinatorFetch` — pass:

```json
{"head":"3dc28f6e92b34d9395ac7af1a1616a4ce6aa0c32","requestSignalComposed":true,"initSignalPrecedence":true}
```

6. Mutation proof on the rebased tree: temporarily restoring the pre-fix
   `init?.signal`-only selection fails with `request abort did not propagate`;
   restoring this patch makes the same production-boundary probe pass.

# Evidence Gate

<!-- evidence-head:3dc28f6e92b34d9395ac7af1a1616a4ce6aa0c32 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-side cancellation behavior has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-side cancellation behavior has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no interactive user flow or visual state.
<!-- evidence-row:backend-logs -->
- [x] N/A - this pure boundary helper emits no structured logs; the real exported function is exercised directly in the transcript above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] The inline JSON transcript above records both observable cancellation properties from the real production export.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model invocation or routing behavior changed.

## Backend + frontend logs

N/A - the internal helper has no logger and no frontend consumer. Its observable
signal behavior is captured by the production-boundary transcript above.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT path changed.

## Known gaps / failures

- `bun run verify` stops immediately on current `develop` because the root
  `check:agents-claude` script invokes the absent
  `scripts/assert-agents-claude-identical.mjs` (`MODULE_NOT_FOUND`). This occurs
  before build/typecheck/lint work and is unrelated to the two changed Cloud
  Shared files.
- The Bun Windows runner stalls at the pre-existing
  `coordinatorFetch aborts a hung Durable Object hop at the timeout` case even
  when filtered to that single test. The changed behavior was therefore proved
  independently through the real exported function, plus Cloud Shared
  typecheck and the committed Linux CI regression tests.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@15d98478444b31b802f4ea411b9c2268621f0a78:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [startrack3r/codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@15d98478444b31b802f4ea411b9c2268621f0a78:packages/skills/skills/contribute-to-eliza"} -->
