### PR TITLE
feat(test-mocks): add production model-provider protocol loopbacks

### DIFF
--- a/packages/cloud/test-mocks/AGENTS.md
+++ b/packages/cloud/test-mocks/AGENTS.md
@@ -25,6 +25,13 @@ exits.
   `Job`/`JobStatus`/`JobType`/`Sandbox`/`SandboxStatus` types.
 - `src/steward/` (export `./steward`) — stateful loopback mock for authenticated
   Steward platform-user deactivation and deletion calls used by account lifecycle E2E.
+- `src/model-provider/` (export `./model-provider`) — resettable real-HTTP
+  configured-embedding, Google Generative Language, Ollama/zerollama, and z.ai
+  protocol slices. Tests point the production raw-fetch/SDK clients at its
+  provider-specific base URLs. The store exposes only sanitized observations
+  and authoritative model/readback state; it is not a world authority. Request
+  admission is generation-fenced: reset prevents delayed old work from mutating
+  or entering current observations and reports it separately as stale.
 - `src/fetch-server.ts` — shared `startFetchServer(fetch, opts)`; uses
   `Bun.serve` when running under Bun, falls back to a `node:http` adapter
   otherwise.

--- a/packages/cloud/test-mocks/CLAUDE.md
+++ b/packages/cloud/test-mocks/CLAUDE.md
@@ -25,6 +25,13 @@ exits.
   `Job`/`JobStatus`/`JobType`/`Sandbox`/`SandboxStatus` types.
 - `src/steward/` (export `./steward`) — stateful loopback mock for authenticated
   Steward platform-user deactivation and deletion calls used by account lifecycle E2E.
+- `src/model-provider/` (export `./model-provider`) — resettable real-HTTP
+  configured-embedding, Google Generative Language, Ollama/zerollama, and z.ai
+  protocol slices. Tests point the production raw-fetch/SDK clients at its
+  provider-specific base URLs. The store exposes only sanitized observations
+  and authoritative model/readback state; it is not a world authority. Request
+  admission is generation-fenced: reset prevents delayed old work from mutating
+  or entering current observations and reports it separately as stale.
 - `src/fetch-server.ts` — shared `startFetchServer(fetch, opts)`; uses
   `Bun.serve` when running under Bun, falls back to a `node:http` adapter
   otherwise.

--- a/packages/cloud/test-mocks/README.md
+++ b/packages/cloud/test-mocks/README.md
@@ -2,6 +2,24 @@
 
 Stateful, in-process mocks of third-party cloud APIs used by Eliza Cloud. Designed for use in unit / integration tests and local development without hitting real provider APIs.
 
+## Model-provider protocol mock
+
+`@elizaos/cloud-test-mocks/model-provider` starts one resettable loopback server
+with provider-specific base URLs for configured OpenAI-compatible embeddings,
+Google Generative Language, Ollama/zerollama, and z.ai. Production handlers and
+SDK clients serialize the requests; the mock validates the provider wire,
+returns deterministic seeded responses or queued faults, redacts credentials
+from its typed request ledger, and exposes authoritative readback of observed
+calls and Ollama model state. It is a standalone protocol fixture, not a second
+synthetic-world authority; shared cross-process generation/reset orchestration
+remains owned by #24078.
+
+Every request captures the store generation before executing a queued delay.
+Reset fences old requests from applying mutations or entering the current
+observation ledger; stale completions are returned as HTTP 409 and retained in
+the separately generation-tagged `staleObservations` audit. Delay faults also
+stop on request cancellation.
+
 ## Managed provider contract harness
 
 `@elizaos/cloud-test-mocks/provider-contract` provides a reusable real-HTTP

--- a/packages/cloud/test-mocks/package.json
+++ b/packages/cloud/test-mocks/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./hetzner": "./src/hetzner/index.ts",
     "./control-plane": "./src/control-plane/index.ts",
+    "./model-provider": "./src/model-provider/index.ts",
     "./steward": "./src/steward/index.ts",
     "./provider-contract": "./src/provider-contract/index.ts"
   },

