### PR TITLE
fix(ui): base Cloud liveness on rendered prose

### DIFF
--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -4629,7 +4629,22 @@ describe("ChatOverlay — empty thread while the sheet is open", () => {
 });
 
 describe("ChatOverlay — streaming + consumer activity render (#10712)", () => {
-  it("exposes interrupted and widget-only rows without treating either as settled text", () => {
+  function assistantTurnBody(messageId: string): HTMLElement {
+    const body = document
+      .getElementById(`chat-message-${messageId}`)
+      ?.querySelector<HTMLElement>(
+        '[data-testid="overlay-assistant-turn-body"]',
+      );
+    expect(body).toBeTruthy();
+    return body as HTMLElement;
+  }
+
+  it("marks parsed prose, not attachment or inline-widget chrome, as message text", () => {
+    const form = JSON.stringify({
+      id: "trip-details",
+      title: "Trip details",
+      fields: [{ name: "destination", type: "text", label: "Destination" }],
+    });
     render(
       <ChatOverlay
         controller={makeController({
@@ -4656,6 +4671,26 @@ describe("ChatOverlay — streaming + consumer activity render (#10712)", () => 
               ],
               createdAt: 2,
             },
+            {
+              id: "a-choice-only",
+              role: "assistant",
+              content:
+                "[CHOICE:approval id=choice-only]\nyes=Approve\nno=Reject\n[/CHOICE]",
+              createdAt: 3,
+            },
+            {
+              id: "a-form-only",
+              role: "assistant",
+              content: `[FORM]\n${form}\n[/FORM]`,
+              createdAt: 4,
+            },
+            {
+              id: "a-prose-widget",
+              role: "assistant",
+              content:
+                "Choose next:\n[CHOICE:next id=choice-with-prose]\ncontinue=Continue\n[/CHOICE]",
+              createdAt: 5,
+            },
           ],
         } as unknown as Partial<ShellController>)}
       />,
@@ -4680,6 +4715,92 @@ describe("ChatOverlay — streaming + consumer activity render (#10712)", () => 
     );
     expect(attachmentBody?.dataset.phase).toBe("reply");
     expect(attachmentBody?.dataset.hasMessageText).toBe("false");
+
+    expect(screen.getByTestId("choice-shell-choice-only")).toBeTruthy();
+    expect(assistantTurnBody("a-choice-only").dataset.hasMessageText).toBe(
+      "false",
+    );
+    expect(screen.getByTestId("form-request")).toBeTruthy();
+    expect(assistantTurnBody("a-form-only").dataset.hasMessageText).toBe(
+      "false",
+    );
+    expect(screen.getByText("Choose next:")).toBeTruthy();
+    expect(assistantTurnBody("a-prose-widget").dataset.hasMessageText).toBe(
+      "true",
+    );
+  });
+
+  it("does not promote hidden or structured-only markup to assistant prose", () => {
+    const uiSpec = JSON.stringify({
+      root: "heading",
+      state: {},
+      elements: {
+        heading: {
+          type: "Heading",
+          props: { text: "Structured only", level: "h2" },
+          children: [],
+        },
+      },
+    });
+    const permissionRequest = JSON.stringify({
+      action: "permission_request",
+      permission: "camera",
+      reason: "Scan a code.",
+      feature: "scanner.qr.read",
+    });
+    render(
+      <ChatOverlay
+        controller={makeController({
+          responding: false,
+          messages: [
+            {
+              id: "a-hidden-only",
+              role: "assistant",
+              content: "<think>private reasoning</think>",
+              createdAt: 1,
+            },
+            {
+              id: "a-code-only",
+              role: "assistant",
+              content: "```ts\nconst answer = 42;\n```",
+              createdAt: 2,
+            },
+            {
+              id: "a-config-only",
+              role: "assistant",
+              content: "[CONFIG:weather]",
+              createdAt: 3,
+            },
+            {
+              id: "a-ui-only",
+              role: "assistant",
+              content: `\`\`\`json\n${uiSpec}\n\`\`\``,
+              createdAt: 4,
+            },
+            {
+              id: "a-permission-only",
+              role: "assistant",
+              content: `\`\`\`json\n${permissionRequest}\n\`\`\``,
+              createdAt: 5,
+            },
+          ],
+        } as unknown as Partial<ShellController>)}
+      />,
+    );
+    fireEvent.focus(screen.getByLabelText("message"));
+
+    expect(screen.queryByText("private reasoning")).toBeNull();
+    expect(screen.getByTestId("code-block")).toBeTruthy();
+    expect(screen.getByTestId("permission-card")).toBeTruthy();
+    for (const messageId of [
+      "a-hidden-only",
+      "a-code-only",
+      "a-config-only",
+      "a-ui-only",
+      "a-permission-only",
+    ]) {
+      expect(assistantTurnBody(messageId).dataset.hasMessageText).toBe("false");
+    }
   });
 
   it("renders the reply while keeping tool traces and reasoning in diagnostics", () => {

--- a/packages/ui/src/components/shell/chat-overlay-transcript.tsx
+++ b/packages/ui/src/components/shell/chat-overlay-transcript.tsx
@@ -4,6 +4,7 @@
  * this module owns transcript-only presentation policy.
  */
 
+import { stripUnclaimedInteractionMarkup } from "@elizaos/core";
 import type { ChatTurnStatus } from "../../api/client-types-chat";
 import { splitLeadingSlashCommand } from "../../chat/slash-menu";
 import {
@@ -18,6 +19,7 @@ import {
   SensitiveRequestBlock,
 } from "../chat/MessageContent";
 import { parseFormSubmitDisplay } from "../chat/message-parser-helpers";
+import { useParsedSegments } from "../chat/use-parsed-segments";
 import { ChatMessage } from "../composites/chat/chat-message";
 import type {
   ChatMessageData,
@@ -54,6 +56,15 @@ function OverlayAssistantTurnBody({
   message: ChatMessageData;
   turnStatus: ChatTurnStatus | null;
 }) {
+  // Liveness consumes this marker as a prose-reply signal, so derive it from
+  // the same normalized segments InlineWidgetText renders, not widget chrome.
+  const renderedSegments = useParsedSegments(
+    stripUnclaimedInteractionMarkup(message.text),
+    false,
+  );
+  const hasRenderedProse = renderedSegments.some(
+    (segment) => segment.kind === "text" && Boolean(segment.text.trim()),
+  );
   const attachmentsNode = message.attachments?.length ? (
     <MessageAttachments attachments={message.attachments} />
   ) : null;
@@ -67,7 +78,7 @@ function OverlayAssistantTurnBody({
       className="grid min-h-[1.4375rem] w-full min-w-0"
       data-testid="overlay-assistant-turn-body"
       data-phase={phase}
-      data-has-message-text={message.text.trim() ? "true" : "false"}
+      data-has-message-text={hasRenderedProse ? "true" : "false"}
     >
       {pending ? (
         <div className="col-start-1 row-start-1 flex min-h-[1.4375rem] items-center">


### PR DESCRIPTION
# Relates to

Related to #18076 and #18045. Follow-up to merged #23132; this PR corrects the local renderer liveness seam but does not claim the required deployed Pages receipt or staging warming trajectory.

- [x] Targets `develop` and was rebased onto `origin/develop` `bfe85040598543b195678dc1f5170d394f5e906b` with zero conflicts.
- [x] `bun install --frozen-lockfile` was run after the final sync. `bun run verify` was run at the prior exact head/base; its identical unrelated blocker is recorded below, and no intervening base commit touches those named files.
- [x] Exact-head unit, contract, build, typecheck, lint, baseline, and independent-review evidence is recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: OpenAI/GPT-5.6
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` `bfe85040598543b195678dc1f5170d394f5e906b`; zero conflicts.
- [x] Stable patch-id `21f65f74ceee8eb38255d9e7261c1fbdc536ba2e` is unchanged across both final rebases.
- [x] Exact `range-diff` equality was confirmed after each rebase.

# Risks

Low. This changes only the machine-readable liveness marker already consumed by the Cloud live harness. The marker now follows the same parsed segment pipeline as the visible message renderer, so hidden reasoning/config/code, attachments, permission cards, and widget-only replies no longer masquerade as rendered assistant prose. User-visible pixels and interaction behavior are unchanged.

The transcript parses each assistant payload once for the liveness marker and once in `InlineWidgetText`; both paths use the incremental parser cache. The independent reviewer judged the duplicate parse non-blocking.

# Background

## What does this PR do?

- Derives `data-has-message-text` from canonical rendered text segments after `stripUnclaimedInteractionMarkup`, instead of raw nonblank payload text.
- Keeps the marker false for CHOICE/FORM widgets, attachments, hidden think/code/config/UiSpec blocks, and permission-only replies.
- Keeps the marker true for visible prose, including prose combined with widgets and interrupted streaming prose.
- Adds focused regression coverage for every classification above.

Historical author tuples inventoried across both affected files, following renames: Bill Ding, hermesagent270-commits, lalalune, NubsCarson, nubs, Sayo, Uuriko, Stan, standujar, Shaw, Sol, William Cory, and the current author.

## What kind of change is this?

Bug fix: non-breaking renderer/liveness classification correction.

# Documentation changes needed?

No project-documentation change is required. The DOM contract and focused tests document the machine-readable seam. The deployed receipt and staging browser trajectory remain separate goal requirements.

# Testing

## Where should a reviewer start?

Start in `packages/ui/src/components/shell/chat-overlay-transcript.tsx`, then inspect the new marker-classification cases in `packages/ui/src/components/shell/ChatOverlay.test.tsx` and the consumer in `packages/app/test/liveness-contract.ts`.

## Detailed testing steps

Exact validated head: `de0366cef41a7019d61c2d1287f4137a572c3042` under Node 24.15.0 and Bun 1.3.14.

- `bun install --frozen-lockfile`: exit 0, no changes.
- `bun run --cwd packages/ui test -- src/components/shell/ChatOverlay.test.tsx`: 203 pass, 0 fail.
- `bun --config=bunfig.live.toml test --reporter=dots packages/app/test/liveness-contract.test.ts`: 21 pass, 0 fail, 51 assertions.
- `bun run --cwd packages/ui typecheck`: exit 0.
- `bun run --cwd packages/ui build`: exit 0; 46 runtime exports verified.
- Targeted Biome on both changed files: exit 0.
- `git diff --check`: exit 0.
- Full UI lint at exact head and clean develop: identical exit 1, one formatting error and five warnings, named below.
- Independent read-only review at exact head/base: no P0-P2 findings; patch-id and range-diff integrity confirmed.

# Evidence Gate

<!-- evidence-head:de0366cef41a7019d61c2d1287f4137a572c3042 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23958-rendered-prose-before-bfe8504.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23958-rendered-prose-after-de0366c.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23958-rendered-prose-walkthrough-de0366c.mp4
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend or server request path changes in this PR.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no request, response, console, or visible frontend state changes; exact-head renderer tests prove the DOM marker transition.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, action, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the affected artifact is an ephemeral DOM data attribute covered at the renderer boundary.
<!-- evidence-row:ocr-review -->
- [x] [23958-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23958-ocr-triage.json)

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM-call behavior changed.

## Backend + frontend logs

N/A - no network or deployed backend path changed. Exact-head Vitest and app contract outputs above cover the renderer-to-liveness contract.

## Screenshots (before / after) + video walkthrough

The required artifacts are attached through the repository's `pr-evidence` release after PR creation. Before and after are intentionally pixel-identical because only the nonvisual DOM liveness attribute changes; semantic before/after behavior is proved by the exact-head tests.

## Audio / voice walkthrough

N/A - no voice, transcript audio, TTS, or STT behavior changed.

## Known gaps / failures

- Full `packages/ui` lint is baseline-red at both the exact pre-rebase head and clean develop `53452c12ce52f3ae7b9f100e4c95a74cea7e4c25`: `packages/ui/src/components/chat/widgets/maps-card.tsx` has the same formatting error; `AppModeEntryRoute.sso.test.tsx` lines 41/118/156/164 and `sso-bridge.test.ts` line 74 have the same five `noDocumentCookie` warnings.
- Root `bun run verify` exits 1 at both compared head/base on the same untouched `packages/agent` Biome diagnostics in `interactions-routes.test.ts`, `database.surrogate.test.ts`, `database.ts`, `knowledge.ts`, and `accounts-routes.ts`. The intervening develop commits do not modify these named files.
- The required full app audit was attempted. Its capture reached 116 views before two unrelated baseline/harness failures: `view readiness surfaces loading and measurement failures` and the `builtin-browser mobile-portrait` minimalism ratchet. This PR does not alter either surface or any visual style; focused exact-base/head artifacts are attached instead.
- Existing React `act(...)` warnings are emitted by neighboring asynchronous ChatOverlay tests, while the focused suite still passes 203/203.
- This PR corrects the local renderer contract only. It is not the `deployedRendererTested=true` Pages receipt and does not claim the #18045 staging warming trajectory.

# Deploy Notes

No manual deploy, live-data operation, migration, environment, or credential change.

AI provider/model: OpenAI / GPT-5.6
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-rendered-prose-liveness]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5.6","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->

