### PR TITLE
fix(companion): validate deterministic mood contract

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1039,6 +1039,7 @@
         "@elizaos/plugin-cli-inference": "workspace:*",
         "@elizaos/plugin-coding-tools": "workspace:*",
         "@elizaos/plugin-commands": "workspace:*",
+        "@elizaos/plugin-companion": "workspace:*",
         "@elizaos/plugin-github": "workspace:*",
         "@elizaos/plugin-health": "workspace:*",
         "@elizaos/plugin-local-inference": "workspace:*",

--- a/packages/scenario-runner/README.md
+++ b/packages/scenario-runner/README.md
@@ -196,8 +196,8 @@ task was killed.
 
 The rollout is staged: undeclared scenarios temporarily retain the legacy
 resolver and reports mark them `legacy-fallback`; declared attempts report
-`strict-fixtures` or `model-free`. The migration ratchet currently records 48
-strict or explicitly model-free and 72 legacy `pr-deterministic` scenario
+`strict-fixtures` or `model-free`. The migration ratchet currently records 49
+strict or explicitly model-free and 71 legacy `pr-deterministic` scenario
 sources across the repository. The declared rows contain only direct action/API work or
 wait/seed/final checks and are validated again by the real executor before each
 attempt. The legacy count may only decrease, and the epic is complete only when

--- a/packages/scenario-runner/package.json
+++ b/packages/scenario-runner/package.json
@@ -91,6 +91,7 @@
     "@elizaos/plugin-cli-inference": "workspace:*",
     "@elizaos/plugin-coding-tools": "workspace:*",
     "@elizaos/plugin-commands": "workspace:*",
+    "@elizaos/plugin-companion": "workspace:*",
     "@elizaos/plugin-native-filesystem": "workspace:*",
     "@elizaos/plugin-github": "workspace:*",
     "@elizaos/plugin-health": "workspace:*",

