### PR TITLE
fix(ui): isolate sandbox status poll lifecycles

### DIFF
--- a/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.test.tsx
+++ b/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.test.tsx
@@ -236,6 +236,53 @@ describe("useSandboxStatusPoll", () => {
     });
   });
 
+  it("keeps an active request alive across interval ticks until its deadline", async () => {
+    vi.useFakeTimers();
+    let resolveFirst: ((response: Response) => void) | undefined;
+    const requestSignals: Array<AbortSignal | null | undefined> = [];
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementationOnce((_input, init) => {
+        requestSignals.push(init?.signal);
+        return new Promise((resolve) => {
+          resolveFirst = resolve;
+        });
+      })
+      .mockResolvedValueOnce(
+        Response.json({
+          data: { status: "running", lastHeartbeatAt: null },
+        }),
+      );
+
+    const { result, unmount } = renderHook(() =>
+      useSandboxStatusPoll("agent-a", { intervalMs: 1_000 }),
+    );
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(requestSignals[0]?.aborted).toBe(false);
+
+    await act(async () => {
+      resolveFirst?.(
+        Response.json({
+          data: { status: "provisioning", lastHeartbeatAt: null },
+        }),
+      );
+      await Promise.resolve();
+    });
+    expect(result.current.status).toBe("provisioning");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.current.status).toBe("running");
+    unmount();
+  });
+
   it("starts polling a replacement agent after the previous agent reached a terminal state", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")

--- a/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.test.tsx
+++ b/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.test.tsx
@@ -1,4 +1,4 @@
-/** Exercises the authenticated, validated agents-list background poll with real React effects. */
+/** Exercises sandbox status and authenticated list polling with real React effects and deterministic transport doubles. */
 // @vitest-environment jsdom
 
 import { act, renderHook, waitFor } from "@testing-library/react";
@@ -163,6 +163,79 @@ describe("useSandboxListPoll", () => {
 });
 
 describe("useSandboxStatusPoll", () => {
+  it("ignores a stale terminal response and keeps replacement polling active", async () => {
+    vi.useFakeTimers();
+    let resolveAgentA: ((response: Response) => void) | undefined;
+    let resolveAgentBFirst: ((response: Response) => void) | undefined;
+    let resolveAgentBNext: ((response: Response) => void) | undefined;
+    const requestSignals: Array<AbortSignal | null | undefined> = [];
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementationOnce((_input, init) => {
+        requestSignals.push(init?.signal);
+        return new Promise((resolve) => {
+          resolveAgentA = resolve;
+        });
+      })
+      .mockImplementationOnce((_input, init) => {
+        requestSignals.push(init?.signal);
+        return new Promise((resolve) => {
+          resolveAgentBFirst = resolve;
+        });
+      })
+      .mockImplementationOnce((_input, init) => {
+        requestSignals.push(init?.signal);
+        return new Promise((resolve) => {
+          resolveAgentBNext = resolve;
+        });
+      });
+
+    const { result, rerender, unmount } = renderHook(
+      ({ agentId }) => useSandboxStatusPoll(agentId, { intervalMs: 1_000 }),
+      { initialProps: { agentId: "agent-a" } },
+    );
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    rerender({ agentId: "agent-b" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(requestSignals[0]?.aborted).toBe(true);
+
+    await act(async () => {
+      resolveAgentBFirst?.(
+        Response.json({
+          data: { status: "provisioning", lastHeartbeatAt: null },
+        }),
+      );
+      await Promise.resolve();
+    });
+    expect(result.current.status).toBe("provisioning");
+
+    await act(async () => {
+      resolveAgentA?.(
+        Response.json({
+          data: { status: "running", lastHeartbeatAt: null },
+        }),
+      );
+      await Promise.resolve();
+    });
+    expect(result.current.status).toBe("provisioning");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.lastCall?.[0]).toBe("/api/v1/eliza/agents/agent-b");
+
+    unmount();
+    expect(requestSignals[2]?.aborted).toBe(true);
+    await act(async () => {
+      resolveAgentBNext?.(
+        Response.json({ data: { status: "running", lastHeartbeatAt: null } }),
+      );
+      await Promise.resolve();
+    });
+  });
+
   it("starts polling a replacement agent after the previous agent reached a terminal state", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")

--- a/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.ts
+++ b/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.ts
@@ -9,7 +9,7 @@
  */
 
 import type { AgentListItemDto } from "@elizaos/cloud-shared/lib/types/cloud-api";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { api } from "../../lib/api-client";
 import { parseAgentsResponse } from "./data/eliza-agents";
 
@@ -53,28 +53,35 @@ export function useSandboxStatusPoll(
     isLoading: false,
   });
 
-  const cancelledRef = useRef(false);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const statusRef = useRef<SandboxStatus>("pending");
-  const consecutiveErrorsRef = useRef(0);
-
-  const cleanup = useCallback(() => {
-    cancelledRef.current = true;
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-  }, []);
+  const effectGenerationRef = useRef(0);
 
   useEffect(() => {
+    const effectGeneration = ++effectGenerationRef.current;
+    let cancelled = false;
+    let interval: ReturnType<typeof setInterval> | null = null;
+    let status: SandboxStatus = "pending";
+    let consecutiveErrors = 0;
+    let requestGeneration = 0;
+    let requestController: AbortController | null = null;
+
+    const isCurrentEffect = () =>
+      !cancelled && effectGenerationRef.current === effectGeneration;
+    const stop = () => {
+      cancelled = true;
+      requestGeneration++;
+      requestController?.abort();
+      requestController = null;
+      if (interval) {
+        clearInterval(interval);
+        interval = null;
+      }
+    };
+
     if (!agentId || !enabled) {
-      cleanup();
-      return;
+      stop();
+      return stop;
     }
 
-    cancelledRef.current = false;
-    statusRef.current = "pending";
-    consecutiveErrorsRef.current = 0;
     // Reset the visible result too, not just the ref. Otherwise the previous
     // agent's terminal status stays on screen and is attributed to the new one
     // — and if the new agent's first fetch fails, the catch only bumps an error
@@ -88,9 +95,9 @@ export function useSandboxStatusPoll(
     });
 
     const poll = async () => {
-      if (cancelledRef.current) return;
-      if (TERMINAL_STATES.has(statusRef.current)) {
-        cleanup();
+      if (!isCurrentEffect()) return;
+      if (TERMINAL_STATES.has(status)) {
+        stop();
         return;
       }
       if (
@@ -100,17 +107,24 @@ export function useSandboxStatusPoll(
         return;
 
       setResult((prev) => ({ ...prev, isLoading: true }));
+      const generation = ++requestGeneration;
+      requestController?.abort();
+      const controller = new AbortController();
+      requestController = controller;
+      const timeoutSignal = AbortSignal.timeout(10_000);
+      const abortForTimeout = () => controller.abort(timeoutSignal.reason);
+      timeoutSignal.addEventListener("abort", abortForTimeout, { once: true });
 
       try {
         // Bound each poll hop so a hung status endpoint cannot leave
         // isLoading pinned forever (the error path only fires on rejection).
         const res = await fetch(`/api/v1/eliza/agents/${agentId}`, {
-          signal: AbortSignal.timeout(10_000),
+          signal: controller.signal,
         });
-        if (cancelledRef.current) return;
+        if (!isCurrentEffect() || generation !== requestGeneration) return;
 
         if (!res.ok) {
-          consecutiveErrorsRef.current++;
+          consecutiveErrors++;
           setResult((prev) => ({
             ...prev,
             isLoading: false,
@@ -118,21 +132,22 @@ export function useSandboxStatusPoll(
           }));
           if (
             (res.status >= 400 && res.status < 500) ||
-            consecutiveErrorsRef.current >= MAX_CONSECUTIVE_ERRORS
+            consecutiveErrors >= MAX_CONSECUTIVE_ERRORS
           ) {
-            cleanup();
+            stop();
           }
           return;
         }
 
-        consecutiveErrorsRef.current = 0;
+        consecutiveErrors = 0;
 
         const json = await res.json();
+        if (!isCurrentEffect() || generation !== requestGeneration) return;
         const data = json?.data;
         if (!data) return;
 
         const newStatus = (data.status as SandboxStatus) ?? "pending";
-        statusRef.current = newStatus;
+        status = newStatus;
 
         setResult({
           status: newStatus,
@@ -142,25 +157,30 @@ export function useSandboxStatusPoll(
         });
 
         if (TERMINAL_STATES.has(newStatus)) {
-          cleanup();
+          stop();
         }
       } catch {
-        if (!cancelledRef.current) {
-          consecutiveErrorsRef.current++;
+        // error-policy:J4 A failed status poll clears loading and retries until
+        // the explicit error limit, while superseded requests stay invisible.
+        if (isCurrentEffect() && generation === requestGeneration) {
+          consecutiveErrors++;
           setResult((prev) => ({ ...prev, isLoading: false }));
-          if (consecutiveErrorsRef.current >= MAX_CONSECUTIVE_ERRORS) {
-            cleanup();
+          if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+            stop();
           }
         }
+      } finally {
+        timeoutSignal.removeEventListener("abort", abortForTimeout);
+        if (requestController === controller) requestController = null;
       }
     };
 
     void poll();
 
-    intervalRef.current = setInterval(() => void poll(), intervalMs);
+    interval = setInterval(() => void poll(), intervalMs);
 
-    return cleanup;
-  }, [agentId, enabled, intervalMs, cleanup]);
+    return stop;
+  }, [agentId, enabled, intervalMs]);
 
   return result;
 }

--- a/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.ts
+++ b/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.ts
@@ -105,10 +105,13 @@ export function useSandboxStatusPoll(
         document.visibilityState !== "visible"
       )
         return;
+      // Keep the current hop alive until its 10-second deadline. Aborting it
+      // on every shorter interval tick would starve otherwise-valid slow
+      // responses (the default interval is five seconds).
+      if (requestController) return;
 
       setResult((prev) => ({ ...prev, isLoading: true }));
       const generation = ++requestGeneration;
-      requestController?.abort();
       const controller = new AbortController();
       requestController = controller;
       const timeoutSignal = AbortSignal.timeout(10_000);


### PR DESCRIPTION
# Relates to

Fixes #23874.

- [x] This PR targets `develop` and is rebased onto exact live `develop@bfe85040598543b195678dc1f5170d394f5e906b` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the deterministic deferred-response evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ce3b570874427467398a366d5ed51df11924eaec:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Independently rebased onto exact live `develop@bfe85040598543b195678dc1f5170d394f5e906b`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. The change is limited to the single-agent sandbox status hook. It replaces cross-effect mutable lifecycle refs with effect-local state, generation guards, and request aborts. Terminal-state, visible-reset, timeout, and replacement polling behavior remain covered.

# Background

## What does this PR do?

Each `agentId` lifecycle now owns its cancellation flag, interval, status, error count, and active request. Interval ticks skip an already-active hop rather than aborting it, so responses that are slower than the polling interval but remain within the 10-second request deadline can complete. A monotonically increasing effect generation prevents a response belonging to agent A from updating agent B's state. Cleanup aborts the request owned by that effect, and a stale terminal response cannot clear the replacement effect's interval.

The regression uses deferred responses to reproduce the original ordering: A starts, the hook switches to B, B reports `provisioning`, then A reports stale terminal `running`. The test verifies A is aborted, B remains visible, B polls again, and B's active request is aborted on unmount.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores the documented hook lifecycle contract and changes no public API or rendered copy.

# Testing

## Where should a reviewer start?

- `packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.ts`
- `packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.test.tsx`

## Detailed testing steps

At exact PR head `ce3b570874427467398a366d5ed51df11924eaec`:

1. `cd packages/ui && ../../node_modules/.bin/vitest run --config ./vitest.config.ts src/cloud/instances/lib/use-sandbox-status-poll.test.tsx --no-cache`
   - PASS: 1 file, 8 tests.
2. `./node_modules/.bin/biome check packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.ts packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.test.tsx`
   - PASS: 2 files, no fixes.
3. `git diff --check origin/develop...HEAD`
   - PASS.

Red/green reproduction: on the untouched source, the new deferred-response regression failed because agent A's signal remained un-aborted (`expected true, received false`). At the PR head it passes and also proves B continues to its next interval and cleanup aborts B's in-flight request.

# Evidence Gate

<!-- evidence-head:ce3b570874427467398a366d5ed51df11924eaec -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - the change is non-rendered polling lifecycle logic with no pixel or layout change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - the change is non-rendered polling lifecycle logic with no pixel or layout change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the race requires deterministic deferred transport ordering rather than a visual interaction.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code path changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - deterministic hook assertions directly observe request URLs, abort signals, state, and continued polling.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, schedule, wallet, generated-file, or media artifact changes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changes.

## Backend + frontend logs

N/A - no backend path changes; the deterministic React hook test is the executable boundary evidence for the concurrency ordering.

## Screenshots (before / after) + video walkthrough

N/A - no rendered output changes.

## Audio / voice walkthrough

N/A - no audio or voice path changes.

## Known gaps / failures

- The task used a minimal sparse checkout to stay within the active disk-pressure constraint, so a complete `bun install`, root `bun run verify`, and `packages/app audit:app` were intentionally not generated. The app audit is also not behavioral evidence for this non-rendered hook race.
- UI package typecheck reached only two unresolved sparse-checkout workspace dependencies (`plugin-task-coordinator`'s `lucide-react` resolution and the unbuilt `@elizaos/capacitor-secure-store` package); it emitted no diagnostic for either changed file. Installing/building the full unrelated workspace was prohibited by the disk constraint.
- Full-package UI Biome reports one pre-existing unrelated formatter failure in `src/components/chat/widgets/maps-card.tsx`; both changed files pass Biome exactly.
- Independent review found and repaired interval starvation: the initial patch aborted every active request on each shorter interval tick. Exact-head regression coverage now proves an in-deadline slow hop remains alive and the next poll starts only after it settles.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@ce3b570874427467398a366d5ed51df11924eaec:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [corrective-23874]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@ce3b570874427467398a366d5ed51df11924eaec:packages/skills/skills/contribute-to-eliza"} -->

