### PR TITLE
fix(agent): stop refreshRegistry from adopting a pre-refresh load

### DIFF
--- a/packages/agent/src/services/registry-client-refresh.test.ts
+++ b/packages/agent/src/services/registry-client-refresh.test.ts
@@ -5,13 +5,19 @@
  * nor let it stamp a fresh TTL over the refreshed result afterwards.
  *
  * The registry caches are module-level, so every case re-imports the module
- * through `vi.resetModules()`.
+ * through `vi.resetModules()`. The listing-route case uses the real refresh
+ * function so cache teardown failures are covered at the HTTP boundary too.
  */
 
 import fsp from "node:fs/promises";
+import type http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  handleRegistryRoutes,
+  type RegistryRouteContext,
+} from "../api/registry-routes.ts";
 
 let stateDir: string;
 let fetchImpl: () => Promise<Map<string, unknown>>;
@@ -40,8 +46,10 @@ vi.mock("./registry-client-network.ts", () => ({
 }));
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-const PAYLOAD_A = () => new Map([["plugin-a", { name: "plugin-a" }]]);
-const PAYLOAD_B = () => new Map([["plugin-b", { name: "plugin-b" }]]);
+const PAYLOAD_A = () =>
+  new Map([["plugin-a", { name: "plugin-a", npm: { v2Version: null } }]]);
+const PAYLOAD_B = () =>
+  new Map([["plugin-b", { name: "plugin-b", npm: { v2Version: null } }]]);
 
 async function loadModule() {
   vi.resetModules();
@@ -123,27 +131,82 @@ describe("refreshRegistry", () => {
   });
 
   it.each(["EACCES", "EROFS"] as const)(
-    "rejects a %s cache removal failure with a typed error",
+    "still returns fresh network data when cache removal fails with %s",
     async (code) => {
+      const cachePath = path.join(stateDir, "cache", "registry.json");
+      await fsp.mkdir(path.dirname(cachePath), { recursive: true });
+      await fsp.writeFile(
+        cachePath,
+        JSON.stringify({
+          fetchedAt: Date.now(),
+          plugins: [...PAYLOAD_A().entries()],
+        }),
+      );
+      fetchImpl = async () => PAYLOAD_B();
       const cause = Object.assign(new Error(`unlink failed: ${code}`), {
         code,
       });
       vi.spyOn(fsp, "unlink").mockRejectedValueOnce(cause);
       const registry = await loadModule();
 
-      const error = await registry.refreshRegistry().catch((caught) => caught);
+      const refreshed = await registry.refreshRegistry();
 
-      expect(error).toBeInstanceOf(registry.RegistryCacheInvalidationError);
-      expect(error).toMatchObject({
-        name: "RegistryCacheInvalidationError",
-        code: "REGISTRY_CACHE_INVALIDATION_FAILED",
-        cause,
-      });
-      expect(fetchCalls).toBe(0);
+      expect([...refreshed.keys()]).toEqual(["plugin-b"]);
+      expect([...(await registry.getRegistryPlugins()).keys()]).toEqual([
+        "plugin-b",
+      ]);
+      expect(fetchCalls).toBe(1);
     },
   );
 
-  it("does not abandon an in-flight load when cache removal fails", async () => {
+  it("keeps GET /api/registry/plugins available when cache removal fails", async () => {
+    const cachePath = path.join(stateDir, "cache", "registry.json");
+    await fsp.mkdir(path.dirname(cachePath), { recursive: true });
+    await fsp.writeFile(
+      cachePath,
+      JSON.stringify({
+        fetchedAt: Date.now(),
+        plugins: [...PAYLOAD_A().entries()],
+      }),
+    );
+    fetchImpl = async () => PAYLOAD_B();
+    vi.spyOn(fsp, "unlink").mockRejectedValueOnce(
+      Object.assign(new Error("permission denied"), { code: "EACCES" }),
+    );
+    const registry = await loadModule();
+    const json = vi.fn();
+    const error = vi.fn();
+    const res = {} as http.ServerResponse;
+    const ctx = {
+      req: { method: "GET", url: "/api/registry/plugins" },
+      res,
+      method: "GET",
+      pathname: "/api/registry/plugins",
+      url: new URL("http://localhost/api/registry/plugins"),
+      json,
+      error,
+      getPluginManager: () => ({
+        refreshRegistry: registry.refreshRegistry,
+        listInstalledPlugins: async () => [],
+        getRegistryPlugin: async () => null,
+        searchRegistry: async () => [],
+      }),
+      getLoadedPluginNames: () => [],
+      getBundledPluginIds: () => new Set<string>(),
+      classifyRegistryPluginRelease: () => ({ status: "compatible" }),
+    } as unknown as RegistryRouteContext;
+
+    await expect(handleRegistryRoutes(ctx)).resolves.toBe(true);
+
+    expect(error).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(res, {
+      count: 1,
+      plugins: [expect.objectContaining({ name: "plugin-b" })],
+    });
+    expect(fetchCalls).toBe(1);
+  });
+
+  it("still supersedes an in-flight load when cache removal fails", async () => {
     let releaseFetch: (() => void) | undefined;
     const fetchGate = new Promise<void>((resolve) => {
       releaseFetch = resolve;
@@ -155,29 +218,22 @@ describe("refreshRegistry", () => {
     const registry = await loadModule();
     const first = registry.getRegistryPlugins();
     while (fetchCalls === 0) await sleep(1);
+    fetchImpl = async () => PAYLOAD_B();
 
     const cause = Object.assign(new Error("permission denied"), {
       code: "EACCES",
     });
     vi.spyOn(fsp, "unlink").mockRejectedValueOnce(cause);
-    const refresh = registry.refreshRegistry().catch((caught) => caught);
-    await sleep(10);
-    const second = registry.getRegistryPlugins();
-    // `getRegistryPlugins` checks the file tier before the shared network slot.
-    // Keep the first fetch gated until the second caller has reached that slot.
-    await sleep(50);
+    const refreshed = await registry.refreshRegistry();
+
+    expect([...refreshed.keys()]).toEqual(["plugin-b"]);
+    expect(fetchCalls).toBe(2);
     releaseFetch?.();
 
-    const [firstResult, secondResult, refreshError] = await Promise.all([
-      first,
-      second,
-      refresh,
+    expect([...(await first).keys()]).toEqual(["plugin-a"]);
+    expect([...(await registry.getRegistryPlugins()).keys()]).toEqual([
+      "plugin-b",
     ]);
-    expect(refreshError).toBeInstanceOf(
-      registry.RegistryCacheInvalidationError,
-    );
-    expect(fetchCalls).toBe(1);
-    expect(secondResult).toBe(firstResult);
   });
 
   it("does not publish a file-cache read that began before refresh", async () => {

--- a/packages/agent/src/services/registry-client-refresh.test.ts
+++ b/packages/agent/src/services/registry-client-refresh.test.ts
@@ -1,0 +1,219 @@
+/**
+ * `refreshRegistry` clears the caches and then delegates to
+ * `getRegistryPlugins`, which returns any load that is already in flight. That
+ * load carries a pre-refresh snapshot, so a force-refresh must not adopt it —
+ * nor let it stamp a fresh TTL over the refreshed result afterwards.
+ *
+ * The registry caches are module-level, so every case re-imports the module
+ * through `vi.resetModules()`.
+ */
+
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let stateDir: string;
+let fetchImpl: () => Promise<Map<string, unknown>>;
+let fetchCalls = 0;
+
+vi.mock("../config/paths.ts", () => ({
+  resolveStateDir: () => stateDir,
+}));
+
+vi.mock("../config/config.ts", () => ({
+  loadElizaConfig: () => ({}),
+  saveElizaConfig: () => {},
+}));
+
+vi.mock("./registry-client-local.ts", () => ({
+  applyLocalWorkspaceApps: async () => {},
+  applyNodeModulePlugins: async () => {},
+}));
+
+vi.mock("./registry-client-network.ts", () => ({
+  fetchFromNetwork: async () => {
+    fetchCalls += 1;
+    return fetchImpl();
+  },
+  isExpectedRegistryNetworkFallback: () => true,
+}));
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const PAYLOAD_A = () => new Map([["plugin-a", { name: "plugin-a" }]]);
+const PAYLOAD_B = () => new Map([["plugin-b", { name: "plugin-b" }]]);
+
+async function loadModule() {
+  vi.resetModules();
+  return import("./registry-client.ts");
+}
+
+beforeEach(async () => {
+  stateDir = await fsp.mkdtemp(path.join(os.tmpdir(), "registry-refresh-"));
+  fetchCalls = 0;
+  fetchImpl = async () => PAYLOAD_A();
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await fsp.rm(stateDir, { recursive: true, force: true });
+});
+
+describe("refreshRegistry", () => {
+  it("does not adopt a load that started before the refresh", async () => {
+    fetchImpl = async () => {
+      await sleep(200);
+      return PAYLOAD_A();
+    };
+    const { getRegistryPlugins, refreshRegistry } = await loadModule();
+
+    const inFlight = getRegistryPlugins();
+    await sleep(20);
+    fetchImpl = async () => PAYLOAD_B();
+
+    const refreshed = await refreshRegistry();
+    expect([...refreshed.keys()]).toEqual(["plugin-b"]);
+
+    // The refreshed snapshot must also survive the older load completing.
+    expect([...(await getRegistryPlugins()).keys()]).toEqual(["plugin-b"]);
+    await inFlight;
+    expect([...(await getRegistryPlugins()).keys()]).toEqual(["plugin-b"]);
+  });
+
+  it("still refetches when no load is in flight", async () => {
+    const { refreshRegistry } = await loadModule();
+
+    const refreshed = await refreshRegistry();
+
+    expect([...refreshed.keys()]).toEqual(["plugin-a"]);
+    expect(fetchCalls).toBe(1);
+  });
+
+  it("still shares one load between concurrent callers", async () => {
+    fetchImpl = async () => {
+      await sleep(50);
+      return PAYLOAD_A();
+    };
+    const { getRegistryPlugins } = await loadModule();
+
+    const [first, second, third] = await Promise.all([
+      getRegistryPlugins(),
+      getRegistryPlugins(),
+      getRegistryPlugins(),
+    ]);
+
+    expect(fetchCalls).toBe(1);
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+  });
+
+  it("still serves a fresh file cache without a network call", async () => {
+    await fsp.mkdir(path.join(stateDir, "cache"), { recursive: true });
+    await fsp.writeFile(
+      path.join(stateDir, "cache", "registry.json"),
+      JSON.stringify({
+        fetchedAt: Date.now(),
+        plugins: [["plugin-file", { name: "plugin-file" }]],
+      }),
+    );
+    const { getRegistryPlugins } = await loadModule();
+
+    expect([...(await getRegistryPlugins()).keys()]).toEqual(["plugin-file"]);
+    expect(fetchCalls).toBe(0);
+  });
+
+  it.each(["EACCES", "EROFS"] as const)(
+    "rejects a %s cache removal failure with a typed error",
+    async (code) => {
+      const cause = Object.assign(new Error(`unlink failed: ${code}`), {
+        code,
+      });
+      vi.spyOn(fsp, "unlink").mockRejectedValueOnce(cause);
+      const registry = await loadModule();
+
+      const error = await registry.refreshRegistry().catch((caught) => caught);
+
+      expect(error).toBeInstanceOf(registry.RegistryCacheInvalidationError);
+      expect(error).toMatchObject({
+        name: "RegistryCacheInvalidationError",
+        code: "REGISTRY_CACHE_INVALIDATION_FAILED",
+        cause,
+      });
+      expect(fetchCalls).toBe(0);
+    },
+  );
+
+  it("does not abandon an in-flight load when cache removal fails", async () => {
+    let releaseFetch: (() => void) | undefined;
+    const fetchGate = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    fetchImpl = async () => {
+      await fetchGate;
+      return PAYLOAD_A();
+    };
+    const registry = await loadModule();
+    const first = registry.getRegistryPlugins();
+    while (fetchCalls === 0) await sleep(1);
+
+    const cause = Object.assign(new Error("permission denied"), {
+      code: "EACCES",
+    });
+    vi.spyOn(fsp, "unlink").mockRejectedValueOnce(cause);
+    const refresh = registry.refreshRegistry().catch((caught) => caught);
+    await sleep(10);
+    const second = registry.getRegistryPlugins();
+    // `getRegistryPlugins` checks the file tier before the shared network slot.
+    // Keep the first fetch gated until the second caller has reached that slot.
+    await sleep(50);
+    releaseFetch?.();
+
+    const [firstResult, secondResult, refreshError] = await Promise.all([
+      first,
+      second,
+      refresh,
+    ]);
+    expect(refreshError).toBeInstanceOf(
+      registry.RegistryCacheInvalidationError,
+    );
+    expect(fetchCalls).toBe(1);
+    expect(secondResult).toBe(firstResult);
+  });
+
+  it("does not publish a file-cache read that began before refresh", async () => {
+    const cachePath = path.join(stateDir, "cache", "registry.json");
+    const staleCache = JSON.stringify({
+      fetchedAt: Date.now(),
+      plugins: [...PAYLOAD_A().entries()],
+    });
+    await fsp.mkdir(path.dirname(cachePath), { recursive: true });
+    await fsp.writeFile(cachePath, staleCache);
+
+    let signalReadStarted: (() => void) | undefined;
+    const readStarted = new Promise<void>((resolve) => {
+      signalReadStarted = resolve;
+    });
+    let releaseRead: (() => void) | undefined;
+    const readGate = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    vi.spyOn(fsp, "readFile").mockImplementationOnce(async () => {
+      signalReadStarted?.();
+      await readGate;
+      return staleCache;
+    });
+    fetchImpl = async () => PAYLOAD_B();
+    const registry = await loadModule();
+
+    const staleCaller = registry.getRegistryPlugins();
+    await readStarted;
+    const refreshed = await registry.refreshRegistry();
+    expect([...refreshed.keys()]).toEqual(["plugin-b"]);
+
+    releaseRead?.();
+    expect([...(await staleCaller).keys()]).toEqual(["plugin-a"]);
+    expect([...(await registry.getRegistryPlugins()).keys()]).toEqual([
+      "plugin-b",
+    ]);
+  });
+});

--- a/packages/agent/src/services/registry-client.ts
+++ b/packages/agent/src/services/registry-client.ts
@@ -70,6 +70,18 @@ export type {
   RegistrySearchResult,
 } from "./registry-client-types.ts";
 
+export class RegistryCacheInvalidationError extends Error {
+  readonly code = "REGISTRY_CACHE_INVALIDATION_FAILED" as const;
+
+  constructor(
+    readonly cachePath: string,
+    cause: unknown,
+  ) {
+    super(`Failed to remove registry cache at ${cachePath}`, { cause });
+    this.name = "RegistryCacheInvalidationError";
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Cache state
 // ---------------------------------------------------------------------------
@@ -80,6 +92,12 @@ let memoryCache: {
   ttlMs?: number;
 } | null = null;
 let registryLoadPromise: Promise<Map<string, RegistryPluginInfo>> | null = null;
+/**
+ * Bumped every time the registry caches are invalidated. A load that started
+ * before the bump carries a pre-invalidation snapshot, so it must not publish
+ * that snapshot (or stamp a fresh TTL over it) once it finally resolves.
+ */
+let registryGeneration = 0;
 
 const LOCAL_FALLBACK_CACHE_TTL_MS = 5 * 60_000;
 
@@ -250,11 +268,18 @@ export async function getRegistryPlugins(): Promise<
     return memoryCache.plugins;
   }
 
+  const fileReadGeneration = registryGeneration;
   const fromFile = await readFileCache();
   if (fromFile) {
     await applyLocalWorkspaceApps(fromFile);
     await applyNodeModulePlugins(fromFile);
     await mergeCustomEndpoints(fromFile, getConfiguredEndpoints());
+
+    // A refresh can unlink the cache while an earlier read still owns an open
+    // file handle. Return that snapshot only to its original caller; publishing
+    // it would replace the post-refresh memory cache with stale disk state.
+    if (fileReadGeneration !== registryGeneration) return fromFile;
+
     memoryCache = { plugins: fromFile, fetchedAt: Date.now() };
     return fromFile;
   }
@@ -263,7 +288,8 @@ export async function getRegistryPlugins(): Promise<
     return registryLoadPromise;
   }
 
-  registryLoadPromise = (async () => {
+  const generation = registryGeneration;
+  const load: Promise<Map<string, RegistryPluginInfo>> = (async () => {
     logger.info("[registry-client] Fetching plugin registry...");
     let plugins: Map<string, RegistryPluginInfo>;
     let usedLocalFallback = false;
@@ -286,6 +312,11 @@ export async function getRegistryPlugins(): Promise<
     await mergeCustomEndpoints(plugins, getConfiguredEndpoints());
     logger.info(`[registry-client] Loaded ${plugins.size} plugins`);
 
+    // The caches were invalidated after this load started, so this snapshot is
+    // already known to be stale. Hand it to the callers that are awaiting it,
+    // but never publish it.
+    if (generation !== registryGeneration) return plugins;
+
     memoryCache = {
       plugins,
       fetchedAt: Date.now(),
@@ -299,22 +330,58 @@ export async function getRegistryPlugins(): Promise<
 
     return plugins;
   })().finally(() => {
-    registryLoadPromise = null;
+    // Only clear the slot if it is still this load's; an invalidation may have
+    // already replaced it with a newer one.
+    if (registryLoadPromise === load) registryLoadPromise = null;
   });
+  registryLoadPromise = load;
 
-  return registryLoadPromise;
+  return load;
+}
+
+/**
+ * Drop every cached registry snapshot, including one that is still loading.
+ * Clearing `memoryCache` alone is not enough: an in-flight load returns its
+ * pre-invalidation snapshot to the refresher and then republishes it with a
+ * fresh TTL, which suppresses later refreshes for the full cache lifetime.
+ */
+function invalidateRegistryCaches(): void {
+  memoryCache = null;
+  registryLoadPromise = null;
+  registryGeneration += 1;
+}
+
+function hasFilesystemErrorCode(error: unknown, code: string): boolean {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as { code?: unknown }).code === code
+  );
+}
+
+async function removeRegistryFileCache(): Promise<void> {
+  const filePath = cacheFilePath();
+  try {
+    await fs.unlink(filePath);
+  } catch (error) {
+    // error-policy:J2 A missing cache is the only successful no-op. Permission,
+    // read-only filesystem, and other I/O failures retain their cause and gain
+    // a stable registry-specific type for callers and route boundaries.
+    if (hasFilesystemErrorCode(error, "ENOENT")) return;
+    throw new RegistryCacheInvalidationError(filePath, error);
+  }
 }
 
 /** Force-refresh from network. */
 export async function refreshRegistry(): Promise<
   Map<string, RegistryPluginInfo>
 > {
-  memoryCache = null;
-  try {
-    await fs.unlink(cacheFilePath());
-  } catch {
-    // Missing cache files are fine; the network refresh below repopulates it.
-  }
+  // Remove the durable snapshot before invalidating the usable in-memory
+  // state. If removal fails, refresh rejects without abandoning an in-flight
+  // load or leaving the process cache half-invalidated.
+  await removeRegistryFileCache();
+  invalidateRegistryCaches();
   return getRegistryPlugins();
 }
 

--- a/packages/agent/src/services/registry-client.ts
+++ b/packages/agent/src/services/registry-client.ts
@@ -70,18 +70,6 @@ export type {
   RegistrySearchResult,
 } from "./registry-client-types.ts";
 
-export class RegistryCacheInvalidationError extends Error {
-  readonly code = "REGISTRY_CACHE_INVALIDATION_FAILED" as const;
-
-  constructor(
-    readonly cachePath: string,
-    cause: unknown,
-  ) {
-    super(`Failed to remove registry cache at ${cachePath}`, { cause });
-    this.name = "RegistryCacheInvalidationError";
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Cache state
 // ---------------------------------------------------------------------------
@@ -257,10 +245,9 @@ export function isDefaultEndpoint(url: string): boolean {
 // Public API
 // ---------------------------------------------------------------------------
 
-/** Get all plugins. Resolution: memory → file → network. */
-export async function getRegistryPlugins(): Promise<
-  Map<string, RegistryPluginInfo>
-> {
+async function loadRegistryPlugins(
+  skipFileCache: boolean,
+): Promise<Map<string, RegistryPluginInfo>> {
   if (
     memoryCache &&
     Date.now() - memoryCache.fetchedAt < (memoryCache.ttlMs ?? CACHE_TTL_MS)
@@ -268,20 +255,22 @@ export async function getRegistryPlugins(): Promise<
     return memoryCache.plugins;
   }
 
-  const fileReadGeneration = registryGeneration;
-  const fromFile = await readFileCache();
-  if (fromFile) {
-    await applyLocalWorkspaceApps(fromFile);
-    await applyNodeModulePlugins(fromFile);
-    await mergeCustomEndpoints(fromFile, getConfiguredEndpoints());
+  if (!skipFileCache) {
+    const fileReadGeneration = registryGeneration;
+    const fromFile = await readFileCache();
+    if (fromFile) {
+      await applyLocalWorkspaceApps(fromFile);
+      await applyNodeModulePlugins(fromFile);
+      await mergeCustomEndpoints(fromFile, getConfiguredEndpoints());
 
-    // A refresh can unlink the cache while an earlier read still owns an open
-    // file handle. Return that snapshot only to its original caller; publishing
-    // it would replace the post-refresh memory cache with stale disk state.
-    if (fileReadGeneration !== registryGeneration) return fromFile;
+      // A refresh can unlink the cache while an earlier read still owns an open
+      // file handle. Return that snapshot only to its original caller; publishing
+      // it would replace the post-refresh memory cache with stale disk state.
+      if (fileReadGeneration !== registryGeneration) return fromFile;
 
-    memoryCache = { plugins: fromFile, fetchedAt: Date.now() };
-    return fromFile;
+      memoryCache = { plugins: fromFile, fetchedAt: Date.now() };
+      return fromFile;
+    }
   }
 
   if (registryLoadPromise) {
@@ -339,6 +328,13 @@ export async function getRegistryPlugins(): Promise<
   return load;
 }
 
+/** Get all plugins. Resolution: memory → file → network. */
+export async function getRegistryPlugins(): Promise<
+  Map<string, RegistryPluginInfo>
+> {
+  return loadRegistryPlugins(false);
+}
+
 /**
  * Drop every cached registry snapshot, including one that is still loading.
  * Clearing `memoryCache` alone is not enough: an in-flight load returns its
@@ -365,11 +361,12 @@ async function removeRegistryFileCache(): Promise<void> {
   try {
     await fs.unlink(filePath);
   } catch (error) {
-    // error-policy:J2 A missing cache is the only successful no-op. Permission,
-    // read-only filesystem, and other I/O failures retain their cause and gain
-    // a stable registry-specific type for callers and route boundaries.
     if (hasFilesystemErrorCode(error, "ENOENT")) return;
-    throw new RegistryCacheInvalidationError(filePath, error);
+    // error-policy:J6 File-cache removal is best-effort teardown. The refresh
+    // below bypasses the retained file and obtains a complete network snapshot.
+    logger.warn(
+      `[registry-client] Cache removal failed at ${filePath}; forcing an uncached refresh: ${String(error)}`,
+    );
   }
 }
 
@@ -377,12 +374,11 @@ async function removeRegistryFileCache(): Promise<void> {
 export async function refreshRegistry(): Promise<
   Map<string, RegistryPluginInfo>
 > {
-  // Remove the durable snapshot before invalidating the usable in-memory
-  // state. If removal fails, refresh rejects without abandoning an in-flight
-  // load or leaving the process cache half-invalidated.
+  // Removal is useful persistent cleanup but is not required for correctness:
+  // the refresh explicitly bypasses the file tier even when unlink is denied.
   await removeRegistryFileCache();
   invalidateRegistryCaches();
-  return getRegistryPlugins();
+  return loadRegistryPlugins(true);
 }
 
 /** Look up a plugin by name (exact → @elizaos/ prefix → bare suffix). */


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #24115.

# Outcome

`refreshRegistry()` no longer adopts or republishes a registry load or file-cache read that began before the refresh. The refresh invalidates the process-local memory/promise generation and starts a new load that bypasses the file tier.

This PR also deliberately changes cache-unlink handling. Failure to unlink `<state>/cache/registry.json` (including `EACCES`, `EROFS`, Windows `EPERM`, or `EBUSY`) is logged as cache-teardown failure, but it does not abort the fresh network load. The public `RegistryCacheInvalidationError` and its new error code were removed. Consequently, read-only consumers such as `GET /api/registry/plugins` do not become 502 responses solely because a derived cache file cannot be removed.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5 (original implementation); openai/gpt-5.6-sol (merge-hold repair)
<!-- attribution-row:client -->
- Agent tooling: claude-code (original implementation); codex (merge-hold repair)
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` at `b8db45bc58b86f1cf476251d7047b8f7d687c749`; no merge commit remains.
- [x] Current tested head: `7b2efb7ed9c5ed45b1b6c10254de18920588247d`.

# Risks and limitations

- The generation counter and promise-identity guard are process-local. They prevent pre-refresh work from republishing inside the current process; they do not coordinate independent processes.
- If the file cache is genuinely immutable, the current process still receives and retains the fresh network snapshot because refresh bypasses the file tier. A later process cannot be guaranteed to avoid the retained on-disk snapshot until its normal TTL expires because this process cannot mutate that file. This is an explicit process-local limitation, not a distributed invalidation claim.
- A caller that was already awaiting a pre-refresh load still receives its originally requested snapshot. That snapshot is not published after the generation changes.
- The three endpoint mutators still clear only `memoryCache`; this PR does not change their contract.
- This PR is from a fork. Hosted CI does not execute this contributor's tests, and no hosted result is claimed.

# Testing

## Regression-first evidence

Command:

```bash
bunx vitest run packages/agent/src/services/registry-client-refresh.test.ts
```

RED, before the caller-impact repair:

```text
Test Files  1 failed (1)
Tests       3 failed | 6 passed (9)
```

The failures were the `EACCES` and `EROFS` fresh-network assertions plus the real `GET /api/registry/plugins` boundary returning 502.

GREEN, after the repair:

```text
Test Files  1 passed (1)
Tests       9 passed (9)
```

The required proof recorder repeated the green command at `7b2efb7ed9c5ed45b1b6c10254de18920588247d`: 1 test file passed, 9 tests passed, exit 0.

Additional local checks:

- `bunx biome check packages/agent/src/services/registry-client.ts packages/agent/src/services/registry-client-refresh.test.ts` — passed, 2 files checked.
- `bun run --cwd packages/agent lint:check` — exited 0; it reported only pre-existing warnings/infos in unrelated files.
- `bun run --cwd packages/agent typecheck` — not green. It is blocked by unrelated missing workspace subpath declarations including `@elizaos/plugin-capacitor-bridge/*`, `@elizaos/plugin-wallet/diagnostic`, `@elizaos/plugin-video`, `@elizaos/plugin-vision`, `@elizaos/plugin-notes/plugin`, and `@elizaos/plugin-todos/edge`. `bun install --frozen-lockfile --ignore-scripts` completed first; the same blockers remained. No typecheck or hosted-CI pass is claimed.

# Evidence Gate

<!-- evidence-head:7b2efb7ed9c5ed45b1b6c10254de18920588247d -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no rendered UI files change.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no rendered UI files change.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - the changed surface is registry cache concurrency and an HTTP response boundary, exercised by deterministic tests.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: focused Vitest output above proves the real `refreshRegistry` function and real `handleRegistryRoutes` listing boundary; RED returned 502 and GREEN returned the fresh plugin list.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code changes; the HTTP boundary is covered directly.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent, action, provider, prompt, model, or planner behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: deterministic stale/fresh registry maps in the 9-test corpus prove that payload A is returned only to its original pre-refresh caller while payload B remains published after refresh, including unlink-denied cases.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no visual surface changes.`

# Documentation changes needed?

No user documentation change is required. The PR description now declares the full behavior and its process-local limitation.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@2744eb9bd27513b5c5081b61cf5d17494a583061:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0K7AJ4PE9345JWRK8AZWYWR","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T22:33:35.638Z","completed_at":"2026-08-21T22:37:39.139Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T22:33:35.963Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"496aed8769403df41b990f4b63f39b806ed04994c44b7c2c42c99b2228581080","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"317feb40-9255-4f5b-9535-0658e9451b35","object_id":"sha256:496aed8769403df41b990f4b63f39b806ed04994c44b7c2c42c99b2228581080","sha256":"496aed8769403df41b990f4b63f39b806ed04994c44b7c2c42c99b2228581080"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"UNrZuVOMiYxYs54S9WxcW5YBYMFuVV50htqWKC8JzYvWSDDtoX1RgN0rMM1k6Wmzzld4xwLhdv3f1SmhKuYRBQ"}} -->
