### PR TITLE
fix(discord): stop a stale voice stateChange handler from double-destroying a connection

### DIFF
--- a/plugins/plugin-discord/__tests__/voice-connection-lifecycle.test.ts
+++ b/plugins/plugin-discord/__tests__/voice-connection-lifecycle.test.ts
@@ -1,0 +1,162 @@
+/**
+ * `VoiceManager` voice-connection lifecycle: the per-connection `stateChange`
+ * listener installed by `joinChannel()` must never act on a connection it no
+ * longer owns, and must never be installed twice on one connection.
+ *
+ * These run against the real `@discordjs/voice` stack driven through a stub
+ * voice adapter (no gateway socket), so `joinVoiceChannel()` de-duplication and
+ * `VoiceConnection.destroy()`'s throw-on-already-destroyed behave exactly as
+ * they do in production.
+ */
+import { EventEmitter } from "node:events";
+import { ChannelType } from "discord.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ICompatRuntime } from "../compat";
+import { VoiceManager } from "../voice";
+
+/** The Disconnected handler probes for a reconnect for 5s before cleaning up. */
+const RECONNECT_PROBE_MS = 5_000;
+
+function makeRuntime() {
+	return {
+		agentId: "00000000-0000-4000-8000-000000000002",
+		getSetting: vi.fn(() => undefined),
+		logger: {
+			debug: vi.fn(),
+			error: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+		},
+	};
+}
+
+function makeChannel(guildId: string) {
+	return {
+		guildId,
+		id: `voice-${guildId}`,
+		name: "Owners Room",
+		members: new Map(),
+		type: ChannelType.GuildVoice,
+		guild: {
+			id: guildId,
+			members: { fetch: vi.fn() },
+			voiceAdapterCreator: () => ({
+				sendPayload: () => true,
+				destroy: () => undefined,
+			}),
+		},
+	};
+}
+
+function makeManager(unregisterVoiceTarget?: (...args: string[]) => void) {
+	const client = new EventEmitter() as EventEmitter & { user?: { id: string } };
+	client.user = { id: "bot-1" };
+	return new VoiceManager(
+		{ accountId: "test", client: client as never, unregisterVoiceTarget },
+		makeRuntime() as unknown as ICompatRuntime,
+	);
+}
+
+/** Discord close code 4014: "do not reconnect" — the real disconnect path. */
+function closeWithoutReconnect(connection: unknown) {
+	(connection as { onNetworkingClose(code: number): void }).onNetworkingClose(
+		4014,
+	);
+}
+
+async function afterReconnectProbe() {
+	await new Promise((resolve) =>
+		setTimeout(resolve, RECONNECT_PROBE_MS + 1_000),
+	);
+	await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("VoiceManager voice-connection lifecycle", () => {
+	let rejections: unknown[] = [];
+	let onRejection: (reason: unknown) => void;
+
+	const rejectionMessages = () =>
+		rejections.map((r) => (r instanceof Error ? r.message : String(r)));
+
+	beforeEach(() => {
+		rejections = [];
+		onRejection = (reason: unknown) => {
+			rejections.push(reason);
+		};
+		process.on("unhandledRejection", onRejection);
+	});
+
+	afterEach(() => {
+		process.off("unhandledRejection", onRejection);
+	});
+
+	it("survives a leave issued while the reconnect probe is still open", async () => {
+		const manager = makeManager();
+		const channel = makeChannel("guild-leave");
+		await manager.joinChannel(channel as never);
+
+		const connection = manager.getVoiceConnection("guild-leave");
+		expect(connection).toBeDefined();
+		if (!connection) return;
+
+		closeWithoutReconnect(connection);
+		expect(connection.state.status).toBe("disconnected");
+
+		// `/voice mode:leave` lands inside the 5s reconnect probe window.
+		manager.leaveChannel(channel as never);
+		expect(connection.state.status).toBe("destroyed");
+
+		await afterReconnectProbe();
+
+		expect(rejectionMessages()).toEqual([]);
+		expect(manager.getVoiceConnection("guild-leave")).toBeUndefined();
+	}, 30_000);
+
+	it("installs exactly one lifecycle listener when two joins overlap", async () => {
+		const manager = makeManager();
+		const channel = makeChannel("guild-overlap");
+		await Promise.all([
+			manager.joinChannel(channel as never),
+			manager.joinChannel(channel as never),
+		]);
+
+		const connection = manager.getVoiceConnection("guild-overlap");
+		expect(connection).toBeDefined();
+		if (!connection) return;
+
+		// `error` is not asserted: each still-pending `entersState` loser from
+		// `Promise.race` holds one of its own until its 20s deadline.
+		expect(connection.listenerCount("stateChange")).toBe(1);
+
+		closeWithoutReconnect(connection);
+		await afterReconnectProbe();
+
+		expect(rejectionMessages()).toEqual([]);
+		// The confirmed disconnect must still tear the channel entry down.
+		expect(connection.state.status).toBe("destroyed");
+		expect(manager.getVoiceConnection("guild-overlap")).toBeUndefined();
+	}, 30_000);
+
+	it("still tears down on an ordinary confirmed disconnect", async () => {
+		const unregisterVoiceTarget = vi.fn();
+		const manager = makeManager(unregisterVoiceTarget);
+		const channel = makeChannel("guild-plain");
+
+		await manager.joinChannel(channel as never);
+		const connection = manager.getVoiceConnection("guild-plain");
+		expect(connection).toBeDefined();
+		if (!connection) return;
+
+		closeWithoutReconnect(connection);
+		await afterReconnectProbe();
+
+		expect(connection.state.status).toBe("destroyed");
+		expect(manager.getVoiceConnection("guild-plain")).toBeUndefined();
+		expect(unregisterVoiceTarget).toHaveBeenCalledWith(
+			"test",
+			"guild-plain",
+			"voice-guild-plain",
+		);
+		expect(rejectionMessages()).toEqual([]);
+	}, 30_000);
+});

--- a/plugins/plugin-discord/voice.ts
+++ b/plugins/plugin-discord/voice.ts
@@ -365,6 +365,14 @@ export class VoiceManager extends EventEmitter {
 	) => boolean;
 	private streams: Map<string, Readable> = new Map();
 	private connections: Map<string, VoiceConnection> = new Map();
+	/**
+	 * Connections this manager has already wired lifecycle listeners onto.
+	 * `joinVoiceChannel()` returns the connection it is *already* tracking for the
+	 * same (group, guildId) instead of creating a new one, so two overlapping
+	 * joins would otherwise stack a second copy of the `stateChange`/`error`
+	 * listeners onto a single connection and run its teardown twice.
+	 */
+	private wiredConnections = new WeakSet<VoiceConnection>();
 	private audioLanes = new Map<string, DiscordAudioLaneConfig>();
 	private lanePlayers = new Map<string, LanePlayerState>();
 	private activeMonitors: Map<
@@ -650,94 +658,123 @@ export class VoiceManager extends EventEmitter {
 				"Voice connection established",
 			);
 
-			// Set up ongoing state change monitoring
-			connection.on("stateChange", async (oldState, newState) => {
-				this.runtime.logger.debug(
-					{
-						src: "plugin:discord:service:voice",
-						agentId: this.runtime.agentId,
-						oldState: oldState.status,
-						newState: newState.status,
-					},
-					"Voice connection state changed",
-				);
+			// Set up ongoing state change monitoring. Wire each connection at most
+			// once: `joinVoiceChannel()` returns an already-tracked connection for
+			// this (group, guildId) rather than a fresh one, so overlapping joins
+			// would otherwise attach a second copy of these listeners to one
+			// connection and run the teardown below twice against it.
+			if (!this.wiredConnections.has(connection)) {
+				this.wiredConnections.add(connection);
+				connection.on("stateChange", async (oldState, newState) => {
+					this.runtime.logger.debug(
+						{
+							src: "plugin:discord:service:voice",
+							agentId: this.runtime.agentId,
+							oldState: oldState.status,
+							newState: newState.status,
+						},
+						"Voice connection state changed",
+					);
 
-				if (newState.status === VoiceConnectionStatus.Disconnected) {
+					if (newState.status === VoiceConnectionStatus.Disconnected) {
+						this.runtime.logger.debug(
+							{
+								src: "plugin:discord:service:voice",
+								agentId: this.runtime.agentId,
+							},
+							"Handling disconnection",
+						);
+
+						try {
+							// Try to reconnect if disconnected
+							await Promise.race([
+								entersState(
+									connection,
+									VoiceConnectionStatus.Signalling,
+									5_000,
+								),
+								entersState(
+									connection,
+									VoiceConnectionStatus.Connecting,
+									5_000,
+								),
+							]);
+							// Seems to be reconnecting to a new channel
+							this.runtime.logger.debug(
+								{
+									src: "plugin:discord:service:voice",
+									agentId: this.runtime.agentId,
+								},
+								"Reconnecting to channel",
+							);
+						} catch (e) {
+							// Seems to be a real disconnect, destroy and cleanup.
+							// This probe resolves up to 5s after the disconnect, by which
+							// time a `/voice leave`, a rejoin or `stop()` may already have
+							// torn this connection down and registered a replacement, so
+							// re-check ownership before destroying or evicting anything.
+							this.runtime.logger.debug(
+								{
+									src: "plugin:discord:service:voice",
+									agentId: this.runtime.agentId,
+									error: e instanceof Error ? e.message : String(e),
+								},
+								"Disconnection confirmed - cleaning up",
+							);
+							const isCurrent = this.connections.get(channel.id) === connection;
+							if (connection.state.status !== VoiceConnectionStatus.Destroyed) {
+								connection.destroy();
+							}
+							if (isCurrent) {
+								this.connections.delete(channel.id);
+								this.unregisterVoiceTarget?.(
+									this.accountId,
+									channel.guild.id,
+									channel.id,
+								);
+							}
+						}
+					} else if (newState.status === VoiceConnectionStatus.Destroyed) {
+						// Only the connection that currently owns this channel entry may
+						// clear it; a superseded connection cleans up itself and nothing
+						// else.
+						if (this.connections.get(channel.id) === connection) {
+							this.connections.delete(channel.id);
+							this.unregisterVoiceTarget?.(
+								this.accountId,
+								channel.guild.id,
+								channel.id,
+							);
+							void this.stopVoiceTranscription(channel.id, "normal_completion");
+						}
+					} else if (
+						!this.connections.has(channel.id) &&
+						(newState.status === VoiceConnectionStatus.Ready ||
+							newState.status === VoiceConnectionStatus.Signalling)
+					) {
+						this.connections.set(channel.id, connection);
+					}
+				});
+
+				connection.on("error", (error) => {
+					this.runtime.logger.error(
+						{
+							src: "plugin:discord:service:voice",
+							agentId: this.runtime.agentId,
+							error: error instanceof Error ? error.message : String(error),
+						},
+						"Voice connection error",
+					);
+					// Don't immediately destroy - let the state change handler deal with it
 					this.runtime.logger.debug(
 						{
 							src: "plugin:discord:service:voice",
 							agentId: this.runtime.agentId,
 						},
-						"Handling disconnection",
+						"Will attempt to recover",
 					);
-
-					try {
-						// Try to reconnect if disconnected
-						await Promise.race([
-							entersState(connection, VoiceConnectionStatus.Signalling, 5_000),
-							entersState(connection, VoiceConnectionStatus.Connecting, 5_000),
-						]);
-						// Seems to be reconnecting to a new channel
-						this.runtime.logger.debug(
-							{
-								src: "plugin:discord:service:voice",
-								agentId: this.runtime.agentId,
-							},
-							"Reconnecting to channel",
-						);
-					} catch (e) {
-						// Seems to be a real disconnect, destroy and cleanup
-						this.runtime.logger.debug(
-							{
-								src: "plugin:discord:service:voice",
-								agentId: this.runtime.agentId,
-								error: e instanceof Error ? e.message : String(e),
-							},
-							"Disconnection confirmed - cleaning up",
-						);
-						connection.destroy();
-						this.connections.delete(channel.id);
-						this.unregisterVoiceTarget?.(
-							this.accountId,
-							channel.guild.id,
-							channel.id,
-						);
-					}
-				} else if (newState.status === VoiceConnectionStatus.Destroyed) {
-					this.connections.delete(channel.id);
-					this.unregisterVoiceTarget?.(
-						this.accountId,
-						channel.guild.id,
-						channel.id,
-					);
-					void this.stopVoiceTranscription(channel.id, "normal_completion");
-				} else if (
-					!this.connections.has(channel.id) &&
-					(newState.status === VoiceConnectionStatus.Ready ||
-						newState.status === VoiceConnectionStatus.Signalling)
-				) {
-					this.connections.set(channel.id, connection);
-				}
-			});
-
-			connection.on("error", (error) => {
-				this.runtime.logger.error(
-					{
-						src: "plugin:discord:service:voice",
-						agentId: this.runtime.agentId,
-						error: error instanceof Error ? error.message : String(error),
-					},
-					"Voice connection error",
-				);
-				// Don't immediately destroy - let the state change handler deal with it
-				this.runtime.logger.debug(
-					{
-						src: "plugin:discord:service:voice",
-						agentId: this.runtime.agentId,
-					},
-					"Will attempt to recover",
-				);
-			});
+				});
+			}
 
 			// Store the connection
 			this.connections.set(channel.id, connection);
@@ -848,8 +885,12 @@ export class VoiceManager extends EventEmitter {
 				},
 				"Failed to establish voice connection",
 			);
