### PR TITLE
fix(plugin-inmemorydb): restore public vector index size

### DIFF
--- a/plugins/plugin-inmemorydb/hnsw.test.ts
+++ b/plugins/plugin-inmemorydb/hnsw.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Verifies the public `EphemeralHNSW` lifecycle against its real in-memory
+ * node map, including replacement inserts that must not increase index size.
+ */
+import { describe, expect, it } from "vitest";
+import { EphemeralHNSW } from "./index";
+
+describe("EphemeralHNSW public lifecycle", () => {
+  it("reports size across initialization, replacement, removal, and clear", async () => {
+    const index = new EphemeralHNSW();
+
+    expect(index.size()).toBe(0);
+    await index.init(3);
+    expect(index.size()).toBe(0);
+
+    await index.add("first", [1, 0, 0]);
+    expect(index.size()).toBe(1);
+
+    await index.add("first", [0, 1, 0]);
+    expect(index.size()).toBe(1);
+    await expect(index.searchExact([0, 1, 0], 1, 0)).resolves.toEqual([
+      { id: "first", distance: 0, similarity: 1 },
+    ]);
+
+    await index.add("second", [0, 0, 1]);
+    expect(index.size()).toBe(2);
+
+    await index.remove("first");
+    expect(index.size()).toBe(1);
+
+    await index.clear();
+    expect(index.size()).toBe(0);
+  });
+});

--- a/plugins/plugin-inmemorydb/hnsw.ts
+++ b/plugins/plugin-inmemorydb/hnsw.ts
@@ -385,4 +385,8 @@ export class EphemeralHNSW implements IVectorStorage {
     this.entryPoint = null;
     this.maxLevel = 0;
   }
+
+  size(): number {
+    return this.nodes.size;
+  }
 }


### PR DESCRIPTION
# Relates to

Fixes #23447

- [x] Targets `develop` and is rebased onto live GitHub `develop@74293573c79732ea19590a994b8a5cba5217f15f` with zero conflicts.
- [x] Exact-head focused/full tests, typecheck, Node/browser/declaration build, Biome, and diff checks pass.
- [x] The public-export lifecycle evidence below exercises the requested real behavior.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@87fdc2e0d6ac07ce3b75acdefbf9e4edb02be816:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Explicitly fetched `+refs/heads/develop:refs/remotes/origin/develop`; the fetched SHA matched the GitHub branches API at `74293573c79732ea19590a994b8a5cba5217f15f`.
- [x] Exact head `87fdc2e0d6ac07ce3b75acdefbf9e4edb02be816` is one commit ahead of that base.

# Risks

Low. This restores one synchronous read-only method over the existing private node map. It does not change vector mutation, ranking, result memory, or the public `IVectorStorage` interface.

# Background

## What does this PR do?

- restores the previously public concrete `EphemeralHNSW.size(): number` method;
- adds a public-package-export regression covering construction, initialization, first add, replacement add of an existing ID, second add, removal, and clear;
- proves replacement insertion updates the exact-search vector without increasing size.

This is deliberately only the residual left after #23880. That prior repair already restored legacy `IVectorStorage` assignability and retained concrete `searchExact`; this PR credits and preserves that work rather than duplicating or widening the interface.

## What kind of change is this?

Bug fix restoring public API compatibility.

# Documentation changes needed?

No. The public export already exposes `EphemeralHNSW`; this restores its pre-#23415 method without changing usage or configuration.

# Testing

## Where should a reviewer start?

- `plugins/plugin-inmemorydb/hnsw.ts`
- `plugins/plugin-inmemorydb/hnsw.test.ts`

## Detailed testing steps

```text
bun run --cwd plugins/plugin-inmemorydb test
Test Files  14 passed (14)
Tests       64 passed (64)

bun run --cwd plugins/plugin-inmemorydb test -- hnsw.test.ts vector-storage-contract.test.ts search-memories-scope.test.ts
Test Files  3 passed (3)
Tests       12 passed (12)

bun run --cwd plugins/plugin-inmemorydb typecheck
PASS: package project and public vector-storage contract project

bun run --cwd plugins/plugin-inmemorydb build
PASS: Node, Browser, and TypeScript declarations

bun run --cwd plugins/plugin-inmemorydb lint:check
Checked 31 files. No fixes applied.

git diff --check origin/develop...HEAD
PASS
```

# Evidence Gate

<!-- evidence-head:87fdc2e0d6ac07ce3b75acdefbf9e4edb02be816 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - headless in-memory vector index has no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - headless in-memory vector index has no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic storage lifecycle, not an interactive flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head Vitest transcript exercises the public export and real node map.

```text
RUN v4.1.10 plugins/plugin-inmemorydb
Test Files  14 passed (14)
Tests       64 passed (64), including the new public EphemeralHNSW lifecycle regression
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network request is involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Real lifecycle artifact: public `size()` observations and exact-search replacement result.

```text
constructor=0; init=0; add(first)=1; add(existing first)=1; add(second)=2; remove(first)=1; clear=0
replacement exact search=[{ id: "first", distance: 0, similarity: 1 }]
existing exact eligible-before-top-K ranking and legacy IVectorStorage contract tests remain green
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or rendered surface changed.

# Evidence Details

The new test imports `EphemeralHNSW` from the package's public `./index` export, not the implementation module, and exercises the real in-memory map without mocks. Existing scoped-ranking and compile-contract regressions remain in the exact focused lane.

## Known gaps / failures

- N/A - all owning exact-head source, test, type, build, format, evidence, and attribution gates passed.
- Independent exact-head review passed on the rebased candidate; hosted CI remains an ordinary ready-state signal.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@87fdc2e0d6ac07ce3b75acdefbf9e4edb02be816:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [fix-23447]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@87fdc2e0d6ac07ce3b75acdefbf9e4edb02be816:packages/skills/skills/contribute-to-eliza"} -->

