### PR TITLE
fix(build): validate macOS alarm helper architecture

### DIFF
--- a/plugins/plugin-native-macosalarm/README.md
+++ b/plugins/plugin-native-macosalarm/README.md
@@ -37,7 +37,11 @@ import macosAlarmPlugin from "@elizaos/macosalarm";
 bun run --cwd plugins/plugin-native-macosalarm build
 ```
 
-This runs `tsc --noCheck` and then `swiftc swift-helper/main.swift -O -o bin/macosalarm-helper`.
+This runs `tsc --noCheck` and then ensures `bin/macosalarm-helper` contains a
+Mach-O slice compatible with the current Node architecture. The tracked helper
+is reused only when both its source-and-flags stamp and target architecture
+match; otherwise `swiftc swift-helper/main.swift -O -o bin/macosalarm-helper`
+rebuilds it.
 
 ## Configuration
 
@@ -78,5 +82,7 @@ The `ALARM` action requires the agent's user to have at minimum the `ADMIN` role
 ## Limitations
 
 - macOS only — no Windows or Linux support.
-- The Swift binary must be compiled locally; pre-built binaries are not bundled in the npm package.
+- The npm package includes the tracked helper under `bin/`. Package and release
+  builds validate its Mach-O architecture and rebuild it locally with `swiftc`
+  when it is incompatible with the current macOS target.
 - `UNUserNotificationCenter` requires the helper to run from a signed app bundle. Invoked as a bare CLI it throws an `NSInternalInconsistencyException` (`bundleProxyForCurrentProcess is nil`); packaging/signing is owned downstream.

--- a/plugins/plugin-native-macosalarm/__tests__/build-helper-stamp.test.ts
+++ b/plugins/plugin-native-macosalarm/__tests__/build-helper-stamp.test.ts
@@ -6,14 +6,26 @@
  * machine with a drifted Swift toolchain is the difference between a working
  * build and a hard failure (#23776).
  *
- * These tests pin the decision to the source's content instead.
+ * These tests pin the decision to the source's content and the helper's Mach-O
+ * architecture instead.
  */
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readFileSync, utimesSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import {
+  helperCacheIsCurrent,
+  readMachOCpuTypes,
+} from "../scripts/build-helper.mjs";
 
 const pkgRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -24,6 +36,25 @@ const source = path.join(pkgRoot, "swift-helper", "main.swift");
 const stamp = path.join(pkgRoot, "bin", "macosalarm-helper.source.sha256");
 
 const COMPILE_FLAGS = ["-O"];
+const CPU_X86_64 = 0x01000007;
+const CPU_ARM64 = 0x0100000c;
+
+function thinMachO(cpuType: number): Buffer {
+  const bytes = Buffer.alloc(32);
+  bytes.writeUInt32LE(0xfeedfacf, 0);
+  bytes.writeUInt32LE(cpuType, 4);
+  return bytes;
+}
+
+function universalMachO(cpuTypes: number[]): Buffer {
+  const bytes = Buffer.alloc(8 + cpuTypes.length * 20);
+  bytes.writeUInt32BE(0xcafebabe, 0);
+  bytes.writeUInt32BE(cpuTypes.length, 4);
+  for (const [index, cpuType] of cpuTypes.entries()) {
+    bytes.writeUInt32BE(cpuType, 8 + index * 20);
+  }
+  return bytes;
+}
 
 function expectedStamp(): string {
   return createHash("sha256")
@@ -55,6 +86,45 @@ function makeNewest(target: string): void {
   const future = new Date(Date.now() + 10_000);
   utimesSync(target, future, future);
 }
+
+describe("Mach-O architecture cache validity", () => {
+  it("reads thin and universal helper architecture declarations", () => {
+    expect(readMachOCpuTypes(thinMachO(CPU_ARM64))).toEqual([CPU_ARM64]);
+    expect(readMachOCpuTypes(universalMachO([CPU_X86_64, CPU_ARM64]))).toEqual([
+      CPU_X86_64,
+      CPU_ARM64,
+    ]);
+  });
+
+  it("rejects a matching source stamp when the helper slice is wrong", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "macosalarm-arch-"));
+    const binaryPath = path.join(directory, "helper");
+    const stampPath = path.join(directory, "helper.source.sha256");
+    try {
+      writeFileSync(stampPath, "same-source-and-flags\n");
+      writeFileSync(binaryPath, thinMachO(CPU_ARM64));
+
+      expect(
+        helperCacheIsCurrent({
+          binaryPath,
+          stampPath,
+          expectedStamp: "same-source-and-flags",
+          targetArch: "x64",
+        }),
+      ).toBe(false);
+      expect(
+        helperCacheIsCurrent({
+          binaryPath,
+          stampPath,
+          expectedStamp: "same-source-and-flags",
+          targetArch: "arm64",
+        }),
+      ).toBe(true);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});
 
 const onDarwin = process.platform === "darwin" ? describe : describe.skip;
 
@@ -100,5 +170,5 @@ onDarwin("build-helper currency check", () => {
       writeFileSync(script, original);
       runBuildSkipped();
     }
-  });
+  }, 60_000);
 });

--- a/plugins/plugin-native-macosalarm/scripts/build-helper.mjs
+++ b/plugins/plugin-native-macosalarm/scripts/build-helper.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
-// Builds the macOS alarm helper binary via `swiftc`.
-//
-// Outputs the binary to `bin/macosalarm-helper` inside this package so the
-// TS runtime can locate it deterministically. Skips on non-darwin platforms.
+/**
+ * Builds the macOS alarm helper with a content- and architecture-aware cache.
+ * The tracked helper may be reused only when its source stamp and Mach-O slice
+ * both match the current Node target; this keeps Intel and Apple Silicon
+ * release artifacts from packaging an incompatible thin binary.
+ */
 
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -22,15 +24,74 @@ const verbosePluginBuild = process.env.ELIZA_VERBOSE_PLUGIN_BUILD === "1";
 const forceHelperBuild =
   process.env.ELIZA_MACOSALARM_FORCE_HELPER_BUILD === "1";
 
-if (process.platform !== "darwin") {
-  console.warn(
-    `[macosalarm] skipping swift helper build on ${process.platform}`,
-  );
-  process.exit(0);
+const MACHO_CPU_TYPES = {
+  arm64: 0x0100000c,
+  x64: 0x01000007,
+};
+
+const THIN_MAGICS = new Map([
+  ["cefaedfe", "le"],
+  ["cffaedfe", "le"],
+  ["feedface", "be"],
+  ["feedfacf", "be"],
+]);
+
+const FAT_MAGICS = new Map([
+  ["cafebabe", { endian: "be", entrySize: 20 }],
+  ["cafebabf", { endian: "be", entrySize: 32 }],
+  ["bebafeca", { endian: "le", entrySize: 20 }],
+  ["bfbafeca", { endian: "le", entrySize: 32 }],
+]);
+
+function readUInt32(bytes, offset, endian) {
+  return endian === "le"
+    ? bytes.readUInt32LE(offset)
+    : bytes.readUInt32BE(offset);
 }
 
-if (!existsSync(source)) {
-  throw new Error(`macosalarm swift source missing: ${source}`);
+/** Returns the CPU types declared by a thin or universal Mach-O header. */
+export function readMachOCpuTypes(bytes) {
+  if (bytes.length < 8) return [];
+
+  const magic = bytes.subarray(0, 4).toString("hex");
+  const thinEndian = THIN_MAGICS.get(magic);
+  if (thinEndian) return [readUInt32(bytes, 4, thinEndian)];
+
+  const fat = FAT_MAGICS.get(magic);
+  if (!fat) return [];
+
+  const sliceCount = readUInt32(bytes, 4, fat.endian);
+  const headerBytes = 8 + sliceCount * fat.entrySize;
+  if (sliceCount === 0 || !Number.isSafeInteger(headerBytes)) return [];
+  if (headerBytes > bytes.length) return [];
+
+  const cpuTypes = [];
+  for (let index = 0; index < sliceCount; index += 1) {
+    cpuTypes.push(readUInt32(bytes, 8 + index * fat.entrySize, fat.endian));
+  }
+  return cpuTypes;
+}
+
+/** Checks whether a Mach-O binary contains the requested Node architecture. */
+export function helperSupportsArchitecture(binaryPath, targetArch) {
+  const cpuType = MACHO_CPU_TYPES[targetArch];
+  if (cpuType === undefined || !existsSync(binaryPath)) return false;
+  return readMachOCpuTypes(readFileSync(binaryPath)).includes(cpuType);
+}
+
+/** Applies every cache-validity condition without invoking the compiler. */
+export function helperCacheIsCurrent({
+  binaryPath,
+  stampPath,
+  expectedStamp,
+  targetArch,
+}) {
+  if (!existsSync(binaryPath) || !existsSync(stampPath)) return false;
+  const stamped = readFileSync(stampPath, "utf8").trim();
+  return (
+    stamped === expectedStamp &&
+    helperSupportsArchitecture(binaryPath, targetArch)
+  );
 }
 
 // Flags that change the emitted binary. Deliberately excludes the absolute
@@ -39,60 +100,90 @@ if (!existsSync(source)) {
 // every machine and destroy its value as a drift guard.
 const COMPILE_FLAGS = ["-O"];
 
-const swiftcArgs = [
-  source,
-  ...COMPILE_FLAGS,
-  "-module-cache-path",
-  moduleCacheDir,
-  "-o",
-  outBin,
-];
-
 const sourceHash = createHash("sha256")
   .update(readFileSync(source))
   .update("\0")
   .update(COMPILE_FLAGS.join(" "))
   .digest("hex");
 
-// Keyed on the source's content, not on its timestamp. The helper binary and
-// its source are both tracked, and git assigns every file the checkout time —
-// so an mtime comparison here decided whether `swiftc` ran based on which of
-// the two git happened to write first, milliseconds apart. That made the build
-// succeed or fail at random on a fresh clone, worktree, CI cache restore or
-// `cp -r`, none of which preserve relative mtimes (#23776).
-if (!forceHelperBuild && existsSync(outBin) && existsSync(outStamp)) {
-  const stamped = readFileSync(outStamp, "utf8").trim();
-  if (stamped === sourceHash) {
+export function buildHelper() {
+  if (process.platform !== "darwin") {
+    console.warn(
+      `[macosalarm] skipping swift helper build on ${process.platform}`,
+    );
+    return;
+  }
+
+  if (!existsSync(source)) {
+    throw new Error(`macosalarm swift source missing: ${source}`);
+  }
+
+  // Keyed on source content and stable compile flags, then separately checked
+  // for a compatible Mach-O slice. The tracked ARM64 helper must never satisfy
+  // the cache on an Intel release runner merely because its stamp matches.
+  if (
+    !forceHelperBuild &&
+    helperCacheIsCurrent({
+      binaryPath: outBin,
+      stampPath: outStamp,
+      expectedStamp: sourceHash,
+      targetArch: process.arch,
+    })
+  ) {
     if (verbosePluginBuild) {
       console.log(`[macosalarm] helper already current: ${outBin}`);
     }
-    process.exit(0);
+    return;
+  }
+
+  mkdirSync(outDir, { recursive: true });
+  mkdirSync(tempDir, { recursive: true });
+
+  const result = spawnSync(
+    "swiftc",
+    [
+      source,
+      ...COMPILE_FLAGS,
+      "-module-cache-path",
+      moduleCacheDir,
+      "-o",
+      outBin,
+    ],
+    {
+      env: {
+        ...process.env,
+        // Keep compiler caches inside the package so sandboxed/local builds do
+        // not need write access to ~/.cache/clang.
+        CLANG_MODULE_CACHE_PATH:
+          process.env.CLANG_MODULE_CACHE_PATH ?? moduleCacheDir,
+        TMPDIR: process.env.TMPDIR ?? tempDir,
+      },
+      stdio: "inherit",
+    },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(`swiftc failed with status ${result.status ?? "unknown"}`);
+  }
+
+  if (!helperSupportsArchitecture(outBin, process.arch)) {
+    throw new Error(
+      `swiftc produced a helper without a ${process.arch} Mach-O slice: ${outBin}`,
+    );
+  }
+
+  // Write the stamp only after checking the emitted artifact. A failed or
+  // wrong-target compiler invocation must not make the next build skip.
+  writeFileSync(outStamp, `${sourceHash}\n`);
+
+  if (verbosePluginBuild) {
+    console.log(`[macosalarm] built ${outBin}`);
   }
 }
 
-mkdirSync(outDir, { recursive: true });
-mkdirSync(tempDir, { recursive: true });
-
-const result = spawnSync("swiftc", swiftcArgs, {
-  env: {
-    ...process.env,
-    // Keep compiler caches inside the package so sandboxed/local builds do not
-    // need write access to ~/.cache/clang.
-    CLANG_MODULE_CACHE_PATH:
-      process.env.CLANG_MODULE_CACHE_PATH ?? moduleCacheDir,
-    TMPDIR: process.env.TMPDIR ?? tempDir,
-  },
-  stdio: "inherit",
-});
-
-if (result.status !== 0) {
-  throw new Error(`swiftc failed with status ${result.status ?? "unknown"}`);
-}
-
-// Record what this binary was built from, so the next build can tell whether it
-// is current without consulting a timestamp.
-writeFileSync(outStamp, `${sourceHash}\n`);
-
-if (verbosePluginBuild) {
-  console.log(`[macosalarm] built ${outBin}`);
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  buildHelper();
 }


### PR DESCRIPTION
# Relates to

Fixes #23802

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto live `develop@de7e2e62c936ec2282edda0ea30f8f95596066c0` with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` and the scoped package gates were run after sync. `bun run verify` reached the monorepo Turbo lane and is blocked only by unrelated formatting defects already present on the base; exact paths are recorded below.
- [x] A reviewer can confirm the build decision and emitted artifact without reading the implementation from the mutation transcript, forced compiler run, Mach-O slice output, helper invocation, and package manifest below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@de7e2e62c936ec2282edda0ea30f8f95596066c0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto live `develop@de7e2e62c936ec2282edda0ea30f8f95596066c0`; zero conflicts.
- [x] Scoped source gates pass at exact head `944058b196443fadb6b370e8442c8858b02ac531`; the unrelated aggregate blockers are documented under **Known gaps / failures**.

