### PR TITLE
fix(agent): migrate personal-assistant deterministic scenarios off model fallback

### DIFF
--- a/packages/scenario-runner/src/model-fixture-migration.test.ts
+++ b/packages/scenario-runner/src/model-fixture-migration.test.ts
@@ -8,7 +8,7 @@ import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
-const MAX_LEGACY_PR_DETERMINISTIC_SCENARIOS = 79;
+const MAX_LEGACY_PR_DETERMINISTIC_SCENARIOS = 53;
 
 type ScenarioSourceClassification = {
   deterministic: boolean;
@@ -184,7 +184,7 @@ describe("scenario model fixture migration", () => {
       strictOrModelFree: deterministic.length - legacy.length,
       legacy: legacy.length,
       total: deterministic.length,
-    }).toEqual({ strictOrModelFree: 40, legacy: 79, total: 119 });
+    }).toEqual({ strictOrModelFree: 66, legacy: 53, total: 119 });
   }, 120_000);
 
   it("recognizes authored properties while ignoring comments and setup strings", () => {

--- a/plugins/plugin-personal-assistant/test/scenarios/adhd-distractor-storm-mid-capture.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/adhd-distractor-storm-mid-capture.scenario.ts
@@ -225,6 +225,20 @@ function assertResurfacesOnce(
 export default scenario({
   id: "adhd-distractor-storm-mid-capture",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 1,
+      },
+    ],
+  },
   title:
     "ADHD distractor storm: a parked capture resurfaces once at its promised time, never early",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-intensity-minimal-chases-none.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-intensity-minimal-chases-none.scenario.ts
@@ -243,6 +243,20 @@ function assertQuietAfterTerminal(
 export default scenario({
   id: "adhd-followthrough-intensity-minimal-chases-none",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 1,
+      },
+    ],
+  },
   title:
     "ADHD follow-through: minimal reminderIntensity drops the no-reply retry entirely — fires once, then stops",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-intensity-persistent-chases-twice.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-intensity-persistent-chases-twice.scenario.ts
@@ -228,6 +228,20 @@ function assertTimeout(
 export default scenario({
   id: "adhd-followthrough-intensity-persistent-chases-twice",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 3,
+      },
+    ],
+  },
   title:
     "ADHD follow-through: persistent reminderIntensity earns a second no-reply retry rung",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-noreply-retry-then-skip.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-noreply-retry-then-skip.scenario.ts
@@ -235,6 +235,20 @@ function assertTimeout(
 export default scenario({
   id: "adhd-followthrough-noreply-retry-then-skip",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 2,
+      },
+    ],
+  },
   title:
     "ADHD follow-through: an ignored reminder re-nudges once, then settles — never lost, never nagged forever",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-reply-breaks-escalation.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-reply-breaks-escalation.scenario.ts
@@ -240,6 +240,20 @@ function assertNoEscalationAfterAck(
 export default scenario({
   id: "adhd-followthrough-reply-breaks-escalation",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 1,
+      },
+    ],
+  },
   title:
     "ADHD follow-through: acknowledging a reminder retires the no-reply ladder — chasing stops on engagement",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/adhd-hyperfocus-guardrail-protects-standup.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/adhd-hyperfocus-guardrail-protects-standup.scenario.ts
@@ -262,6 +262,20 @@ function bothAtPreTick(_status: number, body: unknown): string | undefined {
 export default scenario({
   id: "adhd-hyperfocus-guardrail-protects-standup",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 1,
+      },
+    ],
+  },
   title:
     "ADHD hyperfocus guardrail: important standup nudge breaks through, low-value ping held",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/comms-flood-quiet-hours-vip-exception.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/comms-flood-quiet-hours-vip-exception.scenario.ts
@@ -270,6 +270,20 @@ function bothHeldAtPreTick(_status: number, body: unknown): string | undefined {
 export default scenario({
   id: "comms-flood-quiet-hours-vip-exception",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 1,
+      },
+    ],
+  },
   title:
     "Comms flood quiet-hours VIP exception: VIP nudge breaks through, non-VIP digest ping held",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/corpus/goals/goals.owner-goals-create.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/corpus/goals/goals.owner-goals-create.scenario.ts
@@ -12,7 +12,6 @@
  * keyless runtime (mirrors plugin-goals' own goals.harness.test.ts).
  */
 import type { AgentRuntime } from "@elizaos/core";
-import { ModelType } from "@elizaos/core";
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { executeRawSql } from "../../../../../../plugins/plugin-goals/src/db/sql.ts";
 import { createOwnerGoalsService } from "../../../../../../plugins/plugin-goals/src/goals-runtime.ts";
@@ -25,113 +24,113 @@ import { createOwnerGoalsService } from "../../../../../../plugins/plugin-goals/
 const GOAL_INPUT = "Add a goal to run a marathon next year, and save it.";
 const OWNER_GOALS = "OWNER_GOALS";
 
-type RuntimeWithScenarioModelFixtures = AgentRuntime & {
-  scenarioModelFixtures?: {
-    register: (...fixtures: Array<Record<string, unknown>>) => void;
-  };
-};
-
-function goalsRouteFixtures(): Array<Record<string, unknown>> {
-  const inputMatches = (value: string) => value.includes("marathon");
-  return [
-    {
-      name: "route-owner-goals-stage1",
-      match: {
-        modelType: ModelType.RESPONSE_HANDLER,
-        input: inputMatches,
-        toolName: "HANDLE_RESPONSE",
-      },
-      response: {
-        contexts: ["general"],
-        intents: ["goal"],
-        replyText: "",
-        threadOps: [],
-        candidateActionNames: [OWNER_GOALS],
-      },
-      times: 1,
-    },
-    {
-      name: "route-owner-goals-planner",
-      match: {
-        modelType: ModelType.ACTION_PLANNER,
-        input: inputMatches,
-        toolName: OWNER_GOALS,
-      },
-      response: {
-        text: "",
-        // Non-empty so the planner-loop gate synthesizes a FINISH after the
-        // successful create instead of firing an (unfixtured) in-loop evaluator.
-        thought: "Create the owner's marathon life goal.",
-        messageToUser: "Added your goal.",
-        completed: true,
-        finishReason: "tool-calls",
-        toolCalls: [
-          {
-            id: "call-owner-goals",
-            name: OWNER_GOALS,
-            type: "function",
-            arguments: {
-              action: "create",
-              title: "Run a marathon",
-              confirmed: true,
-            },
-          },
-        ],
-      },
-      times: 1,
-    },
-    {
-      // The action's own resolveActionArgs extraction. Excludes the grounding
-      // prompt (below) so the two TEXT_LARGE fixtures are mutually exclusive, and
-      // is optional because the planner already supplied the create args.
-      name: "owner-goals-extraction-create",
-      match: {
-        modelType: ModelType.TEXT_LARGE,
-        prompt: (v: string) => !v.includes("missingCriticalFields"),
-      },
-      response: JSON.stringify({
-        action: "create",
-        params: { title: "Run a marathon", confirmed: true },
-        missing: [],
-        confidence: 0.95,
-      }),
-      times: { min: 0, max: 1 },
-    },
-    {
-      // #14459's second TEXT_LARGE grounding extractor
-      // (extractGoalCreatePlanWithLlm). Without a grounded plan the create is a
-      // NOOP_GOAL_UNGROUNDED and never persists. successCriteria/supportStrategy
-      // MUST be objects — a string/null re-triggers the NOOP gate.
-      name: "owner-goals-grounding-create",
-      match: {
-        modelType: ModelType.TEXT_LARGE,
-        prompt: (v: string) => v.includes("missingCriticalFields"),
-      },
-      response: JSON.stringify({
-        mode: "create",
-        response: null,
-        title: "Run a marathon",
-        description: "Train for and complete a marathon within the next year.",
-        cadence: { kind: "weekly" },
-        successCriteria: {
-          summary: "Finish a full 42.2km marathon within the next year.",
-        },
-        supportStrategy: {
-          summary: "Follow a progressive weekly long-run training plan.",
-        },
-        groundingState: "grounded",
-        missingCriticalFields: [],
-        confidence: 0.95,
-        evaluationSummary: "Completing a marathon within the next year.",
-        targetDomain: "fitness",
-      }),
-      times: 1,
-    },
-  ];
-}
-
 export default scenario({
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "route-owner-goals-stage1",
+        match: {
+          modelType: "RESPONSE_HANDLER",
+          input: { includes: "marathon" },
+        },
+        response: {
+          json: {
+            contexts: ["general"],
+            intents: ["goal"],
+            replyText: "",
+            threadOps: [],
+            candidateActionNames: [OWNER_GOALS],
+          },
+        },
+        cardinality: 1,
+      },
+      {
+        name: "route-owner-goals-planner",
+        match: {
+          modelType: "ACTION_PLANNER",
+          input: { includes: "marathon" },
+        },
+        response: {
+          json: {
+            text: "",
+            // Non-empty so the planner-loop gate synthesizes a FINISH after the
+            // successful create instead of firing an (unfixtured) in-loop evaluator.
+            thought: "Create the owner's marathon life goal.",
+            messageToUser: "Added your goal.",
+            completed: true,
+            finishReason: "tool-calls",
+            toolCalls: [
+              {
+                id: "call-owner-goals",
+                name: OWNER_GOALS,
+                type: "function",
+                arguments: {
+                  action: "create",
+                  title: "Run a marathon",
+                  confirmed: true,
+                },
+              },
+            ],
+          },
+        },
+        cardinality: 1,
+      },
+      {
+        // The action's own resolveActionArgs extraction. Excludes the grounding
+        // prompt (below) so the two TEXT_LARGE fixtures are mutually exclusive, and
+        // is optional because the planner already supplied the create args.
+        name: "owner-goals-extraction-create",
+        match: {
+          modelType: "TEXT_LARGE",
+          prompt: { pattern: "^((?!missingCriticalFields)[\\s\\S])*$" },
+        },
+        response: {
+          text: JSON.stringify({
+            action: "create",
+            params: { title: "Run a marathon", confirmed: true },
+            missing: [],
+            confidence: 0.95,
+          }),
+        },
+        cardinality: { min: 0, max: 1 },
+      },
+      {
+        // #14459's second TEXT_LARGE grounding extractor
+        // (extractGoalCreatePlanWithLlm). Without a grounded plan the create is a
+        // NOOP_GOAL_UNGROUNDED and never persists. successCriteria/supportStrategy
+        // MUST be objects — a string/null re-triggers the NOOP gate.
+        name: "owner-goals-grounding-create",
+        match: {
+          modelType: "TEXT_LARGE",
+          prompt: { includes: "missingCriticalFields" },
+        },
+        response: {
+          text: JSON.stringify({
+            mode: "create",
+            response: null,
+            title: "Run a marathon",
+            description:
+              "Train for and complete a marathon within the next year.",
+            cadence: { kind: "weekly" },
+            successCriteria: {
+              summary: "Finish a full 42.2km marathon within the next year.",
+            },
+            supportStrategy: {
+              summary: "Follow a progressive weekly long-run training plan.",
+            },
+            groundingState: "grounded",
+            missingCriticalFields: [],
+            confidence: 0.95,
+            evaluationSummary: "Completing a marathon within the next year.",
+            targetDomain: "fitness",
+          }),
+        },
+        cardinality: 1,
+      },
+    ],
+  },
   id: "goals.owner-goals-create",
   title: "Goals: OWNER_GOALS creates a goal from natural language",
   domain: "goals",
@@ -149,7 +148,7 @@ export default scenario({
       type: "custom",
       name: "provision-audit-table-and-fixtures",
       apply: async (ctx) => {
-        const runtime = ctx.runtime as RuntimeWithScenarioModelFixtures;
+        const runtime = ctx.runtime as AgentRuntime;
         await executeRawSql(runtime, "CREATE SCHEMA IF NOT EXISTS app_lifeops");
         await executeRawSql(
           runtime,
@@ -166,7 +165,6 @@ export default scenario({
              created_at text NOT NULL
            )`,
         );
-        runtime.scenarioModelFixtures?.register(...goalsRouteFixtures());
         return undefined;
       },
     },

--- a/plugins/plugin-personal-assistant/test/scenarios/corpus/lifeops.personas/persona.flexible-scheduling.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/corpus/lifeops.personas/persona.flexible-scheduling.scenario.ts
@@ -259,6 +259,20 @@ function deferredFor(
 export default scenario({
   id: "persona.flexible-scheduling",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 5,
+      },
+    ],
+  },
   title:
     "LifeOps persona scheduling: during_window / anchor firing, quiet_hours defer, activity-gated poke allow",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/f1-adversarial-highstakes-confirmation-fail-closed.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/f1-adversarial-highstakes-confirmation-fail-closed.scenario.ts
@@ -314,6 +314,20 @@ function assertSilentReNudgeNotResolved(
 export default scenario({
   id: "f1-adversarial-highstakes-confirmation-fail-closed",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 1,
+      },
+    ],
+  },
   title:
     "Fail-closed baseline: a silent high-stakes approval never self-resolves, standard re-nudge only",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/f1-cross-persona-quiet-hours-respected-baseline.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/f1-cross-persona-quiet-hours-respected-baseline.scenario.ts
@@ -231,6 +231,20 @@ function importantFiresPingHeld(
 export default scenario({
   id: "f1-cross-persona-quiet-hours-respected-baseline",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 1,
+      },
+    ],
+  },
   title:
     "Control baseline: standard quiet hours hold a low-value ping, a high-priority reminder still breaks through",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/f1-multiday-recurrence-control-baseline.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/f1-multiday-recurrence-control-baseline.scenario.ts
@@ -201,6 +201,20 @@ function firedOnceOnDay(
 export default scenario({
   id: "f1-multiday-recurrence-control-baseline",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 3,
+      },
+    ],
+  },
   title:
     "Control baseline: a plain daily habit fires once per day on its literal cadence, three days running",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/f1-timezone-boundary-edge-generic.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/f1-timezone-boundary-edge-generic.scenario.ts
@@ -265,6 +265,20 @@ function assertZoneFire(_status: number, body: unknown): string | undefined {
 export default scenario({
   id: "f1-timezone-boundary-edge-generic",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 1,
+      },
+    ],
+  },
   title:
     "Control baseline: a literal zoned reminder fires at its true wall-clock instant, no re-anchoring",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/lowact-micro-step-deferred-not-dropped.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/lowact-micro-step-deferred-not-dropped.scenario.ts
@@ -216,6 +216,20 @@ function assertResurfacesOnce(
 export default scenario({
   id: "lowact-micro-step-deferred-not-dropped",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 1,
+      },
+    ],
+  },
   title:
     "Low activation: a parked one-small-step resurfaces once at its gentle later time, never dropped or early",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/lowact-morning-single-priority-fires-once.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/lowact-morning-single-priority-fires-once.scenario.ts
@@ -236,6 +236,20 @@ function bulkPingHeldPickPending(
 export default scenario({
   id: "lowact-morning-single-priority-fires-once",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 1,
+      },
+    ],
+  },
   title:
     "Low activation: one gentle morning pick fires once, the whole-list ping stays held",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/lowact-quiet-streak-softens-next-nudge.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/lowact-quiet-streak-softens-next-nudge.scenario.ts
@@ -320,6 +320,20 @@ function expireCheckinTurn(dayIndex: number) {
 export default scenario({
   id: "lowact-quiet-streak-softens-next-nudge",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 4,
+      },
+    ],
+  },
   title:
     "Low activation: three ignored check-ins soften the next nudge (quiet-streak), never chase harder",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/lowact-values-anchored-activity-fires-in-window.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/lowact-values-anchored-activity-fires-in-window.scenario.ts
@@ -207,6 +207,20 @@ function deferredOutOfWindow(
 export default scenario({
   id: "lowact-values-anchored-activity-fires-in-window",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 1,
+      },
+    ],
+  },
   title:
     "Low activation: a values-anchored activity fires inside the owner's evening window, defers outside it",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/persona.night-owl-anchored-day.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/persona.night-owl-anchored-day.scenario.ts
@@ -272,6 +272,20 @@ export default scenario({
   // the id statically, resolve it.
   id: "persona.night-owl-anchored-day",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 2,
+      },
+    ],
+  },
   title:
     "Night owl anchored day: brief fires in her noon window and a wake-anchored reminder fires relative to wake — never at 9am",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/persona.night-owl-quiet-hours-sleep-protection.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/persona.night-owl-quiet-hours-sleep-protection.scenario.ts
@@ -255,6 +255,20 @@ export default scenario({
   // the id statically, resolve it.
   id: "persona.night-owl-quiet-hours-sleep-protection",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 1,
+      },
+    ],
+  },
   title:
     "Night owl sleep protection: a low-value reminder is held in her 04:00–11:30 quiet hours; only a high-priority one breaks through",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-reanchor-protects-new-sleep-window.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-reanchor-protects-new-sleep-window.scenario.ts
@@ -280,6 +280,20 @@ function deferredFor(
 export default scenario({
   id: "shift-rotation-reanchor-protects-new-sleep-window",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 2,
+      },
+    ],
+  },
   title:
     "Shift rotation re-anchors a habit reminder to the shifted waking window and never fires it inside the newly-protected sleep block",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-sleep-protection-holds-low-priority-nudge.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-sleep-protection-holds-low-priority-nudge.scenario.ts
@@ -254,6 +254,20 @@ function protectedSleepTick(
 export default scenario({
   id: "shift-rotation-sleep-protection-holds-low-priority-nudge",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 1,
+      },
+    ],
+  },
   title:
     "Protected post-night-shift sleep holds a low-value ping while an important reminder breaks through",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-wake-anchor-follows-shifted-window.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/shift-rotation-wake-anchor-follows-shifted-window.scenario.ts
@@ -242,6 +242,20 @@ function notFiredFor(
 export default scenario({
   id: "shift-rotation-wake-anchor-follows-shifted-window",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 1,
+      },
+    ],
+  },
   title:
     "Wake-anchored reminder re-anchors to the shifted wake window and stays silent at the old morning slot",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/traveler-absolute-vs-wallclock-disambiguation-flight.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/traveler-absolute-vs-wallclock-disambiguation-flight.scenario.ts
@@ -276,6 +276,20 @@ export default scenario({
   // Literal (not the SCENARIO_ID const) so the static corpus guard can read it.
   id: "traveler-absolute-vs-wallclock-disambiguation-flight",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 2,
+      },
+    ],
+  },
   title:
     "Traveler: a wall-clock morning window re-anchors to the destination while an absolute boarding instant does not",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/traveler-disruption-recovery-missed-connection.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/traveler-disruption-recovery-missed-connection.scenario.ts
@@ -219,6 +219,20 @@ export default scenario({
   // Literal (not the SCENARIO_ID const) so the static corpus guard can read it.
   id: "traveler-disruption-recovery-missed-connection",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 1,
+      },
+    ],
+  },
   title:
     "Traveler disruption recovery: a delayed connection re-times the reminder, it never fires at the stale time",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/traveler-dst-boundary-reminder-integrity.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/traveler-dst-boundary-reminder-integrity.scenario.ts
@@ -233,6 +233,20 @@ export default scenario({
   // Literal (not the SCENARIO_ID const) so the static corpus guard can read it.
   id: "traveler-dst-boundary-reminder-integrity",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 2,
+      },
+    ],
+  },
   title:
     "Traveler DST integrity: a daily 08:00 reminder keeps its local time across a fall-back transition",
   domain: "lifeops",

--- a/plugins/plugin-personal-assistant/test/scenarios/traveler-reanchor-on-timezone-change-signal.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/traveler-reanchor-on-timezone-change-signal.scenario.ts
@@ -297,6 +297,20 @@ export default scenario({
   // Literal (not the SCENARIO_ID const) so the static corpus guard can read it.
   id: "traveler-reanchor-on-timezone-change-signal",
   lane: "pr-deterministic",
+  modelFixtures: {
+    mode: "fixtures",
+    fixtures: [
+      {
+        name: "dispatch-body",
+        match: {
+          modelType: "TEXT_SMALL",
+          prompt: { includes: "\nInstruction:\n" },
+        },
+        response: { text: "Heads up: you have an update from your assistant." },
+        cardinality: 3,
+      },
+    ],
+  },
   title:
     "Traveler tz-change: wall-clock reminder re-anchors to destination, absolute instant is invariant",
   domain: "lifeops",


### PR DESCRIPTION
## Summary

Refs #24088.

All 26 `pr-deterministic` scenarios under `plugins/plugin-personal-assistant/test/scenarios` that previously fell through to the `legacy-fallback` deterministic model resolver now declare an explicit, strict `modelFixtures` manifest:

- 25 of the 26 are `lifeops_scheduler` tick-driven scenarios. Each fire dispatches through `dispatch-render.ts`'s `renderScheduledDispatchMessage` (`useModel(TEXT_SMALL, { prompt })`, prompt containing the `\nInstruction:\n` marker). Every scenario now declares one `dispatch-body` fixture with `cardinality` set to the exact number of real dispatch attempts the scenario drives (verified empirically per scenario — 1 for a single fire, up to 5 where a scenario chains multiple creates/fires/re-fires in one run). None of these scenarios' custom delivery channels ever reach the title-render path (that's `in_app`-notifier-only), so no title fixture is declared.
- `corpus/goals/goals.owner-goals-create` previously registered its fixtures imperatively via `runtime.scenarioModelFixtures.register(...)` in a seed step — invisible to the static `modelFixtures` classifier. Moved the same four fixtures (Stage-1 routing, ACTION_PLANNER tool-call, and the two mutually-exclusive TEXT_LARGE extraction/grounding fixtures) into the declarative `modelFixtures` field, translating the one negated-substring match (`prompt: (v) => !v.includes(...)`) into an equivalent negative-lookahead `pattern` matcher.

Also updates the repo-wide ratchet in `packages/scenario-runner/src/model-fixture-migration.test.ts`: `MAX_LEGACY_PR_DETERMINISTIC_SCENARIOS` 79 → 53, and the expected `{strictOrModelFree, legacy, total}` snapshot to `{66, 53, 119}`.

## Test plan

- [x] `bun run --cwd packages/scenario-runner vitest run src/model-fixture-migration.test.ts` — ratchet passes with the new counts.
- [x] All 26 migrated scenarios run green individually and as a batch through the real deterministic-model-provider harness:
  `SCENARIO_USE_DETERMINISTIC_MODEL=1 TZ=UTC bun --conditions=eliza-source packages/scenario-runner/src/cli.ts run plugins/plugin-personal-assistant/test/scenarios --lane pr-deterministic --scenario <all 26 ids>` → `26 passed, 0 failed`.
- [x] `bun run --cwd packages/scenario-runner typecheck` and `bun run --cwd plugins/plugin-personal-assistant typecheck` — no new errors (remaining errors are pre-existing unbuilt-sibling-package baseline noise, unrelated to any touched file).
- [x] `bun x biome check` on all 27 changed files — clean.
- [ ] `bun run --cwd packages/app audit:app` — not run; this PR touches only test-scenario fixture declarations and a ratchet test, zero rendering/UI surface.

AI provider/model: claude-sonnet-5 / Claude Code

## Maintainer evidence

<!-- evidence-row:before-screenshots -->
N/A - test-scenario fixture declarations only; no UI or production rendering changed.

<!-- evidence-row:after-screenshots -->
N/A - test-scenario fixture declarations only; no UI or production rendering changed.

<!-- evidence-row:walkthrough-video -->
N/A - no user-visible production behavior changed.

<!-- evidence-row:backend-logs -->
```text
Exact rebased head: 1f6095d7fc20a98031de64a364e115c8275a3505
model-fixture-migration.test.ts: 2 tests passed, 0 failed
27 touched files: Biome clean; git diff --check clean
Submitted byte-identical patch: 26 migrated deterministic scenarios passed, 0 failed
```

<!-- evidence-row:frontend-logs -->
N/A - no frontend code or runtime surface changed.

<!-- evidence-row:llm-trajectory -->
N/A - this migrates deterministic test fixtures only; no production model, prompt, or agent behavior changed.

<!-- evidence-row:domain-artifacts -->
N/A - no production database, connector, scheduler, or other domain artifact is changed or produced.

The conflict-free rebase preserved patch-id `01f9879742d9b533806724f3727d1de1b734417d`. An independent exact-head 26-scenario rerun was attempted but the shared checkout has a broken `node_modules/uuid` link and stopped before scenario collection; the contributor’s exact pre-rebase 26/26 run applies to the byte-identical patch.

<!-- evidence-head:1f6095d7fc20a98031de64a364e115c8275a3505 -->
