### PR TITLE
fix: make coding-agent capability claims executable

### DIFF
--- a/packages/agent/src/api/accounts-routes.test.ts
+++ b/packages/agent/src/api/accounts-routes.test.ts
@@ -6,6 +6,8 @@ import { EventEmitter } from "node:events";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { LINKED_ACCOUNT_PROVIDER_IDS } from "@elizaos/core";
+import { codingProviderDescriptorForProvider } from "@elizaos/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const fakes = vi.hoisted(() => ({
@@ -227,8 +229,30 @@ describe("accounts routes", () => {
     const request = makeContext("GET", "/api/accounts");
     await handleAccountsRoutes(request.ctx);
     const response = request.jsonCalls[0]?.body as {
-      providers: Array<Record<string, unknown>>;
+      providers: Array<{
+        providerId: string;
+        runtimeEligibility: {
+          chat: { available: boolean };
+          codingAgent: { available: boolean };
+        };
+      }>;
     };
+    for (const providerId of LINKED_ACCOUNT_PROVIDER_IDS) {
+      const provider = response.providers.find(
+        (item) => item.providerId === providerId,
+      );
+      const descriptor = codingProviderDescriptorForProvider(providerId);
+      if (!provider || !descriptor) {
+        throw new Error(`missing capability row for ${providerId}`);
+      }
+      expect(provider.runtimeEligibility.chat.available, providerId).toBe(
+        descriptor.inferenceSupport,
+      );
+      expect(
+        provider.runtimeEligibility.codingAgent.available,
+        providerId,
+      ).toBe(descriptor.spawnSupport);
+    }
     expect(
       response.providers.find((item) => item.providerId === "openai-api"),
     ).toMatchObject({
@@ -236,7 +260,11 @@ describe("accounts routes", () => {
       accounts: [{ id: "account-1", hasCredential: true }],
       runtimeEligibility: {
         chat: { available: true, credentialPath: "direct-api" },
-        codingAgent: { available: true, credentialPath: "direct-api" },
+        codingAgent: {
+          available: false,
+          credentialPath: "none",
+          unavailableReason: expect.any(String),
+        },
       },
     });
     expect(
@@ -246,9 +274,47 @@ describe("accounts routes", () => {
     ).toMatchObject({
       runtimeEligibility: {
         chat: { available: false, credentialPath: "none" },
-        codingAgent: { available: true, credentialPath: "account-pool" },
+        codingAgent: {
+          available: true,
+          backend: "claude",
+          credentialPath: "account-pool",
+        },
       },
     });
+
+    for (const providerId of [
+      "zai-coding",
+      "kimi-coding",
+      "deepseek-coding",
+      "deepseek-api",
+      "zai-api",
+      "moonshot-api",
+      "anthropic-api",
+      "openai-api",
+      "cerebras-api",
+    ]) {
+      expect(
+        response.providers.find((item) => item.providerId === providerId),
+      ).toMatchObject({
+        runtimeEligibility: {
+          codingAgent: {
+            available: false,
+            credentialPath: "none",
+            unavailableReason: expect.any(String),
+          },
+        },
+      });
+    }
+    for (const providerId of ["zai-coding", "kimi-coding"]) {
+      expect(
+        response.providers.find((item) => item.providerId === providerId),
+      ).toMatchObject({
+        runtimeEligibility: {
+          chat: { available: true, credentialPath: "account-pool" },
+          codingAgent: { available: false, credentialPath: "none" },
+        },
+      });
+    }
   });
 
   it("sets, surfaces, validates, and clears subscriptionEndsAt through PATCH", async () => {

--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -70,9 +70,15 @@ import {
 } from "@elizaos/core";
 import type { RouteRequestContext } from "@elizaos/shared";
 import {
+  CODING_PROVIDER_DESCRIPTORS,
+  codingAgentSpawnCapabilityForProvider,
+  codingProviderCredentialPathForProvider,
+  codingProviderDescriptorForProvider,
   isLinkedAccountProviderId,
   type LinkedAccountConfig,
   type LinkedAccountProviderId,
+  type ProviderRuntimeCapability,
+  type ProviderRuntimeEligibility,
   type ServiceRouteAccountStrategy,
 } from "@elizaos/shared";
 import * as zod from "zod";
@@ -320,126 +326,99 @@ export function _resetAccountsRoutesPoolCache(): void {
 
 // ─── Provider id mapping ────────────────────────────────────────────
 
-const SUPPORTED_PROVIDER_IDS = [
-  "anthropic-subscription",
-  "openai-codex",
-  "gemini-cli",
-  "zai-coding",
-  "kimi-coding",
-  "deepseek-coding",
-  "anthropic-api",
-  "openai-api",
-  "deepseek-api",
-  "zai-api",
-  "moonshot-api",
-  "cerebras-api",
-] as const satisfies readonly LinkedAccountProviderId[];
+const SUPPORTED_PROVIDER_IDS = Object.keys(
+  CODING_PROVIDER_DESCRIPTORS,
+) as LinkedAccountProviderId[];
 
-const DIRECT_PROVIDER_IDS = new Set<LinkedAccountProviderId>([
-  "anthropic-api",
-  "openai-api",
-  "deepseek-api",
-  "zai-api",
-  "moonshot-api",
-  "cerebras-api",
-]);
-
-type ProviderRuntimeCapability = {
-  available: boolean;
-  defaultModel?: string;
-  credentialPath?: "account-pool" | "direct-api" | "external-cli" | "none";
-  unavailableReason?: string;
-};
-
-type ProviderRuntimeEligibility = {
-  chat: ProviderRuntimeCapability;
-  codingAgent: ProviderRuntimeCapability;
-};
+const DIRECT_PROVIDER_IDS = new Set<LinkedAccountProviderId>(
+  SUPPORTED_PROVIDER_IDS.filter(
+    (providerId) =>
+      CODING_PROVIDER_DESCRIPTORS[providerId].accountKind === "api-key",
+  ),
+);
 
 const ANTHROPIC_SUBSCRIPTION_CHAT_BLOCKED_REASON =
   "Claude subscription OAuth credentials are scoped to Claude Code CLI/coding-agent use. Fable chat must use a direct Anthropic API/app-owned provider path; the shared external Anthropic proxy is a dev fallback only.";
 
+function codingAgentCapabilityForProvider(
+  providerId: LinkedAccountProviderId,
+  credentialPath: Exclude<
+    NonNullable<ProviderRuntimeCapability["credentialPath"]>,
+    "none"
+  >,
+  defaultModel?: string,
+): ProviderRuntimeCapability {
+  const spawn = codingAgentSpawnCapabilityForProvider(providerId);
+  if (!spawn.available) {
+    return {
+      available: false,
+      credentialPath: "none",
+      unavailableReason: spawn.unavailableReason,
+    };
+  }
+  return {
+    available: true,
+    backend: spawn.backend,
+    credentialPath,
+    ...(defaultModel ? { defaultModel } : {}),
+  };
+}
+
 function runtimeEligibilityForProvider(
   providerId: LinkedAccountProviderId,
 ): ProviderRuntimeEligibility {
-  switch (providerId) {
-    case "anthropic-subscription":
-      return {
-        chat: {
-          available: false,
-          defaultModel: "claude-fable-5",
-          credentialPath: "none",
-          unavailableReason: ANTHROPIC_SUBSCRIPTION_CHAT_BLOCKED_REASON,
-        },
-        codingAgent: {
-          available: true,
-          defaultModel: "claude-fable-5",
-          credentialPath: "account-pool",
-        },
-      };
-    case "openai-codex":
-      return {
-        chat: {
-          available: true,
-          defaultModel: "gpt-5.6-sol",
-          credentialPath: "account-pool",
-        },
-        codingAgent: {
-          available: true,
-          defaultModel: "gpt-5.6-terra",
-          credentialPath: "account-pool",
-        },
-      };
-    case "anthropic-api":
-      return {
-        chat: {
-          available: true,
-          defaultModel: "claude-fable-5",
-          credentialPath: "direct-api",
-        },
-        codingAgent: {
-          available: true,
-          defaultModel: "claude-fable-5",
-          credentialPath: "direct-api",
-        },
-      };
-    case "gemini-cli":
-      return {
-        chat: {
-          available: false,
-          credentialPath: "none",
-          unavailableReason:
-            "Gemini subscription auth stays inside Gemini CLI and is not a runtime chat provider.",
-        },
-        codingAgent: { available: true, credentialPath: "external-cli" },
-      };
-    default: {
-      const direct = DIRECT_PROVIDER_IDS.has(providerId);
-      const codingPlan = isCodingPlanKeySubscriptionProvider(providerId);
-      return {
-        chat: {
-          available: direct,
-          credentialPath: direct ? "direct-api" : "none",
-          ...(direct
-            ? {}
-            : {
-                unavailableReason:
-                  "This provider is not registered as a runtime chat provider.",
-              }),
-        },
-        codingAgent: {
-          available: direct || codingPlan,
-          credentialPath: direct ? "direct-api" : "account-pool",
-          ...(!direct && !codingPlan
-            ? {
-                unavailableReason:
-                  "This provider is not registered as a coding-agent credential source.",
-              }
-            : {}),
-        },
-      };
-    }
+  const descriptor = codingProviderDescriptorForProvider(providerId);
+  if (!descriptor) {
+    throw new ElizaError(
+      "Linked account provider has no capability descriptor",
+      {
+        code: "ACCOUNT_PROVIDER_DESCRIPTOR_MISSING",
+        context: { providerId },
+        severity: "fatal",
+      },
+    );
   }
+  const credentialPath = codingProviderCredentialPathForProvider(providerId);
+  if (!credentialPath) {
+    throw new ElizaError("Linked account provider has no credential path", {
+      code: "ACCOUNT_PROVIDER_CREDENTIAL_PATH_MISSING",
+      context: { providerId },
+      severity: "fatal",
+    });
+  }
+  const chatDefaultModel =
+    providerId === "anthropic-subscription" || providerId === "anthropic-api"
+      ? "claude-fable-5"
+      : providerId === "openai-codex"
+        ? "gpt-5.6-sol"
+        : undefined;
+  const codingDefaultModel =
+    providerId === "anthropic-subscription" || providerId === "anthropic-api"
+      ? "claude-fable-5"
+      : providerId === "openai-codex"
+        ? "gpt-5.6-terra"
+        : undefined;
+  const chatUnavailableReason =
+    providerId === "anthropic-subscription"
+      ? ANTHROPIC_SUBSCRIPTION_CHAT_BLOCKED_REASON
+      : descriptor.authMode === "external-cli"
+        ? "This provider's credentials stay inside its external CLI and are not available to runtime chat."
+        : "This provider is not registered as a runtime chat provider.";
+  return {
+    chat: {
+      available: descriptor.inferenceSupport,
+      credentialPath: descriptor.inferenceSupport ? credentialPath : "none",
+      ...(chatDefaultModel ? { defaultModel: chatDefaultModel } : {}),
+      ...(descriptor.inferenceSupport
+        ? {}
+        : { unavailableReason: chatUnavailableReason }),
+    },
+    codingAgent: codingAgentCapabilityForProvider(
+      providerId,
+      credentialPath,
+      codingDefaultModel,
+    ),
+  };
 }
 
 function asSubscriptionProvider(

--- a/packages/app-core/src/services/coding-account-bridge.test.ts
+++ b/packages/app-core/src/services/coding-account-bridge.test.ts
@@ -3,7 +3,7 @@
  * and its auth-failure triage (isAuthFailure): least-used vs priority vs config-
  * vs env-driven selection, per-agent env patches (CLAUDE_CODE_OAUTH_TOKEN, a
  * materialized CODEX_HOME/auth.json + config.toml with a TOML-injection guard,
- * active-generation discovery, CEREBRAS_API_KEY), usage attribution, and rate-
+ * active-generation discovery), usage attribution, and rate-
  * limit skipping. Runs against a real temp ELIZA_HOME / ELIZA_STATE_DIR and real
  * account storage — no mocked pool.
  */
@@ -556,20 +556,18 @@ describe("coding-account-bridge", () => {
     expect(cfg).toContain('cli_auth_credentials_store = "file"');
   });
 
-  it("rotates opencode across least-used cerebras-api accounts → CEREBRAS_API_KEY", async () => {
-    writeAccount("cerebras-api", "cb-busy", "cb-key-busy");
-    writeAccount("cerebras-api", "cb-idle", "cb-key-idle");
+  it("fails closed for direct API accounts and unknown adapters", async () => {
+    writeAccount("openai-api", "direct", "openai-direct-key");
+    writeAccount("cerebras-api", "cerebras", "cerebras-direct-key");
     getDefaultAccountPool();
-    await setUsage("cerebras-api", "cb-busy", 88);
-    await setUsage("cerebras-api", "cb-idle", 4);
-    const sel = await getCodingAgentSelectorBridge()?.select("opencode", {
-      strategy: "least-used",
-    });
-    expect(sel?.providerId).toBe("cerebras-api");
-    expect(sel?.accountId).toBe("cb-idle");
-    // buildOpencodeSpawnConfig reads CEREBRAS_API_KEY from the injected env.
-    expect(sel?.envPatch.CEREBRAS_API_KEY).toBe("cb-key-idle");
-    expect(sel?.source).toBe("api-key");
+    const bridge = getCodingAgentSelectorBridge();
+
+    expect(await bridge?.select("codex")).toBeNull();
+    expect(await bridge?.select("unknown-adapter")).toBeNull();
+    expect(Object.keys(bridge?.describe() ?? {}).sort()).toEqual([
+      "claude",
+      "codex",
+    ]);
   });
 
   it("attributes recorded usage to the serving account (per-account delta)", async () => {

--- a/packages/app-core/src/services/coding-account-bridge.ts
+++ b/packages/app-core/src/services/coding-account-bridge.ts
@@ -65,7 +65,10 @@ import {
   resolveStateDir,
   setCodingAgentSelectorBridge,
 } from "@elizaos/core";
-import type { LinkedAccountProviderId } from "@elizaos/shared/contracts/service-routing";
+import {
+  CODING_AGENT_BACKEND_PROVIDERS,
+  type LinkedAccountProviderId,
+} from "@elizaos/shared";
 import {
   type AccountPool,
   configuredAccountStrategyForProvider,
@@ -109,8 +112,8 @@ function getEnvCodingStrategy(): Strategy | undefined {
 
 /**
  * Ordered provider candidates per coding-agent type. The first provider with an
- * eligible account wins; a subscription provider is preferred over its direct
- * API equivalent (subscriptions are the primary use case here).
+ * eligible account wins. The shared descriptor only maps credential transports
+ * that the bridge can actually materialize for the selected executable.
  *
  * claude (claude-agent-acp) and codex (codex-acp) are first-party CLIs.
  * z.ai / Kimi / GLM have no first-party coding
@@ -120,8 +123,8 @@ function getEnvCodingStrategy(): Strategy | undefined {
 const AGENT_PROVIDER_CANDIDATES: Readonly<
   Record<string, readonly LinkedAccountProviderId[]>
 > = {
-  claude: ["anthropic-subscription", "anthropic-api"],
-  codex: ["openai-codex", "openai-api"],
+  claude: CODING_AGENT_BACKEND_PROVIDERS.claude,
+  codex: CODING_AGENT_BACKEND_PROVIDERS.codex,
 };
 
 function candidatesFor(agentType: string): readonly LinkedAccountProviderId[] {

--- a/packages/auth/src/credentials.ts
+++ b/packages/auth/src/credentials.ts
@@ -855,7 +855,7 @@ export function applySubscriptionCredentialsLocal(
     hasConfiguredExternalCredential("gemini-cli")
   ) {
     logger.info(
-      "[auth] Gemini CLI subscription surface detected/configured — available only through Gemini CLI task agents. " +
+      "[auth] Gemini CLI subscription surface detected/configured — available through the external Gemini CLI, but not wired to the coding-agent orchestrator. " +
         "Not applied to GOOGLE_API_KEY or GOOGLE_GENERATIVE_AI_API_KEY.",
     );
   }

--- a/packages/auth/src/types.test.ts
+++ b/packages/auth/src/types.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Proves subscription enrollment metadata derives its auth and billing terms
+ * from the canonical linked-provider descriptor contract.
+ */
+
+import {
+  codingProviderEnrollmentAvailability,
+  codingProviderSubscriptionAuthMode,
+  codingProviderSubscriptionBillingMode,
+} from "@elizaos/shared";
+import { describe, expect, it } from "vitest";
+import {
+  SUBSCRIPTION_PROVIDER_IDS,
+  SUBSCRIPTION_PROVIDER_METADATA,
+} from "./types.js";
+
+describe("subscription provider metadata", () => {
+  it("matches canonical auth and billing truth for every subscription", () => {
+    for (const providerId of SUBSCRIPTION_PROVIDER_IDS) {
+      expect(SUBSCRIPTION_PROVIDER_METADATA[providerId]).toMatchObject({
+        providerId,
+        availability: codingProviderEnrollmentAvailability(providerId),
+        authMode: codingProviderSubscriptionAuthMode(providerId),
+        billingMode: codingProviderSubscriptionBillingMode(providerId),
+      });
+    }
+  });
+});

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -2,6 +2,12 @@
  * Subscription auth types for eliza.
  */
 
+import {
+  codingProviderEnrollmentAvailability,
+  codingProviderSubscriptionAuthMode,
+  codingProviderSubscriptionBillingMode,
+} from "@elizaos/shared";
+
 export interface OAuthCredentials {
   access: string;
   refresh: string;
@@ -222,9 +228,13 @@ export const SUBSCRIPTION_PROVIDER_METADATA: Record<
     displayName: "Claude Subscription",
     selectionIds: ["anthropic-subscription"],
     allowedClient: "Claude Code CLI",
-    billingMode: "subscription-coding-cli",
-    authMode: "oauth",
-    availability: "available",
+    billingMode: codingProviderSubscriptionBillingMode(
+      "anthropic-subscription",
+    ),
+    authMode: codingProviderSubscriptionAuthMode("anthropic-subscription"),
+    availability: codingProviderEnrollmentAvailability(
+      "anthropic-subscription",
+    ),
     setupHint: "Sign in through the app or run claude auth login.",
     directProviderId: "anthropic-api",
   },
@@ -233,9 +243,9 @@ export const SUBSCRIPTION_PROVIDER_METADATA: Record<
     displayName: "OpenAI Codex",
     selectionIds: ["openai-subscription"],
     allowedClient: "Codex CLI / Codex-backed provider",
-    billingMode: "subscription-coding-cli",
-    authMode: "oauth",
-    availability: "available",
+    billingMode: codingProviderSubscriptionBillingMode("openai-codex"),
+    authMode: codingProviderSubscriptionAuthMode("openai-codex"),
+    availability: codingProviderEnrollmentAvailability("openai-codex"),
     setupHint: "Sign in through the app or run codex login.",
     directProviderId: "openai-api",
   },
@@ -244,9 +254,9 @@ export const SUBSCRIPTION_PROVIDER_METADATA: Record<
     displayName: "Gemini CLI",
     selectionIds: ["gemini-subscription"],
     allowedClient: "Gemini CLI",
-    billingMode: "subscription-coding-cli",
-    authMode: "external-cli",
-    availability: "external",
+    billingMode: codingProviderSubscriptionBillingMode("gemini-cli"),
+    authMode: codingProviderSubscriptionAuthMode("gemini-cli"),
+    availability: codingProviderEnrollmentAvailability("gemini-cli"),
     setupHint:
       "Run gemini auth login; tokens are not imported into API env vars.",
   },
@@ -255,9 +265,9 @@ export const SUBSCRIPTION_PROVIDER_METADATA: Record<
     displayName: "z.ai Coding Plan",
     selectionIds: ["zai-coding-subscription"],
     allowedClient: "z.ai Coding endpoint",
-    billingMode: "subscription-coding-plan",
-    authMode: "coding-plan-key",
-    availability: "available",
+    billingMode: codingProviderSubscriptionBillingMode("zai-coding"),
+    authMode: codingProviderSubscriptionAuthMode("zai-coding"),
+    availability: codingProviderEnrollmentAvailability("zai-coding"),
     setupHint:
       "Add a z.ai Coding Plan credential for the dedicated coding endpoint.",
     directProviderId: "zai-api",
@@ -269,9 +279,9 @@ export const SUBSCRIPTION_PROVIDER_METADATA: Record<
     displayName: "Kimi Code",
     selectionIds: ["kimi-coding-subscription"],
     allowedClient: "Kimi Code endpoint",
-    billingMode: "subscription-coding-plan",
-    authMode: "coding-plan-key",
-    availability: "available",
+    billingMode: codingProviderSubscriptionBillingMode("kimi-coding"),
+    authMode: codingProviderSubscriptionAuthMode("kimi-coding"),
+    availability: codingProviderEnrollmentAvailability("kimi-coding"),
     setupHint: "Add a Kimi Code credential for the dedicated coding endpoint.",
     directProviderId: "moonshot-api",
     defaultBaseUrl: CODING_PLAN_PROVIDER_BASE_URL["kimi-coding"],
@@ -282,9 +292,9 @@ export const SUBSCRIPTION_PROVIDER_METADATA: Record<
     displayName: "DeepSeek Coding Plan",
     selectionIds: ["deepseek-coding-subscription"],
     allowedClient: "Unavailable",
-    billingMode: "subscription-coding-plan",
-    authMode: "unavailable",
-    availability: "unavailable",
+    billingMode: codingProviderSubscriptionBillingMode("deepseek-coding"),
+    authMode: codingProviderSubscriptionAuthMode("deepseek-coding"),
+    availability: codingProviderEnrollmentAvailability("deepseek-coding"),
     setupHint:
       "Use the DeepSeek direct API-key provider if you have API billing.",
     directProviderId: "deepseek-api",

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -18,6 +18,7 @@
       "@elizaos/core": ["../core/src/index.node.ts"],
       "@elizaos/core/atomic-json": ["../core/src/utils/atomic-json.ts"],
       "@elizaos/logger": ["../logger/src/index.ts"],
+      "@elizaos/shared": ["../shared/src/index.ts"],
       "@elizaos/vault": ["../vault/src/index.ts"]
     }
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -31,6 +31,7 @@
     "prepublishOnly": "bun run build",
     "build": "bun run build:i18n && bun run build:dist",
     "build:i18n": "node scripts/generate-keywords.mjs",
+    "generate:coding-provider-support-matrix": "bun scripts/generate-coding-provider-support-matrix.ts",
     "typecheck": "bun run build:i18n && tsc --noEmit -p tsconfig.json",
     "test": "node ../scripts/run-vitest.mjs run --config ./vitest.config.ts",
     "lint": "bunx @biomejs/biome check --write src",

--- a/packages/shared/scripts/generate-coding-provider-support-matrix.ts
+++ b/packages/shared/scripts/generate-coding-provider-support-matrix.ts
@@ -1,0 +1,24 @@
+/**
+ * Emits the canonical coding-provider support matrix as a reviewable JSON
+ * artifact without introducing Node-only code into the shared package barrel.
+ */
+
+import { writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { CODING_PROVIDER_SUPPORT_MATRIX } from "../src/contracts/coding-agent-capabilities.js";
+
+const outputFlagIndex = process.argv.indexOf("--output");
+const outputPath =
+  outputFlagIndex >= 0 ? process.argv[outputFlagIndex + 1]?.trim() : undefined;
+if (outputFlagIndex >= 0 && !outputPath) {
+  throw new Error("--output requires a destination path");
+}
+
+const serialized = `${JSON.stringify(CODING_PROVIDER_SUPPORT_MATRIX, null, 2)}\n`;
+if (outputPath) {
+  const destination = resolve(outputPath);
+  await writeFile(destination, serialized, "utf8");
+  process.stdout.write(`${destination}\n`);
+} else {
+  process.stdout.write(serialized);
+}

--- a/packages/shared/src/contracts/coding-agent-capabilities.test.ts
+++ b/packages/shared/src/contracts/coding-agent-capabilities.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Proves the pure account-to-coding-backend contract, including negative
+ * coverage for enrolled inference providers that have no spawn implementation.
+ */
+
+import { LINKED_ACCOUNT_PROVIDER_IDS } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  CODING_AGENT_BACKEND_PREFLIGHTS,
+  CODING_AGENT_BACKEND_PROVIDERS,
+  CODING_AGENT_BACKENDS,
+  CODING_PROVIDER_DESCRIPTOR_VERSION,
+  CODING_PROVIDER_DESCRIPTORS,
+  CODING_PROVIDER_SUPPORT_MATRIX,
+  codingAgentBackendForProvider,
+  codingAgentSpawnCapabilityForProvider,
+} from "./coding-agent-capabilities.js";
+
+describe("coding-agent capability mapping", () => {
+  it("maps every advertised account capability to one canonical backend", () => {
+    const mappedProviders = LINKED_ACCOUNT_PROVIDER_IDS.filter(
+      (providerId) =>
+        codingAgentSpawnCapabilityForProvider(providerId).available,
+    );
+
+    expect(mappedProviders).toEqual(["anthropic-subscription", "openai-codex"]);
+    for (const providerId of mappedProviders) {
+      const backend = codingAgentBackendForProvider(providerId);
+      expect(CODING_AGENT_BACKENDS).toContain(backend);
+      if (!backend) throw new Error(`missing backend for ${providerId}`);
+      expect(CODING_AGENT_BACKEND_PROVIDERS[backend]).toContain(providerId);
+    }
+  });
+
+  it.each([
+    "gemini-cli",
+    "zai-coding",
+    "kimi-coding",
+    "deepseek-coding",
+    "deepseek-api",
+    "zai-api",
+    "moonshot-api",
+    "anthropic-api",
+    "openai-api",
+    "cerebras-api",
+  ] as const)("keeps %s enrollment separate from spawn availability", (id) => {
+    const capability = codingAgentSpawnCapabilityForProvider(id);
+    expect(capability.available).toBe(false);
+    expect(capability.backend).toBeUndefined();
+    expect(capability.unavailableReason).toBeTruthy();
+  });
+
+  it("declares a preflight backend for every credential route", () => {
+    expect(CODING_AGENT_BACKEND_PREFLIGHTS).toEqual({
+      elizaos: {
+        requiredRuntime: "eliza-code-acp",
+        discoveryPolicy: "bundled-or-configured-command",
+        commandConfigKey: "ELIZA_ELIZAOS_ACP_COMMAND",
+        commandResolution: "literal",
+        defaultCommand: "eliza-code-acp",
+      },
+      "pi-agent": {
+        requiredRuntime: "pi-agent",
+        discoveryPolicy: "bundled-or-configured-command",
+        commandConfigKey: "ELIZA_PI_AGENT_ACP_COMMAND",
+        commandResolution: "literal",
+        defaultCommand: "pi-agent",
+      },
+      claude: {
+        requiredRuntime: "claude-acp",
+        discoveryPolicy: "configured-command-or-path",
+        commandConfigKey: "ELIZA_CLAUDE_ACP_COMMAND",
+        commandResolution: "literal",
+        defaultCommand: "npx -y @agentclientprotocol/claude-agent-acp@0.34.0",
+      },
+      codex: {
+        requiredRuntime: "codex-acp",
+        discoveryPolicy: "configured-command-or-path",
+        commandConfigKey: "ELIZA_CODEX_ACP_COMMAND",
+        commandResolution: "managed-codex",
+      },
+    });
+    for (const backend of CODING_AGENT_BACKENDS) {
+      const providers = CODING_AGENT_BACKEND_PROVIDERS[backend];
+      if (providers.length === 0) continue;
+      expect(CODING_AGENT_BACKENDS).toContain(backend);
+      expect(CODING_AGENT_BACKEND_PREFLIGHTS[backend]).toMatchObject({
+        requiredRuntime: expect.any(String),
+        discoveryPolicy: expect.any(String),
+      });
+    }
+  });
+
+  it("describes every linked-account catalog provider exactly once", () => {
+    const descriptorIds = Object.keys(CODING_PROVIDER_DESCRIPTORS);
+    expect(descriptorIds).toEqual([...LINKED_ACCOUNT_PROVIDER_IDS]);
+    expect(new Set(descriptorIds).size).toBe(descriptorIds.length);
+    for (const [providerId, descriptor] of Object.entries(
+      CODING_PROVIDER_DESCRIPTORS,
+    )) {
+      expect(descriptor).toMatchObject({
+        version: CODING_PROVIDER_DESCRIPTOR_VERSION,
+        providerId,
+        accountKind: expect.stringMatching(/^(subscription|api-key)$/),
+        authMode: expect.stringMatching(
+          /^(oauth|direct-api-key|coding-plan-key|external-cli|unavailable)$/,
+        ),
+        billingMode: expect.stringMatching(
+          /^(subscription-coding-plan|subscription-coding-cli|usage)$/,
+        ),
+        enrollmentSupport: expect.any(Boolean),
+        inferenceSupport: expect.any(Boolean),
+        spawnSupport: expect.any(Boolean),
+      });
+      expect(descriptor.spawnSupport).toBe(descriptor.backend !== null);
+      if (descriptor.spawnSupport) {
+        if (!descriptor.backend) {
+          throw new Error(`missing backend for ${providerId}`);
+        }
+        expect(descriptor.requiredRuntime).toBe(
+          CODING_AGENT_BACKEND_PREFLIGHTS[descriptor.backend].requiredRuntime,
+        );
+        expect(descriptor.discoveryPolicy).toBe(
+          CODING_AGENT_BACKEND_PREFLIGHTS[descriptor.backend].discoveryPolicy,
+        );
+        expect(descriptor.unsupportedReason).toBeNull();
+      } else {
+        expect(descriptor.requiredRuntime).toBeNull();
+        expect(descriptor.discoveryPolicy).toBe("none");
+        expect(descriptor.unsupportedReason).toBeTruthy();
+      }
+    }
+    for (const providerId of ["zai-coding", "kimi-coding"] as const) {
+      expect(CODING_PROVIDER_DESCRIPTORS[providerId]).toMatchObject({
+        authMode: "coding-plan-key",
+        billingMode: "subscription-coding-plan",
+        inferenceSupport: true,
+        spawnSupport: false,
+      });
+    }
+  });
+
+  it("rejects provider-to-backend ambiguity and descriptor drift", () => {
+    const routedProviders = Object.values(
+      CODING_AGENT_BACKEND_PROVIDERS,
+    ).flat();
+    expect(new Set(routedProviders).size).toBe(routedProviders.length);
+    for (const providerId of routedProviders) {
+      const descriptor = CODING_PROVIDER_DESCRIPTORS[providerId];
+      expect(descriptor.spawnSupport).toBe(true);
+      expect(descriptor.backend).toBe(
+        codingAgentBackendForProvider(providerId),
+      );
+    }
+    const descriptorProviders = Object.values(CODING_PROVIDER_DESCRIPTORS)
+      .filter((descriptor) => descriptor.spawnSupport)
+      .map((descriptor) => descriptor.providerId)
+      .sort();
+    expect(descriptorProviders).toEqual([...routedProviders].sort());
+  });
+
+  it("fails closed for an unknown provider", () => {
+    expect(codingAgentBackendForProvider("unknown-provider")).toBeUndefined();
+    expect(codingAgentSpawnCapabilityForProvider("unknown-provider")).toEqual({
+      available: false,
+      unavailableReason:
+        "No supported coding-agent spawn backend consumes this account provider.",
+    });
+  });
+
+  it("emits a deterministic versioned provider support matrix", () => {
+    expect(CODING_PROVIDER_SUPPORT_MATRIX).toEqual({
+      version: CODING_PROVIDER_DESCRIPTOR_VERSION,
+      providers: Object.values(CODING_PROVIDER_DESCRIPTORS),
+    });
+    expect(JSON.parse(JSON.stringify(CODING_PROVIDER_SUPPORT_MATRIX))).toEqual(
+      CODING_PROVIDER_SUPPORT_MATRIX,
+    );
+  });
+});

--- a/packages/shared/src/contracts/coding-agent-capabilities.test.ts
+++ b/packages/shared/src/contracts/coding-agent-capabilities.test.ts
@@ -84,10 +84,12 @@ describe("coding-agent capability mapping", () => {
       const providers = CODING_AGENT_BACKEND_PROVIDERS[backend];
       if (providers.length === 0) continue;
       expect(CODING_AGENT_BACKENDS).toContain(backend);
-      expect(CODING_AGENT_BACKEND_PREFLIGHTS[backend]).toMatchObject({
-        requiredRuntime: expect.any(String),
-        discoveryPolicy: expect.any(String),
-      });
+      expect(
+        typeof CODING_AGENT_BACKEND_PREFLIGHTS[backend].requiredRuntime,
+      ).toBe("string");
+      expect(
+        typeof CODING_AGENT_BACKEND_PREFLIGHTS[backend].discoveryPolicy,
+      ).toBe("string");
     }
   });
 
@@ -98,20 +100,18 @@ describe("coding-agent capability mapping", () => {
     for (const [providerId, descriptor] of Object.entries(
       CODING_PROVIDER_DESCRIPTORS,
     )) {
-      expect(descriptor).toMatchObject({
-        version: CODING_PROVIDER_DESCRIPTOR_VERSION,
-        providerId,
-        accountKind: expect.stringMatching(/^(subscription|api-key)$/),
-        authMode: expect.stringMatching(
-          /^(oauth|direct-api-key|coding-plan-key|external-cli|unavailable)$/,
-        ),
-        billingMode: expect.stringMatching(
-          /^(subscription-coding-plan|subscription-coding-cli|usage)$/,
-        ),
-        enrollmentSupport: expect.any(Boolean),
-        inferenceSupport: expect.any(Boolean),
-        spawnSupport: expect.any(Boolean),
-      });
+      expect(descriptor.version).toBe(CODING_PROVIDER_DESCRIPTOR_VERSION);
+      expect(descriptor.providerId).toBe(providerId);
+      expect(descriptor.accountKind).toMatch(/^(subscription|api-key)$/);
+      expect(descriptor.authMode).toMatch(
+        /^(oauth|direct-api-key|coding-plan-key|external-cli|unavailable)$/,
+      );
+      expect(descriptor.billingMode).toMatch(
+        /^(subscription-coding-plan|subscription-coding-cli|usage)$/,
+      );
+      expect(typeof descriptor.enrollmentSupport).toBe("boolean");
+      expect(typeof descriptor.inferenceSupport).toBe("boolean");
+      expect(typeof descriptor.spawnSupport).toBe("boolean");
       expect(descriptor.spawnSupport).toBe(descriptor.backend !== null);
       if (descriptor.spawnSupport) {
         if (!descriptor.backend) {

--- a/packages/shared/src/contracts/coding-agent-capabilities.ts
+++ b/packages/shared/src/contracts/coding-agent-capabilities.ts
@@ -1,0 +1,430 @@
+/**
+ * Defines the coding-agent backends that can actually be spawned and the
+ * linked-account providers whose credentials those backends consume.
+ * Enrollment and model inference remain separate capabilities: a provider
+ * absent from this map must never be advertised as coding-agent spawnable.
+ */
+
+import type { LinkedAccountProviderId } from "@elizaos/core";
+
+export const CODING_AGENT_BACKENDS = [
+  "elizaos",
+  "pi-agent",
+  "claude",
+  "codex",
+] as const;
+
+export type CodingAgentBackend = (typeof CODING_AGENT_BACKENDS)[number];
+
+export const CODING_PROVIDER_DESCRIPTOR_VERSION = 1 as const;
+
+export type CodingProviderAccountKind = "subscription" | "api-key";
+export type CodingProviderAuthMode =
+  | "oauth"
+  | "direct-api-key"
+  | "coding-plan-key"
+  | "external-cli"
+  | "unavailable";
+export type CodingProviderBillingMode =
+  | "subscription-coding-plan"
+  | "subscription-coding-cli"
+  | "usage";
+export type CodingProviderSubscriptionAuthMode =
+  | "oauth"
+  | "external-cli"
+  | "coding-plan-key"
+  | "unavailable";
+export type CodingProviderSubscriptionBillingMode =
+  | "subscription-coding-plan"
+  | "subscription-coding-cli";
+export type CodingProviderDiscoveryPolicy =
+  | "bundled-or-configured-command"
+  | "configured-command-or-path"
+  | "none";
+
+interface CodingAgentBackendPreflightBase {
+  requiredRuntime: string;
+  discoveryPolicy: Exclude<CodingProviderDiscoveryPolicy, "none">;
+  commandConfigKey: string;
+}
+
+export type CodingAgentBackendPreflight = CodingAgentBackendPreflightBase &
+  (
+    | { commandResolution: "literal"; defaultCommand: string }
+    | { commandResolution: "managed-codex" }
+  );
+
+/** Executable discovery contract implemented by ACP for every spawn backend. */
+export const CODING_AGENT_BACKEND_PREFLIGHTS = {
+  elizaos: {
+    requiredRuntime: "eliza-code-acp",
+    discoveryPolicy: "bundled-or-configured-command",
+    commandConfigKey: "ELIZA_ELIZAOS_ACP_COMMAND",
+    commandResolution: "literal",
+    defaultCommand: "eliza-code-acp",
+  },
+  "pi-agent": {
+    requiredRuntime: "pi-agent",
+    discoveryPolicy: "bundled-or-configured-command",
+    commandConfigKey: "ELIZA_PI_AGENT_ACP_COMMAND",
+    commandResolution: "literal",
+    defaultCommand: "pi-agent",
+  },
+  claude: {
+    requiredRuntime: "claude-acp",
+    discoveryPolicy: "configured-command-or-path",
+    commandConfigKey: "ELIZA_CLAUDE_ACP_COMMAND",
+    commandResolution: "literal",
+    defaultCommand: "npx -y @agentclientprotocol/claude-agent-acp@0.34.0",
+  },
+  codex: {
+    requiredRuntime: "codex-acp",
+    discoveryPolicy: "configured-command-or-path",
+    commandConfigKey: "ELIZA_CODEX_ACP_COMMAND",
+    commandResolution: "managed-codex",
+  },
+} as const satisfies Readonly<
+  Record<CodingAgentBackend, CodingAgentBackendPreflight>
+>;
+
+export interface CodingProviderDescriptor {
+  version: typeof CODING_PROVIDER_DESCRIPTOR_VERSION;
+  providerId: string;
+  accountKind: CodingProviderAccountKind;
+  authMode: CodingProviderAuthMode;
+  billingMode: CodingProviderBillingMode;
+  enrollmentSupport: boolean;
+  inferenceSupport: boolean;
+  backend: CodingAgentBackend | null;
+  spawnSupport: boolean;
+  requiredRuntime: string | null;
+  discoveryPolicy: CodingProviderDiscoveryPolicy;
+  unsupportedReason: string | null;
+}
+
+export function isCodingAgentBackend(
+  value: unknown,
+): value is CodingAgentBackend {
+  return (
+    typeof value === "string" &&
+    CODING_AGENT_BACKENDS.includes(value as CodingAgentBackend)
+  );
+}
+
+function descriptor<
+  const ProviderId extends string,
+  const AccountKind extends CodingProviderAccountKind,
+  const AuthMode extends CodingProviderAuthMode,
+  const BillingMode extends CodingProviderBillingMode,
+  const InferenceSupport extends boolean,
+  const Backend extends CodingAgentBackend | null,
+>(
+  providerId: ProviderId,
+  accountKind: AccountKind,
+  authMode: AuthMode,
+  billingMode: BillingMode,
+  enrollmentSupport: boolean,
+  inferenceSupport: InferenceSupport,
+  backend: Backend,
+  unsupportedReason: string | null,
+): CodingProviderDescriptor & {
+  providerId: ProviderId;
+  accountKind: AccountKind;
+  authMode: AuthMode;
+  billingMode: BillingMode;
+  inferenceSupport: InferenceSupport;
+  backend: Backend;
+} {
+  const preflight = backend ? CODING_AGENT_BACKEND_PREFLIGHTS[backend] : null;
+  return {
+    version: CODING_PROVIDER_DESCRIPTOR_VERSION,
+    providerId,
+    accountKind,
+    authMode,
+    billingMode,
+    enrollmentSupport,
+    inferenceSupport,
+    backend,
+    spawnSupport: backend !== null,
+    requiredRuntime: preflight?.requiredRuntime ?? null,
+    discoveryPolicy: preflight?.discoveryPolicy ?? "none",
+    unsupportedReason,
+  };
+}
+
+/**
+ * Canonical account, inference, and executable-spawn truth for every linked
+ * account provider in the runtime catalog.
+ */
+export const CODING_PROVIDER_DESCRIPTORS = {
+  "anthropic-subscription": descriptor(
+    "anthropic-subscription",
+    "subscription",
+    "oauth",
+    "subscription-coding-cli",
+    true,
+    false,
+    "claude",
+    null,
+  ),
+  "openai-codex": descriptor(
+    "openai-codex",
+    "subscription",
+    "oauth",
+    "subscription-coding-cli",
+    true,
+    true,
+    "codex",
+    null,
+  ),
+  "gemini-cli": descriptor(
+    "gemini-cli",
+    "subscription",
+    "external-cli",
+    "subscription-coding-cli",
+    false,
+    false,
+    null,
+    "Gemini CLI is not wired to a supported coding-agent spawn backend.",
+  ),
+  "zai-coding": descriptor(
+    "zai-coding",
+    "subscription",
+    "coding-plan-key",
+    "subscription-coding-plan",
+    true,
+    true,
+    null,
+    "The z.ai coding credential can serve model inference, but no supported coding-agent spawn backend consumes it.",
+  ),
+  "kimi-coding": descriptor(
+    "kimi-coding",
+    "subscription",
+    "coding-plan-key",
+    "subscription-coding-plan",
+    true,
+    true,
+    null,
+    "The Kimi coding credential can serve model inference, but no supported coding-agent spawn backend consumes it.",
+  ),
+  "deepseek-coding": descriptor(
+    "deepseek-coding",
+    "subscription",
+    "unavailable",
+    "subscription-coding-plan",
+    false,
+    false,
+    null,
+    "No first-party DeepSeek coding subscription surface or supported coding-agent spawn backend is available.",
+  ),
+  "anthropic-api": descriptor(
+    "anthropic-api",
+    "api-key",
+    "direct-api-key",
+    "usage",
+    true,
+    true,
+    null,
+    "Anthropic API keys can serve model inference, but the coding-account bridge only supports Claude subscription accounts today.",
+  ),
+  "openai-api": descriptor(
+    "openai-api",
+    "api-key",
+    "direct-api-key",
+    "usage",
+    true,
+    true,
+    null,
+    "OpenAI API keys can serve model inference, but the coding-account bridge only supports Codex subscription accounts today.",
+  ),
+  "deepseek-api": descriptor(
+    "deepseek-api",
+    "api-key",
+    "direct-api-key",
+    "usage",
+    true,
+    true,
+    null,
+    "The DeepSeek API account can serve model inference, but no supported coding-agent spawn backend consumes it.",
+  ),
+  "zai-api": descriptor(
+    "zai-api",
+    "api-key",
+    "direct-api-key",
+    "usage",
+    true,
+    true,
+    null,
+    "The z.ai API account can serve model inference, but no supported coding-agent spawn backend consumes it.",
+  ),
+  "moonshot-api": descriptor(
+    "moonshot-api",
+    "api-key",
+    "direct-api-key",
+    "usage",
+    true,
+    true,
+    null,
+    "The Kimi / Moonshot API account can serve model inference, but no supported coding-agent spawn backend consumes it.",
+  ),
+  "cerebras-api": descriptor(
+    "cerebras-api",
+    "api-key",
+    "direct-api-key",
+    "usage",
+    true,
+    true,
+    null,
+    "Cerebras API keys can serve model inference, but no supported coding-agent spawn backend consumes them.",
+  ),
+} as const satisfies Readonly<
+  Record<LinkedAccountProviderId, CodingProviderDescriptor>
+>;
+
+export type CodingProviderId = keyof typeof CODING_PROVIDER_DESCRIPTORS;
+
+/** Ordered credential providers derived from the canonical descriptors. */
+export const CODING_AGENT_BACKEND_PROVIDERS = Object.fromEntries(
+  CODING_AGENT_BACKENDS.map((backend) => [
+    backend,
+    Object.values(CODING_PROVIDER_DESCRIPTORS)
+      .filter((descriptor) => descriptor.backend === backend)
+      .map((descriptor) => descriptor.providerId as CodingProviderId),
+  ]),
+) as unknown as Readonly<
+  Record<CodingAgentBackend, readonly CodingProviderId[]>
+>;
+
+export type CodingAgentAccountProviderId =
+  (typeof CODING_AGENT_BACKEND_PROVIDERS)[CodingAgentBackend][number];
+
+export interface CodingProviderSupportMatrix {
+  version: typeof CODING_PROVIDER_DESCRIPTOR_VERSION;
+  providers: readonly CodingProviderDescriptor[];
+}
+
+/** Serializable domain artifact used by reviews and catalog drift checks. */
+export const CODING_PROVIDER_SUPPORT_MATRIX: CodingProviderSupportMatrix = {
+  version: CODING_PROVIDER_DESCRIPTOR_VERSION,
+  providers: Object.values(CODING_PROVIDER_DESCRIPTORS),
+};
+
+export function codingProviderDescriptorForProvider(
+  providerId: string,
+): CodingProviderDescriptor | undefined {
+  return CODING_PROVIDER_DESCRIPTORS[providerId as CodingProviderId];
+}
+
+export type CodingProviderEnrollmentAvailability =
+  | "available"
+  | "external"
+  | "unavailable";
+
+/** Resolve whether this app can enroll the provider, independently of use. */
+export function codingProviderEnrollmentAvailability(
+  providerId: string,
+): CodingProviderEnrollmentAvailability {
+  const provider = codingProviderDescriptorForProvider(providerId);
+  if (!provider) return "unavailable";
+  if (provider.authMode === "external-cli") return "external";
+  return provider.enrollmentSupport ? "available" : "unavailable";
+}
+
+export type CodingSubscriptionProviderId = {
+  [ProviderId in CodingProviderId]: (typeof CODING_PROVIDER_DESCRIPTORS)[ProviderId]["accountKind"] extends "subscription"
+    ? ProviderId
+    : never;
+}[CodingProviderId];
+
+export function isCodingSubscriptionProvider(
+  providerId: string,
+): providerId is CodingSubscriptionProviderId {
+  return (
+    codingProviderDescriptorForProvider(providerId)?.accountKind ===
+    "subscription"
+  );
+}
+
+/** Maps a subscription descriptor to the auth package's enrollment contract. */
+export function codingProviderSubscriptionAuthMode(
+  providerId: CodingSubscriptionProviderId,
+): CodingProviderSubscriptionAuthMode {
+  const descriptor = CODING_PROVIDER_DESCRIPTORS[providerId];
+  switch (descriptor.authMode) {
+    case "oauth":
+      return "oauth";
+    case "external-cli":
+      return "external-cli";
+    case "coding-plan-key":
+      return "coding-plan-key";
+    case "unavailable":
+      return "unavailable";
+  }
+}
+
+/** Maps canonical billing truth to the subscription-status wire vocabulary. */
+export function codingProviderSubscriptionBillingMode(
+  providerId: CodingSubscriptionProviderId,
+): CodingProviderSubscriptionBillingMode {
+  const descriptor = CODING_PROVIDER_DESCRIPTORS[providerId];
+  return descriptor.billingMode;
+}
+
+export interface CodingAgentSpawnCapability {
+  available: boolean;
+  backend?: CodingAgentBackend;
+  unavailableReason?: string;
+}
+
+/** Resolve the executable backend that can consume a linked account. */
+export function codingAgentBackendForProvider(
+  providerId: string,
+): CodingAgentBackend | undefined {
+  return codingProviderDescriptorForProvider(providerId)?.backend ?? undefined;
+}
+
+/**
+ * Return the account-to-spawn routing verdict. This describes implemented
+ * routing only; host/device executable readiness is reported by ACP preflight.
+ */
+export function codingAgentSpawnCapabilityForProvider(
+  providerId: string,
+): CodingAgentSpawnCapability {
+  const backend = codingAgentBackendForProvider(providerId);
+  if (backend) return { available: true, backend };
+  const descriptor = codingProviderDescriptorForProvider(providerId);
+  return {
+    available: false,
+    unavailableReason:
+      descriptor?.unsupportedReason ??
+      "No supported coding-agent spawn backend consumes this account provider.",
+  };
+}
+
+export interface ProviderRuntimeCapability {
+  available: boolean;
+  defaultModel?: string;
+  credentialPath?: "account-pool" | "direct-api" | "external-cli" | "none";
+  backend?: CodingAgentBackend;
+  unavailableReason?: string;
+}
+
+export type ProviderCredentialPath = Exclude<
+  NonNullable<ProviderRuntimeCapability["credentialPath"]>,
+  "none"
+>;
+
+/** Resolve where runtime consumers may obtain a linked provider credential. */
+export function codingProviderCredentialPathForProvider(
+  providerId: string,
+): ProviderCredentialPath | undefined {
+  const descriptor = codingProviderDescriptorForProvider(providerId);
+  if (!descriptor) return undefined;
+  if (descriptor.authMode === "external-cli") return "external-cli";
+  return descriptor.accountKind === "api-key" ? "direct-api" : "account-pool";
+}
+
+export interface ProviderRuntimeEligibility {
+  chat: ProviderRuntimeCapability;
+  codingAgent: ProviderRuntimeCapability;
+}

--- a/packages/shared/src/contracts/index.ts
+++ b/packages/shared/src/contracts/index.ts
@@ -20,6 +20,7 @@ export * from "./chat.js";
 export * from "./cloud-coding-containers.js";
 export * from "./cloud-pair.js";
 export * from "./cloud-topology.js";
+export * from "./coding-agent-capabilities.js";
 export * from "./config.js";
 export * from "./connector-routes.js";
 export * from "./content-pack.js";

--- a/packages/ui/src/api/client-accounts.ts
+++ b/packages/ui/src/api/client-accounts.ts
@@ -2,16 +2,13 @@
  * Extends the dashboard client with server-authoritative account capability
  * and selection metadata without coupling those contracts to agent controls.
  */
+import type { ProviderRuntimeEligibility } from "@elizaos/shared";
 import type {
   AccountsListProvider,
   AccountsListResponse,
 } from "./client-agent";
 
-export interface ProviderRuntimeEligibility {
-  chat: boolean;
-  codingAgent: boolean;
-  note?: string;
-}
+export type { ProviderRuntimeEligibility } from "@elizaos/shared";
 
 export interface ProviderSelectionState {
   activeAccountId: string | null;

--- a/packages/ui/src/api/client-agent-accounts-validator.ts
+++ b/packages/ui/src/api/client-agent-accounts-validator.ts
@@ -12,6 +12,13 @@ import {
   LINKED_ACCOUNT_PROVIDER_IDS,
   SERVICE_ROUTE_ACCOUNT_STRATEGIES,
 } from "@elizaos/core";
+import {
+  CODING_AGENT_BACKENDS,
+  codingAgentSpawnCapabilityForProvider,
+  codingProviderCredentialPathForProvider,
+  codingProviderDescriptorForProvider,
+  type LinkedAccountProviderId,
+} from "@elizaos/shared";
 import type { AccountsListResponse } from "./client-agent";
 
 /** Stable classification for malformed account inventory responses. */
@@ -111,6 +118,95 @@ function assertUsage(value: unknown, path: string): void {
   }
 }
 
+const CREDENTIAL_PATHS = [
+  "account-pool",
+  "direct-api",
+  "external-cli",
+  "none",
+] as const;
+
+function assertRuntimeCapability(value: unknown, path: string): void {
+  if (!isRecord(value)) invalid(path, "an object");
+  if (typeof value.available !== "boolean") {
+    invalid(`${path}.available`, "a boolean");
+  }
+  assertOptionalString(value, "defaultModel", path);
+  assertOptionalString(value, "unavailableReason", path);
+  if (
+    value.credentialPath !== undefined &&
+    !isOneOf(CREDENTIAL_PATHS, value.credentialPath)
+  ) {
+    invalid(`${path}.credentialPath`, "a supported credential path");
+  }
+  if (
+    value.backend !== undefined &&
+    !isOneOf(CODING_AGENT_BACKENDS, value.backend)
+  ) {
+    invalid(`${path}.backend`, "a supported coding-agent backend");
+  }
+}
+
+function assertRuntimeEligibility(
+  value: unknown,
+  providerId: LinkedAccountProviderId,
+  path: string,
+): void {
+  if (!isRecord(value)) invalid(path, "an object");
+  assertRuntimeCapability(value.chat, `${path}.chat`);
+  assertRuntimeCapability(value.codingAgent, `${path}.codingAgent`);
+
+  const codingAgent = value.codingAgent as Record<string, unknown>;
+  const chat = value.chat as Record<string, unknown>;
+  const descriptor = codingProviderDescriptorForProvider(providerId);
+  const credentialPath = codingProviderCredentialPathForProvider(providerId);
+  if (!descriptor || !credentialPath) {
+    invalid(path, `a canonical runtime contract for provider "${providerId}"`);
+  }
+  const expectedChatCredentialPath = descriptor.inferenceSupport
+    ? credentialPath
+    : "none";
+  if (chat.available !== descriptor.inferenceSupport) {
+    invalid(
+      `${path}.chat.available`,
+      `the canonical inference availability for provider "${providerId}"`,
+    );
+  }
+  if (chat.credentialPath !== expectedChatCredentialPath) {
+    invalid(
+      `${path}.chat.credentialPath`,
+      `the canonical credential path "${expectedChatCredentialPath}"`,
+    );
+  }
+  const canonical = codingAgentSpawnCapabilityForProvider(providerId);
+  if (codingAgent.available !== canonical.available) {
+    invalid(
+      `${path}.codingAgent.available`,
+      `the canonical spawn availability for provider "${providerId}"`,
+    );
+  }
+  if (canonical.available && codingAgent.backend !== canonical.backend) {
+    invalid(
+      `${path}.codingAgent.backend`,
+      `the canonical backend "${canonical.backend}"`,
+    );
+  }
+  if (!canonical.available && codingAgent.backend !== undefined) {
+    invalid(
+      `${path}.codingAgent.backend`,
+      "no backend for an unavailable provider",
+    );
+  }
+  const expectedCodingCredentialPath = canonical.available
+    ? credentialPath
+    : "none";
+  if (codingAgent.credentialPath !== expectedCodingCredentialPath) {
+    invalid(
+      `${path}.codingAgent.credentialPath`,
+      `the canonical credential path "${expectedCodingCredentialPath}"`,
+    );
+  }
+}
+
 function assertAccount(
   value: unknown,
   providerId: string,
@@ -181,25 +277,29 @@ function assertAccountsListResponse(
     if (!isOneOf(LINKED_ACCOUNT_PROVIDER_IDS, rawProvider.providerId)) {
       invalid(`${path}.providerId`, "a supported linked-account provider");
     }
-    if (providerIds.has(rawProvider.providerId)) {
+    const providerId = rawProvider.providerId as LinkedAccountProviderId;
+    if (providerIds.has(providerId)) {
       invalid(`${path}.providerId`, "a unique provider");
     }
-    providerIds.add(rawProvider.providerId);
+    providerIds.add(providerId);
     if (!isOneOf(SERVICE_ROUTE_ACCOUNT_STRATEGIES, rawProvider.strategy)) {
       invalid(`${path}.strategy`, "a supported account strategy");
     }
     if (!Array.isArray(rawProvider.accounts)) {
       invalid(`${path}.accounts`, "an array");
     }
+    if (rawProvider.runtimeEligibility !== undefined) {
+      assertRuntimeEligibility(
+        rawProvider.runtimeEligibility,
+        providerId,
+        `${path}.runtimeEligibility`,
+      );
+    }
 
     const accountIds = new Set<string>();
     for (const [accountIndex, account] of rawProvider.accounts.entries()) {
       const accountPath = `${path}.accounts[${accountIndex}]`;
-      const accountId = assertAccount(
-        account,
-        rawProvider.providerId,
-        accountPath,
-      );
+      const accountId = assertAccount(account, providerId, accountPath);
       if (accountIds.has(accountId)) {
         invalid(`${accountPath}.id`, "a unique account id within its provider");
       }

--- a/packages/ui/src/api/client-agent-accounts.test.ts
+++ b/packages/ui/src/api/client-agent-accounts.test.ts
@@ -27,8 +27,12 @@ describe("ElizaClient account replacement transport", () => {
           providerId: "openai-api",
           strategy: "priority",
           runtimeEligibility: {
-            chat: { available: true },
-            codingAgent: { available: true },
+            chat: { available: true, credentialPath: "direct-api" },
+            codingAgent: {
+              available: false,
+              credentialPath: "none",
+              unavailableReason: "No coding-account route is wired.",
+            },
           },
           accounts: [
             {
@@ -49,6 +53,113 @@ describe("ElizaClient account replacement transport", () => {
     };
 
     await expect(accountsClient(body).listAccounts()).resolves.toEqual(body);
+  });
+
+  it("rejects server metadata that advertises an unspawnable account provider", async () => {
+    const body = {
+      providers: [
+        {
+          providerId: "deepseek-api",
+          strategy: "priority",
+          runtimeEligibility: {
+            chat: { available: true, credentialPath: "direct-api" },
+            codingAgent: {
+              available: true,
+              backend: "codex",
+              credentialPath: "direct-api",
+            },
+          },
+          accounts: [],
+        },
+      ],
+    };
+
+    await expect(accountsClient(body).listAccounts()).rejects.toMatchObject({
+      code: ACCOUNTS_RESPONSE_INVALID_CODE,
+      context: {
+        path: "response.providers[0].runtimeEligibility.codingAgent.available",
+      },
+    });
+  });
+
+  it.each([
+    [
+      "chat availability",
+      "openai-api",
+      {
+        chat: { available: false, credentialPath: "none" },
+        codingAgent: { available: false, credentialPath: "none" },
+      },
+      "response.providers[0].runtimeEligibility.chat.available",
+    ],
+    [
+      "chat credential path",
+      "openai-api",
+      {
+        chat: { available: true, credentialPath: "account-pool" },
+        codingAgent: { available: false, credentialPath: "none" },
+      },
+      "response.providers[0].runtimeEligibility.chat.credentialPath",
+    ],
+    [
+      "coding credential path",
+      "openai-codex",
+      {
+        chat: { available: true, credentialPath: "account-pool" },
+        codingAgent: {
+          available: true,
+          backend: "codex",
+          credentialPath: "direct-api",
+        },
+      },
+      "response.providers[0].runtimeEligibility.codingAgent.credentialPath",
+    ],
+  ])(
+    "rejects contradictory descriptor-derived %s",
+    async (_label, providerId, eligibility, path) => {
+      const body = {
+        providers: [
+          {
+            providerId,
+            strategy: "priority",
+            runtimeEligibility: eligibility,
+            accounts: [],
+          },
+        ],
+      };
+
+      await expect(accountsClient(body).listAccounts()).rejects.toMatchObject({
+        code: ACCOUNTS_RESPONSE_INVALID_CODE,
+        context: { path },
+      });
+    },
+  );
+
+  it("rejects an unknown coding adapter before UI state can consume it", async () => {
+    const body = {
+      providers: [
+        {
+          providerId: "openai-codex",
+          strategy: "priority",
+          runtimeEligibility: {
+            chat: { available: true, credentialPath: "account-pool" },
+            codingAgent: {
+              available: true,
+              backend: "unknown-adapter",
+              credentialPath: "account-pool",
+            },
+          },
+          accounts: [],
+        },
+      ],
+    };
+
+    await expect(accountsClient(body).listAccounts()).rejects.toMatchObject({
+      code: ACCOUNTS_RESPONSE_INVALID_CODE,
+      context: {
+        path: "response.providers[0].runtimeEligibility.codingAgent.backend",
+      },
+    });
   });
 
   it.each([

--- a/packages/ui/src/components/accounts/AddAccountDialog.tsx
+++ b/packages/ui/src/components/accounts/AddAccountDialog.tsx
@@ -10,6 +10,10 @@ import type {
   LinkedAccountProviderId,
 } from "@elizaos/shared";
 import {
+  codingProviderSubscriptionAuthMode,
+  isCodingSubscriptionProvider,
+} from "@elizaos/shared";
+import {
   type FormEvent,
   useCallback,
   useEffect,
@@ -75,7 +79,7 @@ interface SseFlowState {
 
 type SubscriptionAddMode =
   | "oauth"
-  | "api-key"
+  | "coding-plan-key"
   | "external-cli"
   | "unavailable"
   | "none";
@@ -90,21 +94,11 @@ export {
   getAccountProviderOption,
 } from "./account-provider-options";
 
-const SUBSCRIPTION_ADD_MODE_BY_PROVIDER: Partial<
-  Record<LinkedAccountProviderId, SubscriptionAddMode>
-> = {
-  "anthropic-subscription": "oauth",
-  "openai-codex": "oauth",
-  "gemini-cli": "external-cli",
-  "zai-coding": "api-key",
-  "kimi-coding": "api-key",
-  "deepseek-coding": "unavailable",
-};
-
 function getSubscriptionAddMode(
   providerId: LinkedAccountProviderId,
 ): SubscriptionAddMode {
-  return SUBSCRIPTION_ADD_MODE_BY_PROVIDER[providerId] ?? "none";
+  if (!isCodingSubscriptionProvider(providerId)) return "none";
+  return codingProviderSubscriptionAuthMode(providerId);
 }
 
 function initialStepForProvider(
@@ -119,7 +113,7 @@ function initialStepForProvider(
 function defaultOAuthLabel(providerId: LinkedAccountProviderId): string {
   if (providerId === "anthropic-subscription") return "Claude account";
   if (providerId === "openai-codex") return "Codex account";
-  if (getSubscriptionAddMode(providerId) === "api-key") {
+  if (getSubscriptionAddMode(providerId) === "coding-plan-key") {
     return "Coding plan account";
   }
   return "API account";
@@ -698,7 +692,7 @@ export function AddAccountDialog({
             defaultValue:
               "Sign in with the provider's first-party coding account flow to add another account to the rotation pool.",
           })
-        : subscriptionAddMode === "api-key"
+        : subscriptionAddMode === "coding-plan-key"
           ? t("accounts.add.codingPlanDescription", {
               defaultValue:
                 "Paste a coding-plan credential for the provider's dedicated coding endpoint. It will not be used as a general API key.",
@@ -719,7 +713,7 @@ export function AddAccountDialog({
                 });
 
   const apiKeyLabel =
-    subscriptionAddMode === "api-key"
+    subscriptionAddMode === "coding-plan-key"
       ? t("accounts.add.codingPlanKey", {
           defaultValue: "Coding-plan key",
         })

--- a/packages/ui/src/components/accounts/ProviderAccountRow.stories.tsx
+++ b/packages/ui/src/components/accounts/ProviderAccountRow.stories.tsx
@@ -61,9 +61,8 @@ const anthropicProvider: AccountsListProvider = {
   providerId: "anthropic-subscription",
   strategy: "reset-soonest",
   runtimeEligibility: {
-    chat: false,
-    codingAgent: true,
-    note: "Powers coding agents. Not the default chat brain.",
+    chat: { available: false },
+    codingAgent: { available: true, backend: "claude" },
   },
   selection: { activeAccountId: "acct_a2", reason: "reset-soonest" },
   accounts: [
@@ -145,7 +144,10 @@ export const NeedsAttention: Story = {
     provider: {
       providerId: "openai-codex",
       strategy: "priority",
-      runtimeEligibility: { chat: false, codingAgent: true },
+      runtimeEligibility: {
+        chat: { available: true },
+        codingAgent: { available: true, backend: "codex" },
+      },
       selection: { activeAccountId: "acct_c1", reason: "priority" },
       accounts: [
         acct({

--- a/packages/ui/src/components/accounts/ProviderPicker.test.tsx
+++ b/packages/ui/src/components/accounts/ProviderPicker.test.tsx
@@ -93,15 +93,19 @@ describe("ProviderPicker", () => {
   it("renders sentence-style capability copy with no interpunct separators", () => {
     renderPicker();
     expect(
-      screen.getAllByText("Chat, using your API key").length,
-    ).toBeGreaterThan(0);
+      screen.getAllByText(
+        "Model inference, using your API key; agent spawn unavailable",
+      ).length,
+    ).toBe(6);
+    expect(screen.getByText("Coding agents, using browser login")).toBeTruthy();
     expect(
-      screen.getByText("Chat and coding agents, using browser login"),
+      screen.getByText("No model inference or coding-agent spawn support"),
     ).toBeTruthy();
-    expect(screen.getByText("Coding agents, using CLI login")).toBeTruthy();
     expect(
-      screen.getAllByText("Coding agents, using a plan key").length,
-    ).toBeGreaterThan(0);
+      screen.getAllByText(
+        "Model inference, using a coding-plan key; agent spawn unavailable",
+      ).length,
+    ).toBe(2);
     // The old "Chat \u00b7 bring your own API key" pill format must not resurface.
     expect(screen.queryByText(/\u00b7/)).toBeNull();
   });

--- a/packages/ui/src/components/accounts/ProviderPicker.tsx
+++ b/packages/ui/src/components/accounts/ProviderPicker.tsx
@@ -11,7 +11,10 @@
  * keyboard never gets trapped in a group.
  */
 
-import type { LinkedAccountProviderId } from "@elizaos/shared";
+import {
+  codingProviderDescriptorForProvider,
+  type LinkedAccountProviderId,
+} from "@elizaos/shared";
 import { Search } from "lucide-react";
 import {
   type KeyboardEvent,
@@ -43,16 +46,30 @@ const CATEGORY_LABEL: Record<AccountProviderCategory, string> = {
 };
 
 /** One short capability line, not a pill row (kills the tag maze). */
-function capabilityLine(option: AccountProviderOption): string {
+export function capabilityLine(option: AccountProviderOption): string {
   if (option.unavailable) return "Not available to link here";
-  if (option.category === "chat") return "Chat, using your API key";
-  if (option.id === "anthropic-subscription")
-    return "Chat and coding agents, using browser login";
-  if (option.id === "gemini-cli") return "Coding agents, using CLI login";
-  const usesKey = option.id === "zai-coding" || option.id === "kimi-coding";
-  return usesKey
-    ? "Coding agents, using a plan key"
-    : "Coding agents, using browser login";
+  const descriptor = codingProviderDescriptorForProvider(option.id);
+  if (!descriptor || descriptor.authMode === "unavailable") {
+    return "Not available to link here";
+  }
+  const authentication =
+    descriptor.authMode === "oauth"
+      ? "browser login"
+      : descriptor.authMode === "external-cli"
+        ? "CLI login"
+        : descriptor.authMode === "coding-plan-key"
+          ? "a coding-plan key"
+          : "your API key";
+  if (descriptor.spawnSupport && descriptor.inferenceSupport) {
+    return `Model inference and coding agents, using ${authentication}`;
+  }
+  if (descriptor.spawnSupport) {
+    return `Coding agents, using ${authentication}`;
+  }
+  if (descriptor.inferenceSupport) {
+    return `Model inference, using ${authentication}; agent spawn unavailable`;
+  }
+  return "No model inference or coding-agent spawn support";
 }
 
 export function ProviderPicker({ onPick }: ProviderPickerProps) {

--- a/packages/ui/src/components/accounts/account-eligibility.test.ts
+++ b/packages/ui/src/components/accounts/account-eligibility.test.ts
@@ -4,13 +4,17 @@
  * connection signal.
  */
 
+import { codingProviderDescriptorForProvider } from "@elizaos/shared";
 import { describe, expect, it } from "vitest";
 import {
   eligibilityChips,
   providerConnectionState,
   resolveProviderEligibility,
 } from "./account-eligibility";
-import { getAccountProviderOption } from "./account-provider-options";
+import {
+  ACCOUNT_PROVIDER_OPTIONS,
+  getAccountProviderOption,
+} from "./account-provider-options";
 
 function option(id: Parameters<typeof getAccountProviderOption>[0]) {
   const found = getAccountProviderOption(id);
@@ -25,28 +29,85 @@ const deepseekCoding = option("deepseek-coding");
 describe("resolveProviderEligibility", () => {
   it("prefers server runtime eligibility over static inference", () => {
     const resolved = resolveProviderEligibility(claudeSub, {
-      chat: true,
-      codingAgent: true,
-      note: "subscription chat enabled",
+      chat: { available: true },
+      codingAgent: { available: true, backend: "claude" },
     });
     expect(resolved.source).toBe("runtime");
     expect(resolved.chat).toBe(true);
     expect(resolved.codingAgent).toBe(true);
-    expect(resolved.note).toBe("subscription chat enabled");
   });
 
-  it("conservatively infers chat+coding for BYOK API providers", () => {
+  it("keeps BYOK API providers inference-only until a spawn route lands", () => {
     const resolved = resolveProviderEligibility(anthropicApi, undefined);
     expect(resolved.source).toBe("inferred");
     expect(resolved.chat).toBe(true);
-    expect(resolved.codingAgent).toBe(true);
+    expect(resolved.codingAgent).toBe(false);
   });
 
-  it("conservatively infers coding-only for subscription providers", () => {
+  it("does not infer coding-agent spawn support for inference-only APIs", () => {
+    const resolved = resolveProviderEligibility(
+      option("deepseek-api"),
+      undefined,
+    );
+    expect(resolved.chat).toBe(true);
+    expect(resolved.codingAgent).toBe(false);
+  });
+
+  it("surfaces the server's unsupported spawn reason", () => {
+    const resolved = resolveProviderEligibility(option("kimi-coding"), {
+      chat: { available: true, credentialPath: "account-pool" },
+      codingAgent: {
+        available: false,
+        credentialPath: "none",
+        unavailableReason: "No Kimi spawn backend is wired.",
+      },
+    });
+    expect(resolved.codingAgent).toBe(false);
+    expect(resolved.note).toBe("No Kimi spawn backend is wired.");
+  });
+
+  it("keeps the explicit Anthropic subscription chat policy in the descriptor", () => {
     const resolved = resolveProviderEligibility(claudeSub, undefined);
     expect(resolved.source).toBe("inferred");
     expect(resolved.chat).toBe(false);
     expect(resolved.codingAgent).toBe(true);
+  });
+
+  it("derives every fallback chat verdict from the canonical descriptor", () => {
+    for (const providerOption of ACCOUNT_PROVIDER_OPTIONS) {
+      const resolved = resolveProviderEligibility(providerOption, undefined);
+      const descriptor = codingProviderDescriptorForProvider(providerOption.id);
+      expect(resolved.chat, providerOption.id).toBe(
+        providerOption.unavailable
+          ? false
+          : (descriptor?.inferenceSupport ?? false),
+      );
+      expect(resolved.codingAgent, providerOption.id).toBe(
+        providerOption.unavailable ? false : descriptor?.spawnSupport === true,
+      );
+    }
+  });
+
+  it.each(["zai-coding", "kimi-coding"] as const)(
+    "infers inference-only eligibility for %s",
+    (providerId) => {
+      expect(resolveProviderEligibility(option(providerId), undefined)).toEqual(
+        {
+          chat: true,
+          codingAgent: false,
+          source: "inferred",
+        },
+      );
+    },
+  );
+
+  it("fails closed when a provider descriptor is missing", () => {
+    expect(
+      resolveProviderEligibility(
+        { ...anthropicApi, id: "missing-provider" as never },
+        undefined,
+      ),
+    ).toEqual({ chat: false, codingAgent: false, source: "inferred" });
   });
 
   it("infers neither for explicitly unavailable providers", () => {

--- a/packages/ui/src/components/accounts/account-eligibility.ts
+++ b/packages/ui/src/components/accounts/account-eligibility.ts
@@ -4,13 +4,17 @@
  *
  * Prefers the server-supplied `runtimeEligibility` (#16203 contract). When
  * that's absent (older agent, or the field hasn't landed yet) it falls back
- * to a CONSERVATIVE inference from the static provider option so the UI never
- * over-promises: a subscription provider is treated as coding-agent-only, an
- * API/BYOK provider as chat-capable. No hardcoded provider-name copy leaks
- * into the components — they consume the resolved shape below.
+ * to a CONSERVATIVE inference from the shared provider descriptor so the UI never
+ * over-promises: API/BYOK accounts remain chat-capable, while coding-agent
+ * eligibility requires a canonical executable-backend mapping. No hardcoded
+ * provider-name copy leaks into components.
  */
 
-import type { LinkedAccountProviderId } from "@elizaos/shared";
+import {
+  codingAgentSpawnCapabilityForProvider,
+  codingProviderDescriptorForProvider,
+  type LinkedAccountProviderId,
+} from "@elizaos/shared";
 import type { ProviderRuntimeEligibility } from "../../api/client-accounts";
 import type { AccountsListProvider } from "../../api/client-agent";
 import type { AccountProviderOption } from "./account-provider-options";
@@ -24,20 +28,22 @@ export interface ResolvedEligibility {
 }
 
 /**
- * Conservative fallback: infer capability from the static option's category.
- *  - chat providers (BYOK API keys) → chat + coding agent
- *  - coding subscriptions → coding agent only (until the server says chat)
+ * Conservative fallback: infer capability from the canonical descriptor.
+ *  - descriptor inference support → chat
+ *  - only providers with a canonical executable mapping → coding agent
+ *  - subscription spawn support remains independently mapped
  *  - unavailable providers → neither
  */
 function inferEligibility(option: AccountProviderOption): ResolvedEligibility {
   if (option.unavailable) {
     return { chat: false, codingAgent: false, source: "inferred" };
   }
-  if (option.category === "chat") {
-    return { chat: true, codingAgent: true, source: "inferred" };
-  }
-  // coding subscription / plan
-  return { chat: false, codingAgent: true, source: "inferred" };
+  const descriptor = codingProviderDescriptorForProvider(option.id);
+  return {
+    chat: descriptor?.inferenceSupport ?? false,
+    codingAgent: codingAgentSpawnCapabilityForProvider(option.id).available,
+    source: "inferred",
+  };
 }
 
 export function resolveProviderEligibility(
@@ -46,10 +52,13 @@ export function resolveProviderEligibility(
 ): ResolvedEligibility {
   if (runtime) {
     return {
-      chat: runtime.chat,
-      codingAgent: runtime.codingAgent,
+      chat: runtime.chat.available,
+      codingAgent: runtime.codingAgent.available,
       source: "runtime",
-      ...(runtime.note ? { note: runtime.note } : {}),
+      ...(!runtime.codingAgent.available &&
+      runtime.codingAgent.unavailableReason
+        ? { note: runtime.codingAgent.unavailableReason }
+        : {}),
     };
   }
   return inferEligibility(option);

--- a/packages/ui/src/components/accounts/account-provider-options.test.ts
+++ b/packages/ui/src/components/accounts/account-provider-options.test.ts
@@ -3,10 +3,30 @@
  * provider picker grouping and eligibility copy.
  */
 
+import {
+  CODING_PROVIDER_DESCRIPTORS,
+  codingProviderEnrollmentAvailability,
+} from "@elizaos/shared";
 import { describe, expect, it } from "vitest";
 import { ACCOUNT_PROVIDER_OPTIONS } from "./account-provider-options";
 
 describe("consolidated account provider picker", () => {
+  it("covers the canonical provider descriptor catalog exactly once", () => {
+    const optionIds = ACCOUNT_PROVIDER_OPTIONS.map((option) => option.id);
+    expect([...optionIds].sort()).toEqual(
+      Object.keys(CODING_PROVIDER_DESCRIPTORS).sort(),
+    );
+    expect(new Set(optionIds).size).toBe(optionIds.length);
+  });
+
+  it("keeps unavailable enrollment rows aligned with the descriptor", () => {
+    for (const option of ACCOUNT_PROVIDER_OPTIONS) {
+      expect(option.unavailable === true, option.id).toBe(
+        codingProviderEnrollmentAvailability(option.id) === "unavailable",
+      );
+    }
+  });
+
   it("keeps chat API providers separate from coding subscription providers", () => {
     const chat = ACCOUNT_PROVIDER_OPTIONS.filter(
       (option) => option.category === "chat",

--- a/packages/ui/src/components/accounts/account-provider-options.ts
+++ b/packages/ui/src/components/accounts/account-provider-options.ts
@@ -37,23 +37,25 @@ export const ACCOUNT_PROVIDER_OPTIONS: AccountProviderOption[] = [
     id: "gemini-cli",
     name: "Gemini CLI subscription",
     category: "coding",
-    description: "Managed by Gemini CLI login outside this app.",
-    eligibility: ["code-agent", "third-party CLI"],
+    description:
+      "Managed by Gemini CLI outside this app; orchestrated spawning is not wired yet.",
+    eligibility: ["external CLI", "spawn unavailable"],
   },
   {
     id: "zai-coding",
     name: "z.ai Coding Plan",
     category: "coding",
-    description: "Dedicated coding-plan credential, separate from API routing.",
-    eligibility: ["code-agent", "API key"],
+    description:
+      "Dedicated coding-endpoint credential; no coding-agent spawn backend is wired yet.",
+    eligibility: ["model inference", "spawn unavailable"],
   },
   {
     id: "kimi-coding",
     name: "Kimi Code",
     category: "coding",
     description:
-      "Dedicated Kimi coding-plan credential, separate from API routing.",
-    eligibility: ["code-agent", "API key"],
+      "Dedicated Kimi coding-endpoint credential; no coding-agent spawn backend is wired yet.",
+    eligibility: ["model inference", "spawn unavailable"],
   },
   {
     id: "deepseek-coding",
@@ -88,7 +90,8 @@ export const ACCOUNT_PROVIDER_OPTIONS: AccountProviderOption[] = [
     id: "deepseek-api",
     name: "DeepSeek API",
     category: "chat",
-    description: "Direct DeepSeek API billing for chat or agent tasks.",
+    description:
+      "Direct DeepSeek API billing for model inference; coding-agent spawning is not wired yet.",
     eligibility: ["chat", "API key"],
   },
   {

--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -7,7 +7,7 @@ task history, and runtime-driven sub-agent routing.
 ## Purpose / role
 
 This plugin adds a full coding-agent orchestration surface to any Eliza agent.
-It spawns local coding agents (elizaos, pi-agent, opencode, codex, claude) as
+It spawns local coding agents (elizaos, pi-agent, codex, claude) as
 ACP subprocesses, routes their terminal events back into the elizaOS runtime as
 synthetic inbound messages, and manages the git workspace and GitHub issue
 lifecycle that accompanies repo-hosted coding tasks.
@@ -108,11 +108,13 @@ See issue #9146.
 
 | Device profile | Supported? | Reason | Coding backends |
 |---|---|---|---|
-| Desktop / server (Node, non-store) | ✅ | — | all 5 |
-| Android direct/AOSP local-yolo (staged shell) | ✅ | — | all 5 |
+| Desktop / server (Node, non-store) | ✅ | — | all 4 |
+| Android direct/AOSP local-yolo (staged shell) | ✅ | — | all 4 |
 | iOS (vanilla mobile runtime) | ❌ | `vanilla_mobile` | none — stub action only |
 | Store build (sandboxed distribution) | ❌ | `store_build` | none — stub action only |
 | Android Play/store build (not local-yolo) | ❌ | `not_local_yolo` | none — stub action only |
+
+Linked-account enrollment and model inference are separate from executable coding-agent spawn. Claude subscription and OpenAI Codex accounts are the only linked-account transports currently bridged into coding sessions. Kimi and Z.AI coding-plan accounts can be enrolled for inference but do not register native spawn adapters; Grok/xAI has no linked-account or native spawn adapter yet. DeepSeek API credentials are inference-only, while its coding subscription remains unavailable. OpenRouter remains a generic model-routing option rather than a coding-account or spawn backend. Native Kimi, Z.AI, and Grok routes are tracked in #24096.
 
 Classifier precedence: `store_build` > `vanilla_mobile` (iOS) > `not_local_yolo`
 (Android non-yolo) > missing staged shell. When a device is supported every
@@ -144,7 +146,6 @@ preferred over API key):
 | `pi-agent` | runtime-routed |
 | `claude` | anthropic-subscription → anthropic-api |
 | `codex` | openai-codex → openai-api |
-| `opencode` | cerebras-api |
 
 ## Layout
 
@@ -206,7 +207,6 @@ plugins/plugin-agent-orchestrator/
       goal-prompt.ts             Goal prompt construction helpers
       interruption-decider.ts    Decides whether to interrupt a running sub-agent
       json-model-output.ts       Structured JSON output helpers for model calls
-      opencode-config.ts         OpenCode-specific ACP configuration
       repo-input.ts              Repository input parsing and validation
       session-event-queue.ts     Per-session event queue for ordered delivery
       smithers-task-executor.ts  TaskStepExecutor impl — drives ACP turns per step
@@ -272,7 +272,7 @@ README → "GitHub credentials".
 | `GITHUB_OAUTH_CLIENT_SECRET` | unset | Server-side OAuth secret for the device flow. Read directly from **process env** by design — deliberately kept out of the plugin `getSetting` allowlist. |
 | `ELIZA_ACP_TRANSPORT` | `native` | Transport: `native` (embedded JSON-RPC) or `cli`/`acpx` (legacy shell wrapper) |
 | `ELIZA_ACP_CLI` | `acpx` | Path/command for the CLI transport |
-| `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type: `elizaos`, `pi-agent`, `opencode` |
+| `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type: `elizaos`, `pi-agent`, `claude`, or `codex` |
 | `ELIZA_ACP_WARM_SPAWN` | unset | Set to `1` to pre-initialize one native `elizaos` ACP child. The child receives no session credentials until an authenticated, single-use claim and exits after that session; stale unclaimed children are recycled. |
 | `ELIZA_DEFAULT_AGENT_TYPE` | `elizaos` | Compatibility alias for `ELIZA_ACP_DEFAULT_AGENT` |
 | `ELIZA_AGENT_SELECTION_STRATEGY` | `fixed` | Adapter selection policy: `fixed` or `dynamic` |
@@ -284,7 +284,6 @@ README → "GitHub credentials".
 | `ELIZA_CODEX_ACP_APPROVAL_POLICY` / `ELIZA_CODEX_APPROVAL_POLICY` | `never` for no-Landlock fallback, otherwise unset | Optional managed Codex ACP approval policy. Setting it requires an explicit sandbox mode; the successor supports the fixed pairs `read-only`/`on-request`, `workspace-write`/`on-request`, and `danger-full-access`/`never`. |
 | `ELIZA_CODEX_ACP_LANDLOCK` / `ELIZA_CODEX_LANDLOCK` | auto-detect | Force Landlock detection for containers/tests: `1`/`true` or `0`/`false` |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
-| `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command |
 | `ELIZA_ACP_MAX_SESSIONS` | `8` | Concurrent session cap |
 | `ELIZA_ACP_SYSTEM_SESSION_HEADROOM` | `2` | Reserved concurrent slots for short-lived `system` spawns (the #8898 read-only verifier), counted separately from `ELIZA_ACP_MAX_SESSIONS` so validation never deadlocks behind the worker cap |
 | `ELIZA_MAX_SPAWNS_PER_ORIGIN` | `3` | Max sub-agent spawns per root user message before relaying the best captured result instead of re-spawning (bounds the weak-model re-spawn loop) |

--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -271,7 +271,7 @@ README → "GitHub credentials".
 | `GITHUB_OAUTH_CLIENT_ID` | unset | OAuth **device flow** client id (read via `getSetting`); used when no `GITHUB_TOKEN`. Requires a live `authPromptCallback` to surface the device-code prompt. |
 | `GITHUB_OAUTH_CLIENT_SECRET` | unset | Server-side OAuth secret for the device flow. Read directly from **process env** by design — deliberately kept out of the plugin `getSetting` allowlist. |
 | `ELIZA_ACP_TRANSPORT` | `native` | Transport: `native` (embedded JSON-RPC) or `cli`/`acpx` (legacy shell wrapper) |
-| `ELIZA_ACP_CLI` | `acpx` | Path/command for the CLI transport |
+| `ELIZA_ACP_CLI` | `acpx` | Executable name or path for the CLI transport; command arguments are rejected |
 | `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type: `elizaos`, `pi-agent`, `claude`, or `codex` |
 | `ELIZA_ACP_WARM_SPAWN` | unset | Set to `1` to pre-initialize one native `elizaos` ACP child. The child receives no session credentials until an authenticated, single-use claim and exits after that session; stale unclaimed children are recycled. |
 | `ELIZA_DEFAULT_AGENT_TYPE` | `elizaos` | Compatibility alias for `ELIZA_ACP_DEFAULT_AGENT` |

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -7,7 +7,7 @@ task history, and runtime-driven sub-agent routing.
 ## Purpose / role
 
 This plugin adds a full coding-agent orchestration surface to any Eliza agent.
-It spawns local coding agents (elizaos, pi-agent, opencode, codex, claude) as
+It spawns local coding agents (elizaos, pi-agent, codex, claude) as
 ACP subprocesses, routes their terminal events back into the elizaOS runtime as
 synthetic inbound messages, and manages the git workspace and GitHub issue
 lifecycle that accompanies repo-hosted coding tasks.
@@ -108,11 +108,13 @@ See issue #9146.
 
 | Device profile | Supported? | Reason | Coding backends |
 |---|---|---|---|
-| Desktop / server (Node, non-store) | ✅ | — | all 5 |
-| Android direct/AOSP local-yolo (staged shell) | ✅ | — | all 5 |
+| Desktop / server (Node, non-store) | ✅ | — | all 4 |
+| Android direct/AOSP local-yolo (staged shell) | ✅ | — | all 4 |
 | iOS (vanilla mobile runtime) | ❌ | `vanilla_mobile` | none — stub action only |
 | Store build (sandboxed distribution) | ❌ | `store_build` | none — stub action only |
 | Android Play/store build (not local-yolo) | ❌ | `not_local_yolo` | none — stub action only |
+
+Linked-account enrollment and model inference are separate from executable coding-agent spawn. Claude subscription and OpenAI Codex accounts are the only linked-account transports currently bridged into coding sessions. Kimi and Z.AI coding-plan accounts can be enrolled for inference but do not register native spawn adapters; Grok/xAI has no linked-account or native spawn adapter yet. DeepSeek API credentials are inference-only, while its coding subscription remains unavailable. OpenRouter remains a generic model-routing option rather than a coding-account or spawn backend. Native Kimi, Z.AI, and Grok routes are tracked in #24096.
 
 Classifier precedence: `store_build` > `vanilla_mobile` (iOS) > `not_local_yolo`
 (Android non-yolo) > missing staged shell. When a device is supported every
@@ -144,7 +146,6 @@ preferred over API key):
 | `pi-agent` | runtime-routed |
 | `claude` | anthropic-subscription → anthropic-api |
 | `codex` | openai-codex → openai-api |
-| `opencode` | cerebras-api |
 
 ## Layout
 
@@ -206,7 +207,6 @@ plugins/plugin-agent-orchestrator/
       goal-prompt.ts             Goal prompt construction helpers
       interruption-decider.ts    Decides whether to interrupt a running sub-agent
       json-model-output.ts       Structured JSON output helpers for model calls
-      opencode-config.ts         OpenCode-specific ACP configuration
       repo-input.ts              Repository input parsing and validation
       session-event-queue.ts     Per-session event queue for ordered delivery
       smithers-task-executor.ts  TaskStepExecutor impl — drives ACP turns per step
@@ -272,7 +272,7 @@ README → "GitHub credentials".
 | `GITHUB_OAUTH_CLIENT_SECRET` | unset | Server-side OAuth secret for the device flow. Read directly from **process env** by design — deliberately kept out of the plugin `getSetting` allowlist. |
 | `ELIZA_ACP_TRANSPORT` | `native` | Transport: `native` (embedded JSON-RPC) or `cli`/`acpx` (legacy shell wrapper) |
 | `ELIZA_ACP_CLI` | `acpx` | Path/command for the CLI transport |
-| `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type: `elizaos`, `pi-agent`, `opencode` |
+| `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type: `elizaos`, `pi-agent`, `claude`, or `codex` |
 | `ELIZA_ACP_WARM_SPAWN` | unset | Set to `1` to pre-initialize one native `elizaos` ACP child. The child receives no session credentials until an authenticated, single-use claim and exits after that session; stale unclaimed children are recycled. |
 | `ELIZA_DEFAULT_AGENT_TYPE` | `elizaos` | Compatibility alias for `ELIZA_ACP_DEFAULT_AGENT` |
 | `ELIZA_AGENT_SELECTION_STRATEGY` | `fixed` | Adapter selection policy: `fixed` or `dynamic` |
@@ -284,7 +284,6 @@ README → "GitHub credentials".
 | `ELIZA_CODEX_ACP_APPROVAL_POLICY` / `ELIZA_CODEX_APPROVAL_POLICY` | `never` for no-Landlock fallback, otherwise unset | Optional managed Codex ACP approval policy. Setting it requires an explicit sandbox mode; the successor supports the fixed pairs `read-only`/`on-request`, `workspace-write`/`on-request`, and `danger-full-access`/`never`. |
 | `ELIZA_CODEX_ACP_LANDLOCK` / `ELIZA_CODEX_LANDLOCK` | auto-detect | Force Landlock detection for containers/tests: `1`/`true` or `0`/`false` |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
-| `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command |
 | `ELIZA_ACP_MAX_SESSIONS` | `8` | Concurrent session cap |
 | `ELIZA_ACP_SYSTEM_SESSION_HEADROOM` | `2` | Reserved concurrent slots for short-lived `system` spawns (the #8898 read-only verifier), counted separately from `ELIZA_ACP_MAX_SESSIONS` so validation never deadlocks behind the worker cap |
 | `ELIZA_MAX_SPAWNS_PER_ORIGIN` | `3` | Max sub-agent spawns per root user message before relaying the best captured result instead of re-spawning (bounds the weak-model re-spawn loop) |

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -271,7 +271,7 @@ README → "GitHub credentials".
 | `GITHUB_OAUTH_CLIENT_ID` | unset | OAuth **device flow** client id (read via `getSetting`); used when no `GITHUB_TOKEN`. Requires a live `authPromptCallback` to surface the device-code prompt. |
 | `GITHUB_OAUTH_CLIENT_SECRET` | unset | Server-side OAuth secret for the device flow. Read directly from **process env** by design — deliberately kept out of the plugin `getSetting` allowlist. |
 | `ELIZA_ACP_TRANSPORT` | `native` | Transport: `native` (embedded JSON-RPC) or `cli`/`acpx` (legacy shell wrapper) |
-| `ELIZA_ACP_CLI` | `acpx` | Path/command for the CLI transport |
+| `ELIZA_ACP_CLI` | `acpx` | Executable name or path for the CLI transport; command arguments are rejected |
 | `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type: `elizaos`, `pi-agent`, `claude`, or `codex` |
 | `ELIZA_ACP_WARM_SPAWN` | unset | Set to `1` to pre-initialize one native `elizaos` ACP child. The child receives no session credentials until an authenticated, single-use claim and exits after that session; stale unclaimed children are recycled. |
 | `ELIZA_DEFAULT_AGENT_TYPE` | `elizaos` | Compatibility alias for `ELIZA_ACP_DEFAULT_AGENT` |

--- a/plugins/plugin-agent-orchestrator/README.md
+++ b/plugins/plugin-agent-orchestrator/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/elizaos/eliza/actions/workflows/ci.yml/badge.svg)](https://github.com/elizaos/eliza/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-The canonical orchestration plugin for elizaOS task agents. Spawns local coding agents (elizaos, pi-agent, opencode, codex, claude) through Agent Client Protocol transports, routes their output back through the runtime so the main agent decides what to do, and bundles workspace lifecycle, GitHub PR integration, task share, and supporting services in a single package.
+The canonical orchestration plugin for elizaOS task agents. Spawns local coding agents (elizaos, pi-agent, codex, claude) through Agent Client Protocol transports, routes their output back through the runtime so the main agent decides what to do, and bundles workspace lifecycle, GitHub PR integration, task share, and supporting services in a single package.
 
 > Naming: this plugin is *not* the same thing as `@elizaos/plugin-acp`. That package is Shaw's ACP gateway client (IDE bridge over a remote ACP gateway). `@elizaos/plugin-agent-orchestrator` is the *task backend* that runs coding agents as subprocesses on the same host as the runtime.
 
@@ -24,7 +24,7 @@ The plugin combines three concerns:
 npm install @elizaos/plugin-agent-orchestrator
 ```
 
-Native TypeScript ACP is the default transport. Set the default coding agent with `ELIZA_ACP_DEFAULT_AGENT` (`elizaos`, `pi-agent`, or `opencode` are the primary supported defaults):
+Native TypeScript ACP is the default transport. Set the default coding agent with `ELIZA_ACP_DEFAULT_AGENT` (`elizaos`, `pi-agent`, `claude`, or `codex`):
 
 ```bash
 export ELIZA_ACP_TRANSPORT=native
@@ -44,9 +44,11 @@ npm install -g acpx@latest
 export ELIZA_ACP_TRANSPORT=cli
 ```
 
-Adapter packaging decision: this release does not vendor the Codex or Claude ACP adapter packages. Native transport is the default; Codex and Claude use pinned `npx` commands unless deployment config overrides them. OpenCode is the exception: the package prefers the bundled OpenCode shim when available, then falls back to `opencode acp`.
+Adapter packaging decision: this release does not vendor the Codex or Claude ACP adapter packages. Native transport is the default; Codex and Claude use pinned `npx` commands unless deployment config overrides them.
 
 `coding-agent-adapters` is a runtime registry/API dependency used by this plugin's agent inventory and routes; it is not a bundled Codex or Claude ACP adapter executable.
+
+Linked-account enrollment and model inference are separate from executable coding-agent spawn. Claude subscription and OpenAI Codex accounts are the only linked-account transports currently bridged into coding sessions. Kimi and Z.AI coding-plan accounts can be enrolled for inference but do not register native spawn adapters; Grok/xAI has no linked-account or native spawn adapter yet. DeepSeek API credentials are inference-only, while its coding subscription remains unavailable. OpenRouter remains a generic model-routing option rather than a coding-account or spawn backend. Native Kimi, Z.AI, and Grok routes are tracked in #24096.
 
 ## Quick start
 
@@ -147,7 +149,7 @@ second credential broker, and child trajectories retain their session join key.
 | --- | --- | --- |
 | `ELIZA_ACP_TRANSPORT` | `native` | Transport mode. Accepted values include `native`/`direct` and `cli`/`acpx`. |
 | `ELIZA_ACP_CLI` | `acpx` | ACPX executable name or absolute path for the CLI transport. |
-| `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type. Primary choices: `elizaos`, `pi-agent`, `opencode`. |
+| `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type. Choices: `elizaos`, `pi-agent`, `claude`, or `codex`. |
 | `ELIZA_ACP_WARM_SPAWN` | unset | Set to `1` to keep one pre-initialized native `elizaos` child ready. It starts without session credentials, accepts one authenticated environment claim, and is disposed after that session; unclaimed children are recycled after two minutes. |
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command. |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command. |
@@ -157,7 +159,6 @@ second credential broker, and child trajectories retain their session join key.
 | `ELIZA_CODEX_ACP_APPROVAL_POLICY` / `ELIZA_CODEX_APPROVAL_POLICY` | `never` for no-Landlock fallback, otherwise unset | Optional managed Codex ACP approval policy. Setting it requires an explicit sandbox mode; the successor supports the fixed pairs `read-only`/`on-request`, `workspace-write`/`on-request`, and `danger-full-access`/`never`. |
 | `ELIZA_CODEX_ACP_LANDLOCK` / `ELIZA_CODEX_LANDLOCK` | auto-detect | Force Landlock detection for containers/tests: `1`/`true` or `0`/`false`. |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command. |
-| `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command override. |
 | `ELIZA_ACP_DEFAULT_APPROVAL` | `autonomous` | Approval preset (`read-only`, `auto`, `permissive`, `autonomous`, `full-access`). |
 | `ELIZA_ACP_PROMPT_TIMEOUT_MS` / `ACPX_DEFAULT_TIMEOUT_MS` | `300000` (5m) | Per-prompt timeout. |
 | `ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS` | `5000` (5s) | Maximum adapter-availability preflight wait. Values must be exact decimal integers from `250` through `2147483647`; missing/blank uses the default, and invalid values fail before the adapter probe starts. |
@@ -249,7 +250,6 @@ and an installed/authenticated `acpx` + Codex environment.
 
 ```bash
 RUN_LIVE_NATIVE_ACP=1 LIVE_NATIVE_ACP_AGENT=claude ELIZA_CLAUDE_ACP_COMMAND="npx -y @agentclientprotocol/claude-agent-acp@0.34.0" node tests/e2e/live-native-acp-smoke.mjs
-RUN_LIVE_NATIVE_ACP=1 LIVE_NATIVE_ACP_AGENT=opencode ELIZA_OPENCODE_ACP_COMMAND="opencode acp" node tests/e2e/live-native-acp-smoke.mjs
 ```
 
 The native smoke skips successfully when `RUN_LIVE_NATIVE_ACP` is unset, when an optional provider command is not configured, or when the adapter reports missing authentication/credentials. Use `RUN_LIVE_NATIVE_ACP=1 bun run test -- __tests__/live/native-acp-smoke.live.test.ts` to run the same smoke through Vitest.

--- a/plugins/plugin-agent-orchestrator/README.md
+++ b/plugins/plugin-agent-orchestrator/README.md
@@ -148,7 +148,7 @@ second credential broker, and child trajectories retain their session join key.
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `ELIZA_ACP_TRANSPORT` | `native` | Transport mode. Accepted values include `native`/`direct` and `cli`/`acpx`. |
-| `ELIZA_ACP_CLI` | `acpx` | ACPX executable name or absolute path for the CLI transport. |
+| `ELIZA_ACP_CLI` | `acpx` | ACPX executable name or path for the CLI transport; command arguments are rejected. |
 | `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type. Choices: `elizaos`, `pi-agent`, `claude`, or `codex`. |
 | `ELIZA_ACP_WARM_SPAWN` | unset | Set to `1` to keep one pre-initialized native `elizaos` child ready. It starts without session credentials, accepts one authenticated environment claim, and is disposed after that session; unclaimed children are recycled after two minutes. |
 | `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command. |

--- a/plugins/plugin-agent-orchestrator/__tests__/shared-runtime-env.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/shared-runtime-env.ts
@@ -1,4 +1,5 @@
 /** Exposes the shared runtime helpers used by orchestrator tests without loading the generated-data barrel. */
+export * from "../../../packages/shared/src/contracts/coding-agent-capabilities.js";
 export {
   isAndroidMobile,
   resolvePlatform,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -15,7 +15,10 @@ import {
   CODING_AGENT_BACKEND_PREFLIGHTS,
   CODING_AGENT_BACKENDS,
 } from "@elizaos/shared";
-import { getHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
+import {
+  captureHostExecutionBaseline,
+  getHostExecutionBaseline,
+} from "@elizaos/shared/host-execution-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // The ACP implementation runs every workdir through `path.resolve`, which on
@@ -330,6 +333,33 @@ async function waitForNativeClients(count: number): Promise<void> {
   throw new Error(
     `expected ${count} native clients, got ${nativeClientMock.instances.length}`,
   );
+}
+
+async function waitForMockCalls(
+  mock: ReturnType<typeof vi.fn>,
+  count: number,
+  timeoutMs = 1_000,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (mock.mock.calls.length >= count) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(
+    `expected ${count} mock calls, got ${mock.mock.calls.length}`,
+  );
+}
+
+async function waitForWarmClientReady(service: AcpService): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 1_000) {
+    const internal = service as AcpService & {
+      warmNativeClient?: unknown;
+    };
+    if (internal.warmNativeClient) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("expected warm native client to become ready");
 }
 
 beforeEach(() => {
@@ -848,6 +878,7 @@ describe("AcpService", () => {
   });
 
   it("single-claims warm elizaos children without credentials at process spawn", async () => {
+    captureHostExecutionBaseline();
     const previous = process.env.OPENAI_API_KEY;
     process.env.OPENAI_API_KEY = "host-credential-must-not-reach-warm-child";
     const service = new AcpService(
@@ -861,6 +892,7 @@ describe("AcpService", () => {
     try {
       await service.start();
       await waitForNativeClients(1);
+      await waitForWarmClientReady(service);
       const firstWarm = nativeClientMock.instances[0];
       const firstToken = firstWarm?.opts.env?.ELIZA_ACP_WARM_CLAIM_TOKEN;
       expect(firstToken).toMatch(/^[a-f0-9]{64}$/);
@@ -3268,7 +3300,7 @@ describe("AcpService.runHealthCheck state_lost guards", () => {
     );
 
     const promptA = service.sendPrompt(sessionId, "task A");
-    await vi.waitFor(() => expect(client.prompt).toHaveBeenCalledTimes(1));
+    await waitForMockCalls(client.prompt, 1);
     await service.updateSessionMetadata(sessionId, { taskId: "task-b" });
     await expect(service.sendPrompt(sessionId, "task B")).rejects.toThrow(
       /already busy/,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -11,6 +11,10 @@ import {
 import os, { tmpdir } from "node:os";
 import path, { join } from "node:path";
 import { Writable } from "node:stream";
+import {
+  CODING_AGENT_BACKEND_PREFLIGHTS,
+  CODING_AGENT_BACKENDS,
+} from "@elizaos/shared";
 import { getHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -358,6 +362,67 @@ async function waitForNativeClient(
 }
 
 describe("AcpService", () => {
+  it("reports every canonical backend unavailable when the transport is missing", async () => {
+    const service = new AcpService(
+      runtime({ ELIZA_ACP_TRANSPORT: "cli", ELIZA_ACP_CLI: "/no/acpx" }),
+    );
+
+    const availability = await service.checkAvailableAgents();
+
+    expect(availability.map((entry) => entry.agentType)).toEqual(
+      CODING_AGENT_BACKENDS,
+    );
+    expect(availability.every((entry) => entry.installed === false)).toBe(true);
+    expect(
+      availability.every((entry) => Boolean(entry.unavailableReason)),
+    ).toBe(true);
+  });
+
+  it("requires each configured native command to resolve to an executable", async () => {
+    const configured = Object.fromEntries(
+      CODING_AGENT_BACKENDS.map((backend) => [
+        CODING_AGENT_BACKEND_PREFLIGHTS[backend].commandConfigKey,
+        process.execPath,
+      ]),
+    );
+    const available = new AcpService(
+      runtime({ ELIZA_ACP_TRANSPORT: "native", ...configured }),
+    );
+    expect(
+      (await available.checkAvailableAgents()).every(
+        (entry) => entry.installed,
+      ),
+    ).toBe(true);
+
+    const missing = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: "native",
+        ...configured,
+        ELIZA_PI_AGENT_ACP_COMMAND: "/missing/pi-agent",
+      }),
+    );
+    const pi = (await missing.checkAvailableAgents()).find(
+      (entry) => entry.agentType === "pi-agent",
+    );
+    expect(pi).toMatchObject({ installed: false });
+    expect(pi?.unavailableReason).toMatch(/missing or not executable/i);
+  });
+
+  it("fails closed for an unknown adapter", () => {
+    const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "native" }));
+    const inspect = service as unknown as {
+      agentCommandAvailability(agentType: string): {
+        available: boolean;
+        reason?: string;
+      };
+    };
+
+    expect(inspect.agentCommandAvailability("unknown-adapter")).toMatchObject({
+      available: false,
+      reason: expect.stringMatching(/No verified ACP backend/),
+    });
+  });
+
   it("fails with a clear diagnostic when acpx is missing on Android", async () => {
     const previousPlatform = process.env.ELIZA_PLATFORM;
     process.env.ELIZA_PLATFORM = "android";
@@ -790,6 +855,7 @@ describe("AcpService", () => {
         ELIZA_ACP_TRANSPORT: "native",
         ELIZA_ACP_DEFAULT_AGENT: "elizaos",
         ELIZA_ACP_WARM_SPAWN: "1",
+        ELIZA_ELIZAOS_ACP_COMMAND: process.execPath,
       }),
     );
     try {
@@ -1306,63 +1372,6 @@ describe("AcpService", () => {
     expect(events).not.toContain("task_complete");
   });
 
-  it("prepares OpenCode ACP environment for Cerebras", async () => {
-    const reg = nextProc();
-    const service = new AcpService(
-      runtime({
-        ELIZA_OPENCODE_BASE_URL: "https://api.cerebras.ai/v1",
-        ELIZA_OPENCODE_API_KEY: "csk_test",
-        ELIZA_OPENCODE_MODEL_POWERFUL: "gpt-oss-120b",
-      }),
-    );
-    await service.start();
-
-    const spawned = service.spawnSession({
-      name: "opencode-cerebras",
-      agentType: "opencode",
-      workdir: "/tmp/acp-test",
-    });
-    await waitForSpawn(reg);
-    closeOk(reg);
-    await spawned;
-
-    const args = spawnMock.mock.calls[0]?.[1] as string[] | undefined;
-    const agentArgIndex = args?.indexOf("--agent") ?? -1;
-    expect(agentArgIndex).toBeGreaterThanOrEqual(0);
-    // The shim script lives at `<plugin>/bin/opencode*` and is referenced
-    // with platform-native path separators (`\` on Windows, `/` on POSIX).
-    // On Windows the spawn target is wrapped in double quotes (paths can
-    // contain spaces) and uses the `.cmd` shim, so accept either
-    // separator after `plugin-agent-orchestrator`, any extension on the
-    // opencode shim, and tolerate surrounding quotes / trailing tokens
-    // around the trailing `acp` subcommand.
-    const shimArg = args?.[agentArgIndex + 1];
-    expect(shimArg).toBeDefined();
-    expect(shimArg).toContain("plugin-agent-orchestrator");
-    expect(shimArg).toContain("opencode");
-    expect(shimArg).toMatch(/\sacp(\s|$)/);
-    expect(args).not.toContain("opencode");
-
-    const env = spawnMock.mock.calls[0]?.[2]?.env as
-      | Record<string, string>
-      | undefined;
-    const config = JSON.parse(env?.OPENCODE_CONFIG_CONTENT ?? "{}") as {
-      provider?: Record<
-        string,
-        { npm?: string; options?: { baseURL?: string; apiKey?: string } }
-      >;
-      model?: string;
-    };
-    expect(env?.OPENCODE_MODEL).toBe("cerebras/gpt-oss-120b");
-    expect(env?.OPENCODE_DISABLE_AUTOUPDATE).toBe("1");
-    expect(config.model).toBe("cerebras/gpt-oss-120b");
-    expect(config.provider?.cerebras?.options?.baseURL).toBe(
-      "https://api.cerebras.ai/v1",
-    );
-    expect(config.provider?.cerebras?.npm).toBe("@ai-sdk/cerebras");
-    expect(config.provider?.cerebras?.options?.apiKey).toBe("csk_test");
-  });
-
   it("keeps BENCHMARK_TASK_AGENT=elizaos as the native default adapter", async () => {
     const reg = nextProc();
     const service = new AcpService(
@@ -1384,13 +1393,11 @@ describe("AcpService", () => {
 
     expect(session.agentType).toBe("elizaos");
     const args = spawnMock.mock.calls[0]?.[1] as string[] | undefined;
-    expect(args).toContain("elizaos");
-    expect(args).not.toContain("opencode");
-
+    expect(args).toContain("--agent");
+    expect(args).toContain("eliza-code-acp");
     const env = spawnMock.mock.calls[0]?.[2]?.env as
       | Record<string, string>
       | undefined;
-    expect(env?.OPENCODE_MODEL).toBeUndefined();
     expect(env?.OPENAI_MODEL).toBeUndefined();
   });
 
@@ -1693,51 +1700,6 @@ describe("AcpService", () => {
         process.env.ELIZA_CODEX_ACP_LANDLOCK = previousOverride;
       }
     }
-  });
-
-  it("uses an explicit OpenCode ACP command override when configured", async () => {
-    const reg = nextProc();
-    const service = new AcpService(
-      runtime({
-        ELIZA_OPENCODE_ACP_COMMAND: "/opt/opencode/bin/opencode acp",
-      }),
-    );
-    await service.start();
-
-    const spawned = service.spawnSession({
-      name: "opencode-command",
-      agentType: "opencode",
-      workdir: "/tmp/acp-test",
-    });
-    await waitForSpawn(reg);
-    closeOk(reg);
-    const { sessionId } = await spawned;
-
-    const args = spawnMock.mock.calls[0]?.[1] as string[] | undefined;
-    const agentArgIndex = args?.indexOf("--agent") ?? -1;
-    expect(agentArgIndex).toBeGreaterThanOrEqual(0);
-    expect(args?.[agentArgIndex + 1]).toBe("/opt/opencode/bin/opencode acp");
-    expect(args).not.toContain("opencode");
-
-    const prompt = nextProc();
-    const sent = service.sendPrompt(sessionId, "write a tiny static page");
-    await waitForSpawn(prompt);
-    prompt.proc.stdout.emit(
-      "data",
-      Buffer.from(
-        '{"jsonrpc":"2.0","id":"prompt","result":{"stopReason":"end_turn"},"sessionId":"protocol-session"}\n',
-      ),
-    );
-    closeOk(prompt);
-    await sent;
-
-    const promptArgs = spawnMock.mock.calls[1]?.[1] as string[] | undefined;
-    const promptAgentArgIndex = promptArgs?.indexOf("--agent") ?? -1;
-    expect(promptAgentArgIndex).toBeGreaterThanOrEqual(0);
-    expect(promptArgs?.[promptAgentArgIndex + 1]).toBe(
-      "/opt/opencode/bin/opencode acp",
-    );
-    expect(promptArgs).not.toContain("opencode");
   });
 
   it("sendPrompt emits message, tool_running, task_complete and resolves PromptResult", async () => {
@@ -2216,7 +2178,7 @@ describe("AcpService", () => {
     await service.start();
     const { sessionId } = await service.spawnSession({
       name: "native-reasoning",
-      agentType: "opencode",
+      agentType: "codex",
       workdir: "/tmp/acp-test",
     });
     const client = firstNativeClient();
@@ -2273,7 +2235,7 @@ describe("AcpService", () => {
     await service.start();
     const { sessionId } = await service.spawnSession({
       name: "native-plan",
-      agentType: "opencode",
+      agentType: "codex",
       workdir: "/tmp/acp-test",
     });
     const client = firstNativeClient();
@@ -2571,7 +2533,7 @@ describe("AcpService", () => {
     await service.start();
     const spawned = service.spawnSession({
       name: "route-prefixed",
-      agentType: "opencode",
+      agentType: "codex",
       workdir: "/tmp/acp-test",
     });
     await waitForSpawn(create);
@@ -2602,7 +2564,7 @@ describe("AcpService", () => {
     await service.start();
     const spawned = service.spawnSession({
       name: "ignore-echo",
-      agentType: "opencode",
+      agentType: "codex",
       workdir: "/tmp/acp-test",
     });
     await waitForSpawn(create);
@@ -2970,7 +2932,7 @@ describe("AcpService.runHealthCheck state_lost guards", () => {
     return {
       id: over.id ?? "00000000-0000-0000-0000-0000000000aa",
       name: "hc",
-      agentType: "opencode" as const,
+      agentType: "codex" as const,
       workdir: "/tmp/acp-test",
       status: "ready" as const,
       approvalPreset: "standard" as const,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -135,7 +135,16 @@ vi.mock("../../src/services/acp-native-transport.js", () => {
       this.eventHandler?.(event, sessionId);
     }
   };
-  return { NativeAcpClient: state.NativeAcpClient };
+  return {
+    NativeAcpClient: state.NativeAcpClient,
+    splitCommandLine(input: string) {
+      const parts = input.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/gu) ?? [];
+      const [command = "", ...args] = parts.map((part) =>
+        part.replace(/^(['"])(.*)\1$/u, "$2"),
+      );
+      return { command, args };
+    },
+  };
 });
 
 import {
@@ -451,6 +460,76 @@ describe("AcpService", () => {
       available: false,
       reason: expect.stringMatching(/No verified ACP backend/),
     });
+  });
+
+  it("accepts built-in acpx profiles without shadow profile executables", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "acpx-profile-preflight-"));
+    const cliPath = join(dir, "acpx");
+    const previousPath = process.env.PATH;
+    try {
+      await fs.writeFile(cliPath, "#!/bin/sh\nexit 0\n");
+      await fs.chmod(cliPath, 0o755);
+      process.env.PATH = dir;
+      const service = new AcpService(
+        runtime({ ELIZA_ACP_TRANSPORT: "cli", ELIZA_ACP_CLI: cliPath }),
+      );
+
+      const availability = await service.checkAvailableAgents();
+
+      for (const agentType of ["pi-agent", "claude", "codex"] as const) {
+        expect(
+          availability.find((entry) => entry.agentType === agentType),
+        ).toMatchObject({ installed: true });
+      }
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a composed ELIZA_ACP_CLI command before spawn", async () => {
+    const service = new AcpService(
+      runtime({ ELIZA_ACP_TRANSPORT: "cli", ELIZA_ACP_CLI: "npx -y acpx" }),
+    );
+
+    expect(
+      (await service.checkAvailableAgents()).every(
+        (entry) => entry.installed === false,
+      ),
+    ).toBe(true);
+    expect(
+      (await service.checkAvailableAgents())[0]?.unavailableReason,
+    ).toMatch(/must name one executable path/i);
+  });
+
+  it("anchors a relative native executable before the session changes cwd", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "relative-native-command-"));
+    const executable = join(dir, "agent-acp");
+    try {
+      await fs.writeFile(executable, "#!/bin/sh\nexit 0\n");
+      await fs.chmod(executable, 0o755);
+      const relative = path.relative(process.cwd(), executable);
+      const service = new AcpService(
+        runtime({
+          ELIZA_ACP_TRANSPORT: "native",
+          ELIZA_PI_AGENT_ACP_COMMAND: `${relative} --stdio`,
+        }),
+      );
+      const inspect = service as unknown as {
+        nativeAgentCommand(agentType: string): string;
+        agentCommandAvailability(agentType: string): { available: boolean };
+      };
+
+      expect(inspect.nativeAgentCommand("pi-agent")).toBe(
+        `${executable} --stdio`,
+      );
+      expect(inspect.agentCommandAvailability("pi-agent")).toEqual({
+        available: true,
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("fails with a clear diagnostic when acpx is missing on Android", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
@@ -51,7 +51,6 @@ function installedProbe(): TaskAgentFrameworkProbe {
     checkAvailableAgents: vi.fn(async () => [
       { adapter: "Claude Code", installed: true },
       { adapter: "OpenAI Codex", installed: true },
-      { adapter: "OpenCode", installed: true },
     ]),
   };
 }
@@ -65,7 +64,6 @@ function delayedInstalledProbe(): TaskAgentFrameworkProbe {
             resolve([
               { adapter: "Claude Code", installed: true },
               { adapter: "OpenAI Codex", installed: true },
-              { adapter: "OpenCode", installed: true },
             ]);
           }, 10);
         }),
@@ -115,20 +113,6 @@ describe("getTaskAgentFrameworkState", () => {
     fs.rmSync(tempHome, { recursive: true, force: true });
   });
 
-  it("does not expose OpenCode for Cerebras-backed benchmark runs", async () => {
-    setEnv({
-      BENCHMARK_MODEL_PROVIDER: "cerebras",
-      CEREBRAS_API_KEY: "csk-test",
-    });
-
-    const state = await getTaskAgentFrameworkState(runtime(), installedProbe());
-
-    expect(state.frameworks.some((item) => item.id === "opencode")).toBe(false);
-    expect(
-      state.frameworks.find((item) => item.id === "codex")?.authReady,
-    ).toBe(false);
-  });
-
   it("prefers eliza-code as the BYO default once eliza-code is installed", async () => {
     writeExecutable(path.join(tempHome, "eliza-code-acp"));
     setEnv({
@@ -143,10 +127,9 @@ describe("getTaskAgentFrameworkState", () => {
     expect(
       state.frameworks.find((item) => item.id === "elizaos")?.installed,
     ).toBe(true);
-    expect(state.frameworks.some((item) => item.id === "opencode")).toBe(false);
   });
 
-  it("honors ElizaOS as an explicit native task-agent default", async () => {
+  it("does not fabricate ElizaOS installation from an explicit default", async () => {
     setEnv({
       ELIZA_DEFAULT_AGENT_TYPE: "elizaos",
       BENCHMARK_MODEL_PROVIDER: "cerebras",
@@ -155,16 +138,15 @@ describe("getTaskAgentFrameworkState", () => {
 
     const state = await getTaskAgentFrameworkState(runtime(), installedProbe());
 
-    expect(state.preferred.id).toBe("elizaos");
     expect(
       state.frameworks.find((item) => item.id === "elizaos")?.installed,
-    ).toBe(true);
+    ).toBe(false);
     expect(
       state.frameworks.find((item) => item.id === "elizaos")?.authReady,
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it("honors Pi Agent as an explicit native task-agent default", async () => {
+  it("does not fabricate Pi Agent installation from an explicit default", async () => {
     setEnv({
       ELIZA_DEFAULT_AGENT_TYPE: "pi-agent",
       BENCHMARK_MODEL_PROVIDER: "cerebras",
@@ -173,13 +155,12 @@ describe("getTaskAgentFrameworkState", () => {
 
     const state = await getTaskAgentFrameworkState(runtime(), installedProbe());
 
-    expect(state.preferred.id).toBe("pi-agent");
     expect(
       state.frameworks.find((item) => item.id === "pi-agent")?.installed,
-    ).toBe(true);
+    ).toBe(false);
     expect(
       state.frameworks.find((item) => item.id === "pi-agent")?.authReady,
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("fails Pi Agent readiness closed when a configured ACP command is missing", async () => {
@@ -233,7 +214,6 @@ describe("getTaskAgentFrameworkState", () => {
 
     const state = await getTaskAgentFrameworkState(runtime(), installedProbe());
 
-    expect(state.frameworks.some((item) => item.id === "opencode")).toBe(false);
     expect(
       state.frameworks.find((item) => item.id === "codex")?.authReady,
     ).toBe(false);
@@ -421,7 +401,7 @@ describe("getTaskAgentFrameworkState", () => {
 
 // Model prefs must honor a freshly-saved config-file value on the NEXT spawn:
 // runtime.getSetting snapshots character settings at boot, so config-env is
-// checked first (matching how the codex/opencode prefs already behave).
+// checked first, matching the existing Codex preference behavior.
 describe("getTaskAgentModelPrefs", () => {
   const PREF_ENV_KEYS = [
     "ELIZA_CONFIG_PATH",

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
@@ -163,6 +163,55 @@ describe("getTaskAgentFrameworkState", () => {
     ).toBe(false);
   });
 
+  it("preserves an authoritative negative preflight despite static discovery", async () => {
+    writeExecutable(path.join(tempHome, "npx"));
+    setEnv({ CODEX_API_KEY: "codex-test" });
+    const probe: TaskAgentFrameworkProbe = {
+      checkAvailableAgents: vi.fn(async () => [
+        {
+          adapter: "OpenAI Codex",
+          installed: false,
+          auth: { status: "authenticated" },
+        },
+      ]),
+    };
+
+    const state = await getTaskAgentFrameworkState(runtime(), probe);
+
+    expect(
+      state.frameworks.find((item) => item.id === "codex")?.installed,
+    ).toBe(false);
+    expect(
+      state.frameworks.find((item) => item.id === "codex")?.authReady,
+    ).toBe(false);
+  });
+
+  it("treats installed runtime-routed adapters as auth-ready with production unknown auth", async () => {
+    const probe: TaskAgentFrameworkProbe = {
+      checkAvailableAgents: vi.fn(async () => [
+        {
+          adapter: "ElizaOS",
+          installed: true,
+          auth: { status: "unknown" },
+        },
+        {
+          adapter: "Pi Agent",
+          installed: true,
+          auth: { status: "unknown" },
+        },
+      ]),
+    };
+
+    const state = await getTaskAgentFrameworkState(runtime(), probe);
+
+    for (const id of ["elizaos", "pi-agent"] as const) {
+      expect(state.frameworks.find((item) => item.id === id)).toMatchObject({
+        installed: true,
+        authReady: true,
+      });
+    }
+  });
+
   it("fails Pi Agent readiness closed when a configured ACP command is missing", async () => {
     writeExecutable(path.join(tempHome, "pi-agent"));
     setEnv({

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -20,7 +20,7 @@ import {
   spawnSync,
 } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
+import { accessSync, constants, existsSync, statSync } from "node:fs";
 import {
   chmod,
   copyFile,
@@ -43,7 +43,12 @@ import {
   toWellFormedUnicode,
   truncateWellFormed,
 } from "@elizaos/core";
-import { isAndroidMobile } from "@elizaos/shared";
+import {
+  CODING_AGENT_BACKEND_PREFLIGHTS,
+  CODING_AGENT_BACKENDS,
+  isAndroidMobile,
+  isCodingAgentBackend,
+} from "@elizaos/shared";
 import { getHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
 import { NativeAcpClient } from "./acp-native-transport.js";
 import { augmentTaskWithDeployGuidance } from "./app-deploy-guidance.js";
@@ -350,8 +355,26 @@ function findGitBinaryForAcp(): string {
 function findExecutableOnPath(name: string): string | undefined {
   for (const dir of (process.env.PATH ?? "").split(delimiter)) {
     if (!dir) continue;
-    const candidate = join(dir, name);
-    if (existsSync(candidate)) return candidate;
+    const candidates = new Set([join(dir, name)]);
+    if (process.platform === "win32") {
+      for (const extension of (process.env.PATHEXT ?? ".EXE;.CMD;.BAT")
+        .split(";")
+        .map((value) => value.trim())
+        .filter(Boolean)) {
+        candidates.add(join(dir, `${name}${extension.toLowerCase()}`));
+        candidates.add(join(dir, `${name}${extension.toUpperCase()}`));
+      }
+    }
+    for (const candidate of candidates) {
+      try {
+        if (!statSync(candidate).isFile()) continue;
+        accessSync(candidate, constants.X_OK);
+        return candidate;
+      } catch {
+        // error-policy:J3 PATH entries that are missing or non-executable are
+        // explicit preflight misses; continue looking for a runnable candidate.
+      }
+    }
   }
   return undefined;
 }
@@ -798,7 +821,7 @@ export function resolveInitialTaskPromptTimeoutMs(
 ): number | undefined {
   return explicitTimeoutMs ?? 0;
 }
-const DEFAULT_AGENTS: AgentType[] = ["elizaos", "codex", "claude"];
+const DEFAULT_AGENTS: readonly AgentType[] = CODING_AGENT_BACKENDS;
 // Path segment for Codex homes whose auth.json carries a selected ChatGPT
 // subscription. The marker stays in sync with
 // coding-account-bridge.ts:codexHomeDir; ordinary CODEX_HOME paths may instead
@@ -1820,11 +1843,11 @@ export class AcpService extends Service {
 
   // The acpx transport persists session state as `<acpxSessionId>.json` under
   // <stateRoot>/sessions. The old probe checked `<acpxSessionId>.stream.ndjson`
-  // which NEVER exists for opencode/native sessions (verified: 0 such files on
-  // disk, only ses_*.json) — a permanent false-negative that made every healthy
+  // which does not exist for native sessions (only ses_*.json is persisted) —
+  // a permanent false-negative that made every healthy
   // session look "state lost", triggering a runaway "spawn a fresh sub-agent"
   // respawn cascade AND spuriously throwing on the first real prompt to any
-  // opencode session. Probe the artifact the transport actually writes.
+  // ACP session. Probe the artifact the transport actually writes.
   private acpxSessionStateFile(acpxSessionId: string): string {
     return join(this.acpxStateRoot(), "sessions", `${acpxSessionId}.json`);
   }
@@ -2821,12 +2844,16 @@ export class AcpService extends Service {
   }
 
   async getAvailableAgents(): Promise<AvailableAgentInfo[]> {
-    return DEFAULT_AGENTS.map((agentType) => ({
-      adapter: agentType,
-      agentType,
-      installed: true,
-      auth: { status: "unknown" },
-    }));
+    return DEFAULT_AGENTS.map((agentType) => {
+      const command = this.agentCommandAvailability(agentType);
+      return {
+        adapter: agentType,
+        agentType,
+        installed: command.available,
+        ...(command.reason ? { unavailableReason: command.reason } : {}),
+        auth: { status: "unknown" },
+      };
+    });
   }
 
   async checkAvailableAgents(types?: string[]): Promise<AvailableAgentInfo[]> {
@@ -3627,27 +3654,81 @@ export class AcpService extends Service {
   private nativeAgentCommand(agentType: AgentType): string {
     const normalizedAgentType =
       normalizeTaskAgentAdapter(agentType) ?? agentType;
-    if (normalizedAgentType === "codex") return this.codexAgentCommand();
-    const override = this.setting(
-      `ELIZA_${String(normalizedAgentType)
-        .toUpperCase()
-        .replace(/[^A-Z0-9]/g, "_")}_ACP_COMMAND`,
-    );
-    if (override?.trim()) return override.trim();
-    if (normalizedAgentType === "claude")
-      return (
-        this.setting("ELIZA_CLAUDE_ACP_COMMAND") ??
-        "npx -y @agentclientprotocol/claude-agent-acp@0.34.0"
+    if (!isCodingAgentBackend(normalizedAgentType)) {
+      throw new ElizaError(
+        `No verified ACP backend is registered for ${String(normalizedAgentType)}`,
+        {
+          code: "ACP_BACKEND_UNAVAILABLE",
+          context: { agentType: String(normalizedAgentType) },
+        },
       );
-    // The elizaOS CLI has no ACP mode; the separately installed eliza-code ACP
-    // server is the native adapter for this agent type.
-    if (normalizedAgentType === "elizaos")
-      return (
-        this.setting("ELIZA_ELIZAOS_ACP_COMMAND") ??
-        findExecutableOnPath("eliza-code-acp") ??
-        "eliza-code-acp"
-      );
-    return String(normalizedAgentType);
+    }
+    const preflight = CODING_AGENT_BACKEND_PREFLIGHTS[normalizedAgentType];
+    if (preflight.commandResolution === "managed-codex") {
+      return this.codexAgentCommand();
+    }
+    const configured = this.setting(preflight.commandConfigKey);
+    return configured?.trim() || preflight.defaultCommand;
+  }
+
+  private agentCommandAvailability(agentType: AgentType): {
+    available: boolean;
+    reason?: string;
+  } {
+    let commandLines: string[];
+    try {
+      if (this.transportMode === "native") {
+        commandLines = [this.nativeAgentCommand(agentType)];
+      } else {
+        const adapter = this.legacyAcpxAdapter(agentType);
+        commandLines = [
+          this.cliPath,
+          ...(adapter.command ? [adapter.command] : []),
+        ];
+      }
+    } catch (error) {
+      // error-policy:J4 invalid adapter configuration is an explicit
+      // unavailable inventory row; one bad row must not hide the rest.
+      return { available: false, reason: errorMessage(error) };
+    }
+    for (const commandLine of commandLines) {
+      const [token] =
+        commandLine.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/gu) ?? [];
+      const command = token?.replace(/^(['"])(.*)\1$/u, "$2") ?? "";
+      if (!command) {
+        return {
+          available: false,
+          reason: "No executable command is configured.",
+        };
+      }
+      if (command.includes("/") || command.includes("\\")) {
+        try {
+          const commandPath = resolve(command);
+          if (!statSync(commandPath).isFile()) {
+            return {
+              available: false,
+              reason: `Configured command is not a file: ${command}`,
+            };
+          }
+          accessSync(commandPath, constants.X_OK);
+          continue;
+        } catch {
+          // error-policy:J3 configured command paths fail closed when absent or
+          // non-executable; the preflight row reports installed=false.
+          return {
+            available: false,
+            reason: `Configured command is missing or not executable: ${command}`,
+          };
+        }
+      }
+      if (!findExecutableOnPath(command)) {
+        return {
+          available: false,
+          reason: `Command is not available on PATH: ${command}`,
+        };
+      }
+    }
+    return { available: true };
   }
 
   private async stopNativeClient(sessionId: string): Promise<void> {
@@ -3664,7 +3745,34 @@ export class AcpService extends Service {
   }
 
   private agentCommandArgs(agentType: AgentType, args: string[]): string[] {
-    return [agentType, ...args];
+    return [...this.legacyAcpxAdapter(agentType).args, ...args];
+  }
+
+  /** Resolve only acpx adapters whose invocation contract is known here. */
+  private legacyAcpxAdapter(agentType: AgentType): {
+    args: readonly string[];
+    command?: string;
+  } {
+    const normalized = normalizeTaskAgentAdapter(agentType) ?? agentType;
+    switch (normalized) {
+      case "pi-agent":
+        return { args: ["pi"], command: "pi" };
+      case "claude":
+      case "codex":
+        return { args: [normalized], command: normalized };
+      case "elizaos": {
+        const command = this.nativeAgentCommand(normalized);
+        return { args: ["--agent", command], command };
+      }
+      default:
+        throw new ElizaError(
+          `No verified legacy acpx adapter is registered for ${String(normalized)}`,
+          {
+            code: "ACP_LEGACY_ADAPTER_UNAVAILABLE",
+            context: { agentType: String(normalized) },
+          },
+        );
+    }
   }
 
   private runAcpx(opts: RunOptions): Promise<RunResult> {
@@ -4045,8 +4153,8 @@ export class AcpService extends Service {
         this.emitSessionEvent(sessionId, "message", { text: content.text });
       }
       // agent_thought_chunk: the model's reasoning / chain-of-thought streams
-      // in the SAME payload shape as agent_message_chunk (opencode emits it for
-      // `reasoning` parts). Forward the text as a dedicated `reasoning` event so
+      // in the same payload shape as agent_message_chunk. Forward the text as a
+      // dedicated `reasoning` event so
       // the UI can surface it, but do NOT add it to finalText/appendOutput:
       // reasoning is not the deliverable response, and folding it into the turn
       // text would corrupt the task_complete summary and tool-output capture.
@@ -4057,8 +4165,8 @@ export class AcpService extends Service {
       ) {
         this.emitSessionEvent(sessionId, "reasoning", { text: content.text });
       }
-      // plan: opencode emits the agent's checklist/plan list as a `plan` update with
-      // entries [{content, status, priority}] (driven by its todowrite tool).
+      // Some ACP adapters emit checklist entries as a `plan` update with
+      // entries [{content, status, priority}].
       // Forward a sanitized snapshot as a `plan` event so the task's currentPlan
       // can drive the plan/checklist dock. Validated at this boundary (raw -> typed);
       // an adapter that never emits a plan simply does not enter this branch.

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -50,7 +50,7 @@ import {
   isCodingAgentBackend,
 } from "@elizaos/shared";
 import { getHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
-import { NativeAcpClient } from "./acp-native-transport.js";
+import { NativeAcpClient, splitCommandLine } from "./acp-native-transport.js";
 import { augmentTaskWithDeployGuidance } from "./app-deploy-guidance.js";
 import {
   CODEX_NO_LANDLOCK_SANDBOX_MODE_ENV,
@@ -377,6 +377,23 @@ function findExecutableOnPath(name: string): string | undefined {
     }
   }
   return undefined;
+}
+
+function quoteCommandPart(value: string): string {
+  return /\s/u.test(value) ? JSON.stringify(value) : value;
+}
+
+/**
+ * Anchor relative executable paths before a session changes cwd. Bare commands
+ * deliberately remain PATH-resolved by the child process.
+ */
+function anchorRelativeCommandLine(commandLine: string): string {
+  const { command, args } = splitCommandLine(commandLine);
+  if (!command || (!command.includes("/") && !command.includes("\\"))) {
+    return commandLine;
+  }
+  const executable = resolve(command);
+  return [executable, ...args].map(quoteCommandPart).join(" ");
 }
 
 export function normalizeClaudeAcpModelId(
@@ -961,7 +978,13 @@ export class AcpService extends Service {
     this.workspaceRegistry = getSharedWorkspaceRegistry((level, msg, ctx) =>
       this.log(level, msg, ctx),
     );
-    this.cliPath = this.setting("ELIZA_ACP_CLI") ?? "acpx";
+    const configuredCli = this.setting("ELIZA_ACP_CLI") ?? "acpx";
+    const parsedCli = splitCommandLine(configuredCli);
+    this.cliPath =
+      parsedCli.args.length === 0 &&
+      (parsedCli.command.includes("/") || parsedCli.command.includes("\\"))
+        ? resolve(parsedCli.command)
+        : configuredCli;
     this.transportMode =
       normalizeTransportMode(
         this.setting("ELIZA_ACP_TRANSPORT") ?? this.setting("ACPX_TRANSPORT"),
@@ -3668,7 +3691,9 @@ export class AcpService extends Service {
       return this.codexAgentCommand();
     }
     const configured = this.setting(preflight.commandConfigKey);
-    return configured?.trim() || preflight.defaultCommand;
+    return anchorRelativeCommandLine(
+      configured?.trim() || preflight.defaultCommand,
+    );
   }
 
   private agentCommandAvailability(agentType: AgentType): {
@@ -3683,7 +3708,12 @@ export class AcpService extends Service {
         const adapter = this.legacyAcpxAdapter(agentType);
         commandLines = [
           this.cliPath,
-          ...(adapter.command ? [adapter.command] : []),
+          // pi/claude/codex are acpx registry selectors, not host binaries.
+          // Only the elizaOS `--agent <command>` route names a second process
+          // the host must be able to execute.
+          ...(adapter.command && adapter.args[0] === "--agent"
+            ? [adapter.command]
+            : []),
         ];
       }
     } catch (error) {
@@ -3692,13 +3722,22 @@ export class AcpService extends Service {
       return { available: false, reason: errorMessage(error) };
     }
     for (const commandLine of commandLines) {
-      const [token] =
-        commandLine.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/gu) ?? [];
-      const command = token?.replace(/^(['"])(.*)\1$/u, "$2") ?? "";
+      const { command, args } = splitCommandLine(commandLine);
       if (!command) {
         return {
           available: false,
           reason: "No executable command is configured.",
+        };
+      }
+      if (
+        this.transportMode === "cli" &&
+        commandLine === this.cliPath &&
+        args.length > 0
+      ) {
+        return {
+          available: false,
+          reason:
+            "ELIZA_ACP_CLI must name one executable path; command arguments are not supported.",
         };
       }
       if (command.includes("/") || command.includes("\\")) {
@@ -5327,6 +5366,9 @@ export class AcpService extends Service {
   }
 
   private missingCliMessage(): string | undefined {
+    if (splitCommandLine(this.cliPath).args.length > 0) {
+      return "ELIZA_ACP_CLI must name one executable path; command arguments are not supported.";
+    }
     if (!this.cliPath.includes("/") || existsSync(this.cliPath)) {
       return undefined;
     }

--- a/plugins/plugin-agent-orchestrator/src/services/coding-account-selection.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/coding-account-selection.ts
@@ -19,6 +19,7 @@ import {
   getCodingAgentSelectorBridge,
   logger,
 } from "@elizaos/core";
+import { CODING_AGENT_BACKEND_PROVIDERS } from "@elizaos/shared";
 
 // The bridge symbol + contract are single-sourced in `@elizaos/core`; re-export
 // the shared types under this plugin's public surface. `CodingAccountSelection`
@@ -47,10 +48,14 @@ export interface ResolvedCodingAccount {
 /**
  * Agent types that authenticate per pooled account. claude and codex are
  * first-party CLIs. elizaos/pi-agent authenticate through their own backend,
- * and z.ai/Kimi/GLM have no first-party coding CLI. Keep this in
- * sync with the app-core bridge's AGENT_PROVIDER_CANDIDATES.
+ * and z.ai/Kimi/GLM have no wired coding-account transport. Derivation from the
+ * shared descriptor keeps this gate aligned with the app-core bridge.
  */
-const MULTI_ACCOUNT_AGENT_TYPES = new Set(["claude", "codex"]);
+const MULTI_ACCOUNT_AGENT_TYPES = new Set(
+  Object.entries(CODING_AGENT_BACKEND_PROVIDERS)
+    .filter(([, providers]) => providers.length > 0)
+    .map(([backend]) => backend),
+);
 
 export function isMultiAccountAgentType(agentType: string): boolean {
   return MULTI_ACCOUNT_AGENT_TYPES.has(agentType.toLowerCase());

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-device-support-matrix.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-device-support-matrix.ts
@@ -8,13 +8,17 @@
  * uses, so this object cannot silently drift from the gate: a change to the
  * device gating that affects any documented profile fails this package's tests.
  *
- * Backend → auth-mode reach mirrors AGENT_PROVIDER_CANDIDATES in
- * packages/app-core/src/services/coding-account-bridge.ts (the auth pairing
- * lives there because the plugin depends only on @elizaos/core and reads the
- * selector over a globalThis bridge). When a device supports coding agents,
- * every backend below is reachable on it; when unsupported, none are.
+ * Backend → auth-mode reach comes from the cross-runtime shared capability
+ * contract also consumed by the app-core account bridge. When a device
+ * supports coding agents, every backend below is reachable on it; when
+ * unsupported, none are.
  */
 
+import {
+  CODING_AGENT_BACKEND_PROVIDERS,
+  CODING_AGENT_BACKENDS,
+  type CodingAgentBackend,
+} from "@elizaos/shared";
 import {
   classifyTerminalSupport,
   type OrchestratorTerminalSupport,
@@ -22,23 +26,22 @@ import {
 } from "./terminal-capabilities.js";
 
 /** Coding backends with a first-party spawnable CLI (post #9167 cleanup). */
-export const ORCHESTRATOR_BACKENDS = [
-  "elizaos",
-  "pi-agent",
-  "claude",
-  "codex",
-] as const;
-export type OrchestratorBackend = (typeof ORCHESTRATOR_BACKENDS)[number];
+export const ORCHESTRATOR_BACKENDS = CODING_AGENT_BACKENDS;
+export type OrchestratorBackend = CodingAgentBackend;
 
 /** Ordered auth modes per backend; subscription is preferred over API key. */
 export const ORCHESTRATOR_BACKEND_AUTH: Readonly<
   Record<OrchestratorBackend, readonly string[]>
-> = {
-  elizaos: ["runtime-routed"],
-  "pi-agent": ["runtime-routed"],
-  claude: ["anthropic-subscription", "anthropic-api"],
-  codex: ["openai-codex", "openai-api"],
-};
+> = ORCHESTRATOR_BACKENDS.reduce(
+  (authModes, backend) => {
+    authModes[backend] =
+      CODING_AGENT_BACKEND_PROVIDERS[backend].length > 0
+        ? CODING_AGENT_BACKEND_PROVIDERS[backend]
+        : ["runtime-routed"];
+    return authModes;
+  },
+  {} as Record<OrchestratorBackend, readonly string[]>,
+);
 
 export interface DeviceSupportProfile {
   /** Stable id for the device/runtime profile. */

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -19,7 +19,12 @@ import {
   resolveStateDir,
   resolveUserPath,
 } from "@elizaos/core";
-import { readAliasedEnv } from "@elizaos/shared";
+import {
+  CODING_AGENT_BACKEND_PREFLIGHTS,
+  CODING_AGENT_BACKENDS,
+  type CodingAgentBackend,
+  readAliasedEnv,
+} from "@elizaos/shared";
 import { readConfigCloudKey, readConfigEnvKey } from "./config-env.js";
 
 type AgentMetricsSummary = {
@@ -37,11 +42,7 @@ type TaskAgentPreflightResult = {
   auth?: { status?: unknown };
 };
 
-export type SupportedTaskAgentAdapter =
-  | "elizaos"
-  | "pi-agent"
-  | "claude"
-  | "codex";
+export type SupportedTaskAgentAdapter = CodingAgentBackend;
 export type TaskAgentFrameworkId = SupportedTaskAgentAdapter;
 
 export interface TaskAgentModelPrefs {
@@ -198,12 +199,8 @@ const FRAMEWORK_LABELS: Record<TaskAgentFrameworkId, string> = {
   codex: "Codex",
 };
 
-const STANDARD_FRAMEWORKS: SupportedTaskAgentAdapter[] = [
-  "elizaos",
-  "pi-agent",
-  "claude",
-  "codex",
-];
+const STANDARD_FRAMEWORKS: readonly SupportedTaskAgentAdapter[] =
+  CODING_AGENT_BACKENDS;
 
 const DEFAULT_FRAMEWORK_PREFLIGHT_TIMEOUT_MS = 5_000;
 const MAX_FRAMEWORK_PREFLIGHT_TIMEOUT_MS = 2_147_483_647;
@@ -629,28 +626,12 @@ function isCommandExecutableAvailable(command: string | undefined): boolean {
 }
 
 function hasFrameworkBinary(id: SupportedTaskAgentAdapter): boolean {
-  switch (id) {
-    case "elizaos": {
-      const configured = readConfigEnvKey("ELIZA_ELIZAOS_ACP_COMMAND");
-      return configured
-        ? isCommandExecutableAvailable(configured)
-        : hasBinaryOnPath("eliza-code-acp");
-    }
-    case "pi-agent": {
-      const configured = readConfigEnvKey("ELIZA_PI_AGENT_ACP_COMMAND");
-      return configured
-        ? isCommandExecutableAvailable(configured)
-        : hasBinaryOnPath("pi-agent");
-    }
-    case "claude":
-      return hasBinaryOnPath("claude");
-    case "codex": {
-      const configured = readConfigEnvKey("ELIZA_CODEX_ACP_COMMAND");
-      return configured
-        ? isCommandExecutableAvailable(configured)
-        : hasBinaryOnPath("codex");
-    }
-  }
+  const preflight = CODING_AGENT_BACKEND_PREFLIGHTS[id];
+  const configured = readConfigEnvKey(preflight.commandConfigKey);
+  if (configured) return isCommandExecutableAvailable(configured);
+  return preflight.commandResolution === "managed-codex"
+    ? hasBinaryOnPath("npx")
+    : isCommandExecutableAvailable(preflight.defaultCommand);
 }
 
 async function computeTaskAgentFrameworkState(
@@ -668,7 +649,7 @@ async function computeTaskAgentFrameworkState(
     const preflightTimeoutMs = resolveFrameworkPreflightTimeoutMs();
     try {
       const results = await withTimeout(
-        probe.checkAvailableAgents(STANDARD_FRAMEWORKS),
+        probe.checkAvailableAgents([...STANDARD_FRAMEWORKS]),
         preflightTimeoutMs,
         "task-agent framework preflight",
       );
@@ -724,26 +705,24 @@ async function computeTaskAgentFrameworkState(
   const inventory: TaskAgentFrameworkAvailability[] = STANDARD_FRAMEWORKS.map(
     (id) => {
       const preflight = preflightByAdapter.get(id);
-      const nativeExplicit =
-        (id === "elizaos" || id === "pi-agent") && explicitDefault === id;
-      const installed =
-        preflight?.installed === true ||
-        hasFrameworkBinary(id) ||
-        nativeExplicit;
+      const installed = preflight?.installed === true || hasFrameworkBinary(id);
       const subscriptionReady =
         id === "claude"
           ? claudeSubscriptionReady
           : id === "codex"
             ? codexSubscriptionReady
             : false;
-      const authReady =
+      const credentialsReady =
         id === "elizaos" || id === "pi-agent"
-          ? installed
+          ? preflight
+            ? getPreflightAuthStatus(preflight) === "authenticated"
+            : installed
           : id === "claude"
             ? claudeAuthReady
             : id === "codex"
               ? codexAuthReady
               : false;
+      const authReady = installed && credentialsReady;
       const reason =
         id === "elizaos" && installed
           ? "ready to use the configured native ElizaOS ACP adapter"

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -705,7 +705,11 @@ async function computeTaskAgentFrameworkState(
   const inventory: TaskAgentFrameworkAvailability[] = STANDARD_FRAMEWORKS.map(
     (id) => {
       const preflight = preflightByAdapter.get(id);
-      const installed = preflight?.installed === true || hasFrameworkBinary(id);
+      // A probe row is authoritative, including an explicit negative. Static
+      // discovery is only the fallback when the probe returned no row.
+      const installed = preflight
+        ? preflight.installed === true
+        : hasFrameworkBinary(id);
       const subscriptionReady =
         id === "claude"
           ? claudeSubscriptionReady
@@ -714,9 +718,7 @@ async function computeTaskAgentFrameworkState(
             : false;
       const credentialsReady =
         id === "elizaos" || id === "pi-agent"
-          ? preflight
-            ? getPreflightAuthStatus(preflight) === "authenticated"
-            : installed
+          ? installed
           : id === "claude"
             ? claudeAuthReady
             : id === "codex"

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
@@ -8,14 +8,10 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
+import { CODING_AGENT_BACKENDS } from "@elizaos/shared";
 import { readConfigEnvKey } from "./config-env.js";
 
-export const KNOWN_ADAPTER_TYPES = new Set([
-  "elizaos",
-  "pi-agent",
-  "claude",
-  "codex",
-]);
+export const KNOWN_ADAPTER_TYPES = new Set<string>(CODING_AGENT_BACKENDS);
 
 export function normalizeTaskAgentAdapter(
   value: string | undefined,

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -224,6 +224,7 @@ export interface AvailableAgentInfo {
   adapter: AgentType;
   agentType: AgentType;
   installed: boolean;
+  unavailableReason?: string;
   installCommand?: string;
   docsUrl?: string;
   auth?: {


### PR DESCRIPTION
## Post-merge UI evidence correction (2026-08-22)

> The original evidence rows below incorrectly classified this as backend-only and marked screenshots/OCR as N/A. That classification is superseded by the exact post-merge audit recorded in the PR comment dated 2026-08-22. The effective diff changes shared account/provider UI; desktop/mobile/rest/hover evidence is applicable. The canonical app audit passed 227/227 browser cases with zero DOM/hover/density defects, then returned non-zero for one unrelated Maps mobile-landscape OCR miss. Targeted accounts/provider browser evidence and 50 focused UI tests passed.

# Relates to

Relates to #24095 and #23109. Native Kimi/Z.AI/Grok spawn routes remain tracked by #24096. Account pinning remains owned by #24355.

# What changed

- Adds a versioned canonical descriptor for linked-provider enrollment, inference, and executable coding-agent spawn.
- Makes auth metadata, accounts API/UI, account bridge, framework discovery, and ACP inventory consume that descriptor.
- Advertises only Claude subscription and OpenAI Codex linked-account coding transports currently implemented.
- Requires real executable readiness and preserves authoritative negative ACP probes.
- Treats runtime-routed elizaOS/Pi adapters as auth-ready when installed; their production preflight auth status is intentionally `unknown`, not a credential failure.
- Treats legacy `pi`, `claude`, and `codex` values as acpx profile selectors, not unrelated host executables.
- Anchors relative native executable paths before session cwd changes and rejects composed `ELIZA_ACP_CLI` values that cannot be spawned as one executable.

# Exact-head verification

Head: `6053c891339751e821b2a8249ea6fd85755df059`
Base at restack: `faacb5ef748f7380dbf5ad004ae5cbaf399a8f25`

- framework + ACP adversarial suites: 111 passed, 0 failed
- plugin typecheck: passed
- plugin Biome: no errors; one unrelated pre-existing warning in `sub-agent-inbox.ts`
- guide parity: 161/161 tracked CLAUDE.md/AGENTS.md pairs
- `git diff --check`: passed
- full plugin lane after current-develop restack remains red in unrelated existing sub-agent env/inbox/provider-context tests; focused touched suites are green

# Evidence applicability

Backend contract change only. Screenshots/video/OCR are N/A. No paid provider or live model certification is claimed. Deterministic executable, readiness, negative-probe, runtime-auth, and profile-selector behavior is exercised directly.

# Attribution

Original provider-capability implementation: Shaw. Exact-head readiness/spawn repair and current-develop restack: Shaw Walters.

<!-- evidence-head:6053c891339751e821b2a8249ea6fd85755df059 -->