### PR TITLE
fix(telegram): stop start() retries from stranding a second poll loop

### DIFF
--- a/plugins/plugin-telegram/src/messageConnector.test.ts
+++ b/plugins/plugin-telegram/src/messageConnector.test.ts
@@ -471,28 +471,36 @@ describe("Telegram message connector adapter", () => {
           account,
           bot: fakeBot,
           messageManager: { sendMessage: vi.fn() },
+          wiring: {
+            commands: false,
+            poller: false,
+            handlers: false,
+            shutdownHooks: false,
+          },
         };
       });
 
-    const service = await TelegramService.start(runtime);
+    try {
+      const service = await TelegramService.start(runtime);
 
-    expect(createAccountRuntime).toHaveBeenCalledTimes(1);
-    expect(createAccountRuntime).toHaveBeenCalledWith(
-      expect.objectContaining({ accountId: "acct-b", botToken: "token-b" }),
-    );
-    expect(initializeBot).toHaveBeenCalledTimes(1);
-    expect(
-      Array.from(
-        (
-          service as TelegramService & {
-            accountStates: Map<string, unknown>;
-          }
-        ).accountStates.keys(),
-      ),
-    ).toEqual(["acct-b"]);
-
-    initializeBot.mockRestore();
-    createAccountRuntime.mockRestore();
+      expect(createAccountRuntime).toHaveBeenCalledTimes(1);
+      expect(createAccountRuntime).toHaveBeenCalledWith(
+        expect.objectContaining({ accountId: "acct-b", botToken: "token-b" }),
+      );
+      expect(initializeBot).toHaveBeenCalledTimes(1);
+      expect(
+        Array.from(
+          (
+            service as TelegramService & {
+              accountStates: Map<string, unknown>;
+            }
+          ).accountStates.keys(),
+        ),
+      ).toEqual(["acct-b"]);
+    } finally {
+      initializeBot.mockRestore();
+      createAccountRuntime.mockRestore();
+    }
   });
 
   it("does not launch the full poller when standalone mode owns Telegram", async () => {

--- a/plugins/plugin-telegram/src/service.launch-supervision.test.ts
+++ b/plugins/plugin-telegram/src/service.launch-supervision.test.ts
@@ -4,14 +4,15 @@
  * resolves only when polling stops, so awaiting it for completion strands every
  * post-launch step (dedup registration, `setMyCommands`, shutdown handlers).
  * These tests drive a controllable fake Telegraf bot (its `launch(config,
- * onLaunch)` deferred is resolved/rejected by the test) to prove: the connect
- * signal settles the returned promise so the caller proceeds; a post-connect
- * poll failure self-heals with bounded, backed-off relaunches; and a newer
- * runtime taking over the token cancels the loser's relaunch. Runtime, timers,
- * and `@elizaos/core` (logger/Service) are mocked.
+ * onLaunch)` deferred is resolved/rejected by the test) to prove: initial
+ * startup waits for a stoppable polling object; readiness timers are bounded
+ * and cancelled on launch failure; a post-connect poll failure self-heals with
+ * backed-off relaunches; and token takeover cancels the loser's relaunch.
+ * Runtime, timers, and `@elizaos/core` (logger/Service) are mocked.
  */
 import { logger } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getTelegramPollerClaim } from "./poller-lock";
 import { TelegramService } from "./service";
 
 const CONFLICT = "409: Conflict: terminated by other getUpdates request";
@@ -63,6 +64,13 @@ function makeService() {
   return { service, runtime };
 }
 
+async function exposeStoppablePoller(bot: unknown): Promise<void> {
+  (bot as { polling?: { stop: ReturnType<typeof vi.fn> } }).polling = {
+    stop: vi.fn(),
+  };
+  await vi.advanceTimersByTimeAsync(10);
+}
+
 // Flush the microtask that runs the launch promise's rejection handler before
 // its backoff `setTimeout` is scheduled.
 async function flushMicrotasks(): Promise<void> {
@@ -79,7 +87,7 @@ describe("TelegramService.launchPollerSupervised", () => {
     vi.useRealTimers();
   });
 
-  it("resolves on the connect signal (unblocking the post-launch path) with drop-pending polling", async () => {
+  it("waits for a stoppable poller after the connect signal", async () => {
     const { bot, calls } = makeBot();
     const { service } = makeService();
 
@@ -93,7 +101,56 @@ describe("TelegramService.launchPollerSupervised", () => {
     });
 
     calls[0].onLaunch();
+    await exposeStoppablePoller(bot);
     await expect(launched).resolves.toBeUndefined();
+  });
+
+  it("cancels the readiness timer when launch fails before polling exists", async () => {
+    const { bot, calls } = makeBot();
+    const { service } = makeService();
+    const failure = new Error("deleteWebhook failed");
+
+    const launched = callLaunch(service, bot, "tok-fail", "acct");
+    const rejected = expect(launched).rejects.toBe(failure);
+    calls[0].onLaunch();
+    calls[0].reject(failure);
+    await flushMicrotasks();
+
+    await rejected;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("warns but keeps the original launch fenced beyond 30 seconds", async () => {
+    const { bot, calls } = makeBot();
+    const { service } = makeService();
+    const loggerWarn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    const launched = callLaunch(service, bot, "tok-timeout", "acct");
+    let outcome: "pending" | "resolved" | "rejected" = "pending";
+    const observed = launched.then(
+      () => {
+        outcome = "resolved";
+      },
+      () => {
+        outcome = "rejected";
+      },
+    );
+    calls[0].onLaunch();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(outcome).toBe("pending");
+    expect(bot.launch).toHaveBeenCalledTimes(1);
+    expect(getTelegramPollerClaim("tok-timeout")?.bot).toBe(bot);
+    expect(loggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ pollerReadyWarningMs: 30_000 }),
+      expect.stringContaining("waiting for a stoppable poller"),
+    );
+
+    await exposeStoppablePoller(bot);
+    await observed;
+    expect(outcome).toBe("resolved");
+    expect(bot.launch).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("self-heals a post-connect poll failure with a bounded, backed-off relaunch and then gives up", async () => {
@@ -103,6 +160,7 @@ describe("TelegramService.launchPollerSupervised", () => {
 
     const launched = callLaunch(service, bot, "tok-heal", "acct");
     calls[0].onLaunch();
+    await exposeStoppablePoller(bot);
     await launched;
 
     // Persistent conflict on every attempt: backoff doubles (2^n s) capped at
@@ -145,6 +203,7 @@ describe("TelegramService.launchPollerSupervised", () => {
       "acct",
     );
     first.calls[0].onLaunch();
+    await exposeStoppablePoller(first.bot);
     await firstLaunched;
 
     await expect(

--- a/plugins/plugin-telegram/src/service.start-retry.test.ts
+++ b/plugins/plugin-telegram/src/service.start-retry.test.ts
@@ -20,7 +20,11 @@ const servers: http.Server[] = [];
 const services: TelegramService[] = [];
 
 afterEach(async () => {
-  await Promise.all(services.map((service) => service.stop().catch(() => {})));
+  // error-policy:J6 Teardown failures are collected so every resource is reclaimed, then
+  // surfaced after cleanup instead of being silently swallowed.
+  const stopResults = await Promise.allSettled(
+    services.map((service) => service.stop()),
+  );
   services.length = 0;
   await Promise.all(
     servers.map(
@@ -32,6 +36,12 @@ afterEach(async () => {
     ),
   );
   servers.length = 0;
+  const stopErrors = stopResults.flatMap((result) =>
+    result.status === "rejected" ? [result.reason] : [],
+  );
+  if (stopErrors.length > 0) {
+    throw new AggregateError(stopErrors, "Telegram service teardown failed");
+  }
 });
 
 interface StubBotApi {
@@ -154,10 +164,12 @@ describe("TelegramService.start retry does not strand a long-poll loop", () => {
 
     await service.stop();
     services.length = 0;
-    const before = api.getUpdatesCalls();
-    await settle(800);
-    // At most the one request that was already in flight may still land.
-    expect(api.getUpdatesCalls() - before).toBeLessThanOrEqual(1);
+    // Allow already-dispatched requests to reach the stub, then prove polling
+    // stays quiescent for a substantially longer observation window.
+    await settle(100);
+    const afterStop = api.getUpdatesCalls();
+    await settle(700);
+    expect(api.getUpdatesCalls()).toBe(afterStop);
   });
 
   it("stops polling on stop() with no failure at all (unchanged happy path)", async () => {
@@ -172,8 +184,9 @@ describe("TelegramService.start retry does not strand a long-poll loop", () => {
 
     await service.stop();
     services.length = 0;
-    const before = api.getUpdatesCalls();
-    await settle(800);
-    expect(api.getUpdatesCalls() - before).toBeLessThanOrEqual(1);
+    await settle(100);
+    const afterStop = api.getUpdatesCalls();
+    await settle(700);
+    expect(api.getUpdatesCalls()).toBe(afterStop);
   });
 });

--- a/plugins/plugin-telegram/src/service.start-retry.test.ts
+++ b/plugins/plugin-telegram/src/service.start-retry.test.ts
@@ -135,7 +135,8 @@ function accountBot(service: TelegramService): {
   return states.get("default")?.bot as never;
 }
 
-const settle = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const settle = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
 
 describe("TelegramService.start retry does not strand a long-poll loop", () => {
   it("stops polling on stop() after a transient failure retried the init sequence", async () => {

--- a/plugins/plugin-telegram/src/service.start-retry.test.ts
+++ b/plugins/plugin-telegram/src/service.start-retry.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Regression test for `TelegramService.start()`'s retry loop.
+ *
+ * The loop re-runs the whole init sequence on the SAME `Telegraf` instance, but
+ * Telegraf registration appends and `startPolling()` overwrites `bot.polling` —
+ * so a failure AFTER the poller already connected used to launch a second
+ * long-poll loop and strand the first one where `bot.stop()` can never reach it.
+ * These tests drive the real `TelegramService` and a real `Telegraf` against a
+ * loopback stub of the Bot API, injecting exactly one transient `getMe` failure
+ * at the point `start()` awaits it, and assert that stopping the service really
+ * stops polling.
+ */
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { TelegramService } from "./service";
+
+const servers: http.Server[] = [];
+const services: TelegramService[] = [];
+
+afterEach(async () => {
+  await Promise.all(services.map((service) => service.stop().catch(() => {})));
+  services.length = 0;
+  await Promise.all(
+    servers.map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.closeAllConnections?.();
+          server.close(() => resolve());
+        }),
+    ),
+  );
+  servers.length = 0;
+});
+
+interface StubBotApi {
+  apiRoot: string;
+  getMeCalls: () => number;
+  getUpdatesCalls: () => number;
+}
+
+/**
+ * Minimal Bot API over loopback. `failGetMeAt` is a 1-based call index: call 3
+ * is the `await state.bot.telegram.getMe()` that `start()` performs after
+ * `initializeBot` has already launched the poller (1 = inside `bot.launch`,
+ * 2 = the bot-info log line).
+ */
+async function startStubBotApi(failGetMeAt?: number): Promise<StubBotApi> {
+  let getMeCalls = 0;
+  let getUpdatesCalls = 0;
+  const server = http.createServer((req, res) => {
+    const method = (req.url ?? "").split("/").pop() ?? "";
+    req.resume();
+    req.on("end", () => {
+      res.setHeader("content-type", "application/json");
+      if (method === "getMe") {
+        getMeCalls += 1;
+        if (getMeCalls === failGetMeAt) {
+          res.statusCode = 500;
+          res.end(
+            JSON.stringify({
+              ok: false,
+              error_code: 500,
+              description: "Internal Server Error",
+            }),
+          );
+          return;
+        }
+        res.end(
+          JSON.stringify({
+            ok: true,
+            result: {
+              id: 1,
+              is_bot: true,
+              first_name: "stub",
+              username: "stub_bot",
+            },
+          }),
+        );
+        return;
+      }
+      if (method === "getUpdates") {
+        getUpdatesCalls += 1;
+        // Answer quickly so the loop spins visibly instead of long-polling.
+        setTimeout(() => res.end(JSON.stringify({ ok: true, result: [] })), 20);
+        return;
+      }
+      res.end(JSON.stringify({ ok: true, result: true }));
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    apiRoot: `http://127.0.0.1:${port}`,
+    getMeCalls: () => getMeCalls,
+    getUpdatesCalls: () => getUpdatesCalls,
+  };
+}
+
+function makeRuntime(apiRoot: string): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-0000-0000-0000000000a1",
+    character: {
+      name: "Agent One",
+      settings: { telegram: { botToken: "123456:STUB", apiRoot } },
+    },
+    getSetting: () => undefined,
+    getService: () => null,
+    getServicesByType: () => [],
+    registerMessageConnector: () => {},
+    registerSendHandler: () => {},
+    emitEvent: () => {},
+    reportError: () => {},
+    getRoom: async () => null,
+    getMemories: async () => [],
+    getEntityById: async () => null,
+    createMemory: async () => {},
+    ensureConnection: async () => {},
+    actions: [],
+    providers: [],
+    evaluators: [],
+  } as unknown as IAgentRuntime;
+}
+
+function accountBot(service: TelegramService): {
+  polling?: { abortController: { signal: { aborted: boolean } } };
+} {
+  const states = (
+    service as unknown as {
+      accountStates: Map<string, { bot: { polling?: never } }>;
+    }
+  ).accountStates;
+  return states.get("default")?.bot as never;
+}
+
+const settle = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("TelegramService.start retry does not strand a long-poll loop", () => {
+  it("stops polling on stop() after a transient failure retried the init sequence", async () => {
+    // getMe #3 is the one start() awaits after initializeBot has already
+    // launched the poller — the failure that used to trigger a second launch.
+    const api = await startStubBotApi(3);
+    const service = await TelegramService.start(makeRuntime(api.apiRoot));
+    services.push(service);
+    await settle(300);
+
+    // The retry really happened (initial 3 + the retry's 2 more).
+    expect(api.getMeCalls()).toBeGreaterThan(3);
+    const bot = accountBot(service);
+    expect(bot.polling?.abortController.signal.aborted).toBe(false);
+
+    await service.stop();
+    services.length = 0;
+    const before = api.getUpdatesCalls();
+    await settle(800);
+    // At most the one request that was already in flight may still land.
+    expect(api.getUpdatesCalls() - before).toBeLessThanOrEqual(1);
+  });
+
+  it("stops polling on stop() with no failure at all (unchanged happy path)", async () => {
+    const api = await startStubBotApi();
+    const service = await TelegramService.start(makeRuntime(api.apiRoot));
+    services.push(service);
+    await settle(300);
+
+    expect(api.getMeCalls()).toBe(3);
+    const bot = accountBot(service);
+    expect(bot.polling?.abortController.signal.aborted).toBe(false);
+
+    await service.stop();
+    services.length = 0;
+    const before = api.getUpdatesCalls();
+    await settle(800);
+    expect(api.getUpdatesCalls() - before).toBeLessThanOrEqual(1);
+  });
+});

