### PR TITLE
fix(app): reclaim abandoned credential scopes instead of retaining them forever

### DIFF
--- a/packages/app-core/src/services/credential-tunnel-scope-retention.test.ts
+++ b/packages/app-core/src/services/credential-tunnel-scope-retention.test.ts
@@ -12,7 +12,10 @@
  * Uses the service's injected clock, so no timers and no real waiting.
  */
 import { describe, expect, it } from "vitest";
-import { createCredentialTunnelService } from "./credential-tunnel-service.ts";
+import {
+  CredentialScopeError,
+  createCredentialTunnelService,
+} from "./credential-tunnel-service.ts";
 
 const TTL_MS = 100;
 
@@ -48,6 +51,48 @@ describe("credential tunnel: abandoned scope retention", () => {
     // Nothing is left for a sweep to find: the 50 dead scopes were reclaimed
     // by that declare rather than being retained for the runtime's lifetime.
     expect(service.expireScopes()).toBe(0);
+  });
+
+  it("pins the public error codes for a scope removed by the declare-time sweep", () => {
+    const clock = { now: 1_000 };
+    const service = makeService(clock);
+    const expired = service.declareScope({
+      childSessionId: "pty-expired",
+      credentialKeys: ["OPENAI_API_KEY"],
+    });
+
+    clock.now += TTL_MS * 10;
+    service.declareScope({
+      childSessionId: "pty-next",
+      credentialKeys: ["OTHER_KEY"],
+    });
+
+    let retrieveError: unknown;
+    try {
+      service.retrieveCredential({
+        childSessionId: "pty-expired",
+        key: "OPENAI_API_KEY",
+        scopedToken: expired.scopedToken,
+      });
+    } catch (error) {
+      retrieveError = error;
+    }
+    expect(retrieveError).toBeInstanceOf(CredentialScopeError);
+    expect((retrieveError as CredentialScopeError).code).toBe("invalid_token");
+
+    let tunnelError: unknown;
+    try {
+      service.tunnelCredential({
+        childSessionId: "pty-expired",
+        credentialScopeId: expired.credentialScopeId,
+        key: "OPENAI_API_KEY",
+        value: "sk-too-late",
+      });
+    } catch (error) {
+      tunnelError = error;
+    }
+    expect(tunnelError).toBeInstanceOf(CredentialScopeError);
+    expect((tunnelError as CredentialScopeError).code).toBe("unknown_scope");
   });
 
   it("reclaims a scope whose child redeemed only some of its declared keys", () => {

--- a/packages/app-core/src/services/credential-tunnel-scope-retention.test.ts
+++ b/packages/app-core/src/services/credential-tunnel-scope-retention.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Retention of abandoned credential scopes.
+ *
+ * Eviction in the credential tunnel is otherwise entirely lazy: a scope leaves
+ * the maps only when that same scope is touched again after its TTL, or when
+ * every declared key has been redeemed. A child session that is killed, times
+ * out, or whose owner never fulfils the request does neither, and `expireScopes`
+ * — the only proactive sweep — has no production caller. These pin that
+ * declaring a scope reclaims the dead ones, and that reclaiming them does not
+ * disturb any scope that is still live.
+ *
+ * Uses the service's injected clock, so no timers and no real waiting.
+ */
+import { describe, expect, it } from "vitest";
+import { createCredentialTunnelService } from "./credential-tunnel-service.ts";
+
+const TTL_MS = 100;
+
+function makeService(clock: { now: number }) {
+  return createCredentialTunnelService({
+    ttlMs: TTL_MS,
+    now: () => clock.now,
+  });
+}
+
+describe("credential tunnel: abandoned scope retention", () => {
+  it("reclaims scopes abandoned by their child session when a new one is declared", () => {
+    const clock = { now: 1_000 };
+    const service = makeService(clock);
+
+    // 50 sub-agents each declare a scope and are then killed without ever
+    // redeeming the key they declared.
+    for (let i = 0; i < 50; i += 1) {
+      service.declareScope({
+        childSessionId: `pty-abandoned-${i}`,
+        credentialKeys: ["OPENAI_API_KEY"],
+      });
+    }
+
+    clock.now += TTL_MS * 10;
+
+    // The next sub-agent declares its scope.
+    service.declareScope({
+      childSessionId: "pty-live",
+      credentialKeys: ["OPENAI_API_KEY"],
+    });
+
+    // Nothing is left for a sweep to find: the 50 dead scopes were reclaimed
+    // by that declare rather than being retained for the runtime's lifetime.
+    expect(service.expireScopes()).toBe(0);
+  });
+
+  it("reclaims a scope whose child redeemed only some of its declared keys", () => {
+    const clock = { now: 1_000 };
+    const service = makeService(clock);
+
+    const scope = service.declareScope({
+      childSessionId: "pty-partial",
+      credentialKeys: ["KEY_A", "KEY_B"],
+    });
+    service.tunnelCredential({
+      childSessionId: "pty-partial",
+      credentialScopeId: scope.credentialScopeId,
+      key: "KEY_A",
+      value: "value-a",
+    });
+    service.retrieveCredential({
+      childSessionId: "pty-partial",
+      key: "KEY_A",
+      scopedToken: scope.scopedToken,
+    });
+    // KEY_B is never tunneled or redeemed, so the all-redeemed drop never fires.
+
+    clock.now += TTL_MS * 10;
+    service.declareScope({
+      childSessionId: "pty-next",
+      credentialKeys: ["KEY_C"],
+    });
+
+    expect(service.expireScopes()).toBe(0);
+  });
+
+  it("leaves a still-live scope usable across a later declare", () => {
+    const clock = { now: 1_000 };
+    const service = makeService(clock);
+
+    const live = service.declareScope({
+      childSessionId: "pty-live",
+      credentialKeys: ["OPENAI_API_KEY"],
+    });
+    service.tunnelCredential({
+      childSessionId: "pty-live",
+      credentialScopeId: live.credentialScopeId,
+      key: "OPENAI_API_KEY",
+      value: "sk-live-value",
+    });
+
+    // Time moves, but not past the live scope's TTL.
+    clock.now += TTL_MS - 1;
+    service.declareScope({
+      childSessionId: "pty-other",
+      credentialKeys: ["OTHER_KEY"],
+    });
+
+    expect(
+      service.retrieveCredential({
+        childSessionId: "pty-live",
+        key: "OPENAI_API_KEY",
+        scopedToken: live.scopedToken,
+      }),
+    ).toBe("sk-live-value");
+  });
+
+  it("still refuses an expired scope", () => {
+    const clock = { now: 1_000 };
+    const service = makeService(clock);
+
+    const scope = service.declareScope({
+      childSessionId: "pty-expired",
+      credentialKeys: ["OPENAI_API_KEY"],
+    });
+    service.tunnelCredential({
+      childSessionId: "pty-expired",
+      credentialScopeId: scope.credentialScopeId,
+      key: "OPENAI_API_KEY",
+      value: "sk-expired-value",
+    });
+
+    clock.now += TTL_MS * 10;
+
+    expect(() =>
+      service.retrieveCredential({
+        childSessionId: "pty-expired",
+        key: "OPENAI_API_KEY",
+        scopedToken: scope.scopedToken,
+      }),
+    ).toThrowError();
+  });
+
+  it("still reports the sweep count when expireScopes is called directly", () => {
+    const clock = { now: 1_000 };
+    const service = makeService(clock);
+
+    service.declareScope({
+      childSessionId: "pty-1-a",
+      credentialKeys: ["K1"],
+    });
+    service.declareScope({
+      childSessionId: "pty-1-b",
+      credentialKeys: ["K2"],
+    });
+
+    clock.now += TTL_MS * 10;
+
+    expect(service.expireScopes()).toBe(2);
+    expect(service.expireScopes()).toBe(0);
+  });
+});

--- a/packages/app-core/src/services/credential-tunnel-service.ts
+++ b/packages/app-core/src/services/credential-tunnel-service.ts
@@ -216,6 +216,28 @@ export function createCredentialTunnelService(options?: {
     return false;
   }
 
+  /**
+   * Drop every past-TTL scope. Returns how many were dropped.
+   *
+   * Eviction is otherwise entirely lazy: a scope leaves the maps only when the
+   * same scope is touched again after its TTL, or when every declared key has
+   * been redeemed. A child session that is killed, times out, or whose owner
+   * never fulfils the request does neither, so its entry — an AES key plus any
+   * ciphertext already tunneled into it — stays resident for the life of the
+   * parent runtime. Growth is driven by sub-agent request volume, and a catch
+   * cannot un-allocate a map entry, so the sweep has to actually run.
+   */
+  function sweepExpiredScopes(currentTime: number): number {
+    let swept = 0;
+    for (const entry of [...byTokenHash.values()]) {
+      if (entry.expiresAt <= currentTime) {
+        dropScope(entry);
+        swept += 1;
+      }
+    }
+    return swept;
+  }
+
   return {
     declareScope({ childSessionId, credentialKeys }) {
       if (
@@ -243,6 +265,13 @@ export function createCredentialTunnelService(options?: {
         }
         normalized.add(raw.trim());
       }
+
+      // Declaring is the only operation that grows the maps, so it is also the
+      // point at which abandoned scopes must be reclaimed. Nothing else runs a
+      // proactive sweep: `expireScopes` is public but no caller schedules it,
+      // so without this a parent runtime accumulates one dead entry per
+      // sub-agent that never redeems every key it declared.
+      sweepExpiredScopes(now());
 
       const tokenBytes = randomBytes(TOKEN_BYTES);
       const scopedToken = tokenBytes.toString("hex");
@@ -389,14 +418,7 @@ export function createCredentialTunnelService(options?: {
     },
 
     expireScopes(currentTime = now()) {
-      let swept = 0;
-      for (const entry of [...byTokenHash.values()]) {
-        if (entry.expiresAt <= currentTime) {
-          dropScope(entry);
-          swept += 1;
-        }
-      }
-      return swept;
+      return sweepExpiredScopes(currentTime);
     },
 
     hasCiphertext(credentialScopeId, key) {


### PR DESCRIPTION
# Relates to

Fixes #24168

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is branched from the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` ran clean after sync. `bun run verify` was not run whole; the
      focused suites, package typecheck and biome were run and are recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased (not merged) onto `origin/develop` @ `e495770b667d426b419754bef11c19ed072de614`; zero conflicts.
- [x] The focused suites and Biome pass at exact head. Package typecheck was run
      and still exits 1 on workspace-resolution/native typing failures listed
      under **Known gaps / failures**.

# Risks

**Low, with a named public-contract change.** One service file plus one new test
file, both under `packages/app-core`.

The sweep drops only entries whose `expiresAt` is already past. Every one of
those was already refused by both credential-releasing paths, and nothing a
caller can observe about a live scope changes. However, after the declare-time
sweep removes an expired entry, retrieval reports `invalid_token` instead of
`scope_expired`, while tunneling reports `unknown_scope` instead of
`scope_expired`. The owner HTTP route therefore maps those swept identities to
400/404 rather than 410, and the child bridge maps them to rejected/403 rather
than expired/410. The focused suite now pins both codes. No timer is introduced,
so there is no new lifecycle to schedule, unref, or tear down.

# Outcome

Declaring a scope proactively removes all already-expired scope entries,
including their AES key and any staged ciphertext, so retention is bounded by
live scopes rather than lifetime request volume. `expireScopes()` delegates to
the same sweep. Live scopes retain the existing success and rejection behavior;
already-swept expired identities intentionally use the ordinary unknown-token
and unknown-scope errors described above.

# Background

## What does this PR do?

`createCredentialTunnelService` keeps every declared scope in `byTokenHash` and
`byId`. A `ScopeEntry` holds the scope's AES-256-GCM key and, once the owner has
answered, the per-key ciphertext. Entries leave those maps only when the same
scope is touched again after its TTL, or when *every* declared key has been
redeemed.

A child session that is killed, times out, or whose owner never fulfils the
request satisfies neither, so its entry stays resident for the life of the
parent runtime. `expireScopes()` is the only proactive sweep and it has no
production caller — a repo-wide grep finds the interface declaration, the
implementation, and three test lines, nothing else, and
`sub-agent-credential-bridge-wiring.ts` constructs one service per parent
runtime without ever scheduling it.

Nothing throws here. `declareScope` succeeds and returns a valid scope; the
entry it inserted is simply never removed. Growth is driven directly by
sub-agent request volume, and a catch cannot un-allocate a map entry.

This PR sweeps past-TTL scopes when a new one is declared — the only operation
that grows the maps, and so the natural place to reclaim dead ones. It bounds
retention by the number of *live* scopes instead of by lifetime request volume.
`expireScopes` now delegates to the same sweep rather than duplicating it.

**This is not an authorization defect.** Both credential-releasing paths already
check expiry before releasing anything (`tunnelCredential` at lines 286/293,
`retrieveCredential` at lines 338/345), so an expired scope was never usable.
The only lookup that skips the expiry check is `hasCiphertext`, a read-only
presence predicate documented as test-only that releases no credential material.
The defect is retention, not access.

## What kind of change is this?

Bug fix with an intentional public rejection-code/status change for identities
that have already been removed by the new sweep. The live-scope contract is
unchanged.

# Documentation changes needed?

No product documentation changes are required. This PR description explicitly
documents the declare-time sweep and its post-sweep public error/status mapping.

# Testing

## Where should a reviewer start?

`packages/app-core/src/services/credential-tunnel-scope-retention.test.ts`. It
drives the real service through its real public interface using the injected
clock the service already accepts, so there are no timers and no real waiting.

## Detailed testing steps

```bash
bun install
bun run --cwd packages/core prebuild
node packages/scripts/run-vitest.mjs run \
  --config packages/app-core/vitest.config.ts \
  packages/app-core/src/services/credential-tunnel
```

# Evidence Gate

<!-- evidence-head:ebb59d718b86f06ee255cb2a2d7f43bb20ecb65b -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface. The change is in-memory scope retention in a background service.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface. The change is in-memory scope retention in a background service.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-visible flow; the affected state is an internal map in the parent runtime.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - deterministic in-process service tests are transcribed under Evidence Details; no deployed backend process is involved`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend code path is involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt or model code is touched.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - the affected artifact is ephemeral in-memory map state asserted through the real service API; no persistent artifact exists`
<!-- evidence-row:ocr-review -->
- [x] `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, action, provider, prompt or model code is touched.`

## Backend + frontend logs

Frontend: `N/A - no frontend code path is involved.`

Backend — the dead-sweep grep on unmodified `origin/develop`:

```
$ git grep -n "expireScopes" -- packages/app-core
packages/app-core/src/services/credential-tunnel-service.test.ts:198:  it("expireScopes sweeps past-TTL scopes and returns the count", () => {
packages/app-core/src/services/credential-tunnel-service.test.ts:213:    expect(service.expireScopes()).toBe(2);
packages/app-core/src/services/credential-tunnel-service.test.ts:214:    expect(service.expireScopes()).toBe(0);
packages/app-core/src/services/credential-tunnel-service.ts:186:  expireScopes(now?: number): number;
packages/app-core/src/services/credential-tunnel-service.ts:391:    expireScopes(currentTime = now()) {
```

**Reproduction on unmodified `origin/develop`.** Worktree at
`f9e73252878705555368c3d79058fe7f2f774d7a`; `credential-tunnel-service.ts`
confirmed byte-identical to `origin/develop`. The origin file was extracted with
`git show origin/develop:packages/app-core/src/services/credential-tunnel-service.ts`
and restored by copy-aside (never `git stash`):

<details><summary>origin reproduction — 2 of 5 fail</summary>

```
 ❯ src/services/credential-tunnel-scope-retention.test.ts (5 tests | 2 failed)
     × reclaims scopes abandoned by their child session when a new one is declared
     × reclaims a scope whose child redeemed only some of its declared keys

 Test Files  1 failed (1)
      Tests  2 failed | 3 passed (5)
```

</details>

**On the final rebased head** (`ebb59d718b86f06ee255cb2a2d7f43bb20ecb65b`), the whole
credential-tunnel directory, which includes the pre-existing
`credential-tunnel-service.test.ts` suite:

```
 RUN  v4.1.10 /Volumes/thescoho_1TB/Developer/worktrees/eliza-appcore-mine-20260822

 Test Files  2 passed (2)
      Tests  18 passed (18)
   Start at  01:44:51
   Duration  23.05s (transform 15.50s, setup 0ms, import 22.59s, tests 35ms, environment 0ms)
```

**Load-bearing check**: the fix was reverted by copy-aside, the suite dropped to
2 failed / 3 passed as shown, and restoring the fix returned the original five
retention cases to green. The final exact-head run adds the post-sweep contract
case and passes 18/18 across both files.

## Screenshots (before / after) + video walkthrough

`N/A - no rendered visual surface; this is in-memory scope retention in a background service.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS or STT code is touched.`

## Domain artifacts — no over-rejection

The three cases that pass on **both** sides are the compatibility guards, and
they are deliberately the majority of the new suite:

| case | origin | branch |
|---|---|---|
| a still-live scope stays usable across a later declare | pass | pass |
| an expired scope is still refused | pass | pass |
| a direct `expireScopes()` call still reports its count | pass | pass |
| pre-existing `credential-tunnel-service.test.ts` (12 cases, incl. replay, session isolation, undeclared keys, bad token shapes, bridge dispatch) | pass | pass |

The final suite also pins the intentional post-sweep behavior that the earlier
description omitted:

| operation on the expired identity after a later declare sweeps it | before sweep integration | branch |
|---|---|---|
| retrieve with the former scoped token | `scope_expired` | `invalid_token` |
| tunnel with the former scope id | `scope_expired` | `unknown_scope` |

No previously-passing case changed verdict. The behavior changes are (1)
reclaiming entries that were already past TTL and unusable for credential
release and (2) returning the ordinary unknown-token/unknown-scope errors once
those expired identities have been removed from both indexes.

**Typecheck vs an untouched control**, both measured on the same tree state
(the control was produced by restoring the origin file by copy-aside and moving
the new test out, then restoring both):

```
control:  61 errors
branch:   61 errors
diff <(control) <(branch) -> empty
ZERO ADDED — error sets identical
```

**Biome** on the touched files: clean.

## Known gaps / failures

- **Exact-head `bun run --cwd packages/app-core typecheck` exits 1** on existing
  workspace-resolution and native-platform typing failures outside the two
  touched files. The older same-tree control comparison above established zero
  added errors at the pre-rebase head; I did not repeat that copy-aside control
  after the final rebase, so I do not claim a fresh develop/control comparison.
- **The sweep is O(live scopes) per declare.** That is deliberate: it avoids
  introducing a timer that would need scheduling, `unref()`, and teardown in a
  service that currently owns no lifecycle. If declare volume ever makes the
  linear scan matter, a timer or a min-heap keyed on `expiresAt` would be the
  next step. I did not benchmark declare throughput.
- **I did not measure real process RSS growth.** The retention is demonstrated
  through the service's own `expireScopes()` return value, which reports how many
  past-TTL entries were still resident, rather than from a heap snapshot.
- **`packages/core` needs `prebuild` before this suite runs.** On a fresh install
  `packages/core/src/i18n/generated/validation-keyword-data.ts` does not exist and
  the suite fails to import — on develop as well as on this branch. It is a
  gitignored generated file. Not caused by, and not addressed by, this PR.
- **Hosted CI does not run on this PR** — I am a fork contributor without push
  access, so the workflows are not triggered for me. Every result above is from
  local execution on macOS 15 (darwin 25.5.0), bun + vitest 4.1.10.

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0KCCG1TQGFNJKBCX8CKN155","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-22T00:02:01.915Z","completed_at":"2026-08-22T00:02:54.620Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-22T00:02:03.225Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"cea5c9bcdf04c510a2da84a12112559a5d748024fa555edfca73b28e44fdb319","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"53580196-1c40-4ca6-80c1-e8df722f428a","object_id":"sha256:cea5c9bcdf04c510a2da84a12112559a5d748024fa555edfca73b28e44fdb319","sha256":"cea5c9bcdf04c510a2da84a12112559a5d748024fa555edfca73b28e44fdb319"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"pQOmvxDIBnxOorojhewR8wci6tYwmdYVKL03PO5xHGUqbbhD3fmtXEJnIA82GZBx8n36Z98oKSWf40LknDwvCg"}} -->
