### PR TITLE
fix(cloud): declare durable object exports

### DIFF
--- a/packages/cloud/api/__tests__/durable-object-exports-wrangler.test.ts
+++ b/packages/cloud/api/__tests__/durable-object-exports-wrangler.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+type DurableObjectExport = {
+  type?: string;
+  storage?: string;
+};
+
+describe("Durable Object deployment contract", () => {
+  test("declares every live class without replaying legacy migrations", async () => {
+    const config = Bun.TOML.parse(
+      await Bun.file(new URL("../wrangler.toml", import.meta.url)).text(),
+    ) as {
+      exports?: Record<string, DurableObjectExport>;
+      migrations?: unknown;
+    };
+
+    expect(config.migrations).toBeUndefined();
+    expect(config.exports).toEqual({
+      AnonymousChatGate: { type: "durable-object", storage: "sqlite" },
+      InferenceAdmissionGate: { type: "durable-object", storage: "sqlite" },
+      InferenceRateLimitV2RollbackFloor: {
+        type: "durable-object",
+        storage: "sqlite",
+      },
+      OnboardingSessionCoordinator: {
+        type: "durable-object",
+        storage: "sqlite",
+      },
+      PersonalDeliveryProjection: {
+        type: "durable-object",
+        storage: "sqlite",
+      },
+      PersonalTelegramDelivery: {
+        type: "durable-object",
+        storage: "sqlite",
+      },
+      SharedRuntimeConversation: {
+        type: "durable-object",
+        storage: "sqlite",
+      },
+      TwitterOAuthRefreshCoordinator: {
+        type: "durable-object",
+        storage: "sqlite",
+      },
+    });
+  });
+});

--- a/packages/cloud/api/__tests__/inference-rate-limit-v2-rollback-floor-wrangler.test.ts
+++ b/packages/cloud/api/__tests__/inference-rate-limit-v2-rollback-floor-wrangler.test.ts
@@ -10,14 +10,11 @@ type WorkerConfig = {
     staging?: { durable_objects?: DurableConfig };
     production?: { durable_objects?: DurableConfig };
   };
