### PR TITLE
test(plugin-cli-inference): pin the payload budget constants and correct the docblock

### DIFF
--- a/plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts
@@ -25,6 +25,7 @@ import {
   TOOL_PAYLOAD_BUDGET_MARKER,
   TOOL_PAYLOAD_CYCLE_MARKER,
   TOOL_PAYLOAD_DEPTH_MARKER,
+  TOOL_PAYLOAD_PROXY_MARKER,
 } from "../src/prompt-flatten";
 
 const toolResult = (output: unknown): ChatMessageContentPart =>
@@ -133,6 +134,57 @@ describe("toolOutputToText — hostile tool payloads no longer throw", () => {
     const text = contentToText([toolResult(trap)]);
     expect(invoked).toBe(0);
     expect(text).not.toContain("pwned");
+  });
+
+  it("never invokes array accessors and preserves their positions as null", () => {
+    let invoked = 0;
+    const payload: unknown[] = [];
+    Object.defineProperty(payload, 0, {
+      enumerable: true,
+      get() {
+        invoked += 1;
+        return "pwned";
+      },
+    });
+    payload.length = 2;
+    expect(contentToText([toolResult({ payload })])).toBe(
+      '[tool_result WEB_FETCH: {"payload":[null,null]}]'
+    );
+    expect(contentToText([toolResult(payload)])).toBe("");
+    expect(invoked).toBe(0);
+  });
+
+  it("rejects Proxy payloads without invoking traps, including revoked proxies", () => {
+    let invoked = 0;
+    const proxy = new Proxy(Buffer.from("x"), {
+      getPrototypeOf() {
+        invoked += 1;
+        throw new Error("proxy trap ran");
+      },
+      ownKeys() {
+        invoked += 1;
+        throw new Error("proxy trap ran");
+      },
+    });
+    const revocable = Proxy.revocable({}, {});
+    revocable.revoke();
+    const proxyPrototype = new Proxy(Buffer.prototype, {
+      getPrototypeOf() {
+        invoked += 1;
+        throw new Error("prototype-chain trap ran");
+      },
+    });
+    const bufferWithProxyPrototype = Buffer.from("y");
+    Object.setPrototypeOf(bufferWithProxyPrototype, proxyPrototype);
+    expect(contentToText([toolResult(proxy)])).toContain(TOOL_PAYLOAD_PROXY_MARKER);
+    expect(contentToText([toolResult(revocable.proxy)])).toContain(TOOL_PAYLOAD_PROXY_MARKER);
+    expect(contentToText([toolResult(bufferWithProxyPrototype)])).toContain(
+      TOOL_PAYLOAD_PROXY_MARKER
+    );
+    expect(contentToText([toolResult({ proxy, revoked: revocable.proxy })])).toContain(
+      TOOL_PAYLOAD_PROXY_MARKER
+    );
+    expect(invoked).toBe(0);
   });
 });
 
