### PR TITLE
test(plugin-elizacloud): fix managed-payment client base-url fixtures

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/unit/managed-payment-clients.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/managed-payment-clients.test.ts
@@ -21,12 +21,21 @@ describe("managed payment clients", () => {
 
     const config = resolveEnvElizaCloudManagedClientConfig({
       ELIZAOS_CLOUD_API_KEY: " eliza_test ",
-      ELIZAOS_CLOUD_BASE_URL: "https://cloud.example/api",
+      ELIZAOS_CLOUD_BASE_URL: "https://cloud.example",
     });
 
     expect(config.configured).toBe(true);
     expect(config.apiKey).toBe("eliza_test");
-    expect(config.apiBaseUrl).toContain("cloud.example");
+    // Pin the whole resolved base, not just the host: the clients append bare
+    // route paths, so the `/api/v1` prefix has to come from here or every
+    // managed-payment request 404s against the generated router.
+    expect(config.apiBaseUrl).toBe("https://cloud.example/api/v1");
+    expect(
+      resolveEnvElizaCloudManagedClientConfig({
+        ELIZAOS_CLOUD_API_KEY: "eliza_test",
+        ELIZAOS_CLOUD_BASE_URL: "https://cloud.example/api/v1",
+      }).apiBaseUrl
+    ).toBe("https://cloud.example/api/v1");
   });
 
   it("posts Plaid link token requests through the configured cloud API", async () => {
@@ -42,7 +51,7 @@ describe("managed payment clients", () => {
     const client = new PlaidManagedClient(() => ({
       configured: true,
       apiKey: "eliza_test",
-      apiBaseUrl: "https://cloud.example/api",
+      apiBaseUrl: "https://cloud.example/api/v1",
       siteUrl: "https://cloud.example",
     }));
 
@@ -71,7 +80,7 @@ describe("managed payment clients", () => {
     const client = new PlaidManagedClient(() => ({
       configured: true,
       apiKey: "eliza_test",
-      apiBaseUrl: "https://cloud.example/api",
+      apiBaseUrl: "https://cloud.example/api/v1",
       siteUrl: "https://cloud.example",
     }));
 
@@ -93,7 +102,7 @@ describe("managed payment clients", () => {
     const client = new PaypalManagedClient(() => ({
       configured: true,
       apiKey: "eliza_test",
-      apiBaseUrl: "https://cloud.example/api",
+      apiBaseUrl: "https://cloud.example/api/v1",
       siteUrl: "https://cloud.example",
     }));
 
@@ -117,7 +126,7 @@ describe("managed payment clients", () => {
     const paypal = new PaypalManagedClient(() => ({
       configured: false,
       apiKey: null,
-      apiBaseUrl: "https://cloud.example/api",
+      apiBaseUrl: "https://cloud.example/api/v1",
       siteUrl: "https://cloud.example",
     }));
 


### PR DESCRIPTION
## What

`__tests__/unit/managed-payment-clients.test.ts > posts Plaid link token requests through the configured cloud API` fails on current `develop`:

```
AssertionError: expected "vi.fn()" to be called with arguments: [ …(2) ]
-   "https://cloud.example/api/v1/eliza/plaid/link-token"
+   "https://cloud.example/api/eliza/plaid/link-token"
```

## Why it was wrong

The test hand-built `apiBaseUrl: "https://cloud.example/api"` and expected the client to emit `/api/v1/eliza/...`. The clients append bare route paths (`${config.apiBaseUrl}/eliza/plaid/link-token`, `managed-payment-clients.ts:176`), so the `/api/v1` prefix has to already be in the base.

It always is. `resolveCloudApiBaseUrl` cannot return that fixture's value:

| input | resolved `apiBaseUrl` |
|---|---|
| `https://cloud.example` | `https://cloud.example/api/v1` |
| `https://cloud.example/api/v1` | `https://cloud.example/api/v1` |
| _unset_ | `https://api.eliza.app/api/v1` |

`https://cloud.example/api/v1/eliza/plaid/link-token` is also the real route — `_router.generated.ts:2599`. So the expected URL was right and the fixture was wrong.

## Change

Use the base the clients actually receive, and replace `expect(config.apiBaseUrl).toContain("cloud.example")` with an exact pin plus an idempotency case. The old assertion passed on a base with a duplicated `/api` prefix; the new one does not:

```
-- MUTATION: trimApiPath stops stripping /api/v1 --
AssertionError: expected 'https://cloud.example/api/v1/api/v1'
              to be 'https://cloud.example/api/v1'
```

## Verification

`vitest run __tests__/unit/managed-payment-clients.test.ts` → 5/5 (was 1 failed / 4 passed). Test-only; no production file touched.

## Follow-up, not fixed here

`trimApiPath` (`packages/shared/src/elizacloud/base-url.ts:75`) strips a trailing `/api/v1` but not a bare `/api`, so `ELIZAOS_CLOUD_BASE_URL=https://cloud.example/api` resolves to `https://cloud.example/api/api/v1` and every managed-payment request 404s. That is a plausible thing to configure, and it fails silently. Changing a shared normalizer's semantics is out of scope for a test fix, so I'm flagging rather than folding it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)