### PR TITLE
fix(cloud): commit app and initial API key atomically

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/apps-create-postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps-create-postgres.integration.test.ts
@@ -95,6 +95,8 @@ async function cleanupHarness(): Promise<void> {
     try {
       await operation();
     } catch (error) {
+      // error-policy:J6 Teardown continues through every resource so the first
+      // cleanup failure does not leak the database or PostgreSQL process.
       firstError ??= error;
     }
   };
@@ -172,9 +174,11 @@ afterAll(cleanupHarness, 60_000);
 try {
   await initializeHarness();
 } catch (error) {
+  // error-policy:J2 Preserve initialization and cleanup failures together.
   try {
     await cleanupHarness();
   } catch (cleanupError) {
+    // error-policy:J2 Aggregate both causes instead of masking either failure.
     throw new AggregateError(
       [error, cleanupError],
       "PostgreSQL app atomicity harness initialization and cleanup both failed",

--- a/packages/cloud/shared/src/db/repositories/__tests__/apps-create-postgres.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps-create-postgres.integration.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Proves app and initial API-key creation share one real PostgreSQL transaction.
+ *
+ * Two service calls run on independent pool sessions while an external holder
+ * owns the organization row lock. Both calls must be blocked in open
+ * transactions before the holder releases them; with one slot remaining,
+ * exactly one linked app/key pair commits and the losing key rolls back.
+ */
+
+import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { pushSchema } from "drizzle-kit/api";
+import { Client } from "pg";
+import {
+  acquireEphemeralPostgres,
+  type EphemeralPostgres,
+} from "../../../lib/services/tenant-db/__tests__/ephemeral-postgres";
+import { apiKeys } from "../../schemas/api-keys";
+import {
+  appDeploymentStatusEnum,
+  appReviewStatusEnum,
+  apps,
+  userDatabaseStatusEnum,
+} from "../../schemas/apps";
+import { organizations } from "../../schemas/organizations";
+import { users } from "../../schemas/users";
+
+const SKIP_REASON =
+  "[app API-key atomicity] SKIPPED - no real PostgreSQL available. " +
+  "Set APPS_TENANT_DB_EPHEMERAL=1 with Docker, or provide APPS_TENANT_DB_TEST_DSN.";
+const ORIGINAL_ENV = {
+  DATABASE_URL: process.env.DATABASE_URL,
+  TEST_DATABASE_URL: process.env.TEST_DATABASE_URL,
+  NODE_ENV: process.env.NODE_ENV,
+  ENVIRONMENT: process.env.ENVIRONMENT,
+  MOCK_REDIS: process.env.MOCK_REDIS,
+  CACHE_ENABLED: process.env.CACHE_ENABLED,
+  ELIZA_KMS_BACKEND: process.env.ELIZA_KMS_BACKEND,
+  ELIZA_CLOUD_MAX_APPS_PER_ORG: process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG,
+  LOCAL_PG_POOL_MAX: process.env.LOCAL_PG_POOL_MAX,
+};
+
+let postgres: EphemeralPostgres | null = null;
+let databaseName: string | null = null;
+let isolatedDsn: string | null = null;
+let closeDatabaseConnectionsForTests:
+  | typeof import("../../client").closeDatabaseConnectionsForTests
+  | undefined;
+let dbWrite: typeof import("../../client").dbWrite | undefined;
+let appsRepository: typeof import("../apps").appsRepository | undefined;
+let apiKeysRepository: typeof import("../api-keys").apiKeysRepository | undefined;
+let appsService: typeof import("../../../lib/services/apps").appsService | undefined;
+let apiKeysService: typeof import("../../../lib/services/api-keys").apiKeysService | undefined;
+
+function restoreEnv(name: keyof typeof ORIGINAL_ENV, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+async function createIsolatedDatabase(baseDsn: string): Promise<string> {
+  databaseName = `eliza_app_key_atomicity_${randomUUID().replaceAll("-", "")}`;
+  const admin = new Client({ connectionString: baseDsn });
+  await admin.connect();
+  try {
+    await admin.query(`CREATE DATABASE "${databaseName}"`);
+  } finally {
+    await admin.end();
+  }
+  const url = new URL(baseDsn);
+  url.pathname = `/${databaseName}`;
+  return url.toString();
+}
+
+async function waitUntilBlockedWaiters(observer: Client, minimum: number): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const result = await observer.query<{ waiters: number }>(`
+      SELECT count(*)::int AS waiters
+      FROM pg_stat_activity activity
+      WHERE activity.datname = current_database()
+        AND activity.pid <> pg_backend_pid()
+        AND cardinality(pg_blocking_pids(activity.pid)) > 0
+    `);
+    if ((result.rows[0]?.waiters ?? 0) >= minimum) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for ${minimum} blocked app-create transactions`);
+}
+
+async function cleanupHarness(): Promise<void> {
+  const acquiredPostgres = postgres;
+  const databaseToDrop = databaseName;
+  let firstError: unknown;
+  const capture = async (operation: () => Promise<void>): Promise<void> => {
+    try {
+      await operation();
+    } catch (error) {
+      firstError ??= error;
+    }
+  };
+
+  await capture(async () => {
+    await closeDatabaseConnectionsForTests?.();
+  });
+  closeDatabaseConnectionsForTests = undefined;
+
+  if (acquiredPostgres && databaseToDrop) {
+    await capture(async () => {
+      const admin = new Client({ connectionString: acquiredPostgres.dsn });
+      await admin.connect();
+      try {
+        await admin.query(
+          "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+          [databaseToDrop],
+        );
+        await admin.query(`DROP DATABASE IF EXISTS "${databaseToDrop}"`);
+      } finally {
+        await admin.end();
+      }
+    });
+  }
+
+  await capture(async () => {
+    await acquiredPostgres?.stop();
+  });
+  postgres = null;
+  databaseName = null;
+  isolatedDsn = null;
+  for (const [name, value] of Object.entries(ORIGINAL_ENV)) {
+    restoreEnv(name as keyof typeof ORIGINAL_ENV, value);
+  }
+
+  if (firstError) throw firstError;
+}
+
+async function initializeHarness(): Promise<void> {
+  postgres = await acquireEphemeralPostgres();
+  if (!postgres) {
+    console.warn(SKIP_REASON);
+    return;
+  }
+
+  isolatedDsn = await createIsolatedDatabase(postgres.dsn);
+  process.env.DATABASE_URL = isolatedDsn;
+  process.env.TEST_DATABASE_URL = isolatedDsn;
+  process.env.NODE_ENV = "test";
+  process.env.ENVIRONMENT = "local";
+  process.env.MOCK_REDIS = "1";
+  process.env.CACHE_ENABLED = "true";
+  process.env.ELIZA_KMS_BACKEND = "memory";
+  process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "2";
+  process.env.LOCAL_PG_POOL_MAX = "8";
+
+  const clientModule = await import("../../client");
+  closeDatabaseConnectionsForTests = clientModule.closeDatabaseConnectionsForTests;
+  dbWrite = clientModule.dbWrite;
+  const [appsRepositoryModule, apiKeysRepositoryModule, appsModule, apiKeysModule] =
+    await Promise.all([
+      import("../apps"),
+      import("../api-keys"),
+      import("../../../lib/services/apps"),
+      import("../../../lib/services/api-keys"),
+    ]);
+  appsRepository = appsRepositoryModule.appsRepository;
+  apiKeysRepository = apiKeysRepositoryModule.apiKeysRepository;
+  appsService = appsModule.appsService;
+  apiKeysService = apiKeysModule.apiKeysService;
+}
+
+afterAll(cleanupHarness, 60_000);
+
+try {
+  await initializeHarness();
+} catch (error) {
+  try {
+    await cleanupHarness();
+  } catch (cleanupError) {
+    throw new AggregateError(
+      [error, cleanupError],
+      "PostgreSQL app atomicity harness initialization and cleanup both failed",
+    );
+  }
+  throw error;
+}
+
+beforeAll(async () => {
+  if (!dbWrite) return;
+  const schema = {
+    organizations,
+    users,
+    apiKeys,
+    apps,
+    appDeploymentStatusEnum,
+    appReviewStatusEnum,
+    userDatabaseStatusEnum,
+  };
+  const { apply } = await pushSchema(schema as never, dbWrite as never);
+  await apply();
+}, 60_000);
+
+const realPostgres = postgres ? describe : describe.skip;
+
+realPostgres("app and initial API-key atomicity", () => {
+  test("two creates competing for one slot commit exactly one linked key without compensation", async () => {
+    if (
+      !isolatedDsn ||
+      !dbWrite ||
+      !appsRepository ||
+      !apiKeysRepository ||
+      !appsService ||
+      !apiKeysService
+    ) {
+      throw new Error("real PostgreSQL harness was not initialized");
+    }
+
+    const suffix = randomUUID();
+    const [organization] = await dbWrite
+      .insert(organizations)
+      .values({ name: "Atomicity Org", slug: `atomicity-org-${suffix}` })
+      .returning();
+    const [user] = await dbWrite
+      .insert(users)
+      .values({
+        steward_user_id: `atomicity-user-${suffix}`,
+        organization_id: organization.id,
+      })
+      .returning();
+    await appsRepository.create({
+      name: "Existing Atomicity App",
+      slug: `existing-atomicity-app-${suffix}`,
+      organization_id: organization.id,
+      created_by_user_id: user.id,
+      app_url: "https://existing-atomicity.example",
+      api_key_id: randomUUID(),
+    });
+
+    const names = [`Atomic Left ${suffix}`, `Atomic Right ${suffix}`] as const;
+    const holder = new Client({ connectionString: isolatedDsn });
+    const observer = new Client({ connectionString: isolatedDsn });
+    await Promise.all([holder.connect(), observer.connect()]);
+    await holder.query("BEGIN");
+    await holder.query("SELECT id FROM organizations WHERE id = $1 FOR NO KEY UPDATE", [
+      organization.id,
+    ]);
+
+    const deleteKey = spyOn(apiKeysService, "delete");
+    const creates = names.map((name, index) =>
+      appsService.create({
+        name,
+        organization_id: organization.id,
+        created_by_user_id: user.id,
+        app_url: `https://atomic-${index}.example`,
+      }),
+    );
+    let holderReleased = false;
+
+    try {
+      await waitUntilBlockedWaiters(observer, 2);
+      await holder.query("COMMIT");
+      holderReleased = true;
+
+      const outcomes = await Promise.allSettled(creates);
+      const fulfilled = outcomes.filter(
+        (outcome): outcome is PromiseFulfilledResult<Awaited<(typeof creates)[number]>> =>
+          outcome.status === "fulfilled",
+      );
+      const rejected = outcomes.filter(
+        (outcome): outcome is PromiseRejectedResult => outcome.status === "rejected",
+      );
+
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      const winner = fulfilled[0];
+      const loser = rejected[0];
+      if (!winner || !loser) throw new Error("expected one app-create winner and one loser");
+      expect(loser.reason).toMatchObject({
+        name: "AppCreationLimitError",
+        organizationId: organization.id,
+        limit: 2,
+      });
+      expect(await appsRepository.countByOrganization(organization.id)).toBe(2);
+
+      const durableKeys = (
+        await Promise.all(
+          names.map((name) =>
+            apiKeysRepository.findByUserAndName(user.id, `${name} - App API Key`),
+          ),
+        )
+      ).flat();
+      const durableApps = (await appsRepository.listByOrganization(organization.id)).filter((app) =>
+        names.includes(app.name as (typeof names)[number]),
+      );
+
+      expect(durableKeys).toHaveLength(1);
+      expect(durableApps).toHaveLength(1);
+      const durableKey = durableKeys[0];
+      const durableApp = durableApps[0];
+      if (!durableKey || !durableApp) throw new Error("winning app/key pair did not persist");
+      expect(durableApp.api_key_id).toBe(durableKey.id);
+      expect(winner.value.app.id).toBe(durableApp.id);
+      expect(winner.value.app.api_key_id).toBe(durableKey.id);
+      expect((await apiKeysService.validateApiKey(winner.value.apiKey))?.id).toBe(durableKey.id);
+      expect(deleteKey).not.toHaveBeenCalled();
+    } finally {
+      if (!holderReleased) await holder.query("ROLLBACK");
+      await Promise.allSettled(creates);
+      deleteKey.mockRestore();
+      await Promise.all([holder.end(), observer.end()]);
+    }
+  }, 30_000);
+});

