### PR TITLE
fix(ui): reject a prefix-parsed device call timeout

### DIFF
--- a/packages/ui/src/services/local-inference/device-bridge.timeout.test.ts
+++ b/packages/ui/src/services/local-inference/device-bridge.timeout.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Covers `ELIZA_DEVICE_GENERATE_TIMEOUT_MS` parsing. The value bounds every
+ * device generate/embed call, so a silently truncated setting aborts real work.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveDeviceCallTimeoutMs } from "./device-bridge";
+
+const KEY = "ELIZA_DEVICE_GENERATE_TIMEOUT_MS";
+const original = process.env[KEY];
+
+afterEach(() => {
+  if (original === undefined) delete process.env[KEY];
+  else process.env[KEY] = original;
+});
+
+describe("resolveDeviceCallTimeoutMs", () => {
+  it("ignores a trailing-garbage timeout instead of parsing its prefix", () => {
+    // parseInt("5junk") is 5 — a 5ms budget that aborts every device call.
+    process.env[KEY] = "5junk";
+    expect(resolveDeviceCallTimeoutMs()).toBe(60_000);
+  });
+
+  it("still honours a clean timeout", () => {
+    process.env[KEY] = "30000";
+    expect(resolveDeviceCallTimeoutMs()).toBe(30_000);
+  });
+
+  it("keeps a signed value and rejects one past the safe range", () => {
+    // `parseInt` accepted "+30000"; rejecting it would be a regression.
+    process.env[KEY] = "+30000";
+    expect(resolveDeviceCallTimeoutMs()).toBe(30_000);
+    process.env[KEY] = "9007199254740993";
+    expect(resolveDeviceCallTimeoutMs()).toBe(60_000);
+  });
+
+  it("falls back when unset", () => {
+    delete process.env[KEY];
+    expect(resolveDeviceCallTimeoutMs()).toBe(60_000);
+  });
+});

