### PR TITLE
fix(core): fail closed on absent memory scope (filterByAccessContext + createMessageMemory)

### DIFF
--- a/packages/agent/src/api/memory-remember-idempotency.test.ts
+++ b/packages/agent/src/api/memory-remember-idempotency.test.ts
@@ -85,4 +85,32 @@ describe("POST /api/memory/remember idempotency", () => {
     );
     expect(createMemory).toHaveBeenCalledTimes(1);
   });
+
+  test("stamps hash-memory notes agent-private, never the shared factory default", async () => {
+    // Leak canary: without the route's explicit scope, createMessageMemory
+    // defaults an agentId-less memory to `shared` (world-readable on the
+    // access ladder). Hash memories are the agent's personal store — they
+    // must stamp `agent-private` (OWNER + AGENT + RUNTIME) so strangers are
+    // denied while the agent keeps its own recall.
+    const memories = new Map<UUID, Memory>();
+    const createMemory = vi.fn(async (memory: Memory) => {
+      if (!memory.id)
+        throw new Error("remember handler produced a memory without an id");
+      memories.set(memory.id, memory);
+      return memory.id;
+    });
+    const response: { value?: unknown } = {};
+    const ctx = contextFor({
+      body: { text: "personal note" },
+      memories,
+      createMemory,
+      response,
+    });
+    expect(await handleMemoryRoutes(ctx)).toBe(true);
+    expect(createMemory).toHaveBeenCalledTimes(1);
+    const stored = createMemory.mock.calls[0]?.[0] as Memory;
+    expect((stored.metadata as { scope?: string } | undefined)?.scope).toBe(
+      "agent-private",
+    );
+  });
 });

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -1088,6 +1088,13 @@ export async function handleMemoryRoutes(
         source: HASH_MEMORY_SOURCE,
         channelType: ChannelType.DM,
       },
+      // Hash-memory notes are the agent's personal store: fail closed against
+      // strangers, but keep the AGENT tier readable. `agent-private` (OWNER +
+      // AGENT + RUNTIME) rather than `owner-private` (OWNER + RUNTIME only),
+      // because owner-private would silently deny the agent its own recall
+      // once readers enforce scope. Without an explicit scope the factory
+      // default is `shared` — world-readable — which is wrong for these rows.
+      scope: "agent-private",
     });
     await runtime.createMemory(message, "messages");
     invalidateMemorySearchCache(runtime, roomId);

--- a/packages/agent/src/providers/relevant-conversations.test.ts
+++ b/packages/agent/src/providers/relevant-conversations.test.ts
@@ -101,6 +101,7 @@ function makeRuntime(overrides: Partial<IAgentRuntime> = {}): {
       roomId: OTHER_ROOM,
       entityId: "00000000-0000-0000-0000-0000000000e1",
       content: { text: "earlier relevant message" },
+      metadata: { type: "message", scope: "shared" },
       createdAt: 1,
     } as unknown as Memory,
   ]);
@@ -262,6 +263,7 @@ describe("relevantConversationsProvider — shared recall embed fail-open", () =
       roomId: OTHER_ROOM,
       entityId: "00000000-0000-0000-0000-0000000000e1",
       content: { text: "disclosable launch note" },
+      metadata: { type: "message", scope: "shared" },
       createdAt: 1,
     } as unknown as Memory;
     searchCanonicalConversationMemories.mockResolvedValueOnce({
@@ -328,6 +330,7 @@ describe("relevantConversationsProvider — shared recall embed fail-open", () =
           text: "the launch date is set for next Friday",
           source: "hash_memory",
         },
+        metadata: { type: "message", scope: "shared" },
         createdAt: 5,
       } as unknown as Memory,
       {
@@ -335,6 +338,7 @@ describe("relevantConversationsProvider — shared recall embed fail-open", () =
         roomId: "00000000-0000-0000-0000-0000000000hr",
         entityId: "00000000-0000-0000-0000-0000000000e9",
         content: { text: "unrelated note", source: "hash_memory" },
+        metadata: { type: "message", scope: "shared" },
         createdAt: 6,
       } as unknown as Memory,
     ]);
