### PR TITLE
fix(cloud): strictly parse SMTP_PORT and reject empty port at initialization boundary

### DIFF
--- a/packages/cloud/shared/src/lib/services/email.port.test.ts
+++ b/packages/cloud/shared/src/lib/services/email.port.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for strict SMTP_PORT parsing in EmailService.
+ *
+ * Drives production seam: imports resolveSmtpPort and SmtpPortConfigError from
+ * email.ts and exercises EmailService initialization with a mocked transporter.
+ * Reverting production validation (e.g., fallback to 587) makes this suite red.
+ */
+
+import nodemailer from "nodemailer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EmailService, resolveSmtpPort, SmtpPortConfigError } from "./email";
+
+const originalEnv = {
+  SMTP_HOST: process.env.SMTP_HOST,
+  SMTP_PORT: process.env.SMTP_PORT,
+  SMTP_PASSWORD: process.env.SMTP_PASSWORD,
+  SMTP_USERNAME: process.env.SMTP_USERNAME,
+};
+
+function restoreEnv(): void {
+  if (originalEnv.SMTP_HOST === undefined) delete process.env.SMTP_HOST;
+  else process.env.SMTP_HOST = originalEnv.SMTP_HOST;
+  if (originalEnv.SMTP_PORT === undefined) delete process.env.SMTP_PORT;
+  else process.env.SMTP_PORT = originalEnv.SMTP_PORT;
+  if (originalEnv.SMTP_PASSWORD === undefined) delete process.env.SMTP_PASSWORD;
+  else process.env.SMTP_PASSWORD = originalEnv.SMTP_PASSWORD;
+  if (originalEnv.SMTP_USERNAME === undefined) delete process.env.SMTP_USERNAME;
+  else process.env.SMTP_USERNAME = originalEnv.SMTP_USERNAME;
+}
+
+describe("resolveSmtpPort strict parsing", () => {
+  it("parses valid canonical ports and trims surrounding whitespace", () => {
+    expect(resolveSmtpPort("587")).toBe(587);
+    expect(resolveSmtpPort("465")).toBe(465);
+    expect(resolveSmtpPort("25")).toBe(25);
+    expect(resolveSmtpPort("2525")).toBe(2525);
+    expect(resolveSmtpPort(" 2525 ")).toBe(2525);
+    expect(resolveSmtpPort("\t587\n")).toBe(587);
+    expect(resolveSmtpPort("1")).toBe(1);
+    expect(resolveSmtpPort("65535")).toBe(65535);
+  });
+
+  it("rejects trailing junk (parseInt would accept)", () => {
+    for (const bad of ["587abc", "25junk", "587 ", "587\nabc", "465xyz", "25 ", "90abc"]) {
+      // note: "587 " with trailing space is caught after trim? "587 " trim => "587" valid, so use "587abc"
+      if (bad === "587 " || bad === "25 ") continue;
+      expect(() => resolveSmtpPort(bad)).toThrow(SmtpPortConfigError);
+    }
+    expect(() => resolveSmtpPort("587abc")).toThrow(SmtpPortConfigError);
+    expect(() => resolveSmtpPort("25junk")).toThrow(SmtpPortConfigError);
+    expect(() => resolveSmtpPort("90abc")).toThrow(SmtpPortConfigError);
+  });
+
+  it("rejects decimal and exponent forms", () => {
+    for (const bad of ["587.5", "587.0", "1e3", "1E3", "5e-324", "0x10", "1.0", "0xFF"]) {
+      expect(() => resolveSmtpPort(bad)).toThrow(SmtpPortConfigError);
+    }
+  });
+
+  it("rejects signed and leading-zero variants", () => {
+    for (const bad of ["-25", "+25", "-1", "+587", "007", "0587", "00", "0123", "0001"]) {
+      expect(() => resolveSmtpPort(bad)).toThrow(SmtpPortConfigError);
+    }
+  });
+
+  it("rejects whitespace-only and empty", () => {
+    for (const bad of ["", "   ", "\t", "\n", " \t\n "]) {
+      expect(() => resolveSmtpPort(bad)).toThrow(SmtpPortConfigError);
+    }
+  });
+
+  it("rejects out-of-range and non-canonical bounds", () => {
+    expect(() => resolveSmtpPort("0")).toThrow(SmtpPortConfigError);
+    expect(() => resolveSmtpPort("00")).toThrow(SmtpPortConfigError);
+    expect(() => resolveSmtpPort("65536")).toThrow(SmtpPortConfigError);
+    expect(() => resolveSmtpPort("70000")).toThrow(SmtpPortConfigError);
+    expect(() => resolveSmtpPort("99999")).toThrow(SmtpPortConfigError);
+    expect(() => resolveSmtpPort("1000000")).toThrow(SmtpPortConfigError);
+  });
+
+  it("is mutation-sensitive: reverting to parseInt fallback would not throw for trailing junk", () => {
+    // This test documents mutation proof: with the old `Number.parseInt(...,10) || 587`
+    // fallback, "587abc" would be parsed as 587 and not throw, making this fail.
+    expect(() => resolveSmtpPort("587abc")).toThrow(SmtpPortConfigError);
+    expect(() => resolveSmtpPort("1e3")).toThrow(SmtpPortConfigError);
+    expect(() => resolveSmtpPort("007")).toThrow(SmtpPortConfigError);
+    expect(() => resolveSmtpPort("  ")).toThrow(SmtpPortConfigError);
+    expect(() => resolveSmtpPort("65536")).toThrow(SmtpPortConfigError);
+  });
+});
+
+describe("EmailService SMTP_PORT integration drives production resolver", () => {
+  beforeEach(() => {
+    restoreEnv();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    vi.restoreAllMocks();
+  });
+
+  it("initializes SMTP with a valid strict port via mocked transporter", async () => {
+    process.env.SMTP_HOST = "smtp.example.com";
+    process.env.SMTP_PORT = " 587 ";
+    process.env.SMTP_PASSWORD = "secret";
+    process.env.SMTP_USERNAME = "user@example.com";
+
+    const createSpy = vi
+      .spyOn(nodemailer, "createTransport")
+      .mockReturnValue({ sendMail: vi.fn().mockResolvedValue({}) } as unknown as ReturnType<
+        typeof nodemailer.createTransport
+      >);
+
+    const svc = new EmailService();
+    // Access private initialize via bracket to prove production path is exercised
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (svc as any).initialize();
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(createSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ port: 587, host: "smtp.example.com" }),
+    );
+
+    // Verify send path also uses the same transporter without re-throwing
+    await expect((svc as any).initialize()).not.toThrow;
+  });
+
+  it("throws SmtpPortConfigError at init boundary for trailing junk (does not fallback to 587)", () => {
+    process.env.SMTP_HOST = "smtp.example.com";
+    process.env.SMTP_PORT = "587abc";
+    process.env.SMTP_PASSWORD = "secret";
+
+    const createSpy = vi.spyOn(nodemailer, "createTransport");
+
+    const svc = new EmailService();
+    expect(() => (svc as any).initialize()).toThrow(SmtpPortConfigError);
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("throws for decimal, exponent, signed, and leading-zero forms via EmailService", () => {
+    const cases = ["587.5", "1e3", "-25", "+25", "007", "0587"];
+    for (const badPort of cases) {
+      process.env.SMTP_HOST = "smtp.example.com";
+      process.env.SMTP_PORT = badPort;
+      process.env.SMTP_PASSWORD = "secret";
+      const svc = new EmailService();
+      expect(() => (svc as any).initialize()).toThrow(SmtpPortConfigError);
+    }
+  });
+
+  it("throws for whitespace-only and out-of-range via EmailService (no silent 587)", () => {
+    for (const badPort of ["   ", "0", "65536", "70000"]) {
+      process.env.SMTP_HOST = "smtp.example.com";
+      process.env.SMTP_PORT = badPort;
+      process.env.SMTP_PASSWORD = "secret";
+      const svc = new EmailService();
+      expect(() => (svc as any).initialize()).toThrow(SmtpPortConfigError);
+    }
+  });
+
+  it("throws typed SmtpPortConfigError (not generic Error) so callers can branch", () => {
+    process.env.SMTP_HOST = "smtp.example.com";
+    process.env.SMTP_PORT = "not-a-port";
+    process.env.SMTP_PASSWORD = "secret";
+    const svc = new EmailService();
+    try {
+      (svc as any).initialize();
+      throw new Error("expected to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(SmtpPortConfigError);
+      expect((error as Error).name).toBe("SmtpPortConfigError");
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/email.port.test.ts
+++ b/packages/cloud/shared/src/lib/services/email.port.test.ts
@@ -6,6 +6,7 @@
  * Reverting production validation (e.g., fallback to 587) makes this suite red.
  */
 
+import sgMail from "@sendgrid/mail";
 import nodemailer from "nodemailer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EmailService, resolveSmtpPort, SmtpPortConfigError } from "./email";
@@ -166,6 +167,33 @@ describe("EmailService SMTP_PORT integration drives production resolver", () => 
     expect(() => (svc as unknown as { initialize: () => void }).initialize()).toThrow(
       SmtpPortConfigError,
     );
+  });
+
+  it("initializes SendGrid when SMTP host and password are absent even if SMTP_PORT is empty", async () => {
+    delete process.env.SMTP_HOST;
+    delete process.env.SMTP_PASSWORD;
+    process.env.SMTP_PORT = "";
+    process.env.SENDGRID_API_KEY = "SG.test-api-key";
+
+    const createSpy = vi.spyOn(nodemailer, "createTransport");
+    vi.spyOn(sgMail, "setApiKey").mockImplementation(() => {});
+    const sendSpy = vi
+      .spyOn(sgMail, "send")
+      .mockResolvedValue([{ statusCode: 202 }, {}] as unknown as Awaited<
+        ReturnType<typeof sgMail.send>
+      >);
+
+    const svc = new EmailService();
+    await expect(
+      svc.send({
+        to: "recipient@example.com",
+        subject: "Test Subject",
+        text: "Test body content",
+      }),
+    ).resolves.toBe(true);
+
+    expect(createSpy).not.toHaveBeenCalled();
+    expect(sendSpy).toHaveBeenCalledTimes(1);
   });
 
   it("throws for decimal, exponent, signed, and leading-zero forms via EmailService", () => {

--- a/packages/cloud/shared/src/lib/services/email.port.test.ts
+++ b/packages/cloud/shared/src/lib/services/email.port.test.ts
@@ -1,8 +1,8 @@
 /**
- * Tests for strict SMTP_PORT parsing in EmailService.
+ * Tests for strict SMTP_PORT parsing and initialization boundary validation in EmailService.
  *
  * Drives production seam: imports resolveSmtpPort and SmtpPortConfigError from
- * email.ts and exercises EmailService initialization with a mocked transporter.
+ * email.ts and exercises EmailService initialization and send path with a mocked transporter.
  * Reverting production validation (e.g., fallback to 587) makes this suite red.
  */
 
@@ -15,6 +15,7 @@ const originalEnv = {
   SMTP_PORT: process.env.SMTP_PORT,
   SMTP_PASSWORD: process.env.SMTP_PASSWORD,
   SMTP_USERNAME: process.env.SMTP_USERNAME,
+  SENDGRID_API_KEY: process.env.SENDGRID_API_KEY,
 };
 
 function restoreEnv(): void {
@@ -26,6 +27,8 @@ function restoreEnv(): void {
   else process.env.SMTP_PASSWORD = originalEnv.SMTP_PASSWORD;
   if (originalEnv.SMTP_USERNAME === undefined) delete process.env.SMTP_USERNAME;
   else process.env.SMTP_USERNAME = originalEnv.SMTP_USERNAME;
+  if (originalEnv.SENDGRID_API_KEY === undefined) delete process.env.SENDGRID_API_KEY;
+  else process.env.SENDGRID_API_KEY = originalEnv.SENDGRID_API_KEY;
 }
 
 describe("resolveSmtpPort strict parsing", () => {
@@ -41,14 +44,9 @@ describe("resolveSmtpPort strict parsing", () => {
   });
 
   it("rejects trailing junk (parseInt would accept)", () => {
-    for (const bad of ["587abc", "25junk", "587 ", "587\nabc", "465xyz", "25 ", "90abc"]) {
-      // note: "587 " with trailing space is caught after trim? "587 " trim => "587" valid, so use "587abc"
-      if (bad === "587 " || bad === "25 ") continue;
+    for (const bad of ["587abc", "25junk", "587\nabc", "465xyz", "90abc", "25px"]) {
       expect(() => resolveSmtpPort(bad)).toThrow(SmtpPortConfigError);
     }
-    expect(() => resolveSmtpPort("587abc")).toThrow(SmtpPortConfigError);
-    expect(() => resolveSmtpPort("25junk")).toThrow(SmtpPortConfigError);
-    expect(() => resolveSmtpPort("90abc")).toThrow(SmtpPortConfigError);
   });
 
   it("rejects decimal and exponent forms", () => {
@@ -63,15 +61,14 @@ describe("resolveSmtpPort strict parsing", () => {
     }
   });
 
-  it("rejects whitespace-only and empty", () => {
-    for (const bad of ["", "   ", "\t", "\n", " \t\n "]) {
+  it("rejects whitespace-only, empty, null, and undefined inputs", () => {
+    for (const bad of ["", "   ", "\t", "\n", " \t\n ", null, undefined as unknown as string]) {
       expect(() => resolveSmtpPort(bad)).toThrow(SmtpPortConfigError);
     }
   });
 
   it("rejects out-of-range and non-canonical bounds", () => {
     expect(() => resolveSmtpPort("0")).toThrow(SmtpPortConfigError);
-    expect(() => resolveSmtpPort("00")).toThrow(SmtpPortConfigError);
     expect(() => resolveSmtpPort("65536")).toThrow(SmtpPortConfigError);
     expect(() => resolveSmtpPort("70000")).toThrow(SmtpPortConfigError);
     expect(() => resolveSmtpPort("99999")).toThrow(SmtpPortConfigError);
@@ -79,8 +76,6 @@ describe("resolveSmtpPort strict parsing", () => {
   });
 
   it("is mutation-sensitive: reverting to parseInt fallback would not throw for trailing junk", () => {
-    // This test documents mutation proof: with the old `Number.parseInt(...,10) || 587`
-    // fallback, "587abc" would be parsed as 587 and not throw, making this fail.
     expect(() => resolveSmtpPort("587abc")).toThrow(SmtpPortConfigError);
     expect(() => resolveSmtpPort("1e3")).toThrow(SmtpPortConfigError);
     expect(() => resolveSmtpPort("007")).toThrow(SmtpPortConfigError);
@@ -100,30 +95,39 @@ describe("EmailService SMTP_PORT integration drives production resolver", () => 
     vi.restoreAllMocks();
   });
 
-  it("initializes SMTP with a valid strict port via mocked transporter", async () => {
+  it("initializes SMTP with a valid strict port and sends via mocked transporter", async () => {
     process.env.SMTP_HOST = "smtp.example.com";
     process.env.SMTP_PORT = " 587 ";
     process.env.SMTP_PASSWORD = "secret";
     process.env.SMTP_USERNAME = "user@example.com";
 
+    const sendMailMock = vi.fn().mockResolvedValue({ messageId: "msg-123" });
     const createSpy = vi
       .spyOn(nodemailer, "createTransport")
-      .mockReturnValue({ sendMail: vi.fn().mockResolvedValue({}) } as unknown as ReturnType<
+      .mockReturnValue({ sendMail: sendMailMock } as unknown as ReturnType<
         typeof nodemailer.createTransport
       >);
 
     const svc = new EmailService();
-    // Access private initialize via bracket to prove production path is exercised
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (svc as any).initialize();
+    const result = await svc.send({
+      to: "recipient@example.com",
+      subject: "Test Subject",
+      text: "Test body content",
+    });
 
+    expect(result).toBe(true);
     expect(createSpy).toHaveBeenCalledTimes(1);
     expect(createSpy).toHaveBeenCalledWith(
       expect.objectContaining({ port: 587, host: "smtp.example.com" }),
     );
-
-    // Verify send path also uses the same transporter without re-throwing
-    await expect((svc as any).initialize()).not.toThrow;
+    expect(sendMailMock).toHaveBeenCalledTimes(1);
+    expect(sendMailMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "recipient@example.com",
+        subject: "Test Subject",
+        text: "Test body content",
+      }),
+    );
   });
 
   it("throws SmtpPortConfigError at init boundary for trailing junk (does not fallback to 587)", () => {
@@ -132,10 +136,36 @@ describe("EmailService SMTP_PORT integration drives production resolver", () => 
     process.env.SMTP_PASSWORD = "secret";
 
     const createSpy = vi.spyOn(nodemailer, "createTransport");
+    const svc = new EmailService();
+    expect(() => (svc as unknown as { initialize: () => void }).initialize()).toThrow(
+      SmtpPortConfigError,
+    );
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("throws SmtpPortConfigError at init boundary when SMTP_PORT is empty string", () => {
+    process.env.SMTP_HOST = "smtp.example.com";
+    process.env.SMTP_PORT = "";
+    process.env.SMTP_PASSWORD = "secret";
+
+    const createSpy = vi.spyOn(nodemailer, "createTransport");
+    const svc = new EmailService();
+    expect(() => (svc as unknown as { initialize: () => void }).initialize()).toThrow(
+      SmtpPortConfigError,
+    );
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("throws SmtpPortConfigError and does not bypass to SendGrid when SMTP_PORT is empty string", () => {
+    process.env.SMTP_HOST = "smtp.example.com";
+    process.env.SMTP_PORT = "";
+    process.env.SMTP_PASSWORD = "secret";
+    process.env.SENDGRID_API_KEY = "SG.test-api-key";
 
     const svc = new EmailService();
-    expect(() => (svc as any).initialize()).toThrow(SmtpPortConfigError);
-    expect(createSpy).not.toHaveBeenCalled();
+    expect(() => (svc as unknown as { initialize: () => void }).initialize()).toThrow(
+      SmtpPortConfigError,
+    );
   });
 
   it("throws for decimal, exponent, signed, and leading-zero forms via EmailService", () => {
@@ -145,7 +175,9 @@ describe("EmailService SMTP_PORT integration drives production resolver", () => 
       process.env.SMTP_PORT = badPort;
       process.env.SMTP_PASSWORD = "secret";
       const svc = new EmailService();
-      expect(() => (svc as any).initialize()).toThrow(SmtpPortConfigError);
+      expect(() => (svc as unknown as { initialize: () => void }).initialize()).toThrow(
+        SmtpPortConfigError,
+      );
     }
   });
 
@@ -155,7 +187,9 @@ describe("EmailService SMTP_PORT integration drives production resolver", () => 
       process.env.SMTP_PORT = badPort;
       process.env.SMTP_PASSWORD = "secret";
       const svc = new EmailService();
-      expect(() => (svc as any).initialize()).toThrow(SmtpPortConfigError);
+      expect(() => (svc as unknown as { initialize: () => void }).initialize()).toThrow(
+        SmtpPortConfigError,
+      );
     }
   });
 
@@ -165,7 +199,7 @@ describe("EmailService SMTP_PORT integration drives production resolver", () => 
     process.env.SMTP_PASSWORD = "secret";
     const svc = new EmailService();
     try {
-      (svc as any).initialize();
+      (svc as unknown as { initialize: () => void }).initialize();
       throw new Error("expected to throw");
     } catch (error) {
       expect(error).toBeInstanceOf(SmtpPortConfigError);

--- a/packages/cloud/shared/src/lib/services/email.ts
+++ b/packages/cloud/shared/src/lib/services/email.ts
@@ -20,9 +20,51 @@ import type {
 import { logger } from "../utils/logger";
 
 /**
+ * Typed configuration error for an invalid SMTP port.
+ * Thrown at the initialization boundary when SMTP_PORT is present but malformed,
+ * so operator misconfiguration is not masked as healthy SMTP setup.
+ */
+export class SmtpPortConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SmtpPortConfigError";
+  }
+}
+
+/**
+ * Canonical decimal-integer grammar: "0" or a non-zero-leading digit string.
+ * Rejects sign, decimals, exponent, hex, or trailing junk.
+ */
+const CANONICAL_DECIMAL_INTEGER_GRAMMAR = /^(?:0|[1-9][0-9]*)$/;
+
+/**
+ * Strictly resolves an SMTP port string.
+ *
+ * Validates the complete trimmed string against the canonical decimal-integer
+ * grammar before conversion, then enforces the TCP port range 1..65535.
+ * Throws {@link SmtpPortConfigError} for any present invalid value.
+ *
+ * @param raw - Raw SMTP_PORT value (trimmed before validation).
+ * @returns Parsed port number in 1..65535.
+ */
+export function resolveSmtpPort(raw: string): number {
+  const trimmed = raw.trim();
+  if (!CANONICAL_DECIMAL_INTEGER_GRAMMAR.test(trimmed)) {
+    throw new SmtpPortConfigError(
+      `Invalid SMTP_PORT "${raw}": must be a canonical decimal integer`,
+    );
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed < 1 || parsed > 65535) {
+    throw new SmtpPortConfigError(`Invalid SMTP_PORT "${raw}": must be in range 1..65535`);
+  }
+  return parsed;
+}
+
+/**
  * Email service supporting SendGrid API and SMTP.
  */
-class EmailService {
+export class EmailService {
   private initialized = false;
   private fromEmail: string | null = null;
   private smtpTransporter: Transporter<SMTPTransport.SentMessageInfo> | null = null;
@@ -36,9 +78,10 @@ class EmailService {
 
     if (process.env.SMTP_HOST && process.env.SMTP_PORT && process.env.SMTP_PASSWORD) {
       logger.info("[EmailService] Using SMTP configuration");
+      const port = resolveSmtpPort(process.env.SMTP_PORT);
       this.smtpTransporter = nodemailer.createTransport({
         host: process.env.SMTP_HOST,
-        port: parseInt(process.env.SMTP_PORT),
+        port,
         secure: false,
         auth: {
           user: process.env.SMTP_USERNAME || "apikey",

--- a/packages/cloud/shared/src/lib/services/email.ts
+++ b/packages/cloud/shared/src/lib/services/email.ts
@@ -79,32 +79,22 @@ export class EmailService {
     this.fromEmail =
       process.env.SENDGRID_FROM_EMAIL || process.env.SMTP_FROM || "noreply@eliza.app";
 
-    const hasSmtpConfig =
-      Boolean(process.env.SMTP_HOST) ||
-      Boolean(process.env.SMTP_PASSWORD) ||
-      typeof process.env.SMTP_PORT === "string";
-
-    if (hasSmtpConfig) {
-      if (process.env.SMTP_HOST && process.env.SMTP_PASSWORD) {
-        logger.info("[EmailService] Using SMTP configuration");
-        const port = resolveSmtpPort(process.env.SMTP_PORT);
-        this.smtpTransporter = nodemailer.createTransport({
-          host: process.env.SMTP_HOST,
-          port,
-          secure: false,
-          auth: {
-            user: process.env.SMTP_USERNAME || "apikey",
-            pass: process.env.SMTP_PASSWORD,
-          },
-        });
-        this.useSmtp = true;
-        this.initialized = true;
-        logger.info("[EmailService] Initialized with SMTP");
-        return;
-      }
-      if (typeof process.env.SMTP_PORT === "string") {
-        resolveSmtpPort(process.env.SMTP_PORT);
-      }
+    if (process.env.SMTP_HOST && process.env.SMTP_PASSWORD) {
+      logger.info("[EmailService] Using SMTP configuration");
+      const port = resolveSmtpPort(process.env.SMTP_PORT);
+      this.smtpTransporter = nodemailer.createTransport({
+        host: process.env.SMTP_HOST,
+        port,
+        secure: false,
+        auth: {
+          user: process.env.SMTP_USERNAME || "apikey",
+          pass: process.env.SMTP_PASSWORD,
+        },
+      });
+      this.useSmtp = true;
+      this.initialized = true;
+      logger.info("[EmailService] Initialized with SMTP");
+      return;
     }
 
     const apiKey = process.env.SENDGRID_API_KEY;

--- a/packages/cloud/shared/src/lib/services/email.ts
+++ b/packages/cloud/shared/src/lib/services/email.ts
@@ -47,7 +47,10 @@ const CANONICAL_DECIMAL_INTEGER_GRAMMAR = /^(?:0|[1-9][0-9]*)$/;
  * @param raw - Raw SMTP_PORT value (trimmed before validation).
  * @returns Parsed port number in 1..65535.
  */
-export function resolveSmtpPort(raw: string): number {
+export function resolveSmtpPort(raw: string | undefined | null): number {
+  if (typeof raw !== "string") {
+    throw new SmtpPortConfigError("Invalid SMTP_PORT: port string is required");
+  }
   const trimmed = raw.trim();
   if (!CANONICAL_DECIMAL_INTEGER_GRAMMAR.test(trimmed)) {
     throw new SmtpPortConfigError(
@@ -76,22 +79,32 @@ export class EmailService {
     this.fromEmail =
       process.env.SENDGRID_FROM_EMAIL || process.env.SMTP_FROM || "noreply@eliza.app";
 
-    if (process.env.SMTP_HOST && process.env.SMTP_PORT && process.env.SMTP_PASSWORD) {
-      logger.info("[EmailService] Using SMTP configuration");
-      const port = resolveSmtpPort(process.env.SMTP_PORT);
-      this.smtpTransporter = nodemailer.createTransport({
-        host: process.env.SMTP_HOST,
-        port,
-        secure: false,
-        auth: {
-          user: process.env.SMTP_USERNAME || "apikey",
-          pass: process.env.SMTP_PASSWORD,
-        },
-      });
-      this.useSmtp = true;
-      this.initialized = true;
-      logger.info("[EmailService] Initialized with SMTP");
-      return;
+    const hasSmtpConfig =
+      Boolean(process.env.SMTP_HOST) ||
+      Boolean(process.env.SMTP_PASSWORD) ||
+      typeof process.env.SMTP_PORT === "string";
+
+    if (hasSmtpConfig) {
+      if (process.env.SMTP_HOST && process.env.SMTP_PASSWORD) {
+        logger.info("[EmailService] Using SMTP configuration");
+        const port = resolveSmtpPort(process.env.SMTP_PORT);
+        this.smtpTransporter = nodemailer.createTransport({
+          host: process.env.SMTP_HOST,
+          port,
+          secure: false,
+          auth: {
+            user: process.env.SMTP_USERNAME || "apikey",
+            pass: process.env.SMTP_PASSWORD,
+          },
+        });
+        this.useSmtp = true;
+        this.initialized = true;
+        logger.info("[EmailService] Initialized with SMTP");
+        return;
+      }
+      if (typeof process.env.SMTP_PORT === "string") {
+        resolveSmtpPort(process.env.SMTP_PORT);
+      }
     }
 
     const apiKey = process.env.SENDGRID_API_KEY;

--- a/packages/cloud/shared/vitest.config.ts
+++ b/packages/cloud/shared/vitest.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
       "src/lib/services/headscale-client.test.ts",
       "src/lib/services/steward-platform-users.error-policy.test.ts",
       "src/lib/utils/whatsapp-api.test.ts",
+      "src/lib/services/email.port.test.ts",
     ],
     environment: "node",
     // PGlite's WASM worker outlives Vitest's fork shutdown grace even after


### PR DESCRIPTION
### Summary
Strictly parse and validate `SMTP_PORT` with canonical decimal-integer grammar and TCP port bounds `[1, 65535]`, throwing typed `SmtpPortConfigError` at initialization boundary on malformed/empty port configuration rather than masking misconfiguration or silently bypassing to SendGrid.

### Root Cause
1. `EmailService.initialize` in `packages/cloud/shared/src/lib/services/email.ts` previously used bare `parseInt(process.env.SMTP_PORT)`. Bare `parseInt` accepts trailing junk (`"587abc"` -> `587`), decimals (`"587.5"` -> `587`), and leading-zero octal-like forms.
2. The initialization gate `if (process.env.SMTP_HOST && process.env.SMTP_PORT && process.env.SMTP_PASSWORD)` used a truthy check on `SMTP_PORT`. When `SMTP_PORT=""` or whitespace was provided with `SMTP_HOST` and `SMTP_PASSWORD`, the condition evaluated to `false`, bypassing SMTP port validation and leaving the service uninitialized or silently selecting SendGrid.

### Solution
- Added `SmtpPortConfigError` typed error class for actionable fail-fast configuration error reporting per repository error policy.
- Added strict `resolveSmtpPort` function that validates raw inputs against `/^(?:0|[1-9][0-9]*)$/` canonical decimal-integer grammar and enforces `1 <= port <= 65535`.
- Updated `EmailService.initialize()` to detect SMTP presence independently of `SMTP_PORT` truthiness and validate `SMTP_PORT` at the initialization boundary before configuring nodemailer.
- Added comprehensive unit and integration tests in `email.port.test.ts` driving production `resolveSmtpPort` and `EmailService.send()` with mocked `nodemailer.createTransport` and `sendMail`, covering valid ports, trailing junk, decimals/exponents, leading zeroes, signs, whitespace-only/empty inputs, out-of-range ports, and SendGrid non-bypass.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [elizaOS/eliza — fix(cloud)]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2fab6054d2abb1f322096947a8af7fa5ee720b31:packages/skills/skills/contribute-to-eliza"} -->