# Risks

Low. The cache now reads the helper's Mach-O header before skipping `swiftc`. It recognizes thin 32/64-bit and universal 32/64-bit headers in both byte orders, and fails closed for malformed files or unsupported Node architectures. A cache miss only invokes the existing compiler path. The compiler output is checked before the source stamp is written, so a wrong-target or malformed output cannot poison the next build.

# Background

## What does this PR do?

The tracked helper is a thin ARM64 Mach-O, but its cache stamp contains only Swift source content and compile flags. On an Intel release runner, a matching stamp therefore allowed the ARM64 helper to survive without compilation.

This change:

1. parses thin and universal Mach-O headers and maps Node `arm64` / `x64` targets to their CPU types;
2. requires both the existing source-and-flags stamp and a compatible binary slice before treating the helper as current;
3. verifies the newly compiled helper slice before writing the stamp;
4. adds an architecture-mismatch regression plus thin/universal parser coverage; and
5. corrects the README's packaging contract: `bin/` is included in the published package.

## What kind of change is this?

Bug fix (non-breaking build and packaging correction).

# Documentation changes needed?

The package README is updated to describe the tracked prebuilt helper, architecture validation, and rebuild behavior.

# Testing

## Where should a reviewer start?

`plugins/plugin-native-macosalarm/scripts/build-helper.mjs`, then `plugins/plugin-native-macosalarm/__tests__/build-helper-stamp.test.ts`.

