### PR TITLE
fix(agent-skills): parse catalog pagination with the strict shared integer parser

### DIFF
--- a/plugins/plugin-agent-skills/src/api/skills-routes.test.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.test.ts
@@ -651,3 +651,41 @@ describe("skill install request lifecycle", () => {
     expect(socket.listenerCount("close")).toBe(0);
   });
 });
+
+describe("catalog pagination parameter parsing", () => {
+  function catalogContext(query: string) {
+    const pathname = "/api/skills/catalog";
+    const { ctx, json, error } = createSkillsContext("GET", pathname);
+    ctx.url = new URL(`http://localhost${pathname}${query}`);
+    return { ctx, json, error };
+  }
+
+  it("ignores a non-finite page instead of slicing from Infinity", async () => {
+    // Number("Infinity") is Infinity, so `start = (page - 1) * perPage` became
+    // Infinity: an always-empty page whose echoed `page` serializes as null.
+    const { ctx, json } = catalogContext("?page=Infinity");
+    await handleSkillsRoutes(ctx);
+    expect(json).toHaveBeenCalled();
+    const body = json.mock.calls[0]?.[1] as { page: number };
+    expect(Number.isSafeInteger(body.page)).toBe(true);
+    expect(body.page).toBe(1);
+  });
+
+  it("ignores a fractional page instead of producing overlapping windows", async () => {
+    // page=2.7 sliced [4.59, 7.29), overlapping the windows for pages 2 and 3.
+    const { ctx, json } = catalogContext("?page=2.7&perPage=2");
+    await handleSkillsRoutes(ctx);
+    const body = json.mock.calls[0]?.[1] as { page: number; perPage: number };
+    expect(Number.isSafeInteger(body.page)).toBe(true);
+    expect(body.page).toBe(1);
+    expect(body.perPage).toBe(2);
+  });
+
+  it("still honours clean pagination values", async () => {
+    const { ctx, json } = catalogContext("?page=3&perPage=25");
+    await handleSkillsRoutes(ctx);
+    const body = json.mock.calls[0]?.[1] as { page: number; perPage: number };
+    expect(body.page).toBe(3);
+    expect(body.perPage).toBe(25);
+  });
+});

--- a/plugins/plugin-agent-skills/src/api/skills-routes.ts
+++ b/plugins/plugin-agent-skills/src/api/skills-routes.ts
@@ -662,11 +662,19 @@ export async function handleSkillsRoutes(
       const all = (await getCatalogSkills()).filter((skill) =>
         shouldExposeBinanceSkillRecord(skill),
       );
-      const page = Math.max(1, Number(url.searchParams.get("page")) || 1);
-      const perPage = Math.min(
-        100,
-        Math.max(1, Number(url.searchParams.get("perPage")) || 50),
-      );
+      // `Number()` accepts "Infinity" and fractions, which reach the slice
+      // below as `start = Infinity` (an empty page reported as `"page": null`)
+      // or as fractional bounds that make consecutive pages overlap. The shared
+      // strict parser is already used elsewhere in this file.
+      const page = parseClampedInteger(url.searchParams.get("page"), {
+        min: 1,
+        fallback: 1,
+      });
+      const perPage = parseClampedInteger(url.searchParams.get("perPage"), {
+        min: 1,
+        max: 100,
+        fallback: 50,
+      });
       const sort = url.searchParams.get("sort") ?? "downloads";
       const sorted = [...all];
       if (sort === "downloads")
@@ -745,10 +753,11 @@ export async function handleSkillsRoutes(
       const { searchCatalogSkills } = await import(
         "../services/skill-catalog-client"
       );
-      const limit = Math.min(
-        100,
-        Math.max(1, Number(url.searchParams.get("limit")) || 30),
-      );
+      const limit = parseClampedInteger(url.searchParams.get("limit"), {
+        min: 1,
+        max: 100,
+        fallback: 30,
+      });
       const results = (await searchCatalogSkills(q, limit)).filter((skill) =>
         shouldExposeBinanceSkillRecord(skill),
       );


### PR DESCRIPTION
# Relates to

No separate issue; the strict-pagination defect is described below.

- [x] Rebased onto current `develop` with zero conflicts.
- [x] Exact plugin test, typecheck, lint, format, Biome, and diff gates pass.
- [x] Hosted CI remains an explicit ready-state hold.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@375df4db22efd77f7c6d31d6f68e77c242f3d433:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact head `375df4db22efd77f7c6d31d6f68e77c242f3d433` descends from `develop@9c1fc32c0def7f3da4d40d54d88ac343e24c3a97`.
- [x] The two-file patch replayed without conflict and exact scoped gates pass.

# Risks

Low. Three permissive `Number(...) || fallback` query parsers are replaced with the strict shared parser already imported in the same route. Defaults and bounds are preserved; malformed values continue to fall back rather than becoming a new 400 response.

# Background

`Number()` admitted values pagination cannot represent. `page=Infinity` produced an always-empty slice and serialized the echoed page as `null`; `page=2.7` produced overlapping slice windows. Catalog `page`/`perPage` and marketplace-search `limit` now use `parseClampedInteger`, which requires a whole safe integer, preserves documented fallbacks, and clamps valid values to the existing bounds.

## What kind of change is this?

Bug fix for backend query-parameter parsing.

# Documentation changes needed?

No. The route contract is unchanged for valid and invalid clients.

# Testing

## Where should a reviewer start?

- `plugins/plugin-agent-skills/src/api/skills-routes.ts`
- `plugins/plugin-agent-skills/src/api/skills-routes.test.ts`

## Detailed testing steps

```text
bun run --cwd plugins/plugin-agent-skills test -- src/api/skills-routes.test.ts
37 pass, 0 fail

bun run --cwd plugins/plugin-agent-skills typecheck
PASS

bun run --cwd plugins/plugin-agent-skills lint:check
Checked 70 files. No fixes applied.

bun run --cwd plugins/plugin-agent-skills format:check
PASS

changed-file Biome and git diff --check
PASS
```

The new route regressions prove that `Infinity` and fractional pages fall back to page 1 while clean pagination values remain unchanged. The shared parser owns the exhaustive grammar and range contract used by `limit`.

# Evidence Gate

<!-- evidence-head:375df4db22efd77f7c6d31d6f68e77c242f3d433 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - backend-only pagination parsing; no rendered UI changed.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - backend-only pagination parsing; no rendered UI changed.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - observable response values are asserted by the route suite.`
<!-- evidence-row:backend-logs -->
- [x] Backend runtime logs: `N/A - no service startup changed; the real route handler is exercised directly and exact results are quoted above.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend code changed.`
<!-- evidence-row:llm-trajectory -->
- [x] LLM trajectory: `N/A - no model, prompt, provider, action, or evaluator behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact inspection is included inline:

  ```text
  ?page=Infinity -> page 1
  ?page=2.7&perPage=2 -> page 1, perPage 2
  ?page=3&perPage=25 -> page 3, perPage 25
  all echoed pagination values remain finite safe integers
  ```
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - no rendered visual-text surface changed.`

# Known gaps / failures

- Hosted exact-head CI has not completed on `375df4db22efd77f7c6d31d6f68e77c242f3d433`; this remains an explicit ready-state hold.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@375df4db22efd77f7c6d31d6f68e77c242f3d433:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-23971-pagination]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@375df4db22efd77f7c6d31d6f68e77c242f3d433:packages/skills/skills/contribute-to-eliza"} -->
