### PR TITLE
fix(cloud-test-mocks): preserve void settle adapter

### DIFF
--- a/packages/cloud/test-mocks/src/control-plane/server.ts
+++ b/packages/cloud/test-mocks/src/control-plane/server.ts
@@ -267,16 +267,17 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
             lifecycle_execution_generation: job.execution_generation,
           });
         };
-        const settle = (
+        const settle = async (
           job: ClaimedJob,
           jobResult: Record<string, unknown>,
-        ): Promise<void> =>
-          jobsRepository.settleExecution(
+        ): Promise<void> => {
+          await jobsRepository.settleExecution(
             job,
             "completed",
             { result: jobResult },
             MOCK_EXECUTION_OWNER_ID,
           );
+        };
         // Provision/delete are reimplemented against the Hetzner mock; the
         // remaining lifecycle jobs are reproduced as direct agent_sandboxes
         // row transitions (mirroring the real handlers' DB effects), which is


### PR DESCRIPTION
# Relates to

Closes #24218. This is the one-file Cloud test-mock type-baseline repair exposed by #23333 and observed in Cloud Tests run `32536609862`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is based on the latest `origin/develop`.
- [x] The exact red diagnostic was reproduced before the patch.
- [x] Frozen install, server build, package gates, the complete Cloud workspace gate, diff hygiene, and independent review were run.
- [x] The change preserves runtime rejection behavior and only restores the local `Promise<void>` adapter contract.

# Sync with develop

- [x] Exact base: `origin/develop@9c1fc32c0def7f3da4d40d54d88ac343e24c3a97`.
- [x] A final fetch immediately before push found zero newer `develop` commits and zero conflicts.

# Risks

Very low. The only semantic risk is accidentally swallowing a failed settlement or a meaningful fence result. The adapter still `await`s the repository call, so rejection propagation is unchanged. This call supplies no `additionalFence`, so the repository either returns `true` or rejects; its success boolean carries no state needed by the mock call sites.

# Background

## What does this PR do?

- Converts the expression-bodied `settle(...): Promise<void>` helper into an async void adapter that awaits `JobsRepository.settleExecution()` without forwarding its new boolean return value.
- Fixes the sole `@elizaos/cloud-test-mocks` TypeScript error that currently stops the Cloud Tests `lint-and-types` job.
- Allows the dependent real-PostgreSQL Cloud test lane to start after this repair is merged; it does not retroactively change or certify the currently blocked #24062 hosted run.
- Changes no repository return contract, mock state transition, provider, model, schema, migration, deployment, or configuration.

## What kind of change is this?

Bug fix: restore an intentional local `Promise<void>` adapter after the underlying repository method began returning `Promise<boolean>` in #23333.

# Documentation changes needed?

No. This is an internal test-support contract repair with no public API or user-facing behavior change.

# Testing

## Where should a reviewer start?

Start at `packages/cloud/test-mocks/src/control-plane/server.ts` around the local `settle` adapter, then compare `JobsRepository.settleExecution()` in `packages/cloud/shared/src/db/repositories/jobs.ts`. Confirm that this call does not supply `additionalFence` and that rejections continue into the existing `processDbBackedJobs` catch.

## Detailed testing steps

```bash
bun install --frozen-lockfile
bun run build:server
bun run --cwd packages/cloud/test-mocks typecheck
bun run --cwd packages/cloud/test-mocks lint:check
bun run --cwd packages/cloud/test-mocks test
bun run verify:cloud
git diff --check origin/develop...HEAD
bun run verify
```

Exact-head results at `102fe8a769344887675fa1762b3a90990457197d`: the frozen install completed without tracked changes; server build passed 55/55 tasks; package typecheck passed; package lint reported no error and two inherited warnings outside the changed lines; package tests passed 88/88 with 479 assertions across 16 files; and `verify:cloud` passed 83/83 tasks. Diff hygiene and `AGENTS.md`/`CLAUDE.md` parity passed. Independent final review found no P0-P3 issue and separately confirmed typecheck, test, lint, and rejection semantics.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:102fe8a769344887675fa1762b3a90990457197d -->

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - Internal Cloud test-support TypeScript change with no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Internal Cloud test-support TypeScript change with no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - No interactive or rendered user flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - No production backend runtime path changed; exact red/green typecheck and Cloud workspace results are captured in the domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - No frontend request, console, network, or state path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - No model/provider request or prompt-output behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [24218-cloud-test-mocks-settle-domain-102fe8a.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24218-cloud-test-mocks-settle-domain-102fe8a.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - No visual surface or visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - No LLM path, prompt, provider, model, or output behavior is involved.

## Backend + frontend logs

N/A - This changes an internal test mock rather than a production request path. The applicable proof is the reproduced TypeScript failure, exact-head package gates, and full `verify:cloud` result in the attached domain artifact.

## Screenshots (before / after) + video walkthrough

N/A - No UI files, rendered surface, or interactive flow changed.

## Audio / voice walkthrough

N/A - No audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- `bun run verify` reaches the monorepo fan-out and exits in untouched `@elizaos/agent#lint:check`; no Cloud test-mocks file fails. The exact package typecheck/lint/test gates and the full 15-package `verify:cloud` workflow pass.
- GitHub-hosted Cloud Tests have not yet exercised this branch at PR creation time. The previously observed run `32536609862` failed at this exact diagnostic and skipped its dependent real-PostgreSQL job; this PR only removes that gate after merge.
- No provider, deployment, production service, live database, secret, migration, model call, configuration, or infrastructure mutation was performed.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@9c1fc32c0def7f3da4d40d54d88ac343e24c3a97:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-cloud-test-mocks-settle-baseline]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"elizaOS/eliza@9c1fc32c0def7f3da4d40d54d88ac343e24c3a97:packages/skills/skills/contribute-to-eliza"} -->