-			connection.destroy();
-			this.connections.delete(channel.id);
+			if (connection.state.status !== VoiceConnectionStatus.Destroyed) {
+				connection.destroy();
+			}
+			if (this.connections.get(channel.id) === connection) {
+				this.connections.delete(channel.id);
+			}
 			throw error;
 		}
 	}


### PR DESCRIPTION
# Relates to

Fixes #23906

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (branched off `8e5e0ff034704511e777527a4d0f02440a00940f`).
- [x] `bun install` was run after sync (6654 packages). `bun run verify` was
      **not** run monorepo-wide — see **Known gaps / failures**; the whole
      `plugin-discord` suite (90 files / 738 tests), the package typecheck
      against an untouched control, the copy-aside revert arm, and biome on both
      touched files were run and are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after transcripts below: the same unchanged test file fails on
      `origin/develop` with a real `Cannot destroy VoiceConnection - it has
      already been destroyed` unhandled rejection and passes on this branch.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched off the latest `origin/develop` (`8e5e0ff03470`); zero conflicts.
- [ ] `bun run verify` post-sync — not run monorepo-wide; the exact scope that
      was run, and why the wider run was skipped, is in **Known gaps / failures**.

# Risks

**Low.** One method in one plugin file. No audio, STT, TTS, transcription or
gateway behaviour changes: the diff only decides *whether* a lifecycle listener
is installed and *whether* a given handler still owns the map entry it is about
to mutate. Every existing teardown path keeps running exactly as before, which is
pinned by a dedicated ordinary-disconnect test and by the whole `plugin-discord`
suite (738 tests) passing unchanged. Most of the line count is re-indentation:
the listener bodies are unchanged apart from the three guards.

