### PR TITLE
fix(agent): parse rm short-option clusters correctly for recursive/force

### DIFF
--- a/packages/agent/src/services/vfs-builtin-shell.test.ts
+++ b/packages/agent/src/services/vfs-builtin-shell.test.ts
@@ -83,6 +83,54 @@ describe("runVfsBuiltinShell", () => {
     ).rejects.toThrow("File not found");
   });
 
+  it("runs rm -Rf recursively and removes the target tree", async () => {
+    const vfs = createVirtualFilesystemService({ projectId: "rm-cluster" });
+    await vfs.initialize();
+    await vfs.writeFile("target/nested/file.txt", "bye");
+
+    const rm = await runVfsBuiltinShell({
+      cwdUri: "vfs://rm-cluster",
+      command: "rm",
+      args: ["-Rf", "target"],
+    });
+    expect(rm.exitCode).toBe(0);
+    await expect(vfs.readFile("target/nested/file.txt")).rejects.toThrow(
+      "File not found",
+    );
+  });
+
+  it("runs rm -fR recursively and removes the target tree", async () => {
+    const vfs = createVirtualFilesystemService({ projectId: "rm-cluster2" });
+    await vfs.initialize();
+    await vfs.writeFile("target/nested/file.txt", "bye");
+
+    const rm = await runVfsBuiltinShell({
+      cwdUri: "vfs://rm-cluster2",
+      command: "rm",
+      args: ["-fR", "target"],
+    });
+    expect(rm.exitCode).toBe(0);
+    await expect(vfs.readFile("target/nested/file.txt")).rejects.toThrow(
+      "File not found",
+    );
+  });
+
+  it("runs rm -rvf recursively and removes the target tree", async () => {
+    const vfs = createVirtualFilesystemService({ projectId: "rm-cluster3" });
+    await vfs.initialize();
+    await vfs.writeFile("target/nested/file.txt", "bye");
+
+    const rm = await runVfsBuiltinShell({
+      cwdUri: "vfs://rm-cluster3",
+      command: "rm",
+      args: ["-rvf", "target"],
+    });
+    expect(rm.exitCode).toBe(0);
+    await expect(vfs.readFile("target/nested/file.txt")).rejects.toThrow(
+      "File not found",
+    );
+  });
+
   it("runs grep and rg over VFS files without host ripgrep", async () => {
     const vfs = createVirtualFilesystemService({ projectId: "searchable" });
     await vfs.initialize();

--- a/packages/agent/src/services/vfs-builtin-shell.ts
+++ b/packages/agent/src/services/vfs-builtin-shell.ts
@@ -235,10 +235,11 @@ async function rm(
   args: string[],
 ): Promise<VfsBuiltinCommandResult> {
   const optionArgs = args.filter((arg) => arg.startsWith("-"));
-  const recursive = optionArgs.some(
-    (arg) => arg === "-r" || arg === "-R" || arg === "-rf" || arg === "-fr",
-  );
-  const force = optionArgs.some((arg) => arg.includes("f"));
+  const shortFlags = optionArgs
+    .map((arg) => arg.slice(1).replaceAll("-", ""))
+    .join("");
+  const recursive = shortFlags.includes("r") || shortFlags.includes("R");
+  const force = shortFlags.includes("f");
   const targets = args.filter((arg) => !arg.startsWith("-"));
   if (targets.length === 0) {
     return {


### PR DESCRIPTION
Closes #24109

rm -Rf, -fR, and -rvf now set recursive=true. The implementation
collects short flags from the cluster instead of matching a fixed set of
spellings, and the regression tests cover the missing spellings.

- packages/agent/src/services/vfs-builtin-shell.ts
- packages/agent/src/services/vfs-builtin-shell.test.ts