### PR TITLE
fix(agent): retire an expired chat idempotency entry before comparing fingerprints

### DIFF
--- a/packages/agent/src/services/chat-idempotency-service.test.ts
+++ b/packages/agent/src/services/chat-idempotency-service.test.ts
@@ -147,4 +147,92 @@ describe("chat idempotency store", () => {
       store.admit("principal-b:room", "id", { fingerprint: "request" }).kind,
     ).toBe("owner");
   });
+
+  // `settle` stamps `settledAt` from the real clock while `admit` accepts an
+  // injected `now`. The suite's other expiry cases pass `now: 3`, which makes
+  // `now - settledAt` hugely negative, so the retention branch can never fire
+  // there. These cases derive `now` from the real clock so it actually does.
+  it("re-admits a key reused after the retention window with new content", () => {
+    const store = createChatIdempotencyStore<{ value: string }>({
+      retentionMs: 10,
+    });
+    const owner = store.admit("principal:room", "id", {
+      fingerprint: "request-a",
+    });
+    if (owner.kind !== "owner") throw new Error("fixture admission failed");
+    store.settle("principal:room", "id", { value: "done" }, owner.reservation);
+
+    const afterRetention = Date.now() + store.retentionMs + 1;
+    const replacement = store.admit("principal:room", "id", {
+      fingerprint: "request-b",
+      now: afterRetention,
+    });
+    expect(replacement.kind).toBe("owner");
+    if (replacement.kind !== "owner") throw new Error("re-admission failed");
+
+    store.settle(
+      "principal:room",
+      "id",
+      { value: "second" },
+      replacement.reservation,
+    );
+    expect(store.outcome("principal:room", "id")).toEqual({ value: "second" });
+  });
+
+  it("still conflicts and still replays inside the retention window", () => {
+    const store = createChatIdempotencyStore<{ value: string }>({
+      retentionMs: 60_000,
+    });
+    const owner = store.admit("principal:room", "id", {
+      fingerprint: "request-a",
+    });
+    if (owner.kind !== "owner") throw new Error("fixture admission failed");
+    store.settle("principal:room", "id", { value: "done" }, owner.reservation);
+
+    const inWindow = Date.now() + 1_000;
+    expect(
+      store.admit("principal:room", "id", {
+        fingerprint: "request-b",
+        now: inWindow,
+      }),
+    ).toMatchObject({
+      kind: "conflict",
+      error: { code: "CHAT_IDEMPOTENCY_CONFLICT" },
+    });
+    expect(
+      store.admit("principal:room", "id", {
+        fingerprint: "request-a",
+        now: inWindow,
+      }),
+    ).toMatchObject({ kind: "settled", outcome: { value: "done" } });
+  });
+
+  it("does not retire an ACTIVE turn no matter how old it is", () => {
+    const store = createChatIdempotencyStore<{ value: string }>({
+      retentionMs: 10,
+    });
+    const owner = store.admit("principal:room", "id", {
+      fingerprint: "request-a",
+    });
+    if (owner.kind !== "owner") throw new Error("fixture admission failed");
+
+    // Never settled, so retention does not apply: a long-running generation
+    // keeps its reservation and a different payload still conflicts.
+    const muchLater = Date.now() + 60 * 60_000;
+    expect(
+      store.admit("principal:room", "id", {
+        fingerprint: "request-a",
+        now: muchLater,
+      }).kind,
+    ).toBe("duplicate");
+    expect(
+      store.admit("principal:room", "id", {
+        fingerprint: "request-b",
+        now: muchLater,
+      }),
+    ).toMatchObject({
+      kind: "conflict",
+      error: { code: "CHAT_IDEMPOTENCY_CONFLICT" },
+    });
+  });
 });

