### PR TITLE
feat(bluebubbles): add standalone deterministic loopback contracts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1425,6 +1425,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.8",
+        "@elizaos/scenario-runner": "workspace:*",
         "@types/node": "^24.0.0",
         "@typescript/native": "npm:typescript@^7.0.2",
         "typescript": "^6.0.3",

--- a/plugins/plugin-bluebubbles/AGENTS.md
+++ b/plugins/plugin-bluebubbles/AGENTS.md
@@ -52,8 +52,10 @@ src/
   webhook-auth.ts               X-BlueBubbles-Webhook-Secret validation
   constants.ts                  Service name, default paths, policy constants
   types.ts                      Domain types (BlueBubblesConfig, BlueBubblesMessage, BlueBubblesChat…)
+  testing/loopback.ts           Stateful external-server protocol simulator (mock-only evidence)
   actions/index.ts              Empty — messaging uses connector hooks only
   providers/index.ts            Empty — context via connector getChatContext/getUserContext
+test/scenarios/                 Model-free real-runtime loopback scenarios
 auto-enable.ts                  Lightweight shouldEnable() for the plugin engine
 ```
 

--- a/plugins/plugin-bluebubbles/CLAUDE.md
+++ b/plugins/plugin-bluebubbles/CLAUDE.md
@@ -52,8 +52,10 @@ src/
   webhook-auth.ts               X-BlueBubbles-Webhook-Secret validation
   constants.ts                  Service name, default paths, policy constants
   types.ts                      Domain types (BlueBubblesConfig, BlueBubblesMessage, BlueBubblesChat…)
+  testing/loopback.ts           Stateful external-server protocol simulator (mock-only evidence)
   actions/index.ts              Empty — messaging uses connector hooks only
   providers/index.ts            Empty — context via connector getChatContext/getUserContext
+test/scenarios/                 Model-free real-runtime loopback scenarios
 auto-enable.ts                  Lightweight shouldEnable() for the plugin engine
 ```
 

--- a/plugins/plugin-bluebubbles/README.md
+++ b/plugins/plugin-bluebubbles/README.md
@@ -118,3 +118,17 @@ The plugin registers the following HTTP endpoints on the agent:
   connector-account provider. One service instance connects to the resolved
   default account; run separate agent instances for simultaneous independent
   BlueBubbles servers.
+
+## Deterministic loopback testing
+
+`@elizaos/plugin-bluebubbles/testing/loopback` provides a stateful BlueBubbles
+v1 HTTP loopback for scenario and connector tests. It supports deterministic
+reset, queued protocol faults, multi-account state, `tempGuid` idempotency, and
+mock-only effect/webhook receipts. Tests use it through the production
+`BlueBubblesClient`, webhook route, and `BlueBubblesService`; it is not a stub
+for those production components.
+
+The loopback represents an external BlueBubbles server only. It does not own or
+simulate the separate native local Messages integration in
+`@elizaos/plugin-imessage`, and its receipts are not live-provider
+qualification.

