### PR TITLE
test(wechat): add protocol-faithful proxy simulator

### DIFF
--- a/packages/cloud/test-mocks/AGENTS.md
+++ b/packages/cloud/test-mocks/AGENTS.md
@@ -25,6 +25,9 @@ exits.
   `Job`/`JobStatus`/`JobType`/`Sandbox`/`SandboxStatus` types.
 - `src/steward/` (export `./steward`) — stateful loopback mock for authenticated
   Steward platform-user deactivation and deletion calls used by account lifecycle E2E.
+- `src/wechat/` (export `./wechat`) — resettable WeChat proxy simulator for the
+  production connector client. It owns seeded accounts, contacts, webhook registrations,
+  outbound-message readback, protocol faults, request observations, and inbound webhook delivery.
 - `src/fetch-server.ts` — shared `startFetchServer(fetch, opts)`; uses
   `Bun.serve` when running under Bun, falls back to a `node:http` adapter
   otherwise.
@@ -89,6 +92,9 @@ teardown.
   (default 8791), `HOST`, `CONTROL_PLANE_TICK_MS`, `HCLOUD_API_BASE_URL`.
 - **Mockoon files are stateless** read-only fixtures — they do not share state
   with the Hono mocks; use the Hono mocks when behavior depends on prior writes.
+- **WeChat is loopback-only.** `startWechatProxyMock()` returns an `http://127.0.0.1`
+  URL accepted by the production client only for literal loopback hosts. Authentication,
+  device/account headers, outbound effects, and webhook registration still cross real HTTP.
 
 ## Managed provider contract suites
 

--- a/packages/cloud/test-mocks/CLAUDE.md
+++ b/packages/cloud/test-mocks/CLAUDE.md
@@ -25,6 +25,9 @@ exits.
   `Job`/`JobStatus`/`JobType`/`Sandbox`/`SandboxStatus` types.
 - `src/steward/` (export `./steward`) — stateful loopback mock for authenticated
   Steward platform-user deactivation and deletion calls used by account lifecycle E2E.
+- `src/wechat/` (export `./wechat`) — resettable WeChat proxy simulator for the
+  production connector client. It owns seeded accounts, contacts, webhook registrations,
+  outbound-message readback, protocol faults, request observations, and inbound webhook delivery.
 - `src/fetch-server.ts` — shared `startFetchServer(fetch, opts)`; uses
   `Bun.serve` when running under Bun, falls back to a `node:http` adapter
   otherwise.
@@ -89,6 +92,9 @@ teardown.
   (default 8791), `HOST`, `CONTROL_PLANE_TICK_MS`, `HCLOUD_API_BASE_URL`.
 - **Mockoon files are stateless** read-only fixtures — they do not share state
   with the Hono mocks; use the Hono mocks when behavior depends on prior writes.
+- **WeChat is loopback-only.** `startWechatProxyMock()` returns an `http://127.0.0.1`
+  URL accepted by the production client only for literal loopback hosts. Authentication,
+  device/account headers, outbound effects, and webhook registration still cross real HTTP.
 
 ## Managed provider contract suites
 

--- a/packages/cloud/test-mocks/README.md
+++ b/packages/cloud/test-mocks/README.md
@@ -86,6 +86,12 @@ webhook registrations, and outbound text/image effects. `deliverWebhook()`
 drives the real authenticated callback server; `enqueueFault()` covers rate
 limits, malformed responses, and latency without replacing client methods.
 
+This mock implements only the third-party JSON proxy contract used by
+`plugin-wechat`. It does not claim compatibility with official WeChat XML
+webhooks, SHA signature/timestamp/nonce replay checks, AES encrypted payloads
+or key rotation, remote media fetching, or live WeChat acceptance. Requests
+must be authenticated JSON and both request and response bodies are bounded.
+
 ### Run standalone
 
 ```bash

--- a/packages/cloud/test-mocks/README.md
+++ b/packages/cloud/test-mocks/README.md
@@ -76,6 +76,16 @@ Implements the subset of the Hetzner Cloud API that the autoscaler client in
 
 State is kept in memory and resets when the process exits.
 
+## WeChat proxy mock
+
+`startWechatProxyMock()` from `@elizaos/cloud-test-mocks/wechat` starts a
+resettable loopback HTTP implementation of the proxy protocol consumed by the
+production WeChat connector. Seed accounts and contacts, point `ProxyClient`
+at the returned URL, then inspect `snapshot()` for authenticated requests,
+webhook registrations, and outbound text/image effects. `deliverWebhook()`
+drives the real authenticated callback server; `enqueueFault()` covers rate
+limits, malformed responses, and latency without replacing client methods.
+
 ### Run standalone
 
 ```bash

--- a/packages/cloud/test-mocks/package.json
+++ b/packages/cloud/test-mocks/package.json
@@ -9,6 +9,7 @@
     "./hetzner": "./src/hetzner/index.ts",
     "./control-plane": "./src/control-plane/index.ts",
     "./steward": "./src/steward/index.ts",
+    "./wechat": "./src/wechat/index.ts",
     "./provider-contract": "./src/provider-contract/index.ts"
   },
   "bin": {
@@ -33,6 +34,7 @@
   "devDependencies": {
     "@elizaos/cloud-sdk": "workspace:*",
     "@elizaos/plugin-github": "workspace:*",
+    "@elizaos/plugin-wechat": "workspace:*",
     "@elizaos/plugin-whatsapp": "workspace:*",
     "@typescript/native": "npm:typescript@^7.0.2",
     "bun-types": "*"

--- a/packages/cloud/test-mocks/src/index.ts
+++ b/packages/cloud/test-mocks/src/index.ts
@@ -3,3 +3,4 @@ export * as controlPlane from "./control-plane";
 export * from "./hetzner";
 export * as providerContract from "./provider-contract";
 export * from "./steward";
+export * as wechat from "./wechat";

--- a/packages/cloud/test-mocks/src/wechat/index.ts
+++ b/packages/cloud/test-mocks/src/wechat/index.ts
@@ -1,0 +1,4 @@
+/** Exports the resettable WeChat proxy simulator and its protocol contracts. */
+
+export * from "./server.js";
+export * from "./types.js";

--- a/packages/cloud/test-mocks/src/wechat/server.ts
+++ b/packages/cloud/test-mocks/src/wechat/server.ts
@@ -153,7 +153,7 @@ export async function startWechatProxyMock(
           return envelope(1400, "invalid webhookUrl", undefined, 400);
         }
         account.webhookUrl = webhookUrl;
-        return envelope(SUCCESS, "registered");
+        return envelope(SUCCESS, "registered", { registered: true });
       }
       case "/api/send-text": {
         const to = readString(body, "to");
@@ -167,7 +167,10 @@ export async function startWechatProxyMock(
           to,
           text,
         });
-        return envelope(SUCCESS, "sent");
+        return envelope(SUCCESS, "sent", {
+          accepted: true,
+          operation: "sendText",
+        });
       }
       case "/api/send-image": {
         const to = readString(body, "to");
@@ -182,7 +185,10 @@ export async function startWechatProxyMock(
           imagePath,
           text: readString(body, "text") ?? undefined,
         });
-        return envelope(SUCCESS, "sent");
+        return envelope(SUCCESS, "sent", {
+          accepted: true,
+          operation: "sendImage",
+        });
       }
       default:
         return envelope(1404, "not found", undefined, 404);
