### PR TITLE
fix(plugin-cli-inference): charge JSON-nested strings against the payload cap

### DIFF
--- a/plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts
@@ -197,4 +197,30 @@ describe("toolOutputToText — no over-rejection of ordinary payloads", () => {
       `[tool_result WEB_FETCH: ${JSON.stringify(nested)}]`
     );
   });
+
+  const MiB = 1024 * 1024;
+
+  it("charges strings nested in a JSON object against the character budget", () => {
+    // Every string on the JSON projection path used to be handed back free, so
+    // an object could carry unlimited large fields past the declared char cap
+    // while the node budget counted only one node per field.
+    const out = contentToText([
+      toolResult({ a: "a".repeat(3 * MiB), b: "b".repeat(3 * MiB), c: "c".repeat(3 * MiB) }),
+    ]);
+    expect(out).toContain(TOOL_PAYLOAD_BUDGET_MARKER);
+    expect(out.length).toBeLessThan(9 * MiB);
+  });
+
+  it("still returns a single oversized body whole, nested or bare", () => {
+    // `chargeChars` checks before it charges, so the first oversized body comes
+    // back untouched. That contract must hold identically whether the body
+    // arrives as a bare string or inside an object.
+    const body = "x".repeat(10 * MiB);
+    const bare = contentToText([toolResult(body)]);
+    const wrapped = contentToText([toolResult({ body })]);
+    expect(bare).not.toContain(TOOL_PAYLOAD_BUDGET_MARKER);
+    expect(bare).toContain(body);
+    expect(wrapped).not.toContain(TOOL_PAYLOAD_BUDGET_MARKER);
+    expect(wrapped).toBe(`[tool_result WEB_FETCH: ${JSON.stringify({ body })}]`);
+  });
 });

--- a/plugins/plugin-cli-inference/src/prompt-flatten.ts
+++ b/plugins/plugin-cli-inference/src/prompt-flatten.ts
@@ -124,7 +124,12 @@ function toBoundedJsonValue(
 ): JsonSafe | undefined {
   if (value === null) return null;
   const kind = typeof value;
-  if (kind === "string") return value as string;
+  // Charge nested strings too. `toolOutputToText` charges the strings it
+  // produces, but the JSON projection used to hand back every string free, so
+  // an object could carry unlimited 3 MiB fields past a 4 MiB declared cap
+  // while the node budget saw only one node per field. The pre-charge check in
+  // `chargeChars` still lets the first oversized body through unchanged.
+  if (kind === "string") return chargeChars(budget, value as string);
   if (kind === "number") return Number.isFinite(value as number) ? (value as number) : null;
   if (kind === "boolean") return value as boolean;
   if (kind === "bigint") return (value as bigint).toString();
@@ -218,7 +223,12 @@ function toolOutputToText(
   // projection below treats it as a fresh root rather than as a back-edge onto
   // itself. This is exactly what "path-local" buys: an honest value is never
   // mistaken for a cycle.
-  return chargeChars(budget, stringifyToolPayload(output, budget, depth));
+  // The projection already charged every string it kept, so charging the
+  // serialized result again would double-count a single large body and turn it
+  // into the over-budget marker — the opposite of the documented "first
+  // oversized body comes back whole" contract that the bare-string path at the
+  // top of this function still honors.
+  return stringifyToolPayload(output, budget, depth);
 }
 
 /**


### PR DESCRIPTION
# Relates to

Partially addresses #23885 — the bound-enforcement residue from #23828. **Scoped deliberately:** this is the character-budget defect only. The three silent-loss regressions and the new uncaught-throw vector in that issue are **not** in this PR and the issue stays open for them.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the single failure is unrelated and pre-existing, recorded verbatim in **Known gaps**.
- [x] A reviewer can confirm the change from the before/after transcript below without reading the code.

<!-- evidence-head:96b90bb795d9d9428163ab5c4a15faa5a1f31c1c -->

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

**Low**, and deliberately narrower than the issue's framing.

- The only behavioral change is that the **second and subsequent** strings on the JSON projection path are now charged against `MAX_TOOL_PAYLOAD_CHARS`. Nothing that fit before stops fitting.
- A single oversized body still comes back whole — bare **and** nested — which is the documented `chargeChars` contract ("a single 10 MB WEB_FETCH body flattens exactly as it does today"). Pinned by a test.
- The per-part budget from `newPayloadBudget` is **unchanged on purpose**; see the note at the end.

# Background

## What does this PR do?

`toBoundedJsonValue` returned every string it kept without ever calling `chargeChars`:

```ts
if (kind === "string") return value as string;   // never charged
```

`chargeChars` checks before it charges so the *first* oversized body passes whole — but on the object path it never ran at all, so it was not "the first string is free", it was **every** string, forever. Three 3 MiB fields in one object flattened to 9.4 MB against a declared 4 MiB cap with no marker, while the node budget saw only one node per field.

**Charging nested strings alone is not sufficient and silently regresses the documented contract.** `toolOutputToText` charged the serialized projection *again* at the end, so with nested charging added, a single 10 MiB body nested in an object double-counts and collapses to a 60-char over-budget marker — while the same body as a bare string still flattens whole. The fix is both halves: charge nested strings, and drop the now-redundant outer charge.

## What kind of change is this?

Bug fix (non-breaking). No public type, export, or route change.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-cli-inference/src/prompt-flatten.ts`, then the two new cases at the end of `__tests__/prompt-flatten-bounded.test.ts`.

## Detailed testing steps

Real `contentToText` execution; BEFORE rows produced by `git checkout origin/develop -- prompt-flatten.ts` (revert verified before running):

```text
                                     BEFORE            AFTER
(b) 3x3MiB in ONE object       9,437,226 no marker   6,291,533 + MARKER   <- the fix
(a) 40MiB single string        41,943,071 whole      41,943,071 whole     <- documented contract
(c) 3x3MiB as separate parts    9,437,246 whole       9,437,246 whole     <- per-part budget, unchanged
bare 10MiB string              10,485,785 whole      10,485,785 whole     <- no regression
10MiB body nested in object    10,485,796 whole      10,485,796 whole     <- no regression
```

Suites and mutation proof:

```text
prompt-flatten-bounded + cli-inference    83 passed | 1 skipped (84)
bun run --cwd plugins/plugin-cli-inference typecheck    pass
bunx biome check <2 changed files>                      pass
git diff --check                                        clean

MUTATION 1 (revert nested-string charge)  -> only "charges strings nested in a JSON object…" fails
MUTATION 2 (restore outer double-charge)  -> only "still returns a single oversized body whole…" fails
```

Neither mutation fails the other's test, so the two halves are independently pinned.

# Known gaps / failures

- **`bun run verify` fails on one unrelated, pre-existing check.** Verbatim:

  ```text
  [i18n] en.json missing 7 key(s) used in source:
    - connectoraccount.capabilities.unreported   (packages/ui/src/components/capabilities/ConnectedCapabilityChips.tsx:35)
    - connectoraccount.reconnect                 (packages/ui/src/components/connectors/ConnectorAccountCard.tsx:289)
    … 5 more
  error: script "check:i18n" exited with code 1
  ```

  Confirmed pre-existing: checked out clean `origin/develop` at `8e5e0ff034` with none of this branch's changes and ran `bun run check:i18n` — identical 7 missing keys. This branch touches only `plugins/plugin-cli-inference` and no UI file.

# Note for the reviewer

**I withdrew part of my own claim on the issue and want that visible here.** I initially reported the per-part budget lifetime as a second defect. It is documented intent — `/** One budget per tool part, so a large part never starves its siblings. */` — so N tool-result parts buying N × the declared bound is a conscious trade-off, not an oversight. **I did not change it.** It is still worth a decision (the cap reads as a per-prompt bound and is enforced per-part), but that is a design call for a maintainer, not something to slip into a residue fix. Same for the 40 MiB single-string case, which behaves identically bare or nested and is the documented contract.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - server-side prompt flattening; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - server-side prompt flattening; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic pure-function path; the transcript below is the complete flow.
<!-- evidence-row:backend-logs -->
- [x] Real `contentToText()` execution transcript, before vs after, inline below.

<details><summary>Backend transcript — real <code>contentToText()</code> execution at the exact head</summary>

```text
#23885 — real contentToText() execution transcript
branch head : 96b90bb795d9d9428163ab5c4a15faa5a1f31c1c
base        : bfa465eb14dec1c3b700333fe8ee43fd9afa2791
runtime     : bun 1.3.14 / node 24
probe       : drives the exported contentToText() from plugins/plugin-cli-inference/src/prompt-flatten.ts
              BEFORE rows produced by 'git checkout origin/develop -- prompt-flatten.ts' (verified reverted)

--- BEFORE (origin/develop prompt-flatten.ts) ---
declared MAX_TOOL_PAYLOAD_CHARS = 4194304
(a) 40MiB string in object -> chars: 41943071 | over cap: true | marker: false
(b) 3x3MiB in one object   -> chars: 9437226 | over cap: true | marker: false
(c) 3x3MiB top-level       -> chars: 9437246 | marker: false

bare 10MiB string output                   chars= 10485785 marker=false
10MiB body nested in object                chars= 10485796 marker=false
2MiB body nested (under cap)               chars=  2097188 marker=false
3MiB body nested (under cap)               chars=  3145764 marker=false
small honest payload                       chars=       60 marker=false

--- AFTER (this branch) ---
declared MAX_TOOL_PAYLOAD_CHARS = 4194304
(a) 40MiB string in object -> chars: 41943071 | over cap: true | marker: false
(b) 3x3MiB in one object   -> chars: 6291533 | over cap: true | marker: true
(c) 3x3MiB top-level       -> chars: 9437246 | marker: false

bare 10MiB string output                   chars= 10485785 marker=false
10MiB body nested in object                chars= 10485796 marker=false
2MiB body nested (under cap)               chars=  2097188 marker=false
3MiB body nested (under cap)               chars=  3145764 marker=false
small honest payload                       chars=       60 marker=false

Delta: (b) 9,437,226 chars unmarked -> 6,291,533 chars WITH over-budget marker.
       (a) and (c) unchanged by design; every regression row byte-identical.
```

</details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, request, or state change.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model invocation; this bounds text before it reaches a model.
<!-- evidence-row:domain-artifacts -->
- [x] Suite results and the two-way mutation proof, inline below.

<details><summary>Suites + mutation proof</summary>

```text
#23885 — suite + mutation proof

--- full plugin suites at head 96b90bb795 ---
 Test Files  2 passed (2)
      Tests  83 passed | 1 skipped (84)

--- mutation proof (each half of the fix pinned by exactly one test) ---
MUTATION 1: revert `chargeChars` on the nested-string branch
  × charges strings nested in a JSON object against the character budget
  Tests  1 failed | 16 passed (17)

MUTATION 2: restore the outer double-charge at the end of toolOutputToText
  × still returns a single oversized body whole, nested or bare
  Tests  1 failed | 16 passed (17)

Neither mutation fails the other's test, so the two halves are independently pinned.
```

</details>
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

<!-- eliza-computer-attribution:v1 -->
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-eliza
Attribution status: self-reported
— [kenjohnscreates]
