### PR TITLE
fix(agent): key escalation state by agent so a second runtime's escalation is not absorbed into the first's

### DIFF
--- a/packages/agent/src/providers/escalation-trigger.ts
+++ b/packages/agent/src/providers/escalation-trigger.ts
@@ -89,10 +89,13 @@ async function findLastOwnerMessageTimestamp(
 // Trigger checks
 // ---------------------------------------------------------------------------
 
-async function checkActiveEscalation(triggers: Trigger[]): Promise<void> {
+async function checkActiveEscalation(
+  runtime: IAgentRuntime,
+  triggers: Trigger[],
+): Promise<void> {
   try {
     const { EscalationService } = await import("../services/escalation.ts");
-    const active = EscalationService.getActiveEscalationSync();
+    const active = EscalationService.getActiveEscalationSync(runtime);
     if (active && !active.resolved) {
       triggers.push({
         type: "active_escalation",
@@ -195,7 +198,7 @@ export function createEscalationTriggerProvider(): Provider {
 
       if (isAdminViewer) {
         await Promise.all([
-          checkActiveEscalation(triggers),
+          checkActiveEscalation(runtime, triggers),
           checkOwnerInactivity(runtime, message, triggers),
           checkPendingVerifications(runtime, message, triggers),
         ]);

--- a/packages/agent/src/runtime/error-escalation.test.ts
+++ b/packages/agent/src/runtime/error-escalation.test.ts
@@ -374,6 +374,8 @@ describe("EscalationService coalescing (real service)", () => {
     expect(second.id).toBe(first.id);
     expect(second.text).toContain("first burst");
     expect(second.text).toContain("second burst");
-    expect(EscalationService.getActiveEscalationSync()?.id).toBe(first.id);
+    expect(EscalationService.getActiveEscalationSync(runtime)?.id).toBe(
+      first.id,
+    );
   });
 });

--- a/packages/agent/src/services/escalation-agent-isolation.test.ts
+++ b/packages/agent/src/services/escalation-agent-isolation.test.ts
@@ -1,0 +1,161 @@
+/**
+ * EscalationService keeps its in-memory state in module-level maps while the
+ * cache key it persists under is agent-scoped. A process holding more than one
+ * runtime — a multi-agent boot, or a runtime rebuilt in-process — must not let
+ * one agent's escalation absorb another's: these tests pin per-agent isolation
+ * of the active escalation, of the persisted cache row, and of resolution,
+ * while keeping same-agent coalescing (the documented behaviour) intact.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, test } from "vitest";
+import { EscalationService } from "./escalation.ts";
+
+type CacheStore = Map<string, unknown>;
+
+function makeRuntime(agentId: string, cache: CacheStore): IAgentRuntime {
+  return {
+    agentId,
+    character: { name: `agent-${agentId}` },
+    getRoomsForParticipant: async () => [],
+    getRoom: async () => null,
+    getWorld: async () => null,
+    getService: () => null,
+    getEntityById: async () => null,
+    getMemoriesByRoomIds: async () => [],
+    setCache: async (key: string, value: unknown) => {
+      cache.set(key, value);
+      return true;
+    },
+    getCache: async (key: string) => cache.get(key) ?? null,
+    deleteCache: async (key: string) => {
+      cache.delete(key);
+      return true;
+    },
+    sendMessageToTarget: async () => {},
+  } as unknown as IAgentRuntime;
+}
+
+const keyFor = (agentId: string) => `agent:escalation:active:${agentId}`;
+
+describe("EscalationService per-agent isolation", () => {
+  afterEach(() => {
+    EscalationService._reset();
+  });
+
+  test("a second agent gets its own escalation instead of coalescing into the first", async () => {
+    const cache: CacheStore = new Map();
+    const runtimeA = makeRuntime("agent-a", cache);
+    const runtimeB = makeRuntime("agent-b", cache);
+
+    const first = await EscalationService.startEscalation(
+      runtimeA,
+      "reason A",
+      "agent A private text",
+    );
+    const second = await EscalationService.startEscalation(
+      runtimeB,
+      "reason B",
+      "agent B private text",
+    );
+
+    expect(second.id).not.toBe(first.id);
+    expect(first.text).toBe("agent A private text");
+    expect(first.reason).toBe("reason A");
+    expect(second.text).toBe("agent B private text");
+    expect(second.reason).toBe("reason B");
+  });
+
+  test("each agent's cache row holds that agent's own escalation", async () => {
+    const cache: CacheStore = new Map();
+    const runtimeA = makeRuntime("agent-a", cache);
+    const runtimeB = makeRuntime("agent-b", cache);
+
+    const first = await EscalationService.startEscalation(
+      runtimeA,
+      "reason A",
+      "agent A private text",
+    );
+    const second = await EscalationService.startEscalation(
+      runtimeB,
+      "reason B",
+      "agent B private text",
+    );
+
+    const storedA = cache.get(keyFor("agent-a")) as
+      | { id: string; text: string }
+      | undefined;
+    const storedB = cache.get(keyFor("agent-b")) as
+      | { id: string; text: string }
+      | undefined;
+
+    expect(storedA?.id).toBe(first.id);
+    expect(storedA?.text).toBe("agent A private text");
+    expect(storedB?.id).toBe(second.id);
+    expect(storedB?.text).toBe("agent B private text");
+  });
+
+  test("getActiveEscalationSync only reports the calling agent's escalation", async () => {
+    const cache: CacheStore = new Map();
+    const runtimeA = makeRuntime("agent-a", cache);
+    const runtimeB = makeRuntime("agent-b", cache);
+
+    const first = await EscalationService.startEscalation(
+      runtimeA,
+      "reason A",
+      "agent A private text",
+    );
+
+    expect(EscalationService.getActiveEscalationSync(runtimeA)?.id).toBe(
+      first.id,
+    );
+    expect(EscalationService.getActiveEscalationSync(runtimeB)).toBeNull();
+  });
+
+  test("resolving one agent's escalation leaves the other's active", async () => {
+    const cache: CacheStore = new Map();
+    const runtimeA = makeRuntime("agent-a", cache);
+    const runtimeB = makeRuntime("agent-b", cache);
+
+    const first = await EscalationService.startEscalation(
+      runtimeA,
+      "reason A",
+      "agent A private text",
+    );
+    const second = await EscalationService.startEscalation(
+      runtimeB,
+      "reason B",
+      "agent B private text",
+    );
+
+    await EscalationService.resolveEscalation(first.id, runtimeA);
+
+    expect(EscalationService.getActiveEscalationSync(runtimeA)).toBeNull();
+    expect(EscalationService.getActiveEscalationSync(runtimeB)?.id).toBe(
+      second.id,
+    );
+  });
+
+  test("same-agent coalescing still folds a second reason into the active escalation", async () => {
+    const cache: CacheStore = new Map();
+    const runtime = makeRuntime("agent-a", cache);
+
+    const first = await EscalationService.startEscalation(
+      runtime,
+      "reason 1",
+      "first burst",
+    );
+    const second = await EscalationService.startEscalation(
+      runtime,
+      "reason 2",
+      "second burst",
+    );
+
+    expect(second.id).toBe(first.id);
+    expect(second.reason).toBe("reason 1; reason 2");
+    expect(second.text).toContain("first burst");
+    expect(second.text).toContain("second burst");
+    expect(EscalationService.getActiveEscalationSync(runtime)?.id).toBe(
+      first.id,
+    );
+  });
+});

--- a/packages/agent/src/services/escalation-agent-isolation.test.ts
+++ b/packages/agent/src/services/escalation-agent-isolation.test.ts
@@ -4,10 +4,12 @@
  * runtime — a multi-agent boot, or a runtime rebuilt in-process — must not let
  * one agent's escalation absorb another's: these tests pin per-agent isolation
  * of the active escalation, of the persisted cache row, and of resolution,
- * while keeping same-agent coalescing (the documented behaviour) intact.
+ * while keeping same-agent coalescing (the documented behaviour) intact. They
+ * also pin that empty per-agent timer buckets are deleted on both timer-fire
+ * and resolve, so a long-lived process does not retain one Map per agent id.
  */
 import type { IAgentRuntime } from "@elizaos/core";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { EscalationService } from "./escalation.ts";
 
 type CacheStore = Map<string, unknown>;
@@ -40,6 +42,8 @@ const keyFor = (agentId: string) => `agent:escalation:active:${agentId}`;
 describe("EscalationService per-agent isolation", () => {
   afterEach(() => {
     EscalationService._reset();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   test("a second agent gets its own escalation instead of coalescing into the first", async () => {
@@ -157,5 +161,66 @@ describe("EscalationService per-agent isolation", () => {
     expect(EscalationService.getActiveEscalationSync(runtime)?.id).toBe(
       first.id,
     );
+  });
+
+  test("resolveEscalation deletes the per-agent timer bucket instead of leaving it empty", async () => {
+    const cache: CacheStore = new Map();
+    const runtime = makeRuntime("agent-a", cache);
+
+    const first = await EscalationService.startEscalation(
+      runtime,
+      "reason A",
+      "agent A private text",
+    );
+
+    expect(EscalationService._hasPendingTimerBucket("agent-a")).toBe(true);
+
+    await EscalationService.resolveEscalation(first.id, runtime);
+
+    expect(EscalationService._hasPendingTimerBucket("agent-a")).toBe(false);
+    expect(EscalationService.getActiveEscalationSync(runtime)).toBeNull();
+  });
+
+  test("timer fire deletes the per-agent timer bucket when the check does not reschedule", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const check = vi
+      .spyOn(EscalationService, "checkEscalation")
+      .mockResolvedValue();
+
+    const cache: CacheStore = new Map();
+    const runtime = makeRuntime("agent-a", cache);
+
+    await EscalationService.startEscalation(
+      runtime,
+      "reason A",
+      "agent A private text",
+    );
+    expect(EscalationService._hasPendingTimerBucket("agent-a")).toBe(true);
+
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(check).toHaveBeenCalledTimes(1);
+    expect(EscalationService._hasPendingTimerBucket("agent-a")).toBe(false);
+  });
+
+  test("resolveEscalation does not allocate a timer bucket when none exists", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    vi.spyOn(EscalationService, "checkEscalation").mockResolvedValue();
+
+    const cache: CacheStore = new Map();
+    const runtime = makeRuntime("agent-a", cache);
+
+    const first = await EscalationService.startEscalation(
+      runtime,
+      "reason A",
+      "agent A private text",
+    );
+    await vi.runOnlyPendingTimersAsync();
+    expect(EscalationService._hasPendingTimerBucket("agent-a")).toBe(false);
+
+    // Still active because the check was stubbed. Resolve must read with
+    // pendingTimers.get(), not timersFor(), or this recreates an empty bucket.
+    await EscalationService.resolveEscalation(first.id, runtime);
+    expect(EscalationService._hasPendingTimerBucket("agent-a")).toBe(false);
   });
 });

--- a/packages/agent/src/services/escalation-agent-isolation.test.ts
+++ b/packages/agent/src/services/escalation-agent-isolation.test.ts
@@ -5,8 +5,10 @@
  * one agent's escalation absorb another's: these tests pin per-agent isolation
  * of the active escalation, of the persisted cache row, and of resolution,
  * while keeping same-agent coalescing (the documented behaviour) intact. They
- * also pin that empty per-agent timer buckets are deleted on both timer-fire
- * and resolve, so a long-lived process does not retain one Map per agent id.
+ * also pin that empty per-agent buckets are never retained — timer buckets are
+ * deleted on both timer-fire and resolve, and a read-only lookup for an unknown
+ * escalation allocates nothing — so a long-lived process does not retain one
+ * Map per agent id.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, test, vi } from "vitest";
@@ -222,5 +224,14 @@ describe("EscalationService per-agent isolation", () => {
     // pendingTimers.get(), not timersFor(), or this recreates an empty bucket.
     await EscalationService.resolveEscalation(first.id, runtime);
     expect(EscalationService._hasPendingTimerBucket("agent-a")).toBe(false);
+  });
+
+  test("checkEscalation does not allocate an escalation bucket for an unknown id", async () => {
+    const cache: CacheStore = new Map();
+    const runtime = makeRuntime("agent-a", cache);
+
+    await EscalationService.checkEscalation(runtime, "unknown-id");
+
+    expect(EscalationService._hasActiveEscalationBucket("agent-a")).toBe(false);
   });
 });

--- a/packages/agent/src/services/escalation.ts
+++ b/packages/agent/src/services/escalation.ts
@@ -568,7 +568,9 @@ export class EscalationService {
     runtime: IAgentRuntime,
     escalationId: string,
   ): Promise<void> {
-    const state = escalationsFor(agentIdOf(runtime)).get(escalationId);
+    // Read-only: escalationsFor() would allocate an empty bucket for an
+    // unknown escalation id.
+    const state = activeEscalations.get(agentIdOf(runtime))?.get(escalationId);
     if (!state || state.resolved) return;
 
     const config = loadEscalationConfig();
@@ -717,6 +719,14 @@ export class EscalationService {
    */
   static _hasPendingTimerBucket(agentId: string): boolean {
     return pendingTimers.has(agentId);
+  }
+
+  /**
+   * Test-only: whether `activeEscalations` still holds a bucket for this agent,
+   * including an empty one. Read-only lookups must not allocate one.
+   */
+  static _hasActiveEscalationBucket(agentId: string): boolean {
+    return activeEscalations.has(agentId);
   }
 
   static async _resetDb(runtime: IAgentRuntime): Promise<void> {

--- a/packages/agent/src/services/escalation.ts
+++ b/packages/agent/src/services/escalation.ts
@@ -96,6 +96,22 @@ function timersFor(
 }
 
 /**
+ * Drop one pending timer without allocating a bucket. Empty inner maps are
+ * removed so a long-lived process that boots many agents does not retain one
+ * Map per agent id after the last timer fires or the escalation resolves.
+ */
+function releaseTimer(agentId: string, escalationId: string): void {
+  const timers = pendingTimers.get(agentId);
+  if (!timers) return;
+  const existing = timers.get(escalationId);
+  if (existing) {
+    clearTimeout(existing);
+    timers.delete(escalationId);
+  }
+  if (timers.size === 0) pendingTimers.delete(agentId);
+}
+
+/**
  * Locate an escalation by id. `resolveEscalation` may be called without a
  * runtime, so fall back to a scan across agents when no runtime is supplied.
  */
@@ -445,12 +461,11 @@ function scheduleCheck(
   escalationId: string,
   delayMs: number,
 ): void {
-  const timers = timersFor(agentIdOf(runtime));
-  const existing = timers.get(escalationId);
-  if (existing) clearTimeout(existing);
+  const agentId = agentIdOf(runtime);
+  releaseTimer(agentId, escalationId);
 
   const timer = setTimeout(async () => {
-    timers.delete(escalationId);
+    releaseTimer(agentId, escalationId);
     try {
       await EscalationService.checkEscalation(runtime, escalationId);
     } catch (err) {
@@ -461,7 +476,7 @@ function scheduleCheck(
     }
   }, delayMs);
 
-  timers.set(escalationId, timer);
+  timersFor(agentId).set(escalationId, timer);
 }
 
 let idCounter = 0;
@@ -632,12 +647,8 @@ export class EscalationService {
     state.resolved = true;
     state.resolvedAt = Date.now();
 
-    const timers = timersFor(agentId);
-    const timer = timers.get(escalationId);
-    if (timer) {
-      clearTimeout(timer);
-      timers.delete(escalationId);
-    }
+    // Read-only: timersFor() would allocate an empty bucket on a no-timer path.
+    releaseTimer(agentId, escalationId);
 
     logger.info(`[escalation] Resolved ${escalationId}`);
 
@@ -697,6 +708,15 @@ export class EscalationService {
     pendingTimers.clear();
     activeEscalations.clear();
     idCounter = 0;
+  }
+
+  /**
+   * Test-only: whether `pendingTimers` still holds a bucket for this agent,
+   * including an empty one. Production cleanup must delete the outer entry
+   * when the last timer is released.
+   */
+  static _hasPendingTimerBucket(agentId: string): boolean {
+    return pendingTimers.has(agentId);
   }
 
   static async _resetDb(runtime: IAgentRuntime): Promise<void> {

--- a/packages/agent/src/services/escalation.ts
+++ b/packages/agent/src/services/escalation.ts
@@ -2,11 +2,12 @@
  * EscalationService — escalates an unacknowledged agent message to the owner
  * across the configured ordered channels (client_chat first, then paired
  * connectors), retrying on a wait/backoff timer until the owner responds or the
- * retry budget is exhausted. State is module-level (one active escalation at a
- * time, coalescing new reasons into it) and persisted to the runtime cache so it
- * survives restarts; owner-contact config and routing hints resolve the delivery
- * target per channel. `registerEscalationChannel` appends newly paired channels
- * to the escalation order in eliza.json.
+ * retry budget is exhausted. State is module-level but partitioned per agent
+ * (one active escalation at a time PER AGENT, coalescing new reasons into it)
+ * and persisted to the runtime cache under an agent-scoped key so it survives
+ * restarts; owner-contact config and routing hints resolve the delivery target
+ * per channel. `registerEscalationChannel` appends newly paired channels to the
+ * escalation order in eliza.json.
  */
 import type { IAgentRuntime, UUID } from "@elizaos/core";
 import {
@@ -50,8 +51,69 @@ const DEFAULT_WAIT_MINUTES = 5;
 const DEFAULT_MAX_RETRIES = 3;
 const ESCALATION_CACHE_KEY_PREFIX = "agent:escalation:active";
 
-const activeEscalations = new Map<string, EscalationState>();
-const pendingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+/**
+ * In-memory escalation state, partitioned by `runtime.agentId`.
+ *
+ * These maps used to be flat (`escalationId -> state`) while
+ * {@link escalationCacheKey} was already agent-scoped. A process that holds
+ * more than one runtime — a multi-agent boot (one service instance per runtime
+ * over the same data dir) or a runtime rebuilt in-process by PGLite recovery —
+ * then shared one "active escalation" across agents: agent B's
+ * `startEscalation` found agent A's state, appended B's reason/text to it, and
+ * persisted A's mutated state under B's cache key. B never got its own
+ * escalation and A's timer went on to deliver text that belonged to B.
+ * Partitioning both maps the same way the cache key is partitioned keeps each
+ * agent's escalation to itself.
+ */
+const activeEscalations = new Map<string, Map<string, EscalationState>>();
+const pendingTimers = new Map<
+  string,
+  Map<string, ReturnType<typeof setTimeout>>
+>();
+
+function agentIdOf(runtime: IAgentRuntime): string {
+  return runtime.agentId as string;
+}
+
+function escalationsFor(agentId: string): Map<string, EscalationState> {
+  let bucket = activeEscalations.get(agentId);
+  if (!bucket) {
+    bucket = new Map<string, EscalationState>();
+    activeEscalations.set(agentId, bucket);
+  }
+  return bucket;
+}
+
+function timersFor(
+  agentId: string,
+): Map<string, ReturnType<typeof setTimeout>> {
+  let bucket = pendingTimers.get(agentId);
+  if (!bucket) {
+    bucket = new Map<string, ReturnType<typeof setTimeout>>();
+    pendingTimers.set(agentId, bucket);
+  }
+  return bucket;
+}
+
+/**
+ * Locate an escalation by id. `resolveEscalation` may be called without a
+ * runtime, so fall back to a scan across agents when no runtime is supplied.
+ */
+function findEscalation(
+  escalationId: string,
+  runtime?: IAgentRuntime,
+): { agentId: string; state: EscalationState } | null {
+  if (runtime) {
+    const agentId = agentIdOf(runtime);
+    const state = activeEscalations.get(agentId)?.get(escalationId);
+    return state ? { agentId, state } : null;
+  }
+  for (const [agentId, bucket] of activeEscalations) {
+    const state = bucket.get(escalationId);
+    if (state) return { agentId, state };
+  }
+  return null;
+}
 
 // ---------------------------------------------------------------------------
 // Persistence helpers -- owned by agent state instead of app-lifeops storage.
@@ -383,11 +445,12 @@ function scheduleCheck(
   escalationId: string,
   delayMs: number,
 ): void {
-  const existing = pendingTimers.get(escalationId);
+  const timers = timersFor(agentIdOf(runtime));
+  const existing = timers.get(escalationId);
   if (existing) clearTimeout(existing);
 
   const timer = setTimeout(async () => {
-    pendingTimers.delete(escalationId);
+    timers.delete(escalationId);
     try {
       await EscalationService.checkEscalation(runtime, escalationId);
     } catch (err) {
@@ -398,7 +461,7 @@ function scheduleCheck(
     }
   }, delayMs);
 
-  pendingTimers.set(escalationId, timer);
+  timers.set(escalationId, timer);
 }
 
 let idCounter = 0;
@@ -410,7 +473,7 @@ export class EscalationService {
     reason: string,
     text: string,
   ): Promise<EscalationState> {
-    const existing = EscalationService.getActiveEscalationSync();
+    const existing = EscalationService.getActiveEscalationSync(runtime);
     if (existing) {
       existing.reason = `${existing.reason}; ${reason}`;
       existing.text = `${existing.text}\n---\n${text}`;
@@ -450,7 +513,7 @@ export class EscalationService {
       resolved: false,
     };
 
-    activeEscalations.set(escalationId, state);
+    escalationsFor(agentIdOf(runtime)).set(escalationId, state);
 
     // Initial delivery falls through failed channels immediately: a channel
     // whose send throws (dashboard with no conversation, missing handler) is
@@ -490,7 +553,7 @@ export class EscalationService {
     runtime: IAgentRuntime,
     escalationId: string,
   ): Promise<void> {
-    const state = activeEscalations.get(escalationId);
+    const state = escalationsFor(agentIdOf(runtime)).get(escalationId);
     if (!state || state.resolved) return;
 
     const config = loadEscalationConfig();
@@ -561,16 +624,19 @@ export class EscalationService {
     escalationId: string,
     runtime?: IAgentRuntime,
   ): Promise<void> {
-    const state = activeEscalations.get(escalationId);
-    if (!state || state.resolved) return;
+    const found = findEscalation(escalationId, runtime);
+    if (!found) return;
+    const { agentId, state } = found;
+    if (state.resolved) return;
 
     state.resolved = true;
     state.resolvedAt = Date.now();
 
-    const timer = pendingTimers.get(escalationId);
+    const timers = timersFor(agentId);
+    const timer = timers.get(escalationId);
     if (timer) {
       clearTimeout(timer);
-      pendingTimers.delete(escalationId);
+      timers.delete(escalationId);
     }
 
     logger.info(`[escalation] Resolved ${escalationId}`);
@@ -582,11 +648,18 @@ export class EscalationService {
     // Drop the resolved escalation from the in-memory map. getActiveEscalationSync
     // ignores resolved entries and the resolved state is persisted to cache, so
     // retaining it only grows the map one entry per escalation ever created.
-    activeEscalations.delete(escalationId);
+    const bucket = activeEscalations.get(agentId);
+    bucket?.delete(escalationId);
+    if (bucket?.size === 0) activeEscalations.delete(agentId);
   }
 
-  static getActiveEscalationSync(): EscalationState | null {
-    for (const state of activeEscalations.values()) {
+  /** The calling agent's own active escalation, if any. */
+  static getActiveEscalationSync(
+    runtime: IAgentRuntime,
+  ): EscalationState | null {
+    const bucket = activeEscalations.get(agentIdOf(runtime));
+    if (!bucket) return null;
+    for (const state of bucket.values()) {
       if (!state.resolved) return state;
     }
     return null;
@@ -595,12 +668,12 @@ export class EscalationService {
   static async getActiveEscalation(
     runtime: IAgentRuntime,
   ): Promise<EscalationState | null> {
-    const cached = EscalationService.getActiveEscalationSync();
+    const cached = EscalationService.getActiveEscalationSync(runtime);
     if (cached) return cached;
 
     const persisted = await loadActiveFromCache(runtime);
     if (persisted) {
-      activeEscalations.set(persisted.id, persisted);
+      escalationsFor(agentIdOf(runtime)).set(persisted.id, persisted);
       return persisted;
     }
     return null;
@@ -608,8 +681,9 @@ export class EscalationService {
 
   static async rehydrateFromDb(runtime: IAgentRuntime): Promise<void> {
     const persisted = await loadActiveFromCache(runtime);
-    if (persisted && !activeEscalations.has(persisted.id)) {
-      activeEscalations.set(persisted.id, persisted);
+    const bucket = escalationsFor(agentIdOf(runtime));
+    if (persisted && !bucket.has(persisted.id)) {
+      bucket.set(persisted.id, persisted);
       logger.info(
         `[escalation] Rehydrated unresolved escalation ${persisted.id} from cache`,
       );
@@ -617,7 +691,9 @@ export class EscalationService {
   }
 
   static _reset(): void {
-    for (const timer of pendingTimers.values()) clearTimeout(timer);
+    for (const bucket of pendingTimers.values()) {
+      for (const timer of bucket.values()) clearTimeout(timer);
+    }
     pendingTimers.clear();
     activeEscalations.clear();
     idCounter = 0;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #24157.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (branched from `origin/develop` @ `423aea3`).
- [x] `bun install` was run after sync. `bun run verify` was **not** run in full;
      what was run instead — the package's own vitest suite, `tsc --noEmit` for
      `packages/agent`, and biome — is recorded below with results.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts. The branch's
      single commit is parented directly on `origin/develop` @
      `423aea34a0d875294a4a9a60aff5ad89a46af61b`.
- [x] The package's vitest suite and `tsc --noEmit` were run post-sync and
      compared against an untouched control at the same commit; both are recorded
      under **Testing** with exact counts.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

**Low.** The diff changes where three module-level lookups happen, not what they
do. `activeEscalations` and `pendingTimers` go from `id -> value` to
`agentId -> (id -> value)`; every read and write is routed through the calling
runtime's bucket. No persisted shape changes: `EscalationState` is untouched and
`escalationCacheKey` is untouched, so an existing cache row rehydrates exactly
as before.

What could go wrong and why it does not:

- **`getActiveEscalationSync()` gained a required `runtime` argument.** There are
  exactly two callers in the repo — `startEscalation` itself and
  `providers/escalation-trigger.ts` — and both already hold the runtime. The
  provider's `checkActiveEscalation` takes it as a new first parameter. No public
  export changes shape other than this one static.
- **`resolveEscalation(escalationId, runtime?)` keeps its optional runtime.**
  When a runtime is supplied it resolves in that agent's bucket; when it is not,
  it falls back to a scan across buckets, which is exactly what the flat map did
  before. So the one call path that can arrive without a runtime is unchanged.
- **Buckets could leak one empty `Map` per agent.** `resolveEscalation` deletes
  the agent's bucket when it empties, and `_reset()` clears both top-level maps,
  so the bookkeeping is strictly smaller than the flat map it replaces (which
  retained nothing, but also isolated nothing).
- **Same-agent coalescing is the documented behaviour and had to survive.** It
  does: the existing coalescing test in
  `packages/agent/src/runtime/error-escalation.test.ts` still passes unmodified
  except for passing the runtime into `getActiveEscalationSync`, and the new file
  re-pins it as an explicit no-over-rejection case that is **green on
  `origin/develop` too**.

# Background

## What does this PR do?

`packages/agent/src/services/escalation.ts` holds its live escalation state in
two flat module-level maps:

```ts
const activeEscalations = new Map<string, EscalationState>();            // :53
const pendingTimers = new Map<string, ReturnType<typeof setTimeout>>();  // :54
```

while the key it persists that state under is already agent-scoped:

```ts
function escalationCacheKey(runtime: IAgentRuntime): string {            // :60-62
  return `${ESCALATION_CACHE_KEY_PREFIX}:${runtime.agentId as string}`;
}
```

In a process that holds a second runtime, the two halves disagree:

1. Agent **B** calls `startEscalation(runtimeB, …)`.
2. `getActiveEscalationSync()` (`:588-594`) walks every entry with **no agent
   filter** and returns agent **A's** state.
3. The coalescing branch (`:413-422`) mutates A's state in place —
   `existing.reason += "; " + reason`, `existing.text += "\n---\n" + text` — and
   returns it as if it were B's.
4. `await persistState(runtime, existing)` (`:420`) writes **A's** state under
   **B's** cache key.

So B never gets an escalation, a delivery attempt, or a timer; B's cache row
names A's escalation id; and when A's timer fires, `checkEscalation` re-sends
`state.text` (`:539-546`) — now carrying B's text — on A's channels.

**Reachability.** Multi-agent boots are an explicit deployment shape in this
repo: `services/connector-credential-store.ts:52-53` — *"One state-dir vault per
process: PGlite is single-writer, and multi-agent boots construct one service
instance per runtime over the same data dir."* Sibling modules already scope work
to "THIS agent" for the same reason (`api/attachment-knowledge-backfill.ts:104`,
`providers/page-scoped-live-state.ts:472`) and `triggers/runtime.ts:73` keys its
module state by runtime with a `WeakMap`. Separately, even a single-agent process
can hold two runtimes: PGLite recovery calls
`shutdownRuntime(runtime, "PGLite recovery")` and re-enters `startEliza(...)`
in-process (`runtime/eliza.ts:5949-5965`), and nothing calls
`EscalationService._reset()` outside tests.

**The fix:** partition both maps by `runtime.agentId`, the same way
`escalationCacheKey` is partitioned, and take the runtime in
`getActiveEscalationSync`.

**Not a security boundary.** Owner contacts come from the process-global
`eliza.json` (`escalation.ts:173-180`, no runtime argument), so every agent in
the process escalates to the same operator. Nothing crosses a principal
boundary; this is a state-isolation correctness defect, and I am filing it as
one.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

# Documentation changes needed?

My changes do not require a change to the project documentation. The module
docstring at the top of `escalation.ts` said "one active escalation at a time";
it now says "one active escalation at a time PER AGENT", which is what the
persistence layer already implied.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

`packages/agent/src/services/escalation-agent-isolation.test.ts` — five cases,
two runtimes with distinct `agentId`s sharing one in-memory cache double. Four
are red on `origin/develop`; the fifth is the no-over-rejection guard and is
green on both trees.

## Detailed testing steps

```bash
bun install
node packages/shared/scripts/generate-keywords.mjs   # required before vitest
bunx vitest run \
  packages/agent/src/services/escalation-agent-isolation.test.ts \
  packages/agent/src/services/escalation-channels.test.ts \
  packages/agent/src/runtime/error-escalation.test.ts
```

At `422e58c15fcd1b038ab9eba7b7918093e7b57f0e`:

```
 Test Files  3 passed (3)
      Tests  40 passed (40)
```

### The defect, demonstrated by reverting only `escalation.ts`

`packages/agent/src/services/escalation.ts` was restored to its `origin/develop`
bytes by copy-aside (never `git stash`) and the new test file re-run unchanged:

```
 FAIL  … > a second agent gets its own escalation instead of coalescing into the first
       expected 'esc-1787354716438-1' not to be 'esc-1787354716438-1'
 FAIL  … > each agent's cache row holds that agent's own escalation
 FAIL  … > getActiveEscalationSync only reports the calling agent's escalation
       expected { id: 'esc-…-1', reason: 'reason A', text: 'agent A private text', … } to be null
 FAIL  … > resolving one agent's escalation leaves the other's active
       expected undefined to be 'esc-1787354716438-1'
  ✓    … > same-agent coalescing still folds a second reason into the active escalation

 Test Files  1 failed (1)
      Tests  4 failed | 1 passed (5)
```

The third failure is the whole defect in one line: asked for agent **B's**
active escalation, `origin/develop` hands back agent **A's** state object,
`text: "agent A private text"` and all.

### No over-rejection

The package's own suite for the three affected directories was run on this
branch and on an **untouched control at the same commit** (the four files
restored to their `origin/develop` bytes by copy-aside), same command, same
machine:

```bash
bunx vitest run packages/agent/src/services packages/agent/src/providers packages/agent/src/runtime
```

| | Test Files | Tests |
|---|---|---|
| control (untouched) | 17 failed \| 204 passed \| 2 skipped (223) | 9 failed \| 2004 passed \| 28 skipped (2041) |
| this branch | 17 failed \| 205 passed \| 2 skipped (224) | 9 failed \| 2009 passed \| 28 skipped (2046) |

`diff` of the two sorted `FAIL` file lists is **empty** — 17 files on each side,
identical. The only deltas are `+1` test file and `+5` tests, which are exactly
the new file. **Zero added failures.**

The 17 pre-existing failures are unrelated to escalation
(`relevant-conversations.pglite.integration`, `e2b-capability-router.*`,
`connector-credential-store.runtime`, `mobile-dns`, and 13 suites that fail to
collect); they fail identically without this diff.

### Typecheck

```bash
bun run --cwd packages/agent typecheck    # tsc --noEmit -p ./tsconfig.json
```

- Untouched control at the pre-rebase base `f9e7325`: **27** `error TS` lines.
- This branch at the pre-rebase base: **27** `error TS` lines, and `diff` of the
  two sorted error lists is **empty** — byte-identical error sets, zero added.
- This branch after rebasing onto `423aea3`: **24** `error TS` lines — the same
  set minus three `character-history.test.ts` errors that #24134 fixed
  upstream. Nothing added.

Every remaining error is a `TS2307 Cannot find module` for a workspace package
that is not built in this checkout (`@elizaos/plugin-video`,
`@elizaos/cloud-routing`, `@elizaos/plugin-capacitor-bridge/type-shims/*`, …),
plus three `optional-plugin-imports.generated.ts` entries. None are in a file
this PR touches.

### Lint

```bash
bunx @biomejs/biome check <the four touched files>
# Checked 4 files. No fixes applied.
```

### Source provenance

The branch is one commit parented directly on `423aea34a0d8`.
`git diff origin/develop..HEAD --stat` is exactly the four files below and
nothing else. `escalation.ts` is byte-identical at `f9e7325` and `423aea3`
(`diff` clean), so the pre-rebase measurements above describe the same file.

```
 packages/agent/src/providers/escalation-trigger.ts |   9 +-
 packages/agent/src/runtime/error-escalation.test.ts |   4 +-
 packages/agent/src/services/escalation-agent-isolation.test.ts | 161 +++++
 packages/agent/src/services/escalation.ts          | 126 ++++++++----
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:422e58c15fcd1b038ab9eba7b7918093e7b57f0e -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no UI surface; the diff is module-level
      state bookkeeping in one agent service plus tests.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no UI surface; the diff is module-level
      state bookkeeping in one agent service plus tests.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow. The observable behaviour is
      which agent's state a second startEscalation returns and which cache key it
      lands under, captured as the before/after test output below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — the real
      `startEscalation` / `persistState` / `getActiveEscalationSync` path driven
      by two runtimes with distinct `agentId`s, nothing inside `escalation.ts`
      stubbed. Repeated with full commentary under **Backend + frontend logs**.

<details>
<summary>origin/develop — agent B's startEscalation returns agent A's state</summary>

```
startEscalation(runtimeA, "reason A", "agent A private text") -> esc-1787355808824-1
startEscalation(runtimeB, "reason B", "agent B private text") -> esc-1787355808824-1
  sameObject = true
  A.reason = "reason A; reason B"  A.text = "agent A private text\n---\nagent B private text"
  B.reason = "reason A; reason B"  B.text = "agent A private text\n---\nagent B private text"
cache["agent:escalation:active:agent-a"] = {"id":"esc-1787355808824-1","reason":"reason A; reason B","text":"agent A private text\n---\nagent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355808824,"lastSentAt":1787355808824,"resolved":false}
cache["agent:escalation:active:agent-b"] = {"id":"esc-1787355808824-1","reason":"reason A; reason B","text":"agent A private text\n---\nagent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355808824,"lastSentAt":1787355808824,"resolved":false}
getActiveEscalationSync(runtimeA) -> {"id":"esc-1787355808824-1","reason":"reason A; reason B","text":"agent A private text\n---\nagent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355808824,"lastSentAt":1787355808824,"resolved":false}
getActiveEscalationSync(runtimeB) -> {"id":"esc-1787355808824-1","reason":"reason A; reason B","text":"agent A private text\n---\nagent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355808824,"lastSentAt":1787355808824,"resolved":false}
after resolveEscalation(A) -> A=null B=null
```

</details>

<details>
<summary>this branch — each agent keeps its own</summary>

```
startEscalation(runtimeA, "reason A", "agent A private text") -> esc-1787355786504-1
startEscalation(runtimeB, "reason B", "agent B private text") -> esc-1787355786509-2
  sameObject = false
  A.reason = "reason A"  A.text = "agent A private text"
  B.reason = "reason B"  B.text = "agent B private text"
cache["agent:escalation:active:agent-a"] = {"id":"esc-1787355786504-1","reason":"reason A","text":"agent A private text","currentStep":0,"channelsSent":[],"startedAt":1787355786504,"lastSentAt":1787355786504,"resolved":false}
cache["agent:escalation:active:agent-b"] = {"id":"esc-1787355786509-2","reason":"reason B","text":"agent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355786509,"lastSentAt":1787355786509,"resolved":false}
getActiveEscalationSync(runtimeA) -> {"id":"esc-1787355786504-1","reason":"reason A","text":"agent A private text","currentStep":0,"channelsSent":[],"startedAt":1787355786504,"lastSentAt":1787355786504,"resolved":false}
getActiveEscalationSync(runtimeB) -> {"id":"esc-1787355786509-2","reason":"reason B","text":"agent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355786509,"lastSentAt":1787355786509,"resolved":false}
after resolveEscalation(A) -> A=null B={"id":"esc-1787355786509-2","reason":"reason B","text":"agent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355786509,"lastSentAt":1787355786509,"resolved":false}
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path is
      involved; EscalationService runs on the agent side.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no action, provider prompt, or model call is
      touched. The escalation-trigger provider's signature changed but its
      prompt text did not; no LLM call can exercise the map partitioning.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the persisted `agent:escalation:active:<agentId>` cache
      rows written by `persistState` for both agents:

<details>
<summary>the two persisted cache rows, origin/develop vs this branch</summary>

```
--- origin/develop: agent B's key holds agent A's escalation id (esc-…-1) ---
cache["agent:escalation:active:agent-a"] = {"id":"esc-1787355808824-1","reason":"reason A; reason B","text":"agent A private text\n---\nagent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355808824,"lastSentAt":1787355808824,"resolved":false}
cache["agent:escalation:active:agent-b"] = {"id":"esc-1787355808824-1","reason":"reason A; reason B","text":"agent A private text\n---\nagent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355808824,"lastSentAt":1787355808824,"resolved":false}

--- this branch: each key holds its own agent's escalation (…-1 and …-2) ---
cache["agent:escalation:active:agent-a"] = {"id":"esc-1787355786504-1","reason":"reason A","text":"agent A private text","currentStep":0,"channelsSent":[],"startedAt":1787355786504,"lastSentAt":1787355786504,"resolved":false}
cache["agent:escalation:active:agent-b"] = {"id":"esc-1787355786509-2","reason":"reason B","text":"agent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355786509,"lastSentAt":1787355786509,"resolved":false}
```

</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

`N/A - no model call is involved. The diff partitions two module-level maps and
threads the runtime through one static method; the escalation-trigger provider's
emitted text is unchanged.`

## Backend + frontend logs

Frontend: `N/A - no frontend code path is involved.`

Backend: the real `EscalationService.startEscalation` → `persistState` path,
driven by two runtimes with distinct `agentId`s over one shared cache double.
Nothing inside `escalation.ts` is stubbed.

<details>
<summary>origin/develop — the second agent's escalation is absorbed</summary>

```
startEscalation(runtimeA, "reason A", "agent A private text") -> esc-1787355808824-1
startEscalation(runtimeB, "reason B", "agent B private text") -> esc-1787355808824-1
  sameObject = true
  A.reason = "reason A; reason B"  A.text = "agent A private text\n---\nagent B private text"
  B.reason = "reason A; reason B"  B.text = "agent A private text\n---\nagent B private text"
cache["agent:escalation:active:agent-a"] = {"id":"esc-1787355808824-1","reason":"reason A; reason B","text":"agent A private text\n---\nagent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355808824,"lastSentAt":1787355808824,"resolved":false}
cache["agent:escalation:active:agent-b"] = {"id":"esc-1787355808824-1","reason":"reason A; reason B","text":"agent A private text\n---\nagent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355808824,"lastSentAt":1787355808824,"resolved":false}
getActiveEscalationSync(runtimeA) -> {"id":"esc-1787355808824-1","reason":"reason A; reason B","text":"agent A private text\n---\nagent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355808824,"lastSentAt":1787355808824,"resolved":false}
getActiveEscalationSync(runtimeB) -> {"id":"esc-1787355808824-1","reason":"reason A; reason B","text":"agent A private text\n---\nagent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355808824,"lastSentAt":1787355808824,"resolved":false}
after resolveEscalation(A) -> A=null B=null
```

`sameObject = true`: the second `startEscalation` returned agent A's own state
object. `agent:escalation:active:agent-b` holds `esc-…-1` — **agent A's**
escalation id — and both agents' text. `resolveEscalation(A)` then clears the
active escalation for **both** agents, because there was only ever one.

</details>

<details>
<summary>this branch — each agent keeps its own</summary>

```
startEscalation(runtimeA, "reason A", "agent A private text") -> esc-1787355786504-1
startEscalation(runtimeB, "reason B", "agent B private text") -> esc-1787355786509-2
  sameObject = false
  A.reason = "reason A"  A.text = "agent A private text"
  B.reason = "reason B"  B.text = "agent B private text"
cache["agent:escalation:active:agent-a"] = {"id":"esc-1787355786504-1","reason":"reason A","text":"agent A private text","currentStep":0,"channelsSent":[],"startedAt":1787355786504,"lastSentAt":1787355786504,"resolved":false}
cache["agent:escalation:active:agent-b"] = {"id":"esc-1787355786509-2","reason":"reason B","text":"agent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355786509,"lastSentAt":1787355786509,"resolved":false}
getActiveEscalationSync(runtimeA) -> {"id":"esc-1787355786504-1","reason":"reason A","text":"agent A private text","currentStep":0,"channelsSent":[],"startedAt":1787355786504,"lastSentAt":1787355786504,"resolved":false}
getActiveEscalationSync(runtimeB) -> {"id":"esc-1787355786509-2","reason":"reason B","text":"agent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355786509,"lastSentAt":1787355786509,"resolved":false}
after resolveEscalation(A) -> A=null B={"id":"esc-1787355786509-2","reason":"reason B","text":"agent B private text","currentStep":0,"channelsSent":[],"startedAt":1787355786509,"lastSentAt":1787355786509,"resolved":false}
```

</details>

<details>
<summary>same-agent coalescing — byte-identical on both trees</summary>

`origin/develop`:

```
startEscalation(runtime, "reason 1", "first burst")  -> esc-1787355808839-1
startEscalation(runtime, "reason 2", "second burst") -> esc-1787355808839-1
  reason = "reason 1; reason 2"
  text   = "first burst\n---\nsecond burst"
```

this branch:

```
startEscalation(runtime, "reason 1", "first burst")  -> esc-1787355786510-1
startEscalation(runtime, "reason 2", "second burst") -> esc-1787355786510-1
  reason = "reason 1; reason 2"
  text   = "first burst\n---\nsecond burst"
```

Identical apart from the timestamp inside the generated id.

</details>

One honest caveat on the `origin/develop` block: the cache double stores the
value by reference rather than serializing it, so `agent-a`'s row is shown
already carrying the in-place mutation. A serializing cache adapter would leave
agent A's row at its pre-mutation value. What does not depend on that detail —
and is the actual defect — is that **`agent:escalation:active:agent-b` names
agent A's escalation id**, and that `getActiveEscalationSync(runtimeB)` returns
agent A's state.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

`N/A - no UI change. The diff is confined to two agent-side modules and two test
files; nothing rendered is affected.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT, or omnivoice code is touched.`

## Known gaps / failures

Everything below is stated as measured or not measured; nothing here is inferred.

- **No live two-agent boot was run.** The isolation is demonstrated with two
  `IAgentRuntime` doubles that differ only in `agentId`, sharing one cache map —
  not with two real runtimes over one PGlite data dir. I have not observed this
  in a live session and have no frequency estimate for it. What is measured is
  that the service's own logic does not distinguish the two runtimes.
- **`bun run verify` was not run in full.** The package vitest suite for
  `services`/`providers`/`runtime`, `tsc --noEmit` for `packages/agent`, and
  biome were run and are reported above with control comparisons; the repo-wide
  `verify` target (all packages, build, e2e) was not.
- **17 test files in the measured suite fail on `origin/develop` itself** and
  still fail here, identically. They are listed above; none are escalation
  files. I did not investigate them.
- **`packages/agent typecheck` is red on `origin/develop` too** — 24 unresolved
  workspace-module errors in this checkout. The comparison above is against a
  same-commit control, not against zero.
- **A second, distinct defect in the same file is not fixed here.**
  `startEscalation` only arms a timer when
  `channels.length > 1 || maxRetries > 1` (`:475-478`), so with one deliverable
  channel and `maxRetries: 1` the state stays `resolved: false` with no timer
  that could ever resolve it, and every later escalation coalesces into that
  dead entry. It is flagged in #24157 and left for its own change rather than
  bundled here.
- **`resolveEscalation` without a runtime still scans across agents.** That path
  is unreachable from the current repo (the only caller passes a runtime), but
  the signature allows it, so the fallback is deliberate rather than an
  oversight.
- **Hosted CI does not run on this PR.** It is filed from a fork, so no workflow
  result here should be read as a pass.
- **UI/frontend/LLM/audio evidence rows are marked `N/A`** for the reasons given
  inline on each row: this diff has no rendered surface and makes no model calls.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0KADM7BW6BXVJY69HSFY74E","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T23:27:41.803Z","completed_at":"2026-08-21T23:38:35.337Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T23:27:42.786Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"a86989b46fc29ab2630e16caac9586b541ff45e9b6af86f002293d3b45693642","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"1dbf2869-72ef-494d-af74-6a3773dae7df","object_id":"sha256:a86989b46fc29ab2630e16caac9586b541ff45e9b6af86f002293d3b45693642","sha256":"a86989b46fc29ab2630e16caac9586b541ff45e9b6af86f002293d3b45693642"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"uxSvtJHljwxBpGj6F_Eq3_42z8ijy4asn5fAducwoSNe9slx5xA_kbSqWa-l0ZDLvUN8IQT6bx0wx5aTY36PDQ"}} -->
