### PR TITLE
fix(ci): align script contracts with wrangler 4.116.0 secret tooling

### DIFF
--- a/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
@@ -94,7 +94,7 @@ describe("Cloud CF atomic Worker secrets deploy", () => {
     );
 
     const verify = step("Verify required Worker secret binding names");
-    expect(verify.run).toContain("wrangler@4.100.0 secret list");
+    expect(verify.run).toContain("wrangler@4.116.0 secret list");
     expect(verify.run).toContain("values were not read");
     expect(verify.run).toContain('"DATABASE_URL"');
     expect(verify.run).toContain('"OIDC_SIGNING_JWKS"');

--- a/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
@@ -562,7 +562,7 @@ describe("Personal Shared Telegram edge deploy", () => {
     expect(apply.env?.EXPECTED_GATEWAY_DEPLOYMENT_ID).toContain(
       "steps.gateway_proof.outputs.deployment_id",
     );
-    expect(apply.run).toContain("wrangler@4.100.0 secret put");
+    expect(apply.run).toContain("wrangler@4.116.0 secret put");
     expect(apply.run).toContain(
       '"$EDGE_SECRET_NAME" --env "$TARGET_ENVIRONMENT"',
     );

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -755,7 +755,7 @@ describe("canonical cloud deployment environment contract", () => {
     expect(inventoryIndex).toBeLessThan(healthIndex);
 
     const inventory = steps[inventoryIndex];
-    expect(inventory?.run).toContain("wrangler@4.100.0 secret list");
+    expect(inventory?.run).toContain("wrangler@4.116.0 secret list");
     expect(inventory?.run).toContain("--format json");
     for (const name of cloudWorkerSecretNames) {
       expect(inventory?.run).toContain(`\n    "${name}",\n`);


### PR DESCRIPTION
# Relates to

Unblocks merge holds on #24122 and #24154 by repairing two develop-wide, foreign-author CI reds. No tracking issue exists for either red (verified: no open/merged PR or issue references these failures; the drift was introduced by c6f84b32840 / #23988 and fb7ef5a452d / #23176).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (branched from develop tip `9c1fc32c0de`; contains it — verified with `git merge-base --is-ancestor`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

**Low.** Test-assertion string updates and formatter-only file edits; zero runtime behavior change (proven by re-running every touched file's suite and by the formatter diffs being whitespace/line-wrap only). The wrangler assertions follow deliberate maintainer intent (#23988 "align Wrangler secret tooling"); semantic contract coverage (binding names, values-not-read, atomicity, deploy→inventory→health ordering) is untouched. `pages` command pins intentionally remain `wrangler@4.100.0`.

# Background

## What does this PR do?

Develop is red in two CI lanes for **every** PR branched off current develop, which blocks the approved-PR merge holds (#24122, #24154 — both currently showing `Quality: FAILURE` and `Tests (scripts): FAILURE`).

**Cause 1 — Tests (scripts):** commit c6f84b32840 (merged as #23988, "fix(cloud): align Wrangler secret tooling") bumped `wrangler@4.100.0` → `wrangler@4.116.0` for all **secret** tooling (`secret list` / `secret put`) in `cloud-cf-release.yml` and `activate-personal-shared-telegram-edge.yml`, but the three contract tests asserting the exact version string were not updated:

- `packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts:97` — `secret list`
- `packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts:565` — `secret put`
- `packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts:758` — `secret list`

This PR updates the three assertions to `4.116.0`, matching the actual workflow bytes at develop tip (verified by grep of both workflow files: all five `secret list` invocations and the one `secret put` pin 4.116.0; the three `pages` pins remain 4.100.0 and are asserted nowhere).

**Cause 2 — Quality (`format:check`):** six files landed on develop without passing Biome format:

| File | Landed via |
|---|---|
| `packages/ui/src/components/chat/widgets/maps-card.tsx` | fb7ef5a452d (#23176, feat(maps)) |
| `packages/agent/src/providers/page-scoped-context.surrogate.test.ts` | bbe8550e57f (#23661) |
| `packages/agent/src/providers/recent-conversations.surrogate.test.ts` | 322676aa35d (#23663) |
| `packages/agent/src/actions/database.surrogate.test.ts` | d508c9ac742 (#23676) |
| `packages/agent/src/api/accounts-routes.ts` | 5cf8e0132ad (#23690) |
| `packages/agent/src/api/wallet.ts` | 004a6665041 (#23710) |

This PR applies `biome format --write` to all six. The edits are whitespace/indentation/line-wrap only: the two surrogate test files normalize tab→space indentation (86 lines each); `accounts-routes.ts`/`wallet.ts` re-wrap over-long lines and add trailing commas.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue) — CI/contract repair, no behavior change.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

1. `bun test packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts` → **34 pass / 0 fail** at this head (all three red on develop tip with `expected "wrangler@4.100.0 secret list"` vs actual `4.116.0`).
2. `bun run format:check` → **green over all 142 package tasks** at this head (red on develop tip: `@elizaos/agent#format:check` 5 errors + ui maps-card).

## Detailed testing steps

- RED control at pristine develop tip `9c1fc32c0de` (before any edit): the 3 wrangler contract tests fail exactly as hosted CI does; `format:check` fails on the 6 files above.
- After the fix: 34/34 across the three contract files; `format:check` green (142/142 turbo tasks).
- Behavior-neutrality of the format edits proven by execution — re-ran every touched suite at this head: surrogate suites `database`/`page-scoped-context`/`recent-conversations` **15/15** (vitest), `accounts-routes.surrogate`/`wallet-evm-balance.surrogate` **9/9** (vitest).
- Full `bun run test:scripts` lane failure set diffed head-vs-stash-control at the same tree: **identical** pre-existing reds (see Known gaps); only the 3 wrangler targets turn green.
- Dual review (Hermes manual + independent gpt-5.6-sol reviewer over the embedded diff): both rounds APPROVE; the reviewer independently confirmed literal preservation in the surrogate tests (all length/string literals unchanged, including `199`/`198`/`0xd800`/fox literals), repo-wide wrangler-grep completeness, and sandbox-ran `format:check` to 142/142.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:d7eb95348123f58f82242c127af95a2ae749b5d2 -->

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] Before screenshot (real Chromium render of the five MapsCardWidget kinds at develop's unformatted maps-card.tsx): ![maps-card-before.png](https://github.com/user-attachments/assets/ae07d666-6ec3-4d04-813c-e54823da643c) — byte-identical to the after screenshot, proving the reformat changed nothing rendered.
<!-- evidence-row:after-screenshots -->
- [x] After screenshot (same fixture, same engine, at this PR head's formatted maps-card.tsx): ![maps-card-after.png](https://github.com/user-attachments/assets/ac401476-8375-42a7-94b1-8f8af34b614f) — `cmp` byte-identical to before; OCR text output also identical.
<!-- evidence-row:walkthrough-video -->
- [x] Video capture of the fixture render (all five card kinds mounting in real Chromium, mobile viewport): [maps-card-after-walkthrough.mp4](https://github.com/user-attachments/assets/0275c489-5b75-4b21-b3cb-c86f09b21f73) — the change is a JSX whitespace reflow; the walkthrough shows the unchanged rendered surface.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime code path fires: the three changed test assertions are string expectations over checked-in workflow YAML (no server boot). Transcript of the exact contract-test run at the rebased head:
<details><summary>bun test (3 contract files) at head d7eb9534812 (rebased onto develop tip 9398456b635)</summary>

```
$ bun test packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts

✓ Cloud CF atomic Worker secrets deploy > preserves omitted bindings and verifies authoritative names after deploy
✓ Personal Shared Telegram edge deploy > mutates only the selected environment binding and rolls every unproven exit back off
✓ canonical cloud deployment environment contract > verifies required Worker binding names after deploy without reading values (×2 parametrized workflows)

 34 pass
 0 fail
 471 expect() calls
Ran 34 tests across 3 files. [661.00ms]
```

Scope after rebase: develop's #24472 (9ebe06c0fbf) landed byte-identical format repairs for maps-card.tsx and login-page.same-origin.test.tsx, so those two files dropped out of this branch's diff; the remaining delta is exactly the three wrangler@4.100.0 → wrangler@4.116.0 assertion alignments, byte-identical to the versions approved at 93db42d1921 (git diff --exit-code across heads). Each new assertion matches the actual workflow content at develop tip (cloud-cf-release.yml:1436, activate-personal-shared-telegram-edge.yml:444). Biome on the three files: 0 errors (14 pre-existing warnings, identical set at the develop control). PR push runs pr-static-smoke.yml (lint/typecheck/build of the affected workspace closure), not ci.yml's full test lanes; the develop-wide Tests (scripts) drift beyond these three files is foreign (develop's own hosted job 96979603855 fails on it).
</details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request/response or state change; formatter-only reflow with no console/network surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model code is touched by this diff.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB rows, memories, scheduled tasks, wallet output, or generated artifacts are produced by formatter output and test-assertion strings; the domain artifact here IS the test/gate transcript, attached inline in backend-logs.
<!-- evidence-row:ocr-review -->
- [x] OCR (tesseract) text readout of the rendered surface: [ocr-text.txt](https://github.com/user-attachments/files/31325226/ocr-text.txt) — after.png and before.png OCR outputs are byte-identical (`diff` clean), confirming no rendered text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change; diff is CI contract assertions plus formatter output.

## Backend + frontend logs

See the `<details>` transcript in the backend-logs row: the exact three previously-red contract tests at this head, plus `bun run format:check` green over 142 packages (tail: `Cached: 0 cached, 142 total / Time: 3.157s`). No frontend logs exist for a formatting-only change.

## Screenshots (before / after) + video walkthrough

N/A - no rendered visual surface changed. The single `packages/ui` file is a whitespace-only JSX attribute reflow (`data-testid="maps-attribution"` element unchanged); biome format/check both green, and the file's package format gate passes.

# Known gaps / failures

Recorded honestly, all pre-existing on pristine develop tip `9c1fc32c0de` (proven by stash-control runs), none caused or widened by this PR, all outside its mechanical scope:

- `@elizaos/cloud-test-mocks` typecheck red: `src/control-plane/server.ts(274,11) TS2322: Promise<boolean> not assignable to Promise<void>` — fallout of #23858's `settleExecution` signature change (`packages/cloud/shared/src/db/repositories/jobs.ts:1592` now returns `Promise<boolean>`); the mock's `settle` wrapper still types `Promise<void>`. Needs a one-line type fix in its owning PR.
- `capacitor-gateway#lint:check` (SwiftLint `type_body_length` on untouched `GatewayPlugin.swift`) — pre-existing, identical at control.
- `audit-credit-packs.proof.test.ts`: 5 tests time out at bun's default 5s per-test budget (child-process migrate exceeds it under load) — timeout hardening is tracked as a separate work item; deliberately not folded into this PR to keep diffs disjoint.
- `scripts/evidence-review/evidence-review.test.mjs`: 3 failures reproduce 5/5 on pristine develop in isolation (pre-existing).

# Attribution

AI provider/model: zai / glm-5.3 (implementation + manual review) + GPT-5.6-sol (independent RepoPrompt review agent, 2 rounds, both APPROVE)
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@b447fe2f542af8f12c0c011c3bbf772c7c6b3f50:packages/skills/skills/contribute-to-eliza"} -->



## Maintainer current-develop reconciliation — 2026-08-21

This section supersedes the older file-count and stale hosted-failure notes above.

- Rebased onto `origin/develop@e92396f7482c43c8e52ce1e71dafe23905845b9e`; frozen head `a1a531ab58b2ff0ad8e6cb09b290f5c0bee07d03`.
- Current aggregate patch-id: `d09b9852fec413097d592754e9292e6739a8ff81`.
- Three surrogate test files in the original branch were deleted on current develop and were intentionally **not resurrected** during conflict resolution.
- The original `accounts-routes.ts` and `wallet.ts` formatting changes are already present on develop and dropped cleanly.
- The remaining exact diff is four files only: three Wrangler contract literals (`4.100.0` → `4.116.0`) and the still-needed formatter-only `maps-card.tsx` reflow.
- Pinned Bun 1.3.14 exact contract run: **34 passed, 0 failed, 471 assertions**.
- Biome formatter exact four-file gate: clean; `git diff --check origin/develop...HEAD`: clean.
- The old hosted failures were produced from stale head `8993e07d` and cannot classify the rebased four-file patch. The PR remains draft until hosted checks run against this exact SHA.


