### PR TITLE
fix(app-core): stop failing verification of good desktop artifacts

### DIFF
--- a/packages/app-core/scripts/__tests__/package-linux-gtk-artifact.test.ts
+++ b/packages/app-core/scripts/__tests__/package-linux-gtk-artifact.test.ts
@@ -15,16 +15,21 @@ import { execFileSync } from "node:child_process";
 import { createHash, generateKeyPairSync } from "node:crypto";
 import {
   chmodSync,
+  closeSync,
   existsSync,
+  linkSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   readFileSync,
   renameSync,
   rmSync,
   statSync,
   symlinkSync,
   unlinkSync,
+  utimesSync,
   writeFileSync,
+  writeSync,
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -479,6 +484,109 @@ describe("verifyArtifactDir", () => {
         },
       }),
     ).toThrow(/manifest.*changed during verification/);
+  });
+});
+
+describe("archive inspection is independent of $TMPDIR", () => {
+  function withTmpDir<T>(value: string, run: () => T): T {
+    const previous = process.env.TMPDIR;
+    process.env.TMPDIR = value;
+    try {
+      return run();
+    } finally {
+      if (previous === undefined) delete process.env.TMPDIR;
+      else process.env.TMPDIR = previous;
+    }
+  }
+
+  it("verifies a good artifact when $TMPDIR is unusable", () => {
+    const { outDir, publicKeyPem } = produce("x86_64");
+    const unusable = path.join(tempDir(), "no-such-temp-directory");
+    expect(existsSync(unusable)).toBe(false);
+    const manifest = withTmpDir(unusable, () =>
+      verifyArtifactDir(outDir, publicKeyPem),
+    );
+    expect(manifest.archive).toBe("eliza-desktop-gtk-1.2.3-x86_64.tar.zst");
+    expect(existsSync(unusable)).toBe(false);
+  });
+
+  // On macOS, bsdtar itself uses $TMPDIR for extended-attribute scratch and
+  // prints a cosmetic "Could not open extended attribute file" warning here.
+  // It is tar's own behaviour on both arms, not the module's.
+  it("produces a verifiable artifact when $TMPDIR is unusable", () => {
+    const { privateKeyPem, publicKeyPem } = generateSigningKeyPair();
+    const outDir = tempDir();
+    const stageDir = stageShell();
+    const unusable = path.join(tempDir(), "no-such-temp-directory");
+    withTmpDir(unusable, () =>
+      produceArtifact({
+        stageDir,
+        outDir,
+        privateKeyPem,
+        version: "1.2.3",
+        architecture: "x86_64",
+        sourceCommit: COMMIT,
+      }),
+    );
+    expect(verifyArtifactDir(outDir, publicKeyPem).architecture).toBe("x86_64");
+    expect(existsSync(unusable)).toBe(false);
+  });
+});
+
+describe("stability check decides on content, not on metadata churn", () => {
+  it("accepts a no-op chmod during verification", () => {
+    const { result, outDir, publicKeyPem } = produce("x86_64");
+    const before = readFileSync(result.archivePath);
+    const manifest = verifyArtifactDir(outDir, publicKeyPem, {
+      beforeFinalStableFileCheck: ({ archivePath }) => {
+        chmodSync(archivePath, statSync(archivePath).mode & 0o7777);
+      },
+    });
+    expect(manifest.archive).toBe("eliza-desktop-gtk-1.2.3-x86_64.tar.zst");
+    expect(readFileSync(result.archivePath).equals(before)).toBe(true);
+  });
+
+  it("accepts an extra hard link, as a release mirror creates", () => {
+    const { result, outDir, publicKeyPem } = produce("x86_64");
+    const before = readFileSync(result.archivePath);
+    const mirror = path.join(tempDir(), "mirrored.tar.zst");
+    const manifest = verifyArtifactDir(outDir, publicKeyPem, {
+      beforeFinalStableFileCheck: ({ archivePath }) => {
+        linkSync(archivePath, mirror);
+      },
+    });
+    expect(manifest.archive).toBe("eliza-desktop-gtk-1.2.3-x86_64.tar.zst");
+    expect(statSync(result.archivePath).nlink).toBe(2);
+    expect(readFileSync(result.archivePath).equals(before)).toBe(true);
+  });
+
+  it("still rejects a same-size rewrite whose mtime was restored", () => {
+    const { result, outDir, publicKeyPem } = produce("x86_64");
+    const original = readFileSync(result.archivePath);
+    // Pin the timestamps to a value utimes can restore exactly, so the rewrite
+    // below leaves size and mtime identical and only the change time moves.
+    const FORGED_SECONDS = 1_700_000_000;
+    utimesSync(result.archivePath, FORGED_SECONDS, FORGED_SECONDS);
+    const originalMtimeMs = statSync(result.archivePath).mtimeMs;
+    expect(() =>
+      verifyArtifactDir(outDir, publicKeyPem, {
+        beforeFinalStableFileCheck: ({ archivePath }) => {
+          const fd = openSync(archivePath, "r+");
+          try {
+            writeSync(fd, Buffer.from([original[0] ^ 0xff]), 0, 1, 0);
+          } finally {
+            closeSync(fd);
+          }
+          utimesSync(archivePath, FORGED_SECONDS, FORGED_SECONDS);
+        },
+      }),
+    ).toThrow(/archive .* changed during verification/);
+    const after = readFileSync(result.archivePath);
+    expect(after.length).toBe(original.length);
+    expect(after.equals(original)).toBe(false);
+    // The forged mtime is what makes this the one tampering case that size and
+    // mtime cannot see: only the change time moved, and the re-read decided it.
+    expect(statSync(result.archivePath).mtimeMs).toBe(originalMtimeMs);
   });
 });
 

