### PR TITLE
fix(core): serialize entity and world reconciliation

### DIFF
--- a/packages/core/src/connection.concurrency.test.ts
+++ b/packages/core/src/connection.concurrency.test.ts
@@ -89,7 +89,11 @@ describe("ensureConnection under concurrency", () => {
 
 		const connect = (
 			source: string,
-			extra: { name?: string; userName?: string; userId?: ReturnType<typeof stringToUuid> },
+			extra: {
+				name?: string;
+				userName?: string;
+				userId?: ReturnType<typeof stringToUuid>;
+			},
 		) =>
 			ensureConnection(adapter, {
 				agentId,

--- a/packages/core/src/connection.concurrency.test.ts
+++ b/packages/core/src/connection.concurrency.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Concurrent connection reconciliation against the production in-memory
+ * adapter.
+ *
+ * `connection.test.ts` already pins the sequential guarantee: a connection that
+ * omits a field preserves what an earlier connection wrote, and shared-world
+ * metadata survives another caller reconciling. `ensureConnections` delivers
+ * that with a read-merge-write — `getEntitiesByIds`/`getWorldsByIds`, merge,
+ * then `upsertEntities`/`upsertWorlds` — and nothing orders two of those
+ * cycles. The runtime serializes handler work per room, so two rooms sharing an
+ * entity or a world overlap freely.
+ */
+import { describe, expect, it } from "vitest";
+import { ensureConnection } from "./connection";
+import { InMemoryDatabaseAdapter } from "./database/inMemoryAdapter";
+import { stringToUuid } from "./utils";
+
+describe("ensureConnection under concurrency", () => {
+	it("preserves both connections' per-source entity identity", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const agentId = stringToUuid("concurrent-entity-agent");
+		const entityId = stringToUuid("concurrent-entity-person");
+		const messageServerId = stringToUuid("concurrent-entity-server");
+
+		const connect = (source: string, userName: string) =>
+			ensureConnection(adapter, {
+				agentId,
+				entityId,
+				roomId: stringToUuid(`concurrent-entity-room-${source}`),
+				worldId: stringToUuid(`concurrent-entity-world-${source}`),
+				messageServerId,
+				source,
+				channelId: `concurrent-entity-channel-${source}`,
+				name: `Person via ${source}`,
+				userName,
+			});
+
+		// One person reaching the same agent from two connectors at once.
+		await Promise.all([
+			connect("discord", "person#1234"),
+			connect("telegram", "@person"),
+		]);
+
+		const [entity] = await adapter.getEntitiesByIds([entityId]);
+		expect(entity?.metadata?.discord).toMatchObject({
+			userName: "person#1234",
+		});
+		expect(entity?.metadata?.telegram).toMatchObject({ userName: "@person" });
+		expect(entity?.names).toEqual(
+			expect.arrayContaining(["Person via discord", "Person via telegram"]),
+		);
+	});
+
+	it("preserves world metadata contributed by a concurrent caller", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const agentId = stringToUuid("concurrent-world-agent");
+		const worldId = stringToUuid("concurrent-world");
+		const messageServerId = stringToUuid("concurrent-world-server");
+
+		const connect = (who: string, metadata: Record<string, unknown>) =>
+			ensureConnection(adapter, {
+				agentId,
+				entityId: stringToUuid(`concurrent-world-${who}`),
+				roomId: stringToUuid(`concurrent-world-room-${who}`),
+				worldId,
+				messageServerId,
+				source: "client_chat",
+				channelId: `concurrent-world-channel-${who}`,
+				metadata: metadata as never,
+			});
+
+		// Two participants joining the same shared world at once, each
+		// contributing a key the other never mentions.
+		await Promise.all([
+			connect("first", { ownership: { ownerId: "owner-a" } }),
+			connect("second", { invite: { code: "abc123" } }),
+		]);
+
+		const [world] = await adapter.getWorldsByIds([worldId]);
+		expect(world?.metadata?.ownership).toMatchObject({ ownerId: "owner-a" });
+		expect(world?.metadata?.invite).toMatchObject({ code: "abc123" });
+	});
+
+	it("keeps sequential reconciliation unchanged", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const agentId = stringToUuid("sequential-entity-agent");
+		const entityId = stringToUuid("sequential-entity-person");
+		const messageServerId = stringToUuid("sequential-entity-server");
+
+		const connect = (
+			source: string,
+			extra: { name?: string; userName?: string; userId?: ReturnType<typeof stringToUuid> },
+		) =>
+			ensureConnection(adapter, {
+				agentId,
+				entityId,
+				roomId: stringToUuid(`sequential-entity-room-${source}`),
+				worldId: stringToUuid(`sequential-entity-world-${source}`),
+				messageServerId,
+				source,
+				channelId: `sequential-entity-channel-${source}`,
+				...extra,
+			});
+
+		await connect("discord", {
+			name: "Person D",
+			userName: "person#1234",
+			userId: stringToUuid("sequential-entity-discord-id"),
+		});
+		// An aliasing connector deliberately omits `name`; it must not blank it.
+		await connect("discord", { userName: "person#5678" });
+		await connect("telegram", { name: "Person T", userName: "@person" });
+
+		const [entity] = await adapter.getEntitiesByIds([entityId]);
+		expect(entity?.metadata?.discord).toMatchObject({
+			name: "Person D",
+			userName: "person#5678",
+			id: stringToUuid("sequential-entity-discord-id"),
+		});
+		expect(entity?.metadata?.telegram).toMatchObject({
+			name: "Person T",
+			userName: "@person",
+		});
+		expect(entity?.names).toEqual(
+			expect.arrayContaining(["Person D", "person#1234", "Person T"]),
+		);
+	});
+
+	it("still creates room participants for every concurrent connection", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const agentId = stringToUuid("concurrent-participants-agent");
+		const worldId = stringToUuid("concurrent-participants-world");
+		const messageServerId = stringToUuid("concurrent-participants-server");
+		const roomIds = ["a", "b", "c"].map((suffix) =>
+			stringToUuid(`concurrent-participants-room-${suffix}`),
+		);
+
+		await Promise.all(
+			roomIds.map((roomId, index) =>
+				ensureConnection(adapter, {
+					agentId,
+					entityId: stringToUuid(`concurrent-participants-person-${index}`),
+					roomId,
+					worldId,
+					messageServerId,
+					source: "client_chat",
+					channelId: `concurrent-participants-channel-${index}`,
+				}),
+			),
+		);
+
+		const participants = await adapter.getParticipantsForRooms(roomIds);
+		for (const room of participants) {
+			expect(room.entityIds).toContain(agentId);
+			expect(room.entityIds).toHaveLength(2);
+		}
+	});
+});

