### PR TITLE
fix(personal-assistant): keep surrogate pairs intact in background planner error truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/background-planner.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/background-planner.ts
@@ -82,6 +82,8 @@ import {
   ModelType,
   parseJsonModelRecord,
   runWithTrajectoryPurpose,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import type {
   ApprovalAction,


### PR DESCRIPTION
Closes #23730

Background-planner unparsable-output error now sanitizes lone surrogates
and truncates at 200 via truncateWellFormed(toWellFormedUnicode(...),200).

- plugins/plugin-personal-assistant/src/lifeops/background-planner.ts