--- a/packages/app-core/scripts/package-linux-gtk-artifact.mjs
+++ b/packages/app-core/scripts/package-linux-gtk-artifact.mjs
@@ -38,12 +38,12 @@ import {
   readdirSync,
   readFileSync,
   readlinkSync,
+  readSync,
   realpathSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -177,24 +177,62 @@ function assertStableFile(handle) {
     namedStats.dev !== handle.stats.dev ||
     namedStats.ino !== handle.stats.ino ||
     currentStats.size !== handle.stats.size ||
-    currentStats.mtimeMs !== handle.stats.mtimeMs ||
-    currentStats.ctimeMs !== handle.stats.ctimeMs
+    currentStats.mtimeMs !== handle.stats.mtimeMs
   ) {
+    fail(`${handle.label} changed during verification`);
+  }
+  if (currentStats.ctimeMs === handle.stats.ctimeMs) return;
+  // Only the inode change time moved: identity, size and modification time all
+  // still match. That is either metadata-only churn that never touched the
+  // verified bytes (a release mirror hard-linking the tree, a chmod sweep, an
+  // xattr-setting scanner) or a same-size rewrite whose mtime was forged. Decide
+  // it on content rather than on the timestamp, by re-reading through the same
+  // descriptor the bytes were verified from. Comparing bytes is strictly
+  // stronger evidence than comparing ctime, so nothing a ctime check rejected
+  // on real tampering is accepted here.
+  if (!descriptorStillHoldsVerifiedBytes(handle)) {
     fail(`${handle.label} changed during verification`);
   }
 }
 
