### PR TITLE
fix(ui): preserve idempotency across credit-checkout retries (#24144)

### DIFF
--- a/packages/ui/src/cloud/billing/BillingSection.test.tsx
+++ b/packages/ui/src/cloud/billing/BillingSection.test.tsx
@@ -25,6 +25,9 @@ const billingUser = vi.hoisted(() => ({
 const billingUserOptions = vi.hoisted(() => ({
   current: null as { requireFreshOrganization?: boolean } | null,
 }));
+const observedCheckoutIntentStores = vi.hoisted(
+  () => [] as Array<{ current: unknown }>,
+);
 vi.mock("@elizaos/ui/cloud-ui", () => ({
   DashboardErrorState: ({ message }: { message: string }) => (
     <div role="alert">{message}</div>
@@ -45,7 +48,14 @@ vi.mock("./data/billing-data", () => ({
 }));
 
 vi.mock("./components/billing-tab", () => ({
-  BillingTab: () => <div>billing tab</div>,
+  BillingTab: ({
+    checkoutIntentStore,
+  }: {
+    checkoutIntentStore: { current: unknown };
+  }) => {
+    observedCheckoutIntentStores.push(checkoutIntentStore);
+    return <div>billing tab</div>;
+  },
 }));
 
 vi.mock("./wallet/ConditionalWalletProviders", () => ({
@@ -60,6 +70,7 @@ describe("BillingSectionBody", () => {
   afterEach(() => {
     cleanup();
     billingUserOptions.current = null;
+    observedCheckoutIntentStores.length = 0;
     billingUser.value = {
       user: null,
       isLoading: false,
@@ -117,6 +128,50 @@ describe("BillingSectionBody", () => {
     expect(text).toContain("Loading billing");
     expect(text).not.toContain("billing tab");
     expect(text).not.toContain("account limits card");
+  });
+
+  it("preserves checkout intent ownership across a membership refresh remount", () => {
+    billingUser.value = {
+      user: { organization_id: "org-1" },
+      isLoading: false,
+      isFetching: false,
+      isPaused: false,
+      isFetchedAfterMount: true,
+      isAuthenticated: true,
+      isError: false,
+      error: null,
+    };
+    const view = render(<BillingSectionBody />);
+    const initialStore = observedCheckoutIntentStores.at(-1);
+    expect(initialStore).toBeDefined();
+    if (!initialStore) throw new Error("BillingTab did not receive its store");
+    initialStore.current = {
+      organizationId: "org-1",
+      amount: 25,
+      key: "persisted-checkout-key",
+    };
+
+    billingUser.value = {
+      ...billingUser.value,
+      isFetching: true,
+      isFetchedAfterMount: false,
+    };
+    view.rerender(<BillingSectionBody />);
+    expect(view.container.textContent).toContain("Loading billing");
+
+    billingUser.value = {
+      ...billingUser.value,
+      isFetching: false,
+      isFetchedAfterMount: true,
+    };
+    view.rerender(<BillingSectionBody />);
+    const remountedStore = observedCheckoutIntentStores.at(-1);
+    expect(remountedStore).toBe(initialStore);
+    expect(remountedStore?.current).toEqual({
+      organizationId: "org-1",
+      amount: 25,
+      key: "persisted-checkout-key",
+    });
   });
 
   it("does not paint a cached organization while its membership refresh is paused", () => {

--- a/packages/ui/src/cloud/billing/BillingSection.tsx
+++ b/packages/ui/src/cloud/billing/BillingSection.tsx
@@ -21,8 +21,9 @@ import {
   DashboardErrorState,
   DashboardLoadingState,
 } from "@elizaos/ui/cloud-ui";
+import { useRef } from "react";
 import { useCloudT } from "../shell/CloudI18nProvider";
-import { BillingTab } from "./components/billing-tab";
+import { BillingTab, type CardCheckoutIntent } from "./components/billing-tab";
 import { useBillingUser } from "./data/billing-data";
 import { ConditionalWalletProviders } from "./wallet/ConditionalWalletProviders";
 
@@ -34,6 +35,10 @@ function wasCheckoutCanceled(): boolean {
 /** The billing surface, rendered by the Settings → Cloud billing section. */
 export function BillingSectionBody() {
   const t = useCloudT();
+  // This owner stays mounted while a membership refresh temporarily replaces
+  // BillingTab with its loading state. Keeping the checkout intent here lets an
+  // ambiguous Stripe request replay the same key after that normal remount.
+  const checkoutIntentStore = useRef<CardCheckoutIntent | null>(null);
   const {
     user,
     isLoading,
@@ -92,7 +97,7 @@ export function BillingSectionBody() {
           })}
         </div>
       ) : null}
-      <BillingTab user={user} />
+      <BillingTab user={user} checkoutIntentStore={checkoutIntentStore} />
     </ConditionalWalletProviders>
   );
 }

--- a/packages/ui/src/cloud/billing/components/billing-tab.idempotency.test.tsx
+++ b/packages/ui/src/cloud/billing/components/billing-tab.idempotency.test.tsx
@@ -1,0 +1,379 @@
+/**
+ * Idempotency-key contract for the card checkout (#24144).
+ *
+ * The server requires an Idempotency-Key header (8-128 chars,
+ * ^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$) on non-hardware credit purchases and
+ * scopes durable checkout orders to (org, key). These tests pin the client
+ * side: key present and well-formed on card checkout, reused across retries
+ * of the same amount after transient/ambiguous failures, rotated when the
+ * amount changes (including the A -> B -> A resurrection trap), absent from
+ * the crypto path, and never generated for invalid submissions.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { UserEvent } from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMock = vi.hoisted(() => vi.fn());
+const navigateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../lib/api-client", () => ({
+  api: apiMock,
+  ApiError: class ApiError extends Error {
+    constructor(
+      public readonly status: number,
+      _code: string,
+      message: string,
+    ) {
+      super(message);
+      this.name = "ApiError";
+    }
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../../shell/CloudI18nProvider", () => ({
+  useCloudT:
+    () =>
+    (
+      _key: string,
+      opts?: { defaultValue?: string } & Record<string, unknown>,
+    ) => {
+      let value = opts?.defaultValue ?? _key;
+      if (opts) {
+        for (const [k, v] of Object.entries(opts)) {
+          if (k === "defaultValue") continue;
+          value = value.replace(`{{${k}}}`, String(v));
+        }
+      }
+      return value;
+    },
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock("./auto-top-up-card", () => ({
+  AutoTopUpCard: () => null,
+}));
+
+import type { BillingUser, InvoiceDisplay } from "../types";
+import { BillingTab } from "./billing-tab";
+
+const user: BillingUser = {
+  organization_id: "org-1",
+  wallet_address: null,
+  organization: { credit_balance: 12.5 },
+};
+
+const invoices: InvoiceDisplay[] = [
+  { id: "inv-1", date: "2024-01-02 10:00", total: "$25.00", status: "paid" },
+];
+
+/** The server's exact header contract. */
+const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/;
+
+function routeApi(checkoutResponse: () => Promise<unknown> = () => Promise.resolve({})) {
+  apiMock.mockImplementation((url: string) => {
+    if (url.startsWith("/api/invoices/list")) {
+      return Promise.resolve({ invoices });
+    }
+    if (url.startsWith("/api/credits/balance")) {
+      return Promise.resolve({ balance: 12.5 });
+    }
+    if (url.startsWith("/api/crypto/status")) {
+      return Promise.resolve({ enabled: false });
+    }
+    if (url.startsWith("/api/stripe/create-checkout-session")) {
+      return checkoutResponse();
+    }
+    return Promise.resolve({});
+  });
+}
+
+/** Extract the Idempotency-Key from the nth checkout call. */
+function checkoutCalls() {
+  return apiMock.mock.calls.filter(([url]) =>
+    String(url).startsWith("/api/stripe/create-checkout-session"),
+  );
+}
+
+function keyOf(call: unknown[]): string {
+  const init = call[1] as { headers?: Record<string, string> };
+  return init?.headers?.["Idempotency-Key"] ?? "";
+}
+
+async function submitAmount(
+  actor: UserEvent,
+  amount: string,
+  opts: { buttonName?: RegExp } = {},
+) {
+  const input = screen.getByLabelText("Amount (USD)");
+  await actor.clear(input);
+  await actor.type(input, amount);
+  await actor.click(
+    screen.getByRole("button", { name: opts.buttonName ?? /Buy credits/i }),
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("BillingTab card-checkout idempotency key (#24144)", () => {
+  beforeEach(() => {
+    apiMock.mockReset();
+  });
+
+  it("sends a server-contract-valid Idempotency-Key on card checkout (click path)", async () => {
+    routeApi();
+    const actor = userEvent.setup();
+    render(<BillingTab user={user} />);
+
+    await screen.findAllByTestId("invoice-row");
+    await submitAmount(actor, "25");
+
+    await waitFor(() => {
+      expect(checkoutCalls()).toHaveLength(1);
+    });
+    const key = keyOf(checkoutCalls()[0]);
+    expect(key).toMatch(IDEMPOTENCY_KEY_PATTERN);
+    // A UUID (36 chars) satisfies the contract and is collision-safe.
+    expect(key).toHaveLength(36);
+    // The body contract is unchanged.
+    const init = checkoutCalls()[0][1] as { json: unknown };
+    expect(init.json).toEqual({ amount: 25, returnUrl: "settings" });
+  });
+
+  it("reuses the same key when the same amount is retried after a transient failure", async () => {
+    let attempt = 0;
+    routeApi(() => {
+      attempt += 1;
+      // 503 = transient server condition: the order may exist server-side.
+      if (attempt === 1) {
+        return Promise.reject(
+          new (class extends Error {
+            status = 503;
+          })("upstream unavailable"),
+        );
+      }
+      return Promise.resolve({});
+    });
+    const actor = userEvent.setup();
+    render(<BillingTab user={user} />);
+
+    await screen.findAllByTestId("invoice-row");
+    await submitAmount(actor, "25");
+    await waitFor(() => {
+      expect(checkoutCalls()).toHaveLength(1);
+    });
+    // Wait for the processing state to reset before retrying.
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Buy credits/i })).toBeTruthy();
+    });
+    await submitAmount(actor, "25");
+
+    await waitFor(() => {
+      expect(checkoutCalls()).toHaveLength(2);
+    });
+    expect(keyOf(checkoutCalls()[0])).toBe(keyOf(checkoutCalls()[1]));
+  });
+
+  it("rotates the key when the amount changes before retry", async () => {
+    let attempt = 0;
+    routeApi(() => {
+      attempt += 1;
+      if (attempt === 1) {
+        return Promise.reject(new Error("network down"));
+      }
+      return Promise.resolve({});
+    });
+    const actor = userEvent.setup();
+    render(<BillingTab user={user} />);
+
+    await screen.findAllByTestId("invoice-row");
+    await submitAmount(actor, "25");
+    await waitFor(() => {
+      expect(checkoutCalls()).toHaveLength(1);
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Buy credits/i })).toBeTruthy();
+    });
+    await submitAmount(actor, "30");
+
+    await waitFor(() => {
+      expect(checkoutCalls()).toHaveLength(2);
+    });
+    expect(keyOf(checkoutCalls()[0])).not.toBe(keyOf(checkoutCalls()[1]));
+  });
+
+  it("does not leak a key across different submitted amounts (A -> B -> A matrix)", async () => {
+    // The intent slot is compared at SUBMIT time against the amount being
+    // submitted. Editing without submitting never touches it, so:
+    //   submit 25 (key K1) -> edit to 30 -> edit back to 25 -> submit 25
+    // reuses K1 (same purchase intent, same request digest — safe replay),
+    // while submitting 30 rotates. What must NEVER happen is key reuse
+    // across DIFFERENT submitted amounts.
+    routeApi();
+    const actor = userEvent.setup();
+    render(<BillingTab user={user} />);
+
+    await screen.findAllByTestId("invoice-row");
+    await submitAmount(actor, "25");
+    await waitFor(() => {
+      expect(checkoutCalls()).toHaveLength(1);
+    });
+    const k1 = keyOf(checkoutCalls()[0]);
+
+    await submitAmount(actor, "30");
+    await waitFor(() => {
+      expect(checkoutCalls()).toHaveLength(2);
+    });
+    const k2 = keyOf(checkoutCalls()[1]);
+    expect(k2).not.toBe(k1);
+
+    await submitAmount(actor, "25");
+    await waitFor(() => {
+      expect(checkoutCalls()).toHaveLength(3);
+    });
+    const k3 = keyOf(checkoutCalls()[2]);
+    // No key is ever shared across different submitted amounts: the final
+    // 25-submission must differ from BOTH the 30 key and the original 25
+    // key. The k3 !== k1 assertion is the one that kills a per-amount key
+    // MAP regression (a map would resurrect k1 for the return to 25).
+    expect(k3).not.toBe(k2);
+    expect(k3).not.toBe(k1);
+  });
+
+  it("reuses the key when the amount is edited away and back WITHOUT an intervening submit", async () => {
+    // The single-slot intent survives non-submitting edits: the intent was
+    // never used for another amount, so resubmitting the same amount is the
+    // same purchase intent (same request digest) and replays safely.
+    let attempt = 0;
+    routeApi(() => {
+      attempt += 1;
+      if (attempt === 1) {
+        return Promise.reject(new Error("network down"));
+      }
+      return Promise.resolve({});
+    });
+    const actor = userEvent.setup();
+    render(<BillingTab user={user} />);
+
+    await screen.findAllByTestId("invoice-row");
+    await submitAmount(actor, "25");
+    await waitFor(() => {
+      expect(checkoutCalls()).toHaveLength(1);
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Buy credits/i })).toBeTruthy();
+    });
+    // Edit away and back without submitting.
+    const input = screen.getByLabelText("Amount (USD)");
+    await actor.clear(input);
+    await actor.type(input, "30");
+    await actor.clear(input);
+    await actor.type(input, "25");
+    await actor.click(screen.getByRole("button", { name: /Buy credits/i }));
+
+    await waitFor(() => {
+      expect(checkoutCalls()).toHaveLength(2);
+    });
+    expect(keyOf(checkoutCalls()[1])).toBe(keyOf(checkoutCalls()[0]));
+  });
+
+  it("makes no checkout request for an invalid amount", async () => {
+    routeApi();
+    const actor = userEvent.setup();
+    render(<BillingTab user={user} />);
+
+    await screen.findAllByTestId("invoice-row");
+    await submitAmount(actor, "0");
+
+    await waitFor(() => {
+      expect(screen.getByText(/Minimum amount is \$1/i)).toBeTruthy();
+    });
+    expect(checkoutCalls()).toHaveLength(0);
+  });
+
+  it("generates a fresh key on retry after a definitive 400 — the server rejected before ordering", async () => {
+    // A definitive 4xx clears the intent: the server rejected the request
+    // before creating any durable order, so a retry MUST use a new key.
+    // The rejection must be a real (mocked-module) ApiError instance — the
+    // component classifies via instanceof.
+    const apiClient = await import("../../lib/api-client");
+    let attempt = 0;
+    routeApi(() => {
+      attempt += 1;
+      if (attempt === 1) {
+        return Promise.reject(
+          new apiClient.ApiError(400, "invalid", "Idempotency-Key header is invalid"),
+        );
+      }
+      return Promise.resolve({});
+    });
+    const actor = userEvent.setup();
+    render(<BillingTab user={user} />);
+
+    await screen.findAllByTestId("invoice-row");
+    await submitAmount(actor, "25");
+    await waitFor(() => {
+      expect(checkoutCalls()).toHaveLength(1);
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Buy credits/i })).toBeTruthy();
+    });
+    await submitAmount(actor, "25");
+
+    await waitFor(() => {
+      expect(checkoutCalls()).toHaveLength(2);
+    });
+    expect(keyOf(checkoutCalls()[0])).not.toBe(keyOf(checkoutCalls()[1]));
+  });
+
+  it("sends no Idempotency-Key on the hosted crypto path", async () => {
+    apiMock.mockImplementation((url: string) => {
+      if (url.startsWith("/api/invoices/list")) {
+        return Promise.resolve({ invoices });
+      }
+      if (url.startsWith("/api/credits/balance")) {
+        return Promise.resolve({ balance: 12.5 });
+      }
+      if (url.startsWith("/api/crypto/status")) {
+        return Promise.resolve({ enabled: true, directWallet: { enabled: false } });
+      }
+      if (url.startsWith("/api/crypto/payments")) {
+        // A javascript: payLink is refused client-side (no jsdom navigation),
+        // proving the request itself was made — which is the assertion here.
+        return Promise.resolve({ payLink: "javascript:void(0)" });
+      }
+      return Promise.resolve({});
+    });
+    const actor = userEvent.setup();
+    render(<BillingTab user={user} />);
+
+    await screen.findAllByTestId("invoice-row");
+    // Select the crypto payment-method toggle then submit via its own button.
+    await actor.click(screen.getByRole("button", { name: /^Crypto$/i }));
+    await submitAmount(actor, "25", { buttonName: /Pay with Crypto/i });
+
+    await waitFor(() => {
+      expect(
+        apiMock.mock.calls.some(([url]) => String(url).startsWith("/api/crypto/payments")),
+      ).toBe(true);
+    });
+    const cryptoCall = apiMock.mock.calls.find(([url]) =>
+      String(url).startsWith("/api/crypto/payments"),
+    );
+    const init = cryptoCall?.[1] as { headers?: Record<string, string> } | undefined;
+    expect(init?.headers?.["Idempotency-Key"]).toBeUndefined();
+    expect(checkoutCalls()).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/cloud/billing/components/billing-tab.idempotency.test.tsx
+++ b/packages/ui/src/cloud/billing/components/billing-tab.idempotency.test.tsx
@@ -11,9 +11,15 @@
  */
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { UserEvent } from "@testing-library/user-event";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const apiMock = vi.hoisted(() => vi.fn());
@@ -59,17 +65,53 @@ vi.mock("react-router-dom", () => ({
   useNavigate: () => navigateMock,
 }));
 
+vi.mock("../data/billing-snapshot", () => ({
+  useBillingSnapshotV2: () => ({
+    data: {
+      snapshotStartedAt: "2026-08-21T10:20:30.000Z",
+      snapshotCompletedAt: "2026-08-21T10:20:30.000Z",
+      balance: {
+        status: "available",
+        source: "credit-ledger",
+        observedAt: "2026-08-21T10:20:30.000Z",
+        value: {
+          balance: { value: "12.500000", unit: "usd", currency: "USD" },
+          revision: "7",
+        },
+      },
+      activeCompute: {
+        resources: {
+          status: "available",
+          source: "compute",
+          observedAt: "2026-08-21T10:20:30.000Z",
+          value: [],
+        },
+        estimatedRecurringComputeCostPerDay: {
+          status: "available",
+          source: "compute",
+          observedAt: "2026-08-21T10:20:30.000Z",
+          value: { value: "0.000000", unit: "usd_per_day", currency: "USD" },
+        },
+      },
+    },
+    isError: false,
+    isFetching: false,
+    isRefetchError: false,
+    fetchStatus: "idle",
+    refetch: vi.fn(),
+  }),
+}));
+
 vi.mock("./auto-top-up-card", () => ({
   AutoTopUpCard: () => null,
 }));
 
 import type { BillingUser, InvoiceDisplay } from "../types";
-import { BillingTab } from "./billing-tab";
+import { BillingTab, type CardCheckoutIntentStore } from "./billing-tab";
 
 const user: BillingUser = {
   organization_id: "org-1",
   wallet_address: null,
-  organization: { credit_balance: 12.5 },
 };
 
 const invoices: InvoiceDisplay[] = [
@@ -79,7 +121,9 @@ const invoices: InvoiceDisplay[] = [
 /** The server's exact header contract. */
 const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/;
 
-function routeApi(checkoutResponse: () => Promise<unknown> = () => Promise.resolve({})) {
+function routeApi(
+  checkoutResponse: () => Promise<unknown> = () => Promise.resolve({}),
+) {
   apiMock.mockImplementation((url: string) => {
     if (url.startsWith("/api/invoices/list")) {
       return Promise.resolve({ invoices });
@@ -107,6 +151,24 @@ function checkoutCalls() {
 function keyOf(call: unknown[]): string {
   const init = call[1] as { headers?: Record<string, string> };
   return init?.headers?.["Idempotency-Key"] ?? "";
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function submitFormAmount(amount: string) {
+  const input = screen.getByLabelText("Amount (USD)");
+  fireEvent.change(input, { target: { value: amount } });
+  const form = input.closest("form");
+  if (!form) throw new Error("Billing checkout form is missing");
+  fireEvent.submit(form);
 }
 
 async function submitAmount(
@@ -314,7 +376,11 @@ describe("BillingTab card-checkout idempotency key (#24144)", () => {
       attempt += 1;
       if (attempt === 1) {
         return Promise.reject(
-          new apiClient.ApiError(400, "invalid", "Idempotency-Key header is invalid"),
+          new apiClient.ApiError(
+            400,
+            "invalid",
+            "Idempotency-Key header is invalid",
+          ),
         );
       }
       return Promise.resolve({});
@@ -338,6 +404,96 @@ describe("BillingTab card-checkout idempotency key (#24144)", () => {
     expect(keyOf(checkoutCalls()[0])).not.toBe(keyOf(checkoutCalls()[1]));
   });
 
+  it("does not let an older 4xx clear a newer ambiguous checkout intent", async () => {
+    const first = deferred<unknown>();
+    const second = deferred<unknown>();
+    let attempt = 0;
+    routeApi(() => {
+      attempt += 1;
+      if (attempt === 1) return first.promise;
+      if (attempt === 2) return second.promise;
+      return Promise.resolve({});
+    });
+    const apiClient = await import("../../lib/api-client");
+    render(<BillingTab user={user} />);
+    await screen.findAllByTestId("invoice-row");
+
+    submitFormAmount("25");
+    await waitFor(() => expect(checkoutCalls()).toHaveLength(1));
+    submitFormAmount("30");
+    await waitFor(() => expect(checkoutCalls()).toHaveLength(2));
+
+    first.reject(new apiClient.ApiError(400, "invalid", "rejected"));
+    second.reject(new Error("response lost"));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Buy credits/i })).toBeTruthy(),
+    );
+    submitFormAmount("30");
+    await waitFor(() => expect(checkoutCalls()).toHaveLength(3));
+
+    expect(keyOf(checkoutCalls()[0])).not.toBe(keyOf(checkoutCalls()[1]));
+    expect(keyOf(checkoutCalls()[2])).toBe(keyOf(checkoutCalls()[1]));
+  });
+
+  it("does not let an older ambiguous completion restore a rejected newer intent", async () => {
+    const first = deferred<unknown>();
+    const second = deferred<unknown>();
+    let attempt = 0;
+    routeApi(() => {
+      attempt += 1;
+      if (attempt === 1) return first.promise;
+      if (attempt === 2) return second.promise;
+      return Promise.resolve({});
+    });
+    const apiClient = await import("../../lib/api-client");
+    render(<BillingTab user={user} />);
+    await screen.findAllByTestId("invoice-row");
+
+    submitFormAmount("25");
+    await waitFor(() => expect(checkoutCalls()).toHaveLength(1));
+    submitFormAmount("30");
+    await waitFor(() => expect(checkoutCalls()).toHaveLength(2));
+    const rejectedKey = keyOf(checkoutCalls()[1]);
+
+    second.reject(new apiClient.ApiError(400, "invalid", "rejected"));
+    first.reject(new Error("older response lost"));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Buy credits/i })).toBeTruthy(),
+    );
+    submitFormAmount("30");
+    await waitFor(() => expect(checkoutCalls()).toHaveLength(3));
+
+    expect(keyOf(checkoutCalls()[2])).not.toBe(rejectedKey);
+    expect(keyOf(checkoutCalls()[2])).not.toBe(keyOf(checkoutCalls()[0]));
+  });
+
+  it("reuses an ambiguous intent after BillingTab unmounts and remounts", async () => {
+    const intentStore: CardCheckoutIntentStore = { current: null };
+    let attempt = 0;
+    routeApi(() => {
+      attempt += 1;
+      return attempt === 1
+        ? Promise.reject(new Error("response lost"))
+        : Promise.resolve({});
+    });
+    const firstRender = render(
+      <BillingTab user={user} checkoutIntentStore={intentStore} />,
+    );
+    await screen.findAllByTestId("invoice-row");
+    const actor = userEvent.setup();
+    await submitAmount(actor, "25");
+    await waitFor(() => expect(checkoutCalls()).toHaveLength(1));
+    const originalKey = keyOf(checkoutCalls()[0]);
+
+    firstRender.unmount();
+    render(<BillingTab user={user} checkoutIntentStore={intentStore} />);
+    await screen.findAllByTestId("invoice-row");
+    await submitAmount(actor, "25");
+    await waitFor(() => expect(checkoutCalls()).toHaveLength(2));
+
+    expect(keyOf(checkoutCalls()[1])).toBe(originalKey);
+  });
+
   it("sends no Idempotency-Key on the hosted crypto path", async () => {
     apiMock.mockImplementation((url: string) => {
       if (url.startsWith("/api/invoices/list")) {
@@ -347,7 +503,10 @@ describe("BillingTab card-checkout idempotency key (#24144)", () => {
         return Promise.resolve({ balance: 12.5 });
       }
       if (url.startsWith("/api/crypto/status")) {
-        return Promise.resolve({ enabled: true, directWallet: { enabled: false } });
+        return Promise.resolve({
+          enabled: true,
+          directWallet: { enabled: false },
+        });
       }
       if (url.startsWith("/api/crypto/payments")) {
         // A javascript: payLink is refused client-side (no jsdom navigation),
@@ -366,13 +525,17 @@ describe("BillingTab card-checkout idempotency key (#24144)", () => {
 
     await waitFor(() => {
       expect(
-        apiMock.mock.calls.some(([url]) => String(url).startsWith("/api/crypto/payments")),
+        apiMock.mock.calls.some(([url]) =>
+          String(url).startsWith("/api/crypto/payments"),
+        ),
       ).toBe(true);
     });
     const cryptoCall = apiMock.mock.calls.find(([url]) =>
       String(url).startsWith("/api/crypto/payments"),
     );
-    const init = cryptoCall?.[1] as { headers?: Record<string, string> } | undefined;
+    const init = cryptoCall?.[1] as
+      | { headers?: Record<string, string> }
+      | undefined;
     expect(init?.headers?.["Idempotency-Key"]).toBeUndefined();
     expect(checkoutCalls()).toHaveLength(0);
   });

--- a/packages/ui/src/cloud/billing/components/billing-tab.test.tsx
+++ b/packages/ui/src/cloud/billing/components/billing-tab.test.tsx
@@ -257,9 +257,8 @@ describe("BillingTab buy-credits accessibility", () => {
     await actor.type(input, "{Enter}");
 
     await waitFor(() => {
-      const checkoutCall = apiMock.mock.calls.find(
-        (call) =>
-          String(call[0]).startsWith("/api/stripe/create-checkout-session"),
+      const checkoutCall = apiMock.mock.calls.find((call) =>
+        String(call[0]).startsWith("/api/stripe/create-checkout-session"),
       );
       expect(checkoutCall).toBeDefined();
       const init = checkoutCall?.[1] as {

--- a/packages/ui/src/cloud/billing/components/billing-tab.test.tsx
+++ b/packages/ui/src/cloud/billing/components/billing-tab.test.tsx
@@ -257,9 +257,22 @@ describe("BillingTab buy-credits accessibility", () => {
     await actor.type(input, "{Enter}");
 
     await waitFor(() => {
-      expect(apiMock).toHaveBeenCalledWith(
-        "/api/stripe/create-checkout-session",
-        { method: "POST", json: { amount: 25, returnUrl: "settings" } },
+      const checkoutCall = apiMock.mock.calls.find(
+        (call) =>
+          String(call[0]).startsWith("/api/stripe/create-checkout-session"),
+      );
+      expect(checkoutCall).toBeDefined();
+      const init = checkoutCall?.[1] as {
+        method?: string;
+        json?: unknown;
+        headers?: Record<string, string>;
+      };
+      expect(init.method).toBe("POST");
+      expect(init.json).toEqual({ amount: 25, returnUrl: "settings" });
+      // The idempotency key is present and satisfies the server contract
+      // (#24144); Enter and click submissions share the same handler.
+      expect(init.headers?.["Idempotency-Key"]).toMatch(
+        /^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$/,
       );
     });
     // The in-flight label stays verb-first ("Processing…"), never a passive

--- a/packages/ui/src/cloud/billing/components/billing-tab.tsx
+++ b/packages/ui/src/cloud/billing/components/billing-tab.tsx
@@ -25,7 +25,14 @@ import {
   XCircle,
 } from "lucide-react";
 import type { ComponentType, FormEvent } from "react";
-import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { ApiError, api } from "../../lib/api-client";
@@ -63,6 +70,17 @@ import { Button } from "../../../components/ui/button";
 
 interface BillingTabProps {
   user: BillingUser;
+  checkoutIntentStore?: CardCheckoutIntentStore;
+}
+
+export interface CardCheckoutIntent {
+  organizationId: string;
+  amount: number;
+  key: string;
+}
+
+export interface CardCheckoutIntentStore {
+  current: CardCheckoutIntent | null;
 }
 
 const AMOUNT_LIMITS = {
@@ -228,7 +246,7 @@ function getInvoiceStatusPresentation(status: string): {
   return { Icon: AlertCircle, className: "text-muted-strong" };
 }
 
-export function BillingTab({ user }: BillingTabProps) {
+export function BillingTab({ user, checkoutIntentStore }: BillingTabProps) {
   const t = useCloudT();
   const navigate = useNavigate();
   const billingSnapshot = useBillingSnapshotV2(user.organization_id);
@@ -247,7 +265,8 @@ export function BillingTab({ user }: BillingTabProps) {
   // (plain 4xx) proves the server never accepted the intent. Deliberately a
   // single-slot ref, NOT a per-amount map: editing A -> B -> A must not
   // resurrect A's earlier key as a "same intent" replay.
-  const checkoutIntentRef = useRef<{ amount: number; key: string } | null>(null);
+  const localCheckoutIntentStore = useRef<CardCheckoutIntent | null>(null);
+  const intentStore = checkoutIntentStore ?? localCheckoutIntentStore;
   // Tracks whether a submit has been attempted so an empty submission (which
   // never populates purchaseAmount) still marks the field invalid and renders
   // the adjacent inline error instead of only emitting a transient toast.
@@ -372,10 +391,19 @@ export function BillingTab({ user }: BillingTabProps) {
     // Card checkout only. The crypto branches above have returned by here, so
     // the idempotency intent stays scoped to the route that requires it
     // (/api/stripe/create-checkout-session) and never touches crypto payments.
-    const intent = checkoutIntentRef.current;
+    const intent = intentStore.current;
     const idempotencyKey =
-      intent && intent.amount === amount ? intent.key : crypto.randomUUID();
-    checkoutIntentRef.current = { amount, key: idempotencyKey };
+      intent &&
+      intent.organizationId === user.organization_id &&
+      intent.amount === amount
+        ? intent.key
+        : crypto.randomUUID();
+    const requestIntent: CardCheckoutIntent = {
+      organizationId: user.organization_id,
+      amount,
+      key: idempotencyKey,
+    };
+    intentStore.current = requestIntent;
 
     try {
       const data = await api<{ url?: string }>(
@@ -406,6 +434,9 @@ export function BillingTab({ user }: BillingTabProps) {
         setIsProcessingCheckout(false);
         return;
       }
+      if (intentStore.current?.key === requestIntent.key) {
+        intentStore.current = null;
+      }
       window.location.href = data.url;
     } catch (error) {
       // Preserve the idempotency key across ambiguous/transient outcomes
@@ -425,9 +456,12 @@ export function BillingTab({ user }: BillingTabProps) {
         error.status >= 400 &&
         error.status < 500 &&
         error.status !== 408 &&
-        error.status !== 429
+        error.status !== 429 &&
+        intentStore.current?.organizationId === requestIntent.organizationId &&
+        intentStore.current.amount === requestIntent.amount &&
+        intentStore.current.key === requestIntent.key
       ) {
-        checkoutIntentRef.current = null;
+        intentStore.current = null;
       }
       toast.error(
         error instanceof ApiError

--- a/packages/ui/src/cloud/billing/components/billing-tab.tsx
+++ b/packages/ui/src/cloud/billing/components/billing-tab.tsx
@@ -25,7 +25,7 @@ import {
   XCircle,
 } from "lucide-react";
 import type { ComponentType, FormEvent } from "react";
-import { lazy, Suspense, useCallback, useEffect, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { ApiError, api } from "../../lib/api-client";
@@ -237,6 +237,17 @@ export function BillingTab({ user }: BillingTabProps) {
   const [loadingInvoices, setLoadingInvoices] = useState(true);
   const [invoicesError, setInvoicesError] = useState<string | null>(null);
   const [purchaseAmount, setPurchaseAmount] = useState("");
+
+  // Idempotency intent for the card checkout (#24144): the server requires an
+  // Idempotency-Key (8-128 chars of [A-Za-z0-9._:-]) for non-hardware credit
+  // purchases and scopes durable checkout orders to (org, key). A UUID is
+  // generated only after validation, reused while the purchase intent (the
+  // amount) is unchanged so ambiguous/transient failures can replay safely,
+  // and cleared when the amount changes or a definitive client-side failure
+  // (plain 4xx) proves the server never accepted the intent. Deliberately a
+  // single-slot ref, NOT a per-amount map: editing A -> B -> A must not
+  // resurrect A's earlier key as a "same intent" replay.
+  const checkoutIntentRef = useRef<{ amount: number; key: string } | null>(null);
   // Tracks whether a submit has been attempted so an empty submission (which
   // never populates purchaseAmount) still marks the field invalid and renders
   // the adjacent inline error instead of only emitting a transient toast.
@@ -358,12 +369,21 @@ export function BillingTab({ user }: BillingTabProps) {
       return;
     }
 
+    // Card checkout only. The crypto branches above have returned by here, so
+    // the idempotency intent stays scoped to the route that requires it
+    // (/api/stripe/create-checkout-session) and never touches crypto payments.
+    const intent = checkoutIntentRef.current;
+    const idempotencyKey =
+      intent && intent.amount === amount ? intent.key : crypto.randomUUID();
+    checkoutIntentRef.current = { amount, key: idempotencyKey };
+
     try {
       const data = await api<{ url?: string }>(
         "/api/stripe/create-checkout-session",
         {
           method: "POST",
           json: { amount, returnUrl: "settings" },
+          headers: { "Idempotency-Key": idempotencyKey },
         },
       );
       if (!data.url) {
@@ -388,6 +408,27 @@ export function BillingTab({ user }: BillingTabProps) {
       }
       window.location.href = data.url;
     } catch (error) {
+      // Preserve the idempotency key across ambiguous/transient outcomes
+      // (network errors, 408/429, 5xx): the server may have created the
+      // durable checkout order before the response was lost, and replaying
+      // the same key reconciles to it instead of double-ordering. Clear it
+      // only on definitive client-side failures (plain 4xx except 408/429):
+      // those prove the server rejected the request before creating anything.
+      // Known edge: if the HTTP status was received but the response body
+      // stream itself fails mid-read, the transport error escapes as a
+      // non-ApiError — including after a 4xx. That case conservatively
+      // PRESERVES the key: we cannot prove the server's 4xx semantics were
+      // for this request, so treating it as ambiguous is the safe direction
+      // (worst case, the retry hits the server's own key/digest conflict).
+      if (
+        error instanceof ApiError &&
+        error.status >= 400 &&
+        error.status < 500 &&
+        error.status !== 408 &&
+        error.status !== 429
+      ) {
+        checkoutIntentRef.current = null;
+      }
       toast.error(
         error instanceof ApiError
           ? error.message
@@ -561,6 +602,13 @@ export function BillingTab({ user }: BillingTabProps) {
                         onChange={(e) => {
                           setPurchaseAmount(e.target.value);
                           if (submitAttempted) setSubmitAttempted(false);
+                          // Note: the idempotency intent is intentionally NOT
+                          // cleared on edit here. Intermediate keystrokes
+                          // ("2" while retyping "25") would clear a still-
+                          // valid intent prematurely; the authoritative
+                          // rotation check is at submit time, where the full
+                          // parsed amount is compared against the recorded
+                          // intent (#24144).
                         }}
                         className="pl-7 bg-surface border border-border text-txt h-11 font-mono tabular-nums"
                         placeholder="0.00"


### PR DESCRIPTION
# Relates to

Closes #24144. Claim comment: https://github.com/elizaOS/eliza/issues/24144#issuecomment-5376503314

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` (c3639e22c0a) with zero conflicts.
- [x] Focused verification lanes were run after sync; the one pre-existing unrelated blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3` (implementation) + `CC Zai/gpt-5.6-sol` (RepoPrompt CE investigate + pre-push review, 2 rounds)
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent` / `RepoPrompt CE`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` (c3639e22c0a); zero conflicts.

# Risks

**Low.** Client-only; one component. The header addition cannot break the server (the route already requires and validates it); crypto and hardware paths are untouched by construction (both crypto branches return before key generation; BillingTab never sends hardware requests). Server-side order semantics are unchanged.

# Background

## What does this PR do?

The Billing tab called `/api/stripe/create-checkout-session` with only `{amount, returnUrl}` while the server requires an `Idempotency-Key` header (8–128 chars, `^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$`) for non-hardware credit purchases — every valid card top-up failed 400 before catalog lookup or Stripe work.

**Design** (from an independent read-only investigation, then adversarially reviewed twice):

- A component-scoped **single-slot intent ref** `{amount, key}` — a UUID is generated only **after** client validation passes, so invalid submissions neither create intent state nor make requests.
- **Reuse:** re-submitting the *same* amount reuses the key. Ambiguous/transient failures (network errors, 408/429, 5xx) preserve it, so a retry replays the same key and the server reconciles to its durable checkout order (keyed by org + client key) instead of double-ordering.
- **Rotation:** any *different* submitted amount generates a fresh key — the comparison is the full parsed amount at submit time, which makes a stale key carrying a different request digest impossible.
- **Clearing:** definitive 4xx failures (except 408/429) clear the intent — the server rejected before creating anything. A rare edge (HTTP 4xx received but the body stream fails mid-read, escaping as a non-ApiError) conservatively *preserves* the key; the safe direction, documented inline.
- Deliberately **not** a per-amount key map (A → B → A resurrection) and **not** cleared on keystroke intermediates (`"2"` while retyping `"25"` would kill valid intents). The issue's tests now pin both invariants.
- Crypto and hardware paths untouched.

**Out of scope, flagged on the issue:** the client validates max $10,000 while the server caps at $1,000 (amounts $1,001–$10,000 pass client validation and fail server-side) — pre-existing limit mismatch, separate fix.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`billing-tab.idempotency.test.tsx` — 8 cases pinning the full AC matrix, then the 30-line component diff.

## Detailed testing steps

RED control (fix stashed, pristine component): **4 of the new tests fail** — the key is absent, retry keys differ, amount-change rotation is unprovable, crypto leakage untestable. With the fix:

```
$ cd packages/ui && npx vitest run \
    src/cloud/billing/components/billing-tab.idempotency.test.tsx \
    src/cloud/billing/components/billing-tab.test.tsx
 Tests  16 passed (16)      # 8 new + 8 existing (Enter-path assertion updated to the header contract)
```

AC matrix pinned:

| Issue AC | Test |
|---|---|
| valid card top-up sends a contract-valid key | "sends a server-contract-valid Idempotency-Key" (regex + 36-char UUID + unchanged body) |
| two retries of the same intent send the same key | "reuses the same key ... after a transient failure" (503) + network-failure case + edit-away-and-back-without-submit case |
| changing the amount produces a different key | "rotates the key when the amount changes" + A/B/A submit matrix asserting k3 ≠ k1 AND k3 ≠ k2 (kills per-amount-map resurrection) |
| invalid/empty amounts make no request | "makes no checkout request for an invalid amount" + existing invalid-submit tests |
| click and Enter share the path | Enter-path test updated to the header contract; click used by every other case |

Plus: definitive-400 → fresh key; crypto path carries no key and makes no checkout call.

Gates: `biome check` clean on all three touched files; `tsc --noEmit` carries exactly the 1 pre-existing unrelated error (`storage-bridge.ts` capacitor module, untouched by this diff).

Independent review (2 rounds): round 1 REQUEST_CHANGES — F1 the A/B/A matrix test was missing the `k3 !== k1` assertion that actually distinguishes single-slot from a per-amount map, and the edit-without-submit reuse case was unpinned; F2 the 4xx-with-failed-body-read edge silently preserved the key. Both fixed (F1 asserted; F2 documented as deliberate conservative-ambiguity). Round 2 **APPROVE** at head `6a50bf809ee`.

# Evidence Gate

<!-- evidence-head:6a50bf809eea724545fedaab8bc5f5d6eaac58ab -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - the change is request-header semantics with no visual delta; the Billing tab renders identically (all 8 existing rendering/accessibility tests pass unchanged).
<!-- evidence-row:after-screenshots -->
- [x] N/A - the change is request-header semantics with no visual delta; the Billing tab renders identically (all 8 existing rendering/accessibility tests pass unchanged).
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the change is request-header semantics with no visual delta; the Billing tab renders identically (all 8 existing rendering/accessibility tests pass unchanged).
<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only change; the server route's contract tests (route.test.ts) already prove the header requirement this PR satisfies.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - the jsdom suite asserts the exact request args (URL + init incl. the Idempotency-Key header) - that IS the network evidence, pasted in Testing.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or agent code touched.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no runtime domain artifacts; the behavioral proof is the request-args matrix asserted by the jsdom suite (16/16).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface change.

# Evidence Details

## Real LLM-call trajectory

N/A - no model/prompt/provider/agent changes.

## Backend + frontend logs

N/A - request-args assertions in Testing are the executable network evidence.

## Screenshots (before / after) + video walkthrough

N/A - no visual delta.


### Before

![Billing surface before](https://github.com/HomunculusLabs/eliza/releases/download/pr-evidence-24144/before-billing-surface.png)

### After

![Billing surface after](https://github.com/HomunculusLabs/eliza/releases/download/pr-evidence-24144/after-billing-surface.png)

### Walkthrough video

[Billing surface walkthrough (webm)](https://github.com/HomunculusLabs/eliza/releases/download/pr-evidence-24144/page@ed1cff10bc106389dc873a1de4479afb.webm)

## Audio / voice walkthrough

N/A.

## Known gaps / failures

**Evidence-gate artifact rows (`artifact-required`) are expected for a fork PR.**
The touched file is a rendered `.tsx` under `packages/ui`, so the gate requires
trusted-host media (elizaOS/eliza release or user-attachments) — both need org
push access or web-UI drag-drop, unavailable to fork contributors (verified:
the attachment REST API rejects binary uploads; only elizaOS release URLs match
the gate's trust regex). Real captures ARE attached: full-page before/after
screenshots and a walkthrough video, hosted on the fork release
(`pr-evidence-24144`) and embedded inline above — the change is
request-header semantics, so the surfaces render identically (the screenshots
document the unchanged render; the jsdom request-args matrix in Testing is the
behavioral proof). A maintainer with push access can re-host them on the
`pr-evidence` release to flip the rows to ok.

The pre-existing `storage-bridge.ts` TS2307 error is the only ui-package typecheck failure — identical on pristine develop (diff-verified). The $10k/$1k client/server limit mismatch is documented above as a separate follow-up.

# Database changes

None.

# Deployment instructions

None.

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2bca2475c434e3b57d1b84753087fc73309094ab:packages/skills/skills/contribute-to-eliza"} -->

