### PR TITLE
fix(agent): reject a trailing-garbage DOCUMENTS_SERVICE_TIMEOUT_MS

### DIFF
--- a/packages/agent/src/api/documents-service-loader.test.ts
+++ b/packages/agent/src/api/documents-service-loader.test.ts
@@ -174,8 +174,8 @@ describe("getDocumentsServiceTimeoutMs", () => {
     expect(getDocumentsServiceTimeoutMs()).toBe(2_500);
   });
 
-  it("falls back for a timeout beyond the safe integer range", () => {
+  it("ceiling-clamps a clean timeout beyond the safe integer range", () => {
     vi.stubEnv("DOCUMENTS_SERVICE_TIMEOUT_MS", "9007199254740993");
-    expect(getDocumentsServiceTimeoutMs()).toBe(10_000);
+    expect(getDocumentsServiceTimeoutMs()).toBe(60_000);
   });
 });

--- a/packages/agent/src/api/documents-service-loader.test.ts
+++ b/packages/agent/src/api/documents-service-loader.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type DocumentsServiceLike,
   getDocumentsService,
+  getDocumentsServiceTimeoutMs,
 } from "./documents-service-loader.ts";
 
 const service = {} as DocumentsServiceLike;
@@ -149,5 +150,32 @@ describe("documents-service loader process lifecycle", () => {
       reason: "timeout",
     });
     expect(durationMs).toBeGreaterThanOrEqual(20);
+  });
+});
+
+describe("getDocumentsServiceTimeoutMs", () => {
+  it("ignores a trailing-garbage timeout instead of parsing its prefix", () => {
+    // parseInt("1junk") is 1 — a 1ms budget that makes every load report
+    // `timeout`, from a value nobody meant as a timeout.
+    vi.stubEnv("DOCUMENTS_SERVICE_TIMEOUT_MS", "1junk");
+    expect(getDocumentsServiceTimeoutMs()).toBe(10_000);
+  });
+
+  it("still honours a clean timeout and its ceiling", () => {
+    vi.stubEnv("DOCUMENTS_SERVICE_TIMEOUT_MS", "2500");
+    expect(getDocumentsServiceTimeoutMs()).toBe(2_500);
+    vi.stubEnv("DOCUMENTS_SERVICE_TIMEOUT_MS", "999999");
+    expect(getDocumentsServiceTimeoutMs()).toBe(60_000);
+  });
+
+  it("still honours an explicitly signed positive timeout", () => {
+    // `Number.parseInt` accepted "+2500"; rejecting it would be a regression.
+    vi.stubEnv("DOCUMENTS_SERVICE_TIMEOUT_MS", "+2500");
+    expect(getDocumentsServiceTimeoutMs()).toBe(2_500);
+  });
+
+  it("falls back for a timeout beyond the safe integer range", () => {
+    vi.stubEnv("DOCUMENTS_SERVICE_TIMEOUT_MS", "9007199254740993");
+    expect(getDocumentsServiceTimeoutMs()).toBe(10_000);
   });
 });

--- a/packages/agent/src/api/documents-service-loader.ts
+++ b/packages/agent/src/api/documents-service-loader.ts
@@ -132,7 +132,7 @@ export function getDocumentsServiceTimeoutMs(): number {
   // timeout. Require the whole trimmed value to be decimal.
   const trimmed = envVal.trim();
   const parsed = /^\+?\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN;
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) return DEFAULT_TIMEOUT_MS;
+  if (Number.isNaN(parsed) || parsed <= 0) return DEFAULT_TIMEOUT_MS;
   return Math.min(parsed, MAX_TIMEOUT_MS);
 }
 

--- a/packages/agent/src/api/documents-service-loader.ts
+++ b/packages/agent/src/api/documents-service-loader.ts
@@ -126,8 +126,13 @@ const MAX_TIMEOUT_MS = 60_000;
 export function getDocumentsServiceTimeoutMs(): number {
   const envVal = process.env.DOCUMENTS_SERVICE_TIMEOUT_MS;
   if (!envVal) return DEFAULT_TIMEOUT_MS;
-  const parsed = Number.parseInt(envVal, 10);
-  if (Number.isNaN(parsed) || parsed <= 0) return DEFAULT_TIMEOUT_MS;
+  // `Number.parseInt` stops at the first non-digit, so "1junk" parsed to a
+  // positive 1 and passed the guard below — a 1ms budget that makes every
+  // documents-service load report `timeout`, from a value nobody set as a
+  // timeout. Require the whole trimmed value to be decimal.
+  const trimmed = envVal.trim();
+  const parsed = /^\+?\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN;
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return DEFAULT_TIMEOUT_MS;
   return Math.min(parsed, MAX_TIMEOUT_MS);
 }
 


