### PR TITLE
test(cloud): attest deployed staging renderer

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -67,6 +67,11 @@ on:
         required: false
         default: ""
         type: string
+      run_deployed_renderer_staging:
+        description: Run the credentialed deployed-Pages renderer proof once after a staging release (uses real staging model credits)
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   # #18092: non-PR admission is unique per run so two dispatches/reruns of
@@ -149,6 +154,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           TARGET_ENVIRONMENT: ${{ inputs.environment }}
           FORCE: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
+          RUN_DEPLOYED_RENDERER_STAGING: ${{ github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true }}
         run: |
           set -euo pipefail
 
@@ -156,7 +162,8 @@ jobs:
           if [ "$EVENT_NAME" = "push" ] \
             && [ "$TARGET_ENVIRONMENT" != "production" ] \
             && [ "$GITHUB_REF" != "refs/heads/main" ] \
-            && [ "$FORCE" != "true" ]; then
+            && [ "$FORCE" != "true" ] \
+            && [ "$RUN_DEPLOYED_RENDERER_STAGING" != "true" ]; then
             latest_eligible_run_id="$(
               gh api \
                 "repos/${GITHUB_REPOSITORY}/actions/workflows/cloud-cf-deploy.yml/runs?branch=develop&event=push&per_page=1" \
@@ -169,6 +176,7 @@ jobs:
             "--environment=$TARGET_ENVIRONMENT" \
             "--ref=$GITHUB_REF" \
             "--force=$FORCE" \
+            "--run-deployed-renderer-staging=$RUN_DEPLOYED_RENDERER_STAGING" \
             "--run-id=$GITHUB_RUN_ID" \
             "--latest-eligible-run-id=$latest_eligible_run_id"
 
@@ -361,6 +369,7 @@ jobs:
     with:
       target_environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
       force: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
+      run_deployed_renderer_staging: ${{ github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true }}
 
   certify-staging-release:
     name: Certify successful staging Cloud tree

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -103,9 +103,24 @@ jobs:
           SOURCE_SHA: ${{ inputs.source_sha }}
           TARGET_ENVIRONMENT: ${{ inputs.environment }}
           SOURCE_REF: ${{ github.ref }}
+          FORCE: ${{ inputs.force == true }}
+          RUN_DEPLOYED_RENDERER_STAGING: ${{ inputs.run_deployed_renderer_staging == true }}
         run: |
+          set -euo pipefail
+
           if [ "$EVENT_NAME" != "workflow_dispatch" ]; then
             exit 0
+          fi
+
+          if [ "$RUN_DEPLOYED_RENDERER_STAGING" = "true" ]; then
+            if [ "$TARGET_ENVIRONMENT" != "staging" ]; then
+              echo "::error::The deployed-renderer proof may target only staging."
+              exit 1
+            fi
+            if [ "$FORCE" = "true" ]; then
+              echo "::error::The deployed-renderer proof must keep the canonical freshness guards enabled."
+              exit 1
+            fi
           fi
 
           if [ "$TARGET_ENVIRONMENT" = "production" ]; then

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_deployed_renderer_staging:
+        description: Run the credentialed deployed-Pages renderer proof for this staging release
+        required: false
+        type: boolean
+        default: false
     outputs:
       superseded:
         description: >-
@@ -2527,7 +2532,7 @@ jobs:
   deployed-renderer-staging:
     name: Verify deployed staging renderer (Pages alias)
     needs: [deploy-app, verify-routing]
