### PR TITLE
feat(testing): add cross-process synthetic namespace leases

### DIFF
--- a/packages/cloud/shared/README.md
+++ b/packages/cloud/shared/README.md
@@ -28,6 +28,10 @@ docs/                        WHY docs (provisioning, messaging gateways)
 
 Import via subpath: `@elizaos/cloud-shared/billing`, `/db`, `/db/repositories/apps`, `/lib`, `/lib/services/<x>`, `/types`. Exports map (`package.json`): `.` `./billing` `./db` `./db/*` `./lib` `./lib/*` `./types` `./types/*`.
 
+Synthetic test consumers use `/db/repositories/synthetic-environment-leases`.
+Its guarded callback receives the same locked PostgreSQL/PGlite transaction as
+the generation check, so an old reset generation cannot commit afterward.
+
 `src/lib/` is server-only — browser code lives in `cloud-frontend`. Only the isomorphic helpers (`billing/`, math/string/validation) are safe to import from the frontend.
 
 ## Commands

--- a/packages/cloud/shared/README.md
+++ b/packages/cloud/shared/README.md
@@ -31,6 +31,9 @@ Import via subpath: `@elizaos/cloud-shared/billing`, `/db`, `/db/repositories/ap
 Synthetic test consumers use `/db/repositories/synthetic-environment-leases`.
 Its guarded callback receives the same locked PostgreSQL/PGlite transaction as
 the generation check, so an old reset generation cannot commit afterward.
+The lease and subprocess authorities share the exact 512-character namespace
+validator. Treat a transaction/transport exception as ambiguous and reconcile
+the canonical snapshot before retrying an acquire, rollover, or release.
 
 `src/lib/` is server-only — browser code lives in `cloud-frontend`. Only the isomorphic helpers (`billing/`, math/string/validation) are safe to import from the frontend.
 

--- a/packages/cloud/shared/src/db/migrations/0299_synthetic_environment_leases.sql
+++ b/packages/cloud/shared/src/db/migrations/0299_synthetic_environment_leases.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS "synthetic_environment_leases" (
+	"namespace" text PRIMARY KEY NOT NULL,
+	"generation" integer NOT NULL,
+	"lease_id" uuid,
+	"owner_id" text,
+	"owner_process_id" integer,
+	"owner_host" text,
+	"acquired_at" timestamp with time zone,
+	"heartbeat_at" timestamp with time zone,
+	"expires_at" timestamp with time zone,
+	"released_at" timestamp with time zone,
+	"revision" integer NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "synthetic_environment_leases_generation_check" CHECK (
+		"generation" >= 0 AND "revision" >= 0
+	),
+	CONSTRAINT "synthetic_environment_leases_authority_shape_check" CHECK (
+		(
+			"lease_id" IS NULL
+			AND "owner_id" IS NULL
+			AND "owner_process_id" IS NULL
+			AND "owner_host" IS NULL
+			AND "expires_at" IS NULL
+		) OR (
+			"lease_id" IS NOT NULL
+			AND "owner_id" IS NOT NULL
+			AND "owner_host" IS NOT NULL
+			AND "acquired_at" IS NOT NULL
+			AND "heartbeat_at" IS NOT NULL
+			AND "expires_at" IS NOT NULL
+		)
+	)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "synthetic_environment_leases_expires_idx"
+	ON "synthetic_environment_leases" USING btree ("expires_at");

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1975,6 +1975,13 @@
       "when": 1793995200000,
       "tag": "0298_warm_pool_rate_segment_exemption",
       "breakpoints": true
+    },
+    {
+      "idx": 282,
+      "version": "7",
+      "when": 1793995200001,
+      "tag": "0299_synthetic_environment_leases",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/index.ts
+++ b/packages/cloud/shared/src/db/repositories/index.ts
@@ -127,6 +127,7 @@ export * from "./seo-artifacts";
 export * from "./seo-provider-calls";
 export * from "./seo-requests";
 export * from "./service-pricing";
+export * from "./synthetic-environment-leases";
 // ============================================
 // Token Redemptions (elizaOS payouts)
 // ============================================

--- a/packages/cloud/shared/src/db/repositories/synthetic-environment-leases.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/synthetic-environment-leases.pglite.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Exercises the Cloud synthetic lease repository on real PGlite transactions,
+ * including collision, generation fencing, rollback, and expiry recovery.
+ */
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV = "test";
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { pushSchema } from "drizzle-kit/api";
+import { eq } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../client";
+import { agentTable } from "../schemas/eliza";
+import { syntheticEnvironmentLeases } from "../schemas/synthetic-environment-leases";
+import { agentsRepository } from "./agents/agents";
+import { CloudSyntheticEnvironmentLeaseStore } from "./synthetic-environment-leases";
+
+const store = new CloudSyntheticEnvironmentLeaseStore();
+
+beforeAll(async () => {
+  const { apply } = await pushSchema(
+    { agentTable, syntheticEnvironmentLeases } as never,
+    dbWrite as never,
+  );
+  await apply();
+}, 60_000);
+
+beforeEach(async () => {
+  await dbWrite.delete(agentTable);
+  await dbWrite.delete(syntheticEnvironmentLeases);
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+function owner(ownerId: string) {
+  return { ownerId, processId: process.pid, host: "cloud-test-worker" };
+}
+
+describe("CloudSyntheticEnvironmentLeaseStore", () => {
+  it("admits one concurrent owner and returns canonical readback", async () => {
+    const attempts = await Promise.allSettled([
+      store.acquire({
+        namespace: "cloud:race",
+        owner: owner("worker-a"),
+        leaseDurationMs: 5_000,
+      }),
+      store.acquire({
+        namespace: "cloud:race",
+        owner: owner("worker-b"),
+        leaseDurationMs: 5_000,
+      }),
+    ]);
+    expect(attempts.filter((attempt) => attempt.status === "fulfilled")).toHaveLength(1);
+    const rejected = attempts.find((attempt) => attempt.status === "rejected");
+    expect(rejected).toMatchObject({
+      status: "rejected",
+      reason: { code: "SYNTHETIC_LEASE_COLLISION" },
+    });
+    expect(await store.read("cloud:race")).toEqual(
+      expect.objectContaining({ generation: 1, revision: 1, status: "active" }),
+    );
+  }, 30_000);
+
+  it("holds the generation lock across a production transaction callback", async () => {
+    const committedAgentId = "00000000-0000-4000-8000-000000000101";
+    const staleAgentId = "00000000-0000-4000-8000-000000000102";
+    const acquired = await store.acquire({
+      namespace: "cloud:guarded",
+      owner: owner("worker-a"),
+      leaseDurationMs: 5_000,
+    });
+    const heartbeat = await store.heartbeat({
+      authority: acquired.authority,
+      leaseDurationMs: 5_000,
+    });
+    expect(heartbeat).toEqual(
+      expect.objectContaining({
+        operation: "heartbeat",
+        snapshot: expect.objectContaining({ revision: 2, status: "active" }),
+      }),
+    );
+    const written = await store.withActiveGeneration(acquired.authority, async (tx) => {
+      return agentsRepository.create({ id: committedAgentId, name: "Generation One Agent" }, tx);
+    });
+    expect(written).toEqual(
+      expect.objectContaining({
+        value: true,
+        receipt: expect.objectContaining({ operation: "guarded-write" }),
+      }),
+    );
+
+    const rolled = await store.rollover({
+      authority: acquired.authority,
+      leaseDurationMs: 5_000,
+    });
+    expect(rolled.authority.generation).toBe(2);
+    await expect(
+      store.withActiveGeneration(acquired.authority, async (tx) => {
+        await agentsRepository.create({ id: staleAgentId, name: "Stale Agent" }, tx);
+      }),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_LEASE_LOST" });
+    expect(
+      await dbWrite
+        .select({ id: agentTable.id, name: agentTable.name })
+        .from(agentTable)
+        .where(eq(agentTable.id, committedAgentId)),
+    ).toEqual([{ id: committedAgentId, name: "Generation One Agent" }]);
+    expect(
+      await dbWrite
+        .select({ id: agentTable.id })
+        .from(agentTable)
+        .where(eq(agentTable.id, staleAgentId)),
+    ).toEqual([]);
+
+    await expect(
+      store.release({
+        ...rolled.authority,
+        owner: { ...rolled.authority.owner, ownerId: "worker-b" },
+      }),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_LEASE_LOST" });
+    expect((await store.release(rolled.authority)).snapshot.status).toBe("released");
+  });
+
+  it("rolls back a guarded write that outlives its lease", async () => {
+    const expiredAgentId = "00000000-0000-4000-8000-000000000103";
+    const acquired = await store.acquire({
+      namespace: "cloud:expiry-write",
+      owner: owner("worker-a"),
+      leaseDurationMs: 40,
+    });
+    await expect(
+      store.withActiveGeneration(acquired.authority, async (tx) => {
+        await agentsRepository.create({ id: expiredAgentId, name: "Expired Agent" }, tx);
+        await Bun.sleep(80);
+      }),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_LEASE_LOST" });
+    expect(
+      await dbWrite
+        .select({ id: agentTable.id })
+        .from(agentTable)
+        .where(eq(agentTable.id, expiredAgentId)),
+    ).toEqual([]);
+  });
+
+  it("recovers expiry and advances generations after clean release", async () => {
+    const expired = await store.acquire({
+      namespace: "cloud:recovery",
+      owner: owner("worker-a"),
+      leaseDurationMs: 30,
+    });
+    await Bun.sleep(60);
+    const recovered = await store.acquire({
+      namespace: "cloud:recovery",
+      owner: owner("worker-b"),
+      leaseDurationMs: 5_000,
+    });
+    expect(recovered).toEqual(
+      expect.objectContaining({
+        operation: "recover",
+        authority: expect.objectContaining({ generation: expired.authority.generation + 1 }),
+      }),
+    );
+    await store.release(recovered.authority);
+    const reacquired = await store.acquire({
+      namespace: "cloud:recovery",
+      owner: owner("worker-c"),
+      leaseDurationMs: 5_000,
+    });
+    expect(reacquired).toEqual(
+      expect.objectContaining({
+        operation: "acquire",
+        authority: expect.objectContaining({ generation: recovered.authority.generation + 1 }),
+      }),
+    );
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/synthetic-environment-leases.ts
+++ b/packages/cloud/shared/src/db/repositories/synthetic-environment-leases.ts
@@ -15,7 +15,11 @@ import type {
   SyntheticEnvironmentLeaseSnapshot,
   SyntheticEnvironmentLeaseStore,
 } from "@elizaos/shared/contracts/synthetic-environment-lease";
-import { SYNTHETIC_ENVIRONMENT_LEASE_VERSION } from "@elizaos/shared/contracts/synthetic-environment-lease";
+import {
+  isSyntheticEnvironmentNamespace,
+  SYNTHETIC_ENVIRONMENT_LEASE_VERSION,
+  SYNTHETIC_ENVIRONMENT_NAMESPACE_MAX_LENGTH,
+} from "@elizaos/shared/contracts/synthetic-environment-lease";
 import { eq } from "drizzle-orm";
 import type { DbTransaction } from "../client";
 import { dbWrite } from "../helpers";
@@ -27,6 +31,14 @@ import { readPostLockDatabaseNow } from "./primary-database-clock";
 
 const MAX_LEASE_DURATION_MS = 86_400_000;
 const IDENTIFIER_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:@-]{0,127}$/;
+
+function containsControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
 
 function invalidInput(message: string): ElizaError {
   return new ElizaError(message, {
@@ -43,14 +55,26 @@ function storageFailure(message: string, namespace: string): ElizaError {
   });
 }
 
-function validateIdentifier(value: string, field: string): string {
-  if (!IDENTIFIER_PATTERN.test(value)) {
+function validateNamespace(value: unknown, field: string): string {
+  if (!isSyntheticEnvironmentNamespace(value)) {
+    throw invalidInput(
+      `${field} must contain 1-${SYNTHETIC_ENVIRONMENT_NAMESPACE_MAX_LENGTH} non-control characters`,
+    );
+  }
+  return value;
+}
+
+function validateIdentifier(value: unknown, field: string): string {
+  if (typeof value !== "string" || !IDENTIFIER_PATTERN.test(value)) {
     throw invalidInput(`${field} must be 1-128 safe identifier characters and start alphanumeric`);
   }
   return value;
 }
 
 function validateOwner(owner: SyntheticEnvironmentLeaseOwner): SyntheticEnvironmentLeaseOwner {
+  if (typeof owner !== "object" || owner === null) {
+    throw invalidInput("owner must be an object");
+  }
   validateIdentifier(owner.ownerId, "owner.ownerId");
   if (
     owner.processId !== null &&
@@ -60,8 +84,9 @@ function validateOwner(owner: SyntheticEnvironmentLeaseOwner): SyntheticEnvironm
   ) {
     throw invalidInput("owner.processId must be a positive 32-bit integer or null");
   }
+  if (typeof owner.host !== "string") throw invalidInput("owner.host must be a string");
   const host = owner.host.trim();
-  if (host.length === 0 || host.length > 255 || /[\r\n\0]/.test(host)) {
+  if (host.length === 0 || host.length > 255 || containsControlCharacter(host)) {
     throw invalidInput("owner.host must contain 1-255 safe characters");
   }
   return { ...owner, host };
@@ -81,16 +106,19 @@ function validateDuration(leaseDurationMs: number): number {
 function validateAuthority(
   authority: SyntheticEnvironmentLeaseAuthority,
 ): SyntheticEnvironmentLeaseAuthority {
+  if (typeof authority !== "object" || authority === null) {
+    throw invalidInput("authority must be an object");
+  }
   if (authority.version !== SYNTHETIC_ENVIRONMENT_LEASE_VERSION) {
     throw invalidInput("authority.version is unsupported");
   }
-  validateIdentifier(authority.namespace, "authority.namespace");
+  const namespace = validateNamespace(authority.namespace, "authority.namespace");
   validateIdentifier(authority.leaseId, "authority.leaseId");
   validateOwner(authority.owner);
   if (!Number.isSafeInteger(authority.generation) || authority.generation < 1) {
     throw invalidInput("authority.generation must be a positive integer");
   }
-  return authority;
+  return { ...authority, namespace };
 }
 
 function rowOwner(row: SyntheticEnvironmentLease): SyntheticEnvironmentLeaseOwner | null {
@@ -205,7 +233,10 @@ export class CloudSyntheticEnvironmentLeaseStore
   async acquire(
     input: AcquireSyntheticEnvironmentLeaseInput,
   ): Promise<SyntheticEnvironmentLeaseReceipt> {
-    const namespace = validateIdentifier(input.namespace, "namespace");
+    if (typeof input !== "object" || input === null) {
+      throw invalidInput("acquire input must be an object");
+    }
+    const namespace = validateNamespace(input.namespace, "namespace");
     const owner = validateOwner(input.owner);
     const duration = validateDuration(input.leaseDurationMs);
     return dbWrite.transaction(async (tx) => {
@@ -263,7 +294,7 @@ export class CloudSyntheticEnvironmentLeaseStore
   }
 
   async read(namespace: string): Promise<SyntheticEnvironmentLeaseSnapshot | null> {
-    validateIdentifier(namespace, "namespace");
+    namespace = validateNamespace(namespace, "namespace");
     return dbWrite.transaction(async (tx) => {
       const row = await lockRow(tx, namespace);
       if (!row) return null;
@@ -275,18 +306,21 @@ export class CloudSyntheticEnvironmentLeaseStore
   async heartbeat(
     input: RefreshSyntheticEnvironmentLeaseInput,
   ): Promise<SyntheticEnvironmentLeaseReceipt> {
+    if (typeof input !== "object" || input === null) {
+      throw invalidInput("heartbeat input must be an object");
+    }
     const authority = validateAuthority(input.authority);
     const duration = validateDuration(input.leaseDurationMs);
     return dbWrite.transaction(async (tx) => {
       const row = await lockRow(tx, authority.namespace);
       const databaseNow = await readPostLockDatabaseNow(tx);
-      assertAuthorityMatches(row, authority, databaseNow);
+      const active = assertAuthorityMatches(row, authority, databaseNow);
       const [updated] = await tx
         .update(syntheticEnvironmentLeases)
         .set({
           heartbeat_at: databaseNow,
           expires_at: new Date(databaseNow.getTime() + duration),
-          revision: (row?.revision ?? 0) + 1,
+          revision: active.revision + 1,
           updated_at: databaseNow,
         })
         .where(eq(syntheticEnvironmentLeases.namespace, authority.namespace))
@@ -304,6 +338,9 @@ export class CloudSyntheticEnvironmentLeaseStore
   async rollover(
     input: RefreshSyntheticEnvironmentLeaseInput,
   ): Promise<SyntheticEnvironmentLeaseReceipt> {
+    if (typeof input !== "object" || input === null) {
+      throw invalidInput("rollover input must be an object");
+    }
     const authority = validateAuthority(input.authority);
     const duration = validateDuration(input.leaseDurationMs);
     return dbWrite.transaction(async (tx) => {

--- a/packages/cloud/shared/src/db/repositories/synthetic-environment-leases.ts
+++ b/packages/cloud/shared/src/db/repositories/synthetic-environment-leases.ts
@@ -1,0 +1,394 @@
+/**
+ * Owns Cloud synthetic namespace leases on the primary database clock. Row
+ * locks serialize reset generations with production repository mutations.
+ */
+
+import { randomUUID } from "node:crypto";
+import { ElizaError } from "@elizaos/core";
+import type {
+  AcquireSyntheticEnvironmentLeaseInput,
+  GuardedSyntheticEnvironmentWriteResult,
+  RefreshSyntheticEnvironmentLeaseInput,
+  SyntheticEnvironmentLeaseAuthority,
+  SyntheticEnvironmentLeaseOwner,
+  SyntheticEnvironmentLeaseReceipt,
+  SyntheticEnvironmentLeaseSnapshot,
+  SyntheticEnvironmentLeaseStore,
+} from "@elizaos/shared/contracts/synthetic-environment-lease";
+import { SYNTHETIC_ENVIRONMENT_LEASE_VERSION } from "@elizaos/shared/contracts/synthetic-environment-lease";
+import { eq } from "drizzle-orm";
+import type { DbTransaction } from "../client";
+import { dbWrite } from "../helpers";
+import {
+  type SyntheticEnvironmentLease,
+  syntheticEnvironmentLeases,
+} from "../schemas/synthetic-environment-leases";
+import { readPostLockDatabaseNow } from "./primary-database-clock";
+
+const MAX_LEASE_DURATION_MS = 86_400_000;
+const IDENTIFIER_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:@-]{0,127}$/;
+
+function invalidInput(message: string): ElizaError {
+  return new ElizaError(message, {
+    code: "SYNTHETIC_LEASE_INVALID_INPUT",
+    severity: "fatal",
+  });
+}
+
+function storageFailure(message: string, namespace: string): ElizaError {
+  return new ElizaError(message, {
+    code: "SYNTHETIC_LEASE_STORAGE_FAILURE",
+    severity: "fatal",
+    context: { namespace },
+  });
+}
+
+function validateIdentifier(value: string, field: string): string {
+  if (!IDENTIFIER_PATTERN.test(value)) {
+    throw invalidInput(`${field} must be 1-128 safe identifier characters and start alphanumeric`);
+  }
+  return value;
+}
+
+function validateOwner(owner: SyntheticEnvironmentLeaseOwner): SyntheticEnvironmentLeaseOwner {
+  validateIdentifier(owner.ownerId, "owner.ownerId");
+  if (
+    owner.processId !== null &&
+    (!Number.isSafeInteger(owner.processId) ||
+      owner.processId < 1 ||
+      owner.processId > 2_147_483_647)
+  ) {
+    throw invalidInput("owner.processId must be a positive 32-bit integer or null");
+  }
+  const host = owner.host.trim();
+  if (host.length === 0 || host.length > 255 || /[\r\n\0]/.test(host)) {
+    throw invalidInput("owner.host must contain 1-255 safe characters");
+  }
+  return { ...owner, host };
+}
+
+function validateDuration(leaseDurationMs: number): number {
+  if (
+    !Number.isSafeInteger(leaseDurationMs) ||
+    leaseDurationMs < 10 ||
+    leaseDurationMs > MAX_LEASE_DURATION_MS
+  ) {
+    throw invalidInput("leaseDurationMs must be an integer between 10ms and one day");
+  }
+  return leaseDurationMs;
+}
+
+function validateAuthority(
+  authority: SyntheticEnvironmentLeaseAuthority,
+): SyntheticEnvironmentLeaseAuthority {
+  if (authority.version !== SYNTHETIC_ENVIRONMENT_LEASE_VERSION) {
+    throw invalidInput("authority.version is unsupported");
+  }
+  validateIdentifier(authority.namespace, "authority.namespace");
+  validateIdentifier(authority.leaseId, "authority.leaseId");
+  validateOwner(authority.owner);
+  if (!Number.isSafeInteger(authority.generation) || authority.generation < 1) {
+    throw invalidInput("authority.generation must be a positive integer");
+  }
+  return authority;
+}
+
+function rowOwner(row: SyntheticEnvironmentLease): SyntheticEnvironmentLeaseOwner | null {
+  if (row.owner_id === null || row.owner_host === null) return null;
+  return {
+    ownerId: row.owner_id,
+    processId: row.owner_process_id,
+    host: row.owner_host,
+  };
+}
+
+function snapshot(
+  row: SyntheticEnvironmentLease,
+  databaseNow: Date,
+): SyntheticEnvironmentLeaseSnapshot {
+  const status =
+    row.lease_id === null
+      ? "released"
+      : row.expires_at !== null && row.expires_at.getTime() <= databaseNow.getTime()
+        ? "expired"
+        : "active";
+  return {
+    version: SYNTHETIC_ENVIRONMENT_LEASE_VERSION,
+    namespace: row.namespace,
+    generation: row.generation,
+    leaseId: row.lease_id,
+    owner: rowOwner(row),
+    acquiredAt: row.acquired_at?.toISOString() ?? null,
+    heartbeatAt: row.heartbeat_at?.toISOString() ?? null,
+    expiresAt: row.expires_at?.toISOString() ?? null,
+    releasedAt: row.released_at?.toISOString() ?? null,
+    revision: row.revision,
+    status,
+    observedAt: databaseNow.toISOString(),
+  };
+}
+
+function authorityFromRow(row: SyntheticEnvironmentLease): SyntheticEnvironmentLeaseAuthority {
+  const owner = rowOwner(row);
+  if (!row.lease_id || !owner) {
+    throw new ElizaError("Synthetic lease has no active authority", {
+      code: "SYNTHETIC_LEASE_LOST",
+      severity: "fatal",
+      context: { namespace: row.namespace, generation: row.generation },
+    });
+  }
+  return {
+    version: SYNTHETIC_ENVIRONMENT_LEASE_VERSION,
+    namespace: row.namespace,
+    generation: row.generation,
+    leaseId: row.lease_id,
+    owner,
+  };
+}
+
+function assertAuthorityMatches(
+  row: SyntheticEnvironmentLease | undefined,
+  authority: SyntheticEnvironmentLeaseAuthority,
+  databaseNow: Date,
+): SyntheticEnvironmentLease {
+  if (
+    !row ||
+    row.lease_id !== authority.leaseId ||
+    row.generation !== authority.generation ||
+    row.owner_id !== authority.owner.ownerId ||
+    row.owner_process_id !== authority.owner.processId ||
+    row.owner_host !== authority.owner.host ||
+    !row.expires_at ||
+    row.expires_at.getTime() <= databaseNow.getTime()
+  ) {
+    throw new ElizaError(
+      "Synthetic environment lease authority is stale, expired, or owned elsewhere",
+      {
+        code: "SYNTHETIC_LEASE_LOST",
+        severity: "fatal",
+        context: {
+          namespace: authority.namespace,
+          generation: authority.generation,
+          ownerId: authority.owner.ownerId,
+        },
+      },
+    );
+  }
+  return row;
+}
+
+async function lockRow(
+  tx: DbTransaction,
+  namespace: string,
+): Promise<SyntheticEnvironmentLease | undefined> {
+  const [row] = await tx
+    .select()
+    .from(syntheticEnvironmentLeases)
+    .where(eq(syntheticEnvironmentLeases.namespace, namespace))
+    .for("update")
+    .limit(1);
+  return row;
+}
+
+function receipt(
+  operation: SyntheticEnvironmentLeaseReceipt["operation"],
+  row: SyntheticEnvironmentLease,
+  databaseNow: Date,
+): SyntheticEnvironmentLeaseReceipt {
+  return { operation, authority: authorityFromRow(row), snapshot: snapshot(row, databaseNow) };
+}
+
+/** PostgreSQL/PGlite adapter used by Cloud workers and the local Cloud stack. */
+export class CloudSyntheticEnvironmentLeaseStore
+  implements SyntheticEnvironmentLeaseStore<DbTransaction>
+{
+  async acquire(
+    input: AcquireSyntheticEnvironmentLeaseInput,
+  ): Promise<SyntheticEnvironmentLeaseReceipt> {
+    const namespace = validateIdentifier(input.namespace, "namespace");
+    const owner = validateOwner(input.owner);
+    const duration = validateDuration(input.leaseDurationMs);
+    return dbWrite.transaction(async (tx) => {
+      await tx
+        .insert(syntheticEnvironmentLeases)
+        .values({ namespace, generation: 0, revision: 0 })
+        .onConflictDoNothing({ target: syntheticEnvironmentLeases.namespace });
+      const current = await lockRow(tx, namespace);
+      if (!current) {
+        throw new ElizaError("Synthetic lease row disappeared", {
+          code: "SYNTHETIC_LEASE_NOT_FOUND",
+          severity: "fatal",
+          context: { namespace },
+        });
+      }
+      const databaseNow = await readPostLockDatabaseNow(tx);
+      if (current.lease_id && current.expires_at && current.expires_at > databaseNow) {
+        throw new ElizaError("Synthetic environment namespace already has an active owner", {
+          code: "SYNTHETIC_LEASE_COLLISION",
+          severity: "fatal",
+          context: {
+            namespace,
+            generation: current.generation,
+            ownerId: current.owner_id,
+          },
+        });
+      }
+      const operation = current.lease_id ? "recover" : "acquire";
+      const [updated] = await tx
+        .update(syntheticEnvironmentLeases)
+        .set({
+          generation: current.generation + 1,
+          lease_id: randomUUID(),
+          owner_id: owner.ownerId,
+          owner_process_id: owner.processId,
+          owner_host: owner.host,
+          acquired_at: databaseNow,
+          heartbeat_at: databaseNow,
+          expires_at: new Date(databaseNow.getTime() + duration),
+          released_at: null,
+          revision: current.revision + 1,
+          updated_at: databaseNow,
+        })
+        .where(eq(syntheticEnvironmentLeases.namespace, namespace))
+        .returning();
+      if (!updated) {
+        throw new ElizaError("Synthetic lease update was not committed", {
+          code: "SYNTHETIC_LEASE_NOT_FOUND",
+          severity: "fatal",
+          context: { namespace },
+        });
+      }
+      return receipt(operation, updated, databaseNow);
+    });
+  }
+
+  async read(namespace: string): Promise<SyntheticEnvironmentLeaseSnapshot | null> {
+    validateIdentifier(namespace, "namespace");
+    return dbWrite.transaction(async (tx) => {
+      const row = await lockRow(tx, namespace);
+      if (!row) return null;
+      const databaseNow = await readPostLockDatabaseNow(tx);
+      return snapshot(row, databaseNow);
+    });
+  }
+
+  async heartbeat(
+    input: RefreshSyntheticEnvironmentLeaseInput,
+  ): Promise<SyntheticEnvironmentLeaseReceipt> {
+    const authority = validateAuthority(input.authority);
+    const duration = validateDuration(input.leaseDurationMs);
+    return dbWrite.transaction(async (tx) => {
+      const row = await lockRow(tx, authority.namespace);
+      const databaseNow = await readPostLockDatabaseNow(tx);
+      assertAuthorityMatches(row, authority, databaseNow);
+      const [updated] = await tx
+        .update(syntheticEnvironmentLeases)
+        .set({
+          heartbeat_at: databaseNow,
+          expires_at: new Date(databaseNow.getTime() + duration),
+          revision: (row?.revision ?? 0) + 1,
+          updated_at: databaseNow,
+        })
+        .where(eq(syntheticEnvironmentLeases.namespace, authority.namespace))
+        .returning();
+      if (!updated) {
+        throw storageFailure(
+          "Synthetic lease heartbeat update was not committed",
+          authority.namespace,
+        );
+      }
+      return receipt("heartbeat", updated, databaseNow);
+    });
+  }
+
+  async rollover(
+    input: RefreshSyntheticEnvironmentLeaseInput,
+  ): Promise<SyntheticEnvironmentLeaseReceipt> {
+    const authority = validateAuthority(input.authority);
+    const duration = validateDuration(input.leaseDurationMs);
+    return dbWrite.transaction(async (tx) => {
+      const row = await lockRow(tx, authority.namespace);
+      const databaseNow = await readPostLockDatabaseNow(tx);
+      const active = assertAuthorityMatches(row, authority, databaseNow);
+      const [updated] = await tx
+        .update(syntheticEnvironmentLeases)
+        .set({
+          generation: active.generation + 1,
+          lease_id: randomUUID(),
+          acquired_at: databaseNow,
+          heartbeat_at: databaseNow,
+          expires_at: new Date(databaseNow.getTime() + duration),
+          released_at: null,
+          revision: active.revision + 1,
+          updated_at: databaseNow,
+        })
+        .where(eq(syntheticEnvironmentLeases.namespace, authority.namespace))
+        .returning();
+      if (!updated) {
+        throw storageFailure(
+          "Synthetic lease rollover update was not committed",
+          authority.namespace,
+        );
+      }
+      return receipt("rollover", updated, databaseNow);
+    });
+  }
+
+  async release(
+    uncheckedAuthority: SyntheticEnvironmentLeaseAuthority,
+  ): Promise<SyntheticEnvironmentLeaseReceipt> {
+    const authority = validateAuthority(uncheckedAuthority);
+    return dbWrite.transaction(async (tx) => {
+      const row = await lockRow(tx, authority.namespace);
+      const databaseNow = await readPostLockDatabaseNow(tx);
+      const active = assertAuthorityMatches(row, authority, databaseNow);
+      const [released] = await tx
+        .update(syntheticEnvironmentLeases)
+        .set({
+          lease_id: null,
+          owner_id: null,
+          owner_process_id: null,
+          owner_host: null,
+          expires_at: null,
+          released_at: databaseNow,
+          revision: active.revision + 1,
+          updated_at: databaseNow,
+        })
+        .where(eq(syntheticEnvironmentLeases.namespace, authority.namespace))
+        .returning();
+      if (!released) {
+        throw storageFailure(
+          "Synthetic lease release update was not committed",
+          authority.namespace,
+        );
+      }
+      return {
+        operation: "release",
+        authority: authorityFromRow(active),
+        snapshot: snapshot(released, databaseNow),
+      };
+    });
+  }
+
+  async withActiveGeneration<T>(
+    uncheckedAuthority: SyntheticEnvironmentLeaseAuthority,
+    write: (transaction: DbTransaction) => T | Promise<T>,
+  ): Promise<GuardedSyntheticEnvironmentWriteResult<T>> {
+    const authority = validateAuthority(uncheckedAuthority);
+    return dbWrite.transaction(async (tx) => {
+      const initial = await lockRow(tx, authority.namespace);
+      const initialNow = await readPostLockDatabaseNow(tx);
+      assertAuthorityMatches(initial, authority, initialNow);
+      const value = await write(tx);
+      const committedNow = await readPostLockDatabaseNow(tx);
+      const active = assertAuthorityMatches(
+        await lockRow(tx, authority.namespace),
+        authority,
+        committedNow,
+      );
+      return { value, receipt: receipt("guarded-write", active, committedNow) };
+    });
+  }
+}
+
+export const cloudSyntheticEnvironmentLeaseStore = new CloudSyntheticEnvironmentLeaseStore();

--- a/packages/cloud/shared/src/db/schemas/index.ts
+++ b/packages/cloud/shared/src/db/schemas/index.ts
@@ -120,6 +120,7 @@ export * from "./stripe-checkout-orders";
 export * from "./stripe-checkout-orders";
 export * from "./stripe-connect-accounts";
 export * from "./stripe-customer-attempts";
+export * from "./synthetic-environment-leases";
 export * from "./telegram-chats";
 export * from "./tenant-db-clusters";
 export * from "./token-redemptions";

--- a/packages/cloud/shared/src/db/schemas/synthetic-environment-leases.ts
+++ b/packages/cloud/shared/src/db/schemas/synthetic-environment-leases.ts
@@ -1,0 +1,50 @@
+/** Stores generation-fenced ownership of synthetic test namespaces. */
+
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import { check, index, integer, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+
+export const syntheticEnvironmentLeases = pgTable(
+  "synthetic_environment_leases",
+  {
+    namespace: text("namespace").primaryKey(),
+    generation: integer("generation").notNull(),
+    lease_id: uuid("lease_id"),
+    owner_id: text("owner_id"),
+    owner_process_id: integer("owner_process_id"),
+    owner_host: text("owner_host"),
+    acquired_at: timestamp("acquired_at", { withTimezone: true }),
+    heartbeat_at: timestamp("heartbeat_at", { withTimezone: true }),
+    expires_at: timestamp("expires_at", { withTimezone: true }),
+    released_at: timestamp("released_at", { withTimezone: true }),
+    revision: integer("revision").notNull(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    expires_idx: index("synthetic_environment_leases_expires_idx").on(table.expires_at),
+    generation_check: check(
+      "synthetic_environment_leases_generation_check",
+      sql`${table.generation} >= 0 AND ${table.revision} >= 0`,
+    ),
+    authority_shape_check: check(
+      "synthetic_environment_leases_authority_shape_check",
+      sql`(
+        ${table.lease_id} IS NULL
+        AND ${table.owner_id} IS NULL
+        AND ${table.owner_process_id} IS NULL
+        AND ${table.owner_host} IS NULL
+        AND ${table.expires_at} IS NULL
+      ) OR (
+        ${table.lease_id} IS NOT NULL
+        AND ${table.owner_id} IS NOT NULL
+        AND ${table.owner_host} IS NOT NULL
+        AND ${table.acquired_at} IS NOT NULL
+        AND ${table.heartbeat_at} IS NOT NULL
+        AND ${table.expires_at} IS NOT NULL
+      )`,
+    ),
+  }),
+);
+
+export type SyntheticEnvironmentLease = InferSelectModel<typeof syntheticEnvironmentLeases>;
+export type NewSyntheticEnvironmentLease = InferInsertModel<typeof syntheticEnvironmentLeases>;

--- a/packages/cloud/shared/src/db/synthetic-environment-leases-migration.test.ts
+++ b/packages/cloud/shared/src/db/synthetic-environment-leases-migration.test.ts
@@ -1,0 +1,48 @@
+/** Applies the generated synthetic lease migration to real PGlite and inspects its constraints. */
+
+import { describe, expect, it } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { PGlite } from "@electric-sql/pglite";
+
+const migrationUrl = new URL("./migrations/0299_synthetic_environment_leases.sql", import.meta.url);
+const journalUrl = new URL("./migrations/meta/_journal.json", import.meta.url);
+
+describe("0299 synthetic environment leases migration", () => {
+  it("creates the fenced authority table and rejects partial authority rows", async () => {
+    const journal = JSON.parse(await readFile(journalUrl, "utf8")) as {
+      entries: Array<{ tag: string }>;
+    };
+    expect(journal.entries.at(-1)?.tag).toBe("0299_synthetic_environment_leases");
+    const database = new PGlite();
+    try {
+      const source = await readFile(migrationUrl, "utf8");
+      for (const statement of source.split("--> statement-breakpoint")) {
+        await database.exec(statement);
+      }
+      await database.exec(`
+        INSERT INTO synthetic_environment_leases (namespace, generation, revision)
+        VALUES ('migration:released', 0, 0)
+      `);
+      await expect(
+        database.exec(`
+          INSERT INTO synthetic_environment_leases (
+            namespace, generation, revision, lease_id, owner_id, owner_host
+          ) VALUES (
+            'migration:invalid', 1, 1,
+            '00000000-0000-4000-8000-000000000001', 'owner', 'host'
+          )
+        `),
+      ).rejects.toThrow(/authority_shape_check/i);
+      const indexes = await database.query<{ indexname: string }>(`
+        SELECT indexname FROM pg_indexes
+        WHERE tablename = 'synthetic_environment_leases'
+        ORDER BY indexname
+      `);
+      expect(indexes.rows.map((row) => row.indexname)).toContain(
+        "synthetic_environment_leases_expires_idx",
+      );
+    } finally {
+      await database.close();
+    }
+  });
+});

--- a/packages/cloud/test-mocks/README.md
+++ b/packages/cloud/test-mocks/README.md
@@ -64,6 +64,14 @@ declared capabilities and nonce-bound observations emitted by the executed
 suite. Normal CI is fully offline and credential-free; live/sandbox lanes
 remain optional.
 
+## Synthetic environment leases
+
+`@elizaos/cloud-test-mocks/synthetic-environment` exposes a file-backed SQLite
+lease store for standalone scenario and mock-service processes. Acquisition,
+reset rollover, heartbeat, release, and `withActiveGeneration` use the same
+OS-visible transaction boundary; pass the callback's database handle to local
+synthetic writes instead of checking authority separately.
+
 ## Hetzner Cloud mock
 
 Implements the subset of the Hetzner Cloud API that the autoscaler client in

--- a/packages/cloud/test-mocks/README.md
+++ b/packages/cloud/test-mocks/README.md
@@ -72,6 +72,18 @@ reset rollover, heartbeat, release, and `withActiveGeneration` use the same
 OS-visible transaction boundary; pass the callback's database handle to local
 synthetic writes instead of checking authority separately.
 
+The SQLite adapter is a same-host authority; do not place it on a network
+filesystem or use it to coordinate different machines. The database must live
+in a private, non-symlink directory that is not writable
+by other users; the adapter rejects symlink/non-regular targets and pins the
+database file to owner-only permissions. A storage exception during commit is
+an ambiguous result: read the canonical namespace snapshot and reconcile the
+lease ID/generation before issuing another mutation. Namespace values use the
+same exact, non-normalizing 512-character contract as synthetic subprocess
+control envelopes.
+Processes running under the same OS account are inside this local trust
+boundary and can access the same file-backed authority by design.
+
 ## Hetzner Cloud mock
 
 Implements the subset of the Hetzner Cloud API that the autoscaler client in

--- a/packages/cloud/test-mocks/package.json
+++ b/packages/cloud/test-mocks/package.json
@@ -9,7 +9,8 @@
     "./hetzner": "./src/hetzner/index.ts",
     "./control-plane": "./src/control-plane/index.ts",
     "./steward": "./src/steward/index.ts",
-    "./provider-contract": "./src/provider-contract/index.ts"
+    "./provider-contract": "./src/provider-contract/index.ts",
+    "./synthetic-environment": "./src/synthetic-environment/index.ts"
   },
   "bin": {
     "hetzner-mock": "./bin/hetzner-mock.ts",

--- a/packages/cloud/test-mocks/src/index.ts
+++ b/packages/cloud/test-mocks/src/index.ts
@@ -3,3 +3,4 @@ export * as controlPlane from "./control-plane";
 export * from "./hetzner";
 export * as providerContract from "./provider-contract";
 export * from "./steward";
+export * as syntheticEnvironment from "./synthetic-environment";

--- a/packages/cloud/test-mocks/src/synthetic-environment/index.ts
+++ b/packages/cloud/test-mocks/src/synthetic-environment/index.ts
@@ -1,0 +1,3 @@
+/** Exposes the OS-visible local synthetic-environment lease adapter. */
+
+export * from "./sqlite-lease-store";

--- a/packages/cloud/test-mocks/src/synthetic-environment/sqlite-lease-store.ts
+++ b/packages/cloud/test-mocks/src/synthetic-environment/sqlite-lease-store.ts
@@ -6,7 +6,7 @@
 
 import { Database } from "bun:sqlite";
 import { randomUUID } from "node:crypto";
-import { chmodSync, mkdirSync } from "node:fs";
+import { chmodSync, lstatSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { ElizaError } from "@elizaos/core";
 import type {
@@ -18,7 +18,11 @@ import type {
   SyntheticEnvironmentLeaseSnapshot,
   SyntheticEnvironmentLeaseStore,
 } from "@elizaos/shared/contracts/synthetic-environment-lease";
-import { SYNTHETIC_ENVIRONMENT_LEASE_VERSION } from "@elizaos/shared/contracts/synthetic-environment-lease";
+import {
+  isSyntheticEnvironmentNamespace,
+  SYNTHETIC_ENVIRONMENT_LEASE_VERSION,
+  SYNTHETIC_ENVIRONMENT_NAMESPACE_MAX_LENGTH,
+} from "@elizaos/shared/contracts/synthetic-environment-lease";
 
 interface LeaseRow {
   namespace: string;
@@ -37,15 +41,46 @@ interface LeaseRow {
 const MAX_LEASE_DURATION_MS = 86_400_000;
 const IDENTIFIER_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:@-]{0,127}$/;
 
-function invalidInput(message: string): ElizaError {
+function containsControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function invalidInput(message: string, cause?: unknown): ElizaError {
   return new ElizaError(message, {
     code: "SYNTHETIC_LEASE_INVALID_INPUT",
     severity: "fatal",
+    cause,
   });
 }
 
-function validateIdentifier(value: string, field: string): string {
-  if (!IDENTIFIER_PATTERN.test(value)) {
+function storageFailure(
+  message: string,
+  namespace: string | null,
+  cause: unknown,
+): ElizaError {
+  return new ElizaError(message, {
+    code: "SYNTHETIC_LEASE_STORAGE_FAILURE",
+    severity: "fatal",
+    context: namespace === null ? undefined : { namespace },
+    cause,
+  });
+}
+
+function validateNamespace(value: unknown, field: string): string {
+  if (!isSyntheticEnvironmentNamespace(value)) {
+    throw invalidInput(
+      `${field} must contain 1-${SYNTHETIC_ENVIRONMENT_NAMESPACE_MAX_LENGTH} non-control characters`,
+    );
+  }
+  return value;
+}
+
+function validateIdentifier(value: unknown, field: string): string {
+  if (typeof value !== "string" || !IDENTIFIER_PATTERN.test(value)) {
     throw invalidInput(
       `${field} must be 1-128 safe identifier characters and start alphanumeric`,
     );
@@ -56,6 +91,9 @@ function validateIdentifier(value: string, field: string): string {
 function validateOwner(
   owner: SyntheticEnvironmentLeaseOwner,
 ): SyntheticEnvironmentLeaseOwner {
+  if (typeof owner !== "object" || owner === null) {
+    throw invalidInput("owner must be an object");
+  }
   validateIdentifier(owner.ownerId, "owner.ownerId");
   if (
     owner.processId !== null &&
@@ -67,8 +105,15 @@ function validateOwner(
       "owner.processId must be a positive 32-bit integer or null",
     );
   }
+  if (typeof owner.host !== "string") {
+    throw invalidInput("owner.host must be a string");
+  }
   const host = owner.host.trim();
-  if (host.length === 0 || host.length > 255 || /[\r\n\0]/.test(host)) {
+  if (
+    host.length === 0 ||
+    host.length > 255 ||
+    containsControlCharacter(host)
+  ) {
     throw invalidInput("owner.host must contain 1-255 safe characters");
   }
   return { ...owner, host };
@@ -90,16 +135,22 @@ function validateDuration(leaseDurationMs: number): number {
 function validateAuthority(
   authority: SyntheticEnvironmentLeaseAuthority,
 ): SyntheticEnvironmentLeaseAuthority {
+  if (typeof authority !== "object" || authority === null) {
+    throw invalidInput("authority must be an object");
+  }
   if (authority.version !== SYNTHETIC_ENVIRONMENT_LEASE_VERSION) {
     throw invalidInput("authority.version is unsupported");
   }
-  validateIdentifier(authority.namespace, "authority.namespace");
+  const namespace = validateNamespace(
+    authority.namespace,
+    "authority.namespace",
+  );
   validateIdentifier(authority.leaseId, "authority.leaseId");
   validateOwner(authority.owner);
   if (!Number.isSafeInteger(authority.generation) || authority.generation < 1) {
     throw invalidInput("authority.generation must be a positive integer");
   }
-  return authority;
+  return { ...authority, namespace };
 }
 
 function iso(milliseconds: number | null): string | null {
@@ -196,14 +247,58 @@ export class SqliteSyntheticEnvironmentLeaseStore
 {
   readonly database: Database;
   private transactionTail: Promise<void> = Promise.resolve();
+  private pendingTransactions = 0;
+  private closed = false;
 
   constructor(databasePath: string) {
     if (!path.isAbsolute(databasePath)) {
       throw invalidInput("databasePath must be absolute");
     }
-    mkdirSync(path.dirname(databasePath), { recursive: true, mode: 0o700 });
+    const parentPath = path.dirname(databasePath);
+    mkdirSync(parentPath, { recursive: true, mode: 0o700 });
+    const parent = lstatSync(parentPath);
+    if (!parent.isDirectory() || parent.isSymbolicLink()) {
+      throw invalidInput("databasePath parent must be a real directory");
+    }
+    if (process.platform !== "win32" && (parent.mode & 0o022) !== 0) {
+      throw invalidInput(
+        "databasePath parent must not be writable by group or other users",
+      );
+    }
+    let existingIdentity: { dev: number; ino: number } | null = null;
+    try {
+      const existing = lstatSync(databasePath);
+      if (!existing.isFile() || existing.isSymbolicLink()) {
+        throw invalidInput(
+          "databasePath must be a regular file, not a symbolic link",
+        );
+      }
+      existingIdentity = { dev: existing.dev, ino: existing.ino };
+    } catch (error) {
+      // error-policy:J3 Only an absent path may proceed to SQLite creation.
+      if (
+        typeof error !== "object" ||
+        error === null ||
+        !("code" in error) ||
+        error.code !== "ENOENT"
+      ) {
+        if (error instanceof ElizaError) throw error;
+        throw invalidInput("databasePath could not be inspected safely", error);
+      }
+    }
     this.database = new Database(databasePath, { create: true, strict: true });
     chmodSync(databasePath, 0o600);
+    const opened = lstatSync(databasePath);
+    if (
+      !opened.isFile() ||
+      opened.isSymbolicLink() ||
+      (existingIdentity !== null &&
+        (opened.dev !== existingIdentity.dev ||
+          opened.ino !== existingIdentity.ino))
+    ) {
+      this.database.close(false);
+      throw invalidInput("databasePath identity changed while it was opened");
+    }
     this.database.run("PRAGMA busy_timeout = 10000");
     // The default rollback journal supports atomic cross-process writers and
     // avoids a connection-start WAL mode transition racing another process.
@@ -234,16 +329,28 @@ export class SqliteSyntheticEnvironmentLeaseStore
   }
 
   close(): void {
+    if (this.closed) return;
+    if (this.pendingTransactions > 0) {
+      throw storageFailure(
+        "Cannot close synthetic lease storage while a transaction is pending",
+        null,
+        new Error("transaction in progress"),
+      );
+    }
+    this.closed = true;
     this.database.close(false);
   }
 
   async acquire(
     input: AcquireSyntheticEnvironmentLeaseInput,
   ): Promise<SyntheticEnvironmentLeaseReceipt> {
-    const namespace = validateIdentifier(input.namespace, "namespace");
+    if (typeof input !== "object" || input === null) {
+      throw invalidInput("acquire input must be an object");
+    }
+    const namespace = validateNamespace(input.namespace, "namespace");
     const owner = validateOwner(input.owner);
     const duration = validateDuration(input.leaseDurationMs);
-    return this.transaction(async (nowMs) => {
+    return this.transaction(namespace, async (nowMs) => {
       const current = this.select(namespace);
       if (
         current !== null &&
@@ -304,7 +411,9 @@ export class SqliteSyntheticEnvironmentLeaseStore
   async read(
     namespace: string,
   ): Promise<SyntheticEnvironmentLeaseSnapshot | null> {
-    validateIdentifier(namespace, "namespace");
+    namespace = validateNamespace(namespace, "namespace");
+    await this.transactionTail;
+    this.assertOpen();
     const nowMs = Date.now();
     const row = this.select(namespace);
     return row ? snapshot(row, nowMs) : null;
@@ -313,9 +422,12 @@ export class SqliteSyntheticEnvironmentLeaseStore
   async heartbeat(
     input: RefreshSyntheticEnvironmentLeaseInput,
   ): Promise<SyntheticEnvironmentLeaseReceipt> {
+    if (typeof input !== "object" || input === null) {
+      throw invalidInput("heartbeat input must be an object");
+    }
     const authority = validateAuthority(input.authority);
     const duration = validateDuration(input.leaseDurationMs);
-    return this.transaction(async (nowMs) => {
+    return this.transaction(authority.namespace, async (nowMs) => {
       assertAuthorityMatches(
         this.select(authority.namespace),
         authority,
@@ -339,9 +451,12 @@ export class SqliteSyntheticEnvironmentLeaseStore
   async rollover(
     input: RefreshSyntheticEnvironmentLeaseInput,
   ): Promise<SyntheticEnvironmentLeaseReceipt> {
+    if (typeof input !== "object" || input === null) {
+      throw invalidInput("rollover input must be an object");
+    }
     const authority = validateAuthority(input.authority);
     const duration = validateDuration(input.leaseDurationMs);
-    return this.transaction(async (nowMs) => {
+    return this.transaction(authority.namespace, async (nowMs) => {
       const row = assertAuthorityMatches(
         this.select(authority.namespace),
         authority,
@@ -375,7 +490,7 @@ export class SqliteSyntheticEnvironmentLeaseStore
     uncheckedAuthority: SyntheticEnvironmentLeaseAuthority,
   ): Promise<SyntheticEnvironmentLeaseReceipt> {
     const authority = validateAuthority(uncheckedAuthority);
-    return this.transaction(async (nowMs) => {
+    return this.transaction(authority.namespace, async (nowMs) => {
       const row = assertAuthorityMatches(
         this.select(authority.namespace),
         authority,
@@ -403,7 +518,7 @@ export class SqliteSyntheticEnvironmentLeaseStore
     write: (database: Database) => T | Promise<T>,
   ): Promise<{ value: T; receipt: SyntheticEnvironmentLeaseReceipt }> {
     const authority = validateAuthority(uncheckedAuthority);
-    return this.transaction(async (nowMs) => {
+    return this.transaction(authority.namespace, async (nowMs) => {
       assertAuthorityMatches(
         this.select(authority.namespace),
         authority,
@@ -457,9 +572,22 @@ export class SqliteSyntheticEnvironmentLeaseStore
     };
   }
 
+  private assertOpen(): void {
+    if (this.closed) {
+      throw storageFailure(
+        "Synthetic lease storage is closed",
+        null,
+        new Error("database closed"),
+      );
+    }
+  }
+
   private async transaction<T>(
+    namespace: string,
     operation: (nowMs: number) => Promise<T>,
   ): Promise<T> {
+    this.assertOpen();
+    this.pendingTransactions += 1;
     const previous = this.transactionTail;
     let release: () => void = () => undefined;
     this.transactionTail = new Promise<void>((resolve) => {
@@ -467,18 +595,46 @@ export class SqliteSyntheticEnvironmentLeaseStore
     });
     await previous;
     try {
-      this.database.run("BEGIN IMMEDIATE");
+      try {
+        this.database.run("BEGIN IMMEDIATE");
+      } catch (error) {
+        // error-policy:J2 SQLite lock/open failures become the declared storage boundary error.
+        throw storageFailure(
+          "Synthetic lease transaction could not begin",
+          namespace,
+          error,
+        );
+      }
       try {
         const result = await operation(Date.now());
-        this.database.run("COMMIT");
+        try {
+          this.database.run("COMMIT");
+        } catch (error) {
+          // error-policy:J2 A failed commit is ambiguous and must retain its storage cause.
+          throw storageFailure(
+            "Synthetic lease transaction commit was not confirmed",
+            namespace,
+            error,
+          );
+        }
         return result;
       } catch (error) {
         // error-policy:J2 rollback restores the atomic generation boundary;
         // the original typed failure is preserved for the caller.
-        this.database.run("ROLLBACK");
+        try {
+          this.database.run("ROLLBACK");
+        } catch (rollbackError) {
+          // error-policy:J2 A rollback failure supersedes neither cause and makes storage unusable.
+          throw storageFailure(
+            "Synthetic lease transaction rollback was not confirmed",
+            namespace,
+            new AggregateError([error, rollbackError]),
+          );
+        }
         throw error;
       }
     } finally {
+      this.pendingTransactions -= 1;
       release();
     }
   }

--- a/packages/cloud/test-mocks/src/synthetic-environment/sqlite-lease-store.ts
+++ b/packages/cloud/test-mocks/src/synthetic-environment/sqlite-lease-store.ts
@@ -1,0 +1,485 @@
+/**
+ * Implements synthetic-environment fencing on a file-backed SQLite database.
+ * SQLite's cross-process write transaction is the local production boundary;
+ * guarded mutations receive that same transaction connection.
+ */
+
+import { Database } from "bun:sqlite";
+import { randomUUID } from "node:crypto";
+import { chmodSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { ElizaError } from "@elizaos/core";
+import type {
+  AcquireSyntheticEnvironmentLeaseInput,
+  RefreshSyntheticEnvironmentLeaseInput,
+  SyntheticEnvironmentLeaseAuthority,
+  SyntheticEnvironmentLeaseOwner,
+  SyntheticEnvironmentLeaseReceipt,
+  SyntheticEnvironmentLeaseSnapshot,
+  SyntheticEnvironmentLeaseStore,
+} from "@elizaos/shared/contracts/synthetic-environment-lease";
+import { SYNTHETIC_ENVIRONMENT_LEASE_VERSION } from "@elizaos/shared/contracts/synthetic-environment-lease";
+
+interface LeaseRow {
+  namespace: string;
+  generation: number;
+  lease_id: string | null;
+  owner_id: string | null;
+  owner_process_id: number | null;
+  owner_host: string | null;
+  acquired_at_ms: number | null;
+  heartbeat_at_ms: number | null;
+  expires_at_ms: number | null;
+  released_at_ms: number | null;
+  revision: number;
+}
+
+const MAX_LEASE_DURATION_MS = 86_400_000;
+const IDENTIFIER_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._:@-]{0,127}$/;
+
+function invalidInput(message: string): ElizaError {
+  return new ElizaError(message, {
+    code: "SYNTHETIC_LEASE_INVALID_INPUT",
+    severity: "fatal",
+  });
+}
+
+function validateIdentifier(value: string, field: string): string {
+  if (!IDENTIFIER_PATTERN.test(value)) {
+    throw invalidInput(
+      `${field} must be 1-128 safe identifier characters and start alphanumeric`,
+    );
+  }
+  return value;
+}
+
+function validateOwner(
+  owner: SyntheticEnvironmentLeaseOwner,
+): SyntheticEnvironmentLeaseOwner {
+  validateIdentifier(owner.ownerId, "owner.ownerId");
+  if (
+    owner.processId !== null &&
+    (!Number.isSafeInteger(owner.processId) ||
+      owner.processId < 1 ||
+      owner.processId > 2_147_483_647)
+  ) {
+    throw invalidInput(
+      "owner.processId must be a positive 32-bit integer or null",
+    );
+  }
+  const host = owner.host.trim();
+  if (host.length === 0 || host.length > 255 || /[\r\n\0]/.test(host)) {
+    throw invalidInput("owner.host must contain 1-255 safe characters");
+  }
+  return { ...owner, host };
+}
+
+function validateDuration(leaseDurationMs: number): number {
+  if (
+    !Number.isSafeInteger(leaseDurationMs) ||
+    leaseDurationMs < 10 ||
+    leaseDurationMs > MAX_LEASE_DURATION_MS
+  ) {
+    throw invalidInput(
+      "leaseDurationMs must be an integer between 10ms and one day",
+    );
+  }
+  return leaseDurationMs;
+}
+
+function validateAuthority(
+  authority: SyntheticEnvironmentLeaseAuthority,
+): SyntheticEnvironmentLeaseAuthority {
+  if (authority.version !== SYNTHETIC_ENVIRONMENT_LEASE_VERSION) {
+    throw invalidInput("authority.version is unsupported");
+  }
+  validateIdentifier(authority.namespace, "authority.namespace");
+  validateIdentifier(authority.leaseId, "authority.leaseId");
+  validateOwner(authority.owner);
+  if (!Number.isSafeInteger(authority.generation) || authority.generation < 1) {
+    throw invalidInput("authority.generation must be a positive integer");
+  }
+  return authority;
+}
+
+function iso(milliseconds: number | null): string | null {
+  return milliseconds === null ? null : new Date(milliseconds).toISOString();
+}
+
+function rowOwner(row: LeaseRow): SyntheticEnvironmentLeaseOwner | null {
+  if (row.owner_id === null || row.owner_host === null) return null;
+  return {
+    ownerId: row.owner_id,
+    processId: row.owner_process_id,
+    host: row.owner_host,
+  };
+}
+
+function snapshot(
+  row: LeaseRow,
+  nowMs: number,
+): SyntheticEnvironmentLeaseSnapshot {
+  const status =
+    row.lease_id === null
+      ? "released"
+      : row.expires_at_ms !== null && row.expires_at_ms <= nowMs
+        ? "expired"
+        : "active";
+  return {
+    version: SYNTHETIC_ENVIRONMENT_LEASE_VERSION,
+    namespace: row.namespace,
+    generation: row.generation,
+    leaseId: row.lease_id,
+    owner: rowOwner(row),
+    acquiredAt: iso(row.acquired_at_ms),
+    heartbeatAt: iso(row.heartbeat_at_ms),
+    expiresAt: iso(row.expires_at_ms),
+    releasedAt: iso(row.released_at_ms),
+    revision: row.revision,
+    status,
+    observedAt: new Date(nowMs).toISOString(),
+  };
+}
+
+function authorityFromRow(row: LeaseRow): SyntheticEnvironmentLeaseAuthority {
+  const owner = rowOwner(row);
+  if (row.lease_id === null || owner === null) {
+    throw new ElizaError("Synthetic lease has no active authority", {
+      code: "SYNTHETIC_LEASE_LOST",
+      severity: "fatal",
+      context: { namespace: row.namespace, generation: row.generation },
+    });
+  }
+  return {
+    version: SYNTHETIC_ENVIRONMENT_LEASE_VERSION,
+    namespace: row.namespace,
+    generation: row.generation,
+    leaseId: row.lease_id,
+    owner,
+  };
+}
+
+function assertAuthorityMatches(
+  row: LeaseRow | null,
+  authority: SyntheticEnvironmentLeaseAuthority,
+  nowMs: number,
+): LeaseRow {
+  if (
+    row === null ||
+    row.lease_id !== authority.leaseId ||
+    row.generation !== authority.generation ||
+    row.owner_id !== authority.owner.ownerId ||
+    row.owner_process_id !== authority.owner.processId ||
+    row.owner_host !== authority.owner.host ||
+    row.expires_at_ms === null ||
+    row.expires_at_ms <= nowMs
+  ) {
+    throw new ElizaError(
+      "Synthetic environment lease authority is stale, expired, or owned elsewhere",
+      {
+        code: "SYNTHETIC_LEASE_LOST",
+        severity: "fatal",
+        context: {
+          namespace: authority.namespace,
+          generation: authority.generation,
+          ownerId: authority.owner.ownerId,
+        },
+      },
+    );
+  }
+  return row;
+}
+
+/** File-backed local adapter shared by scenario and provider-mock processes. */
+export class SqliteSyntheticEnvironmentLeaseStore
+  implements SyntheticEnvironmentLeaseStore<Database>
+{
+  readonly database: Database;
+  private transactionTail: Promise<void> = Promise.resolve();
+
+  constructor(databasePath: string) {
+    if (!path.isAbsolute(databasePath)) {
+      throw invalidInput("databasePath must be absolute");
+    }
+    mkdirSync(path.dirname(databasePath), { recursive: true, mode: 0o700 });
+    this.database = new Database(databasePath, { create: true, strict: true });
+    chmodSync(databasePath, 0o600);
+    this.database.run("PRAGMA busy_timeout = 10000");
+    // The default rollback journal supports atomic cross-process writers and
+    // avoids a connection-start WAL mode transition racing another process.
+    this.database.run("PRAGMA synchronous = FULL");
+    this.database.run(`
+      CREATE TABLE IF NOT EXISTS synthetic_environment_leases (
+        namespace TEXT PRIMARY KEY NOT NULL,
+        generation INTEGER NOT NULL CHECK (generation > 0),
+        lease_id TEXT,
+        owner_id TEXT,
+        owner_process_id INTEGER,
+        owner_host TEXT,
+        acquired_at_ms INTEGER,
+        heartbeat_at_ms INTEGER,
+        expires_at_ms INTEGER,
+        released_at_ms INTEGER,
+        revision INTEGER NOT NULL CHECK (revision > 0),
+        CHECK (
+          (lease_id IS NULL AND owner_id IS NULL AND owner_process_id IS NULL
+            AND owner_host IS NULL AND expires_at_ms IS NULL)
+          OR
+          (lease_id IS NOT NULL AND owner_id IS NOT NULL AND owner_host IS NOT NULL
+            AND acquired_at_ms IS NOT NULL AND heartbeat_at_ms IS NOT NULL
+            AND expires_at_ms IS NOT NULL)
+        )
+      )
+    `);
+  }
+
+  close(): void {
+    this.database.close(false);
+  }
+
+  async acquire(
+    input: AcquireSyntheticEnvironmentLeaseInput,
+  ): Promise<SyntheticEnvironmentLeaseReceipt> {
+    const namespace = validateIdentifier(input.namespace, "namespace");
+    const owner = validateOwner(input.owner);
+    const duration = validateDuration(input.leaseDurationMs);
+    return this.transaction(async (nowMs) => {
+      const current = this.select(namespace);
+      if (
+        current !== null &&
+        current.lease_id !== null &&
+        current.expires_at_ms !== null &&
+        current.expires_at_ms > nowMs
+      ) {
+        throw new ElizaError(
+          "Synthetic environment namespace already has an active owner",
+          {
+            code: "SYNTHETIC_LEASE_COLLISION",
+            severity: "fatal",
+            context: {
+              namespace,
+              generation: current.generation,
+              ownerId: current.owner_id,
+            },
+          },
+        );
+      }
+      const generation = (current?.generation ?? 0) + 1;
+      const leaseId = randomUUID();
+      const operation =
+        current?.lease_id === null || current === null ? "acquire" : "recover";
+      this.database
+        .query(`
+          INSERT INTO synthetic_environment_leases (
+            namespace, generation, lease_id, owner_id, owner_process_id, owner_host,
+            acquired_at_ms, heartbeat_at_ms, expires_at_ms, released_at_ms, revision
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, 1)
+          ON CONFLICT(namespace) DO UPDATE SET
+            generation = excluded.generation,
+            lease_id = excluded.lease_id,
+            owner_id = excluded.owner_id,
+            owner_process_id = excluded.owner_process_id,
+            owner_host = excluded.owner_host,
+            acquired_at_ms = excluded.acquired_at_ms,
+            heartbeat_at_ms = excluded.heartbeat_at_ms,
+            expires_at_ms = excluded.expires_at_ms,
+            released_at_ms = NULL,
+            revision = synthetic_environment_leases.revision + 1
+        `)
+        .run(
+          namespace,
+          generation,
+          leaseId,
+          owner.ownerId,
+          owner.processId,
+          owner.host,
+          nowMs,
+          nowMs,
+          nowMs + duration,
+        );
+      return this.receipt(operation, this.requireRow(namespace), nowMs);
+    });
+  }
+
+  async read(
+    namespace: string,
+  ): Promise<SyntheticEnvironmentLeaseSnapshot | null> {
+    validateIdentifier(namespace, "namespace");
+    const nowMs = Date.now();
+    const row = this.select(namespace);
+    return row ? snapshot(row, nowMs) : null;
+  }
+
+  async heartbeat(
+    input: RefreshSyntheticEnvironmentLeaseInput,
+  ): Promise<SyntheticEnvironmentLeaseReceipt> {
+    const authority = validateAuthority(input.authority);
+    const duration = validateDuration(input.leaseDurationMs);
+    return this.transaction(async (nowMs) => {
+      assertAuthorityMatches(
+        this.select(authority.namespace),
+        authority,
+        nowMs,
+      );
+      this.database
+        .query(`
+          UPDATE synthetic_environment_leases
+          SET heartbeat_at_ms = ?, expires_at_ms = ?, revision = revision + 1
+          WHERE namespace = ?
+        `)
+        .run(nowMs, nowMs + duration, authority.namespace);
+      return this.receipt(
+        "heartbeat",
+        this.requireRow(authority.namespace),
+        nowMs,
+      );
+    });
+  }
+
+  async rollover(
+    input: RefreshSyntheticEnvironmentLeaseInput,
+  ): Promise<SyntheticEnvironmentLeaseReceipt> {
+    const authority = validateAuthority(input.authority);
+    const duration = validateDuration(input.leaseDurationMs);
+    return this.transaction(async (nowMs) => {
+      const row = assertAuthorityMatches(
+        this.select(authority.namespace),
+        authority,
+        nowMs,
+      );
+      const leaseId = randomUUID();
+      this.database
+        .query(`
+          UPDATE synthetic_environment_leases
+          SET generation = ?, lease_id = ?, acquired_at_ms = ?, heartbeat_at_ms = ?,
+              expires_at_ms = ?, released_at_ms = NULL, revision = revision + 1
+          WHERE namespace = ?
+        `)
+        .run(
+          row.generation + 1,
+          leaseId,
+          nowMs,
+          nowMs,
+          nowMs + duration,
+          authority.namespace,
+        );
+      return this.receipt(
+        "rollover",
+        this.requireRow(authority.namespace),
+        nowMs,
+      );
+    });
+  }
+
+  async release(
+    uncheckedAuthority: SyntheticEnvironmentLeaseAuthority,
+  ): Promise<SyntheticEnvironmentLeaseReceipt> {
+    const authority = validateAuthority(uncheckedAuthority);
+    return this.transaction(async (nowMs) => {
+      const row = assertAuthorityMatches(
+        this.select(authority.namespace),
+        authority,
+        nowMs,
+      );
+      this.database
+        .query(`
+          UPDATE synthetic_environment_leases
+          SET lease_id = NULL, owner_id = NULL, owner_process_id = NULL, owner_host = NULL,
+              expires_at_ms = NULL, released_at_ms = ?, revision = revision + 1
+          WHERE namespace = ?
+        `)
+        .run(nowMs, authority.namespace);
+      const released = this.requireRow(authority.namespace);
+      return {
+        operation: "release",
+        authority: authorityFromRow(row),
+        snapshot: snapshot(released, nowMs),
+      };
+    });
+  }
+
+  async withActiveGeneration<T>(
+    uncheckedAuthority: SyntheticEnvironmentLeaseAuthority,
+    write: (database: Database) => T | Promise<T>,
+  ): Promise<{ value: T; receipt: SyntheticEnvironmentLeaseReceipt }> {
+    const authority = validateAuthority(uncheckedAuthority);
+    return this.transaction(async (nowMs) => {
+      assertAuthorityMatches(
+        this.select(authority.namespace),
+        authority,
+        nowMs,
+      );
+      const value = await write(this.database);
+      const committedAt = Date.now();
+      const row = assertAuthorityMatches(
+        this.select(authority.namespace),
+        authority,
+        committedAt,
+      );
+      return {
+        value,
+        receipt: this.receipt("guarded-write", row, committedAt),
+      };
+    });
+  }
+
+  private select(namespace: string): LeaseRow | null {
+    return (
+      this.database
+        .query<LeaseRow, [string]>(
+          "SELECT * FROM synthetic_environment_leases WHERE namespace = ?",
+        )
+        .get(namespace) ?? null
+    );
+  }
+
+  private requireRow(namespace: string): LeaseRow {
+    const row = this.select(namespace);
+    if (!row) {
+      throw new ElizaError("Synthetic lease row disappeared", {
+        code: "SYNTHETIC_LEASE_NOT_FOUND",
+        severity: "fatal",
+        context: { namespace },
+      });
+    }
+    return row;
+  }
+
+  private receipt(
+    operation: SyntheticEnvironmentLeaseReceipt["operation"],
+    row: LeaseRow,
+    nowMs: number,
+  ): SyntheticEnvironmentLeaseReceipt {
+    return {
+      operation,
+      authority: authorityFromRow(row),
+      snapshot: snapshot(row, nowMs),
+    };
+  }
+
+  private async transaction<T>(
+    operation: (nowMs: number) => Promise<T>,
+  ): Promise<T> {
+    const previous = this.transactionTail;
+    let release: () => void = () => undefined;
+    this.transactionTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      this.database.run("BEGIN IMMEDIATE");
+      try {
+        const result = await operation(Date.now());
+        this.database.run("COMMIT");
+        return result;
+      } catch (error) {
+        // error-policy:J2 rollback restores the atomic generation boundary;
+        // the original typed failure is preserved for the caller.
+        this.database.run("ROLLBACK");
+        throw error;
+      }
+    } finally {
+      release();
+    }
+  }
+}

--- a/packages/cloud/test-mocks/test/fixtures/synthetic-lease-holder.ts
+++ b/packages/cloud/test-mocks/test/fixtures/synthetic-lease-holder.ts
@@ -1,0 +1,23 @@
+/** Holds a real SQLite lease until its OS process is killed by the test. */
+
+import { writeFileSync } from "node:fs";
+import { hostname } from "node:os";
+import { SqliteSyntheticEnvironmentLeaseStore } from "../../src/synthetic-environment/sqlite-lease-store";
+
+const [databasePath, namespace, acquiredPath, durationText] =
+  process.argv.slice(2);
+if (!databasePath || !namespace || !acquiredPath || !durationText) {
+  throw new Error("missing lease-holder arguments");
+}
+
+const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+const receipt = await store.acquire({
+  namespace,
+  owner: { ownerId: "killed-owner", processId: process.pid, host: hostname() },
+  leaseDurationMs: Number(durationText),
+});
+writeFileSync(acquiredPath, JSON.stringify(receipt.authority), { mode: 0o600 });
+
+await new Promise<never>(() => {
+  // The parent deliberately uses SIGKILL, so no cleanup handler can release the lease.
+});

--- a/packages/cloud/test-mocks/test/fixtures/synthetic-lease-worker.ts
+++ b/packages/cloud/test-mocks/test/fixtures/synthetic-lease-worker.ts
@@ -1,0 +1,45 @@
+/** Drives the real SQLite lease adapter from an independent OS process. */
+
+import { existsSync, writeFileSync } from "node:fs";
+import { hostname } from "node:os";
+import { SqliteSyntheticEnvironmentLeaseStore } from "../../src/synthetic-environment/sqlite-lease-store";
+
+const [databasePath, namespace, ownerId, readyPath, goPath, durationText] =
+  process.argv.slice(2);
+if (
+  !databasePath ||
+  !namespace ||
+  !ownerId ||
+  !readyPath ||
+  !goPath ||
+  !durationText
+) {
+  throw new Error("missing worker arguments");
+}
+
+const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+writeFileSync(readyPath, `${process.pid}\n`, { mode: 0o600 });
+while (!existsSync(goPath)) await Bun.sleep(5);
+
+try {
+  const receipt = await store.acquire({
+    namespace,
+    owner: { ownerId, processId: process.pid, host: hostname() },
+    leaseDurationMs: Number(durationText),
+  });
+  process.stdout.write(
+    `${JSON.stringify({ ok: true, operation: receipt.operation, authority: receipt.authority })}\n`,
+  );
+} catch (error) {
+  process.stdout.write(
+    `${JSON.stringify({
+      ok: false,
+      code:
+        typeof error === "object" && error !== null && "code" in error
+          ? error.code
+          : "UNKNOWN",
+    })}\n`,
+  );
+} finally {
+  store.close();
+}

--- a/packages/cloud/test-mocks/test/fixtures/synthetic-rollover-worker.ts
+++ b/packages/cloud/test-mocks/test/fixtures/synthetic-rollover-worker.ts
@@ -1,0 +1,35 @@
+/** Races a generation rollover from an independent OS process. */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import type { SyntheticEnvironmentLeaseAuthority } from "@elizaos/shared/contracts/synthetic-environment-lease";
+import { SqliteSyntheticEnvironmentLeaseStore } from "../../src/synthetic-environment/sqlite-lease-store";
+
+const [databasePath, authorityPath, readyPath, goPath] = process.argv.slice(2);
+if (!databasePath || !authorityPath || !readyPath || !goPath) {
+  throw new Error("missing rollover worker arguments");
+}
+const authority = JSON.parse(
+  readFileSync(authorityPath, "utf8"),
+) as SyntheticEnvironmentLeaseAuthority;
+const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+writeFileSync(readyPath, `${process.pid}\n`, { mode: 0o600 });
+while (!existsSync(goPath)) await Bun.sleep(5);
+
+try {
+  const receipt = await store.rollover({ authority, leaseDurationMs: 5_000 });
+  process.stdout.write(
+    `${JSON.stringify({ ok: true, operation: receipt.operation, authority: receipt.authority })}\n`,
+  );
+} catch (error) {
+  process.stdout.write(
+    `${JSON.stringify({
+      ok: false,
+      code:
+        typeof error === "object" && error !== null && "code" in error
+          ? error.code
+          : "UNKNOWN",
+    })}\n`,
+  );
+} finally {
+  store.close();
+}

--- a/packages/cloud/test-mocks/test/synthetic-environment-lease.test.ts
+++ b/packages/cloud/test-mocks/test/synthetic-environment-lease.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Proves local synthetic namespace fencing through real file-backed SQLite and
+ * independent Bun processes, including collision, expiry, and write rollback.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { hostname } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { SyntheticEnvironmentLeaseAuthority } from "@elizaos/shared/contracts/synthetic-environment-lease";
+import { SqliteSyntheticEnvironmentLeaseStore } from "../src/synthetic-environment/sqlite-lease-store";
+
+const roots: string[] = [];
+const workerPath = fileURLToPath(
+  new URL("./fixtures/synthetic-lease-worker.ts", import.meta.url),
+);
+const rolloverWorkerPath = fileURLToPath(
+  new URL("./fixtures/synthetic-rollover-worker.ts", import.meta.url),
+);
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(
+    path.join(process.env.TMPDIR ?? "/tmp", "eliza-lease-"),
+  );
+  roots.push(root);
+  return root;
+}
+
+async function waitForFiles(files: string[]): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const found = await Promise.all(
+      files.map((file) => Bun.file(file).exists()),
+    );
+    if (found.every(Boolean)) return;
+    await Bun.sleep(10);
+  }
+  throw new Error(`workers did not reach barrier: ${files.join(", ")}`);
+}
+
+async function workerResult(
+  databasePath: string,
+  namespace: string,
+  ownerId: string,
+  readyPath: string,
+  goPath: string,
+  durationMs: number,
+): Promise<{
+  ok: boolean;
+  code?: string;
+  operation?: string;
+  authority?: SyntheticEnvironmentLeaseAuthority;
+}> {
+  const child = Bun.spawn(
+    [
+      process.execPath,
+      "--conditions=eliza-source",
+      workerPath,
+      databasePath,
+      namespace,
+      ownerId,
+      readyPath,
+      goPath,
+      String(durationMs),
+    ],
+    { cwd: path.dirname(workerPath), stdout: "pipe", stderr: "pipe" },
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (exitCode !== 0) throw new Error(`worker failed (${exitCode}): ${stderr}`);
+  return JSON.parse(stdout.trim()) as {
+    ok: boolean;
+    code?: string;
+    operation?: string;
+    authority?: SyntheticEnvironmentLeaseAuthority;
+  };
+}
+
+async function rolloverWorkerResult(
+  databasePath: string,
+  authorityPath: string,
+  readyPath: string,
+  goPath: string,
+): Promise<{
+  ok: boolean;
+  code?: string;
+  authority?: SyntheticEnvironmentLeaseAuthority;
+}> {
+  const child = Bun.spawn(
+    [
+      process.execPath,
+      "--conditions=eliza-source",
+      rolloverWorkerPath,
+      databasePath,
+      authorityPath,
+      readyPath,
+      goPath,
+    ],
+    { cwd: path.dirname(rolloverWorkerPath), stdout: "pipe", stderr: "pipe" },
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (exitCode !== 0)
+    throw new Error(`rollover worker failed (${exitCode}): ${stderr}`);
+  return JSON.parse(stdout.trim()) as {
+    ok: boolean;
+    code?: string;
+    authority?: SyntheticEnvironmentLeaseAuthority;
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("SqliteSyntheticEnvironmentLeaseStore", () => {
+  it("admits exactly one of two independent OS processes", async () => {
+    const root = await tempRoot();
+    const databasePath = path.join(root, "leases.sqlite");
+    const initialized = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+    initialized.close();
+    const goPath = path.join(root, "go");
+    const readyPaths = [path.join(root, "ready-a"), path.join(root, "ready-b")];
+    const attempts = ["owner-a", "owner-b"].map((owner, index) =>
+      workerResult(
+        databasePath,
+        "race:one",
+        owner,
+        readyPaths[index],
+        goPath,
+        5_000,
+      ),
+    );
+
+    await waitForFiles(readyPaths);
+    await writeFile(goPath, "go\n", { mode: 0o600 });
+    const results = await Promise.all(attempts);
+
+    expect(results.filter((result) => result.ok)).toHaveLength(1);
+    expect(results.filter((result) => !result.ok)).toEqual([
+      expect.objectContaining({ code: "SYNTHETIC_LEASE_COLLISION" }),
+    ]);
+    const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+    expect(await store.read("race:one")).toEqual(
+      expect.objectContaining({ generation: 1, revision: 1, status: "active" }),
+    );
+    store.close();
+  });
+
+  it("recovers an expired crashed owner with a higher generation", async () => {
+    const root = await tempRoot();
+    const databasePath = path.join(root, "leases.sqlite");
+    const firstReady = path.join(root, "first-ready");
+    const firstGo = path.join(root, "first-go");
+    const first = workerResult(
+      databasePath,
+      "recovery:one",
+      "crashed-owner",
+      firstReady,
+      firstGo,
+      80,
+    );
+    await waitForFiles([firstReady]);
+    await writeFile(firstGo, "go\n", { mode: 0o600 });
+    expect(await first).toEqual(
+      expect.objectContaining({ ok: true, operation: "acquire" }),
+    );
+    await Bun.sleep(160);
+
+    const secondReady = path.join(root, "second-ready");
+    const secondGo = path.join(root, "second-go");
+    const second = workerResult(
+      databasePath,
+      "recovery:one",
+      "recovery-owner",
+      secondReady,
+      secondGo,
+      5_000,
+    );
+    await waitForFiles([secondReady]);
+    await writeFile(secondGo, "go\n", { mode: 0o600 });
+
+    expect(await second).toEqual(
+      expect.objectContaining({
+        ok: true,
+        operation: "recover",
+        authority: expect.objectContaining({ generation: 2 }),
+      }),
+    );
+  });
+
+  it("admits exactly one reset generation across independent OS processes", async () => {
+    const root = await tempRoot();
+    const databasePath = path.join(root, "leases.sqlite");
+    const authorityPath = path.join(root, "authority.json");
+    const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+    const acquired = await store.acquire({
+      namespace: "reset:race",
+      owner: {
+        ownerId: "reset-controller",
+        processId: process.pid,
+        host: hostname(),
+      },
+      leaseDurationMs: 5_000,
+    });
+    await writeFile(authorityPath, JSON.stringify(acquired.authority), {
+      mode: 0o600,
+    });
+    store.close();
+
+    const goPath = path.join(root, "reset-go");
+    const readyPaths = [
+      path.join(root, "reset-ready-a"),
+      path.join(root, "reset-ready-b"),
+    ];
+    const attempts = readyPaths.map((readyPath) =>
+      rolloverWorkerResult(databasePath, authorityPath, readyPath, goPath),
+    );
+    await waitForFiles(readyPaths);
+    await writeFile(goPath, "go\n", { mode: 0o600 });
+    const results = await Promise.all(attempts);
+
+    expect(results.filter((result) => result.ok)).toEqual([
+      expect.objectContaining({
+        authority: expect.objectContaining({ generation: 2 }),
+      }),
+    ]);
+    expect(results.filter((result) => !result.ok)).toEqual([
+      expect.objectContaining({ code: "SYNTHETIC_LEASE_LOST" }),
+    ]);
+    const readback = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+    expect(await readback.read("reset:race")).toEqual(
+      expect.objectContaining({ generation: 2, revision: 2, status: "active" }),
+    );
+    readback.close();
+  });
+
+  it("rejects wrong-owner release and stale writes after rollover", async () => {
+    const root = await tempRoot();
+    const store = new SqliteSyntheticEnvironmentLeaseStore(
+      path.join(root, "leases.sqlite"),
+    );
+    store.database.run("CREATE TABLE domain_writes (value TEXT NOT NULL)");
+    const acquired = await store.acquire({
+      namespace: "guarded:one",
+      owner: { ownerId: "owner-a", processId: process.pid, host: hostname() },
+      leaseDurationMs: 5_000,
+    });
+    const wrongOwner = {
+      ...acquired.authority,
+      owner: { ...acquired.authority.owner, ownerId: "owner-b" },
+    };
+    await expect(store.release(wrongOwner)).rejects.toMatchObject({
+      code: "SYNTHETIC_LEASE_LOST",
+    });
+    const heartbeat = await store.heartbeat({
+      authority: acquired.authority,
+      leaseDurationMs: 5_000,
+    });
+    expect(heartbeat).toEqual(
+      expect.objectContaining({
+        operation: "heartbeat",
+        snapshot: expect.objectContaining({ revision: 2, status: "active" }),
+      }),
+    );
+
+    const firstWrite = await store.withActiveGeneration(
+      acquired.authority,
+      (database) => {
+        database.run(
+          "INSERT INTO domain_writes (value) VALUES ('generation-1')",
+        );
+        return "committed";
+      },
+    );
+    expect(firstWrite).toEqual(
+      expect.objectContaining({
+        value: "committed",
+        receipt: expect.objectContaining({ operation: "guarded-write" }),
+      }),
+    );
+    const rolled = await store.rollover({
+      authority: acquired.authority,
+      leaseDurationMs: 5_000,
+    });
+    expect(rolled.authority.generation).toBe(2);
+    await expect(
+      store.withActiveGeneration(acquired.authority, (database) => {
+        database.run("INSERT INTO domain_writes (value) VALUES ('stale')");
+      }),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_LEASE_LOST" });
+    expect(
+      store.database
+        .query("SELECT value FROM domain_writes ORDER BY value")
+        .all(),
+    ).toEqual([{ value: "generation-1" }]);
+
+    const released = await store.release(rolled.authority);
+    expect(released.snapshot).toEqual(
+      expect.objectContaining({
+        generation: 2,
+        revision: 4,
+        status: "released",
+      }),
+    );
+    store.close();
+  });
+
+  it("rolls a write back when the lease expires before commit", async () => {
+    const root = await tempRoot();
+    const store = new SqliteSyntheticEnvironmentLeaseStore(
+      path.join(root, "leases.sqlite"),
+    );
+    store.database.run("CREATE TABLE domain_writes (value TEXT NOT NULL)");
+    const acquired = await store.acquire({
+      namespace: "expiry:write",
+      owner: { ownerId: "owner-a", processId: process.pid, host: hostname() },
+      leaseDurationMs: 40,
+    });
+    await expect(
+      store.withActiveGeneration(acquired.authority, async (database) => {
+        database.run(
+          "INSERT INTO domain_writes (value) VALUES ('must-rollback')",
+        );
+        await Bun.sleep(80);
+      }),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_LEASE_LOST" });
+    expect(
+      store.database.query("SELECT value FROM domain_writes").all(),
+    ).toEqual([]);
+    store.close();
+  });
+});

--- a/packages/cloud/test-mocks/test/synthetic-environment-lease.test.ts
+++ b/packages/cloud/test-mocks/test/synthetic-environment-lease.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { hostname } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,11 +12,15 @@ import type { SyntheticEnvironmentLeaseAuthority } from "@elizaos/shared/contrac
 import { SqliteSyntheticEnvironmentLeaseStore } from "../src/synthetic-environment/sqlite-lease-store";
 
 const roots: string[] = [];
+const holders: Array<ReturnType<typeof Bun.spawn>> = [];
 const workerPath = fileURLToPath(
   new URL("./fixtures/synthetic-lease-worker.ts", import.meta.url),
 );
 const rolloverWorkerPath = fileURLToPath(
   new URL("./fixtures/synthetic-rollover-worker.ts", import.meta.url),
+);
+const holderWorkerPath = fileURLToPath(
+  new URL("./fixtures/synthetic-lease-holder.ts", import.meta.url),
 );
 
 async function tempRoot(): Promise<string> {
@@ -118,11 +122,63 @@ async function rolloverWorkerResult(
 
 afterEach(async () => {
   await Promise.all(
+    holders.splice(0).map(async (holder) => {
+      if (holder.exitCode === null) holder.kill("SIGKILL");
+      await holder.exited;
+    }),
+  );
+  await Promise.all(
     roots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
   );
 });
 
 describe("SqliteSyntheticEnvironmentLeaseStore", () => {
+  it("shares the control protocol namespace contract and rejects malformed runtime input", async () => {
+    const root = await tempRoot();
+    const store = new SqliteSyntheticEnvironmentLeaseStore(
+      path.join(root, "leases.sqlite"),
+    );
+    await expect(store.acquire(null as never)).rejects.toMatchObject({
+      code: "SYNTHETIC_LEASE_INVALID_INPUT",
+    });
+    await expect(
+      store.acquire({
+        namespace: undefined as never,
+        owner: { ownerId: "owner", processId: process.pid, host: hostname() },
+        leaseDurationMs: 5_000,
+      }),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_LEASE_INVALID_INPUT" });
+    await expect(
+      store.acquire({
+        namespace: " namespace-with-outer-space ",
+        owner: { ownerId: "owner", processId: process.pid, host: hostname() },
+        leaseDurationMs: 5_000,
+      }),
+    ).rejects.toMatchObject({ code: "SYNTHETIC_LEASE_INVALID_INPUT" });
+    const compatibleNamespace = `scenario/${"x".repeat(503)}`;
+    const acquired = await store.acquire({
+      namespace: compatibleNamespace,
+      owner: { ownerId: "owner", processId: process.pid, host: hostname() },
+      leaseDurationMs: 5_000,
+    });
+    expect(acquired.authority.namespace).toBe(compatibleNamespace);
+    store.close();
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "refuses a symbolic-link database target",
+    async () => {
+      const root = await tempRoot();
+      const target = path.join(root, "target.sqlite");
+      await writeFile(target, "not a database", { mode: 0o600 });
+      const linked = path.join(root, "linked.sqlite");
+      await symlink(target, linked);
+      expect(() => new SqliteSyntheticEnvironmentLeaseStore(linked)).toThrow(
+        expect.objectContaining({ code: "SYNTHETIC_LEASE_INVALID_INPUT" }),
+      );
+    },
+  );
+
   it("admits exactly one of two independent OS processes", async () => {
     const root = await tempRoot();
     const databasePath = path.join(root, "leases.sqlite");
@@ -196,6 +252,101 @@ describe("SqliteSyntheticEnvironmentLeaseStore", () => {
         authority: expect.objectContaining({ generation: 2 }),
       }),
     );
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "recovers only after a SIGKILL holder's lease expires",
+    async () => {
+      const root = await tempRoot();
+      const databasePath = path.join(root, "leases.sqlite");
+      const acquiredPath = path.join(root, "killed-authority.json");
+      const holder = Bun.spawn(
+        [
+          process.execPath,
+          "--conditions=eliza-source",
+          holderWorkerPath,
+          databasePath,
+          "recovery:killed",
+          acquiredPath,
+          "120",
+        ],
+        { cwd: path.dirname(holderWorkerPath), stdout: "pipe", stderr: "pipe" },
+      );
+      holders.push(holder);
+      await waitForFiles([acquiredPath]);
+      holder.kill("SIGKILL");
+      await holder.exited;
+
+      const store = new SqliteSyntheticEnvironmentLeaseStore(databasePath);
+      await expect(
+        store.acquire({
+          namespace: "recovery:killed",
+          owner: {
+            ownerId: "too-early",
+            processId: process.pid,
+            host: hostname(),
+          },
+          leaseDurationMs: 5_000,
+        }),
+      ).rejects.toMatchObject({ code: "SYNTHETIC_LEASE_COLLISION" });
+      await Bun.sleep(160);
+      const recovered = await store.acquire({
+        namespace: "recovery:killed",
+        owner: {
+          ownerId: "recovery-owner",
+          processId: process.pid,
+          host: hostname(),
+        },
+        leaseDurationMs: 5_000,
+      });
+      expect(recovered).toEqual(
+        expect.objectContaining({
+          operation: "recover",
+          authority: expect.objectContaining({ generation: 2 }),
+        }),
+      );
+      store.close();
+    },
+  );
+
+  it("sequences readback and refuses close during a guarded transaction", async () => {
+    const root = await tempRoot();
+    const store = new SqliteSyntheticEnvironmentLeaseStore(
+      path.join(root, "leases.sqlite"),
+    );
+    const acquired = await store.acquire({
+      namespace: "sequence:one",
+      owner: { ownerId: "owner", processId: process.pid, host: hostname() },
+      leaseDurationMs: 5_000,
+    });
+    let unblock: () => void = () => undefined;
+    const barrier = new Promise<void>((resolve) => {
+      unblock = resolve;
+    });
+    let entered: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    const guarded = store.withActiveGeneration(acquired.authority, async () => {
+      entered();
+      await barrier;
+    });
+    await started;
+    expect(() => store.close()).toThrow(
+      expect.objectContaining({ code: "SYNTHETIC_LEASE_STORAGE_FAILURE" }),
+    );
+    let readResolved = false;
+    const read = store.read("sequence:one").then((snapshot) => {
+      readResolved = true;
+      return snapshot;
+    });
+    await Bun.sleep(20);
+    expect(readResolved).toBe(false);
+    unblock();
+    await guarded;
+    expect(await read).toEqual(expect.objectContaining({ generation: 1 }));
+    store.close();
+    store.close();
   });
 
   it("admits exactly one reset generation across independent OS processes", async () => {

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -55,6 +55,10 @@ import "@elizaos/shared/brand.css";
 | `@elizaos/shared/config/allowed-hosts` | Allowed-hosts config helper |
 | `@elizaos/shared/contracts/synthetic-environment-lease` | Lease, generation, receipt, and guarded-write contract for synthetic environments |
 
+Synthetic environment leases and subprocess control envelopes share the exact
+namespace checked by `isSyntheticEnvironmentNamespace`: 1-512 non-control
+characters with no leading/trailing whitespace normalization.
+
 ## Building
 
 ```bash

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -53,6 +53,7 @@ import "@elizaos/shared/brand.css";
 | `@elizaos/shared/character-presets` | Built-in character preset definitions |
 | `@elizaos/shared/runtime-env` | Port and security config resolvers |
 | `@elizaos/shared/config/allowed-hosts` | Allowed-hosts config helper |
