### PR TITLE
fix(core): restore verification formatting

### DIFF
--- a/packages/core/src/activity-plaintext.surrogate.test.ts
+++ b/packages/core/src/activity-plaintext.surrogate.test.ts
@@ -4,85 +4,88 @@
  * must never split a surrogate pair at the maxLength boundary.
  */
 
-import { toWellFormedUnicode, truncateWellFormed } from "./utils/well-formed";
 import { describe, expect, it } from "vitest";
 import { activityEventToPlaintext } from "./activity-plaintext";
+import { toWellFormedUnicode, truncateWellFormed } from "./utils/well-formed";
 
 function isWellFormed(value: string): boolean {
-  if (!value) return true;
-  if (typeof (value as unknown as { isWellFormed?: () => boolean }).isWellFormed === "function") {
-    return (value as unknown as { isWellFormed: () => boolean }).isWellFormed();
-  }
-  for (let i = 0; i < value.length; i++) {
-    const c = value.charCodeAt(i);
-    if (c >= 0xd800 && c <= 0xdbff) {
-      const n = value.charCodeAt(i + 1);
-      if (!(n >= 0xdc00 && n <= 0xdfff)) return false;
-      i++;
-    } else if (c >= 0xdc00 && c <= 0xdfff) return false;
-  }
-  return true;
+	if (!value) return true;
+	if (
+		typeof (value as unknown as { isWellFormed?: () => boolean })
+			.isWellFormed === "function"
+	) {
+		return (value as unknown as { isWellFormed: () => boolean }).isWellFormed();
+	}
+	for (let i = 0; i < value.length; i++) {
+		const c = value.charCodeAt(i);
+		if (c >= 0xd800 && c <= 0xdbff) {
+			const n = value.charCodeAt(i + 1);
+			if (!(n >= 0xdc00 && n <= 0xdfff)) return false;
+			i++;
+		} else if (c >= 0xdc00 && c <= 0xdfff) return false;
+	}
+	return true;
 }
 
 function normalizePlaintextFixed(value: string, maxLength: number): string {
-  const normalized = toWellFormedUnicode(value.replace(/\s+/g, " ").trim());
-  if (normalized.length <= maxLength) return normalized;
-  return truncateWellFormed(normalized, Math.max(0, maxLength)).trimEnd();
+	const normalized = toWellFormedUnicode(value.replace(/\s+/g, " ").trim());
+	if (normalized.length <= maxLength) return normalized;
+	return truncateWellFormed(normalized, Math.max(0, maxLength)).trimEnd();
 }
 
 describe("activity-plaintext normalizePlaintext well-formed", () => {
-  it("keeps surrogate pairs intact at maxLength boundary (120)", () => {
-    const emoji = String.fromCharCode(0xd83e, 0xdd8a);
-    const text = `${"a".repeat(119)}${emoji}${"b".repeat(20)}`;
-    const out = normalizePlaintextFixed(text, 120);
-    expect(out.length).toBeLessThanOrEqual(120);
-    expect(isWellFormed(out)).toBe(true);
-    expect(out.isWellFormed()).toBe(true);
-    expect(out.length).toBe(119);
-    expect(out).not.toContain(emoji);
-  });
-  it("preserves fitting emoji under cap", () => {
-    const emoji = String.fromCharCode(0xd83e, 0xdd8a);
-    const text = `${"a".repeat(118)}${emoji}`;
-    const out = normalizePlaintextFixed(text, 120);
-    expect(out).toBe(toWellFormedUnicode(text));
-    expect(isWellFormed(out)).toBe(true);
-  });
-  it("sanitizes lone high surrogate before truncation", () => {
-    const lone = `a${String.fromCharCode(0xd800)}bc ${"x".repeat(100)}`;
-    const out = normalizePlaintextFixed(lone, 10);
-    expect(out).toContain("�");
-    expect(isWellFormed(out)).toBe(true);
-  });
-  it("sanitizes lone low surrogate before truncation", () => {
-    const lone = `a${String.fromCharCode(0xdc00)}bc ${"x".repeat(100)}`;
-    const out = normalizePlaintextFixed(lone, 10);
-    expect(out).toContain("�");
-    expect(isWellFormed(out)).toBe(true);
-  });
-  it("backs off astral at 1-char cap to empty well-formed chunk", () => {
-    const emoji = String.fromCharCode(0xd83d, 0xde00);
-    const text = `${emoji}${"a".repeat(10)}`;
-    const out = normalizePlaintextFixed(text, 1);
-    expect(out.length).toBeLessThanOrEqual(1);
-    expect(isWellFormed(out)).toBe(true);
-    expect(out.length).toBe(0);
-  });
-  it("activityEventToPlaintext end-to-end keeps surrogate intact", () => {
-    const emoji = String.fromCharCode(0xd83e, 0xdd8a);
-    const text = `${"a".repeat(119)}${emoji}${"b".repeat(50)}`;
-    const direct = normalizePlaintextFixed(text, 120);
-    expect(isWellFormed(direct)).toBe(true);
-    expect(direct.isWellFormed()).toBe(true);
-  });
-  it("never emits lone surrogates at every boundary around 120", () => {
-    const emoji = String.fromCharCode(0xd83e, 0xdd8a);
-    for (let n = 0; n <= 125; n++) {
-      const text = `${"x".repeat(n)}${emoji}${"y".repeat(20)}`;
-      const out = normalizePlaintextFixed(text, 120);
-      expect(isWellFormed(out)).toBe(true);
-      expect(out.isWellFormed()).toBe(true);
-      expect(out.length).toBeLessThanOrEqual(120);
-    }
-  });
+	it("keeps surrogate pairs intact at maxLength boundary (120)", () => {
+		const emoji = String.fromCharCode(0xd83e, 0xdd8a);
+		const text = `${"a".repeat(119)}${emoji}${"b".repeat(20)}`;
+		const out = normalizePlaintextFixed(text, 120);
+		expect(out.length).toBeLessThanOrEqual(120);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.isWellFormed()).toBe(true);
+		expect(out.length).toBe(119);
+		expect(out).not.toContain(emoji);
+	});
+	it("preserves fitting emoji under cap", () => {
+		const emoji = String.fromCharCode(0xd83e, 0xdd8a);
+		const text = `${"a".repeat(118)}${emoji}`;
+		const out = normalizePlaintextFixed(text, 120);
+		expect(out).toBe(toWellFormedUnicode(text));
+		expect(isWellFormed(out)).toBe(true);
+	});
+	it("sanitizes lone high surrogate before truncation", () => {
+		const lone = `a${String.fromCharCode(0xd800)}bc ${"x".repeat(100)}`;
+		const out = normalizePlaintextFixed(lone, 10);
+		expect(out).toContain("�");
+		expect(isWellFormed(out)).toBe(true);
+	});
+	it("sanitizes lone low surrogate before truncation", () => {
+		const lone = `a${String.fromCharCode(0xdc00)}bc ${"x".repeat(100)}`;
+		const out = normalizePlaintextFixed(lone, 10);
+		expect(out).toContain("�");
+		expect(isWellFormed(out)).toBe(true);
+	});
+	it("backs off astral at 1-char cap to empty well-formed chunk", () => {
+		const emoji = String.fromCharCode(0xd83d, 0xde00);
+		const text = `${emoji}${"a".repeat(10)}`;
+		const out = normalizePlaintextFixed(text, 1);
+		expect(out.length).toBeLessThanOrEqual(1);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.length).toBe(0);
+	});
+	it("activityEventToPlaintext end-to-end keeps surrogate intact", () => {
+		const emoji = String.fromCharCode(0xd83e, 0xdd8a);
+		const text = `${"a".repeat(119)}${emoji}${"b".repeat(50)}`;
+		const direct = normalizePlaintextFixed(text, 120);
+		expect(isWellFormed(direct)).toBe(true);
+		expect(direct.isWellFormed()).toBe(true);
+	});
+	it("never emits lone surrogates at every boundary around 120", () => {
+		const emoji = String.fromCharCode(0xd83e, 0xdd8a);
+		for (let n = 0; n <= 125; n++) {
+			const text = `${"x".repeat(n)}${emoji}${"y".repeat(20)}`;
+			const out = normalizePlaintextFixed(text, 120);
+			expect(isWellFormed(out)).toBe(true);
+			expect(out.isWellFormed()).toBe(true);
+			expect(out.length).toBeLessThanOrEqual(120);
+		}
+	});
 });

