### PR TITLE
fix(cloud): charge the avatar upload budget before formData() parses the body

### DIFF
--- a/packages/cloud/api/__tests__/avatar-storage-quota.test.ts
+++ b/packages/cloud/api/__tests__/avatar-storage-quota.test.ts
@@ -1,11 +1,15 @@
 /**
- * Avatar upload quota contract tests for #20950.
+ * Avatar upload quota and multipart-budget contract tests for #20950 / #24066.
  *
  * These tests drive both real Hono route modules and the real
  * `putPublicObject` helper. Only request authentication, rate limiting, the
  * quota repository, and the user-avatar database boundary are replaced with
  * hermetic boundaries. The in-memory BLOB binding therefore proves the route
  * ordering and compensation behavior without reaching live R2 or Postgres.
+ * Envelope-budget cases drive a real streaming Request through the same
+ * handlers so declared-length, streamed overflow, untrusted content-length,
+ * cancellation reporting, and client-abort paths are pinned in the maintained
+ * suite rather than PR-only ad hoc evidence.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -16,6 +20,7 @@ const ORGANIZATION_ID = "00000000-0000-4000-8000-0000000000aa";
 const USER_ID = "00000000-0000-4000-8000-0000000000bb";
 const PUBLIC_HOST = "blob.test";
 const MAX_AVATAR_BYTES = 5 * 1024 * 1024;
+const MAX_MULTIPART_BODY_BYTES = MAX_AVATAR_BYTES + 1024 * 1024;
 const VALID_AVATAR_CONTENT = "avatar";
 const VALID_AVATAR_BYTES = BigInt(VALID_AVATAR_CONTENT.length);
 const SENSITIVE_UUID = "3f10dc7c-9824-4ba6-aa10-c9a63429b055";
@@ -204,6 +209,83 @@ function uploadAvatar(
     },
     makeEnv(blob),
   );
+}
+
+async function uploadAvatarWithHeaders(
+  route: typeof characterAvatarRoute,
+  file: File,
+  blob: Bindings["BLOB"],
+  extraHeaders: HeadersInit,
+): Promise<Response> {
+  const form = new FormData();
+  form.set("file", file);
+  const base = new Request("http://localhost/", {
+    body: form,
+    method: "POST",
+  });
+  const headers = new Headers(base.headers);
+  for (const [key, value] of new Headers(extraHeaders)) {
+    headers.set(key, value);
+  }
+  const request = new Request(base.url, {
+    body: await base.arrayBuffer(),
+    headers,
+    method: base.method,
+  });
+  return route.request(request, undefined, makeEnv(blob));
+}
+
+function streamAvatarRequest(
+  chunks: readonly Uint8Array[],
+  headers: HeadersInit,
+  options: {
+    onCancel?: () => void | Promise<void>;
+    signal?: AbortSignal;
+    leaveOpen?: boolean;
+  } = {},
+): Request {
+  let index = 0;
+  const body = new ReadableStream<Uint8Array>({
+    cancel() {
+      return options.onCancel?.();
+    },
+    pull(controller) {
+      const chunk = chunks[index];
+      index += 1;
+      if (chunk) {
+        controller.enqueue(chunk);
+        return;
+      }
+      if (!options.leaveOpen) {
+        controller.close();
+      }
+    },
+  });
+  const nextHeaders = new Headers({
+    "content-type": "multipart/form-data; boundary=budget",
+  });
+  for (const [key, value] of new Headers(headers)) {
+    nextHeaders.set(key, value);
+  }
+  return new Request("http://localhost/", {
+    body,
+    headers: nextHeaders,
+    method: "POST",
+    signal: options.signal,
+  });
+}
+
+async function waitUntil(
+  predicate: () => boolean,
+  timeoutMs = 500,
+): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error("waitUntil timed out");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
 }
 
 function sensitiveErrorMessage(label: string): string {
@@ -498,6 +580,131 @@ for (const routeCase of routeCases) {
         expect(databaseUpdate).not.toHaveBeenCalled();
         expect(operations).toEqual(["reserve", "put"]);
       }
+    });
+
+    test("rejects a declared oversize envelope before parsing or reserving quota", async () => {
+      const blob = makeMemoryBlob();
+      const onCancel = mock(() => undefined);
+
+      const response = await routeCase.route.request(
+        streamAvatarRequest(
+          [new Uint8Array(8)],
+          { "content-length": String(MAX_MULTIPART_BODY_BYTES + 1) },
+          { onCancel },
+        ),
+        undefined,
+        makeEnv(blob.binding),
+      );
+
+      expect(response.status).toBe(413);
+      expect(await response.text()).toBe(
+        JSON.stringify({
+          success: false,
+          error: `Upload exceeds the ${MAX_MULTIPART_BODY_BYTES} byte request limit (${MAX_MULTIPART_BODY_BYTES + 1})`,
+        }),
+      );
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(tryReserveBytes).not.toHaveBeenCalled();
+      expect(blob.put).not.toHaveBeenCalled();
+      expect(databaseUpdate).not.toHaveBeenCalled();
+    });
+
+    test("cancels a streamed oversize envelope before reserving quota", async () => {
+      const blob = makeMemoryBlob();
+      const onCancel = mock(() => undefined);
+
+      const response = await routeCase.route.request(
+        streamAvatarRequest(
+          [new Uint8Array(MAX_MULTIPART_BODY_BYTES + 1)],
+          {},
+          { leaveOpen: true, onCancel },
+        ),
+        undefined,
+        makeEnv(blob.binding),
+      );
+
+      expect(response.status).toBe(413);
+      expect(await response.text()).toBe(
+        JSON.stringify({
+          success: false,
+          error: `Upload exceeds the ${MAX_MULTIPART_BODY_BYTES} byte request limit (${MAX_MULTIPART_BODY_BYTES + 1})`,
+        }),
+      );
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(tryReserveBytes).not.toHaveBeenCalled();
+      expect(blob.put).not.toHaveBeenCalled();
+      expect(databaseUpdate).not.toHaveBeenCalled();
+    });
+
+    test("does not treat malformed content-length as a budget grant", async () => {
+      const blob = makeMemoryBlob();
+
+      for (const header of ["abc", "0x400", "-1", "99999999999999999999", ""]) {
+        tryReserveBytes.mockClear();
+        blob.put.mockClear();
+        const response = await uploadAvatarWithHeaders(
+          routeCase.route,
+          avatarFile(),
+          blob.binding,
+          { "content-length": header },
+        );
+
+        expect(response.status).toBe(200);
+        expect(tryReserveBytes).toHaveBeenCalledTimes(1);
+        expect(blob.put).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    test("returns 408 when the client aborts before the body is read", async () => {
+      const blob = makeMemoryBlob();
+      const controller = new AbortController();
+      const request = streamAvatarRequest(
+        [new Uint8Array(8)],
+        {},
+        { leaveOpen: true, signal: controller.signal },
+      );
+      controller.abort();
+
+      const response = await routeCase.route.request(
+        request,
+        undefined,
+        makeEnv(blob.binding),
+      );
+
+      expect(response.status).toBe(408);
+      expect(await response.text()).toBe(
+        JSON.stringify({
+          success: false,
+          error: "Upload body could not be read",
+        }),
+      );
+      expect(tryReserveBytes).not.toHaveBeenCalled();
+      expect(blob.put).not.toHaveBeenCalled();
+      expect(loggerWarn).toHaveBeenCalled();
+    });
+
+    test("reports a rejecting body cancel without reserving quota", async () => {
+      const blob = makeMemoryBlob();
+      const onCancel = mock(async () => {
+        throw new Error("cancel exploded");
+      });
+
+      const response = await routeCase.route.request(
+        streamAvatarRequest(
+          [new Uint8Array(MAX_MULTIPART_BODY_BYTES + 1)],
+          {},
+          { leaveOpen: true, onCancel },
+        ),
+        undefined,
+        makeEnv(blob.binding),
+      );
+
+      expect(response.status).toBe(413);
+      expect(tryReserveBytes).not.toHaveBeenCalled();
+      await waitUntil(() => loggerWarn.mock.calls.length >= 1);
+      const serialized = JSON.stringify(loggerWarn.mock.calls);
+      expect(serialized).toContain("Failed to cancel upload body");
+      expect(serialized).toContain("streamed-budget");
     });
   });
 }

--- a/packages/cloud/api/_lib/multipart-body-budget.test.ts
+++ b/packages/cloud/api/_lib/multipart-body-budget.test.ts
@@ -3,12 +3,13 @@
  *
  * The harness drives real WHATWG Requests and ReadableStreams: declared-length
  * precheck, streamed overflow, malformed content-length, one-byte
- * fragmentation, hung bodies, client abort, cancel reporting, and reader-lock
+ * fragmentation, slab growth, hung bodies, client abort, cancel reporting, and reader-lock
  * ownership. Nothing here reaches Hono, R2, or Postgres.
  */
 
 import { describe, expect, mock, test } from "bun:test";
 import {
+  MULTIPART_SLAB_FLOOR_BYTES,
   parseTrustworthyContentLength,
   readRequestWithinMultipartBudget,
 } from "./multipart-body-budget";
