### PR TITLE
feat(testing): share synthetic subprocess control protocol

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1049,6 +1049,7 @@
         "@elizaos/plugin-video": "workspace:*",
         "@elizaos/plugin-wallet": "workspace:*",
         "@elizaos/plugin-workflow": "workspace:*",
+        "@elizaos/shared": "workspace:*",
         "ws": "^8.21.3",
       },
       "devDependencies": {

--- a/packages/cloud/e2e/src/helpers/synthetic-control.ts
+++ b/packages/cloud/e2e/src/helpers/synthetic-control.ts
@@ -20,6 +20,7 @@ export function openCloudSyntheticWorld(
   return SyntheticControlSession.open({
     client: new SyntheticControlClient({
       baseUrl: options.controlUrl,
+      namespace: options.manifest.namespace,
       token: options.controlToken,
       timeoutMs: options.timeoutMs,
     }),

--- a/packages/cloud/e2e/src/helpers/synthetic-control.ts
+++ b/packages/cloud/e2e/src/helpers/synthetic-control.ts
@@ -1,0 +1,29 @@
+/** Opens Cloud E2E synthetic worlds through the same manifested control session used by scenarios. */
+
+import {
+  SyntheticControlClient,
+  SyntheticControlSession,
+  type SyntheticManifest,
+} from "@elizaos/shared/synthetic-control";
+
+export interface OpenCloudSyntheticWorldOptions {
+  controlUrl: string;
+  controlToken: string;
+  manifest: SyntheticManifest;
+  owner?: string;
+  timeoutMs?: number;
+}
+
+export function openCloudSyntheticWorld(
+  options: OpenCloudSyntheticWorldOptions,
+): Promise<SyntheticControlSession> {
+  return SyntheticControlSession.open({
+    client: new SyntheticControlClient({
+      baseUrl: options.controlUrl,
+      token: options.controlToken,
+      timeoutMs: options.timeoutMs,
+    }),
+    manifest: options.manifest,
+    owner: options.owner ?? "cloud-e2e",
+  });
+}

--- a/packages/cloud/test-mocks/README.md
+++ b/packages/cloud/test-mocks/README.md
@@ -9,7 +9,17 @@ HTTP contract used to seed, reset, advance time, install faults, inspect
 snapshots/ledgers, and tear down independently running mock processes. The
 scenario runner and Cloud E2E helpers both use `SyntheticControlClient` and
 `SyntheticControlSession`; callers must provide an explicit v1 manifest plus a
-control URL and token. A mock-profile string by itself cannot start a session.
+control URL and token. The client, token-bearing handler, request, response,
+manifest, and reset receipt are bound to one explicit namespace. A mock-profile
+string by itself cannot start a session.
+
+Wire bodies use strict uncompressed `application/json`, with a 1 MiB request
+limit, a 4 MiB response limit, and bounded JSON depth/node counts. Cleartext
+HTTP clients are restricted to loopback; non-loopback control URLs require
+HTTPS. A missing authority generation is represented as unknown and poisons an
+active session rather than being rewritten to generation zero.
+Sessions default to a five-minute lease; callers with a shorter authoritative
+lease window must finish reset and release before that lease expires.
 
 The HTTP adapter is state-neutral. Its `SyntheticControlAuthority` is
 implemented by the production owner of the relevant manifest, lease,

--- a/packages/cloud/test-mocks/README.md
+++ b/packages/cloud/test-mocks/README.md
@@ -2,6 +2,33 @@
 
 Stateful, in-process mocks of third-party cloud APIs used by Eliza Cloud. Designed for use in unit / integration tests and local development without hitting real provider APIs.
 
+## Shared subprocess control protocol
+
+`@elizaos/shared/synthetic-control` is the versioned authenticated
+HTTP contract used to seed, reset, advance time, install faults, inspect
+snapshots/ledgers, and tear down independently running mock processes. The
+scenario runner and Cloud E2E helpers both use `SyntheticControlClient` and
+`SyntheticControlSession`; callers must provide an explicit v1 manifest plus a
+control URL and token. A mock-profile string by itself cannot start a session.
+
+The HTTP adapter is state-neutral. Its `SyntheticControlAuthority` is
+implemented by the production owner of the relevant manifest, lease,
+generation, reset receipt, fault, and ledger state. The protocol must not grow
+an in-process fallback or a competing world store. The control-plane mock can
+mount an authority through `startControlPlaneMock({ syntheticControl: ... })`,
+which keeps normal Cloud routes and control commands in the same OS process.
+The concrete production-repository manifest/reset contract, durable
+cross-process lease/generation owner, and canonical fault/ledger/readback owner
+remain #24075, #24076, and #24077 respectively. Until those authorities are
+wired, a subprocess restart starts a fresh fixture generation and is not a
+durable shared-world recovery claim.
+
+If seeding fails after the authority advances its generation but before it
+returns a reset receipt, `SyntheticControlSession.open()` throws
+`SyntheticControlDirtySessionError` and deliberately leaves the lease held for
+authoritative recovery or expiry. It never releases a potentially dirty world
+using the pre-seed generation.
+
 ## Managed provider contract harness
 
 `@elizaos/cloud-test-mocks/provider-contract` provides a reusable real-HTTP

--- a/packages/cloud/test-mocks/src/control-plane/index.ts
+++ b/packages/cloud/test-mocks/src/control-plane/index.ts
@@ -25,6 +25,7 @@ export interface StartControlPlaneMockOptions
   tickMs?: number;
   /** Optional authenticated control transport; state remains owned by the supplied authority. */
   syntheticControl?: {
+    namespace: string;
     token: string;
     authority: SyntheticControlAuthority;
   };
@@ -88,7 +89,7 @@ export async function startControlPlaneMock(
   if (tickMs > 0) {
     interval = setInterval(() => {
       tick().catch(() => {
-        /* swallowed; surfaced via job state */
+        // error-policy:J5 The same rejection is surfaced through the persisted job state.
       });
     }, tickMs);
   }

--- a/packages/cloud/test-mocks/src/control-plane/index.ts
+++ b/packages/cloud/test-mocks/src/control-plane/index.ts
@@ -1,4 +1,9 @@
 /** Public entry that starts the container control-plane mock server and re-exports its app and store builders. */
+
+import {
+  createSyntheticControlHandler,
+  type SyntheticControlAuthority,
+} from "@elizaos/shared/synthetic-control";
 import { startFetchServer } from "../fetch-server";
 import { buildControlPlaneApp, type ControlPlaneMockOptions } from "./server";
 import type { ControlPlaneStore } from "./store";
@@ -18,6 +23,11 @@ export interface StartControlPlaneMockOptions
   hetznerUrl?: string;
   /** Background tick interval. 0 disables auto-tick (test mode). */
   tickMs?: number;
+  /** Optional authenticated control transport; state remains owned by the supplied authority. */
+  syntheticControl?: {
+    token: string;
+    authority: SyntheticControlAuthority;
+  };
 }
 
 export interface RunningControlPlaneMock {
@@ -48,16 +58,26 @@ export async function startControlPlaneMock(
     process.env.HCLOUD_API_BASE_URL ??
     "https://api.hetzner.cloud/v1";
 
+  const { syntheticControl, ...controlPlaneOptions } = options;
   const { app, store, tick, processDbBackedJobs, cleanupStuck } =
     buildControlPlaneApp({
-      ...options,
+      ...controlPlaneOptions,
       hetznerUrl,
     });
 
-  const server = await startFetchServer(app.fetch, {
-    port: options.port ?? 0,
-    hostname: options.hostname ?? "127.0.0.1",
-  });
+  const controlHandler = syntheticControl
+    ? createSyntheticControlHandler(syntheticControl)
+    : null;
+  const server = await startFetchServer(
+    async (request) => {
+      const controlResponse = await controlHandler?.(request);
+      return controlResponse ?? app.fetch(request);
+    },
+    {
+      port: options.port ?? 0,
+      hostname: options.hostname ?? "127.0.0.1",
+    },
+  );
   const port = server.port;
   if (typeof port !== "number") {
     throw new Error("Control plane mock server did not bind to a numeric port");

--- a/packages/cloud/test-mocks/test/fixtures/synthetic-control-authority.ts
+++ b/packages/cloud/test-mocks/test/fixtures/synthetic-control-authority.ts
@@ -14,6 +14,8 @@ import { startControlPlaneMock } from "../../src/control-plane/index.js";
 
 const token = process.env.SYNTHETIC_CONTROL_TOKEN;
 if (!token) throw new Error("SYNTHETIC_CONTROL_TOKEN is required");
+const namespace = process.env.SYNTHETIC_CONTROL_NAMESPACE;
+if (!namespace) throw new Error("SYNTHETIC_CONTROL_NAMESPACE is required");
 
 class FixtureAuthority implements SyntheticControlAuthority {
   private currentGeneration = 0;
@@ -204,15 +206,19 @@ class FixtureAuthority implements SyntheticControlAuthority {
     if (!fault) return;
     fault.count -= 1;
     await new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(resolve, fault.delayMs ?? 100);
-      signal.addEventListener(
-        "abort",
-        () => {
-          clearTimeout(timer);
-          reject(signal.reason);
-        },
-        { once: true },
-      );
+      if (signal.aborted) {
+        reject(signal.reason);
+        return;
+      }
+      const onAbort = () => {
+        clearTimeout(timer);
+        reject(signal.reason);
+      };
+      const timer = setTimeout(() => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, fault.delayMs ?? 100);
+      signal.addEventListener("abort", onAbort, { once: true });
     });
   }
 
@@ -231,7 +237,7 @@ const running = await startControlPlaneMock({
   port: 0,
   tickMs: 0,
   hetznerUrl: "http://127.0.0.1:1/v1",
-  syntheticControl: { token, authority },
+  syntheticControl: { namespace, token, authority },
 });
 authority.onTeardown = () => {
   void running.stop().finally(() => process.exit(0));

--- a/packages/cloud/test-mocks/test/fixtures/synthetic-control-authority.ts
+++ b/packages/cloud/test-mocks/test/fixtures/synthetic-control-authority.ts
@@ -1,0 +1,246 @@
+/** Boots the real control-plane mock subprocess with a deterministic test-only synthetic-state authority. */
+
+import {
+  type JsonValue,
+  type SyntheticControlAuthority,
+  type SyntheticControlCommand,
+  type SyntheticControlExecutionContext,
+  SyntheticControlProtocolError,
+  type SyntheticFault,
+  type SyntheticManifest,
+  type SyntheticResetReceipt,
+} from "@elizaos/shared/synthetic-control";
+import { startControlPlaneMock } from "../../src/control-plane/index.js";
+
+const token = process.env.SYNTHETIC_CONTROL_TOKEN;
+if (!token) throw new Error("SYNTHETIC_CONTROL_TOKEN is required");
+
+class FixtureAuthority implements SyntheticControlAuthority {
+  private currentGeneration = 0;
+  private lease: { id: string; owner: string; expiresAt: number } | null = null;
+  private manifest: SyntheticManifest | null = null;
+  private faults: SyntheticFault[] = [];
+  private logicalTimeMs = 0;
+  private sequence = 0;
+  private readonly entries: JsonValue[] = [];
+  onTeardown: (() => void) | null = null;
+
+  generation(): number {
+    return this.currentGeneration;
+  }
+
+  async execute(
+    command: SyntheticControlCommand,
+    context: SyntheticControlExecutionContext,
+  ): Promise<JsonValue> {
+    if (command.type === "health") {
+      return {
+        status: "ready",
+        pid: process.pid,
+        capabilities: [
+          "lease",
+          "seed",
+          "reset",
+          "time",
+          "fault",
+          "snapshot",
+          "ledger",
+          "teardown",
+        ],
+      };
+    }
+    this.assertGeneration(context.expectedGeneration);
+    if (command.type === "lease.acquire") {
+      const now = Date.now();
+      if (this.lease && this.lease.expiresAt > now) {
+        throw new SyntheticControlProtocolError({
+          code: "LEASE_CONFLICT",
+          message: `lease is held by ${this.lease.owner}`,
+          retryable: true,
+        });
+      }
+      this.lease = {
+        id: `lease-${process.pid}-${++this.sequence}`,
+        owner: command.owner,
+        expiresAt: now + command.ttlMs,
+      };
+      this.currentGeneration += 1;
+      this.append("lease.acquire", { owner: command.owner });
+      return { leaseId: this.lease.id, expiresAt: this.lease.expiresAt };
+    }
+    this.assertLease(context.leaseId);
+    if (command.type === "lease.release") {
+      if (command.leaseId !== this.lease?.id) this.leaseFailure();
+      this.lease = null;
+      this.currentGeneration += 1;
+      this.append("lease.release", {});
+      return { released: true };
+    }
+
+    const startGeneration = this.currentGeneration;
+    await this.applyDelayFault(command.type, context.signal);
+    this.assertGeneration(startGeneration);
+
+    switch (command.type) {
+      case "seed": {
+        this.manifest = structuredClone(command.manifest);
+        this.currentGeneration += 1;
+        const receipt: SyntheticResetReceipt = {
+          version: 1,
+          namespace: command.manifest.namespace,
+          manifestId: command.manifest.manifestId,
+          generation: this.currentGeneration,
+          receipt: { authority: "fixture", pid: process.pid },
+        };
+        this.append("seed", { manifestId: command.manifest.manifestId });
+        return { receipt } as unknown as JsonValue;
+      }
+      case "reset":
+        this.assertReceipt(command.receipt);
+        this.manifest = null;
+        this.faults = [];
+        this.logicalTimeMs = 0;
+        this.currentGeneration += 1;
+        this.append("reset", { manifestId: command.receipt.manifestId });
+        return { reset: true };
+      case "time.advance":
+        this.logicalTimeMs += command.milliseconds;
+        this.currentGeneration += 1;
+        this.append("time.advance", { milliseconds: command.milliseconds });
+        return { logicalTimeMs: this.logicalTimeMs };
+      case "fault.install":
+        this.faults.push(structuredClone(command.fault));
+        this.currentGeneration += 1;
+        this.append("fault.install", { faultId: command.fault.id });
+        return { installed: command.fault.id };
+      case "fault.clear":
+        this.faults = command.scope
+          ? this.faults.filter((fault) => fault.scope !== command.scope)
+          : [];
+        this.currentGeneration += 1;
+        this.append("fault.clear", { scope: command.scope ?? null });
+        return { cleared: true };
+      case "snapshot":
+        return {
+          generation: this.currentGeneration,
+          manifest: this.manifest,
+          logicalTimeMs: this.logicalTimeMs,
+          faultIds: this.faults.map((fault) => fault.id),
+        } as unknown as JsonValue;
+      case "ledger.query": {
+        const after = command.afterSequence ?? 0;
+        const limit = command.limit ?? 100;
+        return {
+          entries: this.entries.slice(after, after + limit),
+          nextSequence: Math.min(this.entries.length, after + limit),
+        };
+      }
+      case "teardown":
+        this.lease = null;
+        this.currentGeneration += 1;
+        this.append("teardown", { reason: command.reason });
+        setTimeout(() => this.onTeardown?.(), 10);
+        return { accepted: true, leaseReleased: true };
+      default:
+        throw new SyntheticControlProtocolError({
+          code: "UNSUPPORTED_COMMAND",
+          message: "fixture received an unsupported command",
+        });
+    }
+  }
+
+  private assertGeneration(expected: number | undefined): void {
+    if (expected !== this.currentGeneration) {
+      throw new SyntheticControlProtocolError({
+        code: "STALE_GENERATION",
+        message: `expected generation ${String(expected)}, current ${this.currentGeneration}`,
+        retryable: true,
+      });
+    }
+  }
+
+  private assertLease(leaseId: string | undefined): void {
+    if (
+      !this.lease ||
+      this.lease.expiresAt <= Date.now() ||
+      leaseId !== this.lease.id
+    ) {
+      this.leaseFailure();
+    }
+  }
+
+  private leaseFailure(): never {
+    throw new SyntheticControlProtocolError({
+      code: "LEASE_REQUIRED",
+      message: "the active lease is required",
+      retryable: true,
+    });
+  }
+
+  private assertReceipt(receipt: SyntheticResetReceipt): void {
+    if (
+      !this.manifest ||
+      receipt.namespace !== this.manifest.namespace ||
+      receipt.manifestId !== this.manifest.manifestId
+    ) {
+      throw new SyntheticControlProtocolError({
+        code: "COMMAND_FAILED",
+        message: "reset receipt does not match active manifest",
+      });
+    }
+  }
+
+  private async applyDelayFault(
+    operation: string,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const fault = this.faults.find(
+      (candidate) =>
+        candidate.mode === "delay" &&
+        candidate.scope === "control" &&
+        candidate.operation === operation &&
+        candidate.count > 0,
+    );
+    if (!fault) return;
+    fault.count -= 1;
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(resolve, fault.delayMs ?? 100);
+      signal.addEventListener(
+        "abort",
+        () => {
+          clearTimeout(timer);
+          reject(signal.reason);
+        },
+        { once: true },
+      );
+    });
+  }
+
+  private append(operation: string, data: JsonValue): void {
+    this.entries.push({
+      sequence: this.entries.length + 1,
+      generation: this.currentGeneration,
+      operation,
+      data,
+    });
+  }
+}
+
+const authority = new FixtureAuthority();
+const running = await startControlPlaneMock({
+  port: 0,
+  tickMs: 0,
+  hetznerUrl: "http://127.0.0.1:1/v1",
+  syntheticControl: { token, authority },
+});
+authority.onTeardown = () => {
+  void running.stop().finally(() => process.exit(0));
+};
+
+process.stdout.write(
+  `${JSON.stringify({ type: "ready", url: running.url, pid: process.pid })}\n`,
+);
+
+const stop = () => void running.stop().finally(() => process.exit(0));
+process.on("SIGINT", stop);
+process.on("SIGTERM", stop);

--- a/packages/cloud/test-mocks/test/synthetic-control.subprocess.test.ts
+++ b/packages/cloud/test-mocks/test/synthetic-control.subprocess.test.ts
@@ -1,9 +1,12 @@
 /** Proves the shared control client against a real control-plane mock in an independent OS process. */
 
 import { afterEach, describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
 import {
   createSyntheticControlHandler,
   type JsonValue,
+  SYNTHETIC_CONTROL_MAX_REQUEST_BYTES,
+  SYNTHETIC_CONTROL_MAX_RESPONSE_BYTES,
   SyntheticControlClient,
   SyntheticControlDirtySessionError,
   SyntheticControlProtocolError,
@@ -14,7 +17,7 @@ import {
 const TOKEN = "synthetic-control-test-token-0001";
 const children: Array<ReturnType<typeof Bun.spawn>> = [];
 
-async function startAuthority(): Promise<{
+async function startAuthority(namespace: string): Promise<{
   child: ReturnType<typeof Bun.spawn>;
   client: SyntheticControlClient;
   url: string;
@@ -24,11 +27,15 @@ async function startAuthority(): Promise<{
     [
       process.execPath,
       "--conditions=eliza-source",
-      "test/fixtures/synthetic-control-authority.ts",
+      resolve(import.meta.dir, "fixtures/synthetic-control-authority.ts"),
     ],
     {
-      cwd: import.meta.dir.replace(/\/test$/, ""),
-      env: { ...process.env, SYNTHETIC_CONTROL_TOKEN: TOKEN },
+      cwd: resolve(import.meta.dir, ".."),
+      env: {
+        ...process.env,
+        SYNTHETIC_CONTROL_NAMESPACE: namespace,
+        SYNTHETIC_CONTROL_TOKEN: TOKEN,
+      },
       stdout: "pipe",
       stderr: "pipe",
     },
@@ -44,6 +51,10 @@ async function startAuthority(): Promise<{
       throw new Error(`authority exited before ready: ${stderr}`);
     }
     buffered += decoder.decode(chunk.value, { stream: true });
+    if (buffered.length > 4_096) {
+      child.kill("SIGKILL");
+      throw new Error("authority ready record exceeded 4096 characters");
+    }
   }
   reader.releaseLock();
   const ready = JSON.parse(buffered.slice(0, buffered.indexOf("\n"))) as {
@@ -55,7 +66,11 @@ async function startAuthority(): Promise<{
     throw new Error("authority emitted invalid ready record");
   return {
     child,
-    client: new SyntheticControlClient({ baseUrl: ready.url, token: TOKEN }),
+    client: new SyntheticControlClient({
+      baseUrl: ready.url,
+      namespace,
+      token: TOKEN,
+    }),
     url: ready.url,
     pid: ready.pid,
   };
@@ -67,6 +82,7 @@ async function rejectionCode(
   try {
     await promise;
   } catch (error) {
+    // error-policy:J1 The test helper translates only the expected protocol rejection shape.
     if (error instanceof SyntheticControlProtocolError) return error.code;
     throw error;
   }
@@ -88,13 +104,23 @@ describe("synthetic control subprocess protocol", () => {
       () =>
         new SyntheticControlClient({
           baseUrl: "http://127.0.0.1:1",
+          namespace: "boundary-test",
           token: TOKEN,
           timeoutMs: 0,
         }),
     ).toThrow("between 1 and 300000");
+    expect(
+      () =>
+        new SyntheticControlClient({
+          baseUrl: "http://example.com",
+          namespace: "boundary-test",
+          token: TOKEN,
+        }),
+    ).toThrow("loopback host");
 
     const secret = "provider_api_key=do-not-return-this";
     const handler = createSyntheticControlHandler({
+      namespace: "boundary-test",
       token: TOKEN,
       authority: {
         generation: () => 7,
@@ -112,6 +138,7 @@ describe("synthetic control subprocess protocol", () => {
         },
         body: JSON.stringify({
           version: 1,
+          namespace: "boundary-test",
           commandId: "secret-failure",
           command: { type: "health" },
         }),
@@ -129,6 +156,7 @@ describe("synthetic control subprocess protocol", () => {
     });
 
     const generationFailure = createSyntheticControlHandler({
+      namespace: "boundary-test",
       token: TOKEN,
       authority: {
         generation: () => {
@@ -146,13 +174,20 @@ describe("synthetic control subprocess protocol", () => {
         },
         body: JSON.stringify({
           version: 1,
+          namespace: "boundary-test",
           commandId: "generation-failure",
           command: { type: "health" },
         }),
       }),
     );
     expect(failedHealth?.status).toBe(503);
-    expect(await failedHealth?.text()).not.toContain(secret);
+    const failedHealthText = await failedHealth?.text();
+    expect(failedHealthText).not.toContain(secret);
+    expect(JSON.parse(failedHealthText ?? "{}")).toMatchObject({
+      ok: false,
+      generation: null,
+      error: { code: "COMMAND_FAILED" },
+    });
 
     const invalidRequest = await handler(
       new Request("http://127.0.0.1/__eliza/synthetic-control/v1", {
@@ -163,6 +198,7 @@ describe("synthetic control subprocess protocol", () => {
         },
         body: JSON.stringify({
           version: 1,
+          namespace: "boundary-test",
           commandId: "invalid-secret-command",
           command: { type: secret },
         }),
@@ -180,10 +216,226 @@ describe("synthetic control subprocess protocol", () => {
     });
   });
 
+  test("binds one bearer token to one namespace before authority execution", async () => {
+    let executions = 0;
+    const handler = createSyntheticControlHandler({
+      namespace: "namespace-a",
+      token: TOKEN,
+      authority: {
+        generation: () => 0,
+        execute: async () => {
+          executions += 1;
+          return { status: "ready" };
+        },
+      },
+    });
+    const wrongNamespace = new SyntheticControlClient({
+      baseUrl: "http://127.0.0.1",
+      namespace: "namespace-b",
+      token: TOKEN,
+      fetch: async (input, init) => {
+        const response = await handler(new Request(input, init));
+        if (!response) throw new Error("control handler declined request");
+        return response;
+      },
+    });
+    expect(
+      await rejectionCode(wrongNamespace.command({ type: "health" })),
+    ).toBe("COMMAND_FAILED");
+
+    const mismatchedManifest = await handler(
+      new Request("http://127.0.0.1/__eliza/synthetic-control/v1", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "content-type": "application/json; charset=utf-8",
+        },
+        body: JSON.stringify({
+          version: 1,
+          namespace: "namespace-a",
+          commandId: "wrong-manifest-namespace",
+          command: {
+            type: "seed",
+            manifest: {
+              version: 1,
+              namespace: "namespace-b",
+              manifestId: "wrong-namespace",
+              domains: {},
+            },
+          },
+        }),
+      }),
+    );
+    expect(mismatchedManifest?.status).toBe(401);
+    expect(executions).toBe(0);
+  });
+
+  test("bounds decoded request and response bodies and rejects lossy/deep JSON", async () => {
+    let executions = 0;
+    const handler = createSyntheticControlHandler({
+      namespace: "bounded-json",
+      token: TOKEN,
+      authority: {
+        generation: () => 0,
+        execute: async () => {
+          executions += 1;
+          return { status: "ready" };
+        },
+      },
+    });
+    const oversized = await handler(
+      new Request("http://127.0.0.1/__eliza/synthetic-control/v1", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: `"${"x".repeat(SYNTHETIC_CONTROL_MAX_REQUEST_BYTES)}"`,
+      }),
+    );
+    expect(oversized?.status).toBe(400);
+    expect(executions).toBe(0);
+
+    const encoded = await handler(
+      new Request("http://127.0.0.1/__eliza/synthetic-control/v1", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "content-encoding": "gzip",
+          "content-type": "application/json",
+        },
+        body: "not-actually-gzip",
+      }),
+    );
+    expect(encoded?.status).toBe(400);
+    expect(executions).toBe(0);
+
+    const responseClient = new SyntheticControlClient({
+      baseUrl: "http://127.0.0.1",
+      namespace: "bounded-json",
+      token: TOKEN,
+      fetch: async () =>
+        new Response(`"${"x".repeat(SYNTHETIC_CONTROL_MAX_RESPONSE_BYTES)}"`, {
+          headers: { "content-type": "application/json" },
+        }),
+    });
+    expect(
+      await rejectionCode(responseClient.command({ type: "health" })),
+    ).toBe("COMMAND_FAILED");
+
+    const mismatchedResponseClient = new SyntheticControlClient({
+      baseUrl: "http://127.0.0.1",
+      namespace: "bounded-json",
+      token: TOKEN,
+      fetch: async () =>
+        Response.json({
+          version: 1,
+          namespace: "bounded-json",
+          commandId: "different-command",
+          ok: true,
+          generation: 99,
+          data: {},
+        }),
+    });
+    await expect(
+      mismatchedResponseClient.command(
+        { type: "health" },
+        { commandId: "expected-command" },
+      ),
+    ).rejects.toMatchObject({
+      code: "COMMAND_FAILED",
+      generation: undefined,
+    });
+
+    const oversizedAuthority = createSyntheticControlHandler({
+      namespace: "bounded-json",
+      token: TOKEN,
+      authority: {
+        generation: () => 0,
+        execute: async () => ({
+          payload: "x".repeat(SYNTHETIC_CONTROL_MAX_RESPONSE_BYTES),
+        }),
+      },
+    });
+    const boundedServerResponse = await oversizedAuthority(
+      new Request("http://127.0.0.1/__eliza/synthetic-control/v1", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          version: 1,
+          namespace: "bounded-json",
+          commandId: "oversized-authority-response",
+          command: { type: "health" },
+        }),
+      }),
+    );
+    expect(await boundedServerResponse?.json()).toMatchObject({
+      ok: false,
+      generation: 0,
+      error: { code: "COMMAND_FAILED" },
+    });
+
+    let nested: unknown = {};
+    for (let index = 0; index < 70; index += 1) nested = { nested };
+    let fetchCalls = 0;
+    const preflightClient = new SyntheticControlClient({
+      baseUrl: "http://127.0.0.1",
+      namespace: "bounded-json",
+      token: TOKEN,
+      fetch: async () => {
+        fetchCalls += 1;
+        throw new Error("invalid JSON must not be sent");
+      },
+    });
+    await expect(
+      preflightClient.command({
+        type: "seed",
+        manifest: {
+          version: 1,
+          namespace: "bounded-json",
+          manifestId: "too-deep",
+          domains: nested as never,
+        },
+      }),
+    ).rejects.toThrow("depth limit");
+    await expect(
+      preflightClient.command({
+        type: "seed",
+        manifest: {
+          version: 1,
+          namespace: "bounded-json",
+          manifestId: "negative-zero",
+          domains: { value: -0 },
+        },
+      }),
+    ).rejects.toThrow("negative zero");
+    await expect(
+      preflightClient.command({
+        type: "seed",
+        manifest: {
+          version: 1,
+          namespace: "bounded-json",
+          manifestId: "too-large",
+          domains: {
+            payload: "x".repeat(SYNTHETIC_CONTROL_MAX_REQUEST_BYTES),
+          },
+        },
+      }),
+    ).rejects.toThrow("request exceeds");
+    await expect(
+      preflightClient.command({ type: "health" }, { expectedGeneration: -0 }),
+    ).rejects.toThrow("expectedGeneration must be an integer");
+    expect(fetchCalls).toBe(0);
+  });
+
   test("marks post-mutation seed failures dirty instead of fabricating cleanup", async () => {
     let generation = 0;
     let leaseHeld = false;
     const handler = createSyntheticControlHandler({
+      namespace: "partial-seed",
       token: TOKEN,
       authority: {
         generation: () => generation,
@@ -209,6 +461,7 @@ describe("synthetic control subprocess protocol", () => {
     });
     const client = new SyntheticControlClient({
       baseUrl: "http://127.0.0.1",
+      namespace: "partial-seed",
       token: TOKEN,
       fetch: async (input, init) => {
         const response = await handler(new Request(input, init));
@@ -228,6 +481,7 @@ describe("synthetic control subprocess protocol", () => {
         },
       });
     } catch (error) {
+      // error-policy:J1 The test captures the expected dirty-session boundary for assertions.
       if (error instanceof SyntheticControlDirtySessionError) dirty = error;
       else throw error;
     }
@@ -242,6 +496,7 @@ describe("synthetic control subprocess protocol", () => {
     let fetchCalls = 0;
     const client = new SyntheticControlClient({
       baseUrl: "http://127.0.0.1:1",
+      namespace: "invalid",
       token: TOKEN,
       fetch: async () => {
         fetchCalls += 1;
@@ -259,6 +514,7 @@ describe("synthetic control subprocess protocol", () => {
         } as never,
       }),
     ).catch((error) => {
+      // error-policy:J1 The test translates the expected local validation error for a single assertion.
       expect(String(error)).toContain("JSON-only");
       return "INVALID_REQUEST" as const;
     });
@@ -267,7 +523,7 @@ describe("synthetic control subprocess protocol", () => {
   });
 
   test("runs the shared scenario and Cloud manifest session with reset-bound teardown", async () => {
-    const { child, client } = await startAuthority();
+    const { child, client } = await startAuthority("shared-session");
     const session = await SyntheticControlSession.open({
       client,
       owner: "shared-harness",
@@ -285,8 +541,118 @@ describe("synthetic control subprocess protocol", () => {
     expect(await child.exited).toBe(0);
   });
 
+  test("serializes concurrent session commands and close behind accepted work", async () => {
+    const { child, client } = await startAuthority("serialized-session");
+    const session = await SyntheticControlSession.open({
+      client,
+      manifest: {
+        version: 1,
+        namespace: "serialized-session",
+        manifestId: "serialized-session",
+        domains: {},
+      },
+    });
+    const first = session.execute({ type: "time.advance", milliseconds: 1 });
+    const second = session.execute({ type: "time.advance", milliseconds: 2 });
+    const closing = session.close({ teardown: true, reason: "serialized" });
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { logicalTimeMs: 1 },
+      { logicalTimeMs: 3 },
+    ]);
+    await closing;
+    expect(await child.exited).toBe(0);
+    await expect(session.execute({ type: "snapshot" })).rejects.toThrow(
+      "closed",
+    );
+  });
+
+  test("poisons a session after a post-mutation timeout and skips unsafe cleanup", async () => {
+    let generation = 0;
+    let resets = 0;
+    let releases = 0;
+    const leaseId = "ambiguous-timeout-lease";
+    const handler = createSyntheticControlHandler({
+      namespace: "ambiguous-timeout",
+      token: TOKEN,
+      authority: {
+        generation: () => generation,
+        execute: async (command): Promise<JsonValue> => {
+          if (command.type === "health") return { status: "ready" };
+          if (command.type === "lease.acquire") {
+            generation += 1;
+            return { leaseId };
+          }
+          if (command.type === "seed") {
+            generation += 1;
+            return {
+              receipt: {
+                version: 1,
+                namespace: command.manifest.namespace,
+                manifestId: command.manifest.manifestId,
+                generation,
+                receipt: {},
+              },
+            };
+          }
+          if (command.type === "time.advance") {
+            generation += 1;
+            await Bun.sleep(50);
+            return { logicalTimeMs: command.milliseconds };
+          }
+          if (command.type === "reset") resets += 1;
+          if (command.type === "lease.release") releases += 1;
+          return {};
+        },
+      },
+    });
+    const client = new SyntheticControlClient({
+      baseUrl: "http://127.0.0.1",
+      namespace: "ambiguous-timeout",
+      token: TOKEN,
+      timeoutMs: 10,
+      fetch: async (input, init) => {
+        const signal = init?.signal;
+        const response = handler(new Request(input, init)).then((value) => {
+          if (!value) throw new Error("control handler declined request");
+          return value;
+        });
+        if (!signal) return response;
+        return Promise.race([
+          response,
+          new Promise<Response>((_, reject) => {
+            signal.addEventListener("abort", () => reject(signal.reason), {
+              once: true,
+            });
+          }),
+        ]);
+      },
+    });
+    const session = await SyntheticControlSession.open({
+      client,
+      manifest: {
+        version: 1,
+        namespace: "ambiguous-timeout",
+        manifestId: "ambiguous-timeout",
+        domains: {},
+      },
+    });
+    await expect(
+      session.execute({ type: "time.advance", milliseconds: 1 }),
+    ).rejects.toBeInstanceOf(SyntheticControlDirtySessionError);
+    await expect(session.execute({ type: "snapshot" })).rejects.toBeInstanceOf(
+      SyntheticControlDirtySessionError,
+    );
+    await expect(session.close()).rejects.toBeInstanceOf(
+      SyntheticControlDirtySessionError,
+    );
+    await Bun.sleep(60);
+    expect(generation).toBe(3);
+    expect(resets).toBe(0);
+    expect(releases).toBe(0);
+  });
+
   test("shares one manifest lifecycle with the real control-plane mock HTTP process", async () => {
-    const { child, client, url, pid } = await startAuthority();
+    const { child, client, url, pid } = await startAuthority("scenario-24078");
 
     const productionHealth = await fetch(`${url}/health`);
     expect(productionHealth.status).toBe(200);
@@ -378,7 +744,7 @@ describe("synthetic control subprocess protocol", () => {
   });
 
   test("fences concurrent commands and reset during an awaited operation", async () => {
-    const { client } = await startAuthority();
+    const { client } = await startAuthority("concurrency");
     const health = await client.command({ type: "health" });
     const lease = await client.command(
       { type: "lease.acquire", owner: "cloud-e2e", ttlMs: 60_000 },
@@ -440,11 +806,19 @@ describe("synthetic control subprocess protocol", () => {
     const concurrent = await Promise.allSettled([
       client.command(
         { type: "time.advance", milliseconds: 1 },
-        { expectedGeneration: reseeded.generation, leaseId },
+        {
+          commandId: "duplicate-generation-fenced-command",
+          expectedGeneration: reseeded.generation,
+          leaseId,
+        },
       ),
       client.command(
         { type: "time.advance", milliseconds: 2 },
-        { expectedGeneration: reseeded.generation, leaseId },
+        {
+          commandId: "duplicate-generation-fenced-command",
+          expectedGeneration: reseeded.generation,
+          leaseId,
+        },
       ),
     ]);
     expect(
@@ -457,12 +831,13 @@ describe("synthetic control subprocess protocol", () => {
   });
 
   test("reports auth, crash, restart, and stale-generation failures without fabricated success", async () => {
-    const first = await startAuthority();
+    const first = await startAuthority("crash-test");
     const unauthorized = await fetch(first.client.endpoint, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         version: 1,
+        namespace: "crash-test",
         commandId: "auth",
         command: { type: "health" },
       }),
@@ -484,7 +859,7 @@ describe("synthetic control subprocess protocol", () => {
       "COMMAND_FAILED",
     );
 
-    const restarted = await startAuthority();
+    const restarted = await startAuthority("crash-test");
     const restartedHealth = await restarted.client.command({ type: "health" });
     expect(restartedHealth.generation).toBe(0);
     expect(

--- a/packages/cloud/test-mocks/test/synthetic-control.subprocess.test.ts
+++ b/packages/cloud/test-mocks/test/synthetic-control.subprocess.test.ts
@@ -1,0 +1,502 @@
+/** Proves the shared control client against a real control-plane mock in an independent OS process. */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  createSyntheticControlHandler,
+  type JsonValue,
+  SyntheticControlClient,
+  SyntheticControlDirtySessionError,
+  SyntheticControlProtocolError,
+  SyntheticControlSession,
+  type SyntheticResetReceipt,
+} from "@elizaos/shared/synthetic-control";
+
+const TOKEN = "synthetic-control-test-token-0001";
+const children: Array<ReturnType<typeof Bun.spawn>> = [];
+
+async function startAuthority(): Promise<{
+  child: ReturnType<typeof Bun.spawn>;
+  client: SyntheticControlClient;
+  url: string;
+  pid: number;
+}> {
+  const child = Bun.spawn(
+    [
+      process.execPath,
+      "--conditions=eliza-source",
+      "test/fixtures/synthetic-control-authority.ts",
+    ],
+    {
+      cwd: import.meta.dir.replace(/\/test$/, ""),
+      env: { ...process.env, SYNTHETIC_CONTROL_TOKEN: TOKEN },
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  children.push(child);
+  const reader = child.stdout.getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  while (!buffered.includes("\n")) {
+    const chunk = await reader.read();
+    if (chunk.done) {
+      const stderr = await new Response(child.stderr).text();
+      throw new Error(`authority exited before ready: ${stderr}`);
+    }
+    buffered += decoder.decode(chunk.value, { stream: true });
+  }
+  reader.releaseLock();
+  const ready = JSON.parse(buffered.slice(0, buffered.indexOf("\n"))) as {
+    type: string;
+    url: string;
+    pid: number;
+  };
+  if (ready.type !== "ready")
+    throw new Error("authority emitted invalid ready record");
+  return {
+    child,
+    client: new SyntheticControlClient({ baseUrl: ready.url, token: TOKEN }),
+    url: ready.url,
+    pid: ready.pid,
+  };
+}
+
+async function rejectionCode(
+  promise: Promise<unknown>,
+): Promise<SyntheticControlProtocolError["code"]> {
+  try {
+    await promise;
+  } catch (error) {
+    if (error instanceof SyntheticControlProtocolError) return error.code;
+    throw error;
+  }
+  throw new Error("expected synthetic control command to reject");
+}
+
+afterEach(async () => {
+  await Promise.all(
+    children.splice(0).map(async (child) => {
+      if (child.exitCode === null) child.kill("SIGTERM");
+      await child.exited;
+    }),
+  );
+});
+
+describe("synthetic control subprocess protocol", () => {
+  test("bounds client timeouts and redacts authority failures on the HTTP boundary", async () => {
+    expect(
+      () =>
+        new SyntheticControlClient({
+          baseUrl: "http://127.0.0.1:1",
+          token: TOKEN,
+          timeoutMs: 0,
+        }),
+    ).toThrow("between 1 and 300000");
+
+    const secret = "provider_api_key=do-not-return-this";
+    const handler = createSyntheticControlHandler({
+      token: TOKEN,
+      authority: {
+        generation: () => 7,
+        execute: async () => {
+          throw new Error(secret);
+        },
+      },
+    });
+    const response = await handler(
+      new Request("http://127.0.0.1/__eliza/synthetic-control/v1", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          version: 1,
+          commandId: "secret-failure",
+          command: { type: "health" },
+        }),
+      }),
+    );
+    const body = await response?.text();
+    expect(body).not.toContain(secret);
+    expect(JSON.parse(body ?? "{}")).toMatchObject({
+      ok: false,
+      generation: 7,
+      error: {
+        code: "COMMAND_FAILED",
+        message: "control authority failed the command",
+      },
+    });
+
+    const generationFailure = createSyntheticControlHandler({
+      token: TOKEN,
+      authority: {
+        generation: () => {
+          throw new Error(secret);
+        },
+        execute: async () => ({ unreachable: true }),
+      },
+    });
+    const failedHealth = await generationFailure(
+      new Request("http://127.0.0.1/__eliza/synthetic-control/v1", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          version: 1,
+          commandId: "generation-failure",
+          command: { type: "health" },
+        }),
+      }),
+    );
+    expect(failedHealth?.status).toBe(503);
+    expect(await failedHealth?.text()).not.toContain(secret);
+
+    const invalidRequest = await handler(
+      new Request("http://127.0.0.1/__eliza/synthetic-control/v1", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          version: 1,
+          commandId: "invalid-secret-command",
+          command: { type: secret },
+        }),
+      }),
+    );
+    const invalidBody = await invalidRequest?.text();
+    expect(invalidBody).not.toContain(secret);
+    expect(JSON.parse(invalidBody ?? "{}")).toMatchObject({
+      ok: false,
+      generation: 7,
+      error: {
+        code: "INVALID_REQUEST",
+        message: "control request is invalid",
+      },
+    });
+  });
+
+  test("marks post-mutation seed failures dirty instead of fabricating cleanup", async () => {
+    let generation = 0;
+    let leaseHeld = false;
+    const handler = createSyntheticControlHandler({
+      token: TOKEN,
+      authority: {
+        generation: () => generation,
+        execute: async (command): Promise<JsonValue> => {
+          if (command.type === "health") return { status: "ready" };
+          if (command.type === "lease.acquire") {
+            leaseHeld = true;
+            generation += 1;
+            return { leaseId: "partial-seed-lease" };
+          }
+          if (command.type === "seed") {
+            generation += 1;
+            throw new Error("seed failed after its first production write");
+          }
+          if (command.type === "lease.release") {
+            leaseHeld = false;
+            generation += 1;
+            return { released: true };
+          }
+          return {};
+        },
+      },
+    });
+    const client = new SyntheticControlClient({
+      baseUrl: "http://127.0.0.1",
+      token: TOKEN,
+      fetch: async (input, init) => {
+        const response = await handler(new Request(input, init));
+        if (!response) throw new Error("control handler declined request");
+        return response;
+      },
+    });
+    let dirty: SyntheticControlDirtySessionError | null = null;
+    try {
+      await SyntheticControlSession.open({
+        client,
+        manifest: {
+          version: 1,
+          namespace: "partial-seed",
+          manifestId: "partial-seed",
+          domains: {},
+        },
+      });
+    } catch (error) {
+      if (error instanceof SyntheticControlDirtySessionError) dirty = error;
+      else throw error;
+    }
+    expect(dirty).toMatchObject({
+      leaseId: "partial-seed-lease",
+      lastKnownGeneration: 2,
+    });
+    expect(leaseHeld).toBe(true);
+  });
+
+  test("rejects lossy manifests before any subprocess request is sent", async () => {
+    let fetchCalls = 0;
+    const client = new SyntheticControlClient({
+      baseUrl: "http://127.0.0.1:1",
+      token: TOKEN,
+      fetch: async () => {
+        fetchCalls += 1;
+        throw new Error("must not send invalid manifest");
+      },
+    });
+    const code = await rejectionCode(
+      client.command({
+        type: "seed",
+        manifest: {
+          version: 1,
+          namespace: "invalid",
+          manifestId: "lossy",
+          domains: { invalid: undefined },
+        } as never,
+      }),
+    ).catch((error) => {
+      expect(String(error)).toContain("JSON-only");
+      return "INVALID_REQUEST" as const;
+    });
+    expect(code).toBe("INVALID_REQUEST");
+    expect(fetchCalls).toBe(0);
+  });
+
+  test("runs the shared scenario and Cloud manifest session with reset-bound teardown", async () => {
+    const { child, client } = await startAuthority();
+    const session = await SyntheticControlSession.open({
+      client,
+      owner: "shared-harness",
+      manifest: {
+        version: 1,
+        namespace: "shared-session",
+        manifestId: "shared-manifest",
+        domains: { notifications: [{ id: "notification-1" }] },
+      },
+    });
+    expect(await session.execute({ type: "snapshot" })).toMatchObject({
+      manifest: { manifestId: "shared-manifest" },
+    });
+    await session.close({ teardown: true, reason: "session verified" });
+    expect(await child.exited).toBe(0);
+  });
+
+  test("shares one manifest lifecycle with the real control-plane mock HTTP process", async () => {
+    const { child, client, url, pid } = await startAuthority();
+
+    const productionHealth = await fetch(`${url}/health`);
+    expect(productionHealth.status).toBe(200);
+
+    const health = await client.command({ type: "health" });
+    expect(health).toMatchObject({
+      generation: 0,
+      data: { status: "ready", pid },
+    });
+    const lease = await client.command(
+      { type: "lease.acquire", owner: "scenario-runner", ttlMs: 60_000 },
+      { expectedGeneration: health.generation },
+    );
+    const leaseId = (lease.data as { leaseId: string }).leaseId;
+    const seeded = await client.command(
+      {
+        type: "seed",
+        manifest: {
+          version: 1,
+          namespace: "scenario-24078",
+          manifestId: "manifest-1",
+          domains: {
+            messages: [{ id: "message-1", text: "synthetic hello" }],
+            schedule: [{ id: "task-1", at: "2042-01-01T00:00:00.000Z" }],
+          },
+        },
+      },
+      { expectedGeneration: lease.generation, leaseId },
+    );
+    const resetReceipt = (
+      seeded.data as unknown as { receipt: SyntheticResetReceipt }
+    ).receipt;
+    const advanced = await client.command(
+      { type: "time.advance", milliseconds: 3_600_000 },
+      { expectedGeneration: seeded.generation, leaseId },
+    );
+    const faulted = await client.command(
+      {
+        type: "fault.install",
+        fault: {
+          id: "provider-error",
+          scope: "provider",
+          mode: "error",
+          count: 1,
+          errorCode: "synthetic_failure",
+        },
+      },
+      { expectedGeneration: advanced.generation, leaseId },
+    );
+    const cleared = await client.command(
+      { type: "fault.clear", scope: "provider" },
+      { expectedGeneration: faulted.generation, leaseId },
+    );
+    const snapshot = await client.command(
+      { type: "snapshot" },
+      { expectedGeneration: cleared.generation, leaseId },
+    );
+    expect(snapshot.data).toMatchObject({
+      logicalTimeMs: 3_600_000,
+      manifest: { manifestId: "manifest-1" },
+    });
+    const ledger = await client.command(
+      { type: "ledger.query", afterSequence: 0, limit: 100 },
+      { expectedGeneration: snapshot.generation, leaseId },
+    );
+    expect(
+      (ledger.data as { entries: unknown[] }).entries.length,
+    ).toBeGreaterThanOrEqual(3);
+
+    const reset = await client.command(
+      { type: "reset", receipt: resetReceipt },
+      { expectedGeneration: ledger.generation, leaseId },
+    );
+    const released = await client.command(
+      { type: "lease.release", leaseId },
+      { expectedGeneration: reset.generation, leaseId },
+    );
+    const reacquired = await client.command(
+      { type: "lease.acquire", owner: "teardown", ttlMs: 60_000 },
+      { expectedGeneration: released.generation },
+    );
+    const teardownLeaseId = (reacquired.data as { leaseId: string }).leaseId;
+    const teardown = await client.command(
+      { type: "teardown", reason: "test complete" },
+      { expectedGeneration: reacquired.generation, leaseId: teardownLeaseId },
+    );
+    expect(teardown.data).toEqual({ accepted: true, leaseReleased: true });
+    expect(await child.exited).toBe(0);
+  });
+
+  test("fences concurrent commands and reset during an awaited operation", async () => {
+    const { client } = await startAuthority();
+    const health = await client.command({ type: "health" });
+    const lease = await client.command(
+      { type: "lease.acquire", owner: "cloud-e2e", ttlMs: 60_000 },
+      { expectedGeneration: health.generation },
+    );
+    const leaseId = (lease.data as { leaseId: string }).leaseId;
+    const seeded = await client.command(
+      {
+        type: "seed",
+        manifest: {
+          version: 1,
+          namespace: "concurrency",
+          manifestId: "manifest-concurrency",
+          domains: {},
+        },
+      },
+      { expectedGeneration: lease.generation, leaseId },
+    );
+    const receipt = (
+      seeded.data as unknown as { receipt: SyntheticResetReceipt }
+    ).receipt;
+    const faulted = await client.command(
+      {
+        type: "fault.install",
+        fault: {
+          id: "delay-snapshot",
+          scope: "control",
+          operation: "snapshot",
+          mode: "delay",
+          count: 1,
+          delayMs: 100,
+        },
+      },
+      { expectedGeneration: seeded.generation, leaseId },
+    );
+    const awaitedSnapshot = client.command(
+      { type: "snapshot" },
+      { expectedGeneration: faulted.generation, leaseId },
+    );
+    await Bun.sleep(20);
+    const reset = await client.command(
+      { type: "reset", receipt },
+      { expectedGeneration: faulted.generation, leaseId },
+    );
+    expect(await rejectionCode(awaitedSnapshot)).toBe("STALE_GENERATION");
+
+    const reseeded = await client.command(
+      {
+        type: "seed",
+        manifest: {
+          version: 1,
+          namespace: "concurrency",
+          manifestId: "manifest-concurrency-2",
+          domains: {},
+        },
+      },
+      { expectedGeneration: reset.generation, leaseId },
+    );
+    const concurrent = await Promise.allSettled([
+      client.command(
+        { type: "time.advance", milliseconds: 1 },
+        { expectedGeneration: reseeded.generation, leaseId },
+      ),
+      client.command(
+        { type: "time.advance", milliseconds: 2 },
+        { expectedGeneration: reseeded.generation, leaseId },
+      ),
+    ]);
+    expect(
+      concurrent.filter((result) => result.status === "fulfilled"),
+    ).toHaveLength(1);
+    const rejected = concurrent.find((result) => result.status === "rejected");
+    expect(rejected?.status === "rejected" && rejected.reason.code).toBe(
+      "STALE_GENERATION",
+    );
+  });
+
+  test("reports auth, crash, restart, and stale-generation failures without fabricated success", async () => {
+    const first = await startAuthority();
+    const unauthorized = await fetch(first.client.endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        version: 1,
+        commandId: "auth",
+        command: { type: "health" },
+      }),
+    });
+    expect(unauthorized.status).toBe(401);
+    expect(await unauthorized.json()).toMatchObject({
+      ok: false,
+      error: { code: "AUTH_REQUIRED" },
+    });
+
+    const health = await first.client.command({ type: "health" });
+    const lease = await first.client.command(
+      { type: "lease.acquire", owner: "crash-test", ttlMs: 60_000 },
+      { expectedGeneration: health.generation },
+    );
+    first.child.kill("SIGKILL");
+    expect(await first.child.exited).not.toBe(0);
+    expect(await rejectionCode(first.client.command({ type: "health" }))).toBe(
+      "COMMAND_FAILED",
+    );
+
+    const restarted = await startAuthority();
+    const restartedHealth = await restarted.client.command({ type: "health" });
+    expect(restartedHealth.generation).toBe(0);
+    expect(
+      await rejectionCode(
+        restarted.client.command(
+          { type: "snapshot" },
+          {
+            expectedGeneration: lease.generation,
+            leaseId: (lease.data as { leaseId: string }).leaseId,
+          },
+        ),
+      ),
+    ).toBe("STALE_GENERATION");
+  });
+});

--- a/packages/cloud/test-mocks/test/synthetic-control.subprocess.test.ts
+++ b/packages/cloud/test-mocks/test/synthetic-control.subprocess.test.ts
@@ -89,6 +89,29 @@ async function rejectionCode(
   throw new Error("expected synthetic control command to reject");
 }
 
+function exposedErrorRepresentations(error: Error): string[] {
+  const serializedCauseChain: unknown[] = [];
+  let cause: unknown = error;
+  while (cause instanceof Error) {
+    serializedCauseChain.push({
+      name: cause.name,
+      message: cause.message,
+      stack: cause.stack,
+    });
+    cause = cause.cause;
+  }
+  if (cause !== undefined) serializedCauseChain.push(cause);
+  return [
+    error.message,
+    error.stack ?? "",
+    String(error),
+    JSON.stringify(error),
+    JSON.stringify(error, Object.getOwnPropertyNames(error)),
+    JSON.stringify(serializedCauseChain),
+    Bun.inspect(error),
+  ];
+}
+
 afterEach(async () => {
   await Promise.all(
     children.splice(0).map(async (child) => {
@@ -214,6 +237,52 @@ describe("synthetic control subprocess protocol", () => {
         message: "control request is invalid",
       },
     });
+
+    const responseSecrets = [
+      "provider_api_key=malformed-response-secret-9371",
+      "authorization=Bearer malformed-response-token-4628",
+    ];
+    const malformedClient = new SyntheticControlClient({
+      baseUrl: "http://127.0.0.1",
+      namespace: "boundary-test",
+      token: TOKEN,
+      fetch: async () =>
+        new Response(
+          JSON.stringify({
+            version: 1,
+            namespace: "boundary-test",
+            commandId: "malformed-secret-response",
+            ok: true,
+            generation: 7,
+            data: {},
+            [responseSecrets[0]]: true,
+            [responseSecrets[1]]: true,
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+    });
+    let malformedError: Error | null = null;
+    try {
+      await malformedClient.command(
+        { type: "health" },
+        { commandId: "malformed-secret-response" },
+      );
+    } catch (error) {
+      // error-policy:J1 The regression captures the public client error for exhaustive redaction assertions.
+      if (error instanceof Error) malformedError = error;
+      else throw error;
+    }
+    expect(malformedError).toBeInstanceOf(SyntheticControlProtocolError);
+    expect(malformedError?.cause).toBeUndefined();
+    expect(malformedError?.message).toBe(
+      "synthetic control returned a malformed response",
+    );
+    for (const exposed of exposedErrorRepresentations(
+      malformedError as SyntheticControlProtocolError,
+    )) {
+      for (const secret of responseSecrets)
+        expect(exposed).not.toContain(secret);
+    }
   });
 
   test("binds one bearer token to one namespace before authority execution", async () => {

--- a/packages/scenario-runner/README.md
+++ b/packages/scenario-runner/README.md
@@ -173,6 +173,12 @@ const report = await runScenario(myScenario, runtime, {
 await cleanup();
 ```
 
+For subprocess-backed synthetic services, use `openScenarioSyntheticWorld`
+with an explicit control URL, bearer token, and v1 `SyntheticManifest`. It uses
+the same `SyntheticControlSession` as Cloud E2E, acquires a generation-fenced
+lease, seeds through the owning service, and retains the authority-issued reset
+receipt for teardown. The runner does not keep a parallel world-state copy.
+
 ## Notes
 
 - A simulated CLI invocation runs its scenarios in one shared runtime because PGLite cannot be recreated in-process. Provider-qualified definitions are restricted to one scenario and still require an external production controller; the ordinary executor deliberately refuses to qualify them.

--- a/packages/scenario-runner/package.json
+++ b/packages/scenario-runner/package.json
@@ -84,6 +84,7 @@
     "@elizaos/agent": "workspace:*",
     "@elizaos/core": "workspace:*",
     "@elizaos/logger": "workspace:*",
+    "@elizaos/shared": "workspace:*",
     "@elizaos/plugin-agent-skills": "workspace:*",
     "@elizaos/plugin-app-control": "workspace:*",
     "@elizaos/plugin-blocker": "workspace:*",

--- a/packages/scenario-runner/src/index.ts
+++ b/packages/scenario-runner/src/index.ts
@@ -38,6 +38,7 @@ export {
   ScenarioRequiredServicePreflightError,
   waitForScenarioRequiredServices,
 } from "./required-services.ts";
+export * from "./synthetic-control.ts";
 export type {
   AggregateReport,
   FinalCheckReport,

--- a/packages/scenario-runner/src/synthetic-control.ts
+++ b/packages/scenario-runner/src/synthetic-control.ts
@@ -33,6 +33,7 @@ export async function openScenarioSyntheticWorld(
   return SyntheticControlSession.open({
     client: new SyntheticControlClient({
       baseUrl: options.controlUrl,
+      namespace: options.manifest.namespace,
       token: options.controlToken,
       timeoutMs: options.timeoutMs,
     }),

--- a/packages/scenario-runner/src/synthetic-control.ts
+++ b/packages/scenario-runner/src/synthetic-control.ts
@@ -1,0 +1,42 @@
+/** Opens an explicitly manifested synthetic-world session through the shared subprocess control client. */
+
+export type {
+  SyntheticControlCommand,
+  SyntheticControlResponse,
+  SyntheticManifest,
+  SyntheticResetReceipt,
+} from "@elizaos/shared/synthetic-control";
+export {
+  SyntheticControlClient,
+  SyntheticControlProtocolError,
+  SyntheticControlSession,
+} from "@elizaos/shared/synthetic-control";
+
+import {
+  SyntheticControlClient,
+  SyntheticControlSession,
+  type SyntheticManifest,
+} from "@elizaos/shared/synthetic-control";
+
+export interface OpenScenarioSyntheticWorldOptions {
+  controlUrl: string;
+  controlToken: string;
+  manifest: SyntheticManifest;
+  owner?: string;
+  timeoutMs?: number;
+}
+
+/** Requires both an endpoint and a concrete manifest; a profile string alone cannot seed a run. */
+export async function openScenarioSyntheticWorld(
+  options: OpenScenarioSyntheticWorldOptions,
+): Promise<SyntheticControlSession> {
+  return SyntheticControlSession.open({
+    client: new SyntheticControlClient({
+      baseUrl: options.controlUrl,
+      token: options.controlToken,
+      timeoutMs: options.timeoutMs,
+    }),
+    manifest: options.manifest,
+    owner: options.owner ?? "scenario-runner",
+  });
+}

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -14,6 +14,7 @@ Shared cross-platform contract library for [elizaOS](https://github.com/elizaOS/
 - **Brand tokens and assets** — canonical colors, font stacks, external URLs, and static brand assets for all elizaOS surfaces
 - **Custom event constants** — typed `eliza:*` DOM event name constants used across app, bridge, and component layers
 - **Shared utilities** — error formatting, rate limiter, streaming text, trajectory format, env parsing, and more
+- **Synthetic control** — a state-neutral subprocess protocol, client, and manifested session lifecycle for scenarios and Cloud E2E
 
 ## Who uses it
 
@@ -52,6 +53,7 @@ import "@elizaos/shared/brand.css";
 | `@elizaos/shared/brand-classic.css` | Eliza Classic CSS custom properties |
 | `@elizaos/shared/character-presets` | Built-in character preset definitions |
 | `@elizaos/shared/runtime-env` | Port and security config resolvers |
+| `@elizaos/shared/synthetic-control` | Versioned mock subprocess control contract and client |
 | `@elizaos/shared/config/allowed-hosts` | Allowed-hosts config helper |
 
 ## Building
@@ -66,4 +68,3 @@ bun run --cwd packages/shared test        # run tests
 
 - The root barrel (`src/index.ts`) must remain importable in both browser and Node.js. Do not add Node.js-only or value-level React imports to it. The only React reference is a type-only `import type { ReactNode }` in `src/config/config-catalog.ts`, which is erased at compile time.
 - Do not import from `@elizaos/agent` inside this package — it creates an ESM cycle that breaks server boot. See comments in `src/config/config.ts`.
-

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -53,7 +53,7 @@ import "@elizaos/shared/brand.css";
 | `@elizaos/shared/brand-classic.css` | Eliza Classic CSS custom properties |
 | `@elizaos/shared/character-presets` | Built-in character preset definitions |
 | `@elizaos/shared/runtime-env` | Port and security config resolvers |
-| `@elizaos/shared/synthetic-control` | Versioned mock subprocess control contract and client |
+| `@elizaos/shared/synthetic-control` | Versioned, namespace-bound mock subprocess control contract and client |
 | `@elizaos/shared/config/allowed-hosts` | Allowed-hosts config helper |
 
 ## Building

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -53,6 +53,16 @@
       "import": "./dist/todo-cutover.js",
       "default": "./dist/todo-cutover.js"
     },
+    "./synthetic-control": {
+      "types": "./dist/synthetic-control/index.d.ts",
+      "eliza-source": {
+        "types": "./src/synthetic-control/index.ts",
+        "import": "./src/synthetic-control/index.ts",
+        "default": "./src/synthetic-control/index.ts"
+      },
+      "import": "./dist/synthetic-control/index.js",
+      "default": "./dist/synthetic-control/index.js"
+    },
     ".": {
       "types": "./dist/index.d.ts",
       "eliza-source": {

--- a/packages/shared/src/synthetic-control/client.ts
+++ b/packages/shared/src/synthetic-control/client.ts
@@ -155,11 +155,11 @@ export class SyntheticControlClient {
           "synthetic control response",
         ),
       );
-    } catch (error) {
-      // error-policy:J1 Malformed wire replies become a typed protocol failure at the client boundary.
+    } catch {
+      // error-policy:J1 Malformed wire replies become a redacted typed failure at the client boundary.
       throw new SyntheticControlProtocolError({
         code: "COMMAND_FAILED",
-        message: `synthetic control returned malformed JSON: ${error instanceof Error ? error.message : String(error)}`,
+        message: "synthetic control returned a malformed response",
       });
     }
     if (parsed.commandId !== commandId) {

--- a/packages/shared/src/synthetic-control/client.ts
+++ b/packages/shared/src/synthetic-control/client.ts
@@ -1,0 +1,136 @@
+/** Sends authenticated synthetic-control commands and rejects malformed or mismatched subprocess replies. */
+
+import { randomUUID } from "node:crypto";
+import {
+  parseSyntheticControlRequest,
+  parseSyntheticControlResponse,
+} from "./codec.js";
+import {
+  type JsonValue,
+  SYNTHETIC_CONTROL_PATH,
+  type SyntheticControlCommand,
+  SyntheticControlProtocolError,
+  type SyntheticControlRequest,
+} from "./types.js";
+
+export interface SyntheticControlClientOptions {
+  baseUrl: string;
+  token: string;
+  timeoutMs?: number;
+  fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+}
+
+export interface SyntheticControlCommandOptions {
+  commandId?: string;
+  expectedGeneration?: number;
+  leaseId?: string;
+  signal?: AbortSignal;
+}
+
+export class SyntheticControlClient {
+  readonly endpoint: URL;
+  private readonly token: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Promise<Response>;
+
+  constructor(options: SyntheticControlClientOptions) {
+    const base = new URL(options.baseUrl);
+    if (base.protocol !== "http:" && base.protocol !== "https:") {
+      throw new Error("synthetic control baseUrl must use http or https");
+    }
+    if (options.token.trim().length < 16) {
+      throw new Error(
+        "synthetic control token must contain at least 16 characters",
+      );
+    }
+    const timeoutMs = options.timeoutMs ?? 10_000;
+    if (
+      !Number.isSafeInteger(timeoutMs) ||
+      timeoutMs < 1 ||
+      timeoutMs > 300_000
+    ) {
+      throw new Error(
+        "synthetic control timeoutMs must be an integer between 1 and 300000",
+      );
+    }
+    this.endpoint = new URL(SYNTHETIC_CONTROL_PATH, base);
+    this.token = options.token;
+    this.timeoutMs = timeoutMs;
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+  }
+
+  async command(
+    command: SyntheticControlCommand,
+    options: SyntheticControlCommandOptions = {},
+  ): Promise<{ generation: number; data: JsonValue }> {
+    const commandId = options.commandId ?? randomUUID();
+    const request: SyntheticControlRequest = {
+      version: 1,
+      commandId,
+      command,
+      ...(options.expectedGeneration === undefined
+        ? {}
+        : { expectedGeneration: options.expectedGeneration }),
+      ...(options.leaseId === undefined ? {} : { leaseId: options.leaseId }),
+    };
+    // Validate before JSON serialization so functions, undefined, cycles, and
+    // non-finite numbers cannot be silently erased or rewritten on the wire.
+    parseSyntheticControlRequest(request);
+    const timeout = AbortSignal.timeout(this.timeoutMs);
+    const signal = options.signal
+      ? AbortSignal.any([options.signal, timeout])
+      : timeout;
+    let response: Response;
+    try {
+      response = await this.fetchImpl(this.endpoint, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${this.token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(request),
+        signal,
+      });
+    } catch (error) {
+      throw new SyntheticControlProtocolError({
+        code: "COMMAND_FAILED",
+        message: `synthetic control transport failed: ${error instanceof Error ? error.message : String(error)}`,
+        retryable: true,
+      });
+    }
+    let parsed: ReturnType<typeof parseSyntheticControlResponse>;
+    try {
+      parsed = parseSyntheticControlResponse(await response.json());
+    } catch (error) {
+      throw new SyntheticControlProtocolError({
+        code: "COMMAND_FAILED",
+        message: `synthetic control returned malformed JSON: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+    if (parsed.commandId !== commandId) {
+      throw new SyntheticControlProtocolError({
+        code: "COMMAND_FAILED",
+        message:
+          "synthetic control response commandId did not match the request",
+        generation: parsed.generation,
+      });
+    }
+    if (!parsed.ok) {
+      throw new SyntheticControlProtocolError({
+        ...parsed.error,
+        generation: parsed.generation,
+      });
+    }
+    if (!response.ok) {
+      throw new SyntheticControlProtocolError({
+        code: "COMMAND_FAILED",
+        message: `synthetic control returned HTTP ${response.status} with a success envelope`,
+        generation: parsed.generation,
+      });
+    }
+    return { generation: parsed.generation, data: parsed.data };
+  }
+}

--- a/packages/shared/src/synthetic-control/client.ts
+++ b/packages/shared/src/synthetic-control/client.ts
@@ -4,9 +4,12 @@ import { randomUUID } from "node:crypto";
 import {
   parseSyntheticControlRequest,
   parseSyntheticControlResponse,
+  readBoundedJson,
 } from "./codec.js";
 import {
   type JsonValue,
+  SYNTHETIC_CONTROL_MAX_REQUEST_BYTES,
+  SYNTHETIC_CONTROL_MAX_RESPONSE_BYTES,
   SYNTHETIC_CONTROL_PATH,
   type SyntheticControlCommand,
   SyntheticControlProtocolError,
@@ -15,6 +18,7 @@ import {
 
 export interface SyntheticControlClientOptions {
   baseUrl: string;
+  namespace: string;
   token: string;
   timeoutMs?: number;
   fetch?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
@@ -29,6 +33,7 @@ export interface SyntheticControlCommandOptions {
 
 export class SyntheticControlClient {
   readonly endpoint: URL;
+  readonly namespace: string;
   private readonly token: string;
   private readonly timeoutMs: number;
   private readonly fetchImpl: (
@@ -40,6 +45,25 @@ export class SyntheticControlClient {
     const base = new URL(options.baseUrl);
     if (base.protocol !== "http:" && base.protocol !== "https:") {
       throw new Error("synthetic control baseUrl must use http or https");
+    }
+    if (
+      base.protocol === "http:" &&
+      base.hostname !== "localhost" &&
+      base.hostname !== "[::1]" &&
+      !base.hostname.startsWith("127.")
+    ) {
+      throw new Error(
+        "synthetic control http baseUrl must resolve to a loopback host",
+      );
+    }
+    if (base.username || base.password) {
+      throw new Error("synthetic control baseUrl must not contain credentials");
+    }
+    const namespace = options.namespace.trim();
+    if (namespace.length === 0 || namespace.length > 512) {
+      throw new Error(
+        "synthetic control namespace must contain at most 512 characters",
+      );
     }
     if (options.token.trim().length < 16) {
       throw new Error(
@@ -57,6 +81,7 @@ export class SyntheticControlClient {
       );
     }
     this.endpoint = new URL(SYNTHETIC_CONTROL_PATH, base);
+    this.namespace = namespace;
     this.token = options.token;
     this.timeoutMs = timeoutMs;
     this.fetchImpl = options.fetch ?? globalThis.fetch;
@@ -69,6 +94,7 @@ export class SyntheticControlClient {
     const commandId = options.commandId ?? randomUUID();
     const request: SyntheticControlRequest = {
       version: 1,
+      namespace: this.namespace,
       commandId,
       command,
       ...(options.expectedGeneration === undefined
@@ -79,6 +105,23 @@ export class SyntheticControlClient {
     // Validate before JSON serialization so functions, undefined, cycles, and
     // non-finite numbers cannot be silently erased or rewritten on the wire.
     parseSyntheticControlRequest(request);
+    const body = JSON.stringify(request);
+    if (
+      new TextEncoder().encode(body).byteLength >
+      SYNTHETIC_CONTROL_MAX_REQUEST_BYTES
+    ) {
+      throw new Error(
+        `synthetic control request exceeds ${SYNTHETIC_CONTROL_MAX_REQUEST_BYTES} bytes`,
+      );
+    }
+    if (options.signal?.aborted) {
+      throw new SyntheticControlProtocolError({
+        code: "COMMAND_FAILED",
+        message: "synthetic control command was aborted before dispatch",
+        retryable: true,
+        generation: options.expectedGeneration,
+      });
+    }
     const timeout = AbortSignal.timeout(this.timeoutMs);
     const signal = options.signal
       ? AbortSignal.any([options.signal, timeout])
@@ -91,20 +134,29 @@ export class SyntheticControlClient {
           authorization: `Bearer ${this.token}`,
           "content-type": "application/json",
         },
-        body: JSON.stringify(request),
+        body,
         signal,
       });
     } catch (error) {
+      // error-policy:J1 The client transport boundary exposes a typed failure without claiming execution state.
       throw new SyntheticControlProtocolError({
         code: "COMMAND_FAILED",
-        message: `synthetic control transport failed: ${error instanceof Error ? error.message : String(error)}`,
+        message: "synthetic control transport failed",
         retryable: true,
+        cause: error,
       });
     }
     let parsed: ReturnType<typeof parseSyntheticControlResponse>;
     try {
-      parsed = parseSyntheticControlResponse(await response.json());
+      parsed = parseSyntheticControlResponse(
+        await readBoundedJson(
+          response,
+          SYNTHETIC_CONTROL_MAX_RESPONSE_BYTES,
+          "synthetic control response",
+        ),
+      );
     } catch (error) {
+      // error-policy:J1 Malformed wire replies become a typed protocol failure at the client boundary.
       throw new SyntheticControlProtocolError({
         code: "COMMAND_FAILED",
         message: `synthetic control returned malformed JSON: ${error instanceof Error ? error.message : String(error)}`,
@@ -115,20 +167,25 @@ export class SyntheticControlClient {
         code: "COMMAND_FAILED",
         message:
           "synthetic control response commandId did not match the request",
-        generation: parsed.generation,
+      });
+    }
+    if (parsed.namespace !== this.namespace) {
+      throw new SyntheticControlProtocolError({
+        code: "COMMAND_FAILED",
+        message:
+          "synthetic control response namespace did not match the request",
       });
     }
     if (!parsed.ok) {
       throw new SyntheticControlProtocolError({
         ...parsed.error,
-        generation: parsed.generation,
+        generation: parsed.generation ?? undefined,
       });
     }
     if (!response.ok) {
       throw new SyntheticControlProtocolError({
         code: "COMMAND_FAILED",
         message: `synthetic control returned HTTP ${response.status} with a success envelope`,
-        generation: parsed.generation,
       });
     }
     return { generation: parsed.generation, data: parsed.data };

--- a/packages/shared/src/synthetic-control/codec.ts
+++ b/packages/shared/src/synthetic-control/codec.ts
@@ -1,0 +1,331 @@
+/** Validates synthetic-control wire messages without accepting lossy or executable values. */
+
+import type {
+  JsonValue,
+  SyntheticControlCommand,
+  SyntheticControlFailure,
+  SyntheticControlRequest,
+  SyntheticControlResponse,
+} from "./types.js";
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function keys(
+  value: Record<string, unknown>,
+  required: readonly string[],
+  optional: readonly string[],
+  label: string,
+): void {
+  const allowed = new Set([...required, ...optional]);
+  const unknown = Object.keys(value).filter((key) => !allowed.has(key));
+  const missing = required.filter((key) => !(key in value));
+  if (unknown.length || missing.length) {
+    throw new Error(
+      `${label} has invalid keys (missing: ${missing.join(", ") || "none"}; unknown: ${unknown.join(", ") || "none"})`,
+    );
+  }
+}
+
+function text(value: unknown, label: string): string {
+  if (
+    typeof value !== "string" ||
+    value.trim().length === 0 ||
+    value.length > 512
+  ) {
+    throw new Error(
+      `${label} must be a non-empty string of at most 512 characters`,
+    );
+  }
+  return value;
+}
+
+function integer(
+  value: unknown,
+  label: string,
+  minimum = 0,
+  maximum = Number.MAX_SAFE_INTEGER,
+): number {
+  if (
+    !Number.isSafeInteger(value) ||
+    (value as number) < minimum ||
+    (value as number) > maximum
+  ) {
+    throw new Error(
+      `${label} must be an integer between ${minimum} and ${maximum}`,
+    );
+  }
+  return value as number;
+}
+
+export function assertJsonValue(
+  value: unknown,
+  label = "value",
+): asserts value is JsonValue {
+  const active = new Set<object>();
+  const visit = (candidate: unknown, path: string): void => {
+    if (
+      candidate === null ||
+      typeof candidate === "string" ||
+      typeof candidate === "boolean"
+    ) {
+      return;
+    }
+    if (typeof candidate === "number") {
+      if (!Number.isFinite(candidate))
+        throw new Error(`${path} must be finite`);
+      return;
+    }
+    if (!candidate || typeof candidate !== "object") {
+      throw new Error(`${path} must contain JSON-only values`);
+    }
+    if (active.has(candidate)) throw new Error(`${path} must not be cyclic`);
+    active.add(candidate);
+    if (Array.isArray(candidate)) {
+      candidate.forEach((item, index) => {
+        visit(item, `${path}[${index}]`);
+      });
+    } else {
+      if (Object.getPrototypeOf(candidate) !== Object.prototype) {
+        throw new Error(`${path} must contain plain JSON objects`);
+      }
+      for (const [key, item] of Object.entries(candidate)) {
+        visit(item, `${path}.${key}`);
+      }
+    }
+    active.delete(candidate);
+  };
+  visit(value, label);
+}
+
+function manifest(
+  value: unknown,
+): Extract<SyntheticControlCommand, { type: "seed" }>["manifest"] {
+  const item = record(value, "manifest");
+  keys(item, ["version", "namespace", "manifestId", "domains"], [], "manifest");
+  if (item.version !== 1) throw new Error("manifest.version must be 1");
+  const domains = record(item.domains, "manifest.domains");
+  assertJsonValue(domains, "manifest.domains");
+  return {
+    version: 1,
+    namespace: text(item.namespace, "manifest.namespace"),
+    manifestId: text(item.manifestId, "manifest.manifestId"),
+    domains,
+  };
+}
+
+function receipt(
+  value: unknown,
+): Extract<SyntheticControlCommand, { type: "reset" }>["receipt"] {
+  const item = record(value, "receipt");
+  keys(
+    item,
+    ["version", "namespace", "manifestId", "generation", "receipt"],
+    [],
+    "receipt",
+  );
+  if (item.version !== 1) throw new Error("receipt.version must be 1");
+  assertJsonValue(item.receipt, "receipt.receipt");
+  return {
+    version: 1,
+    namespace: text(item.namespace, "receipt.namespace"),
+    manifestId: text(item.manifestId, "receipt.manifestId"),
+    generation: integer(item.generation, "receipt.generation"),
+    receipt: item.receipt,
+  };
+}
+
+function fault(
+  value: unknown,
+): Extract<SyntheticControlCommand, { type: "fault.install" }>["fault"] {
+  const item = record(value, "fault");
+  keys(
+    item,
+    ["id", "scope", "mode", "count"],
+    ["operation", "delayMs", "errorCode", "data"],
+    "fault",
+  );
+  const modes = new Set(["delay", "error", "disconnect", "malformed-response"]);
+  if (!modes.has(String(item.mode)))
+    throw new Error("fault.mode is unsupported");
+  if (item.data !== undefined) assertJsonValue(item.data, "fault.data");
+  return {
+    id: text(item.id, "fault.id"),
+    scope: text(item.scope, "fault.scope"),
+    mode: item.mode as "delay" | "error" | "disconnect" | "malformed-response",
+    count: integer(item.count, "fault.count", 1, 1_000_000),
+    ...(item.operation === undefined
+      ? {}
+      : { operation: text(item.operation, "fault.operation") }),
+    ...(item.delayMs === undefined
+      ? {}
+      : { delayMs: integer(item.delayMs, "fault.delayMs", 0, 3_600_000) }),
+    ...(item.errorCode === undefined
+      ? {}
+      : { errorCode: text(item.errorCode, "fault.errorCode") }),
+    ...(item.data === undefined ? {} : { data: item.data }),
+  };
+}
+
+function command(value: unknown): SyntheticControlCommand {
+  const item = record(value, "command");
+  const type = text(item.type, "command.type");
+  switch (type) {
+    case "health":
+      keys(item, ["type"], [], "health command");
+      return { type };
+    case "lease.acquire":
+      keys(item, ["type", "owner", "ttlMs"], [], "lease.acquire command");
+      return {
+        type,
+        owner: text(item.owner, "command.owner"),
+        ttlMs: integer(item.ttlMs, "command.ttlMs", 1, 86_400_000),
+      };
+    case "lease.release":
+      keys(item, ["type", "leaseId"], [], "lease.release command");
+      return { type, leaseId: text(item.leaseId, "command.leaseId") };
+    case "seed":
+      keys(item, ["type", "manifest"], [], "seed command");
+      return { type, manifest: manifest(item.manifest) };
+    case "reset":
+      keys(item, ["type", "receipt"], [], "reset command");
+      return { type, receipt: receipt(item.receipt) };
+    case "time.advance":
+      keys(item, ["type", "milliseconds"], [], "time.advance command");
+      return {
+        type,
+        milliseconds: integer(
+          item.milliseconds,
+          "command.milliseconds",
+          0,
+          31_536_000_000,
+        ),
+      };
+    case "fault.install":
+      keys(item, ["type", "fault"], [], "fault.install command");
+      return { type, fault: fault(item.fault) };
+    case "fault.clear":
+    case "snapshot":
+      keys(item, ["type"], ["scope"], `${type} command`);
+      return {
+        type,
+        ...(item.scope === undefined
+          ? {}
+          : { scope: text(item.scope, "command.scope") }),
+      };
+    case "ledger.query":
+      keys(item, ["type"], ["afterSequence", "limit"], "ledger.query command");
+      return {
+        type,
+        ...(item.afterSequence === undefined
+          ? {}
+          : {
+              afterSequence: integer(
+                item.afterSequence,
+                "command.afterSequence",
+              ),
+            }),
+        ...(item.limit === undefined
+          ? {}
+          : { limit: integer(item.limit, "command.limit", 1, 10_000) }),
+      };
+    case "teardown":
+      keys(item, ["type", "reason"], [], "teardown command");
+      return { type, reason: text(item.reason, "command.reason") };
+    default:
+      throw new Error(`unsupported command type ${type}`);
+  }
+}
+
+export function parseSyntheticControlRequest(
+  value: unknown,
+): SyntheticControlRequest {
+  const item = record(value, "request");
+  keys(
+    item,
+    ["version", "commandId", "command"],
+    ["expectedGeneration", "leaseId"],
+    "request",
+  );
+  if (item.version !== 1) throw new Error("request.version must be 1");
+  return {
+    version: 1,
+    commandId: text(item.commandId, "request.commandId"),
+    command: command(item.command),
+    ...(item.expectedGeneration === undefined
+      ? {}
+      : {
+          expectedGeneration: integer(
+            item.expectedGeneration,
+            "request.expectedGeneration",
+          ),
+        }),
+    ...(item.leaseId === undefined
+      ? {}
+      : { leaseId: text(item.leaseId, "request.leaseId") }),
+  };
+}
+
+export function parseSyntheticControlResponse(
+  value: unknown,
+): SyntheticControlResponse {
+  const item = record(value, "response");
+  if (item.version !== 1) throw new Error("response.version must be 1");
+  const commandId = text(item.commandId, "response.commandId");
+  const generation = integer(item.generation, "response.generation");
+  if (item.ok === true) {
+    keys(
+      item,
+      ["version", "commandId", "ok", "generation", "data"],
+      [],
+      "success response",
+    );
+    assertJsonValue(item.data, "response.data");
+    return { version: 1, commandId, ok: true, generation, data: item.data };
+  }
+  if (item.ok !== false) throw new Error("response.ok must be boolean");
+  keys(
+    item,
+    ["version", "commandId", "ok", "generation", "error"],
+    [],
+    "failure response",
+  );
+  const failure = record(item.error, "response.error");
+  keys(
+    failure,
+    ["code", "message", "retryable"],
+    ["details"],
+    "response.error",
+  );
+  const codes = new Set<SyntheticControlFailure["error"]["code"]>([
+    "AUTH_REQUIRED",
+    "INVALID_REQUEST",
+    "LEASE_CONFLICT",
+    "LEASE_REQUIRED",
+    "STALE_GENERATION",
+    "COMMAND_FAILED",
+    "UNSUPPORTED_COMMAND",
+  ]);
+  if (!codes.has(failure.code as SyntheticControlFailure["error"]["code"]))
+    throw new Error("response.error.code is unsupported");
+  if (typeof failure.retryable !== "boolean")
+    throw new Error("response.error.retryable must be boolean");
+  if (failure.details !== undefined)
+    assertJsonValue(failure.details, "response.error.details");
+  return {
+    version: 1,
+    commandId,
+    ok: false,
+    generation,
+    error: {
+      code: failure.code as SyntheticControlFailure["error"]["code"],
+      message: text(failure.message, "response.error.message"),
+      retryable: failure.retryable,
+      ...(failure.details === undefined ? {} : { details: failure.details }),
+    },
+  };
+}

--- a/packages/shared/src/synthetic-control/codec.ts
+++ b/packages/shared/src/synthetic-control/codec.ts
@@ -8,6 +8,9 @@ import type {
   SyntheticControlResponse,
 } from "./types.js";
 
+const MAX_JSON_DEPTH = 64;
+const MAX_JSON_NODES = 100_000;
+
 function record(value: unknown, label: string): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error(`${label} must be an object`);
@@ -52,6 +55,7 @@ function integer(
 ): number {
   if (
     !Number.isSafeInteger(value) ||
+    Object.is(value, -0) ||
     (value as number) < minimum ||
     (value as number) > maximum
   ) {
@@ -67,39 +71,114 @@ export function assertJsonValue(
   label = "value",
 ): asserts value is JsonValue {
   const active = new Set<object>();
-  const visit = (candidate: unknown, path: string): void => {
+  const pending: Array<
+    { candidate: unknown; depth: number; path: string } | { exit: object }
+  > = [{ candidate: value, depth: 0, path: label }];
+  let nodes = 0;
+  while (pending.length > 0) {
+    const next = pending.pop();
+    if (!next) break;
+    if ("exit" in next) {
+      active.delete(next.exit);
+      continue;
+    }
+    const { candidate, depth, path } = next;
+    nodes += 1;
+    if (nodes > MAX_JSON_NODES) {
+      throw new Error(`${label} exceeds the JSON node limit`);
+    }
+    if (depth > MAX_JSON_DEPTH) {
+      throw new Error(`${path} exceeds the JSON depth limit`);
+    }
     if (
       candidate === null ||
       typeof candidate === "string" ||
       typeof candidate === "boolean"
     ) {
-      return;
+      continue;
     }
     if (typeof candidate === "number") {
       if (!Number.isFinite(candidate))
         throw new Error(`${path} must be finite`);
-      return;
+      if (Object.is(candidate, -0)) {
+        throw new Error(`${path} must not contain negative zero`);
+      }
+      continue;
     }
     if (!candidate || typeof candidate !== "object") {
       throw new Error(`${path} must contain JSON-only values`);
     }
     if (active.has(candidate)) throw new Error(`${path} must not be cyclic`);
     active.add(candidate);
+    pending.push({ exit: candidate });
     if (Array.isArray(candidate)) {
-      candidate.forEach((item, index) => {
-        visit(item, `${path}[${index}]`);
-      });
+      for (let index = candidate.length - 1; index >= 0; index -= 1) {
+        pending.push({
+          candidate: candidate[index],
+          depth: depth + 1,
+          path: `${path}[${index}]`,
+        });
+      }
     } else {
       if (Object.getPrototypeOf(candidate) !== Object.prototype) {
         throw new Error(`${path} must contain plain JSON objects`);
       }
-      for (const [key, item] of Object.entries(candidate)) {
-        visit(item, `${path}.${key}`);
+      for (const [key, item] of Object.entries(candidate).reverse()) {
+        pending.push({
+          candidate: item,
+          depth: depth + 1,
+          path: `${path}.${key}`,
+        });
       }
     }
-    active.delete(candidate);
-  };
-  visit(value, label);
+  }
+}
+
+export async function readBoundedJson(
+  message: Request | Response,
+  maximumBytes: number,
+  label: string,
+): Promise<unknown> {
+  const contentType = message.headers.get("content-type") ?? "";
+  if (!/^application\/json(?:\s*;|$)/i.test(contentType)) {
+    throw new Error(`${label} content-type must be application/json`);
+  }
+  const contentEncoding = message.headers.get("content-encoding");
+  if (contentEncoding && contentEncoding.toLowerCase() !== "identity") {
+    throw new Error(`${label} content-encoding is unsupported`);
+  }
+  const declaredLength = message.headers.get("content-length");
+  if (declaredLength && !/^\d+$/.test(declaredLength)) {
+    throw new Error(`${label} content-length is invalid`);
+  }
+  if (declaredLength) {
+    const bytes = Number(declaredLength);
+    if (!Number.isSafeInteger(bytes) || bytes > maximumBytes) {
+      throw new Error(`${label} exceeds ${maximumBytes} bytes`);
+    }
+  }
+  if (!message.body) throw new Error(`${label} body is required`);
+
+  const reader = message.body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  const chunks: string[] = [];
+  let bytes = 0;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      bytes += next.value.byteLength;
+      if (bytes > maximumBytes) {
+        await reader.cancel();
+        throw new Error(`${label} exceeds ${maximumBytes} bytes`);
+      }
+      chunks.push(decoder.decode(next.value, { stream: true }));
+    }
+    chunks.push(decoder.decode());
+  } finally {
+    reader.releaseLock();
+  }
+  return JSON.parse(chunks.join("")) as unknown;
 }
 
 function manifest(
@@ -247,13 +326,14 @@ export function parseSyntheticControlRequest(
   const item = record(value, "request");
   keys(
     item,
-    ["version", "commandId", "command"],
+    ["version", "namespace", "commandId", "command"],
     ["expectedGeneration", "leaseId"],
     "request",
   );
   if (item.version !== 1) throw new Error("request.version must be 1");
   return {
     version: 1,
+    namespace: text(item.namespace, "request.namespace"),
     commandId: text(item.commandId, "request.commandId"),
     command: command(item.command),
     ...(item.expectedGeneration === undefined
@@ -275,22 +355,34 @@ export function parseSyntheticControlResponse(
 ): SyntheticControlResponse {
   const item = record(value, "response");
   if (item.version !== 1) throw new Error("response.version must be 1");
+  const namespace = text(item.namespace, "response.namespace");
   const commandId = text(item.commandId, "response.commandId");
-  const generation = integer(item.generation, "response.generation");
   if (item.ok === true) {
+    const generation = integer(item.generation, "response.generation");
     keys(
       item,
-      ["version", "commandId", "ok", "generation", "data"],
+      ["version", "namespace", "commandId", "ok", "generation", "data"],
       [],
       "success response",
     );
     assertJsonValue(item.data, "response.data");
-    return { version: 1, commandId, ok: true, generation, data: item.data };
+    return {
+      version: 1,
+      namespace,
+      commandId,
+      ok: true,
+      generation,
+      data: item.data,
+    };
   }
   if (item.ok !== false) throw new Error("response.ok must be boolean");
+  const generation =
+    item.generation === null
+      ? null
+      : integer(item.generation, "response.generation");
   keys(
     item,
-    ["version", "commandId", "ok", "generation", "error"],
+    ["version", "namespace", "commandId", "ok", "generation", "error"],
     [],
     "failure response",
   );
@@ -318,6 +410,7 @@ export function parseSyntheticControlResponse(
     assertJsonValue(failure.details, "response.error.details");
   return {
     version: 1,
+    namespace,
     commandId,
     ok: false,
     generation,

--- a/packages/shared/src/synthetic-control/handler.ts
+++ b/packages/shared/src/synthetic-control/handler.ts
@@ -1,8 +1,10 @@
 /** Translates authenticated HTTP requests into calls on the owning synthetic-state authority. */
 
 import { createHash, timingSafeEqual } from "node:crypto";
-import { parseSyntheticControlRequest } from "./codec.js";
+import { parseSyntheticControlRequest, readBoundedJson } from "./codec.js";
 import {
+  SYNTHETIC_CONTROL_MAX_REQUEST_BYTES,
+  SYNTHETIC_CONTROL_MAX_RESPONSE_BYTES,
   SYNTHETIC_CONTROL_PATH,
   type SyntheticControlAuthority,
   type SyntheticControlFailure,
@@ -12,11 +14,24 @@ import {
 
 export interface SyntheticControlHandlerOptions {
   token: string;
+  namespace: string;
   authority: SyntheticControlAuthority;
 }
 
 function json(body: SyntheticControlResponse, status: number): Response {
-  return Response.json(body, { status });
+  const serialized = JSON.stringify(body);
+  if (
+    new TextEncoder().encode(serialized).byteLength >
+    SYNTHETIC_CONTROL_MAX_RESPONSE_BYTES
+  ) {
+    throw new Error(
+      `synthetic control response exceeds ${SYNTHETIC_CONTROL_MAX_RESPONSE_BYTES} bytes`,
+    );
+  }
+  return new Response(serialized, {
+    status,
+    headers: { "content-type": "application/json" },
+  });
 }
 
 function publicFailureMessage(
@@ -42,12 +57,15 @@ function publicFailureMessage(
 
 async function safeGeneration(
   authority: SyntheticControlAuthority,
-): Promise<number> {
+): Promise<number | null> {
   try {
     const generation = await authority.generation();
-    return Number.isSafeInteger(generation) && generation >= 0 ? generation : 0;
+    return Number.isSafeInteger(generation) && generation >= 0
+      ? generation
+      : null;
   } catch {
-    return 0;
+    // error-policy:J1 Generation lookup failure is translated at the HTTP boundary.
+    return null;
   }
 }
 
@@ -59,6 +77,12 @@ export function createSyntheticControlHandler(
       "synthetic control token must contain at least 16 characters",
     );
   }
+  const namespace = options.namespace.trim();
+  if (namespace.length === 0 || namespace.length > 512) {
+    throw new Error(
+      "synthetic control namespace must contain at most 512 characters",
+    );
+  }
   const expectedTokenHash = createHash("sha256").update(options.token).digest();
   return async (request) => {
     const url = new URL(request.url);
@@ -68,9 +92,10 @@ export function createSyntheticControlHandler(
       return json(
         {
           version: 1,
+          namespace,
           commandId: anonymousCommandId,
           ok: false,
-          generation: 0,
+          generation: null,
           error: {
             code: "INVALID_REQUEST",
             message: "control endpoint accepts POST only",
@@ -91,9 +116,10 @@ export function createSyntheticControlHandler(
       return json(
         {
           version: 1,
+          namespace,
           commandId: anonymousCommandId,
           ok: false,
-          generation: 0,
+          generation: null,
           error: {
             code: "AUTH_REQUIRED",
             message: "control authorization failed",
@@ -110,12 +136,14 @@ export function createSyntheticControlHandler(
         throw new Error("authority generation is invalid");
       }
     } catch {
+      // error-policy:J1 Authority availability is translated into a redacted HTTP failure.
       return json(
         {
           version: 1,
+          namespace,
           commandId: anonymousCommandId,
           ok: false,
-          generation: 0,
+          generation: null,
           error: {
             code: "COMMAND_FAILED",
             message: publicFailureMessage("COMMAND_FAILED"),
@@ -127,11 +155,19 @@ export function createSyntheticControlHandler(
     }
     let parsed: ReturnType<typeof parseSyntheticControlRequest>;
     try {
-      parsed = parseSyntheticControlRequest(await request.json());
+      parsed = parseSyntheticControlRequest(
+        await readBoundedJson(
+          request,
+          SYNTHETIC_CONTROL_MAX_REQUEST_BYTES,
+          "synthetic control request",
+        ),
+      );
     } catch {
+      // error-policy:J3 Untrusted wire input is rejected as invalid without fabricating a command.
       return json(
         {
           version: 1,
+          namespace,
           commandId: anonymousCommandId,
           ok: false,
           generation: initialGeneration,
@@ -144,48 +180,96 @@ export function createSyntheticControlHandler(
         400,
       );
     }
-    try {
-      const data = await options.authority.execute(parsed.command, {
-        commandId: parsed.commandId,
-        expectedGeneration: parsed.expectedGeneration,
-        leaseId: parsed.leaseId,
-        signal: request.signal,
-      });
+    if (
+      parsed.namespace !== namespace ||
+      (parsed.command.type === "seed" &&
+        parsed.command.manifest.namespace !== namespace) ||
+      (parsed.command.type === "reset" &&
+        parsed.command.receipt.namespace !== namespace)
+    ) {
       return json(
         {
           version: 1,
+          namespace,
           commandId: parsed.commandId,
-          ok: true,
-          generation: await options.authority.generation(),
-          data,
+          ok: false,
+          generation: initialGeneration,
+          error: {
+            code: "AUTH_REQUIRED",
+            message: publicFailureMessage("AUTH_REQUIRED"),
+            retryable: false,
+          },
         },
-        200,
+        401,
       );
-    } catch (error) {
-      const normalized =
-        error instanceof SyntheticControlProtocolError
-          ? error
-          : new SyntheticControlProtocolError({
-              code: "COMMAND_FAILED",
-              message: error instanceof Error ? error.message : String(error),
-            });
-      const failure: SyntheticControlFailure = {
-        version: 1,
-        commandId: parsed.commandId,
-        ok: false,
-        generation: await safeGeneration(options.authority),
-        error: {
-          code: normalized.code,
-          message: publicFailureMessage(normalized.code),
-          retryable: normalized.retryable,
-        },
-      };
-      const status =
-        normalized.code === "STALE_GENERATION" ||
-        normalized.code === "LEASE_CONFLICT"
-          ? 409
-          : 400;
-      return json(failure, status);
     }
+
+    const dispatch = async (): Promise<Response> => {
+      if (request.signal.aborted) {
+        return json(
+          {
+            version: 1,
+            namespace,
+            commandId: parsed.commandId,
+            ok: false,
+            generation: await safeGeneration(options.authority),
+            error: {
+              code: "COMMAND_FAILED",
+              message: publicFailureMessage("COMMAND_FAILED"),
+              retryable: true,
+            },
+          },
+          400,
+        );
+      }
+      try {
+        const data = await options.authority.execute(parsed.command, {
+          namespace,
+          commandId: parsed.commandId,
+          expectedGeneration: parsed.expectedGeneration,
+          leaseId: parsed.leaseId,
+          signal: request.signal,
+        });
+        return json(
+          {
+            version: 1,
+            namespace,
+            commandId: parsed.commandId,
+            ok: true,
+            generation: await options.authority.generation(),
+            data,
+          },
+          200,
+        );
+      } catch (error) {
+        // error-policy:J1 Authority errors are redacted and translated at the authenticated HTTP boundary.
+        const normalized =
+          error instanceof SyntheticControlProtocolError
+            ? error
+            : new SyntheticControlProtocolError({
+                code: "COMMAND_FAILED",
+                message: error instanceof Error ? error.message : String(error),
+              });
+        const failure: SyntheticControlFailure = {
+          version: 1,
+          namespace,
+          commandId: parsed.commandId,
+          ok: false,
+          generation: await safeGeneration(options.authority),
+          error: {
+            code: normalized.code,
+            message: publicFailureMessage(normalized.code),
+            retryable: normalized.retryable,
+          },
+        };
+        const status =
+          normalized.code === "STALE_GENERATION" ||
+          normalized.code === "LEASE_CONFLICT"
+            ? 409
+            : 400;
+        return json(failure, status);
+      }
+    };
+    return dispatch();
   };
 }

--- a/packages/shared/src/synthetic-control/handler.ts
+++ b/packages/shared/src/synthetic-control/handler.ts
@@ -1,0 +1,191 @@
+/** Translates authenticated HTTP requests into calls on the owning synthetic-state authority. */
+
+import { createHash, timingSafeEqual } from "node:crypto";
+import { parseSyntheticControlRequest } from "./codec.js";
+import {
+  SYNTHETIC_CONTROL_PATH,
+  type SyntheticControlAuthority,
+  type SyntheticControlFailure,
+  SyntheticControlProtocolError,
+  type SyntheticControlResponse,
+} from "./types.js";
+
+export interface SyntheticControlHandlerOptions {
+  token: string;
+  authority: SyntheticControlAuthority;
+}
+
+function json(body: SyntheticControlResponse, status: number): Response {
+  return Response.json(body, { status });
+}
+
+function publicFailureMessage(
+  code: SyntheticControlFailure["error"]["code"],
+): string {
+  switch (code) {
+    case "AUTH_REQUIRED":
+      return "control authorization failed";
+    case "INVALID_REQUEST":
+      return "control request is invalid";
+    case "LEASE_CONFLICT":
+      return "control lease is already held";
+    case "LEASE_REQUIRED":
+      return "an active control lease is required";
+    case "STALE_GENERATION":
+      return "control generation fence rejected the command";
+    case "UNSUPPORTED_COMMAND":
+      return "control command is unsupported";
+    case "COMMAND_FAILED":
+      return "control authority failed the command";
+  }
+}
+
+async function safeGeneration(
+  authority: SyntheticControlAuthority,
+): Promise<number> {
+  try {
+    const generation = await authority.generation();
+    return Number.isSafeInteger(generation) && generation >= 0 ? generation : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function createSyntheticControlHandler(
+  options: SyntheticControlHandlerOptions,
+): (request: Request) => Promise<Response | null> {
+  if (options.token.trim().length < 16) {
+    throw new Error(
+      "synthetic control token must contain at least 16 characters",
+    );
+  }
+  const expectedTokenHash = createHash("sha256").update(options.token).digest();
+  return async (request) => {
+    const url = new URL(request.url);
+    if (url.pathname !== SYNTHETIC_CONTROL_PATH) return null;
+    const anonymousCommandId = "invalid-request";
+    if (request.method !== "POST") {
+      return json(
+        {
+          version: 1,
+          commandId: anonymousCommandId,
+          ok: false,
+          generation: 0,
+          error: {
+            code: "INVALID_REQUEST",
+            message: "control endpoint accepts POST only",
+            retryable: false,
+          },
+        },
+        405,
+      );
+    }
+    const presented = request.headers.get("authorization");
+    const presentedToken = presented?.startsWith("Bearer ")
+      ? presented.slice("Bearer ".length)
+      : "";
+    const presentedTokenHash = createHash("sha256")
+      .update(presentedToken)
+      .digest();
+    if (!timingSafeEqual(expectedTokenHash, presentedTokenHash)) {
+      return json(
+        {
+          version: 1,
+          commandId: anonymousCommandId,
+          ok: false,
+          generation: 0,
+          error: {
+            code: "AUTH_REQUIRED",
+            message: "control authorization failed",
+            retryable: false,
+          },
+        },
+        401,
+      );
+    }
+    let initialGeneration: number;
+    try {
+      initialGeneration = await options.authority.generation();
+      if (!Number.isSafeInteger(initialGeneration) || initialGeneration < 0) {
+        throw new Error("authority generation is invalid");
+      }
+    } catch {
+      return json(
+        {
+          version: 1,
+          commandId: anonymousCommandId,
+          ok: false,
+          generation: 0,
+          error: {
+            code: "COMMAND_FAILED",
+            message: publicFailureMessage("COMMAND_FAILED"),
+            retryable: true,
+          },
+        },
+        503,
+      );
+    }
+    let parsed: ReturnType<typeof parseSyntheticControlRequest>;
+    try {
+      parsed = parseSyntheticControlRequest(await request.json());
+    } catch {
+      return json(
+        {
+          version: 1,
+          commandId: anonymousCommandId,
+          ok: false,
+          generation: initialGeneration,
+          error: {
+            code: "INVALID_REQUEST",
+            message: publicFailureMessage("INVALID_REQUEST"),
+            retryable: false,
+          },
+        },
+        400,
+      );
+    }
+    try {
+      const data = await options.authority.execute(parsed.command, {
+        commandId: parsed.commandId,
+        expectedGeneration: parsed.expectedGeneration,
+        leaseId: parsed.leaseId,
+        signal: request.signal,
+      });
+      return json(
+        {
+          version: 1,
+          commandId: parsed.commandId,
+          ok: true,
+          generation: await options.authority.generation(),
+          data,
+        },
+        200,
+      );
+    } catch (error) {
+      const normalized =
+        error instanceof SyntheticControlProtocolError
+          ? error
+          : new SyntheticControlProtocolError({
+              code: "COMMAND_FAILED",
+              message: error instanceof Error ? error.message : String(error),
+            });
+      const failure: SyntheticControlFailure = {
+        version: 1,
+        commandId: parsed.commandId,
+        ok: false,
+        generation: await safeGeneration(options.authority),
+        error: {
+          code: normalized.code,
+          message: publicFailureMessage(normalized.code),
+          retryable: normalized.retryable,
+        },
+      };
+      const status =
+        normalized.code === "STALE_GENERATION" ||
+        normalized.code === "LEASE_CONFLICT"
+          ? 409
+          : 400;
+      return json(failure, status);
+    }
+  };
+}

--- a/packages/shared/src/synthetic-control/index.ts
+++ b/packages/shared/src/synthetic-control/index.ts
@@ -1,0 +1,7 @@
+/** Exports the shared synthetic-control wire contract, client, codec, and state-neutral HTTP adapter. */
+
+export * from "./client.js";
+export * from "./codec.js";
+export * from "./handler.js";
+export * from "./session.js";
+export * from "./types.js";

--- a/packages/shared/src/synthetic-control/session.ts
+++ b/packages/shared/src/synthetic-control/session.ts
@@ -1,7 +1,10 @@
 /** Coordinates one leased manifest lifecycle while preserving the authority's generation and reset receipt. */
 
 import { randomUUID } from "node:crypto";
-import type { SyntheticControlClient } from "./client.js";
+import type {
+  SyntheticControlClient,
+  SyntheticControlCommandOptions,
+} from "./client.js";
 import { assertJsonValue, parseSyntheticControlRequest } from "./codec.js";
 import type {
   JsonValue,
@@ -35,7 +38,7 @@ export interface OpenSyntheticControlSessionOptions {
   leaseTtlMs?: number;
 }
 
-/** Seed crossed an ambiguous boundary, so automated release/reset cannot safely claim a clean world. */
+/** A lifecycle command crossed an ambiguous boundary, so automated cleanup cannot claim a clean world. */
 export class SyntheticControlDirtySessionError extends Error {
   constructor(
     readonly leaseId: string,
@@ -43,7 +46,7 @@ export class SyntheticControlDirtySessionError extends Error {
     cause: unknown,
   ) {
     super(
-      `synthetic seed may have mutated generation ${lastKnownGeneration}; lease ${leaseId} remains held for authoritative recovery or expiry`,
+      `synthetic session may have mutated generation ${lastKnownGeneration}; lease ${leaseId} remains held for authoritative recovery or expiry`,
       { cause },
     );
     this.name = "SyntheticControlDirtySessionError";
@@ -52,7 +55,11 @@ export class SyntheticControlDirtySessionError extends Error {
 
 export class SyntheticControlSession {
   private currentGeneration: number;
-  private closed = false;
+  private state: "active" | "closing" | "closed" | "dirty" = "active";
+  private operationTail: Promise<void> = Promise.resolve();
+  private closePromise: Promise<void> | null = null;
+  private resetComplete = false;
+  private dirtyError: SyntheticControlDirtySessionError | null = null;
 
   private constructor(
     readonly client: SyntheticControlClient,
@@ -67,22 +74,56 @@ export class SyntheticControlSession {
   static async open(
     options: OpenSyntheticControlSessionOptions,
   ): Promise<SyntheticControlSession> {
+    if (options.client.namespace !== options.manifest.namespace) {
+      throw new Error(
+        "synthetic control client namespace must match the session manifest namespace",
+      );
+    }
     parseSyntheticControlRequest({
       version: 1,
+      namespace: options.manifest.namespace,
       commandId: "session-seed-preflight",
       command: { type: "seed", manifest: options.manifest },
     });
     const health = await options.client.command({ type: "health" });
-    const acquired = await options.client.command(
-      {
-        type: "lease.acquire",
-        owner: options.owner ?? `harness-${randomUUID()}`,
-        ttlMs: options.leaseTtlMs ?? 60_000,
-      },
-      { expectedGeneration: health.generation },
-    );
-    const lease = resultObject(acquired.data, "lease.acquire data");
-    const leaseId = resultString(lease.leaseId, "lease.acquire data.leaseId");
+    let acquired: Awaited<ReturnType<SyntheticControlClient["command"]>>;
+    try {
+      acquired = await options.client.command(
+        {
+          type: "lease.acquire",
+          owner: options.owner ?? `harness-${randomUUID()}`,
+          ttlMs: options.leaseTtlMs ?? 300_000,
+        },
+        { expectedGeneration: health.generation },
+      );
+    } catch (error) {
+      // error-policy:J2 An ambiguous lease acquisition is surfaced as dirty because its lease id may be lost.
+      if (
+        error instanceof SyntheticControlProtocolError &&
+        error.generation === health.generation
+      ) {
+        throw error;
+      }
+      throw new SyntheticControlDirtySessionError(
+        "unknown",
+        error instanceof SyntheticControlProtocolError
+          ? (error.generation ?? health.generation)
+          : health.generation,
+        error,
+      );
+    }
+    let leaseId: string;
+    try {
+      const lease = resultObject(acquired.data, "lease.acquire data");
+      leaseId = resultString(lease.leaseId, "lease.acquire data.leaseId");
+    } catch (error) {
+      // error-policy:J2 A successful acquisition with an invalid receipt cannot be safely released.
+      throw new SyntheticControlDirtySessionError(
+        "unknown",
+        acquired.generation,
+        error,
+      );
+    }
     let observedGeneration = acquired.generation;
     try {
       const seeded = await options.client.command(
@@ -111,6 +152,7 @@ export class SyntheticControlSession {
         seeded.generation,
       );
     } catch (error) {
+      // error-policy:J2 Seed failures retain the lease whenever mutation cannot be ruled out.
       if (
         error instanceof SyntheticControlProtocolError &&
         error.generation === acquired.generation
@@ -121,6 +163,7 @@ export class SyntheticControlSession {
             { expectedGeneration: acquired.generation, leaseId },
           );
         } catch (releaseError) {
+          // error-policy:J2 Failed cleanup after a proven non-mutating seed failure leaves a dirty lease.
           throw new SyntheticControlDirtySessionError(
             leaseId,
             acquired.generation,
@@ -147,8 +190,11 @@ export class SyntheticControlSession {
 
   async execute(
     command: Parameters<SyntheticControlClient["command"]>[0],
+    options: Pick<SyntheticControlCommandOptions, "signal"> = {},
   ): Promise<JsonValue> {
-    if (this.closed) throw new Error("synthetic control session is closed");
+    if (this.state !== "active") {
+      throw this.unavailableError();
+    }
     if (
       command.type === "health" ||
       command.type.startsWith("lease.") ||
@@ -160,47 +206,165 @@ export class SyntheticControlSession {
         `session.execute does not accept lifecycle command ${command.type}`,
       );
     }
-    const result = await this.client.command(command, {
-      expectedGeneration: this.currentGeneration,
-      leaseId: this.leaseId,
+    parseSyntheticControlRequest({
+      version: 1,
+      namespace: this.manifest.namespace,
+      commandId: "session-command-preflight",
+      command,
     });
-    this.currentGeneration = result.generation;
-    return result.data;
+    return this.enqueue(async () => {
+      if (this.state === "dirty") throw this.unavailableError();
+      const expectedGeneration = this.currentGeneration;
+      try {
+        const result = await this.client.command(command, {
+          ...options,
+          expectedGeneration,
+          leaseId: this.leaseId,
+        });
+        this.currentGeneration = result.generation;
+        return result.data;
+      } catch (error) {
+        // error-policy:J2 Ambiguous command outcomes poison the session instead of permitting unsafe cleanup.
+        throw this.normalizeCommandFailure(error, expectedGeneration);
+      }
+    });
   }
 
   async close(
     options: { teardown?: boolean; reason?: string } = {},
   ): Promise<void> {
-    if (this.closed) return;
-    const reset = await this.client.command(
-      { type: "reset", receipt: this.resetReceipt },
-      { expectedGeneration: this.currentGeneration, leaseId: this.leaseId },
-    );
-    this.currentGeneration = reset.generation;
-    if (options.teardown) {
-      const teardown = await this.client.command(
-        {
-          type: "teardown",
-          reason: options.reason ?? "synthetic session complete",
-        },
-        { expectedGeneration: this.currentGeneration, leaseId: this.leaseId },
-      );
-      const data = resultObject(teardown.data, "teardown data");
-      if (data.leaseReleased !== true) {
-        throw new SyntheticControlDirtySessionError(
-          this.leaseId,
-          teardown.generation,
-          new Error("teardown did not prove atomic lease release"),
+    if (this.state === "closed") return;
+    if (this.state === "dirty") throw this.unavailableError();
+    if (this.state === "closing") {
+      if (!this.closePromise) {
+        throw new Error(
+          "synthetic control session close state is inconsistent",
         );
       }
-      this.currentGeneration = teardown.generation;
-    } else {
-      const released = await this.client.command(
-        { type: "lease.release", leaseId: this.leaseId },
-        { expectedGeneration: this.currentGeneration, leaseId: this.leaseId },
-      );
-      this.currentGeneration = released.generation;
+      return this.closePromise;
     }
-    this.closed = true;
+    this.state = "closing";
+    const closing = this.enqueue(async () => {
+      if (this.state === "dirty") throw this.unavailableError();
+      try {
+        if (!this.resetComplete) {
+          const expectedGeneration = this.currentGeneration;
+          const reset = await this.client
+            .command(
+              { type: "reset", receipt: this.resetReceipt },
+              {
+                expectedGeneration,
+                leaseId: this.leaseId,
+              },
+            )
+            .catch((error: unknown) => {
+              // error-policy:J2 Reset failures are classified against the last authoritative generation.
+              throw this.normalizeCommandFailure(error, expectedGeneration);
+            });
+          this.currentGeneration = reset.generation;
+          this.resetComplete = true;
+        }
+
+        const expectedGeneration = this.currentGeneration;
+        if (options.teardown) {
+          const teardown = await this.client
+            .command(
+              {
+                type: "teardown",
+                reason: options.reason ?? "synthetic session complete",
+              },
+              { expectedGeneration, leaseId: this.leaseId },
+            )
+            .catch((error: unknown) => {
+              // error-policy:J2 Teardown failures cannot be retried after an ambiguous lease release.
+              throw this.normalizeCommandFailure(error, expectedGeneration);
+            });
+          this.currentGeneration = teardown.generation;
+          const data = resultObject(teardown.data, "teardown data");
+          if (data.leaseReleased !== true) {
+            throw this.markDirty(
+              new Error("teardown did not prove atomic lease release"),
+              teardown.generation,
+            );
+          }
+        } else {
+          const released = await this.client
+            .command(
+              { type: "lease.release", leaseId: this.leaseId },
+              { expectedGeneration, leaseId: this.leaseId },
+            )
+            .catch((error: unknown) => {
+              // error-policy:J2 Release failures cannot be retried when the authority outcome is ambiguous.
+              throw this.normalizeCommandFailure(error, expectedGeneration);
+            });
+          this.currentGeneration = released.generation;
+          const data = resultObject(released.data, "lease.release data");
+          if (data.released !== true) {
+            throw this.markDirty(
+              new Error("lease.release did not prove lease release"),
+              released.generation,
+            );
+          }
+        }
+        this.state = "closed";
+      } catch (error) {
+        // error-policy:J2 A proven non-mutating close failure remains retryable; ambiguous failures stay dirty.
+        if (!this.dirtyError) this.state = "active";
+        throw error;
+      }
+    });
+    this.closePromise = closing;
+    try {
+      await closing;
+    } finally {
+      if (this.state !== "closing") this.closePromise = null;
+    }
+  }
+
+  private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.operationTail.then(operation);
+    this.operationTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  private normalizeCommandFailure(
+    error: unknown,
+    expectedGeneration: number,
+  ): unknown {
+    if (
+      error instanceof SyntheticControlProtocolError &&
+      error.generation === expectedGeneration
+    ) {
+      return error;
+    }
+    return this.markDirty(
+      error,
+      error instanceof SyntheticControlProtocolError
+        ? (error.generation ?? expectedGeneration)
+        : expectedGeneration,
+    );
+  }
+
+  private markDirty(
+    cause: unknown,
+    generation: number,
+  ): SyntheticControlDirtySessionError {
+    if (!this.dirtyError) {
+      this.dirtyError = new SyntheticControlDirtySessionError(
+        this.leaseId,
+        generation,
+        cause,
+      );
+    }
+    this.state = "dirty";
+    return this.dirtyError;
+  }
+
+  private unavailableError(): Error {
+    if (this.dirtyError) return this.dirtyError;
+    return new Error(`synthetic control session is ${this.state}`);
   }
 }

--- a/packages/shared/src/synthetic-control/session.ts
+++ b/packages/shared/src/synthetic-control/session.ts
@@ -1,0 +1,206 @@
+/** Coordinates one leased manifest lifecycle while preserving the authority's generation and reset receipt. */
+
+import { randomUUID } from "node:crypto";
+import type { SyntheticControlClient } from "./client.js";
+import { assertJsonValue, parseSyntheticControlRequest } from "./codec.js";
+import type {
+  JsonValue,
+  SyntheticManifest,
+  SyntheticResetReceipt,
+} from "./types.js";
+import { SyntheticControlProtocolError } from "./types.js";
+
+function resultObject(
+  value: JsonValue,
+  label: string,
+): Record<string, JsonValue> {
+  assertJsonValue(value, label);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, JsonValue>;
+}
+
+function resultString(value: JsonValue | undefined, label: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+export interface OpenSyntheticControlSessionOptions {
+  client: SyntheticControlClient;
+  manifest: SyntheticManifest;
+  owner?: string;
+  leaseTtlMs?: number;
+}
+
+/** Seed crossed an ambiguous boundary, so automated release/reset cannot safely claim a clean world. */
+export class SyntheticControlDirtySessionError extends Error {
+  constructor(
+    readonly leaseId: string,
+    readonly lastKnownGeneration: number,
+    cause: unknown,
+  ) {
+    super(
+      `synthetic seed may have mutated generation ${lastKnownGeneration}; lease ${leaseId} remains held for authoritative recovery or expiry`,
+      { cause },
+    );
+    this.name = "SyntheticControlDirtySessionError";
+  }
+}
+
+export class SyntheticControlSession {
+  private currentGeneration: number;
+  private closed = false;
+
+  private constructor(
+    readonly client: SyntheticControlClient,
+    readonly leaseId: string,
+    readonly manifest: SyntheticManifest,
+    readonly resetReceipt: SyntheticResetReceipt,
+    generation: number,
+  ) {
+    this.currentGeneration = generation;
+  }
+
+  static async open(
+    options: OpenSyntheticControlSessionOptions,
+  ): Promise<SyntheticControlSession> {
+    parseSyntheticControlRequest({
+      version: 1,
+      commandId: "session-seed-preflight",
+      command: { type: "seed", manifest: options.manifest },
+    });
+    const health = await options.client.command({ type: "health" });
+    const acquired = await options.client.command(
+      {
+        type: "lease.acquire",
+        owner: options.owner ?? `harness-${randomUUID()}`,
+        ttlMs: options.leaseTtlMs ?? 60_000,
+      },
+      { expectedGeneration: health.generation },
+    );
+    const lease = resultObject(acquired.data, "lease.acquire data");
+    const leaseId = resultString(lease.leaseId, "lease.acquire data.leaseId");
+    let observedGeneration = acquired.generation;
+    try {
+      const seeded = await options.client.command(
+        { type: "seed", manifest: options.manifest },
+        { expectedGeneration: acquired.generation, leaseId },
+      );
+      observedGeneration = seeded.generation;
+      const data = resultObject(seeded.data, "seed data");
+      const receipt = resultObject(data.receipt, "seed data.receipt");
+      if (
+        receipt.version !== 1 ||
+        receipt.namespace !== options.manifest.namespace ||
+        receipt.manifestId !== options.manifest.manifestId ||
+        receipt.generation !== seeded.generation ||
+        !("receipt" in receipt)
+      ) {
+        throw new Error(
+          "seed returned a receipt that is not bound to the requested manifest and generation",
+        );
+      }
+      return new SyntheticControlSession(
+        options.client,
+        leaseId,
+        options.manifest,
+        receipt as unknown as SyntheticResetReceipt,
+        seeded.generation,
+      );
+    } catch (error) {
+      if (
+        error instanceof SyntheticControlProtocolError &&
+        error.generation === acquired.generation
+      ) {
+        try {
+          await options.client.command(
+            { type: "lease.release", leaseId },
+            { expectedGeneration: acquired.generation, leaseId },
+          );
+        } catch (releaseError) {
+          throw new SyntheticControlDirtySessionError(
+            leaseId,
+            acquired.generation,
+            releaseError,
+          );
+        }
+        throw error;
+      }
+      const reportedGeneration =
+        error instanceof SyntheticControlProtocolError
+          ? error.generation
+          : undefined;
+      throw new SyntheticControlDirtySessionError(
+        leaseId,
+        reportedGeneration ?? observedGeneration,
+        error,
+      );
+    }
+  }
+
+  get generation(): number {
+    return this.currentGeneration;
+  }
+
+  async execute(
+    command: Parameters<SyntheticControlClient["command"]>[0],
+  ): Promise<JsonValue> {
+    if (this.closed) throw new Error("synthetic control session is closed");
+    if (
+      command.type === "health" ||
+      command.type.startsWith("lease.") ||
+      command.type === "seed" ||
+      command.type === "reset" ||
+      command.type === "teardown"
+    ) {
+      throw new Error(
+        `session.execute does not accept lifecycle command ${command.type}`,
+      );
+    }
+    const result = await this.client.command(command, {
+      expectedGeneration: this.currentGeneration,
+      leaseId: this.leaseId,
+    });
+    this.currentGeneration = result.generation;
+    return result.data;
+  }
+
+  async close(
+    options: { teardown?: boolean; reason?: string } = {},
+  ): Promise<void> {
+    if (this.closed) return;
+    const reset = await this.client.command(
+      { type: "reset", receipt: this.resetReceipt },
+      { expectedGeneration: this.currentGeneration, leaseId: this.leaseId },
+    );
+    this.currentGeneration = reset.generation;
+    if (options.teardown) {
+      const teardown = await this.client.command(
+        {
+          type: "teardown",
+          reason: options.reason ?? "synthetic session complete",
+        },
+        { expectedGeneration: this.currentGeneration, leaseId: this.leaseId },
+      );
+      const data = resultObject(teardown.data, "teardown data");
+      if (data.leaseReleased !== true) {
+        throw new SyntheticControlDirtySessionError(
+          this.leaseId,
+          teardown.generation,
+          new Error("teardown did not prove atomic lease release"),
+        );
+      }
+      this.currentGeneration = teardown.generation;
+    } else {
+      const released = await this.client.command(
+        { type: "lease.release", leaseId: this.leaseId },
+        { expectedGeneration: this.currentGeneration, leaseId: this.leaseId },
+      );
+      this.currentGeneration = released.generation;
+    }
+    this.closed = true;
+  }
+}

--- a/packages/shared/src/synthetic-control/types.ts
+++ b/packages/shared/src/synthetic-control/types.ts
@@ -1,0 +1,128 @@
+/** Defines the versioned, JSON-only control contract shared by mock subprocesses and their test harnesses. */
+
+export const SYNTHETIC_CONTROL_VERSION = 1 as const;
+export const SYNTHETIC_CONTROL_PATH = "/__eliza/synthetic-control/v1" as const;
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue =
+  | JsonPrimitive
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue };
+
+export interface SyntheticManifest {
+  version: 1;
+  namespace: string;
+  manifestId: string;
+  domains: Readonly<Record<string, JsonValue>>;
+}
+
+export interface SyntheticResetReceipt {
+  version: 1;
+  namespace: string;
+  manifestId: string;
+  generation: number;
+  receipt: JsonValue;
+}
+
+export interface SyntheticFault {
+  id: string;
+  scope: string;
+  operation?: string;
+  mode: "delay" | "error" | "disconnect" | "malformed-response";
+  count: number;
+  delayMs?: number;
+  errorCode?: string;
+  data?: JsonValue;
+}
+
+export type SyntheticControlCommand =
+  | { type: "health" }
+  | { type: "lease.acquire"; owner: string; ttlMs: number }
+  | { type: "lease.release"; leaseId: string }
+  | { type: "seed"; manifest: SyntheticManifest }
+  | { type: "reset"; receipt: SyntheticResetReceipt }
+  | { type: "time.advance"; milliseconds: number }
+  | { type: "fault.install"; fault: SyntheticFault }
+  | { type: "fault.clear"; scope?: string }
+  | { type: "snapshot"; scope?: string }
+  | { type: "ledger.query"; afterSequence?: number; limit?: number }
+  /** Authority must invalidate the supplied active lease before acknowledging teardown. */
+  | { type: "teardown"; reason: string };
+
+export interface SyntheticControlRequest {
+  version: 1;
+  commandId: string;
+  expectedGeneration?: number;
+  leaseId?: string;
+  command: SyntheticControlCommand;
+}
+
+export interface SyntheticControlSuccess {
+  version: 1;
+  commandId: string;
+  ok: true;
+  generation: number;
+  data: JsonValue;
+}
+
+export interface SyntheticControlFailure {
+  version: 1;
+  commandId: string;
+  ok: false;
+  generation: number;
+  error: {
+    code:
+      | "AUTH_REQUIRED"
+      | "INVALID_REQUEST"
+      | "LEASE_CONFLICT"
+      | "LEASE_REQUIRED"
+      | "STALE_GENERATION"
+      | "COMMAND_FAILED"
+      | "UNSUPPORTED_COMMAND";
+    message: string;
+    retryable: boolean;
+    details?: JsonValue;
+  };
+}
+
+export type SyntheticControlResponse =
+  | SyntheticControlSuccess
+  | SyntheticControlFailure;
+
+export interface SyntheticControlExecutionContext {
+  commandId: string;
+  expectedGeneration?: number;
+  leaseId?: string;
+  signal: AbortSignal;
+}
+
+/** The production owner implements this boundary; the protocol never persists a second state copy. */
+export interface SyntheticControlAuthority {
+  generation(): number | Promise<number>;
+  execute(
+    command: SyntheticControlCommand,
+    context: SyntheticControlExecutionContext,
+  ): Promise<JsonValue>;
+}
+
+export class SyntheticControlProtocolError extends Error {
+  readonly code: SyntheticControlFailure["error"]["code"];
+  readonly retryable: boolean;
+  readonly details?: JsonValue;
+  readonly generation?: number;
+
+  constructor(options: {
+    code: SyntheticControlFailure["error"]["code"];
+    message: string;
+    retryable?: boolean;
+    details?: JsonValue;
+    generation?: number;
+  }) {
+    super(options.message);
+    this.name = "SyntheticControlProtocolError";
+    this.code = options.code;
+    this.retryable = options.retryable ?? false;
+    this.details = options.details;
+    this.generation = options.generation;
+  }
+}

--- a/packages/shared/src/synthetic-control/types.ts
+++ b/packages/shared/src/synthetic-control/types.ts
@@ -2,6 +2,8 @@
 
 export const SYNTHETIC_CONTROL_VERSION = 1 as const;
 export const SYNTHETIC_CONTROL_PATH = "/__eliza/synthetic-control/v1" as const;
+export const SYNTHETIC_CONTROL_MAX_REQUEST_BYTES = 1_048_576 as const;
+export const SYNTHETIC_CONTROL_MAX_RESPONSE_BYTES = 4_194_304 as const;
 
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue =
@@ -51,6 +53,7 @@ export type SyntheticControlCommand =
 
 export interface SyntheticControlRequest {
   version: 1;
+  namespace: string;
   commandId: string;
   expectedGeneration?: number;
   leaseId?: string;
@@ -59,6 +62,7 @@ export interface SyntheticControlRequest {
 
 export interface SyntheticControlSuccess {
   version: 1;
+  namespace: string;
   commandId: string;
   ok: true;
   generation: number;
@@ -67,9 +71,10 @@ export interface SyntheticControlSuccess {
 
 export interface SyntheticControlFailure {
   version: 1;
+  namespace: string;
   commandId: string;
   ok: false;
-  generation: number;
+  generation: number | null;
   error: {
     code:
       | "AUTH_REQUIRED"
@@ -90,6 +95,7 @@ export type SyntheticControlResponse =
   | SyntheticControlFailure;
 
 export interface SyntheticControlExecutionContext {
+  namespace: string;
   commandId: string;
   expectedGeneration?: number;
   leaseId?: string;
@@ -117,8 +123,12 @@ export class SyntheticControlProtocolError extends Error {
     retryable?: boolean;
     details?: JsonValue;
     generation?: number;
+    cause?: unknown;
   }) {
-    super(options.message);
+    super(
+      options.message,
+      options.cause === undefined ? undefined : { cause: options.cause },
+    );
     this.name = "SyntheticControlProtocolError";
     this.code = options.code;
     this.retryable = options.retryable ?? false;


### PR DESCRIPTION
# Relates to

Refs #24078. Depends on #24075, #24076, and #24077 for the production manifest/reset, durable authority, and canonical ledger/fault contracts described below.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented below.

# Risks

Medium. This adds an authenticated subprocess control boundary used by scenario and Cloud test infrastructure. Strict decoding, generation fencing, dirty-session diagnostics, atomic teardown acknowledgements, timeout bounds, and fully redacted malformed-response failures constrain the risk. The deterministic fixture is deliberately not a second production state authority.

# Background

## What does this PR do?

- Publishes one versioned `@elizaos/shared/synthetic-control` command/result protocol, codec, authenticated client, transport handler, and reset-bound session lifecycle.
- Mounts that handler on the real Cloud control-plane mock process only when an explicit authority and token are injected.
- Gives scenario-runner and Cloud E2E consumers the same explicit client/session construction path.
- Exercises health, lease acquire/release, seed, reset, time advance, fault install/clear, snapshot, ledger query, and teardown across an independent Bun OS process.
- Makes invalid input, auth failure, authority failure, timeouts, concurrent/reset races, partial seed mutation, crash/restart, stale generations, and teardown acknowledgement deterministic and observable without fabricated success. Malformed provider replies are reduced to a fixed public error with no raw parser cause, and regression coverage checks message, stack, string, JSON, recursive-cause, and runtime-inspection representations for distinctive response secrets.

## What kind of change is this?

Feature: shared synthetic-world subprocess test protocol.

# Documentation changes needed?

Documentation was updated in shared, scenario-runner, and Cloud test-mocks READMEs. It explicitly separates this transport from the pending production authorities.

# Testing

## Where should a reviewer start?

Start with `packages/cloud/test-mocks/test/synthetic-control.subprocess.test.ts`, which launches the production control-plane mock server in an independent process and drives it through the shared scenario/Cloud client.

## Detailed testing steps

Exact head: `fb779138fe83211fce1dc87ad5e8214018184a92`

```bash
env PATH=/Users/shawwalters/.bun/bin:$PATH bun --conditions=eliza-source test packages/cloud/test-mocks/test/synthetic-control.subprocess.test.ts packages/cloud/test-mocks/test/control-plane.test.ts
# 17 pass, 0 fail, 90 assertions

env PATH=/Users/shawwalters/.bun/bin:$PATH bun run --cwd packages/shared typecheck
# pass

env PATH=/Users/shawwalters/.bun/bin:$PATH bun run --cwd packages/shared build
# pass

env PATH=/Users/shawwalters/.bun/bin:$PATH bun run --cwd packages/shared lint:check
# pass: 447 files, no fixes

env PATH=/Users/shawwalters/.bun/bin:$PATH bun run --cwd packages/cloud/test-mocks lint:check
# pass: 37 files; 2 unchanged warnings outside this PR's diff

env PATH=/Users/shawwalters/.bun/bin:$PATH bun run --cwd packages/scenario-runner build
# pass

env PATH=/Users/shawwalters/.bun/bin:$PATH bun run check:agents-claude
# pass: 160 CLAUDE.md/AGENTS.md pairs
```

# Evidence Gate

<!-- evidence-head:fb779138fe83211fce1dc87ad5e8214018184a92 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - subprocess protocol and test infrastructure only; no user flow
<!-- evidence-row:backend-logs -->
- [x] [24209-d88842b-synthetic-world-subprocess-backend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24209-d88842b-synthetic-world-subprocess-backend.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or network surface changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, provider, or agent behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [24209-d88842b-synthetic-world-subprocess-evidence.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24209-d88842b-synthetic-world-subprocess-evidence.json)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - this state-neutral transport does not invoke an LLM or change model selection.

## Backend + frontend logs

Backend proof includes the independent-process lifecycle artifact plus the exact-head `fb779138fe83211fce1dc87ad5e8214018184a92` command transcript above. Frontend is N/A because no frontend was changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/audio change.

## Known gaps / failures

- `bun run --cwd packages/cloud/test-mocks typecheck` still fails at unchanged `packages/cloud/test-mocks/src/control-plane/server.ts:274`: `Promise<boolean>` is not assignable to `Promise<void>`. This file is not changed by the PR; all #24078-introduced type errors are resolved.
- The fixture authority resets generation/state on process restart. Durable cross-process lease/generation authority and restart readback remain #24076; this PR does not claim durable shared state.
- The v1 manifest/reset receipt is a strict generic transport contract, not yet #24075's production catalog/schema contract.
- Fault and ledger payloads are transported and verified structurally, but canonical mutation/readback ownership remains #24077.
- Scenario-runner and Cloud E2E helpers are exported consumer surfaces, not yet composed into every CI/cloud lane. Integration remains open under #24078 and the dependency issues.
- No `bun run verify` claim is made: the focused package and subprocess gates above are the exact proof for this partial, dependency-blocked PR.

# AI-assisted contribution provenance

- AI provider/model: openai / gpt-5.6-sol
- Client / agent tooling: Codex Desktop
- Contribution skill revision: N/A - no contribution skill used
- Attribution status: self-reported
- Lane: `[synthetic-world-subprocess]`

<!-- ai-provenance: {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used","attribution":"self-reported","lane":"synthetic-world-subprocess"} -->