--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -112,10 +112,17 @@ describe("redactSensitiveText (pattern detection)", () => {
 		// `\b`-anchored alphanumeric pattern because `1//` opens with a digit
 		// followed by slashes, which `\b` does not separate from what precedes
 		// it. Assembled at runtime per the fixture convention above.
-		const refreshToken = ["1//0", "AbCdEfGhIjKlMnOpQrStUvWxYz1234567890"].join("");
-		const accessToken = ["ya29.", "AbCdEfGhIjKlMnOpQrStUvWxYz1234-5678_90"].join("");
+		const refreshToken = ["1//0", "AbCdEfGhIjKlMnOpQrStUvWxYz1234567890"].join(
+			"",
+		);
+		const accessToken = [
+			"ya29.",
+			"AbCdEfGhIjKlMnOpQrStUvWxYz1234-5678_90",
+		].join("");
 		for (const token of [refreshToken, accessToken]) {
-			const out = redactSensitiveText(`token endpoint returned ${token} in the body`);
+			const out = redactSensitiveText(
+				`token endpoint returned ${token} in the body`,
+			);
 			expect(out, token).not.toContain(token);
 		}
 	});

--- a/packages/core/src/services/optimized-prompt-resolver.test.ts
+++ b/packages/core/src/services/optimized-prompt-resolver.test.ts
@@ -334,4 +334,3 @@ describe("trimDemonstrationInput surrogate handling", () => {
 		expect(parts[1].isWellFormed()).toBe(true);
 	});
 });
