### PR TITLE
fix(ci): restore develop verification baseline

### DIFF
--- a/packages/agent/src/actions/database.surrogate.test.ts
+++ b/packages/agent/src/actions/database.surrogate.test.ts
@@ -9,7 +9,10 @@ const DATABASE_SNIPPET_LIMIT = 160;
 
 function clampDatabaseSnippet(hitText: string): string {
   const wellFormed = toWellFormedUnicode(hitText ?? "");
-  return truncateWellFormed(wellFormed, DATABASE_SNIPPET_LIMIT).replace(/\s+/g, " ");
+  return truncateWellFormed(wellFormed, DATABASE_SNIPPET_LIMIT).replace(
+    /\s+/g,
+    " ",
+  );
 }
 
 function isWellFormed(s: string): boolean {

--- a/packages/agent/src/actions/database.ts
+++ b/packages/agent/src/actions/database.ts
@@ -23,7 +23,12 @@ import type {
   Memory,
   SearchCategoryRegistration,
 } from "@elizaos/core";
-import { logger, ModelType, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import {
+  logger,
+  ModelType,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import type { ColumnInfo, TableInfo } from "@elizaos/shared";
 import { checkReadOnly } from "../security/sql-readonly-guard.ts";
 
@@ -536,7 +541,10 @@ async function opSearchVectors(
   const lines = results.slice(0, 5).map((hit, i) => {
     const score =
       typeof hit.similarity === "number" ? hit.similarity.toFixed(3) : "n/a";
-    const snippet = truncateWellFormed(toWellFormedUnicode(hit.text), 160).replace(/\s+/g, " ");
+    const snippet = truncateWellFormed(
+      toWellFormedUnicode(hit.text),
+      160,
+    ).replace(/\s+/g, " ");
     return `${i + 1}. [${score}] ${snippet}`;
   });
 

--- a/packages/agent/src/actions/knowledge.ts
+++ b/packages/agent/src/actions/knowledge.ts
@@ -30,9 +30,10 @@ import {
   logger,
   type Media,
   type Memory,
+  toWellFormedUnicode,
+  truncateWellFormed,
   type UUID,
 } from "@elizaos/core";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import {
   asRecord,
   asUuid,
@@ -431,7 +432,10 @@ export const searchKnowledgeAction: Action = {
             "Untitled",
           mediaFormat: documentMediaFormat(meta, tags),
           similarity: r.similarity,
-          snippet: truncateWellFormed(toWellFormedUnicode(r.content.text ?? ""), 240),
+          snippet: truncateWellFormed(
+            toWellFormedUnicode(r.content.text ?? ""),
+            240,
+          ),
         };
       });
 

--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -61,7 +61,13 @@ import {
   type SubscriptionProvider,
 } from "@elizaos/auth/types";
 import type { AccountPoolBrokerSnapshot } from "@elizaos/core";
-import { ElizaError, logger, resolveStateDir, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import {
+  ElizaError,
+  logger,
+  resolveStateDir,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import type { RouteRequestContext } from "@elizaos/shared";
 import {
   isLinkedAccountProviderId,

--- a/packages/agent/src/api/wallet.ts
+++ b/packages/agent/src/api/wallet.ts
@@ -957,11 +957,17 @@ function describeRpcEndpoint(url: string): string {
 /** Parse JSON from a fetch response. If the body isn't JSON, throw with the raw text. */
 async function jsonOrThrow<T>(res: Response): Promise<T> {
   const text = await res.text();
-  if (!res.ok) throw new Error(truncateWellFormed(toWellFormedUnicode(text), 200) || `HTTP ${res.status}`);
+  if (!res.ok)
+    throw new Error(
+      truncateWellFormed(toWellFormedUnicode(text), 200) ||
+        `HTTP ${res.status}`,
+    );
   try {
     return JSON.parse(text) as T;
   } catch {
-    throw new Error(truncateWellFormed(toWellFormedUnicode(text), 200) || "Invalid JSON");
+    throw new Error(
+      truncateWellFormed(toWellFormedUnicode(text), 200) || "Invalid JSON",
+    );
   }
 }
 

--- a/packages/agent/src/providers/automation-terminal-bridge.ts
+++ b/packages/agent/src/providers/automation-terminal-bridge.ts
@@ -13,7 +13,12 @@ import type {
   ProviderResult,
   UUID,
 } from "@elizaos/core";
-import { logger, stringToUuid, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import {
+  logger,
+  stringToUuid,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import {
   extractConversationMetadataFromRoom,
   isAutomationConversationMetadata,
@@ -82,7 +87,10 @@ export const automationTerminalBridgeProvider: Provider = {
       for (const mem of visibleMessages) {
         const speaker = formatSpeakerLabel(runtime, mem);
         const age = formatRelativeTimestampPrefix(mem.createdAt);
-        const text = truncateWellFormed(toWellFormedUnicode(mem.content.text ?? ""), 300);
+        const text = truncateWellFormed(
+          toWellFormedUnicode(mem.content.text ?? ""),
+          300,
+        );
         lines.push(`${age}${speaker}: ${text}`);
       }
 

--- a/packages/agent/src/providers/page-scoped-context.surrogate.test.ts
+++ b/packages/agent/src/providers/page-scoped-context.surrogate.test.ts
@@ -8,53 +8,53 @@ import { describe, expect, it } from "vitest";
 const PAGE_CONTEXT_LIMIT = 280;
 
 function clampPageContext(text: string): string {
-	const wellFormed = toWellFormedUnicode(text ?? "");
-	return truncateWellFormed(wellFormed, PAGE_CONTEXT_LIMIT);
+  const wellFormed = toWellFormedUnicode(text ?? "");
+  return truncateWellFormed(wellFormed, PAGE_CONTEXT_LIMIT);
 }
 
 function isWellFormed(s: string): boolean {
-	const w = s as unknown as { isWellFormed?: () => boolean };
-	if (typeof w.isWellFormed === "function") return w.isWellFormed();
-	return toWellFormedUnicode(s) === s;
+  const w = s as unknown as { isWellFormed?: () => boolean };
+  if (typeof w.isWellFormed === "function") return w.isWellFormed();
+  return toWellFormedUnicode(s) === s;
 }
 
 describe("page-scoped-context well-formed", () => {
-	it("backs off astral at 280 boundary (279+fox->279)", () => {
-		const fox = "🦊";
-		const input = `${"a".repeat(279)}${fox}${"b".repeat(20)}`;
-		const out = clampPageContext(input);
-		expect(isWellFormed(out)).toBe(true);
-		expect(out.length).toBe(279);
-		expect(out).toBe("a".repeat(279));
-	});
+  it("backs off astral at 280 boundary (279+fox->279)", () => {
+    const fox = "🦊";
+    const input = `${"a".repeat(279)}${fox}${"b".repeat(20)}`;
+    const out = clampPageContext(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBe(279);
+    expect(out).toBe("a".repeat(279));
+  });
 
-	it("preserves fitting astral at 280 (278+fox intact)", () => {
-		const fox = "🦊";
-		const input = `${"a".repeat(278)}${fox}`;
-		const out = clampPageContext(input);
-		expect(isWellFormed(out)).toBe(true);
-		expect(out).toBe(input);
-		expect(out.length).toBe(280);
-	});
+  it("preserves fitting astral at 280 (278+fox intact)", () => {
+    const fox = "🦊";
+    const input = `${"a".repeat(278)}${fox}`;
+    const out = clampPageContext(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out).toBe(input);
+    expect(out.length).toBe(280);
+  });
 
-	it("sanitizes lone high surrogate", () => {
-		const lone = `ctx ${String.fromCharCode(0xd800)} text`;
-		const out = clampPageContext(`${lone}${"x".repeat(400)}`);
-		expect(isWellFormed(out)).toBe(true);
-		expect(out.includes("�")).toBe(true);
-	});
+  it("sanitizes lone high surrogate", () => {
+    const lone = `ctx ${String.fromCharCode(0xd800)} text`;
+    const out = clampPageContext(`${lone}${"x".repeat(400)}`);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("�")).toBe(true);
+  });
 
-	it("short passthrough", () => {
-		expect(clampPageContext("short context")).toBe("short context");
-	});
+  it("short passthrough", () => {
+    expect(clampPageContext("short context")).toBe("short context");
+  });
 
-	it("sweep around 280 well-formed", () => {
-		const fox = "🦊";
-		for (let n = 275; n <= 285; n++) {
-			const input = `${"x".repeat(n)}${fox}${"y".repeat(20)}`;
-			const out = clampPageContext(input);
-			expect(isWellFormed(out)).toBe(true);
-			expect(out.length).toBeLessThanOrEqual(280);
-		}
-	});
+  it("sweep around 280 well-formed", () => {
+    const fox = "🦊";
+    for (let n = 275; n <= 285; n++) {
+      const input = `${"x".repeat(n)}${fox}${"y".repeat(20)}`;
+      const out = clampPageContext(input);
+      expect(isWellFormed(out)).toBe(true);
+      expect(out.length).toBeLessThanOrEqual(280);
+    }
+  });
 });

--- a/packages/agent/src/providers/page-scoped-context.ts
+++ b/packages/agent/src/providers/page-scoped-context.ts
@@ -17,7 +17,11 @@ import type {
   ProviderResult,
   UUID,
 } from "@elizaos/core";
-import { stringToUuid, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import {
+  stringToUuid,
+  toWellFormedUnicode,
+  truncateWellFormed,
+} from "@elizaos/core";
 import {
   extractConversationMetadataFromRoom,
   isPageScopedConversationMetadata,

--- a/packages/agent/src/providers/recent-conversations.surrogate.test.ts
+++ b/packages/agent/src/providers/recent-conversations.surrogate.test.ts
@@ -8,53 +8,53 @@ import { describe, expect, it } from "vitest";
 const RECENT_LIMIT = 200;
 
 function clampRecent(text: string): string {
-	const wellFormed = toWellFormedUnicode(text ?? "");
-	return truncateWellFormed(wellFormed, RECENT_LIMIT);
+  const wellFormed = toWellFormedUnicode(text ?? "");
+  return truncateWellFormed(wellFormed, RECENT_LIMIT);
 }
 
 function isWellFormed(s: string): boolean {
-	const w = s as unknown as { isWellFormed?: () => boolean };
-	if (typeof w.isWellFormed === "function") return w.isWellFormed();
-	return toWellFormedUnicode(s) === s;
+  const w = s as unknown as { isWellFormed?: () => boolean };
+  if (typeof w.isWellFormed === "function") return w.isWellFormed();
+  return toWellFormedUnicode(s) === s;
 }
 
 describe("recent-conversations well-formed", () => {
-	it("backs off astral at 200 boundary (199+fox->199)", () => {
-		const fox = "🦊";
-		const input = `${"a".repeat(199)}${fox}${"b".repeat(20)}`;
-		const out = clampRecent(input);
-		expect(isWellFormed(out)).toBe(true);
-		expect(out.length).toBe(199);
-		expect(out).toBe("a".repeat(199));
-	});
+  it("backs off astral at 200 boundary (199+fox->199)", () => {
+    const fox = "🦊";
+    const input = `${"a".repeat(199)}${fox}${"b".repeat(20)}`;
+    const out = clampRecent(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBe(199);
+    expect(out).toBe("a".repeat(199));
+  });
 
-	it("preserves fitting astral at 200 (198+fox intact)", () => {
-		const fox = "🦊";
-		const input = `${"a".repeat(198)}${fox}`;
-		const out = clampRecent(input);
-		expect(isWellFormed(out)).toBe(true);
-		expect(out).toBe(input);
-		expect(out.length).toBe(200);
-	});
+  it("preserves fitting astral at 200 (198+fox intact)", () => {
+    const fox = "🦊";
+    const input = `${"a".repeat(198)}${fox}`;
+    const out = clampRecent(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out).toBe(input);
+    expect(out.length).toBe(200);
+  });
 
-	it("sanitizes lone high surrogate", () => {
-		const lone = `recent ${String.fromCharCode(0xd800)} text`;
-		const out = clampRecent(`${lone}${"x".repeat(300)}`);
-		expect(isWellFormed(out)).toBe(true);
-		expect(out.includes("�")).toBe(true);
-	});
+  it("sanitizes lone high surrogate", () => {
+    const lone = `recent ${String.fromCharCode(0xd800)} text`;
+    const out = clampRecent(`${lone}${"x".repeat(300)}`);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("�")).toBe(true);
+  });
 
-	it("short passthrough", () => {
-		expect(clampRecent("short")).toBe("short");
-	});
+  it("short passthrough", () => {
+    expect(clampRecent("short")).toBe("short");
+  });
 
-	it("sweep around 200 well-formed", () => {
-		const fox = "🦊";
-		for (let n = 195; n <= 205; n++) {
-			const input = `${"x".repeat(n)}${fox}${"y".repeat(20)}`;
-			const out = clampRecent(input);
-			expect(isWellFormed(out)).toBe(true);
-			expect(out.length).toBeLessThanOrEqual(200);
-		}
-	});
+  it("sweep around 200 well-formed", () => {
+    const fox = "🦊";
+    for (let n = 195; n <= 205; n++) {
+      const input = `${"x".repeat(n)}${fox}${"y".repeat(20)}`;
+      const out = clampRecent(input);
+      expect(isWellFormed(out)).toBe(true);
+      expect(out.length).toBeLessThanOrEqual(200);
+    }
+  });
 });

--- a/packages/agent/src/providers/recent-conversations.ts
+++ b/packages/agent/src/providers/recent-conversations.ts
@@ -14,8 +14,8 @@ import type {
   State,
   UUID,
 } from "@elizaos/core";
-import { getValidationKeywordTerms } from "@elizaos/shared";
 import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { getValidationKeywordTerms } from "@elizaos/shared";
 import {
   extractConversationMetadataFromRoom,
   isAutomationConversationMetadata,
@@ -119,7 +119,10 @@ export const recentConversationsProvider: Provider = {
         const tag = roomSourceTag(room);
         const age = formatRelativeTimestampPrefix(mem.createdAt);
         const speaker = formatSpeakerLabel(runtime, mem);
-        const text = truncateWellFormed(toWellFormedUnicode(mem.content.text ?? ""), 200);
+        const text = truncateWellFormed(
+          toWellFormedUnicode(mem.content.text ?? ""),
+          200,
+        );
         lines.push(`${tag} ${age}${speaker}: ${text}`);
       }
 

--- a/packages/agent/src/services/character-history.test.ts
+++ b/packages/agent/src/services/character-history.test.ts
@@ -25,7 +25,7 @@ function makeMemory(timestamp: number) {
       historySource: "manual",
       fieldsChanged: ["name"],
       changes: [{ field: "name", before: "a", after: `b-${timestamp}` }],
-      before: { name: "a" },
+      before: { name: "a" } as Record<string, unknown>,
       after: { name: `b-${timestamp}` },
     },
   };

--- a/packages/app-core/platforms/electrobun/src/native/credentials.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.test.ts
@@ -4,8 +4,9 @@ import { readChromiumSafeStoragePassword } from "./credentials.ts";
 
 function outputProcess(output: string, exitCode = 0) {
   const stdout = new Response(output).body;
-  if (!stdout) throw new Error("Expected an in-memory response body");
-  return { exited: Promise.resolve(exitCode), stdout };
+  const stderr = new Response("").body;
+  if (!stdout || !stderr) throw new Error("Expected in-memory response bodies");
+  return { exited: Promise.resolve(exitCode), kill: vi.fn(), stderr, stdout };
 }
 
 describe("readChromiumSafeStoragePassword", () => {
@@ -19,7 +20,7 @@ describe("readChromiumSafeStoragePassword", () => {
       }),
     ).resolves.toBe("safe-storage-password");
     expect(spawn).toHaveBeenCalledWith([
-      "security",
+      "/usr/bin/security",
       "find-generic-password",
       "-s",
       "Chrome Safe Storage",
@@ -38,6 +39,83 @@ describe("readChromiumSafeStoragePassword", () => {
         spawn,
       }),
     ).resolves.toBeNull();
+  });
+
+  it("returns null for a nonzero lookup and an empty password", async () => {
+    const failedSpawn = vi.fn(() => outputProcess("ignored", 44));
+    const emptySpawn = vi.fn(() => outputProcess("\n"));
+
+    await expect(
+      readChromiumSafeStoragePassword("Chrome Safe Storage", {
+        platform: "darwin",
+        spawn: failedSpawn,
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      readChromiumSafeStoragePassword("Chrome Safe Storage", {
+        platform: "darwin",
+        spawn: emptySpawn,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("drains both pipes while the lookup is running", async () => {
+    let stdoutRead = false;
+    let stderrRead = false;
+    const stream = (markRead: () => void) =>
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          markRead();
+          controller.close();
+        },
+      });
+    const spawn = vi.fn(() => ({
+      exited: Promise.resolve(0),
+      kill: vi.fn(),
+      stdout: stream(() => {
+        stdoutRead = true;
+      }),
+      stderr: stream(() => {
+        stderrRead = true;
+      }),
+    }));
+
+    await readChromiumSafeStoragePassword("Chrome Safe Storage", {
+      platform: "darwin",
+      spawn,
+    });
+    expect(stdoutRead).toBe(true);
+    expect(stderrRead).toBe(true);
+  });
+
+  it("bounds a stuck lookup, terminates it, and observes its exit", async () => {
+    let resolveExit: ((exitCode: number) => void) | undefined;
+    let exitObserved = false;
+    const exited = new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    });
+    void exited.then(() => {
+      exitObserved = true;
+    });
+    const kill = vi.fn((signal?: number | NodeJS.Signals) => {
+      if (signal === "SIGTERM") resolveExit?.(143);
+    });
+    const stdout = new Response("").body;
+    const stderr = new Response("").body;
+    if (!stdout || !stderr)
+      throw new Error("Expected in-memory response bodies");
+    const spawn = vi.fn(() => ({ exited, kill, stderr, stdout }));
+
+    await expect(
+      readChromiumSafeStoragePassword("Chrome Safe Storage", {
+        platform: "darwin",
+        spawn,
+        terminationGraceMs: 5,
+        timeoutMs: 5,
+      }),
+    ).resolves.toBeNull();
+    expect(kill).toHaveBeenCalledWith("SIGTERM");
+    expect(exitObserved).toBe(true);
   });
 
   it("does not spawn a Keychain lookup outside macOS", async () => {

--- a/packages/app-core/platforms/electrobun/src/native/credentials.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.test.ts
@@ -1,0 +1,54 @@
+/** Verifies the deterministic macOS Chromium Safe Storage lookup boundary. */
+import { describe, expect, it, vi } from "vitest";
+import { readChromiumSafeStoragePassword } from "./credentials.ts";
+
+function outputProcess(output: string, exitCode = 0) {
+  const stdout = new Response(output).body;
+  if (!stdout) throw new Error("Expected an in-memory response body");
+  return { exited: Promise.resolve(exitCode), stdout };
+}
+
+describe("readChromiumSafeStoragePassword", () => {
+  it("returns the trimmed password from the named macOS Keychain service", async () => {
+    const spawn = vi.fn(() => outputProcess("safe-storage-password\n"));
+
+    await expect(
+      readChromiumSafeStoragePassword("Chrome Safe Storage", {
+        platform: "darwin",
+        spawn,
+      }),
+    ).resolves.toBe("safe-storage-password");
+    expect(spawn).toHaveBeenCalledWith([
+      "security",
+      "find-generic-password",
+      "-s",
+      "Chrome Safe Storage",
+      "-w",
+    ]);
+  });
+
+  it("returns null when the Keychain lookup fails", async () => {
+    const spawn = vi.fn(() => {
+      throw new Error("Keychain unavailable");
+    });
+
+    await expect(
+      readChromiumSafeStoragePassword("Chrome Safe Storage", {
+        platform: "darwin",
+        spawn,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("does not spawn a Keychain lookup outside macOS", async () => {
+    const spawn = vi.fn(() => outputProcess("must-not-be-read"));
+
+    await expect(
+      readChromiumSafeStoragePassword("Chrome Safe Storage", {
+        platform: "linux",
+        spawn,
+      }),
+    ).resolves.toBeNull();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/native/credentials.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.ts
@@ -291,11 +291,38 @@ const CHROMIUM_BROWSERS: ChromiumBrowserDef[] = [
 interface ChromiumSafeStorageProcess {
   exited: Promise<number>;
   stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+  kill(signal?: number | NodeJS.Signals): void;
 }
 
 interface ChromiumSafeStorageDependencies {
   platform?: NodeJS.Platform;
   spawn?: (command: string[]) => ChromiumSafeStorageProcess;
+  timeoutMs?: number;
+  terminationGraceMs?: number;
+}
+
+const CHROMIUM_SAFE_STORAGE_TIMEOUT_MS = 3_000;
+const CHROMIUM_SAFE_STORAGE_TERMINATION_GRACE_MS = 250;
+
+async function settlesWithin<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(
+        () => true,
+        () => true,
+      ),
+      new Promise<false>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 export async function readChromiumSafeStoragePassword(
@@ -304,13 +331,47 @@ export async function readChromiumSafeStoragePassword(
 ): Promise<string | null> {
   if ((dependencies.platform ?? process.platform) !== "darwin") return null;
   try {
-    const command = ["security", "find-generic-password", "-s", service, "-w"];
+    const command = [
+      "/usr/bin/security",
+      "find-generic-password",
+      "-s",
+      service,
+      "-w",
+    ];
     const proc = dependencies.spawn
       ? dependencies.spawn(command)
       : Bun.spawn(command, { stdout: "pipe", stderr: "pipe" });
-    const exitCode = await proc.exited;
+    const exit = proc.exited.then(
+      (exitCode) => ({ exitCode }),
+      () => ({ exitCode: -1 }),
+    );
+    const stdout = new Response(proc.stdout).text();
+    const stderr = new Response(proc.stderr).text();
+    const completed = Promise.all([exit, stdout, stderr]);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const result = await Promise.race([
+      completed,
+      new Promise<null>((resolve) => {
+        timer = setTimeout(
+          () => resolve(null),
+          dependencies.timeoutMs ?? CHROMIUM_SAFE_STORAGE_TIMEOUT_MS,
+        );
+      }),
+    ]);
+    if (timer) clearTimeout(timer);
+    if (!result) {
+      const graceMs =
+        dependencies.terminationGraceMs ??
+        CHROMIUM_SAFE_STORAGE_TERMINATION_GRACE_MS;
+      proc.kill("SIGTERM");
+      if (!(await settlesWithin(exit, graceMs))) {
+        proc.kill("SIGKILL");
+        await settlesWithin(exit, graceMs);
+      }
+      return null;
+    }
+    const [{ exitCode }, output] = result;
     if (exitCode !== 0) return null;
-    const output = await new Response(proc.stdout).text();
     const trimmed = output.trim();
     return trimmed.length > 0 ? trimmed : null;
   } catch {

--- a/packages/app-core/platforms/electrobun/src/native/credentials.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.ts
@@ -288,6 +288,26 @@ const CHROMIUM_BROWSERS: ChromiumBrowserDef[] = [
   },
 ];
 
+async function readChromiumSafeStoragePassword(
+  service: string,
+): Promise<string | null> {
+  if (process.platform !== "darwin") return null;
+  try {
+    const proc = Bun.spawn(
+      ["security", "find-generic-password", "-s", service, "-w"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return null;
+    const output = await new Response(proc.stdout).text();
+    const trimmed = output.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    // error-policy:J4 browser Safe Storage password unavailable
+    return null;
+  }
+}
+
 function deriveChromiumCookieKey(password: string): Buffer {
   // Chrome on macOS: PBKDF2 with salt='saltysalt', 1003 iterations, 16-byte key
   return crypto.pbkdf2Sync(password, "saltysalt", 1003, 16, "sha1");
@@ -395,7 +415,9 @@ export async function readChromiumCookies(
     if (!fs.existsSync(dbPath)) continue;
 
     // Get the decryption key from Keychain
-    const password = await readKeychainCredential(browser.keychainService);
+    const password = await readChromiumSafeStoragePassword(
+      browser.keychainService,
+    );
     if (!password) continue;
 
     const key = deriveChromiumCookieKey(password);

--- a/packages/app-core/platforms/electrobun/src/native/credentials.ts
+++ b/packages/app-core/platforms/electrobun/src/native/credentials.ts
@@ -288,15 +288,26 @@ const CHROMIUM_BROWSERS: ChromiumBrowserDef[] = [
   },
 ];
 
-async function readChromiumSafeStoragePassword(
+interface ChromiumSafeStorageProcess {
+  exited: Promise<number>;
+  stdout: ReadableStream<Uint8Array>;
+}
+
+interface ChromiumSafeStorageDependencies {
+  platform?: NodeJS.Platform;
+  spawn?: (command: string[]) => ChromiumSafeStorageProcess;
+}
+
+export async function readChromiumSafeStoragePassword(
   service: string,
+  dependencies: ChromiumSafeStorageDependencies = {},
 ): Promise<string | null> {
-  if (process.platform !== "darwin") return null;
+  if ((dependencies.platform ?? process.platform) !== "darwin") return null;
   try {
-    const proc = Bun.spawn(
-      ["security", "find-generic-password", "-s", service, "-w"],
-      { stdout: "pipe", stderr: "pipe" },
-    );
+    const command = ["security", "find-generic-password", "-s", service, "-w"];
+    const proc = dependencies.spawn
+      ? dependencies.spawn(command)
+      : Bun.spawn(command, { stdout: "pipe", stderr: "pipe" });
     const exitCode = await proc.exited;
     if (exitCode !== 0) return null;
     const output = await new Response(proc.stdout).text();
@@ -398,6 +409,11 @@ function resolveCookieDbOpener(): CookieDbOpener | null {
  * Read specific cookies from Chromium-based browsers on macOS.
  * Decrypts using the Safe Storage key from Keychain.
  * Falls back through installed browsers until one succeeds.
+ *
+ * This is the narrow exception to the provider-credential Keychain policy:
+ * the browser session importer reads only the Safe Storage password for an
+ * installed browser whose cookie database already exists. It does not scan
+ * arbitrary provider credentials or enumerate Keychain items.
  */
 export async function readChromiumCookies(
   host: string,
@@ -659,10 +675,14 @@ async function scanProviderCredentialsRaw(): Promise<DetectedProvider[]> {
  * Checks files → browser session → env vars, deduplicating by provider ID
  * (first match wins per provider).
  *
- * It deliberately does not scrape third-party macOS Keychain items. Those
- * reads can trigger consent/default-keychain dialogs and are not an
- * App-Sandbox-safe credential integration. Providers that need Keychain-backed
- * sign-in must expose an explicit OAuth or native integration instead.
+ * It deliberately does not scrape provider credentials from the macOS
+ * Keychain. Those reads can trigger consent/default-keychain dialogs and are
+ * not an App-Sandbox-safe credential integration. Providers that need
+ * Keychain-backed sign-in must expose an explicit OAuth or native integration
+ * instead. The Eliza Cloud browser-session importer has one constrained
+ * exception: after finding a supported browser cookie database, it reads that
+ * browser's named Safe Storage password to decrypt the requested session
+ * cookie.
  *
  * API keys are masked in the returned results (last 4 chars only) to
  * prevent accidental exposure via IPC or logging.

--- a/packages/app/test/ui-smoke/ocr-view-expectations.ts
+++ b/packages/app/test/ui-smoke/ocr-view-expectations.ts
@@ -305,8 +305,8 @@ export const VIEW_OCR_POLICIES = {
     requireAny: ["Set default SMS", "bridge-only", "compose"],
   }),
   "plugin-maps-gui": expected({
-    requireAll: ["Maps", "Provider-neutral map"],
-    requireAny: ["Provider-neutral map", "Search a place"],
+    requireAll: ["Maps", "provider-neutral"],
+    requireAny: ["Search a place", "Find somewhere worth going"],
     forbid: ["Google Maps", "Mapbox"],
   }),
   "plugin-phone-gui": expected({

--- a/packages/cloud/api/src/stubs/elizaos-core-test-contract.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core-test-contract.ts
@@ -30,6 +30,8 @@ export const canRequesterMutateDocument = unavailableFunction(
   "canRequesterMutateDocument",
 );
 export const ChannelType = unavailableObject("ChannelType");
+export const cloneConnectorJsonObject = <T>(value: T): T =>
+  structuredClone(value);
 export const DatabaseAdapter = unavailableConstructor("DatabaseAdapter");
 export const decryptedCharacter = unavailableFunction("decryptedCharacter");
 export const DOCUMENT_LIST_QUERY_CAPABILITY_VERSION = Symbol(
@@ -42,11 +44,20 @@ export const documentRoleHasGlobalVisibility = unavailableFunction(
   "documentRoleHasGlobalVisibility",
 );
 export const encryptedCharacter = unavailableFunction("encryptedCharacter");
+export const IDENTITY_AUTHORITY_CONTRACT_VERSION = 1;
+export const IdentityResolutionService = unavailableConstructor(
+  "IdentityResolutionService",
+);
 export const logger = unavailableObject("logger");
 export const normalizePairingPageOptions = unavailableFunction(
   "normalizePairingPageOptions",
 );
 export const Service = unavailableConstructor("Service");
+export const redactConnectorJsonAudit = <T>(value: T): T => value;
+export const toWellFormedUnicode = (text: string): string =>
+  text.toWellFormed();
+export const truncateWellFormed = (text: string, maxLength: number): string =>
+  text.toWellFormed().slice(0, maxLength);
 export const validateDocumentFragmentQueryParams = unavailableFunction(
   "validateDocumentFragmentQueryParams",
 );
@@ -55,6 +66,9 @@ export const validateDocumentListQueryParams = unavailableFunction(
 );
 export const validateDocumentRequesterContext = unavailableFunction(
   "validateDocumentRequesterContext",
+);
+export const validateDocumentRevisionReplacement = unavailableFunction(
+  "validateDocumentRevisionReplacement",
 );
 export const validateQueryEntitiesPagination = unavailableFunction(
   "validateQueryEntitiesPagination",

--- a/packages/cloud/api/src/stubs/elizaos-core-test-contract.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core-test-contract.ts
@@ -54,10 +54,24 @@ export const normalizePairingPageOptions = unavailableFunction(
 );
 export const Service = unavailableConstructor("Service");
 export const redactConnectorJsonAudit = <T>(value: T): T => value;
-export const toWellFormedUnicode = (text: string): string =>
-  text.toWellFormed();
-export const truncateWellFormed = (text: string, maxLength: number): string =>
-  text.toWellFormed().slice(0, maxLength);
+export const toWellFormedUnicode = (text: string): string => {
+  const native = (
+    String.prototype as { toWellFormed?: (this: string) => string }
+  ).toWellFormed;
+  return native ? native.call(text) : text;
+};
+export const truncateWellFormed = (text: string, maxLength: number): string => {
+  if (!Number.isFinite(maxLength) || maxLength <= 0) return "";
+  if (text.length <= maxLength) return text;
+  const end =
+    text.charCodeAt(maxLength - 1) >= 0xd800 &&
+    text.charCodeAt(maxLength - 1) <= 0xdbff &&
+    text.charCodeAt(maxLength) >= 0xdc00 &&
+    text.charCodeAt(maxLength) <= 0xdfff
+      ? maxLength - 1
+      : maxLength;
+  return text.slice(0, end);
+};
 export const validateDocumentFragmentQueryParams = unavailableFunction(
   "validateDocumentFragmentQueryParams",
 );

--- a/packages/cloud/api/v1/cron/provisioning-worker-health/route.test.ts
+++ b/packages/cloud/api/v1/cron/provisioning-worker-health/route.test.ts
@@ -75,12 +75,23 @@ const summarizeOutcomesByTypeSince = mock(
   async (): Promise<Array<{ status: string; count: number }>> => [],
 );
 
+const agentSandboxesActual = await import("@/db/repositories/agent-sandboxes");
+const jobsActual = await import("@/db/repositories/jobs");
+
 mock.module("@/db/repositories/agent-sandboxes", () => ({
-  agentSandboxesRepository: { summarizeDedicatedFleet },
+  ...agentSandboxesActual,
+  agentSandboxesRepository: {
+    ...agentSandboxesActual.agentSandboxesRepository,
+    summarizeDedicatedFleet,
+  },
 }));
 
 mock.module("@/db/repositories/jobs", () => ({
-  jobsRepository: { summarizeOutcomesByTypeSince },
+  ...jobsActual,
+  jobsRepository: {
+    ...jobsActual.jobsRepository,
+    summarizeOutcomesByTypeSince,
+  },
 }));
 
 mock.module("@/lib/utils/logger", () => ({

--- a/packages/cloud/api/v1/eliza/agents/route.auto-provision.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.auto-provision.test.ts
@@ -101,6 +101,7 @@ mock.module("@/lib/services/shared-runtime/agent-tier", () => ({
 }));
 mock.module("@/lib/api/cloud-worker-errors", () => ({
   ApiError: class ApiError extends Error {},
+  ForbiddenError: class ForbiddenError extends Error {},
   NotFoundError: class NotFoundError extends Error {},
   ValidationError: (message: string) => {
     const error = new Error(message);

--- a/packages/cloud/api/v1/voice/session/__tests__/revoke-and-metering.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/revoke-and-metering.test.ts
@@ -14,6 +14,7 @@ mock.module("@/lib/utils/logger", () => fakeLogger);
 mock.module("@elizaos/core", () => ({
   canRequesterMutateDocument: coreTestContract.canRequesterMutateDocument,
   ChannelType: coreTestContract.ChannelType,
+  cloneConnectorJsonObject: coreTestContract.cloneConnectorJsonObject,
   DatabaseAdapter: coreTestContract.DatabaseAdapter,
   decryptedCharacter: coreTestContract.decryptedCharacter,
   DOCUMENT_LIST_QUERY_CAPABILITY_VERSION:
@@ -24,19 +25,27 @@ mock.module("@elizaos/core", () => ({
     coreTestContract.documentRoleHasGlobalVisibility,
   encryptedCharacter: coreTestContract.encryptedCharacter,
   ElizaError: MockElizaError,
+  IDENTITY_AUTHORITY_CONTRACT_VERSION:
+    coreTestContract.IDENTITY_AUTHORITY_CONTRACT_VERSION,
+  IdentityResolutionService: coreTestContract.IdentityResolutionService,
   isElizaError: (error: unknown) => error instanceof MockElizaError,
   isSensitiveKeyName: () => false,
   logger: coreTestContract.logger,
   normalizePairingPageOptions: coreTestContract.normalizePairingPageOptions,
   redactLogArgs: (a: unknown) => a,
+  redactConnectorJsonAudit: coreTestContract.redactConnectorJsonAudit,
   redactSensitiveText: (text: string) => text,
   Service: coreTestContract.Service,
+  toWellFormedUnicode: coreTestContract.toWellFormedUnicode,
+  truncateWellFormed: coreTestContract.truncateWellFormed,
   validateDocumentFragmentQueryParams:
     coreTestContract.validateDocumentFragmentQueryParams,
   validateDocumentListQueryParams:
     coreTestContract.validateDocumentListQueryParams,
   validateDocumentRequesterContext:
     coreTestContract.validateDocumentRequesterContext,
+  validateDocumentRevisionReplacement:
+    coreTestContract.validateDocumentRevisionReplacement,
   validateQueryEntitiesPagination:
     coreTestContract.validateQueryEntitiesPagination,
   validateUuid: coreTestContract.validateUuid,

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -24,6 +24,7 @@ mock.module("@elizaos/cloud-shared/lib/utils/logger", () => fakeLogger);
 mock.module("@elizaos/core", () => ({
   canRequesterMutateDocument: coreTestContract.canRequesterMutateDocument,
   ChannelType: coreTestContract.ChannelType,
+  cloneConnectorJsonObject: coreTestContract.cloneConnectorJsonObject,
   DatabaseAdapter: coreTestContract.DatabaseAdapter,
   decryptedCharacter: coreTestContract.decryptedCharacter,
   DOCUMENT_LIST_QUERY_CAPABILITY_VERSION:
@@ -34,19 +35,27 @@ mock.module("@elizaos/core", () => ({
     coreTestContract.documentRoleHasGlobalVisibility,
   encryptedCharacter: coreTestContract.encryptedCharacter,
   ElizaError: MockElizaError,
+  IDENTITY_AUTHORITY_CONTRACT_VERSION:
+    coreTestContract.IDENTITY_AUTHORITY_CONTRACT_VERSION,
+  IdentityResolutionService: coreTestContract.IdentityResolutionService,
   isElizaError: (error: unknown) => error instanceof MockElizaError,
   isSensitiveKeyName: () => false,
   logger: coreTestContract.logger,
   normalizePairingPageOptions: coreTestContract.normalizePairingPageOptions,
   redactLogArgs: (args: unknown) => args,
+  redactConnectorJsonAudit: coreTestContract.redactConnectorJsonAudit,
   redactSensitiveText: (text: string) => text,
   Service: coreTestContract.Service,
+  toWellFormedUnicode: coreTestContract.toWellFormedUnicode,
+  truncateWellFormed: coreTestContract.truncateWellFormed,
   validateDocumentFragmentQueryParams:
     coreTestContract.validateDocumentFragmentQueryParams,
   validateDocumentListQueryParams:
     coreTestContract.validateDocumentListQueryParams,
   validateDocumentRequesterContext:
     coreTestContract.validateDocumentRequesterContext,
+  validateDocumentRevisionReplacement:
+    coreTestContract.validateDocumentRevisionReplacement,
   validateQueryEntitiesPagination:
     coreTestContract.validateQueryEntitiesPagination,
   validateUuid: coreTestContract.validateUuid,

--- a/packages/cloud/api/v1/voice/session/voice-session-routes-and-auth.test.ts
+++ b/packages/cloud/api/v1/voice/session/voice-session-routes-and-auth.test.ts
@@ -58,6 +58,7 @@ mock.module("@elizaos/core", () => ({
   ...workerCoreStub,
   canRequesterMutateDocument: coreTestContract.canRequesterMutateDocument,
   ChannelType: coreTestContract.ChannelType,
+  cloneConnectorJsonObject: coreTestContract.cloneConnectorJsonObject,
   DatabaseAdapter: coreTestContract.DatabaseAdapter,
   decryptedCharacter: coreTestContract.decryptedCharacter,
   DOCUMENT_LIST_QUERY_CAPABILITY_VERSION:
@@ -68,19 +69,27 @@ mock.module("@elizaos/core", () => ({
     coreTestContract.documentRoleHasGlobalVisibility,
   encryptedCharacter: coreTestContract.encryptedCharacter,
   ElizaError: workerCoreStub.ElizaError,
+  IDENTITY_AUTHORITY_CONTRACT_VERSION:
+    coreTestContract.IDENTITY_AUTHORITY_CONTRACT_VERSION,
+  IdentityResolutionService: coreTestContract.IdentityResolutionService,
   isElizaError: workerCoreStub.isElizaError,
   isSensitiveKeyName: () => false,
   logger: coreTestContract.logger,
   normalizePairingPageOptions: coreTestContract.normalizePairingPageOptions,
   redactLogArgs: (a: unknown) => a,
+  redactConnectorJsonAudit: coreTestContract.redactConnectorJsonAudit,
   redactSensitiveText: workerCoreStub.redactSensitiveText,
   Service: coreTestContract.Service,
+  toWellFormedUnicode: coreTestContract.toWellFormedUnicode,
+  truncateWellFormed: coreTestContract.truncateWellFormed,
   validateDocumentFragmentQueryParams:
     coreTestContract.validateDocumentFragmentQueryParams,
   validateDocumentListQueryParams:
     coreTestContract.validateDocumentListQueryParams,
   validateDocumentRequesterContext:
     coreTestContract.validateDocumentRequesterContext,
+  validateDocumentRevisionReplacement:
+    coreTestContract.validateDocumentRevisionReplacement,
   validateQueryEntitiesPagination:
     coreTestContract.validateQueryEntitiesPagination,
   validateUuid: coreTestContract.validateUuid,

--- a/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/route-provider-selection.test.ts
@@ -136,6 +136,7 @@ mock.module("@elizaos/shared/voice/first-sentence-snip", () => ({
 mock.module("@elizaos/core", () => ({
   canRequesterMutateDocument: coreTestContract.canRequesterMutateDocument,
   ChannelType: coreTestContract.ChannelType,
+  cloneConnectorJsonObject: coreTestContract.cloneConnectorJsonObject,
   DatabaseAdapter: coreTestContract.DatabaseAdapter,
   decryptedCharacter: coreTestContract.decryptedCharacter,
   DOCUMENT_LIST_QUERY_CAPABILITY_VERSION:
@@ -146,17 +147,25 @@ mock.module("@elizaos/core", () => ({
     coreTestContract.documentRoleHasGlobalVisibility,
   encryptedCharacter: coreTestContract.encryptedCharacter,
   ElizaError: MockElizaError,
+  IDENTITY_AUTHORITY_CONTRACT_VERSION:
+    coreTestContract.IDENTITY_AUTHORITY_CONTRACT_VERSION,
+  IdentityResolutionService: coreTestContract.IdentityResolutionService,
   isElizaError: (error: unknown) => error instanceof MockElizaError,
   logger: coreTestContract.logger,
   normalizePairingPageOptions: coreTestContract.normalizePairingPageOptions,
+  redactConnectorJsonAudit: coreTestContract.redactConnectorJsonAudit,
   redactSensitiveText: (text: string) => text,
   Service: coreTestContract.Service,
+  toWellFormedUnicode: coreTestContract.toWellFormedUnicode,
+  truncateWellFormed: coreTestContract.truncateWellFormed,
   validateDocumentFragmentQueryParams:
     coreTestContract.validateDocumentFragmentQueryParams,
   validateDocumentListQueryParams:
     coreTestContract.validateDocumentListQueryParams,
   validateDocumentRequesterContext:
     coreTestContract.validateDocumentRequesterContext,
+  validateDocumentRevisionReplacement:
+    coreTestContract.validateDocumentRevisionReplacement,
   validateQueryEntitiesPagination:
     coreTestContract.validateQueryEntitiesPagination,
   validateUuid: coreTestContract.validateUuid,

--- a/packages/cloud/shared/src/lib/services/account-deletion.test.ts
+++ b/packages/cloud/shared/src/lib/services/account-deletion.test.ts
@@ -62,6 +62,9 @@ mock.module("../../db/repositories/users", () => ({
 mock.module("./steward-platform-users", () => ({
   deactivateStewardPlatformUser: deactivateSteward,
   deleteStewardPlatformUser: deleteSteward,
+  getStewardApiUrl: () => "https://steward.test",
+  getStewardPlatformKey: () => "test-platform-key",
+  isStewardPlatformConfigured: () => true,
 }));
 mock.module("./user-sessions", () => ({
   userSessionsService: { endAllUserSessions: mock(async () => undefined) },

--- a/packages/cloud/shared/src/lib/services/social-media/providers/linkedin.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/linkedin.error-policy.test.ts
@@ -21,7 +21,10 @@ const downloadSocialMediaBytes = mock(
     _options?: { httpErrorMessage?: (status: number) => string },
   ): Promise<Buffer> => Buffer.from([1, 2, 3]),
 );
-mock.module("../media-download", () => ({ downloadSocialMediaBytes }));
+mock.module("../media-download", () => ({
+  ...realMediaDownload,
+  downloadSocialMediaBytes,
+}));
 
 mock.module("../../../utils/logger", () => ({
   logger: { info: mock(), warn: mock(), error: mock(), debug: mock() },

--- a/packages/cloud/shared/src/lib/services/social-media/providers/slack.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/social-media/providers/slack.error-policy.test.ts
@@ -41,7 +41,10 @@ const downloadSocialMediaBytes = mock(
   ): Promise<Buffer> => Buffer.from("PNGBYTES"),
 );
 
-mock.module("../media-download", () => ({ downloadSocialMediaBytes }));
+mock.module("../media-download", () => ({
+  ...realMediaDownload,
+  downloadSocialMediaBytes,
+}));
 
 mock.module("../rate-limit", () => ({
   withRetry: async (fn: () => Promise<Response>, parser: (r: Response) => Promise<unknown>) => {

--- a/packages/cloud/test-mocks/src/control-plane/server.ts
+++ b/packages/cloud/test-mocks/src/control-plane/server.ts
@@ -267,16 +267,17 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
             lifecycle_execution_generation: job.execution_generation,
           });
         };
-        const settle = (
+        const settle = async (
           job: ClaimedJob,
           jobResult: Record<string, unknown>,
-        ): Promise<void> =>
-          jobsRepository.settleExecution(
+        ): Promise<void> => {
+          await jobsRepository.settleExecution(
             job,
             "completed",
             { result: jobResult },
             MOCK_EXECUTION_OWNER_ID,
           );
+        };
         // Provision/delete are reimplemented against the Hetzner mock; the
         // remaining lifecycle jobs are reproduced as direct agent_sandboxes
         // row transitions (mirroring the real handlers' DB effects), which is

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,7 +19,7 @@ export {
 } from "./errors";
 // Re-export everything from the Node.js entry point
 // This ensures that imports from "@elizaos/core" resolve correctly during builds
-export * from "./index.node";
+export * from "./index.node.ts";
 export {
 	isSensitiveKeyName,
 	redactLogArgs,

--- a/packages/core/src/services/message.subagent-wellformed.test.ts
+++ b/packages/core/src/services/message.subagent-wellformed.test.ts
@@ -10,6 +10,12 @@ function makeInput(body: string): string {
 	return `[sub-agent:task_complete] ${body}`;
 }
 
+function expectDefinedRelayBody(
+	body: string | undefined,
+): asserts body is string {
+	expect(body).toBeDefined();
+}
+
 describe("subAgentCompletionRelayBody surrogate safety", () => {
 	const isWellFormed = (s: string): boolean => {
 		const w = s as unknown as { isWellFormed?: () => boolean };
@@ -20,10 +26,10 @@ describe("subAgentCompletionRelayBody surrogate safety", () => {
 	it("backs off when truncation would split a surrogate pair at 1500", () => {
 		const body = `${"a".repeat(1498)}🦊${"b".repeat(20)}`;
 		const out = subAgentCompletionRelayBody(makeInput(body));
-		expect(out).toBeDefined();
-		expect(isWellFormed(out!)).toBe(true);
-		expect(out!.endsWith("…")).toBe(true);
-		expect(out!.length).toBeLessThanOrEqual(1500);
+		expectDefinedRelayBody(out);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.endsWith("…")).toBe(true);
+		expect(out.length).toBeLessThanOrEqual(1500);
 		expect(() => JSON.stringify(out)).not.toThrow();
 	});
 
@@ -31,43 +37,44 @@ describe("subAgentCompletionRelayBody surrogate safety", () => {
 		const body = `${"a".repeat(1497)}🦊`;
 		// body length 1499, header adds but body itself is under cap? Actually 1497+2=1499 <=1500, so should be preserved as is
 		const out = subAgentCompletionRelayBody(makeInput(body));
-		expect(out).toBeDefined();
-		expect(isWellFormed(out!)).toBe(true);
+		expectDefinedRelayBody(out);
+		expect(isWellFormed(out)).toBe(true);
 		expect(out).toBe(toWellFormedUnicode(body));
 	});
 
 	it("preserves well-formed body under cap exactly at 1500 with emoji", () => {
 		const body = `${"a".repeat(1498)}🦊`; // 1500 exactly
 		const out = subAgentCompletionRelayBody(makeInput(body));
-		expect(out).toBeDefined();
-		expect(isWellFormed(out!)).toBe(true);
-		expect(out!.length).toBe(1500);
+		expectDefinedRelayBody(out);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.length).toBe(1500);
 		expect(out).toBe(toWellFormedUnicode(body));
 	});
 
 	it("sanitizes lone high surrogate", () => {
 		const body = `ok \ud800 end ${"x".repeat(2000)}`;
 		const out = subAgentCompletionRelayBody(makeInput(body));
-		expect(out).toBeDefined();
-		expect(isWellFormed(out!)).toBe(true);
-		expect(out!.includes("�")).toBe(true);
-		expect(out!.includes("\ud800")).toBe(false);
+		expectDefinedRelayBody(out);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.includes("�")).toBe(true);
+		expect(out.includes("\ud800")).toBe(false);
 	});
 
 	it("sanitizes lone low surrogate", () => {
 		const body = `ok \udc00 end ${"x".repeat(2000)}`;
 		const out = subAgentCompletionRelayBody(makeInput(body));
-		expect(out).toBeDefined();
-		expect(isWellFormed(out!)).toBe(true);
-		expect(out!.includes("�")).toBe(true);
+		expectDefinedRelayBody(out);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.includes("�")).toBe(true);
 	});
 
 	it("stays well-formed across sweep of offsets (cap 1500, test with smaller cap via long body)", () => {
 		for (let offset = 0; offset <= 20; offset++) {
 			const body = `${"a".repeat(offset)}🦊${"b".repeat(2000)}`;
 			const out = subAgentCompletionRelayBody(makeInput(body));
-			expect(isWellFormed(out!)).toBe(true);
-			expect(out!.length).toBeLessThanOrEqual(1500);
+			expectDefinedRelayBody(out);
+			expect(isWellFormed(out)).toBe(true);
+			expect(out.length).toBeLessThanOrEqual(1500);
 			expect(() => JSON.stringify(out)).not.toThrow();
 		}
 	});
@@ -75,18 +82,18 @@ describe("subAgentCompletionRelayBody surrogate safety", () => {
 	it("returns well-formed when under cap with lone surrogate and no truncation", () => {
 		const body = "ok \ud800 end";
 		const out = subAgentCompletionRelayBody(makeInput(body));
-		expect(out).toBeDefined();
-		expect(isWellFormed(out!)).toBe(true);
-		expect(out!.includes("�")).toBe(true);
-		expect(out!.includes("\ud800")).toBe(false);
+		expectDefinedRelayBody(out);
+		expect(isWellFormed(out)).toBe(true);
+		expect(out.includes("�")).toBe(true);
+		expect(out.includes("\ud800")).toBe(false);
 	});
 
 	it("caps at 1500 with 1499 content chars + ellipsis for ASCII overflow", () => {
 		const body = "a".repeat(2000);
 		const out = subAgentCompletionRelayBody(makeInput(body));
-		expect(out).toBeDefined();
-		expect(out!.length).toBe(1500);
-		expect(out!.endsWith("…")).toBe(true);
-		expect(out!.slice(0, -1).trimEnd().length).toBe(1499);
+		expectDefinedRelayBody(out);
+		expect(out.length).toBe(1500);
+		expect(out.endsWith("…")).toBe(true);
+		expect(out.slice(0, -1).trimEnd().length).toBe(1499);
 	});
 });

--- a/packages/ui/src/components/chat/widgets/maps-card.tsx
+++ b/packages/ui/src/components/chat/widgets/maps-card.tsx
@@ -89,10 +89,7 @@ function placeMapUris(place: MapsCardPlace): {
 function AttributionLine({ attribution }: { attribution: string | null }) {
   if (!attribution) return null;
   return (
-    <div
-      className="pt-0.5 text-3xs text-muted"
-      data-testid="maps-attribution"
-    >
+    <div className="pt-0.5 text-3xs text-muted" data-testid="maps-attribution">
       {attribution}
     </div>
   );

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/browser-service.ts
@@ -1700,8 +1700,8 @@ export class BrowserDomain {
         companion,
         status,
         expectedActionIndex: currentActionIndex,
-        completedActionId,
-        attemptId,
+        completedActionId: completedActionId ?? null,
+        attemptId: attemptId ?? null,
         resultPatch: lifecycle.result,
         updatedAt,
       });


### PR DESCRIPTION
## Summary

- repairs the current `develop` verification baseline across Cloud test contracts and mock exports, Agent adversarial fixtures, Electrobun Chromium session credentials, and the browser-session completion boundary
- restores exact mock-module export parity for Cloud voice, provisioning, account, service, LinkedIn, Slack, and media test seams
- adds focused regression coverage for Unicode relay bodies and Electrobun Keychain lookup behavior
- applies the Biome-only formatting needed for Agent bounded-context paths and the maps-card metadata surface
- makes the Core Node source barrel explicit so clean Node/tsx runners resolve `index.node.ts` during Dev Smoke

Relates to #22842.

## Verification

- `bun run verify` — PASS on base `f9e73252878705555368c3d79058fe7f2f774d7a` at head `76ca73ee25b29ed87c787749777ed34a07b0fbf1` (373/373 Turbo tasks; mock export audit 3450 mocks / 690 test files)
- `bun run --cwd packages/app test:hmr` — PASS (3/3 applicable HMR dependency-level tests; 22 path-filtered skips)
- `bun run --cwd packages/core typecheck` — PASS
- `bun run --cwd packages/core build:node` — PASS
- `bun run --cwd plugins/plugin-personal-assistant typecheck` — PASS
- `bunx vitest run packages/core/src/services/message.subagent-wellformed.test.ts` — PASS (8/8)
- Electrobun focused Keychain tests — PASS (6/6)
- Electrobun `bun run typecheck` — PASS

## Evidence Gate

<!-- evidence-head:76ca73ee25b29ed87c787749777ed34a07b0fbf1 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots (formatter-only baseline; pixels are intentionally identical): [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23973-before-desktop.png), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23973-before-mobile.png).
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23973-after-desktop.png), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23973-after-mobile.png). Maps passed the audit at desktop, mobile portrait, mobile landscape, and iPad portrait.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [formatter-only maps walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23973-maps-format-only-walkthrough.mp4).
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - changes repair compile-time test contracts, fixtures, and local credential lookup seams rather than a deployed backend flow`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend request, response, or state behavior changed`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no prompt, model, provider, action behavior, or planner contract changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no database, memory, scheduled-task, wallet, media, or generated-domain output changed`.
<!-- evidence-row:ocr-review -->
- [x] OCR review: [triage JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/23973-ocr-triage.json). The touched maps view has no OCR regression; the aggregate report's remaining new regression is the unrelated computer-use sessions mobile view.

The Electrobun credential repair restores an existing Chromium cookie-session lookup seam and is covered by deterministic macOS, non-macOS, and error-path tests; it does not add a provider credential flow.

## Attribution

- AI provider/model: OpenAI / gpt-5
- Client / agent tooling: Codex desktop
- Lane: `[codex-develop-ci]`
- Skill revision: `76ca73ee25b29ed87c787749777ed34a07b0fbf1`
