### PR TITLE
fix(workflow): preserve nested LifeOps dispatch ancestry

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/domains/workflows-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/workflows-service.ts
@@ -978,6 +978,7 @@ export class WorkflowsDomain {
     args: {
       startedAt: string;
       confirmBrowserActions: boolean;
+      triggerChainDepth?: number;
       request: Record<string, unknown>;
       /**
        * Replay guard. A keyed run is reserved durably before its first step,
@@ -1093,6 +1094,7 @@ export class WorkflowsDomain {
     args: {
       startedAt: string;
       confirmBrowserActions: boolean;
+      triggerChainDepth?: number;
       request: Record<string, unknown>;
       idempotencyKey?: string | null;
     },
@@ -1160,6 +1162,7 @@ export class WorkflowsDomain {
           definition,
           startedAt: args.startedAt,
           confirmBrowserActions: args.confirmBrowserActions,
+          triggerChainDepth: args.triggerChainDepth ?? 0,
           request: args.request,
           outputs,
           previousStepValue: steps.at(-1)?.value ?? null,

--- a/plugins/plugin-personal-assistant/src/lifeops/registries/workflow-step-default-pack.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/registries/workflow-step-default-pack.ts
@@ -259,6 +259,7 @@ interface WorkflowDispatchServiceLike {
   execute?: (
     workflowId: string,
     payload?: Record<string, unknown>,
+    options?: { triggerChainDepth?: number },
   ) => Promise<unknown>;
 }
 
@@ -282,11 +283,15 @@ const dispatchWorkflowContribution: AnyWorkflowStepContribution = {
         error: "WORKFLOW_DISPATCH service not registered",
       };
     }
-    return dispatch.execute(typed.workflowId, {
-      ...(typed.payload ?? {}),
-      request: args.request,
-      outputs: args.outputs,
-    });
+    return dispatch.execute(
+      typed.workflowId,
+      {
+        ...(typed.payload ?? {}),
+        request: args.request,
+        outputs: args.outputs,
+      },
+      { triggerChainDepth: args.triggerChainDepth + 1 },
+    );
   },
 };
 

--- a/plugins/plugin-personal-assistant/src/lifeops/registries/workflow-step-registry.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/registries/workflow-step-registry.ts
@@ -96,6 +96,8 @@ export interface WorkflowStepExecuteArgs {
   readonly definition: LifeOpsWorkflowDefinition;
   readonly startedAt: string;
   readonly confirmBrowserActions: boolean;
+  /** Trigger ancestry inherited by native workflows dispatched from this run. */
+  readonly triggerChainDepth: number;
   readonly request: Record<string, unknown>;
   readonly outputs: Record<string, unknown>;
   readonly previousStepValue: unknown;

--- a/plugins/plugin-personal-assistant/test/workflow-step-registry.test.ts
+++ b/plugins/plugin-personal-assistant/test/workflow-step-registry.test.ts
@@ -13,7 +13,7 @@
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import {
   __resetWorkflowStepRegistryForTests,
@@ -73,6 +73,7 @@ function makeStubArgs(): WorkflowStepExecuteArgs {
     } as unknown as WorkflowStepExecuteArgs["definition"],
     startedAt: "2026-05-09T00:00:00.000Z",
     confirmBrowserActions: false,
+    triggerChainDepth: 0,
     request: {},
     outputs: {},
     previousStepValue: null,
@@ -229,6 +230,44 @@ describe("WorkflowStepRegistry", () => {
     )) as { text: string };
     expect(typeof result.text).toBe("string");
     expect(result.text.length).toBeGreaterThan(0);
+  });
+
+  it("dispatch_workflow advances trigger ancestry for the nested execution", async () => {
+    const execute = vi.fn(async () => ({ ok: true, executionId: "run-1" }));
+    const registry = createWorkflowStepRegistry();
+    registerDefaultWorkflowStepPack(registry);
+    const dispatchWorkflow = registry.get("dispatch_workflow");
+    expect(dispatchWorkflow).not.toBeNull();
+    const validated = dispatchWorkflow?.paramSchema.parse({
+      kind: "dispatch_workflow",
+      workflowId: "nested-workflow",
+      payload: { source: "lifeops" },
+    });
+    const args: WorkflowStepExecuteArgs = {
+      ...makeStubArgs(),
+      triggerChainDepth: 3,
+      request: { requestId: "request-1" },
+      outputs: { prepared: true },
+    };
+    const ctx = {
+      ...makeStubCtx(),
+      runtime: {
+        getService: (serviceType: string) =>
+          serviceType === "WORKFLOW_DISPATCH" ? { execute } : null,
+      },
+    } as unknown as WorkflowStepExecuteContext;
+
+    await dispatchWorkflow?.execute(validated, args, ctx);
+
+    expect(execute).toHaveBeenCalledWith(
+      "nested-workflow",
+      {
+        source: "lifeops",
+        request: { requestId: "request-1" },
+        outputs: { prepared: true },
+      },
+      { triggerChainDepth: 4 },
+    );
   });
 
   it("default browser contribution short-circuits when permissionPolicy.allowBrowserActions=false", async () => {


### PR DESCRIPTION
# Relates to

- Corrects the residual identified after merged PR #23876.
- Post-merge race record: https://github.com/elizaOS/eliza/pull/23876#issuecomment-5373671165

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto the latest `origin/develop` with zero conflicts before its exact-head gates.
- [x] `bun install --frozen-lockfile` completed. Exact focused tests and builds are recorded below; broader pre-existing typecheck blockers are recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the changed dispatch contract from the exact invocation and focused regression evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2dce0115934c5b5c9bb48d18dc0603cbf9a9384e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `de7e2e62c936ec2282edda0ea30f8f95596066c0`; zero conflicts.
- [x] Exact focused validation passes. The unrelated aggregate typecheck blockers are documented below.

# Risks

Low. The change adds one typed ancestry field to LifeOps step execution and passes `parentDepth + 1` to the already-shipped `WORKFLOW_DISPATCH.execute` options contract. The principal risk is an off-by-one or omitted propagation; the new regression asserts depth 3 becomes 4 at the registered contribution boundary.

# Background

## What does this PR do?

Merged #23876 moved workflow-trigger ancestry from stale runtime-global state into each execution payload. A concurrent force-push race caused its separately reviewed personal-assistant caller repair to be omitted from the merged head. This PR restores only that four-file residual:

- carry the current ancestry through LifeOps workflow step arguments;
- have `dispatch_workflow` invoke `WORKFLOW_DISPATCH.execute` with `{ triggerChainDepth: current + 1 }`;
- cover the real registered default contribution and its exact payload/options call.

## What kind of change is this?

Bug fix (non-breaking correction to nested workflow ancestry propagation).

# Documentation changes needed?

No. This completes an internal typed dispatch invariant documented by the existing source contracts; it does not change user-facing configuration or workflow authoring syntax.

# Testing

## Where should a reviewer start?

Start with `plugins/plugin-personal-assistant/test/workflow-step-registry.test.ts`, then inspect `workflow-step-default-pack.ts` and the `WorkflowStepExecuteArgs` construction in `workflows-service.ts`.

## Detailed testing steps

All results below are from exact head `2dce0115934c5b5c9bb48d18dc0603cbf9a9384e`:

- `bun run --cwd plugins/plugin-personal-assistant test -- test/workflow-step-registry.test.ts` — 1 file, 9/9 passed.
- `bun test --isolate plugins/plugin-workflow/__tests__/unit/workflow-dispatch.test.ts plugins/plugin-workflow/__tests__/unit/embedded-workflow-lifecycle.test.ts` — 2 files, 12/12 passed, 50 assertions, real PGlite lifecycle.
- `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/triggers/runtime.test.ts` — 45/45 passed.
- `bunx vitest run --config packages/app-core/vitest.config.ts packages/app-core/scripts/assert-required-bundled-packages.test.ts` — 25/25 passed.
- `bun run --cwd plugins/plugin-workflow typecheck` — passed.
- `bun run --cwd plugins/plugin-personal-assistant build` — passed.
- `bun run --cwd plugins/plugin-workflow build` — passed.
- Biome over all four changed files — passed, no fixes.
- `git diff --check origin/develop...HEAD` — passed.
- Earlier full core/app-core/agent dependency build in the same isolated worktree — 59/59 Turbo tasks passed.

# Evidence Gate

<!-- evidence-head:2dce0115934c5b5c9bb48d18dc0603cbf9a9384e -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is an internal service-to-service dispatch contract with no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server transport changes; exact in-process service invocation is captured by the regression output below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network request changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, provider, or action-selection behavior changes; the changed path is deterministic ancestry metadata plumbing.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head domain artifact: the real registered contribution produced the expected nested dispatcher invocation, and the adjacent workflow lifecycle persisted/re-emitted ancestry in 12/12 passing tests.

```text
parent triggerChainDepth: 3
observed WORKFLOW_DISPATCH options: { triggerChainDepth: 4 }
workflow dispatch + real PGlite embedded lifecycle: 12 passed, 0 failed, 50 assertions
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered text or visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic typed dispatch metadata only; no LLM call is involved in the changed boundary.

## Backend + frontend logs

The exact registered contribution regression observed:

```text
WORKFLOW_DISPATCH.execute(
  "nested-workflow",
  { source: "lifeops", request: { requestId: "request-1" }, outputs: { prepared: true } },
  { triggerChainDepth: 4 },
)
```

The test supplies parent depth `3`, invokes the contribution returned by `createWorkflowStepRegistry()` plus `registerDefaultWorkflowStepPack()`, and asserts the full payload and third options argument. Exact-head result: 9/9 passed.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no voice, transcript, STT, or TTS changes.

## Known gaps / failures

- `plugins/plugin-personal-assistant typecheck` remains blocked by existing unbuilt workspace dependency exports and unrelated existing errors; none names any of the four changed files. The package's declaration build passes.
- `packages/agent typecheck` reports three existing `character-history.test.ts` fixture errors; none is in the trigger runtime or this diff.
- `packages/app-core typecheck` reports existing unavailable native Capacitor package declarations and downstream unknown types; none is in this diff. The focused package-inventory test and full app-core build pass.
- Hosted checks remain ordinary merge gates while this PR stays ready for review.

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex Desktop  
Contribution skill revision: elizaOS/eliza@2dce0115934c5b5c9bb48d18dc0603cbf9a9384e:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported  
— [correct-23876-nested]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2dce0115934c5b5c9bb48d18dc0603cbf9a9384e:packages/skills/skills/contribute-to-eliza"} -->
