### PR TITLE
fix(cloud): retire orphaned DoorDash DO namespace

### DIFF
--- a/packages/cloud/api/__tests__/durable-object-exports-wrangler.test.ts
+++ b/packages/cloud/api/__tests__/durable-object-exports-wrangler.test.ts
@@ -3,10 +3,11 @@ import { describe, expect, test } from "bun:test";
 type DurableObjectExport = {
   type?: string;
   storage?: string;
+  state?: string;
 };
 
 describe("Durable Object deployment contract", () => {
-  test("declares every live class without replaying legacy migrations", async () => {
+  test("declares every live class and retired namespace without replaying legacy migrations", async () => {
     const config = Bun.TOML.parse(
       await Bun.file(new URL("../wrangler.toml", import.meta.url)).text(),
     ) as {
@@ -17,6 +18,7 @@ describe("Durable Object deployment contract", () => {
     expect(config.migrations).toBeUndefined();
     expect(config.exports).toEqual({
       AnonymousChatGate: { type: "durable-object", storage: "sqlite" },
+      DoorDashCheckoutGate: { type: "durable-object", state: "deleted" },
       InferenceAdmissionGate: { type: "durable-object", storage: "sqlite" },
       InferenceRateLimitV2RollbackFloor: {
         type: "durable-object",

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -188,6 +188,13 @@ storage = "sqlite"
 type = "durable-object"
 storage = "sqlite"
 
+# The class was removed after its namespace had already been provisioned.
+# Declarative exports require an explicit tombstone so Wrangler can retire the
+# orphaned namespace instead of rejecting every subsequent deployment.
+[exports.DoorDashCheckoutGate]
+type = "durable-object"
+state = "deleted"
+
 # General API limits and queues may use Railway Redis via REDIS_URL. Inference
 # routes never connect to it: Cloudflare Rate Limiting bindings protect ingress,
 # Durable Objects serialize organization/anonymous quotas, and CACHE_KV serves


### PR DESCRIPTION
## Summary
- declare the removed `DoorDashCheckoutGate` Durable Object as a deleted export tombstone
- cover the retired namespace in the declarative exports regression test

## Validation
- `bun test packages/cloud/api/__tests__/durable-object-exports-wrangler.test.ts packages/cloud/api/__tests__/inference-rate-limit-v2-rollback-floor-wrangler.test.ts packages/cloud/api/__tests__/twitter-oauth-coordinator-wrangler.test.ts`
- `git diff --check`
- Biome check
- `wrangler@4.116.0 deploy --dry-run --env staging`