### PR TITLE
fix(cloud): enforce Google Ads operation budgets

### DIFF
--- a/packages/cloud/shared/src/lib/services/advertising/providers/google.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/google.error-policy.test.ts
@@ -1,12 +1,24 @@
-// Pins the error-surfacing contract of the Google Ads provider: a failed provider
-// fetch must PROPAGATE, and must stay distinct from a legitimately-empty result
-// (valid credentials, no accessible customers / no metrics rows in range). No
-// monetary value is asserted beyond the zeroed empty-metrics shape the source itself
-// fixes. Deterministic — global fetch is mocked; no live Google Ads API call.
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+/**
+ * Pins Google Ads failure distinctness, bounded transport/body lifecycle, account-fanout
+ * validation, and resumable-upload authority with deterministic mocked network/media boundaries.
+ */
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 mock.module("../../../utils/logger", () => ({
   logger: { info() {}, warn() {}, error() {}, debug() {} },
+}));
+
+const downloadAdMedia = mock(async () => ({
+  url: "https://media.example.test/ad.mp4",
+  bytes: new Uint8Array([1, 2, 3, 4]),
+  base64: "AQIDBA==",
+  contentType: "video/mp4",
+  fileName: "ad.mp4",
+}));
+
+mock.module("../media-utils", () => ({
+  downloadAdMedia,
+  mediaFileName: () => "ad.mp4",
 }));
 
 const { googleAdsProvider, googleAdsFetch } = await import("./google");
@@ -35,6 +47,7 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  downloadAdMedia.mockClear();
 });
 
 describe("googleAdsProvider.listAdAccounts error surfacing", () => {
@@ -93,6 +106,83 @@ describe("googleAdsProvider.listAdAccounts error surfacing", () => {
       { id: "123", name: "Acme" },
     ]);
   });
