### PR TITLE
fix(cloud): guard against division by zero and NaN in app analytics daily averages

### DIFF
--- a/packages/cloud/shared/src/lib/services/app-analytics.bounds.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-analytics.bounds.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for app analytics getAppUsageSummary division and NaN bounds.
+ */
+
+import { describe, expect, it } from "vitest";
+
+function computeUsageAverages(
+  totalRequests: number,
+  totalCreditsUsed: string | null | undefined,
+  days?: number,
+) {
+  const effectiveDays = Math.max(
+    1,
+    Math.floor(Number.isFinite(days as number) ? (days as number) : 30),
+  );
+  const avgRequestsPerDay = Math.round(totalRequests / effectiveDays);
+  const totalCostNum = parseFloat(totalCreditsUsed ?? "0.00");
+  const safeCost = Number.isFinite(totalCostNum) ? totalCostNum : 0;
+  const avgCostPerDay = (safeCost / effectiveDays).toFixed(2);
+
+  return { avgRequestsPerDay, avgCostPerDay };
+}
+
+describe("app-analytics usage calculation bounds", () => {
+  it("computes standard averages correctly", () => {
+    const res = computeUsageAverages(300, "15.00", 30);
+    expect(res.avgRequestsPerDay).toBe(10);
+    expect(res.avgCostPerDay).toBe("0.50");
+  });
+
+  it("handles days <= 0 or 0 gracefully without producing Infinity", () => {
+    const resZero = computeUsageAverages(100, "5.00", 0);
+    expect(Number.isFinite(resZero.avgRequestsPerDay)).toBe(true);
+    expect(resZero.avgRequestsPerDay).toBe(100);
+    expect(resZero.avgCostPerDay).toBe("5.00");
+
+    const resNeg = computeUsageAverages(100, "5.00", -5);
+    expect(Number.isFinite(resNeg.avgRequestsPerDay)).toBe(true);
+    expect(resNeg.avgRequestsPerDay).toBe(100);
+    expect(resNeg.avgCostPerDay).toBe("5.00");
+  });
+
+  it("handles NaN or malformed credit string safely", () => {
+    const res = computeUsageAverages(50, "invalid-credits", 10);
+    expect(res.avgCostPerDay).toBe("0.00");
+    expect(res.avgRequestsPerDay).toBe(5);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/app-analytics.bounds.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-analytics.bounds.test.ts
@@ -2,47 +2,66 @@
  * Tests for app analytics getAppUsageSummary division and NaN bounds.
  */
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-function computeUsageAverages(
-  totalRequests: number,
-  totalCreditsUsed: string | null | undefined,
-  days?: number,
-) {
-  const effectiveDays = Math.max(
-    1,
-    Math.floor(Number.isFinite(days as number) ? (days as number) : 30),
-  );
-  const avgRequestsPerDay = Math.round(totalRequests / effectiveDays);
-  const totalCostNum = parseFloat(totalCreditsUsed ?? "0.00");
-  const safeCost = Number.isFinite(totalCostNum) ? totalCostNum : 0;
-  const avgCostPerDay = (safeCost / effectiveDays).toFixed(2);
+import { AppAnalyticsService } from "./app-analytics";
 
-  return { avgRequestsPerDay, avgCostPerDay };
+const findByIdMock = mock(async (_appId: string) => app());
+
+function service(): AppAnalyticsService {
+  return new AppAnalyticsService({ findById: findByIdMock } as never);
 }
 
+function app(totalCreditsUsed: string | null = "15.00") {
+  return {
+    total_requests: 300,
+    total_users: 12,
+    total_credits_used: totalCreditsUsed,
+  };
+}
+
+beforeEach(() => {
+  findByIdMock.mockReset();
+});
+
 describe("app-analytics usage calculation bounds", () => {
-  it("computes standard averages correctly", () => {
-    const res = computeUsageAverages(300, "15.00", 30);
-    expect(res.avgRequestsPerDay).toBe(10);
-    expect(res.avgCostPerDay).toBe("0.50");
+  test("computes standard averages correctly", () => {
+    findByIdMock.mockResolvedValue(app());
+
+    const res = service().getAppUsageSummary("app-1", 30);
+
+    return expect(res).resolves.toMatchObject({
+      totalCost: "15.00",
+      avgRequestsPerDay: 10,
+      avgCostPerDay: "0.50",
+    });
   });
 
-  it("handles days <= 0 or 0 gracefully without producing Infinity", () => {
-    const resZero = computeUsageAverages(100, "5.00", 0);
-    expect(Number.isFinite(resZero.avgRequestsPerDay)).toBe(true);
-    expect(resZero.avgRequestsPerDay).toBe(100);
-    expect(resZero.avgCostPerDay).toBe("5.00");
-
-    const resNeg = computeUsageAverages(100, "5.00", -5);
-    expect(Number.isFinite(resNeg.avgRequestsPerDay)).toBe(true);
-    expect(resNeg.avgRequestsPerDay).toBe(100);
-    expect(resNeg.avgCostPerDay).toBe("5.00");
+  test("rejects invalid days before querying the repository", async () => {
+    for (const days of [0, -5, Number.NaN, Number.POSITIVE_INFINITY, 1.5]) {
+      await expect(service().getAppUsageSummary("app-1", days)).rejects.toMatchObject({
+        code: "INVALID_APP_USAGE_SUMMARY_DAYS",
+      });
+    }
+    expect(findByIdMock).not.toHaveBeenCalled();
   });
 
-  it("handles NaN or malformed credit string safely", () => {
-    const res = computeUsageAverages(50, "invalid-credits", 10);
-    expect(res.avgCostPerDay).toBe("0.00");
-    expect(res.avgRequestsPerDay).toBe(5);
+  test("fails fast for malformed stored credits", async () => {
+    for (const credits of ["invalid-credits", "12.50junk", "NaN", "Infinity", ""]) {
+      findByIdMock.mockResolvedValue(app(credits));
+
+      await expect(service().getAppUsageSummary("app-1", 10)).rejects.toMatchObject({
+        code: "INVALID_APP_USAGE_TOTAL_CREDITS",
+      });
+    }
+  });
+
+  test("preserves the schema-established zero for a legacy null credit total", async () => {
+    findByIdMock.mockResolvedValue(app(null));
+
+    await expect(service().getAppUsageSummary("app-1", 10)).resolves.toMatchObject({
+      totalCost: "0.00",
+      avgCostPerDay: "0.00",
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/app-analytics.ts
+++ b/packages/cloud/shared/src/lib/services/app-analytics.ts
@@ -4,6 +4,7 @@
  * Handles tracking and aggregation of app usage analytics
  */
 
+import { ElizaError } from "@elizaos/core";
 import { type AppRequest, appsRepository, type NewAppAnalytics } from "../../db/repositories/apps";
 import type { App } from "../types";
 import { logger } from "../utils/logger";
@@ -45,6 +46,11 @@ export interface AppSessionAnalytics {
   };
 }
 
+type AppAnalyticsRepository = Pick<
+  typeof appsRepository,
+  "findById" | "getRecentRequests" | "incrementUsage" | "trackAppUserActivity"
+>;
+
 function metadataString(
   metadata: Record<string, unknown> | null | undefined,
   key: string,
@@ -83,6 +89,8 @@ function roundPercent(value: number): number {
 }
 
 export class AppAnalyticsService {
+  constructor(private readonly repository: AppAnalyticsRepository = appsRepository) {}
+
   /**
    * Track a request for an app
    * This should be called whenever an app makes an API request
@@ -102,11 +110,11 @@ export class AppAnalyticsService {
     const { appId, userId, requestType, success, creditsUsed = "0.00", metadata } = params;
 
     // Track app usage
-    await appsRepository.incrementUsage(appId, creditsUsed);
+    await this.repository.incrementUsage(appId, creditsUsed);
 
     // Track app user activity if userId is provided
     if (userId) {
-      await appsRepository.trackAppUserActivity(appId, userId, creditsUsed, metadata);
+      await this.repository.trackAppUserActivity(appId, userId, creditsUsed, metadata);
     }
 
     logger.info("Tracked app request", {
@@ -133,7 +141,7 @@ export class AppAnalyticsService {
     periodEnd: Date,
     periodType: "hourly" | "daily" | "monthly",
   ): Promise<NewAppAnalytics | null> {
-    const app = await appsRepository.findById(appId);
+    const app = await this.repository.findById(appId);
     if (!app) return null;
 
     // Return current totals as a snapshot
@@ -175,7 +183,7 @@ export class AppAnalyticsService {
   ): Promise<AppSessionAnalytics> {
     const scanLimit = Math.min(Math.max(options.scanLimit ?? 5000, 1), 5000);
     const sessionLimit = Math.min(Math.max(options.limit ?? 50, 1), 500);
-    const result = await appsRepository.getRecentRequests(appId, {
+    const result = await this.repository.getRecentRequests(appId, {
       requestType: "pageview",
       startDate: options.startDate,
       endDate: options.endDate,
@@ -392,18 +400,29 @@ export class AppAnalyticsService {
     avgRequestsPerDay: number;
     avgCostPerDay: string;
   }> {
-    const app = await appsRepository.findById(appId);
+    if (!Number.isSafeInteger(days) || days < 1) {
+      throw new ElizaError("App usage summary days must be a positive integer", {
+        code: "INVALID_APP_USAGE_SUMMARY_DAYS",
+        context: { appId, days },
+      });
+    }
+    const app = await this.repository.findById(appId);
 
     if (!app) {
       throw new Error("App not found");
     }
 
-    const effectiveDays = Math.max(1, Math.floor(Number.isFinite(days) ? days : 30));
-    const avgRequestsPerDay = Math.round(app.total_requests / effectiveDays);
+    const avgRequestsPerDay = Math.round(app.total_requests / days);
     const totalCreditsUsed = app.total_credits_used ?? "0.00";
-    const totalCostNum = parseFloat(totalCreditsUsed);
-    const safeCost = Number.isFinite(totalCostNum) ? totalCostNum : 0;
-    const avgCostPerDay = (safeCost / effectiveDays).toFixed(2);
+    const totalCostNum = Number(totalCreditsUsed);
+    if (!/^\d+(?:\.\d+)?$/.test(totalCreditsUsed) || !Number.isFinite(totalCostNum)) {
+      throw new ElizaError("Stored app usage credits are invalid", {
+        code: "INVALID_APP_USAGE_TOTAL_CREDITS",
+        context: { appId },
+        severity: "fatal",
+      });
+    }
+    const avgCostPerDay = (totalCostNum / days).toFixed(2);
 
     return {
       totalRequests: app.total_requests,

--- a/packages/cloud/shared/src/lib/services/app-analytics.ts
+++ b/packages/cloud/shared/src/lib/services/app-analytics.ts
@@ -398,10 +398,12 @@ export class AppAnalyticsService {
       throw new Error("App not found");
     }
 
-    const avgRequestsPerDay = Math.round(app.total_requests / days);
+    const effectiveDays = Math.max(1, Math.floor(Number.isFinite(days) ? days : 30));
+    const avgRequestsPerDay = Math.round(app.total_requests / effectiveDays);
     const totalCreditsUsed = app.total_credits_used ?? "0.00";
     const totalCostNum = parseFloat(totalCreditsUsed);
-    const avgCostPerDay = (totalCostNum / days).toFixed(2);
+    const safeCost = Number.isFinite(totalCostNum) ? totalCostNum : 0;
+    const avgCostPerDay = (safeCost / effectiveDays).toFixed(2);
 
     return {
       totalRequests: app.total_requests,


### PR DESCRIPTION
Does not close #23536; that is an unrelated personal-assistant issue. This repairs a latent exported cloud service contract with no current callers found.

<!-- evidence-head:eb70a93597cf8184b81a5b3086c230064bb5dc02 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend analytics service only; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend analytics service only; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-visible flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic service tests are summarized under Exact-head verification; no deployed backend was exercised.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - invalid analytics now fail before producing a domain artifact; real service return and error contracts are asserted in tests.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered pixels.

### Summary
Reject invalid day windows and malformed stored credit totals in `appAnalyticsService.getAppUsageSummary` so the service cannot return fabricated analytics.

### Root Cause
`getAppUsageSummary` divided by an unvalidated `days` value and parsed persisted credits permissively. The original patch silently clamped invalid windows and converted malformed monetary data into a healthy-looking zero, which violated the repository fail-fast/error policy and produced contradictory output. Its tests duplicated the arithmetic rather than calling the service.

### Solution
- Reject non-positive, fractional, non-finite, and unsafe day windows with typed `INVALID_APP_USAGE_SUMMARY_DAYS` before any repository read.
- Strictly validate stored decimal credits and throw typed fatal `INVALID_APP_USAGE_TOTAL_CREDITS`; partial values such as `12.50junk` are rejected instead of coerced.
- Inject the repository through `AppAnalyticsService` so tests drive the real method and prove invalid windows do not touch storage.
- Preserve the schema-established `0.00` default only for legacy null totals.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b687e3bbc9347c6d9d273b67c28a9b05dc52810b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@b687e3bbc9347c6d9d273b67c28a9b05dc52810b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — fix(cloud)]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@b687e3bbc9347c6d9d273b67c28a9b05dc52810b:packages/skills/skills/contribute-to-eliza"} -->


### Exact-head verification

At `eb70a93597cf8184b81a5b3086c230064bb5dc02`:

- `bun test` over `app-analytics.test.ts` and `app-analytics.bounds.test.ts` — 11/11 pass.
- `bun run --cwd packages/cloud/shared typecheck` — pass.
- Pinned Biome check over both changed files — pass.
- `git diff --check` — pass.
- Independent review confirmed the fabricated-zero, invalid-window, disconnected-test, and metadata blockers are repaired.

The PR remains ready for review. Exact-head hosted CI is queued; that hosted gate is an acceptance hold, not a reason to convert the PR to draft.

