### PR TITLE
fix(cloud): honor TikTok ranged video uploads

### DIFF
--- a/packages/cloud/shared/src/lib/services/social-media/index.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/index.ts
@@ -383,14 +383,18 @@ class SocialMediaService {
     const successful = results.filter((r) => r.success);
     const failed = results.filter((r) => !r.success);
 
-    if (failed.length > 0) {
+    const refundableFailures = failed.filter((result) => result.creditDisposition !== "hold");
+
+    if (refundableFailures.length > 0) {
       await creditsService.refundCredits({
         organizationId,
-        amount: failed.length * POST_CREDIT_COST,
-        description: `Refund for failed posts: ${failed.map((f) => f.platform).join(", ")}`,
-        metadata: { userId, failedPlatforms: failed.map((f) => f.platform) },
+        amount: refundableFailures.length * POST_CREDIT_COST,
+        description: `Refund for failed posts: ${refundableFailures.map((f) => f.platform).join(", ")}`,
+        metadata: { userId, failedPlatforms: refundableFailures.map((f) => f.platform) },
       });
+    }
 
+    if (failed.length > 0) {
       alertOnPostFailure(
         organizationId,
         failed.map((f) => f.platform),

--- a/packages/cloud/shared/src/lib/services/social-media/media-budget.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/media-budget.test.ts
@@ -20,6 +20,7 @@ import { ElizaError } from "@elizaos/core";
 import {
   SOCIAL_MEDIA_MEDIA_MAX_BASE64_LENGTH,
   SOCIAL_MEDIA_MEDIA_MAX_BYTES,
+  SOCIAL_MEDIA_VIDEO_MAX_BASE64_BYTES,
   SOCIAL_MEDIA_VIDEO_MAX_BYTES,
 } from "../../types/social-media";
 import { assertSocialMediaBytesWithinBudget, decodeSocialMediaBase64 } from "./media-download";
@@ -148,7 +149,7 @@ describe("assertSocialMediaBytesWithinBudget", () => {
 // TikTok accepts larger URL-backed videos, but inline video keeps the encoded
 // input and decoded bytes resident together in the Worker isolate.
 describe("video budget", () => {
-  test("uses the conservative inline ceiling and accepts it exactly", () => {
+  test("keeps the decoded binary ceiling at 32 MiB for reachable multi-range uploads", () => {
     expect(SOCIAL_MEDIA_VIDEO_MAX_BYTES).toBe(32 * 1024 * 1024);
     expect(() =>
       assertSocialMediaBytesWithinBudget(
@@ -159,13 +160,14 @@ describe("video budget", () => {
     ).not.toThrow();
   });
 
-  test("decodes an inline video at exactly the conservative ceiling", () => {
+  test("uses the shared 10 MiB ceiling for base64 video and accepts it exactly", () => {
+    expect(SOCIAL_MEDIA_VIDEO_MAX_BASE64_BYTES).toBe(SOCIAL_MEDIA_MEDIA_MAX_BYTES);
     const bytes = decodeSocialMediaBase64(
-      base64Of(SOCIAL_MEDIA_VIDEO_MAX_BYTES),
+      base64Of(SOCIAL_MEDIA_VIDEO_MAX_BASE64_BYTES),
       { platform: "tiktok" },
-      SOCIAL_MEDIA_VIDEO_MAX_BYTES,
+      SOCIAL_MEDIA_VIDEO_MAX_BASE64_BYTES,
     );
-    expect(bytes.length).toBe(SOCIAL_MEDIA_VIDEO_MAX_BYTES);
+    expect(bytes.length).toBe(SOCIAL_MEDIA_VIDEO_MAX_BASE64_BYTES);
   });
 
   test("still rejects a payload above the video ceiling", () => {
@@ -180,12 +182,42 @@ describe("video budget", () => {
     expect(rejected.context?.maxBytes).toBe(SOCIAL_MEDIA_VIDEO_MAX_BYTES);
   });
 
-  test("rejects an oversize video before the decode allocates", () => {
-    const encoded = "A".repeat(Math.ceil(SOCIAL_MEDIA_VIDEO_MAX_BYTES / 3) * 4 + 4);
+  test("rejects an oversize base64 video before the decode allocates", () => {
+    const encoded = "A".repeat(Math.ceil(SOCIAL_MEDIA_VIDEO_MAX_BASE64_BYTES / 3) * 4 + 4);
     const rejected = rejection(() =>
-      decodeSocialMediaBase64(encoded, { platform: "tiktok" }, SOCIAL_MEDIA_VIDEO_MAX_BYTES),
+      decodeSocialMediaBase64(encoded, { platform: "tiktok" }, SOCIAL_MEDIA_VIDEO_MAX_BASE64_BYTES),
     );
     expect(rejected.code).toBe("SOCIAL_MEDIA_MEDIA_TOO_LARGE");
     expect(rejected.context?.encodedLength).toBeGreaterThan(0);
+  });
+
+  test("rejects whitespace stuffing beyond RFC 2045 wrapping before decode", () => {
+    const maxEncodedLength = Math.ceil(SOCIAL_MEDIA_VIDEO_MAX_BASE64_BYTES / 3) * 4;
+    const maxRawEncodedLength =
+      maxEncodedLength + Math.max(0, Math.ceil(maxEncodedLength / 76) - 1) * 2;
+    const rejected = rejection(() =>
+      decodeSocialMediaBase64(
+        " ".repeat(maxRawEncodedLength + 1),
+        { platform: "tiktok" },
+        SOCIAL_MEDIA_VIDEO_MAX_BASE64_BYTES,
+      ),
+    );
+    expect(rejected.context).toMatchObject({
+      rawEncodedLength: maxRawEncodedLength + 1,
+      maxRawEncodedLength,
+    });
+    expect(rejected.context).not.toHaveProperty("receivedBytes");
+  });
+
+  test("bounds two overlapping binary or base64 uploads below a 128 MiB isolate", () => {
+    const workerLimit = 128 * 1024 * 1024;
+    const maxChunkCopy = 10_000_000;
+    const maxBase64Encoded = Math.ceil(SOCIAL_MEDIA_VIDEO_MAX_BASE64_BYTES / 3) * 4;
+    const maxBase64Raw = maxBase64Encoded + Math.max(0, Math.ceil(maxBase64Encoded / 76) - 1) * 2;
+
+    expect(2 * (SOCIAL_MEDIA_VIDEO_MAX_BYTES + maxChunkCopy)).toBeLessThan(workerLimit);
+    expect(2 * (maxBase64Raw + SOCIAL_MEDIA_VIDEO_MAX_BASE64_BYTES + maxChunkCopy)).toBeLessThan(
+      workerLimit,
+    );
   });
 });

--- a/packages/cloud/shared/src/lib/services/social-media/media-budget.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/media-budget.test.ts
@@ -145,19 +145,27 @@ describe("assertSocialMediaBytesWithinBudget", () => {
   });
 });
 
-// TikTok chunk-uploads video, so the 10 MiB image ceiling would reject
-// ordinary posts — but the decode is still one allocation inside the Worker
-// isolate. It takes the larger video ceiling rather than no bound at all.
+// TikTok accepts larger URL-backed videos, but inline video keeps the encoded
+// input and decoded bytes resident together in the Worker isolate.
 describe("video budget", () => {
-  test("accepts a payload above the image ceiling but under the video ceiling", () => {
-    const bytes = SOCIAL_MEDIA_MEDIA_MAX_BYTES + 1024;
+  test("uses the conservative inline ceiling and accepts it exactly", () => {
+    expect(SOCIAL_MEDIA_VIDEO_MAX_BYTES).toBe(32 * 1024 * 1024);
     expect(() =>
       assertSocialMediaBytesWithinBudget(
-        bytes,
+        SOCIAL_MEDIA_VIDEO_MAX_BYTES,
         { platform: "tiktok" },
         SOCIAL_MEDIA_VIDEO_MAX_BYTES,
       ),
     ).not.toThrow();
+  });
+
+  test("decodes an inline video at exactly the conservative ceiling", () => {
+    const bytes = decodeSocialMediaBase64(
+      base64Of(SOCIAL_MEDIA_VIDEO_MAX_BYTES),
+      { platform: "tiktok" },
+      SOCIAL_MEDIA_VIDEO_MAX_BYTES,
+    );
+    expect(bytes.length).toBe(SOCIAL_MEDIA_VIDEO_MAX_BYTES);
   });
 
   test("still rejects a payload above the video ceiling", () => {

--- a/packages/cloud/shared/src/lib/services/social-media/media-download.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/media-download.ts
@@ -75,6 +75,24 @@ export function decodeSocialMediaBase64(
   maxBytes: number = SOCIAL_MEDIA_MEDIA_MAX_BYTES,
 ): Buffer {
   const maxEncodedLength = Math.ceil(maxBytes / 3) * 4;
+  // RFC 2045 wraps base64 at 76 characters with CRLF. Bound the raw string to
+  // exactly that worst-case overhead before scanning it, so ignorable spaces
+  // cannot retain an arbitrarily large request beside the decoded allocation.
+  const maxMimeLineBreaks = Math.max(0, Math.ceil(maxEncodedLength / 76) - 1);
+  const maxRawEncodedLength = maxEncodedLength + maxMimeLineBreaks * 2;
+  if (base64.length > maxRawEncodedLength) {
+    throw downloadError(
+      "Media attachment exceeds the raw encoded media limit",
+      "SOCIAL_MEDIA_MEDIA_TOO_LARGE",
+      {
+        rawEncodedLength: base64.length,
+        maxRawEncodedLength,
+        maxEncodedLength,
+        maxBytes,
+        ...context,
+      },
+    );
+  }
   if (base64.length > maxEncodedLength) {
     let encodedLength = 0;
     for (let index = 0; index < base64.length; index += 1) {

--- a/packages/cloud/shared/src/lib/services/social-media/providers/tiktok-upload.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/tiktok-upload.test.ts
@@ -389,9 +389,10 @@ describe("tiktokProvider file upload", () => {
 
     expect(result).toMatchObject({
       success: false,
-      errorCode: "TIKTOK_UPLOAD_CHUNK_STATUS_INVALID",
+      errorCode: "TIKTOK_UPLOAD_OUTCOME_UNKNOWN",
+      creditDisposition: "hold",
     });
-    expect(apiCallCount).toBe(1);
+    expect(apiCallCount).toBe(2);
     expect(putCount).toBe(3);
     expect(cancellations).toEqual([503, 503, 503]);
   });
@@ -455,6 +456,79 @@ describe("tiktokProvider file upload", () => {
     expect(putCalls).toHaveLength(2);
     expect(new Headers(putCalls[0]?.headers)).toEqual(new Headers(putCalls[1]?.headers));
     expect(putCalls[0]?.body).toEqual(putCalls[1]?.body);
+  });
+
+  test("accepts a 416 replay only when its progress proves the ambiguous range committed", async () => {
+    let apiCallCount = 0;
+    let putCount = 0;
+    const cancellations: number[] = [];
+    fetchImpl = async () => {
+      apiCallCount += 1;
+      if (apiCallCount === 1) {
+        return jsonResponse({
+          publish_id: "publish-416",
+          upload_url: "https://open-upload.tiktokapis.com/video?upload_id=416",
+        });
+      }
+      if (apiCallCount === 2) return jsonResponse({ status: "PROCESSING_UPLOAD" });
+      return jsonResponse({ status: "PUBLISH_COMPLETE" });
+    };
+    safeFetchImpl = async () => {
+      putCount += 1;
+      if (putCount === 1) throw new Error("response connection reset");
+      return new Response(
+        new ReadableStream({
+          cancel() {
+            cancellations.push(416);
+          },
+        }),
+        { status: 416, headers: { "content-range": "bytes 0-4/5" } },
+      );
+    };
+
+    const result = await tiktokProvider.createPost(credentials, {
+      text: "hello",
+      media: [{ type: "video", data: Buffer.from("video"), mimeType: "video/mp4" }],
+    });
+
+    expect(result.success).toBe(true);
+    expect(putCount).toBe(2);
+    expect(cancellations).toEqual([416]);
+  });
+
+  test("keeps a mismatched 416 replay unresolved instead of refunding it", async () => {
+    let apiCallCount = 0;
+    let putCount = 0;
+    fetchImpl = async () => {
+      apiCallCount += 1;
+      if (apiCallCount === 1) {
+        return jsonResponse({
+          publish_id: "publish-416-mismatch",
+          upload_url: "https://open-upload.tiktokapis.com/video?upload_id=416-mismatch",
+        });
+      }
+      return jsonResponse({ status: "PROCESSING_UPLOAD" });
+    };
+    safeFetchImpl = async () => {
+      putCount += 1;
+      if (putCount === 1) throw new Error("response connection reset");
+      return new Response(null, {
+        status: 416,
+        headers: { "content-range": "bytes 0-3/5" },
+      });
+    };
+
+    const result = await tiktokProvider.createPost(credentials, {
+      text: "hello",
+      media: [{ type: "video", data: Buffer.from("video"), mimeType: "video/mp4" }],
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      errorCode: "TIKTOK_UPLOAD_OUTCOME_UNKNOWN",
+      creditDisposition: "hold",
+    });
+    expect(putCount).toBe(2);
   });
 
   test("returns an explicit credit hold when final transport and replay remain unresolved", async () => {

--- a/packages/cloud/shared/src/lib/services/social-media/providers/tiktok-upload.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/tiktok-upload.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Exercises TikTok file upload planning and transport through the real
+ * exported provider with only the external HTTP boundary mocked. The suite
+ * pins decimal-MB ranges, sequential response statuses, and zero-copy views.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
+
+import type { SocialCredentials } from "../../../types/social-media";
+import * as realRateLimit from "../rate-limit";
+
+const realRateLimitExports = { ...realRateLimit };
+
+mock.module("../rate-limit", () => ({
+  withRetry: async <T>(
+    fn: () => Promise<Response>,
+    parser: (response: Response) => Promise<T>,
+  ): Promise<{ data: T }> => ({ data: await parser(await fn()) }),
+}));
+
+const { createTikTokUploadPlan, tiktokProvider } = await import("./tiktok");
+
+const credentials = { accessToken: "test-token" } as SocialCredentials;
+const originalFetch = globalThis.fetch;
+let fetchImpl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ data, error: { code: "ok", message: "" } }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) =>
+    fetchImpl(input, init),
+  ) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterAll(() => {
+  mock.module("../rate-limit", () => realRateLimitExports);
+});
+
+describe("createTikTokUploadPlan", () => {
+  test("uses one exact-size chunk for videos below TikTok's 5 MB minimum", () => {
+    expect(createTikTokUploadPlan(4_999_999)).toEqual({
+      chunkSize: 4_999_999,
+      totalChunkCount: 1,
+      chunks: [{ firstByte: 0, lastByte: 4_999_998, byteLength: 4_999_999 }],
+    });
+  });
+
+  test("uses floor-counted decimal chunks and merges the remainder into the final range", () => {
+    const plan = createTikTokUploadPlan(50_000_123);
+
+    expect(plan.chunkSize).toBe(10_000_000);
+    expect(plan.totalChunkCount).toBe(5);
+    expect(plan.chunks).toEqual([
+      { firstByte: 0, lastByte: 9_999_999, byteLength: 10_000_000 },
+      { firstByte: 10_000_000, lastByte: 19_999_999, byteLength: 10_000_000 },
+      { firstByte: 20_000_000, lastByte: 29_999_999, byteLength: 10_000_000 },
+      { firstByte: 30_000_000, lastByte: 39_999_999, byteLength: 10_000_000 },
+      { firstByte: 40_000_000, lastByte: 50_000_122, byteLength: 10_000_123 },
+    ]);
+  });
+
+  test("plans multiple legal ranges above TikTok's 64 MB mandatory-chunk threshold", () => {
+    const plan = createTikTokUploadPlan(64_000_001);
+
+    expect(plan.totalChunkCount).toBe(6);
+    expect(plan.chunks.at(-1)).toEqual({
+      firstByte: 50_000_000,
+      lastByte: 64_000_000,
+      byteLength: 14_000_001,
+    });
+    expect(plan.chunks.every((chunk) => chunk.byteLength >= 5_000_000)).toBe(true);
+    expect(plan.chunks.every((chunk) => chunk.byteLength <= 64_000_000)).toBe(true);
+  });
+
+  test("rejects empty and non-integral sizes with a contextual domain error", () => {
+    for (const videoSize of [0, 1.5]) {
+      let caught: unknown;
+      try {
+        createTikTokUploadPlan(videoSize);
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBeInstanceOf(ElizaError);
+      expect((caught as ElizaError).code).toBe("TIKTOK_INVALID_VIDEO_SIZE");
+      expect((caught as ElizaError).context).toMatchObject({ videoSize });
+    }
+  });
+});
+
+describe("tiktokProvider file upload", () => {
+  test("sends sequential zero-copy ranges and requires 206 then 201", async () => {
+    const videoData = Buffer.alloc(20_000_001, 0x41);
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+
+    fetchImpl = async (input, init) => {
+      const callIndex = calls.push({ url: String(input), init }) - 1;
+      if (callIndex === 0) {
+        return jsonResponse({
+          publish_id: "publish-1",
+          upload_url: "https://upload.example/video",
+        });
+      }
+      if (callIndex === 1) return new Response(null, { status: 206 });
+      if (callIndex === 2) return new Response(null, { status: 201 });
+      if (callIndex === 3) {
+        return jsonResponse({
+          status: "PUBLISH_COMPLETE",
+          publicaly_available_post_id: ["post-1"],
+        });
+      }
+      throw new Error(`unexpected fetch call ${callIndex}`);
+    };
+
+    const result = await tiktokProvider.createPost(credentials, {
+      text: "hello",
+      media: [{ type: "video", data: videoData, mimeType: "video/mp4" }],
+    });
+
+    expect(result).toMatchObject({ success: true, postId: "post-1" });
+    expect(calls).toHaveLength(4);
+
+    const initBody = JSON.parse(String(calls[0]?.init?.body));
+    expect(initBody.source_info).toEqual({
+      source: "FILE_UPLOAD",
+      video_size: 20_000_001,
+      chunk_size: 10_000_000,
+      total_chunk_count: 2,
+    });
+
+    const firstHeaders = new Headers(calls[1]?.init?.headers);
+    const finalHeaders = new Headers(calls[2]?.init?.headers);
+    expect(firstHeaders.get("content-range")).toBe("bytes 0-9999999/20000001");
+    expect(firstHeaders.get("content-length")).toBe("10000000");
+    expect(finalHeaders.get("content-range")).toBe("bytes 10000000-20000000/20000001");
+    expect(finalHeaders.get("content-length")).toBe("10000001");
+
+    const firstBody = calls[1]?.init?.body;
+    const finalBody = calls[2]?.init?.body;
+    expect(firstBody).toBeInstanceOf(Uint8Array);
+    expect(finalBody).toBeInstanceOf(Uint8Array);
+    expect((firstBody as Uint8Array).buffer).toBe(videoData.buffer);
+    expect((finalBody as Uint8Array).buffer).toBe(videoData.buffer);
+    expect((firstBody as Uint8Array).byteOffset).toBe(videoData.byteOffset);
+    expect((finalBody as Uint8Array).byteOffset).toBe(videoData.byteOffset + 10_000_000);
+  });
+
+  test("accepts SharedArrayBuffer input with one ArrayBuffer copy per chunk", async () => {
+    const sharedBacking = new SharedArrayBuffer(20_000_001);
+    const videoData = Buffer.from(sharedBacking);
+    expect(videoData.buffer).toBe(sharedBacking);
+    videoData[0] = 0x41;
+    videoData[10_000_000] = 0x42;
+    videoData[20_000_000] = 0x43;
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+
+    fetchImpl = async (input, init) => {
+      const callIndex = calls.push({ url: String(input), init }) - 1;
+      if (callIndex === 0) {
+        return jsonResponse({
+          publish_id: "publish-shared",
+          upload_url: "https://upload.example/video",
+        });
+      }
+      if (callIndex === 1) return new Response(null, { status: 206 });
+      if (callIndex === 2) return new Response(null, { status: 201 });
+      if (callIndex === 3) return jsonResponse({ status: "PUBLISH_COMPLETE" });
+      throw new Error(`unexpected fetch call ${callIndex}`);
+    };
+
+    const result = await tiktokProvider.createPost(credentials, {
+      text: "hello",
+      media: [{ type: "video", data: videoData, mimeType: "video/mp4" }],
+    });
+
+    expect(result.success).toBe(true);
+    const firstBody = calls[1]?.init?.body as Uint8Array;
+    const finalBody = calls[2]?.init?.body as Uint8Array;
+    expect(firstBody.buffer).toBeInstanceOf(ArrayBuffer);
+    expect(finalBody.buffer).toBeInstanceOf(ArrayBuffer);
+    expect(firstBody.buffer).not.toBe(sharedBacking);
+    expect(finalBody.buffer).not.toBe(sharedBacking);
+    expect(firstBody.buffer).not.toBe(finalBody.buffer);
+    expect(firstBody.buffer.byteLength).toBe(10_000_000);
+    expect(finalBody.buffer.byteLength).toBe(10_000_001);
+    expect(firstBody.byteLength).toBe(10_000_000);
+    expect(finalBody.byteLength).toBe(10_000_001);
+    expect(firstBody[0]).toBe(0x41);
+    expect(finalBody[0]).toBe(0x42);
+    expect(finalBody.at(-1)).toBe(0x43);
+  });
+
+  test("stops before status polling when an intermediate chunk is not 206", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    fetchImpl = async (input, init) => {
+      const callIndex = calls.push({ url: String(input), init }) - 1;
+      if (callIndex === 0) {
+        return jsonResponse({
+          publish_id: "publish-2",
+          upload_url: "https://upload.example/video",
+        });
+      }
+      return new Response(null, { status: 201 });
+    };
+
+    const result = await tiktokProvider.createPost(credentials, {
+      text: "hello",
+      media: [{ type: "video", data: Buffer.alloc(20_000_001), mimeType: "video/mp4" }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("chunk 1/2 returned 201; expected 206");
+    expect(calls).toHaveLength(2);
+  });
+
+  test("requires 201 for the final chunk and does not poll after a 206", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    fetchImpl = async (input, init) => {
+      const callIndex = calls.push({ url: String(input), init }) - 1;
+      if (callIndex === 0) {
+        return jsonResponse({
+          publish_id: "publish-3",
+          upload_url: "https://upload.example/video",
+        });
+      }
+      return new Response(null, { status: 206 });
+    };
+
+    const result = await tiktokProvider.createPost(credentials, {
+      text: "hello",
+      media: [{ type: "video", data: Buffer.from("video"), mimeType: "video/mp4" }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("chunk 1/1 returned 206; expected 201");
+    expect(calls).toHaveLength(2);
+  });
+
+  test("rejects empty inline video before initializing an upload", async () => {
+    let fetchCount = 0;
+    fetchImpl = async () => {
+      fetchCount += 1;
+      throw new Error("transport must not run");
+    };
+
+    const result = await tiktokProvider.createPost(credentials, {
+      text: "hello",
+      media: [{ type: "video", data: Buffer.alloc(0), mimeType: "video/mp4" }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("positive whole number of bytes");
+    expect(fetchCount).toBe(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/social-media/providers/tiktok-upload.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/tiktok-upload.test.ts
@@ -5,11 +5,18 @@
  */
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { ElizaError } from "@elizaos/core";
-
+import * as realSafeFetch from "../../../security/safe-fetch";
 import type { SocialCredentials } from "../../../types/social-media";
 import * as realRateLimit from "../rate-limit";
 
+const realSafeFetchExports = { ...realSafeFetch };
 const realRateLimitExports = { ...realRateLimit };
+let safeFetchImpl: (input: string, init?: RequestInit) => Promise<Response>;
+
+mock.module("../../../security/safe-fetch", () => ({
+  ...realSafeFetchExports,
+  safeFetch: (input: string, init?: RequestInit) => safeFetchImpl(input, init),
+}));
 
 mock.module("../rate-limit", () => ({
   withRetry: async <T>(
@@ -18,7 +25,12 @@ mock.module("../rate-limit", () => ({
   ): Promise<{ data: T }> => ({ data: await parser(await fn()) }),
 }));
 
-const { createTikTokUploadPlan, tiktokProvider } = await import("./tiktok");
+const {
+  createTikTokUploadPlan,
+  tiktokProvider,
+  validateTikTokUploadUrl,
+  validateTikTokVideoMimeType,
+} = await import("./tiktok");
 
 const credentials = { accessToken: "test-token" } as SocialCredentials;
 const originalFetch = globalThis.fetch;
@@ -32,6 +44,7 @@ function jsonResponse(data: unknown): Response {
 }
 
 beforeEach(() => {
+  safeFetchImpl = (input, init) => fetchImpl(input, init);
   globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) =>
     fetchImpl(input, init),
   ) as typeof fetch;
@@ -42,7 +55,50 @@ afterEach(() => {
 });
 
 afterAll(() => {
+  mock.module("../../../security/safe-fetch", () => realSafeFetchExports);
   mock.module("../rate-limit", () => realRateLimitExports);
+});
+
+function cancellableResponse(status: number, cancellations: number[]): Response {
+  return new Response(
+    new ReadableStream({
+      cancel() {
+        cancellations.push(status);
+      },
+    }),
+    { status },
+  );
+}
+
+describe("TikTok upload input validation", () => {
+  test("accepts only documented HTTPS upload hosts without dropping signed queries", () => {
+    expect(
+      validateTikTokUploadUrl("https://open-upload.tiktokapis.com/video?upload_id=signed"),
+    ).toBe("https://open-upload.tiktokapis.com/video?upload_id=signed");
+    expect(validateTikTokUploadUrl("https://upload.us.tiktokapis.com/video?upload_id=signed")).toBe(
+      "https://upload.us.tiktokapis.com/video?upload_id=signed",
+    );
+
+    for (const url of [
+      "http://open-upload.tiktokapis.com/video",
+      "https://upload..tiktokapis.com/video",
+      "https://upload.us.extra.tiktokapis.com/video",
+      "https://example.com/video",
+      "https://user:secret@open-upload.tiktokapis.com/video",
+      "not a url",
+    ]) {
+      expect(() => validateTikTokUploadUrl(url)).toThrow();
+    }
+  });
+
+  test("normalizes the supported containers and rejects unsupported MIME types", () => {
+    expect(validateTikTokVideoMimeType("video/mp4; codecs=avc1")).toBe("video/mp4");
+    expect(validateTikTokVideoMimeType("VIDEO/QUICKTIME")).toBe("video/quicktime");
+    expect(validateTikTokVideoMimeType("video/webm")).toBe("video/webm");
+    for (const mimeType of ["video/avi", "image/png", ""]) {
+      expect(() => validateTikTokVideoMimeType(mimeType)).toThrow();
+    }
+  });
 });
 
 describe("createTikTokUploadPlan", () => {
@@ -98,20 +154,145 @@ describe("createTikTokUploadPlan", () => {
 });
 
 describe("tiktokProvider file upload", () => {
+  test("preserves QuickTime and WebM content types and rejects unsupported video before init", async () => {
+    for (const mimeType of ["video/quicktime", "video/webm"]) {
+      const calls: Array<{ url: string; init?: RequestInit }> = [];
+      fetchImpl = async (input, init) => {
+        const callIndex = calls.push({ url: String(input), init }) - 1;
+        if (callIndex === 0) {
+          return jsonResponse({
+            publish_id: `publish-${mimeType}`,
+            upload_url: "https://upload.us.tiktokapis.com/video?upload_id=mime",
+          });
+        }
+        if (callIndex === 1) return new Response(null, { status: 201 });
+        return jsonResponse({ status: "PUBLISH_COMPLETE" });
+      };
+
+      const result = await tiktokProvider.createPost(credentials, {
+        text: "hello",
+        media: [{ type: "video", data: Buffer.from("video"), mimeType }],
+      });
+
+      expect(result.success).toBe(true);
+      expect(new Headers(calls[1]?.init?.headers).get("content-type")).toBe(mimeType);
+    }
+
+    let fetchCount = 0;
+    fetchImpl = async () => {
+      fetchCount += 1;
+      throw new Error("transport must not run");
+    };
+    const rejected = await tiktokProvider.createPost(credentials, {
+      text: "hello",
+      media: [{ type: "video", data: Buffer.from("video"), mimeType: "video/avi" }],
+    });
+    expect(rejected).toMatchObject({ success: false, errorCode: "TIKTOK_VIDEO_MIME_INVALID" });
+    expect(fetchCount).toBe(0);
+  });
+
+  test("rejects untrusted and private-resolving upload URLs before any outbound PUT", async () => {
+    for (const uploadUrl of [
+      "http://open-upload.tiktokapis.com/video",
+      "https://example.com/video",
+      "https://user:secret@open-upload.tiktokapis.com/video",
+    ]) {
+      let uploadFetchCount = 0;
+      fetchImpl = async () =>
+        jsonResponse({ publish_id: "publish-untrusted", upload_url: uploadUrl });
+      safeFetchImpl = async () => {
+        uploadFetchCount += 1;
+        throw new Error("upload transport must not run");
+      };
+
+      const result = await tiktokProvider.createPost(credentials, {
+        text: "hello",
+        media: [{ type: "video", data: Buffer.from("video"), mimeType: "video/mp4" }],
+      });
+      expect(result).toMatchObject({ success: false, errorCode: "TIKTOK_UPLOAD_URL_INVALID" });
+      expect(uploadFetchCount).toBe(0);
+    }
+
+    let guardCallCount = 0;
+    let apiCallCount = 0;
+    fetchImpl = async () => {
+      apiCallCount += 1;
+      if (apiCallCount === 1) {
+        return jsonResponse({
+          publish_id: "publish-private",
+          upload_url: "https://upload.private.tiktokapis.com/video",
+        });
+      }
+      return jsonResponse({ status: "FAILED", fail_reason: "upload not received" });
+    };
+    safeFetchImpl = async () => {
+      guardCallCount += 1;
+      // Mirrors safeFetch rejecting the allowed-form hostname during DNS
+      // screening, before its pinned transport opens a socket.
+      throw new Error("Endpoint resolves to a private or reserved IP address");
+    };
+    const privateResult = await tiktokProvider.createPost(credentials, {
+      text: "hello",
+      media: [{ type: "video", data: Buffer.from("video"), mimeType: "video/mp4" }],
+    });
+    expect(privateResult.success).toBe(false);
+    expect(guardCallCount).toBe(1);
+    expect(apiCallCount).toBe(2);
+  });
+
+  test("rejects and disposes redirects without sending bytes to their target", async () => {
+    let apiCallCount = 0;
+    let uploadCallCount = 0;
+    const cancellations: number[] = [];
+    fetchImpl = async () => {
+      apiCallCount += 1;
+      return jsonResponse({
+        publish_id: "publish-redirect",
+        upload_url: "https://open-upload.tiktokapis.com/video?upload_id=redirect",
+      });
+    };
+    safeFetchImpl = async (_input, init) => {
+      uploadCallCount += 1;
+      expect(init?.redirect).toBe("manual");
+      return new Response(
+        new ReadableStream({
+          cancel() {
+            cancellations.push(307);
+          },
+        }),
+        { status: 307, headers: { location: "https://attacker.example/steal" } },
+      );
+    };
+
+    const result = await tiktokProvider.createPost(credentials, {
+      text: "hello",
+      media: [{ type: "video", data: Buffer.from("video"), mimeType: "video/mp4" }],
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      errorCode: "TIKTOK_UPLOAD_CHUNK_STATUS_INVALID",
+    });
+    expect(apiCallCount).toBe(1);
+    expect(uploadCallCount).toBe(1);
+    expect(cancellations).toEqual([307]);
+  });
+
   test("sends sequential zero-copy ranges and requires 206 then 201", async () => {
     const videoData = Buffer.alloc(20_000_001, 0x41);
     const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const cancellations: number[] = [];
 
     fetchImpl = async (input, init) => {
       const callIndex = calls.push({ url: String(input), init }) - 1;
       if (callIndex === 0) {
         return jsonResponse({
           publish_id: "publish-1",
-          upload_url: "https://upload.example/video",
+          upload_url: "https://open-upload.tiktokapis.com/video?upload_id=publish-1",
         });
       }
-      if (callIndex === 1) return new Response(null, { status: 206 });
-      if (callIndex === 2) return new Response(null, { status: 201 });
+      if (callIndex === 1) return cancellableResponse(206, cancellations);
+      if (callIndex === 2) return cancellableResponse(201, cancellations);
       if (callIndex === 3) {
         return jsonResponse({
           status: "PUBLISH_COMPLETE",
@@ -141,6 +322,7 @@ describe("tiktokProvider file upload", () => {
     const finalHeaders = new Headers(calls[2]?.init?.headers);
     expect(firstHeaders.get("content-range")).toBe("bytes 0-9999999/20000001");
     expect(firstHeaders.get("content-length")).toBe("10000000");
+    expect(firstHeaders.get("content-type")).toBe("video/mp4");
     expect(finalHeaders.get("content-range")).toBe("bytes 10000000-20000000/20000001");
     expect(finalHeaders.get("content-length")).toBe("10000001");
 
@@ -152,6 +334,156 @@ describe("tiktokProvider file upload", () => {
     expect((finalBody as Uint8Array).buffer).toBe(videoData.buffer);
     expect((firstBody as Uint8Array).byteOffset).toBe(videoData.byteOffset);
     expect((finalBody as Uint8Array).byteOffset).toBe(videoData.byteOffset + 10_000_000);
+    expect(cancellations).toEqual([206, 201]);
+    expect(calls[1]?.init?.redirect).toBe("manual");
+    expect(calls[1]?.url).toContain("upload_id=publish-1");
+  });
+
+  test("retries identical 5xx ranges, disposes responses, and accepts the final 201", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const cancellations: number[] = [];
+    fetchImpl = async (input, init) => {
+      const callIndex = calls.push({ url: String(input), init }) - 1;
+      if (callIndex === 0) {
+        return jsonResponse({
+          publish_id: "publish-retry",
+          upload_url: "https://open-upload.tiktokapis.com/video?upload_id=retry",
+        });
+      }
+      if (callIndex === 1) return cancellableResponse(503, cancellations);
+      if (callIndex === 2) return cancellableResponse(201, cancellations);
+      return jsonResponse({ status: "PUBLISH_COMPLETE" });
+    };
+
+    const result = await tiktokProvider.createPost(credentials, {
+      text: "hello",
+      media: [{ type: "video", data: Buffer.from("video"), mimeType: "video/webm" }],
+    });
+
+    expect(result.success).toBe(true);
+    expect(cancellations).toEqual([503, 201]);
+    expect(new Headers(calls[1]?.init?.headers)).toEqual(new Headers(calls[2]?.init?.headers));
+    expect(calls[1]?.init?.body).toEqual(calls[2]?.init?.body);
+  });
+
+  test("stops after bounded 5xx retries and disposes every response", async () => {
+    let apiCallCount = 0;
+    let putCount = 0;
+    const cancellations: number[] = [];
+    fetchImpl = async () => {
+      apiCallCount += 1;
+      return jsonResponse({
+        publish_id: "publish-503",
+        upload_url: "https://open-upload.tiktokapis.com/video?upload_id=503",
+      });
+    };
+    safeFetchImpl = async () => {
+      putCount += 1;
+      return cancellableResponse(503, cancellations);
+    };
+
+    const result = await tiktokProvider.createPost(credentials, {
+      text: "hello",
+      media: [{ type: "video", data: Buffer.from("video"), mimeType: "video/mp4" }],
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      errorCode: "TIKTOK_UPLOAD_CHUNK_STATUS_INVALID",
+    });
+    expect(apiCallCount).toBe(1);
+    expect(putCount).toBe(3);
+    expect(cancellations).toEqual([503, 503, 503]);
+  });
+
+  test("does not retry a lost final response before status reconciliation", async () => {
+    let apiCallCount = 0;
+    let putCount = 0;
+    fetchImpl = async () => {
+      apiCallCount += 1;
+      if (apiCallCount === 1) {
+        return jsonResponse({
+          publish_id: "publish-lost-final",
+          upload_url: "https://open-upload.tiktokapis.com/video?upload_id=lost",
+        });
+      }
+      return jsonResponse({
+        status: "PUBLISH_COMPLETE",
+        publicaly_available_post_id: ["post-reconciled"],
+      });
+    };
+    safeFetchImpl = async () => {
+      putCount += 1;
+      throw new Error("response connection reset");
+    };
+
+    const result = await tiktokProvider.createPost(credentials, {
+      text: "hello",
+      media: [{ type: "video", data: Buffer.from("video"), mimeType: "video/mp4" }],
+    });
+
+    expect(result).toMatchObject({ success: true, postId: "post-reconciled" });
+    expect(putCount).toBe(1);
+  });
+
+  test("replays the same final range only after PROCESSING_UPLOAD reconciliation", async () => {
+    let apiCallCount = 0;
+    const putCalls: RequestInit[] = [];
+    fetchImpl = async () => {
+      apiCallCount += 1;
+      if (apiCallCount === 1) {
+        return jsonResponse({
+          publish_id: "publish-replay",
+          upload_url: "https://open-upload.tiktokapis.com/video?upload_id=replay",
+        });
+      }
+      if (apiCallCount === 2) return jsonResponse({ status: "PROCESSING_UPLOAD" });
+      return jsonResponse({ status: "PUBLISH_COMPLETE" });
+    };
+    safeFetchImpl = async (_input, init) => {
+      putCalls.push(init ?? {});
+      if (putCalls.length === 1) throw new Error("response connection reset");
+      return new Response(null, { status: 201 });
+    };
+
+    const result = await tiktokProvider.createPost(credentials, {
+      text: "hello",
+      media: [{ type: "video", data: Buffer.from("video"), mimeType: "video/mp4" }],
+    });
+
+    expect(result.success).toBe(true);
+    expect(putCalls).toHaveLength(2);
+    expect(new Headers(putCalls[0]?.headers)).toEqual(new Headers(putCalls[1]?.headers));
+    expect(putCalls[0]?.body).toEqual(putCalls[1]?.body);
+  });
+
+  test("returns an explicit credit hold when final transport and replay remain unresolved", async () => {
+    let apiCallCount = 0;
+    fetchImpl = async () => {
+      apiCallCount += 1;
+      if (apiCallCount === 1) {
+        return jsonResponse({
+          publish_id: "publish-unknown",
+          upload_url: "https://open-upload.tiktokapis.com/video?upload_id=unknown",
+        });
+      }
+      return jsonResponse({ status: "PROCESSING_UPLOAD" });
+    };
+    safeFetchImpl = async () => {
+      throw new Error("response connection reset");
+    };
+
+    const result = await tiktokProvider.createPost(credentials, {
+      text: "hello",
+      media: [{ type: "video", data: Buffer.from("video"), mimeType: "video/mp4" }],
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      errorCode: "TIKTOK_UPLOAD_OUTCOME_UNKNOWN",
+      creditDisposition: "hold",
+      metadata: { publishId: "publish-unknown", providerStatus: "PROCESSING_UPLOAD" },
+    });
   });
 
   test("accepts SharedArrayBuffer input with one ArrayBuffer copy per chunk", async () => {
@@ -168,7 +500,7 @@ describe("tiktokProvider file upload", () => {
       if (callIndex === 0) {
         return jsonResponse({
           publish_id: "publish-shared",
-          upload_url: "https://upload.example/video",
+          upload_url: "https://upload.us.tiktokapis.com/video?upload_id=shared",
         });
       }
       if (callIndex === 1) return new Response(null, { status: 206 });
@@ -201,15 +533,16 @@ describe("tiktokProvider file upload", () => {
 
   test("stops before status polling when an intermediate chunk is not 206", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const cancellations: number[] = [];
     fetchImpl = async (input, init) => {
       const callIndex = calls.push({ url: String(input), init }) - 1;
       if (callIndex === 0) {
         return jsonResponse({
           publish_id: "publish-2",
-          upload_url: "https://upload.example/video",
+          upload_url: "https://open-upload.tiktokapis.com/video?upload_id=publish-2",
         });
       }
-      return new Response(null, { status: 201 });
+      return cancellableResponse(201, cancellations);
     };
 
     const result = await tiktokProvider.createPost(credentials, {
@@ -220,6 +553,7 @@ describe("tiktokProvider file upload", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("chunk 1/2 returned 201; expected 206");
     expect(calls).toHaveLength(2);
+    expect(cancellations).toEqual([201]);
   });
 
   test("requires 201 for the final chunk and does not poll after a 206", async () => {
@@ -229,7 +563,7 @@ describe("tiktokProvider file upload", () => {
       if (callIndex === 0) {
         return jsonResponse({
           publish_id: "publish-3",
-          upload_url: "https://upload.example/video",
+          upload_url: "https://open-upload.tiktokapis.com/video?upload_id=publish-3",
         });
       }
       return new Response(null, { status: 206 });

--- a/packages/cloud/shared/src/lib/services/social-media/providers/tiktok.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/tiktok.ts
@@ -169,12 +169,32 @@ function waitBeforeTikTokUploadRetry(attempt: number): Promise<void> {
   );
 }
 
+function uploadResponseProvesChunkCommitted(
+  response: Response,
+  chunk: TikTokUploadChunk,
+  videoSize: number,
+): boolean {
+  if (response.status !== 416) return false;
+  const progress = response.headers.get("content-range")?.match(/^bytes 0-(\d+)\/(\d+)$/i);
+  if (!progress) return false;
+  const receivedLastByte = Number(progress[1]);
+  const reportedVideoSize = Number(progress[2]);
+  return (
+    Number.isSafeInteger(receivedLastByte) &&
+    Number.isSafeInteger(reportedVideoSize) &&
+    reportedVideoSize === videoSize &&
+    receivedLastByte < reportedVideoSize &&
+    receivedLastByte === chunk.lastByte
+  );
+}
+
 async function uploadTikTokVideo(
   uploadUrl: string,
   videoData: Buffer,
   plan: TikTokUploadPlan,
   mimeType: string,
   startChunkIndex = 0,
+  reconciling = false,
 ): Promise<void> {
   for (let index = startChunkIndex; index < plan.chunks.length; index += 1) {
     const chunk = plan.chunks[index];
@@ -228,7 +248,12 @@ async function uploadTikTokVideo(
       }
 
       try {
-        if (response.status === expectedStatus) break;
+        if (
+          response.status === expectedStatus ||
+          uploadResponseProvesChunkCommitted(response, chunk, videoData.length)
+        ) {
+          break;
+        }
 
         if (
           response.status >= 500 &&
@@ -239,9 +264,13 @@ async function uploadTikTokVideo(
           continue;
         }
 
+        const outcomeUnknown =
+          reconciling ||
+          response.status === 416 ||
+          (response.status >= 500 && response.status <= 599);
         throw tiktokUploadError(
           `TikTok upload chunk ${index + 1}/${plan.totalChunkCount} returned ${response.status}; expected ${expectedStatus}`,
-          "TIKTOK_UPLOAD_CHUNK_STATUS_INVALID",
+          outcomeUnknown ? "TIKTOK_UPLOAD_OUTCOME_UNKNOWN" : "TIKTOK_UPLOAD_CHUNK_STATUS_INVALID",
           {
             chunkIndex: index,
             totalChunkCount: plan.totalChunkCount,
@@ -569,6 +598,7 @@ export const tiktokProvider: SocialMediaProvider = {
                   uploadPlan,
                   videoMimeType,
                   chunkIndex,
+                  true,
                 );
                 reconciliation = await waitForPublish(
                   credentials.accessToken,

--- a/packages/cloud/shared/src/lib/services/social-media/providers/tiktok.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/tiktok.ts
@@ -5,6 +5,7 @@
 
 import { ElizaError } from "@elizaos/core";
 
+import { safeFetch } from "../../../security/safe-fetch";
 import type {
   AccountAnalytics,
   MediaAttachment,
@@ -15,7 +16,10 @@ import type {
   SocialCredentials,
   SocialMediaProvider,
 } from "../../../types/social-media";
-import { SOCIAL_MEDIA_VIDEO_MAX_BYTES } from "../../../types/social-media";
+import {
+  SOCIAL_MEDIA_VIDEO_MAX_BASE64_BYTES,
+  SOCIAL_MEDIA_VIDEO_MAX_BYTES,
+} from "../../../types/social-media";
 import { extractErrorMessage } from "../../../utils/error-handling";
 import { logger } from "../../../utils/logger";
 import { assertSocialMediaBytesWithinBudget, decodeSocialMediaBase64 } from "../media-download";
@@ -25,6 +29,9 @@ const TIKTOK_API_BASE = "https://open.tiktokapis.com/v2";
 
 const TIKTOK_REQUEST_TIMEOUT_MS = 30_000;
 const TIKTOK_UPLOAD_CHUNK_BYTES = 10_000_000;
+const TIKTOK_UPLOAD_MAX_RETRIES = 2;
+const TIKTOK_UPLOAD_RETRY_BASE_DELAY_MS = 100;
+const TIKTOK_VIDEO_MIME_TYPES = new Set(["video/mp4", "video/quicktime", "video/webm"]);
 
 export interface TikTokUploadChunk {
   firstByte: number;
@@ -36,6 +43,73 @@ export interface TikTokUploadPlan {
   chunkSize: number;
   totalChunkCount: number;
   chunks: TikTokUploadChunk[];
+}
+
+function tiktokUploadError(
+  message: string,
+  code: string,
+  context: Record<string, unknown>,
+  cause?: unknown,
+): ElizaError {
+  return new ElizaError(message, {
+    code,
+    context,
+    severity: "ephemeral",
+    ...(cause === undefined ? {} : { cause }),
+  });
+}
+
+/** Normalizes the three video containers accepted by TikTok's upload API. */
+export function validateTikTokVideoMimeType(mimeType: string): string {
+  const normalized = mimeType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+  if (!TIKTOK_VIDEO_MIME_TYPES.has(normalized)) {
+    throw tiktokUploadError(
+      "TikTok file uploads require MP4, QuickTime, or WebM video",
+      "TIKTOK_VIDEO_MIME_INVALID",
+      {
+        mimeType,
+      },
+    );
+  }
+  return normalized;
+}
+
+/**
+ * Restricts provider-returned upload capabilities to TikTok's documented
+ * HTTPS host family before the shared DNS/SSRF guard opens a connection.
+ */
+export function validateTikTokUploadUrl(rawUrl: string): string {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch (cause) {
+    throw tiktokUploadError(
+      "TikTok returned an invalid upload URL",
+      "TIKTOK_UPLOAD_URL_INVALID",
+      {},
+      cause,
+    );
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  const allowedHost =
+    hostname === "open-upload.tiktokapis.com" ||
+    /^upload\.[a-z0-9-]+\.tiktokapis\.com$/.test(hostname);
+  if (
+    url.protocol !== "https:" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    (url.port !== "" && url.port !== "443") ||
+    !allowedHost
+  ) {
+    throw tiktokUploadError(
+      "TikTok returned an upload URL outside the allowed HTTPS host family",
+      "TIKTOK_UPLOAD_URL_INVALID",
+      { protocol: url.protocol, hostname, port: url.port || "443" },
+    );
+  }
+
+  return url.toString();
 }
 
 /**
@@ -80,30 +154,95 @@ function uploadBodyView(videoData: Buffer, chunk: TikTokUploadChunk): Uint8Array
   return Uint8Array.from(chunkView);
 }
 
+async function cancelTikTokUploadResponse(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // error-policy:J6 Upload response teardown is best-effort after its status
+    // has already supplied the authoritative transport result.
+  }
+}
+
+function waitBeforeTikTokUploadRetry(attempt: number): Promise<void> {
+  return new Promise((resolve) =>
+    setTimeout(resolve, TIKTOK_UPLOAD_RETRY_BASE_DELAY_MS * 2 ** attempt),
+  );
+}
+
 async function uploadTikTokVideo(
   uploadUrl: string,
   videoData: Buffer,
   plan: TikTokUploadPlan,
+  mimeType: string,
+  startChunkIndex = 0,
 ): Promise<void> {
-  for (const [index, chunk] of plan.chunks.entries()) {
+  for (let index = startChunkIndex; index < plan.chunks.length; index += 1) {
+    const chunk = plan.chunks[index];
+    if (!chunk) {
+      throw tiktokUploadError(
+        "TikTok upload plan is missing a requested chunk",
+        "TIKTOK_UPLOAD_PLAN_INVALID",
+        {
+          chunkIndex: index,
+          totalChunkCount: plan.totalChunkCount,
+        },
+      );
+    }
     const finalChunk = index === plan.chunks.length - 1;
     const expectedStatus = finalChunk ? 201 : 206;
-    const response = await tiktokFetch(uploadUrl, {
-      method: "PUT",
-      headers: {
-        "Content-Type": "video/mp4",
-        "Content-Length": String(chunk.byteLength),
-        "Content-Range": `bytes ${chunk.firstByte}-${chunk.lastByte}/${videoData.length}`,
-      },
-      body: uploadBodyView(videoData, chunk),
-    });
+    for (let attempt = 0; attempt <= TIKTOK_UPLOAD_MAX_RETRIES; attempt += 1) {
+      let response: Response | undefined;
+      try {
+        response = await safeFetch(uploadUrl, {
+          method: "PUT",
+          redirect: "manual",
+          headers: {
+            "Content-Type": mimeType,
+            "Content-Length": String(chunk.byteLength),
+            "Content-Range": `bytes ${chunk.firstByte}-${chunk.lastByte}/${videoData.length}`,
+          },
+          body: uploadBodyView(videoData, chunk),
+          signal: AbortSignal.timeout(TIKTOK_REQUEST_TIMEOUT_MS),
+        });
+      } catch (cause) {
+        // error-policy:J2 Preserve the ambiguous transport failure: the remote
+        // side may have committed the range even though its response was lost.
+        // A final-chunk response loss is reconciled before any replay because
+        // it may be a lost 201. Intermediate ranges use bounded exact replay.
+        if (!finalChunk && attempt < TIKTOK_UPLOAD_MAX_RETRIES) {
+          await waitBeforeTikTokUploadRetry(attempt);
+          continue;
+        }
+        throw tiktokUploadError(
+          `TikTok upload chunk ${index + 1}/${plan.totalChunkCount} has an unknown remote outcome`,
+          "TIKTOK_UPLOAD_OUTCOME_UNKNOWN",
+          {
+            chunkIndex: index,
+            totalChunkCount: plan.totalChunkCount,
+            firstByte: chunk.firstByte,
+            lastByte: chunk.lastByte,
+            finalChunk,
+          },
+          cause,
+        );
+      }
 
-    if (response.status !== expectedStatus) {
-      throw new ElizaError(
-        `TikTok upload chunk ${index + 1}/${plan.totalChunkCount} returned ${response.status}; expected ${expectedStatus}`,
-        {
-          code: "TIKTOK_UPLOAD_CHUNK_STATUS_INVALID",
-          context: {
+      try {
+        if (response.status === expectedStatus) break;
+
+        if (
+          response.status >= 500 &&
+          response.status <= 599 &&
+          attempt < TIKTOK_UPLOAD_MAX_RETRIES
+        ) {
+          await waitBeforeTikTokUploadRetry(attempt);
+          continue;
+        }
+
+        throw tiktokUploadError(
+          `TikTok upload chunk ${index + 1}/${plan.totalChunkCount} returned ${response.status}; expected ${expectedStatus}`,
+          "TIKTOK_UPLOAD_CHUNK_STATUS_INVALID",
+          {
             chunkIndex: index,
             totalChunkCount: plan.totalChunkCount,
             firstByte: chunk.firstByte,
@@ -111,9 +250,10 @@ async function uploadTikTokVideo(
             actualStatus: response.status,
             expectedStatus,
           },
-          severity: "ephemeral",
-        },
-      );
+        );
+      } finally {
+        await cancelTikTokUploadResponse(response);
+      }
     }
   }
 }
@@ -204,28 +344,41 @@ async function waitForPublish(
   const startTime = Date.now();
 
   while (Date.now() - startTime < maxWait) {
-    const status = await tiktokApiRequest<TikTokPublishStatus>(
-      `/post/publish/status/fetch/`,
-      accessToken,
-      {
-        method: "POST",
-        body: JSON.stringify({ publish_id: publishId }),
-      },
-    );
+    const status = await fetchPublishStatus(accessToken, publishId);
 
     if (status.status === "PUBLISH_COMPLETE") {
       return status;
     }
 
     if (status.status === "FAILED") {
-      throw new Error(status.fail_reason || "Publish failed");
+      throw tiktokUploadError(
+        status.fail_reason || "TikTok publish failed",
+        "TIKTOK_PUBLISH_FAILED",
+        {
+          publishId,
+        },
+      );
     }
 
     // Wait before checking again
     await new Promise((resolve) => setTimeout(resolve, 5000));
   }
 
-  throw new Error("Publish timeout");
+  throw tiktokUploadError(
+    "TikTok publish status is still unresolved",
+    "TIKTOK_PUBLISH_STATUS_UNKNOWN",
+    {
+      publishId,
+      maxWait,
+    },
+  );
+}
+
+function fetchPublishStatus(accessToken: string, publishId: string): Promise<TikTokPublishStatus> {
+  return tiktokApiRequest<TikTokPublishStatus>(`/post/publish/status/fetch/`, accessToken, {
+    method: "POST",
+    body: JSON.stringify({ publish_id: publishId }),
+  });
 }
 
 export const tiktokProvider: SocialMediaProvider = {
@@ -337,6 +490,7 @@ export const tiktokProvider: SocialMediaProvider = {
 
       // File upload method (requires chunked upload)
       if (video.data || video.base64) {
+        const videoMimeType = validateTikTokVideoMimeType(video.mimeType);
         // Bounded against the video ceiling rather than the image budget: the
         // decode is a single allocation inside the Worker isolate, so it needs
         // a bound even though 10 MiB would reject ordinary video posts.
@@ -350,7 +504,7 @@ export const tiktokProvider: SocialMediaProvider = {
           : decodeSocialMediaBase64(
               video.base64!,
               { platform: "tiktok" },
-              SOCIAL_MEDIA_VIDEO_MAX_BYTES,
+              SOCIAL_MEDIA_VIDEO_MAX_BASE64_BYTES,
             );
         const uploadPlan = createTikTokUploadPlan(videoData.length);
 
@@ -373,10 +527,124 @@ export const tiktokProvider: SocialMediaProvider = {
         );
 
         if (!initResponse.upload_url) {
-          throw new Error("No upload URL provided");
+          throw tiktokUploadError(
+            "TikTok did not provide an upload URL",
+            "TIKTOK_UPLOAD_URL_MISSING",
+            { publishId: initResponse.publish_id },
+          );
         }
 
-        await uploadTikTokVideo(initResponse.upload_url, videoData, uploadPlan);
+        const uploadUrl = validateTikTokUploadUrl(initResponse.upload_url);
+        try {
+          await uploadTikTokVideo(uploadUrl, videoData, uploadPlan, videoMimeType);
+        } catch (error) {
+          if (!(error instanceof ElizaError) || error.code !== "TIKTOK_UPLOAD_OUTCOME_UNKNOWN") {
+            throw error;
+          }
+
+          // error-policy:J4 A lost upload response is neither success nor a
+          // refund-safe failure. Query TikTok once: terminal state is
+          // authoritative; unresolved state is visibly returned with a credit
+          // hold so no duplicate post/refund is fabricated.
+          let reconciliation: TikTokPublishStatus | undefined;
+          try {
+            reconciliation = await fetchPublishStatus(
+              credentials.accessToken,
+              initResponse.publish_id,
+            );
+          } catch (reconciliationError) {
+            logger.warn("[TikTok] Upload outcome reconciliation request failed", {
+              publishId: initResponse.publish_id,
+              error: extractErrorMessage(reconciliationError),
+            });
+          }
+
+          if (reconciliation?.status === "PROCESSING_UPLOAD") {
+            const chunkIndex = error.context?.chunkIndex;
+            if (typeof chunkIndex === "number") {
+              try {
+                await uploadTikTokVideo(
+                  uploadUrl,
+                  videoData,
+                  uploadPlan,
+                  videoMimeType,
+                  chunkIndex,
+                );
+                reconciliation = await waitForPublish(
+                  credentials.accessToken,
+                  initResponse.publish_id,
+                );
+              } catch (replayError) {
+                if (
+                  !(replayError instanceof ElizaError) ||
+                  !["TIKTOK_UPLOAD_OUTCOME_UNKNOWN", "TIKTOK_PUBLISH_STATUS_UNKNOWN"].includes(
+                    replayError.code,
+                  )
+                ) {
+                  throw replayError;
+                }
+                logger.warn("[TikTok] Upload replay remains unresolved", {
+                  publishId: initResponse.publish_id,
+                  chunkIndex,
+                  error: extractErrorMessage(replayError),
+                });
+              }
+            }
+          } else if (
+            reconciliation?.status === "PROCESSING_DOWNLOAD" ||
+            reconciliation?.status === "SEND_TO_USER_INBOX"
+          ) {
+            try {
+              reconciliation = await waitForPublish(
+                credentials.accessToken,
+                initResponse.publish_id,
+              );
+            } catch (statusError) {
+              if (
+                !(statusError instanceof ElizaError) ||
+                statusError.code !== "TIKTOK_PUBLISH_STATUS_UNKNOWN"
+              ) {
+                throw statusError;
+              }
+              logger.warn("[TikTok] Advanced publish status remains unresolved", {
+                publishId: initResponse.publish_id,
+                error: extractErrorMessage(statusError),
+              });
+            }
+          }
+
+          if (reconciliation?.status === "PUBLISH_COMPLETE") {
+            const postId = reconciliation.publicaly_available_post_id?.[0];
+            return {
+              platform: "tiktok",
+              success: true,
+              postId: postId || initResponse.publish_id,
+              postUrl: postId ? `https://www.tiktok.com/@me/video/${postId}` : undefined,
+              metadata: { publishId: initResponse.publish_id, reconciled: true },
+            };
+          }
+
+          if (reconciliation?.status === "FAILED") {
+            throw tiktokUploadError(
+              reconciliation.fail_reason || "TikTok upload failed after an ambiguous response",
+              "TIKTOK_UPLOAD_FAILED_AFTER_RECONCILIATION",
+              { publishId: initResponse.publish_id },
+              error,
+            );
+          }
+
+          return {
+            platform: "tiktok",
+            success: false,
+            error: "TikTok upload outcome is still being reconciled",
+            errorCode: "TIKTOK_UPLOAD_OUTCOME_UNKNOWN",
+            creditDisposition: "hold",
+            metadata: {
+              publishId: initResponse.publish_id,
+              providerStatus: reconciliation?.status ?? "UNKNOWN",
+            },
+          };
+        }
 
         // Wait for publish to complete
         const status = await waitForPublish(credentials.accessToken, initResponse.publish_id);
@@ -405,6 +673,7 @@ export const tiktokProvider: SocialMediaProvider = {
         platform: "tiktok",
         success: false,
         error: extractErrorMessage(error),
+        errorCode: error instanceof ElizaError ? error.code : undefined,
       };
     }
   },

--- a/packages/cloud/shared/src/lib/services/social-media/providers/tiktok.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/tiktok.ts
@@ -1,6 +1,9 @@
 /**
- * TikTok Provider - Content Posting API
+ * Implements TikTok Content Posting API operations, including bounded inline
+ * video transfer through the provider's sequential ranged-upload protocol.
  */
+
+import { ElizaError } from "@elizaos/core";
 
 import type {
   AccountAnalytics,
@@ -21,6 +24,99 @@ import { withRetry } from "../rate-limit";
 const TIKTOK_API_BASE = "https://open.tiktokapis.com/v2";
 
 const TIKTOK_REQUEST_TIMEOUT_MS = 30_000;
+const TIKTOK_UPLOAD_CHUNK_BYTES = 10_000_000;
+
+export interface TikTokUploadChunk {
+  firstByte: number;
+  lastByte: number;
+  byteLength: number;
+}
+
+export interface TikTokUploadPlan {
+  chunkSize: number;
+  totalChunkCount: number;
+  chunks: TikTokUploadChunk[];
+}
+
+/**
+ * Plans the sequential ranges required by TikTok's decimal-MB upload
+ * protocol. The final range absorbs the remainder so it cannot become an
+ * undersized trailing chunk.
+ */
+export function createTikTokUploadPlan(videoSize: number): TikTokUploadPlan {
+  if (!Number.isSafeInteger(videoSize) || videoSize <= 0) {
+    throw new ElizaError("TikTok video data must contain a positive whole number of bytes", {
+      code: "TIKTOK_INVALID_VIDEO_SIZE",
+      context: { videoSize },
+      severity: "ephemeral",
+    });
+  }
+
+  const chunkSize = Math.min(videoSize, TIKTOK_UPLOAD_CHUNK_BYTES);
+  const totalChunkCount = Math.floor(videoSize / chunkSize);
+  const chunks = Array.from({ length: totalChunkCount }, (_, index) => {
+    const firstByte = index * chunkSize;
+    const lastByte = index === totalChunkCount - 1 ? videoSize - 1 : firstByte + chunkSize - 1;
+    return {
+      firstByte,
+      lastByte,
+      byteLength: lastByte - firstByte + 1,
+    };
+  });
+
+  return { chunkSize, totalChunkCount, chunks };
+}
+
+function uploadBodyView(videoData: Buffer, chunk: TikTokUploadChunk): Uint8Array<ArrayBuffer> {
+  const chunkView = videoData.subarray(chunk.firstByte, chunk.lastByte + 1);
+  if (videoData.buffer instanceof ArrayBuffer) {
+    return new Uint8Array(videoData.buffer, chunkView.byteOffset, chunkView.byteLength);
+  }
+
+  // Fetch BodyInit requires ArrayBuffer-backed views in the Worker types. A
+  // SharedArrayBuffer input was accepted before ranged uploads, so retain that
+  // compatibility with one bounded copy per outgoing chunk, never a second
+  // full-video allocation.
+  return Uint8Array.from(chunkView);
+}
+
+async function uploadTikTokVideo(
+  uploadUrl: string,
+  videoData: Buffer,
+  plan: TikTokUploadPlan,
+): Promise<void> {
+  for (const [index, chunk] of plan.chunks.entries()) {
+    const finalChunk = index === plan.chunks.length - 1;
+    const expectedStatus = finalChunk ? 201 : 206;
+    const response = await tiktokFetch(uploadUrl, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "video/mp4",
+        "Content-Length": String(chunk.byteLength),
+        "Content-Range": `bytes ${chunk.firstByte}-${chunk.lastByte}/${videoData.length}`,
+      },
+      body: uploadBodyView(videoData, chunk),
+    });
+
+    if (response.status !== expectedStatus) {
+      throw new ElizaError(
+        `TikTok upload chunk ${index + 1}/${plan.totalChunkCount} returned ${response.status}; expected ${expectedStatus}`,
+        {
+          code: "TIKTOK_UPLOAD_CHUNK_STATUS_INVALID",
+          context: {
+            chunkIndex: index,
+            totalChunkCount: plan.totalChunkCount,
+            firstByte: chunk.firstByte,
+            lastByte: chunk.lastByte,
+            actualStatus: response.status,
+            expectedStatus,
+          },
+          severity: "ephemeral",
+        },
+      );
+    }
+  }
+}
 
 /**
  * Bound every TikTok REST hop so a hung or rate-limited API cannot pin the
@@ -256,7 +352,7 @@ export const tiktokProvider: SocialMediaProvider = {
               { platform: "tiktok" },
               SOCIAL_MEDIA_VIDEO_MAX_BYTES,
             );
-        const videoBody = new Uint8Array(videoData);
+        const uploadPlan = createTikTokUploadPlan(videoData.length);
 
         // Initialize chunked upload
         const initResponse = await tiktokApiRequest<TikTokPublishInfo>(
@@ -269,8 +365,8 @@ export const tiktokProvider: SocialMediaProvider = {
               source_info: {
                 source: "FILE_UPLOAD",
                 video_size: videoData.length,
-                chunk_size: 10 * 1024 * 1024, // 10MB chunks
-                total_chunk_count: Math.ceil(videoData.length / (10 * 1024 * 1024)),
+                chunk_size: uploadPlan.chunkSize,
+                total_chunk_count: uploadPlan.totalChunkCount,
               },
             }),
           },
@@ -280,19 +376,7 @@ export const tiktokProvider: SocialMediaProvider = {
           throw new Error("No upload URL provided");
         }
 
-        // Upload the video
-        const uploadResponse = await tiktokFetch(initResponse.upload_url, {
-          method: "PUT",
-          headers: {
-            "Content-Type": "video/mp4",
-            "Content-Length": String(videoData.length),
-          },
-          body: videoBody,
-        });
-
-        if (!uploadResponse.ok) {
-          throw new Error(`Upload failed: ${uploadResponse.status}`);
-        }
+        await uploadTikTokVideo(initResponse.upload_url, videoData, uploadPlan);
 
         // Wait for publish to complete
         const status = await waitForPublish(credentials.accessToken, initResponse.publish_id);

--- a/packages/cloud/shared/src/lib/services/social-media/social-media.credit-refund.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/social-media.credit-refund.test.ts
@@ -139,6 +139,32 @@ describe("createPost refund on thrown credential error (#11680)", () => {
     expect(refundCalls[0]?.amount).toBeCloseTo(1 * POST_CREDIT_COST, 10);
     expect(refundCalls[0]?.metadata?.failedPlatforms).toEqual(["twitter"]);
   });
+
+  test("does not refund a provider outcome that is explicitly held for reconciliation", async () => {
+    const credsSpy = spyOn(socialMediaService, "getCredentialsForPlatform").mockImplementation(
+      async () => ({ platform: "twitter" as const, accessToken: "tok" }),
+    );
+    const postSpy = spyOn(twitterProvider, "createPost").mockImplementation(async () => ({
+      platform: "twitter" as const,
+      success: false,
+      error: "Provider outcome is still being reconciled",
+      errorCode: "PROVIDER_OUTCOME_UNKNOWN",
+      creditDisposition: "hold" as const,
+    }));
+    spies.push(credsSpy, postSpy);
+
+    const result = await socialMediaService.createPost({
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      content: { text: "hello world" },
+      platforms: ["twitter"],
+    });
+
+    expect(result.failureCount).toBe(1);
+    expect(result.failed[0]?.creditDisposition).toBe("hold");
+    expect(deductCalls).toHaveLength(1);
+    expect(refundCalls).toHaveLength(0);
+  });
 });
 
 describe("replyToPost refund on thrown provider error (#11680)", () => {

--- a/packages/cloud/shared/src/lib/types/social-media.ts
+++ b/packages/cloud/shared/src/lib/types/social-media.ts
@@ -203,6 +203,12 @@ export interface PostResult {
   errorCode?: string;
   rateLimited?: boolean;
   retryAfter?: number;
+  /**
+   * Controls settlement when a provider cannot yet prove whether an external
+   * side effect committed. Omitted failures retain the normal refund path;
+   * `hold` prevents a premature refund until provider reconciliation.
+   */
+  creditDisposition?: "hold";
   metadata?: Record<string, unknown>;
 }
 
@@ -566,13 +572,18 @@ export const NotificationPlatformSchema = z.enum(["discord", "telegram", "slack"
 export const SOCIAL_MEDIA_MEDIA_MAX_BYTES = 10 * 1024 * 1024;
 
 /**
- * Ceiling for a video already buffered inside the Worker isolate. TikTok's
- * external API accepts larger videos, but an inline base64 string and its
- * decoded bytes coexist in the 128 MB isolate before upload. Keep enough
- * headroom for request parsing, provider state, and concurrent invocations;
- * larger videos must use the URL-backed transfer path.
+ * Ceiling for video bytes already materialized as a Buffer. Fetch adds one
+ * bounded chunk copy in workerd, so two overlapping maximum-size binary calls
+ * remain below the 128 MB isolate ceiling. Larger videos use URL transfer.
  */
 export const SOCIAL_MEDIA_VIDEO_MAX_BYTES = 32 * 1024 * 1024;
+
+/**
+ * Stricter ceiling for base64 video because its encoded string remains live
+ * beside decoded bytes and Fetch's request-body copy. Reusing the shared media
+ * limit keeps two overlapping maximum-size calls comfortably bounded.
+ */
+export const SOCIAL_MEDIA_VIDEO_MAX_BASE64_BYTES = SOCIAL_MEDIA_MEDIA_MAX_BYTES;
 
 /**
  * Character ceiling of a base64 payload that can decode to

--- a/packages/cloud/shared/src/lib/types/social-media.ts
+++ b/packages/cloud/shared/src/lib/types/social-media.ts
@@ -566,12 +566,13 @@ export const NotificationPlatformSchema = z.enum(["discord", "telegram", "slack"
 export const SOCIAL_MEDIA_MEDIA_MAX_BYTES = 10 * 1024 * 1024;
 
 /**
- * Ceiling for an inline video payload. TikTok chunk-uploads video, so the
- * 10 MiB image budget would reject ordinary posts — but the decode still
- * happens in one `Buffer.from` inside the Worker isolate, so it needs a bound
- * of its own rather than none. Sized to TikTok's documented direct-post limit.
+ * Ceiling for a video already buffered inside the Worker isolate. TikTok's
+ * external API accepts larger videos, but an inline base64 string and its
+ * decoded bytes coexist in the 128 MB isolate before upload. Keep enough
+ * headroom for request parsing, provider state, and concurrent invocations;
+ * larger videos must use the URL-backed transfer path.
  */
-export const SOCIAL_MEDIA_VIDEO_MAX_BYTES = 128 * 1024 * 1024;
+export const SOCIAL_MEDIA_VIDEO_MAX_BYTES = 32 * 1024 * 1024;
 
 /**
  * Character ceiling of a base64 payload that can decode to


### PR DESCRIPTION
# Relates to

Fixes #23834

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

## What changed

- Implements TikTok's sequential decimal-byte ranged upload protocol with tail merging and exact `206` intermediate / `201` final validation.
- Restricts provider-returned upload URLs to documented HTTPS TikTok upload hosts, then sends them through the shared DNS/private-network guard with redirects rejected.
- Validates and preserves MP4, QuickTime, and WebM MIME types.
- Cancels every ranged-upload response body on success and failure.
- Retries identical ranges after authoritative 5xx responses and reconciles ambiguous transport/final-response loss before replay.
- Treats a `416` replay as committed only when TikTok's progress receipt proves the exact range was received.
- Returns an explicit credit hold for unresolved remote outcomes so a possibly published post is neither duplicated nor refunded as a known failure.
- Uses a 10 MiB base64 admission budget with strict raw MIME-wrapping overhead and a 32 MiB binary ceiling so overlapping Worker uploads remain below the isolate memory limit. Larger media remains URL-backed and the broader #23834 work adds streamed object storage.

## Verification

Exact head: `de2b26ad55cfed88a2e4b038fe116196a682174f`, rebased on `develop@d6068e969b3817bae05b79fae22b3cfdaa76799c`.

```text
Focused media, transport, and credit suite: 41 pass, 0 fail, 177 assertions
packages/cloud/shared typecheck: pass
Biome on all seven changed files: pass
git diff --check: pass
```

The full `packages/cloud/shared` suite reached 167 pass / 4 fail before stopping on four unrelated PGlite credit-ledger fixtures in `app-credits-ledger.test.ts`; this PR does not change those files or their dependencies.

Adversarial coverage includes non-HTTPS/non-TikTok/private-resolving URLs, redirect rejection, invalid MIME, exact memory boundaries, MIME whitespace stuffing, 503-to-201 recovery, exhausted 5xx retries, final-response loss, exact and mismatched 416 progress receipts, response disposal, SharedArrayBuffer behavior, and credit-hold semantics.

## Evidence

- UI screenshots/video/OCR: N/A; backend-only provider transport.
- Real-LLM trajectory: N/A; no model or planner behavior changes.
- Deterministic domain artifacts: request ranges, headers, bodies, response sequence, reconciliation state, and credit disposition are asserted in the focused suites.
- Live TikTok acceptance needs a consented private post and production `video.publish` credential; no credential or user consent was available in this worktree.
- Cloudflare staging memory observation requires deployment authority; local admission and overlap calculations are executable tests, not claimed as hosted runtime evidence.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI / gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d6068e969b3817bae05b79fae22b3cfdaa76799c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@d6068e969b3817bae05b79fae22b3cfdaa76799c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex/23834]
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@d6068e969b3817bae05b79fae22b3cfdaa76799c:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:865adad9f5b20afef31e4e62626929a7b24b1fa1 -->