# Background

## What does this PR do?

`VoiceManager.joinChannel()` (`plugins/plugin-discord/voice.ts:597`) attaches an
**`async`** `stateChange` listener to the `VoiceConnection` it just created. On
`Disconnected` the listener probes for a reconnect for up to **5 seconds** and,
if the probe fails, calls `connection.destroy()` unconditionally:

```ts
} catch (e) {
        // Seems to be a real disconnect, destroy and cleanup
        …
        connection.destroy();
        this.connections.delete(channel.id);
        this.unregisterVoiceTarget?.(this.accountId, channel.guild.id, channel.id);
}
```

`VoiceConnection.destroy()` **throws** when the connection is already destroyed
(`@discordjs/voice@0.19.2`, `dist/index.js:2502-2505`):

```js
destroy(adapterAvailable = true) {
  if (this.state.status === "destroyed") {
    throw new Error("Cannot destroy VoiceConnection - it has already been destroyed");
  }
```

So anything that tears the connection down *inside* that 5-second window leaves
the still-pending handler to call `destroy()` a second time:

| what the user does | code |
|---|---|
| `/voice mode:leave` | `leaveChannel()`, `voice.ts:1170-1176` |
| `/voice mode:join` again (rejoin) | `joinChannel()`'s `oldConnection.destroy()`, `voice.ts:601` |
| service shutdown | `stop()`, `voice.ts:512-522` |

