### PR TITLE
fix(android): preserve smoke oracle and streaming

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/BionicDecodeLoop.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/BionicDecodeLoop.java
@@ -80,8 +80,9 @@ final class BionicDecodeLoop {
 
     /**
      * Drive one turn while enforcing caller-supplied textual stop sequences.
-     * A suffix up to the longest marker is withheld from the streaming sink so
-     * markers split across native decode steps never leak to the consumer.
+     * Only a trailing prefix of a stop marker is withheld from the streaming
+     * sink, so markers split across native decode steps never leak while
+     * unrelated text is emitted immediately.
      */
     static Result run(StepFn step, int maxTokens, int stepTokens,
                       List<String> stopSequences, TokenSink sink) throws Exception {
@@ -92,7 +93,6 @@ final class BionicDecodeLoop {
 
         final StringBuilder sb = new StringBuilder();
         final StringBuilder pending = new StringBuilder();
-        final int longestStop = longestStopLength(stopSequences);
         boolean stopped = false;
         int produced = 0;
         while (produced < cap) {
@@ -107,8 +107,8 @@ final class BionicDecodeLoop {
                     pending.setLength(0);
                     stopped = true;
                 } else {
-                    final int safeLength = Math.max(0, pending.length()
-                        - Math.max(0, longestStop - 1));
+                    final int safeLength = pending.length()
+                        - longestPendingStopPrefix(pending, stopSequences);
                     if (safeLength > 0) {
                         commit(pending.substring(0, safeLength), sb, sink);
                         pending.delete(0, safeLength);
@@ -133,12 +133,26 @@ final class BionicDecodeLoop {
         if (sink != null) sink.emit(text);
     }
 
-    private static int longestStopLength(List<String> stopSequences) {
+    private static int longestPendingStopPrefix(
+            CharSequence text, List<String> stopSequences) {
+        if (text.length() == 0 || stopSequences == null || stopSequences.isEmpty()) return 0;
         int longest = 0;
-        if (stopSequences == null) return longest;
         for (String stop : stopSequences) {
-            if (stop != null && !stop.isEmpty()) {
-                longest = Math.max(longest, stop.length());
+            if (stop == null || stop.isEmpty()) continue;
+            final int candidateMax = Math.min(text.length(), stop.length());
+            for (int length = candidateMax; length > longest; length--) {
+                final int suffixStart = text.length() - length;
+                boolean matches = true;
+                for (int i = 0; i < length; i++) {
+                    if (text.charAt(suffixStart + i) != stop.charAt(i)) {
+                        matches = false;
+                        break;
+                    }
+                }
+                if (matches) {
+                    longest = length;
+                    break;
+                }
             }
         }
         return longest;

--- a/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/BionicDecodeLoopTest.java
+++ b/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/BionicDecodeLoopTest.java
@@ -1,6 +1,7 @@
 package ai.elizaos.app;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -154,19 +155,71 @@ public final class BionicDecodeLoopTest {
     }
 
     @Test
-    public void stopSequenceSplitAcrossStepsIsRemovedAndEndsDecode() throws Exception {
+    public void mandatoryStopSequencesSplitAcrossStepsNeverLeak() throws Exception {
+        final List<String> stops =
+            Arrays.asList("<end_of_turn>", "<start_of_turn>", "<endoftext>");
+        for (String marker : stops) {
+            final List<String> frames = new ArrayList<>();
+            final int split = marker.length() / 2;
+            final String[] pieces = {
+                "Ready" + marker.substring(0, split),
+                marker.substring(split) + "ignored",
+                "never reached"
+            };
+            final int[] call = {0};
+            final BionicDecodeLoop.StepFn fn = stepCap ->
+                new BionicDecodeLoop.Step(pieces[call[0]++], 2, false);
+
+            final BionicDecodeLoop.Result r =
+                BionicDecodeLoop.run(fn, 64, 2, stops, frames::add);
+
+            assertEquals("Ready", r.text);
+            assertEquals(Arrays.asList("Ready"), frames);
+            assertFalse(r.text.contains(marker));
+            assertFalse(String.join("", frames).contains(marker));
+            assertEquals(4, r.produced);
+            assertEquals(2, call[0]);
+        }
+    }
+
+    @Test
+    public void longUnrelatedStopDoesNotDelaySafeText() throws Exception {
         final List<String> frames = new ArrayList<>();
-        final String[] pieces = {"Ready<end_", "of_turn>ignored", "never reached"};
+        final StringBuilder longStop = new StringBuilder();
+        for (int i = 0; i < 1024; i++) longStop.append('x');
         final int[] call = {0};
-        final BionicDecodeLoop.StepFn fn = stepCap ->
-            new BionicDecodeLoop.Step(pieces[call[0]++], 2, false);
+        final BionicDecodeLoop.StepFn fn = stepCap -> {
+            call[0]++;
+            if (call[0] == 1) {
+                return new BionicDecodeLoop.Step("safe output", 2, false);
+            }
+            assertEquals(Arrays.asList("safe output"), frames);
+            return new BionicDecodeLoop.Step("", 1, true);
+        };
 
         final BionicDecodeLoop.Result r = BionicDecodeLoop.run(
-            fn, 64, 2, Arrays.asList("<end_of_turn>", "<start_of_turn>"), frames::add);
+            fn, 64, 8, Arrays.asList(longStop.toString()), frames::add);
 
-        assertEquals("Ready", r.text);
-        assertEquals(Arrays.asList("Ready"), frames);
-        assertEquals(4, r.produced);
+        assertEquals("safe output", r.text);
+        assertEquals(Arrays.asList("safe output"), frames);
+        assertEquals(2, call[0]);
+    }
+
+    @Test
+    public void overlappingStopPrefixesWithholdOnlyTheLongestPendingSuffix() throws Exception {
+        final List<String> frames = new ArrayList<>();
+        final String[] pieces = {"visible<sto", "p>hidden", "never reached"};
+        final int[] call = {0};
+        final BionicDecodeLoop.StepFn fn = stepCap -> {
+            if (call[0] == 1) assertEquals(Arrays.asList("visible"), frames);
+            return new BionicDecodeLoop.Step(pieces[call[0]++], 2, false);
+        };
+
+        final BionicDecodeLoop.Result r = BionicDecodeLoop.run(
+            fn, 64, 2, Arrays.asList("<stop-extra>", "<stop>"), frames::add);
+
+        assertEquals("visible", r.text);
+        assertEquals(Arrays.asList("visible"), frames);
         assertEquals(2, call[0]);
     }
 
@@ -183,7 +236,7 @@ public final class BionicDecodeLoopTest {
             fn, 64, 8, Arrays.asList("<end_of_turn>"), frames::add);
 
         assertEquals("answer<end_", r.text);
-        assertEquals(Arrays.asList("answer<end_"), frames);
+        assertEquals(Arrays.asList("answer", "<end_"), frames);
         assertEquals(1, call[0]);
     }
 

--- a/packages/app/scripts/lib/android-device.mjs
+++ b/packages/app/scripts/lib/android-device.mjs
@@ -428,8 +428,15 @@ export function verifyInstalledApkHash({ localHash, deviceHash } = {}) {
   return { sha256: localHash };
 }
 
-export function readInstalledApkPath(adbBin, serial) {
-  const pmPath = adbTry(adbBin, ["-s", serial, "shell", "pm", "path", APP_ID]);
+export function readInstalledApkPath(adbBin, serial, packageId = APP_ID) {
+  const pmPath = adbTry(adbBin, [
+    "-s",
+    serial,
+    "shell",
+    "pm",
+    "path",
+    packageId,
+  ]);
   return parseApkPath(pmPath);
 }
 
@@ -492,9 +499,9 @@ export function readRendererStampFromApk(apkPath) {
 export function readInstalledRendererStamp(
   adbBin,
   serial,
-  { tmpRoot = os.tmpdir(), log = () => {} } = {},
+  { tmpRoot = os.tmpdir(), log = () => {}, packageId = APP_ID } = {},
 ) {
-  const remoteApk = readInstalledApkPath(adbBin, serial);
+  const remoteApk = readInstalledApkPath(adbBin, serial, packageId);
   if (!remoteApk) return null;
 
   const tempDir = fs.mkdtempSync(path.join(tmpRoot, "eliza-android-apk-"));

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -16,6 +16,7 @@ import path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
+import { readInstalledRendererStamp } from "./lib/android-device.mjs";
 import { ANDROID_FULL_TURN_FAILURE_RE } from "./lib/chat-failure-strings.mjs";
 import {
   assertMarkerSurvivedRelaunch,
@@ -830,6 +831,11 @@ function androidDeviceSerial(adb) {
       );
     }
   }
+  if (requireInstalled && connected.length > 1) {
+    throw new Error(
+      `Multiple Android devices are attached (${connected.join(", ")}); set ANDROID_SERIAL so installed-app evidence is bound to one explicit target.`,
+    );
+  }
   return (
     connected.find((serial) => serial.startsWith("emulator-")) ??
     connected[0] ??
@@ -837,7 +843,54 @@ function androidDeviceSerial(adb) {
   );
 }
 
-async function launchAndroidEmulatorApp() {
+function commitsMatch(expected, actual) {
+  if (
+    !/^[0-9a-f]{7,40}$/i.test(expected) ||
+    !/^[0-9a-f]{7,40}$/i.test(actual)
+  ) {
+    return false;
+  }
+  return expected.startsWith(actual) || actual.startsWith(expected);
+}
+
+function currentGitHead() {
+  return requireExec(
+    "git",
+    ["rev-parse", "HEAD"],
+    "Could not resolve the source revision for Android installed-app evidence.",
+  ).trim();
+}
+
+function assertInstalledAndroidRendererIsFresh(
+  context,
+  { expectedCommit, readStamp = readInstalledRendererStamp } = {},
+) {
+  if (!context?.installed) return;
+  const sourceCommit = expectedCommit ?? currentGitHead();
+  const stamp = readStamp(context.adb, context.serial, {
+    packageId: appId(),
+    log: (message) => console.warn(`[local-chat-smoke] ${message}`),
+  });
+  if (
+    typeof stamp?.commit !== "string" ||
+    !commitsMatch(sourceCommit, stamp.commit)
+  ) {
+    const detail =
+      typeof stamp?.commit === "string" && stamp.commit.length > 0
+        ? `revision ${stamp.commit} does not match source HEAD ${sourceCommit}`
+        : "has no valid renderer revision";
+    throw new Error(
+      `Installed Android app on ${context.serial} ${detail}; refusing unverifiable smoke evidence.`,
+    );
+  }
+  console.log(
+    `[local-chat-smoke] Installed Android renderer matches source revision ${sourceCommit.slice(0, 12)}.`,
+  );
+}
+
+async function launchAndroidEmulatorApp({
+  verifyInstalled = assertInstalledAndroidRendererIsFresh,
+} = {}) {
   const adb = adbPath();
   if (!adb) {
     const message =
@@ -865,6 +918,7 @@ async function launchAndroidEmulatorApp() {
   }
 
   const context = { adb, serial, installed: true };
+  verifyInstalled(context);
   const prepareAndLaunch = async () => {
     if (androidSelectLocal) {
       removeAndroidReverse(context, ANDROID_LOCAL_AGENT_DEVICE_PORT);
@@ -2929,6 +2983,7 @@ export {
   androidE2eApiPortOverrideArgs,
   androidRunAs,
   appId,
+  assertInstalledAndroidRendererIsFresh,
   cleanupAndroidAgentForwards,
   copyFileIfChanged,
   describeAndroidSmokeModelSize,

--- a/packages/app/scripts/mobile-local-chat-smoke.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.mjs
@@ -324,7 +324,7 @@ const ANDROID_FULL_TURN_PROMPT =
   "Reply with exactly these four words: android smoke model works.";
 const ANDROID_FULL_TURN_EXPECTED_REPLY = "android smoke model works";
 const ANDROID_FULL_TURN_CONTROL_TOKEN_RE =
-  /<(?:end|start)_of_turn>|<\|(?:im_end|im_start)\|>/i;
+  /<(?:end|start)_of_turn>|<endoftext>|<\|(?:im_end|im_start)\|>/i;
 const ANDROID_SMOKE_MODEL_CONTEXT_SIZE =
   smokeNumbers.androidSmokeModelContextSize;
 const ANDROID_SMOKE_MODEL_ID =
@@ -2453,6 +2453,17 @@ function requireUsableFullTurnReply(done, rawStreamText) {
   }
   if (ANDROID_FULL_TURN_CONTROL_TOKEN_RE.test(reply)) {
     throw new Error(`Full-turn smoke leaked a model control token: ${reply}`);
+  }
+  const normalizedReply = reply
+    .trim()
+    .replace(/^["'`]+|["'`]+$/g, "")
+    .replace(/[.!?]+$/g, "")
+    .replace(/\s+/g, " ")
+    .toLowerCase();
+  if (normalizedReply !== ANDROID_FULL_TURN_EXPECTED_REPLY) {
+    throw new Error(
+      `Full-turn smoke returned the wrong reply: ${reply} (expected ${ANDROID_FULL_TURN_EXPECTED_REPLY})`,
+    );
   }
   return reply;
 }

--- a/packages/app/scripts/mobile-local-chat-smoke.test.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.test.mjs
@@ -389,7 +389,7 @@ describe("mobile smoke result parsing", () => {
     );
   });
 
-  it("requires a useful full-turn reply without leaked model control tokens", () => {
+  it("requires the normalized exact full-turn reply", () => {
     expect(
       smoke.requireUsableFullTurnReply(
         { fullText: '"Android smoke model works!"' },
@@ -402,19 +402,32 @@ describe("mobile smoke result parsing", () => {
       [{ noResponseReason: "muted" }, /noResponseReason/],
       [{ text: "" }, /empty reply/],
       [{ text: "Chat generation failed" }, /unusable reply/],
-      [{ text: "answer<end_of_turn>next prompt" }, /control token/],
     ]) {
       expect(() => smoke.requireUsableFullTurnReply(done, "stream")).toThrow(
         expected,
       );
     }
-    expect(
+  });
+
+  it("rejects a nonempty but semantically wrong full-turn reply", () => {
+    expect(() =>
       smoke.requireUsableFullTurnReply(
         { text: "I am ready to assist you. How can I help?" },
         "stream",
       ),
-    ).toBe("I am ready to assist you. How can I help?");
+    ).toThrow(/wrong reply/);
   });
+
+  for (const marker of ["<end_of_turn>", "<start_of_turn>", "<endoftext>"]) {
+    it(`rejects the leaked ${marker} model control marker`, () => {
+      expect(() =>
+        smoke.requireUsableFullTurnReply(
+          { text: `android smoke model works${marker}` },
+          "stream",
+        ),
+      ).toThrow(/control token/);
+    });
+  }
 
   it("summarizes optional local-inference payloads without inventing readiness", () => {
     expect(

--- a/packages/app/scripts/mobile-local-chat-smoke.test.mjs
+++ b/packages/app/scripts/mobile-local-chat-smoke.test.mjs
@@ -16,6 +16,7 @@ const fakeDirectory = fs.mkdtempSync(
 let fakeDefaultsState;
 let fakeIosDataContainer;
 let fakeAndroidContext;
+let fakeCommandLog;
 
 process.env.ANDROID_STABILITY_SAMPLES = "2";
 process.env.ANDROID_STABILITY_ATTEMPTS = "3";
@@ -107,6 +108,7 @@ function validIosFullBunResult() {
 
 beforeAll(() => {
   fakeDefaultsState = path.join(fakeDirectory, "defaults.json");
+  fakeCommandLog = path.join(fakeDirectory, "commands.jsonl");
   fakeIosDataContainer = path.join(fakeDirectory, "ios-data");
   const fakeIosAppContainer = path.join(fakeDirectory, "App.app");
   const fakeModel = path.join(fakeDirectory, "model.gguf");
@@ -120,6 +122,7 @@ beforeAll(() => {
   fs.writeFileSync(fakeModel, "gguf");
 
   process.env.FAKE_DEFAULTS_STATE = fakeDefaultsState;
+  process.env.FAKE_MOBILE_COMMAND_LOG = fakeCommandLog;
   process.env.FAKE_IOS_DATA_CONTAINER = fakeIosDataContainer;
   process.env.FAKE_IOS_APP_CONTAINER = fakeIosAppContainer;
   process.env.ELIZA_IOS_FULL_BUN_SMOKE_MODEL_PATH = fakeModel;
@@ -249,6 +252,61 @@ describe("mobile smoke filesystem and encoding helpers", () => {
 });
 
 describe("mobile smoke native command boundaries", () => {
+  it("binds installed Android smoke evidence to the current renderer revision", () => {
+    const context = { adb: "adb", serial: "device-1", installed: true };
+    let requestedPackageId = null;
+    expect(() =>
+      smoke.assertInstalledAndroidRendererIsFresh(context, {
+        expectedCommit: "abcdef1234567890",
+        readStamp: (_adb, _serial, options) => {
+          requestedPackageId = options.packageId;
+          return { commit: "abcdef1234", buildId: "build-1" };
+        },
+      }),
+    ).not.toThrow();
+    expect(requestedPackageId).toBe("ai.elizaos.app");
+    expect(() =>
+      smoke.assertInstalledAndroidRendererIsFresh(context, {
+        expectedCommit: "abcdef1234567890",
+        readStamp: () => null,
+      }),
+    ).toThrow(/no valid renderer revision/);
+    expect(() =>
+      smoke.assertInstalledAndroidRendererIsFresh(context, {
+        expectedCommit: "abcdef1234567890",
+        readStamp: () => ({ commit: 123, buildId: "malformed-build" }),
+      }),
+    ).toThrow(/no valid renderer revision/);
+    expect(() =>
+      smoke.assertInstalledAndroidRendererIsFresh(context, {
+        expectedCommit: "abcdef1234567890",
+        readStamp: () => ({ commit: "1111111111", buildId: "old-build" }),
+      }),
+    ).toThrow(/does not match source HEAD/);
+  });
+
+  it("refuses an unverifiable installed Android app before launching it", async () => {
+    fs.writeFileSync(fakeCommandLog, "");
+    await expect(
+      smoke.launchAndroidEmulatorApp({
+        verifyInstalled: () => {
+          throw new Error("installed revision mismatch");
+        },
+      }),
+    ).rejects.toThrow(/revision mismatch/);
+    const commands = fs
+      .readFileSync(fakeCommandLog, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    expect(
+      commands.some(
+        ({ command, args }) => command === "adb" && args.includes("am"),
+      ),
+    ).toBe(false);
+  });
+
   it("seeds, stages, reads, and verifies the iOS full-Bun handshake through simulator defaults", async () => {
     const launched = smoke.launchIosSimulatorApp();
     expect(launched).toMatchObject({
@@ -304,7 +362,9 @@ describe("mobile smoke native command boundaries", () => {
     expect(smoke.androidDeviceSerial(fakeAndroidContext.adb)).toBe(
       "emulator-unit",
     );
-    const launched = await smoke.launchAndroidEmulatorApp();
+    const launched = await smoke.launchAndroidEmulatorApp({
+      verifyInstalled: () => {},
+    });
     expect(launched).toMatchObject({
       serial: "emulator-unit",
       installed: true,

--- a/packages/app/test/fixtures/mobile-command-proxy.cjs
+++ b/packages/app/test/fixtures/mobile-command-proxy.cjs
@@ -4,6 +4,12 @@ const path = require("node:path");
 
 const command = path.basename(process.argv[2]);
 const args = process.argv.slice(3);
+if (process.env.FAKE_MOBILE_COMMAND_LOG) {
+  fs.appendFileSync(
+    process.env.FAKE_MOBILE_COMMAND_LOG,
+    `${JSON.stringify({ command, args })}\n`,
+  );
+}
 
 if (command === "xcrun") {
   if (args[0] !== "simctl") process.exit(2);


### PR DESCRIPTION
# Relates to

Closes #24170.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`9c1fc32c0def7f3da4d40d54d88ac343e24c3a97`).
- [ ] `bun install` and `bun run verify` were not run locally; see **Known gaps / failures**.
- [x] A reviewer can confirm the changed contracts from the exact-head focused evidence below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` requires hosted CI because the shared host does not have enough safe free disk for a fresh monorepo install/build; see **Known gaps / failures**.

# Risks

Medium. This changes native token streaming and the Android smoke success oracle. A regression could delay streamed text or allow a semantically wrong/local-control-marker response to pass the smoke gate. Focused Java and JavaScript tests cover those paths; physical ARM64 proof remains a merge hold.

# Background

## What does this PR do?

- restores normalized exact-reply comparison for the Android full-turn smoke instead of accepting any nonempty response;
- rejects leaked `<end_of_turn>`, `<start_of_turn>`, and `<endoftext>` model control markers;
- makes the bionic decode loop retain only the suffix that can still become a stop sequence, so unrelated long stop strings no longer buffer ordinary output;
- adds regression coverage for wrong prose, each mandatory marker, split markers, overlapping stops, and a 1,024-character unrelated stop.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores the documented smoke and streaming behavior without changing the public interface.

# Testing

## Where should a reviewer start?

- `packages/app/scripts/mobile-local-chat-smoke.mjs`
- `packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/BionicDecodeLoop.java`
- their adjacent focused test files

## Detailed testing steps

Exact head: `ad0a5a9c96203a933dcff832489a7a93f505b8a5`

```bash
bun test packages/app/scripts/mobile-local-chat-smoke.test.mjs
# 31 pass, 0 fail, 139 assertions

bunx biome check packages/app/scripts/mobile-local-chat-smoke.mjs packages/app/scripts/mobile-local-chat-smoke.test.mjs
# Checked 2 files. No fixes applied.

git diff origin/develop...HEAD --check
# clean

cd packages/app-core/platforms/android
./gradlew :app:testDebugUnitTest \
  --tests ai.elizaos.app.BionicDecodeLoopTest \
  --no-daemon \
  -x :app:copyForkLlamaLib
# BUILD SUCCESSFUL; JUnit receipt: tests=18, skipped=0, failures=0, errors=0
```

# Evidence Gate

<!-- evidence-head:ad0a5a9c96203a933dcff832489a7a93f505b8a5 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a native streaming/smoke-contract hotfix with no visual flow change.
<!-- evidence-row:backend-logs -->
- [x] Focused test output above exercises the Java streaming and JavaScript smoke validation paths; physical-device logs remain a merge hold below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/state surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, planner, provider, or model-selection behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] The Android JUnit XML receipt reports 18 tests, zero skipped/failures/errors at the exact head.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - this hotfix changes native output framing and the deterministic smoke oracle, not agent/model behavior.

## Backend + frontend logs

The exact-head focused command results are recorded in **Testing**. No frontend surface changed.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface changed.

## Audio / voice walkthrough

N/A - no voice/TTS/STT path changed.

## Known gaps / failures

- **Merge/acceptance hold:** rerun the exact semantic full-turn smoke on a supported physical ARM64 Android target and attach the device/runtime logs. This is protected device evidence and is not a reason to keep the source-complete PR in draft.
- **Hosted gate hold:** the shared local host has under 1 GiB safely available, so a fresh root `bun install` plus `bun run verify` was not attempted. Required hosted checks must pass at this exact head before merge.
- The Android unit command warns that the machine-local debug signing identity is used and that the staged native library lacks optional fused-voice symbols; neither warning affects this Java-only test target.

# Attribution

- Agent: OpenAI / gpt-5.6-sol
- Client: Codex Desktop
- Skill: N/A
