### PR TITLE
fix(cloud): bound LinkedIn upload lifecycle

### DIFF
--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.error-policy.test.ts
@@ -1,10 +1,22 @@
-// Pins the error-policy boundary of LinkedIn ad-credential validation: a failed
-// account-discovery fetch (transport reject or non-2xx) must surface its real
-// error and stay DISTINCT from a valid-but-empty account list. Deterministic —
-// global fetch is mocked; no live LinkedIn calls.
+/**
+ * Pins LinkedIn transport deadlines, bounded response reads, upload authority, and multipart
+ * validation with deterministic mocked network and media boundaries.
+ */
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 const originalFetch = globalThis.fetch;
+const downloadAdMedia = mock(async () => ({
+  url: "https://media.example.test/ad.mp4",
+  bytes: new Uint8Array([1, 2, 3, 4]),
+  base64: "AQIDBA==",
+  contentType: "video/mp4",
+  fileName: "ad.mp4",
+}));
+
+mock.module("../media-utils", () => ({
+  downloadAdMedia,
+  mediaFileName: () => "ad.mp4",
+}));
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -23,6 +35,7 @@ const EMPTY_ERROR = "No LinkedIn ad accounts found or invalid credentials";
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  downloadAdMedia.mockClear();
 });
 
 describe("linkedinAdsProvider.validateCredentials error policy", () => {
@@ -35,7 +48,6 @@ describe("linkedinAdsProvider.validateCredentials error policy", () => {
 
     expect(result.valid).toBe(false);
     expect(result.error).toBe("network unreachable");
-    // Transport failure must NOT be reported as a legitimately-empty account list.
     expect(result.error).not.toBe(EMPTY_ERROR);
   });
 
@@ -51,7 +63,7 @@ describe("linkedinAdsProvider.validateCredentials error policy", () => {
     expect(result.error).not.toBe(EMPTY_ERROR);
   });
 
-  test("a successful fetch with zero accounts is the DISTINCT legitimately-empty result", async () => {
+  test("a successful fetch with zero accounts is the distinct legitimately-empty result", async () => {
     globalThis.fetch = mock(async () => jsonResponse({ elements: [] })) as typeof fetch;
 
     const result = await (await loadProvider()).provider.validateCredentials(credentials);
@@ -61,7 +73,9 @@ describe("linkedinAdsProvider.validateCredentials error policy", () => {
 
   test("a successful fetch with an account validates without an error", async () => {
     globalThis.fetch = mock(async () =>
-      jsonResponse({ elements: [{ id: 507404993, name: "Dunder Mifflin Account" }] }),
+      jsonResponse({
+        elements: [{ id: 507404993, name: "Dunder Mifflin Account" }],
+      }),
     ) as typeof fetch;
 
     const result = await (await loadProvider()).provider.validateCredentials(credentials);
@@ -74,43 +88,476 @@ describe("linkedinAdsProvider.validateCredentials error policy", () => {
   });
 });
 
-describe("linkedinFetch — bounded hops fail closed and keep caller signals", () => {
-  test("aborts a hung LinkedIn API hop at the timeout", async () => {
-    // An API that never settles on its own: the only way out is the caller's
-    // AbortSignal firing (the 30s default bounds every ads / upload hop).
+describe("linkedinFetch bounded lifecycle", () => {
+  test("aborts a hung header fetch at the deadline", async () => {
     globalThis.fetch = mock(
       (_input: RequestInfo | URL, init?: RequestInit) =>
         new Promise<Response>((_resolve, reject) => {
-          init?.signal?.addEventListener("abort", () => {
-            reject(new DOMException("The operation was aborted.", "AbortError"));
-          });
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
         }),
     ) as typeof fetch;
 
     const start = Date.now();
     const { linkedinFetch } = await loadProvider();
     await expect(
-      linkedinFetch("https://api.linkedin.com/rest/adAccountsV2", undefined, 100),
-    ).rejects.toThrow(/aborted/i);
+      linkedinFetch("https://api.linkedin.com/rest/adAccountsV2", undefined, 50),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
-  test("composes a caller-provided abort signal with the hop deadline", async () => {
+  test("keeps the deadline when a caller signal never aborts", async () => {
     let seen: AbortSignal | undefined;
-    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      seen = init?.signal;
-      return jsonResponse({ elements: [] });
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          seen = init?.signal;
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+        }),
+    ) as typeof fetch;
+
+    const controller = new AbortController();
+    const { linkedinFetch } = await loadProvider();
+    await expect(
+      linkedinFetch(
+        "https://api.linkedin.com/rest/adAccountsV2",
+        { signal: controller.signal },
+        50,
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(seen).not.toBe(controller.signal);
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  test("caller cancellation wins without waiting for the deadline", async () => {
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          seen = init?.signal;
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+        }),
+    ) as typeof fetch;
+
+    const controller = new AbortController();
+    const callerReason = new DOMException("caller stopped", "AbortError");
+    const { linkedinFetch } = await loadProvider();
+    const pending = linkedinFetch(
+      "https://api.linkedin.com/rest/adAccountsV2",
+      { signal: controller.signal },
+      10_000,
+    );
+    controller.abort(callerReason);
+
+    await expect(pending).rejects.toBe(callerReason);
+    expect(seen?.reason).toBe(callerReason);
+  });
+
+  test("bounds and cancels a response body that never completes", async () => {
+    let cancelCount = 0;
+    let originalResponse: Response | undefined;
+    globalThis.fetch = mock(async () => {
+      originalResponse = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("{"));
+          },
+          cancel() {
+            cancelCount += 1;
+          },
+        }),
+      );
+      return originalResponse;
     }) as typeof fetch;
 
     const { linkedinFetch } = await loadProvider();
-    const controller = new AbortController();
-    await linkedinFetch("https://api.linkedin.com/rest/adAccountsV2", {
-      signal: controller.signal,
+    await expect(
+      linkedinFetch("https://api.linkedin.com/rest/adAccountsV2", undefined, 50),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    await Bun.sleep(0);
+    expect(cancelCount).toBe(1);
+    expect(originalResponse?.body?.locked).toBe(false);
+  });
+
+  test("rejects an oversized declared body and cancels it before acquiring a reader", async () => {
+    let cancelCount = 0;
+    let originalResponse: Response | undefined;
+    globalThis.fetch = mock(async () => {
+      originalResponse = new Response(
+        new ReadableStream<Uint8Array>({
+          cancel() {
+            cancelCount += 1;
+          },
+        }),
+        { headers: { "content-length": String(1024 * 1024 + 1) } },
+      );
+      return originalResponse;
+    }) as typeof fetch;
+
+    const { linkedinFetch } = await loadProvider();
+    await expect(
+      linkedinFetch("https://api.linkedin.com/rest/adAccountsV2", undefined, 1_000),
+    ).rejects.toMatchObject({ code: "LINKEDIN_RESPONSE_TOO_LARGE" });
+    expect(cancelCount).toBe(1);
+    expect(originalResponse?.body?.locked).toBe(false);
+  });
+
+  test("cancels a streamed body that exceeds the byte cap", async () => {
+    let cancelCount = 0;
+    let originalResponse: Response | undefined;
+    globalThis.fetch = mock(async () => {
+      originalResponse = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new Uint8Array(1024 * 1024));
+            controller.enqueue(new Uint8Array([1]));
+          },
+          cancel() {
+            cancelCount += 1;
+          },
+        }),
+      );
+      return originalResponse;
+    }) as typeof fetch;
+
+    const { linkedinFetch } = await loadProvider();
+    await expect(
+      linkedinFetch("https://api.linkedin.com/rest/adAccountsV2", undefined, 1_000),
+    ).rejects.toMatchObject({ code: "LINKEDIN_RESPONSE_TOO_LARGE" });
+    expect(cancelCount).toBe(1);
+    expect(originalResponse?.body?.locked).toBe(false);
+  });
+
+  test("clears deadline, caller listener, and response reader after success", async () => {
+    let seen: AbortSignal | undefined;
+    let originalResponse: Response | undefined;
+    const caller = new AbortController();
+    let callerAdds = 0;
+    let callerRemoves = 0;
+    const originalAdd = caller.signal.addEventListener.bind(caller.signal);
+    const originalRemove = caller.signal.removeEventListener.bind(caller.signal);
+    Object.defineProperty(caller.signal, "addEventListener", {
+      value: ((...args: Parameters<AbortSignal["addEventListener"]>) => {
+        callerAdds += 1;
+        return originalAdd(...args);
+      }) as AbortSignal["addEventListener"],
     });
-    // The wrapper owns the deadline, so the signal handed to the transport is
-    // a composition of the caller's signal and that deadline — never the caller's
-    // object verbatim. Asserting identity here would pin the very behavior that
-    // lets a never-firing caller signal defeat the bound.
-    expect(seen).not.toBe(controller.signal);
+    Object.defineProperty(caller.signal, "removeEventListener", {
+      value: ((...args: Parameters<AbortSignal["removeEventListener"]>) => {
+        callerRemoves += 1;
+        return originalRemove(...args);
+      }) as AbortSignal["removeEventListener"],
+    });
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seen = init?.signal;
+      originalResponse = jsonResponse({ elements: [] });
+      return originalResponse;
+    }) as typeof fetch;
+
+    const { linkedinFetch } = await loadProvider();
+    const response = await linkedinFetch(
+      "https://api.linkedin.com/rest/adAccountsV2",
+      { signal: caller.signal },
+      25,
+    );
+    expect(await response.json()).toEqual({ elements: [] });
+    expect(originalResponse?.body?.locked).toBe(false);
+    expect(callerAdds).toBe(1);
+    expect(callerRemoves).toBe(1);
+    await Bun.sleep(50);
+    expect(seen?.aborted).toBe(false);
+  });
+
+  test.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER])(
+    "rejects invalid timeout %p before fetching",
+    async (timeoutMs) => {
+      const fetchMock = mock(async () => jsonResponse({}));
+      globalThis.fetch = fetchMock as typeof fetch;
+      const { linkedinFetch } = await loadProvider();
+      await expect(
+        linkedinFetch("https://api.linkedin.com/rest/adAccountsV2", undefined, timeoutMs),
+      ).rejects.toMatchObject({ code: "INVALID_LINKEDIN_TIMEOUT" });
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+});
+
+function uploadInitializationFetch(value: unknown) {
+  return mock()
+    .mockResolvedValueOnce(jsonResponse({ reference: "urn:li:organization:1" }))
+    .mockResolvedValueOnce(jsonResponse({ value }));
+}
+
+async function uploadVideoWith(value: unknown) {
+  const fetchMock = uploadInitializationFetch(value);
+  globalThis.fetch = fetchMock as typeof fetch;
+  const result = await (await loadProvider()).provider.uploadMedia(credentials, "1", {
+    type: "video",
+    url: "https://media.example.test/ad.mp4",
+  });
+  return { fetchMock, result };
+}
+
+describe("linkedinAdsProvider upload authority and work bounds", () => {
+  test.each([
+    "https://attacker.example/upload",
+    "http://www.linkedin.com/dms-uploads/1",
+    "https://linkedin.com.attacker.example/dms-uploads/1",
+    "https://user@www.linkedin.com/dms-uploads/1",
+  ])("rejects hostile image upload URL %s before forwarding bearer credentials", async (url) => {
+    const fetchMock = uploadInitializationFetch({
+      uploadUrl: url,
+      image: "urn:li:image:1",
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await (await loadProvider()).provider.uploadMedia(credentials, "1", {
+      type: "image",
+      url: "https://media.example.test/ad.png",
+    });
+
+    expect(result).toMatchObject({ success: false });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("rejects a hostile video upload URL before the first PUT", async () => {
+    const { fetchMock, result } = await uploadVideoWith({
+      video: "urn:li:video:1",
+      uploadInstructions: [
+        {
+          uploadUrl: "https://www.linkedin.com.attacker.example/upload",
+          firstByte: 0,
+          lastByte: 3,
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({ success: false });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("refuses a same-origin image redirect before bearer and bytes can be replayed", async () => {
+    const replayed: Array<{
+      authorization: string | null;
+      body: BodyInit | null | undefined;
+    }> = [];
+    const fetchMock = uploadInitializationFetch({
+      uploadUrl: "https://www.linkedin.com/dms-uploads/1",
+      image: "urn:li:image:1",
+    }).mockImplementation(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.redirect === "error") {
+        throw new TypeError("Fetch is configured to reject redirects");
+      }
+      replayed.push({
+        authorization: new Headers(init?.headers).get("authorization"),
+        body: init?.body,
+      });
+      return new Response(null, { status: 200 });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await (await loadProvider()).provider.uploadMedia(credentials, "1", {
+      type: "image",
+      url: "https://media.example.test/ad.png",
+    });
+
+    expect(result).toMatchObject({ success: false });
+    expect(replayed).toEqual([]);
+    expect(fetchMock.mock.calls[2]?.[1]).toMatchObject({ redirect: "error" });
+  });
+
+  test("refuses a cross-origin video redirect before media bytes can be replayed", async () => {
+    const replayed: Array<BodyInit | null | undefined> = [];
+    const fetchMock = uploadInitializationFetch({
+      video: "urn:li:video:1",
+      uploadToken: "upload-token",
+      uploadInstructions: [
+        {
+          uploadUrl: "https://www.linkedin.com/dms-uploads/1",
+          firstByte: 0,
+          lastByte: 3,
+        },
+      ],
+    }).mockImplementation(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.redirect === "error") {
+        throw new TypeError("Fetch is configured to reject redirects");
+      }
+      replayed.push(init?.body);
+      return new Response(null, {
+        status: 200,
+        headers: { etag: "leaked-part" },
+      });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await (await loadProvider()).provider.uploadMedia(credentials, "1", {
+      type: "video",
+      url: "https://media.example.test/ad.mp4",
+    });
+
+    expect(result).toMatchObject({ success: false });
+    expect(replayed).toEqual([]);
+    expect(fetchMock.mock.calls[2]?.[1]).toMatchObject({ redirect: "error" });
+  });
+
+  test.each([
+    {
+      name: "nonzero start",
+      uploadInstructions: [
+        {
+          uploadUrl: "https://www.linkedin.com/dms-uploads/1",
+          firstByte: 1,
+          lastByte: 3,
+        },
+      ],
+    },
+    {
+      name: "fractional boundary",
+      uploadInstructions: [
+        {
+          uploadUrl: "https://www.linkedin.com/dms-uploads/1",
+          firstByte: 0.5,
+          lastByte: 3,
+        },
+      ],
+    },
+    {
+      name: "out-of-bounds end",
+      uploadInstructions: [
+        {
+          uploadUrl: "https://www.linkedin.com/dms-uploads/1",
+          firstByte: 0,
+          lastByte: 4,
+        },
+      ],
+    },
+    {
+      name: "incomplete coverage",
+      uploadInstructions: [
+        {
+          uploadUrl: "https://www.linkedin.com/dms-uploads/1",
+          firstByte: 0,
+          lastByte: 2,
+        },
+      ],
+    },
+    {
+      name: "overlap",
+      uploadInstructions: [
+        {
+          uploadUrl: "https://www.linkedin.com/dms-uploads/1",
+          firstByte: 0,
+          lastByte: 1,
+        },
+        {
+          uploadUrl: "https://www.linkedin.com/dms-uploads/2",
+          firstByte: 1,
+          lastByte: 3,
+        },
+      ],
+    },
+    {
+      name: "gap",
+      uploadInstructions: [
+        {
+          uploadUrl: "https://www.linkedin.com/dms-uploads/1",
+          firstByte: 0,
+          lastByte: 0,
+        },
+        {
+          uploadUrl: "https://www.linkedin.com/dms-uploads/2",
+          firstByte: 2,
+          lastByte: 3,
+        },
+      ],
+    },
+  ])("rejects invalid video byte ranges before any PUT: $name", async ({ uploadInstructions }) => {
+    const { fetchMock, result } = await uploadVideoWith({
+      video: "urn:li:video:1",
+      uploadInstructions,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(
+      /LinkedIn returned invalid video upload byte ranges|LinkedIn video upload instructions do not cover the file/,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("caps video instructions before validating or dispatching any PUT", async () => {
+    const uploadInstructions = Array.from({ length: 17 }, (_, index) => ({
+      uploadUrl: `https://www.linkedin.com/dms-uploads/${index}`,
+      firstByte: index,
+      lastByte: index,
+    }));
+    const { fetchMock, result } = await uploadVideoWith({
+      video: "urn:li:video:1",
+      uploadInstructions,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "LinkedIn returned an invalid video upload part count",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("uploads validated parts in order without OAuth bearer, then finalizes in ETag order", async () => {
+    const fetchMock = uploadInitializationFetch({
+      video: "urn:li:video:1",
+      uploadToken: "upload-token",
+      uploadInstructions: [
+        {
+          uploadUrl: "https://www.linkedin.com/dms-uploads/1",
+          firstByte: 0,
+          lastByte: 1,
+        },
+        {
+          uploadUrl: "https://media.licdn.com/dms-uploads/2",
+          firstByte: 2,
+          lastByte: 3,
+        },
+      ],
+    })
+      .mockResolvedValueOnce(new Response(null, { headers: { etag: "part-1" } }))
+      .mockResolvedValueOnce(new Response(null, { headers: { etag: "part-2" } }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await (await loadProvider()).provider.uploadMedia(credentials, "1", {
+      type: "video",
+      url: "https://media.example.test/ad.mp4",
+    });
+
+    expect(result).toMatchObject({ success: true, metadata: { parts: 2 } });
+    const firstPut = fetchMock.mock.calls[2];
+    const secondPut = fetchMock.mock.calls[3];
+    const finalizeCall = fetchMock.mock.calls[4];
+    if (!firstPut || !secondPut || !finalizeCall) {
+      throw new Error("Expected initialization, two part uploads, and finalization");
+    }
+    expect(firstPut[0]).toBe("https://www.linkedin.com/dms-uploads/1");
+    expect(secondPut[0]).toBe("https://media.licdn.com/dms-uploads/2");
+    expect(new Uint8Array((firstPut[1] as RequestInit).body as ArrayBuffer)).toEqual(
+      new Uint8Array([1, 2]),
+    );
+    expect(new Uint8Array((secondPut[1] as RequestInit).body as ArrayBuffer)).toEqual(
+      new Uint8Array([3, 4]),
+    );
+    for (const call of [firstPut, secondPut]) {
+      expect(call[1]).toMatchObject({ redirect: "error" });
+      const headers = new Headers((call[1] as RequestInit | undefined)?.headers);
+      expect(headers.has("authorization")).toBe(false);
+      expect(headers.get("content-type")).toBe("application/octet-stream");
+    }
+    expect(new Headers((finalizeCall[1] as RequestInit).headers).get("authorization")).toBe(
+      "Bearer linkedin-token",
+    );
+    expect(JSON.parse(String((finalizeCall[1] as RequestInit).body))).toEqual({
+      finalizeUploadRequest: {
+        video: "urn:li:video:1",
+        uploadToken: "upload-token",
+        uploadedPartIds: ["part-1", "part-2"],
+      },
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts
@@ -28,21 +28,209 @@ const LINKEDIN_OAUTH_TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken"
 const LINKEDIN_WORLDWIDE_GEO = "urn:li:geo:92000000";
 
 const LINKEDIN_REQUEST_TIMEOUT_MS = 30_000;
+const LINKEDIN_RESPONSE_MAX_BYTES = 1024 * 1024;
+// Defensive work bound, not a provider maximum. The shared media downloader's
+// 25 MiB ceiling needs at most seven of LinkedIn's documented 4 MiB parts.
+const LINKEDIN_VIDEO_MAX_UPLOAD_PARTS = 16;
+
+async function bufferLinkedInResponse(response: Response, signal: AbortSignal): Promise<Response> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null && /^\d+$/.test(contentLength)) {
+    const declaredBytes = Number(contentLength);
+    if (!Number.isSafeInteger(declaredBytes) || declaredBytes > LINKEDIN_RESPONSE_MAX_BYTES) {
+      const error = new ElizaError("LinkedIn response exceeds the byte limit", {
+        code: "LINKEDIN_RESPONSE_TOO_LARGE",
+        context: { declaredBytes, maxBytes: LINKEDIN_RESPONSE_MAX_BYTES },
+      });
+      if (response.body) {
+        try {
+          await response.body.cancel(error);
+        } catch (cause) {
+          // error-policy:J6 The declared response size already failed closed; cancellation only
+          // releases the unread transport body.
+          logger.debug("[LinkedInAds] Failed to cancel declared-oversize response body", {
+            cause,
+          });
+        }
+      }
+      throw error;
+    }
+  }
+  if (!response.body) return response;
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let receivedBytes = 0;
+  const cancelBody = (): void => {
+    // error-policy:J6 The hop already failed; cancellation only releases its response stream.
+    reader.cancel(signal.reason).catch((cause: unknown) => {
+      logger.debug("[LinkedInAds] Failed to cancel aborted response body", {
+        cause,
+      });
+    });
+  };
+  signal.addEventListener("abort", cancelBody, { once: true });
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      receivedBytes += next.value.byteLength;
+      if (receivedBytes > LINKEDIN_RESPONSE_MAX_BYTES) {
+        const error = new ElizaError("LinkedIn response exceeds the byte limit", {
+          code: "LINKEDIN_RESPONSE_TOO_LARGE",
+          context: { receivedBytes, maxBytes: LINKEDIN_RESPONSE_MAX_BYTES },
+        });
+        try {
+          await reader.cancel(error);
+        } catch (cause) {
+          // error-policy:J6 The bounded read already failed; cancellation only releases the stream.
+          logger.debug("[LinkedInAds] Failed to cancel oversized response body", { cause });
+        }
+        throw error;
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    signal.removeEventListener("abort", cancelBody);
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(receivedBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new Response(body.buffer, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
 
 /**
  * Bound every LinkedIn REST hop so a hung or rate-limited API cannot pin the
- * ad-provider worker indefinitely. A caller-provided abort signal wins.
+ * ad-provider worker indefinitely. The clearable deadline covers headers and
+ * a bounded body read and composes with caller cancellation.
  */
-export function linkedinFetch(
+export async function linkedinFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
   timeoutMs: number = LINKEDIN_REQUEST_TIMEOUT_MS,
 ): Promise<Response> {
-  const deadline = AbortSignal.timeout(timeoutMs);
-  return fetch(input, {
-    ...init,
-    signal: init?.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > 2_147_483_647) {
+    throw new ElizaError("LinkedIn timeout must be a positive timer-safe integer", {
+      code: "INVALID_LINKEDIN_TIMEOUT",
+      context: { timeoutMs },
+    });
+  }
+
+  const controller = new AbortController();
+  let rejectAbort!: (reason: unknown) => void;
+  const abortPromise = new Promise<never>((_resolve, reject) => {
+    rejectAbort = reject;
   });
+  const abort = (reason: unknown): void => {
+    if (controller.signal.aborted) return;
+    controller.abort(reason);
+    rejectAbort(reason);
+  };
+  const onCallerAbort = (): void =>
+    abort(
+      init?.signal?.reason ?? new DOMException("The LinkedIn request was aborted.", "AbortError"),
+    );
+  init?.signal?.addEventListener("abort", onCallerAbort, { once: true });
+  if (init?.signal?.aborted) onCallerAbort();
+  const timeout = setTimeout(
+    () => abort(new DOMException("The LinkedIn request deadline expired.", "TimeoutError")),
+    timeoutMs,
+  );
+  try {
+    const response = await Promise.race([
+      fetch(input, { ...init, signal: controller.signal }),
+      abortPromise,
+    ]);
+    return await Promise.race([bufferLinkedInResponse(response, controller.signal), abortPromise]);
+  } finally {
+    clearTimeout(timeout);
+    init?.signal?.removeEventListener("abort", onCallerAbort);
+  }
+}
+
+function linkedinUploadUrl(rawUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch (cause) {
+    throw new ElizaError("LinkedIn returned an invalid upload URL", {
+      code: "INVALID_LINKEDIN_UPLOAD_URL",
+      cause,
+    });
+  }
+  const hostname = parsed.hostname.toLowerCase();
+  const trustedHostname = ["linkedin.com", "linkedin-ei.com", "licdn.com", "licdn-ei.com"].some(
+    (domain) => hostname === domain || hostname.endsWith(`.${domain}`),
+  );
+  if (
+    parsed.protocol !== "https:" ||
+    !trustedHostname ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    (parsed.port !== "" && parsed.port !== "443")
+  ) {
+    throw new ElizaError("LinkedIn returned an untrusted upload URL", {
+      code: "INVALID_LINKEDIN_UPLOAD_URL",
+      context: { protocol: parsed.protocol, hostname, port: parsed.port },
+    });
+  }
+  return parsed.toString();
+}
+
+function validateVideoUploadInstructions(
+  instructions: Array<{
+    uploadUrl: string;
+    firstByte: number;
+    lastByte: number;
+  }>,
+  byteLength: number,
+): Array<{ uploadUrl: string; firstByte: number; lastByte: number }> {
+  if (instructions.length === 0 || instructions.length > LINKEDIN_VIDEO_MAX_UPLOAD_PARTS) {
+    throw new ElizaError("LinkedIn returned an invalid video upload part count", {
+      code: "INVALID_LINKEDIN_UPLOAD_INSTRUCTIONS",
+      context: {
+        count: instructions.length,
+        maxParts: LINKEDIN_VIDEO_MAX_UPLOAD_PARTS,
+      },
+    });
+  }
+  let expectedFirstByte = 0;
+  const validated = instructions.map((instruction) => {
+    const { firstByte, lastByte } = instruction;
+    if (
+      !Number.isSafeInteger(firstByte) ||
+      !Number.isSafeInteger(lastByte) ||
+      firstByte !== expectedFirstByte ||
+      lastByte < firstByte ||
+      lastByte >= byteLength
+    ) {
+      throw new ElizaError("LinkedIn returned invalid video upload byte ranges", {
+        code: "INVALID_LINKEDIN_UPLOAD_INSTRUCTIONS",
+        context: { firstByte, lastByte, expectedFirstByte, byteLength },
+      });
+    }
+    expectedFirstByte = lastByte + 1;
+    return {
+      ...instruction,
+      uploadUrl: linkedinUploadUrl(instruction.uploadUrl),
+    };
+  });
+  if (expectedFirstByte !== byteLength) {
+    throw new ElizaError("LinkedIn video upload instructions do not cover the file", {
+      code: "INVALID_LINKEDIN_UPLOAD_INSTRUCTIONS",
+      context: { coveredBytes: expectedFirstByte, byteLength },
+    });
+  }
+  return validated;
 }
 
 function linkedinVersion(): string {
@@ -87,7 +275,11 @@ interface LinkedInImageUploadInit {
 
 interface LinkedInVideoUploadInit {
   value?: {
-    uploadInstructions?: Array<{ uploadUrl: string; firstByte: number; lastByte: number }>;
+    uploadInstructions?: Array<{
+      uploadUrl: string;
+      firstByte: number;
+      lastByte: number;
+    }>;
     video?: string;
     uploadToken?: string;
   };
@@ -462,9 +654,16 @@ export const linkedinAdsProvider: AdProvider = {
       };
     }
     if (accounts.length === 0) {
-      return { valid: false, error: "No LinkedIn ad accounts found or invalid credentials" };
+      return {
+        valid: false,
+        error: "No LinkedIn ad accounts found or invalid credentials",
+      };
     }
-    return { valid: true, accountId: accounts[0].id, accountName: accounts[0].name };
+    return {
+      valid: true,
+      accountId: accounts[0].id,
+      accountName: accounts[0].name,
+    };
   },
 
   async refreshToken(refreshToken: string): Promise<{
@@ -509,7 +708,9 @@ export const linkedinAdsProvider: AdProvider = {
     const { body } = await linkedinRequest<LinkedInCollection<LinkedInAdAccount>>(
       "/adAccounts",
       credentials,
-      { rawQuery: "q=search&search=(status:(values:List(ACTIVE)))&pageSize=1000" },
+      {
+        rawQuery: "q=search&search=(status:(values:List(ACTIVE)))&pageSize=1000",
+      },
     );
     return (body.elements ?? []).map((account) => ({
       id: String(account.id),
@@ -546,7 +747,12 @@ export const linkedinAdsProvider: AdProvider = {
             runSchedule: { start, ...(end !== undefined ? { end } : {}) },
             status: "ACTIVE",
             ...(input.budgetType === "lifetime"
-              ? { totalBudget: { amount: moneyAmount(input.budgetAmount), currencyCode: currency } }
+              ? {
+                  totalBudget: {
+                    amount: moneyAmount(input.budgetAmount),
+                    currencyCode: currency,
+                  },
+                }
               : {}),
           }),
         },
@@ -556,8 +762,18 @@ export const linkedinAdsProvider: AdProvider = {
 
       const budget =
         input.budgetType === "lifetime"
-          ? { totalBudget: { amount: moneyAmount(input.budgetAmount), currencyCode: currency } }
-          : { dailyBudget: { amount: moneyAmount(input.budgetAmount), currencyCode: currency } };
+          ? {
+              totalBudget: {
+                amount: moneyAmount(input.budgetAmount),
+                currencyCode: currency,
+              },
+            }
+          : {
+              dailyBudget: {
+                amount: moneyAmount(input.budgetAmount),
+                currencyCode: currency,
+              },
+            };
 
       const campaignResult = await linkedinRequest<Record<string, never>>(
         `/adAccounts/${encodeURIComponent(accountId)}/adCampaigns`,
@@ -595,7 +811,10 @@ export const linkedinAdsProvider: AdProvider = {
         accountId,
         error: error instanceof Error ? error.message : String(error),
       });
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
     }
   },
 
@@ -624,7 +843,10 @@ export const linkedinAdsProvider: AdProvider = {
           campaign.totalBudget && !campaign.dailyBudget ? "totalBudget" : "dailyBudget";
         const currencyCode =
           campaign.dailyBudget?.currencyCode ?? campaign.totalBudget?.currencyCode ?? "USD";
-        set[budgetField] = { amount: moneyAmount(input.budgetAmount), currencyCode };
+        set[budgetField] = {
+          amount: moneyAmount(input.budgetAmount),
+          currencyCode,
+        };
       }
       if (Object.keys(set).length > 0) {
         await partialUpdate(
@@ -635,7 +857,10 @@ export const linkedinAdsProvider: AdProvider = {
       }
       return { success: true, externalCampaignId };
     } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
     }
   },
 
@@ -647,7 +872,10 @@ export const linkedinAdsProvider: AdProvider = {
       await setCampaignStatus(credentials, externalCampaignId, "PAUSED");
       return { success: true, externalCampaignId };
     } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
     }
   },
 
@@ -659,7 +887,10 @@ export const linkedinAdsProvider: AdProvider = {
       await setCampaignStatus(credentials, externalCampaignId, "ACTIVE");
       return { success: true, externalCampaignId };
     } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
     }
   },
 
@@ -678,7 +909,10 @@ export const linkedinAdsProvider: AdProvider = {
       );
       return { success: true };
     } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
     }
   },
 
@@ -748,7 +982,10 @@ export const linkedinAdsProvider: AdProvider = {
         accountId,
         error: error instanceof Error ? error.message : String(error),
       });
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
     }
   },
 
@@ -760,7 +997,11 @@ export const linkedinAdsProvider: AdProvider = {
     try {
       const owner = await resolveOrganizationUrn(credentials, accountId);
       const media = await downloadAdMedia(input.url, {
-        fileName: mediaFileName({ name: input.name, url: input.url, contentType: input.mimeType }),
+        fileName: mediaFileName({
+          name: input.name,
+          url: input.url,
+          contentType: input.mimeType,
+        }),
       });
       const bytes = media.bytes.slice().buffer as ArrayBuffer;
 
@@ -775,8 +1016,9 @@ export const linkedinAdsProvider: AdProvider = {
         if (!uploadUrl || !imageUrn) {
           throw new Error("LinkedIn image upload initialization returned no upload URL");
         }
-        const upload = await linkedinFetch(uploadUrl, {
+        const upload = await linkedinFetch(linkedinUploadUrl(uploadUrl), {
           method: "PUT",
+          redirect: "error",
           headers: { Authorization: `Bearer ${credentials.accessToken}` },
           body: bytes,
         });
@@ -804,15 +1046,17 @@ export const linkedinAdsProvider: AdProvider = {
       });
       const videoUrn = init.body.value?.video;
       const uploadToken = init.body.value?.uploadToken ?? "";
-      const instructions = init.body.value?.uploadInstructions ?? [];
-      if (!videoUrn || instructions.length === 0) {
+      const rawInstructions = init.body.value?.uploadInstructions ?? [];
+      if (!videoUrn || rawInstructions.length === 0) {
         throw new Error("LinkedIn video upload initialization returned no upload instructions");
       }
+      const instructions = validateVideoUploadInstructions(rawInstructions, bytes.byteLength);
       const uploadedPartIds: string[] = [];
       for (const instruction of instructions) {
         const part = await linkedinFetch(instruction.uploadUrl, {
           method: "PUT",
-          headers: { Authorization: `Bearer ${credentials.accessToken}` },
+          redirect: "error",
+          headers: { "Content-Type": "application/octet-stream" },
           body: bytes.slice(instruction.firstByte, instruction.lastByte + 1),
         });
         if (!part.ok) throw new Error(`LinkedIn video part upload failed: ${part.status}`);
@@ -824,7 +1068,11 @@ export const linkedinAdsProvider: AdProvider = {
         rawQuery: "action=finalizeUpload",
         method: "POST",
         body: JSON.stringify({
-          finalizeUploadRequest: { video: videoUrn, uploadToken, uploadedPartIds },
+          finalizeUploadRequest: {
+            video: videoUrn,
+            uploadToken,
+            uploadedPartIds,
+          },
         }),
       });
       return {
@@ -840,7 +1088,10 @@ export const linkedinAdsProvider: AdProvider = {
         type: input.type,
         error: error instanceof Error ? error.message : String(error),
       });
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
     }
   },
 
@@ -866,7 +1117,10 @@ export const linkedinAdsProvider: AdProvider = {
         ready: status === "AVAILABLE",
       };
     } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
     }
   },
 
@@ -895,7 +1149,10 @@ export const linkedinAdsProvider: AdProvider = {
       );
       return { success: true, metrics: sumAnalytics(body.elements ?? []) };
     } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
     }
   },
 };


### PR DESCRIPTION
# Relates to

Fixes #23498.

- [x] This PR targets `develop` and is rebased onto exact live `develop@80ee79c7a8ef2219755e8dce1d0248ecddf53999` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact environment blocker.
- [x] A reviewer can confirm the changed contract from the deterministic transport, hostile-URL, byte-range, and multipart tests below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@425e6c7a33124704acc99e693be20a00bacdf532:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact live `develop@80ee79c7a8ef2219755e8dce1d0248ecddf53999`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact environment blocker is documented in **Known gaps / failures** below.

# Risks

Medium-low. The change is confined to the LinkedIn advertising provider, but it deliberately fails closed on oversized responses, untrusted upload URLs, malformed multipart instructions, and exhausted deadlines. The trusted upload-host suffixes cover LinkedIn's documented `linkedin.com`, `linkedin-ei.com`, `licdn.com`, and `licdn-ei.com` delivery hosts while rejecting deceptive suffixes, credentials in URLs, non-HTTPS URLs, and non-default ports.

# Background

## What does this PR do?

- Replaces an uncleared `AbortSignal.timeout` hop with a clearable timer-safe deadline that composes with caller cancellation and covers both response headers and a bounded 1 MiB body read.
- Cancels unread, hung, aborted, and oversized response bodies and removes caller/body listeners in terminal paths.
- Validates provider-issued image and video upload URLs before dispatch.
- Validates the complete ordered, contiguous, inclusive byte-range matrix before the first video PUT and applies a defensive 16-part local work bound. This is not claimed as a LinkedIn provider maximum; the repository's 25 MiB media ceiling needs at most seven documented 4 MiB parts.
- Refuses all redirects on image and video upload PUTs so validation applies to the actual destination.
- Omits the OAuth bearer from provider-signed video PUTs while preserving it on LinkedIn API initialization/finalization calls.
- Preserves ETag order for finalization.

## What kind of change is this?

Security and reliability bug fix (non-breaking public API).

# Documentation changes needed?

No. This enforces the existing provider boundary and changes no user-facing copy or public package contract.

# Testing

## Where should a reviewer start?

- `packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts`
- `packages/cloud/shared/src/lib/services/advertising/providers/linkedin.error-policy.test.ts`

## Detailed testing steps

At exact PR head `425e6c7a33124704acc99e693be20a00bacdf532`:

1. `bun test packages/cloud/shared/src/lib/services/advertising/providers/linkedin.error-policy.test.ts`
   - PASS: 30 tests, 86 assertions.
   - Exercises header timeout, never-aborting caller composition, caller cancellation, hung body cancellation, declared/streamed oversize rejection, cleanup, invalid timer inputs, hostile upload URLs, same-origin image and cross-origin video redirect refusal, invalid range matrices, pre-PUT part cap, bearer omission, ordered parts, and ETag finalization order.
2. `node_modules/.bin/biome check packages/cloud/shared/src/lib/services/advertising/providers/linkedin.ts packages/cloud/shared/src/lib/services/advertising/providers/linkedin.error-policy.test.ts`
   - PASS: 2 files, no fixes.
3. `git diff --check origin/develop...HEAD`
   - PASS.

# Evidence Gate

<!-- evidence-head:425e6c7a33124704acc99e693be20a00bacdf532 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - provider transport logic has no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - provider transport logic has no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deadline and hostile-input behavior is observable through deterministic transport assertions, not pixels.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live LinkedIn credential was used; executable tests assert every outbound request and cancellation boundary.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, agent, or action-planning behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - deterministic request assertions are executable test evidence, not a retained database, memory, schedule, wallet, generated-file, or media artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

The passing multipart test inspects the two exact outbound signed PUT URLs, byte slices `[1,2]` and `[3,4]`, absence of `authorization`, `application/octet-stream`, ordered ETags, and the authenticated finalization payload. Negative cases assert zero PUT dispatch for hostile URLs, discontinuous/fractional/out-of-bounds ranges, incomplete coverage, and excessive part count.

## Known gaps / failures

- This disk-constrained sparse worktree reuses an existing dependency store. `bun run --cwd packages/cloud/shared typecheck` reaches TypeScript but is blocked by missing root dependency links and unrelated workspace build exports (for example `decimal.js`, `jose`, `ai`, and current `@elizaos/shared` outputs); it emits repository-wide sparse-environment diagnostics rather than a scoped diagnostic for these two files.
- The older broad `linkedin.test.ts` cannot collect in the same sparse environment because `decimal.js` is absent from the reused root links. The new provider-boundary suite imports the real provider with only the media downloader mocked and passes 30/30.
- Full `bun install` and root `bun run verify` were not run because the active checkout has under 3 GiB free and installing another complete monorepo dependency tree would risk the shared queue. Hosted CI and independent review remain acceptance gates while this source-complete PR stays ready for review.
- Independent exact-head review found that default Fetch redirect-follow could replay media bytes after initial URL validation; this head repairs both upload PUTs with `redirect: "error"` and adds same-origin image and cross-origin video regressions.
- No production LinkedIn credential or ad account was used. Live provider acceptance remains a protected-credential hold, not a draft hold.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@425e6c7a33124704acc99e693be20a00bacdf532:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [fix-23498]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@425e6c7a33124704acc99e693be20a00bacdf532:packages/skills/skills/contribute-to-eliza"} -->






