### PR TITLE
fix(discord): keep a durable error listener on the client (#24167)

### DIFF
--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -1607,12 +1607,19 @@ export class DiscordService extends Service implements IDiscordService {
 			}
 			scheduleRetry(closeEvent);
 		});
-		client.once(Events.Error, (error: unknown) => {
+		// Durable error listener: keeps the client error-listener-ful for the
+		// whole lifetime so a rejected async gateway listener can never become
+		// an uncaughtException (captureRejections rethrows via nextTick when no
+		// "error" listener exists). Logging only; retry decisions stay in the
+		// per-attempt once() below so a single error logs exactly once.
+		client.on(Events.Error, (error: unknown) => {
 			this.runtime.logger.error(
 				`Discord client error for account ${state.accountId}: ${
 					error instanceof Error ? error.message : String(error)
 				}`,
 			);
+		});
+		client.once(Events.Error, (error: unknown) => {
 			scheduleRetry(error);
 		});
 		client.login(token).catch((error: unknown) => {


### PR DESCRIPTION
## Summary

Fixes #24167. The Discord connector registered its **only** `"error"` listener with `once()`. With discord.js `captureRejections`, the second rejected async gateway listener became an `uncaughtException` (rethrow via `process.nextTick` when no error listener exists), restarting the entire agent process instead of just the connector.

## Fix

- Attach a durable `client.on(Events.Error, ...)` when the client is created, so the client is never error-listener-less — logging every client error for the client's lifetime
- Keep the per-attempt `once(Events.Error, ...)` carrying only the login-retry decision, so a single error still produces exactly one log line and the retry decision fires once
- A retry nulls `state.client` and builds a fresh client, so listeners cannot accumulate

## Evidence

- Listener structure verified: durable `on` registered before per-attempt `once` before `client.login`
- Repo npm install is blocked by the pre-existing `@playwright/test` EOVERRIDE, so the TS compile runs in CI

## Scope

`plugins/plugin-discord/service.ts` — one listener registration change.

## Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash