### PR TITLE
fix(computeruse): keep clipboard-read previews Unicode-well-formed

### DIFF
--- a/packages/core/src/truncation-suffix-reserve.test.ts
+++ b/packages/core/src/truncation-suffix-reserve.test.ts
@@ -16,8 +16,6 @@ const MAX_ENTITY = 2_000;
 const ENTITY_SUFFIX = "... (truncated)";
 const MAX_RUNTIME = 500;
 const RUNTIME_SUFFIX = "...";
-const CLIPBOARD_MAX = 4096;
-const CLIPBOARD_SUFFIX = "…";
 const SETTINGS_MAX = 12_000;
 const LONG_TERM_MAX = 5_000;
 const SUMMARY_MAX = 3_000;
@@ -76,16 +74,6 @@ describe("truncation suffix reservation — 7-site batch", () => {
 		expect(newTruncate("a".repeat(500), 500, "...").length).toBe(500);
 	});
 
-	it("clipboard preview: 4097 chars truncate to 4096 with …", () => {
-		const input = "a".repeat(CLIPBOARD_MAX + 1);
-		expect(newTruncate(input, CLIPBOARD_MAX, CLIPBOARD_SUFFIX).length).toBe(
-			CLIPBOARD_MAX,
-		);
-		expect(oldTruncate(input, CLIPBOARD_MAX, CLIPBOARD_SUFFIX).length).toBe(
-			4097,
-		);
-	});
-
 	it("settings / long-term / summary: caps reserve 3 for ...", () => {
 		for (const [max, label] of [
 			[SETTINGS_MAX, "settings 12000"],
@@ -105,7 +93,6 @@ describe("truncation suffix reservation — 7-site batch", () => {
 			[MAX_ATTACHMENT, ATTACHMENT_SUFFIX, 87],
 			[MAX_ENTITY, ENTITY_SUFFIX, 15],
 			[MAX_RUNTIME, RUNTIME_SUFFIX, 3],
-			[CLIPBOARD_MAX, CLIPBOARD_SUFFIX, 1],
 			[SETTINGS_MAX, GENERIC_SUFFIX, 3],
 		];
 		for (const [max, suffix, over] of cases) {

--- a/plugins/plugin-computeruse/src/actions/clipboard.surrogate.test.ts
+++ b/plugins/plugin-computeruse/src/actions/clipboard.surrogate.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Exercises clipboard-read Unicode normalization through the real action
+ * handler while mocking only the host clipboard driver boundary.
+ */
+import type { ActionResult, IAgentRuntime, Memory } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { readClipboardMock, writeClipboardMock } = vi.hoisted(() => ({
+  readClipboardMock: vi.fn<() => Promise<string>>(),
+  writeClipboardMock: vi.fn<(text: string) => Promise<void>>(),
+}));
+
+vi.mock("../platform/clipboard.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../platform/clipboard.js")>()),
+  readClipboard: readClipboardMock,
+  writeClipboard: writeClipboardMock,
+}));
+
+import { clipboardAction } from "./clipboard.ts";
+
+const PREVIEW_CAP = 4096;
+const runtime = {
+  getService: () => ({
+    getCapabilities: () => ({ clipboard: { available: true } }),
+  }),
+} as unknown as IAgentRuntime;
+const message = {
+  content: { text: "read my clipboard", action: "read" },
+} as unknown as Memory;
+
+function clipboardPayload(result: ActionResult): {
+  message?: string;
+  text?: string;
+} {
+  const data = result.data as
+    | { result?: { message?: unknown; text?: unknown } }
+    | undefined;
+  return {
+    message:
+      typeof data?.result?.message === "string"
+        ? data.result.message
+        : undefined,
+    text: typeof data?.result?.text === "string" ? data.result.text : undefined,
+  };
+}
+
+function isWellFormed(text: string): boolean {
+  return (
+    (text as unknown as { isWellFormed?: () => boolean }).isWellFormed?.() ??
+    !/[\uD800-\uDFFF]/u.test(text)
+  );
+}
+
+async function readClipboardThroughAction(text: string): Promise<{
+  result: ActionResult;
+  payload: ReturnType<typeof clipboardPayload>;
+}> {
+  readClipboardMock.mockResolvedValueOnce(text);
+  const result = await clipboardAction.handler(runtime, message);
+  return { result, payload: clipboardPayload(result) };
+}
+
+describe("clipboard action Unicode-safe read projection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ["high", "\uD800"],
+    ["low", "\uDC00"],
+  ])(
+    "normalizes a short lone-%s surrogate in text and preview",
+    async (_, lone) => {
+      const { result, payload } = await readClipboardThroughAction(
+        `before ${lone} after`,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.text).toBe("before � after");
+      expect(payload).toEqual({
+        message: "before � after",
+        text: "before � after",
+      });
+    },
+  );
+
+  it("keeps a boundary surrogate pair intact and preserves full returned text", async () => {
+    const fox = "🦊";
+    const fullText = `${"a".repeat(PREVIEW_CAP - 2)}${fox}z`;
+    const { result, payload } = await readClipboardThroughAction(fullText);
+
+    expect(fullText.length).toBe(PREVIEW_CAP + 1);
+    expect(result.text).toBe(`${"a".repeat(PREVIEW_CAP - 2)}…`);
+    expect(isWellFormed(result.text ?? "")).toBe(true);
+    expect(payload.text).toBe(fullText);
+    expect(payload.message).toBe(result.text);
+  });
+
+  it("caps an over-limit preview at exactly 4096 code units including ellipsis", async () => {
+    const fullText = "a".repeat(PREVIEW_CAP + 1);
+    const { result, payload } = await readClipboardThroughAction(fullText);
+
+    expect(result.text).toBe(`${"a".repeat(PREVIEW_CAP - 1)}…`);
+    expect(result.text).toHaveLength(PREVIEW_CAP);
+    expect(payload.text).toBe(fullText);
+    expect(payload.text).toHaveLength(PREVIEW_CAP + 1);
+  });
+});

