### PR TITLE
fix(cloud): bound the credential broker's upstream response read

### DIFF
--- a/packages/cloud/shared/src/lib/services/oauth/credential-broker.test.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/credential-broker.test.ts
@@ -364,6 +364,207 @@ describe("CredentialBroker.callProvider", () => {
   });
 });
 
+/**
+ * Response byte budget. The request side is capped at MAX_REQUEST_BODY_BYTES in
+ * the same function; these pin the counterpart on the response so an
+ * allowlisted host cannot decide how much memory the isolate spends.
+ *
+ * MAX_RESPONSE_BODY_BYTES is module-private by design (it is derived from the
+ * request cap, not a second independent literal), so these tests assert the
+ * observable contract at the boundary rather than importing the number.
+ */
+describe("CredentialBroker.callProvider (upstream response byte budget)", () => {
+  const OVER_BUDGET_BYTES = 5_000_001;
+  const AT_BUDGET_BYTES = 5_000_000;
+
+  /** A body stream that would emit `totalBytes` if it were ever drained. */
+  function chunkedBody(totalBytes: number, chunkBytes = 64 * 1024) {
+    let emitted = 0;
+    let pulls = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (emitted >= totalBytes) {
+          controller.close();
+          return;
+        }
+        pulls += 1;
+        const size = Math.min(chunkBytes, totalBytes - emitted);
+        emitted += size;
+        controller.enqueue(new Uint8Array(size).fill(0x61));
+      },
+    });
+    return { stream, emitted: () => emitted, pulls: () => pulls };
+  }
+
+  it("rejects a declared content-length over budget without reading the body", async () => {
+    const source = chunkedBody(OVER_BUDGET_BYTES);
+    const { broker } = makeHarness({
+      upstream: () =>
+        new Response(source.stream, {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "content-length": String(OVER_BUDGET_BYTES),
+          },
+        }),
+    });
+    await expect(
+      broker.callProvider({
+        organizationId: ORG,
+        userId: USER,
+        connectionId: CONN,
+        request: baseRequest,
+      }),
+    ).rejects.toMatchObject({ code: OAuthErrorCode.UPSTREAM_RESPONSE_TOO_LARGE });
+    // Charged before allocation: the broker never drained the body. The stream
+    // may have handed out at most the one chunk the runtime reads ahead when a
+    // streaming Response is constructed, which is not the broker reading it.
+    expect(source.pulls()).toBeLessThanOrEqual(1);
+    expect(source.emitted()).toBeLessThanOrEqual(64 * 1024);
+  });
+
+  it("cuts off an undeclared over-budget stream instead of draining it", async () => {
+    // 64 MiB of upstream with no content-length: the pre-check cannot help, so
+    // the running total has to stop it. Retained bytes must stay near the
+    // budget, not near what the host offered.
+    const source = chunkedBody(64 * 1024 * 1024);
+    const { broker } = makeHarness({
+      upstream: () =>
+        new Response(source.stream, {
+          status: 200,
+          headers: { "content-type": "application/octet-stream" },
+        }),
+    });
+    await expect(
+      broker.callProvider({
+        organizationId: ORG,
+        userId: USER,
+        connectionId: CONN,
+        request: baseRequest,
+      }),
+    ).rejects.toMatchObject({ code: OAuthErrorCode.UPSTREAM_RESPONSE_TOO_LARGE });
+    // Under 8% of what the host offered: the read stopped, it did not drain.
+    expect(source.emitted()).toBeLessThan((64 * 1024 * 1024) / 12);
+    // At most the budget, plus the chunk that crossed it, plus the runtime's
+    // one-chunk readahead. Never a function of the 64 MiB the host offered.
+    expect(source.emitted()).toBeLessThanOrEqual(AT_BUDGET_BYTES + 2 * 64 * 1024);
+  });
+
+  it("maps the over-budget failure to 502, not to a generic transport 500", async () => {
+    const { broker } = makeHarness({
+      upstream: () =>
+        new Response(new Uint8Array(OVER_BUDGET_BYTES), {
+          status: 200,
+          headers: { "content-type": "application/octet-stream" },
+        }),
+    });
+    let caught: unknown;
+    try {
+      await broker.callProvider({
+        organizationId: ORG,
+        userId: USER,
+        connectionId: CONN,
+        request: baseRequest,
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(OAuthError);
+    expect((caught as OAuthError).code).toBe(OAuthErrorCode.UPSTREAM_RESPONSE_TOO_LARGE);
+    expect((caught as OAuthError).httpStatus).toBe(502);
+    expect((caught as OAuthError).reconnectRequired).toBe(false);
+    // No silent truncation served as success, and no token echo in the message.
+    expect((caught as OAuthError).message).not.toContain(SECRET);
+  });
+
+  it("accepts a large-but-bounded response whole, byte for byte", async () => {
+    const size = AT_BUDGET_BYTES;
+    const source = chunkedBody(size);
+    const { broker } = makeHarness({
+      upstream: () =>
+        new Response(source.stream, {
+          status: 200,
+          headers: { "content-type": "application/octet-stream" },
+        }),
+    });
+    const result = await broker.callProvider({
+      organizationId: ORG,
+      userId: USER,
+      connectionId: CONN,
+      request: baseRequest,
+    });
+    expect(result.status).toBe(200);
+    expect(result.bodyEncoding).toBe("base64");
+    // base64 of `size` bytes, reassembled across many stream chunks.
+    expect(result.body.length).toBe(Math.ceil(size / 3) * 4);
+    expect(source.emitted()).toBe(size);
+  });
+
+  it("reassembles a multi-chunk textual body identically to a single-shot read", async () => {
+    const payload = JSON.stringify({ items: Array.from({ length: 4096 }, (_, i) => ({ i })) });
+    const encoded = new TextEncoder().encode(payload);
+    let offset = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (offset >= encoded.byteLength) {
+          controller.close();
+          return;
+        }
+        // 7 bytes at a time: splits multi-byte boundaries and proves the merge
+        // is a byte concatenation, not a per-chunk decode.
+        const end = Math.min(offset + 7, encoded.byteLength);
+        controller.enqueue(encoded.slice(offset, end));
+        offset = end;
+      },
+    });
+    const { broker } = makeHarness({
+      upstream: () =>
+        new Response(stream, { status: 200, headers: { "content-type": "application/json" } }),
+    });
+    const result = await broker.callProvider({
+      organizationId: ORG,
+      userId: USER,
+      connectionId: CONN,
+      request: baseRequest,
+    });
+    expect(result.bodyEncoding).toBe("utf8");
+    expect(result.body).toBe(payload);
+  });
+
+  it("ignores an absent or unparseable content-length and falls back to counting", async () => {
+    const { broker } = makeHarness({
+      upstream: () =>
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json", "content-length": "not-a-number" },
+        }),
+    });
+    const result = await broker.callProvider({
+      organizationId: ORG,
+      userId: USER,
+      connectionId: CONN,
+      request: baseRequest,
+    });
+    expect(result.status).toBe(200);
+    expect(result.body).toBe(JSON.stringify({ ok: true }));
+  });
+
+  it("still accepts an empty 204 body", async () => {
+    const { broker } = makeHarness({
+      upstream: () => new Response(null, { status: 204 }),
+    });
+    const result = await broker.callProvider({
+      organizationId: ORG,
+      userId: USER,
+      connectionId: CONN,
+      request: baseRequest,
+    });
+    expect(result.status).toBe(204);
+    expect(result.body).toBe("");
+    expect(result.bodyEncoding).toBe("utf8");
+  });
+});
+
 describe("CredentialBroker.refreshToken", () => {
   let refreshedToken: TokenResult;
 

--- a/packages/cloud/shared/src/lib/services/oauth/credential-broker.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/credential-broker.ts
@@ -12,7 +12,10 @@
  * explicit allowlist, upstream redirects are not followed (a credentialed
  * request must not chase an attacker-controllable Location), and connections
  * are pinned to the caller's organization and, when user-owned, to the
- * calling user.
+ * calling user. Both directions of the exchange are byte-budgeted: the request
+ * body against {@link MAX_REQUEST_BODY_BYTES} and the upstream response against
+ * {@link MAX_RESPONSE_BODY_BYTES}, charged before the bytes are retained, so an
+ * allowlisted host cannot decide how much memory the isolate spends.
  */
 
 import { logger } from "../../utils/logger";
@@ -78,6 +81,27 @@ export const BROKER_PLATFORM_POLICIES: Record<string, BrokerPlatformPolicy> = {
 const ALLOWED_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
 const BODY_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const MAX_REQUEST_BODY_BYTES = 1_000_000;
+/**
+ * How much larger than the caller's request budget a brokered response may be.
+ *
+ * Derived from {@link MAX_REQUEST_BODY_BYTES} rather than written as its own
+ * literal so the two halves of `callProvider` cannot drift: the request cap and
+ * the response cap are the same number scaled by one factor, and changing the
+ * request cap moves both.
+ */
+const RESPONSE_BODY_BUDGET_MULTIPLIER = 5;
+/**
+ * Hard byte ceiling on the upstream response the broker will materialize.
+ *
+ * The broker returns provider payloads inside a single JSON envelope field, so
+ * every upstream byte is paid for at least twice inside one isolate: once as
+ * the read bytes and again as the `utf8`/`base64` string (the base64 branch
+ * expands by 4/3 on top). Without a ceiling that cost is set by whatever the
+ * allowlisted host chooses to send. `UPSTREAM_TIMEOUT_MS` bounds the *duration*
+ * of the read, not its size — 30s of provider bandwidth is far more than an
+ * isolate's memory ceiling — so the budget has to be counted in bytes.
+ */
+const MAX_RESPONSE_BODY_BYTES = MAX_REQUEST_BODY_BYTES * RESPONSE_BODY_BUDGET_MULTIPLIER;
 const UPSTREAM_TIMEOUT_MS = 30_000;
 
 /** Headers any brokered request may set, regardless of platform. */
@@ -256,6 +280,122 @@ export function validateBrokeredHeaders(
   return validated;
 }
 
+/**
+ * Typed over-budget failure. The operator-facing numbers go to the log, not to
+ * the caller's message, for the same reason the transport failure above is
+ * generic: the response envelope is caller-visible and must not narrate what an
+ * allowlisted host sent back on a credentialed connection.
+ */
+function responseTooLarge(context: Record<string, unknown>): OAuthError {
+  logger.warn("[CredentialBroker] Upstream response exceeded the broker byte budget", context);
+  return new OAuthError(
+    OAuthErrorCode.UPSTREAM_RESPONSE_TOO_LARGE,
+    `Upstream response exceeds the ${MAX_RESPONSE_BODY_BYTES}-byte broker limit`,
+    false,
+  );
+}
+
+function cancelUpstreamBody(response: Response, reason?: unknown): void {
+  try {
+    void response.body?.cancel(reason).catch(() => {
+      // error-policy:J6 the authoritative failure is already known; cancelling
+      // the upstream body is best-effort connection teardown.
+    });
+  } catch {
+    // error-policy:J6 synchronous cancellation is best-effort teardown.
+  }
+}
+
+function cancelUpstreamReader(reader: ReadableStreamDefaultReader<Uint8Array>): void {
+  try {
+    void reader.cancel().catch(() => {
+      // error-policy:J6 the authoritative failure is already known; cancelling
+      // the reader is best-effort connection teardown.
+    });
+  } catch {
+    // error-policy:J6 synchronous cancellation is best-effort teardown.
+  }
+}
+
+/**
+ * Read an upstream response body under a hard byte budget, charged BEFORE the
+ * bytes are retained.
+ *
+ * Two checks, in this order:
+ *  1. A declared `content-length` over budget is refused without reading the
+ *     body at all, so a provider that announces its size never gets a single
+ *     byte allocated.
+ *  2. Otherwise the body is streamed and each chunk is charged against the
+ *     running total before it is pushed onto the retained list, so a response
+ *     with no `content-length` (or a lying one) is cut off at the budget
+ *     instead of after it. Peak retention is the budget plus the one chunk
+ *     already in hand, never a function of what the host chose to send.
+ *
+ * Over-budget is a typed `UPSTREAM_RESPONSE_TOO_LARGE` failure, never a
+ * truncated body served as success: a caller that received the first N bytes
+ * of a provider payload labelled `status: 200` could not tell it apart from
+ * the real thing.
+ *
+ * This mirrors, contract for contract, `readBodyWithLimit` in
+ * `services/social-media/media-download.ts` — content-length pre-check, then a
+ * charge-before-retain streaming loop, then best-effort cancellation. It is not
+ * called directly because that helper is module-private and welded to the
+ * social-media byte constants and `SOCIAL_MEDIA_DOWNLOAD_TOO_LARGE` error
+ * codes, which are the wrong contract for an OAuth-broker caller that must
+ * surface an `OAuthError` the route boundary can map.
+ */
+async function readUpstreamBodyWithinBudget(
+  response: Response,
+  maxBytes: number,
+): Promise<Uint8Array> {
+  const rawLength = response.headers.get("content-length");
+  const declaredLength = rawLength === null ? null : Number(rawLength);
+  if (declaredLength !== null && Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    cancelUpstreamBody(response);
+    throw responseTooLarge({ declaredBytes: declaredLength, maxBytes });
+  }
+
+  const body = response.body;
+  if (!body) {
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength > maxBytes) {
+      throw responseTooLarge({ receivedBytes: bytes.byteLength, maxBytes });
+    }
+    return bytes;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value?.byteLength) continue;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        cancelUpstreamReader(reader);
+        throw responseTooLarge({ receivedBytes: total, maxBytes });
+      }
+      chunks.push(value);
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // error-policy:J6 stream lock release is best-effort teardown.
+    }
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged;
+}
+
 // Chunked base64 keeps large binary payloads off the argument-spread stack limit.
 function encodeBase64(bytes: Uint8Array): string {
   let binary = "";
@@ -367,7 +507,7 @@ export class CredentialBroker {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
     let upstream: Response;
-    let payload: ArrayBuffer;
+    let payload: Uint8Array;
     try {
       upstream = await this.deps.fetchImpl(url.toString(), {
         method,
@@ -376,8 +516,12 @@ export class CredentialBroker {
         redirect: "manual",
         signal: controller.signal,
       });
-      payload = await upstream.arrayBuffer();
+      payload = await readUpstreamBodyWithinBudget(upstream, MAX_RESPONSE_BODY_BYTES);
     } catch (error) {
+      // An over-budget response is already a typed broker error with its own
+      // code; re-flattening it into "request failed" would hide a caller-fixable
+      // 502 behind a generic transport failure.
+      if (error instanceof OAuthError) throw error;
       // error-policy:J2 context-adding rethrow — transport/deadline failures
       // become a typed broker error; the route boundary maps it to 502. The
       // message never includes the credentialed request headers.
@@ -409,8 +553,7 @@ export class CredentialBroker {
     const contentType = upstream.headers.get("content-type") ?? "";
     const textual = contentType === "" || TEXTUAL_CONTENT_TYPE.test(contentType);
     const bodyEncoding: "utf8" | "base64" = textual ? "utf8" : "base64";
-    const bytes = new Uint8Array(payload);
-    const responseBody = textual ? new TextDecoder().decode(bytes) : encodeBase64(bytes);
+    const responseBody = textual ? new TextDecoder().decode(payload) : encodeBase64(payload);
 
     logger.info("[CredentialBroker] Brokered provider request", {
       organizationId: params.organizationId,

--- a/packages/cloud/shared/src/lib/services/oauth/errors.ts
+++ b/packages/cloud/shared/src/lib/services/oauth/errors.ts
@@ -28,6 +28,9 @@ export enum OAuthErrorCode {
   // Rate limiting
   RATE_LIMITED = "RATE_LIMITED",
 
+  // Upstream provider errors
+  UPSTREAM_RESPONSE_TOO_LARGE = "UPSTREAM_RESPONSE_TOO_LARGE",
+
   // Internal errors
   INTERNAL_ERROR = "INTERNAL_ERROR",
 }
@@ -47,6 +50,7 @@ export const ERROR_STATUS_MAP: Record<OAuthErrorCode, number> = {
   [OAuthErrorCode.UNAUTHORIZED]: 401,
   [OAuthErrorCode.FORBIDDEN]: 403,
   [OAuthErrorCode.RATE_LIMITED]: 429,
+  [OAuthErrorCode.UPSTREAM_RESPONSE_TOO_LARGE]: 502,
   [OAuthErrorCode.INTERNAL_ERROR]: 500,
 };
 


### PR DESCRIPTION
# Relates to

Fixes #23895

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (rebased onto `dbdab0f20460a59f9d3afc81511000aa6e0a4fae`).
- [x] `bun install` was run after sync. `bun run verify` was **not** run
      monorepo-wide — see **Known gaps / failures**; the focused suite, the whole
      `services/oauth` directory measured against an untouched control, the
      package typecheck against an untouched control, and biome on all three
      touched files were run and are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after production-path measurements below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched off `origin/develop` and rebased onto `dbdab0f20460`; zero conflicts.
- [ ] `bun run verify` post-sync — not run monorepo-wide; the exact scope that
      was run, and why the wider run was skipped, is in **Known gaps / failures**.

# Risks

**Low, with one deliberate behaviour change.** Below the budget nothing changes —
proven byte-for-byte across a 396-case origin-vs-branch corpus. Above it, an
upstream response larger than 5,000,000 bytes now fails with a typed 502 where it
previously succeeded at unbounded memory cost. That is the fix, and it is called
out explicitly in **Known gaps** so a reviewer who wants a different ceiling can
say so — the number is one constant.

# Background

## What does this PR do?

`CredentialBroker.callProvider()` capped the **request** body it accepts from the
caller and capped the **response** it reads from the provider at nothing. On
`origin/develop` today, twenty-five lines apart in the same function:

```
:80   const MAX_REQUEST_BODY_BYTES = 1_000_000;
:354  if (new TextEncoder().encode(body).byteLength > MAX_REQUEST_BODY_BYTES) {
:379  payload = await upstream.arrayBuffer();      <- no counterpart
:413  const responseBody = textual ? new TextDecoder().decode(bytes) : encodeBase64(bytes);
```

`:379` materializes whatever the upstream host sends. `:413` decodes it whole or
base64-expands it by 4/3, and `packages/cloud/api/v1/connections/[id]/broker/route.ts:93`
serializes the result into one JSON envelope field, so every upstream byte is
paid for at least twice inside a single Cloudflare Worker isolate
(`packages/cloud/api/wrangler.toml`, `name = "eliza-cloud-api"`).

**On the existing protection, precisely:** the call *is* bounded — by
`UPSTREAM_TIMEOUT_MS = 30_000` (`:81`, `:368`). It is **duration**-bounded, not
**byte**-bounded. Thirty seconds of provider bandwidth is far more than an
isolate's memory ceiling, and in the measurement below the whole 960 MiB transfer
completed in 25.3 s — inside the deadline — and returned `200`. This PR does not
touch the deadline; it adds the byte budget the deadline was never going to
supply.

## Provenance

This was finding 1 of 5 in a `CHANGES_REQUESTED` review I left on **#23149**
(`feat(cloud): credential broker for plugin provider calls (opaque connection
IDs)`) at `2026-08-21T05:48:06Z`, noting there was no upstream response-size cap.
That PR merged at `2026-08-21T09:41:44Z`. PRs merge for many reasons and this is
not a complaint about that decision — the point is only that the finding was not
addressed in the merged tree, so it is on `develop` now. This PR is the fix,
carrying a production-path reproduction the review did not have, plus an owning
issue (#23895) so it is tracked rather than living in a review thread.

## Reachability

`POST /api/v1/connections/:id/broker` authenticates with
`requireAuthOrApiKeyWithOrg` (`packages/cloud/shared/src/lib/auth.ts:470` →
`requireAuthOrApiKey:368`), which accepts a Steward **session cookie**, an
**`X-API-Key`**, or a **`Bearer`** Steward JWT / `eliza_*` API key, from **any**
authenticated user with an active organization. There is no first-party-only or
service-key scope check anywhere on the path, despite the route docstring
describing the endpoint as "for first-party plugins" — the docstring/behaviour
mismatch is worth a line on its own. The correct bindings that *are* implemented
still hold: the connection must belong to the caller's org and, when user-owned,
to the calling user.

So the caller needs one legitimately linked connection of their own. Two of the
pinned audiences are **download** hosts — `drive.googleapis.com` (`:44`) and
`content.dropboxapi.com` (`:65`) — where `files/{id}?alt=media` is exactly the
call a plugin would broker, and the response size is chosen by a file the caller
themselves uploaded.

## The fix

```ts
const MAX_REQUEST_BODY_BYTES = 1_000_000;
const RESPONSE_BODY_BUDGET_MULTIPLIER = 5;
const MAX_RESPONSE_BODY_BYTES = MAX_REQUEST_BODY_BYTES * RESPONSE_BODY_BUDGET_MULTIPLIER;
```

Derived from the request cap rather than written as a second literal, so the two
halves of the function cannot drift: moving the request cap moves both.

`readUpstreamBodyWithinBudget()` charges the budget **before** the bytes are
retained, in two stages:

1. A declared `content-length` over budget is refused **without reading the body
   at all** — a provider that announces its size never gets a byte allocated.
2. Otherwise the body is streamed and each chunk is charged against the running
   total **before** it is pushed onto the retained list, so a response with no
   `content-length` (or a lying one) is cut off *at* the budget rather than
   after it. Peak retention is the budget plus the one chunk in hand, never a
   function of what the host chose to send.

Over-budget is a typed `OAuthErrorCode.UPSTREAM_RESPONSE_TOO_LARGE` → **502**,
never a truncated body served as `200` — a caller handed the first N bytes of a
provider payload labelled `200` could not tell it apart from the real thing. The
new code is re-thrown unflattened out of the existing transport `catch`, so it
does not get hidden behind the generic "request failed".

## Why a new helper rather than calling an existing one

`readBodyWithLimit` in
`packages/cloud/shared/src/lib/services/social-media/media-download.ts` already
implements exactly this contract — content-length pre-check, charge-before-retain
streaming loop, best-effort cancellation — and this helper **mirrors it stage for
stage**. It is not called directly because it is module-private and welded to
`SOCIAL_MEDIA_MEDIA_MAX_BYTES` and the `SOCIAL_MEDIA_DOWNLOAD_TOO_LARGE` /
`SOCIAL_MEDIA_MEDIA_TOO_LARGE` error codes, which are the wrong contract for an
OAuth-broker caller that must surface an `OAuthError` the route boundary can map
to a status. The docblock on the new helper says this, so the duplication is
declared rather than accidental.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue) — with one intentional
behaviour change above the new ceiling, stated in **Known gaps**.

# Documentation changes needed?

My changes do not require a change to the project documentation. The module
docstring's invariant list now names both budgets, and the new constants and
helper carry docblocks stating what is charged, when, and why the number is
derived rather than free-standing.

# Testing

## Where should a reviewer start?

`credential-broker.test.ts` → `describe("CredentialBroker.callProvider (upstream
response byte budget)")`, then `readUpstreamBodyWithinBudget` in
`credential-broker.ts`.

## Detailed testing steps

```bash
git fetch origin develop && git checkout <this branch>
bun install
node packages/shared/scripts/generate-keywords.mjs   # see Known gaps
cd packages/cloud/shared
bun test --conditions eliza-source src/lib/services/oauth/credential-broker.test.ts
```

### 1. Origin reproduction — the real `callProvider`, the real fetch seam

The real, unmodified `createCredentialBroker(...).callProvider(...)` — the same
factory and the same call shape `route.ts:93` uses — driven through the same
injectable `deps.fetchImpl` seam the production singleton wires
(`fetchImpl: (input, init) => fetch(input, init)`, `:442`). The module under test
was extracted with `git show origin/develop:.../credential-broker.ts` and
`diff`-verified byte-for-byte against the shipped file; the only two lines that
differ are the `logger` import path and the elided production singleton, whose
`oauthService` import pulls the whole DB/plugin-sql chain into a standalone
script. `services/oauth/` is unchanged between the tree I measured and
`dbdab0f20460`.

Upstream is an allowlisted host (`content.dropboxapi.com`, pinned at `:65`)
emitting 1 MiB chunks with no `content-length` and a binary content-type.

**Default heap — it does not crash. It succeeds, and hands back 1.28 GB.**

```
$ bun --preload ./stub-core-edge.ts repro-success-1gb.ts   # origin callProvider
start RSS: 27.0MB
upstream will emit 960 MiB, no content-length
  streamed 240 MiB ... RSS 276.5MB
  streamed 480 MiB ... RSS 517.0MB
  streamed 720 MiB ... RSS 757.4MB
  streamed 960 MiB ... RSS 997.6MB
--- callProvider RETURNED (no error) ---
  status         : 200
  bodyEncoding   : base64
  body length    : 1342177280 chars
  body length    : 1280.00 MiB of base64
  elapsed        : 25345ms (UPSTREAM_TIMEOUT_MS is 30000)
  RSS after      : 1793.3MB
  peak RSS seen  : 1793.3MB
```

RSS tracks the upstream byte count linearly through the read (27 MB → 997 MB),
then steps again at base64 materialization (997 MB → 1793 MB). The 4/3 expansion
is exact and measured: 1,342,177,280 characters out of 960 MiB in. A response
that *succeeds* at 1.28 GB is worse than one that crashes, because a crash is at
least visible.

**Constrained heap — same code path, same seam, it OOMs instead.**

```
$ bun --preload ./stub-core-edge.ts broker-repro.ts        # origin callProvider
start RSS: 27.0MB
ERROR: Out of memory RSS at failure: 3425.6MB
```

Same root cause, two symptoms depending on available heap.

### 2. AFTER — same harness, same 960 MiB stream, this branch

```
$ bun --preload ./stub-core-edge.ts repro-fixed-1gb.ts
start RSS: 27.2MB
upstream will emit 960 MiB, no content-length
[ "[CredentialBroker] Upstream response exceeded the broker byte budget", {
    receivedBytes: 5242880,
    maxBytes: 5000000,
  } ]
--- callProvider THREW ---
  error         : OAuthError: Upstream response exceeds the 5000000-byte broker limit
  elapsed       : 3ms
  RSS at failure: 36.6MB
  peak RSS seen : 36.6MB
```

1793.3 MB → 36.6 MB peak, 25,345 ms → 3 ms, `200` → typed 502.

### 3. No over-rejection — 396 cases, origin vs branch, byte-identical

The origin `callProvider` (extracted with `git show origin/develop:`) and the
patched one are run over the same corpus through the same seam, and the full
`BrokeredProviderResponse` is compared — `status`, relayed `headers`,
`bodyEncoding`, `tokenRefreshed`, body length, and a SHA-256 of the body.

The corpus covers realistic `drive#fileList` JSON from 0 to ~2.4 MB at five
chunkings with and without `content-length`; all ten content-type branches
(including absent) at eight sizes and three chunkings; eleven non-2xx statuses
with the full response-header allowlist including `set-cookie` and `location`;
boundary sizes at `BUDGET-2`, `BUDGET-1`, and exactly `BUDGET` on both the utf8
and base64 branches; and seven adversarial byte shapes (lone surrogates, invalid
continuations, BOM, NUL, PNG magic, ZWJ emoji, overlong encodings) that the utf8
branch must decode identically.

```
$ bun --preload ./stub-core-edge.ts compat-corpus.ts
corpus cases            : 396
byte-identical outcomes : 396
divergent outcomes      : 0
RESULT: NO OVER-REJECTION
```

### 4. The 30 s deadline still fires mid-read — real socket, both versions

The read changed from `upstream.arrayBuffer()` to a chunked reader, so the
deadline had to be re-proved rather than assumed. A real `http.createServer`
sends `200` + `content-type` + one chunk and then never ends the body, so the
broker is parked *inside* the read. `deps.fetchImpl` rewrites only the URL origin
and forwards `init` — including the broker's own `AbortSignal` — verbatim to the
runtime's real `fetch`.

```
$ bun --preload ./stub-core-edge.ts deadline-preserved.ts
origin/develop callProvider  after 30004ms  sockets=1  -> OAuthError/INTERNAL_ERROR: Upstream github request timed out
this branch  callProvider    after 30004ms  sockets=1  -> OAuthError/INTERNAL_ERROR: Upstream github request timed out
```

Identical to the millisecond. The deadline is untouched.

### 5. AFTER — the focused suite

```
$ bun test --conditions eliza-source src/lib/services/oauth/credential-broker.test.ts
 41 pass
 0 fail
 70 expect() calls
Ran 41 tests across 1 file. [1.60s]
```

Seven new tests: content-length refused before reading; an undeclared 64 MiB
stream cut off near the budget rather than drained; the 502 mapping and the
absence of a truncated success; a large-but-bounded response accepted whole; a
7-byte-chunked textual body reassembled identically to a single-shot read; an
unparseable `content-length` falling back to counting; and an empty `204`.

### 6. Load-bearing check — reverted by copy-aside, never `git stash`

`credential-broker.ts` restored from `git show origin/develop:` with the new
tests left in place, then restored:

```
(fail) … > rejects a declared content-length over budget without reading the body [7.41ms]
       Expected promise that rejects
       Received promise that resolved: Promise { <resolved> }
(fail) … > cuts off an undeclared over-budget stream instead of draining it [1096.69ms]
       Expected promise that rejects
       Received promise that resolved: Promise { <resolved> }
(fail) … > maps the over-budget failure to 502, not to a generic transport 500 [85.67ms]
       Expected constructor: [class OAuthError extends Error]
       Received value: undefined

 38 pass  3 fail
```

The three defect tests fail; the four compatibility tests (large-but-bounded,
multi-chunk reassembly, unparseable content-length, empty 204) stay green — the
reverted behaviour is caught specifically, not by collateral breakage. Restored,
`41 pass / 0 fail`.

### 7. Whole `services/oauth` directory, branch vs untouched control

```
$ bun test --conditions eliza-source src/lib/services/oauth/     # this branch
 104 pass   1 fail   Ran 105 tests across 12 files.

# control: the same tree with all three touched files restored to origin/develop
$ bun test --conditions eliza-source src/lib/services/oauth/
  97 pass   1 fail   Ran  98 tests across 12 files.
```

+7 passing tests, **zero** new failures. The single failure is identical on both
sides and pre-existing:
`providers/oauth2.error-policy.test.ts:210` — "applies the shared 15-second
deadline to callback and refresh requests". Not touched by this diff.

### 8. Typecheck — zero errors added, measured against an untouched control

```
$ bun run --cwd packages/cloud/shared typecheck     # this branch
Done!        (tsc --noEmit, no diagnostics)

# control: the same tree with all three touched files restored to origin/develop
$ bun run --cwd packages/cloud/shared typecheck
Done!        (tsc --noEmit, no diagnostics)
```

Both clean. Adding `UPSTREAM_RESPONSE_TOO_LARGE` to `OAuthErrorCode` is
type-checked to completeness by the existing
`ERROR_STATUS_MAP: Record<OAuthErrorCode, number>`, which is the only exhaustive
map over that enum in the repository (`git grep "Record<OAuthErrorCode"` → one
hit).

### 9. Biome

```
$ bunx @biomejs/biome check \
    packages/cloud/shared/src/lib/services/oauth/credential-broker.ts \
    packages/cloud/shared/src/lib/services/oauth/credential-broker.test.ts \
    packages/cloud/shared/src/lib/services/oauth/errors.ts
Checked 3 files in 16ms. No fixes applied.
```

# Evidence Gate

<!-- evidence-head:61ddb8f74dced0427efcd4d38f6f89ecd1fc946d -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only change to a Cloud OAuth service module and its error enum; no rendered UI surface is touched by this diff.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only change to a Cloud OAuth service module and its error enum; no rendered UI surface is touched by this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the observable behaviour is how many bytes the isolate allocates for one brokered call, shown as before/after RSS and body-length measurements in Testing above.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — pasted below (the
      real unmodified `callProvider` driven through the production `fetchImpl`
      seam, the real suite, the revert arm, and a real stalling socket).

<details><summary>BEFORE — <code>origin/develop</code>, real unmodified <code>callProvider</code></summary>

```
start RSS: 27.0MB
upstream will emit 960 MiB, no content-length
  streamed 240 MiB ... RSS 276.5MB
  streamed 480 MiB ... RSS 517.0MB
  streamed 720 MiB ... RSS 757.4MB
  streamed 960 MiB ... RSS 997.6MB
--- callProvider RETURNED (no error) ---
  status         : 200
  bodyEncoding   : base64
  body length    : 1342177280 chars
  body length    : 1280.00 MiB of base64
  elapsed        : 25345ms (UPSTREAM_TIMEOUT_MS is 30000)
  RSS after      : 1793.3MB
  peak RSS seen  : 1793.3MB
```

Same code path under a constrained heap:

```
start RSS: 27.0MB
ERROR: Out of memory RSS at failure: 3425.6MB
```

</details>

<details><summary>AFTER — this branch, same harness and same 960 MiB stream</summary>

```
start RSS: 27.2MB
upstream will emit 960 MiB, no content-length
[ "[CredentialBroker] Upstream response exceeded the broker byte budget", {
    receivedBytes: 5242880,
    maxBytes: 5000000,
  } ]
--- callProvider THREW ---
  error         : OAuthError: Upstream response exceeds the 5000000-byte broker limit
  elapsed       : 3ms
  RSS at failure: 36.6MB
  peak RSS seen : 36.6MB

$ bun test --conditions eliza-source src/lib/services/oauth/credential-broker.test.ts
[CredentialBroker] Upstream response exceeded the broker byte budget [Object: null prototype] {
  declaredBytes: 5000001,
  maxBytes: 5000000,
}
[CredentialBroker] Upstream response exceeded the broker byte budget [Object: null prototype] {
  receivedBytes: 5046272,
  maxBytes: 5000000,
}
 41 pass
 0 fail
 70 expect() calls
Ran 41 tests across 1 file. [1.60s]

$ bun --preload ./stub-core-edge.ts deadline-preserved.ts
origin/develop callProvider  after 30004ms  sockets=1  -> OAuthError/INTERNAL_ERROR: Upstream github request timed out
this branch  callProvider    after 30004ms  sockets=1  -> OAuthError/INTERNAL_ERROR: Upstream github request timed out

$ bun --preload ./stub-core-edge.ts compat-corpus.ts
corpus cases            : 396
byte-identical outcomes : 396
divergent outcomes      : 0
RESULT: NO OVER-REJECTION
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path; this module runs server-side in the Cloud Worker only.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behaviour changes; this is an HTTP response byte budget.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB rows, memories, scheduled tasks, on-chain output, or generated files are produced or altered.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behaviour changes.`

## Backend + frontend logs

Backend: inline in **Testing → 1, 2, 4, 5, 6, 7** (the real unmodified
`callProvider` through the production `fetchImpl` seam, the patched one on the
same harness, a real stalling `http.createServer`, the real suite, the revert
arm, and the whole-directory branch-vs-control run).

Frontend: `N/A - server-side module.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT, or omnivoice surface.`

## Known gaps / failures

- **This is a behaviour change above 5,000,000 bytes, by design.** A brokered
  response larger than that previously succeeded at unbounded memory cost and now
  fails with a typed 502. Below the budget nothing changes — 396/396 byte-identical.
  The ceiling is one derived constant
  (`RESPONSE_BODY_BUDGET_MULTIPLIER = 5`); if a maintainer wants a different
  number, or a per-platform override, that is a one-line change and I would
  rather be told than guess. Tunnelling large media through a single JSON
  envelope field is arguably the thing that should not be supported at all, but
  removing that capability is a product decision I have not made here.
- **The peak-memory multiplier is ~2.33x in the worst case, and this run does not
  isolate it.** The 4/3 base64 expansion *is* directly measured (1,342,177,280
  chars from 960 MiB). The compounding figure — raw bytes and encoded string held
  simultaneously — is a shape, not a constant I measured: the 997 MB → 1793 MB
  step reflects GC timing in one runtime, and the constrained-heap run OOM'd
  during the read before the encode ran at all. Treat 2.33x as an upper bound.
- **`UPSTREAM_TIMEOUT_MS` is untouched and remains duration-bounded.** I am not
  claiming the path had no protection; it had the wrong *kind*. The deadline is
  re-proved unchanged in Testing → 4.
- **The route still parses the inbound body before measuring it.**
  `broker/route.ts:72` does `await request.json()` and only afterwards does
  `callProvider` measure it at `:354`, so a very large POST is fully parsed before
  being rejected with a 400. That was finding 2 of the same #23149 review. It is a
  different function in a different file and folding it in would make this a sweep
  rather than one defect; #23895 records this PR's scope as the response side.
- **No rate limit or per-connection concurrency cap is added.** Nothing bounds how
  many brokered calls one API key can make; this PR bounds the cost of *each* one.
  That was finding 5 of the same review and remains open.
- **`bun run verify` was not run monorepo-wide.** It builds and tests the whole
  repository and is far beyond the blast radius of one Cloud service module. What
  was run instead, and passed, is recorded above.
- **`packages/core/src/i18n/generated/validation-keyword-data.ts` had to be
  generated** in the fresh worktree (`node packages/shared/scripts/generate-keywords.mjs`)
  before anything under `packages/cloud/shared` would import. It is a gitignored
  build artifact and is not in this diff.
- **The repro harnesses are not part of this diff.** They are standalone scripts
  that import the extracted origin module and the patched one side by side. The
  permanent regression coverage is the seven new cases in
  `credential-broker.test.ts`.
- **Hosted CI checks do not run on this PR.** I contribute from a fork without
  push access to `elizaOS/eliza`, so no hosted check will report here. Every
  result above was produced locally and is reproducible with the commands given.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-mine-broker-respcap]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JR06515J1BCQZ7WK4ZGPS9","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T18:05:47.042Z","completed_at":"2026-08-21T18:07:14.586Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T18:05:47.975Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"813762eb4064fbaf1c2c581f8673851082ed33711a975bdf59adc52429e9171e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"878d2914-3798-49b7-8133-b9561b50afb0","object_id":"sha256:813762eb4064fbaf1c2c581f8673851082ed33711a975bdf59adc52429e9171e","sha256":"813762eb4064fbaf1c2c581f8673851082ed33711a975bdf59adc52429e9171e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"DlScUIGXqgNPyMFksN5nsKpvrnDc8Jwo3dEyTRLuMdEnWGovQ4_HNihsNYbJz99x7GueARgn_3u6jDmBEMFsCw"}} -->