## Detailed testing steps

```bash
bun install --frozen-lockfile --ignore-scripts
node packages/shared/scripts/generate-keywords.mjs
bun run build:core
bun run --cwd plugins/plugin-native-macosalarm test
bun run --cwd plugins/plugin-native-macosalarm typecheck
bun run --cwd plugins/plugin-native-macosalarm lint:check
ELIZA_MACOSALARM_FORCE_HELPER_BUILD=1 ELIZA_VERBOSE_PLUGIN_BUILD=1 \
  bun run --cwd plugins/plugin-native-macosalarm build
file plugins/plugin-native-macosalarm/bin/macosalarm-helper
lipo -archs plugins/plugin-native-macosalarm/bin/macosalarm-helper
plugins/plugin-native-macosalarm/bin/macosalarm-helper </dev/null
bun pm pack --dry-run
```

Exact-head results:

```text
Test Files  4 passed (4)
Tests       27 passed (27)

$ tsc --noEmit -p tsconfig.json
$ bunx @biomejs/biome check .
Checked 13 files. No fixes applied.

[macosalarm] built .../bin/macosalarm-helper
.../bin/macosalarm-helper: Mach-O 64-bit executable arm64
arm64
invocation_exit=2
[macosalarm-helper] invalid request: empty stdin
{"error":"invalid-request: empty stdin","success":false}

bun pack: bin/macosalarm-helper (113.73KB) and
bin/macosalarm-helper.source.sha256 are both included.
```

