### PR TITLE
fix(scheduling): reject empty edit bodies, honor chunked test-probe framing (#23977)

### DIFF
--- a/plugins/plugin-scheduling/src/routes/scheduled-tasks.seam.test.ts
+++ b/plugins/plugin-scheduling/src/routes/scheduled-tasks.seam.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Integration tests for the scheduled-tasks REST surface through the
+ * PRODUCTION adapter seam (`buildSchedulingRoutes` → `plugin-routes.ts`):
+ * real `IncomingMessage` streams, the real core `readJsonBody` reader, the
+ * real `ScheduledTaskRunnerService` runner resolution, and host-injected
+ * in-memory stores (the documented `registerScheduledTaskRunnerDeps`
+ * injection point). No `SchedulingRouteContext` mock — this is the suite that
+ * pins the reader contracts the route's framing gates depend on (#23977 item 3).
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { IncomingMessage as NodeIncomingMessage } from "node:http";
+import { Socket } from "node:net";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createInMemoryScheduledTaskLogStore,
+  createInMemoryScheduledTaskStore,
+  registerScheduledTaskRunnerDeps,
+  type ScheduledTaskLogEntry,
+  ScheduledTaskRunnerService,
+  TestNoopScheduledTaskDispatcher,
+} from "../scheduled-task/index.js";
+import { buildSchedulingRoutes } from "./plugin-routes.js";
+
+const AGENT_ID = "seam-test-agent";
+
+interface RecordedResponse {
+  statusCode: number;
+  body: string;
+  headers: Record<string, string | number | readonly string[]>;
+}
+
+function responseRecorder(): ServerResponse & RecordedResponse {
+  return {
+    statusCode: 200,
+    body: "",
+    headers: {},
+    setHeader(
+      this: RecordedResponse,
+      name: string,
+      value: string | number | readonly string[],
+    ) {
+      this.headers[name.toLowerCase()] = value;
+      return this as unknown as ServerResponse;
+    },
+    end(this: RecordedResponse, chunk?: unknown) {
+      if (chunk !== undefined) this.body += String(chunk);
+      return this as unknown as ServerResponse;
+    },
+  } as unknown as ServerResponse & RecordedResponse;
+}
+
+function jsonRequest(
+  method: string,
+  url: string,
+  body?: string,
+  headers: Record<string, string> = {},
+): IncomingMessage {
+  const socket = new Socket();
+  Object.defineProperty(socket, "remoteAddress", {
+    value: "127.0.0.1",
+    configurable: true,
+  });
+  const req = new NodeIncomingMessage(socket);
+  req.method = method;
+  req.url = url;
+  req.headers = { "content-type": "application/json", ...headers };
+  // Push after the socket attaches so the handler's stream listeners drain
+  // the buffered chunks once attached (PassThrough-free, real IncomingMessage).
+  if (body !== undefined) req.push(body);
+  req.push(null);
+  return req;
+}
+
+interface SeamHarness {
+  handler: (
+    req: IncomingMessage,
+    res: ServerResponse,
+    runtime: IAgentRuntime,
+  ) => Promise<void>;
+  runtime: IAgentRuntime;
+  logRows: (taskId: string) => Promise<ScheduledTaskLogEntry[]>;
+  stop: () => Promise<void>;
+}
+
+/** One live service per seam; stopped after each test so no runner leaks. */
+const startedServices: { stop(): Promise<void> }[] = [];
+
+async function makeSeam(): Promise<SeamHarness> {
+  const store = createInMemoryScheduledTaskStore();
+  const logStore = createInMemoryScheduledTaskLogStore();
+  const runtime = {
+    agentId: AGENT_ID,
+    getService: () => null,
+    reportError: () => {},
+  } as unknown as IAgentRuntime;
+  registerScheduledTaskRunnerDeps(runtime, () => ({
+    store,
+    logStore,
+    dispatcher: TestNoopScheduledTaskDispatcher,
+    ownerFacts: () => ({}),
+    globalPause: { current: async () => ({ active: false }) },
+    activity: { hasSignalSince: () => false },
+    subjectStore: { wasUpdatedSince: () => false },
+  }));
+  const service = await ScheduledTaskRunnerService.start(runtime);
+  startedServices.push(service);
+  const runtimeWithService = {
+    ...runtime,
+    getService: (type: string) =>
+      type === ScheduledTaskRunnerService.serviceType ? service : null,
+  } as unknown as IAgentRuntime;
+  // buildSchedulingRoutes returns one Route[] sharing a single handler; any
+  // entry's handler is the seam under test.
+  const [route] = buildSchedulingRoutes();
+  if (!route || typeof route.handler !== "function") {
+    throw new Error("expected a scheduling route handler");
+  }
+  const handler = route.handler as unknown as SeamHarness["handler"];
+  return {
+    handler,
+    runtime: runtimeWithService,
+    logRows: (taskId) =>
+      logStore.list({ agentId: AGENT_ID, taskId, excludeRollups: true }),
+    stop: async () => {
+      await service.stop();
+      const idx = startedServices.indexOf(service);
+      if (idx >= 0) startedServices.splice(idx, 1);
+    },
+  };
+}
+
+const BASE_INPUT = JSON.stringify({
+  kind: "reminder",
+  promptInstructions: "seam test reminder",
+  trigger: { kind: "manual" },
+  priority: "low",
+  respectsGlobalPause: true,
+  source: "user_chat",
+  createdBy: "seam-test",
+  ownerVisible: true,
+});
+
+interface SeededTask {
+  seam: SeamHarness;
+  taskId: string;
+}
+
+async function seedTask(): Promise<SeededTask> {
+  const seam = await makeSeam();
+  const res = responseRecorder();
+  await seam.handler(
+    jsonRequest("POST", "/api/lifeops/scheduled-tasks", BASE_INPUT, {
+      "content-length": String(BASE_INPUT.length),
+    }),
+    res,
+    seam.runtime,
+  );
+  if (res.statusCode !== 201) {
+    throw new Error(`seed schedule failed: ${res.statusCode} ${res.body}`);
+  }
+  return {
+    seam,
+    taskId: (JSON.parse(res.body).task as { taskId: string }).taskId,
+  };
+}
+
+describe("scheduled-tasks REST seam (real reader, real service, real routes)", () => {
+  afterEach(async () => {
+    // Every makeSeam registers its service; stop them all so no runner leaks.
+    while (startedServices.length > 0) {
+      const service = startedServices.pop();
+      await service?.stop();
+    }
+  });
+
+  it("schedules a task through the real reader", async () => {
+    const { seam, taskId } = await seedTask();
+    expect(taskId).toBeTruthy();
+    // The seeded row is addressable through the same seam (list).
+    const res = responseRecorder();
+    await seam.handler(
+      jsonRequest("GET", "/api/lifeops/scheduled-tasks"),
+      res,
+      seam.runtime,
+    );
+    expect(res.statusCode).toBe(200);
+    const listed = (JSON.parse(res.body) as { tasks: { taskId: string }[] })
+      .tasks;
+    expect(listed.some((t) => t.taskId === taskId)).toBe(true);
+  });
+
+  it("rejects an explicit {} edit body with 400 and writes no edited log row (#23977)", async () => {
+    const { seam, taskId } = await seedTask();
+    const res = responseRecorder();
+    await seam.handler(
+      jsonRequest("POST", `/api/lifeops/scheduled-tasks/${taskId}/edit`, "{}", {
+        "content-length": "2",
+      }),
+      res,
+      seam.runtime,
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toContain("at least one field");
+    const edited = (await seam.logRows(taskId)).filter(
+      (row) => row.transition === "edited",
+    );
+    expect(edited).toEqual([]);
+  });
+
+  it("applies a real edit and records exactly one edited row with the edited keys", async () => {
+    const { seam, taskId } = await seedTask();
+    const res = responseRecorder();
+    await seam.handler(
+      jsonRequest(
+        "POST",
+        `/api/lifeops/scheduled-tasks/${taskId}/edit`,
+        '{"priority":"high"}',
+        { "content-length": "19" },
+      ),
+      res,
+      seam.runtime,
+    );
+    expect(res.statusCode).toBe(200);
+    const edited = (await seam.logRows(taskId)).filter(
+      (row) => row.transition === "edited",
+    );
+    expect(edited).toHaveLength(1);
+    const first = edited[0];
+    expect(first).toBeDefined();
+    expect((first.detail as { keys?: string[] }).keys).toEqual(["priority"]);
+  });
+
+  it("reads a chunked edit body without content-length (#23930 through the seam)", async () => {
+    const { seam, taskId } = await seedTask();
+    const res = responseRecorder();
+    await seam.handler(
+      jsonRequest(
+        "POST",
+        `/api/lifeops/scheduled-tasks/${taskId}/edit`,
+        '{"promptInstructions":"chunked edit"}',
+        { "transfer-encoding": "chunked" },
+      ),
+      res,
+      seam.runtime,
+    );
+    expect(res.statusCode).toBe(200);
+    const edited = (await seam.logRows(taskId)).filter(
+      (row) => row.transition === "edited",
+    );
+    expect(edited).toHaveLength(1);
+  });
+
+  it("rejects an empty chunked edit body with the reader's 400 parse error", async () => {
+    const { seam, taskId } = await seedTask();
+    const res = responseRecorder();
+    await seam.handler(
+      jsonRequest(
+        "POST",
+        `/api/lifeops/scheduled-tasks/${taskId}/edit`,
+        undefined,
+        { "transfer-encoding": "chunked" },
+      ),
+      res,
+      seam.runtime,
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toContain("Invalid JSON");
+    const edited = (await seam.logRows(taskId)).filter(
+      (row) => row.transition === "edited",
+    );
+    expect(edited).toEqual([]);
+  });
+
+  it("rejects malformed JSON with the reader's 400", async () => {
+    const { seam, taskId } = await seedTask();
+    const res = responseRecorder();
+    const body = "{oops";
+    await seam.handler(
+      jsonRequest("POST", `/api/lifeops/scheduled-tasks/${taskId}/edit`, body, {
+        "content-length": String(body.length),
+      }),
+      res,
+      seam.runtime,
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toContain("Invalid JSON");
+  });
+
+  it("rejects a JSON null body with the reader's non-object 400", async () => {
+    const { seam, taskId } = await seedTask();
+    const res = responseRecorder();
+    await seam.handler(
+      jsonRequest(
+        "POST",
+        `/api/lifeops/scheduled-tasks/${taskId}/edit`,
+        "null",
+        { "content-length": "4" },
+      ),
+      res,
+      seam.runtime,
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toContain("must be a JSON object");
+    const edited = (await seam.logRows(taskId)).filter(
+      (row) => row.transition === "edited",
+    );
+    expect(edited).toEqual([]);
+  });
+
+  it("rejects an over-1MiB edit body with the reader's 413", async () => {
+    const { seam, taskId } = await seedTask();
+    const res = responseRecorder();
+    const body = `{"pad":"${"x".repeat(1_100_000)}"}`;
+    await seam.handler(
+      jsonRequest("POST", `/api/lifeops/scheduled-tasks/${taskId}/edit`, body, {
+        "content-length": String(body.length),
+      }),
+      res,
+      seam.runtime,
+    );
+    expect(res.statusCode).toBe(413);
+    const edited = (await seam.logRows(taskId)).filter(
+      (row) => row.transition === "edited",
+    );
+    expect(edited).toEqual([]);
+  });
+
+  it("honors a chunked test-probe body without content-length (#23977)", async () => {
+    const seam = await makeSeam();
+    const res = responseRecorder();
+    await seam.handler(
+      jsonRequest(
+        "POST",
+        "/api/lifeops/scheduled-tasks/test-probe",
+        '{"kind":"checkin"}',
+        { "transfer-encoding": "chunked" },
+      ),
+      res,
+      seam.runtime,
+    );
+    expect(res.statusCode).toBe(201);
+    const payload = JSON.parse(res.body) as {
+      task: {
+        kind: string;
+        taskId: string;
+        metadata?: Record<string, unknown>;
+      };
+      fire: { kind: string };
+    };
+    expect(payload.task.kind).toBe("checkin");
+    expect(payload.fire.kind).toBe("fired");
+    // The injected dispatcher is void (TestNoop): the runner records a fire
+    // without a typed dispatch result, so no lastDispatchResult may appear.
+    const rows = await seam.logRows(payload.task.taskId);
+    expect(rows.length).toBeGreaterThan(0);
+    const storeTask = payload.task;
+    expect(
+      (storeTask.metadata as { lastDispatchResult?: unknown })
+        ?.lastDispatchResult,
+    ).toBeUndefined();
+  });
+
+  it("defaults the test-probe to a reminder when no body framing is present", async () => {
+    const seam = await makeSeam();
+    const res = responseRecorder();
+    await seam.handler(
+      jsonRequest("POST", "/api/lifeops/scheduled-tasks/test-probe"),
+      res,
+      seam.runtime,
+    );
+    expect(res.statusCode).toBe(201);
+    const payload = JSON.parse(res.body) as { task: { kind: string } };
+    expect(payload.task.kind).toBe("reminder");
+  });
+});

--- a/plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts
+++ b/plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts
@@ -411,6 +411,26 @@ describe("scheduled-tasks REST handler", () => {
     expect(payload.task.kind).toBe("checkin");
   });
 
+  it("POST /test-probe reads a chunked body without content-length instead of silently defaulting (#23977)", async () => {
+    const runner = makeRunner();
+    const handler = makeScheduledTasksRouteHandler({
+      resolveRunner: async () => runner,
+    });
+    const { ctx, res } = buildCtx({
+      method: "POST",
+      pathname: "/api/lifeops/scheduled-tasks/test-probe",
+      body: { kind: "checkin" },
+      headers: {
+        "content-type": "application/json",
+        "transfer-encoding": "chunked",
+      },
+    });
+    await handler(ctx);
+    expect(res.statusCode).toBe(201);
+    const payload = JSON.parse(res.body ?? "{}");
+    expect(payload.task.kind).toBe("checkin");
+  });
+
   it("rejects illegal percent-encoding in task ids with 400 before runner calls", async () => {
     let listed = 0;
     let applied = 0;
@@ -567,6 +587,26 @@ describe("scheduled-tasks REST handler", () => {
       expect(res.statusCode).toBe(400);
       expect(res.body).toContain("request body is required");
       expect(applyCalls).toBe(0);
+      expect(
+        (await runner.list()).find((item) => item.taskId === task.taskId),
+      ).toEqual(task);
+    });
+
+    it("rejects an explicit {} edit body instead of persisting an empty patch (#23977)", async () => {
+      const { runner, handler, task } = await seed();
+      let applyCalls = 0;
+      const originalApply = runner.apply.bind(runner);
+      runner.apply = async (taskId, verb, payload) => {
+        applyCalls += 1;
+        return originalApply(taskId, verb, payload);
+      };
+
+      const res = await edit(handler, task.taskId, {});
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toContain("at least one field");
+      expect(applyCalls).toBe(0);
+      // No spurious `edited {keys:[]}` row survives in the state log.
       expect(
         (await runner.list()).find((item) => item.taskId === task.taskId),
       ).toEqual(task);

--- a/plugins/plugin-scheduling/src/routes/scheduled-tasks.ts
+++ b/plugins/plugin-scheduling/src/routes/scheduled-tasks.ts
@@ -5,6 +5,8 @@
  *   GET    /api/lifeops/scheduled-tasks                              list
  *   POST   /api/lifeops/scheduled-tasks                              schedule
  *   POST   /api/lifeops/scheduled-tasks/:id/<verb>                   apply verb
+ *       (`edit` requires a JSON body with at least one field — body-less
+ *       and `{}` both 400; `snooze` requires minutes or untilIso)
  *   GET    /api/lifeops/scheduled-tasks/:id/history                  user-visible history
  *   GET    /api/lifeops/dev/scheduled-tasks/:id/log                  dev log (loopback)
  *   GET    /api/lifeops/dev/scheduling/registries                    spine registry health (loopback)
@@ -395,8 +397,12 @@ async function handleScheduledTasks(
       (req.headers["content-length"] as string | undefined) ?? "0",
       10,
     );
+    const hasTransferEncoding = req.headers["transfer-encoding"] !== undefined;
     let body: Record<string, unknown> = {};
-    if (Number.isFinite(contentLength) && contentLength > 0) {
+    if (
+      (Number.isFinite(contentLength) && contentLength > 0) ||
+      hasTransferEncoding
+    ) {
       const parsed = await readJsonBody<Record<string, unknown>>(req, res);
       if (parsed === null) return true;
       body = parsed;
@@ -523,7 +529,23 @@ async function handleScheduledTasks(
             error(res, "invalid edit payload: request body is required", 400);
             return true;
           }
-          const raw = (body ?? {}) as Record<string, unknown>;
+          const raw = body as Record<string, unknown>;
+          // An explicit `{}` is schema-valid but carries no edit. Letting it
+          // through makes `applyEdit` `Object.assign` an empty patch,
+          // re-persist the row, and append a spurious `edited {keys:[]}`
+          // state-log row — the same durable-no-op #23917 removed for the
+          // body-less case (and what the typed UI client transmits when
+          // `applyScheduledTask(id, "edit")` is called without a payload, since
+          // it sends `JSON.stringify(payload ?? {})`). Reject it with the
+          // sibling 400 instead.
+          if (Object.keys(raw).length === 0) {
+            error(
+              res,
+              "invalid edit payload: request body must include at least one field",
+              400,
+            );
+            return true;
+          }
           // Refuse the read-only keys up front, with the runner's own message
           // and the 409 the boundary already documents for a read-only field.
           // Zod reports neither: `.strict()` skips `__proto__`, and the two


### PR DESCRIPTION
Adds two boundary fixes and a seam test suite closing the #23977 residue of the scheduled-task `edit` REST family (found by execution-based post-merge reviews of #23930; umbrella family #23917/#23832).

## What changed

**1. `POST /:id/edit` with an explicit `{}` body now returns the sibling 400** instead of performing a durable empty write. At base, `{}` is schema-valid (`.partial().strict()`), passes the `body === undefined` guard, and lands in `applyEdit`, which `Object.assign`s an empty patch, re-persists the row, and appends a spurious `edited {keys:[]}` state-log row (HTTP 200). The typed UI client `applyScheduledTask` (`packages/ui/src/api/client-scheduled-tasks.ts`) sends exactly `JSON.stringify(payload ?? {})` for every verb — so `{}` is the literal wire body of a payload-less edit call. The empty-body gate sits before the read-only-key scan and schema parse; the error message mirrors the body-less case's contract (`snooze`'s `.refine` already 400s an empty payload — sibling consistency).

**2. `POST /test-probe` body reads now honor `transfer-encoding`**, mirroring the apply-verb gate #23930 fixed: `(contentLength > 0 || transfer-encoding !== undefined)`. A chunked probe with `{"kind":"checkin"}` no longer silently runs the default reminder kind. Honest tightening note: a chunked request with zero body bytes now 400s (reader parse error) instead of defaulting to reminder — same choice #23930 made for `edit` and two reviewers upheld; no in-repo client sends an empty chunked POST here.

**3. New seam integration suite** (`scheduled-tasks.seam.test.ts`): drives `buildSchedulingRoutes` (the production `routes:` adapter, `plugin-routes.ts`) with real `IncomingMessage` streams, the REAL core `readJsonBody` reader, and the real `ScheduledTaskRunnerService` (host-injected in-memory stores via `registerScheduledTaskRunnerDeps`, the documented injection point). This pins the real-reader contracts the framing gates now depend on — empty-chunked → 400 parse error, malformed → 400, JSON `null` → 400 non-object, >1MiB → 413, chunked-without-content-length reads — which were previously pinned by NO in-repo test (the route suite's `ctx.readJsonBody` is a stream-blind mock, and the adapter seam had zero tests).

## Evidence (all execution, real reader/runner/routes)

- **Package suite at head `6ec57d36705`** (rebased on develop `f8a29be4c24`): 35 files / **561 tests pass** (was 549; +12 new: 2 unit + 10 seam). `bun run --cwd plugins/plugin-scheduling test`.
- **Red control A (unit)** — route source reverted to pristine develop, new tests kept: the two #23977 unit tests fail exactly as the issue predicts (`{}` edit: expected 400, got 200). 
- **Red control B (seam)** — entire worktree at pristine develop, only the new seam suite present: exactly the 2 residue tests fail (`{}` edit 200-not-400; chunked probe `reminder`-not-`checkin`) while all 8 real-reader pins pass — proving the suite drives the real reader, not a mock.
- **Independent RP review (opus, converged)**: APPROVE, zero must-fix. The reviewer independently re-ran the 561-test suite in the worktree, re-ran its own red control (exactly 4 #23977-named failures at base), re-ran biome, verified the diff base byte-for-byte against `origin/develop` blobs, verified the snooze sibling contract, confirmed no in-repo caller sends `{}` to edit expecting 200 (the only non-test `applyScheduledTask` caller invokes snooze/acknowledge/complete/dismiss, never edit), verified the void-dispatch path (`TestNoop` → `fired`, no `lastDispatchResult` — now pinned by assertion), and confirmed no bypass to the empty-patch persist path is constructible (JSON cannot express symbol keys; `__proto__` own-key → 409 via the read-only scan, re-checked inside `applyEdit`).
- **Typecheck**: `tsc --noEmit -p tsconfig.json` — 1 error, `packages/ui/src/bridge/storage-bridge.ts` missing `@elizaos/capacitor-secure-store`. IDENTICAL at pristine develop in the same worktree (symlinked node_modules platform-package artifact); zero errors from this delta's files.
- **Lint**: `npx biome check` on all three changed files — clean (including the reviewer's independent re-run).
- **Build**: `bun run --cwd plugins/plugin-scheduling build` passes.
- **Plugin boundary gate**: no new imports; `rg "@elizaos/(app-core|agent|plugin-personal-assistant|plugin-google-workspace)" plugins/plugin-scheduling/src` matches comments/strings only (pre-existing).
- Reviewer nits applied before push: `afterEach` service teardown in the seam suite, endpoint-contract note in the route header, explicit `lastDispatchResult === undefined` pin on the void-dispatch probe.

## Test plan for reviewers

```
bun run --cwd plugins/plugin-scheduling test        # 561 pass
# red control: revert only src/routes/scheduled-tasks.ts to develop, re-run —
# exactly the 4 #23977-named tests fail (2 unit + 2 seam), everything else green
```

Closes #23977

AI provider/model: zai / glm-5.3 (manual) + opus (RepoPrompt CE review agent)
Client / agent tooling: Hermes Agent
Skill revision: elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes/t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:4b77940436171197c3085843f0a2699cc87eba6d -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - REST-boundary fix in a server plugin; no UI surface changes

<!-- evidence-row:after-screenshots -->
- [ ] N/A - REST-boundary fix in a server plugin; no UI surface changes

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI; behavior demonstrated by the embedded red-control matrix and suite output in the PR body

<!-- evidence-row:frontend-logs -->
- [ ] N/A - server-plugin-only change; no frontend surface touched

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/agent behavior change; pure route-boundary validation and tests

<!-- evidence-row:backend-logs -->
- [x] backend-logs: inline transcript (suite + red control at fix head)
<details><summary>Backend log transcript — package suite, red control, biome</summary>

```text
# PR 24122 backend evidence — scheduled-tasks route boundary (#23977)
# Worktree head 6ec57d36705 (rebased on origin/develop f8a29be4c24),  8-21

$ bun run --cwd plugins/plugin-scheduling test   (full package lane at fix head)
 Test Files  35 passed (35)
      Tests  561 passed (561)
   Duration  13.95s (transform 74.48s, setup 0ms, import 112.62s, tests 11.46s, environment 3ms)

$ red control A: only src/routes/scheduled-tasks.ts reverted to origin/develop, new tests kept
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/routes/scheduled-tasks.seam.test.ts > scheduled-tasks REST seam (real reader, real service, real routes) > rejects an explicit {} edit body with 400 and writes no edited log row (#23977)
AssertionError: expected 200 to be 400 // Object.is equality
 FAIL  src/routes/scheduled-tasks.seam.test.ts > scheduled-tasks REST seam (real reader, real service, real routes) > honors a chunked test-probe body without content-length (#23977)
AssertionError: expected 'reminder' to be 'checkin' // Object.is equality
 FAIL  src/routes/scheduled-tasks.test.ts > scheduled-tasks REST handler > POST /test-probe reads a chunked body without content-length instead of silently defaulting (#23977)
AssertionError: expected 'reminder' to be 'checkin' // Object.is equality
 FAIL  src/routes/scheduled-tasks.test.ts > scheduled-tasks REST handler > POST /:id/edit validates the body like its sibling snooze verb > rejects an explicit {} edit body instead of persisting an empty patch (#23977)
AssertionError: expected 200 to be 400 // Object.is equality
 Test Files  2 failed (2)
      Tests  4 failed | 33 skipped (37)
(route source restored to fix head)

$ biome check on the three changed files
Checked 3 files in 17ms. No fixes applied.
```

</details>

<!-- evidence-row:domain-artifacts -->
- [x] domain-artifacts: state-log rows through the production seam (develop vs fix head)
<details><summary>Domain artifact — scheduled-task state-log rows</summary>

```text
# PR 24122 domain artifact — scheduled-task state-log rows for an explicit {} edit

Captured by driving the PRODUCTION seam (`buildSchedulingRoutes` → real core `readJsonBody` →
real `ScheduledTaskRunnerService` with in-memory stores) at both heads, 2026-08-21T22:42Z.

## DEVELOP control (route source at origin/develop f8a29be4c24)

POST /api/lifeops/scheduled-tasks/<id>/edit, content-length: 2, body `{}`:

- HTTP status: **200**
- state-log rows after the call:
  1. `{"transition":"scheduled","detail":{"kind":"reminder","priority":"low","triggerKind":"manual"}}`
  2. `{"transition":"edited","detail":{"keys":[]}}`   ← the spurious durable no-op row

## FIX HEAD (6ec57d36705)

Same request:

- HTTP status: **400** `{"error":"invalid edit payload: request body must include at least one field"}`
- state-log rows after the call:
  1. `{"transition":"scheduled","detail":{"kind":"reminder","priority":"low","triggerKind":"manual"}}`
  (no `edited` row — the durable no-op write is gone)

Raw harness outputs (one line per head, JSON):

    develop: {"editStatus":200,"logRows":[{...scheduled...},{"transition":"edited","detail":{"keys":[]}}]}
    head:    {"editStatus":400,"editBody":"{\"error\":\"invalid edit payload: request body must include at least one field\"}","logRows":[{...scheduled...}]}
```

</details>