+| `@elizaos/shared/contracts/synthetic-environment-lease` | Lease, generation, receipt, and guarded-write contract for synthetic environments |
 
 ## Building
 
@@ -66,4 +67,3 @@ bun run --cwd packages/shared test        # run tests
 
 - The root barrel (`src/index.ts`) must remain importable in both browser and Node.js. Do not add Node.js-only or value-level React imports to it. The only React reference is a type-only `import type { ReactNode }` in `src/config/config-catalog.ts`, which is erased at compile time.
 - Do not import from `@elizaos/agent` inside this package — it creates an ESM cycle that breaks server boot. See comments in `src/config/config.ts`.
-

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -323,6 +323,16 @@
       "import": "./dist/contracts/scheduled-task-execution.js",
       "default": "./dist/contracts/scheduled-task-execution.js"
     },
+    "./contracts/synthetic-environment-lease": {
+      "types": "./dist/contracts/synthetic-environment-lease.d.ts",
+      "eliza-source": {
+        "types": "./src/contracts/synthetic-environment-lease.ts",
+        "import": "./src/contracts/synthetic-environment-lease.ts",
+        "default": "./src/contracts/synthetic-environment-lease.ts"
+      },
+      "import": "./dist/contracts/synthetic-environment-lease.js",
+      "default": "./dist/contracts/synthetic-environment-lease.js"
+    },
     "./utils/asset-url": {
       "types": "./dist/utils/asset-url.d.ts",
       "eliza-source": {

--- a/packages/shared/src/contracts/index.ts
+++ b/packages/shared/src/contracts/index.ts
@@ -46,6 +46,7 @@ export * from "./scheduled-task-execution.js";
 export * from "./service-routing.js";
 export * from "./skills-routes.js";
 export * from "./subscription-routes.js";
+export * from "./synthetic-environment-lease.js";
 export * from "./tail-routes.js";
 export * from "./update-status.js";
 export * from "./verification.js";

--- a/packages/shared/src/contracts/synthetic-environment-lease.ts
+++ b/packages/shared/src/contracts/synthetic-environment-lease.ts
@@ -1,0 +1,96 @@
+/**
+ * Defines the fencing contract that synthetic-environment writers use across
+ * local scenario processes and Cloud workers. Implementations must serialize
+ * generation changes with guarded writes so validation cannot race a reset.
+ */
+
+export const SYNTHETIC_ENVIRONMENT_LEASE_VERSION = 1 as const;
+
+export type SyntheticEnvironmentLeaseErrorCode =
+  | "SYNTHETIC_LEASE_COLLISION"
+  | "SYNTHETIC_LEASE_INVALID_INPUT"
+  | "SYNTHETIC_LEASE_LOST"
+  | "SYNTHETIC_LEASE_NOT_FOUND"
+  | "SYNTHETIC_LEASE_STORAGE_FAILURE";
+
+export interface SyntheticEnvironmentLeaseOwner {
+  ownerId: string;
+  processId: number | null;
+  host: string;
+}
+
+export interface SyntheticEnvironmentLeaseAuthority {
+  version: typeof SYNTHETIC_ENVIRONMENT_LEASE_VERSION;
+  namespace: string;
+  generation: number;
+  leaseId: string;
+  owner: SyntheticEnvironmentLeaseOwner;
+}
+
+export interface SyntheticEnvironmentLeaseSnapshot {
+  version: typeof SYNTHETIC_ENVIRONMENT_LEASE_VERSION;
+  namespace: string;
+  generation: number;
+  leaseId: string | null;
+  owner: SyntheticEnvironmentLeaseOwner | null;
+  acquiredAt: string | null;
+  heartbeatAt: string | null;
+  expiresAt: string | null;
+  releasedAt: string | null;
+  revision: number;
+  status: "active" | "expired" | "released";
+  observedAt: string;
+}
+
+export interface SyntheticEnvironmentLeaseReceipt {
+  operation:
+    | "acquire"
+    | "recover"
+    | "heartbeat"
+    | "rollover"
+    | "release"
+    | "guarded-write";
+  authority: SyntheticEnvironmentLeaseAuthority;
+  snapshot: SyntheticEnvironmentLeaseSnapshot;
+}
+
+export interface AcquireSyntheticEnvironmentLeaseInput {
+  namespace: string;
+  owner: SyntheticEnvironmentLeaseOwner;
+  leaseDurationMs: number;
+}
+
+export interface RefreshSyntheticEnvironmentLeaseInput {
+  authority: SyntheticEnvironmentLeaseAuthority;
+  leaseDurationMs: number;
+}
+
+export interface GuardedSyntheticEnvironmentWriteResult<T> {
+  value: T;
+  receipt: SyntheticEnvironmentLeaseReceipt;
+}
+
+/**
+ * A storage boundary that fences reset/reseed generations. The implementation
+ * passes its authoritative transaction to each write so callers can mutate
+ * production repositories within the same exclusion boundary.
+ */
+export interface SyntheticEnvironmentLeaseStore<TWriteContext> {
+  acquire(
+    input: AcquireSyntheticEnvironmentLeaseInput,
+  ): Promise<SyntheticEnvironmentLeaseReceipt>;
+  read(namespace: string): Promise<SyntheticEnvironmentLeaseSnapshot | null>;
+  heartbeat(
+    input: RefreshSyntheticEnvironmentLeaseInput,
+  ): Promise<SyntheticEnvironmentLeaseReceipt>;
+  rollover(
+    input: RefreshSyntheticEnvironmentLeaseInput,
+  ): Promise<SyntheticEnvironmentLeaseReceipt>;
+  release(
+    authority: SyntheticEnvironmentLeaseAuthority,
+  ): Promise<SyntheticEnvironmentLeaseReceipt>;
+  withActiveGeneration<T>(
+    authority: SyntheticEnvironmentLeaseAuthority,
+    write: (context: TWriteContext) => T | Promise<T>,
+  ): Promise<GuardedSyntheticEnvironmentWriteResult<T>>;
+}

--- a/packages/shared/src/contracts/synthetic-environment-lease.ts
+++ b/packages/shared/src/contracts/synthetic-environment-lease.ts
@@ -5,6 +5,29 @@
  */
 
 export const SYNTHETIC_ENVIRONMENT_LEASE_VERSION = 1 as const;
+/** Matches the synthetic subprocess control envelope's namespace bound. */
+export const SYNTHETIC_ENVIRONMENT_NAMESPACE_MAX_LENGTH = 512 as const;
+
+function containsControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+/** Checks the canonical namespace shared by lease and subprocess authorities. */
+export function isSyntheticEnvironmentNamespace(
+  value: unknown,
+): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= SYNTHETIC_ENVIRONMENT_NAMESPACE_MAX_LENGTH &&
+    value === value.trim() &&
+    !containsControlCharacter(value)
+  );
+}
 
 export type SyntheticEnvironmentLeaseErrorCode =
   | "SYNTHETIC_LEASE_COLLISION"


