### PR TITLE
fix(app): reclaim the steward child when a lifecycle fails after the spawn

### DIFF
--- a/packages/app-core/platforms/electrobun/src/native/steward-stop-failure.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/steward-stop-failure.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Electrobun Steward reset contract when child termination cannot be proven.
+ * The native boundary must propagate the stop failure before deleting wallet
+ * state, so the renderer RPC rejects instead of reporting a fabricated reset.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const terminationError = Object.assign(
+    new Error("Steward child failed to confirm exit after SIGTERM and SIGKILL"),
+    { code: "STEWARD_CHILD_TERMINATION_FAILED" },
+  );
+  const sidecar = {
+    stop: vi.fn(async () => {
+      throw terminationError;
+    }),
+    restart: vi.fn(),
+    start: vi.fn(),
+    getStatus: vi.fn(() => ({ state: "error" })),
+    getCredentials: vi.fn(() => null),
+    getApiBase: vi.fn(() => "http://127.0.0.1:3200"),
+  };
+  return { sidecar, terminationError };
+});
+
+vi.mock("@elizaos/app-core", () => ({
+  createDesktopStewardSidecar: vi.fn(() => mocks.sidecar),
+}));
+
+vi.mock("../brand-config", () => ({
+  getBrandConfig: vi.fn(() => ({ namespace: "eliza" })),
+}));
+
+vi.mock("../logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { getStewardSidecar, resetSteward } from "./steward";
+
+let originalHome: string | undefined;
+let originalDataDir: string | undefined;
+let tempHome: string;
+let dataDir: string;
+let walletSentinel: string;
+
+beforeAll(async () => {
+  originalHome = process.env.HOME;
+  originalDataDir = process.env.STEWARD_DATA_DIR;
+  tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-steward-reset-"));
+  dataDir = path.join(tempHome, ".eliza", "steward");
+  walletSentinel = path.join(dataDir, "wallet-state");
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.writeFileSync(walletSentinel, "must survive", "utf8");
+  process.env.HOME = tempHome;
+  process.env.STEWARD_DATA_DIR = dataDir;
+  await getStewardSidecar();
+});
+
+afterAll(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalDataDir === undefined) delete process.env.STEWARD_DATA_DIR;
+  else process.env.STEWARD_DATA_DIR = originalDataDir;
+  fs.rmSync(tempHome, { recursive: true, force: true });
+});
+
+describe("Electrobun Steward reset after termination failure", () => {
+  it("rejects before deleting wallet state", async () => {
+    await expect(resetSteward()).rejects.toBe(mocks.terminationError);
+
+    expect(mocks.sidecar.stop).toHaveBeenCalledTimes(1);
+    expect(mocks.sidecar.start).not.toHaveBeenCalled();
+    expect(fs.readFileSync(walletSentinel, "utf8")).toBe("must survive");
+  });
+});

--- a/packages/app-core/src/services/steward-sidecar-failed-start-child.test.ts
+++ b/packages/app-core/src/services/steward-sidecar-failed-start-child.test.ts
@@ -230,6 +230,78 @@ describe("StewardSidecar: a lifecycle that fails after the spawn", () => {
     expect(status.pid).toBe(7001);
   });
 
