### PR TITLE
fix(android): restore authenticated local E2E diagnostics

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -118,6 +118,8 @@ public class ElizaAgentService extends Service {
     // below). AGENT_PORT is only used when ELIZA_API_EXPOSE_PORT re-opens the
     // HTTP listener for dev/LAN/e2e, and to advertise the port in status text.
     private static final int AGENT_PORT = 31337;
+    private static final String DEBUG_API_EXPOSE_PORT_PROP =
+        "debug.eliza.api_expose_port";
 
     /**
      * Abstract-namespace AF_UNIX socket the in-process bionic GPU inference
@@ -2059,8 +2061,13 @@ public class ElizaAgentService extends Service {
             // LAN access, e2e harnesses) — then the agent advertises AGENT_PORT
             // and the launch.sh PORT default applies. Passing the port env
             // unconditionally is what used to make the agent open 31337.
-            if ("1".equals(env.get("ELIZA_API_EXPOSE_PORT"))
-                    || "true".equalsIgnoreCase(env.get("ELIZA_API_EXPOSE_PORT"))) {
+            boolean exposeAgentApiPort = shouldExposeAgentApiPort(
+                BuildConfig.DEBUG,
+                env.get("ELIZA_API_EXPOSE_PORT"),
+                readDebugProp(DEBUG_API_EXPOSE_PORT_PROP)
+            );
+            if (exposeAgentApiPort) {
+                agentEnv.put("ELIZA_API_EXPOSE_PORT", "1");
                 agentEnv.put("PORT", String.valueOf(AGENT_PORT));
                 agentEnv.put("ELIZA_API_PORT", String.valueOf(AGENT_PORT));
                 agentEnv.put("ELIZA_API_BIND", "127.0.0.1");
@@ -2097,14 +2104,13 @@ public class ElizaAgentService extends Service {
                 Log.i(TAG, "Hybrid cloud inference enabled: ELIZAOS_CLOUD_API_KEY"
                     + " injected from prefs (len=" + cloudInferenceKey.length() + ")");
             }
-            // Local passwordless mode: the on-device agent trusts its own sealed
-            // request socket so the single device owner never hits a login/pairing
-            // gate. The per-boot bearer-token guard (ELIZA_REQUIRE_LOCAL_AUTH=1)
-            // is intentionally OFF — the WebView cannot reliably present that
-            // token at cold start, which otherwise dead-ends the dashboard at
-            // 401 ("Connecting to backend…" forever). The token is still minted
-            // and exposed via the Agent plugin for callers that opt to use it.
-            agentEnv.put("ELIZA_REQUIRE_LOCAL_AUTH", "0");
+            // Abstract UDS requests stay process-confined and passwordless so
+            // the WebView cannot dead-end at cold start waiting for its bearer.
+            // The debug/e2e TCP opt-in shares Android's loopback namespace with
+            // other apps, so it must retain bearer auth even though it never
+            // binds off-device. The Agent plugin exposes the per-boot token to
+            // the harness without weakening the normal port-free path.
+            agentEnv.put("ELIZA_REQUIRE_LOCAL_AUTH", exposeAgentApiPort ? "1" : "0");
             agentEnv.put("ELIZA_API_TOKEN", token);
             agentEnv.put("ELIZA_TERMINAL_RUN_TOKEN", terminalToken);
             // The Capacitor APK always hosts @elizaos/capacitor-llama in the
@@ -4068,6 +4074,18 @@ public class ElizaAgentService extends Service {
         } catch (ReflectiveOperationException | SecurityException e) {
             return "";
         }
+    }
+
+    static boolean shouldExposeAgentApiPort(
+            boolean debugBuild,
+            String inheritedValue,
+            String debugPropertyValue) {
+        if ("1".equals(inheritedValue) || "true".equalsIgnoreCase(inheritedValue)) {
+            return true;
+        }
+        return debugBuild
+            && ("1".equals(debugPropertyValue)
+                || "true".equalsIgnoreCase(debugPropertyValue));
     }
 
     /**

--- a/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java
+++ b/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java
@@ -31,6 +31,21 @@ public class ElizaAgentAutostartPolicyTest {
     private static final long RAM_3GB = 3L * (1L << 30);
 
     @Test
+    public void debugApiPortOverrideIsDebugOnly() {
+        assertTrue(ElizaAgentService.shouldExposeAgentApiPort(true, null, "1"));
+        assertTrue(ElizaAgentService.shouldExposeAgentApiPort(true, null, "true"));
+        assertFalse(ElizaAgentService.shouldExposeAgentApiPort(false, null, "1"));
+        assertFalse(ElizaAgentService.shouldExposeAgentApiPort(true, null, "0"));
+    }
+
+    @Test
+    public void inheritedApiPortOverrideRemainsAvailableToOperators() {
+        assertTrue(ElizaAgentService.shouldExposeAgentApiPort(false, "1", null));
+        assertTrue(ElizaAgentService.shouldExposeAgentApiPort(false, "true", "0"));
+        assertFalse(ElizaAgentService.shouldExposeAgentApiPort(true, "false", null));
+    }
+
+    @Test
     public void brandedDevicesAlwaysStartTheBundledAgent() {
         assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null, RAM_12GB));
         assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null, RAM_3GB));

--- a/packages/app/scripts/mobile-local-chat-smoke-port-policy.test.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke-port-policy.test.mjs
@@ -1,0 +1,74 @@
+/**
+ * Covers the host command contract that opts debug Android builds into the
+ * bearer-protected loopback API used by device acceptance.
+ */
+import { afterAll, describe, expect, it } from "bun:test";
+
+const originalArgv = process.argv;
+process.argv = [
+  "bun",
+  "mobile-local-chat-smoke-port-policy.test.mjs",
+  "--platform",
+  "unit-test",
+];
+const smoke = await import("./mobile-local-chat-smoke.mjs");
+process.argv = originalArgv;
+
+afterAll(() => {
+  process.argv = originalArgv;
+});
+
+describe("Android debug API port policy", () => {
+  it("builds explicit enable and cleanup setprop commands", () => {
+    expect(smoke.androidE2eApiPortOverrideArgs("serial", true)).toEqual([
+      "-s",
+      "serial",
+      "shell",
+      "setprop",
+      "debug.eliza.api_expose_port",
+      "1",
+    ]);
+    expect(smoke.androidE2eApiPortOverrideArgs("serial", false)).toEqual([
+      "-s",
+      "serial",
+      "shell",
+      "setprop",
+      "debug.eliza.api_expose_port",
+      "0",
+    ]);
+  });
+
+  it("uses authenticated status details when health is topology-trimmed", async () => {
+    let uptime = 10;
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        expect(request.headers.get("authorization")).toBe("Bearer secret");
+        if (url.pathname === "/api/status") {
+          uptime += 1;
+          return Response.json({
+            state: "running",
+            canRespond: true,
+            uptime,
+            startup: { attempt: 1 },
+          });
+        }
+        if (url.pathname === "/api/health") {
+          return Response.json({ ready: true });
+        }
+        return new Response("missing", { status: 404 });
+      },
+    });
+    try {
+      await expect(
+        smoke.waitForAndroidProcessStability(
+          server.url.toString().replace(/\/$/, ""),
+          "secret",
+        ),
+      ).resolves.toMatchObject({ state: "running", canRespond: true });
+    } finally {
+      server.stop(true);
+    }
+  });
+});

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -89,6 +89,7 @@ const IOS_FULL_BUN_PREWARM_RESULT_KEY = "eliza:ios-full-bun-prewarm:result";
 const IOS_LOCAL_AGENT_IPC_BASE = "eliza-local-agent://ipc";
 const ANDROID_LOCAL_AGENT_IPC_BASE = IOS_LOCAL_AGENT_IPC_BASE;
 const ANDROID_LOCAL_AGENT_DEVICE_PORT = 31337;
