### PR TITLE
fix(local-inference): reject a trailing-garbage RAM headroom reserve

### DIFF
--- a/plugins/plugin-local-inference/src/provider.ts
+++ b/plugins/plugin-local-inference/src/provider.ts
@@ -58,6 +58,7 @@ import { transcriptsRoutes } from "./routes/transcripts-routes.js";
 import { voiceProfilePluginRoutes } from "./routes/voice-profile-plugin-routes.js";
 import { handleVoiceEntityBound } from "./runtime/voice-entity-binding.js";
 import { mergeElizaTurnStopSequences } from "./services/eliza-turn-stops.js";
+import { ramHeadroomReserveMb } from "./services/ram-budget.js";
 import { augmentVisionRequest } from "./services/vision/augmenter.js";
 import { prepareVisionImageInput } from "./services/vision/image-input.js";
 import type { VisionImageInput } from "./services/vision/types.js";
@@ -1244,6 +1245,10 @@ export const localInferencePlugin: Plugin = {
 	// app come online.
 	models: createStaticPluginModelHandlers(),
 	async init(_config: unknown, runtime: IAgentRuntime) {
+		// Validate explicit resource policy before advertising provider readiness.
+		// An absent override retains the default; malformed configuration throws a
+		// typed fatal error through the runtime's plugin-startup boundary.
+		ramHeadroomReserveMb();
 		const service = serviceFromRuntime(runtime);
 		if (!service) {
 			logger.info(

--- a/plugins/plugin-local-inference/src/services/ram-budget.test.ts
+++ b/plugins/plugin-local-inference/src/services/ram-budget.test.ts
@@ -3,7 +3,9 @@
  * RAM before a model's fit is judged, so a silently truncated value removes the
  * safety margin that refuses an oversized load.
  */
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
+import { localInferencePlugin } from "../provider";
 import { ramHeadroomReserveMb } from "./ram-budget";
 
 const KEY = "ELIZA_LOCAL_RAM_HEADROOM_MB";
@@ -15,10 +17,8 @@ afterEach(() => {
 });
 
 describe("ramHeadroomReserveMb", () => {
-	it("ignores a trailing-garbage reserve instead of parsing its prefix", () => {
-		// parseInt("1junk") is 1 — a 1MB reserve instead of 1536MB, overstating
-		// usable RAM by ~1.5GB so a model that must be refused reports "fits".
-		process.env[KEY] = "1junk";
+	it("uses the default only when the override is absent", () => {
+		delete process.env[KEY];
 		expect(ramHeadroomReserveMb()).toBe(1536);
 	});
 
@@ -35,8 +35,39 @@ describe("ramHeadroomReserveMb", () => {
 		expect(ramHeadroomReserveMb()).toBe(2048);
 	});
 
-	it("falls back for a reserve beyond the safe integer range", () => {
-		process.env[KEY] = "9007199254740993";
-		expect(ramHeadroomReserveMb()).toBe(1536);
+	it.each([
+		"",
+		"   ",
+		"1junk",
+		"2048MB",
+		"2048.7",
+		"2 048",
+		"2_048",
+		"-1",
+		"9007199254740993",
+	])("rejects the explicit malformed reserve %j", (configured) => {
+		process.env[KEY] = configured;
+
+		expect(() => ramHeadroomReserveMb()).toThrowError(ElizaError);
+		try {
+			ramHeadroomReserveMb();
+		} catch (error) {
+			expect(error).toMatchObject({
+				code: "INVALID_LOCAL_RAM_HEADROOM",
+				context: { envKey: KEY, configured },
+				severity: "fatal",
+			});
+		}
+	});
+
+	it("surfaces malformed configuration through plugin startup", async () => {
+		process.env[KEY] = "2048MB";
+		if (!localInferencePlugin.init) {
+			throw new Error("local-inference plugin has no startup initializer");
+		}
+
+		await expect(
+			localInferencePlugin.init({}, {} as IAgentRuntime),
+		).rejects.toMatchObject({ code: "INVALID_LOCAL_RAM_HEADROOM" });
 	});
 });

--- a/plugins/plugin-local-inference/src/services/ram-budget.test.ts
+++ b/plugins/plugin-local-inference/src/services/ram-budget.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Covers `ramHeadroomReserveMb` env parsing. The reserve is subtracted from host
+ * RAM before a model's fit is judged, so a silently truncated value removes the
+ * safety margin that refuses an oversized load.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { ramHeadroomReserveMb } from "./ram-budget";
+
+const KEY = "ELIZA_LOCAL_RAM_HEADROOM_MB";
+const original = process.env[KEY];
+
+afterEach(() => {
+	if (original === undefined) delete process.env[KEY];
+	else process.env[KEY] = original;
+});
+
+describe("ramHeadroomReserveMb", () => {
+	it("ignores a trailing-garbage reserve instead of parsing its prefix", () => {
+		// parseInt("1junk") is 1 — a 1MB reserve instead of 1536MB, overstating
+		// usable RAM by ~1.5GB so a model that must be refused reports "fits".
+		process.env[KEY] = "1junk";
+		expect(ramHeadroomReserveMb()).toBe(1536);
+	});
+
+	it("still honours a clean reserve, including an explicit zero", () => {
+		process.env[KEY] = "2048";
+		expect(ramHeadroomReserveMb()).toBe(2048);
+		process.env[KEY] = "0";
+		expect(ramHeadroomReserveMb()).toBe(0);
+	});
+
+	it("still honours an explicitly signed positive reserve", () => {
+		// `Number.parseInt` accepted "+2048"; rejecting it would be a regression.
+		process.env[KEY] = "+2048";
+		expect(ramHeadroomReserveMb()).toBe(2048);
+	});
+
+	it("falls back for a reserve beyond the safe integer range", () => {
+		process.env[KEY] = "9007199254740993";
+		expect(ramHeadroomReserveMb()).toBe(1536);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/ram-budget.ts
+++ b/plugins/plugin-local-inference/src/services/ram-budget.ts
@@ -54,8 +54,12 @@ const FALLBACK_DEFAULT_CONTEXT_TOKENS = 32768;
 export function ramHeadroomReserveMb(): number {
 	const raw = process.env.ELIZA_LOCAL_RAM_HEADROOM_MB?.trim();
 	if (raw) {
-		const parsed = Number.parseInt(raw, 10);
-		if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+		// `Number.parseInt` stops at the first non-digit, so "1junk" parsed to a
+		// finite, non-negative 1 and passed the guard — a 1MB headroom reserve
+		// instead of 1536MB, which inflates `usableMb` by ~1.5GB and lets a model
+		// that must be refused report `fits`. Require the whole value to be decimal.
+		const parsed = /^\+?\d+$/.test(raw) ? Number(raw) : Number.NaN;
+		if (Number.isSafeInteger(parsed) && parsed >= 0) return parsed;
 	}
 	return DEFAULT_RAM_HEADROOM_RESERVE_MB;
 }

--- a/plugins/plugin-local-inference/src/services/ram-budget.ts
+++ b/plugins/plugin-local-inference/src/services/ram-budget.ts
@@ -28,6 +28,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { ElizaError } from "@elizaos/core";
 import { ELIZA_1_TIER_IDS, type Eliza1TierId, MODEL_CATALOG } from "./catalog";
 import { estimateQuantizedKvBytesPerToken } from "./kv-spill";
 import { type Eliza1Manifest, validateManifest } from "./manifest";
@@ -43,6 +44,7 @@ const BYTES_PER_MB = 1024 * 1024;
  * Override via `ELIZA_LOCAL_RAM_HEADROOM_MB`.
  */
 const DEFAULT_RAM_HEADROOM_RESERVE_MB = 1536;
+const RAM_HEADROOM_ENV_KEY = "ELIZA_LOCAL_RAM_HEADROOM_MB";
 
 /**
  * Default context window assumed for a catalog entry that doesn't declare
@@ -52,16 +54,22 @@ const DEFAULT_RAM_HEADROOM_RESERVE_MB = 1536;
 const FALLBACK_DEFAULT_CONTEXT_TOKENS = 32768;
 
 export function ramHeadroomReserveMb(): number {
-	const raw = process.env.ELIZA_LOCAL_RAM_HEADROOM_MB?.trim();
-	if (raw) {
-		// `Number.parseInt` stops at the first non-digit, so "1junk" parsed to a
-		// finite, non-negative 1 and passed the guard — a 1MB headroom reserve
-		// instead of 1536MB, which inflates `usableMb` by ~1.5GB and lets a model
-		// that must be refused report `fits`. Require the whole value to be decimal.
-		const parsed = /^\+?\d+$/.test(raw) ? Number(raw) : Number.NaN;
-		if (Number.isSafeInteger(parsed) && parsed >= 0) return parsed;
+	const configured = process.env[RAM_HEADROOM_ENV_KEY];
+	if (configured === undefined) {
+		return DEFAULT_RAM_HEADROOM_RESERVE_MB;
 	}
-	return DEFAULT_RAM_HEADROOM_RESERVE_MB;
+	const raw = configured.trim();
+	const parsed = /^\+?\d+$/.test(raw) ? Number(raw) : Number.NaN;
+	if (Number.isSafeInteger(parsed) && parsed >= 0) return parsed;
+
+	throw new ElizaError(
+		`${RAM_HEADROOM_ENV_KEY} must be a complete non-negative decimal integer in MB`,
+		{
+			code: "INVALID_LOCAL_RAM_HEADROOM",
+			context: { envKey: RAM_HEADROOM_ENV_KEY, configured },
+			severity: "fatal",
+		},
+	);
 }
 
 export type { RamBudget } from "./types.js";


### PR DESCRIPTION
# Relates to

No separate issue; this repairs the existing `ELIZA_LOCAL_RAM_HEADROOM_MB` safety boundary.

# What changed

`Number.parseInt` previously accepted malformed prefixes such as `1junk` as 1 MB, removing almost the entire RAM safety reserve. The contributor change added whole-value parsing and safe-integer validation.

The exact-head follow-up makes explicit configuration fail visibly instead of silently substituting a different reserve:

- an absent variable retains the 1536 MB default;
- complete non-negative decimal integers remain accepted, including `0` and `+2048` for compatibility;
- empty, whitespace, suffix, decimal, separator, negative, and unsafe-integer values throw fatal `ElizaError` with code `INVALID_LOCAL_RAM_HEADROOM` and structured configuration context;
- plugin initialization validates the setting before advertising readiness, so malformed explicit configuration rejects startup.

# Exact-head verification

Evidence head: `a3e1bfc3240e61e531d8db3f06e07a61cae4a401`
Restack base: `0a3349d4f4818e11da77ee610465c8163dcdd894`

- Pinned Bun 1.3.14 `bun install --frozen-lockfile`: passed.
- Focused `ram-budget.test.ts`: 13/13 passed after final rebase.
- Package `lint:check`: 510 files clean.
- Package `typecheck`: passed after building the required core/shared declarations.
- Full package Vitest lane: 2,900 passed, 2 skipped, with four unrelated current-tree failures in transcript disclosure and bionic stop-sequence expectations; none touches this three-file delta.
- `git diff --check`: passed.

The focused suite proves absence/default, valid clean and signed values, all malformed explicit classes, structured fatal error fields, and rejection through the real plugin initializer.

# Risk and evidence

Backend-only configuration validation; no UI, prompt/model content, transport, persistence, or generated artifact changes. Screenshots, video, frontend logs, LLM trajectories, OCR, and audio evidence are N/A. The observable artifact is the typed startup rejection asserted at the plugin boundary.

Original contributor attribution is preserved in the first commit: @Svector-anu, Claude Code / claude-opus-5. Maintainer repair used OpenAI Codex.