### PR TITLE
fix(plugin-mcp): make the stdio reconnect ladder reachable

### DIFF
--- a/plugins/plugin-mcp/__tests__/service-reconnect-ladder.test.ts
+++ b/plugins/plugin-mcp/__tests__/service-reconnect-ladder.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests the McpService stdio reconnect ladder.
+ *
+ * A stdio server that never comes back must climb the exponential backoff and
+ * stop after MAX_RECONNECT_ATTEMPTS; a server that does come back must
+ * reconnect and get its ladder reset, so a transient outage is never punished.
+ *
+ * Deterministic unit harness on fake timers. The real private methods
+ * (initializeConnection, deleteConnection, setupTransportHandlers,
+ * handleDisconnection) run unmodified — only the MCP SDK client and the stdio
+ * transport builder are replaced by local re-implementations, because those are
+ * the two places that would otherwise spawn a child process.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const handshake = vi.hoisted(() => ({ fails: false }));
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => {
+  class LocalClient {
+    async connect(): Promise<void> {
+      if (handshake.fails) {
+        throw new Error("MCP handshake failed");
+      }
+    }
+    getServerCapabilities(): Record<string, never> {
+      return {};
+    }
+    async listTools(): Promise<{ tools: [] }> {
+      return { tools: [] };
+    }
+    async listResources(): Promise<{ resources: [] }> {
+      return { resources: [] };
+    }
+    async listResourceTemplates(): Promise<{ resourceTemplates: [] }> {
+      return { resourceTemplates: [] };
+    }
+    async close(): Promise<void> {}
+  }
+  return { Client: LocalClient };
+});
+
+import { McpService } from "../src/service";
+import {
+  BACKOFF_MULTIPLIER,
+  DEFAULT_PING_CONFIG,
+  INITIAL_RETRY_DELAY,
+  MAX_RECONNECT_ATTEMPTS,
+  type McpConnection,
+  type McpServerConfig,
+  type PingConfig,
+} from "../src/types";
+
+const STDIO: McpServerConfig = { type: "stdio", command: "bun", args: ["server.mjs"] };
+
+type LadderInternals = {
+  runtime: { reportError: ReturnType<typeof vi.fn> };
+  connections: Map<string, McpConnection>;
+  connectionStates: Map<string, { status: string; reconnectAttempts: number }>;
+  pingConfig: PingConfig;
+  initializeConnection: (name: string, config: McpServerConfig) => Promise<void>;
+  buildStdioClientTransport: (name: string, config: McpServerConfig) => Promise<unknown>;
+};
+
+/** Every delay handed to setTimeout while the fake clock is installed. */
+let scheduledDelays: number[] = [];
+let restoreSetTimeout: () => void = () => {};
+
+function armedReconnectDelay(): number | undefined {
+  const ladderDelays = scheduledDelays.filter((ms) => ms >= INITIAL_RETRY_DELAY);
+  return ladderDelays.at(-1);
+}
+
+function makeService(): LadderInternals {
+  const service = new McpService() as unknown as LadderInternals;
+  service.runtime = { reportError: vi.fn() };
+  // The ladder is transport-driven; the periodic ping only feeds the same
+  // handleDisconnection entry point, so it is off here to keep the fake clock
+  // showing nothing but reconnect delays.
+  service.pingConfig = { ...DEFAULT_PING_CONFIG, enabled: false };
+  service.buildStdioClientTransport = vi.fn(async () => ({
+    close: vi.fn(async () => {}),
+  }));
+  return service;
+}
+
+/** Fires the real transport onclose handler installed by setupTransportHandlers. */
+async function crashChildProcess(service: LadderInternals): Promise<void> {
+  const transport = service.connections.get("srv")?.transport as
+    | { onclose?: () => Promise<void> }
+    | undefined;
+  if (!transport?.onclose) throw new Error("onclose handler was not installed");
+  scheduledDelays = [];
+  await transport.onclose();
+}
+
+/**
+ * Runs the armed reconnect timer, letting the real timer callback and the real
+ * initializeConnection / handleDisconnection run. Returns the delay that was
+ * waited out, or undefined when the service has stopped retrying.
+ */
+async function runNextReconnect(): Promise<number | undefined> {
+  const delayMs = armedReconnectDelay();
+  if (delayMs === undefined) return undefined;
+  scheduledDelays = [];
+  await vi.advanceTimersByTimeAsync(delayMs);
+  return delayMs;
+}
+
+beforeEach(() => {
+  handshake.fails = false;
+  vi.useFakeTimers();
+  scheduledDelays = [];
+  const clockSetTimeout = globalThis.setTimeout;
+  globalThis.setTimeout = ((handler: TimerHandler, ms?: number, ...args: unknown[]) => {
+    scheduledDelays.push(ms ?? 0);
+    return (clockSetTimeout as (...a: unknown[]) => unknown)(handler, ms, ...args);
+  }) as typeof globalThis.setTimeout;
+  restoreSetTimeout = () => {
+    globalThis.setTimeout = clockSetTimeout;
+  };
+});
+
+afterEach(() => {
+  restoreSetTimeout();
+  vi.useRealTimers();
+});
+
+describe("stdio reconnect ladder", () => {
+  it("backs off exponentially and stops after MAX_RECONNECT_ATTEMPTS on a server that never returns", async () => {
+    const service = makeService();
+    await service.initializeConnection("srv", STDIO);
+    expect(service.connections.get("srv")?.server.status).toBe("connected");
+
+    // The child process dies and every later handshake fails.
+    handshake.fails = true;
+    await crashChildProcess(service);
+
+    const observed: Array<{ attempt: number; delayMs: number }> = [];
+    for (let round = 0; round < MAX_RECONNECT_ATTEMPTS * 3; round++) {
+      const delayMs = await runNextReconnect();
+      if (delayMs === undefined) break;
+      observed.push({
+        attempt: service.connectionStates.get("srv")?.reconnectAttempts ?? -1,
+        delayMs,
+      });
+    }
+
+    expect(observed.map((entry) => entry.attempt)).toEqual([1, 2, 3, 4, 5]);
+    expect(observed.map((entry) => entry.delayMs)).toEqual([
+      INITIAL_RETRY_DELAY,
+      INITIAL_RETRY_DELAY * BACKOFF_MULTIPLIER,
+      INITIAL_RETRY_DELAY * BACKOFF_MULTIPLIER ** 2,
+      INITIAL_RETRY_DELAY * BACKOFF_MULTIPLIER ** 3,
+      INITIAL_RETRY_DELAY * BACKOFF_MULTIPLIER ** 4,
+    ]);
+    // The give-up branch is reached, and it is observable rather than silent.
+    expect(armedReconnectDelay()).toBeUndefined();
+    expect(service.runtime.reportError).toHaveBeenCalledWith(
+      "mcp.reconnect",
+      expect.any(Error),
+      expect.objectContaining({ serverName: "srv", attempts: MAX_RECONNECT_ATTEMPTS })
+    );
+  });
+
+  it("reconnects a server that recovers mid-ladder and rearms the full ladder afterwards", async () => {
+    const service = makeService();
+    await service.initializeConnection("srv", STDIO);
+
+    handshake.fails = true;
+    await crashChildProcess(service);
+    expect(await runNextReconnect()).toBe(INITIAL_RETRY_DELAY);
+    expect(await runNextReconnect()).toBe(INITIAL_RETRY_DELAY * BACKOFF_MULTIPLIER);
+
+    // The server comes back before the ladder runs out.
+    handshake.fails = false;
+    expect(await runNextReconnect()).toBe(INITIAL_RETRY_DELAY * BACKOFF_MULTIPLIER ** 2);
+    expect(service.connections.get("srv")?.server.status).toBe("connected");
+    expect(service.connectionStates.get("srv")?.reconnectAttempts).toBe(0);
+    expect(service.runtime.reportError).not.toHaveBeenCalled();
+
+    // A later outage gets a full fresh ladder, not an immediate give-up.
+    handshake.fails = true;
+    await crashChildProcess(service);
+    expect(armedReconnectDelay()).toBe(INITIAL_RETRY_DELAY);
+    expect(await runNextReconnect()).toBe(INITIAL_RETRY_DELAY);
+    expect(armedReconnectDelay()).toBe(INITIAL_RETRY_DELAY * BACKOFF_MULTIPLIER);
+  });
+
+  it("keeps reconnecting a flapping server whose every reconnect succeeds", async () => {
+    const service = makeService();
+    await service.initializeConnection("srv", STDIO);
+
+    const delays: number[] = [];
+    for (let cycle = 0; cycle < MAX_RECONNECT_ATTEMPTS * 2 + 2; cycle++) {
+      await crashChildProcess(service);
+      const delayMs = await runNextReconnect();
+      expect(delayMs).toBe(INITIAL_RETRY_DELAY);
+      delays.push(delayMs as number);
+      expect(service.connections.get("srv")?.server.status).toBe("connected");
+    }
+
+    expect(delays).toHaveLength(MAX_RECONNECT_ATTEMPTS * 2 + 2);
+    expect(service.runtime.reportError).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-mcp/src/service.ts
+++ b/plugins/plugin-mcp/src/service.ts
@@ -250,11 +250,29 @@ export class McpService extends Service {
     await Promise.all(connectionPromises);
   }
 
-  private async initializeConnection(name: string, config: McpServerConfig): Promise<void> {
+  /**
+   * Builds (or rebuilds) one server's connection.
+   *
+   * `deleteConnection` drops this server's `ConnectionState`, so the retry
+   * ladder in `handleDisconnection` only survives when the caller asks for it:
+   * a reconnect passes `preserveReconnectAttempts` so the count keeps climbing
+   * toward `MAX_RECONNECT_ATTEMPTS` and the backoff keeps doubling, while a
+   * config change or an operator-driven `restartConnection` starts a fresh
+   * ladder. The count is reset to 0 below on every successful connect, so a
+   * server that comes back is never penalised for an earlier outage.
+   */
+  private async initializeConnection(
+    name: string,
+    config: McpServerConfig,
+    options: { readonly preserveReconnectAttempts?: boolean } = {}
+  ): Promise<void> {
+    const carriedReconnectAttempts = options.preserveReconnectAttempts
+      ? (this.connectionStates.get(name)?.reconnectAttempts ?? 0)
+      : 0;
     await this.deleteConnection(name);
     const state: ConnectionState = {
       status: "connecting",
-      reconnectAttempts: 0,
+      reconnectAttempts: carriedReconnectAttempts,
       consecutivePingFailures: 0,
     };
     this.connectionStates.set(name, state);
@@ -402,6 +420,14 @@ export class McpService extends Service {
     if (state.pingInterval) clearInterval(state.pingInterval);
     if (state.reconnectTimeout) clearTimeout(state.reconnectTimeout);
     if (state.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      logger.error(
+        { serverName: name, attempts: state.reconnectAttempts, error: state.lastError?.message },
+        `Giving up on MCP server "${name}" after ${MAX_RECONNECT_ATTEMPTS} failed reconnect attempts`
+      );
+      this.runtime.reportError("mcp.reconnect", state.lastError, {
+        serverName: name,
+        attempts: state.reconnectAttempts,
+      });
       return;
     }
     const delay = INITIAL_RETRY_DELAY * BACKOFF_MULTIPLIER ** state.reconnectAttempts;
@@ -411,7 +437,9 @@ export class McpService extends Service {
       const config = connection?.server?.config;
       if (config) {
         try {
-          await this.initializeConnection(name, JSON.parse(config));
+          await this.initializeConnection(name, JSON.parse(config), {
+            preserveReconnectAttempts: true,
+          });
         } catch (err) {
           // error-policy:J5 background reconnect; failure is observed in
           // handleDisconnection, which records lastError and backs off (capped).


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #23907 (owning issue, filed for this work, carrying the origin
reproduction verbatim and the same scope limits stated below).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched off `origin/develop`
      (`61ec478faafe3b5058c19b620053492cc8d814c5`) with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched off `origin/develop` @ `61ec478faafe3b5058c19b620053492cc8d814c5`;
      zero conflicts. `develop` has since advanced to `c56e80e2af5f`, and
      `git diff 61ec478faafe c56e80e2af5f -- plugins/plugin-mcp/` is **empty**,
      so the reproduction and the diff describe the current tip exactly.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low, and the one axis that matters here is **over-rejection**: a bound that
starts giving up on servers which recover today would be worse than the bug. So
two of the three new tests exist only to prove that does not happen, and one of
them **passes on `develop` as well as on this branch**.

| Server behaviour | Before | After |
| --- | --- | --- |
| connects, dies, reconnects fine (flapping) | retries forever at 2000 ms | **unchanged** — retries forever at 2000 ms |
| fails twice, then comes back | reconnects | reconnects; ladder resets to 0; a later outage gets a full fresh ladder |
| operator `restartConnection` | fresh ladder | **unchanged** — fresh ladder |
| config change via `updateServerConnections` | fresh ladder | **unchanged** — fresh ladder |
| handshake never succeeds again | respawns the child forever, flat 2000 ms | 5 attempts at 2000/4000/8000/16000/32000 ms, then stop and report |

The counter is carried forward **only** on the reconnect-timer path. Every other
caller of `initializeConnection` keeps today's behaviour byte for byte, and
`state.reconnectAttempts = 0` on a successful connect (`service.ts:299`, already
there) is what guarantees a recovered server is never penalised for an earlier
outage.

The one behaviour that is genuinely new is that a permanently broken server now
**stops** being retried. That is the change being proposed, it is what the
existing `MAX_RECONNECT_ATTEMPTS` constant was written to do, and it is now
observable (`logger.error` + `runtime.reportError("mcp.reconnect", …)`) rather
than a silent `return`.

# Background

## What does this PR do?

`plugins/plugin-mcp/src/service.ts` already ships a complete reconnect ladder —
`MAX_RECONNECT_ATTEMPTS = 5`, `BACKOFF_MULTIPLIER = 2`,
`INITIAL_RETRY_DELAY = 2000`, a give-up branch at `:404`, an exponential delay
at `:407`. **None of it could run.** This is not a missing guard; it is an
existing guard that was dead by construction.

`handleDisconnection` (`:397`) reads `state.reconnectAttempts` for both the
give-up test and the delay, arms a timer, and the callback increments the count
and reconnects:

```ts
const delay = INITIAL_RETRY_DELAY * BACKOFF_MULTIPLIER ** state.reconnectAttempts;
state.reconnectTimeout = setTimeout(async () => {
  state.reconnectAttempts++;
  ...
  await this.initializeConnection(name, JSON.parse(config));
```

`initializeConnection` (`:253`) opens with `deleteConnection`, which does
`this.connectionStates.delete(name)` (`:445`), and then unconditionally installs
a brand-new `ConnectionState` with `reconnectAttempts: 0` (`:257`). The object
the timer just incremented is discarded before anything reads it again, so the
next `handleDisconnection` reads `0` back from the replacement — forever.

Consequences, both permanent:

1. `state.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS` is never true.
2. `delay` is always `2000 * 2 ** 0` — the backoff never doubles.

The tell that this is a bug and not a design choice is `:299`: the service
already resets `state.reconnectAttempts = 0` after a *successful* connect. That
line is redundant against a constructor that just zeroed the field, and it only
makes sense if the counter was meant to survive `initializeConnection`.

### Why this matters

`StdioClientTransport.start()` spawns the child process from inside
`client.connect()`, and `initializeConnection` sets `this.connections` **before**
that call (`:277-279`). So when a stdio MCP server's handshake fails — binary
removed, missing dependency, crash on startup, bad credentials — the throw
leaves the config in place, the timer's `this.connections.get(name)` still finds
it, and the chain re-arms. A permanently broken server is respawned every 2
seconds for the lifetime of the agent, with no ceiling and no diagnostic.

### Containment does not apply

There is no error boundary that swallows this, because there is nothing to
swallow: the defect is an unbounded `setTimeout` chain that **raises nothing**
and keeps succeeding at re-arming itself. The reconnect timer's own
`error-policy:J5` catch is the loop, not a boundary — it calls
`handleDisconnection`, which schedules the next attempt.
`updateServerConnections`' `error-policy:J4` catch covers only the *initial*
connect and never calls `handleDisconnection`, so it neither starts nor stops
this loop.

### The fix

`initializeConnection` gains one optional `{ preserveReconnectAttempts }`
option. The reconnect timer is the only caller that passes it. That keeps the
blast radius to exactly the path with the defect:

```ts
const carriedReconnectAttempts = options.preserveReconnectAttempts
  ? (this.connectionStates.get(name)?.reconnectAttempts ?? 0)
  : 0;
await this.deleteConnection(name);
```

and the previously dead give-up branch stops returning silently:

```ts
if (state.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
  logger.error({ serverName: name, attempts: …, error: state.lastError?.message }, …);
  this.runtime.reportError("mcp.reconnect", state.lastError, { serverName: name, attempts: … });
  return;
}
```

`reportError` is core's documented diagnostic boundary and never throws
(`packages/core/src/types/runtime.ts:1017-1033`), so making the branch
observable cannot itself destabilise a timer callback.

No constant changed. No new limit was invented. The ladder that
`MAX_RECONNECT_ATTEMPTS` describes simply runs now.

### Alternatives considered, and why not

- **Always preserve the count in `initializeConnection`.** Rejected: it would
  also change `restartConnection` and `updateServerConnections`, so an operator
  hitting restart on a server sitting at attempt 5 would get an immediate
  give-up. The option keeps those two paths identical to today.
- **Move the `reconnectAttempts++` out of the timer callback.** Does not help —
  the reset in `initializeConnection` is what erases it, wherever the increment
  lives.
- **Store the counter outside `ConnectionState`.** More invasive, and it would
  split the ladder away from the `lastError`/`reconnectTimeout` it belongs with.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

## Reachability, stated honestly

`@elizaos/plugin-mcp` is commented out of
`packages/agent/src/runtime/core-plugins.ts:443` — MCP support is **opt-in**,
not enabled for every agent. It is not dead code: `packages/agent/src/api/server.ts:174`
maps the `mcp` capability key to `@elizaos/plugin-mcp` in
`optionalPluginSpecifiers` / `optionalPluginImports`, the same mechanism that
loads `plugin-signal`, `plugin-whatsapp` and `plugin-elizacloud`, and
`packages/agent/package.json` depends on it as `workspace:*`. So this affects
agents that have MCP turned on, which is the plugin's whole audience — I am not
claiming it affects every install.

# Documentation changes needed?

My changes do not require a change to the project documentation. The class
docstring at `service.ts:12-13` already states that stdio connections are
"reconnected with exponential backoff"; this PR makes that sentence true.

# Testing

## Where should a reviewer start?

`plugins/plugin-mcp/__tests__/service-reconnect-ladder.test.ts`. It drives the
**real** `initializeConnection`, `deleteConnection`, `setupTransportHandlers`
and `handleDisconnection` on fake timers. Only two things are replaced by local
re-implementations — `@modelcontextprotocol/sdk/client/index.js` and the private
`buildStdioClientTransport` — because those are the two places that would
otherwise spawn a child process. Reconnect delays are read by wrapping the fake
clock's `setTimeout`, so the assertions observe the delay the service actually
asked for rather than a derived value.

Three tests:

1. **`backs off exponentially and stops after MAX_RECONNECT_ATTEMPTS on a
   server that never returns`** — load-bearing; fails on `develop`. Asserts the
   attempt sequence `1,2,3,4,5`, the delay sequence
   `2000,4000,8000,16000,32000`, that no timer is armed afterwards, and that the
   give-up is reported.
2. **`reconnects a server that recovers mid-ladder and rearms the full ladder
   afterwards`** — load-bearing; fails on `develop` (on the flat backoff). Its
   second half is the over-rejection guard: after a successful recovery the
   counter is back at `0` and a later outage gets a full fresh ladder starting
   at 2000 ms, not an immediate give-up.
3. **`keeps reconnecting a flapping server whose every reconnect succeeds`** —
   compatibility; **passes on `develop` too**. Twelve crash/recover cycles
   (more than twice the cap) with no give-up and no `reportError`, so a server
   that keeps coming back is never bounded out.

## Detailed testing steps

```
git checkout mine/mcp-reconnect-ladder-20260821
bun install --frozen-lockfile
bun run --cwd packages/cloud/routing build
(cd packages/core && node ../shared/scripts/generate-keywords.mjs)
bun run --cwd plugins/plugin-mcp test
bun run --cwd plugins/plugin-mcp typecheck
bunx @biomejs/biome check \
  plugins/plugin-mcp/src/service.ts \
  plugins/plugin-mcp/__tests__/service-reconnect-ladder.test.ts
```

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-head:7eb7783065f1b31183c3e1a22c1a9ab7e73dcd3d -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - node-only service lifecycle module and its tests; no rendered UI surface in the diff.

<!-- evidence-row:after-screenshots -->
- [x] N/A - node-only service lifecycle module and its tests; no rendered UI surface in the diff.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered user flow in this change.

<!-- evidence-row:backend-logs -->
- [x] The ladder failing to engage, captured from the real `handleDisconnection` on unmodified `develop`. `plugins/plugin-mcp/src/service.ts` in that tree is byte-identical to `origin/develop` (`shasum` `dd5a7da8d438f80d2db7aca7e9fdf352c56ff410`):

```text
 RUN  v4.1.10 .../plugins/plugin-mcp

 ❯ __tests__/service-reconnect-ladder.test.ts (3 tests | 2 failed) 13ms
     × backs off exponentially and stops after MAX_RECONNECT_ATTEMPTS on a server that never returns 9ms
     × reconnects a server that recovers mid-ladder and rearms the full ladder afterwards 1ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  __tests__/service-reconnect-ladder.test.ts > stdio reconnect ladder > backs off exponentially and stops after MAX_RECONNECT_ATTEMPTS on a server that never returns
AssertionError: expected [ Array(15) ] to deeply equal [ 1, 2, 3, 4, 5 ]

- Expected
+ Received

  [
-   1,
-   2,
-   3,
-   4,
-   5,
+   0,
+   0,
+   0,
+   0,
+   0,
+   0,
+   0,
+   0,
+   0,
+   0,
+   0,
+   0,
+   0,
+   0,
+   0,
  ]

 ❯ __tests__/service-reconnect-ladder.test.ts:148:52

 FAIL  __tests__/service-reconnect-ladder.test.ts > stdio reconnect ladder > reconnects a server that recovers mid-ladder and rearms the full ladder afterwards
AssertionError: expected 2000 to be 4000 // Object.is equality

- Expected
+ Received

- 4000
+ 2000

 ❯ __tests__/service-reconnect-ladder.test.ts:172:38

 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

Fifteen reconnect rounds — three times the cap — every one of them at attempt
`0`, and the loop was still running when the test's own bound stopped it. The
second failure is the flat backoff: round two asked for 2000 ms where the
ladder calls for 4000 ms. The one test that passes here is the flapping-server
compatibility test.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser, console, or network hop in this unit.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model *behaviour* changed; this is a connection-lifecycle retry bound. (A device-signed private-trace receipt for this run is finalized in the footer below.)

<!-- evidence-row:domain-artifacts -->
- [x] Origin reproduction, load-bearing copy-aside revert, the after state, the full package suite, typecheck and lint — all at this exact head (inline transcript).
<details>
<summary>domain receipt</summary>

```text
head:              7eb7783065f1b31183c3e1a22c1a9ab7e73dcd3d
branch base:       61ec478faafe3b5058c19b620053492cc8d814c5 (origin/develop)
develop tip now:   c56e80e2af5fb1675dfa2d7026439c100fe9c7d2
  `git diff 61ec478faafe c56e80e2af5f -- plugins/plugin-mcp/` is EMPTY, so the
  base describes the current tip for every file this PR touches.

=== 1. ORIGIN REPRODUCTION ===

Unmodified develop tree; plugins/plugin-mcp/src/service.ts shasum
dd5a7da8d438f80d2db7aca7e9fdf352c56ff410 (byte-identical to origin/develop).

$ ../../node_modules/.bin/vitest run --config ./vitest.config.ts \
    __tests__/service-reconnect-ladder.test.ts
 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
exit 1

(Assertions in the backend-logs row above.)

=== 2. AFTER THE FIX, SAME FILE ===

$ ../../node_modules/.bin/vitest run --config ./vitest.config.ts \
    __tests__/service-reconnect-ladder.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
   Duration  5.89s
exit 0

=== 3. LOAD-BEARING REVERT CHECK (copy-aside, never `git stash`) ===

Production file reverted to the branch base with the test file kept:

$ cp plugins/plugin-mcp/src/service.ts <aside>
$ git show 61ec478faafe:plugins/plugin-mcp/src/service.ts \
    > plugins/plugin-mcp/src/service.ts
$ shasum plugins/plugin-mcp/src/service.ts
dd5a7da8d438f80d2db7aca7e9fdf352c56ff410   <- back to the develop bytes

$ ../../node_modules/.bin/vitest run --config ./vitest.config.ts \
    __tests__/service-reconnect-ladder.test.ts
 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)

  ... > reconnects a server that recovers mid-ladder and rearms the full ladder afterwards
  AssertionError: expected 2000 to be 4000 // Object.is equality

Fix restored from the copy-aside:
$ cp <aside> plugins/plugin-mcp/src/service.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)

The same two tests fail for the same two reasons as the origin run, and the
third passes on both sides. The bound is load-bearing; the compatibility test
is not.

=== 4. FULL plugin-mcp SUITE AT THIS HEAD ===

$ bun run --cwd plugins/plugin-mcp test
 RUN  v4.1.10 .../plugins/plugin-mcp
 Test Files  16 passed (16)
      Tests  126 passed | 3 skipped (129)
exit 0

(Whole package, not just the new file: the pre-existing
service-resilience.test.ts, which pins the J4 per-server containment and the
HTTP transport-error tolerance around the same handlers, passes unchanged.)

=== 5. TYPECHECK ===

$ bun run --cwd plugins/plugin-mcp typecheck
$ tsc --noEmit
exit 0

Zero `error TS` lines on the branch, so no control diff is needed — the branch
adds zero typecheck errors because the package has zero.

=== 6. LINT ===

$ bunx @biomejs/biome check plugins/plugin-mcp/src/service.ts \
                            plugins/plugin-mcp/__tests__/service-reconnect-ladder.test.ts
Checked 2 files in 21ms. No fixes applied.
exit 0

=== 7. DIFF SHAPE ===

$ git status --porcelain
 M plugins/plugin-mcp/src/service.ts
?? plugins/plugin-mcp/__tests__/service-reconnect-ladder.test.ts

$ git diff --stat 61ec478faafe...HEAD
 .../__tests__/service-reconnect-ladder.test.ts     | 205 +++++++++++++++++++++
 plugins/plugin-mcp/src/service.ts                  |  34 +++-
 2 files changed, 236 insertions(+), 3 deletions(-)

Production delta: one optional parameter, one carried value, one option passed
by one caller, and the log/report inside the branch that was already there.
No constant changed.
```

</details>

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface in this change.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behaviour changed. This is a
connection-lifecycle retry bound inside `McpService`; tool discovery, tool
schemas, `callTool` and the provider payload are untouched, which section 4 of
the domain receipt demonstrates against the whole existing package suite. A
device-signed, trace-finalized private-trace receipt for this run is in the
footer.

## Backend + frontend logs

Backend: the origin-reproduction block in the **backend-logs** row is the real
code path failing — the real `handleDisconnection` re-arming its timer fifteen
times at attempt `0` and a flat 2000 ms, on unmodified `develop`.

Frontend: N/A - no browser hop in this unit.

## Screenshots (before / after) + video walkthrough

N/A - node-only service module and its tests; no rendered UI surface in the diff.

### Before

N/A - no rendered UI surface.

### After

N/A - no rendered UI surface.

### Walkthrough video

N/A - no rendered user flow.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

- **No live child-process reproduction.** The harness stops the SDK at
  `Client.connect` and at `buildStdioClientTransport` rather than spawning a
  real crash-looping MCP server, so the "respawned every 2 seconds forever"
  impact is an inference from `StdioClientTransport.start()` spawning inside
  `connect()` plus the proven fifteen-round retry loop — not something I timed
  against a real process. The counter reset and the flat backoff themselves are
  executed, not inferred.
- **The vendored cloud fork has the same defect and is not fixed here.**
  `packages/cloud/shared/src/lib/eliza/plugin-mcp/service.ts` rebuilds
  `ConnectionState` with `reconnectAttempts: 0` in `connect()` (`:191`) and
  reads it back in `handleDisconnect()` (`:387`), and its
  `logger.error("[MCP] Max reconnect attempts for …")` is dead for exactly the
  same reason. I left it out deliberately so this PR stays one file and one
  mechanism; it is recorded in #23907 and is a clean follow-up.
- **A separate stale-completion defect exists in this same file** (a reconnect
  that lands after a newer one can overwrite the newer connection's status).
  Different mechanism, different fix; not addressed here and not claimed.
- **The interleaving I did not model.** A real `StdioClientTransport.close()`
  can drive the child's `close` event and therefore `onclose` on a later tick,
  which can re-enter `handleDisconnection` from a torn-down transport. The
  harness's transport does not synthesize that, so the reproduction is of the
  ordinary sequence only. It does not change the finding — on `develop` every
  path reads a freshly zeroed counter, and after this change every path shares
  one counter that is bounded — but it is the reason I state "the ladder never
  engages in the ordinary reconnect sequence, proven" rather than a blanket
  claim about every possible interleaving.
- **`reportError` on the give-up branch is a new call.** It is core's documented
  never-throwing diagnostic boundary, and the branch it sits in was previously
  unreachable, so nothing that runs today starts calling it. Reviewers who would
  rather this stayed log-only can say so — it is two lines.
- Root `bun run verify` was **not** run on this head. It is a monorepo-wide gate
  that this tree cannot complete (`@elizaos/cloud-routing` and the core i18n
  keyword table have to be generated first, as the testing steps show). The
  package-scoped suite, typecheck and lint above were executed and are the
  proof.
- Hosted CI check-runs: none on this head. Fork branches on this repository do
  not schedule check-runs; that is repo steady state, not a skipped gate.
- Fork cannot upload `pr-evidence` release assets, so the domain receipt is
  inline.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-mcpladder]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JR9Y2GTDA1R7G99SXEET1K","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T18:11:06.448Z","completed_at":"2026-08-21T18:22:34.267Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T18:11:07.444Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"560d6f9052fec83260c8c9e7d9428b0521c5597460d754f32e05604fa336e584","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"7781e24f-2a53-4a9d-a391-0f2c6621e351","object_id":"sha256:560d6f9052fec83260c8c9e7d9428b0521c5597460d754f32e05604fa336e584","sha256":"560d6f9052fec83260c8c9e7d9428b0521c5597460d754f32e05604fa336e584"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"n0HSHliT44ddeUjkYhikl1xP8hlb4nlfDmiVz1zNRT4QL24uAYwTXRQDAGtSaO5aeqsn2mJ43OxG026Zqla0Aw"}} -->
