### PR TITLE
fix(ui): unify registered surface agent bridge

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -173,7 +173,13 @@ import {
 } from "@elizaos/ui/utils/cloud-agent-base";
 // biome-ignore lint/correctness/noUnusedImports: classic JSX output in this app bundle expects React in module scope.
 import * as React from "react";
-import { type ComponentType, lazy, StrictMode, Suspense } from "react";
+import {
+  type ComponentType,
+  lazy,
+  type ReactNode,
+  StrictMode,
+  Suspense,
+} from "react";
 import ReactDomClient from "react-dom/client";
 import {
   APP_BRANDING_BASE,
@@ -225,7 +231,10 @@ import {
   SIDE_EFFECT_APP_MODULE_LOADERS,
   type SideEffectAppModuleLoader,
 } from "./plugin-registrations";
-import { resolveRendererShellKind } from "./renderer-shell-scope";
+import {
+  PHONE_COMPANION_AGENT_VIEW_ID,
+  resolveRendererShellKind,
+} from "./renderer-shell-scope";
 import {
   applyRuntimeChooserOverrideFromUrl,
   removeUrlParameter,
@@ -312,6 +321,17 @@ const App = lazy(async () => {
 const AppWindowRenderer = lazyNamedComponent<{ slug: string }>(async () => {
   const mod = await import("@elizaos/ui/components/apps/AppWindowRenderer");
   return mod.AppWindowRenderer;
+});
+
+const ShellViewAgentSurface = lazyNamedComponent<{
+  viewId: string;
+  surfaceKind: "app-shell";
+  children: ReactNode;
+}>(async () => {
+  const mod = await import(
+    "@elizaos/ui/components/views/ShellViewAgentSurface"
+  );
+  return mod.ShellViewAgentSurface;
 });
 
 /** Desktop-only shell widgets — never static-import into the login entry. */
@@ -2783,7 +2803,12 @@ function mountReactApp(): void {
     ) : (
       <AppProvider branding={APP_BRANDING}>
         {phoneCompanion ? (
-          <PhoneCompanionApp />
+          <ShellViewAgentSurface
+            viewId={PHONE_COMPANION_AGENT_VIEW_ID}
+            surfaceKind="app-shell"
+          >
+            <PhoneCompanionApp />
+          </ShellViewAgentSurface>
         ) : detachedShell ? (
           <div className="flex h-[100dvh] min-h-0 w-full max-w-full flex-col overflow-hidden">
             <DetachedShellRoot route={windowShellRoute} />

--- a/packages/app/src/renderer-shell-scope.test.ts
+++ b/packages/app/src/renderer-shell-scope.test.ts
@@ -6,6 +6,7 @@
  */
 import { describe, expect, it } from "vitest";
 import {
+  PHONE_COMPANION_AGENT_VIEW_ID,
   type RendererShellScopeInputs,
   resolveRendererShellKind,
 } from "./renderer-shell-scope";
@@ -18,7 +19,11 @@ const MAIN_INPUTS: RendererShellScopeInputs = {
   isEmbedRoute: false,
 };
 
-describe("resolveRendererShellKind", () => {
+describe("renderer shell scope", () => {
+  it("keeps the dedicated companion renderer on its app-shell view id", () => {
+    expect(PHONE_COMPANION_AGENT_VIEW_ID).toBe("phone-companion");
+  });
+
   it("classifies the default boot as the main shell", () => {
     expect(resolveRendererShellKind(MAIN_INPUTS)).toBe("main");
   });

--- a/packages/app/src/renderer-shell-scope.ts
+++ b/packages/app/src/renderer-shell-scope.ts
@@ -15,6 +15,9 @@
 import type { RendererShellKind } from "@elizaos/ui/platform/renderer-services";
 import type { WindowShellRoute } from "@elizaos/ui/platform/window-shell";
 
+/** Stable app-shell view id used by the companion's dedicated renderer. */
+export const PHONE_COMPANION_AGENT_VIEW_ID = "phone-companion";
+
 export interface RendererShellScopeInputs {
   windowShellRoute: WindowShellRoute;
   isPopout: boolean;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -85,7 +85,7 @@ import {
   useSlashCommandController,
 } from "./chat/useSlashCommandController";
 import { markCompletedActionNavigationHandled } from "./completed-action-navigation";
-import { getOverlayAppLazyComponent } from "./components/apps/AppWindowRenderer.helpers";
+import { OverlayAppSurface } from "./components/apps/AppWindowRenderer";
 import { GameViewOverlay } from "./components/apps/GameViewOverlay";
 import { getOverlayApp } from "./components/apps/overlay-app-registry";
 import { AgentAuthGateSurface } from "./components/auth/AgentAuthGateSurface";
@@ -233,10 +233,12 @@ import { fetchWithCsrf } from "./api/csrf-client";
 // view, so importing through it folds all of them back into the main chunk.
 import {
   type AppShellPageRegistration,
+  appShellAgentSurfaceDescriptor,
   appShellPageIsAvailable,
   appShellPageMatchesPath,
   getAppShellPageRegistrySnapshot,
   listAppShellPages,
+  requireRegisteredAgentSurface,
   subscribeAppShellPages,
 } from "./app-shell-registry";
 import {
@@ -593,6 +595,9 @@ function RegisteredAppShellPage({
 }: {
   registration: AppShellPageRegistration;
 }) {
+  const bridge = requireRegisteredAgentSurface(
+    appShellAgentSurfaceDescriptor(registration),
+  );
   let content: ReactNode;
   if (registration.Component) {
     const Component = registration.Component;
@@ -627,7 +632,7 @@ function RegisteredAppShellPage({
   // capability bridge for them. This keeps registry pages and remote bundles
   // equivalent: controls registered with useAgentElement are live immediately.
   return (
-    <ShellViewAgentSurface viewId={registration.id}>
+    <ShellViewAgentSurface viewId={bridge.viewId} surfaceKind={bridge.kind}>
       {content}
     </ShellViewAgentSurface>
   );
@@ -3366,25 +3371,17 @@ function AppContent() {
           </div>
         </div>
         {/* Full-screen overlay app — renders whichever overlay app is active */}
-        {resolvedOverlayApp &&
-          (() => {
-            const exitToApps = () => {
+        {resolvedOverlayApp ? (
+          <OverlayAppSurface
+            app={resolvedOverlayApp}
+            exitToApps={() => {
               setState("activeOverlayApp", null);
               setTab("apps");
-            };
-            const theme = uiTheme === "dark" ? "dark" : "light";
-            const LazyOverlay = getOverlayAppLazyComponent(resolvedOverlayApp);
-            if (LazyOverlay) {
-              return (
-                <Suspense fallback={null}>
-                  <LazyOverlay exitToApps={exitToApps} uiTheme={theme} t={t} />
-                </Suspense>
-              );
-            }
-            const Component = resolvedOverlayApp.Component;
-            if (!Component) return null;
-            return <Component exitToApps={exitToApps} uiTheme={theme} t={t} />;
-          })()}
+            }}
+            uiTheme={uiTheme === "dark" ? "dark" : "light"}
+            t={t}
+          />
+        ) : null}
 
         {/* Persistent game overlay — stays visible across all tabs */}
         {activeGameViewerUrl &&

--- a/packages/ui/src/agent-surface/README.md
+++ b/packages/ui/src/agent-surface/README.md
@@ -8,19 +8,23 @@ focus-aware, fillable, clickable, and visible to the agent.
 ## How it fits together
 
 ```
-DynamicViewLoader (host)
- └─ AgentSurfaceProvider viewId/viewType         ← owns one ViewAgentRegistry
-     ├─ <YourView/>  ── useAgentElement(...) ────► registers elements
-     └─ AgentElementOverlay                       ← draws indicators on highlight
+DynamicViewLoader / ShellViewAgentSurface (host)
+ └─ AgentSurfaceProvider viewId/viewType          ← owns one ViewAgentRegistry
+     ├─ <YourView/>  ── useAgentElement(...) ─────► registers elements
+     └─ AgentElementOverlay                        ← draws indicators on highlight
                          ▲
    view-interact handler ┘  POST /api/views/:id/interact → WS → here
        routes agent-surface capabilities to handleAgentSurfaceCapability(registry, …)
 ```
 
-The provider + overlay are mounted by `DynamicViewLoader` for **every** view, so
-a view only has to call `useAgentElement`. `@elizaos/ui` and `react` are
-externalised in the view bundle (see `packages/scripts/view-bundle-vite.config.ts`),
-so the hook resolves to the host singleton and shares the loader's React context.
+The provider + overlay are mounted by `DynamicViewLoader` for served bundles
+and by `ShellViewAgentSurface` for builtins, registered app-shell pages, overlay
+apps, and dedicated app windows. App-shell and overlay owners come from the
+generated registry inventory in `app-shell-registry.ts`; duplicate view ids
+fail before either renderer mounts. A view only has to call `useAgentElement`.
+`@elizaos/ui` and `react` are externalised in served view bundles (see
+`packages/scripts/view-bundle-vite.config.ts`), so the hook resolves to the host
+singleton and shares the loader's React context.
 
 ### Teardown-safe notifications (#20728, #20974)
 

--- a/packages/ui/src/app-shell-registry.test.ts
+++ b/packages/ui/src/app-shell-registry.test.ts
@@ -4,10 +4,13 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  appShellAgentSurfaceDescriptor,
   appShellPageIsAvailable,
   appShellPageMatchesPath,
+  buildRegisteredAgentSurfaceInventory,
   getAppShellPageRegistrySnapshot,
   listAppShellPages,
+  overlayAgentSurfaceDescriptor,
   registerAppShellPage,
   subscribeAppShellPages,
 } from "./app-shell-registry";
@@ -94,5 +97,74 @@ describe("app-shell-registry", () => {
         { managedCloud: false },
       ),
     ).toBe(true);
+  });
+
+  it("derives the exhaustive app-shell and overlay agent-bridge inventory", () => {
+    const page = {
+      id: "wallet.inventory",
+      pluginId: "@elizaos/plugin-wallet",
+      label: "Wallet",
+      path: "/inventory",
+    };
+    const overlay = {
+      name: "@elizaos/plugin-native-settings",
+      displayName: "Device Settings",
+      description: "Device settings",
+      category: "system",
+      icon: null,
+    };
+
+    expect(appShellAgentSurfaceDescriptor(page)).toEqual({
+      kind: "app-shell",
+      viewId: "wallet.inventory",
+      ownerId: "@elizaos/plugin-wallet",
+      path: "/inventory",
+    });
+    expect(overlayAgentSurfaceDescriptor(overlay)).toEqual({
+      kind: "overlay",
+      viewId: "native-settings",
+      ownerId: "@elizaos/plugin-native-settings",
+      path: "/apps/native-settings",
+    });
+    expect(
+      buildRegisteredAgentSurfaceInventory([page], [overlay]).map(
+        ({ viewId }) => viewId,
+      ),
+    ).toEqual(["native-settings", "wallet.inventory"]);
+  });
+
+  it("fails closed when two registered renderers would own one handler key", () => {
+    expect(() =>
+      buildRegisteredAgentSurfaceInventory(
+        [
+          {
+            id: "contacts",
+            pluginId: "@elizaos/plugin-contacts-page",
+            label: "Contacts",
+            path: "/contacts",
+          },
+        ],
+        [
+          {
+            name: "@elizaos/plugin-contacts",
+            displayName: "Contacts",
+            description: "Contacts",
+            category: "system",
+            icon: null,
+          },
+        ],
+      ),
+    ).toThrow(/registered by both app-shell:.* and overlay:/);
+  });
+
+  it("rejects empty app-shell ids before they reach the bridge", () => {
+    expect(() =>
+      appShellAgentSurfaceDescriptor({
+        id: "  ",
+        pluginId: "test-plugin",
+        label: "Invalid",
+        path: "/invalid",
+      }),
+    ).toThrow(/empty agent view id/);
   });
 });

--- a/packages/ui/src/app-shell-registry.ts
+++ b/packages/ui/src/app-shell-registry.ts
@@ -1,6 +1,8 @@
 /**
- * Runtime registry of app-shell nav pages: registerAppShellPage / listAppShellPages.
- * Plugins and the host contribute nav tabs; the shell renders the snapshot.
+ * Owns app-shell page registration and the generated in-process agent-bridge
+ * inventory shared with overlay-app renderers. Plugins contribute metadata;
+ * the shell derives stable bridge owners from the live registry snapshots and
+ * rejects ambiguous handler ids before mounting either surface family.
  */
 import type {
   AppShellBackgroundPolicy,
@@ -8,6 +10,11 @@ import type {
   ViewHeaderPolicy,
   ViewKind,
 } from "@elizaos/core";
+import {
+  getAllOverlayApps,
+  type OverlayApp,
+  packageNameToAppRouteSlug,
+} from "@elizaos/shared";
 import type { ComponentType } from "react";
 import { getUiRegistryStore } from "./registry-host";
 
@@ -177,6 +184,128 @@ export function subscribeAppShellPages(listener: () => void): () => void {
 
 export function getAppShellPageRegistrySnapshot(): number {
   return getRegistryStore().version;
+}
+
+export type RegisteredAgentSurfaceKind = "app-shell" | "overlay";
+
+export interface RegisteredAgentSurfaceDescriptor {
+  kind: RegisteredAgentSurfaceKind;
+  viewId: string;
+  ownerId: string;
+  path: string;
+}
+
+function requireStableAgentViewId(
+  value: string,
+  kind: RegisteredAgentSurfaceKind,
+  ownerId: string,
+): string {
+  const viewId = value.trim();
+  if (viewId.length === 0) {
+    throw new Error(
+      `Registered ${kind} surface "${ownerId}" resolved an empty agent view id`,
+    );
+  }
+  return viewId;
+}
+
+function overlayAgentViewId(appName: string): string {
+  const packageSlug = packageNameToAppRouteSlug(appName);
+  if (packageSlug) return packageSlug;
+  return appName
+    .replace(/^@[^/]+\//, "")
+    .replace(/^(app|plugin)-/, "")
+    .replace(/[^a-z0-9-]/gi, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .toLowerCase();
+}
+
+/** The bridge descriptor generated for one app-shell page registration. */
+export function appShellAgentSurfaceDescriptor(
+  page: AppShellPageRegistration,
+): RegisteredAgentSurfaceDescriptor {
+  return {
+    kind: "app-shell",
+    viewId: requireStableAgentViewId(page.id, "app-shell", page.pluginId),
+    ownerId: page.pluginId,
+    path: page.path,
+  };
+}
+
+/** The bridge descriptor generated for one overlay-app registration. */
+export function overlayAgentSurfaceDescriptor(
+  app: OverlayApp,
+): RegisteredAgentSurfaceDescriptor {
+  const viewId = requireStableAgentViewId(
+    overlayAgentViewId(app.name),
+    "overlay",
+    app.name,
+  );
+  return {
+    kind: "overlay",
+    viewId,
+    ownerId: app.name,
+    path: `/apps/${viewId}`,
+  };
+}
+
+/**
+ * Build the exhaustive in-process bridge inventory from registry snapshots.
+ * Duplicate identities fail closed: two mounted surfaces cannot safely share
+ * one `viewType:viewId` interact-handler key.
+ */
+export function buildRegisteredAgentSurfaceInventory(
+  appShellPages: readonly AppShellPageRegistration[],
+  overlayApps: readonly OverlayApp[],
+): RegisteredAgentSurfaceDescriptor[] {
+  const descriptors = [
+    ...appShellPages.map(appShellAgentSurfaceDescriptor),
+    ...overlayApps.map(overlayAgentSurfaceDescriptor),
+  ];
+  const ownersByViewId = new Map<string, RegisteredAgentSurfaceDescriptor>();
+  for (const descriptor of descriptors) {
+    const existing = ownersByViewId.get(descriptor.viewId);
+    if (existing) {
+      throw new Error(
+        `Agent surface view id "${descriptor.viewId}" is registered by both ` +
+          `${existing.kind}:${existing.ownerId} and ${descriptor.kind}:${descriptor.ownerId}`,
+      );
+    }
+    ownersByViewId.set(descriptor.viewId, descriptor);
+  }
+  return descriptors.sort((left, right) =>
+    left.viewId.localeCompare(right.viewId),
+  );
+}
+
+/** The current exhaustive bridge inventory, generated from both registries. */
+export function listRegisteredAgentSurfaceInventory(): RegisteredAgentSurfaceDescriptor[] {
+  return buildRegisteredAgentSurfaceInventory(
+    listAppShellPages(),
+    getAllOverlayApps(),
+  );
+}
+
+/**
+ * Resolve a renderer's descriptor through the exhaustive live inventory. This
+ * makes duplicate-id validation part of the mount path, not a test-only audit.
+ */
+export function requireRegisteredAgentSurface(
+  expected: RegisteredAgentSurfaceDescriptor,
+): RegisteredAgentSurfaceDescriptor {
+  const descriptor = listRegisteredAgentSurfaceInventory().find(
+    (candidate) =>
+      candidate.kind === expected.kind &&
+      candidate.viewId === expected.viewId &&
+      candidate.ownerId === expected.ownerId,
+  );
+  if (!descriptor) {
+    throw new Error(
+      `Agent surface ${expected.kind}:${expected.viewId} is not present in the live registry inventory`,
+    );
+  }
+  return descriptor;
 }
 
 /**

--- a/packages/ui/src/components/apps/AppWindowRenderer.test.tsx
+++ b/packages/ui/src/components/apps/AppWindowRenderer.test.tsx
@@ -6,11 +6,17 @@
 // @vitest-environment jsdom
 
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AgentButton } from "../../agent-surface";
 import { invokeViewInteract } from "../views/view-interact-registry";
-import { AppWindowRenderer } from "./AppWindowRenderer";
+import { AppWindowRenderer, OverlayAppSurface } from "./AppWindowRenderer";
 import { registerOverlayApp } from "./overlay-app-registry";
+
+const reportRendererDiagnostic = vi.hoisted(() => vi.fn());
+vi.mock("../../utils/renderer-diagnostics", () => ({
+  reportRendererDiagnostic,
+}));
 
 afterEach(cleanup);
 
@@ -58,6 +64,105 @@ describe("AppWindowRenderer agent bridge", () => {
     expect(onClick).toHaveBeenCalledOnce();
 
     rendered.unmount();
-    expect(onStop).toHaveBeenCalledOnce();
+    await waitFor(() => expect(onStop).toHaveBeenCalledOnce());
+  });
+
+  it("waits for an in-flight launch before stopping an unmounted app", async () => {
+    let finishLaunch: (() => void) | undefined;
+    const launchBarrier = new Promise<void>((resolve) => {
+      finishLaunch = resolve;
+    });
+    const onLaunch = vi.fn(() => launchBarrier);
+    const onStop = vi.fn();
+    registerOverlayApp({
+      name: "@elizaos/plugin-bridge-lifecycle-barrier-test",
+      displayName: "Bridge lifecycle barrier test",
+      description: "Agent bridge lifecycle fixture",
+      category: "test",
+      icon: null,
+      Component: () => <div>Lifecycle fixture</div>,
+      onLaunch,
+      onStop,
+    });
+
+    const rendered = render(
+      <AppWindowRenderer slug="bridge-lifecycle-barrier-test" />,
+    );
+    await waitFor(() => expect(onLaunch).toHaveBeenCalledOnce());
+    rendered.unmount();
+    await Promise.resolve();
+    expect(onStop).not.toHaveBeenCalled();
+
+    finishLaunch?.();
+    await waitFor(() => expect(onStop).toHaveBeenCalledOnce());
+  });
+
+  it("reports a rejected launch and still runs ordered teardown", async () => {
+    reportRendererDiagnostic.mockClear();
+    const failure = new Error("launch failed");
+    const onStop = vi.fn();
+    registerOverlayApp({
+      name: "@elizaos/plugin-bridge-lifecycle-failure-test",
+      displayName: "Bridge lifecycle failure test",
+      description: "Agent bridge lifecycle failure fixture",
+      category: "test",
+      icon: null,
+      Component: () => <div>Lifecycle failure fixture</div>,
+      onLaunch: async () => {
+        throw failure;
+      },
+      onStop,
+    });
+
+    const rendered = render(
+      <AppWindowRenderer slug="bridge-lifecycle-failure-test" />,
+    );
+    await waitFor(() =>
+      expect(reportRendererDiagnostic).toHaveBeenCalledWith({
+        scope: "overlay-app.launch",
+        error: failure,
+        context: {
+          appName: "@elizaos/plugin-bridge-lifecycle-failure-test",
+        },
+      }),
+    );
+    rendered.unmount();
+    await waitFor(() => expect(onStop).toHaveBeenCalledOnce());
+  });
+
+  it("serializes Strict Mode lifecycle replay without overlapping owners", async () => {
+    const phases: string[] = [];
+    const app = {
+      name: "@elizaos/plugin-bridge-strict-lifecycle-test",
+      displayName: "Bridge strict lifecycle test",
+      description: "Agent bridge Strict Mode lifecycle fixture",
+      category: "test",
+      icon: null,
+      Component: () => <div>Strict lifecycle fixture</div>,
+      onLaunch: async () => {
+        phases.push("launch");
+      },
+      onStop: async () => {
+        phases.push("stop");
+      },
+    };
+    registerOverlayApp(app);
+
+    const rendered = render(
+      <StrictMode>
+        <OverlayAppSurface
+          app={app}
+          exitToApps={() => {}}
+          uiTheme="light"
+          t={(key) => key}
+        />
+      </StrictMode>,
+    );
+    await waitFor(() => expect(phases).toEqual(["launch", "stop", "launch"]));
+
+    rendered.unmount();
+    await waitFor(() =>
+      expect(phases).toEqual(["launch", "stop", "launch", "stop"]),
+    );
   });
 });

--- a/packages/ui/src/components/apps/AppWindowRenderer.test.tsx
+++ b/packages/ui/src/components/apps/AppWindowRenderer.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Verifies that a real registered overlay mounts through the app-window
+ * renderer's generated agent surface and answers list/click interactions.
+ */
+
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentButton } from "../../agent-surface";
+import { invokeViewInteract } from "../views/view-interact-registry";
+import { AppWindowRenderer } from "./AppWindowRenderer";
+import { registerOverlayApp } from "./overlay-app-registry";
+
+afterEach(cleanup);
+
+describe("AppWindowRenderer agent bridge", () => {
+  it("derives the overlay view id and drives its registered control", async () => {
+    const onClick = vi.fn();
+    const onLaunch = vi.fn();
+    const onStop = vi.fn();
+    registerOverlayApp({
+      name: "@elizaos/plugin-bridge-window-test",
+      displayName: "Bridge Window Test",
+      description: "Agent bridge fixture",
+      category: "test",
+      icon: null,
+      Component: () => (
+        <AgentButton agentId="confirm" onClick={onClick}>
+          Confirm
+        </AgentButton>
+      ),
+      onLaunch,
+      onStop,
+    });
+
+    const rendered = render(<AppWindowRenderer slug="bridge-window-test" />);
+    await screen.findByRole("button", { name: "Confirm" });
+    await waitFor(() => expect(onLaunch).toHaveBeenCalledOnce());
+
+    const marker = rendered.container.querySelector(
+      '[data-agent-surface-view-id="bridge-window-test"]',
+    );
+    expect(marker?.getAttribute("data-agent-surface-kind")).toBe("overlay");
+
+    const elements = (await invokeViewInteract(
+      "bridge-window-test",
+      "gui",
+      "list-elements",
+    )) as Array<{ id: string }>;
+    expect(elements.map(({ id }) => id)).toContain("confirm");
+
+    expect(
+      await invokeViewInteract("bridge-window-test", "gui", "agent-click", {
+        id: "confirm",
+      }),
+    ).toMatchObject({ ok: true, id: "confirm" });
+    expect(onClick).toHaveBeenCalledOnce();
+
+    rendered.unmount();
+    expect(onStop).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ui/src/components/apps/AppWindowRenderer.tsx
+++ b/packages/ui/src/components/apps/AppWindowRenderer.tsx
@@ -12,12 +12,14 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import {
   overlayAgentSurfaceDescriptor,
   requireRegisteredAgentSurface,
 } from "../../app-shell-registry";
+import { reportRendererDiagnostic } from "../../utils/renderer-diagnostics";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 import { getOverlayAppLazyComponent } from "./AppWindowRenderer.helpers";
 import { getAppSlug } from "./helpers";
@@ -30,6 +32,26 @@ export interface AppWindowRendererProps {
 
 export interface OverlayAppSurfaceProps extends OverlayAppContext {
   app: OverlayApp;
+}
+
+async function runOverlayLifecycleHook(
+  app: OverlayApp,
+  phase: "launch" | "stop",
+): Promise<void> {
+  const hook = phase === "launch" ? app.onLaunch : app.onStop;
+  if (!hook) return;
+  try {
+    await hook();
+  } catch (error) {
+    // error-policy:J1 the renderer host owns this lifecycle boundary and emits
+    // a structured diagnostic without turning a hook failure into an unhandled
+    // rejection that can take down the shell.
+    reportRendererDiagnostic({
+      scope: `overlay-app.${phase}`,
+      error,
+      context: { appName: app.name },
+    });
+  }
 }
 
 function resolveOverlayAppBySlug(slug: string): OverlayApp | undefined {
@@ -75,10 +97,20 @@ export function OverlayAppSurface({
     overlayAgentSurfaceDescriptor(app),
   );
 
+  const lifecycleQueueRef = useRef<Promise<void>>(Promise.resolve());
   useEffect(() => {
-    void app.onLaunch?.();
+    const launch = lifecycleQueueRef.current.then(() =>
+      runOverlayLifecycleHook(app, "launch"),
+    );
+    lifecycleQueueRef.current = launch;
     return () => {
-      void app.onStop?.();
+      // React does not await effect cleanup. Retaining this promise as the
+      // next effect's predecessor still provides a strict local lease: a stop
+      // cannot overtake its launch, and the successor cannot launch before the
+      // prior owner has fully stopped.
+      lifecycleQueueRef.current = launch.then(() =>
+        runOverlayLifecycleHook(app, "stop"),
+      );
     };
   }, [app]);
 

--- a/packages/ui/src/components/apps/AppWindowRenderer.tsx
+++ b/packages/ui/src/components/apps/AppWindowRenderer.tsx
@@ -14,6 +14,11 @@ import {
   useMemo,
   useState,
 } from "react";
+import {
+  overlayAgentSurfaceDescriptor,
+  requireRegisteredAgentSurface,
+} from "../../app-shell-registry";
+import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 import { getOverlayAppLazyComponent } from "./AppWindowRenderer.helpers";
 import { getAppSlug } from "./helpers";
 import type { OverlayApp, OverlayAppContext } from "./overlay-app-api";
@@ -21,6 +26,10 @@ import { getAvailableOverlayApps } from "./overlay-app-registry";
 
 export interface AppWindowRendererProps {
   slug: string;
+}
+
+export interface OverlayAppSurfaceProps extends OverlayAppContext {
+  app: OverlayApp;
 }
 
 function resolveOverlayAppBySlug(slug: string): OverlayApp | undefined {
@@ -50,6 +59,61 @@ function AppFallback(): React.ReactElement {
   );
 }
 
+/**
+ * Mount one resolved overlay through the same generated bridge used by
+ * registry-backed app-shell pages. Both the main-window overlay and detached
+ * app-window renderer use this component, so lifecycle and interaction
+ * ownership cannot drift between launch paths.
+ */
+export function OverlayAppSurface({
+  app,
+  exitToApps,
+  uiTheme,
+  t,
+}: OverlayAppSurfaceProps): React.ReactElement {
+  const descriptor = requireRegisteredAgentSurface(
+    overlayAgentSurfaceDescriptor(app),
+  );
+
+  useEffect(() => {
+    void app.onLaunch?.();
+    return () => {
+      void app.onStop?.();
+    };
+  }, [app]);
+
+  const context = useMemo<OverlayAppContext>(
+    () => ({ exitToApps, uiTheme, t }),
+    [exitToApps, t, uiTheme],
+  );
+  const LazyComponent = getLazyComponentForApp(app);
+  let content: React.ReactElement;
+  if (LazyComponent) {
+    content = (
+      <Suspense fallback={<AppFallback />}>
+        <LazyComponent {...context} />
+      </Suspense>
+    );
+  } else if (app.Component) {
+    content = <app.Component {...context} />;
+  } else {
+    content = (
+      <div className="flex h-full items-center justify-center bg-background text-sm text-muted-foreground">
+        App has no component: {descriptor.viewId}
+      </div>
+    );
+  }
+
+  return (
+    <ShellViewAgentSurface
+      viewId={descriptor.viewId}
+      surfaceKind={descriptor.kind}
+    >
+      {content}
+    </ShellViewAgentSurface>
+  );
+}
+
 export function AppWindowRenderer({
   slug,
 }: AppWindowRendererProps): React.ReactElement {
@@ -75,13 +139,6 @@ export function AppWindowRenderer({
     }, RESOLVE_RETRY_INTERVAL_MS);
     return () => window.clearInterval(interval);
   }, [app, slug]);
-
-  useEffect(() => {
-    void app?.onLaunch?.();
-    return () => {
-      void app?.onStop?.();
-    };
-  }, [app]);
 
   // Read the theme from the DOM in an effect (not during render) and keep it in
   // sync as the document class toggles, so the memoized context only changes when
@@ -123,23 +180,5 @@ export function AppWindowRenderer({
       </div>
     );
   }
-
-  const LazyComponent = getLazyComponentForApp(app);
-  if (LazyComponent) {
-    return (
-      <Suspense fallback={<AppFallback />}>
-        <LazyComponent {...context} />
-      </Suspense>
-    );
-  }
-
-  if (app.Component) {
-    return <app.Component {...context} />;
-  }
-
-  return (
-    <div className="flex h-full items-center justify-center bg-background text-sm text-muted-foreground">
-      App has no component: {slug}
-    </div>
-  );
+  return <OverlayAppSurface app={app} {...context} />;
 }

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -1474,7 +1474,12 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
       );
     }
     return (
-      <div ref={containerRef} className="contents">
+      <div
+        ref={containerRef}
+        className="contents"
+        data-agent-surface-kind="dynamic"
+        data-agent-surface-view-id={viewId}
+      >
         <SandboxedViewFrame
           viewId={viewId}
           surface={surface}
@@ -1530,7 +1535,12 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
   };
 
   return (
-    <div ref={containerRef} className="contents">
+    <div
+      ref={containerRef}
+      className="contents"
+      data-agent-surface-kind="dynamic"
+      data-agent-surface-view-id={viewId}
+    >
       <AgentSurfaceProvider viewId={viewId} viewType={viewType}>
         {/* Keyed by bundleUrl+reloadKey so a successful reload (refresh
             capability / dev HMR / Retry) remounts the boundary with cleared

--- a/packages/ui/src/components/views/ShellViewAgentSurface.test.tsx
+++ b/packages/ui/src/components/views/ShellViewAgentSurface.test.tsx
@@ -20,13 +20,19 @@ describe("ShellViewAgentSurface", () => {
     const { dispatchViewInteract } = await import("./view-interact-registry");
 
     const onClick = vi.fn();
-    render(
+    const rendered = render(
       <ShellViewAgentSurface viewId="settings">
         <AgentButton agentId="save" onClick={onClick}>
           Save
         </AgentButton>
       </ShellViewAgentSurface>,
     );
+
+    expect(
+      rendered.container.querySelector(
+        '[data-agent-surface-view-id="settings"][data-agent-surface-kind="builtin"]',
+      ),
+    ).not.toBeNull();
 
     // list-elements through the WS interact dispatch returns the registered button.
     await dispatchViewInteract(

--- a/packages/ui/src/components/views/ShellViewAgentSurface.tsx
+++ b/packages/ui/src/components/views/ShellViewAgentSurface.tsx
@@ -21,6 +21,7 @@ import {
   handleAgentSurfaceCapability,
   isAgentSurfaceCapability,
 } from "../../agent-surface";
+import type { RegisteredAgentSurfaceKind } from "../../app-shell-registry";
 import { registerViewInteractHandler } from "./view-interact-registry";
 
 function idParam(params: Record<string, unknown> | undefined): string | null {
@@ -32,12 +33,15 @@ export interface ShellViewAgentSurfaceProps {
   /** Stable builtin view id (matches the entry in builtin-views.ts). */
   viewId: string;
   viewType?: AgentViewType;
+  /** Registry family that generated this bridge owner, when applicable. */
+  surfaceKind?: RegisteredAgentSurfaceKind | "builtin";
   children: ReactNode;
 }
 
 export function ShellViewAgentSurface({
   viewId,
   viewType = "gui",
+  surfaceKind = "builtin",
   children,
 }: ShellViewAgentSurfaceProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -101,7 +105,12 @@ export function ShellViewAgentSurface({
 
   return (
     <AgentSurfaceProvider viewId={viewId} viewType={viewType}>
-      <div ref={containerRef} className="contents">
+      <div
+        ref={containerRef}
+        className="contents"
+        data-agent-surface-kind={surfaceKind}
+        data-agent-surface-view-id={viewId}
+      >
         {children}
       </div>
       <AgentElementOverlay />

--- a/packages/ui/src/components/views/view-interact-registry.test.ts
+++ b/packages/ui/src/components/views/view-interact-registry.test.ts
@@ -159,7 +159,7 @@ describe("view-interact-registry", () => {
     });
   });
 
-  it("unregisters handlers and does not remove a newer replacement handler", async () => {
+  it("restores a still-mounted handler after an overlapping owner unmounts", async () => {
     const { dispatchViewInteract, registerViewInteractHandler } = await import(
       "./view-interact-registry"
     );
@@ -174,7 +174,6 @@ describe("view-interact-registry", () => {
       async () => ({ version: 2 }),
     );
 
-    firstUnregister();
     await dispatchViewInteract(
       "replaceable",
       "gui",
@@ -198,6 +197,52 @@ describe("view-interact-registry", () => {
       undefined,
       "req-unregistered",
     );
+    expect(sendWsMessage).toHaveBeenCalledWith({
+      type: "view:interact:result",
+      requestId: "req-unregistered",
+      success: true,
+      result: { version: 1 },
+    });
+
+    sendWsMessage.mockClear();
+    firstUnregister();
+    await dispatchViewInteract(
+      "replaceable",
+      "gui",
+      "get-state",
+      undefined,
+      "req-fully-unregistered",
+    );
     expect(sendWsMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps the newest owner when an older overlapping owner unmounts first", async () => {
+    const { dispatchViewInteract, registerViewInteractHandler } = await import(
+      "./view-interact-registry"
+    );
+    const firstUnregister = registerViewInteractHandler(
+      "overlap-order",
+      "gui",
+      async () => ({ version: 1 }),
+    );
+    registerViewInteractHandler("overlap-order", "gui", async () => ({
+      version: 2,
+    }));
+
+    firstUnregister();
+    await dispatchViewInteract(
+      "overlap-order",
+      "gui",
+      "get-state",
+      undefined,
+      "req-newest-survives",
+    );
+
+    expect(sendWsMessage).toHaveBeenCalledWith({
+      type: "view:interact:result",
+      requestId: "req-newest-survives",
+      success: true,
+      result: { version: 2 },
+    });
   });
 });

--- a/packages/ui/src/components/views/view-interact-registry.ts
+++ b/packages/ui/src/components/views/view-interact-registry.ts
@@ -25,8 +25,18 @@ function handlerKey(viewId: string, viewType: ViewType): string {
   return `${viewType}:${viewId}`;
 }
 
-/** viewType:viewId → handler registered by the mounted DynamicViewLoader. */
-const handlers = new Map<string, InteractHandler>();
+interface HandlerRegistration {
+  handler: InteractHandler;
+  token: symbol;
+}
+
+/**
+ * viewType:viewId → mounted handlers in ownership order. Overlapping
+ * providers intentionally share one agent registry; the newest visible owner
+ * answers container-scoped capabilities, and removing it restores the still-
+ * mounted predecessor instead of leaving the shared registry unreachable.
+ */
+const handlers = new Map<string, HandlerRegistration[]>();
 const handledRequestIds = new Map<string, ReturnType<typeof setTimeout>>();
 const HANDLED_REQUEST_TTL_MS = 60_000;
 
@@ -36,12 +46,29 @@ export function registerViewInteractHandler(
   handler: InteractHandler,
 ): () => void {
   const key = handlerKey(viewId, viewType);
-  handlers.set(key, handler);
+  const registration = { handler, token: Symbol(key) };
+  const registrations = handlers.get(key) ?? [];
+  registrations.push(registration);
+  handlers.set(key, registrations);
   return () => {
-    if (handlers.get(key) === handler) {
+    const current = handlers.get(key);
+    if (!current) return;
+    const index = current.findIndex(
+      ({ token }) => token === registration.token,
+    );
+    if (index === -1) return;
+    current.splice(index, 1);
+    if (current.length === 0) {
       handlers.delete(key);
     }
   };
+}
+
+function currentHandler(
+  viewId: string,
+  viewType: ViewType,
+): InteractHandler | undefined {
+  return handlers.get(handlerKey(viewId, viewType))?.at(-1)?.handler;
 }
 
 /**
@@ -56,7 +83,7 @@ export async function dispatchViewInteract(
   requestId: string,
 ): Promise<void> {
   const resolvedViewType = viewType ?? "gui";
-  const handler = handlers.get(handlerKey(viewId, resolvedViewType));
+  const handler = currentHandler(viewId, resolvedViewType);
 
   if (!handler) {
     // The API broadcasts view-interact requests to every connected shell.
@@ -105,7 +132,7 @@ export async function invokeViewInteract(
   capability: string,
   params?: Record<string, unknown>,
 ): Promise<unknown> {
-  const handler = handlers.get(handlerKey(viewId, viewType ?? "gui"));
+  const handler = currentHandler(viewId, viewType ?? "gui");
   if (!handler) {
     throw new Error(
       `No interact handler mounted for ${viewType ?? "gui"}:${viewId}`,


### PR DESCRIPTION
## Summary

- generate one live registry for app-shell and overlay surfaces and reject empty or duplicate view identities
- route main-window overlays, detached app windows, registered app-shell pages, and Phone Companion mode through the shared `ShellViewAgentSurface`
- expose stable shell/dynamic-view audit markers so automated coverage can prove the universal chat/voice bridge without maintaining a second hand-written view list
- add lifecycle, registry, list-elements, and representative interaction coverage while keeping the declaration inventory owned by #24141 separate

## Validation

- UI focused tests: 39/39
- app focused tests: 4/4
- changed-file Biome, app lint, and UI boundary audit passed
- app visual audit: 229/231; remaining readiness/Browser/Finance failures are independently fixed by #24198
- root verify reached Turbo and stopped on pre-existing untouched UI formatting debt; package typechecks only reported existing missing workspace-build/redemption exports

## Scope boundary

This supplies the generated bridge/inventory seam for all registered surfaces. Exhaustive per-control matrices, native-device lanes, and live-model trajectories remain certification work under #24100/#23110; they are not represented as completed by mocked tests.

Closes #24101

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— universal-view-bridge
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:366f2a0953e7436c599cbcb02974a39a0a5fa2cb -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24206-before.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24206-after.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24206-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - registry and renderer bridge change has no backend path

<!-- evidence-row:frontend-logs -->
- [ ] N/A - the recorded real-app bridge interaction completed without browser diagnostics

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - this PR exposes deterministic UI bridge contracts; live-model trajectory certification remains #24100

<!-- evidence-row:domain-artifacts -->
- [x] [24206-app-shell-registry.ts](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24206-app-shell-registry.ts)

<!-- evidence-row:ocr-review -->
- [x] [24206-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24206-ocr-triage.json)