--- a/plugins/plugin-computeruse/src/actions/clipboard.surrogate.test.ts
+++ b/plugins/plugin-computeruse/src/actions/clipboard.surrogate.test.ts
@@ -96,6 +96,35 @@ describe("clipboard action Unicode-safe read projection", () => {
     expect(payload.message).toBe(result.text);
   });
 
+  it.each([
+    ["high", "\uD800"],
+    ["low", "\uDC00"],
+  ])(
+    "normalizes a long lone-%s surrogate before applying the preview cap",
+    async (_, lone) => {
+      const normalizedText = `${"a".repeat(PREVIEW_CAP - 2)}�zz`;
+      const { result, payload } = await readClipboardThroughAction(
+        `${"a".repeat(PREVIEW_CAP - 2)}${lone}zz`,
+      );
+
+      expect(payload.text).toBe(normalizedText);
+      expect(payload.text).toHaveLength(PREVIEW_CAP + 1);
+      expect(result.text).toBe(`${"a".repeat(PREVIEW_CAP - 2)}�…`);
+      expect(result.text).toHaveLength(PREVIEW_CAP);
+      expect(isWellFormed(result.text ?? "")).toBe(true);
+    },
+  );
+
+  it("preserves an exact-cap preview, including a valid astral pair", async () => {
+    const exactText = `${"a".repeat(PREVIEW_CAP - 2)}🦊`;
+    const { result, payload } = await readClipboardThroughAction(exactText);
+
+    expect(exactText).toHaveLength(PREVIEW_CAP);
+    expect(result.text).toBe(exactText);
+    expect(payload).toEqual({ message: exactText, text: exactText });
+    expect(isWellFormed(result.text ?? "")).toBe(true);
+  });
+
   it("caps an over-limit preview at exactly 4096 code units including ellipsis", async () => {
     const fullText = "a".repeat(PREVIEW_CAP + 1);
     const { result, payload } = await readClipboardThroughAction(fullText);

--- a/plugins/plugin-computeruse/src/actions/clipboard.ts
+++ b/plugins/plugin-computeruse/src/actions/clipboard.ts
@@ -10,14 +10,16 @@
  * can pick a specific verb directly from the action catalogue.
  */
 
-import type {
-  Action,
-  ActionResult,
-  HandlerCallback,
-  HandlerOptions,
-  IAgentRuntime,
-  Memory,
-  State,
+import {
+  type Action,
+  type ActionResult,
+  type HandlerCallback,
+  type HandlerOptions,
+  type IAgentRuntime,
+  type Memory,
+  type State,
+  toWellFormedUnicode,
+  truncateWellFormed,
 } from "@elizaos/core";
 import {
   ClipboardUnavailableError,
@@ -50,7 +52,8 @@ type ClipboardParameters = Omit<Partial<ClipboardActionParams>, "action"> & {
   op?: ClipboardActionType | string;
 };
 
-const CLIPBOARD_PREVIEW_BYTES = 4096;
+const CLIPBOARD_PREVIEW_CODE_UNITS = 4096;
+const CLIPBOARD_PREVIEW_SUFFIX = "…";
 
 function getComputerUseService(
   runtime: IAgentRuntime,
@@ -83,10 +86,13 @@ async function runClipboardAction(
   params: ClipboardActionParams,
 ): Promise<ClipboardActionResult> {
   if (params.action === "read") {
-    const text = await driverReadClipboard();
+    const text = toWellFormedUnicode(await driverReadClipboard());
     const preview =
-      text.length > CLIPBOARD_PREVIEW_BYTES
-        ? `${text.slice(0, CLIPBOARD_PREVIEW_BYTES - 1)}…`
+      text.length > CLIPBOARD_PREVIEW_CODE_UNITS
+        ? `${truncateWellFormed(
+            text,
+            CLIPBOARD_PREVIEW_CODE_UNITS - CLIPBOARD_PREVIEW_SUFFIX.length,
+          )}${CLIPBOARD_PREVIEW_SUFFIX}`
         : text;
     return {
       success: true,


### PR DESCRIPTION
# Relates to

Closes #23937. This replaces the stale implementation at old fork head `45226879244baa2caba6c589435fb26f17cfb38e` with one focused commit on current `develop`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebuilt on `develop@b366d6b84a14fbba300c276c0472a12943d8c6d1` with zero conflicts and zero commits behind.
- [x] Focused real-handler tests, mutation control, package lint/format, changed-path Biome, diff checks, and guide parity were rerun after sync.
- [x] Exact-head production outputs and known environment limitations are recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b366d6b84a14fbba300c276c0472a12943d8c6d1:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Useful intent replayed onto live `origin/develop@b366d6b84a14fbba300c276c0472a12943d8c6d1` as exact head `813e8abe84a25299400f5777eb092594ab55e86f`; zero conflicts and zero commits behind.
- [x] Scoped exact-head gates pass; the sparse-worktree dependency limitation is documented under **Known gaps / failures**.

# Risks

Low. Returned clipboard text remains complete but is normalized to valid Unicode. Only the action preview is capped, and the ellipsis counts toward the existing 4,096 UTF-16-code-unit limit.

# Background

## What does this PR do?

- Uses canonical `@elizaos/core` `toWellFormedUnicode` and `truncateWellFormed` helpers.
- Preserves full normalized clipboard text under `data.result.text` while capping only the action preview.
- Reserves preview space for the ellipsis.
- Exercises the real `clipboardAction.handler` with a hoisted partial mock of only the host clipboard driver.
- Pins short and long lone-high/lone-low normalization, exact-cap and max+1 behavior, a valid pair crossing the preview boundary, exact cap accounting, and full returned text.
- Removes Core's cloned clipboard-only suffix assertion now that the owning production action has direct coverage.

## What kind of change is this?

Bug fix (non-breaking action-result Unicode hardening).

# Documentation changes needed?

No. The public clipboard action contract is unchanged.

# Testing

## Where should a reviewer start?

`plugins/plugin-computeruse/src/actions/clipboard.ts`, then `plugins/plugin-computeruse/src/actions/clipboard.surrogate.test.ts`.

## Detailed testing steps

```bash
bunx vitest run --config plugins/plugin-computeruse/vitest.config.ts plugins/plugin-computeruse/src/actions/clipboard.surrogate.test.ts packages/core/src/truncation-suffix-reserve.test.ts
bun run --cwd plugins/plugin-computeruse lint:check
bun run --cwd plugins/plugin-computeruse format:check
bunx @biomejs/biome check plugins/plugin-computeruse/src/actions/clipboard.ts plugins/plugin-computeruse/src/actions/clipboard.surrogate.test.ts packages/core/src/truncation-suffix-reserve.test.ts
git diff --check origin/develop...HEAD
cmp -s CLAUDE.md AGENTS.md
cmp -s plugins/plugin-computeruse/CLAUDE.md plugins/plugin-computeruse/AGENTS.md
```

Mutation control: replacing only `truncateWellFormed(...)` with raw `.slice(...)` made the boundary-pair real-handler regression fail with a preview ending in `�…`. Restoring the canonical helper returned the focused set to green.

# Evidence Gate

<!-- evidence-head:813e8abe84a25299400f5777eb092594ab55e86f -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - server-side action-result string shaping only; no rendered UI changes.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - server-side action-result string shaping only; no rendered UI changes.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - deterministic action-result projection; the real-handler transcript is below.`
<!-- evidence-row:backend-logs -->
- [x] Backend/action-path transcript is included inline:

  ```text
  Head: 813e8abe84a25299400f5777eb092594ab55e86f
  Base: b366d6b84a14fbba300c276c0472a12943d8c6d1
  Test Files  2 passed (2)
  Tests       13 passed (13)
  Package lint: Checked 232 files. No fixes applied.
  Package format: Checked 232 files. No fixes applied.
  Changed-path Biome: Checked 3 files. No fixes applied.
  git diff --check: pass
  root/package guide parity: pass

  Raw-slice mutation: 1 failed | 3 passed; boundary-pair regression failed as intended.
  ```
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend, transport, or network path changes.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - deterministic clipboard result shaping; no model or prompt behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain outputs from the production-handler regression:

  ```text
  lone-high / lone-low: returned text and preview = "before � after"
  boundary-pair input length 4097: full returned text length 4097; well-formed preview = 4094 x "a" + "…"
  plain input length 4097: full returned text length 4097; preview length 4096 including ellipsis
  ```
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - no rendered visual surface changes.`

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic action-result shaping only.`

## Backend + frontend logs

The exact-head real-handler and mutation-control transcripts are inline above. Frontend evidence is not applicable.

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI changes.`

## Audio / voice walkthrough

`N/A - no audio or voice behavior changes.`

## Known gaps / failures

- The sparse repair worktree reused an existing dependency tree because the shared volume is capacity constrained. Package `typecheck` reaches unrelated Core/browser modules but cannot resolve unlinked cached dependencies (`ai`, `mammoth`, `unpdf`, `file-type`, `puppeteer-core`, and `@nut-tree-fork/nut-js`). The changed files execute through Vitest and package-wide Biome; hosted CI must run typecheck from its complete frozen install.
- Full live OS clipboard evidence is not needed for this pure result-shaping correction: the only mocked seam is the existing host driver, while the public production action handler and result wrapper execute unchanged.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@b366d6b84a14fbba300c276c0472a12943d8c6d1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-23945-repair]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@b366d6b84a14fbba300c276c0472a12943d8c6d1:packages/skills/skills/contribute-to-eliza"} -->