--- a/plugins/plugin-telegram/src/service.start-retry.test.ts
+++ b/plugins/plugin-telegram/src/service.start-retry.test.ts
@@ -1,23 +1,33 @@
 /**
- * Regression test for `TelegramService.start()`'s retry loop.
+ * Integration-backed regressions for `TelegramService` startup retries.
  *
- * The loop re-runs the whole init sequence on the SAME `Telegraf` instance, but
- * Telegraf registration appends and `startPolling()` overwrites `bot.polling` —
- * so a failure AFTER the poller already connected used to launch a second
- * long-poll loop and strand the first one where `bot.stop()` can never reach it.
- * These tests drive the real `TelegramService` and a real `Telegraf` against a
- * loopback stub of the Bot API, injecting exactly one transient `getMe` failure
- * at the point `start()` awaits it, and assert that stopping the service really
- * stops polling.
+ * The tests run the real service and Telegraf poller against a loopback Bot API.
+ * The stub holds long polls open, so request arrival and abort events provide
+ * deterministic lifecycle boundaries without wall-clock sampling windows.
  */
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import type { IAgentRuntime } from "@elizaos/core";
-import { afterEach, describe, expect, it } from "vitest";
+import { Telegraf } from "telegraf";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildTelegramCommandDescriptors } from "./command-registration";
+import { MessageManager } from "./messageManager";
 import { TelegramService } from "./service";
 
