### PR TITLE
fix(plugin-elizacloud): reject prefix-parsed text timeout and native concurrency

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/text-native-concurrency.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/text-native-concurrency.test.ts
@@ -248,6 +248,12 @@ describe("native cerebras concurrency limiter", () => {
       { raw: "0", expected: 8 },
       { raw: "abc", expected: 8 },
       { raw: undefined, expected: 8 },
+      // `Number.parseInt` stopped at the first non-digit, so "2junk" silently
+      // tightened the semaphore to 2 instead of falling back.
+      { raw: "2junk", expected: 8 },
+      // A leading sign was accepted by `parseInt` and must stay accepted.
+      { raw: "+2", expected: 2 },
+      { raw: "9007199254740993", expected: 8 },
     ];
 
     for (const { raw, expected } of cases) {

--- a/plugins/plugin-elizacloud/__tests__/text-streaming.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/text-streaming.test.ts
@@ -1117,6 +1117,21 @@ describe("resolveTextTimeoutMs", () => {
     process.env.ELIZAOS_CLOUD_TEXT_TIMEOUT_MS = "abc";
     expect(resolveTextTimeoutMs()).toBe(120_000);
   });
+
+  it("rejects a prefix-parsed timeout instead of installing a 500ms deadline", () => {
+    process.env.ELIZAOS_CLOUD_TEXT_TIMEOUT_MS = "500junk";
+    expect(resolveTextTimeoutMs()).toBe(120_000);
+  });
+
+  it("preserves an explicitly signed positive timeout", () => {
+    process.env.ELIZAOS_CLOUD_TEXT_TIMEOUT_MS = "+5000";
+    expect(resolveTextTimeoutMs()).toBe(5_000);
+  });
+
+  it("rejects an integer beyond Number.MAX_SAFE_INTEGER", () => {
+    process.env.ELIZAOS_CLOUD_TEXT_TIMEOUT_MS = "9007199254740993";
+    expect(resolveTextTimeoutMs()).toBe(120_000);
+  });
 });
 
 /**

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -96,8 +96,12 @@ export function resolveTextTimeoutMs(): number | undefined {
   const raw =
     typeof process !== "undefined" ? process.env[TEXT_TIMEOUT_ENV] : undefined;
   if (raw === undefined || raw.trim() === "") return DEFAULT_TEXT_TIMEOUT_MS;
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed)) return DEFAULT_TEXT_TIMEOUT_MS;
+  // `Number.parseInt` stops at the first non-digit, so "500junk" parsed to 500
+  // and became a 500ms client timeout instead of the documented fallback. The
+  // sign is accepted here on purpose: this setting documents `0`/negative as
+  // the opt-out, so the `<= 0` check below stays the range authority.
+  const parsed = /^[+-]?\d+$/.test(raw.trim()) ? Number(raw) : Number.NaN;
+  if (!Number.isSafeInteger(parsed)) return DEFAULT_TEXT_TIMEOUT_MS;
   return parsed <= 0 ? undefined : parsed;
 }
 
@@ -141,8 +145,14 @@ let nativeChatLimiter: Semaphore | null = null;
 function resolveNativeConcurrency(): number {
   const raw =
     typeof process !== "undefined" ? process.env[NATIVE_CONCURRENCY_ENV] : undefined;
-  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_NATIVE_CONCURRENCY;
+  // Same prefix-parse hole as the timeout above: "2junk" parsed to 2 and
+  // silently tightened the semaphore from 8. The `> 0` check stays the range
+  // authority, so a signed value is still parsed and then judged by it.
+  const parsed =
+    raw && /^[+-]?\d+$/.test(raw.trim()) ? Number(raw) : Number.NaN;
+  return Number.isSafeInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_NATIVE_CONCURRENCY;
 }
 
 function getNativeChatLimiter(): Semaphore {


### PR DESCRIPTION
# Relates to

No separate issue — the defect is described in full below.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is built directly on the current `origin/develop` tree, so it applies with zero conflicts.
- [x] Focused package tests, typecheck and lint were run for the changed files; results are quoted below. Root `bun run verify` was not run green: `develop` currently carries unrelated `@elizaos/agent` Biome formatter diagnostics, the same blocker recorded in #24174.
- [x] A reviewer can confirm the change from the failure/mutation output below without reading the code.

# Sync with develop

- [x] Built on the latest `origin/develop` tree at review time; zero conflicts.
- [x] Exact unrelated blocker documented above (pre-existing `@elizaos/agent` formatter diagnostics).

# Risks

Low. Two env parsers. The documented `0`/negative opt-out on the timeout is deliberately preserved, and the concurrency default is unchanged for every valid value.

# Background

Two env resolvers in `models/text.ts` accept a value `parseInt` merely *starts with*:

```ts
const parsed = Number.parseInt(raw, 10);
if (!Number.isFinite(parsed)) return DEFAULT_TEXT_TIMEOUT_MS;

const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_NATIVE_CONCURRENCY;
```

`parseInt` stops at the first non-digit, so:

| setting | value | resolves to | should be |
| --- | --- | --- | --- |
| `ELIZAOS_CLOUD_TEXT_TIMEOUT_MS` | `500junk` | **500ms** | 120000 |
| `ELIZAOS_CLOUD_NATIVE_CONCURRENCY` | `2junk` | **2** | 8 |

A 500ms client timeout aborts every cloud text round-trip almost immediately — and since that signal also cancels the streaming path, the turn fails rather than degrading. The concurrency case silently serializes a fan-out the default of 8 was specifically chosen to allow.

`NaN` is the only malformed input either guard catches.

## The fix

Require the whole trimmed value to be a decimal integer before converting.

**The sign is deliberately still accepted** (`/^[+-]?\d+$/`) in both, because these functions already own their range semantics and must keep doing so:

- `resolveTextTimeoutMs` documents `0`/negative as the opt-out (*"`0`/negative opts out (no client-side timeout)"*) — a plus-only pattern would have **broken a documented feature**.
- `resolveNativeConcurrency` keeps `> 0` as its authority.

`Number.isSafeInteger` replaces `Number.isFinite` so a value past 2^53 is rejected too.

## Verification

| Gate | Result |
| --- | --- |
| `text-native-concurrency.test.ts` + `text-streaming.test.ts` | 80/80 passed on exact rebased head |
| package typecheck + build/import verification | passed on exact rebased head |
| scoped Biome + `git diff --check` | passed on exact rebased head |

**Drift note:** `develop` added `../utils/trace-correlation` to this module, which is absent from the local checkout, so the suite was executed against the local revision and the shipped file is `develop`'s revision with byte-identical hunks (verified by diff).

## Mutation resistance

Reverting only the source change and keeping the tests:

```
× ELIZAOS_CLOUD_NATIVE_CONCURRENCY="2junk" -> limit 8
  AssertionError: expected 2 to be 8
× ELIZAOS_CLOUD_NATIVE_CONCURRENCY="9007199254740993" -> limit 8
  AssertionError: expected 10 to be 8
```

The semaphore honours a value nobody configured. The new **`+2` case passes in both directions**, which is the point — `parseInt` accepted a signed value and this fix must not regress that.

## Attribution

- Found by OpenAI `gpt-5.6-sol` via Codex (AgentRouter) during a numeric-input validation sweep of `plugins/`.
- Independent verification, preservation of the documented negative opt-out, the signed and unsafe-integer regression cases, and the mutation proof by Claude Code (`claude-opus-5`).

# Documentation changes needed?

My changes do not require a change to the project documentation — the parser's documented contract is unchanged; this makes the implementation match it.

# Testing

## Where should a reviewer start?

Start with the mutation-resistance block below: it reverts only the source change and shows the exact wrong value the current code produces.

## Detailed testing steps

None beyond the automated suites quoted above — the change is a pure input-parsing boundary and is fully covered by the regression tests.

# Evidence Gate

<!-- evidence-head:07c7068026b9a799c6bfb5739c1d105941113f9e -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only change to the plugin-elizacloud text env parsers, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only change to the plugin-elizacloud text env parsers, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - the observable behaviour is the resolved client timeout and semaphore limit, shown by the mutation-proof output quoted below`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started by this change; the exercised path is covered by the unit suite quoted below`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model, prompt, provider or action path is changed; this is an input parser`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain record is produced; the observable output is the resolved client timeout and semaphore limit, asserted in the tests`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - the change has no rendered visual surface`.



Independent maintainer receipt: both parser callers use the parsed value directly as the timeout/semaphore authority; exact decimal signed input is the intended grammar, and safe-integer rejection prevents precision truncation. Conflict-free rebase preserved combined patch-id `c8bfcb637d4fcbd6b278298cffe2bbe9cac1df6d`. Exact head `ed05687968a77c7bf0aeb305fb031369d272a699`: both touched files Biome clean, `git diff --check` clean; focused local collection remains blocked before load by the sparse checkout’s missing `markdown-it`, while the repair’s concurrency 14/14 receipt covers the unchanged patch.


## Exact-current maintainer validation

Rebased onto `develop@95320fc7026773529f85babeccd0ba3f36dd5f67`. Exact head `07c7068026b9a799c6bfb5739c1d105941113f9e`, tree `ad8404c05994b4f247fe38903d95a68821799d9d`. With Bun 1.3.14 and Node 24.15.0, both focused suites passed 80/80 tests; `plugin-elizacloud` typecheck passed; its full Node/browser/CJS/subpath/views build and default-condition built-package import passed; scoped Biome and `git diff --check` passed. The suites cover malformed prefixes, explicit signs, unsafe integers, timeout opt-out, default/positive concurrency, semaphore FIFO/rejection release, and the full streaming contract. No UI or external integration is involved.



Final base refresh: exact head `07c7068026b9a799c6bfb5739c1d105941113f9e` on `develop@95320fc7026773529f85babeccd0ba3f36dd5f67`; 80/80 focused tests, package typecheck, and diff hygiene passed after the rebase.
