### PR TITLE
fix(ci): queue canonical develop push verification

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,15 +6,21 @@ runners, environments, and a concise job graph.
 
 ## Required validation
 
-`ci.yml` is the canonical pull-request, merge-queue, and `develop` branch-health
-workflow. Pull requests targeting `develop` or `main` and every `merge_group`
-candidate run the same fail-closed job graph. Branch rules require only its stable
-`CI / All Tests Passed` aggregate, which succeeds only when every mandatory lane
-succeeds; individual lane names may evolve without silently weakening admission.
-Manual diagnostics use independent concurrency groups, PR and merge candidates
-supersede stale runs, and `develop` pushes share a never-cancelled terminal group.
-GitHub's default single-pending queue therefore lets the running push finish while
-retaining only the newest waiting tip instead of accumulating every merge-wave run.
+`ci.yml` is the reusable canonical pull-request, merge-queue, and `develop`
+branch-health graph. Pull requests targeting `develop` or `main` and every
+`merge_group` candidate run the same fail-closed job graph. Branch rules require
+only its stable `CI / All Tests Passed` aggregate, which succeeds only when every
+mandatory lane succeeds; individual lane names may evolve without silently
+weakening admission. Manual diagnostics use independent concurrency groups, and
+PR and merge candidates supersede stale runs.
+
+`ci-develop-push.yml` owns the sole direct `develop` push trigger for canonical
+CI. Its stable, wrapper-only concurrency group uses `cancel-in-progress: false`
+and `queue: max`, so one branch-health graph runs at a time and GitHub retains up
+to 100 pending merge heads instead of replacing an older pending run. Additional
+arrivals at the platform limit are cancelled, keeping the backlog bounded. The
+wrapper group must remain distinct from `ci.yml`'s internal group because a
+reusable workflow can cancel its caller when both use the same concurrency group.
 
 `merge-candidate-biome.yml` remains a defense-in-depth merge-queue check of
 GitHub's synthesized candidate tree. It runs the repository-pinned full lint and
