### PR TITLE
fix(ui): keep surrogate pairs intact in TTS error preview truncation

### DIFF
--- a/packages/ui/src/hooks/useVoiceChat.surrogate.test.ts
+++ b/packages/ui/src/hooks/useVoiceChat.surrogate.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Surrogate-safe TTS preview truncation for useVoiceChat hook.
+ * Mirrors tts-debug.ts pattern: truncateWellFormed(toWellFormedUnicode) so caps landing mid-emoji back off.
+ */
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+function previewWellFormed(text: string, cap: number): string {
+  return truncateWellFormed(toWellFormedUnicode(text), cap);
+}
+const isWellFormed = (s: string): boolean => {
+  const w = s as unknown as { isWellFormed?: () => boolean };
+  if (typeof w.isWellFormed === "function") return w.isWellFormed();
+  return toWellFormedUnicode(s) === s;
+};
+
+describe("useVoiceChat TTS preview surrogate safety", () => {
+  const ROCKET = "🦊"; // surrogate pair, 2 code units
+
+  it("backs off when 80 cap lands mid-pair", () => {
+    const input = `${"a".repeat(79)}${ROCKET}${"b".repeat(20)}`;
+    const out = previewWellFormed(input, 80);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBe(79);
+    expect(out.endsWith("\ud83e") || out.endsWith("\ud83d")).toBe(false);
+  });
+
+  it("backs off when 120 cap lands mid-pair", () => {
+    const input = `${"a".repeat(119)}${ROCKET}${"b".repeat(20)}`;
+    const out = previewWellFormed(input, 120);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBe(119);
+  });
+
+  it("backs off when 200 cap lands mid-pair", () => {
+    const input = `${"a".repeat(199)}${ROCKET}${"b".repeat(20)}`;
+    const out = previewWellFormed(input, 200);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.length).toBe(199);
+  });
+
+  it("preserves fitting emoji at caps", () => {
+    expect(previewWellFormed(`${"a".repeat(78)}${ROCKET}`, 80)).toBe(
+      `${"a".repeat(78)}${ROCKET}`,
+    );
+    expect(previewWellFormed(`${"a".repeat(118)}${ROCKET}`, 120)).toBe(
+      `${"a".repeat(118)}${ROCKET}`,
+    );
+    expect(previewWellFormed(`${"a".repeat(198)}${ROCKET}`, 200)).toBe(
+      `${"a".repeat(198)}${ROCKET}`,
+    );
+  });
+
+  it("sweep 0..65 at 80 stays well-formed", () => {
+    for (let off = 0; off <= 65; off++) {
+      const input = `${"a".repeat(off)}${ROCKET}${"b".repeat(100)}`;
+      const out = previewWellFormed(input, 80);
+      expect(isWellFormed(out)).toBe(true);
+      expect(() => JSON.stringify(out)).not.toThrow();
+    }
+  });
+
+  it("sanitizes lone surrogate to U+FFFD", () => {
+    const out = previewWellFormed(`ok \ud83d end ${"x".repeat(200)}`, 80);
+    expect(isWellFormed(out)).toBe(true);
+    expect(out.includes("\ud83d")).toBe(false);
+    expect(out.includes("�")).toBe(true);
+  });
+});

--- a/packages/ui/src/hooks/useVoiceChat.surrogate.test.ts
+++ b/packages/ui/src/hooks/useVoiceChat.surrogate.test.ts
@@ -2,12 +2,13 @@
  * Surrogate-safe TTS preview truncation for useVoiceChat hook.
  * Mirrors tts-debug.ts pattern: truncateWellFormed(toWellFormedUnicode) so caps landing mid-emoji back off.
  */
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { toWellFormedUnicode } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
+import {
+  formatNamedVoiceError,
+  formatVoiceErrorPreview,
+} from "./voice-error-preview";
 
