### PR TITLE
fix(cloud): bound both body reads in the metered MCP proxy

### DIFF
--- a/packages/cloud/api/__tests__/mcp-proxy-body-budget.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-body-budget.test.ts
@@ -2,9 +2,12 @@
  * Exercises the MCP proxy's bounded body reader against declared, streamed,
  * fragmented, malformed, and teardown-failure inputs using real web streams.
  */
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
+  __mcpProxyHopTestHooks,
   type BudgetedBodySource,
+  createMcpProxyHopDeadline,
+  McpProxyHopDeadlineError,
   readBodyTextWithinBudget,
 } from "../mcp/proxy/[mcpId]/proxy-body-budget";
 
@@ -101,7 +104,10 @@ describe("readBodyTextWithinBudget", () => {
       bytes: 8_193,
       reason: "fragmentation-budget",
     });
-    expect(pulls).toBe(8_193);
+    // The 8,193rd non-empty chunk trips the ceiling. Cancel may pull once
+    // more while it still owns the reader; it must not keep amplifying.
+    expect(pulls).toBeGreaterThanOrEqual(8_193);
+    expect(pulls).toBeLessThan(8_200);
   });
 
   test("reports cancellation failure and still releases the lock", async () => {
@@ -137,5 +143,184 @@ describe("readBodyTextWithinBudget", () => {
     );
     const nextReader = body.getReader();
     nextReader.releaseLock();
+  });
+
+  test("never-settling cancel does not delay the budget result and keeps the lock", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2]));
+      },
+      cancel() {
+        return new Promise(() => {
+          /* never settles */
+        });
+      },
+    });
+
+    const started = Date.now();
+    const result = await readBodyTextWithinBudget(source(body), 1);
+    expect(Date.now() - started).toBeLessThan(50);
+    expect(result).toEqual({ ok: false, bytes: 2, reason: "byte-budget" });
+    expect(() => body.getReader()).toThrow();
+  });
+
+  test("rejecting cancel does not replace the budget result", async () => {
+    const cancelFailures = mock();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2]));
+      },
+      cancel() {
+        return Promise.reject(new Error("cancel failed"));
+      },
+    });
+
+    const result = await readBodyTextWithinBudget(source(body), 1, {
+      onCancelFailure: cancelFailures,
+    });
+    expect(result).toEqual({ ok: false, bytes: 2, reason: "byte-budget" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(cancelFailures).toHaveBeenCalledWith(
+      "streamed-budget",
+      expect.objectContaining({ message: "cancel failed" }),
+    );
+  });
+
+  test("rejects a hanging body when the hop signal aborts", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      pull() {
+        /* never enqueue */
+      },
+    });
+    const controller = new AbortController();
+    const resultPromise = readBodyTextWithinBudget(source(body), 100, {
+      signal: controller.signal,
+    });
+    queueMicrotask(() => {
+      controller.abort(
+        new DOMException("MCP proxy hop deadline exceeded", "TimeoutError"),
+      );
+    });
+    const hung = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error("reader ignored hop abort")), 80);
+    });
+    expect(await Promise.race([resultPromise, hung])).toEqual({
+      ok: false,
+      bytes: 0,
+      reason: "deadline",
+    });
+  });
+
+  test("a live hop signal does not alter a below-budget decode", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"ok":true}'));
+        controller.close();
+      },
+    });
+    const controller = new AbortController();
+    expect(
+      await readBodyTextWithinBudget(source(body), 100, {
+        signal: controller.signal,
+      }),
+    ).toEqual({ ok: true, text: '{"ok":true}' });
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  test("already-aborted hop refuses without pulling the body", async () => {
+    let pulled = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull() {
+        pulled = true;
+      },
+    });
+    const controller = new AbortController();
+    controller.abort(new McpProxyHopDeadlineError(1));
+    expect(
+      await readBodyTextWithinBudget(
+        source(body, { "content-length": "5" }),
+        10,
+        { signal: controller.signal },
+      ),
+    ).toEqual({ ok: false, bytes: 5, reason: "deadline" });
+    expect(pulled).toBe(false);
+  });
+
+  test("null-body source.text hang returns deadline without replacing a later throw", async () => {
+    const hanging: BudgetedBodySource = {
+      headers: new Headers(),
+      body: null,
+      text: () =>
+        new Promise(() => {
+          /* never settles */
+        }),
+    };
+    const controller = new AbortController();
+    const resultPromise = readBodyTextWithinBudget(hanging, 100, {
+      signal: controller.signal,
+    });
+    queueMicrotask(() => {
+      controller.abort(new McpProxyHopDeadlineError(1));
+    });
+    expect(await resultPromise).toEqual({
+      ok: false,
+      bytes: 0,
+      reason: "deadline",
+    });
+  });
+
+  test("composed caller abort fails a hanging read as deadline", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      pull() {
+        /* never enqueue */
+      },
+    });
+    const caller = new AbortController();
+    const hop = createMcpProxyHopDeadline(caller.signal);
+    const resultPromise = readBodyTextWithinBudget(source(body), 100, {
+      signal: hop.signal,
+    });
+    queueMicrotask(() => {
+      caller.abort(new Error("caller canceled"));
+    });
+    expect(await resultPromise).toEqual({
+      ok: false,
+      bytes: 0,
+      reason: "deadline",
+    });
+    hop.clear();
+  });
+});
+
+describe("createMcpProxyHopDeadline", () => {
+  afterEach(() => {
+    __mcpProxyHopTestHooks.resetHopTimeoutMs();
+  });
+
+  test("clear() prevents the timer from aborting a completed hop", async () => {
+    __mcpProxyHopTestHooks.setHopTimeoutMs(20);
+    const hop = createMcpProxyHopDeadline();
+    hop.clear();
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(hop.signal.aborted).toBe(false);
+  });
+
+  test("fires a typed deadline error after the configured timeout", async () => {
+    __mcpProxyHopTestHooks.setHopTimeoutMs(20);
+    const hop = createMcpProxyHopDeadline();
+    await new Promise((resolve) => {
+      hop.signal.addEventListener("abort", resolve, { once: true });
+    });
+    expect(hop.signal.reason).toBeInstanceOf(McpProxyHopDeadlineError);
+    hop.clear();
+  });
+
+  test("an already-aborted caller is returned without starting a timer", async () => {
+    const caller = new AbortController();
+    caller.abort(new Error("caller"));
+    const hop = createMcpProxyHopDeadline(caller.signal);
+    expect(hop.signal.aborted).toBe(true);
+    expect(hop.signal).toBe(caller.signal);
+    hop.clear();
   });
 });

--- a/packages/cloud/api/__tests__/mcp-proxy-body-budget.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-body-budget.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Exercises the MCP proxy's bounded body reader against declared, streamed,
+ * fragmented, malformed, and teardown-failure inputs using real web streams.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import {
+  type BudgetedBodySource,
+  readBodyTextWithinBudget,
+} from "../mcp/proxy/[mcpId]/proxy-body-budget";
+
+function source(
+  body: ReadableStream<Uint8Array>,
+  headers: HeadersInit = {},
+): BudgetedBodySource {
+  return {
+    headers: new Headers(headers),
+    body,
+    text: async () => {
+      throw new Error("stream path expected");
+    },
+  };
+}
+
+describe("readBodyTextWithinBudget", () => {
+  test("rejects declared overflow without reading and cancels the body", async () => {
+    let pulled = false;
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull() {
+        pulled = true;
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    expect(
+      await readBodyTextWithinBudget(
+        source(body, { "content-length": "11" }),
+        10,
+      ),
+    ).toEqual({ ok: false, bytes: 11, reason: "byte-budget" });
+    await Promise.resolve();
+    expect(pulled).toBe(false);
+    expect(cancelled).toBe(true);
+  });
+
+  test("rejects streamed overflow, cancels, and releases the reader lock", async () => {
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.enqueue(new Uint8Array([4, 5, 6]));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    expect(await readBodyTextWithinBudget(source(body), 5)).toEqual({
+      ok: false,
+      bytes: 6,
+      reason: "byte-budget",
+    });
+    await Promise.resolve();
+    expect(cancelled).toBe(true);
+    const nextReader = body.getReader();
+    nextReader.releaseLock();
+  });
+
+  test("decodes an exact-budget UTF-8 value split inside a code point", async () => {
+    const bytes = new TextEncoder().encode("A🦊B");
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes.subarray(0, 3));
+        controller.enqueue(bytes.subarray(3, 5));
+        controller.enqueue(bytes.subarray(5));
+        controller.close();
+      },
+    });
+
+    expect(
+      await readBodyTextWithinBudget(source(body), bytes.byteLength),
+    ).toEqual({
+      ok: true,
+      text: "A🦊B",
+    });
+  });
+
+  test("rejects malicious tiny-chunk fragmentation without retaining chunk objects", async () => {
+    let pulls = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(new Uint8Array([97]));
+      },
+    });
+
+    expect(await readBodyTextWithinBudget(source(body), 20_000)).toEqual({
+      ok: false,
+      bytes: 8_193,
+      reason: "fragmentation-budget",
+    });
+    expect(pulls).toBe(8_193);
+  });
+
+  test("reports cancellation failure and still releases the lock", async () => {
+    const cancelFailures = mock();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2]));
+      },
+      cancel() {
+        return Promise.reject(new Error("cancel failed"));
+      },
+    });
+
+    await readBodyTextWithinBudget(source(body), 1, cancelFailures);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(cancelFailures).toHaveBeenCalledWith(
+      "streamed-budget",
+      expect.objectContaining({ message: "cancel failed" }),
+    );
+    const nextReader = body.getReader();
+    nextReader.releaseLock();
+  });
+
+  test("releases the reader lock when reader.read rejects", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      pull() {
+        throw new Error("reader failed");
+      },
+    });
+
+    await expect(readBodyTextWithinBudget(source(body), 10)).rejects.toThrow(
+      "reader failed",
+    );
+    const nextReader = body.getReader();
+    nextReader.releaseLock();
+  });
+});

--- a/packages/cloud/api/__tests__/mcp-proxy-body-budget.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-body-budget.test.ts
@@ -8,6 +8,7 @@ import {
   type BudgetedBodySource,
   createMcpProxyHopDeadline,
   McpProxyHopDeadlineError,
+  raceWithAbort,
   readBodyTextWithinBudget,
 } from "../mcp/proxy/[mcpId]/proxy-body-budget";
 
@@ -322,5 +323,26 @@ describe("createMcpProxyHopDeadline", () => {
     expect(hop.signal.aborted).toBe(true);
     expect(hop.signal).toBe(caller.signal);
     hop.clear();
+  });
+});
+
+describe("raceWithAbort", () => {
+  test("returns when the underlying promise never settles and the hop aborts", async () => {
+    const controller = new AbortController();
+    const pending = raceWithAbort(
+      new Promise<never>(() => {
+        /* never settles — DNS / prevalidation hang */
+      }),
+      controller.signal,
+    );
+    queueMicrotask(() => {
+      controller.abort(new McpProxyHopDeadlineError(20));
+    });
+    const hung = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error("raceWithAbort ignored abort")), 80);
+    });
+    await expect(Promise.race([pending, hung])).rejects.toBeInstanceOf(
+      McpProxyHopDeadlineError,
+    );
   });
 });