-    if: ${{ !cancelled() && inputs.target_environment == 'staging' && vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1' && needs.deploy-app.result == 'success' && needs.deploy-app.outputs.pages_deployed == 'true' && needs.verify-routing.result == 'success' }}
+    if: ${{ !cancelled() && inputs.target_environment == 'staging' && (vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1' || (github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true)) && needs.deploy-app.result == 'success' && needs.deploy-app.outputs.pages_deployed == 'true' && needs.verify-routing.result == 'success' }}
     runs-on: ubuntu-latest
     environment: staging
     timeout-minutes: 45

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -1914,6 +1914,8 @@ jobs:
     env:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-app
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}
+    outputs:
+      pages_deployed: ${{ steps.pages-deploy.outputs.deployed }}
     steps:
       - name: Reclaim disk from leaked checkouts of prior runs
         continue-on-error: true
@@ -2264,13 +2266,17 @@ jobs:
           node packages/cloud/scripts/deploy-freshness-guard-cli.mjs "${args[@]}"
 
       - name: Deploy to Cloudflare Pages
+        id: pages-deploy
         if: steps.cf.outputs.configured == 'true' && (github.event_name == 'pull_request' || steps.freshness.outputs.should_deploy == 'true')
         working-directory: ${{ env.CHECKOUT_DIR }}/packages/app
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PAGES_AUTHORITY_FILE: ${{ runner.temp }}/pages-deployment-authority/pages-deployment-authority.json
           PAGES_BRANCH: ${{ steps.pages.outputs.branch }}
           PAGES_PROJECT: eliza-app
+          PAGES_ALIAS: https://develop.eliza-app.pages.dev
+          TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
           EVENT_NAME: ${{ github.event_name }}
           CANONICAL_REF: ${{ inputs.target_environment == 'production' && 'refs/heads/main' || 'refs/heads/develop' }}
           FORCE: ${{ inputs.force }}
@@ -2279,6 +2285,18 @@ jobs:
         # ignore wrangler.toml — which silently drops the `functions/` upload.
         run: |
           set -euo pipefail
+          umask 077
+          wrangler_output="$RUNNER_TEMP/pages-deploy-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.ndjson"
+          mkdir -p "$(dirname "$PAGES_AUTHORITY_FILE")"
+          chmod 700 "$(dirname "$PAGES_AUTHORITY_FILE")"
+          : > "$wrangler_output"
+          chmod 600 "$wrangler_output"
+          cleanup_wrangler_output() {
+            : > "$wrangler_output" 2>/dev/null || true
+            rm -f -- "$wrangler_output"
+          }
+          trap cleanup_wrangler_output EXIT
+          trap 'exit 1' HUP INT TERM
           source_args=(--run-sha "$GITHUB_SHA" --canonical-ref "$CANONICAL_REF")
           if [ "$FORCE" = "true" ]; then
             source_args+=(--force)
@@ -2292,7 +2310,47 @@ jobs:
           fi
           for attempt in 1 2 3; do
             recheck_canonical_source
-            if bunx wrangler@4.100.0 pages deploy --project-name="$PAGES_PROJECT" --branch="$PAGES_BRANCH"; then
+            : > "$wrangler_output"
+            chmod 600 "$wrangler_output"
+            deploy_succeeded=false
+            if [ "$TARGET_ENVIRONMENT" = "staging" ]; then
+              if WRANGLER_OUTPUT_FILE_PATH="$wrangler_output" \
+                bunx wrangler@4.100.0 pages deploy \
+                  --project-name="$PAGES_PROJECT" \
+                  --branch="$PAGES_BRANCH" \
+                  --commit-hash="$GITHUB_SHA" \
+                  --commit-dirty=false; then
+                deploy_succeeded=true
+              fi
+            else
+              if bunx wrangler@4.100.0 pages deploy \
+                --project-name="$PAGES_PROJECT" \
+                --branch="$PAGES_BRANCH" \
+                --commit-hash="$GITHUB_SHA" \
+                --commit-dirty=false; then
+                deploy_succeeded=true
+              fi
+            fi
+            if [ "$deploy_succeeded" = "true" ]; then
+              if [ "$TARGET_ENVIRONMENT" = "staging" ]; then
+                pages_alias="$(node "$CHECKOUT_DIR/packages/cloud/scripts/pages-deployment-authority.mjs" parse \
+                  --input "$wrangler_output" \
+                  --output "$PAGES_AUTHORITY_FILE" \
+                  --expected-project "$PAGES_PROJECT" \
+                  --expected-commit "$GITHUB_SHA" \
+                  --expected-branch "$PAGES_BRANCH" \
+                  --expected-alias "$PAGES_ALIAS" \
+                  --expected-environment preview \
+                  --expected-production-branch main \
+                  --run-id "$GITHUB_RUN_ID" \
+                  --run-attempt "$GITHUB_RUN_ATTEMPT")"
+                [ "$pages_alias" = "$PAGES_ALIAS" ] || {
+                  echo "::error::Closed Pages authority returned an unexpected alias"
+                  exit 1
+                }
+                echo "alias=$pages_alias" >> "$GITHUB_OUTPUT"
+              fi
+              echo "deployed=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             if [ "$attempt" = "3" ]; then
@@ -2311,10 +2369,19 @@ jobs:
           MARKETING_URL: ${{ (inputs.target_environment == 'production') && 'https://eliza.app' || 'https://staging.eliza.app' }}
           CLOUD_APP_URL: ${{ (inputs.target_environment == 'production') && 'https://cloud.eliza.app' || 'https://cloud-staging.eliza.app' }}
           API_URL: ${{ (inputs.target_environment == 'production') && 'https://api.eliza.app' || 'https://api-staging.eliza.app' }}
+          PAGES_ALIAS: ${{ steps.pages-deploy.outputs.alias }}
         run: |
           set -euo pipefail
 
-          for served_url in "$MARKETING_URL" "$CLOUD_APP_URL"; do
+          served_frontends=("$MARKETING_URL" "$CLOUD_APP_URL")
+          if [ "$DEPLOY_ENVIRONMENT" = "staging" ]; then
+            if [ "$PAGES_ALIAS" != "https://develop.eliza-app.pages.dev" ]; then
+              echo "::error::Staging byte verification requires the canonical Pages alias"
+              exit 1
+            fi
+            served_frontends+=("$PAGES_ALIAS")
+          fi
+          for served_url in "${served_frontends[@]}"; do
             node packages/cloud/scripts/verify-pages-frontend-cli.mjs \
               --served-url "$served_url" \
               --dist packages/app/dist \
@@ -2380,6 +2447,15 @@ jobs:
               --callback-url "$served_url/login" \
               --tenant-id "$tenant_id"
           done
+
+      - name: Publish closed Pages deployment authority
+        if: steps.cf.outputs.configured == 'true' && inputs.target_environment == 'staging' && steps.freshness.outputs.should_deploy == 'true' && steps.pages-deploy.outputs.deployed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: pages-deployment-authority-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/pages-deployment-authority/pages-deployment-authority.json
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Clean temp checkout
         if: always()
@@ -2447,3 +2523,162 @@ jobs:
           node packages/cloud/scripts/verify-environment-routing-cli.mjs \
             --environment "${{ steps.env.outputs.environment }}" \
             --require-beacon
+
+  deployed-renderer-staging:
+    name: Verify deployed staging renderer (Pages alias)
+    needs: [deploy-app, verify-routing]
+    if: ${{ !cancelled() && inputs.target_environment == 'staging' && vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1' && needs.deploy-app.result == 'success' && needs.deploy-app.outputs.pages_deployed == 'true' && needs.verify-routing.result == 'success' }}
+    runs-on: ubuntu-latest
+    environment: staging
+    timeout-minutes: 45
+    steps:
+      - name: Checkout exact released source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: "24.15.0"
+
+      - name: Initialize private proof paths
+        run: |
+          set -euo pipefail
+          umask 077
+          proof_dir="$RUNNER_TEMP/deployed-renderer-proof-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          mkdir -p "$proof_dir"
+          chmod 700 "$proof_dir"
+          {
+            printf 'PROOF_DIR=%s\n' "$proof_dir"
+            printf 'AUTHORITY_PATH=%s/authority/pages-deployment-authority.json\n' "$proof_dir"
+            printf 'PREFLIGHT_PATH=%s/preflight.json\n' "$proof_dir"
+            printf 'REMOTE_SMOKE_PATH=%s/remote-smoke.json\n' "$proof_dir"
+            printf 'LATENCY_PATH=%s/latency.json\n' "$proof_dir"
+            printf 'CONTINUITY_PATH=%s/continuity.json\n' "$proof_dir"
+            printf 'POSTFLIGHT_PATH=%s/postflight.json\n' "$proof_dir"
+            printf 'DEPLOYED_PROOF_PATH=%s/deployed-proof.json\n' "$proof_dir"
+            printf 'RECEIPT_PATH=%s/cloud-staging-deployed-receipt.json\n' "$proof_dir"
+          } >> "$GITHUB_ENV"
+
+      - name: Download exact Pages deployment authority
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: pages-deployment-authority-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/deployed-renderer-proof-${{ github.run_id }}-${{ github.run_attempt }}/authority
+
+      - name: Verify public deployment before browser auth
+        run: |
+          set -euo pipefail
+          node packages/cloud/scripts/pages-deployment-authority.mjs verify \
+            --authority "$AUTHORITY_PATH" \
+            --api-base https://api-staging.eliza.app \
+            --phase preflight \
+            --output "$PREFLIGHT_PATH"
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14"
+          install-command: bun install --frozen-lockfile
+          install-native-deps: "false"
+          install-protoc: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Install Playwright Chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
+
+      - name: Run deployed Personal identity, chat, and continuity trajectory
+        id: deployed-browser
+        working-directory: packages/app
+        env:
+          ELIZA_UI_SMOKE_CLOUD_LIVE: "1"
+          ELIZA_UI_SMOKE_LIVE_STACK: "1"
+          ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV: staging
+          ELIZAOS_CLOUD_BASE_URL: https://api-staging.eliza.app
+          ELIZA_UI_SMOKE_DEPLOYED_RENDERER: "1"
+          ELIZA_UI_SMOKE_DEPLOYED_SOURCE_SHA: ${{ github.sha }}
+          ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY }}
+          PLAYWRIGHT_NO_COPY_PROMPT: "1"
+        run: |
+          set -euo pipefail
+          key_without_whitespace="${ELIZAOS_CLOUD_API_KEY:-}"
+          key_without_whitespace="${key_without_whitespace//[[:space:]]/}"
+          if [ -z "$key_without_whitespace" ]; then
+            echo "::error::The deployed staging browser lane requires the staging Environment's ELIZAOS_CLOUD_API_KEY; refusing a green-by-skip run."
+            exit 1
+          fi
+          unset key_without_whitespace
+          mkdir -p "$PROOF_DIR"
+          chmod 700 "$PROOF_DIR"
+          rm -f -- "$REMOTE_SMOKE_PATH" "$LATENCY_PATH" "$CONTINUITY_PATH"
+          export ELIZA_UI_SMOKE_DEPLOYED_BROWSER_EVIDENCE_PATH="$REMOTE_SMOKE_PATH"
+          export ELIZA_UI_SMOKE_STAGING_CHAT_LATENCY_EVIDENCE_PATH="$LATENCY_PATH"
+          export ELIZA_UI_SMOKE_STAGING_CONTINUITY_EVIDENCE_PATH="$CONTINUITY_PATH"
+          started_ms="$(node -e 'process.stdout.write(String(Date.now()))')"
+          echo "started_ms=$started_ms" >> "$GITHUB_OUTPUT"
+          set +e
+          bunx playwright test \
+            --config playwright.cloud-deployed.config.ts \
+            --project chromium \
+            test/ui-smoke/cloud-live.spec.ts
+          smoke_status=$?
+          set -e
+          completed_ms="$(node -e 'process.stdout.write(String(Date.now()))')"
+          echo "completed_ms=$completed_ms" >> "$GITHUB_OUTPUT"
+          exit "$smoke_status"
+
+      - name: Verify public deployment after browser auth
+        if: ${{ always() && steps.deployed-browser.outcome != 'skipped' }}
+        run: |
+          set -euo pipefail
+          node packages/cloud/scripts/pages-deployment-authority.mjs verify \
+            --authority "$AUTHORITY_PATH" \
+            --api-base https://api-staging.eliza.app \
+            --phase postflight \
+            --output "$POSTFLIGHT_PATH"
+
+      - name: Close deployed renderer proof
+        run: |
+          set -euo pipefail
+          node packages/cloud/scripts/pages-deployment-authority.mjs combine \
+            --authority "$AUTHORITY_PATH" \
+            --preflight "$PREFLIGHT_PATH" \
+            --remote-smoke "$REMOTE_SMOKE_PATH" \
+            --latency "$LATENCY_PATH" \
+            --continuity "$CONTINUITY_PATH" \
+            --postflight "$POSTFLIGHT_PATH" \
+            --output "$DEPLOYED_PROOF_PATH"
+
+      - name: Write deployed staging receipt
+        run: |
+          set -euo pipefail
+          latency_ms="$(bun packages/app/test/staging-cloud-chat-latency-evidence.ts "$LATENCY_PATH")"
+          continuity="$(bun packages/app/test/cloud-live-continuity-contract.ts "$CONTINUITY_PATH")"
+          [ "$continuity" = "verified" ] || {
+            echo "::error::Continuity evidence did not close"
+            exit 1
+          }
+          node packages/scripts/write-staging-cloud-receipt.mjs \
+            --output "$RECEIPT_PATH" \
+            --source-sha "$GITHUB_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --outcome success \
+            --started-ms "${{ steps.deployed-browser.outputs.started_ms }}" \
+            --completed-ms "${{ steps.deployed-browser.outputs.completed_ms }}" \
+            --first-turn-latency-ms "$latency_ms" \
+            --continuity-evidence verified \
+            --deployed-proof-file "$DEPLOYED_PROOF_PATH"
+
+      - name: Upload closed deployed staging receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: app-live-e2e-cloud-staging-deployed-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/deployed-renderer-proof-${{ github.run_id }}-${{ github.run_attempt }}/cloud-staging-deployed-receipt.json
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -2532,11 +2532,26 @@ jobs:
   deployed-renderer-staging:
     name: Verify deployed staging renderer (Pages alias)
     needs: [deploy-app, verify-routing]
-    if: ${{ !cancelled() && inputs.target_environment == 'staging' && (vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1' || (github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true)) && needs.deploy-app.result == 'success' && needs.deploy-app.outputs.pages_deployed == 'true' && needs.verify-routing.result == 'success' }}
+    if: ${{ !cancelled() && inputs.target_environment == 'staging' && ((vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1' && needs.deploy-app.result == 'success' && needs.deploy-app.outputs.pages_deployed == 'true' && needs.verify-routing.result == 'success') || (github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true)) }}
     runs-on: ubuntu-latest
     environment: staging
     timeout-minutes: 45
     steps:
+      - name: Require one-shot staging release prerequisites
+        if: ${{ inputs.run_deployed_renderer_staging == true }}
+        env:
+          DEPLOY_APP_RESULT: ${{ needs.deploy-app.result }}
+          PAGES_DEPLOYED: ${{ needs.deploy-app.outputs.pages_deployed }}
+          VERIFY_ROUTING_RESULT: ${{ needs.verify-routing.result }}
+        run: |
+          set -euo pipefail
+          if [ "$DEPLOY_APP_RESULT" != "success" ] \
+            || [ "$PAGES_DEPLOYED" != "true" ] \
+            || [ "$VERIFY_ROUTING_RESULT" != "success" ]; then
+            echo "::error::One-shot deployed-renderer proof requires a successful fresh Pages deployment and routing verification. deploy-app=$DEPLOY_APP_RESULT pages-deployed=$PAGES_DEPLOYED verify-routing=$VERIFY_ROUTING_RESULT"
+            exit 1
+          fi
+
       - name: Checkout exact released source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:

--- a/packages/app/playwright.cloud-deployed.config.ts
+++ b/packages/app/playwright.cloud-deployed.config.ts
@@ -1,0 +1,41 @@
+/**
+ * Runs the credentialed Cloud trajectory against the canonical staging Pages
+ * branch alias. This configuration starts no local server and retains no browser
+ * recording, screenshot, trace, or report artifact.
+ */
+import { defineConfig, devices } from "@playwright/test";
+
+const DEPLOYED_RENDERER_ALIAS = "https://develop.eliza-app.pages.dev";
+
+export default defineConfig({
+  testDir: "./test/ui-smoke",
+  testMatch: "cloud-live.spec.ts",
+  fullyParallel: false,
+  forbidOnly: true,
+  workers: 1,
+  retries: 0,
+  reporter: [["line"]],
+  preserveOutput: "never",
+  timeout: 900_000,
+  expect: { timeout: 30_000 },
+  use: {
+    baseURL: DEPLOYED_RENDERER_ALIAS,
+    serviceWorkers: "block",
+    trace: "off",
+    screenshot: "off",
+    video: "off",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        baseURL: DEPLOYED_RENDERER_ALIAS,
+        serviceWorkers: "block",
+        trace: "off",
+        screenshot: "off",
+        video: "off",
+      },
+    },
+  ],
+});

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -6,6 +6,8 @@
  */
 
 import { randomBytes } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 import { resolveDirectCloudAuthApiBase } from "@elizaos/ui/api/direct-cloud-endpoints";
 import { isPersonalSharedElizaId } from "@elizaos/ui/utils/cloud-agent-base";
 import {
@@ -15,7 +17,10 @@ import {
   type Page,
   test,
 } from "@playwright/test";
-import { seedCloudLiveBrowserAuth } from "../cloud-live-browser-auth";
+import {
+  resolveCloudLiveBrowserAuthSeed,
+  seedCloudLiveBrowserAuth,
+} from "../cloud-live-browser-auth";
 import {
   type CloudLiveBindingReuse,
   type CloudLiveContinuityEvidenceInput,
@@ -40,6 +45,11 @@ const CLOUD_LIVE_ENABLED =
   process.env.ELIZA_UI_SMOKE_CLOUD_LIVE === "1" &&
   process.env.ELIZA_UI_SMOKE_LIVE_STACK === "1";
 const HAS_CLOUD_KEY = Boolean(process.env.ELIZAOS_CLOUD_API_KEY?.trim());
+const DEPLOYED_RENDERER_ENABLED =
+  process.env.ELIZA_UI_SMOKE_DEPLOYED_RENDERER === "1";
+const DEPLOYED_RENDERER_ALIAS = "https://develop.eliza-app.pages.dev";
+const DEPLOYED_RENDERER_MANIFEST_SCHEMA = "elizaos.renderer.build/v1";
+const DEPLOYED_BROWSER_SMOKE_SCHEMA = "elizaos.cloud.deployed-browser-smoke/v1";
 
 const PERSONAL_IDENTITY_ATTEMPT_TIMEOUT_MS = 180_000;
 const PERSONAL_IDENTITY_ATTEMPTS = 2;
@@ -97,18 +107,24 @@ async function chooseCloudRuntime(page: Page): Promise<void> {
 }
 
 async function seedProtectedCloudBlankStart(page: Page): Promise<void> {
-  expect(
-    await seedCloudLiveBrowserAuth({
-      async addInitScript(script, seed) {
-        await page.addInitScript(script, seed);
-      },
-    }),
-    "Cloud-live mode must hand its validated workflow bearer to the browser",
-  ).toBe(true);
+  // A local renderer is already controlled by the checked-out process, so its
+  // established init-script handoff remains safe. A deployed renderer must be
+  // reached and origin-verified before the bearer is ever handed to the page.
+  if (!DEPLOYED_RENDERER_ENABLED) {
+    expect(
+      await seedCloudLiveBrowserAuth({
+        async addInitScript(script, seed) {
+          await page.addInitScript(script, seed);
+        },
+      }),
+      "Cloud-live mode must hand its validated workflow bearer to the browser",
+    ).toBe(true);
+  }
   await page.addInitScript(() => {
     // Do not use the general smoke seed: its local active-server fixture would
-    // invalidate a fresh-context continuity claim. These explicit empty values
-    // plus the protected bearer above are the only values the test seeds.
+    // invalidate a fresh-context continuity claim. These non-secret empty values
+    // are safe before navigation; deployed mode seeds the bearer only after the
+    // exact top-level Pages origin and renderer identity are verified.
     if (localStorage.getItem("eliza:first-run-complete") === null) {
       localStorage.setItem("eliza:first-run-complete", "");
     }
@@ -116,6 +132,217 @@ async function seedProtectedCloudBlankStart(page: Page): Promise<void> {
       localStorage.setItem("elizaos:active-server", "");
     }
   });
+}
+
+async function seedVerifiedDeployedCloudBrowserAuth(page: Page): Promise<void> {
+  const seed = resolveCloudLiveBrowserAuthSeed(process.env);
+  expect(
+    seed,
+    "deployed Cloud-live mode requires a validated workflow bearer",
+  ).not.toBeNull();
+  if (!seed) throw new Error("missing deployed Cloud-live browser auth seed");
+
+  expect(
+    new URL(page.url()).origin,
+    "the bearer must never be handed to a document outside the Pages alias",
+  ).toBe(DEPLOYED_RENDERER_ALIAS);
+  await page.evaluate(
+    ({ expectedOrigin, storageKey, token }) => {
+      if (window.top !== window || window.location.origin !== expectedOrigin) {
+        throw new Error(
+          "refusing to seed deployed Cloud auth outside the verified top-level origin",
+        );
+      }
+      localStorage.setItem(storageKey, token);
+    },
+    { expectedOrigin: DEPLOYED_RENDERER_ALIAS, ...seed },
+  );
+}
+
+interface DeployedRendererIdentity {
+  buildId: string;
+  commit: string;
+  origin: string;
+}
+
+interface ProtectedCloudBlankStart {
+  deployedRenderer: DeployedRendererIdentity | null;
+  rendererApiOrigin: string;
+}
+
+async function requireDeployedRendererIdentity(
+  page: Page,
+  baseURL: string | undefined,
+): Promise<DeployedRendererIdentity | null> {
+  if (!DEPLOYED_RENDERER_ENABLED) return null;
+  const sourceSha =
+    process.env.ELIZA_UI_SMOKE_DEPLOYED_SOURCE_SHA?.trim() ?? "";
+  expect(
+    sourceSha,
+    "deployed renderer mode requires an exact source SHA",
+  ).toMatch(/^[0-9a-f]{40}$/);
+  expect(
+    new URL(baseURL ?? "https://missing.invalid").origin,
+    "deployed Playwright must be hard-pinned to the canonical develop Pages alias",
+  ).toBe(DEPLOYED_RENDERER_ALIAS);
+  expect(
+    new URL(page.url()).origin,
+    "the browser document must not redirect away from the deployment alias",
+  ).toBe(DEPLOYED_RENDERER_ALIAS);
+
+  const observed = await page.evaluate(async (expectedOrigin) => {
+    const response = await fetch(
+      `/eliza-renderer-build.json?deployed-browser-proof=${Date.now()}`,
+      { cache: "no-store", headers: { "cache-control": "no-cache" } },
+    );
+    const responseUrl = new URL(response.url);
+    if (
+      !response.ok ||
+      responseUrl.origin !== expectedOrigin ||
+      responseUrl.pathname !== "/eliza-renderer-build.json"
+    ) {
+      throw new Error(
+        "renderer manifest did not come from the deployment alias",
+      );
+    }
+    return (await response.json()) as Record<string, unknown>;
+  }, DEPLOYED_RENDERER_ALIAS);
+  expect(Object.keys(observed).sort()).toEqual(
+    [
+      "assetCount",
+      "buildId",
+      "builtAt",
+      "capacitorTarget",
+      "commit",
+      "indexHtmlSha256",
+      "iosApnsEnabled",
+      "playwrightTestAuth",
+      "runtimeMode",
+      "schema",
+      "variant",
+    ].sort(),
+  );
+  expect(observed.schema).toBe(DEPLOYED_RENDERER_MANIFEST_SCHEMA);
+  expect(observed.commit).toBe(sourceSha);
+  expect(observed.buildId).toMatch(/^[0-9a-f]{64}$/);
+  expect(observed.indexHtmlSha256).toMatch(/^[0-9a-f]{64}$/);
+  expect(observed.assetCount).toEqual(expect.any(Number));
+  expect(observed.assetCount).toBeGreaterThan(0);
+  expect(observed.playwrightTestAuth).toBe(false);
+  return {
+    buildId: observed.buildId as string,
+    commit: sourceSha,
+    origin: DEPLOYED_RENDERER_ALIAS,
+  };
+}
+
+async function requireRendererCloudApiOrigin(
+  page: Page,
+  expectedApiOrigin: string,
+): Promise<string> {
+  // The renderer carries its own Cloud base, resolved at BUILD time from
+  // VITE_ELIZA_CLOUD_BASE and otherwise defaulted. In deployed mode this check
+  // runs on the first public load, before the staging bearer reaches the page.
+  const readRendererCloudBase = () =>
+    page.evaluate(() => {
+      const config = (
+        window as unknown as {
+          __ELIZAOS_APP_BOOT_CONFIG__?: { cloudApiBase?: string };
+        }
+      ).__ELIZAOS_APP_BOOT_CONFIG__;
+      return config?.cloudApiBase?.trim() ?? "";
+    });
+  await expect
+    .poll(readRendererCloudBase, {
+      message: "renderer boot config must expose its Cloud base",
+      timeout: 30_000,
+    })
+    .not.toBe("");
+  const rendererCloudBase = await readRendererCloudBase();
+  const rendererApiOrigin = (() => {
+    if (!rendererCloudBase) return "";
+    try {
+      return new URL(resolveDirectCloudAuthApiBase(rendererCloudBase)).origin;
+    } catch {
+      // error-policy:J3 a malformed boot value is reported as an explicit
+      // mismatch carrying the offending string, never as a raw TypeError.
+      return `<unparseable: ${rendererCloudBase}>`;
+    }
+  })();
+  expect(
+    rendererApiOrigin,
+    `renderer bundle resolves ${rendererCloudBase || "<unset>"} -> ${rendererApiOrigin || "<empty>"}; the lane pinned ${expectedApiOrigin}`,
+  ).toBe(expectedApiOrigin);
+  return rendererApiOrigin;
+}
+
+async function openProtectedCloudBlankStart(
+  page: Page,
+  baseURL: string | undefined,
+  expectedApiOrigin: string,
+): Promise<ProtectedCloudBlankStart> {
+  await seedProtectedCloudBlankStart(page);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  const publicIdentity = await requireDeployedRendererIdentity(page, baseURL);
+  const publicApiOrigin = await requireRendererCloudApiOrigin(
+    page,
+    expectedApiOrigin,
+  );
+  if (!DEPLOYED_RENDERER_ENABLED) {
+    return {
+      deployedRenderer: publicIdentity,
+      rendererApiOrigin: publicApiOrigin,
+    };
+  }
+
+  // The first load is deliberately public. Only after the document origin,
+  // exact renderer manifest, and build-time Cloud API origin close do we expose
+  // the bearer to that top-level origin, then reload so application boot
+  // observes the authenticated store.
+  expect(publicIdentity).not.toBeNull();
+  await seedVerifiedDeployedCloudBrowserAuth(page);
+  await page.reload({ waitUntil: "domcontentloaded" });
+  const authenticatedIdentity = await requireDeployedRendererIdentity(
+    page,
+    baseURL,
+  );
+  expect(authenticatedIdentity).toEqual(publicIdentity);
+  const authenticatedApiOrigin = await requireRendererCloudApiOrigin(
+    page,
+    expectedApiOrigin,
+  );
+  expect(authenticatedApiOrigin).toBe(publicApiOrigin);
+  return {
+    deployedRenderer: authenticatedIdentity,
+    rendererApiOrigin: authenticatedApiOrigin,
+  };
+}
+
+async function writeDeployedBrowserSmokeEvidence(
+  path: string,
+  renderer: DeployedRendererIdentity,
+  cloudApiOrigin: string,
+): Promise<void> {
+  const outputPath = resolve(path);
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(
+    outputPath,
+    `${JSON.stringify(
+      {
+        schema: DEPLOYED_BROWSER_SMOKE_SCHEMA,
+        sourceSha: renderer.commit,
+        rendererOrigin: renderer.origin,
+        rendererManifestCommit: renderer.commit,
+        rendererBuildId: renderer.buildId,
+        cloudApiOrigin,
+        cloudEnvironment: "staging",
+        outcome: "success",
+      },
+      null,
+      2,
+    )}\n`,
+    { encoding: "utf8", flag: "wx", mode: 0o600 },
+  );
 }
 
 async function readActiveBinding(
@@ -277,13 +504,18 @@ test.describe("real cloud login + personal identity + chat", () => {
       { type: "cloud-api-origin", description: originContract.origin },
       { type: "cloud-environment", description: originContract.environment },
       {
-        // This lane always drives the renderer bundle built from the checked-out
-        // revision through the live stack; it does NOT drive a deployed Pages
-        // artifact. Recorded so run artifacts state what was exercised.
         type: "renderer-source",
-        description: "locally built renderer bundle (not a deployed artifact)",
+        description: DEPLOYED_RENDERER_ENABLED
+          ? "Cloudflare Pages deployment alias"
+          : "locally built renderer bundle (not a deployed artifact)",
       },
     );
+    if (DEPLOYED_RENDERER_ENABLED) {
+      test.info().annotations.push({
+        type: "cloudflare-pages-alias",
+        description: DEPLOYED_RENDERER_ALIAS,
+      });
+    }
     expect(
       originContract.ok,
       originContract.reason ??
@@ -295,6 +527,8 @@ test.describe("real cloud login + personal identity + chat", () => {
       "";
     const stagingContinuityEvidencePath =
       process.env.ELIZA_UI_SMOKE_STAGING_CONTINUITY_EVIDENCE_PATH?.trim() ?? "";
+    const deployedBrowserEvidencePath =
+      process.env.ELIZA_UI_SMOKE_DEPLOYED_BROWSER_EVIDENCE_PATH?.trim() ?? "";
     if (originContract.environment === "staging") {
       expect(
         stagingLatencyEvidencePath,
@@ -304,59 +538,21 @@ test.describe("real cloud login + personal identity + chat", () => {
         stagingContinuityEvidencePath,
         "the staging lane must persist its privacy-safe continuity artifact",
       ).toBeTruthy();
+      if (DEPLOYED_RENDERER_ENABLED) {
+        expect(
+          deployedBrowserEvidencePath,
+          "deployed mode must persist its closed remote-browser proof",
+        ).toBeTruthy();
+      }
     }
 
     const primaryAudit = installNetworkAudit(context);
-    await seedProtectedCloudBlankStart(page);
-    await page.goto("/", { waitUntil: "domcontentloaded" });
-
-    // The process-level contract above only pins the spawned runtime's proxy.
-    // The renderer carries its own Cloud base, resolved at BUILD time from
-    // VITE_ELIZA_CLOUD_BASE and otherwise defaulted, and the shared-agent base
-    // for the chat leg is derived from it
-    // (client-cloud.ts buildCloudSharedAgentApiBase). A bundle built for the
-    // wrong deployment therefore talks to the wrong Cloud with this lane's
-    // bearer. Compare through resolveDirectCloudAuthApiBase because the boot
-    // value is a SITE base ("https://eliza.app") while the contract exposes an
-    // API origin ("https://api.eliza.app") -- equivalent, differently spelled.
-    const readRendererCloudBase = () =>
-      page.evaluate(() => {
-        const config = (
-          window as unknown as {
-            __ELIZAOS_APP_BOOT_CONFIG__?: { cloudApiBase?: string };
-          }
-        ).__ELIZAOS_APP_BOOT_CONFIG__;
-        return config?.cloudApiBase?.trim() ?? "";
-      });
-    // The public shell hands off to the full app asynchronously after the
-    // document event. Wait only for the non-secret boot mirror to exist; once
-    // present, the exact-origin assertion below still fails immediately on a
-    // production or malformed value.
-    await expect
-      .poll(readRendererCloudBase, {
-        message: "renderer boot config must expose its Cloud base",
-        timeout: 30_000,
-      })
-      .not.toBe("");
-    const rendererCloudBase = await readRendererCloudBase();
-    const rendererApiOrigin = (() => {
-      if (!rendererCloudBase) return "";
-      try {
-        return new URL(resolveDirectCloudAuthApiBase(rendererCloudBase)).origin;
-      } catch {
-        // error-policy:J3 a malformed boot value is reported as an explicit
-        // mismatch carrying the offending string, never as a raw TypeError.
-        return `<unparseable: ${rendererCloudBase}>`;
-      }
-    })();
+    const { deployedRenderer, rendererApiOrigin } =
+      await openProtectedCloudBlankStart(page, baseURL, originContract.origin);
     test.info().annotations.push({
       type: "renderer-cloud-origin",
       description: rendererApiOrigin,
     });
-    expect(
-      rendererApiOrigin,
-      `renderer bundle resolves ${rendererCloudBase || "<unset>"} -> ${rendererApiOrigin || "<empty>"}; the lane pinned ${originContract.origin}`,
-    ).toBe(originContract.origin);
 
     // The current Cloud join flow resolves the account-derived Personal Eliza
     // identity through the read-only Personal endpoint. It persists the
@@ -514,7 +710,8 @@ test.describe("real cloud login + personal identity + chat", () => {
     const freshResult = await (async () => {
       // Deliberately omit storageState. The new context gets no cookies or
       // origins from the first one, blocks the production service worker, and
-      // receives only the protected bearer + explicit blank boot values.
+      // receives only explicit blank boot values. Deployed mode hands it the
+      // protected bearer only after its public top-level origin is verified.
       const freshContext = await browser.newContext({
         baseURL,
         serviceWorkers: "block",
@@ -528,8 +725,15 @@ test.describe("real cloud login + personal identity + chat", () => {
 
         const freshPage = await freshContext.newPage();
         const freshAudit = installNetworkAudit(freshContext);
-        await seedProtectedCloudBlankStart(freshPage);
-        await freshPage.goto("/", { waitUntil: "domcontentloaded" });
+        const { deployedRenderer: freshDeployedRenderer } =
+          await openProtectedCloudBlankStart(
+            freshPage,
+            baseURL,
+            originContract.origin,
+          );
+        if (DEPLOYED_RENDERER_ENABLED) {
+          expect(freshDeployedRenderer).toEqual(deployedRenderer);
+        }
         const freshBinding = await resolvePersonalIdentity(freshPage);
         const freshHistoryBefore =
           freshAudit.snapshot().successfulHistoryGetCount;
@@ -609,6 +813,14 @@ test.describe("real cloud login + personal identity + chat", () => {
         stagingContinuityEvidencePath,
         continuityEvidenceInput,
       );
+      if (DEPLOYED_RENDERER_ENABLED) {
+        expect(deployedRenderer).not.toBeNull();
+        await writeDeployedBrowserSmokeEvidence(
+          deployedBrowserEvidencePath,
+          deployedRenderer as DeployedRendererIdentity,
+          originContract.origin,
+        );
+      }
     }
   });
 });

--- a/packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts
+++ b/packages/cloud/scripts/__tests__/pages-deployment-authority.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Exercises the closed Cloudflare Pages authority and deployed-browser proof
+ * contracts with deterministic provider records and public HTTP responses.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  createDeployedRendererProof,
+  DEPLOYED_BROWSER_SMOKE_SCHEMA,
+  PAGES_AUTHORITY_SCHEMA,
+  parseDeployedRendererProof,
+  parseWranglerPagesDeploymentOutput,
+  verifyPublicPagesDeployment,
+} from "../pages-deployment-authority.mjs";
+
+const sourceSha = "87da9c8ba169440f0fb21dc613f7bc425c8014b6";
+const deploymentId = "3d07ff31-d66e-4cf0-948c-3f44cd9ed23d";
+const deploymentUrl = "https://5f02a912.eliza-app.pages.dev";
+const aliasUrl = "https://develop.eliza-app.pages.dev";
+const apiOrigin = "https://api-staging.eliza.app";
+const buildId = "a".repeat(64);
+const indexHtmlSha256 = "b".repeat(64);
+
+function wranglerRecord(overrides: Record<string, unknown> = {}): string {
+  const summary = {
+    type: "pages-deploy",
+    version: 1,
+    pages_project: "eliza-app",
+    deployment_id: deploymentId,
+    url: deploymentUrl,
+    timestamp: "2026-08-21T20:00:00.000Z",
+  };
+  const detailed = {
+    type: "pages-deploy-detailed",
+    version: 1,
+    pages_project: "eliza-app",
+    deployment_id: deploymentId,
+    url: deploymentUrl,
+    alias: aliasUrl,
+    environment: "preview",
+    production_branch: "main",
+    deployment_trigger: { metadata: { commit_hash: sourceSha } },
+    timestamp: "2026-08-21T20:00:00.001Z",
+    ...overrides,
+  };
+  return `${JSON.stringify(summary)}\n${JSON.stringify(detailed)}\n`;
+}
+
+function authority() {
+  return parseWranglerPagesDeploymentOutput(wranglerRecord(), {
+    expectedProject: "eliza-app",
+    expectedCommit: sourceSha,
+    expectedBranch: "develop",
+    expectedAlias: aliasUrl,
+    expectedEnvironment: "preview",
+    expectedProductionBranch: "main",
+    runId: "32500000001",
+    runAttempt: "2",
+  });
+}
+
+function rendererManifest() {
+  return {
+    schema: "elizaos.renderer.build/v1",
+    buildId,
+    indexHtmlSha256,
+    assetCount: 42,
+    builtAt: "2026-08-21T19:59:00.000Z",
+    commit: sourceSha,
+    variant: null,
+    capacitorTarget: null,
+    runtimeMode: null,
+    playwrightTestAuth: false,
+    iosApnsEnabled: null,
+  };
+}
+
+function response(url: string, value: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    url,
+    text: async () => JSON.stringify(value),
+  };
+}
+
+async function publicCheck(phase: "preflight" | "postflight") {
+  const fetchImpl = (async (url: string) => {
+    const parsed = new URL(url);
+    if (parsed.origin === aliasUrl) {
+      return response(
+        `${aliasUrl}/eliza-renderer-build.json?source=${sourceSha}`,
+        rendererManifest(),
+      );
+    }
+    return response(`${apiOrigin}/api/health?source=${sourceSha}`, {
+      commit: sourceSha,
+      environment: "staging",
+      status: "ok",
+    });
+  }) as unknown as typeof fetch;
+  return verifyPublicPagesDeployment(authority(), {
+    apiBase: apiOrigin,
+    phase,
+    fetchImpl,
+  });
+}
+
+function remoteSmoke() {
+  return {
+    schema: DEPLOYED_BROWSER_SMOKE_SCHEMA,
+    sourceSha,
+    rendererOrigin: aliasUrl,
+    rendererManifestCommit: sourceSha,
+    rendererBuildId: buildId,
+    cloudApiOrigin: apiOrigin,
+    cloudEnvironment: "staging",
+    outcome: "success",
+  };
+}
+
+function latency() {
+  return {
+    schemaVersion: 1,
+    lane: "app-live-e2e-cloud-staging",
+    metric: "first-turn-latency",
+    definition:
+      "composer-send-click-to-settled-valid-assistant-turn: starts immediately before the UI send click; ends after the same fresh non-empty assistant row settles and passes the liveness contract; not first-token latency",
+    firstTurnLatencyMs: 12_345,
+  };
+}
+
+function continuity() {
+  return {
+    schemaVersion: 1,
+    lane: "app-live-e2e-cloud-staging",
+    challengeTurnCount: 1,
+    noAdditionalChatSendAfterChallenge: true,
+    personalIdentityEndpointPassed: true,
+    reloadHistoryPassed: true,
+    freshContextHistoryPassed: true,
+    personalIdentityReused: true,
+    runtimeBindingReused: true,
+    apiBaseReused: true,
+    forbiddenAgentMutationCount: 0,
+    cleanupDisposition: "no-test-owned-agent",
+    conversationHistoryDisposition: "preserved",
+  };
+}
+
+describe("Pages deployment authority", () => {
+  test("closes exactly the two Wrangler v1 records and hashes the UUID", () => {
+    const parsed = authority();
+    expect(parsed).toEqual({
+      schema: PAGES_AUTHORITY_SCHEMA,
+      sourceSha,
+      workflow: { runId: 32500000001, runAttempt: 2 },
+      project: "eliza-app",
+      branch: "develop",
+      pagesEnvironment: "preview",
+      productionBranch: "main",
+      deploymentUrl,
+      aliasUrl,
+      deploymentIdSha256:
+        "eb251bd0455144d0f3c6642e81b5ad148ffbc82522239e94028b9154159222fc",
+    });
+    expect(JSON.stringify(parsed)).not.toContain(deploymentId);
+  });
+
+  test("rejects extra records, unexpected fields, and cross-record drift", () => {
+    expect(() =>
+      parseWranglerPagesDeploymentOutput(`${wranglerRecord()}{}\n`, {
+        expectedProject: "eliza-app",
+        expectedCommit: sourceSha,
+        expectedBranch: "develop",
+        expectedAlias: aliasUrl,
+        expectedEnvironment: "preview",
+        expectedProductionBranch: "main",
+        runId: "1",
+        runAttempt: "1",
+      }),
+    ).toThrow("exactly two");
+    expect(() =>
+      parseWranglerPagesDeploymentOutput(
+        wranglerRecord({ deployment_id: "other" }),
+        {
+          expectedProject: "eliza-app",
+          expectedCommit: sourceSha,
+          expectedBranch: "develop",
+          expectedAlias: aliasUrl,
+          expectedEnvironment: "preview",
+          expectedProductionBranch: "main",
+          runId: "1",
+          runAttempt: "1",
+        },
+      ),
+    ).toThrow("deployment_id differs");
+    expect(() =>
+      parseWranglerPagesDeploymentOutput(wranglerRecord({ unexpected: true }), {
+        expectedProject: "eliza-app",
+        expectedCommit: sourceSha,
+        expectedBranch: "develop",
+        expectedAlias: aliasUrl,
+        expectedEnvironment: "preview",
+        expectedProductionBranch: "main",
+        runId: "1",
+        runAttempt: "1",
+      }),
+    ).toThrow("exact closed schema");
+  });
+
+  test("requires exact commit, alias, environment, and production branch", () => {
+    for (const [field, value] of [
+      ["deployment_trigger", { metadata: { commit_hash: "c".repeat(40) } }],
+      ["alias", "https://other.eliza-app.pages.dev"],
+      ["environment", "production"],
+      ["production_branch", "develop"],
+    ] as const) {
+      expect(() =>
+        parseWranglerPagesDeploymentOutput(wranglerRecord({ [field]: value }), {
+          expectedProject: "eliza-app",
+          expectedCommit: sourceSha,
+          expectedBranch: "develop",
+          expectedAlias: aliasUrl,
+          expectedEnvironment: "preview",
+          expectedProductionBranch: "main",
+          runId: "1",
+          runAttempt: "1",
+        }),
+      ).toThrow();
+    }
+  });
+});
+
+describe("deployed renderer proof", () => {
+  test("binds public checks and remote smoke to one exact renderer", async () => {
+    const proof = createDeployedRendererProof({
+      authority: authority(),
+      preflight: await publicCheck("preflight"),
+      remoteSmoke: remoteSmoke(),
+      latency: latency(),
+      continuity: continuity(),
+      postflight: await publicCheck("postflight"),
+    });
+    expect(parseDeployedRendererProof(proof)).toEqual(proof);
+    expect(proof.sourceSha).toBe(sourceSha);
+    expect(proof.remoteSmoke.outcome).toBe("success");
+    expect(proof.continuity.forbiddenAgentMutationCount).toBe(0);
+  });
+
+  test("rejects a stale renderer manifest before browser auth", async () => {
+    const fetchImpl = (async (url: string) => {
+      const parsed = new URL(url);
+      return parsed.origin === aliasUrl
+        ? response(url, { ...rendererManifest(), commit: "c".repeat(40) })
+        : response(url, { commit: sourceSha, environment: "staging" });
+    }) as unknown as typeof fetch;
+    await expect(
+      verifyPublicPagesDeployment(authority(), {
+        apiBase: apiOrigin,
+        phase: "preflight",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("renderer manifest commit is stale");
+  });
+
+  test("rejects renderer drift between browser and postflight", async () => {
+    const preflight = await publicCheck("preflight");
+    const postflight = await publicCheck("postflight");
+    expect(() =>
+      createDeployedRendererProof({
+        authority: authority(),
+        preflight,
+        remoteSmoke: remoteSmoke(),
+        latency: latency(),
+        continuity: continuity(),
+        postflight: {
+          ...postflight,
+          renderer: { ...postflight.renderer, buildId: "c".repeat(64) },
+        },
+      }),
+    ).toThrow("renderer changed");
+  });
+
+  test("rejects forged public manifest schema and commit identities", async () => {
+    const preflight = await publicCheck("preflight");
+    const postflight = await publicCheck("postflight");
+    const inputs = {
+      authority: authority(),
+      preflight,
+      remoteSmoke: remoteSmoke(),
+      latency: latency(),
+      continuity: continuity(),
+      postflight,
+    };
+    expect(() =>
+      createDeployedRendererProof({
+        ...inputs,
+        preflight: {
+          ...preflight,
+          renderer: {
+            ...preflight.renderer,
+            manifestSchema: "elizaos.renderer.build/v0",
+          },
+        },
+      }),
+    ).toThrow("renderer/API source identity is inconsistent");
+    expect(() =>
+      createDeployedRendererProof({
+        ...inputs,
+        postflight: {
+          ...postflight,
+          renderer: { ...postflight.renderer, commit: "b".repeat(40) },
+        },
+      }),
+    ).toThrow("renderer/API source identity is inconsistent");
+  });
+});

--- a/packages/cloud/scripts/pages-deployment-authority.mjs
+++ b/packages/cloud/scripts/pages-deployment-authority.mjs
@@ -1,0 +1,888 @@
+/**
+ * Closes Cloudflare Pages deployment output into a privacy-safe release proof.
+ *
+ * Wrangler's append-only NDJSON is accepted only at the deployment boundary.
+ * This module validates both v1 records, removes the raw deployment UUID, and
+ * binds subsequent public and browser observations to one source SHA, alias,
+ * workflow run, and renderer build before a staging receipt can claim that the
+ * deployed renderer was tested.
+ */
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const PAGES_AUTHORITY_SCHEMA =
+  "elizaos.cloudflare.pages-deployment-authority/v1";
+export const PAGES_PUBLIC_CHECK_SCHEMA =
+  "elizaos.cloudflare.pages-public-check/v1";
+export const DEPLOYED_BROWSER_SMOKE_SCHEMA =
+  "elizaos.cloud.deployed-browser-smoke/v1";
+export const DEPLOYED_RENDERER_PROOF_SCHEMA =
+  "elizaos.cloud.deployed-renderer-proof/v1";
+
+const RECEIPT_LANE = "app-live-e2e-cloud-staging";
+const DEPLOYED_LANE = "app-live-e2e-cloud-staging-deployed";
+const RENDERER_MANIFEST_SCHEMA = "elizaos.renderer.build/v1";
+const LATENCY_METRIC = "first-turn-latency";
+const LATENCY_DEFINITION =
+  "composer-send-click-to-settled-valid-assistant-turn: starts immediately before the UI send click; ends after the same fresh non-empty assistant row settles and passes the liveness contract; not first-token latency";
+const SHA40 = /^[0-9a-f]{40}$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const PROJECT = /^[a-z0-9][a-z0-9-]{0,57}[a-z0-9]$/;
+
+const AUTHORITY_KEYS = [
+  "aliasUrl",
+  "branch",
+  "deploymentIdSha256",
+  "deploymentUrl",
+  "pagesEnvironment",
+  "productionBranch",
+  "project",
+  "schema",
+  "sourceSha",
+  "workflow",
+];
+const WORKFLOW_KEYS = ["runAttempt", "runId"];
+const PUBLIC_CHECK_KEYS = ["api", "phase", "renderer", "schema", "sourceSha"];
+const PUBLIC_RENDERER_KEYS = [
+  "assetCount",
+  "buildId",
+  "commit",
+  "indexHtmlSha256",
+  "manifestSchema",
+  "origin",
+];
+const PUBLIC_API_KEYS = ["commit", "environment", "origin"];
+const REMOTE_SMOKE_KEYS = [
+  "cloudApiOrigin",
+  "cloudEnvironment",
+  "outcome",
+  "rendererBuildId",
+  "rendererManifestCommit",
+  "rendererOrigin",
+  "schema",
+  "sourceSha",
+];
+const LATENCY_KEYS = [
+  "definition",
+  "firstTurnLatencyMs",
+  "lane",
+  "metric",
+  "schemaVersion",
+];
+const CONTINUITY_KEYS = [
+  "apiBaseReused",
+  "challengeTurnCount",
+  "cleanupDisposition",
+  "conversationHistoryDisposition",
+  "forbiddenAgentMutationCount",
+  "freshContextHistoryPassed",
+  "lane",
+  "noAdditionalChatSendAfterChallenge",
+  "personalIdentityEndpointPassed",
+  "personalIdentityReused",
+  "reloadHistoryPassed",
+  "runtimeBindingReused",
+  "schemaVersion",
+];
+const PROOF_KEYS = [
+  "authority",
+  "continuity",
+  "lane",
+  "latency",
+  "postflight",
+  "preflight",
+  "remoteSmoke",
+  "schema",
+  "sourceSha",
+  "workflow",
+];
+
+function fail(message) {
+  throw new Error(`[pages-deployment-authority] ${message}`);
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value, label) {
+  if (!isRecord(value)) fail(`${label} must be an object`);
+  return value;
+}
+
+function requireExactKeys(value, keys, label) {
+  const record = requireRecord(value, label);
+  const actual = Object.keys(record).sort();
+  const expected = [...keys].sort();
+  if (
+    actual.length !== expected.length ||
+    actual.some((key, index) => key !== expected[index])
+  ) {
+    fail(`${label} must use the exact closed schema`);
+  }
+  return record;
+}
+
+function requireString(value, label, pattern) {
+  if (
+    typeof value !== "string" ||
+    !value ||
+    (pattern && !pattern.test(value))
+  ) {
+    fail(`${label} is invalid`);
+  }
+  return value;
+}
+
+function requirePositiveInteger(value, label) {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    fail(`${label} must be a positive safe integer`);
+  }
+  return parsed;
+}
+
+function requireHttpsUrl(value, label) {
+  const raw = requireString(value, label);
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    // error-policy:J3 untrusted provider output is rejected as invalid input.
+    fail(`${label} must be an absolute HTTPS URL`);
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash ||
+    (parsed.pathname !== "/" && parsed.pathname !== "")
+  ) {
+    fail(`${label} must be a bare HTTPS origin`);
+  }
+  return parsed.origin;
+}
+
+function requireIsoTimestamp(value, label) {
+  const raw = requireString(value, label);
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(raw)) {
+    fail(`${label} must be an ISO-8601 UTC timestamp`);
+  }
+  return raw;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function requireNullableString(value, label) {
+  if (value !== null && typeof value !== "string") {
+    fail(`${label} must be a string or null`);
+  }
+}
+
+function parseJson(raw, label) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // error-policy:J3 provider and evidence files are untrusted boundaries.
+    fail(`${label} must contain valid JSON`);
+  }
+}
+
+function parseNdjson(raw) {
+  if (typeof raw !== "string" || !raw.endsWith("\n")) {
+    fail("Wrangler output must end with a newline");
+  }
+  const lines = raw.slice(0, -1).split("\n");
+  if (
+    lines.length !== 2 ||
+    lines.some((line) => !line || line.includes("\r"))
+  ) {
+    fail("Wrangler output must contain exactly two non-empty NDJSON records");
+  }
+  return lines.map((line, index) =>
+    parseJson(line, `Wrangler record ${index + 1}`),
+  );
+}
+
+function parseWorkflow(value, label = "workflow") {
+  const record = requireExactKeys(value, WORKFLOW_KEYS, label);
+  return {
+    runId: requirePositiveInteger(record.runId, `${label}.runId`),
+    runAttempt: requirePositiveInteger(
+      record.runAttempt,
+      `${label}.runAttempt`,
+    ),
+  };
+}
+
+/**
+ * Validates the two records emitted by Wrangler 4.100.0 and returns only the
+ * closed, publishable identity needed by later release jobs.
+ */
+export function parseWranglerPagesDeploymentOutput(
+  raw,
+  {
+    expectedProject,
+    expectedCommit,
+    expectedBranch,
+    expectedAlias,
+    expectedEnvironment,
+    expectedProductionBranch,
+    runId,
+    runAttempt,
+  },
+) {
+  const [summaryValue, detailedValue] = parseNdjson(raw);
+  const summary = requireExactKeys(
+    summaryValue,
+    ["deployment_id", "pages_project", "timestamp", "type", "url", "version"],
+    "pages-deploy record",
+  );
+  const detailed = requireExactKeys(
+    detailedValue,
+    [
+      "alias",
+      "deployment_id",
+      "deployment_trigger",
+      "environment",
+      "pages_project",
+      "production_branch",
+      "timestamp",
+      "type",
+      "url",
+      "version",
+    ],
+    "pages-deploy-detailed record",
+  );
+  if (summary.type !== "pages-deploy" || summary.version !== 1) {
+    fail("first Wrangler record must be pages-deploy/v1");
+  }
+  if (detailed.type !== "pages-deploy-detailed" || detailed.version !== 1) {
+    fail("second Wrangler record must be pages-deploy-detailed/v1");
+  }
+  requireIsoTimestamp(summary.timestamp, "pages-deploy timestamp");
+  requireIsoTimestamp(detailed.timestamp, "pages-deploy-detailed timestamp");
+
+  const project = requireString(
+    summary.pages_project,
+    "pages_project",
+    PROJECT,
+  );
+  const deploymentId = requireString(
+    summary.deployment_id,
+    "deployment_id",
+    UUID,
+  );
+  const deploymentUrl = requireHttpsUrl(summary.url, "deployment URL");
+  const detailedDeploymentUrl = requireHttpsUrl(
+    detailed.url,
+    "detailed deployment URL",
+  );
+  const aliasUrl = requireHttpsUrl(detailed.alias, "deployment alias");
+  const commitMetadata = requireExactKeys(
+    requireExactKeys(
+      detailed.deployment_trigger,
+      ["metadata"],
+      "deployment_trigger",
+    ).metadata,
+    ["commit_hash"],
+    "deployment_trigger.metadata",
+  );
+  const sourceSha = requireString(
+    commitMetadata.commit_hash,
+    "deployment commit hash",
+    SHA40,
+  );
+
+  for (const [label, left, right] of [
+    ["pages_project", detailed.pages_project, project],
+    ["deployment_id", detailed.deployment_id, deploymentId],
+    ["deployment URL", detailedDeploymentUrl, deploymentUrl],
+  ]) {
+    if (left !== right) fail(`${label} differs between Wrangler records`);
+  }
+  if (project !== expectedProject) fail("Pages project does not match release");
+  if (sourceSha !== expectedCommit) fail("commit hash does not match release");
+  if (aliasUrl !== expectedAlias) fail("Pages alias does not match release");
+  if (detailed.environment !== expectedEnvironment) {
+    fail("Pages environment does not match release");
+  }
+  if (detailed.production_branch !== expectedProductionBranch) {
+    fail("Pages production branch does not match release");
+  }
+
+  const expectedDeploymentSuffix = `.${project}.pages.dev`;
+  if (!new URL(deploymentUrl).hostname.endsWith(expectedDeploymentSuffix)) {
+    fail("deployment URL is not owned by the expected Pages project");
+  }
+  const expectedAliasHost = `${expectedBranch}.${project}.pages.dev`;
+  if (new URL(aliasUrl).hostname !== expectedAliasHost) {
+    fail("Pages alias is not owned by the expected release branch");
+  }
+
+  return {
+    schema: PAGES_AUTHORITY_SCHEMA,
+    sourceSha,
+    workflow: {
+      runId: requirePositiveInteger(runId, "run ID"),
+      runAttempt: requirePositiveInteger(runAttempt, "run attempt"),
+    },
+    project,
+    branch: requireString(expectedBranch, "expected branch", PROJECT),
+    pagesEnvironment: expectedEnvironment,
+    productionBranch: expectedProductionBranch,
+    deploymentUrl,
+    aliasUrl,
+    deploymentIdSha256: sha256(deploymentId),
+  };
+}
+
+export function parsePagesDeploymentAuthority(value) {
+  const authority = requireExactKeys(value, AUTHORITY_KEYS, "authority");
+  if (authority.schema !== PAGES_AUTHORITY_SCHEMA) {
+    fail("authority schema is invalid");
+  }
+  const sourceSha = requireString(authority.sourceSha, "sourceSha", SHA40);
+  const project = requireString(authority.project, "project", PROJECT);
+  const branch = requireString(authority.branch, "branch", PROJECT);
+  const deploymentUrl = requireHttpsUrl(
+    authority.deploymentUrl,
+    "deploymentUrl",
+  );
+  const aliasUrl = requireHttpsUrl(authority.aliasUrl, "aliasUrl");
+  if (!new URL(deploymentUrl).hostname.endsWith(`.${project}.pages.dev`)) {
+    fail("authority deployment URL does not match project");
+  }
+  if (new URL(aliasUrl).hostname !== `${branch}.${project}.pages.dev`) {
+    fail("authority alias does not match branch and project");
+  }
+  const parsed = {
+    schema: PAGES_AUTHORITY_SCHEMA,
+    sourceSha,
+    workflow: parseWorkflow(authority.workflow, "authority.workflow"),
+    project,
+    branch,
+    pagesEnvironment: requireString(
+      authority.pagesEnvironment,
+      "pagesEnvironment",
+    ),
+    productionBranch: requireString(
+      authority.productionBranch,
+      "productionBranch",
+      PROJECT,
+    ),
+    deploymentUrl,
+    aliasUrl,
+    deploymentIdSha256: requireString(
+      authority.deploymentIdSha256,
+      "deploymentIdSha256",
+      SHA256,
+    ),
+  };
+  if (parsed.pagesEnvironment !== "preview") {
+    fail(
+      "deployed staging authority must target the Pages preview environment",
+    );
+  }
+  return parsed;
+}
+
+function parseRendererManifest(value, expectedCommit) {
+  const manifest = requireExactKeys(
+    value,
+    [
+      "assetCount",
+      "buildId",
+      "builtAt",
+      "capacitorTarget",
+      "commit",
+      "indexHtmlSha256",
+      "iosApnsEnabled",
+      "playwrightTestAuth",
+      "runtimeMode",
+      "schema",
+      "variant",
+    ],
+    "renderer manifest",
+  );
+  if (manifest.schema !== RENDERER_MANIFEST_SCHEMA) {
+    fail("renderer manifest schema is invalid");
+  }
+  const commit = requireString(manifest.commit, "renderer commit", SHA40);
+  if (commit !== expectedCommit) fail("renderer manifest commit is stale");
+  requireString(manifest.buildId, "renderer buildId", SHA256);
+  requireString(manifest.indexHtmlSha256, "renderer index hash", SHA256);
+  if (!Number.isSafeInteger(manifest.assetCount) || manifest.assetCount <= 0) {
+    fail("renderer assetCount must be a positive safe integer");
+  }
+  requireIsoTimestamp(manifest.builtAt, "renderer builtAt");
+  requireNullableString(manifest.variant, "renderer variant");
+  requireNullableString(manifest.capacitorTarget, "renderer capacitorTarget");
+  requireNullableString(manifest.runtimeMode, "renderer runtimeMode");
+  if (manifest.playwrightTestAuth !== false) {
+    fail("deployed renderer must not contain Playwright test auth");
+  }
+  if (
+    manifest.iosApnsEnabled !== null &&
+    typeof manifest.iosApnsEnabled !== "boolean"
+  ) {
+    fail("renderer iosApnsEnabled is invalid");
+  }
+  return {
+    manifestSchema: RENDERER_MANIFEST_SCHEMA,
+    commit,
+    buildId: manifest.buildId,
+    indexHtmlSha256: manifest.indexHtmlSha256,
+    assetCount: manifest.assetCount,
+  };
+}
+
+function parseHealth(value, expectedCommit) {
+  const health = requireRecord(value, "API health");
+  if (health.commit !== expectedCommit || health.environment !== "staging") {
+    fail("API health does not match the staging release");
+  }
+  return { commit: expectedCommit, environment: "staging" };
+}
+
+async function fetchJson(url, fetchImpl) {
+  let lastError = "no attempts";
+  for (let attempt = 1; attempt <= 4; attempt += 1) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 20_000);
+    try {
+      const response = await fetchImpl(url, {
+        cache: "no-store",
+        headers: { "cache-control": "no-cache" },
+        redirect: "error",
+        signal: controller.signal,
+      });
+      const expected = new URL(url);
+      const observed = response.url ? new URL(response.url) : expected;
+      if (
+        !response.ok ||
+        observed.origin !== expected.origin ||
+        observed.pathname !== expected.pathname
+      ) {
+        lastError = `unexpected HTTP response (${response.status}) or redirect`;
+      } else {
+        const text = await response.text();
+        if (Buffer.byteLength(text) > 128 * 1024) {
+          lastError = "response exceeded the public proof size limit";
+        } else {
+          return parseJson(text, `response from ${expected.origin}`);
+        }
+      }
+    } catch (error) {
+      // error-policy:J1 public network failures remain explicit failed checks.
+      lastError = error instanceof Error ? error.message : String(error);
+    } finally {
+      clearTimeout(timer);
+    }
+    if (attempt < 4)
+      await new Promise((done) => setTimeout(done, attempt * 2_000));
+  }
+  fail(`public check failed after four attempts: ${lastError}`);
+}
+
+export async function verifyPublicPagesDeployment(
+  authorityValue,
+  { apiBase, phase, fetchImpl = fetch },
+) {
+  const authority = parsePagesDeploymentAuthority(authorityValue);
+  if (phase !== "preflight" && phase !== "postflight") {
+    fail("public verification phase must be preflight or postflight");
+  }
+  const apiOrigin = requireHttpsUrl(apiBase, "API base");
+  if (apiOrigin !== "https://api-staging.eliza.app") {
+    fail("public verification API base must be staging");
+  }
+  const manifestUrl = `${authority.aliasUrl}/eliza-renderer-build.json?source=${authority.sourceSha}`;
+  const healthUrl = `${apiOrigin}/api/health?source=${authority.sourceSha}`;
+  const [manifestValue, healthValue] = await Promise.all([
+    fetchJson(manifestUrl, fetchImpl),
+    fetchJson(healthUrl, fetchImpl),
+  ]);
+  const renderer = parseRendererManifest(manifestValue, authority.sourceSha);
+  const api = parseHealth(healthValue, authority.sourceSha);
+  return {
+    schema: PAGES_PUBLIC_CHECK_SCHEMA,
+    phase,
+    sourceSha: authority.sourceSha,
+    renderer: { origin: authority.aliasUrl, ...renderer },
+    api: { origin: apiOrigin, ...api },
+  };
+}
+
+export function parsePagesPublicCheck(value, expectedPhase) {
+  const check = requireExactKeys(value, PUBLIC_CHECK_KEYS, expectedPhase);
+  if (
+    check.schema !== PAGES_PUBLIC_CHECK_SCHEMA ||
+    check.phase !== expectedPhase
+  ) {
+    fail(`${expectedPhase} identity is invalid`);
+  }
+  const sourceSha = requireString(
+    check.sourceSha,
+    `${expectedPhase}.sourceSha`,
+    SHA40,
+  );
+  const renderer = requireExactKeys(
+    check.renderer,
+    PUBLIC_RENDERER_KEYS,
+    `${expectedPhase}.renderer`,
+  );
+  const api = requireExactKeys(
+    check.api,
+    PUBLIC_API_KEYS,
+    `${expectedPhase}.api`,
+  );
+  const parsed = {
+    schema: PAGES_PUBLIC_CHECK_SCHEMA,
+    phase: expectedPhase,
+    sourceSha,
+    renderer: {
+      origin: requireHttpsUrl(
+        renderer.origin,
+        `${expectedPhase}.renderer.origin`,
+      ),
+      manifestSchema: requireString(
+        renderer.manifestSchema,
+        `${expectedPhase}.renderer.manifestSchema`,
+      ),
+      commit: requireString(
+        renderer.commit,
+        `${expectedPhase}.renderer.commit`,
+        SHA40,
+      ),
+      buildId: requireString(
+        renderer.buildId,
+        `${expectedPhase}.renderer.buildId`,
+        SHA256,
+      ),
+      indexHtmlSha256: requireString(
+        renderer.indexHtmlSha256,
+        `${expectedPhase}.renderer.indexHtmlSha256`,
+        SHA256,
+      ),
+      assetCount: requirePositiveInteger(
+        renderer.assetCount,
+        `${expectedPhase}.renderer.assetCount`,
+      ),
+    },
+    api: {
+      origin: requireHttpsUrl(api.origin, `${expectedPhase}.api.origin`),
+      commit: requireString(api.commit, `${expectedPhase}.api.commit`, SHA40),
+      environment: requireString(
+        api.environment,
+        `${expectedPhase}.api.environment`,
+      ),
+    },
+  };
+  if (
+    parsed.renderer.manifestSchema !== RENDERER_MANIFEST_SCHEMA ||
+    parsed.renderer.commit !== sourceSha ||
+    parsed.api.commit !== sourceSha
+  ) {
+    fail(`${expectedPhase} renderer/API source identity is inconsistent`);
+  }
+  return parsed;
+}
+
+export function parseDeployedBrowserSmoke(value) {
+  const smoke = requireExactKeys(value, REMOTE_SMOKE_KEYS, "remoteSmoke");
+  if (
+    smoke.schema !== DEPLOYED_BROWSER_SMOKE_SCHEMA ||
+    smoke.outcome !== "success"
+  ) {
+    fail("remote browser smoke did not close successfully");
+  }
+  return {
+    schema: DEPLOYED_BROWSER_SMOKE_SCHEMA,
+    sourceSha: requireString(smoke.sourceSha, "remoteSmoke.sourceSha", SHA40),
+    rendererOrigin: requireHttpsUrl(
+      smoke.rendererOrigin,
+      "remoteSmoke.rendererOrigin",
+    ),
+    rendererManifestCommit: requireString(
+      smoke.rendererManifestCommit,
+      "remoteSmoke.rendererManifestCommit",
+      SHA40,
+    ),
+    rendererBuildId: requireString(
+      smoke.rendererBuildId,
+      "remoteSmoke.rendererBuildId",
+      SHA256,
+    ),
+    cloudApiOrigin: requireHttpsUrl(
+      smoke.cloudApiOrigin,
+      "remoteSmoke.cloudApiOrigin",
+    ),
+    cloudEnvironment: requireString(
+      smoke.cloudEnvironment,
+      "remoteSmoke.cloudEnvironment",
+    ),
+    outcome: "success",
+  };
+}
+
+function parseLatency(value) {
+  const latency = requireExactKeys(value, LATENCY_KEYS, "latency");
+  if (
+    latency.schemaVersion !== 1 ||
+    latency.lane !== RECEIPT_LANE ||
+    latency.metric !== LATENCY_METRIC ||
+    latency.definition !== LATENCY_DEFINITION
+  ) {
+    fail("latency evidence labels are invalid");
+  }
+  return {
+    schemaVersion: 1,
+    lane: RECEIPT_LANE,
+    metric: LATENCY_METRIC,
+    definition: LATENCY_DEFINITION,
+    firstTurnLatencyMs: requirePositiveInteger(
+      latency.firstTurnLatencyMs,
+      "latency.firstTurnLatencyMs",
+    ),
+  };
+}
+
+function parseContinuity(value) {
+  const continuity = requireExactKeys(value, CONTINUITY_KEYS, "continuity");
+  const expected = {
+    schemaVersion: 1,
+    lane: RECEIPT_LANE,
+    challengeTurnCount: 1,
+    noAdditionalChatSendAfterChallenge: true,
+    personalIdentityEndpointPassed: true,
+    reloadHistoryPassed: true,
+    freshContextHistoryPassed: true,
+    personalIdentityReused: true,
+    runtimeBindingReused: true,
+    apiBaseReused: true,
+    forbiddenAgentMutationCount: 0,
+    cleanupDisposition: "no-test-owned-agent",
+    conversationHistoryDisposition: "preserved",
+  };
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    if (continuity[key] !== expectedValue) {
+      fail(`continuity.${key} is invalid`);
+    }
+  }
+  return expected;
+}
+
+export function createDeployedRendererProof({
+  authority: authorityValue,
+  preflight: preflightValue,
+  remoteSmoke: remoteSmokeValue,
+  latency: latencyValue,
+  continuity: continuityValue,
+  postflight: postflightValue,
+}) {
+  const authority = parsePagesDeploymentAuthority(authorityValue);
+  const preflight = parsePagesPublicCheck(preflightValue, "preflight");
+  const remoteSmoke = parseDeployedBrowserSmoke(remoteSmokeValue);
+  const latency = parseLatency(latencyValue);
+  const continuity = parseContinuity(continuityValue);
+  const postflight = parsePagesPublicCheck(postflightValue, "postflight");
+
+  for (const [label, observed] of [
+    ["preflight", preflight.sourceSha],
+    ["remote smoke", remoteSmoke.sourceSha],
+    ["remote smoke manifest", remoteSmoke.rendererManifestCommit],
+    ["postflight", postflight.sourceSha],
+  ]) {
+    if (observed !== authority.sourceSha) {
+      fail(`${label} source does not match deployment authority`);
+    }
+  }
+  if (
+    preflight.renderer.origin !== authority.aliasUrl ||
+    remoteSmoke.rendererOrigin !== authority.aliasUrl ||
+    postflight.renderer.origin !== authority.aliasUrl
+  ) {
+    fail("renderer observations do not match the deployment alias");
+  }
+  if (
+    preflight.renderer.buildId !== remoteSmoke.rendererBuildId ||
+    preflight.renderer.buildId !== postflight.renderer.buildId ||
+    preflight.renderer.indexHtmlSha256 !==
+      postflight.renderer.indexHtmlSha256 ||
+    preflight.renderer.assetCount !== postflight.renderer.assetCount
+  ) {
+    fail("renderer changed across the deployed browser trajectory");
+  }
+  if (
+    preflight.api.origin !== "https://api-staging.eliza.app" ||
+    remoteSmoke.cloudApiOrigin !== preflight.api.origin ||
+    postflight.api.origin !== preflight.api.origin ||
+    preflight.api.commit !== authority.sourceSha ||
+    postflight.api.commit !== authority.sourceSha ||
+    preflight.api.environment !== "staging" ||
+    remoteSmoke.cloudEnvironment !== "staging" ||
+    postflight.api.environment !== "staging"
+  ) {
+    fail("API observations do not match the exact staging release");
+  }
+
+  return {
+    schema: DEPLOYED_RENDERER_PROOF_SCHEMA,
+    lane: DEPLOYED_LANE,
+    sourceSha: authority.sourceSha,
+    workflow: { ...authority.workflow },
+    authority,
+    preflight,
+    remoteSmoke,
+    latency,
+    continuity,
+    postflight,
+  };
+}
+
+export function parseDeployedRendererProof(value) {
+  const proof = requireExactKeys(value, PROOF_KEYS, "deployed proof");
+  if (
+    proof.schema !== DEPLOYED_RENDERER_PROOF_SCHEMA ||
+    proof.lane !== DEPLOYED_LANE
+  ) {
+    fail("deployed proof identity is invalid");
+  }
+  const rebuilt = createDeployedRendererProof(proof);
+  const workflow = parseWorkflow(proof.workflow, "deployed proof.workflow");
+  if (
+    workflow.runId !== rebuilt.authority.workflow.runId ||
+    workflow.runAttempt !== rebuilt.authority.workflow.runAttempt ||
+    proof.sourceSha !== rebuilt.sourceSha
+  ) {
+    fail("deployed proof workflow or source identity is inconsistent");
+  }
+  return { ...rebuilt, workflow };
+}
+
+async function readJson(path, label) {
+  return parseJson(await readFile(resolve(path), "utf8"), label);
+}
+
+async function writeClosedJson(path, value) {
+  const outputPath = resolve(path);
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o600,
+  });
+  return outputPath;
+}
+
+function parseCliArguments(argv, expected) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith("--") || value === undefined) {
+      fail("arguments must be --name value pairs");
+    }
+    const name = flag.slice(2);
+    if (!expected.has(name)) fail(`unsupported argument: ${flag}`);
+    if (values.has(name)) fail(`duplicate argument: ${flag}`);
+    values.set(name, value);
+  }
+  for (const name of expected) {
+    if (!values.has(name)) fail(`missing argument: --${name}`);
+  }
+  return values;
+}
+
+async function main(argv) {
+  const [command, ...rest] = argv;
+  if (command === "parse") {
+    const values = parseCliArguments(
+      rest,
+      new Set([
+        "input",
+        "output",
+        "expected-project",
+        "expected-commit",
+        "expected-branch",
+        "expected-alias",
+        "expected-environment",
+        "expected-production-branch",
+        "run-id",
+        "run-attempt",
+      ]),
+    );
+    const authority = parseWranglerPagesDeploymentOutput(
+      await readFile(resolve(values.get("input")), "utf8"),
+      {
+        expectedProject: values.get("expected-project"),
+        expectedCommit: values.get("expected-commit"),
+        expectedBranch: values.get("expected-branch"),
+        expectedAlias: values.get("expected-alias"),
+        expectedEnvironment: values.get("expected-environment"),
+        expectedProductionBranch: values.get("expected-production-branch"),
+        runId: values.get("run-id"),
+        runAttempt: values.get("run-attempt"),
+      },
+    );
+    await writeClosedJson(values.get("output"), authority);
+    process.stdout.write(`${authority.aliasUrl}\n`);
+    return;
+  }
+  if (command === "verify") {
+    const values = parseCliArguments(
+      rest,
+      new Set(["authority", "api-base", "phase", "output"]),
+    );
+    const check = await verifyPublicPagesDeployment(
+      await readJson(values.get("authority"), "authority"),
+      { apiBase: values.get("api-base"), phase: values.get("phase") },
+    );
+    await writeClosedJson(values.get("output"), check);
+    return;
+  }
+  if (command === "combine") {
+    const values = parseCliArguments(
+      rest,
+      new Set([
+        "authority",
+        "preflight",
+        "remote-smoke",
+        "latency",
+        "continuity",
+        "postflight",
+        "output",
+      ]),
+    );
+    const proof = createDeployedRendererProof({
+      authority: await readJson(values.get("authority"), "authority"),
+      preflight: await readJson(values.get("preflight"), "preflight"),
+      remoteSmoke: await readJson(values.get("remote-smoke"), "remote smoke"),
+      latency: await readJson(values.get("latency"), "latency"),
+      continuity: await readJson(values.get("continuity"), "continuity"),
+      postflight: await readJson(values.get("postflight"), "postflight"),
+    });
+    await writeClosedJson(values.get("output"), proof);
+    return;
+  }
+  fail("usage: pages-deployment-authority.mjs parse|verify|combine ...");
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main(process.argv.slice(2)).catch((error) => {
+    // error-policy:J1 the CLI boundary fails closed without printing evidence.
+    process.stderr.write(`${error instanceof Error ? error.message : error}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/packages/cloud/scripts/release-admission-cli.mjs
+++ b/packages/cloud/scripts/release-admission-cli.mjs
@@ -25,6 +25,7 @@ const result = decideReleaseAdmission({
   targetEnvironment: args.environment,
   ref: args.ref,
   force: args.force === "true",
+  runDeployedRendererStaging: args["run-deployed-renderer-staging"] === "true",
   runId: args["run-id"],
   latestEligibleRunId: args["latest-eligible-run-id"],
 });

--- a/packages/cloud/scripts/release-admission.mjs
+++ b/packages/cloud/scripts/release-admission.mjs
@@ -2,8 +2,9 @@
  * Decides whether a cloud release may consume build or mutation capacity.
  *
  * Production, previews, manual staging releases, and forced rollbacks are
- * always admitted. Automatic staging releases are latest-wins among runs
- * eligible for this workflow.
+ * always admitted. An explicit deployed-renderer staging proof is admitted
+ * only from its constrained manual dispatch. Automatic staging releases are
+ * latest-wins among runs eligible for this workflow.
  */
 
 export function decideReleaseAdmission({
@@ -11,9 +12,25 @@ export function decideReleaseAdmission({
   targetEnvironment,
   ref,
   force,
+  runDeployedRendererStaging,
   runId,
   latestEligibleRunId,
 }) {
+  if (runDeployedRendererStaging) {
+    if (
+      eventName !== "workflow_dispatch" ||
+      targetEnvironment !== "staging" ||
+      ref !== "refs/heads/develop" ||
+      force
+    ) {
+      throw new Error(
+        "Deployed-renderer staging proof requires a non-forced workflow_dispatch from refs/heads/develop targeting staging",
+      );
+    }
+
+    return { shouldDeploy: true, reason: "explicit-deployed-renderer-staging" };
+  }
+
   if (
     eventName === "pull_request" ||
     eventName === "workflow_dispatch" ||

--- a/packages/cloud/scripts/release-admission.test.mjs
+++ b/packages/cloud/scripts/release-admission.test.mjs
@@ -11,6 +11,7 @@ const staging = {
   targetEnvironment: "",
   ref: "refs/heads/develop",
   force: false,
+  runDeployedRendererStaging: false,
   runId: "200",
   latestEligibleRunId: "200",
 };
@@ -28,6 +29,52 @@ describe("decideReleaseAdmission", () => {
       shouldDeploy: false,
       reason: "superseded-staging-run",
     });
+  });
+
+  it("admits one explicit non-forced deployed-renderer staging dispatch", () => {
+    expect(
+      decideReleaseAdmission({
+        ...staging,
+        eventName: "workflow_dispatch",
+        targetEnvironment: "staging",
+        runDeployedRendererStaging: true,
+        latestEligibleRunId: "",
+      }),
+    ).toEqual({
+      shouldDeploy: true,
+      reason: "explicit-deployed-renderer-staging",
+    });
+  });
+
+  it("keeps an ordinary staging dispatch under latest-wins admission", () => {
+    expect(
+      decideReleaseAdmission({
+        ...staging,
+        eventName: "workflow_dispatch",
+        targetEnvironment: "staging",
+        runId: "199",
+      }),
+    ).toEqual({
+      shouldDeploy: false,
+      reason: "superseded-staging-run",
+    });
+  });
+
+  it.each([
+    { eventName: "push" },
+    { targetEnvironment: "production" },
+    { ref: "refs/heads/main" },
+    { force: true },
+  ])("rejects a proof request outside its exact dispatch fence", (override) => {
+    expect(() =>
+      decideReleaseAdmission({
+        ...staging,
+        eventName: "workflow_dispatch",
+        targetEnvironment: "staging",
+        runDeployedRendererStaging: true,
+        ...override,
+      }),
+    ).toThrow("requires a non-forced workflow_dispatch");
   });
 
   it.each([

--- a/packages/cloud/scripts/release-admission.test.mjs
+++ b/packages/cloud/scripts/release-admission.test.mjs
@@ -46,7 +46,7 @@ describe("decideReleaseAdmission", () => {
     });
   });
 
-  it("keeps an ordinary staging dispatch under latest-wins admission", () => {
+  it("preserves ordinary manual staging admission", () => {
     expect(
       decideReleaseAdmission({
         ...staging,
@@ -55,8 +55,8 @@ describe("decideReleaseAdmission", () => {
         runId: "199",
       }),
     ).toEqual({
-      shouldDeploy: false,
-      reason: "superseded-staging-run",
+      shouldDeploy: true,
+      reason: "non-supersedable-release",
     });
   });
 

--- a/packages/scripts/__tests__/cloud-cf-deployed-browser-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-deployed-browser-workflow.test.ts
@@ -85,6 +85,10 @@ const authorityUpload = requireStep(
   "Publish closed Pages deployment authority",
 );
 const deployedJob = requireJob("deployed-renderer-staging");
+const oneShotPrerequisite = requireStep(
+  deployedJob,
+  "Require one-shot staging release prerequisites",
+);
 const authorityDownload = requireStep(
   deployedJob,
   "Download exact Pages deployment authority",
@@ -186,6 +190,12 @@ describe("Cloudflare deployed browser workflow contract", () => {
       deployWorkflow.on?.workflow_dispatch?.inputs?.[inputName];
     const calledInput = workflow.on?.workflow_call?.inputs?.[inputName];
     const releaseJob = deployWorkflow.jobs?.release;
+    const sourceValidationStep = deployWorkflow.jobs?.[
+      "validate-deploy-source"
+    ]?.steps?.find(
+      (step) =>
+        step.name === "Reject feature refs targeting canonical environments",
+    );
     const admissionJob = deployWorkflow.jobs?.["admit-staging"];
     const admissionStep = admissionJob?.steps?.find(
       (step) =>
@@ -204,6 +214,16 @@ describe("Cloudflare deployed browser workflow contract", () => {
     expect(admissionStep?.env?.RUN_DEPLOYED_RENDERER_STAGING).toBe(
       releaseJob?.with?.[inputName],
     );
+    expect(sourceValidationStep?.env?.RUN_DEPLOYED_RENDERER_STAGING).toBe(
+      githubExpression("inputs.run_deployed_renderer_staging == true"),
+    );
+    expect(sourceValidationStep?.run).toContain(
+      '[ "$RUN_DEPLOYED_RENDERER_STAGING" = "true" ]',
+    );
+    expect(sourceValidationStep?.run).toContain(
+      '[ "$TARGET_ENVIRONMENT" != "staging" ]',
+    );
+    expect(sourceValidationStep?.run).toContain('[ "$FORCE" = "true" ]');
     expect(admissionStep?.run).toContain(
       '&& [ "$RUN_DEPLOYED_RENDERER_STAGING" != "true" ]',
     );
@@ -214,8 +234,25 @@ describe("Cloudflare deployed browser workflow contract", () => {
       "inputs.run_deployed_renderer_staging == true",
     );
     expect(deployedJob.if).toContain(
-      "vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1' || (github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true)",
+      "vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1' && needs.deploy-app.result == 'success'",
     );
+    expect(deployedJob.if).toContain(
+      "|| (github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true)",
+    );
+    expect(oneShotPrerequisite.if).toBe(
+      githubExpression("inputs.run_deployed_renderer_staging == true"),
+    );
+    expect(oneShotPrerequisite.env).toEqual({
+      DEPLOY_APP_RESULT: githubExpression("needs.deploy-app.result"),
+      PAGES_DEPLOYED: githubExpression(
+        "needs.deploy-app.outputs.pages_deployed",
+      ),
+      VERIFY_ROUTING_RESULT: githubExpression("needs.verify-routing.result"),
+    });
+    expect(oneShotPrerequisite.run).toContain(
+      '[ "$PAGES_DEPLOYED" != "true" ]',
+    );
+    expect(oneShotPrerequisite.run).toContain("exit 1");
     expect(deployWorkflow.on?.schedule).toBeUndefined();
   });
 

--- a/packages/scripts/__tests__/cloud-cf-deployed-browser-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-deployed-browser-workflow.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Fail-closed structure for the credentialed browser proof of the exact
+ * Cloudflare Pages staging deployment. The workflow is inspected as data so a
+ * later refactor cannot silently move credentials into public probes, test a
+ * local renderer, or publish Wrangler/Playwright internals as evidence.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+
+function read(path: string): string {
+  return readFileSync(new URL(path, repoRoot), "utf8");
+}
+
+function githubExpression(body: string): string {
+  return ["$", "{{ ", body, " }}"].join("");
+}
+
+function shellExpansion(body: string): string {
+  return ["$", "{", body, "}"].join("");
+}
+
+interface WorkflowStep {
+  id?: string;
+  name?: string;
+  if?: string;
+  uses?: string;
+  env?: Record<string, string>;
+  run?: string;
+  with?: Record<string, string>;
+}
+
+interface WorkflowJob {
+  needs?: string[];
+  if?: string;
+  environment?: string;
+  env?: Record<string, string>;
+  outputs?: Record<string, string>;
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>;
+}
+
+const workflowSource = read(".github/workflows/cloud-cf-release.yml");
+const workflow = Bun.YAML.parse(workflowSource) as Workflow;
+const deployedConfig = read("packages/app/playwright.cloud-deployed.config.ts");
+const smokeSpec = read("packages/app/test/ui-smoke/cloud-live.spec.ts");
+
+function requireJob(name: string): WorkflowJob {
+  const job = workflow.jobs?.[name];
+  if (!job) throw new Error(`Missing workflow job: ${name}`);
+  return job;
+}
+
+function requireStep(job: WorkflowJob, name: string): WorkflowStep {
+  const step = job.steps?.find((candidate) => candidate.name === name);
+  if (!step) throw new Error(`Missing workflow step: ${name}`);
+  return step;
+}
+
+const deployJob = requireJob("deploy-app");
+const deployStep = requireStep(deployJob, "Deploy to Cloudflare Pages");
+const freshnessStep = requireStep(deployJob, "Verify Pages frontend freshness");
+const authorityUpload = requireStep(
+  deployJob,
+  "Publish closed Pages deployment authority",
+);
+const deployedJob = requireJob("deployed-renderer-staging");
+const authorityDownload = requireStep(
+  deployedJob,
+  "Download exact Pages deployment authority",
+);
+const preflightStep = requireStep(
+  deployedJob,
+  "Verify public deployment before browser auth",
+);
+const browserStep = requireStep(
+  deployedJob,
+  "Run deployed Personal identity, chat, and continuity trajectory",
+);
+const postflightStep = requireStep(
+  deployedJob,
+  "Verify public deployment after browser auth",
+);
+const combineStep = requireStep(deployedJob, "Close deployed renderer proof");
+const receiptStep = requireStep(deployedJob, "Write deployed staging receipt");
+const receiptUpload = requireStep(
+  deployedJob,
+  "Upload closed deployed staging receipt",
+);
+
+describe("Cloudflare deployed browser workflow contract", () => {
+  test("closes the append-only Wrangler output before publishing authority", () => {
+    expect(deployJob.outputs?.pages_deployed).toBe(
+      "$" + "{{ steps.pages-deploy.outputs.deployed }}",
+    );
+    expect(deployStep.id).toBe("pages-deploy");
+    expect(deployStep.run).toContain("WRANGLER_OUTPUT_FILE_PATH");
+    expect(deployStep.run).toContain('chmod 600 "$wrangler_output"');
+    expect(deployStep.run).toContain(': > "$wrangler_output"');
+    expect(deployStep.run).toContain('--commit-hash="$GITHUB_SHA"');
+    expect(deployStep.run).toContain("--commit-dirty=false");
+    expect(deployStep.run).toContain('pages-deployment-authority.mjs" parse');
+    expect(deployStep.run).toContain("--expected-environment preview");
+    expect(deployStep.run).toContain("--expected-production-branch main");
+    expect(deployStep.env?.PAGES_BRANCH).toBe(
+      "$" + "{{ steps.pages.outputs.branch }}",
+    );
+    expect(deployStep.run).toContain('--expected-branch "$PAGES_BRANCH"');
+    expect(deployStep.run).toContain("trap cleanup_wrangler_output EXIT");
+    expect(deployStep.run).toContain('rm -f -- "$wrangler_output"');
+
+    expect(authorityUpload.if).toContain(
+      "inputs.target_environment == 'staging'",
+    );
+    expect(authorityUpload.with?.name).toBe(
+      `pages-deployment-authority-${githubExpression("github.run_id")}-${githubExpression("github.run_attempt")}`,
+    );
+    expect(authorityUpload.with?.path).toBe(
+      `${githubExpression("runner.temp")}/pages-deployment-authority/pages-deployment-authority.json`,
+    );
+    expect(authorityUpload.with?.["if-no-files-found"]).toBe("error");
+
+    const uploadPaths = (deployJob.steps ?? [])
+      .filter((step) => step.uses?.startsWith("actions/upload-artifact@"))
+      .map((step) => step.with?.path ?? "")
+      .join("\n");
+    expect(uploadPaths).not.toContain("WRANGLER_OUTPUT_FILE_PATH");
+    expect(uploadPaths).not.toContain("wrangler-output");
+  });
+
+  test("byte-verifies the canonical alias as well as the custom domains", () => {
+    expect(freshnessStep.env?.PAGES_ALIAS).toBe(
+      "$" + "{{ steps.pages-deploy.outputs.alias }}",
+    );
+    expect(freshnessStep.run).toContain(
+      'served_frontends=("$MARKETING_URL" "$CLOUD_APP_URL")',
+    );
+    expect(freshnessStep.run).toContain('served_frontends+=("$PAGES_ALIAS")');
+    expect(freshnessStep.run).toContain(
+      `for served_url in "${shellExpansion("served_frontends[@]")}"`,
+    );
+    expect(freshnessStep.run).toContain("https://develop.eliza-app.pages.dev");
+  });
+
+  test("runs only after the staging deploy and public routing gates", () => {
+    expect(deployedJob.needs).toEqual(["deploy-app", "verify-routing"]);
+    expect(deployedJob.environment).toBe("staging");
+    expect(deployedJob.if).toContain("inputs.target_environment == 'staging'");
+    expect(deployedJob.if).toContain(
+      "vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1'",
+    );
+    expect(deployedJob.if).toContain(
+      "needs.deploy-app.outputs.pages_deployed == 'true'",
+    );
+    expect(deployedJob.if).toContain(
+      "needs.verify-routing.result == 'success'",
+    );
+    expect(authorityDownload.with?.name).toBe(
+      `pages-deployment-authority-${githubExpression("github.run_id")}-${githubExpression("github.run_attempt")}`,
+    );
+  });
+
+  test("keeps public probes secretless and exposes the key only to Chromium", () => {
+    expect(preflightStep.env).toBeUndefined();
+    expect(postflightStep.env).toBeUndefined();
+    expect(preflightStep.run).toContain("--phase preflight");
+    expect(postflightStep.run).toContain("--phase postflight");
+    expect(postflightStep.if).toContain("always()");
+
+    const secretSteps = (deployedJob.steps ?? []).filter((step) =>
+      JSON.stringify(step.env ?? {}).includes("ELIZAOS_CLOUD_API_KEY"),
+    );
+    expect(secretSteps.map((step) => step.name)).toEqual([browserStep.name]);
+    expect(deployedJob.env?.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
+    expect(browserStep.env?.ELIZAOS_CLOUD_API_KEY).toBe(
+      "$" + "{{ secrets.ELIZAOS_CLOUD_API_KEY }}",
+    );
+    expect(browserStep.run).toContain(
+      "--config playwright.cloud-deployed.config.ts",
+    );
+    expect(browserStep.run).not.toContain("webServer");
+  });
+
+  test("combines every strict observation before deriving receipt v3", () => {
+    for (const input of [
+      '--authority "$AUTHORITY_PATH"',
+      '--preflight "$PREFLIGHT_PATH"',
+      '--remote-smoke "$REMOTE_SMOKE_PATH"',
+      '--latency "$LATENCY_PATH"',
+      '--continuity "$CONTINUITY_PATH"',
+      '--postflight "$POSTFLIGHT_PATH"',
+    ]) {
+      expect(combineStep.run).toContain(input);
+    }
+    expect(receiptStep.run).toContain(
+      '--deployed-proof-file "$DEPLOYED_PROOF_PATH"',
+    );
+    expect(receiptStep.run).not.toContain("--deployed-renderer-verified");
+    expect(receiptUpload.with?.name).toBe(
+      `app-live-e2e-cloud-staging-deployed-${githubExpression("github.run_id")}-${githubExpression("github.run_attempt")}`,
+    );
+    expect(receiptUpload.with?.path).toBe(
+      `${githubExpression("runner.temp")}/deployed-renderer-proof-${githubExpression("github.run_id")}-${githubExpression("github.run_attempt")}/cloud-staging-deployed-receipt.json`,
+    );
+    expect(receiptUpload.with?.["if-no-files-found"]).toBe("error");
+
+    const deployedUploads = (deployedJob.steps ?? [])
+      .filter((step) => step.uses?.startsWith("actions/upload-artifact@"))
+      .map((step) => `${step.with?.name ?? ""}\n${step.with?.path ?? ""}`)
+      .join("\n");
+    expect(deployedUploads).not.toContain("playwright-report");
+    expect(deployedUploads).not.toContain("REMOTE_SMOKE_PATH");
+    expect(deployedUploads).not.toContain("DEPLOYED_PROOF_PATH");
+  });
+
+  test("hard-pins a no-retention, service-worker-free remote Chromium run", () => {
+    expect(deployedConfig).toContain(
+      'const DEPLOYED_RENDERER_ALIAS = "https://develop.eliza-app.pages.dev"',
+    );
+    expect(deployedConfig).toContain("workers: 1");
+    expect(deployedConfig).toContain("retries: 0");
+    expect(deployedConfig).toContain('serviceWorkers: "block"');
+    expect(deployedConfig).toContain('trace: "off"');
+    expect(deployedConfig).toContain('screenshot: "off"');
+    expect(deployedConfig).toContain('video: "off"');
+    expect(deployedConfig).toContain('name: "chromium"');
+    expect(deployedConfig).not.toContain("webServer:");
+
+    expect(smokeSpec).toContain("ELIZA_UI_SMOKE_DEPLOYED_RENDERER");
+    expect(smokeSpec).toContain("cloudflare-pages-alias");
+    expect(smokeSpec).toContain("elizaos.renderer.build/v1");
+    expect(smokeSpec).toContain("https://develop.eliza-app.pages.dev");
+  });
+
+  test("verifies the top-level Pages document before handing it the bearer", () => {
+    expect(smokeSpec).toContain("if (!DEPLOYED_RENDERER_ENABLED)");
+    expect(smokeSpec).toContain("resolveCloudLiveBrowserAuthSeed(process.env)");
+    expect(smokeSpec).toContain("window.top !== window");
+    expect(smokeSpec).toContain("window.location.origin !== expectedOrigin");
+
+    const openStart = smokeSpec.indexOf(
+      "async function openProtectedCloudBlankStart",
+    );
+    const navigation = smokeSpec.indexOf(
+      'await page.goto("/", { waitUntil: "domcontentloaded" });',
+      openStart,
+    );
+    const publicIdentity = smokeSpec.indexOf(
+      "await requireDeployedRendererIdentity(page, baseURL)",
+      navigation,
+    );
+    const cloudOrigin = smokeSpec.indexOf(
+      "await requireRendererCloudApiOrigin(",
+      publicIdentity,
+    );
+    const bearerHandoff = smokeSpec.indexOf(
+      "await seedVerifiedDeployedCloudBrowserAuth(page)",
+      cloudOrigin,
+    );
+    expect(openStart).toBeGreaterThan(0);
+    expect(navigation).toBeGreaterThan(openStart);
+    expect(publicIdentity).toBeGreaterThan(navigation);
+    expect(cloudOrigin).toBeGreaterThan(publicIdentity);
+    expect(bearerHandoff).toBeGreaterThan(cloudOrigin);
+    expect(
+      smokeSpec.match(/await requireRendererCloudApiOrigin\(/g),
+    ).toHaveLength(2);
+  });
+});

--- a/packages/scripts/__tests__/cloud-cf-deployed-browser-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-deployed-browser-workflow.test.ts
@@ -38,14 +38,30 @@ interface WorkflowJob {
   env?: Record<string, string>;
   outputs?: Record<string, string>;
   steps?: WorkflowStep[];
+  uses?: string;
+  with?: Record<string, string>;
+}
+
+interface WorkflowInput {
+  default?: boolean | string;
+  description?: string;
+  required?: boolean;
+  type?: string;
 }
 
 interface Workflow {
+  on?: {
+    schedule?: unknown;
+    workflow_call?: { inputs?: Record<string, WorkflowInput> };
+    workflow_dispatch?: { inputs?: Record<string, WorkflowInput> };
+  };
   jobs?: Record<string, WorkflowJob>;
 }
 
 const workflowSource = read(".github/workflows/cloud-cf-release.yml");
 const workflow = Bun.YAML.parse(workflowSource) as Workflow;
+const deployWorkflowSource = read(".github/workflows/cloud-cf-deploy.yml");
+const deployWorkflow = Bun.YAML.parse(deployWorkflowSource) as Workflow;
 const deployedConfig = read("packages/app/playwright.cloud-deployed.config.ts");
 const smokeSpec = read("packages/app/test/ui-smoke/cloud-live.spec.ts");
 
@@ -162,6 +178,45 @@ describe("Cloudflare deployed browser workflow contract", () => {
     expect(authorityDownload.with?.name).toBe(
       `pages-deployment-authority-${githubExpression("github.run_id")}-${githubExpression("github.run_attempt")}`,
     );
+  });
+
+  test("supports an explicit one-shot dispatch without arming scheduled runs", () => {
+    const inputName = "run_deployed_renderer_staging";
+    const dispatchInput =
+      deployWorkflow.on?.workflow_dispatch?.inputs?.[inputName];
+    const calledInput = workflow.on?.workflow_call?.inputs?.[inputName];
+    const releaseJob = deployWorkflow.jobs?.release;
+    const admissionJob = deployWorkflow.jobs?.["admit-staging"];
+    const admissionStep = admissionJob?.steps?.find(
+      (step) =>
+        step.name === "Reject superseded staging SHA before work starts",
+    );
+
+    expect(dispatchInput?.type).toBe("boolean");
+    expect(dispatchInput?.default).toBe(false);
+    expect(calledInput?.type).toBe("boolean");
+    expect(calledInput?.default).toBe(false);
+    expect(releaseJob?.with?.[inputName]).toBe(
+      githubExpression(
+        "github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true",
+      ),
+    );
+    expect(admissionStep?.env?.RUN_DEPLOYED_RENDERER_STAGING).toBe(
+      releaseJob?.with?.[inputName],
+    );
+    expect(admissionStep?.run).toContain(
+      '&& [ "$RUN_DEPLOYED_RENDERER_STAGING" != "true" ]',
+    );
+    expect(admissionStep?.run).toContain(
+      '"--run-deployed-renderer-staging=$RUN_DEPLOYED_RENDERER_STAGING"',
+    );
+    expect(deployedJob.if).toContain(
+      "inputs.run_deployed_renderer_staging == true",
+    );
+    expect(deployedJob.if).toContain(
+      "vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1' || (github.event_name == 'workflow_dispatch' && inputs.run_deployed_renderer_staging == true)",
+    );
+    expect(deployWorkflow.on?.schedule).toBeUndefined();
   });
 
   test("keeps public probes secretless and exposes the key only to Chromium", () => {

--- a/packages/scripts/__tests__/staging-cloud-receipt.test.ts
+++ b/packages/scripts/__tests__/staging-cloud-receipt.test.ts
@@ -1,10 +1,26 @@
 /**
  * Contract tests for the staging Cloud live receipt's closed, secret-free schema.
  */
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createDeployedRendererProof,
+  DEPLOYED_BROWSER_SMOKE_SCHEMA,
+  PAGES_AUTHORITY_SCHEMA,
+  PAGES_PUBLIC_CHECK_SCHEMA,
+} from "../../cloud/scripts/pages-deployment-authority.mjs";
 import { createStagingCloudReceipt } from "../write-staging-cloud-receipt.mjs";
 
 const exactSha = "87da9c8ba169440f0fb21dc613f7bc425c8014b6";
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 function args(overrides: Record<string, string> = {}): string[] {
   const values = {
@@ -23,6 +39,91 @@ function args(overrides: Record<string, string> = {}): string[] {
     `--${name}`,
     value,
   ]);
+}
+
+function deployedProofFile(
+  overrides: { sourceSha?: string; latency?: number } = {},
+): string {
+  const sourceSha = overrides.sourceSha ?? exactSha;
+  const aliasUrl = "https://develop.eliza-app.pages.dev";
+  const apiOrigin = "https://api-staging.eliza.app";
+  const buildId = "a".repeat(64);
+  const renderer = {
+    origin: aliasUrl,
+    manifestSchema: "elizaos.renderer.build/v1",
+    commit: sourceSha,
+    buildId,
+    indexHtmlSha256: "b".repeat(64),
+    assetCount: 42,
+  };
+  const api = { origin: apiOrigin, commit: sourceSha, environment: "staging" };
+  const authority = {
+    schema: PAGES_AUTHORITY_SCHEMA,
+    sourceSha,
+    workflow: { runId: 32237956456, runAttempt: 1 },
+    project: "eliza-app",
+    branch: "develop",
+    pagesEnvironment: "preview",
+    productionBranch: "main",
+    deploymentUrl: "https://5f02a912.eliza-app.pages.dev",
+    aliasUrl,
+    deploymentIdSha256: "c".repeat(64),
+  };
+  const proof = createDeployedRendererProof({
+    authority,
+    preflight: {
+      schema: PAGES_PUBLIC_CHECK_SCHEMA,
+      phase: "preflight",
+      sourceSha,
+      renderer,
+      api,
+    },
+    remoteSmoke: {
+      schema: DEPLOYED_BROWSER_SMOKE_SCHEMA,
+      sourceSha,
+      rendererOrigin: aliasUrl,
+      rendererManifestCommit: sourceSha,
+      rendererBuildId: buildId,
+      cloudApiOrigin: apiOrigin,
+      cloudEnvironment: "staging",
+      outcome: "success",
+    },
+    latency: {
+      schemaVersion: 1,
+      lane: "app-live-e2e-cloud-staging",
+      metric: "first-turn-latency",
+      definition:
+        "composer-send-click-to-settled-valid-assistant-turn: starts immediately before the UI send click; ends after the same fresh non-empty assistant row settles and passes the liveness contract; not first-token latency",
+      firstTurnLatencyMs: overrides.latency ?? 12345,
+    },
+    continuity: {
+      schemaVersion: 1,
+      lane: "app-live-e2e-cloud-staging",
+      challengeTurnCount: 1,
+      noAdditionalChatSendAfterChallenge: true,
+      personalIdentityEndpointPassed: true,
+      reloadHistoryPassed: true,
+      freshContextHistoryPassed: true,
+      personalIdentityReused: true,
+      runtimeBindingReused: true,
+      apiBaseReused: true,
+      forbiddenAgentMutationCount: 0,
+      cleanupDisposition: "no-test-owned-agent",
+      conversationHistoryDisposition: "preserved",
+    },
+    postflight: {
+      schema: PAGES_PUBLIC_CHECK_SCHEMA,
+      phase: "postflight",
+      sourceSha,
+      renderer,
+      api,
+    },
+  });
+  const root = mkdtempSync(join(tmpdir(), "deployed-renderer-proof-"));
+  tempRoots.push(root);
+  const path = join(root, "proof.json");
+  writeFileSync(path, `${JSON.stringify(proof, null, 2)}\n`, { mode: 0o600 });
+  return path;
 }
 
 describe("staging Cloud live receipt", () => {
@@ -98,6 +199,59 @@ describe("staging Cloud live receipt", () => {
     });
     expect(receipt.annotations.loginPersonalIdentityChatPassed).toBe(false);
     expect(receipt.annotations.historyContinuityPassed).toBe(false);
+  });
+
+  test("sets schema v3 and deployedRendererTested only from a closed proof file", () => {
+    const receipt = createStagingCloudReceipt(
+      args({ "deployed-proof-file": deployedProofFile() }),
+    );
+    expect(receipt.schemaVersion).toBe(3);
+    expect(receipt.annotations).toEqual({
+      cloudApiOrigin: "https://api-staging.eliza.app",
+      cloudEnvironment: "staging",
+      rendererSource: "cloudflare-pages-alias",
+      deployedRendererTested: true,
+      loginPersonalIdentityChatPassed: true,
+      historyContinuityPassed: true,
+      cloudflarePagesAlias: "https://develop.eliza-app.pages.dev",
+    });
+    expect(receipt.deployment).toMatchObject({
+      cloudflarePagesAlias: "https://develop.eliza-app.pages.dev",
+      deploymentUrl: "https://5f02a912.eliza-app.pages.dev",
+      deploymentIdSha256: "c".repeat(64),
+      rendererBuildId: "a".repeat(64),
+      rendererManifestCommit: exactSha,
+      publicPreflightPassed: true,
+      remoteBrowserSmokePassed: true,
+      publicPostflightPassed: true,
+    });
+    expect(receipt.deployment.proofSha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("rejects boolean claims and proof/source/latency mismatches", () => {
+    expect(() =>
+      createStagingCloudReceipt([
+        ...args(),
+        "--deployed-renderer-tested",
+        "true",
+      ]),
+    ).toThrow("unsupported argument");
+    expect(() =>
+      createStagingCloudReceipt(
+        args({
+          "deployed-proof-file": deployedProofFile({
+            sourceSha: "a".repeat(40),
+          }),
+        }),
+      ),
+    ).toThrow("does not match the receipt source/run identity");
+    expect(() =>
+      createStagingCloudReceipt(
+        args({
+          "deployed-proof-file": deployedProofFile({ latency: 12346 }),
+        }),
+      ),
+    ).toThrow("latency does not match");
   });
 
   test("requires independently verified continuity on success and forbids it on failure", () => {

--- a/packages/scripts/write-staging-cloud-receipt.mjs
+++ b/packages/scripts/write-staging-cloud-receipt.mjs
@@ -5,10 +5,13 @@
  * timing, and outcome values, while Cloud annotations are fixed here. Bearer
  * credentials, model replies, and raw HTTP bodies can never enter the file.
  */
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
+import { parseDeployedRendererProof } from "../cloud/scripts/pages-deployment-authority.mjs";
 
-const EXPECTED_ARGUMENTS = new Set([
+const REQUIRED_ARGUMENTS = new Set([
   "output",
   "source-sha",
   "run-id",
@@ -19,6 +22,7 @@ const EXPECTED_ARGUMENTS = new Set([
   "first-turn-latency-ms",
   "continuity-evidence",
 ]);
+const OPTIONAL_ARGUMENTS = new Set(["deployed-proof-file"]);
 
 function fail(message) {
   throw new Error(`[staging-cloud-receipt] ${message}`);
@@ -33,7 +37,7 @@ function parseArguments(argv) {
       fail("arguments must be --name value pairs");
     }
     const name = flag.slice(2);
-    if (!EXPECTED_ARGUMENTS.has(name)) {
+    if (!REQUIRED_ARGUMENTS.has(name) && !OPTIONAL_ARGUMENTS.has(name)) {
       fail(`unsupported argument: ${flag}`);
     }
     if (values.has(name)) {
@@ -42,7 +46,7 @@ function parseArguments(argv) {
     values.set(name, value);
   }
 
-  for (const name of EXPECTED_ARGUMENTS) {
+  for (const name of REQUIRED_ARGUMENTS) {
     if (!values.has(name)) {
       fail(`missing argument: --${name}`);
     }
@@ -113,7 +117,7 @@ export function createStagingCloudReceipt(argv) {
     fail("failed outcome must mark continuity-evidence unavailable");
   }
 
-  return {
+  const receipt = {
     schemaVersion: 2,
     lane: "app-live-e2e-cloud-staging",
     sourceSha,
@@ -159,6 +163,55 @@ export function createStagingCloudReceipt(argv) {
       deployedRendererTested: false,
       loginPersonalIdentityChatPassed: outcome === "success",
       historyContinuityPassed: continuityVerified,
+    },
+  };
+
+  const deployedProofPath = values.get("deployed-proof-file");
+  if (!deployedProofPath) return receipt;
+  if (outcome !== "success") {
+    fail("deployed proof requires a successful outcome");
+  }
+  const deployedProofRaw = readFileSync(resolve(deployedProofPath), "utf8");
+  let deployedProofValue;
+  try {
+    deployedProofValue = JSON.parse(deployedProofRaw);
+  } catch {
+    // error-policy:J3 a malformed proof file cannot become deployed evidence.
+    fail("deployed-proof-file must contain valid JSON");
+  }
+  const deployedProof = parseDeployedRendererProof(deployedProofValue);
+  const runId = positiveInteger(values.get("run-id"), "run-id");
+  const runAttempt = positiveInteger(values.get("run-attempt"), "run-attempt");
+  if (
+    deployedProof.sourceSha !== sourceSha ||
+    deployedProof.workflow.runId !== runId ||
+    deployedProof.workflow.runAttempt !== runAttempt
+  ) {
+    fail("deployed proof does not match the receipt source/run identity");
+  }
+  if (deployedProof.latency.firstTurnLatencyMs !== firstTurnLatencyMs) {
+    fail("deployed proof latency does not match the receipt measurement");
+  }
+
+  return {
+    ...receipt,
+    schemaVersion: 3,
+    deployment: {
+      proofSha256: createHash("sha256").update(deployedProofRaw).digest("hex"),
+      cloudflarePagesAlias: deployedProof.authority.aliasUrl,
+      deploymentUrl: deployedProof.authority.deploymentUrl,
+      deploymentIdSha256: deployedProof.authority.deploymentIdSha256,
+      rendererBuildId: deployedProof.preflight.renderer.buildId,
+      rendererManifestCommit: deployedProof.sourceSha,
+      publicPreflightPassed: true,
+      remoteBrowserSmokePassed: true,
+      publicPostflightPassed: true,
+    },
+    annotations: {
+      ...receipt.annotations,
+      rendererSource: "cloudflare-pages-alias",
+      deployedRendererTested: true,
+      cloudflarePagesAlias: deployedProof.authority.aliasUrl,
     },
   };
 }


### PR DESCRIPTION
# Relates to

Relates to #18076. This does not close #18076: the product cleanup decision is still required, and the deployed receipt can exist only after this source lands and a canonical staging release executes it.

Related follow-up: #18045 still requires its named warming-retry trajectory on the deployed staging hostname; this PR does not claim that trajectory.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and integrates exact `origin/develop` `5dee7a4c5e054a36f010aae63dd61008c4a3d0a4` via normal merge `fbc517966ab52396eaefd2dc9ff31dd067513119` with zero conflicts.
- [x] The exact Bun `1.3.14` focused suite was run after sync. A full install/verify was not duplicated in the disk-constrained worktree; the exact unrelated base failure is recorded below.
- [x] A reviewer can confirm the fail-closed proof derivation from the contract tests and independent exact-head reviews summarized below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/GPT-5.6`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Integrated exact `origin/develop` `5dee7a4c5e054a36f010aae63dd61008c4a3d0a4` via normal non-rewriting merge `fbc517966ab52396eaefd2dc9ff31dd067513119`; zero conflicts.
- [x] Relevant post-sync validation passes. The one widened-suite failure is reproduced by exact name on a clean base worktree and documented below.

# Risks

Medium, fail-closed release-workflow change.

- The staging bearer is exposed only to the Chromium step. The first deployed page load is public; the exact top-level Pages origin, renderer manifest, and build-time staging API origin must all validate before browser storage receives the bearer. All three are revalidated after reload and in the fresh context.
- Wrangler Pages output is accepted only as the two audited `4.100.0` NDJSON records. Provider schema drift fails the release rather than manufacturing authority.
- Raw Wrangler output, Playwright traces/screenshots/video, browser proof inputs, bearer values, responses, and model content are never uploaded. Only closed authority and the final secret-free receipt are artifacts.
- The browser runs on `https://develop.eliza-app.pages.dev`. This proves the deployed Pages renderer on the canonical branch alias; it does not exercise hostname-gated behavior unique to `https://cloud-staging.eliza.app` and is not presented as #18045 warming proof.
- The real remote lane spends staging model credits only after merge and an explicit `run_deployed_renderer_staging=true` dispatch (or the existing repo/org opt-in). This PR does not arm a schedule or a global variable.

# Background

## What does this PR do?

- Binds the Pages deployment to the exact source SHA with `--commit-hash` and closes Wrangler's append-only output into a strict, privacy-safe authority record.
- Byte-verifies the canonical develop Pages alias in addition to staging custom domains.
- Adds a staging-only Chromium job after Pages deploy and routing verification. It accepts the existing repo/org opt-in or a one-shot dispatch input; the one-shot is restricted to `develop` + staging + `force=false` and fails explicitly when a fresh Pages deployment or routing proof is absent.
- Combines deployment authority, preflight, remote browser smoke, latency, continuity, and postflight into one strict proof bound to the same SHA, workflow run/attempt, renderer build, API origin, and latency.
- Keeps the existing schema-v2 local receipt honest. Schema v3 and `deployedRendererTested=true` can be derived only from the validated proof file; there is no boolean escape hatch.

Prior authors inventoried before the added caller/admission work. Existing proof surfaces: Shaw (`shawmakesmagic@gmail.com`, `shawgotbags@gmail.com`), nubs / NubsCarson (`nubs@nubs.site`), Stan / standujar (`s.andujar@proton.me`), and raynord22. Newly touched canonical deploy caller: Bill Ding, Claude Fable 5, Marco Guaspari Worms / MarcoWorms, Odilitime, Sayo, Shaw (`shaw@elizalabs.ai` plus the identities above), Sol, agent-cortex, dependabot[bot], lalalune (`elizamakesmagic@gmail.com`, `shaw.nicola.walters@gmail.com`), and the already listed Nubs/Stan/raynord22 identities. The new deployed-browser workflow contract had no base history.

## What kind of change is this?

Improvement: release attestation and deployed E2E coverage. No production UI implementation is changed.

# Documentation changes needed?

No user-facing documentation change is required. The workflow, proof schemas, and fail-closed limitations are documented inline and covered by contract tests.

# Testing

## Where should a reviewer start?

1. `packages/cloud/scripts/pages-deployment-authority.mjs` — closed authority/public/proof schemas.
2. `.github/workflows/cloud-cf-release.yml` — release ordering, secret boundary, and artifact boundary.
3. `packages/app/test/ui-smoke/cloud-live.spec.ts` — public-first deployed browser auth and continuity trajectory.
4. `packages/scripts/write-staging-cloud-receipt.mjs` — the only path to schema v3 / `deployedRendererTested=true`.

## Detailed testing steps

Exact PR head: `fbc517966ab52396eaefd2dc9ff31dd067513119`.

- Bun `1.3.14`: 69/69 focused tests, 394 assertions, across authority, receipt, workflow, app-live, release-admission, canonical-source, continuity, and Pages deployment contracts.
- Biome: all ten changed TS/MJS files pass with no fixes.
- `actionlint .github/workflows/cloud-cf-deploy.yml .github/workflows/cloud-cf-release.yml`: exit 0.
- Playwright remote config `--list`: exactly one Chromium test; no local web server.
- `git diff --check origin/develop...HEAD`: exit 0.
- Independent exact-head review at `fbc517966ab52396eaefd2dc9ff31dd067513119`: GO with no P0/P1/P2. It confirmed the one-shot runs fail-closed across failed/skipped prerequisites, certification cannot succeed without the proof/receipt/upload, production/force/wrong-ref requests are rejected before release, and the twelve-file PR diff remains scoped. Refreshed reviewer rerun: 35/35 tests, 160 assertions.
- Widened contract: 21 pass / 1 fail. The exact failure `canonical cloud deployment environment contract > verifies required Worker binding names after deploy without reading values` reproduces on clean base `5dee7a4c5e054a36f010aae63dd61008c4a3d0a4`: the untouched test expects `wrangler@4.100.0 secret list`, while the untouched workflow uses `4.116.0`.

# Evidence Gate

<!-- evidence-head:fbc517966ab52396eaefd2dc9ff31dd067513119 -->

This diff changes workflow and test/attestation code, not a rendered UI component or style. The remote credentialed proof is intentionally generated only by the post-merge canonical release; no local-checkout artifact is relabeled as deployed evidence.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - no rendered UI surface changes; the remote lane retains no credentialed video by design.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - source-only release attestation change; the real canonical receipt is a post-merge acceptance artifact.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - secret-bearing Playwright output is deliberately not retained or uploaded.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior changes; this only hosts an existing trajectory on deployed Pages.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - the deployed receipt cannot truthfully exist before the source is merged and released.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt, model, provider, agent, or action behavior changes. The existing real staging chat trajectory remains credentialed and will run only in the canonical release lane.

## Backend + frontend logs

N/A pre-merge. The durable output is intentionally limited to the closed, secret-free receipt from the real deployed run; raw browser/network/model output is not an artifact.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI implementation changes.

## Audio / voice walkthrough

N/A - no audio, voice, TTS, or STT changes.

## Known gaps / failures

- A real `deployedRendererTested=true` receipt remains pending merge plus one explicit canonical staging dispatch with `run_deployed_renderer_staging=true` and `force=false`. No workflow has been dispatched and no local result is relabeled.
- #18076 remains blocked on the cleanup product decision independently of this code.
- #18045 remains open: this lane does not assert named warming retries or the absence of its Retry chip on the custom staging hostname.
- The full monorepo install/`bun run verify` was not duplicated due local disk constraints. Focused exact-head validation used an existing frozen dependency tree with Bun `1.3.14`; the only widened-suite failure is the exact clean-base mismatch named above.
- Full app typecheck is not claimed from the borrowed-dependency worktree. Changed TypeScript/MJS files pass Biome, contract tests, and Playwright discovery.

AI provider/model: OpenAI / GPT-5.6
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-deployed-renderer-proof]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5.6","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->



