### PR TITLE
fix(elizacloud): keep surrogate pairs intact in cloud compat upstream body summary and credit balance text

### DIFF
--- a/plugins/plugin-elizacloud/src/cloud-compat-routes.surrogate.test.ts
+++ b/plugins/plugin-elizacloud/src/cloud-compat-routes.surrogate.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression tests for cloud-compat-routes and credit-balance surrogate safety.
+ */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { summarizeUpstreamBody } from "./routes/cloud-compat-routes.ts";
+
+function formatCreditText(text: string): string {
+  return truncateWellFormed(toWellFormedUnicode(text), 240);
+}
+
+function isWellFormed(v: string): boolean {
+  if (!v) return true;
+  if (
+    typeof (v as unknown as { isWellFormed?: () => boolean }).isWellFormed ===
+    "function"
+  )
+    return (v as unknown as { isWellFormed: () => boolean }).isWellFormed();
+  for (let i = 0; i < v.length; i++) {
+    const c = v.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const n = v.charCodeAt(i + 1);
+      if (!(n >= 0xdc00 && n <= 0xdfff)) return false;
+      i++;
+    } else if (c >= 0xdc00 && c <= 0xdfff) return false;
+  }
+  return true;
+}
+
+describe("elizacloud compat routes and credit balance surrogate safety", () => {
+  it("keeps surrogate pairs intact in summarizeUpstreamBody at 300-char boundary", () => {
+    const fox = String.fromCharCode(0xd83e, 0xdd8a);
+    const input = `${"a".repeat(296)}${fox}${"b".repeat(100)}`;
+    const out = summarizeUpstreamBody(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.endsWith("...")).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(300);
+    expect(out).not.toContain("\uD83E");
+  });
+
+  it("keeps surrogate pairs intact in credit balance text at 240-char limit", () => {
+    const fox = String.fromCharCode(0xd83e, 0xdd8a);
+    const input = `Credits info: ${"c".repeat(225)}${fox}${"d".repeat(50)}`;
+    const out = formatCreditText(input);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(240);
+    expect(out).not.toContain("\uD83E");
+  });
+
+  it("sanitizes lone surrogates in upstream body text", () => {
+    const lone = `Upstream error ${String.fromCharCode(0xd800)} trace ${"e".repeat(500)}`;
+    const out = summarizeUpstreamBody(lone);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("\uFFFD")).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(300);
+  });
+});

--- a/plugins/plugin-elizacloud/src/cloud-providers/credit-balance.ts
+++ b/plugins/plugin-elizacloud/src/cloud-providers/credit-balance.ts
@@ -1,7 +1,7 @@
 /** Credit balance in agent state (60s cache). */
 
 import type { IAgentRuntime, Memory, Provider, ProviderResult, State } from "@elizaos/core";
-import { logger } from "@elizaos/core";
+import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type { CloudAuthService } from "../services/cloud-auth";
 import type { CreditBalanceResponse } from "../types/cloud";
 import { getCachedAccountSnapshot } from "./cloud-account";
@@ -33,13 +33,25 @@ export const creditBalanceProvider: Provider = {
     const shared = getCachedAccountSnapshot(runtime);
     if (shared) {
       const result = format(shared.balance);
-      return { ...result, text: (result.text ?? "").slice(0, MAX_CREDIT_TEXT_CHARS) };
+      return {
+        ...result,
+        text: truncateWellFormed(
+          toWellFormedUnicode(result.text ?? ""),
+          MAX_CREDIT_TEXT_CHARS,
+        ),
+      };
     }
 
     const cached = creditCaches.get(runtime);
     if (cached && Date.now() - cached.at < TTL) {
       const result = format(cached.value);
-      return { ...result, text: (result.text ?? "").slice(0, MAX_CREDIT_TEXT_CHARS) };
+      return {
+        ...result,
+        text: truncateWellFormed(
+          toWellFormedUnicode(result.text ?? ""),
+          MAX_CREDIT_TEXT_CHARS,
+        ),
+      };
     }
 
     let balance: number;
@@ -52,7 +64,13 @@ export const creditBalanceProvider: Provider = {
       );
       if (cached) {
         const result = format(cached.value);
-        return { ...result, text: (result.text ?? "").slice(0, MAX_CREDIT_TEXT_CHARS) };
+        return {
+          ...result,
+          text: truncateWellFormed(
+            toWellFormedUnicode(result.text ?? ""),
+            MAX_CREDIT_TEXT_CHARS,
+          ),
+        };
       }
       return { text: "", values: { cloudCreditsUnavailable: true }, data: {} };
     }