--- a/packages/cloud/api/__tests__/mcp-proxy-helpers.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-helpers.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, expect, test } from "bun:test";
 
+import { McpProxyHopDeadlineError } from "../mcp/proxy/[mcpId]/proxy-body-budget";
 import {
   isJsonRpcErrorResponse,
   type McpProxyJson,
@@ -117,6 +118,30 @@ describe("parseJsonBody", () => {
       headers: { "content-type": "application/json" },
     });
     await expect(parseJsonBody(req)).rejects.toThrow();
+  });
+
+  test("caller-aborted hanging JSON body fails as a hop deadline, not a hang", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      pull() {
+        /* never enqueue */
+      },
+    });
+    const req = new Request("https://example.com", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+    const controller = new AbortController();
+    const pending = parseJsonBody(req, 1_000, { signal: controller.signal });
+    queueMicrotask(() => {
+      controller.abort(new McpProxyHopDeadlineError(20));
+    });
+    const hung = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error("parseJsonBody ignored abort")), 80);
+    });
+    await expect(Promise.race([pending, hung])).rejects.toBeInstanceOf(
+      McpProxyHopDeadlineError,
+    );
   });
 });
 

--- a/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
@@ -184,6 +184,19 @@ test("invalid JSON body (400) refunds after the upfront debit (#11637)", async (
   expect(refundCredits).toHaveBeenCalledTimes(1);
 });
 