--- a/plugins/plugin-bluebubbles/__tests__/inbound-policy.test.ts
+++ b/plugins/plugin-bluebubbles/__tests__/inbound-policy.test.ts
@@ -45,6 +45,7 @@ function makeRuntime(
 		createEntity: vi.fn(async () => undefined),
 		ensureConnection: vi.fn(async () => undefined),
 		createMemory,
+		updateMemory: vi.fn(async () => true),
 		getRoom: vi.fn(async () => ({ id: "room-1" as UUID })),
 		messageService: { handleMessage },
 		reportError: vi.fn(),

--- a/plugins/plugin-bluebubbles/package.json
+++ b/plugins/plugin-bluebubbles/package.json
@@ -47,6 +47,7 @@
     "lint:check": "bunx @biomejs/biome check .",
     "format": "bunx @biomejs/biome format --write .",
     "format:check": "bunx @biomejs/biome format .",
+    "test:scenarios": "cd ../.. && SCENARIO_USE_DETERMINISTIC_MODEL=1 EVAL_MODEL_PROVIDER=deterministic bun --conditions eliza-source --tsconfig-override tsconfig.json packages/scenario-runner/src/cli.ts run plugins/plugin-bluebubbles/test/scenarios --lane pr-deterministic --report-dir reports/scenarios/pr-deterministic-bluebubbles --run-dir reports/scenarios/pr-deterministic-bluebubbles",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
@@ -55,6 +56,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.8",
+    "@elizaos/scenario-runner": "workspace:*",
     "@types/node": "^24.0.0",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "^6.0.3",

--- a/plugins/plugin-bluebubbles/src/client-timeout.test.ts
+++ b/plugins/plugin-bluebubbles/src/client-timeout.test.ts
@@ -39,7 +39,11 @@ describe("BlueBubbles client request deadlines", () => {
 		const pending = client().sendMessage("iMessage;-;+14155550100", "hi");
 		controller.abort(new DOMException("deadline", "TimeoutError"));
 
-		await expect(pending).rejects.toMatchObject({ name: "TimeoutError" });
+		await expect(pending).rejects.toMatchObject({
+			name: "BlueBubblesTransportError",
+			kind: "timeout",
+			acceptance: "ambiguous",
+		});
 		expect(timeout).toHaveBeenCalledWith(15_000);
 	});
 
@@ -53,7 +57,7 @@ describe("BlueBubbles client request deadlines", () => {
 
 		await expect(pending).resolves.toMatchObject({
 			ok: false,
-			error: "deadline",
+			error: "BlueBubbles request timed out",
 		});
 	});
 
@@ -103,7 +107,11 @@ describe("BlueBubbles client request deadlines", () => {
 		await vi.waitFor(() => expect(bodyStarted).toBe(true));
 		controller.abort(new DOMException("deadline", "TimeoutError"));
 
-		await expect(pending).rejects.toMatchObject({ name: "TimeoutError" });
+		await expect(pending).rejects.toMatchObject({
+			name: "BlueBubblesTransportError",
+			kind: "timeout",
+			acceptance: "ambiguous",
+		});
 		expect(timeout).toHaveBeenCalledWith(30_000);
 	});
 

--- a/plugins/plugin-bluebubbles/src/client.ts
+++ b/plugins/plugin-bluebubbles/src/client.ts
@@ -8,6 +8,7 @@
 import { API_ENDPOINTS } from "./constants";
 import type {
 	BlueBubblesChat,
+	BlueBubblesClientOptions,
 	BlueBubblesConfig,
 	BlueBubblesMessage,
 	BlueBubblesProbeResult,
@@ -22,9 +23,78 @@ const BLUEBUBBLES_REQUEST_TIMEOUT_MS = 15_000;
 /** Binary attachment POSTs share the documented 30s blob-upload sibling budget. */
 const BLUEBUBBLES_ATTACHMENT_TIMEOUT_MS = 30_000;
 
+function redactPassword(value: string, password: string): string {
+	if (!password) return value;
+	const representations = new Set([password]);
+	let encoded = password;
+	for (let depth = 0; depth < 2; depth += 1) {
+		encoded = encodeURIComponent(encoded);
+		representations.add(encoded);
+	}
+	return [...representations]
+		.sort((left, right) => right.length - left.length)
+		.reduce(
+			(redacted, secret) => redacted.split(secret).join("<redacted>"),
+			value,
+		);
+}
+
+function transportError(
+	error: unknown,
+	callerCancelled: boolean,
+	password: string,
+): BlueBubblesTransportError {
+	const candidate = error instanceof Error ? error : new Error(String(error));
+	const timedOut =
+		candidate.name === "TimeoutError" || /timeout/i.test(candidate.message);
+	const sanitizedCause = new Error(redactPassword(candidate.message, password));
+	sanitizedCause.name = candidate.name;
+	return new BlueBubblesTransportError(
+		`BlueBubbles ${callerCancelled ? "request cancelled" : timedOut ? "request timed out" : "transport failed"}`,
+		callerCancelled ? "cancelled" : timedOut ? "timeout" : "transport",
+		{ cause: sanitizedCause },
+	);
+}
+
+function retryAfterSeconds(headers: Headers | undefined): number | null {
+	const raw = headers?.get("retry-after");
+	if (raw === null || raw === undefined || raw.trim() === "") return null;
+	const seconds = Number(raw);
+	return Number.isFinite(seconds) && seconds >= 0 ? seconds : null;
+}
+
+export type BlueBubblesDeliveryAcceptance = "rejected" | "ambiguous";
+
+/** Preserves retry and provider-acceptance evidence at the HTTP boundary. */
+export class BlueBubblesHttpError extends Error {
+	constructor(
+		message: string,
+		public readonly statusCode: number,
+		public readonly retryAfterSeconds: number | null,
+		public readonly acceptance: BlueBubblesDeliveryAcceptance,
+	) {
+		super(message);
+		this.name = "BlueBubblesHttpError";
+	}
+}
+
+export class BlueBubblesTransportError extends Error {
+	public readonly acceptance = "ambiguous" as const;
+
+	constructor(
+		message: string,
+		public readonly kind: "cancelled" | "timeout" | "transport",
+		options: { cause: unknown },
+	) {
+		super(message, options);
+		this.name = "BlueBubblesTransportError";
+	}
+}
+
 interface BlueBubblesFetchResponse {
 	ok: boolean;
 	status: number;
+	headers?: Headers;
 	text(): Promise<string>;
 	json(): Promise<unknown>;
 }
@@ -32,53 +102,111 @@ interface BlueBubblesFetchResponse {
 async function blueBubblesRequest<T>(
 	urlWithPassword: string,
 	options: RequestInit = {},
+	requestTimeoutMs = BLUEBUBBLES_REQUEST_TIMEOUT_MS,
+	password = "",
 ): Promise<T> {
-	const timeoutSignal = AbortSignal.timeout(BLUEBUBBLES_REQUEST_TIMEOUT_MS);
+	const timeoutSignal = AbortSignal.timeout(requestTimeoutMs);
 	const signal = options.signal
 		? AbortSignal.any([options.signal, timeoutSignal])
 		: timeoutSignal;
-	const response = (await fetch(urlWithPassword, {
-		...options,
-		headers: {
-			"Content-Type": "application/json",
-			...options.headers,
-		},
-		signal,
-	})) as BlueBubblesFetchResponse;
-
-	if (!response.ok) {
-		const errorText = await response.text();
-		throw new Error(`BlueBubbles API error (${response.status}): ${errorText}`);
+	let response: BlueBubblesFetchResponse;
+	try {
+		response = (await fetch(urlWithPassword, {
+			...options,
+			headers: {
+				"Content-Type": "application/json",
+				...options.headers,
+			},
+			signal,
+		})) as BlueBubblesFetchResponse;
+	} catch (error) {
+		throw transportError(error, options.signal?.aborted ?? false, password);
 	}
 
-	return response.json() as Promise<T>;
+	if (!response.ok) {
+		let responseText: string;
+		try {
+			responseText = await response.text();
+		} catch (error) {
+			throw transportError(error, options.signal?.aborted ?? false, password);
+		}
+		const errorText = redactPassword(responseText, password);
+		throw new BlueBubblesHttpError(
+			`BlueBubbles API error (${response.status}): ${errorText}`,
+			response.status,
+			retryAfterSeconds(response.headers),
+			response.status < 500 ? "rejected" : "ambiguous",
+		);
+	}
+
+	try {
+		return (await response.json()) as T;
+	} catch (error) {
+		throw transportError(error, options.signal?.aborted ?? false, password);
+	}
 }
 
 async function blueBubblesSendAttachment(
 	url: string,
 	formData: FormData,
+	timeoutMs = BLUEBUBBLES_ATTACHMENT_TIMEOUT_MS,
+	signal?: AbortSignal,
+	password = "",
 ): Promise<{ data: BlueBubblesMessage }> {
-	const response = (await fetch(url, {
-		method: "POST",
-		body: formData,
-		signal: AbortSignal.timeout(BLUEBUBBLES_ATTACHMENT_TIMEOUT_MS),
-	})) as BlueBubblesFetchResponse;
-
-	if (!response.ok) {
-		const errorText = await response.text();
-		throw new Error(`Failed to send attachment: ${errorText}`);
+	const timeoutSignal = AbortSignal.timeout(timeoutMs);
+	const composedSignal = signal
+		? AbortSignal.any([signal, timeoutSignal])
+		: timeoutSignal;
+	let response: BlueBubblesFetchResponse;
+	try {
+		response = (await fetch(url, {
+			method: "POST",
+			body: formData,
+			signal: composedSignal,
+		})) as BlueBubblesFetchResponse;
+	} catch (error) {
+		throw transportError(error, signal?.aborted ?? false, password);
 	}
 
-	return (await response.json()) as { data: BlueBubblesMessage };
+	if (!response.ok) {
+		let responseText: string;
+		try {
+			responseText = await response.text();
+		} catch (error) {
+			throw transportError(error, signal?.aborted ?? false, password);
+		}
+		const errorText = redactPassword(responseText, password);
+		throw new BlueBubblesHttpError(
+			`Failed to send attachment (${response.status}): ${errorText}`,
+			response.status,
+			retryAfterSeconds(response.headers),
+			response.status < 500 ? "rejected" : "ambiguous",
+		);
+	}
+
+	try {
+		return (await response.json()) as { data: BlueBubblesMessage };
+	} catch (error) {
+		throw transportError(error, signal?.aborted ?? false, password);
+	}
 }
 
 export class BlueBubblesClient {
 	private baseUrl: string;
 	private password: string;
+	private requestTimeoutMs: number;
+	private attachmentTimeoutMs: number;
 
-	constructor(config: BlueBubblesConfig) {
+	constructor(
+		config: BlueBubblesConfig,
+		options: BlueBubblesClientOptions = {},
+	) {
 		this.baseUrl = config.serverUrl.replace(/\/$/, "");
 		this.password = config.password;
+		this.requestTimeoutMs =
+			options.requestTimeoutMs ?? BLUEBUBBLES_REQUEST_TIMEOUT_MS;
+		this.attachmentTimeoutMs =
+			options.attachmentTimeoutMs ?? BLUEBUBBLES_ATTACHMENT_TIMEOUT_MS;
 	}
 
 	private async request<T>(
@@ -89,7 +217,12 @@ export class BlueBubblesClient {
 		const separator = endpoint.includes("?") ? "&" : "?";
 		const urlWithPassword = `${url}${separator}password=${encodeURIComponent(this.password)}`;
 
-		return blueBubblesRequest<T>(urlWithPassword, options);
+		return blueBubblesRequest<T>(
+			urlWithPassword,
+			options,
+			this.requestTimeoutMs,
+			this.password,
+		);
 	}
 
 	/**
@@ -141,27 +274,29 @@ export class BlueBubblesClient {
 		text: string,
 		options: SendMessageOptions = {},
 	): Promise<SendMessageResult> {
+		const { signal, ...providerOptions } = options;
 		const response = await this.request<{ data: BlueBubblesMessage }>(
 			API_ENDPOINTS.MESSAGE_TEXT,
 			{
 				method: "POST",
+				signal,
 				body: JSON.stringify({
 					chatGuid,
 					message: text,
-					tempGuid: options.tempGuid,
-					method: options.method ?? "apple-script",
-					subject: options.subject,
-					effectId: options.effectId,
-					selectedMessageGuid: options.selectedMessageGuid,
-					partIndex: options.partIndex,
-					ddScan: options.ddScan,
+					tempGuid: providerOptions.tempGuid,
+					method: providerOptions.method ?? "apple-script",
+					subject: providerOptions.subject,
+					effectId: providerOptions.effectId,
+					selectedMessageGuid: providerOptions.selectedMessageGuid,
+					partIndex: providerOptions.partIndex,
+					ddScan: providerOptions.ddScan,
 				}),
 			},
 		);
 
 		return {
 			guid: response.data.guid,
-			tempGuid: options.tempGuid,
+			tempGuid: providerOptions.tempGuid,
 			status: "sent",
 			dateCreated: response.data.dateCreated,
 			text: response.data.text ?? text,
@@ -176,26 +311,33 @@ export class BlueBubblesClient {
 		attachmentPath: string,
 		options: SendAttachmentOptions = {},
 	): Promise<SendMessageResult> {
+		const { signal, ...providerOptions } = options;
 		const formData = new FormData();
 		formData.append("chatGuid", chatGuid);
 		formData.append("attachment", attachmentPath);
 
-		if (options.tempGuid) {
-			formData.append("tempGuid", options.tempGuid);
+		if (providerOptions.tempGuid) {
+			formData.append("tempGuid", providerOptions.tempGuid);
 		}
-		if (options.name) {
-			formData.append("name", options.name);
+		if (providerOptions.name) {
+			formData.append("name", providerOptions.name);
 		}
-		if (options.isAudioMessage !== undefined) {
-			formData.append("isAudioMessage", String(options.isAudioMessage));
+		if (providerOptions.isAudioMessage !== undefined) {
+			formData.append("isAudioMessage", String(providerOptions.isAudioMessage));
 		}
 
 		const url = `${this.baseUrl}${API_ENDPOINTS.SEND_ATTACHMENT}?password=${encodeURIComponent(this.password)}`;
-		const result = await blueBubblesSendAttachment(url, formData);
+		const result = await blueBubblesSendAttachment(
+			url,
+			formData,
+			this.attachmentTimeoutMs,
+			signal,
+			this.password,
+		);
 
 		return {
 			guid: result.data.guid,
-			tempGuid: options.tempGuid,
+			tempGuid: providerOptions.tempGuid,
 			status: "sent",
 			dateCreated: result.data.dateCreated,
 			text: result.data.text ?? "",
@@ -225,7 +367,13 @@ export class BlueBubblesClient {
 		}
 
 		const url = `${this.baseUrl}${API_ENDPOINTS.SEND_ATTACHMENT}?password=${encodeURIComponent(this.password)}`;
-		const result = await blueBubblesSendAttachment(url, formData);
+		const result = await blueBubblesSendAttachment(
+			url,
+			formData,
+			this.attachmentTimeoutMs,
+			undefined,
+			this.password,
+		);
 
 		return {
 			guid: result.data.guid,

--- a/plugins/plugin-bluebubbles/src/loopback-contract.test.ts
+++ b/plugins/plugin-bluebubbles/src/loopback-contract.test.ts
@@ -1,0 +1,432 @@
+/**
+ * Exercises production BlueBubbles transport, route, service, and runtime
+ * behavior against the stateful protocol loopback. All receipts are explicitly
+ * mock-only; live provider and native local iMessage qualification are outside
+ * this suite.
+ */
+
+import { createServer } from "node:http";
+import {
+	AgentRuntime,
+	createCharacter,
+	createUniqueUuid,
+	InMemoryDatabaseAdapter,
+	type Memory,
+	type MessageConnectorRegistration,
+	type RouteRequest,
+	type RouteResponse,
+	type UUID,
+} from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BlueBubblesClient, BlueBubblesHttpError } from "./client.js";
+import { blueBubblesDataRoutes } from "./data-routes.js";
+import { BlueBubblesService } from "./service.js";
+import {
+	type RunningBlueBubblesLoopback,
+	startBlueBubblesLoopback,
+} from "./testing/loopback.js";
+
+const AGENT_ID = "00000000-0000-4000-8000-00000000bb01" as UUID;
+const ROOM_ID = "00000000-0000-4000-8000-00000000bb02" as UUID;
+const CHAT_GUID = "iMessage;-;+14155552671";
+const PASSWORD = "personal-p@ss/word?&";
+const WEBHOOK_SECRET = "bluebubbles-webhook-secret";
+const NOW = Date.parse("2032-04-05T06:07:08.000Z");
+
+const loopbacks: RunningBlueBubblesLoopback[] = [];
+const routeServers: Array<{ stop(): Promise<void> }> = [];
+const services: BlueBubblesService[] = [];
+const runtimes: AgentRuntime[] = [];
+
+afterEach(async () => {
+	await Promise.allSettled(services.splice(0).map((service) => service.stop()));
+	await Promise.allSettled(
+		runtimes.splice(0).map((runtime) => runtime.close()),
+	);
+	await Promise.allSettled(
+		routeServers.splice(0).map((server) => server.stop()),
+	);
+	await Promise.allSettled(loopbacks.splice(0).map((server) => server.stop()));
+	vi.restoreAllMocks();
+});
+
+function chat() {
+	return {
+		guid: CHAT_GUID,
+		chatIdentifier: "+14155552671",
+		displayName: "Alice",
+		participants: [{ address: "+14155552671", service: "iMessage" }],
+	};
+}
+
+async function loopback(): Promise<RunningBlueBubblesLoopback> {
+	const running = await startBlueBubblesLoopback({
+		now: () => NOW,
+		sleep: async () => undefined,
+		accounts: [
+			{
+				accountId: "personal",
+				password: PASSWORD,
+				chats: [chat()],
+			},
+		],
+	});
+	loopbacks.push(running);
+	return running;
+}
+
+function protocolMessage(guid: string, text: string): Record<string, unknown> {
+	const handle = {
+		address: "+14155552671",
+		service: "iMessage",
+		country: null,
+		originalROWID: 1,
+		uncanonicalizedId: null,
+	};
+	return {
+		guid,
+		text,
+		subject: null,
+		country: null,
+		handle,
+		handleId: 1,
+		otherHandle: 0,
+		chats: [{ ...chat(), participants: [handle], lastMessage: null }],
+		attachments: [],
+		expressiveSendStyleId: null,
+		dateCreated: NOW,
+		dateRead: null,
+		dateDelivered: null,
+		isFromMe: false,
+		isDelayed: false,
+		isAutoReply: false,
+		isSystemMessage: false,
+		isServiceMessage: false,
+		isForward: false,
+		isArchived: false,
+		hasDdResults: false,
+		hasPayloadData: false,
+		threadOriginatorGuid: null,
+		threadOriginatorPart: null,
+		associatedMessageGuid: null,
+		associatedMessageType: null,
+		balloonBundleId: null,
+		dateEdited: null,
+		error: 0,
+		itemType: 0,
+		groupTitle: null,
+		groupActionType: 0,
+		payloadData: null,
+	};
+}
+
+async function productionRuntime(serverUrl: string): Promise<{
+	runtime: AgentRuntime;
+	service: BlueBubblesService;
+}> {
+	const runtime = new AgentRuntime({
+		agentId: AGENT_ID,
+		character: createCharacter({ name: "BlueBubbles Contract Agent" }),
+		adapter: new InMemoryDatabaseAdapter(),
+		disableBasicCapabilities: true,
+		logLevel: "fatal",
+	});
+	const settings: Record<string, string> = {
+		BLUEBUBBLES_SERVER_URL: serverUrl,
+		BLUEBUBBLES_PASSWORD: PASSWORD,
+		BLUEBUBBLES_WEBHOOK_SECRET: WEBHOOK_SECRET,
+		BLUEBUBBLES_DM_POLICY: "open",
+		BLUEBUBBLES_SEND_READ_RECEIPTS: "false",
+	};
+	vi.spyOn(runtime, "getSetting").mockImplementation((key) => settings[key]);
+	await runtime.initialize();
+	runtimes.push(runtime);
+	const service = await BlueBubblesService.start(runtime);
+	services.push(service);
+	vi.spyOn(runtime, "getService").mockImplementation((serviceType) =>
+		serviceType === BlueBubblesService.serviceType ? service : null,
+	);
+	BlueBubblesService.registerSendHandlers(runtime, service);
+	return { runtime, service };
+}
+
+async function startProductionWebhookRoute(runtime: AgentRuntime): Promise<{
+	url: string;
+	waitForRequests(count: number): Promise<void>;
+}> {
+	const route = blueBubblesDataRoutes.find(
+		(candidate) =>
+			candidate.type === "POST" && candidate.path === "/webhooks/bluebubbles",
+	);
+	if (!route)
+		throw new Error("production BlueBubbles webhook route is missing");
+	let startedRequests = 0;
+	const requestWaiters = new Set<() => void>();
+	const server = createServer(async (request, response) => {
+		const chunks: Buffer[] = [];
+		for await (const chunk of request) {
+			chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+		}
+		let status = 200;
+		const routeResponse = {
+			status(code: number) {
+				status = code;
+				return this;
+			},
+			json(body: unknown) {
+				response.writeHead(status, { "content-type": "application/json" });
+				response.end(JSON.stringify(body));
+				return this;
+			},
+		} as unknown as RouteResponse;
+		const rawBody = Buffer.concat(chunks).toString("utf8");
+		const routeRequest = {
+			method: request.method,
+			url: request.url,
+			headers: request.headers,
+			body: rawBody ? JSON.parse(rawBody) : undefined,
+		} as unknown as RouteRequest;
+		startedRequests += 1;
+		for (const resolve of requestWaiters) resolve();
+		requestWaiters.clear();
+		await route.handler(routeRequest, routeResponse, runtime);
+	});
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			server.off("error", reject);
+			resolve();
+		});
+	});
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("production webhook test route did not bind");
+	}
+	routeServers.push({
+		stop: () =>
+			new Promise<void>((resolve, reject) =>
+				server.close((error) => (error ? reject(error) : resolve())),
+			),
+	});
+	return {
+		url: `http://127.0.0.1:${address.port}/webhooks/bluebubbles`,
+		async waitForRequests(count) {
+			while (startedRequests < count) {
+				await new Promise<void>((resolve) => requestWaiters.add(resolve));
+			}
+		},
+	};
+}
+
+describe("BlueBubbles production contract over the external-server loopback", () => {
+	it("keeps tempGuid sends idempotent across ambiguous acceptance and deterministic reset", async () => {
+		const upstream = await loopback();
+		expect(upstream.owner).toBe("bluebubbles-external");
+		const client = new BlueBubblesClient({
+			serverUrl: upstream.url,
+			password: PASSWORD,
+		});
+		const initial = upstream.snapshot();
+		const first = await client.sendMessage(CHAT_GUID, "hello", {
+			tempGuid: "send-once",
+		});
+		const replay = await client.sendMessage(CHAT_GUID, "hello", {
+			tempGuid: "send-once",
+		});
+		expect(replay.guid).toBe(first.guid);
+
+		upstream.fault("POST", "/api/v1/message/text", {
+			type: "status",
+			status: 503,
+		});
+		await expect(
+			client.sendMessage(CHAT_GUID, "ambiguous", {
+				tempGuid: "ambiguous-once",
+			}),
+		).rejects.toMatchObject({
+			name: "BlueBubblesHttpError",
+			statusCode: 503,
+			acceptance: "ambiguous",
+		});
+		const recovered = await client.sendMessage(CHAT_GUID, "ambiguous", {
+			tempGuid: "ambiguous-once",
+		});
+		expect(recovered.guid).toContain("msg-personal");
+		expect(
+			upstream
+				.snapshot()
+				.accounts[0]?.messages.filter(
+					(message) => message.tempGuid === "ambiguous-once",
+				),
+		).toHaveLength(1);
+		const attachment = await client.sendAttachment(
+			CHAT_GUID,
+			"/tmp/scenario-photo.png",
+			{ tempGuid: "attachment-once" },
+		);
+		const attachmentReplay = await client.sendAttachment(
+			CHAT_GUID,
+			"/tmp/scenario-photo.png",
+			{ tempGuid: "attachment-once" },
+		);
+		expect(attachmentReplay.guid).toBe(attachment.guid);
+		expect((await client.getChat(CHAT_GUID)).guid).toBe(CHAT_GUID);
+		await client.reactToMessage(CHAT_GUID, first.guid, "love");
+		await client.editMessage(first.guid, "edited hello");
+		expect(
+			(await client.getMessages(CHAT_GUID)).find(
+				(message) => message.guid === first.guid,
+			)?.text,
+		).toBe("edited hello");
+		await client.unsendMessage(first.guid);
+		expect(
+			(await client.getMessages(CHAT_GUID)).some(
+				(message) => message.guid === first.guid,
+			),
+		).toBe(false);
+		expect(
+			upstream.receipts.every((receipt) => receipt.evidence === "mock-only"),
+		).toBe(true);
+		expect(JSON.stringify(upstream.receipts)).not.toContain(PASSWORD);
+
+		expect(upstream.reset()).toEqual(initial);
+	});
+
+	it("drives the production connector and resumes persisted-but-unprocessed ingress exactly once", async () => {
+		const upstream = await loopback();
+		const { runtime, service } = await productionRuntime(upstream.url);
+		expect(service.getIsRunning()).toBe(true);
+		const connectors =
+			runtime.getMessageConnectors() as MessageConnectorRegistration[];
+		expect(
+			connectors.some((connector) => connector.source === "bluebubbles"),
+		).toBe(true);
+		const outbound = await runtime.sendMessageToTarget(
+			{ source: "bluebubbles", channelId: CHAT_GUID, roomId: ROOM_ID },
+			{ text: "production egress", agentVoiced: true },
+		);
+		const outboundMemory =
+			outbound && "kind" in outbound
+				? outbound.kind === "delivered" ||
+					outbound.kind === "partially_delivered"
+					? outbound.memories[0]
+					: undefined
+				: outbound;
+		expect(outboundMemory).toMatchObject({
+			metadata: {
+				accountId: "default",
+				bluebubblesChatGuid: CHAT_GUID,
+			},
+		});
+
+		const webhookRoute = await startProductionWebhookRoute(runtime);
+		const enteredFirstProcessing = Promise.withResolvers<void>();
+		const releaseFirstProcessing = Promise.withResolvers<void>();
+		let successfulProcessing = 0;
+		let attempts = 0;
+		vi.spyOn(runtime.messageService, "handleMessage").mockImplementation(
+			async () => {
+				attempts += 1;
+				if (attempts === 1) {
+					enteredFirstProcessing.resolve();
+					await releaseFirstProcessing.promise;
+					throw new Error("injected process failure after persistence");
+				}
+				successfulProcessing += 1;
+				return undefined;
+			},
+		);
+
+		const event = {
+			id: "inbound-event-1",
+			sequence: 1,
+			accountId: "personal",
+			type: "new-message" as const,
+			data: protocolMessage("inbound-message-1", "retry me"),
+		};
+		expect(
+			(
+				await upstream.deliverWebhook(webhookRoute.url, event, "wrong-secret", {
+					maxAttempts: 1,
+				})
+			)[0]?.status,
+		).toBe(401);
+
+		const firstDelivery = upstream.deliverWebhook(
+			webhookRoute.url,
+			event,
+			WEBHOOK_SECRET,
+			{ maxAttempts: 1 },
+		);
+		await enteredFirstProcessing.promise;
+		const memoryId = createUniqueUuid(
+			runtime,
+			"bluebubbles:inbound-message-1",
+		) as UUID;
+		const persistedBeforeFailure = await runtime.getMemoryById(memoryId);
+		expect(persistedBeforeFailure).toBeTruthy();
+		expect(
+			(persistedBeforeFailure?.metadata as Record<string, unknown> | undefined)
+				?.bluebubblesProcessingCompleted,
+		).not.toBe(true);
+
+		const concurrentDuplicate = upstream.deliverWebhook(
+			webhookRoute.url,
+			event,
+			WEBHOOK_SECRET,
+			{ maxAttempts: 1 },
+		);
+		await webhookRoute.waitForRequests(3);
+		releaseFirstProcessing.resolve();
+		expect((await firstDelivery)[0]?.status).toBe(500);
+		expect((await concurrentDuplicate)[0]?.status).toBe(500);
+		expect(attempts).toBe(1);
+
+		expect(
+			(
+				await upstream.deliverWebhook(webhookRoute.url, event, WEBHOOK_SECRET, {
+					maxAttempts: 1,
+				})
+			)[0]?.status,
+		).toBe(200);
+		expect(successfulProcessing).toBe(1);
+		expect(attempts).toBe(2);
+		expect(
+			(
+				await upstream.deliverWebhook(webhookRoute.url, event, WEBHOOK_SECRET, {
+					maxAttempts: 1,
+				})
+			)[0]?.status,
+		).toBe(200);
+		expect(attempts).toBe(2);
+		const completed = (await runtime.getMemoryById(memoryId)) as Memory;
+		expect(
+			(completed.metadata as Record<string, unknown> | undefined)
+				?.bluebubblesProcessingCompleted,
+		).toBe(true);
+		expect(
+			upstream.receipts
+				.filter(
+					(receipt) =>
+						receipt.kind === "webhook" && receipt.idempotencyKey === event.id,
+				)
+				.map((receipt) => receipt.detail.status),
+		).toEqual([401, 500, 500, 200, 200]);
+	});
+
+	it("classifies rejected provider responses without claiming acceptance", async () => {
+		const upstream = await loopback();
+		const client = new BlueBubblesClient({
+			serverUrl: upstream.url,
+			password: PASSWORD,
+		});
+		let caught: unknown;
+		try {
+			await client.sendMessage("iMessage;-;+19999999999", "invalid");
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(BlueBubblesHttpError);
+		expect(caught).toMatchObject({ statusCode: 422, acceptance: "rejected" });
+	});
+});

--- a/plugins/plugin-bluebubbles/src/service.ts
+++ b/plugins/plugin-bluebubbles/src/service.ts
@@ -512,6 +512,7 @@ export class BlueBubblesService extends Service {
 	private knownChats: Map<string, BlueBubblesChat> = new Map();
 	private entityCache: Map<string, UUID> = new Map();
 	private roomCache: Map<string, UUID> = new Map();
+	private incomingMessageWork = new Map<string, Promise<void>>();
 	private webhookPath: string = DEFAULT_WEBHOOK_PATH;
 	private isRunning = false;
 
@@ -785,7 +786,7 @@ export class BlueBubblesService extends Service {
 						...(memory.metadata ?? {}),
 						type: MemoryType.MESSAGE,
 						accountId: service.accountId,
-						bluebubblesChatGuid: chatGuid,
+						bluebubblesChatGuid: result.chatGuid ?? chatGuid,
 						bluebubblesMessageGuid: result.guid,
 						messageIdFull: result.guid,
 					};
@@ -1145,6 +1146,30 @@ export class BlueBubblesService extends Service {
 	private async handleIncomingMessage(
 		message: BlueBubblesMessage,
 	): Promise<void> {
+		const inFlight = this.incomingMessageWork.get(message.guid);
+		if (inFlight) {
+			await inFlight;
+			return;
+		}
+		const work = this.handleIncomingMessageOnce(message);
+		this.incomingMessageWork.set(message.guid, work);
+		try {
+			await work;
+		} finally {
+			if (this.incomingMessageWork.get(message.guid) === work) {
+				this.incomingMessageWork.delete(message.guid);
+			}
+		}
+	}
+
+	/**
+	 * Persists and processes one inbound provider message. Persistence alone is
+	 * not a delivery acknowledgement: retries resume a stored message until its
+	 * completion marker is durably written.
+	 */
+	private async handleIncomingMessageOnce(
+		message: BlueBubblesMessage,
+	): Promise<void> {
 		// Skip outgoing messages
 		if (message.isFromMe) {
 			return;
@@ -1157,6 +1182,21 @@ export class BlueBubblesService extends Service {
 
 		const config = this.blueBubblesConfig;
 		if (!config) {
+			return;
+		}
+		const memoryId = createUniqueUuid(
+			this.runtime,
+			`bluebubbles:${message.guid}`,
+		) as UUID;
+		const existingMemory =
+			typeof this.runtime.getMemoryById === "function"
+				? await this.runtime.getMemoryById(memoryId)
+				: null;
+		if (
+			(existingMemory?.metadata as Record<string, unknown> | undefined)
+				?.bluebubblesProcessingCompleted === true
+		) {
+			logger.debug(`Ignoring duplicate BlueBubbles message ${message.guid}`);
 			return;
 		}
 
@@ -1260,67 +1300,87 @@ export class BlueBubblesService extends Service {
 			},
 		});
 
-		const memory = createMessageMemory({
-			id: createUniqueUuid(this.runtime, `bluebubbles:${message.guid}`) as UUID,
-			agentId: this.runtime.agentId,
-			entityId,
-			roomId,
-			content: {
-				text: message.text ?? "",
+		const memory =
+			existingMemory ??
+			(createMessageMemory({
+				id: memoryId,
+				agentId: this.runtime.agentId,
+				entityId,
+				roomId,
+				content: {
+					text: message.text ?? "",
+					source: "bluebubbles",
+					...(replyToMessageId ? { inReplyTo: replyToMessageId } : {}),
+					...(attachments.length > 0 ? { attachments } : {}),
+				},
+			}) as Memory);
+		if (!existingMemory) {
+			memory.createdAt = message.dateCreated;
+			memory.metadata = {
+				...(memory.metadata ?? {}),
 				source: "bluebubbles",
-				...(replyToMessageId ? { inReplyTo: replyToMessageId } : {}),
-				...(attachments.length > 0 ? { attachments } : {}),
-			},
-		}) as Memory;
-		memory.createdAt = message.dateCreated;
-		memory.metadata = {
-			...(memory.metadata ?? {}),
-			source: "bluebubbles",
-			provider: "bluebubbles",
-			// Top-level accountId per MessageMetadata contract. Inbound connector
-			// stamps this so outbound resolution can route replies back through
-			// the same connector account.
-			accountId: this.accountId,
-			timestamp: message.dateCreated,
-			entityName: message.handle?.address ?? senderHandle,
-			entityUserName: senderHandle,
-			fromId: senderHandle,
-			sourceId: entityId,
-			chatType: isGroup ? ChannelType.GROUP : ChannelType.DM,
-			messageIdFull: message.guid,
-			sender: {
-				id: senderHandle,
-				name: message.handle?.address ?? senderHandle,
-				username: senderHandle,
-			},
-			bluebubbles: {
-				id: senderHandle,
-				userId: senderHandle,
-				username: senderHandle,
-				userName: senderHandle,
-				name: message.handle?.address ?? senderHandle,
-				chatGuid: chat.guid,
-				chatIdentifier: chat.chatIdentifier,
-				messageGuid: message.guid,
-			},
-			bluebubblesChatGuid: chat.guid,
-			bluebubblesChatIdentifier: chat.chatIdentifier,
-			bluebubblesMessageGuid: message.guid,
-			bluebubblesThreadOriginatorGuid:
-				message.threadOriginatorGuid ?? undefined,
-		} as Memory["metadata"];
+				provider: "bluebubbles",
+				// Top-level accountId per MessageMetadata contract. Inbound connector
+				// stamps this so outbound resolution can route replies back through
+				// the same connector account.
+				accountId: this.accountId,
+				timestamp: message.dateCreated,
+				entityName: message.handle?.address ?? senderHandle,
+				entityUserName: senderHandle,
+				fromId: senderHandle,
+				sourceId: entityId,
+				chatType: isGroup ? ChannelType.GROUP : ChannelType.DM,
+				messageIdFull: message.guid,
+				sender: {
+					id: senderHandle,
+					name: message.handle?.address ?? senderHandle,
+					username: senderHandle,
+				},
+				bluebubbles: {
+					id: senderHandle,
+					userId: senderHandle,
+					username: senderHandle,
+					userName: senderHandle,
+					name: message.handle?.address ?? senderHandle,
+					chatGuid: chat.guid,
+					chatIdentifier: chat.chatIdentifier,
+					messageGuid: message.guid,
+				},
+				bluebubblesChatGuid: chat.guid,
+				bluebubblesChatIdentifier: chat.chatIdentifier,
+				bluebubblesMessageGuid: message.guid,
+				bluebubblesThreadOriginatorGuid:
+					message.threadOriginatorGuid ?? undefined,
+			} as Memory["metadata"];
 
-		await this.runtime.createMemory(memory, "messages");
+			await this.runtime.createMemory(memory, "messages");
+		}
 
 		const room = await this.runtime.getRoom(roomId);
 		if (!room) {
-			logger.warn(
-				`BlueBubbles room ${roomId} not found after ensureConnection`,
+			throw new Error(
+				`BlueBubbles room ${roomId} not found after ensureConnection; webhook must be retried`,
 			);
-			return;
 		}
 
 		await this.processMessage(memory, room, chat.guid);
+		const latestMemory =
+			typeof this.runtime.getMemoryById === "function"
+				? ((await this.runtime.getMemoryById(memoryId)) ?? memory)
+				: memory;
+		const completed: Partial<Memory> & { id: UUID } = {
+			...latestMemory,
+			id: latestMemory.id ?? memoryId,
+			metadata: {
+				...(latestMemory.metadata ?? {}),
+				bluebubblesProcessingCompleted: true,
+			} as Memory["metadata"],
+		};
+		if (!(await this.runtime.updateMemory(completed))) {
+			throw new Error(
+				`BlueBubbles message ${message.guid} processed but completion could not be persisted`,
+			);
+		}
 	}
 
 	/**
@@ -1366,10 +1426,33 @@ export class BlueBubblesService extends Service {
 	private async handleMessageUpdate(
 		message: BlueBubblesMessage,
 	): Promise<void> {
-		// Handle edited or unsent messages
-		if (message.dateEdited) {
-			logger.debug(`Message ${message.guid} was edited`);
+		if (
+			!message.dateEdited ||
+			typeof this.runtime.getMemoryById !== "function"
+		) {
+			return;
 		}
+		const memoryId = createUniqueUuid(
+			this.runtime,
+			`bluebubbles:${message.guid}`,
+		) as UUID;
+		const existing = await this.runtime.getMemoryById(memoryId);
+		if (!existing) return;
+		const metadata = existing.metadata as Record<string, unknown> | undefined;
+		const priorEditedAt = Number(metadata?.bluebubblesDateEdited ?? 0);
+		if (message.dateEdited <= priorEditedAt) {
+			logger.debug(`Ignoring stale BlueBubbles update ${message.guid}`);
+			return;
+		}
+		await this.runtime.updateMemory({
+			...existing,
+			id: existing.id ?? memoryId,
+			content: { ...existing.content, text: message.text ?? "" },
+			metadata: {
+				...(existing.metadata ?? {}),
+				bluebubblesDateEdited: message.dateEdited,
+			} as Memory["metadata"],
+		});
 	}
 
 	/**
@@ -1446,7 +1529,7 @@ export class BlueBubblesService extends Service {
 		target: string,
 		text: string,
 		replyToMessageGuid?: string,
-	): Promise<{ guid: string; dateCreated: number }> {
+	): Promise<{ guid: string; dateCreated: number; chatGuid: string }> {
 		if (!this.client) {
 			throw new Error("BlueBubbles client not initialized");
 		}
@@ -1461,6 +1544,7 @@ export class BlueBubblesService extends Service {
 		return {
 			guid: result.guid,
 			dateCreated: result.dateCreated,
+			chatGuid,
 		};
 	}
 
@@ -1471,7 +1555,9 @@ export class BlueBubblesService extends Service {
 	): Promise<void> {
 		const messageService = getMessageService(this.runtime);
 		if (!messageService) {
-			return;
+			throw new Error(
+				"BlueBubbles message service is unavailable; webhook must be retried",
+			);
 		}
 
 		const callback: HandlerCallback = async (

--- a/plugins/plugin-bluebubbles/src/testing/loopback.ts
+++ b/plugins/plugin-bluebubbles/src/testing/loopback.ts
@@ -1,0 +1,756 @@
+/**
+ * Runs a deterministic BlueBubbles v1 loopback for connector and scenario
+ * tests. The harness owns only the external BlueBubbles server boundary; it
+ * does not emulate or claim coverage for the native local iMessage connector.
+ */
+
+import {
+	createServer,
+	type IncomingMessage,
+	type ServerResponse,
+} from "node:http";
+
+export interface BlueBubblesLoopbackChat {
+	guid: string;
+	chatIdentifier: string;
+	displayName: string | null;
+	participants: Array<{ address: string; service: string }>;
+}
+
+export interface BlueBubblesLoopbackMessage {
+	guid: string;
+	text: string | null;
+	dateCreated: number;
+	chatGuid: string;
+	tempGuid?: string;
+	isFromMe: boolean;
+	dateRead?: number | null;
+	dateEdited?: number | null;
+}
+
+export interface BlueBubblesLoopbackAccount {
+	accountId: string;
+	password: string;
+	chats: readonly BlueBubblesLoopbackChat[];
+	messages?: readonly BlueBubblesLoopbackMessage[];
+}
+
+export type BlueBubblesLoopbackFault =
+	| {
+			type: "status";
+			status: number;
+			body?: unknown;
+			headers?: Record<string, string>;
+	  }
+	| { type: "delay"; durationMs: number }
+	| { type: "malformed-json"; body?: string }
+	| { type: "schema-drift"; body: unknown };
+
+export interface BlueBubblesMockReceipt {
+	sequence: number;
+	evidence: "mock-only";
+	kind: "request" | "effect" | "webhook";
+	operation: string;
+	accountId: string | null;
+	outcome: "succeeded" | "rejected" | "ambiguous" | "replayed";
+	idempotencyKey: string | null;
+	occurredAt: string;
+	detail: Record<string, unknown>;
+}
+
+export interface BlueBubblesLoopbackSnapshot {
+	accounts: Array<{
+		accountId: string;
+		chats: string[];
+		messages: BlueBubblesLoopbackMessage[];
+	}>;
+	pendingFaults: Array<{ target: string; count: number }>;
+	receipts: BlueBubblesMockReceipt[];
+}
+
+export interface RunningBlueBubblesLoopback {
+	readonly owner: "bluebubbles-external";
+	url: string;
+	readonly receipts: readonly BlueBubblesMockReceipt[];
+	fault(method: string, path: string, fault: BlueBubblesLoopbackFault): void;
+	reset(): BlueBubblesLoopbackSnapshot;
+	snapshot(): BlueBubblesLoopbackSnapshot;
+	deliverWebhook(
+		targetUrl: string,
+		event: {
+			id: string;
+			sequence: number;
+			accountId: string;
+			type: "new-message" | "updated-message" | "chat-updated";
+			data: Record<string, unknown>;
+		},
+		secret: string,
+		options?: { maxAttempts?: number; retryDelayMs?: number },
+	): Promise<Response[]>;
+	stop(): Promise<void>;
+}
+
+export interface StartBlueBubblesLoopbackOptions {
+	accounts: readonly BlueBubblesLoopbackAccount[];
+	now?: () => number;
+	sleep?: (durationMs: number) => Promise<void>;
+}
+
+interface AccountState {
+	accountId: string;
+	password: string;
+	chats: Map<string, BlueBubblesLoopbackChat>;
+	messages: Map<string, BlueBubblesLoopbackMessage>;
+	tempGuids: Map<string, string>;
+}
+
+/** Starts a stateful protocol server on an ephemeral loopback port. */
+export async function startBlueBubblesLoopback(
+	options: StartBlueBubblesLoopbackOptions,
+): Promise<RunningBlueBubblesLoopback> {
+	if (options.accounts.length === 0) {
+		throw new Error("BlueBubbles loopback requires at least one account");
+	}
+	const initialAccounts = structuredClone(options.accounts);
+	const accounts = new Map<string, AccountState>();
+	const passwordOwners = new Map<string, string>();
+	const faults = new Map<string, BlueBubblesLoopbackFault[]>();
+	const receipts: BlueBubblesMockReceipt[] = [];
+	const deliveredWebhookIds = new Set<string>();
+	const latestWebhookSequences = new Map<string, number>();
+	const now = options.now ?? Date.now;
+	const sleep =
+		options.sleep ??
+		((durationMs: number) =>
+			new Promise<void>((resolve) => setTimeout(resolve, durationMs)));
+	let receiptSequence = 0;
+
+	const restore = (): void => {
+		accounts.clear();
+		passwordOwners.clear();
+		for (const seed of initialAccounts) {
+			if (accounts.has(seed.accountId) || passwordOwners.has(seed.password)) {
+				throw new Error(
+					"BlueBubbles loopback account IDs and passwords must be unique",
+				);
+			}
+			const messages = new Map(
+				(seed.messages ?? []).map((message) => [
+					message.guid,
+					structuredClone(message),
+				]),
+			);
+			accounts.set(seed.accountId, {
+				accountId: seed.accountId,
+				password: seed.password,
+				chats: new Map(
+					seed.chats.map((chat) => [chat.guid, structuredClone(chat)]),
+				),
+				messages,
+				tempGuids: new Map(
+					[...messages.values()]
+						.filter((message) => message.tempGuid)
+						.map((message) => [message.tempGuid as string, message.guid]),
+				),
+			});
+			passwordOwners.set(seed.password, seed.accountId);
+		}
+		faults.clear();
+		receipts.length = 0;
+		deliveredWebhookIds.clear();
+		latestWebhookSequences.clear();
+		receiptSequence = 0;
+	};
+	restore();
+
+	const append = (
+		receipt: Omit<
+			BlueBubblesMockReceipt,
+			"sequence" | "evidence" | "occurredAt"
+		>,
+	): void => {
+		receipts.push({
+			...structuredClone(receipt),
+			sequence: ++receiptSequence,
+			evidence: "mock-only",
+			occurredAt: new Date(now()).toISOString(),
+		});
+	};
+
+	const server = createServer(async (request, response) => {
+		try {
+			await handleProtocolRequest(
+				request,
+				response,
+				accounts,
+				passwordOwners,
+				faults,
+				append,
+				now,
+				sleep,
+			);
+		} catch (error) {
+			json(response, 500, protocolEnvelope(500, null, String(error)));
+		}
+	});
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			server.off("error", reject);
+			resolve();
+		});
+	});
+	const address = server.address();
+	if (!address || typeof address === "string") {
+		throw new Error("BlueBubbles loopback did not bind an IP port");
+	}
+
+	const snapshot = (): BlueBubblesLoopbackSnapshot => ({
+		accounts: [...accounts.values()]
+			.map((account) => ({
+				accountId: account.accountId,
+				chats: [...account.chats.keys()].sort(),
+				messages: [...account.messages.values()].map((message) =>
+					structuredClone(message),
+				),
+			}))
+			.sort((left, right) => left.accountId.localeCompare(right.accountId)),
+		pendingFaults: [...faults.entries()]
+			.map(([target, queue]) => ({ target, count: queue.length }))
+			.sort((left, right) => left.target.localeCompare(right.target)),
+		receipts: structuredClone(receipts),
+	});
+
+	return {
+		owner: "bluebubbles-external",
+		url: `http://127.0.0.1:${address.port}`,
+		get receipts() {
+			return structuredClone(receipts);
+		},
+		fault(method, path, fault) {
+			const key = `${method.toUpperCase()} ${path}`;
+			faults.set(key, [...(faults.get(key) ?? []), structuredClone(fault)]);
+		},
+		reset() {
+			restore();
+			return snapshot();
+		},
+		snapshot,
+		async deliverWebhook(targetUrl, event, secret, deliveryOptions = {}) {
+			const responses: Response[] = [];
+			const maxAttempts = deliveryOptions.maxAttempts ?? 3;
+			const retryDelayMs = deliveryOptions.retryDelayMs ?? 0;
+			for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+				const deliveryKey = `${event.accountId}:${event.id}`;
+				const duplicate = deliveredWebhookIds.has(deliveryKey);
+				const latestSequence = latestWebhookSequences.get(event.accountId) ?? 0;
+				const response = await fetch(targetUrl, {
+					method: "POST",
+					headers: {
+						"content-type": "application/json",
+						"x-bluebubbles-webhook-secret": secret,
+					},
+					body: JSON.stringify({ type: event.type, data: event.data }),
+				});
+				responses.push(response);
+				append({
+					kind: "webhook",
+					operation: event.type,
+					accountId: event.accountId,
+					outcome: duplicate
+						? "replayed"
+						: response.ok
+							? "succeeded"
+							: "rejected",
+					idempotencyKey: event.id,
+					detail: {
+						attempt,
+						status: response.status,
+						sequence: event.sequence,
+						outOfOrder: event.sequence <= latestSequence,
+					},
+				});
+				if (response.ok) {
+					deliveredWebhookIds.add(deliveryKey);
+					latestWebhookSequences.set(
+						event.accountId,
+						Math.max(latestSequence, event.sequence),
+					);
+					break;
+				}
+				if (attempt < maxAttempts) await sleep(retryDelayMs);
+			}
+			return responses;
+		},
+		async stop() {
+			await new Promise<void>((resolve, reject) =>
+				server.close((error) => (error ? reject(error) : resolve())),
+			);
+		},
+	};
+}
+
+type AppendReceipt = (
+	receipt: Omit<BlueBubblesMockReceipt, "sequence" | "evidence" | "occurredAt">,
+) => void;
+
+async function handleProtocolRequest(
+	request: IncomingMessage,
+	response: ServerResponse,
+	accounts: Map<string, AccountState>,
+	passwordOwners: Map<string, string>,
+	faults: Map<string, BlueBubblesLoopbackFault[]>,
+	append: AppendReceipt,
+	now: () => number,
+	sleep: (durationMs: number) => Promise<void>,
+): Promise<void> {
+	const url = new URL(request.url ?? "/", "http://127.0.0.1");
+	const method = request.method ?? "GET";
+	const key = `${method} ${url.pathname}`;
+	const body = await readBody(request);
+	const password = url.searchParams.get("password") ?? "";
+	const accountId = passwordOwners.get(password);
+	const account = accountId ? accounts.get(accountId) : undefined;
+	append({
+		kind: "request",
+		operation: key,
+		accountId: accountId ?? null,
+		outcome: account ? "succeeded" : "rejected",
+		idempotencyKey: null,
+		detail: {
+			path: url.pathname,
+			query: Object.fromEntries(
+				[...url.searchParams.entries()].map(([name, value]) => [
+					name,
+					name.toLowerCase().includes("password") ? "<redacted>" : value,
+				]),
+			),
+			body: redactSecrets(body, passwordOwners.keys()),
+		},
+	});
+	if (!account) {
+		json(response, 401, protocolEnvelope(401, null, "Unauthorized"));
+		return;
+	}
+	const queue = faults.get(key) ?? [];
+	const fault = queue.shift();
+	if (queue.length === 0) faults.delete(key);
+	else faults.set(key, queue);
+	if (fault?.type === "delay") await sleep(fault.durationMs);
+
+	if (method === "POST" && url.pathname === "/api/v1/message/text") {
+		const parsed = parseObject(body);
+		const chatGuid = parsed ? stringField(parsed, "chatGuid") : null;
+		const text = parsed ? stringField(parsed, "message") : null;
+		const tempGuid = parsed ? stringField(parsed, "tempGuid") : null;
+		if (!chatGuid || !text || !account.chats.has(chatGuid)) {
+			json(response, 422, protocolEnvelope(422, null, "Invalid message"));
+			return;
+		}
+		const existingGuid = tempGuid ? account.tempGuids.get(tempGuid) : undefined;
+		if (existingGuid) {
+			const existing = account.messages.get(existingGuid);
+			append({
+				kind: "effect",
+				operation: "message.send",
+				accountId: account.accountId,
+				outcome: "replayed",
+				idempotencyKey: tempGuid,
+				detail: { messageGuid: existingGuid },
+			});
+			json(
+				response,
+				200,
+				protocolEnvelope(200, toProtocolMessage(existing, account)),
+			);
+			return;
+		}
+		const guid = `msg-${account.accountId}-${account.messages.size + 1}`;
+		const message: BlueBubblesLoopbackMessage = {
+			guid,
+			text,
+			dateCreated: now(),
+			chatGuid,
+			tempGuid: tempGuid ?? undefined,
+			isFromMe: true,
+		};
+		const ambiguous = fault?.type === "status" && fault.status >= 500;
+		if (!fault || fault.type === "delay" || ambiguous) {
+			account.messages.set(guid, message);
+			if (tempGuid) account.tempGuids.set(tempGuid, guid);
+			append({
+				kind: "effect",
+				operation: "message.send",
+				accountId: account.accountId,
+				outcome: ambiguous ? "ambiguous" : "succeeded",
+				idempotencyKey: tempGuid,
+				detail: { messageGuid: guid },
+			});
+		}
+		if (writeFault(response, fault)) return;
+		json(
+			response,
+			200,
+			protocolEnvelope(200, toProtocolMessage(message, account)),
+		);
+		return;
+	}
+	if (method === "POST" && url.pathname === "/api/v1/message/attachment") {
+		const chatGuid = multipartField(body, "chatGuid");
+		const tempGuid = multipartField(body, "tempGuid");
+		if (!chatGuid || !account.chats.has(chatGuid)) {
+			json(response, 422, protocolEnvelope(422, null, "Invalid attachment"));
+			return;
+		}
+		const existingGuid = tempGuid ? account.tempGuids.get(tempGuid) : undefined;
+		if (existingGuid) {
+			append({
+				kind: "effect",
+				operation: "attachment.send",
+				accountId: account.accountId,
+				outcome: "replayed",
+				idempotencyKey: tempGuid,
+				detail: { messageGuid: existingGuid },
+			});
+			json(
+				response,
+				200,
+				protocolEnvelope(
+					200,
+					toProtocolMessage(account.messages.get(existingGuid), account),
+				),
+			);
+			return;
+		}
+		const guid = `attachment-${account.accountId}-${account.messages.size + 1}`;
+		const message: BlueBubblesLoopbackMessage = {
+			guid,
+			text: multipartField(body, "message"),
+			dateCreated: now(),
+			chatGuid,
+			tempGuid: tempGuid ?? undefined,
+			isFromMe: true,
+		};
+		const ambiguous = fault?.type === "status" && fault.status >= 500;
+		if (!fault || fault.type === "delay" || ambiguous) {
+			account.messages.set(guid, message);
+			if (tempGuid) account.tempGuids.set(tempGuid, guid);
+			append({
+				kind: "effect",
+				operation: "attachment.send",
+				accountId: account.accountId,
+				outcome: ambiguous ? "ambiguous" : "succeeded",
+				idempotencyKey: tempGuid,
+				detail: { messageGuid: guid },
+			});
+		}
+		if (writeFault(response, fault)) return;
+		json(
+			response,
+			200,
+			protocolEnvelope(200, toProtocolMessage(message, account)),
+		);
+		return;
+	}
+
+	if (writeFault(response, fault)) return;
+	if (method === "GET" && url.pathname === "/api/v1/server/info") {
+		json(
+			response,
+			200,
+			protocolEnvelope(200, {
+				os_version: "14.6-loopback",
+				server_version: "1.9.9",
+				private_api: true,
+				helper_connected: true,
+				proxy_service: null,
+				detected_icloud: null,
+			}),
+		);
+		return;
+	}
+	if (method === "POST" && url.pathname === "/api/v1/chat/query") {
+		const parsed = parseObject(body) ?? {};
+		const limit = numberField(parsed, "limit") ?? 100;
+		const offset = numberField(parsed, "offset") ?? 0;
+		json(
+			response,
+			200,
+			protocolEnvelope(
+				200,
+				[...account.chats.values()].slice(offset, offset + limit),
+			),
+		);
+		return;
+	}
+	const chatMatch = url.pathname.match(/^\/api\/v1\/chat\/([^/]+)$/);
+	if (method === "GET" && chatMatch?.[1]) {
+		const matchingChat = account.chats.get(decodeURIComponent(chatMatch[1]));
+		json(
+			response,
+			matchingChat ? 200 : 404,
+			protocolEnvelope(
+				matchingChat ? 200 : 404,
+				matchingChat ?? null,
+				matchingChat ? "OK" : "Chat does not exist",
+			),
+		);
+		return;
+	}
+	const messageMatch = url.pathname.match(
+		/^\/api\/v1\/chat\/([^/]+)\/message$/,
+	);
+	if (method === "GET" && messageMatch?.[1]) {
+		const chatGuid = decodeURIComponent(messageMatch[1]);
+		const limit = Number(url.searchParams.get("limit") ?? 50);
+		const offset = Number(url.searchParams.get("offset") ?? 0);
+		json(
+			response,
+			200,
+			protocolEnvelope(
+				200,
+				[...account.messages.values()]
+					.filter((message) => message.chatGuid === chatGuid)
+					.slice(offset, offset + limit)
+					.map((message) => toProtocolMessage(message, account)),
+			),
+		);
+		return;
+	}
+	const readMatch = url.pathname.match(/^\/api\/v1\/chat\/([^/]+)\/read$/);
+	if (method === "POST" && readMatch?.[1]) {
+		const chatGuid = decodeURIComponent(readMatch[1]);
+		for (const message of account.messages.values()) {
+			if (message.chatGuid === chatGuid && !message.isFromMe)
+				message.dateRead = now();
+		}
+		append({
+			kind: "effect",
+			operation: "chat.mark-read",
+			accountId: account.accountId,
+			outcome: "succeeded",
+			idempotencyKey: chatGuid,
+			detail: { chatGuid },
+		});
+		json(response, 200, protocolEnvelope(200, { success: true }));
+		return;
+	}
+	if (method === "POST" && url.pathname === "/api/v1/message/react") {
+		const parsed = parseObject(body);
+		const messageGuid = parsed ? stringField(parsed, "messageGuid") : null;
+		const reaction = parsed ? stringField(parsed, "reaction") : null;
+		if (!messageGuid || !reaction || !account.messages.has(messageGuid)) {
+			json(response, 422, protocolEnvelope(422, null, "Invalid reaction"));
+			return;
+		}
+		append({
+			kind: "effect",
+			operation: "message.react",
+			accountId: account.accountId,
+			outcome: "succeeded",
+			idempotencyKey: `${messageGuid}:${reaction}`,
+			detail: { messageGuid, reaction },
+		});
+		json(response, 200, protocolEnvelope(200, { success: true }));
+		return;
+	}
+	const mutationMatch = url.pathname.match(
+		/^\/api\/v1\/message\/([^/]+)\/(edit|unsend)$/,
+	);
+	if (method === "POST" && mutationMatch?.[1] && mutationMatch[2]) {
+		const messageGuid = decodeURIComponent(mutationMatch[1]);
+		const message = account.messages.get(messageGuid);
+		if (!message) {
+			json(
+				response,
+				404,
+				protocolEnvelope(404, null, "Message does not exist"),
+			);
+			return;
+		}
+		if (mutationMatch[2] === "edit") {
+			const parsed = parseObject(body);
+			const editedMessage = parsed
+				? stringField(parsed, "editedMessage")
+				: null;
+			if (!editedMessage) {
+				json(response, 422, protocolEnvelope(422, null, "Invalid edit"));
+				return;
+			}
+			message.text = editedMessage;
+			message.dateEdited = now();
+		} else {
+			account.messages.delete(messageGuid);
+			if (message.tempGuid) account.tempGuids.delete(message.tempGuid);
+		}
+		append({
+			kind: "effect",
+			operation: `message.${mutationMatch[2]}`,
+			accountId: account.accountId,
+			outcome: "succeeded",
+			idempotencyKey: messageGuid,
+			detail: { messageGuid },
+		});
+		json(response, 200, protocolEnvelope(200, { success: true }));
+		return;
+	}
+	json(response, 404, protocolEnvelope(404, null, "Not Found"));
+}
+
+function writeFault(
+	response: ServerResponse,
+	fault: BlueBubblesLoopbackFault | undefined,
+): boolean {
+	if (!fault || fault.type === "delay") return false;
+	if (fault.type === "malformed-json") {
+		response.writeHead(200, { "content-type": "application/json" });
+		response.end(fault.body ?? "{not-json");
+		return true;
+	}
+	if (fault.type === "schema-drift") {
+		json(response, 200, fault.body);
+		return true;
+	}
+	json(
+		response,
+		fault.status,
+		fault.body ?? protocolEnvelope(fault.status, null, "Injected fault"),
+		fault.headers,
+	);
+	return true;
+}
+
+function protocolEnvelope(status: number, data: unknown, message = "OK") {
+	return status >= 400
+		? { status, message, error: { type: "Loopback Error", message }, data }
+		: { status, message, data };
+}
+
+function toProtocolMessage(
+	message: BlueBubblesLoopbackMessage | undefined,
+	account: AccountState,
+): Record<string, unknown> | null {
+	if (!message) return null;
+	const chat = account.chats.get(message.chatGuid);
+	const participant = chat?.participants[0];
+	return {
+		guid: message.guid,
+		text: message.text,
+		subject: null,
+		country: null,
+		handle: participant
+			? {
+					...participant,
+					country: null,
+					originalROWID: 1,
+					uncanonicalizedId: null,
+				}
+			: null,
+		handleId: 1,
+		otherHandle: 0,
+		chats: chat ? [{ ...chat, lastMessage: null }] : [],
+		attachments: [],
+		expressiveSendStyleId: null,
+		dateCreated: message.dateCreated,
+		dateRead: message.dateRead ?? null,
+		dateDelivered: null,
+		isFromMe: message.isFromMe,
+		isDelayed: false,
+		isAutoReply: false,
+		isSystemMessage: false,
+		isServiceMessage: false,
+		isForward: false,
+		isArchived: false,
+		hasDdResults: false,
+		hasPayloadData: false,
+		threadOriginatorGuid: null,
+		threadOriginatorPart: null,
+		associatedMessageGuid: null,
+		associatedMessageType: null,
+		balloonBundleId: null,
+		dateEdited: message.dateEdited ?? null,
+		error: 0,
+		itemType: 0,
+		groupTitle: null,
+		groupActionType: 0,
+		payloadData: null,
+	};
+}
+
+function parseObject(body: string): Record<string, unknown> | null {
+	try {
+		const value: unknown = JSON.parse(body);
+		return value && typeof value === "object" && !Array.isArray(value)
+			? (value as Record<string, unknown>)
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+function stringField(
+	value: Record<string, unknown>,
+	field: string,
+): string | null {
+	const candidate = value[field];
+	return typeof candidate === "string" && candidate.length > 0
+		? candidate
+		: null;
+}
+
+function numberField(
+	value: Record<string, unknown>,
+	field: string,
+): number | null {
+	const candidate = value[field];
+	return typeof candidate === "number" && Number.isFinite(candidate)
+		? candidate
+		: null;
+}
+
+function multipartField(body: string, field: string): string | null {
+	const escaped = field.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const match = body.match(
+		new RegExp(
+			`name="${escaped}"(?:;[^\\r\\n]*)?\\r?\\n(?:[^\\r\\n]*\\r?\\n)?\\r?\\n([^\\r\\n]+)`,
+		),
+	);
+	return match?.[1]?.trim() || null;
+}
+
+function redactSecrets(value: string, secrets: Iterable<string>): string {
+	let redacted = value;
+	for (const secret of secrets) {
+		for (const candidate of [
+			secret,
+			encodeURIComponent(secret),
+			encodeURIComponent(encodeURIComponent(secret)),
+		]
+			.filter(Boolean)
+			.sort((left, right) => right.length - left.length)) {
+			redacted = redacted.split(candidate).join("<redacted>");
+		}
+	}
+	return redacted;
+}
+
+async function readBody(request: IncomingMessage): Promise<string> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of request) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	return Buffer.concat(chunks).toString("utf8");
+}
+
+function json(
+	response: ServerResponse,
+	status: number,
+	body: unknown,
+	headers: Record<string, string> = {},
+): void {
+	response.writeHead(status, {
+		"content-type": "application/json",
+		...headers,
+	});
+	response.end(JSON.stringify(body));
+}

--- a/plugins/plugin-bluebubbles/src/types.ts
+++ b/plugins/plugin-bluebubbles/src/types.ts
@@ -108,12 +108,19 @@ export interface BlueBubblesWebhookPayload {
 
 export interface SendMessageOptions {
 	tempGuid?: string;
+	/** Cancels the provider request before a response is accepted. */
+	signal?: AbortSignal;
 	method?: "apple-script" | "private-api";
 	subject?: string;
 	effectId?: string;
 	selectedMessageGuid?: string;
 	partIndex?: number;
 	ddScan?: boolean;
+}
+
+export interface BlueBubblesClientOptions {
+	requestTimeoutMs?: number;
+	attachmentTimeoutMs?: number;
 }
 
 export interface SendMessageResult {

--- a/plugins/plugin-bluebubbles/test/scenarios/bluebubbles.loopback-egress.scenario.ts
+++ b/plugins/plugin-bluebubbles/test/scenarios/bluebubbles.loopback-egress.scenario.ts
@@ -1,0 +1,138 @@
+/**
+ * Runs BlueBubbles egress through the real scenario AgentRuntime, production
+ * service/client, and plugin-owned v1 loopback without any model call. The
+ * resulting receipt is mock-only and does not qualify a live provider.
+ */
+
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { BlueBubblesService } from "../../src/service.js";
+import { startBlueBubblesLoopback } from "../../src/testing/loopback.js";
+
+const CHAT_GUID = "iMessage;-;+14155552671";
+const PASSWORD = "scenario-password";
+
+interface ScenarioResult {
+	receiptCount: number;
+	mockOnly: boolean;
+	chatGuid: string | undefined;
+}
+
+const results = new WeakMap<IAgentRuntime, ScenarioResult>();
+
+export default scenario({
+	id: "bluebubbles.loopback-egress",
+	lane: "pr-deterministic",
+	modelFixtures: {
+		mode: "model-free",
+		reason:
+			"The direct connector send exercises a real runtime and local protocol boundary without model calls.",
+	},
+	title: "BlueBubbles egress over the deterministic external-server loopback",
+	domain: "messaging",
+	tags: ["bluebubbles", "connector", "mock-only", "deterministic"],
+	status: "active",
+	isolation: "per-scenario",
+	rooms: [
+		{
+			id: "main",
+			source: "dashboard",
+			channelType: "DM",
+			title: "BlueBubbles loopback",
+		},
+	],
+	seed: [
+		{
+			type: "custom",
+			name: "send through the production BlueBubbles connector",
+			apply: async (ctx) => {
+				const runtime = ctx.runtime;
+				const upstream = await startBlueBubblesLoopback({
+					now: () => Date.parse("2032-04-05T06:07:08.000Z"),
+					accounts: [
+						{
+							accountId: "scenario",
+							password: PASSWORD,
+							chats: [
+								{
+									guid: CHAT_GUID,
+									chatIdentifier: "+14155552671",
+									displayName: "Scenario contact",
+									participants: [
+										{ address: "+14155552671", service: "iMessage" },
+									],
+								},
+							],
+						},
+					],
+				});
+				const originalGetSetting = runtime.getSetting.bind(runtime);
+				const settings: Record<string, string> = {
+					BLUEBUBBLES_SERVER_URL: upstream.url,
+					BLUEBUBBLES_PASSWORD: PASSWORD,
+					BLUEBUBBLES_DM_POLICY: "open",
+					BLUEBUBBLES_SEND_READ_RECEIPTS: "false",
+				};
+				runtime.getSetting = (key: string) =>
+					settings[key] ?? originalGetSetting(key);
+				let service: BlueBubblesService | undefined;
+				try {
+					service = await BlueBubblesService.start(runtime);
+					if (!service.getIsRunning()) {
+						return "BlueBubblesService did not connect to the loopback";
+					}
+					BlueBubblesService.registerSendHandlers(runtime, service);
+					const sent = await runtime.sendMessageToTarget(
+						{
+							source: "bluebubbles",
+							channelId: CHAT_GUID,
+							roomId: ctx.primaryRoomId,
+						},
+						{ text: "deterministic BlueBubbles send", agentVoiced: true },
+					);
+					const memory =
+						sent && "kind" in sent
+							? sent.kind === "delivered" || sent.kind === "partially_delivered"
+								? sent.memories[0]
+								: undefined
+							: (sent as Memory | undefined);
+					const effectReceipts = upstream.receipts.filter(
+						(receipt) => receipt.kind === "effect",
+					);
+					results.set(runtime, {
+						receiptCount: effectReceipts.length,
+						mockOnly: effectReceipts.every(
+							(receipt) => receipt.evidence === "mock-only",
+						),
+						chatGuid: (memory?.metadata as Record<string, unknown> | undefined)
+							?.bluebubblesChatGuid as string | undefined,
+					});
+					return undefined;
+				} finally {
+					runtime.getSetting = originalGetSetting;
+					if (service) await service.stop();
+					await upstream.stop();
+				}
+			},
+		},
+	],
+	turns: [],
+	finalChecks: [
+		{
+			type: "custom",
+			name: "one explicitly mock-only BlueBubbles delivery is recorded",
+			predicate: (ctx) => {
+				const result = results.get(ctx.runtime);
+				if (!result) return "scenario did not record a BlueBubbles result";
+				if (result.receiptCount !== 1) {
+					return `expected one delivery effect, saw ${result.receiptCount}`;
+				}
+				if (!result.mockOnly) return "loopback receipt was not marked mock-only";
+				if (result.chatGuid !== CHAT_GUID) {
+					return `production connector returned chat ${String(result.chatGuid)}`;
+				}
+				return undefined;
+			},
+		},
+	],
+});


### PR DESCRIPTION
# Relates to

Relates to #22899 and parent #22896. Replaces the salvageable BlueBubbles slice from closed #23327 without depending on closed #23185 or `packages/synthetic-world`.

- [x] Targets `develop` and is based on current `origin/develop` (`43f9df0f18d6a29de502d2d598e3cee994a0a46e`).
- [ ] Root `bun run verify` has not been run yet; focused package and scenario gates are green below.
- [x] Reviewer-facing protocol receipts and exact commands are included below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on latest `origin/develop`; zero conflicts.
- [ ] Root verify remains a pre-review gate; focused proof is complete.

# Risks

Medium. The client now exposes typed rejected-versus-ambiguous transport failures and the inbound service writes a durable processing-complete disposition. The retry path is deliberately fail-closed when the message service, room, or completion write is unavailable.

# Background

## What does this PR do?

- adds a plugin-owned stateful BlueBubbles v1 HTTP loopback with deterministic reset, queued status/delay/malformed/schema faults, multi-account state, text and attachment `tempGuid` idempotency, chat/message readback, reaction/edit/unsend effects, webhook retries, secret redaction, and receipts permanently labeled `mock-only`
- drives the production `BlueBubblesClient`, production webhook route, `BlueBubblesService`, connector registry, and a real `AgentRuntime` with `InMemoryDatabaseAdapter`
- closes the persist-then-process loss window: persistence is no longer treated as completion, same-GUID concurrent ingress shares one in-flight operation, failed processing remains retryable, and only a durable completion marker allows duplicate acknowledgement
- adds a model-free real-runtime scenario at `bluebubbles.loopback-egress`
- identifies the simulator owner as `bluebubbles-external`; it neither remaps nor simulates the separate native local `@elizaos/plugin-imessage` owner

## What kind of change is this?

Feature plus reliability bug fix. This PR does not add a provider catalog, synthetic-world package, Cloud composition layer, or provider certification.

# Documentation changes needed?

Updated the plugin README and paired package guides with the loopback contract, ownership boundary, and mock-only qualification limits.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-bluebubbles/src/loopback-contract.test.ts`
2. `plugins/plugin-bluebubbles/src/testing/loopback.ts`
3. `plugins/plugin-bluebubbles/src/service.ts` persist/process completion path

## Detailed testing steps

- `bun run --cwd plugins/plugin-bluebubbles test` — 10 files, 73 tests passed
- `bun run --cwd plugins/plugin-bluebubbles typecheck` — passed
- `bun run --cwd plugins/plugin-bluebubbles lint:check` — passed
- `bun run --cwd plugins/plugin-bluebubbles build` — passed; `dist/testing/loopback.js` produced
- `bun run --cwd plugins/plugin-bluebubbles test:scenarios` — 1 passed, 0 failed; `bluebubbles.loopback-egress` passed in 39ms with deterministic provider and simulated profile
- `bun run check:agents-claude` — 160 paired guides passed
- `git diff --check` — passed

The contract test observes the production route returning `[401, 500, 500, 200, 200]` for wrong-secret, fail-once, concurrent duplicate, retry, and completed duplicate delivery. It asserts one persisted inbound memory, exactly one successful processing, two total processing attempts, and a durable completion marker. The client contract asserts one message for each repeated `tempGuid`, recovery from a committed 503 ambiguity, deterministic reset, and mock-only/redacted receipts.

# Evidence Gate

<!-- evidence-head:abb56fc2e5a6722f77a8147036cb14b839341fe8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - protocol and runtime-only change.
<!-- evidence-row:backend-logs -->
- [x] [24107-bluebubbles-24107-backend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24107-bluebubbles-24107-backend.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - this is deliberately model-free mock transport proof; live-provider qualification remains separate and no agent decision behavior is claimed.
<!-- evidence-row:domain-artifacts -->
- [x] [24107-bluebubbles-24107-domain.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24107-bluebubbles-24107-domain.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text.

# Evidence Details

## Real LLM-call trajectory

N/A - the scenario is explicitly `model-free`; this PR proves deterministic connector transport and runtime integration only.

## Backend + frontend logs

Backend proof is the production-route status timeline and green real-runtime scenario listed above. Frontend is N/A.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio surface.

## Known gaps / failures

- Root `bun run verify` is not yet run; this remains an explicit READY-state review hold.
- The scenario runner labels this simulated mock-only run evidence-ineligible and publishable=0, as intended.
- No live BlueBubbles server was contacted. Live provider qualification is outside this PR and remains separate from deterministic receipts.
- No provider catalog or Cloud subprocess composition is claimed in this focused salvage.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [bluebubbles-standalone-22899]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->