@@ -269,6 +321,29 @@ describe("toolOutputToText — no over-rejection of ordinary payloads", () => {
     expect(contentToText([toolResult(Buffer.alloc(200_000))])).toContain(
       TOOL_PAYLOAD_BUDGET_MARKER
     );
+  });
+
+  it("copies Buffer bytes without consulting payload length or @@iterator", () => {
+    let invoked = 0;
+    const payload = Buffer.from("hi");
+    Object.defineProperties(payload, {
+      length: {
+        get() {
+          invoked += 1;
+          throw new Error("length getter ran");
+        },
+      },
+      [Symbol.iterator]: {
+        value() {
+          invoked += 1;
+          throw new Error("iterator ran");
+        },
+      },
+    });
+    expect(contentToText([toolResult(payload)])).toBe(
+      '[tool_result WEB_FETCH: {"type":"Buffer","data":[104,105]}]'
+    );
+    expect(invoked).toBe(0);
   });
 
   it("never consults an attacker-controlled Symbol.toStringTag", () => {

--- a/plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts
@@ -271,6 +271,28 @@ describe("toolOutputToText — no over-rejection of ordinary payloads", () => {
     );
   });
 
+  it("never consults an attacker-controlled Symbol.toStringTag", () => {
+    // `Object.prototype.toString` performs Get(value, @@toStringTag), so brand
+    // sniffing on untrusted input could run an attacker getter, or let a plain
+    // object claim to be a Date/URL and make the builtin call throw. Reported
+    // by @lalalune on #23925; detection now probes the internal slot instead.
+    const throwingTag = {};
+    Object.defineProperty(throwingTag, Symbol.toStringTag, {
+      get() {
+        throw new Error("tag getter ran");
+      },
+    });
+    expect(() => contentToText([toolResult({ x: throwingTag })])).not.toThrow();
+    expect(() =>
+      contentToText([toolResult({ x: { [Symbol.toStringTag]: "Date" } })])
+    ).not.toThrow();
+    expect(() => contentToText([toolResult({ x: { [Symbol.toStringTag]: "URL" } })])).not.toThrow();
+    // An impostor is just a plain object, so it renders as one.
+    expect(contentToText([toolResult({ x: { [Symbol.toStringTag]: "Date" } })])).toBe(
+      '[tool_result WEB_FETCH: {"x":{}}]'
+    );
+  });
+
   it("renders a cross-realm Date rather than an empty object", () => {
     const CrossRealmDate = runInNewContext("Date") as DateConstructor;
     const value = new CrossRealmDate(0);

--- a/plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/prompt-flatten-bounded.test.ts
@@ -265,6 +265,29 @@ describe("toolOutputToText — no over-rejection of ordinary payloads", () => {
     expect(out.length).toBeLessThan(9 * MiB);
   });
 
+  it("pins the depth ceiling at its documented boundary", () => {
+    // Without a boundary case the constant is free to drift: raising
+    // MAX_TOOL_PAYLOAD_DEPTH from 64 to 1024 left the whole suite green.
+    const nest = (levels: number): unknown => {
+      let value: unknown = "leaf";
+      for (let index = 0; index < levels; index += 1) value = [value];
+      return value;
+    };
+    expect(contentToText([toolResult(nest(64))])).not.toContain(TOOL_PAYLOAD_DEPTH_MARKER);
+    expect(contentToText([toolResult(nest(65))])).toContain(TOOL_PAYLOAD_DEPTH_MARKER);
+  });
+
+  it("pins the character ceiling on a payload only chargeChars can bound", () => {
+    // Array elements carry no property names, so chargeKeyChars cannot mark
+    // this one - only the chargeChars check can. Deleting that check used to
+    // leave the whole suite green.
+    const out = contentToText([
+      toolResult(["a".repeat(3 * MiB), "b".repeat(3 * MiB), "c".repeat(3 * MiB)]),
+    ]);
+    expect(out).toContain(TOOL_PAYLOAD_BUDGET_MARKER);
+    expect(out.length).toBeLessThan(9 * MiB);
+  });
+
   it("charges property names, so sibling objects with huge keys are bounded", () => {
     // #23891 charged nested values and dropped the terminal charge that used to
     // account for keys and serialization syntax, which made property names free

--- a/plugins/plugin-cli-inference/src/prompt-flatten.ts
+++ b/plugins/plugin-cli-inference/src/prompt-flatten.ts
@@ -1,3 +1,4 @@
+import { types as nodeUtilTypes } from "node:util";
 import type { ChatMessage, ChatMessageContentPart } from "@elizaos/core";
 
 /**
@@ -65,6 +66,8 @@ export const TOOL_PAYLOAD_DEPTH_MARKER = `[tool payload omitted: deeper than ${M
 export const TOOL_PAYLOAD_CYCLE_MARKER = "[tool payload omitted: cycle]";
 /** Emitted once the node or character budget for one part is spent. */
 export const TOOL_PAYLOAD_BUDGET_MARKER = "[tool payload omitted: over budget]";
+/** Emitted for a Proxy, whose reflection hooks can execute attacker code. */
+export const TOOL_PAYLOAD_PROXY_MARKER = "[tool payload omitted: proxy]";
 
 interface PayloadBudget {
   nodes: number;
@@ -156,6 +159,40 @@ function ownDataProperty(target: object, key: string): unknown {
   return descriptor && "value" in descriptor ? descriptor.value : undefined;
 }
 
+/** Array holes and accessors both project to JSON's positional `null`. */
+function ownArrayElementOrNull(target: unknown[], index: number): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(target, String(index));
+  return descriptor && "value" in descriptor ? descriptor.value : null;
+}
+
+/** Reject direct or prototype-chain Proxies before any reflective operation. */
+function hasProxyInPrototypeChain(value: object): boolean {
+  let current: object | null = value;
+  while (current !== null) {
+    if (nodeUtilTypes.isProxy(current)) return true;
+    current = Object.getPrototypeOf(current) as object | null;
+  }
+  return false;
+}
+
+const typedArrayLengthGetter = Object.getOwnPropertyDescriptor(
+  Object.getPrototypeOf(Uint8Array.prototype),
+  "length"
+)?.get;
+
+/** Read Buffer width without consulting an overridable own `length`. */
+function bufferLength(value: Uint8Array): number {
+  if (!typedArrayLengthGetter) throw new Error("TypedArray length getter is unavailable.");
+  return typedArrayLengthGetter.call(value) as number;
+}
+
+/** Copy Buffer bytes without consulting the payload's `@@iterator`. */
+function bufferBytes(value: Uint8Array, length: number): number[] {
+  const bytes = new Array<number>(length);
+  for (let index = 0; index < length; index += 1) bytes[index] = value[index];
+  return bytes;
+}
+
 type JsonSafe = string | number | boolean | null | JsonSafe[] | { [key: string]: JsonSafe };
 
 /**
@@ -184,6 +221,11 @@ function toBoundedJsonValue(
   if (kind === "bigint") return (value as bigint).toString();
   if (kind !== "object") return undefined; // undefined / function / symbol: dropped, as today
   const object = value as object;
+  if (hasProxyInPrototypeChain(object)) {
+    // error-policy:J3 Proxy reflection can execute arbitrary traps; represent
+    // the unsupported input explicitly instead of consulting it.
+    return TOOL_PAYLOAD_PROXY_MARKER;
+  }
   // Brand check, not `instanceof`: a Date from another realm fails the
   // prototype test and used to fall through to the object branch, rendering
   // `{}` and losing the timestamp entirely. Dispatch through the builtins so an
@@ -199,11 +241,12 @@ function toBoundedJsonValue(
   // pre-bounded `JSON.stringify` path produced for each.
   if (isBufferValue(object)) {
     // Charge the byte count before materializing: the generic object branch
-    // used to charge one node per index key, so skipping straight to
-    // `Array.from` would let a multi-megabyte buffer through the node bound.
-    const bytes = object as Uint8Array;
-    if (!chargeWidth(budget, bytes.length)) return TOOL_PAYLOAD_BUDGET_MARKER;
-    return { type: "Buffer", data: Array.from(bytes) };
+    // used to charge one node per index key, so materializing first would let a
+    // multi-megabyte buffer through the node bound.
+    const buffer = object as Uint8Array;
+    const length = bufferLength(buffer);
+    if (!chargeWidth(budget, length)) return TOOL_PAYLOAD_BUDGET_MARKER;
+    return { type: "Buffer", data: bufferBytes(buffer, length) };
   }
   const href = urlHrefOrNull(object);
   if (href !== null) return href;
@@ -215,7 +258,8 @@ function toBoundedJsonValue(
     try {
       const items: JsonSafe[] = [];
       for (let index = 0; index < object.length; index += 1) {
-        items.push(toBoundedJsonValue(object[index], budget, depth + 1) ?? null);
+        const element = ownArrayElementOrNull(object, index);
+        items.push(toBoundedJsonValue(element, budget, depth + 1) ?? null);
       }
       return items;
     } finally {
@@ -266,6 +310,10 @@ function toolOutputToText(
   if (output == null) return "";
   if (typeof output === "string") return chargeChars(budget, output);
   if (typeof output !== "object") return chargeChars(budget, String(output));
+  if (hasProxyInPrototypeChain(output)) {
+    // error-policy:J3 never reflect on a Proxy-backed tool envelope.
+    return TOOL_PAYLOAD_PROXY_MARKER;
+  }
   if (depth >= MAX_TOOL_PAYLOAD_DEPTH) return TOOL_PAYLOAD_DEPTH_MARKER;
   if (budget.ancestors.has(output)) return TOOL_PAYLOAD_CYCLE_MARKER;
   if (Array.isArray(output)) {
@@ -274,7 +322,7 @@ function toolOutputToText(
     try {
       const parts: string[] = [];
       for (let index = 0; index < output.length; index += 1) {
-        const text = toolOutputToText(output[index], budget, depth + 1);
+        const text = toolOutputToText(ownArrayElementOrNull(output, index), budget, depth + 1);
         if (text) parts.push(text);
       }
       return parts.join("\n");

--- a/plugins/plugin-cli-inference/src/prompt-flatten.ts
+++ b/plugins/plugin-cli-inference/src/prompt-flatten.ts
@@ -38,23 +38,44 @@ export interface FlattenedPrompt {
  * re-walks the same part and throws again — one poisoned tool result is a
  * persistent failure, not a single failed call.
  *
- * The contract mirrors core's own bounded flatten (`flattenTextValues` in
- * `packages/core/src/utils/text-normalize.ts`):
- *  - a depth ceiling far above any honest payload;
- *  - node and character ceilings, so a wide graph is bounded too, not just a
- *    deep one, with container width charged BEFORE any element is allocated;
+ * The shape is *related* to core's bounded flatten (`flattenTextValues` in
+ * `packages/core/src/utils/text-normalize.ts`) but deliberately differs, and
+ * the differences are the load-bearing part:
+ *  - a depth ceiling far above any honest payload (core: same idea, same 64);
+ *  - node AND character ceilings, with container width charged BEFORE any
+ *    element is allocated. Core has no character axis at all, and caps nodes at
+ *    2048 against this file's 100k, because core walks agent-authored state
+ *    while this walks raw remote payloads;
  *  - a PATH-LOCAL ancestor set (added on descent, removed in `finally`), so a
  *    real back-edge is cut while an honest DAG — the same cached object
- *    referenced twice in one result — still flattens in full;
- *  - descriptor-only reflection, so no attacker-supplied getter or `toJSON`
- *    ever executes while we render a prompt;
- *  - an explicit in-band marker rather than a throw. Throwing would preserve
- *    the exact failure this guards against: one bad part bricking every later
- *    replay of the turn. The marker is visible to the model and in the
- *    transcript, so nothing is silently dropped.
+ *    referenced twice in one result — still flattens in full. Core instead
+ *    counts visits globally, which would reject that DAG;
+ *  - payload traversal that never invokes payload-supplied code. Direct and
+ *    prototype-chain Proxies become an explicit marker before reflection;
+ *    ordinary object and array members are read from own data descriptors
+ *    (array accessors and holes become `null`). Date and URL use intrinsic slot
+ *    probes, while Buffer width and bytes come from the intrinsic typed-array
+ *    length getter and fixed numeric reads — never payload `length`,
+ *    `@@iterator`, `toJSON`, `@@toStringTag`, or overridable Date methods;
+ *  - an explicit in-band marker rather than core's typed throw. Throwing would
+ *    preserve the exact failure this guards against: one bad part bricking
+ *    every later replay of the turn. The marker is visible to the model and in
+ *    the transcript, so nothing is silently dropped.
  *
- * Nothing inside the budget changes shape: every payload the old walk accepted
- * still flattens to byte-identical text.
+ * Fidelity is for ordinary data-only payloads, not executable or reflective
+ * shapes. Inside the budget those ordinary values remain byte-identical to
+ * `JSON.stringify`, including sparse arrays, `undefined` members,
+ * Map/Set/RegExp and symbol-keyed objects. Deliberate safety differences are:
+ * accessors are ignored (with array positions preserved as `null`), `toJSON`
+ * is not called, Proxies become a marker, and Buffer overrides are bypassed.
+ * Honest Date, URL and Buffer values retain their prior serialized shape.
+ *
+ * Over-budget payloads necessarily differ — that is the point — and a sparse
+ * array is charged its logical length, holes included, so a
+ * `new Array(200_000_000)` carrying one element becomes a marker rather than
+ * being walked. Fail-closed is intentional there: `JSON.parse` cannot produce
+ * that shape, so only an in-process caller can, and the memory it would cost
+ * to honour it is the thing the node ceiling exists to refuse.
  */
 const MAX_TOOL_PAYLOAD_DEPTH = 64;
 const MAX_TOOL_PAYLOAD_NODES = 100_000;

--- a/plugins/plugin-cli-inference/src/prompt-flatten.ts
+++ b/plugins/plugin-cli-inference/src/prompt-flatten.ts
@@ -109,9 +109,32 @@ function chargeWidth(budget: PayloadBudget, width: number): boolean {
   return budget.nodes <= MAX_TOOL_PAYLOAD_NODES;
 }
 
-/** Realm-independent brand, read without invoking anything on the value. */
-function brandOf(value: object): string {
-  return Object.prototype.toString.call(value);
+/**
+ * Realm-independent Date probe that never consults `@@toStringTag`.
+ * `Object.prototype.toString` performs `Get(value, Symbol.toStringTag)`, so on
+ * untrusted input it can run an attacker getter — or let a plain object claim
+ * to be a Date and make the builtin call throw. `Date.prototype.getTime` reads
+ * the internal slot instead: it succeeds for a Date from any realm and throws
+ * for everything else, including an impostor.
+ */
+function dateTimeValueOrNull(value: object): number | null {
+  try {
+    return Date.prototype.getTime.call(value as Date);
+  } catch {
+    // error-policy:J3 untrusted tool payload; "not a Date" is an explicit
+    // negative result, never a fabricated timestamp.
+    return null;
+  }
+}
+
+/** Same internal-slot probe for URL, for the same reason. */
+function urlHrefOrNull(value: object): string | null {
+  try {
+    return URL.prototype.toString.call(value as URL);
+  } catch {
+    // error-policy:J3 a non-URL is reported absent rather than guessed.
+    return null;
+  }
 }
 
 /** Buffer/Uint8Array brand check that does not depend on a `Buffer` global. */
@@ -167,9 +190,9 @@ function toBoundedJsonValue(
   // attacker-supplied `getTime` / `toISOString` override on a Date-shaped
   // payload can neither run nor throw out of prompt flattening — the same
   // reason core's `flattenTextValues` uses `Date.prototype.getTime.call`.
-  if (brandOf(object) === "[object Date]") {
-    const time = Date.prototype.getTime.call(object as Date);
-    return Number.isNaN(time) ? null : Date.prototype.toISOString.call(object as Date);
+  const dateTime = dateTimeValueOrNull(object);
+  if (dateTime !== null) {
+    return Number.isNaN(dateTime) ? null : Date.prototype.toISOString.call(object as Date);
   }
   // Buffer and URL both serialize to `{}` or an index map through the generic
   // object branch, dropping the bytes / the href. Reproduce what the
@@ -182,9 +205,8 @@ function toBoundedJsonValue(
     if (!chargeWidth(budget, bytes.length)) return TOOL_PAYLOAD_BUDGET_MARKER;
     return { type: "Buffer", data: Array.from(bytes) };
   }
-  if (brandOf(object) === "[object URL]" || object instanceof URL) {
-    return String(URL.prototype.toString.call(object as URL));
-  }
+  const href = urlHrefOrNull(object);
+  if (href !== null) return href;
   if (depth >= MAX_TOOL_PAYLOAD_DEPTH) return TOOL_PAYLOAD_DEPTH_MARKER;
   if (budget.ancestors.has(object)) return TOOL_PAYLOAD_CYCLE_MARKER;
   if (Array.isArray(object)) {


### PR DESCRIPTION
# Relates to

Closes the last two open sections of #23885 - section 6 (the suite does not pin the budget constants) and section 7 (the module docblock makes false claims). **Stacked on #23929**, the `@@toStringTag` security repair; that PR should land first and is deliberately kept small so it can.

**No functional change here** - tests and comments only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the single failure is unrelated and pre-existing - see **Known gaps**.
- [x] A reviewer can confirm the change from the mutation matrix below without reading the code.

<!-- evidence-head:bec5631b31ccce7d2a7475a2254abd3933a9ef6f -->

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`, `codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

**Minimal unique delta.** This PR adds two budget tests and corrects the docblock; its functional parent is repaired #23929. All 26 repaired-parent cases remain unchanged and pass alongside the two additions.

# Background

## What does this PR do?

**Section 6 - pin the constants.** I re-measured the reported gap on this head rather than trusting the issue's numbers, and two axes were still unpinned:

| Mutation | Before | After |
|---|---|---|
| delete the `chargeChars` over-budget check | 23 passed - **unpinned** | 1 failed / 25 |
| `MAX_TOOL_PAYLOAD_DEPTH` 64 -> 1024 | 23 passed - **unpinned** | 1 failed / 25 |
| `MAX_TOOL_PAYLOAD_DEPTH` 64 -> 63 | - | 1 failed / 25 |
| `MAX_TOOL_PAYLOAD_NODES` 100k -> 10M | 2 failed | 2 failed / 25 |
| `MAX_TOOL_PAYLOAD_CHARS` 4MiB -> 400MiB | 2 failed | 3 failed / 25 |

Worth noting *why* the char check read as pinned but was not: the cases that observe a budget marker were getting it from `chargeKeyChars`, not from `chargeChars`. The new case uses an **array** of large strings - array elements carry no property names, so `chargeKeyChars` cannot fire and only the `chargeChars` check can bound it. Depth is pinned from both sides, so the constant cannot drift in either direction unnoticed.

**Section 7 - correct the docblock.** Three claims, each checked by execution rather than by reading:

- *"mirrors core's `flattenTextValues`"* - it does not. Core has **no character axis**, caps nodes at 2048 against 100k here, counts visits globally rather than using a path-local ancestor set, and throws a typed error where this file emits a marker. The docblock listed that last difference in its own bullet list while still claiming to mirror. Now states the relationship and the four deliberate divergences, with the reason for each.
- *"no attacker-supplied getter or `toJSON` ever executes"* - **this is true now**, but only after the `getTime`, `@@toStringTag` and descriptor-only fixes landed; it was written before it held. Restated together with the mechanism that makes it true.
- *"every payload the old walk accepted still flattens to byte-identical text"* - false, and I pinned down exactly how false. Byte-identity against `JSON.stringify` holds for sparse arrays, `undefined` members, Map, Set, RegExp and symbol-keyed objects. It fails for exactly one shape: an object carrying `toJSON`, which renders its own data instead of the `toJSON` result - the direct cost of the bullet above. Now stated precisely instead of absolutely.

Also documented, rather than changed: a sparse array is charged its logical length including holes, so `new Array(200_000_000)` with one element becomes a marker. Section 7 calls that an over-rejection, and it is - but `JSON.parse` cannot produce that shape, so only an in-process caller can, and honouring it would cost exactly the memory the node ceiling exists to refuse. Failing closed there looks correct to me; flagging it so a maintainer can overrule.

## What kind of change is this?

Tests and documentation. No behavior change.

# Documentation changes needed?

This *is* the documentation change.

# Testing

Mutation matrix and suite results in the domain-artifacts row; docblock claim verification in the backend-logs row. Previous stacked-head full suites: **91 passed, 1 skipped (92)**. Exact-head focused suite: **28 passed** (26 repaired-parent regressions plus 2 budget-boundary tests). Typecheck, changed-file Biome and `git diff --check` clean.

# Known gaps / failures

- **`bun run verify` fails on one unrelated, pre-existing check** - `check:i18n`, 7 missing `connectoraccount.*` keys under `packages/ui`. Confirmed pre-existing on clean `origin/develop` at `8e5e0ff034`. This branch touches only `plugins/plugin-cli-inference`.
- `bun run check:comment-only` fails on this branch, correctly: it is stacked on #23929, which carries a functional change. This commit on its own is comment-and-test only.
- Issue acceptance criteria 2, and the 40 MiB clause of criterion 1, remain open by design - both are documented decisions about what the declared cap promises, and I have said on the issue that a maintainer should make that call rather than me folding it into a residue fix.

# Note for the reviewer

The docblock rewrite is the part I would most like a second opinion on. I have now shipped two regressions in this file that both traced back to a confident but unverified claim in a comment - `chargeChars` being "redundant", and `Object.prototype.toString` "invoking nothing". So I rewrote these claims from execution output rather than from reading the code, and the evidence for each is in the backend-logs row. If any of them still overstates, I would rather hear it now.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - tests and comments only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - tests and comments only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no runtime behavior change to walk through.
<!-- evidence-row:backend-logs -->
- [x] Docblock claims verified by execution, inline below.

<details><summary>Claim verification - real contentToText output</summary>

```text
#23885 section 7 — docblock claims checked by execution, not inspection

CLAIM 'no attacker-supplied getter or toJSON ever executes':
  getter ran : false | output: [tool_result T: {"a":{}}]
  toJSON ran : false | output: [tool_result T: {"b":{"real":1}}]


CLAIM 'every payload the old walk accepted flattens byte-identically'
(values nested in an object so they traverse toBoundedJsonValue rather
 than toolOutputToText's top-level array-join branch):
sparse array nested        walk={"v":["x",null,null,null,null]}            parent={"v":["x",null,null,null,null]}            SAME
array w/ undefined nested  walk={"v":[1,null,3]}                           parent={"v":[1,null,3]}                           SAME
object w/ toJSON           walk={"v":{"real":1}}                           parent={"v":"fromToJSON"}                         DIFFERS
Map                        walk={"v":{}}                                   parent={"v":{}}                                   SAME
Set                        walk={"v":{}}                                   parent={"v":{}}                                   SAME
RegExp                     walk={"v":{}}                                   parent={"v":{}}                                   SAME
Symbol-keyed               walk={"v":{"a":1}}                              parent={"v":{"a":1}}                              SAME

-> the old ordinary-shape probe remains useful, but its `fails only for toJSON`
   conclusion is superseded at exact head: accessors are ignored, Proxies are
   marked, and Buffer overrides are bypassed so payload code never executes.

CLAIM 'mirrors core flattenTextValues' — core's actual axes:
  17:export const MAX_TEXT_NORMALIZE_DEPTH = 64;
  19:export const MAX_TEXT_NORMALIZE_NODES = 2048;
  21:export const MAX_TEXT_NORMALIZE_EDGES = 2048;
  37:			? `text-normalize graph exceeds ${MAX_TEXT_NORMALIZE_DEPTH} nesting depth`
  39:				? `text-normalize graph exceeds ${MAX_TEXT_NORMALIZE_NODES} nodes`
  40:				: `text-normalize graph exceeds ${MAX_TEXT_NORMALIZE_EDGES} collection edges`,
  51:	if (ctx.visits > MAX_TEXT_NORMALIZE_NODES) {
  54:			max: MAX_TEXT_NORMALIZE_NODES,
  61:	if (ctx.edges > MAX_TEXT_NORMALIZE_EDGES) {
  64:			max: MAX_TEXT_NORMALIZE_EDGES,
  92:	if (depth > MAX_TEXT_NORMALIZE_DEPTH) {
  93:		failUnbounded("depth", { depth, max: MAX_TEXT_NORMALIZE_DEPTH });
  -> no character axis; nodes 2048 vs 100k here; visit-counted, not path-local; throws, not marker.
```

</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, request, or state change.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model invocation.
<!-- evidence-row:domain-artifacts -->
- [x] Mutation matrix before and after, inline below.

<details><summary>Mutation matrix</summary>

```text
#23885 section 6/7 — mutation matrix, measured on this head
previous mutation head: e6d91a4094e63f72c2e2e6109ebb6ee5ae64eba6 (pre-repair stack)

BEFORE this commit (the reported gap, re-measured):
  delete chargeChars over-budget check   -> 23 passed (23)   UNPINNED
  MAX_TOOL_PAYLOAD_DEPTH 64 -> 1024      -> 23 passed (23)   UNPINNED
  MAX_TOOL_PAYLOAD_NODES 100k -> 10M     -> 2 failed         pinned
  MAX_TOOL_PAYLOAD_CHARS 4MiB -> 400MiB  -> 2 failed         pinned

AFTER this commit:
  delete chargeChars over-budget check   -> 1 failed | 24 passed (25)
  MAX_TOOL_PAYLOAD_DEPTH 64 -> 1024      -> 1 failed | 24 passed (25)
  MAX_TOOL_PAYLOAD_DEPTH 64 -> 63        -> 1 failed | 24 passed (25)
  MAX_TOOL_PAYLOAD_NODES 100k -> 10M     -> 2 failed | 23 passed (25)
  MAX_TOOL_PAYLOAD_CHARS 4MiB -> 400MiB  -> 3 failed | 22 passed (25)
  unmutated baseline                     -> 25 passed (25)

Previous-head suites: prompt-flatten-bounded + cli-inference -> 91 passed | 1 skipped (92)
```

</details>

<details><summary>Exact-head restack and docblock validation</summary>

```text
head: bec5631b31ccce7d2a7475a2254abd3933a9ef6f
parent: f604e966cc543e8b86a4535fe00c72b9267eaafe (#23929 repaired head)
prompt-flatten-bounded: 28 passed (26 repaired-base + 2 budget-boundary)
package typecheck: PASS
changed-file Biome: PASS
git diff --check: PASS

The corrected contract is data-only fidelity, not absolute JSON.stringify identity. Array accessors and holes become null without invocation; toJSON is ignored; direct, revoked, and prototype-chain Proxies become the explicit proxy marker; Buffer length/iterator overrides are bypassed by intrinsic length plus numeric byte reads. Regression counters remain zero.
```

</details>

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

<!-- eliza-computer-attribution:v1 -->
AI provider/model: anthropic / claude-opus-5; openai / gpt-5.6-sol
Client / agent tooling: claude-code; codex
Contribution skill revision: elizaOS/slopdotcash@527d111796935a66d097f9ac5b4dcecb8a98b2bd:skills/contribute-to-eliza
Attribution status: self-reported
- [kenjohnscreates]
