### PR TITLE
fix(cloud): emit Retry-After for HF egress quota

### DIFF
--- a/packages/cloud/api/__tests__/hf-proxy-route.test.ts
+++ b/packages/cloud/api/__tests__/hf-proxy-route.test.ts
@@ -16,6 +16,7 @@ import {
   describe,
   expect,
   mock,
+  setSystemTime,
   test,
 } from "bun:test";
 import { Hono } from "hono";
@@ -74,6 +75,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  setSystemTime();
   requireUserOrApiKeyWithOrg.mockReset();
   loggerInfo.mockReset();
   loggerWarn.mockReset();
@@ -269,6 +271,7 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
   });
 
   test("enforces per-org monthly egress budget before streaming the next response", async () => {
+    setSystemTime(new Date("2026-02-28T23:59:58.250Z"));
     const kv = fakeKv();
     globalThis.fetch = mock(
       async () =>
@@ -292,6 +295,8 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
 
     const second = await app.fetch(makeRequest(RESOLVE_PATH), env);
     expect(second.status).toBe(429);
+    // 1.75 seconds remain until the March UTC bucket, rounded up per HTTP.
+    expect(second.headers.get("Retry-After")).toBe("2");
     const body = (await second.json()) as {
       code?: string;
       limit_bytes?: number;
@@ -300,6 +305,51 @@ describe("GET /api/v1/hf-proxy/[...path]", () => {
     expect(body.code).toBe("HF_PROXY_EGRESS_LIMIT");
     expect(body.limit_bytes).toBe(12);
     expect(body.used_bytes).toBe(8);
+  });
+
+  test("pre-check exhaustion advertises the next UTC month and admits its fresh bucket", async () => {
+    setSystemTime(new Date("2026-01-31T23:59:59.999Z"));
+    const kv = fakeKv();
+    await kv.put(
+      "hf-proxy:egress:org-1:2026-01",
+      JSON.stringify({ bytes: 12 }),
+    );
+
+    let fetchCalls = 0;
+    globalThis.fetch = mock(async () => {
+      fetchCalls += 1;
+      return new Response("NEXT", {
+        status: 200,
+        headers: {
+          "content-type": "application/octet-stream",
+          "content-length": "4",
+        },
+      });
+    }) as unknown as typeof fetch;
+
+    const env = {
+      HF_TOKEN: "hf-secret",
+      CACHE_KV: kv,
+      HF_PROXY_MONTHLY_EGRESS_LIMIT_BYTES: "12",
+    };
+    const blocked = await app.fetch(makeRequest(RESOLVE_PATH), env);
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get("Retry-After")).toBe("1");
+    expect(((await blocked.json()) as { code?: string }).code).toBe(
+      "HF_PROXY_EGRESS_LIMIT",
+    );
+    expect(fetchCalls).toBe(0);
+
+    setSystemTime(new Date("2026-02-01T00:00:00.000Z"));
+    const admitted = await app.fetch(makeRequest(RESOLVE_PATH), env);
+    expect(admitted.status).toBe(200);
+    expect(await admitted.text()).toBe("NEXT");
+    expect(fetchCalls).toBe(1);
+
+    const februaryCounter = JSON.parse(
+      (await kv.get("hf-proxy:egress:org-1:2026-02")) ?? "{}",
+    ) as { bytes?: number };
+    expect(februaryCounter.bytes).toBe(4);
   });
 });
 

--- a/packages/cloud/api/v1/hf-proxy/[...path]/route.ts
+++ b/packages/cloud/api/v1/hf-proxy/[...path]/route.ts
@@ -94,6 +94,18 @@ function monthBucket(now = new Date()): string {
   return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
 }
 
+function retryAfterUntilNextUtcMonth(now: Date): string {
+  const nextMonthStartedAt = Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth() + 1,
+    1,
+  );
+  const secondsUntilReset = Math.ceil(
+    (nextMonthStartedAt - now.getTime()) / 1000,
+  );
+  return String(Math.max(1, secondsUntilReset));
+}
+
 function egressKey(organizationId: string, now = new Date()): string {
   return `hf-proxy:egress:${organizationId}:${monthBucket(now)}`;
 }
