### PR TITLE
fix(personal-assistant): keep surrogate pairs intact in room policy directive truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/providers/room-policy.ts
+++ b/plugins/plugin-personal-assistant/src/providers/room-policy.ts
@@ -19,7 +19,11 @@ import type {
   ProviderResult,
   State,
 } from "@elizaos/core";
-import { logger } from "@elizaos/core";
+import {
+  logger,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import {
   describeResumeCondition,
   resolveHandoffStore,
@@ -88,7 +92,7 @@ export const roomPolicyProvider: Provider = {
     const directive =
       `This room is in handoff mode (since ${status.enteredAt ?? "earlier"}; reason: ${status.reason ?? "n/a"}). ` +
       `Do not respond unless ${resumePhrase}. Stay silent — defer to the human participants.`;
-    const text = directive.slice(0, ONE_LINE_MAX);
+    const text = truncateWellFormed(toWellFormedUnicode(directive), ONE_LINE_MAX);
     return {
       text,
       values: {


### PR DESCRIPTION
Closes #23732

Room-policy handoff directive now sanitizes lone surrogates and truncates
at 240 via truncateWellFormed(toWellFormedUnicode(...),240).

- plugins/plugin-personal-assistant/src/providers/room-policy.ts