### PR TITLE
fix(cloud): compose and bound onboarding hop deadlines

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
@@ -1,8 +1,7 @@
-// Pins the fail-closed contract of the onboarding phone-link path: a genuine
-// linkPhoneToUser infra failure must PROPAGATE out of runOnboardingChat, while
-// its designed tenant-safety decline (success:false) stays a distinguishable
-// non-throwing outcome that lets onboarding continue. Deterministic lib
-// fixtures (no live model, no network).
+/**
+ * Pins onboarding phone-link and internal-hop failures with deterministic
+ * service fixtures and transport streams; no live model or network is used.
+ */
 import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import * as realCloudBindings from "../../runtime/cloud-bindings";
 import * as provisioningObservation from "./provisioning-observation";
@@ -345,6 +344,55 @@ describe("onboardingFetch — bounded hops fail closed and keep caller signals",
       onboardingFetch(stub, "https://onboarding.internal/resolve"),
     ).rejects.toMatchObject({ code: "ONBOARDING_RESPONSE_TOO_LARGE" });
     expect(cancelled).toBe(true);
+  });
+
+  test("bounds retained storage across many one-byte transport chunks", async () => {
+    const chunkCount = 16_384;
+    let emitted = 0;
+    const stub = {
+      fetch: async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              if (emitted === chunkCount) {
+                controller.close();
+                return;
+              }
+              emitted += 1;
+              controller.enqueue(Uint8Array.of(97));
+            },
+          }),
+        ),
+    };
+
+    const response = await onboardingFetch(stub, "https://onboarding.internal/resolve");
+    expect((await response.arrayBuffer()).byteLength).toBe(chunkCount);
+    expect(emitted).toBe(chunkCount);
+  });
+
+  test("drops decoded representation headers when returning the buffered body", async () => {
+    const stub = {
+      fetch: async () =>
+        new Response("decoded", {
+          headers: {
+            "content-encoding": "gzip",
+            "content-length": "1",
+            "content-type": "application/json",
+            trailer: "content-digest",
+            "transfer-encoding": "chunked",
+            "x-request-id": "request-1",
+          },
+        }),
+    };
+
+    const response = await onboardingFetch(stub, "https://onboarding.internal/resolve");
+    expect(await response.text()).toBe("decoded");
+    expect(response.headers.get("content-encoding")).toBeNull();
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("trailer")).toBeNull();
+    expect(response.headers.get("transfer-encoding")).toBeNull();
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get("x-request-id")).toBe("request-1");
   });
 
   test("does not dispatch when the caller is already aborted", async () => {

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
@@ -3,7 +3,7 @@
 // its designed tenant-safety decline (success:false) stays a distinguishable
 // non-throwing outcome that lets onboarding continue. Deterministic lib
 // fixtures (no live model, no network).
-import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import * as realCloudBindings from "../../runtime/cloud-bindings";
 import * as provisioningObservation from "./provisioning-observation";
 
@@ -26,6 +26,10 @@ mock.module("../../cache/client", () => ({
 mock.module("../../runtime/cloud-bindings", () => ({
   ...REAL_CLOUD_BINDINGS,
   getCloudAwareEnv: mock(() => cloudEnv),
+}));
+
+mock.module("../../utils/phone-normalization", () => ({
+  normalizePhoneNumber: (value: string) => value,
 }));
 
 mock.module("../eliza-managed-launch", () => ({
@@ -144,22 +148,144 @@ describe("onboardingFetch — bounded hops fail closed and keep caller signals",
     expect(Date.now() - start).toBeLessThan(5_000);
   });
 
-  test("composes a caller-provided abort signal with the hop deadline", async () => {
+  test("keeps the deadline when a caller signal never aborts", async () => {
     let seen: AbortSignal | undefined;
     const stub = {
-      fetch: async (_input: RequestInfo | URL, init?: RequestInit) => {
-        seen = init?.signal;
-        return new Response("{}", { status: 200 });
+      fetch: (_input: RequestInfo | URL, init?: RequestInit) => {
+        seen = init?.signal ?? undefined;
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+        });
       },
     };
     const controller = new AbortController();
-    await onboardingFetch(stub, "https://onboarding.internal/resolve", {
+    await expect(
+      onboardingFetch(
+        stub,
+        "https://onboarding.internal/resolve",
+        { signal: controller.signal },
+        100,
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(seen).not.toBe(controller.signal);
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  test("propagates caller cancellation through the composed signal", async () => {
+    let seen: AbortSignal | undefined;
+    const stub = {
+      fetch: (_input: RequestInfo | URL, init?: RequestInit) => {
+        seen = init?.signal ?? undefined;
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+        });
+      },
+    };
+    const controller = new AbortController();
+    const pending = onboardingFetch(stub, "https://onboarding.internal/resolve", {
       signal: controller.signal,
     });
-    // The wrapper owns the deadline, so the signal handed to the transport is
-    // a composition of the caller's signal and that deadline — never the caller's
-    // object verbatim. Asserting identity here would pin the very behavior that
-    // lets a never-firing caller signal defeat the bound.
-    expect(seen).not.toBe(controller.signal);
+    controller.abort(new DOMException("caller stopped", "AbortError"));
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(seen?.aborted).toBe(true);
+  });
+
+  test("bounds a response body that never completes", async () => {
+    let cancelled = false;
+    const stub = {
+      fetch: async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("{"));
+            },
+            cancel() {
+              cancelled = true;
+            },
+          }),
+        ),
+    };
+    await expect(
+      onboardingFetch(stub, "https://onboarding.internal/resolve", undefined, 100),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(cancelled).toBe(true);
+  });
+
+  test("clears the deadline and caller listener after a successful bounded body read", async () => {
+    let seen: AbortSignal | undefined;
+    const controller = new AbortController();
+    const clearTimer = spyOn(globalThis, "clearTimeout");
+    const removeListener = spyOn(controller.signal, "removeEventListener");
+    const stub = {
+      fetch: async (_input: RequestInfo | URL, init?: RequestInit) => {
+        seen = init?.signal ?? undefined;
+        return new Response("{}");
+      },
+    };
+    try {
+      const response = await onboardingFetch(stub, "https://onboarding.internal/resolve", {
+        signal: controller.signal,
+      });
+      expect(await response.json()).toEqual({});
+      expect(seen?.aborted).toBe(false);
+      expect(clearTimer).toHaveBeenCalled();
+      expect(removeListener).toHaveBeenCalledWith("abort", expect.any(Function));
+    } finally {
+      clearTimer.mockRestore();
+      removeListener.mockRestore();
+    }
+  });
+
+  test("rejects an oversized body before returning it to a JSON caller", async () => {
+    const stub = {
+      fetch: async () =>
+        new Response(new Uint8Array(1024 * 1024 + 1), {
+          headers: { "content-type": "application/json" },
+        }),
+    };
+    await expect(
+      onboardingFetch(stub, "https://onboarding.internal/resolve"),
+    ).rejects.toMatchObject({ code: "ONBOARDING_RESPONSE_TOO_LARGE" });
+  });
+
+  test("rejects and cancels a declared oversized body before reading", async () => {
+    let cancelled = false;
+    const stub = {
+      fetch: async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            cancel() {
+              cancelled = true;
+            },
+          }),
+          { headers: { "content-length": String(1024 * 1024 + 1) } },
+        ),
+    };
+    await expect(
+      onboardingFetch(stub, "https://onboarding.internal/resolve"),
+    ).rejects.toMatchObject({ code: "ONBOARDING_RESPONSE_TOO_LARGE" });
+    expect(cancelled).toBe(true);
+  });
+
+  test("does not dispatch when the caller is already aborted", async () => {
+    const controller = new AbortController();
+    const reason = new Error("cancelled before dispatch");
+    controller.abort(reason);
+    const fetch = mock(async () => new Response("{}"));
+
+    await expect(
+      onboardingFetch({ fetch }, "https://onboarding.internal/resolve", {
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(reason);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test("rejects an invalid deadline before dispatch", async () => {
+    const fetch = mock(async () => new Response("{}"));
+    await expect(
+      onboardingFetch({ fetch }, "https://onboarding.internal/resolve", undefined, 0),
+    ).rejects.toMatchObject({ code: "INVALID_ONBOARDING_TIMEOUT" });
+    expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
@@ -241,6 +241,38 @@ describe("onboardingFetch — bounded hops fail closed and keep caller signals",
     expect(cancelled).toBe(true);
   });
 
+  test("preserves the caller reason when stream cancellation rejects differently", async () => {
+    const controller = new AbortController();
+    const reason = new DOMException("caller owns this reason", "AbortError");
+    const transportFailure = new Error("transport cancellation failed");
+    let releasePull!: () => void;
+    const blockedPull = new Promise<void>((resolve) => {
+      releasePull = resolve;
+    });
+    const stub = {
+      fetch: async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            async pull() {
+              await blockedPull;
+            },
+            cancel() {
+              throw transportFailure;
+            },
+          }),
+        ),
+    };
+
+    const pending = onboardingFetch(stub, "https://onboarding.internal/resolve", {
+      signal: controller.signal,
+    });
+    await Promise.resolve();
+    controller.abort(reason);
+    releasePull();
+
+    await expect(pending).rejects.toBe(reason);
+  });
+
   test("does not let a bodyless response win over caller cancellation", async () => {
     const controller = new AbortController();
     const reason = new DOMException("caller stopped after headers", "AbortError");

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
@@ -211,6 +211,54 @@ describe("onboardingFetch — bounded hops fail closed and keep caller signals",
     expect(cancelled).toBe(true);
   });
 
+  test("enforces the wall-clock deadline across immediately-ready empty chunks", async () => {
+    let cancelled = false;
+    let emitted = 0;
+    const stub = {
+      fetch: async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              if (emitted < 100_000) {
+                emitted += 1;
+                controller.enqueue(new Uint8Array(0));
+                return;
+              }
+              controller.close();
+            },
+            cancel() {
+              cancelled = true;
+            },
+          }),
+        ),
+    };
+    const startedAt = performance.now();
+    await expect(
+      onboardingFetch(stub, "https://onboarding.internal/resolve", undefined, 1),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
+    expect(emitted).toBeLessThan(100_000);
+    expect(cancelled).toBe(true);
+  });
+
+  test("does not let a bodyless response win over caller cancellation", async () => {
+    const controller = new AbortController();
+    const reason = new DOMException("caller stopped after headers", "AbortError");
+    const stub = {
+      fetch: async () => {
+        const response = new Response(null, { status: 204 });
+        queueMicrotask(() => controller.abort(reason));
+        return response;
+      },
+    };
+
+    await expect(
+      onboardingFetch(stub, "https://onboarding.internal/resolve", {
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(reason);
+  });
+
   test("clears the deadline and caller listener after a successful bounded body read", async () => {
     let seen: AbortSignal | undefined;
     const controller = new AbortController();
@@ -278,6 +326,23 @@ describe("onboardingFetch — bounded hops fail closed and keep caller signals",
         signal: controller.signal,
       }),
     ).rejects.toBe(reason);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test("preserves an explicit null caller-abort reason", async () => {
+    const controller = new AbortController();
+    controller.abort(null);
+    const fetch = mock(async () => new Response("{}"));
+
+    let rejection: unknown = Symbol("not rejected");
+    try {
+      await onboardingFetch({ fetch }, "https://onboarding.internal/resolve", {
+        signal: controller.signal,
+      });
+    } catch (reason) {
+      rejection = reason;
+    }
+    expect(rejection).toBeNull();
     expect(fetch).not.toHaveBeenCalled();
   });
 

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -85,6 +85,10 @@ async function bufferOnboardingResponse(
       const next = await reader.read();
       throwIfAbortedOrExpired();
       if (next.done) break;
+      // Empty fragments do not contribute to the bounded payload. Retaining
+      // them would let a hostile stream grow the chunk-object inventory without
+      // consuming any of the byte budget.
+      if (next.value.byteLength === 0) continue;
       receivedBytes += next.value.byteLength;
       if (receivedBytes > ONBOARDING_RESPONSE_MAX_BYTES) {
         const error = new ElizaError("Onboarding hop response exceeds the byte limit", {
@@ -104,15 +108,24 @@ async function bufferOnboardingResponse(
       chunks.push(next.value);
     }
   } catch (error) {
+    let rejection = error;
     try {
-      await reader.cancel(error);
+      throwIfAbortedOrExpired();
+    } catch (abortOrDeadlineReason) {
+      // The composed signal is the authoritative cancellation boundary. A
+      // transport is allowed to reject its reader/cancel hooks with a different
+      // error, but callers must still observe the exact signal reason.
+      rejection = abortOrDeadlineReason;
+    }
+    try {
+      await reader.cancel(rejection);
     } catch (cause) {
       // error-policy:J6 The bounded read already failed; cancellation only releases the stream.
       logger.debug("[onboarding-chat] Failed to cancel rejected onboarding response body", {
         cause,
       });
     }
-    throw error;
+    throw rejection;
   } finally {
     signal.removeEventListener("abort", cancelBody);
     try {

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -28,23 +28,150 @@ import { type ElizaAppProvisioningStatus, getElizaAppProvisioningStatus } from "
 import { elizaAppUserService } from "./user-service";
 
 const ONBOARDING_REQUEST_TIMEOUT_MS = 10_000;
+const ONBOARDING_RESPONSE_MAX_BYTES = 1024 * 1024;
+
+function onboardingAbortError(message: string, name: "AbortError" | "TimeoutError"): DOMException {
+  return new DOMException(message, name);
+}
+
+async function bufferOnboardingResponse(
+  response: Response,
+  signal: AbortSignal,
+): Promise<Response> {
+  const rawContentLength = response.headers.get("content-length");
+  if (rawContentLength !== null && /^\d+$/.test(rawContentLength)) {
+    const declaredLength = Number(rawContentLength);
+    if (!Number.isSafeInteger(declaredLength) || declaredLength > ONBOARDING_RESPONSE_MAX_BYTES) {
+      const error = new ElizaError("Onboarding hop response exceeds the byte limit", {
+        code: "ONBOARDING_RESPONSE_TOO_LARGE",
+        context: { maxBytes: ONBOARDING_RESPONSE_MAX_BYTES, receivedBytes: declaredLength },
+      });
+      try {
+        await response.body?.cancel(error);
+      } catch (cause) {
+        // error-policy:J6 The response is rejected; cancellation only releases transport.
+        logger.debug("[onboarding-chat] Failed to cancel declared-oversize response body", {
+          cause,
+        });
+      }
+      throw error;
+    }
+  }
+  if (!response.body) return response;
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let receivedBytes = 0;
+  const cancelBody = (): void => {
+    // error-policy:J6 The request already failed; cancellation only releases the response stream.
+    reader.cancel(signal.reason).catch((cause: unknown) => {
+      logger.debug("[onboarding-chat] Failed to cancel aborted onboarding response body", {
+        cause,
+      });
+    });
+  };
+  signal.addEventListener("abort", cancelBody, { once: true });
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      receivedBytes += next.value.byteLength;
+      if (receivedBytes > ONBOARDING_RESPONSE_MAX_BYTES) {
+        const error = new ElizaError("Onboarding hop response exceeds the byte limit", {
+          code: "ONBOARDING_RESPONSE_TOO_LARGE",
+          context: { maxBytes: ONBOARDING_RESPONSE_MAX_BYTES, receivedBytes },
+        });
+        try {
+          await reader.cancel(error);
+        } catch (cause) {
+          // error-policy:J6 The bounded read already failed; cancellation only releases the stream.
+          logger.debug("[onboarding-chat] Failed to cancel oversized onboarding response body", {
+            cause,
+          });
+        }
+        throw error;
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    signal.removeEventListener("abort", cancelBody);
+    try {
+      reader.releaseLock();
+    } catch (cause) {
+      // error-policy:J6 Stream lock release is best-effort transport teardown.
+      logger.debug("[onboarding-chat] Failed to release onboarding response body lock", { cause });
+    }
+  }
+
+  const body = new Uint8Array(receivedBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new Response(body.buffer, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
 
 /**
  * Bound every onboarding coordinator / agent API hop so a hung or overloaded
- * Durable Object or agent cannot pin the onboarding worker indefinitely. A
- * caller-provided abort signal wins.
+ * Durable Object or agent cannot pin the onboarding worker indefinitely. The
+ * clearable deadline covers headers and a bounded body read, and composes with
+ * caller cancellation.
  */
-export function onboardingFetch(
+export async function onboardingFetch(
   stub: { fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> },
   input: string | URL,
   init?: RequestInit,
   timeoutMs: number = ONBOARDING_REQUEST_TIMEOUT_MS,
 ): Promise<Response> {
-  const deadline = AbortSignal.timeout(timeoutMs);
-  return stub.fetch(input, {
-    ...init,
-    signal: init?.signal ? AbortSignal.any([init.signal, deadline]) : deadline,
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > 2_147_483_647) {
+    throw new ElizaError("Onboarding hop timeout must be a positive timer-safe integer", {
+      code: "INVALID_ONBOARDING_TIMEOUT",
+      context: { timeoutMs },
+    });
+  }
+
+  const controller = new AbortController();
+  let rejectAbort!: (reason: unknown) => void;
+  const abortPromise = new Promise<never>((_resolve, reject) => {
+    rejectAbort = reject;
   });
+  const abort = (reason: unknown): void => {
+    if (controller.signal.aborted) return;
+    controller.abort(reason);
+    rejectAbort(reason);
+  };
+  const onCallerAbort = (): void => {
+    abort(
+      init?.signal?.reason ??
+        onboardingAbortError("The onboarding request was aborted.", "AbortError"),
+    );
+  };
+  init?.signal?.addEventListener("abort", onCallerAbort, { once: true });
+  if (init?.signal?.aborted) onCallerAbort();
+  const timeout = setTimeout(
+    () => abort(onboardingAbortError("The onboarding request deadline expired.", "TimeoutError")),
+    timeoutMs,
+  );
+
+  try {
+    if (controller.signal.aborted) return await abortPromise;
+    const response = await Promise.race([
+      stub.fetch(input, { ...init, signal: controller.signal }),
+      abortPromise,
+    ]);
+    return await Promise.race([
+      bufferOnboardingResponse(response, controller.signal),
+      abortPromise,
+    ]);
+  } finally {
+    clearTimeout(timeout);
+    init?.signal?.removeEventListener("abort", onCallerAbort);
+  }
 }
 
 export type OnboardingChatRole = "user" | "assistant";

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -28,7 +28,16 @@ import { type ElizaAppProvisioningStatus, getElizaAppProvisioningStatus } from "
 import { elizaAppUserService } from "./user-service";
 
 const ONBOARDING_REQUEST_TIMEOUT_MS = 10_000;
+// Coordinator replies are small JSON control documents. One MiB leaves room
+// for retained session history while keeping a single internal hop within a
+// fixed Worker-memory budget; larger histories must be bounded or paginated.
 const ONBOARDING_RESPONSE_MAX_BYTES = 1024 * 1024;
+const REBUFFERED_RESPONSE_HEADERS = [
+  "content-encoding",
+  "content-length",
+  "trailer",
+  "transfer-encoding",
+] as const;
 
 function onboardingAbortError(message: string, name: "AbortError" | "TimeoutError"): DOMException {
   return new DOMException(message, name);
@@ -65,7 +74,9 @@ async function bufferOnboardingResponse(
   }
 
   const reader = response.body.getReader();
-  const chunks: Uint8Array[] = [];
+  // Copy every view immediately so a one-byte chunk cannot retain a large
+  // transport-owned backing buffer or grow an unbounded chunk-object list.
+  const body = new Uint8Array(ONBOARDING_RESPONSE_MAX_BYTES);
   let receivedBytes = 0;
   const cancelBody = (): void => {
     // error-policy:J6 The request already failed; cancellation only releases the response stream.
@@ -89,11 +100,14 @@ async function bufferOnboardingResponse(
       // them would let a hostile stream grow the chunk-object inventory without
       // consuming any of the byte budget.
       if (next.value.byteLength === 0) continue;
-      receivedBytes += next.value.byteLength;
-      if (receivedBytes > ONBOARDING_RESPONSE_MAX_BYTES) {
+      const nextReceivedBytes = receivedBytes + next.value.byteLength;
+      if (nextReceivedBytes > ONBOARDING_RESPONSE_MAX_BYTES) {
         const error = new ElizaError("Onboarding hop response exceeds the byte limit", {
           code: "ONBOARDING_RESPONSE_TOO_LARGE",
-          context: { maxBytes: ONBOARDING_RESPONSE_MAX_BYTES, receivedBytes },
+          context: {
+            maxBytes: ONBOARDING_RESPONSE_MAX_BYTES,
+            receivedBytes: nextReceivedBytes,
+          },
         });
         try {
           await reader.cancel(error);
@@ -105,7 +119,8 @@ async function bufferOnboardingResponse(
         }
         throw error;
       }
-      chunks.push(next.value);
+      body.set(next.value, receivedBytes);
+      receivedBytes = nextReceivedBytes;
     }
   } catch (error) {
     let rejection = error;
@@ -136,25 +151,24 @@ async function bufferOnboardingResponse(
     }
   }
 
-  const body = new Uint8Array(receivedBytes);
-  let offset = 0;
-  for (const chunk of chunks) {
-    body.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
   throwIfAbortedOrExpired();
-  return new Response(body.buffer, {
+  const headers = new Headers(response.headers);
+  for (const header of REBUFFERED_RESPONSE_HEADERS) headers.delete(header);
+  const bufferedBody = receivedBytes === body.byteLength ? body : body.slice(0, receivedBytes);
+  return new Response(bufferedBody, {
     status: response.status,
     statusText: response.statusText,
-    headers: response.headers,
+    headers,
   });
 }
 
 /**
  * Bound every onboarding coordinator / agent API hop so a hung or overloaded
  * Durable Object or agent cannot pin the onboarding worker indefinitely. The
- * clearable deadline covers headers and a bounded body read, and composes with
- * caller cancellation.
+ * clearable deadline covers headers and a bounded, fully buffered body read,
+ * and composes with caller cancellation. The returned response preserves
+ * semantic headers but drops transport/representation headers invalidated by
+ * Fetch decoding and rebuffering.
  */
 export async function onboardingFetch(
   stub: { fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> },

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -37,7 +37,9 @@ function onboardingAbortError(message: string, name: "AbortError" | "TimeoutErro
 async function bufferOnboardingResponse(
   response: Response,
   signal: AbortSignal,
+  throwIfAbortedOrExpired: () => void,
 ): Promise<Response> {
+  throwIfAbortedOrExpired();
   const rawContentLength = response.headers.get("content-length");
   if (rawContentLength !== null && /^\d+$/.test(rawContentLength)) {
     const declaredLength = Number(rawContentLength);
@@ -57,7 +59,10 @@ async function bufferOnboardingResponse(
       throw error;
     }
   }
-  if (!response.body) return response;
+  if (!response.body) {
+    throwIfAbortedOrExpired();
+    return response;
+  }
 
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
@@ -73,7 +78,12 @@ async function bufferOnboardingResponse(
   signal.addEventListener("abort", cancelBody, { once: true });
   try {
     while (true) {
+      // An immediately-ready stream can starve the timer queue with an
+      // unbounded microtask chain, especially when chunks are empty. Enforce
+      // the monotonic wall-clock deadline inside the read loop as well.
+      throwIfAbortedOrExpired();
       const next = await reader.read();
+      throwIfAbortedOrExpired();
       if (next.done) break;
       receivedBytes += next.value.byteLength;
       if (receivedBytes > ONBOARDING_RESPONSE_MAX_BYTES) {
@@ -93,6 +103,16 @@ async function bufferOnboardingResponse(
       }
       chunks.push(next.value);
     }
+  } catch (error) {
+    try {
+      await reader.cancel(error);
+    } catch (cause) {
+      // error-policy:J6 The bounded read already failed; cancellation only releases the stream.
+      logger.debug("[onboarding-chat] Failed to cancel rejected onboarding response body", {
+        cause,
+      });
+    }
+    throw error;
   } finally {
     signal.removeEventListener("abort", cancelBody);
     try {
@@ -109,6 +129,7 @@ async function bufferOnboardingResponse(
     body.set(chunk, offset);
     offset += chunk.byteLength;
   }
+  throwIfAbortedOrExpired();
   return new Response(body.buffer, {
     status: response.status,
     statusText: response.statusText,
@@ -136,6 +157,11 @@ export async function onboardingFetch(
   }
 
   const controller = new AbortController();
+  const deadlineAt = performance.now() + timeoutMs;
+  const timeoutError = onboardingAbortError(
+    "The onboarding request deadline expired.",
+    "TimeoutError",
+  );
   let rejectAbort!: (reason: unknown) => void;
   const abortPromise = new Promise<never>((_resolve, reject) => {
     rejectAbort = reject;
@@ -146,28 +172,34 @@ export async function onboardingFetch(
     rejectAbort(reason);
   };
   const onCallerAbort = (): void => {
-    abort(
-      init?.signal?.reason ??
-        onboardingAbortError("The onboarding request was aborted.", "AbortError"),
-    );
+    if (!init?.signal) return;
+    abort(init.signal.reason);
   };
   init?.signal?.addEventListener("abort", onCallerAbort, { once: true });
   if (init?.signal?.aborted) onCallerAbort();
-  const timeout = setTimeout(
-    () => abort(onboardingAbortError("The onboarding request deadline expired.", "TimeoutError")),
-    timeoutMs,
-  );
+  const timeout = setTimeout(() => abort(timeoutError), timeoutMs);
+  const throwIfAbortedOrExpired = (): void => {
+    if (controller.signal.aborted) throw controller.signal.reason;
+    if (performance.now() >= deadlineAt) {
+      abort(timeoutError);
+      throw timeoutError;
+    }
+  };
 
   try {
     if (controller.signal.aborted) return await abortPromise;
+    throwIfAbortedOrExpired();
     const response = await Promise.race([
       stub.fetch(input, { ...init, signal: controller.signal }),
       abortPromise,
     ]);
-    return await Promise.race([
-      bufferOnboardingResponse(response, controller.signal),
+    throwIfAbortedOrExpired();
+    const buffered = await Promise.race([
+      bufferOnboardingResponse(response, controller.signal, throwIfAbortedOrExpired),
       abortPromise,
     ]);
+    throwIfAbortedOrExpired();
+    return buffered;
   } finally {
     clearTimeout(timeout);
     init?.signal?.removeEventListener("abort", onCallerAbort);


### PR DESCRIPTION
Fixes #23497.

## Status

**READY for source review at exact head `d75d33c6df23a75a5e970bb299657b8314742322`.**

The complete four-commit series was rebased without conflicts onto exact `develop@e1e8c1bb68119b3933c653336d7003d15812c7ca`. Exact tree: `2561ff1431e73d107bc1d07e03923df0ca0aded2`. Stable aggregate patch id: `e5d8a41cf67e5313212667a238348d4f093d2bab`.

## Outcome

- Replaces the onboarding `AbortSignal.timeout` hop with a clearable deadline that composes with caller cancellation.
- Applies the same 10-second operation deadline across transport headers and the fully buffered body.
- Rejects non-timer-safe deadlines before dispatch and preserves caller-owned abort reasons, including explicit `null`.
- Enforces the issue-required 1 MiB response ceiling. Accepted chunks are copied immediately into one fixed-capacity buffer, so tiny views cannot retain arbitrarily large transport backing stores or an unbounded chunk-object list.
- Cancels declared and streamed oversized bodies, cancels hung bodies on timeout, and removes timers/listeners/reader locks on terminal paths.
- Reconstructed responses preserve semantic headers while dropping `content-encoding`, `content-length`, `trailer`, and `transfer-encoding`, which are invalid after Fetch decoding and rebuffering.
- Documents that the returned response is fully buffered; larger onboarding histories must be bounded or paginated instead of consuming unbounded Worker memory.

## Exact-head validation

Validation on `d75d33c6df23a75a5e970bb299657b8314742322`:

- `bun test ./packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts` — **18 passed, 0 failed, 48 assertions**.
- The suite covers hung transport/body, caller cancellation, monotonic deadline enforcement, exact abort reasons, zero-dispatch invalid input, fixed-storage many-one-byte chunking, declared/streamed oversize cancellation, decoded-header stripping, semantic-header preservation, and teardown cleanup.
- Package-pinned Biome over both changed files — **passed**.
- Externalized Bun builds for both changed files — **passed**.
- `git diff --check` — **passed**.
- Guide parity — **160 tracked CLAUDE.md/AGENTS.md pairs passed**.
- Independent exact-head audit — **source-complete; no correctness, security, resource-bound, or cleanup blocker**.
- Four-commit `git range-diff` across the final rebase — **all commits patch-equivalent**.

Exact-head hosted CI and reviewer approval remain normal ready-state merge holds. They are not reasons to return this PR to draft.

## Evidence gate

<!-- evidence-head:d75d33c6df23a75a5e970bb299657b8314742322 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - internal onboarding transport logic has no rendered UI.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - internal onboarding transport logic has no rendered UI.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - deadline, cancellation, byte-cap, and cleanup behavior is verified at the deterministic transport boundary.`
<!-- evidence-row:backend-logs -->
- [x] Exact-head command counts and failure boundaries are recorded under Exact-head validation.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend path changed.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model, prompt, provider, or planning behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - request, stream, cancellation, and response assertions are executable tests rather than retained domain artifacts.`
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual text.`

## Risk and rollback

Risk is low and confined to the internal onboarding coordinator/agent fetch boundary. Rollback is the PR revert. The 1 MiB cap intentionally fails closed for unexpectedly large internal responses.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no revisioned contribute-to-eliza skill was used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no revisioned contribute-to-eliza skill was used
Attribution status: self-reported
— [fix-23497]