-function previewWellFormed(text: string, cap: number): string {
-  return truncateWellFormed(toWellFormedUnicode(text), cap);
-}
 const isWellFormed = (s: string): boolean => {
   const w = s as unknown as { isWellFormed?: () => boolean };
   if (typeof w.isWellFormed === "function") return w.isWellFormed();
@@ -16,10 +17,11 @@ const isWellFormed = (s: string): boolean => {
 
 describe("useVoiceChat TTS preview surrogate safety", () => {
   const ROCKET = "🦊"; // surrogate pair, 2 code units
+  const LONE_HIGH_SURROGATE = "\ud83d";
 
   it("backs off when 80 cap lands mid-pair", () => {
     const input = `${"a".repeat(79)}${ROCKET}${"b".repeat(20)}`;
-    const out = previewWellFormed(input, 80);
+    const out = formatVoiceErrorPreview(input, 80);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBe(79);
     expect(out.endsWith("\ud83e") || out.endsWith("\ud83d")).toBe(false);
@@ -27,26 +29,26 @@ describe("useVoiceChat TTS preview surrogate safety", () => {
 
   it("backs off when 120 cap lands mid-pair", () => {
     const input = `${"a".repeat(119)}${ROCKET}${"b".repeat(20)}`;
-    const out = previewWellFormed(input, 120);
+    const out = formatVoiceErrorPreview(input, 120);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBe(119);
   });
 
   it("backs off when 200 cap lands mid-pair", () => {
     const input = `${"a".repeat(199)}${ROCKET}${"b".repeat(20)}`;
-    const out = previewWellFormed(input, 200);
+    const out = formatVoiceErrorPreview(input, 200);
     expect(isWellFormed(out)).toBe(true);
     expect(out.length).toBe(199);
   });
 
   it("preserves fitting emoji at caps", () => {
-    expect(previewWellFormed(`${"a".repeat(78)}${ROCKET}`, 80)).toBe(
+    expect(formatVoiceErrorPreview(`${"a".repeat(78)}${ROCKET}`, 80)).toBe(
       `${"a".repeat(78)}${ROCKET}`,
     );
-    expect(previewWellFormed(`${"a".repeat(118)}${ROCKET}`, 120)).toBe(
+    expect(formatVoiceErrorPreview(`${"a".repeat(118)}${ROCKET}`, 120)).toBe(
       `${"a".repeat(118)}${ROCKET}`,
     );
-    expect(previewWellFormed(`${"a".repeat(198)}${ROCKET}`, 200)).toBe(
+    expect(formatVoiceErrorPreview(`${"a".repeat(198)}${ROCKET}`, 200)).toBe(
       `${"a".repeat(198)}${ROCKET}`,
     );
   });
@@ -54,16 +56,26 @@ describe("useVoiceChat TTS preview surrogate safety", () => {
   it("sweep 0..65 at 80 stays well-formed", () => {
     for (let off = 0; off <= 65; off++) {
       const input = `${"a".repeat(off)}${ROCKET}${"b".repeat(100)}`;
-      const out = previewWellFormed(input, 80);
+      const out = formatVoiceErrorPreview(input, 80);
       expect(isWellFormed(out)).toBe(true);
       expect(() => JSON.stringify(out)).not.toThrow();
     }
   });
 
   it("sanitizes lone surrogate to U+FFFD", () => {
-    const out = previewWellFormed(`ok \ud83d end ${"x".repeat(200)}`, 80);
+    const out = formatVoiceErrorPreview(`ok \ud83d end ${"x".repeat(200)}`, 80);
     expect(isWellFormed(out)).toBe(true);
     expect(out.includes("\ud83d")).toBe(false);
     expect(out.includes("�")).toBe(true);
+  });
+
+  it("formats the complete named queue/debug error through the production formatter", () => {
+    const error = new TypeError(`${"q".repeat(188)}${ROCKET}ignored`);
+    error.name = `Type${LONE_HIGH_SURROGATE}Error`;
+    const preview = formatNamedVoiceError(error);
+
+    expect(preview).toContain("Type�Error: ");
+    expect(preview.length).toBeLessThanOrEqual(200);
+    expect(isWellFormed(preview)).toBe(true);
   });
 });

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -13,6 +13,7 @@
 
 import type { PluginListenerHandle } from "@capacitor/core";
 import { Capacitor } from "@capacitor/core";
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { logger } from "@elizaos/logger";
 import {
   useCallback,
@@ -1032,8 +1033,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
           name: error instanceof Error ? error.name : "Error",
           reason:
             error instanceof Error
-              ? error.message.slice(0, 80)
-              : String(error).slice(0, 80),
+              ? truncateWellFormed(toWellFormedUnicode(error.message), 80)
+              : truncateWellFormed(toWellFormedUnicode(String(error)), 80),
         });
         localAsrRecorderRef.current = null;
         return false;
@@ -1071,8 +1072,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
           name: error instanceof Error ? error.name : "Error",
           reason:
             error instanceof Error
-              ? error.message.slice(0, 80)
-              : String(error).slice(0, 80),
+              ? truncateWellFormed(toWellFormedUnicode(error.message), 80)
+              : truncateWellFormed(toWellFormedUnicode(String(error)), 80),
         });
         localAsrRecorderRef.current = null;
         return false;
@@ -1447,8 +1448,11 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
                 name: error instanceof Error ? error.name : "Error",
                 reason:
                   error instanceof Error
-                    ? error.message.slice(0, 80)
-                    : String(error).slice(0, 80),
+                    ? truncateWellFormed(toWellFormedUnicode(error.message), 80)
+                    : truncateWellFormed(
+                        toWellFormedUnicode(String(error)),
+                        80,
+                      ),
               });
             }
             ttsDebug("asr:cloud:error", {
@@ -1744,9 +1748,11 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
             status: res.status,
             ttsTarget: describeTtsCloudFetchTargetForDebug(),
             hadBearer: Boolean(apiToken),
-            bodyPreview: body.slice(0, 120),
+            bodyPreview: truncateWellFormed(toWellFormedUnicode(body), 120),
           });
-          throw new Error(`ElevenLabs ${res.status}: ${body.slice(0, 200)}`);
+          throw new Error(
+            `ElevenLabs ${res.status}: ${truncateWellFormed(toWellFormedUnicode(body), 200)}`,
+          );
         }
 
         const audioData = await res.arrayBuffer();
@@ -1938,7 +1944,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               if (!directRes.ok) {
                 const preview = await directRes.text().catch(() => "");
                 throw new Error(
-                  `direct cloud TTS ${directRes.status}: ${preview.slice(0, 120)}`,
+                  `direct cloud TTS ${directRes.status}: ${truncateWellFormed(toWellFormedUnicode(preview), 120)}`,
                 );
               }
               res = directRes;
@@ -1976,10 +1982,10 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
             status: res.status,
             ttsTarget: describeTtsFetchTargetForDebug(fetchedTtsUrl),
             hadBearer: Boolean(getElizaApiToken()?.trim()),
-            bodyPreview: body.slice(0, 120),
+            bodyPreview: truncateWellFormed(toWellFormedUnicode(body), 120),
           });
           throw new Error(
-            `Eliza Cloud TTS ${res.status}: ${body.slice(0, 200)}`,
+            `Eliza Cloud TTS ${res.status}: ${truncateWellFormed(toWellFormedUnicode(body), 200)}`,
           );
         }
 
@@ -2079,7 +2085,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         if (!res.ok) {
           const body = await res.text().catch(() => "");
           throw new Error(
-            `Local inference TTS ${res.status}: ${body.slice(0, 200)}`,
+            `Local inference TTS ${res.status}: ${truncateWellFormed(toWellFormedUnicode(body), 200)}`,
           );
         }
 
@@ -2192,8 +2198,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               preview: ttsDebugTextPreview(text),
               err:
                 err instanceof Error
-                  ? `${err.name}: ${err.message.slice(0, 200)}`
-                  : String(err).slice(0, 200),
+                  ? `${err.name}: ${truncateWellFormed(toWellFormedUnicode(err.message), 200)}`
+                  : truncateWellFormed(toWellFormedUnicode(String(err)), 200),
             });
           });
           emitPlaybackStart({
@@ -2436,8 +2442,11 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               ttsDebug("useVoiceChat:native-talkmode-failed", {
                 err:
                   error instanceof Error
-                    ? `${error.name}: ${error.message.slice(0, 200)}`
-                    : String(error).slice(0, 200),
+                    ? `${error.name}: ${truncateWellFormed(toWellFormedUnicode(error.message), 200)}`
+                    : truncateWellFormed(
+                        toWellFormedUnicode(String(error)),
+                        200,
+                      ),
               });
               failClosed("native-talkmode", error);
               break;
@@ -2462,8 +2471,11 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               ttsDebug("useVoiceChat:eliza-cloud-failed", {
                 err:
                   error instanceof Error
-                    ? `${error.name}: ${error.message.slice(0, 200)}`
-                    : String(error).slice(0, 200),
+                    ? `${error.name}: ${truncateWellFormed(toWellFormedUnicode(error.message), 200)}`
+                    : truncateWellFormed(
+                        toWellFormedUnicode(String(error)),
+                        200,
+                      ),
                 ttsTarget: describeTtsCloudFetchTargetForDebug(),
                 hadBearer: Boolean(getElizaApiToken()?.trim()),
               });
@@ -2494,8 +2506,11 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               ttsDebug("useVoiceChat:local-inference-failed", {
                 err:
                   error instanceof Error
-                    ? `${error.name}: ${error.message.slice(0, 200)}`
-                    : String(error).slice(0, 200),
+                    ? `${error.name}: ${truncateWellFormed(toWellFormedUnicode(error.message), 200)}`
+                    : truncateWellFormed(
+                        toWellFormedUnicode(String(error)),
+                        200,
+                      ),
               });
               // FAIL CLOSED (#12253): local-inference (Kokoro) is the configured
               // voice. Do not silently swap to browser SpeechSynthesis — stop the
@@ -2527,8 +2542,11 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               ttsDebug("useVoiceChat:elevenlabs-failed", {
                 err:
                   error instanceof Error
-                    ? `${error.name}: ${error.message.slice(0, 200)}`
-                    : String(error).slice(0, 200),
+                    ? `${error.name}: ${truncateWellFormed(toWellFormedUnicode(error.message), 200)}`
+                    : truncateWellFormed(
+                        toWellFormedUnicode(String(error)),
+                        200,
+                      ),
                 ttsTarget: describeTtsCloudFetchTargetForDebug(),
                 hadBearer: Boolean(getElizaApiToken()?.trim()),
               });
@@ -2564,8 +2582,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         ttsDebug("processQueue:error", {
           err:
             error instanceof Error
-              ? `${error.name}: ${error.message.slice(0, 200)}`
-              : String(error).slice(0, 200),
+              ? `${error.name}: ${truncateWellFormed(toWellFormedUnicode(error.message), 200)}`
+              : truncateWellFormed(toWellFormedUnicode(String(error)), 200),
         });
       } finally {
         queueWorkerRunningRef.current = false;

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -13,7 +13,6 @@
 
 import type { PluginListenerHandle } from "@capacitor/core";
 import { Capacitor } from "@capacitor/core";
-import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import { logger } from "@elizaos/logger";
 import {
   useCallback,
@@ -122,6 +121,10 @@ import {
   webSpeechVoiceDebugFields,
 } from "../voice/voice-chat-types";
 import { resolveWavAsrRoute } from "../voice/voice-provider-defaults";
+import {
+  formatNamedVoiceError,
+  formatVoiceErrorPreview,
+} from "./voice-error-preview";
 
 // ── Re-exports (public API) ──────────────────────────────────────────
 
@@ -1033,8 +1036,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
           name: error instanceof Error ? error.name : "Error",
           reason:
             error instanceof Error
-              ? truncateWellFormed(toWellFormedUnicode(error.message), 80)
-              : truncateWellFormed(toWellFormedUnicode(String(error)), 80),
+              ? formatVoiceErrorPreview(error.message, 80)
+              : formatVoiceErrorPreview(error, 80),
         });
         localAsrRecorderRef.current = null;
         return false;
@@ -1072,8 +1075,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
           name: error instanceof Error ? error.name : "Error",
           reason:
             error instanceof Error
-              ? truncateWellFormed(toWellFormedUnicode(error.message), 80)
-              : truncateWellFormed(toWellFormedUnicode(String(error)), 80),
+              ? formatVoiceErrorPreview(error.message, 80)
+              : formatVoiceErrorPreview(error, 80),
         });
         localAsrRecorderRef.current = null;
         return false;