### PR DESCRIPTION
# Relates to

Refs #24076.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin develop && git rebase origin/develop`).
- [x] `bun install --frozen-lockfile` and `bun run verify` were run after sync; the exact unrelated verify blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code from the subprocess, PGlite, migration, and production-repository evidence below.

# Sync with develop

- [x] Rebased onto `origin/develop` at `a8aa79511f5ea9b4b72a76394f1f2f7196bde49b`; zero conflicts. Exact head: `68f9433b451534607e4a8e396f805a0ffa4abb87`.
- [x] `bun run verify` was run post-sync. It reaches the workspace lane and then fails on pre-existing Biome formatting in `packages/agent/src/api/accounts-routes.ts` and four other untouched agent files; details are below.

# Risks

Medium. This adds a Cloud migration and an authoritative lock boundary. The operations are namespace-scoped, use row/SQLite transactions, never perform broad deletion, and store no credential material. Lease expiry uses the authoritative database clock in Cloud and guarded writes revalidate before commit.

# Background

## What does this PR do?

- Defines one versioned lease/generation/owner/receipt contract shared by local scenario processes and Cloud workers.
- Implements an OS-visible SQLite authority for local/e2e runners. Independent processes serialize through the database, not a process singleton or a parallel world-data model.
- Implements the same contract on the primary Cloud PostgreSQL boundary with row locks and database-clock expiry.
- Fences reset/reseed work with `withActiveGeneration`: the caller receives the same authoritative transaction used by the lease store, and the lease is revalidated after the callback before commit.
- Adds canonical readback, heartbeat, release, generation rollover, collision refusal, stale-owner refusal, and explicit crash/expiry recovery receipts.
- Proves a real existing production consumer by calling `agentsRepository.create(..., tx)` inside the guarded Cloud transaction; stale and expired-generation agent writes are absent after rollback.

