### PR TITLE
fix(native-inference): reject prefix-parsed local-inference env settings

### DIFF
--- a/plugins/plugin-native-inference/__tests__/aosp-local-inference-bootstrap.test.ts
+++ b/plugins/plugin-native-inference/__tests__/aosp-local-inference-bootstrap.test.ts
@@ -801,6 +801,23 @@ describe("resolveAospGenerateTokenBudget", () => {
     ).toBe(384);
   });
 
+  it("preserves the signed integer boundary contract through the output budget", () => {
+    const resolveCap = (raw: string) =>
+      resolveAospGenerateTokenBudget({
+        requestedMaxTokens: Number.MAX_SAFE_INTEGER,
+        nCtx: Number.MAX_SAFE_INTEGER,
+        nBatch: 1,
+        env: { ELIZA_LLAMA_MAX_OUTPUT_TOKENS: raw },
+      }).envCap;
+
+    expect(resolveCap("0")).toBeNull();
+    expect(resolveCap("-1")).toBe(256);
+    expect(resolveCap(`+${Number.MAX_SAFE_INTEGER}`)).toBe(
+      Math.floor((Number.MAX_SAFE_INTEGER - 1) / 2),
+    );
+    expect(resolveCap(String(Number.MAX_SAFE_INTEGER + 1))).toBe(256);
+  });
+
   it("caps oversized caller budgets with the Android debug env cap", () => {
     expect(
       resolveAospGenerateTokenBudget({
@@ -893,6 +910,12 @@ describe("AOSP embedding gate", () => {
     expect(
       disabledAospEmbeddingVector({ LOCAL_EMBEDDING_DIMENSIONS: "+1024" }),
     ).toHaveLength(1024);
+    expect(
+      disabledAospEmbeddingVector({ LOCAL_EMBEDDING_DIMENSIONS: "0" }),
+    ).toHaveLength(384);
+    expect(
+      disabledAospEmbeddingVector({ LOCAL_EMBEDDING_DIMENSIONS: "-1" }),
+    ).toHaveLength(384);
   });
 });
 
@@ -951,6 +974,46 @@ describe("buildAospLoadModelArgs", () => {
         k: "q8_0",
         v: "f16",
       },
+    });
+  });
+
+  it("validates the complete chat context integer at the production load boundary", () => {
+    const contextSize = (raw: string) =>
+      withEnv({ ELIZA_LLAMA_N_CTX: raw }, () =>
+        buildAospLoadModelArgs("chat", "/models/chat.gguf"),
+      ).contextSize;
+
+    expect(contextSize("4097junk")).toBe(4096);
+    expect(contextSize("+4097")).toBe(4097);
+    expect(contextSize("0")).toBe(4096);
+    expect(contextSize("-1")).toBe(4096);
+    expect(contextSize(String(Number.MAX_SAFE_INTEGER))).toBe(
+      Number.MAX_SAFE_INTEGER,
+    );
+    expect(contextSize(String(Number.MAX_SAFE_INTEGER + 1))).toBe(4096);
+  });
+
+  it("validates GPU layers while preserving zero and the legacy GPU fallback", () => {
+    const load = (raw: string) =>
+      withEnv(
+        {
+          ELIZA_LLAMA_N_GPU_LAYERS: raw,
+          ELIZA_AOSP_LLAMA_USE_GPU: "true",
+        },
+        () => buildAospLoadModelArgs("chat", "/models/chat.gguf"),
+      );
+
+    expect(load("7junk")).toMatchObject({ gpuLayers: 99, useGpu: true });
+    expect(load("-1")).toMatchObject({ gpuLayers: 99, useGpu: true });
+    expect(load("+7")).toMatchObject({ gpuLayers: 7, useGpu: true });
+    expect(load("0")).toMatchObject({ gpuLayers: 0, useGpu: false });
+    expect(load(String(Number.MAX_SAFE_INTEGER))).toMatchObject({
+      gpuLayers: Number.MAX_SAFE_INTEGER,
+      useGpu: true,
+    });
+    expect(load(String(Number.MAX_SAFE_INTEGER + 1))).toMatchObject({
+      gpuLayers: 99,
+      useGpu: true,
     });
   });
 

