### PR TITLE
fix(core): bound stableStringify against unbounded hosted metadata

### DIFF
--- a/packages/core/src/entities.ts
+++ b/packages/core/src/entities.ts
@@ -20,6 +20,7 @@ import {
 	normalizeEntityMatches,
 	readEntityResolutionField,
 } from "./entity-matches";
+import { ElizaError } from "./errors";
 import { logger } from "./logger";
 // Type-only (erased at runtime, so no cycle with roles.ts, which imports
 // createUniqueUuid from this module). The role-resolution values are pulled via a
@@ -37,7 +38,11 @@ import {
 	type World,
 } from "./types";
 import * as utils from "./utils";
-import { stableStringify } from "./utils/deterministic";
+import {
+	STABLE_STRINGIFY_UNBOUNDED,
+	StableStringifyUnboundedError,
+	stableStringify,
+} from "./utils/deterministic";
 
 type EntityDetailsRecord = Pick<
 	Entity,
@@ -602,7 +607,22 @@ export async function getEntityDetails({
 						: entity.names[0],
 					names: entity.names,
 					metadata: entity.metadata,
-					data: stableStringify({ ...mergedData, ...entity.metadata }),
+					data: (() => {
+						try {
+							return stableStringify({ ...mergedData, ...entity.metadata });
+						} catch (error) {
+							if (error instanceof StableStringifyUnboundedError) {
+								throw new ElizaError(
+									`entity data is unbounded (${(error as Error).message})`,
+									{
+										code: STABLE_STRINGIFY_UNBOUNDED,
+										cause: error,
+									},
+								);
+							}
+							throw error;
+						}
+					})(),
 				});
 			}
 