@@ -448,6 +452,7 @@ describe("relevantConversationsProvider — shared recall embed fail-open", () =
         roomId: OTHER_ROOM,
         entityId: "00000000-0000-0000-0000-0000000000e1",
         content: { text: "first relevant message" },
+        metadata: { type: "message", scope: "shared" },
         createdAt: 3,
       } as unknown as Memory,
       {
@@ -455,6 +460,7 @@ describe("relevantConversationsProvider — shared recall embed fail-open", () =
         roomId: THIRD_ROOM,
         entityId: "00000000-0000-0000-0000-0000000000e2",
         content: { text: "second relevant message" },
+        metadata: { type: "message", scope: "shared" },
         createdAt: 2,
       } as unknown as Memory,
       {
@@ -462,6 +468,7 @@ describe("relevantConversationsProvider — shared recall embed fail-open", () =
         roomId: OTHER_ROOM,
         entityId: "00000000-0000-0000-0000-0000000000e1",
         content: { text: "third relevant message" },
+        metadata: { type: "message", scope: "shared" },
         createdAt: 1,
       } as unknown as Memory,
     ]);

--- a/packages/core/src/access-control/filter.test.ts
+++ b/packages/core/src/access-control/filter.test.ts
@@ -250,12 +250,16 @@ describe("filterByAccessContext", () => {
 		expect(twice).toEqual(once);
 	});
 
