### PR TITLE
fix(cloud): compare-and-set container status so a completed delete is never overwritten

### DIFF
--- a/packages/cloud/shared/src/db/repositories/containers.ts
+++ b/packages/cloud/shared/src/db/repositories/containers.ts
@@ -13,6 +13,7 @@ import {
   type InferInsertModel,
   type InferSelectModel,
   inArray,
+  ne,
   notInArray,
   sql,
 } from "drizzle-orm";
@@ -24,7 +25,7 @@ import { ObjectNamespaces } from "../../lib/storage/object-namespace";
 import { hydrateTextField, offloadTextField } from "../../lib/storage/object-store";
 import { type Database, dbRead, dbWrite } from "../helpers";
 import { containerComputeStopIntents } from "../schemas/compute-stop-intents";
-import { containers } from "../schemas/containers";
+import { containers, TERMINAL_CONTAINER_STATUS } from "../schemas/containers";
 import { creditTransactions } from "../schemas/credit-transactions";
 import { dockerNodes } from "../schemas/docker-nodes";
 import { organizationConfig } from "../schemas/organization-config";
@@ -46,7 +47,9 @@ export type ContainerStatus =
   | "stopped"
   | "failed"
   | "deleting"
-  | "deleted";
+  // Spelled through the shared constant so the CAS predicate and this union can
+  // never drift apart.
+  | typeof TERMINAL_CONTAINER_STATUS;
 
 export interface QuotaCheckResult {
   /** Distinguishes an authoritative quota decision from an unreadable source. */
@@ -645,6 +648,31 @@ export class ContainersRepository {
 
   /**
    * Updates container status and optional error message.
+   *
+   * Compare-and-set on the hard-terminal status. Lifecycle writers read the row
+   * and write it back in two separate awaited round-trips with no enclosing
+   * transaction (`ContainerRepoAppContainerStore.markRunning` reads at one
+   * statement and lands `updateStatus` at another), and a `CONTAINER_DELETE`
+   * job for the same container is independently claimable during a deploy
+   * overlap — `claimPendingJobs` keys `FOR UPDATE SKIP LOCKED` on JOB rows by
+   * type/status/scheduled_for, never by `containerId`. Without this predicate a
+   * late write resurrects a container that a completed delete already drove to
+   * `deleted`, silently: the row counts toward the organization container quota
+   * again (`checkQuota` excludes only `deleting`/`deleted`), and the app-container
+   * orphan reconciler treats a non-terminal row as LIVE, so it can never detect
+   * or repair the mismatch.
+   *
+   * Scoped to `deleted` ONLY. Every other status is legitimately re-entered by
+   * the lifecycle (a failed deploy retries, `stopped` is restarted by
+   * `prepareFundedRestart`), so a broader CAS would reject transitions the live
+   * path accepts today. Re-asserting `deleted` on a deleted row stays a
+   * permitted idempotent write. Same shape as
+   * `agentSandboxesRepository.markReconnectedFromDisconnected`/
+   * `markRunningFromProvisioning`, which already compare-and-set this exact
+   * class of transition.
+   *
+   * @returns the updated row, or null when the row is absent OR the CAS lost —
+   * callers that must not proceed on a terminal row have to check for null.
    */
   async updateStatus(
     id: string,
@@ -658,7 +686,11 @@ export class ContainersRepository {
         error_message: errorMessage || null,
         updated_at: new Date(),
       })
-      .where(eq(containers.id, id))
+      .where(
+        status === TERMINAL_CONTAINER_STATUS
+          ? eq(containers.id, id)
+          : and(eq(containers.id, id), ne(containers.status, TERMINAL_CONTAINER_STATUS)),
+      )
       .returning();
 
     return updated ? await hydrateContainerDeploymentLog(updated) : null;

--- a/packages/cloud/shared/src/db/schemas/containers.ts
+++ b/packages/cloud/shared/src/db/schemas/containers.ts
@@ -28,6 +28,24 @@ import {
 import { apiKeys } from "./api-keys";
 import { creditTransactions } from "./credit-transactions";
 import { organizations } from "./organizations";
+
+/**
+ * The one HARD-terminal value of `containers.status`.
+ *
+ * `app-container-orphan-reconciler.ts` documents `deleted` as "the hard-terminal
+ * state"; `ContainerRepoAppContainerStore.markDeleted` drives a row here
+ * precisely so it stops counting toward the per-organization container quota
+ * (`checkQuota` excludes only `deleting`/`deleted`), and no deploy ever reuses a
+ * deleted row — each deploy creates a fresh one. Every other status, including
+ * `stopped` and `failed`, is re-entrant by design. Lifecycle writers therefore
+ * compare-and-set against THIS value only; see `containersRepository.updateStatus`.
+ *
+ * Lives in the schema module so the repository and the app-container store can
+ * both spell the predicate from one source without the store taking a runtime
+ * dependency on database-repository concerns.
+ */
+export const TERMINAL_CONTAINER_STATUS = "deleted" as const;
+
 import { userCharacters } from "./user-characters";
 import { users } from "./users";
 

--- a/packages/cloud/shared/src/lib/services/__tests__/app-container-store-recovery.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-container-store-recovery.integration.test.ts
@@ -34,9 +34,13 @@ beforeAll(async () => {
   client = new PGlite();
   database = drizzle(client);
   const repository: AppContainerStoreRepository = {
+    // The real repository returns the updated row and returns null only when its
+    // id + hard-terminal-status compare-and-set matched nothing; `markRunning`
+    // now treats null as "a delete already won", so this stand-in has to report
+    // the applied row rather than a blanket null.
     updateStatus: async (id, status, error) => {
       statusUpdates.push({ id, status, ...(error ? { error } : {}) });
-      return null;
+      return { id, status, error_message: error ?? null } as never;
     },
     update: async (id, organizationId, data) => {
       containerUpdates.push({ id, organizationId, data });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-container-terminal-status.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-container-terminal-status.pglite.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Drives the REAL `ContainerRepoAppContainerStore` and `containersRepository`
+ * against in-process PGlite to pin the hard-terminal container-status
+ * compare-and-set.
+ *
+ * `markRunning` reads the row at one awaited round-trip and writes its status at
+ * another, with no enclosing transaction. During a deploy overlap two live
+ * workers can hold a `CONTAINER_PROVISION` and a `CONTAINER_DELETE` for the same
+ * container at once (`claimPendingJobs` locks JOB rows by
+ * type/status/scheduled_for with `FOR UPDATE SKIP LOCKED`; nothing keys the
+ * claim by `containerId`), so a completed delete can land inside that window.
+ *
+ * The interleave here is made deterministic by gating ONLY the resolution of the
+ * store's read round-trip — every statement executed is the production SQL, run
+ * by the production repository against a real Postgres engine.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const ORG_ID = "00000000-0000-4000-8000-000000000001";
+const USER_ID = "00000000-0000-4000-8000-000000000002";
+const TIMEOUT = 60_000;
+
+type StoreModule = typeof import("../app-container-store");
+type ContainersRepoModule = typeof import("../../../db/repositories/containers");
+type ContainersSchemaModule = typeof import("../../../db/schemas/containers");
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let ContainerRepoAppContainerStore: StoreModule["ContainerRepoAppContainerStore"];
+let containersRepository: ContainersRepoModule["containersRepository"];
+let containers: ContainersSchemaModule["containers"];
+let TERMINAL_CONTAINER_STATUS: ContainersSchemaModule["TERMINAL_CONTAINER_STATUS"];
+let ready = true;
+
+const CONTAINERS_DDL = `CREATE TABLE containers (
+  id uuid PRIMARY KEY,
+  name text NOT NULL,
+  project_name text NOT NULL,
+  description text,
+  organization_id uuid NOT NULL,
+  user_id uuid NOT NULL,
+  api_key_id uuid,
+  character_id uuid,
+  load_balancer_url text,
+  public_hostname text,
+  status text NOT NULL DEFAULT 'pending',
+  image_tag text,
+  environment_vars jsonb NOT NULL DEFAULT '{}',
+  desired_count integer NOT NULL DEFAULT 1,
+  cpu integer NOT NULL DEFAULT 1792,
+  memory integer NOT NULL DEFAULT 1792,
+  port integer NOT NULL DEFAULT 3000,
+  health_check_path text DEFAULT '/health',
+  node_id text,
+  volume_path text,
+  volume_size_gb integer,
+  hcloud_volume_id integer,
+  volume_location text,
+  last_deployed_at timestamp,
+  last_health_check timestamp,
+  deployment_log text,
+  deployment_log_storage text NOT NULL DEFAULT 'inline',
+  deployment_log_key text,
+  error_message text,
+  metadata jsonb NOT NULL DEFAULT '{}',
+  last_billed_at timestamp,
+  next_billing_at timestamp,
+  billing_status text NOT NULL DEFAULT 'active',
+  shutdown_warning_sent_at timestamp,
+  scheduled_shutdown_at timestamp,
+  total_billed numeric(10,2) NOT NULL DEFAULT 0,
+  lifecycle_revision integer NOT NULL DEFAULT 0,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+)`;
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ containersRepository } = await import("../../../db/repositories/containers"));
+    ({ containers, TERMINAL_CONTAINER_STATUS } = await import("../../../db/schemas/containers"));
+    ({ ContainerRepoAppContainerStore } = await import("../app-container-store"));
+    await dbWrite.execute(CONTAINERS_DDL);
+  } catch (error) {
+    ready = false;
+    console.error("[app-container-terminal-status] PGlite setup failed", error);
+  }
+}, TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+let seq = 0;
+function nextId(): string {
+  seq += 1;
+  return `00000000-0000-4000-8000-${String(seq).padStart(12, "0")}`;
+}
+
+async function seedContainer(status: string): Promise<string> {
+  const id = nextId();
+  await dbWrite.execute(
+    `INSERT INTO containers (id, name, project_name, organization_id, user_id, image_tag, status)
+     VALUES ('${id}', 'app-${id.slice(-6)}', '${ORG_ID}', '${ORG_ID}', '${USER_ID}',
+             'ghcr.io/elizaos/eliza:stable', '${status}')`,
+  );
+  return id;
+}
+
+async function statusOf(id: string): Promise<string> {
+  const result = await dbWrite.execute(`SELECT status FROM containers WHERE id = '${id}'`);
+  return String((result.rows[0] as { status: string }).status);
+}
+
+/**
+ * The pre-fix `containersRepository.updateStatus` write, extracted verbatim from
+ * `git show origin/develop:packages/cloud/shared/src/db/repositories/containers.ts`
+ * (id-only WHERE, no status predicate). Kept as a local re-implementation so the
+ * over-rejection corpus can compare the patched repository against the exact
+ * statement that ships today, on the same engine and the same rows.
+ */
+async function originUpdateStatusWrite(
+  id: string,
+  status: string,
+  errorMessage?: string,
+): Promise<boolean> {
+  const [updated] = await dbWrite
+    .update(containers)
+    .set({
+      status,
+      error_message: errorMessage || null,
+      updated_at: new Date(),
+    })
+    .where(eq(containers.id, id))
+    .returning();
+  return Boolean(updated);
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * The production read database, with the resolution of `markRunning`'s SELECT
+ * held open until the test releases it. The SELECT itself is issued and executed
+ * unchanged against PGlite; only the continuation is scheduled.
+ */
+function readDatabaseGatedAfterSelect(gate: Promise<void>) {
+  return {
+    select: (selection: Record<string, unknown>) => {
+      const builder = dbWrite.select(selection as never);
+      return {
+        from: (table: unknown) => {
+          const fromBuilder = builder.from(table as never);
+          return {
+            where: (predicate: unknown) => {
+              const whereBuilder = fromBuilder.where(predicate as never);
+              return {
+                limit: async (count: number) => {
+                  const rows = await whereBuilder.limit(count);
+                  await gate;
+                  return rows;
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+function buildStore(readDatabase: unknown) {
+  return new ContainerRepoAppContainerStore({
+    readDatabase: readDatabase as never,
+    writeDatabase: dbWrite as never,
+    repository: containersRepository,
+    errorFactory: (message, options) => Object.assign(new Error(message), options),
+  });
+}
+
+const PROVISION_RESULT = {
+  hostContainerId: "docker-immutable-1",
+  hostPort: 21000,
+  network: "app-net-x",
+};
+
+describe("app container terminal-status compare-and-set (real PGlite)", () => {
+  test(
+    "a delete that completes inside markRunning's read/write window cannot resurrect the row",
+    async () => {
+      expect(ready).toBe(true);
+      const id = await seedContainer("deploying");
+      const gate = deferred();
+      const store = buildStore(readDatabaseGatedAfterSelect(gate.promise));
+
+      // Worker A: CONTAINER_PROVISION. Issues the real SELECT, then parks.
+      const running = store.markRunning(id, PROVISION_RESULT);
+      // Worker B: CONTAINER_DELETE for the SAME container, claimed independently.
+      await store.markDeleted(id, ORG_ID);
+      expect(await statusOf(id)).toBe(TERMINAL_CONTAINER_STATUS);
+      // Worker A's write now lands, after the terminal transition committed.
+      gate.resolve();
+
+      await expect(running).rejects.toThrow(/terminal state before it became running/);
+      expect(await statusOf(id)).toBe(TERMINAL_CONTAINER_STATUS);
+
+      // The terminal row must also keep the placement metadata write off it.
+      const [row] = await dbWrite
+        .select({ metadata: containers.metadata, last_deployed_at: containers.last_deployed_at })
+        .from(containers)
+        .where(eq(containers.id, id))
+        .limit(1);
+      expect(row?.metadata).toEqual({});
+      expect(row?.last_deployed_at).toBeNull();
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "the same interleave on the pre-fix statement resurrects the row to running",
+    async () => {
+      expect(ready).toBe(true);
+      const id = await seedContainer("deploying");
+      const store = buildStore(dbWrite);
+      await store.markDeleted(id, ORG_ID);
+      expect(await statusOf(id)).toBe(TERMINAL_CONTAINER_STATUS);
+
+      expect(await originUpdateStatusWrite(id, "running")).toBe(true);
+      expect(await statusOf(id)).toBe("running");
+
+      // Restore the invariant for the rest of the suite.
+      await dbWrite
+        .update(containers)
+        .set({ status: TERMINAL_CONTAINER_STATUS })
+        .where(eq(containers.id, id));
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "markError cannot flip a completed delete back to failed",
+    async () => {
+      expect(ready).toBe(true);
+      const id = await seedContainer("deploying");
+      const store = buildStore(dbWrite);
+      await store.markDeleted(id, ORG_ID);
+      await store.markError(id, "provider provision failed");
+      expect(await statusOf(id)).toBe(TERMINAL_CONTAINER_STATUS);
+      const [row] = await dbWrite
+        .select({ error_message: containers.error_message })
+        .from(containers)
+        .where(eq(containers.id, id))
+        .limit(1);
+      expect(row?.error_message).toBeNull();
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "markCleanupRequired cannot pin node capacity on a completed delete",
+    async () => {
+      expect(ready).toBe(true);
+      const id = await seedContainer("deploying");
+      const store = buildStore(dbWrite);
+      await store.markDeleted(id, ORG_ID);
+      await store.markCleanupRequired(id, "Docker absence unproven");
+      expect(await statusOf(id)).toBe(TERMINAL_CONTAINER_STATUS);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "markDeleted stays idempotent and stays organization-scoped",
+    async () => {
+      expect(ready).toBe(true);
+      const id = await seedContainer("deleting");
+      const store = buildStore(dbWrite);
+      await store.markDeleted(id, ORG_ID);
+      await store.markDeleted(id, ORG_ID);
+      expect(await statusOf(id)).toBe(TERMINAL_CONTAINER_STATUS);
+
+      const other = await seedContainer("running");
+      await store.markDeleted(other, "00000000-0000-4000-8000-0000000000ff");
+      expect(await statusOf(other)).toBe("running");
+    },
+    TIMEOUT,
+  );
+});
+
+/**
+ * Over-rejection corpus. Every ordered (from, to) pair over the full
+ * `containers.status` domain is driven through BOTH the patched repository and
+ * the pre-fix statement on identical rows in the same engine, and the two
+ * outcomes are compared. They must agree on every pair whose source status is
+ * not the hard-terminal one — that set is the whole live path.
+ */
+const STATUS_DOMAIN = [
+  "pending",
+  "building",
+  "deploying",
+  "running",
+  "stopped",
+  "failed",
+  "deleting",
+  "deleted",
+  "cleanup_required",
+] as const;
+
+describe("app container status CAS does not over-reject", () => {
+  test(
+    "patched and pre-fix statements agree on every transition out of a non-terminal status",
+    async () => {
+      expect(ready).toBe(true);
+      const divergences: string[] = [];
+      let compared = 0;
+      let intentionallyBlocked = 0;
+
+      for (const from of STATUS_DOMAIN) {
+        for (const to of STATUS_DOMAIN) {
+          if (to === "cleanup_required") continue; // not a ContainerStatus; covered above
+          const patchedId = await seedContainer(from);
+          const originId = await seedContainer(from);
+
+          const patchedRow = await containersRepository.updateStatus(
+            patchedId,
+            to as never,
+            `${from}->${to}`,
+          );
+          await originUpdateStatusWrite(originId, to, `${from}->${to}`);
+
+          const patchedStatus = await statusOf(patchedId);
+          const originStatus = await statusOf(originId);
+          compared += 1;
+
+          if (from === "deleted" && to !== "deleted") {
+            // The only intended divergence.
+            if (patchedStatus !== "deleted" || patchedRow !== null || originStatus !== to) {
+              divergences.push(`guard misbehaved for ${from}->${to}`);
+            } else {
+              intentionallyBlocked += 1;
+            }
+            continue;
+          }
+          if (patchedStatus !== originStatus || patchedRow === null) {
+            divergences.push(
+              `${from}->${to}: patched=${patchedStatus}/${patchedRow === null ? "null" : "row"} origin=${originStatus}`,
+            );
+          }
+        }
+      }
+
+      console.log(
+        `[over-rejection corpus] compared=${compared} divergences=${divergences.length} intentionally-blocked=${intentionallyBlocked}`,
+      );
+      expect(divergences).toEqual([]);
+      expect(compared).toBe(72);
+      expect(intentionallyBlocked).toBe(7);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "a status update on an absent row still returns null (unchanged)",
+    async () => {
+      expect(ready).toBe(true);
+      const absent = nextId();
+      expect(await containersRepository.updateStatus(absent, "failed", "gone")).toBeNull();
+      expect(await originUpdateStatusWrite(absent, "failed", "gone")).toBe(false);
+    },
+    TIMEOUT,
+  );
+
+  test(
+    "org-scoped writes are untouched by the status CAS",
+    async () => {
+      expect(ready).toBe(true);
+      const id = await seedContainer("running");
+      await containersRepository.markStoppedForBilling(id, ORG_ID);
+      expect(await statusOf(id)).toBe("stopped");
+      const restarted = await containersRepository.update(id, ORG_ID, { status: "deploying" });
+      expect(restarted?.status).toBe("deploying");
+    },
+    TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/app-container-terminal-status.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-container-terminal-status.pglite.test.ts
@@ -247,6 +247,28 @@ describe("app container terminal-status compare-and-set (real PGlite)", () => {
     TIMEOUT,
   );
 
+  /**
+   * Negative control. One daemon processes its claimed batch strictly
+   * sequentially, so it cannot race itself; a fully-awaited `markRunning`
+   * followed by a `markDeleted` must reach `deleted` and stay there. This case
+   * passes on the pre-fix statement too, and that is the point: it shows the
+   * corruption above needs the delete to land INSIDE the read/write window, not
+   * merely for both operations to run. The window is the cause, not the harness.
+   */
+  test(
+    "sequential execution — one worker, one batch — is never corrupted",
+    async () => {
+      expect(ready).toBe(true);
+      const id = await seedContainer("deploying");
+      const store = buildStore(dbWrite);
+      await store.markRunning(id, PROVISION_RESULT);
+      expect(await statusOf(id)).toBe("running");
+      await store.markDeleted(id, ORG_ID);
+      expect(await statusOf(id)).toBe(TERMINAL_CONTAINER_STATUS);
+    },
+    TIMEOUT,
+  );
+
   test(
     "markError cannot flip a completed delete back to failed",
     async () => {

--- a/packages/cloud/shared/src/lib/services/app-container-store.ts
+++ b/packages/cloud/shared/src/lib/services/app-container-store.ts
@@ -5,10 +5,10 @@
  * while terminal `deleted` status is required to release organization quota.
  */
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import type { dbWrite } from "../../db/helpers";
 import type { containersRepository } from "../../db/repositories/containers";
-import { containers } from "../../db/schemas/containers";
+import { containers, TERMINAL_CONTAINER_STATUS } from "../../db/schemas/containers";
 import {
   type AppContainerNodeSlotClaim,
   type AppContainerReadDatabase,
@@ -188,7 +188,27 @@ export class ContainerRepoAppContainerStore implements AppContainerStore {
 
     // Two writes: status (id-scoped) + metadata/url/last_deployed_at (org-scoped
     // update, which is the only metadata-writing surface the repo exposes).
-    await this.deps.repository.updateStatus(containerId, "running");
+    //
+    // The read above and this write are separate awaited round-trips with no
+    // enclosing transaction, so a CONTAINER_DELETE claimed by an overlapping
+    // worker can drive the row to the hard-terminal `deleted` in between.
+    // `updateStatus` compare-and-sets on that status and returns null when it
+    // loses; proceeding would stamp `last_deployed_at`/placement metadata onto a
+    // container whose teardown already completed. Failing here routes the
+    // provision job through `settleFailedProvision`, which removes the container
+    // we just started and releases its node slot — the correct settlement for a
+    // deploy that was overtaken by its own delete.
+    const running = await this.deps.repository.updateStatus(containerId, "running");
+    if (!running) {
+      throw this.deps.errorFactory(
+        `App container ${containerId} reached a terminal state before it became running`,
+        {
+          code: "APP_CONTAINER_TERMINALLY_DELETED",
+          context: { containerId, organizationId: row.organization_id, transition: "running" },
+          severity: "fatal",
+        },
+      );
+    }
     await this.deps.repository.update(containerId, row.organization_id, {
       metadata: nextMetadata,
       last_deployed_at: new Date(),
@@ -216,10 +236,19 @@ export class ContainerRepoAppContainerStore implements AppContainerStore {
     await this.deps.repository.updateStatus(containerId, "failed", error);
   }
 
+  /**
+   * `cleanup_required` deliberately RETAINS node capacity until a retry proves
+   * Docker absence, and the orphan reconciler treats such a row as live. Writing
+   * it over a `deleted` row would therefore pin a node slot forever for a
+   * container whose teardown already completed, so this write carries the same
+   * hard-terminal compare-and-set as `updateStatus`. Losing the CAS is not an
+   * error: the delete path already released the slot and reached the state this
+   * call was trying to protect.
+   */
   async markCleanupRequired(containerId: string, error: string): Promise<void> {
     await this.deps.writeDatabase
       .update(containers)
       .set({ status: "cleanup_required", error_message: error, updated_at: new Date() })
-      .where(eq(containers.id, containerId));
+      .where(and(eq(containers.id, containerId), ne(containers.status, TERMINAL_CONTAINER_STATUS)));
   }
 }


### PR DESCRIPTION
# Relates to

Fixes #23886

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (branched off `d9ba0dc482d6c81d2551defe528455e73027619b`).
- [x] `bun install` was run after sync. `bun run verify` was **not** run
      monorepo-wide — see **Known gaps / failures**; the focused suites, the
      whole `db/repositories/__tests__` directory against an untouched control,
      the package typecheck against an untouched control, a 72-pair
      status-transition compatibility corpus, and biome on every touched file
      were run and are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after real-PGlite transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched off the latest `origin/develop` (`d9ba0dc482d6`); zero conflicts.
- [ ] `bun run verify` post-sync — not run monorepo-wide; the exact scope that
      was run, and why the wider run was skipped, is in **Known gaps / failures**.

# Risks

**Low.** One `WHERE` predicate on one repository method, the same predicate on
one direct write, and one `if (!row)` guard on the caller that must not proceed.
No signature changes, no new package edges, no new mechanism — the identical CAS
shape is already used by `agentSandboxesRepository` in the sibling repository
file. The compatibility claim is measured over every ordered pair of the status
domain rather than argued.

# Background

## What does this PR do?

`containersRepository.updateStatus`
(`packages/cloud/shared/src/db/repositories/containers.ts:649`) writes
`containers.status` with **no status predicate**:

```ts
.where(eq(containers.id, id))
```

Every app-container status sink routes through it, and each one is an unguarded
read-modify-write spread across two separate awaited round-trips with **no
enclosing transaction**. `ContainerRepoAppContainerStore.markRunning` reads the
row at `app-container-store.ts:164` and lands its status write at `:191`. A
`CONTAINER_DELETE` that commits in between is silently overwritten, and a
container that a completed delete drove to the hard-terminal `deleted` comes back
as `running`.

| sink | line | write |
|---|---|---|
| `markRunning` | `app-container-store.ts:160` | `updateStatus(containerId, "running")` |
| `markError` | `app-container-store.ts:215` | `updateStatus(containerId, "failed", error)` |
| `markCleanupRequired` | `app-container-store.ts:219` | direct `.where(eq(containers.id, containerId))` |

One root cause, three call sites, one PR.

## The exposure window, stated precisely

A single provisioning daemon processes its claimed batch **strictly
sequentially** — `provisioning-jobs.ts:3727`, `for (const job of claimedJobs) {
await ... }` — so it cannot race itself. This is not a steady-state race, and
the PR does not claim one.

The window is the deploy overlap the code documents about itself, at
`provisioning-jobs.ts:3672-3676`:

> A deployment may overlap two live workers, so process start time narrows the
> scan but never authorizes revocation by itself.

`JobsRepository.claimPendingJobs` locks **job** rows, not container rows:

```sql
WITH claimed AS (
  SELECT id FROM jobs
  WHERE type = $1 AND status = 'pending' AND scheduled_for <= NOW()
  ORDER BY scheduled_for ASC, created_at ASC
  LIMIT $2
  FOR UPDATE SKIP LOCKED
)
```

`FOR UPDATE SKIP LOCKED` stops two claimers taking the same job row. Nothing
keys the claim by `containerId`, and `db/schemas/jobs.ts` declares only plain
`index()` entries — there is no unique constraint that would serialize a
`CONTAINER_PROVISION` and a `CONTAINER_DELETE` for the same container. During
the documented overlap two live workers can therefore hold one of each at once.

There is **no read-replica argument here** and the PR makes none:
`db/client.ts` `getReadConnection()` calls the same `getPrimaryDatabaseUrl()` as
`getWriteConnection()`, and its own comment says replicas were removed. The
window is purely the two awaited round-trips.

## Why nothing detects or repairs the result

`app-container-orphan-reconciler.ts:50` — the app-specific reaper that owns this
lane — defines:

```ts
const TERMINAL_CONTAINER_STATUSES = new Set<string>(["stopped", "failed", "deleted"]);
```

and its header at `:3-4` reads *"a live row protects them together while a
missing or fully terminal row makes each observed Docker ID reapable."*

So a row stomped from `deleted` back to `running` is **no longer terminal**, and
the reaper does not merely fail to clean up — it starts **protecting** the
workload and its DB ambassador as though a real deployment owned them. The
safety net becomes a guard over the leak. `checkQuota` excludes only
`deleting`/`deleted`, so the row also consumes the organization's container
quota again — `markDeleted`'s own comment is that reaching `deleted` is what
releases that quota, and the daemon never reuses the row.

Neither write throws. There is no `error-policy:` boundary anywhere on this
write path. Nothing compares "DB says running" against "a delete already
completed."

## The guard exists on the sibling path, and in this file's own row mapper

`e52dd97ad7b895fd50718af27b5d544e30442e0c` — *"fix(cloud): fence app deployment
retries by generation (#23340)"* — landed in **this exact file** on 2026-08-21,
one day before this branch's base, and wired `deploymentGeneration` onto the row
struct these three writers already hold:

```diff
+  const deploymentGeneration = deploymentGenerationFromMetadata(row.metadata);
   return {
     id: row.id,
     appId: metaAppId ?? row.project_name,
+    ...(deploymentGeneration ? { deploymentGeneration } : {}),
```

And the **same job type**'s permanent-failure writeback
(`provisioning-jobs.ts:4158-4200`) re-selects org-scoped and bails with
`if (jobGeneration && jobGeneration !== rowGeneration) return;` before it
touches its dependent row. To be precise: that guard protects
`apps.deployment_status`, not `containers.status` — but it is one job type,
guarded on the failure side and unguarded on the success side.

To be equally precise in the other direction: the executor **does** already
fence generation on the success path — `executeContainerProvision` calls
`isAppDeploymentCurrent` twice and routes a stale deployment through
`discardStaleProvision` immediately before `markRunning`. Generation is fenced.
**Status is not.** That is exactly what this PR adds, and it is why the fix does
not add a generation predicate to `updateStatus`: it would duplicate a fence the
executor already applies, and would reject writes for agent/user containers that
carry no `deploymentGeneration` at all.

## The fix, and why it is not a new mechanism

`db/repositories/agent-sandboxes.ts` already compare-and-sets this exact class of
transition twice — `markReconnectedFromDisconnected` (`:1375`, with an
`expectedStatus` predicate) and `markRunningFromProvisioning` (`:1410`, CAS plus
an advisory lock) — and `containers.ts:501` `prepareFundedRestart` already fences
with `.for("update")`. The shape is established one file away.

```ts
.where(
  status === TERMINAL_CONTAINER_STATUS
    ? eq(containers.id, id)
    : and(eq(containers.id, id), ne(containers.status, TERMINAL_CONTAINER_STATUS)),
)
```

`markRunning` now checks the result and fails when it loses, which routes the
provision through `settleFailedProvision` — removing the container it had just
started and releasing its node slot. That is the correct settlement for a deploy
overtaken by its own delete; previously it left a live container attached to a
row the delete had already released.

`markCleanupRequired` carries the same predicate for a specific reason:
`cleanup_required` deliberately **retains** node capacity until a retry proves
Docker absence, so writing it over a `deleted` row would pin a node slot forever.

## No over-rejection — proved, not asserted

This is the part worth checking hardest. A CAS that rejects legitimate
transitions would be worse than the bug.

- **The predicate is scoped to `deleted` and nothing else.** Every other status
  is re-entered by the lifecycle by design: a failed deploy retries, `stopped` is
  restarted by `prepareFundedRestart`, `cleanup_required` is retried. The orphan
  reconciler's own docstring names `deleted` "the hard-terminal state".
- **Re-asserting `deleted` on a deleted row stays permitted**, so `markDeleted`
  and any terminal re-drive remain idempotent.
- **All 72 ordered (from, to) pairs** over the full status domain were driven
  through both the patched repository and the pre-fix statement, on identical
  rows in the same PGlite engine, and compared: `divergences=0`,
  `intentionally-blocked=7` — the 7 being exactly `deleted -> {everything else}`.
- **`markDeleted`'s own write is deliberately left without a status predicate.**
  It writes `deleted`, which is the state the predicate exists to protect; a
  predicate there would only block an idempotent re-drive. Its org scope is
  unchanged and is covered by a test.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The affected
docblocks are corrected in this diff.

# Testing

## Where should a reviewer start?

`containersRepository.updateStatus`'s `WHERE`, then `markRunning`'s new
`if (!running)` arm, then
`packages/cloud/shared/src/lib/services/__tests__/app-container-terminal-status.pglite.test.ts`.

## Detailed testing steps

```bash
git fetch origin develop && git checkout <this branch>
bun install && bun run build:core
bun test --cwd packages/cloud/shared \
  src/lib/services/__tests__/app-container-terminal-status.pglite.test.ts \
  src/lib/services/__tests__/app-container-store-recovery.integration.test.ts \
  src/lib/services/__tests__/app-container-store.test.ts \
  src/lib/services/__tests__/container-job-executors.test.ts
```

### 1. Origin reproduction — real PGlite, the real store, on current `develop`

Run at `d9ba0dc482d6c81d2551defe528455e73027619b` with every source file
pristine. The probe constructs the production `ContainerRepoAppContainerStore`
over the production `containersRepository` and a real in-process Postgres, then
starts a `CONTAINER_PROVISION`-shaped `markRunning` and lets a
`CONTAINER_DELETE`-shaped `markDeleted` commit inside its read/write window. The
interleave is made deterministic by holding open only the *resolution* of
`markRunning`'s SELECT; every statement executed is production SQL.

```
$ bun test src/lib/services/__tests__/zz-origin-repro.pglite.test.ts
bun test v1.3.14 (0d9b296a)

after CONTAINER_DELETE committed  -> deleted
after markRunning's write landed  -> running | no error thrown
metadata now                      -> {"network":"app-net-x","hostPort":21000,"hostContainerId":"docker-immutable-1"}
last_deployed_at stamped          -> Fri Aug 21 2026 17:32:01 GMT+0000 (Coordinated Universal Time)

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [3.64s]
```

`deleted -> running`, **no error thrown**, and host-placement metadata plus
`last_deployed_at` stamped onto a container whose teardown already completed.

### 2. The identical probe on this branch

```
$ bun test src/lib/services/__tests__/zz-origin-repro.pglite.test.ts
bun test v1.3.14 (0d9b296a)

after CONTAINER_DELETE committed  -> deleted
after markRunning's write landed  -> deleted | threw: App container 00000000-0000-4000-8000-000000000010 reached a terminal state before it became running
metadata now                      -> {}
last_deployed_at stamped          -> null

expect(final?.status).toBe("running")
Expected: "running"
Received: "deleted"
(fail) ORIGIN REPRO > CONTAINER_DELETE inside markRunning's read/write window resurrects a deleted container
```

The probe asserts the defect, so it passing on `develop` and failing here is the
before/after in one artifact.

### 3. AFTER — the suites

```
$ bun test --cwd packages/cloud/shared \
    src/lib/services/__tests__/app-container-terminal-status.pglite.test.ts \
    src/lib/services/__tests__/app-container-store-recovery.integration.test.ts \
    src/lib/services/__tests__/app-container-store.test.ts \
    src/lib/services/__tests__/container-job-executors.test.ts
bun test v1.3.14 (0d9b296a)

[over-rejection corpus] compared=72 divergences=0 intentionally-blocked=7

 55 pass
 0 fail
 162 expect() calls
Ran 55 tests across 4 files. [14.88s]
```

### 4. Load-bearing check

`containers.ts` and `app-container-store.ts` were reverted to their
`origin/develop` bodies by **copy-aside** (never `git stash`, which is repo-global
on this clone), the new suite was run against them, and the files were restored.

```
===== REVERT repositories/containers.ts + app-container-store.ts -> origin/develop bodies, new tests kept

Expected promise that rejects
Received promise that resolved: Promise { <resolved> }
(fail) terminal-status compare-and-set (real PGlite) > a delete that completes inside markRunning's read/write window cannot resurrect the row

Expected: "deleted"
Received: "failed"
(fail) terminal-status compare-and-set (real PGlite) > markError cannot flip a completed delete back to failed

Expected: "deleted"
Received: "cleanup_required"
(fail) terminal-status compare-and-set (real PGlite) > markCleanupRequired cannot pin node capacity on a completed delete

[over-rejection corpus] compared=72 divergences=7 intentionally-blocked=0
(fail) status CAS does not over-reject > patched and pre-fix statements agree on every transition out of a non-terminal status

 5 pass
 4 fail

===== RESTORE
[over-rejection corpus] compared=72 divergences=0 intentionally-blocked=7

 9 pass
 0 fail
 31 expect() calls
Ran 9 tests across 1 file. [3.44s]
```

All three sinks fail on the reverted file, and only on the reverted file. The
five cases that stay green on the revert are the sequential-execution negative
control (see next section), plus the idempotence, absent-row, org-scope and
over-rejection-shape assertions — correct, because those exist to catch a fix
that changes behaviour it should not touch.

### 4b. Negative control — the window is the cause, not the harness

The most obvious objection to the reproduction above is "you constructed an
artificial interleave to manufacture a race". The suite answers it with a case
that **passes on the pre-fix code**:

```ts
test("sequential execution — one worker, one batch — is never corrupted", async () => {
  const id = await seedContainer("deploying");
  const store = buildStore(dbWrite);
  await store.markRunning(id, PROVISION_RESULT);   // fully awaited
  expect(await statusOf(id)).toBe("running");
  await store.markDeleted(id, ORG_ID);
  expect(await statusOf(id)).toBe(TERMINAL_CONTAINER_STATUS);
});
```

A single daemon runs its claimed batch sequentially, so this is what one worker
actually does — and it is safe on `develop` as well as on this branch (it is one
of the 5 that stay green in the revert arm above). The corruption requires the
read snapshot to precede the delete **and** the write to follow it: exactly the
documented two-worker deploy-overlap window, and nothing wider.

### 5. Over-rejection corpus — 72 transition pairs, patched vs the pre-fix statement

The pre-fix write was extracted with
`git show origin/develop:packages/cloud/shared/src/db/repositories/containers.ts`,
not hand-copied, and both statements run against the same engine on identically
seeded rows.

```
[over-rejection corpus] compared=72 divergences=0 intentionally-blocked=7
```

`divergences=0` is the compatibility claim, measured: across every ordered pair
of `pending / building / deploying / running / stopped / failed / deleting /
deleted / cleanup_required`, the patched repository lands the same final status
and returns a row exactly where the pre-fix statement did — except the 7 pairs
whose source is `deleted`, which are the whole point of the change.

### 6. Regression sweep — whole repository test directory, against an untouched control

```
$ bun test --cwd packages/cloud/shared src/db/repositories/__tests__/     # this branch
 453 pass
 9 skip
 18 fail
 2331 expect() calls
Ran 480 tests across 45 files. [38.79s]

# control: the same tree with all three touched source files restored to origin/develop
$ bun test --cwd packages/cloud/shared src/db/repositories/__tests__/
 453 pass
 9 skip
 18 fail
 2331 expect() calls
Ran 480 tests across 45 files. [66.28s]
```

Identical. The 18 failures are pre-existing on the base and live entirely in
`heartbeat-generation-us-fence.test.ts` and `warm-pool-stranded-readiness.test.ts`
(agent-sandbox warm-pool), which this diff does not touch — confirmed by running
those two files alone on both trees: 2 pass / 16 fail either way.

### 7. Typecheck — zero errors added, measured against an untouched control

```
$ bun run --cwd packages/cloud/shared typecheck        # this branch
src/lib/services/shared-runtime/conversation-coordinator.ts(241,85): error TS2345: Argument of type 'URL | RequestInfo' is not assignable to parameter of type 'string | URL'.
error: script "typecheck" exited with code 1

# control: the same tree with all touched files restored to origin/develop
$ bun run --cwd packages/cloud/shared typecheck
src/lib/services/shared-runtime/conversation-coordinator.ts(241,85): error TS2345: Argument of type 'URL | RequestInfo' is not assignable to parameter of type 'string | URL'.
error: script "typecheck" exited with code 1
```

Identical. The single error is pre-existing, in a file this PR does not touch.

### 8. Biome

```
$ bunx @biomejs/biome check \
    packages/cloud/shared/src/db/repositories/containers.ts \
    packages/cloud/shared/src/db/schemas/containers.ts \
    packages/cloud/shared/src/lib/services/app-container-store.ts \
    packages/cloud/shared/src/lib/services/__tests__/app-container-store-recovery.integration.test.ts \
    packages/cloud/shared/src/lib/services/__tests__/app-container-terminal-status.pglite.test.ts
Checked 5 files in 995ms. No fixes applied.
```

# Evidence Gate

<!-- evidence-head:3ae43375609b6681c0b6d3bd6fcb5f0f2dcd3d62 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only change to one Cloud repository method and one service module; no rendered UI surface is touched by this diff.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only change to one Cloud repository method and one service module; no rendered UI surface is touched by this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the observable behaviour is the durable containers.status value after two interleaved lifecycle operations, shown as before/after transcripts in Testing above.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — pasted below (the
      production store and repository driven against real in-process Postgres,
      first on pristine `origin/develop`, then on this branch).

<details><summary>BEFORE — <code>origin/develop</code> at <code>d9ba0dc482d6</code>, real PGlite</summary>

```
bun test v1.3.14 (0d9b296a)

after CONTAINER_DELETE committed  -> deleted
after markRunning's write landed  -> running | no error thrown
metadata now                      -> {"network":"app-net-x","hostPort":21000,"hostContainerId":"docker-immutable-1"}
last_deployed_at stamped          -> Fri Aug 21 2026 17:32:01 GMT+0000 (Coordinated Universal Time)

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [3.64s]
```

</details>

<details><summary>AFTER — this branch, same probe and same suites</summary>

```
bun test v1.3.14 (0d9b296a)

after CONTAINER_DELETE committed  -> deleted
after markRunning's write landed  -> deleted | threw: App container 00000000-0000-4000-8000-000000000010 reached a terminal state before it became running
metadata now                      -> {}
last_deployed_at stamped          -> null

$ bun test --cwd packages/cloud/shared \
    src/lib/services/__tests__/app-container-terminal-status.pglite.test.ts \
    src/lib/services/__tests__/app-container-store-recovery.integration.test.ts \
    src/lib/services/__tests__/app-container-store.test.ts \
    src/lib/services/__tests__/container-job-executors.test.ts

[over-rejection corpus] compared=72 divergences=0 intentionally-blocked=7

 55 pass
 0 fail
 162 expect() calls
Ran 55 tests across 4 files. [14.88s]
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path; this repository method and service run server-side in Cloud only.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behaviour changes; this is a SQL predicate on a container lifecycle write.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the artifact is the durable `containers` row itself — its
      `status`, `metadata` and `last_deployed_at` after the two interleaved
      lifecycle operations, read back from real Postgres.
  <details><summary>The persisted row, before and after</summary>

  ```
  ORIGIN (d9ba0dc482d6)
    status           -> running
    metadata         -> {"network":"app-net-x","hostPort":21000,"hostContainerId":"docker-immutable-1"}
    last_deployed_at -> Fri Aug 21 2026 17:32:01 GMT+0000 (Coordinated Universal Time)
    error raised     -> none

  BRANCH (3ae43375609b6681c0b6d3bd6fcb5f0f2dcd3d62)
    status           -> deleted
    metadata         -> {}
    last_deployed_at -> null
    error raised     -> APP_CONTAINER_TERMINALLY_DELETED
  ```

  </details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behaviour changes.`

## Backend + frontend logs

Backend: inline in **Testing → 1, 2, 3, 4, 5, 6** (the production store and
repository against real in-process Postgres on pristine `origin/develop` and on
this branch, the copy-aside revert arm, the 72-pair transition corpus, and the
whole-directory regression sweep against an untouched control).

Frontend: `N/A - server-side module.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT, or omnivoice surface.`

## Known gaps / failures

- **`bun run verify` was not run monorepo-wide.** It builds and tests the whole
  repository and is far beyond the blast radius of one `WHERE` predicate. What
  was run instead, and passed, is recorded above: the four focused suites
  (55 pass / 0 fail), the copy-aside revert arm, the 72-pair transition corpus,
  the whole `db/repositories/__tests__` directory against an untouched control,
  the `@elizaos/cloud-shared` typecheck against an untouched control, and biome
  on all five touched files.
- **No organization predicate was added to `updateStatus`, deliberately.** It
  would not fix this defect (the resurrection is same-org), `markError` has no
  organization id at its call site so it would force a signature change through
  the Hetzner client and the service passthrough, and `id` is a uuid primary key.
  Cross-tenant scoping of this method is a separate concern from terminal
  resurrection and is not claimed here.
- **No generation predicate was added to `updateStatus`, deliberately.**
  `executeContainerProvision` already fences generation twice via
  `isAppDeploymentCurrent` immediately before `markRunning`, and agent/user
  containers carry no `deploymentGeneration` at all — a predicate would duplicate
  an existing fence and reject writes the live path accepts today.
- **`markDeleted`'s own write keeps no status predicate.** It writes `deleted`,
  the state the predicate protects; adding one there would only block an
  idempotent re-drive. Its organization scope is unchanged and is pinned by a
  test.
- **One existing test's repository stand-in had to be updated.**
  `app-container-store-recovery.integration.test.ts` returned a blanket `null`
  from its `updateStatus` stand-in, which never matched the real repository's
  contract (it returns the updated row) and now reads as "a delete already won".
  It now reports the applied row. That is the only pre-existing test touched, and
  it is a stand-in, not an assertion.
- **The origin-reproduction probe is not part of this diff.** It is a standalone
  file that asserts the defect, so it cannot live in the suite. The permanent
  regression coverage is the eight cases in
  `app-container-terminal-status.pglite.test.ts`.
- **18 pre-existing failures in `src/db/repositories/__tests__/`** are unchanged
  by this PR, proven by the control run above. They are in
  `heartbeat-generation-us-fence.test.ts` and
  `warm-pool-stranded-readiness.test.ts`.
- **`bun run build:core` is required** in a fresh worktree before anything under
  `packages/cloud/shared` will import `@elizaos/core`; without it every PGlite
  suite in this package fails at setup, including untouched ones. It produces
  gitignored build artifacts that are not in this diff.
- **Hosted CI checks do not run on this PR.** I contribute from a fork without
  push access to `elizaOS/eliza`, so no hosted check will report here. Every
  result above was produced locally and is reproducible with the commands given.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-container-cas]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JQ8SSM0QGSZFSDQ6HH53EV","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T17:53:00.724Z","completed_at":"2026-08-21T17:54:19.467Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T17:53:01.094Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"4c726cdcc5fc4fbb78e204d098cbeafbd2cefde70a969c37ee53145c064f3546","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"25d06110-16f3-48ce-bae5-c33b892b6a43","object_id":"sha256:4c726cdcc5fc4fbb78e204d098cbeafbd2cefde70a969c37ee53145c064f3546","sha256":"4c726cdcc5fc4fbb78e204d098cbeafbd2cefde70a969c37ee53145c064f3546"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"-3jeGGNW7q_ZXh8Lrk04cVcNU8-PJfybxNwehVC27EQ4fvJn6T3Cxwyz0l_iunbYGP-VovDuC_-3kYVGVPSKDQ"}} -->
