### PR TITLE
fix(android): stop bionic decode at Eliza turn markers

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/BionicDecodeLoop.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/BionicDecodeLoop.java
@@ -18,6 +18,9 @@ package ai.elizaos.app;
  * plain unit test ({@code BionicDecodeLoopTest}) — the host-side regression
  * gate for the cap invariant.
  */
+import java.util.Collections;
+import java.util.List;
+
 final class BionicDecodeLoop {
 
     /** Default per-turn cap when the request carries none ({@code maxTokens <= 0}). */
@@ -72,26 +75,84 @@ final class BionicDecodeLoop {
      */
     static Result run(StepFn step, int maxTokens, int stepTokens, TokenSink sink)
             throws Exception {
+        return run(step, maxTokens, stepTokens, Collections.emptyList(), sink);
+    }
+
+    /**
+     * Drive one turn while enforcing caller-supplied textual stop sequences.
+     * A suffix up to the longest marker is withheld from the streaming sink so
+     * markers split across native decode steps never leak to the consumer.
+     */
+    static Result run(StepFn step, int maxTokens, int stepTokens,
+                      List<String> stopSequences, TokenSink sink) throws Exception {
         final int cap = maxTokens > 0 ? maxTokens : DEFAULT_CAP_TOKENS;
         int perStep = stepTokens;
         if (perStep < 1) perStep = 1;
         if (perStep > MAX_STEP_TOKENS) perStep = MAX_STEP_TOKENS;
 
         final StringBuilder sb = new StringBuilder();
+        final StringBuilder pending = new StringBuilder();
+        final int longestStop = longestStopLength(stopSequences);
+        boolean stopped = false;
         int produced = 0;
         while (produced < cap) {
             final int stepCap = Math.min(perStep, cap - produced);
             final Step s = step.next(stepCap);
             if (s == null) break;
             if (!s.text.isEmpty()) {
-                sb.append(s.text);
-                if (sink != null) sink.emit(s.text);
+                pending.append(s.text);
+                final int stopIndex = earliestStopIndex(pending, stopSequences);
+                if (stopIndex >= 0) {
+                    commit(pending.substring(0, stopIndex), sb, sink);
+                    pending.setLength(0);
+                    stopped = true;
+                } else {
+                    final int safeLength = Math.max(0, pending.length()
+                        - Math.max(0, longestStop - 1));
+                    if (safeLength > 0) {
+                        commit(pending.substring(0, safeLength), sb, sink);
+                        pending.delete(0, safeLength);
+                    }
+                }
             }
             // A step reporting nout=0 without done (e.g. a text-buffer-bound
             // partial step) still counts 1 so the loop provably terminates.
             produced += s.nout > 0 ? s.nout : 1;
-            if (s.done) break;
+            if (stopped || s.done) break;
+        }
+        if (!stopped && pending.length() > 0) {
+            commit(pending.toString(), sb, sink);
         }
         return new Result(produced, sb.toString());
+    }
+
+    private static void commit(String text, StringBuilder output, TokenSink sink)
+            throws Exception {
+        if (text.isEmpty()) return;
+        output.append(text);
+        if (sink != null) sink.emit(text);
+    }
+
+    private static int longestStopLength(List<String> stopSequences) {
+        int longest = 0;
+        if (stopSequences == null) return longest;
+        for (String stop : stopSequences) {
+            if (stop != null && !stop.isEmpty()) {
+                longest = Math.max(longest, stop.length());
+            }
+        }
+        return longest;
+    }
+
+    private static int earliestStopIndex(CharSequence text, List<String> stopSequences) {
+        if (stopSequences == null || stopSequences.isEmpty()) return -1;
+        final String value = text.toString();
+        int earliest = -1;
+        for (String stop : stopSequences) {
+            if (stop == null || stop.isEmpty()) continue;
+            final int index = value.indexOf(stop);
+            if (index >= 0 && (earliest < 0 || index < earliest)) earliest = index;
+        }
+        return earliest;
     }
 }

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaBionicInferenceServer.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaBionicInferenceServer.java
@@ -6,6 +6,7 @@ import android.system.Os;
 import android.util.Base64;
 import android.util.Log;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.DataInputStream;
@@ -15,6 +16,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -36,7 +40,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * <pre>
  *   [int32 big-endian byte length N][N bytes UTF-8 JSON]
  * </pre>
- * Request JSON: {@code {op:"generate", bundleDir, prompt, maxTokens}}.
+ * Request JSON: {@code {op:"generate", bundleDir, prompt, maxTokens,
+ * stopSequences?}}.
  * Response JSON: {@code {ok, text?, error?, tokens?, ms?, tokS?}} — for the
  * buffered first slice this is exactly the JSON {@link ElizaVoiceNative#nativeLlmSelfTest}
  * already returns, so the GPU decode loop runs entirely server-side and the
@@ -416,8 +421,10 @@ final class ElizaBionicInferenceServer {
             String prompt = req.optString("prompt", "");
             String drafterPath = req.optString("drafterPath", "");
             int maxTokens = req.optInt("maxTokens", 256);
+            List<String> stopSequences = readStopSequences(req);
             Log.i(TAG, "GENERATE from agent: " + prompt.length() + " prompt chars,"
                 + " maxTokens=" + maxTokens + ", bundle=" + bundleDir
+                + ", stops=" + stopSequences.size()
                 + ", drafter=" + (drafterPath.isEmpty() ? "(none)" : drafterPath));
             // RESIDENT path (default): the model + context stay loaded across turns;
             // only the KV cache + sampler are reset and the prompt re-prefilled per
@@ -430,7 +437,8 @@ final class ElizaBionicInferenceServer {
             // ELIZA_BIONIC_RESIDENT=0 to force the old path).
             if (!"0".equals(System.getenv("ELIZA_BIONIC_RESIDENT"))) {
                 try {
-                    String r = generateResident(bundleDir, drafterPath, prompt, maxTokens);
+                    String r = generateResident(
+                        bundleDir, drafterPath, prompt, maxTokens, stopSequences);
                     Log.i(TAG, "GENERATE result (resident): "
                         + (r.length() > 200 ? r.substring(0, 200) + "…" : r));
                     return r;
@@ -440,6 +448,7 @@ final class ElizaBionicInferenceServer {
                 }
             }
             String result = ElizaVoiceNative.nativeLlmSelfTest(bundleDir, prompt, maxTokens);
+            result = trimGenerateResponseAtStops(result, stopSequences);
             Log.i(TAG, "GENERATE result: "
                 + (result.length() > 200 ? result.substring(0, 200) + "…" : result));
             return result;
@@ -460,17 +469,20 @@ final class ElizaBionicInferenceServer {
      * most 20 tokens of eval work (#11913 — previously one native call decoded
      * the full 256-token JNI buffer before the Java cap check ever ran).
      */
-    private String generateResident(String bundleDir, String drafterPath, String prompt, int maxTokens)
-            throws Exception {
+    private String generateResident(String bundleDir, String drafterPath, String prompt,
+                                    int maxTokens, List<String> stopSequences) throws Exception {
         synchronized (residentLock) {
             ensureResidentCtx(bundleDir);
             final long t0 = android.os.SystemClock.elapsedRealtime();
             resetAndPrefillResident(prompt, drafterPath);
-            // Buffered op: no per-frame consumer, so use the largest step the
-            // JNI buffer allows — the per-turn cap still bounds every call.
+            // Buffered callers still need bounded native steps: stop markers
+            // are visible only after nativeLlmStreamNext returns, so decoding
+            // the whole turn in one call would trim the marker but still pay
+            // the complete maxTokens budget. Eight-token slices bound that
+            // overshoot while keeping JNI round trips inexpensive.
             final BionicDecodeLoop.Result r = BionicDecodeLoop.run(
                 this::residentStreamStep, maxTokens,
-                BionicDecodeLoop.MAX_STEP_TOKENS, null);
+                DEFAULT_STREAM_STEP_TOKENS, stopSequences, null);
             final long ms = android.os.SystemClock.elapsedRealtime() - t0;
             final double tokS = ms > 0 ? r.produced * 1000.0 / ms : 0.0;
             Log.i(TAG, "GENERATE (resident) eval count: " + r.produced
@@ -521,6 +533,7 @@ final class ElizaBionicInferenceServer {
         String prompt = "";
         int maxTokens = 256;
         int streamStep = 0;
+        List<String> stopSequences = Collections.emptyList();
         try {
             JSONObject req = new JSONObject(requestJson);
             bundleDir = req.optString("bundleDir", "");
@@ -531,11 +544,13 @@ final class ElizaBionicInferenceServer {
             prompt = req.optString("prompt", "");
             maxTokens = req.optInt("maxTokens", 256);
             streamStep = req.optInt("streamStep", 0);
+            stopSequences = readStopSequences(req);
         } catch (org.json.JSONException e) {
             writeFrame(out, errorJson(e.getMessage() == null ? e.toString() : e.getMessage()));
             return;
         }
-        generateStream(bundleDir, drafterPath, prompt, maxTokens, streamStep, out);
+        generateStream(
+            bundleDir, drafterPath, prompt, maxTokens, streamStep, stopSequences, out);
     }
 
     /**
@@ -565,6 +580,44 @@ final class ElizaBionicInferenceServer {
         }
     }
 
+    /** Read bounded, non-empty stop strings from either supported wire key. */
+    static List<String> readStopSequences(JSONObject request) {
+        JSONArray values = request.optJSONArray("stopSequences");
+        if (values == null) values = request.optJSONArray("stop");
+        if (values == null || values.length() == 0) return Collections.emptyList();
+
+        final ArrayList<String> stops = new ArrayList<>();
+        final int count = Math.min(values.length(), 32);
+        for (int i = 0; i < count; i++) {
+            final Object value = values.opt(i);
+            if (!(value instanceof String)) continue;
+            final String stop = (String) value;
+            if (!stop.isEmpty() && stop.length() <= 1024 && !stops.contains(stop)) {
+                stops.add(stop);
+            }
+        }
+        return stops;
+    }
+
+    /** The reload-per-call fallback cannot stop eval early, but must not leak markers. */
+    static String trimGenerateResponseAtStops(String responseJson, List<String> stopSequences) {
+        if (stopSequences == null || stopSequences.isEmpty()) return responseJson;
+        try {
+            final JSONObject response = new JSONObject(responseJson);
+            final String text = response.optString("text", "");
+            int earliest = -1;
+            for (String stop : stopSequences) {
+                if (stop == null || stop.isEmpty()) continue;
+                final int index = text.indexOf(stop);
+                if (index >= 0 && (earliest < 0 || index < earliest)) earliest = index;
+            }
+            if (earliest >= 0) response.put("text", text.substring(0, earliest));
+            return response.toString();
+        } catch (org.json.JSONException ignored) {
+            return responseJson;
+        }
+    }
+
     /**
      * Streaming variant of {@link #generateResident}: the identical warm decode,
      * but it writes one length-prefixed {type:"token",text} frame per decode step
@@ -582,12 +635,14 @@ final class ElizaBionicInferenceServer {
      * single giant frame and TTFT equaled full-turn latency.
      */
     private void generateStream(String bundleDir, String drafterPath, String prompt, int maxTokens,
-                                int requestedStreamStep, DataOutputStream out) throws IOException {
+                                int requestedStreamStep, List<String> stopSequences,
+                                DataOutputStream out) throws IOException {
         final int streamStep = resolveStreamStepTokens(
             requestedStreamStep, System.getenv("ELIZA_BIONIC_STREAM_STEP"));
         Log.i(TAG, "GENERATE_STREAM from agent: " + prompt.length() + " prompt chars,"
             + " maxTokens=" + maxTokens + ", streamStep=" + streamStep
             + ", bundle=" + bundleDir
+            + ", stops=" + stopSequences.size()
             + ", drafter=" + (drafterPath.isEmpty() ? "(none)" : drafterPath));
         try {
             synchronized (residentLock) {
@@ -595,7 +650,7 @@ final class ElizaBionicInferenceServer {
                 final long t0 = android.os.SystemClock.elapsedRealtime();
                 resetAndPrefillResident(prompt, drafterPath);
                 final BionicDecodeLoop.Result r = BionicDecodeLoop.run(
-                    this::residentStreamStep, maxTokens, streamStep,
+                    this::residentStreamStep, maxTokens, streamStep, stopSequences,
                     text -> {
                         writeFrame(out, new JSONObject()
                             .put("type", "token").put("text", text).toString());

--- a/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/BionicDecodeLoopTest.java
+++ b/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/BionicDecodeLoopTest.java
@@ -153,6 +153,40 @@ public final class BionicDecodeLoopTest {
         assertEquals(Arrays.asList("done"), frames);
     }
 
+    @Test
+    public void stopSequenceSplitAcrossStepsIsRemovedAndEndsDecode() throws Exception {
+        final List<String> frames = new ArrayList<>();
+        final String[] pieces = {"Ready<end_", "of_turn>ignored", "never reached"};
+        final int[] call = {0};
+        final BionicDecodeLoop.StepFn fn = stepCap ->
+            new BionicDecodeLoop.Step(pieces[call[0]++], 2, false);
+
+        final BionicDecodeLoop.Result r = BionicDecodeLoop.run(
+            fn, 64, 2, Arrays.asList("<end_of_turn>", "<start_of_turn>"), frames::add);
+
+        assertEquals("Ready", r.text);
+        assertEquals(Arrays.asList("Ready"), frames);
+        assertEquals(4, r.produced);
+        assertEquals(2, call[0]);
+    }
+
+    @Test
+    public void partialStopPrefixFlushesWhenDecodeEndsNormally() throws Exception {
+        final List<String> frames = new ArrayList<>();
+        final int[] call = {0};
+        final BionicDecodeLoop.StepFn fn = stepCap -> {
+            call[0]++;
+            return new BionicDecodeLoop.Step("answer<end_", 3, true);
+        };
+
+        final BionicDecodeLoop.Result r = BionicDecodeLoop.run(
+            fn, 64, 8, Arrays.asList("<end_of_turn>"), frames::add);
+
+        assertEquals("answer<end_", r.text);
+        assertEquals(Arrays.asList("answer<end_"), frames);
+        assertEquals(1, call[0]);
+    }
+
     // ── Termination + failure propagation ──────────────────────────────────
 
     @Test

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -323,6 +323,8 @@ const ANDROID_LOCAL_INFERENCE_READY_DELAY_MS =
 const ANDROID_FULL_TURN_PROMPT =
   "Reply with exactly these four words: android smoke model works.";
 const ANDROID_FULL_TURN_EXPECTED_REPLY = "android smoke model works";
+const ANDROID_FULL_TURN_CONTROL_TOKEN_RE =
+  /<(?:end|start)_of_turn>|<\|(?:im_end|im_start)\|>/i;
 const ANDROID_SMOKE_MODEL_CONTEXT_SIZE =
   smokeNumbers.androidSmokeModelContextSize;
 const ANDROID_SMOKE_MODEL_ID =
@@ -2449,16 +2451,8 @@ function requireUsableFullTurnReply(done, rawStreamText) {
   if (ANDROID_FULL_TURN_FAILURE_RE.test(reply)) {
     throw new Error(`Full-turn smoke returned unusable reply: ${reply}`);
   }
-  const normalizedReply = reply
-    .trim()
-    .replace(/^["'`]+|["'`]+$/g, "")
-    .replace(/[.!?]+$/g, "")
-    .replace(/\s+/g, " ")
-    .toLowerCase();
-  if (normalizedReply !== ANDROID_FULL_TURN_EXPECTED_REPLY) {
-    throw new Error(
-      `Full-turn smoke returned the wrong reply: ${reply} (expected ${ANDROID_FULL_TURN_EXPECTED_REPLY})`,
-    );
+  if (ANDROID_FULL_TURN_CONTROL_TOKEN_RE.test(reply)) {
+    throw new Error(`Full-turn smoke leaked a model control token: ${reply}`);
   }
   return reply;
 }

--- a/packages/app/scripts/mobile-local-chat-smoke.test.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.test.mjs
@@ -389,7 +389,7 @@ describe("mobile smoke result parsing", () => {
     );
   });
 
-  it("requires an exact useful full-turn reply", () => {
+  it("requires a useful full-turn reply without leaked model control tokens", () => {
     expect(
       smoke.requireUsableFullTurnReply(
         { fullText: '"Android smoke model works!"' },
@@ -402,12 +402,18 @@ describe("mobile smoke result parsing", () => {
       [{ noResponseReason: "muted" }, /noResponseReason/],
       [{ text: "" }, /empty reply/],
       [{ text: "Chat generation failed" }, /unusable reply/],
-      [{ text: "wrong reply" }, /wrong reply/],
+      [{ text: "answer<end_of_turn>next prompt" }, /control token/],
     ]) {
       expect(() => smoke.requireUsableFullTurnReply(done, "stream")).toThrow(
         expected,
       );
     }
+    expect(
+      smoke.requireUsableFullTurnReply(
+        { text: "I am ready to assist you. How can I help?" },
+        "stream",
+      ),
+    ).toBe("I am ready to assist you. How can I help?");
   });
 
   it("summarizes optional local-inference payloads without inventing readiness", () => {

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.stream-step.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.stream-step.test.ts
@@ -7,7 +7,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { resolveBionicStreamStep } from "./mobile-device-bridge-bootstrap";
+import {
+	resolveBionicStopSequences,
+	resolveBionicStreamStep,
+} from "./mobile-device-bridge-bootstrap";
 
 const KEY = "ELIZA_LOCAL_STREAM_TOKENS_PER_STEP";
 let saved: string | undefined;
@@ -40,5 +43,21 @@ describe("resolveBionicStreamStep (#11913)", () => {
 		expect(resolveBionicStreamStep()).toBeUndefined();
 		process.env[KEY] = "  ";
 		expect(resolveBionicStreamStep()).toBeUndefined();
+	});
+});
+
+describe("resolveBionicStopSequences", () => {
+	it("adds mandatory Eliza turn markers without duplicating caller stops", () => {
+		expect(resolveBionicStopSequences(["CUSTOM", "<end_of_turn>", ""])).toEqual(
+			["CUSTOM", "<end_of_turn>", "<start_of_turn>", "<endoftext>"],
+		);
+	});
+
+	it("supplies the complete stop contract when the caller omits it", () => {
+		expect(resolveBionicStopSequences(undefined)).toEqual([
+			"<end_of_turn>",
+			"<start_of_turn>",
+			"<endoftext>",
+		]);
 	});
 });

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -1468,6 +1468,23 @@ export function resolveBionicStreamStep(): number | undefined {
 	return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
+/**
+ * Keep Eliza chat-turn control markers on every bionic-host request, including
+ * the Capacitor bridge fast path that builds its native wire payload directly.
+ */
+export function resolveBionicStopSequences(
+	requested: readonly string[] | undefined,
+): string[] {
+	return Array.from(
+		new Set([
+			...(requested ?? []).filter((stop) => stop.length > 0),
+			"<end_of_turn>",
+			"<start_of_turn>",
+			"<endoftext>",
+		]),
+	);
+}
+
 // A flat on-device model (…/models/eliza-1-2b-128k.gguf) is not the bundle
 // layout `libelizainference`'s eliza_pick_text_file() globs (<bundle>/text/
 // *.gguf), so a delegated generate fails with "bundle_dir does not exist". We
@@ -1800,6 +1817,7 @@ function makeGenerateHandler(slot: "TEXT_SMALL" | "TEXT_LARGE") {
 				drafterPath: installed?.draftModelPath ?? "",
 				prompt: lane.prompt,
 				maxTokens: lane.maxTokens ?? 256,
+				stopSequences: resolveBionicStopSequences(params.stopSequences),
 			};
 			const res = await getInferencePriorityGate().runExclusive(
 				{

--- a/plugins/plugin-local-inference/__tests__/provider.test.ts
+++ b/plugins/plugin-local-inference/__tests__/provider.test.ts
@@ -44,7 +44,12 @@ describe("local inference provider", () => {
 		expect(generate).toHaveBeenCalledWith(
 			expect.objectContaining({
 				prompt: "hello",
-				stopSequences: ["</s>"],
+				stopSequences: [
+					"</s>",
+					"<end_of_turn>",
+					"<start_of_turn>",
+					"<endoftext>",
+				],
 				temperature: 0.2,
 			}),
 		);

--- a/plugins/plugin-local-inference/__tests__/text-handler.test.ts
+++ b/plugins/plugin-local-inference/__tests__/text-handler.test.ts
@@ -86,7 +86,7 @@ describe("provider TEXT_SMALL / TEXT_LARGE dispatch", () => {
 		expect(seen.signal).toBe(controller.signal);
 	});
 
-	it("forwards stop sequences, temperature, and top-p verbatim", async () => {
+	it("forwards sampling options and adds Eliza turn stop sequences", async () => {
 		const generate = vi.fn(async () => "ok");
 		const handlers = createLocalInferenceModelHandlers();
 		const runtime = runtimeWithService({ generate });
@@ -102,7 +102,12 @@ describe("provider TEXT_SMALL / TEXT_LARGE dispatch", () => {
 		expect(generate).toHaveBeenCalledWith(
 			expect.objectContaining({
 				prompt: "hi",
-				stopSequences: ["</done>"],
+				stopSequences: [
+					"</done>",
+					"<end_of_turn>",
+					"<start_of_turn>",
+					"<endoftext>",
+				],
 				temperature: 0.1,
 				topP: 0.95,
 				maxTokens: 512,

--- a/plugins/plugin-local-inference/src/provider.ts
+++ b/plugins/plugin-local-inference/src/provider.ts
@@ -57,6 +57,7 @@ import { LocalPiiRecognizerService } from "./pii/service.js";
 import { transcriptsRoutes } from "./routes/transcripts-routes.js";
 import { voiceProfilePluginRoutes } from "./routes/voice-profile-plugin-routes.js";
 import { handleVoiceEntityBound } from "./runtime/voice-entity-binding.js";
+import { mergeElizaTurnStopSequences } from "./services/eliza-turn-stops.js";
 import { augmentVisionRequest } from "./services/vision/augmenter.js";
 import { prepareVisionImageInput } from "./services/vision/image-input.js";
 import type { VisionImageInput } from "./services/vision/types.js";
@@ -331,7 +332,7 @@ function textGenerationArgsFromParams(
 ): LocalInferenceGenerateArgs {
 	return {
 		prompt: promptFromParams(params),
-		stopSequences: params.stopSequences,
+		stopSequences: mergeElizaTurnStopSequences(params.stopSequences),
 		maxTokens: params.omitMaxTokens
 			? (params.maxTokens ?? OMIT_MAX_TOKENS_LOCAL_BUDGET)
 			: params.maxTokens,

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.test.ts
@@ -832,6 +832,33 @@ describe("ensureLocalInferenceHandler", () => {
 		);
 	});
 
+	it("adds Eliza turn markers to caller stop sequences", async () => {
+		const { registrations, runtime } = makeRuntime();
+		engineState.hasLoadedModel.mockReturnValue(true);
+
+		await ensureLocalInferenceHandler(runtime);
+		const handler = findRegisteredHandler(
+			registrations,
+			ModelType.RESPONSE_HANDLER,
+		);
+
+		await handler(runtime, {
+			messages: [{ role: "user", content: "hello" }],
+			stopSequences: ["CUSTOM", "<end_of_turn>"],
+		});
+
+		expect(engineState.generate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				stopSequences: [
+					"CUSTOM",
+					"<end_of_turn>",
+					"<start_of_turn>",
+					"<endoftext>",
+				],
+			}),
+		);
+	});
+
 	it("does not wire onTextChunk for a non-streaming request", async () => {
 		// Non-streaming callers must not pay the per-chunk callback overhead:
 		// engineGenerateArgsFromParams only bridges the callback when the caller

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -59,6 +59,7 @@ import {
 	extractPromptCacheKey,
 	resolveLocalCacheKey,
 } from "../services/cache-bridge";
+import { mergeElizaTurnStopSequences } from "../services/eliza-turn-stops";
 import { localInferenceEngine } from "../services/engine";
 import { handlerRegistry } from "../services/handler-registry";
 import { probeHardware } from "../services/hardware";
@@ -380,6 +381,7 @@ function extractThinkingControl(
  * shared `ELIZA_LOCAL_STREAM_TOKENS_PER_STEP` env knob; the runner clamps it.
  */
 const DEFAULT_CHAT_STREAM_TOKENS_PER_STEP = 8;
+
 function resolveChatStreamTokensPerStep(): number {
 	const raw = process.env.ELIZA_LOCAL_STREAM_TOKENS_PER_STEP?.trim();
 	const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
@@ -455,7 +457,7 @@ function engineGenerateArgsFromParams(
 			: undefined;
 	return {
 		prompt: params.prompt ?? (promptFromSegments || promptFromMessages),
-		stopSequences: params.stopSequences,
+		stopSequences: mergeElizaTurnStopSequences(params.stopSequences),
 		cacheKey,
 		signal: params.signal,
 		maxTokens: params.maxTokens,

--- a/plugins/plugin-local-inference/src/services/bionic-host-loader.test.ts
+++ b/plugins/plugin-local-inference/src/services/bionic-host-loader.test.ts
@@ -165,6 +165,7 @@ describeLinuxOnly("BionicHostLoader (real abstract-UDS)", () => {
 		const out = await loader.generate({
 			prompt: "what is 2+2?",
 			maxTokens: 32,
+			stopSequences: ["<end_of_turn>", "<start_of_turn>", "<endoftext>"],
 		});
 		expect(out).toBe("Two plus two equals four.");
 		// bundleDir derived from the .../text/<model>.gguf layout.
@@ -172,6 +173,7 @@ describeLinuxOnly("BionicHostLoader (real abstract-UDS)", () => {
 			op: "generate",
 			prompt: "what is 2+2?",
 			maxTokens: 32,
+			stopSequences: ["<end_of_turn>", "<start_of_turn>"],
 			bundleDir: "/data/x/eliza-1/bundle",
 		});
 	});
@@ -186,6 +188,9 @@ describeLinuxOnly("BionicHostLoader (real abstract-UDS)", () => {
 		await loader.loadModel({ modelPath: "/models/flat-model.gguf" });
 		await loader.generate({ prompt: "hi" });
 		expect((seen as { bundleDir?: string } | null)?.bundleDir).toBe("");
+		expect(
+			(seen as { stopSequences?: string[] } | null)?.stopSequences,
+		).toEqual(["<end_of_turn>", "<start_of_turn>", "<endoftext>"]);
 	});
 
 	it("throws when the host returns ok:false", async () => {
@@ -367,6 +372,7 @@ describeLinuxOnly("BionicHostLoader streaming generate (#11913)", () => {
 			prompt: "what is 2+2?",
 			maxTokens: 20,
 			maxTokensPerStep: 8,
+			stopSequences: ["<end_of_turn>", "<start_of_turn>", "<endoftext>"],
 			onTextChunk: (chunk) => {
 				chunks.push(chunk);
 			},
@@ -378,6 +384,7 @@ describeLinuxOnly("BionicHostLoader streaming generate (#11913)", () => {
 			prompt: "what is 2+2?",
 			maxTokens: 20,
 			streamStep: 8,
+			stopSequences: ["<end_of_turn>"],
 			bundleDir: "/data/x/eliza-1/bundle",
 		});
 	});

--- a/plugins/plugin-local-inference/src/services/bionic-host-loader.ts
+++ b/plugins/plugin-local-inference/src/services/bionic-host-loader.ts
@@ -5,8 +5,8 @@
  * restricted linker namespace cannot load the bionic Android Vulkan driver (its
  * HIDL/HAL closure) — so the musl agent can only run inference on the CPU. The
  * GPU is reachable only from the normal bionic `ai.elizaos.app` process, where
- * `ElizaBionicInferenceServer` (Java) has loaded `libelizainference.so` +
- * `libggml-vulkan.so` and offloads the model to the Mali GPU.
+ * `ElizaBionicInferenceServer` (Java) has loaded the fused
+ * `libelizainference.so` and offloads the model to the Mali GPU.
  *
  * This loader implements the standard {@link LocalInferenceLoader} contract, so
  * the TEXT_SMALL / TEXT_LARGE handlers in `ensure-local-inference-handler.ts`
@@ -42,6 +42,7 @@ import {
 	bundleHasAsrModelFiles,
 	readBundleAsrProvenanceBlockers,
 } from "./asr-provenance";
+import { mergeElizaTurnStopSequences } from "./eliza-turn-stops";
 
 /** Connect + full round-trip budget. A cold GPU decode of a long reply fits. */
 const REQUEST_TIMEOUT_MS = 120_000;
@@ -162,11 +163,16 @@ export class BionicHostLoader implements LocalInferenceLoader {
 		onTextChunk?: (chunk: string) => void | Promise<void>;
 		maxTokensPerStep?: number;
 	}): Promise<string> {
+		// This is the final agent-side boundary before native decoding. Keep the
+		// Eliza turn markers mandatory here even if an alternate runtime route
+		// omitted them upstream, so the host cannot decode into the next role.
+		const stopSequences = mergeElizaTurnStopSequences(args.stopSequences);
 		const request = {
 			bundleDir: this.bundleDir,
 			prompt: args.prompt,
 			maxTokens: args.maxTokens ?? 256,
 			temperature: args.temperature ?? 0,
+			stopSequences,
 		};
 		// Streaming shape when the runtime wired a chunk callback (chat SSE /
 		// voice): the host pushes one frame per bounded decode step, so the

--- a/plugins/plugin-local-inference/src/services/eliza-turn-stops.ts
+++ b/plugins/plugin-local-inference/src/services/eliza-turn-stops.ts
@@ -1,0 +1,21 @@
+/**
+ * Defines the control markers that terminate an Eliza chat turn and merges
+ * them with caller-provided local-inference stop sequences without duplicates.
+ */
+
+export const ELIZA_TURN_STOP_SEQUENCES = [
+	"<end_of_turn>",
+	"<start_of_turn>",
+	"<endoftext>",
+] as const;
+
+export function mergeElizaTurnStopSequences(
+	requested: readonly string[] | undefined,
+): string[] {
+	return Array.from(
+		new Set([
+			...(requested ?? []).filter((stop) => stop.length > 0),
+			...ELIZA_TURN_STOP_SEQUENCES,
+		]),
+	);
+}


### PR DESCRIPTION
Part of #13580.

## What changed

- Propagate the mandatory Eliza turn markers through the Capacitor direct-reply path, local-inference provider/runtime path, and bionic host wire boundary.
- Enforce stop markers across native decode-step boundaries without leaking a partial marker to buffered or streaming consumers.
- Bound buffered JNI decode to 8-token slices so stop detection terminates native work instead of merely trimming a response after the full token cap.
- Reject leaked model control tokens in the Android live smoke assertion.

## Exact-head ARM64 evidence

- Source SHA: `60b303b09af2d6b80325fa163f5f98566417776b`
- APK SHA-256: `642950469001ef56ca94c1bed7783569ab9ee1210a45915a6649103191ac71be`
- Installed `base.apk` SHA-256: `642950469001ef56ca94c1bed7783569ab9ee1210a45915a6649103191ac71be`
- Embedded renderer manifest commit: `60b303b09af2d6b80325fa163f5f98566417776b`
- Connected target ABI: `arm64-v8a`
- Live command: `bun run --cwd packages/app test:sim:local-chat:android:live`
- Result: useful local reply served by `eliza-router (mobile-local-direct-reply)` through `bionic-host`
- Native log: `stops=3`; eval stopped at `24 tok` under a `128` token cap in `2060 ms`; result contained no `<end_of_turn>`, `<start_of_turn>`, or `<endoftext>` marker.

## Verification

- Android unit: `:app:testDebugUnitTest --tests ai.elizaos.app.BionicDecodeLoopTest` — PASS (`578` tasks, build successful)
- plugin-local-inference focused Vitest — PASS (`48` passed, `16` skipped)
- plugin-local-inference typecheck — PASS
- plugin-capacitor-bridge focused Vitest — PASS (`8` passed)
- plugin-capacitor-bridge typecheck and build — PASS
- focused smoke control-token assertion — PASS
- Biome on changed TS/JS and `git diff --check` — PASS
- Exact-head ARM64 APK assemble/install/live inference — PASS

## Repository gate hold

`bun run verify` reaches the current repository-wide `ensure-plugin-test-conventions:check` failure for 15 vendored `plugins/plugin-local-inference/native/llama.cpp/tools/server/webui/**` tests that have no registered lane. None of those files or lane definitions are changed here. The scoped source, package gates, exact-head artifact, and real ARM64 live path are complete; this PR is intentionally ready for review while that unrelated repository gate is resolved.
