### PR TITLE
fix(plugin-cli-inference): restore payload fidelity in the bounded walk

### DIFF
--- a/plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts
@@ -213,6 +213,20 @@ describe("toolOutputToText — no over-rejection of ordinary payloads", () => {
     expect(out.length).toBeLessThan(9 * MiB);
   });
 
+  it("charges property names, so sibling objects with huge keys are bounded", () => {
+    // #23891 charged nested values and dropped the terminal charge that used to
+    // account for keys and serialization syntax, which made property names free
+    // forever. Reported on that PR by @lalalune; this pins the fix.
+    const bigKey = (char: string): Record<string, number> => {
+      const object: Record<string, number> = {};
+      object[char.repeat(3 * MiB)] = 1;
+      return object;
+    };
+    const out = contentToText([toolResult([bigKey("a"), bigKey("b"), bigKey("c")])]);
+    expect(out).toContain(TOOL_PAYLOAD_BUDGET_MARKER);
+    expect(out.length).toBeLessThan(9 * MiB);
+  });
+
   it("cannot be made to throw by a getTime override on a Date-shaped payload", () => {
     // `JSON.stringify` reaches the internal slot via the builtin `valueOf`, so
     // the parent path survived this. Direct `object.getTime()` dispatch made it

--- a/plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts
@@ -15,6 +15,8 @@
  *  2. Ordinary payloads still flatten byte-identically — the guard must not
  *     reject anything the live path accepts today.
  */
+
+import { runInNewContext } from "node:vm";
 import type { ChatMessage, ChatMessageContentPart } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
@@ -209,6 +211,59 @@ describe("toolOutputToText — no over-rejection of ordinary payloads", () => {
     ]);
     expect(out).toContain(TOOL_PAYLOAD_BUDGET_MARKER);
     expect(out.length).toBeLessThan(9 * MiB);
+  });
+
+  it("cannot be made to throw by a getTime override on a Date-shaped payload", () => {
+    // `JSON.stringify` reaches the internal slot via the builtin `valueOf`, so
+    // the parent path survived this. Direct `object.getTime()` dispatch made it
+    // an uncaught throw out of contentToText -> flattenPrompt.
+    class EvilTime extends Date {
+      getTime(): number {
+        throw new Error("attacker code ran");
+      }
+      toISOString(): string {
+        throw new Error("attacker code ran");
+      }
+    }
+    expect(() => contentToText([toolResult({ when: new EvilTime(0) })])).not.toThrow();
+    expect(contentToText([toolResult({ when: new EvilTime(0) })])).toBe(
+      `[tool_result WEB_FETCH: ${JSON.stringify({ when: new Date(0) })}]`
+    );
+  });
+
+  it("renders an own __proto__ data property instead of silently dropping it", () => {
+    // JSON.parse produces a real own "__proto__" key; plain assignment into the
+    // projection hit the Object.prototype setter and the member vanished with
+    // no marker.
+    const payload = JSON.parse('{"__proto__":{"polluted":1},"keep":2}');
+    expect(Object.getOwnPropertyNames(payload)).toContain("__proto__");
+    const out = contentToText([toolResult(payload)]);
+    expect(out).toBe(`[tool_result WEB_FETCH: ${JSON.stringify(payload)}]`);
+    expect(out).toContain("polluted");
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("preserves Buffer and URL shape, and still bounds a large Buffer", () => {
+    expect(contentToText([toolResult(Buffer.from("hi"))])).toBe(
+      '[tool_result WEB_FETCH: {"type":"Buffer","data":[104,105]}]'
+    );
+    expect(contentToText([toolResult(new URL("https://e.com/x"))])).toBe(
+      '[tool_result WEB_FETCH: "https://e.com/x"]'
+    );
+    // Byte count is charged, so a buffer wider than the node budget is marked
+    // rather than materialized into a multi-megabyte index array.
+    expect(contentToText([toolResult(Buffer.alloc(200_000))])).toContain(
+      TOOL_PAYLOAD_BUDGET_MARKER
+    );
+  });
+
+  it("renders a cross-realm Date rather than an empty object", () => {
+    const CrossRealmDate = runInNewContext("Date") as DateConstructor;
+    const value = new CrossRealmDate(0);
+    expect(value instanceof Date).toBe(false);
+    expect(contentToText([toolResult({ at: value })])).toBe(
+      `[tool_result WEB_FETCH: ${JSON.stringify({ at: new Date(0) })}]`
+    );
   });
 
   it("still returns a single oversized body whole, nested or bare", () => {

--- a/plugins/plugin-cli-inference/src/prompt-flatten.ts
+++ b/plugins/plugin-cli-inference/src/prompt-flatten.ts
@@ -89,6 +89,20 @@ function chargeChars(budget: PayloadBudget, text: string): string {
   return text;
 }
 
+/**
+ * Charge a property name against the character budget. Nested *values* are
+ * charged as they are projected, but the serialized output also carries every
+ * key, and #23891 removed the terminal charge that used to account for them —
+ * so without this a payload made of megabyte-sized keys is free forever.
+ * Same check-before-charge rule as `chargeChars`; false means the container
+ * must collapse to the budget marker.
+ */
+function chargeKeyChars(budget: PayloadBudget, key: string): boolean {
+  if (budget.chars > MAX_TOOL_PAYLOAD_CHARS) return false;
+  budget.chars += key.length;
+  return true;
+}
+
 /** Charge container width before allocating anything for its elements. */
 function chargeWidth(budget: PayloadBudget, width: number): boolean {
   budget.nodes += width;
@@ -201,6 +215,7 @@ function toBoundedJsonValue(
     for (const key of keys) {
       const descriptor = Object.getOwnPropertyDescriptor(object, key);
       if (!descriptor || !("value" in descriptor)) continue;
+      if (!chargeKeyChars(budget, key)) return TOOL_PAYLOAD_BUDGET_MARKER;
       const nested = toBoundedJsonValue(descriptor.value, budget, depth + 1);
       if (nested === undefined) continue;
       projected[key] = nested;

--- a/plugins/plugin-cli-inference/src/prompt-flatten.ts
+++ b/plugins/plugin-cli-inference/src/prompt-flatten.ts
@@ -95,6 +95,18 @@ function chargeWidth(budget: PayloadBudget, width: number): boolean {
   return budget.nodes <= MAX_TOOL_PAYLOAD_NODES;
 }
 
+/** Realm-independent brand, read without invoking anything on the value. */
+function brandOf(value: object): string {
+  return Object.prototype.toString.call(value);
+}
+
+/** Buffer/Uint8Array brand check that does not depend on a `Buffer` global. */
+function isBufferValue(value: object): boolean {
+  return (
+    typeof Buffer !== "undefined" && typeof Buffer.isBuffer === "function" && Buffer.isBuffer(value)
+  );
+}
+
 /**
  * Own data property, or `undefined`. Accessors are reported as absent and are
  * never invoked — an attacker-supplied getter must not run during prompt
@@ -135,9 +147,29 @@ function toBoundedJsonValue(
   if (kind === "bigint") return (value as bigint).toString();
   if (kind !== "object") return undefined; // undefined / function / symbol: dropped, as today
   const object = value as object;
-  if (object instanceof Date) {
-    const time = object.getTime();
-    return Number.isNaN(time) ? null : object.toISOString();
+  // Brand check, not `instanceof`: a Date from another realm fails the
+  // prototype test and used to fall through to the object branch, rendering
+  // `{}` and losing the timestamp entirely. Dispatch through the builtins so an
+  // attacker-supplied `getTime` / `toISOString` override on a Date-shaped
+  // payload can neither run nor throw out of prompt flattening — the same
+  // reason core's `flattenTextValues` uses `Date.prototype.getTime.call`.
+  if (brandOf(object) === "[object Date]") {
+    const time = Date.prototype.getTime.call(object as Date);
+    return Number.isNaN(time) ? null : Date.prototype.toISOString.call(object as Date);
+  }
+  // Buffer and URL both serialize to `{}` or an index map through the generic
+  // object branch, dropping the bytes / the href. Reproduce what the
+  // pre-bounded `JSON.stringify` path produced for each.
+  if (isBufferValue(object)) {
+    // Charge the byte count before materializing: the generic object branch
+    // used to charge one node per index key, so skipping straight to
+    // `Array.from` would let a multi-megabyte buffer through the node bound.
+    const bytes = object as Uint8Array;
+    if (!chargeWidth(budget, bytes.length)) return TOOL_PAYLOAD_BUDGET_MARKER;
+    return { type: "Buffer", data: Array.from(bytes) };
+  }
+  if (brandOf(object) === "[object URL]" || object instanceof URL) {
+    return String(URL.prototype.toString.call(object as URL));
   }
   if (depth >= MAX_TOOL_PAYLOAD_DEPTH) return TOOL_PAYLOAD_DEPTH_MARKER;
   if (budget.ancestors.has(object)) return TOOL_PAYLOAD_CYCLE_MARKER;
@@ -160,12 +192,18 @@ function toBoundedJsonValue(
   if (!chargeWidth(budget, keys.length)) return TOOL_PAYLOAD_BUDGET_MARKER;
   budget.ancestors.add(object);
   try {
-    const projected: Record<string, JsonSafe> = {};
+    // Null-prototype staging: on a plain `{}` an assignment of a
+    // `JSON.parse`-produced own `"__proto__"` key hits the `Object.prototype`
+    // setter and the member vanishes with no marker — silent truncation, which
+    // is exactly what the markers exist to prevent. With no prototype there is
+    // no setter to hit, so the key lands as an own data property.
+    const projected = Object.create(null) as Record<string, JsonSafe>;
     for (const key of keys) {
       const descriptor = Object.getOwnPropertyDescriptor(object, key);
       if (!descriptor || !("value" in descriptor)) continue;
       const nested = toBoundedJsonValue(descriptor.value, budget, depth + 1);
-      if (nested !== undefined) projected[key] = nested;
+      if (nested === undefined) continue;
+      projected[key] = nested;
     }
     return projected;
   } finally {


### PR DESCRIPTION
# Relates to

Completes the remaining scope of #23885 - sections 3, 4 and 5 - **and repairs a regression I introduced in #23891**, which merged while this was in progress. @lalalune's exact-head review of that PR found that removing the terminal `chargeChars` left property names uncharged forever; the reproducer and the fix are the third commit here.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the single failure is unrelated and pre-existing - see **Known gaps**.
- [x] A reviewer can confirm every claim from the parent-vs-branch transcript below without reading the code.

<!-- evidence-head:9b5f5ae077e1b0a06705c6f66c7741f80d836fb9 -->

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

**Low.** The fidelity changes move behavior back toward the pre-bounded path; the key-charging change restores accounting that #23891 removed.

- The Date branch no longer dispatches through attacker-reachable overrides, so it can only stop executing untrusted code, never start.
- Buffer, URL and cross-realm Date previously produced an empty object or an index map; they now produce what `JSON.stringify` produced before the bounded walk landed.
- The Buffer branch charges the byte count **before** materializing, so it cannot be used to bypass the node bound - verified against 200k and 5M byte buffers.
- The projection is staged on a null-prototype object and immediately serialized, so restoring `__proto__` as data cannot pollute anything; a test asserts the global stays clean.
- Key charging uses the same check-before-charge rule as `chargeChars`, so no payload that fit before stops fitting.

# Background

## What does this PR do?

| Section | Defect | Parent | Landed walk | This PR |
|---|---|---|---|---|
| 5 | throwing `getTime` override | renders ISO | **uncaught throw** | renders ISO |
| 4 | cross-realm Date | ISO string | empty object | ISO string |
| 4 | `Buffer.from("hi")` | `{"type":"Buffer","data":[104,105]}` | `{"0":104,"1":105}` | parent shape |
| 4 | `new URL(...)` | href string | empty object | href string |
| 3 | own `__proto__` data key | rendered | **silently dropped** | rendered |
| - | property names uncharged (my #23891 regression) | charged via terminal charge | **free forever** | charged |

Section 5 is the serious one and a genuine regression against the parent: `JSON.stringify` reaches a Date's timestamp through the builtin `valueOf` and never dispatches an override, but the walk called `object.getTime()` directly on untrusted input, so the throw escaped `contentToText` into `flattenPrompt`. Fixed by dispatching through `Date.prototype` for both `getTime` and `toISOString` - the same reason core's `flattenTextValues` uses `Date.prototype.getTime.call`.

## What kind of change is this?

Bug fix (non-breaking). No public type, export, or route change.

# Documentation changes needed?

No. Worth noting that the module docblock's claim that "no attacker-supplied getter or `toJSON` ever executes" is now true for the Date branch, where it previously was not.

# Testing

## Where should a reviewer start?

`toBoundedJsonValue` in `plugins/plugin-cli-inference/src/prompt-flatten.ts`, then the five new cases in `__tests__/prompt-flatten-bounded.test.ts`.

## Detailed testing steps

Parent-vs-branch, real `contentToText` execution. Full literal values are in the backend-logs transcript below.

```text
                                  BEFORE                       AFTER
EvilTime getTime override         UNCAUGHT Error: boom         ISO timestamp rendered
own __proto__ payload             member silently gone         rendered as data
Buffer.from('hi')                 index map                    parent Buffer shape
new URL('https://e.com/x')        empty object                 "https://e.com/x"
cross-realm Date                  empty object                 ISO timestamp rendered
Buffer.alloc(200_000)             marker (bounded)             marker (bounded)   <- preserved
3 objects with 3MiB KEYS          9,437,221 no marker          6,291,524 + MARKER
```

Suites: `prompt-flatten-bounded` + `cli-inference` gives **88 passed, 1 skipped (89)**. Typecheck, Biome and `git diff --check` clean. Five mutations, one per fix, each turning exactly its own test red - matrix in the domain-artifacts row.

# Known gaps / failures

- **`bun run verify` fails on one unrelated, pre-existing check** - `check:i18n`, 7 missing `connectoraccount.*` keys under `packages/ui`. Confirmed pre-existing by running `bun run check:i18n` on clean `origin/develop` at `8e5e0ff034` with none of this branch's changes present: identical 7 keys. This branch touches only `plugins/plugin-cli-inference`.
- **A single object carrying two oversized keys still returns whole** (~6.3 MB, shown in the transcript). That is the same check-before-charge allowance that lets one oversized body through; it predates #23891 and I left it rather than change it silently.
- **Not addressed here, deliberately:** issue acceptance criteria 2 (cross-part aggregate bound) and the part of criterion 1 that asks a single 40 MiB string to produce a marker. Both are governed by documented design decisions - `newPayloadBudget`'s "one budget per tool part, so a large part never starves its siblings", and `chargeChars` checking before it charges so "a single 10 MB WEB_FETCH body flattens exactly as it does today". Changing either is a maintainer call about what the declared cap is meant to promise.
- Issue sections 6 (pin the budget constants) and 7 (sparse-array width, docblock claims) are untouched and remain open on #23885.

# Note for the reviewer

Two things I want to point at rather than bury.

The Buffer fix restores the parent shape with `Array.from(buffer)`, but the generic object branch it replaces used to charge one node per index key - so an unguarded version silently removes the node bound for buffers. I caught it with a 5 MB buffer flattening to 10 MB of output with no marker; the branch now charges `bytes.length` first.

The key-charging commit exists because @lalalune caught a real gap in my own merged PR. I reproduced it before fixing it, and the fix is the narrow one they suggested - account for keys without double-charging values - not a revert of #23891.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - server-side prompt flattening; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - server-side prompt flattening; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic pure-function path; the transcript below is the complete flow.
<!-- evidence-row:backend-logs -->
- [x] Parent-vs-branch execution transcript, inline below.

<details><summary>Backend transcript - real execution, revert asserted before every BEFORE block</summary>

```text
#23885 §3/§4/§5 — real contentToText() execution, parent vs this branch
branch head : 039b75642883299d00d94aaa2d110b6ab0deea50
stacked on  : 96b90bb795 (PR #23891)
BEFORE rows : 'git checkout origin/develop -- prompt-flatten.ts', revert asserted before running

--- BEFORE (origin/develop) ---
### §5 getTime() override (claimed P1 uncaught throw)
EvilTime instance                  -> UNCAUGHT Error: boom
EvilTime as whole output           -> UNCAUGHT Error: boom

### §3 own __proto__ data property (claimed silent drop)
  own keys: ["__proto__","keep"]
JSON.parse __proto__ payload       -> [tool_result T: {"keep":2}]
  parent JSON.stringify would give: {"__proto__":{"polluted":1},"keep":2}

### §4 Buffer / URL / cross-realm Date (claimed {} loss)
Buffer.from('hi')                  -> [tool_result T: {"0":104,"1":105}]
new URL(...)                       -> [tool_result T: {}]
  crossRealm instanceof Date: false | toString tag: [object Date]
cross-realm Date                   -> [tool_result T: {}]
same-realm Date (control)          -> [tool_result T: "1970-01-01T00:00:00.000Z"]

Buffer.alloc(        8) -> chars=        66 marker=false ms=2
Buffer.alloc(   200000) -> chars=        54 marker=true ms=32
Buffer.alloc(  5000000) -> chars=        54 marker=true ms=1771

--- AFTER (this branch) ---
### §5 getTime() override (claimed P1 uncaught throw)
EvilTime instance                  -> [tool_result T: {"when":"1970-01-01T00:00:00.000Z"}]
EvilTime as whole output           -> [tool_result T: "1970-01-01T00:00:00.000Z"]

### §3 own __proto__ data property (claimed silent drop)
  own keys: ["__proto__","keep"]
JSON.parse __proto__ payload       -> [tool_result T: {"__proto__":{"polluted":1},"keep":2}]
  parent JSON.stringify would give: {"__proto__":{"polluted":1},"keep":2}

### §4 Buffer / URL / cross-realm Date (claimed {} loss)
Buffer.from('hi')                  -> [tool_result T: {"type":"Buffer","data":[104,105]}]
new URL(...)                       -> [tool_result T: "https://e.com/x"]
  crossRealm instanceof Date: false | toString tag: [object Date]
cross-realm Date                   -> [tool_result T: "1970-01-01T00:00:00.000Z"]
same-realm Date (control)          -> [tool_result T: "1970-01-01T00:00:00.000Z"]

Buffer.alloc(        8) -> chars=        59 marker=false ms=1
Buffer.alloc(   200000) -> chars=        54 marker=true ms=0
Buffer.alloc(  5000000) -> chars=        54 marker=true ms=0

--- key-charging regression (@lalalune's reproducer from #23891) ---
BEFORE = origin/develop (contains #23891 as 1902359088)
  revert took? fixes present = 0 (expect 0)
  BEFORE array of 3 objects, 3MiB KEYS -> 9437221 marker: false
  BEFORE one object with two 3MiB KEYS  -> 6291484 marker: false
  restored? = 2 (expect >=1)
  AFTER  array of 3 objects, 3MiB KEYS -> 6291524 marker: true
  AFTER  one object with two 3MiB KEYS  -> 6291484 marker: false
```

</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, request, or state change.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model invocation; this bounds text before it reaches a model.
<!-- evidence-row:domain-artifacts -->
- [x] Suites and the five-way mutation matrix, inline below.

<details><summary>Suites and mutation matrix</summary>

```text
#23885 §3/§4/§5 — suites + mutation matrix

 Test Files  2 passed (2)
      Tests  87 passed | 1 skipped (88)

--- mutation matrix (each fix pinned by exactly one test; 21-test suite) ---
M1  Date.prototype.getTime.call -> (object as Date).getTime()
      × cannot be made to throw by a getTime override on a Date-shaped payload
      Tests  1 failed | 20 passed (21)

M2  Object.create(null) -> {}
      × renders an own __proto__ data property instead of silently dropping it
      Tests  1 failed | 20 passed (21)

M3  Buffer branch disabled
      × preserves Buffer and URL shape, and still bounds a large Buffer
      Tests  1 failed | 20 passed (21)

M4  brandOf(object) === "[object Date]" -> object instanceof Date
      × renders a cross-realm Date rather than an empty object
      Tests  1 failed | 20 passed (21)

No mutation fails another mutation's test, so the four fixes are independently pinned.

--- added: key-charging mutation ---
M5  remove chargeKeyChars guard
      × charges property names, so sibling objects with huge keys are bounded
      Tests  1 failed | 21 passed (22)

Suites at head: 88 passed | 1 skipped (89)
```

</details>

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

<!-- eliza-computer-attribution:v1 -->
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-eliza
Attribution status: self-reported
- [kenjohnscreates]