--- a/packages/scenario-runner/src/model-fixture-migration.test.ts
+++ b/packages/scenario-runner/src/model-fixture-migration.test.ts
@@ -184,7 +184,7 @@ describe("scenario model fixture migration", () => {
       strictOrModelFree: deterministic.length - legacy.length,
       legacy: legacy.length,
       total: deterministic.length,
-    }).toEqual({ strictOrModelFree: 48, legacy: 72, total: 120 });
+    }).toEqual({ strictOrModelFree: 49, legacy: 71, total: 120 });
   }, 120_000);
 
   it("recognizes authored properties while ignoring comments and setup strings", () => {

--- a/packages/scenario-runner/src/model-fixture-migration.test.ts
+++ b/packages/scenario-runner/src/model-fixture-migration.test.ts
@@ -8,7 +8,7 @@ import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
-const MAX_LEGACY_PR_DETERMINISTIC_SCENARIOS = 73;
+const MAX_LEGACY_PR_DETERMINISTIC_SCENARIOS = 72;
 
 type ScenarioSourceClassification = {
   deterministic: boolean;

--- a/packages/scenario-runner/test/scenarios/deterministic-companion-device.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-companion-device.scenario.ts
@@ -6,6 +6,7 @@
  * credential leaves the process.
  */
 import type { AgentRuntime } from "@elizaos/core";
+import companionPlugin from "@elizaos/plugin-companion";
 import { scenario } from "@elizaos/scenario-runner/schema";
 
 const PAIRING_TOKEN = "companion-scenario-token";
@@ -46,6 +47,10 @@ function successfulAction(
 
 export default scenario({
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [],
+  },
   id: "deterministic-companion-device",
   title: "Companion device actions cross the authenticated WebSocket bridge",
   domain: "companion",
@@ -53,14 +58,13 @@ export default scenario({
   description:
     "Loads the production companion plugin, completes the device handshake, changes mood, and reads status through a loopback protocol peer.",
 
-  requires: { plugins: ["@elizaos/plugin-companion"] },
   isolation: "per-scenario",
 
   seed: [
     {
       type: "custom",
       name: "start authenticated companion protocol peer",
-      apply: (ctx) => {
+      apply: async (ctx) => {
         deviceServer?.stop(true);
         receivedFrames.length = 0;
         let mood = "idle";
@@ -137,6 +141,7 @@ export default scenario({
         runtime.setSetting("COMPANION_PONG_TIMEOUT_MS", "1000");
         runtime.setSetting("COMPANION_COMMAND_TIMEOUT_MS", "2000");
         runtime.setSetting("COMPANION_RECONNECT_DELAY_MS", "60000");
+        await runtime.registerPlugin(companionPlugin);
       },
     },
   ],
@@ -161,7 +166,7 @@ export default scenario({
       name: "set the companion mood",
       actionName: SET_MOOD,
       text: "Show a curious mood.",
-      options: { mood: "curious" },
+      options: { parameters: { mood: "curious" } },
       assertTurn: (turn) => {
         const result = successfulAction(turn, SET_MOOD);
         if (!result?.success) {

--- a/plugins/plugin-companion/src/actions.ts
+++ b/plugins/plugin-companion/src/actions.ts
@@ -25,12 +25,18 @@ function failureText(error: unknown): string {
 }
 
 /**
- * Extracts the requested mood: an explicit `mood` option from the planner
- * wins; otherwise the last quoted or trailing word of the message text is NOT
+ * Extracts the requested mood from the runtime's validated `parameters`
+ * envelope. The last quoted or trailing word of the message text is NOT
  * guessed — a missing parameter is an explicit failure, not a default mood.
  */
 function requestedMood(options?: Record<string, unknown>): string | undefined {
-  const mood = options?.mood;
+  const parameters = options?.parameters;
+  const mood =
+    parameters !== null &&
+    typeof parameters === "object" &&
+    !Array.isArray(parameters)
+      ? (parameters as Record<string, unknown>).mood
+      : undefined;
   return typeof mood === "string" && mood.trim().length > 0
     ? mood.trim()
     : undefined;
@@ -42,6 +48,17 @@ export const setCompanionMoodAction: Action = {
     "Set the companion device's displayed mood. Requires the `mood` parameter; the device confirms or rejects the mood.",
   descriptionCompressed: "Set the companion device mood.",
   tags: ["capability:send"],
+  parameters: [
+    {
+      name: "mood",
+      description:
+        "Mood identifier accepted by the companion firmware, such as happy, sleepy, or curious.",
+      descriptionCompressed: "Firmware mood identifier.",
+      required: true,
+      schema: { type: "string", minLength: 1, pattern: "\\S" },
+      examples: ["happy", "sleepy", "curious"],
+    },
+  ],
   validate: async (runtime) => companionService(runtime) !== null,
   handler: async (
     runtime,

--- a/plugins/plugin-companion/src/companion.test.ts
+++ b/plugins/plugin-companion/src/companion.test.ts
@@ -6,7 +6,11 @@
  * provider against it. No hardware, no vi.mock, no network egress.
  */
 import type { AddressInfo } from "node:net";
-import { ElizaError, type IAgentRuntime } from "@elizaos/core";
+import {
+  ElizaError,
+  type IAgentRuntime,
+  validateActionParams,
+} from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 import { type WebSocket as DeviceSocket, WebSocketServer } from "ws";
 import { getCompanionStatusAction, setCompanionMoodAction } from "./actions";
@@ -320,7 +324,7 @@ describe("commands (UC1/UC2)", () => {
       stub.runtime,
       NO_MESSAGE,
       undefined,
-      { mood: "angry" },
+      { parameters: { mood: "angry" } },
     );
     expect(result?.success).toBe(false);
     expect(result?.text).toContain("invalid mood");
@@ -364,6 +368,64 @@ describe("commands (UC1/UC2)", () => {
     );
     expect(result?.success).toBe(false);
     expect(result?.text).toContain("mood");
+  });
+
+  it("SET_COMPANION_MOOD rejects missing, non-string, and blank planner payloads", async () => {
+    const device = await startMockDevice();
+    const { service, stub } = await startService(device.url);
+    await until(() => service.isReady());
+
+    for (const parameters of [
+      {},
+      { mood: { name: "curious" } },
+      { mood: "   " },
+    ]) {
+      const validation = validateActionParams(
+        setCompanionMoodAction,
+        parameters,
+      );
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).not.toHaveLength(0);
+      const result = await setCompanionMoodAction.handler(
+        stub.runtime,
+        NO_MESSAGE,
+        undefined,
+        { parameters },
+      );
+      expect(result?.success).toBe(false);
+      expect(result?.text).toContain("requires a `mood` parameter");
+    }
+    expect(
+      device.received.filter((frame) => frame.type === "SET_MOOD"),
+    ).toHaveLength(0);
+  });
+
+  it("SET_COMPANION_MOOD accepts the canonical planner parameter envelope", async () => {
+    const device = await startMockDevice();
+    const { service, stub } = await startService(device.url);
+    await until(() => service.isReady());
+
+    expect(setCompanionMoodAction.parameters).toEqual([
+      expect.objectContaining({
+        name: "mood",
+        required: true,
+        schema: expect.objectContaining({
+          type: "string",
+          minLength: 1,
+          pattern: "\\S",
+        }),
+      }),
+    ]);
+    const result = await setCompanionMoodAction.handler(
+      stub.runtime,
+      NO_MESSAGE,
+      undefined,
+      { parameters: { mood: " curious " } },
+    );
+    expect(result).toMatchObject({
+      success: true,
+      data: { mood: "curious" },
+    });
   });
 });
 


### PR DESCRIPTION
# Relates to

Fixes #24071

- [x] Targets `develop` and is rebased onto `origin/develop` at `7e9dfea0e1` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the unrelated root blocker is recorded below.
- [x] The inline strict-run receipt below proves the production action and device-status readback.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts.
- [x] Root verify was run; the exact unrelated workspace lint blocker is documented below.

# Risks

Low. The action now declares the parameter contract the production planner already expects and reads only the canonical validated `options.parameters` envelope. Existing direct callers using the undocumented flat envelope must move to the production contract. The device remains authoritative for its supported mood vocabulary.

# Background

## What does this PR do?

- Declares `SET_COMPANION_MOOD.mood` as a required non-blank string action parameter.
- Reads the mood from the runtime's validated `parameters` envelope.
- Adds missing/non-string/blank payload coverage plus device-rejected mood coverage.
- Configures the loopback peer before registering the production companion plugin, preventing the prior missing-URL service-start failure.
- Migrates `deterministic-companion-device` from `legacy-fallback` to a serializable strict fixture manifest. It has no model calls, so the manifest is intentionally empty and any unexpected model call fails closed.
- Adds the scenario runner's direct workspace dependency on `@elizaos/plugin-companion`.

## What kind of change is this?

Bug fix (non-breaking for the documented production action contract).

# Documentation changes needed?

No. The plugin README already documents `mood` as required and the device as the validation authority.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-companion/src/actions.ts`
2. `packages/scenario-runner/test/scenarios/deterministic-companion-device.scenario.ts`
3. The strict-run receipt below

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-companion test
bun run --cwd plugins/plugin-companion typecheck
bun run --cwd plugins/plugin-companion lint:check
bun test packages/scenario-runner/src/model-fixtures.test.ts
bun run --cwd packages/scenario-runner build
TZ=UTC SCENARIO_USE_DETERMINISTIC_MODEL=1 bun --conditions eliza-source packages/scenario-runner/src/cli.ts run packages/scenario-runner/test/scenarios --scenario deterministic-companion-device --report /tmp/report.json --run-dir /tmp/run
git diff --check origin/develop...HEAD
```

Results: companion 18/18; fixture-manifest 6/6; migration ratchet 2/2; package typecheck/lint/build pass; exact strict scenario 1/1.

# Evidence Gate

<!-- evidence-head:668e9cb039a9fb9b2f34804ba20b0232e029bb20 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI flow changes.
<!-- evidence-row:backend-logs -->
- [x] Production service/action path log:

```text
CompanionService: registered device scenario-esp32 (scenario-fw 1.0.0)
[eliza-scenarios] ✓ deterministic-companion-device passed (304ms)
Scenario run c549a875-e354-4bc1-9238-240fec079ae5: 1 passed, 0 failed, 0 skipped
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - this issue is specifically the keyless direct-action strict-fixture lane; the manifest contains zero model calls and fails closed on any unexpected call.
<!-- evidence-row:domain-artifacts -->
- [x] Action receipt plus independent status readback:

```text
SET_COMPANION_MOOD request: parameters={"parameters":{"mood":"curious"}}
SET_COMPANION_MOOD receipt: success=true data={"mood":"curious"} text="Companion mood set to curious."
GET_COMPANION_STATUS readback: success=true connected=true deviceId="scenario-esp32" firmware="scenario-fw 1.0.0" mood="curious"
Model-call ledger: mode="strict-fixtures" registeredCalls=[] unexpectedCalls=[]
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text changed.

# Evidence Details

Exact post-rebase run: `c549a875-e354-4bc1-9238-240fec079ae5`.

```text
CompanionService: registered device scenario-esp32 (scenario-fw 1.0.0)
[eliza-scenarios] ✓ deterministic-companion-device passed (304ms)
Totals: 1 passed, 0 failed, 0 skipped of 1
```

Strict fixture diagnostics and domain receipt:

```json
{
  "status": "passed",
  "modelFixtureMode": "strict-fixtures",
  "unexpectedCalls": [],
  "fixtures": [],
  "actions": [
    {
      "actionName": "SET_COMPANION_MOOD",
      "parameters": { "parameters": { "mood": "curious" } },
      "success": true,
      "data": { "mood": "curious" },
      "text": "Companion mood set to curious."
    },
    {
      "actionName": "GET_COMPANION_STATUS",
      "success": true,
      "data": {
        "connected": true,
        "deviceId": "scenario-esp32",
        "firmware": "scenario-fw 1.0.0",
        "mood": "curious",
        "status": { "uptimeSeconds": 42 }
      }
    }
  ]
}
```

## Real LLM-call trajectory

N/A - direct action turns deliberately avoid a model. Strict mode reports zero fixtures, zero calls, and zero unexpected calls; an accidental model path is a hard failure.

## Backend + frontend logs

Backend path and receipt are inline above. Frontend: N/A - no frontend surface.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A - no audio, voice, TTS, or STT changes.

## Known gaps / failures

- `bun run verify` reached the workspace Turbo `typecheck lint:check` gate and failed on unrelated pre-existing Biome formatting errors in `packages/agent` (for example `src/actions/database.ts`, `src/actions/knowledge.ts`, and `src/api/accounts-routes.ts`). The changed `@elizaos/plugin-companion` lint task passed in that same run. No failing diagnostic named a changed file.
- A standalone scenario-runner typecheck also resolves unrelated optional workspaces that are not built in a fresh checkout and reported their missing declarations; the scenario-runner build and the exact executable scenario both passed.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [standujar/companion-mood-validation]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
