### PR TITLE
fix(cloud): close Discord REST deadline gaps

### DIFF
--- a/packages/cloud/shared/src/lib/services/discord-automation/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/index.error-policy.test.ts
@@ -283,6 +283,21 @@ describe("sendMessage — shared Discord deadline boundary", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("bounds raw whitespace work before split normalization", async () => {
+    const fetchMock = mock(async () => jsonResponse({ id: "unexpected" }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await discordAutomationService.sendMessage(
+      "channel-1",
+      `${" ".repeat(2_000 * 25 + 1)}x`,
+    );
+    expect(result).toEqual({
+      success: false,
+      error: "Message exceeds the 25-chunk delivery limit",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("does not report full success after a later chunk fails", async () => {
     let requestCount = 0;
     globalThis.fetch = mock(async () => {

--- a/packages/cloud/shared/src/lib/services/discord-automation/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/index.error-policy.test.ts
@@ -2,7 +2,7 @@
 // Discord REST call must PROPAGATE as a throw, while a legitimately-empty guild
 // (no text channels) must stay a distinct, successful [] result. Deterministic
 // harness — global fetch and the DB repositories are mocked; no live Discord.
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, jest, mock } from "bun:test";
 
 // Env is read at module load, so it must be set before the dynamic import below.
 process.env.DISCORD_CLIENT_ID = "test-client-id";
@@ -16,6 +16,14 @@ const guildUpsert = mock(async () => {});
 // unrelated Core Unicode helper hermetic so the focused test does not require
 // a built @elizaos/core workspace package.
 mock.module("@elizaos/core", () => ({
+  ElizaError: class extends Error {
+    readonly code: string;
+
+    constructor(message: string, options: { code: string }) {
+      super(message);
+      this.code = options.code;
+    }
+  },
   truncateWellFormed: (value: string, maxUnits: number) => value.slice(0, maxUnits),
 }));
 mock.module("../../../db/repositories/discord-channels", () => ({
@@ -43,19 +51,17 @@ const realFetch = globalThis.fetch;
 function jsonResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
   const ok = init?.ok ?? true;
   const status = init?.status ?? (ok ? 200 : 500);
-  return {
-    ok,
+  return new Response(typeof body === "string" ? body : JSON.stringify(body), {
     status,
-    json: async () => body,
-    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
-  } as unknown as Response;
+    headers: { "content-type": "application/json" },
+  });
 }
 
 function hungResponse(
   init?: RequestInit,
   onSignal?: (signal: AbortSignal | undefined) => void,
 ): Promise<Response> {
-  onSignal?.(init?.signal);
+  onSignal?.(init?.signal ?? undefined);
   return new Promise<Response>((_resolve, reject) => {
     const guard = setTimeout(
       () => reject(new Error("test guard elapsed before Discord deadline")),
@@ -232,7 +238,7 @@ describe("sendMessage — shared Discord deadline boundary", () => {
   it("passes the shared deadline signal to the message transport", async () => {
     let seen: AbortSignal | undefined;
     globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      seen = init?.signal;
+      seen = init?.signal ?? undefined;
       return jsonResponse({ id: "message-1" });
     }) as unknown as typeof fetch;
 
@@ -240,5 +246,71 @@ describe("sendMessage — shared Discord deadline boundary", () => {
 
     expect(result).toEqual({ success: true, messageId: "message-1" });
     expect(seen).toBeInstanceOf(AbortSignal);
+  });
+
+  it("aborts the underlying hung transport at the overall deadline", async () => {
+    jest.useFakeTimers();
+    let seen: AbortSignal | undefined;
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          seen = init?.signal ?? undefined;
+          seen?.addEventListener("abort", () => reject(seen?.reason), { once: true });
+        }),
+    ) as unknown as typeof fetch;
+
+    const pending = discordAutomationService.sendMessage("channel-1", "hello");
+    await Promise.resolve();
+    expect(seen?.aborted).toBe(false);
+    jest.advanceTimersByTime(25_000);
+
+    await expect(pending).resolves.toEqual({ success: false, error: "Failed to send message" });
+    expect(seen?.aborted).toBe(true);
+  });
+
+  it("rejects over-budget chunk work before the first REST mutation", async () => {
+    const fetchMock = mock(async () => jsonResponse({ id: "unexpected" }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await discordAutomationService.sendMessage(
+      "channel-1",
+      "x".repeat(2_000 * 25 + 1),
+    );
+    expect(result).toEqual({
+      success: false,
+      error: "Message exceeds the 25-chunk delivery limit",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not report full success after a later chunk fails", async () => {
+    let requestCount = 0;
+    globalThis.fetch = mock(async () => {
+      requestCount += 1;
+      return requestCount === 1
+        ? jsonResponse({ id: "partial-message" })
+        : jsonResponse("rate limited", { ok: false, status: 429 });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      discordAutomationService.sendMessage("channel-1", "x".repeat(2_001)),
+    ).resolves.toEqual({ success: false, error: "Failed to send message" });
+    expect(requestCount).toBe(2);
+  });
+
+  it("clears the overall deadline after a completed multi-chunk send", async () => {
+    jest.useFakeTimers();
+    const signals: AbortSignal[] = [];
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.signal) signals.push(init.signal);
+      return jsonResponse({ id: `message-${signals.length}` });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      discordAutomationService.sendMessage("channel-1", "x".repeat(2_001)),
+    ).resolves.toEqual({ success: true, messageId: "message-2" });
+    jest.advanceTimersByTime(25_000);
+    expect(signals).toHaveLength(2);
+    expect(signals.every((signal) => !signal.aborted)).toBe(true);
   });
 });

--- a/packages/cloud/shared/src/lib/services/discord-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/index.ts
@@ -29,6 +29,8 @@ import type {
 const DISCORD_API_BASE = "https://discord.com/api/v10";
 const _DISCORD_CDN_BASE = "https://cdn.discordapp.com";
 const MAX_DISCORD_MESSAGE_CHUNKS = 25;
+const MAX_DISCORD_MESSAGE_WORK_UNITS =
+  MAX_DISCORD_MESSAGE_CHUNKS * DISCORD_RATE_LIMITS.MAX_MESSAGE_LENGTH;
 
 export { discordFetch };
 
@@ -563,6 +565,16 @@ class DiscordAutomationService {
   ): Promise<SendMessageResult> {
     if (!DISCORD_BOT_TOKEN) {
       return { success: false, error: "Bot token not configured" };
+    }
+
+    // Reject oversized work before splitMessage scans and slices the complete
+    // input. The post-split guard remains authoritative for boundary effects
+    // such as Unicode-safe chunking and whitespace break selection.
+    if (content.length > MAX_DISCORD_MESSAGE_WORK_UNITS) {
+      return {
+        success: false,
+        error: `Message exceeds the ${MAX_DISCORD_MESSAGE_CHUNKS}-chunk delivery limit`,
+      };
     }
 
     const deadline = new AbortController();

--- a/packages/cloud/shared/src/lib/services/discord-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/discord-automation/index.ts
@@ -8,7 +8,7 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { discordChannelsRepository } from "../../../db/repositories/discord-channels";
 import { discordGuildsRepository } from "../../../db/repositories/discord-guilds";
-import { discordFetch } from "../../utils/discord-api";
+import { DISCORD_REQUEST_TIMEOUT_MS, discordFetch } from "../../utils/discord-api";
 import {
   DISCORD_RATE_LIMITS,
   getGuildIconUrl,
@@ -28,6 +28,7 @@ import type {
 
 const DISCORD_API_BASE = "https://discord.com/api/v10";
 const _DISCORD_CDN_BASE = "https://cdn.discordapp.com";
+const MAX_DISCORD_MESSAGE_CHUNKS = 25;
 
 export { discordFetch };
 
@@ -564,9 +565,20 @@ class DiscordAutomationService {
       return { success: false, error: "Bot token not configured" };
     }
 
+    const deadline = new AbortController();
+    const timeoutId = setTimeout(() => {
+      deadline.abort(new DOMException("Discord message send timed out", "TimeoutError"));
+    }, DISCORD_REQUEST_TIMEOUT_MS);
+
     try {
       // Split message if too long
       const chunks = splitMessage(content, DISCORD_RATE_LIMITS.MAX_MESSAGE_LENGTH);
+      if (chunks.length > MAX_DISCORD_MESSAGE_CHUNKS) {
+        return {
+          success: false,
+          error: `Message exceeds the ${MAX_DISCORD_MESSAGE_CHUNKS}-chunk delivery limit`,
+        };
+      }
       let lastMessageId: string | undefined;
 
       for (let i = 0; i < chunks.length; i++) {
@@ -588,6 +600,7 @@ class DiscordAutomationService {
             "Content-Type": "application/json",
           },
           body: JSON.stringify(body),
+          signal: deadline.signal,
         });
 
         if (!response.ok) {
@@ -613,6 +626,8 @@ class DiscordAutomationService {
         error: error instanceof Error ? error.message : "Unknown error",
       });
       return { success: false, error: "Failed to send message" };
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 

--- a/packages/cloud/shared/src/lib/services/discord.ts
+++ b/packages/cloud/shared/src/lib/services/discord.ts
@@ -1,10 +1,11 @@
 // Coordinates cloud service discord behavior behind route handlers.
+import { discordFetch } from "../utils/discord-api";
 import { logger } from "../utils/logger";
 
 const DISCORD_API = "https://discord.com/api/v10";
 
 async function discordPost(token: string, path: string, body: unknown): Promise<Response> {
-  return fetch(`${DISCORD_API}${path}`, {
+  return discordFetch(`${DISCORD_API}${path}`, {
     method: "POST",
     headers: {
       Authorization: `Bot ${token}`,

--- a/packages/cloud/shared/src/lib/services/gateway-discord/event-router.ts
+++ b/packages/cloud/shared/src/lib/services/gateway-discord/event-router.ts
@@ -24,7 +24,7 @@ import { discordConnectionsRepository, userCharactersRepository } from "../../..
 import { AgentMode } from "../../eliza/agent-mode-types";
 import { runtimeFactory } from "../../eliza/runtime-factory";
 import { userContextService } from "../../eliza/user-context";
-import { DISCORD_API_BASE, discordBotHeaders } from "../../utils/discord-api";
+import { DISCORD_API_BASE, discordBotHeaders, discordFetch } from "../../utils/discord-api";
 import { logger } from "../../utils/logger";
 import { getEncryptionService } from "../secrets/encryption";
 import {
@@ -84,9 +84,6 @@ function truncateUtf16Safe(str: string, maxLength: number): string {
 
   return truncated;
 }
-
-/** HTTP request timeout for Discord API calls */
-const DISCORD_API_TIMEOUT_MS = 10_000;
 
 // ============================================
 // Rate Limiter
@@ -706,19 +703,11 @@ async function sendDiscordResponse(
   await discordRateLimiter.acquire(botToken);
 
   const makeRequest = async (): Promise<Response> => {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), DISCORD_API_TIMEOUT_MS);
-
-    try {
-      return await fetch(`${DISCORD_API_BASE}/channels/${channelId}/messages`, {
-        method: "POST",
-        headers: discordBotHeaders(botToken),
-        body: JSON.stringify(payload),
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
+    return discordFetch(`${DISCORD_API_BASE}/channels/${channelId}/messages`, {
+      method: "POST",
+      headers: discordBotHeaders(botToken),
+      body: JSON.stringify(payload),
+    });
   };
 
   let response = await makeRequest();

--- a/packages/cloud/shared/src/lib/utils/discord-api.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/utils/discord-api.error-policy.test.ts
@@ -141,6 +141,51 @@ describe("discordFetch", () => {
     expect(cancelled).toBe(true);
   });
 
+  it("enforces the wall-clock deadline across immediately-ready empty chunks", async () => {
+    let cancelled = false;
+    let emitted = 0;
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              if (emitted < 100_000) {
+                emitted += 1;
+                controller.enqueue(new Uint8Array(0));
+                return;
+              }
+              controller.close();
+            },
+            cancel() {
+              cancelled = true;
+            },
+          }),
+        ),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      discordFetch("https://discord.com/api/v10/users/@me", undefined, 1),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(emitted).toBeLessThan(100_000);
+    expect(cancelled).toBe(true);
+  });
+
+  it("does not let a bodyless response win over caller cancellation", async () => {
+    const controller = new AbortController();
+    const reason = new DOMException("caller stopped after headers", "AbortError");
+    globalThis.fetch = mock(async () => {
+      const response = new Response(null, { status: 204 });
+      queueMicrotask(() => controller.abort(reason));
+      return response;
+    }) as unknown as typeof fetch;
+
+    await expect(
+      discordFetch("https://discord.com/api/v10/users/@me", {
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(reason);
+  });
+
   it("rejects and cancels a declared oversized response", async () => {
     let cancelled = false;
     const body = new ReadableStream<Uint8Array>({
@@ -188,6 +233,24 @@ describe("discordFetch", () => {
         discordFetch("https://discord.com/api/v10/users/@me", undefined, timeout),
       ).rejects.toMatchObject({ code: "INVALID_DISCORD_TIMEOUT" });
     }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves an explicit null caller-abort reason", async () => {
+    const controller = new AbortController();
+    controller.abort(null);
+    const fetchMock = mock(async () => new Response());
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    let rejection: unknown = Symbol("not rejected");
+    try {
+      await discordFetch("https://discord.com/api/v10/users/@me", {
+        signal: controller.signal,
+      });
+    } catch (reason) {
+      rejection = reason;
+    }
+    expect(rejection).toBeNull();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/utils/discord-api.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/utils/discord-api.error-policy.test.ts
@@ -170,6 +170,38 @@ describe("discordFetch", () => {
     expect(cancelled).toBe(true);
   });
 
+  it("preserves the caller reason when stream cancellation rejects differently", async () => {
+    const controller = new AbortController();
+    const reason = new DOMException("caller owns this reason", "AbortError");
+    const transportFailure = new Error("transport cancellation failed");
+    let releasePull!: () => void;
+    const blockedPull = new Promise<void>((resolve) => {
+      releasePull = resolve;
+    });
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            async pull() {
+              await blockedPull;
+            },
+            cancel() {
+              throw transportFailure;
+            },
+          }),
+        ),
+    ) as unknown as typeof fetch;
+
+    const pending = discordFetch("https://discord.com/api/v10/users/@me", {
+      signal: controller.signal,
+    });
+    await Promise.resolve();
+    controller.abort(reason);
+    releasePull();
+
+    await expect(pending).rejects.toBe(reason);
+  });
+
   it("does not let a bodyless response win over caller cancellation", async () => {
     const controller = new AbortController();
     const reason = new DOMException("caller stopped after headers", "AbortError");

--- a/packages/cloud/shared/src/lib/utils/discord-api.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/utils/discord-api.error-policy.test.ts
@@ -1,7 +1,18 @@
 // Pins the shared Discord REST deadline contract. Every caller keeps its own
 // cancellation signal, but a caller that never aborts cannot disable the
 // owned per-hop deadline. The bot/bearer helpers must use this same boundary.
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+
+class TestElizaError extends Error {
+  readonly code: string;
+
+  constructor(message: string, options: { code: string }) {
+    super(message);
+    this.code = options.code;
+  }
+}
+
+mock.module("@elizaos/core", () => ({ ElizaError: TestElizaError }));
 
 const { discordBearerApiRequest, discordBotApiRequest, discordFetch } = await import(
   "./discord-api"
@@ -26,7 +37,7 @@ function installHungFetch(): void {
           reject(new DOMException("The operation was aborted.", "AbortError"));
         });
       }),
-  ) as typeof fetch;
+  ) as unknown as typeof fetch;
 }
 
 describe("discordFetch", () => {
@@ -43,7 +54,7 @@ describe("discordFetch", () => {
     globalThis.fetch = mock(
       (_input: RequestInfo | URL, init?: RequestInit) =>
         new Promise<Response>((_resolve, reject) => {
-          seen = init?.signal;
+          seen = init?.signal ?? undefined;
           const guard = setTimeout(
             () => reject(new Error("test guard elapsed before caller abort")),
             2_000,
@@ -53,7 +64,7 @@ describe("discordFetch", () => {
             reject(new DOMException("The operation was aborted.", "AbortError"));
           });
         }),
-    ) as typeof fetch;
+    ) as unknown as typeof fetch;
 
     const controller = new AbortController();
     const pending = discordFetch(
@@ -85,7 +96,7 @@ describe("discordFetch", () => {
         status: 200,
         headers: { "content-type": "application/json" },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
     const never = new AbortController();
 
     await discordBotApiRequest("/users/@me", "bot", {
@@ -97,5 +108,86 @@ describe("discordFetch", () => {
 
     expect(signals).toHaveLength(2);
     expect(signals.every((signal) => signal !== never.signal)).toBe(true);
+  });
+
+  it("does not dispatch when the caller is already aborted", async () => {
+    const controller = new AbortController();
+    const reason = new Error("cancelled before dispatch");
+    controller.abort(reason);
+    const fetchMock = mock(async () => new Response());
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      discordFetch("https://discord.com/api/v10/users/@me", { signal: controller.signal }),
+    ).rejects.toBe(reason);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("bounds a hung response body and cancels its stream", async () => {
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1]));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    globalThis.fetch = mock(async () => new Response(body)) as unknown as typeof fetch;
+
+    await expect(
+      discordFetch("https://discord.com/api/v10/users/@me", undefined, 50),
+    ).rejects.toThrow(/timed out/i);
+    expect(cancelled).toBe(true);
+  });
+
+  it("rejects and cancels a declared oversized response", async () => {
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelled = true;
+      },
+    });
+    globalThis.fetch = mock(
+      async () =>
+        new Response(body, { headers: { "content-length": String(4 * 1024 * 1024 + 1) } }),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      discordFetch("https://discord.com/api/v10/users/@me", undefined, 1_000),
+    ).rejects.toMatchObject({ code: "DISCORD_RESPONSE_TOO_LARGE" });
+    expect(cancelled).toBe(true);
+  });
+
+  it("clears its timer and caller listener after success", async () => {
+    const controller = new AbortController();
+    const clearTimer = spyOn(globalThis, "clearTimeout");
+    const removeListener = spyOn(controller.signal, "removeEventListener");
+    globalThis.fetch = mock(async () => new Response("ok")) as unknown as typeof fetch;
+    try {
+      const response = await discordFetch(
+        "https://discord.com/api/v10/users/@me",
+        { signal: controller.signal },
+        1_000,
+      );
+      expect(await response.text()).toBe("ok");
+      expect(clearTimer).toHaveBeenCalled();
+      expect(removeListener).toHaveBeenCalledWith("abort", expect.any(Function));
+    } finally {
+      clearTimer.mockRestore();
+      removeListener.mockRestore();
+    }
+  });
+
+  it("rejects invalid timeout values before dispatch", async () => {
+    const fetchMock = mock(async () => new Response());
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    for (const timeout of [0, -1, Number.NaN, 2_147_483_648]) {
+      await expect(
+        discordFetch("https://discord.com/api/v10/users/@me", undefined, timeout),
+      ).rejects.toMatchObject({ code: "INVALID_DISCORD_TIMEOUT" });
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/utils/discord-api.ts
+++ b/packages/cloud/shared/src/lib/utils/discord-api.ts
@@ -66,6 +66,10 @@ async function bufferDiscordResponse(
       const next = await reader.read();
       throwIfAbortedOrExpired();
       if (next.done) break;
+      // Empty fragments do not contribute to the bounded payload. Retaining
+      // them would let a hostile stream grow the chunk-object inventory without
+      // consuming any of the byte budget.
+      if (next.value.byteLength === 0) continue;
       receivedBytes += next.value.byteLength;
       if (receivedBytes > DISCORD_RESPONSE_MAX_BYTES) {
         const error = new ElizaError("Discord response exceeds the byte limit", {
@@ -78,8 +82,16 @@ async function bufferDiscordResponse(
       chunks.push(next.value);
     }
   } catch (error) {
-    await cancelReader(error);
-    throw error;
+    let rejection = error;
+    try {
+      throwIfAbortedOrExpired();
+    } catch (abortOrDeadlineReason) {
+      // The composed signal owns cancellation semantics even if the transport
+      // rejects its reader or cancellation hook with a different error.
+      rejection = abortOrDeadlineReason;
+    }
+    await cancelReader(rejection);
+    throw rejection;
   } finally {
     signal.removeEventListener("abort", onAbort);
     try {

--- a/packages/cloud/shared/src/lib/utils/discord-api.ts
+++ b/packages/cloud/shared/src/lib/utils/discord-api.ts
@@ -14,7 +14,12 @@ export const DISCORD_REQUEST_TIMEOUT_MS = 25_000;
 const DISCORD_RESPONSE_MAX_BYTES = 4 * 1024 * 1024;
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
-async function bufferDiscordResponse(response: Response, signal: AbortSignal): Promise<Response> {
+async function bufferDiscordResponse(
+  response: Response,
+  signal: AbortSignal,
+  throwIfAbortedOrExpired: () => void,
+): Promise<Response> {
+  throwIfAbortedOrExpired();
   const contentLength = response.headers.get("content-length");
   if (contentLength !== null && /^\d+$/.test(contentLength)) {
     const declaredBytes = Number(contentLength);
@@ -32,21 +37,34 @@ async function bufferDiscordResponse(response: Response, signal: AbortSignal): P
       throw error;
     }
   }
-  if (!response.body) return response;
+  if (!response.body) {
+    throwIfAbortedOrExpired();
+    return response;
+  }
 
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
   let receivedBytes = 0;
-  const onAbort = (): void => {
-    reader.cancel(signal.reason).catch((cause: unknown) => {
+  let cancellationPromise: Promise<void> | null = null;
+  const cancelReader = (reason: unknown): Promise<void> => {
+    if (cancellationPromise) return cancellationPromise;
+    cancellationPromise = reader.cancel(reason).catch((cause: unknown) => {
       // error-policy:J6 The request failed; cancellation only releases transport.
-      logger.debug("[Discord] Failed to cancel aborted response body", { cause });
+      logger.debug("[Discord] Failed to cancel response body", { cause });
     });
+    return cancellationPromise;
+  };
+  const onAbort = (): void => {
+    void cancelReader(signal.reason);
   };
   signal.addEventListener("abort", onAbort, { once: true });
   try {
     while (true) {
+      // Immediately-ready or empty chunks can starve the timer queue. Check
+      // the monotonic operation deadline inside the read loop as well.
+      throwIfAbortedOrExpired();
       const next = await reader.read();
+      throwIfAbortedOrExpired();
       if (next.done) break;
       receivedBytes += next.value.byteLength;
       if (receivedBytes > DISCORD_RESPONSE_MAX_BYTES) {
@@ -54,19 +72,22 @@ async function bufferDiscordResponse(response: Response, signal: AbortSignal): P
           code: "DISCORD_RESPONSE_TOO_LARGE",
           context: { receivedBytes, maxBytes: DISCORD_RESPONSE_MAX_BYTES },
         });
-        try {
-          await reader.cancel(error);
-        } catch (cause) {
-          // error-policy:J6 The bounded read failed; cancellation only releases transport.
-          logger.debug("[Discord] Failed to cancel oversized response body", { cause });
-        }
+        await cancelReader(error);
         throw error;
       }
       chunks.push(next.value);
     }
+  } catch (error) {
+    await cancelReader(error);
+    throw error;
   } finally {
     signal.removeEventListener("abort", onAbort);
-    reader.releaseLock();
+    try {
+      reader.releaseLock();
+    } catch (cause) {
+      // error-policy:J6 Stream lock release is best-effort transport teardown.
+      logger.debug("[Discord] Failed to release response body lock", { cause });
+    }
   }
 
   const body = new Uint8Array(receivedBytes);
@@ -75,6 +96,7 @@ async function bufferDiscordResponse(response: Response, signal: AbortSignal): P
     body.set(chunk, offset);
     offset += chunk.byteLength;
   }
+  throwIfAbortedOrExpired();
   return new Response(body.buffer, {
     status: response.status,
     statusText: response.statusText,
@@ -101,6 +123,8 @@ export async function discordFetch(
   }
 
   const controller = new AbortController();
+  const deadlineAt = performance.now() + timeoutMs;
+  const timeoutError = new DOMException("Discord API request timed out", "TimeoutError");
   let rejectAbort!: (reason: unknown) => void;
   const abortPromise = new Promise<never>((_resolve, reject) => {
     rejectAbort = reject;
@@ -110,22 +134,35 @@ export async function discordFetch(
     controller.abort(reason);
     rejectAbort(reason);
   };
-  const onCallerAbort = (): void =>
-    abort(init?.signal?.reason ?? new DOMException("Discord request aborted", "AbortError"));
+  const onCallerAbort = (): void => {
+    if (!init?.signal) return;
+    abort(init.signal.reason);
+  };
   init?.signal?.addEventListener("abort", onCallerAbort, { once: true });
   if (init?.signal?.aborted) onCallerAbort();
-  const timeoutId = setTimeout(
-    () => abort(new DOMException("Discord API request timed out", "TimeoutError")),
-    timeoutMs,
-  );
+  const timeoutId = setTimeout(() => abort(timeoutError), timeoutMs);
+  const throwIfAbortedOrExpired = (): void => {
+    if (controller.signal.aborted) throw controller.signal.reason;
+    if (performance.now() >= deadlineAt) {
+      abort(timeoutError);
+      throw timeoutError;
+    }
+  };
 
   try {
     if (controller.signal.aborted) return await abortPromise;
+    throwIfAbortedOrExpired();
     const response = await Promise.race([
       fetch(input, { ...init, signal: controller.signal }),
       abortPromise,
     ]);
-    return await Promise.race([bufferDiscordResponse(response, controller.signal), abortPromise]);
+    throwIfAbortedOrExpired();
+    const buffered = await Promise.race([
+      bufferDiscordResponse(response, controller.signal, throwIfAbortedOrExpired),
+      abortPromise,
+    ]);
+    throwIfAbortedOrExpired();
+    return buffered;
   } finally {
     clearTimeout(timeoutId);
     init?.signal?.removeEventListener("abort", onCallerAbort);

--- a/packages/cloud/shared/src/lib/utils/discord-api.ts
+++ b/packages/cloud/shared/src/lib/utils/discord-api.ts
@@ -5,8 +5,82 @@
  * Consolidates duplicate Discord API base URLs and request patterns.
  */
 
+import { ElizaError } from "@elizaos/core";
+
+import { logger } from "./logger";
+
 export const DISCORD_API_BASE = "https://discord.com/api/v10";
 export const DISCORD_REQUEST_TIMEOUT_MS = 25_000;
+const DISCORD_RESPONSE_MAX_BYTES = 4 * 1024 * 1024;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+async function bufferDiscordResponse(response: Response, signal: AbortSignal): Promise<Response> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null && /^\d+$/.test(contentLength)) {
+    const declaredBytes = Number(contentLength);
+    if (!Number.isSafeInteger(declaredBytes) || declaredBytes > DISCORD_RESPONSE_MAX_BYTES) {
+      const error = new ElizaError("Discord response exceeds the byte limit", {
+        code: "DISCORD_RESPONSE_TOO_LARGE",
+        context: { declaredBytes, maxBytes: DISCORD_RESPONSE_MAX_BYTES },
+      });
+      try {
+        await response.body?.cancel(error);
+      } catch (cause) {
+        // error-policy:J6 The response is rejected; cancellation only releases transport.
+        logger.debug("[Discord] Failed to cancel declared-oversize response body", { cause });
+      }
+      throw error;
+    }
+  }
+  if (!response.body) return response;
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let receivedBytes = 0;
+  const onAbort = (): void => {
+    reader.cancel(signal.reason).catch((cause: unknown) => {
+      // error-policy:J6 The request failed; cancellation only releases transport.
+      logger.debug("[Discord] Failed to cancel aborted response body", { cause });
+    });
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      receivedBytes += next.value.byteLength;
+      if (receivedBytes > DISCORD_RESPONSE_MAX_BYTES) {
+        const error = new ElizaError("Discord response exceeds the byte limit", {
+          code: "DISCORD_RESPONSE_TOO_LARGE",
+          context: { receivedBytes, maxBytes: DISCORD_RESPONSE_MAX_BYTES },
+        });
+        try {
+          await reader.cancel(error);
+        } catch (cause) {
+          // error-policy:J6 The bounded read failed; cancellation only releases transport.
+          logger.debug("[Discord] Failed to cancel oversized response body", { cause });
+        }
+        throw error;
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(receivedBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new Response(body.buffer, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
 
 /**
  * Bound every Discord REST hop while preserving caller cancellation.
@@ -14,16 +88,48 @@ export const DISCORD_REQUEST_TIMEOUT_MS = 25_000;
  * A caller signal is composed with the owned deadline rather than replacing
  * it, so a never-aborted caller signal cannot disable the operation bound.
  */
-export function discordFetch(
+export async function discordFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
   timeoutMs: number = DISCORD_REQUEST_TIMEOUT_MS,
 ): Promise<Response> {
-  const deadline = AbortSignal.timeout(timeoutMs);
-  return fetch(input, {
-    ...init,
-    signal: init?.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_TIMER_DELAY_MS) {
+    throw new ElizaError("Discord timeout must be a positive timer-safe integer", {
+      code: "INVALID_DISCORD_TIMEOUT",
+      context: { timeoutMs },
+    });
+  }
+
+  const controller = new AbortController();
+  let rejectAbort!: (reason: unknown) => void;
+  const abortPromise = new Promise<never>((_resolve, reject) => {
+    rejectAbort = reject;
   });
+  const abort = (reason: unknown): void => {
+    if (controller.signal.aborted) return;
+    controller.abort(reason);
+    rejectAbort(reason);
+  };
+  const onCallerAbort = (): void =>
+    abort(init?.signal?.reason ?? new DOMException("Discord request aborted", "AbortError"));
+  init?.signal?.addEventListener("abort", onCallerAbort, { once: true });
+  if (init?.signal?.aborted) onCallerAbort();
+  const timeoutId = setTimeout(
+    () => abort(new DOMException("Discord API request timed out", "TimeoutError")),
+    timeoutMs,
+  );
+
+  try {
+    if (controller.signal.aborted) return await abortPromise;
+    const response = await Promise.race([
+      fetch(input, { ...init, signal: controller.signal }),
+      abortPromise,
+    ]);
+    return await Promise.race([bufferDiscordResponse(response, controller.signal), abortPromise]);
+  } finally {
+    clearTimeout(timeoutId);
+    init?.signal?.removeEventListener("abort", onCallerAbort);
+  }
 }
 
 /**


### PR DESCRIPTION
# Relates to

Fixes #23464.

- [x] This PR targets `develop` and is rebased onto exact live `develop@9fdf63831baa5afa01a1f8fcbce4ae71c53ebe65` with zero conflicts.
- [ ] `bun install` and root `bun run verify` were run after sync, or the exact environment limitation is recorded below.
- [x] A reviewer can verify the changed contract from deterministic transport, response-stream, multi-chunk mutation, timeout, and cleanup evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no revisioned contribute-to-eliza skill was used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact live `develop@9fdf63831baa5afa01a1f8fcbce4ae71c53ebe65`; zero conflicts.
- [ ] Root `bun run verify` passes post-sync, or the exact environment limitation is documented in **Known gaps / failures**.

# Risks

Medium-low. The change is confined to shared Discord REST transport and server-side message delivery. It fails closed on invalid deadlines, hung or oversized response bodies, expired multi-chunk work, and excessive chunk counts. The 4 MiB response cap is far above the small Discord JSON responses consumed by these paths.

# Background

## What does this PR do?

- Gives every shared Discord REST hop a clearable timer-safe deadline that composes with caller cancellation and covers headers plus a capped 4 MiB body read.
- Cancels hung, aborted, declared-oversize, and streamed-oversize response bodies, and removes caller/body listeners and timers on terminal paths.
- Refuses already-aborted callers before dispatch.
- Carries one 25-second controller through the complete automation multi-chunk send and response-body sequence.
- Rejects messages requiring more than 25 chunks before the first REST mutation and preserves `{ success:false }` after a later chunk fails.
- Routes the remaining legacy Discord notification service through the same bounded helper; the social provider and bot/bearer helpers already use it.

## What kind of change is this?

Security and reliability bug fix (non-breaking public API).

# Documentation changes needed?

No. This enforces the existing Discord connector contract and changes no user-facing copy or package-root export.

# Testing

## Where should a reviewer start?

- `packages/cloud/shared/src/lib/utils/discord-api.ts`
- `packages/cloud/shared/src/lib/services/discord-automation/index.ts`
- `packages/cloud/shared/src/lib/services/discord.ts`

## Detailed testing steps

At exact PR head `317889efc32cc13ad3138d083de34372c864efdc`:

1. `bun test ./packages/cloud/shared/src/lib/utils/discord-api.error-policy.test.ts`
   - PASS: 12 tests, 27 assertions.
   - Covers elapsed deadline, caller abort, never-aborted caller, bot/bearer routing, pre-aborted zero-dispatch, hung body cancellation, declared byte cap, timer/listener cleanup, and invalid timeout inputs.
2. `bun test ./packages/cloud/shared/src/lib/services/discord-automation/index.error-policy.test.ts`
   - PASS: 14 tests, 30 assertions.
   - Covers existing fail-closed/empty semantics, overall send abort reaching the underlying transport, pre-mutation chunk cap, later-chunk terminal failure, and successful multi-chunk cleanup.
3. Package-local pinned Biome 2.5.8 over all five changed files: PASS.
4. Strict targeted TypeScript over the self-contained transport, transport test, and legacy Discord service: PASS.
5. Externalized Bun builds for all five changed files: PASS.
6. `git diff --check origin/develop...HEAD`: PASS.

# Evidence Gate

<!-- evidence-head:317889efc32cc13ad3138d083de34372c864efdc -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Discord server transport logic has no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Discord server transport logic has no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deadlines, cancellation, response caps, and mutation counts are verified at the transport boundary, not visually.
<!-- evidence-row:backend-logs -->
- [x] N/A - no protected Discord credential was used; deterministic tests inspect signals, cancellation, bodies, requests, mutation counts, and typed failure results.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, agent, or action-planning behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - request assertions are executable tests, not retained database, memory, schedule, wallet, generated-file, or media artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

The transport regressions observe the exact signal passed to mocked fetch, prove both caller and owned deadlines abort it, and prove body-stream cancellation after headers. The automation regressions prove the 25-second overall deadline reaches a hung underlying transport, a 50,001-character message makes zero requests, and a successful first chunk followed by HTTP 429 remains a terminal typed failure rather than full success.

## Known gaps / failures

- This disk-constrained sparse checkout reuses an existing dependency store. Package-wide typecheck and root `bun run verify` cannot resolve source directories and optional type packages intentionally omitted by the sparse checkout. The exact self-contained transport surface passes strict targeted TypeScript; all five changed files pass pinned package-local Biome, focused tests, externalized builds, and diff/evidence gates.
- No live Discord credential, guild, or channel was used. Live provider execution is a protected-credential acceptance hold, not a source-completion or draft hold.
- Independent subagent exact-head review is temporarily unavailable because the shared reviewer service reached its capacity limit. The source-complete PR remains ready for review as required; this is a review/merge hold, not a draft hold.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no revisioned contribute-to-eliza skill was used
Attribution status: self-reported
— [fix-23464]

## Post-review corrections

Exact head `317889efc32cc13ad3138d083de34372c864efdc` routes the gateway event-router POST/retry through the bounded transport, rejects raw message work before splitting, and applies monotonic/bodyless/null-reason deadline corrections with deterministic reader cancellation. Focused exact-head suites pass 26 tests / 57 assertions.
