### PR TITLE
fix(cloud): skip shared managed connector restarts

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-managed-connector-execution-tier.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-managed-connector-execution-tier.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Exercises managed Discord and GitHub connector mutations directly with
+ * deterministic repository and provisioning-job spies. The suite proves that
+ * shared or unknown runtime tiers persist configuration without scheduling a
+ * container restart, while a container-backed tier keeps the restart path.
+ */
+
+import { describe, expect, spyOn, test } from "bun:test";
+import type { AgentSandbox } from "../../db/repositories/agent-sandboxes";
+import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
+import { ManagedAgentDiscordService } from "./agent-managed-discord";
+import { ManagedAgentGithubService } from "./agent-managed-github";
+import {
+  AGENT_MANAGED_DISCORD_KEY,
+  AGENT_MANAGED_GITHUB_KEY,
+  type ManagedAgentDiscordBinding,
+  type ManagedAgentGithubBinding,
+  withManagedAgentGithubBinding,
+} from "./eliza-agent-config";
+import { provisioningJobService } from "./provisioning-jobs";
+
+const AGENT_ID = "11111111-1111-4111-8111-111111111111";
+const ORG_ID = "22222222-2222-4222-8222-222222222222";
+const USER_ID = "33333333-3333-4333-8333-333333333333";
+
+const DISCORD_BINDING: ManagedAgentDiscordBinding = {
+  mode: "cloud-managed",
+  applicationId: "discord-app-1",
+  guildId: "discord-guild-1",
+  guildName: "Managed Guild",
+  adminDiscordUserId: "discord-admin-1",
+  adminDiscordUsername: "managed-admin",
+  adminElizaUserId: USER_ID,
+  connectedAt: "2026-08-22T12:00:00.000Z",
+};
+
+const GITHUB_BINDING: ManagedAgentGithubBinding = {
+  mode: "shared-owner",
+  connectionId: "github-connection-1",
+  githubUserId: "github-user-1",
+  githubUsername: "managed-owner",
+  scopes: ["repo"],
+  adminElizaUserId: USER_ID,
+  connectedAt: "2026-08-22T12:00:00.000Z",
+  connectionRole: "owner",
+  source: "platform_credentials",
+};
+
+function runningSandbox(
+  executionTier: string,
+  agentConfig: Record<string, unknown> = {},
+): AgentSandbox {
+  return {
+    id: AGENT_ID,
+    organization_id: ORG_ID,
+    user_id: USER_ID,
+    status: "running",
+    execution_tier: executionTier,
+    agent_config: agentConfig,
+  } as unknown as AgentSandbox;
+}
+
+function installMutationSpies(sandbox: AgentSandbox) {
+  const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(sandbox);
+  const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(sandbox);
+  const enqueueSpy = spyOn(provisioningJobService, "enqueueAgentRestartOnce").mockResolvedValue(
+    {} as never,
+  );
+  const triggerSpy = spyOn(provisioningJobService, "triggerImmediate").mockResolvedValue();
+
+  return {
+    updateSpy,
+    enqueueSpy,
+    triggerSpy,
+    restore() {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+      enqueueSpy.mockRestore();
+      triggerSpy.mockRestore();
+    },
+  };
+}
+
+function expectPersistedAgentConfig(
+  spies: ReturnType<typeof installMutationSpies>,
+): Record<string, unknown> {
+  expect(spies.updateSpy).toHaveBeenCalledTimes(1);
+  const updateCall = spies.updateSpy.mock.calls[0];
+  expect(updateCall?.[0]).toBe(AGENT_ID);
+  expect(updateCall?.[1]).toEqual({
+    agent_config: expect.any(Object),
+  });
+  return updateCall?.[1]?.agent_config as Record<string, unknown>;
+}
+
+async function expectDiscordConnectWithoutRestart(executionTier: string): Promise<void> {
+  const sandbox = runningSandbox(executionTier);
+  const spies = installMutationSpies(sandbox);
+  const guildLookupSpy = spyOn(
+    agentSandboxesRepository,
+    "findByManagedDiscordGuildId",
+  ).mockResolvedValue([]);
+
+  try {
+    const result = await new ManagedAgentDiscordService().connectAgent({
+      agentId: AGENT_ID,
+      organizationId: ORG_ID,
+      binding: DISCORD_BINDING,
+    });
+
+    const persistedConfig = expectPersistedAgentConfig(spies);
+    expect(result.restarted).toBe(false);
+    expect(result.status.connected).toBe(true);
+    expect(persistedConfig[AGENT_MANAGED_DISCORD_KEY]).toEqual(
+      expect.objectContaining({ guildId: DISCORD_BINDING.guildId }),
+    );
+    expect(spies.enqueueSpy).not.toHaveBeenCalled();
+    expect(spies.triggerSpy).not.toHaveBeenCalled();
+  } finally {
+    guildLookupSpy.mockRestore();
+    spies.restore();
+  }
+}
+
+async function expectDiscordDisconnectWithoutRestart(executionTier: string): Promise<void> {
+  const sandbox = runningSandbox(executionTier, {
+    [AGENT_MANAGED_DISCORD_KEY]: DISCORD_BINDING,
+    roles: { connectorAdmins: { discord: [DISCORD_BINDING.adminDiscordUserId] } },
+    env: {
+      AGENT_DISCORD_OWNER_USER_IDS_JSON: JSON.stringify([DISCORD_BINDING.adminDiscordUserId]),
+    },
+  });
+  const spies = installMutationSpies(sandbox);
+
+  try {
+    const result = await new ManagedAgentDiscordService().disconnectAgent({
+      agentId: AGENT_ID,
+      organizationId: ORG_ID,
+      configured: true,
+      applicationId: DISCORD_BINDING.applicationId ?? null,
+    });
+
+    const persistedConfig = expectPersistedAgentConfig(spies);
+    expect(result.restarted).toBe(false);
+    expect(result.status.connected).toBe(false);
+    expect(persistedConfig).not.toHaveProperty(AGENT_MANAGED_DISCORD_KEY);
+    expect(spies.enqueueSpy).not.toHaveBeenCalled();
+    expect(spies.triggerSpy).not.toHaveBeenCalled();
+  } finally {
+    spies.restore();
+  }
+}
+
+async function expectGithubConnectWithoutRestart(executionTier: string): Promise<void> {
+  const sandbox = runningSandbox(executionTier);
+  const spies = installMutationSpies(sandbox);
+
+  try {
+    const result = await new ManagedAgentGithubService().connectAgent({
+      agentId: AGENT_ID,
+      organizationId: ORG_ID,
+      binding: GITHUB_BINDING,
+    });
+
+    const persistedConfig = expectPersistedAgentConfig(spies);
+    expect(result.restarted).toBe(false);
+    expect(result.status.connected).toBe(true);
+    expect(persistedConfig[AGENT_MANAGED_GITHUB_KEY]).toEqual(
+      expect.objectContaining({ githubUsername: GITHUB_BINDING.githubUsername }),
+    );
+    expect(spies.enqueueSpy).not.toHaveBeenCalled();
+    expect(spies.triggerSpy).not.toHaveBeenCalled();
+  } finally {
+    spies.restore();
+  }
+}
+
+async function expectGithubDisconnectWithoutRestart(executionTier: string): Promise<void> {
+  const sandbox = runningSandbox(executionTier, withManagedAgentGithubBinding({}, GITHUB_BINDING));
+  const spies = installMutationSpies(sandbox);
+
+  try {
+    const result = await new ManagedAgentGithubService().disconnectAgent({
+      agentId: AGENT_ID,
+      organizationId: ORG_ID,
+    });
+
+    const persistedConfig = expectPersistedAgentConfig(spies);
+    expect(result.restarted).toBe(false);
+    expect(result.status.connected).toBe(false);
+    expect(persistedConfig).not.toHaveProperty(AGENT_MANAGED_GITHUB_KEY);
+    expect(spies.enqueueSpy).not.toHaveBeenCalled();
+    expect(spies.triggerSpy).not.toHaveBeenCalled();
+  } finally {
+    spies.restore();
+  }
+}
+
+function expectRestartScheduled(
+  result: { restarted: boolean },
+  spies: ReturnType<typeof installMutationSpies>,
+): void {
+  expectPersistedAgentConfig(spies);
+  expect(result.restarted).toBe(true);
+  expect(spies.enqueueSpy).toHaveBeenCalledTimes(1);
+  expect(spies.enqueueSpy).toHaveBeenCalledWith({
+    agentId: AGENT_ID,
+    organizationId: ORG_ID,
+    userId: USER_ID,
+  });
+  expect(spies.triggerSpy).toHaveBeenCalledTimes(1);
+}
+
+async function expectDiscordConnectWithRestart(executionTier: string): Promise<void> {
+  const sandbox = runningSandbox(executionTier);
+  const spies = installMutationSpies(sandbox);
+  const guildLookupSpy = spyOn(
+    agentSandboxesRepository,
+    "findByManagedDiscordGuildId",
+  ).mockResolvedValue([]);
+
+  try {
+    const result = await new ManagedAgentDiscordService().connectAgent({
+      agentId: AGENT_ID,
+      organizationId: ORG_ID,
+      binding: DISCORD_BINDING,
+    });
+    expectRestartScheduled(result, spies);
+  } finally {
+    guildLookupSpy.mockRestore();
+    spies.restore();
+  }
+}
+
+async function expectDiscordDisconnectWithRestart(executionTier: string): Promise<void> {
+  const sandbox = runningSandbox(executionTier, {
+    [AGENT_MANAGED_DISCORD_KEY]: DISCORD_BINDING,
+  });
+  const spies = installMutationSpies(sandbox);
+
+  try {
+    const result = await new ManagedAgentDiscordService().disconnectAgent({
+      agentId: AGENT_ID,
+      organizationId: ORG_ID,
+      configured: true,
+      applicationId: DISCORD_BINDING.applicationId ?? null,
+    });
+    expectRestartScheduled(result, spies);
+  } finally {
+    spies.restore();
+  }
+}
+
+async function expectGithubConnectWithRestart(executionTier: string): Promise<void> {
+  const sandbox = runningSandbox(executionTier);
+  const spies = installMutationSpies(sandbox);
+
+  try {
+    const result = await new ManagedAgentGithubService().connectAgent({
+      agentId: AGENT_ID,
+      organizationId: ORG_ID,
+      binding: GITHUB_BINDING,
+    });
+    expectRestartScheduled(result, spies);
+  } finally {
+    spies.restore();
+  }
+}
+
+async function expectGithubDisconnectWithRestart(executionTier: string): Promise<void> {
+  const sandbox = runningSandbox(executionTier, withManagedAgentGithubBinding({}, GITHUB_BINDING));
+  const spies = installMutationSpies(sandbox);
+
+  try {
+    const result = await new ManagedAgentGithubService().disconnectAgent({
+      agentId: AGENT_ID,
+      organizationId: ORG_ID,
+    });
+    expectRestartScheduled(result, spies);
+  } finally {
+    spies.restore();
+  }
+}
+
+describe("managed connector restart admission", () => {
+  for (const executionTier of ["shared", "future-unknown-tier"]) {
+    test(`Discord connect persists config without restart for ${executionTier}`, async () => {
+      await expectDiscordConnectWithoutRestart(executionTier);
+    });
+
+    test(`Discord disconnect persists config without restart for ${executionTier}`, async () => {
+      await expectDiscordDisconnectWithoutRestart(executionTier);
+    });
+
+    test(`GitHub connect persists config without restart for ${executionTier}`, async () => {
+      await expectGithubConnectWithoutRestart(executionTier);
+    });
+
+    test(`GitHub disconnect persists config without restart for ${executionTier}`, async () => {
+      await expectGithubDisconnectWithoutRestart(executionTier);
+    });
+  }
+
+  for (const executionTier of ["dedicated-lazy", "dedicated-always", "custom"]) {
+    test(`Discord connect schedules restart for ${executionTier}`, async () => {
+      await expectDiscordConnectWithRestart(executionTier);
+    });
+
+    test(`Discord disconnect schedules restart for ${executionTier}`, async () => {
+      await expectDiscordDisconnectWithRestart(executionTier);
+    });
+
+    test(`GitHub connect schedules restart for ${executionTier}`, async () => {
+      await expectGithubConnectWithRestart(executionTier);
+    });
+
+    test(`GitHub disconnect schedules restart for ${executionTier}`, async () => {
+      await expectGithubDisconnectWithRestart(executionTier);
+    });
+  }
+});

