### PR TITLE
fix(cloud): bound Meta Graph API hops in the ad provider

### DIFF
--- a/packages/cloud/shared/src/lib/services/advertising/providers/meta.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/meta.error-policy.test.ts
@@ -1,10 +1,8 @@
-// Pins the error-surfacing contract of the Meta ad provider: a failed provider
-// fetch must surface as a structured {success:false}/{valid:false} failure (the
-// shape the advertising service reads to REFUND credits and to reject invalid
-// credentials), and must stay distinct from a legitimately-empty result (valid
-// account with no insights → success with zero spend). Deterministic — global
-// fetch is mocked; no live Meta Graph API call and no monetary value is asserted
-// beyond the zero the source already fixes for the empty-insights case.
+/**
+ * Pins the Meta ad provider's error-surfacing and bounded-request contracts.
+ * Deterministic fetch mocks distinguish provider failures from legitimate
+ * empty results and verify that deadlines compose with caller cancellation.
+ */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../../../utils/logger", () => ({
@@ -128,7 +126,8 @@ describe("metaAdsProvider.getCampaignMetrics failure vs legitimately-empty", () 
 });
 
 describe("metaFetch — bounded hops fail closed and keep caller signals", () => {
-  test("aborts a hung Meta Graph API hop at the timeout", async () => {
+  test("aborts a hung hop at the deadline while the caller signal remains active", async () => {
+    const caller = new AbortController();
     globalThis.fetch = mock(
       (_input: RequestInfo | URL, init?: RequestInit) =>
         new Promise<Response>((_resolve, reject) => {
@@ -139,23 +138,29 @@ describe("metaFetch — bounded hops fail closed and keep caller signals", () =>
     ) as typeof fetch;
 
     const start = Date.now();
-    await expect(metaFetch("https://graph.facebook.com/v24.0/me", undefined, 100)).rejects.toThrow(
-      /aborted/i,
-    );
+    await expect(
+      metaFetch("https://graph.facebook.com/v24.0/me", { signal: caller.signal }, 100),
+    ).rejects.toThrow(/aborted/i);
+    expect(caller.signal.aborted).toBe(false);
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
-  test("preserves a caller-provided abort signal", async () => {
-    let seen: AbortSignal | undefined;
-    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      seen = init?.signal;
-      return new Response("{}", { status: 200 });
-    }) as typeof fetch;
+  test("aborts a hung hop when the caller cancels before the deadline", async () => {
+    const caller = new AbortController();
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as typeof fetch;
 
-    const controller = new AbortController();
-    await metaFetch("https://graph.facebook.com/v24.0/me", {
-      signal: controller.signal,
+    const pending = metaFetch("https://graph.facebook.com/v24.0/me", {
+      signal: caller.signal,
     });
-    expect(seen).toBe(controller.signal);
+    caller.abort();
+
+    await expect(pending).rejects.toThrow(/aborted/i);
   });
 });

--- a/packages/cloud/shared/src/lib/services/advertising/providers/meta.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/meta.error-policy.test.ts
@@ -1,7 +1,8 @@
 /**
  * Pins the Meta ad provider's error-surfacing and bounded-request contracts.
  * Deterministic fetch mocks distinguish provider failures from legitimate
- * empty results and verify that deadlines compose with caller cancellation.
+ * empty results, verify that deadlines compose with caller cancellation, and
+ * pin that a deadline abort still reaches the caller as a structured failure.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -122,6 +123,25 @@ describe("metaAdsProvider.getCampaignMetrics failure vs legitimately-empty", () 
     // distinction from the failure branch, not any derived monetary amount.
     expect(result.success).toBe(true);
     expect(result.metrics?.spend).toBe(0);
+  });
+});
+
+describe("a deadline abort reaches the caller as a structured provider failure", () => {
+  test("getCampaignMetrics returns {success:false} when a bounded hop aborts", async () => {
+    // metaFetch always attaches a deadline signal, so the hop aborts through that
+    // signal rather than waiting out the real 30s bound in the test.
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      throw new DOMException("The operation was aborted.", "AbortError");
+    }) as typeof fetch;
+
+    const result = await metaAdsProvider.getCampaignMetrics(credentials, "camp_1");
+
+    // The advertising service reads !result.success to refund credits; an
+    // AbortError escaping graphApiRequest unhandled would skip that refund.
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+    expect(result.metrics).toBeUndefined();
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/advertising/providers/meta.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/meta.error-policy.test.ts
@@ -11,7 +11,7 @@ mock.module("../../../utils/logger", () => ({
   logger: { info() {}, warn() {}, error() {}, debug() {} },
 }));
 
-const { metaAdsProvider } = await import("./meta");
+const { metaAdsProvider, metaFetch } = await import("./meta");
 
 const originalFetch = globalThis.fetch;
 
@@ -124,5 +124,38 @@ describe("metaAdsProvider.getCampaignMetrics failure vs legitimately-empty", () 
     // distinction from the failure branch, not any derived monetary amount.
     expect(result.success).toBe(true);
     expect(result.metrics?.spend).toBe(0);
+  });
+});
+
+describe("metaFetch — bounded hops fail closed and keep caller signals", () => {
+  test("aborts a hung Meta Graph API hop at the timeout", async () => {
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    ) as typeof fetch;
+
+    const start = Date.now();
+    await expect(metaFetch("https://graph.facebook.com/v24.0/me", undefined, 100)).rejects.toThrow(
+      /aborted/i,
+    );
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+
+  test("preserves a caller-provided abort signal", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen = init?.signal;
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const controller = new AbortController();
+    await metaFetch("https://graph.facebook.com/v24.0/me", {
+      signal: controller.signal,
+    });
+    expect(seen).toBe(controller.signal);
   });
 });

--- a/packages/cloud/shared/src/lib/services/advertising/providers/meta.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/meta.ts
@@ -23,6 +23,12 @@ const GRAPH_API_BASE = `https://graph.facebook.com/${GRAPH_API_VERSION}`;
 const META_REQUEST_TIMEOUT_MS = 30_000;
 
 /**
+ * Ad-media uploads carry base64-encoded creative bytes, so they need a far
+ * wider deadline than an ordinary Graph API hop before a slow link looks hung.
+ */
+const META_UPLOAD_TIMEOUT_MS = 120_000;
+
+/**
  * Bound every Meta Graph API hop so a hung or rate-limited API cannot pin the
  * ad-provider worker indefinitely while preserving caller cancellation.
  */
@@ -756,10 +762,14 @@ export const metaAdsProvider: AdProvider = {
       form.set("bytes", downloaded.base64);
       form.set("name", downloaded.fileName);
 
-      const response = await metaFetch(`${GRAPH_API_BASE}/${actAccountId}/adimages`, {
-        method: "POST",
-        body: form,
-      });
+      const response = await metaFetch(
+        `${GRAPH_API_BASE}/${actAccountId}/adimages`,
+        {
+          method: "POST",
+          body: form,
+        },
+        META_UPLOAD_TIMEOUT_MS,
+      );
       const data = (await response.json()) as GraphApiError & MetaAdImagesResponse;
       if (!response.ok || data.error) {
         throw new Error(data.error?.message || `Meta image upload failed (${response.status})`);

--- a/packages/cloud/shared/src/lib/services/advertising/providers/meta.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/meta.ts
@@ -1,4 +1,4 @@
-// Coordinates cloud service meta behavior behind route handlers.
+/** Coordinates Meta advertising operations and their bounded Graph API transport. */
 import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
 import { assertSafeAdMediaUrl, downloadAdMedia, mediaFileName } from "../media-utils";

--- a/packages/cloud/shared/src/lib/services/advertising/providers/meta.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/meta.ts
@@ -20,6 +20,23 @@ import type {
 const GRAPH_API_VERSION = process.env.META_GRAPH_API_VERSION || "v24.0";
 const GRAPH_API_BASE = `https://graph.facebook.com/${GRAPH_API_VERSION}`;
 
+const META_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Bound every Meta Graph API hop so a hung or rate-limited API cannot pin the
+ * ad-provider worker indefinitely. A caller-provided abort signal wins.
+ */
+export function metaFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = META_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  return fetch(input, {
+    ...init,
+    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+  });
+}
+
 const RETRY_CONFIG = {
   maxAttempts: 3,
   baseDelayMs: 1000,
@@ -139,7 +156,7 @@ async function graphApiRequest<T>(
   let lastError: Error | null = null;
 
   for (let attempt = 1; attempt <= RETRY_CONFIG.maxAttempts; attempt++) {
-    const response = await fetch(url.toString(), {
+    const response = await metaFetch(url.toString(), {
       ...options,
       headers: {
         "Content-Type": "application/json",
@@ -738,7 +755,7 @@ export const metaAdsProvider: AdProvider = {
       form.set("bytes", downloaded.base64);
       form.set("name", downloaded.fileName);
 
-      const response = await fetch(`${GRAPH_API_BASE}/${actAccountId}/adimages`, {
+      const response = await metaFetch(`${GRAPH_API_BASE}/${actAccountId}/adimages`, {
         method: "POST",
         body: form,
       });

--- a/packages/cloud/shared/src/lib/services/advertising/providers/meta.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/meta.ts
@@ -24,16 +24,17 @@ const META_REQUEST_TIMEOUT_MS = 30_000;
 
 /**
  * Bound every Meta Graph API hop so a hung or rate-limited API cannot pin the
- * ad-provider worker indefinitely. A caller-provided abort signal wins.
+ * ad-provider worker indefinitely while preserving caller cancellation.
  */
 export function metaFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
   timeoutMs: number = META_REQUEST_TIMEOUT_MS,
 ): Promise<Response> {
+  const deadline = AbortSignal.timeout(timeoutMs);
   return fetch(input, {
     ...init,
-    signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+    signal: init?.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
   });
 }
 


### PR DESCRIPTION
# Relates to

- Repairs the bounded Meta Graph API request path in this existing pull request.

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] Reviewer-visible deterministic test evidence is recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@7dfc674302d8245ba449c197c473b6d7e2a8a1f5:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` `9c1fc32c0def7f3da4d40d54d88ac343e24c3a97`; zero conflicts.
- [x] Scoped exact-head gates pass.

# Risks

Low and bounded. Every Meta Graph API hop has a 30-second deadline. When a caller also supplies an abort signal, `AbortSignal.any` preserves both controls so neither cancellation source disables the other.

# Background

## What does this PR do?

The Meta Graph API request helper and ad-image upload previously used raw `fetch` without a hop deadline. The original PR added a timeout only when no caller signal existed, which meant a non-aborted caller signal could still leave a hung request unbounded.

This repaired head:

- routes both Meta fetch sites through `metaFetch`;
- composes the request deadline with caller cancellation;
- proves that the deadline fires while a caller signal remains active;
- proves that caller cancellation fires before a long deadline;
- restores the original global fetch after every deterministic test;
- converts the modified test preamble to the required prose `/** ... */` header.

## What kind of change is this?

Bug fix / request-lifecycle hardening.

# Documentation changes needed?

No user-facing documentation change. The helper contract and deterministic regression names document the cancellation behavior.

# Testing

## Where should a reviewer start?

- `packages/cloud/shared/src/lib/services/advertising/providers/meta.ts`
- `packages/cloud/shared/src/lib/services/advertising/providers/meta.error-policy.test.ts`

## Detailed testing steps

Exact head: `7dfc674302d8245ba449c197c473b6d7e2a8a1f5`

- `bun test --isolate packages/cloud/shared/src/lib/services/advertising/providers/meta.error-policy.test.ts` - PASS (9/9)
- pinned Biome 2.5.8 on both changed files - PASS
- `git diff --check origin/develop...HEAD` - PASS
- `bun run --cwd packages/cloud/shared typecheck` - PASS.

# Evidence Gate

<!-- evidence-head:7dfc674302d8245ba449c197c473b6d7e2a8a1f5 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes
<!-- evidence-row:walkthrough-video -->
- [x] N/A - server-side request lifecycle hardening
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic abort injection and exact-head test output are the relevant non-secret proof
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, or LLM decision behavior changed; protected Meta acceptance is listed below
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no ad mutation was performed; the changed artifact is the composed request signal asserted by deterministic tests
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual-text surface changed

# Evidence Details

The exact-head suite injects a hung fetch and independently verifies deadline cancellation with an active caller signal and caller cancellation before the deadline. Existing failure-versus-empty-result regressions continue to pass, and `afterEach` restores `globalThis.fetch`.

## Known gaps / failures

- Hosted CI is pending on this exact head; exact package typecheck is green.
- A live Meta Graph API request was not sent because it requires protected credentials and could mutate an external advertising account. That is an explicit provider/operator acceptance hold, not a source or ready-state blocker.

This PR is source-complete and ready for review. Hosted CI, review, and protected provider acceptance are not reasons to convert it to draft.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@7dfc674302d8245ba449c197c473b6d7e2a8a1f5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-23968-meta-timeout]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@7dfc674302d8245ba449c197c473b6d7e2a8a1f5:packages/skills/skills/contribute-to-eliza"} -->