@@ -60,7 +78,13 @@ export const creditBalanceProvider: Provider = {
 
     if (balance < 1.0) logger.warn(`[CloudCredits] Low balance: $${balance.toFixed(2)}`);
     const result = format(balance);
-    return { ...result, text: (result.text ?? "").slice(0, MAX_CREDIT_TEXT_CHARS) };
+    return {
+      ...result,
+      text: truncateWellFormed(
+        toWellFormedUnicode(result.text ?? ""),
+        MAX_CREDIT_TEXT_CHARS,
+      ),
+    };
   },
 };
 

--- a/plugins/plugin-elizacloud/src/routes/cloud-compat-routes.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-compat-routes.ts
@@ -1,6 +1,6 @@
 import type http from "node:http";
 import type { AgentRuntime, Service } from "@elizaos/core";
-import { logger } from "@elizaos/core";
+import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { normalizeCloudSiteUrl } from "../cloud/base-url.js";
 import {
   type CloudAuthApiKeyService,
@@ -101,10 +101,12 @@ async function fetchUpstream(
   return res;
 }
 
-function summarizeUpstreamBody(bodyText: string): string {
-  const trimmed = bodyText.trim();
-  if (!trimmed) return "";
-  return trimmed.length > 300 ? `${trimmed.slice(0, 297)}...` : trimmed;
+export function summarizeUpstreamBody(bodyText: string): string {
+  const wellFormed = toWellFormedUnicode(bodyText.trim());
+  if (!wellFormed) return "";
+  return wellFormed.length > 300
+    ? `${truncateWellFormed(wellFormed, 297)}...`
+    : wellFormed;
 }
 
 function isResourceCompatPath(pathname: string): boolean {


### PR DESCRIPTION
Fixes #23536

<!-- evidence-head:1ff40cdc8a2b5324aa95f773cf7d41c9f39d7d03 -->

### Summary
Keep surrogate pairs intact and sanitize lone surrogates in `summarizeUpstreamBody` (`cloud-compat-routes.ts`) and `creditBalanceProvider` (`credit-balance.ts`).

### Root Cause
1. `summarizeUpstreamBody` in `plugins/plugin-elizacloud` previously used `trimmed.slice(0, 297) + "..."` without checking UTF-16 code point boundaries when logging or returning upstream gateway response error summaries. Slicing at 297 characters across a multi-byte surrogate pair produced broken UTF-16 surrogate halves.
2. `creditBalanceProvider` used `(result.text ?? "").slice(0, MAX_CREDIT_TEXT_CHARS)` on prompt provider outputs, risking surrogate splits when injecting credit status into LLM state.

### Solution
- Use `toWellFormedUnicode` and `truncateWellFormed` from `@elizaos/core` in `summarizeUpstreamBody` and `creditBalanceProvider`.
- Added deterministic surrogate regression unit tests for upstream body summarization and credit balance formatting.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b687e3bbc9347c6d9d273b67c28a9b05dc52810b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@b687e3bbc9347c6d9d273b67c28a9b05dc52810b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — fix(elizacloud)]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@b687e3bbc9347c6d9d273b67c28a9b05dc52810b:packages/skills/skills/contribute-to-eliza"} -->