### PR TITLE
fix(scenarios): restore strict view navigation contracts

### DIFF
--- a/packages/scenario-runner/src/model-fixture-migration.test.ts
+++ b/packages/scenario-runner/src/model-fixture-migration.test.ts
@@ -8,7 +8,7 @@ import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
-const MAX_LEGACY_PR_DETERMINISTIC_SCENARIOS = 79;
+const MAX_LEGACY_PR_DETERMINISTIC_SCENARIOS = 75;
 
 type ScenarioSourceClassification = {
   deterministic: boolean;
@@ -184,7 +184,7 @@ describe("scenario model fixture migration", () => {
       strictOrModelFree: deterministic.length - legacy.length,
       legacy: legacy.length,
       total: deterministic.length,
-    }).toEqual({ strictOrModelFree: 40, legacy: 79, total: 119 });
+    }).toEqual({ strictOrModelFree: 44, legacy: 75, total: 119 });
   }, 120_000);
 
   it("recognizes authored properties while ignoring comments and setup strings", () => {

--- a/packages/scenario-runner/test/scenarios/_helpers/view-navigation-effect.ts
+++ b/packages/scenario-runner/test/scenarios/_helpers/view-navigation-effect.ts
@@ -1,0 +1,54 @@
+/**
+ * Asserts the internal VIEWS navigation receipt returned by direct action turns.
+ * Visible acknowledgement prose belongs to the post-tool model path instead.
+ */
+
+import type { ScenarioTurnExecution } from "@elizaos/scenario-runner/schema";
+
+export type ExpectedViewNavigationEffect = {
+  viewId: string;
+  label: string;
+  path: string;
+};
+
+export function expectAcceptedViewNavigationEffect(
+  execution: ScenarioTurnExecution,
+  expected: ExpectedViewNavigationEffect,
+): string | undefined {
+  const expectedReceipt = JSON.stringify({
+    effect: "view_navigation",
+    status: "accepted",
+    viewId: expected.viewId,
+    label: expected.label,
+    path: expected.path,
+  });
+  if (execution.responseText !== expectedReceipt) {
+    return `expected canonical navigation receipt ${expectedReceipt}, saw ${JSON.stringify(execution.responseText)}`;
+  }
+
+  const action = execution.actionsCalled.find(
+    (candidate) => candidate.actionName === "VIEWS",
+  );
+  if (action?.result?.text !== expectedReceipt) {
+    return `expected VIEWS result.text canonical navigation receipt ${expectedReceipt}, saw ${JSON.stringify(action?.result?.text)}`;
+  }
+  const responseBody =
+    execution.responseBody &&
+    typeof execution.responseBody === "object" &&
+    !Array.isArray(execution.responseBody)
+      ? (execution.responseBody as Record<string, unknown>)
+      : {};
+  if (responseBody.transcriptVisibility !== "internal") {
+    return `expected navigation receipt transcriptVisibility=internal, saw ${String(responseBody.transcriptVisibility)}`;
+  }
+  if (responseBody.modelReplyRequired !== true) {
+    return `expected navigation to require one user-facing model reply, saw ${String(responseBody.modelReplyRequired)}`;
+  }
+  if (
+    "userFacingText" in responseBody ||
+    "verifiedUserFacing" in responseBody
+  ) {
+    return "expected internal navigation receipt not to claim user-facing prose";
+  }
+  return undefined;
+}

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-actions.scenario.ts
@@ -1,6 +1,6 @@
 /**
  * Keyless catalog coverage for the plugin-app-control action surface against a
- * seeded set of scenario views. Runs on the pr-deterministic lane under the model provider.
+ * seeded set of scenario views. Runs model-free on the pr-deterministic lane.
  */
 import { promises as fs } from "node:fs";
 import path from "node:path";
@@ -16,6 +16,7 @@ import {
   registerAppControlHttpHandler,
   resetAppControlHttpLoopback,
 } from "./_helpers/app-control-http-loopback";
+import { expectAcceptedViewNavigationEffect } from "./_helpers/view-navigation-effect";
 
 function toRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -83,6 +84,34 @@ function expectActionTurn(
   }
 
   return undefined;
+}
+
+function expectNavigationActionTurn(
+  execution: ScenarioTurnExecution,
+  expected: {
+    parameters: Record<string, unknown>;
+    viewId: string;
+    label: string;
+    path: string;
+  },
+): string | undefined {
+  const effectFailure = expectAcceptedViewNavigationEffect(execution, {
+    viewId: expected.viewId,
+    label: expected.label,
+    path: expected.path,
+  });
+  if (effectFailure) return effectFailure;
+  return expectActionTurn(execution, {
+    actionName: "VIEWS",
+    parameters: expected.parameters,
+    responseText: execution.responseText,
+    resultFields: {
+      "values.mode": "show",
+      "values.viewId": expected.viewId,
+      "values.label": expected.label,
+      "data.view.path": expected.path,
+    },
+  });
 }
 
 const appLoadDirectory = "/tmp/eliza-app-control-scenario-load/apps";
@@ -628,18 +657,12 @@ export default scenario({
       text: "Open the settings view",
       actionName: "VIEWS",
       options: { action: "show", view: "settings", viewType: "gui" },
-      responseIncludesAny: ["Opened Settings"],
       assertTurn: (execution) =>
-        expectActionTurn(execution, {
-          actionName: "VIEWS",
+        expectNavigationActionTurn(execution, {
           parameters: { action: "show", view: "settings", viewType: "gui" },
-          responseText: "Opened Settings.",
-          resultFields: {
-            "values.mode": "show",
-            "values.viewId": "settings",
-            "values.label": "Settings",
-            "data.view.path": "/settings",
-          },
+          viewId: "settings",
+          label: "Settings",
+          path: "/settings",
         }),
     },
     {
@@ -648,22 +671,16 @@ export default scenario({
       text: "Open the remote ledger view",
       actionName: "VIEWS",
       options: { action: "open", view: "remote-ledger", viewType: "gui" },
-      responseIncludesAny: ["Opened Remote Ledger"],
       assertTurn: (execution) =>
-        expectActionTurn(execution, {
-          actionName: "VIEWS",
+        expectNavigationActionTurn(execution, {
           parameters: {
             action: "open",
             view: "remote-ledger",
             viewType: "gui",
           },
-          responseText: "Opened Remote Ledger.",
-          resultFields: {
-            "values.mode": "show",
-            "values.viewId": "remote-ledger",
-            "values.label": "Remote Ledger",
-            "data.view.path": "/remote-ledger",
-          },
+          viewId: "remote-ledger",
+          label: "Remote Ledger",
+          path: "/remote-ledger",
         }),
     },
     {

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
@@ -5,10 +5,9 @@
  */
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { ModelType } from "@elizaos/core";
-import { matchesScenarioInput } from "@elizaos/core/testing";
 import type {
   CapturedAction,
+  ScenarioModelFixture,
   ScenarioTurnExecution,
 } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
@@ -30,9 +29,6 @@ type RuntimeWithScenarioModelFixtures = {
   deleteTask?: (taskId: string) => Promise<void>;
   getService?: (serviceType: string) => unknown;
   getTasks?: (query?: Record<string, unknown>) => Promise<unknown[]>;
-  scenarioModelFixtures?: {
-    register: (...fixtures: Array<Record<string, unknown>>) => void;
-  };
 };
 
 function toRecord(value: unknown): Record<string, unknown> {
@@ -60,6 +56,17 @@ function readPath(value: unknown, path: string): unknown {
 
 function valuesEqual(actual: unknown, expected: unknown): boolean {
   return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function currentUserInputMatcher(input: string): {
+  pattern: string;
+  flags: string;
+} {
+  const escaped = input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return {
+    pattern: `(?:^|\\n)message:user:\\n${escaped}(?:\\n\\n|$)`,
+    flags: "u",
+  };
 }
 
 function expectRoutedAction(
@@ -98,7 +105,10 @@ function expectRoutedAction(
   return undefined;
 }
 
-function handleResponseFixture(input: string, actionName: "APP" | "VIEWS") {
+function handleResponseFixture(
+  input: string,
+  actionName: "APP" | "VIEWS",
+): ScenarioModelFixture {
   const args = {
     contexts: ["settings"],
     intents: [input.toLowerCase()],
@@ -110,12 +120,11 @@ function handleResponseFixture(input: string, actionName: "APP" | "VIEWS") {
   return {
     name: `route-${actionName.toLowerCase()}-stage1-${input}`,
     match: {
-      modelType: ModelType.RESPONSE_HANDLER,
-      input: matchesScenarioInput(input),
-      toolName: "HANDLE_RESPONSE",
+      modelType: "RESPONSE_HANDLER",
+      input: currentUserInputMatcher(input),
+      toolNames: ["HANDLE_RESPONSE"],
     },
-    response: args,
-    times: 1,
+    response: { json: args },
   };
 }
 
@@ -124,30 +133,54 @@ function plannerFixture(
   actionName: "APP" | "VIEWS",
   args: Record<string, unknown>,
   messageToUser: string,
-) {
+  toolNames: string[] = [actionName, "REPLY", "IGNORE", "STOP"],
+): ScenarioModelFixture {
   return {
     name: `route-${actionName.toLowerCase()}-planner-${input}`,
     match: {
-      modelType: ModelType.ACTION_PLANNER,
-      input: matchesScenarioInput(input),
-      toolName: actionName,
+      modelType: "ACTION_PLANNER",
+      input: currentUserInputMatcher(input),
+      toolNames,
     },
     response: {
-      text: "",
-      thought: `Call ${actionName} for ${input}.`,
-      messageToUser,
-      completed: true,
-      finishReason: "tool-calls",
-      toolCalls: [
-        {
-          id: `call-${actionName.toLowerCase()}-${String(args.action)}`,
-          name: actionName,
-          type: "function",
-          arguments: args,
-        },
-      ],
+      json: {
+        text: "",
+        thought: `Call ${actionName} for ${input}.`,
+        messageToUser,
+        completed: true,
+        finishReason: "tool-calls",
+        toolCalls: [
+          {
+            id: `call-${actionName.toLowerCase()}-${String(args.action)}`,
+            name: actionName,
+            type: "function",
+            arguments: args,
+          },
+        ],
+      },
     },
-    times: 1,
+  };
+}
+
+function postToolReplyFixture(
+  input: string,
+  text: string,
+): ScenarioModelFixture {
+  return {
+    name: `post-tool-reply-${input}`,
+    match: {
+      modelType: "ACTION_PLANNER",
+      input: currentUserInputMatcher(input),
+      toolNames: [],
+    },
+    response: {
+      json: {
+        thought: "Acknowledge the completed navigation once.",
+        messageToUser: text,
+        completed: true,
+        toolCalls: [],
+      },
+    },
   };
 }
 
@@ -275,9 +308,128 @@ function normalizedRequests() {
   }));
 }
 
+function appControlModelFixtures(): ScenarioModelFixture[] {
+  return [
+    handleResponseFixture("Open the settings view", "VIEWS"),
+    plannerFixture(
+      "Open the settings view",
+      "VIEWS",
+      { action: "show", view: "settings", viewType: "gui" },
+      "Opened Settings.",
+    ),
+    postToolReplyFixture("Open the settings view", "Opened Settings."),
+    handleResponseFixture("Search views for finance", "VIEWS"),
+    plannerFixture(
+      "Search views for finance",
+      "VIEWS",
+      { action: "search", query: "finance", viewType: "gui" },
+      'Views matching "finance" (1):\n  [91] Remote Ledger (remote-ledger) — /remote-ledger — Track finance balances and remote ledger entries.',
+    ),
+    handleResponseFixture("Launch the feed app", "APP"),
+    plannerFixture(
+      "Launch the feed app",
+      "APP",
+      { action: "launch", app: "feed" },
+      "Launched Feed. Run ID: run-feed-nl-1.",
+      ["APP", "VIEWS", "REPLY", "IGNORE", "STOP"],
+    ),
+    postToolReplyFixture(
+      "Launch the feed app",
+      "Launched Feed. Run ID: run-feed-nl-1.",
+    ),
+    handleResponseFixture("Relaunch the feed app", "APP"),
+    plannerFixture(
+      "Relaunch the feed app",
+      "APP",
+      { action: "relaunch", app: "feed" },
+      "Relaunched Feed. New run ID: run-feed-nl-2.",
+      ["APP", "VIEWS", "REPLY", "IGNORE", "STOP"],
+    ),
+    postToolReplyFixture(
+      "Relaunch the feed app",
+      "Relaunched Feed. New run ID: run-feed-nl-2.",
+    ),
+    handleResponseFixture("Stop the feed app", "APP"),
+    plannerFixture(
+      "Stop the feed app",
+      "APP",
+      { action: "stop", app: "feed" },
+      "Feed stopped.",
+      ["APP", "VIEWS", "REPLY", "IGNORE", "STOP"],
+    ),
+    handleResponseFixture(loadAppsInput, "APP"),
+    plannerFixture(
+      loadAppsInput,
+      "APP",
+      { action: "load_from_directory", directory: appLoadDirectory },
+      `Registered 1 app from ${appLoadDirectory}:\n  - Loaded Console (@scenario/app-loaded-console)\n\nApps are registered only — none were launched.`,
+    ),
+    postToolReplyFixture(
+      loadAppsInput,
+      `Registered 1 app from ${appLoadDirectory}:\n  - Loaded Console (@scenario/app-loaded-console)\n\nApps are registered only — none were launched.`,
+    ),
+    handleResponseFixture("Create a feed dashboard app", "APP"),
+    plannerFixture(
+      "Create a feed dashboard app",
+      "APP",
+      { action: "create", intent: "Create a feed dashboard app" },
+      "Picking next step...",
+      ["APP", "VIEWS", "START_CODING_TASK", "REPLY", "IGNORE", "STOP"],
+    ),
+    handleResponseFixture("Cancel the app create flow", "APP"),
+    plannerFixture(
+      "Cancel the app create flow",
+      "APP",
+      { action: "create", choice: "cancel" },
+      "Canceled. No app changes made.",
+      ["APP", "START_CODING_TASK", "REPLY", "IGNORE", "STOP"],
+    ),
+    postToolReplyFixture(
+      "Cancel the app create flow",
+      "Canceled. No app changes made.",
+    ),
+    handleResponseFixture(editFeedBoardInput, "VIEWS"),
+    plannerFixture(
+      editFeedBoardInput,
+      "VIEWS",
+      {
+        action: "edit",
+        view: "feed-board",
+        intent: "Make feed board show denser queue rows",
+      },
+      `Started view edit task for Feed Board at ${feedPluginDir}. Task session scenario-edit-view-feed-board is running.`,
+    ),
+    handleResponseFixture("Edit the feed app", "APP"),
+    plannerFixture(
+      "Edit the feed app",
+      "APP",
+      {
+        action: "create",
+        editTarget: "feed",
+        intent: "Tighten the feed app table density",
+      },
+      // This must remain distinct from the callback text. APP edit owns the
+      // visible single-delivery response, so planner prose must not escape.
+      "Planner re-render that must not be delivered for the APP edit turn.",
+      ["APP", "VIEWS", "START_CODING_TASK", "REPLY", "IGNORE", "STOP"],
+    ),
+    handleResponseFixture("Delete the remote ledger view", "VIEWS"),
+    plannerFixture(
+      "Delete the remote ledger view",
+      "VIEWS",
+      { action: "delete", view: "remote-ledger", confirm: true },
+      "Deleted Remote Ledger (@elizaos/plugin-remote-ledger). Plugin @elizaos/plugin-remote-ledger unloaded.",
+    ),
+  ];
+}
+
 export default scenario({
   id: "deterministic-app-control-nl-routing",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: appControlModelFixtures(),
+  },
   title: "Deterministic app-control natural-language routing",
   domain: "scenario-runner",
   tags: ["pr", "deterministic", "zero-cost", "app-control", "nl-routing"],
@@ -445,129 +597,6 @@ export default scenario({
         };
 
         let launchCount = 0;
-        runtime.scenarioModelFixtures?.register(
-          handleResponseFixture("Open the settings view", "VIEWS"),
-          plannerFixture(
-            "Open the settings view",
-            "VIEWS",
-            {
-              action: "show",
-              view: "settings",
-              viewType: "gui",
-            },
-            "Opened Settings.",
-          ),
-          handleResponseFixture("Search views for finance", "VIEWS"),
-          plannerFixture(
-            "Search views for finance",
-            "VIEWS",
-            {
-              action: "search",
-              query: "finance",
-              viewType: "gui",
-            },
-            'Views matching "finance" (1):\n  [91] Remote Ledger (remote-ledger) — /remote-ledger — Track finance balances and remote ledger entries.',
-          ),
-          handleResponseFixture("Launch the feed app", "APP"),
-          plannerFixture(
-            "Launch the feed app",
-            "APP",
-            {
-              action: "launch",
-              app: "feed",
-            },
-            "Launched Feed. Run ID: run-feed-nl-1.",
-          ),
-          handleResponseFixture("Relaunch the feed app", "APP"),
-          plannerFixture(
-            "Relaunch the feed app",
-            "APP",
-            {
-              action: "relaunch",
-              app: "feed",
-            },
-            "Relaunched Feed. New run ID: run-feed-nl-2.",
-          ),
-          handleResponseFixture("Stop the feed app", "APP"),
-          plannerFixture(
-            "Stop the feed app",
-            "APP",
-            {
-              action: "stop",
-              app: "feed",
-            },
-            "Feed stopped.",
-          ),
-          handleResponseFixture(loadAppsInput, "APP"),
-          plannerFixture(
-            loadAppsInput,
-            "APP",
-            {
-              action: "load_from_directory",
-              directory: appLoadDirectory,
-            },
-            `Registered 1 app from ${appLoadDirectory}:\n  - Loaded Console (@scenario/app-loaded-console)\n\nApps are registered only — none were launched.`,
-          ),
-          handleResponseFixture("Create a feed dashboard app", "APP"),
-          plannerFixture(
-            "Create a feed dashboard app",
-            "APP",
-            {
-              action: "create",
-              intent: "Create a feed dashboard app",
-            },
-            "Picking next step...",
-          ),
-          handleResponseFixture("Cancel the app create flow", "APP"),
-          plannerFixture(
-            "Cancel the app create flow",
-            "APP",
-            {
-              action: "create",
-              choice: "cancel",
-            },
-            "Canceled. No app changes made.",
-          ),
-          handleResponseFixture(editFeedBoardInput, "VIEWS"),
-          plannerFixture(
-            editFeedBoardInput,
-            "VIEWS",
-            {
-              action: "edit",
-              view: "feed-board",
-              intent: "Make feed board show denser queue rows",
-            },
-            `Started view edit task for Feed Board at ${feedPluginDir}. Task session scenario-edit-view-feed-board is running.`,
-          ),
-          handleResponseFixture("Edit the feed app", "APP"),
-          plannerFixture(
-            "Edit the feed app",
-            "APP",
-            {
-              action: "create",
-              editTarget: "feed",
-              intent: "Tighten the feed app table density",
-            },
-            // Deliberately distinct from the action's own callback text: the APP
-            // edit path opts into single delivery, so this planner bubble must
-            // never reach chat. The turn asserts the callback sentence instead.
-            "Planner re-render that must not be delivered for the APP edit turn.",
-          ),
-          handleResponseFixture("Delete the remote ledger view", "VIEWS"),
-          plannerFixture(
-            "Delete the remote ledger view",
-            "VIEWS",
-            {
-              action: "delete",
-              view: "remote-ledger",
-              // The VIEWS action declares `confirm` as schema type boolean; the
-              // strict model provider validates fixture toolCalls against that
-              // schema, so a string "true" is rejected before the handler runs.
-              confirm: true,
-            },
-            "Deleted Remote Ledger (@elizaos/plugin-remote-ledger). Plugin @elizaos/plugin-remote-ledger unloaded.",
-          ),
-        );
 
         registerAppControlHttpHandler((request) => {
           if (request.method === "GET" && request.pathname === "/api/views") {

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
@@ -29,7 +29,10 @@ type RuntimeWithScenarioModelFixtures = {
   deleteTask?: (taskId: string) => Promise<void>;
   getService?: (serviceType: string) => unknown;
   getTasks?: (query?: Record<string, unknown>) => Promise<unknown[]>;
+  evaluators: unknown[];
 };
+
+let previousEvaluators: unknown[] | null = null;
 
 function toRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -181,6 +184,18 @@ function postToolReplyFixture(
         toolCalls: [],
       },
     },
+  };
+}
+
+function toolResultRescueFixture(text: string): ScenarioModelFixture {
+  return {
+    name: `tool-result-rescue-${text.split("\n", 1)[0]}`,
+    match: {
+      modelType: "TEXT_LARGE",
+      input: { includes: text },
+      toolNames: [],
+    },
+    response: { text },
   };
 }
 
@@ -420,6 +435,12 @@ function appControlModelFixtures(): ScenarioModelFixture[] {
       { action: "delete", view: "remote-ledger", confirm: true },
       "Deleted Remote Ledger (@elizaos/plugin-remote-ledger). Plugin @elizaos/plugin-remote-ledger unloaded.",
     ),
+    toolResultRescueFixture("Launched Feed. Run ID: run-feed-nl-1."),
+    toolResultRescueFixture("Relaunched Feed. New run ID: run-feed-nl-2."),
+    toolResultRescueFixture(
+      "Registered 1 app from /tmp/eliza-app-control-nl-routing/apps:\n  - Loaded Console (@scenario/app-loaded-console)\n\nApps are registered only — none were launched.",
+    ),
+    toolResultRescueFixture("Canceled. No app changes made."),
   ];
 }
 
@@ -446,6 +467,13 @@ export default scenario({
         process.env.ELIZA_WORKSPACE_DIR = repoRoot;
         resetAppControlHttpLoopback();
         const runtime = ctx.runtime as RuntimeWithScenarioModelFixtures;
+
+        // Post-turn field evaluators are outside the app-control routing
+        // contract. Isolate them explicitly so strict diagnostics cover every
+        // model call owned by this scenario, then restore the shared runtime in
+        // cleanup.
+        previousEvaluators = runtime.evaluators;
+        runtime.evaluators = [];
 
         await fs.rm(path.dirname(appLoadDirectory), {
           force: true,
@@ -689,7 +717,12 @@ export default scenario({
     {
       type: "custom",
       name: "remove app-control source fixtures",
-      apply: async () => {
+      apply: async (ctx) => {
+        const runtime = ctx.runtime as RuntimeWithScenarioModelFixtures;
+        if (previousEvaluators !== null) {
+          runtime.evaluators = previousEvaluators;
+          previousEvaluators = null;
+        }
         await fs.rm(path.dirname(appLoadDirectory), {
           force: true,
           recursive: true,

--- a/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-app-control-nl-routing.scenario.ts
@@ -428,7 +428,7 @@ export default scenario({
   lane: "pr-deterministic",
   modelFixtures: {
     mode: "fixtures",
-    fixtures: appControlModelFixtures(),
+    fixtures: [...appControlModelFixtures()],
   },
   title: "Deterministic app-control natural-language routing",
   domain: "scenario-runner",

--- a/packages/scenario-runner/test/scenarios/deterministic-view-switching-multilingual.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-view-switching-multilingual.scenario.ts
@@ -1,6 +1,6 @@
 /**
  * Keyless coverage that view switching resolves across the navigable views in
- * every supported language. Runs on the pr-deterministic lane under the model provider.
+ * every supported language. Runs model-free on the pr-deterministic lane.
  */
 import type {
   CapturedAction,
@@ -17,6 +17,7 @@ import {
   registerAppControlHttpHandler,
   resetAppControlHttpLoopback,
 } from "./_helpers/app-control-http-loopback";
+import { expectAcceptedViewNavigationEffect } from "./_helpers/view-navigation-effect";
 
 /**
  * Exhaustive deterministic scenario matrix (#8797, acceptance criterion 4).
@@ -42,8 +43,8 @@ type CoveredView = {
 
 // The curated domain views covered by CURATED_MULTILINGUAL (calendar, wallet,
 // inbox, settings), with the label + path the loopback registry serves. The
-// VIEWS show handler echoes `label` back ("Opened <label>.") and
-// surfaces `data.view.path`, so these must match what the registry returns.
+// VIEWS show returns an internal structured navigation effect and surfaces
+// `data.view.path`, so these must match what the registry returns.
 const COVERED_VIEWS: CoveredView[] = [
   { id: "calendar", label: "Calendar", path: "/apps/calendar" },
   { id: "wallet", label: "Wallet", path: "/apps/wallet" },
@@ -84,10 +85,12 @@ function expectShowTurn(
   execution: ScenarioTurnExecution,
   view: CoveredView,
 ): string | undefined {
-  const expectedText = `Opened ${view.label}.`;
-  if (execution.responseText !== expectedText) {
-    return `expected responseText=${JSON.stringify(expectedText)}, saw ${JSON.stringify(execution.responseText)}`;
-  }
+  const effectFailure = expectAcceptedViewNavigationEffect(execution, {
+    viewId: view.id,
+    label: view.label,
+    path: view.path,
+  });
+  if (effectFailure) return effectFailure;
   const action = execution.actionsCalled.find(
     (candidate) => candidate.actionName === "VIEWS",
   ) as CapturedAction | undefined;
@@ -128,6 +131,11 @@ function expectShowTurn(
 export default scenario({
   id: "deterministic-view-switching-multilingual",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "model-free",
+    reason:
+      "Direct action turns exercise runtime contracts without model calls.",
+  },
   title:
     "Deterministic view switching across navigable views in every language",
   domain: "scenario-runner",
@@ -186,7 +194,6 @@ export default scenario({
       text: entry.phrase,
       actionName: "VIEWS",
       options: { action: "show", viewType: "gui" },
-      responseIncludesAny: [`Opened ${view.label}`],
       assertTurn: (execution: ScenarioTurnExecution) =>
         expectShowTurn(execution, view),
     };

--- a/packages/scenario-runner/test/scenarios/deterministic-view-switching-multilingual.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-view-switching-multilingual.scenario.ts
@@ -132,9 +132,8 @@ export default scenario({
   id: "deterministic-view-switching-multilingual",
   lane: "pr-deterministic",
   modelFixtures: {
-    mode: "model-free",
-    reason:
-      "Direct action turns exercise runtime contracts without model calls.",
+    mode: "fixtures",
+    fixtures: [],
   },
   title:
     "Deterministic view switching across navigable views in every language",

--- a/packages/scenario-runner/test/scenarios/deterministic-view-switching.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-view-switching.scenario.ts
@@ -1,6 +1,6 @@
 /**
  * Keyless coverage that view switching resolves across every built-in view. Runs
- * on the pr-deterministic lane under the model provider.
+ * model-free on the pr-deterministic lane.
  */
 import type {
   CapturedAction,
@@ -13,6 +13,7 @@ import {
   registerAppControlHttpHandler,
   resetAppControlHttpLoopback,
 } from "./_helpers/app-control-http-loopback";
+import { expectAcceptedViewNavigationEffect } from "./_helpers/view-navigation-effect";
 
 /**
  * End-to-end view-switching coverage for every built-in (first-party) view.
@@ -73,10 +74,12 @@ function expectShowTurn(
   execution: ScenarioTurnExecution,
   view: BuiltinView,
 ): string | undefined {
-  const expectedText = `Opened ${view.navigationLabel ?? view.label}.`;
-  if (execution.responseText !== expectedText) {
-    return `expected responseText=${JSON.stringify(expectedText)}, saw ${JSON.stringify(execution.responseText)}`;
-  }
+  const effectFailure = expectAcceptedViewNavigationEffect(execution, {
+    viewId: view.id,
+    label: view.navigationLabel ?? view.label,
+    path: view.path,
+  });
+  if (effectFailure) return effectFailure;
   const action = execution.actionsCalled.find(
     (candidate) => candidate.actionName === "VIEWS",
   ) as CapturedAction | undefined;
@@ -115,6 +118,11 @@ function expectShowTurn(
 export default scenario({
   id: "deterministic-view-switching",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "model-free",
+    reason:
+      "Direct action turns exercise runtime contracts without model calls.",
+  },
   title: "Deterministic view switching across every built-in view",
   domain: "scenario-runner",
   tags: ["pr", "deterministic", "zero-cost", "app-control", "views"],
@@ -159,7 +167,6 @@ export default scenario({
     text: `Open the ${view.label} view`,
     actionName: "VIEWS",
     options: { action: "show", view: view.id, viewType: "gui" },
-    responseIncludesAny: [`Opened ${view.navigationLabel ?? view.label}`],
     assertTurn: (execution: ScenarioTurnExecution) =>
       expectShowTurn(execution, view),
   })),

--- a/packages/scenario-runner/test/scenarios/deterministic-view-switching.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-view-switching.scenario.ts
@@ -119,9 +119,8 @@ export default scenario({
   id: "deterministic-view-switching",
   lane: "pr-deterministic",
   modelFixtures: {
-    mode: "model-free",
-    reason:
-      "Direct action turns exercise runtime contracts without model calls.",
+    mode: "fixtures",
+    fixtures: [],
   },
   title: "Deterministic view switching across every built-in view",
   domain: "scenario-runner",

--- a/packages/scenario-runner/test/scenarios/deterministic-view-voice.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-view-voice.scenario.ts
@@ -158,9 +158,8 @@ export default scenario({
   id: "deterministic-view-voice",
   lane: "pr-deterministic",
   modelFixtures: {
-    mode: "model-free",
-    reason:
-      "Direct action turns exercise runtime contracts without model calls.",
+    mode: "fixtures",
+    fixtures: [],
   },
   title: "Deterministic per-view voice-transcript navigation",
   domain: "scenario-runner",

--- a/packages/scenario-runner/test/scenarios/deterministic-view-voice.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-view-voice.scenario.ts
@@ -1,6 +1,6 @@
 /**
  * Keyless coverage of per-view voice-transcript navigation. Runs on the
- * pr-deterministic lane under the model provider.
+ * model-free on the pr-deterministic lane.
  */
 import type {
   CapturedAction,
@@ -13,6 +13,7 @@ import {
   registerAppControlHttpHandler,
   resetAppControlHttpLoopback,
 } from "./_helpers/app-control-http-loopback";
+import { expectAcceptedViewNavigationEffect } from "./_helpers/view-navigation-effect";
 
 /**
  * Per-view voice-transcript coverage (#8797, acceptance criterion 5).
@@ -108,10 +109,12 @@ function expectVoiceTurn(
   execution: ScenarioTurnExecution,
   view: VoiceView,
 ): string | undefined {
-  const expectedText = `Opened ${view.navigationLabel ?? view.label}.`;
-  if (execution.responseText !== expectedText) {
-    return `expected responseText=${JSON.stringify(expectedText)}, saw ${JSON.stringify(execution.responseText)}`;
-  }
+  const effectFailure = expectAcceptedViewNavigationEffect(execution, {
+    viewId: view.id,
+    label: view.navigationLabel ?? view.label,
+    path: view.path,
+  });
+  if (effectFailure) return effectFailure;
   const action = execution.actionsCalled.find(
     (candidate) => candidate.actionName === "VIEWS",
   ) as CapturedAction | undefined;
@@ -154,6 +157,11 @@ function expectVoiceTurn(
 export default scenario({
   id: "deterministic-view-voice",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "model-free",
+    reason:
+      "Direct action turns exercise runtime contracts without model calls.",
+  },
   title: "Deterministic per-view voice-transcript navigation",
   domain: "scenario-runner",
   tags: ["pr", "deterministic", "zero-cost", "app-control", "views", "voice"],
@@ -202,7 +210,6 @@ export default scenario({
     text: view.noun,
     actionName: "VIEWS",
     options: { action: "show", viewType: "gui" },
-    responseIncludesAny: [`Opened ${view.navigationLabel ?? view.label}`],
     assertTurn: (execution: ScenarioTurnExecution) =>
       expectVoiceTurn(execution, view),
   })),

--- a/plugins/plugin-app-control/src/actions/views-switching.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-switching.test.ts
@@ -668,10 +668,12 @@ describe("view switching — VIEWS action resolver", () => {
 			expect(result).not.toHaveProperty("userFacingText");
 			expect(result).not.toHaveProperty("verifiedUserFacing");
 			expect(result).not.toHaveProperty("turnComplete");
-			expect(JSON.parse(result?.text ?? "{}")).toMatchObject({
+			expect(JSON.parse(result?.text ?? "{}")).toEqual({
 				effect: "view_navigation",
 				status: "accepted",
 				viewId: "calendar",
+				label: "Calendar",
+				path: "/calendar",
 			});
 		});
 


### PR DESCRIPTION
# Relates to

Fixes #24069.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. `bun run verify` reached an unrelated existing `packages/agent` Biome blocker recorded below.
- [x] A reviewer can confirm the changed contract from the exact five-scenario report linked below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@7e9dfea0e1`; zero conflicts.
- [x] `bun run verify` reached `@elizaos/agent#lint:check` and stopped on pre-existing formatting/non-null-assertion diagnostics in files outside this diff; the exact focused gates for both owning packages pass.

# Risks

Low. The production action behavior is unchanged; this makes its structured internal receipt exact in tests, migrates the NL scenario from the legacy fixture bridge, and aligns direct-action scenarios with the existing response contract.

# Background

## What does this PR do?

- Makes direct VIEWS scenarios require the canonical internal `view_navigation` receipt, `transcriptVisibility: "internal"`, and `modelReplyRequired: true`, while rejecting legacy user-facing fields.
- Keeps visible acknowledgement prose on the real post-tool planner boundary and supplies an exact strict fixture for `Opened Settings.`
- Replaces the NL scenario's runtime fixture registration with an authored serializable `modelFixtures` manifest and exact per-turn planner tool inventories.
- Declares the direct app-control action scenario model-free and the three generated direct view matrices as strict zero-call fixture manifests so they no longer report `legacy-fallback`.
- Tightens plugin-app-control's contract test to reject extra/dual receipt shapes.

## What kind of change is this?

Bug fix (non-breaking test/runtime-contract correction).

# Documentation changes needed?

No. This restores tests to the already documented and implemented contract.

# Testing

## Where should a reviewer start?

Open the attached scenario report and verify 5/5 passed. The app-control action scenario must report `model-free`; the NL scenario and three generated view matrices must report `strict-fixtures` with zero failed assertions. The three generated matrices must have zero model calls.

## Detailed testing steps

```bash
SCENARIO_USE_DETERMINISTIC_MODEL=1 bun packages/scenario-runner/src/cli.ts run packages/scenario-runner/test/scenarios \
  --scenario deterministic-app-control-actions,deterministic-app-control-nl-routing,deterministic-view-switching,deterministic-view-switching-multilingual,deterministic-view-voice \
  --lane pr-deterministic --report /tmp/24069-report.json --run-dir /tmp/24069-run

bun run --cwd plugins/plugin-app-control test -- \
  src/actions/views-switching.test.ts src/runtime/acknowledgement-both-paths.test.ts
bun run --cwd packages/scenario-runner test:unit -- \
  src/schema-strict.test.ts src/model-fixture-migration.test.ts src/model-fixtures.test.ts
bun run --cwd plugins/plugin-app-control typecheck
bun run --cwd packages/scenario-runner typecheck
```

Results: exact scenarios 5/5 passed; focused plugin tests 197/197; strict fixture unit tests 24/24; both package typechecks passed; focused Biome check passed.

# Evidence Gate

<!-- evidence-head:5e17467b714cbe4ebbb279179729f6ae00ad0119 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI files or pixels changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI files or pixels changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI interaction changed.
<!-- evidence-row:backend-logs -->
- [x] [Exact real-runtime five-scenario report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24113-scenario-report-strict-clean.json).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network client changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no production prompt/model/action behavior changed; this PR repairs deterministic fixture and assertion contracts.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this test-contract change does not produce persistent domain state such as DB rows, memories, files, or scheduled items.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no production prompt or model behavior changed. The strict deterministic model manifest is itself the changed test contract.

## Backend + frontend logs

[Exact five-scenario JSON report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24113-scenario-report-strict-clean.json), run `afccdc08-481e-47cc-b071-ac5770621c00`, records 5 passed / 0 failed / 0 skipped. It reports app-control actions as `model-free`; the NL scenario and three generated view matrices are `strict-fixtures`. The three generated matrices record zero calls. The NL path consumes all 31 authored fixtures exactly once with zero unexpected, unused, or over-consumed calls; unrelated post-turn evaluators are explicitly isolated and restored in cleanup.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface changed.

## Audio / voice walkthrough

N/A - the voice scenario supplies text transcripts directly; no TTS/STT/audio service changed.

## Known gaps / failures

`bun run verify` stops at the unrelated `@elizaos/agent#lint:check` gate. A direct rerun reproduces existing Biome findings in files outside this PR, including forbidden non-null assertions in `packages/agent/src/api/interactions-routes.test.ts` and formatting/import-order findings in `packages/agent/src/actions/database.ts`, `database.surrogate.test.ts`, `knowledge.ts`, and `api/accounts-routes.ts`. This branch does not touch `packages/agent`; both changed owning-package typechecks, focused Biome, 221 focused tests, and the exact five-scenario run pass.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-desktop-24069-view-contract]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
