### PR TITLE
fix(discord): reset SUBSCRIBE latch on IPC reconnect (#24166)

### DIFF
--- a/plugins/plugin-discord/discord-local-service.ts
+++ b/plugins/plugin-discord/discord-local-service.ts
@@ -928,6 +928,10 @@ export class DiscordLocalService extends Service {
 			const error = new Error("Discord local RPC connection closed");
 			this.connected = false;
 			this.authenticated = false;
+			// SUBSCRIBE subscriptions are bound to the IPC connection and die
+			// with the socket; the idempotency latch must reset with them or
+			// the reconnect path skips every channel and the service goes deaf.
+			this.subscribedChannelIds.clear();
 			this.connectedIpcPath = null;
 			this.socket = null;
 			this.rejectPendingRequests(error);


### PR DESCRIPTION
## Summary

Fixes #24166. Discord RPC `SUBSCRIBE` subscriptions are bound to the IPC connection and die with the socket. The `close` handler reset `authenticated` but left `subscribedChannelIds` intact, so after any reconnect the `SUBSCRIBE` idempotency guard (`if (this.subscribedChannelIds.has(channelId)) continue;`) skipped every channel — the service went permanently deaf while reporting itself healthy and subscribed.

## Fix

Clear `subscribedChannelIds` in the socket `close` handler alongside `authenticated`, matching what `disconnectSession` already does.

## Evidence

- Close handler now resets both `authenticated` and `subscribedChannelIds` (2 clear sites: `disconnectSession` + socket close)
- Repo npm install is blocked by the pre-existing `@playwright/test` EOVERRIDE, so the TS compile runs in CI

## Scope

`plugins/plugin-discord/discord-local-service.ts` — one line in the socket close handler.

## Agent disclosure

- client: Hermes Agent (manual)
- provider: deepseek
- model: deepseek-v4-flash