### PR TITLE
fix(core): reject invalid trajectory field caps

### DIFF
--- a/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
@@ -1139,6 +1139,21 @@ describe("action exec input/output/error capture (M12)", () => {
 		expect(marker).toBeNull();
 	});
 
+	it.each([17.5, Number.NaN, Number.POSITIVE_INFINITY, -1, 2 ** 53])(
+		"rejects invalid byte cap %s before truncating",
+		(capBytes) => {
+			expect(() =>
+				applyTrajectoryFieldCap("output", "🦊".repeat(10), capBytes),
+			).toThrowError(
+				expect.objectContaining({
+					name: "ElizaError",
+					code: "TRAJECTORY_FIELD_CAP_INVALID",
+					context: { capBytes: String(capBytes) },
+				}),
+			);
+		},
+	);
+
 	it("truncates oversize values and emits a structured marker", () => {
 		const big = "a".repeat(2048);
 		const { value, marker } = applyTrajectoryFieldCap("output", big, 256);

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -1025,6 +1025,15 @@ export function applyTrajectoryFieldCap(
 	value: string,
 	capBytes: number,
 ): { value: string; marker: RecordedTruncationMarker | null } {
+	if (!Number.isSafeInteger(capBytes) || capBytes < 0) {
+		throw new ElizaError(
+			"Trajectory field cap must be a non-negative safe integer",
+			{
+				code: "TRAJECTORY_FIELD_CAP_INVALID",
+				context: { capBytes: String(capBytes) },
+			},
+		);
+	}
 	const byteLength = Buffer.byteLength(value, "utf8");
 	if (byteLength <= capBytes) {
 		return { value, marker: null };


### PR DESCRIPTION
Closes #23856.

## Scope

`applyTrajectoryFieldCap` is a public core API, but its byte budget accepted every JavaScript `number`. Fractional indices bypassed the UTF-8 continuation-byte backoff before `Buffer.subarray` coerced the endpoint, while `NaN`, infinity, negative, and unsafe values produced accidental pass-through or suffix-only behavior.

This change validates the budget before inspecting or truncating the value. Invalid budgets now fail closed with `ElizaError` code `TRAJECTORY_FIELD_CAP_INVALID` and serializable received-value context. Valid integer behavior and the production environment resolver are unchanged.

## Exact-head verification

Candidate: `5c5559f685c83b4f78965a0ae303d9995e4ecc2f`

Parent develop: `2f9011038d0dc7640bfa878bba3b841f59bfbb50`

- trajectory recorder suite: 60/60 pass;
- adversarial invalid-cap table covers `17.5`, `NaN`, `Infinity`, `-1`, and `2 ** 53`;
- mutation control: removing only the production guard fails all five new cases while the other 55 tests pass;
- core typecheck: pass;
- full core Node, browser, edge, testing, declaration, and packed-consumer build: pass;
- Biome and diff checks: pass.
- root `bun run verify` reached the 148-package Turbo typecheck/lint lane, then stopped on unchanged `plugin-personal-assistant` surrogate-test formatting diagnostics; the exact changed core files are green.

The exact remote tree uses the tested source and test blobs; intervening `develop` movement changed only unrelated formatting fixes outside core. This PR is source-complete and ready for review. Hosted CI and independent review are merge holds, not draft holds.

## Evidence Gate

<!-- evidence-head:5c5559f685c83b4f78965a0ae303d9995e4ecc2f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - exported core validation only.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head test, type, build, formatting, mutation, and repository-gate receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23903-23856-backend-5c5559f-v2.log).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head invalid-budget contract proof](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23903-23856-domain-5c5559f.md).
<!-- evidence-row:ocr-review -->
- [x] N/A - no pixels or visual text changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2f9011038d0dc7640bfa878bba3b841f59bfbb50:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@2f9011038d0dc7640bfa878bba3b841f59bfbb50:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@2f9011038d0dc7640bfa878bba3b841f59bfbb50:packages/skills/skills/contribute-to-eliza"} -->
