### PR TITLE
feat: route direct coding APIs through OpenCode

### DIFF
--- a/packages/agent/src/api/accounts-routes.test.ts
+++ b/packages/agent/src/api/accounts-routes.test.ts
@@ -282,14 +282,7 @@ describe("accounts routes", () => {
       },
     });
 
-    for (const providerId of [
-      "zai-coding",
-      "kimi-coding",
-      "deepseek-coding",
-      "deepseek-api",
-      "zai-api",
-      "moonshot-api",
-    ]) {
+    for (const providerId of ["zai-coding", "kimi-coding", "deepseek-coding"]) {
       expect(
         response.providers.find((item) => item.providerId === providerId),
       ).toMatchObject({
@@ -298,6 +291,19 @@ describe("accounts routes", () => {
             available: false,
             credentialPath: "none",
             unavailableReason: expect.any(String),
+          },
+        },
+      });
+    }
+    for (const providerId of ["deepseek-api", "zai-api", "moonshot-api"]) {
+      expect(
+        response.providers.find((item) => item.providerId === providerId),
+      ).toMatchObject({
+        runtimeEligibility: {
+          codingAgent: {
+            available: true,
+            backend: "opencode",
+            credentialPath: "direct-api",
           },
         },
       });

--- a/packages/app-core/src/services/coding-account-bridge.test.ts
+++ b/packages/app-core/src/services/coding-account-bridge.test.ts
@@ -3,8 +3,8 @@
  * and its auth-failure triage (isAuthFailure): least-used vs priority vs config-
  * vs env-driven selection, per-agent env patches (CLAUDE_CODE_OAUTH_TOKEN, a
  * materialized CODEX_HOME/auth.json + config.toml with a TOML-injection guard,
- * active-generation discovery, CEREBRAS_API_KEY), usage attribution, and rate-
- * limit skipping. Runs against a real temp ELIZA_HOME / ELIZA_STATE_DIR and real
+ * active-generation discovery, typed OpenCode direct-API selectors), usage
+ * attribution, and rate-limit skipping. Runs against a real temp ELIZA_HOME / ELIZA_STATE_DIR and real
  * account storage — no mocked pool.
  */
 import {
@@ -569,8 +569,29 @@ describe("coding-account-bridge", () => {
     expect(sel?.accountId).toBe("cb-idle");
     // buildOpencodeSpawnConfig reads CEREBRAS_API_KEY from the injected env.
     expect(sel?.envPatch.CEREBRAS_API_KEY).toBe("cb-key-idle");
+    expect(sel?.envPatch.ELIZA_OPENCODE_PROVIDER_ID).toBe("cerebras-api");
     expect(sel?.source).toBe("api-key");
   });
+
+  it.each([
+    ["deepseek-api", "DEEPSEEK_API_KEY"],
+    ["zai-api", "ZAI_API_KEY"],
+    ["moonshot-api", "MOONSHOT_API_KEY"],
+  ] as const)(
+    "selects %s for OpenCode and pins its provider with %s",
+    async (providerId, envKey) => {
+      writeAccount(providerId, `${providerId}-account`, `${providerId}-secret`);
+      const sel = await getCodingAgentSelectorBridge()?.select("opencode");
+      expect(sel).toMatchObject({
+        providerId,
+        source: "api-key",
+      });
+      expect(sel?.envPatch).toEqual({
+        [envKey]: `${providerId}-secret`,
+        ELIZA_OPENCODE_PROVIDER_ID: providerId,
+      });
+    },
+  );
 
   it("attributes recorded usage to the serving account (per-account delta)", async () => {
     writeAccount("anthropic-subscription", "acct", "sk-ant-oat-acct");

--- a/packages/app-core/src/services/coding-account-bridge.ts
+++ b/packages/app-core/src/services/coding-account-bridge.ts
@@ -114,12 +114,9 @@ function getEnvCodingStrategy(): Strategy | undefined {
  * subscriptions are preferred over direct API credentials.
  *
  * claude (claude-agent-acp) and codex (codex-acp) are first-party CLIs.
- * opencode authenticates through its configured backend; the only backend it
- * resolves from a pooled key is Cerebras (`CEREBRAS_API_KEY`, see
- * buildOpencodeSpawnConfig), so opencode pool-rotates across `cerebras-api`
- * accounts and no-ops otherwise. z.ai / Kimi / GLM have no first-party coding
- * CLI — their accounts serve the main runtime's API-key routing — so they are
- * deliberately absent (advertising them would offer an unspawnable path).
+ * opencode authenticates through a typed direct-API route. Its candidate list
+ * contains only general API/PAYG products; dedicated coding-plan endpoint keys
+ * and native CLI OAuth remain separate capabilities.
  */
 const AGENT_PROVIDER_CANDIDATES: Readonly<
   Record<string, readonly LinkedAccountProviderId[]>
@@ -838,7 +835,15 @@ async function buildEnvPatch(
       // (Z_AI_API_KEY → ZAI_API_KEY, KIMI_API_KEY → MOONSHOT_API_KEY).
       const envKey =
         DIRECT_ACCOUNT_PROVIDER_ENV[providerId as DirectAccountProvider];
-      return envKey ? { [envKey]: accessToken } : {};
+      if (!envKey) return {};
+      const opencodeProviders =
+        CODING_AGENT_BACKEND_PROVIDERS.opencode as readonly string[];
+      return {
+        [envKey]: accessToken,
+        ...(opencodeProviders.includes(providerId)
+          ? { ELIZA_OPENCODE_PROVIDER_ID: providerId }
+          : {}),
+      };
     }
   }
 }

--- a/packages/shared/src/contracts/coding-agent-capabilities.test.ts
+++ b/packages/shared/src/contracts/coding-agent-capabilities.test.ts
@@ -28,6 +28,9 @@ describe("coding-agent capability mapping", () => {
       "openai-codex",
       "anthropic-api",
       "openai-api",
+      "deepseek-api",
+      "zai-api",
+      "moonshot-api",
       "cerebras-api",
     ]);
     for (const providerId of mappedProviders) {
@@ -43,15 +46,22 @@ describe("coding-agent capability mapping", () => {
     "zai-coding",
     "kimi-coding",
     "deepseek-coding",
-    "deepseek-api",
-    "zai-api",
-    "moonshot-api",
   ] as const)("keeps %s enrollment separate from spawn availability", (id) => {
     const capability = codingAgentSpawnCapabilityForProvider(id);
     expect(capability.available).toBe(false);
     expect(capability.backend).toBeUndefined();
     expect(capability.unavailableReason).toBeTruthy();
   });
+
+  it.each(["deepseek-api", "zai-api", "moonshot-api"] as const)(
+    "routes direct API provider %s through OpenCode",
+    (providerId) => {
+      expect(codingAgentSpawnCapabilityForProvider(providerId)).toEqual({
+        available: true,
+        backend: "opencode",
+      });
+    },
+  );
 
   it("declares a preflight backend for every credential route", () => {
     expect(CODING_AGENT_BACKEND_PREFLIGHTS).toEqual({

--- a/packages/shared/src/contracts/coding-agent-capabilities.ts
+++ b/packages/shared/src/contracts/coding-agent-capabilities.ts
@@ -240,8 +240,8 @@ export const CODING_PROVIDER_DESCRIPTORS = {
     "direct-api-key",
     "usage",
     true,
+    "opencode",
     null,
-    "The DeepSeek API account can serve model inference, but no supported coding-agent spawn backend consumes it.",
   ),
   "zai-api": descriptor(
     "zai-api",
@@ -249,8 +249,8 @@ export const CODING_PROVIDER_DESCRIPTORS = {
     "direct-api-key",
     "usage",
     true,
+    "opencode",
     null,
-    "The z.ai API account can serve model inference, but no supported coding-agent spawn backend consumes it.",
   ),
   "moonshot-api": descriptor(
     "moonshot-api",
@@ -258,8 +258,8 @@ export const CODING_PROVIDER_DESCRIPTORS = {
     "direct-api-key",
     "usage",
     true,
+    "opencode",
     null,
-    "The Kimi / Moonshot API account can serve model inference, but no supported coding-agent spawn backend consumes it.",
   ),
   "cerebras-api": descriptor(
     "cerebras-api",

--- a/packages/ui/src/api/client-agent-accounts.test.ts
+++ b/packages/ui/src/api/client-agent-accounts.test.ts
@@ -55,11 +55,11 @@ describe("ElizaClient account replacement transport", () => {
     await expect(accountsClient(body).listAccounts()).resolves.toEqual(body);
   });
 
-  it("rejects server metadata that advertises an unspawnable account provider", async () => {
+  it("rejects server metadata that advertises an unspawnable coding-plan account", async () => {
     const body = {
       providers: [
         {
-          providerId: "deepseek-api",
+          providerId: "kimi-coding",
           strategy: "priority",
           runtimeEligibility: {
             chat: { available: true, credentialPath: "direct-api" },

--- a/packages/ui/src/api/client-agent-accounts.test.ts
+++ b/packages/ui/src/api/client-agent-accounts.test.ts
@@ -62,11 +62,11 @@ describe("ElizaClient account replacement transport", () => {
           providerId: "kimi-coding",
           strategy: "priority",
           runtimeEligibility: {
-            chat: { available: true, credentialPath: "direct-api" },
+            chat: { available: true, credentialPath: "account-pool" },
             codingAgent: {
               available: true,
               backend: "opencode",
-              credentialPath: "direct-api",
+              credentialPath: "account-pool",
             },
           },
           accounts: [],

--- a/packages/ui/src/components/accounts/account-eligibility.test.ts
+++ b/packages/ui/src/components/accounts/account-eligibility.test.ts
@@ -44,13 +44,13 @@ describe("resolveProviderEligibility", () => {
     expect(resolved.codingAgent).toBe(true);
   });
 
-  it("does not infer coding-agent spawn support for inference-only APIs", () => {
+  it("infers OpenCode spawn support for routed direct API accounts", () => {
     const resolved = resolveProviderEligibility(
       option("deepseek-api"),
       undefined,
     );
     expect(resolved.chat).toBe(true);
-    expect(resolved.codingAgent).toBe(false);
+    expect(resolved.codingAgent).toBe(true);
   });
 
   it("surfaces the server's unsupported spawn reason", () => {

--- a/packages/ui/src/components/accounts/account-provider-options.ts
+++ b/packages/ui/src/components/accounts/account-provider-options.ts
@@ -91,22 +91,24 @@ export const ACCOUNT_PROVIDER_OPTIONS: AccountProviderOption[] = [
     name: "DeepSeek API",
     category: "chat",
     description:
-      "Direct DeepSeek API billing for model inference; coding-agent spawning is not wired yet.",
-    eligibility: ["chat", "API key"],
+      "Direct DeepSeek API billing for chat and OpenCode coding agents. This is API PAYG, not a consumer subscription.",
+    eligibility: ["chat", "coding agent", "API key", "PAYG"],
   },
   {
     id: "zai-api",
     name: "z.ai API",
     category: "chat",
-    description: "Direct z.ai API key for model routing.",
-    eligibility: ["chat", "API key"],
+    description:
+      "Direct z.ai general API billing for chat and OpenCode coding agents. The separate Coding Plan uses its dedicated endpoint key.",
+    eligibility: ["chat", "coding agent", "API key", "PAYG"],
   },
   {
     id: "moonshot-api",
     name: "Kimi / Moonshot API",
     category: "chat",
-    description: "Direct Moonshot API key for Kimi models.",
-    eligibility: ["chat", "API key"],
+    description:
+      "Direct Moonshot API billing for chat and OpenCode coding agents. This does not use Kimi membership quota.",
+    eligibility: ["chat", "coding agent", "API key", "PAYG"],
   },
 ];
 

--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -144,7 +144,13 @@ preferred over API key):
 | `pi-agent` | runtime-routed |
 | `claude` | anthropic-subscription → anthropic-api |
 | `codex` | openai-codex → openai-api |
-| `opencode` | cerebras-api |
+| `opencode` | cerebras-api → deepseek-api → zai-api → moonshot-api |
+
+OpenCode also supports explicit environment-only `xai-api` and
+`openrouter-api` routes. They are not pooled account candidates until the
+canonical linked-account authority lands. These are direct API billing routes:
+DeepSeek, Z.AI general API, Moonshot, and xAI are PAYG; OpenRouter uses credits
+or BYOK. They are not consumer or coding-plan subscriptions.
 
 ## Layout
 
@@ -285,6 +291,9 @@ README → "GitHub credentials".
 | `ELIZA_CODEX_ACP_LANDLOCK` / `ELIZA_CODEX_LANDLOCK` | auto-detect | Force Landlock detection for containers/tests: `1`/`true` or `0`/`false` |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command |
+| `ELIZA_OPENCODE_PROVIDER` / `ELIZA_OPENCODE_PROVIDER_ID` | auto-detect only when unambiguous | Atomic direct-API route selector: `cerebras-api`, `deepseek-api`, `zai-api`, `moonshot-api`, `xai-api`, or `openrouter-api`. Pooled account selection writes the `_ID` form for the child. |
+| `ELIZA_OPENCODE_MODEL_POWERFUL` / `OPENCODE_MODEL` | provider default; required for OpenRouter | Model id for the selected route. OpenRouter accepts arbitrary catalog slugs. |
+| `DEEPSEEK_API_KEY` / `ZAI_API_KEY` / `MOONSHOT_API_KEY` / `XAI_API_KEY` / `OPENROUTER_API_KEY` | unset | Direct API/PAYG credentials. Existing `Z_AI_API_KEY` and `KIMI_API_KEY` aliases remain accepted. The selected key is embedded in child-only OpenCode config; conflicting provider keys are removed from the child environment. |
 | `ELIZA_ACP_MAX_SESSIONS` | `8` | Concurrent session cap |
 | `ELIZA_ACP_SYSTEM_SESSION_HEADROOM` | `2` | Reserved concurrent slots for short-lived `system` spawns (the #8898 read-only verifier), counted separately from `ELIZA_ACP_MAX_SESSIONS` so validation never deadlocks behind the worker cap |
 | `ELIZA_MAX_SPAWNS_PER_ORIGIN` | `3` | Max sub-agent spawns per root user message before relaying the best captured result instead of re-spawning (bounds the weak-model re-spawn loop) |

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -144,7 +144,13 @@ preferred over API key):
 | `pi-agent` | runtime-routed |
 | `claude` | anthropic-subscription → anthropic-api |
 | `codex` | openai-codex → openai-api |
-| `opencode` | cerebras-api |
+| `opencode` | cerebras-api → deepseek-api → zai-api → moonshot-api |
+
+OpenCode also supports explicit environment-only `xai-api` and
+`openrouter-api` routes. They are not pooled account candidates until the
+canonical linked-account authority lands. These are direct API billing routes:
+DeepSeek, Z.AI general API, Moonshot, and xAI are PAYG; OpenRouter uses credits
+or BYOK. They are not consumer or coding-plan subscriptions.
 
 ## Layout
 
@@ -285,6 +291,9 @@ README → "GitHub credentials".
 | `ELIZA_CODEX_ACP_LANDLOCK` / `ELIZA_CODEX_LANDLOCK` | auto-detect | Force Landlock detection for containers/tests: `1`/`true` or `0`/`false` |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command |
+| `ELIZA_OPENCODE_PROVIDER` / `ELIZA_OPENCODE_PROVIDER_ID` | auto-detect only when unambiguous | Atomic direct-API route selector: `cerebras-api`, `deepseek-api`, `zai-api`, `moonshot-api`, `xai-api`, or `openrouter-api`. Pooled account selection writes the `_ID` form for the child. |
+| `ELIZA_OPENCODE_MODEL_POWERFUL` / `OPENCODE_MODEL` | provider default; required for OpenRouter | Model id for the selected route. OpenRouter accepts arbitrary catalog slugs. |
+| `DEEPSEEK_API_KEY` / `ZAI_API_KEY` / `MOONSHOT_API_KEY` / `XAI_API_KEY` / `OPENROUTER_API_KEY` | unset | Direct API/PAYG credentials. Existing `Z_AI_API_KEY` and `KIMI_API_KEY` aliases remain accepted. The selected key is embedded in child-only OpenCode config; conflicting provider keys are removed from the child environment. |
 | `ELIZA_ACP_MAX_SESSIONS` | `8` | Concurrent session cap |
 | `ELIZA_ACP_SYSTEM_SESSION_HEADROOM` | `2` | Reserved concurrent slots for short-lived `system` spawns (the #8898 read-only verifier), counted separately from `ELIZA_ACP_MAX_SESSIONS` so validation never deadlocks behind the worker cap |
 | `ELIZA_MAX_SPAWNS_PER_ORIGIN` | `3` | Max sub-agent spawns per root user message before relaying the best captured result instead of re-spawning (bounds the weak-model re-spawn loop) |

--- a/plugins/plugin-agent-orchestrator/README.md
+++ b/plugins/plugin-agent-orchestrator/README.md
@@ -158,6 +158,9 @@ second credential broker, and child trajectories retain their session join key.
 | `ELIZA_CODEX_ACP_LANDLOCK` / `ELIZA_CODEX_LANDLOCK` | auto-detect | Force Landlock detection for containers/tests: `1`/`true` or `0`/`false`. |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command. |
 | `ELIZA_OPENCODE_ACP_COMMAND` | bundled shim or `opencode acp` | Native OpenCode ACP command override. |
+| `ELIZA_OPENCODE_PROVIDER` / `ELIZA_OPENCODE_PROVIDER_ID` | auto-detect only when unambiguous | Atomic OpenCode direct-API route selector: Cerebras, DeepSeek, Z.AI general API, Moonshot, xAI, or OpenRouter. |
+| `ELIZA_OPENCODE_MODEL_POWERFUL` / `OPENCODE_MODEL` | provider default; required for OpenRouter | Model id; OpenRouter accepts arbitrary catalog slugs. |
+| `DEEPSEEK_API_KEY` / `ZAI_API_KEY` / `MOONSHOT_API_KEY` / `XAI_API_KEY` / `OPENROUTER_API_KEY` | unset | Direct API credentials; existing `Z_AI_API_KEY` and `KIMI_API_KEY` aliases remain accepted. These routes are PAYG, credits, or BYOK—not consumer subscriptions. |
 | `ELIZA_ACP_DEFAULT_APPROVAL` | `autonomous` | Approval preset (`read-only`, `auto`, `permissive`, `autonomous`, `full-access`). |
 | `ELIZA_ACP_PROMPT_TIMEOUT_MS` / `ACPX_DEFAULT_TIMEOUT_MS` | `300000` (5m) | Per-prompt timeout. |
 | `ELIZA_FRAMEWORK_PREFLIGHT_TIMEOUT_MS` | `5000` (5s) | Maximum adapter-availability preflight wait. Values must be exact decimal integers from `250` through `2147483647`; missing/blank uses the default, and invalid values fail before the adapter probe starts. |

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -1557,6 +1557,49 @@ describe("AcpService", () => {
     expect(config.provider?.cerebras?.options?.apiKey).toBe("csk_test");
   });
 
+  it("isolates a selected OpenCode direct API route from conflicting host keys", async () => {
+    const reg = nextProc();
+    const service = new AcpService(
+      runtime({
+        ELIZA_OPENCODE_PROVIDER: "deepseek-api",
+        DEEPSEEK_API_KEY: "deepseek-selected-secret",
+        XAI_API_KEY: "xai-conflicting-secret",
+        OPENROUTER_API_KEY: "openrouter-conflicting-secret",
+      }),
+    );
+    await service.start();
+
+    const spawned = service.spawnSession({
+      name: "opencode-deepseek",
+      agentType: "opencode",
+      workdir: "/tmp/acp-test",
+    });
+    await waitForSpawn(reg);
+    closeOk(reg);
+    await spawned;
+
+    const env = spawnMock.mock.calls[0]?.[2]?.env as
+      | Record<string, string>
+      | undefined;
+    const config = JSON.parse(env?.OPENCODE_CONFIG_CONTENT ?? "{}") as {
+      provider?: Record<string, { options?: { apiKey?: string } }>;
+      model?: string;
+    };
+    expect(config.model).toBe("deepseek/deepseek-v4-pro");
+    expect(config.provider?.deepseek?.options?.apiKey).toBe(
+      "deepseek-selected-secret",
+    );
+    expect(env?.DEEPSEEK_API_KEY).toBeUndefined();
+    expect(env?.XAI_API_KEY).toBeUndefined();
+    expect(env?.OPENROUTER_API_KEY).toBeUndefined();
+    expect(env?.OPENCODE_CONFIG_CONTENT).not.toContain(
+      "xai-conflicting-secret",
+    );
+    expect(env?.OPENCODE_CONFIG_CONTENT).not.toContain(
+      "openrouter-conflicting-secret",
+    );
+  });
+
   it("keeps BENCHMARK_TASK_AGENT=elizaos as the native default adapter", async () => {
     const reg = nextProc();
     const service = new AcpService(

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/multi-account-spawn.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/multi-account-spawn.test.ts
@@ -296,6 +296,53 @@ describe("multi-account coding-agent spawn", () => {
     await service.stop();
   });
 
+  it("does not let runtime settings override a pooled OpenCode account", async () => {
+    installBridge({
+      opencode: {
+        providerId: "deepseek-api",
+        accountId: "deepseek-selected",
+        label: "Selected DeepSeek",
+        source: "api-key",
+        strategy: "least-used",
+        envPatch: {
+          ELIZA_OPENCODE_PROVIDER_ID: "deepseek-api",
+          DEEPSEEK_API_KEY: "deepseek-selected-key",
+        },
+      },
+    });
+    const service = new AcpService(
+      runtime({
+        ELIZA_OPENCODE_PROVIDER: "xai-api",
+        DEEPSEEK_API_KEY: "deepseek-stale-runtime-key",
+        XAI_API_KEY: "xai-stale-runtime-key",
+      }),
+    );
+    await service.start();
+    const result = await service.spawnSession({
+      name: "opencode-account-authority",
+      agentType: "opencode",
+      workdir: "/tmp/acp-test",
+    });
+    const env = firstNativeClient().opts.env ?? {};
+    const config = JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? "{}") as {
+      provider?: { deepseek?: { options?: { apiKey?: string } } };
+    };
+    expect(config.provider?.deepseek?.options?.apiKey).toBe(
+      "deepseek-selected-key",
+    );
+    expect(env.OPENCODE_CONFIG_CONTENT).not.toContain(
+      "deepseek-stale-runtime-key",
+    );
+    expect(env.OPENCODE_CONFIG_CONTENT).not.toContain("xai-stale-runtime-key");
+    expect((result.metadata as Record<string, unknown>)?.account).toMatchObject(
+      {
+        providerId: "deepseek-api",
+        accountId: "deepseek-selected",
+      },
+    );
+    await service.stop();
+  });
+
   it("falls back to single-account behavior when no bridge is installed", async () => {
     const service = new AcpService(runtime());
     await service.start();

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/multi-account-spawn.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/multi-account-spawn.test.ts
@@ -139,6 +139,32 @@ function clearBridge() {
   delete (globalThis as Record<symbol, unknown>)[BRIDGE_SYMBOL];
 }
 
+const ROUTING_ENV_KEYS = [
+  "ELIZA_CONFIG_PATH",
+  "ELIZA_MODEL_GATEWAY_URL",
+  "ELIZA_MODEL_GATEWAY_TOKEN",
+] as const;
+
+function replaceRoutingEnv(
+  values: Partial<Record<(typeof ROUTING_ENV_KEYS)[number], string>>,
+): () => void {
+  const previous = Object.fromEntries(
+    ROUTING_ENV_KEYS.map((key) => [key, process.env[key]]),
+  ) as Record<(typeof ROUTING_ENV_KEYS)[number], string | undefined>;
+  for (const key of ROUTING_ENV_KEYS) {
+    const value = values[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  return () => {
+    for (const key of ROUTING_ENV_KEYS) {
+      const value = previous[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  };
+}
+
 function runtime(settings: Record<string, string | undefined> = {}) {
   const values = {
     ELIZA_ACP_TRANSPORT: "native",
@@ -341,6 +367,163 @@ describe("multi-account coding-agent spawn", () => {
       },
     );
     await service.stop();
+  });
+
+  it.each([
+    ["without a Cloud key", undefined],
+    ["with a Cloud key", "cloud-key-must-not-be-billed"],
+  ] as const)(
+    "keeps the pooled DeepSeek account and billed transport aligned under ELIZA_LLM_PROVIDER=cloud %s",
+    async (_label, cloudKey) => {
+      const tempDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "opencode-cloud-spawn-authority-"),
+      );
+      const configPath = path.join(tempDir, "eliza.json");
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify(cloudKey ? { cloud: { apiKey: cloudKey } } : {}),
+      );
+      const restoreEnv = replaceRoutingEnv({ ELIZA_CONFIG_PATH: configPath });
+      const select = installBridge({
+        opencode: {
+          providerId: "deepseek-api",
+          accountId: "deepseek-selected",
+          label: "Selected DeepSeek",
+          source: "api-key",
+          strategy: "least-used",
+          envPatch: {
+            ELIZA_OPENCODE_PROVIDER_ID: "deepseek-api",
+            DEEPSEEK_API_KEY: "deepseek-selected-key",
+          },
+        },
+      });
+      const service = new AcpService(runtime({ ELIZA_LLM_PROVIDER: "cloud" }));
+      try {
+        await service.start();
+        const result = await service.spawnSession({
+          name: "opencode-cloud-account-authority",
+          agentType: "opencode",
+          workdir: "/tmp/acp-test",
+        });
+        const env = firstNativeClient().opts.env ?? {};
+        const config = JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? "{}") as {
+          provider?: { deepseek?: { options?: { apiKey?: string } } };
+        };
+        expect(config.provider?.deepseek?.options?.apiKey).toBe(
+          "deepseek-selected-key",
+        );
+        expect(env.OPENCODE_CONFIG_CONTENT).not.toContain(
+          "cloud-key-must-not-be-billed",
+        );
+        expect(select).toHaveBeenCalledOnce();
+        expect(
+          (result.metadata as Record<string, unknown>)?.account,
+        ).toMatchObject({
+          providerId: "deepseek-api",
+          accountId: "deepseek-selected",
+        });
+      } finally {
+        await service.stop();
+        fs.rmSync(tempDir, { recursive: true, force: true });
+        restoreEnv();
+      }
+    },
+  );
+
+  it("bypasses pooled accounts when the host gateway owns billing", async () => {
+    const restoreEnv = replaceRoutingEnv({
+      ELIZA_CONFIG_PATH:
+        "/nonexistent/multi-account-gateway-authority/eliza.json",
+      ELIZA_MODEL_GATEWAY_URL: "https://gateway.test.invalid/v1",
+      ELIZA_MODEL_GATEWAY_TOKEN: "gateway-token-selected",
+    });
+    const select = installBridge({
+      opencode: {
+        providerId: "deepseek-api",
+        accountId: "deepseek-must-not-be-stamped",
+        label: "DeepSeek must not be selected",
+        source: "api-key",
+        strategy: "least-used",
+        envPatch: {
+          ELIZA_OPENCODE_PROVIDER_ID: "deepseek-api",
+          DEEPSEEK_API_KEY: "deepseek-raw-must-not-reach-child",
+        },
+      },
+    });
+    const service = new AcpService(runtime());
+    try {
+      await service.start();
+      const result = await service.spawnSession({
+        name: "opencode-gateway-authority",
+        agentType: "opencode",
+        workdir: "/tmp/acp-test",
+      });
+      const env = firstNativeClient().opts.env ?? {};
+      const config = JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? "{}") as {
+        provider?: {
+          "eliza-gateway"?: { options?: { apiKey?: string } };
+        };
+      };
+      expect(select).not.toHaveBeenCalled();
+      expect(
+        (result.metadata as Record<string, unknown>)?.account,
+      ).toBeUndefined();
+      expect(config.provider?.["eliza-gateway"]?.options?.apiKey).toBe(
+        "gateway-token-selected",
+      );
+      expect(JSON.stringify(env)).not.toContain(
+        "deepseek-raw-must-not-reach-child",
+      );
+    } finally {
+      await service.stop();
+      restoreEnv();
+    }
+  });
+
+  it("fails before transport if gateway authority changes after account selection", async () => {
+    const restoreEnv = replaceRoutingEnv({
+      ELIZA_CONFIG_PATH: "/nonexistent/multi-account-gateway-race/eliza.json",
+    });
+    const select = vi.fn(async () => {
+      process.env.ELIZA_MODEL_GATEWAY_URL = "https://gateway.test.invalid/v1";
+      process.env.ELIZA_MODEL_GATEWAY_TOKEN = "gateway-token-selected";
+      return {
+        providerId: "deepseek-api",
+        accountId: "deepseek-selected-before-gateway",
+        label: "Selected before gateway",
+        source: "api-key" as const,
+        strategy: "least-used",
+        envPatch: {
+          ELIZA_OPENCODE_PROVIDER_ID: "deepseek-api",
+          DEEPSEEK_API_KEY: "deepseek-must-not-be-billed",
+        },
+      };
+    });
+    (globalThis as Record<symbol, unknown>)[BRIDGE_SYMBOL] = {
+      describe: () => ({}),
+      select,
+      markRateLimited: vi.fn(async () => undefined),
+      markNeedsReauth: vi.fn(async () => undefined),
+      recordUsage: vi.fn(async () => undefined),
+    };
+    const service = new AcpService(runtime());
+    try {
+      await service.start();
+      await expect(
+        service.spawnSession({
+          name: "opencode-gateway-authority-race",
+          agentType: "opencode",
+          workdir: "/tmp/acp-test",
+        }),
+      ).rejects.toMatchObject({
+        code: "OPENCODE_ACCOUNT_TRANSPORT_MISMATCH",
+      });
+      expect(select).toHaveBeenCalledOnce();
+      expect(nativeClientMock.instances).toHaveLength(0);
+    } finally {
+      await service.stop();
+      restoreEnv();
+    }
   });
 
   it("falls back to single-account behavior when no bridge is installed", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/multi-account-spawn.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/multi-account-spawn.test.ts
@@ -256,9 +256,10 @@ describe("multi-account coding-agent spawn", () => {
     }
   });
 
-  it("injects the pooled CEREBRAS_API_KEY for an opencode spawn", async () => {
-    // opencode pool-rotates across cerebras-api accounts; the bridge injects
-    // CEREBRAS_API_KEY which buildOpencodeSpawnConfig reads to target Cerebras.
+  it("isolates a pooled Cerebras key in OpenCode config", async () => {
+    // opencode pool-rotates across typed direct-API accounts; this fixture uses
+    // Cerebras; buildOpencodeSpawnConfig consumes the bridge key and the final
+    // child environment retains only the generated config.
     const select = installBridge({
       opencode: {
         providerId: "cerebras-api",
@@ -277,7 +278,11 @@ describe("multi-account coding-agent spawn", () => {
       workdir: "/tmp/acp-test",
     });
     const env = firstNativeClient().opts.env ?? {};
-    expect(env.CEREBRAS_API_KEY).toBe("cb-key-pooled");
+    expect(env.CEREBRAS_API_KEY).toBeUndefined();
+    const config = JSON.parse(env.OPENCODE_CONFIG_CONTENT ?? "{}") as {
+      provider?: { cerebras?: { options?: { apiKey?: string } } };
+    };
+    expect(config.provider?.cerebras?.options?.apiKey).toBe("cb-key-pooled");
     expect(select).toHaveBeenCalledWith(
       "opencode",
       expect.objectContaining({ sessionKey: result.sessionId }),

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts
@@ -2,6 +2,10 @@
  * Verifies buildOpencodeSpawnConfig.
  * Deterministic unit test with a stubbed runtime; no live model.
  */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -194,6 +198,51 @@ describe("buildOpencodeSpawnConfig", () => {
     expect(result?.configContent).not.toContain("stale-runtime-deepseek-key");
     expect(result?.configContent).not.toContain("stale-runtime-xai-key");
   });
+
+  it.each([
+    ["without a Cloud key", undefined],
+    ["with a Cloud key", "cloud-key-must-not-be-billed"],
+  ] as const)(
+    "keeps a selected DeepSeek account authoritative when ELIZA_LLM_PROVIDER=cloud %s",
+    (_label, cloudKey) => {
+      const configDir = mkdtempSync(
+        path.join(tmpdir(), "opencode-cloud-authority-"),
+      );
+      const configPath = path.join(configDir, "eliza.json");
+      writeFileSync(
+        configPath,
+        JSON.stringify(cloudKey ? { cloud: { apiKey: cloudKey } } : {}),
+      );
+      process.env.ELIZA_CONFIG_PATH = configPath;
+      try {
+        const result = buildOpencodeSpawnConfig(
+          runtime({ ELIZA_LLM_PROVIDER: "cloud" }),
+          {},
+          undefined,
+          {
+            providerId: "deepseek-api",
+            credentials: {
+              DEEPSEEK_API_KEY: "selected-deepseek-key",
+            },
+          },
+        );
+        const config = JSON.parse(result?.configContent ?? "{}");
+        expect(result).toMatchObject({
+          accountProviderId: "deepseek-api",
+          providerId: "deepseek",
+          billingMode: "api-payg",
+        });
+        expect(config.provider.deepseek.options.apiKey).toBe(
+          "selected-deepseek-key",
+        );
+        expect(result?.configContent).not.toContain(
+          "cloud-key-must-not-be-billed",
+        );
+      } finally {
+        rmSync(configDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("does not guess among multiple non-Cerebras billing sources", () => {
     const result = buildOpencodeSpawnConfig(runtime(), {
@@ -403,14 +452,22 @@ describe("buildOpencodeSpawnConfig (model-gateway mode, #11536 E2)", () => {
   });
 
   it("routes through the gateway and never embeds a raw provider key", () => {
-    const result = buildOpencodeSpawnConfig(runtime(), {
-      CEREBRAS_API_KEY: "csk-raw-DO-NOT-LEAK",
-    });
+    const result = buildOpencodeSpawnConfig(
+      runtime({ ELIZA_LLM_PROVIDER: "cloud" }),
+      { CEREBRAS_API_KEY: "csk-raw-DO-NOT-LEAK" },
+      undefined,
+      {
+        providerId: "deepseek-api",
+        credentials: { DEEPSEEK_API_KEY: "deepseek-raw-DO-NOT-LEAK" },
+      },
+    );
     expect(result?.providerId).toBe("eliza-gateway");
+    expect(result?.accountProviderId).toBeUndefined();
     const config = JSON.parse(result?.configContent ?? "{}");
     expect(config.provider["eliza-gateway"].options.baseURL).toBe(GATEWAY_URL);
     expect(config.provider["eliza-gateway"].options.apiKey).toBe(GATEWAY_TOKEN);
     expect(result?.configContent).not.toContain("csk-raw-DO-NOT-LEAK");
+    expect(result?.configContent).not.toContain("deepseek-raw-DO-NOT-LEAK");
     expect(result?.configContent).not.toContain("cerebras.ai");
   });
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts
@@ -55,7 +55,7 @@ describe("buildOpencodeSpawnConfig", () => {
       CEREBRAS_API_KEY: "csk-test",
     });
     expect(result?.providerId).toBe("cerebras");
-    expect(result?.providerLabel).toBe("Cerebras");
+    expect(result?.providerLabel).toBe("Cerebras API");
     expect(result?.model).toBe("cerebras/gemma-4-31b");
     const config = JSON.parse(result?.configContent ?? "{}");
     expect(config.provider.cerebras.options.baseURL).toBe(
@@ -63,6 +63,171 @@ describe("buildOpencodeSpawnConfig", () => {
     );
     expect(config.provider.cerebras.npm).toBe("@ai-sdk/cerebras");
     expect(config.provider.cerebras.options.apiKey).toBe("csk-test");
+  });
+
+  it.each([
+    {
+      selector: "deepseek-api",
+      keyEnv: "DEEPSEEK_API_KEY",
+      key: "deepseek-secret-never-log",
+      provider: "deepseek",
+      baseURL: "https://api.deepseek.com",
+      model: "deepseek-v4-pro",
+      label: "DeepSeek API (PAYG)",
+    },
+    {
+      selector: "zai-api",
+      keyEnv: "ZAI_API_KEY",
+      key: "zai-secret-never-log",
+      provider: "zai",
+      baseURL: "https://api.z.ai/api/paas/v4",
+      model: "glm-5.1",
+      label: "Z.AI API (PAYG)",
+    },
+    {
+      selector: "moonshot-api",
+      keyEnv: "MOONSHOT_API_KEY",
+      key: "moonshot-secret-never-log",
+      provider: "moonshot",
+      baseURL: "https://api.moonshot.ai/v1",
+      model: "kimi-k2.5",
+      label: "Kimi / Moonshot API (PAYG)",
+    },
+    {
+      selector: "xai-api",
+      keyEnv: "XAI_API_KEY",
+      key: "xai-secret-never-log",
+      provider: "xai",
+      baseURL: "https://api.x.ai/v1",
+      model: "grok-build-0.1",
+      label: "xAI API (PAYG)",
+    },
+  ])(
+    "builds an atomic $selector direct API route",
+    ({ selector, keyEnv, key, provider, baseURL, model, label }) => {
+      const result = buildOpencodeSpawnConfig(runtime(), {
+        ELIZA_OPENCODE_PROVIDER_ID: selector,
+        [keyEnv]: key,
+      });
+      expect(result).toMatchObject({
+        accountProviderId: selector,
+        billingMode: "api-payg",
+        termsPolicy: "direct-api",
+        providerLabel: label,
+        baseUrl: baseURL,
+        model: `${provider}/${model}`,
+      });
+      const config = JSON.parse(result?.configContent ?? "{}");
+      expect(config.provider[provider].options).toMatchObject({
+        baseURL,
+        apiKey: key,
+      });
+      expect(config.model).toBe(`${provider}/${model}`);
+    },
+  );
+
+  it("supports arbitrary OpenRouter models while labeling credits/BYOK truthfully", () => {
+    const result = buildOpencodeSpawnConfig(runtime(), {
+      ELIZA_OPENCODE_PROVIDER: "openrouter",
+      OPENROUTER_API_KEY: "openrouter-secret-never-log",
+      ELIZA_OPENCODE_MODEL_POWERFUL: "anthropic/claude-sonnet-4.5",
+    });
+    expect(result).toMatchObject({
+      accountProviderId: "openrouter-api",
+      billingMode: "api-credits-or-byok",
+      termsPolicy: "credits-or-byok",
+      providerLabel: "OpenRouter credits / BYOK",
+      model: "openrouter/anthropic/claude-sonnet-4.5",
+    });
+    const config = JSON.parse(result?.configContent ?? "{}");
+    expect(config.provider.openrouter.options.baseURL).toBe(
+      "https://openrouter.ai/api/v1",
+    );
+    expect(config.provider.openrouter.options.headers).toEqual({
+      "HTTP-Referer": "https://elizaos.ai",
+      "X-OpenRouter-Title": "elizaOS coding agent",
+    });
+  });
+
+  it("fails closed when OpenRouter has no explicit arbitrary model", () => {
+    expect(() =>
+      buildOpencodeSpawnConfig(runtime(), {
+        ELIZA_OPENCODE_PROVIDER: "openrouter",
+        OPENROUTER_API_KEY: "openrouter-secret-never-log",
+      }),
+    ).toThrow(/requires an explicit OpenCode model/i);
+  });
+
+  it("fails closed when an explicit route has no matching credential", () => {
+    expect(() =>
+      buildOpencodeSpawnConfig(runtime(), {
+        ELIZA_OPENCODE_PROVIDER: "xai-api",
+        OPENROUTER_API_KEY: "must-not-be-used-for-xai",
+      }),
+    ).toThrow(/requires XAI_API_KEY/i);
+  });
+
+  it("does not guess among multiple non-Cerebras billing sources", () => {
+    const result = buildOpencodeSpawnConfig(runtime(), {
+      DEEPSEEK_API_KEY: "deepseek-secret",
+      XAI_API_KEY: "xai-secret",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("honors provider-specific endpoint overrides without changing billing identity", () => {
+    const result = buildOpencodeSpawnConfig(runtime(), {
+      ELIZA_OPENCODE_PROVIDER: "z.ai",
+      ZAI_API_KEY: "zai-secret",
+      Z_AI_BASE_URL: "https://zai-proxy.test.invalid/v4",
+    });
+    expect(result?.accountProviderId).toBe("zai-api");
+    expect(result?.billingMode).toBe("api-payg");
+    const config = JSON.parse(result?.configContent ?? "{}");
+    expect(config.provider.zai.options.baseURL).toBe(
+      "https://zai-proxy.test.invalid/v4",
+    );
+  });
+
+  it.each([
+    ["zai-api", "Z_AI_API_KEY", "zai"],
+    ["moonshot-api", "KIMI_API_KEY", "moonshot"],
+  ] as const)(
+    "accepts the existing %s credential alias %s",
+    (selector, keyEnv, provider) => {
+      const result = buildOpencodeSpawnConfig(runtime(), {
+        ELIZA_OPENCODE_PROVIDER: selector,
+        [keyEnv]: `${selector}-legacy-alias-secret`,
+      });
+      const config = JSON.parse(result?.configContent ?? "{}");
+      expect(config.provider[provider].options.apiKey).toBe(
+        `${selector}-legacy-alias-secret`,
+      );
+    },
+  );
+
+  it("rejects malformed model ids and credential-bearing endpoints", () => {
+    expect(() =>
+      buildOpencodeSpawnConfig(runtime(), {
+        ELIZA_OPENCODE_PROVIDER: "deepseek-api",
+        DEEPSEEK_API_KEY: "deepseek-secret",
+        ELIZA_OPENCODE_MODEL_POWERFUL: "deepseek-v4-pro\nignore-policy",
+      }),
+    ).toThrow(/invalid OpenCode model id/i);
+    expect(() =>
+      buildOpencodeSpawnConfig(runtime(), {
+        ELIZA_OPENCODE_PROVIDER: "deepseek-api",
+        DEEPSEEK_API_KEY: "deepseek-secret",
+        DEEPSEEK_BASE_URL: "https://user:secret@example.invalid/v1",
+      }),
+    ).toThrow(/invalid API base URL/i);
+    expect(() =>
+      buildOpencodeSpawnConfig(runtime(), {
+        ELIZA_OPENCODE_PROVIDER: "deepseek-api",
+        DEEPSEEK_API_KEY: "deepseek-secret",
+        DEEPSEEK_BASE_URL: "http://proxy.example.invalid/v1",
+      }),
+    ).toThrow(/invalid API base URL/i);
   });
 
   it("uses ELIZA_OPENCODE_MODEL_POWERFUL with a Cerebras base URL", () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts
@@ -4,7 +4,10 @@
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { buildOpencodeSpawnConfig } from "../../src/services/opencode-config.js";
+import {
+  buildOpencodeSpawnConfig,
+  safeOpencodeEndpointForLog,
+} from "../../src/services/opencode-config.js";
 
 function runtime(settings: Record<string, string | undefined> = {}) {
   return {
@@ -167,6 +170,31 @@ describe("buildOpencodeSpawnConfig", () => {
     ).toThrow(/requires XAI_API_KEY/i);
   });
 
+  it("keeps a selected account tuple authoritative over stale runtime settings", () => {
+    const result = buildOpencodeSpawnConfig(
+      runtime({
+        ELIZA_OPENCODE_PROVIDER: "xai-api",
+        DEEPSEEK_API_KEY: "stale-runtime-deepseek-key",
+        XAI_API_KEY: "stale-runtime-xai-key",
+      }),
+      {},
+      undefined,
+      {
+        providerId: "deepseek-api",
+        credentials: {
+          DEEPSEEK_API_KEY: "selected-account-deepseek-key",
+        },
+      },
+    );
+    const config = JSON.parse(result?.configContent ?? "{}");
+    expect(result?.accountProviderId).toBe("deepseek-api");
+    expect(config.provider.deepseek.options.apiKey).toBe(
+      "selected-account-deepseek-key",
+    );
+    expect(result?.configContent).not.toContain("stale-runtime-deepseek-key");
+    expect(result?.configContent).not.toContain("stale-runtime-xai-key");
+  });
+
   it("does not guess among multiple non-Cerebras billing sources", () => {
     const result = buildOpencodeSpawnConfig(runtime(), {
       DEEPSEEK_API_KEY: "deepseek-secret",
@@ -228,6 +256,52 @@ describe("buildOpencodeSpawnConfig", () => {
         DEEPSEEK_BASE_URL: "http://proxy.example.invalid/v1",
       }),
     ).toThrow(/invalid API base URL/i);
+    expect(() =>
+      buildOpencodeSpawnConfig(runtime(), {
+        ELIZA_OPENCODE_PROVIDER: "deepseek-api",
+        DEEPSEEK_API_KEY: "deepseek-secret",
+        DEEPSEEK_BASE_URL:
+          "https://proxy.example.invalid/v1?api_key=query-secret#fragment-secret",
+      }),
+    ).toThrow(/invalid API base URL/i);
+  });
+
+  it.each([
+    "http://localhost:11434/v1",
+    "http://127.0.0.1:11434/v1",
+    "http://[::1]:11434/v1",
+  ])("allows an explicit HTTP loopback API proxy at %s", (baseUrl) => {
+    const result = buildOpencodeSpawnConfig(runtime(), {
+      ELIZA_OPENCODE_PROVIDER: "deepseek-api",
+      DEEPSEEK_API_KEY: "deepseek-secret",
+      DEEPSEEK_BASE_URL: baseUrl,
+    });
+    expect(result?.baseUrl).toBe(baseUrl);
+  });
+
+  it.each([
+    "http://0.0.0.0:11434/v1",
+    "http://192.168.1.10:11434/v1",
+    "http://localhost.example.invalid:11434/v1",
+  ])("rejects a non-canonical insecure API proxy at %s", (baseUrl) => {
+    expect(() =>
+      buildOpencodeSpawnConfig(runtime(), {
+        ELIZA_OPENCODE_PROVIDER: "deepseek-api",
+        DEEPSEEK_API_KEY: "deepseek-secret",
+        DEEPSEEK_BASE_URL: baseUrl,
+      }),
+    ).toThrow(/invalid API base URL/i);
+  });
+
+  it("never projects endpoint credentials into structured logs", () => {
+    const logged = safeOpencodeEndpointForLog(
+      "https://user:password@proxy.example.invalid/v1?api_key=query-secret#fragment-secret",
+    );
+    expect(logged).toBe("https://proxy.example.invalid/v1");
+    expect(logged).not.toMatch(/user|password|query-secret|fragment-secret/);
+    expect(
+      safeOpencodeEndpointForLog("not a URL with secret material"),
+    ).toBeUndefined();
   });
 
   it("uses ELIZA_OPENCODE_MODEL_POWERFUL with a Cerebras base URL", () => {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -92,6 +92,7 @@ import {
 } from "./model-gateway-lease.js";
 import {
   buildOpencodeAcpEnv,
+  OPENCODE_API_KEY_ENVS,
   resolveVendoredOpencodeAcpCommand,
 } from "./opencode-config.js";
 import {
@@ -4761,10 +4762,25 @@ export class AcpService extends Service {
       const opencode = buildOpencodeAcpEnv(this.runtime, env, model);
       Object.assign(env, opencode.env);
       if (opencode.config) {
+        if (opencode.config.accountProviderId) {
+          for (const key of new Set([
+            ...MODEL_GATEWAY_EXCLUDED_PROVIDER_KEYS,
+            ...OPENCODE_API_KEY_ENVS,
+            "Z_AI_API_KEY",
+            "KIMI_API_KEY",
+            "GROK_API_KEY",
+          ])) {
+            delete env[key];
+          }
+        }
         this.log("info", "OpenCode ACP provider configured", {
           provider: opencode.config.providerLabel,
           model: opencode.config.model,
           smallModel: opencode.config.smallModel,
+          accountProviderId: opencode.config.accountProviderId,
+          billingMode: opencode.config.billingMode,
+          termsPolicy: opencode.config.termsPolicy,
+          endpoint: opencode.config.baseUrl,
           vendored: Boolean(opencode.vendoredShimDir),
         });
       }

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -212,6 +212,9 @@ type RunOptions = {
   workdir: string;
   args: string[];
   env?: Record<string, string | undefined>;
+  customCredentials?: Record<string, string | undefined>;
+  model?: string;
+  expectedAccountProviderId?: string;
   promptPreview?: string;
   promptLength?: number;
   timeoutMs?: number;
@@ -1979,11 +1982,19 @@ export class AcpService extends Service {
       const accountStrategy = resolveCodingAccountStrategy(
         this.setting("ELIZA_CODING_ACCOUNT_STRATEGY"),
       );
-      const resolvedAccount = await selectCodingAccount(agentType, {
-        sessionKey: id,
-        ...(accountStrategy ? { strategy: accountStrategy } : {}),
-        ...(spawnModel ? { model: spawnModel } : {}),
-      });
+      // A host model gateway owns the billed transport for every backend. Do
+      // not select or stamp a pooled account in that mode: its credential is
+      // intentionally excluded from the child, so attributing usage, health,
+      // or affinity to it would be false. The gateway is resolved before the
+      // pool call so selection itself cannot mutate account affinity.
+      const gatewayControlsBilling = Boolean(resolveModelGatewayConfig());
+      const resolvedAccount = gatewayControlsBilling
+        ? null
+        : await selectCodingAccount(agentType, {
+            sessionKey: id,
+            ...(accountStrategy ? { strategy: accountStrategy } : {}),
+            ...(spawnModel ? { model: spawnModel } : {}),
+          });
       const customCredentials = resolvedAccount
         ? {
             ...(opts.customCredentials ?? {}),
@@ -1999,7 +2010,7 @@ export class AcpService extends Service {
           label: resolvedAccount.meta.label,
           strategy: resolvedAccount.meta.strategy,
         });
-      } else {
+      } else if (!gatewayControlsBilling) {
         // A degraded pool must not hard-fail a spawn, but it must not degrade
         // invisibly either (#9960). Warn loudly only when accounts are connected
         // yet none are healthy — a benign empty pool stays quiet.
@@ -2134,13 +2145,10 @@ export class AcpService extends Service {
         agentType,
         workdir,
         args,
-        env: this.buildEnv(
-          sessionEnv,
-          customCredentials,
-          spawnModel,
-          agentType,
-          id,
-        ),
+        env: sessionEnv,
+        customCredentials,
+        model: spawnModel,
+        expectedAccountProviderId: resolvedAccount?.meta.providerId,
       });
 
       if (result.code !== 0) {
@@ -2400,13 +2408,12 @@ export class AcpService extends Service {
       agentType: session.agentType,
       workdir: session.workdir,
       args,
-      env: this.buildEnv(
-        promptEnv,
-        promptCredentials,
-        promptModel,
-        session.agentType,
-        sessionId,
-      ),
+      env: promptEnv,
+      customCredentials: promptCredentials,
+      model: promptModel,
+      expectedAccountProviderId: accountMetaFromSessionMetadata(
+        session.metadata,
+      )?.providerId,
       promptPreview: preview(text),
       promptLength: text.length,
       timeoutMs: opts.timeoutMs,
@@ -3174,6 +3181,7 @@ export class AcpService extends Service {
         session.agentType,
         session.id,
         opts.codexInitialAgentModeOverride,
+        accountMetaFromSessionMetadata(session.metadata)?.providerId,
       ),
       mcpServers: readConfigMcpServers(),
       onEvent: (event, protocolSessionId) => {
@@ -3267,6 +3275,8 @@ export class AcpService extends Service {
           opts.model,
           opts.session.agentType,
           opts.session.id,
+          undefined,
+          accountMetaFromSessionMetadata(opts.session.metadata)?.providerId,
         );
         const trustedExecutionPath = this.trustedSessionExecutionPath(
           opts.session,
@@ -3786,10 +3796,12 @@ export class AcpService extends Service {
         // re-added and override the selected account on the cli transport.
         env: this.buildEnv(
           opts.env,
-          undefined,
-          undefined,
+          opts.customCredentials,
+          opts.model,
           opts.agentType,
           opts.sessionId,
+          undefined,
+          opts.expectedAccountProviderId,
         ),
         stdio: ["pipe", "pipe", "pipe"],
         // Place the child in its own process group so we can SIGTERM the
@@ -4603,6 +4615,7 @@ export class AcpService extends Service {
     agentType?: AgentType,
     childSessionId?: string,
     codexInitialAgentModeOverride?: CodexAcpInitialAgentMode,
+    expectedAccountProviderId?: string,
   ): NodeJS.ProcessEnv {
     // Deny-list-filtered, allowlisted, casing-canonicalized host env (see
     // forwardableSubAgentEnv / canonicalForwardedEnvKey — Bun on Windows reports
@@ -4774,6 +4787,22 @@ export class AcpService extends Service {
             }
           : undefined,
       );
+      if (
+        expectedAccountProviderId &&
+        opencode.config?.accountProviderId !== expectedAccountProviderId
+      ) {
+        throw new ElizaError(
+          "Selected OpenCode account does not control the configured billing transport.",
+          {
+            code: "OPENCODE_ACCOUNT_TRANSPORT_MISMATCH",
+            context: {
+              selectedProviderId: expectedAccountProviderId,
+              configuredProviderId: opencode.config?.accountProviderId,
+            },
+            severity: "fatal",
+          },
+        );
+      }
       Object.assign(env, opencode.env);
       if (opencode.config) {
         if (opencode.config.accountProviderId) {

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -94,6 +94,7 @@ import {
   buildOpencodeAcpEnv,
   OPENCODE_API_KEY_ENVS,
   resolveVendoredOpencodeAcpCommand,
+  safeOpencodeEndpointForLog,
 } from "./opencode-config.js";
 import {
   createOwnedArtifactRecord,
@@ -4759,7 +4760,20 @@ export class AcpService extends Service {
       }
     }
     if (agentType === "opencode") {
-      const opencode = buildOpencodeAcpEnv(this.runtime, env, model);
+      const selectedProviderId =
+        customCredentials?.ELIZA_OPENCODE_PROVIDER_ID ??
+        customCredentials?.ELIZA_OPENCODE_PROVIDER;
+      const opencode = buildOpencodeAcpEnv(
+        this.runtime,
+        env,
+        model,
+        selectedProviderId
+          ? {
+              providerId: selectedProviderId,
+              credentials: customCredentials ?? {},
+            }
+          : undefined,
+      );
       Object.assign(env, opencode.env);
       if (opencode.config) {
         if (opencode.config.accountProviderId) {
@@ -4780,7 +4794,7 @@ export class AcpService extends Service {
           accountProviderId: opencode.config.accountProviderId,
           billingMode: opencode.config.billingMode,
           termsPolicy: opencode.config.termsPolicy,
-          endpoint: opencode.config.baseUrl,
+          endpoint: safeOpencodeEndpointForLog(opencode.config.baseUrl),
           vendored: Boolean(opencode.vendoredShimDir),
         });
       }

--- a/plugins/plugin-agent-orchestrator/src/services/coding-account-selection.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/coding-account-selection.ts
@@ -47,11 +47,9 @@ export interface ResolvedCodingAccount {
 
 /**
  * Agent types that authenticate per pooled account. claude and codex are
- * first-party CLIs; opencode pool-rotates across `cerebras-api` accounts (the
- * one backend it resolves from a pooled key — its injected CEREBRAS_API_KEY is
- * read by buildOpencodeSpawnConfig). elizaos/pi-agent authenticate through their
- * own backend, and z.ai/Kimi/GLM have no first-party coding CLI. The set is
- * derived from the shared executable-backend credential map.
+ * first-party CLIs; opencode pool-rotates across the typed direct-API providers
+ * in the shared executable map. elizaos/pi-agent authenticate through their own
+ * backend. The set is derived from the shared executable-backend credential map.
  */
 const MULTI_ACCOUNT_AGENT_TYPES = new Set(
   Object.entries(CODING_AGENT_BACKEND_PROVIDERS)

--- a/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
@@ -9,7 +9,7 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { IAgentRuntime } from "@elizaos/core";
-import { DEFAULT_CEREBRAS_TEXT_MODEL } from "@elizaos/core";
+import { DEFAULT_CEREBRAS_TEXT_MODEL, ElizaError } from "@elizaos/core";
 import { readConfigCloudKey, readConfigEnvKey } from "./config-env.js";
 import { resolveModelGatewayConfig } from "./model-gateway.js";
 
@@ -19,6 +19,127 @@ const OPENCODE_OPENAI_COMPATIBLE_NPM = "@ai-sdk/openai-compatible";
 const OPENCODE_CEREBRAS_NPM = "@ai-sdk/cerebras";
 const CEREBRAS_DEFAULT_BASE_URL = "https://api.cerebras.ai/v1";
 const CEREBRAS_DEFAULT_MODEL = DEFAULT_CEREBRAS_TEXT_MODEL;
+
+export type OpencodeApiBillingMode = "api-payg" | "api-credits-or-byok";
+
+export type OpencodeApiProviderId =
+  | "cerebras-api"
+  | "deepseek-api"
+  | "zai-api"
+  | "moonshot-api"
+  | "xai-api"
+  | "openrouter-api";
+
+export interface OpencodeApiRoute {
+  accountProviderId: OpencodeApiProviderId;
+  providerId: string;
+  providerLabel: string;
+  keyEnv: string;
+  keyEnvAliases?: readonly string[];
+  baseUrlEnv: readonly string[];
+  defaultBaseUrl: string;
+  defaultModel?: string;
+  authHeader: "Authorization: Bearer";
+  billingMode: OpencodeApiBillingMode;
+  termsPolicy: "direct-api" | "credits-or-byok";
+  headers?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Direct billing routes OpenCode can consume. Coding-plan endpoint keys are
+ * intentionally absent: Kimi and Z.AI subscription quota have distinct keys,
+ * endpoints, and terms, and must never be inferred from these PAYG entries.
+ */
+export const OPENCODE_API_ROUTES = {
+  "cerebras-api": {
+    accountProviderId: "cerebras-api",
+    providerId: "cerebras",
+    providerLabel: "Cerebras API",
+    keyEnv: "CEREBRAS_API_KEY",
+    baseUrlEnv: ["CEREBRAS_BASE_URL"],
+    defaultBaseUrl: CEREBRAS_DEFAULT_BASE_URL,
+    defaultModel: CEREBRAS_DEFAULT_MODEL,
+    authHeader: "Authorization: Bearer",
+    billingMode: "api-payg",
+    termsPolicy: "direct-api",
+  },
+  "deepseek-api": {
+    accountProviderId: "deepseek-api",
+    providerId: "deepseek",
+    providerLabel: "DeepSeek API (PAYG)",
+    keyEnv: "DEEPSEEK_API_KEY",
+    baseUrlEnv: ["DEEPSEEK_BASE_URL"],
+    defaultBaseUrl: "https://api.deepseek.com",
+    defaultModel: "deepseek-v4-pro",
+    authHeader: "Authorization: Bearer",
+    billingMode: "api-payg",
+    termsPolicy: "direct-api",
+  },
+  "zai-api": {
+    accountProviderId: "zai-api",
+    providerId: "zai",
+    providerLabel: "Z.AI API (PAYG)",
+    keyEnv: "ZAI_API_KEY",
+    keyEnvAliases: ["Z_AI_API_KEY"],
+    baseUrlEnv: ["ZAI_BASE_URL", "Z_AI_BASE_URL"],
+    defaultBaseUrl: "https://api.z.ai/api/paas/v4",
+    defaultModel: "glm-5.1",
+    authHeader: "Authorization: Bearer",
+    billingMode: "api-payg",
+    termsPolicy: "direct-api",
+  },
+  "moonshot-api": {
+    accountProviderId: "moonshot-api",
+    providerId: "moonshot",
+    providerLabel: "Kimi / Moonshot API (PAYG)",
+    keyEnv: "MOONSHOT_API_KEY",
+    keyEnvAliases: ["KIMI_API_KEY"],
+    baseUrlEnv: ["MOONSHOT_BASE_URL", "KIMI_BASE_URL"],
+    defaultBaseUrl: "https://api.moonshot.ai/v1",
+    defaultModel: "kimi-k2.5",
+    authHeader: "Authorization: Bearer",
+    billingMode: "api-payg",
+    termsPolicy: "direct-api",
+  },
+  "xai-api": {
+    accountProviderId: "xai-api",
+    providerId: "xai",
+    providerLabel: "xAI API (PAYG)",
+    keyEnv: "XAI_API_KEY",
+    baseUrlEnv: ["XAI_BASE_URL"],
+    defaultBaseUrl: "https://api.x.ai/v1",
+    defaultModel: "grok-build-0.1",
+    authHeader: "Authorization: Bearer",
+    billingMode: "api-payg",
+    termsPolicy: "direct-api",
+  },
+  "openrouter-api": {
+    accountProviderId: "openrouter-api",
+    providerId: "openrouter",
+    providerLabel: "OpenRouter credits / BYOK",
+    keyEnv: "OPENROUTER_API_KEY",
+    baseUrlEnv: ["OPENROUTER_BASE_URL"],
+    defaultBaseUrl: "https://openrouter.ai/api/v1",
+    authHeader: "Authorization: Bearer",
+    billingMode: "api-credits-or-byok",
+    termsPolicy: "credits-or-byok",
+    headers: {
+      "HTTP-Referer": "https://elizaos.ai",
+      "X-OpenRouter-Title": "elizaOS coding agent",
+    },
+  },
+} as const satisfies Readonly<Record<OpencodeApiProviderId, OpencodeApiRoute>>;
+
+export const OPENCODE_API_KEY_ENVS = Object.freeze(
+  Object.values(OPENCODE_API_ROUTES).flatMap((route) => [
+    route.keyEnv,
+    ...("keyEnvAliases" in route ? route.keyEnvAliases : []),
+  ]),
+);
+
+function routeCredentialKeys(route: OpencodeApiRoute): readonly string[] {
+  return [route.keyEnv, ...(route.keyEnvAliases ?? [])];
+}
 
 // `webfetch` is a read-only HTTP GET (opencode caps the response at 5MB and
 // never mutates the workspace). `websearch` is opencode's general web-search
@@ -50,6 +171,10 @@ export interface OpencodeSpawnConfig {
   configContent: string;
   providerLabel: string;
   providerId: string;
+  accountProviderId?: OpencodeApiProviderId;
+  billingMode?: OpencodeApiBillingMode;
+  termsPolicy?: OpencodeApiRoute["termsPolicy"];
+  baseUrl?: string;
   model: string;
   smallModel?: string;
 }
@@ -90,6 +215,11 @@ function providerConfig(
   apiKey: string | undefined,
   powerful: string,
   fast: string | undefined,
+  metadata: Pick<
+    OpencodeSpawnConfig,
+    "accountProviderId" | "billingMode" | "termsPolicy"
+  > = {},
+  headers?: Readonly<Record<string, string>>,
 ): OpencodeSpawnConfig {
   const config = {
     $schema: "https://opencode.ai/config.json",
@@ -97,7 +227,11 @@ function providerConfig(
       [providerId]: {
         npm,
         name,
-        options: { baseURL, ...(apiKey ? { apiKey } : {}) },
+        options: {
+          baseURL,
+          ...(apiKey ? { apiKey } : {}),
+          ...(headers && Object.keys(headers).length > 0 ? { headers } : {}),
+        },
         models: {
           [powerful]: { name: powerful },
           ...(fast && fast !== powerful ? { [fast]: { name: fast } } : {}),
@@ -114,9 +248,177 @@ function providerConfig(
     configContent: JSON.stringify(config),
     providerLabel: name,
     providerId,
+    ...metadata,
+    baseUrl: baseURL,
     model: `${providerId}/${powerful}`,
     smallModel: fast && fast !== powerful ? `${providerId}/${fast}` : undefined,
   };
+}
+
+function firstSetting(
+  runtime: RuntimeLike | undefined,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> | undefined,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = setting(runtime, env, key);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function normalizeRouteId(
+  value: string | undefined,
+): OpencodeApiProviderId | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase();
+  const aliases: Readonly<Record<string, OpencodeApiProviderId>> = {
+    cerebras: "cerebras-api",
+    "cerebras-api": "cerebras-api",
+    deepseek: "deepseek-api",
+    "deepseek-api": "deepseek-api",
+    zai: "zai-api",
+    "z.ai": "zai-api",
+    "zai-api": "zai-api",
+    moonshot: "moonshot-api",
+    kimi: "moonshot-api",
+    "moonshot-api": "moonshot-api",
+    xai: "xai-api",
+    grok: "xai-api",
+    "xai-api": "xai-api",
+    openrouter: "openrouter-api",
+    "openrouter-api": "openrouter-api",
+  };
+  return aliases[normalized];
+}
+
+function explicitlySelectedRoute(
+  runtime: RuntimeLike | undefined,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+): OpencodeApiProviderId | undefined {
+  const raw =
+    setting(runtime, env, "ELIZA_OPENCODE_PROVIDER_ID") ??
+    setting(runtime, env, "ELIZA_OPENCODE_PROVIDER");
+  if (!raw) return undefined;
+  const providerId = normalizeRouteId(raw);
+  if (!providerId) {
+    throw new ElizaError(`Unsupported OpenCode API provider: ${raw}`, {
+      code: "OPENCODE_PROVIDER_UNSUPPORTED",
+      context: { providerId: raw },
+      severity: "fatal",
+    });
+  }
+  return providerId;
+}
+
+function autoDetectedRoute(
+  runtime: RuntimeLike | undefined,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+): OpencodeApiProviderId | undefined {
+  const found = Object.values(OPENCODE_API_ROUTES).filter((route) =>
+    usableApiKey(firstSetting(runtime, env, routeCredentialKeys(route))),
+  );
+  if (found.length === 1) return found[0]?.accountProviderId;
+  // Preserve the historical Cerebras default on hosts with several general
+  // inference keys. A different provider must be selected explicitly so the
+  // provider/account/model/billing tuple cannot depend on object order.
+  if (found.some((route) => route.accountProviderId === "cerebras-api")) {
+    return "cerebras-api";
+  }
+  return undefined;
+}
+
+function buildTypedApiRouteConfig(
+  runtime: RuntimeLike | undefined,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+  routeId: OpencodeApiProviderId,
+  powerfulOverride: string | undefined,
+  fastOverride: string | undefined,
+): OpencodeSpawnConfig {
+  const route: OpencodeApiRoute = OPENCODE_API_ROUTES[routeId];
+  const apiKey = usableApiKey(
+    firstSetting(runtime, env, routeCredentialKeys(route)),
+  );
+  if (!apiKey) {
+    throw new ElizaError(
+      `${route.providerLabel} requires ${route.keyEnv} for direct API billing.`,
+      {
+        code: "OPENCODE_PROVIDER_CREDENTIAL_MISSING",
+        context: { providerId: route.accountProviderId, keyEnv: route.keyEnv },
+        severity: "fatal",
+      },
+    );
+  }
+  const providerPrefix = `${route.providerId}/`;
+  const powerful =
+    powerfulOverride?.startsWith(providerPrefix) === true
+      ? powerfulOverride.slice(providerPrefix.length)
+      : (powerfulOverride ?? route.defaultModel);
+  if (!powerful) {
+    throw new ElizaError(
+      `${route.providerLabel} requires an explicit OpenCode model.`,
+      {
+        code: "OPENCODE_PROVIDER_MODEL_MISSING",
+        context: {
+          providerId: route.accountProviderId,
+          modelSetting: "ELIZA_OPENCODE_MODEL_POWERFUL",
+        },
+        severity: "fatal",
+      },
+    );
+  }
+  if (
+    powerful.length > 256 ||
+    !/^[~A-Za-z0-9][A-Za-z0-9._:/+~-]*$/.test(powerful)
+  ) {
+    throw new ElizaError(
+      `${route.providerLabel} received an invalid OpenCode model id.`,
+      {
+        code: "OPENCODE_PROVIDER_MODEL_INVALID",
+        context: { providerId: route.accountProviderId },
+        severity: "fatal",
+      },
+    );
+  }
+  const configuredBaseUrl =
+    firstSetting(runtime, env, route.baseUrlEnv) ?? route.defaultBaseUrl;
+  let baseUrl: string;
+  try {
+    const parsed = new URL(configuredBaseUrl);
+    if (parsed.protocol !== "https:" || parsed.username || parsed.password) {
+      throw new Error("expected an HTTPS URL without embedded credentials");
+    }
+    baseUrl = parsed.toString().replace(/\/$/, "");
+  } catch (cause) {
+    // error-policy:J3 provider endpoint configuration is untrusted operator
+    // input; reject malformed or credential-bearing URLs before child spawn.
+    throw new ElizaError(
+      `${route.providerLabel} received an invalid API base URL.`,
+      {
+        code: "OPENCODE_PROVIDER_BASE_URL_INVALID",
+        cause,
+        context: { providerId: route.accountProviderId },
+        severity: "fatal",
+      },
+    );
+  }
+  return providerConfig(
+    route.providerId,
+    route.providerLabel,
+    route.accountProviderId === "cerebras-api"
+      ? OPENCODE_CEREBRAS_NPM
+      : OPENCODE_OPENAI_COMPATIBLE_NPM,
+    baseUrl,
+    apiKey,
+    powerful,
+    fastOverride,
+    {
+      accountProviderId: route.accountProviderId,
+      billingMode: route.billingMode,
+      termsPolicy: route.termsPolicy,
+    },
+    route.headers,
+  );
 }
 
 function isCerebrasBaseUrl(value: string | undefined): boolean {
@@ -191,6 +493,12 @@ export function buildOpencodeSpawnConfig(
       powerful || "claude-opus-4-8",
       fast || "claude-haiku-4-5",
     );
+  }
+
+  const explicitRoute = explicitlySelectedRoute(runtime, env);
+  const typedRoute = explicitRoute ?? autoDetectedRoute(runtime, env);
+  if (typedRoute) {
+    return buildTypedApiRouteConfig(runtime, env, typedRoute, powerful, fast);
   }
 
   const opencodeApiKey = usableApiKey(

--- a/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
@@ -12,6 +12,7 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { DEFAULT_CEREBRAS_TEXT_MODEL, ElizaError } from "@elizaos/core";
 import { readConfigCloudKey, readConfigEnvKey } from "./config-env.js";
 import { resolveModelGatewayConfig } from "./model-gateway.js";
+import { classifyIpLiteral } from "./ssrf-guard.js";
 
 const ELIZA_CLOUD_OPENAI_BASE = "https://api.eliza.app/api/v1";
 const OPENCODE_LOCAL_DEFAULT_BASE_URL = "http://localhost:11434/v1";
@@ -185,6 +186,30 @@ export interface OpencodeAcpEnvResult {
   vendoredShimDir?: string;
 }
 
+export interface OpencodeAccountRouteOverride {
+  providerId: string;
+  credentials: Readonly<Record<string, string | undefined>>;
+}
+
+/** Removes URL components that may carry credentials before structured logging. */
+export function safeOpencodeEndpointForLog(
+  value: string | undefined,
+): string | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed = new URL(value);
+    parsed.username = "";
+    parsed.password = "";
+    parsed.search = "";
+    parsed.hash = "";
+    return parsed.toString().replace(/\/$/, "");
+  } catch {
+    // error-policy:J3 logging untrusted configuration must never echo it when
+    // it is not a parseable URL.
+    return undefined;
+  }
+}
+
 function runtimeSetting(
   runtime: RuntimeLike | undefined,
   key: string,
@@ -295,7 +320,20 @@ function normalizeRouteId(
 function explicitlySelectedRoute(
   runtime: RuntimeLike | undefined,
   env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+  accountRoute: OpencodeAccountRouteOverride | undefined,
 ): OpencodeApiProviderId | undefined {
+  const accountProviderId = normalizeRouteId(accountRoute?.providerId);
+  if (accountRoute && !accountProviderId) {
+    throw new ElizaError(
+      `Unsupported selected OpenCode API provider: ${accountRoute.providerId}`,
+      {
+        code: "OPENCODE_PROVIDER_UNSUPPORTED",
+        context: { providerId: accountRoute.providerId },
+        severity: "fatal",
+      },
+    );
+  }
+  if (accountProviderId) return accountProviderId;
   const raw =
     setting(runtime, env, "ELIZA_OPENCODE_PROVIDER_ID") ??
     setting(runtime, env, "ELIZA_OPENCODE_PROVIDER");
@@ -334,10 +372,17 @@ function buildTypedApiRouteConfig(
   routeId: OpencodeApiProviderId,
   powerfulOverride: string | undefined,
   fastOverride: string | undefined,
+  accountRoute: OpencodeAccountRouteOverride | undefined,
 ): OpencodeSpawnConfig {
   const route: OpencodeApiRoute = OPENCODE_API_ROUTES[routeId];
   const apiKey = usableApiKey(
-    firstSetting(runtime, env, routeCredentialKeys(route)),
+    accountRoute
+      ? firstSetting(
+          undefined,
+          accountRoute.credentials,
+          routeCredentialKeys(route),
+        )
+      : firstSetting(runtime, env, routeCredentialKeys(route)),
   );
   if (!apiKey) {
     throw new ElizaError(
@@ -385,10 +430,23 @@ function buildTypedApiRouteConfig(
   let baseUrl: string;
   try {
     const parsed = new URL(configuredBaseUrl);
-    if (parsed.protocol !== "https:" || parsed.username || parsed.password) {
-      throw new Error("expected an HTTPS URL without embedded credentials");
+    const host = parsed.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+    const isLoopback =
+      host === "localhost" || classifyIpLiteral(host) === "loopback";
+    if (
+      (parsed.protocol !== "https:" &&
+        !(parsed.protocol === "http:" && isLoopback)) ||
+      !parsed.hostname ||
+      parsed.username ||
+      parsed.password ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      throw new Error(
+        "expected an HTTPS URL without credentials, query, or fragment",
+      );
     }
-    baseUrl = parsed.toString().replace(/\/$/, "");
+    baseUrl = parsed.toString().replace(/\/+$/, "");
   } catch (cause) {
     // error-policy:J3 provider endpoint configuration is untrusted operator
     // input; reject malformed or credential-bearing URLs before child spawn.
@@ -442,6 +500,7 @@ export function buildOpencodeSpawnConfig(
   runtime: RuntimeLike | undefined,
   env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
   overrideModel?: string,
+  accountRoute?: OpencodeAccountRouteOverride,
 ): OpencodeSpawnConfig | null {
   const llmProvider =
     setting(runtime, env, "ELIZA_LLM_PROVIDER") || "subscription";
@@ -495,10 +554,17 @@ export function buildOpencodeSpawnConfig(
     );
   }
 
-  const explicitRoute = explicitlySelectedRoute(runtime, env);
+  const explicitRoute = explicitlySelectedRoute(runtime, env, accountRoute);
   const typedRoute = explicitRoute ?? autoDetectedRoute(runtime, env);
   if (typedRoute) {
-    return buildTypedApiRouteConfig(runtime, env, typedRoute, powerful, fast);
+    return buildTypedApiRouteConfig(
+      runtime,
+      env,
+      typedRoute,
+      powerful,
+      fast,
+      accountRoute,
+    );
   }
 
   const opencodeApiKey = usableApiKey(
@@ -618,6 +684,7 @@ export function buildOpencodeAcpEnv(
   runtime: RuntimeLike | undefined,
   env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
   model?: string,
+  accountRoute?: OpencodeAccountRouteOverride,
 ): OpencodeAcpEnvResult {
   const next: Record<string, string> = {};
   const vendoredShimDir = resolveVendoredOpencodeShim();
@@ -625,7 +692,8 @@ export function buildOpencodeAcpEnv(
     next.PATH = prependPathDir(env.PATH, vendoredShimDir);
   }
 
-  const config = buildOpencodeSpawnConfig(runtime, env, model) ?? undefined;
+  const config =
+    buildOpencodeSpawnConfig(runtime, env, model, accountRoute) ?? undefined;
   if (config) {
     next.OPENCODE_CONFIG_CONTENT = config.configContent;
     next.OPENCODE_MODEL = config.model;

--- a/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
@@ -540,6 +540,37 @@ export function buildOpencodeSpawnConfig(
     );
   }
 
+  // A pooled account is a per-spawn billing decision, so it is authoritative
+  // over the runtime-wide Cloud preference. Without this ordering a session
+  // could be stamped as DeepSeek while OpenCode either received no config
+  // (Cloud selected without a key) or billed Eliza Cloud (Cloud key present).
+  // Gateway stays above this branch: centralized egress is a host security
+  // policy, not a billing preference a child credential may bypass.
+  if (accountRoute) {
+    const selectedAccountRoute = explicitlySelectedRoute(
+      runtime,
+      env,
+      accountRoute,
+    );
+    if (!selectedAccountRoute) {
+      throw new ElizaError(
+        "Selected OpenCode account did not resolve to a billing route.",
+        {
+          code: "OPENCODE_ACCOUNT_ROUTE_MISSING",
+          severity: "fatal",
+        },
+      );
+    }
+    return buildTypedApiRouteConfig(
+      runtime,
+      env,
+      selectedAccountRoute,
+      powerful,
+      fast,
+      accountRoute,
+    );
+  }
+
   if (llmProvider === "cloud") {
     const cloudKey = readConfigCloudKey("apiKey");
     if (!cloudKey) return null;
@@ -554,7 +585,7 @@ export function buildOpencodeSpawnConfig(
     );
   }
 
-  const explicitRoute = explicitlySelectedRoute(runtime, env, accountRoute);
+  const explicitRoute = explicitlySelectedRoute(runtime, env, undefined);
   const typedRoute = explicitRoute ?? autoDetectedRoute(runtime, env);
   if (typedRoute) {
     return buildTypedApiRouteConfig(
@@ -563,7 +594,7 @@ export function buildOpencodeSpawnConfig(
       typedRoute,
       powerful,
       fast,
-      accountRoute,
+      undefined,
     );
   }
 


### PR DESCRIPTION
## Summary

- add a typed OpenCode direct-API route registry for Cerebras, DeepSeek, Z.AI general API, Moonshot, xAI/Grok, and OpenRouter
- validate provider, credential, model, and HTTPS endpoint as one fail-closed tuple before spawn
- isolate the selected key in child-only OpenCode config and remove conflicting provider keys from the child environment
- route existing pooled `deepseek-api`, `zai-api`, and `moonshot-api` accounts through canonical `opencode`
- preserve billing truth: direct provider routes are API PAYG; OpenRouter is credits/BYOK; none are presented as consumer or coding-plan subscriptions
- require an explicit arbitrary model for OpenRouter and include its optional app-attribution headers

Closes #24097.

## Scope and dependencies

This draft targets the provider-capability truth branch from #24095 / #24130 (`493f1e0611`). Its diff contains only #24097 implementation commits; retarget to `develop` after #24130 merges.

- #24096 owns native Kimi/Grok backends and dedicated Kimi/Z.AI coding-plan credential identity. This PR deliberately does not inject those plan keys into generic API routes.
- #24098 owns canonical linked-account authority for `xai-api` and `openrouter-api`. The registry supports both now through explicit environment configuration; they remain out of pooled account candidates until #24098 lands.
- #24100 owns credentialed live-provider trajectory evidence. No provider secret was available in this environment, so this PR does not claim a live billable request.

## Verification

- Bun `1.3.14`; `bun install` passed after rebase on `origin/develop`
- `check:agents-claude`: 160 pairs passed
- changed-file Biome and `git diff --check`: passed
- package typechecks: agent, shared, and plugin-agent-orchestrator passed
- orchestrator Vitest: 3 files, 134 tests passed
- shared capability contract: 12 tests passed
- focused account bridge/API/UI contract runs: 73 tests passed before the conflict-free rebase; the implementation commit was unchanged by rebase
- `bun run verify`: reached the workspace lint/typecheck lane, then failed on unrelated `origin/develop` debt, chiefly formatting in `packages/ui/src/components/chat/widgets/maps-card.tsx` plus existing core lint diagnostics. None of those files are changed here.
- `bun run --cwd packages/app audit:app`: ran the full capture lane but failed on unrelated existing audit instability: startup/preboot timeouts, the view-readiness self-test, the builtin-browser minimalism ratchet, and cockpit semantic readiness. The changed account-provider copy was not named by any failure.

## Evidence matrix

| Evidence | Result |
| --- | --- |
| Provider/model route construction | Deterministic tests cover all six provider IDs, official base URLs/defaults, billing metadata, selectors, aliases, and OpenRouter arbitrary models. |
| Adversarial configuration | Tests reject unknown providers, missing credentials/models, malformed models, ambiguous auto-detection, insecure or credential-bearing endpoints, and unresolved vault pointers. |
| Secret isolation | ACP test verifies the selected key is embedded only in child config and conflicting host keys are removed. Logs expose provider/model/billing/endpoint metadata, never the key. |
| Linked-account pooling | Real temp account storage test covers Cerebras, DeepSeek, Z.AI, and Moonshot selection plus atomic provider pinning. |
| Live provider request | N/A in this environment: no authorized billable credentials. Tracked by #24100; this draft makes no live-success claim. |
| Screenshots / video | N/A: no interaction/layout change; the only UI change is provider eligibility and billing copy. The mandatory audit run and its unrelated failures are recorded above. |

## Contribution references

- Issue: #24097
- Related: #24095, #24096, #24098, #24100
- Base PR dependency: #24130

<!-- evidence-head:cc65e8f403aa9aefd6823a46a319df99ddea8a95 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24208-before.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24208-after.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24208-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - no authorized billable provider credential was available; live route receipts remain #24100

<!-- evidence-row:frontend-logs -->
- [ ] N/A - the recorded real Settings flow completed without browser diagnostics

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no authorized billable provider credential was available; live task trajectories remain #24100

<!-- evidence-row:domain-artifacts -->
- [x] [24208-opencode-account-authority-cc65e8f.ts](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24208-opencode-account-authority-cc65e8f.ts)

<!-- evidence-row:ocr-review -->
- [x] [24208-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24208-ocr-triage.json)

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [opencode-api-routing]

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@63bce535e32738ad07e39552ed0cf16e36fa8dd9:packages/skills/skills/contribute-to-eliza"} -->


