### PR TITLE
feat(cloud): add dormant manifest-v3 backup catalog worker

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -187,9 +187,10 @@ jobs:
       # compatibility window.
       AGENT_ROUTER_PUBLIC_HOST: ${{ needs.determine-env.outputs.environment == 'production' && 'eliza-production-1.eliza.app' || 'eliza-staging-1.eliza.app' }}
       LEGACY_AGENT_ROUTER_PUBLIC_HOST: ${{ needs.determine-env.outputs.environment == 'production' && 'eliza-production-1.elizacloud.ai' || 'eliza-staging-1.elizacloud.ai' }}
-      # Backup catalogue values are optional while both merge-time gates remain
-      # forced off. They are reconciled by name now so later activation cannot
-      # depend on undocumented host-only configuration.
+      # Non-secret backup catalogue inputs document the future activation
+      # contract while both merge-time gates remain forced off. The five backup
+      # credentials are intentionally not sourced or transported in this
+      # dormant changeset; a reviewed activation must add that authority.
       AGENT_BACKUP_CATALOG_WORKER_ID: ${{ vars.AGENT_BACKUP_CATALOG_WORKER_ID }}
       AGENT_BACKUP_R2_ENDPOINT_ALIAS: ${{ vars.AGENT_BACKUP_R2_ENDPOINT_ALIAS }}
       AGENT_BACKUP_R2_ACCOUNT_ID: ${{ vars.AGENT_BACKUP_R2_ACCOUNT_ID }}
@@ -213,9 +214,22 @@ jobs:
       AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE: ${{ vars.AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE }}
       AGENT_BACKUP_CAPTURE_DEADLINE_MS: ${{ vars.AGENT_BACKUP_CAPTURE_DEADLINE_MS }}
       AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS: ${{ vars.AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS }}
+      AGENT_BACKUP_SCHEDULE_BATCH_SIZE: ${{ vars.AGENT_BACKUP_SCHEDULE_BATCH_SIZE }}
+      AGENT_BACKUP_SCHEDULE_LEASE_MS: ${{ vars.AGENT_BACKUP_SCHEDULE_LEASE_MS }}
+      AGENT_BACKUP_SCHEDULE_RETRY_MS: ${{ vars.AGENT_BACKUP_SCHEDULE_RETRY_MS }}
+      AGENT_BACKUP_OPERATION_BATCH_SIZE: ${{ vars.AGENT_BACKUP_OPERATION_BATCH_SIZE }}
+      AGENT_BACKUP_OPERATION_LEASE_MS: ${{ vars.AGENT_BACKUP_OPERATION_LEASE_MS }}
+      AGENT_BACKUP_OPERATION_RETRY_BASE_MS: ${{ vars.AGENT_BACKUP_OPERATION_RETRY_BASE_MS }}
+      AGENT_BACKUP_OPERATION_RETRY_MAX_MS: ${{ vars.AGENT_BACKUP_OPERATION_RETRY_MAX_MS }}
+      AGENT_BACKUP_GC_BATCH_SIZE: ${{ vars.AGENT_BACKUP_GC_BATCH_SIZE }}
+      AGENT_BACKUP_GC_LEASE_MS: ${{ vars.AGENT_BACKUP_GC_LEASE_MS }}
+      AGENT_BACKUP_GC_RETRY_BASE_MS: ${{ vars.AGENT_BACKUP_GC_RETRY_BASE_MS }}
+      AGENT_BACKUP_GC_RETRY_MAX_MS: ${{ vars.AGENT_BACKUP_GC_RETRY_MAX_MS }}
+      AGENT_BACKUP_DELETION_BATCH_SIZE: ${{ vars.AGENT_BACKUP_DELETION_BATCH_SIZE }}
       AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS: ${{ vars.AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS }}
       AGENT_BACKUP_CATALOG_WORKER_RETRY_MS: ${{ vars.AGENT_BACKUP_CATALOG_WORKER_RETRY_MS }}
       AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS: ${{ vars.AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS }}
+      DATABASE_SSL_NO_VERIFY: ${{ vars.DATABASE_SSL_NO_VERIFY }}
     steps:
       - name: Validate canonical deploy configuration and shared secrets
         id: deploy_config
@@ -313,6 +327,22 @@ jobs:
             echo "::error::Migration checkout is not clean"
             exit 1
           }
+          helper_sha256=$(sha256sum \
+            packages/cloud/scripts/admin/systemd-environment-line.mjs | awk '{print $1}')
+          backup_unit_sha256=$(sha256sum \
+            packages/cloud/scripts/admin/eliza-backup-catalog-worker.service | awk '{print $1}')
+          [[ "$helper_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+            echo "::error::Could not hash the exact-SHA EnvironmentFile helper"
+            exit 1
+          }
+          [[ "$backup_unit_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+            echo "::error::Could not hash the exact-SHA backup systemd unit"
+            exit 1
+          }
+          {
+            echo "SYSTEMD_ENVIRONMENT_HELPER_SHA256=$helper_sha256"
+            echo "BACKUP_SYSTEMD_UNIT_SHA256=$backup_unit_sha256"
+          } >> "$GITHUB_ENV"
 
       - name: Setup Node for migration gate
         if: steps.deploy_config.outputs.configured == 'true'
@@ -441,11 +471,6 @@ jobs:
           SANDBOX_REGISTRY_REDIS_URL: ${{ secrets.SANDBOX_REGISTRY_REDIS_URL }}
           DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.RAILWAY_DATABASE_URL || secrets.NEON_DATABASE_URL }}
           SECRETS_MASTER_KEY: ${{ secrets.SECRETS_MASTER_KEY }}
-          AGENT_BACKUP_R2_ACCESS_KEY_ID: ${{ secrets.AGENT_BACKUP_R2_ACCESS_KEY_ID }}
-          AGENT_BACKUP_R2_SECRET_ACCESS_KEY: ${{ secrets.AGENT_BACKUP_R2_SECRET_ACCESS_KEY }}
-          AGENT_BACKUP_HETZNER_ACCESS_KEY_ID: ${{ secrets.AGENT_BACKUP_HETZNER_ACCESS_KEY_ID }}
-          AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY: ${{ secrets.AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY }}
-          AGENT_BACKUP_STEWARD_KMS_TOKEN: ${{ secrets.AGENT_BACKUP_STEWARD_KMS_TOKEN }}
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
         with:
           host: ${{ secrets.ELIZA_PROVISIONING_HOST }}
@@ -455,7 +480,7 @@ jobs:
           # wait without weakening the preflight's own eight-minute fail-closed
           # fence near the end of this remote script.
           command_timeout: 40m
-          envs: DEPLOY_BRANCH,DEPLOY_SHA,SYSTEMD_UNIT,BACKUP_SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,CONTAINERS_SSH_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE,WARM_POOL_ENABLED,ELIZA_CLOUD_AGENT_BASE_DOMAIN,AGENT_ROUTER_PUBLIC_HOST,LEGACY_AGENT_ROUTER_PUBLIC_HOST,AGENT_BACKUP_CATALOG_WORKER_ID,AGENT_BACKUP_R2_ENDPOINT_ALIAS,AGENT_BACKUP_R2_ACCOUNT_ID,AGENT_BACKUP_R2_ENDPOINT,AGENT_BACKUP_R2_BUCKET,AGENT_BACKUP_R2_REGION,AGENT_BACKUP_R2_ACCESS_KEY_ID,AGENT_BACKUP_R2_SECRET_ACCESS_KEY,AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS,AGENT_BACKUP_HETZNER_ACCOUNT_ID,AGENT_BACKUP_HETZNER_ENDPOINT,AGENT_BACKUP_HETZNER_BUCKET,AGENT_BACKUP_HETZNER_REGION,AGENT_BACKUP_HETZNER_ACCESS_KEY_ID,AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY,AGENT_BACKUP_STEWARD_KMS_BASE_URL,AGENT_BACKUP_STEWARD_KMS_TOKEN,AGENT_BACKUP_AGENT_SCHEMA_VERSION,AGENT_BACKUP_DATABASE_SCHEMA_VERSION,AGENT_BACKUP_RUNTIME_PLUGINS_JSON,AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID,AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT,AGENT_BACKUP_STORAGE_SCOPE,AGENT_BACKUP_SPOOL_MAX_BYTES,AGENT_BACKUP_SPOOL_MIN_FREE_BYTES,AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE,AGENT_BACKUP_CAPTURE_DEADLINE_MS,AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS,AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS,AGENT_BACKUP_CATALOG_WORKER_RETRY_MS,AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS
+          envs: DEPLOY_BRANCH,DEPLOY_SHA,SYSTEMD_UNIT,BACKUP_SYSTEMD_UNIT,SYSTEMD_ENVIRONMENT_HELPER_SHA256,BACKUP_SYSTEMD_UNIT_SHA256,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,CONTAINERS_SSH_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,DATABASE_SSL_NO_VERIFY,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE,WARM_POOL_ENABLED,ELIZA_CLOUD_AGENT_BASE_DOMAIN,AGENT_ROUTER_PUBLIC_HOST,LEGACY_AGENT_ROUTER_PUBLIC_HOST,AGENT_BACKUP_CATALOG_WORKER_ID,AGENT_BACKUP_R2_ENDPOINT_ALIAS,AGENT_BACKUP_R2_ACCOUNT_ID,AGENT_BACKUP_R2_ENDPOINT,AGENT_BACKUP_R2_BUCKET,AGENT_BACKUP_R2_REGION,AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS,AGENT_BACKUP_HETZNER_ACCOUNT_ID,AGENT_BACKUP_HETZNER_ENDPOINT,AGENT_BACKUP_HETZNER_BUCKET,AGENT_BACKUP_HETZNER_REGION,AGENT_BACKUP_STEWARD_KMS_BASE_URL,AGENT_BACKUP_AGENT_SCHEMA_VERSION,AGENT_BACKUP_DATABASE_SCHEMA_VERSION,AGENT_BACKUP_RUNTIME_PLUGINS_JSON,AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID,AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT,AGENT_BACKUP_STORAGE_SCOPE,AGENT_BACKUP_SPOOL_MAX_BYTES,AGENT_BACKUP_SPOOL_MIN_FREE_BYTES,AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE,AGENT_BACKUP_CAPTURE_DEADLINE_MS,AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS,AGENT_BACKUP_SCHEDULE_BATCH_SIZE,AGENT_BACKUP_SCHEDULE_LEASE_MS,AGENT_BACKUP_SCHEDULE_RETRY_MS,AGENT_BACKUP_OPERATION_BATCH_SIZE,AGENT_BACKUP_OPERATION_LEASE_MS,AGENT_BACKUP_OPERATION_RETRY_BASE_MS,AGENT_BACKUP_OPERATION_RETRY_MAX_MS,AGENT_BACKUP_GC_BATCH_SIZE,AGENT_BACKUP_GC_LEASE_MS,AGENT_BACKUP_GC_RETRY_BASE_MS,AGENT_BACKUP_GC_RETRY_MAX_MS,AGENT_BACKUP_DELETION_BATCH_SIZE,AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS,AGENT_BACKUP_CATALOG_WORKER_RETRY_MS,AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS
           script: |
             set -euo pipefail
 
@@ -539,6 +564,113 @@ jobs:
             # installs are lockfile-pinned and deterministic.
             git checkout "$DEPLOY_SHA" -- bun.lock
 
+            # Root must never execute a helper from the deploy-writable checkout.
+            # The runner hashed both privileged artifacts from the already
+            # verified immutable checkout. Copy through a root-only candidate,
+            # verify that candidate, atomically rename it inside the same
+            # root-owned directory, then verify the installed destination again.
+            # TEST-ANCHOR: root-artifact-installer-begin
+            install_root_verified_file() {
+              local source_path="$1"
+              local destination_path="$2"
+              local expected_sha256="$3"
+              local install_mode="$4"
+              local destination_directory="${destination_path%/*}"
+              local destination_name="${destination_path##*/}"
+              local expected_stat_mode="${install_mode#0}"
+              local candidate_path="${destination_directory}/.${destination_name}.candidate.${DEPLOY_SHA}.$$"
+              local digest_output=""
+              local actual_sha256=""
+              local actual_stat=""
+
+              if [[ ! "$expected_sha256" =~ ^[0-9a-f]{64}$ ]]; then
+                echo "::error::Refusing a root artifact without an exact-SHA digest"
+                return 1
+              fi
+              case "$install_mode" in
+                0555|0644) ;;
+                *)
+                  echo "::error::Refusing an unsupported root artifact mode"
+                  return 1
+                  ;;
+              esac
+
+              if ! digest_output=$(/usr/bin/sha256sum -- "$source_path"); then
+                echo "::error::Could not hash a root artifact source"
+                return 1
+              fi
+              actual_sha256="${digest_output%% *}"
+              if [ "$actual_sha256" != "$expected_sha256" ]; then
+                echo "::error::Root artifact source differs from the exact checkout"
+                return 1
+              fi
+
+              if ! sudo /usr/bin/install -d -o root -g root -m 0755 \
+                "$destination_directory"; then
+                echo "::error::Could not prepare the root artifact directory"
+                return 1
+              fi
+              actual_stat=$(sudo /usr/bin/stat -c '%U:%G:%a' \
+                "$destination_directory") || return 1
+              if [ "$actual_stat" != "root:root:755" ]; then
+                echo "::error::Root artifact directory ownership or mode is invalid"
+                return 1
+              fi
+
+              if ! sudo /usr/bin/install -o root -g root -m "$install_mode" -- \
+                "$source_path" "$candidate_path"; then
+                echo "::error::Could not stage a root artifact candidate"
+                return 1
+              fi
+              if ! digest_output=$(sudo /usr/bin/sha256sum -- "$candidate_path"); then
+                sudo /usr/bin/rm -f -- "$candidate_path" || true
+                echo "::error::Could not hash a root artifact candidate"
+                return 1
+              fi
+              actual_sha256="${digest_output%% *}"
+              actual_stat=$(sudo /usr/bin/stat -c '%U:%G:%a' \
+                "$candidate_path") || {
+                sudo /usr/bin/rm -f -- "$candidate_path" || true
+                return 1
+              }
+              if [ "$actual_sha256" != "$expected_sha256" ] \
+                || [ "$actual_stat" != "root:root:$expected_stat_mode" ]; then
+                sudo /usr/bin/rm -f -- "$candidate_path" || true
+                echo "::error::Root artifact candidate failed integrity checks"
+                return 1
+              fi
+
+              if ! sudo /usr/bin/mv -fT -- "$candidate_path" "$destination_path"; then
+                sudo /usr/bin/rm -f -- "$candidate_path" || true
+                echo "::error::Could not atomically install a root artifact"
+                return 1
+              fi
+              digest_output=$(sudo /usr/bin/sha256sum -- "$destination_path") \
+                || return 1
+              actual_sha256="${digest_output%% *}"
+              actual_stat=$(sudo /usr/bin/stat -c '%U:%G:%a' \
+                "$destination_path") || return 1
+              if [ "$actual_sha256" != "$expected_sha256" ] \
+                || [ "$actual_stat" != "root:root:$expected_stat_mode" ]; then
+                echo "::error::Installed root artifact failed integrity checks"
+                return 1
+              fi
+            }
+            # TEST-ANCHOR: root-artifact-installer-end
+
+            NODE_BIN=/usr/bin/node
+            if [ ! -x "$NODE_BIN" ] || [[ "$("$NODE_BIN" --version)" != v24.* ]]; then
+              echo "::error::The canonical root-owned Node 24 binary is unavailable"
+              exit 1
+            fi
+            ENV_SERIALIZER_SOURCE=/opt/eliza/packages/cloud/scripts/admin/systemd-environment-line.mjs
+            ENV_SERIALIZER=/usr/local/lib/eliza-admin/systemd-environment-line.mjs
+            install_root_verified_file \
+              "$ENV_SERIALIZER_SOURCE" \
+              "$ENV_SERIALIZER" \
+              "$SYSTEMD_ENVIRONMENT_HELPER_SHA256" \
+              0555
+
             # git clean removes these intentionally ignored modules. Generate
             # and assert them before install/build, while the healthy daemons
             # are still running, so generator failure cannot cause downtime.
@@ -589,19 +721,6 @@ jobs:
             mkdir -p node_modules/@elizaos
             ln -sfn ../../packages/cloud/shared node_modules/@elizaos/cloud-shared
 
-            # Install/refresh the provisioning, router, and dormant backup units.
-            sudo install -m 0644 \
-              packages/cloud/scripts/admin/eliza-provisioning-worker.service \
-              "/etc/systemd/system/$SYSTEMD_UNIT"
-            sudo install -m 0644 \
-              packages/cloud/scripts/admin/eliza-agent-router.service \
-              /etc/systemd/system/eliza-agent-router.service
-            sudo install -m 0644 \
-              packages/cloud/scripts/admin/eliza-backup-catalog-worker.service \
-              "/etc/systemd/system/$BACKUP_SYSTEMD_UNIT"
-            sudo systemctl daemon-reload
-            sudo systemctl enable "$SYSTEMD_UNIT" eliza-agent-router.service "$BACKUP_SYSTEMD_UNIT"
-
             # Reconcile control-plane secrets (HEADSCALE_API_URL /
             # HEADSCALE_PUBLIC_URL / HEADSCALE_API_KEY /
             # SANDBOX_REGISTRY_REDIS_URL / DATABASE_URL / SECRETS_MASTER_KEY)
@@ -623,7 +742,65 @@ jobs:
             # docker-sandbox-provider throw "HEADSCALE_API_KEY is not
             # configured" when a route is required).
             ENV_FILE=/opt/eliza/cloud/.env.local
-            sudo touch "$ENV_FILE"
+            BACKUP_ENV_FILE=/etc/eliza/backup-catalog-worker.env
+            BUN_BIN=$(command -v bun)
+            SAFE_CHILD_PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/bin
+            # TEST-ANCHOR: atomic-environment-reconcile-begin
+            RECONCILE_PLAN_DIR=$(mktemp -d)
+            chmod 700 "$RECONCILE_PLAN_DIR"
+            ENV_REPLACEMENTS="$RECONCILE_PLAN_DIR/host-replacements"
+            ENV_ASSIGNMENTS="$RECONCILE_PLAN_DIR/host-assignments"
+            BACKUP_REPLACEMENTS="$RECONCILE_PLAN_DIR/backup-replacements"
+            BACKUP_ASSIGNMENTS="$RECONCILE_PLAN_DIR/backup-assignments"
+            : > "$ENV_REPLACEMENTS"
+            : > "$ENV_ASSIGNMENTS"
+            : > "$BACKUP_REPLACEMENTS"
+            : > "$BACKUP_ASSIGNMENTS"
+            chmod 600 \
+              "$ENV_REPLACEMENTS" \
+              "$ENV_ASSIGNMENTS" \
+              "$BACKUP_REPLACEMENTS" \
+              "$BACKUP_ASSIGNMENTS"
+            trap 'rm -rf -- "$RECONCILE_PLAN_DIR"' EXIT
+
+            run_environment_helper() {
+              /usr/bin/env -i PATH="$SAFE_CHILD_PATH" \
+                "$NODE_BIN" "$ENV_SERIALIZER" "$@"
+            }
+
+            append_environment_setting() {
+              local names_file="$1"
+              local assignments_file="$2"
+              local key="$3"
+              local value="$4"
+              printf '%s\n' "$key" >> "$names_file"
+              # The value crosses the external-process boundary only on stdin.
+              # argv and rejection diagnostics contain the non-secret key only.
+              printf '%s' "$value" \
+                | run_environment_helper serialize "$key" \
+                >> "$assignments_file"
+            }
+
+            remove_environment_setting() {
+              printf '%s\n' "$2" >> "$1"
+            }
+
+            require_environment_settings() {
+              local file="$1"
+              shift
+              sudo /usr/bin/env -i PATH="$SAFE_CHILD_PATH" \
+                "$NODE_BIN" "$ENV_SERIALIZER" nonempty "$file" "$@"
+            }
+
+            require_environment_setting_equals() {
+              local file="$1"
+              local key="$2"
+              local expected="$3"
+              printf '%s' "$expected" \
+                | sudo /usr/bin/env -i PATH="$SAFE_CHILD_PATH" \
+                    "$NODE_BIN" "$ENV_SERIALIZER" equals "$file" "$key"
+            }
+
             # Pin this control-plane daemon to the AGENT lane. Unset, a single
             # daemon claims ALL job types (agent + apps); it would claim
             # APP_DEPLOY / CONTAINER_* jobs it can't run (no apps backend wired
@@ -633,24 +810,89 @@ jobs:
             # every deploy (same mechanism as the HEADSCALE_* keys below). This
             # value is constant — not a GH var — so it's reconciled directly,
             # never blanked.
-            sudo sed -i "/^PROVISIONING_JOB_LANES=/d" "$ENV_FILE"
-            printf 'PROVISIONING_JOB_LANES=%s\n' "agent" | sudo tee -a "$ENV_FILE" >/dev/null
+            append_environment_setting \
+              "$ENV_REPLACEMENTS" "$ENV_ASSIGNMENTS" \
+              PROVISIONING_JOB_LANES agent
             # Headscale is the required dedicated-agent ingress. Bridge-host
             # fallback was a legacy escape hatch; if it remains hand-set on the
             # box, docker-sandbox-provider deliberately disables VPN injection
             # and fresh staging agents never receive a headscale_ip (#15347).
-            sudo sed -i "/^AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK=/d" "$ENV_FILE"
+            remove_environment_setting \
+              "$ENV_REPLACEMENTS" AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK
             # The manifest-v3 catalogue ships dormant. Remove stale host edits
-            # and append the two gates exactly once; values are also pinned on
-            # the systemd command line as a second independent fence.
-            sudo sed -i "/^AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=/d" "$ENV_FILE"
-            sudo sed -i "/^AGENT_BACKUP_RPO_SCHEDULER_ENABLED=/d" "$ENV_FILE"
-            sudo sed -i "/^AGENT_BACKUP_SPOOL_STATE_DIRECTORY=/d" "$ENV_FILE"
-            sudo sed -i "/^AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE=/d" "$ENV_FILE"
-            printf '%s=%s\n' AGENT_BACKUP_CATALOG_RUNTIME_ENABLED 0 | sudo tee -a "$ENV_FILE" >/dev/null
-            printf '%s=%s\n' AGENT_BACKUP_RPO_SCHEDULER_ENABLED 0 | sudo tee -a "$ENV_FILE" >/dev/null
-            printf '%s=%s\n' AGENT_BACKUP_SPOOL_STATE_DIRECTORY /var/lib/eliza-backup-catalog/spool | sudo tee -a "$ENV_FILE" >/dev/null
-            printf '%s=%s\n' AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE /run/eliza-backup-catalog/health.json | sudo tee -a "$ENV_FILE" >/dev/null
+            # and append the two gates exactly once. Its systemd unit reads only
+            # the dedicated allowlisted file assembled below.
+            BACKUP_CATALOG_RUNTIME_GATE=0
+            BACKUP_RPO_SCHEDULER_GATE=0
+            BACKUP_SPOOL_STATE_DIRECTORY=/var/lib/eliza-backup-catalog/spool
+            BACKUP_WORKER_HEALTH_FILE=/run/eliza-backup-catalog/health.json
+            BACKUP_WORKER_INTERVAL_MS="${AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS:-60000}"
+            BACKUP_WORKER_RETRY_MS="${AGENT_BACKUP_CATALOG_WORKER_RETRY_MS:-5000}"
+            BACKUP_WORKER_SHUTDOWN_TIMEOUT_MS="${AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS:-25000}"
+            append_environment_setting \
+              "$ENV_REPLACEMENTS" "$ENV_ASSIGNMENTS" \
+              AGENT_BACKUP_CATALOG_RUNTIME_ENABLED "$BACKUP_CATALOG_RUNTIME_GATE"
+            append_environment_setting \
+              "$ENV_REPLACEMENTS" "$ENV_ASSIGNMENTS" \
+              AGENT_BACKUP_RPO_SCHEDULER_ENABLED "$BACKUP_RPO_SCHEDULER_GATE"
+            append_environment_setting \
+              "$ENV_REPLACEMENTS" "$ENV_ASSIGNMENTS" \
+              AGENT_BACKUP_SPOOL_STATE_DIRECTORY "$BACKUP_SPOOL_STATE_DIRECTORY"
+            append_environment_setting \
+              "$ENV_REPLACEMENTS" "$ENV_ASSIGNMENTS" \
+              AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE "$BACKUP_WORKER_HEALTH_FILE"
+            # The provisioning worker and router still consume the shared file.
+            # Delete every known backup-only authority/configuration left by an
+            # older deployment so those processes inherit only the four inert
+            # compatibility settings above. Names, never values, enter this plan.
+            shared_backup_only_names=(
+              AGENT_BACKUP_CATALOG_WORKER_ID
+              AGENT_BACKUP_R2_ENDPOINT_ALIAS
+              AGENT_BACKUP_R2_ACCOUNT_ID
+              AGENT_BACKUP_R2_ENDPOINT
+              AGENT_BACKUP_R2_BUCKET
+              AGENT_BACKUP_R2_REGION
+              AGENT_BACKUP_R2_ACCESS_KEY_ID
+              AGENT_BACKUP_R2_SECRET_ACCESS_KEY
+              AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS
+              AGENT_BACKUP_HETZNER_ACCOUNT_ID
+              AGENT_BACKUP_HETZNER_ENDPOINT
+              AGENT_BACKUP_HETZNER_BUCKET
+              AGENT_BACKUP_HETZNER_REGION
+              AGENT_BACKUP_HETZNER_ACCESS_KEY_ID
+              AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY
+              AGENT_BACKUP_STEWARD_KMS_BASE_URL
+              AGENT_BACKUP_STEWARD_KMS_TOKEN
+              AGENT_BACKUP_AGENT_SCHEMA_VERSION
+              AGENT_BACKUP_DATABASE_SCHEMA_VERSION
+              AGENT_BACKUP_RUNTIME_PLUGINS_JSON
+              AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID
+              AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT
+              AGENT_BACKUP_STORAGE_SCOPE
+              AGENT_BACKUP_SPOOL_MAX_BYTES
+              AGENT_BACKUP_SPOOL_MIN_FREE_BYTES
+              AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE
+              AGENT_BACKUP_CAPTURE_DEADLINE_MS
+              AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS
+              AGENT_BACKUP_SCHEDULE_BATCH_SIZE
+              AGENT_BACKUP_SCHEDULE_LEASE_MS
+              AGENT_BACKUP_SCHEDULE_RETRY_MS
+              AGENT_BACKUP_OPERATION_BATCH_SIZE
+              AGENT_BACKUP_OPERATION_LEASE_MS
+              AGENT_BACKUP_OPERATION_RETRY_BASE_MS
+              AGENT_BACKUP_OPERATION_RETRY_MAX_MS
+              AGENT_BACKUP_GC_BATCH_SIZE
+              AGENT_BACKUP_GC_LEASE_MS
+              AGENT_BACKUP_GC_RETRY_BASE_MS
+              AGENT_BACKUP_GC_RETRY_MAX_MS
+              AGENT_BACKUP_DELETION_BATCH_SIZE
+              AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS
+              AGENT_BACKUP_CATALOG_WORKER_RETRY_MS
+              AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS
+            )
+            for name in "${shared_backup_only_names[@]}"; do
+              remove_environment_setting "$ENV_REPLACEMENTS" "$name"
+            done
             for kv in \
               "HEADSCALE_API_URL=$HEADSCALE_API_URL" \
               "HEADSCALE_PUBLIC_URL=$HEADSCALE_PUBLIC_URL" \
@@ -662,37 +904,7 @@ jobs:
               "ELIZA_AGENT_IMAGE=$ELIZA_AGENT_IMAGE" \
               "WARM_POOL_ENABLED=$WARM_POOL_ENABLED" \
               "ELIZA_CLOUD_AGENT_BASE_DOMAIN=$ELIZA_CLOUD_AGENT_BASE_DOMAIN" \
-              "AGENT_BACKUP_CATALOG_WORKER_ID=$AGENT_BACKUP_CATALOG_WORKER_ID" \
-              "AGENT_BACKUP_R2_ENDPOINT_ALIAS=$AGENT_BACKUP_R2_ENDPOINT_ALIAS" \
-              "AGENT_BACKUP_R2_ACCOUNT_ID=$AGENT_BACKUP_R2_ACCOUNT_ID" \
-              "AGENT_BACKUP_R2_ENDPOINT=$AGENT_BACKUP_R2_ENDPOINT" \
-              "AGENT_BACKUP_R2_BUCKET=$AGENT_BACKUP_R2_BUCKET" \
-              "AGENT_BACKUP_R2_REGION=$AGENT_BACKUP_R2_REGION" \
-              "AGENT_BACKUP_R2_ACCESS_KEY_ID=$AGENT_BACKUP_R2_ACCESS_KEY_ID" \
-              "AGENT_BACKUP_R2_SECRET_ACCESS_KEY=$AGENT_BACKUP_R2_SECRET_ACCESS_KEY" \
-              "AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS=$AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS" \
-              "AGENT_BACKUP_HETZNER_ACCOUNT_ID=$AGENT_BACKUP_HETZNER_ACCOUNT_ID" \
-              "AGENT_BACKUP_HETZNER_ENDPOINT=$AGENT_BACKUP_HETZNER_ENDPOINT" \
-              "AGENT_BACKUP_HETZNER_BUCKET=$AGENT_BACKUP_HETZNER_BUCKET" \
-              "AGENT_BACKUP_HETZNER_REGION=$AGENT_BACKUP_HETZNER_REGION" \
-              "AGENT_BACKUP_HETZNER_ACCESS_KEY_ID=$AGENT_BACKUP_HETZNER_ACCESS_KEY_ID" \
-              "AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY=$AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY" \
-              "AGENT_BACKUP_STEWARD_KMS_BASE_URL=$AGENT_BACKUP_STEWARD_KMS_BASE_URL" \
-              "AGENT_BACKUP_STEWARD_KMS_TOKEN=$AGENT_BACKUP_STEWARD_KMS_TOKEN" \
-              "AGENT_BACKUP_AGENT_SCHEMA_VERSION=$AGENT_BACKUP_AGENT_SCHEMA_VERSION" \
-              "AGENT_BACKUP_DATABASE_SCHEMA_VERSION=$AGENT_BACKUP_DATABASE_SCHEMA_VERSION" \
-              "AGENT_BACKUP_RUNTIME_PLUGINS_JSON=$AGENT_BACKUP_RUNTIME_PLUGINS_JSON" \
-              "AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID=$AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID" \
-              "AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT=$AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT" \
-              "AGENT_BACKUP_STORAGE_SCOPE=$AGENT_BACKUP_STORAGE_SCOPE" \
-              "AGENT_BACKUP_SPOOL_MAX_BYTES=$AGENT_BACKUP_SPOOL_MAX_BYTES" \
-              "AGENT_BACKUP_SPOOL_MIN_FREE_BYTES=$AGENT_BACKUP_SPOOL_MIN_FREE_BYTES" \
-              "AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE=$AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE" \
-              "AGENT_BACKUP_CAPTURE_DEADLINE_MS=$AGENT_BACKUP_CAPTURE_DEADLINE_MS" \
-              "AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS=$AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS" \
-              "AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS=$AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS" \
-              "AGENT_BACKUP_CATALOG_WORKER_RETRY_MS=$AGENT_BACKUP_CATALOG_WORKER_RETRY_MS" \
-              "AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS=$AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS"; do
+              "DATABASE_SSL_NO_VERIFY=$DATABASE_SSL_NO_VERIFY"; do
               key="${kv%%=*}"
               val="${kv#*=}"
               [ -n "$val" ] || continue
@@ -702,10 +914,183 @@ jobs:
                   exit 1
                   ;;
               esac
-              sudo sed -i "/^${key}=/d" "$ENV_FILE"
-              printf '%s=%s\n' "$key" "$val" | sudo tee -a "$ENV_FILE" >/dev/null
+              append_environment_setting \
+                "$ENV_REPLACEMENTS" "$ENV_ASSIGNMENTS" "$key" "$val"
             done
-            sudo chmod 600 "$ENV_FILE"
+
+            # The backup daemon receives a separate exact allowlist. While the
+            # merge-time gates remain hardcoded off, this plan contains only
+            # gates, cadence, spool, and health paths: no database, encryption,
+            # provider, KMS, SSH, Headscale, or registry authority can leak in
+            # from the shared host file or a stale previous deployment.
+            append_environment_setting \
+              "$BACKUP_REPLACEMENTS" "$BACKUP_ASSIGNMENTS" \
+              AGENT_BACKUP_CATALOG_RUNTIME_ENABLED "$BACKUP_CATALOG_RUNTIME_GATE"
+            append_environment_setting \
+              "$BACKUP_REPLACEMENTS" "$BACKUP_ASSIGNMENTS" \
+              AGENT_BACKUP_RPO_SCHEDULER_ENABLED "$BACKUP_RPO_SCHEDULER_GATE"
+            append_environment_setting \
+              "$BACKUP_REPLACEMENTS" "$BACKUP_ASSIGNMENTS" \
+              AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS "$BACKUP_WORKER_INTERVAL_MS"
+            append_environment_setting \
+              "$BACKUP_REPLACEMENTS" "$BACKUP_ASSIGNMENTS" \
+              AGENT_BACKUP_CATALOG_WORKER_RETRY_MS "$BACKUP_WORKER_RETRY_MS"
+            append_environment_setting \
+              "$BACKUP_REPLACEMENTS" "$BACKUP_ASSIGNMENTS" \
+              AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS "$BACKUP_WORKER_SHUTDOWN_TIMEOUT_MS"
+            append_environment_setting \
+              "$BACKUP_REPLACEMENTS" "$BACKUP_ASSIGNMENTS" \
+              AGENT_BACKUP_SPOOL_STATE_DIRECTORY "$BACKUP_SPOOL_STATE_DIRECTORY"
+            append_environment_setting \
+              "$BACKUP_REPLACEMENTS" "$BACKUP_ASSIGNMENTS" \
+              AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE "$BACKUP_WORKER_HEALTH_FILE"
+
+            # Activation remains impossible in this changeset because both gate
+            # variables above are literal zero. Gate 1 stays blocked until the
+            # backup worker has a separate trust domain (an identity without
+            # deploy's sudo/docker authority, or a dedicated host) plus verified
+            # artifact integrity. Only then may a separately reviewed activation
+            # populate this explicit protected authority allowlist.
+            if [ "$BACKUP_CATALOG_RUNTIME_GATE" = "1" ]; then
+              enabled_backup_names=(
+                DATABASE_URL
+                SECRETS_MASTER_KEY
+                AGENT_BACKUP_CATALOG_WORKER_ID
+                AGENT_BACKUP_R2_ENDPOINT_ALIAS
+                AGENT_BACKUP_R2_ACCOUNT_ID
+                AGENT_BACKUP_R2_ENDPOINT
+                AGENT_BACKUP_R2_BUCKET
+                AGENT_BACKUP_R2_REGION
+                AGENT_BACKUP_R2_ACCESS_KEY_ID
+                AGENT_BACKUP_R2_SECRET_ACCESS_KEY
+                AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS
+                AGENT_BACKUP_HETZNER_ACCOUNT_ID
+                AGENT_BACKUP_HETZNER_ENDPOINT
+                AGENT_BACKUP_HETZNER_BUCKET
+                AGENT_BACKUP_HETZNER_REGION
+                AGENT_BACKUP_HETZNER_ACCESS_KEY_ID
+                AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY
+                AGENT_BACKUP_STEWARD_KMS_BASE_URL
+                AGENT_BACKUP_STEWARD_KMS_TOKEN
+                AGENT_BACKUP_AGENT_SCHEMA_VERSION
+                AGENT_BACKUP_DATABASE_SCHEMA_VERSION
+                AGENT_BACKUP_RUNTIME_PLUGINS_JSON
+                AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID
+                AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT
+                AGENT_BACKUP_STORAGE_SCOPE
+                AGENT_BACKUP_SPOOL_MAX_BYTES
+                AGENT_BACKUP_SPOOL_MIN_FREE_BYTES
+                AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE
+                AGENT_BACKUP_CAPTURE_DEADLINE_MS
+                AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS
+              )
+              for name in "${enabled_backup_names[@]}"; do
+                val="${!name-}"
+                if [ -z "$val" ]; then
+                  echo "::error::Backup catalogue activation input is missing required protected setting name: $name"
+                  exit 1
+                fi
+                append_environment_setting \
+                  "$BACKUP_REPLACEMENTS" "$BACKUP_ASSIGNMENTS" "$name" "$val"
+                unset val
+              done
+              optional_enabled_backup_names=(
+                DATABASE_SSL_NO_VERIFY
+                AGENT_BACKUP_SCHEDULE_BATCH_SIZE
+                AGENT_BACKUP_SCHEDULE_LEASE_MS
+                AGENT_BACKUP_SCHEDULE_RETRY_MS
+                AGENT_BACKUP_OPERATION_BATCH_SIZE
+                AGENT_BACKUP_OPERATION_LEASE_MS
+                AGENT_BACKUP_OPERATION_RETRY_BASE_MS
+                AGENT_BACKUP_OPERATION_RETRY_MAX_MS
+                AGENT_BACKUP_GC_BATCH_SIZE
+                AGENT_BACKUP_GC_LEASE_MS
+                AGENT_BACKUP_GC_RETRY_BASE_MS
+                AGENT_BACKUP_GC_RETRY_MAX_MS
+                AGENT_BACKUP_DELETION_BATCH_SIZE
+              )
+              for name in "${optional_enabled_backup_names[@]}"; do
+                val="${!name-}"
+                [ -n "$val" ] || continue
+                append_environment_setting \
+                  "$BACKUP_REPLACEMENTS" "$BACKUP_ASSIGNMENTS" "$name" "$val"
+                unset val
+              done
+            fi
+
+            # An EnvironmentFile replacement cannot revoke authority already in
+            # a running process. Disable and stop any previously installed unit
+            # before even renaming the dedicated safe-off file. An interrupted
+            # deployment therefore cannot leave that old process enabled with
+            # its former environment. The verified unit is re-enabled only at
+            # the final unit-install boundary below.
+            BACKUP_OLD_LOAD_STATE=$(sudo systemctl show "$BACKUP_SYSTEMD_UNIT" \
+              --property=LoadState --value 2>/dev/null || true)
+            if [ "$BACKUP_OLD_LOAD_STATE" != "not-found" ]; then
+              if [ -z "$BACKUP_OLD_LOAD_STATE" ]; then
+                echo "::error::Could not determine the previous backup catalogue unit state"
+                exit 1
+              fi
+              if ! sudo systemctl disable --now "$BACKUP_SYSTEMD_UNIT"; then
+                # Reach and verify the same closed postcondition even when an
+                # older unit's graceful stop fails. No fallback result is trusted.
+                sudo systemctl kill --kill-whom=all --signal=KILL "$BACKUP_SYSTEMD_UNIT" || true
+                sudo systemctl stop --no-block "$BACKUP_SYSTEMD_UNIT" || true
+                sudo systemctl disable "$BACKUP_SYSTEMD_UNIT" || true
+              fi
+              BACKUP_OLD_ACTIVE_STATE=""
+              BACKUP_OLD_MAIN_PID=""
+              for _ in $(seq 1 50); do
+                BACKUP_OLD_ACTIVE_STATE=$(sudo systemctl show "$BACKUP_SYSTEMD_UNIT" \
+                  --property=ActiveState --value)
+                BACKUP_OLD_MAIN_PID=$(sudo systemctl show "$BACKUP_SYSTEMD_UNIT" \
+                  --property=MainPID --value)
+                if { [ "$BACKUP_OLD_ACTIVE_STATE" = "inactive" ] || [ "$BACKUP_OLD_ACTIVE_STATE" = "failed" ]; } \
+                  && [ "$BACKUP_OLD_MAIN_PID" = "0" ]; then
+                  break
+                fi
+                sleep 0.1
+              done
+              if { [ "$BACKUP_OLD_ACTIVE_STATE" != "inactive" ] && [ "$BACKUP_OLD_ACTIVE_STATE" != "failed" ]; } \
+                || [ "$BACKUP_OLD_MAIN_PID" != "0" ]; then
+                echo "::error::Previous backup catalogue process remained live after the safe-off stop boundary"
+                exit 1
+              fi
+              BACKUP_OLD_ENABLE_STATE=$(sudo systemctl is-enabled "$BACKUP_SYSTEMD_UNIT" 2>/dev/null || true)
+              if [ "$BACKUP_OLD_ENABLE_STATE" != "disabled" ]; then
+                echo "::error::Previous backup catalogue unit did not reach the disabled safe-off boundary"
+                exit 1
+              fi
+            fi
+
+            # Install the exact safe-off allowlist only after the old process is
+            # disabled and gone. Helpers run with an empty inherited environment;
+            # the plan files are the only input to the root process.
+            sudo install -d -o root -g root -m 0755 "$(dirname "$BACKUP_ENV_FILE")"
+            sudo flock -w 120 "$BACKUP_ENV_FILE.lock" \
+              /usr/bin/env -i PATH="$SAFE_CHILD_PATH" \
+              "$NODE_BIN" "$ENV_SERIALIZER" install \
+              "$BACKUP_ENV_FILE" "$BACKUP_REPLACEMENTS" "$BACKUP_ASSIGNMENTS"
+            if [ "$(sudo stat -c '%U:%G:%a' "$BACKUP_ENV_FILE")" != "root:root:600" ]; then
+              echo "::error::Dedicated backup catalogue EnvironmentFile ownership or mode is invalid"
+              exit 1
+            fi
+            require_environment_setting_equals \
+              "$BACKUP_ENV_FILE" AGENT_BACKUP_CATALOG_RUNTIME_ENABLED 0
+            require_environment_setting_equals \
+              "$BACKUP_ENV_FILE" AGENT_BACKUP_RPO_SCHEDULER_ENABLED 0
+
+            # The shared file is reconciled only after the dormant worker has
+            # been forced safe-off. Optimistic snapshot verification also
+            # detects writers that do not cooperate with this lock and retries
+            # from their latest contents instead of losing their update.
+            sudo flock -w 120 "$ENV_FILE.lock" \
+              /usr/bin/env -i PATH="$SAFE_CHILD_PATH" \
+              "$NODE_BIN" "$ENV_SERIALIZER" reconcile \
+              "$ENV_FILE" "$ENV_REPLACEMENTS" "$ENV_ASSIGNMENTS"
+            # TEST-ANCHOR: atomic-environment-reconcile-end
+            rm -rf -- "$RECONCILE_PLAN_DIR"
+            trap - EXIT
 
             # Some live secrets predate GitHub environment inventory and cannot
             # be recovered from Cloudflare. Empty CI values deliberately preserve
@@ -722,15 +1107,7 @@ jobs:
             )
             missing_host_settings=()
             for name in "${required_host_settings[@]}"; do
-              if ! sudo awk -F= -v required_name="$name" '
-                $1 == required_name {
-                  sub(/^[^=]*=/, "")
-                  value = $0
-                  gsub(/[[:space:]]/, "", value)
-                  if (length(value) > 0) found = 1
-                }
-                END { exit found ? 0 : 1 }
-              ' "$ENV_FILE"; then
+              if ! require_environment_settings "$ENV_FILE" "$name"; then
                 missing_host_settings+=("$name")
               fi
             done
@@ -745,14 +1122,20 @@ jobs:
             # immediately promotes every production-composition name to a
             # required preflight input.
             for gate_name in AGENT_BACKUP_CATALOG_RUNTIME_ENABLED AGENT_BACKUP_RPO_SCHEDULER_ENABLED; do
-              gate_count=$(sudo awk -F= -v required_name="$gate_name" '$1 == required_name { count += 1 } END { print count + 0 }' "$ENV_FILE")
-              gate_value=$(sudo awk -F= -v required_name="$gate_name" '$1 == required_name { value=$2 } END { print value }' "$ENV_FILE")
-              if [ "$gate_count" -ne 1 ] || [ "$gate_value" != "0" ]; then
+              if ! require_environment_setting_equals "$ENV_FILE" "$gate_name" 0; then
                 echo "::error::Backup catalogue merge-time gate contract is invalid for $gate_name"
                 exit 1
               fi
+              if ! require_environment_setting_equals "$BACKUP_ENV_FILE" "$gate_name" 0; then
+                echo "::error::Dedicated backup catalogue gate contract is invalid for $gate_name"
+                exit 1
+              fi
             done
-            BACKUP_GATE=0
+            if [ "$(sudo stat -c '%U:%G:%a' "$BACKUP_ENV_FILE")" != "root:root:600" ]; then
+              echo "::error::Dedicated backup catalogue EnvironmentFile ownership or mode is invalid"
+              exit 1
+            fi
+            BACKUP_GATE="$BACKUP_CATALOG_RUNTIME_GATE"
             if [ "$BACKUP_GATE" = "1" ]; then
               required_backup_settings=(
                 DATABASE_URL
@@ -789,15 +1172,7 @@ jobs:
               )
               missing_backup_settings=()
               for name in "${required_backup_settings[@]}"; do
-                if ! sudo awk -F= -v required_name="$name" '
-                  $1 == required_name {
-                    sub(/^[^=]*=/, "")
-                    value = $0
-                    gsub(/[[:space:]]/, "", value)
-                    if (length(value) > 0) found = 1
-                  }
-                  END { exit found ? 0 : 1 }
-                ' "$ENV_FILE"; then
+                if ! require_environment_settings "$BACKUP_ENV_FILE" "$name"; then
                   missing_backup_settings+=("$name")
                 fi
               done
@@ -808,7 +1183,10 @@ jobs:
             fi
             echo "Verified disabled backup-catalogue gate and configuration names; values were not printed."
 
-            AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=0 \
+            /usr/bin/env -i \
+              PATH="$SAFE_CHILD_PATH" \
+              HOME=/home/deploy \
+              AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=0 \
               AGENT_BACKUP_RPO_SCHEDULER_ENABLED=0 \
               AGENT_BACKUP_SPOOL_STATE_DIRECTORY=/var/lib/eliza-backup-catalog/spool \
               AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE=/run/eliza-backup-catalog/health.json \
@@ -821,26 +1199,144 @@ jobs:
             # catalog and migration hash instead of assuming another workflow
             # won the race. The bounded preflight leaves the currently healthy
             # daemons running when migration has not completed or drifted.
-            EFFECTIVE_DATABASE_URL="$DATABASE_URL"
-            if [ -z "$EFFECTIVE_DATABASE_URL" ]; then
-              EFFECTIVE_DATABASE_URL=$(sudo awk -F= '
-                $1=="DATABASE_URL" {
-                  sub(/^[^=]*=/, "")
-                  value=$0
-                }
-                END { print value }
-              ' "$ENV_FILE")
-            fi
-            if [ -z "$EFFECTIVE_DATABASE_URL" ]; then
+            if [ -z "$DATABASE_URL" ]; then
               echo "::error::DATABASE_URL is required for the job-interruption schema preflight."
               exit 1
             fi
-            DATABASE_URL="$EFFECTIVE_DATABASE_URL" \
+            /usr/bin/env -i \
+              PATH="$SAFE_CHILD_PATH" \
+              HOME=/home/deploy \
+              DATABASE_URL="$DATABASE_URL" \
+              DATABASE_SSL_NO_VERIFY="$DATABASE_SSL_NO_VERIFY" \
               timeout --foreground --signal=TERM --kill-after=5s 8m \
-              bun --conditions=eliza-source \
+              "$BUN_BIN" --conditions=eliza-source \
               packages/cloud/scripts/admin/preflight-job-execution-interruptions.ts
-            unset EFFECTIVE_DATABASE_URL
 
+            # Prove that the host's real systemd manager consumes this
+            # serializer's EnvironmentFile. The probe contains one public
+            # literal only; no deployment authority is copied into its file,
+            # command line, output, or transient unit. The exact-SHA backup unit
+            # itself is installed and verified from its root-owned destination
+            # at the final disabled-unit boundary below.
+            SYSTEMD_PROBE_DIR=$(mktemp -d)
+            chmod 700 "$SYSTEMD_PROBE_DIR"
+            SYSTEMD_PROBE_SOURCE="$SYSTEMD_PROBE_DIR/environment"
+            SYSTEMD_PROBE_ENV="/run/eliza-backup-environment-probe.$$.env"
+            cleanup_systemd_probe() {
+              sudo rm -f -- "$SYSTEMD_PROBE_ENV"
+              rm -rf -- "$SYSTEMD_PROBE_DIR"
+            }
+            trap cleanup_systemd_probe EXIT
+            printf '%s' expected-safe-literal \
+              | run_environment_helper serialize SYSTEMD_ENVIRONMENT_PROBE \
+              > "$SYSTEMD_PROBE_SOURCE"
+            chmod 600 "$SYSTEMD_PROBE_SOURCE"
+            sudo install -o root -g root -m 0600 \
+              "$SYSTEMD_PROBE_SOURCE" "$SYSTEMD_PROBE_ENV"
+            sudo /usr/bin/env -i PATH="$SAFE_CHILD_PATH" \
+              systemd-run --wait --pipe --quiet --collect \
+              --service-type=oneshot --uid=deploy \
+              --property="EnvironmentFile=$SYSTEMD_PROBE_ENV" \
+              /bin/sh -c '[ "${SYSTEMD_ENVIRONMENT_PROBE:-}" = expected-safe-literal ]'
+            cleanup_systemd_probe
+            trap - EXIT
+
+            # Prove the host manager honors the exact exit-78 restart fence on
+            # a main process. ExecStartPre exits are intentionally absent from
+            # the shipped unit because RestartPreventExitStatus does not cover
+            # them. This public transient probe must execute once and stop.
+            RESTART_PROBE_UNIT="eliza-backup-exit78-probe-${DEPLOY_SHA:0:12}-$$.service"
+            cleanup_restart_probe() {
+              sudo systemctl stop "$RESTART_PROBE_UNIT" >/dev/null 2>&1 || true
+              sudo systemctl reset-failed "$RESTART_PROBE_UNIT" >/dev/null 2>&1 || true
+            }
+            trap cleanup_restart_probe EXIT
+            sudo /usr/bin/env -i PATH="$SAFE_CHILD_PATH" \
+              systemd-run --quiet --unit="$RESTART_PROBE_UNIT" \
+              --property=Restart=always \
+              --property=RestartPreventExitStatus=78 \
+              /bin/sh -c 'exit 78'
+            RESTART_PROBE_STATE=""
+            for _ in $(seq 1 50); do
+              RESTART_PROBE_STATE=$(sudo systemctl show "$RESTART_PROBE_UNIT" \
+                --property=ActiveState --value)
+              if [ "$RESTART_PROBE_STATE" = "failed" ] || [ "$RESTART_PROBE_STATE" = "inactive" ]; then
+                break
+              fi
+              sleep 0.1
+            done
+            RESTART_PROBE_STATUS=$(sudo systemctl show "$RESTART_PROBE_UNIT" \
+              --property=ExecMainStatus --value)
+            RESTART_PROBE_COUNT=$(sudo systemctl show "$RESTART_PROBE_UNIT" \
+              --property=NRestarts --value)
+            if { [ "$RESTART_PROBE_STATE" != "failed" ] && [ "$RESTART_PROBE_STATE" != "inactive" ]; } \
+              || [ "$RESTART_PROBE_STATUS" != "78" ] \
+              || [ "$RESTART_PROBE_COUNT" != "0" ]; then
+              echo "::error::systemd did not honor the backup worker exit-78 restart fence"
+              exit 1
+            fi
+            cleanup_restart_probe
+            trap - EXIT
+
+            # Install units only after both EnvironmentFiles, closed name/value
+            # checks, disabled preflight, database schema preflight, and real
+            # systemd consumption have succeeded. The backup unit is copied,
+            # verified, reloaded, and inspected while it remains disabled.
+            sudo install -m 0644 \
+              packages/cloud/scripts/admin/eliza-provisioning-worker.service \
+              "/etc/systemd/system/$SYSTEMD_UNIT"
+            sudo install -m 0644 \
+              packages/cloud/scripts/admin/eliza-agent-router.service \
+              /etc/systemd/system/eliza-agent-router.service
+            BACKUP_UNIT_SOURCE=/opt/eliza/packages/cloud/scripts/admin/eliza-backup-catalog-worker.service
+            BACKUP_UNIT_DESTINATION="/etc/systemd/system/$BACKUP_SYSTEMD_UNIT"
+            install_root_verified_file \
+              "$BACKUP_UNIT_SOURCE" \
+              "$BACKUP_UNIT_DESTINATION" \
+              "$BACKUP_SYSTEMD_UNIT_SHA256" \
+              0644
+            sudo /usr/bin/env -i PATH="$SAFE_CHILD_PATH" \
+              systemd-analyze verify "$BACKUP_UNIT_DESTINATION"
+            sudo systemctl daemon-reload
+
+            BACKUP_EFFECTIVE_DYNAMIC_USER=$(sudo systemctl show \
+              "$BACKUP_SYSTEMD_UNIT" --property=DynamicUser --value)
+            BACKUP_EFFECTIVE_USER=$(sudo systemctl show \
+              "$BACKUP_SYSTEMD_UNIT" --property=User --value)
+            BACKUP_EFFECTIVE_GROUP=$(sudo systemctl show \
+              "$BACKUP_SYSTEMD_UNIT" --property=Group --value)
+            BACKUP_EFFECTIVE_EXEC_START=$(sudo systemctl show \
+              "$BACKUP_SYSTEMD_UNIT" --property=ExecStart --value)
+            BACKUP_EFFECTIVE_FRAGMENT=$(sudo systemctl show \
+              "$BACKUP_SYSTEMD_UNIT" --property=FragmentPath --value)
+            BACKUP_EFFECTIVE_DROP_INS=$(sudo systemctl show \
+              "$BACKUP_SYSTEMD_UNIT" --property=DropInPaths --value)
+            BACKUP_EFFECTIVE_DIGEST_OUTPUT=$(sudo /usr/bin/sha256sum -- \
+              "$BACKUP_UNIT_DESTINATION")
+            BACKUP_EFFECTIVE_SHA256="${BACKUP_EFFECTIVE_DIGEST_OUTPUT%% *}"
+            BACKUP_EXPECTED_EXECUTABLE=/opt/eliza/node_modules/.bin/tsx
+            BACKUP_EXPECTED_EXEC_START="$BACKUP_EXPECTED_EXECUTABLE --tsconfig /opt/eliza/packages/cloud/shared/tsconfig.json /opt/eliza/packages/cloud/scripts/admin/daemons/backup-catalog-worker.ts"
+            # With DynamicUser=yes and no explicit User=, systemd v255 exposes
+            # the unit-derived dynamic identity through the effective User
+            # property. Require that exact derivation, not an empty value.
+            BACKUP_EXPECTED_DYNAMIC_USER="${BACKUP_SYSTEMD_UNIT%.service}"
+            if [ "$BACKUP_EFFECTIVE_DYNAMIC_USER" != "yes" ] \
+              || [ "$BACKUP_EFFECTIVE_USER" != "$BACKUP_EXPECTED_DYNAMIC_USER" ] \
+              || [ "$BACKUP_EFFECTIVE_GROUP" != "$BACKUP_EXPECTED_DYNAMIC_USER" ] \
+              || [ "$BACKUP_EFFECTIVE_FRAGMENT" != "$BACKUP_UNIT_DESTINATION" ] \
+              || [ -n "$BACKUP_EFFECTIVE_DROP_INS" ] \
+              || [ "$BACKUP_EFFECTIVE_SHA256" != "$BACKUP_SYSTEMD_UNIT_SHA256" ]; then
+              echo "::error::Effective backup systemd identity or fragment integrity is invalid"
+              exit 1
+            fi
+            case "$BACKUP_EFFECTIVE_EXEC_START" in
+              *"path=$BACKUP_EXPECTED_EXECUTABLE ; argv[]=$BACKUP_EXPECTED_EXEC_START ;"*) ;;
+              *)
+                echo "::error::Effective backup systemd ExecStart is invalid"
+                exit 1
+                ;;
+            esac
+            sudo systemctl enable "$SYSTEMD_UNIT" eliza-agent-router.service "$BACKUP_SYSTEMD_UNIT"
             sudo systemctl restart "$SYSTEMD_UNIT"
             sudo systemctl restart eliza-agent-router.service
             sudo systemctl restart "$BACKUP_SYSTEMD_UNIT"
@@ -882,13 +1378,34 @@ jobs:
           username: deploy
           key: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
           command_timeout: 5m
-          envs: SYSTEMD_UNIT,BACKUP_SYSTEMD_UNIT,ELIZA_CLOUD_AGENT_BASE_DOMAIN,AGENT_ROUTER_PUBLIC_HOST
+          envs: SYSTEMD_UNIT,BACKUP_SYSTEMD_UNIT,SYSTEMD_ENVIRONMENT_HELPER_SHA256,ELIZA_CLOUD_AGENT_BASE_DOMAIN,AGENT_ROUTER_PUBLIC_HOST
           script: |
             set -euo pipefail
             ENV_FILE=/opt/eliza/cloud/.env.local
-            ACTUAL_AGENT_BASE_DOMAIN=$(sudo awk -F= '$1=="ELIZA_CLOUD_AGENT_BASE_DOMAIN" { value=$2 } END { print value }' "$ENV_FILE")
-            if [ "$ACTUAL_AGENT_BASE_DOMAIN" != "$ELIZA_CLOUD_AGENT_BASE_DOMAIN" ]; then
-              echo "::error::Agent router base-domain drift: expected $ELIZA_CLOUD_AGENT_BASE_DOMAIN, found ${ACTUAL_AGENT_BASE_DOMAIN:-<missing>}."
+            ENV_SERIALIZER=/usr/local/lib/eliza-admin/systemd-environment-line.mjs
+            NODE_BIN=/usr/bin/node
+            SAFE_CHILD_PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/bin
+            if [ ! -x "$NODE_BIN" ] || [[ "$("$NODE_BIN" --version)" != v24.* ]]; then
+              echo "::error::The canonical root-owned Node 24 binary is unavailable"
+              exit 1
+            fi
+            HEALTH_HELPER_DIGEST_OUTPUT=$(sudo /usr/bin/sha256sum -- \
+              "$ENV_SERIALIZER") || {
+              echo "::error::Could not hash the installed EnvironmentFile helper"
+              exit 1
+            }
+            HEALTH_HELPER_SHA256="${HEALTH_HELPER_DIGEST_OUTPUT%% *}"
+            if [[ ! "$SYSTEMD_ENVIRONMENT_HELPER_SHA256" =~ ^[0-9a-f]{64}$ ]] \
+              || [ "$(sudo /usr/bin/stat -c '%U:%G:%a' "$ENV_SERIALIZER")" != "root:root:555" ] \
+              || [ "$HEALTH_HELPER_SHA256" != "$SYSTEMD_ENVIRONMENT_HELPER_SHA256" ]; then
+              echo "::error::Installed EnvironmentFile helper integrity is invalid"
+              exit 1
+            fi
+            if ! printf '%s' "$ELIZA_CLOUD_AGENT_BASE_DOMAIN" \
+              | sudo /usr/bin/env -i PATH="$SAFE_CHILD_PATH" \
+                  "$NODE_BIN" "$ENV_SERIALIZER" equals \
+                  "$ENV_FILE" ELIZA_CLOUD_AGENT_BASE_DOMAIN; then
+              echo "::error::Agent router base-domain drift. Values were not printed."
               exit 1
             fi
             # The worker logs to journald via systemd's stdout/stderr capture.
@@ -906,29 +1423,34 @@ jobs:
               sudo journalctl -u eliza-agent-router.service --since "$HEALTH_SINCE_TS" -n 200 --no-pager || true
             }
             validate_disabled_backup_health() {
-              node -e '
-                let raw = "";
-                process.stdin.on("data", (chunk) => { raw += chunk; });
-                process.stdin.on("end", () => {
-                  try {
-                    const parsed = JSON.parse(raw);
-                    const valid =
-                      parsed &&
-                      parsed.format === "elizaos.agent-backup.catalog-worker-health.v1" &&
-                      parsed.state === "disabled" &&
-                      parsed.enabled === false;
-                    process.exit(valid ? 0 : 1);
-                  } catch {
-                    process.exit(1);
-                  }
-                });
+              # DynamicUser owns the mode-0700 RuntimeDirectory and mode-0600
+              # snapshot. Validate it as root with a fixed path, bounded bytes,
+              # empty inherited environment, and no stdout value channel.
+              sudo /usr/bin/env -i PATH="$SAFE_CHILD_PATH" "$NODE_BIN" -e '
+                const { readFileSync } = require("node:fs");
+                try {
+                  const bytes = readFileSync("/run/eliza-backup-catalog/health.json");
+                  if (bytes.byteLength === 0 || bytes.byteLength > 65536) process.exit(1);
+                  const raw = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+                  const parsed = JSON.parse(raw);
+                  const valid =
+                    parsed &&
+                    parsed.format === "elizaos.agent-backup.catalog-worker-health.v1" &&
+                    parsed.state === "disabled" &&
+                    parsed.enabled === false;
+                  process.exit(valid ? 0 : 1);
+                } catch {
+                  // error-policy:J1 missing, malformed, or hostile health bytes
+                  // become one closed non-success status without output.
+                  process.exit(1);
+                }
               '
             }
             # The router's health contract is a JSON object with boolean
             # ok === true. A substring grep would also accept HTML error
             # pages that merely contain the text, so parse for real.
             validate_public_health_payload() {
-              node -e '
+              /usr/bin/env -i PATH="$SAFE_CHILD_PATH" "$NODE_BIN" -e '
                 let raw = "";
                 process.stdin.on("data", (chunk) => { raw += chunk; });
                 process.stdin.on("end", () => {
@@ -959,13 +1481,8 @@ jobs:
                 echo "$BACKUP_JOURNAL" | tail -n 50
                 exit 1
               fi
-              if ! test -s /run/eliza-backup-catalog/health.json; then
-                echo "Health check attempt $attempt/18: backup health has not reported disabled yet."
-                sleep 5
-                continue
-              fi
-              if ! validate_disabled_backup_health < /run/eliza-backup-catalog/health.json; then
-                echo "Health check attempt $attempt/18: backup health has not reported disabled yet."
+              if ! validate_disabled_backup_health; then
+                echo "Health check attempt $attempt/18: backup health is unavailable or not the exact disabled contract yet."
                 sleep 5
                 continue
               fi

--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -125,6 +125,7 @@ jobs:
     timeout-minutes: 95
     env:
       SYSTEMD_UNIT: eliza-provisioning-worker.service
+      BACKUP_SYSTEMD_UNIT: eliza-backup-catalog-worker.service
       DEPLOY_BRANCH: ${{ needs.determine-env.outputs.branch }}
       DEPLOY_SHA: ${{ needs.determine-env.outputs.deployment_sha }}
       # Headscale wiring for the provisioning worker (the CONSUMER of the
@@ -186,6 +187,35 @@ jobs:
       # compatibility window.
       AGENT_ROUTER_PUBLIC_HOST: ${{ needs.determine-env.outputs.environment == 'production' && 'eliza-production-1.eliza.app' || 'eliza-staging-1.eliza.app' }}
       LEGACY_AGENT_ROUTER_PUBLIC_HOST: ${{ needs.determine-env.outputs.environment == 'production' && 'eliza-production-1.elizacloud.ai' || 'eliza-staging-1.elizacloud.ai' }}
+      # Backup catalogue values are optional while both merge-time gates remain
+      # forced off. They are reconciled by name now so later activation cannot
+      # depend on undocumented host-only configuration.
+      AGENT_BACKUP_CATALOG_WORKER_ID: ${{ vars.AGENT_BACKUP_CATALOG_WORKER_ID }}
+      AGENT_BACKUP_R2_ENDPOINT_ALIAS: ${{ vars.AGENT_BACKUP_R2_ENDPOINT_ALIAS }}
+      AGENT_BACKUP_R2_ACCOUNT_ID: ${{ vars.AGENT_BACKUP_R2_ACCOUNT_ID }}
+      AGENT_BACKUP_R2_ENDPOINT: ${{ vars.AGENT_BACKUP_R2_ENDPOINT }}
+      AGENT_BACKUP_R2_BUCKET: ${{ vars.AGENT_BACKUP_R2_BUCKET }}
+      AGENT_BACKUP_R2_REGION: ${{ vars.AGENT_BACKUP_R2_REGION }}
+      AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS: ${{ vars.AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS }}
+      AGENT_BACKUP_HETZNER_ACCOUNT_ID: ${{ vars.AGENT_BACKUP_HETZNER_ACCOUNT_ID }}
+      AGENT_BACKUP_HETZNER_ENDPOINT: ${{ vars.AGENT_BACKUP_HETZNER_ENDPOINT }}
+      AGENT_BACKUP_HETZNER_BUCKET: ${{ vars.AGENT_BACKUP_HETZNER_BUCKET }}
+      AGENT_BACKUP_HETZNER_REGION: ${{ vars.AGENT_BACKUP_HETZNER_REGION }}
+      AGENT_BACKUP_STEWARD_KMS_BASE_URL: ${{ vars.AGENT_BACKUP_STEWARD_KMS_BASE_URL }}
+      AGENT_BACKUP_AGENT_SCHEMA_VERSION: ${{ vars.AGENT_BACKUP_AGENT_SCHEMA_VERSION }}
+      AGENT_BACKUP_DATABASE_SCHEMA_VERSION: ${{ vars.AGENT_BACKUP_DATABASE_SCHEMA_VERSION }}
+      AGENT_BACKUP_RUNTIME_PLUGINS_JSON: ${{ vars.AGENT_BACKUP_RUNTIME_PLUGINS_JSON }}
+      AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID: ${{ vars.AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID }}
+      AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT: ${{ vars.AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT }}
+      AGENT_BACKUP_STORAGE_SCOPE: ${{ vars.AGENT_BACKUP_STORAGE_SCOPE }}
+      AGENT_BACKUP_SPOOL_MAX_BYTES: ${{ vars.AGENT_BACKUP_SPOOL_MAX_BYTES }}
+      AGENT_BACKUP_SPOOL_MIN_FREE_BYTES: ${{ vars.AGENT_BACKUP_SPOOL_MIN_FREE_BYTES }}
+      AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE: ${{ vars.AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE }}
+      AGENT_BACKUP_CAPTURE_DEADLINE_MS: ${{ vars.AGENT_BACKUP_CAPTURE_DEADLINE_MS }}
+      AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS: ${{ vars.AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS }}
+      AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS: ${{ vars.AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS }}
+      AGENT_BACKUP_CATALOG_WORKER_RETRY_MS: ${{ vars.AGENT_BACKUP_CATALOG_WORKER_RETRY_MS }}
+      AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS: ${{ vars.AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS }}
     steps:
       - name: Validate canonical deploy configuration and shared secrets
         id: deploy_config
@@ -411,6 +441,11 @@ jobs:
           SANDBOX_REGISTRY_REDIS_URL: ${{ secrets.SANDBOX_REGISTRY_REDIS_URL }}
           DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.RAILWAY_DATABASE_URL || secrets.NEON_DATABASE_URL }}
           SECRETS_MASTER_KEY: ${{ secrets.SECRETS_MASTER_KEY }}
+          AGENT_BACKUP_R2_ACCESS_KEY_ID: ${{ secrets.AGENT_BACKUP_R2_ACCESS_KEY_ID }}
+          AGENT_BACKUP_R2_SECRET_ACCESS_KEY: ${{ secrets.AGENT_BACKUP_R2_SECRET_ACCESS_KEY }}
+          AGENT_BACKUP_HETZNER_ACCESS_KEY_ID: ${{ secrets.AGENT_BACKUP_HETZNER_ACCESS_KEY_ID }}
+          AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY: ${{ secrets.AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY }}
+          AGENT_BACKUP_STEWARD_KMS_TOKEN: ${{ secrets.AGENT_BACKUP_STEWARD_KMS_TOKEN }}
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
         with:
           host: ${{ secrets.ELIZA_PROVISIONING_HOST }}
@@ -420,7 +455,7 @@ jobs:
           # wait without weakening the preflight's own eight-minute fail-closed
           # fence near the end of this remote script.
           command_timeout: 40m
-          envs: DEPLOY_BRANCH,DEPLOY_SHA,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,CONTAINERS_SSH_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE,WARM_POOL_ENABLED,ELIZA_CLOUD_AGENT_BASE_DOMAIN,AGENT_ROUTER_PUBLIC_HOST,LEGACY_AGENT_ROUTER_PUBLIC_HOST
+          envs: DEPLOY_BRANCH,DEPLOY_SHA,SYSTEMD_UNIT,BACKUP_SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,CONTAINERS_SSH_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE,WARM_POOL_ENABLED,ELIZA_CLOUD_AGENT_BASE_DOMAIN,AGENT_ROUTER_PUBLIC_HOST,LEGACY_AGENT_ROUTER_PUBLIC_HOST,AGENT_BACKUP_CATALOG_WORKER_ID,AGENT_BACKUP_R2_ENDPOINT_ALIAS,AGENT_BACKUP_R2_ACCOUNT_ID,AGENT_BACKUP_R2_ENDPOINT,AGENT_BACKUP_R2_BUCKET,AGENT_BACKUP_R2_REGION,AGENT_BACKUP_R2_ACCESS_KEY_ID,AGENT_BACKUP_R2_SECRET_ACCESS_KEY,AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS,AGENT_BACKUP_HETZNER_ACCOUNT_ID,AGENT_BACKUP_HETZNER_ENDPOINT,AGENT_BACKUP_HETZNER_BUCKET,AGENT_BACKUP_HETZNER_REGION,AGENT_BACKUP_HETZNER_ACCESS_KEY_ID,AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY,AGENT_BACKUP_STEWARD_KMS_BASE_URL,AGENT_BACKUP_STEWARD_KMS_TOKEN,AGENT_BACKUP_AGENT_SCHEMA_VERSION,AGENT_BACKUP_DATABASE_SCHEMA_VERSION,AGENT_BACKUP_RUNTIME_PLUGINS_JSON,AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID,AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT,AGENT_BACKUP_STORAGE_SCOPE,AGENT_BACKUP_SPOOL_MAX_BYTES,AGENT_BACKUP_SPOOL_MIN_FREE_BYTES,AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE,AGENT_BACKUP_CAPTURE_DEADLINE_MS,AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS,AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS,AGENT_BACKUP_CATALOG_WORKER_RETRY_MS,AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS
           script: |
             set -euo pipefail
 
@@ -554,15 +589,18 @@ jobs:
             mkdir -p node_modules/@elizaos
             ln -sfn ../../packages/cloud/shared node_modules/@elizaos/cloud-shared
 
-            # Install/refresh both systemd units (provisioning worker + agent router).
+            # Install/refresh the provisioning, router, and dormant backup units.
             sudo install -m 0644 \
               packages/cloud/scripts/admin/eliza-provisioning-worker.service \
               "/etc/systemd/system/$SYSTEMD_UNIT"
             sudo install -m 0644 \
               packages/cloud/scripts/admin/eliza-agent-router.service \
               /etc/systemd/system/eliza-agent-router.service
+            sudo install -m 0644 \
+              packages/cloud/scripts/admin/eliza-backup-catalog-worker.service \
+              "/etc/systemd/system/$BACKUP_SYSTEMD_UNIT"
             sudo systemctl daemon-reload
-            sudo systemctl enable "$SYSTEMD_UNIT" eliza-agent-router.service
+            sudo systemctl enable "$SYSTEMD_UNIT" eliza-agent-router.service "$BACKUP_SYSTEMD_UNIT"
 
             # Reconcile control-plane secrets (HEADSCALE_API_URL /
             # HEADSCALE_PUBLIC_URL / HEADSCALE_API_KEY /
@@ -602,6 +640,17 @@ jobs:
             # box, docker-sandbox-provider deliberately disables VPN injection
             # and fresh staging agents never receive a headscale_ip (#15347).
             sudo sed -i "/^AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK=/d" "$ENV_FILE"
+            # The manifest-v3 catalogue ships dormant. Remove stale host edits
+            # and append the two gates exactly once; values are also pinned on
+            # the systemd command line as a second independent fence.
+            sudo sed -i "/^AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=/d" "$ENV_FILE"
+            sudo sed -i "/^AGENT_BACKUP_RPO_SCHEDULER_ENABLED=/d" "$ENV_FILE"
+            sudo sed -i "/^AGENT_BACKUP_SPOOL_STATE_DIRECTORY=/d" "$ENV_FILE"
+            sudo sed -i "/^AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE=/d" "$ENV_FILE"
+            printf '%s=%s\n' AGENT_BACKUP_CATALOG_RUNTIME_ENABLED 0 | sudo tee -a "$ENV_FILE" >/dev/null
+            printf '%s=%s\n' AGENT_BACKUP_RPO_SCHEDULER_ENABLED 0 | sudo tee -a "$ENV_FILE" >/dev/null
+            printf '%s=%s\n' AGENT_BACKUP_SPOOL_STATE_DIRECTORY /var/lib/eliza-backup-catalog/spool | sudo tee -a "$ENV_FILE" >/dev/null
+            printf '%s=%s\n' AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE /run/eliza-backup-catalog/health.json | sudo tee -a "$ENV_FILE" >/dev/null
             for kv in \
               "HEADSCALE_API_URL=$HEADSCALE_API_URL" \
               "HEADSCALE_PUBLIC_URL=$HEADSCALE_PUBLIC_URL" \
@@ -612,10 +661,47 @@ jobs:
               "SECRETS_MASTER_KEY=$SECRETS_MASTER_KEY" \
               "ELIZA_AGENT_IMAGE=$ELIZA_AGENT_IMAGE" \
               "WARM_POOL_ENABLED=$WARM_POOL_ENABLED" \
-              "ELIZA_CLOUD_AGENT_BASE_DOMAIN=$ELIZA_CLOUD_AGENT_BASE_DOMAIN"; do
+              "ELIZA_CLOUD_AGENT_BASE_DOMAIN=$ELIZA_CLOUD_AGENT_BASE_DOMAIN" \
+              "AGENT_BACKUP_CATALOG_WORKER_ID=$AGENT_BACKUP_CATALOG_WORKER_ID" \
+              "AGENT_BACKUP_R2_ENDPOINT_ALIAS=$AGENT_BACKUP_R2_ENDPOINT_ALIAS" \
+              "AGENT_BACKUP_R2_ACCOUNT_ID=$AGENT_BACKUP_R2_ACCOUNT_ID" \
+              "AGENT_BACKUP_R2_ENDPOINT=$AGENT_BACKUP_R2_ENDPOINT" \
+              "AGENT_BACKUP_R2_BUCKET=$AGENT_BACKUP_R2_BUCKET" \
+              "AGENT_BACKUP_R2_REGION=$AGENT_BACKUP_R2_REGION" \
+              "AGENT_BACKUP_R2_ACCESS_KEY_ID=$AGENT_BACKUP_R2_ACCESS_KEY_ID" \
+              "AGENT_BACKUP_R2_SECRET_ACCESS_KEY=$AGENT_BACKUP_R2_SECRET_ACCESS_KEY" \
+              "AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS=$AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS" \
+              "AGENT_BACKUP_HETZNER_ACCOUNT_ID=$AGENT_BACKUP_HETZNER_ACCOUNT_ID" \
+              "AGENT_BACKUP_HETZNER_ENDPOINT=$AGENT_BACKUP_HETZNER_ENDPOINT" \
+              "AGENT_BACKUP_HETZNER_BUCKET=$AGENT_BACKUP_HETZNER_BUCKET" \
+              "AGENT_BACKUP_HETZNER_REGION=$AGENT_BACKUP_HETZNER_REGION" \
+              "AGENT_BACKUP_HETZNER_ACCESS_KEY_ID=$AGENT_BACKUP_HETZNER_ACCESS_KEY_ID" \
+              "AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY=$AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY" \
+              "AGENT_BACKUP_STEWARD_KMS_BASE_URL=$AGENT_BACKUP_STEWARD_KMS_BASE_URL" \
+              "AGENT_BACKUP_STEWARD_KMS_TOKEN=$AGENT_BACKUP_STEWARD_KMS_TOKEN" \
+              "AGENT_BACKUP_AGENT_SCHEMA_VERSION=$AGENT_BACKUP_AGENT_SCHEMA_VERSION" \
+              "AGENT_BACKUP_DATABASE_SCHEMA_VERSION=$AGENT_BACKUP_DATABASE_SCHEMA_VERSION" \
+              "AGENT_BACKUP_RUNTIME_PLUGINS_JSON=$AGENT_BACKUP_RUNTIME_PLUGINS_JSON" \
+              "AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID=$AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID" \
+              "AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT=$AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT" \
+              "AGENT_BACKUP_STORAGE_SCOPE=$AGENT_BACKUP_STORAGE_SCOPE" \
+              "AGENT_BACKUP_SPOOL_MAX_BYTES=$AGENT_BACKUP_SPOOL_MAX_BYTES" \
+              "AGENT_BACKUP_SPOOL_MIN_FREE_BYTES=$AGENT_BACKUP_SPOOL_MIN_FREE_BYTES" \
+              "AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE=$AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE" \
+              "AGENT_BACKUP_CAPTURE_DEADLINE_MS=$AGENT_BACKUP_CAPTURE_DEADLINE_MS" \
+              "AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS=$AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS" \
+              "AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS=$AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS" \
+              "AGENT_BACKUP_CATALOG_WORKER_RETRY_MS=$AGENT_BACKUP_CATALOG_WORKER_RETRY_MS" \
+              "AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS=$AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS"; do
               key="${kv%%=*}"
               val="${kv#*=}"
               [ -n "$val" ] || continue
+              case "$val" in
+                *$'\n'*|*$'\r'*)
+                  echo "::error::Refusing multiline setting for $key"
+                  exit 1
+                  ;;
+              esac
               sudo sed -i "/^${key}=/d" "$ENV_FILE"
               printf '%s=%s\n' "$key" "$val" | sudo tee -a "$ENV_FILE" >/dev/null
             done
@@ -654,6 +740,82 @@ jobs:
             fi
             echo "Verified required provisioning-host setting names; values were not printed."
 
+            # Verify the dormant gate contract without disclosing the file. If
+            # a future reviewed change enables the runtime, this same block
+            # immediately promotes every production-composition name to a
+            # required preflight input.
+            for gate_name in AGENT_BACKUP_CATALOG_RUNTIME_ENABLED AGENT_BACKUP_RPO_SCHEDULER_ENABLED; do
+              gate_count=$(sudo awk -F= -v required_name="$gate_name" '$1 == required_name { count += 1 } END { print count + 0 }' "$ENV_FILE")
+              gate_value=$(sudo awk -F= -v required_name="$gate_name" '$1 == required_name { value=$2 } END { print value }' "$ENV_FILE")
+              if [ "$gate_count" -ne 1 ] || [ "$gate_value" != "0" ]; then
+                echo "::error::Backup catalogue merge-time gate contract is invalid for $gate_name"
+                exit 1
+              fi
+            done
+            BACKUP_GATE=0
+            if [ "$BACKUP_GATE" = "1" ]; then
+              required_backup_settings=(
+                DATABASE_URL
+                SECRETS_MASTER_KEY
+                AGENT_BACKUP_CATALOG_WORKER_ID
+                AGENT_BACKUP_R2_ENDPOINT_ALIAS
+                AGENT_BACKUP_R2_ACCOUNT_ID
+                AGENT_BACKUP_R2_ENDPOINT
+                AGENT_BACKUP_R2_BUCKET
+                AGENT_BACKUP_R2_REGION
+                AGENT_BACKUP_R2_ACCESS_KEY_ID
+                AGENT_BACKUP_R2_SECRET_ACCESS_KEY
+                AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS
+                AGENT_BACKUP_HETZNER_ACCOUNT_ID
+                AGENT_BACKUP_HETZNER_ENDPOINT
+                AGENT_BACKUP_HETZNER_BUCKET
+                AGENT_BACKUP_HETZNER_REGION
+                AGENT_BACKUP_HETZNER_ACCESS_KEY_ID
+                AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY
+                AGENT_BACKUP_STEWARD_KMS_BASE_URL
+                AGENT_BACKUP_STEWARD_KMS_TOKEN
+                AGENT_BACKUP_AGENT_SCHEMA_VERSION
+                AGENT_BACKUP_DATABASE_SCHEMA_VERSION
+                AGENT_BACKUP_RUNTIME_PLUGINS_JSON
+                AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID
+                AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT
+                AGENT_BACKUP_STORAGE_SCOPE
+                AGENT_BACKUP_SPOOL_STATE_DIRECTORY
+                AGENT_BACKUP_SPOOL_MAX_BYTES
+                AGENT_BACKUP_SPOOL_MIN_FREE_BYTES
+                AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE
+                AGENT_BACKUP_CAPTURE_DEADLINE_MS
+                AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS
+              )
+              missing_backup_settings=()
+              for name in "${required_backup_settings[@]}"; do
+                if ! sudo awk -F= -v required_name="$name" '
+                  $1 == required_name {
+                    sub(/^[^=]*=/, "")
+                    value = $0
+                    gsub(/[[:space:]]/, "", value)
+                    if (length(value) > 0) found = 1
+                  }
+                  END { exit found ? 0 : 1 }
+                ' "$ENV_FILE"; then
+                  missing_backup_settings+=("$name")
+                fi
+              done
+              if [ "${#missing_backup_settings[@]}" -gt 0 ]; then
+                echo "::error::Backup catalogue host is missing required setting name(s): ${missing_backup_settings[*]}"
+                exit 1
+              fi
+            fi
+            echo "Verified disabled backup-catalogue gate and configuration names; values were not printed."
+
+            AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=0 \
+              AGENT_BACKUP_RPO_SCHEDULER_ENABLED=0 \
+              AGENT_BACKUP_SPOOL_STATE_DIRECTORY=/var/lib/eliza-backup-catalog/spool \
+              AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE=/run/eliza-backup-catalog/health.json \
+              /opt/eliza/node_modules/.bin/tsx \
+              --tsconfig /opt/eliza/packages/cloud/shared/tsconfig.json \
+              packages/cloud/scripts/admin/daemons/backup-catalog-worker-preflight.ts
+
             # This workflow can reach the restart independently of the cloud
             # deploy workflow's migrate-db job. Bind activation to the exact
             # catalog and migration hash instead of assuming another workflow
@@ -681,7 +843,8 @@ jobs:
 
             sudo systemctl restart "$SYSTEMD_UNIT"
             sudo systemctl restart eliza-agent-router.service
-            echo "=== Restart issued for both daemons ==="
+            sudo systemctl restart "$BACKUP_SYSTEMD_UNIT"
+            echo "=== Restart issued for provisioning, router, and dormant backup daemons ==="
 
             # The canonical edge origin must terminate in the nginx vhost that
             # proxies the agent-router daemon. Without this alias, nginx
@@ -719,7 +882,7 @@ jobs:
           username: deploy
           key: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
           command_timeout: 5m
-          envs: SYSTEMD_UNIT,ELIZA_CLOUD_AGENT_BASE_DOMAIN,AGENT_ROUTER_PUBLIC_HOST
+          envs: SYSTEMD_UNIT,BACKUP_SYSTEMD_UNIT,ELIZA_CLOUD_AGENT_BASE_DOMAIN,AGENT_ROUTER_PUBLIC_HOST
           script: |
             set -euo pipefail
             ENV_FILE=/opt/eliza/cloud/.env.local
@@ -734,13 +897,32 @@ jobs:
             # error / restart-loop in the journal since deploy.
             HEALTH_SINCE_TS="$(date -u '+%Y-%m-%d %H:%M:%S')"
             STABLE_THRESHOLD_SEC=20
-            FATAL_LOG_PATTERN="\[(provisioning-worker|agent-router)\] (fatal|unhandled rejection)|node:internal/.*Error:|Error \[ERR_|^[A-Za-z]+Error:"
+            FATAL_LOG_PATTERN="\[(provisioning-worker|agent-router|backup-catalog-worker)\] (fatal|unhandled rejection)|node:internal/.*Error:|Error \[ERR_|^[A-Za-z]+Error:"
             report_public_route_failure() {
               sudo nginx -t || true
               sudo systemctl status nginx --no-pager || true
               sudo journalctl -u nginx --since "$HEALTH_SINCE_TS" -n 200 --no-pager || true
               sudo systemctl status eliza-agent-router.service --no-pager || true
               sudo journalctl -u eliza-agent-router.service --since "$HEALTH_SINCE_TS" -n 200 --no-pager || true
+            }
+            validate_disabled_backup_health() {
+              node -e '
+                let raw = "";
+                process.stdin.on("data", (chunk) => { raw += chunk; });
+                process.stdin.on("end", () => {
+                  try {
+                    const parsed = JSON.parse(raw);
+                    const valid =
+                      parsed &&
+                      parsed.format === "elizaos.agent-backup.catalog-worker-health.v1" &&
+                      parsed.state === "disabled" &&
+                      parsed.enabled === false;
+                    process.exit(valid ? 0 : 1);
+                  } catch {
+                    process.exit(1);
+                  }
+                });
+              '
             }
             # The router's health contract is a JSON object with boolean
             # ok === true. A substring grep would also accept HTML error
@@ -766,6 +948,27 @@ jobs:
               '
             }
             for attempt in $(seq 1 18); do
+              if ! sudo systemctl is-active --quiet "$BACKUP_SYSTEMD_UNIT"; then
+                echo "Health check attempt $attempt/18: dormant backup worker not active yet."
+                sleep 5
+                continue
+              fi
+              BACKUP_JOURNAL=$(sudo journalctl -u "$BACKUP_SYSTEMD_UNIT" --since "$HEALTH_SINCE_TS" --no-pager 2>/dev/null || true)
+              if echo "$BACKUP_JOURNAL" | grep -qE "$FATAL_LOG_PATTERN"; then
+                echo "::error::Backup catalogue worker logged a fatal error since deploy."
+                echo "$BACKUP_JOURNAL" | tail -n 50
+                exit 1
+              fi
+              if ! test -s /run/eliza-backup-catalog/health.json; then
+                echo "Health check attempt $attempt/18: backup health has not reported disabled yet."
+                sleep 5
+                continue
+              fi
+              if ! validate_disabled_backup_health < /run/eliza-backup-catalog/health.json; then
+                echo "Health check attempt $attempt/18: backup health has not reported disabled yet."
+                sleep 5
+                continue
+              fi
               if sudo systemctl is-active --quiet "$SYSTEMD_UNIT"; then
                 JOURNAL=$(sudo journalctl -u "$SYSTEMD_UNIT" --since "$HEALTH_SINCE_TS" --no-pager 2>/dev/null || true)
                 if echo "$JOURNAL" | grep -qE "$FATAL_LOG_PATTERN"; then
@@ -829,7 +1032,7 @@ jobs:
                       report_public_route_failure
                       exit 1
                     fi
-                    echo "Both daemons active and stable (worker ${AGE}s, router ${ROUTER_AGE}s, local and canonical health/readiness OK) on attempt $attempt."
+                    echo "Provisioning/router stable and backup worker disabled/healthy (worker ${AGE}s, router ${ROUTER_AGE}s) on attempt $attempt."
                     exit 0
                   fi
                   echo "Health check attempt $attempt/18: worker stable (${AGE}s), router ${ROUTER_AGE}s but health/readiness not ready on port ${ROUTER_PORT}."
@@ -848,6 +1051,8 @@ jobs:
             sudo journalctl -u "$SYSTEMD_UNIT" -n 200 --no-pager || true
             sudo systemctl status eliza-agent-router.service --no-pager || true
             sudo journalctl -u eliza-agent-router.service -n 200 --no-pager || true
+            sudo systemctl status "$BACKUP_SYSTEMD_UNIT" --no-pager || true
+            sudo journalctl -u "$BACKUP_SYSTEMD_UNIT" -n 200 --no-pager || true
             exit 1
 
       - name: Notify Discord (Success)

--- a/packages/cloud/scripts/admin/daemons/backup-catalog-worker-preflight.ts
+++ b/packages/cloud/scripts/admin/daemons/backup-catalog-worker-preflight.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * Value-redacted configuration preflight for the manifest-v3 catalogue worker.
+ * Disabled mode validates only daemon controls and the two gates; enabled mode
+ * loads the same production composition as the daemon, without running a cycle.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createAgentBackupCatalogWorkerComposition } from "@elizaos/cloud-shared/lib/services/agent-backup-catalog-worker-composition";
+import {
+  readBackupCatalogWorkerConfig,
+  safeBackupCatalogConfigurationNames,
+} from "./backup-catalog-worker";
+import { loadLocalEnv } from "./shared/load-env";
+
+export async function preflightBackupCatalogWorker(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{ enabled: boolean }> {
+  readBackupCatalogWorkerConfig(env, []);
+  const composition = await createAgentBackupCatalogWorkerComposition({ env });
+  return { enabled: composition.enabled };
+}
+
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  return entry ? path.resolve(entry) === fileURLToPath(import.meta.url) : false;
+}
+
+if (isMainModule()) {
+  loadLocalEnv(import.meta.url);
+  preflightBackupCatalogWorker()
+    .then(({ enabled }) => {
+      process.stdout.write(
+        `${JSON.stringify({ check: "backup-catalog-worker-config", ok: true, enabled })}\n`,
+      );
+    })
+    .catch((error) => {
+      const names = safeBackupCatalogConfigurationNames(error);
+      process.stderr.write(
+        `[backup-catalog-worker-preflight] rejected${
+          names.length > 0 ? ` configuration name(s): ${names.join(",")}` : ""
+        }\n`,
+      );
+      process.exitCode = 78;
+    });
+}

--- a/packages/cloud/scripts/admin/daemons/backup-catalog-worker-preflight.ts
+++ b/packages/cloud/scripts/admin/daemons/backup-catalog-worker-preflight.ts
@@ -12,7 +12,6 @@ import {
   readBackupCatalogWorkerConfig,
   safeBackupCatalogConfigurationNames,
 } from "./backup-catalog-worker";
-import { loadLocalEnv } from "./shared/load-env";
 
 export async function preflightBackupCatalogWorker(
   env: NodeJS.ProcessEnv = process.env,
@@ -28,7 +27,9 @@ function isMainModule(): boolean {
 }
 
 if (isMainModule()) {
-  loadLocalEnv(import.meta.url);
+  // The matching systemd unit passes only its dedicated allowlisted
+  // EnvironmentFile. Reading cloud/.env.local here would defeat the disabled
+  // no-secret boundary before the composition can inspect its gates.
   preflightBackupCatalogWorker()
     .then(({ enabled }) => {
       process.stdout.write(

--- a/packages/cloud/scripts/admin/daemons/backup-catalog-worker.test.ts
+++ b/packages/cloud/scripts/admin/daemons/backup-catalog-worker.test.ts
@@ -1,6 +1,6 @@
 /** Lifecycle, retry, cancellation, timeout, and replay tests for the daemon. */
 
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, spyOn, test } from "bun:test";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -8,9 +8,40 @@ import type { AgentBackupCatalogRuntimeSummary } from "@elizaos/cloud-shared/lib
 import {
   type BackupCatalogWorkerDependencies,
   type BackupCatalogWorkerHealth,
+  formatBackupCatalogFatalMessage,
   readBackupCatalogWorkerConfig,
   runBackupCatalogWorker,
+  safeBackupCatalogConfigurationNames,
+  waitForShutdownBound,
 } from "./backup-catalog-worker";
+
+function minimalSubprocessEnv(overrides: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+    HOME: process.env.HOME ?? tmpdir(),
+    TMPDIR: tmpdir(),
+    NODE_ENV: "test",
+    ...overrides,
+  };
+}
+
+async function waitForSubprocess(
+  child: ReturnType<typeof Bun.spawn>,
+  timeoutMs = 25_000,
+): Promise<number> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      child.exited,
+      new Promise<number>((resolve) => {
+        timer = setTimeout(() => resolve(-1), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
 
 function summary(overrides: Partial<AgentBackupCatalogRuntimeSummary> = {}) {
   return {
@@ -55,9 +86,9 @@ function summary(overrides: Partial<AgentBackupCatalogRuntimeSummary> = {}) {
 
 function env(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return {
-    AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS: "10",
-    AGENT_BACKUP_CATALOG_WORKER_RETRY_MS: "1",
-    AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS: "5",
+    AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS: "5000",
+    AGENT_BACKUP_CATALOG_WORKER_RETRY_MS: "5000",
+    AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS: "1000",
     AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE:
       "/run/test-backup-catalog/health.json",
     ...overrides,
@@ -109,6 +140,80 @@ describe("backup catalogue worker config", () => {
         [],
       ),
     ).toThrow(/60000/);
+    expect(() =>
+      readBackupCatalogWorkerConfig(
+        { AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS: "4999" },
+        [],
+      ),
+    ).toThrow(/5000/);
+    expect(() =>
+      readBackupCatalogWorkerConfig(
+        { AGENT_BACKUP_CATALOG_WORKER_RETRY_MS: "4999" },
+        [],
+      ),
+    ).toThrow(/5000/);
+    expect(() =>
+      readBackupCatalogWorkerConfig(
+        { AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS: "999" },
+        [],
+      ),
+    ).toThrow(/1000/);
+    expect(() =>
+      readBackupCatalogWorkerConfig(
+        { AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS: "25001" },
+        [],
+      ),
+    ).toThrow(/25000/);
+  });
+
+  test("redacts arbitrary fatal messages and admits only closed known codes", () => {
+    const error = Object.assign(
+      new Error("provider reflected DO_NOT_LEAK_FATAL_SECRET"),
+      { code: "BACKUP_PROVIDER_UNAVAILABLE" },
+    );
+    expect(formatBackupCatalogFatalMessage(error)).toBe(
+      "[backup-catalog-worker] fatal: AGENT_BACKUP_CATALOG_CYCLE_FAILED\n",
+    );
+    expect(formatBackupCatalogFatalMessage(error)).not.toContain(
+      "DO_NOT_LEAK_FATAL_SECRET",
+    );
+    expect(
+      formatBackupCatalogFatalMessage({
+        code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+      }),
+    ).toContain("AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE");
+    expect(
+      formatBackupCatalogFatalMessage({ code: "AKIA_DO_NOT_LEAK_SECRET" }),
+    ).not.toContain("AKIA_DO_NOT_LEAK_SECRET");
+
+    const throwingCode = {};
+    Object.defineProperty(throwingCode, "code", {
+      get() {
+        throw new Error("DO_NOT_LEAK_THROWING_CODE_GETTER");
+      },
+    });
+    expect(formatBackupCatalogFatalMessage(throwingCode)).toBe(
+      "[backup-catalog-worker] fatal: AGENT_BACKUP_CATALOG_CYCLE_FAILED\n",
+    );
+  });
+
+  test("extracts only closed configuration names without invoking message getters", () => {
+    expect(
+      safeBackupCatalogConfigurationNames(
+        new Error(
+          "DATABASE_URL and AGENT_BACKUP_OPERATION_LEASE_MS invalid; " +
+            "AGENT_BACKUP_DO_NOT_LEAK_SECRET and AKIA_DO_NOT_LEAK_SECRET ignored",
+        ),
+      ),
+    ).toEqual(["AGENT_BACKUP_OPERATION_LEASE_MS", "DATABASE_URL"]);
+
+    const throwingMessage = {};
+    Object.defineProperty(throwingMessage, "message", {
+      get() {
+        throw new Error("AGENT_BACKUP_DO_NOT_LEAK_SECRET");
+      },
+    });
+    expect(safeBackupCatalogConfigurationNames(throwingMessage)).toEqual([]);
   });
 });
 
@@ -130,23 +235,20 @@ describe("backup catalogue worker lifecycle", () => {
         ],
         {
           cwd: root,
-          env: {
-            ...process.env,
+          env: minimalSubprocessEnv({
             AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "0",
             AGENT_BACKUP_RPO_SCHEDULER_ENABLED: "0",
             AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE: healthFile,
-          },
+          }),
           stdout: "pipe",
           stderr: "pipe",
         },
       );
-      const exitCode = await Promise.race([
-        child.exited,
-        Bun.sleep(5_000).then(() => {
-          child.kill();
-          return -1;
-        }),
-      ]);
+      const exitCode = await waitForSubprocess(child);
+      if (exitCode === -1) {
+        child.kill();
+        await child.exited;
+      }
       expect(exitCode).toBe(0);
       expect(JSON.parse(await readFile(healthFile, "utf8"))).toMatchObject({
         format: "elizaos.agent-backup.catalog-worker-health.v1",
@@ -154,6 +256,7 @@ describe("backup catalogue worker lifecycle", () => {
         enabled: false,
         cycles: 0,
         failures: 0,
+        lastCycleMetrics: null,
       });
     } finally {
       await rm(proofDirectory, { recursive: true, force: true });
@@ -178,26 +281,23 @@ describe("backup catalogue worker lifecycle", () => {
         ],
         {
           cwd: root,
-          env: {
-            ...process.env,
+          env: minimalSubprocessEnv({
             AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "1",
             AGENT_BACKUP_RPO_SCHEDULER_ENABLED: "0",
             AGENT_BACKUP_CATALOG_WORKER_ID: "",
             AGENT_BACKUP_R2_SECRET_ACCESS_KEY: secretSentinel,
             AGENT_BACKUP_STEWARD_KMS_TOKEN: secretSentinel,
             AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE: healthFile,
-          },
+          }),
           stdout: "pipe",
           stderr: "pipe",
         },
       );
-      const exitCode = await Promise.race([
-        child.exited,
-        Bun.sleep(5_000).then(() => {
-          child.kill();
-          return -1;
-        }),
-      ]);
+      const exitCode = await waitForSubprocess(child);
+      if (exitCode === -1) {
+        child.kill();
+        await child.exited;
+      }
       const stderr = await new Response(child.stderr).text();
       expect(exitCode).toBe(78);
       expect(stderr).toContain("AGENT_BACKUP_CATALOG_WORKER_ID");
@@ -207,6 +307,7 @@ describe("backup catalogue worker lifecycle", () => {
         enabled: false,
         cycles: 0,
         failures: 1,
+        lastCycleMetrics: null,
       });
     } finally {
       await rm(proofDirectory, { recursive: true, force: true });
@@ -238,6 +339,80 @@ describe("backup catalogue worker lifecycle", () => {
       "running",
       "idle",
     ]);
+    expect(health.at(-1)?.lastCycleMetrics).toMatchObject({
+      operationClaimed: 1,
+      operationCaptured: 1,
+      operationProtected: 0,
+    });
+    expect(deps.logger.info).toHaveBeenCalledWith(
+      "[backup-catalog-worker] cycle complete",
+      expect.objectContaining({ operationClaimed: 1, operationCaptured: 1 }),
+    );
+  });
+
+  test("marks a resolved cycle with alerts degraded and uses retry cadence", async () => {
+    const controller = new AbortController();
+    const runCycle = mock(async () =>
+      summary({
+        scheduleIndeterminate: 10_000,
+        alertCodes: ["BACKUP_SCHEDULE_RECONCILE_REQUIRED"],
+      }),
+    );
+    const { deps, health } = dependencies({ runCycle });
+    deps.sleep = mock(async (ms) => {
+      expect(ms).toBe(5_000);
+      controller.abort(new Error("test complete"));
+    });
+    const result = await runBackupCatalogWorker({
+      env: env(),
+      signal: controller.signal,
+      dependencies: deps,
+    });
+    expect(result).toMatchObject({
+      state: "bounded-shutdown",
+      cycles: 1,
+      failures: 1,
+    });
+    expect(health.map((entry) => entry.state)).toContain("degraded");
+    expect(health.every((entry) => "lastCycleMetrics" in entry)).toBe(true);
+    expect(
+      health.find((entry) => entry.state === "degraded")?.lastCycleMetrics,
+    ).toMatchObject({ scheduleIndeterminate: 10_000 });
+    expect(deps.logger.warn).toHaveBeenCalledWith(
+      "[backup-catalog-worker] cycle degraded",
+      expect.objectContaining({
+        failures: 1,
+        alertCodes: ["BACKUP_SCHEDULE_RECONCILE_REQUIRED"],
+      }),
+    );
+  });
+
+  test("keeps hostile alert codes degraded while exposing only bounded metrics", async () => {
+    const hostile = "AKIA_DO_NOT_LEAK_ALERT_CODE";
+    const { deps, health } = dependencies({
+      runCycle: mock(async () =>
+        summary({
+          scheduleClaimed: -1,
+          operationClaimed: Number.MAX_SAFE_INTEGER,
+          alertCodes: [hostile],
+        }),
+      ),
+    });
+    const result = await runBackupCatalogWorker({
+      env: env(),
+      argv: ["--once"],
+      signal: new AbortController().signal,
+      dependencies: deps,
+    });
+    const final = health.at(-1);
+    expect(result.state).toBe("degraded");
+    expect(final?.state).toBe("degraded");
+    expect(final?.lastAlertCodes).toEqual(["BACKUP_ALERT_REDACTED"]);
+    expect(final?.lastCycleMetrics).toMatchObject({
+      scheduleClaimed: 0,
+      operationClaimed: 1_000_000_000,
+    });
+    expect(JSON.stringify(final)).not.toContain(hostile);
   });
 
   test("reports disabled without invoking any runtime cycle", async () => {
@@ -252,6 +427,7 @@ describe("backup catalogue worker lifecycle", () => {
     expect(result.state).toBe("disabled");
     expect(runCycle).not.toHaveBeenCalled();
     expect(health.at(-1)?.state).toBe("disabled");
+    expect(health.at(-1)?.lastCycleMetrics).toBeNull();
   });
 
   test("classifies malformed enabled composition as terminal configuration failure", async () => {
@@ -270,6 +446,98 @@ describe("backup catalogue worker lifecycle", () => {
       failures: 1,
     });
     expect(health.at(-1)?.state).toBe("terminal-configuration-failure");
+  });
+
+  test("keeps exit 78 when invalid daemon config health publication fails", async () => {
+    const { deps } = dependencies();
+    const healthFailure = "DO_NOT_LEAK_CONFIG_HEALTH_FAILURE";
+    const errorLogs: unknown[] = [];
+    deps.writeHealth = mock(async () => {
+      throw new Error(healthFailure);
+    });
+    deps.logger.error = mock((message: unknown, context?: unknown) => {
+      errorLogs.push([message, context]);
+    }) as never;
+
+    const result = await runBackupCatalogWorker({
+      env: env({ AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS: "invalid-value" }),
+      argv: ["--once"],
+      signal: new AbortController().signal,
+      dependencies: deps,
+    });
+
+    expect(result).toEqual({
+      state: "terminal-configuration-failure",
+      exitCode: 78,
+      cycles: 0,
+      failures: 1,
+    });
+    expect(deps.createComposition).not.toHaveBeenCalled();
+    expect(deps.writeHealth).toHaveBeenCalledTimes(1);
+    expect(errorLogs).toEqual([
+      [
+        "[backup-catalog-worker] configuration rejected",
+        {
+          code: "AGENT_BACKUP_CATALOG_CONFIGURATION_INVALID",
+          configurationNames: ["AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS"],
+        },
+      ],
+      [
+        "[backup-catalog-worker] configuration health publication failed",
+        { code: "AGENT_BACKUP_CATALOG_HEALTH_WRITE_FAILED" },
+      ],
+    ]);
+    expect(JSON.stringify(errorLogs)).not.toContain(healthFailure);
+    expect(JSON.stringify(errorLogs)).not.toContain("invalid-value");
+  });
+
+  test("keeps exit 78 when invalid composition health publication fails", async () => {
+    const { deps } = dependencies({
+      createError: new Error(
+        "AGENT_BACKUP_R2_ENDPOINT rejects DO_NOT_LEAK_PROVIDER_VALUE",
+      ),
+    });
+    const healthFailure = "DO_NOT_LEAK_COMPOSITION_HEALTH_FAILURE";
+    const errorLogs: unknown[] = [];
+    deps.writeHealth = mock(async () => {
+      throw new Error(healthFailure);
+    });
+    deps.logger.error = mock((message: unknown, context?: unknown) => {
+      errorLogs.push([message, context]);
+    }) as never;
+
+    const result = await runBackupCatalogWorker({
+      env: env(),
+      argv: ["--once"],
+      signal: new AbortController().signal,
+      dependencies: deps,
+    });
+
+    expect(result).toEqual({
+      state: "terminal-configuration-failure",
+      exitCode: 78,
+      cycles: 0,
+      failures: 1,
+    });
+    expect(deps.createComposition).toHaveBeenCalledTimes(1);
+    expect(deps.writeHealth).toHaveBeenCalledTimes(1);
+    expect(errorLogs).toEqual([
+      [
+        "[backup-catalog-worker] configuration rejected",
+        {
+          code: "AGENT_BACKUP_CATALOG_CONFIGURATION_INVALID",
+          configurationNames: ["AGENT_BACKUP_R2_ENDPOINT"],
+        },
+      ],
+      [
+        "[backup-catalog-worker] configuration health publication failed",
+        { code: "AGENT_BACKUP_CATALOG_HEALTH_WRITE_FAILED" },
+      ],
+    ]);
+    expect(JSON.stringify(errorLogs)).not.toContain(healthFailure);
+    expect(JSON.stringify(errorLogs)).not.toContain(
+      "DO_NOT_LEAK_PROVIDER_VALUE",
+    );
   });
 
   test("retries a transient cycle and stops claiming after cancellation", async () => {
@@ -294,6 +562,33 @@ describe("backup catalogue worker lifecycle", () => {
       failures: 1,
     });
     expect(health.map((entry) => entry.state)).toContain("retryable-failure");
+    expect(
+      health.find((entry) => entry.state === "retryable-failure")
+        ?.lastCycleMetrics,
+    ).toBeNull();
+  });
+
+  test("clears prior-cycle metrics before publishing a later retryable failure", async () => {
+    const controller = new AbortController();
+    let attempt = 0;
+    const runCycle = mock(async () => {
+      attempt += 1;
+      if (attempt === 1) return summary({ operationProtected: 1 });
+      throw new Error("transient provider outage");
+    });
+    const { deps, health } = dependencies({ runCycle });
+    deps.sleep = mock(async () => {
+      if (attempt > 1) controller.abort(new Error("test complete"));
+    });
+    await runBackupCatalogWorker({
+      env: env(),
+      signal: controller.signal,
+      dependencies: deps,
+    });
+    expect(
+      health.findLast((entry) => entry.state === "retryable-failure")
+        ?.lastCycleMetrics,
+    ).toBeNull();
   });
 
   test("propagates SIGTERM-style cancellation into the in-flight executor", async () => {
@@ -318,6 +613,24 @@ describe("backup catalogue worker lifecycle", () => {
     expect(runCycle.mock.calls[0]?.[0]).toBe(controller.signal);
     expect(result.state).toBe("bounded-shutdown");
     expect(health.at(-1)?.state).toBe("bounded-shutdown");
+    expect(health.at(-1)?.lastCycleMetrics).toBeNull();
+  });
+
+  test("clears the shutdown timer when an already-aborted execution settles", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("already stopped"));
+    const clearTimeoutSpy = spyOn(globalThis, "clearTimeout");
+    try {
+      const result = await waitForShutdownBound({
+        pending: Promise.resolve("settled"),
+        signal: controller.signal,
+        timeoutMs: 25_000,
+      });
+      expect(result).toEqual({ kind: "settled", value: "settled" });
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      clearTimeoutSpy.mockRestore();
+    }
   });
 
   test("bounds shutdown when an executor ignores cancellation", async () => {
@@ -330,7 +643,7 @@ describe("backup catalogue worker lifecycle", () => {
       runCycle,
     });
     const running = runBackupCatalogWorker({
-      env: env({ AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS: "1" }),
+      env: env({ AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS: "1000" }),
       signal: controller.signal,
       dependencies: deps,
     });
@@ -339,9 +652,10 @@ describe("backup catalogue worker lifecycle", () => {
     const result = await running;
     expect(result).toMatchObject({ state: "bounded-shutdown", exitCode: 0 });
     expect(health.at(-1)?.state).toBe("bounded-shutdown");
+    expect(health.at(-1)?.lastCycleMetrics).toBeNull();
   });
 
-  test("a fresh process replays work left unacknowledged by a timed-out predecessor", async () => {
+  test("models durable replay ownership after a timed-out predecessor", async () => {
     const firstController = new AbortController();
     let durableProtected = false;
     const firstCycle = mock(
@@ -352,7 +666,7 @@ describe("backup catalogue worker lifecycle", () => {
       runCycle: firstCycle,
     });
     const firstRun = runBackupCatalogWorker({
-      env: env({ AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS: "1" }),
+      env: env({ AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS: "1000" }),
       signal: firstController.signal,
       dependencies: first.deps,
     });

--- a/packages/cloud/scripts/admin/daemons/backup-catalog-worker.test.ts
+++ b/packages/cloud/scripts/admin/daemons/backup-catalog-worker.test.ts
@@ -1,0 +1,379 @@
+/** Lifecycle, retry, cancellation, timeout, and replay tests for the daemon. */
+
+import { describe, expect, mock, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { AgentBackupCatalogRuntimeSummary } from "@elizaos/cloud-shared/lib/services/agent-backup-catalog-runtime";
+import {
+  type BackupCatalogWorkerDependencies,
+  type BackupCatalogWorkerHealth,
+  readBackupCatalogWorkerConfig,
+  runBackupCatalogWorker,
+} from "./backup-catalog-worker";
+
+function summary(overrides: Partial<AgentBackupCatalogRuntimeSummary> = {}) {
+  return {
+    enabled: true,
+    scheduleEnrolled: 0,
+    scheduleProtected: 0,
+    scheduleRecycled: 0,
+    scheduleClaimed: 0,
+    scheduleReserved: 0,
+    scheduleDeferred: 0,
+    scheduleIndeterminate: 0,
+    scheduleOverdue: 0,
+    operationClaimed: 0,
+    operationCaptured: 0,
+    operationCaptureRetryScheduled: 0,
+    operationCaptureTerminal: 0,
+    operationProtected: 0,
+    operationPublicationRetryScheduled: 0,
+    operationDeferred: 0,
+    operationIndeterminate: 0,
+    spoolCleanup: {
+      discovered: 0,
+      authorized: 0,
+      completed: 0,
+      pending: 0,
+      skippedUnprotected: 0,
+      indeterminate: 0,
+    },
+    deletionCandidates: 0,
+    deletionEnqueued: 0,
+    deletionEnqueueIndeterminate: 0,
+    gcClaimed: 0,
+    gcCompleted: 0,
+    gcFailed: 0,
+    gcIndeterminate: 0,
+    deletionFinalized: 0,
+    deletionFinalizeIndeterminate: 0,
+    alertCodes: [] as string[],
+    ...overrides,
+  } satisfies AgentBackupCatalogRuntimeSummary;
+}
+
+function env(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS: "10",
+    AGENT_BACKUP_CATALOG_WORKER_RETRY_MS: "1",
+    AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS: "5",
+    AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE:
+      "/run/test-backup-catalog/health.json",
+    ...overrides,
+  };
+}
+
+function dependencies(
+  params: {
+    enabled?: boolean;
+    runCycle?: (
+      signal?: AbortSignal,
+    ) => Promise<AgentBackupCatalogRuntimeSummary>;
+    createError?: Error;
+  } = {},
+) {
+  const health: BackupCatalogWorkerHealth[] = [];
+  let clock = Date.parse("2026-08-21T00:00:00.000Z");
+  const deps: BackupCatalogWorkerDependencies = {
+    createComposition: mock(async () => {
+      if (params.createError) throw params.createError;
+      return {
+        enabled: params.enabled ?? true,
+        runCycle: params.runCycle ?? mock(async () => summary()),
+      };
+    }),
+    writeHealth: mock(async (_filePath, value) => {
+      health.push(structuredClone(value));
+    }),
+    sleep: mock(async () => undefined),
+    now: mock(() => clock++),
+    logger: {
+      info: mock(() => undefined),
+      warn: mock(() => undefined),
+      error: mock(() => undefined),
+    } as never,
+  };
+  return { deps, health };
+}
+
+describe("backup catalogue worker config", () => {
+  test("keeps cadence no slower than 60 seconds and supports --once", () => {
+    expect(readBackupCatalogWorkerConfig({}, ["--once"])).toMatchObject({
+      runOnce: true,
+      intervalMs: 60_000,
+    });
+    expect(() =>
+      readBackupCatalogWorkerConfig(
+        { AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS: "60001" },
+        [],
+      ),
+    ).toThrow(/60000/);
+  });
+});
+
+describe("backup catalogue worker lifecycle", () => {
+  test("runs the production entrypoint once and exits disabled without credentials", async () => {
+    const root = path.resolve(import.meta.dir, "../../../../..");
+    const proofDirectory = await mkdtemp(
+      path.join(tmpdir(), "eliza-backup-catalog-entrypoint-"),
+    );
+    const healthFile = path.join(proofDirectory, "health.json");
+    try {
+      const child = Bun.spawn(
+        [
+          path.join(root, "node_modules/.bin/tsx"),
+          "--tsconfig",
+          path.join(root, "packages/cloud/shared/tsconfig.json"),
+          path.join(import.meta.dir, "backup-catalog-worker.ts"),
+          "--once",
+        ],
+        {
+          cwd: root,
+          env: {
+            ...process.env,
+            AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "0",
+            AGENT_BACKUP_RPO_SCHEDULER_ENABLED: "0",
+            AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE: healthFile,
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      const exitCode = await Promise.race([
+        child.exited,
+        Bun.sleep(5_000).then(() => {
+          child.kill();
+          return -1;
+        }),
+      ]);
+      expect(exitCode).toBe(0);
+      expect(JSON.parse(await readFile(healthFile, "utf8"))).toMatchObject({
+        format: "elizaos.agent-backup.catalog-worker-health.v1",
+        state: "disabled",
+        enabled: false,
+        cycles: 0,
+        failures: 0,
+      });
+    } finally {
+      await rm(proofDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test("production entrypoint rejects malformed enabled config without leaking values", async () => {
+    const root = path.resolve(import.meta.dir, "../../../../..");
+    const proofDirectory = await mkdtemp(
+      path.join(tmpdir(), "eliza-backup-catalog-malformed-"),
+    );
+    const healthFile = path.join(proofDirectory, "health.json");
+    const secretSentinel = "DO_NOT_LEAK_BACKUP_SECRET";
+    try {
+      const child = Bun.spawn(
+        [
+          path.join(root, "node_modules/.bin/tsx"),
+          "--tsconfig",
+          path.join(root, "packages/cloud/shared/tsconfig.json"),
+          path.join(import.meta.dir, "backup-catalog-worker.ts"),
+          "--once",
+        ],
+        {
+          cwd: root,
+          env: {
+            ...process.env,
+            AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "1",
+            AGENT_BACKUP_RPO_SCHEDULER_ENABLED: "0",
+            AGENT_BACKUP_CATALOG_WORKER_ID: "",
+            AGENT_BACKUP_R2_SECRET_ACCESS_KEY: secretSentinel,
+            AGENT_BACKUP_STEWARD_KMS_TOKEN: secretSentinel,
+            AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE: healthFile,
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      const exitCode = await Promise.race([
+        child.exited,
+        Bun.sleep(5_000).then(() => {
+          child.kill();
+          return -1;
+        }),
+      ]);
+      const stderr = await new Response(child.stderr).text();
+      expect(exitCode).toBe(78);
+      expect(stderr).toContain("AGENT_BACKUP_CATALOG_WORKER_ID");
+      expect(stderr).not.toContain(secretSentinel);
+      expect(JSON.parse(await readFile(healthFile, "utf8"))).toMatchObject({
+        state: "terminal-configuration-failure",
+        enabled: false,
+        cycles: 0,
+        failures: 1,
+      });
+    } finally {
+      await rm(proofDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test("runs exactly one production-composition cycle in --once mode", async () => {
+    const runCycle = mock(async () =>
+      summary({ operationClaimed: 1, operationCaptured: 1 }),
+    );
+    const { deps, health } = dependencies({ runCycle });
+    const controller = new AbortController();
+    const result = await runBackupCatalogWorker({
+      env: env(),
+      argv: ["--once"],
+      signal: controller.signal,
+      dependencies: deps,
+    });
+    expect(result).toEqual({
+      state: "idle",
+      exitCode: 0,
+      cycles: 1,
+      failures: 0,
+    });
+    expect(runCycle).toHaveBeenCalledTimes(1);
+    expect(runCycle).toHaveBeenCalledWith(controller.signal);
+    expect(health.map((entry) => entry.state)).toEqual([
+      "idle",
+      "running",
+      "idle",
+    ]);
+  });
+
+  test("reports disabled without invoking any runtime cycle", async () => {
+    const runCycle = mock(async () => summary());
+    const { deps, health } = dependencies({ enabled: false, runCycle });
+    const result = await runBackupCatalogWorker({
+      env: env(),
+      argv: ["--once"],
+      signal: new AbortController().signal,
+      dependencies: deps,
+    });
+    expect(result.state).toBe("disabled");
+    expect(runCycle).not.toHaveBeenCalled();
+    expect(health.at(-1)?.state).toBe("disabled");
+  });
+
+  test("classifies malformed enabled composition as terminal configuration failure", async () => {
+    const { deps, health } = dependencies({
+      createError: new Error("AGENT_BACKUP_R2_ENDPOINT must be configured"),
+    });
+    const result = await runBackupCatalogWorker({
+      env: env(),
+      argv: ["--once"],
+      signal: new AbortController().signal,
+      dependencies: deps,
+    });
+    expect(result).toMatchObject({
+      state: "terminal-configuration-failure",
+      exitCode: 78,
+      failures: 1,
+    });
+    expect(health.at(-1)?.state).toBe("terminal-configuration-failure");
+  });
+
+  test("retries a transient cycle and stops claiming after cancellation", async () => {
+    const controller = new AbortController();
+    let attempt = 0;
+    const runCycle = mock(async () => {
+      attempt += 1;
+      if (attempt === 1) throw new Error("transient provider outage");
+      controller.abort(new Error("test shutdown"));
+      return summary({ operationProtected: 1 });
+    });
+    const { deps, health } = dependencies({ runCycle });
+    const result = await runBackupCatalogWorker({
+      env: env(),
+      signal: controller.signal,
+      dependencies: deps,
+    });
+    expect(runCycle).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({
+      state: "bounded-shutdown",
+      cycles: 1,
+      failures: 1,
+    });
+    expect(health.map((entry) => entry.state)).toContain("retryable-failure");
+  });
+
+  test("propagates SIGTERM-style cancellation into the in-flight executor", async () => {
+    const controller = new AbortController();
+    const runCycle = mock(
+      async (signal?: AbortSignal) =>
+        new Promise<AgentBackupCatalogRuntimeSummary>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        }),
+    );
+    const { deps, health } = dependencies({ runCycle });
+    const running = runBackupCatalogWorker({
+      env: env(),
+      signal: controller.signal,
+      dependencies: deps,
+    });
+    while (runCycle.mock.calls.length === 0) await Bun.sleep(0);
+    controller.abort(new Error("SIGTERM"));
+    const result = await running;
+    expect(runCycle.mock.calls[0]?.[0]).toBe(controller.signal);
+    expect(result.state).toBe("bounded-shutdown");
+    expect(health.at(-1)?.state).toBe("bounded-shutdown");
+  });
+
+  test("bounds shutdown when an executor ignores cancellation", async () => {
+    const controller = new AbortController();
+    const runCycle = mock(
+      async () =>
+        new Promise<AgentBackupCatalogRuntimeSummary>(() => undefined),
+    );
+    const { deps, health } = dependencies({
+      runCycle,
+    });
+    const running = runBackupCatalogWorker({
+      env: env({ AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS: "1" }),
+      signal: controller.signal,
+      dependencies: deps,
+    });
+    while (runCycle.mock.calls.length === 0) await Bun.sleep(0);
+    controller.abort(new Error("SIGTERM"));
+    const result = await running;
+    expect(result).toMatchObject({ state: "bounded-shutdown", exitCode: 0 });
+    expect(health.at(-1)?.state).toBe("bounded-shutdown");
+  });
+
+  test("a fresh process replays work left unacknowledged by a timed-out predecessor", async () => {
+    const firstController = new AbortController();
+    let durableProtected = false;
+    const firstCycle = mock(
+      async () =>
+        new Promise<AgentBackupCatalogRuntimeSummary>(() => undefined),
+    );
+    const first = dependencies({
+      runCycle: firstCycle,
+    });
+    const firstRun = runBackupCatalogWorker({
+      env: env({ AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS: "1" }),
+      signal: firstController.signal,
+      dependencies: first.deps,
+    });
+    while (firstCycle.mock.calls.length === 0) await Bun.sleep(0);
+    firstController.abort(new Error("host restart"));
+    await firstRun;
+    expect(durableProtected).toBe(false);
+
+    const replay = dependencies({
+      runCycle: mock(async () => {
+        durableProtected = true;
+        return summary({ operationClaimed: 1, operationProtected: 1 });
+      }),
+    });
+    const second = await runBackupCatalogWorker({
+      env: env(),
+      argv: ["--once"],
+      signal: new AbortController().signal,
+      dependencies: replay.deps,
+    });
+    expect(second).toMatchObject({ state: "idle", cycles: 1, failures: 0 });
+    expect(durableProtected).toBe(true);
+  });
+});

--- a/packages/cloud/scripts/admin/daemons/backup-catalog-worker.test.ts
+++ b/packages/cloud/scripts/admin/daemons/backup-catalog-worker.test.ts
@@ -15,6 +15,8 @@ import {
   waitForShutdownBound,
 } from "./backup-catalog-worker";
 
+const ENTRYPOINT_TEST_TIMEOUT_MS = 30_000;
+
 function minimalSubprocessEnv(overrides: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return {
     PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
@@ -218,101 +220,109 @@ describe("backup catalogue worker config", () => {
 });
 
 describe("backup catalogue worker lifecycle", () => {
-  test("runs the production entrypoint once and exits disabled without credentials", async () => {
-    const root = path.resolve(import.meta.dir, "../../../../..");
-    const proofDirectory = await mkdtemp(
-      path.join(tmpdir(), "eliza-backup-catalog-entrypoint-"),
-    );
-    const healthFile = path.join(proofDirectory, "health.json");
-    try {
-      const child = Bun.spawn(
-        [
-          path.join(root, "node_modules/.bin/tsx"),
-          "--tsconfig",
-          path.join(root, "packages/cloud/shared/tsconfig.json"),
-          path.join(import.meta.dir, "backup-catalog-worker.ts"),
-          "--once",
-        ],
-        {
-          cwd: root,
-          env: minimalSubprocessEnv({
-            AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "0",
-            AGENT_BACKUP_RPO_SCHEDULER_ENABLED: "0",
-            AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE: healthFile,
-          }),
-          stdout: "pipe",
-          stderr: "pipe",
-        },
+  test(
+    "runs the production entrypoint once and exits disabled without credentials",
+    async () => {
+      const root = path.resolve(import.meta.dir, "../../../../..");
+      const proofDirectory = await mkdtemp(
+        path.join(tmpdir(), "eliza-backup-catalog-entrypoint-"),
       );
-      const exitCode = await waitForSubprocess(child);
-      if (exitCode === -1) {
-        child.kill();
-        await child.exited;
+      const healthFile = path.join(proofDirectory, "health.json");
+      try {
+        const child = Bun.spawn(
+          [
+            path.join(root, "node_modules/.bin/tsx"),
+            "--tsconfig",
+            path.join(root, "packages/cloud/shared/tsconfig.json"),
+            path.join(import.meta.dir, "backup-catalog-worker.ts"),
+            "--once",
+          ],
+          {
+            cwd: root,
+            env: minimalSubprocessEnv({
+              AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "0",
+              AGENT_BACKUP_RPO_SCHEDULER_ENABLED: "0",
+              AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE: healthFile,
+            }),
+            stdout: "pipe",
+            stderr: "pipe",
+          },
+        );
+        const exitCode = await waitForSubprocess(child);
+        if (exitCode === -1) {
+          child.kill();
+          await child.exited;
+        }
+        expect(exitCode).toBe(0);
+        expect(JSON.parse(await readFile(healthFile, "utf8"))).toMatchObject({
+          format: "elizaos.agent-backup.catalog-worker-health.v1",
+          state: "disabled",
+          enabled: false,
+          cycles: 0,
+          failures: 0,
+          lastCycleMetrics: null,
+        });
+      } finally {
+        await rm(proofDirectory, { recursive: true, force: true });
       }
-      expect(exitCode).toBe(0);
-      expect(JSON.parse(await readFile(healthFile, "utf8"))).toMatchObject({
-        format: "elizaos.agent-backup.catalog-worker-health.v1",
-        state: "disabled",
-        enabled: false,
-        cycles: 0,
-        failures: 0,
-        lastCycleMetrics: null,
-      });
-    } finally {
-      await rm(proofDirectory, { recursive: true, force: true });
-    }
-  });
+    },
+    ENTRYPOINT_TEST_TIMEOUT_MS,
+  );
 
-  test("production entrypoint rejects malformed enabled config without leaking values", async () => {
-    const root = path.resolve(import.meta.dir, "../../../../..");
-    const proofDirectory = await mkdtemp(
-      path.join(tmpdir(), "eliza-backup-catalog-malformed-"),
-    );
-    const healthFile = path.join(proofDirectory, "health.json");
-    const secretSentinel = "DO_NOT_LEAK_BACKUP_SECRET";
-    try {
-      const child = Bun.spawn(
-        [
-          path.join(root, "node_modules/.bin/tsx"),
-          "--tsconfig",
-          path.join(root, "packages/cloud/shared/tsconfig.json"),
-          path.join(import.meta.dir, "backup-catalog-worker.ts"),
-          "--once",
-        ],
-        {
-          cwd: root,
-          env: minimalSubprocessEnv({
-            AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "1",
-            AGENT_BACKUP_RPO_SCHEDULER_ENABLED: "0",
-            AGENT_BACKUP_CATALOG_WORKER_ID: "",
-            AGENT_BACKUP_R2_SECRET_ACCESS_KEY: secretSentinel,
-            AGENT_BACKUP_STEWARD_KMS_TOKEN: secretSentinel,
-            AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE: healthFile,
-          }),
-          stdout: "pipe",
-          stderr: "pipe",
-        },
+  test(
+    "production entrypoint rejects malformed enabled config without leaking values",
+    async () => {
+      const root = path.resolve(import.meta.dir, "../../../../..");
+      const proofDirectory = await mkdtemp(
+        path.join(tmpdir(), "eliza-backup-catalog-malformed-"),
       );
-      const exitCode = await waitForSubprocess(child);
-      if (exitCode === -1) {
-        child.kill();
-        await child.exited;
+      const healthFile = path.join(proofDirectory, "health.json");
+      const secretSentinel = "DO_NOT_LEAK_BACKUP_SECRET";
+      try {
+        const child = Bun.spawn(
+          [
+            path.join(root, "node_modules/.bin/tsx"),
+            "--tsconfig",
+            path.join(root, "packages/cloud/shared/tsconfig.json"),
+            path.join(import.meta.dir, "backup-catalog-worker.ts"),
+            "--once",
+          ],
+          {
+            cwd: root,
+            env: minimalSubprocessEnv({
+              AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "1",
+              AGENT_BACKUP_RPO_SCHEDULER_ENABLED: "0",
+              AGENT_BACKUP_CATALOG_WORKER_ID: "",
+              AGENT_BACKUP_R2_SECRET_ACCESS_KEY: secretSentinel,
+              AGENT_BACKUP_STEWARD_KMS_TOKEN: secretSentinel,
+              AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE: healthFile,
+            }),
+            stdout: "pipe",
+            stderr: "pipe",
+          },
+        );
+        const exitCode = await waitForSubprocess(child);
+        if (exitCode === -1) {
+          child.kill();
+          await child.exited;
+        }
+        const stderr = await new Response(child.stderr).text();
+        expect(exitCode).toBe(78);
+        expect(stderr).toContain("AGENT_BACKUP_CATALOG_WORKER_ID");
+        expect(stderr).not.toContain(secretSentinel);
+        expect(JSON.parse(await readFile(healthFile, "utf8"))).toMatchObject({
+          state: "terminal-configuration-failure",
+          enabled: false,
+          cycles: 0,
+          failures: 1,
+          lastCycleMetrics: null,
+        });
+      } finally {
+        await rm(proofDirectory, { recursive: true, force: true });
       }
-      const stderr = await new Response(child.stderr).text();
-      expect(exitCode).toBe(78);
-      expect(stderr).toContain("AGENT_BACKUP_CATALOG_WORKER_ID");
-      expect(stderr).not.toContain(secretSentinel);
-      expect(JSON.parse(await readFile(healthFile, "utf8"))).toMatchObject({
-        state: "terminal-configuration-failure",
-        enabled: false,
-        cycles: 0,
-        failures: 1,
-        lastCycleMetrics: null,
-      });
-    } finally {
-      await rm(proofDirectory, { recursive: true, force: true });
-    }
-  });
+    },
+    ENTRYPOINT_TEST_TIMEOUT_MS,
+  );
 
   test("runs exactly one production-composition cycle in --once mode", async () => {
     const runCycle = mock(async () =>

--- a/packages/cloud/scripts/admin/daemons/backup-catalog-worker.ts
+++ b/packages/cloud/scripts/admin/daemons/backup-catalog-worker.ts
@@ -14,12 +14,12 @@ import {
   type AgentBackupCatalogWorkerComposition,
   createAgentBackupCatalogWorkerComposition,
 } from "@elizaos/cloud-shared/lib/services/agent-backup-catalog-worker-composition";
-import { loadLocalEnv } from "./shared/load-env";
 
 export type BackupCatalogWorkerState =
   | "disabled"
   | "idle"
   | "running"
+  | "degraded"
   | "retryable-failure"
   | "terminal-configuration-failure"
   | "bounded-shutdown";
@@ -45,6 +45,41 @@ export interface BackupCatalogWorkerHealth {
   lastCycleCompletedAt: string | null;
   lastDurationMs: number | null;
   lastAlertCodes: readonly string[];
+  lastCycleMetrics: Readonly<BackupCatalogWorkerCycleMetrics> | null;
+}
+
+export interface BackupCatalogWorkerCycleMetrics {
+  scheduleEnrolled: number;
+  scheduleProtected: number;
+  scheduleRecycled: number;
+  scheduleClaimed: number;
+  scheduleReserved: number;
+  scheduleDeferred: number;
+  scheduleIndeterminate: number;
+  scheduleOverdue: number;
+  operationClaimed: number;
+  operationCaptured: number;
+  operationCaptureRetryScheduled: number;
+  operationCaptureTerminal: number;
+  operationProtected: number;
+  operationPublicationRetryScheduled: number;
+  operationDeferred: number;
+  operationIndeterminate: number;
+  spoolCleanupDiscovered: number;
+  spoolCleanupAuthorized: number;
+  spoolCleanupCompleted: number;
+  spoolCleanupPending: number;
+  spoolCleanupSkippedUnprotected: number;
+  spoolCleanupIndeterminate: number;
+  deletionCandidates: number;
+  deletionEnqueued: number;
+  deletionEnqueueIndeterminate: number;
+  gcClaimed: number;
+  gcCompleted: number;
+  gcFailed: number;
+  gcIndeterminate: number;
+  deletionFinalized: number;
+  deletionFinalizeIndeterminate: number;
 }
 
 type WorkerLogger =
@@ -75,6 +110,94 @@ const DEFAULT_RETRY_MS = 5_000;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 25_000;
 const DEFAULT_HEALTH_FILE = "/run/eliza-backup-catalog/health.json";
 const CONFIG_ERROR_EXIT_CODE = 78;
+const MIN_CYCLE_DELAY_MS = 5_000;
+const MIN_SHUTDOWN_TIMEOUT_MS = 1_000;
+const MAX_SHUTDOWN_TIMEOUT_MS = 25_000;
+const MAX_HEALTH_COUNTER = 1_000_000_000;
+
+const SAFE_BACKUP_CATALOG_ERROR_CODES = new Set([
+  "AGENT_BACKUP_CATALOG_CYCLE_FAILED",
+  "AGENT_BACKUP_V2_CAPTURE_ABORTED",
+  "AGENT_BACKUP_V2_CAPTURE_DEADLINE_EXCEEDED",
+  "AGENT_BACKUP_V2_PIPELINE_ABORTED",
+  "AGENT_BACKUP_V2_PIPELINE_DEADLINE_EXCEEDED",
+  "AGENT_BACKUP_V2_PIPELINE_LEASE_LOST",
+  "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+  "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_UNAVAILABLE",
+  "AGENT_BACKUP_V3_RUNTIME_IDENTITY_CHANGED",
+  "AGENT_BACKUP_V3_VAULT_AUTHORITY_CHANGED",
+]);
+
+const SAFE_BACKUP_CATALOG_ALERT_CODES = new Set([
+  "BACKUP_CAPTURE_V2_RETRY_SCHEDULED",
+  "BACKUP_CAPTURE_V2_TERMINAL",
+  "BACKUP_DELETION_ENQUEUE_RECONCILE_REQUIRED",
+  "BACKUP_DELETION_FINALIZE_RECONCILE_REQUIRED",
+  "BACKUP_GC_RECONCILE_REQUIRED",
+  "BACKUP_GC_RETRY_SCHEDULED",
+  "BACKUP_OPERATION_RECONCILE_REQUIRED",
+  "BACKUP_PIPELINE_STAGE_UNAVAILABLE",
+  "BACKUP_PRIMARY_PUBLICATION_RETRY",
+  "BACKUP_PUBLICATION_RETRY_SCHEDULED",
+  "BACKUP_SCHEDULE_RECONCILE_REQUIRED",
+  "BACKUP_SCHEDULE_RESERVATION_RETRY",
+  "BACKUP_SCHEDULE_RPO_OVERDUE",
+  "BACKUP_SECONDARY_REPLICATION_RETRY",
+  "BACKUP_SPOOL_CLEANUP_RECONCILE_REQUIRED",
+]);
+
+const SAFE_BACKUP_CATALOG_CONFIGURATION_NAMES = new Set([
+  "AGENT_BACKUP_AGENT_SCHEMA_VERSION",
+  "AGENT_BACKUP_CAPTURE_DEADLINE_MS",
+  "AGENT_BACKUP_CATALOG_RUNTIME_ENABLED",
+  "AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE",
+  "AGENT_BACKUP_CATALOG_WORKER_ID",
+  "AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS",
+  "AGENT_BACKUP_CATALOG_WORKER_RETRY_MS",
+  "AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS",
+  "AGENT_BACKUP_DATABASE_SCHEMA_VERSION",
+  "AGENT_BACKUP_DELETION_BATCH_SIZE",
+  "AGENT_BACKUP_GC_BATCH_SIZE",
+  "AGENT_BACKUP_GC_LEASE_MS",
+  "AGENT_BACKUP_GC_RETRY_BASE_MS",
+  "AGENT_BACKUP_GC_RETRY_MAX_MS",
+  "AGENT_BACKUP_HETZNER_ACCESS_KEY_ID",
+  "AGENT_BACKUP_HETZNER_ACCOUNT_ID",
+  "AGENT_BACKUP_HETZNER_BUCKET",
+  "AGENT_BACKUP_HETZNER_ENDPOINT",
+  "AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS",
+  "AGENT_BACKUP_HETZNER_REGION",
+  "AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY",
+  "AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT",
+  "AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID",
+  "AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS",
+  "AGENT_BACKUP_OPERATION_BATCH_SIZE",
+  "AGENT_BACKUP_OPERATION_LEASE_MS",
+  "AGENT_BACKUP_OPERATION_RETRY_BASE_MS",
+  "AGENT_BACKUP_OPERATION_RETRY_MAX_MS",
+  "AGENT_BACKUP_R2_ACCESS_KEY_ID",
+  "AGENT_BACKUP_R2_ACCOUNT_ID",
+  "AGENT_BACKUP_R2_BUCKET",
+  "AGENT_BACKUP_R2_ENDPOINT",
+  "AGENT_BACKUP_R2_ENDPOINT_ALIAS",
+  "AGENT_BACKUP_R2_REGION",
+  "AGENT_BACKUP_R2_SECRET_ACCESS_KEY",
+  "AGENT_BACKUP_RPO_SCHEDULER_ENABLED",
+  "AGENT_BACKUP_RUNTIME_PLUGINS_JSON",
+  "AGENT_BACKUP_SCHEDULE_BATCH_SIZE",
+  "AGENT_BACKUP_SCHEDULE_LEASE_MS",
+  "AGENT_BACKUP_SCHEDULE_RETRY_MS",
+  "AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE",
+  "AGENT_BACKUP_SPOOL_MAX_BYTES",
+  "AGENT_BACKUP_SPOOL_MIN_FREE_BYTES",
+  "AGENT_BACKUP_SPOOL_STATE_DIRECTORY",
+  "AGENT_BACKUP_STEWARD_KMS_BASE_URL",
+  "AGENT_BACKUP_STEWARD_KMS_TOKEN",
+  "AGENT_BACKUP_STORAGE_SCOPE",
+  "DATABASE_SSL_NO_VERIFY",
+  "DATABASE_URL",
+  "SECRETS_MASTER_KEY",
+]);
 
 function canonicalInteger(params: {
   env: NodeJS.ProcessEnv;
@@ -123,22 +246,22 @@ export function readBackupCatalogWorkerConfig(
       env,
       name: "AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS",
       fallback: DEFAULT_INTERVAL_MS,
-      min: 1,
+      min: MIN_CYCLE_DELAY_MS,
       max: 60_000,
     }),
     retryMs: canonicalInteger({
       env,
       name: "AGENT_BACKUP_CATALOG_WORKER_RETRY_MS",
       fallback: DEFAULT_RETRY_MS,
-      min: 1,
+      min: MIN_CYCLE_DELAY_MS,
       max: 60_000,
     }),
     shutdownTimeoutMs: canonicalInteger({
       env,
       name: "AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS",
       fallback: DEFAULT_SHUTDOWN_TIMEOUT_MS,
-      min: 1,
-      max: 60_000,
+      min: MIN_SHUTDOWN_TIMEOUT_MS,
+      max: MAX_SHUTDOWN_TIMEOUT_MS,
     }),
     healthFile,
   };
@@ -172,6 +295,8 @@ export async function writeBackupCatalogWorkerHealth(
     await writeFile(temporary, `${JSON.stringify(health)}\n`, { mode: 0o600 });
     await rename(temporary, filePath);
   } catch (cause) {
+    // error-policy:J6 attempt teardown of the unpublished temporary file, then
+    // preserve the original health-publication failure below.
     try {
       await unlink(temporary);
     } catch {
@@ -181,83 +306,161 @@ export async function writeBackupCatalogWorkerHealth(
   }
 }
 
-function safeErrorCode(error: unknown): string {
-  if (
-    error &&
-    typeof error === "object" &&
-    "code" in error &&
-    typeof Reflect.get(error, "code") === "string" &&
-    /^[A-Z][A-Z0-9_]{0,95}$/.test(Reflect.get(error, "code") as string)
-  ) {
-    return Reflect.get(error, "code") as string;
+function ownDataString(error: unknown, property: string): string | undefined {
+  if (!error || (typeof error !== "object" && typeof error !== "function")) {
+    return undefined;
   }
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(error, property);
+    return descriptor &&
+      "value" in descriptor &&
+      typeof descriptor.value === "string"
+      ? descriptor.value
+      : undefined;
+  } catch {
+    // error-policy:J1 hostile thrown values become absent metadata without
+    // invoking getters or reflecting their messages at the daemon boundary.
+    return undefined;
+  }
+}
+
+function safeErrorCode(error: unknown): string {
+  const code = ownDataString(error, "code");
+  if (code && SAFE_BACKUP_CATALOG_ERROR_CODES.has(code)) return code;
   return "AGENT_BACKUP_CATALOG_CYCLE_FAILED";
+}
+
+/** Format the process-boundary failure without reflecting provider values/messages. */
+export function formatBackupCatalogFatalMessage(error: unknown): string {
+  return `[backup-catalog-worker] fatal: ${safeErrorCode(error)}\n`;
 }
 
 /** Extract only bounded configuration names; never return rejected values or provider messages. */
 export function safeBackupCatalogConfigurationNames(
   error: unknown,
 ): readonly string[] {
-  if (!(error instanceof Error)) return Object.freeze([]);
-  const matches = error.message.match(
-    /\b(?:AGENT_BACKUP_[A-Z0-9_]+|DATABASE_URL|SECRETS_MASTER_KEY)\b/g,
+  const message = ownDataString(error, "message");
+  if (!message) return Object.freeze([]);
+  const matches = message.match(/\b[A-Z][A-Z0-9_]{1,127}\b/g) ?? [];
+  return Object.freeze(
+    [...new Set(matches)]
+      .filter((name) => SAFE_BACKUP_CATALOG_CONFIGURATION_NAMES.has(name))
+      .sort()
+      .slice(0, 64),
   );
-  return Object.freeze([...new Set(matches ?? [])].sort().slice(0, 32));
 }
 
-function summaryMetrics(summary: Readonly<AgentBackupCatalogRuntimeSummary>) {
-  return {
-    scheduleClaimed: summary.scheduleClaimed,
-    scheduleReserved: summary.scheduleReserved,
-    scheduleOverdue: summary.scheduleOverdue,
-    operationClaimed: summary.operationClaimed,
-    operationCaptured: summary.operationCaptured,
-    operationProtected: summary.operationProtected,
-    operationRetryScheduled:
-      summary.operationCaptureRetryScheduled +
+function boundedHealthCounter(value: unknown): number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
+    ? Math.min(value, MAX_HEALTH_COUNTER)
+    : 0;
+}
+
+function safeAlertCodes(codes: readonly string[]): readonly string[] {
+  const safe = new Set<string>();
+  let redacted = false;
+  for (const code of codes) {
+    if (SAFE_BACKUP_CATALOG_ALERT_CODES.has(code)) safe.add(code);
+    else redacted = true;
+  }
+  if (redacted) safe.add("BACKUP_ALERT_REDACTED");
+  return Object.freeze([...safe].sort());
+}
+
+function summaryMetrics(
+  summary: Readonly<AgentBackupCatalogRuntimeSummary>,
+): Readonly<BackupCatalogWorkerCycleMetrics> {
+  return Object.freeze({
+    scheduleEnrolled: boundedHealthCounter(summary.scheduleEnrolled),
+    scheduleProtected: boundedHealthCounter(summary.scheduleProtected),
+    scheduleRecycled: boundedHealthCounter(summary.scheduleRecycled),
+    scheduleClaimed: boundedHealthCounter(summary.scheduleClaimed),
+    scheduleReserved: boundedHealthCounter(summary.scheduleReserved),
+    scheduleDeferred: boundedHealthCounter(summary.scheduleDeferred),
+    scheduleIndeterminate: boundedHealthCounter(summary.scheduleIndeterminate),
+    scheduleOverdue: boundedHealthCounter(summary.scheduleOverdue),
+    operationClaimed: boundedHealthCounter(summary.operationClaimed),
+    operationCaptured: boundedHealthCounter(summary.operationCaptured),
+    operationCaptureRetryScheduled: boundedHealthCounter(
+      summary.operationCaptureRetryScheduled,
+    ),
+    operationCaptureTerminal: boundedHealthCounter(
+      summary.operationCaptureTerminal,
+    ),
+    operationProtected: boundedHealthCounter(summary.operationProtected),
+    operationPublicationRetryScheduled: boundedHealthCounter(
       summary.operationPublicationRetryScheduled,
-    gcClaimed: summary.gcClaimed,
-    gcCompleted: summary.gcCompleted,
-    spoolCleanupPending: summary.spoolCleanup.pending,
-    alertCodes: summary.alertCodes,
-  };
+    ),
+    operationDeferred: boundedHealthCounter(summary.operationDeferred),
+    operationIndeterminate: boundedHealthCounter(
+      summary.operationIndeterminate,
+    ),
+    spoolCleanupDiscovered: boundedHealthCounter(
+      summary.spoolCleanup.discovered,
+    ),
+    spoolCleanupAuthorized: boundedHealthCounter(
+      summary.spoolCleanup.authorized,
+    ),
+    spoolCleanupCompleted: boundedHealthCounter(summary.spoolCleanup.completed),
+    spoolCleanupPending: boundedHealthCounter(summary.spoolCleanup.pending),
+    spoolCleanupSkippedUnprotected: boundedHealthCounter(
+      summary.spoolCleanup.skippedUnprotected,
+    ),
+    spoolCleanupIndeterminate: boundedHealthCounter(
+      summary.spoolCleanup.indeterminate,
+    ),
+    deletionCandidates: boundedHealthCounter(summary.deletionCandidates),
+    deletionEnqueued: boundedHealthCounter(summary.deletionEnqueued),
+    deletionEnqueueIndeterminate: boundedHealthCounter(
+      summary.deletionEnqueueIndeterminate,
+    ),
+    gcClaimed: boundedHealthCounter(summary.gcClaimed),
+    gcCompleted: boundedHealthCounter(summary.gcCompleted),
+    gcFailed: boundedHealthCounter(summary.gcFailed),
+    gcIndeterminate: boundedHealthCounter(summary.gcIndeterminate),
+    deletionFinalized: boundedHealthCounter(summary.deletionFinalized),
+    deletionFinalizeIndeterminate: boundedHealthCounter(
+      summary.deletionFinalizeIndeterminate,
+    ),
+  });
 }
 
-function waitForShutdownBound<T>(params: {
+export function waitForShutdownBound<T>(params: {
   pending: Promise<T>;
   signal: AbortSignal;
   timeoutMs: number;
 }): Promise<{ kind: "settled"; value: T } | { kind: "shutdown-timeout" }> {
-  if (!params.signal.aborted) {
-    return new Promise((resolve, reject) => {
-      let shutdownTimer: ReturnType<typeof setTimeout> | undefined;
-      const onAbort = () => {
-        shutdownTimer = setTimeout(
-          () => resolve({ kind: "shutdown-timeout" }),
-          params.timeoutMs,
-        );
-      };
-      params.signal.addEventListener("abort", onAbort, { once: true });
-      params.pending.then(
-        (value) => {
-          if (shutdownTimer) clearTimeout(shutdownTimer);
-          params.signal.removeEventListener("abort", onAbort);
-          resolve({ kind: "settled", value });
-        },
-        (error: unknown) => {
-          if (shutdownTimer) clearTimeout(shutdownTimer);
-          params.signal.removeEventListener("abort", onAbort);
-          reject(error);
-        },
-      );
-    });
-  }
-  return Promise.race([
-    params.pending.then((value) => ({ kind: "settled" as const, value })),
-    new Promise<{ kind: "shutdown-timeout" }>((resolve) =>
-      setTimeout(() => resolve({ kind: "shutdown-timeout" }), params.timeoutMs),
-    ),
-  ]);
+  return new Promise((resolve, reject) => {
+    let shutdownTimer: ReturnType<typeof setTimeout> | undefined;
+    const clearShutdownTimer = () => {
+      if (shutdownTimer !== undefined) {
+        clearTimeout(shutdownTimer);
+        shutdownTimer = undefined;
+      }
+    };
+    const onAbort = () => {
+      if (shutdownTimer !== undefined) return;
+      shutdownTimer = setTimeout(() => {
+        shutdownTimer = undefined;
+        params.signal.removeEventListener("abort", onAbort);
+        resolve({ kind: "shutdown-timeout" });
+      }, params.timeoutMs);
+    };
+    if (params.signal.aborted) onAbort();
+    else params.signal.addEventListener("abort", onAbort, { once: true });
+    params.pending.then(
+      (value) => {
+        clearShutdownTimer();
+        params.signal.removeEventListener("abort", onAbort);
+        resolve({ kind: "settled", value });
+      },
+      (error: unknown) => {
+        clearShutdownTimer();
+        params.signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
 }
 
 const EMPTY_ALERTS: readonly string[] = Object.freeze([]);
@@ -286,6 +489,7 @@ export async function runBackupCatalogWorker(input: {
   let lastCycleCompletedAt: string | null = null;
   let lastDurationMs: number | null = null;
   let lastAlertCodes = EMPTY_ALERTS;
+  let lastCycleMetrics: Readonly<BackupCatalogWorkerCycleMetrics> | null = null;
   const health = async (
     state: BackupCatalogWorkerState,
     enabled: boolean,
@@ -304,6 +508,7 @@ export async function runBackupCatalogWorker(input: {
       lastCycleCompletedAt,
       lastDurationMs,
       lastAlertCodes,
+      lastCycleMetrics,
     });
   };
 
@@ -311,7 +516,6 @@ export async function runBackupCatalogWorker(input: {
     error: unknown,
   ): Promise<BackupCatalogWorkerRunResult> => {
     failures = 1;
-    await health("terminal-configuration-failure", false);
     input.dependencies.logger.error(
       "[backup-catalog-worker] configuration rejected",
       {
@@ -319,6 +523,16 @@ export async function runBackupCatalogWorker(input: {
         configurationNames: safeBackupCatalogConfigurationNames(error),
       },
     );
+    try {
+      await health("terminal-configuration-failure", false);
+    } catch {
+      // error-policy:J1 health publication is best-effort at this terminal
+      // boundary. Never reflect its failure or replace the permanent exit 78.
+      input.dependencies.logger.error(
+        "[backup-catalog-worker] configuration health publication failed",
+        { code: "AGENT_BACKUP_CATALOG_HEALTH_WRITE_FAILED" },
+      );
+    }
     return {
       state: "terminal-configuration-failure",
       exitCode: CONFIG_ERROR_EXIT_CODE,
@@ -330,11 +544,15 @@ export async function runBackupCatalogWorker(input: {
   try {
     config = readBackupCatalogWorkerConfig(env, argv);
   } catch (error) {
+    // error-policy:J1 translate the daemon configuration boundary to a
+    // value-redacted terminal health state and bounded process exit code.
     return configurationFailure(error);
   }
   try {
     composition = await input.dependencies.createComposition({ env });
   } catch (error) {
+    // error-policy:J1 construction may cross DB/provider adapters, but the
+    // daemon boundary emits only configuration names and a stable code.
     return configurationFailure(error);
   }
 
@@ -360,6 +578,8 @@ export async function runBackupCatalogWorker(input: {
   while (!input.signal.aborted) {
     const cycleStartedMs = input.dependencies.now();
     lastCycleStartedAt = new Date(cycleStartedMs).toISOString();
+    lastAlertCodes = EMPTY_ALERTS;
+    lastCycleMetrics = null;
     await health("running", true);
     try {
       // Normalize a synchronous composition failure into the same retry path as
@@ -368,6 +588,8 @@ export async function runBackupCatalogWorker(input: {
         composition.runCycle(input.signal),
       );
       // Observe any late rejection after a bounded shutdown return.
+      // error-policy:J5 the durable lease owns replay after the daemon has
+      // already published its bounded-shutdown state.
       void pending.catch(() => undefined);
       const settled = await waitForShutdownBound({
         pending,
@@ -389,14 +611,39 @@ export async function runBackupCatalogWorker(input: {
       const completedAtMs = input.dependencies.now();
       lastCycleCompletedAt = new Date(completedAtMs).toISOString();
       lastDurationMs = Math.max(0, completedAtMs - cycleStartedMs);
-      lastAlertCodes = Object.freeze([...settled.value.alertCodes]);
-      await health(input.signal.aborted ? "bounded-shutdown" : "idle", true);
-      input.dependencies.logger.info("[backup-catalog-worker] cycle complete", {
+      lastAlertCodes = safeAlertCodes(settled.value.alertCodes);
+      lastCycleMetrics = summaryMetrics(settled.value);
+      const degraded = settled.value.alertCodes.length > 0;
+      if (degraded) failures += 1;
+      await health(
+        input.signal.aborted
+          ? "bounded-shutdown"
+          : degraded
+            ? "degraded"
+            : "idle",
+        true,
+      );
+      const metrics = {
         cycle: cycles,
         durationMs: lastDurationMs,
-        ...summaryMetrics(settled.value),
-      });
+        failures,
+        ...lastCycleMetrics,
+        alertCodes: lastAlertCodes,
+      };
+      if (degraded) {
+        input.dependencies.logger.warn(
+          "[backup-catalog-worker] cycle degraded",
+          metrics,
+        );
+      } else {
+        input.dependencies.logger.info(
+          "[backup-catalog-worker] cycle complete",
+          metrics,
+        );
+      }
     } catch (error) {
+      // error-policy:J1 the daemon loop boundary translates cycle failures to
+      // an explicit retryable health state with closed, value-free diagnostics.
       if (input.signal.aborted) {
         await health("bounded-shutdown", true);
         return { state: "bounded-shutdown", exitCode: 0, cycles, failures };
@@ -418,10 +665,20 @@ export async function runBackupCatalogWorker(input: {
       await input.dependencies.sleep(config.retryMs, input.signal);
       continue;
     }
-    if (config.runOnce) return { state: "idle", exitCode: 0, cycles, failures };
+    if (config.runOnce) {
+      const degraded = lastAlertCodes.length > 0;
+      return {
+        state: degraded ? "degraded" : "idle",
+        exitCode: degraded ? 1 : 0,
+        cycles,
+        failures,
+      };
+    }
     const elapsed = Math.max(0, input.dependencies.now() - cycleStartedMs);
     await input.dependencies.sleep(
-      Math.max(0, config.intervalMs - elapsed),
+      lastAlertCodes.length > 0
+        ? config.retryMs
+        : Math.max(0, config.intervalMs - elapsed),
       input.signal,
     );
   }
@@ -430,7 +687,10 @@ export async function runBackupCatalogWorker(input: {
 }
 
 async function main(): Promise<number> {
-  loadLocalEnv(import.meta.url);
+  // Unlike the general provisioning daemons, this process must never ingest
+  // cloud/.env.local. systemd supplies a dedicated allowlisted EnvironmentFile;
+  // loading the shared file here would place unrelated credentials in the
+  // disabled worker's /proc environment before the feature gate is inspected.
   const controller = new AbortController();
   const stop = (signal: string) => {
     if (!controller.signal.aborted)
@@ -473,9 +733,9 @@ if (isMainModule()) {
       process.exit(exitCode);
     },
     (error) => {
-      process.stderr.write(
-        `[backup-catalog-worker] fatal: ${error instanceof Error ? error.message : String(error)}\n`,
-      );
+      // error-policy:J1 this is the final process boundary; arbitrary error
+      // messages may contain credentials and must never reach journald.
+      process.stderr.write(formatBackupCatalogFatalMessage(error));
       process.exit(1);
     },
   );

--- a/packages/cloud/scripts/admin/daemons/backup-catalog-worker.ts
+++ b/packages/cloud/scripts/admin/daemons/backup-catalog-worker.ts
@@ -1,0 +1,482 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * Dedicated manifest-v3 backup catalogue worker. The production composition
+ * is disabled-first, cycles are bounded and serial, and SIGTERM cancellation
+ * is propagated into capture/publication while durable database leases and the
+ * persistent StateDirectory make a later process replay-safe.
+ */
+
+import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AgentBackupCatalogRuntimeSummary } from "@elizaos/cloud-shared/lib/services/agent-backup-catalog-runtime";
+import {
+  type AgentBackupCatalogWorkerComposition,
+  createAgentBackupCatalogWorkerComposition,
+} from "@elizaos/cloud-shared/lib/services/agent-backup-catalog-worker-composition";
+import { loadLocalEnv } from "./shared/load-env";
+
+export type BackupCatalogWorkerState =
+  | "disabled"
+  | "idle"
+  | "running"
+  | "retryable-failure"
+  | "terminal-configuration-failure"
+  | "bounded-shutdown";
+
+export interface BackupCatalogWorkerConfig {
+  runOnce: boolean;
+  intervalMs: number;
+  retryMs: number;
+  shutdownTimeoutMs: number;
+  healthFile: string;
+}
+
+export interface BackupCatalogWorkerHealth {
+  format: "elizaos.agent-backup.catalog-worker-health.v1";
+  state: BackupCatalogWorkerState;
+  enabled: boolean;
+  pid: number;
+  updatedAt: string;
+  startedAt: string;
+  cycles: number;
+  failures: number;
+  lastCycleStartedAt: string | null;
+  lastCycleCompletedAt: string | null;
+  lastDurationMs: number | null;
+  lastAlertCodes: readonly string[];
+}
+
+type WorkerLogger =
+  typeof import("@elizaos/cloud-shared/lib/utils/logger").logger;
+
+export interface BackupCatalogWorkerDependencies {
+  createComposition(input: {
+    env: NodeJS.ProcessEnv;
+  }): Promise<AgentBackupCatalogWorkerComposition>;
+  writeHealth(
+    filePath: string,
+    health: Readonly<BackupCatalogWorkerHealth>,
+  ): Promise<void>;
+  sleep(ms: number, signal: AbortSignal): Promise<void>;
+  now(): number;
+  logger: Pick<WorkerLogger, "info" | "warn" | "error">;
+}
+
+export interface BackupCatalogWorkerRunResult {
+  state: BackupCatalogWorkerState;
+  exitCode: number;
+  cycles: number;
+  failures: number;
+}
+
+const DEFAULT_INTERVAL_MS = 60_000;
+const DEFAULT_RETRY_MS = 5_000;
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 25_000;
+const DEFAULT_HEALTH_FILE = "/run/eliza-backup-catalog/health.json";
+const CONFIG_ERROR_EXIT_CODE = 78;
+
+function canonicalInteger(params: {
+  env: NodeJS.ProcessEnv;
+  name: string;
+  fallback: number;
+  min: number;
+  max: number;
+}): number {
+  const raw = params.env[params.name];
+  if (raw === undefined || raw === "") return params.fallback;
+  if (!/^[1-9][0-9]*$/.test(raw)) {
+    throw new Error(`${params.name} must be a canonical positive integer`);
+  }
+  const value = Number(raw);
+  if (
+    !Number.isSafeInteger(value) ||
+    value < params.min ||
+    value > params.max
+  ) {
+    throw new Error(
+      `${params.name} must be between ${params.min} and ${params.max}`,
+    );
+  }
+  return value;
+}
+
+export function readBackupCatalogWorkerConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  argv: readonly string[] = process.argv.slice(2),
+): BackupCatalogWorkerConfig {
+  const healthFile =
+    env.AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE || DEFAULT_HEALTH_FILE;
+  if (
+    !path.isAbsolute(healthFile) ||
+    path.parse(healthFile).root === healthFile ||
+    healthFile !== healthFile.trim() ||
+    healthFile.includes("\0")
+  ) {
+    throw new Error(
+      "AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE must be a specific absolute path",
+    );
+  }
+  return {
+    runOnce: argv.includes("--once"),
+    intervalMs: canonicalInteger({
+      env,
+      name: "AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS",
+      fallback: DEFAULT_INTERVAL_MS,
+      min: 1,
+      max: 60_000,
+    }),
+    retryMs: canonicalInteger({
+      env,
+      name: "AGENT_BACKUP_CATALOG_WORKER_RETRY_MS",
+      fallback: DEFAULT_RETRY_MS,
+      min: 1,
+      max: 60_000,
+    }),
+    shutdownTimeoutMs: canonicalInteger({
+      env,
+      name: "AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS",
+      fallback: DEFAULT_SHUTDOWN_TIMEOUT_MS,
+      min: 1,
+      max: 60_000,
+    }),
+    healthFile,
+  };
+}
+
+async function sleepAbortable(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return;
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(done, ms);
+    function done() {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", done);
+      resolve();
+    }
+    signal.addEventListener("abort", done, { once: true });
+  });
+}
+
+/** Atomically publish one non-secret health snapshot for systemd/preflight. */
+export async function writeBackupCatalogWorkerHealth(
+  filePath: string,
+  health: Readonly<BackupCatalogWorkerHealth>,
+): Promise<void> {
+  const directory = path.dirname(filePath);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const temporary = path.join(
+    directory,
+    `.${path.basename(filePath)}.${process.pid}.tmp`,
+  );
+  try {
+    await writeFile(temporary, `${JSON.stringify(health)}\n`, { mode: 0o600 });
+    await rename(temporary, filePath);
+  } catch (cause) {
+    try {
+      await unlink(temporary);
+    } catch {
+      // error-policy:J6 cleanup cannot replace the health publication failure.
+    }
+    throw cause;
+  }
+}
+
+function safeErrorCode(error: unknown): string {
+  if (
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    typeof Reflect.get(error, "code") === "string" &&
+    /^[A-Z][A-Z0-9_]{0,95}$/.test(Reflect.get(error, "code") as string)
+  ) {
+    return Reflect.get(error, "code") as string;
+  }
+  return "AGENT_BACKUP_CATALOG_CYCLE_FAILED";
+}
+
+/** Extract only bounded configuration names; never return rejected values or provider messages. */
+export function safeBackupCatalogConfigurationNames(
+  error: unknown,
+): readonly string[] {
+  if (!(error instanceof Error)) return Object.freeze([]);
+  const matches = error.message.match(
+    /\b(?:AGENT_BACKUP_[A-Z0-9_]+|DATABASE_URL|SECRETS_MASTER_KEY)\b/g,
+  );
+  return Object.freeze([...new Set(matches ?? [])].sort().slice(0, 32));
+}
+
+function summaryMetrics(summary: Readonly<AgentBackupCatalogRuntimeSummary>) {
+  return {
+    scheduleClaimed: summary.scheduleClaimed,
+    scheduleReserved: summary.scheduleReserved,
+    scheduleOverdue: summary.scheduleOverdue,
+    operationClaimed: summary.operationClaimed,
+    operationCaptured: summary.operationCaptured,
+    operationProtected: summary.operationProtected,
+    operationRetryScheduled:
+      summary.operationCaptureRetryScheduled +
+      summary.operationPublicationRetryScheduled,
+    gcClaimed: summary.gcClaimed,
+    gcCompleted: summary.gcCompleted,
+    spoolCleanupPending: summary.spoolCleanup.pending,
+    alertCodes: summary.alertCodes,
+  };
+}
+
+function waitForShutdownBound<T>(params: {
+  pending: Promise<T>;
+  signal: AbortSignal;
+  timeoutMs: number;
+}): Promise<{ kind: "settled"; value: T } | { kind: "shutdown-timeout" }> {
+  if (!params.signal.aborted) {
+    return new Promise((resolve, reject) => {
+      let shutdownTimer: ReturnType<typeof setTimeout> | undefined;
+      const onAbort = () => {
+        shutdownTimer = setTimeout(
+          () => resolve({ kind: "shutdown-timeout" }),
+          params.timeoutMs,
+        );
+      };
+      params.signal.addEventListener("abort", onAbort, { once: true });
+      params.pending.then(
+        (value) => {
+          if (shutdownTimer) clearTimeout(shutdownTimer);
+          params.signal.removeEventListener("abort", onAbort);
+          resolve({ kind: "settled", value });
+        },
+        (error: unknown) => {
+          if (shutdownTimer) clearTimeout(shutdownTimer);
+          params.signal.removeEventListener("abort", onAbort);
+          reject(error);
+        },
+      );
+    });
+  }
+  return Promise.race([
+    params.pending.then((value) => ({ kind: "settled" as const, value })),
+    new Promise<{ kind: "shutdown-timeout" }>((resolve) =>
+      setTimeout(() => resolve({ kind: "shutdown-timeout" }), params.timeoutMs),
+    ),
+  ]);
+}
+
+const EMPTY_ALERTS: readonly string[] = Object.freeze([]);
+
+/** Run until cancellation or one deterministic `--once` cycle. */
+export async function runBackupCatalogWorker(input: {
+  env?: NodeJS.ProcessEnv;
+  argv?: readonly string[];
+  signal: AbortSignal;
+  dependencies: BackupCatalogWorkerDependencies;
+}): Promise<BackupCatalogWorkerRunResult> {
+  const env = input.env ?? process.env;
+  const argv = input.argv ?? process.argv.slice(2);
+  const startedAtMs = input.dependencies.now();
+  let config: BackupCatalogWorkerConfig = {
+    runOnce: argv.includes("--once"),
+    intervalMs: DEFAULT_INTERVAL_MS,
+    retryMs: DEFAULT_RETRY_MS,
+    shutdownTimeoutMs: DEFAULT_SHUTDOWN_TIMEOUT_MS,
+    healthFile: DEFAULT_HEALTH_FILE,
+  };
+  let composition: AgentBackupCatalogWorkerComposition;
+  let cycles = 0;
+  let failures = 0;
+  let lastCycleStartedAt: string | null = null;
+  let lastCycleCompletedAt: string | null = null;
+  let lastDurationMs: number | null = null;
+  let lastAlertCodes = EMPTY_ALERTS;
+  const health = async (
+    state: BackupCatalogWorkerState,
+    enabled: boolean,
+  ): Promise<void> => {
+    const now = input.dependencies.now();
+    await input.dependencies.writeHealth(config.healthFile, {
+      format: "elizaos.agent-backup.catalog-worker-health.v1",
+      state,
+      enabled,
+      pid: process.pid,
+      updatedAt: new Date(now).toISOString(),
+      startedAt: new Date(startedAtMs).toISOString(),
+      cycles,
+      failures,
+      lastCycleStartedAt,
+      lastCycleCompletedAt,
+      lastDurationMs,
+      lastAlertCodes,
+    });
+  };
+
+  const configurationFailure = async (
+    error: unknown,
+  ): Promise<BackupCatalogWorkerRunResult> => {
+    failures = 1;
+    await health("terminal-configuration-failure", false);
+    input.dependencies.logger.error(
+      "[backup-catalog-worker] configuration rejected",
+      {
+        code: "AGENT_BACKUP_CATALOG_CONFIGURATION_INVALID",
+        configurationNames: safeBackupCatalogConfigurationNames(error),
+      },
+    );
+    return {
+      state: "terminal-configuration-failure",
+      exitCode: CONFIG_ERROR_EXIT_CODE,
+      cycles,
+      failures,
+    };
+  };
+
+  try {
+    config = readBackupCatalogWorkerConfig(env, argv);
+  } catch (error) {
+    return configurationFailure(error);
+  }
+  try {
+    composition = await input.dependencies.createComposition({ env });
+  } catch (error) {
+    return configurationFailure(error);
+  }
+
+  input.dependencies.logger.info("[backup-catalog-worker] started", {
+    enabled: composition.enabled,
+    runOnce: config.runOnce,
+    intervalMs: config.intervalMs,
+  });
+
+  if (!composition.enabled) {
+    await health("disabled", false);
+    if (config.runOnce)
+      return { state: "disabled", exitCode: 0, cycles, failures };
+    while (!input.signal.aborted) {
+      await input.dependencies.sleep(config.intervalMs, input.signal);
+      if (!input.signal.aborted) await health("disabled", false);
+    }
+    await health("bounded-shutdown", false);
+    return { state: "bounded-shutdown", exitCode: 0, cycles, failures };
+  }
+
+  await health("idle", true);
+  while (!input.signal.aborted) {
+    const cycleStartedMs = input.dependencies.now();
+    lastCycleStartedAt = new Date(cycleStartedMs).toISOString();
+    await health("running", true);
+    try {
+      // Normalize a synchronous composition failure into the same retry path as
+      // an asynchronous provider/database failure.
+      const pending = Promise.resolve().then(() =>
+        composition.runCycle(input.signal),
+      );
+      // Observe any late rejection after a bounded shutdown return.
+      void pending.catch(() => undefined);
+      const settled = await waitForShutdownBound({
+        pending,
+        signal: input.signal,
+        timeoutMs: config.shutdownTimeoutMs,
+      });
+      if (settled.kind === "shutdown-timeout") {
+        failures += 1;
+        await health("bounded-shutdown", true);
+        input.dependencies.logger.warn(
+          "[backup-catalog-worker] shutdown deadline reached",
+          {
+            shutdownTimeoutMs: config.shutdownTimeoutMs,
+          },
+        );
+        return { state: "bounded-shutdown", exitCode: 0, cycles, failures };
+      }
+      cycles += 1;
+      const completedAtMs = input.dependencies.now();
+      lastCycleCompletedAt = new Date(completedAtMs).toISOString();
+      lastDurationMs = Math.max(0, completedAtMs - cycleStartedMs);
+      lastAlertCodes = Object.freeze([...settled.value.alertCodes]);
+      await health(input.signal.aborted ? "bounded-shutdown" : "idle", true);
+      input.dependencies.logger.info("[backup-catalog-worker] cycle complete", {
+        cycle: cycles,
+        durationMs: lastDurationMs,
+        ...summaryMetrics(settled.value),
+      });
+    } catch (error) {
+      if (input.signal.aborted) {
+        await health("bounded-shutdown", true);
+        return { state: "bounded-shutdown", exitCode: 0, cycles, failures };
+      }
+      failures += 1;
+      lastDurationMs = Math.max(0, input.dependencies.now() - cycleStartedMs);
+      lastAlertCodes = Object.freeze([safeErrorCode(error)]);
+      await health("retryable-failure", true);
+      input.dependencies.logger.warn(
+        "[backup-catalog-worker] cycle will retry",
+        {
+          code: safeErrorCode(error),
+          failures,
+        },
+      );
+      if (config.runOnce) {
+        return { state: "retryable-failure", exitCode: 1, cycles, failures };
+      }
+      await input.dependencies.sleep(config.retryMs, input.signal);
+      continue;
+    }
+    if (config.runOnce) return { state: "idle", exitCode: 0, cycles, failures };
+    const elapsed = Math.max(0, input.dependencies.now() - cycleStartedMs);
+    await input.dependencies.sleep(
+      Math.max(0, config.intervalMs - elapsed),
+      input.signal,
+    );
+  }
+  await health("bounded-shutdown", true);
+  return { state: "bounded-shutdown", exitCode: 0, cycles, failures };
+}
+
+async function main(): Promise<number> {
+  loadLocalEnv(import.meta.url);
+  const controller = new AbortController();
+  const stop = (signal: string) => {
+    if (!controller.signal.aborted)
+      controller.abort(new Error(`Received ${signal}`));
+  };
+  const onSigint = () => stop("SIGINT");
+  const onSigterm = () => stop("SIGTERM");
+  process.once("SIGINT", onSigint);
+  process.once("SIGTERM", onSigterm);
+  try {
+    const { logger } = await import("@elizaos/cloud-shared/lib/utils/logger");
+    const result = await runBackupCatalogWorker({
+      signal: controller.signal,
+      dependencies: {
+        createComposition: createAgentBackupCatalogWorkerComposition,
+        writeHealth: writeBackupCatalogWorkerHealth,
+        sleep: sleepAbortable,
+        now: Date.now,
+        logger,
+      },
+    });
+    return result.exitCode;
+  } finally {
+    process.removeListener("SIGINT", onSigint);
+    process.removeListener("SIGTERM", onSigterm);
+  }
+}
+
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  return entry ? path.resolve(entry) === fileURLToPath(import.meta.url) : false;
+}
+
+if (isMainModule()) {
+  main().then(
+    (exitCode) => {
+      // The enabled dependency graph may retain provider/database handles even
+      // after a bounded cycle or shutdown. The daemon has already flushed its
+      // health state, so terminate explicitly and let systemd own restarts.
+      process.exit(exitCode);
+    },
+    (error) => {
+      process.stderr.write(
+        `[backup-catalog-worker] fatal: ${error instanceof Error ? error.message : String(error)}\n`,
+      );
+      process.exit(1);
+    },
+  );
+}

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker-env-reconcile.test.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker-env-reconcile.test.ts
@@ -1,18 +1,18 @@
-// Exercises cloud admin daemons provisioning worker env reconcile.test automation behavior with deterministic script fixtures.
+/** Executes the workflow's atomic EnvironmentFile plan and guards its secret boundary. */
 import { describe, expect, it } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { resolveGnuSed } from "../../../../scripts/lib/gnu-shell.mjs";
-
-// Regression guard for #8756 (operator-step bug): the provisioning-worker
-// deploy workflow must reconcile control-plane secrets into the systemd
-// EnvironmentFile (/opt/eliza/cloud/.env.local). The daemon's consumers read
-// them straight from process.env fed by that file; if the workflow doesn't
-// write them, provisioned sandboxes lose routing secrets or cannot decrypt
-// Worker-written encrypted environment variables.
+import { lookupSystemdEnvironmentValue } from "../systemd-environment-line.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "../../../../..");
@@ -20,248 +20,618 @@ const workflowPath = path.join(
   repoRoot,
   ".github/workflows/deploy-eliza-provisioning-worker.yml",
 );
+const serializerPath = path.join(
+  repoRoot,
+  "packages/cloud/scripts/admin/systemd-environment-line.mjs",
+);
+const servicePath = path.join(
+  repoRoot,
+  "packages/cloud/scripts/admin/eliza-backup-catalog-worker.service",
+);
 const workflow = readFileSync(workflowPath, "utf8");
+const service = readFileSync(servicePath, "utf8");
 
 const ENV_KEY = "SANDBOX_REGISTRY_REDIS_URL";
 const FIELD_ENCRYPTION_KEY = "SECRETS_MASTER_KEY";
 const BRIDGE_FALLBACK_KEY = "AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK";
 const AGENT_BASE_DOMAIN_KEY = "ELIZA_CLOUD_AGENT_BASE_DOMAIN";
 const CONTAINERS_SSH_KEY = "CONTAINERS_SSH_KEY";
+const DORMANT_BACKUP_SECRET_NAMES = [
+  "AGENT_BACKUP_R2_ACCESS_KEY_ID",
+  "AGENT_BACKUP_R2_SECRET_ACCESS_KEY",
+  "AGENT_BACKUP_HETZNER_ACCESS_KEY_ID",
+  "AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY",
+  "AGENT_BACKUP_STEWARD_KMS_TOKEN",
+] as const;
 
-// The reconcile loop runs the workflow's VERBATIM bash, which uses GNU
-// `sed -i "/^KEY=/d"` (no backup-suffix argument). BSD/macOS `sed -i` parses
-// that as a suffix and fails, so the executed cases only run where a
-// GNU-compatible sed exists. CI (Linux) has GNU sed natively; a macOS dev with
-// `brew install gnu-sed` gets coverage via the `gsed` shim injected in
-// runReconcile; otherwise the executed cases skip (the static wiring assertions
-// above still run on every platform).
-const GNU_SED = resolveGnuSed();
+function workflowEnvs(): string[] {
+  const envsLine = workflow
+    .split("\n")
+    .find(
+      (line) => line.trim().startsWith("envs:") && line.includes("DEPLOY_SHA"),
+    );
+  expect(envsLine).toBeDefined();
+  return (envsLine ?? "")
+    .slice((envsLine ?? "").indexOf("envs:") + "envs:".length)
+    .split(",")
+    .map((name) => name.trim());
+}
 
-describe("deploy-eliza-provisioning-worker.yml SANDBOX_REGISTRY_REDIS_URL wiring", () => {
-  it("sources the key from the GitHub secret into the deploy job env", () => {
+function extractAtomicReconcileBlock(): string {
+  const beginMarker =
+    "            # TEST-ANCHOR: atomic-environment-reconcile-begin";
+  const endMarker =
+    "            # TEST-ANCHOR: atomic-environment-reconcile-end";
+  const begin = workflow.indexOf(beginMarker);
+  const end = workflow.indexOf(endMarker);
+  expect(begin).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(begin);
+  const block = workflow.slice(begin + beginMarker.length, end);
+  const deindented = block
+    .split("\n")
+    .map((line) => (line.startsWith("            ") ? line.slice(12) : line))
+    .join("\n")
+    .trim();
+  expect(deindented).toContain("run_environment_helper");
+  expect(deindented).toContain("/usr/bin/env -i");
+  expect(deindented).toContain('$ENV_SERIALIZER" install');
+  expect(deindented).toContain('$ENV_SERIALIZER" reconcile');
+  expect(deindented).toContain(ENV_KEY);
+  expect(deindented).toContain(BRIDGE_FALLBACK_KEY);
+  return deindented;
+}
+
+const atomicReconcileBlock = extractAtomicReconcileBlock();
+
+function extractRootArtifactInstaller(): string {
+  const beginMarker =
+    "            # TEST-ANCHOR: root-artifact-installer-begin";
+  const endMarker = "            # TEST-ANCHOR: root-artifact-installer-end";
+  const begin = workflow.indexOf(beginMarker);
+  const end = workflow.indexOf(endMarker);
+  expect(begin).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(begin);
+  return workflow
+    .slice(begin + beginMarker.length, end)
+    .split("\n")
+    .map((line) => (line.startsWith("            ") ? line.slice(12) : line))
+    .join("\n")
+    .trim();
+}
+
+const rootArtifactInstaller = extractRootArtifactInstaller();
+const loopEnvironmentNames = Array.from(
+  new Set(
+    Array.from(
+      atomicReconcileBlock.matchAll(/"([A-Z0-9_]+)=\$([A-Z0-9_]+)"/g),
+      (match) => {
+        expect(match[1]).toBe(match[2]);
+        return match[1] ?? "";
+      },
+    ),
+  ),
+).filter(Boolean);
+
+function shellLiteral(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function sha256(contents: Buffer): string {
+  return createHash("sha256").update(contents).digest("hex");
+}
+
+function installPinnedHelperWithSourceRace() {
+  const directory = mkdtempSync(path.join(tmpdir(), "root-helper-install-"));
+  const sourcePath = path.join(directory, "deploy-writable-helper.mjs");
+  const mutationPath = path.join(directory, "mutated-helper.mjs");
+  const destinationPath = path.join(
+    directory,
+    "root-owned",
+    "systemd-environment-line.mjs",
+  );
+  const originalBytes = readFileSync(serializerPath);
+  writeFileSync(sourcePath, originalBytes);
+  writeFileSync(
+    mutationPath,
+    'process.stdout.write("MUTATED_SOURCE_EXECUTED");\n',
+  );
+  const sha256Binary = existsSync("/usr/bin/sha256sum")
+    ? "/usr/bin/sha256sum"
+    : "/sbin/sha256sum";
+  expect(existsSync(sha256Binary)).toBe(true);
+  const installer = rootArtifactInstaller.replaceAll(
+    "/usr/bin/sha256sum",
+    sha256Binary,
+  );
+  const script = [
+    "set -euo pipefail",
+    `TEST_SHA256_BIN=${shellLiteral(sha256Binary)}`,
+    `TEST_SOURCE_PATH=${shellLiteral(sourcePath)}`,
+    `TEST_MUTATION_PATH=${shellLiteral(mutationPath)}`,
+    "TEST_FILE_MODE=555",
+    "sudo() {",
+    '  local command="$1"',
+    "  shift",
+    '  case "$command" in',
+    "    /usr/bin/install)",
+    `      if [ "\${1:-}" = "-d" ]; then`,
+    `        local directory="\${!#}"`,
+    '        /bin/mkdir -p -- "$directory"',
+    '        /bin/chmod 0755 "$directory"',
+    "        return",
+    "      fi",
+    '      local mode=""',
+    '      local source=""',
+    '      local destination=""',
+    '      while [ "$#" -gt 0 ]; do',
+    '        case "$1" in',
+    "          -o|-g) shift 2 ;;",
+    '          -m) mode="$2"; shift 2 ;;',
+    '          --) shift; source="$1"; destination="$2"; break ;;',
+    "          *) shift ;;",
+    "        esac",
+    "      done",
+    '      /bin/cp -- "$source" "$destination"',
+    '      /bin/chmod "$mode" "$destination"',
+    `      TEST_FILE_MODE="\${mode#0}"`,
+    '      if [ "$source" = "$TEST_SOURCE_PATH" ]; then',
+    '        /bin/cp -- "$TEST_MUTATION_PATH" "$source"',
+    "      fi",
+    "      ;;",
+    "    /usr/bin/stat)",
+    `      local target="\${!#}"`,
+    '      if [ -d "$target" ]; then',
+    "        printf '%s\\n' root:root:755",
+    "      else",
+    "        printf 'root:root:%s\\n' \"$TEST_FILE_MODE\"",
+    "      fi",
+    "      ;;",
+    "    /usr/bin/mv)",
+    "      shift 2",
+    '      /bin/mv -f -- "$1" "$2"',
+    "      ;;",
+    "    /usr/bin/rm)",
+    '      /bin/rm "$@"',
+    "      ;;",
+    '    "$TEST_SHA256_BIN")',
+    '      "$TEST_SHA256_BIN" "$@"',
+    "      ;;",
+    "    *)",
+    '      printf "unexpected sudo command: %s\\n" "$command" >&2',
+    "      return 1",
+    "      ;;",
+    "  esac",
+    "}",
+    "DEPLOY_SHA=0123456789abcdef0123456789abcdef01234567",
+    installer,
+    `install_root_verified_file ${shellLiteral(sourcePath)} ${shellLiteral(destinationPath)} ${shellLiteral(sha256(originalBytes))} 0555`,
+  ].join("\n");
+
+  try {
+    execFileSync("/bin/bash", ["-c", script], {
+      cwd: repoRoot,
+      env: {
+        PATH: "/usr/bin:/bin:/sbin",
+        TMPDIR: directory,
+      },
+      stdio: "pipe",
+      timeout: 20_000,
+    });
+    const execution = execFileSync(
+      process.execPath,
+      [destinationPath, "serialize", "PINNED_VALUE"],
+      {
+        cwd: repoRoot,
+        env: { PATH: "/usr/bin:/bin:/sbin" },
+        input: "stable",
+        timeout: 20_000,
+      },
+    ).toString();
+    return {
+      destinationBytes: readFileSync(destinationPath),
+      execution,
+      sourceBytes: readFileSync(sourcePath),
+    };
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function runAtomicReconcile(options: {
+  backupUnitLoadState?: "loaded" | "not-found";
+  values?: Readonly<Record<string, string | undefined>>;
+  seedBackupFile?: string;
+  seedHostFile?: string;
+}) {
+  const directory = mkdtempSync(path.join(tmpdir(), "provisioning-env-plan-"));
+  const hostFile = path.join(directory, "cloud.env.local");
+  const backupFile = path.join(directory, "backup-catalog-worker.env");
+  const eventFile = path.join(directory, "events");
+  writeFileSync(hostFile, options.seedHostFile ?? "");
+  writeFileSync(eventFile, "");
+  if (options.seedBackupFile !== undefined) {
+    writeFileSync(backupFile, options.seedBackupFile);
+  }
+  const values = options.values ?? {};
+  const assignments = loopEnvironmentNames.map(
+    (name) => `${name}=${shellLiteral(values[name] ?? "")}`,
+  );
+  const script = [
+    "set -euo pipefail",
+    "sudo() {",
+    `  if [ "\${1:-}" = "install" ] && [ "\${2:-}" = "-d" ]; then`,
+    `    mkdir -p "\${!#}"`,
+    "    return",
+    "  fi",
+    `  if [ "\${1:-}" = "stat" ]; then`,
+    "    printf '%s\\n' root:root:600",
+    "    return",
+    "  fi",
+    `  if [ "\${1:-}" = "flock" ]; then`,
+    `    if [ "\${4:-}" = "$BACKUP_ENV_FILE.lock" ]; then printf '%s\\n' backup-safe-off >> "$SYSTEMCTL_TEST_LOG"; fi`,
+    `    if [ "\${4:-}" = "$ENV_FILE.lock" ]; then printf '%s\\n' shared-reconcile >> "$SYSTEMCTL_TEST_LOG"; fi`,
+    "    shift",
+    `    if [ "\${1:-}" = "-w" ]; then shift 2; fi`,
+    "    shift",
+    '    "$@"',
+    "    return",
+    "  fi",
+    `  if [ "\${1:-}" = "systemctl" ]; then`,
+    `    case "\${2:-}" in`,
+    `      show)`,
+    `        case "$*" in`,
+    `          *--property=LoadState*) printf '%s\\n' backup-load-check >> "$SYSTEMCTL_TEST_LOG"; printf '%s\\n' "$SYSTEMCTL_TEST_LOAD_STATE" ;;`,
+    `          *--property=ActiveState*) printf '%s\\n' backup-active-check >> "$SYSTEMCTL_TEST_LOG"; printf '%s\\n' inactive ;;`,
+    `          *--property=MainPID*) printf '%s\\n' backup-pid-check >> "$SYSTEMCTL_TEST_LOG"; printf '%s\\n' 0 ;;`,
+    `        esac`,
+    `        return`,
+    `        ;;`,
+    `      disable)`,
+    `        if [ "\${3:-}" = "--now" ]; then printf '%s\\n' backup-disable-now >> "$SYSTEMCTL_TEST_LOG"; fi`,
+    `        return`,
+    `        ;;`,
+    `      is-enabled)`,
+    `        printf '%s\\n' backup-enabled-check >> "$SYSTEMCTL_TEST_LOG"`,
+    `        printf '%s\\n' disabled`,
+    `        return 1`,
+    `        ;;`,
+    `      stop) printf '%s\\n' backup-stop >> "$SYSTEMCTL_TEST_LOG"; return ;;`,
+    `      kill) printf '%s\\n' backup-kill >> "$SYSTEMCTL_TEST_LOG"; return ;;`,
+    `    esac`,
+    "  fi",
+    '  "$@"',
+    "}",
+    `ENV_FILE=${shellLiteral(hostFile)}`,
+    `BACKUP_ENV_FILE=${shellLiteral(backupFile)}`,
+    `BACKUP_SYSTEMD_UNIT=${shellLiteral("eliza-backup-catalog-worker.service")}`,
+    `ENV_SERIALIZER=${shellLiteral(serializerPath)}`,
+    `NODE_BIN=${shellLiteral(process.execPath)}`,
+    `SAFE_CHILD_PATH=${shellLiteral(process.env.PATH ?? "/usr/bin:/bin")}`,
+    `SYSTEMCTL_TEST_LOG=${shellLiteral(eventFile)}`,
+    `SYSTEMCTL_TEST_LOAD_STATE=${shellLiteral(options.backupUnitLoadState ?? "loaded")}`,
+    ...assignments,
+    atomicReconcileBlock,
+  ].join("\n");
+  try {
+    execFileSync("bash", ["-c", script], {
+      cwd: repoRoot,
+      env: {
+        PATH: process.env.PATH ?? "/usr/bin:/bin",
+        TMPDIR: directory,
+        POISON_PARENT_SECRET: "AKIA_DO_NOT_INHERIT_IN_HELPERS",
+      },
+      stdio: "pipe",
+      timeout: 20_000,
+    });
+    return {
+      host: readFileSync(hostFile, "utf8"),
+      backup: readFileSync(backupFile, "utf8"),
+      events: readFileSync(eventFile, "utf8").split("\n").filter(Boolean),
+    };
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+describe("provisioning deployment EnvironmentFile wiring", () => {
+  it("sources, forwards, and plans every protected shared setting", () => {
     expect(workflow).toContain(`${ENV_KEY}: \${{ secrets.${ENV_KEY} }}`);
-  });
-
-  it("forwards the key to the remote deploy script via the ssh-action envs allowlist", () => {
-    // appleboy/ssh-action only exports env vars named in `envs:`. If the key
-    // isn't there, $SANDBOX_REGISTRY_REDIS_URL is empty inside the remote
-    // script and the reconcile loop below silently skips it.
-    const envsLine = workflow
-      .split("\n")
-      .find(
-        (line) => line.trim().startsWith("envs:") && line.includes(ENV_KEY),
-      );
-    expect(envsLine).toBeDefined();
-    const line = envsLine ?? "";
-    const forwarded = line
-      .slice(line.indexOf("envs:") + "envs:".length)
-      .split(",")
-      .map((name) => name.trim());
-    expect(forwarded).toContain(ENV_KEY);
-  });
-
-  it("includes the key in the .env.local reconcile loop targeting /opt/eliza/cloud/.env.local", () => {
-    expect(workflow).toContain("ENV_FILE=/opt/eliza/cloud/.env.local");
-    // The loop body iterates "KEY=$VALUE" entries; the entry for our key must
-    // be present so the sed-delete + tee-append rewrites it into the file.
-    expect(workflow).toContain(`"${ENV_KEY}=$${ENV_KEY}"`);
-  });
-
-  it("keeps the field-encryption root key in the same source/forward/reconcile path", () => {
     expect(workflow).toContain(
       `${FIELD_ENCRYPTION_KEY}: \${{ secrets.${FIELD_ENCRYPTION_KEY} }}`,
     );
-    const envsLine = workflow
-      .split("\n")
-      .find(
-        (line) =>
-          line.trim().startsWith("envs:") &&
-          line.includes(FIELD_ENCRYPTION_KEY),
-      );
-    expect(envsLine).toBeDefined();
-    expect(workflow).toContain(
-      `"${FIELD_ENCRYPTION_KEY}=$${FIELD_ENCRYPTION_KEY}"`,
-    );
-  });
-
-  it("reconciles the protected agent-node SSH key into the daemon environment", () => {
     expect(workflow).toContain(
       `${CONTAINERS_SSH_KEY}: \${{ secrets.${CONTAINERS_SSH_KEY} }}`,
     );
-    const envsLine = workflow
-      .split("\n")
-      .find(
-        (line) =>
-          line.trim().startsWith("envs:") && line.includes(CONTAINERS_SSH_KEY),
-      );
-    expect(envsLine).toBeDefined();
+    const forwarded = workflowEnvs();
+    for (const name of [ENV_KEY, FIELD_ENCRYPTION_KEY, CONTAINERS_SSH_KEY]) {
+      expect(forwarded).toContain(name);
+      expect(workflow).toContain(`"${name}=$${name}"`);
+    }
+  });
+
+  it("uses empty inherited environments and closed root checks", () => {
+    expect(workflow).toContain('/usr/bin/env -i PATH="$SAFE_CHILD_PATH"');
+    expect(workflow).toContain('"$NODE_BIN" "$ENV_SERIALIZER" "$@"');
     expect(workflow).toContain(
-      `"${CONTAINERS_SSH_KEY}=$${CONTAINERS_SSH_KEY}"`,
+      '"$NODE_BIN" "$ENV_SERIALIZER" nonempty "$file" "$@"',
+    );
+    expect(workflow).toContain(
+      '"$NODE_BIN" "$ENV_SERIALIZER" equals "$file" "$key"',
+    );
+    expect(workflow).not.toContain("lookup_environment_setting");
+    expect(workflow).not.toContain('sudo cat "$ENV_FILE"');
+    expect(workflow).toContain("AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=0");
+    expect(workflow).toContain('DATABASE_URL="$DATABASE_URL"');
+    expect(workflow).toContain(
+      'DATABASE_SSL_NO_VERIFY="$DATABASE_SSL_NO_VERIFY"',
     );
   });
 
-  it("scrubs the deprecated bridge-host fallback flag during env reconciliation", () => {
+  it("pins privileged helper execution to an exact-SHA root-owned copy", () => {
     expect(workflow).toContain(
-      `sed -i "/^${BRIDGE_FALLBACK_KEY}=/d" "$ENV_FILE"`,
+      "sha256sum \\\n            packages/cloud/scripts/admin/systemd-environment-line.mjs",
     );
-    const lanePinIdx = workflow.indexOf('sed -i "/^PROVISIONING_JOB_LANES=/d"');
-    const scrubIdx = workflow.indexOf(`${BRIDGE_FALLBACK_KEY}=/d`);
-    const secretLoopIdx = workflow.indexOf("for kv in \\");
-    expect(lanePinIdx).toBeGreaterThan(-1);
-    expect(scrubIdx).toBeGreaterThan(-1);
-    expect(secretLoopIdx).toBeGreaterThan(-1);
-    expect(lanePinIdx).toBeLessThan(scrubIdx);
-    expect(scrubIdx).toBeLessThan(secretLoopIdx);
+    expect(workflow).toContain(
+      "SYSTEMD_ENVIRONMENT_HELPER_SHA256=$helper_sha256",
+    );
+    expect(workflow).toContain(
+      "ENV_SERIALIZER=/usr/local/lib/eliza-admin/systemd-environment-line.mjs",
+    );
+    expect(workflow).not.toMatch(
+      /^\s*ENV_SERIALIZER=\/opt\/eliza\/.*systemd-environment-line\.mjs$/m,
+    );
+    expect(workflow).not.toContain("NODE_BIN=$(command -v node)");
+    expect(workflow).toContain("NODE_BIN=/usr/bin/node");
+    expect(rootArtifactInstaller).toContain(
+      "sudo /usr/bin/install -d -o root -g root -m 0755",
+    );
+    expect(rootArtifactInstaller).toContain(
+      'sudo /usr/bin/mv -fT -- "$candidate_path" "$destination_path"',
+    );
+    expect(rootArtifactInstaller).toContain('"root:root:$expected_stat_mode"');
+    const helperInstall = workflow.indexOf(
+      '"$ENV_SERIALIZER_SOURCE" \\',
+      workflow.indexOf("# TEST-ANCHOR: root-artifact-installer-end"),
+    );
+    const firstProtectedPlan = workflow.indexOf("            for kv in \\");
+    expect(helperInstall).toBeGreaterThan(-1);
+    expect(firstProtectedPlan).toBeGreaterThan(helperInstall);
+
+    const installed = installPinnedHelperWithSourceRace();
+    expect(installed.sourceBytes.toString()).toContain(
+      "MUTATED_SOURCE_EXECUTED",
+    );
+    expect(installed.destinationBytes).toEqual(readFileSync(serializerPath));
+    expect(installed.execution).not.toContain("MUTATED_SOURCE_EXECUTED");
+    expect(
+      lookupSystemdEnvironmentValue(installed.execution, "PINNED_VALUE"),
+    ).toBe("stable");
   });
 
-  it("pins the agent router to the protected deployment environment", () => {
+  it("installs and validates the backup unit only from its root-owned exact-SHA destination", () => {
+    expect(workflow).toContain(
+      "sha256sum \\\n            packages/cloud/scripts/admin/eliza-backup-catalog-worker.service",
+    );
+    expect(workflow).toContain(
+      "BACKUP_SYSTEMD_UNIT_SHA256=$backup_unit_sha256",
+    );
+    expect(workflow).toContain(
+      'BACKUP_UNIT_DESTINATION="/etc/systemd/system/$BACKUP_SYSTEMD_UNIT"',
+    );
+    expect(workflow).toContain(
+      'systemd-analyze verify "$BACKUP_UNIT_DESTINATION"',
+    );
+    expect(workflow).not.toContain(
+      "systemd-analyze verify \\\n              packages/cloud/scripts/admin/eliza-backup-catalog-worker.service",
+    );
+    expect(workflow).toContain("--property=DynamicUser --value");
+    expect(workflow).toContain("--property=User --value");
+    expect(workflow).toContain("--property=Group --value");
+    expect(workflow).toContain("--property=ExecStart --value");
+    expect(workflow).toContain("--property=FragmentPath --value");
+    expect(workflow).toContain("--property=DropInPaths --value");
+    expect(workflow).toContain(
+      `BACKUP_EXPECTED_DYNAMIC_USER="\${BACKUP_SYSTEMD_UNIT%.service}"`,
+    );
+    expect(workflow).toContain(
+      '[ "$BACKUP_EFFECTIVE_USER" != "$BACKUP_EXPECTED_DYNAMIC_USER" ]',
+    );
+    expect(workflow).toContain(
+      '[ "$BACKUP_EFFECTIVE_FRAGMENT" != "$BACKUP_UNIT_DESTINATION" ]',
+    );
+    expect(workflow).toContain('[ -n "$BACKUP_EFFECTIVE_DROP_INS" ]');
+  });
+
+  it("keeps activation inputs complete without reading host secrets into the shell", () => {
+    const forwarded = workflowEnvs();
+    const activationPlan = workflow.slice(
+      workflow.indexOf('if [ "$BACKUP_CATALOG_RUNTIME_GATE" = "1" ]; then'),
+      workflow.indexOf(
+        "# An EnvironmentFile replacement cannot revoke authority",
+      ),
+    );
+    const schedulerRuntimeNames = [
+      "DATABASE_SSL_NO_VERIFY",
+      "AGENT_BACKUP_SCHEDULE_BATCH_SIZE",
+      "AGENT_BACKUP_SCHEDULE_LEASE_MS",
+      "AGENT_BACKUP_SCHEDULE_RETRY_MS",
+      "AGENT_BACKUP_OPERATION_BATCH_SIZE",
+      "AGENT_BACKUP_OPERATION_LEASE_MS",
+      "AGENT_BACKUP_OPERATION_RETRY_BASE_MS",
+      "AGENT_BACKUP_OPERATION_RETRY_MAX_MS",
+      "AGENT_BACKUP_GC_BATCH_SIZE",
+      "AGENT_BACKUP_GC_LEASE_MS",
+      "AGENT_BACKUP_GC_RETRY_BASE_MS",
+      "AGENT_BACKUP_GC_RETRY_MAX_MS",
+      "AGENT_BACKUP_DELETION_BATCH_SIZE",
+    ];
+    for (const name of schedulerRuntimeNames) {
+      expect(forwarded).toContain(name);
+      expect(workflow).toContain(`${name}: \${{ vars.${name} }}`);
+      expect(activationPlan).toContain(`                ${name}`);
+    }
+    for (const name of DORMANT_BACKUP_SECRET_NAMES) {
+      expect(forwarded).not.toContain(name);
+    }
+    expect(workflow).toContain(
+      "Backup catalogue activation input is missing required protected setting name",
+    );
+  });
+
+  it("forces safe-off before shared reconciliation and installs units last", () => {
+    const safeOff = workflow.indexOf('"$NODE_BIN" "$ENV_SERIALIZER" install');
+    const shared = workflow.indexOf('"$NODE_BIN" "$ENV_SERIALIZER" reconcile');
+    const unitInstall = workflow.indexOf(
+      "# Install units only after both EnvironmentFiles",
+    );
+    const reenable = workflow.indexOf(
+      'sudo systemctl enable "$SYSTEMD_UNIT" eliza-agent-router.service "$BACKUP_SYSTEMD_UNIT"',
+    );
+    const restart = workflow.indexOf('sudo systemctl restart "$SYSTEMD_UNIT"');
+    expect(safeOff).toBeGreaterThan(-1);
+    const disableOld = workflow.indexOf(
+      'sudo systemctl disable --now "$BACKUP_SYSTEMD_UNIT"',
+    );
+    const inactiveCheck = workflow.indexOf(
+      '[ "$BACKUP_OLD_ACTIVE_STATE" = "inactive" ]',
+    );
+    const pidCheck = workflow.indexOf('[ "$BACKUP_OLD_MAIN_PID" = "0" ]');
+    expect(disableOld).toBeGreaterThan(-1);
+    expect(inactiveCheck).toBeGreaterThan(disableOld);
+    expect(pidCheck).toBeGreaterThan(disableOld);
+    expect(safeOff).toBeGreaterThan(inactiveCheck);
+    expect(safeOff).toBeGreaterThan(pidCheck);
+    expect(shared).toBeGreaterThan(safeOff);
+    expect(unitInstall).toBeGreaterThan(shared);
+    expect(reenable).toBeGreaterThan(unitInstall);
+    expect(restart).toBeGreaterThan(unitInstall);
+  });
+
+  it("requires real host systemd consumption and terminal main-process fencing", () => {
+    expect(workflow).toContain("systemd-analyze verify");
+    expect(workflow).toContain(
+      '--property="EnvironmentFile=$SYSTEMD_PROBE_ENV"',
+    );
+    expect(workflow).toContain(
+      `[ "\${SYSTEMD_ENVIRONMENT_PROBE:-}" = expected-safe-literal ]`,
+    );
+    expect(workflow).toContain("--property=RestartPreventExitStatus=78");
+    expect(workflow).toContain("--property=NRestarts --value");
+    expect(workflow).toContain('[ "$RESTART_PROBE_STATUS" != "78" ]');
+    expect(workflow).toContain('[ "$RESTART_PROBE_COUNT" != "0" ]');
+    expect(service).toContain("RestartPreventExitStatus=78");
+    expect(service).not.toContain("ExecStartPre=");
+    expect(service).toContain("DynamicUser=yes");
+    expect(service).not.toContain("User=deploy");
+    expect(service).not.toContain("Group=deploy");
+    expect(service).toContain("Environment=HOME=/var/lib/eliza-backup-catalog");
+    expect(service).toContain("ReadOnlyPaths=/opt/eliza");
+    expect(service).not.toContain("/home/deploy/.bun/bin");
+    expect(workflow).not.toContain("SAFE_CHILD_PATH=/home/deploy/.bun/bin");
+    expect(workflow).toContain('"$BUN_BIN" --conditions=eliza-source');
+    expect(workflow).not.toMatch(
+      /(?:chown|install -d -o deploy)[^\n]*(?:eliza-backup|BACKUP_)/,
+    );
+  });
+
+  it("pins the router environment without reflecting its value", () => {
     expect(workflow).toContain(
       `${AGENT_BASE_DOMAIN_KEY}: \${{ needs.determine-env.outputs.environment == 'production' && 'cloud.eliza.app' || 'cloud-staging.eliza.app' }}`,
     );
-    const deployEnvs = workflow
-      .split("\n")
-      .find(
-        (line) =>
-          line.trim().startsWith("envs:") && line.includes("DEPLOY_SHA"),
-      );
-    expect(deployEnvs).toContain(AGENT_BASE_DOMAIN_KEY);
+    expect(workflow).toContain('"$ENV_FILE" ELIZA_CLOUD_AGENT_BASE_DOMAIN');
     expect(workflow).toContain(
-      `"${AGENT_BASE_DOMAIN_KEY}=$${AGENT_BASE_DOMAIN_KEY}"`,
-    );
-    expect(workflow).toContain(
-      "Agent router base-domain drift: expected $ELIZA_CLOUD_AGENT_BASE_DOMAIN",
+      "Agent router base-domain drift. Values were not printed.",
     );
   });
 });
 
-// Extract the exact reconcile loop body from the workflow and run it in a
-// scratch dir so the test exercises the real bash, not a re-implementation.
-function extractReconcileLoop(): string {
-  const start = workflow.indexOf('sudo sed -i "/^PROVISIONING_JOB_LANES=/d"');
-  expect(start).toBeGreaterThan(-1);
-  const tail = workflow.slice(start);
-  const doneIdx = tail.indexOf("\n            done");
-  expect(doneIdx).toBeGreaterThan(-1);
-  // Include the "done" line itself.
-  const block = tail.slice(0, doneIdx + "\n            done".length);
-  // De-indent the 12-space YAML script indentation.
-  const loop = block
-    .split("\n")
-    .map((line) => (line.startsWith("            ") ? line.slice(12) : line))
-    .join("\n");
-  // Fail loudly if anchor drift (a renamed loop var, reindented script block, a
-  // reformatted `done`, or a swapped ssh-action) extracted a trivial/empty
-  // block — otherwise the executed cases would silently exercise nothing.
-  expect(loop).toContain("sed -i");
-  expect(loop).toContain("tee -a");
-  expect(loop).toContain(ENV_KEY);
-  expect(loop).toContain(BRIDGE_FALLBACK_KEY);
-  return loop;
-}
+describe("atomic workflow block (executed verbatim)", () => {
+  it("writes a supplied secret canonically and preserves unrelated settings", () => {
+    const value = 'redis://new.example:6379/path?quoted="yes"&slash=\\';
+    const result = runAtomicReconcile({
+      values: { [ENV_KEY]: value },
+      seedHostFile: `${ENV_KEY}=redis://stale.example:6379\nUNRELATED=preserved\n`,
+    });
+    expect(lookupSystemdEnvironmentValue(result.host, ENV_KEY)).toBe(value);
+    expect(result.host.match(new RegExp(`^${ENV_KEY}=`, "gm"))).toHaveLength(1);
+    expect(result.host).toContain("UNRELATED=preserved\n");
+  });
 
-function runReconcile(opts: {
-  redisUrl: string | undefined;
-  seedEnvFile?: string;
-}): string {
-  const loop = extractReconcileLoop();
-  const dir = mkdtempSync(path.join(tmpdir(), "reconcile-"));
-  const envFile = path.join(dir, "env.local");
-  if (opts.seedEnvFile !== undefined) {
-    writeFileSync(envFile, opts.seedEnvFile);
-  } else {
-    writeFileSync(envFile, "");
-  }
-  // The workflow uses `sudo`; replace it with a no-op so the loop runs
-  // unprivileged in the scratch dir, and bind ENV_FILE to the test path.
-  const script = [
-    "set -euo pipefail",
-    'sudo() { "$@"; }',
-    // On a macOS dev box with `brew install gnu-sed`, route the loop's `sed`
-    // through `gsed` so the verbatim GNU `sed -i` invocation behaves. On Linux
-    // (GNU sed is the default) and when skipped this is a no-op.
-    GNU_SED === "gsed" ? 'sed() { gsed "$@"; }' : "",
-    `ENV_FILE='${envFile}'`,
-    // The ssh-action `envs:` allowlist always exports every key the loop reads
-    // (possibly empty); under `set -u` each must be defined or the loop aborts.
-    // Derive them from the loop's own `"KEY=$KEY"` entries and default every key
-    // EXCEPT the one under test to empty (empty == skipped, isolating
-    // SANDBOX_REGISTRY_REDIS_URL behavior) — so a workflow that forwards another
-    // secret (e.g. DATABASE_URL) can't silently abort this test on `set -u`.
-    ...Array.from(
-      new Set(
-        Array.from(
-          loop.matchAll(/"([A-Z0-9_]+)=\$[A-Z0-9_]+"/g),
-          (match) => match[1],
-        ),
+  it("preserves an existing value when GitHub supplies an empty setting", () => {
+    const result = runAtomicReconcile({
+      values: { [ENV_KEY]: "" },
+      seedHostFile: `${ENV_KEY}=redis://hand-set.example:6379\n`,
+    });
+    expect(lookupSystemdEnvironmentValue(result.host, ENV_KEY)).toBe(
+      "redis://hand-set.example:6379",
+    );
+  });
+
+  it("removes bridge fallback, pins the lane, and strips backup authority from the shared file", () => {
+    const result = runAtomicReconcile({
+      seedHostFile:
+        `${BRIDGE_FALLBACK_KEY}=1\nOTHER=keep\n` +
+        "AGENT_BACKUP_R2_SECRET_ACCESS_KEY=must-disappear\n" +
+        "AGENT_BACKUP_OPERATION_LEASE_MS=must-disappear\n",
+      seedBackupFile:
+        "DATABASE_URL=postgres://must-disappear\n" +
+        "AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=1\n",
+    });
+    expect(result.host).not.toContain(BRIDGE_FALLBACK_KEY);
+    expect(
+      lookupSystemdEnvironmentValue(result.host, "PROVISIONING_JOB_LANES"),
+    ).toBe("agent");
+    expect(result.host).toContain("OTHER=keep\n");
+    expect(result.host).not.toContain("AGENT_BACKUP_R2_SECRET_ACCESS_KEY");
+    expect(result.host).not.toContain("AGENT_BACKUP_OPERATION_LEASE_MS");
+    expect(
+      [...result.host.matchAll(/^AGENT_BACKUP_[A-Z0-9_]+=/gm)].map((match) =>
+        match[0].slice(0, -1),
       ),
-    )
-      .filter((name) => name !== ENV_KEY)
-      .map((name) => `${name}=''`),
-    loop,
-  ].join("\n");
-  try {
-    execFileSync("bash", ["-c", script], {
-      cwd: dir,
-      env: {
-        PATH: process.env.PATH ?? "",
-        // The `envs:` allowlist always exports the name; an unset GH secret
-        // surfaces as the empty string in the remote shell, not as undefined.
-        [ENV_KEY]: opts.redisUrl ?? "",
-      },
-    });
-    return readFileSync(envFile, "utf8");
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-}
+    ).toEqual([
+      "AGENT_BACKUP_CATALOG_RUNTIME_ENABLED",
+      "AGENT_BACKUP_RPO_SCHEDULER_ENABLED",
+      "AGENT_BACKUP_SPOOL_STATE_DIRECTORY",
+      "AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE",
+    ]);
+    expect(result.backup).not.toContain("DATABASE_URL");
+    expect(
+      lookupSystemdEnvironmentValue(
+        result.backup,
+        "AGENT_BACKUP_CATALOG_RUNTIME_ENABLED",
+      ),
+    ).toBe("0");
+    expect(
+      lookupSystemdEnvironmentValue(
+        result.backup,
+        "AGENT_BACKUP_RPO_SCHEDULER_ENABLED",
+      ),
+    ).toBe("0");
+    expect(result.backup.split("\n").filter(Boolean)).toHaveLength(7);
+    expect(result.events).toEqual([
+      "backup-load-check",
+      "backup-disable-now",
+      "backup-active-check",
+      "backup-pid-check",
+      "backup-enabled-check",
+      "backup-safe-off",
+      "shared-reconcile",
+    ]);
+  });
 
-// Skip the executed cases when no GNU-compatible sed is reachable (BSD/macOS
-// without gsed); CI runs on Linux with GNU sed and keeps full coverage.
-const executedDescribe = GNU_SED ? describe : describe.skip;
-executedDescribe(
-  "provisioning-worker .env.local reconcile loop (executed)",
-  () => {
-    it("writes SANDBOX_REGISTRY_REDIS_URL into .env.local when the secret is set", () => {
-      const url = "redis://sandbox-registry.example.internal:6379";
-      const out = runReconcile({ redisUrl: url });
-      expect(out).toContain(`${ENV_KEY}=${url}\n`);
-    });
+  it("tolerates a first deployment with no previously installed backup unit", () => {
+    const result = runAtomicReconcile({ backupUnitLoadState: "not-found" });
 
-    it("replaces a stale hand-set value rather than appending a duplicate", () => {
-      const out = runReconcile({
-        redisUrl: "redis://new.example:6379",
-        seedEnvFile: `${ENV_KEY}=redis://stale.example:6379\nOTHER=keep\n`,
-      });
-      const matches = out
-        .split("\n")
-        .filter((line) => line.startsWith(`${ENV_KEY}=`));
-      expect(matches).toEqual([`${ENV_KEY}=redis://new.example:6379`]);
-      // Unrelated keys are preserved.
-      expect(out).toContain("OTHER=keep");
-    });
-
-    it("skips the key (preserving any hand-set value) when the secret is unset", () => {
-      const out = runReconcile({
-        redisUrl: undefined,
-        seedEnvFile: `${ENV_KEY}=redis://hand-set.example:6379\n`,
-      });
-      // An unset GH secret must never blank a working box.
-      expect(out).toContain(`${ENV_KEY}=redis://hand-set.example:6379`);
-    });
-
-    it("skips the key when the secret is the empty string", () => {
-      const out = runReconcile({ redisUrl: "" });
-      expect(out).not.toContain(ENV_KEY);
-    });
-
-    it("removes the deprecated bridge-host fallback flag on every deploy", () => {
-      const out = runReconcile({
-        redisUrl: undefined,
-        seedEnvFile: `${BRIDGE_FALLBACK_KEY}=1\nOTHER=keep\n`,
-      });
-      expect(out).not.toContain(BRIDGE_FALLBACK_KEY);
-      expect(out).toContain("PROVISIONING_JOB_LANES=agent\n");
-      expect(out).toContain("OTHER=keep\n");
-    });
-  },
-);
+    expect(result.events).toEqual([
+      "backup-load-check",
+      "backup-safe-off",
+      "shared-reconcile",
+    ]);
+    expect(
+      lookupSystemdEnvironmentValue(
+        result.backup,
+        "AGENT_BACKUP_CATALOG_RUNTIME_ENABLED",
+      ),
+    ).toBe("0");
+  });
+});

--- a/packages/cloud/scripts/admin/eliza-backup-catalog-worker.service
+++ b/packages/cloud/scripts/admin/eliza-backup-catalog-worker.service
@@ -1,0 +1,44 @@
+[Unit]
+Description=Eliza Manifest-v3 Backup Catalogue Worker (disabled at merge)
+Documentation=https://github.com/elizaOS/eliza
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=deploy
+Group=deploy
+WorkingDirectory=/opt/eliza
+EnvironmentFile=/opt/eliza/cloud/.env.local
+Environment=NODE_OPTIONS=--max-old-space-size=1024
+Environment=PATH=/home/deploy/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/bin
+StateDirectory=eliza-backup-catalog
+StateDirectoryMode=0700
+RuntimeDirectory=eliza-backup-catalog
+RuntimeDirectoryMode=0700
+UMask=0077
+ExecStartPre=/opt/eliza/packages/cloud/scripts/admin/ensure-generated-keywords.sh
+# Both commands pin the dormant gates independently of a stale EnvironmentFile.
+ExecStartPre=/usr/bin/env AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=0 AGENT_BACKUP_RPO_SCHEDULER_ENABLED=0 AGENT_BACKUP_SPOOL_STATE_DIRECTORY=/var/lib/eliza-backup-catalog/spool AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE=/run/eliza-backup-catalog/health.json /opt/eliza/node_modules/.bin/tsx --tsconfig /opt/eliza/packages/cloud/shared/tsconfig.json /opt/eliza/packages/cloud/scripts/admin/daemons/backup-catalog-worker-preflight.ts
+ExecStart=/usr/bin/env AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=0 AGENT_BACKUP_RPO_SCHEDULER_ENABLED=0 AGENT_BACKUP_SPOOL_STATE_DIRECTORY=/var/lib/eliza-backup-catalog/spool AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE=/run/eliza-backup-catalog/health.json /opt/eliza/node_modules/.bin/tsx --tsconfig /opt/eliza/packages/cloud/shared/tsconfig.json /opt/eliza/packages/cloud/scripts/admin/daemons/backup-catalog-worker.ts
+
+Restart=always
+RestartSec=5
+MemoryHigh=1024M
+MemoryMax=1280M
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=eliza-backup-catalog-worker
+
+NoNewPrivileges=yes
+ProtectSystem=strict
+PrivateTmp=true
+ReadWritePaths=/var/lib/eliza-backup-catalog /run/eliza-backup-catalog
+
+# Internal shutdown is bounded at 25s; systemd retains a final 5s fence.
+TimeoutStopSec=30
+KillMode=mixed
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/cloud/scripts/admin/eliza-backup-catalog-worker.service
+++ b/packages/cloud/scripts/admin/eliza-backup-catalog-worker.service
@@ -6,23 +6,29 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=deploy
-Group=deploy
+# Allocate a service-private uid/gid so provisioning and router processes owned
+# by deploy cannot inspect this worker's environment or signal its process.
+DynamicUser=yes
 WorkingDirectory=/opt/eliza
-EnvironmentFile=/opt/eliza/cloud/.env.local
+# Dedicated allowlisted environment. In disabled mode this file contains no
+# database, provider, KMS, SSH, Headscale, registry, or field-encryption secret.
+# PID 1 reads the root-owned file before executing the dynamic service identity.
+EnvironmentFile=/etc/eliza/backup-catalog-worker.env
 Environment=NODE_OPTIONS=--max-old-space-size=1024
-Environment=PATH=/home/deploy/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/bin
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/bin
+Environment=HOME=/var/lib/eliza-backup-catalog
 StateDirectory=eliza-backup-catalog
 StateDirectoryMode=0700
 RuntimeDirectory=eliza-backup-catalog
 RuntimeDirectoryMode=0700
 UMask=0077
-ExecStartPre=/opt/eliza/packages/cloud/scripts/admin/ensure-generated-keywords.sh
-# Both commands pin the dormant gates independently of a stale EnvironmentFile.
-ExecStartPre=/usr/bin/env AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=0 AGENT_BACKUP_RPO_SCHEDULER_ENABLED=0 AGENT_BACKUP_SPOOL_STATE_DIRECTORY=/var/lib/eliza-backup-catalog/spool AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE=/run/eliza-backup-catalog/health.json /opt/eliza/node_modules/.bin/tsx --tsconfig /opt/eliza/packages/cloud/shared/tsconfig.json /opt/eliza/packages/cloud/scripts/admin/daemons/backup-catalog-worker-preflight.ts
-ExecStart=/usr/bin/env AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=0 AGENT_BACKUP_RPO_SCHEDULER_ENABLED=0 AGENT_BACKUP_SPOOL_STATE_DIRECTORY=/var/lib/eliza-backup-catalog/spool AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE=/run/eliza-backup-catalog/health.json /opt/eliza/node_modules/.bin/tsx --tsconfig /opt/eliza/packages/cloud/shared/tsconfig.json /opt/eliza/packages/cloud/scripts/admin/daemons/backup-catalog-worker.ts
+# Deployment writes both gates and every permitted value atomically into the
+# dedicated EnvironmentFile. Keeping values out of ExecStart also keeps them
+# out of the process command line when a staged activation is authorized.
+ExecStart=/opt/eliza/node_modules/.bin/tsx --tsconfig /opt/eliza/packages/cloud/shared/tsconfig.json /opt/eliza/packages/cloud/scripts/admin/daemons/backup-catalog-worker.ts
 
 Restart=always
+RestartPreventExitStatus=78
 RestartSec=5
 MemoryHigh=1024M
 MemoryMax=1280M
@@ -32,7 +38,9 @@ SyslogIdentifier=eliza-backup-catalog-worker
 
 NoNewPrivileges=yes
 ProtectSystem=strict
+ProtectHome=yes
 PrivateTmp=true
+ReadOnlyPaths=/opt/eliza
 ReadWritePaths=/var/lib/eliza-backup-catalog /run/eliza-backup-catalog
 
 # Internal shutdown is bounded at 25s; systemd retains a final 5s fence.

--- a/packages/cloud/scripts/admin/systemd-environment-line.mjs
+++ b/packages/cloud/scripts/admin/systemd-environment-line.mjs
@@ -1,0 +1,514 @@
+#!/usr/bin/env node
+
+/**
+ * Strict helpers for the provisioning host's systemd EnvironmentFile.
+ *
+ * Setting values are accepted only on stdin or through mode-0600 plan files;
+ * the CLI argv and bounded diagnostics contain names and paths, never values.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  chownSync,
+  closeSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmdirSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const MAX_VALUE_BYTES = 128 * 1024;
+const MAX_ENVIRONMENT_FILE_BYTES = 4 * 1024 * 1024;
+const MAX_RECONCILE_ATTEMPTS = 4;
+const NAME_PATTERN = /^[A-Z_][A-Z0-9_]{0,127}$/;
+const EXISTING_ASSIGNMENT_PATTERN =
+  /^[ \t\r]*([A-Za-z_][A-Za-z0-9_]{0,127})[ \t\r]*=([\s\S]*)$/;
+
+function assertName(name) {
+  if (!NAME_PATTERN.test(name)) {
+    throw new Error("SYSTEMD_ENVIRONMENT_NAME_INVALID");
+  }
+}
+
+export function serializeSystemdEnvironmentLine(name, value) {
+  assertName(name);
+  if (
+    typeof value !== "string" ||
+    Buffer.byteLength(value, "utf8") > MAX_VALUE_BYTES ||
+    /[\0\r\n]/.test(value)
+  ) {
+    throw new Error("SYSTEMD_ENVIRONMENT_VALUE_INVALID");
+  }
+  const quoted = value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+  return `${name}="${quoted}"\n`;
+}
+
+/** Decode the deliberately small, single-line subset emitted above. */
+export function decodeSystemdEnvironmentValue(rawValue) {
+  if (typeof rawValue !== "string" || /[\0\r\n]/.test(rawValue)) {
+    throw new Error("SYSTEMD_ENVIRONMENT_VALUE_INVALID");
+  }
+
+  const input = rawValue.trim();
+  if (input === "") return "";
+
+  const quote = input[0];
+  if (quote === '"' || quote === "'") {
+    let decoded = "";
+    let index = 1;
+    for (; index < input.length; index += 1) {
+      const character = input[index];
+      if (character === quote) {
+        if (input.slice(index + 1).trim() !== "") {
+          throw new Error("SYSTEMD_ENVIRONMENT_VALUE_INVALID");
+        }
+        return decoded;
+      }
+      if (quote === "'" || character !== "\\") {
+        decoded += character;
+        continue;
+      }
+
+      index += 1;
+      if (index >= input.length) {
+        throw new Error("SYSTEMD_ENVIRONMENT_VALUE_INVALID");
+      }
+      const escaped = input[index];
+      // systemd preserves a backslash before non-special characters inside
+      // double quotes. The serializer only emits the two supported escapes.
+      decoded += escaped === "\\" || escaped === '"' ? escaped : `\\${escaped}`;
+    }
+    throw new Error("SYSTEMD_ENVIRONMENT_VALUE_INVALID");
+  }
+
+  let decoded = "";
+  for (let index = 0; index < input.length; index += 1) {
+    const character = input[index];
+    if (character !== "\\") {
+      decoded += character;
+      continue;
+    }
+    index += 1;
+    if (index >= input.length) {
+      throw new Error("SYSTEMD_ENVIRONMENT_VALUE_INVALID");
+    }
+    decoded += input[index];
+  }
+  return decoded;
+}
+
+function parseAssignmentLine(line) {
+  const match = EXISTING_ASSIGNMENT_PATTERN.exec(line);
+  if (!match) return null;
+  const name = match[1];
+  const rawValue = match[2];
+  if (!name || rawValue === undefined) return null;
+  return {
+    name,
+    value: decodeSystemdEnvironmentValue(rawValue),
+  };
+}
+
+function parsePreservedEnvironmentLine(line) {
+  if (/^[ \t\r]*(?:$|[#;])/.test(line)) return null;
+  const assignment = parseAssignmentLine(line);
+  if (!assignment) {
+    throw new Error("SYSTEMD_ENVIRONMENT_FILE_INVALID");
+  }
+  return assignment;
+}
+
+export function lookupSystemdEnvironmentValue(contents, name) {
+  assertName(name);
+  if (
+    typeof contents !== "string" ||
+    Buffer.byteLength(contents, "utf8") > MAX_ENVIRONMENT_FILE_BYTES ||
+    contents.includes("\0")
+  ) {
+    throw new Error("SYSTEMD_ENVIRONMENT_FILE_INVALID");
+  }
+
+  const matches = [];
+  for (const line of contents.split(/\r?\n/)) {
+    const assignment = parsePreservedEnvironmentLine(line);
+    if (!assignment || assignment.name !== name) continue;
+    matches.push(assignment.value);
+  }
+  if (matches.length !== 1) {
+    throw new Error(
+      matches.length === 0
+        ? "SYSTEMD_ENVIRONMENT_NAME_MISSING"
+        : "SYSTEMD_ENVIRONMENT_NAME_DUPLICATE",
+    );
+  }
+  return matches[0];
+}
+
+function parseReplacementNames(contents) {
+  const names = new Set();
+  for (const line of contents.split(/\r?\n/)) {
+    if (line === "") continue;
+    assertName(line);
+    if (names.has(line)) {
+      throw new Error("SYSTEMD_ENVIRONMENT_PLAN_INVALID");
+    }
+    names.add(line);
+  }
+  if (names.size === 0) {
+    throw new Error("SYSTEMD_ENVIRONMENT_PLAN_INVALID");
+  }
+  return names;
+}
+
+function parsePlannedAssignments(contents, replacementNames) {
+  const assignments = [];
+  const assignedNames = new Set();
+  for (const line of contents.split(/\r?\n/)) {
+    if (line === "") continue;
+    const assignment = parseAssignmentLine(line);
+    if (
+      !assignment ||
+      !replacementNames.has(assignment.name) ||
+      assignedNames.has(assignment.name)
+    ) {
+      throw new Error("SYSTEMD_ENVIRONMENT_PLAN_INVALID");
+    }
+    assignedNames.add(assignment.name);
+    // Canonicalize again so a hand-crafted plan cannot smuggle unsupported
+    // EnvironmentFile syntax past validation.
+    assignments.push(
+      serializeSystemdEnvironmentLine(assignment.name, assignment.value),
+    );
+  }
+  return assignments.join("");
+}
+
+function mergeEnvironmentFile(current, replacementNames, assignments) {
+  const kept = [];
+  for (const line of current.split(/\r?\n/)) {
+    if (line === "" && kept.length === 0) continue;
+    const assignment = parsePreservedEnvironmentLine(line);
+    if (assignment && replacementNames.has(assignment.name)) continue;
+    kept.push(line);
+  }
+  while (kept.at(-1) === "") kept.pop();
+  const prefix = kept.length > 0 ? `${kept.join("\n")}\n` : "";
+  return `${prefix}${assignments}`;
+}
+
+function isMissingFileError(error) {
+  return Boolean(
+    error &&
+      typeof error === "object" &&
+      Object.getOwnPropertyDescriptor(error, "code")?.value === "ENOENT",
+  );
+}
+
+function snapshotIdentity(stat) {
+  return [stat.dev, stat.ino, stat.size, stat.mtimeNs, stat.ctimeNs].join(":");
+}
+
+function decodeUtf8File(bytes, invalidCode) {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    // error-policy:J3 EnvironmentFile and plan bytes are untrusted; invalid
+    // UTF-8 is a closed validation failure, never replacement characters.
+    throw new Error(invalidCode);
+  }
+}
+
+/** Read a stable content + inode snapshot even when an uncooperative writer is active. */
+function readEnvironmentFileSnapshot(targetPath) {
+  for (let attempt = 0; attempt < MAX_RECONCILE_ATTEMPTS; attempt += 1) {
+    let before;
+    try {
+      before = lstatSync(targetPath, { bigint: true });
+    } catch (error) {
+      // error-policy:J3 ENOENT is an explicit absent snapshot; every other
+      // filesystem failure remains fatal.
+      if (!isMissingFileError(error)) throw error;
+      try {
+        lstatSync(targetPath);
+      } catch (confirmationError) {
+        // error-policy:J3 confirm the untrusted filesystem state before
+        // classifying a missing target as a stable empty snapshot.
+        if (isMissingFileError(confirmationError)) {
+          return Object.freeze({
+            exists: false,
+            contents: "",
+            identity: "absent",
+          });
+        }
+      }
+      continue;
+    }
+    if (!before.isFile() || before.isSymbolicLink()) {
+      throw new Error("SYSTEMD_ENVIRONMENT_TARGET_INVALID");
+    }
+    if (before.size > BigInt(MAX_ENVIRONMENT_FILE_BYTES)) {
+      throw new Error("SYSTEMD_ENVIRONMENT_FILE_INVALID");
+    }
+
+    let contents;
+    let after;
+    try {
+      contents = decodeUtf8File(
+        readFileSync(targetPath),
+        "SYSTEMD_ENVIRONMENT_FILE_INVALID",
+      );
+      after = lstatSync(targetPath, { bigint: true });
+    } catch (error) {
+      // error-policy:J3 disappearance during the read is an invalidated
+      // snapshot that must be retried; unrelated failures remain fatal.
+      if (isMissingFileError(error)) continue;
+      throw error;
+    }
+    if (
+      snapshotIdentity(before) !== snapshotIdentity(after) ||
+      Buffer.byteLength(contents, "utf8") !== Number(after.size)
+    ) {
+      continue;
+    }
+    if (contents.includes("\0")) {
+      throw new Error("SYSTEMD_ENVIRONMENT_FILE_INVALID");
+    }
+    return Object.freeze({
+      exists: true,
+      contents,
+      identity: `${snapshotIdentity(after)}:${createHash("sha256").update(contents).digest("hex")}`,
+    });
+  }
+  throw new Error("SYSTEMD_ENVIRONMENT_TARGET_CHANGED");
+}
+
+function sameEnvironmentFileSnapshot(targetPath, expected) {
+  try {
+    const actual = readEnvironmentFileSnapshot(targetPath);
+    return (
+      actual.exists === expected.exists && actual.identity === expected.identity
+    );
+  } catch (error) {
+    // error-policy:J3 an unstable target is an explicit retry signal, never a
+    // substitute snapshot; unrelated failures remain fatal.
+    if (
+      error instanceof Error &&
+      error.message === "SYSTEMD_ENVIRONMENT_TARGET_CHANGED"
+    ) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Replace the target only after the complete candidate is validated, written,
+ * chmod/chowned, and fsynced. The caller holds flock for the whole operation.
+ */
+export function reconcileSystemdEnvironmentFile({
+  targetPath,
+  replacementNamesPath,
+  assignmentsPath,
+  ownerUid = process.getuid?.() ?? 0,
+  ownerGid = process.getgid?.() ?? 0,
+  preserveUnplanned = true,
+  beforeRename,
+}) {
+  const namesContents = decodeUtf8File(
+    readFileSync(replacementNamesPath),
+    "SYSTEMD_ENVIRONMENT_PLAN_INVALID",
+  );
+  const assignmentsContents = decodeUtf8File(
+    readFileSync(assignmentsPath),
+    "SYSTEMD_ENVIRONMENT_PLAN_INVALID",
+  );
+  const replacementNames = parseReplacementNames(namesContents);
+  const assignments = parsePlannedAssignments(
+    assignmentsContents,
+    replacementNames,
+  );
+
+  const parent = path.dirname(targetPath);
+  mkdirSync(parent, { recursive: true, mode: 0o755 });
+  for (let attempt = 0; attempt < MAX_RECONCILE_ATTEMPTS; attempt += 1) {
+    const snapshot = readEnvironmentFileSnapshot(targetPath);
+    const candidateContents = preserveUnplanned
+      ? mergeEnvironmentFile(snapshot.contents, replacementNames, assignments)
+      : assignments;
+    if (
+      Buffer.byteLength(candidateContents, "utf8") > MAX_ENVIRONMENT_FILE_BYTES
+    ) {
+      throw new Error("SYSTEMD_ENVIRONMENT_FILE_INVALID");
+    }
+
+    const temporaryDirectory = mkdtempSync(
+      path.join(parent, `.${path.basename(targetPath)}.reconcile-`),
+    );
+    const candidatePath = path.join(temporaryDirectory, "candidate");
+    let candidateExists = false;
+    try {
+      const descriptor = openSync(candidatePath, "wx", 0o600);
+      candidateExists = true;
+      try {
+        writeFileSync(descriptor, candidateContents, "utf8");
+        fsyncSync(descriptor);
+      } finally {
+        closeSync(descriptor);
+      }
+      chmodSync(candidatePath, 0o600);
+      chownSync(candidatePath, ownerUid, ownerGid);
+      beforeRename?.(candidatePath, attempt);
+      if (!sameEnvironmentFileSnapshot(targetPath, snapshot)) {
+        continue;
+      }
+      renameSync(candidatePath, targetPath);
+      candidateExists = false;
+
+      const parentDescriptor = openSync(parent, "r");
+      try {
+        fsyncSync(parentDescriptor);
+      } finally {
+        closeSync(parentDescriptor);
+      }
+      return;
+    } finally {
+      if (candidateExists) {
+        try {
+          unlinkSync(candidatePath);
+        } catch {
+          // error-policy:J6 best-effort cleanup only; the target was never replaced.
+        }
+      }
+      try {
+        rmdirSync(temporaryDirectory);
+      } catch {
+        // error-policy:J6 a killed process can leave a root-owned hidden
+        // candidate for operators; it never changes the active EnvironmentFile.
+      }
+    }
+  }
+  throw new Error("SYSTEMD_ENVIRONMENT_TARGET_CHANGED");
+}
+
+async function readStdinBounded(maximumBytes) {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of process.stdin) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.byteLength;
+    if (size > maximumBytes) {
+      throw new Error("SYSTEMD_ENVIRONMENT_VALUE_INVALID");
+    }
+    chunks.push(buffer);
+  }
+  return decodeUtf8File(
+    Buffer.concat(chunks),
+    "SYSTEMD_ENVIRONMENT_VALUE_INVALID",
+  );
+}
+
+const SAFE_ERROR_CODES = new Set([
+  "SYSTEMD_ENVIRONMENT_COMMAND_INVALID",
+  "SYSTEMD_ENVIRONMENT_FILE_INVALID",
+  "SYSTEMD_ENVIRONMENT_NAME_DUPLICATE",
+  "SYSTEMD_ENVIRONMENT_NAME_INVALID",
+  "SYSTEMD_ENVIRONMENT_NAME_MISSING",
+  "SYSTEMD_ENVIRONMENT_PLAN_INVALID",
+  "SYSTEMD_ENVIRONMENT_TARGET_CHANGED",
+  "SYSTEMD_ENVIRONMENT_TARGET_INVALID",
+  "SYSTEMD_ENVIRONMENT_VALUE_EMPTY",
+  "SYSTEMD_ENVIRONMENT_VALUE_INVALID",
+  "SYSTEMD_ENVIRONMENT_VALUE_MISMATCH",
+]);
+
+function safeErrorCode(error) {
+  try {
+    const descriptor =
+      error && (typeof error === "object" || typeof error === "function")
+        ? Object.getOwnPropertyDescriptor(error, "message")
+        : undefined;
+    const code = descriptor && "value" in descriptor ? descriptor.value : "";
+    return typeof code === "string" && SAFE_ERROR_CODES.has(code)
+      ? code
+      : "SYSTEMD_ENVIRONMENT_OPERATION_FAILED";
+  } catch {
+    // error-policy:J1 hostile thrown values collapse to one closed code without
+    // invoking getters or reflecting provider-controlled text.
+    return "SYSTEMD_ENVIRONMENT_OPERATION_FAILED";
+  }
+}
+
+async function main() {
+  const command = process.argv[2] ?? "";
+  try {
+    if (command === "serialize") {
+      const value = await readStdinBounded(MAX_VALUE_BYTES);
+      process.stdout.write(
+        serializeSystemdEnvironmentLine(process.argv[3] ?? "", value),
+      );
+      return;
+    }
+    if (command === "nonempty") {
+      const targetPath = process.argv[3] ?? "";
+      const names = process.argv.slice(4);
+      if (names.length === 0) {
+        throw new Error("SYSTEMD_ENVIRONMENT_NAME_INVALID");
+      }
+      const contents = decodeUtf8File(
+        readFileSync(targetPath),
+        "SYSTEMD_ENVIRONMENT_FILE_INVALID",
+      );
+      for (const name of names) {
+        if (lookupSystemdEnvironmentValue(contents, name).length === 0) {
+          throw new Error("SYSTEMD_ENVIRONMENT_VALUE_EMPTY");
+        }
+      }
+      return;
+    }
+    if (command === "equals") {
+      const expected = await readStdinBounded(MAX_VALUE_BYTES);
+      const contents = decodeUtf8File(
+        readFileSync(process.argv[3] ?? ""),
+        "SYSTEMD_ENVIRONMENT_FILE_INVALID",
+      );
+      if (
+        lookupSystemdEnvironmentValue(contents, process.argv[4] ?? "") !==
+        expected
+      ) {
+        throw new Error("SYSTEMD_ENVIRONMENT_VALUE_MISMATCH");
+      }
+      return;
+    }
+    if (command === "reconcile" || command === "install") {
+      reconcileSystemdEnvironmentFile({
+        targetPath: process.argv[3] ?? "",
+        replacementNamesPath: process.argv[4] ?? "",
+        assignmentsPath: process.argv[5] ?? "",
+        preserveUnplanned: command === "reconcile",
+      });
+      return;
+    }
+    throw new Error("SYSTEMD_ENVIRONMENT_COMMAND_INVALID");
+  } catch (error) {
+    // error-policy:J1 the CLI boundary emits only a closed diagnostic code and
+    // a non-success status; it never reflects file contents or rejected values.
+    process.stderr.write(
+      `[systemd-environment-line] rejected: ${safeErrorCode(error)}\n`,
+    );
+    process.exitCode = 78;
+  }
+}
+
+const entry = process.argv[1];
+if (entry && import.meta.url === pathToFileURL(entry).href) {
+  await main();
+}

--- a/packages/cloud/scripts/admin/systemd-environment-line.test.ts
+++ b/packages/cloud/scripts/admin/systemd-environment-line.test.ts
@@ -1,0 +1,517 @@
+/** Exercises canonical serialization, closed CLI checks, and atomic host-file replacement. */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  lookupSystemdEnvironmentValue,
+  reconcileSystemdEnvironmentFile,
+  serializeSystemdEnvironmentLine,
+} from "./systemd-environment-line.mjs";
+
+const serializer = path.join(import.meta.dir, "systemd-environment-line.mjs");
+const backupService = path.join(
+  import.meta.dir,
+  "eliza-backup-catalog-worker.service",
+);
+const temporaryDirectories: string[] = [];
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(path.join(tmpdir(), "systemd-env-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+function runSerialize(name: string, value: string | Uint8Array) {
+  return Bun.spawnSync([process.execPath, serializer, "serialize", name], {
+    stdin: typeof value === "string" ? Buffer.from(value) : value,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+function runClosedCheck(
+  command: "equals" | "nonempty",
+  targetPath: string,
+  names: readonly string[],
+  stdin = "",
+) {
+  return Bun.spawnSync(
+    [process.execPath, serializer, command, targetPath, ...names],
+    {
+      stdin: Buffer.from(stdin),
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+}
+
+function writePlan(
+  directory: string,
+  names: readonly string[],
+  assignments: Readonly<Record<string, string>>,
+) {
+  const namesPath = path.join(directory, "names");
+  const assignmentsPath = path.join(directory, "assignments");
+  writeFileSync(namesPath, `${names.join("\n")}\n`, { mode: 0o600 });
+  writeFileSync(
+    assignmentsPath,
+    Object.entries(assignments)
+      .map(([name, value]) => serializeSystemdEnvironmentLine(name, value))
+      .join(""),
+    { mode: 0o600 },
+  );
+  return { assignmentsPath, namesPath };
+}
+
+function reconcileForTest(params: {
+  assignmentsPath: string;
+  beforeRename?: (candidatePath: string, attempt: number) => void;
+  namesPath: string;
+  preserveUnplanned?: boolean;
+  targetPath: string;
+}) {
+  reconcileSystemdEnvironmentFile({
+    targetPath: params.targetPath,
+    replacementNamesPath: params.namesPath,
+    assignmentsPath: params.assignmentsPath,
+    preserveUnplanned: params.preserveUnplanned,
+    ownerUid: process.getuid?.() ?? 0,
+    ownerGid: process.getgid?.() ?? 0,
+    beforeRename: params.beforeRename,
+  });
+}
+
+describe("systemd EnvironmentFile serializer", () => {
+  test("round-trips JSON, quotes, backslashes, spaces, hashes, and semicolons", () => {
+    const value =
+      '[{"id":"plugin\\\\windows # one;two","version":"1.0.0+\\"quoted\\""}]';
+    const result = runSerialize("AGENT_BACKUP_RUNTIME_PLUGINS_JSON", value);
+    const output = result.stdout.toString();
+    expect(result.exitCode).toBe(0);
+    expect(
+      lookupSystemdEnvironmentValue(
+        output,
+        "AGENT_BACKUP_RUNTIME_PLUGINS_JSON",
+      ),
+    ).toBe(value);
+    expect(result.stderr.toString()).toBe("");
+  });
+
+  test("keeps a secret on stdin and out of rejection diagnostics", () => {
+    const sentinel = "DO_NOT_LEAK_SYSTEMD_ENV_SECRET";
+    const result = runSerialize(
+      "AGENT_BACKUP_STEWARD_KMS_TOKEN",
+      `${sentinel}\n`,
+    );
+    expect(result.exitCode).toBe(78);
+    expect(result.stdout.toString()).toBe("");
+    expect(result.stderr.toString()).not.toContain(sentinel);
+    expect(result.stderr.toString()).toContain(
+      "SYSTEMD_ENVIRONMENT_VALUE_INVALID",
+    );
+  });
+
+  test("rejects invalid names and NUL without reflecting the value", () => {
+    const result = runSerialize("invalid-name", Buffer.from("secret\0tail"));
+    expect(result.exitCode).toBe(78);
+    expect(result.stdout.toString()).toBe("");
+    expect(result.stderr.toString()).not.toContain("secret");
+    expect(result.stderr.toString()).toContain(
+      "SYSTEMD_ENVIRONMENT_NAME_INVALID",
+    );
+  });
+
+  test("rejects invalid UTF-8 from stdin without reflecting its valid prefix", () => {
+    const sentinel = "AKIA_DO_NOT_LEAK_INVALID_UTF8_PREFIX";
+    const value = Buffer.concat([Buffer.from(sentinel), Buffer.from([0xff])]);
+    const result = runSerialize("AUTHORITY", value);
+
+    expect(result.exitCode).toBe(78);
+    expect(result.stdout.toString()).toBe("");
+    expect(result.stderr.toString()).toContain(
+      "SYSTEMD_ENVIRONMENT_VALUE_INVALID",
+    );
+    expect(result.stderr.toString()).not.toContain(sentinel);
+  });
+
+  test("lookup decodes both canonical quoted and legacy plain assignments", () => {
+    expect(
+      lookupSystemdEnvironmentValue(
+        'ELIZA_CLOUD_AGENT_BASE_DOMAIN="cloud-staging.eliza.app"\n',
+        "ELIZA_CLOUD_AGENT_BASE_DOMAIN",
+      ),
+    ).toBe("cloud-staging.eliza.app");
+    expect(
+      lookupSystemdEnvironmentValue(
+        "ELIZA_CLOUD_AGENT_BASE_DOMAIN=cloud.eliza.app\n",
+        "ELIZA_CLOUD_AGENT_BASE_DOMAIN",
+      ),
+    ).toBe("cloud.eliza.app");
+    expect(() =>
+      lookupSystemdEnvironmentValue(
+        "ELIZA_CLOUD_AGENT_BASE_DOMAIN=one\n  ELIZA_CLOUD_AGENT_BASE_DOMAIN \t=two\n",
+        "ELIZA_CLOUD_AGENT_BASE_DOMAIN",
+      ),
+    ).toThrow("SYSTEMD_ENVIRONMENT_NAME_DUPLICATE");
+  });
+
+  test("does not expose an arbitrary EnvironmentFile value through the CLI", () => {
+    const sentinel = "AKIA_DO_NOT_LEAK_LOOKUP_VALUE";
+    const result = Bun.spawnSync(
+      [process.execPath, serializer, "lookup", "AUTHORITY"],
+      {
+        stdin: Buffer.from(
+          serializeSystemdEnvironmentLine("AUTHORITY", sentinel),
+        ),
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+
+    expect(result.exitCode).toBe(78);
+    expect(result.stdout.toString()).toBe("");
+    expect(result.stderr.toString()).toContain(
+      "SYSTEMD_ENVIRONMENT_COMMAND_INVALID",
+    );
+    expect(result.stderr.toString()).not.toContain(sentinel);
+  });
+});
+
+describe("atomic EnvironmentFile reconciliation", () => {
+  test("preserves unrelated entries and atomically replaces every planned key", () => {
+    const directory = temporaryDirectory();
+    const targetPath = path.join(directory, ".env.local");
+    writeFileSync(
+      targetPath,
+      "KEEP_ME=present\nROTATE_ME=old\nROTATE_ME=duplicate\nREMOVE_ME=stale\n",
+    );
+    const plan = writePlan(directory, ["ROTATE_ME", "REMOVE_ME"], {
+      ROTATE_ME: 'new "quoted" value',
+    });
+
+    reconcileForTest({ targetPath, ...plan });
+
+    const contents = readFileSync(targetPath, "utf8");
+    expect(contents).toContain("KEEP_ME=present\n");
+    expect(contents).not.toContain("REMOVE_ME=");
+    expect(contents.match(/^ROTATE_ME=/gm)).toHaveLength(1);
+    expect(lookupSystemdEnvironmentValue(contents, "ROTATE_ME")).toBe(
+      'new "quoted" value',
+    );
+    expect(statSync(targetPath).mode & 0o777).toBe(0o600);
+  });
+
+  test("a structured failure before rename leaves the old file byte-identical", () => {
+    const directory = temporaryDirectory();
+    const targetPath = path.join(directory, ".env.local");
+    const oldContents = "AUTHORITY=old\nKEEP=stable\n";
+    writeFileSync(targetPath, oldContents);
+    const plan = writePlan(directory, ["AUTHORITY"], {
+      AUTHORITY: "new-secret-value",
+    });
+
+    expect(() =>
+      reconcileForTest({
+        targetPath,
+        ...plan,
+        beforeRename: (candidatePath) => {
+          expect(readFileSync(candidatePath, "utf8")).toContain(
+            'AUTHORITY="new-secret-value"',
+          );
+          throw new Error("TEST_INJECTED_BEFORE_RENAME");
+        },
+      }),
+    ).toThrow("TEST_INJECTED_BEFORE_RENAME");
+
+    expect(readFileSync(targetPath, "utf8")).toBe(oldContents);
+    expect(
+      readdirSync(directory).filter((entry) =>
+        entry.startsWith("..env.local.reconcile-"),
+      ),
+    ).toEqual([]);
+  });
+
+  test("exact install drops stale authorities that are outside the disabled allowlist", () => {
+    const directory = temporaryDirectory();
+    const targetPath = path.join(directory, "backup-catalog-worker.env");
+    writeFileSync(
+      targetPath,
+      "DATABASE_URL=must-disappear\nAGENT_BACKUP_STEWARD_KMS_TOKEN=must-disappear\n",
+    );
+    const plan = writePlan(
+      directory,
+      [
+        "AGENT_BACKUP_CATALOG_RUNTIME_ENABLED",
+        "AGENT_BACKUP_RPO_SCHEDULER_ENABLED",
+      ],
+      {
+        AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "0",
+        AGENT_BACKUP_RPO_SCHEDULER_ENABLED: "0",
+      },
+    );
+
+    reconcileForTest({
+      targetPath,
+      ...plan,
+      preserveUnplanned: false,
+    });
+
+    const contents = readFileSync(targetPath, "utf8");
+    expect(contents).not.toContain("DATABASE_URL");
+    expect(contents).not.toContain("KMS_TOKEN");
+    expect(contents.split("\n").filter(Boolean)).toHaveLength(2);
+  });
+
+  test("rejects a malformed plan before creating a candidate or changing the target", () => {
+    const directory = temporaryDirectory();
+    const targetPath = path.join(directory, ".env.local");
+    writeFileSync(targetPath, "AUTHORITY=old\n");
+    const planDirectory = path.join(directory, "plan");
+    mkdirSync(planDirectory);
+    const namesPath = path.join(planDirectory, "names");
+    const assignmentsPath = path.join(planDirectory, "assignments");
+    writeFileSync(namesPath, "AUTHORITY\n");
+    writeFileSync(assignmentsPath, 'OTHER="not-allowlisted"\n');
+
+    expect(() =>
+      reconcileForTest({ targetPath, namesPath, assignmentsPath }),
+    ).toThrow("SYSTEMD_ENVIRONMENT_PLAN_INVALID");
+    expect(readFileSync(targetPath, "utf8")).toBe("AUTHORITY=old\n");
+    expect(readdirSync(directory).sort()).toEqual([".env.local", "plan"]);
+  });
+
+  test("detects an unlocked concurrent writer and retries without losing its entry", () => {
+    const directory = temporaryDirectory();
+    const targetPath = path.join(directory, ".env.local");
+    writeFileSync(targetPath, "KEEP=initial\nROTATE=old\n");
+    const plan = writePlan(directory, ["ROTATE"], { ROTATE: "new" });
+    let injected = false;
+
+    reconcileForTest({
+      targetPath,
+      ...plan,
+      beforeRename: (_candidatePath, attempt) => {
+        if (attempt === 0 && !injected) {
+          injected = true;
+          writeFileSync(
+            targetPath,
+            "KEEP=initial\nCONCURRENT_WRITER=preserved\nROTATE=old\n",
+          );
+        }
+      },
+    });
+
+    const contents = readFileSync(targetPath, "utf8");
+    expect(injected).toBe(true);
+    expect(contents).toContain("CONCURRENT_WRITER=preserved\n");
+    expect(lookupSystemdEnvironmentValue(contents, "ROTATE")).toBe("new");
+  });
+
+  test("removes legacy assignments with systemd key whitespace", () => {
+    const directory = temporaryDirectory();
+    const targetPath = path.join(directory, ".env.local");
+    writeFileSync(
+      targetPath,
+      "  AGENT_BACKUP_STEWARD_KMS_TOKEN \t=must-disappear\nKEEP=stable\n",
+    );
+    const plan = writePlan(directory, ["AGENT_BACKUP_STEWARD_KMS_TOKEN"], {});
+
+    reconcileForTest({ targetPath, ...plan });
+
+    const contents = readFileSync(targetPath, "utf8");
+    expect(contents).toBe("KEEP=stable\n");
+    expect(contents).not.toContain("must-disappear");
+  });
+
+  test("rejects ambiguous multiline syntax without changing the target", () => {
+    const directory = temporaryDirectory();
+    const targetPath = path.join(directory, ".env.local");
+    const oldContents = "KEEP=stable\\\ncontinued-secret\nROTATE=old\n";
+    writeFileSync(targetPath, oldContents);
+    const plan = writePlan(directory, ["ROTATE"], { ROTATE: "new" });
+
+    expect(() => reconcileForTest({ targetPath, ...plan })).toThrow(
+      "SYSTEMD_ENVIRONMENT_VALUE_INVALID",
+    );
+    expect(readFileSync(targetPath, "utf8")).toBe(oldContents);
+  });
+
+  test("rejects invalid UTF-8 without changing the target", () => {
+    const directory = temporaryDirectory();
+    const targetPath = path.join(directory, ".env.local");
+    const oldContents = Buffer.from([0x4b, 0x45, 0x59, 0x3d, 0xff, 0x0a]);
+    writeFileSync(targetPath, oldContents);
+    const plan = writePlan(directory, ["KEY"], { KEY: "new" });
+
+    expect(() => reconcileForTest({ targetPath, ...plan })).toThrow(
+      "SYSTEMD_ENVIRONMENT_FILE_INVALID",
+    );
+    expect(readFileSync(targetPath)).toEqual(oldContents);
+  });
+
+  test("closed root-style checks return only status and never file values", () => {
+    const directory = temporaryDirectory();
+    const targetPath = path.join(directory, "runtime.env");
+    const sentinel = "AKIA_DO_NOT_LEAK_ENVIRONMENT_VALUE";
+    writeFileSync(
+      targetPath,
+      [
+        serializeSystemdEnvironmentLine("AUTHORITY", sentinel),
+        serializeSystemdEnvironmentLine("EMPTY_VALUE", ""),
+      ].join(""),
+    );
+
+    const present = runClosedCheck("nonempty", targetPath, ["AUTHORITY"]);
+    expect(present.exitCode).toBe(0);
+    expect(present.stdout.toString()).toBe("");
+    expect(present.stderr.toString()).toBe("");
+
+    const equal = runClosedCheck("equals", targetPath, ["AUTHORITY"], sentinel);
+    expect(equal.exitCode).toBe(0);
+    expect(equal.stdout.toString()).toBe("");
+    expect(equal.stderr.toString()).toBe("");
+
+    const rejected = runClosedCheck("nonempty", targetPath, ["EMPTY_VALUE"]);
+    expect(rejected.exitCode).toBe(78);
+    expect(rejected.stdout.toString()).toBe("");
+    expect(rejected.stderr.toString()).toContain(
+      "SYSTEMD_ENVIRONMENT_VALUE_EMPTY",
+    );
+    expect(rejected.stderr.toString()).not.toContain(sentinel);
+  });
+});
+
+const systemdAnalyze = Bun.which("systemd-analyze");
+const systemdVerificationRequired =
+  process.platform === "linux" || process.env.CI === "true";
+test("systemd-analyze accepts a unit that consumes the serialized EnvironmentFile", () => {
+  if (!systemdAnalyze) {
+    if (systemdVerificationRequired) {
+      throw new Error("systemd-analyze is required on Linux/CI");
+    }
+    return;
+  }
+  const directory = temporaryDirectory();
+  const environmentPath = path.join(directory, "runtime.env");
+  const unitPath = path.join(directory, "serializer-test.service");
+  writeFileSync(
+    environmentPath,
+    serializeSystemdEnvironmentLine(
+      "SERIALIZER_SYSTEMD_VALUE",
+      'spaces # semicolon; slash\\ quote"',
+    ),
+  );
+  writeFileSync(
+    unitPath,
+    [
+      "[Unit]",
+      "Description=Environment serializer verification",
+      "[Service]",
+      "Type=oneshot",
+      `EnvironmentFile=${environmentPath}`,
+      "ExecStart=/usr/bin/env",
+      "",
+    ].join("\n"),
+  );
+
+  const result = Bun.spawnSync([systemdAnalyze, "verify", unitPath], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(result.exitCode, result.stderr.toString()).toBe(0);
+});
+
+test("systemd-analyze accepts the shipped DynamicUser hardening directives", () => {
+  if (!systemdAnalyze) {
+    if (systemdVerificationRequired) {
+      throw new Error("systemd-analyze is required on Linux/CI");
+    }
+    return;
+  }
+  const directory = temporaryDirectory();
+  const environmentPath = path.join(directory, "backup.env");
+  const unitPath = path.join(directory, "backup-worker.service");
+  writeFileSync(environmentPath, 'AGENT_BACKUP_CATALOG_RUNTIME_ENABLED="0"\n');
+  const service = readFileSync(backupService, "utf8");
+  expect(service).toContain("DynamicUser=yes");
+  expect(service).not.toContain("User=deploy");
+  expect(service).not.toContain("Group=deploy");
+  writeFileSync(
+    unitPath,
+    service
+      .replace(/^WorkingDirectory=.*$/m, `WorkingDirectory=${directory}`)
+      .replace(/^EnvironmentFile=.*$/m, `EnvironmentFile=${environmentPath}`)
+      .replace(/^ExecStart=.*$/m, "ExecStart=/usr/bin/true"),
+  );
+
+  const result = Bun.spawnSync([systemdAnalyze, "verify", unitPath], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(result.exitCode, result.stderr.toString()).toBe(0);
+});
+
+const systemdRun = Bun.which("systemd-run");
+const systemdUserManagerAvailable = (() => {
+  if (!systemdRun || !Bun.which("env")) return false;
+  const result = Bun.spawnSync([
+    systemdRun,
+    "--user",
+    "--wait",
+    "--pipe",
+    "--quiet",
+    "--collect",
+    "/usr/bin/true",
+  ]);
+  return result.exitCode === 0;
+})();
+
+test.skipIf(!systemdUserManagerAvailable)(
+  "systemd-run consumes the exact serialized value when a user manager is available",
+  () => {
+    if (!systemdRun) throw new Error("systemd-run disappeared");
+    const directory = temporaryDirectory();
+    const environmentPath = path.join(directory, "runtime.env");
+    const expected = 'spaces # semicolon; slash\\ quote"';
+    writeFileSync(
+      environmentPath,
+      serializeSystemdEnvironmentLine("SERIALIZER_SYSTEMD_VALUE", expected),
+    );
+
+    const result = Bun.spawnSync(
+      [
+        systemdRun,
+        "--user",
+        "--wait",
+        "--pipe",
+        "--quiet",
+        "--collect",
+        `--property=EnvironmentFile=${environmentPath}`,
+        "/usr/bin/env",
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    expect(result.exitCode, result.stderr.toString()).toBe(0);
+    const assignment = result.stdout
+      .toString()
+      .split("\n")
+      .find((line) => line.startsWith("SERIALIZER_SYSTEMD_VALUE="));
+    expect(assignment).toBe(`SERIALIZER_SYSTEMD_VALUE=${expected}`);
+  },
+);

--- a/packages/cloud/shared/.env.example
+++ b/packages/cloud/shared/.env.example
@@ -24,8 +24,12 @@ DATABASE_URL=postgresql://user:password@host:5432/eliza_platform?sslmode=require
 # ============================================================================
 # MANIFEST-V3 BACKUP CATALOGUE WORKER (dedicated daemon; forced off at merge)
 # ============================================================================
-# Disabled mode reads only these two gates. Do not enable until the activation,
-# legacy-producer coexistence, and fleet-capacity prerequisites are complete.
+# The disabled authority composition reads only these two gates. The daemon may
+# also read non-secret cadence/health controls below, but never DB/provider/KMS
+# authority. Do not enable until backup authority is outside the shared host's
+# provisioning-account sudo/docker trust domain (or on a dedicated host) and the
+# activation, legacy-producer coexistence, and fleet-capacity prerequisites are
+# complete.
 AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=0
 AGENT_BACKUP_RPO_SCHEDULER_ENABLED=0
 
@@ -59,6 +63,21 @@ AGENT_BACKUP_RPO_SCHEDULER_ENABLED=0
 # AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE=32
 # AGENT_BACKUP_CAPTURE_DEADLINE_MS=60000
 # AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS=60000
+# Scheduler defaults and bounds. Capture and object-transfer deadlines must each
+# be <= AGENT_BACKUP_OPERATION_LEASE_MS - 30000 so fenced settlement retains a
+# full 30-second margin. Retry base values must not exceed their retry maximum.
+# AGENT_BACKUP_SCHEDULE_BATCH_SIZE=32 # 1..100
+# AGENT_BACKUP_SCHEDULE_LEASE_MS=120000 # 1..300000
+# AGENT_BACKUP_SCHEDULE_RETRY_MS=30000 # 1..300000
+# AGENT_BACKUP_OPERATION_BATCH_SIZE=1 # fixed at 1 until a durable fairness cursor exists
+# AGENT_BACKUP_OPERATION_LEASE_MS=240000 # 1..300000
+# AGENT_BACKUP_OPERATION_RETRY_BASE_MS=60000 # 1..86400000
+# AGENT_BACKUP_OPERATION_RETRY_MAX_MS=21600000 # 1..86400000
+# AGENT_BACKUP_GC_BATCH_SIZE=32 # 1..100
+# AGENT_BACKUP_GC_LEASE_MS=240000 # 1..300000
+# AGENT_BACKUP_GC_RETRY_BASE_MS=30000 # 1..21600000
+# AGENT_BACKUP_GC_RETRY_MAX_MS=1800000 # 1..21600000
+# AGENT_BACKUP_DELETION_BATCH_SIZE=32 # 1..100
 # AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS=60000
 # AGENT_BACKUP_CATALOG_WORKER_RETRY_MS=5000
 # AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS=25000

--- a/packages/cloud/shared/.env.example
+++ b/packages/cloud/shared/.env.example
@@ -21,6 +21,49 @@
 #         Use pglite://memory for an in-memory store (tests).
 DATABASE_URL=postgresql://user:password@host:5432/eliza_platform?sslmode=require
 
+# ============================================================================
+# MANIFEST-V3 BACKUP CATALOGUE WORKER (dedicated daemon; forced off at merge)
+# ============================================================================
+# Disabled mode reads only these two gates. Do not enable until the activation,
+# legacy-producer coexistence, and fleet-capacity prerequisites are complete.
+AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=0
+AGENT_BACKUP_RPO_SCHEDULER_ENABLED=0
+
+# Required only when the runtime gate is 1. Never commit real credentials.
+# AGENT_BACKUP_CATALOG_WORKER_ID=backup-catalog-control-plane-1
+# AGENT_BACKUP_R2_ENDPOINT_ALIAS=r2-primary
+# AGENT_BACKUP_R2_ACCOUNT_ID=replace-with-stable-account-identity
+# AGENT_BACKUP_R2_ENDPOINT=https://replace-me.r2.cloudflarestorage.com
+# AGENT_BACKUP_R2_BUCKET=replace-me
+# AGENT_BACKUP_R2_REGION=auto
+# AGENT_BACKUP_R2_ACCESS_KEY_ID=replace-me
+# AGENT_BACKUP_R2_SECRET_ACCESS_KEY=replace-me
+# AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS=hetzner-secondary
+# AGENT_BACKUP_HETZNER_ACCOUNT_ID=replace-with-stable-account-identity
+# AGENT_BACKUP_HETZNER_ENDPOINT=https://replace-me.your-objectstorage.com
+# AGENT_BACKUP_HETZNER_BUCKET=replace-me
+# AGENT_BACKUP_HETZNER_REGION=fsn1
+# AGENT_BACKUP_HETZNER_ACCESS_KEY_ID=replace-me
+# AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY=replace-me
+# AGENT_BACKUP_STEWARD_KMS_BASE_URL=https://steward.example.com
+# AGENT_BACKUP_STEWARD_KMS_TOKEN=replace-with-short-lived-service-bearer
+# AGENT_BACKUP_AGENT_SCHEMA_VERSION=replace-with-deployed-version
+# AGENT_BACKUP_DATABASE_SCHEMA_VERSION=replace-with-deployed-version
+# AGENT_BACKUP_RUNTIME_PLUGINS_JSON=[]
+# AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID=replace-with-deployment-id
+# AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT=2026-01-01T00:00:00.000Z
+# AGENT_BACKUP_STORAGE_SCOPE=production-eu
+# AGENT_BACKUP_SPOOL_STATE_DIRECTORY=/var/lib/eliza-backup-catalog/spool
+# AGENT_BACKUP_SPOOL_MAX_BYTES=8589934592
+# AGENT_BACKUP_SPOOL_MIN_FREE_BYTES=1073741824
+# AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE=32
+# AGENT_BACKUP_CAPTURE_DEADLINE_MS=60000
+# AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS=60000
+# AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS=60000
+# AGENT_BACKUP_CATALOG_WORKER_RETRY_MS=5000
+# AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS=25000
+# AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE=/run/eliza-backup-catalog/health.json
+
 # Optional: override the PGlite data directory for the local fallback.
 # PGLITE_DATA_DIR=.eliza/.pgdata
 

--- a/packages/cloud/shared/docs/agent-backup.md
+++ b/packages/cloud/shared/docs/agent-backup.md
@@ -161,7 +161,7 @@ objects are quarantined instead of guessed away. A spool is removable only
 after an exact current `protected`, `retained`, or `restore_verified` catalogue
 proof covers every primary and secondary object.
 
-### Periodic RPO admission remains dormant
+### Dedicated periodic worker remains dormant
 
 The database scheduler uses database time, preserves one operation ID across
 response loss, admits at most one due operation per organization and source
@@ -169,15 +169,31 @@ node, and advances `next_backup_at` only after exact current manifest-v3 dual
 protection. Retry backoff has a separate timestamp, so a failure never moves the
 RPO deadline or hides an overdue agent.
 
-`AGENT_BACKUP_RPO_SCHEDULER_ENABLED` is off by default. This PR deliberately
-does not wire the catalogue runtime into the provisioning daemon and does not
-construct production capture, KMS, publication, or spool-cleanup executors from
-environment variables. It therefore makes no production 15-minute RPO claim.
-Activation/vault writers, a dedicated control-plane cadence of at most 60
-seconds, durable superseded-operation cancellation, coexistence fencing against
-legacy/manual producers, and fleet-capacity evidence must land before the gate
-may be enabled. Missing authority remains overdue and unroutable; it is never
-reported as protected.
+`eliza-backup-catalog-worker.service` is a dedicated, serial caller of the
+catalogue runtime. Its enabled composition binds one R2/Hetzner registry, one
+Steward KMS operation-key-bundle provider, the exact database-backed capture
+attestation, a persistent `/var/lib/eliza-backup-catalog/spool`, publication,
+GC, and the protected/terminal spool janitor. `--once` runs one deterministic
+cycle. The normal cadence and retry delay are bounded to 60 seconds, and
+SIGTERM reaches capture and publication before systemd's bounded shutdown
+fence. Health is published without locators or credentials at
+`/run/eliza-backup-catalog/health.json`.
+
+Both `AGENT_BACKUP_CATALOG_RUNTIME_ENABLED` and
+`AGENT_BACKUP_RPO_SCHEDULER_ENABLED` are forced to `0` in the merge-time
+systemd/deploy path. The disabled entrypoint reads only those gates and returns
+before importing or constructing database, provider, KMS, executor, or spool
+authority. Enabled configuration is fail-closed: storage identities and
+credentials, Steward KMS bearer, persistent spool bounds, legacy-writer drain
+receipt, and deployment-pinned agent/database/plugin versions must all be
+present before any provider is built. These static runtime metadata values are
+required because the current activation receipt does not persist them; they are
+never inferred from mutable process state.
+
+This worker therefore makes no production 15-minute RPO claim at merge.
+Activation/vault writers, coexistence fencing against legacy/manual producers,
+and fleet-capacity evidence must land before the gates may be enabled. Missing
+authority remains overdue and unroutable; it is never reported as protected.
 
 ## Operational proof
 

--- a/packages/cloud/shared/docs/agent-backup.md
+++ b/packages/cloud/shared/docs/agent-backup.md
@@ -179,11 +179,26 @@ SIGTERM reaches capture and publication before systemd's bounded shutdown
 fence. Health is published without locators or credentials at
 `/run/eliza-backup-catalog/health.json`.
 
+The runtime configuration exposes bounded schedule, operation, garbage-
+collection, and deletion batch/lease/retry controls in
+`packages/cloud/shared/.env.example`. Operation admission is deliberately
+fixed to one claim per cycle until a durable cross-cycle tenant cursor proves
+starvation freedom. Capture and object-transfer deadlines must each leave at
+least 30 seconds inside `AGENT_BACKUP_OPERATION_LEASE_MS` for fenced catalogue
+settlement. Operation and GC retry bases must not exceed their corresponding
+retry maxima; invalid combinations fail before provider authority is built.
+
 Both `AGENT_BACKUP_CATALOG_RUNTIME_ENABLED` and
 `AGENT_BACKUP_RPO_SCHEDULER_ENABLED` are forced to `0` in the merge-time
-systemd/deploy path. The disabled entrypoint reads only those gates and returns
-before importing or constructing database, provider, KMS, executor, or spool
-authority. Enabled configuration is fail-closed: storage identities and
+systemd/deploy path. The disabled authority composition reads only those gates
+and returns before importing or constructing database, provider, KMS, executor,
+or spool authority. The outer daemon may additionally read non-secret cadence
+and health controls needed to publish its dormant status; the dedicated dormant
+file also pins an inert spool path. Before either gate can be activated, backup
+authority must leave the shared host's provisioning-account sudo/docker trust
+domain (or move to a dedicated host) and execute an integrity-protected
+artifact; a root-owned copy on the current shared host alone is not an isolation
+boundary. Enabled configuration is fail-closed: storage identities and
 credentials, Steward KMS bearer, persistent spool bounds, legacy-writer drain
 receipt, and deployment-pinned agent/database/plugin versions must all be
 present before any provider is built. These static runtime metadata values are

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts
@@ -54,6 +54,7 @@ import {
   buildAgentBackupObjectKey,
   claimDueAgentBackupOperations,
   failAgentBackupOperation,
+  handoffCapturedAgentBackupOperation,
   markAgentBackupObjectUploading,
   markAgentBackupObjectVerified,
   recordAgentBackupObjectPresent,
@@ -81,6 +82,7 @@ import { agentSandboxesRepository } from "../agent-sandboxes";
 const PGLITE_TIMEOUT = 60_000;
 const ORG_ID = "00000000-0000-4000-8000-00000000c001";
 const FOREIGN_ORG_ID = "00000000-0000-4000-8000-00000000c00a";
+const FOREIGN_AGENT_ID = "00000000-0000-4000-8000-00000000c01a";
 const USER_ID = "00000000-0000-4000-8000-00000000c002";
 const AGENT_ID = "00000000-0000-4000-8000-00000000c003";
 const OPERATION_ID = "00000000-0000-4000-8000-00000000c004";
@@ -1092,6 +1094,73 @@ afterAll(async () => {
 });
 
 describe("agent backup catalogue on primary PGlite", () => {
+  test("proves repeated limit-one claims reset tenant fairness for A,A versus B", async () => {
+    const [baselineSandbox] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, AGENT_ID));
+    if (!baselineSandbox) throw new Error("Expected baseline sandbox fixture");
+    await dbWrite.insert(agentSandboxes).values({
+      ...baselineSandbox,
+      id: FOREIGN_AGENT_ID,
+      organization_id: FOREIGN_ORG_ID,
+      agent_name: "Foreign Backup Catalogue Agent",
+      sandbox_id: "foreign-container-generation-1",
+      container_name: "foreign-backup-catalogue-agent",
+      activation_receipt: baselineSandbox.activation_receipt
+        ? {
+            ...baselineSandbox.activation_receipt,
+            agentId: FOREIGN_AGENT_ID,
+            organizationId: FOREIGN_ORG_ID,
+          }
+        : null,
+    });
+
+    const firstA = await reserveTestBackup({
+      operationId: "00000000-0000-4000-8000-00000000c021",
+    });
+    const secondA = await reserveTestBackup({
+      operationId: "00000000-0000-4000-8000-00000000c022",
+    });
+    const tenantB = await reserveTestBackup({
+      organizationId: FOREIGN_ORG_ID,
+      agentId: FOREIGN_AGENT_ID,
+      sandboxRecordId: FOREIGN_AGENT_ID,
+      operationId: "00000000-0000-4000-8000-00000000c023",
+      sourceProviderHandle: "foreign-container-generation-1",
+    });
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ catalog_next_attempt_at: new Date("2020-01-01T00:00:00.000Z") })
+      .where(eq(agentSandboxBackups.id, firstA.id));
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ catalog_next_attempt_at: new Date("2020-01-02T00:00:00.000Z") })
+      .where(eq(agentSandboxBackups.id, secondA.id));
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ catalog_next_attempt_at: new Date("2020-01-03T00:00:00.000Z") })
+      .where(eq(agentSandboxBackups.id, tenantB.id));
+
+    const [firstClaim] = await claimDueAgentBackupOperations({
+      ownerId: "fairness-proof-1",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    const [secondClaim] = await claimDueAgentBackupOperations({
+      ownerId: "fairness-proof-2",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    expect(firstClaim?.backup.id).toBe(firstA.id);
+    expect(secondClaim?.backup.id).toBe(secondA.id);
+    const [unclaimedB] = await dbWrite
+      .select({ owner: agentSandboxBackups.catalog_lease_owner })
+      .from(agentSandboxBackups)
+      .where(eq(agentSandboxBackups.id, tenantB.id));
+    expect(unclaimedB?.owner).toBeNull();
+  });
+
   test("reserves and claims only one exact active source authority", async () => {
     const first = await reserveAgentBackupOperation(exactReservation());
     const replay = await reserveAgentBackupOperation(exactReservation());
@@ -1171,6 +1240,102 @@ describe("agent backup catalogue on primary PGlite", () => {
       watermark_digest: manifest.watermarkDigest,
       image_digest: SOURCE_IMAGE_DIGEST,
     });
+  });
+
+  test("hands an exact captured fence to publication without waiting for lease expiry", async () => {
+    const reserved = await reserveAgentBackupOperation(exactReservation());
+    const [claim] = await claimDueAgentBackupOperations({
+      ownerId: "capture-worker-handoff",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!claim) throw new Error("Expected one capture claim");
+    const execution = { ownerId: claim.ownerId, generation: claim.generation };
+    await transitionAgentBackupOperation({
+      organizationId: ORG_ID,
+      backupId: reserved.id,
+      operationId: OPERATION_ID,
+      lifecycleGeneration: LIFECYCLE_GENERATION,
+      expectedState: "scheduled",
+      to: "capturing",
+      execution,
+    });
+
+    await expect(
+      handoffCapturedAgentBackupOperation({
+        organizationId: ORG_ID,
+        backupId: reserved.id,
+        operationId: OPERATION_ID,
+        lifecycleGeneration: LIFECYCLE_GENERATION,
+        execution,
+      }),
+    ).rejects.toThrow("exact execution fence");
+
+    await recordCapturedAgentBackupManifest({
+      organizationId: ORG_ID,
+      backupId: reserved.id,
+      operationId: OPERATION_ID,
+      expectedActivationGeneration: LIFECYCLE_GENERATION,
+      expectedLifecycleRevision: "0",
+      execution,
+      manifest: await capturedManifest([objectDescriptor()], {
+        createdAt: reserved.created_at.toISOString(),
+      }),
+    });
+
+    for (const mismatch of [
+      { organizationId: FOREIGN_ORG_ID },
+      { operationId: INCREMENTAL_OPERATION_ID },
+      { lifecycleGeneration: INCREMENTAL_GENERATION },
+      { execution: { ...execution, ownerId: "foreign-capture-worker" } },
+      { execution: { ...execution, generation: randomUUID() } },
+    ]) {
+      await expect(
+        handoffCapturedAgentBackupOperation({
+          organizationId: ORG_ID,
+          backupId: reserved.id,
+          operationId: OPERATION_ID,
+          lifecycleGeneration: LIFECYCLE_GENERATION,
+          execution,
+          ...mismatch,
+        }),
+      ).rejects.toThrow("exact execution fence");
+    }
+
+    const handedOff = await handoffCapturedAgentBackupOperation({
+      organizationId: ORG_ID,
+      backupId: reserved.id,
+      operationId: OPERATION_ID,
+      lifecycleGeneration: LIFECYCLE_GENERATION,
+      execution,
+    });
+    expect(handedOff).toMatchObject({
+      catalog_state: "captured",
+      catalog_lease_owner: null,
+      catalog_lease_generation: null,
+      catalog_lease_expires_at: null,
+    });
+
+    await expect(
+      handoffCapturedAgentBackupOperation({
+        organizationId: ORG_ID,
+        backupId: reserved.id,
+        operationId: OPERATION_ID,
+        lifecycleGeneration: LIFECYCLE_GENERATION,
+        execution,
+      }),
+    ).rejects.toThrow("exact execution fence");
+
+    const [publicationClaim] = await claimDueAgentBackupOperations({
+      ownerId: "publication-worker-handoff",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    expect(publicationClaim).toMatchObject({
+      ownerId: "publication-worker-handoff",
+      backup: { id: reserved.id, catalog_state: "captured" },
+    });
+    expect(publicationClaim?.generation).not.toBe(execution.generation);
   });
 
   test("persists and exactly replays one manifest-v3 operation key bundle", async () => {

--- a/packages/cloud/shared/src/db/repositories/agent-backup-catalog.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-catalog.ts
@@ -902,6 +902,55 @@ export async function heartbeatAgentBackupOperation(params: {
   return updated;
 }
 
+/**
+ * Release the exact capture execution fence after `recordCaptured` is durably
+ * confirmed. This is a stage handoff only: the catalogue remains `captured`
+ * until an independently claimed publication executor advances it.
+ */
+export async function handoffCapturedAgentBackupOperation(params: {
+  organizationId: string;
+  backupId: string;
+  operationId: string;
+  lifecycleGeneration: string;
+  execution: AgentBackupOperationExecution;
+}): Promise<StoredAgentSandboxBackup> {
+  requireUuid(params.organizationId, "organizationId");
+  requireUuid(params.backupId, "backupId");
+  requireUuid(params.operationId, "operationId");
+  requireUuid(params.lifecycleGeneration, "lifecycleGeneration");
+  requireOperationExecution(params.execution);
+
+  const [updated] = await dbWrite
+    .update(agentSandboxBackups)
+    .set({
+      catalog_lease_owner: null,
+      catalog_lease_generation: null,
+      catalog_lease_expires_at: null,
+      catalog_updated_at: sql`NOW()`,
+    })
+    .where(
+      and(
+        eq(agentSandboxBackups.id, params.backupId),
+        eq(agentSandboxBackups.catalog_version, 2),
+        eq(agentSandboxBackups.catalog_organization_id, params.organizationId),
+        eq(agentSandboxBackups.backup_operation_id, params.operationId),
+        eq(agentSandboxBackups.lifecycle_generation, params.lifecycleGeneration),
+        eq(agentSandboxBackups.catalog_state, "captured"),
+        eq(agentSandboxBackups.catalog_lease_owner, params.execution.ownerId),
+        eq(agentSandboxBackups.catalog_lease_generation, params.execution.generation),
+        gt(agentSandboxBackups.catalog_lease_expires_at, sql`NOW()`),
+        sql`${agentSandboxBackups.sandbox_record_id} IS NOT NULL`,
+      ),
+    )
+    .returning();
+  if (!updated) {
+    throw new AgentBackupCatalogConflictError(
+      "Captured backup handoff lost its exact execution fence",
+    );
+  }
+  return updated;
+}
+
 interface CapturedAgentBackupManifestCommon {
   /** Exact canonical manifest draft bytes (integrity.manifestSha256 omitted). */
   canonicalManifestDraft: string;

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-catalog-executor.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-catalog-executor.test.ts
@@ -8,10 +8,12 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { ElizaError } from "@elizaos/core";
 import { KmsAeadOperationKeyBundleProvider, LocalKmsAdapter } from "@elizaos/core/security/kms";
 import {
   AGENT_BACKUP_CAPTURE_V2_CONTENT_TYPE,
   AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+  AGENT_BACKUP_CAPTURE_V2_REQUEST_FORMAT,
   AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
   type AgentBackupCaptureV2FrameHeader,
   type AgentBackupCaptureV2Request,
@@ -26,13 +28,22 @@ import {
   type ExecuteAgentBackupCaptureV2CatalogClaimDependencies,
   executeAgentBackupCaptureV2CatalogClaim,
 } from "./agent-backup-capture-v2-catalog-executor";
-import { isTrustedAgentBackupCaptureV2TerminalDisposition } from "./agent-backup-capture-v2-failure-disposition";
-import type { AgentBackupCaptureV3KeyBundleProvider } from "./agent-backup-capture-v2-pipeline";
+import {
+  isTrustedAgentBackupCaptureV2TerminalDisposition,
+  normalizeAgentBackupCaptureV2TerminalFailure,
+} from "./agent-backup-capture-v2-failure-disposition";
+import {
+  type AgentBackupCaptureV3KeyBundleProvider,
+  deriveAgentBackupCaptureV3RuntimePrincipalSha256,
+  deriveAgentBackupCaptureV3SpoolAuthorityDigests,
+} from "./agent-backup-capture-v2-pipeline";
+import { createAgentBackupCaptureV3RuntimeContextResolver } from "./agent-backup-capture-v3-runtime-context";
 
 const ORGANIZATION_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const BACKUP_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 const OPERATION_ID = "11111111-1111-4111-8111-111111111111";
 const AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const RUNTIME_AGENT_ID = "88888888-8888-4888-8888-888888888888";
 const ACTIVATION_GENERATION = "33333333-3333-4333-8333-333333333333";
 const CLAIM_GENERATION = "44444444-4444-4444-8444-444444444444";
 const NODE_RECORD_ID = "55555555-5555-4555-8555-555555555555";
@@ -98,7 +109,8 @@ function claim(): AgentBackupOperationClaim {
 function attestation(): AgentBackupCaptureV2RuntimeAttestation {
   return {
     organizationId: ORGANIZATION_ID,
-    agentId: AGENT_ID,
+    catalogAgentId: AGENT_ID,
+    runtimeAgentId: RUNTIME_AGENT_ID,
     activationGeneration: ACTIVATION_GENERATION,
     lifecycleRevision: "7",
     source: {
@@ -290,6 +302,7 @@ describe("executeAgentBackupCaptureV2CatalogClaim", () => {
     let revalidations = 0;
     let fetches = 0;
     const initialAttestation = attestation();
+    let observedRuntimeRequest: AgentBackupCaptureV2Request | undefined;
     try {
       const result = await executeAgentBackupCaptureV2CatalogClaim({
         claim: claim(),
@@ -317,6 +330,9 @@ describe("executeAgentBackupCaptureV2CatalogClaim", () => {
               const headers = new Headers(init?.headers);
               expect(headers.get("authorization")).toBe("Bearer exact-agent-token");
               const request = JSON.parse(String(init?.body)) as AgentBackupCaptureV2Request;
+              observedRuntimeRequest = request;
+              expect(request.agentId).toBe(RUNTIME_AGENT_ID);
+              expect(request.agentId).not.toBe(AGENT_ID);
               return responseFor(request, await wireFrames(request));
             }) as typeof fetch;
             return {
@@ -365,6 +381,58 @@ describe("executeAgentBackupCaptureV2CatalogClaim", () => {
       });
       expect(result.spool.phase).toBe("sealed");
       expect(result.spool.chunks.every((chunk) => !result.spool.isChunkUploaded(chunk))).toBe(true);
+      const durableManifest = JSON.parse(
+        await fs.promises.readFile(
+          path.join(result.spool.operationDirectory, "manifest.json"),
+          "utf8",
+        ),
+      ) as { identity: { agentId: string } };
+      expect(durableManifest.identity.agentId).toBe(AGENT_ID);
+      expect(durableManifest.identity.agentId).not.toBe(RUNTIME_AGENT_ID);
+      const keyBundleContext = result.spool.getOperationKeyBundleMetadata()?.canonicalContext;
+      expect(keyBundleContext).toContain(`"agentId":"${AGENT_ID}"`);
+      expect(keyBundleContext).not.toContain(RUNTIME_AGENT_ID);
+      if (!observedRuntimeRequest) throw new Error("Runtime request was not observed");
+      const journal = JSON.parse(
+        await fs.promises.readFile(
+          path.join(result.spool.operationDirectory, "journal.json"),
+          "utf8",
+        ),
+      ) as { requestSha256: string; runtimePrincipalSha256: string };
+      expect(journal.runtimePrincipalSha256).toBe(
+        deriveAgentBackupCaptureV3RuntimePrincipalSha256(RUNTIME_AGENT_ID),
+      );
+      const durableAuthority = {
+        createdAt: "2026-08-15T10:00:00.000Z",
+        organizationId: ORGANIZATION_ID,
+        source: initialAttestation.source,
+        runtime: initialAttestation.runtime,
+        chain: { kind: "full" as const, baseOperationId: null, parentOperationId: null, depth: 0 },
+        watermarks: initialAttestation.watermarks,
+        kms: {
+          provider: "steward" as const,
+          keyId: `org:${ORGANIZATION_ID}/dek/v1`,
+          keyVersion: 1,
+        },
+        vaultKeyAuthority,
+      };
+      const catalogRequest = {
+        ...observedRuntimeRequest,
+        format: AGENT_BACKUP_CAPTURE_V2_REQUEST_FORMAT,
+        agentId: AGENT_ID,
+      };
+      expect(journal.requestSha256).toBe(
+        deriveAgentBackupCaptureV3SpoolAuthorityDigests({
+          request: catalogRequest,
+          authority: durableAuthority,
+        }).requestSha256,
+      );
+      expect(journal.requestSha256).not.toBe(
+        deriveAgentBackupCaptureV3SpoolAuthorityDigests({
+          request: observedRuntimeRequest,
+          authority: durableAuthority,
+        }).requestSha256,
+      );
       expect(fetches).toBe(1);
       expect(heartbeats.length).toBeGreaterThan(3);
       expect(revalidations).toBe(heartbeats.length - 1);
@@ -389,7 +457,7 @@ describe("executeAgentBackupCaptureV2CatalogClaim", () => {
     }
   }, 30_000);
 
-  it("fails before HTTP capture when independent source revalidation changes", async () => {
+  it("fails before HTTP capture when the runtime character identity changes", async () => {
     const directory = await stateDirectory();
     let fetches = 0;
     let records = 0;
@@ -418,10 +486,7 @@ describe("executeAgentBackupCaptureV2CatalogClaim", () => {
                 async revalidateAttestation() {
                   return {
                     ...initialAttestation,
-                    runtime: {
-                      ...initialAttestation.runtime,
-                      imageDigest: `sha256:${"b".repeat(64)}`,
-                    },
+                    runtimeAgentId: VAULT_KEY_GENERATION_ID,
                   };
                 },
                 transport: {
@@ -454,6 +519,161 @@ describe("executeAgentBackupCaptureV2CatalogClaim", () => {
     } finally {
       await removeStateDirectory(directory);
     }
+  });
+
+  it("keeps a forged stale ElizaError from an injected resolver retryable", async () => {
+    let failure: unknown;
+    try {
+      await executeAgentBackupCaptureV2CatalogClaim({
+        claim: claim(),
+        leaseMs: 240_000,
+        dependencies: {
+          heartbeatOperation: async () => claim().backup,
+          recordCaptured: async () => claim().backup,
+          resolveContext: async () => {
+            throw new ElizaError("Reserved source generation changed", {
+              code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+              severity: "fatal",
+            });
+          },
+        },
+      });
+    } catch (cause) {
+      failure = cause;
+    }
+
+    expect(failure).toBeInstanceOf(ElizaError);
+    expect(isTrustedAgentBackupCaptureV2TerminalDisposition(failure)).toBe(false);
+    expect(failure).toMatchObject({
+      code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+      severity: "fatal",
+    });
+  });
+
+  it("brands concrete resolver staleness terminal only with exact partial-spool cleanup", async () => {
+    const directory = await stateDirectory();
+    const initial = attestation();
+    let authorityReads = 0;
+    const concreteResolver = createAgentBackupCaptureV3RuntimeContextResolver(
+      {
+        spool: inertContext(directory).spool,
+        keyBundle: keyBundle(),
+        runtime: initial.runtime,
+      },
+      {
+        async loadAuthority() {
+          return {
+            organizationId: ORGANIZATION_ID,
+            catalogAgentId: AGENT_ID,
+            runtimeAgentId: ++authorityReads === 1 ? RUNTIME_AGENT_ID : VAULT_KEY_GENERATION_ID,
+            activationGeneration: ACTIVATION_GENERATION,
+            lifecycleRevision: "7",
+            status: "running",
+            activationPhase: "active",
+            source: initial.source,
+            imageDigest: initial.runtime.imageDigest,
+            providerHandle: "agent-runtime-name",
+            bridgeUrl: "https://exact-agent.invalid/",
+            bridgePort: null,
+            headscaleIp: null,
+            nodeHostname: "cloud-node-9",
+            environmentVars: { ELIZA_API_TOKEN: "encrypted-token" },
+          };
+        },
+        async loadVaultAuthority() {
+          return {
+            kms: {
+              provider: "steward" as const,
+              keyId: `org:${ORGANIZATION_ID}/dek/v1`,
+              keyVersion: 1,
+            },
+            vaultKeyAuthority,
+          };
+        },
+        async decryptEnvironmentVars() {
+          return { ELIZA_API_TOKEN: "exact-agent-token" };
+        },
+        async authorizePublicUrl(rawUrl) {
+          return new URL(rawUrl);
+        },
+      },
+    );
+    const catalogRequest: AgentBackupCaptureV2Request = {
+      format: AGENT_BACKUP_CAPTURE_V2_REQUEST_FORMAT,
+      schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+      operationId: OPERATION_ID,
+      agentId: AGENT_ID,
+      activationGeneration: ACTIVATION_GENERATION,
+      lifecycleRevision: "7",
+      deadlineEpochMs: Date.now() + 60_000,
+    };
+    const concreteContext = await concreteResolver({
+      claim: claim(),
+      request: catalogRequest,
+      expectedSource: initial.source,
+      heartbeat: async () => true,
+    });
+    let brandedStale: unknown;
+    try {
+      await concreteContext.revalidateAttestation();
+    } catch (cause) {
+      brandedStale = cause;
+    }
+    expect(brandedStale).toMatchObject({
+      code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+    });
+    expect(normalizeAgentBackupCaptureV2TerminalFailure(brandedStale)).toBeUndefined();
+
+    let revalidations = 0;
+    let failure: unknown;
+    try {
+      await executeAgentBackupCaptureV2CatalogClaim({
+        claim: claim(),
+        leaseMs: 240_000,
+        dependencies: {
+          heartbeatOperation: async () => claim().backup,
+          loadManifestChainAuthority: async () => ({
+            kind: "full",
+            baseOperationId: null,
+            parentOperationId: null,
+            depth: 0,
+          }),
+          recordCaptured: async () => {
+            throw new Error("stale partial spool must not reach recordCaptured");
+          },
+          resolveContext: async () =>
+            inertContext(directory, {
+              async revalidateAttestation() {
+                revalidations += 1;
+                if (revalidations >= 3) throw brandedStale;
+                return structuredClone(initial);
+              },
+            }),
+        },
+      });
+    } catch (cause) {
+      failure = cause;
+    }
+
+    expect(isTrustedAgentBackupCaptureV2TerminalDisposition(failure)).toBe(true);
+    expect(failure).toMatchObject({
+      code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+      terminal: true,
+      terminalSpoolCleanup: {
+        runtimePrincipalSha256: deriveAgentBackupCaptureV3RuntimePrincipalSha256(RUNTIME_AGENT_ID),
+      },
+    });
+    const journal = JSON.parse(
+      await fs.promises.readFile(
+        path.join(directory, "agent-backup-capture-v3", OPERATION_ID, "journal.json"),
+        "utf8",
+      ),
+    ) as { recordCaptured: string; runtimePrincipalSha256: string };
+    expect(journal.recordCaptured).toBe("pending");
+    expect(journal.runtimePrincipalSha256).toBe(
+      deriveAgentBackupCaptureV3RuntimePrincipalSha256(RUNTIME_AGENT_ID),
+    );
+    await removeStateDirectory(directory);
   });
 
   it("attaches exact spool authority to a validated terminal Agent response", async () => {

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-catalog-executor.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-catalog-executor.ts
@@ -33,6 +33,7 @@ import {
   type AgentBackupCaptureV3CatalogManifest,
   type AgentBackupCaptureV3KeyBundleProvider,
   type AgentBackupCaptureV3ManifestAuthority,
+  deriveAgentBackupCaptureV3RuntimePrincipalSha256,
   deriveAgentBackupCaptureV3SpoolAuthorityDigests,
   runAgentBackupCaptureV2Pipeline,
 } from "./agent-backup-capture-v2-pipeline";
@@ -51,7 +52,10 @@ const LEGACY_WRITER_DRAIN_FORMAT =
 
 export interface AgentBackupCaptureV2RuntimeAttestation {
   organizationId: string;
-  agentId: string;
+  /** Durable `agent_sandboxes.id`; this is the only identity used below HTTP. */
+  catalogAgentId: string;
+  /** Runtime `character_id`; this is used only on the `/api/snapshot/v2` wire. */
+  runtimeAgentId: string;
   activationGeneration: string;
   lifecycleRevision: string;
   source: AgentBackupManifestV3["source"];
@@ -280,7 +284,8 @@ function assertAttestation(params: {
   const observed = params.attestation;
   if (
     observed.organizationId !== params.organizationId ||
-    observed.agentId !== params.request.agentId ||
+    observed.catalogAgentId !== params.request.agentId ||
+    !UUID_PATTERN.test(observed.runtimeAgentId) ||
     observed.activationGeneration !== params.request.activationGeneration ||
     observed.lifecycleRevision !== params.request.lifecycleRevision ||
     !isDeepStrictEqual(observed.source, params.expectedSource)
@@ -460,6 +465,16 @@ export async function executeAgentBackupCaptureV2CatalogClaim(
       expectedSource,
     });
     const initialAttestation = structuredClone(context.attestation);
+    // The catalogue request remains the sole durable manifest/KMS/spool
+    // authority. The agent runtime has a distinct character UUID and sees a
+    // wire-only copy, which cannot flow back into pipeline state.
+    const runtimeRequest: AgentBackupCaptureV2Request = {
+      ...request,
+      agentId: initialAttestation.runtimeAgentId,
+    };
+    const runtimePrincipalSha256 = deriveAgentBackupCaptureV3RuntimePrincipalSha256(
+      initialAttestation.runtimeAgentId,
+    );
     const heartbeat = async (): Promise<true> => {
       await heartbeatCatalog();
       const current = await control.await("Runtime attestation revalidation", () =>
@@ -504,6 +519,7 @@ export async function executeAgentBackupCaptureV2CatalogClaim(
       activationGeneration: request.activationGeneration,
       lifecycleRevision: request.lifecycleRevision,
       ...deriveAgentBackupCaptureV3SpoolAuthorityDigests({ request, authority }),
+      runtimePrincipalSha256,
     };
     const recordCaptured = input.dependencies.recordCaptured;
     let result: AgentBackupCaptureV2PipelineResult;
@@ -511,12 +527,13 @@ export async function executeAgentBackupCaptureV2CatalogClaim(
       result = await control.await("Capture-v2 pipeline", () =>
         runAgentBackupCaptureV2Pipeline({
           request,
+          runtimePrincipalSha256,
           executionToken: input.claim.generation,
           authority,
           openCapture: (signal) =>
             openAgentBackupCaptureV2({
               ...context.transport,
-              request,
+              request: runtimeRequest,
               signal,
               now,
             }),

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-failure-disposition.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-failure-disposition.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
+import {
+  createAgentBackupCaptureV2ExecutorError,
+  isTrustedAgentBackupCaptureV2TerminalDisposition,
+  normalizeAgentBackupCaptureV2TerminalFailure,
+} from "./agent-backup-capture-v2-failure-disposition";
+
+describe("capture-v2 failure disposition", () => {
+  test("generic executor factory cannot brand stale authority even with cleanup-shaped input", () => {
+    const generic = createAgentBackupCaptureV2ExecutorError(
+      "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+      "generic factory has no resolver provenance",
+    );
+    const normalized = normalizeAgentBackupCaptureV2TerminalFailure(generic, {
+      organizationId: "00000000-0000-4000-8000-000000000001",
+      agentId: "00000000-0000-4000-8000-000000000002",
+      backupId: "00000000-0000-4000-8000-000000000003",
+      operationId: "00000000-0000-4000-8000-000000000004",
+      activationGeneration: "00000000-0000-4000-8000-000000000005",
+      lifecycleRevision: "7",
+      requestSha256: "a".repeat(64),
+      authoritySha256: "b".repeat(64),
+      runtimePrincipalSha256: "c".repeat(64),
+    });
+
+    expect(generic.terminal).toBe(false);
+    expect(isTrustedAgentBackupCaptureV2TerminalDisposition(generic)).toBe(false);
+    expect(normalized).toBeUndefined();
+  });
+
+  test("does not trust a publicly constructible typed stale-authority failure", () => {
+    const normalized = normalizeAgentBackupCaptureV2TerminalFailure(
+      new ElizaError("Reserved source generation changed", {
+        code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+        severity: "fatal",
+      }),
+    );
+
+    expect(normalized).toBeUndefined();
+    expect(isTrustedAgentBackupCaptureV2TerminalDisposition(normalized)).toBe(false);
+  });
+
+  test("does not trust a plain error that forges the stale authority code", () => {
+    const forged = Object.assign(new Error("forged stale authority"), {
+      code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+      terminal: true,
+    });
+
+    expect(normalizeAgentBackupCaptureV2TerminalFailure(forged)).toBeUndefined();
+  });
+
+  test("requires fatal severity on the typed stale authority error", () => {
+    const retryable = new ElizaError("Authority lookup can be retried", {
+      code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+      severity: "ephemeral",
+    });
+
+    expect(normalizeAgentBackupCaptureV2TerminalFailure(retryable)).toBeUndefined();
+  });
+
+  test("does not make arbitrary typed runtime failures terminal", () => {
+    const unrelated = new ElizaError("Transient authority lookup failed", {
+      code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_UNAVAILABLE",
+      severity: "ephemeral",
+    });
+
+    expect(normalizeAgentBackupCaptureV2TerminalFailure(unrelated)).toBeUndefined();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-failure-disposition.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-failure-disposition.ts
@@ -9,6 +9,7 @@ import { AgentBackupCaptureV2ProtocolError } from "@elizaos/shared";
 import { AgentBackupCaptureV2HttpError } from "./agent-backup-capture-v2-client";
 import { AgentBackupCaptureV2PipelineError } from "./agent-backup-capture-v2-pipeline";
 import { AgentBackupCaptureV3SpoolError } from "./agent-backup-capture-v2-spool";
+import { isResolvedAgentBackupCaptureV3RuntimeAuthorityStale } from "./agent-backup-capture-v3-runtime-context";
 import type { AgentBackupCaptureV3TerminalSpoolCleanupAuthority } from "./agent-backup-capture-v3-spool-cleanup";
 
 const TERMINAL_CAPTURE_FAILURE_CODES = new Set([
@@ -175,6 +176,9 @@ function typedFailure(error: unknown): { code: string; message: string } | undef
   ) {
     return { code: error.code, message: error.message };
   }
+  if (isResolvedAgentBackupCaptureV3RuntimeAuthorityStale(error)) {
+    return { code: error.code, message: error.message };
+  }
   return undefined;
 }
 
@@ -199,6 +203,13 @@ export function normalizeAgentBackupCaptureV2TerminalFailure(
   terminalSpoolCleanup?: AgentBackupCaptureV3TerminalSpoolCleanupAuthority,
 ): AgentBackupCaptureV2CatalogExecutorError | undefined {
   if (isTrustedAgentBackupCaptureV2TerminalDisposition(error)) {
+    if (
+      error.code === "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE" &&
+      !error.terminalSpoolCleanup &&
+      !terminalSpoolCleanup
+    ) {
+      return undefined;
+    }
     if (terminalSpoolCleanup && !error.terminalSpoolCleanup) {
       return trustedTerminalDisposition({
         code: error.code,
@@ -219,7 +230,14 @@ export function normalizeAgentBackupCaptureV2TerminalFailure(
     seen.add(current);
 
     const failure = typedFailure(current);
-    if (failure && isTerminalAgentBackupCaptureV2FailureCode(failure.code)) {
+    const trustedRuntimeAuthorityStale =
+      failure?.code === "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE" &&
+      terminalSpoolCleanup !== undefined &&
+      isResolvedAgentBackupCaptureV3RuntimeAuthorityStale(current);
+    if (
+      failure &&
+      (isTerminalAgentBackupCaptureV2FailureCode(failure.code) || trustedRuntimeAuthorityStale)
+    ) {
       return trustedTerminalDisposition({
         ...failure,
         cause: error,

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-pipeline.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-pipeline.test.ts
@@ -25,6 +25,7 @@ import {
   type AgentBackupCaptureV3Artifacts,
   type AgentBackupCaptureV3KeyBundleProvider,
   type AgentBackupCaptureV3ManifestAuthority,
+  deriveAgentBackupCaptureV3RuntimePrincipalSha256,
   runAgentBackupCaptureV2Pipeline,
 } from "./agent-backup-capture-v2-pipeline";
 import {
@@ -43,6 +44,8 @@ const EXECUTION_TOKEN = "66666666-6666-4666-8666-666666666666";
 const NEXT_EXECUTION_TOKEN = "77777777-7777-4777-8777-777777777777";
 const TEST_BOOT_ID = "88888888-8888-4888-8888-888888888888";
 const VAULT_KEY_GENERATION_ID = "99999999-9999-4999-8999-999999999999";
+const RUNTIME_AGENT_A = "aaaaaaaa-1111-4111-8111-111111111111";
+const RUNTIME_AGENT_B = "bbbbbbbb-2222-4222-8222-222222222222";
 
 const request: AgentBackupCaptureV2Request = {
   format: "elizaos.agent-backup.capture-request",
@@ -272,6 +275,7 @@ function pipelineInput(
 ) {
   return {
     request,
+    runtimePrincipalSha256: "3".repeat(64),
     executionToken: EXECUTION_TOKEN,
     authority,
     openCapture() {
@@ -297,10 +301,72 @@ function directSpoolInput(executionToken: string) {
     executionToken,
     requestSha256: "1".repeat(64),
     authoritySha256: "2".repeat(64),
+    runtimePrincipalSha256: "3".repeat(64),
   };
 }
 
 describe("runAgentBackupCaptureV2Pipeline", () => {
+  it("fences a partial spool to its canonical runtime wire principal before replay appends", async () => {
+    const directory = await stateDirectory();
+    const probe = publicationProbe();
+    const openCount = { value: 0 };
+    const base = pipelineInput(directory, 2 * MIB, probe.boundary, openCount);
+    const principalA = deriveAgentBackupCaptureV3RuntimePrincipalSha256(RUNTIME_AGENT_A);
+    const principalB = deriveAgentBackupCaptureV3RuntimePrincipalSha256(RUNTIME_AGENT_B);
+    try {
+      await expect(
+        runAgentBackupCaptureV2Pipeline({
+          ...base,
+          runtimePrincipalSha256: principalA,
+          async *openCapture() {
+            openCount.value += 1;
+            for await (const capturedFrame of syntheticCapture(2 * MIB)) {
+              yield capturedFrame;
+              if (capturedFrame.header.kind === "component-end") {
+                throw new Error("synthetic partial capture after one durable component");
+              }
+            }
+          },
+        }),
+      ).rejects.toThrow("synthetic partial capture after one durable component");
+
+      const journalPath = path.join(
+        directory,
+        "agent-backup-capture-v3",
+        OPERATION_ID,
+        "journal.json",
+      );
+      const before = await fs.promises.readFile(journalPath, "utf8");
+      const journal = JSON.parse(before) as {
+        runtimePrincipalSha256: string;
+        chunks: unknown[];
+        recordCaptured: string;
+      };
+      expect(journal.runtimePrincipalSha256).toBe(principalA);
+      expect(journal.chunks.length).toBeGreaterThan(0);
+      expect(journal.recordCaptured).toBe("pending");
+
+      await expect(
+        runAgentBackupCaptureV2Pipeline({
+          ...base,
+          executionToken: NEXT_EXECUTION_TOKEN,
+          runtimePrincipalSha256: principalB,
+          openCapture() {
+            openCount.value += 1;
+            return syntheticCapture(2 * MIB);
+          },
+        }),
+      ).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V3_RUNTIME_PRINCIPAL_REPLAY_CONFLICT",
+      });
+      expect(openCount.value).toBe(1);
+      expect(probe.recordCalls).toHaveLength(0);
+      expect(await fs.promises.readFile(journalPath, "utf8")).toBe(before);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
   it("rejects incremental authority before opening capture or allocating a spool", async () => {
     const directory = await stateDirectory();
     const probe = publicationProbe();

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-pipeline.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-pipeline.ts
@@ -147,11 +147,22 @@ export type AgentBackupCaptureV2PublicationBoundary =
   | AgentBackupCaptureV2UploadBoundary;
 
 export interface RunAgentBackupCaptureV2PipelineInput {
+  /**
+   * Durable catalogue identity request. Its `agentId` binds manifest, spool,
+   * chunk AAD, and KMS contexts; it must never be replaced by a runtime
+   * character ID used to open the HTTP stream.
+   */
   request: AgentBackupCaptureV2Request;
+  /** SHA-256 of the canonical wire-only runtime principal authority. */
+  runtimePrincipalSha256: string;
   /** Durable job execution fence bound to exclusive spool ownership. */
   executionToken: string;
   authority: AgentBackupCaptureV3ManifestAuthority;
-  /** Opens a fresh authenticated HTTP framed stream for initial/partial replay. */
+  /**
+   * Opens a fresh authenticated HTTP framed stream for initial/partial replay.
+   * The transport may verify a distinct runtime character identity; returned
+   * frames are ingress data only and cannot redefine durable `request` authority.
+   */
   openCapture(signal?: AbortSignal): AsyncIterable<AgentBackupCaptureV2Frame>;
   spool: AgentBackupCaptureV3SpoolConfig;
   keyBundle: AgentBackupCaptureV3KeyBundleProvider;
@@ -324,6 +335,14 @@ export function canonicalAgentBackupCaptureV3CatalogManifestBytes(
 
 function digestCanonical(value: unknown): string {
   return sha256Hex(new TextEncoder().encode(canonicalJson(value)));
+}
+
+/** Fence a partial spool to the exact `/api/snapshot/v2` character principal. */
+export function deriveAgentBackupCaptureV3RuntimePrincipalSha256(runtimeAgentId: string): string {
+  return digestCanonical({
+    format: "elizaos.agent-backup.capture-v3-runtime-principal.v1",
+    runtimeAgentId,
+  });
 }
 
 /**
@@ -1774,6 +1793,7 @@ export async function runAgentBackupCaptureV2Pipeline(
     executionToken: input.executionToken,
     requestSha256,
     authoritySha256,
+    runtimePrincipalSha256: input.runtimePrincipalSha256,
   });
 
   try {

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-spool.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-spool.ts
@@ -112,6 +112,7 @@ const JournalSchema = z
     operationId: z.string().regex(UUID_PATTERN),
     requestSha256: z.string().regex(SHA256_PATTERN),
     authoritySha256: z.string().regex(SHA256_PATTERN),
+    runtimePrincipalSha256: z.string().regex(SHA256_PATTERN),
     phase: z.enum(["initialized", "capturing", "sealed", "publishing", "published"]),
     operationKeyBundle: OperationKeyBundleSchema.optional(),
     chunks: z.array(ChunkSchema).max(AGENT_BACKUP_MANIFEST_V2_LIMITS.maxChunks),
@@ -359,6 +360,11 @@ export interface OpenAgentBackupCaptureV3SpoolInput {
   executionToken: string;
   requestSha256: string;
   authoritySha256: string;
+  /**
+   * Canonical wire-principal digest. Required for capture/replay; publication
+   * may omit it only after the spool is sealed and can no longer append bytes.
+   */
+  runtimePrincipalSha256?: string;
 }
 
 export interface AgentBackupCaptureV3OperationKeyBundleMetadata {
@@ -394,6 +400,7 @@ export interface AgentBackupCaptureV3DurableOperationAuthority {
   operationId: string;
   requestSha256: string;
   authoritySha256: string;
+  runtimePrincipalSha256: string;
   phase: SpoolJournal["phase"];
   recordCaptured: boolean;
 }
@@ -1033,6 +1040,7 @@ export class AgentBackupCaptureV3Spool {
           operationId: journal.operationId,
           requestSha256: journal.requestSha256,
           authoritySha256: journal.authoritySha256,
+          runtimePrincipalSha256: journal.runtimePrincipalSha256,
           phase: journal.phase,
           recordCaptured: journal.recordCaptured === "confirmed",
         }),
@@ -1065,10 +1073,15 @@ export class AgentBackupCaptureV3Spool {
     if (!UUID_PATTERN.test(input.executionToken)) {
       spoolError("AGENT_BACKUP_V2_SPOOL_IDENTITY_INVALID", "executionToken must be canonical UUID");
     }
-    if (!SHA256_PATTERN.test(input.requestSha256) || !SHA256_PATTERN.test(input.authoritySha256)) {
+    if (
+      !SHA256_PATTERN.test(input.requestSha256) ||
+      !SHA256_PATTERN.test(input.authoritySha256) ||
+      (input.runtimePrincipalSha256 !== undefined &&
+        !SHA256_PATTERN.test(input.runtimePrincipalSha256))
+    ) {
       spoolError(
         "AGENT_BACKUP_V2_SPOOL_IDENTITY_INVALID",
-        "Spool request and authority digests must be SHA-256 hex",
+        "Spool request, authority, and runtime-principal digests must be SHA-256 hex",
       );
     }
 
@@ -1173,13 +1186,38 @@ export class AgentBackupCaptureV3Spool {
             "Backup operation spool belongs to different immutable authority",
           );
         }
+        if (
+          input.runtimePrincipalSha256 !== undefined &&
+          journal.runtimePrincipalSha256 !== input.runtimePrincipalSha256
+        ) {
+          spoolError(
+            "AGENT_BACKUP_V3_RUNTIME_PRINCIPAL_REPLAY_CONFLICT",
+            "Backup operation spool belongs to a different runtime wire principal",
+          );
+        }
+        if (
+          input.runtimePrincipalSha256 === undefined &&
+          (journal.phase === "initialized" || journal.phase === "capturing")
+        ) {
+          spoolError(
+            "AGENT_BACKUP_V3_RUNTIME_PRINCIPAL_REQUIRED",
+            "Append-capable backup spool replay requires its exact runtime wire principal",
+          );
+        }
       } else {
+        if (input.runtimePrincipalSha256 === undefined) {
+          spoolError(
+            "AGENT_BACKUP_V3_RUNTIME_PRINCIPAL_REQUIRED",
+            "Fresh backup spool capture requires an exact runtime wire principal",
+          );
+        }
         journal = {
           format: SPOOL_FORMAT,
           version: SPOOL_VERSION,
           operationId: input.operationId,
           requestSha256: input.requestSha256,
           authoritySha256: input.authoritySha256,
+          runtimePrincipalSha256: input.runtimePrincipalSha256,
           phase: "initialized",
           chunks: [],
           recordCaptured: "pending",

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-publication-source.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-publication-source.test.ts
@@ -216,6 +216,7 @@ async function capturedFixture(directory: string): Promise<AgentBackupCaptureV3A
   let captured: AgentBackupCaptureV3Artifacts | undefined;
   await runAgentBackupCaptureV2Pipeline({
     request,
+    runtimePrincipalSha256: "3".repeat(64),
     executionToken: CAPTURE_EXECUTION,
     authority,
     openCapture: () => captureFrames(),
@@ -408,6 +409,7 @@ describe("capture-v3 publication source", () => {
           activationGeneration: ACTIVATION_GENERATION,
           lifecycleRevision: "42",
           ...deriveAgentBackupCaptureV3SpoolAuthorityDigests({ request, authority }),
+          runtimePrincipalSha256: "3".repeat(64),
         },
         terminalErrorCode: "BACKUP_CAPTURE_V2_TERMINAL",
       });
@@ -471,6 +473,141 @@ describe("capture-v3 publication source", () => {
         execution: { ownerId: ownedClaim.ownerId, generation: ownedClaim.generation },
       });
       await source.close();
+    } finally {
+      await fs.promises.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("stops the cleanup janitor after abort during its first await without starting another action", async () => {
+    const directory = await stateDirectory();
+    const controller = new AbortController();
+    const reason = new Error("shutdown during spool discovery");
+    const actions: string[] = [];
+    let releaseDiscovery!: () => void;
+    let markDiscoveryStarted!: () => void;
+    const discoveryStarted = new Promise<void>((resolve) => {
+      markDiscoveryStarted = resolve;
+    });
+    const discoveryRelease = new Promise<void>((resolve) => {
+      releaseDiscovery = resolve;
+    });
+    try {
+      const janitor = createAgentBackupCaptureV3SpoolCleanupJanitor(
+        { spool: spoolConfig(directory), batchSize: 4 },
+        {
+          async listDurableOperations() {
+            actions.push("list-durable");
+            markDiscoveryStarted();
+            await discoveryRelease;
+            return [];
+          },
+          async listCandidates() {
+            actions.push("list-candidates");
+            return [];
+          },
+          async authorize() {
+            actions.push("authorize-protected");
+            throw new Error("aborted janitor must not authorize protected cleanup");
+          },
+          async authorizeTerminal() {
+            actions.push("authorize-terminal");
+            throw new Error("aborted janitor must not authorize terminal cleanup");
+          },
+          async deriveAuthority() {
+            actions.push("derive-authority");
+            throw new Error("aborted janitor must not derive another authority");
+          },
+          async openExisting() {
+            actions.push("open-cleanup");
+            return undefined;
+          },
+        },
+      );
+
+      const cycle = janitor.runCycle(controller.signal);
+      await discoveryStarted;
+      controller.abort(reason);
+      releaseDiscovery();
+
+      await expect(cycle).rejects.toBe(reason);
+      expect(actions).toEqual(["list-durable"]);
+      expect(await fs.promises.readdir(directory)).toEqual([]);
+    } finally {
+      await fs.promises.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("propagates abort during cleanup without starting a catch-path close", async () => {
+    const directory = await stateDirectory();
+    const controller = new AbortController();
+    const reason = new Error("shutdown during spool cleanup");
+    let releaseCleanup!: () => void;
+    let markCleanupStarted!: () => void;
+    const cleanupStarted = new Promise<void>((resolve) => {
+      markCleanupStarted = resolve;
+    });
+    const cleanupRelease = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    let cleanupCalls = 0;
+    let closeCalls = 0;
+    try {
+      const artifacts = await capturedFixture(directory);
+      const protectedBackup = {
+        ...claim(artifacts).backup,
+        catalog_state: "protected" as const,
+        catalog_lease_owner: null,
+        catalog_lease_generation: null,
+        catalog_lease_expires_at: null,
+        secondary_verified_at: new Date(NOW_MS),
+      };
+      const protectedAuthority =
+        await deriveAgentBackupCaptureV3SpoolAuthorityFromCatalogBackup(protectedBackup);
+      const janitor = createAgentBackupCaptureV3SpoolCleanupJanitor(
+        { spool: spoolConfig(directory), batchSize: 1 },
+        {
+          now: () => NOW_MS,
+          executionToken: () => RETRY_EXECUTION,
+          listDurableOperations: async () => [
+            {
+              operationId: protectedAuthority.operationId,
+              requestSha256: protectedAuthority.requestSha256,
+              authoritySha256: protectedAuthority.authoritySha256,
+              phase: "published",
+              recordCaptured: true,
+            },
+          ],
+          listCandidates: async () => [protectedBackup],
+          authorize: async () => protectedBackup,
+          openExisting: async () =>
+            ({
+              operationId: protectedAuthority.operationId,
+              phase: "published",
+              recordCaptured: true,
+              async cleanup() {
+                cleanupCalls += 1;
+                markCleanupStarted();
+                await cleanupRelease;
+                return { operationId: protectedAuthority.operationId, status: "pending" };
+              },
+              async close() {
+                closeCalls += 1;
+              },
+            }) as unknown as AgentBackupCaptureV3Spool,
+        },
+      );
+
+      const cycle = janitor.runCycle(controller.signal);
+      await cleanupStarted;
+      controller.abort(reason);
+      releaseCleanup();
+
+      await expect(cycle).rejects.toBe(reason);
+      expect(cleanupCalls).toBe(1);
+      expect(closeCalls).toBe(0);
+      expect(
+        await fs.promises.readdir(path.join(directory, "agent-backup-capture-v3-cleanup-outbox")),
+      ).toContain(`${OPERATION_ID}.json`);
     } finally {
       await fs.promises.rm(directory, { recursive: true, force: true });
     }
@@ -558,6 +695,7 @@ describe("capture-v3 publication source", () => {
     const directory = await stateDirectory();
     const pipelineInput = {
       request,
+      runtimePrincipalSha256: "3".repeat(64),
       authority,
       spool: spoolConfig(directory),
       keyBundle: new KmsAeadOperationKeyBundleProvider(
@@ -597,6 +735,7 @@ describe("capture-v3 publication source", () => {
         activationGeneration: ACTIVATION_GENERATION,
         lifecycleRevision: "42",
         ...deriveAgentBackupCaptureV3SpoolAuthorityDigests({ request, authority }),
+        runtimePrincipalSha256: "3".repeat(64),
       };
       const terminalBackup = {
         id: BACKUP_ID,

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-runtime-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-runtime-context.test.ts
@@ -1,10 +1,14 @@
 /** Exact runtime/vault authority tests for the production capture resolver. */
 
 import { describe, expect, mock, test } from "bun:test";
-import { createAgentBackupCaptureV3RuntimeContextResolver } from "./agent-backup-capture-v3-runtime-context";
+import {
+  createAgentBackupCaptureV3RuntimeContextResolver,
+  isResolvedAgentBackupCaptureV3RuntimeAuthorityStale,
+} from "./agent-backup-capture-v3-runtime-context";
 
 const ORGANIZATION_ID = "11111111-1111-4111-8111-111111111111";
-const AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const CATALOG_AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const RUNTIME_AGENT_ID = "77777777-7777-4777-8777-777777777777";
 const ACTIVATION_GENERATION = "33333333-3333-4333-8333-333333333333";
 const NODE_RECORD_ID = "44444444-4444-4444-8444-444444444444";
 const NODE_INCARCERATION = "55555555-5555-4555-8555-555555555555";
@@ -21,7 +25,8 @@ const source = {
 function authority() {
   return {
     organizationId: ORGANIZATION_ID,
-    agentId: AGENT_ID,
+    catalogAgentId: CATALOG_AGENT_ID,
+    runtimeAgentId: RUNTIME_AGENT_ID,
     activationGeneration: ACTIVATION_GENERATION,
     lifecycleRevision: "7",
     status: "running",
@@ -81,7 +86,7 @@ function resolver(overrides: Record<string, unknown> = {}) {
 function input(expectedSource = source) {
   return {
     claim: { backup: {} } as never,
-    request: {} as never,
+    request: { agentId: CATALOG_AGENT_ID } as never,
     expectedSource,
     heartbeat: mock(async () => true as const),
     signal: new AbortController().signal,
@@ -94,7 +99,8 @@ describe("manifest-v3 production runtime context", () => {
     const context = await resolve(input());
     expect(context.attestation).toMatchObject({
       organizationId: ORGANIZATION_ID,
-      agentId: AGENT_ID,
+      catalogAgentId: CATALOG_AGENT_ID,
+      runtimeAgentId: RUNTIME_AGENT_ID,
       activationGeneration: ACTIVATION_GENERATION,
       lifecycleRevision: "7",
       source,
@@ -114,6 +120,27 @@ describe("manifest-v3 production runtime context", () => {
     expect(await context.revalidateAttestation()).toEqual(context.attestation);
   });
 
+  test.each([
+    ["LF", "api-token\nshadow"],
+    ["TAB", "api-token\tshadow"],
+  ])("rejects %s in the decrypted API token without exposing its value", async (_label, token) => {
+    const resolve = resolver({
+      decryptEnvironmentVars: mock(async () => ({ ELIZA_API_TOKEN: token })),
+    });
+    let failure: unknown;
+    try {
+      await resolve(input());
+    } catch (cause) {
+      failure = cause;
+    }
+
+    expect(failure).toMatchObject({
+      code: "AGENT_BACKUP_V3_CAPTURE_TOKEN_INVALID",
+      message: "Capture API token is not canonical",
+    });
+    expect(String(failure)).not.toContain(token);
+  });
+
   test("rejects database authority that differs from the reserved source", async () => {
     const resolve = resolver();
     await expect(
@@ -126,10 +153,112 @@ describe("manifest-v3 production runtime context", () => {
     ).rejects.toMatchObject({ code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_MISMATCH" });
   });
 
+  test("uses the bridge_url container port for a Headscale route, never bridge_port", async () => {
+    const resolve = resolver({
+      loadAuthority: mock(async () => ({
+        ...authority(),
+        bridgeUrl: "http://100.64.0.21:3000",
+        bridgePort: 18_888,
+        headscaleIp: "100.64.0.21",
+      })),
+    });
+    const context = await resolve(input());
+    expect(context.transport.agentApiBaseUrl).toBe("http://100.64.0.21:3000/");
+  });
+
+  test.each(["not a url", "http://100.64.0.21", "http://100.64.0.21/path:3000"])(
+    "fails closed for malformed or portless Headscale bridge_url %s",
+    async (bridgeUrl) => {
+      const resolve = resolver({
+        loadAuthority: mock(async () => ({
+          ...authority(),
+          bridgeUrl,
+          bridgePort: 18_888,
+          headscaleIp: "100.64.0.21",
+        })),
+      });
+      await expect(resolve(input())).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V3_CAPTURE_ROUTE_INVALID",
+      });
+    },
+  );
+
+  test("fails closed for a malformed Headscale address instead of using bridge_port", async () => {
+    const resolve = resolver({
+      loadAuthority: mock(async () => ({
+        ...authority(),
+        bridgeUrl: "http://100.64.0.21:3000",
+        bridgePort: 18_888,
+        headscaleIp: "100.64.0.21.evil",
+      })),
+    });
+    await expect(resolve(input())).rejects.toMatchObject({
+      code: "AGENT_BACKUP_V3_CAPTURE_ROUTE_INVALID",
+    });
+  });
+
+  test("uses the explicit node host fallback only when Headscale is absent", async () => {
+    const resolve = resolver({
+      loadAuthority: mock(async () => ({
+        ...authority(),
+        bridgeUrl: null,
+        bridgePort: 18_888,
+        headscaleIp: null,
+      })),
+    });
+    const context = await resolve(input());
+    expect(context.transport.agentApiBaseUrl).toBe("http://robot-01.example.test:18888/");
+  });
+
+  test("fails before vault or transport resolution without a runtime character identity", async () => {
+    const loadVaultAuthority = mock(async () => vault());
+    const resolve = resolver({
+      loadAuthority: mock(async () => ({ ...authority(), runtimeAgentId: null })),
+      loadVaultAuthority,
+    });
+    await expect(resolve(input())).rejects.toMatchObject({
+      code: "AGENT_BACKUP_V3_RUNTIME_IDENTITY_INVALID",
+    });
+    expect(loadVaultAuthority).not.toHaveBeenCalled();
+  });
+
+  test("fails when durable catalogue identity differs from the claim request", async () => {
+    const resolve = resolver({
+      loadAuthority: mock(async () => ({
+        ...authority(),
+        catalogAgentId: RUNTIME_AGENT_ID,
+      })),
+    });
+    await expect(resolve(input())).rejects.toMatchObject({
+      code: "AGENT_BACKUP_V3_RUNTIME_IDENTITY_INVALID",
+    });
+  });
+
+  test("fails revalidation when the runtime character identity changes", async () => {
+    let reads = 0;
+    const resolve = resolver({
+      loadAuthority: mock(async () => ({
+        ...authority(),
+        runtimeAgentId: ++reads === 1 ? RUNTIME_AGENT_ID : VAULT_GENERATION,
+      })),
+    });
+    const context = await resolve(input());
+    let failure: unknown;
+    try {
+      await context.revalidateAttestation();
+    } catch (cause) {
+      failure = cause;
+    }
+    expect(failure).toMatchObject({ code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE" });
+    expect(isResolvedAgentBackupCaptureV3RuntimeAuthorityStale(failure)).toBe(true);
+  });
+
   test("fails revalidation when the current vault generation rotates", async () => {
     let reads = 0;
     const resolve = resolver({
-      loadVaultAuthority: mock(async () => vault(++reads === 1 ? VAULT_GENERATION : AGENT_ID)),
+      loadVaultAuthority: mock(async () =>
+        vault(++reads === 1 ? VAULT_GENERATION : CATALOG_AGENT_ID),
+      ),
     });
     const context = await resolve(input());
     await expect(context.revalidateAttestation()).rejects.toMatchObject({

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-runtime-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-runtime-context.test.ts
@@ -1,0 +1,148 @@
+/** Exact runtime/vault authority tests for the production capture resolver. */
+
+import { describe, expect, mock, test } from "bun:test";
+import { createAgentBackupCaptureV3RuntimeContextResolver } from "./agent-backup-capture-v3-runtime-context";
+
+const ORGANIZATION_ID = "11111111-1111-4111-8111-111111111111";
+const AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const ACTIVATION_GENERATION = "33333333-3333-4333-8333-333333333333";
+const NODE_RECORD_ID = "44444444-4444-4444-8444-444444444444";
+const NODE_INCARCERATION = "55555555-5555-4555-8555-555555555555";
+const VAULT_GENERATION = "66666666-6666-4666-8666-666666666666";
+const source = {
+  kind: "robot" as const,
+  provider: "hetzner" as const,
+  nodeRecordId: NODE_RECORD_ID,
+  nodeId: "robot-01",
+  nodeIncarnation: NODE_INCARCERATION,
+  containerId: "a".repeat(64),
+};
+
+function authority() {
+  return {
+    organizationId: ORGANIZATION_ID,
+    agentId: AGENT_ID,
+    activationGeneration: ACTIVATION_GENERATION,
+    lifecycleRevision: "7",
+    status: "running",
+    activationPhase: "active",
+    source,
+    imageDigest: `sha256:${"b".repeat(64)}`,
+    providerHandle: "agent-provider-handle",
+    bridgeUrl: "https://agent.example.test/",
+    bridgePort: null,
+    headscaleIp: null,
+    nodeHostname: "robot-01.example.test",
+    environmentVars: { ELIZA_API_TOKEN: "stored-token" },
+  };
+}
+
+function vault(generationId = VAULT_GENERATION) {
+  return {
+    vaultKeyAuthority: {
+      format: "kms-aead-vault-passphrase-v1" as const,
+      generationId,
+      receiptDerivation: "elizaos.agent-vault-key.authority-receipt.v1" as const,
+      receiptDigest: "c".repeat(64),
+    },
+    kms: {
+      provider: "steward" as const,
+      keyId: `org:${ORGANIZATION_ID}/dek/v1`,
+      keyVersion: 1,
+    },
+  };
+}
+
+function resolver(overrides: Record<string, unknown> = {}) {
+  return createAgentBackupCaptureV3RuntimeContextResolver(
+    {
+      spool: {
+        stateDirectory: "/var/lib/eliza-backup-catalog/spool",
+        maxSpoolBytes: 1024 ** 3,
+        minFreeBytes: 1024,
+      },
+      keyBundle: { kind: "shared-key-bundle" } as never,
+      runtime: {
+        agentSchemaVersion: "2.0.0",
+        databaseSchemaVersion: "238",
+        plugins: [{ id: "@elizaos/plugin-sql", version: "2.0.0" }],
+      },
+    },
+    {
+      loadAuthority: mock(async () => authority()),
+      loadVaultAuthority: mock(async () => vault()),
+      decryptEnvironmentVars: mock(async () => ({ ELIZA_API_TOKEN: "api-token" })),
+      authorizePublicUrl: mock(async (value: string) => new URL(value)),
+      ...overrides,
+    } as never,
+  );
+}
+
+function input(expectedSource = source) {
+  return {
+    claim: { backup: {} } as never,
+    request: {} as never,
+    expectedSource,
+    heartbeat: mock(async () => true as const),
+    signal: new AbortController().signal,
+  };
+}
+
+describe("manifest-v3 production runtime context", () => {
+  test("binds exact DB source/runtime, shared spool/KMS and authenticated route", async () => {
+    const resolve = resolver();
+    const context = await resolve(input());
+    expect(context.attestation).toMatchObject({
+      organizationId: ORGANIZATION_ID,
+      agentId: AGENT_ID,
+      activationGeneration: ACTIVATION_GENERATION,
+      lifecycleRevision: "7",
+      source,
+      runtime: {
+        imageDigest: `sha256:${"b".repeat(64)}`,
+        agentSchemaVersion: "2.0.0",
+        databaseSchemaVersion: "238",
+      },
+      watermarks: [{ namespace: "control-plane.lifecycle-revision", value: "7" }],
+    });
+    expect(context.transport).toMatchObject({
+      agentApiBaseUrl: "https://agent.example.test/",
+      apiToken: "api-token",
+    });
+    expect(context.kms).toEqual(vault().kms);
+    expect(context.vaultKeyAuthority).toEqual(vault().vaultKeyAuthority);
+    expect(await context.revalidateAttestation()).toEqual(context.attestation);
+  });
+
+  test("rejects database authority that differs from the reserved source", async () => {
+    const resolve = resolver();
+    await expect(
+      resolve(
+        input({
+          ...source,
+          nodeId: "other-node",
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_MISMATCH" });
+  });
+
+  test("fails revalidation when the current vault generation rotates", async () => {
+    let reads = 0;
+    const resolve = resolver({
+      loadVaultAuthority: mock(async () => vault(++reads === 1 ? VAULT_GENERATION : AGENT_ID)),
+    });
+    const context = await resolve(input());
+    await expect(context.revalidateAttestation()).rejects.toMatchObject({
+      code: "AGENT_BACKUP_V3_VAULT_AUTHORITY_CHANGED",
+    });
+  });
+
+  test("propagates caller cancellation before any authority read", async () => {
+    const loadAuthority = mock(async () => authority());
+    const resolve = resolver({ loadAuthority });
+    const controller = new AbortController();
+    controller.abort(new Error("shutdown"));
+    await expect(resolve({ ...input(), signal: controller.signal })).rejects.toThrow("shutdown");
+    expect(loadAuthority).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-runtime-context.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-runtime-context.ts
@@ -1,0 +1,381 @@
+/**
+ * Resolves the independently revalidatable production authority used by the
+ * manifest-v3 capture executor. Every value comes from the exact reserved
+ * sandbox/node/vault generation; no provider enrollment or activation writer
+ * lives in this module.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import type { AgentBackupManifestV3 } from "@elizaos/shared";
+import { and, eq, sql } from "drizzle-orm";
+import { dbWrite } from "../../db/helpers";
+import type { AgentBackupOperationClaim } from "../../db/repositories/agent-backup-catalog";
+import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import { dockerNodes } from "../../db/schemas/docker-nodes";
+import { assertSafeOutboundUrl } from "../security/outbound-url";
+import type {
+  AgentBackupCaptureV2CatalogExecutionContext,
+  AgentBackupCaptureV2RuntimeAttestation,
+  ResolveAgentBackupCaptureV2CatalogExecutionContext,
+} from "./agent-backup-capture-v2-catalog-executor";
+import type { AgentBackupCaptureV3KeyBundleProvider } from "./agent-backup-capture-v2-pipeline";
+import type { AgentBackupCaptureV3SpoolConfig } from "./agent-backup-capture-v2-spool";
+import { loadAgentBackupCaptureV3VaultAuthority } from "./agent-backup-capture-v3-vault-authority";
+import { decryptAgentEnvVars } from "./agent-env-crypto";
+
+const API_TOKEN_NAMES = ["ELIZA_API_TOKEN", "ELIZAOS_API_KEY", "ELIZAOS_CLOUD_API_KEY"] as const;
+const SHA256_IMAGE_PATTERN = /^sha256:[0-9a-f]{64}$/;
+
+export interface AgentBackupCaptureV3RuntimeMetadata {
+  agentSchemaVersion: string;
+  databaseSchemaVersion: string;
+  plugins: readonly { id: string; version: string }[];
+}
+
+export interface AgentBackupCaptureV3RuntimeAuthority {
+  organizationId: string;
+  agentId: string;
+  activationGeneration: string;
+  lifecycleRevision: string;
+  status: string;
+  activationPhase: string | null;
+  source: AgentBackupManifestV3["source"];
+  imageDigest: string;
+  providerHandle: string;
+  bridgeUrl: string | null;
+  bridgePort: number | null;
+  headscaleIp: string | null;
+  nodeHostname: string;
+  environmentVars: Record<string, string>;
+}
+
+export interface AgentBackupCaptureV3RuntimeContextDependencies {
+  loadAuthority(input: {
+    claim: Readonly<AgentBackupOperationClaim>;
+    signal?: AbortSignal;
+  }): Promise<AgentBackupCaptureV3RuntimeAuthority>;
+  loadVaultAuthority: typeof loadAgentBackupCaptureV3VaultAuthority;
+  decryptEnvironmentVars: typeof decryptAgentEnvVars;
+  authorizePublicUrl(rawUrl: string): Promise<URL>;
+}
+
+export interface AgentBackupCaptureV3RuntimeContextConfig {
+  spool: Readonly<AgentBackupCaptureV3SpoolConfig>;
+  keyBundle: AgentBackupCaptureV3KeyBundleProvider;
+  runtime: Readonly<AgentBackupCaptureV3RuntimeMetadata>;
+}
+
+function contextError(code: string, message: string, cause?: unknown): never {
+  throw new ElizaError(message, { code, cause, severity: "fatal" });
+}
+
+function requireClaimIdentity(claim: Readonly<AgentBackupOperationClaim>): {
+  organizationId: string;
+  agentId: string;
+  sandboxRecordId: string;
+  activationGeneration: string;
+  lifecycleRevision: string;
+  providerHandle: string;
+} {
+  const backup = claim.backup;
+  if (
+    !backup.catalog_organization_id ||
+    !backup.catalog_agent_id ||
+    !backup.sandbox_record_id ||
+    !backup.lifecycle_generation ||
+    backup.lifecycle_revision === null ||
+    !backup.source_provider_handle
+  ) {
+    contextError(
+      "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_INCOMPLETE",
+      "Capture claim is missing its exact sandbox runtime authority",
+    );
+  }
+  return {
+    organizationId: backup.catalog_organization_id,
+    agentId: backup.catalog_agent_id,
+    sandboxRecordId: backup.sandbox_record_id,
+    activationGeneration: backup.lifecycle_generation,
+    lifecycleRevision: backup.lifecycle_revision.toString(),
+    providerHandle: backup.source_provider_handle,
+  };
+}
+
+async function loadRuntimeAuthority(input: {
+  claim: Readonly<AgentBackupOperationClaim>;
+  signal?: AbortSignal;
+}): Promise<AgentBackupCaptureV3RuntimeAuthority> {
+  input.signal?.throwIfAborted();
+  const identity = requireClaimIdentity(input.claim);
+  const sourceRecordId = input.claim.backup.source_node_record_id;
+  if (!sourceRecordId) {
+    contextError(
+      "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_INCOMPLETE",
+      "Capture claim is missing its exact node record authority",
+    );
+  }
+  const [row] = await dbWrite
+    .select({
+      organizationId: agentSandboxes.organization_id,
+      agentId: agentSandboxes.id,
+      status: agentSandboxes.status,
+      activationGeneration: agentSandboxes.activation_generation,
+      activationLifecycleRevision: sql<
+        string | null
+      >`${agentSandboxes.activation_lifecycle_revision}::text`,
+      lifecycleRevision: sql<string>`${agentSandboxes.lifecycle_revision}::text`,
+      activationPhase: agentSandboxes.activation_phase,
+      activationContainerId: agentSandboxes.activation_container_id,
+      activationNodeId: agentSandboxes.activation_node_id,
+      activationImageDigest: agentSandboxes.activation_image_digest,
+      providerHandle: agentSandboxes.sandbox_id,
+      bridgeUrl: agentSandboxes.bridge_url,
+      bridgePort: agentSandboxes.bridge_port,
+      headscaleIp: agentSandboxes.headscale_ip,
+      environmentVars: agentSandboxes.environment_vars,
+      nodeRecordId: dockerNodes.id,
+      nodeId: dockerNodes.node_id,
+      nodeHostname: dockerNodes.hostname,
+      fleetKind: dockerNodes.fleet_kind,
+      infrastructureProvider: dockerNodes.infrastructure_provider,
+      providerServerId: dockerNodes.provider_server_id,
+      nodeIncarnation: dockerNodes.node_incarnation,
+    })
+    .from(agentSandboxes)
+    .innerJoin(
+      dockerNodes,
+      and(eq(dockerNodes.id, sourceRecordId), eq(dockerNodes.node_id, agentSandboxes.node_id)),
+    )
+    .where(
+      and(
+        eq(agentSandboxes.id, identity.sandboxRecordId),
+        eq(agentSandboxes.organization_id, identity.organizationId),
+      ),
+    )
+    .limit(1);
+  input.signal?.throwIfAborted();
+  if (
+    !row ||
+    row.agentId !== identity.agentId ||
+    row.status !== "running" ||
+    row.activationPhase !== "active" ||
+    row.activationGeneration !== identity.activationGeneration ||
+    row.activationLifecycleRevision !== identity.lifecycleRevision ||
+    row.lifecycleRevision !== identity.lifecycleRevision ||
+    !row.activationContainerId ||
+    !row.activationNodeId ||
+    !row.activationImageDigest ||
+    !row.providerHandle ||
+    !row.nodeIncarnation ||
+    row.infrastructureProvider !== "hetzner" ||
+    (row.fleetKind !== "robot" && row.fleetKind !== "cloud")
+  ) {
+    contextError(
+      "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+      "Reserved capture source is no longer the exact active sandbox generation",
+    );
+  }
+  if (
+    row.providerHandle !== identity.providerHandle ||
+    !SHA256_IMAGE_PATTERN.test(row.activationImageDigest)
+  ) {
+    contextError(
+      "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+      "Reserved capture provider handle or image authority changed",
+    );
+  }
+  const source: AgentBackupManifestV3["source"] =
+    row.fleetKind === "robot"
+      ? {
+          kind: "robot",
+          provider: "hetzner",
+          nodeRecordId: row.nodeRecordId,
+          nodeId: row.activationNodeId,
+          nodeIncarnation: row.nodeIncarnation,
+          containerId: row.activationContainerId,
+        }
+      : row.providerServerId
+        ? {
+            kind: "cloud",
+            provider: "hetzner",
+            nodeRecordId: row.nodeRecordId,
+            nodeId: row.activationNodeId,
+            nodeIncarnation: row.nodeIncarnation,
+            containerId: row.activationContainerId,
+            providerServerId: row.providerServerId,
+          }
+        : contextError(
+            "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+            "Cloud capture source lost its provider server authority",
+          );
+  return {
+    organizationId: row.organizationId,
+    agentId: row.agentId,
+    activationGeneration: row.activationGeneration,
+    lifecycleRevision: row.lifecycleRevision,
+    status: row.status,
+    activationPhase: row.activationPhase,
+    source,
+    imageDigest: row.activationImageDigest,
+    providerHandle: row.providerHandle,
+    bridgeUrl: row.bridgeUrl,
+    bridgePort: row.bridgePort,
+    headscaleIp: row.headscaleIp,
+    nodeHostname: row.nodeHostname,
+    environmentVars: row.environmentVars,
+  };
+}
+
+const DEFAULT_DEPENDENCIES: AgentBackupCaptureV3RuntimeContextDependencies = {
+  loadAuthority: loadRuntimeAuthority,
+  loadVaultAuthority: loadAgentBackupCaptureV3VaultAuthority,
+  decryptEnvironmentVars: decryptAgentEnvVars,
+  authorizePublicUrl: assertSafeOutboundUrl,
+};
+
+function sameSource(
+  left: Readonly<AgentBackupManifestV3["source"]>,
+  right: Readonly<AgentBackupManifestV3["source"]>,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function buildAttestation(
+  authority: Readonly<AgentBackupCaptureV3RuntimeAuthority>,
+  runtime: Readonly<AgentBackupCaptureV3RuntimeMetadata>,
+): AgentBackupCaptureV2RuntimeAttestation {
+  return {
+    organizationId: authority.organizationId,
+    agentId: authority.agentId,
+    activationGeneration: authority.activationGeneration,
+    lifecycleRevision: authority.lifecycleRevision,
+    source: authority.source,
+    runtime: {
+      imageDigest: authority.imageDigest,
+      agentSchemaVersion: runtime.agentSchemaVersion,
+      databaseSchemaVersion: runtime.databaseSchemaVersion,
+      plugins: runtime.plugins.map((plugin) => ({ ...plugin })),
+    },
+    watermarks: [
+      { namespace: "control-plane.lifecycle-revision", value: authority.lifecycleRevision },
+    ],
+  };
+}
+
+async function resolveAgentApiBaseUrl(
+  authority: Readonly<AgentBackupCaptureV3RuntimeAuthority>,
+  dependencies: Readonly<AgentBackupCaptureV3RuntimeContextDependencies>,
+): Promise<string> {
+  if (authority.bridgePort && authority.bridgePort > 0 && authority.bridgePort <= 65_535) {
+    const host = authority.headscaleIp || authority.nodeHostname;
+    if (host && /^[A-Za-z0-9][A-Za-z0-9.:-]{0,253}$/.test(host)) {
+      const bracketed = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+      return new URL(`http://${bracketed}:${authority.bridgePort}/`).toString();
+    }
+  }
+  if (!authority.bridgeUrl) {
+    contextError(
+      "AGENT_BACKUP_V3_CAPTURE_ROUTE_MISSING",
+      "Exact capture source has no authorized bridge route",
+    );
+  }
+  let candidate: URL;
+  try {
+    candidate = new URL(authority.bridgeUrl);
+  } catch (cause) {
+    contextError(
+      "AGENT_BACKUP_V3_CAPTURE_ROUTE_INVALID",
+      "Capture bridge route is malformed",
+      cause,
+    );
+  }
+  if (candidate.username || candidate.password || candidate.search || candidate.hash) {
+    contextError(
+      "AGENT_BACKUP_V3_CAPTURE_ROUTE_INVALID",
+      "Capture bridge route contains unsupported URL authority",
+    );
+  }
+  return (await dependencies.authorizePublicUrl(candidate.toString())).toString();
+}
+
+async function resolveApiToken(
+  authority: Readonly<AgentBackupCaptureV3RuntimeAuthority>,
+  dependencies: Readonly<AgentBackupCaptureV3RuntimeContextDependencies>,
+): Promise<string> {
+  for (const name of API_TOKEN_NAMES) {
+    const stored = authority.environmentVars[name];
+    if (typeof stored !== "string" || stored.length === 0) continue;
+    const materialized = await dependencies.decryptEnvironmentVars({ [name]: stored });
+    const token = materialized[name];
+    if (
+      !token ||
+      token !== token.trim() ||
+      token.includes("\0") ||
+      Buffer.byteLength(token, "utf8") > 16 * 1024
+    ) {
+      contextError("AGENT_BACKUP_V3_CAPTURE_TOKEN_INVALID", "Capture API token is not canonical");
+    }
+    return token;
+  }
+  contextError("AGENT_BACKUP_V3_CAPTURE_TOKEN_MISSING", "Exact capture source has no API token");
+}
+
+/** Bind the production runtime resolver once to the shared spool/KMS authority. */
+export function createAgentBackupCaptureV3RuntimeContextResolver(
+  config: Readonly<AgentBackupCaptureV3RuntimeContextConfig>,
+  dependencyOverrides: Partial<AgentBackupCaptureV3RuntimeContextDependencies> = {},
+): ResolveAgentBackupCaptureV2CatalogExecutionContext {
+  const dependencies = { ...DEFAULT_DEPENDENCIES, ...dependencyOverrides };
+  return async (input): Promise<AgentBackupCaptureV2CatalogExecutionContext> => {
+    input.signal?.throwIfAborted();
+    const authority = await dependencies.loadAuthority({
+      claim: input.claim,
+      signal: input.signal,
+    });
+    if (!sameSource(authority.source, input.expectedSource)) {
+      contextError(
+        "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_MISMATCH",
+        "Database runtime authority differs from the reserved capture source",
+      );
+    }
+    await input.heartbeat();
+    const vault = await dependencies.loadVaultAuthority({
+      organizationId: authority.organizationId,
+      agentId: authority.agentId,
+      sourceActivationGeneration: authority.activationGeneration,
+    });
+    input.signal?.throwIfAborted();
+    const attestation = buildAttestation(authority, config.runtime);
+    const agentApiBaseUrl = await resolveAgentApiBaseUrl(authority, dependencies);
+    const apiToken = await resolveApiToken(authority, dependencies);
+    return {
+      attestation,
+      async revalidateAttestation(signal) {
+        signal?.throwIfAborted();
+        const current = await dependencies.loadAuthority({ claim: input.claim, signal });
+        const currentVault = await dependencies.loadVaultAuthority({
+          organizationId: current.organizationId,
+          agentId: current.agentId,
+          sourceActivationGeneration: current.activationGeneration,
+        });
+        if (
+          currentVault.vaultKeyAuthority.generationId !== vault.vaultKeyAuthority.generationId ||
+          currentVault.vaultKeyAuthority.receiptDigest !== vault.vaultKeyAuthority.receiptDigest ||
+          currentVault.kms.keyId !== vault.kms.keyId ||
+          currentVault.kms.keyVersion !== vault.kms.keyVersion
+        ) {
+          contextError(
+            "AGENT_BACKUP_V3_VAULT_AUTHORITY_CHANGED",
+            "Vault/KMS authority changed while capture held the catalogue lease",
+          );
+        }
+        return buildAttestation(current, config.runtime);
+      },
+      transport: { agentApiBaseUrl, apiToken },
+      spool: config.spool,
+      keyBundle: config.keyBundle,
+      kms: vault.kms,
+      vaultKeyAuthority: vault.vaultKeyAuthority,
+    };
+  };
+}

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-runtime-context.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-runtime-context.ts
@@ -5,6 +5,7 @@
  * lives in this module.
  */
 
+import { isIP } from "node:net";
 import { ElizaError } from "@elizaos/core";
 import type { AgentBackupManifestV3 } from "@elizaos/shared";
 import { and, eq, sql } from "drizzle-orm";
@@ -25,6 +26,27 @@ import { decryptAgentEnvVars } from "./agent-env-crypto";
 
 const API_TOKEN_NAMES = ["ELIZA_API_TOKEN", "ELIZAOS_API_KEY", "ELIZAOS_CLOUD_API_KEY"] as const;
 const SHA256_IMAGE_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const RESOLVED_RUNTIME_AUTHORITY_STALE_FAILURES = new WeakSet<ElizaError>();
+
+/**
+ * Only this database-backed resolver may mint stale-authority evidence. An
+ * injected resolver can throw an identically shaped ElizaError, but it cannot
+ * authorize irreversible catalogue settlement.
+ */
+export function isResolvedAgentBackupCaptureV3RuntimeAuthorityStale(
+  error: unknown,
+): error is ElizaError & {
+  code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE";
+  severity: "fatal";
+} {
+  return (
+    error instanceof ElizaError &&
+    error.code === "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE" &&
+    error.severity === "fatal" &&
+    RESOLVED_RUNTIME_AUTHORITY_STALE_FAILURES.has(error)
+  );
+}
 
 export interface AgentBackupCaptureV3RuntimeMetadata {
   agentSchemaVersion: string;
@@ -34,7 +56,10 @@ export interface AgentBackupCaptureV3RuntimeMetadata {
 
 export interface AgentBackupCaptureV3RuntimeAuthority {
   organizationId: string;
-  agentId: string;
+  /** Durable `agent_sandboxes.id` used by the backup catalogue. */
+  catalogAgentId: string;
+  /** Runtime `agent_sandboxes.character_id` accepted by `/api/snapshot/v2`. */
+  runtimeAgentId: string;
   activationGeneration: string;
   lifecycleRevision: string;
   status: string;
@@ -67,6 +92,16 @@ export interface AgentBackupCaptureV3RuntimeContextConfig {
 
 function contextError(code: string, message: string, cause?: unknown): never {
   throw new ElizaError(message, { code, cause, severity: "fatal" });
+}
+
+function resolvedRuntimeAuthorityStale(message: string, cause?: unknown): never {
+  const error = new ElizaError(message, {
+    code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+    cause,
+    severity: "fatal",
+  });
+  RESOLVED_RUNTIME_AUTHORITY_STALE_FAILURES.add(error);
+  throw error;
 }
 
 function requireClaimIdentity(claim: Readonly<AgentBackupOperationClaim>): {
@@ -117,7 +152,8 @@ async function loadRuntimeAuthority(input: {
   const [row] = await dbWrite
     .select({
       organizationId: agentSandboxes.organization_id,
-      agentId: agentSandboxes.id,
+      catalogAgentId: agentSandboxes.id,
+      runtimeAgentId: agentSandboxes.character_id,
       status: agentSandboxes.status,
       activationGeneration: agentSandboxes.activation_generation,
       activationLifecycleRevision: sql<
@@ -156,7 +192,7 @@ async function loadRuntimeAuthority(input: {
   input.signal?.throwIfAborted();
   if (
     !row ||
-    row.agentId !== identity.agentId ||
+    row.catalogAgentId !== identity.agentId ||
     row.status !== "running" ||
     row.activationPhase !== "active" ||
     row.activationGeneration !== identity.activationGeneration ||
@@ -170,19 +206,21 @@ async function loadRuntimeAuthority(input: {
     row.infrastructureProvider !== "hetzner" ||
     (row.fleetKind !== "robot" && row.fleetKind !== "cloud")
   ) {
-    contextError(
-      "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+    resolvedRuntimeAuthorityStale(
       "Reserved capture source is no longer the exact active sandbox generation",
+    );
+  }
+  if (!row.runtimeAgentId) {
+    contextError(
+      "AGENT_BACKUP_V3_RUNTIME_IDENTITY_MISSING",
+      "Exact active sandbox has no runtime character identity",
     );
   }
   if (
     row.providerHandle !== identity.providerHandle ||
     !SHA256_IMAGE_PATTERN.test(row.activationImageDigest)
   ) {
-    contextError(
-      "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
-      "Reserved capture provider handle or image authority changed",
-    );
+    resolvedRuntimeAuthorityStale("Reserved capture provider handle or image authority changed");
   }
   const source: AgentBackupManifestV3["source"] =
     row.fleetKind === "robot"
@@ -204,13 +242,11 @@ async function loadRuntimeAuthority(input: {
             containerId: row.activationContainerId,
             providerServerId: row.providerServerId,
           }
-        : contextError(
-            "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
-            "Cloud capture source lost its provider server authority",
-          );
+        : resolvedRuntimeAuthorityStale("Cloud capture source lost its provider server authority");
   return {
     organizationId: row.organizationId,
-    agentId: row.agentId,
+    catalogAgentId: row.catalogAgentId,
+    runtimeAgentId: row.runtimeAgentId,
     activationGeneration: row.activationGeneration,
     lifecycleRevision: row.lifecycleRevision,
     status: row.status,
@@ -246,7 +282,8 @@ function buildAttestation(
 ): AgentBackupCaptureV2RuntimeAttestation {
   return {
     organizationId: authority.organizationId,
-    agentId: authority.agentId,
+    catalogAgentId: authority.catalogAgentId,
+    runtimeAgentId: authority.runtimeAgentId,
     activationGeneration: authority.activationGeneration,
     lifecycleRevision: authority.lifecycleRevision,
     source: authority.source,
@@ -266,12 +303,57 @@ async function resolveAgentApiBaseUrl(
   authority: Readonly<AgentBackupCaptureV3RuntimeAuthority>,
   dependencies: Readonly<AgentBackupCaptureV3RuntimeContextDependencies>,
 ): Promise<string> {
-  if (authority.bridgePort && authority.bridgePort > 0 && authority.bridgePort <= 65_535) {
-    const host = authority.headscaleIp || authority.nodeHostname;
-    if (host && /^[A-Za-z0-9][A-Za-z0-9.:-]{0,253}$/.test(host)) {
-      const bracketed = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
-      return new URL(`http://${bracketed}:${authority.bridgePort}/`).toString();
+  if (authority.headscaleIp !== null) {
+    const headscaleIp = authority.headscaleIp.trim();
+    if (headscaleIp !== authority.headscaleIp || isIP(headscaleIp) === 0) {
+      contextError(
+        "AGENT_BACKUP_V3_CAPTURE_ROUTE_INVALID",
+        "Exact capture source has a malformed Headscale address",
+      );
     }
+    if (!authority.bridgeUrl) {
+      contextError(
+        "AGENT_BACKUP_V3_CAPTURE_ROUTE_MISSING",
+        "Headscale capture source has no canonical container bridge route",
+      );
+    }
+    let bridge: URL;
+    try {
+      bridge = new URL(authority.bridgeUrl);
+    } catch (cause) {
+      contextError(
+        "AGENT_BACKUP_V3_CAPTURE_ROUTE_INVALID",
+        "Headscale capture bridge route is malformed",
+        cause,
+      );
+    }
+    if (
+      (bridge.protocol !== "http:" && bridge.protocol !== "https:") ||
+      !bridge.port ||
+      bridge.username ||
+      bridge.password ||
+      bridge.search ||
+      bridge.hash ||
+      (bridge.pathname !== "/" && bridge.pathname !== "")
+    ) {
+      contextError(
+        "AGENT_BACKUP_V3_CAPTURE_ROUTE_INVALID",
+        "Headscale capture bridge route has no canonical container port",
+      );
+    }
+    const bracketed = isIP(headscaleIp) === 6 ? `[${headscaleIp}]` : headscaleIp;
+    return new URL(`${bridge.protocol}//${bracketed}:${bridge.port}/`).toString();
+  }
+  if (
+    authority.bridgePort &&
+    authority.bridgePort > 0 &&
+    authority.bridgePort <= 65_535 &&
+    authority.nodeHostname &&
+    /^[A-Za-z0-9][A-Za-z0-9.:-]{0,253}$/.test(authority.nodeHostname)
+  ) {
+    const host = authority.nodeHostname;
+    const bracketed = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+    return new URL(`http://${bracketed}:${authority.bridgePort}/`).toString();
   }
   if (!authority.bridgeUrl) {
     contextError(
@@ -310,7 +392,7 @@ async function resolveApiToken(
     if (
       !token ||
       token !== token.trim() ||
-      token.includes("\0") ||
+      /[\u0000-\u001f\u007f]/.test(token) ||
       Buffer.byteLength(token, "utf8") > 16 * 1024
     ) {
       contextError("AGENT_BACKUP_V3_CAPTURE_TOKEN_INVALID", "Capture API token is not canonical");
@@ -332,6 +414,16 @@ export function createAgentBackupCaptureV3RuntimeContextResolver(
       claim: input.claim,
       signal: input.signal,
     });
+    if (
+      !UUID_PATTERN.test(authority.catalogAgentId) ||
+      authority.catalogAgentId !== input.request.agentId ||
+      !UUID_PATTERN.test(authority.runtimeAgentId)
+    ) {
+      contextError(
+        "AGENT_BACKUP_V3_RUNTIME_IDENTITY_INVALID",
+        "Database runtime authority has no exact catalogue/runtime identity binding",
+      );
+    }
     if (!sameSource(authority.source, input.expectedSource)) {
       contextError(
         "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_MISMATCH",
@@ -341,7 +433,7 @@ export function createAgentBackupCaptureV3RuntimeContextResolver(
     await input.heartbeat();
     const vault = await dependencies.loadVaultAuthority({
       organizationId: authority.organizationId,
-      agentId: authority.agentId,
+      agentId: authority.catalogAgentId,
       sourceActivationGeneration: authority.activationGeneration,
     });
     input.signal?.throwIfAborted();
@@ -353,9 +445,17 @@ export function createAgentBackupCaptureV3RuntimeContextResolver(
       async revalidateAttestation(signal) {
         signal?.throwIfAborted();
         const current = await dependencies.loadAuthority({ claim: input.claim, signal });
+        if (
+          current.catalogAgentId !== authority.catalogAgentId ||
+          current.runtimeAgentId !== authority.runtimeAgentId
+        ) {
+          resolvedRuntimeAuthorityStale(
+            "Catalogue/runtime identity binding changed while capture held the catalogue lease",
+          );
+        }
         const currentVault = await dependencies.loadVaultAuthority({
           organizationId: current.organizationId,
-          agentId: current.agentId,
+          agentId: current.catalogAgentId,
           sourceActivationGeneration: current.activationGeneration,
         });
         if (

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-spool-cleanup.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-spool-cleanup.ts
@@ -75,6 +75,7 @@ const TerminalIntentSchema = z.strictObject({
   lifecycleRevision: z.string().regex(/^(?:0|[1-9][0-9]{0,19})$/),
   requestSha256: z.string().regex(SHA256_PATTERN),
   authoritySha256: z.string().regex(SHA256_PATTERN),
+  runtimePrincipalSha256: z.string().regex(SHA256_PATTERN),
   terminalErrorCode: z
     .string()
     .min(1)
@@ -104,6 +105,7 @@ export interface AgentBackupCaptureV3TerminalSpoolCleanupAuthority {
   lifecycleRevision: string;
   requestSha256: string;
   authoritySha256: string;
+  runtimePrincipalSha256: string;
 }
 
 export interface AgentBackupCaptureV3SpoolCleanupDependencies {
@@ -130,6 +132,7 @@ export interface AgentBackupCaptureV3SpoolCleanupDependencies {
       executionToken: string;
       requestSha256: string;
       authoritySha256: string;
+      runtimePrincipalSha256?: string;
     },
   ): Promise<AgentBackupCaptureV3Spool | undefined>;
   now(): number;
@@ -168,7 +171,7 @@ export interface AgentBackupCaptureV3SpoolCleanupJanitor {
     authority: Readonly<AgentBackupCaptureV3TerminalSpoolCleanupAuthority>;
     terminalErrorCode: string;
   }): Promise<"pending">;
-  runCycle(): Promise<AgentBackupCaptureV3SpoolCleanupSummary>;
+  runCycle(signal?: AbortSignal): Promise<AgentBackupCaptureV3SpoolCleanupSummary>;
 }
 
 function batchSize(value: number | undefined): number {
@@ -222,6 +225,7 @@ function terminalCleanupAuthority(
     lifecycleRevision: evidence.lifecycleRevision,
     requestSha256: evidence.requestSha256,
     authoritySha256: evidence.authoritySha256,
+    runtimePrincipalSha256: evidence.runtimePrincipalSha256,
   };
 }
 
@@ -447,6 +451,7 @@ function sameTerminalIntent(
     left.lifecycleRevision === right.lifecycleRevision &&
     left.requestSha256 === right.requestSha256 &&
     left.authoritySha256 === right.authoritySha256 &&
+    left.runtimePrincipalSha256 === right.runtimePrincipalSha256 &&
     left.terminalErrorCode === right.terminalErrorCode
   );
 }
@@ -526,6 +531,7 @@ function sameTerminalCandidate(
     left.lifecycleRevision === right.lifecycleRevision &&
     left.requestSha256 === right.requestSha256 &&
     left.authoritySha256 === right.authoritySha256 &&
+    left.runtimePrincipalSha256 === right.runtimePrincipalSha256 &&
     left.terminalErrorCode === right.terminalErrorCode
   );
 }
@@ -731,6 +737,7 @@ function assertTerminalCleanupAuthorization(params: {
     lifecycleRevision: true,
     requestSha256: true,
     authoritySha256: true,
+    runtimePrincipalSha256: true,
     terminalErrorCode: true,
   }).parse({ ...authority, terminalErrorCode: params.terminalErrorCode });
 }
@@ -745,18 +752,24 @@ export function createAgentBackupCaptureV3SpoolCleanupJanitor(
   const authorizeAndPersist = async (
     outbox: string,
     authority: Readonly<AgentBackupCaptureV3SpoolAuthority>,
+    signal?: AbortSignal,
   ): Promise<void> => {
+    signal?.throwIfAborted();
     const authorized = await dependencies.authorize(authorizationInput(authority));
+    signal?.throwIfAborted();
     const rederived = await dependencies.deriveAuthority(authorized);
+    signal?.throwIfAborted();
     if (!sameAuthority(authority, rederived)) {
       throw new Error("Protected cleanup repository returned different spool authority");
     }
+    signal?.throwIfAborted();
     await persistIntent({
       outbox,
       authority,
       authorizedAt: canonicalAuthorizedAt(dependencies.now()),
       nonce: dependencies.executionToken(),
     });
+    signal?.throwIfAborted();
   };
 
   return {
@@ -783,6 +796,7 @@ export function createAgentBackupCaptureV3SpoolCleanupJanitor(
         lifecycleRevision: true,
         requestSha256: true,
         authoritySha256: true,
+        runtimePrincipalSha256: true,
         terminalErrorCode: true,
       }).parse({ ...input.authority, terminalErrorCode: input.terminalErrorCode });
       const durable = await dependencies.listDurableOperations(config.spool);
@@ -793,6 +807,7 @@ export function createAgentBackupCaptureV3SpoolCleanupJanitor(
         operation &&
         (operation.requestSha256 !== input.authority.requestSha256 ||
           operation.authoritySha256 !== input.authority.authoritySha256 ||
+          operation.runtimePrincipalSha256 !== input.authority.runtimePrincipalSha256 ||
           operation.recordCaptured)
       ) {
         throw new Error("Terminal spool cleanup candidate differs from durable capture state");
@@ -811,7 +826,9 @@ export function createAgentBackupCaptureV3SpoolCleanupJanitor(
       return "pending";
     },
 
-    async runCycle() {
+    async runCycle(signal) {
+      const throwIfAborted = (): void => signal?.throwIfAborted();
+      throwIfAborted();
       const summary: AgentBackupCaptureV3SpoolCleanupSummary = {
         discovered: 0,
         authorized: 0,
@@ -820,50 +837,65 @@ export function createAgentBackupCaptureV3SpoolCleanupJanitor(
         skippedUnprotected: 0,
         indeterminate: 0,
       };
+      throwIfAborted();
       const durable = await dependencies.listDurableOperations(config.spool);
+      throwIfAborted();
       const outbox = await ensureOutboxDirectory(config.spool.stateDirectory);
+      throwIfAborted();
       const terminalOutbox = await ensureOutboxDirectory(
         config.spool.stateDirectory,
         TERMINAL_OUTBOX_DIRECTORY,
       );
+      throwIfAborted();
       const terminalCandidateOutbox = await ensureOutboxDirectory(
         config.spool.stateDirectory,
         TERMINAL_CANDIDATE_DIRECTORY,
       );
+      throwIfAborted();
       summary.discovered = durable.length;
       const terminalCandidates = await listTerminalCandidates(terminalCandidateOutbox, limit);
+      throwIfAborted();
       for (const candidate of terminalCandidates) {
+        throwIfAborted();
         const operation = durable.find(
           (durableOperation) => durableOperation.operationId === candidate.operationId,
         );
         if (!operation) {
+          throwIfAborted();
           await removeIntent(terminalCandidateOutbox, candidate.operationId);
+          throwIfAborted();
           continue;
         }
         if (operation.recordCaptured) {
           // A confirmed local handoff is written only after exact catalogue
           // proof. The stale pre-CAS candidate must never block publication or
           // the later protected-spool cleanup path.
+          throwIfAborted();
           await removeIntent(terminalCandidateOutbox, candidate.operationId);
+          throwIfAborted();
           continue;
         }
         if (
           operation.requestSha256 !== candidate.requestSha256 ||
-          operation.authoritySha256 !== candidate.authoritySha256
+          operation.authoritySha256 !== candidate.authoritySha256 ||
+          operation.runtimePrincipalSha256 !== candidate.runtimePrincipalSha256
         ) {
           summary.indeterminate += 1;
           continue;
         }
         try {
+          throwIfAborted();
           const authority = terminalCleanupAuthority(candidate);
           const authorized = await dependencies.authorizeTerminal(
             terminalAuthorizationInput(candidate),
           );
+          throwIfAborted();
           assertTerminalCleanupAuthorization({
             backup: authorized,
             authority,
             terminalErrorCode: candidate.terminalErrorCode,
           });
+          throwIfAborted();
           await persistTerminalIntent({
             outbox: terminalOutbox,
             authority,
@@ -871,21 +903,27 @@ export function createAgentBackupCaptureV3SpoolCleanupJanitor(
             authorizedAt: canonicalAuthorizedAt(dependencies.now()),
             nonce: dependencies.executionToken(),
           });
+          throwIfAborted();
           await removeIntent(terminalCandidateOutbox, candidate.operationId);
+          throwIfAborted();
           summary.authorized += 1;
         } catch {
+          throwIfAborted();
           // A staged candidate is deliberately non-authorizing. Keep it until
           // the exact terminal row becomes visible or a confirmed handoff makes
           // the candidate stale.
           summary.pending += 1;
         }
       }
+      throwIfAborted();
       const terminalIntents = await listTerminalIntents(terminalOutbox, limit);
+      throwIfAborted();
       const terminalOperationIds = new Set(terminalIntents.map((intent) => intent.operationId));
-      const existingIntents = new Set(
-        (await listIntents(outbox, MAX_BATCH_SIZE)).map((intent) => intent.operationId),
-      );
+      const protectedIntents = await listIntents(outbox, MAX_BATCH_SIZE);
+      throwIfAborted();
+      const existingIntents = new Set(protectedIntents.map((intent) => intent.operationId));
       for (const operation of durable.slice(0, limit)) {
+        throwIfAborted();
         if (
           existingIntents.has(operation.operationId) ||
           terminalOperationIds.has(operation.operationId)
@@ -897,12 +935,16 @@ export function createAgentBackupCaptureV3SpoolCleanupJanitor(
           continue;
         }
         try {
+          throwIfAborted();
           const candidates = await dependencies.listCandidates({
             operationId: operation.operationId,
           });
+          throwIfAborted();
           const matches: AgentBackupCaptureV3SpoolAuthority[] = [];
           for (const candidate of candidates) {
+            throwIfAborted();
             const authority = await dependencies.deriveAuthority(candidate);
+            throwIfAborted();
             if (
               authority.operationId === operation.operationId &&
               authority.requestSha256 === operation.requestSha256 &&
@@ -916,100 +958,137 @@ export function createAgentBackupCaptureV3SpoolCleanupJanitor(
             continue;
           }
           if (matches.length !== 1) throw new Error("Protected cleanup authority is ambiguous");
-          await authorizeAndPersist(outbox, matches[0]!);
+          throwIfAborted();
+          await authorizeAndPersist(outbox, matches[0]!, signal);
+          throwIfAborted();
           await removeIntent(terminalCandidateOutbox, operation.operationId);
+          throwIfAborted();
           existingIntents.add(operation.operationId);
           summary.authorized += 1;
         } catch {
+          throwIfAborted();
           summary.indeterminate += 1;
         }
       }
 
       for (const intent of terminalIntents) {
+        throwIfAborted();
         let spool: AgentBackupCaptureV3Spool | undefined;
         try {
+          throwIfAborted();
           const authority = terminalCleanupAuthority(intent);
           const authorized = await dependencies.authorizeTerminal(
             terminalAuthorizationInput(intent),
           );
+          throwIfAborted();
           assertTerminalCleanupAuthorization({
             backup: authorized,
             authority,
             terminalErrorCode: intent.terminalErrorCode,
           });
+          throwIfAborted();
           spool = await dependencies.openExisting(config.spool, {
             operationId: intent.operationId,
             executionToken: dependencies.executionToken(),
             requestSha256: intent.requestSha256,
             authoritySha256: intent.authoritySha256,
+            runtimePrincipalSha256: intent.runtimePrincipalSha256,
           });
+          throwIfAborted();
           if (!spool) {
             await removeIntent(terminalOutbox, intent.operationId);
+            throwIfAborted();
             summary.completed += 1;
             continue;
           }
           if (spool.recordCaptured) {
             await spool.close();
+            throwIfAborted();
             summary.indeterminate += 1;
             continue;
           }
+          throwIfAborted();
           const receipt = await spool.cleanup();
+          throwIfAborted();
           if (receipt.status === "complete") {
             await removeIntent(terminalOutbox, intent.operationId);
+            throwIfAborted();
             summary.completed += 1;
           } else {
             await spool.close();
+            throwIfAborted();
             summary.pending += 1;
           }
         } catch {
+          throwIfAborted();
           if (spool) await spool.close().catch(() => undefined);
+          throwIfAborted();
           summary.pending += 1;
         }
       }
 
+      throwIfAborted();
       const protectedCleanupLimit = Math.max(0, limit - terminalIntents.length);
       const intents =
         protectedCleanupLimit > 0 ? await listIntents(outbox, protectedCleanupLimit) : [];
+      throwIfAborted();
       for (const intent of intents) {
+        throwIfAborted();
         const authority = intentAuthority(intent);
         let spool: AgentBackupCaptureV3Spool | undefined;
         try {
+          throwIfAborted();
           const authorized = await dependencies.authorize(authorizationInput(authority));
+          throwIfAborted();
           const rederived = await dependencies.deriveAuthority(authorized);
+          throwIfAborted();
           if (!sameAuthority(authority, rederived)) {
             throw new Error("Protected cleanup intent no longer matches catalogue authority");
           }
+          throwIfAborted();
           spool = await dependencies.openExisting(config.spool, {
             operationId: authority.operationId,
             executionToken: dependencies.executionToken(),
             requestSha256: authority.requestSha256,
             authoritySha256: authority.authoritySha256,
           });
+          throwIfAborted();
           if (!spool) {
             await removeIntent(outbox, authority.operationId);
+            throwIfAborted();
             await removeIntent(terminalCandidateOutbox, authority.operationId);
+            throwIfAborted();
             summary.completed += 1;
             continue;
           }
           if (!spool.recordCaptured || spool.phase !== "published") {
             await spool.close();
+            throwIfAborted();
             summary.pending += 1;
             continue;
           }
+          throwIfAborted();
           const receipt = await spool.cleanup();
+          throwIfAborted();
           if (receipt.status === "complete") {
             await removeIntent(outbox, authority.operationId);
+            throwIfAborted();
             await removeIntent(terminalCandidateOutbox, authority.operationId);
+            throwIfAborted();
             summary.completed += 1;
           } else {
             await spool.close();
+            throwIfAborted();
             summary.pending += 1;
           }
         } catch {
+          throwIfAborted();
           if (spool) await spool.close().catch(() => undefined);
+          throwIfAborted();
           summary.pending += 1;
         }
       }
+      throwIfAborted();
       return summary;
     },
   };

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-vault-authority.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-vault-authority.ts
@@ -1,0 +1,84 @@
+/**
+ * Read-only adapter from the current validated vault pointer to the exact KMS
+ * wrapping authority required by manifest-v3 capture. It intentionally lives
+ * outside the restore/occurrence repository so it cannot add a writer or
+ * change restore lock ordering.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import { orgKey } from "@elizaos/core/security/kms";
+import { and, eq } from "drizzle-orm";
+import { dbWrite } from "../../db/helpers";
+import { loadCurrentAgentVaultKeyAuthority } from "../../db/repositories/agent-vault-key-authority";
+import { agentVaultKeyGenerations } from "../../db/schemas/agent-vault-key-authority";
+
+export interface AgentBackupCaptureV3VaultAuthority {
+  vaultKeyAuthority: Awaited<ReturnType<typeof loadCurrentAgentVaultKeyAuthority>>;
+  kms: { provider: "steward"; keyId: string; keyVersion: number };
+}
+
+function vaultCaptureError(code: string, message: string): never {
+  throw new ElizaError(message, { code, severity: "fatal" });
+}
+
+/**
+ * Load a validated current pointer, bind it to its activation generation, and
+ * re-read the current pointer to fence a concurrent rotation.
+ */
+export async function loadAgentBackupCaptureV3VaultAuthority(input: {
+  organizationId: string;
+  agentId: string;
+  sourceActivationGeneration: string;
+}): Promise<AgentBackupCaptureV3VaultAuthority> {
+  const initial = await loadCurrentAgentVaultKeyAuthority(input);
+  const [generation] = await dbWrite
+    .select({
+      generationId: agentVaultKeyGenerations.generation_id,
+      sourceActivationGeneration: agentVaultKeyGenerations.source_activation_generation,
+      kmsKeyId: agentVaultKeyGenerations.kms_key_id,
+      kmsKeyVersion: agentVaultKeyGenerations.kms_key_version,
+      authorityReceiptDigest: agentVaultKeyGenerations.authority_receipt_digest,
+    })
+    .from(agentVaultKeyGenerations)
+    .where(
+      and(
+        eq(agentVaultKeyGenerations.organization_id, input.organizationId),
+        eq(agentVaultKeyGenerations.agent_id, input.agentId),
+        eq(agentVaultKeyGenerations.generation_id, initial.generationId),
+        eq(agentVaultKeyGenerations.source_activation_generation, input.sourceActivationGeneration),
+      ),
+    )
+    .limit(1);
+  if (
+    !generation ||
+    generation.generationId !== initial.generationId ||
+    generation.sourceActivationGeneration !== input.sourceActivationGeneration ||
+    generation.authorityReceiptDigest !== initial.receiptDigest ||
+    generation.kmsKeyId !== orgKey(input.organizationId, "dek") ||
+    generation.kmsKeyVersion < 1n ||
+    generation.kmsKeyVersion > BigInt(Number.MAX_SAFE_INTEGER)
+  ) {
+    vaultCaptureError(
+      "AGENT_BACKUP_V3_VAULT_AUTHORITY_INVALID",
+      "Current vault generation lacks the exact capture/KMS authority",
+    );
+  }
+  const confirmed = await loadCurrentAgentVaultKeyAuthority(input);
+  if (
+    confirmed.generationId !== initial.generationId ||
+    confirmed.receiptDigest !== initial.receiptDigest
+  ) {
+    vaultCaptureError(
+      "AGENT_BACKUP_V3_VAULT_AUTHORITY_CHANGED",
+      "Vault authority rotated while capture context was being resolved",
+    );
+  }
+  return Object.freeze({
+    vaultKeyAuthority: initial,
+    kms: Object.freeze({
+      provider: "steward" as const,
+      keyId: generation.kmsKeyId,
+      keyVersion: Number(generation.kmsKeyVersion),
+    }),
+  });
+}

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.test.ts
@@ -1,10 +1,14 @@
 /** Deterministic unit proofs for the bounded backup catalogue runtime tick. */
 
 import { describe, expect, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
 import type { AgentBackupOperationClaim } from "../../db/repositories/agent-backup-catalog";
 import type { AgentBackupGcClaim } from "../../db/repositories/agent-backup-gc";
 import type { AgentBackupObjectStoreRegistry } from "../storage/agent-backup-object-store";
-import { normalizeAgentBackupCaptureV2TerminalFailure } from "./agent-backup-capture-v2-failure-disposition";
+import {
+  createAgentBackupCaptureV2ExecutorError,
+  normalizeAgentBackupCaptureV2TerminalFailure,
+} from "./agent-backup-capture-v2-failure-disposition";
 import { AgentBackupCaptureV2PipelineError } from "./agent-backup-capture-v2-pipeline";
 import type { AgentBackupCaptureV3TerminalSpoolCleanupAuthority } from "./agent-backup-capture-v3-spool-cleanup";
 import {
@@ -43,7 +47,7 @@ const ENABLED_CONFIG: Extract<AgentBackupCatalogRuntimeConfig, { enabled: true }
   scheduleBatchSize: 32,
   scheduleLeaseMs: 120_000,
   scheduleRetryMs: 30_000,
-  operationBatchSize: 8,
+  operationBatchSize: 1,
   gcBatchSize: 32,
   deletionBatchSize: 32,
   operationLeaseMs: 240_000,
@@ -120,6 +124,9 @@ function dependencies(
     countOverdueSchedules: async () => 0,
     claimOperations: async () => [],
     heartbeatOperation: async () => undefined,
+    handoffCapturedOperation: async () => {
+      throw new Error("unexpected captured-operation handoff");
+    },
     transitionOperation: async () => {
       throw new Error("unexpected transition");
     },
@@ -137,6 +144,17 @@ function dependencies(
       throw new Error("unexpected deletion finalization");
     },
     ...overrides,
+  };
+}
+
+function claimOperationsInOrder(
+  ...claims: AgentBackupOperationClaim[]
+): AgentBackupCatalogRuntimeDependencies["claimOperations"] {
+  const pending = [...claims];
+  return async ({ limit }) => {
+    if (limit !== 1) throw new Error(`Expected a single-slot claim, received ${limit}`);
+    const claim = pending.shift();
+    return claim ? [claim] : [];
   };
 }
 
@@ -200,7 +218,16 @@ describe("agent backup catalogue runtime config", () => {
     ).rejects.toThrow("AGENT_BACKUP_R2_ENDPOINT_ALIAS");
   });
 
-  test("starts the operation dispatcher at one claim unless explicitly raised", () => {
+  test("rejects control characters in the worker identity before claiming", () => {
+    expect(() =>
+      readAgentBackupCatalogRuntimeConfig({
+        AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "1",
+        AGENT_BACKUP_CATALOG_WORKER_ID: "worker\tshadow",
+      }),
+    ).toThrow("AGENT_BACKUP_CATALOG_WORKER_ID");
+  });
+
+  test("fixes the operation dispatcher to one claim until cross-tick fairness is durable", () => {
     const config = readAgentBackupCatalogRuntimeConfig({
       AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "1",
       AGENT_BACKUP_CATALOG_WORKER_ID: "worker-1",
@@ -211,6 +238,13 @@ describe("agent backup catalogue runtime config", () => {
       scheduleBatchSize: 32,
       operationBatchSize: 1,
     });
+    expect(() =>
+      readAgentBackupCatalogRuntimeConfig({
+        AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "1",
+        AGENT_BACKUP_CATALOG_WORKER_ID: "worker-1",
+        AGENT_BACKUP_OPERATION_BATCH_SIZE: "2",
+      }),
+    ).toThrow("AGENT_BACKUP_OPERATION_BATCH_SIZE must be between 1 and 1");
   });
 
   test("keeps periodic admission off by default and rejects an orphaned schedule gate", () => {
@@ -490,10 +524,14 @@ describe("agent backup catalogue runtime scheduling", () => {
       config: ENABLED_CONFIG,
       registry: UNUSED_REGISTRY,
       dependencies: dependencies({
-        claimOperations: async () => [claim],
+        claimOperations: claimOperationsInOrder(claim),
         transitionOperation: async (params) => {
           calls.push(`${params.expectedState}->${params.to}`);
           return { ...claim.backup, catalog_state: params.to };
+        },
+        handoffCapturedOperation: async (params) => {
+          calls.push(`handoff:${params.operationId}:${params.execution.generation}`);
+          return { ...claim.backup, catalog_state: "captured" };
         },
       }),
       captureExecutor: {
@@ -504,7 +542,11 @@ describe("agent backup catalogue runtime scheduling", () => {
       },
     });
 
-    expect(calls).toEqual(["scheduled->capturing", "capture:capturing:240000"]);
+    expect(calls).toEqual([
+      "scheduled->capturing",
+      "capture:capturing:240000",
+      `handoff:${OPERATION_ID}:${CLAIM_GENERATION}`,
+    ]);
     expect(summary).toMatchObject({
       operationClaimed: 1,
       operationCaptured: 1,
@@ -512,6 +554,226 @@ describe("agent backup catalogue runtime scheduling", () => {
       operationDeferred: 0,
       operationIndeterminate: 0,
     });
+  });
+
+  test("reclaims captured work after a lost handoff response while preserving indeterminate evidence", async () => {
+    const claim = operationClaim();
+    const reclaimed = publicationClaim("captured");
+    reclaimed.generation = "00000000-0000-4000-8000-000000000006";
+    let failureWrites = 0;
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: { ...ENABLED_CONFIG, operationBatchSize: 2 },
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({
+        claimOperations: claimOperationsInOrder(claim, reclaimed),
+        transitionOperation: async (params) => ({
+          ...claim.backup,
+          catalog_state: params.to,
+        }),
+        handoffCapturedOperation: async () => {
+          throw new Error("release committed but response was lost");
+        },
+        failOperation: async () => {
+          failureWrites += 1;
+          return claim.backup;
+        },
+      }),
+      captureExecutor: {
+        async execute() {
+          return { state: "captured-upload-pending" };
+        },
+      },
+      publicationExecutor: {
+        async execute({ claim: publication }) {
+          expect(publication.generation).toBe(reclaimed.generation);
+          return { state: "protected" };
+        },
+      },
+    });
+
+    expect(failureWrites).toBe(0);
+    expect(summary).toMatchObject({
+      operationClaimed: 2,
+      operationCaptured: 0,
+      operationProtected: 1,
+      operationIndeterminate: 1,
+    });
+    expect(summary.alertCodes).toContain("BACKUP_OPERATION_RECONCILE_REQUIRED");
+  });
+
+  test("claims one operation immediately before each serial processing slot", async () => {
+    const first = publicationClaim("captured");
+    const second = publicationClaim("secondary_pending");
+    second.backup.id = "00000000-0000-4000-8000-000000000008";
+    const pending = [first, second];
+    const events: string[] = [];
+    let leasedButNotStarted = 0;
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: { ...ENABLED_CONFIG, operationBatchSize: 2 },
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({
+        claimOperations: async ({ limit }) => {
+          events.push(`claim:${limit}`);
+          expect(leasedButNotStarted).toBe(0);
+          const claim = pending.shift();
+          if (claim) leasedButNotStarted += 1;
+          return claim ? [claim] : [];
+        },
+      }),
+      publicationExecutor: {
+        async execute({ claim }) {
+          leasedButNotStarted -= 1;
+          events.push(`execute:${claim.backup.id}`);
+          return { state: "protected" };
+        },
+      },
+    });
+
+    expect(events).toEqual([
+      "claim:1",
+      `execute:${first.backup.id}`,
+      "claim:1",
+      `execute:${second.backup.id}`,
+    ]);
+    expect(leasedButNotStarted).toBe(0);
+    expect(summary).toMatchObject({ operationClaimed: 2, operationProtected: 2 });
+  });
+
+  test("does not acquire another operation after the cycle is aborted", async () => {
+    const controller = new AbortController();
+    const claim = publicationClaim("captured");
+    let claimCalls = 0;
+    let failureWrites = 0;
+    const cycle = runAgentBackupCatalogRuntimeCycle({
+      config: { ...ENABLED_CONFIG, operationBatchSize: 2 },
+      registry: UNUSED_REGISTRY,
+      signal: controller.signal,
+      dependencies: dependencies({
+        claimOperations: async ({ limit }) => {
+          expect(limit).toBe(1);
+          claimCalls += 1;
+          return [claim];
+        },
+        failOperation: async () => {
+          failureWrites += 1;
+          return claim.backup;
+        },
+      }),
+      publicationExecutor: {
+        async execute() {
+          controller.abort(new Error("stop after the first processing slot"));
+          return { state: "protected" };
+        },
+      },
+    });
+
+    await expect(cycle).rejects.toThrow("stop after the first processing slot");
+    expect(claimCalls).toBe(1);
+    expect(failureWrites).toBe(0);
+  });
+
+  test("stops immediately when cancellation lands after the DB claim", async () => {
+    const controller = new AbortController();
+    const claim = operationClaim();
+    let transitions = 0;
+    let executions = 0;
+    const cycle = runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      signal: controller.signal,
+      dependencies: dependencies({
+        claimOperations: async () => {
+          controller.abort(new Error("shutdown after DB claim"));
+          return [claim];
+        },
+        transitionOperation: async () => {
+          transitions += 1;
+          return claim.backup;
+        },
+      }),
+      captureExecutor: {
+        async execute() {
+          executions += 1;
+          return { state: "captured-upload-pending" };
+        },
+      },
+    });
+
+    await expect(cycle).rejects.toThrow("shutdown after DB claim");
+    expect(transitions).toBe(0);
+    expect(executions).toBe(0);
+  });
+
+  test("stops after normalization CAS before executor or handoff", async () => {
+    const controller = new AbortController();
+    const claim = operationClaim();
+    let executions = 0;
+    let handoffs = 0;
+    const cycle = runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      signal: controller.signal,
+      dependencies: dependencies({
+        claimOperations: claimOperationsInOrder(claim),
+        transitionOperation: async (params) => {
+          controller.abort(new Error("shutdown after normalization CAS"));
+          return { ...claim.backup, catalog_state: params.to };
+        },
+        handoffCapturedOperation: async () => {
+          handoffs += 1;
+          return claim.backup;
+        },
+      }),
+      captureExecutor: {
+        async execute() {
+          executions += 1;
+          return { state: "captured-upload-pending" };
+        },
+      },
+    });
+
+    await expect(cycle).rejects.toThrow("shutdown after normalization CAS");
+    expect(executions).toBe(0);
+    expect(handoffs).toBe(0);
+  });
+
+  test("stops after handoff response without claiming or transitioning further work", async () => {
+    const controller = new AbortController();
+    const claim = operationClaim();
+    let claimCalls = 0;
+    let failureWrites = 0;
+    const cycle = runAgentBackupCatalogRuntimeCycle({
+      config: { ...ENABLED_CONFIG, operationBatchSize: 2 },
+      registry: UNUSED_REGISTRY,
+      signal: controller.signal,
+      dependencies: dependencies({
+        claimOperations: async () => {
+          claimCalls += 1;
+          return [claim];
+        },
+        transitionOperation: async (params) => ({
+          ...claim.backup,
+          catalog_state: params.to,
+        }),
+        handoffCapturedOperation: async () => {
+          controller.abort(new Error("shutdown after captured handoff"));
+          return { ...claim.backup, catalog_state: "captured" };
+        },
+        failOperation: async () => {
+          failureWrites += 1;
+          return claim.backup;
+        },
+      }),
+      captureExecutor: {
+        async execute() {
+          return { state: "captured-upload-pending" };
+        },
+      },
+    });
+
+    await expect(cycle).rejects.toThrow("shutdown after captured handoff");
+    expect(claimCalls).toBe(1);
+    expect(failureWrites).toBe(0);
   });
 
   test("records a bounded retry when capture fails before recordCaptured is confirmed", async () => {
@@ -522,7 +784,7 @@ describe("agent backup catalogue runtime scheduling", () => {
       registry: UNUSED_REGISTRY,
       random: () => 0.5,
       dependencies: dependencies({
-        claimOperations: async () => [claim],
+        claimOperations: claimOperationsInOrder(claim),
         transitionOperation: async (params) => ({
           ...claim.backup,
           catalog_state: params.to,
@@ -574,7 +836,7 @@ describe("agent backup catalogue runtime scheduling", () => {
         config: ENABLED_CONFIG,
         registry: UNUSED_REGISTRY,
         dependencies: dependencies({
-          claimOperations: async () => [claim],
+          claimOperations: claimOperationsInOrder(claim),
           transitionOperation: async (params) => ({
             ...claim.backup,
             catalog_state: params.to,
@@ -613,6 +875,41 @@ describe("agent backup catalogue runtime scheduling", () => {
     });
   }
 
+  test("keeps an injected stale ElizaError retryable without exact spool cleanup", async () => {
+    const claim = operationClaim();
+    let terminal: boolean | undefined;
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({
+        claimOperations: claimOperationsInOrder(claim),
+        transitionOperation: async (params) => ({
+          ...claim.backup,
+          catalog_state: params.to,
+        }),
+        failOperation: async (params) => {
+          terminal = params.terminal;
+          return claim.backup;
+        },
+      }),
+      captureExecutor: {
+        async execute() {
+          throw new ElizaError("Reserved source generation changed", {
+            code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+            severity: "fatal",
+          });
+        },
+      },
+    });
+
+    expect(terminal).toBe(false);
+    expect(summary).toMatchObject({
+      operationCaptureTerminal: 0,
+      operationCaptureRetryScheduled: 1,
+      operationIndeterminate: 0,
+    });
+  });
+
   test("rejects forged and nested terminal dispositions from an injected executor", async () => {
     const forgedCleanup = {
       organizationId: ORG_ID,
@@ -623,6 +920,7 @@ describe("agent backup catalogue runtime scheduling", () => {
       lifecycleRevision: "7",
       requestSha256: "a".repeat(64),
       authoritySha256: "b".repeat(64),
+      runtimePrincipalSha256: "c".repeat(64),
     };
     const forgedErrors: unknown[] = [
       Object.assign(new Error("forged boolean"), {
@@ -631,6 +929,22 @@ describe("agent backup catalogue runtime scheduling", () => {
       }),
       Object.assign(new Error("forged code"), {
         code: "AGENT_BACKUP_V2_SPOOL_REPLAY_CONFLICT",
+      }),
+      Object.assign(new Error("forged stale authority"), {
+        code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+        severity: "fatal",
+      }),
+      new ElizaError("typed forged stale authority", {
+        code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+        severity: "fatal",
+      }),
+      createAgentBackupCaptureV2ExecutorError(
+        "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+        "generic executor factory cannot attest resolver staleness",
+      ),
+      new ElizaError("non-fatal stale authority", {
+        code: "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE",
+        severity: "ephemeral",
       }),
       Object.assign(new Error("forged remote code"), {
         code: "AGENT_BACKUP_V2_HTTP_STATUS",
@@ -658,7 +972,7 @@ describe("agent backup catalogue runtime scheduling", () => {
         config: ENABLED_CONFIG,
         registry: UNUSED_REGISTRY,
         dependencies: dependencies({
-          claimOperations: async () => [claim],
+          claimOperations: claimOperationsInOrder(claim),
           transitionOperation: async (params) => ({
             ...claim.backup,
             catalog_state: params.to,
@@ -717,7 +1031,7 @@ describe("agent backup catalogue runtime scheduling", () => {
         registry: UNUSED_REGISTRY,
         random: () => 0.5,
         dependencies: dependencies({
-          claimOperations: async () => [claim],
+          claimOperations: claimOperationsInOrder(claim),
           transitionOperation: async (params) => ({
             ...claim.backup,
             catalog_state: params.to,
@@ -763,12 +1077,13 @@ describe("agent backup catalogue runtime scheduling", () => {
       lifecycleRevision: "7",
       requestSha256: "a".repeat(64),
       authoritySha256: "b".repeat(64),
+      runtimePrincipalSha256: "c".repeat(64),
     };
     const summary = await runAgentBackupCatalogRuntimeCycle({
       config: ENABLED_CONFIG,
       registry: UNUSED_REGISTRY,
       dependencies: dependencies({
-        claimOperations: async () => [claim],
+        claimOperations: claimOperationsInOrder(claim),
         transitionOperation: async (params) => ({
           ...claim.backup,
           catalog_state: params.to,
@@ -839,12 +1154,13 @@ describe("agent backup catalogue runtime scheduling", () => {
       lifecycleRevision: "7",
       requestSha256: "a".repeat(64),
       authoritySha256: "b".repeat(64),
+      runtimePrincipalSha256: "c".repeat(64),
     };
     const summary = await runAgentBackupCatalogRuntimeCycle({
       config: ENABLED_CONFIG,
       registry: UNUSED_REGISTRY,
       dependencies: dependencies({
-        claimOperations: async () => [claim],
+        claimOperations: claimOperationsInOrder(claim),
         transitionOperation: async (params) => ({
           ...claim.backup,
           catalog_state: params.to,
@@ -889,6 +1205,75 @@ describe("agent backup catalogue runtime scheduling", () => {
     expect(summary.alertCodes).toContain("BACKUP_SPOOL_CLEANUP_RECONCILE_REQUIRED");
   });
 
+  test("does not settle terminal when cancellation lands during cleanup staging", async () => {
+    const claim = operationClaim();
+    const controller = new AbortController();
+    const reason = new Error("shutdown during terminal cleanup staging");
+    let failureWrites = 0;
+    let releaseStage!: () => void;
+    let markStageStarted!: () => void;
+    const stageStarted = new Promise<void>((resolve) => {
+      markStageStarted = resolve;
+    });
+    const stageRelease = new Promise<void>((resolve) => {
+      releaseStage = resolve;
+    });
+    const terminalSpoolCleanup = {
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      backupId: BACKUP_ID,
+      operationId: OPERATION_ID,
+      activationGeneration: LIFECYCLE_GENERATION,
+      lifecycleRevision: "7",
+      requestSha256: "a".repeat(64),
+      authoritySha256: "b".repeat(64),
+      runtimePrincipalSha256: "c".repeat(64),
+    };
+    const cycle = runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      signal: controller.signal,
+      dependencies: dependencies({
+        claimOperations: claimOperationsInOrder(claim),
+        transitionOperation: async (params) => ({
+          ...claim.backup,
+          catalog_state: params.to,
+        }),
+        failOperation: async () => {
+          failureWrites += 1;
+          return claim.backup;
+        },
+      }),
+      captureExecutor: {
+        async execute() {
+          throw trustedTerminalCaptureFailure(
+            "AGENT_BACKUP_V2_SPOOL_REPLAY_CONFLICT",
+            terminalSpoolCleanup,
+          );
+        },
+      },
+      spoolCleanupJanitor: {
+        async enqueueProtectedBackup() {
+          return "pending";
+        },
+        async stageTerminalFailure() {
+          markStageStarted();
+          await stageRelease;
+          return "pending";
+        },
+        async runCycle() {
+          throw new Error("aborted cycle must not run cleanup reconciliation");
+        },
+      },
+    });
+
+    await stageStarted;
+    controller.abort(reason);
+    releaseStage();
+    await expect(cycle).rejects.toBe(reason);
+    expect(failureWrites).toBe(0);
+  });
+
   test("stages terminal cleanup before a settlement response can be lost", async () => {
     const claim = operationClaim();
     let terminalStages = 0;
@@ -901,12 +1286,13 @@ describe("agent backup catalogue runtime scheduling", () => {
       lifecycleRevision: "7",
       requestSha256: "a".repeat(64),
       authoritySha256: "b".repeat(64),
+      runtimePrincipalSha256: "c".repeat(64),
     };
     const summary = await runAgentBackupCatalogRuntimeCycle({
       config: ENABLED_CONFIG,
       registry: UNUSED_REGISTRY,
       dependencies: dependencies({
-        claimOperations: async () => [claim],
+        claimOperations: claimOperationsInOrder(claim),
         transitionOperation: async (params) => ({
           ...claim.backup,
           catalog_state: params.to,
@@ -976,7 +1362,7 @@ describe("agent backup catalogue runtime scheduling", () => {
     });
 
     expect(calls).toEqual([
-      "claim:8",
+      "claim:1",
       "heartbeat",
       "defer:scheduled:BACKUP_PIPELINE_STAGE_UNAVAILABLE",
     ]);
@@ -993,7 +1379,7 @@ describe("agent backup catalogue runtime scheduling", () => {
       config: ENABLED_CONFIG,
       registry: UNUSED_REGISTRY,
       dependencies: dependencies({
-        claimOperations: async () => [claim],
+        claimOperations: claimOperationsInOrder(claim),
         transitionOperation: async (params) => {
           transitions.push(`${params.expectedState}->${params.to}`);
           return { ...claim.backup, catalog_state: params.to };
@@ -1015,7 +1401,7 @@ describe("agent backup catalogue runtime scheduling", () => {
     const summary = await runAgentBackupCatalogRuntimeCycle({
       config: ENABLED_CONFIG,
       registry: UNUSED_REGISTRY,
-      dependencies: dependencies({ claimOperations: async () => [owned] }),
+      dependencies: dependencies({ claimOperations: claimOperationsInOrder(owned) }),
       publicationExecutor: {
         async execute({ claim, leaseMs }) {
           calls.push(`${claim.backup.catalog_state}:${leaseMs}`);
@@ -1045,7 +1431,7 @@ describe("agent backup catalogue runtime scheduling", () => {
       registry: UNUSED_REGISTRY,
       random: () => 0.5,
       dependencies: dependencies({
-        claimOperations: async () => [retryable, healthy],
+        claimOperations: claimOperationsInOrder(retryable, healthy),
         failOperation: async (input) => {
           failures.push(`${input.expectedState}:${input.error.code}:${input.retryDelayMs}`);
           return retryable.backup;
@@ -1088,7 +1474,7 @@ describe("agent backup catalogue runtime scheduling", () => {
       config: { ...ENABLED_CONFIG, operationBatchSize: 2 },
       registry: UNUSED_REGISTRY,
       dependencies: dependencies({
-        claimOperations: async () => [responseLost, healthy],
+        claimOperations: claimOperationsInOrder(responseLost, healthy),
       }),
       publicationExecutor: {
         async execute({ claim }) {
@@ -1111,11 +1497,13 @@ describe("agent backup catalogue runtime scheduling", () => {
 
   test("runs protected spool reconciliation even after a lost publication response", async () => {
     const responseLost = publicationClaim("secondary_pending");
+    const controller = new AbortController();
     let cleanupCycles = 0;
     const summary = await runAgentBackupCatalogRuntimeCycle({
       config: ENABLED_CONFIG,
       registry: UNUSED_REGISTRY,
-      dependencies: dependencies({ claimOperations: async () => [responseLost] }),
+      signal: controller.signal,
+      dependencies: dependencies({ claimOperations: claimOperationsInOrder(responseLost) }),
       publicationExecutor: {
         async execute() {
           throw new Error("protected committed but transition response was lost");
@@ -1128,7 +1516,8 @@ describe("agent backup catalogue runtime scheduling", () => {
         async stageTerminalFailure() {
           return "pending";
         },
-        async runCycle() {
+        async runCycle(signal) {
+          expect(signal).toBe(controller.signal);
           cleanupCycles += 1;
           return {
             discovered: 1,

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.ts
@@ -1,12 +1,12 @@
 /**
  * Runs one bounded scheduler tick for the durable sandbox-backup catalogue.
  *
- * The caller owns cadence and logging. Production daemon composition is
- * intentionally absent until activation/vault authorities and a dedicated
- * sub-minute lane exist. This service owns feature-gated storage authority
- * resolution, fair operation leases, retry deferral for pipeline stages that
- * do not yet have an executor, and isolated exact-object GC. It never logs
- * credentials, endpoint URLs, object keys, or locators.
+ * The dedicated daemon owns cadence and logging, and imports its production
+ * composition only after the disabled-first gate boundary. This service owns
+ * feature-gated storage authority resolution, fair operation leases, retry
+ * deferral for pipeline stages that do not yet have an executor, and isolated
+ * exact-object GC. It never logs credentials, endpoint URLs, object keys, or
+ * locators.
  */
 
 import {
@@ -14,6 +14,7 @@ import {
   type AgentBackupOperationExecution,
   claimDueAgentBackupOperations,
   failAgentBackupOperation,
+  handoffCapturedAgentBackupOperation,
   heartbeatAgentBackupOperation,
   transitionAgentBackupOperation,
 } from "../../db/repositories/agent-backup-catalog";
@@ -49,15 +50,16 @@ import type {
 } from "./agent-backup-capture-v3-spool-cleanup";
 import { executeAgentBackupGcClaims } from "./agent-backup-catalog-worker";
 
-const MAX_OPERATION_BATCH = 100;
+// Repeated fair-SQL claims reset tenant ordering. Keep one operation per tick
+// until a durable cross-tick tenant cursor can prove starvation freedom.
+const MAX_OPERATION_BATCH = 1;
 const MAX_SCHEDULE_BATCH = 100;
 const MAX_GC_BATCH = 100;
 const MAX_LEASE_MS = 5 * 60_000;
 const MAX_OPERATION_RETRY_MS = 24 * 60 * 60_000;
 const MAX_GC_RETRY_MS = 6 * 60 * 60_000;
 
-// Start deliberately serial. Operators may raise the bounded override after
-// observing provider quotas and memory pressure in their own deployment.
+// Deliberately fixed, not merely a default; see MAX_OPERATION_BATCH.
 const DEFAULT_OPERATION_BATCH = 1;
 const DEFAULT_SCHEDULE_BATCH = 32;
 const DEFAULT_SCHEDULE_LEASE_MS = 2 * 60_000;
@@ -177,6 +179,7 @@ export interface AgentBackupCatalogRuntimeDependencies {
     execution: AgentBackupOperationExecution;
     leaseMs: number;
   }): Promise<unknown>;
+  handoffCapturedOperation: typeof handoffCapturedAgentBackupOperation;
   transitionOperation: typeof transitionAgentBackupOperation;
   failOperation: typeof failAgentBackupOperation;
   listDueDeletions: typeof listDueAgentBackupDeletions;
@@ -234,6 +237,7 @@ const DEFAULT_DEPENDENCIES: AgentBackupCatalogRuntimeDependencies = {
   countOverdueSchedules: countOverdueAgentBackupSchedules,
   claimOperations: claimDueAgentBackupOperations,
   heartbeatOperation: heartbeatAgentBackupOperation,
+  handoffCapturedOperation: handoffCapturedAgentBackupOperation,
   transitionOperation: transitionAgentBackupOperation,
   failOperation: failAgentBackupOperation,
   listDueDeletions: listDueAgentBackupDeletions,
@@ -265,7 +269,7 @@ function readBoundedInteger(params: {
 
 function requiredEnv(env: NodeJS.ProcessEnv, name: string): string {
   const value = env[name];
-  if (!value || value.trim() !== value || value.includes("\0")) {
+  if (!value || value.trim() !== value || /[\u0000-\u001f\u007f]/.test(value)) {
     throw new Error(
       `${name} must be explicitly configured when backup catalogue runtime is enabled`,
     );
@@ -562,6 +566,13 @@ interface CaptureFailureDisposition {
 
 function classifyCaptureFailure(error: unknown): CaptureFailureDisposition {
   if (!isTrustedAgentBackupCaptureV2TerminalDisposition(error)) return { terminal: false };
+  // A stale runtime generation is irreversible only after the concrete
+  // pipeline opened a spool and attached the exact cleanup authority. Stale
+  // evidence raised during context resolution has no local artifact proof and
+  // therefore remains retryable.
+  if (error.code === "AGENT_BACKUP_V3_RUNTIME_AUTHORITY_STALE" && !error.terminalSpoolCleanup) {
+    return { terminal: false };
+  }
   return {
     terminal: true,
     terminalSpoolCleanup: error.terminalSpoolCleanup,
@@ -770,27 +781,41 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
   throwIfAborted();
   await countOverdueSchedules();
 
-  let operationClaims: AgentBackupOperationClaim[] = [];
-  throwIfAborted();
-  try {
-    operationClaims = await dependencies.claimOperations({
-      ownerId: params.config.ownerId,
-      limit: params.config.operationBatchSize,
-      leaseMs: params.config.operationLeaseMs,
-    });
-    summary.operationClaimed = operationClaims.length;
-  } catch (error) {
+  // Each serial processing slot acquires its own lease immediately before use.
+  // A slow or poisoned first operation can therefore never idle-lease the rest
+  // of the configured batch while it waits behind that operation.
+  for (
+    let operationSlot = 0;
+    operationSlot < params.config.operationBatchSize;
+    operationSlot += 1
+  ) {
     throwIfAborted();
-    if (!params.config.scheduleEnabled) throw error;
-    summary.operationIndeterminate += 1;
-    alertCodes.add(OPERATION_RECONCILE_CODE);
-  }
-  for (const claim of operationClaims) {
-    throwIfAborted();
+    let operationClaims: AgentBackupOperationClaim[];
+    try {
+      operationClaims = await dependencies.claimOperations({
+        ownerId: params.config.ownerId,
+        limit: 1,
+        leaseMs: params.config.operationLeaseMs,
+      });
+      throwIfAborted();
+      if (operationClaims.length > 1) {
+        throw new Error("Backup operation claimant exceeded the single-slot lease contract");
+      }
+    } catch (error) {
+      throwIfAborted();
+      if (!params.config.scheduleEnabled) throw error;
+      summary.operationIndeterminate += 1;
+      alertCodes.add(OPERATION_RECONCILE_CODE);
+      break;
+    }
+    const claim = operationClaims[0];
+    if (!claim) break;
+    summary.operationClaimed += 1;
     if (params.captureExecutor && isCaptureOperationClaim(claim)) {
       let normalized: AgentBackupOperationClaim;
       try {
         normalized = await normalizeCaptureOperationClaim({ claim, dependencies });
+        throwIfAborted();
       } catch {
         throwIfAborted();
         // A lost transition response is indeterminate. The exact lease/state
@@ -800,13 +825,42 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
         continue;
       }
       try {
+        throwIfAborted();
         const result = await params.captureExecutor.execute({
           claim: normalized,
           leaseMs: params.config.operationLeaseMs,
           signal: params.signal,
         });
+        throwIfAborted();
         if (result.state !== "captured-upload-pending") {
           throw new Error("Capture executor crossed an unsupported publication boundary");
+        }
+        const identity = claimIdentity(normalized);
+        if (!identity) {
+          summary.operationIndeterminate += 1;
+          alertCodes.add(OPERATION_RECONCILE_CODE);
+          continue;
+        }
+        try {
+          throwIfAborted();
+          await dependencies.handoffCapturedOperation({
+            organizationId: identity.organizationId,
+            backupId: identity.backupId,
+            operationId: identity.operationId,
+            lifecycleGeneration: identity.lifecycleGeneration,
+            execution: {
+              ownerId: normalized.ownerId,
+              generation: normalized.generation,
+            },
+          });
+          throwIfAborted();
+        } catch {
+          throwIfAborted();
+          // The release CAS may have committed before its response was lost.
+          // Never synthesize publication success or overwrite captured state.
+          summary.operationIndeterminate += 1;
+          alertCodes.add(OPERATION_RECONCILE_CODE);
+          continue;
         }
         summary.operationCaptured += 1;
       } catch (error) {
@@ -832,6 +886,7 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
               authority: disposition.terminalSpoolCleanup,
               terminalErrorCode: OPERATION_CAPTURE_TERMINAL_CODE,
             });
+            throwIfAborted();
           } catch {
             throwIfAborted();
             // The non-authorizing local candidate is the crash bridge between
@@ -845,6 +900,7 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
           }
         }
         try {
+          throwIfAborted();
           await dependencies.failOperation({
             ...identity,
             expectedState: "capturing",
@@ -889,11 +945,13 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
     }
     if (params.publicationExecutor && isPublicationOperationClaim(claim)) {
       try {
+        throwIfAborted();
         const result = await params.publicationExecutor.execute({
           claim,
           leaseMs: params.config.operationLeaseMs,
           signal: params.signal,
         });
+        throwIfAborted();
         if (result.state === "protected") {
           summary.operationProtected += 1;
           continue;
@@ -960,12 +1018,13 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
   // immediately; response-loss cases are picked up here as well.
   throwIfAborted();
   await reconcileSchedules();
-  if (operationClaims.length > 0) await countOverdueSchedules();
+  if (summary.operationClaimed > 0) await countOverdueSchedules();
 
   throwIfAborted();
   if (params.spoolCleanupJanitor) {
     try {
-      const cleanup = await params.spoolCleanupJanitor.runCycle();
+      const cleanup = await params.spoolCleanupJanitor.runCycle(params.signal);
+      throwIfAborted();
       summary.spoolCleanup = {
         discovered: summary.spoolCleanup.discovered + cleanup.discovered,
         authorized: summary.spoolCleanup.authorized + cleanup.authorized,
@@ -1019,6 +1078,7 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
       limit: params.config.gcBatchSize,
       leaseMs: params.config.gcLeaseMs,
     });
+    throwIfAborted();
     summary.gcClaimed = gcClaims.length;
   } catch (error) {
     throwIfAborted();
@@ -1032,6 +1092,7 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
       const result = await dependencies.executeGcClaims({
         claims: [claim],
         registry: params.registry,
+        signal: params.signal,
         retryDelayMs: agentBackupCatalogRetryDelay({
           attempt: claim.outbox.attempts,
           baseMs: params.config.gcRetryBaseMs,
@@ -1039,6 +1100,7 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
           random: params.random,
         }),
       });
+      throwIfAborted();
       summary.gcCompleted += result.completed;
       summary.gcFailed += result.failed;
       if (result.failed > 0) alertCodes.add(GC_RETRY_CODE);

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.ts
@@ -208,7 +208,11 @@ export type AgentBackupCatalogRuntimePublicationState =
   | "secondary_pending";
 
 export interface AgentBackupCatalogRuntimePublicationExecutor {
-  execute(params: { claim: Readonly<AgentBackupOperationClaim>; leaseMs: number }): Promise<
+  execute(params: {
+    claim: Readonly<AgentBackupOperationClaim>;
+    leaseMs: number;
+    signal?: AbortSignal;
+  }): Promise<
     | { state: "protected" }
     | {
         state: "retryable-failure";
@@ -672,6 +676,8 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
   if (!params.registry) {
     throw new Error("Backup catalogue runtime requires both configured storage authorities");
   }
+  const throwIfAborted = (): void => params.signal?.throwIfAborted();
+  throwIfAborted();
 
   const dependencies = params.dependencies ?? DEFAULT_DEPENDENCIES;
   const alertCodes = new Set<string>();
@@ -684,6 +690,7 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
       summary.scheduleProtected += reconciled.protected;
       summary.scheduleRecycled += reconciled.recycled;
     } catch {
+      throwIfAborted();
       summary.scheduleIndeterminate += 1;
       alertCodes.add(SCHEDULE_RECONCILE_CODE);
     }
@@ -696,18 +703,21 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
         alertCodes.add(SCHEDULE_RPO_OVERDUE_CODE);
       }
     } catch {
+      throwIfAborted();
       summary.scheduleIndeterminate += 1;
       alertCodes.add(SCHEDULE_RECONCILE_CODE);
     }
   };
 
   if (params.config.scheduleEnabled) {
+    throwIfAborted();
     await reconcileSchedules();
     try {
       summary.scheduleEnrolled = await dependencies.enrollSchedules({
         limit: params.config.scheduleBatchSize,
       });
     } catch {
+      throwIfAborted();
       summary.scheduleIndeterminate += 1;
       alertCodes.add(SCHEDULE_RECONCILE_CODE);
     }
@@ -721,14 +731,17 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
       });
       summary.scheduleClaimed = scheduleClaims.length;
     } catch {
+      throwIfAborted();
       summary.scheduleIndeterminate += 1;
       alertCodes.add(SCHEDULE_RECONCILE_CODE);
     }
     for (const claim of scheduleClaims) {
+      throwIfAborted();
       try {
         await dependencies.reserveSchedule({ claim });
         summary.scheduleReserved += 1;
       } catch {
+        throwIfAborted();
         try {
           if (
             await dependencies.deferSchedule({
@@ -744,6 +757,7 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
             alertCodes.add(SCHEDULE_RECONCILE_CODE);
           }
         } catch {
+          throwIfAborted();
           summary.scheduleIndeterminate += 1;
           alertCodes.add(SCHEDULE_RECONCILE_CODE);
         }
@@ -753,9 +767,11 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
 
   // Emit the strict RPO signal before unrelated catalogue/GC dependencies can
   // fail. A later pass refreshes it when this tick may have published proof.
+  throwIfAborted();
   await countOverdueSchedules();
 
   let operationClaims: AgentBackupOperationClaim[] = [];
+  throwIfAborted();
   try {
     operationClaims = await dependencies.claimOperations({
       ownerId: params.config.ownerId,
@@ -764,16 +780,19 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
     });
     summary.operationClaimed = operationClaims.length;
   } catch (error) {
+    throwIfAborted();
     if (!params.config.scheduleEnabled) throw error;
     summary.operationIndeterminate += 1;
     alertCodes.add(OPERATION_RECONCILE_CODE);
   }
   for (const claim of operationClaims) {
+    throwIfAborted();
     if (params.captureExecutor && isCaptureOperationClaim(claim)) {
       let normalized: AgentBackupOperationClaim;
       try {
         normalized = await normalizeCaptureOperationClaim({ claim, dependencies });
       } catch {
+        throwIfAborted();
         // A lost transition response is indeterminate. The exact lease/state
         // will reconcile on a later claim without running a second executor.
         summary.operationIndeterminate += 1;
@@ -791,6 +810,7 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
         }
         summary.operationCaptured += 1;
       } catch (error) {
+        throwIfAborted();
         const identity = claimIdentity(normalized);
         if (!identity) {
           summary.operationIndeterminate += 1;
@@ -813,6 +833,7 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
               terminalErrorCode: OPERATION_CAPTURE_TERMINAL_CODE,
             });
           } catch {
+            throwIfAborted();
             // The non-authorizing local candidate is the crash bridge between
             // the terminal database CAS and cleanup. Never commit terminal when
             // that bridge is not durably confirmed.
@@ -857,6 +878,7 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
             alertCodes.add(OPERATION_CAPTURE_RETRY_CODE);
           }
         } catch {
+          throwIfAborted();
           // recordCaptured or the failure write may have committed before a lost
           // response. Never overwrite that ambiguity with a synthetic success.
           summary.operationIndeterminate += 1;
@@ -870,6 +892,7 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
         const result = await params.publicationExecutor.execute({
           claim,
           leaseMs: params.config.operationLeaseMs,
+          signal: params.signal,
         });
         if (result.state === "protected") {
           summary.operationProtected += 1;
@@ -900,6 +923,7 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
         summary.operationPublicationRetryScheduled += 1;
         alertCodes.add(OPERATION_PUBLICATION_RETRY_CODE);
       } catch {
+        throwIfAborted();
         // A transition or retry write may have committed before response loss.
         // Leave the exact leased row for reconciliation rather than guessing.
         summary.operationIndeterminate += 1;
@@ -923,6 +947,7 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
         alertCodes.add(OPERATION_RECONCILE_CODE);
       }
     } catch {
+      throwIfAborted();
       // error-policy:J1 the daemon receives static aggregate evidence; the
       // durable lease/state is reconciled after expiry without leaking locator data.
       summary.operationIndeterminate += 1;
@@ -933,9 +958,11 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
   // A publication executor may have reached `protected` in this cycle. Run a
   // second bounded exact-proof pass so its DB-clock RPO deadline is visible
   // immediately; response-loss cases are picked up here as well.
+  throwIfAborted();
   await reconcileSchedules();
   if (operationClaims.length > 0) await countOverdueSchedules();
 
+  throwIfAborted();
   if (params.spoolCleanupJanitor) {
     try {
       const cleanup = await params.spoolCleanupJanitor.runCycle();
@@ -951,27 +978,32 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
         alertCodes.add(SPOOL_CLEANUP_RECONCILE_CODE);
       }
     } catch {
+      throwIfAborted();
       summary.spoolCleanup.indeterminate += 1;
       alertCodes.add(SPOOL_CLEANUP_RECONCILE_CODE);
     }
   }
 
   let dueDeletions: AgentBackupDeletionCandidate[] = [];
+  throwIfAborted();
   try {
     dueDeletions = await dependencies.listDueDeletions({
       limit: params.config.deletionBatchSize,
     });
     summary.deletionCandidates = dueDeletions.length;
   } catch (error) {
+    throwIfAborted();
     if (!params.config.scheduleEnabled) throw error;
     summary.deletionEnqueueIndeterminate += 1;
     alertCodes.add(DELETION_ENQUEUE_RECONCILE_CODE);
   }
   for (const candidate of dueDeletions) {
+    throwIfAborted();
     try {
       const result = await dependencies.enqueueDeletion(candidate);
       summary.deletionEnqueued += result.enqueued;
     } catch {
+      throwIfAborted();
       // error-policy:J1 enqueue revalidates under lock; a stale or lost response
       // is retried from durable catalogue state without logging its locator.
       summary.deletionEnqueueIndeterminate += 1;
@@ -980,6 +1012,7 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
   }
 
   let gcClaims: AgentBackupGcClaim[] = [];
+  throwIfAborted();
   try {
     gcClaims = await dependencies.claimGc({
       ownerId: params.config.ownerId,
@@ -988,11 +1021,13 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
     });
     summary.gcClaimed = gcClaims.length;
   } catch (error) {
+    throwIfAborted();
     if (!params.config.scheduleEnabled) throw error;
     summary.gcIndeterminate += 1;
     alertCodes.add(GC_RECONCILE_CODE);
   }
   for (const claim of gcClaims) {
+    throwIfAborted();
     try {
       const result = await dependencies.executeGcClaims({
         claims: [claim],
@@ -1008,6 +1043,7 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
       summary.gcFailed += result.failed;
       if (result.failed > 0) alertCodes.add(GC_RETRY_CODE);
     } catch {
+      throwIfAborted();
       // A lost settlement response is deliberately indeterminate: the durable
       // completed row wins, or the lease expires and the exact claim is retried.
       summary.gcIndeterminate += 1;
@@ -1016,20 +1052,24 @@ export async function runAgentBackupCatalogRuntimeCycle(params: {
   }
 
   let finalizable: AgentBackupDeletionCandidate[] = [];
+  throwIfAborted();
   try {
     finalizable = await dependencies.listFinalizableDeletions({
       limit: params.config.deletionBatchSize,
     });
   } catch (error) {
+    throwIfAborted();
     if (!params.config.scheduleEnabled) throw error;
     summary.deletionFinalizeIndeterminate += 1;
     alertCodes.add(DELETION_FINALIZE_RECONCILE_CODE);
   }
   for (const candidate of finalizable) {
+    throwIfAborted();
     try {
       await dependencies.finalizeDeletion(candidate);
       summary.deletionFinalized += 1;
     } catch {
+      throwIfAborted();
       // error-policy:J1 finalization is receipt/CAS guarded; an ambiguous
       // response is harmless and a later bounded tick reconciles the tombstone.
       summary.deletionFinalizeIndeterminate += 1;

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker-composition.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker-composition.test.ts
@@ -5,7 +5,10 @@ import {
   createAgentBackupCatalogWorkerComposition,
   isAgentBackupCatalogWorkerEnabled,
 } from "./agent-backup-catalog-worker-composition";
-import { createAgentBackupCatalogWorkerEnabledComposition } from "./agent-backup-catalog-worker-enabled-composition";
+import {
+  createAgentBackupCatalogWorkerEnabledComposition,
+  readAgentBackupCatalogWorkerEnabledConfig,
+} from "./agent-backup-catalog-worker-enabled-composition";
 
 function enabledEnv(): NodeJS.ProcessEnv {
   return {
@@ -152,6 +155,18 @@ describe("backup catalogue disabled-first composition", () => {
 });
 
 describe("backup catalogue enabled provider graph", () => {
+  test("sorts plugin ids by manifest code-unit order instead of locale collation", () => {
+    const env = enabledEnv();
+    env.AGENT_BACKUP_RUNTIME_PLUGINS_JSON = JSON.stringify([
+      { id: "a_b", version: "1.0.0" },
+      { id: "a-b", version: "1.0.0" },
+    ]);
+    expect(readAgentBackupCatalogWorkerEnabledConfig(env).runtimeMetadata.plugins).toEqual([
+      { id: "a-b", version: "1.0.0" },
+      { id: "a_b", version: "1.0.0" },
+    ]);
+  });
+
   test("validates the complete config before constructing a provider", async () => {
     const createRegistry = mock(async () => ({}));
     await expect(
@@ -185,6 +200,46 @@ describe("backup catalogue enabled provider graph", () => {
         dependencies: { createRegistry: createRegistry as never },
       }),
     ).rejects.toThrow(/SECRETS_MASTER_KEY/);
+    expect(createRegistry).not.toHaveBeenCalled();
+  });
+
+  test("rejects provider deadlines that can outlive the operation lease fence", async () => {
+    const createRegistry = mock(async () => ({}));
+    for (const deadlineName of [
+      "AGENT_BACKUP_CAPTURE_DEADLINE_MS",
+      "AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS",
+    ] as const) {
+      const env = enabledEnv();
+      env.AGENT_BACKUP_OPERATION_LEASE_MS = "240000";
+      env[deadlineName] = "210001";
+      await expect(
+        createAgentBackupCatalogWorkerEnabledComposition({
+          env,
+          dependencies: { createRegistry: createRegistry as never },
+        }),
+      ).rejects.toThrow(/leave 30000ms.*OPERATION_LEASE_MS/);
+    }
+    expect(createRegistry).not.toHaveBeenCalled();
+  });
+
+  test("rejects control characters before constructing provider authorities", async () => {
+    const createRegistry = mock(async () => ({}));
+    for (const [name, value] of [
+      ["AGENT_BACKUP_CATALOG_WORKER_ID", "worker\tshadow"],
+      ["AGENT_BACKUP_R2_ENDPOINT_ALIAS", "r2\tshadow"],
+      ["AGENT_BACKUP_HETZNER_BUCKET", "bucket\nshadow"],
+      ["AGENT_BACKUP_HETZNER_ACCOUNT_ID", "a".repeat(257)],
+      ["AGENT_BACKUP_STEWARD_KMS_TOKEN", "kms-token\nshadow"],
+    ] as const) {
+      const env = enabledEnv();
+      env[name] = value;
+      await expect(
+        createAgentBackupCatalogWorkerEnabledComposition({
+          env,
+          dependencies: { createRegistry: createRegistry as never },
+        }),
+      ).rejects.toThrow(name);
+    }
     expect(createRegistry).not.toHaveBeenCalled();
   });
 

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker-composition.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker-composition.test.ts
@@ -1,0 +1,250 @@
+/** Production-composition contracts for the disabled manifest-v3 worker. */
+
+import { describe, expect, mock, test } from "bun:test";
+import {
+  createAgentBackupCatalogWorkerComposition,
+  isAgentBackupCatalogWorkerEnabled,
+} from "./agent-backup-catalog-worker-composition";
+import { createAgentBackupCatalogWorkerEnabledComposition } from "./agent-backup-catalog-worker-enabled-composition";
+
+function enabledEnv(): NodeJS.ProcessEnv {
+  return {
+    AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "1",
+    AGENT_BACKUP_RPO_SCHEDULER_ENABLED: "0",
+    AGENT_BACKUP_CATALOG_WORKER_ID: "catalog-worker-1",
+    DATABASE_URL: "postgresql://backup-worker:secret@database.example.test/eliza",
+    SECRETS_MASTER_KEY: "a".repeat(64),
+    AGENT_BACKUP_R2_ENDPOINT_ALIAS: "r2-primary",
+    AGENT_BACKUP_R2_ACCOUNT_ID: "r2-account",
+    AGENT_BACKUP_R2_BUCKET: "r2-bucket",
+    AGENT_BACKUP_R2_REGION: "auto",
+    AGENT_BACKUP_R2_ENDPOINT: "https://r2.example.test",
+    AGENT_BACKUP_R2_ACCESS_KEY_ID: "r2-access",
+    AGENT_BACKUP_R2_SECRET_ACCESS_KEY: "r2-secret",
+    AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS: "hetzner-secondary",
+    AGENT_BACKUP_HETZNER_ACCOUNT_ID: "hetzner-account",
+    AGENT_BACKUP_HETZNER_ENDPOINT: "https://object-storage.example.test",
+    AGENT_BACKUP_HETZNER_BUCKET: "hetzner-bucket",
+    AGENT_BACKUP_HETZNER_REGION: "fsn1",
+    AGENT_BACKUP_HETZNER_ACCESS_KEY_ID: "hetzner-access",
+    AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY: "hetzner-secret",
+    AGENT_BACKUP_SPOOL_STATE_DIRECTORY: "/var/lib/eliza-backup-catalog/spool",
+    AGENT_BACKUP_SPOOL_MAX_BYTES: String(8 * 1024 ** 3),
+    AGENT_BACKUP_SPOOL_MIN_FREE_BYTES: String(1024 ** 3),
+    AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE: "32",
+    AGENT_BACKUP_CAPTURE_DEADLINE_MS: "60000",
+    AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS: "60000",
+    AGENT_BACKUP_STORAGE_SCOPE: "production-eu",
+    AGENT_BACKUP_AGENT_SCHEMA_VERSION: "2.0.0",
+    AGENT_BACKUP_DATABASE_SCHEMA_VERSION: "238",
+    AGENT_BACKUP_RUNTIME_PLUGINS_JSON: JSON.stringify([
+      { id: "@elizaos/plugin-sql", version: "2.0.0" },
+    ]),
+    AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID: "deploy-23844",
+    AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT: "2026-08-21T00:00:00.000Z",
+    AGENT_BACKUP_STEWARD_KMS_BASE_URL: "https://steward.example.test",
+    AGENT_BACKUP_STEWARD_KMS_TOKEN: "kms-token",
+  };
+}
+
+function runtimeSummary() {
+  return {
+    enabled: true,
+    scheduleEnrolled: 0,
+    scheduleProtected: 0,
+    scheduleRecycled: 0,
+    scheduleClaimed: 0,
+    scheduleReserved: 0,
+    scheduleDeferred: 0,
+    scheduleIndeterminate: 0,
+    scheduleOverdue: 0,
+    operationClaimed: 0,
+    operationCaptured: 0,
+    operationCaptureRetryScheduled: 0,
+    operationCaptureTerminal: 0,
+    operationProtected: 0,
+    operationPublicationRetryScheduled: 0,
+    operationDeferred: 0,
+    operationIndeterminate: 0,
+    spoolCleanup: {
+      discovered: 0,
+      authorized: 0,
+      completed: 0,
+      pending: 0,
+      skippedUnprotected: 0,
+      indeterminate: 0,
+    },
+    deletionCandidates: 0,
+    deletionEnqueued: 0,
+    deletionEnqueueIndeterminate: 0,
+    gcClaimed: 0,
+    gcCompleted: 0,
+    gcFailed: 0,
+    gcIndeterminate: 0,
+    deletionFinalized: 0,
+    deletionFinalizeIndeterminate: 0,
+    alertCodes: [] as string[],
+  };
+}
+
+describe("backup catalogue disabled-first composition", () => {
+  test("reads only the two gates and never loads the enabled provider graph", async () => {
+    const reads: string[] = [];
+    const env = new Proxy(
+      {
+        AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "0",
+        AGENT_BACKUP_RPO_SCHEDULER_ENABLED: "0",
+      } as NodeJS.ProcessEnv,
+      {
+        get(target, property, receiver) {
+          if (typeof property === "string") reads.push(property);
+          return Reflect.get(target, property, receiver);
+        },
+      },
+    );
+    const loadEnabledComposition = mock(async () => {
+      throw new Error("enabled composition must stay unloaded");
+    });
+    const composition = await createAgentBackupCatalogWorkerComposition({
+      env,
+      loadEnabledComposition,
+    });
+    expect(composition.enabled).toBe(false);
+    expect((await composition.runCycle()).enabled).toBe(false);
+    expect(loadEnabledComposition).not.toHaveBeenCalled();
+    expect(reads.sort()).toEqual([
+      "AGENT_BACKUP_CATALOG_RUNTIME_ENABLED",
+      "AGENT_BACKUP_RPO_SCHEDULER_ENABLED",
+    ]);
+  });
+
+  test("rejects an orphaned schedule gate before importing enabled dependencies", async () => {
+    const loadEnabledComposition = mock(async () => {
+      throw new Error("unexpected import");
+    });
+    expect(() =>
+      isAgentBackupCatalogWorkerEnabled({
+        AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "0",
+        AGENT_BACKUP_RPO_SCHEDULER_ENABLED: "1",
+      }),
+    ).toThrow(/requires/);
+    expect(loadEnabledComposition).not.toHaveBeenCalled();
+  });
+
+  test("loads one enabled production module and forwards exactly one cycle", async () => {
+    const runCycle = mock(async () => runtimeSummary());
+    const createEnabled = mock(async () => ({ enabled: true, runCycle }));
+    const composition = await createAgentBackupCatalogWorkerComposition({
+      env: {
+        AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "1",
+        AGENT_BACKUP_RPO_SCHEDULER_ENABLED: "0",
+      },
+      loadEnabledComposition: async () => ({
+        createAgentBackupCatalogWorkerEnabledComposition: createEnabled,
+      }),
+    });
+    const signal = new AbortController().signal;
+    await composition.runCycle(signal);
+    expect(createEnabled).toHaveBeenCalledTimes(1);
+    expect(runCycle).toHaveBeenCalledTimes(1);
+    expect(runCycle).toHaveBeenCalledWith(signal);
+  });
+});
+
+describe("backup catalogue enabled provider graph", () => {
+  test("validates the complete config before constructing a provider", async () => {
+    const createRegistry = mock(async () => ({}));
+    await expect(
+      createAgentBackupCatalogWorkerEnabledComposition({
+        env: {
+          AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "1",
+          AGENT_BACKUP_RPO_SCHEDULER_ENABLED: "0",
+        },
+        dependencies: { createRegistry: createRegistry as never },
+      }),
+    ).rejects.toThrow(/AGENT_BACKUP_CATALOG_WORKER_ID/);
+    expect(createRegistry).not.toHaveBeenCalled();
+  });
+
+  test("rejects database and field-encryption fallbacks before constructing a provider", async () => {
+    const createRegistry = mock(async () => ({}));
+    const missingDatabase = enabledEnv();
+    delete missingDatabase.DATABASE_URL;
+    await expect(
+      createAgentBackupCatalogWorkerEnabledComposition({
+        env: missingDatabase,
+        dependencies: { createRegistry: createRegistry as never },
+      }),
+    ).rejects.toThrow(/DATABASE_URL/);
+
+    const missingMasterKey = enabledEnv();
+    delete missingMasterKey.SECRETS_MASTER_KEY;
+    await expect(
+      createAgentBackupCatalogWorkerEnabledComposition({
+        env: missingMasterKey,
+        dependencies: { createRegistry: createRegistry as never },
+      }),
+    ).rejects.toThrow(/SECRETS_MASTER_KEY/);
+    expect(createRegistry).not.toHaveBeenCalled();
+  });
+
+  test("binds one registry, KMS, key bundle and spool across the real runtime cycle", async () => {
+    const registry = { kind: "registry" };
+    const kms = { kind: "kms" };
+    const keyBundle = { kind: "key-bundle" };
+    const resolveContext = mock(async () => ({}));
+    const captureExecutor = { kind: "capture" };
+    const resolveSource = mock(async () => ({}));
+    const publicationExecutor = { kind: "publication" };
+    const janitor = { kind: "janitor" };
+    const createRegistry = mock(async () => registry);
+    const createKms = mock(() => kms);
+    const createKeyBundle = mock(() => keyBundle);
+    const createContextResolver = mock(() => resolveContext);
+    const createCaptureExecutor = mock(() => captureExecutor);
+    const createPublicationSource = mock(() => resolveSource);
+    const createPublicationExecutor = mock(() => publicationExecutor);
+    const createJanitor = mock(() => janitor);
+    const runCycle = mock(async () => runtimeSummary());
+    const composition = await createAgentBackupCatalogWorkerEnabledComposition({
+      env: enabledEnv(),
+      dependencies: {
+        createRegistry: createRegistry as never,
+        createKms: createKms as never,
+        createKeyBundle: createKeyBundle as never,
+        createContextResolver: createContextResolver as never,
+        createCaptureExecutor: createCaptureExecutor as never,
+        createPublicationSource: createPublicationSource as never,
+        createPublicationExecutor: createPublicationExecutor as never,
+        createJanitor: createJanitor as never,
+        runCycle: runCycle as never,
+      },
+    });
+    const signal = new AbortController().signal;
+    await composition.runCycle(signal);
+
+    expect(createRegistry).toHaveBeenCalledTimes(1);
+    expect(createKms).toHaveBeenCalledTimes(1);
+    expect(createKeyBundle).toHaveBeenCalledTimes(1);
+    expect(createContextResolver).toHaveBeenCalledTimes(1);
+    expect(createCaptureExecutor).toHaveBeenCalledTimes(1);
+    expect(createPublicationSource).toHaveBeenCalledTimes(1);
+    expect(createPublicationExecutor).toHaveBeenCalledTimes(1);
+    expect(createJanitor).toHaveBeenCalledTimes(1);
+    expect(createContextResolver.mock.calls[0]?.[0]).toMatchObject({
+      keyBundle,
+      spool: { stateDirectory: "/var/lib/eliza-backup-catalog/spool" },
+    });
+    expect(createPublicationSource.mock.calls[0]?.[0]).toMatchObject({
+      spool: { stateDirectory: "/var/lib/eliza-backup-catalog/spool" },
+    });
+    expect(createPublicationExecutor.mock.calls[0]?.[0]).toMatchObject({ registry, resolveSource });
+    expect(runCycle.mock.calls[0]?.[0]).toMatchObject({
+      registry,
+      captureExecutor,
+      publicationExecutor,
+      spoolCleanupJanitor: janitor,
+      signal,
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker-composition.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker-composition.ts
@@ -1,0 +1,98 @@
+/**
+ * Disabled-first production entrypoint for the manifest-v3 backup catalogue.
+ * The two gates are the only environment names read before the enabled
+ * composition is dynamically imported, so disabled hosts cannot initialize
+ * storage, KMS, database, provider, executor, or spool authorities.
+ */
+
+import type { AgentBackupCatalogRuntimeSummary } from "./agent-backup-catalog-runtime";
+
+export interface AgentBackupCatalogWorkerComposition {
+  readonly enabled: boolean;
+  runCycle(signal?: AbortSignal): Promise<AgentBackupCatalogRuntimeSummary>;
+}
+
+export interface AgentBackupCatalogWorkerEnabledCompositionModule {
+  createAgentBackupCatalogWorkerEnabledComposition(input: {
+    env: NodeJS.ProcessEnv;
+  }): Promise<AgentBackupCatalogWorkerComposition>;
+}
+
+export interface CreateAgentBackupCatalogWorkerCompositionOptions {
+  env?: NodeJS.ProcessEnv;
+  /** Test seam proving the disabled branch performs no enabled-module load. */
+  loadEnabledComposition?: () => Promise<AgentBackupCatalogWorkerEnabledCompositionModule>;
+}
+
+function disabledSummary(): AgentBackupCatalogRuntimeSummary {
+  return {
+    enabled: false,
+    scheduleEnrolled: 0,
+    scheduleProtected: 0,
+    scheduleRecycled: 0,
+    scheduleClaimed: 0,
+    scheduleReserved: 0,
+    scheduleDeferred: 0,
+    scheduleIndeterminate: 0,
+    scheduleOverdue: 0,
+    operationClaimed: 0,
+    operationCaptured: 0,
+    operationCaptureRetryScheduled: 0,
+    operationCaptureTerminal: 0,
+    operationProtected: 0,
+    operationPublicationRetryScheduled: 0,
+    operationDeferred: 0,
+    operationIndeterminate: 0,
+    spoolCleanup: {
+      discovered: 0,
+      authorized: 0,
+      completed: 0,
+      pending: 0,
+      skippedUnprotected: 0,
+      indeterminate: 0,
+    },
+    deletionCandidates: 0,
+    deletionEnqueued: 0,
+    deletionEnqueueIndeterminate: 0,
+    gcClaimed: 0,
+    gcCompleted: 0,
+    gcFailed: 0,
+    gcIndeterminate: 0,
+    deletionFinalized: 0,
+    deletionFinalizeIndeterminate: 0,
+    alertCodes: [],
+  };
+}
+
+/** Parse only the two gates; every other environment read belongs after this boundary. */
+export function isAgentBackupCatalogWorkerEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const scheduleEnabled = env.AGENT_BACKUP_RPO_SCHEDULER_ENABLED === "1";
+  if (env.AGENT_BACKUP_CATALOG_RUNTIME_ENABLED !== "1") {
+    if (scheduleEnabled) {
+      throw new Error(
+        "AGENT_BACKUP_RPO_SCHEDULER_ENABLED requires AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=1",
+      );
+    }
+    return false;
+  }
+  return true;
+}
+
+/** Build one process-wide production composition, or a zero-authority disabled facade. */
+export async function createAgentBackupCatalogWorkerComposition(
+  options: CreateAgentBackupCatalogWorkerCompositionOptions = {},
+): Promise<AgentBackupCatalogWorkerComposition> {
+  const env = options.env ?? process.env;
+  if (!isAgentBackupCatalogWorkerEnabled(env)) {
+    return Object.freeze({
+      enabled: false,
+      async runCycle() {
+        return disabledSummary();
+      },
+    });
+  }
+  const enabledModule = options.loadEnabledComposition
+    ? await options.loadEnabledComposition()
+    : await import("./agent-backup-catalog-worker-enabled-composition");
+  return enabledModule.createAgentBackupCatalogWorkerEnabledComposition({ env });
+}

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker-enabled-composition.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker-enabled-composition.ts
@@ -1,0 +1,376 @@
+/**
+ * Real enabled composition for the dedicated manifest-v3 catalogue worker.
+ * This module is imported only after the disabled-first gate boundary. It
+ * validates all configuration before constructing one shared registry, spool,
+ * Steward KMS/key-bundle provider, capture/publication pair, and janitor.
+ */
+
+import path from "node:path";
+import {
+  createKmsClient,
+  KmsAeadOperationKeyBundleProvider,
+  type KmsClient,
+} from "@elizaos/core/security/kms";
+import { AGENT_BACKUP_CAPTURE_V2_LIMITS } from "@elizaos/shared";
+import { recordCapturedAgentBackupManifest } from "../../db/repositories/agent-backup-catalog";
+import {
+  type AgentBackupCaptureV3LegacyWriterDrainReceipt,
+  createAgentBackupCaptureV2CatalogExecutor,
+} from "./agent-backup-capture-v2-catalog-executor";
+import type { AgentBackupCaptureV3SpoolConfig } from "./agent-backup-capture-v2-spool";
+import { createAgentBackupCaptureV3PublicationSourceResolver } from "./agent-backup-capture-v3-publication-source";
+import { createAgentBackupCaptureV3RuntimeContextResolver } from "./agent-backup-capture-v3-runtime-context";
+import { createAgentBackupCaptureV3SpoolCleanupJanitor } from "./agent-backup-capture-v3-spool-cleanup";
+import {
+  type AgentBackupCatalogRuntimeConfig,
+  createAgentBackupCatalogRegistryFromEnv,
+  readAgentBackupCatalogRuntimeConfig,
+  runAgentBackupCatalogRuntimeCycle,
+} from "./agent-backup-catalog-runtime";
+import type { AgentBackupCatalogWorkerComposition } from "./agent-backup-catalog-worker-composition";
+import { createAgentBackupCatalogPublicationExecutor } from "./agent-backup-publication-executor";
+
+const MAX_SPOOL_BYTES = 1024 ** 4;
+const MAX_TOKEN_BYTES = 16 * 1024;
+const PLUGIN_ID_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/;
+const VERSION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+:-]{0,127}$/;
+const DEPLOYMENT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+export interface AgentBackupCatalogWorkerEnabledConfig {
+  runtime: Extract<AgentBackupCatalogRuntimeConfig, { enabled: true }>;
+  spool: AgentBackupCaptureV3SpoolConfig;
+  spoolCleanupBatchSize: number;
+  captureDeadlineMs: number;
+  publication: {
+    scope: string;
+    primaryEndpointAlias: string;
+    secondaryEndpointAlias: string;
+    objectTransferDeadlineMs: number;
+  };
+  runtimeMetadata: {
+    agentSchemaVersion: string;
+    databaseSchemaVersion: string;
+    plugins: readonly { id: string; version: string }[];
+  };
+  legacyWriterDrain: AgentBackupCaptureV3LegacyWriterDrainReceipt;
+  kms: {
+    baseUrl: string;
+    token: string;
+  };
+}
+
+export interface AgentBackupCatalogWorkerEnabledCompositionDependencies {
+  createRegistry: typeof createAgentBackupCatalogRegistryFromEnv;
+  createKms(options: { baseUrl: string; tokenProvider: () => Promise<string> }): KmsClient;
+  createKeyBundle(kms: KmsClient): KmsAeadOperationKeyBundleProvider;
+  createContextResolver: typeof createAgentBackupCaptureV3RuntimeContextResolver;
+  createCaptureExecutor: typeof createAgentBackupCaptureV2CatalogExecutor;
+  createPublicationSource: typeof createAgentBackupCaptureV3PublicationSourceResolver;
+  createPublicationExecutor: typeof createAgentBackupCatalogPublicationExecutor;
+  createJanitor: typeof createAgentBackupCaptureV3SpoolCleanupJanitor;
+  runCycle: typeof runAgentBackupCatalogRuntimeCycle;
+}
+
+function requiredText(env: NodeJS.ProcessEnv, name: string, maxBytes = 512): string {
+  const value = env[name];
+  if (
+    !value ||
+    value !== value.trim() ||
+    value.includes("\0") ||
+    Buffer.byteLength(value, "utf8") > maxBytes
+  ) {
+    throw new Error(`${name} must be explicitly configured with a canonical value`);
+  }
+  return value;
+}
+
+function requiredSecret(env: NodeJS.ProcessEnv, name: string): string {
+  const value = env[name];
+  if (!value || value.includes("\0") || Buffer.byteLength(value, "utf8") > MAX_TOKEN_BYTES) {
+    throw new Error(`${name} must be explicitly configured when backup catalogue is enabled`);
+  }
+  return value;
+}
+
+function boundedInteger(params: {
+  env: NodeJS.ProcessEnv;
+  name: string;
+  min: number;
+  max: number;
+}): number {
+  const value = requiredText(params.env, params.name, 32);
+  if (!/^[1-9][0-9]*$/.test(value)) {
+    throw new Error(`${params.name} must be a canonical positive integer`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < params.min || parsed > params.max) {
+    throw new Error(`${params.name} must be between ${params.min} and ${params.max}`);
+  }
+  return parsed;
+}
+
+function canonicalUrl(env: NodeJS.ProcessEnv, name: string): string {
+  const value = requiredText(env, name, 2048);
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch (cause) {
+    throw new Error(`${name} must be an absolute URL`, { cause });
+  }
+  const loopbackHttp =
+    parsed.protocol === "http:" &&
+    (parsed.hostname === "localhost" ||
+      parsed.hostname === "127.0.0.1" ||
+      parsed.hostname === "[::1]");
+  if (
+    (parsed.protocol !== "https:" && !loopbackHttp) ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    throw new Error(`${name} must be a credential-free HTTPS URL`);
+  }
+  parsed.pathname = parsed.pathname.replace(/\/+$/, "") || "/";
+  return parsed.toString().replace(/\/$/, "");
+}
+
+function pluginVersions(env: NodeJS.ProcessEnv): readonly { id: string; version: string }[] {
+  const raw = requiredText(env, "AGENT_BACKUP_RUNTIME_PLUGINS_JSON", 64 * 1024);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (cause) {
+    throw new Error("AGENT_BACKUP_RUNTIME_PLUGINS_JSON must be valid JSON", { cause });
+  }
+  if (!Array.isArray(parsed) || parsed.length > 256) {
+    throw new Error("AGENT_BACKUP_RUNTIME_PLUGINS_JSON must be an array with at most 256 entries");
+  }
+  const result = parsed.map((entry, index) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`AGENT_BACKUP_RUNTIME_PLUGINS_JSON[${index}] must be an object`);
+    }
+    const keys = Object.keys(entry).sort();
+    const id = Reflect.get(entry, "id");
+    const version = Reflect.get(entry, "version");
+    if (
+      keys.length !== 2 ||
+      keys[0] !== "id" ||
+      keys[1] !== "version" ||
+      typeof id !== "string" ||
+      typeof version !== "string" ||
+      id.length > 214 ||
+      !PLUGIN_ID_PATTERN.test(id) ||
+      !VERSION_PATTERN.test(version)
+    ) {
+      throw new Error(`AGENT_BACKUP_RUNTIME_PLUGINS_JSON[${index}] is not canonical`);
+    }
+    return { id, version };
+  });
+  result.sort((left, right) => left.id.localeCompare(right.id));
+  if (result.some((entry, index) => index > 0 && entry.id === result[index - 1]?.id)) {
+    throw new Error("AGENT_BACKUP_RUNTIME_PLUGINS_JSON contains a duplicate plugin id");
+  }
+  return Object.freeze(result.map((entry) => Object.freeze(entry)));
+}
+
+function kmsConfig(env: NodeJS.ProcessEnv): AgentBackupCatalogWorkerEnabledConfig["kms"] {
+  const baseUrl = canonicalUrl(env, "AGENT_BACKUP_STEWARD_KMS_BASE_URL");
+  return {
+    baseUrl,
+    token: requiredSecret(env, "AGENT_BACKUP_STEWARD_KMS_TOKEN"),
+  };
+}
+
+/** Validate the complete enabled contract before any provider or spool is created. */
+export function readAgentBackupCatalogWorkerEnabledConfig(
+  env: NodeJS.ProcessEnv,
+): AgentBackupCatalogWorkerEnabledConfig {
+  const runtime = readAgentBackupCatalogRuntimeConfig(env);
+  if (!runtime.enabled) throw new Error("Enabled backup catalogue composition requires its gate");
+
+  const databaseUrl = requiredText(env, "DATABASE_URL", 16 * 1024);
+  let parsedDatabaseUrl: URL;
+  try {
+    parsedDatabaseUrl = new URL(databaseUrl);
+  } catch (cause) {
+    throw new Error("DATABASE_URL must be an absolute PostgreSQL URL", { cause });
+  }
+  if (
+    (parsedDatabaseUrl.protocol !== "postgres:" && parsedDatabaseUrl.protocol !== "postgresql:") ||
+    !parsedDatabaseUrl.hostname
+  ) {
+    throw new Error("DATABASE_URL must be an absolute PostgreSQL URL");
+  }
+  const secretsMasterKey = requiredSecret(env, "SECRETS_MASTER_KEY");
+  if (!/^[0-9a-fA-F]{64}$/.test(secretsMasterKey)) {
+    throw new Error("SECRETS_MASTER_KEY must be exactly 32 bytes encoded as hexadecimal");
+  }
+
+  // Validate every storage name up-front; the registry factory is not allowed
+  // to partially initialize before a later configuration failure is found.
+  for (const name of [
+    "AGENT_BACKUP_R2_ENDPOINT_ALIAS",
+    "AGENT_BACKUP_R2_ACCOUNT_ID",
+    "AGENT_BACKUP_R2_BUCKET",
+    "AGENT_BACKUP_R2_REGION",
+    "AGENT_BACKUP_R2_ENDPOINT",
+    "AGENT_BACKUP_R2_ACCESS_KEY_ID",
+    "AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS",
+    "AGENT_BACKUP_HETZNER_ACCOUNT_ID",
+    "AGENT_BACKUP_HETZNER_ENDPOINT",
+    "AGENT_BACKUP_HETZNER_BUCKET",
+    "AGENT_BACKUP_HETZNER_REGION",
+    "AGENT_BACKUP_HETZNER_ACCESS_KEY_ID",
+  ] as const) {
+    requiredText(env, name, 2048);
+  }
+  requiredSecret(env, "AGENT_BACKUP_R2_SECRET_ACCESS_KEY");
+  requiredSecret(env, "AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY");
+  canonicalUrl(env, "AGENT_BACKUP_R2_ENDPOINT");
+  canonicalUrl(env, "AGENT_BACKUP_HETZNER_ENDPOINT");
+
+  const primaryEndpointAlias = requiredText(env, "AGENT_BACKUP_R2_ENDPOINT_ALIAS");
+  const secondaryEndpointAlias = requiredText(env, "AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS");
+  if (primaryEndpointAlias === secondaryEndpointAlias) {
+    throw new Error("Primary and secondary backup endpoint aliases must be distinct");
+  }
+  const stateDirectory = requiredText(env, "AGENT_BACKUP_SPOOL_STATE_DIRECTORY", 4096);
+  if (!path.isAbsolute(stateDirectory) || path.parse(stateDirectory).root === stateDirectory) {
+    throw new Error("AGENT_BACKUP_SPOOL_STATE_DIRECTORY must be a specific absolute path");
+  }
+  const maxSpoolBytes = boundedInteger({
+    env,
+    name: "AGENT_BACKUP_SPOOL_MAX_BYTES",
+    min: 1024 ** 2,
+    max: MAX_SPOOL_BYTES,
+  });
+  const minFreeBytes = boundedInteger({
+    env,
+    name: "AGENT_BACKUP_SPOOL_MIN_FREE_BYTES",
+    min: 1,
+    max: MAX_SPOOL_BYTES,
+  });
+  if (minFreeBytes >= maxSpoolBytes) {
+    throw new Error("AGENT_BACKUP_SPOOL_MIN_FREE_BYTES must be smaller than spool capacity");
+  }
+  const agentSchemaVersion = requiredText(env, "AGENT_BACKUP_AGENT_SCHEMA_VERSION", 128);
+  const databaseSchemaVersion = requiredText(env, "AGENT_BACKUP_DATABASE_SCHEMA_VERSION", 128);
+  if (!VERSION_PATTERN.test(agentSchemaVersion) || !VERSION_PATTERN.test(databaseSchemaVersion)) {
+    throw new Error("Backup runtime schema versions must be canonical manifest versions");
+  }
+  const deploymentId = requiredText(env, "AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID", 128);
+  const drainedAt = requiredText(env, "AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT", 64);
+  if (
+    !DEPLOYMENT_ID_PATTERN.test(deploymentId) ||
+    !Number.isFinite(Date.parse(drainedAt)) ||
+    new Date(drainedAt).toISOString() !== drainedAt
+  ) {
+    throw new Error("Backup legacy-writer drain receipt must be canonical");
+  }
+  const scope = requiredText(env, "AGENT_BACKUP_STORAGE_SCOPE", 128);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(scope)) {
+    throw new Error("AGENT_BACKUP_STORAGE_SCOPE must be a canonical storage scope");
+  }
+  return {
+    runtime,
+    spool: { stateDirectory, maxSpoolBytes, minFreeBytes },
+    spoolCleanupBatchSize: boundedInteger({
+      env,
+      name: "AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE",
+      min: 1,
+      max: 100,
+    }),
+    captureDeadlineMs: boundedInteger({
+      env,
+      name: "AGENT_BACKUP_CAPTURE_DEADLINE_MS",
+      min: 1,
+      max: AGENT_BACKUP_CAPTURE_V2_LIMITS.maxDeadlineAheadMs,
+    }),
+    publication: {
+      scope,
+      primaryEndpointAlias,
+      secondaryEndpointAlias,
+      objectTransferDeadlineMs: boundedInteger({
+        env,
+        name: "AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS",
+        min: 1,
+        max: 15 * 60_000,
+      }),
+    },
+    runtimeMetadata: {
+      agentSchemaVersion,
+      databaseSchemaVersion,
+      plugins: pluginVersions(env),
+    },
+    legacyWriterDrain: {
+      format: "elizaos.agent-backup.capture-v3-legacy-writer-drain.v1",
+      deploymentId,
+      drainedAt,
+    },
+    kms: kmsConfig(env),
+  };
+}
+
+const DEFAULT_DEPENDENCIES: AgentBackupCatalogWorkerEnabledCompositionDependencies = {
+  createRegistry: createAgentBackupCatalogRegistryFromEnv,
+  createKms: ({ baseUrl, tokenProvider }) =>
+    createKmsClient({ backend: "steward", steward: { baseUrl, tokenProvider } }),
+  createKeyBundle: (kms) => new KmsAeadOperationKeyBundleProvider(kms),
+  createContextResolver: createAgentBackupCaptureV3RuntimeContextResolver,
+  createCaptureExecutor: createAgentBackupCaptureV2CatalogExecutor,
+  createPublicationSource: createAgentBackupCaptureV3PublicationSourceResolver,
+  createPublicationExecutor: createAgentBackupCatalogPublicationExecutor,
+  createJanitor: createAgentBackupCaptureV3SpoolCleanupJanitor,
+  runCycle: runAgentBackupCatalogRuntimeCycle,
+};
+
+/** Construct exactly one compatible provider/executor graph for this process. */
+export async function createAgentBackupCatalogWorkerEnabledComposition(input: {
+  env: NodeJS.ProcessEnv;
+  dependencies?: Partial<AgentBackupCatalogWorkerEnabledCompositionDependencies>;
+}): Promise<AgentBackupCatalogWorkerComposition> {
+  const config = readAgentBackupCatalogWorkerEnabledConfig(input.env);
+  const dependencies = { ...DEFAULT_DEPENDENCIES, ...input.dependencies };
+  const registry = await dependencies.createRegistry({ env: input.env });
+  const kms = dependencies.createKms({
+    baseUrl: config.kms.baseUrl,
+    tokenProvider: async () => config.kms.token,
+  });
+  const keyBundle = dependencies.createKeyBundle(kms);
+  const resolveContext = dependencies.createContextResolver({
+    spool: config.spool,
+    keyBundle,
+    runtime: config.runtimeMetadata,
+  });
+  const captureExecutor = dependencies.createCaptureExecutor(
+    {
+      resolveContext,
+      recordCaptured: recordCapturedAgentBackupManifest,
+      captureDeadlineMs: config.captureDeadlineMs,
+    },
+    config.legacyWriterDrain,
+  );
+  const resolveSource = dependencies.createPublicationSource({ spool: config.spool });
+  const publicationExecutor = dependencies.createPublicationExecutor({
+    config: config.publication,
+    registry,
+    resolveSource,
+  });
+  const spoolCleanupJanitor = dependencies.createJanitor({
+    spool: config.spool,
+    batchSize: config.spoolCleanupBatchSize,
+  });
+  return Object.freeze({
+    enabled: true,
+    runCycle: (signal?: AbortSignal) =>
+      dependencies.runCycle({
+        config: config.runtime,
+        registry,
+        captureExecutor,
+        publicationExecutor,
+        spoolCleanupJanitor,
+        signal,
+      }),
+  });
+}

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker-enabled-composition.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker-enabled-composition.ts
@@ -32,9 +32,11 @@ import { createAgentBackupCatalogPublicationExecutor } from "./agent-backup-publ
 
 const MAX_SPOOL_BYTES = 1024 ** 4;
 const MAX_TOKEN_BYTES = 16 * 1024;
+const MAX_PROVIDER_IDENTITY_BYTES = 256;
 const PLUGIN_ID_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/;
 const VERSION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+:-]{0,127}$/;
 const DEPLOYMENT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const OPERATION_LEASE_SETTLEMENT_MARGIN_MS = 30_000;
 
 export interface AgentBackupCatalogWorkerEnabledConfig {
   runtime: Extract<AgentBackupCatalogRuntimeConfig, { enabled: true }>;
@@ -76,7 +78,7 @@ function requiredText(env: NodeJS.ProcessEnv, name: string, maxBytes = 512): str
   if (
     !value ||
     value !== value.trim() ||
-    value.includes("\0") ||
+    /[\u0000-\u001f\u007f]/.test(value) ||
     Buffer.byteLength(value, "utf8") > maxBytes
   ) {
     throw new Error(`${name} must be explicitly configured with a canonical value`);
@@ -86,7 +88,11 @@ function requiredText(env: NodeJS.ProcessEnv, name: string, maxBytes = 512): str
 
 function requiredSecret(env: NodeJS.ProcessEnv, name: string): string {
   const value = env[name];
-  if (!value || value.includes("\0") || Buffer.byteLength(value, "utf8") > MAX_TOKEN_BYTES) {
+  if (
+    !value ||
+    /[\u0000-\u001f\u007f]/.test(value) ||
+    Buffer.byteLength(value, "utf8") > MAX_TOKEN_BYTES
+  ) {
     throw new Error(`${name} must be explicitly configured when backup catalogue is enabled`);
   }
   return value;
@@ -167,7 +173,8 @@ function pluginVersions(env: NodeJS.ProcessEnv): readonly { id: string; version:
     }
     return { id, version };
   });
-  result.sort((left, right) => left.id.localeCompare(right.id));
+  // Manifest canonicalization compares code units, not locale collation.
+  result.sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0));
   if (result.some((entry, index) => index > 0 && entry.id === result[index - 1]?.id)) {
     throw new Error("AGENT_BACKUP_RUNTIME_PLUGINS_JSON contains a duplicate plugin id");
   }
@@ -214,15 +221,16 @@ export function readAgentBackupCatalogWorkerEnabledConfig(
     "AGENT_BACKUP_R2_ACCOUNT_ID",
     "AGENT_BACKUP_R2_BUCKET",
     "AGENT_BACKUP_R2_REGION",
-    "AGENT_BACKUP_R2_ENDPOINT",
     "AGENT_BACKUP_R2_ACCESS_KEY_ID",
     "AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS",
     "AGENT_BACKUP_HETZNER_ACCOUNT_ID",
-    "AGENT_BACKUP_HETZNER_ENDPOINT",
     "AGENT_BACKUP_HETZNER_BUCKET",
     "AGENT_BACKUP_HETZNER_REGION",
     "AGENT_BACKUP_HETZNER_ACCESS_KEY_ID",
   ] as const) {
+    requiredText(env, name, MAX_PROVIDER_IDENTITY_BYTES);
+  }
+  for (const name of ["AGENT_BACKUP_R2_ENDPOINT", "AGENT_BACKUP_HETZNER_ENDPOINT"] as const) {
     requiredText(env, name, 2048);
   }
   requiredSecret(env, "AGENT_BACKUP_R2_SECRET_ACCESS_KEY");
@@ -230,8 +238,16 @@ export function readAgentBackupCatalogWorkerEnabledConfig(
   canonicalUrl(env, "AGENT_BACKUP_R2_ENDPOINT");
   canonicalUrl(env, "AGENT_BACKUP_HETZNER_ENDPOINT");
 
-  const primaryEndpointAlias = requiredText(env, "AGENT_BACKUP_R2_ENDPOINT_ALIAS");
-  const secondaryEndpointAlias = requiredText(env, "AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS");
+  const primaryEndpointAlias = requiredText(
+    env,
+    "AGENT_BACKUP_R2_ENDPOINT_ALIAS",
+    MAX_PROVIDER_IDENTITY_BYTES,
+  );
+  const secondaryEndpointAlias = requiredText(
+    env,
+    "AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS",
+    MAX_PROVIDER_IDENTITY_BYTES,
+  );
   if (primaryEndpointAlias === secondaryEndpointAlias) {
     throw new Error("Primary and secondary backup endpoint aliases must be distinct");
   }
@@ -272,6 +288,28 @@ export function readAgentBackupCatalogWorkerEnabledConfig(
   if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(scope)) {
     throw new Error("AGENT_BACKUP_STORAGE_SCOPE must be a canonical storage scope");
   }
+  const captureDeadlineMs = boundedInteger({
+    env,
+    name: "AGENT_BACKUP_CAPTURE_DEADLINE_MS",
+    min: 1,
+    max: AGENT_BACKUP_CAPTURE_V2_LIMITS.maxDeadlineAheadMs,
+  });
+  const objectTransferDeadlineMs = boundedInteger({
+    env,
+    name: "AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS",
+    min: 1,
+    max: 15 * 60_000,
+  });
+  const providerDeadlineCeiling = runtime.operationLeaseMs - OPERATION_LEASE_SETTLEMENT_MARGIN_MS;
+  if (
+    providerDeadlineCeiling < 1 ||
+    captureDeadlineMs > providerDeadlineCeiling ||
+    objectTransferDeadlineMs > providerDeadlineCeiling
+  ) {
+    throw new Error(
+      "Backup capture and object-transfer deadlines must leave 30000ms inside AGENT_BACKUP_OPERATION_LEASE_MS for fenced settlement",
+    );
+  }
   return {
     runtime,
     spool: { stateDirectory, maxSpoolBytes, minFreeBytes },
@@ -281,22 +319,12 @@ export function readAgentBackupCatalogWorkerEnabledConfig(
       min: 1,
       max: 100,
     }),
-    captureDeadlineMs: boundedInteger({
-      env,
-      name: "AGENT_BACKUP_CAPTURE_DEADLINE_MS",
-      min: 1,
-      max: AGENT_BACKUP_CAPTURE_V2_LIMITS.maxDeadlineAheadMs,
-    }),
+    captureDeadlineMs,
     publication: {
       scope,
       primaryEndpointAlias,
       secondaryEndpointAlias,
-      objectTransferDeadlineMs: boundedInteger({
-        env,
-        name: "AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS",
-        min: 1,
-        max: 15 * 60_000,
-      }),
+      objectTransferDeadlineMs,
     },
     runtimeMetadata: {
       agentSchemaVersion,

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { AgentBackupGcClaim } from "../../db/repositories/agent-backup-gc";
 import type { AgentBackupObject } from "../../db/schemas/agent-backup-catalog";
 import type {
   AgentBackupObjectStore,
@@ -12,6 +13,7 @@ import {
 } from "../storage/object-store";
 import {
   type AgentBackupObjectUploadRepository,
+  executeAgentBackupGcClaims,
   executeAgentBackupObjectUpload,
   executeAgentBackupSecondaryObjectReplication,
 } from "./agent-backup-catalog-worker";
@@ -655,5 +657,75 @@ describe("secondary backup replication", () => {
     } finally {
       process.off("unhandledRejection", onUnhandled);
     }
+  });
+});
+
+describe("backup GC provider cancellation", () => {
+  test("propagates abort and the lease deadline to delete without settling or starting the next claim", async () => {
+    const keyFingerprint = (await sha256(PRIMARY_KEY)).hex;
+    const authority: AgentBackupStorageAuthority = {
+      provider: "cloudflare-r2",
+      transport: "worker-r2",
+      endpointAlias: "primary-r2",
+      endpointIdentityFingerprint: FINGERPRINT,
+      bucket: "primary-bucket",
+      region: "auto",
+    };
+    const object = objectRow({
+      id: "e0000000-0000-4000-8000-000000000005",
+      role: "primary",
+      provider: "cloudflare-r2",
+      transport: "worker-r2",
+      authority,
+      objectKey: PRIMARY_KEY,
+      keyFingerprint,
+      ciphertextSha256: "a".repeat(64),
+      sizeBytes: 32,
+      state: "verified",
+    });
+    const leaseExpiresAt = new Date(Date.now() + 60_000);
+    const claim = (index: number) =>
+      ({
+        outbox: {
+          id: `f0000000-0000-4000-8000-00000000000${index}`,
+          organization_id: ORGANIZATION_ID,
+          object_id: object.id,
+          action: "delete_object",
+          state: "leased",
+          claim_owner: "gc-worker-1",
+          claim_generation: EXECUTION.generation,
+          lease_expires_at: leaseExpiresAt,
+          attempts: 0,
+        },
+        object: { ...object, id: `e0000000-0000-4000-8000-00000000000${index}` },
+      }) as AgentBackupGcClaim;
+    const controller = new AbortController();
+    let deleteCalls = 0;
+    const store = {
+      authority,
+      async delete(_target, control) {
+        deleteCalls += 1;
+        expect(control?.signal).toBe(controller.signal);
+        expect(control?.deadline?.getTime()).toBe(leaseExpiresAt.getTime() - 1_000);
+        controller.abort(new Error("shutdown during provider delete"));
+        control?.signal?.throwIfAborted();
+        throw new Error("unreachable delete continuation");
+      },
+    } as AgentBackupObjectStore;
+    const registry = {
+      forStoredObject() {
+        return store;
+      },
+    } as AgentBackupObjectStoreRegistry;
+
+    await expect(
+      executeAgentBackupGcClaims({
+        claims: [claim(1), claim(2)],
+        registry,
+        retryDelayMs: 1_000,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("shutdown during provider delete");
+    expect(deleteCalls).toBe(1);
   });
 });

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker.ts
@@ -35,10 +35,12 @@ import {
   type ObjectDeleteReceipt,
   type ObjectHeadReceipt,
   ObjectLocatorReceipt,
+  type ObjectRequestControl,
   ObjectStorageLifecycleError,
 } from "../storage/object-store";
 
 const MAX_GC_RETRY_DELAY_MS = 6 * 60 * 60 * 1_000;
+const GC_LEASE_SETTLEMENT_MARGIN_MS = 1_000;
 
 async function sha256Bytes(bytes: Uint8Array): Promise<Uint8Array> {
   const stableBytes = new Uint8Array(new ArrayBuffer(bytes.byteLength));
@@ -184,12 +186,14 @@ function storedObjectLocator(object: AgentBackupObject): ObjectLocatorReceipt | 
 async function resolveGcDeletionLocator(
   store: AgentBackupObjectStore,
   claim: AgentBackupGcClaim,
+  control: ObjectRequestControl,
 ): Promise<{ claim: AgentBackupGcClaim; locator: ObjectLocatorReceipt }> {
   const { object } = claim;
   const persisted = storedObjectLocator(object);
   if (persisted) return { claim, locator: persisted };
 
-  const observed = await store.head(object.object_key);
+  const observed = await store.head(object.object_key, control);
+  control.signal?.throwIfAborted();
   requireLocatorMatchesObject(object, observed.locator);
   if (observed.status === "absent") {
     if (!object.provider_write_started) {
@@ -243,6 +247,7 @@ async function resolveGcDeletionLocator(
     providerChecksum: checksumIdentity(observed.metadata.checksum),
     uploadReceiptDigest: recoveredUploadReceiptDigest,
   });
+  control.signal?.throwIfAborted();
   const locator = storedObjectLocator(adopted.object);
   if (!locator) {
     throw new ObjectStorageLifecycleError(
@@ -661,6 +666,7 @@ async function deletionReceiptDigest(
 export async function executeAgentBackupGcClaim(params: {
   claim: AgentBackupGcClaim;
   registry: AgentBackupObjectStoreRegistry;
+  signal?: AbortSignal;
 }): Promise<void> {
   const { claim } = params;
   const generation = claim.outbox.claim_generation;
@@ -668,14 +674,29 @@ export async function executeAgentBackupGcClaim(params: {
   if (!generation || !ownerId) {
     throw new Error("Claimed backup GC intent is missing its execution fence");
   }
+  params.signal?.throwIfAborted();
+  const leaseExpiresAt = claim.outbox.lease_expires_at;
+  if (!(leaseExpiresAt instanceof Date) || !Number.isFinite(leaseExpiresAt.getTime())) {
+    throw new Error("Claimed backup GC intent has no canonical lease expiry");
+  }
+  const control: ObjectRequestControl = {
+    signal: params.signal,
+    deadline: new Date(leaseExpiresAt.getTime() - GC_LEASE_SETTLEMENT_MARGIN_MS),
+  };
   const store = params.registry.forStoredObject(storedAgentBackupObjectAuthority(claim.object));
-  const resolved = await resolveGcDeletionLocator(store, claim);
-  const receipt = await store.delete({
-    key: resolved.claim.object.object_key,
-    locator: resolved.locator,
-  });
+  const resolved = await resolveGcDeletionLocator(store, claim, control);
+  params.signal?.throwIfAborted();
+  const receipt = await store.delete(
+    {
+      key: resolved.claim.object.object_key,
+      locator: resolved.locator,
+    },
+    control,
+  );
+  params.signal?.throwIfAborted();
   requireLocatorMatchesObject(resolved.claim.object, receipt.locator);
   const receiptDigest = await deletionReceiptDigest(resolved.claim, receipt);
+  params.signal?.throwIfAborted();
   await settleAgentBackupGc({
     outboxId: resolved.claim.outbox.id,
     ownerId,
@@ -711,6 +732,7 @@ export async function executeAgentBackupGcClaims(params: {
   claims: readonly AgentBackupGcClaim[];
   registry: AgentBackupObjectStoreRegistry;
   retryDelayMs: number;
+  signal?: AbortSignal;
 }): Promise<{ completed: number; failed: number }> {
   if (
     !Number.isSafeInteger(params.retryDelayMs) ||
@@ -722,10 +744,16 @@ export async function executeAgentBackupGcClaims(params: {
   let completed = 0;
   let failed = 0;
   for (const claim of params.claims) {
+    params.signal?.throwIfAborted();
     try {
-      await executeAgentBackupGcClaim({ claim, registry: params.registry });
+      await executeAgentBackupGcClaim({
+        claim,
+        registry: params.registry,
+        signal: params.signal,
+      });
       completed += 1;
     } catch (error) {
+      params.signal?.throwIfAborted();
       // error-policy:J1 the durable worker boundary translates provider failure
       // into a retryable or terminal outbox receipt before continuing the batch.
       const ownerId = claim.outbox.claim_owner;

--- a/packages/cloud/shared/src/lib/services/agent-backup-publication-executor.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-publication-executor.test.ts
@@ -197,6 +197,164 @@ function dependencies(params: {
 }
 
 describe("post-capture backup publication", () => {
+  test("rejects an already-aborted signal at every executor entry without transition or I/O", async () => {
+    const fixture = await publicationFixture();
+    const capturedClaim = claim({ state: "captured", inventoryDigest: fixture.inventoryDigest });
+    const primaryVerifiedClaim = claim({
+      state: "primary_verified",
+      inventoryDigest: fixture.inventoryDigest,
+    });
+    const events: string[] = [];
+    const reason = new Error("publication shutdown");
+    const controller = new AbortController();
+    controller.abort(reason);
+    const resolveSource = async (): Promise<AgentBackupCapturedPublicationSource> => {
+      events.push("source-resolve");
+      throw new Error("aborted publication must not resolve its source");
+    };
+    const abortedDependencies = dependencies({
+      initialClaim: primaryVerifiedClaim,
+      events,
+      listPrimary: async () => {
+        events.push("primary-list");
+        return fixture.chunks.map((chunk) => primaryObject(chunk));
+      },
+      replicate: async () => {
+        events.push("replicate");
+        return {} as AgentBackupObject;
+      },
+    });
+
+    for (const execute of [
+      () =>
+        executeAgentBackupPrimaryPublication({
+          claim: capturedClaim,
+          leaseMs: 60_000,
+          scope: "production-eu",
+          primaryEndpointAlias: "primary-r2",
+          registry: UNUSED_REGISTRY,
+          resolveSource,
+          dependencies: abortedDependencies,
+          signal: controller.signal,
+        }),
+      () =>
+        executeAgentBackupSecondaryReplication({
+          claim: primaryVerifiedClaim,
+          leaseMs: 60_000,
+          scope: "production-eu",
+          secondaryEndpointAlias: "secondary-hetzner",
+          registry: UNUSED_REGISTRY,
+          dependencies: abortedDependencies,
+          signal: controller.signal,
+        }),
+      () =>
+        executeAgentBackupPostCapturePublication({
+          claim: primaryVerifiedClaim,
+          leaseMs: 60_000,
+          config: {
+            scope: "production-eu",
+            primaryEndpointAlias: "primary-r2",
+            secondaryEndpointAlias: "secondary-hetzner",
+          },
+          registry: UNUSED_REGISTRY,
+          resolveSource,
+          dependencies: abortedDependencies,
+          signal: controller.signal,
+        }),
+    ]) {
+      await expect(execute()).rejects.toBe(reason);
+    }
+    expect(events).toEqual([]);
+  });
+
+  test("stops between primary and secondary after abort while preserving an exact replay boundary", async () => {
+    const fixture = await publicationFixture();
+    const initialClaim = claim({
+      state: "primary_uploaded",
+      inventoryDigest: fixture.inventoryDigest,
+    });
+    const events: string[] = [];
+    const controller = new AbortController();
+    const reason = new Error("shutdown after primary source close");
+    let secondaryLists = 0;
+    let replications = 0;
+    await expect(
+      executeAgentBackupPostCapturePublication({
+        claim: initialClaim,
+        leaseMs: 60_000,
+        config: {
+          scope: "production-eu",
+          primaryEndpointAlias: "primary-r2",
+          secondaryEndpointAlias: "secondary-hetzner",
+        },
+        registry: UNUSED_REGISTRY,
+        resolveSource: async () => {
+          const source = sourceFixture({
+            chunks: fixture.chunks,
+            bodies: fixture.bodies,
+            inventoryDigest: fixture.inventoryDigest,
+            events,
+            returnedBodies: [],
+          });
+          return {
+            ...source,
+            async close() {
+              events.push("source-close");
+              controller.abort(reason);
+            },
+          };
+        },
+        dependencies: dependencies({
+          initialClaim,
+          events,
+          listPrimary: async () => {
+            secondaryLists += 1;
+            return fixture.chunks.map((chunk) => primaryObject(chunk));
+          },
+          replicate: async () => {
+            replications += 1;
+            return {} as AgentBackupObject;
+          },
+        }),
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(reason);
+
+    expect(events).toContain("transition:primary_uploaded->primary_verified");
+    expect(events).not.toContain("transition:primary_verified->secondary_pending");
+    expect(secondaryLists).toBe(0);
+    expect(replications).toBe(0);
+
+    const replayClaim = claim({
+      state: "primary_verified",
+      inventoryDigest: fixture.inventoryDigest,
+    });
+    const replayed = await executeAgentBackupPostCapturePublication({
+      claim: replayClaim,
+      leaseMs: 60_000,
+      config: {
+        scope: "production-eu",
+        primaryEndpointAlias: "primary-r2",
+        secondaryEndpointAlias: "secondary-hetzner",
+      },
+      registry: UNUSED_REGISTRY,
+      resolveSource: async () => {
+        throw new Error("primary-verified replay must not reopen the spool");
+      },
+      dependencies: dependencies({
+        initialClaim: replayClaim,
+        events: [],
+        listPrimary: async () => fixture.chunks.map((chunk) => primaryObject(chunk)),
+        replicate: async () => {
+          replications += 1;
+          return {} as AgentBackupObject;
+        },
+      }),
+    });
+    expect(replayed.backup.catalog_state).toBe("protected");
+    expect(replications).toBe(fixture.chunks.length);
+  });
+
   test("publishes repository-owned primary slots, journals every chunk, and zeroes spool copies", async () => {
     const fixture = await publicationFixture();
     const initialClaim = claim({ state: "captured", inventoryDigest: fixture.inventoryDigest });

--- a/packages/cloud/shared/src/lib/services/agent-backup-publication-executor.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-publication-executor.ts
@@ -242,7 +242,9 @@ async function heartbeat(params: {
   claim: Readonly<AgentBackupOperationClaim>;
   leaseMs: number;
   dependencies: AgentBackupPublicationExecutorDependencies;
+  signal?: AbortSignal;
 }): Promise<void> {
+  params.signal?.throwIfAborted();
   const identity = operationIdentity(params.claim);
   await params.dependencies.heartbeatOperation({
     organizationId: identity.organizationId,
@@ -250,6 +252,7 @@ async function heartbeat(params: {
     execution: execution(params.claim),
     leaseMs: params.leaseMs,
   });
+  params.signal?.throwIfAborted();
 }
 
 async function transition(params: {
@@ -259,8 +262,11 @@ async function transition(params: {
   resumeState?: AgentBackupCatalogState;
   leaseMs: number;
   dependencies: AgentBackupPublicationExecutorDependencies;
+  signal?: AbortSignal;
 }): Promise<AgentBackupOperationClaim> {
+  params.signal?.throwIfAborted();
   await heartbeat(params);
+  params.signal?.throwIfAborted();
   const backup = await params.dependencies.transitionOperation({
     ...operationIdentity(params.claim),
     expectedState: params.expectedState,
@@ -268,6 +274,7 @@ async function transition(params: {
     resumeState: params.resumeState,
     execution: execution(params.claim),
   });
+  params.signal?.throwIfAborted();
   return { ...params.claim, backup };
 }
 
@@ -275,7 +282,9 @@ async function resumePublicationClaim(params: {
   claim: Readonly<AgentBackupOperationClaim>;
   leaseMs: number;
   dependencies: AgentBackupPublicationExecutorDependencies;
+  signal?: AbortSignal;
 }): Promise<AgentBackupOperationClaim> {
+  params.signal?.throwIfAborted();
   const state = params.claim.backup.catalog_state;
   if (state !== "failed_retryable") return { ...params.claim };
   const resumeState = params.claim.backup.catalog_resume_state;
@@ -334,7 +343,9 @@ function canonicalChunks(
 async function validatePublicationSource(params: {
   claim: Readonly<AgentBackupOperationClaim>;
   source: AgentBackupCapturedPublicationSource;
+  signal?: AbortSignal;
 }): Promise<AgentBackupCapturedPublicationChunk[]> {
+  params.signal?.throwIfAborted();
   const identity = operationIdentity(params.claim);
   const backup = params.claim.backup;
   if (
@@ -354,9 +365,11 @@ async function validatePublicationSource(params: {
     });
   }
   const chunks = canonicalChunks(params.source.chunks);
+  const inventoryDigest = await agentBackupObjectInventoryDigest(chunks);
+  params.signal?.throwIfAborted();
   if (
     chunks.length !== backup.manifest_object_count ||
-    (await agentBackupObjectInventoryDigest(chunks)) !== backup.object_inventory_digest
+    inventoryDigest !== backup.object_inventory_digest
   ) {
     throw new ElizaError("Captured publication inventory does not match the manifest digest", {
       code: "BACKUP_PUBLICATION_SOURCE_MISMATCH",
@@ -404,6 +417,7 @@ export interface ExecuteAgentBackupPrimaryPublicationInput {
 export async function executeAgentBackupPrimaryPublication(
   input: Readonly<ExecuteAgentBackupPrimaryPublicationInput>,
 ): Promise<AgentBackupOperationClaim> {
+  input.signal?.throwIfAborted();
   requireLeaseMs(input.leaseMs);
   const dependencies = input.dependencies ?? DEFAULT_DEPENDENCIES;
   const deadline = resolveTransferDeadline({
@@ -411,11 +425,14 @@ export async function executeAgentBackupPrimaryPublication(
     deadlineMs: input.objectTransferDeadlineMs,
     dependencies,
   });
+  input.signal?.throwIfAborted();
   let claim = await resumePublicationClaim({
     claim: input.claim,
     leaseMs: input.leaseMs,
     dependencies,
+    signal: input.signal,
   });
+  input.signal?.throwIfAborted();
   let state = claim.backup.catalog_state;
   if (state === "primary_verified" || state === "secondary_pending") return claim;
   if (state !== "captured" && state !== "uploading" && state !== "primary_uploaded") {
@@ -431,12 +448,14 @@ export async function executeAgentBackupPrimaryPublication(
 
   let source: AgentBackupCapturedPublicationSource;
   try {
+    input.signal?.throwIfAborted();
     source = await input.resolveSource({
       claim,
       execution: execution(claim),
       signal: input.signal,
     });
   } catch (cause) {
+    input.signal?.throwIfAborted();
     // error-policy:J2 source failures retain their durable spool and become an
     // exact-state retry without exposing filesystem or object-key details.
     throw stageFailure({ state, phase: "primary", cause });
@@ -444,35 +463,48 @@ export async function executeAgentBackupPrimaryPublication(
 
   let failure: unknown;
   try {
-    const chunks = await validatePublicationSource({ claim, source });
+    input.signal?.throwIfAborted();
+    const chunks = await validatePublicationSource({ claim, source, signal: input.signal });
+    input.signal?.throwIfAborted();
     if (state === "captured") {
       try {
+        input.signal?.throwIfAborted();
         claim = await transition({
           claim,
           expectedState: "captured",
           to: "uploading",
           leaseMs: input.leaseMs,
           dependencies,
+          signal: input.signal,
         });
+        input.signal?.throwIfAborted();
         state = "uploading";
       } catch (cause) {
+        input.signal?.throwIfAborted();
         throw stageFailure({ state: "captured", phase: "primary", cause });
       }
     }
+    input.signal?.throwIfAborted();
     await source.beginPrimaryPublication();
+    input.signal?.throwIfAborted();
     if (state === "uploading") {
       const identity = operationIdentity(claim);
       for (const chunk of chunks) {
-        await heartbeat({ claim, leaseMs: input.leaseMs, dependencies });
+        input.signal?.throwIfAborted();
+        await heartbeat({ claim, leaseMs: input.leaseMs, dependencies, signal: input.signal });
+        input.signal?.throwIfAborted();
         let body: Uint8Array | undefined;
         try {
+          input.signal?.throwIfAborted();
           body = await source.readCiphertextChunk(chunk, input.signal);
+          input.signal?.throwIfAborted();
           if (body.byteLength !== chunk.sizeBytes) {
             throw new ElizaError("Capture spool returned a different encrypted byte length", {
               code: "BACKUP_PUBLICATION_SOURCE_MISMATCH",
               severity: "fatal",
             });
           }
+          input.signal?.throwIfAborted();
           await dependencies.uploadObject({
             organizationId: identity.organizationId,
             backupId: identity.backupId,
@@ -488,29 +520,41 @@ export async function executeAgentBackupPrimaryPublication(
             contentType: "application/octet-stream",
             signal: input.signal,
             deadline,
-            revalidateLease: () => heartbeat({ claim, leaseMs: input.leaseMs, dependencies }),
+            revalidateLease: () =>
+              heartbeat({ claim, leaseMs: input.leaseMs, dependencies, signal: input.signal }),
           });
+          input.signal?.throwIfAborted();
           await source.markPrimaryChunkUploaded(chunk);
+          input.signal?.throwIfAborted();
         } catch (cause) {
+          input.signal?.throwIfAborted();
           // error-policy:J2 the static stage error preserves the underlying
           // provider/spool cause without exposing its key in the public message.
           throw stageFailure({ state: "uploading", phase: "primary", cause });
         } finally {
           body?.fill(0);
         }
-        await heartbeat({ claim, leaseMs: input.leaseMs, dependencies });
+        input.signal?.throwIfAborted();
+        await heartbeat({ claim, leaseMs: input.leaseMs, dependencies, signal: input.signal });
+        input.signal?.throwIfAborted();
       }
+      input.signal?.throwIfAborted();
       claim = await transition({
         claim,
         expectedState: "uploading",
         to: "primary_uploaded",
         leaseMs: input.leaseMs,
         dependencies,
+        signal: input.signal,
       });
+      input.signal?.throwIfAborted();
     }
     try {
+      input.signal?.throwIfAborted();
       await source.markPrimaryPublished();
+      input.signal?.throwIfAborted();
     } catch (cause) {
+      input.signal?.throwIfAborted();
       // error-policy:J2 the persisted primary objects remain replayable while
       // the exact primary_uploaded state retains source-journal reconciliation.
       throw stageFailure({ state: "primary_uploaded", phase: "primary", cause });
@@ -521,18 +565,23 @@ export async function executeAgentBackupPrimaryPublication(
       to: "primary_verified",
       leaseMs: input.leaseMs,
       dependencies,
+      signal: input.signal,
     });
+    input.signal?.throwIfAborted();
   } catch (cause) {
     failure = cause;
   }
   await closeSource(source, failure);
+  input.signal?.throwIfAborted();
   return claim;
 }
 
 async function validatePrimaryInventory(params: {
   backup: StoredAgentSandboxBackup;
   objects: readonly AgentBackupObject[];
+  signal?: AbortSignal;
 }): Promise<AgentBackupObject[]> {
+  params.signal?.throwIfAborted();
   if (!params.backup.manifest_object_count || !params.backup.object_inventory_digest) {
     throw new ElizaError("Secondary replication is missing manifest inventory authority", {
       code: "BACKUP_PUBLICATION_AUTHORITY_INCOMPLETE",
@@ -566,6 +615,7 @@ async function validatePrimaryInventory(params: {
       sizeBytes: object.size_bytes,
     })),
   );
+  params.signal?.throwIfAborted();
   if (
     objects.length !== params.backup.manifest_object_count ||
     digest !== params.backup.object_inventory_digest
@@ -595,6 +645,7 @@ export interface ExecuteAgentBackupSecondaryReplicationInput {
 export async function executeAgentBackupSecondaryReplication(
   input: Readonly<ExecuteAgentBackupSecondaryReplicationInput>,
 ): Promise<AgentBackupOperationClaim> {
+  input.signal?.throwIfAborted();
   requireLeaseMs(input.leaseMs);
   const dependencies = input.dependencies ?? DEFAULT_DEPENDENCIES;
   const deadline = resolveTransferDeadline({
@@ -602,19 +653,25 @@ export async function executeAgentBackupSecondaryReplication(
     deadlineMs: input.objectTransferDeadlineMs,
     dependencies,
   });
+  input.signal?.throwIfAborted();
   let claim = await resumePublicationClaim({
     claim: input.claim,
     leaseMs: input.leaseMs,
     dependencies,
+    signal: input.signal,
   });
+  input.signal?.throwIfAborted();
   if (claim.backup.catalog_state === "primary_verified") {
+    input.signal?.throwIfAborted();
     claim = await transition({
       claim,
       expectedState: "primary_verified",
       to: "secondary_pending",
       leaseMs: input.leaseMs,
       dependencies,
+      signal: input.signal,
     });
+    input.signal?.throwIfAborted();
   }
   if (claim.backup.catalog_state === "protected") return claim;
   if (claim.backup.catalog_state !== "secondary_pending") {
@@ -634,16 +691,22 @@ export async function executeAgentBackupSecondaryReplication(
   }
   let primaryObjects: AgentBackupObject[];
   try {
-    await heartbeat({ claim, leaseMs: input.leaseMs, dependencies });
+    input.signal?.throwIfAborted();
+    await heartbeat({ claim, leaseMs: input.leaseMs, dependencies, signal: input.signal });
+    input.signal?.throwIfAborted();
     primaryObjects = await dependencies.listVerifiedPrimaryObjects({
       ...identity,
       execution: execution(claim),
     });
+    input.signal?.throwIfAborted();
     primaryObjects = await validatePrimaryInventory({
       backup: claim.backup,
       objects: primaryObjects,
+      signal: input.signal,
     });
+    input.signal?.throwIfAborted();
   } catch (cause) {
+    input.signal?.throwIfAborted();
     // error-policy:J2 an unprovable persisted primary inventory remains in the
     // exact secondary_pending state for fenced retry.
     throw stageFailure({ state: "secondary_pending", phase: "secondary", cause });
@@ -651,7 +714,9 @@ export async function executeAgentBackupSecondaryReplication(
 
   for (const primaryObject of primaryObjects) {
     try {
-      await heartbeat({ claim, leaseMs: input.leaseMs, dependencies });
+      input.signal?.throwIfAborted();
+      await heartbeat({ claim, leaseMs: input.leaseMs, dependencies, signal: input.signal });
+      input.signal?.throwIfAborted();
       await dependencies.replicateObject({
         organizationId: identity.organizationId,
         backupId: identity.backupId,
@@ -662,24 +727,32 @@ export async function executeAgentBackupSecondaryReplication(
         manifestDigest,
         registry: input.registry,
         execution: execution(claim),
-        revalidateLease: () => heartbeat({ claim, leaseMs: input.leaseMs, dependencies }),
+        revalidateLease: () =>
+          heartbeat({ claim, leaseMs: input.leaseMs, dependencies, signal: input.signal }),
         signal: input.signal,
         deadline,
       });
-      await heartbeat({ claim, leaseMs: input.leaseMs, dependencies });
+      input.signal?.throwIfAborted();
+      await heartbeat({ claim, leaseMs: input.leaseMs, dependencies, signal: input.signal });
+      input.signal?.throwIfAborted();
     } catch (cause) {
+      input.signal?.throwIfAborted();
       // error-policy:J2 provider/read failures stay key-free and retry from the
       // persisted exact primary locator; no capture source is available here.
       throw stageFailure({ state: "secondary_pending", phase: "secondary", cause });
     }
   }
-  return transition({
+  input.signal?.throwIfAborted();
+  const protectedClaim = await transition({
     claim,
     expectedState: "secondary_pending",
     to: "protected",
     leaseMs: input.leaseMs,
     dependencies,
+    signal: input.signal,
   });
+  input.signal?.throwIfAborted();
+  return protectedClaim;
 }
 
 export interface ExecuteAgentBackupPostCapturePublicationInput {
@@ -696,11 +769,13 @@ export interface ExecuteAgentBackupPostCapturePublicationInput {
 export async function executeAgentBackupPostCapturePublication(
   input: Readonly<ExecuteAgentBackupPostCapturePublicationInput>,
 ): Promise<AgentBackupOperationClaim> {
+  input.signal?.throwIfAborted();
   const dependencies = input.dependencies ?? DEFAULT_DEPENDENCIES;
   const deadline = resolveTransferDeadline({
     deadlineMs: input.config.objectTransferDeadlineMs,
     dependencies,
   });
+  input.signal?.throwIfAborted();
   const primary = await executeAgentBackupPrimaryPublication({
     claim: input.claim,
     leaseMs: input.leaseMs,
@@ -712,7 +787,8 @@ export async function executeAgentBackupPostCapturePublication(
     signal: input.signal,
     deadline,
   });
-  return executeAgentBackupSecondaryReplication({
+  input.signal?.throwIfAborted();
+  const protectedClaim = await executeAgentBackupSecondaryReplication({
     claim: primary,
     leaseMs: input.leaseMs,
     scope: input.config.scope,
@@ -722,6 +798,8 @@ export async function executeAgentBackupPostCapturePublication(
     signal: input.signal,
     deadline,
   });
+  input.signal?.throwIfAborted();
+  return protectedClaim;
 }
 
 /** Bind post-capture authorities once for the bounded catalogue dispatcher. */
@@ -734,6 +812,7 @@ export function createAgentBackupCatalogPublicationExecutor(params: {
   return {
     async execute({ claim, leaseMs, signal }) {
       try {
+        signal?.throwIfAborted();
         const completed = await executeAgentBackupPostCapturePublication({
           claim,
           leaseMs,
@@ -743,6 +822,7 @@ export function createAgentBackupCatalogPublicationExecutor(params: {
           dependencies: params.dependencies,
           signal,
         });
+        signal?.throwIfAborted();
         if (completed.backup.catalog_state !== "protected") {
           throw new ElizaError("Backup publication did not reach protected", {
             code: "BACKUP_PUBLICATION_STATE_INVALID",

--- a/packages/cloud/shared/src/lib/services/agent-backup-publication-executor.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-publication-executor.ts
@@ -732,7 +732,7 @@ export function createAgentBackupCatalogPublicationExecutor(params: {
   dependencies?: AgentBackupPublicationExecutorDependencies;
 }): AgentBackupCatalogRuntimePublicationExecutor {
   return {
-    async execute({ claim, leaseMs }) {
+    async execute({ claim, leaseMs, signal }) {
       try {
         const completed = await executeAgentBackupPostCapturePublication({
           claim,
@@ -741,6 +741,7 @@ export function createAgentBackupCatalogPublicationExecutor(params: {
           registry: params.registry,
           resolveSource: params.resolveSource,
           dependencies: params.dependencies,
+          signal,
         });
         if (completed.backup.catalog_state !== "protected") {
           throw new ElizaError("Backup publication did not reach protected", {

--- a/packages/cloud/shared/src/lib/storage/agent-backup-object-store.ts
+++ b/packages/cloud/shared/src/lib/storage/agent-backup-object-store.ts
@@ -73,7 +73,7 @@ export interface AgentBackupObjectStore {
   /** Stream one exact catalogued generation; await `completion` before commit. */
   getExactObject(input: GetExactObjectInput): Promise<ExactObjectRead>;
   putImmutable(params: PutImmutableObjectInput): Promise<ImmutableObjectUploadReceipt>;
-  delete(target: ObjectDeleteTarget): Promise<ObjectDeleteReceipt>;
+  delete(target: ObjectDeleteTarget, control?: ObjectRequestControl): Promise<ObjectDeleteReceipt>;
 }
 
 /** Explicit alias registry used by catalogue workers and GC replayers. */
@@ -229,7 +229,8 @@ export async function createAgentBackupObjectStore(
     getExactObject: (input: GetExactObjectInput) => getExactObjectAtBackend({ backend, input }),
     putImmutable: (params: Parameters<AgentBackupObjectStore["putImmutable"]>[0]) =>
       putImmutableObjectAtBackend({ backend, ...params }),
-    delete: (target: ObjectDeleteTarget) => deleteObjectAtBackend({ backend, target }),
+    delete: (target: ObjectDeleteTarget, control?: ObjectRequestControl) =>
+      deleteObjectAtBackend({ backend, target, control }),
   });
 }
 

--- a/packages/cloud/shared/src/lib/storage/object-store.test.ts
+++ b/packages/cloud/shared/src/lib/storage/object-store.test.ts
@@ -49,6 +49,7 @@ const s3Versions = new Map<string, Map<string, StoredTestObject>>();
 const s3ReplacementBeforeDelete = new Map<string, StoredTestObject>();
 const s3Calls: S3Call[] = [];
 let s3Server: ReturnType<typeof Bun.serve>;
+let slowDeleteAborted = false;
 
 function clearStorageEnv(): void {
   for (const key of STORAGE_ENV_KEYS) delete process.env[key];
@@ -151,6 +152,26 @@ beforeAll(() => {
         });
       }
       if (request.method === "DELETE") {
+        if (key === "slow-delete") {
+          return new Promise<Response>((resolve) => {
+            let settled = false;
+            const finish = (response: Response) => {
+              if (settled) return;
+              settled = true;
+              clearTimeout(timer);
+              resolve(response);
+            };
+            const timer = setTimeout(() => finish(new Response(null, { status: 504 })), 2_000);
+            request.signal.addEventListener(
+              "abort",
+              () => {
+                slowDeleteAborted = true;
+                finish(new Response(null, { status: 499 }));
+              },
+              { once: true },
+            );
+          });
+        }
         const replacement = s3ReplacementBeforeDelete.get(key);
         if (replacement) {
           s3ReplacementBeforeDelete.delete(key);
@@ -187,6 +208,7 @@ beforeEach(() => {
   s3Versions.clear();
   s3ReplacementBeforeDelete.clear();
   s3Calls.length = 0;
+  slowDeleteAborted = false;
 });
 
 afterEach(() => {
@@ -481,6 +503,37 @@ describe("S3-compatible exact-key lifecycle", () => {
       },
       { method: "HEAD", bucket: "backup-catalog-test", key, versionId: "s3-version-1" },
     ]);
+  });
+
+  test("propagates caller abort through the S3 delete command and skips the post-delete HEAD", async () => {
+    configureS3();
+    const key = "slow-delete";
+    setS3Object(key, {
+      size: 42,
+      etag: "slow-etag",
+      version: "slow-version",
+      sha256: "c2xvdy1zaGEyNTY=",
+    });
+    const observed = await headObject(key);
+    if (observed.status !== "present") throw new Error("Expected a present S3 object");
+    s3Calls.length = 0;
+    const controller = new AbortController();
+    const deletion = deleteObject(
+      { key, locator: observed.locator },
+      { signal: controller.signal, deadline: new Date(Date.now() + 60_000) },
+    );
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      if (s3Calls.some((call) => call.method === "DELETE")) break;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    expect(s3Calls.some((call) => call.method === "DELETE")).toBe(true);
+    controller.abort(new Error("shutdown"));
+    await expectLifecycleError(deletion, "OBJECT_STORAGE_DELETE_ABORTED");
+    for (let attempt = 0; attempt < 100 && !slowDeleteAborted; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    expect(slowDeleteAborted).toBe(true);
+    expect(s3Calls.filter((call) => call.method === "HEAD")).toHaveLength(1);
   });
 
   test("deletes the catalogued S3 version even when the current key is hidden by a delete marker", async () => {

--- a/packages/cloud/shared/src/lib/storage/object-store.ts
+++ b/packages/cloud/shared/src/lib/storage/object-store.ts
@@ -246,6 +246,8 @@ export type ObjectStorageLifecycleErrorCode =
   | "OBJECT_STORAGE_LOCATOR_MISMATCH"
   | "OBJECT_STORAGE_VERSION_MISMATCH"
   | "OBJECT_STORAGE_DELETE_UNCONFIRMED"
+  | "OBJECT_STORAGE_DELETE_ABORTED"
+  | "OBJECT_STORAGE_DELETE_DEADLINE_EXCEEDED"
   | "OBJECT_STORAGE_UPLOAD_TOO_LARGE"
   | "OBJECT_STORAGE_IMMUTABLE_CONFLICT"
   | "OBJECT_STORAGE_IMMUTABLE_PUT_UNSUPPORTED"
@@ -897,7 +899,7 @@ async function headObjectOnBackend(
   keyFingerprint: string,
   requestChecksum = false,
   providerVersionId?: string,
-  control?: ImmutableUploadAbortContext,
+  control?: ProviderRequestAbortContext,
 ): Promise<ObjectHeadReceipt> {
   if (backend.runtimeBucket) {
     const request = backend.runtimeBucket.head(key);
@@ -1569,7 +1571,7 @@ export async function getExactObjectAtBackend(params: {
   return getExactObjectOnBackend(params.backend, params.input);
 }
 
-interface ImmutableUploadAbortContext {
+interface ProviderRequestAbortContext {
   readonly signal: AbortSignal;
   ensureActive(): void;
   failure(): ObjectStorageLifecycleError;
@@ -1578,22 +1580,31 @@ interface ImmutableUploadAbortContext {
   dispose(): void;
 }
 
-function createImmutableUploadAbortContext(
+function createProviderRequestAbortContext(
   input: ObjectRequestControl,
-): ImmutableUploadAbortContext {
+  policy: Readonly<{
+    operation: string;
+    deadlineCode: ObjectStorageLifecycleErrorCode;
+    abortCode: ObjectStorageLifecycleErrorCode;
+  }> = {
+    operation: "Immutable object upload",
+    deadlineCode: "OBJECT_STORAGE_UPLOAD_DEADLINE_EXCEEDED",
+    abortCode: "OBJECT_STORAGE_UPLOAD_ABORTED",
+  },
+): ProviderRequestAbortContext {
   const now = Date.now();
   const suppliedDeadline = input.deadline?.getTime();
   if (suppliedDeadline !== undefined && !Number.isFinite(suppliedDeadline)) {
     throw new ObjectStorageLifecycleError(
       "OBJECT_STORAGE_METADATA_INVALID",
-      "Immutable object upload requires a valid absolute deadline",
+      `${policy.operation} requires a valid absolute deadline`,
     );
   }
   const deadlineAt = suppliedDeadline ?? now + DEFAULT_IMMUTABLE_UPLOAD_DURATION_MS;
   if (deadlineAt - now > MAX_IMMUTABLE_UPLOAD_DURATION_MS) {
     throw new ObjectStorageLifecycleError(
       "OBJECT_STORAGE_METADATA_INVALID",
-      "Immutable object upload deadline exceeds the bounded provider-I/O window",
+      `${policy.operation} deadline exceeds the bounded provider-I/O window`,
     );
   }
 
@@ -1624,12 +1635,12 @@ function createImmutableUploadAbortContext(
   const failure = () =>
     source === "deadline"
       ? new ObjectStorageLifecycleError(
-          "OBJECT_STORAGE_UPLOAD_DEADLINE_EXCEEDED",
-          "Immutable object provider I/O exceeded its deadline",
+          policy.deadlineCode,
+          `${policy.operation} provider I/O exceeded its deadline`,
         )
       : new ObjectStorageLifecycleError(
-          "OBJECT_STORAGE_UPLOAD_ABORTED",
-          "Immutable object provider I/O was aborted",
+          policy.abortCode,
+          `${policy.operation} provider I/O was aborted`,
         );
 
   const ensureActive = () => {
@@ -1684,7 +1695,7 @@ export async function headObject(
   control: ObjectRequestControl = {},
 ): Promise<ObjectHeadReceipt> {
   requireExactKey(key);
-  const context = createImmutableUploadAbortContext(control);
+  const context = createProviderRequestAbortContext(control);
   try {
     const [backend, keyFingerprint] = await context.race(
       Promise.all([resolveLifecycleBackend(), fingerprintKey(key)]),
@@ -1703,7 +1714,7 @@ export async function headObjectAtBackend(
 ): Promise<ObjectHeadReceipt> {
   requireExactKey(key);
   requireExactBackendLocator(backend.locator);
-  const context = createImmutableUploadAbortContext(control);
+  const context = createProviderRequestAbortContext(control);
   try {
     const keyFingerprint = await context.race(fingerprintKey(key));
     return await headObjectOnBackend(backend, key, keyFingerprint, false, undefined, context);
@@ -1827,7 +1838,7 @@ function immutableReceiptFromHead(
 
 async function immutableRetryBackoff(
   attempt: number,
-  context: ImmutableUploadAbortContext,
+  context: ProviderRequestAbortContext,
 ): Promise<void> {
   const delayMs = 25 * 2 ** Math.max(0, attempt - 1);
   await context.wait(delayMs);
@@ -1863,10 +1874,10 @@ async function putImmutableObjectOnBackend(params: {
     );
   }
   const body = immutableUploadBytes(params.body, params.transferBodyOwnership === true);
-  let context: ImmutableUploadAbortContext | undefined;
+  let context: ProviderRequestAbortContext | undefined;
   let digestBytes: Uint8Array<ArrayBuffer> | undefined;
   try {
-    context = createImmutableUploadAbortContext(params);
+    context = createProviderRequestAbortContext(params);
     const backend = params.backend;
     const [keyFingerprint, sha256] = await context.race(
       Promise.all([fingerprintKey(params.key), immutableSha256(body)]),
@@ -2067,7 +2078,9 @@ export async function putImmutableObjectAtBackend(params: {
 async function deleteObjectOnBackend(
   backend: ExactObjectStorageBackend,
   target: ObjectDeleteTarget,
+  control: ProviderRequestAbortContext,
 ): Promise<ObjectDeleteReceipt> {
+  control.ensureActive();
   requireExactKey(target.key);
   requireExactBackendLocator(backend.locator);
   const keyFingerprint = await fingerprintKey(target.key);
@@ -2089,6 +2102,7 @@ async function deleteObjectOnBackend(
     keyFingerprint,
     false,
     providerVersionId,
+    control,
   );
   if (before.status === "absent") {
     return {
@@ -2113,22 +2127,25 @@ async function deleteObjectOnBackend(
 
   let providerRequestId: string | null = null;
   if (backend.runtimeBucket) {
-    await backend.runtimeBucket.delete(target.key);
+    await control.race(backend.runtimeBucket.delete(target.key));
   } else {
     try {
-      const output = await backend.s3Client.send(
-        new DeleteObjectCommand({
-          Bucket: backend.locator.bucket,
-          Key: target.key,
-          VersionId:
-            target.locator.versionSource === "provider"
-              ? (target.locator.version ?? undefined)
-              : undefined,
-          IfMatch:
-            target.locator.versionSource === "etag"
-              ? (target.locator.version ?? undefined)
-              : undefined,
-        }),
+      const output = await control.race(
+        backend.s3Client.send(
+          new DeleteObjectCommand({
+            Bucket: backend.locator.bucket,
+            Key: target.key,
+            VersionId:
+              target.locator.versionSource === "provider"
+                ? (target.locator.version ?? undefined)
+                : undefined,
+            IfMatch:
+              target.locator.versionSource === "etag"
+                ? (target.locator.version ?? undefined)
+                : undefined,
+          }),
+          { abortSignal: control.signal },
+        ),
       );
       providerRequestId = output.$metadata.requestId ?? null;
     } catch (error) {
@@ -2148,6 +2165,7 @@ async function deleteObjectOnBackend(
     keyFingerprint,
     false,
     providerVersionId,
+    control,
   );
   if (after.status !== "absent") {
     throw new ObjectStorageLifecycleError(
@@ -2165,16 +2183,40 @@ async function deleteObjectOnBackend(
 }
 
 /** Delete using the legacy process-global backend selector. */
-export async function deleteObject(target: ObjectDeleteTarget): Promise<ObjectDeleteReceipt> {
-  return deleteObjectOnBackend(await resolveLifecycleBackend(), target);
+export async function deleteObject(
+  target: ObjectDeleteTarget,
+  control: ObjectRequestControl = {},
+): Promise<ObjectDeleteReceipt> {
+  const context = createProviderRequestAbortContext(control, {
+    operation: "Exact object deletion",
+    deadlineCode: "OBJECT_STORAGE_DELETE_DEADLINE_EXCEEDED",
+    abortCode: "OBJECT_STORAGE_DELETE_ABORTED",
+  });
+  try {
+    return await context.race(
+      resolveLifecycleBackend().then((backend) => deleteObjectOnBackend(backend, target, context)),
+    );
+  } finally {
+    context.dispose();
+  }
 }
 
 /** Delete one exact object on a caller-resolved backend and prove absence. */
 export async function deleteObjectAtBackend(params: {
   backend: ExactObjectStorageBackend;
   target: ObjectDeleteTarget;
+  control?: ObjectRequestControl;
 }): Promise<ObjectDeleteReceipt> {
-  return deleteObjectOnBackend(params.backend, params.target);
+  const context = createProviderRequestAbortContext(params.control ?? {}, {
+    operation: "Exact object deletion",
+    deadlineCode: "OBJECT_STORAGE_DELETE_DEADLINE_EXCEEDED",
+    abortCode: "OBJECT_STORAGE_DELETE_ABORTED",
+  });
+  try {
+    return await deleteObjectOnBackend(params.backend, params.target, context);
+  } finally {
+    context.dispose();
+  }
 }
 
 /**

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -19,12 +19,24 @@ const provisioningService = readFileSync(
   join(root, "packages/cloud/scripts/admin/eliza-provisioning-worker.service"),
   "utf8",
 );
+const backupService = readFileSync(
+  join(
+    root,
+    "packages/cloud/scripts/admin/eliza-backup-catalog-worker.service",
+  ),
+  "utf8",
+);
+const backupEnvExample = readFileSync(
+  join(root, "packages/cloud/shared/.env.example"),
+  "utf8",
+);
 const services = [
   provisioningService,
   readFileSync(
     join(root, "packages/cloud/scripts/admin/eliza-agent-router.service"),
     "utf8",
   ),
+  backupService,
 ];
 
 interface WorkflowStep {
@@ -154,6 +166,11 @@ describe("provisioning worker deployment contract", () => {
       "SANDBOX_REGISTRY_REDIS_URL",
       "DATABASE_URL",
       "SECRETS_MASTER_KEY",
+      "AGENT_BACKUP_R2_ACCESS_KEY_ID",
+      "AGENT_BACKUP_R2_SECRET_ACCESS_KEY",
+      "AGENT_BACKUP_HETZNER_ACCESS_KEY_ID",
+      "AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY",
+      "AGENT_BACKUP_STEWARD_KMS_TOKEN",
     ];
     const deployJob = parsedWorkflow.jobs?.deploy;
     expect(deployJob).toBeDefined();
@@ -218,6 +235,11 @@ describe("provisioning worker deployment contract", () => {
       "SANDBOX_REGISTRY_REDIS_URL",
       "DATABASE_URL",
       "SECRETS_MASTER_KEY",
+      "AGENT_BACKUP_R2_ACCESS_KEY_ID",
+      "AGENT_BACKUP_R2_SECRET_ACCESS_KEY",
+      "AGENT_BACKUP_HETZNER_ACCESS_KEY_ID",
+      "AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY",
+      "AGENT_BACKUP_STEWARD_KMS_TOKEN",
     ]) {
       expect(remoteDeploy.env?.[name]).toContain("secrets.");
     }
@@ -282,7 +304,7 @@ describe("provisioning worker deployment contract", () => {
     expect(workflow).toContain("timeout-minutes: 95");
   });
 
-  it("regenerates before deploy and self-heals both services", () => {
+  it("regenerates before deploy and self-heals every service", () => {
     expect(workflow).toContain(
       "bash packages/cloud/scripts/admin/ensure-generated-keywords.sh",
     );
@@ -291,6 +313,89 @@ describe("provisioning worker deployment contract", () => {
         "ExecStartPre=/opt/eliza/packages/cloud/scripts/admin/ensure-generated-keywords.sh",
       );
     }
+  });
+
+  it("installs the dormant backup worker with persistent spool and exact disabled health", () => {
+    expect(workflow).toContain(
+      "packages/cloud/scripts/admin/eliza-backup-catalog-worker.service",
+    );
+    expect(workflow).toContain(
+      'sudo systemctl enable "$SYSTEMD_UNIT" eliza-agent-router.service "$BACKUP_SYSTEMD_UNIT"',
+    );
+    expect(workflow).toContain('sudo systemctl restart "$BACKUP_SYSTEMD_UNIT"');
+    expect(workflow).toContain(
+      'parsed.format === "elizaos.agent-backup.catalog-worker-health.v1"',
+    );
+    expect(workflow).toContain('parsed.state === "disabled"');
+    expect(workflow).toContain("parsed.enabled === false");
+
+    expect(backupService).toContain("StateDirectory=eliza-backup-catalog");
+    expect(backupService).toContain("RuntimeDirectory=eliza-backup-catalog");
+    expect(backupService).toContain("TimeoutStopSec=30");
+    expect(backupService).toContain("KillSignal=SIGTERM");
+    expect(backupService).toContain("backup-catalog-worker-preflight.ts");
+    expect(
+      backupService.match(/AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=0/g),
+    ).toHaveLength(2);
+    expect(
+      backupService.match(/AGENT_BACKUP_RPO_SCHEDULER_ENABLED=0/g),
+    ).toHaveLength(2);
+  });
+
+  it("documents and reconciles every enabled backup authority name", () => {
+    for (const name of [
+      "DATABASE_URL",
+      "SECRETS_MASTER_KEY",
+      "AGENT_BACKUP_CATALOG_WORKER_ID",
+      "AGENT_BACKUP_R2_ENDPOINT_ALIAS",
+      "AGENT_BACKUP_R2_ACCOUNT_ID",
+      "AGENT_BACKUP_R2_ENDPOINT",
+      "AGENT_BACKUP_R2_BUCKET",
+      "AGENT_BACKUP_R2_REGION",
+      "AGENT_BACKUP_R2_ACCESS_KEY_ID",
+      "AGENT_BACKUP_R2_SECRET_ACCESS_KEY",
+      "AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS",
+      "AGENT_BACKUP_HETZNER_ACCOUNT_ID",
+      "AGENT_BACKUP_HETZNER_ENDPOINT",
+      "AGENT_BACKUP_HETZNER_BUCKET",
+      "AGENT_BACKUP_HETZNER_REGION",
+      "AGENT_BACKUP_HETZNER_ACCESS_KEY_ID",
+      "AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY",
+      "AGENT_BACKUP_STEWARD_KMS_BASE_URL",
+      "AGENT_BACKUP_STEWARD_KMS_TOKEN",
+      "AGENT_BACKUP_AGENT_SCHEMA_VERSION",
+      "AGENT_BACKUP_DATABASE_SCHEMA_VERSION",
+      "AGENT_BACKUP_RUNTIME_PLUGINS_JSON",
+      "AGENT_BACKUP_LEGACY_WRITER_DRAIN_DEPLOYMENT_ID",
+      "AGENT_BACKUP_LEGACY_WRITER_DRAINED_AT",
+      "AGENT_BACKUP_STORAGE_SCOPE",
+      "AGENT_BACKUP_SPOOL_STATE_DIRECTORY",
+      "AGENT_BACKUP_SPOOL_MAX_BYTES",
+      "AGENT_BACKUP_SPOOL_MIN_FREE_BYTES",
+      "AGENT_BACKUP_SPOOL_CLEANUP_BATCH_SIZE",
+      "AGENT_BACKUP_CAPTURE_DEADLINE_MS",
+      "AGENT_BACKUP_OBJECT_TRANSFER_DEADLINE_MS",
+    ]) {
+      expect(workflow).toContain(name);
+      expect(backupEnvExample).toContain(name);
+    }
+  });
+
+  it("keeps both backup gates uniquely off while treating enabled authority as optional", () => {
+    for (const gate of [
+      "AGENT_BACKUP_CATALOG_RUNTIME_ENABLED",
+      "AGENT_BACKUP_RPO_SCHEDULER_ENABLED",
+    ]) {
+      expect(workflow).toContain(`sudo sed -i "/^${gate}=/d" "$ENV_FILE"`);
+      expect(workflow).toContain(
+        `printf '%s=%s\\n' ${gate} 0 | sudo tee -a "$ENV_FILE" >/dev/null`,
+      );
+    }
+    expect(workflow).toContain("BACKUP_GATE=0");
+    expect(workflow).toContain('if [ "$BACKUP_GATE" = "1" ]; then');
+    expect(workflow).toContain(
+      "Verified disabled backup-catalogue gate and configuration names; values were not printed.",
+    );
   });
 
   it("reconciles WARM_POOL_ENABLED from the protected environment so re-arms cannot drop it (#16961)", () => {

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -30,13 +30,16 @@ const backupEnvExample = readFileSync(
   join(root, "packages/cloud/shared/.env.example"),
   "utf8",
 );
-const services = [
+const systemdEnvironmentHelper = readFileSync(
+  join(root, "packages/cloud/scripts/admin/systemd-environment-line.mjs"),
+  "utf8",
+);
+const generatedKeywordServices = [
   provisioningService,
   readFileSync(
     join(root, "packages/cloud/scripts/admin/eliza-agent-router.service"),
     "utf8",
   ),
-  backupService,
 ];
 
 interface WorkflowStep {
@@ -84,6 +87,12 @@ describe("provisioning worker deployment contract", () => {
     expect(workflow).toContain('-B "$DEPLOY_BRANCH" "$DEPLOY_SHA"');
     expect(workflow).toContain('test "$(git rev-parse HEAD)" = "$DEPLOY_SHA"');
     expect(workflow).toContain('git checkout "$DEPLOY_SHA" -- bun.lock');
+    expect(workflow).toContain(
+      "SYSTEMD_ENVIRONMENT_HELPER_SHA256=$helper_sha256",
+    );
+    expect(workflow).toContain(
+      "BACKUP_SYSTEMD_UNIT_SHA256=$backup_unit_sha256",
+    );
     expect(workflow).not.toContain(
       'origin "+$DEPLOY_BRANCH:refs/remotes/origin/$DEPLOY_BRANCH"',
     );
@@ -235,13 +244,20 @@ describe("provisioning worker deployment contract", () => {
       "SANDBOX_REGISTRY_REDIS_URL",
       "DATABASE_URL",
       "SECRETS_MASTER_KEY",
+    ]) {
+      expect(remoteDeploy.env?.[name]).toContain("secrets.");
+    }
+    const dormantBackupSecrets = [
       "AGENT_BACKUP_R2_ACCESS_KEY_ID",
       "AGENT_BACKUP_R2_SECRET_ACCESS_KEY",
       "AGENT_BACKUP_HETZNER_ACCESS_KEY_ID",
       "AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY",
       "AGENT_BACKUP_STEWARD_KMS_TOKEN",
-    ]) {
-      expect(remoteDeploy.env?.[name]).toContain("secrets.");
+    ];
+    const forwardedNames = (remoteDeploy.with?.envs ?? "").split(",");
+    for (const name of dormantBackupSecrets) {
+      expect(remoteDeploy.env?.[name]).toBeUndefined();
+      expect(forwardedNames).not.toContain(name);
     }
     expect(remoteDeploy.env?.DEPLOY_SSH_KEY).toBeUndefined();
     expect(remoteDeploy.with?.key).toContain(
@@ -308,11 +324,15 @@ describe("provisioning worker deployment contract", () => {
     expect(workflow).toContain(
       "bash packages/cloud/scripts/admin/ensure-generated-keywords.sh",
     );
-    for (const service of services) {
+    for (const service of generatedKeywordServices) {
       expect(service).toContain(
         "ExecStartPre=/opt/eliza/packages/cloud/scripts/admin/ensure-generated-keywords.sh",
       );
     }
+    // The deployment already generated the sources before systemd is
+    // restarted. This unit has ProtectSystem=strict and must not attempt a
+    // second write beneath /opt/eliza from its read-only ExecStartPre sandbox.
+    expect(backupService).not.toContain("ensure-generated-keywords.sh");
   });
 
   it("installs the dormant backup worker with persistent spool and exact disabled health", () => {
@@ -324,6 +344,49 @@ describe("provisioning worker deployment contract", () => {
     );
     expect(workflow).toContain('sudo systemctl restart "$BACKUP_SYSTEMD_UNIT"');
     expect(workflow).toContain(
+      'BACKUP_UNIT_DESTINATION="/etc/systemd/system/$BACKUP_SYSTEMD_UNIT"',
+    );
+    expect(workflow).toContain(
+      'systemd-analyze verify "$BACKUP_UNIT_DESTINATION"',
+    );
+    expect(workflow).not.toMatch(
+      /sudo install -m 0644 \\\s*packages\/cloud\/scripts\/admin\/eliza-backup-catalog-worker\.service/,
+    );
+    expect(workflow).toContain("--property=DynamicUser --value");
+    expect(workflow).toContain("--property=User --value");
+    expect(workflow).toContain("--property=Group --value");
+    expect(workflow).toContain("--property=ExecStart --value");
+    expect(workflow).toContain("--property=FragmentPath --value");
+    expect(workflow).toContain("--property=DropInPaths --value");
+    expect(workflow).toContain('[ -n "$BACKUP_EFFECTIVE_DROP_INS" ]');
+    expect(workflow).toContain(
+      `BACKUP_EXPECTED_DYNAMIC_USER="\${BACKUP_SYSTEMD_UNIT%.service}"`,
+    );
+    const backupDestination = workflow.indexOf(
+      'BACKUP_UNIT_DESTINATION="/etc/systemd/system/$BACKUP_SYSTEMD_UNIT"',
+    );
+    const destinationVerify = workflow.indexOf(
+      'systemd-analyze verify "$BACKUP_UNIT_DESTINATION"',
+      backupDestination,
+    );
+    const daemonReload = workflow.indexOf(
+      "sudo systemctl daemon-reload",
+      destinationVerify,
+    );
+    const effectiveFragment = workflow.indexOf(
+      "--property=FragmentPath --value",
+      daemonReload,
+    );
+    const enable = workflow.indexOf(
+      'sudo systemctl enable "$SYSTEMD_UNIT" eliza-agent-router.service "$BACKUP_SYSTEMD_UNIT"',
+      effectiveFragment,
+    );
+    expect(backupDestination).toBeGreaterThan(-1);
+    expect(destinationVerify).toBeGreaterThan(backupDestination);
+    expect(daemonReload).toBeGreaterThan(destinationVerify);
+    expect(effectiveFragment).toBeGreaterThan(daemonReload);
+    expect(enable).toBeGreaterThan(effectiveFragment);
+    expect(workflow).toContain(
       'parsed.format === "elizaos.agent-backup.catalog-worker-health.v1"',
     );
     expect(workflow).toContain('parsed.state === "disabled"');
@@ -333,16 +396,35 @@ describe("provisioning worker deployment contract", () => {
     expect(backupService).toContain("RuntimeDirectory=eliza-backup-catalog");
     expect(backupService).toContain("TimeoutStopSec=30");
     expect(backupService).toContain("KillSignal=SIGTERM");
-    expect(backupService).toContain("backup-catalog-worker-preflight.ts");
-    expect(
-      backupService.match(/AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=0/g),
-    ).toHaveLength(2);
-    expect(
-      backupService.match(/AGENT_BACKUP_RPO_SCHEDULER_ENABLED=0/g),
-    ).toHaveLength(2);
+    expect(backupService).toContain("DynamicUser=yes");
+    expect(backupService).not.toContain("User=deploy");
+    expect(backupService).not.toContain("Group=deploy");
+    expect(backupService).toContain(
+      "Environment=HOME=/var/lib/eliza-backup-catalog",
+    );
+    expect(backupService).toContain("ProtectHome=yes");
+    expect(backupService).toContain("ReadOnlyPaths=/opt/eliza");
+    expect(backupService).not.toContain("/home/deploy/.bun/bin");
+    expect(workflow).not.toContain("SAFE_CHILD_PATH=/home/deploy/.bun/bin");
+    expect(workflow).toContain('"$BUN_BIN" --conditions=eliza-source');
+    expect(backupService).not.toContain("ExecStartPre=");
+    expect(backupService).toContain("RestartPreventExitStatus=78");
+    expect(workflow).toContain(
+      "packages/cloud/scripts/admin/daemons/backup-catalog-worker-preflight.ts",
+    );
+    expect(backupService).toContain(
+      "EnvironmentFile=/etc/eliza/backup-catalog-worker.env",
+    );
+    expect(backupService).not.toContain(
+      "AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=0",
+    );
+    expect(backupService).not.toContain("AGENT_BACKUP_RPO_SCHEDULER_ENABLED=0");
+    expect(workflow).not.toMatch(
+      /(?:chown|install -d -o deploy)[^\n]*(?:eliza-backup|BACKUP_)/,
+    );
   });
 
-  it("documents and reconciles every enabled backup authority name", () => {
+  it("documents every enabled backup authority name for a future activation", () => {
     for (const name of [
       "DATABASE_URL",
       "SECRETS_MASTER_KEY",
@@ -382,20 +464,211 @@ describe("provisioning worker deployment contract", () => {
   });
 
   it("keeps both backup gates uniquely off while treating enabled authority as optional", () => {
-    for (const gate of [
-      "AGENT_BACKUP_CATALOG_RUNTIME_ENABLED",
-      "AGENT_BACKUP_RPO_SCHEDULER_ENABLED",
-    ]) {
-      expect(workflow).toContain(`sudo sed -i "/^${gate}=/d" "$ENV_FILE"`);
-      expect(workflow).toContain(
-        `printf '%s=%s\\n' ${gate} 0 | sudo tee -a "$ENV_FILE" >/dev/null`,
-      );
-    }
-    expect(workflow).toContain("BACKUP_GATE=0");
+    expect(workflow.match(/^\s*BACKUP_CATALOG_RUNTIME_GATE=0$/gm)).toHaveLength(
+      1,
+    );
+    expect(workflow.match(/^\s*BACKUP_RPO_SCHEDULER_GATE=0$/gm)).toHaveLength(
+      1,
+    );
+    expect(workflow).not.toContain("BACKUP_CATALOG_RUNTIME_GATE=${{");
+    expect(workflow).not.toContain("BACKUP_RPO_SCHEDULER_GATE=${{");
+    expect(workflow).toContain('BACKUP_GATE="$BACKUP_CATALOG_RUNTIME_GATE"');
     expect(workflow).toContain('if [ "$BACKUP_GATE" = "1" ]; then');
     expect(workflow).toContain(
       "Verified disabled backup-catalogue gate and configuration names; values were not printed.",
     );
+  });
+
+  it("validates complete plans before root-owned atomic EnvironmentFile replacement", () => {
+    expect(workflow).toContain("printf '%s' \"$value\" \\");
+    expect(workflow).toContain('| run_environment_helper serialize "$key" \\');
+    expect(workflow).toContain('sudo flock -w 120 "$ENV_FILE.lock" \\');
+    expect(workflow).toContain('"$NODE_BIN" "$ENV_SERIALIZER" reconcile \\');
+    expect(workflow).toContain('sudo flock -w 120 "$BACKUP_ENV_FILE.lock" \\');
+    expect(workflow).toContain('"$NODE_BIN" "$ENV_SERIALIZER" install \\');
+    expect(workflow).not.toContain(
+      'printf \'%s=%s\\n\' "$key" "$val" | sudo tee -a "$ENV_FILE"',
+    );
+    expect(workflow).not.toMatch(/sudo sed -i [^\n]*"\$ENV_FILE"/);
+    expect(workflow).not.toMatch(/sudo tee -a "\$ENV_FILE"/);
+
+    const safeOffReplacement = workflow.indexOf(
+      'sudo flock -w 120 "$BACKUP_ENV_FILE.lock"',
+    );
+    const oldProcessDisable = workflow.indexOf(
+      'sudo systemctl disable --now "$BACKUP_SYSTEMD_UNIT"',
+    );
+    const inactiveCheck = workflow.indexOf(
+      '[ "$BACKUP_OLD_ACTIVE_STATE" = "inactive" ]',
+      oldProcessDisable,
+    );
+    const pidCheck = workflow.indexOf(
+      '[ "$BACKUP_OLD_MAIN_PID" = "0" ]',
+      oldProcessDisable,
+    );
+    const disabledCheck = workflow.indexOf(
+      '[ "$BACKUP_OLD_ENABLE_STATE" != "disabled" ]',
+      oldProcessDisable,
+    );
+    const firstAtomicReplacement = workflow.indexOf(
+      'sudo flock -w 120 "$ENV_FILE.lock"',
+    );
+    expect(oldProcessDisable).toBeGreaterThan(-1);
+    expect(inactiveCheck).toBeGreaterThan(oldProcessDisable);
+    expect(pidCheck).toBeGreaterThan(oldProcessDisable);
+    expect(disabledCheck).toBeGreaterThan(oldProcessDisable);
+    expect(safeOffReplacement).toBeGreaterThan(inactiveCheck);
+    expect(safeOffReplacement).toBeGreaterThan(pidCheck);
+    expect(safeOffReplacement).toBeGreaterThan(disabledCheck);
+    expect(firstAtomicReplacement).toBeGreaterThan(safeOffReplacement);
+    expect(firstAtomicReplacement).toBeGreaterThan(
+      workflow.indexOf('if [ "$BACKUP_CATALOG_RUNTIME_GATE" = "1" ]; then'),
+    );
+
+    const reconcileFunction = systemdEnvironmentHelper.slice(
+      systemdEnvironmentHelper.indexOf(
+        "export function reconcileSystemdEnvironmentFile",
+      ),
+      systemdEnvironmentHelper.indexOf("async function readStdinBounded"),
+    );
+    const write = reconcileFunction.indexOf("writeFileSync(descriptor");
+    const chmod = reconcileFunction.indexOf("chmodSync(candidatePath, 0o600)");
+    const chown = reconcileFunction.indexOf("chownSync(candidatePath");
+    const injection = reconcileFunction.indexOf(
+      "beforeRename?.(candidatePath, attempt)",
+    );
+    const rename = reconcileFunction.indexOf(
+      "renameSync(candidatePath, targetPath)",
+    );
+    expect(write).toBeGreaterThan(-1);
+    expect(chmod).toBeGreaterThan(write);
+    expect(chown).toBeGreaterThan(chmod);
+    expect(injection).toBeGreaterThan(chown);
+    expect(rename).toBeGreaterThan(injection);
+  });
+
+  it("installs an exact disabled backup allowlist with no secret authority", () => {
+    expect(workflow).toContain(
+      "BACKUP_ENV_FILE=/etc/eliza/backup-catalog-worker.env",
+    );
+    expect(workflow).toContain(
+      'sudo install -d -o root -g root -m 0755 "$(dirname "$BACKUP_ENV_FILE")"',
+    );
+    expect(workflow).toContain(
+      '"$(sudo stat -c \'%U:%G:%a\' "$BACKUP_ENV_FILE")" != "root:root:600"',
+    );
+
+    const disabledPlan = workflow.slice(
+      workflow.indexOf(
+        "# The backup daemon receives a separate exact allowlist.",
+      ),
+      workflow.indexOf("# Activation remains impossible in this changeset"),
+    );
+    const disabledNames = [
+      "AGENT_BACKUP_CATALOG_RUNTIME_ENABLED",
+      "AGENT_BACKUP_RPO_SCHEDULER_ENABLED",
+      "AGENT_BACKUP_CATALOG_WORKER_INTERVAL_MS",
+      "AGENT_BACKUP_CATALOG_WORKER_RETRY_MS",
+      "AGENT_BACKUP_CATALOG_WORKER_SHUTDOWN_TIMEOUT_MS",
+      "AGENT_BACKUP_SPOOL_STATE_DIRECTORY",
+      "AGENT_BACKUP_CATALOG_WORKER_HEALTH_FILE",
+    ];
+    for (const name of disabledNames) {
+      expect(disabledPlan).toContain(name);
+    }
+    const plannedDisabledNames = [
+      ...new Set(
+        [...disabledPlan.matchAll(/\bAGENT_BACKUP_[A-Z0-9_]+\b/g)].map(
+          (match) => match[0],
+        ),
+      ),
+    ].sort();
+    expect(plannedDisabledNames).toEqual([...disabledNames].sort());
+    for (const forbidden of [
+      "DATABASE_URL",
+      "SECRETS_MASTER_KEY",
+      "AGENT_BACKUP_R2_ACCESS_KEY_ID",
+      "AGENT_BACKUP_R2_SECRET_ACCESS_KEY",
+      "AGENT_BACKUP_STEWARD_KMS_TOKEN",
+      "CONTAINERS_SSH_KEY",
+      "HEADSCALE_API_KEY",
+      "SANDBOX_REGISTRY_REDIS_URL",
+    ]) {
+      expect(disabledPlan).not.toContain(forbidden);
+    }
+
+    const sharedAssignmentLoopStart = workflow.indexOf(
+      "            for kv in \\",
+    );
+    const sharedAssignmentLoopEnd = workflow.indexOf(
+      '"DATABASE_SSL_NO_VERIFY=$DATABASE_SSL_NO_VERIFY"; do',
+      sharedAssignmentLoopStart,
+    );
+    const sharedAssignmentLoop = workflow.slice(
+      sharedAssignmentLoopStart,
+      sharedAssignmentLoopEnd,
+    );
+    expect(sharedAssignmentLoopStart).toBeGreaterThan(-1);
+    expect(sharedAssignmentLoopEnd).toBeGreaterThan(sharedAssignmentLoopStart);
+    expect(sharedAssignmentLoop).not.toContain("AGENT_BACKUP_");
+    expect(workflow).toContain("shared_backup_only_names=(");
+    expect(workflow).toContain(
+      'remove_environment_setting "$ENV_REPLACEMENTS" "$name"',
+    );
+
+    const enabledAllowlist = workflow.slice(
+      workflow.indexOf("enabled_backup_names=("),
+      workflow.indexOf(
+        "# An EnvironmentFile replacement cannot revoke authority",
+      ),
+    );
+    expect(enabledAllowlist).toContain("DATABASE_URL");
+    expect(enabledAllowlist).toContain("AGENT_BACKUP_STEWARD_KMS_TOKEN");
+    for (const forbidden of [
+      "CONTAINERS_SSH_KEY",
+      "HEADSCALE_API_KEY",
+      "SANDBOX_REGISTRY_REDIS_URL",
+    ]) {
+      expect(enabledAllowlist).not.toContain(forbidden);
+    }
+  });
+
+  it("does not offer a value-returning EnvironmentFile CLI command", () => {
+    expect(systemdEnvironmentHelper).not.toContain('command === "lookup"');
+    expect(systemdEnvironmentHelper).toContain('command === "nonempty"');
+    expect(systemdEnvironmentHelper).toContain('command === "equals"');
+  });
+
+  it("compares the canonical domain inside the root helper without returning values", () => {
+    const healthStep = workflow.slice(workflow.indexOf("- name: Health check"));
+    expect(workflow).not.toContain("NODE_BIN=$(command -v node)");
+    expect(workflow).not.toMatch(
+      /^\s*ENV_SERIALIZER=\/opt\/eliza\/.*systemd-environment-line\.mjs$/m,
+    );
+    expect(healthStep).toContain("NODE_BIN=/usr/bin/node");
+    expect(healthStep).toContain(
+      "ENV_SERIALIZER=/usr/local/lib/eliza-admin/systemd-environment-line.mjs",
+    );
+    expect(healthStep).toContain("root:root:555");
+    expect(healthStep).toContain("HEALTH_HELPER_SHA256");
+    expect(healthStep).toContain('"$NODE_BIN" "$ENV_SERIALIZER" equals \\');
+    expect(healthStep).toContain('"$ENV_FILE" ELIZA_CLOUD_AGENT_BASE_DOMAIN');
+    expect(healthStep).not.toContain(" lookup ");
+    expect(healthStep).not.toMatch(/awk[^\n]*ELIZA_CLOUD_AGENT_BASE_DOMAIN/);
+    expect(healthStep).toContain(
+      "Agent router base-domain drift. Values were not printed.",
+    );
+    expect(healthStep).not.toContain("found ${ACTUAL_AGENT_BASE_DOMAIN");
+    expect(healthStep).toContain(
+      'sudo /usr/bin/env -i PATH="$SAFE_CHILD_PATH" "$NODE_BIN" -e',
+    );
+    expect(healthStep).toContain(
+      'readFileSync("/run/eliza-backup-catalog/health.json")',
+    );
+    expect(healthStep).not.toContain(
+      "test -s /run/eliza-backup-catalog/health.json",
+    );
+    expect(healthStep).not.toContain("< /run/eliza-backup-catalog/health.json");
   });
 
   it("reconciles WARM_POOL_ENABLED from the protected environment so re-arms cannot drop it (#16961)", () => {
@@ -482,7 +755,7 @@ describe("provisioning worker deployment contract", () => {
     // Execute the actual validator embedded in the workflow rather than
     // asserting on its text, so a regression to substring matching fails.
     const validator = workflow.match(
-      /validate_public_health_payload\(\) \{\n\s*node -e '([\s\S]*?)'\n\s*\}/,
+      /validate_public_health_payload\(\) \{\n\s*\/usr\/bin\/env -i PATH="\$SAFE_CHILD_PATH" "\$NODE_BIN" -e '([\s\S]*?)'\n\s*\}/,
     );
     expect(validator).not.toBeNull();
     const script = (validator as RegExpMatchArray)[1];
@@ -490,6 +763,12 @@ describe("provisioning worker deployment contract", () => {
     const runValidator = (payload: string): number => {
       const proc = Bun.spawnSync(["node", "-e", script], {
         stdin: Buffer.from(payload),
+        env: {
+          PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+          HOME: process.env.HOME ?? "/tmp",
+          TMPDIR: "/tmp",
+          NODE_ENV: "test",
+        },
       });
       return proc.exitCode;
     };


### PR DESCRIPTION
# Relates to

Closes #23844. Contributes the dormant A2 worker slice of #20726.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

> **Ready dormant dependency slice; activation remains held.** Activation/vault publication (#24123), trust-domain isolation, immutable artifact verification, and the remaining coordinator/failover slices are separate acceptance and merge-order holds. This source-complete dormant worker remains ready so hosted CI and independent review can run; ready status does not authorize deployment, credential injection, or either activation gate.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      monorepo lint blocker is recorded below.
- [x] A reviewer can confirm the dormant worker and systemd boundary from the
      exact-head tests and disposable Ubuntu proof attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@3a9578dc8730a10fb241f8991b1e82be5fd1a721:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@43f9df0f18d6a29de502d2d598e3cee994a0a46e`; zero conflicts.
- [x] `bun run verify` was run post-sync. It stops only at inherited
      `@elizaos/agent#lint:check` diagnostics; this branch has no
      `packages/agent` or `packages/core` diff. All scoped gates pass below.

# Risks

Medium. This changes the provisioning deployment workflow and installs a new
systemd daemon, but both runtime/scheduler gates are uniquely forced to literal
`0`. Disabled composition reads only those gates and performs no DB, provider,
KMS, SSH, registry, or field-encryption credential read.

Activation is explicitly out of scope and blocked: before either gate can be
`1`, backup authority must leave the shared host's `deploy` sudo/docker trust
domain (dedicated identity or host), execute an immutable verified artifact,
and receive credentials through root/PID 1. The prerequisite is documented in
`agent-backup.md` and `.env.example`.

# Background

## What does this PR do?

- Adds a dedicated manifest-v3 backup-catalog daemon with cadence bounded to at
  most 60 seconds, retry metrics, redacted health, and bounded shutdown.
- Composes the existing scheduler/catalog, authenticated Agent capture, KMS key
  bundles, affinity-aware durable spool, native R2 primary, Hetzner S3
  secondary, publication/verification, retention, deletion, and GC paths.
- Hardens runtime authority, cancellation, deadline, response-loss replay,
  partial-spool cleanup, exact provider deletion, and catalogue settlement.
- Adds a strict atomic systemd EnvironmentFile helper and fail-safe deployment:
  stop/disable old authority before safe-off replacement, install helper/unit
  through exact-SHA root-owned candidates, verify effective unit identity,
  fragment, drop-ins, and ExecStart before enabling.
- Keeps periodic admission and worker runtime disabled by default and forced off
  by deployment. It does not enroll the fleet, activate credentials, remove the
  legacy writer, mutate a live provider, or advertise an RPO.

## What kind of change is this?

Feature plus non-breaking safety fixes for the dormant Sandboxes V3 backup
worker path.

# Documentation changes needed?

Documentation is required and updated: the environment contract, bounds,
disabled deployment behavior, and activation trust-domain prerequisite are
documented.

# Testing

## Where should a reviewer start?

1. `packages/cloud/shared/src/lib/services/agent-backup-catalog-worker-composition.ts`
2. `packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.ts`
3. `packages/cloud/scripts/admin/daemons/backup-catalog-worker.ts`
4. `packages/cloud/scripts/admin/eliza-backup-catalog-worker.service`
5. `.github/workflows/deploy-eliza-provisioning-worker.yml`

## Detailed testing steps

- `mise exec -- bun install --frozen-lockfile`
- Runtime matrix: 212 pass / 0 fail / 1,036 assertions across daemon,
  scheduler/catalog, PGlite, capture, publication, spool/GC, exact object delete,
  runtime authority, and upstream FIELD hydration.
- Deployment matrix: 71 pass / 1 environment skip / 0 fail / 670 assertions.
- `mise exec -- bun run --cwd packages/cloud/shared typecheck`
- Changed-file Biome and `git diff --check`.
- Secret-leak, Hetzner-routing, workflow-trigger, scripts/inventory, and focused
  test audits all pass.
- Disposable Ubuntu 24/systemd 255 proof verifies exact-SHA root artifacts,
  EnvironmentFile consumption, DynamicUser/User/Group, exact fragment with no
  drop-ins, exact ExecStart, and exit-78 restart fencing (`NRestarts=0`). The VM
  was deleted after the proof.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:3a9578dc8730a10fb241f8991b1e82be5fd1a721 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend daemon, workflow, and systemd change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend daemon, workflow, and systemd change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual or user-operated frontend flow is changed
<!-- evidence-row:backend-logs -->
- [x] [24080-23844-3a9578dc873-backend-v2.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24080-23844-3a9578dc873-backend-v2.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, console, or network path is changed
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, prompt, provider, or model behavior is changed
<!-- evidence-row:domain-artifacts -->
- [x] [24080-23844-3a9578dc873-domain.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24080-23844-3a9578dc873-domain.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text or UI surface is changed

# Evidence Details

## Real LLM-call trajectory

N/A - no agent action, prompt, provider, or model behavior is changed.

## Backend + frontend logs

The backend/systemd exact-head log and structured domain receipt are attached in
the evidence rows above. Frontend logs are N/A because the diff has no frontend
surface.

## Screenshots (before / after) + video walkthrough

N/A - backend daemon, workflow, and systemd-only change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT path is changed.

## Known gaps / failures

- Root `mise exec -- bun run verify` stops at 12 inherited Biome errors in
  `packages/agent` plus inherited warnings in `packages/agent`/`packages/core`.
  This branch changes neither package; the changed-file Biome, focused tests,
  typecheck, and relevant repo audits all pass.
- The local macOS systemd test skips transient user-manager consumption. The
  same exact EnvironmentFile/unit behavior passed on disposable Ubuntu
  24/systemd 255 and is included in backend evidence.
- No live R2, Hetzner, KMS, database, staging, production, deployment, or gate
  mutation was performed. Those are intentionally forbidden for this dormant
  slice.
- Gate-1 activation remains blocked on trust-domain and immutable-artifact
  isolation. The PR remains ready for review with both gates forced to `0`;
  readiness is not activation or deployment authorization.

# Deploy Notes

No deployment was performed. On a later separately authorized deployment, this
workflow installs and starts only the dormant daemon with both gates forced to
`0`. Do not inject provider/KMS/database secrets or change either gate until the
documented activation prerequisite is implemented and reviewed.

## Database changes

None. This worker composes already-landed catalogue/migration foundations.

## Deployment instructions

None for this PR. Keep it DRAFT; do not dispatch the staging workflow as part
of review.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@3a9578dc8730a10fb241f8991b1e82be5fd1a721:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-sandboxes-v3-scheduler-worker]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@3a9578dc8730a10fb241f8991b1e82be5fd1a721:packages/skills/skills/contribute-to-eliza"} -->