## Why this is not cosmetic

The throw happens inside an `async` EventEmitter listener, on a **timer**, up to
five seconds after `joinChannel()` already returned successfully. `EventEmitter`
discards the promise the listener returns, so the throw becomes an **unhandled
rejection** that no call-stack `try/catch` anywhere up the chain can contain.

There is no `process.on("unhandledRejection")` handler anywhere in this
repository, and both runtimes terminate the process on one:

```
$ node urej.mjs   # an async EventEmitter listener that throws
Error: boom from async listener
node exit=1

$ bun urej.mjs
error: boom from async listener
bun exit=1
```

`"STILL ALIVE after 200ms"` never prints in either. **The agent process dies
because a user typed `/voice mode:leave` a few seconds after Discord dropped the
voice connection.**

That this throw is expected is already acknowledged in this file: `stop()`
(`voice.ts:512-522`) wraps its own `connection.destroy()` in `try/catch` and logs
*"Failed to destroy Discord voice connection during shutdown"*. The listener is
the one place that call is left unguarded — and the one place where the throw
cannot be caught by anything.

## The second half: overlapping joins stack listeners onto one connection

`joinChannel()` has no mutex, and it `await`s `entersState(…, 20_000)` **before**
registering the connection, so the window in which a second join sees an empty
`this.connections` map is up to twenty seconds wide. Two live production callers
reach it without synchronisation:

