### PR TITLE
fix(core): sanitize JSON-array action params

### DIFF
--- a/packages/core/src/actions-param-array.surrogate.test.ts
+++ b/packages/core/src/actions-param-array.surrogate.test.ts
@@ -1,8 +1,11 @@
 /**
- * Regression for action parameter array split capping surrogate safety (10,000).
+ * Regression for action parameter array split capping and JSON coercion
+ * surrogate safety.
  */
 
 import { describe, expect, it } from "vitest";
+import { validateActionParams } from "./actions";
+import type { Action } from "./types";
 import {
 	toWellFormedUnicode,
 	truncateWellFormed,
@@ -68,5 +71,28 @@ describe("action param array split surrogate safety", () => {
 			expect(isWellFormed(item)).toBe(true);
 		}
 		expect(out[1]).toBe("\uFFFD");
+	});
+});
+
+const ARRAY_ACTION = {
+	name: "TAG_ITEMS",
+	parameters: [
+		{
+			name: "tags",
+			required: true,
+			schema: { type: "array", items: { type: "string" } },
+		},
+	],
+} as Action;
+
+describe("JSON-array action parameter Unicode safety", () => {
+	it("replaces lone surrogates while preserving valid astral pairs", () => {
+		const result = validateActionParams(ARRAY_ACTION, {
+			tags: '["\\ud800abc","\\ud83e\\udd8a"]',
+		});
+
+		expect(result).toMatchObject({ valid: true, errors: [] });
+		expect(result.params?.tags).toEqual(["�abc", "🦊"]);
+		expect(JSON.stringify(result.params)).toBe('{"tags":["�abc","🦊"]}');
 	});
 });

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -37,7 +37,10 @@ import {
 	getDeterministicNames,
 } from "./utils/deterministic";
 import { compressPromptDescription } from "./utils/prompt-compression";
-import { toWellFormedUnicode } from "./utils/well-formed.ts";
+import {
+	deepToWellFormedUnicode,
+	toWellFormedUnicode,
+} from "./utils/well-formed.ts";
 
 export {
 	type ExtractorPipelineResult,
@@ -488,7 +491,7 @@ function coerceActionParamValue(
 			// delimited-string form; malformed JSON remains untrusted string input.
 		}
 		if (Array.isArray(parsed)) {
-			return toActionParameterValue(parsed);
+			return toActionParameterValue(deepToWellFormedUnicode(parsed));
 		}
 	}
 


### PR DESCRIPTION
# Relates to

Fixes #24006.

- [x] This PR targets `develop` and is based on the latest `origin/develop` (`43f9df0f18d6a29de502d2d598e3cee994a0a46e`) with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync; unrelated repository blockers are recorded below.
- [x] A reviewer can confirm the boundary behavior from the focused production-path tests and mutation proof below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b687e3bbc9347c6d9d273b67c28a9b05dc52810b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` was attempted post-sync; its exact unrelated base failure is documented in **Known gaps / failures**.

# Risks

Low. The change is confined to the already parsed JSON-array coercion branch. It uses the existing bounded deep Unicode sanitizer before the existing bounded action-parameter conversion.

# Background

## What does this PR do?

- Sanitizes every string in a JSON-array action parameter before validated parameters leave the Core boundary.
- Replaces lone UTF-16 surrogates with U+FFFD while preserving valid astral pairs.
- Extends the existing array surrogate suite with a regression that imports and exercises `validateActionParams` directly.

## What kind of change is this?

Bug fix, non-breaking.

# Documentation changes needed?

No. This makes the JSON-array input form honor the existing Unicode safety contract already applied to the delimited-string form.

# Testing

## Where should a reviewer start?

Start with the new production-path case in `actions-param-array.surrogate.test.ts`, then the one-line boundary change in `actions.ts`.

## Detailed testing steps

- `mise exec -- bun run --cwd packages/core test -- src/actions-param-array.surrogate.test.ts src/action-parameter-value.test.ts` — 28 passed.
- Mutation proof: temporarily removing only `deepToWellFormedUnicode(parsed)` makes the new regression fail because the first array element retains the lone surrogate; restoring it returns the suite to green.
- `mise exec -- bun run --cwd packages/core typecheck` — passed.
- `mise exec -- bun run --cwd packages/core lint:check` — exited 0; diagnostics are warnings/infos in untouched files.
- Focused Biome check on the two changed files — passed.
- `git diff --check` — passed.

# Evidence Gate

<!-- evidence-head:cf677eca23e0ed17d6fdc86ef77a3ba86be5b9fa -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic Core validation boundary only; no UI flow changed
<!-- evidence-row:backend-logs -->
- [ ] N/A - no running backend or external provider is needed; the production validator is exercised directly
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or network flow changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic parsing of already supplied action parameters; a live model would not provide stronger reproducible lone-surrogate evidence
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, scheduled-task, wallet, file, or media artifact is produced
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - the changed branch is a deterministic validation boundary. The test injects the exact JSON text a model response supplies and exercises the real exported validator.

## Backend + frontend logs

N/A - no service process or frontend path changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio or voice change.

## Known gaps / failures

- The complete Core suite ran 7,655 tests: 7,632 passed, 16 skipped, and 7 failed across untouched retrieval, trajectory, and PGlite tests. Eight additional untouched suites failed collection because local workspace build entries were initially absent. The two changed-file suites pass 28/28.
- `mise exec -- bun run --cwd packages/core build` completed Node, browser, edge, testing, and declaration builds. Its final package smoke step failed when Node executed the local mise `npm` shell wrapper as JavaScript (`set -euo pipefail` SyntaxError); this occurs after all Core build outputs succeed.
- `mise exec -- bun run verify` reaches Turbo and fails on an untouched UI formatting error in `packages/ui/src/components/chat/widgets/maps-card.tsx`. The changed Core files pass their focused Biome check, package typecheck, and tests.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@b687e3bbc9347c6d9d273b67c28a9b05dc52810b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [standujar/fix-core-action-array-unicode]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@b687e3bbc9347c6d9d273b67c28a9b05dc52810b:packages/skills/skills/contribute-to-eliza"} -->

## Maintainer restack receipt

Restacked onto `develop@ce20804092dc9503a772d7d9ab6d135939b5bb0e` after the original head conflicted with the removal of the obsolete production split-truncation import. The sanitizer call itself applied unchanged. Exact-head validation at `cf677eca23e0ed17d6fdc86ef77a3ba86be5b9fa`: 29/29 focused Core tests passed, focused Biome passed, and diff hygiene passed. The sparse-checkout typecheck reached only missing/broken workspace dependency links and reported no changed-file diagnostic.

Maintainer AI provider/model: OpenAI / gpt-5
Maintainer client / agent tooling: Codex
Maintainer attribution status: system-confirmed
— [codex-maintainer-restack-24065]
