### PR TITLE
fix(android-cloud): cancel stale login and surface voice errors

### DIFF
--- a/packages/app/src/main.android-cloud.behavior.test.tsx
+++ b/packages/app/src/main.android-cloud.behavior.test.tsx
@@ -12,6 +12,7 @@ const playEntry = vi.hoisted(() => ({
   appListeners: new Map<string, (value: unknown) => void>(),
   voiceListeners: new Map<string, (value: never) => void>(),
   voiceListenerRemovals: new Map<string, ReturnType<typeof vi.fn>>(),
+  voiceListenerGate: null as Promise<void> | null,
   voiceStart: vi.fn(async () => ({ started: true })),
   voiceStop: vi.fn(async () => undefined),
   createRoot: vi.fn(() => ({ render: vi.fn() })),
@@ -48,6 +49,7 @@ vi.mock("@capacitor/core", () => ({
       : {
           addListener: vi.fn(
             async (eventName: string, listener: (value: never) => void) => {
+              await playEntry.voiceListenerGate;
               playEntry.voiceListeners.set(eventName, listener);
               const remove = vi.fn(async () => {
                 if (playEntry.voiceListeners.get(eventName) === listener) {
@@ -109,6 +111,17 @@ vi.mock("@capacitor/status-bar", () => ({
 
 let entry: typeof import("./main.android-cloud");
 
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
 beforeAll(async () => {
   document.body.innerHTML = '<div id="root"></div>';
   entry = await import("./main.android-cloud");
@@ -124,6 +137,7 @@ beforeEach(async () => {
   playEntry.appListeners.clear();
   playEntry.voiceListeners.clear();
   playEntry.voiceListenerRemovals.clear();
+  playEntry.voiceListenerGate = null;
   playEntry.voiceStart.mockResolvedValue({ started: true });
   playEntry.voiceStop.mockResolvedValue(undefined);
   window.localStorage.clear();
@@ -169,6 +183,50 @@ describe("Android Cloud renderer behavior", () => {
       playEntry.voiceListenerRemovals.get("transcript"),
     ).toHaveBeenCalledOnce();
     expect(playEntry.voiceListenerRemovals.get("error")).toHaveBeenCalledOnce();
+  });
+
+  it("cancels startup and removes listeners when stopped during registration", async () => {
+    const listenerGate = deferred<void>();
+    playEntry.voiceListenerGate = listenerGate.promise;
+
+    const startup = entry.androidCloudVoice.requestAndStart(vi.fn(), vi.fn());
+    await vi.waitFor(() => expect(playEntry.voiceStop).toHaveBeenCalledOnce());
+    const stopped = entry.androidCloudVoice.stop();
+    listenerGate.resolve(undefined);
+
+    await expect(startup).rejects.toMatchObject({ name: "AbortError" });
+    await expect(stopped).resolves.toBeUndefined();
+    expect(playEntry.voiceStart).not.toHaveBeenCalled();
+    expect(playEntry.voiceListeners.size).toBe(0);
+  });
+
+  it("serializes overlapping starts without leaking the first listener pair", async () => {
+    const firstNativeStart = deferred<{ started: boolean }>();
+    playEntry.voiceStart
+      .mockReturnValueOnce(firstNativeStart.promise)
+      .mockResolvedValueOnce({ started: true });
+
+    const first = entry.androidCloudVoice.requestAndStart(vi.fn(), vi.fn());
+    await vi.waitFor(() => expect(playEntry.voiceStart).toHaveBeenCalledOnce());
+    const firstRemovals = [
+      playEntry.voiceListenerRemovals.get("transcript"),
+      playEntry.voiceListenerRemovals.get("error"),
+    ];
+    const second = entry.androidCloudVoice.requestAndStart(vi.fn(), vi.fn());
+    firstNativeStart.resolve({ started: true });
+
+    await expect(first).rejects.toMatchObject({ name: "AbortError" });
+    await expect(second).resolves.toBeUndefined();
+    expect(playEntry.voiceStart).toHaveBeenCalledTimes(2);
+    expect(firstRemovals[0]).toHaveBeenCalledOnce();
+    expect(firstRemovals[1]).toHaveBeenCalledOnce();
+    expect([...playEntry.voiceListeners.keys()].sort()).toEqual([
+      "error",
+      "transcript",
+    ]);
+
+    await entry.androidCloudVoice.stop();
+    expect(playEntry.voiceListeners.size).toBe(0);
   });
 
   it("migrates a legacy bearer into the secure plugin before deleting plaintext", async () => {

--- a/packages/app/src/main.android-cloud.behavior.test.tsx
+++ b/packages/app/src/main.android-cloud.behavior.test.tsx
@@ -10,6 +10,10 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const playEntry = vi.hoisted(() => ({
   appListeners: new Map<string, (value: unknown) => void>(),
+  voiceListeners: new Map<string, (value: never) => void>(),
+  voiceListenerRemovals: new Map<string, ReturnType<typeof vi.fn>>(),
+  voiceStart: vi.fn(async () => ({ started: true })),
+  voiceStop: vi.fn(async () => undefined),
   createRoot: vi.fn(() => ({ render: vi.fn() })),
   preferenceGet: vi.fn(async (_options: { key: string }) => ({
     value: null as string | null,
@@ -42,11 +46,22 @@ vi.mock("@capacitor/core", () => ({
           remove: playEntry.secureClear,
         }
       : {
-          addListener: vi.fn(async () => ({ remove: vi.fn() })),
+          addListener: vi.fn(
+            async (eventName: string, listener: (value: never) => void) => {
+              playEntry.voiceListeners.set(eventName, listener);
+              const remove = vi.fn(async () => {
+                if (playEntry.voiceListeners.get(eventName) === listener) {
+                  playEntry.voiceListeners.delete(eventName);
+                }
+              });
+              playEntry.voiceListenerRemovals.set(eventName, remove);
+              return { remove };
+            },
+          ),
           requestPermission: vi.fn(async () => ({ granted: true })),
           speak: vi.fn(async () => undefined),
-          startDictation: vi.fn(async () => ({ started: true })),
-          stopDictation: vi.fn(async () => undefined),
+          startDictation: playEntry.voiceStart,
+          stopDictation: playEntry.voiceStop,
         },
 }));
 vi.mock("@capacitor/preferences", () => ({
@@ -103,9 +118,14 @@ beforeAll(async () => {
   await vi.waitFor(() => expect(playEntry.createRoot).toHaveBeenCalledOnce());
 });
 
-beforeEach(() => {
+beforeEach(async () => {
+  await entry.androidCloudVoice.stop();
   vi.clearAllMocks();
   playEntry.appListeners.clear();
+  playEntry.voiceListeners.clear();
+  playEntry.voiceListenerRemovals.clear();
+  playEntry.voiceStart.mockResolvedValue({ started: true });
+  playEntry.voiceStop.mockResolvedValue(undefined);
   window.localStorage.clear();
   playEntry.preferenceGet.mockResolvedValue({ value: null });
   playEntry.secureGet.mockResolvedValue({ value: null });
@@ -113,6 +133,44 @@ beforeEach(() => {
 });
 
 describe("Android Cloud renderer behavior", () => {
+  it("surfaces native voice errors and removes both terminal listeners", async () => {
+    const onTranscript = vi.fn();
+    const onError = vi.fn();
+
+    await entry.androidCloudVoice.requestAndStart(onTranscript, onError);
+    expect([...playEntry.voiceListeners.keys()].sort()).toEqual([
+      "error",
+      "transcript",
+    ]);
+
+    playEntry.voiceListeners.get("error")?.({ code: 7 } as never);
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "No speech was recognized. Try again.",
+      }),
+    );
+    await vi.waitFor(() => expect(playEntry.voiceListeners.size).toBe(0));
+    expect(
+      playEntry.voiceListenerRemovals.get("transcript"),
+    ).toHaveBeenCalledOnce();
+    expect(playEntry.voiceListenerRemovals.get("error")).toHaveBeenCalledOnce();
+  });
+
+  it("removes both native listeners when dictation fails to start", async () => {
+    playEntry.voiceStart.mockRejectedValueOnce(new Error("recognizer failed"));
+
+    await expect(
+      entry.androidCloudVoice.requestAndStart(vi.fn(), vi.fn()),
+    ).rejects.toThrow("Voice dictation could not start.");
+
+    expect(playEntry.voiceListeners.size).toBe(0);
+    expect(
+      playEntry.voiceListenerRemovals.get("transcript"),
+    ).toHaveBeenCalledOnce();
+    expect(playEntry.voiceListenerRemovals.get("error")).toHaveBeenCalledOnce();
+  });
+
   it("migrates a legacy bearer into the secure plugin before deleting plaintext", async () => {
     const order: string[] = [];
     playEntry.preferenceGet.mockImplementation(async ({ key }) => ({

--- a/packages/app/src/main.android-cloud.behavior.test.tsx
+++ b/packages/app/src/main.android-cloud.behavior.test.tsx
@@ -13,6 +13,10 @@ const playEntry = vi.hoisted(() => ({
   voiceListeners: new Map<string, (value: never) => void>(),
   voiceListenerRemovals: new Map<string, ReturnType<typeof vi.fn>>(),
   voiceListenerGate: null as Promise<void> | null,
+  voiceRegistrationEvent: null as {
+    eventName: string;
+    value: never;
+  } | null,
   voiceStart: vi.fn(async () => ({ started: true })),
   voiceStop: vi.fn(async () => undefined),
   createRoot: vi.fn(() => ({ render: vi.fn() })),
@@ -49,6 +53,9 @@ vi.mock("@capacitor/core", () => ({
       : {
           addListener: vi.fn(
             async (eventName: string, listener: (value: never) => void) => {
+              if (playEntry.voiceRegistrationEvent?.eventName === eventName) {
+                listener(playEntry.voiceRegistrationEvent.value);
+              }
               await playEntry.voiceListenerGate;
               playEntry.voiceListeners.set(eventName, listener);
               const remove = vi.fn(async () => {
@@ -138,6 +145,7 @@ beforeEach(async () => {
   playEntry.voiceListeners.clear();
   playEntry.voiceListenerRemovals.clear();
   playEntry.voiceListenerGate = null;
+  playEntry.voiceRegistrationEvent = null;
   playEntry.voiceStart.mockResolvedValue({ started: true });
   playEntry.voiceStop.mockResolvedValue(undefined);
   window.localStorage.clear();
@@ -183,6 +191,22 @@ describe("Android Cloud renderer behavior", () => {
       playEntry.voiceListenerRemovals.get("transcript"),
     ).toHaveBeenCalledOnce();
     expect(playEntry.voiceListenerRemovals.get("error")).toHaveBeenCalledOnce();
+  });
+
+  it("ignores native events delivered before the listener pair is active", async () => {
+    const onError = vi.fn();
+    playEntry.voiceRegistrationEvent = {
+      eventName: "error",
+      value: { code: 7 } as never,
+    };
+
+    await entry.androidCloudVoice.requestAndStart(vi.fn(), onError);
+
+    expect(onError).not.toHaveBeenCalled();
+    expect([...playEntry.voiceListeners.keys()].sort()).toEqual([
+      "error",
+      "transcript",
+    ]);
   });
 
   it("cancels startup and removes listeners when stopped during registration", async () => {

--- a/packages/app/src/main.android-cloud.tsx
+++ b/packages/app/src/main.android-cloud.tsx
@@ -378,7 +378,12 @@ export const androidCloudVoice: AndroidCloudVoiceAdapter = {
       let listeners: ActivePlayVoiceListeners | null = null;
       const listenerResults = await Promise.allSettled([
         PlayVoice.addListener("transcript", (event) => {
-          if (activeVoiceListeners !== listeners || !event.isFinal) return;
+          if (
+            !listeners ||
+            activeVoiceListeners !== listeners ||
+            !event.isFinal
+          )
+            return;
           const transcript = event.text.trim();
           if (transcript) onFinalTranscript(transcript);
           void androidCloudVoice
@@ -387,7 +392,7 @@ export const androidCloudVoice: AndroidCloudVoiceAdapter = {
             .catch((error) => logOptionalPluginFailure("PlayVoice", error));
         }),
         PlayVoice.addListener("error", (event) => {
-          if (activeVoiceListeners !== listeners) return;
+          if (!listeners || activeVoiceListeners !== listeners) return;
           onError(playVoiceError(event.code));
           void androidCloudVoice
             .stop()

--- a/packages/app/src/main.android-cloud.tsx
+++ b/packages/app/src/main.android-cloud.tsx
@@ -279,6 +279,8 @@ interface ActivePlayVoiceListeners {
 }
 
 let activeVoiceListeners: ActivePlayVoiceListeners | null = null;
+let voiceLifecycleGeneration = 0;
+let voiceLifecycleMutation: Promise<void> = Promise.resolve();
 
 interface PlayVoicePlugin {
   requestPermission(): Promise<{ granted: boolean }>;
@@ -323,92 +325,139 @@ function playVoiceError(code: number): Error {
   return new Error(message);
 }
 
+function enqueueVoiceLifecycle<T>(operation: () => Promise<T>): Promise<T> {
+  const mutation = voiceLifecycleMutation.then(operation, operation);
+  // error-policy:J5 callers observe the returned mutation; this tail only
+  // keeps later lifecycle operations ordered after a rejected predecessor.
+  voiceLifecycleMutation = mutation.then(
+    () => undefined,
+    () => undefined,
+  );
+  return mutation;
+}
+
+async function removeVoiceListeners(
+  listeners: ActivePlayVoiceListeners,
+): Promise<void> {
+  await Promise.all([listeners.transcript.remove(), listeners.error.remove()]);
+}
+
+async function stopActiveVoice(): Promise<void> {
+  const listeners = activeVoiceListeners;
+  activeVoiceListeners = null;
+  try {
+    await PlayVoice.stopDictation();
+  } finally {
+    if (listeners) await removeVoiceListeners(listeners);
+  }
+}
+
+function throwIfVoiceAttemptCancelled(
+  generation: number,
+  signal?: AbortSignal,
+): void {
+  if (generation !== voiceLifecycleGeneration || signal?.aborted) {
+    throw new DOMException("Voice dictation was cancelled.", "AbortError");
+  }
+}
+
 export const androidCloudVoice: AndroidCloudVoiceAdapter = {
-  async requestAndStart(onFinalTranscript, onError) {
-    await androidCloudVoice.stop();
-    const permissions = await PlayVoice.requestPermission();
-    if (!permissions.granted) {
-      throw new Error("Microphone permission is required for voice dictation.");
-    }
-    let listeners: ActivePlayVoiceListeners | null = null;
-    const listenerResults = await Promise.allSettled([
-      PlayVoice.addListener("transcript", (event) => {
-        if (activeVoiceListeners !== listeners || !event.isFinal) return;
-        const transcript = event.text.trim();
-        if (transcript) onFinalTranscript(transcript);
-        void androidCloudVoice
-          .stop()
-          // error-policy:J6 listener teardown is best effort after a terminal event.
-          .catch((error) => logOptionalPluginFailure("PlayVoice", error));
-      }),
-      PlayVoice.addListener("error", (event) => {
-        if (activeVoiceListeners !== listeners) return;
-        onError(playVoiceError(event.code));
-        void androidCloudVoice
-          .stop()
-          // error-policy:J6 listener teardown is best effort after a terminal event.
-          .catch((error) => logOptionalPluginFailure("PlayVoice", error));
-      }),
-    ]);
-    const rejected = listenerResults.find(
-      (result): result is PromiseRejectedResult => result.status === "rejected",
-    );
-    if (rejected) {
-      await Promise.all(
-        listenerResults.flatMap((result) =>
-          result.status === "fulfilled" ? [result.value.remove()] : [],
-        ),
-      );
-      throw new Error("Voice dictation listeners could not be registered.", {
-        cause: rejected.reason,
-      });
-    }
-    const [transcriptResult, errorResult] = listenerResults;
-    if (
-      transcriptResult.status !== "fulfilled" ||
-      errorResult.status !== "fulfilled"
-    ) {
-      throw new Error("Voice dictation listeners could not be registered.");
-    }
-    listeners = {
-      transcript: transcriptResult.value,
-      error: errorResult.value,
-    };
-    activeVoiceListeners = listeners;
-    const [startResult] = await Promise.allSettled([
-      PlayVoice.startDictation({
-        language: navigator.language || "en-US",
-      }),
-    ]);
-    if (startResult.status === "rejected" || !startResult.value.started) {
-      if (activeVoiceListeners === listeners) activeVoiceListeners = null;
-      await Promise.all([
-        listeners.transcript.remove(),
-        listeners.error.remove(),
+  requestAndStart(onFinalTranscript, onError, signal) {
+    const generation = voiceLifecycleGeneration + 1;
+    voiceLifecycleGeneration = generation;
+    return enqueueVoiceLifecycle(async () => {
+      await stopActiveVoice();
+      throwIfVoiceAttemptCancelled(generation, signal);
+      const permissions = await PlayVoice.requestPermission();
+      throwIfVoiceAttemptCancelled(generation, signal);
+      if (!permissions.granted) {
+        throw new Error(
+          "Microphone permission is required for voice dictation.",
+        );
+      }
+      let listeners: ActivePlayVoiceListeners | null = null;
+      const listenerResults = await Promise.allSettled([
+        PlayVoice.addListener("transcript", (event) => {
+          if (activeVoiceListeners !== listeners || !event.isFinal) return;
+          const transcript = event.text.trim();
+          if (transcript) onFinalTranscript(transcript);
+          void androidCloudVoice
+            .stop()
+            // error-policy:J6 listener teardown is best effort after a terminal event.
+            .catch((error) => logOptionalPluginFailure("PlayVoice", error));
+        }),
+        PlayVoice.addListener("error", (event) => {
+          if (activeVoiceListeners !== listeners) return;
+          onError(playVoiceError(event.code));
+          void androidCloudVoice
+            .stop()
+            // error-policy:J6 listener teardown is best effort after a terminal event.
+            .catch((error) => logOptionalPluginFailure("PlayVoice", error));
+        }),
       ]);
-      if (startResult.status === "rejected") {
-        throw new Error("Voice dictation could not start.", {
-          cause: startResult.reason,
+      const fulfilledListeners = listenerResults.flatMap((result) =>
+        result.status === "fulfilled" ? [result.value] : [],
+      );
+      const rejected = listenerResults.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+      if (rejected) {
+        await Promise.all(
+          fulfilledListeners.map((listener) => listener.remove()),
+        );
+        throw new Error("Voice dictation listeners could not be registered.", {
+          cause: rejected.reason,
         });
       }
-      throw new Error(
-        startResult.value.error || "Voice dictation could not start.",
-      );
-    }
-  },
-  async stop() {
-    const listeners = activeVoiceListeners;
-    activeVoiceListeners = null;
-    try {
-      await PlayVoice.stopDictation();
-    } finally {
-      if (listeners) {
-        await Promise.all([
-          listeners.transcript.remove(),
-          listeners.error.remove(),
-        ]);
+      try {
+        throwIfVoiceAttemptCancelled(generation, signal);
+      } catch (error) {
+        await Promise.all(
+          fulfilledListeners.map((listener) => listener.remove()),
+        );
+        throw error;
       }
-    }
+      const [transcriptResult, errorResult] = listenerResults;
+      if (
+        transcriptResult.status !== "fulfilled" ||
+        errorResult.status !== "fulfilled"
+      ) {
+        throw new Error("Voice dictation listeners could not be registered.");
+      }
+      listeners = {
+        transcript: transcriptResult.value,
+        error: errorResult.value,
+      };
+      activeVoiceListeners = listeners;
+      const [startResult] = await Promise.allSettled([
+        PlayVoice.startDictation({
+          language: navigator.language || "en-US",
+        }),
+      ]);
+      if (startResult.status === "rejected" || !startResult.value.started) {
+        if (activeVoiceListeners === listeners) activeVoiceListeners = null;
+        await removeVoiceListeners(listeners);
+        if (startResult.status === "rejected") {
+          throw new Error("Voice dictation could not start.", {
+            cause: startResult.reason,
+          });
+        }
+        throw new Error(
+          startResult.value.error || "Voice dictation could not start.",
+        );
+      }
+      try {
+        throwIfVoiceAttemptCancelled(generation, signal);
+      } catch (error) {
+        await stopActiveVoice();
+        throw error;
+      }
+    });
+  },
+  stop() {
+    voiceLifecycleGeneration += 1;
+    return enqueueVoiceLifecycle(stopActiveVoice);
   },
   async speak(text) {
     await PlayVoice.speak({ text, language: navigator.language || "en-US" });

--- a/packages/app/src/main.android-cloud.tsx
+++ b/packages/app/src/main.android-cloud.tsx
@@ -269,7 +269,16 @@ async function initializeAndroidCloudPlatform(): Promise<void> {
     .catch((error) => logOptionalPluginFailure("Network", error));
 }
 
-let activeTranscriptListener: { remove: () => Promise<void> } | null = null;
+interface PlayVoiceListener {
+  remove(): Promise<void>;
+}
+
+interface ActivePlayVoiceListeners {
+  transcript: PlayVoiceListener;
+  error: PlayVoiceListener;
+}
+
+let activeVoiceListeners: ActivePlayVoiceListeners | null = null;
 
 interface PlayVoicePlugin {
   requestPermission(): Promise<{ granted: boolean }>;
@@ -281,47 +290,124 @@ interface PlayVoicePlugin {
   addListener(
     eventName: "transcript",
     listener: (event: { text: string; isFinal: boolean }) => void,
-  ): Promise<{ remove: () => Promise<void> }>;
+  ): Promise<PlayVoiceListener>;
+  addListener(
+    eventName: "error",
+    listener: (event: { code: number }) => void,
+  ): Promise<PlayVoiceListener>;
 }
 
 const PlayVoice = registerPlugin<PlayVoicePlugin>("ElizaPlayVoice");
 
-const androidCloudVoice: AndroidCloudVoiceAdapter = {
-  async requestAndStart(onFinalTranscript) {
-    await activeTranscriptListener?.remove();
-    activeTranscriptListener = null;
+function playVoiceError(code: number): Error {
+  const message =
+    code === 1
+      ? "Voice recognition timed out. Check your connection and try again."
+      : code === 2
+        ? "Voice recognition lost its network connection. Try again."
+        : code === 3
+          ? "The microphone audio could not be recorded. Try again."
+          : code === 6
+            ? "No speech was heard. Try speaking again."
+            : code === 7
+              ? "No speech was recognized. Try again."
+              : code === 8
+                ? "Voice recognition is busy. Wait a moment and try again."
+                : code === 9
+                  ? "Microphone permission is required for voice dictation."
+                  : code === 10
+                    ? "Voice recognition received too many requests. Wait and try again."
+                    : code === 12 || code === 13
+                      ? "Voice recognition does not support this language on this device."
+                      : "Voice recognition failed. Try again.";
+  return new Error(message);
+}
+
+export const androidCloudVoice: AndroidCloudVoiceAdapter = {
+  async requestAndStart(onFinalTranscript, onError) {
+    await androidCloudVoice.stop();
     const permissions = await PlayVoice.requestPermission();
     if (!permissions.granted) {
       throw new Error("Microphone permission is required for voice dictation.");
     }
-    const transcriptListener = await PlayVoice.addListener(
-      "transcript",
-      (event) => {
-        if (!event.isFinal) return;
+    let listeners: ActivePlayVoiceListeners | null = null;
+    const listenerResults = await Promise.allSettled([
+      PlayVoice.addListener("transcript", (event) => {
+        if (activeVoiceListeners !== listeners || !event.isFinal) return;
         const transcript = event.text.trim();
         if (transcript) onFinalTranscript(transcript);
-        void androidCloudVoice.stop();
-      },
+        void androidCloudVoice
+          .stop()
+          // error-policy:J6 listener teardown is best effort after a terminal event.
+          .catch((error) => logOptionalPluginFailure("PlayVoice", error));
+      }),
+      PlayVoice.addListener("error", (event) => {
+        if (activeVoiceListeners !== listeners) return;
+        onError(playVoiceError(event.code));
+        void androidCloudVoice
+          .stop()
+          // error-policy:J6 listener teardown is best effort after a terminal event.
+          .catch((error) => logOptionalPluginFailure("PlayVoice", error));
+      }),
+    ]);
+    const rejected = listenerResults.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
     );
-    activeTranscriptListener = transcriptListener;
-    const result = await PlayVoice.startDictation({
-      language: navigator.language || "en-US",
-    });
-    if (!result.started) {
-      await transcriptListener.remove();
-      if (activeTranscriptListener === transcriptListener) {
-        activeTranscriptListener = null;
+    if (rejected) {
+      await Promise.all(
+        listenerResults.flatMap((result) =>
+          result.status === "fulfilled" ? [result.value.remove()] : [],
+        ),
+      );
+      throw new Error("Voice dictation listeners could not be registered.", {
+        cause: rejected.reason,
+      });
+    }
+    const [transcriptResult, errorResult] = listenerResults;
+    if (
+      transcriptResult.status !== "fulfilled" ||
+      errorResult.status !== "fulfilled"
+    ) {
+      throw new Error("Voice dictation listeners could not be registered.");
+    }
+    listeners = {
+      transcript: transcriptResult.value,
+      error: errorResult.value,
+    };
+    activeVoiceListeners = listeners;
+    const [startResult] = await Promise.allSettled([
+      PlayVoice.startDictation({
+        language: navigator.language || "en-US",
+      }),
+    ]);
+    if (startResult.status === "rejected" || !startResult.value.started) {
+      if (activeVoiceListeners === listeners) activeVoiceListeners = null;
+      await Promise.all([
+        listeners.transcript.remove(),
+        listeners.error.remove(),
+      ]);
+      if (startResult.status === "rejected") {
+        throw new Error("Voice dictation could not start.", {
+          cause: startResult.reason,
+        });
       }
-      throw new Error(result.error || "Voice dictation could not start.");
+      throw new Error(
+        startResult.value.error || "Voice dictation could not start.",
+      );
     }
   },
   async stop() {
-    const listener = activeTranscriptListener;
-    activeTranscriptListener = null;
+    const listeners = activeVoiceListeners;
+    activeVoiceListeners = null;
     try {
       await PlayVoice.stopDictation();
     } finally {
-      await listener?.remove();
+      if (listeners) {
+        await Promise.all([
+          listeners.transcript.remove(),
+          listeners.error.remove(),
+        ]);
+      }
     }
   },
   async speak(text) {

--- a/packages/ui/src/android-cloud/AndroidCloudApp.test.tsx
+++ b/packages/ui/src/android-cloud/AndroidCloudApp.test.tsx
@@ -191,6 +191,10 @@ describe("AndroidCloudApp", () => {
     const client = createClient();
     const voice = createVoice();
     const startup = deferred<void>();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.mocked(voice.stop).mockRejectedValueOnce(
+      new Error("native stop unavailable"),
+    );
     let startupSignal: AbortSignal | undefined;
     vi.mocked(voice.requestAndStart).mockImplementation(
       async (_onTranscript, _onError, signal) => {
@@ -208,10 +212,44 @@ describe("AndroidCloudApp", () => {
 
     expect(startupSignal?.aborted).toBe(true);
     expect(voice.stop).toHaveBeenCalledOnce();
+    await waitFor(() =>
+      expect(warn).toHaveBeenCalledWith(
+        "[AndroidCloudApp] Voice teardown failed",
+        expect.objectContaining({ message: "native stop unavailable" }),
+      ),
+    );
     await act(async () => {
       startup.resolve(undefined);
       await startup.promise;
     });
+  });
+
+  it("surfaces a system-browser close failure during sign-in cancellation", async () => {
+    const client = createClient();
+    const login = deferred<{
+      sessionId: string;
+      browserUrl: string;
+    }>();
+    vi.spyOn(client, "restoreSession").mockResolvedValue(null);
+    vi.spyOn(client, "beginLogin").mockReturnValue(login.promise);
+    const closeExternal = vi.fn(async () => {
+      throw new Error("browser close unavailable");
+    });
+    render(
+      <AndroidCloudApp
+        client={client}
+        closeExternal={closeExternal}
+        voice={createVoice()}
+      />,
+    );
+    await screen.findByRole("button", { name: "Sign in" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel sign-in" }));
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "The sign-in browser could not be closed: browser close unavailable",
+    );
   });
 
   it("ends dictation and surfaces an asynchronous native voice failure", async () => {

--- a/packages/ui/src/android-cloud/AndroidCloudApp.test.tsx
+++ b/packages/ui/src/android-cloud/AndroidCloudApp.test.tsx
@@ -45,13 +45,99 @@ function createVoice(): AndroidCloudVoiceAdapter {
   };
 }
 
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
 describe("AndroidCloudApp", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.restoreAllMocks();
   });
 
-  afterEach(() => cleanup());
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it("does not persist a poll response that resolves after sign-in cancellation", async () => {
+    const client = createClient();
+    const poll = deferred<{ status: "authenticated"; token: string }>();
+    vi.spyOn(client, "restoreSession").mockResolvedValue(null);
+    vi.spyOn(client, "beginLogin").mockResolvedValue({
+      sessionId: "10000000-0000-4000-8000-000000000001",
+      browserUrl:
+        "https://cloud.eliza.app/auth/cli-login?session=10000000-0000-4000-8000-000000000001",
+    });
+    vi.spyOn(client, "pollLogin").mockReturnValue(poll.promise);
+    const persistLogin = vi.spyOn(client, "persistLogin");
+    const openExternal = vi.fn(async () => undefined);
+    render(
+      <AndroidCloudApp
+        client={client}
+        openExternal={openExternal}
+        voice={createVoice()}
+      />,
+    );
+    await screen.findByRole("button", { name: "Sign in" });
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+    await act(async () => {
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    expect(client.pollLogin).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel sign-in" }));
+    await act(async () => {
+      poll.resolve({ status: "authenticated", token: "stale-token" });
+      await poll.promise;
+      await Promise.resolve();
+    });
+
+    expect(persistLogin).not.toHaveBeenCalled();
+    expect(client.restoreSession).toHaveBeenCalledOnce();
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeTruthy();
+  });
+
+  it("ends dictation and surfaces an asynchronous native voice failure", async () => {
+    const client = createClient();
+    const voice = createVoice();
+    let publishError: ((error: Error) => void) | undefined;
+    vi.mocked(voice.requestAndStart).mockImplementation(
+      async (_onTranscript, onError) => {
+        publishError = onError;
+      },
+    );
+    vi.spyOn(client, "restoreSession").mockResolvedValue(session);
+    render(<AndroidCloudApp client={client} voice={voice} />);
+    await screen.findByText("Ada");
+
+    fireEvent.click(screen.getByRole("button", { name: "Start dictation" }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Stop dictation" }),
+      ).toBeTruthy(),
+    );
+    act(() =>
+      publishError?.(new Error("No speech was recognized. Try again.")),
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Start dictation" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("alert").textContent).toContain(
+      "No speech was recognized. Try again.",
+    );
+  });
 
   it("renders a retryable signed-out state when no stored session exists", async () => {
     const client = createClient();

--- a/packages/ui/src/android-cloud/AndroidCloudApp.test.tsx
+++ b/packages/ui/src/android-cloud/AndroidCloudApp.test.tsx
@@ -108,6 +108,112 @@ describe("AndroidCloudApp", () => {
     expect(screen.getByRole("button", { name: "Sign in" })).toBeTruthy();
   });
 
+  it("rolls back a committed login cancelled while the browser is closing", async () => {
+    const client = createClient();
+    const close = deferred<void>();
+    vi.spyOn(client, "restoreSession").mockResolvedValue(null);
+    vi.spyOn(client, "beginLogin").mockResolvedValue({
+      sessionId: "10000000-0000-4000-8000-000000000001",
+      browserUrl:
+        "https://cloud.eliza.app/auth/cli-login?session=10000000-0000-4000-8000-000000000001",
+    });
+    vi.spyOn(client, "pollLogin").mockResolvedValue({
+      status: "authenticated",
+      token: "committed-token",
+    });
+    const persistLogin = vi
+      .spyOn(client, "persistLogin")
+      .mockResolvedValue(undefined);
+    const discardLogin = vi
+      .spyOn(client, "discardLogin")
+      .mockResolvedValue(undefined);
+    const closeExternal = vi.fn(() => close.promise);
+    render(
+      <AndroidCloudApp
+        client={client}
+        closeExternal={closeExternal}
+        openExternal={vi.fn()}
+        voice={createVoice()}
+      />,
+    );
+    await screen.findByRole("button", { name: "Sign in" });
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+    await act(async () => {
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    await vi.waitFor(() =>
+      expect(persistLogin).toHaveBeenCalledWith(
+        "committed-token",
+        expect.any(AbortSignal),
+      ),
+    );
+    expect(closeExternal).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel sign-in" }));
+    await act(async () => {
+      close.resolve(undefined);
+      await close.promise;
+      await Promise.resolve();
+    });
+
+    expect(discardLogin).toHaveBeenCalledWith("committed-token");
+    expect(client.restoreSession).toHaveBeenCalledOnce();
+  });
+
+  it("turns a second dictation click into a stop while startup is pending", async () => {
+    const client = createClient();
+    const voice = createVoice();
+    const startup = deferred<void>();
+    vi.mocked(voice.requestAndStart).mockReturnValue(startup.promise);
+    vi.spyOn(client, "restoreSession").mockResolvedValue(session);
+    render(<AndroidCloudApp client={client} voice={voice} />);
+    await screen.findByText("Ada");
+
+    fireEvent.click(screen.getByRole("button", { name: "Start dictation" }));
+    expect(screen.getByRole("button", { name: "Stop dictation" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Stop dictation" }));
+
+    expect(voice.requestAndStart).toHaveBeenCalledOnce();
+    expect(voice.stop).toHaveBeenCalledOnce();
+    expect(
+      screen.getByRole("button", { name: "Start dictation" }),
+    ).toBeTruthy();
+    await act(async () => {
+      startup.resolve(undefined);
+      await startup.promise;
+    });
+  });
+
+  it("aborts a pending native voice startup when the shell unmounts", async () => {
+    const client = createClient();
+    const voice = createVoice();
+    const startup = deferred<void>();
+    let startupSignal: AbortSignal | undefined;
+    vi.mocked(voice.requestAndStart).mockImplementation(
+      async (_onTranscript, _onError, signal) => {
+        startupSignal = signal;
+        await startup.promise;
+      },
+    );
+    vi.spyOn(client, "restoreSession").mockResolvedValue(session);
+    const view = render(<AndroidCloudApp client={client} voice={voice} />);
+    await screen.findByText("Ada");
+
+    fireEvent.click(screen.getByRole("button", { name: "Start dictation" }));
+    expect(startupSignal?.aborted).toBe(false);
+    view.unmount();
+
+    expect(startupSignal?.aborted).toBe(true);
+    expect(voice.stop).toHaveBeenCalledOnce();
+    await act(async () => {
+      startup.resolve(undefined);
+      await startup.promise;
+    });
+  });
+
   it("ends dictation and surfaces an asynchronous native voice failure", async () => {
     const client = createClient();
     const voice = createVoice();

--- a/packages/ui/src/android-cloud/AndroidCloudApp.tsx
+++ b/packages/ui/src/android-cloud/AndroidCloudApp.tsx
@@ -27,7 +27,10 @@ export interface AndroidCloudAppProps {
 }
 
 export interface AndroidCloudVoiceAdapter {
-  requestAndStart(onFinalTranscript: (text: string) => void): Promise<void>;
+  requestAndStart(
+    onFinalTranscript: (text: string) => void,
+    onError: (error: Error) => void,
+  ): Promise<void>;
   stop(): Promise<void>;
   speak(text: string): Promise<void>;
 }
@@ -73,6 +76,7 @@ export function AndroidCloudApp({
   const [listening, setListening] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const loginAbortRef = useRef<AbortController | null>(null);
   const loginAttemptRef = useRef(0);
 
   const restore = useCallback(async () => {
@@ -120,6 +124,7 @@ export function AndroidCloudApp({
     void restore();
     return () => {
       loginAttemptRef.current += 1;
+      loginAbortRef.current?.abort();
       abortRef.current?.abort();
       void voice?.stop();
     };
@@ -139,6 +144,9 @@ export function AndroidCloudApp({
   const signIn = useCallback(async () => {
     const attemptNumber = loginAttemptRef.current + 1;
     loginAttemptRef.current = attemptNumber;
+    loginAbortRef.current?.abort();
+    const controller = new AbortController();
+    loginAbortRef.current = controller;
     setBusy(true);
     setError(null);
     try {
@@ -149,10 +157,28 @@ export function AndroidCloudApp({
         await new Promise((resolve) =>
           window.setTimeout(resolve, LOGIN_POLL_MS),
         );
-        if (loginAttemptRef.current !== attemptNumber) return;
-        const result = await client.pollLogin(attempt.sessionId);
+        if (
+          controller.signal.aborted ||
+          loginAttemptRef.current !== attemptNumber
+        )
+          return;
+        const result = await client.pollLogin(
+          attempt.sessionId,
+          controller.signal,
+        );
+        if (
+          controller.signal.aborted ||
+          loginAttemptRef.current !== attemptNumber
+        )
+          return;
         if (result.status === "pending") continue;
         if (result.status === "expired") throw new Error(result.error);
+        await client.persistLogin(result.token, controller.signal);
+        if (
+          controller.signal.aborted ||
+          loginAttemptRef.current !== attemptNumber
+        )
+          return;
         await closeExternal?.();
         await restore();
         return;
@@ -160,14 +186,24 @@ export function AndroidCloudApp({
       throw new Error("Sign-in timed out. Please try again.");
     } catch (signInError) {
       // error-policy:J4 the sign-in boundary renders the actionable failure.
-      setError(errorMessage(signInError));
+      if (
+        !controller.signal.aborted &&
+        loginAttemptRef.current === attemptNumber
+      ) {
+        setError(errorMessage(signInError));
+      }
     } finally {
-      if (loginAttemptRef.current === attemptNumber) setBusy(false);
+      if (loginAttemptRef.current === attemptNumber) {
+        loginAbortRef.current = null;
+        setBusy(false);
+      }
     }
   }, [client, closeExternal, openExternal, restore]);
 
   const cancelSignIn = useCallback(() => {
     loginAttemptRef.current += 1;
+    loginAbortRef.current?.abort();
+    loginAbortRef.current = null;
     setBusy(false);
     void closeExternal?.();
   }, [closeExternal]);
@@ -265,15 +301,28 @@ export function AndroidCloudApp({
       return;
     }
     try {
-      await voice.requestAndStart((value) => {
-        const transcript = value.trim();
-        if (transcript) {
-          setDraft((current) => `${current}${current ? " " : ""}${transcript}`);
-        }
-        setListening(false);
-      });
-      setError(null);
-      setListening(true);
+      let nativeAttemptFinished = false;
+      await voice.requestAndStart(
+        (value) => {
+          nativeAttemptFinished = true;
+          const transcript = value.trim();
+          if (transcript) {
+            setDraft(
+              (current) => `${current}${current ? " " : ""}${transcript}`,
+            );
+          }
+          setListening(false);
+        },
+        (nativeError) => {
+          nativeAttemptFinished = true;
+          setListening(false);
+          setError(errorMessage(nativeError));
+        },
+      );
+      if (!nativeAttemptFinished) {
+        setError(null);
+        setListening(true);
+      }
     } catch (dictationError) {
       // error-policy:J4 denied or failed dictation is visible at the input.
       setListening(false);

--- a/packages/ui/src/android-cloud/AndroidCloudApp.tsx
+++ b/packages/ui/src/android-cloud/AndroidCloudApp.tsx
@@ -144,7 +144,11 @@ export function AndroidCloudApp({
       abortRef.current?.abort();
       voiceAttemptRef.current += 1;
       voiceAbortRef.current?.abort();
-      void voice?.stop();
+      void voice?.stop().catch((stopError) => {
+        // error-policy:J6 unmount owns this best-effort native teardown and
+        // cannot render a failure after the component has been removed.
+        console.warn("[AndroidCloudApp] Voice teardown failed", stopError);
+      });
     };
   }, [restore, voice]);
 
@@ -244,7 +248,15 @@ export function AndroidCloudApp({
     loginAbortRef.current?.abort();
     loginAbortRef.current = null;
     setBusy(false);
-    void closeExternal?.();
+    void Promise.resolve()
+      .then(() => closeExternal?.())
+      .catch((closeError) => {
+        // error-policy:J4 cancellation remains complete while a duplicate
+        // system-browser close failure is surfaced to the signed-out shell.
+        setError(
+          `The sign-in browser could not be closed: ${errorMessage(closeError)}`,
+        );
+      });
   }, [closeExternal]);
 
   const signOut = useCallback(async () => {

--- a/packages/ui/src/android-cloud/AndroidCloudApp.tsx
+++ b/packages/ui/src/android-cloud/AndroidCloudApp.tsx
@@ -30,6 +30,7 @@ export interface AndroidCloudVoiceAdapter {
   requestAndStart(
     onFinalTranscript: (text: string) => void,
     onError: (error: Error) => void,
+    signal?: AbortSignal,
   ): Promise<void>;
   stop(): Promise<void>;
   speak(text: string): Promise<void>;
@@ -78,47 +79,62 @@ export function AndroidCloudApp({
   const abortRef = useRef<AbortController | null>(null);
   const loginAbortRef = useRef<AbortController | null>(null);
   const loginAttemptRef = useRef(0);
+  const voiceAbortRef = useRef<AbortController | null>(null);
+  const voiceAttemptRef = useRef(0);
 
-  const restore = useCallback(async () => {
-    setError(null);
-    setPhase("loading");
-    try {
-      const restored = await client.restoreSession();
-      setSession(restored);
-      if (restored) {
-        const storedConversationId = localStorage
-          .getItem(ANDROID_CLOUD_CONVERSATION_ID_KEY)
-          ?.trim();
-        if (storedConversationId) {
-          setConversationId(storedConversationId);
-          try {
-            const restoredMessages = await client.getConversationMessages(
-              restored,
-              storedConversationId,
-            );
-            setMessages(restoredMessages.slice(-100));
-          } catch (historyError) {
-            // error-policy:J4 conversation restore failure remains visible
-            // while the authenticated shell stays usable for a new chat.
-            setError(
-              `Your previous conversation could not be restored: ${errorMessage(historyError)}`,
-            );
+  const restore = useCallback(
+    async (signal?: AbortSignal) => {
+      setError(null);
+      if (!signal) setPhase("loading");
+      try {
+        const restored = await client.restoreSession();
+        if (signal?.aborted) return;
+        let storedConversationId: string | null = null;
+        let restoredMessages: AndroidCloudMessage[] = [];
+        let historyErrorMessage: string | null = null;
+        if (restored) {
+          storedConversationId =
+            localStorage.getItem(ANDROID_CLOUD_CONVERSATION_ID_KEY)?.trim() ||
+            null;
+          if (storedConversationId) {
+            try {
+              restoredMessages = (
+                await client.getConversationMessages(
+                  restored,
+                  storedConversationId,
+                )
+              ).slice(-100);
+            } catch (historyError) {
+              if (signal?.aborted) return;
+              // error-policy:J4 conversation restore failure remains visible
+              // while the authenticated shell stays usable for a new chat.
+              historyErrorMessage = `Your previous conversation could not be restored: ${errorMessage(historyError)}`;
+            }
           }
         }
-      } else {
-        localStorage.removeItem(ANDROID_CLOUD_CONVERSATION_ID_KEY);
-        setConversationId(null);
-        setMessages([]);
+        if (signal?.aborted) return;
+        setSession(restored);
+        if (restored) {
+          setConversationId(storedConversationId);
+          setMessages(restoredMessages);
+          if (historyErrorMessage) setError(historyErrorMessage);
+        } else {
+          localStorage.removeItem(ANDROID_CLOUD_CONVERSATION_ID_KEY);
+          setConversationId(null);
+          setMessages([]);
+        }
+        setPhase(restored ? "ready" : "signed-out");
+      } catch (restoreError) {
+        if (signal?.aborted) return;
+        // error-policy:J4 session verification failure becomes an explicit
+        // signed-out error state with a retry affordance.
+        setSession(null);
+        setPhase("signed-out");
+        setError(errorMessage(restoreError));
       }
-      setPhase(restored ? "ready" : "signed-out");
-    } catch (restoreError) {
-      // error-policy:J4 session verification failure becomes an explicit
-      // signed-out error state with a retry affordance.
-      setSession(null);
-      setPhase("signed-out");
-      setError(errorMessage(restoreError));
-    }
-  }, [client]);
+    },
+    [client],
+  );
 
   useEffect(() => {
     void restore();
@@ -126,6 +142,8 @@ export function AndroidCloudApp({
       loginAttemptRef.current += 1;
       loginAbortRef.current?.abort();
       abortRef.current?.abort();
+      voiceAttemptRef.current += 1;
+      voiceAbortRef.current?.abort();
       void voice?.stop();
     };
   }, [restore, voice]);
@@ -147,6 +165,7 @@ export function AndroidCloudApp({
     loginAbortRef.current?.abort();
     const controller = new AbortController();
     loginAbortRef.current = controller;
+    let committedToken: string | null = null;
     setBusy(true);
     setError(null);
     try {
@@ -174,13 +193,19 @@ export function AndroidCloudApp({
         if (result.status === "pending") continue;
         if (result.status === "expired") throw new Error(result.error);
         await client.persistLogin(result.token, controller.signal);
+        committedToken = result.token;
         if (
           controller.signal.aborted ||
           loginAttemptRef.current !== attemptNumber
         )
           return;
         await closeExternal?.();
-        await restore();
+        if (
+          controller.signal.aborted ||
+          loginAttemptRef.current !== attemptNumber
+        )
+          return;
+        await restore(controller.signal);
         return;
       }
       throw new Error("Sign-in timed out. Please try again.");
@@ -193,6 +218,20 @@ export function AndroidCloudApp({
         setError(errorMessage(signInError));
       }
     } finally {
+      if (
+        committedToken &&
+        (controller.signal.aborted || loginAttemptRef.current !== attemptNumber)
+      ) {
+        try {
+          await client.discardLogin(committedToken);
+        } catch (rollbackError) {
+          // error-policy:J4 a secure-store rollback failure is visible instead
+          // of becoming an unhandled event-handler rejection.
+          setError(
+            `Sign-in was cancelled, but its credential could not be removed: ${errorMessage(rollbackError)}`,
+          );
+        }
+      }
       if (loginAttemptRef.current === attemptNumber) {
         loginAbortRef.current = null;
         setBusy(false);
@@ -292,18 +331,38 @@ export function AndroidCloudApp({
 
   const toggleDictation = useCallback(async () => {
     if (listening) {
-      await voice?.stop();
+      voiceAttemptRef.current += 1;
+      voiceAbortRef.current?.abort();
+      voiceAbortRef.current = null;
       setListening(false);
+      try {
+        await voice?.stop();
+      } catch (stopError) {
+        // error-policy:J4 a native stop failure remains visible at the input.
+        setError(errorMessage(stopError));
+      }
       return;
     }
     if (!voice) {
       setError("Voice dictation is not available on this device.");
       return;
     }
+    const attemptNumber = voiceAttemptRef.current + 1;
+    voiceAttemptRef.current = attemptNumber;
+    voiceAbortRef.current?.abort();
+    const controller = new AbortController();
+    voiceAbortRef.current = controller;
+    setError(null);
+    setListening(true);
+    let nativeAttemptFinished = false;
     try {
-      let nativeAttemptFinished = false;
       await voice.requestAndStart(
         (value) => {
+          if (
+            controller.signal.aborted ||
+            voiceAttemptRef.current !== attemptNumber
+          )
+            return;
           nativeAttemptFinished = true;
           const transcript = value.trim();
           if (transcript) {
@@ -314,19 +373,31 @@ export function AndroidCloudApp({
           setListening(false);
         },
         (nativeError) => {
+          if (
+            controller.signal.aborted ||
+            voiceAttemptRef.current !== attemptNumber
+          )
+            return;
           nativeAttemptFinished = true;
           setListening(false);
           setError(errorMessage(nativeError));
         },
+        controller.signal,
       );
-      if (!nativeAttemptFinished) {
-        setError(null);
-        setListening(true);
-      }
     } catch (dictationError) {
       // error-policy:J4 denied or failed dictation is visible at the input.
-      setListening(false);
-      setError(errorMessage(dictationError));
+      if (
+        !nativeAttemptFinished &&
+        !controller.signal.aborted &&
+        voiceAttemptRef.current === attemptNumber
+      ) {
+        setListening(false);
+        setError(errorMessage(dictationError));
+      }
+    } finally {
+      if (voiceAttemptRef.current === attemptNumber) {
+        voiceAbortRef.current = null;
+      }
     }
   }, [listening, voice]);
 

--- a/packages/ui/src/android-cloud/android-cloud-client.test.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.test.ts
@@ -130,6 +130,26 @@ describe("AndroidCloudClient", () => {
     expect(secureToken).toBe("fresh-token");
   });
 
+  it("does not discard a newer credential when rolling back a stale login", async () => {
+    let secureToken: string | null = "fresh-token";
+    const credentialStore = {
+      read: vi.fn(async () => secureToken),
+      write: vi.fn(async (token: string) => {
+        secureToken = token;
+      }),
+      clear: vi.fn(async () => {
+        secureToken = null;
+      }),
+    };
+    const client = new AndroidCloudClient({ credentialStore });
+
+    await client.discardLogin("stale-token");
+
+    expect(credentialStore.read).toHaveBeenCalledOnce();
+    expect(credentialStore.clear).not.toHaveBeenCalled();
+    expect(secureToken).toBe("fresh-token");
+  });
+
   it("restores identity and resolves its managed runtime before chat", async () => {
     localStorage.setItem(STEWARD_TOKEN_KEY, "steward-token");
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValueOnce(

--- a/packages/ui/src/android-cloud/android-cloud-client.test.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.test.ts
@@ -76,12 +76,58 @@ describe("AndroidCloudClient", () => {
       status: "authenticated",
       token: "steward-token",
     });
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+    await client.persistLogin("steward-token");
     expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe("steward-token");
     expect(fetchImpl).toHaveBeenNthCalledWith(
       1,
       "https://api.eliza.app/api/auth/cli-session",
       expect.objectContaining({ method: "POST" }),
     );
+  });
+
+  it("removes an aborted credential commit before a newer login can persist", async () => {
+    let releaseWrite: (() => void) | undefined;
+    let secureToken: string | null = null;
+    let writeCount = 0;
+    const mutationOrder: string[] = [];
+    const credentialStore = {
+      read: vi.fn(async () => secureToken),
+      write: vi.fn(async (token: string) => {
+        writeCount += 1;
+        mutationOrder.push(`write:${token}`);
+        if (writeCount === 1) {
+          await new Promise<void>((resolve) => {
+            releaseWrite = resolve;
+          });
+        }
+        secureToken = token;
+      }),
+      clear: vi.fn(async () => {
+        mutationOrder.push("clear");
+        secureToken = null;
+      }),
+    };
+    const client = new AndroidCloudClient({ credentialStore });
+    const controller = new AbortController();
+    const staleCommit = client.persistLogin("stale-token", controller.signal);
+
+    await vi.waitFor(() =>
+      expect(credentialStore.write).toHaveBeenCalledOnce(),
+    );
+    controller.abort();
+    const freshCommit = client.persistLogin("fresh-token");
+    releaseWrite?.();
+
+    await expect(staleCommit).rejects.toMatchObject({ name: "AbortError" });
+    await expect(freshCommit).resolves.toBeUndefined();
+    expect(credentialStore.clear).toHaveBeenCalledOnce();
+    expect(mutationOrder).toEqual([
+      "write:stale-token",
+      "clear",
+      "write:fresh-token",
+    ]);
+    expect(secureToken).toBe("fresh-token");
   });
 
   it("restores identity and resolves its managed runtime before chat", async () => {

--- a/packages/ui/src/android-cloud/android-cloud-client.test.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.test.ts
@@ -25,6 +25,17 @@ function json(status: number, body: unknown): Response {
   });
 }
 
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
 describe("AndroidCloudClient", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -150,6 +161,31 @@ describe("AndroidCloudClient", () => {
     expect(secureToken).toBe("fresh-token");
   });
 
+  it("does not let a delayed stale 401 clear a newer login", async () => {
+    let secureToken: string | null = "stale-token";
+    const verification = deferred<Response>();
+    const credentialStore = {
+      read: vi.fn(async () => secureToken),
+      write: vi.fn(async (token: string) => {
+        secureToken = token;
+      }),
+      clear: vi.fn(async () => {
+        secureToken = null;
+      }),
+    };
+    const fetchImpl = vi.fn<typeof fetch>(() => verification.promise);
+    const client = new AndroidCloudClient({ credentialStore, fetchImpl });
+
+    const staleRestore = client.restoreSession();
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledOnce());
+    await client.persistLogin("fresh-token");
+    verification.resolve(json(401, {}));
+
+    await expect(staleRestore).resolves.toBeNull();
+    expect(credentialStore.clear).not.toHaveBeenCalled();
+    expect(secureToken).toBe("fresh-token");
+  });
+
   it("restores identity and resolves its managed runtime before chat", async () => {
     localStorage.setItem(STEWARD_TOKEN_KEY, "steward-token");
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValueOnce(
@@ -227,7 +263,7 @@ describe("AndroidCloudClient", () => {
     });
 
     await expect(client.restoreSession()).resolves.toBeNull();
-    expect(credentialStore.read).toHaveBeenCalledOnce();
+    expect(credentialStore.read).toHaveBeenCalledTimes(2);
     expect(credentialStore.clear).toHaveBeenCalledOnce();
     expect(secureToken).toBeNull();
     expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();

--- a/packages/ui/src/android-cloud/android-cloud-client.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.ts
@@ -160,6 +160,7 @@ export class AndroidCloudClient {
   readonly apiBase: string;
   private readonly fetchImpl: typeof fetch;
   private readonly credentialStore: AndroidCloudCredentialStore;
+  private loginCredentialMutation: Promise<void> = Promise.resolve();
 
   constructor(options: AndroidCloudClientOptions = {}) {
     this.apiBase = resolveCanonicalDirectCloudApiBase(options.cloudApiBase);
@@ -251,12 +252,16 @@ export class AndroidCloudClient {
     return { sessionId, browserUrl: url.toString() };
   }
 
-  async pollLogin(sessionId: string): Promise<AndroidCloudLoginPoll> {
+  async pollLogin(
+    sessionId: string,
+    signal?: AbortSignal,
+  ): Promise<AndroidCloudLoginPoll> {
     if (!SESSION_ID_PATTERN.test(sessionId)) {
       throw new Error("The sign-in session is invalid.");
     }
     const response = await this.fetchImpl(
       `${this.apiBase}/api/auth/cli-session/${encodeURIComponent(sessionId)}`,
+      { signal },
     );
     if (response.status === 404) {
       return { status: "expired", error: "Sign-in expired. Please try again." };
@@ -276,7 +281,6 @@ export class AndroidCloudClient {
         stringField(data.accessToken) ??
         stringField(data.access_token);
       if (!token) throw new Error("Sign-in completed without a session token.");
-      await this.credentialStore.write(token);
       return { status: "authenticated", token };
     }
     if (status === "expired" || status === "error") {
@@ -286,6 +290,37 @@ export class AndroidCloudClient {
       };
     }
     return { status: "pending" };
+  }
+
+  /**
+   * Persists a completed login only while its owning attempt remains active.
+   * Login writes are serialized so an aborted attempt finishes its cleanup
+   * before a newer attempt can commit a replacement credential.
+   */
+  async persistLogin(token: string, signal?: AbortSignal): Promise<void> {
+    const normalizedToken = token.trim();
+    if (!normalizedToken) {
+      throw new Error("Sign-in completed without a session token.");
+    }
+
+    const commit = async () => {
+      if (signal?.aborted) {
+        throw new DOMException("Sign-in was cancelled.", "AbortError");
+      }
+      await this.credentialStore.write(normalizedToken);
+      if (signal?.aborted) {
+        await this.credentialStore.clear();
+        throw new DOMException("Sign-in was cancelled.", "AbortError");
+      }
+    };
+    const mutation = this.loginCredentialMutation.then(commit, commit);
+    // error-policy:J5 the caller awaits `mutation`; this tail only keeps the
+    // next credential commit from inheriting the already-observed rejection.
+    this.loginCredentialMutation = mutation.then(
+      () => undefined,
+      () => undefined,
+    );
+    await mutation;
   }
 
   async sendChat(

--- a/packages/ui/src/android-cloud/android-cloud-client.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.ts
@@ -162,6 +162,19 @@ export class AndroidCloudClient {
   private readonly credentialStore: AndroidCloudCredentialStore;
   private loginCredentialMutation: Promise<void> = Promise.resolve();
 
+  private enqueueLoginCredentialMutation(
+    operation: () => Promise<void>,
+  ): Promise<void> {
+    const mutation = this.loginCredentialMutation.then(operation, operation);
+    // error-policy:J5 the caller awaits `mutation`; this tail only keeps the
+    // next credential mutation from inheriting the observed rejection.
+    this.loginCredentialMutation = mutation.then(
+      () => undefined,
+      () => undefined,
+    );
+    return mutation;
+  }
+
   constructor(options: AndroidCloudClientOptions = {}) {
     this.apiBase = resolveCanonicalDirectCloudApiBase(options.cloudApiBase);
     this.fetchImpl = options.fetchImpl ?? fetch;
@@ -313,14 +326,18 @@ export class AndroidCloudClient {
         throw new DOMException("Sign-in was cancelled.", "AbortError");
       }
     };
-    const mutation = this.loginCredentialMutation.then(commit, commit);
-    // error-policy:J5 the caller awaits `mutation`; this tail only keeps the
-    // next credential commit from inheriting the already-observed rejection.
-    this.loginCredentialMutation = mutation.then(
-      () => undefined,
-      () => undefined,
-    );
-    await mutation;
+    await this.enqueueLoginCredentialMutation(commit);
+  }
+
+  /** Clears an abandoned login token without deleting a newer login. */
+  async discardLogin(token: string): Promise<void> {
+    const abandonedToken = token.trim();
+    if (!abandonedToken) return;
+    await this.enqueueLoginCredentialMutation(async () => {
+      if ((await this.credentialStore.read()) === abandonedToken) {
+        await this.credentialStore.clear();
+      }
+    });
   }
 
   async sendChat(

--- a/packages/ui/src/android-cloud/android-cloud-client.ts
+++ b/packages/ui/src/android-cloud/android-cloud-client.ts
@@ -195,7 +195,7 @@ export class AndroidCloudClient {
       },
     );
     if (response.status === 401) {
-      await this.credentialStore.clear();
+      await this.discardLogin(token);
       return null;
     }
     if (!response.ok) {


### PR DESCRIPTION
# Relates to

Fixes #23933.

# What this changes

- Makes device-code polling transport-cancellable and separates token polling from credential persistence.
- Rechecks login-attempt ownership after every asynchronous boundary and performs a serialized compare-and-clear rollback if cancellation lands after the credential commit, without clobbering a newer login.
- Routes delayed 401 session teardown through the same compare-and-clear queue so stale verification cannot delete a newer credential.
- Serializes native voice permission, listener registration, recognizer startup, terminal teardown, and stop operations behind a generation guard.
- Makes pending voice startup immediately stoppable and aborts it on shell unmount; overlapping starts cannot overwrite or leak an earlier listener pair.
- Preserves actionable native voice errors instead of overwriting them with a later cancellation result.

# Exact source state

<!-- evidence-head:00c5ed2a2c76ed72be1cb597618e69d40a9f11a1 -->

- Head: `00c5ed2a2c76ed72be1cb597618e69d40a9f11a1`
- Base: `develop@5dee7a4c5e054a36f010aae63dd61008c4a3d0a4`
- Branch is three commits ahead and zero behind the fetched base.

# Testing

- UI Android Cloud component and client: 2 files, 32 tests passed.
- App Play renderer source and executable native-boundary behavior: 2 files, 13 tests passed.
- Android build and Play policy matrix: 8 files, 153 tests passed, 8 fixture-dependent skips.
- Exact Android Cloud production Vite build: passed, 944 modules transformed; emitted-bundle policy and renderer entry/viewport policy passed.
- Biome check on all 6 changed files: passed.
- `git diff --check`: passed.
- Package typechecks report zero diagnostics in every changed file. The package-wide commands remain blocked by unrelated sparse-install/workspace diagnostics such as missing `pg`, `stripe`, `ai`, `lucide-react`, and existing generated package exports.
- Exact-head `bun run verify` passed guide parity, Biome-version, i18n, Bun/Turbo, workspace dependency, alias, and tsconfig gates. It stopped in the aggregate Turbo lint lane on untouched base formatting errors in `packages/ui/src/components/chat/widgets/maps-card.tsx` and untouched `packages/agent` files; the six changed files pass Biome independently.
- `bun run --cwd packages/app audit:app` reached authoritative view builds, then stopped on the untouched sparse dependency `@xterm/xterm` required by `plugins/plugin-task-coordinator`; no visual artifact was fabricated from that incomplete audit.

# Reviewer path

1. Review cancellation during deferred browser close and the serialized compare-and-clear credential rollback tests.
2. Review immediate stop and unmount during pending voice startup in `AndroidCloudApp.test.tsx`.
3. Review stop during deferred listener registration and overlapping native starts in `main.android-cloud.behavior.test.tsx`.
4. Confirm a stale start cannot install listeners, start recognition, or overwrite a newer attempt after its generation changes.

# Protected acceptance hold

This PR is READY for review. Physical-device evidence remains the separate protected boundary stated in #23933: build and install this exact head on a supported Android target, force no-match/network recognition errors, and capture the installed revision, screenshots/video, and device logs. That hold does not require draft state and does not hide any source defect.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Protected physical-device hold: exact-head installed Android before state.
<!-- evidence-row:after-screenshots -->
- [ ] Protected physical-device hold: cancelled sign-in and native voice-error after states.
<!-- evidence-row:walkthrough-video -->
- [ ] Protected physical-device hold: installed-device cancellation and dictation-error walkthrough.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend contract or deployment changes; deterministic client boundaries only.
<!-- evidence-row:frontend-logs -->
- [ ] Protected physical-device hold: Android renderer and native plugin logs from the exact installed head.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or agent-planning behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] The [exact source commit](https://github.com/elizaOS/eliza/commit/00c5ed2a2c76ed72be1cb597618e69d40a9f11a1) contains the compare-and-clear credential rollback and generation-serialized voice lifecycle, exercised by 45 focused production-path tests and the 153-test Android policy matrix.
<!-- evidence-row:ocr-review -->
- [ ] Protected physical-device hold: review the captured actionable voice failure on the installed app.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@5dee7a4c5e054a36f010aae63dd61008c4a3d0a4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@5dee7a4c5e054a36f010aae63dd61008c4a3d0a4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [root/fix-23933]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5dee7a4c5e054a36f010aae63dd61008c4a3d0a4:packages/skills/skills/contribute-to-eliza"} -->
