### PR TITLE
fix(android): clear acceptance port override on launch failure

### DIFF
--- a/packages/app/scripts/mobile-local-chat-smoke-port-policy.test.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke-port-policy.test.mjs
@@ -1,6 +1,6 @@
 /**
- * Covers the host command contract that opts debug Android builds into the
- * bearer-protected loopback API used by device acceptance.
+ * Covers the host command contract that opts Android acceptance builds into
+ * the bearer-protected loopback API and reliably removes that override.
  */
 import { afterAll, describe, expect, it } from "bun:test";
 
@@ -18,7 +18,7 @@ afterAll(() => {
   process.argv = originalArgv;
 });
 
-describe("Android debug API port policy", () => {
+describe("Android acceptance API port policy", () => {
   it("builds explicit enable and cleanup setprop commands", () => {
     expect(smoke.androidE2eApiPortOverrideArgs("serial", true)).toEqual([
       "-s",
@@ -36,6 +36,29 @@ describe("Android debug API port policy", () => {
       "debug.eliza.api_expose_port",
       "0",
     ]);
+  });
+
+  it("clears the override when launch preparation fails after enablement", async () => {
+    const calls = [];
+    const launchFailure = new Error("model staging failed");
+    const context = { adb: "adb", serial: "serial", installed: true };
+
+    await expect(
+      smoke.withAndroidE2eApiPortOverride(
+        context,
+        async () => {
+          calls.push("prepare");
+          throw launchFailure;
+        },
+        (target, enabled) => {
+          calls.push(enabled ? "enable" : "clear");
+          target.e2eApiPortOverride = enabled;
+        },
+      ),
+    ).rejects.toBe(launchFailure);
+
+    expect(calls).toEqual(["enable", "prepare", "clear"]);
+    expect(context.e2eApiPortOverride).toBe(false);
   });
 
   it("uses authenticated status details when health is topology-trimmed", async () => {

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -863,35 +863,62 @@ async function launchAndroidEmulatorApp() {
   }
 
   const context = { adb, serial, installed: true };
-  if (androidSelectLocal) {
-    setAndroidE2eApiPortOverride(context, true);
-    removeAndroidReverse(context, ANDROID_LOCAL_AGENT_DEVICE_PORT);
-    forceStopConflictingAndroidAgents(context);
-    preseedAndroidLocalRuntime(context);
-  }
-  if (androidStageSmokeModel) {
-    await stageAndroidSmokeModel(context);
-  }
+  const prepareAndLaunch = async () => {
+    if (androidSelectLocal) {
+      removeAndroidReverse(context, ANDROID_LOCAL_AGENT_DEVICE_PORT);
+      forceStopConflictingAndroidAgents(context);
+      preseedAndroidLocalRuntime(context);
+    }
+    if (androidStageSmokeModel) {
+      await stageAndroidSmokeModel(context);
+    }
 
-  console.log(`[local-chat-smoke] Launching ${id} on ${serial}.`);
-  requireExec(
-    adb,
-    ["-s", serial, "shell", "am", "start", "-n", `${id}/.MainActivity`],
-    `Failed to launch ${id} on ${serial}.`,
-  );
-  tryExec(adb, [
-    "-s",
-    serial,
-    "shell",
-    "am",
-    "start",
-    "-a",
-    "android.intent.action.VIEW",
-    "-d",
-    "elizaos://chat",
-    id,
-  ]);
-  return context;
+    console.log(`[local-chat-smoke] Launching ${id} on ${serial}.`);
+    requireExec(
+      adb,
+      ["-s", serial, "shell", "am", "start", "-n", `${id}/.MainActivity`],
+      `Failed to launch ${id} on ${serial}.`,
+    );
+    tryExec(adb, [
+      "-s",
+      serial,
+      "shell",
+      "am",
+      "start",
+      "-a",
+      "android.intent.action.VIEW",
+      "-d",
+      "elizaos://chat",
+      id,
+    ]);
+    return context;
+  };
+
+  return androidSelectLocal
+    ? withAndroidE2eApiPortOverride(context, prepareAndLaunch)
+    : prepareAndLaunch();
+}
+
+async function withAndroidE2eApiPortOverride(
+  context,
+  operation,
+  setOverride = setAndroidE2eApiPortOverride,
+) {
+  setOverride(context, true);
+  try {
+    return await operation();
+  } catch (error) {
+    try {
+      setOverride(context, false);
+    } catch (cleanupError) {
+      // error-policy:J6 best-effort teardown; preserve the launch failure while
+      // reporting that the operator-visible API-port override may remain set.
+      console.warn(
+        `[local-chat-smoke] Failed to clear Android API port override after launch preparation failed: ${cleanupError instanceof Error ? cleanupError.message : cleanupError}`,
+      );
+    }
+    throw error;
+  }
 }
 
 function setAndroidE2eApiPortOverride(context, enabled) {
@@ -2881,8 +2908,8 @@ async function main() {
       try {
         setAndroidE2eApiPortOverride(androidContext, false);
       } catch (error) {
-        // error-policy:J6 best-effort teardown; the debug-only property is
-        // ignored by release builds and the runner still needs its root cause.
+        // error-policy:J6 best-effort teardown; preserve the runner's root
+        // failure while reporting the operator-visible override cleanup issue.
         console.warn(
           `[local-chat-smoke] Failed to clear Android debug API port override: ${error instanceof Error ? error.message : error}`,
         );
@@ -2937,6 +2964,7 @@ export {
   verifyIosFullBunSmoke,
   verifySmokeModelFile,
   waitForAndroidProcessStability,
+  withAndroidE2eApiPortOverride,
   withTransientRetry,
   writeAndroidCapacitorPreferences,
   writeAndroidLocalInferenceRegistry,


### PR DESCRIPTION
# Relates to

- Corrective follow-up to merged PR #23946
- Relates to #13580

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] Reviewer-visible deterministic test evidence is recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@bfe85040598543b195678dc1f5170d394f5e906b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` `bfe85040598543b195678dc1f5170d394f5e906b`; zero conflicts.
- [x] Scoped exact-head gates pass.

# Risks

Low. The harness-controlled `debug.eliza.api_expose_port` property is honored only by debug builds. Release builds can still expose the loopback API through the separate inherited `ELIZA_API_EXPOSE_PORT` operator override, so the listener is not categorically debug-only. In either path it stays loopback-bound and bearer-protected. Normal local-agent IPC remains port-free.

# Background

## What does this PR do?

PR #23946 enabled the Android acceptance port before several fallible preparation steps, but returned the cleanup context only after all preparation and launch work completed. If reverse removal, agent shutdown, preference seeding, model staging, or app launch threw, the outer finalizer received no context and left `debug.eliza.api_expose_port=1` on the device.

This corrective PR:

- owns enablement across the complete async preparation-and-launch window;
- clears the property on every failure after successful enablement before rethrowing the original failure;
- reports cleanup failure without masking the launch root cause;
- adds a deterministic regression proving `enable -> failing preparation -> clear` ordering;
- corrects source wording so it does not describe the release-capable inherited override as debug-only.

## What kind of change is this?

Bug fix / test-infrastructure repair.

# Documentation changes needed?

No user documentation change. The source/test contract and this risk section document the distinction between the debug system property and the separate release-capable inherited environment override.

# Testing

## Where should a reviewer start?

- `packages/app/scripts/mobile-local-chat-smoke.mjs`
- `packages/app/scripts/mobile-local-chat-smoke-port-policy.test.mjs`

## Detailed testing steps

Exact head: `6a7ee47f05e7444a39f8e190253b5baa6bd8b860`

- `node --check packages/app/scripts/mobile-local-chat-smoke.mjs` - PASS
- `node --check packages/app/scripts/mobile-local-chat-smoke-port-policy.test.mjs` - PASS
- `bun test packages/app/scripts/mobile-local-chat-smoke-port-policy.test.mjs` - PASS (3/3)
- `bun test packages/app/scripts/mobile-local-chat-smoke.test.mjs` - PASS (27/27)
- pinned Biome check on both touched files - PASS
- `git diff --check origin/develop...HEAD` - PASS

# Evidence Gate

<!-- evidence-head:6a7ee47f05e7444a39f8e190253b5baa6bd8b860 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - headless launch-cleanup contract change
<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic host-side failure injection is the relevant proof
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend behavior changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, provider, model, or agent decision behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - deterministic exact-head test output is recorded in the Testing section; no durable domain artifact is produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual-text surface changed

# Evidence Details

The regression injects a failure after the override has been enabled, asserts the original error is rethrown, asserts the observed call order is `enable`, `prepare`, `clear`, and confirms the context records the override as disabled.

## Known gaps / failures

- Physical ARM64 Android local-model acceptance remains the protected device/runner hold already documented on #23946 and #13580. It does not block this deterministic source cleanup repair.
- No install was run in this corrective worktree; existing pinned dependencies were reused to avoid new artifacts under current disk pressure.

This PR is source-complete and ready for review. Hosted CI and protected physical-device acceptance are explicit ready-state holds, not reasons to convert it to draft.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@bfe85040598543b195678dc1f5170d394f5e906b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-followup-23946]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@bfe85040598543b195678dc1f5170d394f5e906b:packages/skills/skills/contribute-to-eliza"} -->