## What kind of change is this?

Feature (non-breaking testing and Cloud persistence primitive).

# Documentation changes needed?

The shared contract, local adapter, Cloud adapter, and export paths are documented in their owning READMEs.

# Testing

## Where should a reviewer start?

Start with `packages/shared/src/contracts/synthetic-environment-lease.ts`, then the SQLite subprocess test and the PGlite production-repository test.

## Detailed testing steps

```bash
bun install --frozen-lockfile
bun --conditions=eliza-source test packages/cloud/test-mocks/test/synthetic-environment-lease.test.ts
bun --conditions=eliza-source test --isolate packages/cloud/shared/src/db/repositories/synthetic-environment-leases.pglite.test.ts
bun --conditions=eliza-source test packages/cloud/shared/src/db/synthetic-environment-leases-migration.test.ts
bun run --cwd packages/cloud/shared db:check-migrations
bun run --cwd packages/shared typecheck
bun run --cwd packages/cloud/shared typecheck
```

Post-rebase results at this head:

- SQLite/subprocess: 9 passed, 0 failed, 27 assertions. Two independent OS processes race acquisition and rollover; exactly one wins each race. Real SIGKILL/expiry recovery, canonical namespace validation, symlink refusal, read/close serialization, wrong-owner release, stale generation refusal, receipt/readback, and rollback after expiry pass.
- Cloud/PGlite: 4 passed, 0 failed, 15 assertions. Concurrent collision, canonical readback, production `AgentsRepository` commit, stale/expired production-write rollback, wrong-owner release, expiry recovery, and clean reacquisition pass.
- Migration/PGlite: 1 passed, 0 failed, 3 assertions. The table, active-authority constraint, and expiry index are exercised.
- `drizzle-kit check`: `Everything's fine`.
- Shared typecheck passes. Cloud-shared typecheck is blocked only by an unrelated missing declaration for the existing `@elizaos/plugin-doordash` build overlay; no touched lease file has a TypeScript diagnostic.
- Touched-file Biome check and `git diff --check` pass.

