### PR TITLE
fix(app-core): preserve explicit leading plus in Electrobun integer envs

### DIFF
--- a/packages/app-core/platforms/electrobun/src/renderer-api-proxy.test.ts
+++ b/packages/app-core/platforms/electrobun/src/renderer-api-proxy.test.ts
@@ -102,7 +102,7 @@ describe("renderer API proxy", () => {
     ).toBe(30);
   });
 
-  it("keeps accepting a signed timeout and rejects one past the safe range", () => {
+  it("keeps accepting an explicit leading plus and rejects one past the safe range", () => {
     // `parseInt` accepted "+30"; rejecting it would be a regression.
     expect(
       resolveRendererProxyIdleTimeoutSeconds({

--- a/packages/app-core/platforms/electrobun/src/renderer-api-proxy.test.ts
+++ b/packages/app-core/platforms/electrobun/src/renderer-api-proxy.test.ts
@@ -101,4 +101,18 @@ describe("renderer API proxy", () => {
       }),
     ).toBe(30);
   });
+
+  it("keeps accepting a signed timeout and rejects one past the safe range", () => {
+    // `parseInt` accepted "+30"; rejecting it would be a regression.
+    expect(
+      resolveRendererProxyIdleTimeoutSeconds({
+        ELIZA_RENDERER_PROXY_IDLE_TIMEOUT_SECONDS: "+30",
+      }),
+    ).toBe(30);
+    expect(
+      resolveRendererProxyIdleTimeoutSeconds({
+        ELIZA_RENDERER_PROXY_IDLE_TIMEOUT_SECONDS: "9007199254740993",
+      }),
+    ).toBe(255);
+  });
 });

--- a/packages/app-core/platforms/electrobun/src/renderer-api-proxy.ts
+++ b/packages/app-core/platforms/electrobun/src/renderer-api-proxy.ts
@@ -36,9 +36,10 @@ const BUN_SERVE_MAX_IDLE_TIMEOUT_SECONDS = 255;
 function parsePositiveInteger(value: string | undefined): number | null {
   if (!value) return null;
   // parseInt stops at the first non-digit, so "1junk" would yield 1 and be
-  // accepted as a deliberate setting. Require the whole value to be decimal.
+  // accepted as a deliberate setting. Require the whole value to be decimal; the optional leading plus is
+  // kept because `parseInt` accepted it.
   const trimmed = value.trim();
-  if (!/^\d+$/.test(trimmed)) return null;
+  if (!/^\+?\d+$/.test(trimmed)) return null;
   const parsed = Number(trimmed);
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
 }

--- a/packages/app-core/platforms/electrobun/src/trace/trace-store.test.ts
+++ b/packages/app-core/platforms/electrobun/src/trace/trace-store.test.ts
@@ -159,4 +159,20 @@ describe("trace store env limits", () => {
     }
     expect(traces.listSessions().length).toBe(5);
   });
+
+  it("keeps an explicit leading plus and rejects one past the safe range", () => {
+    process.env[KEY] = "+2";
+    const explicitlyBounded = new TraceStore();
+    for (let i = 0; i < 5; i++) {
+      explicitlyBounded.createSession({ title: `run ${i}`, source: "agent" });
+    }
+    expect(explicitlyBounded.listSessions()).toHaveLength(2);
+
+    process.env[KEY] = String(Number.MAX_SAFE_INTEGER + 1);
+    const fallbackBounded = new TraceStore();
+    for (let i = 0; i < 5; i++) {
+      fallbackBounded.createSession({ title: `run ${i}`, source: "agent" });
+    }
+    expect(fallbackBounded.listSessions()).toHaveLength(5);
+  });
 });

--- a/packages/app-core/platforms/electrobun/src/trace/trace-store.ts
+++ b/packages/app-core/platforms/electrobun/src/trace/trace-store.ts
@@ -63,7 +63,7 @@ function readPositiveIntEnv(
   if (!raw) return fallback;
   // parseInt stops at the first non-digit, so "2junk" would yield 2 and shrink
   // a retention limit to a fraction of its default. Require full decimal.
-  if (!/^\d+$/.test(raw)) return fallback;
+  if (!/^\+?\d+$/.test(raw)) return fallback;
   const parsed = Number(raw);
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }

--- a/packages/app-core/platforms/electrobun/src/voice/voice-latency-budget.test.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-latency-budget.test.ts
@@ -46,6 +46,19 @@ describe("voice latency budget", () => {
     );
   });
 