Mutation guard: with only the architecture predicate removed from `helperCacheIsCurrent`, the exact new regression failed:

```text
FAIL Mach-O architecture cache validity >
  rejects a matching source stamp when the helper slice is wrong
AssertionError: expected true to be false
Test Files 1 failed (1)
Tests 1 failed | 4 passed (5)
```

After restoring the predicate, the same file passed 5/5 and the full package passed 27/27.

# Evidence Gate

<!-- evidence-head:944058b196443fadb6b370e8442c8858b02ac531 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - build-only native artifact change with no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - build-only native artifact change with no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - the observable contract is deterministic compiler/cache behavior and Mach-O artifact metadata, captured inline above.`
<!-- evidence-row:backend-logs -->
- [x] [23923-backend-944058b.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23923-backend-944058b.log)
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend, HTTP, or network path is changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - deterministic build tooling only; no agent, action, provider, prompt, or model behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] [23923-domain-944058b.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23923-domain-944058b.md)
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic build tooling only.`

## Backend + frontend logs

Backend/build artifact logs are included under **Testing**. Frontend is `N/A`.

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no audio, voice, transcript, TTS, or STT behavior changes.`

## Known gaps / failures

- **Intel hosted acceptance hold (PR remains ready):** the source-level x64 mismatch is covered deterministically, but this Apple Silicon machine cannot perform a real x64 `swiftc` build/invocation. Before merge, the supported `macos-15-intel` release runner must compile, report an `x86_64` slice, and execute the helper's invalid-input boundary. This is protected hosted-runner evidence, not a source-completeness or draft-status blocker.
- `bun run verify` reached the repository Turbo typecheck/lint lane after a pinned install refresh. It is blocked by unrelated base formatting defects, including `packages/app/scripts/mobile-local-chat-smoke.mjs`, `packages/ui/src/components/chat/widgets/maps-card.tsx`, `packages/agent/src/api/accounts-routes.ts`, and `plugins/plugin-personal-assistant/src/actions/lib/scheduling-handler.surrogate.test.ts`. The changed `@elizaos/macosalarm` package's tests, typecheck, lint, build, artifact inspection, and pack inspection all pass at the exact head.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@de7e2e62c936ec2282edda0ea30f8f95596066c0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-23802-macosalarm-arch]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@de7e2e62c936ec2282edda0ea30f8f95596066c0:packages/skills/skills/contribute-to-eliza"} -->

