### PR TITLE
fix(cloud): recover staging Blooio secrets

### DIFF
--- a/.github/workflows/deploy-gateway-webhook.yml
+++ b/.github/workflows/deploy-gateway-webhook.yml
@@ -10,13 +10,154 @@ on:
         options:
           - staging
           - production
+      recover_staging_blooio_secrets:
+        description: Restore staging Blooio GitHub secrets from the canonical Railway service without deploying
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
 
 jobs:
+  recover-staging-blooio-secrets:
+    name: Recover staging Blooio secrets
+    if: inputs.recover_staging_blooio_secrets == true
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: staging
+    env:
+      REQUESTED_ENVIRONMENT: ${{ inputs.environment }}
+      RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+      RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+      RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK }}
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_PAT }}
+    steps:
+      - name: Validate recovery authority and target
+        shell: bash
+        run: |
+          set -euo pipefail
+          [ "$REQUESTED_ENVIRONMENT" = "staging" ] || {
+            echo "::error::Blooio secret recovery is staging-only"
+            exit 1
+          }
+          [ "$GITHUB_REF" = "refs/heads/develop" ] || {
+            echo "::error::Blooio secret recovery must run from develop"
+            exit 1
+          }
+          for name in RAILWAY_PROJECT_ID RAILWAY_ENVIRONMENT_ID RAILWAY_SERVICE_ID RAILWAY_TOKEN GH_TOKEN; do
+            value="${!name:-}"
+            [ -n "${value//[[:space:]]/}" ] || {
+              echo "::error::Missing required recovery setting: $name"
+              exit 1
+            }
+          done
+          for name in RAILWAY_PROJECT_ID RAILWAY_ENVIRONMENT_ID RAILWAY_SERVICE_ID; do
+            value="${!name}"
+            [[ "$value" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]] || {
+              echo "::error::$name must be a Railway UUID"
+              exit 1
+            }
+          done
+          gh api "repos/$GITHUB_REPOSITORY" --silent
+          echo "Recovery authority and canonical staging target are available."
+
+      - name: Install pinned Railway CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          cli_root="$RUNNER_TEMP/railway-cli"
+          archive="$RUNNER_TEMP/railway-v5.38.0.tar.gz"
+          mkdir -p "$cli_root"
+          curl \
+            --fail \
+            --location \
+            --silent \
+            --show-error \
+            --retry 3 \
+            --output "$archive" \
+            "https://github.com/railwayapp/cli/releases/download/v5.38.0/railway-v5.38.0-x86_64-unknown-linux-gnu.tar.gz"
+          printf '%s  %s\n' \
+            "72835c48a710c48c4542141bf12264823cf3a029b514f9e27994096c036c539e" \
+            "$archive" | sha256sum --check --status
+          tar -xzf "$archive" -C "$cli_root" railway
+          chmod 0755 "$cli_root/railway"
+          echo "$cli_root" >> "$GITHUB_PATH"
+          "$cli_root/railway" --version | grep -F "railway 5.38.0"
+
+      - name: Restore exact Blooio secrets without logging values
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          status_path="$RUNNER_TEMP/blooio-recovery-status.json"
+          variables_path="$RUNNER_TEMP/blooio-recovery-variables.json"
+          cleanup() {
+            for path in "$status_path" "$variables_path"; do
+              if [ -f "$path" ]; then
+                shred -u "$path" 2>/dev/null || rm -f "$path"
+              fi
+            done
+          }
+          trap cleanup EXIT
+
+          railway status \
+            --project "$RAILWAY_PROJECT_ID" \
+            --environment "$RAILWAY_ENVIRONMENT_ID" \
+            --json > "$status_path"
+          jq -e --arg id "$RAILWAY_PROJECT_ID" '.id == $id' "$status_path" >/dev/null
+          jq -e --arg id "$RAILWAY_ENVIRONMENT_ID" \
+            'any(.environments.edges[]; .node.id == $id and .node.name == "staging")' \
+            "$status_path" >/dev/null
+          jq -e --arg id "$RAILWAY_SERVICE_ID" \
+            'any(.services.edges[]; .node.id == $id and .node.name == "gateway-webhook-stg")' \
+            "$status_path" >/dev/null
+
+          railway variable list \
+            --project "$RAILWAY_PROJECT_ID" \
+            --environment "$RAILWAY_ENVIRONMENT_ID" \
+            --service "$RAILWAY_SERVICE_ID" \
+            --json > "$variables_path"
+
+          required_names=(
+            ELIZA_APP_BLOOIO_API_KEY
+            ELIZA_APP_BLOOIO_PHONE_NUMBER
+            ELIZA_APP_BLOOIO_WEBHOOK_SECRET
+          )
+          for name in "${required_names[@]}"; do
+            jq -e --arg name "$name" \
+              '.[$name] | type == "string" and test("\\S")' \
+              "$variables_path" >/dev/null || {
+              echo "::error::Canonical Railway staging value is absent or blank: $name"
+              exit 1
+            }
+          done
+          jq -e '.ELIZA_APP_BLOOIO_PHONE_NUMBER == "+18087881821"' \
+            "$variables_path" >/dev/null || {
+            echo "::error::Canonical Railway staging Blooio number is not the Eliza 808 line"
+            exit 1
+          }
+
+          for name in "${required_names[@]}"; do
+            jq -jr --arg name "$name" '.[$name]' "$variables_path" |
+              gh secret set "$name" \
+                --repo "$GITHUB_REPOSITORY" \
+                --env staging
+          done
+
+          inventory="$(gh secret list --repo "$GITHUB_REPOSITORY" --env staging --json name)"
+          for name in "${required_names[@]}"; do
+            jq -e --arg name "$name" 'any(.[]; .name == $name)' <<<"$inventory" >/dev/null || {
+              echo "::error::GitHub did not report restored environment secret name: $name"
+              exit 1
+            }
+          done
+          echo "Restored 3 staging Blooio environment secrets from canonical Railway values; no values were printed."
+
   authorize-target:
     name: Authorize gateway webhook (${{ inputs.environment }})
