### PR TITLE
fix(cloud): accept MIME-wrapped base64 within media budget

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/media-budget.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/media-budget.test.ts
@@ -28,6 +28,14 @@ function base64Of(byteLength: number): string {
   return Buffer.alloc(byteLength, 0x41).toString("base64");
 }
 
+function mimeWrap(base64: string): string {
+  const lines: string[] = [];
+  for (let index = 0; index < base64.length; index += 76) {
+    lines.push(base64.slice(index, index + 76));
+  }
+  return lines.join("\r\n");
+}
+
 function rejection(run: () => unknown): ElizaError {
   try {
     run();
@@ -57,13 +65,24 @@ describe("decodeSocialMediaBase64", () => {
     expect(bytes.length).toBe(SOCIAL_MEDIA_MEDIA_MAX_BYTES);
   });
 
-  test("accepts a MIME line-wrapped payload under the budget", () => {
-    const raw = Buffer.alloc(64 * 1024, 0x42);
-    const wrapped = (raw.toString("base64").match(/.{1,76}/g) ?? []).join("\r\n");
-    expect(wrapped.length).toBeGreaterThan(raw.toString("base64").length);
+  test("accepts an exact-budget MIME line-wrapped payload", () => {
+    const encoded = base64Of(SOCIAL_MEDIA_MEDIA_MAX_BYTES);
+    const wrapped = mimeWrap(encoded);
+    expect(wrapped.length).toBeGreaterThan(encoded.length);
 
     const bytes = decodeSocialMediaBase64(wrapped);
-    expect(bytes.length).toBe(raw.length);
+    expect(bytes.length).toBe(SOCIAL_MEDIA_MEDIA_MAX_BYTES);
+  });
+
+  test("rejects a wrapped payload one byte over the budget after decoding", () => {
+    const wrapped = mimeWrap(base64Of(SOCIAL_MEDIA_MEDIA_MAX_BYTES + 1));
+
+    const error = rejection(() => decodeSocialMediaBase64(wrapped));
+    expect(error.code).toBe("SOCIAL_MEDIA_MEDIA_TOO_LARGE");
+    expect(error.context).toMatchObject({
+      receivedBytes: SOCIAL_MEDIA_MEDIA_MAX_BYTES + 1,
+      maxBytes: SOCIAL_MEDIA_MEDIA_MAX_BYTES,
+    });
   });
 
   test("rejects one byte over the budget after decoding — the encoded length is identical", () => {
@@ -82,13 +101,15 @@ describe("decodeSocialMediaBase64", () => {
 
   test("rejects an oversized payload BEFORE the decode allocates", () => {
     const encodedLength = SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH + 4;
-    const error = rejection(() => decodeSocialMediaBase64("A".repeat(encodedLength)));
+    const encoded = ` \t\r\n${"A".repeat(encodedLength)}\r\n `;
+    const error = rejection(() => decodeSocialMediaBase64(encoded));
 
     expect(error.code).toBe("SOCIAL_MEDIA_MEDIA_TOO_LARGE");
     // `encodedLength` is only reported by the pre-allocation branch; the
     // post-decode branch reports `receivedBytes`.
     expect(error.context).toMatchObject({
       encodedLength,
+      rawEncodedLength: encoded.length,
       maxEncodedLength: SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH,
     });
     expect(error.context).not.toHaveProperty("receivedBytes");

--- a/packages/cloud/shared/src/lib/services/social-media/media-download.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/media-download.ts
@@ -16,10 +16,7 @@
 import { ElizaError } from "@elizaos/core";
 
 import { safeFetch } from "../../security/safe-fetch";
-import {
-  SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH,
-  SOCIAL_MEDIA_MEDIA_MAX_BYTES,
-} from "../../types/social-media";
+import { SOCIAL_MEDIA_MEDIA_MAX_BYTES } from "../../types/social-media";
 
 const SOCIAL_MEDIA_DOWNLOAD_TIMEOUT_MS = 10_000;
 
@@ -66,12 +63,10 @@ export function assertSocialMediaBytesWithinBudget(
  *
  * The budget is a DECODED-byte budget, charged twice. First against the
  * encoded character count, so an oversized payload is rejected BEFORE
- * `Buffer.from` allocates the decode; every payload the URL branch accepts
- * (at most {@link SOCIAL_MEDIA_MEDIA_MAX_BYTES} bytes) encodes to at most
- * {@link SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH} characters, so nothing that
- * posts today is rejected by that pre-check. Then against the buffer actually
- * produced, because `Buffer.from` skips characters outside the base64 alphabet
- * and a padded string of the maximum accepted length can still decode two
+ * `Buffer.from` allocates the decode. MIME formatting whitespace does not
+ * count toward that encoded-data ceiling because the decoder ignores ASCII
+ * space, tab, CR, and LF. The buffer actually produced is charged again
+ * because a padded string of the maximum accepted length can still decode two
  * bytes past the budget.
  */
 export function decodeSocialMediaBase64(
@@ -81,16 +76,27 @@ export function decodeSocialMediaBase64(
 ): Buffer {
   const maxEncodedLength = Math.ceil(maxBytes / 3) * 4;
   if (base64.length > maxEncodedLength) {
-    throw downloadError(
-      "Media attachment exceeds the media byte limit",
-      "SOCIAL_MEDIA_MEDIA_TOO_LARGE",
-      {
-        encodedLength: base64.length,
-        maxEncodedLength,
-        maxBytes,
-        ...context,
-      },
-    );
+    let encodedLength = 0;
+    for (let index = 0; index < base64.length; index += 1) {
+      const code = base64.charCodeAt(index);
+      if (code === 0x09 || code === 0x0a || code === 0x0d || code === 0x20) {
+        continue;
+      }
+      encodedLength += 1;
+    }
+    if (encodedLength > maxEncodedLength) {
+      throw downloadError(
+        "Media attachment exceeds the media byte limit",
+        "SOCIAL_MEDIA_MEDIA_TOO_LARGE",
+        {
+          encodedLength,
+          rawEncodedLength: base64.length,
+          maxEncodedLength,
+          maxBytes,
+          ...context,
+        },
+      );
+    }
   }
 
   const bytes = Buffer.from(base64, "base64");

--- a/packages/cloud/shared/src/lib/services/social-media/providers/media-budget.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/media-budget.error-policy.test.ts
@@ -54,6 +54,14 @@ const OVERSIZE_DATA = Buffer.alloc(SOCIAL_MEDIA_MEDIA_MAX_BYTES + 1, 0x41);
 const SMALL_BYTES = Buffer.from("PNGBYTES");
 const SMALL_BASE64 = SMALL_BYTES.toString("base64");
 
+function mimeWrap(base64: string): string {
+  const lines: string[] = [];
+  for (let index = 0; index < base64.length; index += 76) {
+    lines.push(base64.slice(index, index + 76));
+  }
+  return lines.join("\r\n");
+}
+
 const oversizeBase64Media = (): MediaAttachment =>
   ({ type: "image", base64: OVERSIZE_BASE64, mimeType: "image/png" }) as MediaAttachment;
 const oversizeDataMedia = (): MediaAttachment =>
@@ -147,6 +155,31 @@ describe("blueskyProvider — media budget", () => {
     const result = await blueskyProvider.uploadMedia!(BSKY_CREDS, smallBase64Media());
     expect(result.mediaId).toBe("blob-link");
     expect(Buffer.from(mediaBodies[0]!).toString()).toBe("PNGBYTES");
+  });
+
+  test("uploadMedia posts an exact-budget MIME-wrapped attachment", async () => {
+    const wrapped = mimeWrap(Buffer.alloc(SOCIAL_MEDIA_MEDIA_MAX_BYTES, 0x41).toString("base64"));
+    fetchQueue = [
+      BSKY_SESSION,
+      () =>
+        json({
+          blob: {
+            $type: "blob",
+            ref: { $link: "max-blob-link" },
+            mimeType: "image/png",
+            size: SOCIAL_MEDIA_MEDIA_MAX_BYTES,
+          },
+        }),
+    ];
+
+    const result = await blueskyProvider.uploadMedia!(BSKY_CREDS, {
+      type: "image",
+      base64: wrapped,
+      mimeType: "image/png",
+    } as MediaAttachment);
+
+    expect(result.mediaId).toBe("max-blob-link");
+    expect(mediaBodies[0]?.byteLength).toBe(SOCIAL_MEDIA_MEDIA_MAX_BYTES);
   });
 
   test("createPost fails closed on an oversized base64 attachment instead of posting", async () => {


### PR DESCRIPTION
# Relates to

Fixes #23833

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Charges effective non-whitespace base64 length before decoding.
- [x] Retains the authoritative decoded-byte budget charge.
- [x] Covers MIME-wrapped exact-budget, wrapped budget-plus-one, and whitespace-stuffed oversize boundaries.
- [x] Drives the real exported Bluesky upload path with an exact 10 MiB decoded attachment.
- [x] Independently reviewed at exact head with no source or test findings.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@100cdea997f5ac378ac532c2bf495f2c8917c55d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto live `develop@100cdea997f5ac378ac532c2bf495f2c8917c55d`; zero conflicts.
- [x] Exact head: `319313169723bd22bc2dda687be2ba4b81594de1`.
- [x] Focused tests, package Biome, and diff hygiene pass.

# Risks

Low. The decoded-byte ceiling is unchanged. This only stops MIME formatting whitespace from consuming that byte budget; non-whitespace oversize input still fails before decode, and decoded output is still charged afterward. The currently unused `MediaAttachmentSchema` retains its old raw-string `.max()` constraint; repository search found no consumers, so it does not affect the live provider path or this issue's definition of done.

# Background

## What does this PR do?

`decodeSocialMediaBase64` previously compared raw string length with the encoded-data ceiling. Standard MIME CRLF wrapping therefore rejected an exact 10 MiB attachment even though Node decodes it to the permitted 10 MiB.

This PR counts encoded characters while excluding ASCII space, tab, CR, and LF when the raw string crosses the ceiling. It then preserves the existing decoded-buffer charge. Tests prove both boundaries and capture the exact decoded body passed by `blueskyProvider.uploadMedia`.

## What kind of change is this?

Compatibility bug fix with allocation-aware boundary tests.

# Documentation changes needed?

No. The function-level contract comment is corrected; no public request shape or byte ceiling changes.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/social-media/media-download.ts`, then `media-budget.test.ts` and the exported-provider test in `providers/media-budget.error-policy.test.ts`.

## Detailed testing steps

```bash
bun --conditions=eliza-source test \
  packages/cloud/shared/src/lib/services/social-media/media-budget.test.ts \
  packages/cloud/shared/src/lib/services/social-media/providers/media-budget.error-policy.test.ts \
  --timeout 120000
bun run --cwd packages/cloud/shared lint:check
git diff --check origin/develop...HEAD
```

Exact-head receipt:

```text
30 pass
0 fail
85 expect() calls
Ran 30 tests across 2 files.
Biome: Checked 2262 files. No fixes applied.
git diff --check: exit 0
Independent review: no findings; patch byte-for-byte identical after final rebase.
```

Mutation receipts:

```text
Raw-length precheck restored: 4 tests fail, including exact-budget MIME and real Bluesky transport.
Post-decode charge removed: 2 tests fail, both budget-plus-one boundaries.
```

# Evidence Gate

<!-- evidence-head:319313169723bd22bc2dda687be2ba4b81594de1 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only decoder and provider transport behavior.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI surface changed.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - deterministic byte-boundary behavior is captured by executable tests.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs:
  <details><summary>exact-head focused and mutation transcript</summary>

  ```text
  Focused lane: 30 pass, 0 fail, 85 assertions.
  Exact-budget MIME-wrapped Bluesky upload body: 10,485,760 bytes.
  Raw-length mutation: 4 expected failures.
  Post-decode-charge mutation: 2 expected failures.
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend or browser network path changed.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, prompt, action, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - the domain result is the captured 10 MiB Bluesky upload request body asserted in the backend suite.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Known gaps / failures

- The full social-media directory run is blocked by unrelated base/sparse-checkout failures, including absent `decimal.js`, unrelated alerts/token-refresh export mismatches, a pre-existing TikTok test import failure, and token-expiry baseline failures. The two changed-surface files pass 30/30.
- `bun run --cwd packages/cloud/shared typecheck` is blocked by unhydrated external declarations and unrelated base diagnostics; no diagnostic points to any changed file.
- Root `bun run verify` was not rerun in this sparse checkout. These hosted/environment gates are explicit merge/acceptance holds while this source-complete PR remains ready for review.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@100cdea997f5ac378ac532c2bf495f2c8917c55d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-23833-mime-base64-budget]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@100cdea997f5ac378ac532c2bf495f2c8917c55d:packages/skills/skills/contribute-to-eliza"} -->
