### PR TITLE
fix(core): align CHOOSE_OPTION spec examples and parameter contract

### DIFF
--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -92,6 +92,8 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 		/truncateWellFormed/,
 		/text\s*=\s*text\.slice\(/,
 	],
+	"packages/prompts/specs/actions/core.json": [/"c0a8012e"/],
+	"packages/core/src/generated/action-docs.ts": [/"c0a8012e"/],
 	"packages/core/src/runtime/trajectory-recorder.ts": [
 		/resolveTrajectoryFieldCapBytes/,
 		/applyTrajectoryFieldCap/,

--- a/packages/core/src/features/basic-capabilities/actions/choice.test.ts
+++ b/packages/core/src/features/basic-capabilities/actions/choice.test.ts
@@ -49,6 +49,12 @@ function createMessage(): Memory {
 }
 
 describe("CHOOSE_OPTION action", () => {
+	it("advertises the canonical option parameter used by the action spec", () => {
+		expect(choiceAction.parameters?.map((parameter) => parameter.name)).toEqual(
+			["taskId", "option"],
+		);
+	});
+
 	it("accepts the complete task UUID as taskId", async () => {
 		const executed = { options: null as unknown | null };
 		const runtime = createRuntime(executed);

--- a/packages/core/src/features/basic-capabilities/actions/choice.test.ts
+++ b/packages/core/src/features/basic-capabilities/actions/choice.test.ts
@@ -68,6 +68,25 @@ describe("CHOOSE_OPTION action", () => {
 		expect(executed.options).toEqual({ option: "post" });
 	});
 
+	it("accepts option parameter conforming to canonical spec", async () => {
+		const executed = { options: null as unknown | null };
+		const runtime = createRuntime(executed);
+
+		const result = await choiceAction.handler?.(
+			runtime,
+			createMessage(),
+			undefined,
+			{
+				parameters: { taskId: TASK_ID, option: "post" },
+			} as HandlerOptions,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values?.selectedOption).toBe("post");
+		expect(result?.values?.taskId).toBe(TASK_ID);
+		expect(executed.options).toEqual({ option: "post" });
+	});
+
 	it("rejects an eight-character prefix instead of guessing between tasks", async () => {
 		const executed = { options: null as unknown | null };
 		const runtime = createRuntime(executed);

--- a/packages/core/src/features/basic-capabilities/actions/choice.ts
+++ b/packages/core/src/features/basic-capabilities/actions/choice.ts
@@ -368,7 +368,7 @@ export const choiceAction: Action = {
 			schema: { type: "string" as const, minLength: 1 },
 		},
 		{
-			name: "selectedOption",
+			name: "option",
 			description: "Option name to select for the pending task.",
 			required: true,
 			schema: { type: "string" as const, minLength: 1 },

--- a/packages/core/src/features/basic-capabilities/actions/choice.ts
+++ b/packages/core/src/features/basic-capabilities/actions/choice.ts
@@ -35,7 +35,10 @@ function _readChoiceParameters(
 			: {};
 	const taskId = params.taskId ?? message.content.taskId;
 	const selectedOption =
-		params.selectedOption ?? message.content.selectedOption;
+		params.selectedOption ??
+		params.option ??
+		message.content.selectedOption ??
+		message.content.option;
 	return {
 		taskId:
 			typeof taskId === "string" && taskId.trim() ? taskId.trim() : undefined,

--- a/packages/core/src/generated/action-docs.ts
+++ b/packages/core/src/generated/action-docs.ts
@@ -1006,7 +1006,7 @@ export const coreActionsSpec = {
 					schema: {
 						type: "string",
 					},
-					examples: ["c0a8012e"],
+					examples: ["aabbccdd-1111-2222-3333-444455556666"],
 					descriptionCompressed: "Pending task id.",
 				},
 				{
@@ -2627,7 +2627,7 @@ export const allActionsSpec = {
 					schema: {
 						type: "string",
 					},
-					examples: ["c0a8012e"],
+					examples: ["aabbccdd-1111-2222-3333-444455556666"],
 					descriptionCompressed: "Pending task id.",
 				},
 				{

--- a/packages/prompts/specs/actions/core.json
+++ b/packages/prompts/specs/actions/core.json
@@ -873,7 +873,7 @@
           "schema": {
             "type": "string"
           },
-          "examples": ["c0a8012e"],
+          "examples": ["aabbccdd-1111-2222-3333-444455556666"],
           "descriptionCompressed": "Pending task id."
         },
         {


### PR DESCRIPTION
## Summary

Align canonical `CHOOSE_OPTION` action spec examples and parameter contract with runtime handler expectations and prompt integrity invariants. The spec example now uses a complete UUID rather than a short prefix (`c0a8012e`), and `choiceAction` resolves the canonical `option` parameter name in addition to `selectedOption`.

Follow-up to #24152.

## Changes

- Update `CHOOSE_OPTION` canonical prompt spec in `packages/prompts/specs/actions/core.json` to replace the 8-character example `"c0a8012e"` with canonical complete UUID `"aabbccdd-1111-2222-3333-444455556666"`.
- Support `params.option` in `packages/core/src/features/basic-capabilities/actions/choice.ts` alongside `params.selectedOption` so LLM tool calls matching the canonical spec schema resolve successfully.
- Regenerate model-facing action docs in `packages/core/src/generated/action-docs.ts` via prompts build codegen.
- Add unit test in `packages/core/src/features/basic-capabilities/actions/choice.test.ts` verifying selection via the canonical `option` parameter.
- Extend `packages/core/src/__tests__/prompt-integrity-policy.test.ts` to audit `core.json` and `action-docs.ts` against short-ID regressions.

## Exact-head verification

Base: `c3639e22c0af5f3c8c034c076294a4d8b739503e`  
Head: `8c2df62db47ca91940fb11c37ad878043e33e5fa`

| Gate | Result |
| --- | --- |
| focused choice action tests (`choice.test.ts`) | 8/8 passed |
| prompt integrity policy audit (`prompt-integrity-policy.test.ts`) | 3/3 passed (550 assertions) |
| scoped Biome check | clean |
| `bun run --cwd packages/core typecheck` | passed |
| `bun run --cwd packages/prompts build:action-docs` | clean |
| `git diff --check` | clean |

## Reviewer start

Start at `packages/prompts/specs/actions/core.json:876` for the UUID parameter example, then `packages/core/src/features/basic-capabilities/actions/choice.ts:38` for parameter resolution. `choice.test.ts` covers parameter compatibility and prefix rejection.

## Risks

Low. Non-breaking parameter widening accepts both `option` and `selectedOption`. Preserving complete UUIDs eliminates prefix ambiguity and hash collision risks in model-facing menus.

## Attribution

- Analysis, spec alignment, handler compatibility, and prompt integrity regression guards by Antigravity / Gemini 3.7.

## Evidence Gate

<!-- evidence-head:8c2df62db47ca91940fb11c37ad878043e33e5fa -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - core action contract and prompts spec have no rendered UI surface`.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - core action contract and prompts spec have no rendered UI surface`.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - deterministic choice and prompt-integrity suites exercise the complete changed boundary`.

<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - deterministic unit tests cover parameter resolution and catalog generation`.

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs `N/A - no frontend path changes`.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - canonical prompt spec schema alignment; deterministic action tests pass`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - codegen output packages/core/src/generated/action-docs.ts is verified in-tree`.

<!-- evidence-row:ocr-review -->
- [x] OCR review `N/A - no rendered visual text changes`.

# Documentation changes needed?

No. Regenerated canonical `action-docs.ts` via the standard prompts generator.

### Maintainer repair receipt

The submitted head accepted canonical `option` but still advertised runtime parameter `selectedOption`. Exact repair `8c2df62db47ca91940fb11c37ad878043e33e5fa` changes the public action parameter to `option`, retains the legacy reader alias, and adds a direct runtime-schema regression. Pinned Bun 1.3.14 focused suites: 12/12, 597 assertions; five-file Biome and diff-check pass.