### PR TITLE
feat(cloud): bind restores to durable node occurrences

### DIFF
--- a/packages/cloud/api/__tests__/admin-agent-image-canary-route.pglite.test.ts
+++ b/packages/cloud/api/__tests__/admin-agent-image-canary-route.pglite.test.ts
@@ -24,6 +24,7 @@ process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
 
 import { closeDatabaseConnectionsForTests, dbWrite } from "@/db/client";
 import { pushSchema } from "@/db/push-schema-for-tests";
+import { agentNodeIncarnationHistories } from "@/db/schemas/agent-node-incarnation-histories";
 import { agentSandboxes } from "@/db/schemas/agent-sandboxes";
 import { apiKeys } from "@/db/schemas/api-keys";
 import { dockerNodes } from "@/db/schemas/docker-nodes";
@@ -176,6 +177,7 @@ beforeAll(async () => {
         apiKeys,
         usageRecords,
         generations,
+        agentNodeIncarnationHistories,
         dockerNodes,
         agentSandboxes,
         jobs,

--- a/packages/cloud/shared/src/db/agent-backup-restore-api-boundary.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-restore-api-boundary.test.ts
@@ -90,7 +90,7 @@ describe("dormant restore API boundary", () => {
     expect(readFileSync(join(import.meta.dir, "index.ts"), "utf8")).not.toMatch(
       /agent-backup-restore|agent-vault-key-authority/,
     );
-  });
+  }, 15_000);
 
   test("keeps target reservation free of remote effects and generic identity bypasses", () => {
     const operationSource = readFileSync(
@@ -113,6 +113,14 @@ describe("dormant restore API boundary", () => {
     expect(genericAdvance).toContain(
       "Restore operation cannot leave target reservation without complete target authority",
     );
+    expect(genericAdvance).toContain("operation.expected_node_history_id === null");
+
+    const dockerNodeSource = readFileSync(
+      join(import.meta.dir, "repositories/docker-nodes.ts"),
+      "utf8",
+    );
+    expect(dockerNodeSource).toContain('"current_node_history_id"');
+    expect(dockerNodeSource).not.toMatch(/\bcurrent_node_history_id\s*:/);
 
     const openOperation = operationSource.slice(
       operationSource.indexOf("export async function openAgentBackupRestoreOperation"),
@@ -141,12 +149,14 @@ describe("dormant restore API boundary", () => {
     const transactionalReserve = reserveSource.slice(
       reserveSource.indexOf("return await dbWrite.transaction"),
     );
+    expect(reserveSource).toContain("targetNodeHistoryId: string");
+    expect(reserveSource).toContain("expected_node_history_id: target.nodeHistoryId");
     const lockAnchors = [
       ".from(agentSandboxBackups)",
       ".from(agentBackupRestoreOperations)",
       ".from(agentBackupRestoreLeases)",
       ".from(dockerNodes)",
-      "proveUnambiguousAgentNodeIncarnationForLockedNode(",
+      "proveExactAgentNodeOccurrenceForLockedNode(",
       "lockAgentBackupCatalogAuthority(",
       "readPostLockDatabaseNow(tx)",
     ];
@@ -171,6 +181,7 @@ describe("dormant restore API boundary", () => {
       "restoreClaimGeneration",
       "targetNodeRecordId",
       "targetNodeIncarnation",
+      "targetNodeHistoryId",
     ]) {
       expect(restoreVaultAuthority).toContain(requiredAuthorityField);
     }
@@ -184,7 +195,7 @@ describe("dormant restore API boundary", () => {
       ".from(agentBackupRestoreOperations)",
       ".from(agentBackupRestoreLeases)",
       ".from(dockerNodes)",
-      "proveUnambiguousAgentNodeIncarnationForLockedNode(",
+      "proveExactAgentNodeOccurrenceForLockedNode(",
       "lockAgentBackupCatalogAuthority(",
       "readPostLockDatabaseNow(tx)",
     ];
@@ -216,16 +227,16 @@ describe("dormant restore API boundary", () => {
       "utf8",
     );
     const incarnationProof = historySource.slice(
-      historySource.indexOf(
-        "export async function proveUnambiguousAgentNodeIncarnationForLockedNode",
-      ),
+      historySource.indexOf("export async function proveExactAgentNodeOccurrenceForLockedNode"),
       historySource.indexOf("async function lockCurrentNodeHistory"),
     );
+    expect(incarnationProof).toContain("node.current_node_history_id !== expectedNodeHistoryId");
     expect(incarnationProof).toContain(
-      "ne(agentNodeIncarnationHistories.node_incarnation, expectedIncarnation)",
+      "eq(agentNodeIncarnationHistories.id, expectedNodeHistoryId)",
     );
-    expect(incarnationProof).toContain("node.created_at > history.attested_at");
-    expect(incarnationProof).not.toMatch(/\bxmin\b|\bage\s*\(|\bgte\s*\(/);
+    expect(incarnationProof).not.toMatch(
+      /\bxmin\b|\bage\s*\(|\bgte\s*\(|\bne\s*\(|created_at|attested_at/,
+    );
 
     const vaultCallback = restoreVaultAuthority.slice(
       restoreVaultAuthority.indexOf("export async function withAgentBackupRestoreVaultPassphrase"),
@@ -315,7 +326,7 @@ describe("dormant restore API boundary", () => {
       ".from(agentBackupRestoreLeases)",
       ".from(agentSandboxes)",
       ".from(dockerNodes)",
-      "proveUnambiguousAgentNodeIncarnationForLockedNode(",
+      "proveExactAgentNodeOccurrenceForLockedNode(",
       "lockAgentBackupCatalogAuthority(",
       "readPostLockDatabaseNow(tx)",
     ];

--- a/packages/cloud/shared/src/db/agent-backup-restore-locks.integration.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-restore-locks.integration.test.ts
@@ -24,6 +24,7 @@ import {
   acquireEphemeralPostgres,
   type EphemeralPostgres,
 } from "../lib/services/tenant-db/__tests__/ephemeral-postgres";
+import { installAgentNodeOccurrenceTriggerForTests } from "./agent-node-occurrence-test-support";
 import type { AgentBackupRestoreLeaseAuthorityReceipt } from "./repositories/agent-backup-restore-lease";
 import {
   agentBackupCatalogAuthorities,
@@ -99,16 +100,16 @@ const RECEIPT_SHA = "b".repeat(64);
 
 const WRITER_BACKUP_ID = "00000000-0000-4000-8000-00000000b301";
 const WRITER_OPERATION_ID = "00000000-0000-4000-8000-00000000b302";
-const WRITER_ATTEMPT_ID = "00000000-0000-4000-8000-00000000b303";
+const WRITER_RESTORE_OPERATION_ROW_ID = "00000000-0000-4000-8000-00000000b303";
 const WRITER_LEASE_ID = "00000000-0000-4000-8000-00000000b304";
 const WRITER_FENCE = "00000000-0000-4000-8000-00000000b305";
 const WRITER_SEED_ID = "00000000-0000-4000-8000-00000000b306";
 const WRITER_PUBLICATION_ID = "00000000-0000-4000-8000-00000000b307";
 const WRITER_FINAL_ID = "00000000-0000-4000-8000-00000000b308";
 const WRITER_TARGET_GENERATION = "00000000-0000-4000-8000-00000000b309";
+const WRITER_ATTEMPT_ID = WRITER_TARGET_GENERATION;
 const WRITER_VAULT_GENERATION = "00000000-0000-4000-8000-00000000b30a";
 const WRITER_RESERVE_ONE = "00000000-0000-4000-8000-00000000b30b";
-const WRITER_RESERVE_TWO = "00000000-0000-4000-8000-00000000b30c";
 
 const LOCK_BACKUP_ONE = "00000000-0000-4000-8000-00000000b401";
 const LOCK_BACKUP_TWO = "00000000-0000-4000-8000-00000000b402";
@@ -128,6 +129,7 @@ const LOCK_KEY_BUNDLE_SHA = createHash("sha256").update(LOCK_KEY_BUNDLE).digest(
 let postgres: EphemeralPostgres | null = await acquireEphemeralPostgres();
 let isolatedDatabaseName: string | null = null;
 let isolatedDsn: string | null = null;
+let sourceNodeHistoryId: string | null = null;
 let closeDatabaseConnectionsForTests:
   | typeof import("./client").closeDatabaseConnectionsForTests
   | undefined;
@@ -626,6 +628,7 @@ const realPostgres = postgres ? describe : describe.skip;
 realPostgres("restore authority PostgreSQL lock proofs", () => {
   beforeAll(async () => {
     if (!dbWrite) throw new Error("isolated database was not initialized");
+    const schemaDatabase = dbWrite;
     const { apply } = await pushSchema(
       {
         organizations,
@@ -646,9 +649,12 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
         agentVaultKeyAuthorities,
         agentVaultKeyBackupBindings,
       } as never,
-      dbWrite as never,
+      schemaDatabase as never,
     );
     await apply();
+    await installAgentNodeOccurrenceTriggerForTests((statement) =>
+      schemaDatabase.execute(sql.raw(statement)),
+    );
     await dbWrite.insert(organizations).values({
       id: ORG_ID,
       name: "Restore Lock Org",
@@ -659,17 +665,22 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
       steward_user_id: "restore-lock-user",
       organization_id: ORG_ID,
     });
-    await dbWrite.insert(dockerNodes).values({
-      id: NODE_RECORD_ID,
-      node_id: "robot-node-lock",
-      hostname: "robot-node-lock.example.test",
-      host_key_fingerprint: "sha256:restore-lock-host-key",
-      fleet_kind: "robot",
-      infrastructure_provider: "hetzner",
-      node_incarnation: NODE_INCARNATION,
-      status: "healthy",
-      enabled: true,
-    });
+    const [sourceNode] = await dbWrite
+      .insert(dockerNodes)
+      .values({
+        id: NODE_RECORD_ID,
+        node_id: "robot-node-lock",
+        hostname: "robot-node-lock.example.test",
+        host_key_fingerprint: "sha256:restore-lock-host-key",
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        node_incarnation: NODE_INCARNATION,
+        status: "healthy",
+        enabled: true,
+      })
+      .returning({ historyId: dockerNodes.current_node_history_id });
+    sourceNodeHistoryId = sourceNode?.historyId ?? null;
+    if (!sourceNodeHistoryId) throw new Error("source node occurrence token fixture is missing");
     await dbWrite.insert(agentSandboxes).values({
       id: AGENT_ID,
       organization_id: ORG_ID,
@@ -723,7 +734,12 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
     if (!dbWrite) return;
     await dbWrite
       .delete(agentBackupRestoreOperations)
-      .where(eq(agentBackupRestoreOperations.restore_attempt_id, LOCK_ATTEMPT_ID));
+      .where(
+        inArray(agentBackupRestoreOperations.restore_attempt_id, [
+          LOCK_ATTEMPT_ID,
+          WRITER_ATTEMPT_ID,
+        ]),
+      );
     await dbWrite
       .update(agentSandboxes)
       .set({
@@ -768,7 +784,6 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
         inArray(agentSandboxBackups.backup_operation_id, [
           WRITER_OPERATION_ID,
           WRITER_RESERVE_ONE,
-          WRITER_RESERVE_TWO,
           LOCK_OPERATION_ONE,
           LOCK_OPERATION_TWO,
         ]),
@@ -784,10 +799,10 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
           LOCK_VAULT_GENERATION,
         ]),
       );
+    await dbWrite.delete(dockerNodes).where(eq(dockerNodes.id, LOCK_TARGET_NODE_RECORD_ID));
     await dbWrite
       .delete(agentNodeIncarnationHistories)
-      .where(eq(agentNodeIncarnationHistories.docker_node_record_id, NODE_RECORD_ID));
-    await dbWrite.delete(dockerNodes).where(eq(dockerNodes.id, LOCK_TARGET_NODE_RECORD_ID));
+      .where(eq(agentNodeIncarnationHistories.docker_node_record_id, LOCK_TARGET_NODE_RECORD_ID));
   });
 
   test("reservation replay and actual restore acquisition share backup-before-authority order", async () => {
@@ -1108,31 +1123,27 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
       throw new Error("real PostgreSQL harness was not initialized");
     }
     const fixture = await seedRestoreOperationLockFixture(true);
-    await dbWrite.insert(dockerNodes).values({
-      id: LOCK_TARGET_NODE_RECORD_ID,
-      node_id: "restore-lock-target",
-      hostname: "restore-lock-target.example.test",
-      capacity: 2,
-      allocated_count: 0,
-      enabled: true,
-      status: "healthy",
-      placement_state: "open",
-      host_key_fingerprint: "SHA256:restore-lock-target-host-key",
-      fleet_kind: "robot",
-      infrastructure_provider: "hetzner",
-      provider_server_id: null,
-      node_incarnation: LOCK_TARGET_NODE_INCARNATION,
-      metadata: {},
-    });
-    await dbWrite.insert(agentNodeIncarnationHistories).values({
-      docker_node_record_id: LOCK_TARGET_NODE_RECORD_ID,
-      node_id: "restore-lock-target",
-      node_incarnation: LOCK_TARGET_NODE_INCARNATION,
-      fleet_kind: "robot",
-      infrastructure_provider: "hetzner",
-      provider_server_id: null,
-      host_key_fingerprint: "SHA256:restore-lock-target-host-key",
-    });
+    const [targetNode] = await dbWrite
+      .insert(dockerNodes)
+      .values({
+        id: LOCK_TARGET_NODE_RECORD_ID,
+        node_id: "restore-lock-target",
+        hostname: "restore-lock-target.example.test",
+        capacity: 2,
+        allocated_count: 0,
+        enabled: true,
+        status: "healthy",
+        placement_state: "open",
+        host_key_fingerprint: "SHA256:restore-lock-target-host-key",
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        provider_server_id: null,
+        node_incarnation: LOCK_TARGET_NODE_INCARNATION,
+        metadata: {},
+      })
+      .returning({ historyId: dockerNodes.current_node_history_id });
+    const targetNodeHistoryId = targetNode?.historyId;
+    if (!targetNodeHistoryId) throw new Error("target node occurrence token fixture is missing");
     const claimed = await claim({
       operationId: fixture.operationId,
       ownerId: LOCK_OWNER_ID,
@@ -1160,6 +1171,7 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
         claimGeneration: claimed.claimGeneration,
         targetNodeRecordId: LOCK_TARGET_NODE_RECORD_ID,
         targetNodeIncarnation: LOCK_TARGET_NODE_INCARNATION,
+        targetNodeHistoryId,
       }).then(
         (result) => {
           reservationResult = result;
@@ -1203,12 +1215,14 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
         nodeRecordId: LOCK_TARGET_NODE_RECORD_ID,
         nodeId: "restore-lock-target",
         nodeIncarnation: LOCK_TARGET_NODE_INCARNATION,
+        nodeHistoryId: targetNodeHistoryId,
         imageDigest: `sha256:${SHA}`,
       });
       expect(reservationResult?.operation.expected_node_record_id).toBe(LOCK_TARGET_NODE_RECORD_ID);
       expect(reservationResult?.operation.expected_node_incarnation).toBe(
         LOCK_TARGET_NODE_INCARNATION,
       );
+      expect(reservationResult?.operation.expected_node_history_id).toBe(targetNodeHistoryId);
       expect(reservationResult?.operation.expected_image_digest).toBe(`sha256:${SHA}`);
       const [targetNode] = await dbWrite
         .select({ allocatedCount: dockerNodes.allocated_count })
@@ -1222,7 +1236,7 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
     }
   }, 30_000);
 
-  test("restore receipt writers cannot deadlock a concurrent sandbox-first reservation", async () => {
+  test("final restore receipt writer cannot deadlock a concurrent sandbox-first reservation", async () => {
     const reserve = reserveAgentBackupOperation;
     const publish = recordAgentActivationPublication;
     const seed = recordAgentVaultKeySeedReceipt;
@@ -1230,6 +1244,8 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
     if (!isolatedDsn || !dbWrite || !reserve || !publish || !seed || !finalize) {
       throw new Error("real PostgreSQL harness was not initialized");
     }
+    const targetNodeHistoryId = sourceNodeHistoryId;
+    if (!targetNodeHistoryId) throw new Error("source node occurrence token fixture is missing");
 
     await dbWrite
       .insert(agentBackupCatalogAuthorities)
@@ -1347,6 +1363,28 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
       catalog_epoch: initialAuthority.revision,
       expires_at: new Date(Date.now() + 300_000),
     });
+    await dbWrite.insert(agentBackupRestoreOperations).values({
+      id: WRITER_RESTORE_OPERATION_ROW_ID,
+      organization_id: ORG_ID,
+      agent_id: AGENT_ID,
+      backup_id: WRITER_BACKUP_ID,
+      restore_attempt_id: WRITER_ATTEMPT_ID,
+      lease_id: WRITER_LEASE_ID,
+      lease_generation: WRITER_FENCE,
+      lease_owner_id: "writer-lock-owner",
+      catalog_epoch: initialAuthority.revision,
+      copy_role: "primary",
+      phase: "restart_attested",
+      expected_manifest_sha256: SHA,
+      expected_operation_id: WRITER_OPERATION_ID,
+      expected_activation_generation: ACTIVATION_GENERATION,
+      expected_lifecycle_revision: 0n,
+      expected_node_history_id: targetNodeHistoryId,
+      expected_node_record_id: NODE_RECORD_ID,
+      expected_node_incarnation: NODE_INCARNATION,
+      expected_container_id: SOURCE_CONTAINER_ID,
+      expected_image_digest: `sha256:${SHA}`,
+    });
     await dbWrite
       .update(agentSandboxes)
       .set({
@@ -1374,6 +1412,7 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
       expectedContainerId: SOURCE_CONTAINER_ID,
       expectedNodeRecordId: NODE_RECORD_ID,
       expectedNodeIncarnation: NODE_INCARNATION,
+      expectedNodeHistoryId: targetNodeHistoryId,
       expectedTokenSha256: SHA,
     });
 
@@ -1442,34 +1481,28 @@ realPostgres("restore authority PostgreSQL lock proofs", () => {
       }
     };
 
+    await seed({
+      receiptId: WRITER_SEED_ID,
+      receiptDigest: RECEIPT_SHA,
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      backupId: WRITER_BACKUP_ID,
+      restoreAttemptId: WRITER_ATTEMPT_ID,
+      leaseId: WRITER_LEASE_ID,
+      leaseOwnerId: "writer-lock-owner",
+      leaseFencingToken: WRITER_FENCE,
+      targetActivationGeneration: WRITER_TARGET_GENERATION,
+      targetNodeRecordId: NODE_RECORD_ID,
+      targetNodeIncarnation: NODE_INCARNATION,
+      targetNodeHistoryId,
+    });
+
+    // Seed and finalization share the same backup -> operation -> lease ->
+    // sandbox -> node -> catalogue prefix. Interleave the final writer because
+    // it also proves the receipt/publication suffix while keeping the lease's
+    // write-once catalogue epoch intact; the competing new reservation advances
+    // the epoch only after this writer commits.
     await interleaveWithReservation(WRITER_RESERVE_ONE, () =>
-      seed({
-        receiptId: WRITER_SEED_ID,
-        receiptDigest: RECEIPT_SHA,
-        organizationId: ORG_ID,
-        agentId: AGENT_ID,
-        backupId: WRITER_BACKUP_ID,
-        restoreAttemptId: WRITER_ATTEMPT_ID,
-        leaseId: WRITER_LEASE_ID,
-        leaseOwnerId: "writer-lock-owner",
-        leaseFencingToken: WRITER_FENCE,
-        targetActivationGeneration: WRITER_TARGET_GENERATION,
-        targetNodeRecordId: NODE_RECORD_ID,
-        targetNodeIncarnation: NODE_INCARNATION,
-      }),
-    );
-
-    const [currentAuthority] = await dbWrite
-      .select({ revision: agentBackupCatalogAuthorities.catalog_revision })
-      .from(agentBackupCatalogAuthorities)
-      .where(eq(agentBackupCatalogAuthorities.agent_id, AGENT_ID));
-    if (!currentAuthority) throw new Error("writer fixture catalogue authority disappeared");
-    await dbWrite
-      .update(agentBackupRestoreLeases)
-      .set({ catalog_epoch: currentAuthority.revision })
-      .where(eq(agentBackupRestoreLeases.id, WRITER_LEASE_ID));
-
-    await interleaveWithReservation(WRITER_RESERVE_TWO, () =>
       finalize({
         receiptId: WRITER_FINAL_ID,
         receiptDigest: SHA,

--- a/packages/cloud/shared/src/db/agent-node-occurrence-authority-migration.test.ts
+++ b/packages/cloud/shared/src/db/agent-node-occurrence-authority-migration.test.ts
@@ -1,0 +1,498 @@
+/** PGlite proofs for the durable Docker-node occurrence and restore-target cutovers. */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+
+const NODE_MIGRATION = readFileSync(
+  join(import.meta.dir, "migrations", "0300_agent_node_occurrence_authority.sql"),
+  "utf8",
+);
+const NODE_TRIGGER_MIGRATION = readFileSync(
+  join(import.meta.dir, "migrations", "0301_agent_node_occurrence_trigger.sql"),
+  "utf8",
+);
+const RESTORE_MIGRATION = readFileSync(
+  join(import.meta.dir, "migrations", "0302_agent_restore_target_occurrence.sql"),
+  "utf8",
+);
+
+const NODE = "00000000-0000-4000-8000-000000000101";
+const NODE_TWO = "00000000-0000-4000-8000-000000000102";
+const BOOT_A = "00000000-0000-4000-8000-000000000201";
+const BOOT_B = "00000000-0000-4000-8000-000000000202";
+const LEGACY_HISTORY = "00000000-0000-4000-8000-000000000301";
+const LEGACY_RECEIPT = "00000000-0000-4000-8000-000000000401";
+const OPERATION = "00000000-0000-4000-8000-000000000501";
+const SHA = "a".repeat(64);
+
+async function databaseBeforeOccurrenceAuthority(options?: {
+  targetBearingOperation?: boolean;
+}): Promise<PGlite> {
+  const database = new PGlite();
+  await database.exec(`
+    CREATE TABLE agent_node_incarnation_histories (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      docker_node_record_id uuid NOT NULL,
+      node_id text NOT NULL,
+      node_incarnation uuid NOT NULL,
+      fleet_kind text NOT NULL,
+      infrastructure_provider text NOT NULL,
+      provider_server_id text,
+      host_key_fingerprint text NOT NULL,
+      attested_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+      CONSTRAINT agent_node_incarnation_histories_record_incarnation_unique
+        UNIQUE (docker_node_record_id, node_incarnation),
+      CONSTRAINT agent_node_incarnation_histories_receipt_authority_unique
+        UNIQUE (id, docker_node_record_id, node_incarnation),
+      CONSTRAINT agent_node_incarnation_histories_shape_check CHECK ((
+        node_id = btrim(node_id) AND octet_length(node_id) BETWEEN 1 AND 255
+        AND fleet_kind IN ('robot', 'cloud')
+        AND infrastructure_provider = 'hetzner'
+        AND btrim(host_key_fingerprint) <> ''
+        AND ((fleet_kind = 'robot' AND provider_server_id IS NULL)
+          OR (fleet_kind = 'cloud' AND provider_server_id ~ '^[1-9][0-9]{0,19}$'))
+      ) IS TRUE)
+    );
+    CREATE TABLE docker_nodes (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      node_id text UNIQUE NOT NULL,
+      node_incarnation uuid,
+      fleet_kind text,
+      infrastructure_provider text,
+      provider_server_id text,
+      host_key_fingerprint text,
+      updated_at timestamptz NOT NULL DEFAULT clock_timestamp()
+    );
+    CREATE UNIQUE INDEX docker_nodes_node_incarnation_uidx
+      ON docker_nodes (node_incarnation) WHERE node_incarnation IS NOT NULL;
+    CREATE TABLE agent_backup_restore_operations (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      organization_id uuid NOT NULL,
+      agent_id uuid NOT NULL,
+      backup_id uuid NOT NULL,
+      restore_attempt_id uuid NOT NULL,
+      lease_id uuid NOT NULL,
+      lease_generation uuid NOT NULL,
+      lease_owner_id text NOT NULL,
+      catalog_epoch bigint NOT NULL,
+      copy_role text NOT NULL,
+      phase text NOT NULL DEFAULT 'reserved',
+      resume_phase text,
+      claim_owner text,
+      claim_generation uuid,
+      claim_expires_at timestamptz,
+      attempts integer NOT NULL DEFAULT 0,
+      next_attempt_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+      expected_manifest_sha256 text NOT NULL,
+      expected_operation_id uuid NOT NULL,
+      expected_activation_generation uuid NOT NULL,
+      expected_lifecycle_revision numeric(20, 0) NOT NULL,
+      expected_node_record_id uuid,
+      expected_node_incarnation uuid,
+      expected_container_id text,
+      expected_image_digest text,
+      receipt_digest text,
+      last_error_code text,
+      last_error text,
+      last_failure_generation uuid,
+      last_failure_digest text,
+      completed_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+      updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+      CONSTRAINT agent_backup_restore_operations_expected_shape_check CHECK ((
+        attempts >= 0 AND catalog_epoch >= 0
+        AND expected_lifecycle_revision BETWEEN 0 AND 18446744073709551615
+        AND expected_manifest_sha256 ~ '^[0-9a-f]{64}$'
+        AND copy_role IN ('primary','secondary')
+        AND btrim(lease_owner_id) = lease_owner_id
+        AND octet_length(lease_owner_id) BETWEEN 1 AND 255
+        AND (expected_container_id IS NULL OR expected_container_id ~ '^[0-9a-f]{64}$')
+        AND (expected_image_digest IS NULL
+          OR expected_image_digest ~ '^sha256:[0-9a-f]{64}$')
+        AND (expected_node_record_id IS NULL) = (expected_node_incarnation IS NULL)
+      ) IS TRUE)
+    );
+    CREATE TABLE agent_activation_publications (
+      id uuid PRIMARY KEY,
+      node_history_id uuid NOT NULL,
+      docker_node_record_id uuid NOT NULL,
+      node_incarnation uuid NOT NULL,
+      CONSTRAINT agent_activation_publications_node_history_fkey FOREIGN KEY (
+        node_history_id, docker_node_record_id, node_incarnation
+      ) REFERENCES agent_node_incarnation_histories (
+        id, docker_node_record_id, node_incarnation
+      ) ON DELETE RESTRICT
+    );
+    CREATE OR REPLACE FUNCTION reject_agent_restore_immutable_mutation()
+    RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN
+      RAISE EXCEPTION 'immutable restore authority cannot be changed'
+        USING ERRCODE = '55000';
+    END; $$;
+    CREATE TRIGGER agent_node_incarnation_histories_immutable
+      BEFORE UPDATE OR DELETE ON agent_node_incarnation_histories
+      FOR EACH ROW EXECUTE FUNCTION reject_agent_restore_immutable_mutation();
+    CREATE OR REPLACE FUNCTION journal_agent_node_incarnation()
+    RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END; $$;
+    CREATE TRIGGER docker_nodes_incarnation_history
+      BEFORE INSERT OR UPDATE OF node_id, node_incarnation, fleet_kind,
+        infrastructure_provider, provider_server_id, host_key_fingerprint
+      ON docker_nodes FOR EACH ROW EXECUTE FUNCTION journal_agent_node_incarnation();
+    CREATE OR REPLACE FUNCTION guard_agent_backup_restore_operation()
+    RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN
+      IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'restore operation authority cannot be deleted'
+          USING ERRCODE = '55000';
+      END IF;
+      IF (OLD.expected_node_record_id IS NOT NULL
+          AND NEW.expected_node_record_id IS DISTINCT FROM OLD.expected_node_record_id)
+        OR (OLD.expected_node_incarnation IS NOT NULL
+          AND NEW.expected_node_incarnation IS DISTINCT FROM OLD.expected_node_incarnation)
+        OR (OLD.expected_image_digest IS NOT NULL
+          AND NEW.expected_image_digest IS DISTINCT FROM OLD.expected_image_digest) THEN
+        RAISE EXCEPTION 'restore operation side-effect identity is write-once'
+          USING ERRCODE = '55000';
+      END IF;
+      RETURN NEW;
+    END; $$;
+    CREATE TRIGGER agent_backup_restore_operation_guard
+      BEFORE UPDATE OR DELETE ON agent_backup_restore_operations
+      FOR EACH ROW EXECUTE FUNCTION guard_agent_backup_restore_operation();
+
+    INSERT INTO agent_node_incarnation_histories (
+      id, docker_node_record_id, node_id, node_incarnation, fleet_kind,
+      infrastructure_provider, provider_server_id, host_key_fingerprint
+    ) VALUES (
+      '${LEGACY_HISTORY}', '${NODE}', 'node-a', '${BOOT_A}', 'robot',
+      'hetzner', NULL, 'ssh-ed25519 legacy'
+    );
+    INSERT INTO docker_nodes (
+      id, node_id, node_incarnation, fleet_kind, infrastructure_provider,
+      provider_server_id, host_key_fingerprint
+    ) VALUES (
+      '${NODE}', 'node-a', '${BOOT_A}', 'robot', 'hetzner', NULL,
+      'ssh-ed25519 legacy'
+    );
+    INSERT INTO agent_activation_publications
+      (id, node_history_id, docker_node_record_id, node_incarnation)
+    VALUES ('${LEGACY_RECEIPT}', '${LEGACY_HISTORY}', '${NODE}', '${BOOT_A}');
+  `);
+  if (options?.targetBearingOperation) {
+    await insertOperation(database, {
+      expectedNodeRecordId: NODE,
+      expectedNodeIncarnation: BOOT_A,
+    });
+  }
+  return database;
+}
+
+async function insertOperation(
+  database: PGlite,
+  target?: { expectedNodeRecordId?: string; expectedNodeIncarnation?: string },
+): Promise<void> {
+  await database.exec(`INSERT INTO agent_backup_restore_operations (
+    id, organization_id, agent_id, backup_id, restore_attempt_id, lease_id,
+    lease_generation, lease_owner_id, catalog_epoch, copy_role,
+    expected_manifest_sha256, expected_operation_id,
+    expected_activation_generation, expected_lifecycle_revision,
+    expected_node_record_id, expected_node_incarnation
+  ) VALUES (
+    '${OPERATION}', gen_random_uuid(), gen_random_uuid(), gen_random_uuid(),
+    gen_random_uuid(), gen_random_uuid(), gen_random_uuid(), 'restore-worker', 1,
+    'primary', '${SHA}', gen_random_uuid(), gen_random_uuid(), 1,
+    ${target?.expectedNodeRecordId ? `'${target.expectedNodeRecordId}'` : "NULL"},
+    ${target?.expectedNodeIncarnation ? `'${target.expectedNodeIncarnation}'` : "NULL"}
+  )`);
+}
+
+async function applyMigrations(database: PGlite): Promise<void> {
+  await database.exec(NODE_MIGRATION);
+  await database.exec(NODE_TRIGGER_MIGRATION);
+  await database.exec(RESTORE_MIGRATION);
+}
+
+async function currentOccurrence(database: PGlite): Promise<string> {
+  const [node] = (
+    await database.query<{ current_node_history_id: string }>(`
+      SELECT current_node_history_id FROM docker_nodes WHERE id = '${NODE}'
+    `)
+  ).rows;
+  if (!node) throw new Error("Expected current Docker node");
+  return node.current_node_history_id;
+}
+
+async function occurrenceIds(database: PGlite): Promise<string[]> {
+  return (
+    await database.query<{ id: string }>(`
+      SELECT id FROM agent_node_incarnation_histories
+      WHERE docker_node_record_id = '${NODE}' ORDER BY attested_at, id
+    `)
+  ).rows.map(({ id }) => id);
+}
+
+describe("0300/0301/0302 Docker-node occurrence authority", () => {
+  test("mints a fresh baseline without rewriting legacy receipt authority", async () => {
+    const database = await databaseBeforeOccurrenceAuthority();
+    try {
+      await applyMigrations(database);
+      const baseline = await currentOccurrence(database);
+      expect(baseline).not.toBe(LEGACY_HISTORY);
+      expect(await occurrenceIds(database)).toHaveLength(2);
+
+      const [receipt] = (
+        await database.query<{ node_history_id: string }>(`
+          SELECT node_history_id FROM agent_activation_publications
+          WHERE id = '${LEGACY_RECEIPT}'
+        `)
+      ).rows;
+      expect(receipt?.node_history_id).toBe(LEGACY_HISTORY);
+      const [authority] = (
+        await database.query<{ diagnostic_index: boolean; pair_unique: boolean }>(`
+          SELECT
+            EXISTS (SELECT 1 FROM pg_indexes WHERE indexname =
+              'agent_node_incarnation_histories_record_incarnation_idx') AS diagnostic_index,
+            EXISTS (SELECT 1 FROM pg_constraint WHERE conname =
+              'agent_node_incarnation_histories_record_incarnation_unique') AS pair_unique
+        `)
+      ).rows;
+      expect(authority).toEqual({ diagnostic_index: true, pair_unique: false });
+      await expect(
+        database.exec(`DELETE FROM agent_node_incarnation_histories
+          WHERE id = '${LEGACY_HISTORY}'`),
+      ).rejects.toThrow(/immutable restore authority/);
+    } finally {
+      await database.close();
+    }
+  }, 60_000);
+
+  test("keeps occurrence identity writes fail-closed between 0300 and 0301", async () => {
+    const database = await databaseBeforeOccurrenceAuthority();
+    try {
+      await database.exec(NODE_MIGRATION);
+      const baseline = await currentOccurrence(database);
+      for (const statement of [
+        `UPDATE docker_nodes SET node_incarnation = '${BOOT_B}' WHERE id = '${NODE}'`,
+        `UPDATE docker_nodes SET current_node_history_id = '${LEGACY_HISTORY}' WHERE id = '${NODE}'`,
+        `INSERT INTO docker_nodes (
+          id, node_id, node_incarnation, fleet_kind, infrastructure_provider,
+          provider_server_id, host_key_fingerprint
+        ) VALUES (
+          '${NODE_TWO}', 'node-b', '${BOOT_B}', 'robot', 'hetzner', NULL,
+          'ssh-ed25519 node-b'
+        )`,
+      ]) {
+        await expect(database.exec(statement)).rejects.toThrow(/trigger cutover is incomplete/);
+      }
+      expect(await currentOccurrence(database)).toBe(baseline);
+
+      await database.exec(NODE_TRIGGER_MIGRATION);
+      await database.exec(`UPDATE docker_nodes SET node_incarnation = '${BOOT_B}'
+        WHERE id = '${NODE}'`);
+      expect(await currentOccurrence(database)).not.toBe(baseline);
+    } finally {
+      await database.close();
+    }
+  }, 60_000);
+
+  test("distinguishes A1 to B to A2, NULL rearm, and exact-id reinsert", async () => {
+    const database = await databaseBeforeOccurrenceAuthority();
+    try {
+      await applyMigrations(database);
+      const a1 = await currentOccurrence(database);
+      await database.exec(`UPDATE docker_nodes SET node_incarnation = '${BOOT_A}'
+        WHERE id = '${NODE}'`);
+      expect(await currentOccurrence(database)).toBe(a1);
+
+      await database.exec(`UPDATE docker_nodes SET node_incarnation = '${BOOT_B}'
+        WHERE id = '${NODE}'`);
+      const b = await currentOccurrence(database);
+      await database.exec(`UPDATE docker_nodes SET node_incarnation = '${BOOT_A}'
+        WHERE id = '${NODE}'`);
+      const a2 = await currentOccurrence(database);
+      expect(new Set([a1, b, a2]).size).toBe(3);
+
+      await database.exec(`UPDATE docker_nodes SET node_incarnation = NULL WHERE id = '${NODE}'`);
+      const [cleared] = (
+        await database.query<{ incarnation: string | null; history_id: string | null }>(`
+          SELECT node_incarnation AS incarnation, current_node_history_id AS history_id
+          FROM docker_nodes WHERE id = '${NODE}'
+        `)
+      ).rows;
+      expect(cleared).toEqual({ incarnation: null, history_id: null });
+      await database.exec(`UPDATE docker_nodes SET node_incarnation = '${BOOT_A}'
+        WHERE id = '${NODE}'`);
+      const a3 = await currentOccurrence(database);
+      expect(a3).not.toBe(a2);
+
+      await database.exec(`DELETE FROM docker_nodes WHERE id = '${NODE}'`);
+      await database.exec(`INSERT INTO docker_nodes (
+        id, node_id, node_incarnation, fleet_kind, infrastructure_provider,
+        provider_server_id, host_key_fingerprint
+      ) VALUES (
+        '${NODE}', 'node-a', '${BOOT_A}', 'robot', 'hetzner', NULL,
+        'ssh-ed25519 legacy'
+      )`);
+      expect(await currentOccurrence(database)).not.toBe(a3);
+    } finally {
+      await database.close();
+    }
+  }, 60_000);
+
+  test("rolls back pointer/history together and rejects pointer spoofing", async () => {
+    const database = await databaseBeforeOccurrenceAuthority();
+    try {
+      await applyMigrations(database);
+      const before = await currentOccurrence(database);
+      const historyCount = (await occurrenceIds(database)).length;
+      await database.exec("BEGIN");
+      try {
+        await database.exec(`UPDATE docker_nodes SET node_incarnation = '${BOOT_B}'
+          WHERE id = '${NODE}'`);
+        expect(await currentOccurrence(database)).not.toBe(before);
+      } finally {
+        await database.exec("ROLLBACK");
+      }
+      expect(await currentOccurrence(database)).toBe(before);
+      expect(await occurrenceIds(database)).toHaveLength(historyCount);
+      await expect(
+        database.exec(`UPDATE docker_nodes SET current_node_history_id = '${LEGACY_HISTORY}'
+          WHERE id = '${NODE}'`),
+      ).rejects.toThrow(/trigger-owned/);
+      await expect(
+        database.exec(`UPDATE docker_nodes SET host_key_fingerprint = 'ssh-ed25519 rewritten'
+          WHERE id = '${NODE}'`),
+      ).rejects.toThrow(/conflicts with immutable history/);
+      await expect(
+        database.exec(`INSERT INTO docker_nodes (
+          id, node_id, node_incarnation, current_node_history_id, fleet_kind,
+          infrastructure_provider, provider_server_id, host_key_fingerprint
+        ) VALUES (
+          '${NODE_TWO}', 'node-b', '${BOOT_B}', '${LEGACY_HISTORY}', 'robot',
+          'hetzner', NULL, 'ssh-ed25519 node-b'
+        )`),
+      ).rejects.toThrow(/trigger-owned/);
+    } finally {
+      await database.close();
+    }
+  }, 60_000);
+
+  test("requires one exact write-once occurrence tuple on restore operations", async () => {
+    const database = await databaseBeforeOccurrenceAuthority();
+    try {
+      await applyMigrations(database);
+      await insertOperation(database);
+      const baseline = await currentOccurrence(database);
+
+      for (const assignment of [
+        `expected_node_history_id = '${baseline}'`,
+        `expected_node_history_id = '${baseline}', expected_node_record_id = '${NODE}'`,
+        `expected_node_record_id = '${NODE}', expected_node_incarnation = '${BOOT_A}'`,
+        `expected_container_id = '${"b".repeat(64)}'`,
+        `expected_image_digest = 'sha256:${SHA}'`,
+      ]) {
+        await expect(
+          database.exec(`UPDATE agent_backup_restore_operations SET ${assignment}
+            WHERE id = '${OPERATION}'`),
+        ).rejects.toThrow(/expected_shape_check/);
+      }
+      await expect(
+        database.exec(`UPDATE agent_backup_restore_operations SET
+          expected_node_history_id = '${baseline}', expected_node_record_id = '${NODE_TWO}',
+          expected_node_incarnation = '${BOOT_A}', expected_image_digest = 'sha256:${SHA}'
+          WHERE id = '${OPERATION}'`),
+      ).rejects.toThrow(/node_occurrence_fkey/);
+
+      await database.exec(`UPDATE agent_backup_restore_operations SET
+        expected_node_history_id = '${baseline}', expected_node_record_id = '${NODE}',
+        expected_node_incarnation = '${BOOT_A}', expected_image_digest = 'sha256:${SHA}'
+        WHERE id = '${OPERATION}'`);
+      await expect(
+        database.exec(`UPDATE agent_backup_restore_operations SET
+          expected_node_history_id = '${LEGACY_HISTORY}' WHERE id = '${OPERATION}'`),
+      ).rejects.toThrow(/target occurrence is write-once/);
+      await expect(
+        database.exec(`UPDATE agent_backup_restore_operations SET
+          expected_node_history_id = NULL, expected_node_record_id = NULL,
+          expected_node_incarnation = NULL, expected_image_digest = NULL
+          WHERE id = '${OPERATION}'`),
+      ).rejects.toThrow(/write-once/);
+    } finally {
+      await database.close();
+    }
+  }, 60_000);
+
+  test("0302 fails closed before binding a legacy target-bearing operation", async () => {
+    const database = await databaseBeforeOccurrenceAuthority({ targetBearingOperation: true });
+    try {
+      await database.exec(NODE_MIGRATION);
+      await database.exec(NODE_TRIGGER_MIGRATION);
+      await expect(database.exec(RESTORE_MIGRATION)).rejects.toThrow(/requires target-free/);
+      const columns = await database.query<{ column_name: string }>(`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'agent_backup_restore_operations'
+          AND column_name = 'expected_node_history_id'
+      `);
+      expect(columns.rows).toEqual([]);
+      expect(await currentOccurrence(database)).not.toBe(LEGACY_HISTORY);
+    } finally {
+      await database.close();
+    }
+  }, 60_000);
+
+  test("journal, file budgets, and Drizzle schema register the exact three live ordinals", () => {
+    const journal = JSON.parse(
+      readFileSync(join(import.meta.dir, "migrations", "meta", "_journal.json"), "utf8"),
+    ) as {
+      entries: Array<{
+        idx: number;
+        version: string;
+        when: number;
+        tag: string;
+        breakpoints: boolean;
+      }>;
+    };
+    const occurrenceTags = new Set([
+      "0300_agent_node_occurrence_authority",
+      "0301_agent_node_occurrence_trigger",
+      "0302_agent_restore_target_occurrence",
+    ]);
+    // Other contributions may append later journal entries while this branch is
+    // in review. Assert the exact immutable occurrence slice without requiring
+    // it to remain the global tail.
+    expect(journal.entries.filter((entry) => occurrenceTags.has(entry.tag))).toEqual([
+      {
+        idx: 283,
+        version: "7",
+        when: 1793995200002,
+        tag: "0300_agent_node_occurrence_authority",
+        breakpoints: true,
+      },
+      {
+        idx: 284,
+        version: "7",
+        when: 1793995200003,
+        tag: "0301_agent_node_occurrence_trigger",
+        breakpoints: true,
+      },
+      {
+        idx: 285,
+        version: "7",
+        when: 1793995200004,
+        tag: "0302_agent_restore_target_occurrence",
+        breakpoints: true,
+      },
+    ]);
+    for (const migration of [NODE_MIGRATION, NODE_TRIGGER_MIGRATION, RESTORE_MIGRATION]) {
+      expect(migration.trimEnd().split(/\r?\n/).length).toBeLessThanOrEqual(100);
+    }
+    const dockerSchema = readFileSync(join(import.meta.dir, "schemas", "docker-nodes.ts"), "utf8");
+    const restoreSchema = readFileSync(
+      join(import.meta.dir, "schemas", "agent-backup-catalog.ts"),
+      "utf8",
+    );
+    expect(dockerSchema).toContain('current_node_history_id: uuid("current_node_history_id")');
+    expect(restoreSchema).toContain('expected_node_history_id: uuid("expected_node_history_id")');
+    expect(restoreSchema).toContain("agent_backup_restore_operations_node_occurrence_fkey");
+  });
+});

--- a/packages/cloud/shared/src/db/agent-node-occurrence-test-support.ts
+++ b/packages/cloud/shared/src/db/agent-node-occurrence-test-support.ts
@@ -1,0 +1,36 @@
+/** Test-only helpers for exercising migration-owned Docker-node occurrence authority. */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const NODE_OCCURRENCE_MIGRATION_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "migrations/0301_agent_node_occurrence_trigger.sql",
+);
+
+/**
+ * Install only the function and trigger that `pushSchema` cannot derive from
+ * the Drizzle schema. Reading them from the migration prevents test fixtures
+ * from drifting away from the production occurrence-token authority.
+ */
+export async function installAgentNodeOccurrenceTriggerForTests(
+  executeStatement: (statement: string) => Promise<unknown>,
+): Promise<void> {
+  const statements = readFileSync(NODE_OCCURRENCE_MIGRATION_PATH, "utf8")
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter(
+      (statement) =>
+        statement.includes('CREATE OR REPLACE FUNCTION "journal_agent_node_incarnation"()') ||
+        statement.includes('CREATE TRIGGER "docker_nodes_incarnation_history"'),
+    );
+  if (
+    statements.length !== 2 ||
+    !statements[0]?.includes('CREATE OR REPLACE FUNCTION "journal_agent_node_incarnation"()') ||
+    !statements[1]?.includes('CREATE TRIGGER "docker_nodes_incarnation_history"')
+  ) {
+    throw new Error("node occurrence migration trigger statements are missing or reordered");
+  }
+  for (const statement of statements) await executeStatement(statement);
+}

--- a/packages/cloud/shared/src/db/migrations/0300_agent_node_occurrence_authority.sql
+++ b/packages/cloud/shared/src/db/migrations/0300_agent_node_occurrence_authority.sql
@@ -1,0 +1,98 @@
+-- Backfill one durable token for every live Docker-node occurrence.
+-- A temporary trigger blocks identity writes until 0301 installs journaling.
+
+LOCK TABLE "docker_nodes" IN ACCESS EXCLUSIVE MODE;
+--> statement-breakpoint
+LOCK TABLE "agent_node_incarnation_histories" IN ACCESS EXCLUSIVE MODE;
+--> statement-breakpoint
+ALTER TABLE "docker_nodes"
+  ADD COLUMN IF NOT EXISTS "current_node_history_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "agent_node_incarnation_histories"
+  DROP CONSTRAINT IF EXISTS
+    "agent_node_incarnation_histories_record_incarnation_unique";
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_node_incarnation_histories_record_incarnation_idx"
+  ON "agent_node_incarnation_histories"
+    ("docker_node_record_id", "node_incarnation");
+--> statement-breakpoint
+DROP TRIGGER "docker_nodes_incarnation_history" ON "docker_nodes";
+--> statement-breakpoint
+-- Mint a fresh baseline instead of reusing a pre-cutover history row. This
+-- preserves old receipt meaning while establishing an unambiguous live token.
+WITH "fresh_baselines" AS MATERIALIZED (
+  SELECT
+    gen_random_uuid() AS "history_id", node."id" AS "docker_node_record_id",
+    node."node_id", node."node_incarnation", node."fleet_kind",
+    node."infrastructure_provider", node."provider_server_id",
+    node."host_key_fingerprint"
+  FROM "docker_nodes" node
+  WHERE node."node_incarnation" IS NOT NULL
+    AND node."current_node_history_id" IS NULL
+), "inserted_baselines" AS (
+  INSERT INTO "agent_node_incarnation_histories" (
+    "id", "docker_node_record_id", "node_id", "node_incarnation", "fleet_kind",
+    "infrastructure_provider", "provider_server_id", "host_key_fingerprint",
+    "attested_at"
+  )
+  SELECT
+    baseline."history_id", baseline."docker_node_record_id", baseline."node_id",
+    baseline."node_incarnation", baseline."fleet_kind",
+    baseline."infrastructure_provider", baseline."provider_server_id",
+    baseline."host_key_fingerprint", clock_timestamp()
+  FROM "fresh_baselines" baseline
+  RETURNING "id", "docker_node_record_id"
+)
+UPDATE "docker_nodes" node
+SET "current_node_history_id" = baseline."id"
+FROM "inserted_baselines" baseline
+WHERE node."id" = baseline."docker_node_record_id";
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "docker_nodes" node
+    LEFT JOIN "agent_node_incarnation_histories" history
+      ON history."id" = node."current_node_history_id"
+     AND history."docker_node_record_id" = node."id"
+     AND history."node_incarnation" = node."node_incarnation"
+    WHERE (node."node_incarnation" IS NULL)
+        IS DISTINCT FROM (node."current_node_history_id" IS NULL)
+      OR (node."node_incarnation" IS NOT NULL AND (
+        history."id" IS NULL OR history."node_id" <> node."node_id"
+        OR history."fleet_kind" <> node."fleet_kind"
+        OR history."infrastructure_provider" <> node."infrastructure_provider"
+        OR history."provider_server_id" IS DISTINCT FROM node."provider_server_id"
+        OR history."host_key_fingerprint" <> node."host_key_fingerprint"
+      ))
+  ) THEN
+    RAISE EXCEPTION 'current Docker-node occurrence conflicts with immutable history'
+      USING ERRCODE = '55000';
+  END IF;
+END;
+$$;
+--> statement-breakpoint
+ALTER TABLE "docker_nodes"
+  ADD CONSTRAINT "docker_nodes_current_node_history_fkey"
+  FOREIGN KEY ("current_node_history_id", "id", "node_incarnation")
+  REFERENCES "agent_node_incarnation_histories"
+    ("id", "docker_node_record_id", "node_incarnation")
+  ON DELETE RESTRICT;
+--> statement-breakpoint
+ALTER TABLE "docker_nodes"
+  ADD CONSTRAINT "docker_nodes_node_occurrence_shape_check"
+  CHECK (("node_incarnation" IS NULL) = ("current_node_history_id" IS NULL));
+--> statement-breakpoint
+CREATE FUNCTION "block_agent_node_occurrence_cutover"()
+RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN
+  RAISE EXCEPTION 'Docker-node occurrence trigger cutover is incomplete'
+    USING ERRCODE = '55000';
+END; $$;
+--> statement-breakpoint
+CREATE TRIGGER "docker_nodes_occurrence_cutover_guard"
+  BEFORE INSERT OR UPDATE OF
+    "node_id", "node_incarnation", "fleet_kind", "infrastructure_provider",
+    "provider_server_id", "host_key_fingerprint", "current_node_history_id"
+  ON "docker_nodes"
+  FOR EACH ROW EXECUTE FUNCTION "block_agent_node_occurrence_cutover"();

--- a/packages/cloud/shared/src/db/migrations/0301_agent_node_occurrence_trigger.sql
+++ b/packages/cloud/shared/src/db/migrations/0301_agent_node_occurrence_trigger.sql
@@ -1,0 +1,69 @@
+-- Replace the fail-closed cutover guard with causal occurrence journaling.
+
+LOCK TABLE "docker_nodes" IN ACCESS EXCLUSIVE MODE;
+--> statement-breakpoint
+LOCK TABLE "agent_node_incarnation_histories" IN SHARE ROW EXCLUSIVE MODE;
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION "journal_agent_node_incarnation"()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  occurrence_id uuid;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW."current_node_history_id" IS NOT NULL THEN
+      RAISE EXCEPTION 'current node history id is trigger-owned'
+        USING ERRCODE = '55000';
+    END IF;
+  ELSIF NEW."current_node_history_id" IS DISTINCT FROM OLD."current_node_history_id" THEN
+    RAISE EXCEPTION 'current node history id is trigger-owned'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF NEW."node_incarnation" IS NULL THEN
+    NEW."current_node_history_id" := NULL;
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD."node_incarnation" IS NOT NULL
+    AND NEW."node_incarnation" IS NOT DISTINCT FROM OLD."node_incarnation" THEN
+    SELECT history."id" INTO occurrence_id
+    FROM "agent_node_incarnation_histories" history
+    WHERE history."id" = OLD."current_node_history_id"
+      AND history."docker_node_record_id" = NEW."id"
+      AND history."node_incarnation" = NEW."node_incarnation"
+      AND history."node_id" = NEW."node_id"
+      AND history."fleet_kind" = NEW."fleet_kind"
+      AND history."infrastructure_provider" = NEW."infrastructure_provider"
+      AND history."provider_server_id" IS NOT DISTINCT FROM NEW."provider_server_id"
+      AND history."host_key_fingerprint" = NEW."host_key_fingerprint";
+    IF occurrence_id IS NULL THEN
+      RAISE EXCEPTION 'node occurrence conflicts with immutable history'
+        USING ERRCODE = '55000';
+    END IF;
+    NEW."current_node_history_id" := occurrence_id;
+    RETURN NEW;
+  END IF;
+
+  INSERT INTO "agent_node_incarnation_histories" (
+    "docker_node_record_id", "node_id", "node_incarnation", "fleet_kind",
+    "infrastructure_provider", "provider_server_id", "host_key_fingerprint"
+  ) VALUES (
+    NEW."id", NEW."node_id", NEW."node_incarnation", NEW."fleet_kind",
+    NEW."infrastructure_provider", NEW."provider_server_id",
+    NEW."host_key_fingerprint"
+  ) RETURNING "id" INTO occurrence_id;
+  NEW."current_node_history_id" := occurrence_id;
+  RETURN NEW;
+END;
+$$;
+--> statement-breakpoint
+DROP TRIGGER "docker_nodes_occurrence_cutover_guard" ON "docker_nodes";
+--> statement-breakpoint
+CREATE TRIGGER "docker_nodes_incarnation_history"
+  BEFORE INSERT OR UPDATE OF
+    "node_id", "node_incarnation", "fleet_kind", "infrastructure_provider",
+    "provider_server_id", "host_key_fingerprint", "current_node_history_id"
+  ON "docker_nodes"
+  FOR EACH ROW EXECUTE FUNCTION "journal_agent_node_incarnation"();
+--> statement-breakpoint
+DROP FUNCTION "block_agent_node_occurrence_cutover"();

--- a/packages/cloud/shared/src/db/migrations/0302_agent_restore_target_occurrence.sql
+++ b/packages/cloud/shared/src/db/migrations/0302_agent_restore_target_occurrence.sql
@@ -1,0 +1,85 @@
+-- Bind each restore target to the exact durable Docker-node occurrence.
+
+LOCK TABLE "agent_backup_restore_operations" IN ACCESS EXCLUSIVE MODE;
+--> statement-breakpoint
+LOCK TABLE "agent_node_incarnation_histories" IN SHARE ROW EXCLUSIVE MODE;
+--> statement-breakpoint
+DO $$
+BEGIN
+  -- Existing target bindings cannot be assigned a causal token safely from
+  -- the mutable node row. Fail closed instead of inventing backfill authority.
+  IF NOT EXISTS (
+      SELECT 1 FROM pg_attribute
+      WHERE attrelid = 'agent_backup_restore_operations'::regclass
+        AND attname = 'expected_node_history_id' AND NOT attisdropped
+    ) AND EXISTS (
+      SELECT 1 FROM "agent_backup_restore_operations"
+      WHERE "expected_node_record_id" IS NOT NULL
+        OR "expected_node_incarnation" IS NOT NULL
+        OR "expected_container_id" IS NOT NULL
+        OR "expected_image_digest" IS NOT NULL
+    ) THEN
+    RAISE EXCEPTION
+      'node occurrence authority migration requires target-free restore operations'
+      USING ERRCODE = '55000';
+  END IF;
+END;
+$$;
+--> statement-breakpoint
+ALTER TABLE "agent_backup_restore_operations"
+  ADD COLUMN IF NOT EXISTS "expected_node_history_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "agent_backup_restore_operations"
+  DROP CONSTRAINT IF EXISTS "agent_backup_restore_operations_expected_shape_check";
+--> statement-breakpoint
+ALTER TABLE "agent_backup_restore_operations"
+  ADD CONSTRAINT "agent_backup_restore_operations_expected_shape_check" CHECK ((
+    "attempts" >= 0 AND "catalog_epoch" >= 0
+    AND "expected_lifecycle_revision" BETWEEN 0 AND 18446744073709551615
+    AND "expected_manifest_sha256" ~ '^[0-9a-f]{64}$'
+    AND "copy_role" IN ('primary','secondary')
+    AND btrim("lease_owner_id") = "lease_owner_id"
+    AND octet_length("lease_owner_id") BETWEEN 1 AND 255
+    AND ("expected_container_id" IS NULL
+      OR "expected_container_id" ~ '^[0-9a-f]{64}$')
+    AND ("expected_container_id" IS NULL OR "expected_node_history_id" IS NOT NULL)
+    AND ("expected_image_digest" IS NULL
+      OR "expected_image_digest" ~ '^sha256:[0-9a-f]{64}$')
+    AND (("expected_node_history_id" IS NULL
+        AND "expected_node_record_id" IS NULL
+        AND "expected_node_incarnation" IS NULL
+        AND "expected_image_digest" IS NULL)
+      OR ("expected_node_history_id" IS NOT NULL
+        AND "expected_node_record_id" IS NOT NULL
+        AND "expected_node_incarnation" IS NOT NULL
+        AND "expected_image_digest" IS NOT NULL))
+  ) IS TRUE);
+--> statement-breakpoint
+ALTER TABLE "agent_backup_restore_operations"
+  ADD CONSTRAINT "agent_backup_restore_operations_node_occurrence_fkey"
+  FOREIGN KEY (
+    "expected_node_history_id", "expected_node_record_id",
+    "expected_node_incarnation"
+  ) REFERENCES "agent_node_incarnation_histories" (
+    "id", "docker_node_record_id", "node_incarnation"
+  ) ON DELETE RESTRICT;
+--> statement-breakpoint
+-- Keep the existing phase/identity guard untouched and add one narrow trigger
+-- for the new write-once field. A null target may be bound once; it can never
+-- be cleared or replaced afterward, including through a raw SQL writer.
+CREATE OR REPLACE FUNCTION "guard_agent_restore_target_occurrence"()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF OLD."expected_node_history_id" IS NOT NULL
+    AND NEW."expected_node_history_id" IS DISTINCT FROM OLD."expected_node_history_id" THEN
+    RAISE EXCEPTION 'restore operation target occurrence is write-once: %', OLD."id"
+      USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+--> statement-breakpoint
+CREATE TRIGGER "agent_backup_restore_target_occurrence_guard"
+  BEFORE UPDATE OF "expected_node_history_id"
+  ON "agent_backup_restore_operations"
+  FOR EACH ROW EXECUTE FUNCTION "guard_agent_restore_target_occurrence"();

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1982,6 +1982,27 @@
       "when": 1793995200001,
       "tag": "0299_synthetic_environment_leases",
       "breakpoints": true
+    },
+    {
+      "idx": 283,
+      "version": "7",
+      "when": 1793995200002,
+      "tag": "0300_agent_node_occurrence_authority",
+      "breakpoints": true
+    },
+    {
+      "idx": 284,
+      "version": "7",
+      "when": 1793995200003,
+      "tag": "0301_agent_node_occurrence_trigger",
+      "breakpoints": true
+    },
+    {
+      "idx": 285,
+      "version": "7",
+      "when": 1793995200004,
+      "tag": "0302_agent_restore_target_occurrence",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts
@@ -34,6 +34,7 @@ import type {
   RuntimeR2Bucket,
   RuntimeR2ObjectMetadata,
 } from "../../../lib/storage/r2-runtime-binding";
+import { installAgentNodeOccurrenceTriggerForTests } from "../../agent-node-occurrence-test-support";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
 import {
   agentBackupCatalogAuthorities,
@@ -41,6 +42,7 @@ import {
   agentBackupObjects,
   agentBackupRestoreLeases,
 } from "../../schemas/agent-backup-catalog";
+import { agentNodeIncarnationHistories } from "../../schemas/agent-node-incarnation-histories";
 import { agentSandboxBackups, agentSandboxes } from "../../schemas/agent-sandboxes";
 import { dockerNodes } from "../../schemas/docker-nodes";
 import { organizations } from "../../schemas/organizations";
@@ -975,6 +977,7 @@ beforeAll(async () => {
         organizations,
         users,
         userCharacters,
+        agentNodeIncarnationHistories,
         dockerNodes,
         agentSandboxes,
         agentSandboxBackups,
@@ -986,6 +989,7 @@ beforeAll(async () => {
       dbWrite as never,
     );
     await apply();
+    await installAgentNodeOccurrenceTriggerForTests((statement) => dbWrite.execute(statement));
   } catch (error) {
     schemaFailure = error instanceof Error ? error.message : String(error);
   }
@@ -1000,6 +1004,7 @@ beforeEach(async () => {
   await dbWrite.delete(agentBackupCatalogAuthorities);
   await dbWrite.delete(agentSandboxes);
   await dbWrite.delete(dockerNodes);
+  await dbWrite.delete(agentNodeIncarnationHistories);
   await dbWrite.delete(userCharacters);
   await dbWrite.delete(users);
   await dbWrite.delete(organizations);

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-global-lock-order.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-global-lock-order.test.ts
@@ -25,43 +25,47 @@ function expectOrder(body: string, first: string, second: string, label: string)
   expect(firstIndex, `${label}: ${first} must precede ${second}`).toBeLessThan(secondIndex);
 }
 
+function expectRestoreWriterOrder(body: string, label: string): void {
+  const anchors = [
+    ".from(agentSandboxBackups)",
+    "lockExactRestoreOperationTarget(tx",
+    ".from(agentBackupRestoreLeases)",
+    ".from(agentSandboxes)",
+    "lockCurrentNodeHistory(tx",
+    "lockAgentBackupCatalogAuthority(",
+  ];
+  let previous = -1;
+  for (const anchor of anchors) {
+    const index = body.indexOf(anchor, previous + 1);
+    expect(index, `${label}: missing ordered lock anchor ${anchor}`).toBeGreaterThan(previous);
+    previous = index;
+  }
+}
+
 describe("agent backup global lock order", () => {
-  test("vault-seed receipt locks sandbox and node before catalogue authority", () => {
+  test("restore publication follows backup-to-catalogue lock order", () => {
+    const history = source("agent-backup-restore-history.ts");
+    const start = history.indexOf("async function recordRestoreActivationPublication");
+    const end = history.indexOf("export async function recordAgentActivationPublication", start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    expectRestoreWriterOrder(history.slice(start, end), "restore publication");
+  });
+
+  test("vault-seed receipt follows backup-to-catalogue lock order", () => {
     const history = source("agent-backup-restore-history.ts");
     const seed = exportedFunction(
       history,
       "recordAgentVaultKeySeedReceipt",
       "commitAgentBackupRestore",
     );
-    expectOrder(
-      seed,
-      ".from(agentSandboxes)",
-      ".from(agentBackupCatalogAuthorities)",
-      "vault-seed receipt",
-    );
-    expectOrder(
-      seed,
-      "lockCurrentNodeHistory(tx",
-      ".from(agentBackupCatalogAuthorities)",
-      "vault-seed receipt",
-    );
+    expectRestoreWriterOrder(seed, "vault-seed receipt");
   });
 
-  test("restore finalizer locks sandbox and node before catalogue authority", () => {
+  test("restore finalizer follows backup-to-catalogue lock order", () => {
     const history = source("agent-backup-restore-history.ts");
     const finalizer = exportedFunction(history, "commitAgentBackupRestore");
-    expectOrder(
-      finalizer,
-      ".from(agentSandboxes)",
-      ".from(agentBackupCatalogAuthorities)",
-      "restore finalizer",
-    );
-    expectOrder(
-      finalizer,
-      "lockCurrentNodeHistory(tx",
-      ".from(agentBackupCatalogAuthorities)",
-      "restore finalizer",
-    );
+    expectRestoreWriterOrder(finalizer, "restore finalizer");
   });
 
   test("reservation, capture, and vault rotation preserve the same order", () => {

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts
@@ -28,6 +28,7 @@ process.env.MOCK_REDIS = "1";
 process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
 
 import { pushSchema } from "drizzle-kit/api";
+import { installAgentNodeOccurrenceTriggerForTests } from "../../agent-node-occurrence-test-support";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
 import {
   agentBackupCatalogAuthorities,
@@ -94,12 +95,14 @@ const VAULT_GENERATION = "00000000-0000-4000-8000-00000000d006";
 const ROTATED_VAULT_GENERATION = "00000000-0000-4000-8000-00000000d030";
 const STALE_VAULT_GENERATION = "00000000-0000-4000-8000-00000000d031";
 const USER_ID = "00000000-0000-4000-8000-00000000d032";
-const TARGET_ACTIVATION_GENERATION = "00000000-0000-4000-8000-00000000d042";
+const SOURCE_NODE_INCARNATION = "00000000-0000-4000-8000-00000000d034";
+const SOURCE_NODE_RECORD_ID = "00000000-0000-4000-8000-00000000d035";
+const NON_RESTORE_PUBLICATION_ID = "00000000-0000-4000-8000-00000000d036";
+const TARGET_ACTIVATION_GENERATION = "00000000-0000-4000-8000-00000000d048";
 const TARGET_NODE_RECORD_ID = "00000000-0000-4000-8000-00000000d043";
 const TARGET_NODE_INCARNATION = "00000000-0000-4000-8000-00000000d044";
 const REARMED_TARGET_NODE_INCARNATION = "00000000-0000-4000-8000-00000000d065";
 const TARGET_NODE_CREATED_AT = new Date("2026-08-19T23:59:59.000Z");
-const TARGET_NODE_ATTESTED_AT = new Date("2026-08-20T00:00:00.000Z");
 const ACTIVATION_PUBLICATION_ID = "00000000-0000-4000-8000-00000000d045";
 const SEED_RECEIPT_ID = "00000000-0000-4000-8000-00000000d046";
 const FINAL_RECEIPT_ID = "00000000-0000-4000-8000-00000000d047";
@@ -197,7 +200,7 @@ async function insertActiveSandbox(): Promise<void> {
     activation_image_digest: `sha256:${SHA}`,
     activation_token_hash: SHA,
     activation_token_ciphertext: "sealed-restore-authority-token",
-    activation_boot_id: "00000000-0000-4000-8000-00000000d034",
+    activation_boot_id: SOURCE_NODE_INCARNATION,
     activation_funding_revision: 1n,
     activation_authority_published_at: new Date("2026-08-17T00:00:00.000Z"),
     activation_dispatched_at: new Date("2026-08-17T00:00:01.000Z"),
@@ -660,7 +663,7 @@ async function acquireVaultPassphraseFixture(
     ownerId: acquired.authority.ownerId,
     claimMs: 60_000,
   });
-  await dbWrite.insert(dockerNodes).values({
+  const targetNode = await dockerNodesRepository.create({
     id: TARGET_NODE_RECORD_ID,
     node_id: "vault-restore-target-node",
     hostname: "vault-restore-target-node.internal",
@@ -676,16 +679,8 @@ async function acquireVaultPassphraseFixture(
     metadata: {},
     created_at: TARGET_NODE_CREATED_AT,
   });
-  await dbWrite.insert(agentNodeIncarnationHistories).values({
-    docker_node_record_id: TARGET_NODE_RECORD_ID,
-    node_id: "vault-restore-target-node",
-    node_incarnation: TARGET_NODE_INCARNATION,
-    fleet_kind: "robot",
-    infrastructure_provider: "hetzner",
-    provider_server_id: null,
-    host_key_fingerprint: `SHA256:${SHA}`,
-    attested_at: TARGET_NODE_ATTESTED_AT,
-  });
+  const targetNodeHistoryId = targetNode.current_node_history_id;
+  if (!targetNodeHistoryId) throw new Error("vault target occurrence token fixture is missing");
   if (options.reserveTarget !== false) {
     await reserveAgentBackupRestoreTarget({
       operationId: opened.operation.id,
@@ -693,6 +688,7 @@ async function acquireVaultPassphraseFixture(
       claimGeneration: claimed.claimGeneration,
       targetNodeRecordId: TARGET_NODE_RECORD_ID,
       targetNodeIncarnation: TARGET_NODE_INCARNATION,
+      targetNodeHistoryId,
     });
   }
   return {
@@ -705,41 +701,37 @@ async function acquireVaultPassphraseFixture(
       restoreClaimGeneration: claimed.claimGeneration,
       targetNodeRecordId: TARGET_NODE_RECORD_ID,
       targetNodeIncarnation: TARGET_NODE_INCARNATION,
+      targetNodeHistoryId,
       vaultKeyGenerationId: generation.authority.generationId,
       vaultKeyAuthorityReceiptDigest: generation.authority.receiptDigest,
     },
   } as const;
 }
 
-async function rearmVaultTargetNodeThroughIncarnation(
-  nextIncarnation: string,
-  timing: "later" | "backdated" = "later",
-): Promise<void> {
-  const [originalHistory] = await dbWrite
-    .select()
-    .from(agentNodeIncarnationHistories)
-    .where(eq(agentNodeIncarnationHistories.docker_node_record_id, TARGET_NODE_RECORD_ID));
-  if (!originalHistory) throw new Error("vault target history fixture is missing");
-  await dbWrite
-    .update(dockerNodes)
-    .set({ node_incarnation: nextIncarnation })
-    .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
-  await dbWrite.insert(agentNodeIncarnationHistories).values({
-    docker_node_record_id: TARGET_NODE_RECORD_ID,
-    node_id: originalHistory.node_id,
-    node_incarnation: nextIncarnation,
-    fleet_kind: originalHistory.fleet_kind,
-    infrastructure_provider: originalHistory.infrastructure_provider,
-    provider_server_id: originalHistory.provider_server_id,
-    host_key_fingerprint: originalHistory.host_key_fingerprint,
-    attested_at: new Date(
-      originalHistory.attested_at.getTime() + (timing === "backdated" ? -1_000 : 1_000),
-    ),
+async function rearmVaultTargetNodeThroughActualAba(): Promise<{
+  bHistoryId: string;
+  a2HistoryId: string;
+}> {
+  const b = await dockerNodesRepository.attestNodeIncarnation({
+    id: TARGET_NODE_RECORD_ID,
+    nodeId: "vault-restore-target-node",
+    expectedIncarnation: TARGET_NODE_INCARNATION,
+    expectedHostKeyFingerprint: `SHA256:${SHA}`,
+    observedIncarnation: REARMED_TARGET_NODE_INCARNATION,
   });
-  await dbWrite
-    .update(dockerNodes)
-    .set({ node_incarnation: TARGET_NODE_INCARNATION })
-    .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+  if (!b.current_node_history_id) throw new Error("vault target B occurrence token is missing");
+  const a2 = await dockerNodesRepository.attestNodeIncarnation({
+    id: TARGET_NODE_RECORD_ID,
+    nodeId: "vault-restore-target-node",
+    expectedIncarnation: REARMED_TARGET_NODE_INCARNATION,
+    expectedHostKeyFingerprint: `SHA256:${SHA}`,
+    observedIncarnation: TARGET_NODE_INCARNATION,
+  });
+  if (!a2.current_node_history_id) throw new Error("vault target A2 occurrence token is missing");
+  return {
+    bHistoryId: b.current_node_history_id,
+    a2HistoryId: a2.current_node_history_id,
+  };
 }
 
 beforeAll(async () => {
@@ -767,6 +759,9 @@ beforeAll(async () => {
       dbWrite as never,
     );
     await apply();
+    await installAgentNodeOccurrenceTriggerForTests((statement) =>
+      dbWrite.execute(sql.raw(statement)),
+    );
     // error-policy:J1 setup failure is retained for the test boundary assertion.
   } catch (error) {
     schemaFailure = error instanceof Error ? error.message : String(error);
@@ -778,7 +773,6 @@ beforeEach(async () => {
   await dbWrite.delete(agentBackupRestoreReceipts);
   await dbWrite.delete(agentVaultKeySeedReceipts);
   await dbWrite.delete(agentActivationPublications);
-  await dbWrite.delete(agentNodeIncarnationHistories);
   await dbWrite.delete(agentVaultKeyBackupBindings);
   await dbWrite.delete(agentBackupRestoreOperations);
   await dbWrite.delete(agentBackupRestoreLeases);
@@ -789,6 +783,7 @@ beforeEach(async () => {
   await dbWrite.delete(agentBackupCatalogAuthorities);
   await dbWrite.delete(agentSandboxes);
   await dbWrite.delete(dockerNodes);
+  await dbWrite.delete(agentNodeIncarnationHistories);
   await dbWrite.delete(userCharacters);
   await dbWrite.delete(users);
   await dbWrite.delete(organizations);
@@ -805,6 +800,54 @@ afterAll(async () => {
 });
 
 describe("strict restore catalogue authority", () => {
+  test("publishes, replays, and dispatch-authorizes a non-restore node occurrence", async () => {
+    const sourceNode = await dockerNodesRepository.create({
+      id: SOURCE_NODE_RECORD_ID,
+      node_id: "restore-source-node",
+      hostname: "restore-source-node.internal",
+      capacity: 2,
+      enabled: true,
+      placement_state: "open",
+      status: "healthy",
+      host_key_fingerprint: `SHA256:${SHA}`,
+      fleet_kind: "robot",
+      infrastructure_provider: "hetzner",
+      provider_server_id: null,
+      node_incarnation: SOURCE_NODE_INCARNATION,
+      metadata: {},
+    });
+    if (!sourceNode.current_node_history_id) {
+      throw new Error("non-restore source occurrence token is missing");
+    }
+    const input = {
+      publicationId: NON_RESTORE_PUBLICATION_ID,
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      activationGeneration: ACTIVATION_GENERATION,
+      expectedActivationReceiptSha256: RECEIPT_SHA,
+      expectedContainerId: "c".repeat(64),
+      expectedNodeRecordId: SOURCE_NODE_RECORD_ID,
+      expectedNodeIncarnation: SOURCE_NODE_INCARNATION,
+      expectedNodeHistoryId: sourceNode.current_node_history_id,
+      expectedTokenSha256: SHA,
+    };
+
+    const first = await recordAgentActivationPublication(input);
+    const replay = await recordAgentActivationPublication(input);
+    expect(first.replayed).toBe(false);
+    expect(replay.replayed).toBe(true);
+    expect(first.publication).toMatchObject({
+      purpose: "provision",
+      docker_node_record_id: SOURCE_NODE_RECORD_ID,
+      node_incarnation: SOURCE_NODE_INCARNATION,
+      node_history_id: sourceNode.current_node_history_id,
+    });
+    await expect(authorizeAgentActivationDispatch(input)).resolves.toMatchObject({
+      id: NON_RESTORE_PUBLICATION_ID,
+      node_history_id: sourceNode.current_node_history_id,
+    });
+  });
+
   test("creates, replays, rotates, zeroizes, and retains vault-key authority", async () => {
     const kms = new MemoryKmsAdapter({ seed: () => new Uint8Array(32).fill(0x91) });
     let entropyCalls = 0;
@@ -1241,16 +1284,56 @@ describe("strict restore catalogue authority", () => {
     );
     generation.secret.release();
     const { exact } = await insertExactProtectedSource(generation.authority);
-    await dbWrite.insert(dockerNodes).values({
+    const restoreTargetNode = await dockerNodesRepository.create({
       id: TARGET_NODE_RECORD_ID,
       node_id: "restore-target-node",
       hostname: "restore-target-node.internal",
+      capacity: 2,
+      enabled: true,
+      placement_state: "open",
+      status: "healthy",
       host_key_fingerprint: `SHA256:${SHA}`,
       fleet_kind: "robot",
       infrastructure_provider: "hetzner",
       provider_server_id: null,
       node_incarnation: TARGET_NODE_INCARNATION,
     });
+    const restoreTargetHistoryId = restoreTargetNode.current_node_history_id;
+    if (!restoreTargetHistoryId) throw new Error("restore target occurrence token is missing");
+    const acquired = await acquireAgentBackupRestoreLease({
+      organizationId: ORG_ID,
+      backupId: BACKUP_ID,
+      operationId: OPERATION_ID,
+      sourceActivationGeneration: ACTIVATION_GENERATION,
+      sourceLifecycleRevision: "7",
+      expectedManifestSha256: exact.manifest.integrity.manifestSha256,
+      copyRole: "primary",
+      restoreAttemptId: RESTORE_ATTEMPT_ID,
+      ownerId: "immutable-restore-worker",
+      fencingToken: "00000000-0000-4000-8000-00000000d051",
+      leaseMs: 60_000,
+    });
+    const opened = await openAgentBackupRestoreOperation({
+      authority: acquired.authority,
+      leaseId: acquired.authority.leaseId,
+    });
+    const claimed = await claimAgentBackupRestoreOperation({
+      operationId: opened.operation.id,
+      ownerId: acquired.authority.ownerId,
+      claimMs: 60_000,
+    });
+    await reserveAgentBackupRestoreTarget({
+      operationId: opened.operation.id,
+      ownerId: acquired.authority.ownerId,
+      claimGeneration: claimed.claimGeneration,
+      targetNodeRecordId: TARGET_NODE_RECORD_ID,
+      targetNodeIncarnation: TARGET_NODE_INCARNATION,
+      targetNodeHistoryId: restoreTargetHistoryId,
+    });
+    await dbWrite
+      .update(agentBackupRestoreOperations)
+      .set({ expected_container_id: RESTORE_CONTAINER_ID })
+      .where(eq(agentBackupRestoreOperations.id, opened.operation.id));
     await dbWrite
       .update(agentSandboxes)
       .set({
@@ -1306,6 +1389,7 @@ describe("strict restore catalogue authority", () => {
       expectedContainerId: RESTORE_CONTAINER_ID,
       expectedNodeRecordId: TARGET_NODE_RECORD_ID,
       expectedNodeIncarnation: TARGET_NODE_INCARNATION,
+      expectedNodeHistoryId: restoreTargetHistoryId,
       expectedTokenSha256: SHA,
     } as const;
     const [publicationFirst, publicationReplay] = await Promise.all([
@@ -1327,33 +1411,6 @@ describe("strict restore catalogue authority", () => {
       .update(agentSandboxes)
       .set({ activation_boot_id: TARGET_NODE_INCARNATION })
       .where(eq(agentSandboxes.id, AGENT_ID));
-    await dbWrite
-      .update(dockerNodes)
-      .set({ node_incarnation: "00000000-0000-4000-8000-00000000d050" })
-      .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
-    await expect(authorizeAgentActivationDispatch(publicationInput)).rejects.toThrow(
-      "Target node incarnation is absent",
-    );
-    await dbWrite
-      .update(dockerNodes)
-      .set({ node_incarnation: TARGET_NODE_INCARNATION })
-      .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
-    // This direct mutation did not publish a B history. Journaled A -> B -> A
-    // is covered separately and remains rejected after the mutable row rewinds.
-
-    const acquired = await acquireAgentBackupRestoreLease({
-      organizationId: ORG_ID,
-      backupId: BACKUP_ID,
-      operationId: OPERATION_ID,
-      sourceActivationGeneration: ACTIVATION_GENERATION,
-      sourceLifecycleRevision: "7",
-      expectedManifestSha256: exact.manifest.integrity.manifestSha256,
-      copyRole: "primary",
-      restoreAttemptId: RESTORE_ATTEMPT_ID,
-      ownerId: "immutable-restore-worker",
-      fencingToken: "00000000-0000-4000-8000-00000000d051",
-      leaseMs: 60_000,
-    });
     const seedInput = {
       receiptId: SEED_RECEIPT_ID,
       receiptDigest: CONTENT_SHA,
@@ -1367,6 +1424,7 @@ describe("strict restore catalogue authority", () => {
       targetActivationGeneration: TARGET_ACTIVATION_GENERATION,
       targetNodeRecordId: TARGET_NODE_RECORD_ID,
       targetNodeIncarnation: TARGET_NODE_INCARNATION,
+      targetNodeHistoryId: restoreTargetHistoryId,
     } as const;
     await expect(
       recordAgentVaultKeySeedReceipt({
@@ -1374,7 +1432,7 @@ describe("strict restore catalogue authority", () => {
         receiptId: "00000000-0000-4000-8000-00000000d052",
         targetNodeIncarnation: "00000000-0000-4000-8000-00000000d050",
       }),
-    ).rejects.toThrow("unattested, changed, or blocked");
+    ).rejects.toThrow("durable operation target");
     // The seed receipt is append-only (0250), so a stale catalogue epoch must be
     // refused BEFORE the row exists rather than left as an unremovable record.
     const [epochBefore] = await dbWrite
@@ -1449,20 +1507,6 @@ describe("strict restore catalogue authority", () => {
       .set({ expires_at: originalLeaseExpiry })
       .where(eq(agentBackupRestoreLeases.id, acquired.authority.leaseId));
 
-    // A target that reboots between publication and commit must not earn a
-    // permanent receipt naming an incarnation that no longer exists.
-    await dbWrite
-      .update(dockerNodes)
-      .set({ node_incarnation: "00000000-0000-4000-8000-00000000d055" })
-      .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
-    await expect(commitAgentBackupRestore(finalInput)).rejects.toThrow(
-      "Target node incarnation is absent",
-    );
-    await dbWrite
-      .update(dockerNodes)
-      .set({ node_incarnation: TARGET_NODE_INCARNATION })
-      .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
-
     await releaseAgentBackupRestoreLease(acquired.authority);
     await expect(commitAgentBackupRestore(finalInput)).rejects.toThrow(
       "lost its exact live restore lease",
@@ -1534,6 +1578,246 @@ describe("strict restore catalogue authority", () => {
       generation: 1n,
       receiptDigest: CIPHERTEXT_SHA,
     });
+
+    await dockerNodesRepository.attestNodeIncarnation({
+      id: TARGET_NODE_RECORD_ID,
+      nodeId: "restore-target-node",
+      expectedIncarnation: TARGET_NODE_INCARNATION,
+      expectedHostKeyFingerprint: `SHA256:${SHA}`,
+      observedIncarnation: "00000000-0000-4000-8000-00000000d055",
+    });
+    await expect(authorizeAgentActivationDispatch(publicationInput)).rejects.toThrow(
+      "exact current node-occurrence authority",
+    );
+  });
+
+  test("rejects caller-substituted current A2 when the restore operation reserved A1", async () => {
+    const kms = new MemoryKmsAdapter({ seed: () => new Uint8Array(32).fill(0x95) });
+    const generation = await createOrRotateAgentVaultKeyGeneration(
+      {
+        organizationId: ORG_ID,
+        agentId: AGENT_ID,
+        generationId: VAULT_GENERATION,
+        sourceActivationGeneration: ACTIVATION_GENERATION,
+        expectedCurrentGenerationId: null,
+      },
+      {
+        kmsClient: kms,
+        randomBytes: (size) => new Uint8Array(size).fill(0x45),
+      },
+    );
+    generation.secret.release();
+    const { exact } = await insertExactProtectedSource(generation.authority);
+    const targetA1 = await dockerNodesRepository.create({
+      id: TARGET_NODE_RECORD_ID,
+      node_id: "vault-restore-target-node",
+      hostname: "vault-restore-target-node.internal",
+      capacity: 2,
+      enabled: true,
+      placement_state: "open",
+      status: "healthy",
+      host_key_fingerprint: `SHA256:${SHA}`,
+      fleet_kind: "robot",
+      infrastructure_provider: "hetzner",
+      provider_server_id: null,
+      node_incarnation: TARGET_NODE_INCARNATION,
+    });
+    if (!targetA1.current_node_history_id) throw new Error("target A1 token is missing");
+    const acquired = await acquireAgentBackupRestoreLease({
+      organizationId: ORG_ID,
+      backupId: BACKUP_ID,
+      operationId: OPERATION_ID,
+      sourceActivationGeneration: ACTIVATION_GENERATION,
+      sourceLifecycleRevision: "7",
+      expectedManifestSha256: exact.manifest.integrity.manifestSha256,
+      copyRole: "primary",
+      restoreAttemptId: RESTORE_ATTEMPT_ID,
+      ownerId: "aba-restore-worker",
+      fencingToken: "00000000-0000-4000-8000-00000000d051",
+      leaseMs: 60_000,
+    });
+    const opened = await openAgentBackupRestoreOperation({
+      authority: acquired.authority,
+      leaseId: acquired.authority.leaseId,
+    });
+    const claimed = await claimAgentBackupRestoreOperation({
+      operationId: opened.operation.id,
+      ownerId: acquired.authority.ownerId,
+      claimMs: 60_000,
+    });
+    await reserveAgentBackupRestoreTarget({
+      operationId: opened.operation.id,
+      ownerId: acquired.authority.ownerId,
+      claimGeneration: claimed.claimGeneration,
+      targetNodeRecordId: TARGET_NODE_RECORD_ID,
+      targetNodeIncarnation: TARGET_NODE_INCARNATION,
+      targetNodeHistoryId: targetA1.current_node_history_id,
+    });
+    await dbWrite
+      .update(agentBackupRestoreOperations)
+      .set({ expected_container_id: RESTORE_CONTAINER_ID })
+      .where(eq(agentBackupRestoreOperations.id, opened.operation.id));
+
+    const { a2HistoryId } = await rearmVaultTargetNodeThroughActualAba();
+    expect(a2HistoryId).not.toBe(targetA1.current_node_history_id);
+    const activationReceipt = {
+      schemaVersion: 1,
+      generation: TARGET_ACTIVATION_GENERATION,
+      purpose: "restore",
+      agentId: AGENT_ID,
+      organizationId: ORG_ID,
+      lifecycleRevision: "8",
+      backupId: BACKUP_ID,
+      backupHash: exact.manifest.integrity.manifestSha256,
+      manifestHash: exact.manifest.integrity.manifestSha256,
+      componentHashes: null,
+      freshAuthorization: null,
+      containerId: RESTORE_CONTAINER_ID,
+      imageDigest: `sha256:${SHA}`,
+      receiptId: "00000000-0000-4000-8000-00000000d049",
+      receiptHash: RECEIPT_SHA,
+      receiptMac: CONTENT_SHA,
+      appliedAt: "2026-08-17T02:00:00.000Z",
+      restored: true,
+      requiresRestart: true,
+    } as const;
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        lifecycle_revision: 8,
+        activation_generation: TARGET_ACTIVATION_GENERATION,
+        activation_previous_generation: ACTIVATION_GENERATION,
+        activation_lifecycle_revision: 8n,
+        activation_purpose: "restore",
+        activation_phase: "restart_attested",
+        activation_backup_id: BACKUP_ID,
+        activation_backup_hash: exact.manifest.integrity.manifestSha256,
+        activation_receipt: activationReceipt,
+        activation_receipt_hash: RECEIPT_SHA,
+        activation_container_id: RESTORE_CONTAINER_ID,
+        activation_node_id: "vault-restore-target-node",
+        activation_image_digest: `sha256:${SHA}`,
+        activation_token_hash: SHA,
+        activation_token_ciphertext: "sealed-aba-restore-token",
+        activation_boot_id: TARGET_NODE_INCARNATION,
+        activation_funding_revision: 2n,
+        activation_authority_published_at: null,
+        activation_dispatched_at: null,
+        activation_completed_at: null,
+      })
+      .where(eq(agentSandboxes.id, AGENT_ID));
+
+    const publicationInput = {
+      publicationId: ACTIVATION_PUBLICATION_ID,
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      activationGeneration: TARGET_ACTIVATION_GENERATION,
+      expectedActivationReceiptSha256: RECEIPT_SHA,
+      expectedContainerId: RESTORE_CONTAINER_ID,
+      expectedNodeRecordId: TARGET_NODE_RECORD_ID,
+      expectedNodeIncarnation: TARGET_NODE_INCARNATION,
+      expectedNodeHistoryId: a2HistoryId,
+      expectedTokenSha256: SHA,
+    } as const;
+    await expect(recordAgentActivationPublication(publicationInput)).rejects.toThrow(
+      "durable operation target",
+    );
+    const seedInput = {
+      receiptId: SEED_RECEIPT_ID,
+      receiptDigest: CONTENT_SHA,
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      backupId: BACKUP_ID,
+      restoreAttemptId: RESTORE_ATTEMPT_ID,
+      leaseId: acquired.authority.leaseId,
+      leaseOwnerId: acquired.authority.ownerId,
+      leaseFencingToken: acquired.authority.fencingToken,
+      targetActivationGeneration: TARGET_ACTIVATION_GENERATION,
+      targetNodeRecordId: TARGET_NODE_RECORD_ID,
+      targetNodeIncarnation: TARGET_NODE_INCARNATION,
+      targetNodeHistoryId: a2HistoryId,
+    } as const;
+    await expect(recordAgentVaultKeySeedReceipt(seedInput)).rejects.toThrow(
+      "durable operation target",
+    );
+
+    const [publication] = await dbWrite
+      .insert(agentActivationPublications)
+      .values({
+        id: ACTIVATION_PUBLICATION_ID,
+        organization_id: ORG_ID,
+        agent_id: AGENT_ID,
+        activation_generation: TARGET_ACTIVATION_GENERATION,
+        previous_activation_generation: ACTIVATION_GENERATION,
+        lifecycle_revision: 8n,
+        purpose: "restore",
+        backup_id: BACKUP_ID,
+        backup_manifest_sha256: exact.manifest.integrity.manifestSha256,
+        activation_receipt: activationReceipt,
+        activation_receipt_sha256: RECEIPT_SHA,
+        container_id: RESTORE_CONTAINER_ID,
+        node_history_id: a2HistoryId,
+        docker_node_record_id: TARGET_NODE_RECORD_ID,
+        node_id: "vault-restore-target-node",
+        node_incarnation: TARGET_NODE_INCARNATION,
+        image_digest: `sha256:${SHA}`,
+        token_sha256: SHA,
+        funding_revision: 2n,
+      })
+      .returning();
+    if (!publication) throw new Error("adversarial A2 publication fixture is missing");
+    await dbWrite.insert(agentVaultKeySeedReceipts).values({
+      id: SEED_RECEIPT_ID,
+      receipt_digest: CONTENT_SHA,
+      organization_id: ORG_ID,
+      agent_id: AGENT_ID,
+      backup_id: BACKUP_ID,
+      restore_attempt_id: RESTORE_ATTEMPT_ID,
+      lease_id: acquired.authority.leaseId,
+      lease_owner_id: acquired.authority.ownerId,
+      lease_fencing_token: acquired.authority.fencingToken,
+      lease_expires_at: acquired.authority.expiresAt,
+      operation_id: OPERATION_ID,
+      source_activation_generation: ACTIVATION_GENERATION,
+      source_lifecycle_revision: 7n,
+      manifest_sha256: exact.manifest.integrity.manifestSha256,
+      vault_key_generation_id: generation.authority.generationId,
+      vault_key_authority_receipt_digest: generation.authority.receiptDigest,
+      target_activation_generation: TARGET_ACTIVATION_GENERATION,
+      node_history_id: a2HistoryId,
+      docker_node_record_id: TARGET_NODE_RECORD_ID,
+      node_incarnation: TARGET_NODE_INCARNATION,
+    });
+    const dispatchedAt = new Date(publication.published_at.getTime() + 1_000);
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        status: "running",
+        sandbox_id: "restored-aba-provider-handle",
+        node_id: "vault-restore-target-node",
+        image_digest: `sha256:${SHA}`,
+        activation_phase: "active",
+        activation_authority_published_at: publication.published_at,
+        activation_dispatched_at: dispatchedAt,
+        activation_completed_at: new Date(dispatchedAt.getTime() + 1_000),
+      })
+      .where(eq(agentSandboxes.id, AGENT_ID));
+    await expect(
+      commitAgentBackupRestore({
+        receiptId: FINAL_RECEIPT_ID,
+        receiptDigest: CIPHERTEXT_SHA,
+        organizationId: ORG_ID,
+        agentId: AGENT_ID,
+        backupId: BACKUP_ID,
+        restoreAttemptId: RESTORE_ATTEMPT_ID,
+        seedReceiptId: SEED_RECEIPT_ID,
+        seedReceiptDigest: CONTENT_SHA,
+        activationPublicationId: ACTIVATION_PUBLICATION_ID,
+        targetActivationGeneration: TARGET_ACTIVATION_GENERATION,
+        expectedActivationReceiptSha256: RECEIPT_SHA,
+      }),
+    ).rejects.toThrow("durable operation target");
+    expect(await dbWrite.select().from(agentBackupRestoreReceipts)).toHaveLength(0);
   });
 
   test("rechecks the live DB clock after expensive restore-source validation", async () => {
@@ -1593,7 +1877,7 @@ describe("strict restore catalogue authority", () => {
       ".from(agentBackupRestoreOperations)",
       ".from(agentBackupRestoreLeases)",
       ".from(dockerNodes)",
-      "proveUnambiguousAgentNodeIncarnationForLockedNode(",
+      "proveExactAgentNodeOccurrenceForLockedNode(",
       "lockAgentBackupCatalogAuthority(",
       "readPostLockDatabaseNow(",
     ]);
@@ -1650,6 +1934,7 @@ describe("strict restore catalogue authority", () => {
       { ...fixture.input, restoreClaimGeneration: "00000000-0000-4000-8000-00000000d061" },
       { ...fixture.input, targetNodeRecordId: "00000000-0000-4000-8000-00000000d062" },
       { ...fixture.input, targetNodeIncarnation: "00000000-0000-4000-8000-00000000d063" },
+      { ...fixture.input, targetNodeHistoryId: "00000000-0000-4000-8000-00000000d064" },
     ] as const;
     try {
       for (const input of mismatches) {
@@ -1717,9 +2002,18 @@ describe("strict restore catalogue authority", () => {
     }
   });
 
-  test("rejects a backdated target B history before KMS", async () => {
+  test("rejects reserved A1 before KMS after a real A to B to A2 occurrence transition", async () => {
     const fixture = await acquireVaultPassphraseFixture();
-    await rearmVaultTargetNodeThroughIncarnation(REARMED_TARGET_NODE_INCARNATION, "backdated");
+    const { bHistoryId, a2HistoryId } = await rearmVaultTargetNodeThroughActualAba();
+    expect(a2HistoryId).not.toBe(fixture.input.targetNodeHistoryId);
+    expect(bHistoryId).not.toBe(a2HistoryId);
+    const histories = await dbWrite
+      .select({ id: agentNodeIncarnationHistories.id })
+      .from(agentNodeIncarnationHistories)
+      .where(eq(agentNodeIncarnationHistories.docker_node_record_id, TARGET_NODE_RECORD_ID));
+    expect(histories.map(({ id }) => id).sort()).toEqual(
+      [fixture.input.targetNodeHistoryId, bHistoryId, a2HistoryId].sort(),
+    );
     const decryptSpy = spyOn(fixture.kms, "decrypt");
     let useCalls = 0;
     try {
@@ -1731,7 +2025,7 @@ describe("strict restore catalogue authority", () => {
           },
           { kmsClient: fixture.kms },
         ),
-      ).rejects.toThrow("ambiguous multi-incarnation history");
+      ).rejects.toThrow("target node occurrence was lost");
       expect(decryptSpy).toHaveBeenCalledTimes(0);
       expect(useCalls).toBe(0);
     } finally {
@@ -1739,37 +2033,24 @@ describe("strict restore catalogue authority", () => {
     }
   });
 
-  test("fails while incarnation is NULL and resumes after exact host-key CAS re-attestation", async () => {
+  test("preserves the A1 occurrence token on same-incarnation A to A replay", async () => {
     const fixture = await acquireVaultPassphraseFixture(0x4a);
     const decryptSpy = spyOn(fixture.kms, "decrypt");
     let useCalls = 0;
     try {
-      await dockerNodesRepository.invalidateNodeIncarnation({
+      const replayed = await dockerNodesRepository.attestNodeIncarnation({
         id: fixture.input.targetNodeRecordId,
         nodeId: "vault-restore-target-node",
         expectedIncarnation: TARGET_NODE_INCARNATION,
         expectedHostKeyFingerprint: `SHA256:${SHA}`,
-      });
-      await expect(
-        withAgentBackupRestoreVaultPassphrase(
-          fixture.input,
-          () => {
-            useCalls += 1;
-          },
-          { kmsClient: fixture.kms },
-        ),
-      ).rejects.toThrow("target node record or incarnation was lost");
-      expect(decryptSpy).toHaveBeenCalledTimes(0);
-      expect(useCalls).toBe(0);
-
-      const reattested = await dockerNodesRepository.attestNodeIncarnation({
-        id: fixture.input.targetNodeRecordId,
-        nodeId: "vault-restore-target-node",
-        expectedIncarnation: null,
-        expectedHostKeyFingerprint: `SHA256:${SHA}`,
         observedIncarnation: TARGET_NODE_INCARNATION,
       });
-      expect(reattested.id).toBe(TARGET_NODE_RECORD_ID);
+      expect(replayed.current_node_history_id).toBe(fixture.input.targetNodeHistoryId);
+      const histories = await dbWrite
+        .select({ id: agentNodeIncarnationHistories.id })
+        .from(agentNodeIncarnationHistories)
+        .where(eq(agentNodeIncarnationHistories.docker_node_record_id, TARGET_NODE_RECORD_ID));
+      expect(histories).toEqual([{ id: fixture.input.targetNodeHistoryId }]);
       const result = await withAgentBackupRestoreVaultPassphrase(
         fixture.input,
         (passphrase) => {
@@ -1781,6 +2062,43 @@ describe("strict restore catalogue authority", () => {
       expect(result).toBe("4a".repeat(32));
       expect(decryptSpy).toHaveBeenCalledTimes(1);
       expect(useCalls).toBe(1);
+    } finally {
+      decryptSpy.mockRestore();
+    }
+  });
+
+  test("rejects reserved A1 before KMS after A to NULL to A2 re-attestation", async () => {
+    const fixture = await acquireVaultPassphraseFixture();
+    const invalidated = await dockerNodesRepository.invalidateNodeIncarnation({
+      id: fixture.input.targetNodeRecordId,
+      nodeId: "vault-restore-target-node",
+      expectedIncarnation: TARGET_NODE_INCARNATION,
+      expectedHostKeyFingerprint: `SHA256:${SHA}`,
+    });
+    expect(invalidated.current_node_history_id).toBeNull();
+    const a2 = await dockerNodesRepository.attestNodeIncarnation({
+      id: fixture.input.targetNodeRecordId,
+      nodeId: "vault-restore-target-node",
+      expectedIncarnation: null,
+      expectedHostKeyFingerprint: `SHA256:${SHA}`,
+      observedIncarnation: TARGET_NODE_INCARNATION,
+    });
+    expect(a2.current_node_history_id).not.toBe(fixture.input.targetNodeHistoryId);
+
+    const decryptSpy = spyOn(fixture.kms, "decrypt");
+    let useCalls = 0;
+    try {
+      await expect(
+        withAgentBackupRestoreVaultPassphrase(
+          fixture.input,
+          () => {
+            useCalls += 1;
+          },
+          { kmsClient: fixture.kms },
+        ),
+      ).rejects.toThrow("target node occurrence was lost");
+      expect(decryptSpy).toHaveBeenCalledTimes(0);
+      expect(useCalls).toBe(0);
     } finally {
       decryptSpy.mockRestore();
     }
@@ -1859,7 +2177,7 @@ describe("strict restore catalogue authority", () => {
     }
   });
 
-  test("revalidates after KMS and zeroizes plaintext when the target incarnation is lost", async () => {
+  test("revalidates after KMS and zeroizes plaintext when the target occurrence is lost", async () => {
     const fixture = await acquireVaultPassphraseFixture();
     const secretRelease = captureVaultRawKeyAtRelease();
     const originalDecrypt = fixture.kms.decrypt.bind(fixture.kms);
@@ -1869,10 +2187,13 @@ describe("strict restore catalogue authority", () => {
       async (keyId, ciphertext, nonce, authTag, aad, keyVersion) => {
         const plaintext = await originalDecrypt(keyId, ciphertext, nonce, authTag, aad, keyVersion);
         borrowedPlaintext = plaintext;
-        await dbWrite
-          .update(dockerNodes)
-          .set({ node_incarnation: "00000000-0000-4000-8000-00000000d065" })
-          .where(eq(dockerNodes.id, fixture.input.targetNodeRecordId));
+        await dockerNodesRepository.attestNodeIncarnation({
+          id: fixture.input.targetNodeRecordId,
+          nodeId: "vault-restore-target-node",
+          expectedIncarnation: TARGET_NODE_INCARNATION,
+          expectedHostKeyFingerprint: `SHA256:${SHA}`,
+          observedIncarnation: REARMED_TARGET_NODE_INCARNATION,
+        });
         return plaintext;
       },
     );
@@ -1885,7 +2206,7 @@ describe("strict restore catalogue authority", () => {
           },
           { kmsClient: fixture.kms },
         ),
-      ).rejects.toThrow("target node record or incarnation was lost");
+      ).rejects.toThrow("target node occurrence was lost");
 
       expect(decryptSpy).toHaveBeenCalledTimes(1);
       expect(useCalls).toBe(0);
@@ -1897,7 +2218,7 @@ describe("strict restore catalogue authority", () => {
     }
   });
 
-  test("revalidates after KMS and zeroizes plaintext after a backdated B history", async () => {
+  test("revalidates after KMS and zeroizes plaintext after a real A to B to A2 transition", async () => {
     const fixture = await acquireVaultPassphraseFixture();
     const secretRelease = captureVaultRawKeyAtRelease();
     const originalDecrypt = fixture.kms.decrypt.bind(fixture.kms);
@@ -1907,7 +2228,8 @@ describe("strict restore catalogue authority", () => {
       async (keyId, ciphertext, nonce, authTag, aad, keyVersion) => {
         const plaintext = await originalDecrypt(keyId, ciphertext, nonce, authTag, aad, keyVersion);
         borrowedPlaintext = plaintext;
-        await rearmVaultTargetNodeThroughIncarnation(REARMED_TARGET_NODE_INCARNATION, "backdated");
+        const { a2HistoryId } = await rearmVaultTargetNodeThroughActualAba();
+        expect(a2HistoryId).not.toBe(fixture.input.targetNodeHistoryId);
         return plaintext;
       },
     );
@@ -1920,7 +2242,7 @@ describe("strict restore catalogue authority", () => {
           },
           { kmsClient: fixture.kms },
         ),
-      ).rejects.toThrow("ambiguous multi-incarnation history");
+      ).rejects.toThrow("target node occurrence was lost");
 
       expect(decryptSpy).toHaveBeenCalledTimes(1);
       expect(useCalls).toBe(0);

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-operations.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-operations.pglite.test.ts
@@ -27,7 +27,8 @@ process.env.MOCK_REDIS = "1";
 process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
 
 import { pushSchema } from "drizzle-kit/api";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
+import { installAgentNodeOccurrenceTriggerForTests } from "../../agent-node-occurrence-test-support";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
 import type { AgentBackupRestorePhase } from "../../schemas/agent-backup-catalog";
 import {
@@ -54,7 +55,7 @@ import {
   failAgentBackupRestoreOperation,
   heartbeatAgentBackupRestoreOperation,
   openAgentBackupRestoreOperation,
-  reserveAgentBackupRestoreTarget,
+  reserveAgentBackupRestoreTarget as reserveAgentBackupRestoreTargetRepository,
 } from "../agent-backup-restore-operations";
 import { dockerNodesRepository } from "../docker-nodes";
 
@@ -78,8 +79,6 @@ const TARGET_NODE_RECORD_ID = "00000000-0000-4000-8000-00000000f010";
 const TARGET_NODE_INCARNATION = "00000000-0000-4000-8000-00000000f011";
 const OTHER_NODE_RECORD_ID = "00000000-0000-4000-8000-00000000f012";
 const OTHER_NODE_INCARNATION = "00000000-0000-4000-8000-00000000f013";
-const TARGET_NODE_CREATED_AT = new Date("2026-08-19T23:59:59.000Z");
-const TARGET_NODE_ATTESTED_AT = new Date("2026-08-20T00:00:00.000Z");
 let schemaFailure = "";
 let manifestFixture: Readonly<{ canonicalDraft: string; digest: string }>;
 
@@ -237,10 +236,8 @@ async function seedTargetNode(
     status?: "healthy" | "degraded" | "offline" | "unknown";
     placementState?: "open" | "cordoned" | "evacuating" | "drained";
     capacityProvisional?: boolean;
-    createdAt?: Date;
-    recordHistory?: boolean;
   } = {},
-): Promise<void> {
+): Promise<typeof dockerNodes.$inferSelect> {
   const [node] = await dbWrite
     .insert(dockerNodes)
     .values({
@@ -259,48 +256,58 @@ async function seedTargetNode(
       node_incarnation:
         input.incarnation === undefined ? TARGET_NODE_INCARNATION : input.incarnation,
       metadata: input.capacityProvisional ? { capacityProvisional: true } : {},
-      created_at: input.createdAt ?? TARGET_NODE_CREATED_AT,
     })
     .returning();
   if (!node) throw new Error("restore target fixture was not inserted");
-  if (node.node_incarnation && input.recordHistory !== false) {
-    await dbWrite.insert(agentNodeIncarnationHistories).values({
-      docker_node_record_id: node.id,
-      node_id: node.node_id,
-      node_incarnation: node.node_incarnation,
-      fleet_kind: node.fleet_kind ?? "robot",
-      infrastructure_provider: node.infrastructure_provider ?? "hetzner",
-      provider_server_id: node.provider_server_id,
-      host_key_fingerprint: node.host_key_fingerprint ?? "SHA256:test-only-host-key",
-      attested_at: TARGET_NODE_ATTESTED_AT,
-    });
+  if (node.node_incarnation !== null && node.current_node_history_id === null) {
+    throw new Error("restore target occurrence trigger did not assign a history id");
   }
+  return node;
 }
 
-async function rearmTargetNodeThroughIncarnation(nextIncarnation: string): Promise<void> {
-  const [originalHistory] = await dbWrite
-    .select()
-    .from(agentNodeIncarnationHistories)
-    .where(eq(agentNodeIncarnationHistories.docker_node_record_id, TARGET_NODE_RECORD_ID));
-  if (!originalHistory) throw new Error("restore target history fixture is missing");
-  await dbWrite
-    .update(dockerNodes)
-    .set({ node_incarnation: nextIncarnation })
-    .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
-  await dbWrite.insert(agentNodeIncarnationHistories).values({
-    docker_node_record_id: TARGET_NODE_RECORD_ID,
-    node_id: originalHistory.node_id,
-    node_incarnation: nextIncarnation,
-    fleet_kind: originalHistory.fleet_kind,
-    infrastructure_provider: originalHistory.infrastructure_provider,
-    provider_server_id: originalHistory.provider_server_id,
-    host_key_fingerprint: originalHistory.host_key_fingerprint,
-    attested_at: new Date(originalHistory.attested_at.getTime() + 1_000),
+async function currentTargetNodeHistoryId(nodeRecordId: string): Promise<string> {
+  const [node] = await dbWrite.select().from(dockerNodes).where(eq(dockerNodes.id, nodeRecordId));
+  if (!node?.current_node_history_id) {
+    throw new Error("restore target current occurrence is missing");
+  }
+  return node.current_node_history_id;
+}
+
+type ReserveTargetInput = Parameters<typeof reserveAgentBackupRestoreTargetRepository>[0];
+
+async function reserveAgentBackupRestoreTarget(
+  params: Omit<ReserveTargetInput, "targetNodeHistoryId"> & { targetNodeHistoryId?: string },
+) {
+  return reserveAgentBackupRestoreTargetRepository({
+    ...params,
+    targetNodeHistoryId:
+      params.targetNodeHistoryId ?? (await currentTargetNodeHistoryId(params.targetNodeRecordId)),
   });
-  await dbWrite
-    .update(dockerNodes)
-    .set({ node_incarnation: TARGET_NODE_INCARNATION })
-    .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+}
+
+async function rearmTargetNodeThroughIncarnation(nextIncarnation: string): Promise<{
+  initialHistoryId: string;
+  currentHistoryId: string;
+}> {
+  const initialHistoryId = await currentTargetNodeHistoryId(TARGET_NODE_RECORD_ID);
+  const intermediate = await dockerNodesRepository.attestNodeIncarnation({
+    id: TARGET_NODE_RECORD_ID,
+    nodeId: "restore-target-a",
+    expectedIncarnation: TARGET_NODE_INCARNATION,
+    expectedHostKeyFingerprint: "SHA256:test-only-host-key",
+    observedIncarnation: nextIncarnation,
+  });
+  const rearmed = await dockerNodesRepository.attestNodeIncarnation({
+    id: TARGET_NODE_RECORD_ID,
+    nodeId: "restore-target-a",
+    expectedIncarnation: intermediate.node_incarnation,
+    expectedHostKeyFingerprint: "SHA256:test-only-host-key",
+    observedIncarnation: TARGET_NODE_INCARNATION,
+  });
+  if (!rearmed.current_node_history_id) {
+    throw new Error("rearmed restore target occurrence is missing");
+  }
+  return { initialHistoryId, currentHistoryId: rearmed.current_node_history_id };
 }
 
 async function openAndClaim(): Promise<{
@@ -417,6 +424,9 @@ beforeAll(async () => {
       dbWrite as never,
     );
     await apply();
+    await installAgentNodeOccurrenceTriggerForTests((statement) =>
+      dbWrite.execute(sql.raw(statement)),
+    );
   } catch (error) {
     schemaFailure = error instanceof Error ? error.message : String(error);
   }
@@ -426,8 +436,8 @@ beforeEach(async () => {
   expect(schemaFailure).toBe("");
   await dbWrite.delete(agentBackupRestoreOperations);
   await dbWrite.delete(agentBackupRestoreLeases);
-  await dbWrite.delete(agentNodeIncarnationHistories);
   await dbWrite.delete(dockerNodes);
+  await dbWrite.delete(agentNodeIncarnationHistories);
   await dbWrite.delete(agentSandboxBackups);
   await dbWrite.delete(agentVaultKeyGenerations);
   await dbWrite.delete(agentBackupCatalogAuthorities);
@@ -542,14 +552,16 @@ describe("restore operation spine", () => {
       if (!reserved || !replay) {
         throw new Error("concurrent reservation did not return one reservation and one replay");
       }
-      expect(reserved.target).toEqual({
+      expect(reserved.target).toMatchObject({
         nodeRecordId: TARGET_NODE_RECORD_ID,
         nodeId: "restore-target-a",
         nodeIncarnation: TARGET_NODE_INCARNATION,
         imageDigest: `sha256:${SHA}`,
       });
+      expect(reserved.target.nodeHistoryId).toMatch(/^[0-9a-f-]{36}$/);
       expect(reserved.operation.expected_node_record_id).toBe(TARGET_NODE_RECORD_ID);
       expect(reserved.operation.expected_node_incarnation).toBe(TARGET_NODE_INCARNATION);
+      expect(reserved.operation.expected_node_history_id).toBe(reserved.target.nodeHistoryId);
       expect(reserved.operation.expected_image_digest).toBe(`sha256:${SHA}`);
       const [node] = await dbWrite.select().from(dockerNodes);
       expect(node?.allocated_count).toBe(1);
@@ -590,6 +602,7 @@ describe("restore operation spine", () => {
       const [operation] = await dbWrite.select().from(agentBackupRestoreOperations);
       expect(node?.allocated_count).toBe(0);
       expect(operation?.expected_node_record_id).toBeNull();
+      expect(operation?.expected_node_history_id).toBeNull();
       expect(operation?.expected_node_incarnation).toBeNull();
       expect(operation?.expected_image_digest).toBeNull();
     },
@@ -648,6 +661,7 @@ describe("restore operation spine", () => {
       expect(nodes.find((node) => node.id === OTHER_NODE_RECORD_ID)?.allocated_count).toBe(0);
       const [operation] = await dbWrite.select().from(agentBackupRestoreOperations);
       expect(operation?.expected_node_record_id).toBeNull();
+      expect(operation?.expected_node_history_id).toBeNull();
     },
     TIMEOUT,
   );
@@ -699,11 +713,14 @@ describe("restore operation spine", () => {
   );
 
   test(
-    "rejects a target rearmed A-to-B-to-A before reservation without consuming capacity",
+    "rejects stale A1 authority after A-to-B-to-A2 and accepts only the exact current token",
     async () => {
       await seedTargetNode();
       const authority = await openAndClaim();
-      await rearmTargetNodeThroughIncarnation("00000000-0000-4000-8000-00000000f014");
+      const { initialHistoryId, currentHistoryId } = await rearmTargetNodeThroughIncarnation(
+        "00000000-0000-4000-8000-00000000f014",
+      );
+      expect(currentHistoryId).not.toBe(initialHistoryId);
 
       await expect(
         reserveAgentBackupRestoreTarget({
@@ -711,29 +728,31 @@ describe("restore operation spine", () => {
           ownerId: "restore-worker",
           targetNodeRecordId: TARGET_NODE_RECORD_ID,
           targetNodeIncarnation: TARGET_NODE_INCARNATION,
+          targetNodeHistoryId: initialHistoryId,
         }),
-      ).rejects.toThrow("ambiguous multi-incarnation history");
-
-      const [node] = await dbWrite
-        .select()
-        .from(dockerNodes)
-        .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
+      ).rejects.toThrow("node occurrence changed");
       const [operation] = await dbWrite
         .select()
         .from(agentBackupRestoreOperations)
         .where(eq(agentBackupRestoreOperations.id, authority.operationId));
-      expect(node?.allocated_count).toBe(0);
-      expect(operation?.expected_node_record_id).toBeNull();
-      expect(operation?.expected_node_incarnation).toBeNull();
-      expect(operation?.expected_image_digest).toBeNull();
+      expect(operation?.expected_node_history_id).toBeNull();
+
+      const reserved = await reserveAgentBackupRestoreTarget({
+        ...authority,
+        ownerId: "restore-worker",
+        targetNodeRecordId: TARGET_NODE_RECORD_ID,
+        targetNodeIncarnation: TARGET_NODE_INCARNATION,
+        targetNodeHistoryId: currentHistoryId,
+      });
+      expect(reserved.target.nodeHistoryId).toBe(currentHistoryId);
     },
     TIMEOUT,
   );
 
   test(
-    "rejects a B inserted after A even when B is backdated before reservation",
+    "ignores unrelated old histories when the exact current occurrence still matches",
     async () => {
-      await seedTargetNode();
+      const node = await seedTargetNode();
       const authority = await openAndClaim();
       await dbWrite.insert(agentNodeIncarnationHistories).values({
         docker_node_record_id: TARGET_NODE_RECORD_ID,
@@ -743,99 +762,55 @@ describe("restore operation spine", () => {
         infrastructure_provider: "hetzner",
         provider_server_id: null,
         host_key_fingerprint: "SHA256:test-only-host-key",
-        attested_at: new Date(TARGET_NODE_ATTESTED_AT.getTime() - 60_000),
+        attested_at: new Date("2000-01-01T00:00:00.000Z"),
       });
-
-      await expect(
-        reserveAgentBackupRestoreTarget({
-          ...authority,
-          ownerId: "restore-worker",
-          targetNodeRecordId: TARGET_NODE_RECORD_ID,
-          targetNodeIncarnation: TARGET_NODE_INCARNATION,
-        }),
-      ).rejects.toThrow("ambiguous multi-incarnation history");
-      const [node] = await dbWrite.select().from(dockerNodes);
-      expect(node?.allocated_count).toBe(0);
+      if (!node.current_node_history_id) throw new Error("initial occurrence is missing");
+      const reserved = await reserveAgentBackupRestoreTarget({
+        ...authority,
+        ownerId: "restore-worker",
+        targetNodeRecordId: TARGET_NODE_RECORD_ID,
+        targetNodeIncarnation: TARGET_NODE_INCARNATION,
+        targetNodeHistoryId: node.current_node_history_id,
+      });
+      expect(reserved.target.nodeHistoryId).toBe(node.current_node_history_id);
     },
     TIMEOUT,
   );
 
   test(
-    "fails closed when an older B history predates the current A history",
+    "rejects a stale token after exact-id delete and reinsert",
     async () => {
-      await seedTargetNode();
+      const original = await seedTargetNode();
       const authority = await openAndClaim();
-      await dbWrite.delete(agentNodeIncarnationHistories);
-      await dbWrite.insert(agentNodeIncarnationHistories).values({
-        docker_node_record_id: TARGET_NODE_RECORD_ID,
-        node_id: "restore-target-a",
-        node_incarnation: OTHER_NODE_INCARNATION,
-        fleet_kind: "robot",
-        infrastructure_provider: "hetzner",
-        provider_server_id: null,
-        host_key_fingerprint: "SHA256:test-only-host-key",
-        attested_at: new Date(TARGET_NODE_ATTESTED_AT.getTime() - 60_000),
-      });
-      await dbWrite.insert(agentNodeIncarnationHistories).values({
-        docker_node_record_id: TARGET_NODE_RECORD_ID,
-        node_id: "restore-target-a",
-        node_incarnation: TARGET_NODE_INCARNATION,
-        fleet_kind: "robot",
-        infrastructure_provider: "hetzner",
-        provider_server_id: null,
-        host_key_fingerprint: "SHA256:test-only-host-key",
-        attested_at: TARGET_NODE_ATTESTED_AT,
-      });
-
-      await expect(
-        reserveAgentBackupRestoreTarget({
-          ...authority,
-          ownerId: "restore-worker",
-          targetNodeRecordId: TARGET_NODE_RECORD_ID,
-          targetNodeIncarnation: TARGET_NODE_INCARNATION,
-        }),
-      ).rejects.toThrow("ambiguous multi-incarnation history");
-      const [node] = await dbWrite.select().from(dockerNodes);
-      expect(node?.allocated_count).toBe(0);
-    },
-    TIMEOUT,
-  );
-
-  test(
-    "rejects a fresh-created exact node delete/reinsert as defense in depth",
-    async () => {
-      await seedTargetNode();
-      const authority = await openAndClaim();
+      if (!original.current_node_history_id) throw new Error("initial occurrence is missing");
       await dbWrite.delete(dockerNodes).where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
-      await seedTargetNode({
-        createdAt: new Date(TARGET_NODE_ATTESTED_AT.getTime() + 1_000),
-        recordHistory: false,
-      });
-
+      const replacement = await seedTargetNode();
+      expect(replacement.current_node_history_id).not.toBe(original.current_node_history_id);
       await expect(
         reserveAgentBackupRestoreTarget({
           ...authority,
           ownerId: "restore-worker",
           targetNodeRecordId: TARGET_NODE_RECORD_ID,
           targetNodeIncarnation: TARGET_NODE_INCARNATION,
+          targetNodeHistoryId: original.current_node_history_id,
         }),
-      ).rejects.toThrow("lacks exact immutable node-incarnation history");
-      const [node] = await dbWrite.select().from(dockerNodes);
-      expect(node?.allocated_count).toBe(0);
+      ).rejects.toThrow("node occurrence changed");
     },
     TIMEOUT,
   );
 
   test(
-    "fails while incarnation is NULL and accepts exact host-key CAS re-attestation",
+    "mints a new occurrence for NULL-to-A re-attestation and rejects the old token",
     async () => {
-      await seedTargetNode();
+      const original = await seedTargetNode();
       const authority = await openAndClaim();
+      if (!original.current_node_history_id) throw new Error("initial occurrence is missing");
       const request = {
         ...authority,
         ownerId: "restore-worker",
         targetNodeRecordId: TARGET_NODE_RECORD_ID,
         targetNodeIncarnation: TARGET_NODE_INCARNATION,
+        targetNodeHistoryId: original.current_node_history_id,
       } as const;
       await dockerNodesRepository.invalidateNodeIncarnation({
         id: TARGET_NODE_RECORD_ID,
@@ -855,9 +830,18 @@ describe("restore operation spine", () => {
         observedIncarnation: TARGET_NODE_INCARNATION,
       });
       expect(reattested.id).toBe(TARGET_NODE_RECORD_ID);
-      const reserved = await reserveAgentBackupRestoreTarget(request);
+      if (!reattested.current_node_history_id) throw new Error("re-attested occurrence is missing");
+      expect(reattested.current_node_history_id).not.toBe(original.current_node_history_id);
+      await expect(reserveAgentBackupRestoreTarget(request)).rejects.toThrow(
+        "node occurrence changed",
+      );
+      const reserved = await reserveAgentBackupRestoreTarget({
+        ...request,
+        targetNodeHistoryId: reattested.current_node_history_id,
+      });
       expect(reserved.replayed).toBe(false);
       expect(reserved.target.nodeIncarnation).toBe(TARGET_NODE_INCARNATION);
+      expect(reserved.target.nodeHistoryId).toBe(reattested.current_node_history_id);
     },
     TIMEOUT,
   );
@@ -973,7 +957,7 @@ describe("restore operation spine", () => {
       ".from(agentBackupRestoreOperations)",
       ".from(agentBackupRestoreLeases)",
       ".from(dockerNodes)",
-      "proveUnambiguousAgentNodeIncarnationForLockedNode(",
+      "proveExactAgentNodeOccurrenceForLockedNode(",
       "lockAgentBackupCatalogAuthority(",
       "readPostLockDatabaseNow(",
     ]);
@@ -1082,6 +1066,20 @@ describe("restore operation spine", () => {
         .where(eq(agentBackupRestoreOperations.id, operation.id));
       expect(stillReserved?.phase).toBe("reserved");
       expect(stillReserved?.expected_node_record_id).toBeNull();
+      expect(stillReserved?.expected_node_history_id).toBeNull();
+      let containerOnlyError: unknown;
+      try {
+        await dbWrite
+          .update(agentBackupRestoreOperations)
+          .set({ expected_container_id: CONTAINER })
+          .where(eq(agentBackupRestoreOperations.id, operation.id))
+          .execute();
+      } catch (error) {
+        containerOnlyError = error;
+      }
+      expect((containerOnlyError as { cause?: { constraint?: string } }).cause?.constraint).toBe(
+        "agent_backup_restore_operations_expected_shape_check",
+      );
 
       await reserveAgentBackupRestoreTarget({
         operationId: operation.id,

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-quarantine.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-quarantine.pglite.test.ts
@@ -22,6 +22,7 @@ process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
 
 import { pushSchema } from "drizzle-kit/api";
 import { eq, sql } from "drizzle-orm";
+import { installAgentNodeOccurrenceTriggerForTests } from "../../agent-node-occurrence-test-support";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
 import {
   agentBackupCatalogAuthorities,
@@ -203,7 +204,7 @@ function expectCanonicalQuarantineLockOrder(body: string): void {
     ".from(agentBackupRestoreLeases)",
     ".from(agentSandboxes)",
     ".from(dockerNodes)",
-    "proveUnambiguousAgentNodeIncarnationForLockedNode(",
+    "proveExactAgentNodeOccurrenceForLockedNode(",
     "lockAgentBackupCatalogAuthority(",
     "readPostLockDatabaseNow(tx)",
   ];
@@ -255,21 +256,27 @@ async function seedFixture(): Promise<void> {
     steward_user_id: "restore-quarantine-user",
     organization_id: ORG_ID,
   });
-  await dbWrite.insert(dockerNodes).values({
-    id: TARGET_NODE_RECORD_ID,
-    node_id: "restore-target",
-    hostname: "restore-target.invalid",
-    capacity: 2,
-    allocated_count: 0,
-    enabled: true,
-    placement_state: "open",
-    status: "healthy",
-    host_key_fingerprint: "SHA256:test-only-target",
-    fleet_kind: "robot",
-    infrastructure_provider: "hetzner",
-    provider_server_id: null,
-    node_incarnation: TARGET_NODE_INCARNATION,
-  });
+  const [targetNode] = await dbWrite
+    .insert(dockerNodes)
+    .values({
+      id: TARGET_NODE_RECORD_ID,
+      node_id: "restore-target",
+      hostname: "restore-target.invalid",
+      capacity: 2,
+      allocated_count: 0,
+      enabled: true,
+      placement_state: "open",
+      status: "healthy",
+      host_key_fingerprint: "SHA256:test-only-target",
+      fleet_kind: "robot",
+      infrastructure_provider: "hetzner",
+      provider_server_id: null,
+      node_incarnation: TARGET_NODE_INCARNATION,
+    })
+    .returning();
+  if (!targetNode?.current_node_history_id) {
+    throw new Error("restore target occurrence trigger did not assign a history id");
+  }
   const publishedAt = new Date("2026-08-20T08:00:00.000Z");
   const dispatchedAt = new Date("2026-08-20T08:00:01.000Z");
   const completedAt = new Date("2026-08-20T08:00:02.000Z");
@@ -399,6 +406,7 @@ async function seedFixture(): Promise<void> {
     claimGeneration: claimed.claimGeneration,
     targetNodeRecordId: TARGET_NODE_RECORD_ID,
     targetNodeIncarnation: TARGET_NODE_INCARNATION,
+    targetNodeHistoryId: targetNode.current_node_history_id,
   });
   operationId = opened.operation.id;
   initialClaimGeneration = claimed.claimGeneration;
@@ -457,6 +465,9 @@ beforeAll(async () => {
       dbWrite as never,
     );
     await apply();
+    await installAgentNodeOccurrenceTriggerForTests((statement) =>
+      dbWrite.execute(sql.raw(statement)),
+    );
     // pushSchema creates the shape, while deployed databases also have the
     // lifecycle trigger. Install that authority so the CAS is tested honestly.
     await dbWrite.execute(
@@ -477,33 +488,6 @@ beforeAll(async () => {
       FOR EACH ROW EXECUTE FUNCTION test_advance_agent_sandbox_lifecycle_revision()
     `),
     );
-    await dbWrite.execute(
-      sql.raw(`
-      CREATE OR REPLACE FUNCTION test_journal_node_incarnation()
-      RETURNS trigger LANGUAGE plpgsql AS $$
-      BEGIN
-        IF NEW.node_incarnation IS NULL THEN RETURN NEW; END IF;
-        INSERT INTO agent_node_incarnation_histories (
-          docker_node_record_id, node_id, node_incarnation, fleet_kind,
-          infrastructure_provider, provider_server_id, host_key_fingerprint, attested_at
-        ) VALUES (
-          NEW.id, NEW.node_id, NEW.node_incarnation, NEW.fleet_kind,
-          NEW.infrastructure_provider, NEW.provider_server_id, NEW.host_key_fingerprint,
-          clock_timestamp()
-        ) ON CONFLICT (docker_node_record_id, node_incarnation) DO NOTHING;
-        RETURN NEW;
-      END;
-      $$
-    `),
-    );
-    await dbWrite.execute(
-      sql.raw(`
-      CREATE TRIGGER test_docker_nodes_incarnation_history
-      BEFORE INSERT OR UPDATE OF node_id, node_incarnation, fleet_kind,
-        infrastructure_provider, provider_server_id, host_key_fingerprint
-      ON docker_nodes FOR EACH ROW EXECUTE FUNCTION test_journal_node_incarnation()
-    `),
-    );
   } catch (error) {
     schemaFailure = error instanceof Error ? error.message : String(error);
   }
@@ -515,8 +499,8 @@ beforeEach(async () => {
   await dbWrite.delete(agentBackupRestoreLeases);
   await dbWrite.delete(agentSandboxBackups);
   await dbWrite.delete(agentSandboxes);
-  await dbWrite.delete(agentNodeIncarnationHistories);
   await dbWrite.delete(dockerNodes);
+  await dbWrite.delete(agentNodeIncarnationHistories);
   await dbWrite.delete(agentBackupCatalogAuthorities);
   await dbWrite.delete(userCharacters);
   await dbWrite.delete(users);
@@ -589,6 +573,7 @@ describe("restore activation quarantine", () => {
       });
       expect(operation.phase).toBe("reserved");
       expect(operation.claim_generation).toBe(initialClaimGeneration);
+      expect(operation.expected_node_history_id).toBe(node.current_node_history_id);
       expect(node.allocated_count).toBe(1);
     },
     TIMEOUT,
@@ -688,7 +673,7 @@ describe("restore activation quarantine", () => {
         .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
       expect((await readRows()).node.node_incarnation).toBe(TARGET_NODE_INCARNATION);
       await expect(openAgentBackupRestoreQuarantine(openInput())).rejects.toThrow(
-        "ambiguous multi-incarnation history",
+        "target node occurrence changed",
       );
       const after = await readRows();
       expect(after.sandbox.activation_generation).toBe(PREVIOUS_ACTIVATION_GENERATION);
@@ -699,7 +684,7 @@ describe("restore activation quarantine", () => {
   );
 
   test(
-    "rejects an ancient backdated B history before the first quarantine write",
+    "ignores an unrelated ancient history when the exact current occurrence still matches",
     async () => {
       const [history] = await dbWrite
         .select()
@@ -717,11 +702,10 @@ describe("restore activation quarantine", () => {
         attested_at: new Date("2000-01-01T00:00:00.000Z"),
       });
 
-      await expect(openAgentBackupRestoreQuarantine(openInput())).rejects.toThrow(
-        "ambiguous multi-incarnation history",
-      );
+      const result = await openAgentBackupRestoreQuarantine(openInput());
+      expect(result.replayed).toBe(false);
       const after = await readRows();
-      expect(after.sandbox.activation_generation).toBe(PREVIOUS_ACTIVATION_GENERATION);
+      expect(after.sandbox.activation_generation).toBe(RESTORE_ATTEMPT_ID);
       expect(after.operation.phase).toBe("reserved");
       expect(after.operation.expected_container_id).toBeNull();
     },
@@ -871,7 +855,7 @@ describe("restore activation quarantine", () => {
   );
 
   test(
-    "rejects container recording after node loss without partial phase writes",
+    "rejects container recording after target occurrence loss without partial phase writes",
     async () => {
       const claimGeneration = await openAndClaimVaultSeeded();
       const request = {
@@ -886,7 +870,7 @@ describe("restore activation quarantine", () => {
         .set({ node_incarnation: OTHER_NODE_INCARNATION })
         .where(eq(dockerNodes.id, TARGET_NODE_RECORD_ID));
       await expect(recordAgentBackupRestoreQuarantinedContainer(request)).rejects.toThrow(
-        "node incarnation changed",
+        "target node occurrence changed",
       );
       const after = await readRows();
       expect(after.sandbox.activation_phase).toBe("container_pending");

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-scheduler.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-scheduler.pglite.test.ts
@@ -10,8 +10,10 @@ process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
 process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
 
+import { installAgentNodeOccurrenceTriggerForTests } from "../../agent-node-occurrence-test-support";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
 import { agentBackupCatalogAuthorities } from "../../schemas/agent-backup-catalog";
+import { agentNodeIncarnationHistories } from "../../schemas/agent-node-incarnation-histories";
 import { agentSandboxBackups, agentSandboxes } from "../../schemas/agent-sandboxes";
 import { dockerNodes } from "../../schemas/docker-nodes";
 import { organizations } from "../../schemas/organizations";
@@ -149,6 +151,7 @@ beforeAll(async () => {
         organizations,
         users,
         userCharacters,
+        agentNodeIncarnationHistories,
         dockerNodes,
         agentSandboxes,
         agentSandboxBackups,
@@ -157,6 +160,9 @@ beforeAll(async () => {
       dbWrite as never,
     );
     await apply();
+    await installAgentNodeOccurrenceTriggerForTests((statement) =>
+      dbWrite.execute(sql.raw(statement)),
+    );
     for (const migration of [
       "../../migrations/0189_agent_sandbox_lifecycle_revision_scope.sql",
       "../../migrations/0235_agent_backup_rpo_scheduler.sql",
@@ -177,6 +183,7 @@ beforeEach(async () => {
   await dbWrite.delete(agentBackupCatalogAuthorities);
   await dbWrite.delete(agentSandboxes);
   await dbWrite.delete(dockerNodes);
+  await dbWrite.delete(agentNodeIncarnationHistories);
   await dbWrite.delete(userCharacters);
   await dbWrite.delete(users);
   await dbWrite.delete(organizations);

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-source-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-source-authority.pglite.test.ts
@@ -8,7 +8,9 @@ process.env.MOCK_REDIS = "1";
 process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
 
 import { pushSchema } from "drizzle-kit/api";
+import { installAgentNodeOccurrenceTriggerForTests } from "../../agent-node-occurrence-test-support";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
+import { agentNodeIncarnationHistories } from "../../schemas/agent-node-incarnation-histories";
 import { dockerNodes } from "../../schemas/docker-nodes";
 import {
   AgentBackupSourceAuthorityError,
@@ -42,8 +44,12 @@ function registration(hostname = "robot.example.test") {
 
 beforeAll(async () => {
   try {
-    const { apply } = await pushSchema({ dockerNodes } as never, dbWrite as never);
+    const { apply } = await pushSchema(
+      { agentNodeIncarnationHistories, dockerNodes } as never,
+      dbWrite as never,
+    );
     await apply();
+    await installAgentNodeOccurrenceTriggerForTests((statement) => dbWrite.execute(statement));
   } catch (error) {
     schemaFailure = error instanceof Error ? error.message : String(error);
   }
@@ -52,6 +58,7 @@ beforeAll(async () => {
 beforeEach(async () => {
   expect(schemaFailure).toBe("");
   await dbWrite.delete(dockerNodes);
+  await dbWrite.delete(agentNodeIncarnationHistories);
 });
 
 afterAll(async () => {

--- a/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/warm-pool-stranded-readiness.test.ts
@@ -6,6 +6,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { pushSchema } from "drizzle-kit/api";
 import { eq, sql } from "drizzle-orm";
+import { agentNodeIncarnationHistories } from "../../schemas/agent-node-incarnation-histories";
 import { agentSandboxes, WARM_POOL_ORG_ID, WARM_POOL_USER_ID } from "../../schemas/agent-sandboxes";
 import { apiKeys } from "../../schemas/api-keys";
 import { dockerNodes } from "../../schemas/docker-nodes";
@@ -52,6 +53,7 @@ beforeAll(async () => {
     users,
     userCharacters,
     agentSandboxes,
+    agentNodeIncarnationHistories,
     dockerNodes,
     apiKeys,
     usageRecords,

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-history.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-history.ts
@@ -1,6 +1,6 @@
 /** Appends and replays immutable restore authorities without wiring a production coordinator. */
 
-import { and, eq, inArray, ne } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import {
   assertAgentBackupCatalogTransition,
   requireBoundedIdentity,
@@ -10,8 +10,10 @@ import { isValidUUID } from "../../lib/utils/validation";
 import type { DbTransaction } from "../client";
 import { dbWrite } from "../helpers";
 import {
+  type AgentBackupRestoreOperation,
   agentBackupCatalogAuthorities,
   agentBackupRestoreLeases,
+  agentBackupRestoreOperations,
 } from "../schemas/agent-backup-catalog";
 import {
   type AgentActivationPublication,
@@ -26,14 +28,17 @@ import {
 import { agentSandboxBackups, agentSandboxes } from "../schemas/agent-sandboxes";
 import { agentVaultKeyBackupBindings } from "../schemas/agent-vault-key-authority";
 import { type DockerNode, dockerNodes } from "../schemas/docker-nodes";
-import { AgentBackupCatalogConflictError } from "./agent-backup-catalog";
+import {
+  AgentBackupCatalogConflictError,
+  lockAgentBackupCatalogAuthority,
+} from "./agent-backup-catalog";
 import { readPostLockDatabaseNow } from "./primary-database-clock";
 
 const MAX_SIGNED_BIGINT = 9_223_372_036_854_775_807n;
 
 function requireUuid(value: string, field: string): string {
   if (!isValidUUID(value) || value !== value.toLowerCase()) {
-    throw new Error(`${field} must be a canonical lowercase UUID`);
+    throw new AgentBackupCatalogConflictError(`${field} must be a canonical lowercase UUID`);
   }
   return value;
 }
@@ -42,38 +47,92 @@ function conflict(message: string): never {
   throw new AgentBackupCatalogConflictError(message);
 }
 
+interface ExactRestoreOperationTarget {
+  organizationId: string;
+  agentId: string;
+  backupId: string;
+  restoreAttemptId: string;
+  targetActivationGeneration: string;
+  expectedOperationId: string;
+  expectedManifestSha256: string;
+  expectedSourceActivationGeneration: string;
+  expectedSourceLifecycleRevision: bigint;
+  expectedNodeRecordId: string;
+  expectedNodeIncarnation: string;
+  expectedNodeHistoryId: string;
+}
+
+/** Lock and prove the write-once target selected for one restore attempt. */
+async function lockExactRestoreOperationTarget(
+  tx: DbTransaction,
+  target: Readonly<ExactRestoreOperationTarget>,
+): Promise<AgentBackupRestoreOperation> {
+  const [operation] = await tx
+    .select()
+    .from(agentBackupRestoreOperations)
+    .where(
+      and(
+        eq(agentBackupRestoreOperations.organization_id, target.organizationId),
+        eq(agentBackupRestoreOperations.restore_attempt_id, target.restoreAttemptId),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  if (
+    !operation ||
+    target.targetActivationGeneration !== target.restoreAttemptId ||
+    operation.agent_id !== target.agentId ||
+    operation.backup_id !== target.backupId ||
+    operation.expected_operation_id !== target.expectedOperationId ||
+    operation.expected_manifest_sha256 !== target.expectedManifestSha256 ||
+    operation.expected_activation_generation !== target.expectedSourceActivationGeneration ||
+    operation.expected_lifecycle_revision !== target.expectedSourceLifecycleRevision ||
+    operation.expected_node_record_id !== target.expectedNodeRecordId ||
+    operation.expected_node_incarnation !== target.expectedNodeIncarnation ||
+    operation.expected_node_history_id !== target.expectedNodeHistoryId
+  ) {
+    conflict("Restore writer differs from its durable operation target");
+  }
+  return operation;
+}
+
+function operationMatchesRuntimeTarget(
+  operation: Readonly<AgentBackupRestoreOperation>,
+  containerId: string,
+  imageDigest: string,
+): boolean {
+  return (
+    operation.expected_container_id === containerId &&
+    operation.expected_image_digest === imageDigest
+  );
+}
+
 /**
  * Prove that an already row-locked mutable node still names one exact,
- * unambiguous append-only boot authority for that record.
+ * append-only occurrence authority for that record and boot.
  *
  * The history reads deliberately stay MVCC reads. The caller owns the node's
  * `FOR UPDATE` lock, so no concurrent attestation can change that node while
  * this proof runs; locking append-only history rows would only add an
- * unnecessary lock class. This schema has no durable causal ordinal for
- * histories, so timestamps or transaction ids cannot safely distinguish an
- * old B -> A from an A -> B -> A replay. Restore therefore fails closed when
- * this node record has ever carried any different incarnation. Such a record
- * remains ineligible until a lifecycle/re-creation contract with durable row
- * generations is migrated.
- *
- * A -> NULL -> A is intentionally not an A -> B -> A replay: while NULL, the
- * mutable row fails this proof; an exact CAS re-attestation of the same Linux
- * boot UUID under the same host-key authority may reuse its immutable A row.
- * The created-at check catches ordinary exact-id delete/reinsert accidents, but
- * it is only defense in depth and is never used to order immutable histories.
+ * unnecessary lock class. The trigger-owned pointer is the causal ordinal:
+ * A1 -> B -> A2 has two different history ids even though the Linux boot UUID
+ * is A both times. No timestamp, transaction id, or scan of unrelated older
+ * histories participates in the decision.
  */
-export async function proveUnambiguousAgentNodeIncarnationForLockedNode(
+export async function proveExactAgentNodeOccurrenceForLockedNode(
   tx: DbTransaction,
   node: Readonly<DockerNode>,
   expectedIncarnation: string,
-): Promise<void> {
+  expectedNodeHistoryId: string,
+): Promise<AgentNodeIncarnationHistory> {
   if (
     node.node_incarnation !== expectedIncarnation ||
+    node.current_node_history_id !== expectedNodeHistoryId ||
     (node.fleet_kind !== "robot" && node.fleet_kind !== "cloud") ||
     node.infrastructure_provider !== "hetzner" ||
     !node.host_key_fingerprint
   ) {
-    conflict("Restore target lacks exact immutable node-incarnation history");
+    conflict("Restore target lacks exact current node-occurrence authority");
   }
 
   const [history] = await tx
@@ -81,6 +140,7 @@ export async function proveUnambiguousAgentNodeIncarnationForLockedNode(
     .from(agentNodeIncarnationHistories)
     .where(
       and(
+        eq(agentNodeIncarnationHistories.id, expectedNodeHistoryId),
         eq(agentNodeIncarnationHistories.docker_node_record_id, node.id),
         eq(agentNodeIncarnationHistories.node_incarnation, expectedIncarnation),
       ),
@@ -94,30 +154,21 @@ export async function proveUnambiguousAgentNodeIncarnationForLockedNode(
     history.fleet_kind !== node.fleet_kind ||
     history.infrastructure_provider !== node.infrastructure_provider ||
     history.provider_server_id !== node.provider_server_id ||
-    history.host_key_fingerprint !== node.host_key_fingerprint ||
-    node.created_at > history.attested_at
+    history.host_key_fingerprint !== node.host_key_fingerprint
   ) {
-    conflict("Restore target lacks exact immutable node-incarnation history");
+    conflict("Restore target lacks exact current node-occurrence authority");
   }
-
-  const [differentIncarnation] = await tx
-    .select({ id: agentNodeIncarnationHistories.id })
-    .from(agentNodeIncarnationHistories)
-    .where(
-      and(
-        eq(agentNodeIncarnationHistories.docker_node_record_id, node.id),
-        ne(agentNodeIncarnationHistories.node_incarnation, expectedIncarnation),
-      ),
-    )
-    .limit(1);
-  if (differentIncarnation) {
-    conflict("Restore target node record has ambiguous multi-incarnation history");
-  }
+  return history;
 }
 
 async function lockCurrentNodeHistory(
   tx: DbTransaction,
-  input: { nodeRecordId: string; nodeId?: string; nodeIncarnation: string },
+  input: {
+    nodeRecordId: string;
+    nodeId?: string;
+    nodeIncarnation: string;
+    nodeHistoryId: string;
+  },
 ): Promise<AgentNodeIncarnationHistory> {
   const [node] = await tx
     .select()
@@ -127,6 +178,7 @@ async function lockCurrentNodeHistory(
         eq(dockerNodes.id, input.nodeRecordId),
         input.nodeId ? eq(dockerNodes.node_id, input.nodeId) : undefined,
         eq(dockerNodes.node_incarnation, input.nodeIncarnation),
+        eq(dockerNodes.current_node_history_id, input.nodeHistoryId),
       ),
     )
     .for("update")
@@ -137,51 +189,14 @@ async function lockCurrentNodeHistory(
     !node.host_key_fingerprint ||
     node.infrastructure_provider !== "hetzner"
   ) {
-    conflict("Target node incarnation is absent or lacks typed immutable authority");
+    conflict("Restore target lacks exact current node-occurrence authority");
   }
-  await tx
-    .insert(agentNodeIncarnationHistories)
-    .values({
-      docker_node_record_id: node.id,
-      node_id: node.node_id,
-      node_incarnation: input.nodeIncarnation,
-      fleet_kind: node.fleet_kind,
-      infrastructure_provider: node.infrastructure_provider,
-      provider_server_id: node.provider_server_id,
-      host_key_fingerprint: node.host_key_fingerprint,
-    })
-    .onConflictDoNothing({
-      target: [
-        agentNodeIncarnationHistories.docker_node_record_id,
-        agentNodeIncarnationHistories.node_incarnation,
-      ],
-    });
-  // Read back on the same composite key the insert arbitrates on. A boot id is
-  // unique per node record, not globally (0259), so selecting on the incarnation
-  // alone would pick an arbitrary record's row once a host re-registers.
-  const [history] = await tx
-    .select()
-    .from(agentNodeIncarnationHistories)
-    .where(
-      and(
-        eq(agentNodeIncarnationHistories.docker_node_record_id, node.id),
-        eq(agentNodeIncarnationHistories.node_incarnation, input.nodeIncarnation),
-      ),
-    )
-    .limit(1);
-  if (
-    !history ||
-    history.docker_node_record_id !== node.id ||
-    history.node_id !== node.node_id ||
-    history.fleet_kind !== node.fleet_kind ||
-    history.infrastructure_provider !== node.infrastructure_provider ||
-    history.provider_server_id !== node.provider_server_id ||
-    history.host_key_fingerprint !== node.host_key_fingerprint
-  ) {
-    conflict("Target node incarnation conflicts with immutable history");
-  }
-  await proveUnambiguousAgentNodeIncarnationForLockedNode(tx, node, input.nodeIncarnation);
-  return history;
+  return proveExactAgentNodeOccurrenceForLockedNode(
+    tx,
+    node,
+    input.nodeIncarnation,
+    input.nodeHistoryId,
+  );
 }
 
 export interface RecordAgentActivationPublicationInput {
@@ -193,6 +208,7 @@ export interface RecordAgentActivationPublicationInput {
   expectedContainerId: string;
   expectedNodeRecordId: string;
   expectedNodeIncarnation: string;
+  expectedNodeHistoryId: string;
   expectedTokenSha256: string;
 }
 
@@ -203,6 +219,7 @@ function validatePublicationInput(input: RecordAgentActivationPublicationInput):
   requireUuid(input.activationGeneration, "activationGeneration");
   requireUuid(input.expectedNodeRecordId, "expectedNodeRecordId");
   requireUuid(input.expectedNodeIncarnation, "expectedNodeIncarnation");
+  requireUuid(input.expectedNodeHistoryId, "expectedNodeHistoryId");
   requireSha256Hex(input.expectedActivationReceiptSha256, "expectedActivationReceiptSha256");
   requireSha256Hex(input.expectedTokenSha256, "expectedTokenSha256");
   if (!/^[0-9a-f]{64}$/.test(input.expectedContainerId)) {
@@ -223,8 +240,186 @@ function publicationMatchesInput(
     publication.container_id === input.expectedContainerId &&
     publication.docker_node_record_id === input.expectedNodeRecordId &&
     publication.node_incarnation === input.expectedNodeIncarnation &&
+    publication.node_history_id === input.expectedNodeHistoryId &&
     publication.token_sha256 === input.expectedTokenSha256
   );
+}
+
+async function recordRestoreActivationPublication(
+  tx: DbTransaction,
+  input: Readonly<RecordAgentActivationPublicationInput>,
+  authority: Readonly<{ backupId: string; manifestSha256: string; imageDigest: string }>,
+): Promise<{ publication: AgentActivationPublication; replayed: boolean }> {
+  const [backup] = await tx
+    .select()
+    .from(agentSandboxBackups)
+    .where(
+      and(
+        eq(agentSandboxBackups.id, authority.backupId),
+        eq(agentSandboxBackups.catalog_organization_id, input.organizationId),
+        eq(agentSandboxBackups.catalog_agent_id, input.agentId),
+        eq(agentSandboxBackups.manifest_digest, authority.manifestSha256),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  if (
+    !backup?.backup_operation_id ||
+    !backup.lifecycle_generation ||
+    backup.lifecycle_revision === null ||
+    !backup.manifest_digest ||
+    !["protected", "retained", "restore_verified"].includes(backup.catalog_state ?? "")
+  ) {
+    conflict("Restore publication source lacks exact restorable backup authority");
+  }
+
+  const operation = await lockExactRestoreOperationTarget(tx, {
+    organizationId: input.organizationId,
+    agentId: input.agentId,
+    backupId: backup.id,
+    restoreAttemptId: input.activationGeneration,
+    targetActivationGeneration: input.activationGeneration,
+    expectedOperationId: backup.backup_operation_id,
+    expectedManifestSha256: backup.manifest_digest,
+    expectedSourceActivationGeneration: backup.lifecycle_generation,
+    expectedSourceLifecycleRevision: backup.lifecycle_revision,
+    expectedNodeRecordId: input.expectedNodeRecordId,
+    expectedNodeIncarnation: input.expectedNodeIncarnation,
+    expectedNodeHistoryId: input.expectedNodeHistoryId,
+  });
+  if (!operationMatchesRuntimeTarget(operation, input.expectedContainerId, authority.imageDigest)) {
+    conflict("Restore publication differs from its durable operation target");
+  }
+
+  const [lease] = await tx
+    .select()
+    .from(agentBackupRestoreLeases)
+    .where(
+      and(
+        eq(agentBackupRestoreLeases.id, operation.lease_id),
+        eq(agentBackupRestoreLeases.organization_id, operation.organization_id),
+        eq(agentBackupRestoreLeases.agent_id, operation.agent_id),
+        eq(agentBackupRestoreLeases.backup_id, operation.backup_id),
+        eq(agentBackupRestoreLeases.restore_attempt_id, operation.restore_attempt_id),
+        eq(agentBackupRestoreLeases.owner_id, operation.lease_owner_id),
+        eq(agentBackupRestoreLeases.generation, operation.lease_generation),
+        eq(agentBackupRestoreLeases.catalog_epoch, operation.catalog_epoch),
+        eq(agentBackupRestoreLeases.copy_role, operation.copy_role),
+        eq(agentBackupRestoreLeases.operation_id, operation.expected_operation_id),
+        eq(
+          agentBackupRestoreLeases.activation_generation,
+          operation.expected_activation_generation,
+        ),
+        eq(agentBackupRestoreLeases.lifecycle_revision, operation.expected_lifecycle_revision),
+        eq(agentBackupRestoreLeases.expected_manifest_sha256, operation.expected_manifest_sha256),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  if (!lease) conflict("Restore publication lost its exact lease authority");
+
+  const [sandbox] = await tx
+    .select()
+    .from(agentSandboxes)
+    .where(
+      and(
+        eq(agentSandboxes.id, input.agentId),
+        eq(agentSandboxes.organization_id, input.organizationId),
+        eq(agentSandboxes.activation_generation, input.activationGeneration),
+        inArray(agentSandboxes.activation_phase, ["restart_attested", "active"]),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  const [concurrentPublication] = await tx
+    .select()
+    .from(agentActivationPublications)
+    .where(
+      and(
+        eq(agentActivationPublications.organization_id, input.organizationId),
+        eq(agentActivationPublications.agent_id, input.agentId),
+        eq(agentActivationPublications.activation_generation, input.activationGeneration),
+      ),
+    )
+    .limit(1);
+  if (concurrentPublication && !publicationMatchesInput(concurrentPublication, input)) {
+    conflict("Activation publication replay mismatch");
+  }
+  if (
+    !sandbox?.activation_receipt ||
+    !sandbox.activation_receipt_hash ||
+    !sandbox.activation_container_id ||
+    !sandbox.activation_node_id ||
+    !sandbox.activation_boot_id ||
+    !sandbox.activation_image_digest ||
+    !sandbox.activation_token_hash ||
+    sandbox.activation_funding_revision === null ||
+    sandbox.activation_lifecycle_revision === null ||
+    sandbox.activation_purpose !== "restore" ||
+    sandbox.activation_backup_id !== backup.id ||
+    sandbox.activation_backup_hash !== backup.manifest_digest ||
+    sandbox.activation_receipt_hash !== input.expectedActivationReceiptSha256 ||
+    sandbox.activation_container_id !== input.expectedContainerId ||
+    sandbox.activation_boot_id !== input.expectedNodeIncarnation ||
+    sandbox.activation_token_hash !== input.expectedTokenSha256 ||
+    !operationMatchesRuntimeTarget(
+      operation,
+      sandbox.activation_container_id,
+      sandbox.activation_image_digest,
+    )
+  ) {
+    conflict("Restore publication differs from mutable or durable operation authority");
+  }
+
+  const history = await lockCurrentNodeHistory(tx, {
+    nodeRecordId: input.expectedNodeRecordId,
+    nodeId: sandbox.activation_node_id,
+    nodeIncarnation: input.expectedNodeIncarnation,
+    nodeHistoryId: input.expectedNodeHistoryId,
+  });
+  const catalogAuthority = await lockAgentBackupCatalogAuthority(
+    tx,
+    input.organizationId,
+    input.agentId,
+  );
+  const databaseNow = await readPostLockDatabaseNow(tx);
+  if (
+    lease.released_at !== null ||
+    lease.expires_at <= databaseNow ||
+    lease.catalog_epoch !== catalogAuthority.catalog_revision
+  ) {
+    conflict("Restore publication lost its exact live restore lease");
+  }
+  if (concurrentPublication) {
+    return { publication: concurrentPublication, replayed: true };
+  }
+
+  const [publication] = await tx
+    .insert(agentActivationPublications)
+    .values({
+      id: input.publicationId,
+      organization_id: input.organizationId,
+      agent_id: input.agentId,
+      activation_generation: input.activationGeneration,
+      previous_activation_generation: sandbox.activation_previous_generation,
+      lifecycle_revision: sandbox.activation_lifecycle_revision,
+      purpose: "restore",
+      backup_id: backup.id,
+      backup_manifest_sha256: backup.manifest_digest,
+      activation_receipt: sandbox.activation_receipt,
+      activation_receipt_sha256: sandbox.activation_receipt_hash,
+      container_id: sandbox.activation_container_id,
+      node_history_id: history.id,
+      docker_node_record_id: history.docker_node_record_id,
+      node_id: history.node_id,
+      node_incarnation: history.node_incarnation,
+      image_digest: sandbox.activation_image_digest,
+      token_sha256: sandbox.activation_token_hash,
+      funding_revision: sandbox.activation_funding_revision,
+    })
+    .returning();
+  if (!publication) conflict("Activation publication insert returned no row");
+  return { publication, replayed: false };
 }
 
 /**
@@ -247,10 +442,61 @@ export async function recordAgentActivationPublication(
         ),
       )
       .limit(1);
+    if (existing?.purpose === "restore") {
+      if (
+        !existing.backup_id ||
+        !existing.backup_manifest_sha256 ||
+        !publicationMatchesInput(existing, input)
+      ) {
+        conflict("Activation publication replay mismatch");
+      }
+      return recordRestoreActivationPublication(tx, input, {
+        backupId: existing.backup_id,
+        manifestSha256: existing.backup_manifest_sha256,
+        imageDigest: existing.image_digest,
+      });
+    }
     if (existing) {
       if (!publicationMatchesInput(existing, input))
         conflict("Activation publication replay mismatch");
+      await lockCurrentNodeHistory(tx, {
+        nodeRecordId: existing.docker_node_record_id,
+        nodeId: existing.node_id,
+        nodeIncarnation: existing.node_incarnation,
+        nodeHistoryId: existing.node_history_id,
+      });
       return { publication: existing, replayed: true };
+    }
+
+    const [activationAuthority] = await tx
+      .select({
+        purpose: agentSandboxes.activation_purpose,
+        backupId: agentSandboxes.activation_backup_id,
+        manifestSha256: agentSandboxes.activation_backup_hash,
+        imageDigest: agentSandboxes.activation_image_digest,
+      })
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.id, input.agentId),
+          eq(agentSandboxes.organization_id, input.organizationId),
+          eq(agentSandboxes.activation_generation, input.activationGeneration),
+        ),
+      )
+      .limit(1);
+    if (activationAuthority?.purpose === "restore") {
+      if (
+        !activationAuthority.backupId ||
+        !activationAuthority.manifestSha256 ||
+        !activationAuthority.imageDigest
+      ) {
+        conflict("Restore activation lacks an exact backup authority");
+      }
+      return recordRestoreActivationPublication(tx, input, {
+        backupId: activationAuthority.backupId,
+        manifestSha256: activationAuthority.manifestSha256,
+        imageDigest: activationAuthority.imageDigest,
+      });
     }
 
     const [sandbox] = await tx
@@ -266,6 +512,9 @@ export async function recordAgentActivationPublication(
       )
       .for("update")
       .limit(1);
+    if (sandbox?.activation_purpose === "restore") {
+      conflict("Restore activation changed before durable operation authority was locked");
+    }
     const [concurrentPublication] = await tx
       .select()
       .from(agentActivationPublications)
@@ -281,6 +530,12 @@ export async function recordAgentActivationPublication(
       if (!publicationMatchesInput(concurrentPublication, input)) {
         conflict("Activation publication replay mismatch");
       }
+      await lockCurrentNodeHistory(tx, {
+        nodeRecordId: concurrentPublication.docker_node_record_id,
+        nodeId: concurrentPublication.node_id,
+        nodeIncarnation: concurrentPublication.node_incarnation,
+        nodeHistoryId: concurrentPublication.node_history_id,
+      });
       return { publication: concurrentPublication, replayed: true };
     }
     if (
@@ -301,16 +556,11 @@ export async function recordAgentActivationPublication(
     ) {
       conflict("Mutable activation authority is incomplete or differs from publication input");
     }
-    if (
-      sandbox.activation_purpose === "restore" &&
-      (!sandbox.activation_backup_id || !sandbox.activation_backup_hash)
-    ) {
-      conflict("Restore activation lacks an exact backup authority");
-    }
     const history = await lockCurrentNodeHistory(tx, {
       nodeRecordId: input.expectedNodeRecordId,
       nodeId: sandbox.activation_node_id,
       nodeIncarnation: input.expectedNodeIncarnation,
+      nodeHistoryId: input.expectedNodeHistoryId,
     });
     const [publication] = await tx
       .insert(agentActivationPublications)
@@ -391,6 +641,7 @@ export async function authorizeAgentActivationDispatch(
       nodeRecordId: publication.docker_node_record_id,
       nodeId: publication.node_id,
       nodeIncarnation: publication.node_incarnation,
+      nodeHistoryId: publication.node_history_id,
     });
     return publication;
   });
@@ -410,6 +661,7 @@ export interface RecordAgentVaultKeySeedReceiptInput {
   targetActivationGeneration: string;
   targetNodeRecordId: string;
   targetNodeIncarnation: string;
+  targetNodeHistoryId: string;
 }
 
 function validateSeedInput(input: RecordAgentVaultKeySeedReceiptInput): void {
@@ -437,7 +689,8 @@ function seedMatchesInput(
     receipt.lease_fencing_token === input.leaseFencingToken &&
     receipt.target_activation_generation === input.targetActivationGeneration &&
     receipt.docker_node_record_id === input.targetNodeRecordId &&
-    receipt.node_incarnation === input.targetNodeIncarnation
+    receipt.node_incarnation === input.targetNodeIncarnation &&
+    receipt.node_history_id === input.targetNodeHistoryId
   );
 }
 
@@ -459,6 +712,11 @@ export async function recordAgentVaultKeySeedReceipt(
       .limit(1);
     if (existing) {
       if (!seedMatchesInput(existing, input)) conflict("Vault-seed receipt replay mismatch");
+      await lockCurrentNodeHistory(tx, {
+        nodeRecordId: existing.docker_node_record_id,
+        nodeIncarnation: existing.node_incarnation,
+        nodeHistoryId: existing.node_history_id,
+      });
       return { receipt: existing, replayed: true };
     }
 
@@ -488,6 +746,11 @@ export async function recordAgentVaultKeySeedReceipt(
       if (!seedMatchesInput(concurrentReceipt, input)) {
         conflict("Vault-seed receipt replay mismatch");
       }
+      await lockCurrentNodeHistory(tx, {
+        nodeRecordId: concurrentReceipt.docker_node_record_id,
+        nodeIncarnation: concurrentReceipt.node_incarnation,
+        nodeHistoryId: concurrentReceipt.node_history_id,
+      });
       return { receipt: concurrentReceipt, replayed: true };
     }
     if (
@@ -501,6 +764,20 @@ export async function recordAgentVaultKeySeedReceipt(
     ) {
       conflict("Vault seed source is absent or lacks restorable manifest-v3 authority");
     }
+    const operation = await lockExactRestoreOperationTarget(tx, {
+      organizationId: input.organizationId,
+      agentId: input.agentId,
+      backupId: input.backupId,
+      restoreAttemptId: input.restoreAttemptId,
+      targetActivationGeneration: input.targetActivationGeneration,
+      expectedOperationId: backup.backup_operation_id,
+      expectedManifestSha256: backup.manifest_digest,
+      expectedSourceActivationGeneration: backup.lifecycle_generation,
+      expectedSourceLifecycleRevision: backup.lifecycle_revision,
+      expectedNodeRecordId: input.targetNodeRecordId,
+      expectedNodeIncarnation: input.targetNodeIncarnation,
+      expectedNodeHistoryId: input.targetNodeHistoryId,
+    });
     const [lease] = await tx
       .select()
       .from(agentBackupRestoreLeases)
@@ -513,15 +790,22 @@ export async function recordAgentVaultKeySeedReceipt(
           eq(agentBackupRestoreLeases.restore_attempt_id, input.restoreAttemptId),
           eq(agentBackupRestoreLeases.owner_id, input.leaseOwnerId),
           eq(agentBackupRestoreLeases.generation, input.leaseFencingToken),
+          eq(agentBackupRestoreLeases.catalog_epoch, operation.catalog_epoch),
+          eq(agentBackupRestoreLeases.copy_role, operation.copy_role),
+          eq(agentBackupRestoreLeases.operation_id, operation.expected_operation_id),
+          eq(
+            agentBackupRestoreLeases.activation_generation,
+            operation.expected_activation_generation,
+          ),
+          eq(agentBackupRestoreLeases.lifecycle_revision, operation.expected_lifecycle_revision),
+          eq(agentBackupRestoreLeases.expected_manifest_sha256, operation.expected_manifest_sha256),
         ),
       )
       .for("update")
       .limit(1);
-    const databaseNow = await readPostLockDatabaseNow(tx);
     if (
       !lease ||
       lease.released_at !== null ||
-      lease.expires_at.getTime() <= databaseNow.getTime() ||
       lease.operation_id !== backup.backup_operation_id ||
       lease.activation_generation !== backup.lifecycle_generation ||
       lease.lifecycle_revision !== backup.lifecycle_revision ||
@@ -563,35 +847,39 @@ export async function recordAgentVaultKeySeedReceipt(
       !sandbox ||
       (sandbox.activation_phase !== "restart_attested" && sandbox.activation_phase !== "active") ||
       !sandbox.activation_node_id ||
-      sandbox.activation_boot_id !== input.targetNodeIncarnation
+      !sandbox.activation_container_id ||
+      !sandbox.activation_image_digest ||
+      sandbox.activation_boot_id !== input.targetNodeIncarnation ||
+      !operationMatchesRuntimeTarget(
+        operation,
+        sandbox.activation_container_id,
+        sandbox.activation_image_digest,
+      )
     ) {
-      conflict("Vault seed target activation is absent, unattested, changed, or blocked");
+      conflict(
+        "Vault seed target activation is absent, unattested, changed, or blocked by its durable operation target",
+      );
     }
     const history = await lockCurrentNodeHistory(tx, {
       nodeRecordId: input.targetNodeRecordId,
       nodeId: sandbox.activation_node_id,
       nodeIncarnation: input.targetNodeIncarnation,
+      nodeHistoryId: input.targetNodeHistoryId,
     });
     // Backup writers that also fence a live sandbox take sandbox and node
     // authority before the per-agent catalogue authority. Keeping this global
     // order aligned with reservation/capture and vault-key rotation prevents
     // sandbox <-> catalogue-authority AB-BA deadlocks.
-    const [authority] = await tx
-      .select()
-      .from(agentBackupCatalogAuthorities)
-      .where(
-        and(
-          eq(agentBackupCatalogAuthorities.organization_id, input.organizationId),
-          eq(agentBackupCatalogAuthorities.agent_id, input.agentId),
-        ),
-      )
-      .for("update")
-      .limit(1);
-    if (!authority || lease.catalog_epoch !== authority.catalog_revision) {
+    const authority = await lockAgentBackupCatalogAuthority(
+      tx,
+      input.organizationId,
+      input.agentId,
+    );
+    if (lease.catalog_epoch !== authority.catalog_revision) {
       conflict("Vault seed lost its exact live restore lease");
     }
     const finalDatabaseNow = await readPostLockDatabaseNow(tx);
-    if (lease.expires_at.getTime() <= finalDatabaseNow.getTime()) {
+    if (lease.released_at !== null || lease.expires_at.getTime() <= finalDatabaseNow.getTime()) {
       conflict("Vault seed lease expired while mutable authorities were revalidated");
     }
     const [receipt] = await tx
@@ -769,6 +1057,7 @@ export async function commitAgentBackupRestore(
       seed.source_lifecycle_revision !== backup.lifecycle_revision ||
       seed.manifest_sha256 !== backup.manifest_digest ||
       seed.target_activation_generation !== publication.activation_generation ||
+      seed.node_history_id !== publication.node_history_id ||
       seed.docker_node_record_id !== publication.docker_node_record_id ||
       seed.node_incarnation !== publication.node_incarnation ||
       publication.backup_id !== backup.id ||
@@ -776,18 +1065,46 @@ export async function commitAgentBackupRestore(
     ) {
       conflict("Final restore chain differs from source, seed, or activation publication");
     }
+    const operation = await lockExactRestoreOperationTarget(tx, {
+      organizationId: input.organizationId,
+      agentId: input.agentId,
+      backupId: input.backupId,
+      restoreAttemptId: input.restoreAttemptId,
+      targetActivationGeneration: input.targetActivationGeneration,
+      expectedOperationId: backup.backup_operation_id,
+      expectedManifestSha256: backup.manifest_digest,
+      expectedSourceActivationGeneration: backup.lifecycle_generation,
+      expectedSourceLifecycleRevision: backup.lifecycle_revision,
+      expectedNodeRecordId: publication.docker_node_record_id,
+      expectedNodeIncarnation: publication.node_incarnation,
+      expectedNodeHistoryId: publication.node_history_id,
+    });
+    if (
+      !operationMatchesRuntimeTarget(operation, publication.container_id, publication.image_digest)
+    ) {
+      conflict("Final restore chain differs from its durable operation target");
+    }
     const [lease] = await tx
       .select()
       .from(agentBackupRestoreLeases)
       .where(
         and(
-          eq(agentBackupRestoreLeases.id, seed.lease_id),
+          eq(agentBackupRestoreLeases.id, operation.lease_id),
           eq(agentBackupRestoreLeases.organization_id, seed.organization_id),
           eq(agentBackupRestoreLeases.agent_id, seed.agent_id),
           eq(agentBackupRestoreLeases.backup_id, seed.backup_id),
           eq(agentBackupRestoreLeases.restore_attempt_id, seed.restore_attempt_id),
           eq(agentBackupRestoreLeases.owner_id, seed.lease_owner_id),
           eq(agentBackupRestoreLeases.generation, seed.lease_fencing_token),
+          eq(agentBackupRestoreLeases.catalog_epoch, operation.catalog_epoch),
+          eq(agentBackupRestoreLeases.copy_role, operation.copy_role),
+          eq(agentBackupRestoreLeases.operation_id, operation.expected_operation_id),
+          eq(
+            agentBackupRestoreLeases.activation_generation,
+            operation.expected_activation_generation,
+          ),
+          eq(agentBackupRestoreLeases.lifecycle_revision, operation.expected_lifecycle_revision),
+          eq(agentBackupRestoreLeases.expected_manifest_sha256, operation.expected_manifest_sha256),
         ),
       )
       .for("update")
@@ -795,6 +1112,9 @@ export async function commitAgentBackupRestore(
     if (
       !lease ||
       lease.released_at !== null ||
+      seed.lease_id !== operation.lease_id ||
+      seed.lease_owner_id !== operation.lease_owner_id ||
+      seed.lease_fencing_token !== operation.lease_generation ||
       lease.operation_id !== seed.operation_id ||
       lease.activation_generation !== seed.source_activation_generation ||
       lease.lifecycle_revision !== seed.source_lifecycle_revision ||
@@ -840,23 +1160,17 @@ export async function commitAgentBackupRestore(
       nodeRecordId: publication.docker_node_record_id,
       nodeId: publication.node_id,
       nodeIncarnation: publication.node_incarnation,
+      nodeHistoryId: publication.node_history_id,
     });
     // Match every sandbox-bearing backup writer: sandbox and node authority
     // precede catalogue authority. Writers without a sandbox still serialize
     // on the already-locked backup row before reaching this authority.
-    const [authority] = await tx
-      .select()
-      .from(agentBackupCatalogAuthorities)
-      .where(
-        and(
-          eq(agentBackupCatalogAuthorities.organization_id, input.organizationId),
-          eq(agentBackupCatalogAuthorities.agent_id, input.agentId),
-        ),
-      )
-      .for("update")
-      .limit(1);
+    const authority = await lockAgentBackupCatalogAuthority(
+      tx,
+      input.organizationId,
+      input.agentId,
+    );
     if (
-      !authority ||
       authority.restore_generation >= MAX_SIGNED_BIGINT ||
       lease.catalog_epoch !== authority.catalog_revision
     ) {

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-operations.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-operations.ts
@@ -29,7 +29,7 @@ import {
 } from "./agent-backup-catalog";
 import { parseAgentBackupManifestV3Authority } from "./agent-backup-restore";
 import { hasAgentBackupRestoreAuthority } from "./agent-backup-restore-authority";
-import { proveUnambiguousAgentNodeIncarnationForLockedNode } from "./agent-backup-restore-history";
+import { proveExactAgentNodeOccurrenceForLockedNode } from "./agent-backup-restore-history";
 import type { AgentBackupRestoreLeaseAuthorityReceipt } from "./agent-backup-restore-lease";
 import { readPostLockDatabaseNow } from "./primary-database-clock";
 
@@ -68,6 +68,7 @@ export interface AgentBackupRestoreTargetAuthority {
   nodeRecordId: string;
   nodeId: string;
   nodeIncarnation: string;
+  nodeHistoryId: string;
   imageDigest: string;
 }
 
@@ -361,7 +362,7 @@ export async function claimAgentBackupRestoreOperation(params: {
 /**
  * Reserve one caller-selected, already-attested Docker target before any remote
  * restore effect. This repository never discovers, autoscales, or reselects a
- * node: the exact record/incarnation pair is the request authority.
+ * node: the exact record/incarnation/occurrence tuple is the request authority.
  *
  * Capacity and the operation target commit in the same transaction. A lost
  * response can therefore replay the exact tuple without consuming a second
@@ -377,11 +378,13 @@ export async function reserveAgentBackupRestoreTarget(params: {
   claimGeneration: string;
   targetNodeRecordId: string;
   targetNodeIncarnation: string;
+  targetNodeHistoryId: string;
 }): Promise<ReserveAgentBackupRestoreTargetResult> {
   const operationId = requireUuid(params.operationId, "operationId");
   const claimGeneration = requireUuid(params.claimGeneration, "claimGeneration");
   const targetNodeRecordId = requireUuid(params.targetNodeRecordId, "targetNodeRecordId");
   const targetNodeIncarnation = requireUuid(params.targetNodeIncarnation, "targetNodeIncarnation");
+  const targetNodeHistoryId = requireUuid(params.targetNodeHistoryId, "targetNodeHistoryId");
   requireOwnerId(params.ownerId);
 
   // This first read supplies immutable keys for the global lock order. The row
@@ -534,7 +537,15 @@ export async function reserveAgentBackupRestoreTarget(params: {
     if (node.node_incarnation !== targetNodeIncarnation) {
       throw new AgentBackupCatalogConflictError("Restore target node incarnation changed");
     }
-    await proveUnambiguousAgentNodeIncarnationForLockedNode(tx, node, targetNodeIncarnation);
+    if (node.current_node_history_id !== targetNodeHistoryId) {
+      throw new AgentBackupCatalogConflictError("Restore target node occurrence changed");
+    }
+    await proveExactAgentNodeOccurrenceForLockedNode(
+      tx,
+      node,
+      targetNodeIncarnation,
+      targetNodeHistoryId,
+    );
 
     const catalogAuthority = await lockAgentBackupCatalogAuthority(
       tx,
@@ -567,6 +578,7 @@ export async function reserveAgentBackupRestoreTarget(params: {
       nodeRecordId: node.id,
       nodeId: node.node_id,
       nodeIncarnation: targetNodeIncarnation,
+      nodeHistoryId: targetNodeHistoryId,
       imageDigest: manifest.runtime.imageDigest,
     });
     const targetAlreadyRecorded = operation.expected_node_record_id !== null;
@@ -574,13 +586,18 @@ export async function reserveAgentBackupRestoreTarget(params: {
       if (
         operation.expected_node_record_id !== target.nodeRecordId ||
         operation.expected_node_incarnation !== target.nodeIncarnation ||
+        operation.expected_node_history_id !== target.nodeHistoryId ||
         operation.expected_image_digest !== target.imageDigest
       ) {
         throw new AgentBackupCatalogConflictError("Restore target replay authority mismatch");
       }
       return { operation: Object.freeze(operation), target, replayed: true };
     }
-    if (operation.expected_node_incarnation !== null || operation.expected_image_digest !== null) {
+    if (
+      operation.expected_node_incarnation !== null ||
+      operation.expected_node_history_id !== null ||
+      operation.expected_image_digest !== null
+    ) {
       throw new AgentBackupCatalogConflictError("Restore target authority is only partially set");
     }
     if (
@@ -607,6 +624,7 @@ export async function reserveAgentBackupRestoreTarget(params: {
         and(
           eq(dockerNodes.id, targetNodeRecordId),
           eq(dockerNodes.node_incarnation, targetNodeIncarnation),
+          eq(dockerNodes.current_node_history_id, targetNodeHistoryId),
           eq(dockerNodes.enabled, true),
           eq(dockerNodes.status, "healthy"),
           eq(dockerNodes.placement_state, PLACEABLE_NODE_STATE),
@@ -624,6 +642,7 @@ export async function reserveAgentBackupRestoreTarget(params: {
       .set({
         expected_node_record_id: target.nodeRecordId,
         expected_node_incarnation: target.nodeIncarnation,
+        expected_node_history_id: target.nodeHistoryId,
         expected_image_digest: target.imageDigest,
         updated_at: databaseNow,
       })
@@ -634,6 +653,7 @@ export async function reserveAgentBackupRestoreTarget(params: {
           eq(agentBackupRestoreOperations.claim_generation, claimGeneration),
           sql`${agentBackupRestoreOperations.expected_node_record_id} IS NULL`,
           sql`${agentBackupRestoreOperations.expected_node_incarnation} IS NULL`,
+          sql`${agentBackupRestoreOperations.expected_node_history_id} IS NULL`,
           sql`${agentBackupRestoreOperations.expected_image_digest} IS NULL`,
         ),
       )
@@ -743,6 +763,7 @@ export async function advanceAgentBackupRestoreOperation(params: {
       targetAuthorityRequired &&
       (operation.expected_node_record_id === null ||
         operation.expected_node_incarnation === null ||
+        operation.expected_node_history_id === null ||
         operation.expected_image_digest === null)
     ) {
       throw new AgentBackupCatalogConflictError(
@@ -782,6 +803,7 @@ export async function advanceAgentBackupRestoreOperation(params: {
             ? and(
                 isNotNull(agentBackupRestoreOperations.expected_node_record_id),
                 isNotNull(agentBackupRestoreOperations.expected_node_incarnation),
+                isNotNull(agentBackupRestoreOperations.expected_node_history_id),
                 isNotNull(agentBackupRestoreOperations.expected_image_digest),
               )
             : undefined,

--- a/packages/cloud/shared/src/db/repositories/agent-backup-restore-quarantine.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-restore-quarantine.ts
@@ -24,7 +24,7 @@ import {
   lockAgentBackupCatalogAuthority,
 } from "./agent-backup-catalog";
 import { hasAgentBackupRestoreAuthority } from "./agent-backup-restore-authority";
-import { proveUnambiguousAgentNodeIncarnationForLockedNode } from "./agent-backup-restore-history";
+import { proveExactAgentNodeOccurrenceForLockedNode } from "./agent-backup-restore-history";
 import { readPostLockDatabaseNow } from "./primary-database-clock";
 
 const MAX_TOKEN_CIPHERTEXT_BYTES = 16_384;
@@ -106,6 +106,7 @@ function immutableOperationAuthorityMatches(
     operation.expected_manifest_sha256 === authority.expected_manifest_sha256 &&
     operation.expected_activation_generation === authority.expected_activation_generation &&
     operation.expected_lifecycle_revision === authority.expected_lifecycle_revision &&
+    operation.expected_node_history_id === authority.expected_node_history_id &&
     operation.expected_node_record_id === authority.expected_node_record_id &&
     operation.expected_node_incarnation === authority.expected_node_incarnation &&
     operation.expected_image_digest === authority.expected_image_digest
@@ -115,11 +116,13 @@ function immutableOperationAuthorityMatches(
 function hasCompleteTargetAuthority(
   operation: AgentBackupRestoreOperation,
 ): operation is AgentBackupRestoreOperation & {
+  expected_node_history_id: string;
   expected_node_record_id: string;
   expected_node_incarnation: string;
   expected_image_digest: string;
 } {
   return (
+    operation.expected_node_history_id !== null &&
     operation.expected_node_record_id !== null &&
     operation.expected_node_incarnation !== null &&
     operation.expected_image_digest !== null
@@ -211,8 +214,7 @@ function isExactContainerReplay(params: {
  *
  * The canonical route (`sandbox_id`, `node_id`, `image_digest`, and `status`)
  * is intentionally untouched. Definition-only: no production caller may use
- * this until restore allocation ownership has a durable settlement path and
- * node authority carries a durable incarnation-occurrence token.
+ * this until restore allocation ownership has a durable settlement path.
  */
 export async function openAgentBackupRestoreQuarantine(
   input: Readonly<OpenAgentBackupRestoreQuarantineInput>,
@@ -335,13 +337,19 @@ export async function openAgentBackupRestoreQuarantine(
       .where(eq(dockerNodes.id, operation.expected_node_record_id))
       .for("update")
       .limit(1);
-    if (!node || node.node_incarnation !== operation.expected_node_incarnation || !node.node_id) {
-      conflict("Restore quarantine target node incarnation changed");
+    if (
+      !node ||
+      node.node_incarnation !== operation.expected_node_incarnation ||
+      node.current_node_history_id !== operation.expected_node_history_id ||
+      !node.node_id
+    ) {
+      conflict("Restore quarantine target node occurrence changed");
     }
-    await proveUnambiguousAgentNodeIncarnationForLockedNode(
+    await proveExactAgentNodeOccurrenceForLockedNode(
       tx,
       node,
       operation.expected_node_incarnation,
+      operation.expected_node_history_id,
     );
 
     // Every sandbox-bearing backup writer takes the mutable sandbox and node
@@ -588,13 +596,19 @@ export async function recordAgentBackupRestoreQuarantinedContainer(
       .where(eq(dockerNodes.id, operation.expected_node_record_id))
       .for("update")
       .limit(1);
-    if (!node || node.node_incarnation !== operation.expected_node_incarnation || !node.node_id) {
-      conflict("Quarantined container target node incarnation changed");
+    if (
+      !node ||
+      node.node_incarnation !== operation.expected_node_incarnation ||
+      node.current_node_history_id !== operation.expected_node_history_id ||
+      !node.node_id
+    ) {
+      conflict("Quarantined container target node occurrence changed");
     }
-    await proveUnambiguousAgentNodeIncarnationForLockedNode(
+    await proveExactAgentNodeOccurrenceForLockedNode(
       tx,
       node,
       operation.expected_node_incarnation,
+      operation.expected_node_history_id,
     );
 
     const catalogAuthority = await lockAgentBackupCatalogAuthority(
@@ -711,6 +725,10 @@ export async function recordAgentBackupRestoreQuarantinedContainer(
           eq(agentBackupRestoreOperations.claim_owner, input.ownerId),
           eq(agentBackupRestoreOperations.claim_generation, claimGeneration),
           isNull(agentBackupRestoreOperations.expected_container_id),
+          eq(
+            agentBackupRestoreOperations.expected_node_history_id,
+            operation.expected_node_history_id,
+          ),
           eq(
             agentBackupRestoreOperations.expected_node_record_id,
             operation.expected_node_record_id,

--- a/packages/cloud/shared/src/db/repositories/agent-vault-key-authority.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-vault-key-authority.ts
@@ -35,7 +35,7 @@ import {
   loadAgentBackupRestoreSourceV3,
 } from "./agent-backup-restore";
 import { hasAgentBackupRestoreAuthority } from "./agent-backup-restore-authority";
-import { proveUnambiguousAgentNodeIncarnationForLockedNode } from "./agent-backup-restore-history";
+import { proveExactAgentNodeOccurrenceForLockedNode } from "./agent-backup-restore-history";
 import { readPostLockDatabaseNow } from "./primary-database-clock";
 
 const RAW_KEY_BYTES = 32;
@@ -867,6 +867,8 @@ export interface AgentBackupRestoreVaultPassphraseInput extends AgentBackupResto
   restoreClaimGeneration: string;
   targetNodeRecordId: string;
   targetNodeIncarnation: string;
+  /** Exact durable occurrence token for this node record and boot incarnation. */
+  targetNodeHistoryId: string;
   vaultKeyGenerationId: string;
   vaultKeyAuthorityReceiptDigest: string;
 }
@@ -1001,6 +1003,10 @@ async function proveAgentBackupRestoreVaultTargetAuthority(
     input.targetNodeIncarnation,
     "targetNodeIncarnation",
   );
+  const targetNodeHistoryId = requireCanonicalUuid(
+    input.targetNodeHistoryId,
+    "targetNodeHistoryId",
+  );
   const sourceLifecycleRevision = requireCanonicalUint64(
     input.sourceLifecycleRevision,
     "sourceLifecycleRevision",
@@ -1082,6 +1088,7 @@ async function proveAgentBackupRestoreVaultTargetAuthority(
     if (
       operation.expected_node_record_id !== targetNodeRecordId ||
       operation.expected_node_incarnation !== targetNodeIncarnation ||
+      operation.expected_node_history_id !== targetNodeHistoryId ||
       operation.expected_image_digest !== manifestImageDigest
     ) {
       throw new AgentBackupCatalogConflictError(
@@ -1121,12 +1128,19 @@ async function proveAgentBackupRestoreVaultTargetAuthority(
       .where(eq(dockerNodes.id, targetNodeRecordId))
       .for("update")
       .limit(1);
-    if (!node || node.node_incarnation !== targetNodeIncarnation) {
-      throw new AgentBackupCatalogConflictError(
-        "Restore vault target node record or incarnation was lost",
-      );
+    if (
+      !node ||
+      node.node_incarnation !== targetNodeIncarnation ||
+      node.current_node_history_id !== targetNodeHistoryId
+    ) {
+      throw new AgentBackupCatalogConflictError("Restore vault target node occurrence was lost");
     }
-    await proveUnambiguousAgentNodeIncarnationForLockedNode(tx, node, targetNodeIncarnation);
+    await proveExactAgentNodeOccurrenceForLockedNode(
+      tx,
+      node,
+      targetNodeIncarnation,
+      targetNodeHistoryId,
+    );
 
     const catalogAuthority = await lockAgentBackupCatalogAuthority(
       tx,

--- a/packages/cloud/shared/src/db/repositories/docker-nodes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/docker-nodes.test.ts
@@ -20,6 +20,8 @@ const from = mock(() => ({ where }));
 const select = mock(() => ({ from }));
 
 const returning = mock(() => []);
+const values = mock(() => ({ returning }));
+const insert = mock(() => ({ values }));
 const updateWhere = mock((clause: SQL) => {
   capturedUpdateWhere = clause;
   return { returning };
@@ -39,6 +41,7 @@ const dbReadMock = new Proxy(realHelpers.dbRead as unknown as Record<PropertyKey
 });
 const dbWriteMock = new Proxy(realHelpers.dbWrite as unknown as Record<PropertyKey, unknown>, {
   get(target, prop, receiver) {
+    if (prop === "insert" && useRepositoryMocks) return insert;
     if (prop === "update" && useRepositoryMocks) return update;
     return Reflect.get(target, prop, receiver);
   },
@@ -152,6 +155,7 @@ describe("DockerNodesRepository environment guard", () => {
       ["id", "replacement-row"],
       ["node_id", "replacement-node"],
       ["node_incarnation", "99999999-9999-4999-8999-999999999999"],
+      ["current_node_history_id", "99999999-9999-4999-8999-999999999998"],
       ["fleet_kind", "cloud"],
       ["infrastructure_provider", "hetzner"],
       ["provider_server_id", "12345"],
@@ -167,6 +171,17 @@ describe("DockerNodesRepository environment guard", () => {
 
     await expect(repository.update("row-1", { enabled: false })).resolves.toBeNull();
     expect(capturedSet).toMatchObject({ enabled: false });
+  });
+
+  test("create refuses a caller-supplied trigger-owned occurrence token", async () => {
+    const { DockerNodesRepository } = await import("./docker-nodes");
+
+    await expect(
+      new DockerNodesRepository().create({
+        current_node_history_id: "99999999-9999-4999-8999-999999999998",
+      } as never),
+    ).rejects.toThrow("cannot set trigger-owned current_node_history_id");
+    expect(values).not.toHaveBeenCalled();
   });
 
   test("findLeastLoaded applies the same environment guard to schedulable capacity", async () => {

--- a/packages/cloud/shared/src/db/repositories/docker-nodes.ts
+++ b/packages/cloud/shared/src/db/repositories/docker-nodes.ts
@@ -26,6 +26,8 @@ export type {
   NewDockerNode,
 };
 
+export type NewDockerNodeInput = Omit<NewDockerNode, "current_node_history_id">;
+
 export interface NodeIncarnationCasInput {
   id: string;
   nodeId: string;
@@ -53,6 +55,7 @@ const DOCKER_NODE_IDENTITY_FIELDS = [
   "id",
   "node_id",
   "node_incarnation",
+  "current_node_history_id",
   "fleet_kind",
   "infrastructure_provider",
   "provider_server_id",
@@ -255,7 +258,12 @@ export class DockerNodesRepository {
   // WRITE OPERATIONS
   // ============================================================================
 
-  async create(data: NewDockerNode): Promise<DockerNode> {
+  async create(data: NewDockerNodeInput): Promise<DockerNode> {
+    if (Object.hasOwn(data, "current_node_history_id")) {
+      throw new AgentBackupSourceAuthorityError(
+        "Docker node creation cannot set trigger-owned current_node_history_id",
+      );
+    }
     const [r] = await dbWrite.insert(dockerNodes).values(data).returning();
     if (!r) throw new Error("Failed to create docker node record");
     return r;

--- a/packages/cloud/shared/src/db/schemas/agent-backup-catalog.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-backup-catalog.ts
@@ -25,6 +25,7 @@ import {
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
+import { agentNodeIncarnationHistories } from "./agent-node-incarnation-histories";
 import { agentBackupCatalogAuthorities, agentSandboxBackups } from "./agent-sandboxes";
 import { organizations } from "./organizations";
 
@@ -433,6 +434,7 @@ export const agentBackupRestoreOperations = pgTable(
       scale: 0,
       mode: "bigint",
     }).notNull(),
+    expected_node_history_id: uuid("expected_node_history_id"),
     expected_node_record_id: uuid("expected_node_record_id"),
     expected_node_incarnation: uuid("expected_node_incarnation"),
     expected_container_id: text("expected_container_id"),
@@ -486,6 +488,19 @@ export const agentBackupRestoreOperations = pgTable(
       foreignColumns: [
         agentBackupCatalogAuthorities.organization_id,
         agentBackupCatalogAuthorities.agent_id,
+      ],
+    }).onDelete("restrict"),
+    node_occurrence_fk: foreignKey({
+      name: "agent_backup_restore_operations_node_occurrence_fkey",
+      columns: [
+        table.expected_node_history_id,
+        table.expected_node_record_id,
+        table.expected_node_incarnation,
+      ],
+      foreignColumns: [
+        agentNodeIncarnationHistories.id,
+        agentNodeIncarnationHistories.docker_node_record_id,
+        agentNodeIncarnationHistories.node_incarnation,
       ],
     }).onDelete("restrict"),
     attempt_uidx: uniqueIndex("agent_backup_restore_operations_attempt_uidx").on(
@@ -542,9 +557,18 @@ export const agentBackupRestoreOperations = pgTable(
         AND octet_length(${table.lease_owner_id}) BETWEEN 1 AND 255
         AND (${table.expected_container_id} IS NULL
           OR ${table.expected_container_id} ~ '^[0-9a-f]{64}$')
+        AND (${table.expected_container_id} IS NULL
+          OR ${table.expected_node_history_id} IS NOT NULL)
         AND (${table.expected_image_digest} IS NULL
           OR ${table.expected_image_digest} ~ '^sha256:[0-9a-f]{64}$')
-        AND (${table.expected_node_record_id} IS NULL) = (${table.expected_node_incarnation} IS NULL)
+        AND ((${table.expected_node_history_id} IS NULL
+            AND ${table.expected_node_record_id} IS NULL
+            AND ${table.expected_node_incarnation} IS NULL
+            AND ${table.expected_image_digest} IS NULL)
+          OR (${table.expected_node_history_id} IS NOT NULL
+            AND ${table.expected_node_record_id} IS NOT NULL
+            AND ${table.expected_node_incarnation} IS NOT NULL
+            AND ${table.expected_image_digest} IS NOT NULL))
       ) IS TRUE`,
     ),
   }),

--- a/packages/cloud/shared/src/db/schemas/agent-backup-restore-history.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-backup-restore-history.ts
@@ -15,6 +15,7 @@ import {
   uuid,
 } from "drizzle-orm/pg-core";
 import { agentBackupRestoreLeases } from "./agent-backup-catalog";
+import { agentNodeIncarnationHistories } from "./agent-node-incarnation-histories";
 import {
   type AgentActivationPurpose,
   type AgentActivationReceipt,
@@ -23,38 +24,8 @@ import {
 import { agentVaultKeyBackupBindings } from "./agent-vault-key-authority";
 import { organizations } from "./organizations";
 
-export const agentNodeIncarnationHistories = pgTable(
-  "agent_node_incarnation_histories",
-  {
-    id: uuid("id").defaultRandom().primaryKey(),
-    docker_node_record_id: uuid("docker_node_record_id").notNull(),
-    node_id: text("node_id").notNull(),
-    node_incarnation: uuid("node_incarnation").notNull(),
-    fleet_kind: text("fleet_kind").notNull(),
-    infrastructure_provider: text("infrastructure_provider").notNull(),
-    provider_server_id: text("provider_server_id"),
-    host_key_fingerprint: text("host_key_fingerprint").notNull(),
-    attested_at: timestamp("attested_at", { withTimezone: true }).notNull().defaultNow(),
-  },
-  (table) => ({
-    record_incarnation_unique: unique(
-      "agent_node_incarnation_histories_record_incarnation_unique",
-    ).on(table.docker_node_record_id, table.node_incarnation),
-    receipt_authority_unique: unique(
-      "agent_node_incarnation_histories_receipt_authority_unique",
-    ).on(table.id, table.docker_node_record_id, table.node_incarnation),
-    shape_check: check(
-      "agent_node_incarnation_histories_shape_check",
-      sql`(${table.node_id} = btrim(${table.node_id})
-        AND octet_length(${table.node_id}) BETWEEN 1 AND 255
-        AND ${table.fleet_kind} IN ('robot', 'cloud')
-        AND ${table.infrastructure_provider} = 'hetzner'
-        AND btrim(${table.host_key_fingerprint}) <> ''
-        AND ((${table.fleet_kind} = 'robot' AND ${table.provider_server_id} IS NULL)
-          OR (${table.fleet_kind} = 'cloud' AND ${table.provider_server_id} ~ '^[1-9][0-9]{0,19}$'))) IS TRUE`,
-    ),
-  }),
-);
+export type { AgentNodeIncarnationHistory } from "./agent-node-incarnation-histories";
+export { agentNodeIncarnationHistories };
 
 export const agentActivationPublications = pgTable(
   "agent_activation_publications",
@@ -377,7 +348,6 @@ export const agentBackupRestoreReceipts = pgTable(
   }),
 );
 
-export type AgentNodeIncarnationHistory = InferSelectModel<typeof agentNodeIncarnationHistories>;
 export type AgentActivationPublication = InferSelectModel<typeof agentActivationPublications>;
 export type AgentVaultKeySeedReceipt = InferSelectModel<typeof agentVaultKeySeedReceipts>;
 export type AgentBackupRestoreReceipt = InferSelectModel<typeof agentBackupRestoreReceipts>;

--- a/packages/cloud/shared/src/db/schemas/agent-node-incarnation-histories.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-node-incarnation-histories.ts
@@ -1,0 +1,49 @@
+/** Append-only Docker-node occurrence authorities. */
+
+import type { InferSelectModel } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import { check, index, pgTable, text, timestamp, unique, uuid } from "drizzle-orm/pg-core";
+
+/**
+ * One immutable attestation occurrence for a Docker-node record.
+ *
+ * `node_incarnation` may recur on the same record after NULL/rearm, ABA, or a
+ * delete/reinsert. The row `id`, not the mutable incarnation UUID, is the
+ * durable occurrence token used by current nodes and restore operations.
+ */
+export const agentNodeIncarnationHistories = pgTable(
+  "agent_node_incarnation_histories",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    docker_node_record_id: uuid("docker_node_record_id").notNull(),
+    node_id: text("node_id").notNull(),
+    node_incarnation: uuid("node_incarnation").notNull(),
+    fleet_kind: text("fleet_kind").notNull(),
+    infrastructure_provider: text("infrastructure_provider").notNull(),
+    provider_server_id: text("provider_server_id"),
+    host_key_fingerprint: text("host_key_fingerprint").notNull(),
+    attested_at: timestamp("attested_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    record_incarnation_idx: index("agent_node_incarnation_histories_record_incarnation_idx").on(
+      table.docker_node_record_id,
+      table.node_incarnation,
+    ),
+    receipt_authority_unique: unique(
+      "agent_node_incarnation_histories_receipt_authority_unique",
+    ).on(table.id, table.docker_node_record_id, table.node_incarnation),
+    shape_check: check(
+      "agent_node_incarnation_histories_shape_check",
+      sql`(${table.node_id} = btrim(${table.node_id})
+        AND octet_length(${table.node_id}) BETWEEN 1 AND 255
+        AND ${table.fleet_kind} IN ('robot', 'cloud')
+        AND ${table.infrastructure_provider} = 'hetzner'
+        AND btrim(${table.host_key_fingerprint}) <> ''
+        AND ((${table.fleet_kind} = 'robot' AND ${table.provider_server_id} IS NULL)
+          OR (${table.fleet_kind} = 'cloud'
+            AND ${table.provider_server_id} ~ '^[1-9][0-9]{0,19}$'))) IS TRUE`,
+    ),
+  }),
+);
+
+export type AgentNodeIncarnationHistory = InferSelectModel<typeof agentNodeIncarnationHistories>;

--- a/packages/cloud/shared/src/db/schemas/docker-nodes.ts
+++ b/packages/cloud/shared/src/db/schemas/docker-nodes.ts
@@ -3,6 +3,7 @@ import { type InferInsertModel, type InferSelectModel, sql } from "drizzle-orm";
 import {
   boolean,
   check,
+  foreignKey,
   index,
   integer,
   jsonb,
@@ -12,6 +13,7 @@ import {
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
+import { agentNodeIncarnationHistories } from "./agent-node-incarnation-histories";
 
 export type DockerNodeStatus = "healthy" | "degraded" | "offline" | "unknown";
 export type DockerNodeFleetKind = "robot" | "cloud";
@@ -62,6 +64,8 @@ export const dockerNodes = pgTable(
     provider_server_id: text("provider_server_id"),
     /** Exact lowercase Linux boot UUID attested over host-key-verified SSH. */
     node_incarnation: uuid("node_incarnation"),
+    /** Trigger-owned durable token for this exact mutable-node occurrence. */
+    current_node_history_id: uuid("current_node_history_id"),
     metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
     created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
@@ -76,6 +80,19 @@ export const dockerNodes = pgTable(
     node_incarnation_uidx: uniqueIndex("docker_nodes_node_incarnation_uidx")
       .on(table.node_incarnation)
       .where(sql`${table.node_incarnation} IS NOT NULL`),
+    current_node_history_fk: foreignKey({
+      name: "docker_nodes_current_node_history_fkey",
+      columns: [table.current_node_history_id, table.id, table.node_incarnation],
+      foreignColumns: [
+        agentNodeIncarnationHistories.id,
+        agentNodeIncarnationHistories.docker_node_record_id,
+        agentNodeIncarnationHistories.node_incarnation,
+      ],
+    }).onDelete("restrict"),
+    node_occurrence_shape_check: check(
+      "docker_nodes_node_occurrence_shape_check",
+      sql`(${table.node_incarnation} IS NULL) = (${table.current_node_history_id} IS NULL)`,
+    ),
     backup_source_authority_shape_check: check(
       "docker_nodes_backup_source_authority_shape_check",
       sql`((

--- a/packages/cloud/shared/src/db/schemas/index.ts
+++ b/packages/cloud/shared/src/db/schemas/index.ts
@@ -22,6 +22,7 @@ export * from "./agent-budgets";
 export * from "./agent-compute-stop-intents";
 export * from "./agent-events";
 export * from "./agent-identities";
+export * from "./agent-node-incarnation-histories";
 export * from "./agent-pairing-tokens";
 export * from "./agent-phone-contacts";
 export * from "./agent-phone-numbers";

--- a/packages/cloud/shared/src/lib/services/__tests__/deletion-allocation-ownership.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/deletion-allocation-ownership.test.ts
@@ -28,6 +28,7 @@ process.env.MOCK_REDIS = "1";
 
 import { pushSchema } from "drizzle-kit/api";
 import { and, eq } from "drizzle-orm";
+import { agentNodeIncarnationHistories } from "../../../db/schemas/agent-node-incarnation-histories";
 import { agentSandboxes } from "../../../db/schemas/agent-sandboxes";
 import { apiKeys } from "../../../db/schemas/api-keys";
 import { containers } from "../../../db/schemas/containers";
@@ -88,6 +89,7 @@ beforeAll(async () => {
       usageRecords,
       jobs,
       jobExecutionLeases,
+      agentNodeIncarnationHistories,
       dockerNodes,
       containers,
     };

--- a/packages/cloud/shared/src/lib/services/__tests__/deletion-release-proven-absence.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/deletion-release-proven-absence.test.ts
@@ -98,6 +98,7 @@ beforeAll(async () => {
       "infrastructure_provider" text,
       "provider_server_id" text,
       "node_incarnation" uuid,
+      "current_node_history_id" uuid,
       "metadata" jsonb NOT NULL DEFAULT '{}'::jsonb,
       "created_at" timestamptz NOT NULL DEFAULT now(),
       "updated_at" timestamptz NOT NULL DEFAULT now(),

--- a/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
@@ -19,6 +19,7 @@ import { pushSchema } from "drizzle-kit/api";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../db/client";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { type Job, jobsRepository } from "../../db/repositories/jobs";
+import { agentNodeIncarnationHistories } from "../../db/schemas/agent-node-incarnation-histories";
 import {
   type AgentSandboxBackup,
   agentSandboxes,
@@ -332,6 +333,7 @@ beforeAll(async () => {
       apiKeys,
       usageRecords,
       generations,
+      agentNodeIncarnationHistories,
       dockerNodes,
       agentSandboxes,
       jobs,

--- a/packages/cloud/shared/src/lib/services/managed-launch-credential-rotation.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/managed-launch-credential-rotation.pglite.test.ts
@@ -35,6 +35,7 @@ process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
 import { pushSchema } from "drizzle-kit/api";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../db/client";
 import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";
+import { agentNodeIncarnationHistories } from "../../db/schemas/agent-node-incarnation-histories";
 import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { apiKeys } from "../../db/schemas/api-keys";
 import { dockerNodes } from "../../db/schemas/docker-nodes";
@@ -117,7 +118,15 @@ beforeAll(async () => {
   }
   try {
     const { apply } = await pushSchema(
-      { organizations, users, userCharacters, apiKeys, dockerNodes, agentSandboxes } as never,
+      {
+        organizations,
+        users,
+        userCharacters,
+        apiKeys,
+        agentNodeIncarnationHistories,
+        dockerNodes,
+        agentSandboxes,
+      } as never,
       dbWrite as never,
     );
     await apply();


### PR DESCRIPTION
# Relates to

Relates to #20732. Parent epic: #20726 (Sandboxes V3, chantier 1).

> **Ready dormant dependency slice; activation remains held.** This PR is independently deployable database authority with no activation caller or external side effect in scope. The #24123 activation/vault writer, later #20732 coordinator, phase/claim receipts, allocator settlement, and remote activation effects remain separate acceptance/merge-order holds; they do not require this source-complete PR to remain Draft. This slice deliberately performs no Docker, vault, registry, routing, scheduler, staging, or production effect.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto `origin/develop@9c1fc32c0def7f3da4d40d54d88ac343e24c3a97`.
- [x] Preserves the upstream `0296_mcp_usage_canonical_receipts` journal entry byte-for-byte at idx 279 and appends this slice at idx 280–282.
- [x] Current exact-head PGlite, production-caller boundary, cloud-shared typecheck, migration, Biome, and whitespace checks pass; disposable real PostgreSQL and Worker-bundle evidence are retained from the source-identical pre-rebase head.
- [x] Repository-wide verification was run on the source-identical pre-rebase head; its inherited `packages/agent` blocker is recorded below rather than represented as green.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@271e3bbbd4814757a08aa13ba78db5f55c76633a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@9c1fc32c0def7f3da4d40d54d88ac343e24c3a97` with zero source conflicts.
- [x] The migration journal is append-only relative to that base: upstream `0296` remains idx 279 / `when` 1793822400000; `0283`, `0284`, and `0285` are idx 280–282 / `when` +1…+3.
- [x] GitHub reports the rebased head as mergeable at the time of this update.

# Risks

**Large identity/migration risk, dormant runtime exposure.** The migrations add a write-once occurrence-history authority to every Docker-node identity transition and bind restore operations to one exact history row. A bad constraint or lock order could block node/restore writers, so the change is split into three sub-100-line migrations and exercised against both PGlite and disposable real PostgreSQL. No production caller is enabled by this PR.

# Background

## What does this PR do?

- Appends migrations `0283`, `0284`, and `0285` after the current live journal tail.
- Adds immutable node-incarnation history and a trigger-owned current occurrence pointer. A real A1 → B → A2 transition produces distinct authorities even when the logical node record returns to A.
- Adds `expected_node_history_id` to restore-operation target identity and makes the full target tuple relationally exact and write-once.
- Carries the occurrence fence through reservation, vault seed, activation publication, and final receipt writers under the repository's global backup → operation → lease → sandbox → node → catalogue lock order.
- Preserves non-restore publication/replay/dispatch behavior while binding it to the same durable node record, incarnation, and history.
- Fails closed if deployment is interrupted between the three migrations or if legacy target-bearing operations exist before the final binding migration.

## What kind of change is this?

Feature: durable database authority and repository fencing for the next bounded #20732 restore-quarantine slice.

# Documentation changes needed?

No project-documentation change is required for this dormant internal authority. The migrations, repository contracts, issue claim, and this PR describe the operational boundary. Production-caller and deploy documentation belongs to the later caller slice.

# Testing

## Where should a reviewer start?

1. `agent-node-occurrence-authority-migration.test.ts` for append safety, interrupted-migration behavior, A1 → B → A2 discrimination, rollback, and write-once target binding.
2. `agent-backup-restore-authority.pglite.test.ts` for seed/publication/final-receipt fencing and non-restore compatibility.
3. `agent-backup-restore-locks.integration.test.ts` for real PostgreSQL lock and DB-clock behavior.

## Detailed testing steps

Run with repository-pinned Bun `1.3.14`:

```bash
bun --config=/dev/null test --no-coverage \
  packages/cloud/shared/src/db/agent-node-occurrence-authority-migration.test.ts \
  packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-operations.pglite.test.ts \
  packages/cloud/shared/src/db/repositories/__tests__/agent-backup-scheduler.pglite.test.ts \
  packages/cloud/shared/src/db/repositories/__tests__/agent-backup-restore-authority.pglite.test.ts \
  packages/cloud/shared/src/db/repositories/__tests__/agent-backup-global-lock-order.test.ts

APPS_TENANT_DB_TEST_DSN=<disposable-local-postgresql-dsn> \
  bun --config=/dev/null test --no-coverage \
  packages/cloud/shared/src/db/agent-backup-restore-locks.integration.test.ts

bun run --cwd packages/cloud/shared typecheck
bun run --cwd packages/cloud/shared db:check-migrations
bun run --cwd packages/cloud/api typecheck
git diff --name-only --diff-filter=ACMR origin/develop...HEAD \
  -- '*.ts' '*.tsx' '*.js' '*.mjs' '*.json' | xargs bunx biome check
git diff --check origin/develop...HEAD
bun run verify
```

# Evidence Gate

Evidence below matches the exact reviewed commit.
<!-- evidence-head:271e3bbbd4814757a08aa13ba78db5f55c76633a -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A — database authority only; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A — database authority only; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A — no interactive or rendered flow exists in this dormant slice.
<!-- evidence-row:backend-logs -->
- [x] [Source-identical pre-rebase backend logs](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/pr23967-3472d5bb-tests.log) — SHA-256 `e81c3ab3965b6a571be39415d0777efb282bb6e19c702c6838255c23c2178715`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A — no frontend code, request, or state transition changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A — no agent, action, prompt, model, or provider behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Source-identical pre-rebase domain receipt: [23967-6e41261650e6-domain.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23967-6e41261650e6-domain.json) — SHA-256 `c0a167b1798963e11553d6e9934676dd07cf4e8ef552e4d416bf36fbc618764b`
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A — no rendered visual or textual UI surface changed.

# Evidence details

Exact head: `271e3bbbd4814757a08aa13ba78db5f55c76633a`.
Exact base: `b687e3bbc9347c6d9d273b67c28a9b05dc52810b`.

```text
PGlite occurrence/restore/scheduler/lock suites:
77 pass, 0 fail, 586 expect() calls across 5 files

Source-identical pre-rebase disposable PostgreSQL 17.11 restore-lock suite:
8 pass, 0 fail, 37 expect() calls across 1 file

@elizaos/cloud-shared typecheck: PASS
@elizaos/cloud-api tsc --noEmit: PASS; exact Worker dry-run: local disk-capacity blocked (source-identical pre-rebase bundle: PASS)
drizzle-kit check: PASS (Everything's fine)
Biome changed TS/JSON files: 29 checked, 0 fixes
git diff --check: PASS
```

The domain artifact is a source-identical pre-rebase execution of the three migrations; the current exact-head PGlite suite re-executed the same occurrence transitions and migration bytes. It records distinct A1, B, and A2 occurrence IDs, an operation bound to A1, rejection of caller-substituted A2 with SQLSTATE `55000`, and the unchanged stored A1 binding.

The source-identical pre-rebase real PostgreSQL suite proves reservation replay ordering, lease/operation wait graphs, divergent replay, node-before-catalogue target reservation, final-writer concurrency, expiration fencing, and DB-clock acquisition. Docker Desktop's local containerd cache returned a `meta.db` I/O error, so the exact same real-PostgreSQL lane ran against a disposable Homebrew PostgreSQL 17.11 cluster instead; it was stopped and its explicit temporary directory moved to Trash by the cleanup trap.

# Known gaps / failures

- `bun run verify` was not rerun after this source-identical rebase. The exact Worker dry-run also stopped while writing its generated source map because only 167 MiB remained locally; its generated directory was removed. The source-identical pre-rebase Worker bundle passed. On prior source head `6e41261650e6f109d7b5773542b127648fb490b0` it exited 1 at inherited `@elizaos/agent#lint:check`; this PR has no `packages/agent` diff. The current exact-head package/type/migration/Biome gates are recorded above, and the global gate is not represented as green.
- Publication/seed/final writers intentionally remain caller-less. This is an explicit activation and merge-order hold: later #20732 slices must bind operation phase/claim receipts and enforce target environment/capacity ownership through the shared allocator (#22916) before any production caller is enabled. The PR remains ready so hosted CI and independent review can evaluate this dormant source-complete slice; ready status does not authorize activation or deployment.
- No staging or production mutation, deployment, autoscale, Docker creation, registry publication, or R2 write was performed. Hosted checks are reported by GitHub separately and are not represented here as green.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@271e3bbbd4814757a08aa13ba78db5f55c76633a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-sandboxes-v3-restore-occurrence]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@271e3bbbd4814757a08aa13ba78db5f55c76633a:packages/skills/skills/contribute-to-eliza"} -->

