### PR TITLE
fix(plugin-x): bound the five user-timeline pagination generators against empty pages with live cursors

### DIFF
--- a/plugins/plugin-x/src/client/client.ts
+++ b/plugins/plugin-x/src/client/client.ts
@@ -72,6 +72,7 @@ import {
   getTweetV2,
   getTweetWhere,
   likeTweet,
+  nextTimelinePageCursor,
   type PollData,
   parseTweetV2ToV1,
   type Retweeter,
@@ -574,8 +575,11 @@ export class Client {
     const tweets = await this.withAuthenticatedSession(async () => {
       const collected: Tweet[] = [];
       let cursor: string | undefined;
+      let pageCount = 0;
+      const seenCursors = new Set<string>();
 
       while (collected.length < maxTweets) {
+        pageCount += 1;
         const response = await this.getUserTweets(
           userId,
           maxTweets - collected.length,
@@ -584,7 +588,15 @@ export class Client {
         collected.push(
           ...response.tweets.slice(0, maxTweets - collected.length),
         );
-        cursor = response.next;
+
+        if (collected.length >= maxTweets) break;
+
+        cursor = nextTimelinePageCursor(
+          "getUserTweetsIterator",
+          response.next,
+          seenCursors,
+          pageCount,
+        );
         if (!cursor) break;
       }
       return collected;

--- a/plugins/plugin-x/src/client/timeline-pagination.test.ts
+++ b/plugins/plugin-x/src/client/timeline-pagination.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Regression tests for the user-timeline pagination generators
+ * (`getTweets`, `getTweetsByUserId`, `getTweetsAndReplies`,
+ * `getTweetsAndRepliesByUserId` in `tweets.ts` and
+ * `Client.getUserTweetsIterator` in `client.ts`).
+ *
+ * These pin two things: that a provider which never stops paginating —
+ * including the real X API v2 case of a page with zero tweets and a live
+ * `next_token` — terminates with a typed error instead of looping forever, and
+ * that ordinary multi-page timelines still page through to completion.
+ *
+ * The provider is a local re-implementation of the `twitter-api-v2` paginator
+ * surface these helpers touch: async iteration over the page's tweets,
+ * `.includes`, and `.meta.next_token`. Each request costs one macrotask, the
+ * way a real network hop does.
+ *
+ * Termination is asserted as a race against a watchdog rather than a bare
+ * `await`, because an unbounded generator never settles: a regression must
+ * surface as `expect("STILL-RUNNING").toBe(<code>)` in a few seconds instead of
+ * hanging the runner until its own timeout.
+ */
+import { describe, expect, it } from "vitest";
+import { Client } from "./client";
+import {
+  getTweets,
+  getTweetsAndReplies,
+  getTweetsAndRepliesByUserId,
+  getTweetsByUserId,
+  MAX_TIMELINE_PAGES,
+} from "./tweets";
+
+const WATCHDOG_MS = 5_000;
+/** Backstop so a reverted generator cannot spin for the rest of the file. */
+const HARNESS_CALL_CEILING = 200_000;
+
+type Page = { ids: string[]; next?: string };
+type ProviderState = { calls: number; stop: boolean };
+
+function timelinePage(page: Page) {
+  return {
+    includes: undefined,
+    meta: page.next ? { next_token: page.next } : {},
+    async *[Symbol.asyncIterator]() {
+      for (const id of page.ids) {
+        yield { id, text: `tweet ${id}` };
+      }
+    },
+  };
+}
+
+/** Builds a stub `TwitterAuth` serving `pages(index)` and counting requests. */
+function stubAuth(pages: (index: number) => Page) {
+  const state: ProviderState = { calls: 0, stop: false };
+  const auth = {
+    async getV2Client() {
+      return {
+        v2: {
+          async userByUsername(username: string) {
+            return { data: { id: `id-${username}`, username, name: username } };
+          },
+          async userTimeline() {
+            await new Promise((resolve) => setImmediate(resolve));
+            if (state.stop || state.calls >= HARNESS_CALL_CEILING) {
+              throw new Error("HARNESS-STOP");
+            }
+            const page = pages(state.calls);
+            state.calls += 1;
+            return timelinePage(page);
+          },
+        },
+      };
+    },
+    async withAuthenticatedSession(
+      operation: (session: unknown) => Promise<unknown>,
+    ) {
+      return operation({ client: "client-1", revision: 1 });
+    },
+    async getAuthenticatedSession() {
+      return { client: "client-1", revision: 1 };
+    },
+    isAuthenticatedSessionCurrent() {
+      return true;
+    },
+  };
+  return { auth, state };
+}
+
+function clientWith(auth: unknown): Client {
+  const client = new Client();
+  (client as unknown as { auth: unknown }).auth = auth;
+  return client;
+}
+
+async function collect(iterable: AsyncIterable<{ id: string }>) {
+  const ids: string[] = [];
+  for await (const tweet of iterable) {
+    ids.push(tweet.id);
+  }
+  return ids;
+}
+
+/** Resolves to the thrown `ElizaError` code, `"COMPLETED"`, or the watchdog's
+ * `"STILL-RUNNING"` sentinel when the generator never settles. */
+async function terminationOf(
+  iterable: AsyncIterable<{ id: string }>,
+  state: ProviderState,
+) {
+  const consume = collect(iterable).then(
+    () => "COMPLETED",
+    (error: { code?: string; message: string }) => error.code ?? error.message,
+  );
+  const watchdog = new Promise<string>((resolve) => {
+    const timer = setTimeout(() => resolve("STILL-RUNNING"), WATCHDOG_MS);
+    timer.unref?.();
+  });
+  const outcome = await Promise.race([consume, watchdog]);
+  state.stop = true;
+  await consume;
+  return outcome;
+}
+
+/** Every page is empty but always advertises a brand new cursor — the real X
+ * API v2 shape when server-side filtering empties a non-final page. */
+const emptyPageWithNovelCursor = (index: number): Page => ({
+  ids: [],
+  next: `cursor-${index}`,
+});
+
+let screenNameSeq = 0;
+/** Unique screen name per case so the profile id cache cannot mask a lookup. */
+function freshScreenName() {
+  screenNameSeq += 1;
+  return `alice-${screenNameSeq}`;
+}
+
+describe("user-timeline pagination is bounded", () => {
+  it("getTweets stops on empty pages that keep advertising a new cursor", async () => {
+    const { auth, state } = stubAuth(emptyPageWithNovelCursor);
+
+    expect(
+      await terminationOf(
+        getTweets(freshScreenName(), 200, auth as never),
+        state,
+      ),
+    ).toBe("X_TIMELINE_PAGINATION_LIMIT_EXCEEDED");
+    expect(state.calls).toBe(MAX_TIMELINE_PAGES);
+  }, 30_000);
+
+  it("getTweetsByUserId stops when the provider repeats a cursor", async () => {
+    const { auth, state } = stubAuth(() => ({ ids: [], next: "stuck" }));
+
+    expect(
+      await terminationOf(
+        getTweetsByUserId("user-1", 200, auth as never),
+        state,
+      ),
+    ).toBe("X_TIMELINE_PAGINATION_CURSOR_REPEATED");
+    // Caught on the page that repeats it, not after a third request.
+    expect(state.calls).toBe(2);
+  }, 30_000);
+
+  it("getTweetsAndReplies catches a longer A -> B -> A cycle", async () => {
+    const cycle = ["A", "B", "A"];
+    const { auth, state } = stubAuth((index) => ({
+      ids: [],
+      next: cycle[index] ?? "A",
+    }));
+
+    expect(
+      await terminationOf(
+        getTweetsAndReplies(freshScreenName(), 200, auth as never),
+        state,
+      ),
+    ).toBe("X_TIMELINE_PAGINATION_CURSOR_REPEATED");
+    expect(state.calls).toBe(3);
+  }, 30_000);
+
+  it("getTweetsAndRepliesByUserId stops on perpetually novel cursors", async () => {
+    const { auth, state } = stubAuth(emptyPageWithNovelCursor);
+
+    expect(
+      await terminationOf(
+        getTweetsAndRepliesByUserId("user-1", 200, auth as never),
+        state,
+      ),
+    ).toBe("X_TIMELINE_PAGINATION_LIMIT_EXCEEDED");
+    expect(state.calls).toBe(MAX_TIMELINE_PAGES);
+  }, 30_000);
+
+  it("Client.getUserTweetsIterator stops on perpetually novel cursors", async () => {
+    const { auth, state } = stubAuth(emptyPageWithNovelCursor);
+
+    expect(
+      await terminationOf(
+        clientWith(auth).getUserTweetsIterator("user-1", 200),
+        state,
+      ),
+    ).toBe("X_TIMELINE_PAGINATION_LIMIT_EXCEEDED");
+    expect(state.calls).toBe(MAX_TIMELINE_PAGES);
+  }, 30_000);
+});
+
+describe("ordinary timelines still page through completely", () => {
+  const threePages = (index: number): Page =>
+    index === 0
+      ? { ids: ["t1", "t2"], next: "c1" }
+      : index === 1
+        ? { ids: ["t3", "t4"], next: "c2" }
+        : { ids: ["t5"] };
+
+  it("getTweets follows every page until the provider stops", async () => {
+    const { auth, state } = stubAuth(threePages);
+
+    expect(
+      await collect(getTweets(freshScreenName(), 200, auth as never)),
+    ).toEqual(["t1", "t2", "t3", "t4", "t5"]);
+    expect(state.calls).toBe(3);
+  });
+
+  it("getTweetsByUserId follows every page until the provider stops", async () => {
+    const { auth, state } = stubAuth(threePages);
+
+    expect(
+      await collect(getTweetsByUserId("user-1", 200, auth as never)),
+    ).toEqual(["t1", "t2", "t3", "t4", "t5"]);
+    expect(state.calls).toBe(3);
+  });
+
+  it("getTweetsAndReplies follows every page until the provider stops", async () => {
+    const { auth, state } = stubAuth(threePages);
+
+    expect(
+      await collect(getTweetsAndReplies(freshScreenName(), 200, auth as never)),
+    ).toEqual(["t1", "t2", "t3", "t4", "t5"]);
+    expect(state.calls).toBe(3);
+  });
+
+  it("getTweetsAndRepliesByUserId follows every page until the provider stops", async () => {
+    const { auth, state } = stubAuth(threePages);
+
+    expect(
+      await collect(getTweetsAndRepliesByUserId("user-1", 200, auth as never)),
+    ).toEqual(["t1", "t2", "t3", "t4", "t5"]);
+    expect(state.calls).toBe(3);
+  });
+
+  it("Client.getUserTweetsIterator follows every page until the provider stops", async () => {
+    const { auth, state } = stubAuth(threePages);
+
+    expect(
+      await collect(clientWith(auth).getUserTweetsIterator("user-1", 200)),
+    ).toEqual(["t1", "t2", "t3", "t4", "t5"]);
+    expect(state.calls).toBe(3);
+  });
+
+  it("a timeline that legitimately ends on the last allowed page still completes", async () => {
+    const { auth, state } = stubAuth((index) =>
+      index < MAX_TIMELINE_PAGES - 1
+        ? { ids: [`t${index}`], next: `cursor-${index}` }
+        : { ids: [`t${index}`] },
+    );
+
+    const ids = await collect(
+      getTweetsByUserId("user-1", MAX_TIMELINE_PAGES, auth as never),
+    );
+
+    expect(ids).toHaveLength(MAX_TIMELINE_PAGES);
+    expect(state.calls).toBe(MAX_TIMELINE_PAGES);
+  }, 30_000);
+
+  it("a satisfied request returns normally even if its last page repeats a cursor", async () => {
+    // maxTweets is reached on page 2, whose next_token repeats page 1's. The
+    // guards only apply where pagination would actually continue, so this is
+    // the same success the pre-fix code produced.
+    const { auth, state } = stubAuth((index) =>
+      index === 0
+        ? { ids: ["t1"], next: "same" }
+        : { ids: ["t2"], next: "same" },
+    );
+
+    expect(
+      await collect(getTweetsByUserId("user-1", 2, auth as never)),
+    ).toEqual(["t1", "t2"]);
+    expect(state.calls).toBe(2);
+  });
+});

--- a/plugins/plugin-x/src/client/tweets.ts
+++ b/plugins/plugin-x/src/client/tweets.ts
@@ -710,6 +710,69 @@ export async function deleteTweet(tweetId: string, auth: TwitterAuth) {
   }
 }
 
+/**
+ * Bounds the user-timeline pagination generators against a provider that never
+ * stops paginating. `userTimeline` legitimately answers with zero tweets and a
+ * non-empty `next_token` — server-side filtering (`exclude: ["retweets",
+ * "replies"]`) can empty a page that still has data behind it — so a loop
+ * guarded only by a fetched-tweet counter never advances that counter and never
+ * terminates. X serves at most 3,200 recent tweets per user timeline, so 1,000
+ * pages is ~30x more than a well-behaved provider can ever need while keeping
+ * worst-case requests finite. Same bound, and the same repeated-cursor guard,
+ * that `getAllRetweeters` below already carries.
+ */
+export const MAX_TIMELINE_PAGES = 1000;
+
+/**
+ * Resolves the cursor for the next timeline page, or `undefined` when the
+ * provider signalled the end of the timeline.
+ *
+ * Only called when pagination is actually about to continue, so a caller that
+ * already collected everything it asked for is never subject to these guards.
+ * @param source Name of the calling generator, for the thrown error context.
+ * @param next The `next_token` the provider just returned.
+ * @param seenCursors Cursors this pagination run has already followed.
+ * @param pageCount Pages fetched so far in this run.
+ */
+export function nextTimelinePageCursor(
+  source: string,
+  next: string | undefined,
+  seenCursors: Set<string>,
+  pageCount: number,
+): string | undefined {
+  // A terminal page ends the run before any guard applies, so a timeline that
+  // legitimately ends on page 1,000 still completes.
+  if (!next) {
+    return undefined;
+  }
+
+  // A cursor the provider already handed out means pagination stopped
+  // advancing (an immediate repeat or a longer A -> B -> A cycle) — a fault,
+  // not something to keep looping on.
+  if (seenCursors.has(next)) {
+    throw new ElizaError(
+      `X timeline pagination in ${source} repeated a page cursor`,
+      {
+        code: "X_TIMELINE_PAGINATION_CURSOR_REPEATED",
+        context: { source, pageCount },
+      },
+    );
+  }
+
+  if (pageCount >= MAX_TIMELINE_PAGES) {
+    throw new ElizaError(
+      `X timeline pagination in ${source} exceeded ${MAX_TIMELINE_PAGES} pages`,
+      {
+        code: "X_TIMELINE_PAGINATION_LIMIT_EXCEEDED",
+        context: { source, pageCount },
+      },
+    );
+  }
+
+  seenCursors.add(next);
+  return next;
+}
+
 export async function* getTweets(
   user: string,
   maxTweets: number,
@@ -725,8 +788,11 @@ export async function* getTweets(
 
   let cursor: string | undefined;
   let totalFetched = 0;
+  let pageCount = 0;
+  const seenCursors = new Set<string>();
 
   while (totalFetched < maxTweets) {
+    pageCount += 1;
     const response = await fetchTweets(
       userId,
       maxTweets - totalFetched,
@@ -740,7 +806,14 @@ export async function* getTweets(
       if (totalFetched >= maxTweets) break;
     }
 
-    cursor = response.next;
+    if (totalFetched >= maxTweets) break;
+
+    cursor = nextTimelinePageCursor(
+      "getTweets",
+      response.next,
+      seenCursors,
+      pageCount,
+    );
     if (!cursor) break;
   }
 }
@@ -752,8 +825,11 @@ export async function* getTweetsByUserId(
 ): AsyncGenerator<Tweet, void> {
   let cursor: string | undefined;
   let totalFetched = 0;
+  let pageCount = 0;
+  const seenCursors = new Set<string>();
 
   while (totalFetched < maxTweets) {
+    pageCount += 1;
     const response = await fetchTweets(
       userId,
       maxTweets - totalFetched,
@@ -767,7 +843,14 @@ export async function* getTweetsByUserId(
       if (totalFetched >= maxTweets) break;
     }
 
-    cursor = response.next;
+    if (totalFetched >= maxTweets) break;
+
+    cursor = nextTimelinePageCursor(
+      "getTweetsByUserId",
+      response.next,
+      seenCursors,
+      pageCount,
+    );
     if (!cursor) break;
   }
 }
@@ -787,8 +870,11 @@ export async function* getTweetsAndReplies(
 
   let cursor: string | undefined;
   let totalFetched = 0;
+  let pageCount = 0;
+  const seenCursors = new Set<string>();
 
   while (totalFetched < maxTweets) {
+    pageCount += 1;
     const response = await fetchTweetsAndReplies(
       userId,
       maxTweets - totalFetched,
@@ -802,7 +888,14 @@ export async function* getTweetsAndReplies(
       if (totalFetched >= maxTweets) break;
     }
 
-    cursor = response.next;
+    if (totalFetched >= maxTweets) break;
+
+    cursor = nextTimelinePageCursor(
+      "getTweetsAndReplies",
+      response.next,
+      seenCursors,
+      pageCount,
+    );
     if (!cursor) break;
   }
 }
@@ -814,8 +907,11 @@ export async function* getTweetsAndRepliesByUserId(
 ): AsyncGenerator<Tweet, void> {
   let cursor: string | undefined;
   let totalFetched = 0;
+  let pageCount = 0;
+  const seenCursors = new Set<string>();
 
   while (totalFetched < maxTweets) {
+    pageCount += 1;
     const response = await fetchTweetsAndReplies(
       userId,
       maxTweets - totalFetched,
@@ -829,7 +925,14 @@ export async function* getTweetsAndRepliesByUserId(
       if (totalFetched >= maxTweets) break;
     }
 
-    cursor = response.next;
+    if (totalFetched >= maxTweets) break;
+
+    cursor = nextTimelinePageCursor(
+      "getTweetsAndRepliesByUserId",
+      response.next,
+      seenCursors,
+      pageCount,
+    );
     if (!cursor) break;
   }
 }


### PR DESCRIPTION
# Relates to

Fixes #23888

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (rebased onto `5974ae28094b456fd70a601cf5d2986f2c2b5a45`).
- [x] `bun install` was run after sync. `bun run verify` was **not** run
      monorepo-wide — see **Known gaps / failures**; the focused suite, the whole
      `src/client` directory measured against an untouched control, the package
      typecheck against an untouched control, and biome on all three touched files
      were run and are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after run-to-completion measurements below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched off and rebased onto the latest `origin/develop` (`5974ae28094b`); zero conflicts.
- [ ] `bun run verify` post-sync — not run monorepo-wide; the exact scope that
      was run, and why the wider run was skipped, is in **Known gaps / failures**.

# Risks

**Low.** Each generator gains a page counter, a `Set` of cursors it has already
followed, and one call to a shared helper that is consulted *only where
pagination would otherwise continue*. Every honest timeline behaves exactly as
before — proved byte-for-byte against the pre-fix modules over 13,000 randomized
runs, not argued (see *No over-rejection*).

# Background

## The maintainer already fixed this class one function below, in this same file

`getAllRetweeters` (`plugins/plugin-x/src/client/tweets.ts:1281`) was bounded in
#21445 with `MAX_RETWEETER_PAGES = 1000` plus a `seenCursors` repeat-cursor
guard, and refined in #22612. The comment above it names the reason outright:

```
// Bounds `getAllRetweeters` against a provider that never stops paginating
// (repeated or perpetually-novel cursors) — 1,000 pages * 40/page covers even
// a very viral tweet while keeping worst-case requests/memory finite.
```

Five siblings got neither guard.

## What does this PR do?

| file:line | symbol |
|---|---|
| `plugins/plugin-x/src/client/tweets.ts:713` | `getTweets` |
| `plugins/plugin-x/src/client/tweets.ts:748` | `getTweetsByUserId` |
| `plugins/plugin-x/src/client/tweets.ts:775` | `getTweetsAndReplies` |
| `plugins/plugin-x/src/client/tweets.ts:810` | `getTweetsAndRepliesByUserId` |
| `plugins/plugin-x/src/client/client.ts:568` | `Client.getUserTweetsIterator` |

All five share one loop whose only exits are "collected `maxTweets`" and "no next
cursor":

```ts
while (totalFetched < maxTweets) {
  const response = await fetchTweets(userId, maxTweets - totalFetched, cursor, auth);
  for (const tweet of response.tweets) { yield tweet; totalFetched++; if (totalFetched >= maxTweets) break; }
  cursor = response.next;
  if (!cursor) break;
}
```

Give it a page with **zero tweets and a non-empty `next_token`** and neither exit
is ever taken: `totalFetched` never advances, `cursor` is never falsy. One HTTP
round trip per iteration, forever, yielding nothing.

This is ordinary X API v2 behaviour, not a hostile provider. `fetchTweets`
(`tweets.ts:322`) calls `userTimeline` with `exclude: ["retweets", "replies"]`,
and v2 applies that filter *after* assembling the page — so a page whose tweets
are all retweets or replies comes back as an empty `data` array with a live
`next_token`. Deleted, protected and withheld tweets do the same.

## Nothing can contain this, and that is structural rather than empirical

`{ "data": [], "meta": { "next_token": "…" } }` with a 200 OK is a valid
response. **The loop never raises**, so there is nothing for a `try/catch` — or
for one of this repo's documented `error-policy:J1`/`J3` boundaries — to
intercept. An error boundary can translate a thrown error into a handled failure;
it cannot rescue a generator that never returns.

Traced empirically too, and the result agrees: no `AbortSignal`, no per-operation
deadline and no `try/catch` anywhere up the chain. `base.ts:667` shows the repo
does install a watchdog where it cares (`fetchSearchTweets`, 15 s
`X_SEARCH_TIMEOUT`) — that is a different path, and these five have nothing.

`Client.authenticatedGenerator` (`client.ts:173-224`) deserves specific mention
because its own comment promises the opposite:

```ts
// One provider step holds one credential lease. This preserves
// streaming and lets consumer cancellation or credential rotation
// stop pagination between pages instead of draining the full source.
```

It can only honour that *between yields*: it awaits `iterator.next()`, and on the
empty-page path that call never returns. The documented cancellation point is
never reached.

Consequently a consumer gets **no runtime signal at all** — no error, no log, no
failed status — just a process that stops making progress while continuing to
issue network calls.

## "Who calls this?", answered from both directions

The hunter's honest finding first: none of the five has a production consumer
*inside this repo*. All five are exported public methods on `Client` with JSDoc
(`client.ts:612`, `:624`, `:756`, `:771`, `:570`), i.e. published SDK surface of
`@elizaos/plugin-x`.

That is the same status `getAllRetweeters` had when the maintainer fixed it, and
I verified it rather than assuming it:

```
$ git grep -n "getAllRetweeters" origin/develop
origin/develop:plugins/plugin-x/src/client/client.ts:63:  getAllRetweeters,
origin/develop:plugins/plugin-x/src/client/client.ts:1194:      getAllRetweeters(tweetId, this.requireAuth()),
origin/develop:plugins/plugin-x/src/client/tweets.ts:1281:export async function getAllRetweeters(
  (+ retweeters.test.ts)

$ git grep -n "getRetweetersOfTweet" origin/develop
origin/develop:plugins/plugin-x/src/client/client.ts:1192:  public async getRetweetersOfTweet(tweetId: string): Promise<Retweeter[]> {
```

Its single in-repo caller is a public `Client` method that nothing in the repo
calls. Public-surface-only, exactly like these five — and it was still worth
1,000 pages and a cursor set.

These five are in fact slightly *more* reachable: `getTweets` additionally has an
in-repo drain, `getLatestTweet` (`tweets.ts:928`), which for `max > 1` hands the
generator to `getTweetWhere` (`tweets.ts:885`) and consumes it with a bare
`for await`.

## The fix

`tweets.ts` gains `MAX_TIMELINE_PAGES = 1000` and one helper, mirroring the
merged sibling constant-for-constant rather than inventing a variant:

```ts
export function nextTimelinePageCursor(
  source: string,
  next: string | undefined,
  seenCursors: Set<string>,
  pageCount: number,
): string | undefined {
  // A terminal page ends the run before any guard applies, so a timeline that
  // legitimately ends on page 1,000 still completes.
  if (!next) return undefined;

  if (seenCursors.has(next)) {
    throw new ElizaError(`X timeline pagination in ${source} repeated a page cursor`, {
      code: "X_TIMELINE_PAGINATION_CURSOR_REPEATED",
      context: { source, pageCount },
    });
  }

  if (pageCount >= MAX_TIMELINE_PAGES) {
    throw new ElizaError(`X timeline pagination in ${source} exceeded ${MAX_TIMELINE_PAGES} pages`, {
      code: "X_TIMELINE_PAGINATION_LIMIT_EXCEEDED",
      context: { source, pageCount },
    });
  }

  seenCursors.add(next);
  return next;
}
```

Each loop calls it, and each gains one `if (totalFetched >= maxTweets) break;`
before that call so the guards are consulted **only where pagination would
actually continue**. That extra break is behaviourally a no-op under the old code
— the `while` condition ended the loop identically — but it keeps a request that
is already satisfied by its final page completely outside the new logic.

Why `1000` is not a new limit on anybody: X serves at most **3,200 recent tweets**
per user timeline, at `max_results` ≤ 100 per page. 1,000 pages is roughly 30×
more than a well-behaved provider can ever serve.

`getAllRetweeters` is deliberately left on its own constant and its own error
codes: it has a `previous_token` subtlety (#22612) that `userTimeline`'s
`meta.next_token` does not, and rewriting merged, tested code to share a helper
would widen this diff past the defect.

## Why one PR and not five

Same defect, same shape, same file family, four of the five in one file. Five
one-line PRs would be split-only work.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The new constant
and helper each carry a docblock stating the exact provider behaviour they guard
against and why the bound is where it is.

# Testing

## Where should a reviewer start?

`plugins/plugin-x/src/client/timeline-pagination.test.ts`, then
`nextTimelinePageCursor` in `tweets.ts` — the five call sites are identical in
shape.

## Detailed testing steps

```bash
git fetch origin develop && git checkout <this branch>
bun install
node packages/shared/scripts/generate-keywords.mjs   # see Known gaps
cd plugins/plugin-x && ../../node_modules/.bin/vitest run --config ./vitest.config.ts src/client/
```

### 1. Origin reproduction — the real exported generators on `origin/develop`

A harness (not part of this diff) imports the five real exported generators and
drives them against a provider answering every page with zero tweets and a fresh
`next_token`. Each arm races a 10 s watchdog; when the watchdog wins, the harness
flips a stop flag so the process can exit at all, and reports how many requests
the generator had made by then.

```
$ vitest run --reporter=verbose src/client/xpag-origin-repro.test.ts   # on origin/develop d9ba0dc482d6
getTweets                    STILL-RUNNING after 10001ms with 270654 network round trips and 0 tweets yielded (generator settled only once the harness threw: THREW Failed to fetch tweets: HARNESS-STOP after 270654 calls)
getTweetsByUserId            STILL-RUNNING after 10000ms with 245313 network round trips and 0 tweets yielded (generator settled only once the harness threw: THREW Failed to fetch tweets: HARNESS-STOP after 245313 calls)
getTweetsAndReplies          STILL-RUNNING after 9999ms with 280890 network round trips and 0 tweets yielded (generator settled only once the harness threw: THREW Failed to fetch tweets and replies: HARNESS-STOP after 280890 calls)
getTweetsAndRepliesByUserId  STILL-RUNNING after 9999ms with 316006 network round trips and 0 tweets yielded (generator settled only once the harness threw: THREW Failed to fetch tweets and replies: HARNESS-STOP after 316006 calls)
getUserTweetsIterator        STILL-RUNNING after 9999ms with 332907 network round trips and 0 tweets yielded (generator settled only once the harness threw: THREW HARNESS-STOP after 332907 calls)

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Five of five. `STILL-RUNNING` is the harness abandoning a generator that had no
bound; the trailing clause records that the generator settled only because the
harness itself started throwing.

One measurement worth flagging, because it is worse than the numbers above: the
harness costs each request one macrotask, standing in for the network hop. With
an instantaneous provider the loop is pure microtasks and starves the event loop
outright — the first version of this run produced no output at all and had to be
killed after 400 s.

### 2. AFTER — same harness, same driver, this branch

```
getTweets                    THREW X timeline pagination in getTweets exceeded 1000 pages after 39ms with 1000 network round trips and 0 tweets yielded
getTweetsByUserId            THREW X timeline pagination in getTweetsByUserId exceeded 1000 pages after 39ms with 1000 network round trips and 0 tweets yielded
getTweetsAndReplies          THREW X timeline pagination in getTweetsAndReplies exceeded 1000 pages after 37ms with 1000 network round trips and 0 tweets yielded
getTweetsAndRepliesByUserId  THREW X timeline pagination in getTweetsAndRepliesByUserId exceeded 1000 pages after 33ms with 1000 network round trips and 0 tweets yielded
getUserTweetsIterator        THREW X timeline pagination in getUserTweetsIterator exceeded 1000 pages after 29ms with 1000 network round trips and 0 tweets yielded
```

Exactly 1,000 requests, a typed `ElizaError`, in tens of milliseconds.

### 3. No over-rejection — proved against the shipped code, not asserted

The pre-fix modules were extracted verbatim with
`git show origin/develop:plugins/plugin-x/src/client/tweets.ts` and
`…/client.ts` into probe modules, imported alongside the patched ones, and both
driven with the same corpus of honest, terminating timelines (1-8 pages, 0-5
tweets per page including empty intermediate pages, unique cursors, random
`maxTweets` from 1 to 30). The compared value is the exact JSON of
`{ yielded ids, provider request count, error }`.

```
$ vitest run --reporter=verbose src/client/xpag-compat-probe.test.ts
 ✓ getTweetsByUserId over 4000 randomized honest timelines 241ms
 ✓ getTweetsAndRepliesByUserId over 4000 randomized honest timelines 145ms
 ✓ Client.getUserTweetsIterator over 4000 randomized honest timelines 20585ms
 ✓ the screen-name generators agree too (500 runs each, profile lookup is cached) 31ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

13,000 comparisons, every one byte-identical. Two boundary cases are additionally
pinned in the permanent suite:

- **A timeline that legitimately ends on page 1,000 still completes** — 1,000
  tweets returned, 1,000 requests, no throw. The terminal-page check runs before
  the cap for exactly this reason.
- **A request satisfied by a page whose `next_token` repeats an earlier one still
  returns normally** — the guards are never consulted on the satisfied path.

### 4. AFTER — the permanent regression suite

```
$ vitest run --config ./vitest.config.ts src/client/timeline-pagination.test.ts

 Test Files  1 passed (1)
      Tests  12 passed (12)
```

Five bounded arms, seven no-over-rejection arms. Termination is asserted as a
race against a 5 s watchdog rather than a bare `await`, because an unbounded
generator never settles: a regression surfaces as
`expect("STILL-RUNNING").toBe("X_TIMELINE_PAGINATION_LIMIT_EXCEEDED")` in about
five seconds instead of hanging the runner until its own timeout. That is
measured below, not assumed.

### 5. Load-bearing check — per site, reverted by copy-aside (never `git stash`)

Two arms, because a helper that is correct but unused would pass a helper-only
test. In each arm the helper and constant stay in place and only the call sites
are reverted, then restored.

**Arm A — the four `tweets.ts` call sites reverted to `cursor = response.next;`:**

```
     × getTweets stops on empty pages that keep advertising a new cursor 5007ms
     × getTweetsByUserId stops when the provider repeats a cursor 5001ms
     × getTweetsAndReplies catches a longer A -> B -> A cycle 5000ms
     × getTweetsAndRepliesByUserId stops on perpetually novel cursors 5001ms

AssertionError: expected 'STILL-RUNNING' to be 'X_TIMELINE_PAGINATION_LIMIT_EXCEEDED'
AssertionError: expected 'STILL-RUNNING' to be 'X_TIMELINE_PAGINATION_CURSOR_REPEATED'

      Tests  4 failed | 8 passed (12)
```

**Arm B — `client.ts`'s single call site reverted, `tweets.ts` left correct:**

```
     × Client.getUserTweetsIterator stops on perpetually novel cursors 5004ms

AssertionError: expected 'STILL-RUNNING' to be 'X_TIMELINE_PAGINATION_LIMIT_EXCEEDED'

      Tests  1 failed | 11 passed (12)
```

Exactly the reverted site fails, in ~5 s, and the seven compatibility arms stay
green in both arms — the reverted behaviour is caught specifically.

### 6. Whole `src/client` suite, branch vs untouched control

```
$ vitest run --config ./vitest.config.ts src/client/          # this branch
 Test Files  10 passed (10)
      Tests  90 passed (90)

# control: the same tree with both files restored to origin/develop and the
# new test file removed
$ vitest run --config ./vitest.config.ts src/client/
 Test Files  9 passed (9)
      Tests  78 passed (78)
```

+12 passing tests, zero failures on either side.

### 7. Typecheck — zero errors added, measured against an untouched control

```
$ bun run --cwd plugins/plugin-x typecheck    # this branch
72 errors

# control: the same tree with both touched source files restored to origin/develop
$ bun run --cwd plugins/plugin-x typecheck
72 errors

$ diff <(grep "error TS" control.txt) <(grep "error TS" branch.txt) && echo IDENTICAL
IDENTICAL
```

Identical, line for line. The 72 errors are pre-existing and dominated by
`Cannot find module '@elizaos/core'` because `packages/core` is not built in this
worktree; none is in a file this PR touches. See **Known gaps**.

### 8. Biome

```
$ bunx @biomejs/biome check plugins/plugin-x/src/client/tweets.ts \
    plugins/plugin-x/src/client/client.ts \
    plugins/plugin-x/src/client/timeline-pagination.test.ts
Checked 3 files in 25ms. No fixes applied.
```

# Evidence Gate

<!-- evidence-head:c8cc65a9b27596ce427dd9c7f05e944ade101526 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only change to two X connector client modules; no rendered UI surface is touched by this diff.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only change to two X connector client modules; no rendered UI surface is touched by this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the observable behaviour is whether a pagination generator terminates, shown as before/after request counts and wall-clock measurements in Testing above.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — pasted below (the
      five real exported generators driven on `origin/develop` and on this branch,
      the real suite, and both per-site revert arms).

<details><summary>BEFORE — <code>origin/develop</code> d9ba0dc482d6, five real exported generators</summary>

```
getTweets                    STILL-RUNNING after 10001ms with 270654 network round trips and 0 tweets yielded (generator settled only once the harness threw: THREW Failed to fetch tweets: HARNESS-STOP after 270654 calls)
getTweetsByUserId            STILL-RUNNING after 10000ms with 245313 network round trips and 0 tweets yielded (generator settled only once the harness threw: THREW Failed to fetch tweets: HARNESS-STOP after 245313 calls)
getTweetsAndReplies          STILL-RUNNING after 9999ms with 280890 network round trips and 0 tweets yielded (generator settled only once the harness threw: THREW Failed to fetch tweets and replies: HARNESS-STOP after 280890 calls)
getTweetsAndRepliesByUserId  STILL-RUNNING after 9999ms with 316006 network round trips and 0 tweets yielded (generator settled only once the harness threw: THREW Failed to fetch tweets and replies: HARNESS-STOP after 316006 calls)
getUserTweetsIterator        STILL-RUNNING after 9999ms with 332907 network round trips and 0 tweets yielded (generator settled only once the harness threw: THREW HARNESS-STOP after 332907 calls)

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

</details>

<details><summary>AFTER — this branch, same harness, same driver</summary>

```
getTweets                    THREW X timeline pagination in getTweets exceeded 1000 pages after 39ms with 1000 network round trips and 0 tweets yielded
getTweetsByUserId            THREW X timeline pagination in getTweetsByUserId exceeded 1000 pages after 39ms with 1000 network round trips and 0 tweets yielded
getTweetsAndReplies          THREW X timeline pagination in getTweetsAndReplies exceeded 1000 pages after 37ms with 1000 network round trips and 0 tweets yielded
getTweetsAndRepliesByUserId  THREW X timeline pagination in getTweetsAndRepliesByUserId exceeded 1000 pages after 33ms with 1000 network round trips and 0 tweets yielded
getUserTweetsIterator        THREW X timeline pagination in getUserTweetsIterator exceeded 1000 pages after 29ms with 1000 network round trips and 0 tweets yielded

$ vitest run --config ./vitest.config.ts src/client/timeline-pagination.test.ts
 Test Files  1 passed (1)
      Tests  12 passed (12)

$ vitest run --config ./vitest.config.ts src/client/
 Test Files  10 passed (10)
      Tests  90 passed (90)
```

Revert arm A (four `tweets.ts` call sites reverted):

```
     × getTweets stops on empty pages that keep advertising a new cursor 5007ms
     × getTweetsByUserId stops when the provider repeats a cursor 5001ms
     × getTweetsAndReplies catches a longer A -> B -> A cycle 5000ms
     × getTweetsAndRepliesByUserId stops on perpetually novel cursors 5001ms
      Tests  4 failed | 8 passed (12)
```

Revert arm B (`client.ts` call site reverted):

```
     × Client.getUserTweetsIterator stops on perpetually novel cursors 5004ms
      Tests  1 failed | 11 passed (12)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path; these modules are the server-side X connector client.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behaviour changes; this is a pagination bound in an HTTP client.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the compatibility corpus comparing this branch against
      the verbatim pre-fix modules, pasted below.

<details><summary>13,000 randomized honest timelines, patched vs <code>git show origin/develop</code></summary>

```
$ vitest run --reporter=verbose src/client/xpag-compat-probe.test.ts
 ✓ no over-rejection: patched output is byte-identical to origin/develop > getTweetsByUserId over 4000 randomized honest timelines 241ms
 ✓ no over-rejection: patched output is byte-identical to origin/develop > getTweetsAndRepliesByUserId over 4000 randomized honest timelines 145ms
 ✓ no over-rejection: patched output is byte-identical to origin/develop > Client.getUserTweetsIterator over 4000 randomized honest timelines 20585ms
 ✓ no over-rejection: patched output is byte-identical to origin/develop > the screen-name generators agree too (500 runs each, profile lookup is cached) 31ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behaviour changes.`

## Backend + frontend logs

Backend: inline in **Testing → 1, 2, 3, 4, 5, 6** (the five real exported
generators on `origin/develop` and on this branch, the permanent suite, both
per-site revert arms, and the whole-directory branch-vs-control run).

Frontend: `N/A - server-side connector modules.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT, or omnivoice surface.`

## Known gaps / failures

- **None of the five has an in-repo production consumer.** Stated plainly rather
  than buried: all five are public `Client` methods of the published
  `@elizaos/plugin-x` package, and only `getTweets` has an in-repo drain
  (`getLatestTweet`, itself only reachable through a public `Client` method with
  no in-repo caller). I verified that `getAllRetweeters` had exactly this status
  when #21445 bounded it — its sole in-repo caller `Client.getRetweetersOfTweet`
  has zero callers — which is why I judged the same fix worth making here. A
  reviewer who disagrees with that precedent should say so; it is the load-bearing
  reachability argument.
- **`getAllRetweeters` is intentionally not migrated onto the new helper.** It has
  a `previous_token` subtlety that #22612 landed specifically for, which
  `userTimeline`'s `meta.next_token` does not have. Rewriting merged, tested code
  to share a helper would widen this diff past the defect. Its constant and error
  codes therefore stay distinct.
- **`fetchLikedTweets`, `fetchListTweets` and the search paths were not
  audited for this.** Deliberate scope limit: this PR covers the five
  user-timeline generators that share one identical loop.
- **The 1,000-page cap is a bound, not a latency budget.** Against a fast
  adversarial provider it still costs 1,000 requests before throwing. That matches
  the merged sibling; a smaller cap or an overall operation deadline is a policy
  change I did not make here.
- **The repro and compatibility harnesses are not in this diff.** They are
  standalone test files that import the real modules (and, for the corpus, the
  pre-fix modules extracted with `git show origin/develop:<path>`). The permanent
  regression coverage is `src/client/timeline-pagination.test.ts`.
- **`bun run verify` was not run monorepo-wide.** It builds and tests the whole
  repository and is far beyond the blast radius of two connector modules. What was
  run instead, and passed, is recorded above.
- **`packages/core/src/i18n/generated/validation-keyword-data.ts` had to be
  generated** in the fresh worktree (`node packages/shared/scripts/generate-keywords.mjs`)
  before anything under `plugins/plugin-x` would import. It is a gitignored build
  artifact and is not in this diff.
- **The 72 typecheck errors are pre-existing and mostly environmental** —
  `packages/core` is unbuilt in this worktree, so `@elizaos/core` has no `.d.ts`.
  Identical on the branch and on the untouched control, so this PR adds none. Note
  also that `plugins/plugin-x/tsconfig.json` excludes `**/*.test.ts`, so the new
  test file is not covered by that command; it is exercised by vitest instead.
- **Hosted CI checks do not run on this PR.** I contribute from a fork without
  push access to `elizaOS/eliza`, so no hosted check will report here. Every
  result above was produced locally and is reproducible with the commands given.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-mine-xpag]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JQ5K7GC7EV27W3QKAWE6NM","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T17:51:15.696Z","completed_at":"2026-08-21T17:52:38.009Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T17:51:16.089Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"97074519816ccf7edf4b14b3d61ae5046aa12b460d1e59a1b80503389b40dae4","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"9a4d43f5-0354-4cf2-a362-964f21afd5ac","object_id":"sha256:97074519816ccf7edf4b14b3d61ae5046aa12b460d1e59a1b80503389b40dae4","sha256":"97074519816ccf7edf4b14b3d61ae5046aa12b460d1e59a1b80503389b40dae4"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"AuvmpR9SUe1xwy5wR2aOkMtCcTM-LQC-20g39hX1noh7ljt0NdNDJ3BowcvjyuP5z-C3VYYXmrzO5fDU5RAJCg"}} -->
