### PR TITLE
fix(cloud): persist fee-inclusive MCP usage receipts

### DIFF
--- a/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
@@ -26,8 +26,9 @@ mock.module("@/lib/security/outbound-url", () => ({ assertSafeOutboundUrl }));
 const safeFetch = mock();
 mock.module("@/lib/security/safe-fetch", () => ({ safeFetch }));
 
+const getReferrer = mock();
 mock.module("@/lib/services/affiliates", () => ({
-  affiliatesService: { getReferrer: async () => null },
+  affiliatesService: { getReferrer },
 }));
 
 const containersGetById = mock();
@@ -42,10 +43,11 @@ mock.module("@/lib/services/credits", () => ({
 }));
 
 const getById = mock();
+const recordUsageWithoutDeduction = mock(async () => {});
 mock.module("@/lib/services/user-mcps", () => ({
   userMcpsService: {
     getById,
-    recordUsageWithoutDeduction: mock(async () => {}),
+    recordUsageWithoutDeduction,
   },
 }));
 
@@ -83,6 +85,9 @@ beforeEach(() => {
     organization_id: "org1",
   });
   getById.mockResolvedValue({ ...EXTERNAL_MCP });
+  getReferrer.mockReset();
+  getReferrer.mockResolvedValue(null);
+  recordUsageWithoutDeduction.mockClear();
   reserveAndDeductCredits.mockClear();
   reserveAndDeductCredits.mockResolvedValue({
     success: true,
@@ -207,4 +212,38 @@ test("successful call does NOT refund", async () => {
   const res = await post();
   expect(res.status).toBe(200);
   expect(refundCredits).not.toHaveBeenCalled();
+});
+
+test("affiliate surcharge uses one exact debit, persisted receipt, and refund authority", async () => {
+  getReferrer.mockResolvedValue({
+    user_id: "affiliate-user",
+    id: "affiliate-code",
+    markup_percent: "10",
+  });
+  safeFetch.mockResolvedValue(
+    new Response(JSON.stringify({ ok: true }), { status: 200 }),
+  );
+  const success = await post();
+  expect(success.status).toBe(200);
+  expect(reserveAndDeductCredits.mock.calls[0]?.[0].amount).toBe(0.065);
+  expect(recordUsageWithoutDeduction).toHaveBeenCalledWith(
+    expect.objectContaining({
+      creditsCharged: 5,
+      affiliateFeeCredits: 0.5,
+      platformFeeCredits: 1,
+      chargeReceipt: {
+        creditUnit: "USD",
+        baseAmountUsd: 0.05,
+        affiliateFeeUsd: 0.005,
+        platformFeeUsd: 0.01,
+        totalAmountUsd: 0.065,
+        feeComponentsKnown: true,
+      },
+    }),
+  );
+
+  safeFetch.mockRejectedValue(new Error("offline"));
+  const failure = await post();
+  expect(failure.status).toBe(502);
+  expect(refundCredits.mock.calls[0]?.[0].amount).toBe(0.065);
 });

--- a/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
@@ -10,7 +10,8 @@
 import {
   calculateCreditMarkup,
   DEFAULT_PLATFORM_FEE_RATE,
-  legacyMcpPointsToOrganizationCredits,
+  formatOrganizationCreditUsd,
+  mcpUsageChargeReceiptFromLegacyPoints,
   ORGANIZATION_CREDIT_UNIT,
 } from "@elizaos/cloud-shared/billing";
 import { Hono } from "hono";
@@ -258,10 +259,15 @@ app.post("/", async (c) => {
     markupPercent: referrer ? Number(referrer.markup_percent) : 0,
     platformFeeRate: referrer ? DEFAULT_PLATFORM_FEE_RATE : 0,
   });
+  const chargeReceipt = mcpUsageChargeReceiptFromLegacyPoints({
+    basePoints: creditsRequired,
+    affiliateFeePoints: affiliateFeeCredits,
+    platformFeePoints: platformFeeCredits,
+  });
 
   const preChargeResult = await creditsService.reserveAndDeductCredits({
     organizationId: user.organization_id,
-    amount: legacyMcpPointsToOrganizationCredits(totalCreditsRequired),
+    amount: chargeReceipt.totalAmountUsd,
     description: `MCP: ${mcp.name}`,
     metadata: {
       mcp_id: mcp.id,
@@ -271,8 +277,16 @@ app.post("/", async (c) => {
       affiliate_fee: affiliateFeeCredits.toFixed(4),
       platform_fee: platformFeeCredits.toFixed(4),
       total_credits_charged: totalCreditsRequired.toFixed(4),
-      price_usd:
-        legacyMcpPointsToOrganizationCredits(totalCreditsRequired).toString(),
+      base_amount_usd: formatOrganizationCreditUsd(chargeReceipt.baseAmountUsd),
+      affiliate_fee_usd: formatOrganizationCreditUsd(
+        chargeReceipt.affiliateFeeUsd,
+      ),
+      platform_fee_usd: formatOrganizationCreditUsd(
+        chargeReceipt.platformFeeUsd,
+      ),
+      total_amount_usd: formatOrganizationCreditUsd(
+        chargeReceipt.totalAmountUsd,
+      ),
       credit_unit: ORGANIZATION_CREDIT_UNIT,
       ...(affiliateOwnerId && { affiliate_owner_id: affiliateOwnerId }),
       ...(affiliateCodeId && { affiliate_code_id: affiliateCodeId }),
@@ -284,7 +298,7 @@ app.post("/", async (c) => {
       {
         error: "Insufficient credits",
         creditUnit: ORGANIZATION_CREDIT_UNIT,
-        requiredUsd: legacyMcpPointsToOrganizationCredits(totalCreditsRequired),
+        requiredUsd: chargeReceipt.totalAmountUsd,
         /** @deprecated Legacy MCP pricing points (100 points = $1). */
         required: totalCreditsRequired,
         balance: preChargeResult.newBalance,
@@ -307,7 +321,7 @@ app.post("/", async (c) => {
     await creditsService
       .refundCredits({
         organizationId: user.organization_id,
-        amount: legacyMcpPointsToOrganizationCredits(totalCreditsRequired),
+        amount: chargeReceipt.totalAmountUsd,
         description: `MCP refund: ${mcp.name} (${reason})`,
         metadata: {
           mcp_id: mcp.id,
@@ -463,6 +477,7 @@ app.post("/", async (c) => {
         creditsCharged: creditsRequired,
         affiliateFeeCredits,
         platformFeeCredits,
+        chargeReceipt,
         affiliateOwnerId,
         affiliateCodeId,
         metadata: {

--- a/packages/cloud/shared/src/billing/index.ts
+++ b/packages/cloud/shared/src/billing/index.ts
@@ -32,6 +32,8 @@ export {
   LEGACY_MCP_POINTS_FRACTION_DIGITS,
   LEGACY_MCP_POINTS_PER_DOLLAR,
   legacyMcpPointsToOrganizationCredits,
+  type McpUsageChargeReceipt,
+  mcpUsageChargeReceiptFromLegacyPoints,
   ORGANIZATION_CREDIT_PRICING,
   ORGANIZATION_CREDIT_UNIT,
   ORGANIZATION_CREDIT_USD_PRECISION,

--- a/packages/cloud/shared/src/billing/organization-credits.test.ts
+++ b/packages/cloud/shared/src/billing/organization-credits.test.ts
@@ -5,6 +5,7 @@ import {
   formatOrganizationCreditUsd,
   LEGACY_MCP_POINTS_PER_DOLLAR,
   legacyMcpPointsToOrganizationCredits,
+  mcpUsageChargeReceiptFromLegacyPoints,
   ORGANIZATION_CREDIT_PRICING,
   organizationCreditsToLegacyMcpPoints,
   RETRIEVE_MEMORIES_PRICE_USD,
@@ -55,6 +56,23 @@ describe("organization credit unit", () => {
     expect(formatOrganizationCreditUsd(0.0125)).toBe("0.0125");
     expect(formatOrganizationCreditUsd(0.000001)).toBe("0.000001");
     expect(formatOrganizationCreditUsd(100)).toBe("100");
+  });
+
+  test("builds the exact fee-inclusive receipt used by debit and persistence", () => {
+    expect(
+      mcpUsageChargeReceiptFromLegacyPoints({
+        basePoints: 1,
+        affiliateFeePoints: 0.1,
+        platformFeePoints: 0.2,
+      }),
+    ).toEqual({
+      creditUnit: "USD",
+      baseAmountUsd: 0.01,
+      affiliateFeeUsd: 0.001,
+      platformFeeUsd: 0.002,
+      totalAmountUsd: 0.013,
+      feeComponentsKnown: true,
+    });
   });
 
   test("rejects negative and non-finite amounts", () => {

--- a/packages/cloud/shared/src/billing/organization-credits.ts
+++ b/packages/cloud/shared/src/billing/organization-credits.ts
@@ -38,6 +38,16 @@ export const ORGANIZATION_CREDIT_USD_PRECISION = 6 as const;
 /** Fraction digits the legacy `credits_per_request` column stores. */
 export const LEGACY_MCP_POINTS_FRACTION_DIGITS = 4 as const;
 
+/** Canonical, fee-inclusive receipt persisted for one MCP credit charge. */
+export interface McpUsageChargeReceipt {
+  creditUnit: typeof ORGANIZATION_CREDIT_UNIT;
+  baseAmountUsd: number;
+  affiliateFeeUsd: number;
+  platformFeeUsd: number;
+  totalAmountUsd: number;
+  feeComponentsKnown: true;
+}
+
 export const ORGANIZATION_CREDIT_PRICING = Object.freeze({
   creditUnit: ORGANIZATION_CREDIT_UNIT,
   creditsPerDollar: ORGANIZATION_CREDITS_PER_DOLLAR,
@@ -79,4 +89,30 @@ export function organizationCreditsToLegacyMcpPoints(creditsUsd: number): number
   // 1.1000000000000001); the stored column holds four fraction digits, which
   // is exactly the canonical micro-dollar grid divided by 100.
   return roundUsd(creditsUsd * LEGACY_MCP_POINTS_PER_DOLLAR, LEGACY_MCP_POINTS_FRACTION_DIGITS);
+}
+
+/**
+ * Convert the authoritative legacy-point charge components to one canonical
+ * micro-dollar receipt. The total is the exact sum that callers must debit,
+ * refund, and persist; no route or UI may reconstruct it independently.
+ */
+export function mcpUsageChargeReceiptFromLegacyPoints(input: {
+  basePoints: number;
+  affiliateFeePoints: number;
+  platformFeePoints: number;
+}): McpUsageChargeReceipt {
+  const baseAmountUsd = legacyMcpPointsToOrganizationCredits(input.basePoints);
+  const affiliateFeeUsd = legacyMcpPointsToOrganizationCredits(input.affiliateFeePoints);
+  const platformFeeUsd = legacyMcpPointsToOrganizationCredits(input.platformFeePoints);
+  const totalAmountUsd = quantizeOrganizationCreditUsd(
+    baseAmountUsd + affiliateFeeUsd + platformFeeUsd,
+  );
+  return Object.freeze({
+    creditUnit: ORGANIZATION_CREDIT_UNIT,
+    baseAmountUsd,
+    affiliateFeeUsd,
+    platformFeeUsd,
+    totalAmountUsd,
+    feeComponentsKnown: true,
+  });
 }

--- a/packages/cloud/shared/src/db/migrations/0296_mcp_usage_canonical_receipts.sql
+++ b/packages/cloud/shared/src/db/migrations/0296_mcp_usage_canonical_receipts.sql
@@ -1,0 +1,49 @@
+-- Adds the canonical, fee-inclusive MCP usage receipt without reinterpreting
+-- the historical credits_charged base-price points column (100 points = $1).
+ALTER TABLE "mcp_usage" ADD COLUMN IF NOT EXISTS "base_amount_usd" numeric(18, 6);
+ALTER TABLE "mcp_usage" ADD COLUMN IF NOT EXISTS "affiliate_fee_usd" numeric(18, 6);
+ALTER TABLE "mcp_usage" ADD COLUMN IF NOT EXISTS "platform_fee_usd" numeric(18, 6);
+ALTER TABLE "mcp_usage" ADD COLUMN IF NOT EXISTS "total_amount_usd" numeric(18, 6);
+ALTER TABLE "mcp_usage" ADD COLUMN IF NOT EXISTS "fee_components_known" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+-- Old application writers remain value-preserving while migration and deploy
+-- overlap. New code supplies every canonical component and marks it known.
+CREATE OR REPLACE FUNCTION mcp_usage_fill_legacy_receipt()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.base_amount_usd IS NULL THEN
+    NEW.base_amount_usd := round(NEW.credits_charged / 100, 6);
+  END IF;
+  IF NEW.affiliate_fee_usd IS NULL THEN NEW.affiliate_fee_usd := 0; END IF;
+  IF NEW.platform_fee_usd IS NULL THEN NEW.platform_fee_usd := 0; END IF;
+  IF NEW.total_amount_usd IS NULL THEN NEW.total_amount_usd := NEW.base_amount_usd; END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS mcp_usage_fill_legacy_receipt ON mcp_usage;
+CREATE TRIGGER mcp_usage_fill_legacy_receipt
+BEFORE INSERT ON mcp_usage FOR EACH ROW EXECUTE FUNCTION mcp_usage_fill_legacy_receipt();
+--> statement-breakpoint
+UPDATE "mcp_usage"
+SET "base_amount_usd" = round("credits_charged" / 100, 6),
+    "affiliate_fee_usd" = 0,
+    "platform_fee_usd" = 0,
+    "total_amount_usd" = round("credits_charged" / 100, 6),
+    "fee_components_known" = false
+WHERE "base_amount_usd" IS NULL OR "affiliate_fee_usd" IS NULL
+   OR "platform_fee_usd" IS NULL OR "total_amount_usd" IS NULL;
+--> statement-breakpoint
+ALTER TABLE "mcp_usage" ALTER COLUMN "base_amount_usd" SET NOT NULL;
+ALTER TABLE "mcp_usage" ALTER COLUMN "affiliate_fee_usd" SET NOT NULL;
+ALTER TABLE "mcp_usage" ALTER COLUMN "platform_fee_usd" SET NOT NULL;
+ALTER TABLE "mcp_usage" ALTER COLUMN "total_amount_usd" SET NOT NULL;
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "mcp_usage" ADD CONSTRAINT "mcp_usage_canonical_receipt_check" CHECK (
+    base_amount_usd >= 0 AND affiliate_fee_usd >= 0 AND platform_fee_usd >= 0
+    AND total_amount_usd = base_amount_usd + affiliate_fee_usd + platform_fee_usd
+    AND base_amount_usd::text <> 'NaN' AND affiliate_fee_usd::text <> 'NaN'
+    AND platform_fee_usd::text <> 'NaN' AND total_amount_usd::text <> 'NaN'
+  );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;

--- a/packages/cloud/shared/src/db/migrations/mcp-usage-canonical-receipts.test.ts
+++ b/packages/cloud/shared/src/db/migrations/mcp-usage-canonical-receipts.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Applies the canonical MCP receipt migration to real PGlite, including a
+ * pre-migration row, replay, transitional legacy writer, and corrupt money.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+
+const migration = await Bun.file(
+  new URL("./0296_mcp_usage_canonical_receipts.sql", import.meta.url),
+).text();
+const databases: PGlite[] = [];
+
+async function database(): Promise<PGlite> {
+  const db = new PGlite();
+  databases.push(db);
+  await db.exec(`CREATE TABLE mcp_usage (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    credits_charged numeric(10,4) DEFAULT '0.0000'
+  )`);
+  return db;
+}
+
+afterEach(async () => {
+  await Promise.all(databases.splice(0).map((db) => db.close()));
+});
+
+describe("0296 canonical MCP usage receipts", () => {
+  test("backfills legacy points value-preservingly and replays idempotently", async () => {
+    const db = await database();
+    await db.exec("INSERT INTO mcp_usage (credits_charged) VALUES ('1.2345')");
+    await db.exec(migration);
+    await db.exec(migration);
+
+    const result = await db.query<{
+      credits_charged: string;
+      base_amount_usd: string;
+      affiliate_fee_usd: string;
+      platform_fee_usd: string;
+      total_amount_usd: string;
+      fee_components_known: boolean;
+    }>(`SELECT credits_charged::text, base_amount_usd::text,
+      affiliate_fee_usd::text, platform_fee_usd::text, total_amount_usd::text,
+      fee_components_known FROM mcp_usage`);
+    expect(result.rows).toEqual([
+      {
+        credits_charged: "1.2345",
+        base_amount_usd: "0.012345",
+        affiliate_fee_usd: "0.000000",
+        platform_fee_usd: "0.000000",
+        total_amount_usd: "0.012345",
+        fee_components_known: false,
+      },
+    ]);
+  });
+
+  test("keeps an overlapping legacy writer value-preserving", async () => {
+    const db = await database();
+    await db.exec(migration);
+    const result = await db.query<{ base: string; total: string; known: boolean }>(
+      `INSERT INTO mcp_usage (credits_charged) VALUES ('0.0001')
+       RETURNING base_amount_usd::text AS base, total_amount_usd::text AS total,
+         fee_components_known AS known`,
+    );
+    expect(result.rows).toEqual([{ base: "0.000001", total: "0.000001", known: false }]);
+  });
+
+  test("accepts coherent known fees and rejects corrupt or inconsistent money", async () => {
+    const db = await database();
+    await db.exec(migration);
+    await db.exec(`INSERT INTO mcp_usage (
+      credits_charged, base_amount_usd, affiliate_fee_usd, platform_fee_usd,
+      total_amount_usd, fee_components_known
+    ) VALUES ('1', '0.01', '0.001', '0.002', '0.013', true)`);
+    const aggregate = await db.query<{
+      base: string;
+      affiliate: string;
+      platform: string;
+      total: string;
+    }>(`SELECT sum(base_amount_usd)::text AS base,
+      sum(affiliate_fee_usd)::text AS affiliate,
+      sum(platform_fee_usd)::text AS platform,
+      sum(total_amount_usd)::text AS total FROM mcp_usage`);
+    expect(aggregate.rows).toEqual([
+      {
+        base: "0.010000",
+        affiliate: "0.001000",
+        platform: "0.002000",
+        total: "0.013000",
+      },
+    ]);
+    await expect(
+      db.exec(`INSERT INTO mcp_usage (
+      base_amount_usd, affiliate_fee_usd, platform_fee_usd, total_amount_usd
+    ) VALUES ('NaN', 0, 0, 'NaN')`),
+    ).rejects.toThrow();
+    await expect(
+      db.exec(`INSERT INTO mcp_usage (
+      base_amount_usd, affiliate_fee_usd, platform_fee_usd, total_amount_usd
+    ) VALUES ('0.01', '0.001', '0.002', '0.012')`),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1954,6 +1954,13 @@
       "when": 1793736000001,
       "tag": "0295_phone_message_payload_jsonb",
       "breakpoints": true
+    },
+    {
+      "idx": 279,
+      "version": "7",
+      "when": 1793822400000,
+      "tag": "0296_mcp_usage_canonical_receipts",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/usage-money.ts
+++ b/packages/cloud/shared/src/db/repositories/usage-money.ts
@@ -1,0 +1,18 @@
+/** Preserves exact persisted MCP usage money at the repository boundary. */
+
+import { ElizaError } from "@elizaos/core";
+
+const NON_NEGATIVE_DECIMAL = /^(?:0|[1-9]\d*)(?:\.\d+)?$/;
+
+/** Preserve Postgres NUMERIC precision instead of coercing money through IEEE-754. */
+export function parseUsageMoneyAggregate(value: unknown, field: string): string {
+  if (value === null || value === undefined) return "0";
+  if (typeof value !== "string" || !NON_NEGATIVE_DECIMAL.test(value)) {
+    throw new ElizaError("Stored MCP usage aggregate is corrupt.", {
+      code: "CORRUPT_MCP_USAGE_RECEIPT",
+      context: { field, value },
+      severity: "fatal",
+    });
+  }
+  return value;
+}

--- a/packages/cloud/shared/src/db/repositories/user-mcps-usage-aggregate.test.ts
+++ b/packages/cloud/shared/src/db/repositories/user-mcps-usage-aggregate.test.ts
@@ -1,0 +1,25 @@
+/** Verifies exact, fail-closed parsing of persisted MCP usage money aggregates. */
+
+import { describe, expect, test } from "bun:test";
+import { parseUsageMoneyAggregate } from "./usage-money";
+
+describe("parseUsageMoneyAggregate", () => {
+  test("preserves the full NUMERIC decimal instead of rounding through a number", () => {
+    expect(parseUsageMoneyAggregate("999999999999.999999", "totalAmountUsd")).toBe(
+      "999999999999.999999",
+    );
+  });
+
+  test("maps an empty aggregate to exact zero", () => {
+    expect(parseUsageMoneyAggregate(null, "totalAmountUsd")).toBe("0");
+  });
+
+  test.each(["NaN", "Infinity", "-1", "1e3", 0.1])(
+    "rejects corrupt or already-lossy aggregate %p",
+    (value) => {
+      expect(() => parseUsageMoneyAggregate(value, "totalAmountUsd")).toThrow(
+        "Stored MCP usage aggregate is corrupt.",
+      );
+    },
+  );
+});

--- a/packages/cloud/shared/src/db/repositories/user-mcps.ts
+++ b/packages/cloud/shared/src/db/repositories/user-mcps.ts
@@ -1,4 +1,5 @@
 // Persists user mcps records for cloud services through the shared DB boundary.
+import { ElizaError } from "@elizaos/core";
 import { and, desc, eq, ilike, or, sql } from "drizzle-orm";
 import { mutateRowCount } from "../execute-helpers";
 import { dbRead, dbWrite } from "../helpers";
@@ -11,6 +12,18 @@ import {
   userMcps,
 } from "../schemas";
 import { escapeLikePattern } from "../utils/like-pattern";
+
+function parseUsageAggregate(value: unknown, field: string): number {
+  const parsed = Number(value ?? 0);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new ElizaError("Stored MCP usage aggregate is corrupt.", {
+      code: "CORRUPT_MCP_USAGE_RECEIPT",
+      context: { field, value },
+      severity: "fatal",
+    });
+  }
+  return parsed;
+}
 
 /**
  * User MCPs Repository
@@ -307,7 +320,13 @@ export const mcpUsageRepository = {
    */
   async getStats(mcpId: string): Promise<{
     totalRequests: number;
+    /** @deprecated Legacy base-price points (100 points = $1). */
     totalCreditsCharged: number;
+    baseAmountUsd: number;
+    affiliateFeeUsd: number;
+    platformFeeUsd: number;
+    totalAmountUsd: number;
+    feeComponentsKnown: boolean;
     totalX402Usd: number;
     uniqueOrgs: number;
   }> {
@@ -315,6 +334,11 @@ export const mcpUsageRepository = {
       .select({
         totalRequests: sql<number>`sum(${mcpUsage.request_count})`,
         totalCreditsCharged: sql<number>`sum(${mcpUsage.credits_charged})`,
+        baseAmountUsd: sql<string>`sum(${mcpUsage.base_amount_usd})`,
+        affiliateFeeUsd: sql<string>`sum(${mcpUsage.affiliate_fee_usd})`,
+        platformFeeUsd: sql<string>`sum(${mcpUsage.platform_fee_usd})`,
+        totalAmountUsd: sql<string>`sum(${mcpUsage.total_amount_usd})`,
+        feeComponentsKnown: sql<boolean>`coalesce(bool_and(${mcpUsage.fee_components_known}), true)`,
         totalX402Usd: sql<number>`sum(${mcpUsage.x402_amount_usd})`,
         uniqueOrgs: sql<number>`count(distinct ${mcpUsage.organization_id})`,
       })
@@ -322,10 +346,15 @@ export const mcpUsageRepository = {
       .where(eq(mcpUsage.mcp_id, mcpId));
 
     return {
-      totalRequests: Number(result?.totalRequests ?? 0),
-      totalCreditsCharged: Number(result?.totalCreditsCharged ?? 0),
-      totalX402Usd: Number(result?.totalX402Usd ?? 0),
-      uniqueOrgs: Number(result?.uniqueOrgs ?? 0),
+      totalRequests: parseUsageAggregate(result?.totalRequests, "totalRequests"),
+      totalCreditsCharged: parseUsageAggregate(result?.totalCreditsCharged, "totalCreditsCharged"),
+      baseAmountUsd: parseUsageAggregate(result?.baseAmountUsd, "baseAmountUsd"),
+      affiliateFeeUsd: parseUsageAggregate(result?.affiliateFeeUsd, "affiliateFeeUsd"),
+      platformFeeUsd: parseUsageAggregate(result?.platformFeeUsd, "platformFeeUsd"),
+      totalAmountUsd: parseUsageAggregate(result?.totalAmountUsd, "totalAmountUsd"),
+      feeComponentsKnown: result?.feeComponentsKnown ?? true,
+      totalX402Usd: parseUsageAggregate(result?.totalX402Usd, "totalX402Usd"),
+      uniqueOrgs: parseUsageAggregate(result?.uniqueOrgs, "uniqueOrgs"),
     };
   },
 

--- a/packages/cloud/shared/src/db/repositories/user-mcps.ts
+++ b/packages/cloud/shared/src/db/repositories/user-mcps.ts
@@ -12,6 +12,7 @@ import {
   userMcps,
 } from "../schemas";
 import { escapeLikePattern } from "../utils/like-pattern";
+import { parseUsageMoneyAggregate } from "./usage-money";
 
 function parseUsageAggregate(value: unknown, field: string): number {
   const parsed = Number(value ?? 0);
@@ -322,10 +323,10 @@ export const mcpUsageRepository = {
     totalRequests: number;
     /** @deprecated Legacy base-price points (100 points = $1). */
     totalCreditsCharged: number;
-    baseAmountUsd: number;
-    affiliateFeeUsd: number;
-    platformFeeUsd: number;
-    totalAmountUsd: number;
+    baseAmountUsd: string;
+    affiliateFeeUsd: string;
+    platformFeeUsd: string;
+    totalAmountUsd: string;
     feeComponentsKnown: boolean;
     totalX402Usd: number;
     uniqueOrgs: number;
@@ -348,10 +349,10 @@ export const mcpUsageRepository = {
     return {
       totalRequests: parseUsageAggregate(result?.totalRequests, "totalRequests"),
       totalCreditsCharged: parseUsageAggregate(result?.totalCreditsCharged, "totalCreditsCharged"),
-      baseAmountUsd: parseUsageAggregate(result?.baseAmountUsd, "baseAmountUsd"),
-      affiliateFeeUsd: parseUsageAggregate(result?.affiliateFeeUsd, "affiliateFeeUsd"),
-      platformFeeUsd: parseUsageAggregate(result?.platformFeeUsd, "platformFeeUsd"),
-      totalAmountUsd: parseUsageAggregate(result?.totalAmountUsd, "totalAmountUsd"),
+      baseAmountUsd: parseUsageMoneyAggregate(result?.baseAmountUsd, "baseAmountUsd"),
+      affiliateFeeUsd: parseUsageMoneyAggregate(result?.affiliateFeeUsd, "affiliateFeeUsd"),
+      platformFeeUsd: parseUsageMoneyAggregate(result?.platformFeeUsd, "platformFeeUsd"),
+      totalAmountUsd: parseUsageMoneyAggregate(result?.totalAmountUsd, "totalAmountUsd"),
       feeComponentsKnown: result?.feeComponentsKnown ?? true,
       totalX402Usd: parseUsageAggregate(result?.totalX402Usd, "totalX402Usd"),
       uniqueOrgs: parseUsageAggregate(result?.uniqueOrgs, "uniqueOrgs"),

--- a/packages/cloud/shared/src/db/schemas/user-mcps.ts
+++ b/packages/cloud/shared/src/db/schemas/user-mcps.ts
@@ -1,7 +1,8 @@
 // Defines the user mcps Drizzle table shape used by cloud repositories and services.
-import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { type InferInsertModel, type InferSelectModel, sql } from "drizzle-orm";
 import {
   boolean,
+  check,
   index,
   integer,
   jsonb,
@@ -207,6 +208,13 @@ export const mcpUsage = pgTable(
       precision: 10,
       scale: 4,
     }).default("0.0000"),
+    // Canonical fee-inclusive receipt. `credits_charged` remains the legacy
+    // base-price points mirror (100 points = $1) for compatibility.
+    base_amount_usd: numeric("base_amount_usd", { precision: 18, scale: 6 }).notNull(),
+    affiliate_fee_usd: numeric("affiliate_fee_usd", { precision: 18, scale: 6 }).notNull(),
+    platform_fee_usd: numeric("platform_fee_usd", { precision: 18, scale: 6 }).notNull(),
+    total_amount_usd: numeric("total_amount_usd", { precision: 18, scale: 6 }).notNull(),
+    fee_components_known: boolean("fee_components_known").notNull().default(false),
     x402_amount_usd: numeric("x402_amount_usd", {
       precision: 10,
       scale: 6,
@@ -242,6 +250,10 @@ export const mcpUsage = pgTable(
     user_idx: index("mcp_usage_user_idx").on(table.user_id),
     created_at_idx: index("mcp_usage_created_at_idx").on(table.created_at),
     mcp_org_idx: index("mcp_usage_mcp_org_idx").on(table.mcp_id, table.organization_id),
+    canonical_receipt_check: check(
+      "mcp_usage_canonical_receipt_check",
+      sql`${table.base_amount_usd} >= 0 AND ${table.affiliate_fee_usd} >= 0 AND ${table.platform_fee_usd} >= 0 AND ${table.total_amount_usd} = ${table.base_amount_usd} + ${table.affiliate_fee_usd} + ${table.platform_fee_usd} AND ${table.base_amount_usd}::text <> 'NaN' AND ${table.affiliate_fee_usd}::text <> 'NaN' AND ${table.platform_fee_usd}::text <> 'NaN' AND ${table.total_amount_usd}::text <> 'NaN'`,
+    ),
   }),
 );
 

--- a/packages/cloud/shared/src/lib/services/user-mcps-recordusage-numeric.test.ts
+++ b/packages/cloud/shared/src/lib/services/user-mcps-recordusage-numeric.test.ts
@@ -216,6 +216,13 @@ describe("recordUsage, NUMERIC money reads fail closed (#13415)", () => {
     // usage row records real numeric strings, never "NaN".
     expect(usageCreateCalls).toHaveLength(1);
     expect(usageCreateCalls[0].credits_charged).toBe("1");
+    expect(usageCreateCalls[0]).toMatchObject({
+      base_amount_usd: "0.01",
+      affiliate_fee_usd: "0",
+      platform_fee_usd: "0",
+      total_amount_usd: "0.01",
+      fee_components_known: true,
+    });
     expect(usageCreateCalls[0].creator_earnings).not.toContain("NaN");
   });
 
@@ -358,6 +365,32 @@ describe("recordUsage, NUMERIC money reads fail closed (#13415)", () => {
     expect(usageCreateCalls).toHaveLength(0);
   });
 
+  test("healthy affiliate charge persists the exact fee-inclusive debit receipt", async () => {
+    referrer = { user_id: AFFILIATE_USER, id: AFFILIATE_CODE, markup_percent: "10.00" };
+    const result = await userMcpsService.recordUsage({
+      mcpId: "mcp-1",
+      organizationId: CONSUMER_ORG,
+      userId: BUYER_USER,
+      toolName: "get_weather",
+      paymentType: "credits",
+    });
+    expect(deductCalls[0]?.amount).toBe(0.013);
+    expect(result).toMatchObject({
+      basePriceUsd: 0.01,
+      affiliateFeeUsd: 0.001,
+      platformFeeUsd: 0.002,
+      totalPriceUsd: 0.013,
+    });
+    expect(usageCreateCalls[0]).toMatchObject({
+      credits_charged: "1",
+      base_amount_usd: "0.01",
+      affiliate_fee_usd: "0.001",
+      platform_fee_usd: "0.002",
+      total_amount_usd: "0.013",
+      fee_components_known: true,
+    });
+  });
+
   test("explicit domain zero price stays a legit free-tier value (does not throw)", async () => {
     mcpRow = makeRow({ credits_per_request: "0.0000" as unknown as string });
 
@@ -394,6 +427,13 @@ describe("recordUsageWithoutDeduction, share reads fail closed (#13415)", () => 
     expect(addCreditsCalls[0].amount).toBeCloseTo(0.008, 6);
     expect(usageCreateCalls).toHaveLength(1);
     expect(usageCreateCalls[0].creator_earnings).not.toContain("NaN");
+    expect(usageCreateCalls[0]).toMatchObject({
+      base_amount_usd: "0.01",
+      affiliate_fee_usd: "0",
+      platform_fee_usd: "0",
+      total_amount_usd: "0.01",
+      fee_components_known: true,
+    });
   });
 
   test("REGRESSION: corrupt platform_share_percentage THROWS before recording", async () => {

--- a/packages/cloud/shared/src/lib/services/user-mcps.test.ts
+++ b/packages/cloud/shared/src/lib/services/user-mcps.test.ts
@@ -28,10 +28,10 @@ let idCounter: number;
 let usageStats: {
   totalRequests: number;
   totalCreditsCharged: number;
-  baseAmountUsd: number;
-  affiliateFeeUsd: number;
-  platformFeeUsd: number;
-  totalAmountUsd: number;
+  baseAmountUsd: string;
+  affiliateFeeUsd: string;
+  platformFeeUsd: string;
+  totalAmountUsd: string;
   feeComponentsKnown: boolean;
   totalX402Usd: number;
   uniqueOrgs: number;
@@ -186,10 +186,18 @@ mock.module("../../db/repositories", () => ({
     }) {
       usageStats.totalRequests += 1;
       usageStats.totalCreditsCharged += Number(data.credits_charged);
-      usageStats.baseAmountUsd += Number(data.base_amount_usd);
-      usageStats.affiliateFeeUsd += Number(data.affiliate_fee_usd);
-      usageStats.platformFeeUsd += Number(data.platform_fee_usd);
-      usageStats.totalAmountUsd += Number(data.total_amount_usd);
+      usageStats.baseAmountUsd = String(
+        Number(usageStats.baseAmountUsd) + Number(data.base_amount_usd),
+      );
+      usageStats.affiliateFeeUsd = String(
+        Number(usageStats.affiliateFeeUsd) + Number(data.affiliate_fee_usd),
+      );
+      usageStats.platformFeeUsd = String(
+        Number(usageStats.platformFeeUsd) + Number(data.platform_fee_usd),
+      );
+      usageStats.totalAmountUsd = String(
+        Number(usageStats.totalAmountUsd) + Number(data.total_amount_usd),
+      );
       usageStats.uniqueOrgs = 1;
       return { id: "usage-1" };
     },
@@ -255,10 +263,10 @@ beforeEach(() => {
   usageStats = {
     totalRequests: 0,
     totalCreditsCharged: 0,
-    baseAmountUsd: 0,
-    affiliateFeeUsd: 0,
-    platformFeeUsd: 0,
-    totalAmountUsd: 0,
+    baseAmountUsd: "0",
+    affiliateFeeUsd: "0",
+    platformFeeUsd: "0",
+    totalAmountUsd: "0",
     feeComponentsKnown: true,
     totalX402Usd: 0,
     uniqueOrgs: 0,
@@ -630,10 +638,10 @@ describe("userMcpsService fee-inclusive receipt stats", () => {
     const stats = await userMcpsService.getStats(mcp.id, ORG);
     expect(stats).toMatchObject({
       totalCreditsEarned: 100,
-      baseCloudCreditsCharged: 1,
-      affiliateFeesCloudCreditsCharged: 0.25,
-      platformFeesCloudCreditsCharged: 0.2,
-      totalCloudCreditsCharged: 1.45,
+      baseCloudCreditsCharged: "1",
+      affiliateFeesCloudCreditsCharged: "0.25",
+      platformFeesCloudCreditsCharged: "0.2",
+      totalCloudCreditsCharged: "1.45",
       feeComponentsKnown: true,
       creditUnit: "USD",
     });

--- a/packages/cloud/shared/src/lib/services/user-mcps.test.ts
+++ b/packages/cloud/shared/src/lib/services/user-mcps.test.ts
@@ -28,6 +28,11 @@ let idCounter: number;
 let usageStats: {
   totalRequests: number;
   totalCreditsCharged: number;
+  baseAmountUsd: number;
+  affiliateFeeUsd: number;
+  platformFeeUsd: number;
+  totalAmountUsd: number;
+  feeComponentsKnown: boolean;
   totalX402Usd: number;
   uniqueOrgs: number;
 };
@@ -172,9 +177,19 @@ mock.module("../../db/repositories", () => ({
     async getStats() {
       return usageStats;
     },
-    async create(data: { credits_charged: string }) {
+    async create(data: {
+      credits_charged: string;
+      base_amount_usd: string;
+      affiliate_fee_usd: string;
+      platform_fee_usd: string;
+      total_amount_usd: string;
+    }) {
       usageStats.totalRequests += 1;
       usageStats.totalCreditsCharged += Number(data.credits_charged);
+      usageStats.baseAmountUsd += Number(data.base_amount_usd);
+      usageStats.affiliateFeeUsd += Number(data.affiliate_fee_usd);
+      usageStats.platformFeeUsd += Number(data.platform_fee_usd);
+      usageStats.totalAmountUsd += Number(data.total_amount_usd);
       usageStats.uniqueOrgs = 1;
       return { id: "usage-1" };
     },
@@ -240,6 +255,11 @@ beforeEach(() => {
   usageStats = {
     totalRequests: 0,
     totalCreditsCharged: 0,
+    baseAmountUsd: 0,
+    affiliateFeeUsd: 0,
+    platformFeeUsd: 0,
+    totalAmountUsd: 0,
+    feeComponentsKnown: true,
     totalX402Usd: 0,
     uniqueOrgs: 0,
   };
@@ -588,8 +608,8 @@ describe("userMcpsService.toRegistryFormat", () => {
   });
 });
 
-describe("userMcpsService base-price stats", () => {
-  test("names the base amount honestly when a precharge also included surcharges", async () => {
+describe("userMcpsService fee-inclusive receipt stats", () => {
+  test("returns the persisted base, fees, and debit total separately", async () => {
     const mcp = await userMcpsService.create(baseCreateParams({ creatorSharePercentage: 0 }));
 
     const result = await userMcpsService.recordUsageWithoutDeduction({
@@ -611,9 +631,12 @@ describe("userMcpsService base-price stats", () => {
     expect(stats).toMatchObject({
       totalCreditsEarned: 100,
       baseCloudCreditsCharged: 1,
+      affiliateFeesCloudCreditsCharged: 0.25,
+      platformFeesCloudCreditsCharged: 0.2,
+      totalCloudCreditsCharged: 1.45,
+      feeComponentsKnown: true,
       creditUnit: "USD",
     });
-    expect(stats).not.toHaveProperty("totalCloudCreditsCharged");
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/user-mcps.ts
+++ b/packages/cloud/shared/src/lib/services/user-mcps.ts
@@ -10,6 +10,8 @@ import crypto from "crypto";
 import {
   formatOrganizationCreditUsd,
   legacyMcpPointsToOrganizationCredits,
+  type McpUsageChargeReceipt,
+  mcpUsageChargeReceiptFromLegacyPoints,
   ORGANIZATION_CREDIT_UNIT,
   organizationCreditsToLegacyMcpPoints,
 } from "../../billing/organization-credits";
@@ -107,6 +109,8 @@ export interface UseMcpWithoutDeductionParams {
   creditsCharged: number;
   affiliateFeeCredits?: number;
   platformFeeCredits?: number;
+  /** Exact canonical receipt used by the caller's completed precharge. */
+  chargeReceipt?: McpUsageChargeReceipt;
   affiliateOwnerId?: string;
   affiliateCodeId?: string;
   metadata?: Record<string, unknown>;
@@ -118,6 +122,9 @@ export interface UseMcpResult {
   creditsCharged: number;
   /** Canonical base price; excludes affiliate and platform surcharges. */
   basePriceUsd: number;
+  affiliateFeeUsd: number;
+  platformFeeUsd: number;
+  totalPriceUsd: number;
   creditUnit: typeof ORGANIZATION_CREDIT_UNIT;
   x402AmountUsd: number;
   creatorEarnings: number;
@@ -715,6 +722,11 @@ class UserMcpsService {
     }
 
     const totalCreditsToDeduct = creditsCharged + affiliateFeeCredits + platformFeeCredits;
+    const chargeReceipt = mcpUsageChargeReceiptFromLegacyPoints({
+      basePoints: creditsCharged,
+      affiliateFeePoints: affiliateFeeCredits,
+      platformFeePoints: platformFeeCredits,
+    });
 
     const creatorSharePct =
       parseMcpSharePercentage(mcp.creator_share_percentage, "creator_share_percentage", 0) / 100;
@@ -728,7 +740,7 @@ class UserMcpsService {
     if (params.paymentType === "credits" && totalCreditsToDeduct > 0) {
       const deductResult = await creditsService.deductCredits({
         organizationId: params.organizationId,
-        amount: legacyMcpPointsToOrganizationCredits(totalCreditsToDeduct),
+        amount: chargeReceipt.totalAmountUsd,
         description: `MCP: ${mcp.name} - ${params.toolName}`,
         metadata: {
           mcp_id: mcp.id,
@@ -738,7 +750,10 @@ class UserMcpsService {
           affiliate_fee: affiliateFeeCredits.toFixed(4),
           platform_fee: platformFeeCredits.toFixed(4),
           total_credits_charged: totalCreditsToDeduct.toFixed(4),
-          price_usd: legacyMcpPointsToOrganizationCredits(totalCreditsToDeduct).toString(),
+          base_amount_usd: formatOrganizationCreditUsd(chargeReceipt.baseAmountUsd),
+          affiliate_fee_usd: formatOrganizationCreditUsd(chargeReceipt.affiliateFeeUsd),
+          platform_fee_usd: formatOrganizationCreditUsd(chargeReceipt.platformFeeUsd),
+          total_amount_usd: formatOrganizationCreditUsd(chargeReceipt.totalAmountUsd),
           credit_unit: ORGANIZATION_CREDIT_UNIT,
         },
       });
@@ -815,6 +830,11 @@ class UserMcpsService {
       tool_name: params.toolName,
       request_count: 1,
       credits_charged: creditsCharged.toString(),
+      base_amount_usd: formatOrganizationCreditUsd(chargeReceipt.baseAmountUsd),
+      affiliate_fee_usd: formatOrganizationCreditUsd(chargeReceipt.affiliateFeeUsd),
+      platform_fee_usd: formatOrganizationCreditUsd(chargeReceipt.platformFeeUsd),
+      total_amount_usd: formatOrganizationCreditUsd(chargeReceipt.totalAmountUsd),
+      fee_components_known: true,
       x402_amount_usd: x402AmountUsd.toString(),
       payment_type: params.paymentType,
       creator_earnings: creatorEarnings.toString(),
@@ -836,6 +856,9 @@ class UserMcpsService {
       success: true,
       creditsCharged,
       basePriceUsd: legacyMcpPointsToOrganizationCredits(creditsCharged),
+      affiliateFeeUsd: chargeReceipt.affiliateFeeUsd,
+      platformFeeUsd: chargeReceipt.platformFeeUsd,
+      totalPriceUsd: chargeReceipt.totalAmountUsd,
       creditUnit: ORGANIZATION_CREDIT_UNIT,
       x402AmountUsd,
       creatorEarnings,
@@ -871,6 +894,13 @@ class UserMcpsService {
       "platformFeeCredits",
       0,
     );
+    const chargeReceipt =
+      params.chargeReceipt ??
+      mcpUsageChargeReceiptFromLegacyPoints({
+        basePoints: creditsCharged,
+        affiliateFeePoints: affiliateFeeCredits,
+        platformFeePoints: platformFeeCredits,
+      });
     const creatorSharePct =
       parseMcpSharePercentage(mcp.creator_share_percentage, "creator_share_percentage", 0) / 100;
     const platformSharePct =
@@ -958,6 +988,11 @@ class UserMcpsService {
       tool_name: params.toolName,
       request_count: 1,
       credits_charged: creditsCharged.toString(),
+      base_amount_usd: formatOrganizationCreditUsd(chargeReceipt.baseAmountUsd),
+      affiliate_fee_usd: formatOrganizationCreditUsd(chargeReceipt.affiliateFeeUsd),
+      platform_fee_usd: formatOrganizationCreditUsd(chargeReceipt.platformFeeUsd),
+      total_amount_usd: formatOrganizationCreditUsd(chargeReceipt.totalAmountUsd),
+      fee_components_known: true,
       x402_amount_usd: "0", // No x402 for pre-paid
       payment_type: "credits",
       creator_earnings: creatorEarnings.toString(),
@@ -979,6 +1014,9 @@ class UserMcpsService {
       success: true,
       creditsCharged,
       basePriceUsd: legacyMcpPointsToOrganizationCredits(creditsCharged),
+      affiliateFeeUsd: chargeReceipt.affiliateFeeUsd,
+      platformFeeUsd: chargeReceipt.platformFeeUsd,
+      totalPriceUsd: chargeReceipt.totalAmountUsd,
       creditUnit: ORGANIZATION_CREDIT_UNIT,
       x402AmountUsd: 0,
       creatorEarnings,
@@ -997,8 +1035,12 @@ class UserMcpsService {
     totalRequests: number;
     /** @deprecated Legacy MCP pricing points (100 points = $1). */
     totalCreditsEarned: number;
-    /** Base MCP prices only; excludes affiliate and platform surcharges. */
+    /** Canonical base MCP prices. */
     baseCloudCreditsCharged: number;
+    affiliateFeesCloudCreditsCharged: number;
+    platformFeesCloudCreditsCharged: number;
+    totalCloudCreditsCharged: number;
+    feeComponentsKnown: boolean;
     creditUnit: typeof ORGANIZATION_CREDIT_UNIT;
     totalX402EarnedUsd: number;
     uniqueUsers: number;
@@ -1015,7 +1057,11 @@ class UserMcpsService {
     return {
       totalRequests: stats.totalRequests,
       totalCreditsEarned: stats.totalCreditsCharged,
-      baseCloudCreditsCharged: legacyMcpPointsToOrganizationCredits(stats.totalCreditsCharged),
+      baseCloudCreditsCharged: stats.baseAmountUsd,
+      affiliateFeesCloudCreditsCharged: stats.affiliateFeeUsd,
+      platformFeesCloudCreditsCharged: stats.platformFeeUsd,
+      totalCloudCreditsCharged: stats.totalAmountUsd,
+      feeComponentsKnown: stats.feeComponentsKnown,
       creditUnit: ORGANIZATION_CREDIT_UNIT,
       totalX402EarnedUsd: stats.totalX402Usd,
       uniqueUsers: stats.uniqueOrgs,

--- a/packages/cloud/shared/src/lib/services/user-mcps.ts
+++ b/packages/cloud/shared/src/lib/services/user-mcps.ts
@@ -1036,10 +1036,10 @@ class UserMcpsService {
     /** @deprecated Legacy MCP pricing points (100 points = $1). */
     totalCreditsEarned: number;
     /** Canonical base MCP prices. */
-    baseCloudCreditsCharged: number;
-    affiliateFeesCloudCreditsCharged: number;
-    platformFeesCloudCreditsCharged: number;
-    totalCloudCreditsCharged: number;
+    baseCloudCreditsCharged: string;
+    affiliateFeesCloudCreditsCharged: string;
+    platformFeesCloudCreditsCharged: string;
+    totalCloudCreditsCharged: string;
     feeComponentsKnown: boolean;
     creditUnit: typeof ORGANIZATION_CREDIT_UNIT;
     totalX402EarnedUsd: number;

--- a/packages/ui/src/cloud/mcps/McpDetailDrawer.tsx
+++ b/packages/ui/src/cloud/mcps/McpDetailDrawer.tsx
@@ -41,7 +41,10 @@ import { StatusBadge } from "../../components/ui/status-badge";
 import { ApiError } from "../lib/api-client";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import type { UserMcpRecord } from "./lib/api-types";
-import { formatCloudCreditUsd } from "./lib/format-cloud-credit";
+import {
+  formatCloudCreditUsd,
+  formatMcpUsageTotal,
+} from "./lib/format-cloud-credit";
 import {
   useDeleteMcp,
   usePublishMcp,
@@ -259,11 +262,9 @@ export function McpDetailDrawer({
                     />
                     <Stat
                       label={t("cloud.mcps.statCredits", {
-                        defaultValue: "Base cloud credits charged",
+                        defaultValue: "Total cloud credits charged",
                       })}
-                      value={formatCloudCreditUsd(
-                        stats.baseCloudCreditsCharged,
-                      )}
+                      value={formatMcpUsageTotal(stats)}
                     />
                     <Stat
                       label={t("cloud.mcps.statX402", {

--- a/packages/ui/src/cloud/mcps/lib/api-types.ts
+++ b/packages/ui/src/cloud/mcps/lib/api-types.ts
@@ -133,8 +133,14 @@ export interface McpStats {
   totalRequests: number;
   /** @deprecated Legacy MCP pricing points (100 points = $1). */
   totalCreditsEarned: number;
-  /** Base MCP price only; excludes affiliate and platform surcharges. */
+  /** Canonical base MCP price. */
   baseCloudCreditsCharged: number;
+  affiliateFeesCloudCreditsCharged: number;
+  platformFeesCloudCreditsCharged: number;
+  /** Fee-inclusive amount actually debited. */
+  totalCloudCreditsCharged: number;
+  /** False when historical rows predate durable fee-component receipts. */
+  feeComponentsKnown: boolean;
   creditUnit: "USD";
   totalX402EarnedUsd: number;
   uniqueUsers: number;

--- a/packages/ui/src/cloud/mcps/lib/api-types.ts
+++ b/packages/ui/src/cloud/mcps/lib/api-types.ts
@@ -134,11 +134,11 @@ export interface McpStats {
   /** @deprecated Legacy MCP pricing points (100 points = $1). */
   totalCreditsEarned: number;
   /** Canonical base MCP price. */
-  baseCloudCreditsCharged: number;
-  affiliateFeesCloudCreditsCharged: number;
-  platformFeesCloudCreditsCharged: number;
+  baseCloudCreditsCharged: string;
+  affiliateFeesCloudCreditsCharged: string;
+  platformFeesCloudCreditsCharged: string;
   /** Fee-inclusive amount actually debited. */
-  totalCloudCreditsCharged: number;
+  totalCloudCreditsCharged: string;
   /** False when historical rows predate durable fee-component receipts. */
   feeComponentsKnown: boolean;
   creditUnit: "USD";

--- a/packages/ui/src/cloud/mcps/lib/format-cloud-credit.test.ts
+++ b/packages/ui/src/cloud/mcps/lib/format-cloud-credit.test.ts
@@ -1,7 +1,10 @@
 /** Locks exact visible MCP cloud-credit formatting, including micro-prices. */
 
 import { describe, expect, test } from "vitest";
-import { formatCloudCreditUsd } from "./format-cloud-credit";
+import {
+  formatCloudCreditUsd,
+  formatMcpUsageTotal,
+} from "./format-cloud-credit";
 
 describe("formatCloudCreditUsd", () => {
   test.each([
@@ -14,5 +17,11 @@ describe("formatCloudCreditUsd", () => {
 
   test("fails closed for non-finite values", () => {
     expect(formatCloudCreditUsd(Number.NaN)).toBe("—");
+  });
+
+  test("renders the fee-inclusive persisted total instead of the base", () => {
+    expect(formatMcpUsageTotal({ totalCloudCreditsCharged: 0.013 })).toBe(
+      "$0.013",
+    );
   });
 });

--- a/packages/ui/src/cloud/mcps/lib/format-cloud-credit.test.ts
+++ b/packages/ui/src/cloud/mcps/lib/format-cloud-credit.test.ts
@@ -20,8 +20,11 @@ describe("formatCloudCreditUsd", () => {
   });
 
   test("renders the fee-inclusive persisted total instead of the base", () => {
-    expect(formatMcpUsageTotal({ totalCloudCreditsCharged: 0.013 })).toBe(
+    expect(formatMcpUsageTotal({ totalCloudCreditsCharged: "0.013000" })).toBe(
       "$0.013",
     );
+    expect(
+      formatMcpUsageTotal({ totalCloudCreditsCharged: "999999999999.999999" }),
+    ).toBe("$999,999,999,999.999999");
   });
 });

--- a/packages/ui/src/cloud/mcps/lib/format-cloud-credit.ts
+++ b/packages/ui/src/cloud/mcps/lib/format-cloud-credit.ts
@@ -9,9 +9,17 @@ export function formatCloudCreditUsd(value: number): string {
   return `$${CLOUD_CREDIT_FORMATTER.format(value)}`;
 }
 
+function formatExactCloudCreditUsd(value: string): string {
+  if (!/^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(value)) return "—";
+  const [integer, rawFraction = ""] = value.split(".");
+  const fraction = rawFraction.replace(/0+$/, "");
+  const groupedInteger = integer.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return `$${groupedInteger}${fraction ? `.${fraction}` : ""}`;
+}
+
 /** Owner stats always render the persisted fee-inclusive debit authority. */
 export function formatMcpUsageTotal(stats: {
-  totalCloudCreditsCharged: number;
+  totalCloudCreditsCharged: string;
 }): string {
-  return formatCloudCreditUsd(stats.totalCloudCreditsCharged);
+  return formatExactCloudCreditUsd(stats.totalCloudCreditsCharged);
 }

--- a/packages/ui/src/cloud/mcps/lib/format-cloud-credit.ts
+++ b/packages/ui/src/cloud/mcps/lib/format-cloud-credit.ts
@@ -8,3 +8,10 @@ export function formatCloudCreditUsd(value: number): string {
   if (!Number.isFinite(value)) return "—";
   return `$${CLOUD_CREDIT_FORMATTER.format(value)}`;
 }
+
+/** Owner stats always render the persisted fee-inclusive debit authority. */
+export function formatMcpUsageTotal(stats: {
+  totalCloudCreditsCharged: number;
+}): string {
+  return formatCloudCreditUsd(stats.totalCloudCreditsCharged);
+}

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -8452,7 +8452,7 @@
   "cloud.mcps.saving": "Saving...",
   "cloud.mcps.slugHint": "Lowercase letters, numbers and dashes only.",
   "cloud.mcps.slugLabel": "Slug",
-  "cloud.mcps.statCredits": "Base cloud credits charged",
+  "cloud.mcps.statCredits": "Total cloud credits charged",
   "cloud.mcps.statRequests": "Requests",
   "cloud.mcps.statsTitle": "Usage",
   "cloud.mcps.statUsers": "Unique users",


### PR DESCRIPTION
# Relates to

Fixes #23470.

- [x] Targets `develop` and is rebased onto `73895c49e9b160f30b96ab87be833fe791a0fccc` with zero conflicts.
- [ ] `bun install` and `bun run verify` were not run: this coordinated sparse-checkout lane was explicitly constrained to reuse existing dependencies because the host was under disk pressure. Exact scoped results and dependency blockers are below.
- [x] The real PGlite migration rows and focused contract tests below make the changed behavior reviewable without inferring it from implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@c62d0c109ee64bfbae52afdc958f04554e5fefa3:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto live `origin/develop` `73895c49e9b160f30b96ab87be833fe791a0fccc`; zero conflicts.
- [ ] Full `bun run verify` was not run in the disk-constrained sparse checkout. Scoped Biome, diff, migration, shared-service, and UI contract gates pass at the exact head.

# Risks

Medium. This is an append-only billing migration and changes which persisted amount owner stats render. The compatibility trigger preserves overlapping legacy writers; existing rows retain `credits_charged` unchanged and are marked `fee_components_known = false`. The check constraint rejects negative, non-finite, or incoherent canonical receipts. No production migration or customer-data mutation was performed.

# Background

## What does this PR do?

- Adds canonical `base_amount_usd`, `affiliate_fee_usd`, `platform_fee_usd`, and `total_amount_usd` receipt columns while retaining legacy base-price `credits_charged` points.
- Backfills old rows at 100 legacy points per USD, with historical fees explicitly zero/unknown, and safely supports migration replay plus overlapping old writers.
- Uses one quantized fee-inclusive receipt for debit, refund authority, persistence, aggregation, DTOs, and the owner-facing total.
- Fails closed on corrupt persisted money and tests micro-dollar precision.

## What kind of change is this?

Bug fix (non-breaking, additive persistence contract).

# Documentation changes needed?

No external documentation change is needed. The migration, schema, DTO comments, compatibility field deprecation, and tests document the storage and backfill rules.

# Testing

## Where should a reviewer start?

1. `packages/cloud/shared/src/db/migrations/0296_mcp_usage_canonical_receipts.sql`
2. `packages/cloud/shared/src/lib/services/user-mcps.ts`
3. `packages/cloud/api/mcp/proxy/[mcpId]/route.ts`
4. `packages/ui/src/cloud/mcps/McpDetailDrawer.tsx`

## Detailed testing steps

Exact head: `c62d0c109ee64bfbae52afdc958f04554e5fefa3`

- `bun test packages/cloud/shared/src/db/migrations/mcp-usage-canonical-receipts.test.ts packages/cloud/shared/src/billing/organization-credits.test.ts` — 11 passed, 0 failed.
- `bun test packages/cloud/shared/src/lib/services/user-mcps-recordusage-numeric.test.ts` — 17 passed, 0 failed.
- `bun test packages/cloud/shared/src/lib/services/user-mcps.test.ts` — 32 passed, 0 failed.
- `bun test packages/cloud/shared/src/db/repositories/user-mcps-usage-aggregate.test.ts` — 7 passed, 0 failed; preserves `999999999999.999999` exactly and rejects lossy/non-decimal aggregates.
- `../../node_modules/.bin/vitest run --config ./vitest.config.ts src/cloud/mcps/lib/format-cloud-credit.test.ts` from `packages/ui` — 5 passed, 0 failed.
- Scoped Biome across all 17 TypeScript/TSX/JSON files — passed; `git diff --check origin/develop...HEAD` — passed.
- The proxy refund suite passed 11/11 before the final assertion was strengthened to inspect the canonical receipt passed to settlement. At the exact head, the reused dependency tree fails during module initialization before tests because its stale `@elizaos/core` build does not export `validateDocumentRevisionReplacement`; the changed test has no TypeScript diagnostic.
- Package typechecks were attempted after the repair. No diagnostic references a changed file; remaining diagnostics are sparse/reused-dependency gaps (`ai`, `mammoth`, `unpdf`, `file-type`, `pg`, `@elizaos/capacitor-secure-store`, and plugin packages); no diagnostic references a changed file.

# Evidence Gate

<!-- evidence-head:c62d0c109ee64bfbae52afdc958f04554e5fefa3 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - source-complete coordinated lane was explicitly prohibited from broad UI capture under host disk pressure; the only rendered change replaces a base-only number with the persisted total.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no running Cloud UI or production data mutation was authorized in this lane.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no running Cloud UI or deployment was authorized in this lane.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no deployed backend or customer-data mutation was authorized; real in-memory Postgres artifacts are included below.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no running frontend was authorized; the exact formatter contract passes 5/5.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, action, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Real PGlite artifacts from the exact head:

```text
pre-migration legacy row: credits_charged=1.2345
post-migration replay: base=0.012345 affiliate=0 platform=0 total=0.012345 known=false
known-fee row: base=0.010000 affiliate=0.001000 platform=0.002000 total=0.013000; NaN and inconsistent totals rejected
```
<!-- evidence-row:ocr-review -->
- [ ] N/A - UI capture was explicitly out of scope for this disk-constrained lane.

# Evidence Details

## Domain artifacts

<details>
<summary>Real PGlite migration, backfill, replay, precision, and corruption checks</summary>

```text
0296 canonical MCP usage receipts
PASS backfills legacy points value-preservingly and replays idempotently
  credits_charged=1.2345
  base_amount_usd=0.012345
  affiliate_fee_usd=0.000000
  platform_fee_usd=0.000000
  total_amount_usd=0.012345
  fee_components_known=false
exact aggregate/UI decimal: 999999999999.999999 (no IEEE-754 coercion)
PASS keeps an overlapping legacy writer value-preserving
  credits_charged=0.0001 -> base=total=0.000001, known=false
PASS accepts coherent known fees and rejects corrupt or inconsistent money
  base=0.010000 affiliate=0.001000 platform=0.002000 total=0.013000
  NaN receipt rejected; 0.012 inconsistent total rejected
3 passed, 0 failed
```

</details>

## Known gaps / failures

- Full install/build/verify and visual capture were intentionally not run in the coordinator's disk-constrained sparse lane.
- Exact-head proxy test startup is blocked by stale reused `@elizaos/core` output (`validateDocumentRevisionReplacement` missing), before any test executes. The suite was green 11/11 before the final receipt-object assertion; focused service tests independently prove the canonical receipt is what is persisted.
- Hosted CI and independent review remain acceptance gates while this source-complete PR stays ready for review.
- No production migration, deployment, or customer-data mutation was run.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@c62d0c109ee64bfbae52afdc958f04554e5fefa3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-23935]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@c62d0c109ee64bfbae52afdc958f04554e5fefa3:packages/skills/skills/contribute-to-eliza"} -->

