### PR TITLE
fix(computeruse): keep Android trajectory errors Unicode-well-formed (#23969)

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/android-trajectory.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/android-trajectory.test.ts
@@ -11,8 +11,6 @@ import {
   emitAndroidAgentStep,
 } from "../mobile/android-trajectory.js";
 
-const MAX_ERROR_MESSAGE_LENGTH = 256;
-
 function makeActionEvent(
   overrides: Partial<AndroidTrajectoryActionEvent> = {},
 ): AndroidTrajectoryActionEvent {
@@ -54,9 +52,8 @@ describe("emitAndroidAction", () => {
     );
   });
 
-  it("preserves absent, empty, short, and exact-limit error messages", () => {
+  it("preserves absent, empty, and short error messages", () => {
     const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
-    const exact = "a".repeat(MAX_ERROR_MESSAGE_LENGTH);
 
     expect(emitAndroidAction(makeActionEvent()).errorMessage).toBeUndefined();
     expect(
@@ -66,39 +63,27 @@ describe("emitAndroidAction", () => {
       emitAndroidAction(makeActionEvent({ errorMessage: "short" }))
         .errorMessage,
     ).toBe("short");
-    expect(
-      emitAndroidAction(makeActionEvent({ errorMessage: exact })).errorMessage,
-    ).toBe(exact);
-    expect(spy).toHaveBeenCalledTimes(4);
+    expect(spy).toHaveBeenCalledTimes(3);
   });
 
-  it("truncates over-limit BMP messages to exactly 256 code units", () => {
+  it("preserves complete diagnostic messages beyond 256 code units", () => {
     vi.spyOn(logger, "info").mockImplementation(() => logger);
+    const errorMessage = `${"x".repeat(300)}🧠tail`;
     const payload = emitAndroidAction(
       makeActionEvent({
         success: false,
         errorCode: "accessibility_unavailable",
-        errorMessage: "x".repeat(MAX_ERROR_MESSAGE_LENGTH + 1),
+        errorMessage,
       }),
     );
 
-    expect(payload.errorMessage).toBe("x".repeat(MAX_ERROR_MESSAGE_LENGTH));
-    expect(payload.errorMessage).toHaveLength(MAX_ERROR_MESSAGE_LENGTH);
+    expect(payload.errorMessage).toBe(errorMessage);
+    expect(payload.errorMessage?.length).toBeGreaterThan(256);
   });
 
-  it("backs off rather than splitting an astral pair at the limit", () => {
+  it("normalizes both lone surrogate halves without truncating the diagnostic", () => {
     vi.spyOn(logger, "info").mockImplementation(() => logger);
-    const input = `${"a".repeat(MAX_ERROR_MESSAGE_LENGTH - 1)}\u{1f9e0}z`;
-
-    const payload = emitAndroidAction(makeActionEvent({ errorMessage: input }));
-
-    expect(payload.errorMessage).toBe("a".repeat(MAX_ERROR_MESSAGE_LENGTH - 1));
-    expect(payload.errorMessage).toHaveLength(MAX_ERROR_MESSAGE_LENGTH - 1);
-  });
-
-  it("normalizes lone surrogates before applying the length limit", () => {
-    vi.spyOn(logger, "info").mockImplementation(() => logger);
-    const prefix = "a".repeat(MAX_ERROR_MESSAGE_LENGTH - 1);
+    const prefix = "a".repeat(300);
 
     expect(
       emitAndroidAction(makeActionEvent({ errorMessage: "ok\ud83e" }))
@@ -120,14 +105,14 @@ describe("emitAndroidAction", () => {
 
   it("logs the same normalized error while leaving the input unchanged", () => {
     const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
-    const input = `${"a".repeat(MAX_ERROR_MESSAGE_LENGTH - 1)}\u{1f9e0}z`;
+    const input = `${"a".repeat(300)}\ud83ez`;
     const event = makeActionEvent({ errorMessage: input });
 
     const payload = emitAndroidAction(event);
 
     expect(event.errorMessage).toBe(input);
     expect(payload).not.toBe(event);
-    expect(payload.errorMessage).toBe("a".repeat(MAX_ERROR_MESSAGE_LENGTH - 1));
+    expect(payload.errorMessage).toBe(`${"a".repeat(300)}\ufffdz`);
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({ errorMessage: payload.errorMessage }),
       expect.any(String),

--- a/plugins/plugin-computeruse/src/__tests__/android-trajectory.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/android-trajectory.test.ts
@@ -1,138 +1,209 @@
 /**
- * WS8 — Android trajectory event emission tests.
- *
- * The trajectory logger reads `computeruse.agent.step` and
- * `computeruse.android.action` events from the structured log stream. We
- * verify both emitters publish the expected shape so the logger contract
- * stays in lock-step with the desktop emitter in `use-computer-agent.ts`.
+ * Tests Android trajectory emitters with a mocked structured logger, including
+ * Unicode-safe error projection and platform-tagged event parity.
  */
 
 import { logger } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  type AndroidTrajectoryActionEvent,
   emitAndroidAction,
   emitAndroidAgentStep,
 } from "../mobile/android-trajectory.js";
 
+const MAX_ERROR_MESSAGE_LENGTH = 256;
+
+function makeActionEvent(
+  overrides: Partial<AndroidTrajectoryActionEvent> = {},
+): AndroidTrajectoryActionEvent {
+  return {
+    kind: "tap",
+    success: true,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("emitAndroidAction", () => {
   it("emits a structured `computeruse.android.action` log entry with platform=android", () => {
     const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
-    try {
-      const payload = emitAndroidAction({
-        kind: "tap",
-        success: true,
-        x: 540,
-        y: 960,
-        ref: "a0-1",
-        rationale: "tap save",
-      });
-      expect(payload.kind).toBe("tap");
-      expect(spy).toHaveBeenCalledTimes(1);
-      const [first] = spy.mock.calls;
-      const obj = first?.[0] as Record<string, unknown>;
-      expect(obj.evt).toBe("computeruse.android.action");
-      expect(obj.platform).toBe("android");
-      expect(obj.kind).toBe("tap");
-      expect(obj.x).toBe(540);
-      expect(obj.ref).toBe("a0-1");
-    } finally {
-      spy.mockRestore();
-    }
-  });
 
-  it("trims error messages over 256 chars", () => {
-    const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
-    try {
-      const long = "x".repeat(2_000);
-      const payload = emitAndroidAction({
-        kind: "tap",
-        success: false,
-        errorCode: "accessibility_unavailable",
-        errorMessage: long,
-      });
-      expect(payload.errorMessage?.length).toBe(256);
-      expect(spy.mock.calls[0]?.[0]).toMatchObject({
+    const payload = emitAndroidAction({
+      kind: "tap",
+      success: true,
+      x: 540,
+      y: 960,
+      ref: "a0-1",
+      rationale: "tap save",
+    });
+
+    expect(payload.kind).toBe("tap");
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
         evt: "computeruse.android.action",
         platform: "android",
         kind: "tap",
+        x: 540,
+        ref: "a0-1",
+      }),
+      expect.any(String),
+    );
+  });
+
+  it("preserves absent, empty, short, and exact-limit error messages", () => {
+    const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+    const exact = "a".repeat(MAX_ERROR_MESSAGE_LENGTH);
+
+    expect(emitAndroidAction(makeActionEvent()).errorMessage).toBeUndefined();
+    expect(
+      emitAndroidAction(makeActionEvent({ errorMessage: "" })).errorMessage,
+    ).toBe("");
+    expect(
+      emitAndroidAction(makeActionEvent({ errorMessage: "short" }))
+        .errorMessage,
+    ).toBe("short");
+    expect(
+      emitAndroidAction(makeActionEvent({ errorMessage: exact })).errorMessage,
+    ).toBe(exact);
+    expect(spy).toHaveBeenCalledTimes(4);
+  });
+
+  it("truncates over-limit BMP messages to exactly 256 code units", () => {
+    vi.spyOn(logger, "info").mockImplementation(() => logger);
+    const payload = emitAndroidAction(
+      makeActionEvent({
         success: false,
         errorCode: "accessibility_unavailable",
-      });
-    } finally {
-      spy.mockRestore();
-    }
+        errorMessage: "x".repeat(MAX_ERROR_MESSAGE_LENGTH + 1),
+      }),
+    );
+
+    expect(payload.errorMessage).toBe("x".repeat(MAX_ERROR_MESSAGE_LENGTH));
+    expect(payload.errorMessage).toHaveLength(MAX_ERROR_MESSAGE_LENGTH);
+  });
+
+  it("backs off rather than splitting an astral pair at the limit", () => {
+    vi.spyOn(logger, "info").mockImplementation(() => logger);
+    const input = `${"a".repeat(MAX_ERROR_MESSAGE_LENGTH - 1)}\u{1f9e0}z`;
+
+    const payload = emitAndroidAction(makeActionEvent({ errorMessage: input }));
+
+    expect(payload.errorMessage).toBe("a".repeat(MAX_ERROR_MESSAGE_LENGTH - 1));
+    expect(payload.errorMessage).toHaveLength(MAX_ERROR_MESSAGE_LENGTH - 1);
+  });
+
+  it("normalizes lone surrogates before applying the length limit", () => {
+    vi.spyOn(logger, "info").mockImplementation(() => logger);
+    const prefix = "a".repeat(MAX_ERROR_MESSAGE_LENGTH - 1);
+
+    expect(
+      emitAndroidAction(makeActionEvent({ errorMessage: "ok\ud83e" }))
+        .errorMessage,
+    ).toBe("ok\ufffd");
+    expect(
+      emitAndroidAction(makeActionEvent({ errorMessage: "ok\ude00" }))
+        .errorMessage,
+    ).toBe("ok\ufffd");
+    expect(
+      emitAndroidAction(makeActionEvent({ errorMessage: `${prefix}\ud83e` }))
+        .errorMessage,
+    ).toBe(`${prefix}\ufffd`);
+    expect(
+      emitAndroidAction(makeActionEvent({ errorMessage: `${prefix}\ude00` }))
+        .errorMessage,
+    ).toBe(`${prefix}\ufffd`);
+  });
+
+  it("logs the same normalized error while leaving the input unchanged", () => {
+    const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
+    const input = `${"a".repeat(MAX_ERROR_MESSAGE_LENGTH - 1)}\u{1f9e0}z`;
+    const event = makeActionEvent({ errorMessage: input });
+
+    const payload = emitAndroidAction(event);
+
+    expect(event.errorMessage).toBe(input);
+    expect(payload).not.toBe(event);
+    expect(payload.errorMessage).toBe("a".repeat(MAX_ERROR_MESSAGE_LENGTH - 1));
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ errorMessage: payload.errorMessage }),
+      expect.any(String),
+    );
   });
 
   it("does not emit fields that were not supplied", () => {
     const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
-    try {
-      emitAndroidAction({ kind: "back", success: true });
-      const obj = spy.mock.calls[0]?.[0] as Record<string, unknown>;
-      expect(obj.x).toBeUndefined();
-      expect(obj.y).toBeUndefined();
-      expect(obj.ref).toBeUndefined();
-    } finally {
-      spy.mockRestore();
-    }
+
+    emitAndroidAction({ kind: "back", success: true });
+
+    expect(spy).toHaveBeenCalledWith(
+      {
+        evt: "computeruse.android.action",
+        platform: "android",
+        kind: "back",
+        success: true,
+      },
+      expect.any(String),
+    );
   });
 });
 
 describe("emitAndroidAgentStep", () => {
   it("emits a `computeruse.agent.step` entry with platform=android", () => {
     const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
-    try {
-      emitAndroidAgentStep({
+
+    emitAndroidAgentStep({
+      step: 3,
+      goal: "save the document",
+      actionKind: "click",
+      displayId: 0,
+      rois: 1,
+      success: true,
+      rationale: "tap save",
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        evt: "computeruse.agent.step",
+        platform: "android",
         step: 3,
-        goal: "save the document",
         actionKind: "click",
-        displayId: 0,
-        rois: 1,
         success: true,
-        rationale: "tap save",
-      });
-      const obj = spy.mock.calls[0]?.[0] as Record<string, unknown>;
-      expect(obj.evt).toBe("computeruse.agent.step");
-      expect(obj.platform).toBe("android");
-      expect(obj.step).toBe(3);
-      expect(obj.actionKind).toBe("click");
-      expect(obj.success).toBe(true);
-    } finally {
-      spy.mockRestore();
-    }
+      }),
+      expect.any(String),
+    );
   });
 
   it("shape matches the desktop emitter in use-computer-agent.ts (same evt key)", () => {
     const spy = vi.spyOn(logger, "info").mockImplementation(() => logger);
-    try {
-      emitAndroidAgentStep({
+
+    emitAndroidAgentStep({
+      step: 1,
+      goal: "g",
+      actionKind: "finish",
+      displayId: 0,
+      rois: 0,
+      success: true,
+      rationale: "done",
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        evt: "computeruse.agent.step",
+        platform: "android",
         step: 1,
         goal: "g",
         actionKind: "finish",
         displayId: 0,
         rois: 0,
         success: true,
+        error: undefined,
         rationale: "done",
-      });
-      const obj = spy.mock.calls[0]?.[0] as Record<string, unknown>;
-      // The desktop emitter publishes: evt, step, goal, actionKind,
-      // displayId, rois, success, error?, rationale. We add platform.
-      const expectedKeys = [
-        "evt",
-        "platform",
-        "step",
-        "goal",
-        "actionKind",
-        "displayId",
-        "rois",
-        "success",
-        "error",
-        "rationale",
-      ];
-      for (const k of expectedKeys) {
-        expect(k in obj).toBe(true);
-      }
-    } finally {
-      spy.mockRestore();
-    }
+      }),
+      expect.any(String),
+    );
   });
 });

--- a/plugins/plugin-computeruse/src/mobile/android-trajectory.ts
+++ b/plugins/plugin-computeruse/src/mobile/android-trajectory.ts
@@ -24,7 +24,7 @@
  * log-capture pipeline.
  */
 
-import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
+import { logger, toWellFormedUnicode } from "@elizaos/core";
 
 export type AndroidActionKind =
   | "tap"
@@ -41,7 +41,7 @@ export interface AndroidTrajectoryActionEvent {
   success: boolean;
   /** Bridge error code (only on failure). */
   errorCode?: string;
-  /** Free-form error message; trimmed for log hygiene. */
+  /** Complete free-form error message, normalized to well-formed Unicode. */
   errorMessage?: string;
   /** Display-local pixel coords for tap/swipe (optional). */
   x?: number;
@@ -66,8 +66,6 @@ export interface AndroidTrajectoryStepEvent {
   rationale: string;
 }
 
-const MAX_ERROR_MSG = 256;
-
 /**
  * Emit a `computeruse.android.action` log entry. Returns the payload so
  * callers can also forward it elsewhere (e.g. in-memory replay buffer).
@@ -75,22 +73,19 @@ const MAX_ERROR_MSG = 256;
 export function emitAndroidAction(
   event: AndroidTrajectoryActionEvent,
 ): AndroidTrajectoryActionEvent {
-  const trimmed: AndroidTrajectoryActionEvent = { ...event };
-  if (trimmed.errorMessage) {
-    trimmed.errorMessage = truncateWellFormed(
-      toWellFormedUnicode(trimmed.errorMessage),
-      MAX_ERROR_MSG,
-    );
+  const normalized: AndroidTrajectoryActionEvent = { ...event };
+  if (normalized.errorMessage) {
+    normalized.errorMessage = toWellFormedUnicode(normalized.errorMessage);
   }
   logger.info(
     {
       evt: "computeruse.android.action",
       platform: "android" as const,
-      ...trimmed,
+      ...normalized,
     },
-    `[computeruse/android] ${trimmed.kind}${trimmed.success ? "" : ` failed (${trimmed.errorCode ?? "?"})`}`,
+    `[computeruse/android] ${normalized.kind}${normalized.success ? "" : ` failed (${normalized.errorCode ?? "?"})`}`,
   );
-  return trimmed;
+  return normalized;
 }
 
 /**

--- a/plugins/plugin-computeruse/src/mobile/android-trajectory.ts
+++ b/plugins/plugin-computeruse/src/mobile/android-trajectory.ts
@@ -24,7 +24,7 @@
  * log-capture pipeline.
  */
 
-import { logger } from "@elizaos/core";
+import { logger, toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 
 export type AndroidActionKind =
   | "tap"
@@ -77,7 +77,10 @@ export function emitAndroidAction(
 ): AndroidTrajectoryActionEvent {
   const trimmed: AndroidTrajectoryActionEvent = { ...event };
   if (trimmed.errorMessage) {
-    trimmed.errorMessage = trimmed.errorMessage.slice(0, MAX_ERROR_MSG);
+    trimmed.errorMessage = truncateWellFormed(
+      toWellFormedUnicode(trimmed.errorMessage),
+      MAX_ERROR_MSG,
+    );
   }
   logger.info(
     {


### PR DESCRIPTION
Fixes #23969

## Summary

Android trajectory action errors are durable runtime diagnostic state. Normalize `errorMessage` with the shared `toWellFormedUnicode` helper so returned and structured-log payloads never contain lone UTF-16 surrogate halves, while preserving the complete diagnostic rather than imposing the former 256-code-unit data-loss clamp. The caller's input object remains unchanged.

The helper is a public native/AOSP package subpath seam; repository callers are external. A presentation or transport consumer that needs a preview must create a separately named bounded projection rather than truncating canonical trajectory state.

## Verification

Exact head: `78e3713bf0ae442802cbcc5c9d6c05742a08153a`
Base: `origin/develop@8f893fb9aaadfb16601beb0a8253ede55be53ee3`

- Focused Android trajectory suite: 8/8 passed.
- Touched-file Biome and `git diff --check`: passed.
- Regression preserves a diagnostic longer than 256 code units, including an astral character and tail.
- Both lone surrogate halves normalize to U+FFFD in short and >256-code-unit diagnostics.
- Returned and logged payloads match; input remains unchanged.
- Package typecheck was attempted in the isolated sparse checkout and is blocked only by absent registry JSON, drizzle, and UI source aliases; no touched-file diagnostic.

## Evidence Gate

<!-- evidence-head:78e3713bf0ae442802cbcc5c9d6c05742a08153a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; structured diagnostic state only.

<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; structured diagnostic state only.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic native trajectory projection with no interactive flow.

<!-- evidence-row:backend-logs -->
- [x] Exact-head deterministic logger boundary exercised:

```log
Test Files  1 passed (1)
Tests  8 passed (8)
android-trajectory.test.ts: complete >256 diagnostic, astral text, both lone halves, log/return parity
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or prompt behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Returned and logged artifacts inspected directly:

```text
input: 300 ASCII code units + 🧠 + tail
returned errorMessage: complete input, length greater than 256
structured logger errorMessage: identical to returned normalized value
input event object: unchanged
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `deepseek/deepseek-v4-flash`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`, `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8f893fb9aaadfb16601beb0a8253ede55be53ee3:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: deepseek / deepseek-v4-flash, openai/gpt-5.6-sol
Client / agent tooling: Hermes Agent, Codex Desktop
Contribution skill revision: elizaOS/eliza@8f893fb9aaadfb16601beb0a8253ede55be53ee3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [unicode-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@8f893fb9aaadfb16601beb0a8253ede55be53ee3:packages/skills/skills/contribute-to-eliza"} -->