@@ -219,6 +220,44 @@ describe("readRequestWithinMultipartBudget", () => {
     expect(body.byteLength).toBe(BUDGET);
     expect(body.every((value) => value === 7)).toBe(true);
     expect(stream.locked).toBe(false);
+  });
+
+  test("grows past the initial slab and keeps an in-budget body intact", async () => {
+    const chunkCount = 24;
+    const chunkSize = 4096;
+    const total = chunkCount * chunkSize;
+    // No trustworthy declared length, so the slab starts at the floor and has
+    // to grow at least once before the whole body fits.
+    expect(total).toBeGreaterThan(MULTIPART_SLAB_FLOOR_BYTES);
+    const chunks = Array.from({ length: chunkCount }, (_unused, index) =>
+      new Uint8Array(chunkSize).fill(index + 1),
+    );
+    const { request, stream } = streamRequest(chunks);
+
+    const result = await readRequestWithinMultipartBudget(request, total * 4);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected success");
+    const body = new Uint8Array(await result.request.arrayBuffer());
+    expect(body.byteLength).toBe(total);
+    for (let index = 0; index < chunkCount; index += 1) {
+      const slice = body.subarray(index * chunkSize, (index + 1) * chunkSize);
+      expect(slice.every((value) => value === index + 1)).toBe(true);
+    }
+    expect(stream.locked).toBe(false);
+  });
+
+  test("grows past an understated content-length seed without losing bytes", async () => {
+    const chunks = [bytes(1, 2, 3, 4), bytes(5, 6, 7, 8), bytes(9)];
+    const { request } = streamRequest(chunks, { "content-length": "2" });
+
+    const result = await readRequestWithinMultipartBudget(request, BUDGET);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected success");
+    expect(
+      Array.from(new Uint8Array(await result.request.arrayBuffer())),
+    ).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
   });
 
   test("charges a one-byte overflow before retaining the over-budget byte", async () => {

--- a/packages/cloud/api/_lib/multipart-body-budget.test.ts
+++ b/packages/cloud/api/_lib/multipart-body-budget.test.ts
@@ -1,0 +1,425 @@
+/**
+ * Deterministic unit tests for the import-free multipart byte-budget reader.
+ *
+ * The harness drives real WHATWG Requests and ReadableStreams: declared-length
+ * precheck, streamed overflow, malformed content-length, one-byte
+ * fragmentation, hung bodies, client abort, cancel reporting, and reader-lock
+ * ownership. Nothing here reaches Hono, R2, or Postgres.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import {
+  parseTrustworthyContentLength,
+  readRequestWithinMultipartBudget,
+} from "./multipart-body-budget";
+
+const BUDGET = 64;
+const URL = "https://cloud.test/upload";
+
+function bytes(...values: number[]): Uint8Array {
+  return Uint8Array.from(values);
+}
+
+function streamRequest(
+  chunks: readonly Uint8Array[],
+  headers: HeadersInit = {},
+  options: {
+    onCancel?: () => void | Promise<void>;
+    signal?: AbortSignal;
+    hang?: boolean;
+    failWith?: Error;
+    leaveOpen?: boolean;
+  } = {},
+): { request: Request; stream: ReadableStream<Uint8Array> } {
+  let index = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    cancel() {
+      return options.onCancel?.();
+    },
+    pull(controller) {
+      if (options.failWith) {
+        controller.error(options.failWith);
+        return;
+      }
+      if (options.hang) {
+        return;
+      }
+      const chunk = chunks[index];
+      index += 1;
+      if (chunk) {
+        controller.enqueue(chunk);
+        return;
+      }
+      // A still-open upload is the hostile case: closing here races Bun's
+      // Request-body prefetch and makes reader.cancel() a no-op.
+      if (!options.leaveOpen) {
+        controller.close();
+      }
+    },
+  });
+  return {
+    stream,
+    request: new Request(URL, {
+      body: stream,
+      headers,
+      method: "POST",
+      signal: options.signal,
+    }),
+  };
+}
+
+async function waitUntil(
+  predicate: () => boolean,
+  timeoutMs = 500,
+): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error("waitUntil timed out");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+describe("parseTrustworthyContentLength", () => {
+  const cases: Array<[string | null, number | null]> = [
+    [null, null],
+    ["", null],
+    ["abc", null],
+    ["0x400", null],
+    ["-1", null],
+    ["12.5", null],
+    ["99999999999999999999", null],
+    ["0", 0],
+    ["64", 64],
+    [" 7 ", 7],
+  ];
+
+  for (const [header, expected] of cases) {
+    test(`maps ${JSON.stringify(header)} to ${String(expected)}`, () => {
+      const headers = new Headers();
+      if (header !== null) headers.set("content-length", header);
+      const request = new Request(URL, { headers, method: "POST" });
+      expect(parseTrustworthyContentLength(request)).toBe(expected);
+    });
+  }
+});
+
+describe("readRequestWithinMultipartBudget", () => {
+  test("refuses a declared length over budget without pulling the body", async () => {
+    const onCancel = mock(() => undefined);
+    let pulls = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      cancel() {
+        onCancel();
+      },
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(bytes(1, 2, 3, 4));
+      },
+    });
+    const request = new Request(URL, {
+      body: stream,
+      headers: { "content-length": String(BUDGET + 1) },
+      method: "POST",
+    });
+
+    const result = await readRequestWithinMultipartBudget(request, BUDGET);
+
+    expect(result).toEqual({
+      ok: false,
+      outcome: "oversized",
+      bytes: BUDGET + 1,
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(pulls).toBe(0);
+  });
+
+  test("cancels a chunked body as soon as retained bytes would exceed the budget", async () => {
+    const onCancel = mock(() => undefined);
+    const { request } = streamRequest(
+      [new Uint8Array(40), new Uint8Array(40)],
+      {},
+      { leaveOpen: true, onCancel },
+    );
+
+    const result = await readRequestWithinMultipartBudget(request, BUDGET);
+
+    expect(result).toEqual({
+      ok: false,
+      outcome: "oversized",
+      bytes: 80,
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("still streams when a trustworthy content-length is under budget", async () => {
+    const onCancel = mock(() => undefined);
+    const { request } = streamRequest(
+      [new Uint8Array(40), new Uint8Array(40)],
+      { "content-length": "1" },
+      { leaveOpen: true, onCancel },
+    );
+
+    const result = await readRequestWithinMultipartBudget(request, BUDGET);
+
+    expect(result).toEqual({
+      ok: false,
+      outcome: "oversized",
+      bytes: 80,
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("accepts malformed content-length headers on an in-budget body", async () => {
+    const payload = bytes(9, 8, 7, 6);
+    for (const header of ["abc", "0x400", "-1", "99999999999999999999", ""]) {
+      const { request } = streamRequest([payload], {
+        "content-length": header,
+      });
+      const result = await readRequestWithinMultipartBudget(request, BUDGET);
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("expected success");
+      expect(result.request.headers.has("content-length")).toBe(false);
+      expect(
+        Array.from(new Uint8Array(await result.request.arrayBuffer())),
+      ).toEqual(Array.from(payload));
+    }
+  });
+
+  test("strips content-length from a successful buffered request", async () => {
+    const payload = bytes(1, 2, 3);
+    const { request } = streamRequest([payload], {
+      "content-length": "3",
+      "content-type": "multipart/form-data; boundary=x",
+    });
+
+    const result = await readRequestWithinMultipartBudget(request, BUDGET);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected success");
+    expect(result.request.headers.get("content-type")).toBe(
+      "multipart/form-data; boundary=x",
+    );
+    expect(result.request.headers.has("content-length")).toBe(false);
+    expect(
+      Array.from(new Uint8Array(await result.request.arrayBuffer())),
+    ).toEqual(Array.from(payload));
+  });
+
+  test("retains a hostile one-byte stream in one slab and accepts exactly the budget", async () => {
+    const chunks = Array.from({ length: BUDGET }, () => bytes(7));
+    const { request, stream } = streamRequest(chunks);
+
+    const result = await readRequestWithinMultipartBudget(request, BUDGET);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected success");
+    const body = new Uint8Array(await result.request.arrayBuffer());
+    expect(body.byteLength).toBe(BUDGET);
+    expect(body.every((value) => value === 7)).toBe(true);
+    expect(stream.locked).toBe(false);
+  });
+
+  test("charges a one-byte overflow before retaining the over-budget byte", async () => {
+    const onCancel = mock(() => undefined);
+    const chunks = [
+      ...Array.from({ length: BUDGET }, () => bytes(1)),
+      bytes(1),
+    ];
+    const { request } = streamRequest(
+      chunks,
+      {},
+      { leaveOpen: true, onCancel },
+    );
+
+    const result = await readRequestWithinMultipartBudget(request, BUDGET);
+
+    expect(result).toEqual({
+      ok: false,
+      outcome: "oversized",
+      bytes: BUDGET + 1,
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("releases the reader lock on success", async () => {
+    const { request, stream } = streamRequest([bytes(1, 2, 3)]);
+
+    const result = await readRequestWithinMultipartBudget(request, BUDGET);
+
+    expect(result.ok).toBe(true);
+    expect(stream.locked).toBe(false);
+  });
+
+  test("releases the reader lock only after detached cancel settles", async () => {
+    let releaseCancel: (() => void) | undefined;
+    const cancelGate = new Promise<void>((resolve) => {
+      releaseCancel = resolve;
+    });
+    const onCancel = mock(() => cancelGate);
+    const { request, stream } = streamRequest(
+      [new Uint8Array(BUDGET + 1)],
+      {},
+      { leaveOpen: true, onCancel },
+    );
+
+    const result = await readRequestWithinMultipartBudget(request, BUDGET);
+
+    expect(result).toEqual({
+      ok: false,
+      outcome: "oversized",
+      bytes: BUDGET + 1,
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(stream.locked).toBe(true);
+    releaseCancel?.();
+    await waitUntil(() => stream.locked === false);
+    expect(stream.locked).toBe(false);
+  });
+
+  test("reports a rejecting cancel without throwing out of the reader", async () => {
+    const onCancelFailure = mock<(label: string, error: unknown) => void>(
+      () => undefined,
+    );
+    const { request } = streamRequest(
+      [new Uint8Array(BUDGET + 1)],
+      {},
+      {
+        leaveOpen: true,
+        onCancel: async () => {
+          throw new Error("cancel exploded");
+        },
+      },
+    );
+
+    const result = await readRequestWithinMultipartBudget(
+      request,
+      BUDGET,
+      onCancelFailure,
+    );
+
+    expect(result.ok).toBe(false);
+    await waitUntil(() => onCancelFailure.mock.calls.length === 1);
+    expect(onCancelFailure).toHaveBeenCalledTimes(1);
+    expect(onCancelFailure.mock.calls[0]?.[0]).toBe("streamed-budget");
+    expect(onCancelFailure.mock.calls[0]?.[1]).toBeInstanceOf(Error);
+  });
+
+  test("swallows a throwing cancel reporter", async () => {
+    const { request } = streamRequest(
+      [new Uint8Array(BUDGET + 1)],
+      {},
+      {
+        leaveOpen: true,
+        onCancel: async () => {
+          throw new Error("cancel exploded");
+        },
+      },
+    );
+
+    const result = await readRequestWithinMultipartBudget(
+      request,
+      BUDGET,
+      () => {
+        throw new Error("reporter exploded");
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      outcome: "oversized",
+      bytes: BUDGET + 1,
+    });
+  });
+
+  test("abandons a hung body at the owned deadline", async () => {
+    const onCancel = mock(() => undefined);
+    const { request, stream } = streamRequest([], {}, { hang: true, onCancel });
+
+    const result = await readRequestWithinMultipartBudget(
+      request,
+      BUDGET,
+      undefined,
+      { timeoutMs: 50 },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      outcome: "incomplete",
+      reason: "deadline",
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    await waitUntil(() => stream.locked === false);
+    expect(stream.locked).toBe(false);
+  });
+
+  test("returns client-aborted when the Worker request signal is already aborted", async () => {
+    const onCancel = mock(() => undefined);
+    const controller = new AbortController();
+    const { request } = streamRequest(
+      [],
+      {},
+      {
+        hang: true,
+        onCancel,
+        signal: controller.signal,
+      },
+    );
+    controller.abort();
+
+    const result = await readRequestWithinMultipartBudget(request, BUDGET);
+
+    expect(result).toEqual({
+      ok: false,
+      outcome: "incomplete",
+      reason: "client-aborted",
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns client-aborted when the request signal fires mid-read", async () => {
+    const onCancel = mock(() => undefined);
+    const controller = new AbortController();
+    const { request } = streamRequest(
+      [],
+      {},
+      {
+        hang: true,
+        onCancel,
+        signal: controller.signal,
+      },
+    );
+
+    const pending = readRequestWithinMultipartBudget(
+      request,
+      BUDGET,
+      undefined,
+      { timeoutMs: 5_000 },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    controller.abort();
+    const result = await pending;
+
+    expect(result).toEqual({
+      ok: false,
+      outcome: "incomplete",
+      reason: "client-aborted",
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("maps a stream error to an incomplete read-failed outcome", async () => {
+    const boom = new Error("stream exploded");
+    const { request } = streamRequest([], {}, { failWith: boom });
+
+    const result = await readRequestWithinMultipartBudget(request, BUDGET);
+
+    expect(result.ok).toBe(false);
+    if (result.ok || result.outcome !== "incomplete") {
+      throw new Error("expected incomplete");
+    }
+    expect(result.reason).toBe("read-failed");
+    expect(result.error).toBe(boom);
+  });
+});

--- a/packages/cloud/api/_lib/multipart-body-budget.ts
+++ b/packages/cloud/api/_lib/multipart-body-budget.ts
@@ -1,0 +1,136 @@
+/**
+ * Byte budget for a multipart upload, charged BEFORE the body is parsed.
+ *
+ * `Request.formData()` parses *and materializes* every part: by the time a
+ * handler can ask `entry.size > MAX_BYTES`, the bytes it wants to refuse are
+ * already resident. On a route whose declared cap is 5 MiB that is the whole
+ * guard arriving after the whole cost, and the handler's `catch` cannot give a
+ * completed allocation back — this package deploys as a Cloudflare Worker
+ * (`packages/cloud/api/wrangler.toml`), where per-isolate memory is a hard
+ * platform limit.
+ *
+ * `readRequestWithinMultipartBudget` puts the charge first, in the two stages
+ * `packages/cloud/api/v1/voice/stt/route.ts` already uses for its own multipart
+ * limit:
+ *
+ *  1. a declared `content-length` over budget is refused **without reading the
+ *     body at all**, and the upload is cancelled best-effort;
+ *  2. otherwise the body is streamed and each chunk is charged against the
+ *     running total **before** it is retained, so peak retention is the budget
+ *     plus the chunk in hand. A `content-length` that is absent, non-numeric,
+ *     or not a safe integer is not treated as a budget grant.
+ *
+ * On success it returns a `Request` carrying the same URL, method and headers
+ * (minus `content-length`, which no longer describes the buffered body) whose
+ * body is the bytes that were charged, so the caller goes on to
+ * `.formData()` exactly as before.
+ *
+ * Deliberately import-free so it can be driven on its own.
+ */
+
+export type BudgetedMultipartRequest =
+  | { readonly ok: true; readonly request: Request }
+  | { readonly ok: false; readonly bytes: number };
+
+/**
+ * The declared body length, or `null` when the header is absent or is not a
+ * plain decimal integer that survives `Number.isSafeInteger`.
+ */
+export function parseTrustworthyContentLength(request: Request): number | null {
+  const raw = request.headers.get("content-length");
+  if (!raw) return null;
+  if (!/^\d+$/.test(raw.trim())) return null;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function cancelBestEffort(
+  target: { cancel: () => Promise<unknown> },
+  label: string,
+  onCancelFailure?: (label: string, error: unknown) => void,
+): void {
+  const report = (error: unknown) => onCancelFailure?.(label, error);
+  try {
+    target.cancel().catch(report);
+  } catch (error) {
+    // error-policy:J6 best-effort teardown for an upload already rejected.
+    report(error);
+  }
+}
+
+function bufferedHeaders(request: Request): Headers {
+  const headers = new Headers(request.headers);
+  headers.delete("content-length");
+  return headers;
+}
+
+/**
+ * Reads `request`'s body under `maxBytes` and hands back an equivalent
+ * `Request` to parse, or the size the refusal was made on.
+ */
+export async function readRequestWithinMultipartBudget(
+  request: Request,
+  maxBytes: number,
+  onCancelFailure?: (label: string, error: unknown) => void,
+): Promise<BudgetedMultipartRequest> {
+  const declaredLength = parseTrustworthyContentLength(request);
+  if (declaredLength !== null && declaredLength > maxBytes) {
+    if (request.body) {
+      cancelBestEffort(
+        request.body,
+        "content-length-precheck",
+        onCancelFailure,
+      );
+    }
+    return { ok: false, bytes: declaredLength };
+  }
+
+  const headers = bufferedHeaders(request);
+
+  if (!request.body) {
+    const buffer = await request.arrayBuffer();
+    if (buffer.byteLength > maxBytes) {
+      return { ok: false, bytes: buffer.byteLength };
+    }
+    return {
+      ok: true,
+      request: new Request(request.url, {
+        body: buffer,
+        headers,
+        method: request.method,
+      }),
+    };
+  }
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    received += value.byteLength;
+    if (received > maxBytes) {
+      cancelBestEffort(reader, "streamed-budget", onCancelFailure);
+      return { ok: false, bytes: received };
+    }
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return {
+    ok: true,
+    request: new Request(request.url, {
+      body,
+      headers,
+      method: request.method,
+    }),
+  };
+}

--- a/packages/cloud/api/_lib/multipart-body-budget.ts
+++ b/packages/cloud/api/_lib/multipart-body-budget.ts
@@ -3,9 +3,11 @@
  *
  * `Request.formData()` materializes every part, so a post-parse size check
  * cannot bound isolate memory. This helper refuses a trustworthy over-budget
- * `content-length` without reading; otherwise it streams into one `maxBytes`
- * slab and charges each chunk before retaining it. Peak residency is that
- * slab plus the chunk in hand, regardless of transport fragmentation.
+ * `content-length` without reading; otherwise it streams into one slab sized
+ * to the body in flight — seeded from a trustworthy declared length, else
+ * grown by doubling under the `maxBytes` ceiling — and charges each chunk
+ * before retaining it. Peak residency is that slab plus the chunk in hand,
+ * regardless of transport fragmentation.
  *
  * The Worker request `signal` and an owned deadline stop a body that never
  * completes. Reader-lock ownership is finally-based: success releases
@@ -43,6 +45,12 @@ export interface MultipartBudgetReadOptions {
 
 /** Default wall-clock bound for one streamed multipart body read. */
 export const MULTIPART_BODY_READ_DEADLINE_MS = 60_000;
+
+/**
+ * Initial slab size for a body that declares no trustworthy length. Small
+ * uploads never grow past it; larger ones double up to the budget ceiling.
+ */
+export const MULTIPART_SLAB_FLOOR_BYTES = 64 * 1024;
 
 type InterruptReason = "client-aborted" | "deadline";
 
@@ -212,8 +220,17 @@ export async function readRequestWithinMultipartBudget(
     try {
       let received = 0;
       // One bounded slab, allocated only after the first in-budget chunk is
-      // charged. Hostile one-byte streams still occupy this single object.
+      // charged and sized to the body actually in flight: a trustworthy
+      // declared length up front, otherwise a small floor grown by doubling
+      // and clamped to `maxBytes`. A 4 KB avatar never reserves the ceiling,
+      // and hostile one-byte streams still occupy this single object.
       let slab: Uint8Array<ArrayBuffer> | undefined;
+      // A declared zero would leave doubling stuck, so the seed keeps a floor
+      // of one byte; nothing is allocated until a chunk is actually charged.
+      let capacity = Math.min(
+        maxBytes,
+        Math.max(1, declaredLength ?? MULTIPART_SLAB_FLOOR_BYTES),
+      );
 
       while (true) {
         const pendingRead = reader.read();
@@ -254,7 +271,17 @@ export async function readRequestWithinMultipartBudget(
             bytes: received + chunkSize,
           };
         }
-        slab ??= new Uint8Array(maxBytes);
+        if (received + chunkSize > capacity) {
+          capacity = Math.min(
+            maxBytes,
+            Math.max(capacity * 2, received + chunkSize),
+          );
+        }
+        if (!slab || slab.byteLength < capacity) {
+          const grown = new Uint8Array(capacity);
+          if (slab) grown.set(slab.subarray(0, received));
+          slab = grown;
+        }
         slab.set(value, received);
         received += chunkSize;
       }

--- a/packages/cloud/api/_lib/multipart-body-budget.ts
+++ b/packages/cloud/api/_lib/multipart-body-budget.ts
@@ -1,36 +1,50 @@
 /**
- * Byte budget for a multipart upload, charged BEFORE the body is parsed.
+ * Byte budget for a multipart upload, charged before the body is parsed.
  *
- * `Request.formData()` parses *and materializes* every part: by the time a
- * handler can ask `entry.size > MAX_BYTES`, the bytes it wants to refuse are
- * already resident. On a route whose declared cap is 5 MiB that is the whole
- * guard arriving after the whole cost, and the handler's `catch` cannot give a
- * completed allocation back — this package deploys as a Cloudflare Worker
- * (`packages/cloud/api/wrangler.toml`), where per-isolate memory is a hard
- * platform limit.
+ * `Request.formData()` materializes every part, so a post-parse size check
+ * cannot bound isolate memory. This helper refuses a trustworthy over-budget
+ * `content-length` without reading; otherwise it streams into one `maxBytes`
+ * slab and charges each chunk before retaining it. Peak residency is that
+ * slab plus the chunk in hand, regardless of transport fragmentation.
  *
- * `readRequestWithinMultipartBudget` puts the charge first, in the two stages
- * `packages/cloud/api/v1/voice/stt/route.ts` already uses for its own multipart
- * limit:
- *
- *  1. a declared `content-length` over budget is refused **without reading the
- *     body at all**, and the upload is cancelled best-effort;
- *  2. otherwise the body is streamed and each chunk is charged against the
- *     running total **before** it is retained, so peak retention is the budget
- *     plus the chunk in hand. A `content-length` that is absent, non-numeric,
- *     or not a safe integer is not treated as a budget grant.
- *
- * On success it returns a `Request` carrying the same URL, method and headers
- * (minus `content-length`, which no longer describes the buffered body) whose
- * body is the bytes that were charged, so the caller goes on to
- * `.formData()` exactly as before.
- *
- * Deliberately import-free so it can be driven on its own.
+ * The Worker request `signal` and an owned deadline stop a body that never
+ * completes. Reader-lock ownership is finally-based: success releases
+ * immediately; overflow, abort, deadline, and read failure detach a no-throw
+ * `cancel()` and release the lock only after cancellation settles.
  */
+
+export type BudgetIncompleteReason =
+  | "client-aborted"
+  | "deadline"
+  | "read-failed";
 
 export type BudgetedMultipartRequest =
   | { readonly ok: true; readonly request: Request }
-  | { readonly ok: false; readonly bytes: number };
+  | {
+      readonly ok: false;
+      readonly outcome: "oversized";
+      readonly bytes: number;
+    }
+  | {
+      readonly ok: false;
+      readonly outcome: "incomplete";
+      readonly reason: BudgetIncompleteReason;
+      readonly error?: unknown;
+    };
+
+export interface MultipartBudgetReadOptions {
+  /**
+   * Owned wall-clock bound on the streamed read. A body that neither
+   * completes nor errors within this window is abandoned rather than allowed
+   * to pin the isolate.
+   */
+  readonly timeoutMs?: number;
+}
+
+/** Default wall-clock bound for one streamed multipart body read. */
+export const MULTIPART_BODY_READ_DEADLINE_MS = 60_000;
+
+type InterruptReason = "client-aborted" | "deadline";
 
 /**
  * The declared body length, or `null` when the header is absent or is not a
@@ -44,17 +58,63 @@ export function parseTrustworthyContentLength(request: Request): number | null {
   return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
+function reportCancelFailure(
+  onCancelFailure: ((label: string, error: unknown) => void) | undefined,
+  label: string,
+  error: unknown,
+): void {
+  if (!onCancelFailure) return;
+  try {
+    onCancelFailure(label, error);
+  } catch {
+    // error-policy:J6 a throwing reporter must not escalate best-effort teardown.
+  }
+}
+
 function cancelBestEffort(
   target: { cancel: () => Promise<unknown> },
   label: string,
   onCancelFailure?: (label: string, error: unknown) => void,
 ): void {
-  const report = (error: unknown) => onCancelFailure?.(label, error);
+  const report = (error: unknown) =>
+    reportCancelFailure(onCancelFailure, label, error);
   try {
     target.cancel().catch(report);
   } catch (error) {
     // error-policy:J6 best-effort teardown for an upload already rejected.
     report(error);
+  }
+}
+
+/**
+ * Detached no-throw teardown of a reader we are abandoning: cancellation runs
+ * unobserved, failures go to the reporter, and the lock is released only once
+ * cancellation has settled either way.
+ */
+function detachReaderWithCancel(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  label: string,
+  onCancelFailure?: (label: string, error: unknown) => void,
+): void {
+  const releaseAfterSettle = () => {
+    try {
+      reader.releaseLock();
+    } catch {
+      // error-policy:J6 the runtime already tore the lock down; nothing to do.
+    }
+  };
+  try {
+    reader
+      .cancel()
+      .catch((error: unknown) =>
+        reportCancelFailure(onCancelFailure, label, error),
+      )
+      .finally(releaseAfterSettle);
+  } catch (error) {
+    // error-policy:J6 best-effort teardown for an upload already rejected;
+    // a synchronous cancel throw leaves nothing pending, so release now.
+    reportCancelFailure(onCancelFailure, label, error);
+    releaseAfterSettle();
   }
 }
 
@@ -64,14 +124,27 @@ function bufferedHeaders(request: Request): Headers {
   return headers;
 }
 
+function bufferedBody(
+  slab: Uint8Array<ArrayBuffer> | undefined,
+  received: number,
+): Uint8Array<ArrayBuffer> {
+  if (!slab || received === 0) return new Uint8Array(0);
+  if (received === slab.byteLength) return slab;
+  const body = new Uint8Array(received);
+  body.set(slab.subarray(0, received));
+  return body;
+}
+
 /**
  * Reads `request`'s body under `maxBytes` and hands back an equivalent
- * `Request` to parse, or the size the refusal was made on.
+ * `Request` to parse, the size the refusal was made on, or why the body could
+ * not be read to completion.
  */
 export async function readRequestWithinMultipartBudget(
   request: Request,
   maxBytes: number,
   onCancelFailure?: (label: string, error: unknown) => void,
+  options?: MultipartBudgetReadOptions,
 ): Promise<BudgetedMultipartRequest> {
   const declaredLength = parseTrustworthyContentLength(request);
   if (declaredLength !== null && declaredLength > maxBytes) {
@@ -82,55 +155,131 @@ export async function readRequestWithinMultipartBudget(
         onCancelFailure,
       );
     }
-    return { ok: false, bytes: declaredLength };
+    return { ok: false, outcome: "oversized", bytes: declaredLength };
   }
 
   const headers = bufferedHeaders(request);
+  const signal = request.signal;
 
   if (!request.body) {
-    const buffer = await request.arrayBuffer();
-    if (buffer.byteLength > maxBytes) {
-      return { ok: false, bytes: buffer.byteLength };
+    try {
+      const buffer = await request.arrayBuffer();
+      if (buffer.byteLength > maxBytes) {
+        return { ok: false, outcome: "oversized", bytes: buffer.byteLength };
+      }
+      return {
+        ok: true,
+        request: new Request(request.url, {
+          body: buffer,
+          headers,
+          method: request.method,
+        }),
+      };
+    } catch (error) {
+      // error-policy:J3 an unreadable body becomes an explicit invalid result.
+      return {
+        ok: false,
+        outcome: "incomplete",
+        reason: "read-failed",
+        error,
+      };
     }
-    return {
-      ok: true,
-      request: new Request(request.url, {
-        body: buffer,
-        headers,
-        method: request.method,
-      }),
-    };
+  }
+
+  if (signal.aborted) {
+    cancelBestEffort(request.body, "client-aborted", onCancelFailure);
+    return { ok: false, outcome: "incomplete", reason: "client-aborted" };
   }
 
   const reader = request.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let received = 0;
+  let detachedCancelOwnsRelease = false;
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    if (!value) continue;
-    received += value.byteLength;
-    if (received > maxBytes) {
-      cancelBestEffort(reader, "streamed-budget", onCancelFailure);
-      return { ok: false, bytes: received };
+  try {
+    let fireInterrupt: ((reason: InterruptReason) => void) | undefined;
+    const interrupted = new Promise<InterruptReason>((resolve) => {
+      fireInterrupt = resolve;
+    });
+    const onAbort = () => fireInterrupt?.("client-aborted");
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      fireInterrupt?.("client-aborted");
     }
-    chunks.push(value);
-  }
+    const timer = setTimeout(
+      () => fireInterrupt?.("deadline"),
+      options?.timeoutMs ?? MULTIPART_BODY_READ_DEADLINE_MS,
+    );
 
-  const body = new Uint8Array(received);
-  let offset = 0;
-  for (const chunk of chunks) {
-    body.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
+    try {
+      let received = 0;
+      // One bounded slab, allocated only after the first in-budget chunk is
+      // charged. Hostile one-byte streams still occupy this single object.
+      let slab: Uint8Array<ArrayBuffer> | undefined;
 
-  return {
-    ok: true,
-    request: new Request(request.url, {
-      body,
-      headers,
-      method: request.method,
-    }),
-  };
+      while (true) {
+        const pendingRead = reader.read();
+        // error-policy:J5 the same pending read is observed by Promise.race;
+        // a late rejection after interrupt/cancel must not become unhandled.
+        void pendingRead.then(
+          () => undefined,
+          () => undefined,
+        );
+        const raced = await Promise.race([pendingRead, interrupted]);
+        if (raced === "client-aborted" || raced === "deadline") {
+          detachedCancelOwnsRelease = true;
+          detachReaderWithCancel(reader, "stream-interrupted", onCancelFailure);
+          return { ok: false, outcome: "incomplete", reason: raced };
+        }
+        const { done, value } = raced;
+        if (done) {
+          return {
+            ok: true,
+            request: new Request(request.url, {
+              body: bufferedBody(slab, received),
+              headers,
+              method: request.method,
+            }),
+          };
+        }
+        if (!value || value.byteLength === 0) continue;
+
+        const chunkSize = value.byteLength;
+        // Charge before retention: an over-budget chunk is not copied and
+        // never causes the slab to be allocated.
+        if (chunkSize > maxBytes - received) {
+          detachedCancelOwnsRelease = true;
+          detachReaderWithCancel(reader, "streamed-budget", onCancelFailure);
+          return {
+            ok: false,
+            outcome: "oversized",
+            bytes: received + chunkSize,
+          };
+        }
+        slab ??= new Uint8Array(maxBytes);
+        slab.set(value, received);
+        received += chunkSize;
+      }
+    } finally {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+    }
+  } catch (error) {
+    // error-policy:J3 an unreadable stream becomes an explicit invalid result,
+    // never a fake-valid body, and the route boundary reports it.
+    detachedCancelOwnsRelease = true;
+    detachReaderWithCancel(reader, "read-failure", onCancelFailure);
+    return {
+      ok: false,
+      outcome: "incomplete",
+      reason: "read-failed",
+      error,
+    };
+  } finally {
+    if (!detachedCancelOwnsRelease) {
+      try {
+        reader.releaseLock();
+      } catch {
+        // error-policy:J6 the lock was already torn down with the reader; nothing to do.
+      }
+    }
+  }
 }

--- a/packages/cloud/api/my-agents/characters/avatar/route.ts
+++ b/packages/cloud/api/my-agents/characters/avatar/route.ts
@@ -64,17 +64,27 @@ app.post("/", async (c) => {
       MAX_MULTIPART_BODY_BYTES,
       (reason, cancelError) => {
         // error-policy:J6 best-effort teardown for an upload already rejected.
-        logger.warn(
-          "[Character Avatar] Failed to cancel oversized upload body",
-          {
-            errorType:
-              cancelError instanceof Error ? cancelError.name : "unknown",
-            reason,
-          },
-        );
+        logger.warn("[Character Avatar] Failed to cancel upload body", {
+          errorType:
+            cancelError instanceof Error ? cancelError.name : "unknown",
+          reason,
+        });
       },
     );
     if (!budgeted.ok) {
+      if (budgeted.outcome === "incomplete") {
+        // error-policy:J4 a body that was aborted or never completed is a
+        // visibly distinct client-side failure, not an internal error.
+        logger.warn("[Character Avatar] Multipart body read did not complete", {
+          reason: budgeted.reason,
+          errorType:
+            budgeted.error instanceof Error ? budgeted.error.name : "unknown",
+        });
+        return c.json(
+          { success: false, error: "Upload body could not be read" },
+          408,
+        );
+      }
       return c.json(
         {
           success: false,

--- a/packages/cloud/api/my-agents/characters/avatar/route.ts
+++ b/packages/cloud/api/my-agents/characters/avatar/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { Hono } from "hono";
+import { readRequestWithinMultipartBudget } from "@/api/_lib/multipart-body-budget";
 import { orgStorageQuotaRepository } from "@/db/repositories/org-storage-quota";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
@@ -17,6 +18,12 @@ import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const MAX_BYTES = 5 * 1024 * 1024;
+// The multipart envelope — boundaries, part headers, any additional fields —
+// riding on top of the file this route accepts. Derived from MAX_BYTES so the
+// two cannot drift, and generous by design: this budget exists to bound the
+// isolate, not to police framing overhead.
+const MULTIPART_ENVELOPE_HEADROOM_BYTES = 1024 * 1024;
+const MAX_MULTIPART_BODY_BYTES = MAX_BYTES + MULTIPART_ENVELOPE_HEADROOM_BYTES;
 const ALLOWED = new Set(["image/jpeg", "image/png", "image/webp", "image/gif"]);
 
 function isFile(value: FormDataEntryValue | null): value is File {
@@ -47,7 +54,37 @@ app.post("/", async (c) => {
       );
     }
 
-    const form = await c.req.formData();
+    // Charge the byte budget before the body is parsed. `formData()` parses
+    // AND materializes every part, so the `entry.size > MAX_BYTES` check below
+    // used to run only once the bytes it exists to refuse were already
+    // resident — and this handler's catch cannot give a completed allocation
+    // back on a Cloudflare isolate (see @/api/_lib/multipart-body-budget).
+    const budgeted = await readRequestWithinMultipartBudget(
+      c.req.raw,
+      MAX_MULTIPART_BODY_BYTES,
+      (reason, cancelError) => {
+        // error-policy:J6 best-effort teardown for an upload already rejected.
+        logger.warn(
+          "[Character Avatar] Failed to cancel oversized upload body",
+          {
+            errorType:
+              cancelError instanceof Error ? cancelError.name : "unknown",
+            reason,
+          },
+        );
+      },
+    );
+    if (!budgeted.ok) {
+      return c.json(
+        {
+          success: false,
+          error: `Upload exceeds the ${MAX_MULTIPART_BODY_BYTES} byte request limit (${budgeted.bytes})`,
+        },
+        413,
+      );
+    }
+
+    const form = await budgeted.request.formData();
     const entry = form.get("file");
     if (!isFile(entry)) {
       return c.json({ success: false, error: "Missing file" }, 400);

--- a/packages/cloud/api/v1/user/avatar/route.ts
+++ b/packages/cloud/api/v1/user/avatar/route.ts
@@ -6,8 +6,8 @@
 
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { dbWrite } from "@/db/helpers";
 import { readRequestWithinMultipartBudget } from "@/api/_lib/multipart-body-budget";
+import { dbWrite } from "@/db/helpers";
 import { orgStorageQuotaRepository } from "@/db/repositories/org-storage-quota";
 import { users } from "@/db/schemas/users";
 import { failureResponse, NotFoundError } from "@/lib/api/cloud-worker-errors";
@@ -67,17 +67,27 @@ app.post("/", async (c) => {
       MAX_MULTIPART_BODY_BYTES,
       (reason, cancelError) => {
         // error-policy:J6 best-effort teardown for an upload already rejected.
-        logger.warn(
-          "[User Avatar] Failed to cancel oversized upload body",
-          {
-            errorType:
-              cancelError instanceof Error ? cancelError.name : "unknown",
-            reason,
-          },
-        );
+        logger.warn("[User Avatar] Failed to cancel upload body", {
+          errorType:
+            cancelError instanceof Error ? cancelError.name : "unknown",
+          reason,
+        });
       },
     );
     if (!budgeted.ok) {
+      if (budgeted.outcome === "incomplete") {
+        // error-policy:J4 a body that was aborted or never completed is a
+        // visibly distinct client-side failure, not an internal error.
+        logger.warn("[User Avatar] Multipart body read did not complete", {
+          reason: budgeted.reason,
+          errorType:
+            budgeted.error instanceof Error ? budgeted.error.name : "unknown",
+        });
+        return c.json(
+          { success: false, error: "Upload body could not be read" },
+          408,
+        );
+      }
       return c.json(
         {
           success: false,

--- a/packages/cloud/api/v1/user/avatar/route.ts
+++ b/packages/cloud/api/v1/user/avatar/route.ts
@@ -7,6 +7,7 @@
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { dbWrite } from "@/db/helpers";
+import { readRequestWithinMultipartBudget } from "@/api/_lib/multipart-body-budget";
 import { orgStorageQuotaRepository } from "@/db/repositories/org-storage-quota";
 import { users } from "@/db/schemas/users";
 import { failureResponse, NotFoundError } from "@/lib/api/cloud-worker-errors";
@@ -20,6 +21,12 @@ import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const MAX_BYTES = 5 * 1024 * 1024;
+// The multipart envelope — boundaries, part headers, any additional fields —
+// riding on top of the file this route accepts. Derived from MAX_BYTES so the
+// two cannot drift, and generous by design: this budget exists to bound the
+// isolate, not to police framing overhead.
+const MULTIPART_ENVELOPE_HEADROOM_BYTES = 1024 * 1024;
+const MAX_MULTIPART_BODY_BYTES = MAX_BYTES + MULTIPART_ENVELOPE_HEADROOM_BYTES;
 const ALLOWED = new Set(["image/jpeg", "image/png", "image/webp", "image/gif"]);
 
 function isFile(value: FormDataEntryValue | null): value is File {
@@ -50,7 +57,37 @@ app.post("/", async (c) => {
       );
     }
 
-    const form = await c.req.formData();
+    // Charge the byte budget before the body is parsed. `formData()` parses
+    // AND materializes every part, so the `entry.size > MAX_BYTES` check below
+    // used to run only once the bytes it exists to refuse were already
+    // resident — and this handler's catch cannot give a completed allocation
+    // back on a Cloudflare isolate (see @/api/_lib/multipart-body-budget).
+    const budgeted = await readRequestWithinMultipartBudget(
+      c.req.raw,
+      MAX_MULTIPART_BODY_BYTES,
+      (reason, cancelError) => {
+        // error-policy:J6 best-effort teardown for an upload already rejected.
+        logger.warn(
+          "[User Avatar] Failed to cancel oversized upload body",
+          {
+            errorType:
+              cancelError instanceof Error ? cancelError.name : "unknown",
+            reason,
+          },
+        );
+      },
+    );
+    if (!budgeted.ok) {
+      return c.json(
+        {
+          success: false,
+          error: `Upload exceeds the ${MAX_MULTIPART_BODY_BYTES} byte request limit (${budgeted.bytes})`,
+        },
+        413,
+      );
+    }
+
+    const form = await budgeted.request.formData();
     const entry = form.get("file");
     if (!isFile(entry)) {
       return c.json({ success: false, error: "Missing file" }, 400);


### PR DESCRIPTION
# Relates to

Fixes #24066.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is a single commit on
      `bb4054a818619fa221fe098dd6c923f4f214ac1a` (the `origin/develop` tip when
      it was cut), zero conflicts.
- [ ] `bun install` / `bun run verify` after sync — **not run**. See
      **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      before/after allocation measurements and the 29-case corpus below.

# Sync with develop

- [x] Branched off `origin/develop` at `bb4054a81861`; zero conflicts.
- [ ] `bun run verify` post-sync — not run; the exact blocker is in
      **Known gaps / failures**.

# Risks

**Low, with one deliberate behaviour change that this PR measures rather than
asserts.**

- Below the budget nothing changes — proven byte-for-byte across a 29-case
  origin-vs-branch corpus (status **and** exact response body).
- The budget bounds the whole multipart **envelope**, not the file. It is
  `MAX_BYTES + MULTIPART_ENVELOPE_HEADROOM_BYTES` = 5 MiB + 1 MiB = 6,291,456
  bytes. A request whose file is within the 5 MiB cap but whose *envelope*
  exceeds 6 MiB — e.g. a 5 MiB avatar plus 2 MiB of additional form fields —
  now gets a `413` where it previously succeeded. The same driver that proves
  the corpus also prints this case explicitly, with the byte counts, so the
  change is visible rather than inferred. Neither route reads any field except
  `file`, so 1 MiB of headroom is far more than the framing actually needs; if a
  maintainer wants a different number it is one constant.
- The read now consumes `c.req.raw.body` and re-wraps it, instead of Hono's
  cached `c.req.formData()`. Nothing downstream in either handler reads the body
  again.

# Background

## What does this PR do?

Both avatar upload routes declare a 5 MiB cap and then consult it one statement
after the whole multipart body has already been parsed into memory. Identical
code in both files on `origin/develop`:

```
:22   const MAX_BYTES = 5 * 1024 * 1024;
...
:53   const form = await c.req.formData();      <- parses AND materializes every part
:58   if (entry.size > MAX_BYTES) { ... 400 }    <- asks after paying
```

`formData()` does not hand back a lazy handle: it parses the envelope and
materializes each part, so `entry.size` cannot be consulted until the bytes the
comparison exists to refuse are already resident. This package deploys as a
Cloudflare Worker (`packages/cloud/api/wrangler.toml`,
`name = "eliza-cloud-api"`), where per-isolate memory is a hard platform limit.

**On the existing protection, precisely.** Both handlers *are* wrapped —
`try { … } catch (error) { return failureResponse(c, error); }` — and that
catch is real: it maps auth, quota and object-storage failures to the canonical
API error, and the R2/quota compensation logic around it is careful. It cannot
help here, because a `catch` runs *after* the allocation it would like to
prevent. The 400 arrives on top of the spend, not instead of it. Both routes are
also behind `rateLimit(RateLimitPresets.STANDARD)`, which bounds how *many*
requests an org may make, not what one of them costs — and one is enough.

**Reachability.** `requireUserOrApiKeyWithOrg(c)` — any authenticated user with
an active organization. The routes accept `multipart/form-data` and the body
size is whatever the client sends.

## What kind of change is this?

Bug fix (non-breaking, except as stated under **Risks**).

## The fix

A new import-free module,
`packages/cloud/api/_lib/multipart-body-budget.ts`, exporting
`readRequestWithinMultipartBudget(request, maxBytes, onCancelFailure?)`. It
charges the budget **before** the body is parsed, in two stages:

1. a declared `content-length` over budget is refused **without reading the body
   at all**, and the upload is cancelled best-effort;
2. otherwise the body is streamed and each chunk is charged against the running
   total **before** it is retained, so peak retention is the budget plus the
   chunk in hand. A `content-length` that is absent, non-numeric, or not a safe
   integer is **not** treated as a budget grant.

On success it hands back a `Request` with the same URL, method and headers
(minus `content-length`, which no longer describes the buffered body) so the
handler goes on to `.formData()` exactly as before.

Both stages are copied from `packages/cloud/api/v1/voice/stt/route.ts:370`
(`readRequestWithMultipartLimit`), the other multipart upload in this package,
which already does exactly this for its own limit. It is module-private there
and welded to the STT byte constants and 413 body, so the shape is reused rather
than the function; the new module is placed in `api/_lib` (alongside the
existing `api/compat/_lib` convention) because these two routes live in
different trees and would otherwise duplicate it.

The budget itself is derived, not a third literal:

```ts
const MAX_BYTES = 5 * 1024 * 1024;
const MULTIPART_ENVELOPE_HEADROOM_BYTES = 1024 * 1024;
const MAX_MULTIPART_BODY_BYTES = MAX_BYTES + MULTIPART_ENVELOPE_HEADROOM_BYTES;
```

so moving the file cap moves the envelope budget with it.

## Why both routes in one PR

`my-agents/characters/avatar/route.ts` and `v1/user/avatar/route.ts` are the
same handler twice: same `MAX_BYTES`, same `ALLOWED` set, same `isFile` helper,
same read, same check, same 400 body. They are already tested together by one
file (`packages/cloud/api/__tests__/avatar-storage-quota.test.ts`, which imports
both route modules and runs one table of cases against each). Fixing one and not
the other would leave the identical defect on the identical line.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Either avatar `route.ts` — the diff is one import, two derived constants, and
one replaced read; the two diffs are line-for-line the same apart from the
logger label. Then `_lib/multipart-body-budget.ts`, which is 136 lines and
imports nothing.

## Detailed testing steps

### 1. Allocation, origin vs branch, through the production seam

Hono's `c.req.formData()` is a cached passthrough to `c.req.raw.formData()`, so
the production seam is `Request.formData()` on the real request. The driver
builds a real WHATWG `Request` whose body is a real `ReadableStream` carrying a
real multipart envelope (`--boundary`, `Content-Disposition`, `Content-Type`,
1 MiB payload chunks, closing delimiter) and samples `process.memoryUsage()` at
the instant the parse resolves — before the `entry.size > MAX_BYTES` line runs.

| | upload | declared `content-length` | RSS at parse complete | status |
| --- | --- | --- | --- | --- |
| `origin/develop` | 4 MiB (a normal avatar) | yes | +15.2 MiB | `200` |
| `origin/develop` | 256 MiB | yes | **+776.5 MiB** | `400` "File too large (max 5MB)" |
| `origin/develop` | 256 MiB | no | **+776.5 MiB** | `400` "File too large (max 5MB)" |
| this branch | 4 MiB (a normal avatar) | yes | +20.3 MiB | `200` |
| this branch | 256 MiB | yes | **+3.9 MiB** | `413` |
| this branch | 256 MiB | no | **+10.8 MiB** | `413` |

`develop` enforces a 5 MiB cap at a cost of three quarters of a gigabyte. On this
branch the declared case never reads the body, and the chunked case stops at the
budget plus the chunk in hand.

### 2. No over-rejection — 29 cases, origin vs branch, identical

Every case is an upload that succeeds (or fails identically) on `develop` today.
Two identical `Request`s per case; status **and** exact JSON body compared.

- File sizes 1 B, 1 KiB, 1 MiB, 4 MiB, `MAX_BYTES - 1`, and `MAX_BYTES` exactly,
  each declared and chunked.
- A jpeg at the cap, a gif with a 512 KiB additional `notes` form field, an
  over-cap file that already 400s on `develop`, an unsupported MIME, a wrong
  field name, and a body with no parts at all.
- Five untrustworthy `content-length` headers on a valid 1 KiB upload:
  `"abc"`, `"0x400"`, `"-1"`, `"99999999999999999999"`, `""`.

```
corpus: 29 cases, identical=29, divergent=0
```

The same driver then prints the one intended divergence with its byte counts —
see **Risks**.

### 3. Load-bearing revert, by copy-aside (not `git stash`)

The new module was copied aside and only the budget was neutralized inside it
(`maxBytes = Number.POSITIVE_INFINITY`), leaving the restructured read intact.
The 256 MiB upload went back to `400` "File too large (max 5MB)" at **+1034.8
MiB RSS** (higher than `develop` because the re-wrap adds a copy when the budget
is not enforcing anything). Restoring the file restored `413` at +10.8 MiB.

### 4. Typecheck

The new module compiles clean under the package's own strict compiler settings,
TypeScript 6.0.3, zero diagnostics.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only change to two Cloud Worker route handlers and one new import-free module; no rendered UI surface is touched by this diff.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only change to two Cloud Worker route handlers and one new import-free module; no rendered UI surface is touched by this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-visible flow change; a valid avatar upload behaves identically, proven byte-for-byte in the corpus below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — pasted below: the
      `origin/develop` parse sequence and the real new module, both driven
      against real WHATWG `Request` objects carrying real multipart envelopes,
      with `process.memoryUsage()` sampled at the instant the parse resolves.

<details><summary>BEFORE — <code>origin/develop</code>, real <code>Request.formData()</code></summary>

```
$ bun proof-c-alloc.mjs origin 4 1     # develop, a normal 4 MiB avatar
{"mode":"origin","fileMiB":4,"declaredContentLength":true,"status":200,"body":{"success":true,"acceptedBytes":4194304},"elapsedMs":3,"rssAtParseCompleteMiB":"15.2","arrayBuffersAtParseCompleteMiB":"0.0","externalAtParseCompleteMiB":"0.0"}

$ bun proof-c-alloc.mjs origin 256 1   # develop, 256 MiB upload, declared
{"mode":"origin","fileMiB":256,"declaredContentLength":true,"status":400,"body":{"success":false,"error":"File too large (max 5MB)"},"elapsedMs":195,"rssAtParseCompleteMiB":"776.5","arrayBuffersAtParseCompleteMiB":"0.0","externalAtParseCompleteMiB":"190.1"}

$ bun proof-c-alloc.mjs origin 256 0   # develop, 256 MiB upload, chunked
{"mode":"origin","fileMiB":256,"declaredContentLength":false,"status":400,"body":{"success":false,"error":"File too large (max 5MB)"},"elapsedMs":116,"rssAtParseCompleteMiB":"776.5","arrayBuffersAtParseCompleteMiB":"0.0","externalAtParseCompleteMiB":"190.1"}
```

`rssAtParseCompleteMiB` is measured immediately after `formData()` resolves and
**before** the `entry.size > MAX_BYTES` line runs. The 400 that follows is
correct and is also three quarters of a gigabyte too late.

</details>

<details><summary>AFTER — this branch, same driver, same uploads</summary>

```
$ bun proof-c-alloc.mjs branch 4 1     # this branch, a normal 4 MiB avatar
{"mode":"branch","fileMiB":4,"declaredContentLength":true,"status":200,"body":{"success":true,"acceptedBytes":4194304},"elapsedMs":219,"rssAtParseCompleteMiB":"20.3","arrayBuffersAtParseCompleteMiB":"0.0","externalAtParseCompleteMiB":"0.0"}

$ bun proof-c-alloc.mjs branch 256 1   # this branch, 256 MiB upload, declared
{"mode":"branch","fileMiB":256,"declaredContentLength":true,"status":413,"body":{"success":false,"error":"Upload exceeds the 6291456 byte request limit (268435637)"},"elapsedMs":18,"rssAtParseCompleteMiB":"3.9","arrayBuffersAtParseCompleteMiB":"0.0","externalAtParseCompleteMiB":"0.0"}

$ bun proof-c-alloc.mjs branch 256 0   # this branch, 256 MiB upload, chunked
{"mode":"branch","fileMiB":256,"declaredContentLength":false,"status":413,"body":{"success":false,"error":"Upload exceeds the 6291456 byte request limit (6291592)"},"elapsedMs":20,"rssAtParseCompleteMiB":"10.8","arrayBuffersAtParseCompleteMiB":"0.0","externalAtParseCompleteMiB":"0.0"}
```

</details>

<details><summary>NO OVER-REJECTION — 29-case corpus, plus the one declared divergence</summary>

```
$ bun proof-c-corpus.mjs
SAME  1B png declared                              origin={"status":200,"body":{"success":true,"acceptedBytes":1,"mime":"image/png"}}
SAME  1B png chunked                               origin={"status":200,"body":{"success":true,"acceptedBytes":1,"mime":"image/png"}}
SAME  1KiB png declared                            origin={"status":200,"body":{"success":true,"acceptedBytes":1024,"mime":"image/png"}}
SAME  1KiB png chunked                             origin={"status":200,"body":{"success":true,"acceptedBytes":1024,"mime":"image/png"}}
SAME  1MiB png declared                            origin={"status":200,"body":{"success":true,"acceptedBytes":1048576,"mime":"image/png"}}
SAME  1MiB png chunked                             origin={"status":200,"body":{"success":true,"acceptedBytes":1048576,"mime":"image/png"}}
SAME  4MiB png declared                            origin={"status":200,"body":{"success":true,"acceptedBytes":4194304,"mime":"image/png"}}
SAME  4MiB png chunked                             origin={"status":200,"body":{"success":true,"acceptedBytes":4194304,"mime":"image/png"}}
SAME  cap-minus-1 png declared                     origin={"status":200,"body":{"success":true,"acceptedBytes":5242879,"mime":"image/png"}}
SAME  cap-minus-1 png chunked                      origin={"status":200,"body":{"success":true,"acceptedBytes":5242879,"mime":"image/png"}}
SAME  cap-exact png declared                       origin={"status":200,"body":{"success":true,"acceptedBytes":5242880,"mime":"image/png"}}
SAME  cap-exact png chunked                        origin={"status":200,"body":{"success":true,"acceptedBytes":5242880,"mime":"image/png"}}
SAME  cap-exact jpeg declared                      origin={"status":200,"body":{"success":true,"acceptedBytes":5242880,"mime":"image/jpeg"}}
SAME  cap-exact jpeg chunked                       origin={"status":200,"body":{"success":true,"acceptedBytes":5242880,"mime":"image/jpeg"}}
SAME  4MiB gif + 512KiB notes field declared       origin={"status":200,"body":{"success":true,"acceptedBytes":4194304,"mime":"image/gif"}}
SAME  4MiB gif + 512KiB notes field chunked        origin={"status":200,"body":{"success":true,"acceptedBytes":4194304,"mime":"image/gif"}}
SAME  cap+1 png (already 400 on develop) declared  origin={"status":400,"body":{"success":false,"error":"File too large (max 5MB)"}}
SAME  cap+1 png (already 400 on develop) chunked   origin={"status":400,"body":{"success":false,"error":"File too large (max 5MB)"}}
SAME  unsupported mime declared                    origin={"status":400,"body":{"success":false,"error":"Unsupported image type"}}
SAME  unsupported mime chunked                     origin={"status":400,"body":{"success":false,"error":"Unsupported image type"}}
SAME  wrong field name declared                    origin={"status":400,"body":{"success":false,"error":"Missing file"}}
SAME  wrong field name chunked                     origin={"status":400,"body":{"success":false,"error":"Missing file"}}
SAME  no parts at all declared                     origin={"status":400,"body":{"success":false,"error":"Missing file"}}
SAME  no parts at all chunked                      origin={"status":400,"body":{"success":false,"error":"Missing file"}}
SAME  1KiB png header="abc"                        origin={"status":200,"body":{"success":true,"acceptedBytes":1024,"mime":"image/png"}}
SAME  1KiB png header="0x400"                      origin={"status":200,"body":{"success":true,"acceptedBytes":1024,"mime":"image/png"}}
SAME  1KiB png header="-1"                         origin={"status":200,"body":{"success":true,"acceptedBytes":1024,"mime":"image/png"}}
SAME  1KiB png header="99999999999999999999"       origin={"status":200,"body":{"success":true,"acceptedBytes":1024,"mime":"image/png"}}
SAME  1KiB png header=""                           origin={"status":200,"body":{"success":true,"acceptedBytes":1024,"mime":"image/png"}}

corpus: 29 cases, identical=29, divergent=0

DECLARED DIVERGENCE (this is the behaviour change, not a surprise):
  cap-exact png + 2MiB extra field  envelope=7340304B budget=6291456B
    origin={"status":200,"body":{"success":true,"acceptedBytes":5242880,"mime":"image/png"}}
    branch={"status":413,"body":{"success":false,"error":"Upload exceeds the 6291456 byte request limit (7340304)"}}
```

</details>

<details><summary>LOAD-BEARING REVERT — copy-aside, budget alone neutralized</summary>

```
$ # copy-aside revert: budget alone neutralized inside the new module
$ bun proof-c-alloc.mjs branch 256 1
{"mode":"branch","fileMiB":256,"declaredContentLength":true,"status":400,"body":{"success":false,"error":"File too large (max 5MB)"},"elapsedMs":207,"rssAtParseCompleteMiB":"1034.8","arrayBuffersAtParseCompleteMiB":"0.0","externalAtParseCompleteMiB":"190.1"}
$ bun proof-c-alloc.mjs branch 256 0
{"mode":"branch","fileMiB":256,"declaredContentLength":false,"status":400,"body":{"success":false,"error":"File too large (max 5MB)"},"elapsedMs":141,"rssAtParseCompleteMiB":"1035.3","arrayBuffersAtParseCompleteMiB":"0.0","externalAtParseCompleteMiB":"190.1"}
$ # file restored
$ bun proof-c-alloc.mjs branch 256 0
{"mode":"branch","fileMiB":256,"declaredContentLength":false,"status":413,"body":{"success":false,"error":"Upload exceeds the 6291456 byte request limit (6291592)"},"elapsedMs":12,"rssAtParseCompleteMiB":"10.8","arrayBuffersAtParseCompleteMiB":"0.0","externalAtParseCompleteMiB":"0.0"}
```

</details>

<details><summary>TYPECHECK — the new module under the package's strict settings</summary>

```
$ node tsc --noEmit --strict --target ES2022 --module ESNext --moduleResolution Bundler \
    --isolatedModules --skipLibCheck --lib ES2023,WebWorker,DOM,DOM.Iterable \
    packages/cloud/api/_lib/multipart-body-budget.ts
Version 6.0.3
TSC_CLEAN
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend surface; the change is a request-body read inside two Worker routes.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, or model surface is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB rows, memories, scheduled tasks, wallet/on-chain output, or generated files are produced or altered; the storage-quota reservation and R2 compensation paths are untouched.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model surface is touched.`

## Backend + frontend logs

Backend: the runs under **Testing** are the code path firing end to end — the
real `Request.formData()` seam on `develop`, and the real
`readRequestWithinMultipartBudget()` module on this branch. Frontend:
`N/A - no frontend surface.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered visual surface.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT, or omnivoice surface.`

## Known gaps / failures

- **`bun run verify` was not run, and neither was the `packages/cloud` package
  typecheck nor `packages/cloud/api/__tests__/avatar-storage-quota.test.ts`** —
  the existing suite that drives both of these route modules. This machine could
  not complete a workspace install: the checkout lives on an external volume
  measured at ~1.6 MB/s under concurrent load, and `bun install` did not finish.
  Everything above was produced without `node_modules` by driving the real new
  module — deliberately import-free for exactly this reason — under `bun`. That
  suite builds its uploads with `FormData` + `route.request(...)`, which
  produces small in-budget bodies, so it should be unaffected; that is reasoning,
  not a green run, and closing it is the gap a reviewer should close.
- **`biome` was not run** on the touched files, for the same reason.
- **No new test file is added**: a `__tests__` entry that has never been executed
  would be a claim, not evidence. The natural home is
  `avatar-storage-quota.test.ts`, which already runs one table of cases against
  both route modules; I will add oversize cases there in this PR if a maintainer
  prefers that to merging the fix first.
- **Node/bun `formData()` is not workerd.** The absolute MiB figures would differ
  on workerd; the *shape* — whole body materialized before the check on
  `develop`, not materialized on this branch — is a property of the code, not the
  runtime. Bun's parser also derives `File.type` from the filename extension
  rather than the part's `Content-Type`, which is why the corpus names each file
  to match the MIME it exercises; both arms see byte-identical input either way.
- **Three sibling routes have the same shape and are deliberately not touched.**
  `v1/files/route.ts` (`MAX_UPLOAD_BYTES` 50 MiB × `MAX_UPLOAD_FILES` 10, both
  checked after the parse — its own permitted maximum is already 500 MiB),
  `v1/voice/clone/route.ts` (`MAX_TOTAL_SIZE` 100 MiB), and
  `v1/documents/pre-upload/route.ts`. Their declared ceilings are per-file or
  per-batch totals that already exceed what an isolate can hold, so charging a
  whole-envelope budget there is a decision about what the real ceiling should
  be, not a mechanical port of this diff. They are named in the issue as
  deserving their own.
- **Hosted CI checks do not run on this PR.** I contribute from a fork without
  push access to `elizaOS/eliza`, so no hosted check will report here, and
  nothing above should be read as "CI passed".

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:b3ed16b058a590681cc43546a498926369879695 -->

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0K5MV2QBWRD38TE4ZCEGYSW","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T22:04:15.319Z","completed_at":"2026-08-21T22:05:45.865Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T22:04:16.241Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"3a287915738f5ebb5f73530da12a91993076ffd5b77f93a1ed7fe5dc3a726974","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"89f05a41-3a48-41a5-8546-94775980224a","object_id":"sha256:3a287915738f5ebb5f73530da12a91993076ffd5b77f93a1ed7fe5dc3a726974","sha256":"3a287915738f5ebb5f73530da12a91993076ffd5b77f93a1ed7fe5dc3a726974"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"vEzyxvujIr5zcPzdWTMWee2yEGFWXEiNEcrt5lJ0J6HN5Uz1HpUOl4xxiEXstnpuRMQyLDeGkTgv5spSvhvRDQ"}} -->
