### PR TITLE
fix(plugin-x): route quote posts through connector

### DIFF
--- a/plugins/plugin-x/src/client/client.ts
+++ b/plugins/plugin-x/src/client/client.ts
@@ -1049,14 +1049,15 @@ export class Client {
    * Sends a quote tweet.
    * @param text The text of the tweet.
    * @param quotedTweetId The ID of the tweet to quote.
-   * @param options Optional parameters, such as media data.
+   * @param options Optional uploaded media identifiers.
    * @returns The response from the Twitter API.
    */
   public async sendQuoteTweet(
     text: string,
     quotedTweetId: string,
     options?: {
-      mediaData: { data: Buffer; mediaType: string }[];
+      mediaData?: { data: Buffer; mediaType: string }[];
+      mediaIds?: string[];
     },
   ) {
     return this.withAuthenticatedSession(() =>
@@ -1065,6 +1066,7 @@ export class Client {
         quotedTweetId,
         this.requireAuth(),
         options?.mediaData,
+        options?.mediaIds,
       ),
     );
   }

--- a/plugins/plugin-x/src/client/quote-tweet.test.ts
+++ b/plugins/plugin-x/src/client/quote-tweet.test.ts
@@ -1,0 +1,53 @@
+/** Verifies quote-tweet request assembly at the final X API client boundary. */
+
+import { describe, expect, it, vi } from "vitest";
+import type { TwitterAuth } from "./auth";
+import { createQuoteTweetRequest } from "./tweets";
+
+describe("createQuoteTweetRequest", () => {
+  it("preserves uploaded media ids on the quote tweet", async () => {
+    const tweet = vi.fn(async () => ({ data: { id: "quote-1" } }));
+    const auth = {
+      getV2Client: async () => ({ v2: { tweet } }),
+    } as unknown as TwitterAuth;
+
+    await createQuoteTweetRequest("context", "source-1", auth, undefined, [
+      "media-1",
+      "media-2",
+    ]);
+
+    expect(tweet).toHaveBeenCalledWith({
+      text: "context https://twitter.com/i/status/source-1",
+      media: { media_ids: ["media-1", "media-2"] },
+    });
+  });
+
+  it("rejects invalid media arity before the provider write", async () => {
+    const tweet = vi.fn();
+    const auth = {
+      getV2Client: async () => ({ v2: { tweet } }),
+    } as unknown as TwitterAuth;
+
+    await createQuoteTweetRequest("context", "source-1", auth, undefined, []);
+    expect(tweet).toHaveBeenCalledWith({
+      text: "context https://twitter.com/i/status/source-1",
+    });
+
+    tweet.mockClear();
+    await expect(
+      createQuoteTweetRequest("context", "source-1", auth, undefined, [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+      ]),
+    ).rejects.toMatchObject({
+      code: "X_QUOTE_REQUEST_FAILED",
+      cause: expect.objectContaining({
+        message: expect.stringContaining("between 1 and 4"),
+      }),
+    });
+    expect(tweet).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-x/src/client/tweets.ts
+++ b/plugins/plugin-x/src/client/tweets.ts
@@ -1174,6 +1174,7 @@ export async function createQuoteTweetRequest(
   quotedTweetId: string,
   auth: TwitterAuth,
   _mediaData?: { data: Buffer; mediaType: string }[],
+  mediaIds?: string[],
 ) {
   const v2client = await auth.getV2Client();
   if (!v2client) {
@@ -1185,17 +1186,30 @@ export async function createQuoteTweetRequest(
     const quotedTweetUrl = `https://twitter.com/i/status/${quotedTweetId}`;
     const fullText = `${text} ${quotedTweetUrl}`;
 
-    const result = await v2client.v2.tweet({
+    const tweetConfig: SendTweetV2Params = {
       text: fullText,
-    });
+    };
+    if (mediaIds && mediaIds.length > 0) {
+      tweetConfig.media = {
+        media_ids: toTweetMediaIds(mediaIds),
+      };
+    }
+
+    const result = await v2client.v2.tweet(tweetConfig);
 
     return {
       ok: true,
       json: async () => result,
       data: result,
     };
-  } catch (error) {
-    throw new Error(`Failed to create quote tweet: ${errorMessage(error)}`);
+  } catch (cause) {
+    // error-policy:J2 Preserve the provider or request-assembly failure at the
+    // connector boundary so callers can distinguish it from an accepted write.
+    throw new ElizaError("Failed to create quote tweet", {
+      code: "X_QUOTE_REQUEST_FAILED",
+      cause,
+      context: { quotedTweetId },
+    });
   }
 }
 

--- a/plugins/plugin-x/src/services/PostService.test.ts
+++ b/plugins/plugin-x/src/services/PostService.test.ts
@@ -171,6 +171,79 @@ describe("TwitterPostService", () => {
     });
   });
 
+  it("attaches uploaded media to the quote request", async () => {
+    const uploadMedia = vi.fn(async () => "media-1");
+    const sendQuoteTweet = vi.fn(async () => ({ data: { id: "quote-media" } }));
+    const current = new TwitterPostService({
+      ...withSession(CURRENT_PROFILE, {}),
+      twitterClient: { uploadMedia, sendQuoteTweet },
+    } as unknown as ClientBase);
+    const data = Buffer.from("image");
+
+    await current.createPost({
+      agentId: AGENT_ID,
+      roomId: ROOM_ID,
+      text: "illustrated context",
+      quotedPostId: "source-post-2",
+      media: [{ data, type: "image/png" }],
+    });
+
+    expect(uploadMedia).toHaveBeenCalledWith(data, { mimeType: "image/png" });
+    expect(sendQuoteTweet).toHaveBeenCalledWith(
+      "illustrated context",
+      "source-post-2",
+      { mediaIds: ["media-1"] },
+    );
+  });
+
+  it("rejects ambiguous reply and quote targets before external mutation", async () => {
+    const uploadMedia = vi.fn();
+    const sendTweet = vi.fn();
+    const sendQuoteTweet = vi.fn();
+    const current = new TwitterPostService({
+      ...withSession(CURRENT_PROFILE, {}),
+      twitterClient: { uploadMedia, sendTweet, sendQuoteTweet },
+    } as unknown as ClientBase);
+
+    await expect(
+      current.createPost({
+        agentId: AGENT_ID,
+        roomId: ROOM_ID,
+        text: "ambiguous",
+        inReplyTo: "reply-target",
+        quotedPostId: "quote-target",
+        media: [{ data: Buffer.from("image"), type: "image/png" }],
+      }),
+    ).rejects.toMatchObject({ code: "X_POST_TARGET_CONFLICT" });
+    expect(uploadMedia).not.toHaveBeenCalled();
+    expect(sendTweet).not.toHaveBeenCalled();
+    expect(sendQuoteTweet).not.toHaveBeenCalled();
+  });
+
+  it("rejects excessive quote media before uploading any attachment", async () => {
+    const uploadMedia = vi.fn();
+    const sendQuoteTweet = vi.fn();
+    const current = new TwitterPostService({
+      ...withSession(CURRENT_PROFILE, {}),
+      twitterClient: { uploadMedia, sendQuoteTweet },
+    } as unknown as ClientBase);
+
+    await expect(
+      current.createPost({
+        agentId: AGENT_ID,
+        roomId: ROOM_ID,
+        text: "too many attachments",
+        quotedPostId: "quote-target",
+        media: Array.from({ length: 5 }, () => ({
+          data: Buffer.from("image"),
+          type: "image/png",
+        })),
+      }),
+    ).rejects.toMatchObject({ code: "X_POST_MEDIA_COUNT_INVALID" });
+    expect(uploadMedia).not.toHaveBeenCalled();
+    expect(sendQuoteTweet).not.toHaveBeenCalled();
+  });
+
   it("surfaces an accepted post without a receipt as non-retriable and indeterminate", async () => {
     const sendTweet = vi.fn(async () => ({ data: { id: "   " } }));
     const current = new TwitterPostService({

--- a/plugins/plugin-x/src/services/PostService.test.ts
+++ b/plugins/plugin-x/src/services/PostService.test.ts
@@ -145,6 +145,32 @@ describe("TwitterPostService", () => {
     });
   });
 
+  it("routes quote posts through the dedicated quote request", async () => {
+    const sendTweet = vi.fn();
+    const sendQuoteTweet = vi.fn(async () => ({ data: { id: "quote-b" } }));
+    const current = new TwitterPostService({
+      ...withSession(CURRENT_PROFILE, {}),
+      twitterClient: { sendTweet, sendQuoteTweet },
+    } as unknown as ClientBase);
+
+    const post = await current.createPost({
+      agentId: AGENT_ID,
+      roomId: ROOM_ID,
+      text: "why this post matters",
+      quotedPostId: "source-post-1",
+    });
+
+    expect(sendQuoteTweet).toHaveBeenCalledWith(
+      "why this post matters",
+      "source-post-1",
+    );
+    expect(sendTweet).not.toHaveBeenCalled();
+    expect(post).toMatchObject({
+      id: "quote-b",
+      quotedPostId: "source-post-1",
+    });
+  });
+
   it("surfaces an accepted post without a receipt as non-retriable and indeterminate", async () => {
     const sendTweet = vi.fn(async () => ({ data: { id: "   " } }));
     const current = new TwitterPostService({

--- a/plugins/plugin-x/src/services/PostService.ts
+++ b/plugins/plugin-x/src/services/PostService.ts
@@ -35,6 +35,30 @@ export class TwitterPostService implements IPostService {
         );
       }
       try {
+        if (options.quotedPostId && options.inReplyTo) {
+          throw new ElizaError(
+            "An X post cannot be both a reply and a quote through one connector request",
+            {
+              code: "X_POST_TARGET_CONFLICT",
+              context: {
+                hasReplyTarget: true,
+                hasQuoteTarget: true,
+              },
+              severity: "fatal",
+            },
+          );
+        }
+        if ((options.media?.length ?? 0) > 4) {
+          throw new ElizaError(
+            "X posts accept at most four media attachments",
+            {
+              code: "X_POST_MEDIA_COUNT_INVALID",
+              context: { mediaCount: options.media?.length },
+              severity: "fatal",
+            },
+          );
+        }
+
         // Handle media uploads if needed
         const mediaIds: string[] = [];
 
@@ -78,6 +102,7 @@ export class TwitterPostService implements IPostService {
           ? await this.client.twitterClient.sendQuoteTweet(
               options.text,
               options.quotedPostId,
+              ...(mediaIds.length > 0 ? [{ mediaIds }] : []),
             )
           : mediaIds.length > 0
             ? await this.client.twitterClient.sendTweet(

--- a/plugins/plugin-x/src/services/PostService.ts
+++ b/plugins/plugin-x/src/services/PostService.ts
@@ -74,8 +74,12 @@ export class TwitterPostService implements IPostService {
             code: "X_AUTH_SESSION_ROTATED",
           });
         }
-        const result =
-          mediaIds.length > 0
+        const result = options.quotedPostId
+          ? await this.client.twitterClient.sendQuoteTweet(
+              options.text,
+              options.quotedPostId,
+            )
+          : mediaIds.length > 0
             ? await this.client.twitterClient.sendTweet(
                 options.text,
                 options.inReplyTo,

--- a/plugins/plugin-x/src/services/x.service.test.ts
+++ b/plugins/plugin-x/src/services/x.service.test.ts
@@ -448,6 +448,56 @@ describe("XService trusted account routing", () => {
     expect(getClient).toHaveBeenCalledWith("trusted");
   });
 
+  it("forwards the canonical quote id through the post connector", async () => {
+    const runtime = runtimeWithSettings({});
+    const service = new XService(runtime);
+    const profile = {
+      id: "account-owner",
+      username: "account-owner",
+      screenName: "Account Owner",
+      bio: "",
+      nicknames: [],
+    };
+    const base = {
+      profile,
+      withAuthenticatedSession: async <T>(
+        operation: (session: {
+          client: never;
+          profile: typeof profile;
+          revision: number;
+        }) => Promise<T>,
+      ) => operation({ client: {} as never, profile, revision: 1 }),
+    } as unknown as ClientBase;
+    vi.spyOn(
+      service as unknown as {
+        getTwitterClientForAccount: () => Promise<{ client: ClientBase }>;
+      },
+      "getTwitterClientForAccount",
+    ).mockResolvedValue({ client: base });
+    const createPost = vi
+      .spyOn(TwitterPostService.prototype, "createPost")
+      .mockResolvedValue({
+        id: "quote-1",
+        agentId: runtime.agentId,
+        roomId: "room-1" as never,
+        userId: "account-owner",
+        username: "account-owner",
+        text: "commentary",
+        timestamp: 1,
+        quotedPostId: "source-post-1",
+      });
+
+    await service.handleSendPost(runtime, {
+      text: "commentary",
+      quotedPostId: "source-post-1",
+    } as Content);
+
+    expect(createPost).toHaveBeenCalledWith(
+      expect.objectContaining({ quotedPostId: "source-post-1" }),
+      profile,
+    );
+  });
+
   it("keeps DM recipient lookup and send inside one authenticated session", async () => {
     const runtime = runtimeWithSettings({});
     const service = new XService(runtime);

--- a/plugins/plugin-x/src/services/x.service.ts
+++ b/plugins/plugin-x/src/services/x.service.ts
@@ -834,6 +834,7 @@ export class XService extends Service {
         "replyTo",
         "inReplyToTweetId",
       ]);
+      const quotedPostId = readContentString(content, ["quotedPostId"]);
       const postService = new TwitterPostService(base);
       const post = await postService.createPost(
         {
@@ -844,6 +845,7 @@ export class XService extends Service {
           ),
           text,
           ...(replyToTweetId ? { inReplyTo: replyToTweetId } : {}),
+          ...(quotedPostId ? { quotedPostId } : {}),
         },
         profile,
       );


### PR DESCRIPTION
# Relates to

Fixes #24036.

- [x] This PR targets `develop` and is based on the latest `origin/develop` (`b687e3bbc9347c6d9d273b67c28a9b05dc52810b`) with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync; the unrelated monorepo blocker is recorded below.
- [x] A reviewer can confirm the routing behavior from the focused tests below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b687e3bbc9347c6d9d273b67c28a9b05dc52810b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` was attempted post-sync; its exact unrelated base failure is documented in **Known gaps / failures**.

# Risks

Low. The change only selects the already implemented `sendQuoteTweet` request when the canonical quote id is present and leaves existing plain-post and reply routing untouched.

# Background

## What does this PR do?

- Routes `CreatePostOptions.quotedPostId` through `sendQuoteTweet` instead of the ordinary tweet request.
- Forwards canonical `content.quotedPostId` from `XService.handleSendPost` into the post service.
- Adds production-path regressions at both routing seams.

## What kind of change is this?

Bug fix, non-breaking.

# Documentation changes needed?

No. This restores the behavior already expressed by the public option and connector content contract.

# Testing

## Where should a reviewer start?

Start with `PostService.test.ts` for the final X client request, then `x.service.test.ts` for connector forwarding.

## Detailed testing steps

- `mise exec -- bun run --cwd plugins/plugin-x test -- src/services/PostService.test.ts` — 11 passed.
- `mise exec -- bun run --cwd plugins/plugin-x test -- src/services/x.service.test.ts -t "forwards the canonical quote id through the post connector"` — 1 passed.
- `mise exec -- bun run --cwd plugins/plugin-x typecheck` — passed.
- `mise exec -- bunx @biomejs/biome check plugins/plugin-x/src/services/PostService.ts plugins/plugin-x/src/services/x.service.ts plugins/plugin-x/src/services/PostService.test.ts plugins/plugin-x/src/services/x.service.test.ts` — passed.
- `mise exec -- bun run --cwd plugins/plugin-x build` — passed.
- `git diff --check` — passed.

# Evidence Gate

<!-- evidence-head:64d461da64495e6cc23a5ff360cd1cb97a51a836 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend connector routing only; no UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - a live X write would require credentials and create a public side effect; focused tests exercise the real service path through the final client seam.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduled-task, wallet, file, or media artifact is produced.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM path changed.

## Backend + frontend logs

N/A - no live X write was performed. The focused tests prove both the connector-to-service forwarding and service-to-quote-request routing without external side effects.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio or voice change.

## Known gaps / failures

- `mise exec -- bun run verify` reaches the monorepo Turbo lint/typecheck lane, then fails in untouched `packages/agent` files on pre-existing Biome diagnostics such as non-null assertions in `src/api/interactions-routes.test.ts` and formatting in `src/actions/database.ts`. No `packages/agent` file is part of this PR.
- A combined `x.service.test.ts` run also encounters two existing account-status expectation failures before this new connector case; the exact new connector regression passes in isolation. The complete `PostService.test.ts` suite passes 11/11.
- `packages/core` build artifacts were generated locally for type resolution. Its packaging tail hit a local mise npm-wrapper syntax error after JS and declaration outputs succeeded; the plugin typecheck and build then passed.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@b687e3bbc9347c6d9d273b67c28a9b05dc52810b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [standujar/fix-x-quote-routing]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@b687e3bbc9347c6d9d273b67c28a9b05dc52810b:packages/skills/skills/contribute-to-eliza"} -->

## Maintainer corrective review

The original head routed ordinary quotes correctly but regressed combined quote+media writes: it uploaded attachments and then omitted every uploaded ID from the final request. It also silently discarded a reply target when both reply and quote IDs were present.

The reviewed head `64d461da64495e6cc23a5ff360cd1cb97a51a836` now:

- carries uploaded media IDs into the final quote-tweet payload;
- rejects reply+quote ambiguity and more than four media items before any upload or public write;
- wraps final quote request failures as typed `X_QUOTE_REQUEST_FAILED` errors; and
- tests both connector seams and the final API request assembly.

Exact-head validation: quote API boundary 2/2, post service 14/14, connector forwarding 1/1, focused Biome, and diff hygiene passed. Plugin typecheck remained blocked by the isolated checkout's absent prebuilt `@elizaos/core` declarations and emitted no changed-file-specific diagnostic; the exercised Vitest transformations compiled all changed modules.

Maintainer AI provider/model: OpenAI / gpt-5
Maintainer client / agent tooling: Codex
Maintainer attribution status: system-confirmed
— [codex-maintainer-corrective-review-24056]
