### PR TITLE
fix(scheduling): honor edit request body framing

### DIFF
--- a/plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts
+++ b/plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts
@@ -66,7 +66,12 @@ function setRemoteAddress(socket: Socket, remoteAddress: string): void {
   });
 }
 
-function buildCtx(args: { method: string; pathname: string; body?: unknown }): {
+function buildCtx(args: {
+  method: string;
+  pathname: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+}): {
   ctx: SchedulingRouteContext;
   res: MockResponse;
 } {
@@ -75,9 +80,11 @@ function buildCtx(args: { method: string; pathname: string; body?: unknown }): {
   setRemoteAddress(socket, "127.0.0.1");
   const httpReq = new IncomingMessage(socket);
   httpReq.method = args.method;
-  httpReq.headers = args.body
-    ? { "content-type": "application/json", "content-length": "1" }
-    : {};
+  httpReq.headers =
+    args.headers ??
+    (args.body
+      ? { "content-type": "application/json", "content-length": "1" }
+      : {});
   const httpRes = new ServerResponse(httpReq);
 
   const ctx: SchedulingRouteContext = {
@@ -533,16 +540,76 @@ describe("scheduled-tasks REST handler", () => {
     async function edit(
       handler: (ctx: SchedulingRouteContext) => Promise<boolean>,
       taskId: string,
-      body: unknown,
+      body?: unknown,
+      headers?: Record<string, string>,
     ): Promise<MockResponse> {
       const { ctx, res } = buildCtx({
         method: "POST",
         pathname: `/api/lifeops/scheduled-tasks/${taskId}/edit`,
         body,
+        headers,
       });
       await handler(ctx);
       return res;
     }
+
+    it("rejects a body-less edit before the runner can persist an empty patch", async () => {
+      const { runner, handler, task } = await seed();
+      let applyCalls = 0;
+      const originalApply = runner.apply.bind(runner);
+      runner.apply = async (taskId, verb, payload) => {
+        applyCalls += 1;
+        return originalApply(taskId, verb, payload);
+      };
+
+      const res = await edit(handler, task.taskId);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toContain("request body is required");
+      expect(applyCalls).toBe(0);
+      expect(
+        (await runner.list()).find((item) => item.taskId === task.taskId),
+      ).toEqual(task);
+    });
+
+    it("reads and applies a chunked edit without a content-length header", async () => {
+      const { runner, handler, task } = await seed();
+      const res = await edit(
+        handler,
+        task.taskId,
+        { priority: "high" },
+        {
+          "content-type": "application/json",
+          "transfer-encoding": "chunked",
+        },
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(
+        (await runner.list()).find((item) => item.taskId === task.taskId)
+          ?.priority,
+      ).toBe("high");
+    });
+
+    it("keeps the sibling body-less snooze contract at 400", async () => {
+      const { runner, handler, task } = await seed();
+      let applyCalls = 0;
+      const originalApply = runner.apply.bind(runner);
+      runner.apply = async (taskId, verb, payload) => {
+        applyCalls += 1;
+        return originalApply(taskId, verb, payload);
+      };
+      const { ctx, res } = buildCtx({
+        method: "POST",
+        pathname: `/api/lifeops/scheduled-tasks/${task.taskId}/snooze`,
+      });
+
+      await handler(ctx);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toContain("invalid snooze payload");
+      expect(applyCalls).toBe(0);
+    });
 
     it("still accepts every editable ScheduledTaskInput field (no over-rejection)", async () => {
       const { runner, handler, task } = await seed();

--- a/plugins/plugin-scheduling/src/routes/scheduled-tasks.ts
+++ b/plugins/plugin-scheduling/src/routes/scheduled-tasks.ts
@@ -487,8 +487,13 @@ async function handleScheduledTasks(
           (req.headers["content-length"] as string | undefined) ?? "0",
           10,
         );
+        const hasTransferEncoding =
+          req.headers["transfer-encoding"] !== undefined;
         let body: unknown;
-        if (Number.isFinite(contentLength) && contentLength > 0) {
+        if (
+          (Number.isFinite(contentLength) && contentLength > 0) ||
+          hasTransferEncoding
+        ) {
           const parsed = await readJsonBody<Record<string, unknown>>(req, res);
           if (parsed === null) return true;
           body = parsed;
@@ -514,6 +519,10 @@ async function handleScheduledTasks(
           // boundary promises for malformed input. A `JSON.parse`-produced own
           // `"__proto__"` key additionally re-parents the task object, because
           // `Object.assign` writes through `[[Set]]`.
+          if (body === undefined) {
+            error(res, "invalid edit payload: request body is required", 400);
+            return true;
+          }
           const raw = (body ?? {}) as Record<string, unknown>;
           // Refuse the read-only keys up front, with the runner's own message
           // and the 409 the boundary already documents for a read-only field.


### PR DESCRIPTION
# Relates to

Fixes #23917

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto live `develop@53452c12ce52f3ae7b9f100e4c95a74cea7e4c25` with zero conflicts.
- [x] The affected route suite, package typecheck, package build, and changed-file Biome pass at exact head `df0e29023eb5d10a5bb6a3f5f130f3c3cbbf8028`.
- [x] Mutation controls prove each new regression fails when its corresponding guard is removed.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@53452c12ce52f3ae7b9f100e4c95a74cea7e4c25:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto live `develop@53452c12ce52f3ae7b9f100e4c95a74cea7e4c25`; zero conflicts.
- [x] Exact-head scoped gates pass. The aggregate environment boundary is documented below.

# Risks

Low. The route now recognizes standard chunked transfer framing in addition to a positive content length. Body-less `edit` changes from a spurious successful write to an explicit 400 before `runner.apply`; other body-optional verbs retain their existing behavior, and body-less `snooze` remains 400. No scheduler state-machine or persistence code changes.

# Background

## What does this PR do?

The apply-verb route previously read JSON only when `content-length > 0`. A valid chunked edit was therefore replaced with `undefined`, and the partial edit schema normalized a body-less request to `{}`, causing an empty store upsert and `edited {keys:[]}` log row.

This PR:

1. treats `transfer-encoding` as body framing and invokes the existing bounded JSON reader;
2. rejects a truly body-less edit before the runner is called;
3. pins both paths through the real route handler and in-memory runner/store; and
4. pins unchanged body-less snooze behavior.

## What kind of change is this?

Bug fix (non-breaking HTTP boundary correction).

# Documentation changes needed?

No. The existing route contract already treats malformed edit/snooze inputs as 400; this restores that boundary and correct body delivery.

# Testing

## Where should a reviewer start?

`plugins/plugin-scheduling/src/routes/scheduled-tasks.ts`, then the edit block in `plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts`.

## Detailed testing steps

```bash
node packages/shared/scripts/generate-keywords.mjs
bun run --cwd plugins/plugin-scheduling test
bun run --cwd plugins/plugin-scheduling typecheck
bun run --cwd plugins/plugin-scheduling build
bunx @biomejs/biome check \
  plugins/plugin-scheduling/src/routes/scheduled-tasks.ts \
  plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts
```

Exact-head scoped receipt:

```text
scheduled-tasks.test.ts: 25 passed
typecheck: exit 0
build: ESM, view bundle, and declarations pass
Biome: Checked 2 files. No fixes applied.
```

The full package lane on the immediately preceding rebased source head reached 32/34 files and 547/549 tests; the two PGlite cases that exceeded the shared-host timeout passed together on immediate rerun (2/2 files, 22/22 tests). The subsequent no-path-change rebase was verified at the exact final head with the affected route suite (25/25), typecheck, package build, Biome, and diff hygiene.

Mutation receipts:

```text
Without transfer-encoding recognition:
  chunked edit: expected 400 to be 200 (regression fails)

Without the empty-body guard:
  body-less edit: expected 200 to be 400 (regression fails)
```

# Evidence Gate

<!-- evidence-head:df0e29023eb5d10a5bb6a3f5f130f3c3cbbf8028 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only HTTP and persistence boundary; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only HTTP and persistence boundary; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - deterministic route/store behavior is captured by executable tests and attached logs.`
<!-- evidence-row:backend-logs -->
- [x] [23930-backend-df0e290-v2.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23930-backend-df0e290-v2.log)
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend or browser network path changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] [23930-domain-df0e290.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23930-domain-df0e290.md)
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic HTTP boundary only.`

## Backend + frontend logs

Backend test and mutation receipts are attached through the Evidence Gate. Frontend is `N/A`.

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice, audio, transcript, TTS, or STT behavior changes.`

## Known gaps / failures

- Root `bun run verify` was not rerun in this sparse worktree. The package lane had two shared-host PGlite timeouts in its aggregate run; both timed-out files passed together on immediate rerun. The exact final head passes the affected route suite, typecheck, package build, changed-file Biome, and diff hygiene. The temporary `/core/edge` resolver used only for Vitest is documented in the attached backend receipt and is not part of the PR diff.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@53452c12ce52f3ae7b9f100e4c95a74cea7e4c25:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-23917-scheduled-edit-body]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@53452c12ce52f3ae7b9f100e4c95a74cea7e4c25:packages/skills/skills/contribute-to-eliza"} -->