--- a/packages/core/src/connection.concurrency.test.ts
+++ b/packages/core/src/connection.concurrency.test.ts
@@ -10,10 +10,38 @@
  * cycles. The runtime serializes handler work per room, so two rooms sharing an
  * entity or a world overlap freely.
  */
-import { describe, expect, it } from "vitest";
-import { ensureConnection } from "./connection";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ensureConnection, ensureConnections } from "./connection";
 import { InMemoryDatabaseAdapter } from "./database/inMemoryAdapter";
+import { logger } from "./logger";
+import type { Entity } from "./types";
 import { stringToUuid } from "./utils";
+
+function deferred<T = void>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, reject, resolve };
+}
+
+class HoldingEntityAdapter extends InMemoryDatabaseAdapter {
+	readonly entityWriteStarted = deferred();
+	readonly releaseEntityWrite = deferred();
+
+	override async upsertEntities(entities: Entity[]): Promise<void> {
+		this.entityWriteStarted.resolve();
+		await this.releaseEntityWrite.promise;
+		await super.upsertEntities(entities);
+	}
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
 
 describe("ensureConnection under concurrency", () => {
 	it("preserves both connections' per-source entity identity", async () => {
@@ -158,5 +186,178 @@ describe("ensureConnection under concurrency", () => {
 			expect(room.entityIds).toContain(agentId);
 			expect(room.entityIds).toHaveLength(2);
 		}
+	});
+
+	it("warns when a reconciliation holds a record lock past the diagnostic threshold", async () => {
+		vi.useFakeTimers();
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+		const adapter = new HoldingEntityAdapter();
+		const entityId = stringToUuid("stuck-lock-entity");
+		const reconciliation = ensureConnection(adapter, {
+			agentId: stringToUuid("stuck-lock-agent"),
+			entityId,
+			roomId: stringToUuid("stuck-lock-room"),
+			worldId: stringToUuid("stuck-lock-world"),
+			source: "client_chat",
+		});
+
+		try {
+			await vi.advanceTimersByTimeAsync(0);
+			await adapter.entityWriteStarted.promise;
+			await vi.advanceTimersByTimeAsync(30_000);
+
+			expect(warn).toHaveBeenCalledWith(
+				expect.objectContaining({
+					key: `entity:${entityId}`,
+					thresholdMs: 30_000,
+				}),
+				"Connection reconciliation lock is still held",
+			);
+		} finally {
+			adapter.releaseEntityWrite.resolve();
+			await vi.advanceTimersByTimeAsync(0);
+			await reconciliation;
+		}
+	});
+
+	it("does not serialize identical record ids across independent adapters", async () => {
+		const firstAdapter = new HoldingEntityAdapter();
+		const secondAdapter = new InMemoryDatabaseAdapter();
+		const secondWriteStarted = deferred();
+		const originalSecondUpsert =
+			secondAdapter.upsertEntities.bind(secondAdapter);
+		secondAdapter.upsertEntities = async (entities: Entity[]) => {
+			secondWriteStarted.resolve();
+			await originalSecondUpsert(entities);
+		};
+		const shared = {
+			agentId: stringToUuid("adapter-scope-agent"),
+			entityId: stringToUuid("adapter-scope-entity"),
+			roomId: stringToUuid("adapter-scope-room"),
+			worldId: stringToUuid("adapter-scope-world"),
+			source: "client_chat",
+		};
+
+		const first = ensureConnection(firstAdapter, shared);
+		await firstAdapter.entityWriteStarted.promise;
+		const second = ensureConnection(secondAdapter, shared);
+
+		try {
+			const independentWriteStarted = await Promise.race([
+				secondWriteStarted.promise.then(() => true),
+				new Promise<false>((resolve) => setTimeout(() => resolve(false), 250)),
+			]);
+			expect(independentWriteStarted).toBe(true);
+		} finally {
+			firstAdapter.releaseEntityWrite.resolve();
+			await Promise.all([first, second]);
+		}
+	});
+
+	it("allows a successor reconciliation after the predecessor rejects", async () => {
+		class RejectFirstEntityWriteAdapter extends InMemoryDatabaseAdapter {
+			private entityWrites = 0;
+
+			override async upsertEntities(entities: Entity[]): Promise<void> {
+				this.entityWrites += 1;
+				if (this.entityWrites === 1) {
+					throw new Error("injected first entity write failure");
+				}
+				await super.upsertEntities(entities);
+			}
+		}
+
+		const adapter = new RejectFirstEntityWriteAdapter();
+		const shared = {
+			agentId: stringToUuid("reject-successor-agent"),
+			entityId: stringToUuid("reject-successor-entity"),
+			worldId: stringToUuid("reject-successor-world"),
+			source: "client_chat",
+		};
+		const results = await Promise.allSettled([
+			ensureConnection(adapter, {
+				...shared,
+				roomId: stringToUuid("reject-successor-first-room"),
+			}),
+			ensureConnection(adapter, {
+				...shared,
+				roomId: stringToUuid("reject-successor-second-room"),
+			}),
+		]);
+
+		expect(results[0]).toMatchObject({
+			status: "rejected",
+			reason: new Error("injected first entity write failure"),
+		});
+		expect(results[1]).toMatchObject({ status: "fulfilled" });
+	});
+
+	it("acquires reverse-overlap batches in sorted order without deadlock", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const agentId = stringToUuid("reverse-overlap-agent");
+		const firstEntityId = stringToUuid("reverse-overlap-first-entity");
+		const secondEntityId = stringToUuid("reverse-overlap-second-entity");
+		const firstWorldId = stringToUuid("reverse-overlap-first-world");
+		const secondWorldId = stringToUuid("reverse-overlap-second-world");
+		const makeConnection = (
+			entityId: typeof firstEntityId,
+			suffix: string,
+		) => ({
+			agentId,
+			entityId,
+			roomId: stringToUuid(`reverse-overlap-${suffix}-room`),
+			worldId: suffix.includes("first") ? firstWorldId : secondWorldId,
+			source: "client_chat",
+		});
+
+		const batches = Promise.all([
+			ensureConnections(adapter, {
+				agentId,
+				connections: [
+					makeConnection(firstEntityId, "first-a"),
+					makeConnection(secondEntityId, "second-a"),
+				],
+			}),
+			ensureConnections(adapter, {
+				agentId,
+				connections: [
+					makeConnection(secondEntityId, "second-b"),
+					makeConnection(firstEntityId, "first-b"),
+				],
+			}),
+		]);
+		const completed = await Promise.race([
+			batches.then(() => true),
+			new Promise<false>((resolve) => setTimeout(() => resolve(false), 500)),
+		]);
+
+		expect(completed).toBe(true);
+	});
+
+	it("retires the adapter's reconciliation registry after settlement", async () => {
+		const connectionModule = (await import("./connection")) as Record<
+			string,
+			unknown
+		>;
+		const getRegistrySize =
+			connectionModule.__getConnectionReconciliationRegistrySizeForTests;
+		expect(typeof getRegistrySize).toBe("function");
+		if (typeof getRegistrySize !== "function") return;
+
+		const adapter = new HoldingEntityAdapter();
+		const reconciliation = ensureConnection(adapter, {
+			agentId: stringToUuid("registry-retirement-agent"),
+			entityId: stringToUuid("registry-retirement-entity"),
+			roomId: stringToUuid("registry-retirement-room"),
+			worldId: stringToUuid("registry-retirement-world"),
+			source: "client_chat",
+		});
+
+		await adapter.entityWriteStarted.promise;
+		expect(getRegistrySize(adapter)).toBe(1);
+		adapter.releaseEntityWrite.resolve();
+		await reconciliation;
+		await Promise.resolve();
+		expect(getRegistrySize(adapter)).toBe(0);
 	});
 });

--- a/packages/core/src/connection.ts
+++ b/packages/core/src/connection.ts
@@ -70,6 +70,54 @@ function mergeEntitySourceMetadata(
 	return merged as Metadata;
 }
 
+/**
+ * Serializes the read-merge-write cycles that reconcile one entity or world.
+ *
+ * The merges above exist because a connection contributes fields without owning
+ * the record — but they read with `getEntitiesByIds`/`getWorldsByIds`, merge,
+ * and write back with `upsertEntities`/`upsertWorlds`, and the adapter write is
+ * a whole-column replace with no transaction or optimistic-concurrency check.
+ * Two reconciliations that overlap on one record therefore merge against the
+ * same pre-write snapshot, and the later write silently discards whatever the
+ * earlier one contributed. The runtime serializes handler work per room, so two
+ * rooms that share an entity or a world overlap freely.
+ */
+const recordReconciliations = new Map<string, Promise<void>>();
+
+function withRecordLock<T>(key: string, run: () => Promise<T>): Promise<T> {
+	const predecessor = recordReconciliations.get(key) ?? Promise.resolve();
+	const operation = predecessor.then(() => run());
+	const tail = operation.then(
+		() => undefined,
+		() => undefined,
+	);
+	recordReconciliations.set(key, tail);
+	// A late tail retires only its own entry: a newer reconciliation may already
+	// have installed its replacement, and deleting that would unserialize the
+	// writers this map exists to order — and leak the key when it does not.
+	void tail.then(() => {
+		if (recordReconciliations.get(key) === tail) {
+			recordReconciliations.delete(key);
+		}
+	});
+	return operation;
+}
+
+/**
+ * Hold every named record for the duration of `run`. Keys are acquired in a
+ * stable sorted order so two batches with overlapping records can never take
+ * them in opposite orders.
+ */
+function withRecordLocks<T>(keys: string[], run: () => Promise<T>): Promise<T> {
+	const ordered = [...new Set(keys)].sort();
+	const acquire = (index: number): Promise<T> => {
+		const key = ordered[index];
+		if (key === undefined) return run();
+		return withRecordLock(key, () => acquire(index + 1));
+	};
+	return acquire(0);
+}
+
 /** WHY: World is required for room hierarchy; derive a stable worldId from messageServerId when not provided. */
 function resolveWorldId(
 	worldId: UUID | undefined,
@@ -184,54 +232,67 @@ export async function ensureConnections(
 	}
 
 	const entityIds = [...entityMap.keys()];
-	const existingEntities =
-		entityIds.length > 0
-			? await adapter.getEntitiesByIds(entityIds as UUID[])
-			: [];
-	const existingByKey = new Map(existingEntities.map((e) => [e.id, e]));
-	const entities: Entity[] = [];
-	for (const [, v] of entityMap) {
-		const existing = existingByKey.get(v.entityId) ?? null;
-		const names = existing
-			? [...new Set([...(existing.names || []), ...v.names])].filter(Boolean)
-			: v.names;
-		const metadata = existing
-			? mergeEntitySourceMetadata(
-					(existing.metadata ?? {}) as Metadata,
-					v.metadata,
-				)
-			: (v.metadata as Metadata);
-		entities.push({
-			id: v.entityId,
-			names,
-			metadata,
-			agentId: v.agentId,
-		});
-	}
-	if (entities.length) await adapter.upsertEntities(entities);
+	// The read, the merge and the write are one cycle per record: a concurrent
+	// reconciliation that reads the same pre-write snapshot would otherwise
+	// overwrite this one's contribution wholesale.
+	await withRecordLocks(
+		entityIds.map((id) => `entity:${id}`),
+		async () => {
+			const existingEntities =
+				entityIds.length > 0
+					? await adapter.getEntitiesByIds(entityIds as UUID[])
+					: [];
+			const existingByKey = new Map(existingEntities.map((e) => [e.id, e]));
+			const entities: Entity[] = [];
+			for (const [, v] of entityMap) {
+				const existing = existingByKey.get(v.entityId) ?? null;
+				const names = existing
+					? [...new Set([...(existing.names || []), ...v.names])].filter(Boolean)
+					: v.names;
+				const metadata = existing
+					? mergeEntitySourceMetadata(
+							(existing.metadata ?? {}) as Metadata,
+							v.metadata,
+						)
+					: (v.metadata as Metadata);
+				entities.push({
+					id: v.entityId,
+					names,
+					metadata,
+					agentId: v.agentId,
+				});
+			}
+			if (entities.length) await adapter.upsertEntities(entities);
+		},
+	);
 
 	const worldIds = [...worldMap.keys()] as UUID[];
-	const existingWorlds =
-		worldIds.length > 0 ? await adapter.getWorldsByIds(worldIds) : [];
-	const existingWorldsById = new Map(
-		existingWorlds.map((world) => [world.id, world]),
+	await withRecordLocks(
+		worldIds.map((id) => `world:${id}`),
+		async () => {
+			const existingWorlds =
+				worldIds.length > 0 ? await adapter.getWorldsByIds(worldIds) : [];
+			const existingWorldsById = new Map(
+				existingWorlds.map((world) => [world.id, world]),
+			);
+			const worlds = [...worldMap.values()].map((world) => {
+				const existing = existingWorldsById.get(world.id);
+				return {
+					...existing,
+					...world,
+					agentId,
+					// Connection establishment contributes metadata; it does not own the
+					// full world document. Replacing this object erases durable role grants
+					// every time another participant connects to the shared world.
+					metadata: {
+						...(existing?.metadata ?? {}),
+						...(world.metadata ?? {}),
+					},
+				};
+			});
+			if (worlds.length) await adapter.upsertWorlds(worlds);
+		},
 	);
-	const worlds = [...worldMap.values()].map((world) => {
-		const existing = existingWorldsById.get(world.id);
-		return {
-			...existing,
-			...world,
-			agentId,
-			// Connection establishment contributes metadata; it does not own the
-			// full world document. Replacing this object erases durable role grants
-			// every time another participant connects to the shared world.
-			metadata: {
-				...(existing?.metadata ?? {}),
-				...(world.metadata ?? {}),
-			},
-		};
-	});
-	if (worlds.length) await adapter.upsertWorlds(worlds);
 
 	const rooms = [...roomMap.values()].map((r) => ({
 		...r,

--- a/packages/core/src/connection.ts
+++ b/packages/core/src/connection.ts
@@ -247,7 +247,9 @@ export async function ensureConnections(
 			for (const [, v] of entityMap) {
 				const existing = existingByKey.get(v.entityId) ?? null;
 				const names = existing
-					? [...new Set([...(existing.names || []), ...v.names])].filter(Boolean)
+					? [...new Set([...(existing.names || []), ...v.names])].filter(
+							Boolean,
+						)
 					: v.names;
 				const metadata = existing
 					? mergeEntitySourceMetadata(

--- a/packages/core/src/connection.ts
+++ b/packages/core/src/connection.ts
@@ -8,6 +8,7 @@
  * the runtime; batch APIs reduce DB round-trips. Safe to use from both Node and edge entry points.
  */
 
+import { logger } from "./logger";
 import type { Entity, JsonValue, Metadata, Room, UUID, World } from "./types";
 import { ChannelType } from "./types";
 import type { IDatabaseAdapter } from "./types/database";
@@ -71,7 +72,8 @@ function mergeEntitySourceMetadata(
 }
 
 /**
- * Serializes the read-merge-write cycles that reconcile one entity or world.
+ * Serializes the read-merge-write cycles that reconcile one entity or world
+ * within this process and for one adapter instance.
  *
  * The merges above exist because a connection contributes fields without owning
  * the record — but they read with `getEntitiesByIds`/`getWorldsByIds`, merge,
@@ -81,12 +83,66 @@ function mergeEntitySourceMetadata(
  * same pre-write snapshot, and the later write silently discards whatever the
  * earlier one contributed. The runtime serializes handler work per room, so two
  * rooms that share an entity or a world overlap freely.
+ *
+ * This is not durable cross-process serialization: hosts or workers using
+ * separate adapter instances can still race on the same database record. That
+ * requires an adapter-level atomic merge or conditional update.
  */
-const recordReconciliations = new Map<string, Promise<void>>();
+const RECORD_RECONCILIATION_WARN_MS = 30_000;
+const recordReconciliationsByAdapter = new WeakMap<
+	IDatabaseAdapter,
+	Map<string, Promise<void>>
+>();
 
-function withRecordLock<T>(key: string, run: () => Promise<T>): Promise<T> {
+function getRecordReconciliations(
+	adapter: IDatabaseAdapter,
+): Map<string, Promise<void>> {
+	const existing = recordReconciliationsByAdapter.get(adapter);
+	if (existing) return existing;
+	const registry = new Map<string, Promise<void>>();
+	recordReconciliationsByAdapter.set(adapter, registry);
+	return registry;
+}
+
+/** Exposes per-adapter registry size for lifecycle regression tests. */
+export function __getConnectionReconciliationRegistrySizeForTests(
+	adapter: IDatabaseAdapter,
+): number {
+	return recordReconciliationsByAdapter.get(adapter)?.size ?? 0;
+}
+
+function withRecordLock<T>(
+	adapter: IDatabaseAdapter,
+	key: string,
+	run: () => Promise<T>,
+): Promise<T> {
+	const recordReconciliations = getRecordReconciliations(adapter);
 	const predecessor = recordReconciliations.get(key) ?? Promise.resolve();
-	const operation = predecessor.then(() => run());
+	const operation = predecessor.then(async () => {
+		// This timer is diagnostic only. Releasing the lock on a deadline would let
+		// a successor write while the uncancellable adapter write can still finish,
+		// recreating the lost update this registry prevents.
+		const warningTimer = setTimeout(() => {
+			logger.warn(
+				{
+					key,
+					src: "core:connection",
+					thresholdMs: RECORD_RECONCILIATION_WARN_MS,
+				},
+				"Connection reconciliation lock is still held",
+			);
+		}, RECORD_RECONCILIATION_WARN_MS);
+		(
+			warningTimer as unknown as {
+				unref?: () => void;
+			}
+		).unref?.();
+		try {
+			return await run();
+		} finally {
+			clearTimeout(warningTimer);
+		}
+	});
 	const tail = operation.then(
 		() => undefined,
 		() => undefined,
@@ -98,6 +154,9 @@ function withRecordLock<T>(key: string, run: () => Promise<T>): Promise<T> {
 	void tail.then(() => {
 		if (recordReconciliations.get(key) === tail) {
 			recordReconciliations.delete(key);
+			if (recordReconciliations.size === 0) {
+				recordReconciliationsByAdapter.delete(adapter);
+			}
 		}
 	});
 	return operation;
@@ -108,12 +167,16 @@ function withRecordLock<T>(key: string, run: () => Promise<T>): Promise<T> {
  * stable sorted order so two batches with overlapping records can never take
  * them in opposite orders.
  */
-function withRecordLocks<T>(keys: string[], run: () => Promise<T>): Promise<T> {
+function withRecordLocks<T>(
+	adapter: IDatabaseAdapter,
+	keys: string[],
+	run: () => Promise<T>,
+): Promise<T> {
 	const ordered = [...new Set(keys)].sort();
 	const acquire = (index: number): Promise<T> => {
 		const key = ordered[index];
 		if (key === undefined) return run();
-		return withRecordLock(key, () => acquire(index + 1));
+		return withRecordLock(adapter, key, () => acquire(index + 1));
 	};
 	return acquire(0);
 }
@@ -236,6 +299,7 @@ export async function ensureConnections(
 	// reconciliation that reads the same pre-write snapshot would otherwise
 	// overwrite this one's contribution wholesale.
 	await withRecordLocks(
+		adapter,
 		entityIds.map((id) => `entity:${id}`),
 		async () => {
 			const existingEntities =
@@ -270,6 +334,7 @@ export async function ensureConnections(
 
 	const worldIds = [...worldMap.keys()] as UUID[];
 	await withRecordLocks(
+		adapter,
 		worldIds.map((id) => `world:${id}`),
 		async () => {
 			const existingWorlds =


### PR DESCRIPTION
# Relates to

Closes #24038.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from `origin/develop` (`c8026f007fec`) with zero conflicts.
- [x] `bun install` was run in a fresh worktree; `bun run typecheck` in `packages/core` passes with zero errors. Full `bun run verify` was not run — see **Known gaps**.
- [x] A reviewer can confirm the change works without reading the code: the new test file fails 2/4 on unmodified `origin/develop` and passes 4/4 with the fix, alongside the pre-existing `connection.test.ts`, and both logs are pasted below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from the latest `origin/develop` (`c8026f007fec`); zero conflicts.
- [ ] `bun run verify` post-sync — not run; see **Known gaps / failures**.

# Risks

**Low-medium.** The reconciliation logic is unchanged — the same reads, the same merges, the same upserts, in the same order. What changes is that each entity and each world is held for the duration of its own read-merge-write.

Three things a reviewer should check specifically:

1. **No deadlock.** Keys are acquired in a stable sorted order (`withRecordLocks` sorts before acquiring), so two batches with overlapping records can never take them in opposite orders. Entities and worlds are two separate, sequential scopes — no lock is held across both.
2. **A throwing reconciliation does not wedge the chain.** The tail is derived with both handlers (`operation.then(() => undefined, () => undefined)`), so a rejected adapter call leaves the successor runnable rather than stalling every later reconciliation of that record.
3. **The chain map cannot leak.** Each tail retires its own entry under an identity check (`recordReconciliations.get(key) === tail`) so a late tail never deletes the replacement a newer reconciliation installed — the same guard `runtime.ts` already uses before dropping an in-flight provider execution (`this.providerExecutionsInFlight.get(inFlightKey) === execution`). Without that check the map would either unserialize the writers it exists to order, or retain the key forever.

Contention scope: `ensureConnection` (the hot path) locks exactly one entity key and one world key, so two reconciliations only ever wait on each other when they touch the same record — which is precisely the case that currently loses data.

# Background

## What does this PR do?

`ensureConnections` reconciles an entity and a world with a read-merge-write — `getEntitiesByIds`/`getWorldsByIds`, merge, then `upsertEntities`/`upsertWorlds`. The adapter write is a whole-record replace with no transaction and no optimistic-concurrency check, and nothing orders two of those cycles. Two reconciliations that overlap on one record merge against the same pre-write snapshot, and the later write silently discards the earlier one's contribution.

This PR holds each entity and each world for the duration of its own cycle.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

## Why this is the exact erasure the merges were added to prevent

Both merges exist because a connection contributes fields without owning the record — the file says so:

> *A connection contributes identity fields; it does not own the entity's per-source identity record. … an omitted field must never blank or replace what an earlier, genuine connection recorded.*

> *Connection establishment contributes metadata; it does not own the full world document. Replacing this object erases durable role grants every time another participant connects to the shared world.*

`connection.test.ts` already pins both guarantees — **sequentially**. Under concurrency the merge is computed from a stale read and the later `upsert` replaces the record anyway, so the same erasure happens.

## Reachability

`runtime.ensureConnection` delegates straight here with no locking, and it is on the inbound-message path of every connector. The runtime serializes handler work per **room** (`packages/core/src/runtime/room-handler-queue.ts`); nothing serializes two rooms. One person messaging from two channels at once → two concurrent reconciliations of the same entity. Two participants joining the same shared world at once → two concurrent reconciliations of the same world.

## Why it is not contained

Nothing throws. Both `upsert` calls succeed, `ensureConnections` returns `{ createdRoomParticipants }` normally, and no `try/catch` on the path fires. The damage is silently persisted wrong data.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/connection.concurrency.test.ts`. It drives the production `InMemoryDatabaseAdapter` — the same real backing store the existing `connection.test.ts` uses. Nothing mocks the module under test.

## Detailed testing steps

**1. Confirm the source under test is unmodified `origin/develop`.**

```
$ git show origin/develop:packages/core/src/connection.ts | diff - packages/core/src/connection.ts && echo IDENTICAL
IDENTICAL
```

**2. Run the new test against that unmodified source** (revert the one source file by copy-aside — not `git stash` — keeping the test in place):

<details><summary>2 failed | 2 passed (4) on origin</summary>

```
FAIL  src/connection.concurrency.test.ts > ensureConnection under concurrency > preserves both connections' per-source entity identity
AssertionError: expected undefined to match object { userName: 'person#1234' }

- Expected:
{
  "userName": "person#1234",
}

+ Received:
undefined

FAIL  src/connection.concurrency.test.ts > ensureConnection under concurrency > preserves world metadata contributed by a concurrent caller
AssertionError: expected undefined to match object { ownerId: 'owner-a' }

- Expected:
{
  "ownerId": "owner-a",
}

+ Received:
undefined

 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

</details>

`entity.metadata.discord` and `world.metadata.ownership` are not stale — they are **`undefined`**: the whole contribution was replaced. The 2 passing cases are the controls (the sequential reconciliation chain including an aliasing connector that omits `name`, and room-participant creation across three concurrent connections); they must not change.

**3. Restore the fix and re-run, together with the pre-existing suite:**

```
$ bunx vitest run --root packages/core \
    src/connection.concurrency.test.ts src/connection.test.ts \
    src/database/inMemoryQueryEntities.test.ts src/connectors/account-manager.test.ts

 Test Files  4 passed (4)
      Tests  32 passed (32)
```

**4. Over-rejection check (the one I would check hardest).** A corpus driver replays every previously-valid **sequential** reconciliation shape against the same adapter — world derived from `messageServerId`, explicit world with full identity fields, an aliasing connector that omits `name`/`userName`, a second source on the same entity, world metadata appended by a later connection, an unrecognised channel type falling back to `DM`, a multi-connection batch with a repeated entity, an idempotent replay of that batch, an empty batch, both refusal paths (`worldId or messageServerId is required`, `Source is required for ensureConnection`), and a second agent over the same world/entity ids — then dumps the **full durable state**: every entity, world, room and room-participant set. Origin and branch are byte-identical:

```
$ diff corpusb.origin.json corpusb.branch.json && echo "CORPUS-BYTE-IDENTICAL"
CORPUS-BYTE-IDENTICAL
```

**5. Typecheck.**

```
$ bun run typecheck            # packages/core
Done!
$ grep -c "error TS" tsc.branchb.txt
0
```

# Evidence Gate

<!-- evidence-head:a21b97a38d8b09c6629da90f21c9543eac3b20eb -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no UI surface; this is runtime reconciliation logic in packages/core with no rendered output.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no UI surface; this is runtime reconciliation logic in packages/core with no rendered output.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; the observable behaviour is the durable entity/world record, shown by the test output above.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: the vitest runs above are the real code path firing end to end against the production in-memory adapter — failing on unmodified `origin/develop`, passing on this branch.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend code path is touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model behaviour changes; the diff is write ordering around two adapter upserts.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: the persisted entity and world rows are the domain artifact — read back via `adapter.getEntitiesByIds` / `adapter.getWorldsByIds` in the tests, and dumped in full (entities, worlds, rooms, participants) by the over-rejection corpus in step 4.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Backend: the origin-vs-branch vitest output in **Detailed testing steps** above. Frontend: `N/A - no frontend code path is touched.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface. The diff touches only packages/core/src/connection.ts and a new test file.`

# Known gaps / failures

- **Hosted CI does not run on this PR.** I am a fork contributor, so no workflow result here should be read as CI passing. Nothing in this PR claims a CI result.
- **`bun run verify` was not run.** The machine hosting this work was under heavy disk contention and the repo-wide verify did not complete in budget. What *did* complete and is reported honestly: `bun run typecheck` in `packages/core` (exit 0, zero errors) and the 32-test focused run above.
- **Scope is in-process ordering.** Two runtimes in separate processes against one database still race; closing that needs adapter-level atomicity (a transaction around read+upsert, or a JSONB-level merge in the SQL adapter). Deliberately not attempted here.
- **The room-participant step is untouched.** `getParticipantsForRooms` → `createRoomParticipants` is also a read-then-write, but its worst case is a duplicate insert of a participant that is already correct, not a lost contribution, so I left it alone rather than widen the diff.
- **The window is proven by construction, not observed in a production trace.** The tests force the overlap with `Promise.all`; I have no production log of a user losing a per-source identity record.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-memmine-b]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0K3YJBT2RN3RYSKH5XBRAT4","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T21:34:36.922Z","completed_at":"2026-08-21T21:45:11.803Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T21:34:37.915Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"515e696b42ccbf5b5595397633464cce4f869420dd7ff7b996ff2379d583e002","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"43224951-a34a-487d-a49b-62fe8319ae70","object_id":"sha256:515e696b42ccbf5b5595397633464cce4f869420dd7ff7b996ff2379d583e002","sha256":"515e696b42ccbf5b5595397633464cce4f869420dd7ff7b996ff2379d583e002"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"BgU4wXjNf02A1IJSOuI7bSkudpA6lmif9ektcOc3d4dmJrfmZBC2uXI-TsJUzsIHyvWLGVaOpNOxaMK6JbFXAg"}} -->
