### PR TITLE
fix(cloud): preserve agent-billing lease fencing across Postgres precision

### DIFF
--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -124,6 +124,12 @@ jobs:
         run: >-
           bun test --config=/dev/null --isolate
           packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-stuck-provisioning-lock.integration.test.ts
+      - name: Run PostgreSQL agent billing lease precision tests
+        env:
+          APPS_TENANT_DB_TEST_DSN: postgresql://postgres@127.0.0.1:5432/postgres
+        run: >-
+          bun test --config=/dev/null --isolate
+          packages/cloud/shared/src/db/repositories/__tests__/agent-billing-runs-postgres.integration.test.ts
       - name: Run cloud e2e tests
         run: bun run test:cloud:e2e
 

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-billing-runs-postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-billing-runs-postgres.integration.test.ts
@@ -62,6 +62,8 @@ async function cleanupHarnessOnce(): Promise<void> {
     try {
       await operation();
     } catch (error) {
+      // error-policy:J6 Teardown continues through every resource so the first
+      // cleanup failure does not leak the database or PostgreSQL process.
       firstError ??= error;
     }
   };
@@ -171,9 +173,11 @@ afterAll(cleanupHarness, 60_000);
 try {
   await initializeHarness();
 } catch (error) {
+  // error-policy:J2 Preserve initialization and cleanup failures together.
   try {
     await cleanupHarness();
   } catch (cleanupError) {
+    // error-policy:J2 Aggregate both causes instead of masking either failure.
     throw new AggregateError(
       [error, cleanupError],
       "PostgreSQL agent-billing harness initialization and cleanup both failed",

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-billing-runs-postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-billing-runs-postgres.integration.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Proves agent-billing lease fencing against real PostgreSQL timestamp
+ * precision. The harness injects a future lease with explicit microseconds so
+ * node-postgres must round-trip it through a millisecond-only Date.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { pushSchema } from "drizzle-kit/api";
+import { eq, sql } from "drizzle-orm";
+import { Client } from "pg";
+import {
+  acquireEphemeralPostgres,
+  type EphemeralPostgres,
+} from "../../../lib/services/tenant-db/__tests__/ephemeral-postgres";
+import { agentBillingRuns } from "../../schemas/compute-billing";
+
+const SKIP_REASON =
+  "[agent billing lease precision] SKIPPED - no real PostgreSQL available. " +
+  "Set APPS_TENANT_DB_EPHEMERAL=1 with Docker, or provide APPS_TENANT_DB_TEST_DSN.";
+const ORIGINAL_ENV = {
+  DATABASE_URL: process.env.DATABASE_URL,
+  TEST_DATABASE_URL: process.env.TEST_DATABASE_URL,
+  MOCK_REDIS: process.env.MOCK_REDIS,
+  NODE_ENV: process.env.NODE_ENV,
+};
+
+let postgres: EphemeralPostgres | null = await acquireEphemeralPostgres();
+let isolatedDatabaseName: string | null = null;
+let closeDatabaseConnectionsForTests:
+  | typeof import("../../client").closeDatabaseConnectionsForTests
+  | undefined;
+let dbWrite: typeof import("../../client").dbWrite | undefined;
+let agentBillingRunRepository:
+  | typeof import("../agent-billing-runs").agentBillingRunRepository
+  | undefined;
+
+function restoreEnv(name: keyof typeof ORIGINAL_ENV, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+async function createIsolatedDatabase(baseDsn: string): Promise<{
+  databaseName: string;
+  dsn: string;
+}> {
+  const databaseName = `eliza_agent_billing_lease_${randomUUID().replaceAll("-", "")}`;
+  const admin = new Client({ connectionString: baseDsn });
+  await admin.connect();
+  try {
+    await admin.query(`CREATE DATABASE "${databaseName}"`);
+  } finally {
+    await admin.end();
+  }
+  const url = new URL(baseDsn);
+  url.pathname = `/${databaseName}`;
+  return { databaseName, dsn: url.toString() };
+}
+
+async function dropIsolatedDatabase(baseDsn: string, databaseName: string): Promise<void> {
+  const admin = new Client({ connectionString: baseDsn });
+  await admin.connect();
+  try {
+    await admin.query(
+      "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+      [databaseName],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS "${databaseName}"`);
+  } finally {
+    await admin.end();
+  }
+}
+
+async function setLeaseWithSubmillisecondPrecision(runId: string): Promise<void> {
+  if (!dbWrite) throw new Error("real PostgreSQL harness was not initialized");
+  await dbWrite
+    .update(agentBillingRuns)
+    .set({
+      lease_expires_at: sql`date_trunc('milliseconds', clock_timestamp() + INTERVAL '5 minutes') + INTERVAL '456 microseconds'`,
+      updated_at: sql`date_trunc('milliseconds', clock_timestamp())`,
+    })
+    .where(eq(agentBillingRuns.id, runId));
+}
+
+async function readLeaseSubmillisecondPrecision(runId: string): Promise<number> {
+  if (!dbWrite) throw new Error("real PostgreSQL harness was not initialized");
+  const [row] = await dbWrite
+    .select({
+      submillisecond: sql<string>`mod(
+        extract(microseconds FROM ${agentBillingRuns.lease_expires_at})::bigint,
+        1000
+      )::text`,
+    })
+    .from(agentBillingRuns)
+    .where(eq(agentBillingRuns.id, runId));
+  if (!row) throw new Error("agent billing run was not found");
+  return Number(row.submillisecond);
+}
+
+if (!postgres) {
+  console.warn(SKIP_REASON);
+} else {
+  const isolated = await createIsolatedDatabase(postgres.dsn);
+  isolatedDatabaseName = isolated.databaseName;
+  process.env.DATABASE_URL = isolated.dsn;
+  process.env.TEST_DATABASE_URL = isolated.dsn;
+  process.env.MOCK_REDIS = "1";
+  process.env.NODE_ENV = "test";
+  const [clientModule, repositoryModule] = await Promise.all([
+    import("../../client"),
+    import("../agent-billing-runs"),
+  ]);
+  closeDatabaseConnectionsForTests = clientModule.closeDatabaseConnectionsForTests;
+  dbWrite = clientModule.dbWrite;
+  agentBillingRunRepository = repositoryModule.agentBillingRunRepository;
+}
+
+beforeAll(async () => {
+  if (!dbWrite) return;
+  const { apply } = await pushSchema({ agentBillingRuns } as never, dbWrite as never);
+  await apply();
+}, 60_000);
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests?.();
+  if (postgres && isolatedDatabaseName) {
+    await dropIsolatedDatabase(postgres.dsn, isolatedDatabaseName);
+  }
+  await postgres?.stop();
+  postgres = null;
+  for (const [name, value] of Object.entries(ORIGINAL_ENV)) {
+    restoreEnv(name as keyof typeof ORIGINAL_ENV, value);
+  }
+}, 60_000);
+
+const realPostgres = postgres ? describe : describe.skip;
+
+realPostgres("agent billing lease precision", () => {
+  test("renews and completes a submillisecond lease without weakening token fencing", async () => {
+    if (!dbWrite || !agentBillingRunRepository) {
+      throw new Error("real PostgreSQL harness was not initialized");
+    }
+    const input = {
+      invocationKey: `manual:agent-billing:lease-precision:${randomUUID()}`,
+      triggerKind: "manual" as const,
+      schedule: null,
+      scheduledAt: null,
+      leaseDurationMs: 5 * 60_000,
+    };
+    const first = await agentBillingRunRepository.startOrLoad(input);
+    if (!first.leaseToken) throw new Error("expected initial lease token");
+
+    await dbWrite
+      .update(agentBillingRuns)
+      .set({
+        lease_expires_at: sql`date_trunc('milliseconds', clock_timestamp() - INTERVAL '1 second')`,
+        updated_at: sql`date_trunc('milliseconds', clock_timestamp() - INTERVAL '2 seconds')`,
+      })
+      .where(eq(agentBillingRuns.id, first.run.id));
+    const recovered = await agentBillingRunRepository.startOrLoad(input);
+    if (!recovered.leaseToken) throw new Error("expected recovered lease token");
+    expect(recovered.leaseToken).not.toBe(first.leaseToken);
+
+    await setLeaseWithSubmillisecondPrecision(first.run.id);
+    expect(await readLeaseSubmillisecondPrecision(first.run.id)).toBe(456);
+    await expect(
+      agentBillingRunRepository.renewLease(first.run.id, first.leaseToken, 5 * 60_000),
+    ).rejects.toMatchObject({ code: "AGENT_BILLING_RUN_LEASE_LOST" });
+    await expect(
+      agentBillingRunRepository.complete(first.run.id, first.leaseToken, {
+        status: "succeeded",
+        sandboxesProcessed: 1,
+        sandboxesBilled: 1,
+        warningsSent: 0,
+        sandboxesShutdown: 0,
+        errors: 0,
+        totalRevenue: "0.100000",
+        errorSamples: [],
+      }),
+    ).rejects.toMatchObject({ code: "AGENT_BILLING_RUN_LEASE_LOST" });
+
+    const renewed = await agentBillingRunRepository.renewLease(
+      first.run.id,
+      recovered.leaseToken,
+      5 * 60_000,
+    );
+    expect(renewed).toMatchObject({
+      id: first.run.id,
+      status: "started",
+      lease_token: recovered.leaseToken,
+    });
+    expect(await readLeaseSubmillisecondPrecision(first.run.id)).toBe(0);
+
+    await setLeaseWithSubmillisecondPrecision(first.run.id);
+    expect(await readLeaseSubmillisecondPrecision(first.run.id)).toBe(456);
+    const completionInput = {
+      status: "succeeded" as const,
+      sandboxesProcessed: 1,
+      sandboxesBilled: 1,
+      warningsSent: 0,
+      sandboxesShutdown: 0,
+      errors: 0,
+      totalRevenue: "0.100000",
+      errorSamples: [],
+    };
+    const completions = await Promise.all([
+      agentBillingRunRepository.complete(first.run.id, recovered.leaseToken, completionInput),
+      agentBillingRunRepository.complete(first.run.id, recovered.leaseToken, completionInput),
+    ]);
+    expect(completions.map((result) => result.completedByCaller).sort()).toEqual([false, true]);
+    expect(completions.map((result) => result.terminalReplay).sort()).toEqual([false, true]);
+    expect(completions[0]!.run).toEqual(completions[1]!.run);
+    expect(completions[0]!.run).toMatchObject({
+      id: first.run.id,
+      status: "succeeded",
+      lease_token: recovered.leaseToken,
+      lease_expires_at: null,
+    });
+
+    const fresh = await agentBillingRunRepository.startOrLoad({
+      ...input,
+      invocationKey: `manual:agent-billing:lease-normalization:${randomUUID()}`,
+    });
+    expect(await readLeaseSubmillisecondPrecision(fresh.run.id)).toBe(0);
+  }, 30_000);
+});

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-billing-runs-postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-billing-runs-postgres.integration.test.ts
@@ -25,8 +25,9 @@ const ORIGINAL_ENV = {
   NODE_ENV: process.env.NODE_ENV,
 };
 
-let postgres: EphemeralPostgres | null = await acquireEphemeralPostgres();
+let postgres: EphemeralPostgres | null = null;
 let isolatedDatabaseName: string | null = null;
+let cleanupPromise: Promise<void> | null = null;
 let closeDatabaseConnectionsForTests:
   | typeof import("../../client").closeDatabaseConnectionsForTests
   | undefined;
@@ -40,35 +41,103 @@ function restoreEnv(name: keyof typeof ORIGINAL_ENV, value: string | undefined):
   else process.env[name] = value;
 }
 
-async function createIsolatedDatabase(baseDsn: string): Promise<{
-  databaseName: string;
-  dsn: string;
-}> {
-  const databaseName = `eliza_agent_billing_lease_${randomUUID().replaceAll("-", "")}`;
+async function createIsolatedDatabase(baseDsn: string, databaseName: string): Promise<string> {
+  const url = new URL(baseDsn);
+  url.pathname = `/${databaseName}`;
   const admin = new Client({ connectionString: baseDsn });
-  await admin.connect();
   try {
+    await admin.connect();
     await admin.query(`CREATE DATABASE "${databaseName}"`);
   } finally {
     await admin.end();
   }
-  const url = new URL(baseDsn);
-  url.pathname = `/${databaseName}`;
-  return { databaseName, dsn: url.toString() };
+  return url.toString();
 }
 
-async function dropIsolatedDatabase(baseDsn: string, databaseName: string): Promise<void> {
-  const admin = new Client({ connectionString: baseDsn });
-  await admin.connect();
-  try {
-    await admin.query(
-      "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
-      [databaseName],
-    );
-    await admin.query(`DROP DATABASE IF EXISTS "${databaseName}"`);
-  } finally {
-    await admin.end();
+async function cleanupHarnessOnce(): Promise<void> {
+  const acquiredPostgres = postgres;
+  const databaseToDrop = isolatedDatabaseName;
+  let firstError: unknown;
+  const capture = async (operation: () => Promise<void>): Promise<void> => {
+    try {
+      await operation();
+    } catch (error) {
+      firstError ??= error;
+    }
+  };
+
+  await capture(async () => {
+    await closeDatabaseConnectionsForTests?.();
+  });
+  closeDatabaseConnectionsForTests = undefined;
+  dbWrite = undefined;
+  agentBillingRunRepository = undefined;
+
+  if (acquiredPostgres && databaseToDrop) {
+    let admin: Client | undefined;
+    let connected = false;
+    await capture(async () => {
+      admin = new Client({ connectionString: acquiredPostgres.dsn });
+      await admin.connect();
+      connected = true;
+    });
+    if (admin && connected) {
+      await capture(async () => {
+        await admin?.query(
+          "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+          [databaseToDrop],
+        );
+      });
+      await capture(async () => {
+        await admin?.query(`DROP DATABASE IF EXISTS "${databaseToDrop}"`);
+      });
+    }
+    if (admin) {
+      await capture(async () => {
+        await admin?.end();
+      });
+    }
   }
+
+  await capture(async () => {
+    await acquiredPostgres?.stop();
+  });
+  postgres = null;
+  isolatedDatabaseName = null;
+
+  for (const [name, value] of Object.entries(ORIGINAL_ENV)) {
+    await capture(async () => {
+      restoreEnv(name as keyof typeof ORIGINAL_ENV, value);
+    });
+  }
+
+  if (firstError) throw firstError;
+}
+
+function cleanupHarness(): Promise<void> {
+  cleanupPromise ??= cleanupHarnessOnce();
+  return cleanupPromise;
+}
+
+async function initializeHarness(): Promise<void> {
+  postgres = await acquireEphemeralPostgres();
+  if (!postgres) {
+    console.warn(SKIP_REASON);
+    return;
+  }
+
+  isolatedDatabaseName = `eliza_agent_billing_lease_${randomUUID().replaceAll("-", "")}`;
+  const isolatedDsn = await createIsolatedDatabase(postgres.dsn, isolatedDatabaseName);
+  process.env.DATABASE_URL = isolatedDsn;
+  process.env.TEST_DATABASE_URL = isolatedDsn;
+  process.env.MOCK_REDIS = "1";
+  process.env.NODE_ENV = "test";
+
+  const clientModule = await import("../../client");
+  closeDatabaseConnectionsForTests = clientModule.closeDatabaseConnectionsForTests;
+  dbWrite = clientModule.dbWrite;
+  const repositoryModule = await import("../agent-billing-runs");
+  agentBillingRunRepository = repositoryModule.agentBillingRunRepository;
 }
 
 async function setLeaseWithSubmillisecondPrecision(runId: string): Promise<void> {
@@ -97,40 +166,26 @@ async function readLeaseSubmillisecondPrecision(runId: string): Promise<number> 
   return Number(row.submillisecond);
 }
 
-if (!postgres) {
-  console.warn(SKIP_REASON);
-} else {
-  const isolated = await createIsolatedDatabase(postgres.dsn);
-  isolatedDatabaseName = isolated.databaseName;
-  process.env.DATABASE_URL = isolated.dsn;
-  process.env.TEST_DATABASE_URL = isolated.dsn;
-  process.env.MOCK_REDIS = "1";
-  process.env.NODE_ENV = "test";
-  const [clientModule, repositoryModule] = await Promise.all([
-    import("../../client"),
-    import("../agent-billing-runs"),
-  ]);
-  closeDatabaseConnectionsForTests = clientModule.closeDatabaseConnectionsForTests;
-  dbWrite = clientModule.dbWrite;
-  agentBillingRunRepository = repositoryModule.agentBillingRunRepository;
+afterAll(cleanupHarness, 60_000);
+
+try {
+  await initializeHarness();
+} catch (error) {
+  try {
+    await cleanupHarness();
+  } catch (cleanupError) {
+    throw new AggregateError(
+      [error, cleanupError],
+      "PostgreSQL agent-billing harness initialization and cleanup both failed",
+    );
+  }
+  throw error;
 }
 
 beforeAll(async () => {
   if (!dbWrite) return;
   const { apply } = await pushSchema({ agentBillingRuns } as never, dbWrite as never);
   await apply();
-}, 60_000);
-
-afterAll(async () => {
-  await closeDatabaseConnectionsForTests?.();
-  if (postgres && isolatedDatabaseName) {
-    await dropIsolatedDatabase(postgres.dsn, isolatedDatabaseName);
-  }
-  await postgres?.stop();
-  postgres = null;
-  for (const [name, value] of Object.entries(ORIGINAL_ENV)) {
-    restoreEnv(name as keyof typeof ORIGINAL_ENV, value);
-  }
 }, 60_000);
 
 const realPostgres = postgres ? describe : describe.skip;

--- a/packages/cloud/shared/src/db/repositories/agent-billing-runs.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-billing-runs.ts
@@ -5,7 +5,7 @@
  */
 
 import { ElizaError } from "@elizaos/core";
-import { and, asc, eq, sql } from "drizzle-orm";
+import { and, asc, eq, gt, sql } from "drizzle-orm";
 import type { DbTransaction } from "../client";
 import { dbWrite } from "../helpers";
 import {
@@ -321,7 +321,7 @@ export class AgentBillingRunRepository {
             started_at: sql`date_trunc('milliseconds', clock_timestamp())`,
             billing_cutoff_at: sql`date_trunc('milliseconds', clock_timestamp())`,
             lease_token: leaseToken,
-            lease_expires_at: sql`clock_timestamp() + ${leaseDurationMs} * INTERVAL '1 millisecond'`,
+            lease_expires_at: sql`date_trunc('milliseconds', clock_timestamp()) + ${leaseDurationMs} * INTERVAL '1 millisecond'`,
             created_at: sql`date_trunc('milliseconds', clock_timestamp())`,
             updated_at: sql`date_trunc('milliseconds', clock_timestamp())`,
           })
@@ -466,7 +466,7 @@ export class AgentBillingRunRepository {
             eq(agentBillingRuns.id, existing.id),
             eq(agentBillingRuns.status, "started"),
             eq(agentBillingRuns.lease_token, leaseToken),
-            eq(agentBillingRuns.lease_expires_at, existing.lease_expires_at),
+            gt(agentBillingRuns.lease_expires_at, sql`clock_timestamp()`),
           ),
         )
         .returning();
@@ -532,7 +532,7 @@ export class AgentBillingRunRepository {
             eq(agentBillingRuns.id, existing.id),
             eq(agentBillingRuns.status, "started"),
             eq(agentBillingRuns.lease_token, leaseToken),
-            eq(agentBillingRuns.lease_expires_at, existing.lease_expires_at),
+            gt(agentBillingRuns.lease_expires_at, sql`clock_timestamp()`),
           ),
         )
         .returning();


### PR DESCRIPTION
# Relates to

Relates to #22983. Follow-up to #23219 and the live broken-window classification on #22553.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      baseline blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      real-PostgreSQL regression evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ce20804092dc9503a772d7d9ab6d135939b5bb0e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on the latest `origin/develop` at `ce20804092dc9503a772d7d9ab6d135939b5bb0e`; zero conflicts.
- [x] `bun run verify` was run post-sync; its exact unrelated `@elizaos/ui`
      lint blocker is documented in **Known gaps / failures** below.

# Risks

Medium. This changes the lease fence used by the production hourly agent-billing
sweep. The patch preserves the existing row lock, status fence, and UUID lease
token, replaces only a lossy timestamp equality with a database-clock expiry
predicate, and adds a real PostgreSQL concurrency regression. It changes no
price, billable predicate, debit arithmetic, schedule, schema, or provider call.

# Background

## What does this PR do?

- Normalizes newly created billing-run leases to JavaScript-safe millisecond
  precision.
- Keeps `id + status + lease_token` as the stable fencing authority and checks
  `lease_expires_at > clock_timestamp()` inside PostgreSQL for renew/finalize.
- Adds a real PostgreSQL test that injects a future lease with `+456` microseconds,
  rejects the old token, renews the active token, and proves exactly one winner
  across concurrent completion calls.
- Registers teardown before PostgreSQL acquisition/import and makes cleanup
  idempotent and exhaustive across initialization failures.
- Runs that regression explicitly in the existing PostgreSQL Cloud Tests lane.

Production Workers Observability showed the same pre-selection failure at 19:00,
20:00, and 21:00 UTC on 2026-08-21 and at 00:00, 01:00, 02:00, and 03:00 UTC on
2026-08-22: the biller failed, receipt finalization failed, and the route returned
HTTP 500. The logs do not expose the internal error code. The control flow plus
the real-PostgreSQL precision regression strongly corroborate the lossy timestamp
CAS as the cause; recovery remains unproven until an authorized deployment and a
subsequent hourly observation.

## What kind of change is this?

Bug fix (non-breaking billing-run lease fencing correction).

# Documentation changes needed?

No project documentation change is needed. The public API and operator contract
are unchanged; the corrected precision invariant is captured in the repository
test and CI lane.

# Testing

## Where should a reviewer start?

Start with `packages/cloud/shared/src/db/repositories/agent-billing-runs.ts`, then
the new `agent-billing-runs-postgres.integration.test.ts`, and finally the
PostgreSQL step in `.github/workflows/cloud-tests.yml`.

## Detailed testing steps

```bash
bun install --frozen-lockfile
bun test --config=/dev/null --timeout=60000 --isolate \
  packages/cloud/shared/src/db/repositories/__tests__/agent-billing-runs.pglite.test.ts \
  packages/cloud/api/cron/agent-billing/route.receipts.pglite.test.ts \
  packages/cloud/api/cron/agent-billing/route.full-flow.pglite.test.ts \
  packages/cloud/api/cron/agent-billing/route.test.ts

# Point APPS_TENANT_DB_TEST_DSN at a disposable real PostgreSQL superuser DB.
APPS_TENANT_DB_TEST_DSN=postgresql://127.0.0.1:55439/postgres?sslmode=disable \
  bun test --config=/dev/null --timeout=60000 --isolate \
  packages/cloud/shared/src/db/repositories/__tests__/agent-billing-runs-postgres.integration.test.ts

bun run --cwd packages/cloud/shared typecheck
bun run --cwd packages/cloud/shared lint:check
actionlint -config-file .github/actionlint.yaml .github/workflows/cloud-tests.yml
git diff --check origin/develop...HEAD
bun run verify
```

Exact-head results: frozen install had no changes; 36 PGlite/route tests passed
with 234 assertions; the PostgreSQL 17 regression passed with 12 assertions;
cloud-shared typecheck, its 2,279-file Biome lane, actionlint, and diff hygiene
passed. Earlier independent reviews found no P0-P3 issue; a fresh explicit review
of this rebased exact head is requested below.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:d52128cd82deedff2aa2bcd86180046e5e48ca0b -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Repository, PostgreSQL, and workflow-only change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - Repository, PostgreSQL, and workflow-only change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No interactive or rendered user flow is changed.
<!-- evidence-row:backend-logs -->
- [x] [24062-agent-billing-backend-verification-b362071.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24062-agent-billing-backend-verification-b362071.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend request, response, console, or state path is changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No agent, action, provider, prompt, or model behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [x] [24062-agent-billing-postgres-domain-b362071.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24062-agent-billing-postgres-domain-b362071.txt)
<!-- evidence-row:ocr-review -->
- [ ] N/A - The diff has no rendered visual surface or visual text.

# Evidence Details

## Real LLM-call trajectory

N/A - No agent, action, provider, prompt, or model behavior is changed.

## Backend + frontend logs

The exact-head backend and PostgreSQL domain artifact is attached in the evidence
rows above. Frontend logs are N/A because this diff has no frontend code.

## Screenshots (before / after) + video walkthrough

N/A - The diff has no rendered UI or interactive user flow.

## Audio / voice walkthrough

N/A - No voice, transcript, TTS, STT, or omnivoice behavior is changed.

## Known gaps / failures

- `bun run verify` exits in the untouched `@elizaos/ui#lint:check` task after 73
  successful Turbo tasks. The inherited baseline reports a formatter error in
  `packages/ui/src/components/chat/widgets/maps-card.tsx`, plus `document.cookie`
  diagnostics in SSO tests. This branch touches none of those files; focused
  gates pass.
- The cached local Docker layer for `postgres:16-alpine` is unreadable in this
  workspace (`containerd` I/O error before test startup). The real integration
  proof therefore used a disposable Homebrew PostgreSQL 17 cluster; it passed,
  then its process and temporary directory were verified absent. The checked-in
  CI lane uses the repository's clean PostgreSQL service container.
- No deployment, live cron invocation, production database query, secret change,
  or provider call was performed. Live recovery still requires a maintainer merge,
  authorized deployment, and a sliced observation of a subsequent hourly window;
  #22983 must remain open until that proof exists.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@ce20804092dc9503a772d7d9ab6d135939b5bb0e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-billing-v3-agent-biller-recovery]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@ce20804092dc9503a772d7d9ab6d135939b5bb0e:packages/skills/skills/contribute-to-eliza"} -->

## Maintainer exact-head review

Restacked cleanly onto `develop@92f841367c56c79d76e08fc52fc82a09bb102104`. The production patch remained unchanged. The harness catches now carry the required J2/J6 error-policy classifications.

Independent exact-head results at `d52128cd82deedff2aa2bcd86180046e5e48ca0b`: PGlite repository suite 7/7 with 39 assertions; no-PostgreSQL cleanup/skip path 1/1; focused Biome, actionlint, and diff hygiene passed. The attached real-PostgreSQL artifact remains patch-equivalent and proves the microsecond lease plus concurrent completion behavior. The sparse-checkout package typecheck was invalidated by its temporary dependency link farm (two PGlite versions and absent optional workspaces) and emitted no changed-file diagnostic.

Maintainer AI provider/model: OpenAI / gpt-5
Maintainer client / agent tooling: Codex
Maintainer attribution status: system-confirmed
— [codex-maintainer-exact-head-24062]