-function inspectArchiveBytes(archiveBytes, inspect) {
-  const inspectionDir = mkdtempSync(
-    path.join(tmpdir(), "eliza-linux-gtk-archive-"),
-  );
-  const snapshotPath = path.join(inspectionDir, "artifact.tar.zst");
-  try {
-    writeFileSync(snapshotPath, archiveBytes, { flag: "wx", mode: 0o600 });
-    return inspect(snapshotPath);
-  } finally {
-    rmSync(inspectionDir, { force: true, recursive: true });
+/**
+ * Re-reads `handle.fd` from offset 0 and reports whether it still yields the
+ * exact bytes that were digested and signature-verified. Positional `readSync`
+ * is required because the descriptor is already at EOF from the initial read.
+ */
+function descriptorStillHoldsVerifiedBytes(handle) {
+  const expected = handle.bytes;
+  const chunk = Buffer.allocUnsafe(Math.min(expected.length, 1 << 20) || 1);
+  let position = 0;
+  while (position < expected.length) {
+    const wanted = Math.min(chunk.length, expected.length - position);
+    const read = readSync(handle.fd, chunk, 0, wanted, position);
+    if (read <= 0) return false;
+    if (
+      !chunk
+        .subarray(0, read)
+        .equals(expected.subarray(position, position + read))
+    ) {
+      return false;
+    }
+    position += read;
   }
+  // A file that grew past the verified bytes would already have failed the
+  // size comparison above; re-check the descriptor is exhausted regardless.
+  return readSync(handle.fd, chunk, 0, 1, position) === 0;
+}
+
+/**
+ * Argument shape for a `tar` inspection of `archive`, which is either a
+ * filesystem path or the exact archive bytes. Bytes are streamed to `tar` on
+ * stdin so that inspecting them needs no temporary copy: the release path must
+ * not acquire a free-space requirement equal to the whole archive, and a full
+ * `$TMPDIR` must not surface as a verification failure on a good artifact.
+ */
+function archiveSource(archive) {
+  return Buffer.isBuffer(archive)
+    ? { input: archive, target: "-" }
+    : { input: undefined, target: archive };
 }
 
 function isWithinDirectory(rootDir, candidatePath) {
@@ -455,10 +493,15 @@ function runTar(args) {
   execFileSync("tar", args, { stdio: ["ignore", "pipe", "inherit"] });
 }
 
-/** Lists archive member paths, normalized without a leading "./". */
-export function listArchiveMembers(archivePath) {
-  const out = execFileSync("tar", ["--zstd", "-tf", archivePath], {
+/**
+ * Lists archive member paths, normalized without a leading "./". `archive` is
+ * either a filesystem path or the exact archive bytes.
+ */
+export function listArchiveMembers(archive) {
+  const { input, target } = archiveSource(archive);
+  const out = execFileSync("tar", ["--zstd", "-tf", target], {
     encoding: "utf8",
+    input,
   });
   return out
     .split("\n")
@@ -466,8 +509,8 @@ export function listArchiveMembers(archivePath) {
     .filter((line) => line.length > 0 && line !== ".");
 }
 
-function assertSafeArchiveMembers(archivePath) {
-  for (const member of listArchiveMembers(archivePath)) {
+function assertSafeArchiveMembers(archive) {
+  for (const member of listArchiveMembers(archive)) {
     if (
       path.posix.isAbsolute(member) ||
       member.split("/").some((segment) => segment === "..") ||
@@ -476,9 +519,11 @@ function assertSafeArchiveMembers(archivePath) {
       fail(`archive contains an unsafe member path: ${JSON.stringify(member)}`);
     }
   }
-  const verbose = execFileSync("tar", ["--zstd", "-tvf", archivePath], {
+  const { input, target } = archiveSource(archive);
+  const verbose = execFileSync("tar", ["--zstd", "-tvf", target], {
     encoding: "utf8",
     env: { ...process.env, LC_ALL: "C" },
+    input,
   });
   for (const line of verbose.split("\n").filter(Boolean)) {
     const type = line[0];
@@ -501,11 +546,12 @@ function assertSafeArchiveMembers(archivePath) {
   }
 }
 
-function assertArchivedEntrypoint(archivePath, relativePath, key) {
+function assertArchivedEntrypoint(archive, relativePath, key) {
+  const { input, target } = archiveSource(archive);
   const listing = execFileSync(
     "tar",
-    ["--zstd", "-tvf", archivePath, `./${relativePath}`],
-    { encoding: "utf8", env: { ...process.env, LC_ALL: "C" } },
+    ["--zstd", "-tvf", target, `./${relativePath}`],
+    { encoding: "utf8", env: { ...process.env, LC_ALL: "C" }, input },
   ).trim();
   const mode = listing.split(/\s+/, 1)[0] ?? "";
   if (!/^-[rwx-]{9}$/.test(mode)) {
@@ -589,7 +635,7 @@ export function produceArtifact({
     const stagedArchivePath = path.join(stagingDir, archiveName);
     runTar(["--zstd", "-cf", stagedArchivePath, "-C", canonicalStageDir, "."]);
     const archiveBytes = readFileSync(stagedArchivePath);
-    inspectArchiveBytes(archiveBytes, assertSafeArchiveMembers);
+    assertSafeArchiveMembers(archiveBytes);
     const archiveDigest = createHash("sha256")
       .update(archiveBytes)
       .digest("hex");
@@ -712,18 +758,16 @@ export function verifyArtifactDir(outDir, publicKeyPem, testHooks = {}) {
       fail("archive signature does not verify over the exact archive bytes");
     }
 
-    inspectArchiveBytes(archiveBytes, (snapshotPath) => {
-      const members = new Set(listArchiveMembers(snapshotPath));
-      assertSafeArchiveMembers(snapshotPath);
-      for (const key of REQUIRED_ENTRYPOINTS) {
-        if (!members.has(manifest.entrypoints[key])) {
-          fail(
-            `entrypoint ${key} (${manifest.entrypoints[key]}) is not present in the archive`,
-          );
-        }
-        assertArchivedEntrypoint(snapshotPath, manifest.entrypoints[key], key);
+    const members = new Set(listArchiveMembers(archiveBytes));
+    assertSafeArchiveMembers(archiveBytes);
+    for (const key of REQUIRED_ENTRYPOINTS) {
+      if (!members.has(manifest.entrypoints[key])) {
+        fail(
+          `entrypoint ${key} (${manifest.entrypoints[key]}) is not present in the archive`,
+        );
       }
-    });
+      assertArchivedEntrypoint(archiveBytes, manifest.entrypoints[key], key);
+    }
     testHooks.beforeFinalStableFileCheck?.({ archivePath, manifestPath });
     for (const handle of handles) assertStableFile(handle);
     return manifest;


### PR DESCRIPTION
# Relates to

Closes #23912.

Follow-up to #23866 (merged as `ba37e11a94355ccf1271c57cf1bb407d9de33847`). This
is **not** a security report — see "What does this PR do?".

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` was run after sync. `bun run verify` was not run whole-repo;
      the exact focused commands and their real output are below, and the
      blocker is recorded in **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched off `origin/develop` at `dbdab0f20460a59f9d3afc81511000aa6e0a4fae`;
      zero conflicts.
- [x] Focused verification passes post-sync. The whole-repo `bun run verify`
      blocker is documented in **Known gaps / failures** below.

# Risks

**Low–medium**, confined to one release-tooling script.

- The archive is now handed to `tar` on **stdin** instead of via a temporary
  file. The one real risk was `tar` portability, so it was executed rather than
  assumed: all three inspection forms confirmed on **bsdtar 3.5.3** (macOS) and
  **GNU tar 1.34** (Debian 12 container), plus a 10-archive corpus proving the
  listings are byte-identical to the current path-based ones on both. No EPIPE
  on a 400 MB archive.
- The stability check is **not weakened**. `ctimeMs` still gates; when it is the
  only field that moved, the decision is escalated from a timestamp to the
  actual bytes, re-read through the same descriptor. All ten tampering cases in
  the adversarial suite are rejected identically before and after.
- The exported `listArchiveMembers(archivePath)` signature is unchanged; it now
  additionally accepts a `Buffer`.

# Background

## What does this PR do?

Two runtime defects landed with the stable-file binding in #23866, and both make
`verifyArtifactDir` report a **good** artifact as a failure. The source blob
`4cd82cd22a087c7e8ffd08356ada7b2a6e42fcb4` is live on `origin/develop` today, so
both reproduce on the shipped code, not a dead branch.

Framing first, because it matters: an independent adversarial pass over the four
properties #23866 names — stable opened-file binding, exact-byte archive
inspection, final-pathname/in-place mutation detection, and replacement-safe
publication failure — found **all four hold**. Nothing here is a security
finding. Both items are availability/robustness on the good-artifact path.

**1. Verification acquired a `$TMPDIR` free-space requirement equal to the whole
archive, and its failure is untyped.** `inspectArchiveBytes` wrote the entire
archive into `os.tmpdir()` before handing a pathname to `tar`. The merge-base
wrote nothing there. On a capped `/tmp` — routine on CI runners and in
containers — the copy fails with a raw `Error: ENOSPC`, **not** an
`ArtifactContractError`. That type is the load-bearing part:
`ArtifactContractError` is documented as "Error type for every contract
violation this module detects", so a caller that catches it to separate "the
artifact is bad" from "the environment is broken" now misclassifies a full
`/tmp`, and the operator is shown a verification failure on a perfectly good
artifact. `produceArtifact` had the same exposure.

The fix streams the exact archive bytes to `tar` on stdin, so inspection needs
**zero** temp space. The exact-byte property is strengthened rather than
weakened: the bytes never touch the filesystem again at all.

**2. The final stability check aborted on metadata-only churn.** Of the six
compared fields, `ctimeMs` is the only one that moves on a pure-metadata
operation. A release mirror hard-linking the tree (`cp -al`), a `chmod -R`, an
xattr-setting scanner or an SELinux relabel landing inside the window aborts the
release with a message that reads like tampering, while the bytes are provably
unchanged. The window is ~4 s of wall clock on a 400 MB artifact.

The fix does **not** drop the field — dropping it would trade a robustness bug
for a security one, since `ctime` is what catches a same-size in-place rewrite
whose `mtime` was forged. Instead, when `ctimeMs` is the *only* field that moved
(identity, size and mtime all still match), the verified bytes are re-read
positionally through the **same held descriptor** and compared. Deciding on
content is strictly stronger evidence than deciding on a timestamp, so every
case the ctime check rejected on real tampering is still rejected.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The two
behaviour changes are documented in-file where the decision is made.

# Testing

## Where should a reviewer start?

`packages/app-core/scripts/package-linux-gtk-artifact.mjs`, at `assertStableFile`
and at `archiveSource`. Then the five new regressions in
`packages/app-core/scripts/__tests__/package-linux-gtk-artifact.test.ts`.

## Detailed testing steps

```
bun install
node ../scripts/run-vitest.mjs run --config vitest.config.ts \
  scripts/__tests__/package-linux-gtk-artifact.test.ts
```

Four of the five new tests fail against the reverted source; the fifth is the
anti-weakening guard and passes on both arms by design.

# Evidence Gate

<!-- evidence-head:0858bee6bcc2572bf24b6cdd4a5fd8ecdf8dde90 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - this changes a Node release-packaging script under packages/app-core/scripts; it renders no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - this changes a Node release-packaging script under packages/app-core/scripts; it renders no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - there is no user flow; the entry point is a CLI verifier whose complete output is pasted below.`
<!-- evidence-row:backend-logs -->
- [x] Real command output showing the release-verifier path firing end to end on
      `origin/develop` and on this head:

<details><summary>verifyArtifactDir, Linux container, GNU tar 1.34, $TMPDIR on an 8 MB tmpfs</summary>

```
tmpfs           8.0M     0  8.0M   0% /smalltmp
--- merge-base ---
[linux-mergebase] archive bytes = 25169726
[linux-mergebase] TMPDIR = /smalltmp
[linux-mergebase] verifyArtifactDir: OK
--- origin/develop ---
[linux-develop] archive bytes = 25169726
[linux-develop] TMPDIR = /smalltmp
[linux-develop] verifyArtifactDir THREW
[linux-develop]   constructor            = Error
[linux-develop]   error.name             = Error
[linux-develop]   instanceof ArtifactContractError = false
[linux-develop]   code                   = ENOSPC
[linux-develop]   message                = ENOSPC: no space left on device, write
[linux-develop]       at Object.writeSync (node:fs:978:3)
[linux-develop]       at writeFileSync (node:fs:2503:26)
[linux-develop]       at inspectArchiveBytes (file:///scripts/mine-origin.mjs:193:5)
--- HEAD ---
[linux-HEAD] archive bytes = 25169726
[linux-HEAD] TMPDIR = /smalltmp
[linux-HEAD] verifyArtifactDir: OK
```

</details>

More transcripts, including the 400 MB natural race and the adversarial suite,
are under **Backend + frontend logs** below.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no browser surface is involved; there is no request/response or client state to trace.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model behaviour changes; this is filesystem and subprocess code with no model in the path.`
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact is the signed desktop artifact set this script emits —
      a real `.tar.zst` archive, `desktop-artifact-manifest.json`, and two
      detached Ed25519 signatures — produced and verified in every run. Sizes,
      SHA-256 prefixes and verify outcomes for the 400 MB set:

<details><summary>produced artifact set, 400 MB, natural hardlink race during verify</summary>

```
### F2 natural hardlink race, 400 MB artifact, no testHooks
[develop] archive=419446256 B mode=0644
[develop] verify window   : 5366 ms
[develop] outcome         : THREW ArtifactContractError: archive eliza-desktop-gtk-1.2.3-x86_64.tar.zst changed during verification
[develop] bytes unchanged : true (fb003833acc0a92c…)
[develop] mode unchanged  : true
[HEAD] archive=419446270 B mode=0644
[HEAD] verify window   : 3117 ms
[HEAD] outcome         : verified OK
[HEAD] bytes unchanged : true (8ff960b3704eb8c2…)
[HEAD] mode unchanged  : true
```

</details>
<!-- evidence-row:ocr-review -->
- [x] `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, action, provider, prompt, or model behaviour changes.`

## Backend + frontend logs

Frontend: `N/A - no browser surface.`

Backend, all executed locally. `mine-origin.mjs` and `mine-mergebase.mjs` are
verbatim `git show` extractions of `origin/develop` and of the merge-base
`62e25b18baa6fa0c446f2087f9633f65dec451de`, so every comparison is against the
code that actually shipped.

<details><summary>Target is live on develop</summary>

```
$ git ls-tree origin/develop packages/app-core/scripts/package-linux-gtk-artifact.mjs
100644 blob 4cd82cd22a087c7e8ffd08356ada7b2a6e42fcb4	packages/app-core/scripts/package-linux-gtk-artifact.mjs
$ git log --oneline -1 origin/develop -- packages/app-core/scripts/package-linux-gtk-artifact.mjs
ba37e11a9435 fix(app-core): bind artifact verification to stable files (#23866)
```

</details>

<details><summary>Defect 1 — ENOSPC on a good artifact, macOS, TMPDIR on a 10 MB volume</summary>

```
### F1 ENOSPC — merge-base 62e25b18 vs origin/develop blob 4cd82cd2 vs HEAD 0858bee6
[mergebase] archive bytes = 25172631
[mergebase] TMPDIR = /Volumes/elizatmp
[mergebase] verifyArtifactDir: OK
[develop] archive bytes = 25172627
[develop] TMPDIR = /Volumes/elizatmp
[develop] verifyArtifactDir THREW
[develop]   constructor            = Error
[develop]   error.name             = Error
[develop]   instanceof ArtifactContractError = false
[develop]   code                   = ENOSPC
[develop]   message                = ENOSPC: no space left on device, write
[develop]   Error: ENOSPC: no space left on device, write
[develop]       at Object.writeSync (node:fs:917:3)
[develop]       at writeFileSync (node:fs:2434:26)
[develop]       at inspectArchiveBytes (.../mine-origin.mjs:193:5)
[HEAD] archive bytes = 25172643
[HEAD] TMPDIR = /Volumes/elizatmp
[HEAD] verifyArtifactDir: OK
```

</details>

<details><summary>Defect 1 — same reproduction on Linux, GNU tar 1.34, tmpfs size=8m</summary>

```
tmpfs           8.0M     0  8.0M   0% /smalltmp
--- merge-base ---
[linux-mergebase] archive bytes = 25169726
[linux-mergebase] TMPDIR = /smalltmp
[linux-mergebase] verifyArtifactDir: OK
--- origin/develop ---
[linux-develop] archive bytes = 25169726
[linux-develop] TMPDIR = /smalltmp
[linux-develop] verifyArtifactDir THREW
[linux-develop]   constructor            = Error
[linux-develop]   error.name             = Error
[linux-develop]   instanceof ArtifactContractError = false
[linux-develop]   code                   = ENOSPC
[linux-develop]   message                = ENOSPC: no space left on device, write
[linux-develop]       at Object.writeSync (node:fs:978:3)
[linux-develop]       at writeFileSync (node:fs:2503:26)
[linux-develop]       at inspectArchiveBytes (file:///scripts/mine-origin.mjs:193:5)
--- HEAD ---
[linux-HEAD] archive bytes = 25169726
[linux-HEAD] TMPDIR = /smalltmp
[linux-HEAD] verifyArtifactDir: OK
```

</details>

Peak `$TMPDIR` occupancy during one `verifyArtifactDir`, sampled by an external
`du -sk` loop because the verifier is fully synchronous and blocks the event
loop:

| arm | peak `$TMPDIR` | archive |
| --- | --- | --- |
| merge-base `62e25b18` | **0 KB** (361 samples) | 25,172,628 B |
| `origin/develop` `4cd82cd2` | **24,584 KB** | 25,172,635 B |
| this PR `0858bee6` | **0 KB** (179 samples) | 25,172,584 B |

<details><summary>Defect 2 — natural race, 400 MB artifact, no test hooks at all</summary>

A separate `/bin/sh` process hard-links the archive in a loop (the `cp -al`
release-mirror pattern) while `verifyArtifactDir` runs.

```
### F2 natural hardlink race, 400 MB artifact, no testHooks
[develop] archive=419446256 B mode=0644
[develop] verify window   : 5366 ms
[develop] outcome         : THREW ArtifactContractError: archive eliza-desktop-gtk-1.2.3-x86_64.tar.zst changed during verification
[develop] bytes unchanged : true (fb003833acc0a92c…)
[develop] mode unchanged  : true
[HEAD] archive=419446270 B mode=0644
[HEAD] verify window   : 3117 ms
[HEAD] outcome         : verified OK
[HEAD] bytes unchanged : true (8ff960b3704eb8c2…)
[HEAD] mode unchanged  : true
```

An earlier attempt using a same-mode `/bin/chmod` loop did **not** reproduce it:
BSD `chmod(1)` stats first and skips the syscall when the mode already matches,
so it never moves `ctime`. `fs.chmodSync(p, currentMode)` does, and so does
`link(2)`.

</details>

<details><summary>No over-rejection — 19-case adversarial suite, both arms, bsdtar 3.5.3</summary>

Every case declares its required outcome. Ten tampering cases must be REJECTed,
four benign metadata cases and five structural cases must behave as before.

```
[develop] PASS  want=REJECT T1 in-place single-byte overwrite of target #0
[develop] PASS  want=REJECT T2 in-place single-byte overwrite of target #1
[develop] PASS  want=REJECT T3 in-place single-byte overwrite of target #2
[develop] PASS  want=REJECT T4 in-place single-byte overwrite of target #3
[develop] PASS  want=REJECT T5 same-size in-place rewrite with mtime restored (forged mtime)
[develop] PASS  want=REJECT T6 atomic rename-over with different content
[develop] PASS  want=REJECT T7 atomic rename-over with byte-IDENTICAL content
[develop] PASS  want=REJECT T8 unlink + recreate at the same pathname
[develop] PASS  want=REJECT T9 truncate-and-append (size change)
[develop] PASS  want=REJECT T10 archive removed mid-verification
[develop] FAIL  want=ACCEPT B1 no-op chmod to the same mode (bytes unchanged=true)
[develop] FAIL  want=ACCEPT B2 extra hardlink (cp -al mirror) (bytes unchanged=true)
[develop] FAIL  want=ACCEPT B3 chmod on every verified file (bytes unchanged=true)
[develop] PASS  want=ACCEPT B4 untouched control (bytes unchanged=true)
[develop] PASS  want=ACCEPT S1 clean stage produces + verifies
[develop] PASS  want=ACCEPT S2 stage with a relative symlink is packaged
[develop] PASS  want=REJECT S4 stage missing an entrypoint is refused
[develop] PASS  want=REJECT S5 tampered archive bytes fail the digest gate
[develop] PASS  want=REJECT S6 archive replaced by a symlink is refused
[develop] TOTAL pass=16 fail=3

[HEAD] PASS  want=REJECT T1 in-place single-byte overwrite of target #0
[HEAD] PASS  want=REJECT T2 in-place single-byte overwrite of target #1
[HEAD] PASS  want=REJECT T3 in-place single-byte overwrite of target #2
[HEAD] PASS  want=REJECT T4 in-place single-byte overwrite of target #3
[HEAD] PASS  want=REJECT T5 same-size in-place rewrite with mtime restored (forged mtime)
[HEAD] PASS  want=REJECT T6 atomic rename-over with different content
[HEAD] PASS  want=REJECT T7 atomic rename-over with byte-IDENTICAL content
[HEAD] PASS  want=REJECT T8 unlink + recreate at the same pathname
[HEAD] PASS  want=REJECT T9 truncate-and-append (size change)
[HEAD] PASS  want=REJECT T10 archive removed mid-verification
[HEAD] PASS  want=ACCEPT B1 no-op chmod to the same mode (bytes unchanged=true)
[HEAD] PASS  want=ACCEPT B2 extra hardlink (cp -al mirror) (bytes unchanged=true)
[HEAD] PASS  want=ACCEPT B3 chmod on every verified file (bytes unchanged=true)
[HEAD] PASS  want=ACCEPT B4 untouched control (bytes unchanged=true)
[HEAD] PASS  want=ACCEPT S1 clean stage produces + verifies
[HEAD] PASS  want=ACCEPT S2 stage with a relative symlink is packaged
[HEAD] PASS  want=REJECT S4 stage missing an entrypoint is refused
[HEAD] PASS  want=REJECT S5 tampered archive bytes fail the digest gate
[HEAD] PASS  want=REJECT S6 archive replaced by a symlink is refused
[HEAD] TOTAL pass=19 fail=0
```

The three flips are exactly the benign-metadata cases. Nothing that was rejected
before is accepted now.

</details>

<details><summary>GNU tar 1.34 parity — the same suite in a Debian 12 container</summary>

```
node v24.19.0 | tar (GNU tar) 1.34 | *** Zstandard CLI (64-bit) v1.5.4, by Yann Collet ***
[gnu-develop] FAIL  want=ACCEPT B1 no-op chmod to the same mode (bytes unchanged=true)
[gnu-develop] FAIL  want=ACCEPT B2 extra hardlink (cp -al mirror) (bytes unchanged=true)
[gnu-develop] FAIL  want=ACCEPT B3 chmod on every verified file (bytes unchanged=true)
[gnu-develop] TOTAL pass=16 fail=3
[gnu-HEAD] TOTAL pass=19 fail=0
```

Identical verdicts to bsdtar on both arms, including the same three flips.

</details>

<details><summary>Compatibility — listing output is byte-identical to the shipped path-based code</summary>

`origin/develop`'s `listArchiveMembers(path)` versus this PR's
`listArchiveMembers(bytes)` and `listArchiveMembers(path)`, over a corpus chosen
to stress the stdin change (empty archive, nested tree, symlinks including an
escaping target, unicode and spaces, 500 members, a 30-deep path, mixed modes, a
48 MB member, dotfiles). Run on bsdtar 3.5.3 and on GNU tar 1.34.

```
SAME  empty-dir          members=0 bytes=343
SAME  single-file        members=1 bytes=406
SAME  nested             members=4 bytes=1638
SAME  symlinks           members=3 bytes=565
SAME  unicode            members=2 bytes=581
SAME  many-members       members=500 bytes=16496
SAME  deep-path          members=31 bytes=1912
SAME  executable-modes   members=5 bytes=573
SAME  large-member       members=1 bytes=50335389
SAME  dotfiles           members=3 bytes=545
TOTAL archives=10 identical=10 divergent=0
```

The 50 MB case and the 400 MB verify above are also the EPIPE check: `tar` reads
the whole stream, so no truncated-stdin failure occurs.

</details>

<details><summary>Focused suite at the pushed head</summary>

```
$ node ../scripts/run-vitest.mjs run --config vitest.config.ts \
    scripts/__tests__/package-linux-gtk-artifact.test.ts
 Test Files  1 passed (1)
      Tests  39 passed (39)
```

</details>

<details><summary>Load-bearing revert (copy-aside, not git stash)</summary>

Patched source copied aside, `git show origin/develop:...` restored in its place,
new tests kept:

```
     × verifies a good artifact when $TMPDIR is unusable 44ms
     × produces a verifiable artifact when $TMPDIR is unusable 15ms
     × accepts a no-op chmod during verification 101ms
     × accepts an extra hard link, as a release mirror creates 93ms
 Tests  4 failed | 35 passed (39)
```

with the reasons:

```
Error: ENOENT: no such file or directory, mkdtemp '.../no-such-temp-directory/eliza-linux-gtk-archive-XXXXXX'
Error: ENOENT: no such file or directory, mkdtemp '.../no-such-temp-directory/eliza-linux-gtk-archive-XXXXXX'
ArtifactContractError: archive eliza-desktop-gtk-1.2.3-x86_64.tar.zst changed during verification
ArtifactContractError: archive eliza-desktop-gtk-1.2.3-x86_64.tar.zst changed during verification
```

Patch restored (sha-verified identical to the aside copy): `39 passed (39)`.

The fifth new test, "still rejects a same-size rewrite whose mtime was restored",
passes on **both** arms by design — it is the guard that kills any future attempt
to fix defect 2 by simply deleting the `ctimeMs` comparison.

</details>

<details><summary>Typecheck against an untouched control, and lint</summary>

```
$ bun run --cwd packages/app-core typecheck          # branch
70 errors
$ bun run --cwd packages/app-core typecheck          # both files restored to origin/develop
70 errors
$ diff <(grep "error TS" control) <(grep "error TS" branch) && echo IDENTICAL_ERROR_SETS
IDENTICAL_ERROR_SETS
```

This PR adds **zero** typecheck errors. All 70 are pre-existing unresolved
workspace-dependency errors (`Cannot find module '@elizaos/cloud-routing'` and
similar) in unrelated packages, present identically on unmodified `origin/develop`.

```
$ bunx @biomejs/biome check packages/app-core/scripts/package-linux-gtk-artifact.mjs \
    packages/app-core/scripts/__tests__/package-linux-gtk-artifact.test.ts
Checked 2 files in 25ms. No fixes applied.
```

</details>

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no rendered visual surface; this is a Node release-packaging script.`

### After

`N/A - no rendered visual surface; this is a Node release-packaging script.`

### Walkthrough video

`N/A - no user flow; the CLI verifier's complete output is inline above.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT, or omnivoice surface is touched.`

## Known gaps / failures

- **Whole-repo `bun run verify` was not run.** It builds and tests every package
  in the monorepo and several are unbuildable in this checkout for reasons
  unrelated to this change — the same 70 unresolved workspace-dependency
  typecheck errors shown above exist on unmodified `origin/develop`. The focused
  package suite, the package typecheck against an origin control, and biome on
  both touched files were run instead, with real output above.
- **No hosted CI on this PR.** I am a fork contributor without push access to
  `elizaOS/eliza`, so upstream checks do not run on my side and I claim none.
  Everything above is local execution on macOS 26 / APFS / Node v24.15.0 /
  bsdtar 3.5.3, and in a Debian 12 container on Node v24.19.0 / GNU tar 1.34 /
  zstd 1.5.4.
- **A cosmetic `tar` warning in one new test.** `produces a verifiable artifact
  when $TMPDIR is unusable` makes bsdtar print `Could not open extended
  attribute file: No such file or directory` on macOS, because bsdtar itself
  uses `$TMPDIR` for xattr scratch when creating an archive. That is `tar`'s own
  behaviour on both arms, not the module's, and it does not occur under GNU tar.
  The test's assertion — that the produced artifact verifies — passes.
- **Deliberate behaviour change, stated so a reviewer does not read it as an
  oversight.** After this PR, a metadata-only change to a verified file during
  the window (mode, ownership, xattrs, link count) no longer aborts verification,
  which matches the merge-base behaviour. Anything that changes the bytes still
  aborts, including the same-size/forged-mtime case, which now has a dedicated
  regression. If the project *wants* metadata churn to be in scope, that is a
  deliberate policy decision and the message should say "content or metadata
  changed" rather than reading as tampering — I did not assume it.
- **Not addressed here, deliberately: three separate follow-ups.** The same
  independent pass found (a) the headline descriptor-binding property of #23866
  has no failure-sensitive coverage — changing `readFileSync(fd)` to
  `readFileSync(filePath)` survives the whole suite, with a demonstrated
  parent-directory-symlink divergence; (b) the descriptor-leak teardown added in
  `8b83fc79` ships untested; and (c) the `flag: "wx"` on the private-key write is
  unpinned because the existing test stops at the `pathEntryExists` guard. All
  three are pure test-hardening on a different property from this PR's two
  runtime defects, so bundling them would muddy the revert story. They are
  tracked separately and are not claimed here.
- **Archive size ceiling unchanged.** `readFileSync` refuses anything over
  2 GiB, so this module still cannot verify an archive larger than that. That is
  not a regression — the merge-base buffered the whole archive too — and this PR
  does not change it either way.
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-mine28-gtk]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0JS566QB03PZ4H7W480YAK5","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T18:25:59.512Z","completed_at":"2026-08-21T18:28:25.947Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T18:26:00.444Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"54e2b35cd0a7c5ac8b8d4ca7d56c6907ff8b5bb61d0213e37609d65142266987","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"016c5b26-fa27-4ab3-a26e-48789993a82b","object_id":"sha256:54e2b35cd0a7c5ac8b8d4ca7d56c6907ff8b5bb61d0213e37609d65142266987","sha256":"54e2b35cd0a7c5ac8b8d4ca7d56c6907ff8b5bb61d0213e37609d65142266987"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"wRH-KUI1GEfwWgSNF6eEoyiKYMq_4u84-kFZ9FeNv4uR5EKKszOYani0xwTawI1NNnCYksMFDuf-mYk7jaxcDg"}} -->