--- a/packages/cloud/test-mocks/src/fetch-server.ts
+++ b/packages/cloud/test-mocks/src/fetch-server.ts
@@ -140,9 +140,7 @@ async function handleNodeRequest(
   } catch (error) {
     if (!outgoing.headersSent && !outgoing.destroyed) {
       outgoing.statusCode = 500;
-      outgoing.end(
-        error instanceof Error ? error.message : "mock server error",
-      );
+      outgoing.end("mock server error");
     } else if (!outgoing.destroyed) {
       outgoing.destroy(error instanceof Error ? error : undefined);
     }

--- a/packages/cloud/test-mocks/src/fetch-server.ts
+++ b/packages/cloud/test-mocks/src/fetch-server.ts
@@ -1,6 +1,7 @@
 /** Exports shared cloud mock helpers for deterministic local provider API tests. */
 import http from "node:http";
 import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 
 export interface FetchServerOptions {
   port?: number;
@@ -90,6 +91,16 @@ async function handleNodeRequest(
   incoming: http.IncomingMessage,
   outgoing: http.ServerResponse,
 ) {
+  const abortController = new AbortController();
+  const abortIncoming = () =>
+    abortController.abort(
+      new DOMException("Client disconnected", "AbortError"),
+    );
+  const abortOutgoing = () => {
+    if (!outgoing.writableEnded) abortIncoming();
+  };
+  incoming.once("aborted", abortIncoming);
+  outgoing.once("close", abortOutgoing);
   try {
     const headers = new Headers();
     for (const [key, value] of Object.entries(incoming.headers)) {
@@ -108,6 +119,7 @@ async function handleNodeRequest(
       headers,
       body: hasBody ? Readable.toWeb(incoming) : undefined,
       duplex: hasBody ? "half" : undefined,
+      signal: abortController.signal,
     } as RequestInit & { duplex?: "half" });
 
     const response = await fetch(request);
@@ -115,9 +127,27 @@ async function handleNodeRequest(
     response.headers.forEach((value, key) => {
       outgoing.setHeader(key, value);
     });
-    outgoing.end(Buffer.from(await response.arrayBuffer()));
+    if (!response.body) {
+      outgoing.end();
+    } else {
+      await pipeline(
+        Readable.fromWeb(
+          response.body as unknown as import("node:stream/web").ReadableStream,
+        ),
+        outgoing,
+      );
+    }
   } catch (error) {
-    outgoing.statusCode = 500;
-    outgoing.end(error instanceof Error ? error.message : "mock server error");
+    if (!outgoing.headersSent && !outgoing.destroyed) {
+      outgoing.statusCode = 500;
+      outgoing.end(
+        error instanceof Error ? error.message : "mock server error",
+      );
+    } else if (!outgoing.destroyed) {
+      outgoing.destroy(error instanceof Error ? error : undefined);
+    }
+  } finally {
+    incoming.off("aborted", abortIncoming);
+    outgoing.off("close", abortOutgoing);
   }
 }

--- a/packages/cloud/test-mocks/src/index.ts
+++ b/packages/cloud/test-mocks/src/index.ts
@@ -1,5 +1,6 @@
 /** Exports cloud mocks and provider-contract infrastructure for deterministic tests. */
 export * as controlPlane from "./control-plane";
 export * from "./hetzner";
+export * as modelProvider from "./model-provider";
 export * as providerContract from "./provider-contract";
 export * from "./steward";

--- a/packages/cloud/test-mocks/src/model-provider/index.ts
+++ b/packages/cloud/test-mocks/src/model-provider/index.ts
@@ -1,0 +1,30 @@
+/** Starts and exports the resettable local model-provider protocol mock. */
+
+import { startFetchServer } from "../fetch-server";
+import { buildModelProviderMockFetch, ModelProviderMockStore } from "./server";
+import type { ModelProviderSeed } from "./types";
+
+export * from "./server";
+export * from "./types";
+
+export async function startModelProviderMock(options: {
+  seed: ModelProviderSeed;
+  port?: number;
+  hostname?: string;
+}) {
+  const store = new ModelProviderMockStore(options.seed);
+  const server = await startFetchServer(buildModelProviderMockFetch(store), {
+    port: options.port,
+    hostname: options.hostname,
+  });
+  const origin = `http://${server.hostname}:${server.port}`;
+  return {
+    origin,
+    configuredEmbeddingBaseUrl: `${origin}/configured/v1`,
+    googleBaseUrl: `${origin}/google`,
+    ollamaBaseUrl: `${origin}/ollama`,
+    zaiBaseUrl: `${origin}/zai`,
+    store,
+    stop: server.stop,
+  };
+}

--- a/packages/cloud/test-mocks/src/model-provider/server.ts
+++ b/packages/cloud/test-mocks/src/model-provider/server.ts
@@ -9,9 +9,41 @@ import type {
 } from "./types";
 
 const JSON_HEADERS = { "content-type": "application/json" };
+export const MODEL_PROVIDER_MAX_REQUEST_BYTES = 1024 * 1024;
+const MODEL_PROVIDER_MAX_JSON_DEPTH = 64;
+const MODEL_PROVIDER_MAX_JSON_NODES = 100_000;
+
+class InvalidProviderRequest extends Error {
+  constructor(
+    readonly status: 400 | 413,
+    readonly code:
+      | "INVALID_JSON"
+      | "REQUEST_TOO_LARGE"
+      | "JSON_TOO_COMPLEX"
+      | "UNSUPPORTED_ENCODING"
+      | "UNSUPPORTED_MEDIA_TYPE",
+  ) {
+    super(code);
+  }
+}
 
 function clone<T>(value: T): T {
   return structuredClone(value);
+}
+
+function boundedObservationBody(value: unknown): unknown {
+  try {
+    assertJsonComplexity(value);
+    if (
+      new TextEncoder().encode(JSON.stringify(value)).byteLength >
+      MODEL_PROVIDER_MAX_REQUEST_BYTES
+    ) {
+      throw new InvalidProviderRequest(413, "REQUEST_TOO_LARGE");
+    }
+    return clone(value);
+  } catch {
+    return { omitted: "observation body exceeded protocol bounds" };
+  }
 }
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -24,7 +56,10 @@ function redactHeaders(headers: Headers): Record<string, string> {
   const sanitized: Record<string, string> = {};
   headers.forEach((value, key) => {
     sanitized[key] =
-      key === "authorization" || key === "x-goog-api-key"
+      key === "authorization" ||
+      key === "x-goog-api-key" ||
+      key === "x-api-key" ||
+      key === "api-key"
         ? "<redacted>"
         : value;
   });
@@ -33,7 +68,9 @@ function redactHeaders(headers: Headers): Record<string, string> {
 
 function sanitizedPath(url: URL): string {
   const copy = new URL(url);
-  if (copy.searchParams.has("key")) copy.searchParams.set("key", "<redacted>");
+  for (const key of ["key", "api_key", "access_token", "token"]) {
+    if (copy.searchParams.has(key)) copy.searchParams.set(key, "<redacted>");
+  }
   return `${copy.pathname}${copy.search}`;
 }
 
@@ -56,12 +93,82 @@ function unauthorized(provider: string): Response {
 }
 
 async function requestBody(request: Request): Promise<unknown> {
-  const text = await request.text();
-  if (!text) return null;
+  if (request.method === "GET" || request.method === "HEAD") return null;
+  const contentEncoding = request.headers.get("content-encoding");
+  if (contentEncoding !== null && contentEncoding.toLowerCase() !== "identity")
+    throw new InvalidProviderRequest(400, "UNSUPPORTED_ENCODING");
+  const contentType = request.headers.get("content-type");
+  if (!contentType || !/^application\/json(?:\s*;|$)/i.test(contentType))
+    throw new InvalidProviderRequest(400, "UNSUPPORTED_MEDIA_TYPE");
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength !== null) {
+    const length = Number(declaredLength);
+    if (!Number.isSafeInteger(length) || length < 0)
+      throw new InvalidProviderRequest(400, "INVALID_JSON");
+    if (length > MODEL_PROVIDER_MAX_REQUEST_BYTES)
+      throw new InvalidProviderRequest(413, "REQUEST_TOO_LARGE");
+  }
+
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  const reader = request.body?.getReader();
+  if (reader) {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += value.byteLength;
+      if (received > MODEL_PROVIDER_MAX_REQUEST_BYTES) {
+        await reader.cancel("model-provider request body limit exceeded");
+        throw new InvalidProviderRequest(413, "REQUEST_TOO_LARGE");
+      }
+      chunks.push(value);
+    }
+  }
+  const bytes = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  let text: string;
   try {
-    return JSON.parse(text) as unknown;
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   } catch {
-    return { malformedJson: true, raw: text };
+    throw new InvalidProviderRequest(400, "INVALID_JSON");
+  }
+  if (!text) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch {
+    throw new InvalidProviderRequest(400, "INVALID_JSON");
+  }
+  assertJsonComplexity(parsed);
+  return parsed;
+}
+
+function assertJsonComplexity(value: unknown): void {
+  const pending: Array<{ value: unknown; depth: number }> = [
+    { value, depth: 0 },
+  ];
+  let nodes = 0;
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current) break;
+    nodes += 1;
+    if (
+      nodes > MODEL_PROVIDER_MAX_JSON_NODES ||
+      current.depth > MODEL_PROVIDER_MAX_JSON_DEPTH
+    ) {
+      throw new InvalidProviderRequest(413, "JSON_TOO_COMPLEX");
+    }
+    if (Array.isArray(current.value)) {
+      for (const child of current.value)
+        pending.push({ value: child, depth: current.depth + 1 });
+    } else if (current.value !== null && typeof current.value === "object") {
+      for (const child of Object.values(current.value))
+        pending.push({ value: child, depth: current.depth + 1 });
+    }
   }
 }
 
@@ -158,7 +265,7 @@ export class ModelProviderMockStore {
     const observation = {
       sequence: ++this.sequence,
       generation,
-      ...clone(args),
+      ...clone({ ...args, body: boundedObservationBody(args.body) }),
     };
     if (this.isCurrent(generation)) this.observations.push(observation);
     else this.staleObservations.push(observation);
@@ -245,12 +352,31 @@ export function buildModelProviderMockFetch(store: ModelProviderMockStore) {
     const admittedGeneration = store.generation;
     const admittedSeed = store.seed;
     const operation = classify(url.pathname);
-    const body = await requestBody(request);
     if (!operation)
       return json(
         { error: { message: "unknown synthetic provider route" } },
         404,
       );
+    let body: unknown;
+    try {
+      body = await requestBody(request);
+    } catch (error) {
+      if (!(error instanceof InvalidProviderRequest)) throw error;
+      const response = json(
+        { error: { code: error.code, message: "invalid provider request" } },
+        error.status,
+        { connection: "close" },
+      );
+      store.record(admittedGeneration, {
+        operation,
+        method: request.method,
+        path: sanitizedPath(url),
+        headers: redactHeaders(request.headers),
+        body: { invalidRequest: error.code },
+        status: response.status,
+      });
+      return response;
+    }
 
     if (!store.isCurrent(admittedGeneration)) {
       const stale = json(

--- a/packages/cloud/test-mocks/src/model-provider/server.ts
+++ b/packages/cloud/test-mocks/src/model-provider/server.ts
@@ -1,0 +1,561 @@
+/** Implements protocol-shaped configured-embedding, Gemini, Ollama, and z.ai loopback APIs. */
+
+import type {
+  ModelProviderFault,
+  ModelProviderObservation,
+  ModelProviderOperation,
+  ModelProviderReadback,
+  ModelProviderSeed,
+} from "./types";
+
+const JSON_HEADERS = { "content-type": "application/json" };
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value))
+    return {};
+  return value as Record<string, unknown>;
+}
+
+function redactHeaders(headers: Headers): Record<string, string> {
+  const sanitized: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    sanitized[key] =
+      key === "authorization" || key === "x-goog-api-key"
+        ? "<redacted>"
+        : value;
+  });
+  return sanitized;
+}
+
+function sanitizedPath(url: URL): string {
+  const copy = new URL(url);
+  if (copy.searchParams.has("key")) copy.searchParams.set("key", "<redacted>");
+  return `${copy.pathname}${copy.search}`;
+}
+
+function json(
+  body: unknown,
+  status = 200,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...JSON_HEADERS, ...headers },
+  });
+}
+
+function unauthorized(provider: string): Response {
+  return json(
+    { error: { code: 401, message: `${provider} authentication failed` } },
+    401,
+  );
+}
+
+async function requestBody(request: Request): Promise<unknown> {
+  const text = await request.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return { malformedJson: true, raw: text };
+  }
+}
+
+function extractGoogleText(body: Record<string, unknown>): string {
+  const contents = body.contents as
+    | Array<{ parts?: Array<{ text?: string }> }>
+    | undefined;
+  const requests = body.requests as
+    | Array<{ content?: { parts?: Array<{ text?: string }> } }>
+    | undefined;
+  return (
+    contents?.[0]?.parts?.[0]?.text ??
+    requests?.[0]?.content?.parts?.[0]?.text ??
+    ""
+  );
+}
+
+function authMatches(
+  request: Request,
+  expected: string | undefined,
+  kind: "bearer" | "google",
+) {
+  if (!expected) return true;
+  if (kind === "google") {
+    const url = new URL(request.url);
+    return (
+      request.headers.get("x-goog-api-key") === expected ||
+      url.searchParams.get("key") === expected
+    );
+  }
+  return request.headers.get("authorization") === `Bearer ${expected}`;
+}
+
+export class ModelProviderMockStore {
+  private currentSeed: ModelProviderSeed;
+  private faults: Partial<Record<ModelProviderOperation, ModelProviderFault[]>>;
+  private observations: ModelProviderObservation[] = [];
+  private staleObservations: ModelProviderObservation[] = [];
+  private generationValue = 1;
+  private sequence = 0;
+  private ollamaModels: Set<string>;
+
+  constructor(seed: ModelProviderSeed) {
+    this.currentSeed = clone(seed);
+    this.faults = clone(seed.faults ?? {});
+    this.ollamaModels = new Set(seed.ollama?.models ?? []);
+  }
+
+  get seed(): Readonly<ModelProviderSeed> {
+    return clone(this.currentSeed);
+  }
+
+  get generation(): number {
+    return this.generationValue;
+  }
+
+  isCurrent(generation: number): boolean {
+    return generation === this.generationValue;
+  }
+
+  reset(seed: ModelProviderSeed = this.currentSeed): number {
+    this.currentSeed = clone(seed);
+    this.faults = clone(seed.faults ?? {});
+    this.observations = [];
+    this.staleObservations = [];
+    this.ollamaModels = new Set(seed.ollama?.models ?? []);
+    this.sequence = 0;
+    this.generationValue += 1;
+    return this.generationValue;
+  }
+
+  takeFault(
+    operation: ModelProviderOperation,
+    generation: number,
+  ): ModelProviderFault | undefined {
+    if (!this.isCurrent(generation)) return undefined;
+    return this.faults[operation]?.shift();
+  }
+
+  hasOllamaModel(model: string): boolean {
+    return this.ollamaModels.has(model);
+  }
+
+  addOllamaModel(model: string, generation: number): boolean {
+    if (!this.isCurrent(generation)) return false;
+    this.ollamaModels.add(model);
+    return true;
+  }
+
+  record(
+    generation: number,
+    args: Omit<ModelProviderObservation, "sequence" | "generation">,
+  ): void {
+    const observation = {
+      sequence: ++this.sequence,
+      generation,
+      ...clone(args),
+    };
+    if (this.isCurrent(generation)) this.observations.push(observation);
+    else this.staleObservations.push(observation);
+  }
+
+  readback(): ModelProviderReadback {
+    const remainingFaults: Partial<Record<ModelProviderOperation, number>> = {};
+    for (const [operation, faults] of Object.entries(this.faults)) {
+      if (faults?.length)
+        remainingFaults[operation as ModelProviderOperation] = faults.length;
+    }
+    return {
+      generation: this.generationValue,
+      observations: clone(this.observations),
+      staleObservations: clone(this.staleObservations),
+      ollamaModels: [...this.ollamaModels].sort(),
+      remainingFaults,
+    };
+  }
+}
+
+async function faultResponse(
+  fault: ModelProviderFault | undefined,
+  signal: AbortSignal,
+): Promise<Response | undefined> {
+  if (!fault) return undefined;
+  if (fault.type === "delay") {
+    await abortableDelay(fault.delayMs, signal);
+    return undefined;
+  }
+  if (fault.type === "malformed") {
+    return new Response(fault.body ?? "{not-json", {
+      status: 200,
+      headers: JSON_HEADERS,
+    });
+  }
+  return json(
+    fault.body ?? { error: { message: `synthetic HTTP ${fault.status}` } },
+    fault.status,
+    fault.headers,
+  );
+}
+
+async function abortableDelay(
+  delayMs: number,
+  signal: AbortSignal,
+): Promise<void> {
+  if (signal.aborted)
+    throw signal.reason ?? new DOMException("Aborted", "AbortError");
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(done, delayMs);
+    signal.addEventListener("abort", aborted, { once: true });
+    function done() {
+      signal.removeEventListener("abort", aborted);
+      resolve();
+    }
+    function aborted() {
+      clearTimeout(timer);
+      reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+    }
+  });
+}
+
+function classify(path: string): ModelProviderOperation | null {
+  if (path === "/configured/v1/embeddings") return "configured-embedding";
+  if (path === "/zai/chat/completions") return "zai-chat";
+  if (path.startsWith("/google/") && path.includes(":countTokens"))
+    return "google-count-tokens";
+  if (path.startsWith("/google/") && path.includes(":batchEmbedContents"))
+    return "google-embedding";
+  if (path.startsWith("/google/") && path.includes(":generateContent"))
+    return "google-generate";
+  if (path === "/ollama/api/version") return "ollama-version";
+  if (path === "/ollama/api/show") return "ollama-model-show";
+  if (path === "/ollama/api/pull") return "ollama-model-pull";
+  if (path === "/ollama/api/chat") return "ollama-chat";
+  if (path === "/ollama/api/embed") return "ollama-embedding";
+  return null;
+}
+
+export function buildModelProviderMockFetch(store: ModelProviderMockStore) {
+  return async (request: Request): Promise<Response> => {
+    const url = new URL(request.url);
+    const admittedGeneration = store.generation;
+    const admittedSeed = store.seed;
+    const operation = classify(url.pathname);
+    const body = await requestBody(request);
+    if (!operation)
+      return json(
+        { error: { message: "unknown synthetic provider route" } },
+        404,
+      );
+
+    if (!store.isCurrent(admittedGeneration)) {
+      const stale = json(
+        { error: { message: "synthetic provider generation is stale" } },
+        409,
+      );
+      store.record(admittedGeneration, {
+        operation,
+        method: request.method,
+        path: sanitizedPath(url),
+        headers: redactHeaders(request.headers),
+        body,
+        status: stale.status,
+      });
+      return stale;
+    }
+
+    let failure: Response | undefined;
+    try {
+      failure = await faultResponse(
+        store.takeFault(operation, admittedGeneration),
+        request.signal,
+      );
+    } catch (error) {
+      store.record(admittedGeneration, {
+        operation,
+        method: request.method,
+        path: sanitizedPath(url),
+        headers: redactHeaders(request.headers),
+        body,
+        status: 499,
+      });
+      throw error;
+    }
+    if (!store.isCurrent(admittedGeneration)) {
+      const stale = json(
+        { error: { message: "synthetic provider generation is stale" } },
+        409,
+      );
+      store.record(admittedGeneration, {
+        operation,
+        method: request.method,
+        path: sanitizedPath(url),
+        headers: redactHeaders(request.headers),
+        body,
+        status: stale.status,
+      });
+      return stale;
+    }
+    if (failure) {
+      store.record(admittedGeneration, {
+        operation,
+        method: request.method,
+        path: sanitizedPath(url),
+        headers: redactHeaders(request.headers),
+        body,
+        status: failure.status,
+      });
+      return failure;
+    }
+
+    let response: Response;
+    const row = asRecord(body);
+    switch (operation) {
+      case "configured-embedding": {
+        if (
+          !authMatches(
+            request,
+            admittedSeed.auth?.["configured-embedding"],
+            "bearer",
+          )
+        ) {
+          response = unauthorized("configured embedding");
+          break;
+        }
+        const fixture = admittedSeed.configuredEmbedding;
+        if (!fixture || row.model !== fixture.model) {
+          response = json(
+            { error: { message: "unknown embedding model" } },
+            400,
+          );
+          break;
+        }
+        const inputs = Array.isArray(row.input) ? row.input : [row.input];
+        if (!inputs.every((input) => typeof input === "string")) {
+          response = json(
+            { error: { message: "input must be string or string[]" } },
+            400,
+          );
+          break;
+        }
+        const vectors = inputs.map((input) => fixture.vectors[input as string]);
+        if (vectors.some((vector) => !vector)) {
+          response = json(
+            { error: { message: "unseeded embedding input" } },
+            422,
+          );
+          break;
+        }
+        const requestedDimensions = row.dimensions;
+        if (
+          requestedDimensions !== undefined &&
+          requestedDimensions !== fixture.dimensions
+        ) {
+          response = json(
+            { error: { message: "unsupported dimensions" } },
+            400,
+          );
+          break;
+        }
+        response = json({
+          object: "list",
+          data: vectors.map((embedding, index) => ({
+            object: "embedding",
+            index,
+            embedding,
+          })),
+          model: fixture.model,
+          usage: {
+            prompt_tokens: fixture.promptTokens ?? inputs.length,
+            total_tokens: fixture.promptTokens ?? inputs.length,
+          },
+        });
+        break;
+      }
+      case "zai-chat": {
+        if (!authMatches(request, admittedSeed.auth?.zai, "bearer")) {
+          response = unauthorized("z.ai");
+          break;
+        }
+        const fixture = admittedSeed.zai;
+        if (
+          !fixture ||
+          row.model !== fixture.model ||
+          !Array.isArray(row.messages)
+        ) {
+          response = json(
+            { error: { message: "invalid z.ai chat request" } },
+            400,
+          );
+          break;
+        }
+        response = json({
+          id: "chatcmpl_synthetic",
+          object: "chat.completion",
+          created: 1,
+          model: fixture.model,
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: fixture.text },
+              finish_reason: "stop",
+            },
+          ],
+          usage: {
+            prompt_tokens: fixture.promptTokens ?? 3,
+            completion_tokens: fixture.completionTokens ?? 2,
+            total_tokens:
+              (fixture.promptTokens ?? 3) + (fixture.completionTokens ?? 2),
+          },
+        });
+        break;
+      }
+      case "google-count-tokens": {
+        if (!authMatches(request, admittedSeed.auth?.google, "google")) {
+          response = unauthorized("Google");
+          break;
+        }
+        response = json({ totalTokens: admittedSeed.google?.inputTokens ?? 0 });
+        break;
+      }
+      case "google-embedding": {
+        if (!authMatches(request, admittedSeed.auth?.google, "google")) {
+          response = unauthorized("Google");
+          break;
+        }
+        response = json({
+          embeddings: [{ values: admittedSeed.google?.embedding ?? [] }],
+        });
+        break;
+      }
+      case "google-generate": {
+        if (!authMatches(request, admittedSeed.auth?.google, "google")) {
+          response = unauthorized("Google");
+          break;
+        }
+        const fixture = admittedSeed.google;
+        response = json({
+          candidates: [
+            {
+              content: {
+                role: "model",
+                parts: [{ text: fixture?.text ?? "" }],
+              },
+              finishReason: "STOP",
+              index: 0,
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: fixture?.inputTokens ?? 0,
+            candidatesTokenCount: fixture?.outputTokens ?? 0,
+            totalTokenCount:
+              (fixture?.inputTokens ?? 0) + (fixture?.outputTokens ?? 0),
+          },
+        });
+        break;
+      }
+      case "ollama-version": {
+        const distribution = admittedSeed.ollama?.distribution ?? "zerollama";
+        response = json({ version: "0.0.0-synthetic", distribution });
+        break;
+      }
+      case "ollama-model-show": {
+        const model = typeof row.model === "string" ? row.model : "";
+        response = store.hasOllamaModel(model)
+          ? json({ model_info: { "general.context_length": 8192 } })
+          : json({ error: "model not found" }, 404);
+        break;
+      }
+      case "ollama-model-pull": {
+        const model = typeof row.model === "string" ? row.model : "";
+        if (!model) response = json({ error: "model required" }, 400);
+        else {
+          response = store.addOllamaModel(model, admittedGeneration)
+            ? json({ status: "success" })
+            : json({ error: "synthetic provider generation is stale" }, 409);
+        }
+        break;
+      }
+      case "ollama-chat": {
+        const fixture = admittedSeed.ollama;
+        if (
+          !fixture ||
+          typeof row.model !== "string" ||
+          !Array.isArray(row.messages)
+        ) {
+          response = json({ error: "invalid chat request" }, 400);
+          break;
+        }
+        if (row.stream === true) {
+          const chunks = fixture.streamChunks ?? [fixture.text];
+          const encoder = new TextEncoder();
+          const stream = new ReadableStream<Uint8Array>({
+            start(controller) {
+              for (const [index, chunk] of chunks.entries()) {
+                controller.enqueue(
+                  encoder.encode(
+                    `${JSON.stringify({
+                      model: row.model,
+                      message: { role: "assistant", content: chunk },
+                      done: index === chunks.length - 1,
+                      ...(index === chunks.length - 1
+                        ? {
+                            done_reason: "stop",
+                            prompt_eval_count: fixture.promptTokens ?? 3,
+                            eval_count:
+                              fixture.completionTokens ?? chunks.length,
+                          }
+                        : {}),
+                    })}\n`,
+                  ),
+                );
+              }
+              controller.close();
+            },
+          });
+          response = new Response(stream, {
+            headers: { "content-type": "application/x-ndjson" },
+          });
+        } else {
+          response = json({
+            model: row.model,
+            message: { role: "assistant", content: fixture.text },
+            done: true,
+            done_reason: "stop",
+            prompt_eval_count: fixture.promptTokens ?? 3,
+            eval_count: fixture.completionTokens ?? 2,
+          });
+        }
+        break;
+      }
+      case "ollama-embedding": {
+        const fixture = admittedSeed.ollama;
+        const input = row.input;
+        const count = Array.isArray(input) ? input.length : 1;
+        response = json({
+          embeddings: Array.from(
+            { length: count },
+            () => fixture?.embedding ?? [],
+          ),
+        });
+        break;
+      }
+    }
+
+    store.record(admittedGeneration, {
+      operation,
+      method: request.method,
+      path: sanitizedPath(url),
+      headers: redactHeaders(request.headers),
+      body: operation.startsWith("google-")
+        ? { ...row, extractedText: extractGoogleText(row) }
+        : body,
+      status: response.status,
+    });
+    return response;
+  };
+}

