### PR TITLE
fix(core): preserve complete choice task IDs

### DIFF
--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -47,6 +47,11 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 		/MAX_INTERACTION_HISTORY/,
 		/trimmedInteractions/,
 	],
+	"packages/core/src/features/basic-capabilities/actions/choice.ts": [
+		/task\.id\.(?:slice|substring)\(/,
+		/shortId/,
+		/Short or full ID/,
+	],
 	"packages/core/src/runtime/trajectory-recorder.ts": [
 		/resolveTrajectoryFieldCapBytes/,
 		/applyTrajectoryFieldCap/,

--- a/packages/core/src/features/basic-capabilities/actions/choice.test.ts
+++ b/packages/core/src/features/basic-capabilities/actions/choice.test.ts
@@ -1,7 +1,7 @@
 /**
  * Deterministic unit tests for the CHOOSE_OPTION action (`choiceAction`). The
  * runtime is a vi.fn stub (getTasks/getTaskWorker/getRoom) — no live model, no
- * DB — covering full-UUID and short-id task lookup, the #12087 Item 17
+ * DB — covering complete-ID task lookup, the #12087 Item 17
  * authorization contract (validate checks only a pending choice, never a stored
  * world role), and unknown-id rejection.
  */
@@ -49,7 +49,7 @@ function createMessage(): Memory {
 }
 
 describe("CHOOSE_OPTION action", () => {
-	it("accepts the full task UUID as taskId (parameter contract: short or full ID)", async () => {
+	it("accepts the complete task UUID as taskId", async () => {
 		const executed = { options: null as unknown | null };
 		const runtime = createRuntime(executed);
 
@@ -68,7 +68,7 @@ describe("CHOOSE_OPTION action", () => {
 		expect(executed.options).toEqual({ option: "post" });
 	});
 
-	it("still accepts the 8-char short task id", async () => {
+	it("rejects an eight-character prefix instead of guessing between tasks", async () => {
 		const executed = { options: null as unknown | null };
 		const runtime = createRuntime(executed);
 
@@ -84,9 +84,47 @@ describe("CHOOSE_OPTION action", () => {
 			} as HandlerOptions,
 		);
 
+		expect(result?.success).toBe(false);
+		expect(result?.values?.error).toBe("TASK_NOT_FOUND");
+		expect(executed.options).toBeNull();
+	});
+
+	it("renders the complete task ID in the returned choice menu", async () => {
+		const executed = { options: null as unknown | null };
+		const runtime = createRuntime(executed);
+		const callback = vi.fn(async () => {});
+
+		const result = await choiceAction.handler?.(
+			runtime,
+			createMessage(),
+			undefined,
+			undefined,
+			callback,
+		);
+
 		expect(result?.success).toBe(true);
-		expect(result?.values?.taskId).toBe(TASK_ID);
-		expect(executed.options).toEqual({ option: "post" });
+		expect(result?.userFacingText).toContain(TASK_ID);
+		expect(callback).toHaveBeenCalledWith(
+			expect.objectContaining({ text: expect.stringContaining(TASK_ID) }),
+		);
+	});
+
+	it("keeps colliding eight-character prefixes distinguishable", async () => {
+		const first = "aabbccdd-1111-2222-3333-444455556666";
+		const second = "aabbccdd-7777-8888-9999-000011112222";
+		const runtime = {
+			agentId: AGENT_ID,
+			getTasks: vi.fn(async () => [
+				{ id: first, name: "first", metadata: { options: ["yes"] } },
+				{ id: second, name: "second", metadata: { options: ["no"] } },
+			]),
+		} as unknown as IAgentRuntime;
+
+		const result = await choiceAction.handler?.(runtime, createMessage());
+
+		expect(result?.userFacingText).toContain(first);
+		expect(result?.userFacingText).toContain(second);
+		expect(result?.userFacingText?.match(/aabbccdd/g)).toHaveLength(2);
 	});
 
 	// #12087 Item 17: validate() must NOT re-derive authorization from a stored

--- a/packages/core/src/features/basic-capabilities/actions/choice.ts
+++ b/packages/core/src/features/basic-capabilities/actions/choice.ts
@@ -3,10 +3,12 @@
  * agent's way to resolve a pending choice task (tasks tagged AWAITING_CHOICE
  * whose metadata carries `options`). validate() gates on the declared
  * `roleGate: { minRole: "ADMIN" }` plus the existence of such a task — it never
- * re-derives the role itself. handler() matches the caller's taskId (short
- * 8-char prefix or full UUID) and selectedOption, then runs the matching task
+ * re-derives the role itself. handler() matches the caller's complete taskId
+ * and selectedOption, then runs the matching task
  * worker (or deletes the task on the "ABORT" option); with no valid selection it
- * replies with the formatted menu of tasks and their options.
+ * replies with the formatted menu of tasks and their options. Task identifiers
+ * remain complete in both the menu and lookup so chat context cannot hide a
+ * distinguishing suffix or create an eight-character collision.
  */
 import { requireActionSpec } from "../../../generated/spec-helpers.ts";
 import { logger } from "../../../logger.ts";
@@ -146,13 +148,11 @@ export const choiceAction: Action = {
 				},
 			)
 			.map((task) => {
-				const shortId = task.id.substring(0, 8);
 				const taskMetadata = task.metadata;
 				const taskOptions = taskMetadata?.options;
 
 				return {
-					taskId: shortId,
-					fullId: task.id,
+					taskId: task.id,
 					name: task.name,
 					options: taskOptions
 						? taskOptions.map((opt) => ({
@@ -167,14 +167,9 @@ export const choiceAction: Action = {
 		const { taskId, selectedOption } = _readChoiceParameters(message, _options);
 
 		if (taskId && selectedOption) {
-			// The taskId parameter accepts the "Short or full ID of the pending
-			// choice task" — key the lookup by both so a model passing the full
-			// UUID (as stored on the task) is not rejected with TASK_NOT_FOUND.
-			const taskMap = new Map<string, (typeof formattedTasks)[0]>();
-			for (const task of formattedTasks) {
-				taskMap.set(task.taskId, task);
-				taskMap.set(task.fullId, task);
-			}
+			const taskMap = new Map(
+				formattedTasks.map((task) => [task.taskId, task] as const),
+			);
 			const taskInfo = taskMap.get(taskId);
 
 			if (!taskInfo) {
@@ -198,7 +193,7 @@ export const choiceAction: Action = {
 
 			// Find the actual task using the full UUID
 			const selectedTask = tasksWithOptions.find(
-				(task) => task.id === taskInfo.fullId,
+				(task) => task.id === taskInfo.taskId,
 			);
 
 			if (!selectedTask) {
@@ -319,9 +314,7 @@ export const choiceAction: Action = {
 			"Please select a valid option from one of these tasks:\n\n";
 
 		tasksWithOptions.forEach((task) => {
-			const shortId = task.id?.substring(0, 8);
-
-			optionsText += `**${task.name}** (ID: ${shortId}):\n`;
+			optionsText += `**${task.name}** (ID: ${task.id}):\n`;
 			const taskMetadata = task.metadata;
 			const options = taskMetadata?.options
 				? taskMetadata.options.map((opt) =>
@@ -367,7 +360,7 @@ export const choiceAction: Action = {
 	parameters: [
 		{
 			name: "taskId",
-			description: "Short or full ID of the pending choice task.",
+			description: "Complete ID of the pending choice task.",
 			required: true,
 			schema: { type: "string" as const, minLength: 1 },
 		},


### PR DESCRIPTION
## Summary

- render complete pending-choice task IDs in chat/model-visible menus
- require the complete ID for selection instead of accepting an ambiguous eight-character prefix
- add a same-prefix collision regression and extend the prompt-integrity anti-reversion audit

## Verification

- focused choice and prompt-integrity suites: 10 passed
- core typecheck: passed
- guide parity: passed
- Biome and git diff checks: passed

Closes #24151.

Follow-up to #24134; supersedes #23982.