### PR TITLE
fix(scenarios): register strict MCP stdio fixture

### DIFF
--- a/packages/scenario-runner/src/model-fixture-migration.test.ts
+++ b/packages/scenario-runner/src/model-fixture-migration.test.ts
@@ -8,7 +8,7 @@ import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
-const MAX_LEGACY_PR_DETERMINISTIC_SCENARIOS = 79;
+const MAX_LEGACY_PR_DETERMINISTIC_SCENARIOS = 78;
 
 type ScenarioSourceClassification = {
   deterministic: boolean;
@@ -184,7 +184,7 @@ describe("scenario model fixture migration", () => {
       strictOrModelFree: deterministic.length - legacy.length,
       legacy: legacy.length,
       total: deterministic.length,
-    }).toEqual({ strictOrModelFree: 40, legacy: 79, total: 119 });
+    }).toEqual({ strictOrModelFree: 41, legacy: 78, total: 119 });
   }, 120_000);
 
   it("recognizes authored properties while ignoring comments and setup strings", () => {

--- a/packages/scenario-runner/test/fixtures/mcp-stdio-fixture.mjs
+++ b/packages/scenario-runner/test/fixtures/mcp-stdio-fixture.mjs
@@ -1,9 +1,11 @@
 /**
  * Standalone stdio MCP server used as a fixture by the MCP scenarios: exposes a
  * deterministic echo tool and a fixed resource over the Model Context Protocol
- * stdio transport. Spawned as a child process so plugin-mcp connects to a real
- * server rather than a mock.
+ * stdio transport. The optional JSONL receipt records the real SDK request,
+ * response, and child lifecycle boundary for scenario evidence and orphan checks.
  */
+import { appendFileSync } from "node:fs";
+
 const sdkRoot = new URL(
   "../../../../plugins/plugin-mcp/node_modules/@modelcontextprotocol/sdk/dist/esm/",
   import.meta.url,
@@ -22,60 +24,114 @@ const {
 
 const RESOURCE_URI = "fixture://mcp-note";
 const RESOURCE_TEXT = "mcp-resource-note:alpha-42";
+const receiptPath = process.env.SCENARIO_MCP_RECEIPT_PATH;
+let stopped = false;
+
+function receipt(direction, method, payload = {}) {
+  if (!receiptPath) return;
+  appendFileSync(
+    receiptPath,
+    `${JSON.stringify({ direction, method, payload, pid: process.pid })}\n`,
+    "utf8",
+  );
+}
+
+function recordStop(reason) {
+  if (stopped) return;
+  stopped = true;
+  receipt("lifecycle", "stopped", { reason });
+}
+
+receipt("lifecycle", "started");
+process.once("SIGTERM", () => {
+  recordStop("SIGTERM");
+  process.exit(0);
+});
+process.once("SIGINT", () => {
+  recordStop("SIGINT");
+  process.exit(0);
+});
+process.once("exit", () => recordStop("exit"));
 
 const server = new Server(
   { name: "scenario-mcp", version: "1.0.0" },
   { capabilities: { resources: {}, tools: {} } },
 );
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [
-    {
-      name: "echo_code",
-      description: "Echo a deterministic code string.",
-      inputSchema: {
-        type: "object",
-        required: ["code"],
-        properties: {
-          code: { type: "string" },
+server.setRequestHandler(ListToolsRequestSchema, async (request) => {
+  receipt("request", "tools/list", request.params);
+  const response = {
+    tools: [
+      {
+        name: "echo_code",
+        description: "Echo a deterministic code string.",
+        inputSchema: {
+          type: "object",
+          required: ["code"],
+          properties: {
+            code: { type: "string" },
+          },
         },
       },
-    },
-  ],
-}));
+    ],
+  };
+  receipt("response", "tools/list", response);
+  return response;
+});
 
-server.setRequestHandler(CallToolRequestSchema, async (request) => ({
-  content: [
-    {
-      type: "text",
-      text: `mcp-tool-echo:${request.params.arguments?.code ?? ""}`,
-    },
-  ],
-}));
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  receipt("request", "tools/call", request.params);
+  const response = {
+    content: [
+      {
+        type: "text",
+        text: `mcp-tool-echo:${request.params.arguments?.code ?? ""}`,
+      },
+    ],
+  };
+  receipt("response", "tools/call", response);
+  return response;
+});
 
-server.setRequestHandler(ListResourcesRequestSchema, async () => ({
-  resources: [
-    {
-      uri: RESOURCE_URI,
-      name: "Deterministic MCP Note",
-      description: "Deterministic scenario resource.",
-      mimeType: "text/plain",
-    },
-  ],
-}));
+server.setRequestHandler(ListResourcesRequestSchema, async (request) => {
+  receipt("request", "resources/list", request.params);
+  const response = {
+    resources: [
+      {
+        uri: RESOURCE_URI,
+        name: "Deterministic MCP Note",
+        description: "Deterministic scenario resource.",
+        mimeType: "text/plain",
+      },
+    ],
+  };
+  receipt("response", "resources/list", response);
+  return response;
+});
 
-server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({
-  resourceTemplates: [],
-}));
+server.setRequestHandler(
+  ListResourceTemplatesRequestSchema,
+  async (request) => {
+    receipt("request", "resources/templates/list", request.params);
+    const response = { resourceTemplates: [] };
+    receipt("response", "resources/templates/list", response);
+    return response;
+  },
+);
 