-

--- a/packages/core/src/services/optimized-prompt-resolver.ts
+++ b/packages/core/src/services/optimized-prompt-resolver.ts
@@ -18,16 +18,16 @@
  */
 
 import {
+	tailWellFormed,
+	toWellFormedUnicode,
+	truncateWellFormed,
+} from "../utils/well-formed.ts";
+import {
 	OPTIMIZED_PROMPT_SERVICE,
 	type OptimizedPromptFewShotExample,
 	type OptimizedPromptService,
 	type OptimizedPromptTask,
 } from "./optimized-prompt.js";
-import {
-	tailWellFormed,
-	toWellFormedUnicode,
-	truncateWellFormed,
-} from "../utils/well-formed.ts";
 
 /**
  * Minimal shape of `IAgentRuntime` we need to look up the


### PR DESCRIPTION
# Relates to

Closes #23913.

# Summary

Applies the repository-pinned Biome formatter and safe import ordering to the four core files that blocked `bun run verify`. No runtime behavior is changed.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@57dbecdfd87e8c9a3c16cbcb4e0fdbd116b34156:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Testing

- `bun run --cwd packages/core lint:check` — passes (warnings are pre-existing advisory diagnostics).
- `bun run --cwd packages/core typecheck` — passes.
- Focused Vitest: 3 files, 164 tests passed.

# Evidence Gate

<!-- evidence-head:b7a8b4f33257b8b0ceda3b2f7b5d5583b438b139 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - formatter-only core source/test repair.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime behavior changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Core package validation transcript.
<details><summary>Focused validation</summary>

```text
Core lint: completed successfully with zero error diagnostics.
Core typecheck: completed successfully.
Vitest: 3 files passed, 164 tests passed, 0 failed.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

AI provider/model: openai / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@57dbecdfd87e8c9a3c16cbcb4e0fdbd116b34156:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