@@ -1448,11 +1451,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
                 name: error instanceof Error ? error.name : "Error",
                 reason:
                   error instanceof Error
-                    ? truncateWellFormed(toWellFormedUnicode(error.message), 80)
-                    : truncateWellFormed(
-                        toWellFormedUnicode(String(error)),
-                        80,
-                      ),
+                    ? formatVoiceErrorPreview(error.message, 80)
+                    : formatVoiceErrorPreview(error, 80),
               });
             }
             ttsDebug("asr:cloud:error", {
@@ -1748,10 +1748,10 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
             status: res.status,
             ttsTarget: describeTtsCloudFetchTargetForDebug(),
             hadBearer: Boolean(apiToken),
-            bodyPreview: truncateWellFormed(toWellFormedUnicode(body), 120),
+            bodyPreview: formatVoiceErrorPreview(body, 120),
           });
           throw new Error(
-            `ElevenLabs ${res.status}: ${truncateWellFormed(toWellFormedUnicode(body), 200)}`,
+            `ElevenLabs ${res.status}: ${formatVoiceErrorPreview(body, 200)}`,
           );
         }
 
@@ -1944,7 +1944,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               if (!directRes.ok) {
                 const preview = await directRes.text().catch(() => "");
                 throw new Error(
-                  `direct cloud TTS ${directRes.status}: ${truncateWellFormed(toWellFormedUnicode(preview), 120)}`,
+                  `direct cloud TTS ${directRes.status}: ${formatVoiceErrorPreview(preview, 120)}`,
                 );
               }
               res = directRes;