--- a/packages/cloud/shared/src/lib/services/agent-managed-discord-quota.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-managed-discord-quota.test.ts
@@ -64,25 +64,26 @@ describe("ensureManagedDiscordGatewayInTransaction", () => {
       return chain;
     });
 
-    const insert = mock(() => ({
-      values: mock(() => ({
-        returning: mock(async () => {
-          events.push("insert");
-          return [
-            {
-              id: AGENT_ID,
-              organization_id: ORG_ID,
-              user_id: USER_ID,
-              agent_config: {
-                __agentManagedDiscordGateway: {
-                  mode: "shared-gateway",
-                  createdAt: "2026-08-20T00:00:00.000Z",
-                },
+    const values = mock((_input: Record<string, unknown>) => ({
+      returning: mock(async () => {
+        events.push("insert");
+        return [
+          {
+            id: AGENT_ID,
+            organization_id: ORG_ID,
+            user_id: USER_ID,
+            agent_config: {
+              __agentManagedDiscordGateway: {
+                mode: "shared-gateway",
+                createdAt: "2026-08-20T00:00:00.000Z",
               },
             },
-          ];
-        }),
-      })),
+          },
+        ];
+      }),
+    }));
+    const insert = mock(() => ({
+      values,
     }));
 
     const tx = { execute, select, insert } as unknown as DbTransaction;
@@ -93,6 +94,8 @@ describe("ensureManagedDiscordGatewayInTransaction", () => {
 
     expect(result.created).toBe(true);
     expect(result.sandbox.id).toBe(AGENT_ID);
+    expect(values).toHaveBeenCalledTimes(1);
+    expect(values.mock.calls[0]?.[0].execution_tier).toBe("shared");
     expect(events).toEqual([
       "deadlines",
       "org-lock",

--- a/packages/cloud/shared/src/lib/services/agent-managed-discord.ts
+++ b/packages/cloud/shared/src/lib/services/agent-managed-discord.ts
@@ -1,10 +1,18 @@
-// Coordinates cloud service agent managed discord behavior behind route handlers.
+/**
+ * Coordinates managed Discord gateway admission and agent connector
+ * configuration. Connector mutations persist first, then schedule lifecycle
+ * work only for running agents backed by a container.
+ */
 import { and, desc, eq, sql } from "drizzle-orm";
 import type { DbTransaction } from "../../db/client";
 import { ensureAgentSandboxSchema } from "../../db/ensure-agent-sandbox-schema";
 import { dbWrite } from "../../db/helpers";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
-import { type AgentSandbox, agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import {
+  type AgentSandbox,
+  agentSandboxes,
+  CONTAINER_BACKED_EXECUTION_TIERS,
+} from "../../db/schemas/agent-sandboxes";
 import { organizations } from "../../db/schemas/organizations";
 import { getMaxNonTerminalAgentsForOrg } from "../constants/agent-sandbox-quota";
 import { logger } from "../utils/logger";
@@ -202,6 +210,7 @@ export async function ensureManagedDiscordGatewayInTransaction(
       // `pending` + non-pool is intentionally quota-counted. Keep this aligned
       // with QUOTA_COUNTED_STATUSES and account-limit snapshots.
       status: "pending",
+      execution_tier: "shared",
       pool_status: null,
       database_status: "none",
     })
@@ -306,7 +315,10 @@ export class ManagedAgentDiscordService {
     // daemon picks it up, stops the container, and re-provisions with
     // the freshly-persisted agent_config above.
     let restarted = false;
-    if (sandbox.status === "running") {
+    if (
+      sandbox.status === "running" &&
+      CONTAINER_BACKED_EXECUTION_TIERS.some((tier) => tier === sandbox.execution_tier)
+    ) {
       await provisioningJobService.enqueueAgentRestartOnce({
         agentId: sandbox.id,
         organizationId: params.organizationId,
@@ -314,7 +326,8 @@ export class ManagedAgentDiscordService {
       });
       // The restart job is already enqueued; triggerImmediate only nudges the
       // daemon to pick it up now. A failed nudge delays restart to the next poll.
-      // error-policy:J7 nudge failure only delays an already-enqueued restart; logged, not fatal.
+      // error-policy:J5 The durable restart remains observable by the scheduled poller;
+      // this handler observes and reports only the failed immediate nudge.
       void provisioningJobService.triggerImmediate().catch((err) =>
         logger.warn("[managed-discord] provisioning triggerImmediate nudge failed", {
           agentId: sandbox.id,
@@ -368,7 +381,10 @@ export class ManagedAgentDiscordService {
     // daemon picks it up, stops the container, and re-provisions with
     // the freshly-persisted agent_config above.
     let restarted = false;
-    if (sandbox.status === "running") {
+    if (
+      sandbox.status === "running" &&
+      CONTAINER_BACKED_EXECUTION_TIERS.some((tier) => tier === sandbox.execution_tier)
+    ) {
       await provisioningJobService.enqueueAgentRestartOnce({
         agentId: sandbox.id,
         organizationId: params.organizationId,
@@ -376,7 +392,8 @@ export class ManagedAgentDiscordService {
       });
       // The restart job is already enqueued; triggerImmediate only nudges the
       // daemon to pick it up now. A failed nudge delays restart to the next poll.
-      // error-policy:J7 nudge failure only delays an already-enqueued restart; logged, not fatal.
+      // error-policy:J5 The durable restart remains observable by the scheduled poller;
+      // this handler observes and reports only the failed immediate nudge.
       void provisioningJobService.triggerImmediate().catch((err) =>
         logger.warn("[managed-discord] provisioning triggerImmediate nudge failed", {
           agentId: sandbox.id,

--- a/packages/cloud/shared/src/lib/services/agent-managed-github.ts
+++ b/packages/cloud/shared/src/lib/services/agent-managed-github.ts
@@ -1,5 +1,10 @@
-// Coordinates cloud service agent managed github behavior behind route handlers.
+/**
+ * Coordinates managed GitHub connector configuration and OAuth teardown.
+ * Connector mutations persist first, then schedule lifecycle work only for
+ * running agents backed by a container.
+ */
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
+import { CONTAINER_BACKED_EXECUTION_TIERS } from "../../db/schemas/agent-sandboxes";
 import { logger } from "../utils/logger";
 import {
   type ManagedAgentGithubBinding,
@@ -102,7 +107,10 @@ export class ManagedAgentGithubService {
     // daemon picks it up, stops the container, and re-provisions with
     // the freshly-persisted agent_config above.
     let restarted = false;
-    if (sandbox.status === "running") {
+    if (
+      sandbox.status === "running" &&
+      CONTAINER_BACKED_EXECUTION_TIERS.some((tier) => tier === sandbox.execution_tier)
+    ) {
       await provisioningJobService.enqueueAgentRestartOnce({
         agentId: sandbox.id,
         organizationId: params.organizationId,
@@ -111,7 +119,8 @@ export class ManagedAgentGithubService {
       // The restart job is already enqueued above; triggerImmediate only nudges the
       // daemon to pick it up now. A failed nudge delays the restart to the next poll,
       // so it is logged rather than swallowed or thrown.
-      // error-policy:J7 nudge failure only delays an already-enqueued restart; logged, not fatal.
+      // error-policy:J5 The durable restart remains observable by the scheduled poller;
+      // this handler observes and reports only the failed immediate nudge.
       void provisioningJobService.triggerImmediate().catch((err) =>
         logger.warn("[managed-github] provisioning triggerImmediate nudge failed", {
           agentId: sandbox.id,
@@ -158,6 +167,7 @@ export class ManagedAgentGithubService {
           connectionId: currentBinding.connectionId,
         });
       } catch (error) {
+        // error-policy:J6 OAuth revocation is best-effort teardown; warn while the requested local disconnect proceeds.
         logger.warn("[managed-github] Failed to revoke OAuth connection during disconnect", {
           connectionId: currentBinding.connectionId,
           error: error instanceof Error ? error.message : String(error),
@@ -176,7 +186,10 @@ export class ManagedAgentGithubService {
     // daemon picks it up, stops the container, and re-provisions with
     // the freshly-persisted agent_config above.
     let restarted = false;
-    if (sandbox.status === "running") {
+    if (
+      sandbox.status === "running" &&
+      CONTAINER_BACKED_EXECUTION_TIERS.some((tier) => tier === sandbox.execution_tier)
+    ) {
       await provisioningJobService.enqueueAgentRestartOnce({
         agentId: sandbox.id,
         organizationId: params.organizationId,
@@ -185,7 +198,8 @@ export class ManagedAgentGithubService {
       // The restart job is already enqueued above; triggerImmediate only nudges the
       // daemon to pick it up now. A failed nudge delays the restart to the next poll,
       // so it is logged rather than swallowed or thrown.
-      // error-policy:J7 nudge failure only delays an already-enqueued restart; logged, not fatal.
+      // error-policy:J5 The durable restart remains observable by the scheduled poller;
+      // this handler observes and reports only the failed immediate nudge.
       void provisioningJobService.triggerImmediate().catch((err) =>
         logger.warn("[managed-github] provisioning triggerImmediate nudge failed", {
           agentId: sandbox.id,


### PR DESCRIPTION
# Relates to

- #22947 — Slice G: managed connector restart admission for container-backed tiers only.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun run verify` was run after sync; its exact unrelated blocker is recorded below. A fresh install was not repeated because the lockfile is unchanged.
- [x] A reviewer can confirm the backend contract from the focused exact-head tests and independent reviews below.

# Sync with develop

- [x] Rebased onto `origin/develop@5c10de39dc5992667422528400bc12ba86cd8a22`; zero conflicts.
- [x] The exact unrelated root-verify blocker is documented in **Known gaps / failures**.

# Risks

Medium. This changes whether four managed Discord/GitHub connect/disconnect paths schedule a container restart. A false negative could leave a real container on stale config; a false positive recreates the Shared failure. The implementation uses the existing canonical explicit allowlist, and the test matrix covers all four operations across Shared, an unknown tier, and all three container-backed tiers.

# Background

## What does this PR do?

Managed connector mutations persist `agent_config` and then previously enqueued a restart for every sandbox whose status was `running`. Shared agents have no container, so the authoritative provisioning admission added in #23858 rejects that job after the configuration write. The caller therefore saw a failure even though the logical connector mutation had succeeded.

This PR:

- keeps configuration persistence for every tier;
- returns `restarted:false` for `shared` and unknown runtime tiers without calling `enqueueAgentRestartOnce` or `triggerImmediate`;
- preserves enqueue + nudge for `dedicated-lazy`, `dedicated-always`, and `custom`;
- makes the logical managed Discord gateway insert explicitly `execution_tier: "shared"` instead of relying on the schema default;
- classifies the pre-existing best-effort OAuth revoke catch as `error-policy:J6`.

The allowlist is `CONTAINER_BACKED_EXECUTION_TIERS`; this is deliberately fail-closed for any future or corrupt tier value. No route, OAuth contract, schema, migration, billing path, provisioning admission, deployment, or live environment is changed.

Historical authors inventoried before implementation: Shaw, Stan, and Claude Fable 5. No open PR overlapped these files when the slice was claimed.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is required. This narrows an internal restart side effect while preserving the existing connect/disconnect response shape.

# Testing

## Where should a reviewer start?

1. `packages/cloud/shared/src/lib/services/agent-managed-discord.ts`
2. `packages/cloud/shared/src/lib/services/agent-managed-github.ts`
3. `packages/cloud/shared/src/lib/services/agent-managed-connector-execution-tier.test.ts`
4. `packages/cloud/shared/src/lib/services/agent-managed-discord-quota.test.ts`

## Detailed testing steps

Exact candidate: `5392d9d96ee8d68be47028a21c3c415472758297`  
Toolchain: Node `24.15.0`, Bun `1.3.14`.

- `bun --config=/dev/null test packages/cloud/shared/src/lib/services/agent-managed-connector-execution-tier.test.ts packages/cloud/shared/src/lib/services/agent-managed-discord-quota.test.ts`
  - 21 named tests pass, 0 fail, 161 assertions.
  - The four connector operations persist config and skip restart for `shared` and `future-unknown-tier`.
  - The same four operations persist config and enqueue/nudge exactly once for each of `dedicated-lazy`, `dedicated-always`, and `custom`.
  - The gateway transaction test asserts the raw insert includes `execution_tier: "shared"`.
- `bun run --cwd packages/cloud/shared typecheck` — passes.
- `bunx @biomejs/biome check <the four changed files>` — passes.
- `bun run --cwd packages/cloud/shared check:tenant-scope` — passes across 128 repository files.
- `git diff --check origin/develop...HEAD` — passes.
- Two independent exact-head reviews found no P0–P3 source or test finding after the review fixes.

Baseline by exact test name on clean `origin/develop@5c10de39dc5992667422528400bc12ba86cd8a22`:

- `ensureManagedDiscordGatewayInTransaction > orders the org lock before primary tier, scoped marker, quota, and insert` passes (11 assertions).
- The new managed-connector matrix is absent on the base.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:5392d9d96ee8d68be47028a21c3c415472758297 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Backend-only service and queue-admission change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Backend-only service and queue-admission change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - No user-driven visual flow or frontend behavior changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - No live connector, OAuth account, or deployed agent was mutated; focused service tests exercise the exact persistence and zero/one job boundaries.
<!-- evidence-row:frontend-logs -->
- [x] N/A - No frontend code, console behavior, or browser request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - No agent prompt, action, provider, model, or LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - No durable external artifact was created; deterministic spies assert config persistence and exact zero/one enqueue behavior.
<!-- evidence-row:ocr-review -->
- [x] N/A - No rendered visual surface or visible text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - No prompt, action, provider, model, or LLM behavior changes.

## Backend + frontend logs

N/A - Exercising the real path would mutate managed connector/OAuth state and potentially restart deployed agents. The focused suite invokes the real services with deterministic repository and job-boundary spies.

## Screenshots (before / after) + video walkthrough

N/A - Backend-only change with no UI surface.

## Audio / voice walkthrough

N/A - No audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- On exact head `5392d9d96ee8d68be47028a21c3c415472758297`, `bun run verify` reaches the root Turbo typecheck/lint matrix and fails on unrelated `@elizaos/capacitor-gateway#lint:check`: `node-swiftlint: command not found` (exit 127). The affected `cloud-shared` lint, focused Biome, package typecheck, tenant-scope gate, and tests pass.
- A fresh `bun install` was not repeated in this isolated worktree. The lockfile is unchanged and validation used the existing Bun 1.3.14 workspace installation.
- No live connector/OAuth/deployed-agent evidence was captured because that would mutate external state and is not required to prove this bounded admission rule.
- Hosted CI is not claimed as green; its jobs may remain queued under repository concurrency.

AI provider/model: OpenAI / GPT-5.6
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-managed-connector-tier]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5.6","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->

## Maintainer review receipt

Restacked without conflicts onto `origin/develop@5c10de39dc5992667422528400bc12ba86cd8a22`. On exact head `5392d9d96ee8d68be47028a21c3c415472758297`, the maintainer independently ran both focused suites: 21 tests passed, 0 failed, 161 assertions. Focused Biome and `git diff --check` pass. Review confirmed Shared connector routing reads durable sandbox configuration and does not require a container restart; all three canonical container tiers retain the restart. The four retained immediate-nudge handlers were corrected from the diagnostics category to the durable-job observation category required by repository policy.

Maintainer AI provider/model: OpenAI / gpt-5
Maintainer client / agent tooling: Codex
Maintainer attribution status: system-confirmed
— [maintainer-review-5392d9d]