### PR TITLE
fix(scenario-runner): validate turn timeout before runtime startup

### DIFF
--- a/packages/scenario-runner/src/cli.test.ts
+++ b/packages/scenario-runner/src/cli.test.ts
@@ -737,6 +737,7 @@ describe("scenario-runner CLI", () => {
     await expect(runCli(["run", tempDir], dependencies)).rejects.toThrow(
       "SCENARIO_TURN_TIMEOUT_MS must be a positive integer",
     );
+    expect(dependencies.createScenarioRuntime).not.toHaveBeenCalled();
     expect(dependencies.runScenario).not.toHaveBeenCalled();
   });
 
@@ -746,7 +747,11 @@ describe("scenario-runner CLI", () => {
     const dependencies = createDependencies(() => "passed");
 
     await runCli(["run", tempDir], dependencies);
-    expect(dependencies.runScenario).toHaveBeenCalled();
+    expect(dependencies.runScenario).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ turnTimeoutMs: 500 }),
+    );
   });
 
   it("still accepts an explicitly signed positive timeout", async () => {
@@ -767,6 +772,18 @@ describe("scenario-runner CLI", () => {
     await expect(runCli(["run", tempDir], dependencies)).rejects.toThrow(
       "SCENARIO_TURN_TIMEOUT_MS must be a positive integer",
     );
+    expect(dependencies.createScenarioRuntime).not.toHaveBeenCalled();
+  });
+
+  it("rejects a timeout beyond Node's supported timer range", async () => {
+    process.env.SCENARIO_TURN_TIMEOUT_MS = "2147483648";
+    writeScenario(tempDir, "cli-timeout-timer-overflow");
+    const dependencies = createDependencies(() => "passed");
+
+    await expect(runCli(["run", tempDir], dependencies)).rejects.toThrow(
+      "no greater than 2147483647",
+    );
+    expect(dependencies.createScenarioRuntime).not.toHaveBeenCalled();
   });
 
   it("allows skipped scenarios when SKIP_REASON documents the skip", async () => {

--- a/packages/scenario-runner/src/cli.test.ts
+++ b/packages/scenario-runner/src/cli.test.ts
@@ -39,6 +39,7 @@ const ENV_KEYS = [
   "ELIZA_LIFEOPS_RUN_ID",
   "ELIZA_LIFEOPS_SCENARIO_ID",
   "LIFEOPS_LIVE_JUDGE_MIN_SCORE",
+  "SCENARIO_TURN_TIMEOUT_MS",
   "OPENAI_API_KEY",
   "CEREBRAS_API_KEY",
   "SCENARIO_JUDGE_REQUIRE_INDEPENDENT",
@@ -726,6 +727,46 @@ describe("scenario-runner CLI", () => {
 
     expect(code).toBe(2);
     expect(stderr).toContain("skipped without SKIP_REASON");
+  });
+
+  it("rejects trailing garbage in the per-turn timeout environment", async () => {
+    process.env.SCENARIO_TURN_TIMEOUT_MS = "500junk";
+    writeScenario(tempDir, "cli-timeout-config");
+    const dependencies = createDependencies(() => "passed");
+
+    await expect(runCli(["run", tempDir], dependencies)).rejects.toThrow(
+      "SCENARIO_TURN_TIMEOUT_MS must be a positive integer",
+    );
+    expect(dependencies.runScenario).not.toHaveBeenCalled();
+  });
+
+  it("still accepts a clean per-turn timeout value", async () => {
+    process.env.SCENARIO_TURN_TIMEOUT_MS = "500";
+    writeScenario(tempDir, "cli-timeout-ok");
+    const dependencies = createDependencies(() => "passed");
+
+    await runCli(["run", tempDir], dependencies);
+    expect(dependencies.runScenario).toHaveBeenCalled();
+  });
+
+  it("still accepts an explicitly signed positive timeout", async () => {
+    // `Number.parseInt` accepted "+500"; rejecting it would be a regression.
+    process.env.SCENARIO_TURN_TIMEOUT_MS = "+500";
+    writeScenario(tempDir, "cli-timeout-signed");
+    const dependencies = createDependencies(() => "passed");
+
+    await runCli(["run", tempDir], dependencies);
+    expect(dependencies.runScenario).toHaveBeenCalled();
+  });
+
+  it("rejects a timeout beyond the safe integer range", async () => {
+    process.env.SCENARIO_TURN_TIMEOUT_MS = "9007199254740993";
+    writeScenario(tempDir, "cli-timeout-unsafe");
+    const dependencies = createDependencies(() => "passed");
+
+    await expect(runCli(["run", tempDir], dependencies)).rejects.toThrow(
+      "SCENARIO_TURN_TIMEOUT_MS must be a positive integer",
+    );
   });
 
   it("allows skipped scenarios when SKIP_REASON documents the skip", async () => {

--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -49,6 +49,8 @@ const LIVE_PROVIDER_NAMES = [
   "cli",
 ] as const satisfies readonly LiveProviderName[];
 
+const MAX_TURN_TIMEOUT_MS = 2_147_483_647;
+
 function isScenarioLane(value: string): value is ScenarioLane {
   return (SCENARIO_LANES as readonly string[]).includes(value);
 }
@@ -628,6 +630,26 @@ export async function runCli(
     return 2;
   }
 
+  // A real local model on a CPU backend may need a larger per-turn budget than
+  // the 120s default, but the configured value must remain an exact timer
+  // delay. Number.parseInt would accept prefixes such as "500junk", while
+  // delays above Node's timer ceiling are clamped and fire almost immediately.
+  const turnTimeoutMs = (() => {
+    const raw = process.env.SCENARIO_TURN_TIMEOUT_MS?.trim();
+    if (!raw) return 120_000;
+    const parsedTimeoutMs = /^\+?\d+$/.test(raw) ? Number(raw) : Number.NaN;
+    if (
+      !Number.isSafeInteger(parsedTimeoutMs) ||
+      parsedTimeoutMs <= 0 ||
+      parsedTimeoutMs > MAX_TURN_TIMEOUT_MS
+    ) {
+      throw new Error(
+        `SCENARIO_TURN_TIMEOUT_MS must be a positive integer no greater than ${MAX_TURN_TIMEOUT_MS} (got '${raw}')`,
+      );
+    }
+    return parsedTimeoutMs;
+  })();
+
   const loaded = await loadAllScenarios(
     parsed.dir,
     parsed.filter,
@@ -725,25 +747,6 @@ export async function runCli(
   logger.info(
     `[eliza-scenarios] provider: ${providerName}; execution profile: ${executionProfile}`,
   );
-
-  // Per-turn timeout. Defaults to 120s (fast hosted providers), but a real
-  // local model on a CPU backend needs a larger budget; expose it via env so
-  // the local-model bench lane can run without editing this file.
-  const turnTimeoutMs = (() => {
-    const raw = process.env.SCENARIO_TURN_TIMEOUT_MS?.trim();
-    if (!raw) return 120_000;
-    // `Number.parseInt` stops at the first non-digit, so "500junk" parsed to a
-    // finite, positive 500 and slipped past the guard below — silently running
-    // every turn on a 500ms budget instead of failing the way this check
-    // already intends to.
-    const parsed = /^\+?\d+$/.test(raw) ? Number(raw) : Number.NaN;
-    if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-      throw new Error(
-        `SCENARIO_TURN_TIMEOUT_MS must be a positive integer (got '${raw}')`,
-      );
-    }
-    return parsed;
-  })();
 
   const reports: ScenarioReport[] = [];
   let interruptedSignal: NodeJS.Signals | undefined;

--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -732,8 +732,12 @@ export async function runCli(
   const turnTimeoutMs = (() => {
     const raw = process.env.SCENARIO_TURN_TIMEOUT_MS?.trim();
     if (!raw) return 120_000;
-    const parsed = Number.parseInt(raw, 10);
-    if (!Number.isFinite(parsed) || parsed <= 0) {
+    // `Number.parseInt` stops at the first non-digit, so "500junk" parsed to a
+    // finite, positive 500 and slipped past the guard below — silently running
+    // every turn on a 500ms budget instead of failing the way this check
+    // already intends to.
+    const parsed = /^\+?\d+$/.test(raw) ? Number(raw) : Number.NaN;
+    if (!Number.isSafeInteger(parsed) || parsed <= 0) {
       throw new Error(
         `SCENARIO_TURN_TIMEOUT_MS must be a positive integer (got '${raw}')`,
       );


### PR DESCRIPTION
## Summary

`SCENARIO_TURN_TIMEOUT_MS` is now parsed as a complete decimal integer and validated before scenario discovery or runtime/PGLite startup. Malformed prefixes such as `500junk`, unsafe integers, zero/negative values, and delays above Node's supported timer ceiling fail loudly instead of creating a misleading ultra-short turn budget.

Clean decimal values and the previously accepted explicit `+` sign remain compatible.

## Why

`Number.parseInt("500junk", 10)` returns `500`, bypassing the existing invalid-config guard. Separately, Node clamps timer delays above `2_147_483_647`, which can turn an apparently huge timeout into an almost immediate failure. Both cases make scenario failures look like model/runtime problems rather than configuration errors.

## Changes

- Require the entire trimmed value to match `^\+?\d+$`.
- Require a positive safe integer no greater than `2_147_483_647`.
- Validate before loading scenarios or creating the runtime.
- Prove malformed/overflow values never call `createScenarioRuntime` or `runScenario`.
- Assert a clean `500` value is passed to the real CLI execution dependency unchanged.
- Preserve explicit `+500` compatibility and environment cleanup isolation.

## Exact-head verification

Base: `9c1fc32c0def7f3da4d40d54d88ac343e24c3a97`  
Head: `1baf6a6c2e238bf0abd5785668dc2851febe1ca0`

| Gate | Result |
| --- | --- |
| `vitest run src/cli.test.ts --config vitest.config.ts` | 26/26 passed |
| scoped Biome on `cli.ts` and `cli.test.ts` | clean |
| `bun run --cwd packages/scenario-runner build` | passed |
| `git diff --check` | clean |
| package typecheck | the changed files produced no diagnostics; the sparse validation checkout stopped on excluded/stale transitive plugin workspaces (`plugin-personal-assistant` -> `@elizaos/agent` and provider endpoint packages) |
| package aggregate tests | intentionally not accepted as a scoped result: the sparse checkout excludes the external scenario corpus and plugin fixtures those suites require; direct owning CLI suite is green |

Hosted exact-head CI is pending. The failures shown on the previous head belong to its superseded run.

## Reviewer start

Start at the timeout validation immediately after provider/judge configuration. The malformed and timer-overflow tests assert runtime creation never occurs, while the clean-value test asserts the exact `turnTimeoutMs: 500` option reaches `runScenario`.

## Risks

Low. Valid operational values are unchanged. Values Node cannot represent as timer delays are now rejected instead of silently clamped.

## Attribution

- Original defect discovery, strict parser, and regression tests by Codex/Claude tooling as recorded in the prior PR body.
- Exact-head rebase, pre-runtime validation repair, timer-ceiling bound, stronger assertions, and verification by Codex (`openai/gpt-5`).

## Evidence Gate

<!-- evidence-head:1baf6a6c2e238bf0abd5785668dc2851febe1ca0 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - headless scenario-runner CLI configuration has no rendered UI surface`.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - headless scenario-runner CLI configuration has no rendered UI surface`.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - deterministic CLI tests exercise the complete changed startup boundary`.

<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - malformed configuration is rejected before a backend/runtime starts; exact-head CLI execution is recorded above`.

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs `N/A - no frontend path changes`.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - validation completes before model/runtime creation`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - correct behavior is absence of runtime/scenario effects, asserted directly by the CLI tests`.

<!-- evidence-row:ocr-review -->
- [x] OCR review `N/A - no rendered visual text changes`.

# Documentation changes needed?

No. The documented positive-integer contract is unchanged; the implementation now enforces it within the timer's real range.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol, anthropic/claude-opus-5, openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop, Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@9c1fc32c0def7f3da4d40d54d88ac343e24c3a97:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol, gpt-5; anthropic / claude-opus-5
Client / agent tooling: Codex Desktop, Claude Code
Contribution skill revision: elizaOS/eliza@9c1fc32c0def7f3da4d40d54d88ac343e24c3a97:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [fix-scenario-turn-timeout-strict]
<!-- eliza-computer-attribution:v1 {"provider":"openai,anthropic","model":"gpt-5.6-sol,claude-opus-5,gpt-5","client":"Codex Desktop,Claude Code","skill_revision":"elizaOS/eliza@9c1fc32c0def7f3da4d40d54d88ac343e24c3a97:packages/skills/skills/contribute-to-eliza"} -->