| caller | path |
|---|---|
| `/voice mode:join` | `slash-commands.ts:548` |
| ready-time autonomous join | `voice.ts:1704` (`scanGuild`), called from `service.ts:3681` |

`joinVoiceChannel()` does **not** create a second connection in that case — it
returns the connection it is already tracking for the same `(group, guildId)`
(`createVoiceConnection`, `dist/index.js:2659-2677`), and the group here is
constant (`this.client?.user?.id ?? "default-group"`, `voice.ts:630`). Confirmed
against the real installed library:

```
$ node probe.cjs
same object on second joinVoiceChannel?  true
c1.state.status = signalling
after destroy status = destroyed
second destroy threw: Cannot destroy VoiceConnection - it has already been destroyed
new object after destroy?  true
```

So the second `joinChannel()` attaches a **second copy** of the `stateChange` and
`error` listeners to the *same* connection, and nothing ever removes them. On the
next confirmed disconnect both copies run the teardown above, both call
`connection.destroy()`, and the loser throws — the same fatal unhandled
rejection, this time with no user action beyond joining twice. The duplicated
handler also double-fires `unregisterVoiceTarget()` and
`stopVoiceTranscription()`.

## What the fix is, and where the pattern comes from

`plugins/plugin-elizacloud/src/services/cloud-bridge.ts` already solves exactly
this shape — every listener it installs re-checks that it still owns the map
entry before touching shared state, and a superseded handler cleans up only
itself:

```ts
ws.addEventListener("close", (event) => {
  // A late close must clean up its own timer without mutating the replacement.
  if (this.connections.get(containerId) !== conn) {
    if (conn.heartbeatTimer) clearInterval(conn.heartbeatTimer);
    return;
  }
```

(`cloud-bridge.ts:141`, `154`, `189`, `210`, `237`.) `voice.ts` had no such guard
on any of its `this.connections` writes. This PR mirrors it:

1. **Wire each `VoiceConnection` at most once.** A `WeakSet<VoiceConnection>`
   records which connections this manager has already attached lifecycle
   listeners to, because `joinVoiceChannel()` may hand back an already-wired one.
2. **Never destroy a destroyed connection.** The Disconnected teardown and the
   failed-join teardown (`voice.ts:886`) both check
   `connection.state.status !== VoiceConnectionStatus.Destroyed` first.
3. **Identity-check every `this.connections` write in the listener.** The
   Disconnected branch captures ownership *before* destroying; the Destroyed
   branch clears the entry only when `this.connections.get(channel.id) ===
   connection`.

## On the framing this started from

The lead this work started from claimed the stale handler *evicts a live map
entry*, orphaning a still-connected `VoiceConnection`. That is **not** what
happens, and the probe above is why: two racing joins do not produce two distinct
live connections, so there is no live entry to evict. Guard (3) is still correct
and is what `cloud-bridge.ts` does, but the defect that is actually reachable —
and the one the tests pin — is the fatal double `destroy()`. Stating that
plainly rather than filing the stronger-sounding claim.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`joinChannel()`'s `stateChange` listener in `plugins/plugin-discord/voice.ts`,
then `plugins/plugin-discord/__tests__/voice-connection-lifecycle.test.ts`.

## Detailed testing steps

```bash
git fetch origin develop && git checkout <this branch>
bun install
node packages/shared/scripts/generate-keywords.mjs
cd plugins/plugin-discord
../../node_modules/.bin/vitest run --config ./vitest.config.ts \
  __tests__/voice-connection-lifecycle.test.ts
```

The new suite drives the real `VoiceManager` against the real `@discordjs/voice`
stack through a stub voice adapter (no gateway socket), so `joinVoiceChannel()`
de-duplication and `destroy()`'s throw-on-already-destroyed behave exactly as
they do in production. Disconnects are driven with the real
`connection.onNetworkingClose(4014)` — Discord's "do not reconnect" close code.

