### PR TITLE
fix(build): audit guide parity across sparse checkouts

### DIFF
--- a/scripts/assert-agents-claude-identical.mjs
+++ b/scripts/assert-agents-claude-identical.mjs
@@ -18,9 +18,15 @@ function git(args) {
   return execFileSync("git", args, { encoding: "utf8", maxBuffer: 1 << 30 });
 }
 
+function gitBuffer(args) {
+  return execFileSync("git", args, { maxBuffer: 1 << 30 });
+}
+
 function guideFiles() {
   return git([
     "ls-files",
+    "-t",
+    "--stage",
     "-z",
     "AGENTS.md",
     "CLAUDE.md",
@@ -29,8 +35,16 @@ function guideFiles() {
   ])
     .split("\0")
     .filter(Boolean)
-    .filter((file) => existsSync(file))
-    .filter(shouldCheckGuideFile);
+    .map((entry) => {
+      const match = /^([A-Z?]) \d+ ([0-9a-f]+) \d+\t([\s\S]+)$/.exec(entry);
+      if (!match) throw new Error(`unexpected git ls-files entry: ${entry}`);
+      return {
+        file: match[3],
+        objectId: match[2],
+        skipWorktree: match[1] === "S",
+      };
+    })
+    .filter(({ file }) => shouldCheckGuideFile(file));
 }
 
 export function shouldCheckGuideFile(file) {
@@ -47,15 +61,35 @@ function directoryFor(file) {
   return dir === "." ? "." : dir;
 }
 
+function readGuide(entry) {
+  if (existsSync(entry.file)) return readFileSync(entry.file);
+  if (entry.skipWorktree) return gitBuffer(["show", `:${entry.file}`]);
+  return null;
+}
+
+function guidesEqual(left, right) {
+  const leftExists = existsSync(left.file);
+  const rightExists = existsSync(right.file);
+
+  if (!leftExists && left.skipWorktree && !rightExists && right.skipWorktree) {
+    return left.objectId === right.objectId;
+  }
+
+  const leftBytes = readGuide(left);
+  const rightBytes = readGuide(right);
+  return leftBytes && rightBytes ? leftBytes.equals(rightBytes) : null;
+}
+
 function main() {
   const byDirectory = new Map();
 
-  for (const file of guideFiles()) {
+  for (const guideEntry of guideFiles()) {
+    const { file } = guideEntry;
     const directory = directoryFor(file);
     const entry = byDirectory.get(directory) ?? {};
 
-    if (file.endsWith("AGENTS.md")) entry.agents = file;
-    if (file.endsWith("CLAUDE.md")) entry.claude = file;
+    if (file.endsWith("AGENTS.md")) entry.agents = guideEntry;
+    if (file.endsWith("CLAUDE.md")) entry.claude = guideEntry;
 
     byDirectory.set(directory, entry);
   }
@@ -76,10 +110,24 @@ function main() {
     }
 
     pairs += 1;
-    const agents = readFileSync(entry.agents);
-    const claude = readFileSync(entry.claude);
+    const equal = guidesEqual(entry.agents, entry.claude);
 
-    if (!agents.equals(claude)) {
+    if (equal === null) {
+      const missing = [
+        !existsSync(entry.agents.file) && !entry.agents.skipWorktree
+          ? entry.agents.file
+          : null,
+        !existsSync(entry.claude.file) && !entry.claude.skipWorktree
+          ? entry.claude.file
+          : null,
+      ].filter(Boolean);
+      failures.push(
+        `${directory}: tracked guide missing from working tree: ${missing.join(", ")}`,
+      );
+      continue;
+    }
+
+    if (!equal) {
       failures.push(
         `${directory}: CLAUDE.md and AGENTS.md differ; author CLAUDE.md, then copy it to AGENTS.md`,
       );

--- a/scripts/assert-agents-claude-identical.test.mjs
+++ b/scripts/assert-agents-claude-identical.test.mjs
@@ -1,6 +1,75 @@
+/**
+ * Exercises guide-pair filtering and real sparse-checkout behavior through the
+ * repository checker process.
+ */
+
 import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
 import { shouldCheckGuideFile } from "./assert-agents-claude-identical.mjs";
+
+const checkerPath = fileURLToPath(
+  new URL("./assert-agents-claude-identical.mjs", import.meta.url),
+);
+
+function git(cwd, args) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+}
+
+function createSparseRepository({ divergentNestedPair = false } = {}) {
+  const repository = mkdtempSync(join(tmpdir(), "eliza-guide-parity-"));
+  mkdirSync(join(repository, "kept"), { recursive: true });
+  mkdirSync(join(repository, "packages", "example"), { recursive: true });
+
+  writeFileSync(join(repository, "AGENTS.md"), "root guide\n");
+  writeFileSync(join(repository, "CLAUDE.md"), "root guide\n");
+  writeFileSync(join(repository, "kept", "README.md"), "sparse cone\n");
+  writeFileSync(
+    join(repository, "packages", "example", "AGENTS.md"),
+    divergentNestedPair ? "agents guide\n" : "nested guide\n",
+  );
+  writeFileSync(
+    join(repository, "packages", "example", "CLAUDE.md"),
+    divergentNestedPair ? "claude guide\n" : "nested guide\n",
+  );
+
+  git(repository, ["init", "--quiet"]);
+  git(repository, ["config", "user.name", "Guide Test"]);
+  git(repository, ["config", "user.email", "guide-test@example.invalid"]);
+  git(repository, ["config", "core.autocrlf", "false"]);
+  git(repository, ["add", "."]);
+  git(repository, ["commit", "--quiet", "-m", "seed guide pairs"]);
+  git(repository, ["sparse-checkout", "init", "--cone"]);
+  git(repository, ["sparse-checkout", "set", "kept"]);
+
+  assert.equal(existsSync(join(repository, "AGENTS.md")), true);
+  assert.equal(
+    existsSync(join(repository, "packages", "example", "AGENTS.md")),
+    false,
+  );
+  return repository;
+}
+
+function runChecker(repository) {
+  return spawnSync(process.execPath, [checkerPath], {
+    cwd: repository,
+    encoding: "utf8",
+  });
+}
 
 describe("assert-agents-claude-identical guide filtering", () => {
   it("checks authored guide pairs", () => {
@@ -23,5 +92,62 @@ describe("assert-agents-claude-identical guide filtering", () => {
       ),
       false,
     );
+  });
+});
+
+describe("assert-agents-claude-identical sparse checkout coverage", () => {
+  it("audits byte-identical guide pairs omitted from the worktree", () => {
+    const repository = createSparseRepository();
+    try {
+      const result = runChecker(repository);
+      assert.equal(result.status, 0, result.stderr);
+      assert.match(
+        result.stdout,
+        /PASS: 2 tracked CLAUDE\.md\/AGENTS\.md pair/,
+      );
+    } finally {
+      rmSync(repository, { recursive: true, force: true });
+    }
+  });
+
+  it("fails on a divergent pair omitted from the worktree", () => {
+    const repository = createSparseRepository({ divergentNestedPair: true });
+    try {
+      const result = runChecker(repository);
+      assert.equal(result.status, 1, result.stdout);
+      assert.match(
+        result.stderr,
+        /packages[\\/]example: CLAUDE\.md and AGENTS\.md differ/,
+      );
+    } finally {
+      rmSync(repository, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps checked-out worktree edits authoritative", () => {
+    const repository = createSparseRepository();
+    try {
+      writeFileSync(join(repository, "AGENTS.md"), "modified worktree guide\n");
+      const result = runChecker(repository);
+      assert.equal(result.status, 1, result.stdout);
+      assert.match(result.stderr, /\.: CLAUDE\.md and AGENTS\.md differ/);
+    } finally {
+      rmSync(repository, { recursive: true, force: true });
+    }
+  });
+
+  it("fails when an ordinary tracked guide is deleted", () => {
+    const repository = createSparseRepository();
+    try {
+      rmSync(join(repository, "AGENTS.md"));
+      const result = runChecker(repository);
+      assert.equal(result.status, 1, result.stdout);
+      assert.match(
+        result.stderr,
+        /tracked guide missing from working tree: AGENTS\.md/,
+      );
+    } finally {
+      rmSync(repository, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
# Relates to

Fixes #23905

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto `origin/develop@b5612ebc20a7e4958aba9f8ef70779db22c86088` with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` and `bun run verify` were run after sync; the exact unrelated verify blocker is recorded below.
- [x] A reviewer can confirm the change from the real temporary sparse-repository transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@15d98478444b31b802f4ea411b9c2268621f0a78:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [x] Root verify was run with pinned Bun 1.3.14 and Node 24.15.0; its unrelated baseline lint blocker is documented below.

# Risks

Low. The checker still reads checked-out files from the worktree, but now reads
intentionally omitted `S` (skip-worktree) entries from the index. When both
files in an omitted pair are skipped, their Git blob IDs provide the same
byte-identity proof without hundreds of subprocesses.

# Background

## What does this PR do?

The guide-parity checker used `git ls-files` and then discarded every path for
which `existsSync()` was false. In sparse checkouts, that silently removed all
skip-worktree guide pairs from the audit. A checkout with 320 tracked guide
files reported success after checking only two pairs.

This change parses `git ls-files -t --stage` so the checker can distinguish a
deliberately omitted guide from an ordinary deleted file. It:

- compares index blob IDs when both guides are skip-worktree entries;
- uses the worktree bytes whenever a guide is materialized, preserving staged
  and unstaged edit detection;
- reads the index blob only for a mixed present/skipped pair;
- reports an ordinary tracked-file deletion as a failure;
- preserves the existing fixture/test/archive exclusions.

The tests create real temporary Git repositories, commit guide pairs, enable
cone-mode sparse checkout, and execute the real checker process.

## What kind of change is this?

Bug fix (build/repository verification tooling; non-breaking).

# Documentation changes needed?

No. The existing root guide already says all tracked guide pairs must be
byte-identical; this makes the checker enforce that documented contract.

# Testing

## Where should a reviewer start?

- `scripts/assert-agents-claude-identical.mjs`
- `scripts/assert-agents-claude-identical.test.mjs`

## Detailed testing steps

Exact head: `b10b752cd647d74ea5d38861d1bf22a13ea6a039`

1. `bun install --frozen-lockfile --ignore-scripts` — pass, no source changes.
2. Node 24.15.0: `node --test scripts/assert-agents-claude-identical.test.mjs` — 6 pass, 0 fail.
3. Bun 1.3.14: `bun test scripts/assert-agents-claude-identical.test.mjs` — 6 pass, 0 fail.
4. `bun run check:agents-claude` — pass, 160 tracked pairs audited.
5. `bun x @biomejs/biome check <two changed files>` — pass.
6. `git diff --check origin/develop...HEAD` — pass.

### Mutation control

Restoring the pre-fix `existsSync` filter makes the real sparse suite fail:

```text
tests 6 | pass 3 | fail 3
PASS: 1 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.
fails on a divergent pair omitted from the worktree:
  actual status 0, expected status 1
```

With this patch restored:

```text
tests 6 | pass 6 | fail 0
[assert-agents-claude-identical] PASS: 160 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.
```

# Evidence Gate

<!-- evidence-head:b10b752cd647d74ea5d38861d1bf22a13ea6a039 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - terminal-only repository tooling has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - terminal-only repository tooling has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no interactive product flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server/backend path changed; the real checker subprocess transcript is included above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Real temporary-Git sparse-checkout transcript:

<details>
<summary>Focused checker and mutation-control output</summary>

```text
Node 24.15.0 sparse suite: tests 6 | pass 6 | fail 0
Bun 1.3.14 sparse suite: 6 pass | 0 fail
identical skipped pair: PASS count includes both root and omitted pair
divergent skipped pair: exit 1 and names packages/example
checked-out guide edit: exit 1 and names the root pair
ordinary tracked deletion: exit 1 with tracked-guide-missing diagnostic
pre-fix mutation control: tests 6 | pass 3 | fail 3
pre-fix divergent skipped pair: actual exit 0, expected exit 1
[assert-agents-claude-identical] PASS: 160 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic repository verification only; no model call or routing path changed.

## Backend + frontend logs

N/A - no backend or frontend runtime changed. The relevant process output is
the focused checker/test transcript above.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no audio or voice surface changed.

## Known gaps / failures

`bun run verify` passes the changed `check:agents-claude` gate, Biome-version,
i18n, Bun/Turbo contracts, workspace dependency checks, alias guard, and
workspace-resolution audit. It then stops in the repository-wide Turbo
`lint:check` fan-out on CRLF formatting in the unrelated
`packages/app-core/src/styles/electrobun-mac-window-drag.css`. That file is
byte-identical to `origin/develop`; this PR changes only the two checker files
listed above. Focused Biome and both pinned-runtime test lanes are green.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@15d98478444b31b802f4ea411b9c2268621f0a78:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [startrack3r/codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@15d98478444b31b802f4ea411b9c2268621f0a78:packages/skills/skills/contribute-to-eliza"} -->
