### PR TITLE
fix(personal-assistant): keep surrogate pairs intact in candidate sources label truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.ts
@@ -19,6 +19,7 @@
  */
 
 import type { FactMetadata, IAgentRuntime, Memory } from "@elizaos/core";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { resolveOwnerFactStore } from "../owner/fact-store.js";
 import type {
   ImplicitReferentCandidate,
@@ -97,7 +98,9 @@ function factToCandidate(
   if (!summary) return null;
   const source: ImplicitReferentSource = "owner_fact";
   const label =
-    summary.length > 60 ? `${summary.slice(0, 59).trimEnd()}…` : summary;
+    summary.length > 60
+      ? `${truncateWellFormed(toWellFormedUnicode(summary), 59).trimEnd()}…`
+      : summary;
   const prior = factPrior(memory);
   const tags = factTags(memory);
   const occurredAt = factOccurredAt(memory);


### PR DESCRIPTION
Closes #23722

Candidate-sources label now sanitizes lone surrogates and truncates
at 59 via truncateWellFormed(toWellFormedUnicode(...),59).

- plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.ts