### PR TITLE
fix(cloud): fence active billing cancellation authority

### DIFF
--- a/packages/cloud/shared/src/lib/services/active-billing-numeric-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/active-billing-numeric-fail-closed.test.ts
@@ -38,6 +38,7 @@ let dbWriteUpdateRows: Array<Record<string, unknown>> | null = null;
 let containerInfrastructureCalls = 0;
 let agentInfrastructureCalls = 0;
 let lastAgentSuspendParams: Record<string, unknown> | null = null;
+let agentInfrastructureMutation: (() => Promise<void>) | null = null;
 
 // Identify which fixture a `.from(table)` call wants without importing the real
 // drizzle table objects: the schema modules export named tables, and the real
@@ -124,6 +125,7 @@ mock.module("./provisioning-jobs", () => ({
     enqueueAgentSuspendOnce: async (params: Record<string, unknown>) => {
       agentInfrastructureCalls += 1;
       lastAgentSuspendParams = params;
+      await agentInfrastructureMutation?.();
     },
     enqueueAgentDeleteOnce: async () => {
       agentInfrastructureCalls += 1;
@@ -176,7 +178,7 @@ const baseAgent = (overrides: Record<string, unknown> = {}) => ({
   last_billed_at: null,
   last_backup_at: null,
   scheduled_shutdown_at: null,
-  execution_tier: "dedicated",
+  execution_tier: "dedicated-always",
   ...overrides,
 });
 
@@ -199,6 +201,7 @@ beforeEach(() => {
   containerInfrastructureCalls = 0;
   agentInfrastructureCalls = 0;
   lastAgentSuspendParams = null;
+  agentInfrastructureMutation = null;
 });
 
 // ── Parser boundary (exhaustive) ─────────────────────────────────────────────
@@ -410,14 +413,17 @@ describe("cancelResource fail-closed before side effects", () => {
   });
 
   test("deletion winning the billing CAS returns an explicit conflict instead of fake suspension", async () => {
-    agentRows = [
-      baseAgent({
-        deletion_attempt_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-        deletion_started_at: new Date("2026-07-23T12:30:00.000Z"),
-        status: "deletion_pending",
-        billing_status: "active",
-      }),
-    ];
+    agentRows = [baseAgent()];
+    agentInfrastructureMutation = async () => {
+      agentRows = [
+        baseAgent({
+          deletion_attempt_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          deletion_started_at: new Date("2026-07-23T12:30:00.000Z"),
+          status: "deletion_pending",
+          billing_status: "active",
+        }),
+      ];
+    };
     dbWriteUpdateRows = [];
 
     try {

--- a/packages/cloud/shared/src/lib/services/active-billing-pool-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/active-billing-pool-authority.pglite.test.ts
@@ -19,7 +19,7 @@ process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
 
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../db/client";
-import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import { agentSandboxes, CONTAINER_BACKED_EXECUTION_TIERS } from "../../db/schemas/agent-sandboxes";
 import { apiKeys } from "../../db/schemas/api-keys";
 import { containers } from "../../db/schemas/containers";
 import { creditTransactions } from "../../db/schemas/credit-transactions";
@@ -36,6 +36,8 @@ let userId = "";
 let enqueueSuspendCalls = 0;
 let enqueueDeleteCalls = 0;
 let triggerImmediateCalls = 0;
+let enqueueSuspendMutation: (() => Promise<void>) | null = null;
+let enqueueSuspendFailure: Error | null = null;
 let restoredSpies: Array<{ mockRestore: () => void }> = [];
 
 beforeAll(async () => {
@@ -56,9 +58,13 @@ beforeEach(async () => {
   enqueueSuspendCalls = 0;
   enqueueDeleteCalls = 0;
   triggerImmediateCalls = 0;
+  enqueueSuspendMutation = null;
+  enqueueSuspendFailure = null;
   restoredSpies = [
     spyOn(provisioningJobService, "enqueueAgentSuspendOnce").mockImplementation(async () => {
       enqueueSuspendCalls += 1;
+      await enqueueSuspendMutation?.();
+      if (enqueueSuspendFailure) throw enqueueSuspendFailure;
       return { job: { id: crypto.randomUUID() } as never, created: true };
     }),
     spyOn(provisioningJobService, "enqueueAgentDeleteOnce").mockImplementation(async () => {
@@ -98,16 +104,34 @@ afterAll(async () => {
   await closeDatabaseConnectionsForTests();
 });
 
-async function seedDedicated(poolStatus: "unclaimed" | null): Promise<string> {
+async function seedAgent(
+  options: {
+    executionTier?: string;
+    poolStatus?: "unclaimed" | null;
+    deletedAt?: Date | null;
+    deletionAttemptId?: string | null;
+    deletionStartedAt?: Date | null;
+  } = {},
+): Promise<string> {
+  const {
+    executionTier = "dedicated-always",
+    poolStatus = null,
+    deletedAt = null,
+    deletionAttemptId = null,
+    deletionStartedAt = null,
+  } = options;
   const [row] = await dbWrite
     .insert(agentSandboxes)
     .values({
       organization_id: organizationId,
       user_id: userId,
-      agent_name: poolStatus === null ? "claimed-user-agent" : "sentinel-capacity",
+      agent_name: poolStatus === null ? `${executionTier}-agent` : "sentinel-capacity",
       status: "running",
-      execution_tier: "dedicated-always",
+      execution_tier: executionTier as never,
       pool_status: poolStatus,
+      deleted_at: deletedAt,
+      deletion_attempt_id: deletionAttemptId,
+      deletion_started_at: deletionStartedAt,
       billing_status: "active",
       last_billed_at: new Date("2026-08-20T00:00:00.000Z"),
       node_id: "node-1",
@@ -115,6 +139,38 @@ async function seedDedicated(poolStatus: "unclaimed" | null): Promise<string> {
     })
     .returning();
   return row.id;
+}
+
+async function seedDedicated(poolStatus: "unclaimed" | null): Promise<string> {
+  return seedAgent({ poolStatus });
+}
+
+async function expectSuspendAuthorityConflict(
+  agentId: string,
+  mutateAuthority: () => Promise<void>,
+): Promise<void> {
+  enqueueSuspendMutation = mutateAuthority;
+
+  await expect(
+    activeBillingService.cancelResource({
+      organizationId,
+      resourceId: agentId,
+      resourceType: "agent_sandbox",
+    }),
+  ).rejects.toMatchObject({ status: 409, code: "session_not_ready" });
+
+  expect(enqueueSuspendCalls).toBe(1);
+  expect(triggerImmediateCalls).toBe(1);
+  const [stored] = await dbWrite
+    .select({ billing_status: agentSandboxes.billing_status })
+    .from(agentSandboxes)
+    .where(eq(agentSandboxes.id, agentId));
+  expect(stored.billing_status).toBe("active");
+  expect(
+    (await activeBillingService.listActiveResources(organizationId)).map(
+      (resource) => resource.resourceId,
+    ),
+  ).not.toContain(agentId);
 }
 
 describe("active billing warm-pool authority", () => {
@@ -164,6 +220,194 @@ describe("active billing warm-pool authority", () => {
       .select({ billing_status: agentSandboxes.billing_status })
       .from(agentSandboxes)
       .where(eq(agentSandboxes.id, claimedId));
+    expect(stored.billing_status).toBe("suspended");
+  });
+
+  test("all canonical container-backed tiers remain listed and cancellable", async () => {
+    const seeded = await Promise.all(
+      CONTAINER_BACKED_EXECUTION_TIERS.map(async (executionTier) => ({
+        executionTier,
+        id: await seedAgent({ executionTier }),
+      })),
+    );
+
+    const listedIds = (await activeBillingService.listActiveResources(organizationId)).map(
+      (resource) => resource.resourceId,
+    );
+    for (const { id } of seeded) expect(listedIds).toContain(id);
+
+    for (const { id } of seeded) {
+      await expect(
+        activeBillingService.cancelResource({
+          organizationId,
+          resourceId: id,
+          resourceType: "agent_sandbox",
+        }),
+      ).resolves.toMatchObject({ stoppedBilling: true });
+    }
+    expect(enqueueSuspendCalls).toBe(CONTAINER_BACKED_EXECUTION_TIERS.length);
+    expect(triggerImmediateCalls).toBe(CONTAINER_BACKED_EXECUTION_TIERS.length);
+
+    for (const { id } of seeded) {
+      const [stored] = await dbWrite
+        .select({ billing_status: agentSandboxes.billing_status })
+        .from(agentSandboxes)
+        .where(eq(agentSandboxes.id, id));
+      expect(stored.billing_status).toBe("suspended");
+    }
+  });
+
+  test("shared and unknown execution tiers are neither listed nor cancellable", async () => {
+    const sharedId = await seedAgent({ executionTier: "shared" });
+    const unknownId = await seedAgent({ executionTier: "future-container-tier" });
+
+    const listedIds = (await activeBillingService.listActiveResources(organizationId)).map(
+      (resource) => resource.resourceId,
+    );
+    expect(listedIds).not.toContain(sharedId);
+    expect(listedIds).not.toContain(unknownId);
+
+    for (const resourceId of [sharedId, unknownId]) {
+      await expect(
+        activeBillingService.cancelResource({
+          organizationId,
+          resourceId,
+          resourceType: "agent_sandbox",
+        }),
+      ).rejects.toThrow("Billable resource not found");
+    }
+    expect(enqueueSuspendCalls).toBe(0);
+    expect(triggerImmediateCalls).toBe(0);
+    for (const resourceId of [sharedId, unknownId]) {
+      const [stored] = await dbWrite
+        .select({ billing_status: agentSandboxes.billing_status })
+        .from(agentSandboxes)
+        .where(eq(agentSandboxes.id, resourceId));
+      expect(stored.billing_status).toBe("active");
+    }
+  });
+
+  test("soft-deleted and deletion-owned rows are neither listed nor cancellable", async () => {
+    const deletedId = await seedAgent({ deletedAt: new Date("2026-08-22T10:00:00.000Z") });
+    const deletionOwnedId = await seedAgent({
+      deletionAttemptId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      deletionStartedAt: new Date("2026-08-22T10:00:00.000Z"),
+    });
+
+    const listedIds = (await activeBillingService.listActiveResources(organizationId)).map(
+      (resource) => resource.resourceId,
+    );
+    expect(listedIds).not.toContain(deletedId);
+    expect(listedIds).not.toContain(deletionOwnedId);
+
+    for (const resourceId of [deletedId, deletionOwnedId]) {
+      await expect(
+        activeBillingService.cancelResource({
+          organizationId,
+          resourceId,
+          resourceType: "agent_sandbox",
+        }),
+      ).rejects.toThrow("Billable resource not found");
+    }
+    expect(enqueueSuspendCalls).toBe(0);
+    expect(triggerImmediateCalls).toBe(0);
+    for (const resourceId of [deletedId, deletionOwnedId]) {
+      const [stored] = await dbWrite
+        .select({ billing_status: agentSandboxes.billing_status })
+        .from(agentSandboxes)
+        .where(eq(agentSandboxes.id, resourceId));
+      expect(stored.billing_status).toBe("active");
+    }
+  });
+
+  test("a concurrent transition to Shared wins over billing suspension", async () => {
+    const agentId = await seedDedicated(null);
+
+    await expectSuspendAuthorityConflict(agentId, async () => {
+      await dbWrite
+        .update(agentSandboxes)
+        .set({ execution_tier: "shared" })
+        .where(eq(agentSandboxes.id, agentId));
+    });
+  });
+
+  test("a concurrent transition back to pool authority wins over billing suspension", async () => {
+    const agentId = await seedDedicated(null);
+
+    await expectSuspendAuthorityConflict(agentId, async () => {
+      await dbWrite
+        .update(agentSandboxes)
+        .set({ pool_status: "unclaimed" })
+        .where(eq(agentSandboxes.id, agentId));
+    });
+  });
+
+  test("a concurrent deletion attempt wins over billing suspension", async () => {
+    const agentId = await seedDedicated(null);
+
+    await expectSuspendAuthorityConflict(agentId, async () => {
+      await dbWrite
+        .update(agentSandboxes)
+        .set({
+          deletion_attempt_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          deletion_started_at: new Date("2026-08-22T10:00:00.000Z"),
+        })
+        .where(eq(agentSandboxes.id, agentId));
+    });
+  });
+
+  test("a concurrent soft deletion wins over billing suspension", async () => {
+    const agentId = await seedDedicated(null);
+
+    await expectSuspendAuthorityConflict(agentId, async () => {
+      await dbWrite
+        .update(agentSandboxes)
+        .set({ deleted_at: new Date("2026-08-22T10:00:00.000Z") })
+        .where(eq(agentSandboxes.id, agentId));
+    });
+  });
+
+  test("a row deleted concurrently retains the explicit deleted result", async () => {
+    const agentId = await seedDedicated(null);
+    enqueueSuspendMutation = async () => {
+      await dbWrite.delete(agentSandboxes).where(eq(agentSandboxes.id, agentId));
+    };
+
+    await expect(
+      activeBillingService.cancelResource({
+        organizationId,
+        resourceId: agentId,
+        resourceType: "agent_sandbox",
+      }),
+    ).resolves.toMatchObject({
+      stoppedBilling: true,
+      message: "Managed agent was deleted while billing cancellation was in progress.",
+      resource: { resourceId: agentId, status: "deleted", billingStatus: "suspended" },
+    });
+    expect(enqueueSuspendCalls).toBe(1);
+    expect(triggerImmediateCalls).toBe(1);
+  });
+
+  test("an enqueue failure still suspends billing while authority remains valid", async () => {
+    const agentId = await seedDedicated(null);
+    enqueueSuspendFailure = new Error("queue unavailable");
+
+    await expect(
+      activeBillingService.cancelResource({
+        organizationId,
+        resourceId: agentId,
+        resourceType: "agent_sandbox",
+      }),
+    ).resolves.toMatchObject({
+      stoppedBilling: true,
+      infrastructureAction: { attempted: true, status: "failed", error: "queue unavailable" },
+    });
+    expect(enqueueSuspendCalls).toBe(1);
+    expect(triggerImmediateCalls).toBe(0);
+    const [stored] = await dbWrite
+      .select({ billing_status: agentSandboxes.billing_status })
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, agentId));
     expect(stored.billing_status).toBe("suspended");
   });
 });

--- a/packages/cloud/shared/src/lib/services/active-billing.ts
+++ b/packages/cloud/shared/src/lib/services/active-billing.ts
@@ -5,9 +5,9 @@
  * one primary-database observation boundary.
  */
 
-import { and, desc, eq, inArray, isNotNull, isNull, or, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, isNull, or } from "drizzle-orm";
 import { type Database, dbRead, dbWrite } from "../../db/client";
-import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import { agentSandboxes, CONTAINER_BACKED_EXECUTION_TIERS } from "../../db/schemas/agent-sandboxes";
 import { containers } from "../../db/schemas/containers";
 import { creditTransactions } from "../../db/schemas/credit-transactions";
 import type { AppEnv } from "../../types/cloud-worker-env";
@@ -80,6 +80,16 @@ function cancelEndpoint(resource: BillableResourceType, id: string): string {
   return `/api/v1/billing/resources/${id}/cancel?resourceType=${resource}`;
 }
 
+/** Canonical authority for user-owned compute that this billing surface may mutate. */
+function activeBillingAgentAuthorityPredicate() {
+  return and(
+    inArray(agentSandboxes.execution_tier, [...CONTAINER_BACKED_EXECUTION_TIERS]),
+    isNull(agentSandboxes.pool_status),
+    isNull(agentSandboxes.deleted_at),
+    isNull(agentSandboxes.deletion_attempt_id),
+  );
+}
+
 function detectLedgerResource(metadata: Record<string, unknown>): {
   resourceType: BillingLedgerEntry["resourceType"];
   resourceId: string | null;
@@ -135,8 +145,7 @@ class ActiveBillingService {
         .where(
           and(
             eq(agentSandboxes.organization_id, organizationId),
-            sql`${agentSandboxes.execution_tier} <> 'shared'`,
-            isNull(agentSandboxes.pool_status),
+            activeBillingAgentAuthorityPredicate(),
             inArray(agentSandboxes.billing_status, ["active", "warning", "shutdown_pending"]),
             or(
               eq(agentSandboxes.status, "running"),
@@ -370,8 +379,9 @@ class ActiveBillingService {
     }
 
     if (!resourceType || resourceType === "agent_sandbox") {
-      // pool_status is the server-owned capacity authority. Authorize against
-      // the primary immediately before enqueueing any infrastructure side effect.
+      // Authorize against the primary immediately before enqueueing any
+      // infrastructure side effect. The final billing write repeats the same
+      // predicate so a concurrent tier, pool, or deletion transition wins.
       const [agent] = await dbWrite
         .select()
         .from(agentSandboxes)
@@ -379,8 +389,7 @@ class ActiveBillingService {
           and(
             eq(agentSandboxes.id, resourceId),
             eq(agentSandboxes.organization_id, organizationId),
-            sql`${agentSandboxes.execution_tier} <> 'shared'`,
-            isNull(agentSandboxes.pool_status),
+            activeBillingAgentAuthorityPredicate(),
           ),
         )
         .limit(1);
@@ -443,27 +452,39 @@ class ActiveBillingService {
             and(
               eq(agentSandboxes.id, resourceId),
               eq(agentSandboxes.organization_id, organizationId),
-              isNull(agentSandboxes.pool_status),
-              sql`${agentSandboxes.deletion_attempt_id} IS NULL`,
+              activeBillingAgentAuthorityPredicate(),
             ),
           )
           .returning();
-        const effective =
-          updated ??
-          (
-            await dbWrite
-              .select()
-              .from(agentSandboxes)
-              .where(
-                and(
-                  eq(agentSandboxes.id, resourceId),
-                  eq(agentSandboxes.organization_id, organizationId),
-                  isNull(agentSandboxes.pool_status),
-                ),
-              )
-              .limit(1)
-          )[0];
-        if (!effective) {
+        if (!updated) {
+          const [current] = await dbWrite
+            .select()
+            .from(agentSandboxes)
+            .where(
+              and(
+                eq(agentSandboxes.id, resourceId),
+                eq(agentSandboxes.organization_id, organizationId),
+              ),
+            )
+            .limit(1);
+          if (current) {
+            throw new ApiError(
+              409,
+              "session_not_ready",
+              current.deletion_attempt_id || current.deleted_at
+                ? "Managed agent deletion is in progress"
+                : "Managed agent billing authority changed",
+              {
+                agentId: current.id,
+                status: current.status,
+                billingStatus: current.billing_status,
+                executionTier: current.execution_tier,
+                poolStatus: current.pool_status,
+                deletionAttemptId: current.deletion_attempt_id,
+                deletedAt: iso(current.deleted_at),
+              },
+            );
+          }
           return {
             stoppedBilling: true,
             message: "Managed agent was deleted while billing cancellation was in progress.",
@@ -491,13 +512,6 @@ class ActiveBillingService {
             },
           };
         }
-        if (!updated) {
-          throw new ApiError(409, "session_not_ready", "Managed agent deletion is in progress", {
-            agentId: effective.id,
-            status: effective.status,
-            billingStatus: effective.billing_status,
-          });
-        }
 
         return {
           stoppedBilling: true,
@@ -508,20 +522,20 @@ class ActiveBillingService {
           infrastructureAction,
           resource: {
             resourceType: "agent_sandbox",
-            resourceId: effective.id,
-            name: effective.agent_name ?? effective.id.slice(0, 8),
-            status: effective.status,
-            billingStatus: effective.billing_status,
+            resourceId: updated.id,
+            name: updated.agent_name ?? updated.id.slice(0, 8),
+            status: updated.status,
+            billingStatus: updated.billing_status,
             unitPrice,
             billingInterval: "hour",
-            lastBilledAt: iso(effective.last_billed_at),
+            lastBilledAt: iso(updated.last_billed_at),
             nextBillingAt: null,
             estimatedNextBillingAt: null,
             totalBilled,
-            cancelEndpoint: cancelEndpoint("agent_sandbox", effective.id),
+            cancelEndpoint: cancelEndpoint("agent_sandbox", updated.id),
             cancelAction: "suspend_billing",
             metadata: {
-              characterId: effective.character_id,
+              characterId: updated.character_id,
               cancelledAt: now.toISOString(),
               mode,
               infrastructureAction,


### PR DESCRIPTION
# Relates to

- #22947 — micro-slice I: close the local active-billing authority race without claiming the provider stop is fully closed.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` from fresh `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated verify blocker is recorded below.
- [x] A reviewer can confirm the boundary from focused real-PGlite race tests and two independent exact-head reviews.

# Sync with develop

- [x] Based on current `origin/develop@9c1fc32c0def7f3da4d40d54d88ac343e24c3a97`; zero conflicts.
- [x] The exact unrelated root-verify blocker is documented in **Known gaps / failures**.

# Risks

Medium. This is a money and shutdown-admission boundary. A predicate that is too broad could suspend billing for Shared or server-owned pool capacity; one that is too narrow could prevent a legitimate container owner from cancelling billing. The implementation reuses the schema's canonical explicit container-tier allowlist, repeats the same authority in the final atomic update, and exercises every allowed tier plus initial and concurrent loss-of-authority cases against PGlite.

# Background

## What does this PR do?

The active-billing surface previously authorized an agent from one primary read, enqueued infrastructure work, and then suspended billing with a weaker predicate. During that gap, the sandbox could become Shared, return to warm-pool authority, or enter deletion. The final write could still suspend the newly ineligible row, and the old fallback could misreport a present pool-owned row as deleted.

This PR centralizes active-billing agent authority as:

- `execution_tier IN ('dedicated-lazy', 'dedicated-always', 'custom')`;
- `pool_status IS NULL`;
- `deleted_at IS NULL`;
- `deletion_attempt_id IS NULL`.

The same predicate now protects resource listing, the initial cancellation read, and the final billing-status update. If that update loses authority, the service re-reads only by exact `(id, organization_id)` identity: a still-present but ineligible row returns `409 session_not_ready`; a physically deleted row retains the explicit deleted result. A genuine enqueue failure still suspends billing while authority remains valid, preserving the existing financial partial-success contract.

The historical numeric test fixture now uses a canonical tier and injects deletion ownership during enqueue, so it no longer passes through a mock-only impossible starting state.

This slice intentionally does not claim that an already-enqueued asynchronous provider action is safe. Suspend-specific and `authorization: "billing_request"` delete guards in `provisioning-jobs.ts` / `eliza-sandbox.ts`, final worker/provider revalidation, stop-intent recovery filtering, and the ordered historical intent/job/lease cutover remain separate work after #24162 and #23949.

Historical authors inventoried before implementation: Claude Fable 5, ngngocnhan1997-hub, NubsCarson, Shaw, Stan. No open PR or later #22947 claim overlapped these three files when the slice was claimed.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No user-facing documentation change is required. This tightens an existing internal billing authority contract.

# Testing

## Where should a reviewer start?

1. `packages/cloud/shared/src/lib/services/active-billing.ts`
2. `packages/cloud/shared/src/lib/services/active-billing-pool-authority.pglite.test.ts`
3. `packages/cloud/shared/src/lib/services/active-billing-numeric-fail-closed.test.ts`

## Detailed testing steps

Exact candidate: `9235d387958ed89a5b856cacedf7aa7bfd594dcc`  
Base: `9c1fc32c0def7f3da4d40d54d88ac343e24c3a97`  
Toolchain: Node `24.15.0`, Bun `1.3.14`.

- `bun --config=/dev/null test packages/cloud/shared/src/lib/services/active-billing-pool-authority.pglite.test.ts`
  - 12 tests pass, 0 fail, 65 expect calls.
  - Covers all three canonical container-backed tiers; initial Shared, unknown-tier, pool, soft-delete, and deletion-owned exclusions; concurrent transitions to Shared, pool, deletion ownership, soft-delete, and physical deletion; and genuine enqueue failure.
- `bun --config=/dev/null test packages/cloud/shared/src/lib/services/active-billing-numeric-fail-closed.test.ts`
  - 26 tests pass, 0 fail, 45 expect calls.
  - Preserves numeric fail-closed behavior and models deletion ownership changing during enqueue before the billing CAS.
- `bun run --cwd packages/cloud/shared typecheck` — passes.
- `bunx @biomejs/biome check <the three changed files>` — passes.
- `bun run --cwd packages/cloud/shared check:tenant-scope` — passes across 128 repository files.
- `git diff --check origin/develop...HEAD` — passes.
- Two independent exact-head reviews found no P0–P3 source or test finding after their two initial P3 test-coverage observations were fixed and re-reviewed.

Baseline by exact test name on clean `origin/develop@9c1fc32c0def7f3da4d40d54d88ac343e24c3a97`:

- `active billing warm-pool authority > list exposes the claimed Dedicated resource but never its pool-owned sibling` — passes.
- `active billing warm-pool authority > pool capacity cannot be cancelled or mutated through the billing surface` — passes.
- `active billing warm-pool authority > a claimed slot remains cancellable and billable once pool_status is null` — passes.
- `cancelResource fail-closed before side effects > funded explicit agent cancellation enqueues unconditional user stop authority` — passes.
- `cancelResource fail-closed before side effects > deletion winning the billing CAS returns an explicit conflict instead of fake suspension` — passes, but its old mock setup used the non-canonical `dedicated` fixture; this PR makes the scenario production-reachable.
- The new Shared/unknown/deleted exclusions and concurrent Shared/pool/deletion/soft-delete race cases are absent on the base.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:9235d387958ed89a5b856cacedf7aa7bfd594dcc -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Backend-only billing authority change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Backend-only billing authority change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - No user-driven visual flow or frontend behavior changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - No live customer billing or agent state was mutated; real-PGlite tests exercise the exact database transition boundary.
<!-- evidence-row:frontend-logs -->
- [x] N/A - No frontend code, console behavior, or browser request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - No agent prompt, action, provider, model, or LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - No external durable artifact was created; deterministic PGlite row state is asserted in the focused tests.
<!-- evidence-row:ocr-review -->
- [x] N/A - No rendered visual surface or visible text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - No prompt, action, provider, model, or LLM behavior changes.

## Backend + frontend logs

N/A - Exercising this race against a live path would mutate customer billing and agent shutdown authority. The focused suites use the real service and database predicates against PGlite and assert exact state transitions and non-transitions.

## Screenshots (before / after) + video walkthrough

N/A - Backend-only change with no UI surface.

## Audio / voice walkthrough

N/A - No audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- On exact head `9235d387958ed89a5b856cacedf7aa7bfd594dcc`, `bun run verify` reaches the root Turbo typecheck/lint matrix and fails in unrelated `@elizaos/agent#lint:check` on five existing Biome formatting errors under `packages/agent`. No `packages/agent` file is in this three-file PR; those blobs are unchanged from the base. The changed files, `cloud-shared` typecheck, focused Biome, tenant-scope gate, and both focused suites pass.
- The local `build:core` helper completes the core bundles but its later package-verification step cannot execute the bundled fallback `npm` shell wrapper through Node. This toolchain-only helper failure does not affect the successful focused tests or package typecheck and changes no tracked file.
- The pre-provider enqueue/worker/service guards and historical intent cleanup are intentionally out of scope. No live billing row, job, intent, worker, migration, deployment, or provider resource was changed.
- Hosted CI is not claimed as green; repository concurrency may queue or cancel jobs, and only exact-head local exit codes are used as proof.

AI provider/model: OpenAI / GPT-5.6
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-active-billing-authority]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5.6","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