--- a/packages/agent/src/services/chat-idempotency-service.ts
+++ b/packages/agent/src/services/chat-idempotency-service.ts
@@ -139,7 +139,23 @@ export function createChatIdempotencyStore<Outcome>(options?: {
     const key = keyFor(scope, clientMessageId);
     const current = entries.get(key);
     if (current) {
-      if (
+      // Retire a settled entry that has outlived the retention window BEFORE
+      // comparing fingerprints. Past `retentionMs` the reservation no longer
+      // exists as far as this contract is concerned, so a client reusing the
+      // same `clientMessageId` for genuinely new content is a fresh request.
+      // Comparing fingerprints first pinned the key to its original content
+      // permanently — the caller got CHAT_IDEMPOTENCY_CONFLICT forever, and
+      // the route layer hands that value straight to the client as an SSE
+      // error. It also returned before the opportunistic sweep below, so the
+      // dead entry was never collected either. `reserve()` already retires the
+      // expired entry first; this makes `admit()` agree with it.
+      const settledAndExpired =
+        current.status === "settled" &&
+        current.settledAt !== undefined &&
+        now - current.settledAt > retentionMs;
+      if (settledAndExpired) {
+        entries.delete(key);
+      } else if (
         current.fingerprint !== undefined &&
         options.fingerprint !== current.fingerprint
       ) {
@@ -147,13 +163,6 @@ export function createChatIdempotencyStore<Outcome>(options?: {
           kind: "conflict",
           error: new ChatIdempotencyConflictError(scope, clientMessageId),
         };
-      }
-      if (
-        current.status === "settled" &&
-        current.settledAt !== undefined &&
-        now - current.settledAt > retentionMs
-      ) {
-        entries.delete(key);
       } else if (
         current.status === "settled" &&
         current.outcome !== undefined


### PR DESCRIPTION
Closes #24133.


## What this fixes

`admit()` compared the stored fingerprint **before** dropping a settled entry
that had outlived `retentionMs`:

```ts
if (current) {
  if (current.fingerprint !== undefined &&
      options.fingerprint !== current.fingerprint) {
    return { kind: "conflict", ... };                 // <- first
  }
  if (current.status === "settled" && ... > retentionMs) {
    entries.delete(key);                              // <- unreachable for that caller
  } else if (...)
```

So a client reusing a `clientMessageId` after the retention window with
different content got `CHAT_IDEMPOTENCY_CONFLICT` — **permanently**, because the
early `return` also skips the opportunistic sweep at the bottom of `admit()`,
so the dead entry is never collected and every retry lands on the same branch.

`reserve()`, the legacy path over the same entries
(`chat-idempotency-service.ts:229-241`), already retires the expired entry
first. This makes `admit()` agree with it.

Nothing contains the wrong answer — the value *is* the output.
`chat-routes.ts:331` hands the admission to `conversation-routes.ts`, which
writes it to the caller as an SSE `type:"error"` (3990-3998) or a 409
(4880-4885).

## Why the existing test did not catch it

`chat-idempotency-service.test.ts:112-139` covers settled-key reuse with a
different fingerprint, but injects `now: 3` while `settle()` stamps `settledAt`
from the real clock (line 289). `now - settledAt` is hugely negative, so the
retention branch can never fire there — the test asserts a conflict that the
*correct* implementation also produces. The new cases derive `now` from the
real clock, and that test is left untouched and still passes.

## Verification

**Origin reproduction on unmodified code.** Executed a copy of
`chat-idempotency-service.ts` proved byte-identical to `origin/develop` by
comparing `git hash-object` against `git rev-parse origin/develop:<path>`:

```
origin/develop = d6068e969b3817bae05b79fae22b3cfdaa76799c
IDENTICAL  8da5fcdc913453f67d8956e854684e2b531b6500  packages/agent/src/services/chat-idempotency-service.ts
```

```
A. reuse of a key AFTER retentionMs with different content
  PASS  first admit: want owner, got owner
  FAIL  re-admit past retention with new content: want owner, got conflict
```

**Load-bearing revert (copy-aside, not `git stash`).** Branch tests in place,
`chat-idempotency-service.ts` restored from `git show origin/develop:...`:

```
 FAIL  re-admits a key reused after the retention window with new content
       AssertionError: expected 'conflict' to be 'owner'
 Tests  1 failed | 10 passed (11)
```

Fix restored: `Tests 11 passed (11)`.

**No over-rejection — this is the axis that matters here, since the change can
only loosen.** An 86-row transcript sweeps `admit()` across every prior-entry
state (`none` / `active` / `settled` / `released` / legacy `reserve`) x
fingerprint (`match` / `differs` / `absent`) x clock offset (`0`, exactly
`retentionMs`, `retentionMs + 1`, `10x retentionMs`), plus
`reserve`/`release`/`settle`/`outcome`/`firstSeenAt`/`normalize`/`reset`,
duplicate `wait()` settle and release, fabricated- and wrong-scope reservation
ownership, and cross-principal scope isolation. Origin vs branch `diff`:

```
31,32c31,32
< admit[prior=settled fp=fp-B off=+1001]  = conflict:CHAT_IDEMPOTENCY_CONFLICT
< admit[prior=settled fp=fp-B off=+10000] = conflict:CHAT_IDEMPOTENCY_CONFLICT
---
> admit[prior=settled fp=fp-B off=+1001]  = owner
> admit[prior=settled fp=fp-B off=+10000] = owner
35,36c35,36
< admit[prior=settled fp=none off=+1001]  = conflict:CHAT_IDEMPOTENCY_CONFLICT
< admit[prior=settled fp=none off=+10000] = conflict:CHAT_IDEMPOTENCY_CONFLICT
---
> admit[prior=settled fp=none off=+1001]  = owner
> admit[prior=settled fp=none off=+10000] = owner
```

4 rows of 86 change, all of them settled-and-expired. Every in-window row is
identical — notably `admit[prior=settled fp=fp-B off=+0]` and `off=+1000`
(exactly `retentionMs`, which is not `>` it) still conflict, `prior=active`
still conflicts at any age, and every replay/duplicate/scope row is unchanged.
A new test pins the `prior=active` case explicitly: an unsettled turn is never
retired no matter how old.

**Suites.** `vitest run src/services/chat-idempotency-service.test.ts`:
11 passed (8 pre-existing + 3 new).

**Lint.** `biome check` on both changed files: clean.

**Typecheck.** `tsc --noEmit -p packages/agent/tsconfig.json`: zero errors in
`chat-idempotency-service.ts`.

## Known gaps

- Hosted CI does not run for fork contributors; every result above is a local
  run, not a GitHub Actions result.
- `src/api/__tests__/conversation-idempotency.test.ts` could not be used as
  evidence in this environment: it fails 39/39 with
  `TypeError: decodeUrlPathComponent is not a function` from
  `server-helpers.ts:459`. That is a pre-existing environment artifact, not a
  regression — the identical 39/39 failure reproduces with
  `chat-idempotency-service.ts` restored to `origin/develop` (control run), so
  the suite is red on both sides and says nothing about this change either way.
- `settle()` stamps `settledAt` from `Date.now()` and ignores the injected
  `now` that `admit()`/`reserve()` accept. That asymmetry is what made the
  existing expiry test blind. Threading an injectable clock through `settle()`
  would be the real cleanup, but it changes a public signature and is out of
  scope for this fix; the new tests work around it by deriving `now` from the
  real clock.

# Relates to

Closes #24133.

## Rebase restamp (2026-08-22)

Rebased onto origin/develop `307af8bbaaa909065078ccd781f3bb0ebcc88001`: applied
with zero conflicts, and upstream never touched either file this PR changes
(`git diff <old-head> <new-head> -- <both files>` is empty), so the reviewed
code is byte-identical to the approved head. Re-run at the new head:

- Focused suite: `vitest run src/services/chat-idempotency-service.test.ts` in
  `packages/agent` — **11 passed (11)** (same count as the reviewed evidence).
- `bunx biome check` on both changed files — clean.
- Fresh trace-finalized receipt minted for the restamp run
  (openrouter / ox-alpha via opencode); the original implementation, reproduction,
  revert proof, and over-rejection corpus above were produced under
  anthropic / claude-opus-5 against code identical to this head.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openrouter/ox-alpha
<!-- attribution-row:client -->
- Agent tooling: opencode
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:5a6feb172d34281c9dbc1fc3b5777a82f41b19da -->

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: openrouter / ox-alpha
Client / agent tooling: opencode
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-rb24137]
<!-- slop-contribution-attribution:v1 {"provider":"openrouter","model":"ox-alpha","client":"opencode","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0KT36P3PB20CJ9R5XYMMFW6","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T04:01:37.475Z","completed_at":"2026-08-22T04:08:44.422Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T04:01:38.444Z"},"usage":{"source":"none","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"2e4955cc6595d08b3355a4caa1e4396f16f815edde677ac8532e27630c37b5ae","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"e1a89c7d-da93-402f-a4ae-e647fda62212","object_id":"sha256:2e4955cc6595d08b3355a4caa1e4396f16f815edde677ac8532e27630c37b5ae","sha256":"2e4955cc6595d08b3355a4caa1e4396f16f815edde677ac8532e27630c37b5ae"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"3M9vAXvGVfNyv-QTusEK41HtjqAABzSEGXaQPgxC_ki4domubPd0U2_jnRqc1RTeCeMarG6rC8Sg5cCIuTrKBA"}} -->