### 1. Origin reproduction — the unchanged test file on `origin/develop`

`plugins/plugin-discord/voice.ts` was restored to
`8e5e0ff034704511e777527a4d0f02440a00940f` by copy-aside (never `git stash`) and
the same test file re-run:

```
 x survives a leave issued while the reconnect probe is still open 6081ms
AssertionError: expected [ Array(1) ] to deeply equal []
+ [
+   "Cannot destroy VoiceConnection - it has already been destroyed",
+ ]

 x installs exactly one lifecycle listener when two joins overlap 1ms
AssertionError: expected 2 to be 1

 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

The one that **passes** on origin is the third case — an ordinary confirmed
disconnect with no leave and no second join. That is the no-over-rejection
control: origin's teardown is correct there and must stay correct.

### 2. AFTER — the same file on this branch

```
 Test Files  5 passed (5)
      Tests  45 passed (45)
```

(`voice-connection-lifecycle`, `voice`, `voice-meetings`,
`voice-target-registry`, `slash-commands`.)

### 3. No over-rejection — the whole plugin suite

```
 Test Files  90 passed (90)
      Tests  738 passed (738)
   Duration  63.89s
```

### 4. Typecheck against an untouched control

```
$ bun run --cwd plugins/plugin-discord typecheck     # branch
$ bun run --cwd plugins/plugin-discord typecheck     # control: voice.ts restored
                                                     # to HEAD, new test removed
$ diff tc-control.txt tc-branch.txt
(no output)
```

Both print the same five pre-existing errors, all unbuilt workspace deps
(`@elizaos/cloud-routing`, `@elizaos/vault`, `@elizaos/plugin-commands`). **The
branch adds zero typecheck errors.**

### 5. Lint

```
$ bunx @biomejs/biome check voice.ts __tests__/voice-connection-lifecycle.test.ts
Checked 2 files in 29ms. No fixes applied.
```

# Known gaps / failures

- `bun run verify` was **not** run monorepo-wide. The change is confined to one
  method in one plugin file; the whole `plugin-discord` suite, the package
  typecheck against a control, and biome on both touched files were run instead.
- We are a fork contributor without push access, so no hosted CI check ran on
  this PR. Every result above is from a local run and is pasted verbatim.
- The suite spends ~12s in real `setTimeout` waits, because the 5s reconnect
  probe is the thing under test and faking those timers would stop exercising the
  real `entersState` deadline.
- `listenerCount("error")` is deliberately not asserted: each still-pending
  `entersState` loser from `Promise.race` holds an `error` listener of its own
  until its 20s deadline, so that count is not a stable property of this change.
- `handleJoinChannelCommand()` (`voice.ts:2089`) is a third `joinChannel()`
  caller, but `git grep` finds no live interaction dispatcher for it — its only
  non-test caller is `plugins/plugin-discord/tests.ts`. It is not counted as a
  production path above.
- The pre-existing 20s `entersState(Ready)` loser inside `joinChannel()`'s
  `Promise.race` keeps a timer alive after the race resolves. It is harmless
  (`Promise.race` handles the rejection) and is left untouched here.

# Evidence Gate

<!-- evidence-head:db49557908da9302fb2476994abdcdb468502035 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only change to one plugin service module; no rendered UI surface is touched by this diff.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only change to one plugin service module; no rendered UI surface is touched by this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - the observable behaviour is whether the agent process survives a leave issued during the reconnect probe, shown as before/after transcripts below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — pasted below (the
      real `VoiceManager` driven against the real `@discordjs/voice` stack, first
      with `voice.ts` restored to `origin/develop`, then on this branch).

<details><summary>BEFORE — <code>voice.ts</code> restored to <code>8e5e0ff03470</code> by copy-aside</summary>

```
 RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/worktrees/eliza-mine-voice-20260821/plugins/plugin-discord

 ❯ __tests__/voice-connection-lifecycle.test.ts (3 tests | 2 failed) 12087ms
     × survives a leave issued while the reconnect probe is still open 6081ms
     × installs exactly one lifecycle listener when two joins overlap 1ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  __tests__/voice-connection-lifecycle.test.ts > VoiceManager voice-connection lifecycle > survives a leave issued while the reconnect probe is still open