@@ -1982,10 +1982,10 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
             status: res.status,
             ttsTarget: describeTtsFetchTargetForDebug(fetchedTtsUrl),
             hadBearer: Boolean(getElizaApiToken()?.trim()),
-            bodyPreview: truncateWellFormed(toWellFormedUnicode(body), 120),
+            bodyPreview: formatVoiceErrorPreview(body, 120),
           });
           throw new Error(
-            `Eliza Cloud TTS ${res.status}: ${truncateWellFormed(toWellFormedUnicode(body), 200)}`,
+            `Eliza Cloud TTS ${res.status}: ${formatVoiceErrorPreview(body, 200)}`,
           );
         }
 
@@ -2085,7 +2085,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         if (!res.ok) {
           const body = await res.text().catch(() => "");
           throw new Error(
-            `Local inference TTS ${res.status}: ${truncateWellFormed(toWellFormedUnicode(body), 200)}`,
+            `Local inference TTS ${res.status}: ${formatVoiceErrorPreview(body, 200)}`,
           );
         }
 
@@ -2196,10 +2196,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
             ttsDebug("play:talkmode:speak-failed", {
               segment: task.segment,
               preview: ttsDebugTextPreview(text),
-              err:
-                err instanceof Error
-                  ? `${err.name}: ${truncateWellFormed(toWellFormedUnicode(err.message), 200)}`
-                  : truncateWellFormed(toWellFormedUnicode(String(err)), 200),
+              err: formatNamedVoiceError(err),
             });
           });
           emitPlaybackStart({
@@ -2440,13 +2437,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               usingAudioAnalysisRef.current = false;
               setUsingAudioAnalysis(false);
               ttsDebug("useVoiceChat:native-talkmode-failed", {
-                err:
-                  error instanceof Error
-                    ? `${error.name}: ${truncateWellFormed(toWellFormedUnicode(error.message), 200)}`
-                    : truncateWellFormed(
-                        toWellFormedUnicode(String(error)),
-                        200,
-                      ),
+                err: formatNamedVoiceError(error),
               });
               failClosed("native-talkmode", error);
               break;
@@ -2469,13 +2460,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               usingAudioAnalysisRef.current = false;
               setUsingAudioAnalysis(false);
               ttsDebug("useVoiceChat:eliza-cloud-failed", {
-                err:
-                  error instanceof Error
-                    ? `${error.name}: ${truncateWellFormed(toWellFormedUnicode(error.message), 200)}`
-                    : truncateWellFormed(
-                        toWellFormedUnicode(String(error)),
-                        200,
-                      ),
+                err: formatNamedVoiceError(error),
                 ttsTarget: describeTtsCloudFetchTargetForDebug(),
                 hadBearer: Boolean(getElizaApiToken()?.trim()),
               });
@@ -2504,13 +2489,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               usingAudioAnalysisRef.current = false;
               setUsingAudioAnalysis(false);
               ttsDebug("useVoiceChat:local-inference-failed", {
-                err:
-                  error instanceof Error
-                    ? `${error.name}: ${truncateWellFormed(toWellFormedUnicode(error.message), 200)}`
-                    : truncateWellFormed(
-                        toWellFormedUnicode(String(error)),
-                        200,
-                      ),
+                err: formatNamedVoiceError(error),
               });
               // FAIL CLOSED (#12253): local-inference (Kokoro) is the configured
               // voice. Do not silently swap to browser SpeechSynthesis — stop the
@@ -2540,13 +2519,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
                 break;
               }
               ttsDebug("useVoiceChat:elevenlabs-failed", {
-                err:
-                  error instanceof Error
-                    ? `${error.name}: ${truncateWellFormed(toWellFormedUnicode(error.message), 200)}`
-                    : truncateWellFormed(
-                        toWellFormedUnicode(String(error)),
-                        200,
-                      ),
+                err: formatNamedVoiceError(error),
                 ttsTarget: describeTtsCloudFetchTargetForDebug(),
                 hadBearer: Boolean(getElizaApiToken()?.trim()),
               });
@@ -2580,10 +2553,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         workerError = error;
         queueRef.current = [];
         ttsDebug("processQueue:error", {
-          err:
-            error instanceof Error
-              ? `${error.name}: ${truncateWellFormed(toWellFormedUnicode(error.message), 200)}`
-              : truncateWellFormed(toWellFormedUnicode(String(error)), 200),
+          err: formatNamedVoiceError(error),
         });
       } finally {
         queueWorkerRunningRef.current = false;

--- a/packages/ui/src/hooks/voice-error-preview.ts
+++ b/packages/ui/src/hooks/voice-error-preview.ts
@@ -1,0 +1,22 @@
+/** Surrogate-safe preview formatting shared by voice failure and debug paths. */
+
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+
+export type VoiceErrorPreviewLimit = 80 | 120 | 200;
+
+/** Normalize untrusted failure text and clamp it without splitting UTF-16 pairs. */
+export function formatVoiceErrorPreview(
+  value: unknown,
+  limit: VoiceErrorPreviewLimit,
+): string {
+  const text = typeof value === "string" ? value : String(value);
+  return truncateWellFormed(toWellFormedUnicode(text), limit);
+}
+
+/** Format a named Error through the same bounded, well-formed preview path. */
+export function formatNamedVoiceError(error: unknown): string {
+  return formatVoiceErrorPreview(
+    error instanceof Error ? `${error.name}: ${error.message}` : error,
+    200,
+  );
+}


### PR DESCRIPTION
## Summary

- Make every bounded TTS/ASR/provider error preview in `useVoiceChat` Unicode-well-formed before truncation.
- Centralize the production behavior in `voice-error-preview.ts`, including the complete mutable `Error.name: message` string.
- Exercise the production formatter at the 80, 120, and 200 code-unit limits, fitting surrogate pairs, offset sweeps, lone surrogates, and named errors.

No issue is linked: the previously listed #23536 is unrelated and already resolved.

## Changes

| File | Change |
| --- | --- |
| `packages/ui/src/hooks/voice-error-preview.ts` | Adds the bounded, well-formed production formatters. |
| `packages/ui/src/hooks/useVoiceChat.ts` | Routes ASR, provider-body, playback, provider, and queue/debug previews through those formatters. |
| `packages/ui/src/hooks/useVoiceChat.surrogate.test.ts` | Tests the production formatter rather than a test-local copy, including malformed `Error.name`. |

## Exact-head verification

<!-- evidence-head:fa722245087620c60d9a65c2ea7bc1db484d09b7 -->

- Rebased onto `origin/develop@9c1fc32c0def7f3da4d40d54d88ac343e24c3a97` with no conflicts.
- `bun run --cwd packages/ui test -- src/hooks/useVoiceChat.surrogate.test.ts src/utils/tts-debug.test.ts` — 18 passed, 0 failed.
- `bun run --cwd packages/ui typecheck` — passed.
- `bunx biome check packages/ui/src/hooks/useVoiceChat.ts packages/ui/src/hooks/useVoiceChat.surrogate.test.ts packages/ui/src/hooks/voice-error-preview.ts packages/ui/src/utils/tts-debug.ts packages/ui/src/utils/tts-debug.test.ts` — passed.
- `git diff --check` — passed before commit.

## Evidence gate

<!-- evidence-row:before-screenshots -->
- [ ] Current-head before imagery is unavailable because this repair was rebased from a prior source head; prior-head imagery is not restamped as exact-head evidence.

<!-- evidence-row:after-screenshots -->
- [x] `bun run --cwd packages/app audit:app` built all 21 authoritative view bundles and captured all 228 real viewport cases at the exact head; 228/228 real view cases completed. The aggregate command remains held by the two unrelated audit failures named below.

<!-- evidence-row:walkthrough-video -->
- [ ] Current-head interaction video remains an acceptance hold. This change affects diagnostic strings rather than a directly navigable product flow.

<!-- evidence-row:backend-logs -->
- [x] Focused production-formatter test output above: 18/18 passed.

<!-- evidence-row:frontend-logs -->
- [x] Exact-head app audit: 229/231 Playwright cases passed. The failures were (1) the audit readiness fixture expected `semanticReady: true` but received `false`, and (2) the final aggregate minimalism ratchet reported unrelated existing regressions in `builtin-browser` and `plugin-finances-gui`. This PR touches neither view.

<!-- evidence-row:llm-trajectory -->
- [x] N/A — no prompt, model, planner, action, or provider delegation behavior changes.

<!-- evidence-row:domain-artifacts -->
- [x] The domain artifact is the bounded diagnostic preview: the exact-head tests prove well-formed output at all three limits, sanitize lone surrogates in both names and messages, and exercise the production helper used by the hook.

<!-- evidence-row:ocr-review -->
- [ ] OCR did not run because the capture command stopped after the two named aggregate audit failures. This is an explicit ready-state acceptance hold, not a source blocker.

## Ready-state holds

- Hosted CI and independent review must rerun on `fa722245087620c60d9a65c2ea7bc1db484d09b7`.
- App audit acceptance is held by the two unrelated repository-wide failures documented above; the PR remains ready for review because its source blockers are repaired and scoped gates pass.

## Risk

Low. The change centralizes existing string-hygiene behavior and expands it to cover the entire named diagnostic string without altering voice selection, network routing, or playback behavior.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@9c1fc32c0def7f3da4d40d54d88ac343e24c3a97:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@9c1fc32c0def7f3da4d40d54d88ac343e24c3a97:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — agent]
