### PR TITLE
fix(gateway-discord): reject prefix-parsed integer environment values

### DIFF
--- a/packages/cloud/services/gateway-discord/package.json
+++ b/packages/cloud/services/gateway-discord/package.json
@@ -29,6 +29,7 @@
     "@discordjs/opus": "^0.10.0",
     "@discordjs/voice": "^0.19.2",
     "@elizaos/cloud-services-common": "workspace:*",
+    "@elizaos/core": "workspace:*",
     "@elizaos/shared": "workspace:*",
     "@hono/node-server": "2.0.10",
     "@upstash/redis": "^1.37.0",

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -38,7 +38,7 @@ import {
 } from "./dm-policy";
 import { pollTrackedDiscordDms, type TrackedDiscordDm } from "./dm-polling";
 import { tryConfirmDiscordIdentityLink } from "./identity-link";
-import { parseIntegerEnvValue } from "./integer-env";
+import { invalidIntegerEnvError, parseIntegerEnvValue } from "./integer-env";
 import { logger } from "./logger";
 import {
   createManagedGuildVoiceCloudBridge,
@@ -131,8 +131,11 @@ function parseIntEnv(
   const parsed = parseIntegerEnvValue(name, process.env[name]);
   if (parsed === undefined) return defaultValue;
   if (parsed < minValue) {
-    throw new Error(
-      `Invalid ${name} environment variable: ${parsed} is below minimum value of ${minValue}`,
+    throw invalidIntegerEnvError(
+      name,
+      process.env[name] ?? String(parsed),
+      `${parsed} is below minimum value of ${minValue}`,
+      { parsed, minimum: minValue },
     );
   }
   return parsed;

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -38,6 +38,7 @@ import {
 } from "./dm-policy";
 import { pollTrackedDiscordDms, type TrackedDiscordDm } from "./dm-polling";
 import { tryConfirmDiscordIdentityLink } from "./identity-link";
+import { parseIntegerEnvValue } from "./integer-env";
 import { logger } from "./logger";
 import {
   createManagedGuildVoiceCloudBridge,
@@ -127,14 +128,8 @@ function parseIntEnv(
   defaultValue: number,
   minValue: number = 1,
 ): number {
-  const value = process.env[name];
-  if (value === undefined) return defaultValue;
-  const parsed = parseInt(value, 10);
-  if (Number.isNaN(parsed)) {
-    throw new Error(
-      `Invalid ${name} environment variable: "${value}" is not a valid integer`,
-    );
-  }
+  const parsed = parseIntegerEnvValue(name, process.env[name]);
+  if (parsed === undefined) return defaultValue;
   if (parsed < minValue) {
     throw new Error(
       `Invalid ${name} environment variable: ${parsed} is below minimum value of ${minValue}`,

--- a/packages/cloud/services/gateway-discord/src/integer-env.ts
+++ b/packages/cloud/services/gateway-discord/src/integer-env.ts
@@ -1,0 +1,34 @@
+/**
+ * Lexical integer parsing for gateway-discord environment variables.
+ *
+ * Owns only the question "is this string an integer we can trust", so each
+ * caller keeps its own range policy. `Number.parseInt` cannot answer that
+ * question: it stops at the first non-digit, so "3600junk" parses to 3600 and
+ * silently becomes configuration nobody set.
+ */
+
+/**
+ * Parse an environment value that must be a whole integer.
+ *
+ * Returns `undefined` when the variable is unset so the caller can apply its
+ * own default. Throws when a value is present but is not a whole integer, or
+ * is outside the safe-integer range where arithmetic stops being exact.
+ *
+ * A leading sign is accepted because `Number.parseInt` accepted it; rejecting
+ * it here would be a compatibility regression rather than a fix. Range checks
+ * (minimums, positivity) remain the caller's responsibility.
+ */
+export function parseIntegerEnvValue(
+  name: string,
+  value: string | undefined,
+): number | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  const parsed = /^[+-]?\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN;
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(
+      `Invalid ${name} environment variable: "${value}" is not a valid integer`,
+    );
+  }
+  return parsed;
+}

--- a/packages/cloud/services/gateway-discord/src/integer-env.ts
+++ b/packages/cloud/services/gateway-discord/src/integer-env.ts
@@ -6,6 +6,21 @@
  * question: it stops at the first non-digit, so "3600junk" parses to 3600 and
  * silently becomes configuration nobody set.
  */
+import { ElizaError } from "@elizaos/core";
+
+/** Build the fatal configuration error shared by lexical and range checks. */
+export function invalidIntegerEnvError(
+  name: string,
+  value: string,
+  reason: string,
+  context: Record<string, unknown> = {},
+): ElizaError {
+  return new ElizaError(`Invalid ${name} environment variable: ${reason}`, {
+    code: "INVALID_GATEWAY_INTEGER_ENV",
+    context: { envKey: name, configured: value, ...context },
+    severity: "fatal",
+  });
+}
 
 /**
  * Parse an environment value that must be a whole integer.
@@ -26,8 +41,10 @@ export function parseIntegerEnvValue(
   const trimmed = value.trim();
   const parsed = /^[+-]?\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN;
   if (!Number.isSafeInteger(parsed)) {
-    throw new Error(
-      `Invalid ${name} environment variable: "${value}" is not a valid integer`,
+    throw invalidIntegerEnvError(
+      name,
+      value,
+      `"${value}" is not a valid integer`,
     );
   }
   return parsed;

--- a/packages/cloud/services/gateway-discord/src/voice-message-handler.ts
+++ b/packages/cloud/services/gateway-discord/src/voice-message-handler.ts
@@ -10,6 +10,7 @@
 
 import { createHash } from "node:crypto";
 import { type Attachment, MessageFlags } from "discord.js";
+import { parseIntegerEnvValue } from "./integer-env";
 import { logger } from "./logger";
 
 /**
@@ -17,15 +18,7 @@ import { logger } from "./logger";
  * Throws if the value is not a valid integer to fail fast on misconfiguration.
  */
 function parseIntEnv(name: string, defaultValue: number): number {
-  const value = process.env[name];
-  if (value === undefined) return defaultValue;
-  const parsed = parseInt(value, 10);
-  if (Number.isNaN(parsed)) {
-    throw new Error(
-      `Invalid ${name} environment variable: "${value}" is not a valid integer`,
-    );
-  }
-  return parsed;
+  return parseIntegerEnvValue(name, process.env[name]) ?? defaultValue;
 }
 
 const VOICE_AUDIO_TTL_SECONDS = parseIntEnv("VOICE_AUDIO_TTL_SECONDS", 3600);

--- a/packages/cloud/services/gateway-discord/tests/integer-env-parsing.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/integer-env-parsing.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Covers the single lexical integer parser both gateway-discord env helpers
+ * delegate to, plus the range policy each caller keeps for itself.
+ *
+ * `Number.parseInt` stops at the first non-digit, so "3600junk" previously
+ * parsed to 3600 and became configuration nobody set.
+ */
+import { describe, expect, test } from "bun:test";
+import { parseIntegerEnvValue } from "../src/integer-env";
+
+const NAME = "VOICE_AUDIO_TTL_SECONDS";
+
+describe("parseIntegerEnvValue", () => {
+  test("returns undefined when the variable is unset so callers apply their default", () => {
+    expect(parseIntegerEnvValue(NAME, undefined)).toBeUndefined();
+  });
+
+  test("rejects trailing garbage rather than parsing its prefix", () => {
+    expect(() => parseIntegerEnvValue(NAME, "3600junk")).toThrow(
+      "is not a valid integer",
+    );
+  });
+
+  test("rejects a fractional value", () => {
+    expect(() => parseIntegerEnvValue(NAME, "3600.5")).toThrow(
+      "is not a valid integer",
+    );
+  });
+
+  test("rejects an integer beyond the safe range", () => {
+    expect(() => parseIntegerEnvValue(NAME, "9007199254740993")).toThrow(
+      "is not a valid integer",
+    );
+  });
+
+  test("accepts a clean integer, including a signed one", () => {
+    // `Number.parseInt` accepted "+3600"; rejecting it would be a regression.
+    expect(parseIntegerEnvValue(NAME, "3600")).toBe(3600);
+    expect(parseIntegerEnvValue(NAME, "+3600")).toBe(3600);
+    expect(parseIntegerEnvValue(NAME, " 3600 ")).toBe(3600);
+  });
+
+  test("leaves range policy to the caller by accepting a negative integer", () => {
+    // The gateway manager's `minValue` check is the range authority, so the
+    // lexical parser must not pre-empt it.
+    expect(parseIntegerEnvValue(NAME, "-1")).toBe(-1);
+  });
+});
+
+describe("gateway-discord env helpers over the shared parser", () => {
+  const saved = new Map<string, string | undefined>();
+  function stub(key: string, value: string): void {
+    if (!saved.has(key)) saved.set(key, process.env[key]);
+    process.env[key] = value;
+  }
+  function restore(): void {
+    for (const [k, v] of saved) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    saved.clear();
+  }
+
+  test("the voice handler refuses a prefix-parsed TTL at module load", async () => {
+    stub("VOICE_AUDIO_TTL_SECONDS", "3600junk");
+    try {
+      await expect(
+        import(`../src/voice-message-handler?case=vmh-${Date.now()}`),
+      ).rejects.toThrow("is not a valid integer");
+    } finally {
+      restore();
+    }
+  });
+
+  test("the gateway manager refuses a prefix-parsed value at module load", async () => {
+    stub("MAX_BOTS_PER_POD", "5junk");
+    try {
+      await expect(
+        import(`../src/gateway-manager?case=gm-${Date.now()}`),
+      ).rejects.toThrow("is not a valid integer");
+    } finally {
+      restore();
+    }
+  });
+
+  test("the gateway manager still enforces its own minimum", async () => {
+    stub("MAX_BOTS_PER_POD", "0");
+    try {
+      await expect(
+        import(`../src/gateway-manager?case=gm-min-${Date.now()}`),
+      ).rejects.toThrow("below minimum value");
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/cloud/services/gateway-discord/tests/integer-env-parsing.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/integer-env-parsing.test.ts
@@ -6,6 +6,7 @@
  * parsed to 3600 and became configuration nobody set.
  */
 import { describe, expect, test } from "bun:test";
+import { ElizaError } from "@elizaos/core";
 import { parseIntegerEnvValue } from "../src/integer-env";
 
 const NAME = "VOICE_AUDIO_TTL_SECONDS";
@@ -16,9 +17,18 @@ describe("parseIntegerEnvValue", () => {
   });
 
   test("rejects trailing garbage rather than parsing its prefix", () => {
-    expect(() => parseIntegerEnvValue(NAME, "3600junk")).toThrow(
-      "is not a valid integer",
-    );
+    let thrown: unknown;
+    try {
+      parseIntegerEnvValue(NAME, "3600junk");
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ElizaError);
+    expect(thrown).toMatchObject({
+      code: "INVALID_GATEWAY_INTEGER_ENV",
+      context: { envKey: NAME, configured: "3600junk" },
+      severity: "fatal",
+    });
   });
 
   test("rejects a fractional value", () => {
@@ -86,9 +96,22 @@ describe("gateway-discord env helpers over the shared parser", () => {
   test("the gateway manager still enforces its own minimum", async () => {
     stub("MAX_BOTS_PER_POD", "0");
     try {
-      await expect(
-        import(`../src/gateway-manager?case=gm-min-${Date.now()}`),
-      ).rejects.toThrow("below minimum value");
+      try {
+        await import(`../src/gateway-manager?case=gm-min-${Date.now()}`);
+        throw new Error("expected gateway manager import to reject");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ElizaError);
+        expect(error).toMatchObject({
+          code: "INVALID_GATEWAY_INTEGER_ENV",
+          context: {
+            envKey: "MAX_BOTS_PER_POD",
+            configured: "0",
+            parsed: 0,
+            minimum: 1,
+          },
+          severity: "fatal",
+        });
+      }
     } finally {
       restore();
     }

--- a/packages/cloud/services/gateway-discord/tests/integer-env-parsing.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/integer-env-parsing.test.ts
@@ -70,7 +70,7 @@ describe("gateway-discord env helpers over the shared parser", () => {
     } finally {
       restore();
     }
-  });
+  }, 30_000);
 
   test("the gateway manager refuses a prefix-parsed value at module load", async () => {
     stub("MAX_BOTS_PER_POD", "5junk");
@@ -81,7 +81,7 @@ describe("gateway-discord env helpers over the shared parser", () => {
     } finally {
       restore();
     }
-  });
+  }, 30_000);
 
   test("the gateway manager still enforces its own minimum", async () => {
     stub("MAX_BOTS_PER_POD", "0");
@@ -92,5 +92,5 @@ describe("gateway-discord env helpers over the shared parser", () => {
     } finally {
       restore();
     }
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
# Relates to

No separate issue — this PR fixes gateway-discord integer environment parsing.

# What changed

The voice handler and gateway manager previously used `Number.parseInt`, so values such as `3600junk` silently became `3600`. This exact-head restack requires a complete trimmed signed decimal spelling and a JavaScript safe integer. Unset settings retain their existing defaults. Explicit malformed values and gateway values below their setting minimum now abort module startup with a fatal `ElizaError` (`INVALID_GATEWAY_INTEGER_ENV`) carrying the environment key, configured value, and range context where applicable.

# Verification

Exact head: `c2d3dec968c1ad5debf867468fb593f6bf2dd23e`
Base: `e1e8c1bb68119b3933c653336d7003d15812c7ca`

- focused integer/startup suite: 9 passed, 0 failed, 13 assertions
- full `@elizaos/gateway-discord` suite: 162 passed, 0 failed, 475 assertions across 24 files
- package typecheck: passed
- package build: passed (2,093 modules)
- package Biome `lint:check`: passed (47 files)
- `git diff --check`: passed

# Evidence Gate

<!-- evidence-head:c2d3dec968c1ad5debf867468fb593f6bf2dd23e -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only environment parsing; no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only environment parsing; no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - deterministic startup behavior is asserted directly`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - malformed configuration is rejected before the service starts`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model or prompt path changes`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - structured startup failures are the tested output`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no visual surface`.

# Attribution

Original strict-parser implementation: Svector-anu. Structured-error repair, current-develop restack, and verification: Shaw Walters.