### PR TITLE
fix(computeruse): keep clipboard-read previews Unicode-well-formed (#23937)

### DIFF
--- a/plugins/plugin-computeruse/src/actions/clipboard.ts
+++ b/plugins/plugin-computeruse/src/actions/clipboard.ts
@@ -10,14 +10,16 @@
  * can pick a specific verb directly from the action catalogue.
  */
 
-import type {
-  Action,
-  ActionResult,
-  HandlerCallback,
-  HandlerOptions,
-  IAgentRuntime,
-  Memory,
-  State,
+import {
+  toWellFormedUnicode,
+  truncateWellFormed,
+  type Action,
+  type ActionResult,
+  type HandlerCallback,
+  type HandlerOptions,
+  type IAgentRuntime,
+  type Memory,
+  type State,
 } from "@elizaos/core";
 import {
   ClipboardUnavailableError,
@@ -84,13 +86,14 @@ async function runClipboardAction(
 ): Promise<ClipboardActionResult> {
   if (params.action === "read") {
     const text = await driverReadClipboard();
+    const wellFormed = toWellFormedUnicode(text);
     const preview =
-      text.length > CLIPBOARD_PREVIEW_BYTES
-        ? `${text.slice(0, CLIPBOARD_PREVIEW_BYTES - 1)}…`
-        : text;
+      wellFormed.length > CLIPBOARD_PREVIEW_BYTES
+        ? `${truncateWellFormed(wellFormed, CLIPBOARD_PREVIEW_BYTES - 1)}…`
+        : wellFormed;
     return {
       success: true,
-      text,
+      text: wellFormed,
       message: text.length === 0 ? "Clipboard is empty." : preview,
     };
   }

--- a/plugins/plugin-computeruse/test/clipboard-wellformed.test.ts
+++ b/plugins/plugin-computeruse/test/clipboard-wellformed.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Production-path regression coverage for the clipboard-read preview
+ * (issue #23937): the preview must never contain a lone surrogate, and
+ * pre-existing lone surrogates must be normalized at the result boundary.
+ *
+ * Only the host clipboard driver is mocked; the public
+ * `clipboardAction.handler` path is exercised directly.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const driverMock = vi.hoisted(() => ({
+  readClipboard: vi.fn(),
+  writeClipboard: vi.fn(),
+}));
+
+vi.mock("../src/platform/clipboard.js", () => driverMock);
+
+import { clipboardAction } from "../src/actions/clipboard.js";
+
+const CLIPBOARD_PREVIEW_BYTES = 4096;
+
+function isWellFormed(text: string): boolean {
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = text.charCodeAt(i + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
+      i++;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function readResult(text: string) {
+  driverMock.readClipboard.mockResolvedValue(text);
+  let captured: any;
+  const callback = async (msg: any) => {
+    captured = msg;
+    return [];
+  };
+  await clipboardAction.handler(
+    {} as any,
+    { action: "read" } as any,
+    callback as any,
+    {} as any,
+    {} as any,
+  );
+  return captured;
+}
+
+describe("clipboard read preview well-formedness (#23937)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps empty and short text unchanged", async () => {
+    const msg = await readResult("");
+    expect(msg.text).toBe("");
+    expect(msg.message).toBe("Clipboard is empty.");
+
+    const short = await readResult("short");
+    expect(short.text).toBe("short");
+    expect(short.message).toBe("short");
+  });
+
+  it("keeps exact-max text unchanged", async () => {
+    const text = "a".repeat(CLIPBOARD_PREVIEW_BYTES);
+    const msg = await readResult(text);
+    expect(msg.text).toBe(text);
+    expect(msg.message).toBe(text);
+  });
+
+  it("truncates max+1 with a suffix ellipsis and stays well-formed", async () => {
+    const text = "a".repeat(CLIPBOARD_PREVIEW_BYTES + 1);
+    const msg = await readResult(text);
+    expect(msg.message.length).toBe(CLIPBOARD_PREVIEW_BYTES);
+    expect(msg.message.endsWith("…")).toBe(true);
+    expect(isWellFormed(msg.message)).toBe(true);
+  });
+
+  it("never splits an astral pair crossing the cut", async () => {
+    const emoji = "\u{1F9E0}";
+    const text = "a".repeat(CLIPBOARD_PREVIEW_BYTES - 2) + emoji + "z";
+    const msg = await readResult(text);
+    expect(isWellFormed(msg.message)).toBe(true);
+  });
+
+  it("normalizes short lone-high and lone-low surrogates", async () => {
+    const high = await readResult("ok\uD83E");
+    expect(isWellFormed(high.text)).toBe(true);
+
+    const low = await readResult("ok\uDE00");
+    expect(isWellFormed(low.text)).toBe(true);
+  });
+
+  it("normalizes long lone surrogates", async () => {
+    const high = await readResult("a".repeat(CLIPBOARD_PREVIEW_BYTES - 1) + "\uD83E");
+    expect(isWellFormed(high.message)).toBe(true);
+
+    const low = await readResult("a".repeat(CLIPBOARD_PREVIEW_BYTES - 1) + "\uDE00");
+    expect(isWellFormed(low.message)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #23937. `plugins/plugin-computeruse/src/actions/clipboard.ts` built the read preview with raw `text.slice(0, CLIPBOARD_PREVIEW_BYTES - 1)`, which could cut between the two UTF-16 code units of an astral character (leaving a lone high surrogate in the action message). Pre-existing lone surrogates from the host clipboard also passed through both the preview and the returned `text` unchanged.

## Fix

- Normalize the clipboard text with the shared `toWellFormedUnicode` helper at the action-result boundary (both `message` preview and returned `text`)
- Truncate the preview with `truncateWellFormed` (reserving one code unit for the `…` suffix); the existing 4096-code-unit maximum is preserved and never creates a lone surrogate

## Evidence

- `plugins/plugin-computeruse/test/clipboard-wellformed.test.ts`: 8 cases covering empty/short, exact max, max+1, astral pair crossing the cut, and short/long lone-high and lone-low surrogates (public handler path, only the host driver mocked)
- Verified green in an isolated vitest environment (repo npm install is blocked by the pre-existing `@playwright/test` EOVERRIDE)

## Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash