### PR TITLE
fix(agent): swallow detached promise rejections in push fan-out

### DIFF
--- a/packages/agent/src/services/push/notification-push-service.test.ts
+++ b/packages/agent/src/services/push/notification-push-service.test.ts
@@ -12,8 +12,8 @@ import type {
   AgentNotification,
   IAgentRuntime,
 } from "@elizaos/core";
-import { NOTIFICATION_STREAM, ServiceType } from "@elizaos/core";
-import { beforeEach, describe, expect, it } from "vitest";
+import { logger, NOTIFICATION_STREAM, ServiceType } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NotificationPushService } from "./notification-push-service.ts";
 import { PushTokenRegistry } from "./push-token-registry.ts";
 import {
@@ -73,6 +73,7 @@ function makeHarness(): Harness {
     },
     deleteCache: async (key: string): Promise<boolean> => cache.delete(key),
     getService: (t: string) => (t === ServiceType.AGENT_EVENT ? bus : null),
+    reportError: () => {},
   } as unknown as IAgentRuntime;
 
   const emitRaw = (event: AgentEventPayload) => {
@@ -253,9 +254,9 @@ describe("NotificationPushService", () => {
       providers: { ios, android },
     });
     await service.attach();
-    const listSpy = vi.spyOn(h.registry, "list").mockRejectedValueOnce(
-      new Error("db down"),
-    );
+    const listSpy = vi
+      .spyOn(h.registry, "list")
+      .mockRejectedValueOnce(new Error("db down"));
     const loggerSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
     const reportErrorSpy = vi
       .spyOn(h.runtime, "reportError")

--- a/packages/agent/src/services/push/notification-push-service.test.ts
+++ b/packages/agent/src/services/push/notification-push-service.test.ts
@@ -245,6 +245,70 @@ describe("NotificationPushService", () => {
     expect(h.listenerCount()).toBe(0);
   });
 
+  it("logs and drops fan-out failures from registry list()", async () => {
+    const ios = new FakeProvider("apns", true);
+    const android = new FakeProvider("fcm", true);
+    const service = new NotificationPushService(h.runtime, {
+      registry: h.registry,
+      providers: { ios, android },
+    });
+    await service.attach();
+    const listSpy = vi.spyOn(h.registry, "list").mockRejectedValueOnce(
+      new Error("db down"),
+    );
+    const loggerSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const reportErrorSpy = vi
+      .spyOn(h.runtime, "reportError")
+      .mockImplementation(() => {});
+
+    h.emit(notification());
+    await flush();
+
+    expect(listSpy).toHaveBeenCalledTimes(1);
+    expect(loggerSpy).toHaveBeenCalledWith(
+      { src: "service:notification_push", error: expect.any(Error) },
+      "[NotificationPushService] fan-out failed",
+    );
+    expect(reportErrorSpy).toHaveBeenCalledWith(
+      "NotificationPushService.fanOut",
+      expect.any(Error),
+      { stream: NOTIFICATION_STREAM },
+    );
+    expect(ios.sent).toHaveLength(0);
+  });
+
+  it("logs and drops fan-out failures from dead-token unregister()", async () => {
+    const ios = new FakeProvider("apns", true, new Set(["dead-token"]));
+    const android = new FakeProvider("fcm", false);
+    const service = new NotificationPushService(h.runtime, {
+      registry: h.registry,
+      providers: { ios, android },
+    });
+    await service.attach();
+    await h.registry.register("ios", "dead-token");
+    const unregisterSpy = vi
+      .spyOn(h.registry, "unregister")
+      .mockRejectedValueOnce(new Error("durable write rejected"));
+    const loggerSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const reportErrorSpy = vi
+      .spyOn(h.runtime, "reportError")
+      .mockImplementation(() => {});
+
+    h.emit(notification());
+    await flush();
+
+    expect(unregisterSpy).toHaveBeenCalledWith("dead-token");
+    expect(loggerSpy).toHaveBeenCalledWith(
+      { src: "service:notification_push", error: expect.any(Error) },
+      "[NotificationPushService] fan-out failed",
+    );
+    expect(reportErrorSpy).toHaveBeenCalledWith(
+      "NotificationPushService.fanOut",
+      expect.any(Error),
+      { stream: NOTIFICATION_STREAM },
+    );
+  });
+
   it("starts dormant (no throw) when there is no event bus", async () => {
     const noBusRuntime = {
       ...h.runtime,

--- a/packages/agent/src/services/push/notification-push-service.ts
+++ b/packages/agent/src/services/push/notification-push-service.ts
@@ -127,7 +127,25 @@ export class NotificationPushService extends Service {
 
     this.unsubscribe = bus.subscribe((event) => {
       if (event.stream !== NOTIFICATION_STREAM) return;
-      void this.onNotification(event);
+      void (async () => {
+        try {
+          await this.onNotification(event);
+        } catch (error) {
+          // error-policy:J7 best-effort fan-out must not escape as an
+          // unhandled rejection; log + report and drop the event.
+          logger.error(
+            { src: "service:notification_push", error },
+            "[NotificationPushService] fan-out failed",
+          );
+          if (typeof this.runtime.reportError === "function") {
+            this.runtime.reportError(
+              "NotificationPushService.fanOut",
+              error as Error,
+              { stream: NOTIFICATION_STREAM },
+            );
+          }
+        }
+      })();
     });
   }
 


### PR DESCRIPTION
Closes #24086

## Summary

Contain detached notification push fan-out rejections at the event-listener boundary so registry reads and dead-token cleanup failures cannot become process-level unhandled rejections. The boundary logs the failure and reports it through `runtime.reportError` under error-policy J7.

## Verification

Exact head: `10ddc2a73a6534b3ca16ae01f834dd04580f16c9`

- Focused Vitest: `packages/agent/src/services/push/notification-push-service.test.ts` — 10/10 passed.
- The two regressions exercise rejected `registry.list()` and rejected dead-token `unregister()` through the real subscribed listener.
- Scoped Biome and `git diff --check`: clean.
- Package typecheck was attempted in a sparse disposable checkout but is not evidence: unrelated omitted workspace packages make that environment unresolved.

## Risk

Low and bounded to the detached event-listener boundary. Per-token provider failures retain their existing handling; the new outer boundary only handles failures that otherwise have no observer. `runtime.reportError` is the runtime's no-throw diagnostic seam.

## Evidence Gate

<!-- evidence-head:10ddc2a73a6534b3ca16ae01f834dd04580f16c9 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - no rendered UI surface; this is a background service rejection boundary.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - no rendered UI surface; this is a background service rejection boundary.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no interactive UI flow; the exact event-listener boundary is exercised deterministically.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs:

<details><summary>Exact-head focused rejection-boundary run</summary>

```text
RUN v4.1.10 /private/tmp/eliza-agent-runtime-prs
Test Files 1 passed (1); Tests 10 passed (10)
Both registry.list and dead-token unregister rejections were contained, logged, and reported through runtime.reportError.
```

</details>

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend path is involved.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no model, prompt, provider, action, or evaluator behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no persisted domain artifact changes; failures are injected before delivery.`
<!-- evidence-row:ocr-review -->
- [x] OCR review: `N/A - no rendered visual text changes.`

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes — exact-head review and test-harness repair used AI; original implementation provenance was not supplied by its author.
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5 for exact-head review and test-harness repair.
<!-- attribution-row:client -->
- Agent tooling: Codex desktop app.
<!-- attribution-row:skill-revision -->
- Skill path: N/A - direct repository review; no contribution skill was invoked.
<!-- attribution-row:status -->
- Provenance status: self-reported


Independent maintainer receipt: source/caller review confirms the event bus does not await listener promises, so this J7 detached boundary is required; `runtime.reportError` is explicitly no-throw. Conflict-free rebase preserved combined patch-id `75e00f8d2d382155b40e4997a1353add9bc0f377`. Exact head `10ddc2a73a6534b3ca16ae01f834dd04580f16c9`: Biome clean on both touched files, `git diff --check` clean, evidence gate pending the updated marker. Independent local test collection stopped before execution because the shared `uuid@14` workspace link is broken; the repair agent’s 10/10 exact-patch run remains the execution receipt.
Current-base maintainer validation at exact head `10ddc2a73a6534b3ca16ae01f834dd04580f16c9` (base `a610d06618957a2880535c072a3c5dece76df16f`): focused Vitest 10/10 passed, scoped Biome passed, and `git diff --check` passed. Package typecheck was attempted and remains non-evidence because this isolated worktree lacks unrelated workspace build/dependency links; no diagnostic referenced either changed file.