+const ANDROID_E2E_API_EXPOSE_PORT_PROP = "debug.eliza.api_expose_port";
 const IOS_FULL_BUN_SMOKE_MODEL_ID = "eliza-1-2b";
 const IOS_FULL_BUN_SMOKE_MODEL_RELATIVE_PATH =
   "models/eliza-1-2b.bundle/text/eliza-1-2b-128k.gguf";
@@ -863,6 +864,7 @@ async function launchAndroidEmulatorApp() {
 
   const context = { adb, serial, installed: true };
   if (androidSelectLocal) {
+    setAndroidE2eApiPortOverride(context, true);
     removeAndroidReverse(context, ANDROID_LOCAL_AGENT_DEVICE_PORT);
     forceStopConflictingAndroidAgents(context);
     preseedAndroidLocalRuntime(context);
@@ -890,6 +892,26 @@ async function launchAndroidEmulatorApp() {
     id,
   ]);
   return context;
+}
+
+function setAndroidE2eApiPortOverride(context, enabled) {
+  requireExec(
+    context.adb,
+    androidE2eApiPortOverrideArgs(context.serial, enabled),
+    `Failed to ${enabled ? "enable" : "clear"} the Android debug API port override.`,
+  );
+  context.e2eApiPortOverride = enabled;
+}
+
+function androidE2eApiPortOverrideArgs(serial, enabled) {
+  return [
+    "-s",
+    serial,
+    "shell",
+    "setprop",
+    ANDROID_E2E_API_EXPOSE_PORT_PROP,
+    enabled ? "1" : "0",
+  ];
 }
 
 function xmlEscape(value) {
@@ -2148,6 +2170,33 @@ async function probeHealth(baseUrl, authToken) {
   });
 }
 