# Evidence Gate

<!-- evidence-head:68f9433b451534607e4a8e396f805a0ffa4abb87 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - this persistence/concurrency primitive has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - this persistence/concurrency primitive has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no user-facing interaction or visual flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no HTTP or long-running backend service path changes; the authoritative database executions are recorded as domain evidence below.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, request, or state path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head database and separate-process receipts/readback, including production repository commits and rollbacks:

```text
OS processes: acquisition race = one generation-1 receipt + one SYNTHETIC_LEASE_COLLISION; rollover race = one generation-2 receipt + one SYNTHETIC_LEASE_LOST.
Cloud production repository: committed agent readback = [{ id: generationOneId, name: "Generation One Agent" }]; stale-generation agent readback = [].
Cloud expiry rollback: the production AgentsRepository callback inserted an agent, exceeded the lease, returned SYNTHETIC_LEASE_LOST, and final agent readback = [].
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changes.

# Evidence Details

## Real LLM-call trajectory

N/A - this change is below the model/runtime behavior boundary.

## Backend + frontend logs

N/A - no frontend or network server flow is involved.

## Domain artifacts

<details>
<summary>Independent OS-process lease authority</summary>

```text
(pass) shares the control protocol namespace contract and rejects malformed runtime input
(pass) refuses a symbolic-link database target
(pass) admits exactly one of two independent OS processes
(pass) recovers an expired crashed owner with a higher generation
(pass) recovers only after a SIGKILL holder's lease expires
(pass) sequences readback and refuses close during a guarded transaction
(pass) admits exactly one reset generation across independent OS processes
(pass) rejects wrong-owner release and stale writes after rollover
(pass) rolls a write back when the lease expires before commit

