### PR TITLE
fix(plugins): preserve complete provider errors

### DIFF
--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -70,6 +70,14 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 		/TOOL_PAYLOAD_.*MARKER/,
 		/payload budget/i,
 	],
+	"plugins/plugin-dropbox/src/client.ts": [/bodyText\.slice\(/],
+	"plugins/plugin-dropbox/src/connector-account-provider.ts": [/body\.slice\(/],
+	"plugins/plugin-elizacloud/src/cloud/managed-payment-clients.ts": [
+		/text\.slice\(/,
+	],
+	"plugins/plugin-elizacloud/src/cloud/bridge-client.ts": [
+		/(?:text|errorText)\.slice\(/,
+	],
 	"packages/core/src/runtime/limits.ts": [
 		/compactionEnabled/,
 		/compactionKeepSteps/,

--- a/plugins/plugin-dropbox/src/__tests__/client.test.ts
+++ b/plugins/plugin-dropbox/src/__tests__/client.test.ts
@@ -184,6 +184,21 @@ describe("DropboxClient.listFolder", () => {
       .catch((e: unknown) => e);
     expect((e2 as ElizaError).code).toBe("DROPBOX_MALFORMED_RESPONSE");
   });
+
+  it("preserves a long rejected-request body through the typed error", async () => {
+    const suffix = "DISTINGUISHING-DROPBOX-SUFFIX";
+    const rejected = fakeDropbox(() => ({
+      status: 400,
+      raw: `${"x".repeat(10_000)}${suffix}`,
+    }));
+
+    const error = await client(rejected.fetchImpl)
+      .listFolder({ accountId: "acct" })
+      .catch((thrown: unknown) => thrown as ElizaError);
+
+    expect(error.code).toBe("DROPBOX_INVALID_REQUEST");
+    expect(error.message).toContain(suffix);
+  });
 });
 
 describe("DropboxClient.search", () => {

--- a/plugins/plugin-dropbox/src/__tests__/connector-account-provider.test.ts
+++ b/plugins/plugin-dropbox/src/__tests__/connector-account-provider.test.ts
@@ -11,6 +11,7 @@ import type {
   ConnectorAccountManager,
   ConnectorOAuthCallbackRequest,
   ConnectorOAuthStartRequest,
+  ElizaError,
   IAgentRuntime,
 } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
@@ -240,5 +241,20 @@ describe("Dropbox OAuth callback", () => {
     await expect(invalid.completeOAuth?.(callbackRequest("code"), manager)).rejects.toThrow(
       /invalid payload/
     );
+  });
+
+  it("preserves the complete failed token-exchange body", async () => {
+    const suffix = "DISTINGUISHING-TOKEN-SUFFIX";
+    const { runtime } = fakeRuntime(SETTINGS);
+    const provider = createDropboxConnectorAccountProvider(runtime, {
+      fetchImpl: async () => new Response(`${"x".repeat(10_000)}${suffix}`, { status: 400 }),
+    });
+    const { manager } = fakeManager();
+
+    const error = await provider
+      .completeOAuth?.(callbackRequest("bad"), manager)
+      .catch((thrown: unknown) => thrown as ElizaError);
+
+    expect(error?.context?.body).toContain(suffix);
   });
 });

--- a/plugins/plugin-dropbox/src/client.ts
+++ b/plugins/plugin-dropbox/src/client.ts
@@ -371,7 +371,7 @@ async function dropboxHttpError(
   }
   if (response.status === 400) {
     return new ElizaError(
-      `DropboxClient: request rejected: ${summary ?? (bodyText.slice(0, 200) || "bad input")}`,
+      `DropboxClient: request rejected: ${summary ?? (bodyText || "bad input")}`,
       { code: "DROPBOX_INVALID_REQUEST", context: base }
     );
   }

--- a/plugins/plugin-dropbox/src/connector-account-provider.ts
+++ b/plugins/plugin-dropbox/src/connector-account-provider.ts
@@ -142,7 +142,7 @@ export async function exchangeDropboxAuthorizationCode(
     const body = await response.text();
     throw new ElizaError(`Dropbox token exchange failed with ${response.status}.`, {
       code: "DROPBOX_OAUTH_TOKEN_EXCHANGE_FAILED",
-      context: { status: response.status, body: body.slice(0, 500) },
+      context: { status: response.status, body },
       severity: "fatal",
     });
   }

--- a/plugins/plugin-elizacloud/__tests__/unit/managed-payment-clients.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/managed-payment-clients.test.ts
@@ -229,6 +229,32 @@ describe("managed payment clients", () => {
     } satisfies Partial<PaypalManagedClientError>);
   });
 
+  it("preserves complete plain-text provider errors", async () => {
+    const suffix = "DISTINGUISHING-PROVIDER-SUFFIX";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(
+        async () => new Response(`${"x".repeat(10_000)}${suffix}`, { status: 503 })
+      )
+    );
+    const config = () => ({
+      configured: true as const,
+      apiKey: "eliza_test",
+      apiBaseUrl: "https://cloud.example/api/v1",
+      siteUrl: "https://cloud.example",
+    });
+
+    const plaidError = await new PlaidManagedClient(config)
+      .createLinkToken()
+      .catch((thrown: unknown) => thrown as PlaidManagedClientError);
+    const paypalError = await new PaypalManagedClient(config)
+      .buildAuthorizeUrl({ state: "state" })
+      .catch((thrown: unknown) => thrown as PaypalManagedClientError);
+
+    expect(plaidError.message).toContain(suffix);
+    expect(paypalError.message).toContain(suffix);
+  });
+
   it("fails before fetch when cloud auth is missing", async () => {
     const fetchMock = vi.fn<typeof fetch>();
     vi.stubGlobal("fetch", fetchMock);

--- a/plugins/plugin-elizacloud/src/cloud/bridge-client.ts
+++ b/plugins/plugin-elizacloud/src/cloud/bridge-client.ts
@@ -148,7 +148,7 @@ function formatApiErrorBody(text: string): string | null {
     /* plain text */
   }
 
-  return text.slice(0, 200) || null;
+  return text || null;
 }
 
 function isRedirectResponse(response: Response): boolean {
@@ -274,7 +274,7 @@ export class ElizaCloudClient {
     if (!response.ok) {
       const errorText = await response.text().catch(() => "");
       throw new Error(
-        `Bridge request failed: HTTP ${response.status} ${errorText.slice(0, 200)}`,
+        `Bridge request failed: HTTP ${response.status} ${errorText}`,
       );
     }
 
@@ -553,7 +553,7 @@ export class ElizaCloudClient {
       const parsed = JSON.parse(text) as { error?: string };
       if (parsed.error) errMessage = parsed.error;
     } catch {
-      if (text) errMessage = text.slice(0, 200);
+      if (text) errMessage = text;
     }
 
     if (response.status === 401) {

--- a/plugins/plugin-elizacloud/src/cloud/managed-payment-clients.ts
+++ b/plugins/plugin-elizacloud/src/cloud/managed-payment-clients.ts
@@ -85,10 +85,10 @@ async function readPlaidJson<T>(
           error?: string;
           message?: string;
         };
-        detail = parsed.message ?? parsed.error ?? text.slice(0, 240);
+        detail = parsed.message ?? parsed.error ?? text;
         code = typeof parsed.code === "string" ? parsed.code : null;
       } catch {
-        detail = text.slice(0, 240);
+        detail = text;
       }
     }
     for (const secret of secrets) {
@@ -123,10 +123,10 @@ async function readPaypalJson<T>(response: Response): Promise<T> {
           message?: string;
           fallback?: "csv_export" | null;
         };
-        detail = parsed.message ?? parsed.error ?? text.slice(0, 240);
+        detail = parsed.message ?? parsed.error ?? text;
         fallback = parsed.fallback ?? null;
       } catch {
-        detail = text.slice(0, 240);
+        detail = text;
       }
     }
     throw new PaypalManagedClientError(response.status, detail, fallback);


### PR DESCRIPTION
## Summary

- preserve complete Dropbox rejected-request and OAuth exchange bodies in typed errors
- preserve complete Eliza Cloud managed-payment and bridge error text after existing secret redaction
- add 10,000-character distinguishing-suffix regressions
- extend the repository prompt-integrity audit over all four provider boundaries

## Verification

- Dropbox: 34 tests passed; typecheck passed
- Eliza Cloud unit lane: 263 passed / 2 skipped
- prompt-integrity policy: 3 passed / 552 assertions
- guide parity, Biome, and git diff checks passed
- Eliza Cloud aggregate typecheck remains blocked by the unchanged missing @elizaos/capacitor-secure-store dependency in packages/ui/src/bridge/storage-bridge.ts

Closes #24156.

Follow-up to #24134; supersedes #24009 and #23997.