### PR TITLE
fix(agent): normalize GitHub bug-report startup context

### DIFF
--- a/packages/agent/src/api/bug-report-routes.ts
+++ b/packages/agent/src/api/bug-report-routes.ts
@@ -197,10 +197,19 @@ function formatIssueBody(body: BugReportBody): string {
     sections.push(
       `### Startup Context\n\n\`\`\`json\n${JSON.stringify(
         {
-          reason: body.startup.reason,
-          phase: body.startup.phase,
+          reason:
+            body.startup.reason === undefined
+              ? undefined
+              : sanitize(body.startup.reason, 120),
+          phase:
+            body.startup.phase === undefined
+              ? undefined
+              : sanitize(body.startup.phase, 120),
           status: body.startup.status,
-          path: body.startup.path,
+          path:
+            body.startup.path === undefined
+              ? undefined
+              : sanitize(body.startup.path, 500),
         },
         null,
         2,

--- a/packages/agent/test/api/bug-report-routes.test.ts
+++ b/packages/agent/test/api/bug-report-routes.test.ts
@@ -17,6 +17,31 @@ const validBugReport = {
   stepsToReproduce: "Run the agent",
 };
 
+const fox = String.fromCodePoint(0x1f98a);
+const loneHighSurrogate = String.fromCharCode(0xd800);
+const loneLowSurrogate = String.fromCharCode(0xdc00);
+
+function taggedBoundaryInput(maxLen: number, visiblePrefix: string): string {
+  const taggedPrefix = `<b>${visiblePrefix}${loneHighSurrogate}H${loneLowSurrogate}L</b>`;
+  return `${taggedPrefix}${"x".repeat(maxLen - taggedPrefix.length - 1)}${fox}${loneHighSurrogate}`;
+}
+
+function expectWellFormedWithin(value: string, maxLen: number): void {
+  expect(value.isWellFormed()).toBe(true);
+  expect(value.length).toBeLessThanOrEqual(maxLen);
+  expect(value).toContain("\uFFFD");
+  expect(value).not.toMatch(/[<>]/);
+}
+
+function markdownSection(body: string, heading: string): string {
+  const marker = `### ${heading}\n\n`;
+  const start = body.indexOf(marker);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const contentStart = start + marker.length;
+  const nextSection = body.indexOf("\n\n### ", contentStart);
+  return body.slice(contentStart, nextSection === -1 ? undefined : nextSection);
+}
+
 function createContext(
   body: Record<string, unknown> = validBugReport,
   ip = "127.0.0.1",
@@ -139,6 +164,7 @@ describe.sequential("bug report repository routing", () => {
       description: "<b>Broken</b>\nagent",
       stepsToReproduce: "Run <script>unsafe</script> once",
       logs: `credential ghp_${"a".repeat(20)}`,
+      startup: { reason: "", phase: "", path: "" },
     });
 
     expect(await handleBugReportRoutes(ctx)).toBe(true);
@@ -155,10 +181,74 @@ describe.sequential("bug report repository routing", () => {
     expect(payload.title).toBe("[Bug] Broken agent");
     expect(payload.body).toContain("Run unsafe once");
     expect(payload.body).toContain("credential [redacted-token]");
+    expect(payload.body).toContain('"reason": ""');
+    expect(payload.body).toContain('"phase": ""');
+    expect(payload.body).toContain('"path": ""');
     expect(payload.labels).toEqual(["bug", "triage", "user-reported"]);
     expect(ctx.responseBody).toEqual({
       url: "https://github.com/elizaOS/eliza/issues/123",
     });
+  });
+
+  it("keeps the outgoing GitHub issue Unicode-safe, bounded, tag-clean, and redacted", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "test-token-not-a-credential");
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            html_url: "https://github.com/elizaOS/eliza/issues/456",
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const ctx = createContext({
+      description: taggedBoundaryInput(10_000, "boundary description "),
+      stepsToReproduce: taggedBoundaryInput(10_000, "boundary steps "),
+      logs: taggedBoundaryInput(50_000, `credential ghp_${"a".repeat(20)} `),
+      category: "startup-failure",
+      startup: {
+        reason: taggedBoundaryInput(120, "reason "),
+        phase: taggedBoundaryInput(120, "phase "),
+        status: 503,
+        path: taggedBoundaryInput(500, "path "),
+      },
+    });
+
+    expect(await handleBugReportRoutes(ctx)).toBe(true);
+    const [, init] = fetchMock.mock.calls[0];
+    const payload = JSON.parse(String(init.body)) as {
+      title: string;
+      body: string;
+      labels: string[];
+    };
+
+    expectWellFormedWithin(payload.title, "[Bug] ".length + 80);
+    expect(payload.body.isWellFormed()).toBe(true);
+    expect(payload.body).not.toContain("ghp_");
+    expect(payload.body).toContain("credential [redacted-token]");
+    expectWellFormedWithin(
+      markdownSection(payload.body, "Description"),
+      10_000,
+    );
+    expectWellFormedWithin(
+      markdownSection(payload.body, "Steps to Reproduce"),
+      10_000,
+    );
+    const startupSection = markdownSection(payload.body, "Startup Context");
+    const startup = JSON.parse(
+      startupSection.slice("```json\n".length, -"\n```".length),
+    ) as {
+      reason: string;
+      phase: string;
+      status: number;
+      path: string;
+    };
+    expectWellFormedWithin(startup.reason, 120);
+    expectWellFormedWithin(startup.phase, 120);
+    expectWellFormedWithin(startup.path, 500);
+    expect(startup.status).toBe(503);
+    expect(payload.labels).toEqual(["bug", "triage", "user-reported"]);
   });
 
   it("keeps remote intake precedence over token-backed GitHub submission", async () => {
@@ -192,6 +282,90 @@ describe.sequential("bug report repository routing", () => {
       url: "https://intake.example.test/reports/report-1",
       destination: "remote",
     });
+  });
+
+  it("keeps every outgoing remote-intake text field Unicode-safe and bounded", async () => {
+    vi.stubEnv(
+      "ELIZA_BUG_REPORT_API_URL",
+      "https://intake.example.test/reports",
+    );
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(JSON.stringify({ accepted: true, id: "report-2" }), {
+          status: 202,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const ctx = createContext({
+      description: taggedBoundaryInput(500, "description "),
+      stepsToReproduce: taggedBoundaryInput(10_000, "steps "),
+      expectedBehavior: taggedBoundaryInput(10_000, "expected "),
+      actualBehavior: taggedBoundaryInput(10_000, "actual "),
+      environment: taggedBoundaryInput(200, "environment "),
+      nodeVersion: taggedBoundaryInput(200, "node "),
+      modelProvider: taggedBoundaryInput(200, "provider "),
+      appVersion: taggedBoundaryInput(200, "app "),
+      releaseChannel: taggedBoundaryInput(200, "release "),
+      logs: taggedBoundaryInput(50_000, `credential ghp_${"a".repeat(20)} `),
+      category: "startup-failure",
+      startup: {
+        reason: taggedBoundaryInput(120, "reason "),
+        phase: taggedBoundaryInput(120, "phase "),
+        message: taggedBoundaryInput(1_000, `token ghp_${"b".repeat(20)} `),
+        detail: taggedBoundaryInput(10_000, `token ghp_${"c".repeat(20)} `),
+        status: 500,
+        path: taggedBoundaryInput(500, "path "),
+      },
+    });
+
+    expect(await handleBugReportRoutes(ctx)).toBe(true);
+    const [, init] = fetchMock.mock.calls[0];
+    const payload = JSON.parse(String(init.body)) as {
+      description: string;
+      stepsToReproduce: string;
+      expectedBehavior: string;
+      actualBehavior: string;
+      environment: string;
+      nodeVersion: string;
+      modelProvider: string;
+      appVersion: string;
+      releaseChannel: string;
+      logs: string;
+      startup: {
+        reason: string;
+        phase: string;
+        message: string;
+        detail: string;
+        status: number;
+        path: string;
+      };
+    };
+    const cappedFields = [
+      [payload.description, 500],
+      [payload.stepsToReproduce, 10_000],
+      [payload.expectedBehavior, 10_000],
+      [payload.actualBehavior, 10_000],
+      [payload.environment, 200],
+      [payload.nodeVersion, 200],
+      [payload.modelProvider, 200],
+      [payload.appVersion, 200],
+      [payload.releaseChannel, 200],
+      [payload.logs, 50_000],
+      [payload.startup.reason, 120],
+      [payload.startup.phase, 120],
+      [payload.startup.message, 1_000],
+      [payload.startup.detail, 10_000],
+      [payload.startup.path, 500],
+    ] as const;
+
+    for (const [value, maxLen] of cappedFields) {
+      expectWellFormedWithin(value, maxLen);
+    }
+    expect(payload.logs).toContain("credential [redacted-token]");
+    expect(payload.startup.message).toContain("token [redacted-token]");
+    expect(payload.startup.detail).toContain("token [redacted-token]");
+    expect(payload.startup.status).toBe(500);
   });
 
   it("preserves the per-client submission rate limit", async () => {


### PR DESCRIPTION
# Relates to

Fixes #23638

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto live `develop@bb4054a818619fa221fe098dd6c923f4f214ac1a` with zero conflicts.
- [x] Real GitHub and remote-intake handler tests capture every changed outbound payload at exact head `9ba84038675d1b1db8f801b7a97cb03e94712dec`.
- [x] Independent source review found and then verified the empty-string compatibility correction.
- [x] Mutation controls prove the new tests reject raw surrogate splitting and unsanitized GitHub startup context.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@bb4054a818619fa221fe098dd6c923f4f214ac1a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto live `develop@bb4054a818619fa221fe098dd6c923f4f214ac1a`; zero conflicts.
- [x] Exact-head affected suites, changed-file Biome, and diff hygiene pass.

# Risks

Low. The existing sanitizer already normalizes and truncates normal bug-report fields. This PR applies those same caps to GitHub startup `reason`, `phase`, and `path`, preserves explicitly empty fields, and adds route-level payload coverage. Remote intake behavior is unchanged and now pinned by the same matrix.

# Background

## What does this PR do?

Direct develop commit `c1f19878dae780842c9f118e7b6f17860e57bd8f` made the core sanitizer surrogate-safe, but its tests only called `sanitize()` directly. The required real-sink coverage was absent, and GitHub startup context still bypassed sanitization.

This PR:

1. normalizes, tag-cleans, and caps GitHub startup `reason` and `phase` at 120 UTF-16 units and `path` at 500;
2. preserves the prior distinction between an omitted field and an explicit empty string;
3. captures the real GitHub request JSON and verifies title/body well-formedness, field caps, tag removal, token redaction, and startup JSON;
4. captures the real remote-intake request JSON and verifies every text field at its existing cap; and
5. exercises boundary-split astral characters plus supplied lone high and low surrogate halves through both sinks.

## What kind of change is this?

Bug fix and missing acceptance coverage for an HTTP validation boundary.

# Documentation changes needed?

No. This makes the implementation conform to the issue's existing server-boundary contract without changing the public request shape.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/bug-report-routes.ts`, then the two captured-payload tests in `packages/agent/test/api/bug-report-routes.test.ts`.

## Detailed testing steps

```bash
node packages/shared/scripts/generate-keywords.mjs
bunx vitest run \
  packages/agent/test/api/bug-report-routes.test.ts \
  packages/agent/src/api/bug-report-routes.surrogate.test.ts \
  packages/agent/src/api/bug-report-routes.timeout.test.ts \
  packages/shared/src/contracts/tail-routes.test.ts
bunx biome check \
  packages/agent/src/api/bug-report-routes.ts \
  packages/agent/test/api/bug-report-routes.test.ts
git diff --check
```

Exact-head receipt:

```text
Test Files 3 passed (3)
Tests 28 passed (28)
Biome: Checked 2 files. No fixes applied.
git diff --check: exit 0
```

Mutation receipts:

```text
(FAIL) raw String.slice truncation: GitHub outbound body is not well formed
(FAIL) raw String.slice truncation: remote capped field is not well formed
(FAIL) raw GitHub startup fields: startup reason is not well formed
```

# Evidence Gate

<!-- evidence-head:9ba84038675d1b1db8f801b7a97cb03e94712dec -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only request sanitization; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only request sanitization; no rendered UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - deterministic handler payloads are captured by executable tests below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs:
  <details><summary>exact-head route and mutation transcript</summary>

  ```text
  $ bunx vitest run packages/agent/test/api/bug-report-routes.test.ts packages/agent/src/api/bug-report-routes.surrogate.test.ts packages/agent/src/api/bug-report-routes.timeout.test.ts packages/shared/src/contracts/tail-routes.test.ts
  Test Files 3 passed (3)
  Tests 28 passed (28)
  (FAIL) mutation: GitHub body well-formed assertion rejected raw slice
  (FAIL) mutation: remote payload well-formed assertion rejected raw slice
  (FAIL) mutation: GitHub startup assertion rejected unsanitized input
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend or browser network path changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - the domain artifact is the captured outbound GitHub and remote JSON asserted in the backend route suite.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Known gaps / failures

- `bun run --cwd packages/agent typecheck` is blocked in this sparse worktree by absent unrelated plugin/cloud/app-core source trees and unhydrated external declarations (`ws`, `pngjs`, `jpeg-js`, `esbuild`, `isomorphic-git`, and `@clack/prompts`). No diagnostic points to either changed file.
- `bun run --cwd packages/agent build` completed package-boundary validation and TypeScript emission, then stopped in distribution preparation because the sparse checkout omits the unrelated `@elizaos/plugin-contacts` workspace manifest.
- Root `bun run verify` was not rerun in this sparse checkout. These environment gates are explicit acceptance holds while the source-complete PR remains ready for review.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@bb4054a818619fa221fe098dd6c923f4f214ac1a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-23638-route-unicode]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@bb4054a818619fa221fe098dd6c923f4f214ac1a:packages/skills/skills/contribute-to-eliza"} -->