--- a/packages/ui/src/services/local-inference/device-bridge.ts
+++ b/packages/ui/src/services/local-inference/device-bridge.ts
@@ -47,6 +47,27 @@ import type {
 import { localInferenceRoot } from "./paths";
 
 const DEFAULT_CALL_TIMEOUT_MS = 60_000;
+
+/**
+ * Resolve the per-call device timeout from the environment.
+ *
+ * `Number.parseInt` stops at the first non-digit, so "60000junk" parsed to a
+ * finite, positive 60000 and "5junk" to 5 — a 5ms budget that aborts every
+ * device call. Require the whole trimmed value to be a decimal integer; the
+ * optional leading sign is kept because `parseInt` accepted it, and the `> 0`
+ * check stays the range authority.
+ *
+ * Exported for direct unit coverage, matching the other env resolvers in the
+ * codebase (`resolveTextTimeoutMs`, `getDocumentsServiceTimeoutMs`).
+ */
+export function resolveDeviceCallTimeoutMs(): number {
+  const raw = process.env.ELIZA_DEVICE_GENERATE_TIMEOUT_MS?.trim();
+  if (!raw) return DEFAULT_CALL_TIMEOUT_MS;
+  const parsed = /^[+-]?\d+$/.test(raw) ? Number(raw) : Number.NaN;
+  return Number.isSafeInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_CALL_TIMEOUT_MS;
+}
 const DEFAULT_LOAD_TIMEOUT_MS = 120_000;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const PENDING_LOG_FILENAME = "pending-requests.json";
@@ -950,14 +971,7 @@ export class DeviceBridge {
   async embed(args: {
     input: string;
   }): Promise<{ embedding: number[]; tokens: number }> {
-    const envTimeout = Number.parseInt(
-      process.env.ELIZA_DEVICE_GENERATE_TIMEOUT_MS?.trim() ?? "",
-      10,
-    );
-    const timeoutMs =
-      Number.isFinite(envTimeout) && envTimeout > 0
-        ? envTimeout
-        : DEFAULT_CALL_TIMEOUT_MS;
+    const timeoutMs = resolveDeviceCallTimeoutMs();
 
     const correlationId = randomUUID();
     const request: AgentOutbound = {
@@ -1016,14 +1030,7 @@ export class DeviceBridge {
     maxTokens?: number;
     temperature?: number;
   }): Promise<string> {
-    const envTimeout = Number.parseInt(
-      process.env.ELIZA_DEVICE_GENERATE_TIMEOUT_MS?.trim() ?? "",
-      10,
-    );
-    const timeoutMs =
-      Number.isFinite(envTimeout) && envTimeout > 0
-        ? envTimeout
-        : DEFAULT_CALL_TIMEOUT_MS;
+    const timeoutMs = resolveDeviceCallTimeoutMs();
 
     const correlationId = randomUUID();
     const request: AgentOutbound = {


### PR DESCRIPTION
# Relates to

No separate issue — the defect is described in full below.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is built directly on the current `origin/develop` tree, so it applies with zero conflicts.
- [x] Focused tests and scoped lint were run; results are quoted below. Root `bun run verify` was not run green: `develop` currently carries unrelated `@elizaos/agent` Biome formatter diagnostics, the same blocker recorded in #24174.
- [x] A reviewer can confirm the change from the mutation output below without reading the code.

# Sync with develop

- [x] Built on the current `origin/develop` tree; zero conflicts.
- [x] Exact unrelated blocker documented above.

# Risks

Low. One environment parser, resolved once instead of twice. The `> 0` range check is unchanged and the signed form `parseInt` accepted is preserved, so only strings that could not be honoured change behaviour.

# Background

## What does this PR do?

Both device-bridge round-trips parse their timeout inline, twice, identically:

```ts
const envTimeout = Number.parseInt(
  process.env.ELIZA_DEVICE_GENERATE_TIMEOUT_MS?.trim() ?? "",
  10,
);
const timeoutMs =
  Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : DEFAULT_CALL_TIMEOUT_MS;
```

`parseInt` stops at the first non-digit, so `ELIZA_DEVICE_GENERATE_TIMEOUT_MS=5junk` yields `5` — a **5ms budget that aborts every device generate and embed call** before the device can answer, instead of falling back to the 60s default. `NaN` is the only malformed input the guard catches.

## What kind of change is this?

Bug fix (non-breaking).

## Approach

Resolve the timeout once in `resolveDeviceCallTimeoutMs`, requiring the whole trimmed value to be a decimal integer. The two identical inline copies become one call, so the parse cannot drift between the embed and generate paths. The optional leading sign is kept because `parseInt` accepted it, and the `> 0` check stays the range authority.

The helper is exported for direct unit coverage, matching the other env resolvers in this codebase (`resolveTextTimeoutMs`, `getDocumentsServiceTimeoutMs`) — so the assertion is on a resolved value rather than on call timing.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Start with the mutation block below: it reproduces develop's exact parse behind the same exported name and shows the 5ms budget.

## Detailed testing steps

| Gate | Result |
| --- | --- |
| new `device-bridge.timeout.test.ts` | 4 passed |
| `biome check` (both changed files) | clean |

Mutation resistance:

```
AssertionError: expected 5 to be 60000
AssertionError: expected 9007199254740992 to be 60000
Tests  2 failed | 2 passed (4)
```

The `+30000` and clean-value cases pass in **both** directions, so the signed form `parseInt` accepted is preserved rather than regressed.

# Evidence Gate

<!-- evidence-head:97745261a1e64c5dda2a2b74d3b129fb2b528237 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - the changed files are a non-rendering service module (.ts) and its test; no rendered component is touched`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - the changed files are a non-rendering service module (.ts) and its test; no rendered component is touched`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough `N/A - the observable behaviour is the resolved timeout value, shown by the mutation-proof output quoted below`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - no service is started by this change; the resolver is exercised directly by the unit suite quoted below`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs `N/A - no request/response or rendered state changes; only how an env string is parsed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - no model, prompt, provider or action path is changed; this is an environment-variable parser`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - no domain record is produced; the observable output is the resolved timeout, asserted in the tests`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review `N/A - the change has no rendered visual surface`.

# Attribution

- Found by OpenAI `gpt-5.6-sol` via Codex (AgentRouter) during a numeric-input validation sweep of `packages/ui`.
- Independent verification, the exported-helper surface, the signed-form preservation, and the mutation proof by Claude Code (`claude-opus-5`).