@@ -101,8 +113,9 @@ function egressKey(organizationId: string, now = new Date()): string {
 async function readMonthlyEgress(
   env: AppEnv["Bindings"],
   organizationId: string,
+  bucketNow = new Date(),
 ): Promise<number> {
-  const key = egressKey(organizationId);
+  const key = egressKey(organizationId, bucketNow);
   const kv = env.CACHE_KV;
   if (kv) {
     const raw = await kv.get(key);
@@ -265,9 +278,14 @@ app.get("/*", async (c) => {
     }
 
     const limitBytes = monthlyEgressLimitBytes(c.env);
-    const usedBytes = await readMonthlyEgress(c.env, orgId);
+    // Pin quota lookup and reset advice to one instant so a request at the UTC
+    // month boundary cannot read one bucket and advertise another reset.
+    const egressNow = new Date();
+    const usedBytes = await readMonthlyEgress(c.env, orgId, egressNow);
     if (usedBytes >= limitBytes) {
-      return c.json(egressLimitResponse(orgId, limitBytes, usedBytes), 429);
+      return c.json(egressLimitResponse(orgId, limitBytes, usedBytes), 429, {
+        "Retry-After": retryAfterUntilNextUtcMonth(egressNow),
+      });
     }
 
     const incomingUrl = new URL(c.req.url);
@@ -330,7 +348,9 @@ app.get("/*", async (c) => {
     }
 
     if (contentLength !== null && usedBytes + contentLength > limitBytes) {
-      return c.json(egressLimitResponse(orgId, limitBytes, usedBytes), 429);
+      return c.json(egressLimitResponse(orgId, limitBytes, usedBytes), 429, {
+        "Retry-After": retryAfterUntilNextUtcMonth(egressNow),
+      });
     }
 
     const responseHeaders = new Headers();


### PR DESCRIPTION
# Relates to

Closes #24119. The separate permanent-cap status decision remains in #24121.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated
      baseline blocker is recorded below.
- [x] A reviewer can confirm the two quota responses and UTC rollover from the
      exact-head backend and HTTP-domain artifacts below.

# Sync with develop

- [x] Rebased onto `origin/develop@5dee7a4c5e054a36f010aae63dd61008c4a3d0a4`;
      zero conflicts and no upstream edits on the two changed paths.
- [x] `bun run verify` ran post-sync; its untouched `@elizaos/agent` lint blocker
      is documented in **Known gaps / failures**.

# Risks

Low. This adds a standards-compliant integer `Retry-After` header to two existing
local HTTP 429 responses. It does not change status codes, JSON bodies, quota
size, bucket/accounting writes, KV TTL, billing, entitlement, provider requests,
or generic rate-limit middleware. A wrong time boundary could delay a retry, so
the tests pin millisecond-level month-end and rollover behavior in UTC.

# Background

## What does this PR do?

- Captures one `Date` for the monthly quota lookup and retry boundary.
- Computes `max(1, ceil(seconds until the first instant of the next UTC month))`.
- Emits that value on both local `HF_PROXY_EGRESS_LIMIT` paths: an already-full
  bucket and a response whose `Content-Length` would exceed the bucket.
- Proves month-end rounding, no upstream fetch on pre-check rejection, fresh
  bucket admission after rollover, and accounting in the new bucket.

## What kind of change is this?

Bug fix: complete the HTTP retry contract for a deterministic monthly quota.

# Documentation changes needed?

No public documentation change is needed. The existing quota and response body
remain unchanged; the reset invariant is documented beside the helper and in
the route tests.

# Testing

## Where should a reviewer start?

Start with `retryAfterUntilNextUtcMonth()` and the single captured `egressNow`
in `packages/cloud/api/v1/hf-proxy/[...path]/route.ts`, then the two month-end
tests in `packages/cloud/api/__tests__/hf-proxy-route.test.ts`.

## Detailed testing steps

```bash
bun install --frozen-lockfile
cd packages/cloud/api
bun test --conditions=eliza-source __tests__/hf-proxy-route.test.ts
cd ../../..
bun run --cwd packages/cloud/api typecheck
bun run --cwd packages/cloud/api lint
git diff --check origin/develop...HEAD
bun run verify
```

Exact-head results at `5936b13a3a1d046221c68d5ee1a80a19506d307e`:
frozen install made no changes; the HF route suite passed 9 tests / 40
assertions; cloud-api typecheck and its Wrangler production dry-run passed;
the 1,364-file package lint and diff hygiene passed. Independent final-head
review found no P0-P3 issue.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:5cfc275a430ee572da19500d3cd036e151ef4e63 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Server-only HTTP response-header change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - Server-only HTTP response-header change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No interactive or rendered user flow changes.
<!-- evidence-row:backend-logs -->
- [x] [24140-hf-retry-backend-5936b13.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24140-hf-retry-backend-5936b13.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend request, console, network, or state path changes.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No agent, action, prompt, model, or provider request behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [24140-hf-retry-domain-5936b13.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24140-hf-retry-domain-5936b13.txt)
<!-- evidence-row:ocr-review -->
- [ ] N/A - The diff has no rendered visual surface or visual text.

# Evidence Details

## Real LLM-call trajectory

N/A - No agent, action, prompt, model, or provider request behavior changes; the
new responses are produced locally before a provider call or before streaming.

## Backend + frontend logs

Exact-head backend and normalized HTTP response artifacts are attached in the
rows above. Frontend logs are N/A because there is no frontend diff.

## Screenshots (before / after) + video walkthrough

N/A - The diff has no rendered UI or interactive user flow.

## Audio / voice walkthrough

N/A - No voice, transcript, TTS, STT, or omnivoice behavior changes.

## Known gaps / failures

- `bun run verify` exits only in the untouched `@elizaos/agent#lint:check`
  task: 12 errors, 39 warnings, and 7 infos across 1,034 agent files. Neither
  changed file is in that package; #23973 owns the baseline repair.
- An exploratory root-scoped test invocation enabled the repository coverage
  policy and exited 1 after reporting all 9 HF tests / 40 assertions passing.
  The canonical package-scoped command above exits 0, as do cloud-api typecheck,
  its Worker dry-run, and package lint.
- The route test uses an in-memory KV double and a deterministic upstream body.
  That is the real Hono response boundary changed here; no live Hugging Face call
  is needed or permitted to prove a rejection produced before provider use.
- Permanent app/agent caps remain deliberately excluded pending #24121. No
  deployment, production call, secret, provider, quota, billing, KV, or
  infrastructure mutation was performed.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@5936b13a3a1d046221c68d5ee1a80a19506d307e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [billing-v3-hf-retry-after]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@5936b13a3a1d046221c68d5ee1a80a19506d307e:packages/skills/skills/contribute-to-eliza"} -->

## Maintainer restack receipt

Restacked without conflict onto `develop@d705e85b7f87b962bafaa432a5261df1d62db1a6`; the two-file patch applied unchanged. Exact-head focused Biome and diff hygiene pass at `5cfc275a430ee572da19500d3cd036e151ef4e63`. The independent local HTTP-suite attempt stopped during dependency resolution because the shared checkout's `uuid` link targets a reclaimed temporary install, before this route or its tests loaded. The original exact-head backend artifact records 9/9 route tests and 40 assertions; the restack changed no patch content.

Maintainer AI provider/model: OpenAI / gpt-5
Maintainer client / agent tooling: Codex
Maintainer attribution status: system-confirmed
— [codex-maintainer-restack-24140]