9 pass, 0 fail, 27 expect() calls
```

The subprocess result channel carries either a full acquire/rollover receipt or an `ElizaError` code. The tests assert one fulfilled generation receipt plus one `SYNTHETIC_LEASE_COLLISION`, then canonical SQLite readback; after rollover, the old authority receives `SYNTHETIC_LEASE_LOST`.
</details>

<details>
<summary>Cloud primary-transaction production consumer</summary>

```text
(pass) admits one concurrent owner and returns canonical readback
(pass) holds the generation lock across a production transaction callback
(pass) rolls back a guarded write that outlives its lease
(pass) recovers expiry and advances generations after clean release

4 pass, 0 fail, 15 expect() calls
```

The guarded callback calls the existing production `agentsRepository.create` with the lease transaction. Readback is exactly one generation-one agent row; the stale-generation agent row and the row written after lease expiry are both exactly `[]` after rollback.
</details>

<details>
<summary>Migration and schema readback</summary>

```text
(pass) 0299 synthetic environment leases migration > creates the fenced authority table and rejects partial authority rows
1 pass, 0 fail, 3 expect() calls

drizzle-kit check: Everything's fine
```
</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changes.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT changes.

## Known gaps / failures

- A prior `bun run verify` was run after rebase and install; the final two commits are patch-equivalent after the current-base rebase. The touched Cloud package now passes Biome, but the repository lane stops on pre-existing formatting errors in untouched `packages/agent` files, including `src/api/accounts-routes.ts`. No changed file appears in that diagnostic.
- `bun run --cwd packages/cloud/test-mocks typecheck` reaches the existing unrelated `src/control-plane/server.ts:274` error: `Promise<boolean>` is not assignable to `Promise<void>`. Cloud-shared typecheck is additionally blocked by an unrelated missing `@elizaos/plugin-doordash` declaration in the local build overlay. The focused runtime tests pass and no touched file has a TypeScript diagnostic.
- Screenshots, video, OCR, frontend logs, backend server logs, live-model trajectory, and audio are inapplicable because this PR changes only shared contracts and transaction-backed persistence/test infrastructure.

## Provenance

- AI provider / model: openai / gpt-5.6-sol
- Client / agent tooling: Codex Desktop
- Contribution skill revision: N/A - no contribution skill used
- Attribution status: self-reported

— [synthetic-world-child]