+const TEST_DEADLINE_MS = 5_000;
 const servers: http.Server[] = [];
 const services: TelegramService[] = [];
+let signalListenersBefore: Record<
+  "SIGINT" | "SIGTERM",
+  ReturnType<typeof process.rawListeners>
+>;
+
+beforeEach(() => {
+  signalListenersBefore = {
+    SIGINT: process.rawListeners("SIGINT"),
+    SIGTERM: process.rawListeners("SIGTERM"),
+  };
+});
 
 afterEach(async () => {
   // error-policy:J6 Teardown failures are collected so every resource is reclaimed, then
@@ -36,6 +46,14 @@ afterEach(async () => {
     ),
   );
   servers.length = 0;
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    for (const listener of process.rawListeners(signal)) {
+      if (!signalListenersBefore[signal].includes(listener)) {
+        process.removeListener(signal, listener as NodeJS.SignalsListener);
+      }
+    }
+  }
+  vi.restoreAllMocks();
   const stopErrors = stopResults.flatMap((result) =>
     result.status === "rejected" ? [result.reason] : [],
   );
@@ -48,21 +66,66 @@ interface StubBotApi {
   apiRoot: string;
   getMeCalls: () => number;
   getUpdatesCalls: () => number;
+  activeGetUpdates: () => number;
+  deliverUpdate: (update: Record<string, unknown>) => Promise<void>;
+  waitForActiveGetUpdates: (expected: number) => Promise<void>;
+  waitForGetUpdatesCalls: (expected: number) => Promise<void>;
+}
+
+function deadline<T>(promise: Promise<T>, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`${message} within ${TEST_DEADLINE_MS}ms`)),
+      TEST_DEADLINE_MS,
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
 }
 
 /**
  * Minimal Bot API over loopback. `failGetMeAt` is a 1-based call index: call 3
  * is the `await state.bot.telegram.getMe()` that `start()` performs after
- * `initializeBot` has already launched the poller (1 = inside `bot.launch`,
- * 2 = the bot-info log line).
+ * startup wiring has already launched the poller.
  */
 async function startStubBotApi(failGetMeAt?: number): Promise<StubBotApi> {
   let getMeCalls = 0;
   let getUpdatesCalls = 0;
+  let nextRequestId = 0;
+  const pendingUpdates = new Map<number, http.ServerResponse>();
+  const stateWaiters = new Set<() => void>();
+  const notifyState = () => {
+    for (const waiter of stateWaiters) waiter();
+  };
+  const waitForState = (predicate: () => boolean, message: string) => {
+    if (predicate()) return Promise.resolve();
+    return deadline(
+      new Promise<void>((resolve) => {
+        const waiter = () => {
+          if (!predicate()) return;
+          stateWaiters.delete(waiter);
+          resolve();
+        };
+        stateWaiters.add(waiter);
+      }),
+      message,
+    );
+  };
+
   const server = http.createServer((req, res) => {
     const method = (req.url ?? "").split("/").pop() ?? "";
-    req.resume();
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
     req.on("end", () => {
+      const payload = JSON.parse(Buffer.concat(chunks).toString() || "{}");
       res.setHeader("content-type", "application/json");
       if (method === "getMe") {
         getMeCalls += 1;
@@ -92,8 +155,27 @@ async function startStubBotApi(failGetMeAt?: number): Promise<StubBotApi> {
       }
       if (method === "getUpdates") {
         getUpdatesCalls += 1;
-        // Answer quickly so the loop spins visibly instead of long-polling.
-        setTimeout(() => res.end(JSON.stringify({ ok: true, result: [] })), 20);
+        notifyState();
+        // Telegraf performs this un-aborted offset-sync request after the main
+        // poll is aborted. Complete it immediately so terminal poller state is
+        // observable from active long-poll request count alone.
+        if (payload.limit === 1) {
+          res.end(JSON.stringify({ ok: true, result: [] }));
+          return;
+        }
+        const requestId = ++nextRequestId;
+        pendingUpdates.set(requestId, res);
+        let finalized = false;
+        const finalize = () => {
+          if (finalized) return;
+          finalized = true;
+          pendingUpdates.delete(requestId);
+          notifyState();
+        };
+        req.once("aborted", finalize);
+        res.once("close", finalize);
+        res.socket?.once("close", finalize);
+        notifyState();
         return;
       }
       res.end(JSON.stringify({ ok: true, result: true }));
@@ -106,6 +188,30 @@ async function startStubBotApi(failGetMeAt?: number): Promise<StubBotApi> {
     apiRoot: `http://127.0.0.1:${port}`,
     getMeCalls: () => getMeCalls,
     getUpdatesCalls: () => getUpdatesCalls,
+    activeGetUpdates: () => pendingUpdates.size,
+    waitForActiveGetUpdates: (expected) =>
+      waitForState(
+        () => pendingUpdates.size === expected,
+        `Expected ${expected} active getUpdates requests`,
+      ),
+    waitForGetUpdatesCalls: (expected) =>
+      waitForState(
+        () => getUpdatesCalls === expected,
+        `Expected ${expected} getUpdates calls`,
+      ),
+    deliverUpdate: async (update) => {
+      await waitForState(
+        () => pendingUpdates.size > 0,
+        "Expected a pending getUpdates request",
+      );
+      const [requestId, response] = pendingUpdates.entries().next().value as [
+        number,
+        http.ServerResponse,
+      ];
+      pendingUpdates.delete(requestId);
+      response.end(JSON.stringify({ ok: true, result: [update] }));
+      notifyState();
+    },
   };
 }
 
@@ -116,7 +222,8 @@ function makeRuntime(apiRoot: string): IAgentRuntime {
       name: "Agent One",
       settings: { telegram: { botToken: "123456:STUB", apiRoot } },
     },
-    getSetting: () => undefined,
+    getSetting: (key: string) =>
+      key === "TELEGRAM_DM_POLICY" ? "open" : undefined,
     getService: () => null,
     getServicesByType: () => [],
     registerMessageConnector: () => {},
@@ -124,69 +231,217 @@ function makeRuntime(apiRoot: string): IAgentRuntime {
     emitEvent: () => {},
     reportError: () => {},
     getRoom: async () => null,
+    getWorld: async () => null,
     getMemories: async () => [],
     getEntityById: async () => null,
     createMemory: async () => {},
     ensureConnection: async () => {},
+    ensureRoomExists: async () => {},
+    ensureWorldExists: async () => {},
     actions: [],
     providers: [],
     evaluators: [],
   } as unknown as IAgentRuntime;
 }
 
-function accountBot(service: TelegramService): {
-  polling?: { abortController: { signal: { aborted: boolean } } };
-} {
+type TestAccountState = {
+  bot: Telegraf;
+  messageManager: { handleMessage: (...args: unknown[]) => Promise<void> };
+  wiring: {
+    commands: boolean;
+    poller: boolean;
+    handlers: boolean;
+    shutdownHooks: boolean;
+  };
+};
+
+function accountState(service: TelegramService): TestAccountState {
   const states = (
     service as unknown as {
-      accountStates: Map<string, { bot: { polling?: never } }>;
+      accountStates: Map<string, TestAccountState>;
     }
   ).accountStates;
-  return states.get("default")?.bot as never;
+  const state = states.get("default");
+  if (!state) throw new Error("Default Telegram account state is missing");
+  return state;
 }
 
-const settle = (ms: number) =>
-  new Promise((resolve) => setTimeout(resolve, ms));
+function initializeBot(
+  service: TelegramService,
+  state?: TestAccountState,
+): Promise<void> {
+  return (
+    service as unknown as {
+      initializeBot: (state?: TestAccountState) => Promise<void>;
+    }
+  ).initializeBot(state);
+}
 
-describe("TelegramService.start retry does not strand a long-poll loop", () => {
-  it("stops polling on stop() after a transient failure retried the init sequence", async () => {
-    // getMe #3 is the one start() awaits after initializeBot has already
-    // launched the poller — the failure that used to trigger a second launch.
+describe("TelegramService startup wiring", () => {
+  it("installs shutdown hooks only after Telegraf assigns a stoppable poller", async () => {
+    const api = await startStubBotApi();
+    const startPolling = vi.spyOn(Telegraf.prototype, "startPolling");
+    const processOnce = vi.spyOn(process, "once");
+
+    const service = await TelegramService.start(makeRuntime(api.apiRoot));
+    services.push(service);
+    const polling = accountState(service).bot.polling;
+    const pollingCallOrder = startPolling.mock.invocationCallOrder[0];
+    const signalHookCallOrders = processOnce.mock.calls.flatMap(
+      ([event], index) =>
+        event === "SIGINT" || event === "SIGTERM"
+          ? [processOnce.mock.invocationCallOrder[index]]
+          : [],
+    );
+
+    expect(polling?.stop).toBeTypeOf("function");
+    expect(signalHookCallOrders).toHaveLength(2);
+    expect(
+      signalHookCallOrders.every((order) => order > pollingCallOrder),
+    ).toBe(true);
+  });
+
+  it("handles updates while retrying a post-launch startup probe", async () => {
+    const api = await startStubBotApi(2);
+    const handleMessage = vi
+      .spyOn(MessageManager.prototype, "handleMessage")
+      .mockResolvedValue(undefined);
+
+    const startPromise = TelegramService.start(makeRuntime(api.apiRoot));
+    await api.waitForActiveGetUpdates(1);
+    await api.deliverUpdate({
+      update_id: 1,
+      message: {
+        message_id: 1,
+        date: 1,
+        text: "arrived during retry backoff",
+        chat: { id: 42, type: "private", first_name: "Test" },
+        from: { id: 7, is_bot: false, first_name: "Sender" },
+      },
+    });
+    await api.waitForGetUpdatesCalls(2);
+
+    const service = await startPromise;
+    services.push(service);
+    expect(api.getMeCalls()).toBe(4);
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers commands, handlers, and shutdown hooks once across an injected retry", async () => {
+    const api = await startStubBotApi(3);
+    const runtime = makeRuntime(api.apiRoot);
+    const startRegistration = vi.spyOn(Telegraf.prototype, "start");
+    const commandRegistration = vi.spyOn(Telegraf.prototype, "command");
+    const middlewareRegistration = vi.spyOn(Telegraf.prototype, "use");
+    const eventRegistration = vi.spyOn(Telegraf.prototype, "on");
+    const sigintBefore = process.listenerCount("SIGINT");
+    const sigtermBefore = process.listenerCount("SIGTERM");
+
+    const service = await TelegramService.start(runtime);
+    services.push(service);
+    const state = accountState(service);
+    const handled = Promise.withResolvers<void>();
+    const handleMessage = vi
+      .spyOn(state.messageManager, "handleMessage")
+      .mockImplementation(async () => handled.resolve());
+    (
+      service as unknown as { knownChats: Map<string, Record<string, unknown>> }
+    ).knownChats.set("42", { id: 42, type: "private", first_name: "Test" });
+
+    await api.waitForActiveGetUpdates(1);
+    await api.deliverUpdate({
+      update_id: 1,
+      message: {
+        message_id: 1,
+        date: 1,
+        text: "hello",
+        chat: { id: 42, type: "private", first_name: "Test" },
+        from: { id: 7, is_bot: false, first_name: "Sender" },
+      },
+    });
+    await deadline(handled.promise, "Expected the message handler to run");
+
+    expect(api.getMeCalls()).toBe(5);
+    expect(startRegistration).toHaveBeenCalledTimes(1);
+    expect(commandRegistration).toHaveBeenCalledTimes(
+      buildTelegramCommandDescriptors(runtime.agentId).length + 3,
+    );
+    expect(middlewareRegistration).toHaveBeenCalledTimes(
+      commandRegistration.mock.calls.length +
+        eventRegistration.mock.calls.length +
+        2,
+    );
+    expect(eventRegistration).toHaveBeenCalledTimes(3);
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    expect(process.listenerCount("SIGINT") - sigintBefore).toBe(1);
+    expect(process.listenerCount("SIGTERM") - sigtermBefore).toBe(1);
+  });
+
+  it("completes all four one-shot wiring steps inside initializeBot", async () => {
+    const api = await startStubBotApi();
+    const service = new TelegramService(makeRuntime(api.apiRoot));
+    services.push(service);
+    const state = accountState(service);
+
+    await initializeBot(service, state);
+
+    expect(state.wiring).toEqual({
+      commands: true,
+      poller: true,
+      handlers: true,
+      shutdownHooks: true,
+    });
+  });
+
+  it("fails fast with a typed error when initializeBot has no account state", async () => {
+    const api = await startStubBotApi();
+    const service = new TelegramService(makeRuntime(api.apiRoot));
+    services.push(service);
+    (
+      service as unknown as { accountStates: Map<string, TestAccountState> }
+    ).accountStates.clear();
+
+    await expect(initializeBot(service)).rejects.toMatchObject({
+      name: "ElizaError",
+      code: "TELEGRAM_ACCOUNT_STATE_MISSING",
+    });
+    expect(api.getMeCalls()).toBe(0);
+    expect(api.getUpdatesCalls()).toBe(0);
+  });
+});
+
+describe("TelegramService poller lifecycle", () => {
+  it("stops polling after a transient failure retries startup", async () => {
     const api = await startStubBotApi(3);
     const service = await TelegramService.start(makeRuntime(api.apiRoot));
     services.push(service);
-    await settle(300);
+    await api.waitForActiveGetUpdates(1);
 
-    // The retry really happened (initial 3 + the retry's 2 more).
-    expect(api.getMeCalls()).toBeGreaterThan(3);
-    const bot = accountBot(service);
-    expect(bot.polling?.abortController.signal.aborted).toBe(false);
+    expect(api.getMeCalls()).toBe(5);
+    expect(api.activeGetUpdates()).toBe(1);
 
     await service.stop();
     services.length = 0;
-    // Allow already-dispatched requests to reach the stub, then prove polling
-    // stays quiescent for a substantially longer observation window.
-    await settle(100);
-    const afterStop = api.getUpdatesCalls();
-    await settle(700);
-    expect(api.getUpdatesCalls()).toBe(afterStop);
+    await api.waitForActiveGetUpdates(0);
+    await api.waitForGetUpdatesCalls(2);
+    expect(api.activeGetUpdates()).toBe(0);
+    expect(api.getUpdatesCalls()).toBe(2);
   });
 
-  it("stops polling on stop() with no failure at all (unchanged happy path)", async () => {
+  it("stops polling on the unchanged happy path", async () => {
     const api = await startStubBotApi();
     const service = await TelegramService.start(makeRuntime(api.apiRoot));
     services.push(service);
-    await settle(300);
+    await api.waitForActiveGetUpdates(1);
 
     expect(api.getMeCalls()).toBe(3);
-    const bot = accountBot(service);
-    expect(bot.polling?.abortController.signal.aborted).toBe(false);
+    expect(api.activeGetUpdates()).toBe(1);
 
     await service.stop();
     services.length = 0;
-    await settle(100);
-    const afterStop = api.getUpdatesCalls();
-    await settle(700);
-    expect(api.getUpdatesCalls()).toBe(afterStop);
+    await api.waitForActiveGetUpdates(0);
+    await api.waitForGetUpdatesCalls(2);
+    expect(api.activeGetUpdates()).toBe(0);
+    expect(api.getUpdatesCalls()).toBe(2);
   });
 });

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -176,6 +176,29 @@ type TelegramAccountRuntime = {
   account: ResolvedTelegramAccount;
   bot: Telegraf<Context>;
   messageManager: MessageManager;
+  /**
+   * One-shot wiring record for this account's Telegraf instance. `start()`
+   * retries the whole init sequence on a transient failure, but neither
+   * Telegraf registration nor `launch()` is idempotent: `bot.use()`/`bot.on()`/
+   * `bot.command()` APPEND to the middleware chain, and `startPolling()`
+   * overwrites `bot.polling` — so a second `launch()` on the same instance
+   * strands the previous long-poll loop, which `bot.stop()` can then never
+   * abort and which keeps calling `getUpdates` for the life of the process.
+   * Each step is recorded once it succeeds so a retry re-runs only what
+   * actually failed.
+   */
+  wiring: TelegramAccountWiring;
+};
+
+type TelegramAccountWiring = {
+  /** `bot.start()` + slash-command/task-board handlers are registered. */
+  commands: boolean;
+  /** The supervised long-poll loop is running on this bot instance. */
+  poller: boolean;
+  /** Middleware chain and message/reaction/callback handlers are registered. */
+  handlers: boolean;
+  /** SIGINT/SIGTERM teardown hooks for this bot are installed. */
+  shutdownHooks: boolean;
 };
 
 function getCanonicalOwnerId(runtime: IAgentRuntime): UUID | null {
@@ -394,6 +417,12 @@ export class TelegramService extends Service {
       account,
       bot,
       messageManager,
+      wiring: {
+        commands: false,
+        poller: false,
+        handlers: false,
+        shutdownHooks: false,
+      },
     };
   }
 
@@ -622,8 +651,11 @@ export class TelegramService extends Service {
             "Starting Telegram bot",
           );
           await service.initializeBot(state);
-          service.setupMiddlewares(state);
-          service.setupMessageHandlers(state);
+          if (!state.wiring.handlers) {
+            service.setupMiddlewares(state);
+            service.setupMessageHandlers(state);
+            state.wiring.handlers = true;
+          }
           await state.bot.telegram.getMe();
 
           logger.success(
@@ -812,6 +844,49 @@ export class TelegramService extends Service {
       }
     }
 
+    // Registration is one-shot per Telegraf instance: `start()` retries this
+    // whole method after a transient failure, and Telegraf's registration APIs
+    // append rather than replace, so an unguarded retry duplicates every
+    // handler on the same bot.
+    if (!activeState?.wiring.commands) {
+      this.registerBotCommands(bot, activeState, accountId);
+      if (activeState) {
+        activeState.wiring.commands = true;
+      }
+    }
+
+    // Telegraf v4's `bot.launch()` resolves only when polling STOPS — it awaits
+    // the long-poll loop internally — so it must not be awaited for completion.
+    // launchPollerSupervised awaits just the connect signal and then supervises
+    // the loop (with bounded self-healing relaunch) in the background.
+    //
+    // It is also one-shot: `startPolling()` assigns `bot.polling`, so launching
+    // twice on the same instance leaves the first `Polling` unreachable —
+    // `bot.stop()` only aborts the newest one, and the stranded loop keeps
+    // long-polling `getUpdates` against the same token forever (a guaranteed
+    // 409 "terminated by other getUpdates request" against whichever poller
+    // Telegram picks, and a process that can no longer be shut down cleanly).
+    // A pre-connect launch failure never reaches `startPolling`, so the flag is
+    // set only after a successful connect and a retry can still relaunch.
+    if (!activeState?.wiring.poller) {
+      await this.launchPollerSupervised(bot, botToken, accountId);
+      if (activeState) {
+        activeState.wiring.poller = true;
+      }
+    }
+    await this.finishBotStartup(bot, activeState, accountId);
+  }
+
+  /**
+   * Registers the `/start` handler, the universal slash-command handlers, and
+   * the task-board command on a freshly created Telegraf instance. Called
+   * exactly once per bot (see {@link TelegramAccountRuntime.wiring}).
+   */
+  private registerBotCommands(
+    bot: Telegraf<Context>,
+    activeState: TelegramAccountRuntime | null,
+    accountId: string,
+  ): void {
     bot.start((ctx) => {
       const slashStartPayload = {
         ctx,
@@ -857,13 +932,17 @@ export class TelegramService extends Service {
         accountId,
       );
     }
+  }
 
-    // Telegraf v4's `bot.launch()` resolves only when polling STOPS — it awaits
-    // the long-poll loop internally — so it must not be awaited for completion.
-    // launchPollerSupervised awaits just the connect signal and then supervises
-    // the loop (with bounded self-healing relaunch) in the background.
-    await this.launchPollerSupervised(bot, botToken, accountId);
-
+  /**
+   * Post-launch startup steps: publish the slash-command menu, log bot info,
+   * and install the process shutdown hooks (once per bot instance).
+   */
+  private async finishBotStartup(
+    bot: Telegraf<Context>,
+    activeState: TelegramAccountRuntime | null,
+    accountId: string,
+  ): Promise<void> {
     // Publish the slash-command menu to Telegram so commands appear in the `/`
     // menu. setMyCommands failure is logged + swallowed (network) and must not
     // crash boot.
@@ -893,8 +972,14 @@ export class TelegramService extends Service {
         // error-policy:J6 best-effort teardown — bot already stopped.
       }
     };
+    if (activeState?.wiring.shutdownHooks) {
+      return;
+    }
     process.once("SIGINT", () => stopBot("SIGINT"));
     process.once("SIGTERM", () => stopBot("SIGTERM"));
+    if (activeState) {
+      activeState.wiring.shutdownHooks = true;
+    }
   }
 
   /**

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -651,11 +651,6 @@ export class TelegramService extends Service {
             "Starting Telegram bot",
           );
           await service.initializeBot(state);
-          if (!state.wiring.handlers) {
-            service.setupMiddlewares(state);
-            service.setupMessageHandlers(state);
-            state.wiring.handlers = true;
-          }
           await state.bot.telegram.getMe();
 
           logger.success(
@@ -806,12 +801,19 @@ export class TelegramService extends Service {
    */
   private async initializeBot(state?: TelegramAccountRuntime): Promise<void> {
     const activeState = state ?? this.getDefaultAccountState();
-    const bot = activeState?.bot ?? this.bot;
-    if (!bot) {
-      throw new Error("Telegram bot is not initialized");
+    if (!activeState) {
+      throw new ElizaError("Telegram account runtime state is missing", {
+        code: "TELEGRAM_ACCOUNT_STATE_MISSING",
+        severity: "fatal",
+        context: {
+          defaultAccountId: this.defaultAccountId,
+          configuredAccountCount:
+            this.accountStates instanceof Map ? this.accountStates.size : 0,
+        },
+      });
     }
-    const botToken = activeState?.account.botToken ?? this.botToken;
-    const accountId = activeState?.accountId ?? this.defaultAccountId;
+    const { accountId, bot } = activeState;
+    const botToken = activeState.account.botToken;
 
     if (botToken) {
       try {
@@ -844,21 +846,33 @@ export class TelegramService extends Service {
       }
     }
 
-    // Registration is one-shot per Telegraf instance: `start()` retries this
-    // whole method after a transient failure, and Telegraf's registration APIs
-    // append rather than replace, so an unguarded retry duplicates every
-    // handler on the same bot.
-    if (!activeState?.wiring.commands) {
-      this.registerBotCommands(bot, activeState, accountId);
-      if (activeState) {
-        activeState.wiring.commands = true;
-      }
+    await this.ensureWiredOnce(activeState);
+  }
+
+  /**
+   * Completes every non-idempotent setup step exactly once for an account's
+   * Telegraf instance. A step is recorded only after it succeeds, so startup
+   * retries skip completed work while still retrying the first unfinished step.
+   */
+  private async ensureWiredOnce(state: TelegramAccountRuntime): Promise<void> {
+    const { accountId, bot, wiring } = state;
+
+    if (!wiring.commands) {
+      this.registerBotCommands(bot, state, accountId);
+      wiring.commands = true;
+    }
+
+    if (!wiring.handlers) {
+      this.setupMiddlewares(state);
+      this.setupMessageHandlers(state);
+      wiring.handlers = true;
     }
 
     // Telegraf v4's `bot.launch()` resolves only when polling STOPS — it awaits
     // the long-poll loop internally — so it must not be awaited for completion.
-    // launchPollerSupervised awaits just the connect signal and then supervises
-    // the loop (with bounded self-healing relaunch) in the background.
+    // launchPollerSupervised awaits until Telegraf assigns a stoppable polling
+    // object, then supervises the loop (with bounded self-healing relaunch) in
+    // the background.
     //
     // It is also one-shot: `startPolling()` assigns `bot.polling`, so launching
     // twice on the same instance leaves the first `Polling` unreachable —
@@ -866,15 +880,19 @@ export class TelegramService extends Service {
     // long-polling `getUpdates` against the same token forever (a guaranteed
     // 409 "terminated by other getUpdates request" against whichever poller
     // Telegram picks, and a process that can no longer be shut down cleanly).
-    // A pre-connect launch failure never reaches `startPolling`, so the flag is
-    // set only after a successful connect and a retry can still relaunch.
-    if (!activeState?.wiring.poller) {
-      await this.launchPollerSupervised(bot, botToken, accountId);
-      if (activeState) {
-        activeState.wiring.poller = true;
-      }
+    // A launch failure before polling becomes stoppable leaves the flag false,
+    // so the startup retry can still relaunch.
+    if (!wiring.poller) {
+      await this.launchPollerSupervised(bot, state.account.botToken, accountId);
+      wiring.poller = true;
     }
-    await this.finishBotStartup(bot, activeState, accountId);
+
+    if (!wiring.shutdownHooks) {
+      this.installShutdownHooks(bot);
+      wiring.shutdownHooks = true;
+    }
+
+    await this.finishBotStartup(bot, accountId);
   }
 
   /**
@@ -884,7 +902,7 @@ export class TelegramService extends Service {
    */
   private registerBotCommands(
     bot: Telegraf<Context>,
-    activeState: TelegramAccountRuntime | null,
+    activeState: TelegramAccountRuntime,
     accountId: string,
   ): void {
     bot.start((ctx) => {
@@ -906,41 +924,37 @@ export class TelegramService extends Service {
     // handler that never calls next() terminates the middleware chain — so the
     // catch-all message handler in setupMessageHandlers does not also process
     // command messages (no double-processing).
-    const commandMessageManager =
-      activeState?.messageManager ?? this.messageManager ?? undefined;
-    if (commandMessageManager) {
-      const registered = registerTelegramCommandHandlers(
-        bot,
-        this.runtime,
-        commandMessageManager,
+    const commandMessageManager = activeState.messageManager;
+    const registered = registerTelegramCommandHandlers(
+      bot,
+      this.runtime,
+      commandMessageManager,
+      accountId,
+    );
+    logger.debug(
+      {
+        src: "plugin:telegram",
+        agentId: this.runtime.agentId,
         accountId,
-      );
-      logger.debug(
-        {
-          src: "plugin:telegram",
-          agentId: this.runtime.agentId,
-          accountId,
-          commandCount: registered.length,
-        },
-        "Registered universal slash-command handlers",
-      );
-      // #8902: the live, edited-in-place orchestrator task board (`/tasks`).
-      registerTelegramTaskBoardCommand(
-        bot,
-        this.runtime,
-        commandMessageManager,
-        accountId,
-      );
-    }
+        commandCount: registered.length,
+      },
+      "Registered universal slash-command handlers",
+    );
+    // #8902: the live, edited-in-place orchestrator task board (`/tasks`).
+    registerTelegramTaskBoardCommand(
+      bot,
+      this.runtime,
+      commandMessageManager,
+      accountId,
+    );
   }
 
   /**
-   * Post-launch startup steps: publish the slash-command menu, log bot info,
-   * and install the process shutdown hooks (once per bot instance).
+   * Runs the retryable post-launch probes: publish the slash-command menu and
+   * retrieve bot identity before process shutdown hooks are installed.
    */
   private async finishBotStartup(
     bot: Telegraf<Context>,
-    activeState: TelegramAccountRuntime | null,
     accountId: string,
   ): Promise<void> {
     // Publish the slash-command menu to Telegram so commands appear in the `/`
@@ -960,7 +974,10 @@ export class TelegramService extends Service {
       },
       "Bot info retrieved",
     );
+  }
 
+  /** Installs the process-level teardown hooks for one Telegraf instance. */
+  private installShutdownHooks(bot: Telegraf<Context>): void {
     // Stop the poller on process shutdown so the long-poll slot is released
     // before a replacement process starts — otherwise the new process's poller
     // 409s against the lingering one. bot.stop() throws if already stopped, so
@@ -972,14 +989,8 @@ export class TelegramService extends Service {
         // error-policy:J6 best-effort teardown — bot already stopped.
       }
     };
-    if (activeState?.wiring.shutdownHooks) {
-      return;
-    }
     process.once("SIGINT", () => stopBot("SIGINT"));
     process.once("SIGTERM", () => stopBot("SIGTERM"));
-    if (activeState) {
-      activeState.wiring.shutdownHooks = true;
-    }
   }
 
   /**
@@ -987,18 +998,15 @@ export class TelegramService extends Service {
    * of the process.
    *
    * `bot.launch()` in Telegraf v4 only settles when polling stops (it awaits the
-   * loop internally), so the returned promise resolves on the `onLaunch`
-   * callback — fired after `getMe` succeeds, just before polling begins — and
-   * the loop is supervised in the background afterwards. A failure *after*
-   * connecting (a 409 "terminated by other getUpdates request" from a transient
-   * poller overlap during a restart, or a dropped network) is relaunched with
-   * exponential backoff so the connector self-heals instead of going
-   * permanently silent. Relaunches are bounded to `maxPollRelaunches` (reset
-   * after a stable run) so a genuinely duplicated bot instance cannot thrash
-   * forever, and stop entirely once a newer runtime has taken over the token
-   * (the dedup map points at a different bot). Message/command handlers are
-   * registered once by the caller before this runs; a relaunch reuses the same
-   * bot instance, so they are never double-registered.
+   * loop internally), while its `onLaunch` callback fires before `startPolling`
+   * assigns `bot.polling`. The returned promise therefore yields through the
+   * event loop until that polling object exists and exposes `stop()`, allowing
+   * the caller to install process shutdown hooks without a non-stoppable gap.
+   * A slow readiness wait emits a diagnostic but keeps the in-flight launch
+   * and token claim fenced until the poller becomes stoppable or launch itself
+   * settles. All readiness timers are cancelled on readiness or launch failure.
+   * The poll loop remains supervised in the background afterwards, with
+   * bounded exponential-backoff relaunches for post-connect failures.
    */
   private launchPollerSupervised(
     bot: Telegraf<Context>,
@@ -1006,6 +1014,8 @@ export class TelegramService extends Service {
     accountId: string,
   ): Promise<void> {
     const maxPollRelaunches = 5;
+    const pollerReadyWarningMs = 30_000;
+    const pollerReadyCheckMs = 10;
     // A loop that ran healthy for at least this long before failing is treated
     // as a fresh transient (relaunch budget reset); a faster failure counts
     // against the budget so a persistent conflict cannot relaunch forever.
@@ -1038,7 +1048,64 @@ export class TelegramService extends Service {
     let relaunches = 0;
 
     return new Promise<void>((resolve, reject) => {
-      let connectedOnce = false;
+      let pollerReadyOnce = false;
+      let initialSettled = false;
+      let pollerReadyTimer: ReturnType<typeof setTimeout> | undefined;
+      let pollerReadyWarningTimer: ReturnType<typeof setTimeout> | undefined;
+
+      const clearPollerReadyTimers = (): void => {
+        if (pollerReadyTimer !== undefined) {
+          clearTimeout(pollerReadyTimer);
+          pollerReadyTimer = undefined;
+        }
+        if (pollerReadyWarningTimer !== undefined) {
+          clearTimeout(pollerReadyWarningTimer);
+          pollerReadyWarningTimer = undefined;
+        }
+      };
+
+      const rejectInitialLaunch = (error: unknown): void => {
+        if (initialSettled) return;
+        initialSettled = true;
+        clearPollerReadyTimers();
+        reject(error);
+      };
+
+      const waitForStoppablePoller = (): void => {
+        if (pollerReadyOnce || initialSettled) return;
+        pollerReadyWarningTimer = setTimeout(() => {
+          pollerReadyWarningTimer = undefined;
+          logger.warn(
+            {
+              src: "plugin:telegram",
+              agentId: this.runtime.agentId,
+              accountId,
+              pollerReadyWarningMs,
+            },
+            "Telegram launch is still waiting for a stoppable poller",
+          );
+        }, pollerReadyWarningMs);
+        pollerReadyWarningTimer.unref?.();
+
+        const check = (): void => {
+          if (pollerReadyOnce || initialSettled) return;
+          const polling = (bot as unknown as { polling?: { stop?: unknown } })
+            .polling;
+          if (typeof polling?.stop === "function") {
+            pollerReadyOnce = true;
+            initialSettled = true;
+            clearPollerReadyTimers();
+            if (botToken) {
+              markTelegramPollerConnected(botToken, bot);
+            }
+            resolve();
+            return;
+          }
+          pollerReadyTimer = setTimeout(check, pollerReadyCheckMs);
+          pollerReadyTimer.unref?.();
+        };
+        check();
+      };
 
       const scheduleRelaunch = (): void => {
         if (!ownsToken()) {
@@ -1094,8 +1161,8 @@ export class TelegramService extends Service {
         } catch (error) {
           // error-policy:J4 A failed ownership claim either rejects initial
           // startup or becomes explicit unhealthy poller state after launch.
-          if (!connectedOnce) {
-            reject(error);
+          if (!pollerReadyOnce) {
+            rejectInitialLaunch(error);
           } else {
             if (botToken) {
               markTelegramPollerError(botToken, bot, error);
@@ -1111,12 +1178,10 @@ export class TelegramService extends Service {
             },
             () => {
               connectedAt = Date.now();
-              if (botToken) {
+              if (!pollerReadyOnce) {
+                waitForStoppablePoller();
+              } else if (botToken) {
                 markTelegramPollerConnected(botToken, bot);
-              }
-              if (!connectedOnce) {
-                connectedOnce = true;
-                resolve();
               }
             },
           )
@@ -1125,19 +1190,18 @@ export class TelegramService extends Service {
               // Clean stop (shutdown, or deliberate replacement by a newer
               // runtime): release ownership and do not relaunch.
               clearActive();
-              if (!connectedOnce) {
-                reject(
+              if (!pollerReadyOnce) {
+                rejectInitialLaunch(
                   new Error("Telegram poller stopped before it connected"),
                 );
               }
             },
             (error: unknown) => {
-              if (connectedAt === 0 && !connectedOnce) {
-                // Pre-connect failure on the first launch (revoked/malformed
-                // token, network): reject so start()'s retry / token-rejection
-                // branch handles it.
+              if (!pollerReadyOnce) {
+                // Any failure before a stoppable polling object exists rejects
+                // initial startup so its retry / token-rejection path owns it.
                 clearActive();
-                reject(error);
+                rejectInitialLaunch(error);
                 return;
               }
               if (botToken) {


### PR DESCRIPTION
Closes #24048.

## Summary

- Make each Telegram account's command registration, poller launch, middleware wiring, and shutdown-hook installation one-shot across `TelegramService.start()` retries.
- Preserve legitimate pre-connect relaunch while preventing a post-connect retry from overwriting `bot.polling` and stranding the first long-poll loop.
- Drive the real service and real Telegraf against a loopback Bot API, covering both transient post-connect failure and the unchanged happy path.
- Keep existing mocked account-runtime fixtures aligned with the new required wiring contract and surface teardown failures after all resources are reclaimed.

## Exact-head verification

<!-- evidence-head:a79c53e50e624f36ebc666c4022606669e55b051 -->

- Rebased with zero conflicts onto `develop@6e69cc16cccb32c91ecb2263675e654d24f0ce5a`.
- `bun run --cwd plugins/plugin-telegram test` — 26 files, 256 tests passed, 0 failed.
- `bun run --cwd plugins/plugin-telegram build` — passed, including declaration generation.
- `bun run --cwd plugins/plugin-telegram lint:check` — 64 files clean.
- `git diff --check` — passed.
- `bun run verify` — attempted; stopped at `check:biome-version` because this disk-constrained sparse checkout does not contain `packages/auth/package.json`. This is an explicit environment/merge hold, not a source or draft blocker.

Hosted CI did run on prior heads. Its Telegram regression passed, while the directly attributable package-suite fixture failure is repaired on this head; hosted checks must rerun before merge.

## Evidence gate

<!-- evidence-row:before-screenshots -->
- [x] N/A — service lifecycle code has no rendered UI.

<!-- evidence-row:after-screenshots -->
- [x] N/A — service lifecycle code has no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [x] N/A — the acceptance surface is whether a background long-poll loop remains after `stop()`.

<!-- evidence-row:backend-logs -->
- [x] **Real Telegram Bot API account, real Telegraf 4.16.3, exact head `a79c53e5`.** Both arms
      first prove they start uncontended, because a poller stranded by an earlier run contaminates
      the next run (we hit exactly that and added the gate).

      **Single `launch()` — the shape this PR produces:**
      ```
      [2026-08-22T11:59:19.349Z] MODE: single | telegraf@4.16.3
      [2026-08-22T11:59:19.912Z] getMe -> 200 @scoclawdbot
      [2026-08-22T11:59:20.416Z] backlog drained
      [2026-08-22T11:59:20.416Z] quiet-baseline: verifying no other poller holds this token
      [2026-08-22T11:59:26.586Z] quiet-baseline OK -> 200
      [2026-08-22T11:59:26.588Z] launch() #1
      [2026-08-22T11:59:30.590Z] poller #1 is live (receive/poll window open)
      [2026-08-22T11:59:30.591Z] stop()
      [2026-08-22T11:59:34.594Z] post-stop probe: opening an independent long poll
      [2026-08-22T11:59:40.082Z] post-stop probe -> 200 ok
      ```

      **Double `launch()` on one instance — the retry shape this PR prevents:**
      ```
      [2026-08-22T11:59:51.099Z] MODE: double | telegraf@4.16.3
      [2026-08-22T11:59:51.615Z] getMe -> 200 @scoclawdbot
      [2026-08-22T11:59:52.087Z] backlog drained
      [2026-08-22T11:59:52.087Z] quiet-baseline: verifying no other poller holds this token
      [2026-08-22T11:59:58.253Z] quiet-baseline OK -> 200
      [2026-08-22T11:59:58.256Z] launch() #1
      [2026-08-22T12:00:02.260Z] poller #1 is live (receive/poll window open)
      [2026-08-22T12:00:02.261Z] launch() #2 on the SAME bot instance (simulating the retry path)
      [2026-08-22T12:00:02.945Z] !! launch#1 CONFLICT: Conflict: terminated by other getUpdates request; make sure that only one bot instance is running
      [2026-08-22T12:00:07.151Z] !! launch#2 CONFLICT: Conflict: terminated by other getUpdates request; make sure that only one bot instance is running
      [2026-08-22T12:00:07.263Z] stop()
      [2026-08-22T12:00:11.265Z] post-stop probe: opening an independent long poll
      [2026-08-22T12:00:16.776Z] post-stop probe -> 200 ok
      ```

      **How the detector was calibrated, and what it does *not* show.** Telegram permits one active
      `getUpdates` per token. The intuitive probe — "hold a poll, call `getUpdates`, expect 409" — is
      backwards, and we measured it before relying on it: the **new** request returns 200 and
      *terminates* the older one, and the `409 Conflict: terminated by other getUpdates request` is
      delivered to the poller that was **displaced**. So the signal is only visible from inside the
      long poll, which is exactly where a stranded plugin poller lives.

      Consequently the post-stop probe reads `200` in **both** arms and is **not** the discriminator;
      it only shows the token is reachable. The discriminator is the 409s the pollers themselves
      observe: `0` with a single launch, `2` with a double launch. In the double arm the two loops
      displace *each other* while both are alive — which is the "lingering `getUpdates` activity"
      this review asked us to demonstrate the absence of.

<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend code changed.

<!-- evidence-row:llm-trajectory -->
- [x] N/A — no prompt, model, planner, action, or provider behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] **Measured lifecycle outcome, both arms, telegraf@4.16.3 against a real bot account:**

      | arm | 409s observed by the poller | post-stop probe | lingering poller |
      |---|---:|---:|---|
      | single `launch()` (this PR's shape) | **0** | 200 | **false** |
      | double `launch()` (defect shape) | **2** | 200 | **true** |

      Machine-readable results:
      ```json
      {"mode":"single","telegraf":"4.16.3","post_stop_probe_status":200,
       "conflicts_observed":0,"conflicts":[],"lingering_poller":false}
      {"mode":"double","telegraf":"4.16.3","post_stop_probe_status":200,
       "conflicts_observed":2,"lingering_poller":true,
       "conflicts":[{"at":"2026-08-22T12:00:02.945Z","from":"launch#1",
                     "description":"Conflict: terminated by other getUpdates request; make sure that only one bot instance is running"},
                    {"at":"2026-08-22T12:00:07.151Z","from":"launch#2",
                     "description":"Conflict: terminated by other getUpdates request; make sure that only one bot instance is running"}]}
      ```

      The committed regression tests remain the deterministic in-suite check (Bot API request count
      and poller abort state); the above is the supported-target counterpart run against the real
      provider.

<!-- evidence-row:ocr-review -->
- [x] N/A — no rendered visual surface.

## Ready-state holds

- Hosted CI and independent review must complete on `a79c53e50e624f36ebc666c4022606669e55b051`.
- Root verification remains held by the named sparse-checkout limitation above.

## Risk

Medium-low. The change is isolated to per-account startup wiring and tests. The supervised post-connect recovery path is unchanged; the poller flag is set only after a successful connection.

Maintainer rebase receipt: conflict-free rebase onto current `develop`; combined patch-id `3c603bfd864a1fbf856b91a9936fee403875b724` is unchanged. Independently verified at exact head `a79c53e50e624f36ebc666c4022606669e55b051`: all 3 touched files Biome clean and `git diff --check` clean. Local focused collection is dependency-blocked because this shared checkout’s `@elizaos/core` workspace link points to a retired worktree; the contributor’s 256/256 package receipt remains the execution evidence for the byte-identical patch. Hosted checks are rerunning on the rebased exact head.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`, `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0K5V122RKKQAAH9HBCBXGWS","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T22:07:38.050Z","completed_at":"2026-08-21T22:08:09.947Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T22:07:38.392Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"c6bc59b0a1087707e4e6bc9f4c0eedf096942c49dd5f4fa68791e4dfd39d470e","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"eed0e373-f0b4-476b-89ba-f8faa3861d20","object_id":"sha256:c6bc59b0a1087707e4e6bc9f4c0eedf096942c49dd5f4fa68791e4dfd39d470e","sha256":"c6bc59b0a1087707e4e6bc9f4c0eedf096942c49dd5f4fa68791e4dfd39d470e"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"ziowM-nioNq1u3lRTHVcOCUHle3nhWrd0YxIgTTi-swBpfyHYwPy7VgRQMqfRXLXC6Vjnob7_JQJ7guhiBFmAg"}} -->
