### PR TITLE
fix: traverse provider cursors without fixed page ceilings

### DIFF
--- a/packages/cloud/api/stripe/create-checkout-session/route.test.ts
+++ b/packages/cloud/api/stripe/create-checkout-session/route.test.ts
@@ -105,7 +105,7 @@ mock.module("@/lib/utils/logger", () => ({
   },
 }));
 
-const { default: app } = await import("./route");
+const { default: app, findCheckoutSessionForOrder } = await import("./route");
 
 function request(idempotencyKey?: string): Request {
   return new Request("https://api.example.test/", {
@@ -117,6 +117,33 @@ function request(idempotencyKey?: string): Request {
     body: JSON.stringify({ creditPackId: PACK_ID }),
   });
 }
+
+test("bounds endlessly advancing reconciliation cursors by one operation deadline", async () => {
+  let clock = 0;
+  const list = mock(async () => {
+    clock += 5_000;
+    return {
+      data: [{ id: `cs_unique_${clock}` }],
+      has_more: true,
+    };
+  });
+  const stripe = { checkout: { sessions: { list } } } as never;
+
+  await expect(
+    findCheckoutSessionForOrder(
+      stripe,
+      {
+        id: "30000000-0000-4000-8000-000000000001",
+        stripe_customer_id: "cus_a",
+        updated_at: new Date("2026-08-21T00:00:00.000Z"),
+      },
+      () => clock,
+    ),
+  ).rejects.toThrow(
+    "Stripe Checkout reconciliation exceeded its operation deadline",
+  );
+  expect(list).toHaveBeenCalledTimes(2);
+});
 
 beforeEach(() => {
   getCreditPackById.mockClear();

--- a/packages/cloud/api/stripe/create-checkout-session/route.ts
+++ b/packages/cloud/api/stripe/create-checkout-session/route.ts
@@ -436,7 +436,8 @@ async function findCheckoutSessionForOrder(
   }
   const providerAttemptSeconds = Math.floor(order.updated_at.getTime() / 1000);
   let startingAfter: string | undefined;
-  for (let page = 0; page < 10; page += 1) {
+  const seenCursors = new Set<string>();
+  while (true) {
     const sessions = await stripe.checkout.sessions.list({
       customer: order.stripe_customer_id,
       created: {
@@ -452,10 +453,19 @@ async function findCheckoutSessionForOrder(
         session.metadata?.checkout_order_id === order.id,
     );
     if (match) return match;
-    if (!sessions.has_more || sessions.data.length === 0) return null;
-    startingAfter = sessions.data.at(-1)?.id;
+    if (!sessions.has_more) return null;
+    if (sessions.data.length === 0) {
+      throw new Error(
+        "Stripe Checkout reconciliation returned an empty continuation page",
+      );
+    }
+    const nextCursor = sessions.data.at(-1)?.id;
+    if (!nextCursor || seenCursors.has(nextCursor)) {
+      throw new Error(
+        "Stripe Checkout reconciliation returned invalid pagination",
+      );
+    }
+    seenCursors.add(nextCursor);
+    startingAfter = nextCursor;
   }
-  throw new Error(
-    "Stripe Checkout reconciliation exceeded its safe search bound",
-  );
 }

--- a/packages/cloud/api/stripe/create-checkout-session/route.ts
+++ b/packages/cloud/api/stripe/create-checkout-session/route.ts
@@ -23,6 +23,7 @@ import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const CUSTOM_AMOUNT_LIMITS = { MIN_AMOUNT: 1, MAX_AMOUNT: 1000 } as const;
+const CHECKOUT_RECONCILIATION_TIMEOUT_MS = 10_000;
 
 const checkoutRequestSchema = z
   .object({
@@ -423,21 +424,28 @@ function canonicalCredits(value: string | number): string {
   return `${match[1]}.${(match[2] ?? "").padEnd(6, "0")}`;
 }
 
-async function findCheckoutSessionForOrder(
+export async function findCheckoutSessionForOrder(
   stripe: Stripe,
   order: {
     id: string;
     stripe_customer_id: string | null;
     updated_at: Date;
   },
+  now: () => number = Date.now,
 ): Promise<Stripe.Checkout.Session | null> {
   if (!order.stripe_customer_id) {
     throw new Error("Checkout order has no pinned Stripe customer");
   }
   const providerAttemptSeconds = Math.floor(order.updated_at.getTime() / 1000);
+  const deadlineAt = now() + CHECKOUT_RECONCILIATION_TIMEOUT_MS;
   let startingAfter: string | undefined;
   const seenCursors = new Set<string>();
   while (true) {
+    if (now() >= deadlineAt) {
+      throw new Error(
+        "Stripe Checkout reconciliation exceeded its operation deadline",
+      );
+    }
     const sessions = await stripe.checkout.sessions.list({
       customer: order.stripe_customer_id,
       created: {
@@ -447,6 +455,11 @@ async function findCheckoutSessionForOrder(
       limit: 100,
       ...(startingAfter ? { starting_after: startingAfter } : {}),
     });
+    if (now() >= deadlineAt) {
+      throw new Error(
+        "Stripe Checkout reconciliation exceeded its operation deadline",
+      );
+    }
     const match = sessions.data.find(
       (session) =>
         session.client_reference_id === order.id &&

--- a/packages/cloud/api/v1/credits/checkout/route.test.ts
+++ b/packages/cloud/api/v1/credits/checkout/route.test.ts
@@ -339,6 +339,64 @@ describe("credits checkout service-key agent bridge", () => {
     expect(markProviderStarted).not.toHaveBeenCalled();
   });
 
+  test("reconciles beyond the former ten-page Stripe search ceiling", async () => {
+    const orderId = "30000000-0000-4000-8000-000000000001";
+    createOrder.mockImplementationOnce(async () => ({
+      id: orderId,
+      status: "provider_ambiguous",
+      stripe_customer_id: "cus_order_winner",
+      updated_at: new Date(),
+    }));
+    ensureStripeCustomer.mockResolvedValueOnce("cus_order_winner");
+    checkoutList.mockImplementation(async () => {
+      const page = checkoutList.mock.calls.length;
+      return {
+        data: [
+          page === 11
+            ? {
+                id: "cs_recovered_late",
+                url: "https://checkout.stripe.test/recovered-late",
+                client_reference_id: orderId,
+                metadata: { checkout_order_id: orderId },
+              }
+            : { id: `cs_unrelated_${page}` },
+        ],
+        has_more: page < 11,
+      };
+    });
+
+    const response = await app.fetch(
+      new Request("https://api.example.test/", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "X-Service-Key": "svc",
+          "Idempotency-Key": "agent-checkout-request-late-recovery",
+        },
+        body: JSON.stringify({
+          credits: 5,
+          agent_id: agentId,
+          success_url: "https://waifu.example.test/success",
+          cancel_url: "https://waifu.example.test/cancel",
+        }),
+      }),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(checkoutList).toHaveBeenCalledTimes(11);
+    const checkoutCalls = checkoutList.mock.calls as unknown as Array<
+      [Record<string, unknown>]
+    >;
+    expect(checkoutCalls[10]?.[0]).toMatchObject({
+      starting_after: "cs_unrelated_10",
+    });
+    await expect(response.json()).resolves.toEqual({
+      url: "https://checkout.stripe.test/recovered-late",
+      sessionId: "cs_recovered_late",
+    });
+  });
+
   test("uses shared durable customer authority when the organization is unbound", async () => {
     ensureStripeCustomer.mockResolvedValueOnce("cus_created");
     getWithOrganization.mockImplementationOnce(async () => ({

--- a/packages/cloud/api/v1/credits/checkout/route.test.ts
+++ b/packages/cloud/api/v1/credits/checkout/route.test.ts
@@ -157,7 +157,7 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   },
 }));
 
-const { default: app } = await import("./route");
+const { default: app, findCheckoutSessionForOrder } = await import("./route");
 
 describe("credits checkout service-key agent bridge", () => {
   beforeEach(() => {
@@ -395,6 +395,34 @@ describe("credits checkout service-key agent bridge", () => {
       url: "https://checkout.stripe.test/recovered-late",
       sessionId: "cs_recovered_late",
     });
+  });
+
+  test("bounds endlessly advancing Stripe cursors by one reconciliation deadline", async () => {
+    const orderId = "30000000-0000-4000-8000-000000000001";
+    let clock = 0;
+    const list = mock(async () => {
+      clock += 5_000;
+      return {
+        data: [{ id: `cs_unique_${clock}` }],
+        has_more: true,
+      };
+    });
+    const stripe = { checkout: { sessions: { list } } } as never;
+
+    await expect(
+      findCheckoutSessionForOrder(
+        stripe,
+        {
+          id: orderId,
+          stripe_customer_id: "cus_order_winner",
+          updated_at: new Date("2026-08-21T00:00:00.000Z"),
+        },
+        () => clock,
+      ),
+    ).rejects.toThrow(
+      "Stripe Checkout reconciliation exceeded its operation deadline",
+    );
+    expect(list).toHaveBeenCalledTimes(2);
   });
 
   test("uses shared durable customer authority when the organization is unbound", async () => {

--- a/packages/cloud/api/v1/credits/checkout/route.ts
+++ b/packages/cloud/api/v1/credits/checkout/route.ts
@@ -32,6 +32,8 @@ import { decodeRequestJson } from "@/lib/utils/json-parsing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
+const CHECKOUT_RECONCILIATION_TIMEOUT_MS = 10_000;
+
 const checkoutAmountSchema = z.number().min(1).max(1000);
 
 const CheckoutSchema = z
@@ -276,17 +278,24 @@ app.post("/", async (c) => {
 
 export default app;
 
-async function findCheckoutSessionForOrder(
+export async function findCheckoutSessionForOrder(
   stripe: Stripe,
   order: { id: string; stripe_customer_id: string | null; updated_at: Date },
+  now: () => number = Date.now,
 ): Promise<Stripe.Checkout.Session | null> {
   if (!order.stripe_customer_id) {
     throw new Error("Checkout order has no pinned Stripe customer");
   }
   const providerAttemptSeconds = Math.floor(order.updated_at.getTime() / 1000);
+  const deadlineAt = now() + CHECKOUT_RECONCILIATION_TIMEOUT_MS;
   let startingAfter: string | undefined;
   const seenCursors = new Set<string>();
   while (true) {
+    if (now() >= deadlineAt) {
+      throw new Error(
+        "Stripe Checkout reconciliation exceeded its operation deadline",
+      );
+    }
     const sessions = await stripe.checkout.sessions.list({
       customer: order.stripe_customer_id,
       created: {
@@ -296,6 +305,11 @@ async function findCheckoutSessionForOrder(
       limit: 100,
       ...(startingAfter ? { starting_after: startingAfter } : {}),
     });
+    if (now() >= deadlineAt) {
+      throw new Error(
+        "Stripe Checkout reconciliation exceeded its operation deadline",
+      );
+    }
     const match = sessions.data.find(
       (session) =>
         session.client_reference_id === order.id &&

--- a/packages/cloud/api/v1/credits/checkout/route.ts
+++ b/packages/cloud/api/v1/credits/checkout/route.ts
@@ -285,7 +285,8 @@ async function findCheckoutSessionForOrder(
   }
   const providerAttemptSeconds = Math.floor(order.updated_at.getTime() / 1000);
   let startingAfter: string | undefined;
-  for (let page = 0; page < 10; page += 1) {
+  const seenCursors = new Set<string>();
+  while (true) {
     const sessions = await stripe.checkout.sessions.list({
       customer: order.stripe_customer_id,
       created: {
@@ -301,12 +302,21 @@ async function findCheckoutSessionForOrder(
         session.metadata?.checkout_order_id === order.id,
     );
     if (match) return match;
-    if (!sessions.has_more || sessions.data.length === 0) return null;
-    startingAfter = sessions.data.at(-1)?.id;
+    if (!sessions.has_more) return null;
+    if (sessions.data.length === 0) {
+      throw new Error(
+        "Stripe Checkout reconciliation returned an empty continuation page",
+      );
+    }
+    const nextCursor = sessions.data.at(-1)?.id;
+    if (!nextCursor || seenCursors.has(nextCursor)) {
+      throw new Error(
+        "Stripe Checkout reconciliation returned invalid pagination",
+      );
+    }
+    seenCursors.add(nextCursor);
+    startingAfter = nextCursor;
   }
-  throw new Error(
-    "Stripe Checkout reconciliation exceeded its safe search bound",
-  );
 }
 
 async function resolveCreditUser(

--- a/packages/cloud/scripts/admin/auto-top-up-cutover.ts
+++ b/packages/cloud/scripts/admin/auto-top-up-cutover.ts
@@ -32,7 +32,6 @@ import { parseArgs } from "node:util";
 
 const PLAN_SCHEMA_VERSION = 1 as const;
 const STRIPE_PAGE_LIMIT = 100;
-const MAX_STRIPE_PAGES = 10_000;
 const MIN_CREDIT_AMOUNT_CENTS = 100;
 const MAX_CREDIT_AMOUNT_CENTS = 100_000;
 const MAX_CHARGE_AMOUNT_CENTS = 1_120_000;
@@ -410,7 +409,7 @@ export async function listPaymentIntentsForCutover(
   const seen = new Set<string>();
   let startingAfter: string | undefined;
 
-  for (let pageNumber = 1; pageNumber <= MAX_STRIPE_PAGES; pageNumber += 1) {
+  while (true) {
     const page = await stripe.paymentIntents.list({
       created: { gte, lte },
       limit: STRIPE_PAGE_LIMIT,
@@ -453,9 +452,6 @@ export async function listPaymentIntentsForCutover(
       );
     startingAfter = last.id;
   }
-  throw new RangeError(
-    `Stripe PaymentIntent inventory exceeded ${MAX_STRIPE_PAGES} pages`,
-  );
 }
 
 function classifyLegacyPayment(

--- a/packages/cloud/scripts/admin/slophub-cutover.ts
+++ b/packages/cloud/scripts/admin/slophub-cutover.ts
@@ -19,7 +19,6 @@ const TARGET = Object.freeze({
   sourceCidrs: ["0.0.0.0/0", "::/0"] as const,
 });
 const SOURCE_SHA = /^[a-f0-9]{40}$/;
-const MAX_PROVIDER_PAGES = 10;
 const MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
 const MAX_ACTION_POLLS = 30;
 const ACTION_POLL_DELAY_MS = 2_000;
@@ -194,7 +193,8 @@ async function listHetzner(
   request: Request,
 ): Promise<unknown[]> {
   const values: unknown[] = [];
-  for (let page = 1; page <= MAX_PROVIDER_PAGES; page += 1) {
+  let terminalPage: number | null = null;
+  for (let page = 1; ; page += 1) {
     const separator = path.includes("?") ? "&" : "?";
     const response = await hetznerRequest(
       `${path}${separator}page=${page}&per_page=50`,
@@ -207,12 +207,19 @@ async function listHetzner(
       "pagination",
     );
     const lastPage = integer(pagination.last_page, "pagination.last_page");
-    if (lastPage > MAX_PROVIDER_PAGES) {
-      throw new RangeError(`Hetzner ${field} exceeds the page limit`);
+    if (lastPage < page) {
+      throw new RangeError(
+        `Hetzner ${field} returned invalid pagination metadata`,
+      );
     }
-    if (page >= lastPage) return values;
+    terminalPage ??= lastPage;
+    if (lastPage !== terminalPage) {
+      throw new RangeError(
+        `Hetzner ${field} changed its terminal page during traversal`,
+      );
+    }
+    if (page >= terminalPage) return values;
   }
-  throw new RangeError(`Hetzner ${field} pagination did not terminate`);
 }
 
 function parseDnsRecord(value: unknown): DnsRecord {

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.pagination.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.pagination.test.ts
@@ -1,6 +1,6 @@
 /**
  * Exercises the real managed Calendar feed through its authenticated fetch
- * boundary, including token cycles and independent request/event ceilings.
+ * boundary, including token cycles and the accumulated event ceiling.
  */
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { logger } from "../../utils/logger";
@@ -80,24 +80,12 @@ describe("fetchManagedGoogleCalendarFeed pagination", () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
   });
 
-  test("bounds pagination against a provider that never repeats but never stops", async () => {
-    let callCount = 0;
-    installFetchSequence(() => {
-      callCount += 1;
-      return page(`token-${callCount}`);
-    });
-    await expect(fetchManagedGoogleCalendarFeed(FEED_ARGS)).rejects.toBeInstanceOf(
-      AgentGoogleConnectorError,
-    );
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1_000);
-  });
-
-  test("allows the exact terminal page ceiling", async () => {
-    installFetchSequence((i) => (i === 999 ? page() : page(`token-${i + 1}`)));
+  test("follows provider cursors beyond the former fixed page ceiling", async () => {
+    installFetchSequence((i) => (i === 1_000 ? page() : page(`token-${i + 1}`)));
     await expect(fetchManagedGoogleCalendarFeed(FEED_ARGS)).resolves.toMatchObject({
       events: [],
     });
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1_000);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1_001);
   });
 
   test("allows exactly 10,000 normalized events", async () => {

--- a/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts
+++ b/packages/cloud/shared/src/lib/services/agent-google-connector/calendar.ts
@@ -15,8 +15,6 @@ import {
 const GOOGLE_CALENDAR_EVENTS_ENDPOINT = "https://www.googleapis.com/calendar/v3/calendars";
 const GOOGLE_CALENDAR_LIST_ENDPOINT =
   "https://www.googleapis.com/calendar/v3/users/me/calendarList";
-// Bounds provider calls independently from the accumulated Worker response.
-const MAX_GOOGLE_CALENDAR_FEED_PAGES = 1_000;
 const MAX_GOOGLE_CALENDAR_FEED_EVENTS = 10_000;
 
 type GoogleCalendarEventDate = {
@@ -326,16 +324,8 @@ export async function fetchManagedGoogleCalendarFeed(args: {
 
   const events: ManagedGoogleCalendarEvent[] = [];
   let pageToken: string | undefined;
-  let pageCount = 0;
   const seenPageTokens = new Set<string>();
   do {
-    pageCount += 1;
-    if (pageCount > MAX_GOOGLE_CALENDAR_FEED_PAGES) {
-      fail(
-        502,
-        `Google Calendar feed pagination exceeded ${MAX_GOOGLE_CALENDAR_FEED_PAGES} pages.`,
-      );
-    }
     const params = new URLSearchParams(baseParams);
     if (pageToken) {
       params.set("pageToken", pageToken);

--- a/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.ts
+++ b/packages/cloud/shared/src/lib/services/containers/hetzner-cloud-api.ts
@@ -28,7 +28,6 @@ export type { CreateServerInput, CreateVolumeInput, ProvisionedServer } from "./
 const OFFICIAL_HCLOUD_API_BASE = "https://api.hetzner.cloud/v1";
 const REQUEST_TIMEOUT_MS = 30_000;
 const MAX_REQUEST_TIMEOUT_MS = 2_147_483_647;
-const MAX_LIST_PAGES = 10_000;
 
 export type HetznerCloudErrorCode =
   | "missing_token"
@@ -221,7 +220,7 @@ export class HetznerCloudClient implements ComputeProvider {
     const visitedPages = new Set<number>([1]);
     let path = basePath;
 
-    for (let pageCount = 0; pageCount < MAX_LIST_PAGES; pageCount += 1) {
+    while (true) {
       const data = await this.request<{
         servers: HetznerServer[];
         meta?: { pagination?: { next_page?: number | null } };
@@ -262,11 +261,6 @@ export class HetznerCloudClient implements ComputeProvider {
       visitedPages.add(nextPage);
       path = `${basePath}${basePath.includes("?") ? "&" : "?"}page=${nextPage}`;
     }
-
-    throw new HetznerCloudError(
-      "server_error",
-      `Hetzner Cloud API list servers exceeded ${MAX_LIST_PAGES} pages`,
-    );
   }
 
   async getServer(serverId: number): Promise<HetznerServer | null> {

--- a/packages/core/src/database/document-list-query.ts
+++ b/packages/core/src/database/document-list-query.ts
@@ -26,8 +26,6 @@ export const DOCUMENT_LIST_MAX_QUERY_LENGTH = 512;
 export const DOCUMENT_LIST_MAX_TAGS = 32;
 export const DOCUMENT_LIST_MAX_TAG_LENGTH = 128;
 export const DOCUMENT_LIST_MAX_REQUESTER_ROOMS = 1_000;
-export const DOCUMENT_LIST_MAX_PINNED_PAGES =
-	Math.floor(DOCUMENT_LIST_MAX_OFFSET / DOCUMENT_LIST_MAX_LIMIT) + 1;
 export const DOCUMENT_REVISION_MAX_FRAGMENTS = 10_000;
 
 export interface DocumentListQueryCapableAdapter {

--- a/packages/core/src/features/documents/provider-pinned.test.ts
+++ b/packages/core/src/features/documents/provider-pinned.test.ts
@@ -3,10 +3,7 @@
  * boundary with deterministic adapter responses.
  */
 import { describe, expect, it, vi } from "vitest";
-import {
-	DOCUMENT_LIST_MAX_LIMIT,
-	DOCUMENT_LIST_MAX_PINNED_PAGES,
-} from "../../database/document-list-query";
+import { DOCUMENT_LIST_MAX_LIMIT } from "../../database/document-list-query";
 import { logger } from "../../logger";
 import { type Memory, MemoryType, type UUID } from "../../types";
 import {
@@ -251,64 +248,6 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 		});
 	});
 
-	it("rejects pagination exceeding the maximum page limit when listing pinned documents", async () => {
-		const agentId = "00000000-0000-0000-0000-0000000000a1" as UUID;
-		let callCount = 0;
-		const queryDocumentsMock = vi.fn(async () => {
-			callCount += 1;
-			return {
-				status: "ok",
-				totalVisible: 0,
-				totalAvailable: 0,
-				totalMatched: 0,
-				documents: [],
-				availableDocuments: [],
-				availableHasMore: false,
-				hasMore: true,
-				nextCursor: {
-					createdAt: 1000 + callCount,
-					id: `00000000-0000-0000-0000-${callCount.toString(16).padStart(12, "0")}` as UUID,
-				},
-			};
-		});
-		const runtime = {
-			agentId,
-			adapter: {
-				documentListQueryCapability: 3,
-				queryDocuments: queryDocumentsMock,
-				queryDocumentFragments: vi.fn(async () => []),
-				getDocument: vi.fn(async () => null),
-				compareAndSwapDocument: vi.fn(async () => ({ status: "ok" })),
-				replaceDocumentRevision: vi.fn(async () => ({ status: "ok" })),
-				deleteDocumentWithSnapshot: vi.fn(async () => ({ status: "ok" })),
-			},
-			getMemories: vi.fn(async () => []),
-			searchMemories: vi.fn(async () => []),
-			getModel: vi.fn(() => null),
-			reportError: vi.fn(),
-			logger: {
-				info: vi.fn(),
-				warn: vi.fn(),
-				error: vi.fn(),
-				debug: vi.fn(),
-			},
-		};
-		const service = new DocumentService(runtime as never);
-		const message = {
-			...document("query", "test query"),
-			entityId: agentId,
-		};
-
-		await expect(
-			service.composeProviderDocuments(message, { limit: 10 }),
-		).rejects.toMatchObject({
-			code: "DOCUMENT_LIST_PAGE_LIMIT_EXCEEDED",
-		});
-		expect(queryDocumentsMock).toHaveBeenCalledTimes(
-			1 + DOCUMENT_LIST_MAX_PINNED_PAGES,
-		);
-	});
-
 	it("rejects an oversized adapter page before filtering or retaining rows", async () => {
 		const oversizedPage = Array.from(
 			{ length: DOCUMENT_LIST_MAX_LIMIT + 1 },
@@ -407,7 +346,7 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 		);
 	});
 
-	it("accepts a pinned document returned on the final legal page", async () => {
+	it("accepts a pinned document beyond the former fixed page ceiling", async () => {
 		let pinnedCalls = 0;
 		const finalPinned = document("Final rule", "ALWAYS VERIFY", true);
 		const queryDocumentsMock = vi.fn(async ({ limit }: { limit: number }) => {
@@ -424,7 +363,7 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 				};
 			}
 			pinnedCalls += 1;
-			const isFinal = pinnedCalls === DOCUMENT_LIST_MAX_PINNED_PAGES;
+			const isFinal = pinnedCalls === 102;
 			return {
 				status: "ok",
 				totalVisible: 1,
@@ -452,7 +391,7 @@ describe("pinned DOCUMENTS provider knowledge", () => {
 
 		const result = await listPinnedDocuments(service);
 
-		expect(pinnedCalls).toBe(DOCUMENT_LIST_MAX_PINNED_PAGES);
+		expect(pinnedCalls).toBe(102);
 		expect(result).toEqual([finalPinned]);
 	});
 });

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -20,7 +20,6 @@ import {
 	canRequesterMutateDocument,
 	DOCUMENT_LIST_MAX_LIMIT,
 	DOCUMENT_LIST_MAX_OFFSET,
-	DOCUMENT_LIST_MAX_PINNED_PAGES,
 	documentRoleHasGlobalVisibility,
 	isDocumentVisibleToRequester,
 	queryDocumentsWithCapability,
@@ -715,22 +714,7 @@ export class DocumentService extends Service {
 		const pinnedDocuments: Memory[] = [];
 		let cursor: DocumentListCursor | undefined;
 		const seenCursors = new Set<string>();
-		let pageCount = 0;
 		do {
-			pageCount += 1;
-			if (pageCount > DOCUMENT_LIST_MAX_PINNED_PAGES) {
-				throw new ElizaError(
-					"Pinned document list exceeded maximum page limit",
-					{
-						code: "DOCUMENT_LIST_PAGE_LIMIT_EXCEEDED",
-						context: {
-							pageCount,
-							maxPages: DOCUMENT_LIST_MAX_PINNED_PAGES,
-						},
-						severity: "fatal",
-					},
-				);
-			}
 			const page = await this.listDocumentsDetailedWithRequester(
 				{
 					limit: DOCUMENT_LIST_MAX_LIMIT,

--- a/packages/core/src/integrations/managed-provider/managed-provider.test.ts
+++ b/packages/core/src/integrations/managed-provider/managed-provider.test.ts
@@ -425,6 +425,20 @@ describe("collectProviderPages", () => {
 		).resolves.toEqual([]);
 	});
 
+	it("follows provider cursors beyond the former default page ceiling", async () => {
+		let calls = 0;
+		const items = await collectProviderPages(async () => {
+			calls += 1;
+			return {
+				items: calls === 21 ? ["complete"] : [],
+				nextCursor: calls === 21 ? null : `cursor-${calls}`,
+			};
+		});
+
+		expect(calls).toBe(21);
+		expect(items).toEqual(["complete"]);
+	});
+
 	it("rejects cursor loops, empty cursors, and limit overflows", async () => {
 		await expect(
 			collectProviderPages(async () => ({ items: ["x"], nextCursor: "same" }), {

--- a/packages/core/src/integrations/managed-provider/pagination.ts
+++ b/packages/core/src/integrations/managed-provider/pagination.ts
@@ -1,8 +1,7 @@
 /**
  * Cursor pagination helper for provider adapters. Providers hand back opaque
- * cursors; this walker enforces page and item ceilings and rejects repeated
- * cursors so a malicious or buggy upstream cannot loop the runtime or grow
- * memory without bound.
+ * cursors; this walker rejects repeated cursors and enforces only the explicit
+ * limits selected by its caller.
  */
 
 import { ManagedProviderError } from "./errors";
@@ -14,13 +13,12 @@ export interface ProviderPage<T> {
 }
 
 export interface CollectProviderPagesOptions {
-	/** Ceiling on fetched pages; default 20. */
+	/** Optional ceiling on fetched pages for deliberately partial operations. */
 	maxPages?: number;
 	/** Ceiling on accumulated items; default 1000. */
 	maxItems?: number;
 }
 
-const DEFAULT_MAX_PAGES = 20;
 const DEFAULT_MAX_ITEMS = 1_000;
 
 /**
@@ -31,9 +29,9 @@ export async function collectProviderPages<T>(
 	fetchPage: (cursor: string | undefined) => Promise<ProviderPage<T>>,
 	options: CollectProviderPagesOptions = {},
 ): Promise<T[]> {
-	const maxPages = options.maxPages ?? DEFAULT_MAX_PAGES;
+	const maxPages = options.maxPages;
 	const maxItems = options.maxItems ?? DEFAULT_MAX_ITEMS;
-	if (!Number.isInteger(maxPages) || maxPages < 1) {
+	if (maxPages !== undefined && (!Number.isInteger(maxPages) || maxPages < 1)) {
 		throw new ManagedProviderError("The pagination page limit is invalid.", {
 			code: "INVALID_INPUT",
 		});
@@ -46,7 +44,15 @@ export async function collectProviderPages<T>(
 	const seenCursors = new Set<string>();
 	const items: T[] = [];
 	let cursor: string | undefined;
-	for (let page = 0; page < maxPages; page += 1) {
+	let page = 0;
+	while (true) {
+		if (maxPages !== undefined && page >= maxPages) {
+			throw new ManagedProviderError(
+				"The provider listing exceeded the page limit.",
+				{ code: "PAGINATION_OVERFLOW", context: { maxPages } },
+			);
+		}
+		page += 1;
 		const result = await fetchPage(cursor);
 		items.push(...result.items);
 		if (items.length > maxItems) {
@@ -65,8 +71,4 @@ export async function collectProviderPages<T>(
 		seenCursors.add(result.nextCursor);
 		cursor = result.nextCursor;
 	}
-	throw new ManagedProviderError(
-		"The provider listing exceeded the page limit.",
-		{ code: "PAGINATION_OVERFLOW", context: { maxPages } },
-	);
 }

--- a/packages/scripts/ci-autoheal-context.mjs
+++ b/packages/scripts/ci-autoheal-context.mjs
@@ -336,7 +336,7 @@ function createClient(token) {
 
 async function collectFailures(client, repo, runId, budget) {
   const failures = [];
-  for (let page = 1; page <= 10; page += 1) {
+  for (let page = 1; ; page += 1) {
     const payload = await client.json(
       `/repos/${repo}/actions/runs/${runId}/jobs?per_page=100&page=${page}&filter=latest`,
     );
@@ -367,9 +367,8 @@ async function collectFailures(client, repo, runId, budget) {
         logError,
       });
     }
-    if (jobs.length < 100) break;
+    if (jobs.length < 100) return failures;
   }
-  return failures;
 }
 
 async function findOpenHealPr(client, repo, branch) {

--- a/packages/scripts/github-actions-approval.mjs
+++ b/packages/scripts/github-actions-approval.mjs
@@ -7,7 +7,6 @@
 
 const ACTION_REQUIRED = "action_required";
 const PAGE_SIZE = 100;
-const MAX_PAGES = 10;
 
 function workflowRunsFromPage(payload, page, url) {
   if (
@@ -58,7 +57,7 @@ export async function loadActionRequiredWorkflowPaths({
 }) {
   const workflowRuns = [];
 
-  for (let page = 1; page <= MAX_PAGES; page += 1) {
+  for (let page = 1; ; page += 1) {
     const url =
       `https://api.github.com/repos/${repository}/actions/runs` +
       `?event=pull_request&head_sha=${encodeURIComponent(headSha)}` +
@@ -66,10 +65,9 @@ export async function loadActionRequiredWorkflowPaths({
     const payload = await requestJson(url);
     const pageRuns = workflowRunsFromPage(payload, page, url);
     workflowRuns.push(...pageRuns);
-    if (pageRuns.length < PAGE_SIZE) break;
+    if (pageRuns.length < PAGE_SIZE)
+      return actionRequiredWorkflowPaths(workflowRuns, headSha);
   }
-
-  return actionRequiredWorkflowPaths(workflowRuns, headSha);
 }
 
 export function awaitingApprovalMessage(paths) {

--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -496,6 +496,10 @@ export function ChatView({
   // never prepend into the newly active one.
   const loadOlderConversationIdRef = useRef(activeConversationId);
   loadOlderConversationIdRef.current = activeConversationId;
+  const loadOlderResumeRef = useRef<{
+    conversationId: string | null;
+    before?: number;
+  }>({ conversationId: activeConversationId });
   // Keep a ref to conversationMessages so fetchOlder reads the latest value at
   // call-time without carrying it as a dep. conversationMessages changes on
   // every streaming token, which would give fetchOlder a new identity every
@@ -505,16 +509,27 @@ export function ChatView({
   const fetchOlder = useCallback(async () => {
     const conversationId = activeConversationId;
     if (!conversationId) return { hasMore: false, prependedCount: 0 };
-    return await loadOlderConversationMessages({
+    if (loadOlderResumeRef.current.conversationId !== conversationId) {
+      loadOlderResumeRef.current = { conversationId };
+    }
+    const result = await loadOlderConversationMessages({
       client,
       conversationId,
       currentMessages: conversationMessagesRef.current,
+      before: loadOlderResumeRef.current.before,
       prependMessages: (older) => {
         if (loadOlderConversationIdRef.current === conversationId) {
           prependConversationMessages(older);
         }
       },
     });
+    if (loadOlderConversationIdRef.current === conversationId) {
+      loadOlderResumeRef.current = {
+        conversationId,
+        before: result.resumeBefore,
+      };
+    }
+    return result;
   }, [activeConversationId, prependConversationMessages]);
 
   // Bound the mounted DOM to the newest window of loaded turns (#15281): the

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -2016,19 +2016,34 @@ export function ChatOverlay({
   // never prepend into the newly active one.
   const loadOlderConversationIdRef = React.useRef(activeConversationId);
   loadOlderConversationIdRef.current = activeConversationId;
+  const loadOlderResumeRef = React.useRef<{
+    conversationId: string | null;
+    before?: number;
+  }>({ conversationId: activeConversationId });
   const fetchOlder = React.useCallback(async () => {
     const conversationId = activeConversationId;
     if (!conversationId) return { hasMore: false, prependedCount: 0 };
-    return await loadOlderConversationMessages({
+    if (loadOlderResumeRef.current.conversationId !== conversationId) {
+      loadOlderResumeRef.current = { conversationId };
+    }
+    const result = await loadOlderConversationMessages({
       client,
       conversationId,
       currentMessages: conversationMessages,
+      before: loadOlderResumeRef.current.before,
       prependMessages: (older) => {
         if (loadOlderConversationIdRef.current === conversationId) {
           prependConversationMessages(older);
         }
       },
     });
+    if (loadOlderConversationIdRef.current === conversationId) {
+      loadOlderResumeRef.current = {
+        conversationId,
+        before: result.resumeBefore,
+      };
+    }
+    return result;
   }, [activeConversationId, conversationMessages, prependConversationMessages]);
   // The render window slides UP as the reader scrolls into history (#14329,
   // #15281): it opens at MAX_RENDERED_SHELL_MESSAGES (lean idle/drag DOM) and

--- a/packages/ui/src/state/load-older-conversation-messages.test.ts
+++ b/packages/ui/src/state/load-older-conversation-messages.test.ts
@@ -140,14 +140,20 @@ describe("loadOlderConversationMessages", () => {
     expect(result).toEqual({ hasMore: false, prependedCount: 2 });
   });
 
-  it("stops at the hop budget on a long filtered run but keeps hasMore armed", async () => {
+  it("crosses a filtered run beyond the former five-hop ceiling", async () => {
     const prependMessages = vi.fn();
     let call = 0;
     const client: LoadOlderClient = {
       getConversationMessages: vi.fn(async () => {
         call += 1;
+        if (call === 7) {
+          return {
+            messages: [userMsg("visible", 900)],
+            hasMore: false,
+          };
+        }
         return {
-          messages: [blankAssistant(`s-${call}`, 1000 - call * 10)],
+          messages: [blankAssistant(`s-${call}`, 2000 - call * 100)],
           hasMore: true,
         };
       }),
@@ -160,9 +166,27 @@ describe("loadOlderConversationMessages", () => {
       prependMessages,
     });
 
-    expect(call).toBe(5);
-    expect(prependMessages).not.toHaveBeenCalled();
-    expect(result).toEqual({ hasMore: true, prependedCount: 0 });
+    expect(call).toBe(7);
+    expect(prependMessages).toHaveBeenCalledWith([userMsg("visible", 900)]);
+    expect(result).toEqual({ hasMore: false, prependedCount: 1 });
+  });
+
+  it("rejects a filtered page that does not advance to an older cursor", async () => {
+    const client: LoadOlderClient = {
+      getConversationMessages: vi.fn(async () => ({
+        messages: [blankAssistant("stuck", 20)],
+        hasMore: true,
+      })),
+    };
+
+    await expect(
+      loadOlderConversationMessages({
+        client,
+        conversationId: "conv-1",
+        currentMessages: [userMsg("c", 20)],
+        prependMessages: () => {},
+      }),
+    ).rejects.toThrow("Conversation pagination did not return an older cursor");
   });
 
   it("propagates fetch failures so the caller can retry", async () => {

--- a/packages/ui/src/state/load-older-conversation-messages.test.ts
+++ b/packages/ui/src/state/load-older-conversation-messages.test.ts
@@ -189,6 +189,51 @@ describe("loadOlderConversationMessages", () => {
     ).rejects.toThrow("Conversation pagination did not return an older cursor");
   });
 
+  it("time-slices endlessly advancing filtered cursors and returns a resume point", async () => {
+    const calls: number[] = [];
+    let clock = 0;
+    const client: LoadOlderClient = {
+      getConversationMessages: vi.fn(async (_id, options) => {
+        calls.push(options?.before ?? -1);
+        clock += 1;
+        return {
+          messages: [
+            blankAssistant(`silent-${clock}`, (options?.before ?? 0) - 1),
+          ],
+          hasMore: true,
+        };
+      }),
+    };
+
+    const result = await loadOlderConversationMessages({
+      client,
+      conversationId: "conv-1",
+      currentMessages: [userMsg("current", 100)],
+      prependMessages: () => {},
+      maxDurationMs: 3,
+      now: () => clock,
+    });
+
+    expect(calls).toEqual([100, 99, 98]);
+    expect(result).toEqual({
+      hasMore: true,
+      prependedCount: 0,
+      resumeBefore: 97,
+    });
+
+    clock = 0;
+    await loadOlderConversationMessages({
+      client,
+      conversationId: "conv-1",
+      currentMessages: [userMsg("current", 100)],
+      prependMessages: () => {},
+      before: result.resumeBefore,
+      maxDurationMs: 1,
+      now: () => clock,
+    });
+    expect(calls.at(-1)).toBe(97);
+  });
+
   it("propagates fetch failures so the caller can retry", async () => {
     const client: LoadOlderClient = {
       getConversationMessages: vi.fn(async () => {

--- a/packages/ui/src/state/load-older-conversation-messages.ts
+++ b/packages/ui/src/state/load-older-conversation-messages.ts
@@ -4,10 +4,8 @@
  * The cursor is the timestamp of the oldest currently retained message. The
  * caller owns scroll anchoring; this helper owns the API cursor, transcript
  * filtering, prepend dispatch, and the `hasMore` result that gates the next
- * fetch. One load may issue a bounded number of page fetches: fully
- * non-renderable pages advance the cursor in-invocation (see
- * MAX_FILTERED_PAGE_HOPS) because the retained-oldest cursor alone can never
- * move past them.
+ * fetch. Fully non-renderable pages advance the cursor in-invocation because
+ * the retained-oldest cursor alone can never move past them.
  */
 
 import type { ConversationMessage } from "../api";
@@ -46,15 +44,6 @@ export interface LoadOlderResult {
   prependedCount: number;
 }
 
-/**
- * How many consecutive fully-non-renderable pages one invocation will hop
- * past. The cursor is the oldest RETAINED (renderable) message, so a page
- * where every turn filters out (a run of silent assistant turns) would
- * otherwise leave the cursor parked and every retry would refetch the same
- * page. Bounded so a pathological store can't spin the client.
- */
-const MAX_FILTERED_PAGE_HOPS = 5;
-
 export async function loadOlderConversationMessages(
   deps: LoadOlderConversationMessagesDeps,
 ): Promise<LoadOlderResult> {
@@ -73,7 +62,8 @@ export async function loadOlderConversationMessages(
   }
 
   let cursor = oldest.timestamp;
-  for (let hop = 0; hop < MAX_FILTERED_PAGE_HOPS; hop++) {
+  const seenCursors = new Set<number>([cursor]);
+  while (true) {
     const response = await client.getConversationMessages(conversationId, {
       before: cursor,
       ...(limit !== undefined ? { limit } : {}),
@@ -98,10 +88,16 @@ export async function loadOlderConversationMessages(
     // (messages arrive ascending; [0] is its oldest) and fetch the next one —
     // the retained thread's oldest message can't move, so without this hop the
     // next attempt would refetch this exact page.
-    cursor = response.messages[0].timestamp;
+    const nextCursor = response.messages[0].timestamp;
+    if (
+      typeof nextCursor !== "number" ||
+      !Number.isFinite(nextCursor) ||
+      nextCursor >= cursor ||
+      seenCursors.has(nextCursor)
+    ) {
+      throw new Error("Conversation pagination did not return an older cursor");
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
   }
-
-  // Hop budget exhausted with more history behind the filtered run: report
-  // hasMore so a later scroll-up (with the same in-invocation hops) resumes.
-  return { hasMore: true, prependedCount: 0 };
 }

--- a/packages/ui/src/state/load-older-conversation-messages.ts
+++ b/packages/ui/src/state/load-older-conversation-messages.ts
@@ -35,6 +35,12 @@ export interface LoadOlderConversationMessagesDeps {
   /** Page size hint; the server may clamp it. */
   limit?: number;
   signal?: AbortSignal;
+  /** Cursor returned by a prior time-sliced filtered-page traversal. */
+  before?: number;
+  /** Wall-clock budget for one scroll action; traversal resumes on the next action. */
+  maxDurationMs?: number;
+  /** Deterministic clock seam for tests. */
+  now?: () => number;
 }
 
 export interface LoadOlderResult {
@@ -42,7 +48,11 @@ export interface LoadOlderResult {
   hasMore: boolean;
   /** How many renderable turns were prepended. */
   prependedCount: number;
+  /** Continuation for filtered pages when the current operation time slice ends. */
+  resumeBefore?: number;
 }
+
+const DEFAULT_FILTERED_TRAVERSAL_DURATION_MS = 1_000;
 
 export async function loadOlderConversationMessages(
   deps: LoadOlderConversationMessagesDeps,
@@ -61,9 +71,18 @@ export async function loadOlderConversationMessages(
     return { hasMore: false, prependedCount: 0 };
   }
 
-  let cursor = oldest.timestamp;
+  const now = deps.now ?? Date.now;
+  const maxDurationMs =
+    typeof deps.maxDurationMs === "number" && deps.maxDurationMs > 0
+      ? deps.maxDurationMs
+      : DEFAULT_FILTERED_TRAVERSAL_DURATION_MS;
+  const deadlineAt = now() + maxDurationMs;
+  let cursor = deps.before ?? oldest.timestamp;
   const seenCursors = new Set<number>([cursor]);
   while (true) {
+    if (now() >= deadlineAt) {
+      return { hasMore: true, prependedCount: 0, resumeBefore: cursor };
+    }
     const response = await client.getConversationMessages(conversationId, {
       before: cursor,
       ...(limit !== undefined ? { limit } : {}),
@@ -99,5 +118,8 @@ export async function loadOlderConversationMessages(
     }
     seenCursors.add(nextCursor);
     cursor = nextCursor;
+    if (now() >= deadlineAt) {
+      return { hasMore: true, prependedCount: 0, resumeBefore: cursor };
+    }
   }
 }

--- a/plugins/plugin-agent-skills/src/services/skills.startup.test.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.startup.test.ts
@@ -119,7 +119,7 @@ describe("Agent Skills startup catalog policy", () => {
 		);
 	});
 
-	it("bounds unique-cursor pagination without publishing partial data", async () => {
+	it("syncs catalogs beyond the former fixed page ceiling", async () => {
 		const fetchMock = vi
 			.fn()
 			.mockResolvedValueOnce(
@@ -131,7 +131,10 @@ describe("Agent Skills startup catalog policy", () => {
 				new Response(
 					JSON.stringify({
 						items: [{ slug: `skill-${fetchMock.mock.calls.length}` }],
-						nextCursor: `cursor-${fetchMock.mock.calls.length}`,
+						nextCursor:
+							fetchMock.mock.calls.length === 102
+								? undefined
+								: `cursor-${fetchMock.mock.calls.length}`,
 					}),
 					{ status: 200 },
 				),
@@ -143,11 +146,12 @@ describe("Agent Skills startup catalog policy", () => {
 			storage: new MemorySkillStore(),
 		});
 		await service.syncCatalog();
-		await expect(service.syncCatalog()).rejects.toThrow(
-			"Catalog pagination exceeded 100 pages",
-		);
+		await expect(service.syncCatalog()).resolves.toMatchObject({
+			added: 100,
+			updated: 101,
+		});
 
-		expect(fetchMock).toHaveBeenCalledTimes(101);
-		expect(service.getCatalogStats().total).toBe(1);
+		expect(fetchMock).toHaveBeenCalledTimes(102);
+		expect(service.getCatalogStats().total).toBe(101);
 	});
 });

--- a/plugins/plugin-agent-skills/src/services/skills.ts
+++ b/plugins/plugin-agent-skills/src/services/skills.ts
@@ -114,7 +114,6 @@ function skillScanReportDigest(report: SkillScanReport): string {
  * Prevents hammering the API when it returns errors (e.g. 429 rate-limit).
  */
 const FETCH_ERROR_COOLDOWN = 1000 * 60 * 5;
-const MAX_CATALOG_PAGES = 100;
 
 class CatalogPaginationError extends Error {
 	constructor(message: string) {
@@ -2210,14 +2209,8 @@ export class AgentSkillsService extends Service {
 			const entries: SkillCatalogEntry[] = [];
 			let cursor: string | undefined;
 			const requestedCursors = new Set<string>();
-			let pageCount = 0;
 
 			do {
-				if (pageCount >= MAX_CATALOG_PAGES) {
-					throw new CatalogPaginationError(
-						`Catalog pagination exceeded ${MAX_CATALOG_PAGES} pages`,
-					);
-				}
 				if (cursor) {
 					if (requestedCursors.has(cursor)) {
 						throw new CatalogPaginationError(
@@ -2271,7 +2264,6 @@ export class AgentSkillsService extends Service {
 					typeof data.nextCursor === "string" && data.nextCursor.trim()
 						? data.nextCursor
 						: undefined;
-				pageCount += 1;
 			} while (cursor);
 
 			this.catalogCache = { data: entries, cachedAt: Date.now() };

--- a/plugins/plugin-calendar/src/microsoft/graph.ts
+++ b/plugins/plugin-calendar/src/microsoft/graph.ts
@@ -20,7 +20,6 @@ import {
 
 const DEFAULT_GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0/";
 const GRAPH_MAX_PAGE_SIZE = 1_000;
-const GRAPH_MAX_PAGES = 1_000;
 const GRAPH_MAX_SCHEDULES_PER_REQUEST = 20;
 const GRAPH_MAX_RETRIES = 3;
 const GRAPH_RETRY_CAP_MS = 30_000;
@@ -706,23 +705,11 @@ export class DefaultMicrosoftGraphCalendarPort
     assertCapability(account, "microsoft.calendar.read_basic");
     const calendars: MicrosoftGraphCalendarSummary[] = [];
     const seenLinks = new Set<string>();
-    let pageCount = 0;
     let url: URL | null = new URL(
       `me/calendars?$top=${GRAPH_MAX_PAGE_SIZE}`,
       this.baseUrl,
     );
     while (url) {
-      pageCount += 1;
-      if (pageCount > GRAPH_MAX_PAGES) {
-        throw new ElizaError(
-          "Microsoft Graph calendar pagination exceeded its safety limit.",
-          {
-            code: "MICROSOFT_GRAPH_PAGE_LIMIT_EXCEEDED",
-            context: { connectorAccountId: account.account.id },
-            severity: "fatal",
-          },
-        );
-      }
       const page = await this.request(account, url, { method: "GET" });
       calendars.push(
         ...valueArray(page.body, "list_calendars").map(parseCalendar),
@@ -770,22 +757,7 @@ export class DefaultMicrosoftGraphCalendarPort
     const seenLinks = new Set<string>();
     const changes: MicrosoftGraphEventChange[] = [];
     const issues: MicrosoftGraphEventParseIssue[] = [];
-    let pageCount = 0;
     while (true) {
-      pageCount += 1;
-      if (pageCount > GRAPH_MAX_PAGES) {
-        throw new ElizaError(
-          "Microsoft Graph calendar delta pagination exceeded its safety limit.",
-          {
-            code: "MICROSOFT_GRAPH_PAGE_LIMIT_EXCEEDED",
-            context: {
-              connectorAccountId: args.account.account.id,
-              calendarId: args.calendarId,
-            },
-            severity: "fatal",
-          },
-        );
-      }
       const page = await this.request(args.account, url, {
         method: "GET",
         headers: {

--- a/plugins/plugin-calendar/src/service/CalendarService.ts
+++ b/plugins/plugin-calendar/src/service/CalendarService.ts
@@ -214,9 +214,6 @@ type GoogleCalendarSyncBatch = {
 const CALENDAR_FEED_FRESHNESS_MS = 60_000;
 const DEFAULT_ICS_SYNC_LEASE_MS = 30_000;
 const CALENDAR_SOURCE_UNSUPPORTED = "CALENDAR_SOURCE_UNSUPPORTED";
-// Keep the page cap as a pathological-work backstop; the retained-event bound
-// is the normal product/memory boundary for full and incremental syncs.
-export const MAX_GOOGLE_CALENDAR_PAGES = 1_000;
 export const MAX_GOOGLE_CALENDAR_EVENTS = 10_000;
 
 type CalendarSecretsService = {
@@ -2983,24 +2980,8 @@ export class CalendarService extends Service {
     const seenPageTokens = new Set<string>();
     let pageToken: string | undefined;
     let nextSyncToken: string | null = null;
-    let pageCount = 0;
 
     do {
-      pageCount += 1;
-      if (pageCount > MAX_GOOGLE_CALENDAR_PAGES) {
-        throw new ElizaError(
-          "Google Calendar event pagination exceeded maximum page limit.",
-          {
-            code: "GOOGLE_CALENDAR_PAGE_LIMIT_EXCEEDED",
-            context: {
-              accountId: args.accountId,
-              calendarId: args.calendarId,
-              maxPages: MAX_GOOGLE_CALENDAR_PAGES,
-            },
-            severity: "fatal",
-          },
-        );
-      }
       const page = await listEventPage({
         accountId: args.accountId,
         calendarId: args.calendarId,

--- a/plugins/plugin-calendar/test/calendar-prune-grant-scope.test.ts
+++ b/plugins/plugin-calendar/test/calendar-prune-grant-scope.test.ts
@@ -26,10 +26,7 @@ import type {
 import { sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/pglite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-  MAX_GOOGLE_CALENDAR_EVENTS,
-  MAX_GOOGLE_CALENDAR_PAGES,
-} from "../src/service/CalendarService.js";
+import { MAX_GOOGLE_CALENDAR_EVENTS } from "../src/service/CalendarService.js";
 import {
   type CalendarHostGate,
   CalendarRepository,
@@ -447,55 +444,7 @@ describe("CalendarService feed sync — two Google accounts, both named 'primary
     expect(grantsById.get("evt-b-1")).toBe(GRANT_B.id);
   });
 
-  it("rejects Google Calendar event sync pagination exceeding the maximum page limit", async () => {
-    await clearEvents();
-    let pageCount = 0;
-    const originalGoogleService = runtime.getService?.("google");
-    (runtime as { getService: (name: string) => unknown }).getService = (
-      name: string,
-    ) =>
-      name === "google"
-        ? {
-            listEventPage: async () => {
-              pageCount += 1;
-              return {
-                events: [],
-                nextPageToken: `page-token-${pageCount}`,
-                nextSyncToken: null,
-              };
-            },
-          }
-        : null;
-
-    try {
-      const feed = await calendar.getCalendarFeed(
-        INTERNAL_URL,
-        {
-          grantId: GRANT_A.id,
-          calendarId: "primary",
-          timeMin: WINDOW_MIN,
-          timeMax: WINDOW_MAX,
-          forceSync: true,
-        },
-        new Date("2026-06-02T12:00:00.000Z"),
-      );
-
-      expect(feed.state).toBe("partial");
-      expect(feed.sources[0]?.error).toMatchObject({
-        code: "GOOGLE_CALENDAR_PAGE_LIMIT_EXCEEDED",
-        message:
-          "Google Calendar event pagination exceeded maximum page limit.",
-      });
-      expect(pageCount).toBe(MAX_GOOGLE_CALENDAR_PAGES);
-    } finally {
-      (runtime as { getService: (name: string) => unknown }).getService = (
-        name: string,
-      ) => (name === "google" ? originalGoogleService : null);
-    }
-  });
-
-  it("accepts the final legal Google Calendar page and exact event limit", async () => {
-    expect(MAX_GOOGLE_CALENDAR_PAGES).toBe(1_000);
+  it("accepts a sync beyond the former page ceiling and exact event limit", async () => {
     expect(MAX_GOOGLE_CALENDAR_EVENTS).toBe(10_000);
     let pageCount = 0;
     const originalGoogleService = runtime.getService?.("google");
@@ -506,7 +455,7 @@ describe("CalendarService feed sync — two Google accounts, both named 'primary
         ? {
             listEventPage: async () => {
               pageCount += 1;
-              const isFinal = pageCount === MAX_GOOGLE_CALENDAR_PAGES;
+              const isFinal = pageCount === 1_001;
               return {
                 events:
                   pageCount <= 4
@@ -541,7 +490,7 @@ describe("CalendarService feed sync — two Google accounts, both named 'primary
         timeZone: "UTC",
       });
 
-      expect(pageCount).toBe(MAX_GOOGLE_CALENDAR_PAGES);
+      expect(pageCount).toBe(1_001);
       expect(batch.events).toHaveLength(MAX_GOOGLE_CALENDAR_EVENTS);
       expect(batch.nextSyncToken).toBe("sync-final");
     } finally {

--- a/plugins/plugin-calendar/test/microsoft-graph-http.contract.test.ts
+++ b/plugins/plugin-calendar/test/microsoft-graph-http.contract.test.ts
@@ -345,6 +345,39 @@ describe("Microsoft Graph calendar HTTP contract", () => {
     expect(deltaRequest?.headers.prefer).toContain('outlook.timezone="UTC"');
   });
 
+  it("follows calendar continuation links beyond the former fixed page ceiling", async () => {
+    let page = 0;
+    handler = () => {
+      page += 1;
+      return {
+        body: {
+          value:
+            page === 1_001
+              ? [
+                  {
+                    id: "late-calendar",
+                    name: "Late calendar",
+                    owner: { address: "owner@example.test" },
+                  },
+                ]
+              : [],
+          ...(page === 1_001
+            ? {}
+            : {
+                "@odata.nextLink": `${baseUrl}me/calendars?$skiptoken=page-${page + 1}`,
+              }),
+        },
+      };
+    };
+
+    const calendars = await port().listCalendars(microsoftAccount());
+
+    expect(page).toBe(1_001);
+    expect(calendars).toEqual([
+      expect.objectContaining({ id: "late-calendar", name: "Late calendar" }),
+    ]);
+  });
+
   it("creates one-off events with a stable transaction id and explicit invitation approval", async () => {
     handler = (request) => {
       expect(request.method).toBe("POST");

--- a/plugins/plugin-finances/src/finances-service.ts
+++ b/plugins/plugin-finances/src/finances-service.ts
@@ -88,7 +88,6 @@ const VALID_SOURCE_KINDS: readonly LifeOpsPaymentSourceKind[] = [
 
 const EMAIL_SOURCE_LABEL = "Email bills";
 const SENSITIVE_PAYMENT_SOURCE_METADATA_KEYS = new Set(["plaid", "paypal"]);
-const PLAID_SYNC_PAGE_LIMIT = 20;
 const PLAID_SYNC_MUTATION_RESTART_LIMIT = 3;
 const PLAID_RELINK_CODES = new Set([
   "ITEM_LOGIN_REQUIRED",
@@ -1142,9 +1141,13 @@ export class FinancesService {
       modified = [];
       removedExternalIds = [];
       let hasMore = true;
-      let pageGuard = 0;
+      const seenPageCursors = new Set<string>();
       let restartRequired = false;
-      while (hasMore && pageGuard < PLAID_SYNC_PAGE_LIMIT) {
+      while (hasMore) {
+        if (seenPageCursors.has(pageCursor)) {
+          fail(502, "Plaid sync returned a repeated pagination cursor.");
+        }
+        seenPageCursors.add(pageCursor);
         let delta: PlaidSyncResponse;
         try {
           delta = await this.getPlaidManagedClient().syncTransactions({
@@ -1173,15 +1176,8 @@ export class FinancesService {
         );
         pageCursor = delta.nextCursor;
         hasMore = delta.hasMore;
-        pageGuard += 1;
       }
       if (restartRequired) continue;
-      if (hasMore) {
-        fail(
-          502,
-          "Plaid sync exceeded the 20-page safety limit; retry from the stored cursor.",
-        );
-      }
       completed = true;
       break;
     }

--- a/plugins/plugin-finances/src/finances-service.ts
+++ b/plugins/plugin-finances/src/finances-service.ts
@@ -1446,7 +1446,7 @@ export class FinancesService {
     let inserted = 0;
     let skipped = 0;
     let page = 1;
-    let totalPages = 1;
+    let totalPages: number | null = null;
     try {
       do {
         const result = await this.getPaypalManagedClient().searchTransactions({
@@ -1455,7 +1455,9 @@ export class FinancesService {
           endDate,
           page,
         });
-        totalPages = result.totalPages;
+        if (totalPages === null) {
+          totalPages = result.totalPages;
+        }
         for (const transaction of result.transactions) {
           const wasInserted = await this.upsertPaypalTransaction({
             sourceId,
@@ -1468,7 +1470,7 @@ export class FinancesService {
           }
         }
         page += 1;
-      } while (page <= totalPages && page <= 50);
+      } while (page <= (totalPages ?? 0));
     } catch (error) {
       if (
         error instanceof PaypalManagedClientError &&

--- a/plugins/plugin-finances/test/finances.real-db.test.ts
+++ b/plugins/plugin-finances/test/finances.real-db.test.ts
@@ -300,7 +300,7 @@ describe("FinancesService + FinancesRepository — real PGLite", () => {
     }
   });
 
-  it("fails without advancing the stored cursor when Plaid pagination exceeds the guard", async () => {
+  it("drains Plaid pagination beyond the former 20-page ceiling", async () => {
     let page = 0;
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
@@ -321,10 +321,76 @@ describe("FinancesService + FinancesRepository — real PGLite", () => {
         if (url.endsWith("/sync")) {
           page += 1;
           return Response.json({
-            added: [plaidTransaction(`guard-page-${page}`)],
+            added: [plaidTransaction(`page-${page}`)],
             modified: [],
             removed: [],
-            nextCursor: crypto.randomUUID(),
+            nextCursor: `cursor-${page}`,
+            hasMore: page < 25,
+          });
+        }
+        return Response.json({ error: "unexpected route" }, { status: 500 });
+      });
+
+    try {
+      service.plaidManagedClientCache = new PlaidManagedClient(() => ({
+        configured: true,
+        apiKey: "eliza_test",
+        apiBaseUrl: "https://cloud.example/api/v1",
+        siteUrl: "https://cloud.example",
+      }));
+      const source = await service.completePlaidLink({
+        publicToken: "public-token",
+      });
+
+      await expect(
+        service.syncPlaidTransactions({ sourceId: source.id }),
+      ).resolves.toEqual({
+        inserted: 25,
+        skipped: 0,
+        nextCursor: "cursor-25",
+      });
+
+      const stored = await repository.getPaymentSource(
+        runtime.agentId,
+        source.id,
+      );
+      expect(stored?.metadata.plaid).toMatchObject({ cursor: "cursor-25" });
+      await expect(
+        repository.listPaymentTransactions(runtime.agentId, {
+          sourceId: source.id,
+        }),
+      ).resolves.toHaveLength(25);
+    } finally {
+      fetchSpy.mockRestore();
+      service.plaidManagedClientCache = null;
+    }
+  });
+
+  it("rejects a Plaid cursor cycle without advancing state or persisting a partial delta", async () => {
+    let page = 0;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input) => {
+        const url = String(input);
+        if (url.endsWith("/exchange")) {
+          return Response.json({
+            connectionId: "33333333-3333-4333-8333-333333333334",
+            environment: "sandbox",
+            institution: {
+              institutionId: "ins-cycle",
+              institutionName: "Cycle Bank",
+              primaryAccountMask: null,
+              accounts: [],
+            },
+          });
+        }
+        if (url.endsWith("/sync")) {
+          page += 1;
+          return Response.json({
+            added: [plaidTransaction(`cycle-page-${page}`)],
+            modified: [],
+            removed: [],
+            nextCursor: page === 1 ? "cursor-a" : "",
             hasMore: true,
           });
         }
@@ -344,7 +410,8 @@ describe("FinancesService + FinancesRepository — real PGLite", () => {
 
       await expect(
         service.syncPlaidTransactions({ sourceId: source.id }),
-      ).rejects.toThrow("Plaid sync exceeded the 20-page safety limit");
+      ).rejects.toThrow("Plaid sync returned a repeated pagination cursor");
+      expect(page).toBe(2);
 
       const stored = await repository.getPaymentSource(
         runtime.agentId,

--- a/plugins/plugin-github/src/actions/notification-triage.test.ts
+++ b/plugins/plugin-github/src/actions/notification-triage.test.ts
@@ -2,7 +2,6 @@
  * Deterministic coverage for unread-notification pagination before priority
  * ranking, using a structural GitHub activity client with multiple pages.
  */
-import { logger } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import type { GitHubOctokitClient } from "../types.js";
 import {
@@ -94,8 +93,7 @@ describe("fetchAllUnreadNotifications", () => {
     expect(result.totalUnreadIsLowerBound).toBe(false);
   });
 
-  it("stops after the page cap instead of looping on an always-full inbox", async () => {
-    const warning = vi.spyOn(logger, "warn").mockImplementation(() => {});
+  it("follows unread pages beyond the former fixed page ceiling", async () => {
     const page = (start: number) =>
       Array.from({ length: 50 }, (_, index) => ({
         id: String(start + index),
@@ -104,7 +102,7 @@ describe("fetchAllUnreadNotifications", () => {
     const listNotificationsForAuthenticatedUser = vi
       .fn()
       .mockImplementation(async ({ page: pageNumber }: { page: number }) => ({
-        data: page((pageNumber - 1) * 50),
+        data: pageNumber === 21 ? [] : page((pageNumber - 1) * 50),
       }));
     const activity = {
       listNotificationsForAuthenticatedUser,
@@ -112,14 +110,9 @@ describe("fetchAllUnreadNotifications", () => {
 
     const result = await fetchAllUnreadNotifications(activity);
 
-    expect(listNotificationsForAuthenticatedUser).toHaveBeenCalledTimes(20);
+    expect(listNotificationsForAuthenticatedUser).toHaveBeenCalledTimes(21);
     expect(result.notifications).toHaveLength(1000);
-    expect(result.totalUnreadIsLowerBound).toBe(true);
-    expect(warning).toHaveBeenCalledWith(
-      { pages: 20, collected: 1000 },
-      "[GitHub:GITHUB_NOTIFICATION_TRIAGE] unread notifications truncated at page cap",
-    );
-    warning.mockRestore();
+    expect(result.totalUnreadIsLowerBound).toBe(false);
   });
 });
 

--- a/plugins/plugin-github/src/actions/notification-triage.ts
+++ b/plugins/plugin-github/src/actions/notification-triage.ts
@@ -52,10 +52,6 @@ const SUBJECT_TYPE_SCORES: Record<string, number> = {
 
 const NOTIFICATION_TRIAGE_LIMIT = 25;
 const NOTIFICATION_PAGE_SIZE = 50;
-// Bounds the unread-notification traversal against an inbox that never
-// returns a short page (misbehaving server, or a genuinely huge backlog):
-// 20 pages * 50/page is 1000 notifications, generous for a triage pass.
-const NOTIFICATION_MAX_PAGES = 20;
 
 export interface TriagedNotification {
   id: string;
@@ -73,13 +69,13 @@ interface UnreadNotificationFetchResult {
   totalUnreadIsLowerBound: boolean;
 }
 
-/** Fetch bounded unread pages and report when the collected total is partial. */
+/** Fetch every unread page, deduplicating rows shifted by a mutating inbox. */
 export async function fetchAllUnreadNotifications(
   activity: GitHubOctokitClient["activity"],
 ): Promise<UnreadNotificationFetchResult> {
   const notifications: GitHubNotificationSummary[] = [];
   const seenIds = new Set<string>();
-  for (let page = 1; page <= NOTIFICATION_MAX_PAGES; page += 1) {
+  for (let page = 1; ; page += 1) {
     const response = await activity.listNotificationsForAuthenticatedUser({
       all: false,
       per_page: NOTIFICATION_PAGE_SIZE,
@@ -96,11 +92,6 @@ export async function fetchAllUnreadNotifications(
       return { notifications, totalUnreadIsLowerBound: false };
     }
   }
-  logger.warn(
-    { pages: NOTIFICATION_MAX_PAGES, collected: notifications.length },
-    "[GitHub:GITHUB_NOTIFICATION_TRIAGE] unread notifications truncated at page cap",
-  );
-  return { notifications, totalUnreadIsLowerBound: true };
 }
 
 function scoreNotification(params: {

--- a/plugins/plugin-google-workspace/src/calendar.pagination.test.ts
+++ b/plugins/plugin-google-workspace/src/calendar.pagination.test.ts
@@ -1,7 +1,7 @@
 /**
  * `listEvents`/`listCalendars` drain pages via `nextPageToken`, which must
- * terminate even when the Google Calendar API (or a misbehaving proxy)
- * repeats a page token or never stops minting new ones. Mirrors the
+ * terminate when the Google Calendar API (or a misbehaving proxy)
+ * repeats a page token. Mirrors the
  * equivalent Google Meet pagination coverage in
  * `meet.canonical-artifact.test.ts`.
  */
@@ -46,31 +46,14 @@ describe("listEvents pagination", () => {
     expect(list).toHaveBeenCalledTimes(2);
   });
 
-  it("bounds event-list pagination against a provider that never repeats but never stops", async () => {
-    let page = 0;
-    const list = vi.fn(async () => {
-      page += 1;
-      return { data: { items: [], nextPageToken: `unique-token-${page}` } };
-    });
-    const client = clientFor({ events: { list } });
-
-    await expect(client.listEvents({ accountId: "acct-1" })).rejects.toMatchObject({
-      code: "GOOGLE_CALENDAR_PAGINATION_LIMIT_EXCEEDED",
-    });
-    expect(list).toHaveBeenCalledTimes(1_000);
-    expect(list).toHaveBeenLastCalledWith(
-      expect.objectContaining({ pageToken: "unique-token-999" })
-    );
-  });
-
-  it("accepts a terminal response on the exact final allowed page", async () => {
+  it("accepts a terminal response beyond the former fixed page ceiling", async () => {
     let page = 0;
     const list = vi.fn(async () => {
       page += 1;
       return {
         data: {
-          items: page === 1_000 ? [{ id: "last-event" }] : [],
-          ...(page < 1_000 && { nextPageToken: `unique-token-${page}` }),
+          items: page === 1_001 ? [{ id: "last-event" }] : [],
+          ...(page < 1_001 && { nextPageToken: `unique-token-${page}` }),
         },
       };
     });
@@ -79,7 +62,7 @@ describe("listEvents pagination", () => {
     await expect(client.listEvents({ accountId: "acct-1" })).resolves.toMatchObject([
       { id: "last-event" },
     ]);
-    expect(list).toHaveBeenCalledTimes(1_000);
+    expect(list).toHaveBeenCalledTimes(1_001);
   });
 });
 
@@ -98,17 +81,22 @@ describe("listCalendars pagination", () => {
     expect(list).toHaveBeenNthCalledWith(2, expect.objectContaining({ pageToken: "c1" }));
   });
 
-  it("bounds calendar-list pagination against a provider that never repeats but never stops", async () => {
+  it("accepts a calendar beyond the former fixed page ceiling", async () => {
     let page = 0;
     const list = vi.fn(async () => {
       page += 1;
-      return { data: { items: [], nextPageToken: `unique-token-${page}` } };
+      return {
+        data: {
+          items: page === 1_001 ? [{ id: "late-calendar" }] : [],
+          ...(page < 1_001 && { nextPageToken: `unique-token-${page}` }),
+        },
+      };
     });
     const client = clientFor({ calendarList: { list } });
 
-    await expect(client.listCalendars({ accountId: "acct-1" })).rejects.toMatchObject({
-      code: "GOOGLE_CALENDAR_PAGINATION_LIMIT_EXCEEDED",
-    });
-    expect(list).toHaveBeenCalledTimes(1_000);
+    await expect(client.listCalendars({ accountId: "acct-1" })).resolves.toMatchObject([
+      { calendarId: "late-calendar" },
+    ]);
+    expect(list).toHaveBeenCalledTimes(1_001);
   });
 });

--- a/plugins/plugin-google-workspace/src/calendar.ts
+++ b/plugins/plugin-google-workspace/src/calendar.ts
@@ -916,15 +916,12 @@ function normalizedToken(value: string | null | undefined): string | null {
   return normalized ? normalized : null;
 }
 
-const MAX_GOOGLE_CALENDAR_PAGES = 1_000;
-
 interface CalendarPaginationState {
-  pageCount: number;
   seenPageTokens: Set<string>;
 }
 
 function createCalendarPaginationState(): CalendarPaginationState {
-  return { pageCount: 0, seenPageTokens: new Set<string>() };
+  return { seenPageTokens: new Set<string>() };
 }
 
 function nextPageToken(
@@ -932,7 +929,6 @@ function nextPageToken(
   state: CalendarPaginationState,
   resource: string
 ): string | undefined {
-  state.pageCount += 1;
   if (!value) {
     return undefined;
   }
@@ -942,16 +938,6 @@ function nextPageToken(
       context: { resource },
       severity: "fatal",
     });
-  }
-  if (state.pageCount >= MAX_GOOGLE_CALENDAR_PAGES) {
-    throw new ElizaError(
-      `Google Calendar ${resource} pagination exceeded ${MAX_GOOGLE_CALENDAR_PAGES} pages.`,
-      {
-        code: "GOOGLE_CALENDAR_PAGINATION_LIMIT_EXCEEDED",
-        context: { maxPages: MAX_GOOGLE_CALENDAR_PAGES, resource },
-        severity: "fatal",
-      }
-    );
   }
   state.seenPageTokens.add(value);
   return value;

--- a/plugins/plugin-google-workspace/src/gmail.pagination.test.ts
+++ b/plugins/plugin-google-workspace/src/gmail.pagination.test.ts
@@ -3,7 +3,7 @@
  * < limit)`, but that count only advances on a page with at least one mapped
  * message — a page with an empty `messages` array and a distinct
  * `nextPageToken` never grows it. Both must still terminate against a
- * repeated or a never-repeating-but-never-stopping page token. Mirrors the
+ * repeated page token. Mirrors the
  * equivalent Calendar pagination coverage in `calendar.pagination.test.ts`.
  */
 import { describe, expect, it, vi } from "vitest";
@@ -74,27 +74,13 @@ describe("searchGmailMessages pagination", () => {
     expect(list).toHaveBeenNthCalledWith(2, expect.objectContaining({ pageToken: opaqueToken }));
   });
 
-  it("bounds pagination against a provider that mints a novel token on every empty page", async () => {
-    let page = 0;
-    const list = vi.fn(async () => {
-      page += 1;
-      return { data: { messages: [], nextPageToken: `token-${page}` } };
-    });
-    const client = clientFor(list);
-
-    await expect(
-      client.searchGmailMessages({ accountId: "acct-1", query: "in:inbox" })
-    ).rejects.toMatchObject({ code: "GOOGLE_GMAIL_PAGINATION_LIMIT_EXCEEDED" });
-    expect(list).toHaveBeenCalledTimes(1_000);
-  });
-
-  it("returns a satisfied result limit on the final allowed page", async () => {
+  it("returns a satisfied result beyond the former fixed page ceiling", async () => {
     let page = 0;
     const list = vi.fn(async () => {
       page += 1;
       return {
         data: {
-          messages: page === 1_000 ? [{ id: "last" }] : [],
+          messages: page === 1_001 ? [{ id: "last" }] : [],
           nextPageToken: `token-${page}`,
         },
       };
@@ -107,7 +93,7 @@ describe("searchGmailMessages pagination", () => {
     await expect(
       client.searchGmailMessages({ accountId: "acct-1", query: "in:inbox", maxResults: 1 })
     ).resolves.toMatchObject([{ externalId: "last" }]);
-    expect(list).toHaveBeenCalledTimes(1_000);
+    expect(list).toHaveBeenCalledTimes(1_001);
   });
 });
 
@@ -125,20 +111,6 @@ describe("getGmailSubscriptionHeaders pagination", () => {
     expect(list).toHaveBeenCalledTimes(2);
   });
 
-  it("bounds pagination against a provider that mints a novel token on every empty page", async () => {
-    let page = 0;
-    const list = vi.fn(async () => {
-      page += 1;
-      return { data: { messages: [], nextPageToken: `token-${page}` } };
-    });
-    const client = clientFor(list);
-
-    await expect(client.getGmailSubscriptionHeaders({ accountId: "acct-1" })).rejects.toMatchObject(
-      { code: "GOOGLE_GMAIL_PAGINATION_LIMIT_EXCEEDED" }
-    );
-    expect(list).toHaveBeenCalledTimes(1_000);
-  });
-
   it("rejects a cursor cycle instead of looping forever on empty pages", async () => {
     const list = vi
       .fn()
@@ -153,13 +125,13 @@ describe("getGmailSubscriptionHeaders pagination", () => {
     expect(list).toHaveBeenCalledTimes(3);
   });
 
-  it("returns a satisfied result limit on the final allowed page", async () => {
+  it("returns subscription headers beyond the former fixed page ceiling", async () => {
     let page = 0;
     const list = vi.fn(async () => {
       page += 1;
       return {
         data: {
-          messages: page === 1_000 ? [{ id: "last" }] : [],
+          messages: page === 1_001 ? [{ id: "last" }] : [],
           nextPageToken: `token-${page}`,
         },
       };
@@ -172,6 +144,6 @@ describe("getGmailSubscriptionHeaders pagination", () => {
     await expect(
       client.getGmailSubscriptionHeaders({ accountId: "acct-1", maxMessages: 1 })
     ).resolves.toMatchObject([{ messageId: "last" }]);
-    expect(list).toHaveBeenCalledTimes(1_000);
+    expect(list).toHaveBeenCalledTimes(1_001);
   });
 });

--- a/plugins/plugin-google-workspace/src/gmail.ts
+++ b/plugins/plugin-google-workspace/src/gmail.ts
@@ -54,15 +54,13 @@ const SUBSCRIPTION_SCAN_QUERY_DEFAULT =
 const GMAIL_LIST_PAGE_SIZE = 500;
 const GMAIL_METADATA_CONCURRENCY = 25;
 const MAX_GMAIL_RESULTS = 1000;
-const MAX_GMAIL_PAGES = 1_000;
 
 interface GmailPaginationState {
-  pageCount: number;
   seenPageTokens: Set<string>;
 }
 
 function createGmailPaginationState(): GmailPaginationState {
-  return { pageCount: 0, seenPageTokens: new Set<string>() };
+  return { seenPageTokens: new Set<string>() };
 }
 
 // Both searchGmailMessages and getGmailSubscriptionHeaders loop `while
@@ -75,7 +73,6 @@ function nextGmailPageToken(
   state: GmailPaginationState,
   resource: string
 ): string | undefined {
-  state.pageCount += 1;
   if (!value?.trim()) {
     return undefined;
   }
@@ -86,13 +83,6 @@ function nextGmailPageToken(
     throw new ElizaError(`Gmail repeated a ${resource} page token.`, {
       code: "GOOGLE_GMAIL_PAGINATION_LOOP",
       context: { resource },
-      severity: "fatal",
-    });
-  }
-  if (state.pageCount >= MAX_GMAIL_PAGES) {
-    throw new ElizaError(`Gmail ${resource} pagination exceeded ${MAX_GMAIL_PAGES} pages.`, {
-      code: "GOOGLE_GMAIL_PAGINATION_LIMIT_EXCEEDED",
-      context: { maxPages: MAX_GMAIL_PAGES, resource },
       severity: "fatal",
     });
   }

--- a/plugins/plugin-google-workspace/src/meet.canonical-artifact.test.ts
+++ b/plugins/plugin-google-workspace/src/meet.canonical-artifact.test.ts
@@ -358,11 +358,16 @@ describe("Google Meet canonical artifact mapping", () => {
     expect(list).toHaveBeenNthCalledWith(2, expect.objectContaining({ pageToken: opaqueToken }));
   });
 
-  it("bounds Google Meet pagination with unique provider tokens", async () => {
+  it("accepts Google Meet results beyond the former fixed page ceiling", async () => {
     let page = 0;
     const list = vi.fn(async () => {
       page += 1;
-      return { data: { transcripts: [], nextPageToken: `unique-token-${page}` } };
+      return {
+        data: {
+          transcripts: page === 1_001 ? [{ name: "transcripts/late" }] : [],
+          ...(page < 1_001 && { nextPageToken: `unique-token-${page}` }),
+        },
+      };
     });
     const fakeMeet = { conferenceRecords: { transcripts: { list } } };
     const factory = { meet: vi.fn(async () => fakeMeet) } as unknown as GoogleApiClientFactory;
@@ -373,7 +378,7 @@ describe("Google Meet canonical artifact mapping", () => {
         accountId: "acct_google_1",
         conferenceRecordName: CONFERENCE_RECORD,
       })
-    ).rejects.toMatchObject({ code: "GOOGLE_MEET_PAGE_LIMIT_EXCEEDED" });
-    expect(list).toHaveBeenCalledTimes(1_000);
+    ).resolves.toMatchObject([{ name: "transcripts/late" }]);
+    expect(list).toHaveBeenCalledTimes(1_001);
   });
 });

--- a/plugins/plugin-google-workspace/src/meet.ts
+++ b/plugins/plugin-google-workspace/src/meet.ts
@@ -49,15 +49,12 @@ export const GOOGLE_MEET_API_SURFACE = [
   { method: "generateReport", capabilities: ["meet.read"] },
 ] as const;
 
-const MAX_GOOGLE_MEET_PAGES = 1_000;
-
 interface MeetPaginationState {
-  pageCount: number;
   seenPageTokens: Set<string>;
 }
 
 function createMeetPaginationState(): MeetPaginationState {
-  return { pageCount: 0, seenPageTokens: new Set<string>() };
+  return { seenPageTokens: new Set<string>() };
 }
 
 function nextMeetPageToken(
@@ -65,7 +62,6 @@ function nextMeetPageToken(
   state: MeetPaginationState,
   resource: string
 ): string | undefined {
-  state.pageCount += 1;
   if (!token?.trim()) return undefined;
   if (state.seenPageTokens.has(token)) {
     throw new ElizaError(`Google Meet repeated a ${resource} page token.`, {
@@ -73,16 +69,6 @@ function nextMeetPageToken(
       context: { resource },
       severity: "fatal",
     });
-  }
-  if (state.pageCount >= MAX_GOOGLE_MEET_PAGES) {
-    throw new ElizaError(
-      `Google Meet ${resource} pagination exceeded ${MAX_GOOGLE_MEET_PAGES} pages.`,
-      {
-        code: "GOOGLE_MEET_PAGE_LIMIT_EXCEEDED",
-        context: { maxPages: MAX_GOOGLE_MEET_PAGES, resource },
-        severity: "fatal",
-      }
-    );
   }
   state.seenPageTokens.add(token);
   return token;

--- a/plugins/plugin-health/src/health-bridge/health-connectors.ts
+++ b/plugins/plugin-health/src/health-bridge/health-connectors.ts
@@ -21,6 +21,7 @@ import {
 } from "./health-records.js";
 
 const HEALTH_CONNECTOR_TIMEOUT_MS = 15_000;
+const HEALTH_CONNECTOR_SYNC_TIMEOUT_MS = 60_000;
 
 export class HealthConnectorApiError extends Error {
   constructor(
@@ -708,16 +709,31 @@ async function fetchOuraCollection(args: {
   token: StoredHealthConnectorToken;
   path: string;
   query: Record<string, string>;
+  deadlineAt: number;
 }): Promise<Record<string, unknown>[]> {
   const items: Record<string, unknown>[] = [];
   const seenTokens = new Set<string>();
   let nextToken: string | null = null;
   for (;;) {
+    if (Date.now() >= args.deadlineAt) {
+      throw new HealthConnectorApiError(
+        504,
+        args.token.provider,
+        "Oura pagination exceeded the sync deadline",
+      );
+    }
     const json = await fetchHealthJson({
       token: args.token,
       path: args.path,
       query: { ...args.query, next_token: nextToken },
     });
+    if (Date.now() >= args.deadlineAt) {
+      throw new HealthConnectorApiError(
+        504,
+        args.token.provider,
+        "Oura pagination exceeded the sync deadline",
+      );
+    }
     items.push(...getArray(json, "data"));
     nextToken = getText(json, "next_token");
     if (!nextToken) break;
@@ -734,6 +750,7 @@ async function fetchOuraCollection(args: {
 }
 
 async function syncOura(args: SyncArgs): Promise<HealthConnectorSyncPayload> {
+  const deadlineAt = Date.now() + HEALTH_CONNECTOR_SYNC_TIMEOUT_MS;
   const startDatetime = `${args.startDate}T00:00:00Z`;
   const endDatetime = `${args.endDate}T23:59:59Z`;
   const [
@@ -752,26 +769,31 @@ async function syncOura(args: SyncArgs): Promise<HealthConnectorSyncPayload> {
       token: args.token,
       path: "/v2/usercollection/daily_activity",
       query: { start_date: args.startDate, end_date: args.endDate },
+      deadlineAt,
     }),
     fetchOuraCollection({
       token: args.token,
       path: "/v2/usercollection/daily_readiness",
       query: { start_date: args.startDate, end_date: args.endDate },
+      deadlineAt,
     }),
     fetchOuraCollection({
       token: args.token,
       path: "/v2/usercollection/sleep",
       query: { start_date: args.startDate, end_date: args.endDate },
+      deadlineAt,
     }),
     fetchOuraCollection({
       token: args.token,
       path: "/v2/usercollection/heartrate",
       query: { start_datetime: startDatetime, end_datetime: endDatetime },
+      deadlineAt,
     }),
     fetchOuraCollection({
       token: args.token,
       path: "/v2/usercollection/workout",
       query: { start_date: args.startDate, end_date: args.endDate },
+      deadlineAt,
     }),
   ]);
   const samples: LifeOpsHealthMetricSample[] = [];

--- a/plugins/plugin-health/src/health-bridge/health-connectors.ts
+++ b/plugins/plugin-health/src/health-bridge/health-connectors.ts
@@ -21,7 +21,6 @@ import {
 } from "./health-records.js";
 
 const HEALTH_CONNECTOR_TIMEOUT_MS = 15_000;
-const MAX_PAGINATION_PAGES = 5;
 
 export class HealthConnectorApiError extends Error {
   constructor(
@@ -711,8 +710,9 @@ async function fetchOuraCollection(args: {
   query: Record<string, string>;
 }): Promise<Record<string, unknown>[]> {
   const items: Record<string, unknown>[] = [];
+  const seenTokens = new Set<string>();
   let nextToken: string | null = null;
-  for (let page = 0; page < MAX_PAGINATION_PAGES; page += 1) {
+  for (;;) {
     const json = await fetchHealthJson({
       token: args.token,
       path: args.path,
@@ -720,9 +720,15 @@ async function fetchOuraCollection(args: {
     });
     items.push(...getArray(json, "data"));
     nextToken = getText(json, "next_token");
-    if (!nextToken) {
-      break;
+    if (!nextToken) break;
+    if (seenTokens.has(nextToken)) {
+      throw new HealthConnectorApiError(
+        502,
+        args.token.provider,
+        "Oura pagination repeated a next_token",
+      );
     }
+    seenTokens.add(nextToken);
   }
   return items;
 }

--- a/plugins/plugin-health/test/oura-connector.contract.test.ts
+++ b/plugins/plugin-health/test/oura-connector.contract.test.ts
@@ -204,4 +204,55 @@ describe("Oura connector — recorded real API contract", () => {
       expect(s.localDate).toBe(s.startAt.slice(0, 10));
     }
   });
+
+  it("follows collection cursors beyond the former five-page ceiling", async () => {
+    let activityPages = 0;
+    vi.stubGlobal("fetch", async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/usercollection/personal_info")) {
+        return jsonResponse({ id: "oura-user" });
+      }
+      if (url.includes("/usercollection/daily_activity")) {
+        activityPages += 1;
+        return jsonResponse({
+          data: [],
+          next_token:
+            activityPages === 6 ? null : `activity-page-${activityPages + 1}`,
+        });
+      }
+      return jsonResponse({ data: [], next_token: null });
+    });
+
+    await expect(
+      syncHealthConnectorData({
+        token,
+        grantId: "grant-oura",
+        startDate: "2026-05-01",
+        endDate: "2026-05-01",
+      }),
+    ).resolves.toMatchObject({ samples: [], workouts: [] });
+    expect(activityPages).toBe(6);
+  });
+
+  it("rejects a repeated Oura collection cursor", async () => {
+    vi.stubGlobal("fetch", async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/usercollection/personal_info")) {
+        return jsonResponse({ id: "oura-user" });
+      }
+      if (url.includes("/usercollection/daily_activity")) {
+        return jsonResponse({ data: [], next_token: "repeated-token" });
+      }
+      return jsonResponse({ data: [], next_token: null });
+    });
+
+    await expect(
+      syncHealthConnectorData({
+        token,
+        grantId: "grant-oura",
+        startDate: "2026-05-01",
+        endDate: "2026-05-01",
+      }),
+    ).rejects.toThrow("Oura pagination repeated a next_token");
+  });
 });

--- a/plugins/plugin-health/test/oura-connector.contract.test.ts
+++ b/plugins/plugin-health/test/oura-connector.contract.test.ts
@@ -78,6 +78,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("Oura connector — recorded real API contract", () => {
@@ -254,5 +255,36 @@ describe("Oura connector — recorded real API contract", () => {
         endDate: "2026-05-01",
       }),
     ).rejects.toThrow("Oura pagination repeated a next_token");
+  });
+
+  it("bounds endlessly advancing Oura cursors by the shared sync deadline", async () => {
+    let clock = 0;
+    let activityPages = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => clock);
+    vi.stubGlobal("fetch", async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/usercollection/personal_info")) {
+        return jsonResponse({ id: "oura-user" });
+      }
+      if (url.includes("/usercollection/daily_activity")) {
+        activityPages += 1;
+        clock += 30_000;
+        return jsonResponse({
+          data: [],
+          next_token: `unique-${activityPages}`,
+        });
+      }
+      return jsonResponse({ data: [], next_token: null });
+    });
+
+    await expect(
+      syncHealthConnectorData({
+        token,
+        grantId: "grant-oura",
+        startDate: "2026-05-01",
+        endDate: "2026-05-01",
+      }),
+    ).rejects.toThrow("Oura pagination exceeded the sync deadline");
+    expect(activityPages).toBeLessThanOrEqual(2);
   });
 });

--- a/plugins/plugin-mcp/__tests__/mcp-marketplace.test.ts
+++ b/plugins/plugin-mcp/__tests__/mcp-marketplace.test.ts
@@ -7,7 +7,6 @@ import { getEventListeners } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getMcpServerDetails,
-  MAX_MCP_MARKETPLACE_PAGES,
   McpMarketplaceError,
   searchMcpMarketplace,
 } from "../src/mcp-marketplace.js";
@@ -333,11 +332,11 @@ describe("MCP marketplace client", () => {
     );
   });
 
-  it("allows a match on the final page in the request budget", async () => {
+  it("allows a match beyond the former fixed page ceiling", async () => {
     let callIndex = 0;
     fetchMock.mockImplementation(async () => {
       callIndex += 1;
-      if (callIndex === MAX_MCP_MARKETPLACE_PAGES) {
+      if (callIndex === 201) {
         return jsonResponse(
           registryPage([
             {
@@ -355,7 +354,7 @@ describe("MCP marketplace client", () => {
     await expect(searchMcpMarketplace("last page", 1)).resolves.toEqual({
       results: [expect.objectContaining({ name: "io.example/final-page" })],
     });
-    expect(fetchMock).toHaveBeenCalledTimes(MAX_MCP_MARKETPLACE_PAGES);
+    expect(fetchMock).toHaveBeenCalledTimes(201);
   });
 
   it("rejects a pagination cursor cycle before refetching it", async () => {
@@ -366,23 +365,6 @@ describe("MCP marketplace client", () => {
       message: expect.stringContaining("repeated a pagination cursor"),
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("rejects MCP registry pagination exceeding the maximum page limit", async () => {
-    let callIndex = 0;
-    fetchMock.mockImplementation(async () => {
-      callIndex += 1;
-      return jsonResponse(registryPage([], `runaway-cursor-${callIndex}`));
-    });
-
-    await expect(searchMcpMarketplace("unmatched-query", 10)).rejects.toMatchObject({
-      code: "invalid_response",
-      message: expect.stringContaining(
-        `pagination exceeded ${MAX_MCP_MARKETPLACE_PAGES} page limit`
-      ),
-    });
-
-    expect(fetchMock).toHaveBeenCalledTimes(MAX_MCP_MARKETPLACE_PAGES);
   });
 
   it("rejects declared and streamed responses over the configured byte cap", async () => {

--- a/plugins/plugin-mcp/src/mcp-marketplace.ts
+++ b/plugins/plugin-mcp/src/mcp-marketplace.ts
@@ -9,9 +9,6 @@ export const DEFAULT_MCP_MARKETPLACE_MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 const MAX_MCP_MARKETPLACE_TIMEOUT_MS = 2 * 60_000;
 const MAX_MCP_MARKETPLACE_RESPONSE_BYTES = 8 * 1024 * 1024;
 const MAX_MCP_MARKETPLACE_RESULTS = 50;
-// This is a request-count backstop for pathological tiny/empty pages. The
-// byte and deadline budgets normally bind first for a legitimate catalog.
-export const MAX_MCP_MARKETPLACE_PAGES = 200;
 
 export type McpMarketplaceErrorCode =
   | "aborted"
@@ -503,13 +500,8 @@ export async function searchMcpMarketplace(
     const pageLimit = normalizedQuery ? MAX_MCP_MARKETPLACE_RESULTS : requestedLimit;
     let cursor: string | undefined;
     const seenCursors = new Set<string>();
-    let pageCount = 0;
 
     do {
-      pageCount += 1;
-      if (pageCount > MAX_MCP_MARKETPLACE_PAGES) {
-        invalidResponse(`MCP registry pagination exceeded ${MAX_MCP_MARKETPLACE_PAGES} page limit`);
-      }
       const page = await fetchRegistryJson(
         createSearchUrl(pageLimit, cursor),
         parseListResponse,

--- a/plugins/plugin-meetings/src/platforms/zoom/__tests__/cloud-import.test.ts
+++ b/plugins/plugin-meetings/src/platforms/zoom/__tests__/cloud-import.test.ts
@@ -215,14 +215,18 @@ describe("Zoom cloud import", () => {
     expect(participantCalls).toBe(3);
   });
 
-  it("stops before requesting a 101st participant page", async () => {
+  it("accepts participants beyond the former 100-page ceiling", async () => {
     let participantCalls = 0;
     const fetchImpl = async (input: RequestInfo | URL): Promise<Response> => {
       if (String(input).includes("/participants")) {
         participantCalls += 1;
         return json({
-          participants: [],
-          next_page_token: `unique-token-${participantCalls}`,
+          participants:
+            participantCalls === 101
+              ? [{ id: "participant-101", name: "Late" }]
+              : [],
+          next_page_token:
+            participantCalls === 101 ? "" : `unique-token-${participantCalls}`,
         });
       }
       return json({ uuid: "meeting-page-limit" });
@@ -234,11 +238,14 @@ describe("Zoom cloud import", () => {
         accessToken: TOKEN,
         fetchImpl,
       }),
-    ).rejects.toMatchObject<Partial<ZoomCloudImportError>>({
-      code: "invalid_response",
-      status: 502,
+    ).resolves.toMatchObject({
+      artifact: {
+        platformParticipants: [
+          expect.objectContaining({ id: "participant-101" }),
+        ],
+      },
     });
-    expect(participantCalls).toBe(100);
+    expect(participantCalls).toBe(101);
   });
 
   it("fails closed when a streamed recording exceeds its byte quota", async () => {

--- a/plugins/plugin-meetings/src/platforms/zoom/cloud-import.ts
+++ b/plugins/plugin-meetings/src/platforms/zoom/cloud-import.ts
@@ -22,7 +22,6 @@ const ZOOM_API_BASE = "https://api.zoom.us/v2";
 const DEFAULT_JSON_LIMIT = 8 * 1024 * 1024;
 const DEFAULT_FILE_LIMIT = 256 * 1024 * 1024;
 const DEFAULT_TOTAL_LIMIT = 512 * 1024 * 1024;
-const MAX_PARTICIPANT_PAGES = 100;
 
 type FetchLike = (
   input: RequestInfo | URL,
@@ -258,16 +257,7 @@ async function requestAllParticipants(
   const participants: ZoomParticipantResponse[] = [];
   const seenTokens = new Set<string>();
   let token: string | undefined;
-  let pageCount = 0;
   do {
-    pageCount += 1;
-    if (pageCount > MAX_PARTICIPANT_PAGES) {
-      throw new ZoomCloudImportError(
-        "invalid_response",
-        `Zoom participants pagination exceeded ${MAX_PARTICIPANT_PAGES} pages.`,
-        502,
-      );
-    }
     const url = new URL(
       `${ZOOM_API_BASE}/past_meetings/${encodedId}/participants`,
     );

--- a/plugins/plugin-notion/src/__tests__/client.test.ts
+++ b/plugins/plugin-notion/src/__tests__/client.test.ts
@@ -265,6 +265,58 @@ describe("NotionClient.getPageContent", () => {
     // page read + two block pages
     expect(requests).toHaveLength(3);
   });
+
+  it("follows block cursors until the provider reaches a terminal page", async () => {
+    const pageId = "11111111-2222-3333-4444-555555555555";
+    let blockPage = 0;
+    const { fetchImpl, requests } = fakeNotion((request) => {
+      if (request.url.includes("/v1/pages/")) {
+        return { status: 200, body: page(pageId, "Long Doc") };
+      }
+      blockPage += 1;
+      return {
+        status: 200,
+        body: {
+          object: "list",
+          results: [
+            {
+              object: "block",
+              type: "paragraph",
+              paragraph: { rich_text: [{ plain_text: `line-${blockPage}` }] },
+            },
+          ],
+          next_cursor: blockPage <= 20 ? `cursor-${blockPage + 1}` : null,
+          has_more: blockPage <= 20,
+        },
+      };
+    });
+
+    const content = await client(fetchImpl).getPageContent({ accountId: "acct", pageId });
+
+    expect(content.plainText.split("\n")).toHaveLength(21);
+    expect(content.plainText).toContain("line-21");
+    expect(requests).toHaveLength(22);
+  });
+
+  it("rejects a repeated block continuation cursor", async () => {
+    const pageId = "11111111-2222-3333-4444-555555555555";
+    const { fetchImpl } = fakeNotion((request) => {
+      if (request.url.includes("/v1/pages/")) {
+        return { status: 200, body: page(pageId, "Looping Doc") };
+      }
+      return {
+        status: 200,
+        body: { object: "list", results: [], next_cursor: "same-cursor", has_more: true },
+      };
+    });
+
+    const error = await client(fetchImpl)
+      .getPageContent({ accountId: "acct", pageId })
+      .catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ElizaError);
+    expect((error as ElizaError).code).toBe("NOTION_MALFORMED_RESPONSE");
+  });
 });
 
 describe("NotionClient writes", () => {

--- a/plugins/plugin-notion/src/__tests__/client.test.ts
+++ b/plugins/plugin-notion/src/__tests__/client.test.ts
@@ -317,6 +317,42 @@ describe("NotionClient.getPageContent", () => {
     expect(error).toBeInstanceOf(ElizaError);
     expect((error as ElizaError).code).toBe("NOTION_MALFORMED_RESPONSE");
   });
+
+  it("bounds endlessly advancing block cursors by one operation deadline", async () => {
+    const pageId = "11111111-2222-3333-4444-555555555555";
+    let clock = 0;
+    let blockPage = 0;
+    const { fetchImpl } = fakeNotion((request) => {
+      if (request.url.includes("/v1/pages/")) {
+        return { status: 200, body: page(pageId, "Endless Doc") };
+      }
+      blockPage += 1;
+      clock += 1;
+      return {
+        status: 200,
+        body: {
+          object: "list",
+          results: [],
+          next_cursor: `unique-${blockPage}`,
+          has_more: true,
+        },
+      };
+    });
+    const notion = new NotionClient(resolver, {
+      baseUrl: "https://notion.test",
+      fetchImpl,
+      operationTimeoutMs: 3,
+      now: () => clock,
+    });
+
+    const error = await notion
+      .getPageContent({ accountId: "acct", pageId })
+      .catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ElizaError);
+    expect((error as ElizaError).code).toBe("NOTION_UPSTREAM_FAILURE");
+    expect(blockPage).toBe(3);
+  });
 });
 
 describe("NotionClient writes", () => {

--- a/plugins/plugin-notion/src/client.ts
+++ b/plugins/plugin-notion/src/client.ts
@@ -29,8 +29,6 @@ const NOTION_MAX_JSON_BYTES = 4_000_000;
 const NOTION_MAX_ERROR_BYTES = 64_000;
 
 const MAX_PAGE_SIZE = 100;
-/** Cap block-children pagination so one pathological page cannot spin forever. */
-const MAX_CONTENT_PAGES = 20;
 
 type JsonRecord = Record<string, unknown>;
 
@@ -91,8 +89,9 @@ export class NotionClient {
     const page = await this.getPage(params);
     const lines: string[] = [];
     const unsupported = new Set<string>();
+    const seenCursors = new Set<string>();
     let cursor: string | null = null;
-    for (let fetched = 0; fetched < MAX_CONTENT_PAGES; fetched += 1) {
+    while (true) {
       const query = cursor
         ? `?page_size=${MAX_PAGE_SIZE}&start_cursor=${encodeURIComponent(cursor)}`
         : `?page_size=${MAX_PAGE_SIZE}`;
@@ -109,8 +108,25 @@ export class NotionClient {
           unsupported.add(typeof block.type === "string" ? block.type : "unknown");
         }
       }
-      cursor = payload.has_more === true ? readNullableString(payload, "next_cursor") : null;
-      if (!cursor) break;
+      if (payload.has_more !== true) break;
+      const nextCursor = readNullableString(payload, "next_cursor");
+      if (!nextCursor) {
+        throw new ElizaError(
+          "NotionClient: block pagination claimed more results without a continuation cursor.",
+          {
+            code: "NOTION_MALFORMED_RESPONSE",
+            context: { pageId: params.pageId, accountId: params.accountId },
+          }
+        );
+      }
+      if (seenCursors.has(nextCursor)) {
+        throw new ElizaError("NotionClient: block pagination repeated a continuation cursor.", {
+          code: "NOTION_MALFORMED_RESPONSE",
+          context: { pageId: params.pageId, accountId: params.accountId, cursor: nextCursor },
+        });
+      }
+      seenCursors.add(nextCursor);
+      cursor = nextCursor;
     }
     return {
       id: page.id,

--- a/plugins/plugin-notion/src/client.ts
+++ b/plugins/plugin-notion/src/client.ts
@@ -24,6 +24,8 @@ export const NOTION_API_VERSION = "2022-06-28";
 export const NOTION_DEFAULT_BASE_URL = "https://api.notion.com";
 /** Maximum time allowed for one Notion API request. */
 export const NOTION_FETCH_TIMEOUT_MS = 20_000;
+/** Maximum wall-clock time for one multi-page Notion operation. */
+export const NOTION_OPERATION_TIMEOUT_MS = 60_000;
 
 const NOTION_MAX_JSON_BYTES = 4_000_000;
 const NOTION_MAX_ERROR_BYTES = 64_000;
@@ -36,12 +38,16 @@ export interface NotionClientOptions {
   baseUrl?: string;
   fetchImpl?: typeof fetch;
   timeoutMs?: number;
+  operationTimeoutMs?: number;
+  now?: () => number;
 }
 
 export class NotionClient {
   private readonly baseUrl: string;
   private readonly fetchImpl: typeof fetch;
   private readonly timeoutMs: number;
+  private readonly operationTimeoutMs: number;
+  private readonly now: () => number;
 
   constructor(
     private readonly credentialResolver: NotionCredentialResolver,
@@ -54,6 +60,8 @@ export class NotionClient {
     ).replace(/\/$/, "");
     this.fetchImpl = options.fetchImpl ?? globalThis.fetch;
     this.timeoutMs = options.timeoutMs ?? NOTION_FETCH_TIMEOUT_MS;
+    this.operationTimeoutMs = options.operationTimeoutMs ?? NOTION_OPERATION_TIMEOUT_MS;
+    this.now = options.now ?? Date.now;
   }
 
   async search(
@@ -86,12 +94,15 @@ export class NotionClient {
   }
 
   async getPageContent(params: NotionAccountRef & { pageId: string }): Promise<NotionPageContent> {
+    const deadline = this.now() + this.operationTimeoutMs;
     const page = await this.getPage(params);
+    this.assertTraversalDeadline(deadline, params);
     const lines: string[] = [];
     const unsupported = new Set<string>();
     const seenCursors = new Set<string>();
     let cursor: string | null = null;
     while (true) {
+      this.assertTraversalDeadline(deadline, params);
       const query = cursor
         ? `?page_size=${MAX_PAGE_SIZE}&start_cursor=${encodeURIComponent(cursor)}`
         : `?page_size=${MAX_PAGE_SIZE}`;
@@ -100,6 +111,7 @@ export class NotionClient {
         "GET",
         `/v1/blocks/${encodeURIComponent(params.pageId)}/children${query}`
       );
+      this.assertTraversalDeadline(deadline, params);
       for (const block of readArray(payload, "results")) {
         const text = blockPlainText(block);
         if (text !== null) {
@@ -135,6 +147,21 @@ export class NotionClient {
       plainText: lines.join("\n"),
       unsupportedBlockTypes: [...unsupported].sort(),
     };
+  }
+
+  private assertTraversalDeadline(
+    deadline: number,
+    params: NotionAccountRef & { pageId: string }
+  ): void {
+    if (this.now() < deadline) return;
+    throw new ElizaError("NotionClient: block pagination exceeded the operation deadline.", {
+      code: "NOTION_UPSTREAM_FAILURE",
+      context: {
+        pageId: params.pageId,
+        accountId: params.accountId,
+        operationTimeoutMs: this.operationTimeoutMs,
+      },
+    });
   }
 
   async createPage(params: NotionCreatePageInput): Promise<NotionObjectSummary> {

--- a/plugins/plugin-slack/src/policy.test.ts
+++ b/plugins/plugin-slack/src/policy.test.ts
@@ -6,7 +6,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ResolvedSlackAccount, SlackAccountConfig } from "./accounts";
 import {
-  MAX_SLACK_DIRECTORY_PAGES,
   SlackAccountPolicyResolver,
   type SlackInboundEventContext,
   SlackPolicyConfigurationError,
@@ -577,69 +576,13 @@ describe("SlackAccountPolicyResolver event policy", () => {
     ).rejects.toThrowError(SlackPolicyConfigurationError);
   });
 
-  it("rejects channel directory pagination exceeding the maximum page limit", async () => {
+  it("accepts a channel beyond the former fixed directory-page ceiling", async () => {
     let callCount = 0;
     const client = {
       conversations: {
         list: vi.fn().mockImplementation(async () => {
           callCount += 1;
-          return {
-            channels: [],
-            response_metadata: { next_cursor: `cursor-${callCount}` },
-          };
-        }),
-        info: vi.fn(),
-      },
-      users: {
-        list: vi.fn().mockResolvedValue({ members: [] }),
-      },
-    } as unknown as SlackPolicyDirectoryClient;
-
-    await expect(
-      resolver(
-        { groupPolicy: "allowlist", channels: { ops: true } },
-        { client, accountId: "test-acc" },
-      ),
-    ).rejects.toThrowError(
-      /channel directory exceeds the 250-page safety limit/,
-    );
-    expect(callCount).toBe(MAX_SLACK_DIRECTORY_PAGES);
-  });
-
-  it("rejects user directory pagination exceeding the maximum page limit", async () => {
-    let callCount = 0;
-    const client = {
-      conversations: {
-        list: vi.fn().mockResolvedValue({ channels: [] }),
-        info: vi.fn(),
-      },
-      users: {
-        list: vi.fn().mockImplementation(async () => {
-          callCount += 1;
-          return {
-            members: [],
-            response_metadata: { next_cursor: `cursor-${callCount}` },
-          };
-        }),
-      },
-    } as unknown as SlackPolicyDirectoryClient;
-
-    await expect(
-      resolver(
-        { dm: { policy: "allowlist", allowFrom: ["alice"] } },
-        { client, accountId: "test-acc" },
-      ),
-    ).rejects.toThrowError(/user directory exceeds the 250-page safety limit/);
-    expect(callCount).toBe(MAX_SLACK_DIRECTORY_PAGES);
-  });
-
-  it("accepts a channel found on the final legal directory page", async () => {
-    let callCount = 0;
-    const client = {
-      conversations: {
-        list: vi.fn().mockImplementation(async () => {
-          callCount += 1;
-          const isFinal = callCount === MAX_SLACK_DIRECTORY_PAGES;
+          const isFinal = callCount === 251;
           return {
             channels: isFinal ? [{ id: CHANNEL, name: "ops" }] : [],
             response_metadata: {
@@ -657,13 +600,13 @@ describe("SlackAccountPolicyResolver event policy", () => {
       { client, accountId: "test-acc" },
     );
 
-    expect(callCount).toBe(MAX_SLACK_DIRECTORY_PAGES);
+    expect(callCount).toBe(251);
     await expect(
       compiled.authorize(event({ channelId: CHANNEL, userId: ALICE })),
     ).resolves.toMatchObject({ allowed: true });
   });
 
-  it("accepts a user found on the final legal directory page", async () => {
+  it("accepts a user beyond the former fixed directory-page ceiling", async () => {
     let callCount = 0;
     const client = {
       conversations: {
@@ -673,7 +616,7 @@ describe("SlackAccountPolicyResolver event policy", () => {
       users: {
         list: vi.fn().mockImplementation(async () => {
           callCount += 1;
-          const isFinal = callCount === MAX_SLACK_DIRECTORY_PAGES;
+          const isFinal = callCount === 251;
           return {
             members: isFinal ? [{ id: ALICE, name: "alice" }] : [],
             response_metadata: {
@@ -689,7 +632,7 @@ describe("SlackAccountPolicyResolver event policy", () => {
       { client, accountId: "test-acc" },
     );
 
-    expect(callCount).toBe(MAX_SLACK_DIRECTORY_PAGES);
+    expect(callCount).toBe(251);
     await expect(
       compiled.authorize(
         event({ channelId: DM, userId: ALICE, channelType: "im" }),

--- a/plugins/plugin-slack/src/policy.ts
+++ b/plugins/plugin-slack/src/policy.ts
@@ -966,8 +966,6 @@ function classifyDirectoryChannel(
   return "public_channel";
 }
 
-export const MAX_SLACK_DIRECTORY_PAGES = 250;
-
 async function listAllChannels(
   client: SlackPolicyDirectoryClient,
   accountId: string,
@@ -975,15 +973,7 @@ async function listAllChannels(
   const result: SlackDirectoryChannel[] = [];
   const seenCursors = new Set<string>();
   let cursor: string | undefined;
-  let pageCount = 0;
   do {
-    pageCount += 1;
-    if (pageCount > MAX_SLACK_DIRECTORY_PAGES) {
-      throw new SlackPolicyConfigurationError(
-        "channel directory exceeds the 250-page safety limit; use immutable IDs only",
-        accountId,
-      );
-    }
     const page = await client.conversations.list({
       ...(cursor ? { cursor } : {}),
       limit: 200,
@@ -1018,15 +1008,7 @@ async function listAllUsers(
   const result: SlackDirectoryUser[] = [];
   const seenCursors = new Set<string>();
   let cursor: string | undefined;
-  let pageCount = 0;
   do {
-    pageCount += 1;
-    if (pageCount > MAX_SLACK_DIRECTORY_PAGES) {
-      throw new SlackPolicyConfigurationError(
-        "user directory exceeds the 250-page safety limit; use explicit id:<opaque-slack-id> entries",
-        accountId,
-      );
-    }
     const page = await client.users.list({
       ...(cursor ? { cursor } : {}),
       limit: 200,

--- a/plugins/plugin-x/src/client/retweeters.test.ts
+++ b/plugins/plugin-x/src/client/retweeters.test.ts
@@ -1,8 +1,8 @@
 /**
  * Unit tests for `fetchRetweetersPage` (Twitter API v2 retweeter payload
  * mapping) and `getAllRetweeters` (pagination termination, including
- * repeated-cursor and page-cap guards against an API that never stops
- * paginating); mocked API.
+ * repeated-cursor rejection and traversal beyond the former fixed ceiling);
+ * mocked API.
  */
 import { describe, expect, it, vi } from "vitest";
 import { fetchRetweetersPage, getAllRetweeters } from "./tweets";
@@ -186,11 +186,13 @@ describe("getAllRetweeters", () => {
     );
   });
 
-  it("caps total pages so a provider that never repeats but never stops still terminates", async () => {
+  it("accepts a valid result beyond the former 1000-page ceiling", async () => {
     let page = 0;
     const tweetRetweetedBy = vi.fn().mockImplementation(async () => {
       page += 1;
-      return retweeterPage(`user-${page}`, `cursor-${page}`);
+      return page === 1001
+        ? terminalPage(`user-${page}`)
+        : retweeterPage(`user-${page}`, `cursor-${page}`);
     });
     const auth = {
       getV2Client: async () => ({ v2: { tweetRetweetedBy } }),
@@ -198,7 +200,7 @@ describe("getAllRetweeters", () => {
 
     await expect(
       getAllRetweeters("tweet-1", auth as never),
-    ).rejects.toMatchObject({ code: "X_RETWEETERS_PAGINATION_LIMIT_EXCEEDED" });
-    expect(tweetRetweetedBy).toHaveBeenCalledTimes(1000);
+    ).resolves.toHaveLength(1001);
+    expect(tweetRetweetedBy).toHaveBeenCalledTimes(1001);
   });
 });

--- a/plugins/plugin-x/src/client/timeline-pagination.test.ts
+++ b/plugins/plugin-x/src/client/timeline-pagination.test.ts
@@ -4,10 +4,9 @@
  * `getTweetsAndRepliesByUserId` in `tweets.ts` and
  * `Client.getUserTweetsIterator` in `client.ts`).
  *
- * These pin two things: that a provider which never stops paginating —
- * including the real X API v2 case of a page with zero tweets and a live
- * `next_token` — terminates with a typed error instead of looping forever, and
- * that ordinary multi-page timelines still page through to completion.
+ * These pin two things: repeated provider cursors fail instead of looping, and
+ * ordinary multi-page timelines follow provider continuation tokens through
+ * to completion without an arbitrary page ceiling.
  *
  * The provider is a local re-implementation of the `twitter-api-v2` paginator
  * surface these helpers touch: async iteration over the page's tweets,
@@ -26,7 +25,6 @@ import {
   getTweetsAndReplies,
   getTweetsAndRepliesByUserId,
   getTweetsByUserId,
-  MAX_TIMELINE_PAGES,
 } from "./tweets";
 
 const WATCHDOG_MS = 5_000;
@@ -119,13 +117,6 @@ async function terminationOf(
   return outcome;
 }
 
-/** Every page is empty but always advertises a brand new cursor — the real X
- * API v2 shape when server-side filtering empties a non-final page. */
-const emptyPageWithNovelCursor = (index: number): Page => ({
-  ids: [],
-  next: `cursor-${index}`,
-});
-
 let screenNameSeq = 0;
 /** Unique screen name per case so the profile id cache cannot mask a lookup. */
 function freshScreenName() {
@@ -133,19 +124,7 @@ function freshScreenName() {
   return `alice-${screenNameSeq}`;
 }
 
-describe("user-timeline pagination is bounded", () => {
-  it("getTweets stops on empty pages that keep advertising a new cursor", async () => {
-    const { auth, state } = stubAuth(emptyPageWithNovelCursor);
-
-    expect(
-      await terminationOf(
-        getTweets(freshScreenName(), 200, auth as never),
-        state,
-      ),
-    ).toBe("X_TIMELINE_PAGINATION_LIMIT_EXCEEDED");
-    expect(state.calls).toBe(MAX_TIMELINE_PAGES);
-  }, 30_000);
-
+describe("user-timeline pagination rejects cursor cycles", () => {
   it("getTweetsByUserId stops when the provider repeats a cursor", async () => {
     const { auth, state } = stubAuth(() => ({ ids: [], next: "stuck" }));
 
@@ -173,30 +152,6 @@ describe("user-timeline pagination is bounded", () => {
       ),
     ).toBe("X_TIMELINE_PAGINATION_CURSOR_REPEATED");
     expect(state.calls).toBe(3);
-  }, 30_000);
-
-  it("getTweetsAndRepliesByUserId stops on perpetually novel cursors", async () => {
-    const { auth, state } = stubAuth(emptyPageWithNovelCursor);
-
-    expect(
-      await terminationOf(
-        getTweetsAndRepliesByUserId("user-1", 200, auth as never),
-        state,
-      ),
-    ).toBe("X_TIMELINE_PAGINATION_LIMIT_EXCEEDED");
-    expect(state.calls).toBe(MAX_TIMELINE_PAGES);
-  }, 30_000);
-
-  it("Client.getUserTweetsIterator stops on perpetually novel cursors", async () => {
-    const { auth, state } = stubAuth(emptyPageWithNovelCursor);
-
-    expect(
-      await terminationOf(
-        clientWith(auth).getUserTweetsIterator("user-1", 200),
-        state,
-      ),
-    ).toBe("X_TIMELINE_PAGINATION_LIMIT_EXCEEDED");
-    expect(state.calls).toBe(MAX_TIMELINE_PAGES);
   }, 30_000);
 });
 
@@ -253,19 +208,18 @@ describe("ordinary timelines still page through completely", () => {
     expect(state.calls).toBe(3);
   });
 
-  it("a timeline that legitimately ends on the last allowed page still completes", async () => {
+  it("a timeline beyond the former thousand-page ceiling still completes", async () => {
+    const formerPageLimit = 1_000;
     const { auth, state } = stubAuth((index) =>
-      index < MAX_TIMELINE_PAGES - 1
-        ? { ids: [`t${index}`], next: `cursor-${index}` }
-        : { ids: [`t${index}`] },
+      index < formerPageLimit
+        ? { ids: [], next: `cursor-${index}` }
+        : { ids: ["after-former-limit"] },
     );
 
-    const ids = await collect(
-      getTweetsByUserId("user-1", MAX_TIMELINE_PAGES, auth as never),
-    );
+    const ids = await collect(getTweetsByUserId("user-1", 1, auth as never));
 
-    expect(ids).toHaveLength(MAX_TIMELINE_PAGES);
-    expect(state.calls).toBe(MAX_TIMELINE_PAGES);
+    expect(ids).toEqual(["after-former-limit"]);
+    expect(state.calls).toBe(formerPageLimit + 1);
   }, 30_000);
 
   it("a satisfied request returns normally even if its last page repeats a cursor", async () => {

--- a/plugins/plugin-x/src/client/tweets.ts
+++ b/plugins/plugin-x/src/client/tweets.ts
@@ -711,19 +711,6 @@ export async function deleteTweet(tweetId: string, auth: TwitterAuth) {
 }
 
 /**
- * Bounds the user-timeline pagination generators against a provider that never
- * stops paginating. `userTimeline` legitimately answers with zero tweets and a
- * non-empty `next_token` — server-side filtering (`exclude: ["retweets",
- * "replies"]`) can empty a page that still has data behind it — so a loop
- * guarded only by a fetched-tweet counter never advances that counter and never
- * terminates. X serves at most 3,200 recent tweets per user timeline, so 1,000
- * pages is ~30x more than a well-behaved provider can ever need while keeping
- * worst-case requests finite. Same bound, and the same repeated-cursor guard,
- * that `getAllRetweeters` below already carries.
- */
-export const MAX_TIMELINE_PAGES = 1000;
-
-/**
  * Resolves the cursor for the next timeline page, or `undefined` when the
  * provider signalled the end of the timeline.
  *
@@ -740,8 +727,7 @@ export function nextTimelinePageCursor(
   seenCursors: Set<string>,
   pageCount: number,
 ): string | undefined {
-  // A terminal page ends the run before any guard applies, so a timeline that
-  // legitimately ends on page 1,000 still completes.
+  // A terminal page ends the run before any integrity guard applies.
   if (!next) {
     return undefined;
   }
@@ -754,16 +740,6 @@ export function nextTimelinePageCursor(
       `X timeline pagination in ${source} repeated a page cursor`,
       {
         code: "X_TIMELINE_PAGINATION_CURSOR_REPEATED",
-        context: { source, pageCount },
-      },
-    );
-  }
-
-  if (pageCount >= MAX_TIMELINE_PAGES) {
-    throw new ElizaError(
-      `X timeline pagination in ${source} exceeded ${MAX_TIMELINE_PAGES} pages`,
-      {
-        code: "X_TIMELINE_PAGINATION_LIMIT_EXCEEDED",
         context: { source, pageCount },
       },
     );

--- a/plugins/plugin-x/src/client/tweets.ts
+++ b/plugins/plugin-x/src/client/tweets.ts
@@ -1370,11 +1370,6 @@ export async function fetchRetweetersPage(
   };
 }
 
-// Bounds `getAllRetweeters` against a provider that never stops paginating
-// (repeated or perpetually-novel cursors) — 1,000 pages * 40/page covers even
-// a very viral tweet while keeping worst-case requests/memory finite.
-const MAX_RETWEETER_PAGES = 1000;
-
 /**
  * Retrieves *all* retweeters by chaining requests until no next cursor is found.
  * @param tweetId The ID of the tweet.
@@ -1392,16 +1387,6 @@ export async function getAllRetweeters(
 
   while (true) {
     pageCount += 1;
-    if (pageCount > MAX_RETWEETER_PAGES) {
-      throw new ElizaError(
-        `Retweeter pagination for tweet ${tweetId} exceeded ${MAX_RETWEETER_PAGES} pages`,
-        {
-          code: "X_RETWEETERS_PAGINATION_LIMIT_EXCEEDED",
-          context: { tweetId, pageCount },
-        },
-      );
-    }
-
     const { retweeters, bottomCursor } = await fetchRetweetersPage(
       tweetId,
       auth,

--- a/plugins/plugin-x/src/direct-messages.test.ts
+++ b/plugins/plugin-x/src/direct-messages.test.ts
@@ -601,15 +601,15 @@ describe("TwitterDirectMessageClient", () => {
     await dmClient.stop();
   });
 
-  it("paginates beyond twenty pages without advancing past unseen events", async () => {
+  it("paginates beyond the former thousand-page ceiling without advancing past unseen events", async () => {
     vi.useFakeTimers();
     const paginator = {
       events: [
         {
-          id: "122",
+          id: "1102",
           sender_id: "person-1",
           dm_conversation_id: "conversation-1",
-          text: "message 122",
+          text: "message 1102",
           event_type: "MessageCreate",
         },
       ],
@@ -618,7 +618,7 @@ describe("TwitterDirectMessageClient", () => {
       },
       done: false,
       fetchNext: vi.fn(async () => {
-        const oldest = Number(paginator.events.at(-1)?.id ?? "122");
+        const oldest = Number(paginator.events.at(-1)?.id ?? "1102");
         paginator.events.push({
           id: String(oldest - 1),
           sender_id: "person-1",
@@ -675,9 +675,9 @@ describe("TwitterDirectMessageClient", () => {
     } as unknown as TwitterClientState);
 
     await dmClient.start();
-    expect(paginator.fetchNext).toHaveBeenCalledTimes(22);
-    expect(handleMessage).toHaveBeenCalledTimes(22);
-    expect(cache.get("twitter/agent/agent-user-id/dm_cursor")).toBe("122");
+    expect(paginator.fetchNext).toHaveBeenCalledTimes(1002);
+    expect(handleMessage).toHaveBeenCalledTimes(1002);
+    expect(cache.get("twitter/agent/agent-user-id/dm_cursor")).toBe("1102");
     await dmClient.stop();
   });
 

--- a/plugins/plugin-x/src/direct-messages.ts
+++ b/plugins/plugin-x/src/direct-messages.ts
@@ -57,9 +57,6 @@ interface DirectMessagePage {
   fetchNext?: (maxResults?: number) => Promise<unknown>;
 }
 
-/** Fail closed before an anomalous paginator can monopolize the polling loop. */
-const MAX_DM_PAGES_PER_POLL = 1_000;
-
 function parseBoolean(value: unknown, fallback: boolean): boolean {
   if (typeof value === "boolean") return value;
   if (typeof value !== "string" || !value.trim()) return fallback;
@@ -271,7 +268,6 @@ export class TwitterDirectMessageClient {
     // needs the newest event, so it never paginates.
     if (cursor) {
       let previousEventCount = -1;
-      let fetchedPages = 1;
       while (page.done === false && typeof page.fetchNext === "function") {
         const fetched = collectEvents();
         const oldest = fetched[fetched.length - 1];
@@ -282,13 +278,7 @@ export class TwitterDirectMessageClient {
           );
         }
         previousEventCount = fetched.length;
-        if (fetchedPages >= MAX_DM_PAGES_PER_POLL) {
-          throw new Error(
-            `X DM catch-up exceeded ${MAX_DM_PAGES_PER_POLL} pages before reaching the durable cursor.`,
-          );
-        }
         await page.fetchNext(50);
-        fetchedPages += 1;
       }
     }
 

--- a/scripts/audit-ai-workflow-output.mjs
+++ b/scripts/audit-ai-workflow-output.mjs
@@ -22,7 +22,6 @@ import { evaluateCommentAttribution } from "./check-agent-comment-attribution.mj
 const API_ROOT = "https://api.github.com";
 const API_VERSION = "2022-11-28";
 const PAGE_SIZE = 100;
-const MAX_PAGES = 20;
 const MAX_SNAPSHOT_CHARACTERS = 400_000;
 const REPOSITORY_RE =
   /^[a-z0-9](?:[a-z0-9_.-]{0,99})\/[a-z0-9](?:[a-z0-9_.-]{0,99})$/i;
@@ -232,7 +231,7 @@ export function createGithubReader({
 
   async function getAll(endpoint, query = {}) {
     const values = [];
-    for (let page = 1; page <= MAX_PAGES; page += 1) {
+    for (let page = 1; ; page += 1) {
       const batch = ensureArray(
         await get(endpoint, { ...query, per_page: PAGE_SIZE, page }),
         endpoint,
@@ -240,9 +239,6 @@ export function createGithubReader({
       values.push(...batch);
       if (batch.length < PAGE_SIZE) return values;
     }
-    throw new Error(
-      `GitHub GET ${endpoint} exceeded the ${MAX_PAGES * PAGE_SIZE}-record audit limit`,
-    );
   }
 
   return { get, getAll };


### PR DESCRIPTION
Closes #24106.

## Outcome

This replaces arbitrary fixed traversal ceilings with terminal provider semantics across the repository surfaces found in the audit:

- drain cursors until the provider reports completion
- reject repeated and longer cursor cycles with bounded cursor state
- preserve explicit caller-requested result limits and provider page-size limits
- retain response-byte, admission, retry, and concurrency bounds that protect a real resource rather than truncate valid traversal
- add one overall operation deadline where a provider can emit infinitely many unique cursors (Notion, Oura, Stripe reconciliation)
- time-slice filtered chat history and return/persist a resumable `before` cursor instead of repeating pages or silently truncating

Affected collectors include managed-provider documents, Google/Microsoft calendars, Gmail/Meet, GitHub notifications, Slack, MCP marketplace, Zoom imports, X timelines/DMs/retweeters, finances, skill catalog startup, cloud admin traversals, and associated audit scripts.

The original omnibus was split after review:

- TikTok issue #23834: merged separately in #23972
- R2 streaming/browser integrity issue #24105: merged separately in #24111
- this PR: traversal-only issue #24106

## Exact-head verification

Verified revision: `dd33a950c4e7246560718fc9b4775864e3956a14`

Full owning suites:

- Agent Skills: 377 pass
- Calendar: 642 pass, 4 skipped
- Finances: 143 pass
- GitHub: 140 pass
- Google Workspace: 317 pass
- Health: 204 pass, 4 skipped
- MCP: 125 pass, 3 skipped
- Meetings: 252 pass
- Notion: 31 pass
- Slack: 167 pass

Focused boundary suites:

- core documents + managed provider: 31 pass
- UI older-message traversal/resumption: 9 pass
- X timeline/DM/retweeter pagination: 36 pass
- cloud shared calendar pagination: 5 pass
- Stripe reconciliation: 12 pass across both routes
- Oura contract: 4 pass, including endlessly unique cursors

Static gates:

- typecheck: cloud API/shared, core, UI, Agent Skills, Calendar, Finances, GitHub, Google Workspace, Health, MCP, Meetings, Notion, Slack, X — pass
- Biome on all 52 changed files and `git diff --check` — pass

## Evidence and boundaries

| Surface | Evidence |
| --- | --- |
| Valid long traversal | tests cross the former 5-page and 1,000-page ceilings and reach terminal pages |
| Cursor adversary | repeated cursors and longer A→B→A cycles fail explicitly |
| Unique-cursor adversary | Notion/Oura/Stripe deadlines and UI resumption prevent unbounded per-operation work |
| UI behavior | deterministic state test proves time-sliced filtered history resumes from the returned cursor |
| Visual screenshots/video | N/A — continuation state is nonvisual; the app audit was attempted but the machine exhausted disk while packaging core before capture |
| Live provider credentials | N/A — recorded provider contracts and deterministic HTTP fixtures exercise traversal without mutating external accounts |

The repository-wide `bun run verify` remains blocked by pre-existing `packages/agent` Biome backlog. The owning-package gates above pass on this exact head. The app audit failure was `ENOSPC` during core package extraction, before Playwright or OCR ran; it is not reported as visual acceptance.

Attribution: OpenAI / gpt-5.6-sol
