### PR TITLE
fix(agent): make bug-report submission truncation Unicode-safe

### DIFF
--- a/packages/agent/src/api/bug-report-routes.ts
+++ b/packages/agent/src/api/bug-report-routes.ts
@@ -8,7 +8,7 @@
  * opens itself.
  */
 import os from "node:os";
-import { logger, type RouteRequestContext } from "@elizaos/core";
+import { logger, type RouteRequestContext, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { PostBugReportRequestSchema } from "@elizaos/shared";
 
 export const DEFAULT_BUG_REPORT_REPO = "elizaOS/eliza";
@@ -101,14 +101,24 @@ interface BugReportBody {
 }
 
 export function sanitize(input: string, maxLen = 10_000): string {
-  const clipped = input.length > maxLen ? input.slice(0, maxLen) : input;
-  let prev = clipped;
+  const bounded = toWellFormedUnicode(input);
+  if (bounded.length > maxLen) {
+    const clipped = truncateWellFormed(bounded, maxLen);
+    let prev = clipped;
+    let next = prev.replace(/<[^<>]{0,1024}>/g, "");
+    while (next !== prev) {
+      prev = next;
+      next = prev.replace(/<[^<>]{0,1024}>/g, "");
+    }
+    return truncateWellFormed(next.replace(/[<>]/g, ""), maxLen);
+  }
+  let prev = bounded;
   let next = prev.replace(/<[^<>]{0,1024}>/g, "");
   while (next !== prev) {
     prev = next;
     next = prev.replace(/<[^<>]{0,1024}>/g, "");
   }
-  return next.replace(/[<>]/g, "").slice(0, maxLen);
+  return truncateWellFormed(next.replace(/[<>]/g, ""), maxLen);
 }
 
 function redactSecrets(input: string, maxLen = 10_000): string {

--- a/packages/agent/test/api/bug-report-routes.test.ts
+++ b/packages/agent/test/api/bug-report-routes.test.ts
@@ -208,3 +208,56 @@ describe.sequential("bug report repository routing", () => {
     });
   });
 });
+
+describe("bug-report Unicode-safe truncation", () => {
+  beforeEach(() => {
+    resetBugReportRateLimit();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  const isWellFormed = (value: string) =>
+    (value as unknown as { isWellFormed(): boolean }).isWellFormed?.() ?? true;
+
+  it("normalizes lone surrogates in GitHub-mode title/body", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "test-token");
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ html_url: "https://github.com/elizaOS/eliza/issues/1" }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const description = `${"a".repeat(78)}🦊extra`;
+    const ctx = createContext({ description, stepsToReproduce: "Run" });
+
+    await handleBugReportRoutes(ctx);
+    const payload = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(isWellFormed(payload.title)).toBe(true);
+    expect(isWellFormed(payload.body)).toBe(true);
+    expect(payload.title.length).toBeLessThanOrEqual(80);
+  });
+
+  it("normalizes lone surrogates in remote-mode fields", async () => {
+    vi.stubEnv("ELIZA_BUG_REPORT_API_URL", "https://intake.example.test/reports");
+    vi.stubEnv("ELIZA_BUG_REPORT_API_TOKEN", "remote-token");
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ accepted: true, id: "r1" }),
+          { status: 202, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const description = `${"b".repeat(499)}🦊extra`;
+    const ctx = createContext({ description, stepsToReproduce: "Run" });
+
+    await handleBugReportRoutes(ctx);
+    const payload = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(isWellFormed(payload.description)).toBe(true);
+    expect(payload.description.length).toBeLessThanOrEqual(500);
+  });
+});


### PR DESCRIPTION
Closes #23638

sanitize() now normalizes lone surrogates and uses surrogate-safe truncation
at both clamps. Route tests cover GitHub and remote intake payloads.

- packages/agent/src/api/bug-report-routes.ts
- packages/agent/test/api/bug-report-routes.test.ts: regression coverage