+
+  test("rejects an oversized accessible-customer set before detail fanout", async () => {
+    let fetches = 0;
+    mockFetch((url) => {
+      fetches += 1;
+      if (url.includes("listAccessibleCustomers")) {
+        return jsonResponse({
+          resourceNames: Array.from({ length: 10_001 }, (_, index) => `customers/${index + 1}`),
+        });
+      }
+      throw new Error(`unexpected detail fetch: ${url}`);
+    });
+
+    await expect(googleAdsProvider.listAdAccounts(credentials)).rejects.toThrow(
+      /more than 10000 accessible customers/,
+    );
+    expect(fetches).toBe(1);
+  });
+
+  test.each([
+    { name: "non-array", resourceNames: "customers/123" },
+    { name: "non-string", resourceNames: [123] },
+    { name: "wrong prefix", resourceNames: ["accounts/123"] },
+    { name: "empty id", resourceNames: ["customers/"] },
+    { name: "non-numeric id", resourceNames: ["customers/abc"] },
+    { name: "duplicate", resourceNames: ["customers/123", "customers/123"] },
+  ])(
+    "rejects $name accessible-customer resources before detail fanout",
+    async ({ resourceNames }) => {
+      let fetches = 0;
+      mockFetch((url) => {
+        fetches += 1;
+        if (url.includes("listAccessibleCustomers")) {
+          return jsonResponse({ resourceNames });
+        }
+        throw new Error(`unexpected detail fetch: ${url}`);
+      });
+
+      await expect(googleAdsProvider.listAdAccounts(credentials)).rejects.toThrow(
+        /malformed|invalid resource|duplicate resource/,
+      );
+      expect(fetches).toBe(1);
+    },
+  );
+
+  test("enforces one overall deadline across accessible-customer detail fanout", async () => {
+    const originalSetTimeout = globalThis.setTimeout;
+    const shortenedTimers = spyOn(globalThis, "setTimeout").mockImplementation(((
+      callback: TimerHandler,
+      delay?: number,
+      ...args: unknown[]
+    ) =>
+      originalSetTimeout(callback, delay === 60_000 ? 20 : delay, ...args)) as typeof setTimeout);
+    let detailSignal: AbortSignal | undefined;
+    const fetchMock = mock()
+      .mockResolvedValueOnce(jsonResponse({ resourceNames: ["customers/123"] }))
+      .mockImplementation(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            detailSignal = init?.signal ?? undefined;
+            init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+              once: true,
+            });
+          }),
+      );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      await expect(googleAdsProvider.listAdAccounts(credentials)).rejects.toMatchObject({
+        name: "TimeoutError",
+      });
+      expect(detailSignal?.aborted).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      shortenedTimers.mockRestore();
+    }
+  });
 });
 
 describe("googleAdsProvider.getCampaignMetrics money-path distinctness", () => {
@@ -148,21 +238,327 @@ describe("googleAdsFetch — bounded hops fail closed and keep caller signals", 
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
-  test("composes a caller-provided abort signal with the hop deadline", async () => {
+  test("composes caller cancellation with the hop deadline", async () => {
     let seen: AbortSignal | undefined;
-    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      seen = init?.signal;
-      return jsonResponse({ resourceNames: [] });
-    }) as unknown as typeof fetch;
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          seen = init?.signal ?? undefined;
+          seen?.addEventListener("abort", () => reject(seen?.reason), { once: true });
+        }),
+    ) as unknown as typeof fetch;
 
     const controller = new AbortController();
-    await googleAdsFetch("https://googleads.googleapis.com/v24/customers:listAccessibleCustomers", {
-      signal: controller.signal,
-    });
-    // The wrapper owns the deadline, so the signal handed to the transport is
-    // a composition of the caller's signal and that deadline — never the caller's
-    // object verbatim. Asserting identity here would pin the very behavior that
-    // lets a never-firing caller signal defeat the bound.
+    const pending = googleAdsFetch(
+      "https://googleads.googleapis.com/v24/customers:listAccessibleCustomers",
+      { signal: controller.signal },
+    );
+    await Promise.resolve();
     expect(seen).not.toBe(controller.signal);
+    controller.abort(new Error("caller cancelled"));
+    await expect(pending).rejects.toThrow(/caller cancelled/);
+    expect(seen?.aborted).toBe(true);
+  });
+
+  test("keeps the deadline when a supplied caller signal never aborts", async () => {
+    const controller = new AbortController();
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+            once: true,
+          });
+        }),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      googleAdsFetch(
+        "https://googleads.googleapis.com/v24/customers:listAccessibleCustomers",
+        { signal: controller.signal },
+        100,
+      ),
+    ).rejects.toThrow(/timed out/i);
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  test("bounds and cancels a response body that never completes", async () => {
+    let cancelCount = 0;
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("{"));
+            },
+            cancel() {
+              cancelCount += 1;
+            },
+          }),
+        ),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      googleAdsFetch(
+        "https://googleads.googleapis.com/v24/customers:listAccessibleCustomers",
+        undefined,
+        50,
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    await Bun.sleep(0);
+    expect(cancelCount).toBe(1);
+  });
+
+  test("rejects and cancels an oversized declared response body", async () => {
+    let cancelCount = 0;
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            cancel() {
+              cancelCount += 1;
+            },
+          }),
+          { headers: { "content-length": String(4 * 1024 * 1024 + 1) } },
+        ),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      googleAdsFetch("https://googleads.googleapis.com/v24/customers:listAccessibleCustomers"),
+    ).rejects.toMatchObject({ code: "GOOGLE_ADS_RESPONSE_TOO_LARGE" });
+    expect(cancelCount).toBe(1);
+  });
+
+  test("clears its timer and caller listener after a successful bounded body read", async () => {
+    const controller = new AbortController();
+    const addListener = spyOn(controller.signal, "addEventListener");
+    const removeListener = spyOn(controller.signal, "removeEventListener");
+    const clearTimer = spyOn(globalThis, "clearTimeout");
+    globalThis.fetch = mock(async () => jsonResponse({ ok: true })) as unknown as typeof fetch;
+
+    const response = await googleAdsFetch(
+      "https://googleads.googleapis.com/v24/customers:listAccessibleCustomers",
+      { signal: controller.signal },
+      1_000,
+    );
+
+    expect(await response.json()).toEqual({ ok: true });
+    expect(addListener).toHaveBeenCalledTimes(1);
+    expect(removeListener).toHaveBeenCalledTimes(1);
+    expect(clearTimer).toHaveBeenCalledTimes(1);
+    addListener.mockRestore();
+    removeListener.mockRestore();
+    clearTimer.mockRestore();
+  });
+
+  test("clears its timer and caller listener after a transport failure", async () => {
+    const controller = new AbortController();
+    const removeListener = spyOn(controller.signal, "removeEventListener");
+    const clearTimer = spyOn(globalThis, "clearTimeout");
+    globalThis.fetch = mock(async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+
+    try {
+      await expect(
+        googleAdsFetch(
+          "https://googleads.googleapis.com/v24/customers:listAccessibleCustomers",
+          { signal: controller.signal },
+          1_000,
+        ),
+      ).rejects.toThrow("network down");
+      expect(removeListener).toHaveBeenCalledTimes(1);
+      expect(clearTimer).toHaveBeenCalledTimes(1);
+    } finally {
+      removeListener.mockRestore();
+      clearTimer.mockRestore();
+    }
+  });
+
+  test.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER])(
+    "rejects invalid timeout %p before fetching",
+    async (timeoutMs) => {
+      const fetchMock = mock(async () => jsonResponse({}));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(
+        googleAdsFetch(
+          "https://googleads.googleapis.com/v24/customers:listAccessibleCustomers",
+          undefined,
+          timeoutMs,
+        ),
+      ).rejects.toMatchObject({ code: "INVALID_GOOGLE_ADS_TIMEOUT" });
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+});
+
+function videoUploadInput() {
+  return {
+    type: "video" as const,
+    url: "https://media.example.test/ad.mp4",
+    name: "Campaign video",
+  };
+}
+
+function uploadStartResponse(uploadUrl: string): Response {
+  return new Response(null, { headers: { "x-goog-upload-url": uploadUrl } });
+}
+
+async function uploadVideo() {
+  const uploadMedia = googleAdsProvider.uploadMedia;
+  if (!uploadMedia) throw new Error("Google Ads provider does not expose media upload");
+  return uploadMedia(credentials, "123", videoUploadInput());
+}
+
+describe("googleAdsProvider resumable upload authority and lifecycle", () => {
+  test.each([
+    "https://attacker.example/upload",
+    "http://googleads.googleapis.com/upload",
+    "https://googleads.googleapis.com.attacker.example/upload",
+    "https://user@googleads.googleapis.com/upload",
+    "https://googleads.googleapis.com:444/upload",
+    "https://googleads.googleapis.com/upload#fragment",
+  ])(
+    "rejects untrusted upload URL %s before forwarding credentials or bytes",
+    async (uploadUrl) => {
+      const fetchMock = mock().mockResolvedValueOnce(uploadStartResponse(uploadUrl));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const result = await uploadVideo();
+
+      expect(result).toMatchObject({ success: false });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test("refuses upload redirects before bearer credentials or media bytes can be replayed", async () => {
+    const replayed: Array<{ authorization: string | null; body: BodyInit | null | undefined }> = [];
+    const fetchMock = mock()
+      .mockResolvedValueOnce(
+        uploadStartResponse("https://googleads.googleapis.com/resumable/upload/v24/session"),
+      )
+      .mockImplementation(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.redirect === "error") {
+          throw new TypeError("Fetch is configured to reject redirects");
+        }
+        replayed.push({
+          authorization: new Headers(init?.headers).get("authorization"),
+          body: init?.body,
+        });
+        return jsonResponse({ resourceName: "customers/123/assets/456" });
+      });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await uploadVideo();
+
+    expect(result).toMatchObject({ success: false });
+    expect(replayed).toEqual([]);
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({ redirect: "error" });
+  });
+
+  test("aborts a hung finalize transport with the shared operation deadline", async () => {
+    const originalSetTimeout = globalThis.setTimeout;
+    const shortenedTimers = spyOn(globalThis, "setTimeout").mockImplementation(((
+      callback: TimerHandler,
+      delay?: number,
+      ...args: unknown[]
+    ) =>
+      originalSetTimeout(callback, delay === 60_000 ? 20 : delay, ...args)) as typeof setTimeout);
+    let finalizeSignal: AbortSignal | undefined;
+    const fetchMock = mock()
+      .mockResolvedValueOnce(
+        uploadStartResponse("https://googleads.googleapis.com/resumable/upload/v24/session"),
+      )
+      .mockImplementation(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            finalizeSignal = init?.signal ?? undefined;
+            init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+              once: true,
+            });
+          }),
+      );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const result = await uploadVideo();
+      expect(result).toMatchObject({ success: false });
+      expect(result.error).toMatch(/video upload timed out/i);
+      expect(finalizeSignal?.aborted).toBe(true);
+    } finally {
+      shortenedTimers.mockRestore();
+    }
+  });
+
+  test("aborts and cancels a hung finalize response body with the shared deadline", async () => {
+    const originalSetTimeout = globalThis.setTimeout;
+    const shortenedTimers = spyOn(globalThis, "setTimeout").mockImplementation(((
+      callback: TimerHandler,
+      delay?: number,
+      ...args: unknown[]
+    ) =>
+      originalSetTimeout(callback, delay === 60_000 ? 20 : delay, ...args)) as typeof setTimeout);
+    let finalizeSignal: AbortSignal | undefined;
+    let cancelCount = 0;
+    const fetchMock = mock()
+      .mockResolvedValueOnce(
+        uploadStartResponse("https://googleads.googleapis.com/resumable/upload/v24/session"),
+      )
+      .mockImplementation(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        finalizeSignal = init?.signal ?? undefined;
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("{"));
+            },
+            cancel() {
+              cancelCount += 1;
+            },
+          }),
+        );
+      });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const result = await uploadVideo();
+      expect(result).toMatchObject({ success: false });
+      expect(result.error).toMatch(/video upload timed out/i);
+      expect(finalizeSignal?.aborted).toBe(true);
+      expect(cancelCount).toBe(1);
+    } finally {
+      shortenedTimers.mockRestore();
+    }
+  });
+
+  test("clears the shared operation timer after a successful direct upload", async () => {
+    const setTimer = spyOn(globalThis, "setTimeout");
+    const clearTimer = spyOn(globalThis, "clearTimeout");
+    const fetchMock = mock()
+      .mockResolvedValueOnce(
+        uploadStartResponse("https://googleads.googleapis.com/resumable/upload/v24/session"),
+      )
+      .mockResolvedValueOnce(jsonResponse({ resourceName: "customers/123/assets/456" }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const result = await uploadVideo();
+      expect(result).toMatchObject({
+        success: true,
+        providerAssetId: "customers/123/assets/456",
+      });
+      const finalizeCall = fetchMock.mock.calls[1];
+      if (!finalizeCall) throw new Error("Expected a finalize upload request");
+      const finalizeInit = finalizeCall[1] as RequestInit;
+      expect(finalizeInit).toMatchObject({ redirect: "error" });
+      expect(new Headers(finalizeInit.headers).get("authorization")).toBe("Bearer token");
+      expect(new Uint8Array(finalizeInit.body as ArrayBuffer)).toEqual(
+        new Uint8Array([1, 2, 3, 4]),
+      );
+      expect(setTimer).toHaveBeenCalledTimes(3);
+      expect(clearTimer).toHaveBeenCalledTimes(3);
+    } finally {
+      setTimer.mockRestore();
+      clearTimer.mockRestore();
+    }
   });
 });