-server.setRequestHandler(ReadResourceRequestSchema, async () => ({
-  contents: [
-    {
-      uri: RESOURCE_URI,
-      mimeType: "text/plain",
-      text: RESOURCE_TEXT,
-    },
-  ],
-}));
+server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+  receipt("request", "resources/read", request.params);
+  const response = {
+    contents: [
+      {
+        uri: RESOURCE_URI,
+        mimeType: "text/plain",
+        text: RESOURCE_TEXT,
+      },
+    ],
+  };
+  receipt("response", "resources/read", response);
+  return response;
+});
 
 await server.connect(new StdioServerTransport());

--- a/packages/scenario-runner/test/scenarios/README.md
+++ b/packages/scenario-runner/test/scenarios/README.md
@@ -36,8 +36,9 @@ provider always requires an exact fixture or explicit resolver:
 - `deterministic-mcp-actions-routes` covers the real `@elizaos/plugin-mcp`
   service against a committed stdio MCP fixture, the parent `MCP` router,
   `MCP_READ_RESOURCE`, `MCP_CALL_TOOL`, `MCP_SEARCH_ACTIONS`,
-  `MCP_LIST_CONNECTIONS`, strict deterministic LLM JSON for tool selection and
-  arguments, deterministic tool/resource response synthesis, and
+  `MCP_LIST_CONNECTIONS`, authored strict deterministic model fixtures for
+  routing, tool selection, arguments, and response synthesis, plus JSONL
+  request/response receipts and child-process teardown proof. It also covers
   `/api/mcp/status` route capability reporting for the discovered fixture tool
   and resource.
 - `deterministic-workflow-actions-routes` covers real embedded workflow services

--- a/packages/scenario-runner/test/scenarios/deterministic-mcp-actions-routes.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-mcp-actions-routes.scenario.ts
@@ -2,19 +2,16 @@
  * Keyless catalog coverage for the plugin-mcp action and route surface. Runs on
  * the pr-deterministic lane under the model provider.
  */
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync } from "node:fs";
 import type http from "node:http";
+import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { type IAgentRuntime, ModelType, type Plugin } from "@elizaos/core";
-import {
-  matchesScenarioInput,
-  type RuntimeWithScenarioModelFixtures,
-  registerStrictActionRouteFixtures,
-} from "@elizaos/core/testing";
+import type { IAgentRuntime, Plugin } from "@elizaos/core";
 import type {
   CapturedAction,
   ScenarioContext,
+  ScenarioModelFixture,
   ScenarioTurnExecution,
 } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
@@ -45,6 +42,10 @@ const listConnectionsInput = "Fetch deterministic MCP connections.";
 const scenarioDir = dirname(fileURLToPath(import.meta.url));
 const fixturePath = resolve(scenarioDir, "../fixtures/mcp-stdio-fixture.mjs");
 const fixtureSource = readFileSync(fixturePath, "utf8");
+const receiptPath = resolve(
+  tmpdir(),
+  `eliza-scenario-mcp-${process.pid}.jsonl`,
+);
 
 type JsonRecord = Record<string, unknown>;
 
@@ -114,54 +115,177 @@ const strictMcpRoutes = [
   },
 ];
 
