### PR TITLE
fix(cloud): align Wrangler secret tooling

### DIFF
--- a/.github/workflows/activate-personal-shared-telegram-edge.yml
+++ b/.github/workflows/activate-personal-shared-telegram-edge.yml
@@ -441,7 +441,7 @@ jobs:
 
           activation_cli_confirmed=false
           for attempt in 1 2 3; do
-            if printf '%s' 'true' | bunx wrangler@4.100.0 secret put \
+            if printf '%s' 'true' | bunx wrangler@4.116.0 secret put \
               "$EDGE_SECRET_NAME" --env "$TARGET_ENVIRONMENT"; then
               activation_cli_confirmed=true
               break

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -1028,7 +1028,7 @@ jobs:
               return 0
             fi
             local secret_inventory
-            secret_inventory="$(bunx wrangler@4.100.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
+            secret_inventory="$(bunx wrangler@4.116.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
             printf '%s' "$secret_inventory" | node -e '
               const fs = require("node:fs");
               const parsed = JSON.parse(fs.readFileSync(0, "utf8"));
@@ -1056,7 +1056,7 @@ jobs:
 
           verify_apns_binding_candidates() {
             local secret_inventory
-            secret_inventory="$(bunx wrangler@4.100.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
+            secret_inventory="$(bunx wrangler@4.116.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
             printf '%s' "$secret_inventory" | node -e '
               const fs = require("node:fs");
               const parsed = JSON.parse(fs.readFileSync(0, "utf8"));
@@ -1088,7 +1088,7 @@ jobs:
               return 0
             fi
             local secret_inventory
-            secret_inventory="$(bunx wrangler@4.100.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
+            secret_inventory="$(bunx wrangler@4.116.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
             printf '%s' "$secret_inventory" | node -e '
               const fs = require("node:fs");
               const parsed = JSON.parse(fs.readFileSync(0, "utf8"));
@@ -1112,7 +1112,7 @@ jobs:
               return 0
             fi
             local secret_inventory
-            secret_inventory="$(bunx wrangler@4.100.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
+            secret_inventory="$(bunx wrangler@4.116.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
 
             # Names-only wiring (above/below) proves a binding NAME exists or
             # is queued; it cannot prove the VALUE still matches the live
@@ -1421,7 +1421,7 @@ jobs:
           VOICE_REALTIME_WS_ENABLED: ${{ (steps.env.outputs.deploy_environment == 'production' || contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED)) && 'true' || 'false' }}
         run: |
           set -euo pipefail
-          secret_inventory="$(bunx wrangler@4.100.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
+          secret_inventory="$(bunx wrangler@4.116.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
           printf '%s' "$secret_inventory" | node -e '
             const fs = require("node:fs");
             const parsed = JSON.parse(fs.readFileSync(0, "utf8"));

--- a/packages/cloud/scripts/ensure-worker-secret-absent.mjs
+++ b/packages/cloud/scripts/ensure-worker-secret-absent.mjs
@@ -85,7 +85,7 @@ export function validateWranglerEnvironmentArgs(args) {
 }
 
 async function runWrangler(args) {
-  const result = await execFileAsync("bunx", ["wrangler@4.100.0", ...args], {
+  const result = await execFileAsync("bunx", ["wrangler@4.116.0", ...args], {
     encoding: "utf8",
     maxBuffer: 1024 * 1024,
   });


### PR DESCRIPTION
## Summary
- align API Worker secret inventory/removal commands with Wrangler 4.116 used by the deploy
- update the Personal Shared Telegram activation secret write to the same compatible Wrangler version
- keep Pages-only Wrangler pins unchanged

## Incident
After migrating Durable Object lifecycle config to declarative exports, the staging release passed the original Cloudflare migration failure but stopped before deploy because `ensure-worker-secret-absent.mjs` pinned Wrangler 4.100, which cannot parse the new config.

## Validation
- `bun test packages/cloud/scripts/__tests__/ensure-worker-secret-absent.test.ts` (8/8)
- `git diff --check`
- Biome check
- live names-only staging secret inventory via Wrangler 4.116; cutover secret confirmed absent