### PR TITLE
fix(android): delegate fused inference to bionic host

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -2217,8 +2217,8 @@ public class ElizaAgentService extends Service {
             boolean legacyLibllamaBundled = abiLibllama.isFile() && abiLlamaShim.isFile();
             boolean nativeLlamaBundled = fusedInferenceBundled || legacyLibllamaBundled;
             boolean brandedAospBuild = BuildConfig.AOSP_BUILD && isBrandedDevice();
-            // When the dynamic-Vulkan fused lib is staged (libelizainference.so +
-            // libggml-vulkan.so), the GPU is only reachable from THIS bionic app
+            // When the fused inference lib is staged, its Android Vulkan dependency
+            // is only reachable from THIS bionic app
             // process — the musl agent's ld can't load libvulkan's HIDL closure
             // (project_android_gpu_vulkan_wall). So instead of pointing the musl
             // agent at the bun:ffi AOSP loader (ELIZA_LOCAL_LLAMA=1 → the wall),
@@ -2237,8 +2237,9 @@ public class ElizaAgentService extends Service {
             // would fail with a cryptic "bionic socket error: connect ENOENT".
             boolean bionicJniBridgeBundled =
                 resolveBundledNativeLib(abiDir, "libelizavoicejni.so").isFile();
-            boolean delegateToBionicHost =
-                fusedInferenceBundled && abiGgmlVulkan.isFile() && bionicJniBridgeBundled;
+            boolean delegateToBionicHost = shouldDelegateToBionicHost(
+                fusedInferenceBundled,
+                bionicJniBridgeBundled);
             // #11760: export the device RAM class + idle-unload default so the
             // bun agent's in-process loader (plugin-native-inference) applies
             // the same inference memory policy as the bionic host. Operator env
@@ -2252,9 +2253,9 @@ public class ElizaAgentService extends Service {
                     "ELIZA_LOCAL_IDLE_UNLOAD_MS",
                     String.valueOf(inferenceIdleUnloadMs(inferenceRamClass)));
             }
-            if (fusedInferenceBundled && abiGgmlVulkan.isFile() && !bionicJniBridgeBundled) {
+            if (fusedInferenceBundled && !bionicJniBridgeBundled) {
                 Log.w(TAG, "agent/" + abiDir.getName()
-                    + ": fused Vulkan libs are staged but libelizavoicejni.so is absent "
+                    + ": fused inference is staged but libelizavoicejni.so is absent "
                     + "(this build skipped the fused-voice JNI bridge); on-device GPU "
                     + "inference via the bionic host is UNAVAILABLE. Rebuild with "
                     + "stage-elizavoice-lib.mjs to re-enable. Falling back to the "
@@ -2264,7 +2265,7 @@ public class ElizaAgentService extends Service {
                 agentEnv.put("ELIZA_BIONIC_HOST_DELEGATED", "1");
                 agentEnv.put("ELIZA_BIONIC_INFERENCE_SOCK", BIONIC_INFERENCE_SOCKET_NAME);
                 Log.i(TAG, "agent/" + abiDir.getName()
-                    + "/libggml-vulkan.so present; delegating inference to the in-process"
+                    + "/libelizainference.so present; delegating inference to the in-process"
                     + " bionic Vulkan host over UDS \"" + BIONIC_INFERENCE_SOCKET_NAME
                     + "\" (NOT taking the musl bun:ffi AOSP path)");
                 // Stand up the in-process GPU inference server BEFORE the agent
@@ -4086,6 +4087,16 @@ public class ElizaAgentService extends Service {
         return debugBuild
             && ("1".equals(debugPropertyValue)
                 || "true".equalsIgnoreCase(debugPropertyValue));
+    }
+
+    static boolean shouldDelegateToBionicHost(
+            boolean fusedInferenceBundled,
+            boolean bionicJniBridgeBundled) {
+        // The Android artifact is a single fused ABI. Vulkan is linked into
+        // libelizainference.so, so a separate libggml-vulkan.so is not a valid
+        // capability sentinel. The JNI bridge is the fail-closed proof that the
+        // app process can host the fused library for the musl agent.
+        return fusedInferenceBundled && bionicJniBridgeBundled;
     }
 
     /**

--- a/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java
+++ b/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java
@@ -1,6 +1,6 @@
 /**
- * Host-side coverage for the Android service boot gate that decides whether a
- * stock phone should spawn the bundled local agent before the renderer starts.
+ * Host-side coverage for Android service boot gates that select local-agent
+ * autostart and the bionic host for a bundled fused inference runtime.
  */
 package ai.elizaos.app;
 
@@ -137,5 +137,12 @@ public class ElizaAgentAutostartPolicyTest {
         assertTrue(ElizaAgentService.coldBootStampTrustworthy(false, true));
         assertTrue(ElizaAgentService.coldBootStampTrustworthy(true, true));
         assertFalse(ElizaAgentService.coldBootStampTrustworthy(true, false));
+    }
+
+    @Test
+    public void fusedInferenceUsesBionicHostWithoutSplitVulkanLibrary() {
+        assertTrue(ElizaAgentService.shouldDelegateToBionicHost(true, true));
+        assertFalse(ElizaAgentService.shouldDelegateToBionicHost(true, false));
+        assertFalse(ElizaAgentService.shouldDelegateToBionicHost(false, true));
     }
 }

--- a/packages/app-core/scripts/run-mobile-build-android-app-actions.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-app-actions.test.mjs
@@ -14,12 +14,28 @@ import {
   ANDROID_CLOUD_STRIPPED_JAVA_FILES,
   androidAospRoleLauncherIntentFilter,
   ensureAndroidMainActivityShortcutsMetadata,
+  findAndroidBionicInferenceOffenders,
   injectCopyForkLlamaLibTask,
   patchAndroidAppActionsXmlResource,
   removeInactiveAndroidJavaSourceRoots,
   syncAndroidVoiceStringResources,
   validateAndroidAppActionsXmlResource,
 } from "./run-mobile-build.mjs";
+
+test("Android bionic inference audit rejects Linux libc symbols", () => {
+  assert.deepEqual(
+    findAndroidBionicInferenceOffenders(
+      Buffer.from("ELF-prefix-__errno_location-suffix"),
+    ),
+    ["__errno_location"],
+  );
+  assert.deepEqual(
+    findAndroidBionicInferenceOffenders(
+      Buffer.from("ELF-prefix-stderr@LIBC-liblog.so-suffix"),
+    ),
+    [],
+  );
+});
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..", "..", "..");

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -7824,10 +7824,50 @@ function auditAndroidSideloadArtifact({ javaHome } = {}) {
     requireAgent: true,
     label: "android",
   });
+  const fusedEntry = entries.find((entry) =>
+    /(?:^|\/)lib\/arm64-v8a\/libelizainference\.so$/i.test(
+      entry.replaceAll("\\", "/"),
+    ),
+  );
+  if (fusedEntry) {
+    const [fusedBytes] = readAndroidArtifactEntryBuffers(
+      artifact,
+      [fusedEntry],
+      javaHome,
+      {
+        label: "Android bionic fused inference audit",
+        maxEntryBytes: 128 * 1024 * 1024,
+        maxTotalBytes: 128 * 1024 * 1024,
+      },
+    );
+    const offenders = findAndroidBionicInferenceOffenders(fusedBytes);
+    if (offenders.length > 0) {
+      throw mobileBuildError(
+        `[mobile-build] android sideload artifact contains a Linux/musl fused inference library that Android's bionic loader cannot load: ${offenders.join(", ")}. Rebuild and stage it with \`node packages/app-core/scripts/stage-elizavoice-lib.mjs --abi arm64-v8a --variant cpu\` (or the Vulkan variant with its required host tooling).`,
+        {
+          code: "ANDROID_BIONIC_INFERENCE_INCOMPATIBLE",
+          context: { artifact, fusedEntry, offenders },
+        },
+      );
+    }
+  }
   console.log(
     `[mobile-build] android sideload artifact audit passed: ${artifact}`,
   );
   return artifact;
+}
+
+/**
+ * Detect libc ABI markers that are valid for Linux/musl builds but unresolved
+ * on Android. The bionic host dlopens this library inside the app process, so
+ * accepting one of these symbols would defer a deterministic packaging defect
+ * until device startup.
+ */
+export function findAndroidBionicInferenceOffenders(bytes) {
+  const binary = Buffer.from(bytes);
+  return ["__errno_location"].filter((symbol) =>
+    binary.includes(Buffer.from(symbol, "utf8")),
+  );
 }
 
 /** Audit the hosted-emulator debug APK without requiring a local agent payload. */


### PR DESCRIPTION
# Relates to

- Relates to #13580

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` ran after the rebase.
- [x] Reviewer-visible device and test evidence is recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@5dee7a4c5e054a36f010aae63dd61008c4a3d0a4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` `5dee7a4c5e054a36f010aae63dd61008c4a3d0a4`; zero conflicts.
- [ ] Root `bun run verify` reaches an unrelated current-develop plugin-test inventory failure described below. Scoped gates pass.

# Background

## What does this PR do?

The Android service treated a separate `libggml-vulkan.so` as a required capability sentinel before delegating fused inference to its bionic host. The current Android artifact is one fused `libelizainference.so`, so a valid NDK-built runtime was incorrectly routed into the musl `bun:ffi` path. Separately, the sideload build accepted Linux/musl fused libraries that Android's bionic loader deterministically rejects at startup.

This PR:

- delegates fused inference whenever `libelizainference.so` and the bionic JNI bridge are bundled, without requiring the retired split Vulkan library;
- adds host-side policy coverage for the delegation gate;
- audits the packaged ARM64 fused library and fails the build on the observed Linux/musl `__errno_location` ABI marker;
- reports the canonical NDK staging command in the build failure.

## What kind of change is this?

Bug fix and packaging guard.

# Risks

Low and fail-closed. Delegation still requires both the fused library and its JNI bridge. The new artifact audit runs only when the ARM64 fused library is packaged and rejects a deterministic non-bionic ABI marker before installation.

# Documentation changes needed?

No user documentation change. The capability and failure contracts are documented in source and tests.

# Testing

Exact head: `059484e94409f1dc506cb56df788386274f95b4f`

- `bun install --frozen-lockfile` — PASS, no changes
- `bun run --cwd packages/app build:android` — PASS; 794 Gradle tasks; sideload artifact audit passed
- focused Gradle policy test — PASS (`BUILD SUCCESSFUL`, 578 tasks)
- focused mobile-build Node tests — PASS (13/13)
- Biome on touched JavaScript sources — PASS
- `git diff --check origin/develop...HEAD` — PASS
- exact APK renderer stamp — `059484e94409f1dc506cb56df788386274f95b4f`
- APK SHA-256 — `c0108eb287a9bff34e2475501c7e876ddde6063c15dd7157adb1939d7a18bd3a`
- installed ARM64 emulator APK SHA-256 — exact match
- packaged fused-library dependencies — `libm.so`, `libdl.so`, `liblog.so`, `libc.so`; `__errno_location` absent
- cold launch — PASS
- local-agent health/status — ready, running, `canRespond=true`, cloud disconnected
- bionic host startup — PASS; fused library `dlopen` succeeded and abstract UDS `eliza_bionic_infer_v1` listened
- real Eliza-1 local generation — PASS at the runtime layer: 128 tokens in 4,350 ms (29.43 tok/s), non-empty model response

# Evidence Gate

<!-- evidence-head:059484e94409f1dc506cb56df788386274f95b4f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - headless packaging and native-runtime routing change
<!-- evidence-row:backend-logs -->
- [x] Exact-head command and device log excerpts are summarized below
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend behavior changed
<!-- evidence-row:llm-trajectory -->
- [x] Exact-head real local-model output and token timing are summarized below
<!-- evidence-row:domain-artifacts -->
- [x] Exact APK stamp, digest, installed digest, ELF dependencies, and forbidden-symbol audit are summarized above
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual-text surface changed

# Evidence details and named holds

The exact installed APK loaded `libelizainference.so` in Android's bionic namespace, started the bionic inference host, and completed a real local Eliza-1 turn. Device log evidence:

```text
libelizainference.so present; delegating inference to the in-process bionic Vulkan host over UDS "eliza_bionic_infer_v1"
Load .../lib/arm64/libelizainference.so ...: ok
bionic inference host listening on abstract UDS "eliza_bionic_infer_v1"
GENERATE result (resident): {"ok":true,"tokens":128,"ms":4350,"tokS":29.42528735632184,...}
```

Named acceptance holds, while this source-complete PR remains ready:

- The strict smoke command exits 1 after runtime success because Eliza-1 replied `I am ready to assist you with your queries. How can I help you today?` instead of the harness's exact expected literal `android smoke model works`; generation also continued past the model's `<end_of_turn>` marker. This is a model-semantic/stop-contract acceptance gap outside this fused-routing and ABI-packaging diff; no transport, native-load, or inference failure occurred.
- Root `bun run verify` exits 1 in the current-develop `ensure-plugin-test-conventions:check` gate because 15 vendored `plugins/plugin-local-inference/native/llama.cpp/tools/server/webui` tests are orphaned from registered lanes. None of the four changed files modifies that inventory.

This PR is ready for review. These holds are not reasons to convert it to draft.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@5dee7a4c5e054a36f010aae63dd61008c4a3d0a4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-oldest50-13580]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@5dee7a4c5e054a36f010aae63dd61008c4a3d0a4:packages/skills/skills/contribute-to-eliza"} -->