--- a/packages/cloud/test-mocks/src/model-provider/types.ts
+++ b/packages/cloud/test-mocks/src/model-provider/types.ts
@@ -1,0 +1,74 @@
+/** Defines deterministic model-provider fixtures, faults, observations, and readback state. */
+
+export type ModelProviderOperation =
+  | "configured-embedding"
+  | "google-count-tokens"
+  | "google-embedding"
+  | "google-generate"
+  | "ollama-version"
+  | "ollama-model-show"
+  | "ollama-model-pull"
+  | "ollama-chat"
+  | "ollama-embedding"
+  | "zai-chat";
+
+export type ModelProviderFault =
+  | {
+      type: "http";
+      status: number;
+      body?: unknown;
+      headers?: Record<string, string>;
+    }
+  | { type: "malformed"; body?: string }
+  | { type: "delay"; delayMs: number };
+
+export interface ModelProviderSeed {
+  auth?: Partial<Record<"configured-embedding" | "google" | "zai", string>>;
+  configuredEmbedding?: {
+    model: string;
+    dimensions: number;
+    vectors: Record<string, number[]>;
+    promptTokens?: number;
+  };
+  google?: {
+    text: string;
+    embedding: number[];
+    inputTokens: number;
+    outputTokens?: number;
+  };
+  ollama?: {
+    distribution?: "ollama" | "zerollama";
+    models: string[];
+    text: string;
+    streamChunks?: string[];
+    embedding: number[];
+    promptTokens?: number;
+    completionTokens?: number;
+  };
+  zai?: {
+    model: string;
+    text: string;
+    promptTokens?: number;
+    completionTokens?: number;
+  };
+  faults?: Partial<Record<ModelProviderOperation, ModelProviderFault[]>>;
+}
+
+export interface ModelProviderObservation {
+  sequence: number;
+  generation: number;
+  operation: ModelProviderOperation;
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  body: unknown;
+  status: number;
+}
+
+export interface ModelProviderReadback {
+  generation: number;
+  observations: ModelProviderObservation[];
+  staleObservations: ModelProviderObservation[];
+  ollamaModels: string[];
+  remainingFaults: Partial<Record<ModelProviderOperation, number>>;
+}