+    if: inputs.recover_staging_blooio_secrets != true
     runs-on: ubuntu-24.04
     timeout-minutes: 2
     # Approval completes outside the shared mutation lock so a waiting review
@@ -28,6 +169,7 @@ jobs:
 
   deploy:
     name: Deploy gateway webhook (${{ inputs.environment }})
+    if: inputs.recover_staging_blooio_secrets != true
     needs: authorize-target
     runs-on: ubuntu-24.04
     timeout-minutes: 45

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -55,6 +55,7 @@ interface WorkflowJob {
   };
   env?: Record<string, string>;
   environment?: string;
+  if?: string;
   needs?: string;
   steps?: WorkflowStep[];
 }
@@ -69,6 +70,12 @@ interface Workflow {
           required?: boolean;
           type?: string;
         };
+        recover_staging_blooio_secrets?: {
+          default?: boolean;
+          description?: string;
+          required?: boolean;
+          type?: string;
+        };
       };
     };
   };
@@ -78,11 +85,19 @@ interface Workflow {
 const workflow = Bun.YAML.parse(source) as Workflow;
 const deploy = workflow.jobs?.deploy;
 const authorization = workflow.jobs?.["authorize-target"];
+const recovery = workflow.jobs?.["recover-staging-blooio-secrets"];
 const steps = deploy?.steps ?? [];
+const recoverySteps = recovery?.steps ?? [];
 
 function step(name: string): WorkflowStep {
   const found = steps.find((candidate) => candidate.name === name);
   if (!found) throw new Error(`Missing gateway-webhook workflow step: ${name}`);
+  return found;
+}
+
+function recoveryStep(name: string): WorkflowStep {
+  const found = recoverySteps.find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`Missing Blooio recovery workflow step: ${name}`);
   return found;
 }
 
@@ -293,6 +308,53 @@ function assertExactForwarderAuthReadinessProbe(run: string): void {
 }
 
 describe("protected gateway-webhook deployment workflow", () => {
+  test("recovers only the exact staging Blooio set without exposing values or deploying", () => {
+    expect(
+      workflow.on?.workflow_dispatch?.inputs?.recover_staging_blooio_secrets,
+    ).toEqual({
+      description:
+        "Restore staging Blooio GitHub secrets from the canonical Railway service without deploying",
+      required: false,
+      default: false,
+      type: "boolean",
+    });
+    expect(recovery?.if).toBe("inputs.recover_staging_blooio_secrets == true");
+    expect(recovery?.environment).toBe("staging");
+    expect(authorization?.if).toBe(
+      "inputs.recover_staging_blooio_secrets != true",
+    );
+    expect(deploy?.if).toBe("inputs.recover_staging_blooio_secrets != true");
+
+    const authority = recoveryStep("Validate recovery authority and target");
+    expect(authority.run).toContain('[ "$REQUESTED_ENVIRONMENT" = "staging" ]');
+    expect(authority.run).toContain('[ "$GITHUB_REF" = "refs/heads/develop" ]');
+    expect(recovery?.env?.GH_TOKEN).toBe(githubExpression("secrets.GH_PAT"));
+
+    const restore = recoveryStep(
+      "Restore exact Blooio secrets without logging values",
+    );
+    expect(restore.run).toContain("umask 077");
+    expect(restore.run).toContain("railway variable list");
+    expect(restore.run).toContain('== "+18087881821"');
+    expect(restore.run).toContain('jq -jr --arg name "$name"');
+    expect(restore.run).toContain('gh secret set "$name"');
+    expect(restore.run).toContain("--env staging");
+    expect(restore.run).toContain('shred -u "$path"');
+    for (const name of blooioNames) expect(restore.run).toContain(name);
+    for (const forbidden of [
+      "railway variable set",
+      'cat "$variables_path"',
+      'echo "$variables_path"',
+      'echo "${!name}"',
+      "gh secret set --body",
+    ]) {
+      expect(restore.run).not.toContain(forbidden);
+    }
+    expect(
+      recoverySteps.some((candidate) => candidate.run?.includes("railway up")),
+    ).toBe(false);
+  });
+
   test("authorizes before the shared protected mutation lock", () => {
     expect(Object.keys(workflow.on ?? {})).toEqual(["workflow_dispatch"]);
     expect(workflow.on?.workflow_dispatch?.inputs?.environment).toEqual({


### PR DESCRIPTION
Closes #23934

Adds a one-time, staging-only recovery mode to the protected gateway webhook workflow. It copies the canonical Blooio values from the exact Railway staging service into the GitHub staging environment without printing them, requires the Eliza 808 line, and skips all deployment jobs in recovery mode.

Validation:
- `bun test packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts` (9 pass)
- `bun run audit:workflow-triggers`
- pinned actionlint on the changed workflow
- `git diff --check`

After recovery and equality proof, this temporary mode will be removed in a follow-up PR.