-	describe("absent scope fails closed to owner-private", () => {
+	describe("absent scope fails closed to private (author-scoped)", () => {
 		// Leak canary: an UNSTAMPED row (no metadata.scope at all, the shape of
 		// legacy rows and of any writer that forgot to stamp) must NOT be visible
-		// to a non-owner viewer. Under the old `?? "global"` default the
-		// USER/GUEST cases here FAIL (the stranger reads the row); with the
-		// fail-closed default they pass.
+		// to a stranger. Under the old `?? "global"` default the USER/GUEST cases
+		// here FAIL (the stranger reads the row); with the fail-closed default
+		// they pass. The tier is `private` — not owner-private — so the row's
+		// author and the agent keep reading legacy unstamped rows (deliberate
+		// divergence from normalizeScope in artifact-disclosure.ts, which
+		// defaults artifacts to owner-private: artifacts don't need agent
+		// self-recall, messages do).
 		const noScope = {
 			entityId: OTHER,
 			roomId: SELF,
@@ -281,19 +285,30 @@ describe("filterByAccessContext", () => {
 			expect(filterByAccessContext([noScope], unresolved, AGENT)).toEqual([]);
 		});
 
-		it("still lets the OWNER read an unstamped row (owner-private tier)", () => {
+		it("lets the AUTHOR read their own unstamped row (private tier)", () => {
+			// The owning entity resolves scopedToEntityId -> addedBy -> entityId;
+			// this row has only entityId, so its author is OTHER.
+			const ctx: AccessContext = { requesterEntityId: OTHER, role: "USER" };
+			expect(filterByAccessContext([noScope], ctx, AGENT)).toHaveLength(1);
+		});
+
+		it("lets the AGENT read an unstamped row (self-recall stays intact)", () => {
+			// `private` admits the AGENT tier, so legacy unstamped rows remain
+			// available to the agent's own recall — the reason this default is
+			// `private` and not owner-private.
+			const ctx: AccessContext = { requesterEntityId: AGENT };
+			expect(filterByAccessContext([noScope], ctx, AGENT)).toHaveLength(1);
+		});
+
+		it("denies an OWNER reading someone else's unstamped row without scopedToEntityId", () => {
+			// Standard `private` semantics: an OWNER reads another entity's private
+			// row only on that entity's behalf (opts.scopedToEntityId), which this
+			// call path does not pass.
 			const ctx: AccessContext = {
 				requesterEntityId: SELF,
 				role: "OWNER",
 				isOwner: true,
 			};
-			expect(filterByAccessContext([noScope], ctx, AGENT)).toHaveLength(1);
-		});
-
-		it("matches normalizeScope's owner-private default: AGENT self-read is also denied", () => {
-			// owner-private is OWNER/RUNTIME only on the ladder, so even the agent
-			// tier does not read an unstamped row through this filter.
-			const ctx: AccessContext = { requesterEntityId: AGENT };
 			expect(filterByAccessContext([noScope], ctx, AGENT)).toEqual([]);
 		});
 	});

--- a/packages/core/src/access-control/filter.test.ts
+++ b/packages/core/src/access-control/filter.test.ts
@@ -250,14 +250,52 @@ describe("filterByAccessContext", () => {
 		expect(twice).toEqual(once);
 	});
 
-	it("defaults a memory with no scope to global (readable)", () => {
+	describe("absent scope fails closed to owner-private", () => {
+		// Leak canary: an UNSTAMPED row (no metadata.scope at all, the shape of
+		// legacy rows and of any writer that forgot to stamp) must NOT be visible
+		// to a non-owner viewer. Under the old `?? "global"` default the
+		// USER/GUEST cases here FAIL (the stranger reads the row); with the
+		// fail-closed default they pass.
 		const noScope = {
 			entityId: OTHER,
 			roomId: SELF,
-			content: { text: "m" },
+			content: { text: "private note that was never stamped" },
 		} as Memory;
-		const ctx: AccessContext = { requesterEntityId: SELF, role: "USER" };
-		expect(filterByAccessContext([noScope], ctx, AGENT)).toHaveLength(1);
+		const noScopeEmptyMeta = {
+			entityId: OTHER,
+			roomId: SELF,
+			content: { text: "m" },
+			metadata: { type: "custom" },
+		} as Memory;
+
+		it("hides an unstamped row from a USER (stranger in a group)", () => {
+			const ctx: AccessContext = { requesterEntityId: SELF, role: "USER" };
+			expect(filterByAccessContext([noScope], ctx, AGENT)).toEqual([]);
+			expect(filterByAccessContext([noScopeEmptyMeta], ctx, AGENT)).toEqual([]);
+		});
+
+		it("hides an unstamped row from a GUEST and an unresolved role", () => {
+			const guest: AccessContext = { requesterEntityId: SELF, role: "GUEST" };
+			const unresolved: AccessContext = { requesterEntityId: SELF };
+			expect(filterByAccessContext([noScope], guest, AGENT)).toEqual([]);
+			expect(filterByAccessContext([noScope], unresolved, AGENT)).toEqual([]);
+		});
+
+		it("still lets the OWNER read an unstamped row (owner-private tier)", () => {
+			const ctx: AccessContext = {
+				requesterEntityId: SELF,
+				role: "OWNER",
+				isOwner: true,
+			};
+			expect(filterByAccessContext([noScope], ctx, AGENT)).toHaveLength(1);
+		});
+
+		it("matches normalizeScope's owner-private default: AGENT self-read is also denied", () => {
+			// owner-private is OWNER/RUNTIME only on the ladder, so even the agent
+			// tier does not read an unstamped row through this filter.
+			const ctx: AccessContext = { requesterEntityId: AGENT };
+			expect(filterByAccessContext([noScope], ctx, AGENT)).toEqual([]);
+		});
 	});
 
 	it("preserves the concrete shape of document-search results", () => {

--- a/packages/core/src/access-control/filter.ts
+++ b/packages/core/src/access-control/filter.ts
@@ -118,13 +118,14 @@ export function canReadScope(
  * Filter retrieval records down to those `ctx`'s requester may read. A pure,
  * strictly subtractive `.filter()`: it composes with (never duplicates)
  * Postgres RLS, which gates on `entity_id`/`server_id` while this gates on
- * `metadata.scope`. An ABSENT scope fails CLOSED to `owner-private` (the most
- * restrictive tier), matching `normalizeScope` in artifact-disclosure.ts: an
- * unstamped legacy row must never be treated as globally readable, because a
- * write path that forgot to stamp a scope would otherwise silently publish
- * private data to every actor. Malformed scopes also fail closed. The owning
- * entity is taken from `metadata.scopedToEntityId`, else `metadata.addedBy`,
- * else `entityId` (mirroring the documents plugin).
+ * `metadata.scope`. An ABSENT scope fails CLOSED to `private` (author-scoped):
+ * an unstamped legacy row must never be treated as globally readable, because
+ * a write path that forgot to stamp a scope would otherwise silently publish
+ * private data to every actor. `private` (rather than `owner-private`) keeps
+ * the author's own rows and the agent's self-recall working on legacy
+ * unstamped data while still denying strangers. Malformed scopes also fail
+ * closed. The owning entity is taken from `metadata.scopedToEntityId`, else
+ * `metadata.addedBy`, else `entityId` (mirroring the documents plugin).
  */
 export function filterByAccessContext<T extends AccessScopedRecord>(
 	memories: T[],
@@ -137,10 +138,15 @@ export function filterByAccessContext<T extends AccessScopedRecord>(
 		if (rawScope !== undefined && !isMemoryScope(rawScope)) {
 			return false;
 		}
-		// Fail closed: no stamp = owner-private, never `global`. Keep in lockstep
-		// with normalizeScope (artifact-disclosure.ts), which already defaults
-		// unknown/absent scopes to owner-private.
-		const scope = rawScope ?? "owner-private";
+		// Fail closed: no stamp = `private` (author-scoped), never `global`. The
+		// author (via the scopedToEntityId -> addedBy -> entityId resolution
+		// below), the agent, and the runtime can still read an unstamped row;
+		// strangers (USER/GUEST/unresolved) cannot. This deliberately DIVERGES
+		// from normalizeScope (artifact-disclosure.ts), which defaults absent
+		// scopes to owner-private: artifacts have no agent-self-recall
+		// requirement, but messages do — legacy unstamped message rows must stay
+		// readable to their author and to the agent, or recall silently breaks.
+		const scope = rawScope ?? "private";
 		const meta = memory.metadata;
 		const scopedTo = meta?.scopedToEntityId;
 		const addedBy = meta?.addedBy;

--- a/packages/core/src/access-control/filter.ts
+++ b/packages/core/src/access-control/filter.ts
@@ -118,10 +118,13 @@ export function canReadScope(
  * Filter retrieval records down to those `ctx`'s requester may read. A pure,
  * strictly subtractive `.filter()`: it composes with (never duplicates)
  * Postgres RLS, which gates on `entity_id`/`server_id` while this gates on
- * `metadata.scope`. Scope defaults to `global` only when absent; malformed
- * scopes fail closed. The owning entity is taken from
- * `metadata.scopedToEntityId`, else `metadata.addedBy`, else `entityId`
- * (mirroring the documents plugin).
+ * `metadata.scope`. An ABSENT scope fails CLOSED to `owner-private` (the most
+ * restrictive tier), matching `normalizeScope` in artifact-disclosure.ts: an
+ * unstamped legacy row must never be treated as globally readable, because a
+ * write path that forgot to stamp a scope would otherwise silently publish
+ * private data to every actor. Malformed scopes also fail closed. The owning
+ * entity is taken from `metadata.scopedToEntityId`, else `metadata.addedBy`,
+ * else `entityId` (mirroring the documents plugin).
  */
 export function filterByAccessContext<T extends AccessScopedRecord>(
 	memories: T[],
@@ -134,7 +137,10 @@ export function filterByAccessContext<T extends AccessScopedRecord>(
 		if (rawScope !== undefined && !isMemoryScope(rawScope)) {
 			return false;
 		}
-		const scope = rawScope ?? "global";
+		// Fail closed: no stamp = owner-private, never `global`. Keep in lockstep
+		// with normalizeScope (artifact-disclosure.ts), which already defaults
+		// unknown/absent scopes to owner-private.
+		const scope = rawScope ?? "owner-private";
 		const meta = memory.metadata;
 		const scopedTo = meta?.scopedToEntityId;
 		const addedBy = meta?.addedBy;

--- a/packages/core/src/memory.test.ts
+++ b/packages/core/src/memory.test.ts
@@ -30,14 +30,20 @@ import {
 const id = (s: string) => s as UUID;
 
 describe("createMessageMemory", () => {
-	it("stamps MESSAGE metadata and scope by agentId presence", () => {
-		const shared = createMessageMemory({
+	it("fails closed: no explicit scope and no agentId stamps owner-private, never shared", () => {
+		// Leak canary. This exact shape is what POST /api/memory/remember builds
+		// for hash-memory notes. The old default (`shared`) made every unscoped
+		// note readable by any USER/GUEST on the scope ladder — an unstamped
+		// personal note must never be world-readable by omission.
+		const unstamped = createMessageMemory({
 			entityId: id("e1"),
 			roomId: id("r1"),
 			content: { text: "hi" },
 		});
-		expect(shared.metadata?.type).toBe(MemoryType.MESSAGE);
-		expect((shared.metadata as { scope?: string }).scope).toBe("shared");
+		expect(unstamped.metadata?.type).toBe(MemoryType.MESSAGE);
+		expect((unstamped.metadata as { scope?: string }).scope).toBe(
+			"owner-private",
+		);
 
 		const priv = createMessageMemory({
 			entityId: id("e1"),
@@ -46,6 +52,32 @@ describe("createMessageMemory", () => {
 			content: { text: "hi" },
 		});
 		expect((priv.metadata as { scope?: string }).scope).toBe("private");
+	});
+
+	it("honors an explicit scope: shared must be opted into, never inherited", () => {
+		const explicitShared = createMessageMemory({
+			entityId: id("e1"),
+			roomId: id("r1"),
+			content: { text: "hi" },
+			scope: "shared",
+		});
+		expect((explicitShared.metadata as { scope?: string }).scope).toBe(
+			"shared",
+		);
+		// The scope param must not leak onto the memory record itself — it only
+		// belongs in metadata, where the access-control ladder reads it.
+		expect("scope" in explicitShared).toBe(false);
+
+		const explicitOwner = createMessageMemory({
+			entityId: id("e1"),
+			agentId: id("a1"),
+			roomId: id("r1"),
+			content: { text: "hi" },
+			scope: "owner-private",
+		});
+		expect((explicitOwner.metadata as { scope?: string }).scope).toBe(
+			"owner-private",
+		);
 	});
 });
 

--- a/packages/core/src/memory.test.ts
+++ b/packages/core/src/memory.test.ts
@@ -30,20 +30,18 @@ import {
 const id = (s: string) => s as UUID;
 
 describe("createMessageMemory", () => {
-	it("fails closed: no explicit scope and no agentId stamps owner-private, never shared", () => {
-		// Leak canary. This exact shape is what POST /api/memory/remember builds
-		// for hash-memory notes. The old default (`shared`) made every unscoped
-		// note readable by any USER/GUEST on the scope ladder — an unstamped
-		// personal note must never be world-readable by omission.
-		const unstamped = createMessageMemory({
+	it("stamps MESSAGE metadata and scope by agentId presence", () => {
+		// Intentional factory defaults: `shared` without an agentId, `private`
+		// with one. Omit-agentId production writers (inbound chat, cloud events,
+		// CLI chat) rely on `shared` so the sender and the agent can both read
+		// the row. Writers needing a tighter tier pass `scope` explicitly.
+		const shared = createMessageMemory({
 			entityId: id("e1"),
 			roomId: id("r1"),
 			content: { text: "hi" },
 		});
-		expect(unstamped.metadata?.type).toBe(MemoryType.MESSAGE);
-		expect((unstamped.metadata as { scope?: string }).scope).toBe(
-			"owner-private",
-		);
+		expect(shared.metadata?.type).toBe(MemoryType.MESSAGE);
+		expect((shared.metadata as { scope?: string }).scope).toBe("shared");
 
 		const priv = createMessageMemory({
 			entityId: id("e1"),
@@ -54,19 +52,19 @@ describe("createMessageMemory", () => {
 		expect((priv.metadata as { scope?: string }).scope).toBe("private");
 	});
 
-	it("honors an explicit scope: shared must be opted into, never inherited", () => {
-		const explicitShared = createMessageMemory({
+	it("honors an explicit scope over the agentId-derived default", () => {
+		const explicitAgentPrivate = createMessageMemory({
 			entityId: id("e1"),
 			roomId: id("r1"),
 			content: { text: "hi" },
-			scope: "shared",
+			scope: "agent-private",
 		});
-		expect((explicitShared.metadata as { scope?: string }).scope).toBe(
-			"shared",
+		expect((explicitAgentPrivate.metadata as { scope?: string }).scope).toBe(
+			"agent-private",
 		);
 		// The scope param must not leak onto the memory record itself — it only
 		// belongs in metadata, where the access-control ladder reads it.
-		expect("scope" in explicitShared).toBe(false);
+		expect("scope" in explicitAgentPrivate).toBe(false);
 
 		const explicitOwner = createMessageMemory({
 			entityId: id("e1"),

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -1,9 +1,9 @@
 /**
  * Factory and type guards for {@link Memory} records: `createMessageMemory`
- * stamps a MESSAGE-metadata memory (scope derived from whether an `agentId` is
- * present), and the `is*Metadata` / `is*Memory` guards discriminate a record's
- * kind by its `MemoryType` tag so storage, embedding, and retrieval can branch
- * on it. `isCustomMetadata` is the catch-all for any type outside the four known
+ * stamps a MESSAGE-metadata memory (scope from the explicit `scope` param,
+ * else a fail-closed default), and the `is*Metadata` / `is*Memory` guards
+ * discriminate a record's kind by its `MemoryType` tag so storage, embedding,
+ * and retrieval can branch on it. `isCustomMetadata` is the catch-all for any type outside the four known
  * kinds. The types come from `./types` (`types/memory.ts`); this module holds
  * only the runtime helpers over them.
  */
@@ -16,12 +16,22 @@ import {
 	type FragmentMetadata,
 	type Memory,
 	type MemoryMetadata,
+	type MemoryScope,
 	MemoryType,
 	type MessageMemory,
 	type MessageMetadata,
 	type UUID,
 } from "./types";
 
+/**
+ * Build a MESSAGE-metadata memory. Scope is FAIL-CLOSED by default: an
+ * unspecified scope stamps `private` when an `agentId` is present (unchanged
+ * historical behavior) and `owner-private` otherwise. It used to default to
+ * `shared` — readable by every actor on the scope ladder — which meant any
+ * writer that forgot to think about scope (e.g. the `/api/memory/remember`
+ * hash-memory route) published its rows to strangers. A caller that truly
+ * wants a world-readable memory must now say so explicitly via `scope`.
+ */
 export function createMessageMemory(params: {
 	id?: UUID;
 	entityId: UUID;
@@ -29,15 +39,17 @@ export function createMessageMemory(params: {
 	roomId: UUID;
 	content: Content & { text: string };
 	embedding?: number[];
+	scope?: MemoryScope;
 }): MessageMemory {
+	const { scope, ...memoryFields } = params;
 	const now = Date.now();
 	return {
-		...params,
+		...memoryFields,
 		createdAt: now,
 		metadata: {
 			type: MemoryType.MESSAGE,
 			timestamp: now,
-			scope: params.agentId ? "private" : "shared",
+			scope: scope ?? (params.agentId ? "private" : "owner-private"),
 		},
 	};
 }

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -1,9 +1,10 @@
 /**
  * Factory and type guards for {@link Memory} records: `createMessageMemory`
  * stamps a MESSAGE-metadata memory (scope from the explicit `scope` param,
- * else a fail-closed default), and the `is*Metadata` / `is*Memory` guards
- * discriminate a record's kind by its `MemoryType` tag so storage, embedding,
- * and retrieval can branch on it. `isCustomMetadata` is the catch-all for any type outside the four known
+ * else derived from whether an `agentId` is present), and the `is*Metadata` /
+ * `is*Memory` guards discriminate a record's kind by its `MemoryType` tag so
+ * storage, embedding, and retrieval can branch on it. `isCustomMetadata` is
+ * the catch-all for any type outside the four known
  * kinds. The types come from `./types` (`types/memory.ts`); this module holds
  * only the runtime helpers over them.
  */
@@ -24,13 +25,13 @@ import {
 } from "./types";
 
 /**
- * Build a MESSAGE-metadata memory. Scope is FAIL-CLOSED by default: an
- * unspecified scope stamps `private` when an `agentId` is present (unchanged
- * historical behavior) and `owner-private` otherwise. It used to default to
- * `shared` — readable by every actor on the scope ladder — which meant any
- * writer that forgot to think about scope (e.g. the `/api/memory/remember`
- * hash-memory route) published its rows to strangers. A caller that truly
- * wants a world-readable memory must now say so explicitly via `scope`.
+ * Build a MESSAGE-metadata memory. When `scope` is omitted the historical
+ * defaults apply: `private` with an `agentId`, `shared` without one. Those
+ * defaults are intentional — omit-`agentId` callers (inbound chat, cloud
+ * events, CLI chat) rely on `shared` so a non-owner's own message stays
+ * readable to them and to the agent. Writers that need a tighter tier (e.g.
+ * the `/api/memory/remember` hash-memory route, which stamps `agent-private`)
+ * pass `scope` explicitly instead of the factory guessing for them.
  */
 export function createMessageMemory(params: {
 	id?: UUID;
@@ -49,7 +50,7 @@ export function createMessageMemory(params: {
 		metadata: {
 			type: MemoryType.MESSAGE,
 			timestamp: now,
-			scope: scope ?? (params.agentId ? "private" : "owner-private"),
+			scope: scope ?? (params.agentId ? "private" : "shared"),
 		},
 	};
 }


### PR DESCRIPTION
## The leak

`filterByAccessContext` (packages/core/src/access-control/filter.ts) treated an ABSENT `metadata.scope` as `global`, i.e. readable by everyone. This filter is the enforcement layer on the documents and chat-augmentation recall paths and post-filters relevant-conversations recall, so any unstamped legacy row (or any future writer that forgets to stamp) was silently world-readable. Separately, the hash-memory notes written by `POST /api/memory/remember` were stamped `shared` (world-readable) purely by factory omission - the route never chose that.

## The fix (narrowed per review)

- **`filterByAccessContext`: absent scope fails closed to `private` (author-scoped).** Strangers (USER / GUEST / unresolved role) are denied on unstamped rows - the leak is closed. The row's author (resolved via `scopedToEntityId` -> `addedBy` -> `entityId`) and the AGENT/RUNTIME tiers still read, so legacy unstamped rows don't silently vanish from the author's own view or from agent recall. This deliberately diverges from `normalizeScope` in artifact-disclosure.ts, which keeps its `owner-private` default: artifacts have no agent-self-recall requirement, messages do. The divergence is documented in a code comment at the default site. Malformed-scope handling is unchanged (still drops the row).
- **`POST /api/memory/remember` stamps `scope: "agent-private"` explicitly** (packages/agent/src/api/memory-routes.ts). Hash memories are the agent's personal store: `agent-private` (OWNER + AGENT + RUNTIME) fails closed against strangers while keeping the agent's own recall intact. `owner-private` would have excluded the AGENT tier and landmined agent self-recall the moment readers migrate to scope-enforced retrieval.
- **`createMessageMemory` keeps its historical defaults** (`private` with `agentId`, `shared` without) and gains the optional explicit `scope` param so writers can choose a tighter tier at the call site. The earlier revision of this PR flipped the omit-`agentId` default to `owner-private`; review found that regressed ~10 production omit-`agentId` writers (cloud inbound, CLI chat, agent-sent messages) - a non-owner's own message became unreadable to them and to the agent - while being inert for its stated goal, since the hash-memory read paths (`loadHashMemories`, `/api/memory/search`) use plain `getMemories` and bypass this filter entirely. Reverted.

**Behavior change on legacy data:** unstamped rows move from world-readable to author + agent + runtime readable. Rows whose author cannot be resolved from metadata/entityId become unreadable outside AGENT/RUNTIME. A backfill migration stamping explicit scopes on legacy rows is the follow-up to this PR.

## Bidirectional proof (leak canaries)

Each remaining runtime change has tests that fail on develop code and pass with the fix (verified by restoring the three source files to their develop state with the new tests kept):

- `filter.test.ts` > "absent scope fails closed to private (author-scoped)": unstamped row hidden from USER / GUEST / unresolved viewers (**3 tests fail on develop code** - the stranger reads the row), author readable, agent readable, OWNER denied without `scopedToEntityId`.
- `memory-remember-idempotency.test.ts` > "stamps hash-memory notes agent-private": **fails on develop code** (route stamps `shared` via the factory default), passes with the explicit route stamp.
- `memory.test.ts`: factory default assertions restored to `shared`/`private` (documenting intentional behavior) plus the explicit-scope opt-in test (`agent-private`, `owner-private` honored; the `scope` param does not leak onto the record).

## Test runs

- `packages/core` full `src/access-control/` dir + `src/memory.test.ts`: **7 files, 112 tests: 109 pass**; the 3 failures are `canonical-memory-pglite.integration.test.ts` failing to resolve the `@elizaos/core` package entry in this worktree (env resolution, identical on clean develop, unrelated to this diff).
- `packages/agent`: `memory-remember-idempotency.test.ts` + `relevant-conversations.test.ts` + `relevant-conversations.fastfail.test.ts` + `chat-augmentation.test.ts` + `chat-augmentation.access-context.test.ts` + `chat-augmentation-route.test.ts`: **6 files, 43 tests, all pass**.
- `bun run typecheck`: core clean (exit 0). Agent lane has **27 pre-existing errors on clean develop, byte-identical before and after this change** (capacitor-bridge subpath + plugin-wallet + cloud-shared resolution, none in touched files).
- biome: clean on all touched files.

## Test-only adjustments

- `relevant-conversations.test.ts`: seven mock recall rows that previously relied on the fail-open default carry explicit `scope: "shared"` stamps. Production connector rows are always stamped; these mocks support embed-behavior tests, not access-control tests (the access-control tests in that file already used explicit scopes and are untouched).
- The old `filter.test.ts` case "defaults a memory with no scope to global (readable)" is replaced by the fail-closed suite - that test was pinning the leak.