### PR TITLE
fix(core): prioritize categorical risk policy denial

### DIFF
--- a/packages/core/src/capability-selection/account-selection.ts
+++ b/packages/core/src/capability-selection/account-selection.ts
@@ -17,6 +17,7 @@ import {
 	type CapabilityPolicyDenialCode,
 	type CapabilityRiskLevel,
 	type CapabilityUnavailableCode,
+	CONNECTED_ACCOUNT_STATUSES,
 	type ConnectedAccount,
 	type ConnectedAccountMode,
 } from "../types/provider-integrations";
@@ -143,6 +144,12 @@ function validateSelectionFacts(
 		}
 	}
 	for (const account of accounts) {
+		if (!CONNECTED_ACCOUNT_STATUSES.includes(account.status)) {
+			invalidSelectionInput("Connected account has an unknown status.", {
+				accountId: account.accountId,
+				status: account.status,
+			});
+		}
 		if (!signalsById.has(account.accountId)) {
 			invalidSelectionInput(
 				"Every connected account requires a selection signal.",

--- a/packages/core/src/capability-selection/account-selection.ts
+++ b/packages/core/src/capability-selection/account-selection.ts
@@ -6,7 +6,10 @@
  * `requestedAccountId` is honored exactly or fails loudly: an ineligible
  * pinned account is never silently substituted with a different account
  * (wrong-account prevention). Failures reuse the typed policy-denial and
- * unavailable codes from `types/provider-integrations`.
+ * unavailable codes from `types/provider-integrations`, and a policy denial
+ * always outranks mere unavailability: an account-independent denial is
+ * decided before any account is inspected, and an account-scoped denial is
+ * preferred over any unavailability collected across candidates.
  */
 import { ElizaError } from "../errors";
 import {
@@ -255,9 +258,6 @@ function evaluateAccount(
 			retryable: UNAVAILABLE_RETRYABLE[capability.status],
 		};
 	}
-	if (RISK_RANK[intent.riskLevel] > RISK_RANK[policy.maxRiskLevel]) {
-		return { kind: "denied", reasonCode: "risk_policy_denied" };
-	}
 	if (RISK_RANK[intent.riskLevel] > RISK_RANK[capability.riskLevel]) {
 		return { kind: "unavailable", code: "needs_scope", retryable: false };
 	}
@@ -340,6 +340,18 @@ export function selectConnectedAccount(
 		);
 	}
 	validateSelectionFacts(accounts, policy, signals, signalsById);
+
+	// The intent-vs-policy risk comparison names no field of any account, so it
+	// is decided once before any account is inspected. Leaving it inside the
+	// per-account loop let an unavailable account mask a categorical denial and
+	// send the caller down a reauth path that could never unblock the request.
+	if (RISK_RANK[intent.riskLevel] > RISK_RANK[policy.maxRiskLevel]) {
+		return {
+			outcome: "denied",
+			reasonCode: "risk_policy_denied",
+			accountId: null,
+		};
+	}
 
 	if (intent.requestedAccountId !== null) {
 		const account = accounts.find(

--- a/packages/core/src/capability-selection/capability-selection.test.ts
+++ b/packages/core/src/capability-selection/capability-selection.test.ts
@@ -216,6 +216,87 @@ describe("deterministic account selection", () => {
 		});
 	});
 
+	const RISK_DENYING_POLICY: AccountSelectionPolicy = {
+		...OPEN_POLICY,
+		maxRiskLevel: "R1",
+	};
+	const overRiskIntent = { ...intent, riskLevel: "R3" } as const;
+	const riskDenial = {
+		outcome: "denied",
+		reasonCode: "risk_policy_denied",
+		accountId: null,
+	};
+
+	it("denies a policy-exceeding intent when every account needs reauthorization", () => {
+		const result = selectConnectedAccount(
+			overRiskIntent,
+			[{ ...baseAccount, accountId: "acct-a", status: "reauth_required" }],
+			RISK_DENYING_POLICY,
+			[{ accountId: "acct-a", healthy: true, region: "us", unitCostMicros: 1 }],
+		);
+		expect(result).toEqual(riskDenial);
+	});
+
+	it("denies a policy-exceeding intent when every account is revoked", () => {
+		const result = selectConnectedAccount(
+			overRiskIntent,
+			[{ ...baseAccount, accountId: "acct-a", status: "revoked" }],
+			RISK_DENYING_POLICY,
+			[{ accountId: "acct-a", healthy: true, region: "us", unitCostMicros: 1 }],
+		);
+		expect(result).toEqual(riskDenial);
+	});
+
+	it("denies a policy-exceeding intent when no account grants the capability", () => {
+		const result = selectConnectedAccount(
+			overRiskIntent,
+			[{ ...baseAccount, accountId: "acct-a", capabilities: [] }],
+			RISK_DENYING_POLICY,
+			[{ accountId: "acct-a", healthy: true, region: "us", unitCostMicros: 1 }],
+		);
+		expect(result).toEqual(riskDenial);
+	});
+
+	it("denies a policy-exceeding intent when there are no accounts at all", () => {
+		expect(
+			selectConnectedAccount(overRiskIntent, [], RISK_DENYING_POLICY, []),
+		).toEqual(riskDenial);
+	});
+
+	it("denies a policy-exceeding intent pinned to an unavailable account", () => {
+		const result = selectConnectedAccount(
+			{ ...overRiskIntent, requestedAccountId: "acct-a" },
+			[{ ...baseAccount, accountId: "acct-a", status: "reauth_required" }],
+			RISK_DENYING_POLICY,
+			[{ accountId: "acct-a", healthy: true, region: "us", unitCostMicros: 1 }],
+		);
+		expect(result).toEqual(riskDenial);
+	});
+
+	it("denies a policy-exceeding intent pinned to an account that does not exist", () => {
+		const result = selectConnectedAccount(
+			{ ...overRiskIntent, requestedAccountId: "acct-missing" },
+			[{ ...baseAccount, accountId: "acct-a" }],
+			RISK_DENYING_POLICY,
+			[{ accountId: "acct-a", healthy: true, region: "us", unitCostMicros: 1 }],
+		);
+		expect(result).toEqual(riskDenial);
+	});
+
+	it("still reports account unavailability when the intent is within policy risk", () => {
+		const result = selectConnectedAccount(
+			{ ...intent, riskLevel: "R1" },
+			[{ ...baseAccount, accountId: "acct-a", status: "reauth_required" }],
+			RISK_DENYING_POLICY,
+			[{ accountId: "acct-a", healthy: true, region: "us", unitCostMicros: 1 }],
+		);
+		expect(result).toEqual({
+			outcome: "unavailable",
+			code: "needs_scope",
+			retryable: false,
+		});
+	});
+
 	it("fails closed on an invalid policy maxRiskLevel instead of skipping the risk check", () => {
 		expect(() =>
 			selectConnectedAccount(

--- a/packages/core/src/capability-selection/capability-selection.test.ts
+++ b/packages/core/src/capability-selection/capability-selection.test.ts
@@ -283,6 +283,30 @@ describe("deterministic account selection", () => {
 		expect(result).toEqual(riskDenial);
 	});
 
+	it("rejects malformed account status before applying the categorical risk denial", () => {
+		expect(() =>
+			selectConnectedAccount(
+				overRiskIntent,
+				[
+					{
+						...baseAccount,
+						accountId: "acct-a",
+						status: "malformed" as unknown as typeof baseAccount.status,
+					},
+				],
+				RISK_DENYING_POLICY,
+				[
+					{
+						accountId: "acct-a",
+						healthy: true,
+						region: "us",
+						unitCostMicros: 1,
+					},
+				],
+			),
+		).toThrowError(ElizaError);
+	});
+
 	it("still reports account unavailability when the intent is within policy risk", () => {
 		const result = selectConnectedAccount(
 			{ ...intent, riskLevel: "R1" },


### PR DESCRIPTION
# Relates to

Fixes #23418

- [x] Targets `develop` and was explicitly rebased onto live GitHub `develop@cb908dede0242310a09bb11e8b0016df447c9b39` with zero conflicts.
- [x] `bun install` completed after sync.
- [x] The deterministic contract evidence below exercises every requested denial and preservation path.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@973e83c0b15322db42941aa4cf2deb7e088690e0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Explicitly fetched `+refs/heads/develop:refs/remotes/origin/develop`; the fetched SHA matched the GitHub branches API at `cb908dede0242310a09bb11e8b0016df447c9b39`.
- [x] Exact head `973e83c0b15322db42941aa4cf2deb7e088690e0` is two commits ahead of that base.
- [x] Focused test, package typecheck, scoped Biome, and diff checks pass. Broad-suite baseline findings are recorded below.

# Risks

Low. This changes only failure precedence for an account-independent policy ceiling. It remains fail-closed, does not alter account ranking, and preserves the separate per-capability `needs_scope` result.

# Background

## What does this PR do?

- evaluates `intent.riskLevel > policy.maxRiskLevel` once before both pinned-account lookup and candidate ranking;
- returns the categorical `denied / risk_policy_denied` result with `accountId: null` even when accounts are unavailable, revoked, unsupported, absent, or the requested pin is missing;
- removes the redundant per-account policy comparison while retaining the capability grant risk comparison inside `evaluateAccount`;
- updates the module's precedence contract and adds all requested regressions.

## What kind of change is this?

Bug fix (non-breaking).

The implementation commit preserves the existing `Co-Authored-By: Claude Fable 5` credit from the unpublished contributor branch that originally prepared this scoped patch.

# Documentation changes needed?

No external documentation change. The owning module header now states the corrected precedence contract.

# Testing

## Where should a reviewer start?

`packages/core/src/capability-selection/account-selection.ts`, then the deterministic account-selection block in `capability-selection.test.ts`.

## Detailed testing steps

```text
bun run --cwd packages/core test -- src/capability-selection/capability-selection.test.ts
Test Files  1 passed (1)
Tests       30 passed (30)

bun run --cwd packages/core typecheck
PASS (tsc --noEmit after canonical keyword generation)

bunx @biomejs/biome check packages/core/src/capability-selection/account-selection.ts packages/core/src/capability-selection/capability-selection.test.ts
Checked 2 files. No fixes applied.

git diff --check origin/develop...HEAD
PASS
```

# Evidence Gate

<!-- evidence-head:973e83c0b15322db42941aa4cf2deb7e088690e0 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - headless core selection logic has no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - headless core selection logic has no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic policy contract, not an interactive flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head Vitest output is included above and exercises the real exported selection function without mocks.

```text
RUN v4.1.10 packages/core
Test Files  1 passed (1)
Tests       30 passed (30), including every risk-denial precedence regression requested by #23418
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network request is involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or agent behavior changed; the selector is deterministic pure core logic.
<!-- evidence-row:domain-artifacts -->
- [x] The domain artifacts are typed `AccountSelectionResult` values asserted by the 30-test deterministic suite, including all six new denial scenarios and the preserved per-capability `needs_scope` scenario.

```text
over-policy unavailable/revoked/unsupported/empty/pinned-unavailable/pinned-missing => denied:risk_policy_denied accountId:null
within-policy reauth_required => unavailable:needs_scope retryable:false
intent risk above capability grant risk => unavailable:needs_scope retryable:false
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or rendered surface changed.

# Evidence Details

Independent exact-head review found and repaired one malformed-input ordering regression: an unknown runtime account status is now validated before the categorical denial, with a dedicated adversarial test.

The regression suite proves `risk_policy_denied` for all-reauth, all-revoked, unsupported-capability, empty-list, unavailable pinned-account, and missing pinned-account inputs. It also proves an in-policy intent still reports account unavailability and the existing lower capability-risk grant still reports `unavailable / needs_scope`.

## Known gaps / failures

- The first broad core run in the clean worktree reached 5,875 passing tests but failed because clean-checkout generated keyword data and the `@elizaos/cloud-routing` build were absent. Running the canonical core prebuild resolved those bootstrap failures.
- A subsequent broad run exposed unrelated current-`develop` failures in untouched PGlite audience-recall, Stage 1 routing, action retrieval, and trajectory-recorder suites under the heavily concurrent shared runner; it was stopped after those baseline failures were established. None names either changed file or the capability-selection contract.
- Root `bun run verify` was not rerun after the final fast-moving `develop` rebase. Exact-head package typecheck, scoped Biome, focused behavior tests, and diff checks are green; hosted CI remains an ordinary ready-for-review merge gate.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@973e83c0b15322db42941aa4cf2deb7e088690e0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [fix-23418]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@973e83c0b15322db42941aa4cf2deb7e088690e0:packages/skills/skills/contribute-to-eliza"} -->