+  it("keeps an explicit leading plus and rejects one past the safe range", () => {
+    const defaults = getDefaultVoiceLatencyBudget();
+    const budget = getVoiceLatencyBudgetFromEnv({
+      ELIZA_VOICE_BUDGET_RUNTIME_TO_FIRST_TOKEN_MS: "+250",
+      ELIZA_VOICE_BUDGET_TOTAL_TO_PLAYBACK_MS: String(
+        Number.MAX_SAFE_INTEGER + 1,
+      ),
+    });
+
+    expect(budget.runtimeToFirstTokenMs).toBe(250);
+    expect(budget.totalToPlaybackMs).toBe(defaults.totalToPlaybackMs);
+  });
+
   it("evaluates stage pass and miss results", () => {
     const results = evaluateVoiceLatencyBudget(
       {

--- a/packages/app-core/platforms/electrobun/src/voice/voice-latency-budget.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-latency-budget.ts
@@ -157,8 +157,9 @@ function readPositiveInt(
   const raw = env[key]?.trim();
   if (!raw) return fallback;
   // parseInt stops at the first non-digit, so "250junk" would yield 250 and be
-  // treated as a deliberate budget. Require the whole value to be decimal.
-  if (!/^\d+$/.test(raw)) return fallback;
+  // treated as a deliberate budget. Require the whole value to be decimal; the optional leading plus is
+  // kept because `parseInt` accepted it.
+  if (!/^\+?\d+$/.test(raw)) return fallback;
   const parsed = Number(raw);
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }

--- a/packages/app-core/platforms/electrobun/src/voice/voice-tts-chunker.test.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-tts-chunker.test.ts
@@ -113,4 +113,18 @@ describe("voice TTS chunking config from env", () => {
 
     expect(config.maxChars).toBe(120);
   });
+
+  it("keeps a signed limit and rejects one past the safe range", () => {
+    // `parseInt` accepted "+120"; rejecting it would be a regression.
+    expect(
+      getVoiceTtsChunkingConfigFromEnv({
+        ELIZA_VOICE_TTS_CHUNK_MAX_CHARS: "+120",
+      }).maxChars,
+    ).toBe(120);
+    expect(
+      getVoiceTtsChunkingConfigFromEnv({
+        ELIZA_VOICE_TTS_CHUNK_MAX_CHARS: "9007199254740993",
+      }).maxChars,
+    ).toBe(getDefaultVoiceTtsChunkingConfig().maxChars);
+  });
 });

--- a/packages/app-core/platforms/electrobun/src/voice/voice-tts-chunker.test.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-tts-chunker.test.ts
@@ -114,7 +114,7 @@ describe("voice TTS chunking config from env", () => {
     expect(config.maxChars).toBe(120);
   });
 
-  it("keeps a signed limit and rejects one past the safe range", () => {
+  it("keeps an explicit leading plus and rejects one past the safe range", () => {
     // `parseInt` accepted "+120"; rejecting it would be a regression.
     expect(
       getVoiceTtsChunkingConfigFromEnv({

--- a/packages/app-core/platforms/electrobun/src/voice/voice-tts-chunker.ts
+++ b/packages/app-core/platforms/electrobun/src/voice/voice-tts-chunker.ts
@@ -34,8 +34,9 @@ function readPositiveInt(
   const raw = env[key]?.trim();
   if (!raw) return fallback;
   // parseInt stops at the first non-digit, so "12junk" would yield 12 and
-  // silently replace the default. Require the whole value to be decimal.
-  if (!/^\d+$/.test(raw)) return fallback;
+  // silently replace the default. Require the whole value to be decimal; the optional leading plus is
+  // kept because `parseInt` accepted it.
+  if (!/^\+?\d+$/.test(raw)) return fallback;
   const parsed = Number(raw);
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }


### PR DESCRIPTION
# Relates to

Follow-up to merged #23970.

# What changed

#23970 correctly stopped four Electrobun environment parsers from accepting trailing garbage, but its `^\d+$` checks also rejected an explicit leading plus that `Number.parseInt` had accepted. This restores that compatibility with `^\+?\d+$` while retaining safe-integer and positive-range validation.

The four independent parser implementations are all covered at their observable production boundaries:

- renderer proxy idle timeout
- trace-store retention limit
- voice latency budget
- voice TTS chunk limit

Each asserts that `+N` is accepted and a value above `Number.MAX_SAFE_INTEGER` falls back. Existing trailing-garbage tests remain intact.

# Verification

- Final exact focused suite: **25 passed across 4 files**.
- Mutation proof: reverting the four source edits with final tests retained produces **4 failures / 21 passes**, exactly one leading-plus failure per parser implementation.
- Biome on all eight touched files: clean.
- `git diff --check`: clean.
- Contributor baseline full Electrobun lane: **586 passed across 76 files**.

# Risk

Low. Negative and zero values remain rejected by these positive-integer parsers. Only the previously supported explicit leading-plus form is restored; trailing garbage and unsafe integers still fall back.

# Evidence Gate

<!-- evidence-head:341b25291e2f0a9fd3c26a2683494c438f4bfec3 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only Electrobun environment parsing; no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only Electrobun environment parsing; no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - resolved numeric settings are asserted at production boundaries`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - deterministic parser-boundary tests are the observable evidence`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model, prompt, provider, or action path changes`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - resolved numeric settings are the outputs under test`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface`.

# Attribution

- Compatibility regression identified during review by lalalune.
- Original repair and baseline verification: Svector-anu.
- Final four-parser regression coverage, mutation proof, freshness rebase, and evidence: OpenAI `gpt-5.6-sol` via Codex.

## Maintainer exact-head review receipt

Independent caller audit and current-develop rebase at `341b25291e2f0a9fd3c26a2683494c438f4bfec3`: the renderer proxy, trace retention store, voice latency budget, and TTS chunker keep their independent positive-integer/default/range policies. Each observable exported consumer accepts a trimmed explicit `+N`, rejects zero/negative/prefix garbage/unsafe integers through its existing default path, and preserves downstream clamping or retention behavior. Exact focused suite: **4 files / 25 tests passed**. Reverting the four optional-plus edits with these tests retained yields the recorded **4 failures / 21 passes**, one mutation killed per parser. Aggregate patch-id stayed `92908b7748f69e8f27b16b94547b1dbbf838a667`. Exact Biome (8 files), diff check, and evidence validation pass.
Current-base Linux maintainer receipt: exact head `341b25291e2f0a9fd3c26a2683494c438f4bfec3` on `develop@adf35ab5fb343ce0a45437fa54bb383b2e5d8aa4` preserves the reviewed patch by range-diff. The four production-boundary suites pass 25/25; targeted TypeScript compilation of all four parsers, scoped Biome, and `git diff --check` pass.
