### PR TITLE
fix(cloud): preserve Request inputs in coordinator stubs

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -15,7 +15,7 @@ import type {
 } from "../../mobile-push/types";
 import { logger } from "../../utils/logger";
 import type { BridgeRequest, BridgeResponse } from "../eliza-sandbox-bridge";
-import { deadlineBoundCoordinatorStub } from "./coordinator-fetch";
+import { coordinatorFetch, deadlineBoundCoordinatorStub } from "./coordinator-fetch";
 import type { SharedRuntimeChannel, SharedTurnMessage } from "./run-shared-agent-turn";
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 import type { BridgeExecutionContext } from "./shared-runtime-chat";
@@ -212,7 +212,7 @@ function coordinatorName(agentId: string, rpc: BridgeRequest): string {
   return `${agentId}:${coordinatorRoom(rpc.params?.roomId, rpc.params?.userId)}`;
 }
 
-export { coordinatorFetch } from "./coordinator-fetch";
+export { coordinatorFetch };
 
 function coordinatorStub(
   namespace: RuntimeDurableObjectNamespace,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -15,6 +15,7 @@ import type {
 } from "../../mobile-push/types";
 import { logger } from "../../utils/logger";
 import type { BridgeRequest, BridgeResponse } from "../eliza-sandbox-bridge";
+import { deadlineBoundCoordinatorStub } from "./coordinator-fetch";
 import type { SharedRuntimeChannel, SharedTurnMessage } from "./run-shared-agent-turn";
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 import type { BridgeExecutionContext } from "./shared-runtime-chat";
@@ -211,36 +212,14 @@ function coordinatorName(agentId: string, rpc: BridgeRequest): string {
   return `${agentId}:${coordinatorRoom(rpc.params?.roomId, rpc.params?.userId)}`;
 }
 
-const SHARED_RUNTIME_FETCH_TIMEOUT_MS = 10_000;
-
-/**
- * Bound every shared-runtime Durable Object hop so a hung or overloaded
- * coordinator cannot pin the calling worker indefinitely. Caller cancellation
- * and the hop deadline are composed so whichever fires first aborts the fetch.
- */
-export function coordinatorFetch(
-  stub: { fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> },
-  input: RequestInfo | URL,
-  init?: RequestInit,
-  timeoutMs: number = SHARED_RUNTIME_FETCH_TIMEOUT_MS,
-): Promise<Response> {
-  const timeoutSignal = AbortSignal.timeout(timeoutMs);
-  const callerSignal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
-  return stub.fetch(input, {
-    ...init,
-    signal: callerSignal ? AbortSignal.any([callerSignal, timeoutSignal]) : timeoutSignal,
-  });
-}
+export { coordinatorFetch } from "./coordinator-fetch";
 
 function coordinatorStub(
   namespace: RuntimeDurableObjectNamespace,
   agentId: string,
   roomId: string,
 ) {
-  const stub = namespace.getByName(`${agentId}:${coordinatorRoom(roomId)}`);
-  return {
-    fetch: (input: string | URL, init?: RequestInit) => coordinatorFetch(stub, input, init),
-  };
+  return deadlineBoundCoordinatorStub(namespace.getByName(`${agentId}:${coordinatorRoom(roomId)}`));
 }
 
 function cacheContextUnavailable(): SharedRuntimeCacheWarmingError {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/coordinator-fetch.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/coordinator-fetch.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Verifies the deterministic deadline-bound Durable Object fetch adapter.
+ */
+
+import { expect, test } from "bun:test";
+import type { RuntimeDurableObjectStub } from "../../../types/cloud-worker-env";
+import { deadlineBoundCoordinatorStub } from "./coordinator-fetch";
+
+test("deadline-bound coordinator stubs preserve Request inputs", async () => {
+  const controller = new AbortController();
+  const request = new Request("https://shared-runtime.internal/bridge", {
+    method: "POST",
+    body: "{}",
+    signal: controller.signal,
+  });
+  let seenInput: RequestInfo | URL | undefined;
+  let seenSignal: AbortSignal | null | undefined;
+  const stub: RuntimeDurableObjectStub = {
+    fetch: async (input, init) => {
+      seenInput = input;
+      seenSignal = init?.signal;
+      return Response.json({ ok: true });
+    },
+  };
+
+  const response = await deadlineBoundCoordinatorStub(stub).fetch(request);
+
+  expect(response.ok).toBe(true);
+  expect(seenInput).toBe(request);
+  expect(seenSignal).toBeInstanceOf(AbortSignal);
+  expect(seenSignal).not.toBe(controller.signal);
+  expect(seenSignal?.aborted).toBe(false);
+  controller.abort();
+  expect(seenSignal?.aborted).toBe(true);
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/coordinator-fetch.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/coordinator-fetch.ts
@@ -1,0 +1,32 @@
+/**
+ * Applies a bounded deadline to shared-runtime Durable Object fetches.
+ *
+ * The adapter preserves the platform's complete `RequestInfo | URL` input
+ * contract while composing caller cancellation with the per-hop timeout.
+ */
+
+import type { RuntimeDurableObjectStub } from "../../../types/cloud-worker-env";
+
+const SHARED_RUNTIME_FETCH_TIMEOUT_MS = 10_000;
+
+export function coordinatorFetch(
+  stub: RuntimeDurableObjectStub,
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = SHARED_RUNTIME_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const callerSignal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
+  return stub.fetch(input, {
+    ...init,
+    signal: callerSignal ? AbortSignal.any([callerSignal, timeoutSignal]) : timeoutSignal,
+  });
+}
+
+export function deadlineBoundCoordinatorStub(
+  stub: RuntimeDurableObjectStub,
+): RuntimeDurableObjectStub {
+  return {
+    fetch: (input: RequestInfo | URL, init?: RequestInit) => coordinatorFetch(stub, input, init),
+  };
+}


### PR DESCRIPTION
# Relates to

Closes #23875.

- [x] This PR targets `develop` and is based on the exact current `develop` head with zero conflicts.
- [ ] The full install/root verify lane is deferred to hosted CI; exact focused evidence is recorded below.
- [x] A reviewer can confirm the contract from the isolated adapter and direct `Request` regression.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@dbdab0f20460a59f9d3afc81511000aa6e0a4fae:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact parent: `dbdab0f20460a59f9d3afc81511000aa6e0a4fae`; zero conflicts at creation.
- [ ] Hosted CI and repository-wide verification remain merge holds.

# Risks

Low. This preserves the existing `coordinatorFetch` export and behavior while making the deadline-bound stub return the complete platform `RequestInfo | URL` contract. The extracted adapter also retains request-signal cancellation added on current `develop`.

# Background

## What does this PR do?

- Extracts the deadline-bound Durable Object fetch adapter into a dependency-free module.
- Makes the production coordinator stub use that adapter, eliminating its leftover `string | URL` narrowing.
- Preserves caller cancellation from either `init.signal` or `Request.signal` while composing the hop timeout.
- Adds a direct runtime regression that passes a real `Request` through the same wrapper production uses.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores the declared Fetch API contract.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/shared-runtime/coordinator-fetch.test.ts`

## Exact-head focused evidence

- `bun test packages/cloud/shared/src/lib/services/shared-runtime/coordinator-fetch.test.ts` — 1 pass, 0 fail, 6 assertions; adapter coverage 100%.
- `bunx tsc --ignoreConfig --noEmit --strict --target ES2023 --module ESNext --moduleResolution Bundler --lib ES2023,DOM,DOM.Iterable --types bun packages/cloud/shared/src/lib/services/shared-runtime/coordinator-fetch.ts packages/cloud/shared/src/lib/services/shared-runtime/coordinator-fetch.test.ts` — pass.
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts packages/cloud/shared/src/lib/services/shared-runtime/coordinator-fetch.ts packages/cloud/shared/src/lib/services/shared-runtime/coordinator-fetch.test.ts` — pass, 3 files.

# Evidence Gate

<!-- evidence-head:18912cfec2e62486329074e48a337b7c4f907324 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend TypeScript contract only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend TypeScript contract only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend contract only; no visual flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic adapter unit test and strict TypeScript compile are the runtime/contract evidence.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or planner behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted domain artifact; the artifact is the exact `Request` identity and composed abort signal observed by the fake Durable Object stub.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Known gaps / merge holds

- The package-level `typecheck` launcher could not find its local `tsc` executable in the isolated dependency snapshot. A direct `bunx tsc -p packages/cloud/shared/tsconfig.json` reached the package graph but failed on missing/stripped third-party declarations in that borrowed snapshot; it reported no errors in any changed file. The exact changed module and regression test pass strict TypeScript compilation via `bunx tsc`.
- Hosted CI and repository-wide gates must pass on this exact head before merge.

AI provider/model: openai / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@dbdab0f20460a59f9d3afc81511000aa6e0a4fae:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@dbdab0f20460a59f9d3afc81511000aa6e0a4fae:packages/skills/skills/contribute-to-eliza"} -->
