### PR TITLE
fix(agent): key update-check cache by release channel

### DIFF
--- a/packages/agent/src/services/update-checker.test.ts
+++ b/packages/agent/src/services/update-checker.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { checkForUpdate, resolveChannel } from "./update-checker.ts";
+
+const baseConfig = {
+  update: {
+    channel: "stable" as const,
+    lastCheckAt: new Date().toISOString(),
+    lastCheckVersion: "9.9.9",
+    lastCheckChannel: "stable" as const,
+  },
+};
+
+function makeRuntime(config = baseConfig) {
+  const cache = new Map<string, unknown>();
+  cache.set("elizaConfig", config);
+  return {
+    agentId: "00000000-0000-0000-0000-0000000000aa",
+    getCache: async <T>(key: string): Promise<T | undefined> =>
+      cache.get(key) as T | undefined,
+    setCache: async <T>(key: string, value: T): Promise<boolean> => {
+      cache.set(key, value);
+      return true;
+    },
+    deleteCache: async (_key: string): Promise<boolean> => false,
+    getService: () => null,
+  };
+}
+
+vi.mock("../config/config.ts", async () => ({
+  loadElizaConfig: () => baseConfig,
+  saveElizaConfig: (cfg: unknown) => {
+    baseConfig = cfg as typeof baseConfig;
+    return Promise.resolve();
+  },
+}));
+
+let baseConfig = { ...baseConfig };
+
+describe("checkForUpdate", () => {
+  it("returns cached result for the same channel", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ "dist-tags": { latest: "9.9.9", beta: "9.9.9-beta.1" } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const runtime = makeRuntime();
+    const result = await checkForUpdate({}, runtime);
+    expect(result.cached).toBe(true);
+    expect(result.latestVersion).toBe("9.9.9");
+    expect(result.channel).toBe("stable");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("bypasses cache when ELIZA_UPDATE_CHANNEL env changes the effective channel", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ "dist-tags": { latest: "9.9.9", beta: "9.9.9-beta.1" } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.stubEnv("ELIZA_UPDATE_CHANNEL", "beta");
+
+    const runtime = makeRuntime();
+    const result = await checkForUpdate({}, runtime);
+    expect(result.cached).toBe(false);
+    expect(result.channel).toBe("beta");
+    expect(result.latestVersion).toBe("9.9.9-beta.1");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(baseConfig.update.lastCheckChannel).toBe("beta");
+
+    vi.unstubEnv("ELIZA_UPDATE_CHANNEL");
+  });
+});

--- a/packages/agent/src/services/update-checker.ts
+++ b/packages/agent/src/services/update-checker.ts
@@ -50,8 +50,9 @@ async function fetchDistTags(): Promise<Record<string, string> | null> {
   }
 }
 
-function shouldSkipCheck(cfg: UpdateConfig | undefined): boolean {
+function shouldSkipCheck(cfg: UpdateConfig | undefined, channel: ReleaseChannel): boolean {
   if (!cfg?.lastCheckAt) return false;
+  if (cfg.lastCheckChannel && cfg.lastCheckChannel !== channel) return false;
   const interval = cfg.checkIntervalSeconds ?? CHECK_INTERVAL_SECONDS;
   const elapsed = (Date.now() - new Date(cfg.lastCheckAt).getTime()) / 1_000;
   return elapsed < interval;
@@ -76,7 +77,7 @@ export async function checkForUpdate(options?: {
   const channel = resolveChannel(updateCfg);
   const distTag = CHANNEL_DIST_TAGS[channel];
 
-  if (!options?.force && shouldSkipCheck(updateCfg)) {
+  if (!options?.force && shouldSkipCheck(updateCfg, channel)) {
     return {
       updateAvailable: updateCfg?.lastCheckVersion
         ? (compareSemver(VERSION, updateCfg.lastCheckVersion) ?? 0) < 0
@@ -128,6 +129,7 @@ export async function checkForUpdate(options?: {
         ...config.update,
         lastCheckAt: new Date().toISOString(),
         lastCheckVersion: latestVersion,
+        lastCheckChannel: channel,
       },
     });
   } catch (err) {

--- a/packages/shared/src/config/types.eliza.ts
+++ b/packages/shared/src/config/types.eliza.ts
@@ -660,6 +660,8 @@ export type UpdateConfig = {
   checkOnStart?: boolean;
   lastCheckAt?: string;
   lastCheckVersion?: string;
+  /** Channel that produced the cached version. */
+  lastCheckChannel?: ReleaseChannel;
   /** Seconds between automatic checks. Default: 14400 (4 hours). */
   checkIntervalSeconds?: number;
 };


### PR DESCRIPTION
Closes #24082

- UpdateConfig now stores lastCheckChannel
- shouldSkipCheck returns false when the cached channel differs from the
  effective channel, including ELIZA_UPDATE_CHANNEL env changes
- Regression test covers stale stable cache with env override to beta

- packages/agent/src/services/update-checker.ts
- packages/shared/src/config/types.eliza.ts
- packages/agent/src/services/update-checker.test.ts