### PR TITLE
fix(cloud): ack Shared top-ups without restarting compute

### DIFF
--- a/packages/cloud/api/__tests__/stripe-event-waifu.test.ts
+++ b/packages/cloud/api/__tests__/stripe-event-waifu.test.ts
@@ -1,5 +1,6 @@
 /** Exercises the Stripe queue callback for agent credit top-ups. */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
 
 const agentId = "123e4567-e89b-12d3-a456-426614174000";
 const paymentIntentId = "pi_agent_topup";
@@ -13,6 +14,16 @@ const createInvoice = mock(async () => undefined);
 const calculateRevenueSplits = mock(async () => ({ splits: [] }));
 const enqueueAgentRestartOnce = mock(async () => ({ jobId: "job-restart" }));
 const triggerImmediate = mock(async () => undefined);
+const containerBackedTargetRejectionReason =
+  "agent_job_target_not_container_backed";
+const settleLegacy = mock(async () => ({
+  organizationId: "agent-org",
+  initiatedByUserId: "agent-user",
+  purchaseType: "custom_amount" as const,
+  creditsToGrant: "5.000000",
+  alreadyApplied: false,
+  newBalance: 5,
+}));
 
 function dbChain(rows: unknown[]) {
   return {
@@ -110,6 +121,8 @@ mock.module("@/lib/services/org-rate-limits", () => ({
   invalidateOrgTierCache: mock(async () => undefined),
 }));
 mock.module("@/lib/services/provisioning-jobs", () => ({
+  CONTAINER_BACKED_TARGET_REJECTION_REASON:
+    containerBackedTargetRejectionReason,
   provisioningJobService: {
     enqueueAgentRestartOnce,
     triggerImmediate,
@@ -125,14 +138,48 @@ mock.module("@/lib/services/referrals", () => ({
     calculateRevenueSplits,
   },
 }));
-mock.module("@/lib/security/safe-fetch", () => ({
-  safeFetch: webhookFetch,
+mock.module("@/lib/services/stripe-checkout-orders", () => ({
+  stripeCheckoutOrdersService: { settleLegacy },
 }));
 mock.module("@/lib/stripe", () => ({
   requireStripe: () => ({}),
 }));
 
 const { processStripeEvent } = await import("../src/queue/stripe-event");
+
+function agentTopUpDelivery(eventId: string, attempts = 1) {
+  return {
+    attempts,
+    body: {
+      kind: "stripe.event",
+      eventId,
+      eventType: "checkout.session.completed",
+      paymentIntentId,
+      receivedAt: Date.now(),
+      event: {
+        id: eventId,
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            id: `cs_${eventId}`,
+            payment_status: "paid",
+            amount_total: 500,
+            currency: "usd",
+            customer: "cus_agent",
+            payment_intent: paymentIntentId,
+            metadata: {
+              organization_id: "agent-org",
+              user_id: "agent-user",
+              credits: "5.00",
+              type: "custom_amount",
+              agent_id: agentId,
+            },
+          },
+        },
+      },
+    },
+  } as unknown as Parameters<typeof processStripeEvent>[0];
+}
 
 describe("stripe checkout queue waifu top-up callback", () => {
   beforeEach(() => {
@@ -145,6 +192,7 @@ describe("stripe checkout queue waifu top-up callback", () => {
     webhookFetch.mockClear();
     enqueueAgentRestartOnce.mockClear();
     triggerImmediate.mockClear();
+    settleLegacy.mockClear();
     getTransactionByStripePaymentIntent.mockImplementation(async () => null);
   });
 
@@ -182,17 +230,15 @@ describe("stripe checkout queue waifu top-up callback", () => {
     } as unknown as Parameters<typeof processStripeEvent>[0]);
 
     expect(result).toBe("ack");
-    expect(addCredits).toHaveBeenCalledWith(
+    expect(settleLegacy).toHaveBeenCalledWith(
       expect.objectContaining({
         organizationId: "agent-org",
-        amount: 5,
-        stripePaymentIntentId: paymentIntentId,
-        metadata: expect.objectContaining({
-          agent_id: agentId,
-          session_id: "cs_agent_paid",
-        }),
+        initiatedByUserId: "agent-user",
+        paymentIntentId,
+        checkoutSessionId: "cs_agent_paid",
       }),
     );
+    expect(addCredits).not.toHaveBeenCalled();
     expect(webhookFetch).toHaveBeenCalledTimes(1);
     const [url, init] = (webhookFetch.mock.calls[0] ?? []) as unknown as [
       string,
@@ -204,7 +250,7 @@ describe("stripe checkout queue waifu top-up callback", () => {
     const body = JSON.parse(String((init as RequestInit).body));
     expect(body).toMatchObject({
       event: "credits.topped_up",
-      eventId: `stripe:evt_agent_topup:credits.topped_up:${agentId}`,
+      eventId: `stripe:evt_agent_topup:credits.topped_up:${agentId}:settled`,
       elizaCloudAgentId: agentId,
       organizationId: "agent-org",
       tokenContractAddress: "0x0000000000000000000000000000000000000009",
@@ -264,22 +310,29 @@ describe("stripe checkout queue waifu top-up callback", () => {
     } as unknown as Parameters<typeof processStripeEvent>[0]);
 
     expect(result).toBe("ack");
-    expect(addCredits).toHaveBeenCalledWith(
+    expect(settleLegacy).toHaveBeenCalledWith(
       expect.objectContaining({
         organizationId: "agent-org",
-        amount: 5,
-        stripePaymentIntentId: "pi_org_topup",
+        initiatedByUserId: "agent-user",
+        paymentIntentId: "pi_org_topup",
+        checkoutSessionId: "cs_org_paid",
       }),
     );
+    expect(addCredits).not.toHaveBeenCalled();
     expect(webhookFetch).not.toHaveBeenCalled();
     expect(enqueueAgentRestartOnce).not.toHaveBeenCalled();
     expect(triggerImmediate).not.toHaveBeenCalled();
   });
 
   test("retries the restart enqueue for duplicate agent top-up deliveries", async () => {
-    getTransactionByStripePaymentIntent.mockImplementationOnce(async () => ({
-      id: "existing-credit",
-    }));
+    settleLegacy.mockResolvedValueOnce({
+      organizationId: "agent-org",
+      initiatedByUserId: "agent-user",
+      purchaseType: "custom_amount",
+      creditsToGrant: "5.000000",
+      alreadyApplied: true,
+      newBalance: 5,
+    });
 
     const result = await processStripeEvent({
       attempts: 2,
@@ -330,5 +383,55 @@ describe("stripe checkout queue waifu top-up callback", () => {
       userId: "agent-user",
     });
     expect(triggerImmediate).toHaveBeenCalledTimes(1);
+  });
+
+  test("acks a Shared-like locked tier rejection without nudging compute", async () => {
+    enqueueAgentRestartOnce.mockRejectedValueOnce(
+      new ApiError(
+        409,
+        "session_not_ready",
+        "Agent job requires a container-backed tier",
+        {
+          reason: containerBackedTargetRejectionReason,
+          jobType: "agent_restart",
+        },
+      ),
+    );
+
+    expect(
+      await processStripeEvent(agentTopUpDelivery("evt_shared_topup")),
+    ).toBe("ack");
+    expect(settleLegacy).toHaveBeenCalledTimes(1);
+    expect(enqueueAgentRestartOnce).toHaveBeenCalledWith({
+      agentId,
+      organizationId: "agent-org",
+      userId: "agent-user",
+    });
+    expect(triggerImmediate).not.toHaveBeenCalled();
+    expect(calculateRevenueSplits).toHaveBeenCalledTimes(1);
+    expect(createInvoice).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries an unrelated restart admission failure", async () => {
+    enqueueAgentRestartOnce.mockRejectedValueOnce(
+      new ApiError(
+        409,
+        "session_not_ready",
+        "Another lifecycle job is active",
+        {
+          reason: "exclusive_lifecycle_conflict",
+          jobType: "agent_restart",
+        },
+      ),
+    );
+
+    expect(
+      await processStripeEvent(agentTopUpDelivery("evt_restart_conflict")),
+    ).toBe("retry");
+    expect(settleLegacy).toHaveBeenCalledTimes(1);
+    expect(enqueueAgentRestartOnce).toHaveBeenCalledTimes(1);
+    expect(triggerImmediate).not.toHaveBeenCalled();
+    expect(calculateRevenueSplits).not.toHaveBeenCalled();
+    expect(createInvoice).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/src/queue/stripe-event.ts
+++ b/packages/cloud/api/src/queue/stripe-event.ts
@@ -36,6 +36,7 @@ import { dbRead } from "@/db/helpers";
 import { organizationsRepository } from "@/db/repositories/organizations";
 import { usersRepository } from "@/db/repositories/users";
 import { agentSandboxes } from "@/db/schemas/agent-sandboxes";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
 import type { DrainResult } from "@/lib/queue/redis-queue";
 import { safeFetch } from "@/lib/security/safe-fetch";
 import { appChargeCallbacksService } from "@/lib/services/app-charge-callbacks";
@@ -46,7 +47,11 @@ import { creditsService } from "@/lib/services/credits";
 import { discordService } from "@/lib/services/discord";
 import { invoicesService } from "@/lib/services/invoices";
 import { invalidateOrgTierCache } from "@/lib/services/org-rate-limits";
-import { provisioningJobService } from "@/lib/services/provisioning-jobs";
+import { JOB_TYPES } from "@/lib/services/provisioning-job-types";
+import {
+  CONTAINER_BACKED_TARGET_REJECTION_REASON,
+  provisioningJobService,
+} from "@/lib/services/provisioning-jobs";
 import { redeemableEarningsService } from "@/lib/services/redeemable-earnings";
 import { referralsService } from "@/lib/services/referrals";
 import { stripeCheckoutOrdersService } from "@/lib/services/stripe-checkout-orders";
@@ -592,12 +597,40 @@ async function enqueueAgentRestartAfterTopUp(params: {
     return;
   }
 
-  await provisioningJobService.enqueueAgentRestartOnce({
-    agentId: params.agentId,
-    organizationId: params.organizationId,
-    userId: params.userId,
-  });
+  try {
+    await provisioningJobService.enqueueAgentRestartOnce({
+      agentId: params.agentId,
+      organizationId: params.organizationId,
+      userId: params.userId,
+    });
+  } catch (error) {
+    // error-policy:J1 the payment boundary translates only the authoritative,
+    // locked non-container target rejection into the designed no-restart outcome.
+    if (
+      !(
+        error instanceof ApiError &&
+        error.status === 409 &&
+        error.code === "session_not_ready" &&
+        error.details?.reason === CONTAINER_BACKED_TARGET_REJECTION_REASON &&
+        error.details.jobType === JOB_TYPES.AGENT_RESTART
+      )
+    ) {
+      throw error;
+    }
+    logger.info(
+      "[Stripe Queue] Agent top-up targets a non-container-backed tier; restart skipped",
+      {
+        agentId: params.agentId,
+        organizationId: params.organizationId,
+        paymentIntentId: params.paymentIntentId,
+        sessionId: params.sessionId,
+      },
+    );
+    return;
+  }
   void provisioningJobService.triggerImmediate().catch((err) =>
+    // error-policy:J5 The durable restart job remains observable by the scheduled poller;
+    // this handler observes and reports only the failed best-effort immediate nudge.
     logger.warn(
       "[Stripe Queue] provisioning triggerImmediate nudge failed after agent top-up",
       {

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-container-tier-guard.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-container-tier-guard.pglite.test.ts
@@ -18,7 +18,10 @@ import { organizations } from "../../db/schemas/organizations";
 import { users } from "../../db/schemas/users";
 import { PROVISIONING_JOB_TEST_TABLES } from "./__tests__/tier-upgrade-pglite-schema";
 import { JOB_TYPES, type ProvisioningJobType } from "./provisioning-job-types";
-import { ProvisioningJobService } from "./provisioning-jobs";
+import {
+  CONTAINER_BACKED_TARGET_REJECTION_REASON,
+  ProvisioningJobService,
+} from "./provisioning-jobs";
 
 const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
 const CAN_USE_ISOLATED_PGLITE =
@@ -188,6 +191,7 @@ beforeAll(async () => {
       await dbWrite.execute(sql.raw(ddl));
     }
   } catch {
+    // error-policy:J1 The harness boundary records setup failure for the mandatory readiness assertion.
     pgliteReady = false;
   }
 }, PGLITE_TIMEOUT);
@@ -221,7 +225,14 @@ describe("container-backed enqueue admission", () => {
       .where(eq(agentSandboxes.id, dedicated.agentId));
     await expect(
       service.enqueueAgentProvisionOnce({ ...dedicated, agentName: "Dedicated Agent" }),
-    ).rejects.toMatchObject({ status: 409, code: "session_not_ready" });
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "session_not_ready",
+      details: {
+        reason: CONTAINER_BACKED_TARGET_REJECTION_REASON,
+        jobType: JOB_TYPES.AGENT_PROVISION,
+      },
+    });
     const active = await dbWrite
       .select()
       .from(jobs)
@@ -237,7 +248,31 @@ describe("container-backed enqueue admission", () => {
           agentName: "Shared Agent",
         }),
       ),
-    ).rejects.toMatchObject({ status: 409, code: "session_not_ready" });
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "session_not_ready",
+      details: {
+        reason: CONTAINER_BACKED_TARGET_REJECTION_REASON,
+        jobType: JOB_TYPES.AGENT_PROVISION,
+      },
+    });
+    const sharedJobs = await dbWrite.select().from(jobs).where(eq(jobs.agent_id, shared.agentId));
+    expect(sharedJobs).toHaveLength(0);
+  });
+
+  test("tags a Shared restart rejection before inserting the job", async () => {
+    const service = new ProvisioningJobService();
+    const shared = await seedSandbox("shared");
+
+    await expect(service.enqueueAgentRestartOnce(shared)).rejects.toMatchObject({
+      status: 409,
+      code: "session_not_ready",
+      details: {
+        reason: CONTAINER_BACKED_TARGET_REJECTION_REASON,
+        jobType: JOB_TYPES.AGENT_RESTART,
+      },
+    });
+
     const sharedJobs = await dbWrite.select().from(jobs).where(eq(jobs.agent_id, shared.agentId));
     expect(sharedJobs).toHaveLength(0);
   });

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -143,6 +143,7 @@ function safeErrorKind<T extends Error>(
 
 const CONTAINER_BACKED_TARGET_REQUIRED_MESSAGE =
   "Agent job requires a container-backed execution tier";
+export const CONTAINER_BACKED_TARGET_REJECTION_REASON = "agent_job_target_not_container_backed";
 
 function isContainerBackedExecutionTier(tier: AgentExecutionTier): boolean {
   return (CONTAINER_BACKED_EXECUTION_TIERS as readonly AgentExecutionTier[]).includes(tier);
@@ -1608,6 +1609,10 @@ export class ProvisioningJobService {
         409,
         "session_not_ready",
         `${CONTAINER_BACKED_TARGET_REQUIRED_MESSAGE}: ${opts.jobType}`,
+        {
+          reason: CONTAINER_BACKED_TARGET_REJECTION_REASON,
+          jobType: opts.jobType,
+        },
       );
     }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Relates to #22947. This is slice F only and does not close the parent issue.

Definition of Done: full standard in [CONTRIBUTING.md](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop@1f7b2e252e097744a2a46ac61b14a8a0abc19648` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code from the named tests and exact-head evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop@1f7b2e252e097744a2a46ac61b14a8a0abc19648`; zero conflicts.
- [ ] `bun run verify` passes post-sync. Its exact unrelated local blocker is documented below.

# Risks

Medium: this changes acknowledgement behavior for a settled Stripe top-up when the target cannot own a container. The catch requires canonical `ApiError` identity, status 409, code `session_not_ready`, reason `agent_job_target_not_container_backed`, and `jobType=agent_restart`. Every other enqueue failure remains retryable.

# Background

## What does this PR do?

- Adds a stable structured reason and job type to the container-tier rejection inside the advisory-lock plus `SELECT ... FOR UPDATE` admission transaction.
- Treats only that exact `agent_restart` rejection as the designed no-compute outcome after successful Stripe settlement.
- Skips both restart insertion and `triggerImmediate` for Shared/non-container targets, then continues revenue-split and invoice projections and ACKs.
- Preserves retry/DLQ behavior for unrelated lifecycle conflicts.
- Updates the Waifu top-up fixture to current replay-safe `settleLegacy` authority.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This changes an internal queue/admission contract and adds focused executable coverage.

# Testing

Exact reviewed head: `8ea6b238ba0355040da7674173628cac56a3c236`

Runtime: Node `24.15.0`, Bun `1.3.14`.

## Where should a reviewer start?

1. `packages/cloud/shared/src/lib/services/provisioning-jobs.ts`: locked structured rejection.
2. `packages/cloud/api/src/queue/stripe-event.ts`: exact payment-boundary translation.
3. The two focused test files: real PGlite admission and queue outcomes.

## Detailed testing steps

- `bun test packages/cloud/api/__tests__/stripe-event-waifu.test.ts --timeout 300000`
  - `emits token and wallet context for agent credit top-ups`
  - `does not enqueue an agent restart for org-only credit top-ups`
  - `retries the restart enqueue for duplicate agent top-up deliveries`
  - `acks a Shared-like locked tier rejection without nudging compute`
  - `retries an unrelated restart admission failure`
- `bun --config=/dev/null test packages/cloud/shared/src/lib/services/provisioning-jobs-container-tier-guard.pglite.test.ts --timeout 300000`
  - `admits a dedicated provision and rejects Shared before insert or reuse`
  - `tags a Shared restart rejection before inserting the job`
  - `terminally rejects all eleven Shared container jobs before handlers and remains idempotent`
  - `rejects forged payload identity before a dedicated target handler`
  - `fails closed when a container-required target row disappeared before dispatch`
  - `allows Shared message delivery and logical deletion through the common preflight`
  - `rejects once, reconstructs an ambiguous acknowledgement, and stops lease renewal`
  - `classifies terminal, stale, missing, wrong-owner, and expired authority without mutation`
- `bunx tsc --noEmit -p packages/cloud/shared/tsconfig.json`
- `bunx tsc --noEmit -p packages/cloud/api/tsconfig.json`
- `bun run --cwd packages/cloud/api check:worker-bundle`
- `bunx @biomejs/biome check <the four changed files>`
- `git diff --check`

All commands above pass. Independent exact-head review found no correctness, security, test, bundle, or instruction-compliance finding.

Baseline by exact test name on clean `origin/develop@1f7b2e252e097744a2a46ac61b14a8a0abc19648`:

- The seven pre-existing PGlite tests named above pass. The head adds `tags a Shared restart rejection before inserting the job`.
- `stripe-event-waifu.test.ts` fails before named test collection with `Export named 'writeTransaction' not found`: its fixture loads the newer checkout-order service through an obsolete DB mock. This PR restamps that fixture to `settleLegacy`; the three pre-existing and two new named outcomes pass.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:8ea6b238ba0355040da7674173628cac56a3c236 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Backend-only queue and admission change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Backend-only queue and admission change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - Backend-only queue and admission change; no user-driven visual flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - No live Stripe payment or deployed compute was mutated; focused queue and real PGlite tests exercise the boundary.
<!-- evidence-row:frontend-logs -->
- [x] N/A - No frontend code or browser request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - No agent prompt, action, provider, model, or LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - No durable external artifact was created; PGlite asserts zero restart-job rows for Shared.
<!-- evidence-row:ocr-review -->
- [x] N/A - No rendered visual surface or text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - No agent prompt, action, provider, model, or LLM behavior changes.

## Backend + frontend logs

N/A - A real Stripe settlement would mutate payment and customer-credit state. Focused queue coverage proves settlement then ACK/projections/no nudge; PGlite proves locked rejection before insert.

## Screenshots (before / after) + video walkthrough

N/A - Backend-only change with no UI surface.

## Audio / voice walkthrough

N/A - No audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- `bun run verify` reaches the root Turbo typecheck/lint matrix and then fails on unrelated `@elizaos/capacitor-gateway#lint:check`: `node-swiftlint: command not found` (exit 127). Changed-file Biome, both affected-package typechecks, and Worker dry-run pass.
- A fresh `bun install` was not repeated in this isolated worktree. The lockfile is unchanged and validation used the existing Bun 1.3.14 workspace dependency installation.
- The clean-develop Stripe fixture load failure is documented by exact error above and repaired here.
- Live Stripe/deployed-environment evidence is intentionally absent because it would mutate real payment/compute state.

AI provider/model: OpenAI / GPT-5.6
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-shared-topup-settlement]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5.6","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->

## Maintainer review receipt

Restacked without conflicts onto `origin/develop@1f7b2e252e097744a2a46ac61b14a8a0abc19648`. On exact head `8ea6b238ba0355040da7674173628cac56a3c236`, the maintainer independently ran the Stripe queue and real-PGlite admission suites: 13 tests passed, 0 failed, 109 assertions. Focused Biome and `git diff --check` pass. Review tightened the boundary to compare the canonical restart job constant and classified the retained setup/nudge handlers under the repository error policy. Local full-package typecheck was dependency-incomplete in the sparse review worktree; the original exact-head package typechecks and hosted changed-source compilation remain recorded above.

Maintainer AI provider/model: OpenAI / gpt-5
Maintainer client / agent tooling: Codex
Maintainer attribution status: system-confirmed
— [maintainer-review-8ea6b23]