@@ -626,7 +646,20 @@ function formatEntityNames(names: string[]): string {
 }
 
 export function formatEntityMetadata(metadata: unknown): string {
-	return stableStringify(metadata);
+	try {
+		return stableStringify(metadata);
+	} catch (error) {
+		if (error instanceof StableStringifyUnboundedError) {
+			throw new ElizaError(
+				`entity metadata is unbounded (${(error as Error).message})`,
+				{
+					code: STABLE_STRINGIFY_UNBOUNDED,
+					cause: error,
+				},
+			);
+		}
+		throw error;
+	}
 }
 
 export function formatEntities({ entities }: { entities: Entity[] }) {

--- a/packages/core/src/utils/deterministic.bounded.test.ts
+++ b/packages/core/src/utils/deterministic.bounded.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Comprehensive bound coverage for stableStringify.
+ * Mirrors reviewer request: byte-for-byte, boundary, wide-object, digest translation.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	MAX_STABLE_STRINGIFY_DEPTH,
+	MAX_STABLE_STRINGIFY_NODES,
+	MAX_STABLE_STRINGIFY_STRING_BYTES,
+	STABLE_STRINGIFY_UNBOUNDED,
+	StableStringifyUnboundedError,
+	stableStringify,
+} from "./deterministic.ts";
+
+function buildDeep(depth: number): unknown {
+	let cur: unknown = { leaf: 1 };
+	for (let i = 0; i < depth; i++) cur = { nest: cur };
+	return cur;
+}
+
+describe("stableStringify byte-for-byte compatibility (plain JSON)", () => {
+	it("nested objects sorted", () => {
+		expect(stableStringify({ z: { y: 2, x: 1 }, a: 3 })).toBe(
+			'{"a":3,"z":{"x":1,"y":2}}',
+		);
+	});
+	it("arrays keep order", () => {
+		expect(stableStringify([3, 1, 2])).toBe("[3,1,2]");
+	});
+	it("sparse arrays -> null holes", () => {
+		// biome-ignore lint/suspicious/noSparseArray: intentional sparse hole preserved for byte-for-byte compatibility proof
+		const sparse = [1, , 3] as unknown[];
+		expect(stableStringify(sparse)).toBe("[1,null,3]");
+		// Also via explicit hole using Array constructor
+		const viaLength = new Array(3);
+		viaLength[0] = 1;
+		viaLength[2] = 3;
+		expect(stableStringify(viaLength)).toBe("[1,null,3]");
+	});
+	it("Dates", () => {
+		const d = new Date("2026-01-01T00:00:00.000Z");
+		expect(stableStringify(d)).toBe('"2026-01-01T00:00:00.000Z"');
+		expect(stableStringify({ d })).toBe('{"d":"2026-01-01T00:00:00.000Z"}');
+		expect(stableStringify(new Date(NaN))).toBe("null");
+		expect(stableStringify([new Date(NaN)])).toBe("[null]");
+	});
+	it("shared DAG (same ref twice) not flagged as cycle", () => {
+		const shared = { x: 1 };
+		expect(stableStringify({ y: shared, z: shared })).toBe(
+			'{"y":{"x":1},"z":{"x":1}}',
+		);
+	});
+	it("undefined/function/symbol in objects dropped, in arrays -> null", () => {
+		expect(
+			stableStringify({ a: undefined, b: 1, c: () => {}, d: Symbol("s") }),
+		).toBe('{"b":1}');
+		expect(stableStringify([undefined, () => {}, Symbol("s")])).toBe(
+			"[null,null,null]",
+		);
+		expect(stableStringify({ a: { b: undefined } })).toBe('{"a":{}}');
+	});
+	it("numeric edges", () => {
+		expect(stableStringify({ a: 0, b: -0 })).toBe('{"a":0,"b":0}');
+		expect(stableStringify([Infinity, -Infinity, NaN])).toBe(
+			"[null,null,null]",
+		);
+		expect(stableStringify(Number.MAX_SAFE_INTEGER)).toBe(
+			String(Number.MAX_SAFE_INTEGER),
+		);
+	});
+	it("entity-metadata style payload (hosted plain JSON)", () => {
+		const metadata = {
+			discord: { id: "123", username: "alice", discriminator: "0" },
+			origin: "discord",
+			session: { id: "s1", platform: "discord" },
+			sender: { id: "u1", names: ["Alice"] },
+			extra: { b: 2, a: 1, nested: { y: 2, x: 1 } },
+		};
+		// byte-for-byte equals historic unsorted? Check ordering
+		expect(stableStringify(metadata)).toBe(
+			'{"discord":{"discriminator":"0","id":"123","username":"alice"},"extra":{"a":1,"b":2,"nested":{"x":1,"y":2}},"origin":"discord","sender":{"id":"u1","names":["Alice"]},"session":{"id":"s1","platform":"discord"}}',
+		);
+		// spread merge used in entities.ts
+		const merged = { ...{ a: 1 }, ...metadata };
+		expect(stableStringify(merged)).toContain('"origin":"discord"');
+	});
+	it("approval payload shape", () => {
+		const payload = {
+			action: "send",
+			channel: "discord",
+			reason: "test",
+			data: { b: 2, a: 1 },
+		};
+		expect(stableStringify(payload)).toBe(
+			'{"action":"send","channel":"discord","data":{"a":1,"b":2},"reason":"test"}',
+		);
+		expect(stableStringify(payload)).toBe(
+			stableStringify({
+				reason: "test",
+				data: { a: 1, b: 2 },
+				channel: "discord",
+				action: "send",
+			}),
+		);
+	});
+	it("scheduled-task digest shape", () => {
+		const task = {
+			taskId: "t1",
+			agentId: "a1",
+			kind: "reminder" as const,
+			trigger: { kind: "once" as const, atIso: "2026-01-01T00:00:00.000Z" },
+			promptInstructions: "hello",
+			state: { status: "scheduled" as const },
+			metadata: {
+				extra: { nested: { b: 2, a: 1 } },
+				sharedCutoverImport: null,
+			},
+			createdAt: new Date("2026-01-01T00:00:00.000Z"),
+		};
+		const digest = stableStringify(task);
+		expect(digest).toBe(
+			'{"agentId":"a1","createdAt":"2026-01-01T00:00:00.000Z","kind":"reminder","metadata":{"extra":{"nested":{"a":1,"b":2}},"sharedCutoverImport":null},"promptInstructions":"hello","state":{"status":"scheduled"},"taskId":"t1","trigger":{"atIso":"2026-01-01T00:00:00.000Z","kind":"once"}}',
+		);
+		// order independence
+		expect(
+			stableStringify({
+				b: task.metadata.extra.nested.b,
+				a: task.metadata.extra.nested.a,
+			}),
+		).toBe('{"a":1,"b":2}');
+	});
+});
+
+describe("stableStringify bounds - depth / nodes / string bytes", () => {
+	it(`depth at limit ${MAX_STABLE_STRINGIFY_DEPTH - 1} passes`, () => {
+		expect(() =>
+			stableStringify(buildDeep(MAX_STABLE_STRINGIFY_DEPTH - 1)),
+		).not.toThrow();
+	});
+	it(`depth just over limit throws depth`, () => {
+		expect(() =>
+			stableStringify(buildDeep(MAX_STABLE_STRINGIFY_DEPTH)),
+		).toThrow(StableStringifyUnboundedError);
+		try {
+			stableStringify(buildDeep(MAX_STABLE_STRINGIFY_DEPTH + 1));
+		} catch (e) {
+			expect((e as StableStringifyUnboundedError).message).toContain("depth");
+			expect((e as { code: unknown }).code).toBe(STABLE_STRINGIFY_UNBOUNDED);
+		}
+	});
+	it(`nodes at limit via array length passes, just over throws`, () => {
+		const ok = Array.from({ length: MAX_STABLE_STRINGIFY_NODES }, () => 1);
+		expect(() => stableStringify(ok)).not.toThrow();
+		const over = Array.from(
+			{ length: MAX_STABLE_STRINGIFY_NODES + 1 },
+			() => 1,
+		);
+		expect(() => stableStringify(over)).toThrow(StableStringifyUnboundedError);
+	});
+	it("nodes just over via object keys throws", () => {
+		const base: Record<string, number> = {};
+		for (let i = 0; i < MAX_STABLE_STRINGIFY_NODES; i++) base[`k${i}`] = 1;
+		// This creates ~MAX keys, each counted plus values; may exceed due to key byte accounting.
+		// Use array variant for precise boundary above; this just ensures wide throws nodes
+		expect(() => stableStringify(base)).toThrow(StableStringifyUnboundedError);
+	});
+	it(`value string at ${MAX_STABLE_STRINGIFY_STRING_BYTES} passes, +1 throws leaf`, () => {
+		const ok = "a".repeat(MAX_STABLE_STRINGIFY_STRING_BYTES);
+		expect(() => stableStringify(ok)).not.toThrow();
+		expect(() => stableStringify({ k: ok })).not.toThrow();
+		const over = "a".repeat(MAX_STABLE_STRINGIFY_STRING_BYTES + 1);
+		expect(() => stableStringify(over)).toThrow(StableStringifyUnboundedError);
+		try {
+			stableStringify(over);
+		} catch (e) {
+			expect((e as Error).message).toContain("leaf");
+		}
+	});
+	it("key bytes at limit passes, over throws leaf", () => {
+		const okKey = "k".repeat(MAX_STABLE_STRINGIFY_STRING_BYTES);
+		expect(() => stableStringify({ [okKey]: 1 })).not.toThrow();
+		const overKey = "k".repeat(MAX_STABLE_STRINGIFY_STRING_BYTES + 1);
+		expect(() => stableStringify({ [overKey]: 1 })).toThrow(
+			StableStringifyUnboundedError,
+		);
+	});
+	it("cycle throws cycle", () => {
+		const a: Record<string, unknown> = {} as Record<string, unknown>;
+		a.self = a;
+		expect(() => stableStringify(a)).toThrow(StableStringifyUnboundedError);
+		try {
+			stableStringify(a);
+		} catch (e) {
+			expect((e as Error).message).toContain("cycle");
+		}
+		// array cycle
+		const arr: unknown[] = [];
+		arr.push(arr);
+		expect(() => stableStringify(arr)).toThrow(StableStringifyUnboundedError);
+	});
+	it("accessor preserves output (not thrown) — historic compatibility", () => {
+		const o = {
+			get a() {
+				return 1;
+			},
+			b: 2,
+		};
+		expect(stableStringify(o)).toBe('{"a":1,"b":2}');
+		// array accessor via getter
+		const arr = [1, 2, 3];
+		Object.defineProperty(arr, "1", {
+			get() {
+				return 99;
+			},
+			enumerable: true,
+			configurable: true,
+		});
+		expect(stableStringify(arr)).toBe("[1,99,3]");
+	});
+	it("prototype: Map/Set/class instances serialize as {} or own keys (preserved)", () => {
+		expect(stableStringify(new Map([["k", 1]]))).toBe("{}");
+		expect(stableStringify(new Set([1, 2, 3]))).toBe("{}");
+		class C {
+			x = 1;
+			y = 2;
+		}
+		expect(stableStringify(new C())).toBe('{"x":1,"y":2}');
+		expect(
+			stableStringify(
+				Object.create(null, { a: { value: 1, enumerable: true } }),
+			),
+		).toBe('{"a":1}');
+	});
+});
+
+describe("wide object ownKeys allocation limitation", () => {
+	it("demonstrates that a wide object allocates full key list before nodes check", () => {
+		// Create object with 3000 keys (>2048 node budget) — Reflect.ownKeys/Object.keys
+		// will allocate a 3000-element array before the walk can throw. This is the
+		// unavoidable allocation noted in the header.
+		const wide: Record<string, number> = {};
+		for (let i = 0; i < 3000; i++) wide[`k${i}`] = i;
+		// It still throws, but the throw occurs AFTER the keys array was allocated.
+		// We assert the throw is nodes, not depth, and that the keys array length is observable.
+		const keysBeforeThrow = Object.keys(wide);
+		expect(keysBeforeThrow.length).toBe(3000);
+		expect(() => stableStringify(wide)).toThrow(StableStringifyUnboundedError);
+		try {
+			stableStringify(wide);
+		} catch (e) {
+			expect((e as StableStringifyUnboundedError).message).toContain("nodes");
+		}
+		// Document mitigation: callers with untrusted wide objects should cap JSON length
+		// or key count before calling stableStringify, not rely on the walk to avoid allocation.
+	});
+});
+
+describe("scheduled-task digest boundary translation", () => {
+	it("successful digest is stable and order-independent", () => {
+		const taskA = {
+			taskId: "t1",
+			metadata: { b: 2, a: 1 },
+			state: { status: "scheduled" },
+		};
+		const taskB = {
+			state: { status: "scheduled" },
+			taskId: "t1",
+			metadata: { a: 1, b: 2 },
+		};
+		expect(stableStringify(taskA)).toBe(stableStringify(taskB));
+	});
+	it("over-budget digest throws typed error with code for explicit translation", () => {
+		const over = Array.from(
+			{ length: MAX_STABLE_STRINGIFY_NODES + 10 },
+			() => ({ x: 1 }),
+		);
+		let caught: unknown;
+		try {
+			stableStringify({ tasks: over });
+		} catch (e) {
+			caught = e;
+		}
+		expect(caught).toBeInstanceOf(StableStringifyUnboundedError);
+		expect((caught as StableStringifyUnboundedError).code).toBe(
+			STABLE_STRINGIFY_UNBOUNDED,
+		);
+		// Caller translation must not block legitimate execution with unhandled throw:
+		// example handler mirrors what plugin-scheduling should do.
+		function computeDigest(
+			task: unknown,
+		): string | { error: string; code: string } {
+			try {
+				return stableStringify(task);
+			} catch (e) {
+				if (e instanceof StableStringifyUnboundedError) {
+					return {
+						error: (e as Error).message,
+						code: (e as { code: unknown }).code,
+					};
+				}
+				throw e;
+			}
+		}
+		const result = computeDigest({ tasks: over });
+		expect(typeof result).toBe("object");
+		expect((result as { code: string }).code).toBe(STABLE_STRINGIFY_UNBOUNDED);
+	});
+	it("Proxy trap limitation: hostile Proxy get trap runs before budget, plain JSON does not", () => {
+		// A Proxy that traps ownKeys/get can execute code before the walk's budget check.
+		// This demonstrates why the utility is NOT a hostile-Proxy sandbox — hosted data is plain JSON.
+		let trapRan = false;
+		const proxy = new Proxy(
+			{ a: 1 },
+			{
+				ownKeys() {
+					trapRan = true;
+					return ["a"];
+				},
+			},
+		);
+		// On plain-key path we call Object.keys which triggers ownKeys trap.
+		stableStringify(proxy);
+		expect(trapRan).toBe(true);
+	});
+});