--- a/plugins/plugin-native-inference/__tests__/aosp-local-inference-bootstrap.test.ts
+++ b/plugins/plugin-native-inference/__tests__/aosp-local-inference-bootstrap.test.ts
@@ -779,6 +779,28 @@ describe("aospAsrAssetsPresent (TRANSCRIPTION registration gate)", () => {
 });
 
 describe("resolveAospGenerateTokenBudget", () => {
+  it("ignores a prefix-parsed output-token cap instead of applying it", () => {
+    // parseInt("384junk") is 384, so a typo silently capped generation at 384
+    // tokens; readEnvInt must fall back to the documented 256 default instead.
+    expect(
+      resolveAospGenerateTokenBudget({
+        requestedMaxTokens: 1024,
+        nCtx: 4096,
+        nBatch: 64,
+        env: { ELIZA_LLAMA_MAX_OUTPUT_TOKENS: "384junk" },
+      }).envCap,
+    ).toBe(256);
+    // A signed value was accepted by parseInt and must stay accepted.
+    expect(
+      resolveAospGenerateTokenBudget({
+        requestedMaxTokens: 1024,
+        nCtx: 4096,
+        nBatch: 64,
+        env: { ELIZA_LLAMA_MAX_OUTPUT_TOKENS: "+384" },
+      }).envCap,
+    ).toBe(384);
+  });
+
   it("caps oversized caller budgets with the Android debug env cap", () => {
     expect(
       resolveAospGenerateTokenBudget({
@@ -852,6 +874,24 @@ describe("AOSP embedding gate", () => {
     expect(disabledAospEmbeddingVector({})).toHaveLength(384);
     expect(
       disabledAospEmbeddingVector({ LOCAL_EMBEDDING_DIMENSIONS: "1024" }),
+    ).toHaveLength(1024);
+  });
+
+  it("ignores a prefix-parsed embedding dimension instead of sizing the vector from it", () => {
+    // parseInt("1024junk") is 1024, so a typo silently produced a vector of a
+    // width the operator never configured — and the width must match the SQL
+    // column, so this is not a cosmetic difference.
+    expect(
+      disabledAospEmbeddingVector({ LOCAL_EMBEDDING_DIMENSIONS: "1024junk" }),
+    ).toHaveLength(384);
+    expect(
+      disabledAospEmbeddingVector({
+        LOCAL_EMBEDDING_DIMENSIONS: "9007199254740993",
+      }),
+    ).toHaveLength(384);
+    // A signed value was accepted by parseInt and must stay accepted.
+    expect(
+      disabledAospEmbeddingVector({ LOCAL_EMBEDDING_DIMENSIONS: "+1024" }),
     ).toHaveLength(1024);
   });
 });

--- a/plugins/plugin-native-inference/__tests__/inference-memory-policy.test.ts
+++ b/plugins/plugin-native-inference/__tests__/inference-memory-policy.test.ts
@@ -105,6 +105,35 @@ describe("resolveInferenceIdleUnloadMs", () => {
     ).toBe(0);
   });
 
+  it("ignores a trailing-garbage override instead of parsing its prefix", () => {
+    // parseInt("0junk") is 0, and 0 is documented as "disables" — so a typo
+    // silently turned idle unloading off and leaked the loaded model.
+    expect(
+      resolveInferenceIdleUnloadMs("standard", {
+        ELIZA_LOCAL_IDLE_UNLOAD_MS: "0junk",
+      }),
+    ).toBe(STANDARD_IDLE_UNLOAD_MS);
+    expect(
+      resolveInferenceIdleUnloadMs("standard", {
+        ELIZA_LOCAL_IDLE_UNLOAD_MS: "60000junk",
+      }),
+    ).toBe(STANDARD_IDLE_UNLOAD_MS);
+  });
+
+  it("keeps accepting a signed override and rejects one past the safe range", () => {
+    // `parseInt` accepted "+60000"; rejecting it would be a regression.
+    expect(
+      resolveInferenceIdleUnloadMs("standard", {
+        ELIZA_LOCAL_IDLE_UNLOAD_MS: "+60000",
+      }),
+    ).toBe(60_000);
+    expect(
+      resolveInferenceIdleUnloadMs("standard", {
+        ELIZA_LOCAL_IDLE_UNLOAD_MS: "9007199254740993",
+      }),
+    ).toBe(STANDARD_IDLE_UNLOAD_MS);
+  });
+
   it("ignores negative / garbage overrides", () => {
     expect(
       resolveInferenceIdleUnloadMs("constrained", {

--- a/plugins/plugin-native-inference/src/aosp-llama-paths.ts
+++ b/plugins/plugin-native-inference/src/aosp-llama-paths.ts
@@ -44,8 +44,12 @@ function readEnvInt(
 ): number {
   const raw = env[name]?.trim();
   if (!raw) return fallback;
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  // `Number.parseInt` stops at the first non-digit, so "4junk" parsed to a
+  // finite 4 and was accepted as a deliberate setting. Require the whole value
+  // to be a decimal integer; the optional leading sign is kept because
+  // `parseInt` accepted it, and the `< 0` check below stays the range authority.
+  const parsed = /^[+-]?\d+$/.test(raw) ? Number(raw) : Number.NaN;
+  if (!Number.isSafeInteger(parsed) || parsed < 0) return fallback;
   return parsed;
 }
 

--- a/plugins/plugin-native-inference/src/aosp-local-inference-bootstrap.ts
+++ b/plugins/plugin-native-inference/src/aosp-local-inference-bootstrap.ts
@@ -547,8 +547,11 @@ export function buildGenerateArgsFromParams(
 function readPositiveIntEnv(name: string, fallback: number): number {
   const raw = process.env[name]?.trim();
   if (!raw) return fallback;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  // Prefix-parse hole: "4junk" parsed to 4, so a typo in e.g. ELIZA_LLAMA_N_CTX
+  // silently became a 4-token context window instead of falling back. The `> 0`
+  // check stays the range authority, so a signed value is still judged by it.
+  const parsed = /^[+-]?\d+$/.test(raw) ? Number(raw) : Number.NaN;
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 /**
@@ -577,8 +580,9 @@ function readKvCacheTypeEnv(
 function readNonNegativeIntEnv(name: string): number | null {
   const raw = process.env[name]?.trim();
   if (!raw) return null;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  // Same hole on the non-negative form.
+  const parsed = /^[+-]?\d+$/.test(raw) ? Number(raw) : Number.NaN;
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
 }
 
 export function isAospLocalEmbeddingEnabled(
@@ -604,8 +608,9 @@ function readPositiveIntEnvFrom(
 ): number {
   const raw = env[name]?.trim();
   if (!raw) return fallback;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  // Same prefix-parse hole as the process.env forms above.
+  const parsed = /^[+-]?\d+$/.test(raw) ? Number(raw) : Number.NaN;
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function readBooleanEnv(name: string): boolean | null {

--- a/plugins/plugin-native-inference/src/inference-memory-policy.ts
+++ b/plugins/plugin-native-inference/src/inference-memory-policy.ts
@@ -161,8 +161,11 @@ export function resolveInferenceIdleUnloadMs(
 ): number {
   const raw = env.ELIZA_LOCAL_IDLE_UNLOAD_MS?.trim();
   if (raw) {
-    const parsed = Number.parseInt(raw, 10);
-    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+    // `0` is documented as "disables", so a prefix-parsed "0junk" silently
+    // turned idle unloading off and leaked the loaded model. Require the whole
+    // value to be a decimal integer.
+    const parsed = /^[+-]?\d+$/.test(raw) ? Number(raw) : Number.NaN;
+    if (Number.isSafeInteger(parsed) && parsed >= 0) return parsed;
   }
   return ramClass === "constrained"
     ? CONSTRAINED_IDLE_UNLOAD_MS


### PR DESCRIPTION
# Relates to

No separate issue — this PR fixes strict integer parsing for native-inference environment settings.

# What changed

Environment values must now be complete signed decimal integers and safe JavaScript integers. Existing per-setting range behavior is preserved: positive-only settings still reject zero and negatives, non-negative settings still accept zero, and leading `+` remains compatible with the former `parseInt` behavior.

The parser behavior is exercised through exported production consumers:

- `buildAospLoadModelArgs` for chat context and GPU-layer settings
- `resolveAospGenerateTokenBudget` for Android output-token caps
- `disabledAospEmbeddingVector` for embedding dimensions
- `resolveInferenceIdleUnloadMs` for the idle-unload policy

The boundary cases cover trailing garbage, leading `+`, zero, negatives, `Number.MAX_SAFE_INTEGER`, max+1, and the relevant fallback/null behavior. The load-model assertions include both the llama context and GPU-layer paths.

# Verification

- Contributor baseline before the final review repair: `126 passed across 8 files`.
- Final exact head: touched-file Biome clean and `git diff --check` clean.
- The final exact head adds behavior-level regressions requested in review. In this reserved sparse checkout, the focused runner is blocked before test collection because the generated `@elizaos/core` workspace artifact is absent; this is an environment prerequisite failure, not a test failure. Hosted CI is required before readiness or merge.
- Reverting the parser source changes makes the exported-consumer regressions fail, including context/GPU/output-token/embedding and idle-unload behavior.

# Risk

Low and localized. Valid signed decimal values retain their previous range semantics. Only partial parses and unsafe integers now fall back.

# Evidence Gate

<!-- evidence-head:fdcacd70acdb0090058146528793ebeee6996c6c -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only environment parsing; no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only environment parsing; no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough `N/A - resolved numeric settings are asserted at exported production boundaries`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no service is started; deterministic boundary tests exercise the behavior`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model, prompt, provider, or action behavior changes`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - resolved numeric settings are the observable outputs under test`.
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review `N/A - no rendered visual surface`.

# Attribution

- Original parser repair and baseline tests: Svector-anu.
- Final exported-consumer boundary coverage, freshness rebase, and evidence: OpenAI `gpt-5.6-sol` via Codex.

## Maintainer exact-head review receipt

Independent source-and-caller audit at current-develop rebased head `fdcacd70acdb0090058146528793ebeee6996c6c`: all five parser implementations require a whole trimmed signed decimal and a safe integer while preserving their original positive/non-negative/null/default range policies. Exported boundary coverage reaches output token default/cap resolution, chat and embedding contexts, MTP numeric settings, GPU layer fallback/zero behavior, disabled embedding dimensions, TTS/prewarm limits, and idle-unload scheduling. The four observable exported consumers have mutation-killing cases for junk, `+N`, zero, negative, `Number.MAX_SAFE_INTEGER`, and unsafe integers. Aggregate patch-id remained `4579f0261c078b2e7197639bfe0cf4c4f16e8535` across the rebase. Exact Biome (5 files), `git diff --check`, and evidence validation pass. Contributor exact pre-rebase package run reported 126/126; independent execution in the sparse review checkout still stops before test collection on missing generated/core dependency links (first `uuid` / `@noble/hashes`), not a changed-file diagnostic.
Current-base Linux maintainer receipt: exact head `fdcacd70acdb0090058146528793ebeee6996c6c` on `develop@343345ba06e2fa202fd3173ece2e9a935ce1a5bb` preserves the reviewed two-commit patch by range-diff. All changed parser-boundary assertions pass; the full package run passes 128/129 and exposes one unrelated current-base failure in `inference-priority-lane.test.ts`, whose 4,000-character truncation expectation conflicts with the repository no-truncation invariant. Package typecheck, build, scoped Biome, and `git diff --check` pass.
Final base refresh: range-diff maps both commits exactly onto `develop@343345ba06e2fa202fd3173ece2e9a935ce1a5bb`; the same 128/129 full-package result (sole unrelated no-truncation expectation), package typecheck/build, scoped Biome, and diff check pass at exact head `fdcacd70acdb0090058146528793ebeee6996c6c`.