--- a/packages/cloud/shared/src/lib/services/advertising/providers/google.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/google.ts
@@ -1,5 +1,9 @@
-// Google Ads API integration - https://developers.google.com/google-ads/api
+/**
+ * Implements the Google Ads provider boundary, including bounded REST calls and resumable media
+ * uploads against provider-issued authorities.
+ */
 
+import { ElizaError } from "@elizaos/core";
 import { logger } from "../../../utils/logger";
 import { downloadAdMedia, mediaFileName } from "../media-utils";
 import type {
@@ -23,21 +27,130 @@ const GOOGLE_ADS_BASE_URL = `https://googleads.googleapis.com/${GOOGLE_ADS_API_V
 const GOOGLE_ADS_RESUMABLE_UPLOAD_BASE_URL = `https://googleads.googleapis.com/resumable/upload/${GOOGLE_ADS_API_VERSION}`;
 
 const GOOGLE_ADS_REQUEST_TIMEOUT_MS = 30_000;
+const GOOGLE_ADS_LIST_ACCOUNTS_TIMEOUT_MS = 60_000;
+const GOOGLE_ADS_UPLOAD_TIMEOUT_MS = 60_000;
+const MAX_GOOGLE_ADS_ACCESSIBLE_CUSTOMERS = 10_000;
+const GOOGLE_ADS_RESPONSE_MAX_BYTES = 4 * 1024 * 1024;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+async function bufferGoogleAdsResponse(response: Response, signal: AbortSignal): Promise<Response> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null && /^\d+$/.test(contentLength)) {
+    const declaredBytes = Number(contentLength);
+    if (!Number.isSafeInteger(declaredBytes) || declaredBytes > GOOGLE_ADS_RESPONSE_MAX_BYTES) {
+      const error = new ElizaError("Google Ads response exceeds the byte limit", {
+        code: "GOOGLE_ADS_RESPONSE_TOO_LARGE",
+        context: { declaredBytes, maxBytes: GOOGLE_ADS_RESPONSE_MAX_BYTES },
+      });
+      if (response.body) {
+        try {
+          await response.body.cancel(error);
+        } catch (cause) {
+          // error-policy:J6 The response already failed closed; cancellation only releases the
+          // unread transport body.
+          logger.debug("[GoogleAds] Failed to cancel declared-oversize response body", { cause });
+        }
+      }
+      throw error;
+    }
+  }
+  if (!response.body) return response;
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let receivedBytes = 0;
+  const cancelBody = (): void => {
+    reader.cancel(signal.reason).catch((cause: unknown) => {
+      // error-policy:J6 The hop already failed; cancellation only releases its response stream.
+      logger.debug("[GoogleAds] Failed to cancel aborted response body", { cause });
+    });
+  };
+  signal.addEventListener("abort", cancelBody, { once: true });
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      receivedBytes += next.value.byteLength;
+      if (receivedBytes > GOOGLE_ADS_RESPONSE_MAX_BYTES) {
+        const error = new ElizaError("Google Ads response exceeds the byte limit", {
+          code: "GOOGLE_ADS_RESPONSE_TOO_LARGE",
+          context: { receivedBytes, maxBytes: GOOGLE_ADS_RESPONSE_MAX_BYTES },
+        });
+        try {
+          await reader.cancel(error);
+        } catch (cause) {
+          // error-policy:J6 The bounded read already failed; cancellation only releases the stream.
+          logger.debug("[GoogleAds] Failed to cancel oversized response body", { cause });
+        }
+        throw error;
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    signal.removeEventListener("abort", cancelBody);
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(receivedBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new Response(body.buffer, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
 
 /**
  * Bound every Google Ads REST hop so a hung or rate-limited API cannot pin the
- * ad-provider worker indefinitely. A caller-provided abort signal wins.
+ * ad-provider worker indefinitely. Caller cancellation and the deadline are
+ * composed so neither can disable the other.
  */
-export function googleAdsFetch(
+export async function googleAdsFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
   timeoutMs: number = GOOGLE_ADS_REQUEST_TIMEOUT_MS,
 ): Promise<Response> {
-  const deadline = AbortSignal.timeout(timeoutMs);
-  return fetch(input, {
-    ...init,
-    signal: init?.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_TIMER_DELAY_MS) {
+    throw new ElizaError("Google Ads timeout must be a positive timer-safe integer", {
+      code: "INVALID_GOOGLE_ADS_TIMEOUT",
+      context: { timeoutMs },
+    });
+  }
+
+  const controller = new AbortController();
+  let rejectAbort!: (reason: unknown) => void;
+  const abortPromise = new Promise<never>((_resolve, reject) => {
+    rejectAbort = reject;
   });
+  const abort = (reason: unknown): void => {
+    if (controller.signal.aborted) return;
+    controller.abort(reason);
+    rejectAbort(reason);
+  };
+  const onCallerAbort = (): void =>
+    abort(
+      init?.signal?.reason ?? new DOMException("The Google Ads request was aborted.", "AbortError"),
+    );
+  init?.signal?.addEventListener("abort", onCallerAbort, { once: true });
+  if (init?.signal?.aborted) onCallerAbort();
+  const timeoutId = setTimeout(
+    () => abort(new DOMException("Google Ads API request timed out", "TimeoutError")),
+    timeoutMs,
+  );
+  try {
+    const response = await Promise.race([
+      fetch(input, { ...init, signal: controller.signal }),
+      abortPromise,
+    ]);
+    return await Promise.race([bufferGoogleAdsResponse(response, controller.signal), abortPromise]);
+  } finally {
+    clearTimeout(timeoutId);
+    init?.signal?.removeEventListener("abort", onCallerAbort);
+  }
 }
 
 interface GoogleAdsError {
@@ -55,6 +168,79 @@ interface GoogleAdsCustomer {
 }
 
 type GoogleAdsSearchStreamResponse<T> = { results?: T[] } | Array<{ results?: T[] }>;
+
+function accessibleCustomerIds(resourceNames: unknown): string[] {
+  if (!Array.isArray(resourceNames)) {
+    throw new ElizaError("Google Ads accessible-customer response is malformed", {
+      code: "INVALID_GOOGLE_ADS_CUSTOMER_RESOURCES",
+    });
+  }
+  if (resourceNames.length > MAX_GOOGLE_ADS_ACCESSIBLE_CUSTOMERS) {
+    throw new ElizaError(
+      `Google Ads returned more than ${MAX_GOOGLE_ADS_ACCESSIBLE_CUSTOMERS} accessible customers`,
+      {
+        code: "GOOGLE_ADS_CUSTOMER_LIMIT_EXCEEDED",
+        context: {
+          count: resourceNames.length,
+          maxCustomers: MAX_GOOGLE_ADS_ACCESSIBLE_CUSTOMERS,
+        },
+      },
+    );
+  }
+
+  const seen = new Set<string>();
+  return resourceNames.map((resourceName) => {
+    if (typeof resourceName !== "string" || !/^customers\/\d+$/.test(resourceName)) {
+      throw new ElizaError("Google Ads accessible-customer response contains an invalid resource", {
+        code: "INVALID_GOOGLE_ADS_CUSTOMER_RESOURCES",
+        context: { resourceName },
+      });
+    }
+    const customerId = resourceName.slice("customers/".length);
+    if (seen.has(customerId)) {
+      throw new ElizaError(
+        "Google Ads accessible-customer response contains a duplicate resource",
+        {
+          code: "INVALID_GOOGLE_ADS_CUSTOMER_RESOURCES",
+          context: { customerId },
+        },
+      );
+    }
+    seen.add(customerId);
+    return customerId;
+  });
+}
+
+function googleAdsUploadUrl(rawUrl: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch (cause) {
+    // error-policy:J2 Preserve the parser cause while adding provider-boundary context.
+    throw new ElizaError("Google Ads video upload returned an invalid upload URL", {
+      code: "INVALID_GOOGLE_ADS_UPLOAD_URL",
+      cause,
+    });
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.hostname.toLowerCase() !== "googleads.googleapis.com" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.port !== "" ||
+    parsed.hash !== ""
+  ) {
+    throw new ElizaError("Google Ads video upload returned an untrusted upload URL", {
+      code: "INVALID_GOOGLE_ADS_UPLOAD_URL",
+      context: {
+        protocol: parsed.protocol,
+        hostname: parsed.hostname,
+        port: parsed.port,
+      },
+    });
+  }
+  return parsed;
+}
 
 async function googleAdsRequest<T>(
   endpoint: string,
@@ -302,50 +488,59 @@ export const googleAdsProvider: AdProvider = {
   async listAdAccounts(
     credentials: AdAccountCredentials,
   ): Promise<Array<{ id: string; name: string }>> {
-    const response = await googleAdsFetch(
-      `${GOOGLE_ADS_BASE_URL}/customers:listAccessibleCustomers`,
-      {
-        headers: {
-          Authorization: `Bearer ${credentials.accessToken}`,
-          "developer-token": process.env.GOOGLE_ADS_DEVELOPER_TOKEN || "",
+    const deadline = new AbortController();
+    const timeoutId = setTimeout(() => {
+      deadline.abort(new DOMException("Google Ads account listing timed out", "TimeoutError"));
+    }, GOOGLE_ADS_LIST_ACCOUNTS_TIMEOUT_MS);
+    try {
+      const response = await googleAdsFetch(
+        `${GOOGLE_ADS_BASE_URL}/customers:listAccessibleCustomers`,
+        {
+          headers: {
+            Authorization: `Bearer ${credentials.accessToken}`,
+            "developer-token": process.env.GOOGLE_ADS_DEVELOPER_TOKEN || "",
+          },
+          signal: deadline.signal,
         },
-      },
-    );
+      );
 
-    if (!response.ok) {
-      throw new Error("Failed to list Google Ads accounts");
-    }
-
-    const data = (await response.json()) as { resourceNames: string[] };
-
-    // Get details for each customer
-    const accounts: Array<{ id: string; name: string }> = [];
-
-    for (const resourceName of data.resourceNames || []) {
-      const customerId = resourceName.replace("customers/", "");
-
-      const customerResponse = await googleAdsRequest<
-        GoogleAdsSearchStreamResponse<{
-          customer: GoogleAdsCustomer;
-        }>
-      >("/googleAds:searchStream", credentials.accessToken, customerId, {
-        method: "POST",
-        body: JSON.stringify({
-          query: `SELECT customer.id, customer.descriptive_name FROM customer LIMIT 1`,
-        }),
-      });
-
-      const row = firstGoogleAdsSearchResult(customerResponse);
-      if (row) {
-        const customer = row.customer;
-        accounts.push({
-          id: customer.id,
-          name: customer.descriptiveName || `Account ${customer.id}`,
-        });
+      if (!response.ok) {
+        throw new Error("Failed to list Google Ads accounts");
       }
-    }
 
-    return accounts;
+      const data = (await response.json()) as { resourceNames?: unknown };
+      const customerIds = accessibleCustomerIds(data.resourceNames);
+
+      // Get details for each customer
+      const accounts: Array<{ id: string; name: string }> = [];
+
+      for (const customerId of customerIds) {
+        const customerResponse = await googleAdsRequest<
+          GoogleAdsSearchStreamResponse<{
+            customer: GoogleAdsCustomer;
+          }>
+        >("/googleAds:searchStream", credentials.accessToken, customerId, {
+          method: "POST",
+          body: JSON.stringify({
+            query: `SELECT customer.id, customer.descriptive_name FROM customer LIMIT 1`,
+          }),
+          signal: deadline.signal,
+        });
+
+        const row = firstGoogleAdsSearchResult(customerResponse);
+        if (row) {
+          const customer = row.customer;
+          accounts.push({
+            id: customer.id,
+            name: customer.descriptiveName || `Account ${customer.id}`,
+          });
+        }
+      }
+
+      return accounts;
+    } finally {
+      clearTimeout(timeoutId);
+    }
   },
 
   async createCampaign(
@@ -723,74 +918,94 @@ export const googleAdsProvider: AdProvider = {
           "X-Goog-Upload-Header-Content-Length": String(downloaded.bytes.byteLength),
           "X-Goog-Upload-Header-Content-Type": downloaded.contentType,
         };
-        const startResponse = await googleAdsFetch(
-          `${GOOGLE_ADS_RESUMABLE_UPLOAD_BASE_URL}/customers/${accountId}/youTubeVideoUploads:create`,
-          {
-            method: "POST",
-            headers,
-            body: JSON.stringify({
-              customer_id: accountId,
-              you_tube_video_upload: {
-                video_title: input.name || downloaded.fileName,
-                video_description: input.name || downloaded.fileName,
-                video_privacy: "UNLISTED",
-              },
-            }),
-          },
-        );
-        if (!startResponse.ok) {
-          throw new Error(`Google Ads video upload initiation failed (${startResponse.status})`);
-        }
+        const deadline = new AbortController();
+        const timeoutId = setTimeout(() => {
+          deadline.abort(new DOMException("Google Ads video upload timed out", "TimeoutError"));
+        }, GOOGLE_ADS_UPLOAD_TIMEOUT_MS);
+        try {
+          const startResponse = await googleAdsFetch(
+            `${GOOGLE_ADS_RESUMABLE_UPLOAD_BASE_URL}/customers/${accountId}/youTubeVideoUploads:create`,
+            {
+              method: "POST",
+              headers,
+              body: JSON.stringify({
+                customer_id: accountId,
+                you_tube_video_upload: {
+                  video_title: input.name || downloaded.fileName,
+                  video_description: input.name || downloaded.fileName,
+                  video_privacy: "UNLISTED",
+                },
+              }),
+              signal: deadline.signal,
+            },
+          );
+          if (!startResponse.ok) {
+            throw new Error(`Google Ads video upload initiation failed (${startResponse.status})`);
+          }
 
-        const uploadUrl = startResponse.headers.get("x-goog-upload-url");
-        if (!uploadUrl) {
-          throw new Error("Google Ads video upload did not return an upload URL");
-        }
+          const uploadUrl = startResponse.headers.get("x-goog-upload-url");
+          if (!uploadUrl) {
+            throw new Error("Google Ads video upload did not return an upload URL");
+          }
+          const parsedUploadUrl = googleAdsUploadUrl(uploadUrl);
 
-        const videoBody = downloaded.bytes.buffer.slice(
-          downloaded.bytes.byteOffset,
-          downloaded.bytes.byteOffset + downloaded.bytes.byteLength,
-        ) as ArrayBuffer;
-        const finalizeResponse = await googleAdsFetch(uploadUrl, {
-          method: "PUT",
-          headers: {
-            Authorization: `Bearer ${credentials.accessToken}`,
-            "Content-Type": downloaded.contentType,
-            "Content-Length": String(downloaded.bytes.byteLength),
-            "X-Goog-Upload-Offset": "0",
-            "X-Goog-Upload-Command": "upload, finalize",
-          },
-          body: videoBody,
-        });
-        // error-policy:J3 finalize body may be empty/non-JSON; the !ok check below still
-        // surfaces HTTP failures, and a 2xx with no resourceName reports an explicit failure.
-        const data = (await finalizeResponse.json().catch(() => ({}))) as {
-          resourceName?: string;
-        };
-        if (!finalizeResponse.ok) {
-          throw new Error(`Google Ads video upload failed (${finalizeResponse.status})`);
-        }
-        if (!data.resourceName) {
+          const videoBody = downloaded.bytes.buffer.slice(
+            downloaded.bytes.byteOffset,
+            downloaded.bytes.byteOffset + downloaded.bytes.byteLength,
+          ) as ArrayBuffer;
+          const finalizeResponse = await googleAdsFetch(parsedUploadUrl, {
+            method: "PUT",
+            redirect: "error",
+            headers: {
+              Authorization: `Bearer ${credentials.accessToken}`,
+              "Content-Type": downloaded.contentType,
+              "Content-Length": String(downloaded.bytes.byteLength),
+              "X-Goog-Upload-Offset": "0",
+              "X-Goog-Upload-Command": "upload, finalize",
+            },
+            body: videoBody,
+            signal: deadline.signal,
+          });
+          const responseText = await finalizeResponse.text();
+          if (!finalizeResponse.ok) {
+            throw new Error(`Google Ads video upload failed (${finalizeResponse.status})`);
+          }
+          let data: { resourceName?: string } = {};
+          if (responseText !== "") {
+            try {
+              data = JSON.parse(responseText) as { resourceName?: string };
+            } catch (cause) {
+              // error-policy:J2 Preserve the parse cause while adding provider-boundary context.
+              throw new ElizaError("Google Ads video upload returned invalid JSON", {
+                code: "INVALID_GOOGLE_ADS_UPLOAD_RESPONSE",
+                cause,
+              });
+            }
+          }
+          if (!data.resourceName) {
+            return {
+              success: false,
+              error: "Google Ads video upload returned no resource name",
+              metadata: { response: data },
+            };
+          }
+
           return {
-            success: false,
-            error: "Google Ads video upload returned no resource name",
-            metadata: { response: data },
+            success: true,
+            providerAssetId: data.resourceName,
+            providerAssetUrl: downloaded.url,
+            providerAssetResourceName: data.resourceName,
+            metadata: {
+              fileName: downloaded.fileName,
+              contentType: downloaded.contentType,
+              sizeBytes: downloaded.bytes.byteLength,
+              uploadType: "youtube_video_upload",
+              state: "UPLOADED",
+            },
           };
+        } finally {
+          clearTimeout(timeoutId);
         }
-
-        return {
-          success: true,
-          providerAssetId: data.resourceName,
-          providerAssetUrl: downloaded.url,
-          providerAssetResourceName: data.resourceName,
-          metadata: {
-            fileName: downloaded.fileName,
-            contentType: downloaded.contentType,
-            sizeBytes: downloaded.bytes.byteLength,
-            uploadType: "youtube_video_upload",
-            state: "UPLOADED",
-          },
-        };
       }
 
       const downloaded = await downloadAdMedia(input.url, {


### PR DESCRIPTION
# Relates to

Fixes #23484.

- [x] This PR targets `develop` and is rebased onto exact live `develop@b687e3bbc9347c6d9d273b67c28a9b05dc52810b` with zero conflicts.
- [ ] `bun install` and root `bun run verify` were run after sync, or the exact environment limitation is recorded below.
- [x] A reviewer can verify the changed contract from deterministic transport, body-stream, customer-fanout, upload-authority, redirect, and timer-cleanup evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@7c30438efdff172469a03d7239616bbff5dac73d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact live `develop@b687e3bbc9347c6d9d273b67c28a9b05dc52810b`; zero conflicts.
- [ ] Root `bun run verify` passes post-sync, or the exact environment limitation is documented in **Known gaps / failures**.

# Risks

Medium-low. The change is confined to the Google Ads provider transport and resumable-video path. It deliberately fails closed on oversized or hung responses, malformed/duplicate customer resource names, excessive account fanout, expired operation deadlines, untrusted upload URLs, and upload redirects. The 4 MiB response cap covers this provider's bounded account, single-row searchStream, mutation, metrics, OAuth, and upload-control responses without changing the 100 MiB video download ceiling.

# Background

## What does this PR do?

- Replaces an uncleared `AbortSignal.timeout` hop with a clearable timer-safe deadline that composes with caller cancellation and covers headers plus a capped 4 MiB body read.
- Cancels unread, hung, aborted, and oversized bodies and removes caller/body listeners and timers on terminal paths.
- Validates the full accessible-customer array before any detail request: maximum 10,000 entries, exact `customers/<numeric-id>` grammar, and no duplicates.
- Carries one clearable 60-second deadline across account discovery plus every sequential detail hop.
- Carries one clearable 60-second deadline across resumable video start, provider-issued upload, finalize response body, and parse.
- Accepts only credential-free HTTPS upload URLs on exact `googleads.googleapis.com` default authority, rejects fragments/non-default ports, and sets `redirect: "error"` before forwarding bearer credentials or media bytes.
- Preserves failure-vs-empty account and metrics semantics and preserves the existing money path.

## What kind of change is this?

Security and reliability bug fix (non-breaking public API).

# Documentation changes needed?

No. This enforces the existing provider contract and changes no user-facing copy or public package export.

# Testing

## Where should a reviewer start?

- `packages/cloud/shared/src/lib/services/advertising/providers/google.ts`
- `packages/cloud/shared/src/lib/services/advertising/providers/google.error-policy.test.ts`

## Detailed testing steps

At exact PR head `7c30438efdff172469a03d7239616bbff5dac73d`:

1. `bun test packages/cloud/shared/src/lib/services/advertising/providers/google.error-policy.test.ts`
   - PASS: 35 tests, 77 assertions.
   - Covers typed empty/failure behavior, pre-fanout count and resource validation, one overall list deadline, per-hop caller/deadline composition, hung/oversized body cancellation, timer/listener cleanup on success and error, invalid timeout inputs, hostile upload authorities, redirect refusal, shared upload deadline across hung transport and body, exact bytes/bearer, and operation-timer cleanup.
2. `node_modules/.bin/biome check packages/cloud/shared/src/lib/services/advertising/providers/google.ts packages/cloud/shared/src/lib/services/advertising/providers/google.error-policy.test.ts`
   - PASS with pinned Biome 2.5.8 and package-local `packages/cloud/shared/biome.json`.
3. Strict targeted TypeScript:
   - `node_modules/.bin/tsc --ignoreConfig --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --skipLibCheck --strict --lib ES2022,DOM,DOM.Iterable --types node,bun packages/cloud/shared/src/lib/services/advertising/providers/google.ts packages/cloud/shared/src/lib/services/advertising/providers/google.error-policy.test.ts`
   - PASS.
4. Externalized source/test builds:
   - `bun build <file> --target=bun --external='*' --outdir=/tmp/eliza-23484-build`
   - PASS for both changed files.
5. `git diff --check origin/develop...HEAD`
   - PASS.

# Evidence Gate

<!-- evidence-head:7c30438efdff172469a03d7239616bbff5dac73d -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - provider transport logic has no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - provider transport logic has no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - concurrency, deadlines, and hostile-input behavior are verified at the transport boundary, not visually.
<!-- evidence-row:backend-logs -->
- [x] N/A - no protected Google Ads credential was used; deterministic tests inspect requests, signals, bodies, cancellation, and failure results.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, agent, or action-planning behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - request assertions are executable tests, not retained database, memory, schedule, wallet, generated-file, or media artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

The successful resumable-upload regression inspects the exact provider-issued destination, `redirect: "error"`, bearer header, and byte-for-byte media body. Counterfactual redirect mocks replay credentials/bytes and return success unless redirect refusal is present. Hostile URL cases prove zero finalize dispatch. Deadline cases observe the composed underlying signal and response-stream cancellation. Account cases prove malformed, duplicate, and 10,001-entry responses stop after exactly one fetch.

## Known gaps / failures

- This disk-constrained sparse checkout reuses an existing dependency store. A second full `bun install`, package-wide typecheck, and root `bun run verify` were not generated; the exact changed source/test pair instead passes strict targeted TypeScript, pinned package-local Biome, focused tests, both externalized builds, and diff/evidence gates.
- No live Google Ads credential, customer, or resumable upload was used. Live provider execution is a protected-credential acceptance hold, not a source-completion or draft hold.
- Independent exact-head review remains required before merge while this source-complete PR stays ready for review.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@7c30438efdff172469a03d7239616bbff5dac73d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [fix-23484]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@7c30438efdff172469a03d7239616bbff5dac73d:packages/skills/skills/contribute-to-eliza"} -->