-function matchesUnsupportedMcpEvaluation(expectedInput: string) {
-  const matchesInput = matchesScenarioInput(expectedInput);
-  return (value: string) =>
-    matchesInput(value) &&
-    value.includes("event:message_handler:") &&
-    value.includes(
-      "Stage 1 router marked this current turn as requiring a tool",
-    );
+const PLANNER_TOOL_NAMES = [
+  "MCP",
+  "MCP_CALL_TOOL",
+  "MCP_READ_RESOURCE",
+  "MCP_SEARCH_ACTIONS",
+  "MCP_LIST_CONNECTIONS",
+  "REPLY",
+  "IGNORE",
+  "STOP",
+] as const;
+
+function regexEscape(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function unsupportedMcpEvaluationFixture(input: string, op: string) {
+function actionRouteModelFixtures(
+  route: (typeof strictMcpRoutes)[number],
+): ScenarioModelFixture[] {
+  const slug = route.actionName.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  return [
+    {
+      name: `route-${slug}-stage1-${route.input}`,
+      match: {
+        modelType: "RESPONSE_HANDLER",
+        input: { includes: route.input },
+        toolNames: ["HANDLE_RESPONSE"],
+      },
+      response: {
+        json: {
+          contexts: [...route.contextIds],
+          intents: [route.input.toLowerCase()],
+          replyText: route.messageToUser,
+          threadOps: [],
+          candidateActionNames: [route.actionName],
+        },
+      },
+    },
+    {
+      name: `route-${slug}-planner-${route.input}`,
+      match: {
+        modelType: "ACTION_PLANNER",
+        input: { includes: route.input },
+        toolNames: PLANNER_TOOL_NAMES,
+      },
+      response: {
+        json: {
+          text: "",
+          thought: `Call ${route.actionName} for ${route.input}.`,
+          messageToUser: route.messageToUser,
+          completed: true,
+          finishReason: "tool-calls",
+          toolCalls: [
+            {
+              id: `call-${slug}`,
+              name: route.actionName,
+              type: "function",
+              arguments: route.args,
+            },
+          ],
+        },
+      },
+    },
+  ];
+}
+
+function unsupportedMcpModelFixtures(
+  input: string,
+  op: "search_actions" | "list_connections",
+): ScenarioModelFixture[] {
   const text = `MCP op=${op} is only available in the cloud runtime.`;
-  return {
-    name: `mcp-unsupported-${op}-evaluator-${input}`,
+  return [
+    {
+      name: `mcp-unsupported-${op}-evaluator-${input}`,
+      match: {
+        modelType: "RESPONSE_HANDLER",
+        input: {
+          pattern: `^(?=[\\s\\S]*${regexEscape(input)})(?=[\\s\\S]*event:message_handler:)(?=[\\s\\S]*Stage 1 router marked this current turn as requiring a tool)[\\s\\S]*$`,
+        },
+        toolNames: [],
+      },
+      response: {
+        json: {
+          success: false,
+          decision: "FINISH",
+          thought: `The ${op} action reported the local-runtime boundary.`,
+          messageToUser: text,
+        },
+      },
+    },
+    {
+      name: `mcp-unsupported-${op}-failure-synthesis-${input}`,
+      match: {
+        modelType: "ACTION_PLANNER",
+        input: { includes: input },
+        toolNames: [],
+      },
+      response: {
+        json: {
+          text,
+          thought: `Report the ${op} local-runtime boundary.`,
+          messageToUser: text,
+          completed: true,
+          finishReason: "stop",
+          toolCalls: [],
+        },
+      },
+    },
+  ];
+}
+
+const modelFixtures: ScenarioModelFixture[] = [
+  ...strictMcpRoutes.flatMap(actionRouteModelFixtures),
+  {
+    name: "mcp-resource-analysis",
     match: {
-      modelType: ModelType.RESPONSE_HANDLER,
-      input: matchesUnsupportedMcpEvaluation(input),
+      modelType: "TEXT_SMALL",
+      prompt: {
+        pattern: `^(?=[\\s\\S]*${regexEscape(RESOURCE_URI)})(?=[\\s\\S]*${regexEscape(RESOURCE_TEXT)})[\\s\\S]*$`,
+      },
+    },
+    response: { text: RESOURCE_ANALYSIS_TEXT },
+  },
+  {
+    name: "mcp-tool-selection-arguments",
+    match: {
+      modelType: "TEXT_LARGE",
+      prompt: {
+        pattern: `^(?=[\\s\\S]*# TASK: Generate Tool Arguments for Tool Execution)(?=[\\s\\S]*${TOOL_NAME})(?=[\\s\\S]*"code")[\\s\\S]*$`,
+      },
     },
     response: {
-      success: false,
-      decision: "FINISH",
-      thought: `The ${op} action reported the local-runtime boundary.`,
-      messageToUser: text,
+      json: {
+        toolArguments: { code: TOOL_CODE },
+        reasoning: "The requested code is alpha-42.",
+      },
     },
-    times: 1,
-  };
-}
+  },
+  {
+    name: "mcp-tool-reasoning",
+    match: {
+      modelType: "TEXT_SMALL",
+      prompt: {
+        pattern: `^(?=[\\s\\S]*Synthesize the result from the "${TOOL_NAME}" tool)(?=[\\s\\S]*${regexEscape(TOOL_OUTPUT)})[\\s\\S]*$`,
+      },
+    },
+    response: { text: TOOL_REASONING_TEXT },
+  },
+  ...unsupportedMcpModelFixtures(
+    parentListConnectionsInput,
+    "list_connections",
+  ),
+  ...unsupportedMcpModelFixtures(searchActionsInput, "search_actions"),
+  ...unsupportedMcpModelFixtures(listConnectionsInput, "list_connections"),
+];
 
-type RuntimeWithMcpScenario = IAgentRuntime &
-  RuntimeWithScenarioModelFixtures & {
-    plugins?: Plugin[];
-    getServiceLoadPromise?: (serviceType: string) => Promise<unknown>;
-    registerPlugin: (plugin: Plugin) => Promise<void>;
-    routes?: Array<{
-      type?: string;
-      path: string;
-      handler?: (
-        req: http.IncomingMessage,
-        res: http.ServerResponse,
-        runtime: unknown,
-      ) => Promise<void> | void;
-      __scenarioMcpRoute?: boolean;
-    }>;
-    scenarioModelFixtures?: {
-      register: (...fixtures: Array<Record<string, unknown>>) => void;
-    };
-    setSetting: (key: string, value: unknown, secret?: boolean) => void;
-  };
+type RuntimeWithMcpScenario = IAgentRuntime & {
+  plugins?: Plugin[];
+  getServiceLoadPromise?: (serviceType: string) => Promise<unknown>;
+  registerPlugin: (plugin: Plugin) => Promise<void>;
+  routes?: Array<{
+    type?: string;
+    path: string;
+    handler?: (
+      req: http.IncomingMessage,
+      res: http.ServerResponse,
+      runtime: unknown,
+    ) => Promise<void> | void;
+    __scenarioMcpRoute?: boolean;
+  }>;
+  setSetting: (key: string, value: unknown, secret?: boolean) => void;
+};
 
 type RouteStatusBody = {
   ok?: unknown;
@@ -169,6 +293,8 @@ type RouteStatusBody = {
 };
 
 let scenarioRuntime: RuntimeWithMcpScenario | null = null;
+let previousEvaluators: IAgentRuntime["evaluators"] | null = null;
+let previousMcpSetting: unknown;
 
 function isRecord(value: unknown): value is JsonRecord {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -378,6 +504,7 @@ function mcpConfig(): McpRouteConfig {
           type: "stdio",
           command: "node",
           args: [fixturePath],
+          env: { SCENARIO_MCP_RECEIPT_PATH: receiptPath },
           timeoutInMillis: 5_000,
         },
       },
@@ -504,82 +631,18 @@ async function seedMcp(ctx: ScenarioContext): Promise<string | undefined> {
   const runtime = ctx.runtime as RuntimeWithMcpScenario | undefined;
   if (!runtime) return "scenario runtime was not available";
   scenarioRuntime = runtime;
+  rmSync(receiptPath, { force: true });
   if (!fixtureSource.includes(RESOURCE_TEXT)) {
     return `MCP fixture source does not contain ${RESOURCE_TEXT}`;
   }
 
+  previousMcpSetting = runtime.getSetting("mcp");
   runtime.setSetting("mcp", mcpConfig().mcp, false);
-  registerStrictActionRouteFixtures(runtime, strictMcpRoutes);
-  runtime.scenarioModelFixtures?.register(
-    {
-      name: "mcp-resource-analysis",
-      match: {
-        modelType: ModelType.TEXT_SMALL,
-        prompt: (prompt: string) =>
-          prompt.includes(RESOURCE_URI) && prompt.includes(RESOURCE_TEXT),
-      },
-      response: RESOURCE_ANALYSIS_TEXT,
-      times: 1,
-    },
-    // Optional since plugin-mcp's direct tool selection (#18218): when the
-    // planner already names the server/tool in the action parameters, the
-    // model selection call is skipped entirely.
-    {
-      name: "mcp-tool-selection-name",
-      match: {
-        modelType: ModelType.TEXT_LARGE,
-        prompt: (prompt: string) =>
-          prompt.includes(
-            "# TASK: Select the Most Appropriate Tool and Server",
-          ) &&
-          prompt.includes(MCP_SERVER_NAME) &&
-          prompt.includes(TOOL_NAME),
-      },
-      response: JSON.stringify({
-        serverName: MCP_SERVER_NAME,
-        toolName: TOOL_NAME,
-        reasoning:
-          "The user asked to echo alpha-42 through the deterministic MCP fixture.",
-        noToolAvailable: false,
-      }),
-      times: { min: 0, max: 1 },
-    },
-    {
-      name: "mcp-tool-selection-arguments",
-      match: {
-        modelType: ModelType.TEXT_LARGE,
-        prompt: (prompt: string) =>
-          prompt.includes(
-            "# TASK: Generate Tool Arguments for Tool Execution",
-          ) &&
-          prompt.includes(TOOL_NAME) &&
-          prompt.includes('"code"'),
-      },
-      response: JSON.stringify({
-        toolArguments: { code: TOOL_CODE },
-        reasoning: "The requested code is alpha-42.",
-      }),
-      times: 1,
-    },
-    {
-      name: "mcp-tool-reasoning",
-      match: {
-        modelType: ModelType.TEXT_SMALL,
-        prompt: (prompt: string) =>
-          prompt.includes(
-            `Synthesize the result from the "${TOOL_NAME}" tool`,
-          ) && prompt.includes(TOOL_OUTPUT),
-      },
-      response: TOOL_REASONING_TEXT,
-      times: 1,
-    },
-    unsupportedMcpEvaluationFixture(
-      parentListConnectionsInput,
-      "list_connections",
-    ),
-    unsupportedMcpEvaluationFixture(searchActionsInput, "search_actions"),
-    unsupportedMcpEvaluationFixture(listConnectionsInput, "list_connections"),
-  );
+  // Post-turn evaluators are outside this MCP contract. Keep the manifest
+  // limited to the message loop and MCP-owned model calls, then restore them in
+  // cleanup so a shared runtime cannot leak the isolation choice.
+  previousEvaluators = runtime.evaluators;
+  runtime.evaluators = [];
 
   const registered = (runtime.plugins ?? []).some(
     (plugin) => plugin.name === mcpPlugin.name,
@@ -598,6 +661,9 @@ async function seedMcp(ctx: ScenarioContext): Promise<string | undefined> {
   if (!server) return `MCP server ${MCP_SERVER_NAME} was not registered`;
   if (server.status !== "connected") {
     return `MCP server ${MCP_SERVER_NAME} status was ${server.status}`;
+  }
+  if (process.env.ELIZA_SCENARIO_MCP_FAIL_AFTER_CONNECT === "1") {
+    return "forced MCP post-connect failure for teardown verification";
   }
   registerMcpRoutes(runtime);
   return undefined;
@@ -653,25 +719,108 @@ async function finalMcpCheck(
   if (readPath(server.resources?.[0], "uri") !== RESOURCE_URI) {
     return `expected MCP resource uri ${RESOURCE_URI}, saw ${stableStringify(server.resources)}`;
   }
-  await service.stop();
+  const receiptFailure = expectMcpReceipts();
+  if (receiptFailure) return receiptFailure;
   return undefined;
+}
+
+type McpReceipt = {
+  direction?: unknown;
+  method?: unknown;
+  payload?: unknown;
+  pid?: unknown;
+};
+
+function readMcpReceipts(): McpReceipt[] {
+  if (!existsSync(receiptPath)) return [];
+  return readFileSync(receiptPath, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as McpReceipt);
+}
+
+function expectMcpReceipts(): string | undefined {
+  const receipts = readMcpReceipts();
+  for (const method of [
+    "tools/list",
+    "resources/list",
+    "resources/templates/list",
+    "resources/read",
+    "tools/call",
+  ]) {
+    for (const direction of ["request", "response"]) {
+      if (
+        !receipts.some(
+          (receipt) =>
+            receipt.direction === direction && receipt.method === method,
+        )
+      ) {
+        return `missing MCP ${direction} receipt for ${method}: ${stableStringify(receipts)}`;
+      }
+    }
+  }
+  return undefined;
+}
+
+async function stopMcpAndProveNoOrphan(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  const runtime =
+    (ctx.runtime as RuntimeWithMcpScenario | undefined) ?? scenarioRuntime;
+  if (runtime && previousEvaluators) {
+    runtime.evaluators = previousEvaluators;
+    previousEvaluators = null;
+  }
+  runtime?.setSetting("mcp", previousMcpSetting, false);
+  previousMcpSetting = undefined;
+  const service = runtime?.getService<McpService>(MCP_SERVICE_NAME);
+  const started = readMcpReceipts().find(
+    (receipt) =>
+      receipt.direction === "lifecycle" && receipt.method === "started",
+  );
+  const pid = typeof started?.pid === "number" ? started.pid : null;
+  await service?.stop();
+  if (pid === null) return "MCP fixture did not record its child pid";
+
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    try {
+      process.kill(pid, 0);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ESRCH") return undefined;
+      return `MCP orphan probe failed for pid ${pid}: ${String(error)}`;
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+  }
+  return `MCP fixture process ${pid} remained alive after service.stop()`;
 }
 
 export default scenario({
   id: "deterministic-mcp-actions-routes",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [...modelFixtures],
+  },
   title: "Deterministic MCP action and route coverage",
   domain: "scenario-runner",
   tags: ["pr", "deterministic", "zero-cost", "mcp", "routes"],
   isolation: "shared-runtime",
   requires: {
-    plugins: ["@elizaos/plugin-mcp"],
+    services: [MCP_SERVICE_NAME],
   },
   seed: [
     {
       type: "custom",
       name: "start real stdio MCP fixture and register strict resource-analysis fixture",
       apply: seedMcp,
+    },
+  ],
+  cleanup: [
+    {
+      type: "custom",
+      name: "stop the MCP stdio fixture and prove its child process exited",
+      apply: stopMcpAndProveNoOrphan,
     },
   ],
   rooms: [


### PR DESCRIPTION
# Relates to

Closes #24072. Parent tracking: #22901 and #22896.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun run verify` was not run; exact focused checks and current checkout typecheck blockers are recorded below.
- [x] A reviewer can confirm the change from the strict report, MCP receipts, and teardown proof below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `f8a29be4c2`; zero conflicts.
- [ ] Root verify is deferred while this draft has the explicit #24108 prerequisite and the package typecheck checkout is missing generated/private plugin declarations (listed below).

# Risks

Low. The diff is scenario-only. The scenario now owns plugin start ordering, temporarily isolates unrelated post-turn evaluators, restores shared runtime settings/evaluators in cleanup, and fails if the real stdio child is not registered, does not answer the expected MCP protocol requests, or remains alive after cleanup.

# Background

## What does this PR do?

- Seeds MCP settings before registering the real `@elizaos/plugin-mcp`, fixing the prior initialize-with-zero-servers failure.
- Migrates `deterministic-mcp-actions-routes` from `legacy-fallback` to authored serializable strict fixtures.
- Exercises the real production MCP client over stdio for capability discovery, resource read, tool call, connection/action routing boundaries, and `/api/mcp/status`.
- Records JSONL request/response/lifecycle receipts in the scenario-owned child and verifies teardown by PID on both pass and intentional post-connect failure.
- Advances the migration ratchet from 40/79 to 41 strict-or-model-free / 78 legacy (119 total).

## What kind of change is this?

Bug fix and deterministic test-harness improvement.

# Documentation changes needed?

Updated the scenario catalog to describe strict fixtures, protocol receipts, and subprocess teardown proof.

# Testing

## Where should a reviewer start?

`packages/scenario-runner/test/scenarios/deterministic-mcp-actions-routes.scenario.ts` and `packages/scenario-runner/test/fixtures/mcp-stdio-fixture.mjs`.

## Detailed testing steps

```bash
SCENARIO_USE_DETERMINISTIC_MODEL=1 bun --conditions eliza-source \
  --tsconfig-override ../../tsconfig.json src/cli.ts run test/scenarios \
  --scenario deterministic-mcp-actions-routes --report /tmp/mcp.json \
  --run-dir /tmp/mcp-run

bunx vitest run --config vitest.config.ts \
  src/model-fixture-migration.test.ts src/schema-strict.test.ts \
  src/executor-cleanup.test.ts

bun run build
```

Observed at the reviewed head:

- exact scenario: passed; `modelFixtureMode=strict-fixtures`; 19/19 required fixtures consumed exactly once; zero unexpected calls.
- focused tests: 3 files, 21 tests passed.
- scenario-runner build: passed.
- Biome on all changed source/test files: passed.
- `git diff --check`: passed.
- forced post-connect failure: scenario exited 1 with the authored seed failure and the recorded child PID was absent after cleanup.

# Evidence Gate

<!-- evidence-head:25fe248848eb44c387643505f7a5ea4090ecf4a9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered interaction changed.
<!-- evidence-row:backend-logs -->
- [x] Real scenario backend summary:

```text
scenario=deterministic-mcp-actions-routes status=passed mode=strict-fixtures
requiredFixtures=19 consumedExactlyOnce=19 unexpectedCalls=0
actions=MCP_READ_RESOURCE,MCP_CALL_TOOL,MCP,MCP_SEARCH_ACTIONS,MCP_LIST_CONNECTIONS finalChecks=6/6
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - this PR changes the deterministic mock-LLM scenario contract, not live-model behavior; strict fixture diagnostics are the acceptance artifact.
<!-- evidence-row:domain-artifacts -->
- [x] MCP protocol and lifecycle artifacts: [pass-path raw JSONL receipts](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24126-eliza-scenario-mcp-26867.jsonl) and [forced-failure raw JSONL receipts](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24126-eliza-scenario-mcp-22265.jsonl).

```text
pid=27124 requestMethods=tools/list,resources/list,resources/templates/list,resources/read,tools/call
resourceText=mcp-resource-note:alpha-42 toolResponse=mcp-tool-echo:alpha-42 receiptRecords=12
lifecycleEvents=started,stopped orphanAfterPass=false; forcedFailurePid=22606 orphanAfterFailure=false
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text changed.

# Evidence Details

## Strict model report

```json
{
  "status": "passed",
  "modelFixtureMode": "strict-fixtures",
  "requiredFixtureCount": 19,
  "consumedExactlyOnce": 19,
  "unexpectedCalls": []
}
```

## MCP request/response receipts

The scenario-owned stdio child produced [12 raw JSONL receipts](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24126-eliza-scenario-mcp-26867.jsonl) at PID `27124`:

```json
{
  "requests": [
    "tools/list",
    "resources/list",
    "resources/templates/list",
    "resources/read",
    "tools/call"
  ],
  "resourceResponse": {
    "uri": "fixture://mcp-note",
    "text": "mcp-resource-note:alpha-42"
  },
  "toolResponse": "mcp-tool-echo:alpha-42",
  "lifecycle": ["started", "stopped"],
  "orphanAfterPass": false
}
```

Intentional failure proof used PID `22606` ([raw JSONL receipts](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24126-eliza-scenario-mcp-22265.jsonl)):

```json
{
  "scenarioStatus": "failed",
  "error": "forced MCP post-connect failure for teardown verification",
  "lifecycle": ["started", "stopped"],
  "orphanAfterFailure": false
}
```

## Known gaps / failures

- `src/__tests__/deterministic-action-coverage.test.ts`: current `develop` still recognizes only imperative `scenarioModelFixtures.register` and `ModelType.*` source strings, so it reports the authored MCP manifest as three missing declarations. #24108 already contains the generic runtime-manifest recognition and is the preferred prerequisite; this PR intentionally does not duplicate or diverge from it.
- `bun run --cwd packages/scenario-runner typecheck`: the fresh worktree lacks multiple private/generated plugin declaration outputs (`@elizaos/plugin-discord`, `@elizaos/plugin-elizacloud`, wallet, personal-assistant subpaths, native packages) and reports unrelated existing lifeops type errors. The changed scenario is parsed/executed by the exact scenario run, and `tsc6 --noCheck` package build passes.
- Root `bun run verify` was not run for this draft because the focused prerequisite and checkout-wide typecheck blockers above are already explicit.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [issue-24072-mcp-stdio]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