@@ -351,6 +357,8 @@ function isAllowedWebhookUrl(value: string, accountId: string): boolean {
       (url.hostname === "127.0.0.1" || url.hostname === "[::1]") &&
       url.username === "" &&
       url.password === "" &&
+      url.search === "" &&
+      url.hash === "" &&
       url.pathname === `/webhook/wechat/${encodeURIComponent(accountId)}`
     );
   } catch {

--- a/packages/cloud/test-mocks/src/wechat/server.ts
+++ b/packages/cloud/test-mocks/src/wechat/server.ts
@@ -1,0 +1,280 @@
+/** Hosts a resettable WeChat proxy protocol simulator that real connector clients reach over loopback HTTP. */
+
+import { startFetchServer } from "../fetch-server.js";
+import type {
+  WechatProxyAccountSeed,
+  WechatProxyFault,
+  WechatProxyOutboundMessage,
+  WechatProxyRequestObservation,
+  WechatProxySeed,
+  WechatProxySnapshot,
+  WechatWebhookDeliveryOptions,
+} from "./types.js";
+
+const SUCCESS = 1000;
+
+interface AccountState extends WechatProxyAccountSeed {
+  deviceType: "ipad" | "mac";
+  loginState: "waiting" | "need_verify" | "logged_in";
+  friends: Array<{ wxid: string; name: string }>;
+  chatrooms: Array<{ wxid: string; name: string }>;
+  webhookUrl?: string;
+}
+
+export interface RunningWechatProxyMock {
+  url: string;
+  port: number;
+  enqueueFault(path: string, fault: WechatProxyFault): void;
+  reset(seed?: WechatProxySeed): void;
+  snapshot(): WechatProxySnapshot;
+  deliverWebhook(
+    accountId: string,
+    payload: unknown,
+    options?: WechatWebhookDeliveryOptions,
+  ): Promise<Response>;
+  stop(): Promise<void>;
+}
+
+export async function startWechatProxyMock(
+  seed: WechatProxySeed,
+): Promise<RunningWechatProxyMock> {
+  let generation = 0;
+  let currentSeed = cloneSeed(seed);
+  let accounts = buildAccounts(currentSeed);
+  let sequence = 0;
+  let requests: WechatProxyRequestObservation[] = [];
+  let outboundMessages: WechatProxyOutboundMessage[] = [];
+  const faults = new Map<string, WechatProxyFault[]>();
+
+  const server = await startFetchServer(async (request) => {
+    const url = new URL(request.url);
+    const accountId = request.headers.get("x-account-id");
+    const deviceType = request.headers.get("x-device-type");
+    const account = accountId ? accounts.get(accountId) : undefined;
+    const authenticated = Boolean(
+      account &&
+        request.headers.get("x-api-key") === account.apiKey &&
+        deviceType === account.deviceType,
+    );
+    const body = await readJsonBody(request);
+    requests.push({
+      sequence: ++sequence,
+      accountId,
+      deviceType,
+      method: request.method,
+      path: url.pathname,
+      body,
+      authenticated,
+    });
+
+    if (request.method !== "POST") {
+      return envelope(1405, "method not allowed", undefined, 405);
+    }
+    if (!authenticated || !account) {
+      return envelope(1401, "unauthorized", undefined, 401);
+    }
+
+    const queued = faults.get(url.pathname);
+    const fault = queued?.shift();
+    if (fault) {
+      if (fault.delayMs) await delay(fault.delayMs);
+      const headers = new Headers({ "content-type": "application/json" });
+      if (fault.retryAfter !== undefined) {
+        headers.set("retry-after", fault.retryAfter);
+      }
+      const responseBody =
+        fault.rawBody ??
+        JSON.stringify(fault.body ?? { code: 1500, message: "seeded fault" });
+      return new Response(responseBody, {
+        status: fault.status ?? 500,
+        headers,
+      });
+    }
+
+    switch (url.pathname) {
+      case "/api/status":
+        return envelope(SUCCESS, "ok", {
+          valid: true,
+          loginState: account.loginState,
+          wcId: account.wcId,
+          nickName: account.nickName,
+        });
+      case "/api/qrcode":
+        return envelope(SUCCESS, "ok", {
+          qrCodeUrl: `https://wechat.mock/qr/${encodeURIComponent(account.accountId)}`,
+        });
+      case "/api/check-login":
+        return envelope(SUCCESS, "ok", {
+          status: account.loginState,
+          wcId: account.wcId,
+          nickName: account.nickName,
+        });
+      case "/api/contacts":
+        return envelope(SUCCESS, "ok", {
+          friends: account.friends,
+          chatrooms: account.chatrooms,
+        });
+      case "/api/webhook/register": {
+        const webhookUrl = readString(body, "webhookUrl");
+        if (
+          !webhookUrl ||
+          !isAllowedWebhookUrl(webhookUrl, account.accountId)
+        ) {
+          return envelope(1400, "invalid webhookUrl", undefined, 400);
+        }
+        account.webhookUrl = webhookUrl;
+        return envelope(SUCCESS, "registered");
+      }
+      case "/api/send-text": {
+        const to = readString(body, "to");
+        const text = readString(body, "text");
+        if (!to || !text)
+          return envelope(1400, "invalid text message", undefined, 400);
+        outboundMessages.push({
+          sequence: ++sequence,
+          accountId: account.accountId,
+          kind: "text",
+          to,
+          text,
+        });
+        return envelope(SUCCESS, "sent");
+      }
+      case "/api/send-image": {
+        const to = readString(body, "to");
+        const imagePath = readString(body, "imagePath");
+        if (!to || !imagePath)
+          return envelope(1400, "invalid image message", undefined, 400);
+        outboundMessages.push({
+          sequence: ++sequence,
+          accountId: account.accountId,
+          kind: "image",
+          to,
+          imagePath,
+          text: readString(body, "text") ?? undefined,
+        });
+        return envelope(SUCCESS, "sent");
+      }
+      default:
+        return envelope(1404, "not found", undefined, 404);
+    }
+  });
+
+  return {
+    url: `http://${server.hostname}:${server.port}`,
+    port: server.port,
+    enqueueFault(path, fault) {
+      const queue = faults.get(path) ?? [];
+      queue.push({ ...fault });
+      faults.set(path, queue);
+    },
+    reset(nextSeed = currentSeed) {
+      currentSeed = cloneSeed(nextSeed);
+      accounts = buildAccounts(currentSeed);
+      requests = [];
+      outboundMessages = [];
+      faults.clear();
+      sequence = 0;
+      generation += 1;
+    },
+    snapshot() {
+      return {
+        generation,
+        requests: structuredClone(requests),
+        outboundMessages: structuredClone(outboundMessages),
+        webhooks: Object.fromEntries(
+          [...accounts].flatMap(([accountId, account]) =>
+            account.webhookUrl ? [[accountId, account.webhookUrl]] : [],
+          ),
+        ),
+      };
+    },
+    async deliverWebhook(accountId, payload, options = {}) {
+      const account = accounts.get(accountId);
+      if (!account?.webhookUrl) {
+        throw new Error(
+          `WeChat mock account '${accountId}' has no registered webhook`,
+        );
+      }
+      return fetch(account.webhookUrl, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": options.apiKey ?? account.apiKey,
+        },
+        body: JSON.stringify(payload),
+      });
+    },
+    stop: server.stop,
+  };
+}
+
+function buildAccounts(seed: WechatProxySeed): Map<string, AccountState> {
+  if (seed.accounts.length === 0)
+    throw new Error("WeChat proxy seed requires an account");
+  const accounts = new Map<string, AccountState>();
+  for (const entry of seed.accounts) {
+    if (!entry.accountId.trim() || !entry.apiKey)
+      throw new Error("invalid WeChat account seed");
+    if (accounts.has(entry.accountId))
+      throw new Error("duplicate WeChat account seed");
+    accounts.set(entry.accountId, {
+      ...structuredClone(entry),
+      deviceType: entry.deviceType ?? "ipad",
+      loginState: entry.loginState ?? "logged_in",
+      friends: structuredClone(entry.friends ?? []),
+      chatrooms: structuredClone(entry.chatrooms ?? []),
+    });
+  }
+  return accounts;
+}
+
+function cloneSeed(seed: WechatProxySeed): WechatProxySeed {
+  return structuredClone(seed);
+}
+
+async function readJsonBody(request: Request): Promise<unknown> {
+  const text = await request.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function readString(body: unknown, key: string): string | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  const value = (body as Record<string, unknown>)[key];
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function envelope(
+  code: number,
+  message: string,
+  data?: unknown,
+  status = 200,
+): Response {
+  return Response.json(
+    data === undefined ? { code, message } : { code, message, data },
+    { status },
+  );
+}
+
+function isAllowedWebhookUrl(value: string, accountId: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "http:" &&
+      (url.hostname === "127.0.0.1" || url.hostname === "[::1]") &&
+      url.username === "" &&
+      url.password === "" &&
+      url.pathname === `/webhook/wechat/${encodeURIComponent(accountId)}`
+    );
+  } catch {
+    return false;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/cloud/test-mocks/src/wechat/server.ts
+++ b/packages/cloud/test-mocks/src/wechat/server.ts
@@ -12,6 +12,7 @@ import type {
 } from "./types.js";
 
 const SUCCESS = 1000;
+const MAX_REQUEST_BODY_BYTES = 1024 * 1024;
 
 interface AccountState extends WechatProxyAccountSeed {
   deviceType: "ipad" | "mac";
@@ -47,6 +48,7 @@ export async function startWechatProxyMock(
   const faults = new Map<string, WechatProxyFault[]>();
 
   const server = await startFetchServer(async (request) => {
+    const requestGeneration = generation;
     const url = new URL(request.url);
     const accountId = request.headers.get("x-account-id");
     const deviceType = request.headers.get("x-device-type");
@@ -56,28 +58,56 @@ export async function startWechatProxyMock(
         request.headers.get("x-api-key") === account.apiKey &&
         deviceType === account.deviceType,
     );
-    const body = await readJsonBody(request);
-    requests.push({
+    const observation: WechatProxyRequestObservation = {
       sequence: ++sequence,
       accountId,
       deviceType,
       method: request.method,
       path: url.pathname,
-      body,
+      body: null,
       authenticated,
-    });
-
+    };
+    requests.push(observation);
     if (request.method !== "POST") {
       return envelope(1405, "method not allowed", undefined, 405);
     }
     if (!authenticated || !account) {
       return envelope(1401, "unauthorized", undefined, 401);
     }
+    if (
+      !isJsonMediaType(request.headers.get("content-type")) ||
+      !isIdentityEncoding(request.headers.get("content-encoding"))
+    ) {
+      return envelope(
+        1415,
+        "content-type must be application/json",
+        undefined,
+        415,
+      );
+    }
+
+    const parsedBody = await readJsonBody(request);
+    observation.body = parsedBody.ok ? parsedBody.value : null;
+    if (!parsedBody.ok) {
+      return envelope(
+        parsedBody.tooLarge ? 1413 : 1400,
+        parsedBody.tooLarge ? "payload too large" : "invalid JSON",
+        undefined,
+        parsedBody.tooLarge ? 413 : 400,
+      );
+    }
+    const body = parsedBody.value;
+    if (requestGeneration !== generation) {
+      return envelope(1409, "stale simulator generation", undefined, 409);
+    }
 
     const queued = faults.get(url.pathname);
     const fault = queued?.shift();
     if (fault) {
       if (fault.delayMs) await delay(fault.delayMs);
+      if (requestGeneration !== generation) {
+        return envelope(1409, "stale simulator generation", undefined, 409);
+      }
       const headers = new Headers({ "content-type": "application/json" });
       if (fault.retryAfter !== undefined) {
         headers.set("retry-after", fault.retryAfter);
@@ -195,6 +225,18 @@ export async function startWechatProxyMock(
           `WeChat mock account '${accountId}' has no registered webhook`,
         );
       }
+      const timeoutMs = options.timeoutMs ?? 1000;
+      if (
+        !Number.isSafeInteger(timeoutMs) ||
+        timeoutMs <= 0 ||
+        timeoutMs > 30_000
+      ) {
+        throw new Error("WeChat webhook timeoutMs must be between 1 and 30000");
+      }
+      const timeoutSignal = AbortSignal.timeout(timeoutMs);
+      const signal = options.signal
+        ? AbortSignal.any([options.signal, timeoutSignal])
+        : timeoutSignal;
       return fetch(account.webhookUrl, {
         method: "POST",
         headers: {
@@ -202,6 +244,8 @@ export async function startWechatProxyMock(
           "x-api-key": options.apiKey ?? account.apiKey,
         },
         body: JSON.stringify(payload),
+        redirect: "error",
+        signal,
       });
     },
     stop: server.stop,
@@ -232,14 +276,53 @@ function cloneSeed(seed: WechatProxySeed): WechatProxySeed {
   return structuredClone(seed);
 }
 
-async function readJsonBody(request: Request): Promise<unknown> {
-  const text = await request.text();
-  if (!text) return {};
-  try {
-    return JSON.parse(text);
-  } catch {
-    return null;
+async function readJsonBody(
+  request: Request,
+): Promise<{ ok: true; value: unknown } | { ok: false; tooLarge: boolean }> {
+  const declaredLength = Number(request.headers.get("content-length"));
+  if (
+    Number.isFinite(declaredLength) &&
+    declaredLength > MAX_REQUEST_BODY_BYTES
+  ) {
+    return { ok: false, tooLarge: true };
   }
+  if (!request.body) return { ok: true, value: {} };
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_REQUEST_BODY_BYTES) {
+      await reader.cancel("request body exceeds simulator limit");
+      return { ok: false, tooLarge: true };
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    if (!text) return { ok: true, value: {} };
+    return { ok: true, value: JSON.parse(text) };
+  } catch {
+    // error-policy:J3 invalid UTF-8 or JSON is an explicit protocol error.
+    return { ok: false, tooLarge: false };
+  }
+}
+
+function isJsonMediaType(value: string | null): boolean {
+  return value?.split(";", 1)[0]?.trim().toLowerCase() === "application/json";
+}
+
+function isIdentityEncoding(value: string | null): boolean {
+  return value === null || value.trim().toLowerCase() === "identity";
 }
 
 function readString(body: unknown, key: string): string | null {

--- a/packages/cloud/test-mocks/src/wechat/types.ts
+++ b/packages/cloud/test-mocks/src/wechat/types.ts
@@ -1,0 +1,54 @@
+/** Defines deterministic seed, fault, observation, and readback contracts for the WeChat proxy simulator. */
+
+export interface WechatProxyAccountSeed {
+  accountId: string;
+  apiKey: string;
+  deviceType?: "ipad" | "mac";
+  loginState?: "waiting" | "need_verify" | "logged_in";
+  wcId?: string;
+  nickName?: string;
+  friends?: Array<{ wxid: string; name: string }>;
+  chatrooms?: Array<{ wxid: string; name: string }>;
+}
+
+export interface WechatProxySeed {
+  accounts: WechatProxyAccountSeed[];
+}
+
+export interface WechatProxyFault {
+  status?: number;
+  body?: unknown;
+  rawBody?: string;
+  retryAfter?: string;
+  delayMs?: number;
+}
+
+export interface WechatProxyRequestObservation {
+  sequence: number;
+  accountId: string | null;
+  deviceType: string | null;
+  method: string;
+  path: string;
+  body: unknown;
+  authenticated: boolean;
+}
+
+export interface WechatProxyOutboundMessage {
+  sequence: number;
+  accountId: string;
+  kind: "text" | "image";
+  to: string;
+  text?: string;
+  imagePath?: string;
+}
+
+export interface WechatProxySnapshot {
+  generation: number;
+  requests: WechatProxyRequestObservation[];
+  outboundMessages: WechatProxyOutboundMessage[];
+  webhooks: Record<string, string>;
+}
+
+export interface WechatWebhookDeliveryOptions {
+  apiKey?: string;
+}

--- a/packages/cloud/test-mocks/src/wechat/types.ts
+++ b/packages/cloud/test-mocks/src/wechat/types.ts
@@ -51,4 +51,6 @@ export interface WechatProxySnapshot {
 
 export interface WechatWebhookDeliveryOptions {
   apiKey?: string;
+  signal?: AbortSignal;
+  timeoutMs?: number;
 }

--- a/packages/cloud/test-mocks/test/wechat-proxy.contract.test.ts
+++ b/packages/cloud/test-mocks/test/wechat-proxy.contract.test.ts
@@ -154,7 +154,7 @@ describe("WeChat proxy production boundary", () => {
 
     await expect(
       wrongClient.sendText("wxid_alice", "must not send"),
-    ).rejects.toThrow("sendText failed: unauthorized");
+    ).rejects.toThrow("HTTP 401");
     expect(proxy.snapshot().outboundMessages).toEqual([]);
     expect(proxy.snapshot().requests).toEqual([
       expect.objectContaining({ authenticated: false, path: "/api/send-text" }),
@@ -177,6 +177,42 @@ describe("WeChat proxy production boundary", () => {
         .requests.filter((request) => request.path === "/api/send-text"),
     ).toHaveLength(2);
     expect(proxy.snapshot().outboundMessages).toHaveLength(1);
+  });
+
+  test("never trusts forged success JSON on an HTTP error status", async () => {
+    const proxy = await startWechatProxyMock(seed);
+    stops.push(proxy.stop);
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      proxy.enqueueFault("/api/send-text", {
+        status: 500,
+        body: { code: 1000, message: "forged success" },
+      });
+    }
+
+    await expect(
+      client(proxy.url).sendText("wxid_alice", "must not send"),
+    ).rejects.toThrow("HTTP 500");
+    expect(proxy.snapshot().requests).toHaveLength(3);
+    expect(proxy.snapshot().outboundMessages).toEqual([]);
+  });
+
+  test("retries transient server errors boundedly before one applied effect", async () => {
+    const proxy = await startWechatProxyMock(seed);
+    stops.push(proxy.stop);
+    proxy.enqueueFault("/api/send-text", {
+      status: 503,
+      body: { code: 1503, message: "temporarily unavailable" },
+    });
+
+    await client(proxy.url).sendText("wxid_alice", "retry server failure");
+    expect(
+      proxy
+        .snapshot()
+        .requests.filter((request) => request.path === "/api/send-text"),
+    ).toHaveLength(2);
+    expect(proxy.snapshot().outboundMessages).toEqual([
+      expect.objectContaining({ text: "retry server failure" }),
+    ]);
   });
 
   test("bounds malformed responses and timed-out requests to three attempts", async () => {

--- a/packages/cloud/test-mocks/test/wechat-proxy.contract.test.ts
+++ b/packages/cloud/test-mocks/test/wechat-proxy.contract.test.ts
@@ -1,0 +1,223 @@
+/** Proves the production WeChat client and webhook gate against a resettable real-HTTP proxy simulator. */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { Bot, ProxyClient } from "@elizaos/plugin-wechat";
+import { startCallbackServer } from "@elizaos/plugin-wechat/callback-server";
+import { startWechatProxyMock } from "../src/wechat";
+
+const API_KEY = "wechat-contract-key";
+const ACCOUNT_ID = "main";
+const seed = {
+  accounts: [
+    {
+      accountId: ACCOUNT_ID,
+      apiKey: API_KEY,
+      wcId: "wxid_bot",
+      nickName: "Synthetic Bot",
+      friends: [{ wxid: "wxid_alice", name: "Alice" }],
+      chatrooms: [{ wxid: "team@chatroom", name: "Synthetic Team" }],
+    },
+  ],
+};
+
+const stops: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(stops.splice(0).map((stop) => stop()));
+});
+
+function client(
+  url: string,
+  options: ConstructorParameters<typeof ProxyClient>[1] = {},
+): ProxyClient {
+  return new ProxyClient(
+    {
+      id: ACCOUNT_ID,
+      apiKey: API_KEY,
+      proxyUrl: url,
+      deviceType: "ipad",
+      webhookPort: 0,
+    },
+    { requestTimeoutMs: 100, retryBaseDelayMs: 1, ...options },
+  );
+}
+
+function inboundPayload(messageId = "wechat-msg-1") {
+  return {
+    data: {
+      type: 60001,
+      sender: "wxid_alice",
+      recipient: "wxid_bot",
+      content: "hello from the synthetic world",
+      timestamp: 1_710_969_600_000,
+      msgId: messageId,
+    },
+  };
+}
+
+describe("WeChat proxy production boundary", () => {
+  test("authenticates, reads contacts, sends, delivers inbound, deduplicates, and resets", async () => {
+    const proxy = await startWechatProxyMock(seed);
+    stops.push(proxy.stop);
+    const delivered: string[] = [];
+    const bot = new Bot({
+      onMessage: (message) => {
+        delivered.push(message.id);
+      },
+    });
+    const callback = await startCallbackServer({
+      port: 0,
+      accounts: [{ accountId: ACCOUNT_ID, apiKey: API_KEY }],
+      onMessage: (_accountId, message) => bot.handleIncoming(message),
+    });
+    stops.push(async () => {
+      bot.stop();
+      await callback.close();
+    });
+
+    const productionClient = client(proxy.url);
+    expect(await productionClient.getStatus()).toEqual(
+      expect.objectContaining({ loginState: "logged_in", wcId: "wxid_bot" }),
+    );
+    expect(await productionClient.getContacts()).toEqual({
+      friends: [{ wxid: "wxid_alice", name: "Alice" }],
+      chatrooms: [{ wxid: "team@chatroom", name: "Synthetic Team" }],
+    });
+    await productionClient.registerWebhook(
+      `http://127.0.0.1:${callback.port}/webhook/wechat/${ACCOUNT_ID}`,
+    );
+    await productionClient.sendText("wxid_alice", "outbound text");
+    await productionClient.sendImage(
+      "wxid_alice",
+      "/synthetic/image.png",
+      "caption",
+    );
+
+    const unauthorized = await proxy.deliverWebhook(
+      ACCOUNT_ID,
+      inboundPayload(),
+      {
+        apiKey: "wrong-key",
+      },
+    );
+    expect(unauthorized.status).toBe(401);
+    const [first, duplicate] = await Promise.all([
+      proxy.deliverWebhook(ACCOUNT_ID, inboundPayload()),
+      proxy.deliverWebhook(ACCOUNT_ID, inboundPayload()),
+    ]);
+    expect([first.status, duplicate.status]).toEqual([200, 200]);
+    expect(delivered).toEqual(["wechat-msg-1"]);
+
+    const snapshot = proxy.snapshot();
+    expect(snapshot.webhooks).toEqual({
+      main: `http://127.0.0.1:${callback.port}/webhook/wechat/main`,
+    });
+    expect(snapshot.outboundMessages).toEqual([
+      expect.objectContaining({
+        kind: "text",
+        to: "wxid_alice",
+        text: "outbound text",
+      }),
+      expect.objectContaining({
+        kind: "image",
+        to: "wxid_alice",
+        imagePath: "/synthetic/image.png",
+        text: "caption",
+      }),
+    ]);
+    expect(snapshot.requests.every((request) => request.authenticated)).toBe(
+      true,
+    );
+
+    proxy.reset();
+    expect(proxy.snapshot()).toEqual({
+      generation: 1,
+      requests: [],
+      outboundMessages: [],
+      webhooks: {},
+    });
+  });
+
+  test("rejects bad client authentication without applying an effect", async () => {
+    const proxy = await startWechatProxyMock(seed);
+    stops.push(proxy.stop);
+    const wrongClient = new ProxyClient(
+      {
+        id: ACCOUNT_ID,
+        apiKey: "wrong-key",
+        proxyUrl: proxy.url,
+        deviceType: "ipad",
+        webhookPort: 0,
+      },
+      { requestTimeoutMs: 100, retryBaseDelayMs: 1 },
+    );
+
+    await expect(
+      wrongClient.sendText("wxid_alice", "must not send"),
+    ).rejects.toThrow("sendText failed: unauthorized");
+    expect(proxy.snapshot().outboundMessages).toEqual([]);
+    expect(proxy.snapshot().requests).toEqual([
+      expect.objectContaining({ authenticated: false, path: "/api/send-text" }),
+    ]);
+  });
+
+  test("honors rate limits and retries through the real client", async () => {
+    const proxy = await startWechatProxyMock(seed);
+    stops.push(proxy.stop);
+    proxy.enqueueFault("/api/send-text", {
+      status: 429,
+      retryAfter: "0",
+      body: { code: 1429, message: "rate limited" },
+    });
+
+    await client(proxy.url).sendText("wxid_alice", "retry me");
+    expect(
+      proxy
+        .snapshot()
+        .requests.filter((request) => request.path === "/api/send-text"),
+    ).toHaveLength(2);
+    expect(proxy.snapshot().outboundMessages).toHaveLength(1);
+  });
+
+  test("bounds malformed responses and timed-out requests to three attempts", async () => {
+    const proxy = await startWechatProxyMock(seed);
+    stops.push(proxy.stop);
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      proxy.enqueueFault("/api/status", { status: 200, rawBody: "not-json" });
+    }
+    await expect(client(proxy.url).getStatus()).rejects.toThrow();
+    expect(proxy.snapshot().requests).toHaveLength(3);
+
+    proxy.reset();
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      proxy.enqueueFault("/api/status", {
+        status: 200,
+        delayMs: 80,
+        body: { code: 1000, data: { valid: true, loginState: "logged_in" } },
+      });
+    }
+    await expect(
+      client(proxy.url, { requestTimeoutMs: 10 }).getStatus(),
+    ).rejects.toThrow();
+    expect(proxy.snapshot().requests).toHaveLength(3);
+  });
+
+  test("external cancellation interrupts rate-limit backoff before a retry", async () => {
+    const proxy = await startWechatProxyMock(seed);
+    stops.push(proxy.stop);
+    proxy.enqueueFault("/api/send-text", {
+      status: 429,
+      body: { code: 1429, message: "rate limited" },
+    });
+    const controller = new AbortController();
+    const pending = client(proxy.url, {
+      requestTimeoutMs: 1_000,
+      retryBaseDelayMs: 500,
+      signal: controller.signal,
+    }).sendText("wxid_alice", "cancel me");
+    setTimeout(() => controller.abort(new Error("test cancellation")), 10);
+
+    await expect(pending).rejects.toThrow("test cancellation");
+    expect(proxy.snapshot().requests).toHaveLength(1);
+  });
+});

--- a/packages/cloud/test-mocks/test/wechat-proxy.contract.test.ts
+++ b/packages/cloud/test-mocks/test/wechat-proxy.contract.test.ts
@@ -101,6 +101,18 @@ describe("WeChat proxy production boundary", () => {
       },
     );
     expect(unauthorized.status).toBe(401);
+    const unsupportedMedia = await fetch(
+      `http://127.0.0.1:${callback.port}/webhook/wechat/${ACCOUNT_ID}`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/xml",
+          "x-api-key": API_KEY,
+        },
+        body: "<xml/>",
+      },
+    );
+    expect(unsupportedMedia.status).toBe(415);
     const [first, duplicate] = await Promise.all([
       proxy.deliverWebhook(ACCOUNT_ID, inboundPayload()),
       proxy.deliverWebhook(ACCOUNT_ID, inboundPayload()),
@@ -161,6 +173,52 @@ describe("WeChat proxy production boundary", () => {
     ]);
   });
 
+  test("rejects non-JSON and oversized chunked requests before applying effects", async () => {
+    const proxy = await startWechatProxyMock(seed);
+    stops.push(proxy.stop);
+    const headers = {
+      "x-api-key": API_KEY,
+      "x-account-id": ACCOUNT_ID,
+      "x-device-type": "ipad",
+    };
+
+    const wrongMediaType = await fetch(`${proxy.url}/api/send-text`, {
+      method: "POST",
+      headers: { ...headers, "content-type": "text/plain" },
+      body: JSON.stringify({ to: "wxid_alice", text: "must not send" }),
+    });
+    expect(wrongMediaType.status).toBe(415);
+    const encoded = await fetch(`${proxy.url}/api/send-text`, {
+      method: "POST",
+      headers: {
+        ...headers,
+        "content-type": "application/json",
+        "content-encoding": "gzip",
+      },
+      body: "not-a-bounded-supported-gzip-stream",
+    });
+    expect(encoded.status).toBe(415);
+
+    const oversized = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const chunk = new Uint8Array(64 * 1024).fill(97);
+        for (let index = 0; index < 17; index += 1) controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+    const tooLarge = await fetch(`${proxy.url}/api/send-text`, {
+      method: "POST",
+      headers: {
+        ...headers,
+        "content-type": "application/json; charset=utf-8",
+      },
+      body: oversized,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+    expect(tooLarge.status).toBe(413);
+    expect(proxy.snapshot().outboundMessages).toEqual([]);
+  });
+
   test("honors rate limits and retries through the real client", async () => {
     const proxy = await startWechatProxyMock(seed);
     stops.push(proxy.stop);
@@ -179,40 +237,65 @@ describe("WeChat proxy production boundary", () => {
     expect(proxy.snapshot().outboundMessages).toHaveLength(1);
   });
 
-  test("never trusts forged success JSON on an HTTP error status", async () => {
+  test("never trusts forged success JSON or retries an ambiguous send", async () => {
     const proxy = await startWechatProxyMock(seed);
     stops.push(proxy.stop);
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      proxy.enqueueFault("/api/send-text", {
-        status: 500,
-        body: { code: 1000, message: "forged success" },
-      });
-    }
+    proxy.enqueueFault("/api/send-text", {
+      status: 500,
+      body: { code: 1000, message: "forged success" },
+    });
 
     await expect(
       client(proxy.url).sendText("wxid_alice", "must not send"),
     ).rejects.toThrow("HTTP 500");
-    expect(proxy.snapshot().requests).toHaveLength(3);
+    expect(proxy.snapshot().requests).toHaveLength(1);
     expect(proxy.snapshot().outboundMessages).toEqual([]);
   });
 
-  test("retries transient server errors boundedly before one applied effect", async () => {
+  test("retries transient server errors boundedly for an idempotent read", async () => {
     const proxy = await startWechatProxyMock(seed);
     stops.push(proxy.stop);
-    proxy.enqueueFault("/api/send-text", {
+    proxy.enqueueFault("/api/status", {
       status: 503,
       body: { code: 1503, message: "temporarily unavailable" },
     });
 
-    await client(proxy.url).sendText("wxid_alice", "retry server failure");
+    await client(proxy.url).getStatus();
     expect(
       proxy
         .snapshot()
-        .requests.filter((request) => request.path === "/api/send-text"),
+        .requests.filter((request) => request.path === "/api/status"),
     ).toHaveLength(2);
-    expect(proxy.snapshot().outboundMessages).toEqual([
-      expect.objectContaining({ text: "retry server failure" }),
-    ]);
+    expect(proxy.snapshot().outboundMessages).toEqual([]);
+  });
+
+  test("fences a delayed request when reset changes the simulator generation", async () => {
+    const proxy = await startWechatProxyMock(seed);
+    stops.push(proxy.stop);
+    proxy.enqueueFault("/api/status", {
+      status: 200,
+      delayMs: 30,
+      body: { code: 1000, data: { valid: true, loginState: "logged_in" } },
+    });
+    const pending = fetch(`${proxy.url}/api/status`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": API_KEY,
+        "x-account-id": ACCOUNT_ID,
+        "x-device-type": "ipad",
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    proxy.reset();
+
+    expect((await pending).status).toBe(409);
+    expect(proxy.snapshot()).toEqual({
+      generation: 1,
+      requests: [],
+      outboundMessages: [],
+      webhooks: {},
+    });
   });
 
   test("bounds malformed responses and timed-out requests to three attempts", async () => {
@@ -235,6 +318,23 @@ describe("WeChat proxy production boundary", () => {
     await expect(
       client(proxy.url, { requestTimeoutMs: 10 }).getStatus(),
     ).rejects.toThrow();
+    expect(proxy.snapshot().requests).toHaveLength(3);
+  });
+
+  test("rejects an oversized successful proxy response boundedly", async () => {
+    const proxy = await startWechatProxyMock(seed);
+    stops.push(proxy.stop);
+    const oversized = JSON.stringify({
+      code: 1000,
+      data: { padding: "x".repeat(1024 * 1024) },
+    });
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      proxy.enqueueFault("/api/status", { status: 200, rawBody: oversized });
+    }
+
+    await expect(client(proxy.url).getStatus()).rejects.toThrow(
+      "response body exceeds 1048576 bytes",
+    );
     expect(proxy.snapshot().requests).toHaveLength(3);
   });
 

--- a/packages/cloud/test-mocks/test/wechat-proxy.contract.test.ts
+++ b/packages/cloud/test-mocks/test/wechat-proxy.contract.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { Bot, ProxyClient } from "@elizaos/plugin-wechat";
-import { startCallbackServer } from "@elizaos/plugin-wechat/callback-server";
+import { startCallbackServer } from "../../../../plugins/plugin-wechat/src/callback-server";
 import { startWechatProxyMock } from "../src/wechat";
 
 const API_KEY = "wechat-contract-key";
@@ -53,6 +53,32 @@ function inboundPayload(messageId = "wechat-msg-1") {
       msgId: messageId,
     },
   };
+}
+
+async function captureError(operation: Promise<unknown>): Promise<Error> {
+  try {
+    await operation;
+  } catch (error) {
+    // error-policy:J1 The contract captures the public client error for redaction assertions.
+    if (error instanceof Error) return error;
+    throw error;
+  }
+  throw new Error("expected WeChat proxy operation to reject");
+}
+
+function exposedErrorRepresentations(error: Error): string[] {
+  return [
+    error.message,
+    error.stack ?? "",
+    String(error),
+    JSON.stringify(error),
+    JSON.stringify(error, Object.getOwnPropertyNames(error)),
+    JSON.stringify({
+      context: (error as Error & { context?: unknown }).context,
+      cause: error.cause,
+    }),
+    Bun.inspect(error),
+  ];
 }
 
 describe("WeChat proxy production boundary", () => {
@@ -171,6 +197,140 @@ describe("WeChat proxy production boundary", () => {
     expect(proxy.snapshot().requests).toEqual([
       expect.objectContaining({ authenticated: false, path: "/api/send-text" }),
     ]);
+  });
+
+  test("strictly decodes every success shape before returning or accepting an effect", async () => {
+    const proxy = await startWechatProxyMock(seed);
+    stops.push(proxy.stop);
+    const productionClient = client(proxy.url);
+    const malformed: Array<{
+      path: string;
+      body: unknown;
+      invoke: () => Promise<unknown>;
+    }> = [
+      {
+        path: "/api/status",
+        body: {
+          code: 1000,
+          data: { valid: true, loginState: "logged_in", unexpected: true },
+        },
+        invoke: () => productionClient.getStatus(),
+      },
+      {
+        path: "/api/qrcode",
+        body: { code: 1000, data: { qrCodeUrl: 42 } },
+        invoke: () => productionClient.getQRCode(),
+      },
+      {
+        path: "/api/check-login",
+        body: { code: 1000, data: { status: "provider-secret-state" } },
+        invoke: () => productionClient.checkLogin(),
+      },
+      {
+        path: "/api/contacts",
+        body: {
+          code: 1000,
+          data: {
+            friends: [{ wxid: "wxid_alice", name: "Alice", extra: true }],
+            chatrooms: [],
+          },
+        },
+        invoke: () => productionClient.getContacts(),
+      },
+      {
+        path: "/api/send-text",
+        body: { code: 1000 },
+        invoke: () => productionClient.sendText("wxid_alice", "invalid ack"),
+      },
+      {
+        path: "/api/send-image",
+        body: { code: 1000, data: { accepted: true, operation: "sendText" } },
+        invoke: () =>
+          productionClient.sendImage("wxid_alice", "/invalid-ack.png"),
+      },
+      {
+        path: "/api/webhook/register",
+        body: { code: 1000, data: { registered: false } },
+        invoke: () =>
+          productionClient.registerWebhook(
+            "http://127.0.0.1:18790/webhook/wechat/main",
+          ),
+      },
+    ];
+    for (const item of malformed) {
+      proxy.enqueueFault(item.path, { status: 200, body: item.body });
+      await expect(item.invoke()).rejects.toThrow(
+        "WeChat proxy returned an invalid response",
+      );
+    }
+    expect(proxy.snapshot().outboundMessages).toEqual([]);
+    expect(proxy.snapshot().webhooks).toEqual({});
+  });
+
+  test("redacts provider failure messages from every public error representation", async () => {
+    const proxy = await startWechatProxyMock(seed);
+    stops.push(proxy.stop);
+    const productionClient = client(proxy.url);
+    const secret = "provider_api_key=wechat-upstream-secret-8437";
+    const failures: Array<{ path: string; invoke: () => Promise<unknown> }> = [
+      { path: "/api/status", invoke: () => productionClient.getStatus() },
+      { path: "/api/qrcode", invoke: () => productionClient.getQRCode() },
+      {
+        path: "/api/check-login",
+        invoke: () => productionClient.checkLogin(),
+      },
+      { path: "/api/contacts", invoke: () => productionClient.getContacts() },
+      {
+        path: "/api/send-text",
+        invoke: () => productionClient.sendText("wxid_alice", "redact"),
+      },
+      {
+        path: "/api/send-image",
+        invoke: () => productionClient.sendImage("wxid_alice", "/redact.png"),
+      },
+      {
+        path: "/api/webhook/register",
+        invoke: () =>
+          productionClient.registerWebhook(
+            "http://127.0.0.1:18790/webhook/wechat/main",
+          ),
+      },
+    ];
+    for (const failure of failures) {
+      proxy.enqueueFault(failure.path, {
+        status: 200,
+        body: { code: 1500, message: secret },
+      });
+      const error = await captureError(failure.invoke());
+      expect(error.cause).toBeUndefined();
+      expect((error as Error & { context?: unknown }).context).toBeUndefined();
+      for (const exposed of exposedErrorRepresentations(error))
+        expect(exposed).not.toContain(secret);
+    }
+    expect(proxy.snapshot().outboundMessages).toEqual([]);
+    expect(proxy.snapshot().webhooks).toEqual({});
+  });
+
+  test("rejects webhook callback query and fragment components without storing them", async () => {
+    const proxy = await startWechatProxyMock(seed);
+    stops.push(proxy.stop);
+    const headers = {
+      "content-type": "application/json",
+      "x-api-key": API_KEY,
+      "x-account-id": ACCOUNT_ID,
+      "x-device-type": "ipad",
+    };
+    for (const suffix of ["?token=callback-secret", "#callback-secret"]) {
+      const response = await fetch(`${proxy.url}/api/webhook/register`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          webhookUrl: `http://127.0.0.1:18790/webhook/wechat/main${suffix}`,
+        }),
+      });
+      expect(response.status).toBe(400);
+    }
+    expect(proxy.snapshot().webhooks).toEqual({});
   });
 
   test("rejects non-JSON and oversized chunked requests before applying effects", async () => {

--- a/plugins/plugin-wechat/AGENTS.md
+++ b/plugins/plugin-wechat/AGENTS.md
@@ -120,8 +120,12 @@ mapping to `WECHAT_TYPE_MAP` in `src/callback-server.ts`.
 
 ## Conventions / Gotchas
 
-- **Proxy-only.** There is no direct WeChat API access. All calls go through an
-  HTTPS proxy service. The proxy URL must be `https://` with no embedded creds.
+- **Proxy-only.** There is no direct WeChat API access. All calls go through a
+  proxy service. Production proxy URLs must be `https://` with no embedded creds;
+  literal loopback `http://127.0.0.1`/`http://[::1]` is allowed for local protocol simulators.
+- **Bounded client requests.** `ProxyClientOptions` can narrow the default 30-second
+  request timeout and retry delay and can carry a lifecycle `AbortSignal`. External
+  cancellation stops retries immediately; normal transport failures remain bounded to three attempts.
 - **Login flow.** On first start (or after session expiry), `WechatChannel`
   polls for QR-code login. `displayQRUrl` prints the URL; the user must scan it
   via the WeChat mobile app within `loginTimeoutMs` (default 5 min).

--- a/plugins/plugin-wechat/AGENTS.md
+++ b/plugins/plugin-wechat/AGENTS.md
@@ -126,6 +126,8 @@ mapping to `WECHAT_TYPE_MAP` in `src/callback-server.ts`.
 - **Bounded client requests.** `ProxyClientOptions` can narrow the default 30-second
   request timeout and retry delay and can carry a lifecycle `AbortSignal`. External
   cancellation stops retries immediately; normal transport failures remain bounded to three attempts.
+  HTTP status is authoritative: 408/429/5xx are bounded retry cases, other non-2xx
+  statuses fail immediately, redirects fail closed, and error JSON can never claim success.
 - **Login flow.** On first start (or after session expiry), `WechatChannel`
   polls for QR-code login. `displayQRUrl` prints the URL; the user must scan it
   via the WeChat mobile app within `loginTimeoutMs` (default 5 min).

--- a/plugins/plugin-wechat/CLAUDE.md
+++ b/plugins/plugin-wechat/CLAUDE.md
@@ -120,8 +120,12 @@ mapping to `WECHAT_TYPE_MAP` in `src/callback-server.ts`.
 
 ## Conventions / Gotchas
 
-- **Proxy-only.** There is no direct WeChat API access. All calls go through an
-  HTTPS proxy service. The proxy URL must be `https://` with no embedded creds.
+- **Proxy-only.** There is no direct WeChat API access. All calls go through a
+  proxy service. Production proxy URLs must be `https://` with no embedded creds;
+  literal loopback `http://127.0.0.1`/`http://[::1]` is allowed for local protocol simulators.
+- **Bounded client requests.** `ProxyClientOptions` can narrow the default 30-second
+  request timeout and retry delay and can carry a lifecycle `AbortSignal`. External
+  cancellation stops retries immediately; normal transport failures remain bounded to three attempts.
 - **Login flow.** On first start (or after session expiry), `WechatChannel`
   polls for QR-code login. `displayQRUrl` prints the URL; the user must scan it
   via the WeChat mobile app within `loginTimeoutMs` (default 5 min).

--- a/plugins/plugin-wechat/CLAUDE.md
+++ b/plugins/plugin-wechat/CLAUDE.md
@@ -126,6 +126,8 @@ mapping to `WECHAT_TYPE_MAP` in `src/callback-server.ts`.
 - **Bounded client requests.** `ProxyClientOptions` can narrow the default 30-second
   request timeout and retry delay and can carry a lifecycle `AbortSignal`. External
   cancellation stops retries immediately; normal transport failures remain bounded to three attempts.
+  HTTP status is authoritative: 408/429/5xx are bounded retry cases, other non-2xx
+  statuses fail immediately, redirects fail closed, and error JSON can never claim success.
 - **Login flow.** On first start (or after session expiry), `WechatChannel`
   polls for QR-code login. `displayQRUrl` prints the URL; the user must scan it
   via the WeChat mobile app within `loginTimeoutMs` (default 5 min).

--- a/plugins/plugin-wechat/README.md
+++ b/plugins/plugin-wechat/README.md
@@ -28,7 +28,7 @@ npx elizaos plugins add @elizaos/plugin-wechat
 | Env Var | Required | Description |
 |---|---|---|
 | `WECHAT_API_KEY` | Yes | Proxy service API key |
-| `WECHAT_PROXY_URL` | Yes | Base URL of the WeChat proxy (`https://` only) |
+| `WECHAT_PROXY_URL` | Yes | Base URL of the WeChat proxy (`https://`; literal loopback HTTP is reserved for local protocol simulators) |
 | `ELIZA_WECHAT_WEBHOOK_PORT` | No | Webhook listener port (default: `18790`) |
 
 ### Character config block (recommended)
@@ -92,4 +92,3 @@ npx elizaos plugins add @elizaos/plugin-wechat
   owner account over WeChat therefore extends full OWNER trust to the proxy
   operator — a forged POST naming the owner's wxid produces OWNER-role turns.
   Only pair owners over WeChat with a proxy you control.
-

--- a/plugins/plugin-wechat/src/callback-server.test.ts
+++ b/plugins/plugin-wechat/src/callback-server.test.ts
@@ -329,7 +329,10 @@ describe("webhook server malformed-path handling (#19060)", () => {
     closers.push(handle.close);
 
     const res = await requestRaw(handle.port, "/webhook/wechat/main", {
-      headers: { "x-api-key": "key-main" },
+      headers: {
+        "x-api-key": "key-main",
+        "content-type": "application/json",
+      },
       body: JSON.stringify(basePayload()),
     });
 
@@ -353,7 +356,10 @@ describe("webhook server malformed-path handling (#19060)", () => {
     closers.push(handle.close);
 
     const res = await requestRaw(handle.port, "/webhook/wechat/main", {
-      headers: { "x-api-key": "key-main" },
+      headers: {
+        "x-api-key": "key-main",
+        "content-type": "application/json",
+      },
       body: JSON.stringify(basePayload()),
     });
 
@@ -387,7 +393,10 @@ describe("webhook server malformed-path handling (#19060)", () => {
     });
 
     const options = {
-      headers: { "x-api-key": "key-main" },
+      headers: {
+        "x-api-key": "key-main",
+        "content-type": "application/json",
+      },
       body: JSON.stringify(basePayload({ msgId: "concurrent-success" })),
     };
     const owner = requestRaw(handle.port, "/webhook/wechat/main", options);
@@ -424,7 +433,10 @@ describe("webhook server malformed-path handling (#19060)", () => {
     });
 
     const options = {
-      headers: { "x-api-key": "key-main" },
+      headers: {
+        "x-api-key": "key-main",
+        "content-type": "application/json",
+      },
       body: JSON.stringify(basePayload({ msgId: "concurrent-failure" })),
     };
     const owner = requestRaw(handle.port, "/webhook/wechat/main", options);

--- a/plugins/plugin-wechat/src/callback-server.ts
+++ b/plugins/plugin-wechat/src/callback-server.ts
@@ -86,6 +86,15 @@ export async function startCallbackServer(
       res.end("Unauthorized");
       return;
     }
+    if (
+      !isJsonMediaType(readHeaderValue(req.headers["content-type"])) ||
+      !isIdentityEncoding(readHeaderValue(req.headers["content-encoding"]))
+    ) {
+      res.writeHead(415);
+      res.end("Unsupported Media Type");
+      req.destroy();
+      return;
+    }
 
     // Accumulate raw bytes and decode once on "end". Decoding each TCP chunk
     // independently with Buffer.toString() corrupts any multi-byte UTF-8 code
@@ -254,6 +263,14 @@ function readHeaderValue(
     return value[0];
   }
   return value;
+}
+
+function isJsonMediaType(value: string | undefined): boolean {
+  return value?.split(";", 1)[0]?.trim().toLowerCase() === "application/json";
+}
+
+function isIdentityEncoding(value: string | undefined): boolean {
+  return value === undefined || value.trim().toLowerCase() === "identity";
 }
 
 function safeCompare(a: string, b: string): boolean {

--- a/plugins/plugin-wechat/src/proxy-client.test.ts
+++ b/plugins/plugin-wechat/src/proxy-client.test.ts
@@ -1,9 +1,10 @@
 /**
  * Coverage for `retryDelayMs`'s RFC 7231 Retry-After parsing (delay-seconds
- * and HTTP-date forms) and its exponential-backoff fallback.
+ * and HTTP-date forms), its exponential-backoff fallback, and the production
+ * client's fail-closed transport configuration.
  */
 import { describe, expect, it } from "vitest";
-import { retryDelayMs } from "./proxy-client";
+import { ProxyClient, retryDelayMs } from "./proxy-client";
 
 describe("retryDelayMs", () => {
   it("parses delay-seconds form", () => {
@@ -51,6 +52,53 @@ describe("retryDelayMs", () => {
     expect(retryDelayMs("999999999999999999999999", 0)).toBe(2_147_483_647);
     expect(retryDelayMs("Fri, 31 Dec 9999 23:59:59 GMT", 0)).toBe(
       2_147_483_647,
+    );
+  });
+});
+
+describe("ProxyClient transport policy", () => {
+  const account = {
+    id: "main",
+    apiKey: "secret",
+    proxyUrl: "https://proxy.example.test",
+    deviceType: "ipad" as const,
+    webhookPort: 18790,
+  };
+
+  it.each([
+    "https://proxy.example.test",
+    "http://127.0.0.1:4567",
+    "http://[::1]:4567",
+  ])(
+    "accepts secure production or literal loopback simulator URL %s",
+    (proxyUrl) => {
+      expect(() => new ProxyClient({ ...account, proxyUrl })).not.toThrow();
+    },
+  );
+
+  it.each([
+    "http://localhost:4567",
+    "http://192.168.1.10:4567",
+    "http://proxy.example.test",
+  ])("rejects non-literal insecure proxy URL %s", (proxyUrl) => {
+    expect(() => new ProxyClient({ ...account, proxyUrl })).toThrow(
+      "proxyUrl must use https://",
+    );
+  });
+
+  it("rejects embedded credentials and invalid request budgets", () => {
+    expect(
+      () =>
+        new ProxyClient({
+          ...account,
+          proxyUrl: "https://username:password@proxy.example.test",
+        }),
+    ).toThrow("must not include credentials");
+    expect(() => new ProxyClient(account, { requestTimeoutMs: 0 })).toThrow(
+      "requestTimeoutMs must be a positive integer",
+    );
+    expect(() => new ProxyClient(account, { retryBaseDelayMs: 1.5 })).toThrow(
+      "retryBaseDelayMs must be a positive integer",
     );
   });
 });

--- a/plugins/plugin-wechat/src/proxy-client.test.ts
+++ b/plugins/plugin-wechat/src/proxy-client.test.ts
@@ -100,5 +100,23 @@ describe("ProxyClient transport policy", () => {
     expect(() => new ProxyClient(account, { retryBaseDelayMs: 1.5 })).toThrow(
       "retryBaseDelayMs must be a positive integer",
     );
+    expect(
+      () => new ProxyClient(account, { requestTimeoutMs: 300_001 }),
+    ).toThrow(
+      "requestTimeoutMs must be a positive integer no greater than 300000",
+    );
+    expect(() => new ProxyClient(account, { retryBaseDelayMs: 8_001 })).toThrow(
+      "retryBaseDelayMs must be a positive integer no greater than 8000",
+    );
+  });
+
+  it("rejects base URL query parameters before path concatenation", () => {
+    expect(
+      () =>
+        new ProxyClient({
+          ...account,
+          proxyUrl: "https://proxy.example.test?tenant=unexpected",
+        }),
+    ).toThrow("proxyUrl must not include query parameters");
   });
 });

--- a/plugins/plugin-wechat/src/proxy-client.test.ts
+++ b/plugins/plugin-wechat/src/proxy-client.test.ts
@@ -119,4 +119,14 @@ describe("ProxyClient transport policy", () => {
         }),
     ).toThrow("proxyUrl must not include query parameters");
   });
+
+  it("rejects base URL fragments instead of silently discarding them", () => {
+    expect(
+      () =>
+        new ProxyClient({
+          ...account,
+          proxyUrl: "https://proxy.example.test#provider-secret",
+        }),
+    ).toThrow("proxyUrl must not include a fragment");
+  });
 });

--- a/plugins/plugin-wechat/src/proxy-client.ts
+++ b/plugins/plugin-wechat/src/proxy-client.ts
@@ -15,6 +15,7 @@ const LOGIN_NEEDED = 1001;
 const REQUEST_TIMEOUT_MS = 30_000;
 const MAX_REQUEST_TIMEOUT_MS = 5 * 60_000;
 const MAX_RETRY_BASE_DELAY_MS = 8_000;
+const MAX_RESPONSE_BODY_BYTES = 1024 * 1024;
 
 export interface ProxyClientOptions {
   requestTimeoutMs?: number;
@@ -55,6 +56,7 @@ export class ProxyClient {
   private async request<T>(
     path: string,
     body?: Record<string, unknown>,
+    retryAmbiguousFailures = true,
   ): Promise<ProxyApiResponse<T>> {
     const url = `${this.baseUrl}${path}`;
     const headers: Record<string, string> = {
@@ -89,7 +91,7 @@ export class ProxyClient {
             this.retryBaseDelayMs,
           );
           // Consume the response body to release the connection
-          await res.text().catch(() => {});
+          await discardBoundedBody(res);
           await sleep(delay, this.signal);
           continue;
         }
@@ -98,11 +100,17 @@ export class ProxyClient {
           // Consume the body to release the connection, but never trust or
           // surface an untrusted error envelope. HTTP status is authoritative:
           // a forged `{ code: 1000 }` on an error status cannot become success.
-          await res.text().catch(() => {});
+          await discardBoundedBody(res);
           throw new ProxyHttpStatusError(res.status);
         }
 
-        const json = (await res.json()) as ProxyApiResponse<T>;
+        if (!isJsonMediaType(res.headers.get("content-type"))) {
+          await discardBoundedBody(res);
+          throw new Error("WeChat proxy response must use application/json");
+        }
+        const json = JSON.parse(
+          await readBoundedBody(res),
+        ) as ProxyApiResponse<T>;
         return json;
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));
@@ -111,6 +119,9 @@ export class ProxyClient {
         }
         if (err instanceof ProxyHttpStatusError && !err.retryable) {
           throw err;
+        }
+        if (!retryAmbiguousFailures) {
+          throw lastError;
         }
         if (attempt === 2) {
           throw lastError;
@@ -164,7 +175,7 @@ export class ProxyClient {
   }
 
   async sendText(to: string, text: string): Promise<void> {
-    const res = await this.request("/api/send-text", { to, text });
+    const res = await this.request("/api/send-text", { to, text }, false);
     if (res.code === LOGIN_NEEDED) {
       throw new LoginExpiredError();
     }
@@ -174,11 +185,11 @@ export class ProxyClient {
   }
 
   async sendImage(to: string, imagePath: string, text?: string): Promise<void> {
-    const res = await this.request("/api/send-image", {
-      to,
-      imagePath,
-      text,
-    });
+    const res = await this.request(
+      "/api/send-image",
+      { to, imagePath, text },
+      false,
+    );
     if (res.code === LOGIN_NEEDED) {
       throw new LoginExpiredError();
     }
@@ -328,4 +339,49 @@ function requireData<T>(response: ProxyApiResponse<T>, action: string): T {
     throw new Error(`${action} failed: missing response data`);
   }
   return response.data;
+}
+
+function isJsonMediaType(value: string | null): boolean {
+  return value?.split(";", 1)[0]?.trim().toLowerCase() === "application/json";
+}
+
+async function readBoundedBody(response: Response): Promise<string> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (
+    Number.isFinite(declaredLength) &&
+    declaredLength > MAX_RESPONSE_BODY_BYTES
+  ) {
+    await response.body?.cancel("response body exceeds client limit");
+    throw new Error("WeChat proxy response body exceeds 1048576 bytes");
+  }
+  if (!response.body) return "";
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_RESPONSE_BODY_BYTES) {
+      await reader.cancel("response body exceeds client limit");
+      throw new Error("WeChat proxy response body exceeds 1048576 bytes");
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+}
+
+async function discardBoundedBody(response: Response): Promise<void> {
+  try {
+    await readBoundedBody(response);
+  } catch {
+    // error-policy:J6 draining is connection-reuse cleanup; status remains authoritative.
+  }
 }

--- a/plugins/plugin-wechat/src/proxy-client.ts
+++ b/plugins/plugin-wechat/src/proxy-client.ts
@@ -14,17 +14,38 @@ const SUCCESS = 1000;
 const LOGIN_NEEDED = 1001;
 const REQUEST_TIMEOUT_MS = 30_000;
 
+export interface ProxyClientOptions {
+  requestTimeoutMs?: number;
+  retryBaseDelayMs?: number;
+  signal?: AbortSignal;
+}
+
 export class ProxyClient {
   private readonly apiKey: string;
   private readonly baseUrl: string;
   private readonly accountId: string;
   private readonly deviceType: string;
+  private readonly requestTimeoutMs: number;
+  private readonly retryBaseDelayMs: number;
+  private readonly signal?: AbortSignal;
 
-  constructor(account: ResolvedWechatAccount) {
+  constructor(
+    account: ResolvedWechatAccount,
+    options: ProxyClientOptions = {},
+  ) {
     this.apiKey = account.apiKey;
     this.baseUrl = normalizeProxyUrl(account.proxyUrl);
     this.accountId = account.id;
     this.deviceType = account.deviceType ?? "ipad";
+    this.requestTimeoutMs = requirePositiveInteger(
+      options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS,
+      "requestTimeoutMs",
+    );
+    this.retryBaseDelayMs = requirePositiveInteger(
+      options.retryBaseDelayMs ?? 1000,
+      "retryBaseDelayMs",
+    );
+    this.signal = options.signal;
   }
 
   private async request<T>(
@@ -42,18 +63,29 @@ export class ProxyClient {
     let lastError: Error | undefined;
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
+        if (this.signal?.aborted) {
+          throw this.signal.reason ?? new Error("WeChat proxy request aborted");
+        }
+        const timeoutSignal = AbortSignal.timeout(this.requestTimeoutMs);
+        const signal = this.signal
+          ? AbortSignal.any([this.signal, timeoutSignal])
+          : timeoutSignal;
         const res = await fetch(url, {
           method: "POST",
           headers,
           body: body ? JSON.stringify(body) : undefined,
-          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+          signal,
         });
 
         if (res.status === 429) {
-          const delay = retryDelayMs(res.headers.get("Retry-After"), attempt);
+          const delay = retryDelayMs(
+            res.headers.get("Retry-After"),
+            attempt,
+            this.retryBaseDelayMs,
+          );
           // Consume the response body to release the connection
           await res.text().catch(() => {});
-          await sleep(delay);
+          await sleep(delay, this.signal);
           continue;
         }
 
@@ -61,8 +93,11 @@ export class ProxyClient {
         return json;
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));
-        const delay = Math.min(1000 * 2 ** attempt, 8000);
-        await sleep(delay);
+        if (this.signal?.aborted) {
+          throw this.signal.reason ?? lastError;
+        }
+        const delay = Math.min(this.retryBaseDelayMs * 2 ** attempt, 8000);
+        await sleep(delay, this.signal);
       }
     }
 
@@ -168,8 +203,23 @@ export class LoginExpiredError extends Error {
   }
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(
+      signal.reason ?? new Error("WeChat proxy request aborted"),
+    );
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new Error("WeChat proxy request aborted"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 const MAX_BACKOFF_MS = 8000;
@@ -189,8 +239,9 @@ const HTTP_DATE_PATTERN =
 export function retryDelayMs(
   retryAfterHeader: string | null,
   attempt: number,
+  baseDelayMs = 1000,
 ): number {
-  const fallback = Math.min(1000 * 2 ** attempt, MAX_BACKOFF_MS);
+  const fallback = Math.min(baseDelayMs * 2 ** attempt, MAX_BACKOFF_MS);
   if (!retryAfterHeader) return fallback;
 
   const value = retryAfterHeader.trim();
@@ -212,14 +263,26 @@ export function retryDelayMs(
 
 function normalizeProxyUrl(proxyUrl: string): string {
   const parsed = new URL(proxyUrl);
-  if (parsed.protocol !== "https:") {
-    throw new Error("[wechat] proxyUrl must use https://");
+  const isLoopbackHttp =
+    parsed.protocol === "http:" &&
+    (parsed.hostname === "127.0.0.1" || parsed.hostname === "[::1]");
+  if (parsed.protocol !== "https:" && !isLoopbackHttp) {
+    throw new Error(
+      "[wechat] proxyUrl must use https:// (loopback http:// is allowed for local protocol simulators)",
+    );
   }
   if (parsed.username || parsed.password) {
     throw new Error("[wechat] proxyUrl must not include credentials");
   }
   parsed.hash = "";
   return parsed.toString().replace(/\/$/, "");
+}
+
+function requirePositiveInteger(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`[wechat] ${name} must be a positive integer`);
+  }
+  return value;
 }
 
 function requireData<T>(response: ProxyApiResponse<T>, action: string): T {

--- a/plugins/plugin-wechat/src/proxy-client.ts
+++ b/plugins/plugin-wechat/src/proxy-client.ts
@@ -108,10 +108,15 @@ export class ProxyClient {
           await discardBoundedBody(res);
           throw new Error("WeChat proxy response must use application/json");
         }
-        const json = JSON.parse(
-          await readBoundedBody(res),
-        ) as ProxyApiResponse<T>;
-        return json;
+        let json: unknown;
+        const responseBody = await readBoundedBody(res);
+        try {
+          json = JSON.parse(responseBody);
+        } catch {
+          // error-policy:J1 Provider-controlled parser details are redacted at the client boundary.
+          throw new ProxyResponseError();
+        }
+        return parseEnvelope(json) as ProxyApiResponse<T>;
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));
         if (this.signal?.aborted) {
@@ -143,17 +148,17 @@ export class ProxyClient {
       };
     }
     if (res.code !== SUCCESS && res.code !== 1002) {
-      throw new Error(`getStatus failed: ${res.message ?? res.code}`);
+      throw new ProxyProviderError("getStatus", res.code);
     }
-    return requireData(res, "getStatus");
+    return parseAccountStatus(requireData(res));
   }
 
   async getQRCode(): Promise<string> {
     const res = await this.request<{ qrCodeUrl: string }>("/api/qrcode");
     if (res.code !== SUCCESS) {
-      throw new Error(`getQRCode failed: ${res.message ?? res.code}`);
+      throw new ProxyProviderError("getQRCode", res.code);
     }
-    return requireData(res, "getQRCode").qrCodeUrl;
+    return parseQrCode(requireData(res));
   }
 
   async checkLogin(): Promise<{
@@ -169,9 +174,9 @@ export class ProxyClient {
       nickName?: string;
     }>("/api/check-login");
     if (res.code !== SUCCESS && res.code !== 1002) {
-      throw new Error(`checkLogin failed: ${res.message ?? res.code}`);
+      throw new ProxyProviderError("checkLogin", res.code);
     }
-    return requireData(res, "checkLogin");
+    return parseLoginStatus(requireData(res));
   }
 
   async sendText(to: string, text: string): Promise<void> {
@@ -180,8 +185,9 @@ export class ProxyClient {
       throw new LoginExpiredError();
     }
     if (res.code !== SUCCESS && res.code !== 1002) {
-      throw new Error(`sendText failed: ${res.message ?? res.code}`);
+      throw new ProxyProviderError("sendText", res.code);
     }
+    parseAcceptedMutation(requireData(res), "sendText");
   }
 
   async sendImage(to: string, imagePath: string, text?: string): Promise<void> {
@@ -194,8 +200,9 @@ export class ProxyClient {
       throw new LoginExpiredError();
     }
     if (res.code !== SUCCESS && res.code !== 1002) {
-      throw new Error(`sendImage failed: ${res.message ?? res.code}`);
+      throw new ProxyProviderError("sendImage", res.code);
     }
+    parseAcceptedMutation(requireData(res), "sendImage");
   }
 
   async getContacts(): Promise<{
@@ -207,9 +214,9 @@ export class ProxyClient {
       chatrooms: Array<{ wxid: string; name: string }>;
     }>("/api/contacts");
     if (res.code !== SUCCESS) {
-      throw new Error(`getContacts failed: ${res.message ?? res.code}`);
+      throw new ProxyProviderError("getContacts", res.code);
     }
-    return requireData(res, "getContacts");
+    return parseContacts(requireData(res));
   }
 
   async registerWebhook(url: string): Promise<void> {
@@ -217,8 +224,9 @@ export class ProxyClient {
       webhookUrl: url,
     });
     if (res.code !== SUCCESS && res.code !== 1002) {
-      throw new Error(`registerWebhook failed: ${res.message ?? res.code}`);
+      throw new ProxyProviderError("registerWebhook", res.code);
     }
+    parseRegisteredWebhook(requireData(res));
   }
 
   get needsLogin(): boolean {
@@ -230,6 +238,23 @@ export class LoginExpiredError extends Error {
   constructor() {
     super("WeChat login expired — re-login required");
     this.name = "LoginExpiredError";
+  }
+}
+
+export class ProxyProviderError extends Error {
+  constructor(
+    readonly operation: string,
+    readonly providerCode: number,
+  ) {
+    super(`WeChat proxy ${operation} failed with code ${providerCode}`);
+    this.name = "ProxyProviderError";
+  }
+}
+
+class ProxyResponseError extends Error {
+  constructor() {
+    super("WeChat proxy returned an invalid response");
+    this.name = "ProxyResponseError";
   }
 }
 
@@ -317,7 +342,9 @@ function normalizeProxyUrl(proxyUrl: string): string {
   if (parsed.search) {
     throw new Error("[wechat] proxyUrl must not include query parameters");
   }
-  parsed.hash = "";
+  if (parsed.hash) {
+    throw new Error("[wechat] proxyUrl must not include a fragment");
+  }
   return parsed.toString().replace(/\/$/, "");
 }
 
@@ -334,11 +361,145 @@ function requireBoundedPositiveInteger(
   return value;
 }
 
-function requireData<T>(response: ProxyApiResponse<T>, action: string): T {
+function requireData<T>(response: ProxyApiResponse<T>): T {
   if (response.data === undefined) {
-    throw new Error(`${action} failed: missing response data`);
+    throw new ProxyResponseError();
   }
   return response.data;
+}
+
+function parseEnvelope(value: unknown): ProxyApiResponse<unknown> {
+  const record = strictRecord(value, ["code"], ["message", "data"]);
+  if (!Number.isSafeInteger(record.code)) throw new ProxyResponseError();
+  if (
+    record.message !== undefined &&
+    (typeof record.message !== "string" || record.message.length > 4096)
+  ) {
+    throw new ProxyResponseError();
+  }
+  return {
+    code: record.code as number,
+    ...(record.message === undefined
+      ? {}
+      : { message: record.message as string }),
+    ...(record.data === undefined ? {} : { data: record.data }),
+  };
+}
+
+function parseAccountStatus(value: unknown): AccountStatus {
+  const record = strictRecord(
+    value,
+    ["valid", "loginState"],
+    ["wcId", "nickName", "tier", "quota"],
+  );
+  if (typeof record.valid !== "boolean") throw new ProxyResponseError();
+  if (!isLoginStatus(record.loginState)) throw new ProxyResponseError();
+  optionalStrings(record, ["wcId", "nickName", "tier"]);
+  if (
+    record.quota !== undefined &&
+    (typeof record.quota !== "number" || !Number.isFinite(record.quota))
+  ) {
+    throw new ProxyResponseError();
+  }
+  return record as unknown as AccountStatus;
+}
+
+function parseQrCode(value: unknown): string {
+  const record = strictRecord(value, ["qrCodeUrl"], []);
+  return requiredString(record.qrCodeUrl);
+}
+
+function parseLoginStatus(value: unknown): {
+  status: "waiting" | "need_verify" | "logged_in";
+  verifyUrl?: string;
+  wcId?: string;
+  nickName?: string;
+} {
+  const record = strictRecord(
+    value,
+    ["status"],
+    ["verifyUrl", "wcId", "nickName"],
+  );
+  if (!isLoginStatus(record.status)) throw new ProxyResponseError();
+  optionalStrings(record, ["verifyUrl", "wcId", "nickName"]);
+  return record as ReturnType<typeof parseLoginStatus>;
+}
+
+function parseContacts(value: unknown): {
+  friends: Array<{ wxid: string; name: string }>;
+  chatrooms: Array<{ wxid: string; name: string }>;
+} {
+  const record = strictRecord(value, ["friends", "chatrooms"], []);
+  return {
+    friends: parseContactList(record.friends),
+    chatrooms: parseContactList(record.chatrooms),
+  };
+}
+
+function parseContactList(
+  value: unknown,
+): Array<{ wxid: string; name: string }> {
+  if (!Array.isArray(value) || value.length > 100_000)
+    throw new ProxyResponseError();
+  return value.map((item) => {
+    const record = strictRecord(item, ["wxid", "name"], []);
+    return {
+      wxid: requiredString(record.wxid),
+      name: requiredString(record.name),
+    };
+  });
+}
+
+function parseAcceptedMutation(value: unknown, operation: string): void {
+  const record = strictRecord(value, ["accepted", "operation"], []);
+  if (record.accepted !== true || record.operation !== operation)
+    throw new ProxyResponseError();
+}
+
+function parseRegisteredWebhook(value: unknown): void {
+  const record = strictRecord(value, ["registered"], []);
+  if (record.registered !== true) throw new ProxyResponseError();
+}
+
+function strictRecord(
+  value: unknown,
+  required: readonly string[],
+  optional: readonly string[],
+): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new ProxyResponseError();
+  const record = value as Record<string, unknown>;
+  const allowed = new Set([...required, ...optional]);
+  if (
+    required.some((key) => !(key in record)) ||
+    Object.keys(record).some((key) => !allowed.has(key))
+  ) {
+    throw new ProxyResponseError();
+  }
+  return record;
+}
+
+function requiredString(value: unknown): string {
+  if (typeof value !== "string" || !value.trim() || value.length > 4096)
+    throw new ProxyResponseError();
+  return value;
+}
+
+function optionalStrings(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+): void {
+  for (const key of keys) {
+    if (record[key] !== undefined) requiredString(record[key]);
+  }
+}
+
+function isLoginStatus(
+  value: unknown,
+): value is "waiting" | "need_verify" | "logged_in" {
+  return (
+    value === "waiting" || value === "need_verify" || value === "logged_in"
+  );
 }
 
 function isJsonMediaType(value: string | null): boolean {

--- a/plugins/plugin-wechat/src/proxy-client.ts
+++ b/plugins/plugin-wechat/src/proxy-client.ts
@@ -13,6 +13,8 @@ import type {
 const SUCCESS = 1000;
 const LOGIN_NEEDED = 1001;
 const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_REQUEST_TIMEOUT_MS = 5 * 60_000;
+const MAX_RETRY_BASE_DELAY_MS = 8_000;
 
 export interface ProxyClientOptions {
   requestTimeoutMs?: number;
@@ -37,13 +39,15 @@ export class ProxyClient {
     this.baseUrl = normalizeProxyUrl(account.proxyUrl);
     this.accountId = account.id;
     this.deviceType = account.deviceType ?? "ipad";
-    this.requestTimeoutMs = requirePositiveInteger(
+    this.requestTimeoutMs = requireBoundedPositiveInteger(
       options.requestTimeoutMs ?? REQUEST_TIMEOUT_MS,
       "requestTimeoutMs",
+      MAX_REQUEST_TIMEOUT_MS,
     );
-    this.retryBaseDelayMs = requirePositiveInteger(
+    this.retryBaseDelayMs = requireBoundedPositiveInteger(
       options.retryBaseDelayMs ?? 1000,
       "retryBaseDelayMs",
+      MAX_RETRY_BASE_DELAY_MS,
     );
     this.signal = options.signal;
   }
@@ -75,6 +79,7 @@ export class ProxyClient {
           headers,
           body: body ? JSON.stringify(body) : undefined,
           signal,
+          redirect: "error",
         });
 
         if (res.status === 429) {
@@ -89,12 +94,26 @@ export class ProxyClient {
           continue;
         }
 
+        if (!res.ok) {
+          // Consume the body to release the connection, but never trust or
+          // surface an untrusted error envelope. HTTP status is authoritative:
+          // a forged `{ code: 1000 }` on an error status cannot become success.
+          await res.text().catch(() => {});
+          throw new ProxyHttpStatusError(res.status);
+        }
+
         const json = (await res.json()) as ProxyApiResponse<T>;
         return json;
       } catch (err) {
         lastError = err instanceof Error ? err : new Error(String(err));
         if (this.signal?.aborted) {
           throw this.signal.reason ?? lastError;
+        }
+        if (err instanceof ProxyHttpStatusError && !err.retryable) {
+          throw err;
+        }
+        if (attempt === 2) {
+          throw lastError;
         }
         const delay = Math.min(this.retryBaseDelayMs * 2 ** attempt, 8000);
         await sleep(delay, this.signal);
@@ -203,6 +222,16 @@ export class LoginExpiredError extends Error {
   }
 }
 
+class ProxyHttpStatusError extends Error {
+  readonly retryable: boolean;
+
+  constructor(readonly status: number) {
+    super(`WeChat proxy request failed with HTTP ${status}`);
+    this.name = "ProxyHttpStatusError";
+    this.retryable = status === 408 || status >= 500;
+  }
+}
+
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   if (signal?.aborted) {
     return Promise.reject(
@@ -274,13 +303,22 @@ function normalizeProxyUrl(proxyUrl: string): string {
   if (parsed.username || parsed.password) {
     throw new Error("[wechat] proxyUrl must not include credentials");
   }
+  if (parsed.search) {
+    throw new Error("[wechat] proxyUrl must not include query parameters");
+  }
   parsed.hash = "";
   return parsed.toString().replace(/\/$/, "");
 }
 
-function requirePositiveInteger(value: number, name: string): number {
-  if (!Number.isSafeInteger(value) || value <= 0) {
-    throw new Error(`[wechat] ${name} must be a positive integer`);
+function requireBoundedPositiveInteger(
+  value: number,
+  name: string,
+  maximum: number,
+): number {
+  if (!Number.isSafeInteger(value) || value <= 0 || value > maximum) {
+    throw new Error(
+      `[wechat] ${name} must be a positive integer no greater than ${maximum}`,
+    );
   }
   return value;
 }


### PR DESCRIPTION
# Relates to

Refs #24093. This is a consumer-first WeChat protocol slice only; the parent issue remains open for Instagram, Matrix, shared receipt/lease composition, strict scenarios, and Cloud subprocess proof.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [ ] Repository-wide verification is blocked by the unchanged package-resolution failures below.
- [x] Exact-head real-client HTTP/webhook proof is recorded below.

# What changed

- Adds `startWechatProxyMock()`, a resettable loopback service with seeded accounts/contacts, auth and device validation, webhook registration/delivery, outbound text/image effect readback, request observations, and queued protocol faults.
- Drives the real production `ProxyClient`; no client method is mocked.
- Keeps production proxies HTTPS-only while allowing literal `127.0.0.1`/`[::1]` HTTP for local simulators. `localhost`, LAN, credentials-in-URL, and other insecure URLs remain rejected.
- Adds configurable bounded timeout/backoff and lifecycle cancellation; external abort interrupts fetch or rate-limit backoff without another attempt.
- Makes HTTP status authoritative: forged success JSON on error status is rejected, 408/429/5xx retry boundedly for safe reads, permanent and ambiguous mutation failures do not retry, redirects fail closed, and timer budgets have safe upper bounds. Every operation now strictly decodes its exact success schema; text/image/webhook mutations require explicit typed acknowledgements.
- Translates provider-controlled failure text into stable operation/code errors with no upstream cause or context, and proves secrets stay absent from message, stack, JSON, recursive fields, and runtime inspection. Proxy base URLs and stored callback URLs reject query/fragment components.
- Proves the real callback server and `Bot` concurrent duplicate suppression.

# Testing

```text
Exact head: 99b3054736b20388487c30c700a3a0931f934ef6
cloud-test-mocks focused contract: 13 passed, 111 assertions
plugin-wechat ProxyClient + callback policy: 47 passed
plugin-wechat build: passed
focused WeChat source TypeScript: passed
changed-file Biome checks: 4 files passed
AGENTS/CLAUDE parity: 160 pairs passed
```

# Evidence Gate

<!-- evidence-head:99b3054736b20388487c30c700a3a0931f934ef6 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - protocol boundary only; real HTTP artifacts and readback are direct evidence.
<!-- evidence-row:backend-logs -->
- [x] Exact-head real-client run passed 13/13 with 111 assertions over actual loopback HTTP and webhook listeners.

```text
bun test v1.3.14
13 pass | 0 fail | 111 expect() calls
Authenticated strict reads/typed mutation acknowledgements/webhook delivery/reset: PASS
Wrong auth/rate limit/malformed/oversized/timeout/cancellation: PASS
Distinctive provider-secret redaction across all public error representations: PASS
Callback query/fragment authoritative-storage rejection: PASS
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM, prompt, action selection, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head authoritative provider-state readback was asserted through the simulator snapshot.

```text
webhook registration: main -> exact loopback account-scoped callback URL; query/hash variants rejected with no stored state
outbound effects: ordered text + image records with target and payload readback
reset receipt: generation 1, requests [], outboundMessages [], webhooks {}; wrong auth applied zero effects
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact.

# Known gaps / failures

- Partial draft: Instagram Graph and Matrix client-server protocol services are not in this PR.
- The simulator is not yet attached to #24076-#24078 generation leases, receipts, or subprocess control because those shared contracts are still separate drafts. It therefore does not claim accepted-effect ledger certification, restart persistence, or Cloud E2E composition.
- WeChat send has no production idempotency key or provider receipt. The client does not retry an ambiguous mutation transport failure, but an accept-then-disconnect still cannot prove whether the provider applied the effect; this PR does not invent an unsupported proxy guarantee.
- Pagination/sync tokens, edits/deletes/reactions, strict deterministic scenarios, and Cloud subprocess execution remain open under #24093.
- `bun run --cwd packages/cloud/test-mocks typecheck` is blocked by unchanged `@elizaos/core/edge` resolution plus existing `control-plane/server.ts` Promise type failure. `bun run --cwd plugins/plugin-wechat typecheck` is blocked by the shared worktree node_modules link resolving `@elizaos/core` to an unbuilt checkout.
- Aggregate package gates retain the same shared-worktree resolution blockers: plugin full tests run 53 passing tests before only `index.test.ts` fails to resolve the unbuilt core package. The exact focused WeChat contract passes 13/13 (111 assertions), ProxyClient + callback policy passes 47/47, focused source TypeScript and the package build pass.
- Full `bun run verify` was not run because these deterministic package-resolution blockers prevent it.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [messaging-protocol-mocks]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A"} -->



