### PR TITLE
fix(ui): report why a sandbox status poll failed instead of leaving it blank

### DIFF
--- a/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.test.tsx
+++ b/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.test.tsx
@@ -126,7 +126,13 @@ describe("useSandboxListPoll", () => {
     // timers cannot drive, so back it with the faked global setTimeout here.
     vi.spyOn(AbortSignal, "timeout").mockImplementation((ms) => {
       const controller = new AbortController();
-      setTimeout(() => controller.abort(), ms);
+      setTimeout(
+        () =>
+          controller.abort(
+            new DOMException("Status request timed out", "TimeoutError"),
+          ),
+        ms,
+      );
       return controller.signal;
     });
     const hungFetch = vi.fn(
@@ -134,7 +140,8 @@ describe("useSandboxListPoll", () => {
         new Promise<Response>((_resolve, reject) => {
           init?.signal?.addEventListener("abort", () =>
             reject(
-              new DOMException("The operation was aborted.", "AbortError"),
+              init.signal?.reason ??
+                new DOMException("The operation was aborted.", "AbortError"),
             ),
           );
         }),
@@ -159,6 +166,7 @@ describe("useSandboxListPoll", () => {
     });
     expect(hungFetch.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe("Status request timed out");
   });
 });
 
@@ -298,6 +306,20 @@ describe("useSandboxStatusPoll", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.error).toBeTruthy();
     expect(result.current.status).not.toBe("running");
+    unmount();
+  });
+
+  it("distinguishes an interrupted status request from a generic transport failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      new DOMException("The operation was aborted", "AbortError"),
+    );
+
+    const { result, unmount } = renderHook(() =>
+      useSandboxStatusPoll("agent-a", { intervalMs: 60_000 }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBe("Status request was interrupted");
     unmount();
   });
 

--- a/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.test.tsx
+++ b/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.test.tsx
@@ -283,6 +283,24 @@ describe("useSandboxStatusPoll", () => {
     unmount();
   });
 
+  it("reports why a status poll failed instead of leaving the reason blank", async () => {
+    // The !res.ok branch reports `HTTP <status>`, but a rejected request had no
+    // status and previously left `error` null — indistinguishable from a status
+    // that simply has not loaded yet.
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(
+      new TypeError("network down"),
+    );
+
+    const { result, unmount } = renderHook(() =>
+      useSandboxStatusPoll("agent-a", { intervalMs: 60_000 }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.status).not.toBe("running");
+    unmount();
+  });
+
   it("starts polling a replacement agent after the previous agent reached a terminal state", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")

--- a/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.ts
+++ b/packages/ui/src/cloud/instances/lib/use-sandbox-status-poll.ts
@@ -38,6 +38,22 @@ const TERMINAL_STATES = new Set<SandboxStatus>([
 const ACTIVE_STATES = new Set<SandboxStatus>(["pending", "provisioning"]);
 const MAX_CONSECUTIVE_ERRORS = 5;
 
+/**
+ * Describe why a status poll failed, so the UI can distinguish a transport
+ * failure from a status it has not loaded yet. The `!res.ok` branch already
+ * reports `HTTP <status>`; a rejected request had no status to report and was
+ * previously left silent.
+ */
+function describePollFailure(err: unknown): string {
+  if (err instanceof DOMException && err.name === "TimeoutError") {
+    return "Status request timed out";
+  }
+  if (err instanceof DOMException && err.name === "AbortError") {
+    return "Status request was interrupted";
+  }
+  return "Status request failed";
+}
+
 export function useSandboxStatusPoll(
   agentId: string | null,
   options: {
@@ -162,12 +178,20 @@ export function useSandboxStatusPoll(
         if (TERMINAL_STATES.has(newStatus)) {
           stop();
         }
-      } catch {
-        // error-policy:J4 A failed status poll clears loading and retries until
-        // the explicit error limit, while superseded requests stay invisible.
+      } catch (err) {
+        // error-policy:J4 A failed status poll clears loading, records why it
+        // failed, and retries until the explicit error limit, while superseded
+        // requests stay invisible. The reason matters: without it a transport
+        // failure is indistinguishable from a status we simply have not loaded
+        // yet, and the operator is left reading a stale screen with no
+        // indication that polling is failing.
         if (isCurrentEffect() && generation === requestGeneration) {
           consecutiveErrors++;
-          setResult((prev) => ({ ...prev, isLoading: false }));
+          setResult((prev) => ({
+            ...prev,
+            isLoading: false,
+            error: describePollFailure(err),
+          }));
           if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
             stop();
           }


### PR DESCRIPTION
# Relates to

Follow-up to merged #23861 at the reviewer's explicit request.

## What changed

`useSandboxStatusPoll` now records a visible reason when its fetch rejects instead of clearing `isLoading` while leaving `error` blank:

- `TimeoutError` -> `Status request timed out`
- `AbortError` -> `Status request was interrupted`
- other transport failures -> `Status request failed`

The retry counter, five-failure stop threshold, HTTP-status handling, and polling cadence are unchanged.

This exact head also adds direct regression assertions for the timeout and interruption branches, closing the prior review gap where only the generic transport case was pinned.

## Risks

Low. The change only populates the existing error field on an existing J4 failure path. It does not change successful responses or retry control flow.

## Exact-head verification

Head: `b600219dd64f30bf7cb73fb78b992dd9213f5a08`

| Gate | Result |
| --- | --- |
| `bun run --cwd packages/ui test -- src/cloud/instances/lib/use-sandbox-status-poll.test.tsx` | 10/10 passed |
| `bunx biome check` on the source and test | clean |
| `git diff --check` | clean |
| `bun run --cwd packages/ui typecheck` | blocked outside the changed files by sparse-checkout dependency declarations (`pg`, `stripe`, and `@elizaos/capacitor-secure-store`) |
| `bun run --cwd packages/app audit:app` | the exact-tree app/source build completed, but the Playwright API stub did not become reachable and timed out in `startStubStack` with `TypeError: fetch failed`; no captures were produced |

The typecheck and app-audit failures are explicit acceptance/evidence holds while this source-complete PR remains ready for review. Hosted exact-head CI is also pending.

## Reviewer start

Start with `use-sandbox-status-poll.test.tsx`: the hung request now supplies the `TimeoutError` abort reason and asserts the exact timeout message; a separate rejected `AbortError` asserts the interruption message.

## Attribution

- Gap identified by the reviewer of #23861 (@lalalune).
- Original diagnosis, implementation, generic regression, and mutation proof by Claude Code (`claude-opus-5`).
- Exact-head rebase, direct timeout/interruption regressions, and verification by Codex (`gpt-5`).

## Evidence Gate

<!-- evidence-head:b600219dd64f30bf7cb73fb78b992dd9213f5a08 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots — blocked: the mandatory app audit's API stub timed out before capture.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots — blocked: the mandatory app audit's API stub timed out before capture.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video — blocked with the same app-audit stack startup failure.
<!-- evidence-row:backend-logs -->
- [x] Backend logs — N/A: no backend path changes; the relevant failure is a client hook fetch rejection.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs — N/A: the contract under change is the returned hook state and is asserted directly.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — N/A: no model call is involved.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — N/A: the observable artifact is `SandboxStatusResult`, covered by the focused test.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — blocked because the capture phase did not start.

# Documentation changes needed?

No. This corrects an existing UI error-state contract without changing a public configuration or workflow.
