### PR TITLE
fix(app-core): reject trailing garbage in electrobun integer env parsing

### DIFF
--- a/packages/app-core/platforms/electrobun/src/renderer-api-proxy.test.ts
+++ b/packages/app-core/platforms/electrobun/src/renderer-api-proxy.test.ts
@@ -86,4 +86,19 @@ describe("renderer API proxy", () => {
     ).toBe(180);
     expect(resolveRendererProxyIdleTimeoutSeconds({})).toBe(255);
   });
+
+  it("ignores a trailing-garbage idle timeout instead of parsing its prefix", () => {
+    // parseInt("1junk") is 1 — a one-second proxy idle timeout that would tear
+    // down in-flight renderer requests, from a value nobody meant as a setting.
+    expect(
+      resolveRendererProxyIdleTimeoutSeconds({
+        ELIZA_RENDERER_PROXY_IDLE_TIMEOUT_SECONDS: "1junk",
+      }),
+    ).toBe(255);
+    expect(
+      resolveRendererProxyIdleTimeoutSeconds({
+        ELIZA_RENDERER_PROXY_IDLE_TIMEOUT_SECONDS: "30",
+      }),
+    ).toBe(30);
+  });
 });

--- a/packages/app-core/platforms/electrobun/src/renderer-api-proxy.ts
+++ b/packages/app-core/platforms/electrobun/src/renderer-api-proxy.ts
@@ -35,8 +35,12 @@ const BUN_SERVE_MAX_IDLE_TIMEOUT_SECONDS = 255;
 
 function parsePositiveInteger(value: string | undefined): number | null {
   if (!value) return null;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  // parseInt stops at the first non-digit, so "1junk" would yield 1 and be
+  // accepted as a deliberate setting. Require the whole value to be decimal.
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
 function clampBunServeIdleTimeout(seconds: number): number {

--- a/packages/app-core/platforms/electrobun/src/trace/trace-store.test.ts
+++ b/packages/app-core/platforms/electrobun/src/trace/trace-store.test.ts
@@ -1,5 +1,5 @@
 /** Exercises trace store behavior with deterministic app-core test fixtures. */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { TraceError } from "./errors";
 import { TraceStore } from "./trace-store";
 
@@ -138,5 +138,25 @@ describe("TraceStore", () => {
     expect(() =>
       traces.recordEvent({ sessionId: "missing", kind: "log" }),
     ).toThrow(TraceError);
+  });
+});
+
+describe("trace store env limits", () => {
+  const KEY = "ELIZA_TRACE_MAX_SESSIONS";
+  const original = process.env[KEY];
+  afterEach(() => {
+    if (original === undefined) delete process.env[KEY];
+    else process.env[KEY] = original;
+  });
+
+  it("ignores a trailing-garbage session limit instead of parsing its prefix", () => {
+    // parseInt("2junk") is 2 — a two-session retention window that evicts
+    // almost every trace, from a value nobody meant as a setting.
+    process.env[KEY] = "2junk";
+    const traces = new TraceStore();
+    for (let i = 0; i < 5; i++) {
+      traces.createSession({ title: `run ${i}`, source: "agent" });
+    }
+    expect(traces.listSessions().length).toBe(5);
   });
 });

