### PR TITLE
fix(app): resolve cloud shared workspace exports

### DIFF
--- a/packages/app/test/vite-source-resolution.test.ts
+++ b/packages/app/test/vite-source-resolution.test.ts
@@ -109,6 +109,34 @@ describe("workspace package resolution", () => {
     }
   });
 
+  test.each(["serve", "build"] as const)(
+    "resolves Cloud shared wildcard exports from workspace source while %s config resolves",
+    async (command) => {
+      const { server } = await createAppResolutionServer(command);
+
+      try {
+        const resolved =
+          await server.environments.client.pluginContainer.resolveId(
+            "@elizaos/cloud-shared/types/redemption-contract",
+            path.resolve(
+              appRoot,
+              "../ui/src/cloud/monetization/earnings/EarningsPageClient.tsx",
+            ),
+          );
+        expect(resolved?.id).toBe(
+          normalizePath(
+            path.resolve(
+              appRoot,
+              "../cloud/shared/src/types/redemption-contract.ts",
+            ),
+          ),
+        );
+      } finally {
+        await server.close();
+      }
+    },
+  );
+
   test("resolves the shared terminal palette from workspace source while serving", async () => {
     const { server } = await createAppResolutionServer("serve");
 

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -839,6 +839,58 @@ function createWorkspacePackageAliases(packageRoots: string[]) {
   return aliases;
 }
 
+function createWorkspacePackageExportAliases(packageDirs: string[]) {
+  const aliases = [];
+  for (const packageDir of packageDirs) {
+    const pkgPath = path.join(packageDir, "package.json");
+    if (!fs.existsSync(pkgPath)) continue;
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    const pkgName = pkg.name;
+    if (typeof pkgName !== "string") continue;
+    const pkgExports =
+      pkg.exports && typeof pkg.exports === "object"
+        ? (pkg.exports as Record<string, unknown>)
+        : {};
+
+    for (const [key, value] of Object.entries(pkgExports)) {
+      if (key !== "." && !key.startsWith("./")) continue;
+      const exportTarget = resolvePackageExportTarget(value);
+      if (!exportTarget) continue;
+      const packageSpecifier =
+        key === "." ? pkgName : `${pkgName}/${key.slice(2)}`;
+
+      const keyWildcard = packageSpecifier.indexOf("*");
+      const targetWildcard = exportTarget.indexOf("*");
+      if (keyWildcard >= 0 || targetWildcard >= 0) {
+        if (keyWildcard < 0 || targetWildcard < 0) continue;
+        const keyPrefix = packageSpecifier.slice(0, keyWildcard);
+        const keySuffix = packageSpecifier.slice(keyWildcard + 1);
+        const wildcardPlaceholder = "__ELIZA_PACKAGE_EXPORT_WILDCARD__";
+        const targetPattern = path.resolve(
+          packageDir,
+          `${exportTarget.slice(0, targetWildcard)}${wildcardPlaceholder}${exportTarget.slice(targetWildcard + 1)}`,
+        );
+        aliases.push({
+          find: new RegExp(
+            `^${escapeRegExp(keyPrefix)}(.+)${escapeRegExp(keySuffix)}$`,
+          ),
+          replacement: targetPattern.replace(wildcardPlaceholder, "$1"),
+        });
+        continue;
+      }
+
+      aliases.push({
+        find: new RegExp(`^${escapeRegExp(packageSpecifier)}$`),
+        replacement: path.resolve(packageDir, exportTarget),
+      });
+    }
+  }
+  return aliases;
+}
+
 function resolveAppPluginBrowserEntry(pkgDir: string): string | null {
   const preferred = [
     "src/ui.ts",
@@ -2938,6 +2990,12 @@ export const INVALID_TRACER_PROVIDER = {};
       // Dynamic aliases for local app plugin package roots that do not have a
       // dedicated browser facade.
       ...createWorkspacePackageAliases([path.resolve(elizaRoot, "plugins")]),
+      // Cloud UI imports shared contracts from this private source workspace.
+      // Alias its complete export map so clean renderer builds do not depend on
+      // package-manager subpath resolution or artifacts from another checkout.
+      ...createWorkspacePackageExportAliases([
+        path.resolve(elizaRoot, "packages/cloud/shared"),
+      ]),
       ...(() => {
         const sharedPkgPath = path.resolve(
           elizaRoot,


### PR DESCRIPTION
# Relates to

Closes #24116
Unblocks evidence for #24114 and #24103

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] Clean-worktree install, real production renderer build, focused Vite resolution tests, and the complete audit command were exercised.
- [x] A reviewer can verify the resolver path from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop`; zero conflicts.
- [ ] Root `verify` has unrelated current-develop lint blockers; focused and real build/audit validation is recorded below.

# Risks

Low. The new helper aliases one private workspace package from its declared export map, including exact and wildcard exports. It changes build resolution only and does not alter rendered UI behavior.

# Background

## What does this PR do?

Generates Vite aliases for the complete `@elizaos/cloud-shared` export map so clean isolated app builds resolve UI-imported cloud contracts from workspace source. Adds real Vite serve/build resolver coverage for the wildcard redemption-contract subpath.

## What kind of change is this?

Build-system bug fix and regression coverage.

# Documentation changes needed?

No public documentation change is needed.

# Testing

## Where should a reviewer start?

`packages/app/test/vite-source-resolution.test.ts` and the adjacent alias helper in `packages/app/vite.config.ts`.

## Detailed testing steps

1. Run `bunx vitest run packages/app/test/vite-source-resolution.test.ts`; all 8 tests pass for serve/build resolution.
2. Run `bun run build:core`, then `bun run --cwd packages/app build:web`; the 9,308-module renderer and 575 chunks build successfully.
3. Run `bun run --cwd packages/app audit:app`; it reaches Playwright and executes all 231 cases instead of failing before capture.

# Evidence Gate

<!-- evidence-head:54c2cf219de64abb49d7256b8bc0540fbfdea615 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - build-resolution-only change has no rendered visual delta.
<!-- evidence-row:after-screenshots -->
- [x] N/A - build-resolution-only change has no rendered visual delta.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend request path changes.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - Vite resolver coverage and the full app audit completed without a resolver-related browser diagnostic
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/provider/model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual delta; the audit reaches capture, but its existing visual baselines still fail as documented.

# Evidence Details

## Real LLM-call trajectory

N/A - build configuration only.

## Backend + frontend logs

Frontend proof:

- Focused real Vite resolver suite: 8/8 passed.
- Production renderer: 9,308 modules transformed, 575 chunks rendered, chunk-safety and viewport verification passed.
- Full audit: 229/231 Playwright cases passed; the two unrelated baseline failures are listed below.

Backend: N/A.

## Screenshots (before / after) + video walkthrough

N/A - no visual output changes.

## Audio / voice walkthrough

N/A - no audio/voice behavior changes.

## Known gaps / failures

`bun run --cwd packages/app audit:app` now runs the entire matrix but exits nonzero on existing unrelated audit defects:

- negative-path readiness self-test expected `semanticReady: true` and observed `false`;
- minimalism ratchet failures for builtin-browser mobile portrait and plugin-finances mobile portrait/landscape.

These occur after the resolver objective is proven and do not involve this two-file build configuration diff.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [app-audit-resolution]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->

