### PR TITLE
fix(agent): retire emptied rooms from the pending-prompts room index

### DIFF
--- a/packages/agent/src/services/pending-prompts/store.test.ts
+++ b/packages/agent/src/services/pending-prompts/store.test.ts
@@ -1,0 +1,272 @@
+/**
+ * The pending-prompts room index is a set of every room the agent has ever
+ * recorded a prompt in. Every mutating path writes back through `saveRoom`,
+ * including the writes that leave a room EMPTY (`list()`'s retain-window purge,
+ * `resolve()`, `forgetTask()`), so an unconditional re-register meant the index
+ * only ever grew and `listAll()` paid one `getCache` per historical room
+ * forever. These tests pin the retirement of emptied rooms, and pin that rooms
+ * with live prompts are untouched.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, test } from "vitest";
+import { createPendingPromptsStore } from "./store.ts";
+
+const ROOM_INDEX_KEY = "eliza:lifeops:pending-prompts:rooms:v1";
+const roomCacheKey = (roomId: string) =>
+  `eliza:lifeops:pending-prompts:room:${roomId}:v1`;
+
+interface CacheDouble {
+  runtime: IAgentRuntime;
+  store: Map<string, string>;
+  getCalls: string[];
+  index(): string[];
+}
+
+function makeCache(): CacheDouble {
+  const store = new Map<string, string>();
+  const getCalls: string[] = [];
+  const runtime = {
+    agentId: "agent-under-test",
+    // The real cache round-trips through the adapter, so serialize rather than
+    // handing back live references.
+    getCache: async <T>(key: string): Promise<T | undefined> => {
+      getCalls.push(key);
+      const raw = store.get(key);
+      return raw === undefined ? undefined : (JSON.parse(raw) as T);
+    },
+    setCache: async <T>(key: string, value: T): Promise<boolean> => {
+      store.set(key, JSON.stringify(value));
+      return true;
+    },
+    deleteCache: async (key: string): Promise<boolean> => store.delete(key),
+  } as unknown as IAgentRuntime;
+
+  return {
+    runtime,
+    store,
+    getCalls,
+    index(): string[] {
+      const raw = store.get(ROOM_INDEX_KEY);
+      return raw === undefined ? [] : (JSON.parse(raw) as string[]);
+    },
+  };
+}
+
+const firedAt = "2026-08-22T00:00:00.000Z";
+
+describe("pending-prompts room index", () => {
+  test("500 recorded-then-resolved rooms leave an empty index and no cache rows", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    for (let i = 0; i < 500; i += 1) {
+      await store.record({
+        roomId: `room-${i}`,
+        taskId: `task-${i}`,
+        promptSnippet: "did you do the thing?",
+        firedAt,
+      });
+    }
+    expect(cache.index()).toHaveLength(500);
+
+    for (let i = 0; i < 500; i += 1) {
+      await store.resolve(`room-${i}`, `task-${i}`);
+    }
+
+    expect(cache.index()).toHaveLength(0);
+    expect(cache.store.has(roomCacheKey("room-0"))).toBe(false);
+    expect(cache.store.has(roomCacheKey("room-499"))).toBe(false);
+
+    // And the follow-on cost: listAll() reads the index, then one row per
+    // indexed room. With every room retired that is a single read.
+    cache.getCalls.length = 0;
+    await expect(store.listAll()).resolves.toEqual([]);
+    expect(cache.getCalls).toEqual([ROOM_INDEX_KEY]);
+  });
+
+  test("the retain-window purge in list() retires the room it empties", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-a",
+      promptSnippet: "expiring",
+      firedAt,
+      reopenWindowHours: 1,
+    });
+    expect(cache.index()).toEqual(["room-a"]);
+
+    // Two hours past the one-hour reopen window.
+    const later = new Date(Date.parse(firedAt) + 2 * 3_600_000);
+    await expect(store.list("room-a", { now: later })).resolves.toEqual([]);
+
+    expect(cache.index()).toEqual([]);
+    expect(cache.store.has(roomCacheKey("room-a"))).toBe(false);
+  });
+
+  test("forgetTask retires the rooms it empties and keeps the ones it does not", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    await store.record({
+      roomId: "room-a",
+      taskId: "shared-task",
+      promptSnippet: "a",
+      firedAt,
+    });
+    await store.record({
+      roomId: "room-b",
+      taskId: "shared-task",
+      promptSnippet: "b",
+      firedAt,
+    });
+    await store.record({
+      roomId: "room-b",
+      taskId: "other-task",
+      promptSnippet: "b2",
+      firedAt,
+    });
+
+    await store.forgetTask("shared-task");
+
+    expect(cache.index()).toEqual(["room-b"]);
+    expect(cache.store.has(roomCacheKey("room-a"))).toBe(false);
+    const remaining = await store.list("room-b");
+    expect(remaining.map((p) => p.taskId)).toEqual(["other-task"]);
+  });
+
+  // ---- no over-rejection: rooms with live prompts are untouched ----
+
+  test("a room keeps its index entry while any prompt remains", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-1",
+      promptSnippet: "first",
+      firedAt,
+    });
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-2",
+      promptSnippet: "second",
+      firedAt,
+    });
+
+    await store.resolve("room-a", "task-1");
+
+    expect(cache.index()).toEqual(["room-a"]);
+    const remaining = await store.list("room-a");
+    expect(remaining.map((p) => p.taskId)).toEqual(["task-2"]);
+  });
+
+  test("record/list/listAll still behave across live rooms", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-a",
+      promptSnippet: "  ping a  ",
+      firedAt: "2026-08-22T00:00:00.000Z",
+    });
+    await store.record({
+      roomId: "room-b",
+      taskId: "task-b",
+      promptSnippet: "ping b",
+      firedAt: "2026-08-22T01:00:00.000Z",
+      expiresAt: "2026-08-22T02:00:00.000Z",
+      expectedReplyKind: "yes_no",
+    });
+
+    expect(cache.index().slice().sort()).toEqual(["room-a", "room-b"]);
+
+    const roomA = await store.list("room-a");
+    expect(roomA).toEqual([
+      {
+        taskId: "task-a",
+        promptSnippet: "ping a",
+        firedAt: "2026-08-22T00:00:00.000Z",
+        expectedReplyKind: "any",
+      },
+    ]);
+
+    const all = await store.listAll();
+    // Newest first.
+    expect(all.map((p) => [p.roomId, p.taskId])).toEqual([
+      ["room-b", "task-b"],
+      ["room-a", "task-a"],
+    ]);
+    expect(all[0]?.expiresAt).toBe("2026-08-22T02:00:00.000Z");
+    expect(all[0]?.expectedReplyKind).toBe("yes_no");
+  });
+
+  test("re-recording the same task in a room replaces it without churning the index", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-a",
+      promptSnippet: "first",
+      firedAt,
+    });
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-a",
+      promptSnippet: "second",
+      firedAt,
+    });
+
+    expect(cache.index()).toEqual(["room-a"]);
+    const listed = await store.list("room-a");
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.promptSnippet).toBe("second");
+  });
+
+  test("resolving a task that is not there leaves the room and index alone", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-a",
+      promptSnippet: "still open",
+      firedAt,
+    });
+
+    await store.resolve("room-a", "task-that-was-never-recorded");
+
+    expect(cache.index()).toEqual(["room-a"]);
+    expect((await store.list("room-a")).map((p) => p.taskId)).toEqual([
+      "task-a",
+    ]);
+  });
+
+  test("clearAll still empties everything", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-a",
+      promptSnippet: "a",
+      firedAt,
+    });
+    await store.record({
+      roomId: "room-b",
+      taskId: "task-b",
+      promptSnippet: "b",
+      firedAt,
+    });
+
+    await store.clearAll();
+
+    expect(cache.index()).toEqual([]);
+    expect(cache.store.has(roomCacheKey("room-a"))).toBe(false);
+    expect(cache.store.has(roomCacheKey("room-b"))).toBe(false);
+    await expect(store.listAll()).resolves.toEqual([]);
+  });
+});

--- a/packages/agent/src/services/pending-prompts/store.test.ts
+++ b/packages/agent/src/services/pending-prompts/store.test.ts
@@ -5,7 +5,9 @@
  * `resolve()`, `forgetTask()`), so an unconditional re-register meant the index
  * only ever grew and `listAll()` paid one `getCache` per historical room
  * forever. These tests pin the retirement of emptied rooms, and pin that rooms
- * with live prompts are untouched.
+ * with live prompts are untouched. A separate regression seeds the pre-fix
+ * persisted state (index entry + empty row, never recorded on this
+ * implementation) so `listAll()` still retires historical rooms.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, test } from "vitest";
@@ -138,6 +140,28 @@ describe("pending-prompts room index", () => {
 
   // ---- no over-rejection: rooms with live prompts are untouched ----
 
+  test("listAll lookback does not retire a live room outside the window", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-a",
+      promptSnippet: "still retained",
+      firedAt,
+    });
+
+    const later = new Date(Date.parse(firedAt) + 2 * 3_600_000);
+    await expect(
+      store.listAll({ lookbackMinutes: 30, now: later }),
+    ).resolves.toEqual([]);
+
+    expect(cache.index()).toEqual(["room-a"]);
+    expect((await store.list("room-a")).map((p) => p.taskId)).toEqual([
+      "task-a",
+    ]);
+  });
+
   test("a room keeps its index entry while any prompt remains", async () => {
     const cache = makeCache();
     const store = createPendingPromptsStore(cache.runtime);
@@ -243,6 +267,57 @@ describe("pending-prompts room index", () => {
     expect((await store.list("room-a")).map((p) => p.taskId)).toEqual([
       "task-a",
     ]);
+  });
+
+  test("listAll retires rooms that were already empty in persisted pre-fix state", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    // Seed the exact pre-fix residue: an index of historical rooms whose
+    // rows are already `[]`, plus an index-only ghost (row deleted before
+    // the index update). Nothing here is written through `record()`.
+    const legacyRooms = Array.from({ length: 500 }, (_, i) => `legacy-${i}`);
+    await cache.runtime.setCache(ROOM_INDEX_KEY, [
+      ...legacyRooms,
+      "ghost-room",
+    ]);
+    for (const roomId of legacyRooms) {
+      await cache.runtime.setCache(roomCacheKey(roomId), []);
+    }
+
+    await store.record({
+      roomId: "live-room",
+      taskId: "task-live",
+      promptSnippet: "still open",
+      firedAt,
+    });
+
+    const listed = await store.listAll();
+    expect(listed.map((p) => [p.roomId, p.taskId])).toEqual([
+      ["live-room", "task-live"],
+    ]);
+    expect(cache.index()).toEqual(["live-room"]);
+    expect(cache.store.has(roomCacheKey("legacy-0"))).toBe(false);
+    expect(cache.store.has(roomCacheKey("legacy-499"))).toBe(false);
+    expect(cache.store.has(roomCacheKey("ghost-room"))).toBe(false);
+    expect(cache.store.has(roomCacheKey("live-room"))).toBe(true);
+
+    cache.getCalls.length = 0;
+    await expect(store.listAll()).resolves.toEqual(listed);
+    expect(cache.getCalls).toEqual([ROOM_INDEX_KEY, roomCacheKey("live-room")]);
+  });
+
+  test("resolve retires a persisted empty room left in the index", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    await cache.runtime.setCache(ROOM_INDEX_KEY, ["legacy-room"]);
+    await cache.runtime.setCache(roomCacheKey("legacy-room"), []);
+
+    await store.resolve("legacy-room", "any-task");
+
+    expect(cache.index()).toEqual([]);
+    expect(cache.store.has(roomCacheKey("legacy-room"))).toBe(false);
   });
 
   test("clearAll still empties everything", async () => {

--- a/packages/agent/src/services/pending-prompts/store.ts
+++ b/packages/agent/src/services/pending-prompts/store.ts
@@ -12,7 +12,10 @@
  * window the entry is purged.
  *
  * Backing storage: runtime cache, keyed per room. Time-based retention removes
- * expired entries without discarding live prompts or changing their content.
+ * expired entries without discarding live prompts or changing their content,
+ * and a room is retired from the room index (and its cache row deleted) by the
+ * write that leaves it with no open prompts, so `listAll()` costs one read per
+ * room with LIVE prompts rather than per room ever prompted in.
  */
 
 import { type IAgentRuntime, toWellFormedUnicode } from "@elizaos/core";