+  it("runs the SIGTERM-to-SIGKILL ladder and recovery path for a Bun child", async () => {
+    vi.useFakeTimers();
+    vi.mocked(waitForHealthy).mockRejectedValueOnce(
+      new Error("health timeout"),
+    );
+    const firstChild = fakeBunChild(7100);
+    const secondChild = fakeBunChild(7101);
+    const bunSpawn = vi
+      .fn()
+      .mockReturnValueOnce(firstChild)
+      .mockReturnValueOnce(secondChild);
+    vi.stubGlobal("Bun", { spawn: bunSpawn });
+    const sidecar = makeSidecar();
+
+    const firstStart = sidecar.start();
+    const firstFailure = expect(firstStart).rejects.toMatchObject({
+      code: "STEWARD_START_CLEANUP_FAILED",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(firstChild.kill).toHaveBeenCalledWith("SIGTERM");
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(firstChild.kill).toHaveBeenCalledWith("SIGKILL");
+    await vi.advanceTimersByTimeAsync(5_000);
+    await firstFailure;
+
+    await expect(sidecar.start()).rejects.toMatchObject({
+      code: "STEWARD_CHILD_EXIT_UNCONFIRMED",
+    });
+    expect(bunSpawn).toHaveBeenCalledTimes(1);
+
+    firstChild.kill.mockImplementation((signal?: string) => {
+      queueMicrotask(() => firstChild.exit(signal === "SIGKILL" ? 137 : 143));
+      return true;
+    });
+    vi.mocked(waitForHealthy).mockResolvedValue(undefined);
+
+    const recovered = await sidecar.restart();
+    expect(firstChild.kill).toHaveBeenLastCalledWith("SIGTERM");
+    expect(bunSpawn).toHaveBeenCalledTimes(2);
+    expect(recovered).toMatchObject({ state: "running", pid: 7101 });
+  });
+
+  it("reclaims a Bun child when a crash-restart health check fails", async () => {
+    vi.useFakeTimers();
+    const firstChild = fakeBunChild(7200);
+    const secondChild = fakeBunChild(7201);
+    secondChild.kill.mockImplementation((signal?: string) => {
+      queueMicrotask(() => secondChild.exit(signal === "SIGKILL" ? 137 : 143));
+      return true;
+    });
+    const bunSpawn = vi
+      .fn()
+      .mockReturnValueOnce(firstChild)
+      .mockReturnValueOnce(secondChild);
+    vi.stubGlobal("Bun", { spawn: bunSpawn });
+    const sidecar = makeSidecar();
+
+    await sidecar.start();
+    vi.mocked(waitForHealthy).mockRejectedValue(new Error("health timeout"));
+    firstChild.exit(1);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(bunSpawn).toHaveBeenCalledTimes(2);
+    expect(secondChild.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(sidecar.getStatus()).toMatchObject({
+      state: "error",
+      pid: null,
+      restartCount: 1,
+    });
+  });
+
   it("escalates to SIGKILL when SIGTERM does not produce an exit", async () => {
     vi.useFakeTimers();
     vi.mocked(waitForHealthy).mockRejectedValue(new Error("health timeout"));
@@ -285,6 +357,27 @@ describe("StewardSidecar: a lifecycle that fails after the spawn", () => {
       code: "STEWARD_CHILD_EXIT_UNCONFIRMED",
     });
     expect(spawnedChildren).toHaveLength(1);
+
+    const restart = sidecar.restart();
+    const restartFailure = expect(restart).rejects.toMatchObject({
+      code: "STEWARD_CHILD_TERMINATION_FAILED",
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await restartFailure;
+    expect(spawnedChildren).toHaveLength(1);
+
+    spawnedChildren[0].kill.mockImplementation((signal?: string) => {
+      queueMicrotask(() =>
+        spawnedChildren[0].exit(signal === "SIGKILL" ? 137 : 143),
+      );
+      return true;
+    });
+    vi.mocked(waitForHealthy).mockResolvedValue(undefined);
+
+    const recovered = await sidecar.restart();
+    expect(spawnedChildren).toHaveLength(2);
+    expect(recovered.state).toBe("running");
   });
 
   it("does not read the reclaimed child's exit as a crash", async () => {

--- a/packages/app-core/src/services/steward-sidecar-failed-start-child.test.ts
+++ b/packages/app-core/src/services/steward-sidecar-failed-start-child.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Steward child-process ownership when a lifecycle fails AFTER the spawn.
+ *
+ * `spawnProcess` publishes `this.process` as soon as the child exists, which is
+ * before `waitForHealthy` and `ensureWalletSetup` run. `stop()` is the only
+ * other path that kills the child, and the failing lifecycle never calls it —
+ * so before this fix a failed start left a live steward bound to the port with
+ * the wallet database open, and the next `start()` overwrote the only reference
+ * to it. These pin that the child is reclaimed instead, and that reclaiming it
+ * is not mistaken for a crash.
+ */
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./steward-sidecar/helpers", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./steward-sidecar/helpers")>();
+  return {
+    ...actual,
+    allocateFirstFreeLoopbackPort: vi.fn(async (port: number) => port),
+  };
+});
+
+vi.mock("./steward-sidecar/process-management", () => ({
+  findStewardEntryPoint: vi.fn(async () => "/fake/entry.js"),
+  pipeOutput: vi.fn(),
+}));
+
+vi.mock("./steward-sidecar/health-check", () => ({
+  waitForHealthy: vi.fn(async () => undefined),
+}));
+
+vi.mock("./steward-sidecar/wallet-setup", () => ({
+  ensureWalletSetup: vi.fn(async () => ({
+    tenantId: "tenant",
+    tenantApiKey: "tenant-key",
+    agentId: "agent",
+    agentToken: "agent-token",
+    walletAddress: "0x1234",
+  })),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawn: vi.fn() };
+});
+
+import * as childProcess from "node:child_process";
+import { StewardSidecar } from "./steward-sidecar";
+import { waitForHealthy } from "./steward-sidecar/health-check";
+import { ensureWalletSetup } from "./steward-sidecar/wallet-setup";
+
+type FakeChild = EventEmitter & {
+  kill: ReturnType<typeof vi.fn>;
+  stdout: null;
+  stderr: null;
+  pid: number;
+};
+
+/** Every child handed to the sidecar during one test, in spawn order. */
+let spawnedChildren: FakeChild[];
+
+function fakeChild(pid: number): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.kill = vi.fn();
+  child.stdout = null;
+  child.stderr = null;
+  child.pid = pid;
+  return child;
+}
+
+beforeEach(() => {
+  // Force the Node child_process branch regardless of the runtime this suite
+  // happens to execute under.
+  vi.stubGlobal("Bun", undefined);
+  spawnedChildren = [];
+  vi.mocked(childProcess.spawn).mockImplementation((() => {
+    const child = fakeChild(5000 + spawnedChildren.length);
+    spawnedChildren.push(child);
+    return child as unknown as ReturnType<typeof childProcess.spawn>;
+  }) as unknown as typeof childProcess.spawn);
+  vi.mocked(waitForHealthy).mockResolvedValue(undefined);
+  vi.mocked(ensureWalletSetup).mockResolvedValue({
+    tenantId: "tenant",
+    tenantApiKey: "tenant-key",
+    agentId: "agent",
+    agentToken: "agent-token",
+    walletAddress: "0x1234",
+  } as Awaited<ReturnType<typeof ensureWalletSetup>>);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function makeSidecar() {
+  return new StewardSidecar({
+    dataDir: "/tmp/steward-sidecar-failed-start-test",
+    stewardEntryPoint: "/fake/entry.js",
+  });
+}
+
+async function expectStartToFail(sidecar: StewardSidecar) {
+  await expect(sidecar.start()).rejects.toThrow();
+}
+
+describe("StewardSidecar: a lifecycle that fails after the spawn", () => {
+  it("kills the child when the health check never succeeds", async () => {
+    vi.mocked(waitForHealthy).mockRejectedValue(new Error("health timeout"));
+    const sidecar = makeSidecar();
+
+    await expectStartToFail(sidecar);
+
+    expect(spawnedChildren).toHaveLength(1);
+    expect(spawnedChildren[0].kill).toHaveBeenCalledWith("SIGTERM");
+    expect(sidecar.getStatus().state).toBe("error");
+    expect(sidecar.getStatus().pid).toBeNull();
+  });
+
+  it("kills the child when wallet setup fails", async () => {
+    vi.mocked(ensureWalletSetup).mockRejectedValue(new Error("wallet failed"));
+    const sidecar = makeSidecar();
+
+    await expectStartToFail(sidecar);
+
+    expect(spawnedChildren).toHaveLength(1);
+    expect(spawnedChildren[0].kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("does not strand the first child when start is retried after a failure", async () => {
+    // `startSteward()` only skips when the state is "running", so a retry after
+    // a failed start reaches spawnProcess again. Before the fix that overwrote
+    // the only reference to the first child, which then outlived the app.
+    vi.mocked(waitForHealthy).mockRejectedValueOnce(
+      new Error("health timeout"),
+    );
+    const sidecar = makeSidecar();
+
+    await expectStartToFail(sidecar);
+    const status = await sidecar.start();
+
+    expect(spawnedChildren).toHaveLength(2);
+    expect(spawnedChildren[0].kill).toHaveBeenCalledWith("SIGTERM");
+    expect(status.state).toBe("running");
+  });
+
+  it("does not read the reclaimed child's exit as a crash", async () => {
+    vi.useFakeTimers();
+    vi.mocked(waitForHealthy).mockRejectedValue(new Error("health timeout"));
+    const sidecar = makeSidecar();
+
+    await expectStartToFail(sidecar);
+    expect(spawnedChildren).toHaveLength(1);
+
+    // The child now exits because we killed it. That must not enter the
+    // restart backoff and spawn a replacement.
+    spawnedChildren[0].emit("exit", 143);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(spawnedChildren).toHaveLength(1);
+    expect(sidecar.getStatus().state).toBe("error");
+    expect(sidecar.getStatus().restartCount).toBe(0);
+  });
+
+  it("kills the child when a crash-restart attempt fails its health check", async () => {
+    vi.useFakeTimers();
+    const sidecar = makeSidecar();
+
+    await sidecar.start();
+    expect(spawnedChildren).toHaveLength(1);
+
+    // The running child crashes; the restart attempt then fails to come up.
+    vi.mocked(waitForHealthy).mockRejectedValue(new Error("health timeout"));
+    spawnedChildren[0].emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(spawnedChildren).toHaveLength(2);
+    expect(spawnedChildren[1].kill).toHaveBeenCalledWith("SIGTERM");
+    expect(sidecar.getStatus().state).toBe("error");
+  });
+
+  it("leaves a healthy start untouched", async () => {
+    const sidecar = makeSidecar();
+
+    const status = await sidecar.start();
+
+    expect(status.state).toBe("running");
+    expect(spawnedChildren).toHaveLength(1);
+    expect(spawnedChildren[0].kill).not.toHaveBeenCalled();
+    expect(status.pid).toBe(5000);
+  });
+
+  it("still kills the child on an explicit stop after a healthy start", async () => {
+    const sidecar = makeSidecar();
+
+    await sidecar.start();
+    const stopped = sidecar.stop();
+    spawnedChildren[0].emit("exit", 0);
+    await stopped;
+
+    expect(spawnedChildren[0].kill).toHaveBeenCalledWith("SIGTERM");
+    expect(sidecar.getStatus().state).toBe("stopped");
+  });
+});

--- a/packages/app-core/src/services/steward-sidecar-failed-start-child.test.ts
+++ b/packages/app-core/src/services/steward-sidecar-failed-start-child.test.ts
@@ -55,17 +55,57 @@ type FakeChild = EventEmitter & {
   stdout: null;
   stderr: null;
   pid: number;
+  exit: (code: number) => void;
+};
+
+type FakeBunChild = {
+  kill: ReturnType<typeof vi.fn>;
+  stdout: null;
+  stderr: null;
+  pid: number;
+  exited: Promise<number>;
+  exit: (code: number) => void;
 };
 
 /** Every child handed to the sidecar during one test, in spawn order. */
 let spawnedChildren: FakeChild[];
+let configureNextChild: ((child: FakeChild) => void) | null;
 
 function fakeChild(pid: number): FakeChild {
   const child = new EventEmitter() as FakeChild;
-  child.kill = vi.fn();
+  let exited = false;
+  child.exit = (code: number) => {
+    if (exited) return;
+    exited = true;
+    child.emit("exit", code);
+  };
+  child.kill = vi.fn((signal?: string) => {
+    queueMicrotask(() => child.exit(signal === "SIGKILL" ? 137 : 143));
+    return true;
+  });
   child.stdout = null;
   child.stderr = null;
   child.pid = pid;
+  return child;
+}
+
+function fakeBunChild(pid: number): FakeBunChild {
+  let resolveExit!: (code: number) => void;
+  let exited = false;
+  const child: FakeBunChild = {
+    kill: vi.fn(() => true),
+    stdout: null,
+    stderr: null,
+    pid,
+    exited: new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    }),
+    exit: (code: number) => {
+      if (exited) return;
+      exited = true;
+      resolveExit(code);
+    },
+  };
   return child;
 }
 
@@ -74,8 +114,11 @@ beforeEach(() => {
   // happens to execute under.
   vi.stubGlobal("Bun", undefined);
   spawnedChildren = [];
+  configureNextChild = null;
   vi.mocked(childProcess.spawn).mockImplementation((() => {
     const child = fakeChild(5000 + spawnedChildren.length);
+    configureNextChild?.(child);
+    configureNextChild = null;
     spawnedChildren.push(child);
     return child as unknown as ReturnType<typeof childProcess.spawn>;
   }) as unknown as typeof childProcess.spawn);
@@ -146,6 +189,104 @@ describe("StewardSidecar: a lifecycle that fails after the spawn", () => {
     expect(status.state).toBe("running");
   });
 
+  it("serializes a retry until the Bun child confirms its delayed exit", async () => {
+    vi.mocked(waitForHealthy).mockRejectedValueOnce(
+      new Error("health timeout"),
+    );
+    const firstChild = fakeBunChild(7000);
+    const secondChild = fakeBunChild(7001);
+    secondChild.kill.mockImplementation((signal?: string) => {
+      queueMicrotask(() => secondChild.exit(signal === "SIGKILL" ? 137 : 143));
+      return true;
+    });
+    const bunSpawn = vi
+      .fn()
+      .mockReturnValueOnce(firstChild)
+      .mockReturnValueOnce(secondChild);
+    vi.stubGlobal("Bun", { spawn: bunSpawn });
+    const sidecar = makeSidecar();
+
+    const firstStart = sidecar.start();
+    const firstFailure = expect(firstStart).rejects.toThrow("health timeout");
+    await vi.waitFor(() => {
+      expect(firstChild.kill).toHaveBeenCalledWith("SIGTERM");
+    });
+
+    const overlappingRetry = sidecar.start();
+    const retryFailure =
+      expect(overlappingRetry).rejects.toThrow("health timeout");
+    await Promise.resolve();
+    expect(bunSpawn).toHaveBeenCalledTimes(1);
+    expect(sidecar.getStatus().pid).toBe(7000);
+
+    firstChild.exit(143);
+    await firstFailure;
+    await retryFailure;
+    expect(sidecar.getStatus().pid).toBeNull();
+
+    const status = await sidecar.start();
+    expect(bunSpawn).toHaveBeenCalledTimes(2);
+    expect(status.state).toBe("running");
+    expect(status.pid).toBe(7001);
+  });
+
+  it("escalates to SIGKILL when SIGTERM does not produce an exit", async () => {
+    vi.useFakeTimers();
+    vi.mocked(waitForHealthy).mockRejectedValue(new Error("health timeout"));
+    configureNextChild = (child) => {
+      child.kill.mockImplementation((signal?: string) => {
+        if (signal === "SIGKILL") {
+          queueMicrotask(() => child.exit(137));
+        }
+        return true;
+      });
+    };
+    const sidecar = makeSidecar();
+
+    const start = sidecar.start();
+    const failure = expect(start).rejects.toThrow("health timeout");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(spawnedChildren[0].kill).toHaveBeenCalledWith("SIGTERM");
+    expect(sidecar.getStatus().pid).toBe(5000);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await failure;
+    expect(spawnedChildren[0].kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+    expect(sidecar.getStatus().pid).toBeNull();
+  });
+
+  it("retains an unconfirmed child and blocks another start", async () => {
+    vi.useFakeTimers();
+    vi.mocked(waitForHealthy).mockRejectedValue(new Error("health timeout"));
+    configureNextChild = (child) => {
+      child.kill.mockImplementation(() => {
+        throw new Error("kill syscall failed");
+      });
+    };
+    const sidecar = makeSidecar();
+
+    const start = sidecar.start();
+    const failure = expect(start).rejects.toMatchObject({
+      code: "STEWARD_START_CLEANUP_FAILED",
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await failure;
+
+    expect(spawnedChildren[0].kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+    expect(spawnedChildren[0].kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+    expect(sidecar.getStatus()).toMatchObject({
+      state: "error",
+      pid: 5000,
+      error:
+        "Steward startup failed and spawned-child cleanup did not complete",
+    });
+    await expect(sidecar.start()).rejects.toMatchObject({
+      code: "STEWARD_CHILD_EXIT_UNCONFIRMED",
+    });
+    expect(spawnedChildren).toHaveLength(1);
+  });
+
   it("does not read the reclaimed child's exit as a crash", async () => {
     vi.useFakeTimers();
     vi.mocked(waitForHealthy).mockRejectedValue(new Error("health timeout"));
@@ -154,9 +295,8 @@ describe("StewardSidecar: a lifecycle that fails after the spawn", () => {
     await expectStartToFail(sidecar);
     expect(spawnedChildren).toHaveLength(1);
 
-    // The child now exits because we killed it. That must not enter the
+    // The child exits because cleanup killed it. That must not enter the
     // restart backoff and spawn a replacement.
-    spawnedChildren[0].emit("exit", 143);
     await vi.advanceTimersByTimeAsync(60_000);
 
     expect(spawnedChildren).toHaveLength(1);
@@ -173,7 +313,7 @@ describe("StewardSidecar: a lifecycle that fails after the spawn", () => {
 
     // The running child crashes; the restart attempt then fails to come up.
     vi.mocked(waitForHealthy).mockRejectedValue(new Error("health timeout"));
-    spawnedChildren[0].emit("exit", 1);
+    spawnedChildren[0].exit(1);
     await vi.advanceTimersByTimeAsync(60_000);
 
     expect(spawnedChildren).toHaveLength(2);
@@ -196,9 +336,7 @@ describe("StewardSidecar: a lifecycle that fails after the spawn", () => {
     const sidecar = makeSidecar();
 
     await sidecar.start();
-    const stopped = sidecar.stop();
-    spawnedChildren[0].emit("exit", 0);
-    await stopped;
+    await sidecar.stop();
 
     expect(spawnedChildren[0].kill).toHaveBeenCalledWith("SIGTERM");
     expect(sidecar.getStatus().state).toBe("stopped");

--- a/packages/app-core/src/services/steward-sidecar-real-child.test.ts
+++ b/packages/app-core/src/services/steward-sidecar-real-child.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Integration proof that failed-start cleanup terminates an actual OS child.
+ * Only health and wallet collaborators are substituted; node:child_process is
+ * real, and the assertion probes the spawned PID after the lifecycle rejects.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./steward-sidecar/helpers", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./steward-sidecar/helpers")>();
+  return {
+    ...actual,
+    allocateFirstFreeLoopbackPort: vi.fn(async (port: number) => port),
+  };
+});
+
+vi.mock("./steward-sidecar/health-check", () => ({
+  waitForHealthy: vi.fn(async () => {
+    throw new Error("integration health failure");
+  }),
+}));
+
+vi.mock("./steward-sidecar/wallet-setup", () => ({
+  ensureWalletSetup: vi.fn(),
+}));
+
+import { StewardSidecar } from "./steward-sidecar";
+
+let observedPid: number | null = null;
+let tempDir: string | null = null;
+
+function processStillExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  if (observedPid && processStillExists(observedPid)) {
+    process.kill(observedPid, "SIGKILL");
+  }
+  if (tempDir) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+  observedPid = null;
+  tempDir = null;
+});
+
+describe("StewardSidecar real child cleanup", () => {
+  it("leaves no live OS process after a post-spawn health failure", async () => {
+    vi.stubGlobal("Bun", undefined);
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-steward-child-"));
+    const childEntry = path.join(tempDir, "child.mjs");
+    fs.writeFileSync(childEntry, "setInterval(() => {}, 1_000);\n", "utf8");
+
+    const sidecar = new StewardSidecar({
+      dataDir: path.join(tempDir, "state"),
+      stewardEntryPoint: childEntry,
+      onStatusChange: (status) => {
+        if (status.pid !== null) observedPid = status.pid;
+      },
+    });
+
+    await expect(sidecar.start()).rejects.toThrow("integration health failure");
+
+    expect(observedPid).not.toBeNull();
+    expect(processStillExists(observedPid as number)).toBe(false);
+    expect(sidecar.getStatus()).toMatchObject({ state: "error", pid: null });
+  });
+});

--- a/packages/app-core/src/services/steward-sidecar.ts
+++ b/packages/app-core/src/services/steward-sidecar.ts
@@ -92,6 +92,11 @@ function getBunRuntime(): BunRuntimeLike | null {
   return (globalThis as { Bun?: BunRuntimeLike }).Bun ?? null;
 }
 
+/**
+ * Each signal gets its own grace period: SIGTERM may take 5s, then SIGKILL may
+ * take another 5s. Stop/reset stay blocked for at most 10s while the sidecar
+ * proves the child released its port and wallet database.
+ */
 const PROCESS_TERMINATION_GRACE_MS = 5_000;
 
 /** The spawned steward child, normalized across the Bun and Node spawn paths. */

--- a/packages/app-core/src/services/steward-sidecar.ts
+++ b/packages/app-core/src/services/steward-sidecar.ts
@@ -28,7 +28,7 @@
 import * as childProcess from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { logger } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import { readAliasedEnv } from "@elizaos/shared";
 import { waitForHealthy } from "./steward-sidecar/health-check";
 import {
@@ -92,13 +92,19 @@ function getBunRuntime(): BunRuntimeLike | null {
   return (globalThis as { Bun?: BunRuntimeLike }).Bun ?? null;
 }
 
+const PROCESS_TERMINATION_GRACE_MS = 5_000;
+
 /** The spawned steward child, normalized across the Bun and Node spawn paths. */
 type StewardProcessHandle = {
-  kill: (signal?: string) => void;
+  kill: (signal?: string) => unknown;
   pid?: number | null;
   exitCode?: number | null;
-  exited?: Promise<number>;
+  exited: Promise<number>;
 };
+
+type ProcessExitWaitResult =
+  | { exited: true }
+  | { exited: false; error?: unknown };
 
 // ---------------------------------------------------------------------------
 // StewardSidecar
@@ -117,6 +123,11 @@ export class StewardSidecar {
    * must not start the restart backoff.
    */
   private discardedProcesses = new WeakSet<StewardProcessHandle>();
+  /** One termination sequence owns a handle even when stop races failed start. */
+  private terminationPromises = new WeakMap<
+    StewardProcessHandle,
+    Promise<void>
+  >();
   private stopping = false;
   private lifecycleGeneration = 0;
   private startPromise: Promise<StewardSidecarStatus> | null = null;
@@ -159,6 +170,19 @@ export class StewardSidecar {
 
     if (this.startPromise) {
       return this.startPromise;
+    }
+
+    if (this.process) {
+      const error = new ElizaError(
+        "Cannot start Steward while the previous child has not confirmed exit",
+        {
+          code: "STEWARD_CHILD_EXIT_UNCONFIRMED",
+          context: { pid: this.process.pid ?? null },
+          severity: "fatal",
+        },
+      );
+      this.updateStatus({ state: "error", error: error.message });
+      throw error;
     }
 
     const generation = ++this.lifecycleGeneration;
@@ -224,9 +248,37 @@ export class StewardSidecar {
 
       return this.status;
     } catch (err) {
-      this.discardSpawnedProcess(spawned);
+      let cleanupError: unknown = null;
+      try {
+        await this.discardSpawnedProcess(spawned, "failed start");
+      } catch (error) {
+        // error-policy:J2 the startup boundary below preserves both the
+        // lifecycle failure and the child-cleanup failure in one typed cause.
+        cleanupError = error;
+      }
       if (!this.isLifecycleActive(generation)) {
+        if (cleanupError) {
+          // error-policy:J6 stop/supersession owns the visible lifecycle state,
+          // but a concurrent cleanup failure must still be observable.
+          logger.warn(
+            { error: cleanupError, generation },
+            "[StewardSidecar] Spawned-child cleanup failed after the start lifecycle was superseded",
+          );
+        }
         return this.status;
+      }
+      if (cleanupError) {
+        const error = new ElizaError(
+          "Steward startup failed and spawned-child cleanup did not complete",
+          {
+            code: "STEWARD_START_CLEANUP_FAILED",
+            cause: new AggregateError([err, cleanupError]),
+            context: { generation, pid: spawned?.pid ?? null },
+            severity: "fatal",
+          },
+        );
+        this.updateStatus({ state: "error", error: error.message });
+        throw error;
       }
       const error = err instanceof Error ? err.message : String(err);
       this.updateStatus({ state: "error", error, pid: null });
@@ -253,21 +305,13 @@ export class StewardSidecar {
     const processToStop = this.process;
     if (processToStop) {
       try {
-        processToStop.kill("SIGTERM");
-        const timeout = setTimeout(() => {
-          try {
-            processToStop.kill("SIGKILL");
-          } catch {
-            // already dead
-          }
-        }, 5_000);
-
-        if (processToStop.exited) {
-          await processToStop.exited;
-        }
-        clearTimeout(timeout);
-      } catch {
-        // process already dead
+        await this.terminateProcess(processToStop, "explicit stop");
+      } catch (error) {
+        // error-policy:J1 the public lifecycle boundary reports an explicit
+        // failed stop and retains the unconfirmed child for a later retry.
+        const message = error instanceof Error ? error.message : String(error);
+        this.updateStatus({ state: "error", error: message });
+        throw error;
       }
       if (this.process === processToStop) {
         this.process = null;
@@ -455,14 +499,7 @@ export class StewardSidecar {
       pipeOutput(proc.stdout, "stdout", this.config.onLog);
       pipeOutput(proc.stderr, "stderr", this.config.onLog);
 
-      proc.exited.then((code: number) => {
-        if (!this.stopping && !this.discardedProcesses.has(proc)) {
-          logger.warn(
-            `[StewardSidecar] Process exited unexpectedly (code ${code})`,
-          );
-          void this.handleCrash(code);
-        }
-      });
+      proc.exited.then((code: number) => this.observeProcessExit(proc, code));
     } else {
       const child = childProcess.spawn("node", [entryPoint], {
         env,
@@ -504,14 +541,7 @@ export class StewardSidecar {
         });
       }
 
-      exitPromise.then((code) => {
-        if (!this.stopping && !this.discardedProcesses.has(handle)) {
-          logger.warn(
-            `[StewardSidecar] Process exited unexpectedly (code ${code})`,
-          );
-          void this.handleCrash(code);
-        }
-      });
+      exitPromise.then((code) => this.observeProcessExit(handle, code));
     }
 
     return true;
@@ -576,8 +606,40 @@ export class StewardSidecar {
           error: null,
         });
       } catch (err) {
-        this.discardSpawnedProcess(spawned);
+        let cleanupError: unknown = null;
+        try {
+          await this.discardSpawnedProcess(spawned, "failed crash restart");
+        } catch (error) {
+          // error-policy:J1 this background restart boundary publishes both
+          // failures as one visible terminal status and structured log.
+          cleanupError = error;
+        }
         if (!this.isLifecycleActive(generation)) {
+          if (cleanupError) {
+            // error-policy:J6 stop/supersession owns the visible lifecycle
+            // state, but its concurrent cleanup failure remains observable.
+            logger.warn(
+              { error: cleanupError, generation },
+              "[StewardSidecar] Spawned-child cleanup failed after the restart lifecycle was superseded",
+            );
+          }
+          return;
+        }
+        if (cleanupError) {
+          const error = new ElizaError(
+            "Steward restart failed and spawned-child cleanup did not complete",
+            {
+              code: "STEWARD_RESTART_CLEANUP_FAILED",
+              cause: new AggregateError([err, cleanupError]),
+              context: { generation, pid: spawned?.pid ?? null },
+              severity: "fatal",
+            },
+          );
+          logger.error(
+            { error },
+            "[StewardSidecar] Crash restart cleanup failed",
+          );
+          this.updateStatus({ state: "error", error: error.message });
           return;
         }
         const error = err instanceof Error ? err.message : String(err);
@@ -604,17 +666,150 @@ export class StewardSidecar {
    * `this.process`, and it is recorded as discarded so its exit is not read as
    * a crash and does not start the restart backoff.
    */
-  private discardSpawnedProcess(spawned: StewardProcessHandle | null): void {
+  private async discardSpawnedProcess(
+    spawned: StewardProcessHandle | null,
+    reason: string,
+  ): Promise<void> {
     if (!spawned || this.process !== spawned) {
       return;
     }
     this.discardedProcesses.add(spawned);
-    try {
-      spawned.kill("SIGTERM");
-    } catch {
-      // Already dead — nothing to reclaim.
+    await this.terminateProcess(spawned, reason);
+    if (this.process === spawned) {
+      this.process = null;
+    }
+  }
+
+  private observeProcessExit(
+    processHandle: StewardProcessHandle,
+    exitCode: number,
+  ): void {
+    if (this.process !== processHandle) {
+      return;
     }
     this.process = null;
+    if (!this.stopping && !this.discardedProcesses.has(processHandle)) {
+      logger.warn(
+        `[StewardSidecar] Process exited unexpectedly (code ${exitCode})`,
+      );
+      void this.handleCrash(exitCode);
+    }
+  }
+
+  private async terminateProcess(
+    processHandle: StewardProcessHandle,
+    reason: string,
+  ): Promise<void> {
+    const existing = this.terminationPromises.get(processHandle);
+    if (existing) {
+      return existing;
+    }
+
+    const termination = this.terminateProcessOnce(processHandle, reason);
+    this.terminationPromises.set(processHandle, termination);
+    try {
+      await termination;
+    } finally {
+      if (this.terminationPromises.get(processHandle) === termination) {
+        this.terminationPromises.delete(processHandle);
+      }
+    }
+  }
+
+  private async terminateProcessOnce(
+    processHandle: StewardProcessHandle,
+    reason: string,
+  ): Promise<void> {
+    const errors: unknown[] = [];
+    this.requestTerminationSignal(processHandle, "SIGTERM", reason, errors);
+
+    let exit = await this.waitForProcessExit(processHandle);
+    if (exit.exited) {
+      return;
+    }
+    if (exit.error) {
+      errors.push(exit.error);
+    }
+    errors.push(
+      new Error(
+        `Steward child did not exit within ${PROCESS_TERMINATION_GRACE_MS}ms of SIGTERM`,
+      ),
+    );
+
+    this.requestTerminationSignal(processHandle, "SIGKILL", reason, errors);
+    exit = await this.waitForProcessExit(processHandle);
+    if (exit.exited) {
+      return;
+    }
+    if (exit.error) {
+      errors.push(exit.error);
+    }
+    errors.push(
+      new Error(
+        `Steward child did not exit within ${PROCESS_TERMINATION_GRACE_MS}ms of SIGKILL`,
+      ),
+    );
+
+    throw new ElizaError(
+      "Steward child failed to confirm exit after SIGTERM and SIGKILL",
+      {
+        code: "STEWARD_CHILD_TERMINATION_FAILED",
+        cause: new AggregateError(errors),
+        context: { pid: processHandle.pid ?? null, reason },
+        severity: "fatal",
+      },
+    );
+  }
+
+  private requestTerminationSignal(
+    processHandle: StewardProcessHandle,
+    signal: "SIGTERM" | "SIGKILL",
+    reason: string,
+    errors: unknown[],
+  ): void {
+    try {
+      const delivered = processHandle.kill(signal);
+      if (delivered === false) {
+        const error = new Error(`Steward child rejected ${signal}`);
+        errors.push(error);
+        logger.warn(
+          { error, pid: processHandle.pid ?? null, reason, signal },
+          "[StewardSidecar] Child termination signal was not delivered",
+        );
+      }
+    } catch (error) {
+      // error-policy:J6 a failed signal request is recorded and the bounded
+      // termination ladder continues; an unconfirmed exit throws below.
+      errors.push(error);
+      logger.warn(
+        { error, pid: processHandle.pid ?? null, reason, signal },
+        "[StewardSidecar] Child termination signal failed",
+      );
+    }
+  }
+
+  private async waitForProcessExit(
+    processHandle: StewardProcessHandle,
+  ): Promise<ProcessExitWaitResult> {
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    try {
+      return await Promise.race([
+        processHandle.exited.then(
+          (): ProcessExitWaitResult => ({ exited: true }),
+          (error: unknown): ProcessExitWaitResult => ({ exited: false, error }),
+        ),
+        new Promise<ProcessExitWaitResult>((resolve) => {
+          timeout = setTimeout(
+            () => resolve({ exited: false }),
+            PROCESS_TERMINATION_GRACE_MS,
+          );
+        }),
+      ]);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
   }
 
   private isLifecycleActive(generation: number): boolean {

--- a/packages/app-core/src/services/steward-sidecar.ts
+++ b/packages/app-core/src/services/steward-sidecar.ts
@@ -92,6 +92,14 @@ function getBunRuntime(): BunRuntimeLike | null {
   return (globalThis as { Bun?: BunRuntimeLike }).Bun ?? null;
 }
 
+/** The spawned steward child, normalized across the Bun and Node spawn paths. */
+type StewardProcessHandle = {
+  kill: (signal?: string) => void;
+  pid?: number | null;
+  exitCode?: number | null;
+  exited?: Promise<number>;
+};
+
 // ---------------------------------------------------------------------------
 // StewardSidecar
 // ---------------------------------------------------------------------------
@@ -102,12 +110,13 @@ export class StewardSidecar {
   > &
     StewardSidecarConfig;
   private status: StewardSidecarStatus;
-  private process: {
-    kill: (signal?: string) => void;
-    pid?: number | null;
-    exitCode?: number | null;
-    exited?: Promise<number>;
-  } | null = null;
+  private process: StewardProcessHandle | null = null;
+  /**
+   * Handles this class killed on purpose because their lifecycle failed after
+   * the spawn. Their exit is expected, so it must not be read as a crash and
+   * must not start the restart backoff.
+   */
+  private discardedProcesses = new WeakSet<StewardProcessHandle>();
   private stopping = false;
   private lifecycleGeneration = 0;
   private startPromise: Promise<StewardSidecarStatus> | null = null;
@@ -171,12 +180,15 @@ export class StewardSidecar {
     this.stopping = false;
     this.updateStatus({ state: "starting", error: null });
 
+    let spawned: StewardProcessHandle | null = null;
+
     try {
       await this.ensureDataDir();
       await this.loadOrCreateCredentials();
       if (!(await this.spawnProcess(generation))) {
         return this.status;
       }
+      spawned = this.process;
 
       const abort = new AbortController();
       this.healthCheckAbort = abort;
@@ -212,11 +224,12 @@ export class StewardSidecar {
 
       return this.status;
     } catch (err) {
+      this.discardSpawnedProcess(spawned);
       if (!this.isLifecycleActive(generation)) {
         return this.status;
       }
       const error = err instanceof Error ? err.message : String(err);
-      this.updateStatus({ state: "error", error });
+      this.updateStatus({ state: "error", error, pid: null });
       throw err;
     }
   }
@@ -443,7 +456,7 @@ export class StewardSidecar {
       pipeOutput(proc.stderr, "stderr", this.config.onLog);
 
       proc.exited.then((code: number) => {
-        if (!this.stopping) {
+        if (!this.stopping && !this.discardedProcesses.has(proc)) {
           logger.warn(
             `[StewardSidecar] Process exited unexpectedly (code ${code})`,
           );
@@ -461,12 +474,13 @@ export class StewardSidecar {
         child.on("exit", (code) => resolve(code ?? 1));
       });
 
-      this.process = {
+      const handle: StewardProcessHandle = {
         kill: (signal?: string) =>
           child.kill((signal as NodeJS.Signals) ?? "SIGTERM"),
         pid: child.pid ?? null,
         exited: exitPromise,
       };
+      this.process = handle;
 
       this.updateStatus({ pid: child.pid ?? null });
 
@@ -491,7 +505,7 @@ export class StewardSidecar {
       }
 
       exitPromise.then((code) => {
-        if (!this.stopping) {
+        if (!this.stopping && !this.discardedProcesses.has(handle)) {
           logger.warn(
             `[StewardSidecar] Process exited unexpectedly (code ${code})`,
           );
@@ -533,10 +547,13 @@ export class StewardSidecar {
     this.restartTimer = setTimeout(async () => {
       if (!this.isLifecycleActive(generation)) return;
 
+      let spawned: StewardProcessHandle | null = null;
+
       try {
         if (!(await this.spawnProcess(generation))) {
           return;
         }
+        spawned = this.process;
 
         const abort = new AbortController();
         this.healthCheckAbort = abort;
@@ -559,13 +576,45 @@ export class StewardSidecar {
           error: null,
         });
       } catch (err) {
+        this.discardSpawnedProcess(spawned);
         if (!this.isLifecycleActive(generation)) {
           return;
         }
         const error = err instanceof Error ? err.message : String(err);
-        this.updateStatus({ state: "error", error });
+        this.updateStatus({ state: "error", error, pid: null });
       }
     }, backoff);
+  }
+
+  /**
+   * Kill a child this lifecycle spawned but never managed to bring up.
+   *
+   * `spawnProcess` publishes `this.process` as soon as the child exists, which
+   * is before `waitForHealthy` and `ensureWalletSetup` run. If either of those
+   * fails, the child is still alive — bound to the steward port with the wallet
+   * database open — and `stop()` is the only other code path that kills it. The
+   * failing lifecycle never calls `stop()`, and `startSteward()` only skips a
+   * restart when the state is `"running"`, so a retry after a failed start
+   * reaches `spawnProcess` again and overwrites `this.process`. At that point
+   * nothing holds a reference to the first child and no code path can ever kill
+   * it: it outlives the app, still holding the port and the wallet data.
+   *
+   * A catch cannot un-allocate a process, so the kill has to happen here. The
+   * handle is identity-checked first because a newer generation may already own
+   * `this.process`, and it is recorded as discarded so its exit is not read as
+   * a crash and does not start the restart backoff.
+   */
+  private discardSpawnedProcess(spawned: StewardProcessHandle | null): void {
+    if (!spawned || this.process !== spawned) {
+      return;
+    }
+    this.discardedProcesses.add(spawned);
+    try {
+      spawned.kill("SIGTERM");
+    } catch {
+      // Already dead — nothing to reclaim.
+    }
+    this.process = null;
   }
 
   private isLifecycleActive(generation: number): boolean {


### PR DESCRIPTION
# Relates to

Fixes #24159.

## Outcome

This PR closes the failed-Steward-lifecycle process leak and deliberately includes the adjacent termination-safety contract required to avoid deleting or replacing state while a child may still own the port and PGLite wallet database:

- failed initial starts and failed crash-restarts reclaim the exact child that lifecycle spawned;
- cleanup requests SIGTERM, waits up to 5 seconds for an observed exit, then requests SIGKILL and waits up to another 5 seconds;
- the child handle and PID remain owned until exit is observed; a kill call alone is never treated as proof of death;
- if exit cannot be confirmed, cleanup fails closed with `STEWARD_START_CLEANUP_FAILED` or `STEWARD_RESTART_CLEANUP_FAILED`, and later `start()` calls reject with `STEWARD_CHILD_EXIT_UNCONFIRMED` instead of overwriting the live handle;
- `stop()` now uses the same termination ladder and rejects with `STEWARD_CHILD_TERMINATION_FAILED` when exit remains unconfirmed;
- `restartSteward()`, `resetSteward()`, and their Electrobun RPC calls inherit that rejection. In particular, reset aborts before deleting credentials or wallet data;
- a later `stop()` or `restart()` retries termination and restores start eligibility once exit is observed;
- expected cleanup exits are excluded from crash-restart accounting, while healthy start, healthy stop, and the existing ownership race behavior remain unchanged.

These typed errors, the hard start guard, the public stop/reset/restart rejection, and the bounded SIGTERM-to-SIGKILL deadline are intentional product behavior changes in this PR, not incidental implementation details.

## Recovery and visible behavior

An unconfirmed child intentionally leaves Steward unavailable for the remainder of the app process unless a later stop/restart retry confirms exit or the child exits on its own. Status remains `state: "error"` with the retained PID and actionable message. The Electrobun status callback forwards that state to the renderer, and the start/restart/reset RPC promise rejects instead of returning a fabricated healthy result. This PR adds no new rendered Steward error screen, so UI screenshots are not claimed.

The shutdown/reset wait is intentionally bounded at up to 10 seconds total: one 5-second grace period after SIGTERM and another after SIGKILL. Reset never proceeds while exit is unconfirmed.

## Exact-head verification

Evidence head: `ed0f23a2391e20c918132b5d98174441fbc9dada`.

- `node packages/scripts/run-vitest.mjs run --config packages/app-core/vitest.config.ts packages/app-core/src/services/steward packages/app-core/platforms/electrobun/src/native/steward-stop-failure.test.ts` — **6 files passed, 33 tests passed, 0 failed**. The same command is recorded by `scripts/proof-run.mjs` at this SHA.
- New focused coverage alone — **3 files passed, 14 tests passed, 0 failed**.
- `bunx biome check` on the four repair files — **4 files clean, no fixes applied**.
- The real-process case starts an actual Node child running a live interval, forces the post-spawn health failure, waits for sidecar cleanup, and proves `process.kill(pid, 0)` reports the PID gone.
- The native reset case writes a real wallet-state sentinel and proves an unconfirmed termination rejects before the sentinel can be deleted.
- Bun-path cases cover delayed exit ownership, SIGTERM-to-SIGKILL escalation, unconfirmed-child start blocking, restart recovery, and failed crash-restart cleanup.

## Known verification limits

- Hosted CI does **not** run this fork contributor's tests. Every result above is local macOS evidence and is not represented as hosted CI.
- `bun run --cwd packages/app-core typecheck` still exits 1 on unrelated unresolved workspace/plugin and iOS bridge imports; none of its diagnostics names a touched file.
- Root `bun run verify` passes the guide-parity, Biome-version, i18n, Bun-version, dependency, plugin-convention, and alias-read gates, then exits at the existing tsconfig workspace audit: 16 unrelated plugin projects cannot resolve `@elizaos/capacitor-secure-store` from `packages/ui/src/bridge/storage-bridge.ts`.
- The real-process proof exercises the Node spawn path. Bun's subprocess contract is covered with controlled subprocess handles because the shipped desktop path runs under Bun and must deterministically exercise delayed and never-settling exits.

## Evidence Gate

<!-- evidence-head:ed0f23a2391e20c918132b5d98174441fbc9dada -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - background child-process lifecycle only; no rendered UI changed.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - background child-process lifecycle only; no rendered UI changed.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-visible flow was added or changed.`
<!-- evidence-row:backend-logs -->
- [x] Exact-head 6-file / 33-test output plus root-gate result is summarized above.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend code changed; the existing RPC/status boundary propagates the typed failure.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] Actual child PID disappearance and wallet-sentinel preservation are asserted by committed tests.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0KBD3XQXEJ4CSRNE46YFY8C","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T23:44:53.688Z","completed_at":"2026-08-21T23:45:40.620Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T23:44:54.834Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"b8ea03d82652ad9b3986c17c955c3782e65c9539fb98523fa7d7b7078dd093c4","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"7c3402ab-b275-4fba-bab4-35fe54d6d152","object_id":"sha256:b8ea03d82652ad9b3986c17c955c3782e65c9539fb98523fa7d7b7078dd093c4","sha256":"b8ea03d82652ad9b3986c17c955c3782e65c9539fb98523fa7d7b7078dd093c4"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"LN34M0fta855BpcQxQz49aSuMvR1KblXIuzuoi4-lxfl2V-2wRQni2RzqHBHKR7wpQjR6QWORip6d2dXQAxgCg"}} -->