--- a/packages/cloud/test-mocks/test/fetch-server.node.test.ts
+++ b/packages/cloud/test-mocks/test/fetch-server.node.test.ts
@@ -1,0 +1,58 @@
+/** Proves the shared HTTP adapter preserves streaming and cancellation in a real Node subprocess. */
+
+import { afterEach, expect, it } from "bun:test";
+
+const children: Bun.Subprocess[] = [];
+
+afterEach(async () => {
+  for (const child of children.splice(0)) {
+    child.kill("SIGTERM");
+    await child.exited;
+  }
+});
+
+async function readLine(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<string> {
+  const decoder = new TextDecoder();
+  let line = "";
+  while (!line.includes("\n")) {
+    const { done, value } = await reader.read();
+    if (done) throw new Error("Node fixture exited before emitting a line");
+    line += decoder.decode(value, { stream: true });
+  }
+  return line.slice(0, line.indexOf("\n"));
+}
+
+it("streams the first chunk without buffering and aborts work on disconnect", async () => {
+  const child = Bun.spawn(
+    [
+      "node",
+      "--experimental-strip-types",
+      "test/fixtures/fetch-server-node-stream.ts",
+    ],
+    {
+      cwd: import.meta.dir.replace(/\/test$/, ""),
+      stdout: "pipe",
+      stderr: "inherit",
+    },
+  );
+  children.push(child);
+  const stdout = child.stdout.getReader();
+  const port = Number(await readLine(stdout));
+  expect(Number.isInteger(port)).toBe(true);
+
+  const startedAt = performance.now();
+  const controller = new AbortController();
+  const response = await fetch(`http://127.0.0.1:${port}/stream`, {
+    signal: controller.signal,
+  });
+  const body = response.body?.getReader();
+  if (!body) throw new Error("Node fixture returned no response body");
+  const first = await body.read();
+  expect(new TextDecoder().decode(first.value)).toBe("first\n");
+  expect(performance.now() - startedAt).toBeLessThan(750);
+
+  controller.abort("test disconnect");
+  expect(await readLine(stdout)).toBe("aborted");
+});

--- a/packages/cloud/test-mocks/test/fetch-server.node.test.ts
+++ b/packages/cloud/test-mocks/test/fetch-server.node.test.ts
@@ -55,4 +55,10 @@ it("streams the first chunk without buffering and aborts work on disconnect", as
 
   controller.abort("test disconnect");
   expect(await readLine(stdout)).toBe("aborted");
+
+  const failed = await fetch(`http://127.0.0.1:${port}/throw`);
+  expect(failed.status).toBe(500);
+  const failureBody = await failed.text();
+  expect(failureBody).toBe("mock server error");
+  expect(failureBody).not.toContain("NODE_ADAPTER_SECRET");
 });

--- a/packages/cloud/test-mocks/test/fixtures/fetch-server-node-stream.ts
+++ b/packages/cloud/test-mocks/test/fixtures/fetch-server-node-stream.ts
@@ -4,8 +4,11 @@ import { startFetchServer } from "../../src/fetch-server.ts";
 
 const encoder = new TextEncoder();
 const server = await startFetchServer(
-  (request) =>
-    new Response(
+  (request) => {
+    if (new URL(request.url).pathname === "/throw") {
+      throw new Error("NODE_ADAPTER_SECRET_do-not-reflect_9e37");
+    }
+    return new Response(
       new ReadableStream<Uint8Array>({
         start(controller) {
           controller.enqueue(encoder.encode("first\n"));
@@ -25,7 +28,8 @@ const server = await startFetchServer(
         },
       }),
       { headers: { "content-type": "text/plain" } },
-    ),
+    );
+  },
   { hostname: "127.0.0.1", port: 0 },
 );
 

--- a/packages/cloud/test-mocks/test/fixtures/fetch-server-node-stream.ts
+++ b/packages/cloud/test-mocks/test/fixtures/fetch-server-node-stream.ts
@@ -1,0 +1,39 @@
+/** Runs the Node fallback HTTP adapter for subprocess streaming and cancellation proof. */
+
+import { startFetchServer } from "../../src/fetch-server.ts";
+
+const encoder = new TextEncoder();
+const server = await startFetchServer(
+  (request) =>
+    new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode("first\n"));
+          const timer = setTimeout(() => {
+            controller.enqueue(encoder.encode("second\n"));
+            controller.close();
+          }, 1_000);
+          request.signal.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              process.stdout.write("aborted\n");
+              controller.error(request.signal.reason);
+            },
+            { once: true },
+          );
+        },
+      }),
+      { headers: { "content-type": "text/plain" } },
+    ),
+  { hostname: "127.0.0.1", port: 0 },
+);
+
+process.stdout.write(`${server.port}\n`);
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.once(signal, async () => {
+    await server.stop();
+    process.exit(0);
+  });
+}

