### PR TITLE
test(cloud): cover the usage-quota barrier future-suffix matrix

### DIFF
--- a/packages/cloud/scripts/admin/migrate-with-diagnostics-release-barrier.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics-release-barrier.test.ts
@@ -59,19 +59,28 @@ function appliedRows(
 function migrationClient(applied: ReturnType<typeof appliedRows>): {
   client: {
     backend: "pglite";
-    query<T = unknown>(text: string): Promise<{ rows: T[] }>;
+    query<T = unknown>(
+      text: string,
+      params?: unknown[],
+    ): Promise<{ rows: T[] }>;
     end(): Promise<void>;
   };
   queries: string[];
+  queryParams: unknown[][];
   ended: () => boolean;
 } {
   const queries: string[] = [];
+  const queryParams: unknown[][] = [];
   let didEnd = false;
   return {
     client: {
       backend: "pglite",
-      query: async <T = unknown>(text: string): Promise<{ rows: T[] }> => {
+      query: async <T = unknown>(
+        text: string,
+        params?: unknown[],
+      ): Promise<{ rows: T[] }> => {
         queries.push(text);
+        queryParams.push(params ?? []);
         if (text.includes(`FROM "drizzle"."__drizzle_migrations"`)) {
           return { rows: applied as T[] };
         }
@@ -82,6 +91,7 @@ function migrationClient(applied: ReturnType<typeof appliedRows>): {
       },
     },
     queries,
+    queryParams,
     ended: () => didEnd,
   };
 }
@@ -289,5 +299,171 @@ describe("usage-quotas migration release barrier", () => {
     const dropAt = tags.indexOf(DROP_TAG);
     expect(dropAt).toBeGreaterThanOrEqual(0);
     expect(tags[dropAt + 1]).toBe(RESTORE_TAG);
+  });
+
+  // A ledger sitting exactly at 0282 must repair forward: the restore runs
+  // first, every later migration follows in journal order, and the already-
+  // applied drop never executes again. Requiring the pair to be the journal
+  // tail here would push the stop-the-world failure onto the first ledger
+  // that adopts any future migration.
+  test("applies the restore then later migrations when 0282 is ledgered with future suffixes", async () => {
+    const migrations = [
+      ...barrierMigrations(),
+      migration(284, "0284_first_future_feature", "SELECT future_one"),
+      migration(285, "0285_second_future_feature", "SELECT future_two"),
+    ];
+    const harness = migrationClient(appliedRows(barrierMigrations(), 2));
+    let convergenceCalls = 0;
+    const outputLog = spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      await runMigrations(
+        harness.client,
+        migrations,
+        OPTIONS,
+        undefined,
+        undefined,
+        async () => {
+          convergenceCalls += 1;
+        },
+      );
+    } finally {
+      outputLog.mockRestore();
+    }
+
+    expect(harness.queries).not.toContain("DROP TABLE usage_quotas");
+    // Each applied migration is individually ledgered in journal order: the
+    // statements run inside their own transaction and the ledger INSERT
+    // carries the migration's hash before the COMMIT.
+    const appliedInOrder = [
+      ["CREATE TABLE usage_quotas (id uuid)", RESTORE_TAG],
+      ["SELECT future_one", "0284_first_future_feature"],
+      ["SELECT future_two", "0285_second_future_feature"],
+    ] as const;
+    let searchFrom = 0;
+    for (const [statement, tag] of appliedInOrder) {
+      const begin = harness.queries.indexOf("BEGIN", searchFrom);
+      const run = harness.queries.indexOf(statement, searchFrom);
+      const ledgered = harness.queries.findIndex(
+        (query, index) =>
+          index > run &&
+          query.includes("INSERT INTO") &&
+          query.includes("__drizzle_migrations"),
+      );
+      const commit = harness.queries.indexOf("COMMIT", ledgered);
+      expect(begin).toBeGreaterThanOrEqual(0);
+      expect(run).toBeGreaterThan(begin);
+      expect(ledgered).toBeGreaterThan(run);
+      expect(commit).toBeGreaterThan(ledgered);
+      expect(harness.queryParams[ledgered]).toContain(`hash-${tag}`);
+      searchFrom = commit + 1;
+    }
+    expect(harness.queries.filter((query) => query === "BEGIN")).toHaveLength(
+      3,
+    );
+    expect(harness.queries.filter((query) => query === "COMMIT")).toHaveLength(
+      3,
+    );
+    expect(convergenceCalls).toBe(1);
+    expect(harness.ended()).toBe(true);
+  });
+
+  // Future suffixes behind the barrier must not unlock the guarded pair: an
+  // older ledger still pauses before the drop, never touching the restore or
+  // anything appended after it, and still reports the pause to the operator.
+  test("still pauses before the guarded pair when an older ledger has future suffixes pending", async () => {
+    const migrations = [
+      ...barrierMigrations(),
+      migration(284, "0284_pending_future_feature", "SELECT pending_future"),
+    ];
+    const harness = migrationClient(appliedRows(barrierMigrations(), 1));
+    let convergenceCalls = 0;
+    const barrierEvents: string[] = [];
+    const outputLog = spyOn(console, "log").mockImplementation(() => {});
+    const warningLog = spyOn(console, "warn").mockImplementation(
+      (message: string) => {
+        if (message.includes("release barrier paused")) {
+          barrierEvents.push("warning");
+        }
+      },
+    );
+
+    try {
+      await runMigrations(
+        harness.client,
+        migrations,
+        OPTIONS,
+        undefined,
+        undefined,
+        async () => {
+          convergenceCalls += 1;
+          barrierEvents.push("convergence");
+        },
+      );
+    } finally {
+      outputLog.mockRestore();
+      warningLog.mockRestore();
+    }
+
+    expect(harness.queries).not.toContain("BEGIN");
+    expect(harness.queries).not.toContain("DROP TABLE usage_quotas");
+    expect(harness.queries).not.toContain(
+      "CREATE TABLE usage_quotas (id uuid)",
+    );
+    expect(harness.queries).not.toContain("SELECT pending_future");
+    expect(convergenceCalls).toBe(1);
+    // Convergence must finish before the pause is reported, so the schema is
+    // consistent when the operator reads the warning.
+    expect(barrierEvents).toEqual(["convergence", "warning"]);
+    expect(harness.ended()).toBe(true);
+  });
+
+  // A ledger that has already adopted a future suffix is fully migrated: the
+  // run is a no-op for migration SQL, yet still converges the schema and
+  // closes the client - and critically never reruns the drop or the restore.
+  test("no-ops when the ledger is already past a future suffix", async () => {
+    const migrations = [
+      ...barrierMigrations(),
+      migration(284, "0284_adopted_future_feature", "SELECT adopted_future"),
+    ];
+    const harness = migrationClient(appliedRows(migrations, 4));
+    let convergenceCalls = 0;
+    const outputLog = spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      await runMigrations(
+        harness.client,
+        migrations,
+        OPTIONS,
+        undefined,
+        undefined,
+        async () => {
+          convergenceCalls += 1;
+        },
+      );
+    } finally {
+      outputLog.mockRestore();
+    }
+
+    expect(harness.queries).not.toContain("BEGIN");
+    expect(harness.queries).not.toContain("DROP TABLE usage_quotas");
+    expect(harness.queries).not.toContain(
+      "CREATE TABLE usage_quotas (id uuid)",
+    );
+    expect(harness.queries).not.toContain("SELECT adopted_future");
+    expect(convergenceCalls).toBe(1);
+    expect(harness.ended()).toBe(true);
+  });
+
+  // Journal order is part of the guarded contract, not just adjacency count:
+  // a restore indexed before the drop fails closed instead of "repairing"
+  // backwards.
+  test("fails closed when the restore is journal-indexed before the drop", () => {
+    const [checkpoint, before, drop, restore] = barrierMigrations();
+    const migrations = [checkpoint, before, restore, drop];
+
+    expect(() => evaluateMigrationReleaseBarrier(migrations, 1)).toThrow(
+      "adjacent journal entries",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Completes the usage-quota release-barrier regression matrix from #23877. Test-only change: one file, `+178/−2`, no runtime modifications.

**Pre-claim verification:** the journal-tail assertion quoted in the issue (`test.ts:284-287`, `slice(-2)`) no longer exists on develop — #23860 (merged 17:22:37Z, three minutes after the issue was filed) converted it to the index-based adjacency contract and added one "unrelated migration appended" test. The runtime `evaluateMigrationReleaseBarrier` (from #23859) was already adjacency-anchored. What remained uncovered was exactly the issue's strengthened future-suffix matrix, which this PR delivers:

| Issue matrix row | Covered by |
|---|---|
| ledger at `0282` with `0282_01` + ≥2 future migrations pending: restore first, then suffixes, drop never reruns | **new** `applies the restore then later migrations when 0282 is ledgered with future suffixes` |
| ledger before `0282` with future suffixes present: pause before the guarded pair | **new** `still pauses before the guarded pair when an older ledger has future suffixes pending` |
| ledger at `0282_01` and after a future suffix: continue / no-op | existing `allows an unrelated migration appended after the guarded pair` (at restore + one future) + **new** `no-ops when the ledger is already past a future suffix` |
| duplicate, missing, reversed, non-adjacent guarded tags fail closed | existing duplicate/missing/non-adjacent tests + **new** `fails closed when the restore is journal-indexed before the drop` |

The new continue-path test pins per-migration transaction discipline: `BEGIN` → migration SQL → ledger `INSERT` carrying `hash-<tag>` → `COMMIT`, in journal order (harness extended to capture query params). The pause-path test pins ordering: convergence completes before the barrier warning is reported.

## Evidence

**Test verification (exact head 83e6abe974e, rebased onto develop a8aa79511f5):**

```
$ bun test --config=/dev/null --isolate packages/cloud/scripts/admin/migrate-with-diagnostics-release-barrier.test.ts
 12 pass / 0 fail / 64 expect() calls
```

Sibling suites sharing the runtime module (ledger, database-identity, error-precedence, error-preserving-cleanup): 26 pass / 0 fail across 5 files. `migrate-database.copy-table.test.ts` has 9 failures **pre-existing on develop** — proven by a stash control on the same worktree (identical 9 failures with this diff removed; this PR does not touch any file that suite imports).

**Mutation controls (proving the new tests pin the contract, not just pass):**

```
# Mutation A — runtime reverted to require the pair at the journal tail (the old mistake):
(fail) allows an unrelated migration appended after the guarded pair
(fail) applies the restore then later migrations when 0282 is ledgered with future suffixes
(fail) still pauses before the guarded pair when an older ledger has future suffixes pending
(fail) no-ops when the ledger is already past a future suffix

# Mutation B — runtime order/adjacency check dropped:
(fail) fails closed when a migration interleaves between the drop and the restore
(fail) fails closed when the restore is journal-indexed before the drop
```

**Review:** independent RepoPrompt (gpt-5.6-sol) review round 1 returned REQUEST_CHANGES with 3 strengthening items (convergence on the continue path; convergence-before-warning ordering; per-migration ledger-hash pinning) — all three applied; round 2 returned APPROVE with zero must-fix.

**Notes:** no tsconfig includes `scripts/admin`, so `tsc` gates do not cover this suite — it runs via `bun test` in the cloud unit lane (`test-cloud-run.mjs` walks `packages/cloud/scripts`). Biome clean on the touched file.

| evidence row | artifact |
|---|---|
| backend-logs | `12 pass / 0 fail / 64 expect() calls` at head 83e6abe974e (bun test output above); mutation controls A (4 fail) + B (2 fail) prove the matrix bites |
| test-suite | barrier suite 12/12; siblings 26/26; copy-table 9 pre-existing failures stash-controlled |
| screenshots | N/A - test-only change, no UI surface |
| mp4-walkthrough | N/A - test-only change, no user-visible behavior |
| llm-trajectory | N/A - no model/trajectory behavior changed |

Closes #23877

<!-- evidence-row:backend-logs -->
Suite at exact head 83e6abe974e — `bun test scripts/admin/migrate-with-diagnostics-release-barrier.test.ts` → 12 pass / 0 fail / 64 expect() calls:
```
$ bun test scripts/admin/migrate-with-diagnostics-release-barrier.test.ts
(exact head 83e6abe974ed4df7f9d36b14ec4112f6e208a7dd, conflict-free rebase onto develop a8aa79511f5)

bun test v1.3.14 (0d9b296a)

packages/cloud/scripts/admin/migrate-with-diagnostics-release-barrier.test.ts:
(pass) usage-quotas migration release barrier > pauses a validated 0281 ledger before either 0282 or 0282_01 SQL [0.60ms]
(pass) usage-quotas migration release barrier > applies an older ledger's safe prefix then pauses before 0282 [3.24ms]
(pass) usage-quotas migration release barrier > applies 0282_01 when 0282 is already ledgered [0.13ms]
(pass) usage-quotas migration release barrier > allows an unrelated migration appended after the guarded pair [0.09ms]
(pass) usage-quotas migration release barrier > fails closed when a migration interleaves between the drop and the restore [0.06ms]
(pass) usage-quotas migration release barrier > plans a pause at 0282 for any older validated ledger [0.02ms]
(pass) usage-quotas migration release barrier > fails closed when either guarded migration is missing or duplicated [0.05ms]
(pass) usage-quotas migration release barrier > keeps the release workflow and package scripts on the guarded runner [1.13ms]
(pass) usage-quotas migration release barrier > applies the restore then later migrations when 0282 is ledgered with future suffixes [0.38ms]
(pass) usage-quotas migration release barrier > still pauses before the guarded pair when an older ledger has future suffixes pending [0.17ms]
(pass) usage-quotas migration release barrier > no-ops when the ledger is already past a future suffix [0.12ms]
(pass) usage-quotas migration release barrier > fails closed when the restore is journal-indexed before the drop [0.04ms]

  12 pass
  0 fail
  64 expect() calls
Ran 12 tests across 1 file. [434.00ms]
```
Mutation control A (runtime reverted to journal-tail pinning): 4 failures including 3 of the new tests. Mutation control B (order/adjacency check dropped): 2 failures (reversed + interleaved). Sibling suites sharing the runtime module (ledger, database-identity, error-precedence, error-preserving-cleanup): 26 pass / 0 fail. copy-table suite 9 failures pre-existing on develop — stash control on the same worktree shows identical 9 with this diff removed. Rebased 2026-08-22: same 12/12 green at the new head; Biome clean on the touched file.
<!-- evidence-row:llm-trajectory -->
N/A - test-only change; no model, prompt, or trajectory behavior modified

<!-- evidence-row:frontend-logs -->
N/A - test-only change; no frontend surface touched

<!-- evidence-row:before-screenshots -->
N/A - test-only change; no UI surface

<!-- evidence-row:after-screenshots -->
N/A - test-only change; no UI surface

<!-- evidence-row:walkthrough-video -->
N/A - test-only change; no user-visible behavior

<!-- evidence-row:domain-artifacts -->
N/A - test-only change; no domain artifact (DB rows, on-chain state, media) is produced. Regression matrix summary: at-0282+2-futures repair-forward order (per-migration BEGIN→SQL→ledger INSERT hash-<tag>→COMMIT); before-0282+futures pause with convergence-before-warning ordering; past-future-adopted no-op that still converges; reversed pair fails closed. Independent RepoPrompt (gpt-5.6-sol) two-round review: R1 REQUEST_CHANGES (3 items) → all applied → R2 APPROVE zero must-fix.

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->
<!-- evidence-head:83e6abe974ed4df7f9d36b14ec4112f6e208a7dd -->




Maintainer rebase receipt: patch-id `cac4c68abead9a7f108e940943d9517c5348ec8b` is unchanged after a conflict-free rebase onto current `develop`; independently verified at exact head `fc8508b77188017668957cb929c7b3dd013710cf`: `git diff --check` clean and Biome clean on the touched file. The focused local test attempt stopped before collection because this sparse review checkout lacks `@upstash/redis`; the submitted pre-rebase 12/12 receipt remains applicable to the byte-identical patch, while hosted checks are rerunning on the rebased head.