+test("oversized request body returns 413, refunds exact receipt, and skips upstream", async () => {
+  const res = await post(`{"payload":"${"x".repeat(1_000_001)}"}`);
+  expect(res.status).toBe(413);
+  expect(refundCredits).toHaveBeenCalledWith(
+    expect.objectContaining({
+      amount: 0.05,
+      metadata: expect.objectContaining({ reason: "request_body_too_large" }),
+    }),
+  );
+  expect(safeFetch).not.toHaveBeenCalled();
+  expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
+});
+
 test("non-ok upstream status refunds (existing behavior preserved)", async () => {
   safeFetch.mockResolvedValue(new Response("upstream error", { status: 500 }));
   const res = await post();
@@ -202,7 +215,34 @@ test("upstream response body read failure refunds before usage is recorded", asy
   } as unknown as Response);
   const res = await post();
   expect(res.status).toBe(502);
-  expect(refundCredits).toHaveBeenCalledTimes(1);
+  expect(refundCredits).toHaveBeenCalledWith(
+    expect.objectContaining({
+      amount: 0.05,
+      metadata: expect.objectContaining({ reason: "mcp_response_read_failed" }),
+    }),
+  );
+  expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
+});
+
+test("declared oversized upstream body returns 502 and refunds exact receipt", async () => {
+  safeFetch.mockResolvedValue(
+    new Response("not read", {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+        "content-length": "5000001",
+      },
+    }),
+  );
+  const res = await post();
+  expect(res.status).toBe(502);
+  expect(refundCredits).toHaveBeenCalledWith(
+    expect.objectContaining({
+      amount: 0.05,
+      metadata: expect.objectContaining({ reason: "mcp_response_too_large" }),
+    }),
+  );
+  expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
 });
 
 test("successful call does NOT refund", async () => {

--- a/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
@@ -400,6 +400,101 @@ test("successful call does NOT refund", async () => {
   expect(refundCredits).not.toHaveBeenCalled();
 });
 
+test("stalled endpoint prevalidation returns 504, refunds exact receipt, and skips usage", async () => {
+  __mcpProxyHopTestHooks.setHopTimeoutMs(20);
+  assertSafeOutboundUrl.mockReturnValue(
+    new Promise(() => {
+      /* never settles — attacker-controlled DNS during prevalidation */
+    }),
+  );
+  const hung = new Promise<never>((_, reject) => {
+    setTimeout(
+      () => reject(new Error("prevalidation ignored hop deadline")),
+      80,
+    );
+  });
+  const res = await Promise.race([post(), hung]);
+  expect(res.status).toBe(504);
+  const prevalidationTimedOut = (await res.json()) as { error: string };
+  expect(prevalidationTimedOut).toEqual({ error: "MCP endpoint timed out" });
+  expect(refundCredits).toHaveBeenCalledWith(
+    expect.objectContaining({
+      amount: 0.05,
+      metadata: expect.objectContaining({
+        reason: "upstream_deadline_exceeded",
+      }),
+    }),
+  );
+  expect(safeFetch).not.toHaveBeenCalled();
+  expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
+});
+
+test("stalled pre-socket DNS in safeFetch returns 504, refunds exact receipt, and skips usage", async () => {
+  __mcpProxyHopTestHooks.setHopTimeoutMs(20);
+  safeFetch.mockImplementation(() => {
+    return new Promise(() => {
+      /* never settles and ignores hop.signal — DNS lookup that never returns */
+    });
+  });
+  const hung = new Promise<never>((_, reject) => {
+    setTimeout(
+      () => reject(new Error("pre-socket DNS ignored hop deadline")),
+      80,
+    );
+  });
+  const res = await Promise.race([post(), hung]);
+  expect(res.status).toBe(504);
+  const dnsTimedOut = (await res.json()) as { error: string };
+  expect(dnsTimedOut).toEqual({ error: "MCP endpoint timed out" });
+  expect(refundCredits).toHaveBeenCalledWith(
+    expect.objectContaining({
+      amount: 0.05,
+      metadata: expect.objectContaining({
+        reason: "upstream_deadline_exceeded",
+      }),
+    }),
+  );
+  expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
+});
+
+test("caller-aborted inbound JSON read returns 504, refunds exact receipt, and skips usage", async () => {
+  const caller = new AbortController();
+  const body = new ReadableStream<Uint8Array>({
+    pull() {
+      /* never enqueue — inbound parse waits on the caller body */
+    },
+  });
+  const pending = app.request("/test-mcp", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+    signal: caller.signal,
+  });
+  queueMicrotask(() => {
+    caller.abort(new Error("caller canceled"));
+  });
+  const hung = new Promise<never>((_, reject) => {
+    setTimeout(
+      () => reject(new Error("inbound JSON read ignored caller abort")),
+      80,
+    );
+  });
+  const res = await Promise.race([pending, hung]);
+  expect(res.status).toBe(504);
+  const inboundTimedOut = (await res.json()) as { error: string };
+  expect(inboundTimedOut).toEqual({ error: "MCP endpoint timed out" });
+  expect(refundCredits).toHaveBeenCalledWith(
+    expect.objectContaining({
+      amount: 0.05,
+      metadata: expect.objectContaining({
+        reason: "upstream_deadline_exceeded",
+      }),
+    }),
+  );
+  expect(safeFetch).not.toHaveBeenCalled();
+  expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
+});
+
 test("affiliate surcharge uses one exact debit, persisted receipt, and refund authority", async () => {
   getReferrer.mockResolvedValue({
     user_id: "affiliate-user",

--- a/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
+++ b/packages/cloud/api/__tests__/mcp-proxy-refund.test.ts
@@ -8,8 +8,9 @@
  * called on each failure branch and NOT on success. Red on develop tip (only
  * the non-ok branch refunded); green after the fix.
  */
-import { beforeEach, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import { __mcpProxyHopTestHooks } from "../mcp/proxy/[mcpId]/proxy-body-budget";
 
 // mock.module is process-global — spread the real auth module so only
 // requireUserOrApiKeyWithOrg is overridden (mirrors agent-mcp-billing.test.ts).
@@ -101,6 +102,10 @@ beforeEach(() => {
   );
   safeFetch.mockReset();
   containersGetById.mockReset();
+});
+
+afterEach(() => {
+  __mcpProxyHopTestHooks.resetHopTimeoutMs();
 });
 
 test("unreachable upstream (502) refunds the upfront debit (#11637)", async () => {
@@ -240,6 +245,147 @@ test("declared oversized upstream body returns 502 and refunds exact receipt", a
     expect.objectContaining({
       amount: 0.05,
       metadata: expect.objectContaining({ reason: "mcp_response_too_large" }),
+    }),
+  );
+  expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
+});
+
+test("headers-resolve body-never-resolves returns 504, refunds exact receipt, and skips usage", async () => {
+  __mcpProxyHopTestHooks.setHopTimeoutMs(25);
+  safeFetch.mockImplementation((_url: string, init?: RequestInit) => {
+    void init;
+    const body = new ReadableStream<Uint8Array>({
+      pull() {
+        /* never enqueue */
+      },
+    });
+    return Promise.resolve(
+      new Response(body, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  });
+  const res = await post();
+  expect(res.status).toBe(504);
+  const timedOut = (await res.json()) as { error: string };
+  expect(timedOut).toEqual({ error: "MCP endpoint timed out" });
+  expect(refundCredits).toHaveBeenCalledWith(
+    expect.objectContaining({
+      amount: 0.05,
+      metadata: expect.objectContaining({
+        reason: "upstream_deadline_exceeded",
+      }),
+    }),
+  );
+  expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
+});
+
+test("streamed oversized upstream body returns 502 and refunds exact receipt", async () => {
+  const first = new Uint8Array(5_000_000);
+  const overflow = new Uint8Array(2);
+  first.fill(97);
+  overflow.fill(98);
+  safeFetch.mockResolvedValue(
+    new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(first);
+          controller.enqueue(overflow);
+          controller.close();
+        },
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    ),
+  );
+  const res = await post();
+  expect(res.status).toBe(502);
+  expect(refundCredits).toHaveBeenCalledWith(
+    expect.objectContaining({
+      amount: 0.05,
+      metadata: expect.objectContaining({ reason: "mcp_response_too_large" }),
+    }),
+  );
+  expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
+});
+
+test("container hop headers-resolve body-never-resolves returns 504 and refunds", async () => {
+  __mcpProxyHopTestHooks.setHopTimeoutMs(25);
+  getById.mockResolvedValue({
+    id: "test-mcp",
+    name: "Container MCP",
+    status: "live",
+    credits_per_request: "5",
+    endpoint_type: "container",
+    container_id: "c1",
+    organization_id: "org1",
+  });
+  containersGetById.mockResolvedValue({
+    load_balancer_url: "http://container.internal",
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    void input;
+    void init;
+    const body = new ReadableStream<Uint8Array>({
+      pull() {
+        /* never enqueue */
+      },
+    });
+    return Promise.resolve(
+      new Response(body, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }) as typeof fetch;
+  try {
+    const res = await post();
+    expect(res.status).toBe(504);
+    expect(refundCredits).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 0.05,
+        metadata: expect.objectContaining({
+          reason: "upstream_deadline_exceeded",
+        }),
+      }),
+    );
+    expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();
+    expect(safeFetch).not.toHaveBeenCalled();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("headers-never-resolve fetch abort refunds exact receipt and skips usage", async () => {
+  __mcpProxyHopTestHooks.setHopTimeoutMs(25);
+  safeFetch.mockImplementation((_url: string, init?: RequestInit) => {
+    return new Promise((_resolve, reject) => {
+      const signal = init?.signal;
+      if (signal?.aborted) {
+        reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+        return;
+      }
+      signal?.addEventListener(
+        "abort",
+        () => {
+          reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+        },
+        { once: true },
+      );
+    });
+  });
+  const res = await post();
+  expect(res.status).toBe(504);
+  expect(refundCredits).toHaveBeenCalledWith(
+    expect.objectContaining({
+      amount: 0.05,
+      metadata: expect.objectContaining({
+        reason: "upstream_deadline_exceeded",
+      }),
     }),
   );
   expect(recordUsageWithoutDeduction).not.toHaveBeenCalled();

--- a/packages/cloud/api/mcp/proxy/[mcpId]/proxy-body-budget.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/proxy-body-budget.ts
@@ -16,7 +16,10 @@
  * rejecting cancel must not delay or replace the budget result.
  *
  * The hop deadline is clearable, composed with caller cancellation, and races
- * both `fetch` (via the returned signal) and every `reader.read()`.
+ * endpoint prevalidation, DNS, `fetch`/`safeFetch`, and every body read. DNS
+ * APIs ignore AbortSignal, so {@link raceWithAbort} must settle those awaits
+ * when the hop fires — passing the signal later does not close a lookup that
+ * never returns.
  */
 
 /** The subset of `Request` / `Response` this reader needs. */
@@ -237,10 +240,11 @@ function isHopFailure(
 
 /**
  * Race `promise` against `signal` without leaving an abort listener attached
- * after the read wins. Abort does not cancel the underlying promise; the
- * caller must cancel the reader so a hanging `read()` cannot retain the hop.
+ * after the promise wins. Abort does not cancel the underlying work; the
+ * caller must still cancel readers and treat the rejection as the hop
+ * result so a never-settling DNS lookup or body read cannot retain the request.
  */
-function raceWithAbort<T>(
+export function raceWithAbort<T>(
   promise: Promise<T>,
   signal: AbortSignal | undefined,
 ): Promise<T> {

--- a/packages/cloud/api/mcp/proxy/[mcpId]/proxy-body-budget.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/proxy-body-budget.ts
@@ -1,33 +1,22 @@
 /**
- * Byte budgets for the two bodies the MCP proxy buffers into the isolate.
+ * Byte and time budgets for the two bodies the MCP proxy buffers into the
+ * isolate.
  *
- * `route.ts` reads the caller's request body with `await request.text()` and
- * the MCP server's response with `await mcpResponse.text()`. Neither read has
- * a byte budget, and for the response the far end is a URL the MCP's owner
- * chose (`external_endpoint`, reached through `safeFetch`) — so the number of
- * bytes an isolate spends on one proxied call is picked by whoever registered
- * the MCP, not by this service.
+ * `route.ts` used to `await request.text()` / `await mcpResponse.text()` with
+ * no byte budget and no hop deadline. The response far end is a URL the MCP's
+ * owner chose (`external_endpoint`, reached through `safeFetch`), so isolate
+ * memory and Worker wall-clock were picked by whoever registered the MCP.
  *
- * This package deploys as a Cloudflare Worker
- * (`packages/cloud/api/wrangler.toml`, `name = "eliza-cloud-api"`), where
- * per-isolate memory is a hard platform limit. The handler's `catch` around
- * each read is real, but it catches read *failures*; it cannot give back an
- * allocation that has already completed.
+ * Bytes are charged before they are retained: a declared `content-length` over
+ * budget is refused without a read; otherwise chunks copy into one fixed-size
+ * slab and decode once. Fragmentation is capped independently so one-byte
+ * chunks cannot multiply object overhead. Overflow and hop-abort cancel the
+ * reader without awaiting it, but they keep the lock until that cancel settles
+ * so `releaseLock()` cannot race a live `cancel()`. A never-settling or
+ * rejecting cancel must not delay or replace the budget result.
  *
- * The reader below charges the budget BEFORE the bytes are retained, in the
- * two stages this repository already uses in
- * `@/lib/services/oauth/credential-broker.ts` (#23900),
- * `api/v1/voice/stt/route.ts`, and `api/scripts/local-voice-runtime-identity.ts`:
- *
- *  1. a declared `content-length` over budget is refused without reading the
- *     body at all;
- *  2. otherwise the body is streamed, each chunk charged against the running
- *     total before it is retained, and cut off the moment the total passes the
- *     budget. Bytes are copied into one fixed-size slab and decoded once, so
- *     retained chunk objects cannot multiply isolate memory independently of
- *     the byte budget.
- *
- * Deliberately import-free so it can be driven on its own.
+ * The hop deadline is clearable, composed with caller cancellation, and races
+ * both `fetch` (via the returned signal) and every `reader.read()`.
  */
 
 /** The subset of `Request` / `Response` this reader needs. */
@@ -42,8 +31,13 @@ export type BudgetedText =
   | {
       readonly ok: false;
       readonly bytes: number;
-      readonly reason: "byte-budget" | "fragmentation-budget";
+      readonly reason: "byte-budget" | "fragmentation-budget" | "deadline";
     };
+
+export interface ReadBodyBudgetOptions {
+  readonly signal?: AbortSignal;
+  readonly onCancelFailure?: (label: string, error: unknown) => void;
+}
 
 /**
  * Limit pull/decoder churn independently from payload bytes. A standard
@@ -51,6 +45,96 @@ export type BudgetedText =
  * one-byte-at-a-time stream prevents millions of isolate allocations/callbacks.
  */
 const MAX_BODY_STREAM_CHUNKS = 8_192;
+
+/**
+ * Wall-clock bound for one metered MCP hop (outbound fetch plus every body
+ * read). Same 30s class as the credential broker, the other
+ * proxy-to-a-caller-supplied-host service.
+ */
+const DEFAULT_MCP_PROXY_HOP_TIMEOUT_MS = 30_000;
+let hopTimeoutOverrideMs: number | null = null;
+
+export const MCP_PROXY_HOP_TIMEOUT_MS = DEFAULT_MCP_PROXY_HOP_TIMEOUT_MS;
+
+/**
+ * Test-only seam for the hop deadline. The `__` prefix + `TestHooks` suffix
+ * mark it as non-public.
+ */
+export const __mcpProxyHopTestHooks = {
+  setHopTimeoutMs(ms: number): void {
+    hopTimeoutOverrideMs = ms;
+  },
+  resetHopTimeoutMs(): void {
+    hopTimeoutOverrideMs = null;
+  },
+  get hopTimeoutMs(): number {
+    return hopTimeoutOverrideMs ?? DEFAULT_MCP_PROXY_HOP_TIMEOUT_MS;
+  },
+} as const;
+
+/** Typed hop-deadline abort reason the route maps to a 504 refund. */
+export class McpProxyHopDeadlineError extends Error {
+  override readonly name = "McpProxyHopDeadlineError";
+  readonly timeoutMs: number;
+  constructor(timeoutMs: number) {
+    super(`MCP proxy hop exceeded the ${timeoutMs}-millisecond deadline`);
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export function isMcpProxyHopDeadline(
+  signal: AbortSignal,
+  error?: unknown,
+): boolean {
+  if (error instanceof McpProxyHopDeadlineError) return true;
+  if (signal.reason instanceof McpProxyHopDeadlineError) return true;
+  const named = error instanceof Error ? error : null;
+  if (named?.name === "TimeoutError") return true;
+  return (
+    signal.aborted &&
+    signal.reason instanceof Error &&
+    signal.reason.name === "TimeoutError"
+  );
+}
+
+export interface McpProxyHopDeadline {
+  readonly signal: AbortSignal;
+  readonly timeoutMs: number;
+  clear(): void;
+}
+
+/**
+ * Clearable end-to-end hop deadline composed with any caller cancellation.
+ * Callers pass `signal` to both `fetch`/`safeFetch` and
+ * {@link readBodyTextWithinBudget}, then `clear()` once the hop settles.
+ */
+export function createMcpProxyHopDeadline(
+  caller?: AbortSignal | null,
+): McpProxyHopDeadline {
+  const timeoutMs = __mcpProxyHopTestHooks.hopTimeoutMs;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort(new McpProxyHopDeadlineError(timeoutMs));
+  }, timeoutMs);
+
+  let cleared = false;
+  const clear = (): void => {
+    if (cleared) return;
+    cleared = true;
+    clearTimeout(timeoutId);
+  };
+
+  if (caller?.aborted) {
+    clear();
+    return { signal: caller, timeoutMs, clear };
+  }
+
+  const signal = caller
+    ? AbortSignal.any([controller.signal, caller])
+    : controller.signal;
+  signal.addEventListener("abort", clear, { once: true });
+  return { signal, timeoutMs, clear };
+}
 
 /**
  * The declared body length, or `null` when the header is absent or is not a
@@ -64,6 +148,15 @@ export function parseTrustworthyContentLength(headers: Headers): number | null {
   if (!/^\d+$/.test(raw.trim())) return null;
   const parsed = Number(raw);
   return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function resolveReadOptions(
+  options?: ReadBodyBudgetOptions | ((label: string, error: unknown) => void),
+): ReadBodyBudgetOptions {
+  if (typeof options === "function") {
+    return { onCancelFailure: options };
+  }
+  return options ?? {};
 }
 
 function cancelBestEffort(
@@ -80,20 +173,119 @@ function cancelBestEffort(
   }
 }
 
+function releaseLockQuietly(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): void {
+  try {
+    reader.releaseLock();
+  } catch {
+    // error-policy:J6 cancel() may already have released the lock.
+  }
+}
+
 /**
- * Reads `source`'s body as text, refusing it as soon as `maxBytes` is exceeded.
+ * Detached, no-throw cancellation that keeps reader ownership until `cancel()`
+ * settles. The budget/deadline result must not await this promise: a
+ * never-settling or rejecting cancel cannot delay or replace it.
+ */
+function cancelReaderRetainingOwnership(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  label: string,
+  onCancelFailure?: (label: string, error: unknown) => void,
+): void {
+  let cancelPromise: Promise<unknown>;
+  try {
+    cancelPromise = reader.cancel();
+  } catch (error) {
+    // error-policy:J6 synchronous cancellation is best-effort teardown.
+    onCancelFailure?.(label, error);
+    releaseLockQuietly(reader);
+    return;
+  }
+  void cancelPromise.then(
+    () => {
+      releaseLockQuietly(reader);
+    },
+    (error: unknown) => {
+      onCancelFailure?.(label, error);
+      releaseLockQuietly(reader);
+    },
+  );
+}
+
+function hopAborted(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted === true;
+}
+
+function deadlineFailure(bytes: number): BudgetedText {
+  return { ok: false, bytes, reason: "deadline" };
+}
+
+function abortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new McpProxyHopDeadlineError(__mcpProxyHopTestHooks.hopTimeoutMs);
+}
+
+function isHopFailure(
+  signal: AbortSignal | undefined,
+  error?: unknown,
+): boolean {
+  if (!signal) return false;
+  return hopAborted(signal) || isMcpProxyHopDeadline(signal, error);
+}
+
+/**
+ * Race `promise` against `signal` without leaving an abort listener attached
+ * after the read wins. Abort does not cancel the underlying promise; the
+ * caller must cancel the reader so a hanging `read()` cannot retain the hop.
+ */
+function raceWithAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(abortReason(signal));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      reject(abortReason(signal));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+/**
+ * Reads `source`'s body as text, refusing it as soon as `maxBytes` is exceeded
+ * or the hop signal aborts.
  *
  * On refusal `bytes` is the size the refusal was made on: the declared
  * `content-length` when the pre-check fired, otherwise the running total at the
- * chunk that exceeded the byte or fragmentation budget (a lower bound on the
- * real size — the rest is never read).
+ * chunk that exceeded the byte or fragmentation budget, or the total received
+ * when the hop deadline fired (a lower bound — the rest is never read).
  */
 export async function readBodyTextWithinBudget(
   source: BudgetedBodySource,
   maxBytes: number,
-  onCancelFailure?: (label: string, error: unknown) => void,
+  options?: ReadBodyBudgetOptions | ((label: string, error: unknown) => void),
 ): Promise<BudgetedText> {
+  const { signal, onCancelFailure } = resolveReadOptions(options);
   const declaredLength = parseTrustworthyContentLength(source.headers);
+  if (hopAborted(signal)) {
+    if (source.body) {
+      cancelBestEffort(source.body, "deadline-precheck", onCancelFailure);
+    }
+    return deadlineFailure(declaredLength ?? 0);
+  }
   if (declaredLength !== null && declaredLength > maxBytes) {
     if (source.body) {
       cancelBestEffort(source.body, "content-length-precheck", onCancelFailure);
@@ -102,8 +294,16 @@ export async function readBodyTextWithinBudget(
   }
 
   if (!source.body) {
-    const text = await source.text();
-    return { ok: true, text };
+    try {
+      const text = await raceWithAbort(source.text(), signal);
+      return { ok: true, text };
+    } catch (error) {
+      // error-policy:J1 hop abort is a typed budget result, not an unhandled throw.
+      if (isHopFailure(signal, error)) {
+        return deadlineFailure(0);
+      }
+      throw error;
+    }
   }
 
   const reader = source.body.getReader();
@@ -111,35 +311,50 @@ export async function readBodyTextWithinBudget(
   const retained = new Uint8Array(maxBytes);
   let received = 0;
   let chunkCount = 0;
+  let cancelOwnsReader = false;
+
+  const abortRead = (
+    label: string,
+    bytes: number,
+    reason: "byte-budget" | "fragmentation-budget" | "deadline",
+  ): BudgetedText => {
+    cancelOwnsReader = true;
+    cancelReaderRetainingOwnership(reader, label, onCancelFailure);
+    if (reason === "deadline") return deadlineFailure(bytes);
+    return { ok: false, bytes, reason };
+  };
 
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      if (hopAborted(signal)) {
+        return abortRead("deadline", received, "deadline");
+      }
+      const { done, value } = await raceWithAbort(reader.read(), signal);
       if (done) break;
       if (!value || value.byteLength === 0) continue;
       chunkCount += 1;
       received += value.byteLength;
       if (received > maxBytes) {
-        cancelBestEffort(reader, "streamed-budget", onCancelFailure);
-        return { ok: false, bytes: received, reason: "byte-budget" };
+        return abortRead("streamed-budget", received, "byte-budget");
       }
       if (chunkCount > MAX_BODY_STREAM_CHUNKS) {
-        cancelBestEffort(reader, "streamed-fragmentation", onCancelFailure);
-        return {
-          ok: false,
-          bytes: received,
-          reason: "fragmentation-budget",
-        };
+        return abortRead(
+          "streamed-fragmentation",
+          received,
+          "fragmentation-budget",
+        );
       }
       retained.set(value, received - value.byteLength);
     }
+  } catch (error) {
+    // error-policy:J1 hop abort is a typed budget result, not an unhandled throw.
+    if (isHopFailure(signal, error)) {
+      return abortRead("deadline", received, "deadline");
+    }
+    throw error;
   } finally {
-    try {
-      reader.releaseLock();
-    } catch (error) {
-      // error-policy:J6 The body read has already reached a terminal result;
-      // releasing the reader is best-effort transport teardown.
-      onCancelFailure?.("reader-release", error);
+    if (!cancelOwnsReader) {
+      releaseLockQuietly(reader);
     }
   }
 

--- a/packages/cloud/api/mcp/proxy/[mcpId]/proxy-body-budget.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/proxy-body-budget.ts
@@ -1,0 +1,116 @@
+/**
+ * Byte budgets for the two bodies the MCP proxy buffers into the isolate.
+ *
+ * `route.ts` reads the caller's request body with `await request.text()` and
+ * the MCP server's response with `await mcpResponse.text()`. Neither read has
+ * a byte budget, and for the response the far end is a URL the MCP's owner
+ * chose (`external_endpoint`, reached through `safeFetch`) — so the number of
+ * bytes an isolate spends on one proxied call is picked by whoever registered
+ * the MCP, not by this service.
+ *
+ * This package deploys as a Cloudflare Worker
+ * (`packages/cloud/api/wrangler.toml`, `name = "eliza-cloud-api"`), where
+ * per-isolate memory is a hard platform limit. The handler's `catch` around
+ * each read is real, but it catches read *failures*; it cannot give back an
+ * allocation that has already completed.
+ *
+ * The reader below charges the budget BEFORE the bytes are retained, in the
+ * two stages this repository already uses in
+ * `@/lib/services/oauth/credential-broker.ts` (#23900),
+ * `api/v1/voice/stt/route.ts`, and `api/scripts/local-voice-runtime-identity.ts`:
+ *
+ *  1. a declared `content-length` over budget is refused without reading the
+ *     body at all;
+ *  2. otherwise the body is streamed, each chunk charged against the running
+ *     total before it is retained, and cut off the moment the total passes the
+ *     budget. Decoding is incremental, so the raw bytes are not held alongside
+ *     the finished string.
+ *
+ * Deliberately import-free so it can be driven on its own.
+ */
+
+/** The subset of `Request` / `Response` this reader needs. */
+export interface BudgetedBodySource {
+  readonly headers: Headers;
+  readonly body: ReadableStream<Uint8Array> | null;
+  text(): Promise<string>;
+}
+
+export type BudgetedText =
+  | { readonly ok: true; readonly text: string }
+  | { readonly ok: false; readonly bytes: number };
+
+/**
+ * The declared body length, or `null` when the header is absent or is not a
+ * plain decimal integer that survives `Number.isSafeInteger`. A header that
+ * cannot be trusted is not treated as a budget grant — such a body falls
+ * through to the streamed charge below.
+ */
+export function parseTrustworthyContentLength(headers: Headers): number | null {
+  const raw = headers.get("content-length");
+  if (!raw) return null;
+  if (!/^\d+$/.test(raw.trim())) return null;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function cancelBestEffort(
+  target: { cancel: () => Promise<unknown> },
+  label: string,
+  onCancelFailure?: (label: string, error: unknown) => void,
+): void {
+  const report = (error: unknown) => onCancelFailure?.(label, error);
+  try {
+    target.cancel().catch(report);
+  } catch (error) {
+    // error-policy:J6 best-effort teardown for a body already rejected.
+    report(error);
+  }
+}
+
+/**
+ * Reads `source`'s body as text, refusing it as soon as `maxBytes` is exceeded.
+ *
+ * On refusal `bytes` is the size the refusal was made on: the declared
+ * `content-length` when the pre-check fired, otherwise the running total at the
+ * chunk that blew the budget (a lower bound on the real size — the rest is
+ * never read).
+ */
+export async function readBodyTextWithinBudget(
+  source: BudgetedBodySource,
+  maxBytes: number,
+  onCancelFailure?: (label: string, error: unknown) => void,
+): Promise<BudgetedText> {
+  const declaredLength = parseTrustworthyContentLength(source.headers);
+  if (declaredLength !== null && declaredLength > maxBytes) {
+    if (source.body) {
+      cancelBestEffort(source.body, "content-length-precheck", onCancelFailure);
+    }
+    return { ok: false, bytes: declaredLength };
+  }
+
+  if (!source.body) {
+    const text = await source.text();
+    return { ok: true, text };
+  }
+
+  const reader = source.body.getReader();
+  const decoder = new TextDecoder("utf-8");
+  const parts: string[] = [];
+  let received = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    received += value.byteLength;
+    if (received > maxBytes) {
+      cancelBestEffort(reader, "streamed-budget", onCancelFailure);
+      return { ok: false, bytes: received };
+    }
+    parts.push(decoder.decode(value, { stream: true }));
+  }
+  parts.push(decoder.decode());
+
+  return { ok: true, text: parts.join("") };
+}

--- a/packages/cloud/api/mcp/proxy/[mcpId]/proxy-body-budget.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/proxy-body-budget.ts
@@ -23,8 +23,9 @@
  *     body at all;
  *  2. otherwise the body is streamed, each chunk charged against the running
  *     total before it is retained, and cut off the moment the total passes the
- *     budget. Decoding is incremental, so the raw bytes are not held alongside
- *     the finished string.
+ *     budget. Bytes are copied into one fixed-size slab and decoded once, so
+ *     retained chunk objects cannot multiply isolate memory independently of
+ *     the byte budget.
  *
  * Deliberately import-free so it can be driven on its own.
  */
@@ -38,7 +39,18 @@ export interface BudgetedBodySource {
 
 export type BudgetedText =
   | { readonly ok: true; readonly text: string }
-  | { readonly ok: false; readonly bytes: number };
+  | {
+      readonly ok: false;
+      readonly bytes: number;
+      readonly reason: "byte-budget" | "fragmentation-budget";
+    };
+
+/**
+ * Limit pull/decoder churn independently from payload bytes. A standard
+ * transport should coalesce far below this count; rejecting a deliberately
+ * one-byte-at-a-time stream prevents millions of isolate allocations/callbacks.
+ */
+const MAX_BODY_STREAM_CHUNKS = 8_192;
 
 /**
  * The declared body length, or `null` when the header is absent or is not a
@@ -73,8 +85,8 @@ function cancelBestEffort(
  *
  * On refusal `bytes` is the size the refusal was made on: the declared
  * `content-length` when the pre-check fired, otherwise the running total at the
- * chunk that blew the budget (a lower bound on the real size — the rest is
- * never read).
+ * chunk that exceeded the byte or fragmentation budget (a lower bound on the
+ * real size — the rest is never read).
  */
 export async function readBodyTextWithinBudget(
   source: BudgetedBodySource,
@@ -86,7 +98,7 @@ export async function readBodyTextWithinBudget(
     if (source.body) {
       cancelBestEffort(source.body, "content-length-precheck", onCancelFailure);
     }
-    return { ok: false, bytes: declaredLength };
+    return { ok: false, bytes: declaredLength, reason: "byte-budget" };
   }
 
   if (!source.body) {
@@ -96,21 +108,40 @@ export async function readBodyTextWithinBudget(
 
   const reader = source.body.getReader();
   const decoder = new TextDecoder("utf-8");
-  const parts: string[] = [];
+  const retained = new Uint8Array(maxBytes);
   let received = 0;
+  let chunkCount = 0;
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    if (!value) continue;
-    received += value.byteLength;
-    if (received > maxBytes) {
-      cancelBestEffort(reader, "streamed-budget", onCancelFailure);
-      return { ok: false, bytes: received };
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value || value.byteLength === 0) continue;
+      chunkCount += 1;
+      received += value.byteLength;
+      if (received > maxBytes) {
+        cancelBestEffort(reader, "streamed-budget", onCancelFailure);
+        return { ok: false, bytes: received, reason: "byte-budget" };
+      }
+      if (chunkCount > MAX_BODY_STREAM_CHUNKS) {
+        cancelBestEffort(reader, "streamed-fragmentation", onCancelFailure);
+        return {
+          ok: false,
+          bytes: received,
+          reason: "fragmentation-budget",
+        };
+      }
+      retained.set(value, received - value.byteLength);
     }
-    parts.push(decoder.decode(value, { stream: true }));
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch (error) {
+      // error-policy:J6 The body read has already reached a terminal result;
+      // releasing the reader is best-effort transport teardown.
+      onCancelFailure?.("reader-release", error);
+    }
   }
-  parts.push(decoder.decode());
 
-  return { ok: true, text: parts.join("") };
+  return { ok: true, text: decoder.decode(retained.subarray(0, received)) };
 }

--- a/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
@@ -5,6 +5,11 @@
  *
  * POST /api/mcp/proxy/[mcpId] - Proxy MCP request
  * GET /api/mcp/proxy/[mcpId] - Get MCP info
+ *
+ * After the precharge succeeds, the owned hop deadline starts before endpoint
+ * resolution and inbound body parsing. Untrusted waits (SSRF DNS, inbound JSON
+ * reads, outbound fetch, response reads) are raced against that signal so a
+ * never-settling lookup or caller abort still refunds as a typed 504.
  */
 
 import {
@@ -29,6 +34,9 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 import {
   createMcpProxyHopDeadline,
   isMcpProxyHopDeadline,
+  MCP_PROXY_HOP_TIMEOUT_MS,
+  McpProxyHopDeadlineError,
+  raceWithAbort,
   readBodyTextWithinBudget,
 } from "./proxy-body-budget";
 
@@ -157,15 +165,24 @@ export class McpProxyBodyTooLargeError extends Error {
 export async function parseJsonBody(
   request: Request,
   maxBytes: number = MAX_PROXY_REQUEST_BODY_BYTES,
+  options?: { signal?: AbortSignal },
 ): Promise<McpProxyJson> {
   const contentType = request.headers.get("content-type");
   if (!contentType?.includes("application/json")) {
     return {};
   }
+  const signal = options?.signal ?? request.signal;
   // Charge the budget before the bytes are retained: reading the whole body and
   // measuring it afterwards spends the memory the measurement exists to refuse.
-  const budgeted = await readBodyTextWithinBudget(request, maxBytes);
+  const budgeted = await readBodyTextWithinBudget(request, maxBytes, {
+    signal,
+  });
   if (!budgeted.ok) {
+    if (budgeted.reason === "deadline") {
+      throw signal.reason instanceof Error
+        ? signal.reason
+        : new McpProxyHopDeadlineError(MCP_PROXY_HOP_TIMEOUT_MS);
+    }
     throw new McpProxyBodyTooLargeError(budgeted.bytes, maxBytes);
   }
   const text = budgeted.text;
@@ -379,92 +396,9 @@ app.post("/", async (c) => {
       });
   };
 
-  let targetUrl: string;
-  // External (user-configured) endpoints are fetched through safeFetch below,
-  // which re-validates AND pins the resolved IP for the actual request (closing
-  // the validate-then-fetch TOCTOU / DNS-rebind window on the Node path).
-  // Container endpoints resolve to a platform-internal load-balancer URL on the
-  // private tailnet, which safeFetch would (correctly) reject as a private IP —
-  // so those stay on the platform fetch.
-  let isExternalEndpoint = false;
-
-  if (mcp.endpoint_type === "external" && mcp.external_endpoint) {
-    let parsed: URL;
-    try {
-      parsed = await assertSafeOutboundUrl(mcp.external_endpoint);
-    } catch (error) {
-      logger.warn("[MCP Proxy] Blocked unsafe external endpoint", {
-        mcpId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      await refundPrecharge("unsafe_endpoint");
-      return c.json({ error: "Unsafe external MCP endpoint" }, 400);
-    }
-    targetUrl = parsed.toString();
-    isExternalEndpoint = true;
-  } else if (mcp.endpoint_type === "container" && mcp.container_id) {
-    let container: Awaited<ReturnType<typeof containersService.getById>>;
-    try {
-      container = await containersService.getById(
-        mcp.container_id,
-        mcp.organization_id,
-      );
-    } catch (error) {
-      logger.error("[MCP Proxy] Failed to resolve MCP container", {
-        mcpId,
-        containerId: mcp.container_id,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      await refundPrecharge("container_lookup_failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return c.json({ error: "MCP container not available" }, 502);
-    }
-    if (!container?.load_balancer_url) {
-      await refundPrecharge("container_unavailable");
-      return c.json({ error: "MCP container not available" }, 503);
-    }
-    targetUrl = `${container.load_balancer_url}${mcp.endpoint_path || "/mcp"}`;
-  } else {
-    await refundPrecharge("endpoint_misconfigured");
-    return c.json({ error: "MCP endpoint not configured" }, 500);
-  }
-
-  let proxyBody: McpProxyJson;
-  try {
-    proxyBody = await parseJsonBody(c.req.raw);
-  } catch (error) {
-    if (error instanceof McpProxyBodyTooLargeError) {
-      logger.warn("[MCP Proxy] Request body exceeded the proxy byte budget", {
-        mcpId,
-        bytes: error.bytes,
-        maxBytes: error.maxBytes,
-      });
-      await refundPrecharge("request_body_too_large", {
-        maxBytes: error.maxBytes,
-      });
-      return c.json({ error: "MCP request body is too large" }, 413);
-    }
-    logger.warn("[MCP Proxy] Invalid JSON request body", {
-      mcpId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    await refundPrecharge("invalid_json");
-    return c.json({ error: "Invalid MCP request body" }, 400);
-  }
-  const toolName = toolNameFromRpcBody(proxyBody);
-
-  const proxyRequestInit: RequestInit = {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...(c.req.header("accept") && {
-        Accept: c.req.header("accept"),
-      }),
-    },
-    body: JSON.stringify(proxyBody),
-  };
-
+  // Own the wall-clock bound before every untrusted post-precharge wait.
+  // Creating the timer after endpoint DNS or inbound parsing left those
+  // awaits able to retain the Worker request and the debit indefinitely.
   const hop = createMcpProxyHopDeadline(c.req.raw.signal);
   const refundDeadline = async (): Promise<Response> => {
     logger.warn("[MCP Proxy] MCP hop exceeded the proxy deadline", {
@@ -476,34 +410,149 @@ app.post("/", async (c) => {
     });
     return c.json({ error: "MCP endpoint timed out" }, 504);
   };
+  const hopAborted = (error?: unknown): boolean =>
+    isMcpProxyHopDeadline(hop.signal, error) || hop.signal.aborted;
 
-  let mcpResponse: Response;
+  let targetUrl: string;
+  // External (user-configured) endpoints are fetched through safeFetch below,
+  // which re-validates AND pins the resolved IP for the actual request (closing
+  // the validate-then-fetch TOCTOU / DNS-rebind window on the Node path).
+  // Container endpoints resolve to a platform-internal load-balancer URL on the
+  // private tailnet, which safeFetch would (correctly) reject as a private IP —
+  // so those stay on the platform fetch.
+  let isExternalEndpoint = false;
+
   try {
+    if (mcp.endpoint_type === "external" && mcp.external_endpoint) {
+      let parsed: URL;
+      try {
+        parsed = await raceWithAbort(
+          assertSafeOutboundUrl(mcp.external_endpoint, { signal: hop.signal }),
+          hop.signal,
+        );
+      } catch (error) {
+        // error-policy:J1 hop abort maps to a 504 refund; other failures stay 400.
+        if (hopAborted(error)) {
+          return await refundDeadline();
+        }
+        logger.warn("[MCP Proxy] Blocked unsafe external endpoint", {
+          mcpId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        await refundPrecharge("unsafe_endpoint");
+        return c.json({ error: "Unsafe external MCP endpoint" }, 400);
+      }
+      targetUrl = parsed.toString();
+      isExternalEndpoint = true;
+    } else if (mcp.endpoint_type === "container" && mcp.container_id) {
+      let container: Awaited<ReturnType<typeof containersService.getById>>;
+      try {
+        container = await raceWithAbort(
+          containersService.getById(mcp.container_id, mcp.organization_id),
+          hop.signal,
+        );
+      } catch (error) {
+        // error-policy:J1 hop abort maps to a 504 refund; other failures stay 502.
+        if (hopAborted(error)) {
+          return await refundDeadline();
+        }
+        logger.error("[MCP Proxy] Failed to resolve MCP container", {
+          mcpId,
+          containerId: mcp.container_id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        await refundPrecharge("container_lookup_failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return c.json({ error: "MCP container not available" }, 502);
+      }
+      if (!container?.load_balancer_url) {
+        await refundPrecharge("container_unavailable");
+        return c.json({ error: "MCP container not available" }, 503);
+      }
+      targetUrl = `${container.load_balancer_url}${mcp.endpoint_path || "/mcp"}`;
+    } else {
+      await refundPrecharge("endpoint_misconfigured");
+      return c.json({ error: "MCP endpoint not configured" }, 500);
+    }
+
+    let proxyBody: McpProxyJson;
+    try {
+      proxyBody = await raceWithAbort(
+        parseJsonBody(c.req.raw, MAX_PROXY_REQUEST_BODY_BYTES, {
+          signal: hop.signal,
+        }),
+        hop.signal,
+      );
+    } catch (error) {
+      // error-policy:J1 hop abort maps to a 504 refund; overflow stays 413.
+      if (hopAborted(error)) {
+        return await refundDeadline();
+      }
+      if (error instanceof McpProxyBodyTooLargeError) {
+        logger.warn("[MCP Proxy] Request body exceeded the proxy byte budget", {
+          mcpId,
+          bytes: error.bytes,
+          maxBytes: error.maxBytes,
+        });
+        await refundPrecharge("request_body_too_large", {
+          maxBytes: error.maxBytes,
+        });
+        return c.json({ error: "MCP request body is too large" }, 413);
+      }
+      logger.warn("[MCP Proxy] Invalid JSON request body", {
+        mcpId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      await refundPrecharge("invalid_json");
+      return c.json({ error: "Invalid MCP request body" }, 400);
+    }
+    const toolName = toolNameFromRpcBody(proxyBody);
+
+    const proxyRequestInit: RequestInit = {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(c.req.header("accept") && {
+          Accept: c.req.header("accept"),
+        }),
+      },
+      body: JSON.stringify(proxyBody),
+    };
+
+    let mcpResponse: Response;
     try {
       if (isExternalEndpoint) {
         // safeFetch validates + IP-pins the request and (redirect: "error")
         // rejects any redirect — the single SSRF guard for outbound-from-user
-        // fetches, replacing the prior validate-then-raw-fetch pair.
-        mcpResponse = await safeFetch(targetUrl, {
-          ...proxyRequestInit,
-          redirect: "error",
-          signal: hop.signal,
-        });
+        // fetches, replacing the prior validate-then-raw-fetch pair. Race the
+        // await so a DNS lookup that never settles still hits the 504 refund.
+        mcpResponse = await raceWithAbort(
+          safeFetch(targetUrl, {
+            ...proxyRequestInit,
+            redirect: "error",
+            signal: hop.signal,
+          }),
+          hop.signal,
+        );
       } else {
         // Platform-internal container LB URL (private tailnet) — not a user-input
         // SSRF surface; keep the platform fetch with the manual redirect block.
-        mcpResponse = await fetch(targetUrl, {
-          ...proxyRequestInit,
-          redirect: "manual",
-          signal: hop.signal,
-        });
+        mcpResponse = await raceWithAbort(
+          fetch(targetUrl, {
+            ...proxyRequestInit,
+            redirect: "manual",
+            signal: hop.signal,
+          }),
+          hop.signal,
+        );
         if (mcpResponse.status >= 300 && mcpResponse.status < 400) {
           throw new Error("External MCP redirects are not allowed");
         }
       }
     } catch (error) {
       // error-policy:J1 hop abort maps to a 504 refund; other failures stay 502.
-      if (isMcpProxyHopDeadline(hop.signal, error) || hop.signal.aborted) {
+      if (hopAborted(error)) {
         return await refundDeadline();
       }
       logger.error("[MCP Proxy] Failed to reach MCP endpoint", {
@@ -555,7 +604,7 @@ app.post("/", async (c) => {
       responseBody = budgeted.text;
     } catch (error) {
       // error-policy:J1 hop abort maps to a 504 refund; other failures stay 502.
-      if (isMcpProxyHopDeadline(hop.signal, error) || hop.signal.aborted) {
+      if (hopAborted(error)) {
         return await refundDeadline();
       }
       logger.error("[MCP Proxy] Failed to read MCP response body", {

--- a/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
@@ -26,6 +26,7 @@ import { creditsService } from "@/lib/services/credits";
 import { userMcpsService } from "@/lib/services/user-mcps";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { readBodyTextWithinBudget } from "./proxy-body-budget";
 
 /** JSON subset for proxied MCP-RPC bodies (avoid `unknown`; values are forwarded as JSON). */
 export type McpProxyJson =
@@ -123,12 +124,47 @@ export function resolveMcpProxyView(params: {
   return { allowed: isOwner || params.mcpIsPublic, isOwner };
 }
 
-export async function parseJsonBody(request: Request): Promise<McpProxyJson> {
+/**
+ * Byte budgets for the two bodies this route buffers into the isolate.
+ *
+ * The numbers are not new: `@/lib/services/oauth/credential-broker.ts` — the
+ * platform's other "proxy one call to a caller-supplied host" service — caps
+ * the request body it accepts at 1 MB and derives its response budget from that
+ * cap so the two halves cannot drift (#23900). Same shape of hop, same numbers,
+ * derived the same way rather than written as a second pair of literals.
+ */
+const MAX_PROXY_REQUEST_BODY_BYTES = 1_000_000;
+const PROXY_RESPONSE_BODY_BUDGET_MULTIPLIER = 5;
+const MAX_PROXY_RESPONSE_BODY_BYTES =
+  MAX_PROXY_REQUEST_BODY_BYTES * PROXY_RESPONSE_BODY_BUDGET_MULTIPLIER;
+
+/** Raised by `parseJsonBody` when the caller's body is over budget. */
+export class McpProxyBodyTooLargeError extends Error {
+  readonly bytes: number;
+  readonly maxBytes: number;
+  constructor(bytes: number, maxBytes: number) {
+    super(`MCP proxy body exceeds the ${maxBytes}-byte limit (${bytes})`);
+    this.name = "McpProxyBodyTooLargeError";
+    this.bytes = bytes;
+    this.maxBytes = maxBytes;
+  }
+}
+
+export async function parseJsonBody(
+  request: Request,
+  maxBytes: number = MAX_PROXY_REQUEST_BODY_BYTES,
+): Promise<McpProxyJson> {
   const contentType = request.headers.get("content-type");
   if (!contentType?.includes("application/json")) {
     return {};
   }
-  const text = await request.text();
+  // Charge the budget before the bytes are retained: reading the whole body and
+  // measuring it afterwards spends the memory the measurement exists to refuse.
+  const budgeted = await readBodyTextWithinBudget(request, maxBytes);
+  if (!budgeted.ok) {
+    throw new McpProxyBodyTooLargeError(budgeted.bytes, maxBytes);
+  }
+  const text = budgeted.text;
   if (!text.trim()) {
     return {};
   }
@@ -394,6 +430,17 @@ app.post("/", async (c) => {
   try {
     proxyBody = await parseJsonBody(c.req.raw);
   } catch (error) {
+    if (error instanceof McpProxyBodyTooLargeError) {
+      logger.warn("[MCP Proxy] Request body exceeded the proxy byte budget", {
+        mcpId,
+        bytes: error.bytes,
+        maxBytes: error.maxBytes,
+      });
+      await refundPrecharge("request_body_too_large", {
+        maxBytes: error.maxBytes,
+      });
+      return c.json({ error: "MCP request body is too large" }, 413);
+    }
     logger.warn("[MCP Proxy] Invalid JSON request body", {
       mcpId,
       error: error instanceof Error ? error.message : String(error),
@@ -447,7 +494,36 @@ app.post("/", async (c) => {
 
   let responseBody: string;
   try {
-    responseBody = await mcpResponse.text();
+    // The far end of this read is a URL the MCP's owner chose. Charge the
+    // budget before the bytes are retained — a catch below can report a read
+    // failure but cannot give back memory the isolate has already spent.
+    const budgeted = await readBodyTextWithinBudget(
+      mcpResponse,
+      MAX_PROXY_RESPONSE_BODY_BYTES,
+      (label, cancelError) => {
+        // error-policy:J6 best-effort teardown for a body already rejected.
+        logger.warn("[MCP Proxy] Failed to cancel oversized MCP response", {
+          mcpId,
+          label,
+          errorType:
+            cancelError instanceof Error ? cancelError.name : "unknown",
+        });
+      },
+    );
+    if (!budgeted.ok) {
+      logger.warn("[MCP Proxy] MCP response exceeded the proxy byte budget", {
+        mcpId,
+        status: mcpResponse.status,
+        receivedBytes: budgeted.bytes,
+        maxBytes: MAX_PROXY_RESPONSE_BODY_BYTES,
+      });
+      await refundPrecharge("mcp_response_too_large", {
+        status: mcpResponse.status,
+        maxBytes: MAX_PROXY_RESPONSE_BODY_BYTES,
+      });
+      return c.json({ error: "MCP response is too large" }, 502);
+    }
+    responseBody = budgeted.text;
   } catch (error) {
     logger.error("[MCP Proxy] Failed to read MCP response body", {
       mcpId,

--- a/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
+++ b/packages/cloud/api/mcp/proxy/[mcpId]/route.ts
@@ -26,7 +26,11 @@ import { creditsService } from "@/lib/services/credits";
 import { userMcpsService } from "@/lib/services/user-mcps";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
-import { readBodyTextWithinBudget } from "./proxy-body-budget";
+import {
+  createMcpProxyHopDeadline,
+  isMcpProxyHopDeadline,
+  readBodyTextWithinBudget,
+} from "./proxy-body-budget";
 
 /** JSON subset for proxied MCP-RPC bodies (avoid `unknown`; values are forwarded as JSON). */
 export type McpProxyJson =
@@ -461,144 +465,178 @@ app.post("/", async (c) => {
     body: JSON.stringify(proxyBody),
   };
 
+  const hop = createMcpProxyHopDeadline(c.req.raw.signal);
+  const refundDeadline = async (): Promise<Response> => {
+    logger.warn("[MCP Proxy] MCP hop exceeded the proxy deadline", {
+      mcpId,
+      timeoutMs: hop.timeoutMs,
+    });
+    await refundPrecharge("upstream_deadline_exceeded", {
+      timeoutMs: hop.timeoutMs,
+    });
+    return c.json({ error: "MCP endpoint timed out" }, 504);
+  };
+
   let mcpResponse: Response;
   try {
-    if (isExternalEndpoint) {
-      // safeFetch validates + IP-pins the request and (redirect: "error")
-      // rejects any redirect — the single SSRF guard for outbound-from-user
-      // fetches, replacing the prior validate-then-raw-fetch pair.
-      mcpResponse = await safeFetch(targetUrl, {
-        ...proxyRequestInit,
-        redirect: "error",
-      });
-    } else {
-      // Platform-internal container LB URL (private tailnet) — not a user-input
-      // SSRF surface; keep the platform fetch with the manual redirect block.
-      mcpResponse = await fetch(targetUrl, {
-        ...proxyRequestInit,
-        redirect: "manual",
-      });
-      if (mcpResponse.status >= 300 && mcpResponse.status < 400) {
-        throw new Error("External MCP redirects are not allowed");
-      }
-    }
-  } catch (error) {
-    logger.error("[MCP Proxy] Failed to reach MCP endpoint", {
-      mcpId,
-      targetUrl,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    await refundPrecharge("upstream_unreachable");
-    return c.json({ error: "Failed to reach MCP endpoint" }, 502);
-  }
-
-  let responseBody: string;
-  try {
-    // The far end of this read is a URL the MCP's owner chose. Charge the
-    // budget before the bytes are retained — a catch below can report a read
-    // failure but cannot give back memory the isolate has already spent.
-    const budgeted = await readBodyTextWithinBudget(
-      mcpResponse,
-      MAX_PROXY_RESPONSE_BODY_BYTES,
-      (label, cancelError) => {
-        // error-policy:J6 best-effort teardown for a body already rejected.
-        logger.warn("[MCP Proxy] Failed to cancel oversized MCP response", {
-          mcpId,
-          label,
-          errorType:
-            cancelError instanceof Error ? cancelError.name : "unknown",
+    try {
+      if (isExternalEndpoint) {
+        // safeFetch validates + IP-pins the request and (redirect: "error")
+        // rejects any redirect — the single SSRF guard for outbound-from-user
+        // fetches, replacing the prior validate-then-raw-fetch pair.
+        mcpResponse = await safeFetch(targetUrl, {
+          ...proxyRequestInit,
+          redirect: "error",
+          signal: hop.signal,
         });
-      },
-    );
-    if (!budgeted.ok) {
-      logger.warn("[MCP Proxy] MCP response exceeded the proxy byte budget", {
+      } else {
+        // Platform-internal container LB URL (private tailnet) — not a user-input
+        // SSRF surface; keep the platform fetch with the manual redirect block.
+        mcpResponse = await fetch(targetUrl, {
+          ...proxyRequestInit,
+          redirect: "manual",
+          signal: hop.signal,
+        });
+        if (mcpResponse.status >= 300 && mcpResponse.status < 400) {
+          throw new Error("External MCP redirects are not allowed");
+        }
+      }
+    } catch (error) {
+      // error-policy:J1 hop abort maps to a 504 refund; other failures stay 502.
+      if (isMcpProxyHopDeadline(hop.signal, error) || hop.signal.aborted) {
+        return await refundDeadline();
+      }
+      logger.error("[MCP Proxy] Failed to reach MCP endpoint", {
+        mcpId,
+        targetUrl,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      await refundPrecharge("upstream_unreachable");
+      return c.json({ error: "Failed to reach MCP endpoint" }, 502);
+    }
+
+    let responseBody: string;
+    try {
+      // The far end of this read is a URL the MCP's owner chose. Charge the
+      // budget before the bytes are retained — a catch below can report a read
+      // failure but cannot give back memory the isolate has already spent.
+      const budgeted = await readBodyTextWithinBudget(
+        mcpResponse,
+        MAX_PROXY_RESPONSE_BODY_BYTES,
+        {
+          signal: hop.signal,
+          onCancelFailure: (label, cancelError) => {
+            // error-policy:J6 best-effort teardown for a body already rejected.
+            logger.warn("[MCP Proxy] Failed to cancel oversized MCP response", {
+              mcpId,
+              label,
+              errorType:
+                cancelError instanceof Error ? cancelError.name : "unknown",
+            });
+          },
+        },
+      );
+      if (!budgeted.ok) {
+        if (budgeted.reason === "deadline") {
+          return await refundDeadline();
+        }
+        logger.warn("[MCP Proxy] MCP response exceeded the proxy byte budget", {
+          mcpId,
+          status: mcpResponse.status,
+          receivedBytes: budgeted.bytes,
+          maxBytes: MAX_PROXY_RESPONSE_BODY_BYTES,
+        });
+        await refundPrecharge("mcp_response_too_large", {
+          status: mcpResponse.status,
+          maxBytes: MAX_PROXY_RESPONSE_BODY_BYTES,
+        });
+        return c.json({ error: "MCP response is too large" }, 502);
+      }
+      responseBody = budgeted.text;
+    } catch (error) {
+      // error-policy:J1 hop abort maps to a 504 refund; other failures stay 502.
+      if (isMcpProxyHopDeadline(hop.signal, error) || hop.signal.aborted) {
+        return await refundDeadline();
+      }
+      logger.error("[MCP Proxy] Failed to read MCP response body", {
         mcpId,
         status: mcpResponse.status,
-        receivedBytes: budgeted.bytes,
-        maxBytes: MAX_PROXY_RESPONSE_BODY_BYTES,
+        error: error instanceof Error ? error.message : String(error),
       });
-      await refundPrecharge("mcp_response_too_large", {
+      await refundPrecharge("mcp_response_read_failed", {
         status: mcpResponse.status,
-        maxBytes: MAX_PROXY_RESPONSE_BODY_BYTES,
+        error: error instanceof Error ? error.message : String(error),
       });
-      return c.json({ error: "MCP response is too large" }, 502);
+      return c.json({ error: "Failed to read MCP response" }, 502);
     }
-    responseBody = budgeted.text;
-  } catch (error) {
-    logger.error("[MCP Proxy] Failed to read MCP response body", {
-      mcpId,
-      status: mcpResponse.status,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    await refundPrecharge("mcp_response_read_failed", {
-      status: mcpResponse.status,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return c.json({ error: "Failed to read MCP response" }, 502);
-  }
 
-  // A 2xx transport does NOT mean the tool call succeeded: MCP speaks JSON-RPC
-  // 2.0, so a failed call is delivered as HTTP 200 with an `{ error: {...} }`
-  // envelope. Billing on `mcpResponse.ok` alone charged the caller for a call
-  // the MCP never completed (#11637 at the HTTP layer, still open at the RPC
-  // layer). Refund on an explicit JSON-RPC error instead of success-shaping it.
-  const rpcErrored = mcpResponse.ok && isJsonRpcErrorResponse(responseBody);
-  if (mcpResponse.ok && !rpcErrored) {
-    await userMcpsService
-      .recordUsageWithoutDeduction({
-        mcpId: mcp.id,
-        organizationId: user.organization_id,
-        userId: user.id,
-        toolName,
-        creditsCharged: creditsRequired,
-        affiliateFeeCredits,
-        platformFeeCredits,
-        chargeReceipt,
-        affiliateOwnerId,
-        affiliateCodeId,
-        metadata: {
-          responseTime: Date.now() - startTime,
-          success: true,
-          preChargeTransactionId: preChargeResult.transaction?.id,
-          totalCreditsCharged: totalCreditsRequired,
+    // A 2xx transport does NOT mean the tool call succeeded: MCP speaks JSON-RPC
+    // 2.0, so a failed call is delivered as HTTP 200 with an `{ error: {...} }`
+    // envelope. Billing on `mcpResponse.ok` alone charged the caller for a call
+    // the MCP never completed (#11637 at the HTTP layer, still open at the RPC
+    // layer). Refund on an explicit JSON-RPC error instead of success-shaping it.
+    const rpcErrored = mcpResponse.ok && isJsonRpcErrorResponse(responseBody);
+    if (mcpResponse.ok && !rpcErrored) {
+      await userMcpsService
+        .recordUsageWithoutDeduction({
+          mcpId: mcp.id,
+          organizationId: user.organization_id,
+          userId: user.id,
+          toolName,
+          creditsCharged: creditsRequired,
           affiliateFeeCredits,
           platformFeeCredits,
-        },
-      })
-      // error-policy:J7 usage recording is diagnostic and runs after the proxied
-      // call already succeeded and settled; a failed write is logged, not fatal.
-      .catch((usageError: Error | string) => {
-        logger.error("[MCP Proxy] Failed to record usage", {
-          mcpId,
-          error:
-            typeof usageError === "string" ? usageError : usageError.message,
+          chargeReceipt,
+          affiliateOwnerId,
+          affiliateCodeId,
+          metadata: {
+            responseTime: Date.now() - startTime,
+            success: true,
+            preChargeTransactionId: preChargeResult.transaction?.id,
+            totalCreditsCharged: totalCreditsRequired,
+            affiliateFeeCredits,
+            platformFeeCredits,
+          },
+        })
+        // error-policy:J7 usage recording is diagnostic and runs after the proxied
+        // call already succeeded and settled; a failed write is logged, not fatal.
+        .catch((usageError: Error | string) => {
+          logger.error("[MCP Proxy] Failed to record usage", {
+            mcpId,
+            error:
+              typeof usageError === "string" ? usageError : usageError.message,
+          });
         });
-      });
-  } else if (rpcErrored) {
-    // Protocol-level failure over a 2xx transport: refund and do not bill. The
-    // caller still receives the MCP's error envelope verbatim below.
-    logger.warn(
-      "[MCP Proxy] MCP returned a JSON-RPC error over 2xx; refunding",
-      {
-        mcpId,
+    } else if (rpcErrored) {
+      // Protocol-level failure over a 2xx transport: refund and do not bill. The
+      // caller still receives the MCP's error envelope verbatim below.
+      logger.warn(
+        "[MCP Proxy] MCP returned a JSON-RPC error over 2xx; refunding",
+        {
+          mcpId,
+          status: mcpResponse.status,
+          toolName,
+        },
+      );
+      await refundPrecharge("mcp_jsonrpc_error", {
         status: mcpResponse.status,
-        toolName,
-      },
-    );
-    await refundPrecharge("mcp_jsonrpc_error", { status: mcpResponse.status });
-  } else {
-    await refundPrecharge("mcp_call_failed", { status: mcpResponse.status });
-  }
+      });
+    } else {
+      await refundPrecharge("mcp_call_failed", { status: mcpResponse.status });
+    }
 
-  return new Response(responseBody, {
-    status: mcpResponse.status,
-    headers: {
-      "Content-Type":
-        mcpResponse.headers.get("content-type") || "application/json",
-      "X-MCP-Id": mcp.id,
-      "X-MCP-Name": mcp.name,
-    },
-  });
+    return new Response(responseBody, {
+      status: mcpResponse.status,
+      headers: {
+        "Content-Type":
+          mcpResponse.headers.get("content-type") || "application/json",
+        "X-MCP-Id": mcp.id,
+        "X-MCP-Name": mcp.name,
+      },
+    });
+  } finally {
+    hop.clear();
+  }
 });
 
 app.options("/", () => {

--- a/packages/cloud/shared/src/lib/security/outbound-url.test.ts
+++ b/packages/cloud/shared/src/lib/security/outbound-url.test.ts
@@ -140,6 +140,26 @@ describe("outbound URL SSRF validation", () => {
       "Unable to resolve endpoint hostname",
     );
   });
+
+  test("never-settling DNS lookup returns when the caller signal aborts", async () => {
+    lookupMock.mockReturnValue(
+      new Promise(() => {
+        /* never settles */
+      }),
+    );
+    const controller = new AbortController();
+    const reason = new DOMException("Aborted", "AbortError");
+    const pending = assertSafeOutboundUrl("https://example.com/", {
+      signal: controller.signal,
+    });
+    queueMicrotask(() => {
+      controller.abort(reason);
+    });
+    const hung = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error("assertSafeOutboundUrl ignored abort")), 80);
+    });
+    await expect(Promise.race([pending, hung])).rejects.toBe(reason);
+  });
 });
 
 describe("isSafeRegistrationUrl", () => {

--- a/packages/cloud/shared/src/lib/security/outbound-url.ts
+++ b/packages/cloud/shared/src/lib/security/outbound-url.ts
@@ -2,6 +2,9 @@
  * SSRF guard for cloud-shared outbound fetches and registration-time URL
  * screening: rejects credentials, localhost, and private/reserved IP literals,
  * and resolves+pins DNS at fetch time so rebinding cannot bypass the check.
+ * Hostname lookups ignore AbortSignal, so the DNS await is raced against the
+ * caller's signal and must return on deadline or cancellation rather than
+ * waiting for `lookup()` to settle.
  */
 import type { LookupAddress } from "node:dns";
 import { lookup } from "node:dns/promises";
@@ -184,6 +187,40 @@ function isForbiddenIpv6(address: string): boolean {
   return false;
 }
 
+/** Abort control for fetch-time DNS. `lookup()` itself cannot be cancelled. */
+export interface OutboundUrlResolveOptions {
+  readonly signal?: AbortSignal;
+}
+
+function abortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error ? signal.reason : new DOMException("Aborted", "AbortError");
+}
+
+/**
+ * `node:dns` lookup cannot be cancelled. Race the await so a never-settling
+ * resolution still returns when the caller or hop deadline aborts.
+ */
+function raceWithAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(abortReason(signal));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      reject(abortReason(signal));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
 export function isForbiddenIpAddress(address: string): boolean {
   const normalized = normalizeHostname(address);
   const family = isIP(normalized);
@@ -270,7 +307,10 @@ export function isSafeRegistrationUrl(value: string | null | undefined): boolean
  * set if any record points at a private/reserved range. Returns every resolved
  * address so callers can both validate and pin a single connection target.
  */
-async function resolveValidatedAddresses(hostname: string): Promise<LookupAddress[]> {
+async function resolveValidatedAddresses(
+  hostname: string,
+  signal?: AbortSignal,
+): Promise<LookupAddress[]> {
   const literalFamily = isIP(hostname);
   if (literalFamily) {
     // IP literals are already screened by validateUrlSyntax (isForbiddenIpAddress),
@@ -280,9 +320,12 @@ async function resolveValidatedAddresses(hostname: string): Promise<LookupAddres
 
   let records: LookupAddress[];
   try {
-    records = await lookup(hostname, { all: true, verbatim: true });
-  } catch {
-    throw new Error("Unable to resolve endpoint hostname");
+    records = await raceWithAbort(lookup(hostname, { all: true, verbatim: true }), signal);
+  } catch (error) {
+    if (signal?.aborted) {
+      throw abortReason(signal);
+    }
+    throw new Error("Unable to resolve endpoint hostname", { cause: error });
   }
 
   if (!records.length) {
@@ -303,13 +346,18 @@ async function resolveValidatedAddresses(hostname: string): Promise<LookupAddres
  * For hostnames, DNS is resolved at call time so rebinding to private ranges
  * cannot bypass creation-time validation.
  */
-export async function assertSafeOutboundUrl(rawUrl: string): Promise<URL> {
+export async function assertSafeOutboundUrl(
+  rawUrl: string,
+  options?: OutboundUrlResolveOptions,
+): Promise<URL> {
+  options?.signal?.throwIfAborted();
   const parsed = validateUrlSyntax(rawUrl);
   const hostname = normalizeHostname(parsed.hostname);
 
   if (!isIP(hostname)) {
-    await resolveValidatedAddresses(hostname);
+    await resolveValidatedAddresses(hostname, options?.signal);
   }
+  options?.signal?.throwIfAborted();
 
   return parsed;
 }
@@ -324,10 +372,13 @@ export async function assertSafeOutboundUrl(rawUrl: string): Promise<URL> {
  */
 export async function resolveSafeOutboundTarget(
   rawUrl: string,
+  options?: OutboundUrlResolveOptions,
 ): Promise<{ url: URL; address: string; family: number }> {
+  options?.signal?.throwIfAborted();
   const parsed = validateUrlSyntax(rawUrl);
   const hostname = normalizeHostname(parsed.hostname);
-  const [pinned] = await resolveValidatedAddresses(hostname);
+  const [pinned] = await resolveValidatedAddresses(hostname, options?.signal);
+  options?.signal?.throwIfAborted();
 
   return { url: parsed, address: pinned.address, family: pinned.family };
 }

--- a/packages/cloud/shared/src/lib/security/safe-fetch.test.ts
+++ b/packages/cloud/shared/src/lib/security/safe-fetch.test.ts
@@ -220,6 +220,27 @@ describe("safeFetch fail-closed", () => {
     expect(requestMock).not.toHaveBeenCalled();
   });
 
+  test("returns when DNS never settles if the request is aborted", async () => {
+    lookupMock.mockReturnValue(
+      new Promise(() => {
+        /* never settles */
+      }),
+    );
+    const controller = new AbortController();
+    const reason = new Error("deadline expired");
+    const pending = safeFetch("https://slow-dns.example/image", {
+      signal: controller.signal,
+    });
+    queueMicrotask(() => {
+      controller.abort(reason);
+    });
+    const hung = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error("safeFetch ignored abort during DNS")), 80);
+    });
+    await expect(Promise.race([pending, hung])).rejects.toBe(reason);
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
   test("rejects credential-bearing and non-http targets before any lookup", async () => {
     await expect(safeFetch("http://user:pass@example.com/")).rejects.toThrow();
     await expect(safeFetch("ftp://example.com/file")).rejects.toThrow();

--- a/packages/cloud/shared/src/lib/security/safe-fetch.ts
+++ b/packages/cloud/shared/src/lib/security/safe-fetch.ts
@@ -263,8 +263,13 @@ export async function safeFetch(rawUrl: string, init: RequestInit = {}): Promise
     // Validate (resolve DNS + screen every address) on every hop in both
     // runtimes. On Node we then pin the connection to the validated IP; on
     // workerd we cannot pin an arbitrary IP, so the platform fetch re-resolves
-    // — a residual rebinding window documented on canPinSockets().
-    const { url, address, family } = await resolveSafeOutboundTarget(currentUrl);
+    // — a residual rebinding window documented on canPinSockets(). DNS lookup
+    // is raced against this signal inside resolveSafeOutboundTarget so a
+    // never-settling resolution returns on deadline instead of retaining the
+    // Worker request until lookup happens to complete.
+    const { url, address, family } = await resolveSafeOutboundTarget(currentUrl, {
+      signal: currentInit.signal ?? undefined,
+    });
     // DNS APIs do not accept AbortSignal. Re-check immediately after the await
     // so a lookup that outlives its caller's deadline cannot open a socket.
     currentInit.signal?.throwIfAborted();


### PR DESCRIPTION
# Relates to

Fixes #24050.

## Outcome

`POST /api/mcp/proxy/:mcpId` now bounds both request and upstream response bodies before retaining them in the Worker isolate:

- caller request bodies are capped at 1,000,000 bytes and return `413` with an exact fee-inclusive precharge refund;
- MCP response bodies are capped at 5,000,000 bytes and return `502` with an exact fee-inclusive precharge refund;
- trustworthy over-budget `content-length` values are rejected before reading;
- chunked bodies are copied into one fixed-size byte slab and decoded once;
- a separate 8,192 non-empty-chunk ceiling prevents tiny-chunk object/callback amplification while staying within the byte budget;
- the stream reader lock is released in `finally` on success, rejection, cancellation, and read failure;
- teardown failures are reported without fabricating success.

The proxy preserves the fee-inclusive `chargeReceipt.totalAmountUsd` authority introduced on current `develop`; it does not recompute refunds from the base tool price.

## Exact-head verification

Evidence head: `822e290c304579bcf2bed6571f0675f82e5a5f99`

Rebased onto `origin/develop` `6e69cc16cccb32c91ecb2263675e654d24f0ce5a` with no unresolved conflicts.

- `bun --config=/private/tmp/bunfig-no-coverage.toml test packages/cloud/api/__tests__/mcp-proxy-body-budget.test.ts packages/cloud/api/__tests__/mcp-proxy-refund.test.ts packages/cloud/api/__tests__/mcp-proxy-helpers.test.ts` — **43 passed, 0 failed, 86 assertions**.
- `bun run --cwd packages/cloud/api typecheck` — **passed**; the package script also completed the Wrangler production dry-run (**24,990.85 KiB**, gzip **5,949.77 KiB**).
- `bunx biome check packages/cloud/api/mcp/proxy/[mcpId]/proxy-body-budget.ts packages/cloud/api/__tests__/mcp-proxy-body-budget.test.ts packages/cloud/api/__tests__/mcp-proxy-refund.test.ts` — **passed**.
- `git diff --check` — **passed**.
- The package-wide test lane was attempted. It exposed unrelated current-base failures in `admin-agent-image-canary-route.pglite.test.ts` (expected 202, received 409; two cases) and `analytics-dashboard-empty-org-guard.test.ts` (expected 200, received 500), so the 515-file aggregate was stopped after those baseline failures. The three MCP proxy suites above are green on this exact head.
- Root `bun run verify` was attempted. Guide parity passed, then the sparse audit checkout stopped at `check:biome-version` because `packages/auth/package.json` is absent from the sparse checkout. This is an environment hold, not a source-completeness or readiness blocker.

The committed tests cover declared overflow without a read, streamed overflow, exact-budget UTF-8 split across chunk boundaries, hostile tiny-chunk fragmentation, cancellation failure, reader failure/lock release, route-level `413`/`502` responses, exact refund amount/reasons, skipped upstream execution, and skipped usage recording.

## Risks and acceptance holds

Below-budget behavior remains unchanged. Over-budget or maliciously fragmented bodies now fail closed rather than being truncated and returned as success.

Hosted CI, independent re-review, and a workerd/live Worker resource observation remain explicit merge/acceptance holds while this source-complete PR stays **ready for review**. They are not reasons to return it to draft.

The existing lack of an end-to-end upstream deadline and per-key concurrency cap are separate mechanisms outside issue #24050's byte-budget scope.

## Evidence gate

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - backend-only Worker route; no rendered UI.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - backend-only Worker route; no rendered UI.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no user-visible flow.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: exact-head focused tests and Wrangler production dry-run summarized above.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend surface.`
<!-- evidence-row:llm-trajectory -->
- [x] LLM trajectory: `N/A - no model, prompt, provider, or agent behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: exact refund amount/reason assertions are committed in the route-level test suite.
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - no rendered visual surface.`

## Contribution provenance

Original contributor receipt retained in the PR timeline/body history; exact-head repair and verification performed by the maintainer review lane.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-5; openai/codex`
<!-- attribution-row:client -->
- Agent tooling: `claude-code; codex`
<!-- attribution-row:skill-revision -->
- Skill path: `SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:822e290c304579bcf2bed6571f0675f82e5a5f99 -->

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0K4RNSCNV01VGFVK1RXAVF4","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T21:48:52.397Z","completed_at":"2026-08-21T21:49:31.167Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T21:48:52.717Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"498bb72a3609f51d15fa816bb675adee37cba5c7f2145ebd636719e4c55cf0e7","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"11335242-4f11-4f42-8462-32dabb43d03b","object_id":"sha256:498bb72a3609f51d15fa816bb675adee37cba5c7f2145ebd636719e4c55cf0e7","sha256":"498bb72a3609f51d15fa816bb675adee37cba5c7f2145ebd636719e4c55cf0e7"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"PO0srheq8JmtukYkL-w1dy3HePvRl6w0p4xpKHM0VFSEkfFXYu3LcNDG6Svn21mZNBg8c6z2N2sR467HUqrZCg"}} -->