--- a/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
@@ -1377,7 +1377,7 @@ describe("AppsService.create organization cap", () => {
     }
   });
 
-  test("rejects before API key creation when the org is already at the configured app cap", async () => {
+  test("rolls back the API key when the org is already at the configured app cap", async () => {
     expect(pgliteReady).toBe(true);
     const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
     process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "1";
@@ -1388,24 +1388,30 @@ describe("AppsService.create organization cap", () => {
         organization_id: organizationId,
         created_by_user_id: userId,
       });
+      const deleteKey = spyOn(apiKeysService, "delete");
 
-      await expect(
-        appsService.create({
-          name: "Blocked App",
-          organization_id: organizationId,
-          created_by_user_id: userId,
-          app_url: "https://blocked.example",
-        }),
-      ).rejects.toMatchObject({
-        name: "AppCreationLimitError",
-        organizationId,
-        limit: 1,
-      });
+      try {
+        await expect(
+          appsService.create({
+            name: "Blocked App",
+            organization_id: organizationId,
+            created_by_user_id: userId,
+            app_url: "https://blocked.example",
+          }),
+        ).rejects.toMatchObject({
+          name: "AppCreationLimitError",
+          organizationId,
+          limit: 1,
+        });
 
-      expect(await appsRepository.countByOrganization(organizationId)).toBe(1);
-      expect(
-        await apiKeysRepository.findByUserAndName(userId, "Blocked App - App API Key"),
-      ).toEqual([]);
+        expect(await appsRepository.countByOrganization(organizationId)).toBe(1);
+        expect(
+          await apiKeysRepository.findByUserAndName(userId, "Blocked App - App API Key"),
+        ).toEqual([]);
+        expect(deleteKey).not.toHaveBeenCalled();
+      } finally {
+        deleteKey.mockRestore();
+      }
     } finally {
       if (previousLimit === undefined) {
         delete process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
@@ -1434,9 +1440,12 @@ describe("AppsService.create organization cap", () => {
       expect(result.apiKey).toMatch(/^eliza_/);
       expect(await appsRepository.countByOrganization(organizationId)).toBe(1);
 
-      const apiKey = await apiKeysRepository.findById(result.app.api_key_id ?? "");
+      const apiKeyId = result.app.api_key_id;
+      if (!apiKeyId) throw new Error("created app did not retain its API-key identity");
+      const apiKey = await apiKeysRepository.findById(apiKeyId);
       expect(apiKey?.organization_id).toBe(organizationId);
       expect(apiKey?.user_id).toBe(userId);
+      expect((await apiKeysService.validateApiKey(result.apiKey))?.id).toBe(apiKey?.id);
     } finally {
       if (previousLimit === undefined) {
         delete process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
@@ -1446,34 +1455,85 @@ describe("AppsService.create organization cap", () => {
     }
   });
 
-  test("cleans up the generated API key when the transactional cap check rejects", async () => {
+  test("rolls back the generated API key without compensation when the cap check rejects", async () => {
     expect(pgliteReady).toBe(true);
     const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
-    const originalCreateIfBelowLimit = appsRepository.createIfOrganizationBelowLimit;
     process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "25";
     try {
       const { organizationId, userId } = await seedOrgAndUser();
-      appsRepository.createIfOrganizationBelowLimit = async () => undefined;
+      const createIfBelowLimit = spyOn(
+        appsRepository,
+        "createIfOrganizationBelowLimit",
+      ).mockImplementation(async () => undefined);
+      const deleteKey = spyOn(apiKeysService, "delete");
 
-      await expect(
-        appsService.create({
-          name: "Race Rejected App",
-          organization_id: organizationId,
-          created_by_user_id: userId,
-          app_url: "https://race-rejected.example",
-        }),
-      ).rejects.toMatchObject({
-        name: "AppCreationLimitError",
-        organizationId,
-        limit: 25,
-      });
+      try {
+        await expect(
+          appsService.create({
+            name: "Race Rejected App",
+            organization_id: organizationId,
+            created_by_user_id: userId,
+            app_url: "https://race-rejected.example",
+          }),
+        ).rejects.toMatchObject({
+          name: "AppCreationLimitError",
+          organizationId,
+          limit: 25,
+        });
 
-      expect(
-        await apiKeysRepository.findByUserAndName(userId, "Race Rejected App - App API Key"),
-      ).toEqual([]);
-      expect(await appsRepository.countByOrganization(organizationId)).toBe(0);
+        expect(
+          await apiKeysRepository.findByUserAndName(userId, "Race Rejected App - App API Key"),
+        ).toEqual([]);
+        expect(await appsRepository.countByOrganization(organizationId)).toBe(0);
+        expect(deleteKey).not.toHaveBeenCalled();
+      } finally {
+        deleteKey.mockRestore();
+        createIfBelowLimit.mockRestore();
+      }
     } finally {
-      appsRepository.createIfOrganizationBelowLimit = originalCreateIfBelowLimit;
+      if (previousLimit === undefined) {
+        delete process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
+      } else {
+        process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = previousLimit;
+      }
+    }
+  });
+
+  test("preserves an app insert failure while rolling back the generated API key", async () => {
+    expect(pgliteReady).toBe(true);
+    const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
+    process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "25";
+    try {
+      const { organizationId, userId } = await seedOrgAndUser();
+      const insertFailure = new Error("synthetic app insert failure");
+      const createIfBelowLimit = spyOn(
+        appsRepository,
+        "createIfOrganizationBelowLimit",
+      ).mockImplementation(async () => {
+        throw insertFailure;
+      });
+      const deleteKey = spyOn(apiKeysService, "delete");
+
+      try {
+        await expect(
+          appsService.create({
+            name: "Insert Failure App",
+            organization_id: organizationId,
+            created_by_user_id: userId,
+            app_url: "https://insert-failure.example",
+          }),
+        ).rejects.toBe(insertFailure);
+
+        expect(
+          await apiKeysRepository.findByUserAndName(userId, "Insert Failure App - App API Key"),
+        ).toEqual([]);
+        expect(await appsRepository.countByOrganization(organizationId)).toBe(0);
+        expect(deleteKey).not.toHaveBeenCalled();
+      } finally {
+        deleteKey.mockRestore();
+        createIfBelowLimit.mockRestore();
+      }
+    } finally {
       if (previousLimit === undefined) {
         delete process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
       } else {

--- a/packages/cloud/shared/src/db/repositories/apps.ts
+++ b/packages/cloud/shared/src/db/repositories/apps.ts
@@ -550,25 +550,29 @@ export class AppsRepository {
    *
    * The organization row lock serializes concurrent app creates for one org in
    * Postgres, so parallel requests cannot all observe the same pre-insert count.
+   * `NO KEY UPDATE` remains exclusive between contenders while staying compatible
+   * with the foreign-key `KEY SHARE` lock held by their transactional API-key insert.
    */
-  async createIfOrganizationBelowLimit(data: NewApp, maxApps: number): Promise<App | undefined> {
-    return dbWrite.transaction(async (tx) => {
-      await tx.execute(
-        sql`SELECT ${organizations.id} FROM ${organizations} WHERE ${organizations.id} = ${data.organization_id} FOR UPDATE`,
-      );
+  async createIfOrganizationBelowLimit(
+    data: NewApp,
+    maxApps: number,
+    tx: DbTransaction,
+  ): Promise<App | undefined> {
+    await tx.execute(
+      sql`SELECT ${organizations.id} FROM ${organizations} WHERE ${organizations.id} = ${data.organization_id} FOR NO KEY UPDATE`,
+    );
 
-      const [row] = await tx
-        .select({ count: count() })
-        .from(apps)
-        .where(eq(apps.organization_id, data.organization_id));
+    const [row] = await tx
+      .select({ count: count() })
+      .from(apps)
+      .where(eq(apps.organization_id, data.organization_id));
 
-      if ((row?.count ?? 0) >= maxApps) {
-        return undefined;
-      }
+    if ((row?.count ?? 0) >= maxApps) {
+      return undefined;
+    }
 
-      const [app] = await tx.insert(apps).values(data).returning();
-      return app;
-    });
+    const [app] = await tx.insert(apps).values(data).returning();
+    return app;
   }
 
   /**

--- a/packages/cloud/shared/src/lib/services/apps.ts
+++ b/packages/cloud/shared/src/lib/services/apps.ts
@@ -4,6 +4,7 @@
 
 import { ElizaError } from "@elizaos/core";
 import crypto from "crypto";
+import { writeTransaction } from "../../db/helpers";
 import {
   type App,
   type AppUser,
@@ -455,19 +456,20 @@ export class AppsService {
       throw new Error("Failed to generate unique slug");
     }
 
-    const { limit } = await this.assertCanCreateForOrganization(data.organization_id);
+    const limit = getMaxAppsPerOrg();
+    const created = await writeTransaction(async (tx) => {
+      const { apiKey, plainKey } = await apiKeysService.create(
+        {
+          name: `${data.name} - App API Key`,
+          description: `API key for app: ${data.name}`,
+          organization_id: data.organization_id,
+          user_id: data.created_by_user_id,
+          rate_limit: 10000,
+        },
+        tx,
+      );
 
-    const { apiKey, plainKey } = await apiKeysService.create({
-      name: `${data.name} - App API Key`,
-      description: `API key for app: ${data.name}`,
-      organization_id: data.organization_id,
-      user_id: data.created_by_user_id,
-      rate_limit: 10000,
-    });
-
-    let app: App | undefined;
-    try {
-      app = await appsRepository.createIfOrganizationBelowLimit(
+      const app = await appsRepository.createIfOrganizationBelowLimit(
         {
           name: data.name,
           description: data.description,
@@ -482,40 +484,23 @@ export class AppsService {
           contact_email: data.contact_email,
         },
         limit,
+        tx,
       );
-    } catch (error) {
-      // error-policy:J2 — remove the provisional API key, then preserve the
-      // original atomic app-create failure for the caller.
-      await apiKeysService.delete(apiKey.id).catch((cleanupError) => {
-        // error-policy:J6 — key rollback is best-effort after the primary app
-        // create failure and cannot replace that failure.
-        logger.warn("[Apps] Failed to clean up API key after app create failure", {
-          apiKeyId: apiKey.id,
-          error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
-        });
-      });
-      throw error;
-    }
 
-    if (!app) {
-      await apiKeysService.delete(apiKey.id).catch((cleanupError) => {
-        // error-policy:J6 — key rollback is best-effort after the authoritative
-        // cap rejection; the typed cap error remains the result.
-        logger.warn("[Apps] Failed to clean up API key after app cap rejection", {
-          apiKeyId: apiKey.id,
-          error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
-        });
-      });
-      throw new AppCreationLimitError(data.organization_id, limit);
-    }
+      if (!app) {
+        throw new AppCreationLimitError(data.organization_id, limit);
+      }
 
-    logger.info(`Created app: ${app.name} (${app.id})`, {
-      appId: app.id,
-      slug: app.slug,
-      organizationId: app.organization_id,
+      return { app, apiKey: plainKey };
     });
 
-    return { app, apiKey: plainKey };
+    logger.info(`Created app: ${created.app.name} (${created.app.id})`, {
+      appId: created.app.id,
+      slug: created.app.slug,
+      organizationId: created.app.organization_id,
+    });
+
+    return created;
   }
 
   async update(id: string, data: Partial<NewApp>): Promise<App | undefined> {


### PR DESCRIPTION
# Relates to

Relates to #24083. Follow-up to the app-cap implementation in #10468.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` ran after sync; the
      exact unrelated baseline blocker is recorded below.
- [x] A reviewer can verify the change without reading the implementation from
      the attached real-PostgreSQL N/N+1 evidence.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d6d8dcda44dc473d0eeda9169fe2cf257746c397:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Based on `origin/develop@5dee7a4c5e054a36f010aae63dd61008c4a3d0a4`;
      zero conflicts and no upstream edits on the four changed paths.
- [x] `bun run verify` was run post-rebase; its exact unrelated
      `@elizaos/agent` lint blocker is documented below.

# Risks

Medium. This changes the commit boundary and PostgreSQL row-lock mode for app
creation. The app row and its initial credential now commit or roll back as one
unit. `FOR NO KEY UPDATE` remains exclusive between quota contenders while
staying compatible with the `KEY SHARE` lock acquired by the credential's
organization foreign key. No quota value, HTTP response, schema, migration,
price, entitlement, cache contract, or provider request changes.

# Background

## What does this PR do?

- Opens one caller-owned write transaction in `AppsService.create()`.
- Creates the initial API key and the app inside that same transaction.
- Reuses the transaction in the quota-authoritative repository insert instead
  of committing the credential before a nested transaction.
- Removes best-effort create-path credential deletion: rollback is now the only
  failure path.
- Adds PGlite rollback/error-identity coverage and a real PostgreSQL two-session
  N/N+1 regression.

The real PostgreSQL test caught a lock-upgrade deadlock during development:
concurrent key inserts hold `KEY SHARE` on the organization row, so upgrading to
`FOR UPDATE` allowed the two requests to block each other. The final
`FOR NO KEY UPDATE` lock is compatible with those FK locks and still serializes
the cap check; the regression now blocks both contenders specifically on that
quota lock and proves exactly one winner.

## What kind of change is this?

Bug fix (credential/app transactional atomicity and concurrency correctness).

# Documentation changes needed?

No public documentation change is needed. The API and quota contract are
unchanged; the transaction and lock invariants are captured in repository tests.

# Testing

## Where should a reviewer start?

Start with `AppsService.create()` in
`packages/cloud/shared/src/lib/services/apps.ts`, then
`createIfOrganizationBelowLimit()` in the apps repository, and finally the new
real-PostgreSQL integration test.

## Detailed testing steps

```bash
bun install --frozen-lockfile
bun test --config=/dev/null --timeout=60000 --isolate \
  packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts

# Point APPS_TENANT_DB_TEST_DSN at a disposable real PostgreSQL superuser DB.
APPS_TENANT_DB_TEST_DSN=postgresql://127.0.0.1:55443/postgres?sslmode=disable \
  bun test --config=/dev/null --timeout=60000 --isolate \
  packages/cloud/shared/src/db/repositories/__tests__/apps-create-postgres.integration.test.ts

bun run --cwd packages/cloud/shared typecheck
bun run --cwd packages/cloud/shared lint
git diff --check origin/develop...HEAD
bun run verify
```

Exact-head results at `d6d8dcda44dc473d0eeda9169fe2cf257746c397`:
frozen install made no changes; PGlite passed 37 tests / 218 assertions; real
PostgreSQL 17 passed 1 test / 11 assertions and an independent 10/10 stress
repetition; cloud-shared typecheck and its 2,267-file lint passed; diff hygiene
passed. Independent final-head review found no P0-P3 issue.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:c741462fcf06004e757fea022455ac213288a6d7 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Database repository, service, and tests only; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - Database repository, service, and tests only; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No interactive or rendered user flow is changed.
<!-- evidence-row:backend-logs -->
- [x] [24127-app-key-backend-d6d8dcd.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24127-app-key-backend-d6d8dcd.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend request, response, console, or state path is changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No agent, action, prompt, provider, or model behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [x] [24127-app-key-domain-d6d8dcd.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24127-app-key-domain-d6d8dcd.txt)
<!-- evidence-row:ocr-review -->
- [ ] N/A - The diff has no rendered visual surface or visual text.

# Evidence Details

## Real LLM-call trajectory

N/A - No agent, action, prompt, provider, or model behavior is changed.

## Backend + frontend logs

Exact-head backend and PostgreSQL domain artifacts are attached in the evidence
rows above. Frontend logs are N/A because there is no frontend diff.

## Screenshots (before / after) + video walkthrough

N/A - The diff has no rendered UI or interactive user flow.

## Audio / voice walkthrough

N/A - No voice, transcript, TTS, STT, or omnivoice behavior is changed.

## Known gaps / failures

- `bun run verify` exits only in the untouched `@elizaos/agent#lint:check`
  task: 12 errors, 39 warnings, and 7 infos across 1,034 agent files. None of
  those files are in this four-file diff; #23973 owns the current baseline fix.
- The real PostgreSQL test skips explicitly without an external DSN or requested
  ephemeral server. It passed locally on a disposable PostgreSQL 17 server and
  an independent 10/10 stress run. This PR intentionally does not edit the
  active `cloud-tests.yml` lane currently owned by #24062.
- The existing `apiKeysService.create(data, tx)` contract performs KMS encryption
  inside the transaction. The local memory backend has no external I/O; a future
  prepare/persist split may reduce connection hold time for a remote KMS without
  weakening the authoritative quota check.
- No deployment, production database access, credential mutation, provider call,
  secret change, or infrastructure mutation was performed.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@d6d8dcda44dc473d0eeda9169fe2cf257746c397:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [billing-v3-app-key-atomicity]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@d6d8dcda44dc473d0eeda9169fe2cf257746c397:packages/skills/skills/contribute-to-eliza"} -->

## Maintainer exact-head review

Restacked cleanly onto `develop@5cb54c90e3849604dee0bde8bd18af7c33627383`; the production transaction/lock patch applied unchanged. The PostgreSQL harness catches now carry mandatory J2/J6 classifications.

Independent exact-head results at `c741462fcf06004e757fea022455ac213288a6d7`: app repository/service PGlite suite 37/37 with 218 assertions; no-PostgreSQL cleanup/skip path 1/1; focused Biome and diff hygiene passed. The attached real-PostgreSQL evidence remains patch-equivalent and proves the two-session N/N+1 contention behavior, including 10/10 repetition.

Maintainer AI provider/model: OpenAI / gpt-5
Maintainer client / agent tooling: Codex
Maintainer attribution status: system-confirmed
— [codex-maintainer-exact-head-24127]