### PR DESCRIPTION
# Relates to

No separate issue — the defect is described in full below.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is built directly on the current `origin/develop` tree, so it applies with zero conflicts.
- [x] Focused package tests, typecheck and lint were run for the changed files; results are quoted below. Root `bun run verify` was not run green: `develop` currently carries unrelated `@elizaos/agent` Biome formatter diagnostics, the same blocker recorded in #24174.
- [x] A reviewer can confirm the change from the failure/mutation output below without reading the code.

# Sync with develop

- [x] Rebased onto `9c1fc32c0def7f3da4d40d54d88ac343e24c3a97`; zero conflicts.
- [x] Exact unrelated blocker documented above (pre-existing `@elizaos/agent` formatter diagnostics).

# Risks

Low. A single env-var parser; malformed values now take the fallback the function already defined, and every valid value is unchanged.

# Background

`getDocumentsServiceTimeoutMs` guards against a nonsense timeout, but `Number.parseInt` gets past the guard:

```ts
const parsed = Number.parseInt(envVal, 10);
if (Number.isNaN(parsed) || parsed <= 0) return DEFAULT_TIMEOUT_MS;
```

`parseInt` stops at the first non-digit, so `DOCUMENTS_SERVICE_TIMEOUT_MS=1junk` yields `1` — not `NaN`, and positive, so the fallback never fires and the loader runs on a **1ms budget instead of 10s**.

Every documents-service load then loses its race and returns:

```ts
{ service: null, reason: "timeout" }
```

Documents are reported unavailable, attributed to a timeout that reflects a typo rather than anything about the service. `NaN` is the only malformed input the existing check actually catches.

## The fix

Require the whole trimmed value to be decimal before converting, so malformed input reaches the fallback the function already defines. Positive clean decimals retain the established `MAX_TIMEOUT_MS` saturation, including values beyond the safe-integer range where precision is irrelevant after clamping.

## Verification

| Gate | Result |
| --- | --- |
| `documents-service-loader.test.ts` | 10 passed at exact head |
| `biome check` (both changed files) | clean |

Drift-checked against current `develop`: the parse is present upstream (develop line 129), so the defect is live.

## Mutation resistance

Reverting only the source change and keeping the tests:

```
× ignores a trailing-garbage timeout instead of parsing its prefix
AssertionError: expected 1 to be 10000
Tests  1 failed | 7 passed (8)
```

The failure surfaces the 1ms budget itself. The clean-timeout regressions cover ordinary, explicitly plus-signed, ceiling-exceeding, and beyond-safe-integer values, so the fix is specific to malformed input without shortening valid operator timeouts.

## Attribution

- Found by OpenAI `gpt-5.6-sol` via Codex (AgentRouter) during a validation review of `packages/agent`.
- Independent verification, the safe-integer bound, the ceiling regression guard, and the mutation proof by Claude Code (`claude-opus-5`).

# Documentation changes needed?

My changes do not require a change to the project documentation — the parser's documented contract is unchanged; this makes the implementation match it.

# Testing

## Where should a reviewer start?

Start with the mutation-resistance block below: it reverts only the source change and shows the exact wrong value the current code produces.

## Detailed testing steps

None beyond the automated suites quoted above — the change is a pure input-parsing boundary and is fully covered by the regression tests.

# Evidence Gate

<!-- evidence-head:02ec6cc658172ef8d2a4a438b16c7d8bacfffcfc -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only change to the documents-service timeout env parser, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only change to the documents-service timeout env parser, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable behaviour is the resolved timeout in milliseconds, shown by the mutation-proof output quoted below`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started by this change; the exercised path is covered by the unit suite quoted below`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model, prompt, provider or action path is changed; this is an input parser`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain record is produced; the observable output is the resolved timeout in milliseconds, asserted in the tests`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - the change has no rendered visual surface`.



## Exact-head coordination update

At `02ec6cc658172ef8d2a4a438b16c7d8bacfffcfc`, focused Vitest passes 10/10, pinned Biome passes both changed files, and `git diff --check` is clean. Package typecheck is blocked in this sparse worktree by absent transitive plugin dependencies and reports no diagnostics in either changed file. Independent review found and the current head repairs one compatibility regression: a clean oversized decimal continues to saturate at 60,000 ms rather than falling back to 10,000 ms.

The PR remains ready for review. Exact-head hosted checks and their unrelated/transitive failures are explicit merge holds, not reasons to convert it to draft.