+/**
+ * GET /api/status for authenticated process-state diagnostics. Android's
+ * debug-only TCP lane requires local auth, which deliberately trims
+ * /api/health to its public `{ ready }` liveness shape even with a valid bearer
+ * token. The protected status route owns the agent state, uptime, and startup
+ * attempt needed by the stability gate.
+ */
+async function probeAgentStatus(baseUrl, authToken) {
+  return withTransientRetry("status probe", async () => {
+    const { response, data, text } = await requestJsonResponse(
+      "GET",
+      "/api/status",
+      undefined,
+      baseUrl,
+      authToken,
+      { timeoutMs: ANDROID_HEALTH_PROBE_TIMEOUT_MS },
+    );
+    if (!response.ok) {
+      throw new Error(`GET /api/status failed: ${response.status} ${text}`);
+    }
+    if (!text || !data || typeof data !== "object") {
+      throw new Error("GET /api/status returned an empty body.");
+    }
+    return data;
+  });
+}
+
 function readStartupAttempt(health) {
   const attempt = health?.startup?.attempt;
   return typeof attempt === "number" && Number.isFinite(attempt)
@@ -2157,9 +2206,9 @@ function readStartupAttempt(health) {
 
 /**
  * Process-stability gate. Requires ANDROID_STABILITY_SAMPLES consecutive
- * /api/health reads with: agentState==running, ready==true, monotonically
+ * /api/status reads with: state==running, canRespond==true, monotonically
  * increasing uptime, and a non-climbing startup.attempt. Keyed on PROCESS
- * health only — NOT on device-bridge connected:true, which is legitimately
+ * state only — NOT on device-bridge connected:true, which is legitimately
  * false now that inference is served in-process.
  */
 async function waitForAndroidProcessStability(baseUrl, authToken) {
@@ -2170,7 +2219,7 @@ async function waitForAndroidProcessStability(baseUrl, authToken) {
   for (let attempt = 1; attempt <= ANDROID_STABILITY_ATTEMPTS; attempt += 1) {
     let health;
     try {
-      health = await probeHealth(baseUrl, authToken);
+      health = await probeAgentStatus(baseUrl, authToken);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       consecutive = 0;
@@ -2187,7 +2236,7 @@ async function waitForAndroidProcessStability(baseUrl, authToken) {
     lastHealth = health;
     const uptime = typeof health.uptime === "number" ? health.uptime : null;
     const startupAttempt = readStartupAttempt(health);
-    const running = health.agentState === "running" && health.ready === true;
+    const running = health.state === "running" && health.canRespond === true;
     const uptimeMonotonic =
       uptime !== null && (previousUptime === null || uptime >= previousUptime);
     const attemptStable =
@@ -2395,7 +2444,7 @@ async function runLocalInferenceApiSmoke(
     `[local-chat-smoke] Exercising app-core API at ${baseUrl} (conversation + local-inference full turn).`,
   );
   // Process-stability gate: wait for a settled agent process (monotonic uptime,
-  // agentState==running, startup.attempt not climbing) before exercising, so a
+  // state==running, canRespond==true, startup.attempt not climbing) before exercising, so a
   // turn is never fired mid-restart. Keyed on process health, NOT device-bridge
   // connected:true (inference is in-process now, so the bridge stays detached).
   await waitForAndroidProcessStability(baseUrl, authToken);
@@ -2828,12 +2877,24 @@ async function main() {
       });
     }
     cleanupAndroidAgentForwards(androidContext, "shutdown");
+    if (androidContext?.e2eApiPortOverride) {
+      try {
+        setAndroidE2eApiPortOverride(androidContext, false);
+      } catch (error) {
+        // error-policy:J6 best-effort teardown; the debug-only property is
+        // ignored by release builds and the runner still needs its root cause.
+        console.warn(
+          `[local-chat-smoke] Failed to clear Android debug API port override: ${error instanceof Error ? error.message : error}`,
+        );
+      }
+    }
   }
 }
 
 export {
   androidBackgroundServicesReady,
   androidDeviceSerial,
+  androidE2eApiPortOverrideArgs,
   androidRunAs,
   appId,
   cleanupAndroidAgentForwards,
@@ -2853,6 +2914,7 @@ export {
   preseedAndroidLocalRuntime,
   preseedIosFullBunSmoke,
   preseedIosLocalRuntime,
+  probeAgentStatus,
   probeHealth,
   readAndroidLocalAgentToken,
   readIosFullBunSmokeDiagnostics,
@@ -2867,6 +2929,7 @@ export {
   requireLocalInferenceReady,
   requireUsableFullTurnReply,
   runLocalInferenceApiSmoke,
+  setAndroidE2eApiPortOverride,
   shellQuote,
   stageAndroidSmokeModel,
   stageIosFullBunSmokeModel,

--- a/packages/app/scripts/mobile-local-chat-smoke.test.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.test.mjs
@@ -145,10 +145,13 @@ beforeAll(() => {
       });
 
       if (url.pathname === "/api/health") {
+        return json({ ready: true });
+      }
+      if (url.pathname === "/api/status") {
         uptime += 1;
         return json({
-          ready: true,
-          agentState: "running",
+          state: "running",
+          canRespond: true,
           uptime,
           startup: { attempt: 1 },
         });
@@ -517,8 +520,8 @@ describe("mobile smoke failure states", () => {
       port: 0,
       fetch(request) {
         const url = new URL(request.url);
-        if (url.pathname === "/api/health") {
-          return json({ ready: false, agentState: "starting", uptime: null });
+        if (url.pathname === "/api/status") {
+          return json({ state: "starting", canRespond: false, uptime: null });
         }
         if (url.pathname === "/api/local-inference/hub") {
           return json({ active: { status: "error", error: "model failed" } });


### PR DESCRIPTION
# Relates to

- Relates to #13580

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` ran after the rebase.
- [x] Reviewer-visible device and test evidence is recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@53452c12ce52f3ae7b9f100e4c95a74cea7e4c25:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` `53452c12ce52f3ae7b9f100e4c95a74cea7e4c25`; zero conflicts.
- [ ] `bun run verify` reaches the shared `@elizaos/agent` lint lane and fails on unrelated current-develop diagnostics listed below. Scoped gates pass.

# Risks

Low. The TCP listener is debug-build-only, opt-in through an Android debug system property, loopback-bound, and bearer-protected. Production local-agent IPC remains port-free and passwordless inside the app process.

# Background

## What does this PR do?

The ARM64 Android acceptance harness previously forwarded TCP 31337 even though production local-agent mode intentionally binds only an abstract UDS. This made the harness unable to inspect the embedded agent it had just launched.

This PR:

- adds a debug-only `debug.eliza.api_expose_port=1` opt-in in `ElizaAgentService`;
- requires `ELIZA_REQUIRE_LOCAL_AUTH=1` whenever the diagnostic TCP port is active;
- has the smoke harness set the property before launch and clear it during best-effort teardown;
- reads protected process stability from `/api/status`, because authenticated Android mode deliberately trims `/api/health` to `{ ready }`;
- adds Java and JS policy coverage.

## What kind of change is this?

Bug fix / test-infrastructure repair.

# Documentation changes needed?

No user documentation change. The behavior is a debug-only acceptance hook and is documented in source/tests.

# Testing

## Where should a reviewer start?

- `packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java`
- `packages/app/scripts/mobile-local-chat-smoke.mjs`
- `packages/app/scripts/mobile-local-chat-smoke-port-policy.test.mjs`

## Detailed testing steps

Exact head: `19e51a287ffdde8ef9a7f74786cb77d5ca240245`

- `bun install --frozen-lockfile` — PASS
- focused Gradle policy test — PASS (`BUILD SUCCESSFUL`, 578 tasks)
- focused JS policy/readiness tests — PASS (11/11)
- Biome on touched sources — PASS
- guide parity — PASS (160 pairs)
- `git diff --check origin/develop...HEAD` — PASS
- 8 GB ARM64 AVD exact-head install — PASS; protected `/api/health` and `/api/status` returned 200 through the temporary forwarded port; stability gate passed.

# Evidence Gate

<!-- evidence-head:19e51a287ffdde8ef9a7f74786cb77d5ca240245 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - headless debug transport and harness contract change
<!-- evidence-row:backend-logs -->
- [x] [23946-runner.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23946-runner.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend behavior changed; WebView state is summarized in the runner evidence
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, provider, model, or agent decision behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [23946-summary.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23946-summary.json)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual-text surface changed

# Evidence Details

The exact-head ARM64 run proved the source scope: APK build/install succeeded, the debug property opened only the bearer-protected loopback listener, `/api/status` exposed `state=running` and `canRespond=true`, and the process stability gate completed.

## Known gaps / failures

- Full local-model acceptance remains held by #13580's named infrastructure prerequisite: live repository inventory has 28 self-hosted runners, all Linux/X64, and zero runners matching `[self-hosted, Linux, ARM64, android-device]`.
- The local 8 GB ARM64 AVD has no staged fused `libelizainference.so` runtime. Its exact-head run therefore stops honestly at `capacitor-llama: Waiting for device bridge` / `connected:false`; it does not claim a model turn.
- `bun run verify` fails outside this diff in current-develop `@elizaos/agent` lint (pre-existing formatting and non-null assertion diagnostics, including `src/actions/database.ts`, `src/actions/knowledge.ts`, `src/api/accounts-routes.ts`, and `src/api/interactions-routes.test.ts`).
- An initial incremental Gradle build encountered a missing generated Cordova manifest; `./gradlew clean` repaired the isolated cache, and the clean exact-head build/install succeeded.

This PR is ready for review. The external ARM64 runner/fused-runtime requirement is an acceptance hold for closing #13580, not a reason to keep this source-complete PR in draft.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@53452c12ce52f3ae7b9f100e4c95a74cea7e4c25:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-oldest50-13580]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@53452c12ce52f3ae7b9f100e4c95a74cea7e4c25:packages/skills/skills/contribute-to-eliza"} -->

