### PR TITLE
fix(personal-assistant): keep surrogate pairs intact in owner policy writes truncation

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/lib/owner-policy-writes.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/owner-policy-writes.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ActionResult, IAgentRuntime, Memory } from "@elizaos/core";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type {
   LifeOpsDefinitionRecord,
   LifeOpsDomain,
@@ -71,7 +72,10 @@ function policyProvenance(intent: string): OwnerFactProvenance {
     recordedAt: new Date().toISOString(),
   };
   if (intent.length > 0) {
-    provenance.note = intent.slice(0, 200);
+    provenance.note = truncateWellFormed(
+      toWellFormedUnicode(intent),
+      200,
+    );
   }
   return provenance;
 }


### PR DESCRIPTION
Closes #23727

Owner-policy provenance note now sanitizes lone surrogates and truncates
at 200 via truncateWellFormed(toWellFormedUnicode(...),200).

- plugins/plugin-personal-assistant/src/actions/lib/owner-policy-writes.ts