--- a/packages/app-core/platforms/electrobun/src/trace/trace-store.ts
+++ b/packages/app-core/platforms/electrobun/src/trace/trace-store.ts
@@ -61,8 +61,11 @@ function readPositiveIntEnv(
 ): number {
   const raw = env[name]?.trim();
   if (!raw) return fallback;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  // parseInt stops at the first non-digit, so "2junk" would yield 2 and shrink
+  // a retention limit to a fraction of its default. Require full decimal.
+  if (!/^\d+$/.test(raw)) return fallback;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function nowIso(now: () => Date): string {

--- a/packages/app-core/platforms/electrobun/src/voice/voice-latency-budget.test.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-latency-budget.test.ts
@@ -35,6 +35,17 @@ describe("voice latency budget", () => {
     expect(budget.inputToVadMs).toBe(50);
   });
 
+  it("ignores a trailing-garbage budget instead of parsing its prefix", () => {
+    const budget = getVoiceLatencyBudgetFromEnv({
+      ELIZA_VOICE_BUDGET_RUNTIME_TO_FIRST_TOKEN_MS: "250junk",
+    });
+
+    expect(budget.runtimeToFirstTokenMs).not.toBe(250);
+    expect(budget.runtimeToFirstTokenMs).toBe(
+      getDefaultVoiceLatencyBudget().runtimeToFirstTokenMs,
+    );
+  });
+
   it("evaluates stage pass and miss results", () => {
     const results = evaluateVoiceLatencyBudget(
       {

--- a/packages/app-core/platforms/electrobun/src/voice/voice-latency-budget.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-latency-budget.ts
@@ -154,10 +154,13 @@ function readPositiveInt(
   key: string,
   fallback: number,
 ): number {
-  const raw = env[key];
+  const raw = env[key]?.trim();
   if (!raw) return fallback;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  // parseInt stops at the first non-digit, so "250junk" would yield 250 and be
+  // treated as a deliberate budget. Require the whole value to be decimal.
+  if (!/^\d+$/.test(raw)) return fallback;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 export function getDefaultVoiceLatencyBudget(): VoiceLatencyBudget {

--- a/packages/app-core/platforms/electrobun/src/voice/voice-tts-chunker.test.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-tts-chunker.test.ts
@@ -1,6 +1,10 @@
 /** Exercises voice tts chunker behavior with deterministic app-core test fixtures. */
 import { describe, expect, it } from "vitest";
-import { VoiceTtsChunker } from "./voice-tts-chunker";
+import {
+  getDefaultVoiceTtsChunkingConfig,
+  getVoiceTtsChunkingConfigFromEnv,
+  VoiceTtsChunker,
+} from "./voice-tts-chunker";
 
 describe("VoiceTtsChunker", () => {
   it("flushes on punctuation after the minimum length", () => {
@@ -88,5 +92,25 @@ describe("VoiceTtsChunker", () => {
         reason: "final",
       },
     ]);
+  });
+});
+
+describe("voice TTS chunking config from env", () => {
+  it("ignores a trailing-garbage chunk limit instead of parsing its prefix", () => {
+    // parseInt("12junk") is 12 — a 12-character speech chunk limit, which
+    // shatters synthesis into fragments, from a value nobody meant as a setting.
+    const config = getVoiceTtsChunkingConfigFromEnv({
+      ELIZA_VOICE_TTS_CHUNK_MAX_CHARS: "12junk",
+    });
+
+    expect(config.maxChars).toBe(getDefaultVoiceTtsChunkingConfig().maxChars);
+  });
+
+  it("still honours a clean chunk limit", () => {
+    const config = getVoiceTtsChunkingConfigFromEnv({
+      ELIZA_VOICE_TTS_CHUNK_MAX_CHARS: "120",
+    });
+
+    expect(config.maxChars).toBe(120);
   });
 });

--- a/packages/app-core/platforms/electrobun/src/voice/voice-tts-chunker.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-tts-chunker.ts
@@ -31,10 +31,13 @@ function readPositiveInt(
   key: string,
   fallback: number,
 ): number {
-  const raw = env[key];
+  const raw = env[key]?.trim();
   if (!raw) return fallback;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  // parseInt stops at the first non-digit, so "12junk" would yield 12 and
+  // silently replace the default. Require the whole value to be decimal.
+  if (!/^\d+$/.test(raw)) return fallback;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function readBoolean(


### PR DESCRIPTION
## What's wrong

Four helpers across the electrobun platform parse an operator-supplied integer with `Number.parseInt(raw, 10)` and accept the result if it is merely finite and positive. `parseInt` stops at the first non-digit, so a value that was never a valid setting silently becomes a small one:

| env var | value | parsed | effect |
| --- | --- | --- | --- |
| `ELIZA_RENDERER_PROXY_IDLE_TIMEOUT_SECONDS` | `1junk` | `1` | proxy idle timeout drops 255s → **1s**, tearing down in-flight renderer requests |
| `ELIZA_VOICE_TTS_CHUNK_MAX_CHARS` | `12junk` | `12` | speech chunk limit drops 240 → **12 chars**, shattering synthesis into fragments |
| `ELIZA_VOICE_BUDGET_*_MS` | `250junk` | `250` | latency budget silently redefined |
| `ELIZA_TRACE_MAX_SESSIONS` | `2junk` | `2` | trace retention drops 200 → **2 sessions**, evicting nearly every trace |

The failure mode runs in the dangerous direction: a typo neither falls back to the documented default nor errors — it installs an aggressive limit that looks deliberate. `Number.isFinite` cannot catch this, because the prefix parse has already produced a finite number.

## The fix

Require the whole trimmed value to be decimal before converting, in each of the four helpers. An unparseable value now takes the same path as an absent one — the helper's existing fallback, which is the behaviour each of these functions already documents for invalid input. Clean values are unaffected.

`Number.isSafeInteger` replaces `Number.isFinite` so a value past 2^53 is rejected rather than silently rounded.

## Scope note

The lane that surfaced this found two of the four. I grepped the platform for the same helper and found two more verbatim copies, so this fixes the class rather than the two instances that happened to be noticed. All four are the same three-line helper, each with its own regression test.

## Verification

| Gate | Result |
| --- | --- |
| 4 affected suites | 21 passed |
| **full electrobun test lane** | **586 passed across 76 files** |
| `biome check` (all 8 changed files) | clean |
| `tsc --noEmit` | no errors in any changed file |

Drift-checked against current `develop`: all four source files are **byte-identical upstream**, so every defect is live and the fixes apply cleanly.

## Mutation resistance

Reverting only the four source files and keeping the tests fails all four new cases with the exact predicted values:

```
× ignores a trailing-garbage idle timeout    AssertionError: expected 1 to be 255
× ignores a trailing-garbage chunk limit     AssertionError: expected 12 to be 240
× ignores a trailing-garbage budget          AssertionError: expected 250 not to be 250
× ignores a trailing-garbage session limit   AssertionError: expected 2 to be 5
Tests  4 failed | 17 passed (21)
```

The other 17 tests in those suites still pass, so each new test is specific to its own defect. Reapplying returns all 21 to green.

## Attribution

- Two of the four (renderer proxy, TTS chunker) found by OpenAI `gpt-5.6-sol` via Codex (AgentRouter) during a numeric-input validation sweep.
- Independent verification, discovery of the two further copies of the same helper, the safe-integer bound, regression tests for all four, and the mutation proof by Claude Code (`claude-opus-5`).