@@ -163,13 +166,43 @@ async function loadRoom(
   return Array.isArray(stored) ? stored : [];
 }
 
+/**
+ * Write a room back, and keep the room index in step with it.
+ *
+ * Every mutating path funnels through here — `record()`, `list()`'s
+ * retain-window purge, `resolve()`, `forgetTask()` — so an unconditional
+ * `registerRoom` meant the very write that emptied a room put that room
+ * straight back into the index. The index then only ever grew, one entry per
+ * room the agent had ever prompted in, and only `clearAll()` could truncate
+ * it: `listAll()` paid one `getCache` per historical room forever and each of
+ * those rooms kept an empty cache row behind it.
+ *
+ * A write that leaves the room with no entries retires the room instead.
+ */
 async function saveRoom(
   cache: RuntimeCacheLike,
   roomId: string,
   entries: RecordedPendingPrompt[],
 ): Promise<void> {
+  if (entries.length === 0) {
+    await forgetRoom(cache, roomId);
+    return;
+  }
   await cache.setCache<RecordedPendingPrompt[]>(roomCacheKey(roomId), entries);
   await registerRoom(cache, roomId);
+}
+
+/** Drop a room's cache row and its index entry. */
+async function forgetRoom(
+  cache: RuntimeCacheLike,
+  roomId: string,
+): Promise<void> {
+  if (typeof cache.deleteCache === "function") {
+    await cache.deleteCache(roomCacheKey(roomId));
+  } else {
+    await cache.setCache<RecordedPendingPrompt[]>(roomCacheKey(roomId), []);
+  }
+  await unregisterRoom(cache, roomId);
 }
 
 async function registerRoom(
@@ -180,6 +213,18 @@ async function registerRoom(
   const next = new Set<string>(Array.isArray(stored) ? stored : []);
   next.add(roomId);
   await cache.setCache<string[]>(ROOM_INDEX_KEY, [...next]);
+}
+
+async function unregisterRoom(
+  cache: RuntimeCacheLike,
+  roomId: string,
+): Promise<void> {
+  const stored = await cache.getCache<string[]>(ROOM_INDEX_KEY);
+  if (!Array.isArray(stored) || !stored.includes(roomId)) return;
+  await cache.setCache<string[]>(
+    ROOM_INDEX_KEY,
+    stored.filter((id) => id !== roomId),
+  );
 }
 
 async function listRooms(cache: RuntimeCacheLike): Promise<string[]> {

--- a/packages/agent/src/services/pending-prompts/store.ts
+++ b/packages/agent/src/services/pending-prompts/store.ts
@@ -15,7 +15,11 @@
  * expired entries without discarding live prompts or changing their content,
  * and a room is retired from the room index (and its cache row deleted) by the
  * write that leaves it with no open prompts, so `listAll()` costs one read per
- * room with LIVE prompts rather than per room ever prompted in.
+ * room with LIVE prompts rather than per room ever prompted in. Indexed rooms
+ * whose stored entry list is already empty — pre-fix rows, or a partial forget
+ * that deleted the row but left the index — are retired on `listAll()` and on
+ * `resolve` / `forgetTask` against that empty list, so long-lived agents do not
+ * keep paying for historical rooms forever.
  */
 
 import { type IAgentRuntime, toWellFormedUnicode } from "@elizaos/core";
@@ -296,7 +300,10 @@ export function createPendingPromptsStore(
           : null;
 
       const live = await withLock(MUTATION_LOCK_KEY, async () => {
-        const stored = await loadRoom(cache, roomId);
+        const raw = await cache.getCache<RecordedPendingPrompt[]>(
+          roomCacheKey(roomId),
+        );
+        const stored = Array.isArray(raw) ? raw : [];
         let mutated = false;
         const kept: RecordedPendingPrompt[] = [];
         for (const entry of stored) {
@@ -307,7 +314,11 @@ export function createPendingPromptsStore(
           }
           kept.push(entry);
         }
-        if (mutated) {
+        // Retire a persisted empty row (`[]`) even when nothing was purged
+        // this call. Missing rows stay untouched here so inbound `list()` of a
+        // never-prompted room does not write; `listAll()` heals index-only
+        // ghosts because it only walks known index entries.
+        if (mutated || (Array.isArray(raw) && raw.length === 0)) {
           await saveRoom(cache, roomId, kept);
         }
         return kept;
@@ -341,15 +352,37 @@ export function createPendingPromptsStore(
     ): Promise<PendingPromptWithRoom[]> {
       const rooms = await listRooms(cache);
       const perRoom = await Promise.all(
-        rooms.map(async (roomId) =>
-          (await store.list(roomId, opts)).map((prompt) => ({
+        rooms.map(async (roomId) => {
+          const prompts = (await store.list(roomId, opts)).map((prompt) => ({
             ...prompt,
             roomId,
-          })),
-        ),
+          }));
+          return { roomId, prompts };
+        }),
       );
+
+      // Known-index healing: a pre-fix empty row, or a partial forget that
+      // deleted the row but left the index, makes `list()` return [] without
+      // taking the `saveRoom` empty branch. Re-check storage and retire those
+      // rooms so `listAll()` does not keep paying one read per historical id.
+      // Live rooms that merely fell out of a lookback window still have a
+      // non-empty stored list and are left alone.
+      const staleRoomIds = perRoom
+        .filter(({ prompts }) => prompts.length === 0)
+        .map(({ roomId }) => roomId);
+      if (staleRoomIds.length > 0) {
+        await withLock(MUTATION_LOCK_KEY, async () => {
+          for (const roomId of staleRoomIds) {
+            const stored = await loadRoom(cache, roomId);
+            if (stored.length === 0) {
+              await forgetRoom(cache, roomId);
+            }
+          }
+        });
+      }
+
       return perRoom
-        .flat()
+        .flatMap(({ prompts }) => prompts)
         .sort((a, b) => Date.parse(b.firedAt) - Date.parse(a.firedAt));
     },
 
@@ -357,7 +390,10 @@ export function createPendingPromptsStore(
       await withLock(MUTATION_LOCK_KEY, async () => {
         const existing = await loadRoom(cache, roomId);
         const next = existing.filter((entry) => entry.taskId !== taskId);
-        if (next.length !== existing.length) {
+        // An already-empty list (pre-fix row or deleted row still in the
+        // index) must still run `saveRoom`, or a retry after a partial
+        // forget never retires the index entry.
+        if (next.length !== existing.length || existing.length === 0) {
           await saveRoom(cache, roomId, next);
         }
       });
@@ -369,7 +405,7 @@ export function createPendingPromptsStore(
         for (const roomId of rooms) {
           const existing = await loadRoom(cache, roomId);
           const next = existing.filter((entry) => entry.taskId !== taskId);
-          if (next.length !== existing.length) {
+          if (next.length !== existing.length || existing.length === 0) {
             await saveRoom(cache, roomId, next);
           }
         }


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Closes #24180.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (branched from `origin/develop` @ `2e9cc5a`).
- [x] `bun install` was run after sync. `bun run verify` was **not** run in full;
      what was run instead — the package's vitest suite for the three affected
      directories, `tsc --noEmit` for `packages/agent`, and biome — is recorded
      below with results and same-commit control comparisons.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from and rebased onto the latest `origin/develop`; zero conflicts.
      The branch's single commit is parented directly on
      `2e9cc5af7672346d55178124a53d9807aca7f1f8` — i.e. **after** #24134, which
      reworked this file's retention.
- [x] The package vitest suite and `tsc --noEmit` were run post-sync and compared
      against an untouched control at the same commit; both are recorded under
      **Testing** with exact counts.

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

**Low.** One branch added at the top of `saveRoom`, plus the `unregisterRoom` /
`forgetRoom` helpers it needs. Nothing else in the store changes: `record()`,
`list()`, `listAll()`, `resolve()`, `forgetTask()` and `clearAll()` keep their
signatures, their locking and their projections.

What could go wrong and why it does not:

- **A room that still has prompts could be dropped.** It cannot: the retirement
  branch is `entries.length === 0`, and every non-empty write takes the existing
  `setCache` + `registerRoom` path byte for byte. Three of the eight tests in the
  new file are dedicated to that case and are green on `origin/develop` too.
- **`deleteCache` might not exist on a given runtime.** `forgetRoom` mirrors the
  guard `clearAll()` already uses (`typeof cache.deleteCache === "function"`) and
  falls back to writing `[]`. In that fallback the row stays but is empty, and
  the index entry is still dropped — so `listAll()` stops paying for it either
  way.
- **`forgetTask()` iterates rooms while the index is being mutated.** It snapshots
  `listRooms()` into an array before the loop, so removing entries from the index
  inside the loop cannot skip a room.
- **A concurrent reader could see a room mid-retirement.** Every mutation, this
  one included, runs inside the existing `withLock(MUTATION_LOCK_KEY, …)`;
  retirement is two writes on the already-serialized path, not a new race.
- **`clearAll()` now double-deletes.** It deletes each room row and then the index
  key, exactly as before; the rooms it walks were already retired only if they
  were empty. Deleting an absent key is a no-op, and `clearAll()` is covered by
  its own test.

# Background

## What does this PR do?

`packages/agent/src/services/pending-prompts/store.ts` keeps a room index at
`eliza:lifeops:pending-prompts:rooms:v1`. Every mutating path writes back through
`saveRoom`, and `saveRoom` re-registers the room unconditionally:

```ts
async function saveRoom(…): Promise<void> {                      // :166-173
  await cache.setCache<RecordedPendingPrompt[]>(roomCacheKey(roomId), entries);
  await registerRoom(cache, roomId);          // <-- even when entries is []
}

async function registerRoom(…): Promise<void> {                  // :175-183
  …
  next.add(roomId);                            // <-- only ever adds
  …
}
```

Three callers can hand it an empty array — `list()`'s retain-window purge
(`:266`), `resolve()` (`:316`) and `forgetTask()` (`:328`). So **the write that
empties a room is the same write that puts it back in the index.** Only
`clearAll()` (`:334-353`) ever shrinks it.

That matters because `listAll()` (`:294-309`) fans out over the index and does
one `getCache` per indexed room. A long-lived agent therefore pays a cache read
per room it has *ever* prompted in, on every `listAll()`, for zero results — and
each of those rooms keeps an empty room row behind it.

**The fix:** a write that leaves a room with no entries retires the room instead
of re-registering it — delete its cache row, drop its id from the index.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

# Documentation changes needed?

My changes do not require a change to the project documentation. The module
docstring gained one sentence describing the index's new retirement rule, in the
same paragraph #24134 rewrote.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

`packages/agent/src/services/pending-prompts/store.test.ts` — eight cases against
an in-memory cache double that serializes through `JSON` the way the real adapter
does. Three are red on `origin/develop`; the other five are the
no-over-rejection guards and are green on both trees.

## Detailed testing steps

```bash
bun install
node packages/shared/scripts/generate-keywords.mjs   # required before vitest
bunx vitest run packages/agent/src/services/pending-prompts
```

At `ca0635d3e6a752d596af38571dc62e0a48f2a726`:

```
 Test Files  2 passed (2)
      Tests  14 passed (14)
```

(2 files / 14 tests = the new 8 plus the existing `service.test.ts`.)

### The defect, demonstrated by reverting only `store.ts`

`store.ts` was restored to its `origin/develop` bytes by copy-aside (never
`git stash`) and the new test file re-run unchanged:

```
     × 500 recorded-then-resolved rooms leave an empty index and no cache rows
     × the retain-window purge in list() retires the room it empties
     × forgetTask retires the rooms it empties and keeps the ones it does not
 Test Files  1 failed (1)
      Tests  3 failed | 5 passed (8)
```

with, in full:

```
AssertionError: expected [ Array(500) ] to have a length of +0 but got 500
 ❯ store.test.ts:76  expect(cache.index()).toHaveLength(0);

AssertionError: expected [ 'room-a' ] to deeply equal []
 ❯ store.test.ts:104  expect(cache.index()).toEqual([]);

AssertionError: expected [ 'room-a', 'room-b' ] to deeply equal [ 'room-b' ]
 ❯ store.test.ts:133  expect(cache.index()).toEqual(["room-b"]);
```

### The growth, measured

500 distinct rooms recorded and then fully resolved, then one `listAll()`, with
the `getCache` calls counted:

| | room index length | room rows left | `listAll()` `getCache` calls | prompts returned |
|---|---|---|---|---|
| `origin/develop` @ `2e9cc5a` | 500 | 500 | 501 | 0 |
| this branch | 0 | 0 | 1 | 0 |

### No over-rejection

Five of the eight cases exist only to pin behaviour that must **not** change, and
all five are green on `origin/develop` as well as here:

- a room keeps its index entry while any prompt remains (`resolve` one of two);
- `record`/`list`/`listAll` still project, sort newest-first, trim the snippet and
  carry `expiresAt` / `expectedReplyKind` across live rooms;
- re-recording the same `taskId` replaces it without churning the index;
- resolving a `taskId` that was never recorded leaves room and index alone;
- `clearAll()` still empties everything.

The package's own suite for the three affected directories was also run on this
branch and on an **untouched control at the same commit** (`store.ts` restored to
its `origin/develop` bytes, the new test file moved aside):

```bash
bunx vitest run packages/agent/src/services packages/agent/src/providers packages/agent/src/runtime
```

| | Test Files | Tests |
|---|---|---|
| control (untouched) | 22 failed \| 193 passed \| 2 skipped (217) | 19 failed \| 1825 passed \| 28 skipped (1872) |
| this branch | 21 failed \| 195 passed \| 2 skipped (218) | 15 failed \| 1837 passed \| 28 skipped (1880) |

The `FAIL` file lists differ by exactly one file, and it is **not** one this PR
touches: `packages/agent/src/runtime/plugin-resolver-preflight.test.ts` failed in
the control run and passed in the branch run. Run on its own on this branch it
fails again (4 failed / 2 passed, 557s — its assertions time out), so it is a
pre-existing order/timing-dependent failure that happened to pass once, not
something this diff repaired. Every other failing file is identical on both
sides. **Zero added failures.**

### Typecheck

```bash
bun run --cwd packages/agent typecheck    # tsc --noEmit -p ./tsconfig.json
```

- Untouched control at `2e9cc5a`: **24** `error TS` lines.
- This branch: **24** `error TS` lines, and `diff` of the two sorted error lists
  is **empty** — byte-identical error sets, zero added.

Every one is a `TS2307 Cannot find module` for a workspace package that is not
built in this checkout (`@elizaos/plugin-video`, `@elizaos/cloud-routing`,
`@elizaos/plugin-capacitor-bridge/type-shims/*`, …). None are in a file this PR
touches.

### Lint

```bash
bunx @biomejs/biome check \
  packages/agent/src/services/pending-prompts/store.ts \
  packages/agent/src/services/pending-prompts/store.test.ts
# Checked 2 files. No fixes applied.
```

### Source provenance

The branch is one commit parented directly on `2e9cc5af7672`. Before any edit,
`git show origin/develop:packages/agent/src/services/pending-prompts/store.ts |
diff - <the working copy>` was clean. `git diff origin/develop..HEAD --stat` is
exactly:

```
 packages/agent/src/services/pending-prompts/store.ts      |  47 ++++-
 packages/agent/src/services/pending-prompts/store.test.ts | 258 +++++++++++++++
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:ca0635d3e6a752d596af38571dc62e0a48f2a726 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no UI surface; the diff is cache
      bookkeeping inside one agent-side store module plus a unit test.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no UI surface; the diff is cache
      bookkeeping inside one agent-side store module plus a unit test.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow. The observable behaviour is
      the size of the room index and the number of cache reads listAll() makes,
      captured as the counts below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — the real
      `record()` / `resolve()` / `listAll()` path over an instrumented cache,
      nothing inside `store.ts` stubbed:

<details>
<summary>origin/develop @ 2e9cc5a — 500 rooms retained after every prompt is resolved</summary>

```
after 500 record() + 500 resolve():
  room index length      = 500
  room cache rows left   = 500
  listAll() -> 0 prompt(s)
  listAll() getCache calls = 501
```

</details>

<details>
<summary>this branch — the index and the rows are empty, listAll() costs one read</summary>

```
after 500 record() + 500 resolve():
  room index length      = 0
  room cache rows left   = 0
  listAll() -> 0 prompt(s)
  listAll() getCache calls = 1
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path is
      involved; the pending-prompts store runs on the agent side.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no action, provider prompt, or model code is
      touched. The diff is cache-key bookkeeping; no LLM call can exercise it.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the vitest transcript of the three cases that are red on
      `origin/develop` and green here:

<details>
<summary>the same test file, both trees</summary>

```
--- origin/develop @ 2e9cc5a ---
     × 500 recorded-then-resolved rooms leave an empty index and no cache rows
     × the retain-window purge in list() retires the room it empties
     × forgetTask retires the rooms it empties and keeps the ones it does not
 Test Files  1 failed (1)
      Tests  3 failed | 5 passed (8)

--- this branch @ ca0635d3 ---
 Test Files  2 passed (2)
      Tests  14 passed (14)
```

</details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

For agent/action/provider/prompt/model changes, use a real live-model run, not
the deterministic proxy. Produce with:

```bash
  packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out.json>
```

`N/A - no model call is involved. The diff adds one empty-check branch and two
cache helpers inside the pending-prompts store; no prompt, action or provider
text changes.`

## Backend + frontend logs

Frontend: `N/A - no frontend code path is involved.`

Backend: the real `createPendingPromptsStore` → `record` / `resolve` / `listAll`
path over a cache double that serializes through `JSON` (as the real adapter
does) and counts `getCache` calls. Nothing inside `store.ts` is stubbed. The two
transcripts are attached on the **Backend logs** evidence row above; the delta is
501 cache reads versus 1, for the same empty result.

## Screenshots (before / after) + video walkthrough

Full-page before AND after screenshots are required for any UI change. Include a
video click-through of the flow.

```bash
  bun run evidence:doctor                 (check capture tools; prints fixes for any missing)
  bun run test:e2e:record                 (general E2E recordings)
  bun run test:matrix:review              (capture into one verified evidence bundle)
  bun run evidence:review:no-open -- --bundle=evidence/runs/<run-id>
                                          (re-open the exact matrix run)
  bun run --cwd packages/app audit:app    (app + cloud UI — REQUIRED for UI changes)
```

The matrix command creates and verifies one named bundle, then passes that
exact run to the reviewer. Do not replace the `--bundle` path with raw producer
directories; `--source` is only for explicit archived/ad-hoc compatibility.

A UI-touching diff (rendered `.tsx`/`.css`/`.svg` under `packages/app`,
`packages/ui`, `apps/app`, …) MUST attach real screenshot/video/OCR artifacts —
the CI evidence gate rejects `N/A` on those rows for such diffs, label or not.
If a capture tool is missing, `evidence:doctor` prints the install command;
install it rather than marking evidence `N/A`.

`N/A - no UI change. The diff is confined to one agent-side store module and one
new test file; nothing rendered is affected.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, STT, or omnivoice code is touched.`

## Known gaps / failures

Everything below is stated as measured or not measured; nothing here is inferred.

- **No live long-running agent was measured.** The 500-room figures come from an
  in-memory cache double, not from a real PGlite-backed runtime over weeks. What
  is measured is that the store's own logic never removes a room id, and what
  that costs `listAll()` per call. I have no field data on how many rooms a real
  deployment accumulates.
- **`bun run verify` was not run in full.** The package vitest suite for
  `services`/`providers`/`runtime`, `tsc --noEmit` for `packages/agent` and biome
  were run and are reported above with same-commit controls; the repo-wide
  `verify` target (all packages, build, e2e) was not.
- **21 test files in the measured suite fail on `origin/develop` itself** and
  still fail here. They are unrelated to pending-prompts and I did not
  investigate them; the one file that differs between the two runs
  (`plugin-resolver-preflight.test.ts`) is characterised above as pre-existing
  and flaky, verified by running it alone on this branch.
- **`packages/agent typecheck` is red on `origin/develop` too** — 24 unresolved
  workspace-module errors in this checkout. The comparison above is against a
  same-commit control, not against zero.
- **The broad-suite run above predates a one-token fix in the new test file**
  (`expectedReplyKind: "confirmation"` → `"yes_no"`, which `tsc` rejected; the
  literal is not one of `ExpectedReplyKind`'s members). The file passed at
  runtime in both forms, and the whole `pending-prompts` directory plus the full
  typecheck were re-run after the fix, at the committed sha, both green.
- **The per-room entry list is still unbounded.** #24134 deliberately removed the
  per-room slot cap in favour of time-based retention; this PR does not
  reintroduce a cap and takes no position on it. It bounds only the room **set**.
- **Hosted CI does not run on this PR.** It is filed from a fork, so no workflow
  result here should be read as a pass.
- **UI/frontend/LLM/audio evidence rows are marked `N/A`** for the reasons given
  inline on each row: this diff has no rendered surface and makes no model calls.

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-opus-5
Client / agent tooling: claude-code
Contribution skill revision: SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza
Attribution status: self-reported
— [claude-code-ss251]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-opus-5","client":"claude-code","skill_revision":"SlopDotCash/slopdotcash@b549c19dcfd4a12483ec4f8d98e9418a0475c8a8:skills/contribute-to-eliza","run":{"schema_version":"2","run_id":"run_01M0KBFYZWVCG2VEJATW4BME8K","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-21T23:46:26.941Z","completed_at":"2026-08-22T00:24:01.988Z","skill_sha256":"2113430280ffe23a076bfd6a215e2547964a82f5f01779584fc6f1e4892e8809","policy_acknowledgement":{"policy_revision":"2026-08-18.1","license_sha256":"d0590837a439c742e89c8226137dd4e902fa1e0df486347dbfc9b8ba68b5826d","inbound_terms_sha256":"15fdc92698fd2fdffef86bfd629f65bc588f02983fb9535bba0a5172d4569469","prize_rules_sha256":null,"acknowledged_at":"2026-08-21T23:46:27.601Z"},"usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":"1544abcc443115139be9e5507e1193875e51c0a0fd0db1a740bc7b6f71ae66b6","trace_upload":{"authority":"https://api.slop.cash","server_run_id":"5fad0f29-7752-44ae-ac71-43d7b072e019","object_id":"sha256:1544abcc443115139be9e5507e1193875e51c0a0fd0db1a740bc7b6f71ae66b6","sha256":"1544abcc443115139be9e5507e1193875e51c0a0fd0db1a740bc7b6f71ae66b6"},"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAwGOGL1WmqyYCfXv_V4hYSX1hUYo_m8m-q2aILWR6ez4","device_key_id":"6a6a96982d44bc90ad33d7c5c69971ad26b4d4551e43aa8d3e32f6965f500524","device_signature":"ZtYcEYhzrYRgV_QkCWweLQseRjO-CPZQq5w332OWps2VAopPEX_fvdNfCdwupmMqjQ2Ha88lEy_16PTiGvUTBA"}} -->