--- a/packages/cloud/test-mocks/test/model-provider.test.ts
+++ b/packages/cloud/test-mocks/test/model-provider.test.ts
@@ -1,0 +1,361 @@
+/** Exercises four production model-provider clients against the resettable real-HTTP mock. */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import type { IAgentRuntime } from "@elizaos/core";
+import { handleTextEmbedding as handleConfiguredEmbedding } from "../../../../plugins/plugin-embeddings/src/models/embedding";
+import { handleTextEmbedding as handleGoogleEmbedding } from "../../../../plugins/plugin-google-genai/models/embedding";
+import { handleTextSmall as handleGoogleText } from "../../../../plugins/plugin-google-genai/models/text";
+import { handleTextSmall as handleZaiText } from "../../../../plugins/plugin-zai/models/text";
+import { handleTextEmbedding as handleOllamaEmbedding } from "../../../../plugins/plugin-zerollama/models/embedding";
+import { handleTextSmall as handleOllamaText } from "../../../../plugins/plugin-zerollama/models/text";
+import { clearOllamaHostFlavorCache } from "../../../../plugins/plugin-zerollama/utils/host-flavor";
+import { startModelProviderMock } from "../src/model-provider";
+import type { ModelProviderSeed } from "../src/model-provider/types";
+
+const vector = (length: number, offset = 0) =>
+  Array.from(
+    { length },
+    (_, index) => (index + 1 + offset) / (length + offset + 1),
+  );
+const configuredAlpha = vector(384);
+const configuredBeta = vector(384, 1);
+const googleEmbedding = [1, ...Array(767).fill(0)];
+const ollamaEmbedding = vector(384);
+const baseOllamaSeed: NonNullable<ModelProviderSeed["ollama"]> = {
+  distribution: "zerollama",
+  models: ["synthetic-text", "synthetic-embed"],
+  text: "ollama synthetic answer",
+  streamChunks: ["ollama ", "synthetic ", "answer"],
+  embedding: ollamaEmbedding,
+  promptTokens: 5,
+  completionTokens: 3,
+};
+
+const baseSeed: ModelProviderSeed = {
+  auth: {
+    "configured-embedding": "embedding-key",
+    google: "google-key",
+    zai: "zai-key",
+  },
+  configuredEmbedding: {
+    model: "synthetic-embedding",
+    dimensions: 384,
+    vectors: { alpha: configuredAlpha, beta: configuredBeta },
+    promptTokens: 4,
+  },
+  google: {
+    text: "google synthetic answer",
+    embedding: googleEmbedding,
+    inputTokens: 7,
+    outputTokens: 3,
+  },
+  ollama: baseOllamaSeed,
+  zai: {
+    model: "glm-synthetic",
+    text: "z.ai synthetic answer",
+    promptTokens: 6,
+    completionTokens: 4,
+  },
+};
+
+const running: Array<{ stop(): Promise<void> }> = [];
+
+afterEach(async () => {
+  clearOllamaHostFlavorCache();
+  await Promise.all(running.splice(0).map((server) => server.stop()));
+});
+
+function runtime(settings: Record<string, string>): IAgentRuntime {
+  const trajectoryLogger = {
+    isEnabled: () => false,
+    logLlmCall: () => undefined,
+  };
+  return {
+    agentId: "synthetic-model-agent",
+    character: {
+      name: "Ada",
+      system: "Answer from the deterministic synthetic world.",
+    },
+    emitEvent: async () => undefined,
+    getService: (name: string) =>
+      name === "trajectories" ? trajectoryLogger : null,
+    getServicesByType: (type: string) =>
+      type === "trajectories" ? [trajectoryLogger] : [],
+    getSetting: (key: string) => settings[key] ?? null,
+    reportError: () => undefined,
+  } as unknown as IAgentRuntime;
+}
+
+async function start(seed: ModelProviderSeed = baseSeed) {
+  const server = await startModelProviderMock({ seed });
+  running.push(server);
+  return server;
+}
+
+describe("model-provider production protocol mocks", () => {
+  it("drives configured embeddings through real fetch with dimensions, usage, auth redaction, and reset", async () => {
+    const server = await start();
+    const agent = runtime({
+      EMBEDDING_BASE_URL: server.configuredEmbeddingBaseUrl,
+      EMBEDDING_API_KEY: "embedding-key",
+      EMBEDDING_MODEL: "synthetic-embedding",
+      EMBEDDING_DIMENSIONS: "384",
+    });
+
+    const result = await handleConfiguredEmbedding(agent, { text: "alpha" });
+    expect(result).toEqual(configuredAlpha);
+
+    const readback = server.store.readback();
+    expect(readback.observations).toHaveLength(1);
+    expect(readback.observations[0]).toMatchObject({
+      operation: "configured-embedding",
+      status: 200,
+      headers: { authorization: "<redacted>" },
+      body: {
+        model: "synthetic-embedding",
+        input: "alpha",
+        dimensions: 384,
+      },
+    });
+    expect(JSON.stringify(readback)).not.toContain("embedding-key");
+
+    const priorGeneration = readback.generation;
+    expect(server.store.reset()).toBe(priorGeneration + 1);
+    expect(server.store.readback().observations).toEqual([]);
+  });
+
+  it("fences a delayed old-generation Ollama mutation across reset", async () => {
+    const server = await start({
+      ...baseSeed,
+      ollama: { ...baseOllamaSeed, models: ["old-generation-model"] },
+      faults: { "ollama-model-pull": [{ type: "delay", delayMs: 100 }] },
+    });
+    const oldGeneration = server.store.generation;
+    const pending = fetch(`${server.ollamaBaseUrl}/api/pull`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "must-not-cross-reset", stream: false }),
+    });
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      if (!server.store.readback().remainingFaults["ollama-model-pull"]) break;
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    server.store.reset({
+      ...baseSeed,
+      ollama: { ...baseOllamaSeed, models: ["new-generation-model"] },
+      faults: { "ollama-model-pull": [{ type: "delay", delayMs: 1 }] },
+    });
+
+    expect((await pending).status).toBe(409);
+    const readback = server.store.readback();
+    expect(readback.ollamaModels).toEqual(["new-generation-model"]);
+    expect(readback.observations).toEqual([]);
+    expect(readback.remainingFaults["ollama-model-pull"]).toBe(1);
+    expect(readback.staleObservations).toEqual([
+      expect.objectContaining({
+        generation: oldGeneration,
+        operation: "ollama-model-pull",
+        status: 409,
+      }),
+    ]);
+  });
+
+  it("surfaces auth and rate limits, retries only the configured fallback, and honors cancellation", async () => {
+    const primary = await start({
+      ...baseSeed,
+      faults: { "configured-embedding": [{ type: "http", status: 429 }] },
+    });
+    const fallback = await start();
+    const agent = runtime({
+      EMBEDDING_BASE_URL: primary.configuredEmbeddingBaseUrl,
+      EMBEDDING_API_KEY: "embedding-key",
+      EMBEDDING_FALLBACK_BASE_URL: fallback.configuredEmbeddingBaseUrl,
+      EMBEDDING_FALLBACK_API_KEY: "embedding-key",
+      EMBEDDING_MODEL: "synthetic-embedding",
+      EMBEDDING_FALLBACK_MODEL: "synthetic-embedding",
+      EMBEDDING_DIMENSIONS: "384",
+    });
+
+    expect(await handleConfiguredEmbedding(agent, { text: "alpha" })).toEqual(
+      configuredAlpha,
+    );
+    expect(primary.store.readback().observations[0]?.status).toBe(429);
+    expect(fallback.store.readback().observations[0]?.status).toBe(200);
+
+    const unauthorized = runtime({
+      EMBEDDING_BASE_URL: fallback.configuredEmbeddingBaseUrl,
+      EMBEDDING_API_KEY: "wrong-key",
+      EMBEDDING_MODEL: "synthetic-embedding",
+      EMBEDDING_DIMENSIONS: "384",
+    });
+    await expect(
+      handleConfiguredEmbedding(unauthorized, { text: "alpha" }),
+    ).rejects.toThrow(/HTTP 401/);
+
+    fallback.store.reset({
+      ...baseSeed,
+      faults: { "configured-embedding": [{ type: "delay", delayMs: 500 }] },
+    });
+    const cancellable = runtime({
+      EMBEDDING_BASE_URL: fallback.configuredEmbeddingBaseUrl,
+      EMBEDDING_API_KEY: "embedding-key",
+      EMBEDDING_MODEL: "synthetic-embedding",
+      EMBEDDING_DIMENSIONS: "384",
+    });
+    const controller = new AbortController();
+    const pending = handleConfiguredEmbedding(cancellable, {
+      text: "alpha",
+      signal: controller.signal,
+    });
+    setTimeout(() => controller.abort(new Error("synthetic cancellation")), 10);
+    await expect(pending).rejects.toThrow();
+  });
+
+  it("drives the production Google SDK through configured text and embedding HTTP routes", async () => {
+    const server = await start();
+    const agent = runtime({
+      GOOGLE_GENERATIVE_AI_API_KEY: "google-key",
+      GOOGLE_GENERATIVE_AI_BASE_URL: server.googleBaseUrl,
+      GOOGLE_SMALL_MODEL: "gemini-synthetic",
+      GOOGLE_EMBEDDING_MODEL: "gemini-embedding-001",
+    });
+
+    expect(await handleGoogleText(agent, { prompt: "hello Google" })).toBe(
+      "google synthetic answer",
+    );
+    expect(await handleGoogleEmbedding(agent, "embed this")).toEqual(
+      googleEmbedding,
+    );
+
+    const observations = server.store.readback().observations;
+    expect(observations.map(({ operation }) => operation)).toEqual([
+      "google-generate",
+      "google-count-tokens",
+      "google-embedding",
+    ]);
+    expect(
+      observations.every(
+        ({ headers }) => headers["x-goog-api-key"] !== "google-key",
+      ),
+    ).toBe(true);
+    expect(observations[0]?.body).toMatchObject({
+      extractedText: "hello Google",
+      generationConfig: { maxOutputTokens: 8192, temperature: 0.7 },
+    });
+    expect(observations[2]?.body).toMatchObject({
+      extractedText: "embed this",
+    });
+  });
+
+  it("rejects malformed Google provider output through the production SDK parser", async () => {
+    const server = await start({
+      ...baseSeed,
+      faults: { "google-generate": [{ type: "malformed" }] },
+    });
+    const agent = runtime({
+      GOOGLE_GENERATIVE_AI_API_KEY: "google-key",
+      GOOGLE_GENERATIVE_AI_BASE_URL: server.googleBaseUrl,
+      GOOGLE_SMALL_MODEL: "gemini-synthetic",
+    });
+
+    await expect(
+      handleGoogleText(agent, { prompt: "malformed please" }),
+    ).rejects.toThrow();
+    expect(server.store.readback().observations[0]).toMatchObject({
+      operation: "google-generate",
+      status: 200,
+    });
+  });
+
+  it("selects zerollama from the real version route, streams exact NDJSON chunks, and embeds", async () => {
+    const server = await start();
+    const agent = runtime({
+      OLLAMA_BASE_URL: server.ollamaBaseUrl,
+      OLLAMA_SMALL_MODEL: "synthetic-text",
+      OLLAMA_EMBEDDING_MODEL: "synthetic-embed",
+    });
+
+    const streamed = (await handleOllamaText(agent, {
+      prompt: "hello Ollama",
+      stream: true,
+    })) as unknown as {
+      textStream: AsyncIterable<string>;
+      text: Promise<string>;
+    };
+    const chunks: string[] = [];
+    for await (const chunk of streamed.textStream) chunks.push(chunk);
+    expect(chunks).toEqual(["ollama ", "synthetic ", "answer"]);
+    expect(await streamed.text).toBe("ollama synthetic answer");
+
+    expect(
+      await handleOllamaEmbedding(agent, { text: "embed locally" }),
+    ).toEqual(ollamaEmbedding);
+    const operations = server.store
+      .readback()
+      .observations.map(({ operation }) => operation);
+    expect(operations).toEqual([
+      "ollama-model-show",
+      "ollama-version",
+      "ollama-chat",
+      "ollama-model-show",
+      "ollama-embedding",
+    ]);
+    const chat = server.store
+      .readback()
+      .observations.find(({ operation }) => operation === "ollama-chat");
+    expect(chat?.body).toMatchObject({
+      model: "synthetic-text",
+      stream: true,
+      think: false,
+      options: { temperature: 0.7, num_predict: 8192 },
+    });
+    expect(chat?.body).not.toHaveProperty("temperature");
+  });
+
+  it("drives z.ai's production AI SDK client, including thinking selection and provider faults", async () => {
+    const server = await start();
+    const agent = runtime({
+      ZAI_API_KEY: "zai-key",
+      ZAI_BASE_URL: server.zaiBaseUrl,
+      ZAI_SMALL_MODEL: "glm-synthetic",
+      ZAI_THINKING_TYPE: "enabled",
+    });
+
+    expect(
+      await handleZaiText(agent, { prompt: "hello z.ai", maxTokens: 32 }),
+    ).toBe("z.ai synthetic answer");
+    const first = server.store.readback().observations[0];
+    expect(first).toMatchObject({
+      operation: "zai-chat",
+      status: 200,
+      headers: { authorization: "<redacted>" },
+      body: { model: "glm-synthetic", thinking: { type: "enabled" } },
+    });
+    expect(first?.body).toMatchObject({
+      max_tokens: 32,
+      messages: expect.arrayContaining([
+        expect.objectContaining({ role: "user", content: "hello z.ai" }),
+      ]),
+    });
+
+    server.store.reset({
+      ...baseSeed,
+      faults: { "zai-chat": [{ type: "http", status: 429 }] },
+    });
+    expect(await handleZaiText(agent, { prompt: "rate limited" })).toBe(
+      "z.ai synthetic answer",
+    );
+    expect(
+      server.store.readback().observations.map(({ status }) => status),
+    ).toEqual([429, 200]);
+
+    server.store.reset({
+      ...baseSeed,
+      faults: { "zai-chat": [{ type: "malformed" }] },
+    });
+    await expect(
+      handleZaiText(agent, { prompt: "malformed" }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/cloud/test-mocks/test/model-provider.test.ts
+++ b/packages/cloud/test-mocks/test/model-provider.test.ts
@@ -9,7 +9,11 @@ import { handleTextSmall as handleZaiText } from "../../../../plugins/plugin-zai
 import { handleTextEmbedding as handleOllamaEmbedding } from "../../../../plugins/plugin-zerollama/models/embedding";
 import { handleTextSmall as handleOllamaText } from "../../../../plugins/plugin-zerollama/models/text";
 import { clearOllamaHostFlavorCache } from "../../../../plugins/plugin-zerollama/utils/host-flavor";
-import { startModelProviderMock } from "../src/model-provider";
+import {
+  MODEL_PROVIDER_MAX_REQUEST_BYTES,
+  ModelProviderMockStore,
+  startModelProviderMock,
+} from "../src/model-provider";
 import type { ModelProviderSeed } from "../src/model-provider/types";
 
 const vector = (length: number, offset = 0) =>
@@ -122,6 +126,102 @@ describe("model-provider production protocol mocks", () => {
     const priorGeneration = readback.generation;
     expect(server.store.reset()).toBe(priorGeneration + 1);
     expect(server.store.readback().observations).toEqual([]);
+  });
+
+  it("bounds adversarial provider bodies and redacts alternate credential carriers", async () => {
+    const server = await start();
+    const oversized = await fetch(
+      `${server.zaiBaseUrl}/chat/completions?access_token=query-secret&api_key=other-secret`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "header-secret",
+        },
+        body: JSON.stringify({
+          model: "glm-synthetic",
+          prompt: "x".repeat(MODEL_PROVIDER_MAX_REQUEST_BYTES),
+        }),
+      },
+    );
+    expect(oversized.status).toBe(413);
+    expect(await oversized.json()).toEqual({
+      error: {
+        code: "REQUEST_TOO_LARGE",
+        message: "invalid provider request",
+      },
+    });
+    const oversizedReadback = server.store.readback();
+    expect(oversizedReadback.observations[0]).toMatchObject({
+      operation: "zai-chat",
+      status: 413,
+      headers: { "x-api-key": "<redacted>" },
+      body: { invalidRequest: "REQUEST_TOO_LARGE" },
+    });
+    expect(oversizedReadback.observations[0]?.path).toBe(
+      "/zai/chat/completions?access_token=%3Credacted%3E&api_key=%3Credacted%3E",
+    );
+    expect(JSON.stringify(oversizedReadback)).not.toContain("secret");
+
+    server.store.reset();
+    let nested: unknown = "leaf";
+    for (let depth = 0; depth < 66; depth += 1) nested = { nested };
+    const tooDeep = await fetch(`${server.zaiBaseUrl}/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(nested),
+    });
+    expect(tooDeep.status).toBe(413);
+    expect(await tooDeep.json()).toEqual({
+      error: {
+        code: "JSON_TOO_COMPLEX",
+        message: "invalid provider request",
+      },
+    });
+    expect(server.store.readback().observations[0]?.body).toEqual({
+      invalidRequest: "JSON_TOO_COMPLEX",
+    });
+
+    server.store.reset();
+    const wrongMediaType = await fetch(
+      `${server.zaiBaseUrl}/chat/completions`,
+      {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body: "{}",
+      },
+    );
+    expect(wrongMediaType.status).toBe(400);
+    expect(await wrongMediaType.json()).toMatchObject({
+      error: { code: "UNSUPPORTED_MEDIA_TYPE" },
+    });
+
+    server.store.reset();
+    const compressed = await fetch(`${server.zaiBaseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "content-encoding": "gzip",
+        "content-type": "application/json; charset=utf-8",
+      },
+      body: "{}",
+    });
+    expect(compressed.status).toBe(400);
+    expect(await compressed.json()).toMatchObject({
+      error: { code: "UNSUPPORTED_ENCODING" },
+    });
+
+    const boundedStore = new ModelProviderMockStore(baseSeed);
+    boundedStore.record(boundedStore.generation, {
+      operation: "zai-chat",
+      method: "POST",
+      path: "/zai/chat/completions",
+      headers: {},
+      body: nested,
+      status: 200,
+    });
+    expect(boundedStore.readback().observations[0]?.body).toEqual({
+      omitted: "observation body exceeded protocol bounds",
+    });
   });
 
   it("fences a delayed old-generation Ollama mutation across reset", async () => {

--- a/packages/cloud/test-mocks/test/model-provider.test.ts
+++ b/packages/cloud/test-mocks/test/model-provider.test.ts
@@ -128,6 +128,40 @@ describe("model-provider production protocol mocks", () => {
     expect(server.store.readback().observations).toEqual([]);
   });
 
+  it("rejects scalar, object, and mixed configured-embedding inputs with a stable protocol response", async () => {
+    const server = await start();
+    const invalidInputs: unknown[] = [42, { text: "alpha" }, ["alpha", 42]];
+
+    for (const input of invalidInputs) {
+      const response = await fetch(
+        `${server.configuredEmbeddingBaseUrl}/embeddings`,
+        {
+          method: "POST",
+          headers: {
+            authorization: "Bearer embedding-key",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            model: "synthetic-embedding",
+            input,
+            dimensions: 384,
+          }),
+        },
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: { message: "input must be string or string[]" },
+      });
+    }
+
+    expect(
+      server.store
+        .readback()
+        .observations.map((observation) => observation.status),
+    ).toEqual([400, 400, 400]);
+  });
+
   it("bounds adversarial provider bodies and redacts alternate credential carriers", async () => {
     const server = await start();
     const oversized = await fetch(

--- a/plugins/plugin-google-genai/AGENTS.md
+++ b/plugins/plugin-google-genai/AGENTS.md
@@ -68,6 +68,7 @@ Settings are read first from `runtime.getSetting(key)`, then from `process.env`.
 | Env var | Required | Default | Notes |
 |---|---|---|---|
 | `GOOGLE_GENERATIVE_AI_API_KEY` | Yes | — | The only key `getApiKey` reads. `GOOGLE_API_KEY` and `GEMINI_API_KEY` trigger auto-enable (`auto-enable.ts`) but are not read as the API key. |
+| `GOOGLE_GENERATIVE_AI_BASE_URL` | No | Google Generative Language API | Optional API origin for a private compatible gateway or deterministic local protocol mock. HTTPS is required except for literal `127.0.0.1`/`::1`; URL credentials, query, and fragment are rejected. The production `GoogleGenAI` client still owns request serialization and response parsing. |
 | `GOOGLE_NANO_MODEL` / `NANO_MODEL` | No | falls back to small | |
 | `GOOGLE_SMALL_MODEL` / `SMALL_MODEL` | No | `gemini-2.0-flash-001` | |
 | `GOOGLE_MEDIUM_MODEL` / `MEDIUM_MODEL` | No | falls back to small | |

--- a/plugins/plugin-google-genai/CLAUDE.md
+++ b/plugins/plugin-google-genai/CLAUDE.md
@@ -68,6 +68,7 @@ Settings are read first from `runtime.getSetting(key)`, then from `process.env`.
 | Env var | Required | Default | Notes |
 |---|---|---|---|
 | `GOOGLE_GENERATIVE_AI_API_KEY` | Yes | — | The only key `getApiKey` reads. `GOOGLE_API_KEY` and `GEMINI_API_KEY` trigger auto-enable (`auto-enable.ts`) but are not read as the API key. |
+| `GOOGLE_GENERATIVE_AI_BASE_URL` | No | Google Generative Language API | Optional API origin for a private compatible gateway or deterministic local protocol mock. HTTPS is required except for literal `127.0.0.1`/`::1`; URL credentials, query, and fragment are rejected. The production `GoogleGenAI` client still owns request serialization and response parsing. |
 | `GOOGLE_NANO_MODEL` / `NANO_MODEL` | No | falls back to small | |
 | `GOOGLE_SMALL_MODEL` / `SMALL_MODEL` | No | `gemini-2.0-flash-001` | |
 | `GOOGLE_MEDIUM_MODEL` / `MEDIUM_MODEL` | No | falls back to small | |

--- a/plugins/plugin-google-genai/README.md
+++ b/plugins/plugin-google-genai/README.md
@@ -37,6 +37,7 @@ Or register it explicitly in your agent character file:
 | Environment variable | Required | Default | Description |
 |---|---|---|---|
 | `GOOGLE_GENERATIVE_AI_API_KEY` | Yes | — | API key from [Google AI Studio](https://aistudio.google.com/) |
+| `GOOGLE_GENERATIVE_AI_BASE_URL` | No | Google Generative Language API | Optional API origin for a private compatible gateway or local protocol mock. HTTPS is required except for literal `127.0.0.1`/`::1`; embedded credentials, query, and fragment are rejected. |
 | `GOOGLE_SMALL_MODEL` | No | `gemini-2.0-flash-001` | Small/fast text model |
 | `GOOGLE_LARGE_MODEL` | No | `gemini-2.5-pro-preview-03-25` | Large/capable text model |
 | `GOOGLE_NANO_MODEL` | No | falls back to small | Nano text model |

--- a/plugins/plugin-google-genai/__tests__/config.test.ts
+++ b/plugins/plugin-google-genai/__tests__/config.test.ts
@@ -39,6 +39,7 @@ import {
   getApiKey,
   getEmbeddingInputTokenLimit,
   getEmbeddingModel,
+  getGoogleGenAIBaseURL,
   getLargeModel,
   getResponseHandlerModel,
   getSmallModel,
@@ -127,6 +128,80 @@ describe("Google GenAI config", () => {
 
     expect(mocks.googleGenAI).toHaveBeenCalledWith({ apiKey: "test-key" });
   });
+
+  it("wires a literal-loopback HTTP override into the production SDK", () => {
+    const runtime = runtimeWith({
+      GOOGLE_GENERATIVE_AI_API_KEY: "test-key",
+      GOOGLE_GENERATIVE_AI_BASE_URL: " http://127.0.0.1:4567/google/ ",
+    });
+
+    expect(getGoogleGenAIBaseURL(runtime)).toBe("http://127.0.0.1:4567/google");
+    createGoogleGenAI(runtime);
+    expect(mocks.googleGenAI).toHaveBeenCalledWith({
+      apiKey: "test-key",
+      httpOptions: { baseUrl: "http://127.0.0.1:4567/google" },
+    });
+  });
+
+  it("allows HTTPS and literal IPv4/IPv6 loopback while normalizing trailing path slashes", () => {
+    expect(
+      getGoogleGenAIBaseURL(
+        runtimeWith({
+          GOOGLE_GENERATIVE_AI_BASE_URL:
+            "https://gateway.example.test/google///",
+        }),
+      ),
+    ).toBe("https://gateway.example.test/google");
+    expect(
+      getGoogleGenAIBaseURL(
+        runtimeWith({
+          GOOGLE_GENERATIVE_AI_BASE_URL: "http://127.0.0.1:4567/google/",
+        }),
+      ),
+    ).toBe("http://127.0.0.1:4567/google");
+    expect(
+      getGoogleGenAIBaseURL(
+        runtimeWith({
+          GOOGLE_GENERATIVE_AI_BASE_URL: "http://[::1]:4567/google/",
+        }),
+      ),
+    ).toBe("http://[::1]:4567/google");
+  });
+
+  it.each([
+    ["remote cleartext", "http://api.example.test/google", /must use HTTPS/],
+    ["localhost DNS", "http://localhost:4567/google", /must use HTTPS/],
+    [
+      "embedded username",
+      "https://user@gateway.example.test/google",
+      /credentials/,
+    ],
+    [
+      "embedded password",
+      "https://user:pass@gateway.example.test/google",
+      /credentials/,
+    ],
+    [
+      "query",
+      "https://gateway.example.test/google?key=value",
+      /query or fragment/,
+    ],
+    [
+      "fragment",
+      "https://gateway.example.test/google#route",
+      /query or fragment/,
+    ],
+    ["unsafe scheme", "file:///tmp/not-an-api", /HTTP or HTTPS/],
+  ])(
+    "rejects %s base URLs before creating a credentialed client",
+    (_label, baseURL, pattern) => {
+      expect(() =>
+        getGoogleGenAIBaseURL(
+          runtimeWith({ GOOGLE_GENERATIVE_AI_BASE_URL: baseURL }),
+        ),
+      ).toThrow(pattern);
+    },
+  );
 
   it("defaults the embedding model to a v1beta-valid id, not the 404-ing text-embedding-004", () => {
     // Regression: the historical default text-embedding-004 404s on the current

--- a/plugins/plugin-google-genai/models/embedding.ts
+++ b/plugins/plugin-google-genai/models/embedding.ts
@@ -122,6 +122,14 @@ function extractText(
   );
 }
 
+function extractSignal(
+  params: TextEmbeddingParams | string | null,
+): AbortSignal | undefined {
+  return typeof params === "object" && params !== null
+    ? params.signal
+    : undefined;
+}
+
 async function providerTokenCount(
   genAI: GoogleGenAI,
   model: string,
@@ -202,6 +210,7 @@ export async function handleTextEmbedding(
   runtime: IAgentRuntime,
   params: TextEmbeddingParams | string | null,
 ): Promise<number[]> {
+  const signal = extractSignal(params);
   if (params === null) {
     return createInitProbeVector();
   }
@@ -241,7 +250,10 @@ export async function handleTextEmbedding(
       // written matches the pgvector column the runtime sized from the probe.
       // Without this, `gemini-embedding-001` returns its 3072-dim default and
       // every write fails against the 768-wide column (#22010).
-      config: { outputDimensionality: EMBEDDING_DIMENSIONS },
+      config: {
+        outputDimensionality: EMBEDDING_DIMENSIONS,
+        ...(signal ? { abortSignal: signal } : {}),
+      },
     });
 
     // The provider billed this call when it returned. Reuse the exact token

--- a/plugins/plugin-google-genai/models/text.ts
+++ b/plugins/plugin-google-genai/models/text.ts
@@ -520,6 +520,7 @@ function buildGoogleGenerationConfig(
           responseJsonSchema,
         }
       : {}),
+    ...(params.signal ? { abortSignal: params.signal } : {}),
   };
 
   return baseConfig as NonNullable<GenerateContentParams["config"]>;

--- a/plugins/plugin-google-genai/package.json
+++ b/plugins/plugin-google-genai/package.json
@@ -98,6 +98,12 @@
         "required": true,
         "sensitive": true
       },
+      "GOOGLE_GENERATIVE_AI_BASE_URL": {
+        "type": "string",
+        "description": "Optional Google Generative Language API origin for a private compatible gateway or deterministic local protocol mock. HTTPS is required except for literal loopback.",
+        "required": false,
+        "sensitive": false
+      },
       "GOOGLE_EMBEDDING_MODEL": {
         "type": "string",
         "description": "Overrides the default text embedding model used by Google Generative AI.",

--- a/plugins/plugin-google-genai/registry-entry.json
+++ b/plugins/plugin-google-genai/registry-entry.json
@@ -16,6 +16,14 @@
       "advanced": false,
       "autoEnableProvider": true
     },
+    "GOOGLE_GENERATIVE_AI_BASE_URL": {
+      "type": "string",
+      "required": false,
+      "sensitive": false,
+      "label": "Generative AI Base URL",
+      "help": "Optional API origin for a private compatible gateway or deterministic local protocol mock. HTTPS is required except for literal loopback.",
+      "advanced": true
+    },
     "GOOGLE_API_KEY": {
       "type": "secret",
       "required": false,

--- a/plugins/plugin-google-genai/utils/config.ts
+++ b/plugins/plugin-google-genai/utils/config.ts
@@ -44,6 +44,47 @@ export function getApiKey(runtime: IAgentRuntime): string | undefined {
   return getSetting(runtime, "GOOGLE_GENERATIVE_AI_API_KEY");
 }
 
+/** Optional full API origin used by local protocol mocks and private compatible gateways. */
+export function getGoogleGenAIBaseURL(
+  runtime: IAgentRuntime,
+): string | undefined {
+  const value = getSetting(runtime, "GOOGLE_GENERATIVE_AI_BASE_URL");
+  if (!value) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch (error) {
+    throw new Error(
+      "GOOGLE_GENERATIVE_AI_BASE_URL must be an absolute HTTP(S) URL",
+      {
+        cause: error,
+      },
+    );
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("GOOGLE_GENERATIVE_AI_BASE_URL must use HTTP or HTTPS");
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error(
+      "GOOGLE_GENERATIVE_AI_BASE_URL must not contain URL credentials",
+    );
+  }
+  if (parsed.search || parsed.hash) {
+    throw new Error(
+      "GOOGLE_GENERATIVE_AI_BASE_URL must not contain a query or fragment",
+    );
+  }
+  const isLiteralLoopback =
+    parsed.hostname === "127.0.0.1" || parsed.hostname === "[::1]";
+  if (parsed.protocol === "http:" && !isLiteralLoopback) {
+    throw new Error(
+      "GOOGLE_GENERATIVE_AI_BASE_URL must use HTTPS unless the host is literal loopback (127.0.0.1 or ::1)",
+    );
+  }
+  const normalizedPath = parsed.pathname.replace(/\/+$/, "");
+  return `${parsed.origin}${normalizedPath === "/" ? "" : normalizedPath}`;
+}
+
 export function getSmallModel(runtime: IAgentRuntime): string {
   return (
     getSetting(runtime, "GOOGLE_SMALL_MODEL") ??
@@ -179,7 +220,11 @@ export function createGoogleGenAI(runtime: IAgentRuntime): GoogleGenAI | null {
     return null;
   }
 
-  return new GoogleGenAI({ apiKey });
+  const baseUrl = getGoogleGenAIBaseURL(runtime);
+  return new GoogleGenAI({
+    apiKey,
+    ...(baseUrl ? { httpOptions: { baseUrl } } : {}),
+  });
 }
 
 export function getSafetySettings() {

--- a/plugins/plugin-zai/__tests__/text-params.test.ts
+++ b/plugins/plugin-zai/__tests__/text-params.test.ts
@@ -62,6 +62,34 @@ describe("z.ai text parameter resolution", () => {
     );
   });
 
+  it("maps the public maxTokens and cancellation signal to AI SDK v7 parameters", async () => {
+    const runtime = {
+      character: {},
+      getSetting(key: string) {
+        if (key === "ZAI_API_KEY") return "test-key";
+        return undefined;
+      },
+    };
+    const controller = new AbortController();
+    const { handleTextSmall } = await import("../models/text");
+
+    await expect(
+      handleTextSmall(runtime as never, {
+        prompt: "hello",
+        maxTokens: 37,
+        signal: controller.signal,
+      })
+    ).resolves.toBe("ok");
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxOutputTokens: 37,
+        abortSignal: controller.signal,
+      })
+    );
+    expect(generateTextMock.mock.calls[0]?.[0]).not.toHaveProperty("maxTokens");
+  });
+
   it("honors a per-call model override before z.ai slot defaults", async () => {
     const runtime = {
       character: {},

--- a/plugins/plugin-zai/models/text.ts
+++ b/plugins/plugin-zai/models/text.ts
@@ -144,7 +144,8 @@ async function generateTextWithModel(
     presencePenalty: resolved.presencePenalty,
     experimental_telemetry: telemetryConfig,
     topP: resolved.topP,
-    ...(typeof resolved.maxTokens === "number" ? { maxTokens: resolved.maxTokens } : {}),
+    ...(typeof resolved.maxTokens === "number" ? { maxOutputTokens: resolved.maxTokens } : {}),
+    ...(params.signal ? { abortSignal: params.signal } : {}),
   };
 
   const { text, usage, finishReason } = await generateText(


### PR DESCRIPTION
# Relates to

Refs #24091. This is a reviewable protocol-foundation slice; it intentionally does not close the issue because shared-control composition and scenario/Cloud lane consumers remain.

- [x] This PR targets `develop` and is based on current `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync.
- [ ] `bun run verify` passes, or the exact unrelated blockers are documented below.
- [x] A reviewer can confirm the real client behavior from the focused proof below.

# Risks

Medium. This adds local provider protocol surfaces and two production parameter/wiring fixes. Credentials are provider-owned seeds and are redacted from headers/query readback. The fixture is standalone protocol state, not a second synthetic-world authority.

# Background

## What does this PR do?

- Adds one resettable real-HTTP loopback with configured OpenAI-compatible embeddings, Google Generative Language, Ollama/zerollama, and z.ai protocol routes.
- Seeds deterministic text, embedding, usage, model, streaming-chunk, auth, and fault behavior and exposes a typed sanitized observation ledger plus authoritative Ollama model/readback state.
- Fences every admitted request to its generation: delayed old requests return 409, cannot mutate reset state, and are recorded only in generation-tagged stale observations. Delay faults stop on cancellation.
- Drives the real production raw-fetch, Google SDK, Ollama/zerollama native, and z.ai AI SDK handlers. No client method is mocked in the contract suite.
- Adds the missing production Google SDK base-URL seam with a credential-safe URL boundary: HTTPS generally, HTTP only on literal 127.0.0.1/::1 loopback, and rejection of embedded credentials, query strings, fragments, localhost DNS, and remote cleartext targets.
- Propagates caller cancellation through Google text/embedding and z.ai generation.
- Fixes z.ai's AI SDK v7 token-cap mapping (`maxOutputTokens`); the real wire proof verifies `max_tokens` is now emitted.

## What kind of change is this?

Feature: model-provider protocol mock foundation with production-client contract fixes.

# Testing

## Where should a reviewer start?

Start with `packages/cloud/test-mocks/test/model-provider.test.ts`. It starts real loopback HTTP servers and invokes the four production model handlers.

## Detailed testing steps

Exact head: `866aa199f07498e38ebbe0af02a44603903f9690`

```bash
bun --conditions=eliza-source test --timeout 15000 packages/cloud/test-mocks/test/model-provider.test.ts
# 9 pass, 0 fail, 56 expect

bun test plugins/plugin-google-genai/__tests__/config.test.ts
# 17 pass, including HTTPS/loopback allow cases and unsafe URL rejection

bun run --cwd plugins/plugin-zai test
# 7 files passed, 57 tests passed

bun run --cwd plugins/plugin-google-genai test:unit
# 11 files passed, 1 skipped; 109 passed, 2 skipped

bun run --cwd plugins/plugin-{embeddings,google-genai,zerollama,zai} typecheck
# all four pass (run individually because brace expansion is explanatory here)

bun run --cwd plugins/plugin-google-genai build
bun run --cwd plugins/plugin-zai build
# both pass

bun run check:agents-claude
# pass: 160 pairs
```

# Evidence Gate

<!-- evidence-head:866aa199f07498e38ebbe0af02a44603903f9690 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI change
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI change
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - protocol/test infrastructure only
<!-- evidence-row:backend-logs -->
- [x] [24226-dfb8183-model-provider-real-http.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24226-866aa19-model-provider-exact-head.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser flow
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic protocol fixtures intentionally make no paid/live LLM call; this is mock qualification, not live-provider certification
<!-- evidence-row:domain-artifacts -->
- [x] [24226-dfb8183-model-provider-readback.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24226-866aa19-model-provider-readback.json)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual artifact

# Known gaps / failures

- This partial does not yet compose reset through #24078's shared subprocess control protocol, and it does not add scenario-runner/Cloud E2E consumers. Those remain in #24091 after #24078 lands.
- The loopback also rejects scalar, object, and mixed-array configured-embedding inputs with stable 400 envelopes. It covers exact best-case wires plus configured-embedding auth/429/fallback/cancellation, Google malformed output, z.ai 429 retry/malformed output, and Ollama NDJSON boundaries. A follow-up must finish the per-provider auth/rate-limit/malformed/timeout matrix and stock-Ollama AI SDK branch.
- This is deterministic mock proof, not live/sandbox provider certification, and the report-only dependency catalog is deliberately unchanged.
- `bun run --cwd packages/cloud/test-mocks typecheck` fails at unchanged `src/control-plane/server.ts:274`: `Promise<boolean>` is not assignable to `Promise<void>`.
- `bun run verify` reaches Turbo and then fails on pre-existing `packages/agent` Biome errors, including forbidden non-null assertions in `src/api/interactions-routes.test.ts` and formatting in `src/actions/database.surrogate.test.ts` / `src/api/accounts-routes.ts`. None are touched here.

# AI-assisted contribution provenance

- AI provider/model: openai / gpt-5.6-sol
- Client / agent tooling: Codex Desktop
- Contribution skill revision: N/A - no contribution skill used
- Attribution status: self-reported
- Lane: `[model-provider-protocol-mocks]`

<!-- ai-provenance: {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used","attribution":"self-reported","lane":"model-provider-protocol-mocks"} -->

