### PR TITLE
fix(ui): verify the protected-storage interception actually installed

### DIFF
--- a/packages/ui/src/bridge/storage-bridge-secure-contract.test.ts
+++ b/packages/ui/src/bridge/storage-bridge-secure-contract.test.ts
@@ -13,9 +13,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Captured once, before any test installs the storage-bridge proxy, so every
 // test can read/write "the raw disk" (bypassing whatever proxy state a prior
 // test in this file left behind) instead of accidentally re-capturing an
-// already-patched `Storage.prototype` method.
-const rawGetItem = Storage.prototype.getItem;
-const rawSetItem = Storage.prototype.setItem;
+// already-patched method. Bind the functions `localStorage` itself resolves:
+// jsdom exposes Storage through a proxy whose branded internal-slot check
+// rejects `Storage.prototype.getItem.call(localStorage)`.
+const rawStorage = window.localStorage;
+const rawGetItem = rawStorage.getItem.bind(rawStorage) as (
+  key: string,
+) => string | null;
+const rawSetItem = rawStorage.setItem.bind(rawStorage) as (
+  key: string,
+  value: string,
+) => void;
 
 const nativeStores = vi.hoisted(() => ({
   preferences: new Map<string, string>(),
@@ -139,7 +147,7 @@ describe("native protected-storage bridge contract", () => {
       // The raw Storage prototype (bypassing the secure-store cache) must
       // never see the plaintext value — only the protected native store and
       // the in-memory cache may hold it.
-      expect(rawGetItem.call(window.localStorage, key)).toBeNull();
+      expect(rawGetItem(key)).toBeNull();
       expect(window.localStorage.getItem(key)).toBeNull();
       expect(await bridge.getStorageValue(key)).toBe(value);
     }
@@ -153,7 +161,7 @@ describe("native protected-storage bridge contract", () => {
       bridge.setStorageValue(STEWARD_TOKEN_KEY, "attempted-plaintext-fallback"),
     ).rejects.toThrow();
 
-    expect(rawGetItem.call(window.localStorage, STEWARD_TOKEN_KEY)).toBeNull();
+    expect(rawGetItem(STEWARD_TOKEN_KEY)).toBeNull();
     expect(window.localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
     expect(nativeStores.secure.has("session.steward_token")).toBe(false);
   });
@@ -274,14 +282,10 @@ describe("native protected-storage bridge contract", () => {
 
   it("installs the storage proxy before the native secure store responds, so a concurrent write during migration never touches plaintext", async () => {
     nativeStores.preferences.set("eliza.device.auth", "legacy-device-secret");
-    // Seed through the raw prototype: this must be a genuine pre-migration
+    // Seed through the raw handle: this must be a genuine pre-migration
     // plaintext value on disk, not a write that a proxy from an earlier test
     // in this file might already intercept.
-    rawSetItem.call(
-      window.localStorage,
-      "eliza.device.auth",
-      "legacy-device-secret",
-    );
+    rawSetItem("eliza.device.auth", "legacy-device-secret");
     let releaseGet: () => void = () => {};
     nativeStores.secureGetWait = new Promise<void>((resolve) => {
       releaseGet = resolve;
@@ -303,9 +307,7 @@ describe("native protected-storage bridge contract", () => {
       "eliza.device.auth",
       "concurrent-write-during-migration",
     );
-    expect(
-      rawGetItem.call(window.localStorage, "eliza.device.auth"),
-    ).toBeNull();
+    expect(rawGetItem("eliza.device.auth")).toBeNull();
 
     // Fail the rest of this migration pass so `initialized` stays false —
     // this file's other tests import the same module singleton and the next
@@ -322,9 +324,7 @@ describe("native protected-storage bridge contract", () => {
         "set:start:session.device_auth",
       );
     });
-    expect(
-      rawGetItem.call(window.localStorage, "eliza.device.auth"),
-    ).toBeNull();
+    expect(rawGetItem("eliza.device.auth")).toBeNull();
     nativeStores.secureAvailable = true;
   });
 
@@ -371,22 +371,19 @@ describe("native protected-storage bridge contract", () => {
   });
 
   it("migrates an Android plaintext session only after exact secure read-back", async () => {
-    const rawStorage = window.localStorage;
     nativeStores.preferences.set("eliza.device.auth", "legacy-device-secret");
-    // Seed through the raw prototype, not `window.localStorage` — an earlier
+    // Seed through the raw handle, not `window.localStorage` — an earlier
     // test in this file may have already installed the storage proxy (it is
     // a one-time, idempotent install on the shared module), and a proxied
     // write to a protected key would route into the secure-store path instead
     // of leaving a genuine pre-migration plaintext value on raw disk.
-    rawSetItem.call(rawStorage, "eliza.device.auth", "legacy-device-secret");
+    rawSetItem("eliza.device.auth", "legacy-device-secret");
 
     const bridge = await import("./storage-bridge");
     nativeStores.secureAvailable = false;
     await bridge.initializeStorageBridge();
     expect(bridge.isStorageBridgeInitialized()).toBe(false);
-    expect(rawGetItem.call(rawStorage, "eliza.device.auth")).toBe(
-      "legacy-device-secret",
-    );
+    expect(rawGetItem("eliza.device.auth")).toBe("legacy-device-secret");
 
     nativeStores.secureAvailable = true;
     await bridge.initializeStorageBridge();
@@ -401,7 +398,7 @@ describe("native protected-storage bridge contract", () => {
     expect(window.localStorage.getItem("eliza.device.auth")).toBe(
       "legacy-device-secret",
     );
-    expect(rawGetItem.call(rawStorage, "eliza.device.auth")).toBeNull();
+    expect(rawGetItem("eliza.device.auth")).toBeNull();
     window.sessionStorage.setItem("storage-bridge-probe", "unchanged");
     expect(window.sessionStorage.getItem("storage-bridge-probe")).toBe(
       "unchanged",

--- a/packages/ui/src/bridge/storage-bridge.ts
+++ b/packages/ui/src/bridge/storage-bridge.ts
@@ -251,9 +251,14 @@ function getNativeLocalStorageMethods(): NativeStorageMethods {
   const prototypeRemoveItem = prototype.removeItem;
   nativeLocalStorageMethods = {
     storage,
-    setItem: prototypeSetItem.bind(storage),
-    getItem: prototypeGetItem.bind(storage),
-    removeItem: prototypeRemoveItem.bind(storage),
+    // Bind the functions the instance itself resolves rather than the
+    // prototype slots. Hosts that hand out `localStorage` through a proxy
+    // (jsdom does) reject a prototype method invoked with the proxy as `this`
+    // on their branded internal-slot check; the instance-resolved function
+    // works on both a proxied and a plain Storage object.
+    setItem: storage.setItem.bind(storage),
+    getItem: storage.getItem.bind(storage),
+    removeItem: storage.removeItem.bind(storage),
     prototypeSetItem,
     prototypeGetItem,
     prototypeRemoveItem,
@@ -604,36 +609,63 @@ function setupStorageProxy(): void {
     }
   };
 
+  function storageBridgeSetItem(this: Storage, key: string, value: string) {
+    if (this === localStorageInstance) return secureSetItem(key, value);
+    return prototypeSetItem.call(this, key, value);
+  }
+  function storageBridgeGetItem(this: Storage, key: string) {
+    if (this === localStorageInstance) return secureGetItem(key);
+    return prototypeGetItem.call(this, key);
+  }
+  function storageBridgeRemoveItem(this: Storage, key: string) {
+    if (this === localStorageInstance) return secureRemoveItem(key);
+    return prototypeRemoveItem.call(this, key);
+  }
+
   Object.defineProperties(storagePrototype, {
     setItem: {
       configurable: true,
       writable: true,
-      value: function storageBridgeSetItem(
-        this: Storage,
-        key: string,
-        value: string,
-      ) {
-        if (this === localStorageInstance) return secureSetItem(key, value);
-        return prototypeSetItem.call(this, key, value);
-      },
+      value: storageBridgeSetItem,
     },
     getItem: {
       configurable: true,
       writable: true,
-      value: function storageBridgeGetItem(this: Storage, key: string) {
-        if (this === localStorageInstance) return secureGetItem(key);
-        return prototypeGetItem.call(this, key);
-      },
+      value: storageBridgeGetItem,
     },
     removeItem: {
       configurable: true,
       writable: true,
-      value: function storageBridgeRemoveItem(this: Storage, key: string) {
-        if (this === localStorageInstance) return secureRemoveItem(key);
-        return prototypeRemoveItem.call(this, key);
-      },
+      value: storageBridgeRemoveItem,
     },
   });
+
+  // A host may hand out `localStorage` through a wrapper that does not resolve
+  // method lookups through the prototype patched above (jsdom's proxy does
+  // not). Interception is a security boundary, so verify it rather than assume
+  // it, and install the same branch directly on the instance when the
+  // prototype patch is not observable there. `defineProperty` is used instead
+  // of plain assignment because a Web Storage `[[Set]]` on an unknown name is
+  // a named-property write that would persist a bogus "setItem" entry.
+  if (localStorageInstance.getItem !== storageBridgeGetItem) {
+    Object.defineProperties(localStorageInstance, {
+      setItem: {
+        configurable: true,
+        writable: true,
+        value: secureSetItem,
+      },
+      getItem: {
+        configurable: true,
+        writable: true,
+        value: secureGetItem,
+      },
+      removeItem: {
+        configurable: true,
+        writable: true,
+        value: secureRemoveItem,
+      },
+    });
+  }
   storageProxyInstalled = true;
 }
 

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -1316,7 +1316,7 @@ describe("notification-store — authority isolation (#18391)", () => {
       // client-cloud's dedicated-agent 401 path calls this canonical clear
       // while the unrelated Eliza API bearer remains present.
       expect(hasToken()).toBe(true);
-      clearStoredStewardToken();
+      await clearStoredStewardToken();
 
       expect(__getStateForTests().notifications).toHaveLength(0);
       expect(__getStateForTests().hydrationStatus).toBe("idle");


### PR DESCRIPTION
# Relates to

Follow-up to #23068 (merged as b5612ebc20a7).

# What this PR does

Post-merge review of #23068 found two defects in the native/desktop protected-storage bridge that landed on `develop`.

1. **`packages/ui/src/bridge/storage-bridge.ts` — interception could silently not install.** `setupStorageProxy` patched only the object returned by `Object.getPrototypeOf(window.localStorage)` and then declared `storageProxyInstalled = true` without checking that the patch was observable on the instance. A host that hands out `localStorage` through a wrapper does not resolve method lookups through that object, so the `PROTECTED_STORAGE_KIND` branch never ran: `localStorage.setItem(STEWARD_TOKEN_KEY, …)` wrote the credential to plaintext storage and `localStorage.getItem` read the legacy plaintext value straight off disk. Interception here is a security boundary, so it is now verified after install and the same branch is defined directly on the instance when the prototype patch is not observable there. `Object.defineProperty` is used rather than plain assignment, because a Web Storage `[[Set]]` on an unknown name is a named-property write that would persist a bogus `"setItem"` entry — the exact hazard the original comment cites.

   `getNativeLocalStorageMethods` also captured its "raw" handles as `prototypeGetItem.bind(storage)`. A wrapper's branded internal-slot check rejects a prototype method invoked with the wrapper as `this`, so those handles threw instead of reaching real storage. They are now bound from the functions `localStorage` itself resolves, which works on both a wrapped and a plain `Storage`.

2. **`packages/ui/src/state/notifications/notification-store.test.ts`** still called `clearStoredStewardToken()` without awaiting it. #23068 made that function async; the case asserts on the synchronous next line, so the notification authority switch had not run yet.

# Verification

Run on this exact head against the repository's pinned toolchain (`jsdom@29.1.1`, `vitest@4.1.10`), which reproduces the wrapped-`localStorage` shape:

- `packages/ui` `src/bridge/storage-bridge-secure-contract.test.ts`: 15/15 passed. Before this change the same suite failed 6 of 15 — four with `TypeError: 'getItem' called on an object that is not a valid instance of Storage` from the raw handles, and two because the protected-key branch was never reached.
- `packages/ui` `src/state/notifications/notification-store.test.ts`: 63/63 passed (1 failing before).
- `packages/ui` `src/bridge`, `src/state`, `src/cloud/shell`, `src/cloud/public-pages/lib`, `src/api`: no new failures. The 15 remaining failures in `src/api/android-native-agent-transport.test.ts`, `src/api/client-cloud-direct-auth-web.test.ts`, and `src/state/cloud-login-callsite-contract.test.ts` are pre-existing on `develop`, touch files neither this PR nor #23068 changed, and reproduce with these commits reverted.
- `biome check` on all three touched files: passed.
- No hosted CI run, signed-device run, or physical iOS/Android capture is claimed on this head.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered surface changes; the diff is the storage interception seam and one test await.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered surface changes.
<!-- evidence-row:walkthrough-video -->
- [ ] Native protected write/read/relaunch walkthrough on a signed device build.
<!-- evidence-row:backend-logs -->
- [x] N/A - renderer-only change; no backend path is touched.
<!-- evidence-row:frontend-logs -->
- [x] N/A - covered by the deterministic contract suite results above.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] Signed iOS/Android receipt that a protected key never appears in plaintext localStorage after upgrade.
<!-- evidence-row:ocr-review -->
- [x] N/A - no view is added, removed, or restyled.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - maintainer review flow is external to this repository`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

🤖 Generated with [Claude Code](https://claude.com/claude-code)