AssertionError: expected [ Array(1) ] to deeply equal []

- Expected
+ Received

- []
+ [
+   "Cannot destroy VoiceConnection - it has already been destroyed",
+ ]

 ❯ __tests__/voice-connection-lifecycle.test.ts:111:31
    109|   await afterReconnectProbe();
    110|
    111|   expect(rejectionMessages()).toEqual([]);
       |                               ^
    112|   expect(manager.getVoiceConnection("guild-leave")).toBeUndefined();
    113|  }, 30_000);

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  __tests__/voice-connection-lifecycle.test.ts > VoiceManager voice-connection lifecycle > installs exactly one lifecycle listener when two joins overlap
AssertionError: expected 2 to be 1 // Object.is equality

- Expected
+ Received

- 1
+ 2

 ❯ __tests__/voice-connection-lifecycle.test.ts:129:51

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯

 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
   Start at  23:46:01
   Duration  17.90s (transform 4.17s, setup 89ms, import 5.62s, tests 12.09s, environment 0ms)
```

</details>

<details><summary>AFTER — the same test file on this branch</summary>

```
 RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/worktrees/eliza-mine-voice-20260821/plugins/plugin-discord

 Test Files  5 passed (5)
      Tests  45 passed (45)
   Start at  23:45:21
   Duration  25.78s (transform 11.06s, setup 287ms, import 17.44s, tests 18.30s, environment 0ms)
```

</details>

<details><summary>Whole <code>plugin-discord</code> suite on this branch</summary>

```
 RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/worktrees/eliza-mine-voice-20260821/plugins/plugin-discord

 Test Files  90 passed (90)
      Tests  738 passed (738)
   Start at  23:47:31
   Duration  63.89s (transform 15.32s, setup 2.13s, import 86.60s, tests 29.56s, environment 5ms)
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path; VoiceManager runs inside the agent process only.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behaviour changes; this is voice-connection lifecycle bookkeeping.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the artifact is the `VoiceConnection` lifecycle itself —
      what the installed `@discordjs/voice` actually does on a second
      `joinVoiceChannel()` and a second `destroy()`, which is what the whole
      diagnosis rests on.
  <details><summary>Real <code>@discordjs/voice@0.19.2</code> driven directly</summary>

  ```
  $ node probe.cjs
  same object on second joinVoiceChannel?  true
  c1.state.status = signalling
  after destroy status = destroyed
  second destroy threw: Cannot destroy VoiceConnection - it has already been destroyed
  new object after destroy?  true
  ```

  And what an unhandled rejection from an async EventEmitter listener does to
  each runtime:

  ```
  $ node urej.mjs
  Error: boom from async listener
      at EventEmitter.<anonymous> (urej.mjs:3:31)
      at EventEmitter.emit (node:events:509:28)
  node exit=1

  $ bun urej.mjs
  error: boom from async listener
        at <anonymous> (urej.mjs:3:35)
        at emit (node:events:92:22)
  bun exit=1
  ```

  </details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behaviour changes.`

## Backend + frontend logs

Backend: inline in **Testing → 1, 2, 3, 4, 5** and in the Evidence Gate blocks
above — the real `VoiceManager` driven against the real `@discordjs/voice` stack,
the copy-aside revert arm, the whole plugin suite, the typecheck control diff,
and biome.

Frontend: `N/A - no frontend code path.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no audio, STT, TTS, transcription or playback behaviour changes. The diff
only decides whether a lifecycle listener is installed and whether a handler
still owns the connection map entry it is about to mutate; the audio pipeline in
this file is untouched.`

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251-voice]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JQP4PQTYDPGKYR7VBN67JS","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T18:00:17.880Z","completed_at":"2026-08-21T18:20:58.202Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T18:00:18.871Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"7ff89e370cc87c2ff81549c26f50072b246bdbbec819882440cc67f8c3e662a9","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"f7e8ef53-5d55-4c30-8667-290dde1fc000","object_id":"sha256:7ff89e370cc87c2ff81549c26f50072b246bdbbec819882440cc67f8c3e662a9","sha256":"7ff89e370cc87c2ff81549c26f50072b246bdbbec819882440cc67f8c3e662a9"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"rfIyB5v6GL8hoxMm2ARO9Oy0hpuM_SSVR74hRIWKxV_eVfyNyxsBjPXTTRMhEnbCFXL1PXMQwWUIIOv4xkHWCA"}} -->