@@ -54,15 +60,15 @@ force-push/deletion bans remain active here.
 core smoke tests. It never publishes packages or creates releases.
 
 `develop-health.yml` is the canonical uncontended trunk-health lane (#19181).
-Pending push-triggered develop runs can still supersede each other during merge
-waves and hosted capacity can delay their start. This lane independently runs
-the repository verify gate on the live develop tip four times a day (and on
-manual dispatch) from a single hosted runner, in a fixed
-never-cancelled concurrency group, and publishes the outcome as a
-`develop-health` commit status on the exact SHA it measured. A missing status
-means no measurement concluded; a red status means develop is actually red —
-the lane exists to keep those two states distinguishable while the fleet is
-saturated.
+Canonical push-triggered CI now retains up to 100 pending develop heads, but
+hosted capacity can still delay their start and arrivals beyond that platform
+limit are cancelled. This lane independently runs the repository verify gate on
+the live develop tip four times a day (and on manual dispatch) from a single
+hosted runner, in a fixed never-cancelled concurrency group, and publishes the
+outcome as a `develop-health` commit status on the exact SHA it measured. A
+missing status means no measurement concluded; a red status means develop is
+actually red — the lane exists to keep those two states distinguishable while
+the fleet is saturated.
 [![develop health](https://github.com/elizaOS/eliza/actions/workflows/develop-health.yml/badge.svg?branch=develop)](https://github.com/elizaOS/eliza/actions/workflows/develop-health.yml)
 
 ## Scheduled security analysis

--- a/.github/workflows/ci-develop-push.yml
+++ b/.github/workflows/ci-develop-push.yml
@@ -1,0 +1,30 @@
+# Serializes develop pushes before entering the reusable canonical CI graph.
+# `queue: max` retains up to GitHub's bounded limit of 100 pending merge-wave
+# heads instead of replacing an older pending run; arrivals beyond that limit
+# are cancelled. Keep this group distinct from ci.yml's internal group: a caller
+# and called workflow sharing one group can cancel each other.
+name: CI Develop Push
+
+on:
+  push:
+    branches: [develop]
+
+concurrency:
+  group: ci-develop-push-${{ github.ref }}
+  cancel-in-progress: false
+  queue: max
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: Canonical CI
+    # GitHub validates permissions across the full reusable-workflow graph
+    # before evaluating job conditions. These permissions cover ci.yml's
+    # opt-in device caller even though a push can never select that job.
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+    uses: ./.github/workflows/ci.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,23 @@
-# This workflow is the canonical required merge-candidate and develop branch-health
-# validation entry point. Every pull request and merge-group candidate publishes
-# the stable fail-closed `CI / All Tests Passed` admission context.
+# This reusable workflow is the canonical required merge-candidate and develop
+# branch-health validation graph. Every pull request and merge-group candidate
+# publishes the stable fail-closed `CI / All Tests Passed` admission context.
 name: CI
 
 on:
   pull_request:
     branches: [develop, main]
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
-  push:
-    branches: [develop]
   merge_group:
     types: [checks_requested]
   workflow_call:
   workflow_dispatch:
 
-# Manual diagnostics keep a run-scoped identity, while PR and merge-queue runs
-# still supersede stale work. A develop push uses a stable terminal-v2 group
-# with the default single-pending queue: the running verification finishes and
-# GitHub retains only the newest waiting tip. The versioned group also avoids
-# inheriting the pre-fix ci-refs/heads/develop run that can remain retained.
-# Do not add queue: max here; it is incompatible with cancellable PR/merge
-# events and would retain every merge-wave push instead of only the latest.
+# ci-develop-push.yml serializes branch pushes with a distinct queue:max group
+# before calling this graph. Caller-backed push, schedule, and dispatch runs use
+# a run-scoped internal group so Nightly and other reusable callers cannot evict
+# the wrapper's queued work. PR and merge candidates still supersede stale work.
 concurrency:
-  group: ci-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'push' && format('terminal-v2-{0}', github.ref) || github.ref || github.run_id }}
+  group: ci-internal-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'merge_group' && format('merge-{0}', github.ref) || format('run-{0}', github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
 
 permissions:

--- a/.github/workflows/claude-ci-autoheal.yml
+++ b/.github/workflows/claude-ci-autoheal.yml
@@ -29,6 +29,7 @@ on:
   workflow_run:
     workflows:
       - CI
+      - CI Develop Push
       - Develop Exhaustive Lane
       - Quality (Extended)
     types: [completed]

--- a/.github/workflows/develop-health.yml
+++ b/.github/workflows/develop-health.yml
@@ -1,13 +1,14 @@
 # Scheduled, low-footprint canonical health signal for the develop branch
-# (#19181). During merge waves nearly every push-triggered CI run on develop
-# is superseded before finishing, so the branch's true state becomes
-# unobservable through Actions. This lane always checks out the current
-# develop tip on a single hosted runner, runs the repository verify gate, and
-# publishes the outcome as a `develop-health` commit status on the exact SHA
-# it measured — a timestamped signal that survives push storms because it
-# never shares a concurrency group with push-triggered runs and never
-# cancels in progress. It intentionally stays one job wide: fleet saturation
-# is the failure mode being observed, so the observer must not add fan-out.
+# (#19181). During merge waves the bounded canonical push queue can be delayed
+# by hosted capacity and can reject arrivals beyond its 100-pending platform
+# limit, so not every develop head is guaranteed a terminal Actions signal.
+# This lane always checks out the current develop tip on a single hosted runner,
+# runs the repository verify gate, and publishes the outcome as a
+# `develop-health` commit status on the exact SHA it measured — a timestamped
+# signal that survives push storms because it never shares a concurrency group
+# with push-triggered runs and never cancels in progress. It intentionally stays
+# one job wide: fleet saturation is the failure mode being observed, so the
+# observer must not add fan-out.
 name: Develop Health
 
 on:

--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -64,6 +64,8 @@ jobs:
         run: >-
           "$RUNNER_TEMP/workflow-linters/actionlint"
           -config-file .github/actionlint.yaml
+          .github/workflows/claude-ci-autoheal.yml
+          .github/workflows/ci-develop-push.yml
           .github/workflows/ci.yml
           .github/workflows/develop-pr.yml
           .github/workflows/cloud-tests.yml

--- a/packages/scripts/__tests__/ci-path-gate.test.mjs
+++ b/packages/scripts/__tests__/ci-path-gate.test.mjs
@@ -8,6 +8,7 @@ import { unlinkSync, writeFileSync } from "node:fs";
 import { CONFIGS, evaluate, parseGitNameStatus } from "../ci-path-gate.mjs";
 
 const CLASSIFIER_PATH = ".github/workflows/classify-paths.yml";
+const DEVELOP_PUSH_WRAPPER_PATH = ".github/workflows/ci-develop-push.yml";
 const tmpFile = `${import.meta.dir}/.tmp-classifier-only-diff`;
 
 /**
@@ -20,6 +21,22 @@ const tmpFile = `${import.meta.dir}/.tmp-classifier-only-diff`;
  * consumer (#14051 review round 2, P1 finding). This test proves the fix.
  */
 describe("classifier self-registration regression", () => {
+  it("test config triggers all seven lanes for a develop-push wrapper diff", () => {
+    writeFileSync(tmpFile, `${DEVELOP_PUSH_WRAPPER_PATH}\n`);
+    try {
+      const result = evaluate(CONFIGS.test, {
+        eventName: "pull_request",
+        labels: "",
+        changedFilesPath: tmpFile,
+      });
+      for (const lane of CONFIGS.test.outputs) {
+        expect(result.matchesByLane.get(lane).length).toBeGreaterThan(0);
+      }
+    } finally {
+      unlinkSync(tmpFile);
+    }
+  });
+
   it("test config triggers all seven lanes for a classifier-only diff", () => {
     writeFileSync(tmpFile, `${CLASSIFIER_PATH}\n`);
     try {

--- a/packages/scripts/__tests__/ci-workflow-concurrency.test.ts
+++ b/packages/scripts/__tests__/ci-workflow-concurrency.test.ts
@@ -1,7 +1,7 @@
 /**
- * Pins the canonical CI event-specific concurrency contract. This deterministic
- * check protects terminal develop health without weakening stale PR or merge
- * queue cancellation and without creating an unbounded push backlog.
+ * Pins the two-level canonical CI concurrency contract. The push-only wrapper
+ * uses GitHub's bounded max queue while the reusable graph preserves stale PR
+ * and merge-candidate cancellation.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -10,23 +10,50 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
-const workflowPath = join(repoRoot, ".github", "workflows", "ci.yml");
-const workflow = Bun.YAML.parse(readFileSync(workflowPath, "utf8")) as {
+
+type Permissions = Record<string, string>;
+
+interface Workflow {
+  name?: string;
+  on?: Record<string, unknown>;
   concurrency?: {
     group?: string;
     "cancel-in-progress"?: string | boolean;
     queue?: string;
   };
-};
+  permissions?: Permissions;
+  jobs?: Record<
+    string,
+    { uses?: string; permissions?: Permissions; name?: string }
+  >;
+}
 
-describe("ci.yml concurrency contract", () => {
+function readWorkflow(name: string): Workflow {
+  const source = readFileSync(
+    join(repoRoot, ".github", "workflows", name),
+    "utf8",
+  );
+  return Bun.YAML.parse(source) as Workflow;
+}
+
+const workflow = readWorkflow("ci.yml");
+const pushWrapper = readWorkflow("ci-develop-push.yml");
+const autoheal = readWorkflow("claude-ci-autoheal.yml");
+
+describe("ci.yml internal concurrency contract", () => {
   const concurrency = workflow.concurrency;
   const group = concurrency?.group ?? "";
 
-  test("gives every manual diagnostic an independent run-scoped group", () => {
-    expect(group).toContain(
-      "github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id)",
-    );
+  test("has no direct push trigger and remains reusable", () => {
+    expect(workflow.on?.push).toBeUndefined();
+    expect(workflow.on).toHaveProperty("pull_request");
+    expect(workflow.on).toHaveProperty("merge_group");
+    expect(workflow.on).toHaveProperty("workflow_call");
+    expect(workflow.on).toHaveProperty("workflow_dispatch");
+  });
+
+  test("gives caller-backed push, schedule, and dispatch runs independent groups", () => {
+    expect(group).toContain("format('run-{0}', github.run_id)");
   });
 
   test("supersedes pull-request runs by pull-request number", () => {
@@ -36,16 +63,19 @@ describe("ci.yml concurrency contract", () => {
   });
 
   test("supersedes merge-group runs by their stable candidate ref", () => {
-    expect(group).not.toContain("github.event_name == 'merge_group'");
-    expect(group).toContain("|| github.ref || github.run_id");
+    expect(group).toContain(
+      "github.event_name == 'merge_group' && format('merge-{0}', github.ref)",
+    );
   });
 
-  test("lets one develop push finish while retaining only the newest pending tip", () => {
-    expect(group).toContain(
-      "github.event_name == 'push' && format('terminal-v2-{0}', github.ref)",
-    );
-    expect(group).not.toContain("format('terminal-v2-{0}', github.run_id)");
-    expect(group).not.toContain("format('terminal-v2-{0}', github.sha)");
+  test("does not let a Nightly caller collide with a queued develop push", () => {
+    expect(group).not.toContain("|| github.ref || github.run_id");
+    expect(group).not.toContain("github.event_name == 'push'");
+  });
+
+  test("keeps its group distinct from the develop-push wrapper", () => {
+    expect(group).toStartWith("ci-internal-");
+    expect(group).not.toBe(pushWrapper.concurrency?.group);
     expect(concurrency?.queue).toBeUndefined();
   });
 
@@ -53,5 +83,42 @@ describe("ci.yml concurrency contract", () => {
     expect(concurrency?.["cancel-in-progress"]).toBe(
       `\${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}`,
     );
+  });
+});
+
+describe("ci-develop-push.yml queue contract", () => {
+  const concurrency = pushWrapper.concurrency;
+  const group = concurrency?.group ?? "";
+  const job = pushWrapper.jobs?.ci;
+
+  test("owns only the direct develop push trigger", () => {
+    expect(pushWrapper.name).toBe("CI Develop Push");
+    expect(Object.keys(pushWrapper.on ?? {})).toEqual(["push"]);
+    expect(pushWrapper.on?.push).toEqual({ branches: ["develop"] });
+  });
+
+  test("uses one stable bounded max queue without run-scoped identity", () => {
+    expect(group).toBe(`ci-develop-push-\${{ github.ref }}`);
+    expect(group).not.toContain("github.run_id");
+    expect(group).not.toContain("github.sha");
+    expect(concurrency?.["cancel-in-progress"]).toBe(false);
+    expect(concurrency?.queue).toBe("max");
+  });
+
+  test("calls canonical CI with the transitive permission ceiling", () => {
+    expect(job?.uses).toBe("./.github/workflows/ci.yml");
+    expect(pushWrapper.permissions).toEqual({ contents: "read" });
+    expect(job?.permissions).toEqual({
+      actions: "read",
+      contents: "read",
+      issues: "write",
+    });
+  });
+
+  test("keeps develop-push failures visible to CI autoheal", () => {
+    const workflowRun = autoheal.on?.workflow_run as
+      | { workflows?: string[] }
+      | undefined;
+    expect(workflowRun?.workflows).toContain(pushWrapper.name);
   });
 });

--- a/packages/scripts/__tests__/develop-health-workflow.test.ts
+++ b/packages/scripts/__tests__/develop-health-workflow.test.ts
@@ -1,11 +1,12 @@
 /**
  * Pins the develop-health.yml canonical trunk-signal contract (#19181).
- * During merge waves push-triggered CI runs on develop are superseded before
- * concluding, so the lane exists to produce a signal that always terminates:
- * it must stay schedule/dispatch-only, never cancel in progress, never share
- * a ref-scoped concurrency group with push runs, measure the live develop
- * tip, stay one job wide, and publish a `develop-health` commit status on
- * the exact SHA it measured. Deterministic, reads the real workflow file.
+ * During merge waves hosted capacity can delay the bounded canonical push queue
+ * and arrivals beyond its 100-pending limit can be rejected, so this lane exists
+ * to produce an independent signal that always terminates. It must stay
+ * schedule/dispatch-only, never cancel in progress, never share a ref-scoped
+ * concurrency group with push runs, measure the live develop tip, stay one job
+ * wide, and publish a `develop-health` commit status on the exact SHA it measured.
+ * Deterministic, reads the real workflow file.
  */
 
 import { describe, expect, test } from "bun:test";

--- a/packages/scripts/__tests__/workflow-trigger-policy.test.ts
+++ b/packages/scripts/__tests__/workflow-trigger-policy.test.ts
@@ -34,10 +34,15 @@ on:
   pull_request:
     branches: [develop, main]
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
-  push:
-    branches: [develop]
   merge_group:
     types: [checks_requested]
+jobs: {}
+`;
+
+const canonicalDevelopPush = `name: CI Develop Push
+on:
+  push:
+    branches: [develop]
 jobs: {}
 `;
 
@@ -93,11 +98,14 @@ jobs: {}
   });
 
   test("accepts the exact canonical PR and merge-group aggregate", () => {
-    const root = buildRepo({ "ci.yml": canonicalCi });
+    const root = buildRepo({
+      "ci-develop-push.yml": canonicalDevelopPush,
+      "ci.yml": canonicalCi,
+    });
     try {
       expect(validateWorkflowTriggerPolicy(root)).toEqual({
         developPushWorkflows: 1,
-        files: 1,
+        files: 2,
       });
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -116,7 +124,10 @@ jobs: {}
       ),
     ];
     for (const workflow of variants) {
-      const root = buildRepo({ "ci.yml": workflow });
+      const root = buildRepo({
+        "ci-develop-push.yml": canonicalDevelopPush,
+        "ci.yml": workflow,
+      });
       try {
         expect(() => validateWorkflowTriggerPolicy(root)).toThrow(
           /canonical (pull_request|merge_group) trigger is absent or invalid/,
@@ -134,14 +145,43 @@ jobs: {}
       ),
     ).toThrow(/merge_group is reserved/);
     const root = buildRepo({
+      "ci-develop-push.yml": canonicalDevelopPush,
       "ci.yml": canonicalCi,
       "merge-candidate-biome.yml": `on:\n  merge_group:\n    types: [checks_requested]\njobs: {}\n`,
     });
     try {
       expect(validateWorkflowTriggerPolicy(root)).toEqual({
         developPushWorkflows: 1,
-        files: 2,
+        files: 3,
       });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a direct canonical CI push trigger", () => {
+    const root = buildRepo({
+      "ci-develop-push.yml": canonicalDevelopPush,
+      "ci.yml": canonicalCi.replace(
+        "  merge_group:\n",
+        "  push:\n    branches: [develop]\n  merge_group:\n",
+      ),
+    });
+    try {
+      expect(() => validateWorkflowTriggerPolicy(root)).toThrow(
+        /direct develop pushes must enter through ci-develop-push\.yml/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("fails closed when the canonical develop push wrapper is absent", () => {
+    const root = buildRepo({ "ci.yml": canonicalCi });
+    try {
+      expect(() => validateWorkflowTriggerPolicy(root)).toThrow(
+        /canonical develop push trigger is absent or invalid/,
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/scripts/ci-path-gate.mjs
+++ b/packages/scripts/ci-path-gate.mjs
@@ -68,6 +68,7 @@ export const CONFIGS = {
           "android_aab",
         ],
         patterns: [
+          ".github/workflows/ci-develop-push.yml",
           ".github/workflows/ci.yml",
           ".github/workflows/test.yml",
           ".github/actions/setup-bun-workspace/**",

--- a/packages/scripts/workflow-trigger-policy.mjs
+++ b/packages/scripts/workflow-trigger-policy.mjs
@@ -17,6 +17,7 @@ const FORBIDDEN_EVENTS = new Set([
   "pull_request_target",
 ]);
 const CANONICAL_ADMISSION_WORKFLOW = "ci.yml";
+const CANONICAL_DEVELOP_PUSH_WORKFLOW = "ci-develop-push.yml";
 const MERGE_GROUP_WORKFLOWS = new Set([
   CANONICAL_ADMISSION_WORKFLOW,
   "merge-candidate-biome.yml",
@@ -56,6 +57,7 @@ export function validateWorkflowTriggerPolicy(repoRoot) {
   let files = 0;
   let developPushWorkflows = 0;
   let sawCanonicalWorkflow = false;
+  let sawCanonicalDevelopPush = false;
   let sawCanonicalPullRequest = false;
   let sawCanonicalMergeGroup = false;
 
@@ -121,6 +123,12 @@ export function validateWorkflowTriggerPolicy(repoRoot) {
       }
 
       if (eventName !== "push") continue;
+      if (name === CANONICAL_ADMISSION_WORKFLOW) {
+        failures.push(
+          `${CANONICAL_ADMISSION_WORKFLOW}: direct develop pushes must enter through ${CANONICAL_DEVELOP_PUSH_WORKFLOW}`,
+        );
+        continue;
+      }
       if (!config || typeof config !== "object") {
         failures.push(
           `${name}: push must be branch-filtered to develop (tag-only release pushes are allowed)`,
@@ -143,6 +151,8 @@ export function validateWorkflowTriggerPolicy(repoRoot) {
         continue;
       }
       developPushWorkflows += 1;
+      if (name === CANONICAL_DEVELOP_PUSH_WORKFLOW)
+        sawCanonicalDevelopPush = true;
     }
   }
 
@@ -157,6 +167,11 @@ export function validateWorkflowTriggerPolicy(repoRoot) {
   if (sawCanonicalWorkflow && !sawCanonicalMergeGroup) {
     failures.push(
       `${CANONICAL_ADMISSION_WORKFLOW}: canonical merge_group trigger is absent or invalid`,
+    );
+  }
+  if (sawCanonicalWorkflow && !sawCanonicalDevelopPush) {
+    failures.push(
+      `${CANONICAL_DEVELOP_PUSH_WORKFLOW}: canonical develop push trigger is absent or invalid`,
     );
   }
   if (failures.length > 0) {


### PR DESCRIPTION
# Relates to

Relates to #19181. Follow-up to the live concurrency evidence from #23873.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      `@elizaos/agent` lint blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      deterministic contract evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e04ae361ad333800c2d13e14aca50e0b8f3424d2:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `d6068e969b3817bae05b79fae22b3cfdaa76799c`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Medium. This changes scheduling for canonical `develop` push CI. The wrapper
keeps at most one canonical graph running and up to 100 pending; arrivals beyond
the platform limit are cancelled. Pull-request and merge-queue cancellation
semantics stay unchanged. Distinct wrapper and reusable-workflow concurrency
groups prevent caller/callee or Nightly collisions.

# Background

## What does this PR do?

- Moves the sole direct canonical `develop` push trigger into
  `ci-develop-push.yml`.
- Uses one stable `queue: max` wrapper group with `cancel-in-progress: false`,
  preventing GitHub's default single-pending replacement during ordinary merge
  waves while keeping the backlog bounded.
- Keeps `ci.yml` reusable for PR, merge-group, dispatch, and other callers.
- Gives push/schedule/dispatch callees run-scoped internal groups so Nightly
  cannot evict a queued wrapper run; stale PR and merge candidates still cancel.
- Extends trigger-policy, concurrency, permission, path-gate, autoheal, and
  documentation contracts around the new entry point.

This implementation follows #23873, whose live runs showed that a stable group
lets the active run terminate but GitHub's default queue replaces an older
pending successor. This PR does not claim terminal proof yet: that requires a
maintainer merge followed by two real `develop` pushes.

## What kind of change is this?

Bug fix (non-breaking CI orchestration change).

# Documentation changes needed?

The workflow README is updated with the bounded queue contract, its 100-pending
limit, overflow behavior, and the distinct caller/callee group requirement.

# Testing

## Where should a reviewer start?

Start with `.github/workflows/ci-develop-push.yml`, then review the internal
group in `.github/workflows/ci.yml` and the deterministic concurrency contract
in `packages/scripts/__tests__/ci-workflow-concurrency.test.ts`.

## Detailed testing steps

```bash
bun install --frozen-lockfile
bun test packages/scripts/__tests__/ci-workflow-concurrency.test.ts \
  packages/scripts/__tests__/workflow-trigger-policy.test.ts \
  packages/scripts/__tests__/ci-path-gate.test.mjs \
  packages/scripts/__tests__/workflow-call-permissions.test.ts \
  packages/scripts/__tests__/actionlint-config.test.ts \
  packages/scripts/__tests__/develop-health-workflow.test.ts \
  packages/scripts/__tests__/ci-classifier-dedup-contract.test.ts \
  packages/scripts/__tests__/device-e2e-workflow.test.ts \
  packages/scripts/__tests__/repository-ruleset-contract.test.ts
node packages/scripts/workflow-trigger-policy.mjs
actionlint -config-file .github/actionlint.yaml \
  .github/workflows/ci-develop-push.yml \
  .github/workflows/claude-ci-autoheal.yml \
  .github/workflows/develop-health.yml \
  .github/workflows/develop-pr.yml
git diff --check origin/develop...HEAD
bun run verify
```

Results at the evidence head: 82 tests pass / 0 fail / 305 expectations;
trigger policy verifies 61 workflows and 18 `develop` push surfaces; changed
workflow lint and diff checks pass. See the attached CI verification log.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:e04ae361ad333800c2d13e14aca50e0b8f3424d2 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Workflow and script contract change; no rendered UI surface exists.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - Workflow and script contract change; no rendered UI surface exists.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No interactive user flow or rendered UI is changed.
<!-- evidence-row:backend-logs -->
- [x] [24023-ci-develop-push-verification-e04ae361.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24023-ci-develop-push-verification-e04ae361.txt)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend request, response, console, or state path is changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No agent, action, provider, prompt, or model behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No database, memory, task, wallet, generated-file, or audio domain output is changed.
<!-- evidence-row:ocr-review -->
- [ ] N/A - The diff has no rendered visual surface or visual text.

# Evidence Details

## Real LLM-call trajectory

N/A - No agent, action, provider, prompt, or model behavior is changed.

## Backend + frontend logs

The attached CI verification log records the exact head, targeted test totals,
workflow-policy inventory, workflow lint, diff hygiene, and inherited full-verify
blocker. Frontend logs are N/A because this diff has no frontend code path.

## Screenshots (before / after) + video walkthrough

N/A - Workflow and deterministic contract files only; there is no rendered UI.

## Audio / voice walkthrough

N/A - No voice, transcript, TTS, STT, or omnivoice behavior is changed.

## Known gaps / failures

- `bun install --frozen-lockfile` succeeds with no dependency changes.
- `bun run verify` exits in the untouched `@elizaos/agent#lint:check` task:
  Biome reports 12 errors, 39 warnings, and 7 infos in `packages/agent` files.
  This PR does not touch `packages/agent`; all checks specific to this diff pass.
- Standalone `actionlint` on the complete pre-existing `ci.yml` reports SC2034
  for an unused shell variable at line 614, outside this diff. Every changed
  workflow surface passes the repository-pinned linter.
- The queue is deliberately bounded: GitHub retains up to 100 pending runs and
  cancels overflow. The guarantee therefore covers two rapid merges when the
  queue is not already at capacity, not an unbounded merge wave.
- Live terminal proof is intentionally pending maintainer merge. After merge,
  two real `develop` pushes must both reach non-cancelled terminal conclusions
  with non-empty job graphs and at most one wrapper active. Until then #19181
  must remain open and this PR must not be described as proven live.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: `elizaOS/eliza@e04ae361ad333800c2d13e14aca50e0b8f3424d2:packages/skills/skills/contribute-to-eliza`
Attribution status: self-reported
— [ci-develop-push-queue]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@e04ae361ad333800c2d13e14aca50e0b8f3424d2:packages/skills/skills/contribute-to-eliza"} -->

