### PR TITLE
fix(cloud): classify canonical JSON budget failures as invalid backup payloads

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
@@ -156,6 +156,17 @@ function sampleState(marker: string): AgentBackupStateData {
   };
 }
 
+/**
+ * Legal JSON nested `depth` objects deep — valid for `JSON.parse`/`stringify`
+ * and for the legacy unbounded canonical walk, but past the bounded walk's
+ * `maxDepth: 64` (#23817), so hashing it throws `CANONICAL_JSON_UNBOUNDED`.
+ */
+function nestObject(depth: number): Record<string, unknown> {
+  let value: Record<string, unknown> = { leaf: true };
+  for (let i = 0; i < depth; i += 1) value = { child: value };
+  return value;
+}
+
 async function seedFullBackup(
   sandboxRecordId: string,
   state: AgentBackupStateData,
@@ -577,6 +588,87 @@ describe("runBackupVerificationCycle (real PGlite + real memory KMS)", () => {
     expect(row.verification_error).toStartWith("hash-mismatch:");
     expect(row.verification_error).toContain("media/avatar.png");
     expect(alerts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("over-depth payload (#23836): failed invalid-payload, not thrown, not errored", async () => {
+    expect(pgliteReady).toBe(true);
+    const sandboxId = await seedSandbox();
+    const state: AgentBackupStateData = {
+      ...sampleState("deep"),
+      config: { deep: nestObject(80) },
+    };
+    // Historical-compatibility receipt: this content_hash is minted with the
+    // test's legacy unbounded sorted-key scheme — the hash the pre-#23817
+    // verifier computed for this exact state. The bounded walk now rejects the
+    // state at maxDepth 64, so the chosen behavior for such a backup is a
+    // deterministic `failed: invalid-payload` stamp (it can no longer hash on
+    // the producer, differ, or restore path either), never infra `errored`.
+    const backupId = await seedFullBackup(sandboxId, state, {
+      contentHash: fixtureSha256Json(state),
+    });
+
+    const result = await verifyBackupRestorability(await readBackupRow(backupId));
+
+    expect(result).toMatchObject({
+      ok: false,
+      failure: { kind: "invalid-payload" },
+      checks: { decrypted: true, contentHashChecked: false, manifestChecked: false },
+    });
+    expect(result.failure?.message).toStartWith("content_hash:");
+    expect(result.failure?.message).toContain('"max":64');
+    // Metadata-only: the stamped message never carries backup content.
+    expect(result.failure?.message).not.toContain("deep");
+  });
+
+  test("over-depth manifest character (#23836): failed invalid-payload from the manifest site", async () => {
+    expect(pgliteReady).toBe(true);
+    const sandboxId = await seedSandbox();
+    const manifest = fixtureManifest(sandboxId);
+    const runtimeCharacter = { name: "Deep", bio: nestObject(80) };
+    manifest.components.character = {
+      runtimeCharacter,
+      sha256: fixtureSha256Json({ runtimeCharacter, configFile: undefined }),
+    };
+    manifest.integrity.componentHashes.character = manifest.components.character.sha256;
+    const state: AgentBackupStateData = { ...sampleState("deep-manifest"), manifest };
+    const backupId = await seedFullBackup(sandboxId, state, { contentHash: null });
+
+    const result = await verifyBackupRestorability(await readBackupRow(backupId));
+
+    expect(result).toMatchObject({
+      ok: false,
+      failure: { kind: "invalid-payload" },
+      checks: { decrypted: true, contentHashChecked: false, manifestChecked: false },
+    });
+    expect(result.failure?.message).toStartWith("manifest:");
+  });
+
+  test("two-row cycle (#23836): first row invalid-payload, second still verified, errored 0", async () => {
+    expect(pgliteReady).toBe(true);
+    const sandboxA = await seedSandbox();
+    const deepState: AgentBackupStateData = {
+      ...sampleState("cycle-deep"),
+      config: { deep: nestObject(80) },
+    };
+    const backupA = await seedFullBackup(sandboxA, deepState, {
+      contentHash: fixtureSha256Json(deepState),
+    });
+    const sandboxB = await seedSandbox();
+    const backupB = await seedFullBackup(sandboxB, sampleState("cycle-healthy"));
+
+    const { alerts, alert } = makeAlertSpy();
+    const summary = await runBackupVerificationCycle({ config: CONFIG, alert });
+
+    expect(summary).toMatchObject({ sampled: 2, verified: 1, failed: 1, errored: 0 });
+    expect(summary.failures).toHaveLength(1);
+    expect(summary.failures[0]).toMatchObject({ backupId: backupA, kind: "invalid-payload" });
+    const rowA = await readBackupRow(backupA);
+    expect(rowA.verification_status).toBe("failed");
+    expect(rowA.verification_error).toStartWith("invalid-payload: content_hash:");
+    const rowB = await readBackupRow(backupB);
+    expect(rowB.verification_status).toBe("verified");
+    expect(rowB.verification_error).toBeNull();
+    expect(alerts.map((a) => a.dedupKey)).toEqual(["agent-backup-verification-failure"]);
   });
 
   test("corrupted ciphertext: AEAD failure is stamped decrypt-failed and alerts fire", async () => {

--- a/packages/cloud/shared/src/lib/services/agent-backup-verifier.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-verifier.ts
@@ -51,7 +51,11 @@
 
 import { createHash } from "node:crypto";
 import { ElizaError } from "@elizaos/core";
-import { AGENT_BACKUP_CANONICAL_JSON, stableJsonString } from "@elizaos/shared/canonical-json";
+import {
+  AGENT_BACKUP_CANONICAL_JSON,
+  CANONICAL_JSON_UNBOUNDED,
+  stableJsonString,
+} from "@elizaos/shared/canonical-json";
 import { and, desc, eq, isNotNull, isNull, lt, or, type SQL, sql } from "drizzle-orm";
 import {
   decryptAgentBackupStateData,
@@ -293,6 +297,31 @@ export function classifyCryptoError(error: unknown): BackupVerificationFailure |
     return { kind: "decrypt-failed", message: error.message };
   }
   return null;
+}
+
+/**
+ * Map the canonical-JSON budget rejection (#23817) to a verification failure,
+ * or null for anything else. `stableJsonString` throws `ElizaError` /
+ * `CANONICAL_JSON_UNBOUNDED` for a payload that is over-depth, over the node
+ * budget, or cyclic — a deterministic defect of the stored backup, not
+ * verifier infrastructure, so it must stamp `failed: invalid-payload` rather
+ * than `errored`. Compatibility note: a legal-JSON state deeper than
+ * `maxDepth: 64` that hashed under the pre-#23817 unbounded walk now
+ * classifies here too; the producer, differ, and restore path all share
+ * `AGENT_BACKUP_CANONICAL_JSON`, so such a state can no longer be hashed
+ * anywhere and the backup is honestly non-restorable. The error's `context`
+ * is structural-only (budget counters, never reflected content), so it is
+ * safe for the stamped verification_error and logs.
+ */
+function classifyCanonicalJsonError(
+  error: unknown,
+  site: "content_hash" | "manifest",
+): BackupVerificationFailure | null {
+  if (!(error instanceof ElizaError) || error.code !== CANONICAL_JSON_UNBOUNDED) return null;
+  return {
+    kind: "invalid-payload",
+    message: `${site}: ${error.message} ${JSON.stringify(error.context ?? {})}`,
+  };
 }
 
 function classifyMissingObjectPayload(error: unknown): BackupVerificationFailure | null {
@@ -778,7 +807,16 @@ export async function verifyBackupRestorability(
   }
 
   if (row.content_hash) {
-    const actual = computeStateHash(state);
+    let actual: string;
+    try {
+      actual = computeStateHash(state);
+    } catch (error) {
+      // error-policy:J3 untrusted-input sanitizing — an over-budget stored
+      // payload is an explicit invalid-payload result, never infra `errored`.
+      const classified = classifyCanonicalJsonError(error, "content_hash");
+      if (classified) return fail(classified);
+      throw error;
+    }
     if (actual !== row.content_hash) {
       return fail({
         kind: "hash-mismatch",
@@ -789,7 +827,16 @@ export async function verifyBackupRestorability(
   }
 
   if (state.manifest) {
-    const mismatches = verifyManifestIntegrity(state.manifest);
+    let mismatches: string[];
+    try {
+      mismatches = verifyManifestIntegrity(state.manifest);
+    } catch (error) {
+      // error-policy:J3 untrusted-input sanitizing — same classification as
+      // the content_hash site; unrelated throws stay verifier-infrastructure.
+      const classified = classifyCanonicalJsonError(error, "manifest");
+      if (classified) return fail(classified);
+      throw error;
+    }
     if (mismatches.length > 0) {
       return fail({
         kind: "hash-mismatch",


### PR DESCRIPTION
# Relates to

Relates to #23836

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`. Base is `origin/develop` @ `ada074ab6a31aa2c7c7bd596775508259f2d1f6c` (frozen at claim time earlier today); at open time the tip is `dbdab0f2`, 21 commits ahead. Verified via `git log HEAD..origin/develop -- <changed files + canonical-json>`: **none** of those 21 commits touch `agent-backup-verifier.{ts,test.ts}` or the canonical-json module — zero conflicts, no overlap. Happy to rebase on request; evidence below is exact-head for `a95f9022`.
- [ ] `bun run verify` was **not** run (see Known gaps — focused suite that owns this surface passes 45/45 on this head).
- [x] A reviewer can confirm the change works from the evidence below (structured backend logs + regression tests) without reading the code.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on `origin/develop` @ `ada074ab` with zero conflicts; no upstream commit since then touches the changed files (checked, see above).
- [ ] `bun run verify` post-sync: not run — documented in **Known gaps / failures**.

# Risks

Low. Two `try/catch` wrappers in `verifyBackupRestorability` that classify exactly one error code (`ElizaError` / `CANONICAL_JSON_UNBOUNDED`) as `failed: invalid-payload`; every other throw is rethrown unchanged to the existing per-row infrastructure catch, so `errored` semantics for real infra faults are untouched. No schema, API, or UI changes.

# Background

## What does this PR do?

Since #23817, `stableJsonString` (shared via `AGENT_BACKUP_CANONICAL_JSON`) throws `ElizaError` code `CANONICAL_JSON_UNBOUNDED` for a stored backup payload that is over-depth, over the node budget, or cyclic. In the provisioning-worker backup verifier, that throw escaped `computeStateHash` / `verifyManifestIntegrity` into the per-row infrastructure catch and stamped the row **`errored`** (retryable infra fault) instead of the typed **`failed: invalid-payload`** (deterministic payload defect). This PR adds `classifyCanonicalJsonError` and wraps only those two hash sites (`content_hash`, `manifest`), mapping only that error code; unrelated throws still reach the infra catch. error-policy: J3 untrusted-input sanitizing — the stamped message carries the error's structural-only `context` (budget counters, never reflected payload content).

**Historical `maxDepth: 64` compatibility** (documented in the `classifyCanonicalJsonError` doc comment and exercised in tests): a legal-JSON state deeper than 64 that hashed under the pre-#23817 unbounded walk now classifies as `invalid-payload` too. The producer, differ, and restore path all share `AGENT_BACKUP_CANONICAL_JSON`, so such a state can no longer be hashed anywhere — the backup is honestly non-restorable, and stamping it `failed` rather than `errored` is the truthful outcome.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/agent-backup-verifier.ts` — `classifyCanonicalJsonError` and the two wrapped hash sites in `verifyBackupRestorability`. Then the three `(#23836)` regression tests in `agent-backup-verifier.test.ts`.

## Detailed testing steps

Automated. On head `a95f9022550521267390f642da2607c5c729d144`:

```
$ bun test packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
 45 pass
 0 fail
 294 expect() calls
Ran 45 tests across 1 file. [67.51s]
```

New regression tests (all in the changed test file):

- `over-depth payload (#23836): failed invalid-payload, not thrown, not errored` — asserts the stamped message contains `"max":64` (legacy maxDepth-64 fixture).
- `over-depth manifest character (#23836): failed invalid-payload from the manifest site`
- `two-row cycle (#23836): first row invalid-payload, second still verified, errored 0`

Tests were edited: **yes** — `packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts` (+92 lines, additive regression tests only; no existing test changed or removed).

# Evidence Gate

<!-- evidence-head:a95f9022550521267390f642da2607c5c729d144 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - backend library change in packages/cloud/shared; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - backend library change; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-facing flow; verifier service internals.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: inline transcript below — structured `[AgentBackupVerifier]` line showing the new `invalid-payload` classification firing end to end from the test run on this head (`a95f9022`).

<details><summary>Backend logger output (over-depth payload case)</summary>

```
$ bun test packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
[AgentBackupVerifier] backup failed restorability verification [Object: null prototype] {
  backupId: "72b04ef6-c967-4ed2-81a8-e8305ba03195",
  sandboxRecordId: "a20b6f43-4a23-4932-8afa-b2a97ea966d8",
  snapshotType: "auto",
  backupKind: "full",
  createdAt: "2026-08-21T17:56:43.142Z",
  failureKind: "invalid-payload",
  error: "content_hash: Payload exceeds the canonical JSON walk budget {\"depth\":65,\"max\":64}",
}
 45 pass
 0 fail
 294 expect() calls
Ran 45 tests across 1 file. [67.51s]
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend surface touched; no request/response path.`
<!-- evidence-row:llm-trajectory -->
- [x] LLM trajectory: `N/A - no agent/action/provider/prompt/model change; backup verifier error classification only.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB rows, memories, wallet output, or generated files; the per-row failed-vs-errored stamps are asserted in the unit tests and shown in the backend log transcript above.`
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Backend (from `bun test packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts` on `a95f9022`, over-depth payload case — note `failureKind: "invalid-payload"` and the structural-only budget context, not `errored`):

```
[AgentBackupVerifier] backup failed restorability verification [Object: null prototype] {
  backupId: "72b04ef6-c967-4ed2-81a8-e8305ba03195",
  sandboxRecordId: "a20b6f43-4a23-4932-8afa-b2a97ea966d8",
  snapshotType: "auto",
  backupKind: "full",
  createdAt: "2026-08-21T17:56:43.142Z",
  failureKind: "invalid-payload",
  error: "content_hash: Payload exceeds the canonical JSON walk budget {\"depth\":65,\"max\":64}",
}
```

Frontend: `N/A - no frontend surface.`

## Screenshots (before / after) + video walkthrough

`N/A - backend library change; no UI surface (no files under packages/app, packages/ui, or apps/).`

## Audio / voice walkthrough

`N/A - no voice/TTS/STT surface.`

## Known gaps / failures

- `bun run verify` (repo-wide) was **not** run on this head; verified instead with the focused suite that owns the changed surface: `bun test packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts` → 45 pass / 0 fail / 294 expect() calls. Not a blocker: the diff is confined to `agent-backup-verifier.{ts,test.ts}` and only wraps two call sites with a single-error-code classifier.
- Not exercised live: a real provisioning-worker cycle against production object storage/DB — the regression tests drive `verifyBackupRestorability` and the verifier cycle directly with the suite's existing fixtures.
- Manifest-site evidence is via test assertion (`failed invalid-payload from the manifest site`) rather than a captured logger line; the content_hash-site logger line is pasted above.
- Rollback / previous-green: `origin/develop` @ `ada074ab6a31aa2c7c7bd596775508259f2d1f6c` (this branch's merge base).

---

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [claude-23836]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01M0JM6C5Q9JQHN7CQH8QFXMP2","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T16:59:15.512Z","completed_at":"2026-08-21T17:09:51.182Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEA1wup-TpOQbidV6XOR-nWj5-01vmuc1Uuv5emKqsM8iA","device_key_id":"dbd0806ed31cfab14a18eeb4990c66497a5ce64fdb0d37d3c878b8f5e6227484","device_signature":"zcG-DoiInK0froF0dTQc-Qcod491QW2p-9uP-TbuCN4L2gT874mGPwAWnWVNxaRpYF92-MLEAaY6OoF-ynL7CQ"}} -->