--- a/packages/core/src/utils/deterministic.ts
+++ b/packages/core/src/utils/deterministic.ts
@@ -5,6 +5,7 @@
  * provides stableStringify — key-order-independent JSON for stable hashing/IDs.
  */
 
+import { ElizaError } from "../errors";
 import { EXAMPLE_NAMES } from "./example-names";
 
 const UINT32_MAX = 0x100000000;
@@ -106,30 +107,207 @@ export function getDeterministicNames(
 	});
 }
 
-export function stableStringify(value: unknown): string {
-	return JSON.stringify(sortStable(value));
+export const STABLE_STRINGIFY_UNBOUNDED = "STABLE_STRINGIFY_UNBOUNDED";
+export const MAX_STABLE_STRINGIFY_DEPTH = 32;
+export const MAX_STABLE_STRINGIFY_NODES = 2_048;
+export const MAX_STABLE_STRINGIFY_STRING_BYTES = 64 * 1024;
+
+export class StableStringifyUnboundedError extends ElizaError {
+	override readonly name = "StableStringifyUnboundedError";
+	constructor(
+		reason: string,
+		context: Record<string, unknown> = {},
+		cause?: unknown,
+	) {
+		super(`stableStringify is unbounded (${reason})`, {
+			code: STABLE_STRINGIFY_UNBOUNDED,
+			context: { reason, ...context },
+			severity: "fatal",
+			...(cause !== undefined ? { cause } : {}),
+		});
+	}
 }
 
-function sortStable(value: unknown): unknown {
-	if (Array.isArray(value)) {
-		return value.map((entry) => sortStable(entry));
+export function stableStringify(value: unknown): string {
+	const sorted = sortStable(value);
+	return JSON.stringify(sorted);
+}
+
+function sortStableBounded(
+	value: unknown,
+	depth: number,
+	state: { nodes: number; seen: WeakSet<object> },
+): unknown {
+	if (depth > MAX_STABLE_STRINGIFY_DEPTH) {
+		throw new StableStringifyUnboundedError("depth", { depth });
+	}
+	if (state.nodes > MAX_STABLE_STRINGIFY_NODES) {
+		throw new StableStringifyUnboundedError("nodes", { nodes: state.nodes });
 	}
 
-	if (value instanceof Date) {
-		// Keep native Date#toJSON behavior, including null for an invalid date.
+	if (value === null || typeof value !== "object") {
+		if (typeof value === "string") {
+			const bytes = new TextEncoder().encode(value).byteLength;
+			if (bytes > MAX_STABLE_STRINGIFY_STRING_BYTES) {
+				throw new StableStringifyUnboundedError("leaf", { stringBytes: bytes });
+			}
+			state.nodes += Math.max(1, Math.ceil(bytes / 1024));
+		} else {
+			state.nodes += 1;
+		}
+		if (state.nodes > MAX_STABLE_STRINGIFY_NODES) {
+			throw new StableStringifyUnboundedError("nodes", { nodes: state.nodes });
+		}
 		return value;
 	}
 
-	if (value && typeof value === "object") {
-		return Object.fromEntries(
-			Object.entries(value as Record<string, unknown>)
-				// Code-unit order, not localeCompare: ICU collation is
-				// environment-dependent, so hashes derived from this output
-				// must not vary with the host locale.
-				.sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
-				.map(([key, nestedValue]) => [key, sortStable(nestedValue)]),
-		);
+	if (value instanceof Date) {
+		state.nodes += 1;
+		if (state.nodes > MAX_STABLE_STRINGIFY_NODES) {
+			throw new StableStringifyUnboundedError("nodes", { nodes: state.nodes });
+		}
+		return value;
+	}
+
+	if (typeof value === "object") {
+		if (state.seen.has(value as object)) {
+			throw new StableStringifyUnboundedError("cycle", {});
+		}
+		state.seen.add(value as object);
+		try {
+			if (Array.isArray(value)) {
+				let prototype: object | null;
+				try {
+					prototype = Object.getPrototypeOf(value) as object | null;
+				} catch (error) {
+					throw new StableStringifyUnboundedError("reflection", {}, error);
+				}
+				if (prototype !== Array.prototype && prototype !== null) {
+					throw new StableStringifyUnboundedError("leaf", {
+						type: "non-array-object",
+					});
+				}
+				let lengthDescriptor: PropertyDescriptor | undefined;
+				try {
+					lengthDescriptor = Object.getOwnPropertyDescriptor(value, "length");
+				} catch (error) {
+					throw new StableStringifyUnboundedError(
+						"reflection",
+						{ field: "length" },
+						error,
+					);
+				}
+				if (
+					!lengthDescriptor ||
+					!("value" in lengthDescriptor) ||
+					typeof lengthDescriptor.value !== "number" ||
+					!Number.isSafeInteger(lengthDescriptor.value) ||
+					lengthDescriptor.value < 0
+				) {
+					throw new StableStringifyUnboundedError("reflection", {
+						field: "length",
+					});
+				}
+				const length = lengthDescriptor.value;
+				if (length > MAX_STABLE_STRINGIFY_NODES - state.nodes) {
+					throw new StableStringifyUnboundedError("nodes", {
+						nodes: state.nodes + length,
+					});
+				}
+				const out: unknown[] = [];
+				for (let index = 0; index < length; index += 1) {
+					let descriptor: PropertyDescriptor | undefined;
+					try {
+						descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+					} catch (error) {
+						throw new StableStringifyUnboundedError(
+							"reflection",
+							{ index },
+							error,
+						);
+					}
+					if (!descriptor) {
+						state.nodes += 1;
+						if (state.nodes > MAX_STABLE_STRINGIFY_NODES) {
+							throw new StableStringifyUnboundedError("nodes", {
+								nodes: state.nodes,
+							});
+						}
+						out.push(null);
+						continue;
+					}
+					if (!("value" in descriptor)) {
+						throw new StableStringifyUnboundedError("accessor", { index });
+					}
+					out.push(sortStableBounded(descriptor.value, depth + 1, state));
+				}
+				return out;
+			}
+
+			let prototype: object | null;
+			try {
+				prototype = Object.getPrototypeOf(value) as object | null;
+			} catch (error) {
+				throw new StableStringifyUnboundedError("reflection", {}, error);
+			}
+			if (prototype !== Object.prototype && prototype !== null) {
+				throw new StableStringifyUnboundedError("leaf", {
+					type: "non-plain-object",
+				});
+			}
+			let keys: readonly PropertyKey[];
+			try {
+				keys = Reflect.ownKeys(value as object);
+			} catch (error) {
+				throw new StableStringifyUnboundedError("reflection", {}, error);
+			}
+			if (keys.length > MAX_STABLE_STRINGIFY_NODES - state.nodes) {
+				throw new StableStringifyUnboundedError("nodes", {
+					nodes: state.nodes + keys.length,
+				});
+			}
+			const sortedKeys = (keys as string[])
+				.filter((k): k is string => typeof k === "string")
+				.sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+			const output: Record<string, unknown> = {};
+			for (const key of sortedKeys) {
+				let descriptor: PropertyDescriptor | undefined;
+				try {
+					descriptor = Object.getOwnPropertyDescriptor(value as object, key);
+				} catch (error) {
+					throw new StableStringifyUnboundedError("reflection", { key }, error);
+				}
+				if (!descriptor?.enumerable) continue;
+				const keyBytes = new TextEncoder().encode(key).byteLength;
+				if (keyBytes > MAX_STABLE_STRINGIFY_STRING_BYTES) {
+					throw new StableStringifyUnboundedError("leaf", { keyBytes });
+				}
+				state.nodes += Math.max(1, Math.ceil(keyBytes / 1024));
+				if (state.nodes > MAX_STABLE_STRINGIFY_NODES) {
+					throw new StableStringifyUnboundedError("nodes", {
+						nodes: state.nodes,
+					});
+				}
+				if (!("value" in descriptor)) {
+					throw new StableStringifyUnboundedError("accessor", { key });
+				}
+				const nested = sortStableBounded(descriptor.value, depth + 1, state);
+				Object.defineProperty(output, key, {
+					configurable: true,
+					enumerable: true,
+					value: nested,
+					writable: true,
+				});
+			}
+			return output;
+		} finally {
+			state.seen.delete(value as object);
+		}
 	}
 
 	return value;
+}
+
+function sortStable(value: unknown): unknown {
+	return sortStableBounded(value, 0, { nodes: 0, seen: new WeakSet() });
 }

--- a/packages/core/src/utils/deterministic.ts
+++ b/packages/core/src/utils/deterministic.ts
@@ -3,6 +3,24 @@
  * seed-driven shuffle/sample/pick plus example-name generation, all keyed by a
  * string or number seed so the same seed always yields the same result. Also
  * provides stableStringify — key-order-independent JSON for stable hashing/IDs.
+ *
+ * stableStringify contract + bounds
+ * - Intended for validated plain JSON (plain objects, arrays, primitives, Dates)
+ *   plus the historic undefined/function/symbol dropping handled by
+ *   JSON.stringify. Hosted metadata (entity/metadata, payload, scheduled-task
+ *   digests) is JSON-derived after JSON.parse, so data-only descriptors are the
+ *   expected shape. Map/Set/class instances with no enumerable own string keys
+ *   serialize as {} (same as the pre-bound implementation); accessor getters are
+ *   invoked once via normal property read, preserving historic output.
+ * - Not a hostile-Proxy sandbox: Object.keys / Object.getOwnPropertyDescriptor /
+ *   Object.getPrototypeOf and property reads can invoke Proxy traps before any
+ *   budget check can run. Hosted data is plain JSON, not a trap-bearing Proxy.
+ * - OwnKeys/allocation limitation: Object.keys enumerates and allocates the
+ *   full key list before keys.length can be charged against the node budget.
+ *   A wide object (e.g. 10k keys) will allocate that array even though the walk
+ *   then throws StableStringifyUnboundedError. Bounding before materialization
+ *   would require capping at the JSON/materialization boundary instead of inside
+ *   the walk.
  */
 
 import { ElizaError } from "../errors";
@@ -169,56 +187,78 @@ function sortStableBounded(
 		return value;
 	}
 
-	if (typeof value === "object") {
+	if (Array.isArray(value)) {
 		if (state.seen.has(value as object)) {
 			throw new StableStringifyUnboundedError("cycle", {});
 		}
 		state.seen.add(value as object);
 		try {
-			if (Array.isArray(value)) {
-				let prototype: object | null;
+			// Length is read via descriptor to preserve sparse-hole semantics without
+			// invoking a Proxy get trap for every index via value.length; descriptor
+			// access still invokes the length trap once if value is a Proxy.
+			let lengthDescriptor: PropertyDescriptor | undefined;
+			try {
+				lengthDescriptor = Object.getOwnPropertyDescriptor(value, "length");
+			} catch (error) {
+				throw new StableStringifyUnboundedError(
+					"reflection",
+					{ field: "length" },
+					error,
+				);
+			}
+			if (
+				!lengthDescriptor ||
+				!("value" in lengthDescriptor) ||
+				typeof lengthDescriptor.value !== "number" ||
+				!Number.isSafeInteger(lengthDescriptor.value) ||
+				lengthDescriptor.value < 0
+			) {
+				throw new StableStringifyUnboundedError("reflection", {
+					field: "length",
+				});
+			}
+			const length = lengthDescriptor.value;
+			// Note: we charge for length only after reading it; a Proxy that fakes a
+			// huge length still allocates the loop structure. Hosted data is plain
+			// JSON arrays, not Proxies.
+			if (length > MAX_STABLE_STRINGIFY_NODES - state.nodes) {
+				throw new StableStringifyUnboundedError("nodes", {
+					nodes: state.nodes + length,
+				});
+			}
+			const out: unknown[] = [];
+			for (let index = 0; index < length; index += 1) {
+				// Sparse holes: descriptor missing -> JSON.stringify yields null, same as original value.map hole
+				let descriptor: PropertyDescriptor | undefined;
 				try {
-					prototype = Object.getPrototypeOf(value) as object | null;
-				} catch (error) {
-					throw new StableStringifyUnboundedError("reflection", {}, error);
-				}
-				if (prototype !== Array.prototype && prototype !== null) {
-					throw new StableStringifyUnboundedError("leaf", {
-						type: "non-array-object",
-					});
-				}
-				let lengthDescriptor: PropertyDescriptor | undefined;
-				try {
-					lengthDescriptor = Object.getOwnPropertyDescriptor(value, "length");
+					descriptor = Object.getOwnPropertyDescriptor(value, String(index));
 				} catch (error) {
 					throw new StableStringifyUnboundedError(
 						"reflection",
-						{ field: "length" },
+						{ index },
 						error,
 					);
 				}
-				if (
-					!lengthDescriptor ||
-					!("value" in lengthDescriptor) ||
-					typeof lengthDescriptor.value !== "number" ||
-					!Number.isSafeInteger(lengthDescriptor.value) ||
-					lengthDescriptor.value < 0
-				) {
-					throw new StableStringifyUnboundedError("reflection", {
-						field: "length",
-					});
+				if (!descriptor) {
+					state.nodes += 1;
+					if (state.nodes > MAX_STABLE_STRINGIFY_NODES) {
+						throw new StableStringifyUnboundedError("nodes", {
+							nodes: state.nodes,
+						});
+					}
+					out.push(null);
+					continue;
 				}
-				const length = lengthDescriptor.value;
-				if (length > MAX_STABLE_STRINGIFY_NODES - state.nodes) {
-					throw new StableStringifyUnboundedError("nodes", {
-						nodes: state.nodes + length,
-					});
-				}
-				const out: unknown[] = [];
-				for (let index = 0; index < length; index += 1) {
-					let descriptor: PropertyDescriptor | undefined;
+				// Preserve historic accessor behavior: Object.entries/value[i] invokes getter once.
+				// For plain JSON (data descriptors), this is a direct value read; for an
+				// accessor, we intentionally read the getter result once rather than throwing,
+				// to keep byte-for-byte compatibility with the pre-bound implementation.
+				let entry: unknown;
+				if ("value" in descriptor) {
+					entry = descriptor.value;
+				} else {
 					try {
-						descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+						entry = (value as unknown[])[index];
 					} catch (error) {
 						throw new StableStringifyUnboundedError(
 							"reflection",
@@ -226,86 +266,83 @@ function sortStableBounded(
 							error,
 						);
 					}
-					if (!descriptor) {
-						state.nodes += 1;
-						if (state.nodes > MAX_STABLE_STRINGIFY_NODES) {
-							throw new StableStringifyUnboundedError("nodes", {
-								nodes: state.nodes,
-							});
-						}
-						out.push(null);
-						continue;
-					}
-					if (!("value" in descriptor)) {
-						throw new StableStringifyUnboundedError("accessor", { index });
-					}
-					out.push(sortStableBounded(descriptor.value, depth + 1, state));
 				}
-				return out;
+				out.push(sortStableBounded(entry, depth + 1, state));
 			}
-
-			let prototype: object | null;
-			try {
-				prototype = Object.getPrototypeOf(value) as object | null;
-			} catch (error) {
-				throw new StableStringifyUnboundedError("reflection", {}, error);
-			}
-			if (prototype !== Object.prototype && prototype !== null) {
-				throw new StableStringifyUnboundedError("leaf", {
-					type: "non-plain-object",
-				});
-			}
-			let keys: readonly PropertyKey[];
-			try {
-				keys = Reflect.ownKeys(value as object);
-			} catch (error) {
-				throw new StableStringifyUnboundedError("reflection", {}, error);
-			}
-			if (keys.length > MAX_STABLE_STRINGIFY_NODES - state.nodes) {
-				throw new StableStringifyUnboundedError("nodes", {
-					nodes: state.nodes + keys.length,
-				});
-			}
-			const sortedKeys = (keys as string[])
-				.filter((k): k is string => typeof k === "string")
-				.sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
-			const output: Record<string, unknown> = {};
-			for (const key of sortedKeys) {
-				let descriptor: PropertyDescriptor | undefined;
-				try {
-					descriptor = Object.getOwnPropertyDescriptor(value as object, key);
-				} catch (error) {
-					throw new StableStringifyUnboundedError("reflection", { key }, error);
-				}
-				if (!descriptor?.enumerable) continue;
-				const keyBytes = new TextEncoder().encode(key).byteLength;
-				if (keyBytes > MAX_STABLE_STRINGIFY_STRING_BYTES) {
-					throw new StableStringifyUnboundedError("leaf", { keyBytes });
-				}
-				state.nodes += Math.max(1, Math.ceil(keyBytes / 1024));
-				if (state.nodes > MAX_STABLE_STRINGIFY_NODES) {
-					throw new StableStringifyUnboundedError("nodes", {
-						nodes: state.nodes,
-					});
-				}
-				if (!("value" in descriptor)) {
-					throw new StableStringifyUnboundedError("accessor", { key });
-				}
-				const nested = sortStableBounded(descriptor.value, depth + 1, state);
-				Object.defineProperty(output, key, {
-					configurable: true,
-					enumerable: true,
-					value: nested,
-					writable: true,
-				});
-			}
-			return output;
+			return out;
 		} finally {
 			state.seen.delete(value as object);
 		}
 	}
 
-	return value;
+	// Generic object (plain object, class instance, Map/Set etc.)
+	// Preserve historic behavior: enumerate own enumerable string keys and sort.
+	// Maps/Sets have no enumerable string keys, so they serialize as {} — same as pre-bound.
+	// Class instances with enumerable own properties serialize those fields.
+	if (state.seen.has(value as object)) {
+		throw new StableStringifyUnboundedError("cycle", {});
+	}
+	state.seen.add(value as object);
+	try {
+		let keys: string[];
+		try {
+			// Object.keys allocates the full key list before we can charge it — see
+			// header limitation for wide objects. This mirrors the pre-bound
+			// Object.entries allocation.
+			keys = Object.keys(value as Record<string, unknown>);
+		} catch (error) {
+			throw new StableStringifyUnboundedError("reflection", {}, error);
+		}
+		if (keys.length > MAX_STABLE_STRINGIFY_NODES - state.nodes) {
+			throw new StableStringifyUnboundedError("nodes", {
+				nodes: state.nodes + keys.length,
+			});
+		}
+		const sortedKeys = keys.sort((left, right) =>
+			left < right ? -1 : left > right ? 1 : 0,
+		);
+		const output: Record<string, unknown> = {};
+		for (const key of sortedKeys) {
+			let entryValue: unknown;
+			let descriptor: PropertyDescriptor | undefined;
+			try {
+				descriptor = Object.getOwnPropertyDescriptor(value as object, key);
+			} catch (error) {
+				throw new StableStringifyUnboundedError("reflection", { key }, error);
+			}
+			if (descriptor && !descriptor.enumerable) continue;
+			if (descriptor && "value" in descriptor) {
+				entryValue = descriptor.value;
+			} else {
+				// Accessor: invoke getter once to preserve historic output (Object.entries would invoke)
+				try {
+					entryValue = (value as Record<string, unknown>)[key];
+				} catch (error) {
+					throw new StableStringifyUnboundedError("reflection", { key }, error);
+				}
+			}
+			const keyBytes = new TextEncoder().encode(key).byteLength;
+			if (keyBytes > MAX_STABLE_STRINGIFY_STRING_BYTES) {
+				throw new StableStringifyUnboundedError("leaf", { keyBytes });
+			}
+			state.nodes += Math.max(1, Math.ceil(keyBytes / 1024));
+			if (state.nodes > MAX_STABLE_STRINGIFY_NODES) {
+				throw new StableStringifyUnboundedError("nodes", {
+					nodes: state.nodes,
+				});
+			}
+			const nested = sortStableBounded(entryValue, depth + 1, state);
+			Object.defineProperty(output, key, {
+				configurable: true,
+				enumerable: true,
+				value: nested,
+				writable: true,
+			});
+		}
+		return output;
+	} finally {
+		state.seen.delete(value as object);
+	}
 }
 
 function sortStable(value: unknown): unknown {

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
@@ -259,6 +259,44 @@ describe("ScheduledTaskRunner — schedule + idempotency", () => {
     ).rejects.toThrow("does not carry the expected cutover receipt");
   });
 
+  it("rejects an unbounded hosted task digest with a typed code rather than a raw throw", async () => {
+    const h = makeHarness();
+    // Build a task that exceeds stableStringify node budget (2048 + slack) via a wide metadata bag.
+    // This is plain hosted JSON the runner must reject with a typed error, not crash with a raw StableStringifyUnboundedError.
+    const wideMetadata: Record<string, unknown> = {};
+    for (let i = 0; i < 2500; i++) wideMetadata[`k${i}`] = { v: i };
+    const task: ScheduledTask = {
+      ...baseInput({
+        trigger: { kind: "once" as const, atIso: "2026-05-10T09:00:00.000Z" } as never,
+      }),
+      taskId: "shared-reminder-wide",
+      state: { status: "scheduled", followupCount: 0 } as never,
+      metadata: wideMetadata as never,
+    } as ScheduledTask;
+    const receipt = {
+      sourceAgentId: "personal:source",
+      cutoverToken: "cutover-token-wide",
+    };
+    let caught: unknown;
+    try {
+      await h.runner.importTask(task, receipt);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    // Must be a typed ElizaError with STABLE_STRINGIFY_UNBOUNDED, not a raw unbounded throw that blocks the runner
+    const code = (caught as { code?: unknown })?.code ?? (caught as { cause?: { code?: unknown } })?.cause?.code;
+    // Also accept code via ElizaError.code
+    expect(String(code ?? (caught as Error).message)).toContain("STABLE_STRINGIFY_UNBOUNDED");
+    // Runner must still accept a legitimate successor task after the rejection — no global block.
+    const legit = await h.runner.schedule(
+      baseInput({
+        trigger: { kind: "once" as const, atIso: "2026-05-10T09:01:00.000Z" } as never,
+      }),
+    );
+    expect(legit.task.state.status).toBe("scheduled");
+  });
+
   it("logs validation when both pipeline.onSkip and followupAfterMinutes are set", async () => {
     const h = makeHarness();
     const task = await h.runner.schedule(

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -18,7 +18,12 @@
  *    skip: pause suppresses proactive behavior, and chaining is proactive.
  */
 
-import { ElizaError, stableStringify } from "@elizaos/core/edge";
+import {
+  ElizaError,
+  STABLE_STRINGIFY_UNBOUNDED,
+  StableStringifyUnboundedError,
+  stableStringify,
+} from "@elizaos/core/edge";
 import { decideDispatchPolicy } from "../dispatch-policy.js";
 import type { DispatchResult } from "../dispatch-types.js";
 import type { CompletionCheckRegistry } from "./completion-check-registry.js";
@@ -1152,7 +1157,25 @@ export function createScheduledTaskRunner(
   ): Promise<{ task: ScheduledTask; imported: boolean }> {
     const existing = await deps.store.get(task.taskId);
     const existingReceipt = existing?.metadata?.sharedCutoverImport;
-    const taskDigest = stableStringify(task);
+    let taskDigest: string;
+    try {
+      taskDigest = stableStringify(task);
+    } catch (error) {
+      if (error instanceof StableStringifyUnboundedError) {
+        throw new ElizaError(
+          `scheduled task digest is unbounded (${(error as StableStringifyUnboundedError).message})`,
+          {
+            code: STABLE_STRINGIFY_UNBOUNDED,
+            cause: error,
+            context: {
+              taskId: task.taskId,
+              reason: (error as StableStringifyUnboundedError).message,
+            },
+          },
+        );
+      }
+      throw error;
+    }
     if (existing) {
       if (
         existingReceipt !== null &&


### PR DESCRIPTION
## Summary

Bounds the core hashing/identity primitive `stableStringify` at the deterministic layer with explicit depth/nodes/string budgets and a typed `StableStringifyUnboundedError`. Plain-JSON callers (validated post-`JSON.parse` hosted metadata) remain byte-for-byte compatible; the contract is documented as plain JSON only and not a hostile-Proxy sandbox.

Inventory (grepped `stableStringify` excluding tests):
- `packages/core/src/entities.ts:605,629` — entity/metadata hash (`stableStringify({ ...mergedData, ...entity.metadata })`) — now wraps `StableStringifyUnboundedError` into `ElizaError{code: STABLE_STRINGIFY_UNBOUNDED}` (entity data / metadata boundaries)
- `plugins/plugin-scheduling/src/scheduled-task/runner.ts:1155` — scheduled-task digest `taskDigest = stableStringify(task)` used to deduplicate cutover imports — now wraps with `ElizaError{code: STABLE_STRINGIFY_UNBOUNDED, context:{taskId, reason}}` so an oversized hosted bag does not crash the runner with a raw throw and does not block legitimate successor imports
- `packages/cloud/shared/src/lib/services/agent-backup-diff.ts:87` — has a **local** `stableStringify` copy with separate bounds; not affected by this core primitive change.
- `packages/core/src/runtime/context-hash.ts` — uses a separate `stableStringifyValue` impl, not this helper.

## Contract + known limitations (documented in header)

- **Intended for validated plain JSON** (plain objects, arrays, primitives, Dates) plus historic `undefined`/`function`/`symbol` dropping handled by `JSON.stringify`. Hosted metadata is JSON-derived, so data-only descriptors are expected.
- **Map/Set/class instances** with no enumerable own string keys serialize as `{}` (same as pre-bound via `Object.entries`); enumerable own properties on class instances are preserved.
- **Accessors** are invoked **once** via normal property read to preserve historic output (`Object.entries` also invokes getters); not thrown.
- **Not a hostile-Proxy sandbox**: `Object.keys` / `Object.getOwnPropertyDescriptor` / `Object.getPrototypeOf` and property reads can invoke Proxy traps before any budget check can run. Hosted data is plain JSON, not a trap-bearing Proxy.
- **OwnKeys/allocation limitation**: `Object.keys` enumerates and allocates the full key list before `keys.length` can be charged against the node budget. A wide object (e.g. 10k keys) will allocate that array even though the walk then throws `StableStringifyUnboundedError`. Bounding before materialization would require capping at the JSON/materialization boundary instead of inside the walk.

## Implementation

- `MAX_STABLE_STRINGIFY_DEPTH = 32`
- `MAX_STABLE_STRINGIFY_NODES = 2048`
- `MAX_STABLE_STRINGIFY_STRING_BYTES = 64 KiB` (per leaf string and per key, UTF-8 bytes)
- `StableStringifyUnboundedError` (`code = STABLE_STRINGIFY_UNBOUNDED`, `ElizaError`, `severity: fatal`) with `reason: depth|nodes|leaf|cycle|reflection` and typed context.
- Depth checked on entry; nodes/string bytes charged before and after materialization; shared-reference DAG is not flagged as cycle (WeakSet tracks recursion stack only); sparse holes (`descriptor === undefined`) push `null`; non-enumerable own properties skipped.
- Production boundary translations:
  - `plugins/plugin-scheduling/src/scheduled-task/runner.ts:1155` — `taskDigest = stableStringify(task)` wrapped in try/catch → `ElizaError{code: STABLE_STRINGIFY_UNBOUNDED}` with `taskId` context
  - `packages/core/src/entities.ts:605` (`getEntityDetails.data`) and `:629` (`formatEntityMetadata`) — same typed translation

## Tests (23 + 1, red-before/green-after)

`packages/core/src/utils/deterministic.bounded.test.ts` — run `bun --bun x vitest run packages/core/src/utils/deterministic.bounded.test.ts` (all 23 pass):
- Byte-for-byte: nested sorted, arrays order, sparse arrays → null holes, Dates (incl. invalid), shared DAG, undefined/function/symbol positions, numeric edges (-0, Infinity, NaN), entity-metadata fixture, approval payload, scheduled-task digest fixture.
- Bounds: depth at limit 31 passes / 32 throws `depth`; nodes at limit 2048 via array length passes / 2049 throws `nodes`; value string 64KiB passes / +1 throws `leaf`; key bytes 64KiB passes / +1 throws `leaf`; cycle (object + array) throws `cycle`; accessor preserves output; prototype (Map/Set → `{}`, class owns preserved).
- Wide-object allocation limitation (3000 keys): demonstrates `Object.keys` allocates before nodes throw.
- Digest boundary translation helper: `computeDigest` try/catch returning `{ error, code: STABLE_STRINGIFY_UNBOUNDED }` so legitimate task import is not blocked; Proxy trap limitation demo (`ownKeys` runs before budget).

`plugins/plugin-scheduling/src/scheduled-task/runner.test.ts` — new `rejects an unbounded hosted task digest with a typed code rather than a raw throw` (1 added):
- Constructs a 2500-key `wideMetadata` bag exceeding the node budget, calls `importTask` and asserts the rejection carries `STABLE_STRINGIFY_UNBOUNDED` (via `code` or `cause.code`), then asserts a legitimate successor `schedule()` still succeeds — proving the runner is not globally blocked by the typed boundary.

Existing `packages/core/src/utils/deterministic.test.ts` remains green (12 tests).

## Checks

- `bun --bun x @biomejs/biome check packages/core/src/utils/deterministic.ts packages/core/src/utils/deterministic.bounded.test.ts packages/core/src/entities.ts plugins/plugin-scheduling/src/scheduled-task/runner.ts plugins/plugin-scheduling/src/scheduled-task/runner.test.ts` — no errors (sparse-hole suppressed via `biome-ignore lint/suspicious/noSparseArray`)
- `bun --bun x tsc --noEmit --project packages/core/tsconfig.json` — pass
- `bun --bun x vitest run packages/core/src/utils/deterministic.test.ts packages/core/src/utils/deterministic.bounded.test.ts` — 35 passed
- Worktree `bash -c 'cd /tmp/wt-24186 && ./node_modules/.bin/vitest run packages/core/src/utils/deterministic.bounded.test.ts'` — 23 passed

## Repro

```bash
bun --bun x vitest run packages/core/src/utils/deterministic.bounded.test.ts --reporter=verbose
```

---

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@1b03eb54c0:packages/skills/skills/contribute-to-eliza
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@1b03eb54c0:packages/skills/skills/contribute-to-eliza"} -->
Evidence: rebased onto origin/develop@1b03eb54c0
- `bun --bun x @biomejs/biome check packages/core/src/utils/deterministic.ts packages/core/src/utils/deterministic.bounded.test.ts packages/core/src/entities.ts plugins/plugin-scheduling/src/scheduled-task/runner.ts` — clean
- `bun --bun x tsc --noEmit --project packages/core/tsconfig.json` — pass
- `bash -c 'cd /tmp/wt-24186 && ./node_modules/.bin/vitest run packages/core/src/utils/deterministic.bounded.test.ts'` — 23 passed (35 with deterministic.test.ts)
- `git show --stat HEAD` at evidence-head 2fb85facbe57dc73cbb7320e111894bc7a56d7b5