-  migrations?: Array<{
-    tag?: string;
-    new_sqlite_classes?: string[];
-  }>;
+  exports?: Record<string, { type?: string; storage?: string }>;
 };
 
 describe("inference rate-limit v2 rollback floor", () => {
-  test("exports a migration-only Durable Object class without a runtime binding", async () => {
+  test("exports a binding-free Durable Object class", async () => {
     const config = Bun.TOML.parse(
       await Bun.file(new URL("../wrangler.toml", import.meta.url)).text(),
     ) as WorkerConfig;
@@ -25,9 +22,9 @@ describe("inference rate-limit v2 rollback floor", () => {
       new URL("../src/index.ts", import.meta.url),
     ).text();
 
-    expect(config.migrations).toContainEqual({
-      tag: "inference-rate-limit-v2-rollback-floor-v1",
-      new_sqlite_classes: ["InferenceRateLimitV2RollbackFloor"],
+    expect(config.exports?.InferenceRateLimitV2RollbackFloor).toEqual({
+      type: "durable-object",
+      storage: "sqlite",
     });
     expect(entrypoint).toContain(
       'export { InferenceRateLimitV2RollbackFloor } from "./inference-rate-limit-v2-rollback-floor";',

--- a/packages/cloud/api/__tests__/twitter-oauth-coordinator-wrangler.test.ts
+++ b/packages/cloud/api/__tests__/twitter-oauth-coordinator-wrangler.test.ts
@@ -21,10 +21,13 @@ describe("X OAuth refresh coordinator deployment contract", () => {
     ).toHaveLength(3);
   });
 
-  test("registers the Durable Object class migration", () => {
-    expect(wrangler).toContain('tag = "twitter-oauth-refresh-coordinator-v1"');
-    expect(wrangler).toContain(
-      'new_sqlite_classes = ["TwitterOAuthRefreshCoordinator"]',
-    );
+  test("declares the Durable Object class export", () => {
+    const config = Bun.TOML.parse(wrangler) as {
+      exports?: Record<string, { type?: string; storage?: string }>;
+    };
+    expect(config.exports?.TwitterOAuthRefreshCoordinator).toEqual({
+      type: "durable-object",
+      storage: "sqlite",
+    });
   });
 });

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -1257,10 +1257,7 @@ describe("cloud-api worker entrypoint", () => {
         staging?: { durable_objects?: DurableConfig };
         production?: { durable_objects?: DurableConfig };
       };
-      migrations?: Array<{
-        tag?: string;
-        new_sqlite_classes?: string[];
-      }>;
+      exports?: Record<string, { type?: string; storage?: string }>;
     };
 
     for (const durableObjects of [
@@ -1273,9 +1270,9 @@ describe("cloud-api worker entrypoint", () => {
         class_name: "PersonalTelegramDelivery",
       });
     }
-    expect(config.migrations).toContainEqual({
-      tag: "personal-telegram-delivery-v1",
-      new_sqlite_classes: ["PersonalTelegramDelivery"],
+    expect(config.exports?.PersonalTelegramDelivery).toEqual({
+      type: "durable-object",
+      storage: "sqlite",
     });
   });
 

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -154,37 +154,39 @@ class_name = "PersonalDeliveryProjection"
 name = "PERSONAL_TELEGRAM_DELIVERIES"
 class_name = "PersonalTelegramDelivery"
 
-[[migrations]]
-tag = "shared-runtime-conversations-v1"
-new_sqlite_classes = ["SharedRuntimeConversation"]
+# Declarative exports preserve the existing namespaces without replaying the
+# Worker's historical migration tags. Do not mix this with `[[migrations]]`.
+[exports.SharedRuntimeConversation]
+type = "durable-object"
+storage = "sqlite"
 
-[[migrations]]
-tag = "inference-admission-gates-v1"
-new_sqlite_classes = ["InferenceAdmissionGate"]
+[exports.InferenceAdmissionGate]
+type = "durable-object"
+storage = "sqlite"
 
-[[migrations]]
-tag = "anonymous-chat-gates-v1"
-new_sqlite_classes = ["AnonymousChatGate"]
+[exports.AnonymousChatGate]
+type = "durable-object"
+storage = "sqlite"
 
-[[migrations]]
-tag = "onboarding-session-coordinator-v1"
-new_sqlite_classes = ["OnboardingSessionCoordinator"]
+[exports.OnboardingSessionCoordinator]
+type = "durable-object"
+storage = "sqlite"
 
-[[migrations]]
-tag = "twitter-oauth-refresh-coordinator-v1"
-new_sqlite_classes = ["TwitterOAuthRefreshCoordinator"]
+[exports.TwitterOAuthRefreshCoordinator]
+type = "durable-object"
+storage = "sqlite"
 
-[[migrations]]
-tag = "personal-delivery-projection-v1"
-new_sqlite_classes = ["PersonalDeliveryProjection"]
+[exports.PersonalDeliveryProjection]
+type = "durable-object"
+storage = "sqlite"
 
-[[migrations]]
-tag = "personal-telegram-delivery-v1"
-new_sqlite_classes = ["PersonalTelegramDelivery"]
+[exports.PersonalTelegramDelivery]
+type = "durable-object"
+storage = "sqlite"
 
-[[migrations]]
-tag = "inference-rate-limit-v2-rollback-floor-v1"
-new_sqlite_classes = ["InferenceRateLimitV2RollbackFloor"]
+[exports.InferenceRateLimitV2RollbackFloor]
+type = "durable-object"
+storage = "sqlite"
 
 # General API limits and queues may use Railway Redis via REDIS_URL. Inference
 # routes never connect to it: Cloudflare Rate Limiting bindings protect ingress,


### PR DESCRIPTION
## Summary
- replace the fragile legacy Durable Object migration list with Cloudflare declarative exports
- preserve all eight existing SQLite-backed namespaces without replaying missing historical tags
- update deployment-contract tests and add a regression test that forbids legacy migration replay

## Incident
The staging release failed with Cloudflare code 10074 because the deployed Worker reported migration tag `doordash-checkout-gates-v1`, which is absent from the current config. Wrangler therefore attempted to replay every migration and collided with the live `SharedRuntimeConversation` namespace.

## Validation
- `bun run build:core` (59/59 tasks)
- focused + `packages/cloud/api/src/index.test.ts` test suite
- Biome check on changed TypeScript files
- Wrangler 4.116 staging and production dry-runs
- full bundled Wrangler 4.116 staging dry-run