### PR TITLE
feat(testing): add Fish Audio protocol mock

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -794,12 +794,15 @@
         "@elizaos/cloud-shared": "workspace:*",
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
+        "@msgpack/msgpack": "3.1.3",
         "hono": "4.13.1",
+        "ws": "^8.21.3",
       },
       "devDependencies": {
         "@elizaos/cloud-sdk": "workspace:*",
         "@elizaos/plugin-github": "workspace:*",
         "@elizaos/plugin-whatsapp": "workspace:*",
+        "@types/ws": "^8.18.1",
         "@typescript/native": "npm:typescript@^7.0.2",
         "bun-types": "*",
       },
@@ -1883,6 +1886,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.8",
+        "@elizaos/cloud-test-mocks": "workspace:*",
         "@elizaos/core": "workspace:*",
         "@types/bun": "^1.3.8",
         "@types/node": "^25.0.3",

--- a/packages/cloud/test-mocks/AGENTS.md
+++ b/packages/cloud/test-mocks/AGENTS.md
@@ -25,6 +25,11 @@ exits.
   `Job`/`JobStatus`/`JobType`/`Sandbox`/`SandboxStatus` types.
 - `src/steward/` (export `./steward`) — stateful loopback mock for authenticated
   Steward platform-user deactivation and deletion calls used by account lifecycle E2E.
+- `src/fish-audio/` (export `./fish-audio`) — resettable WebSocket/MessagePack
+  upstream for the production Fish Audio realtime TTS client. It supports
+  seeded PCM chunks, cancellation, auth rejection, rate limits, malformed
+  frames, provider errors, early close, stalls, and credential-redacted
+  ordered readback.
 - `src/fetch-server.ts` — shared `startFetchServer(fetch, opts)`; uses
   `Bun.serve` when running under Bun, falls back to a `node:http` adapter
   otherwise.

--- a/packages/cloud/test-mocks/CLAUDE.md
+++ b/packages/cloud/test-mocks/CLAUDE.md
@@ -25,6 +25,11 @@ exits.
   `Job`/`JobStatus`/`JobType`/`Sandbox`/`SandboxStatus` types.
 - `src/steward/` (export `./steward`) — stateful loopback mock for authenticated
   Steward platform-user deactivation and deletion calls used by account lifecycle E2E.
+- `src/fish-audio/` (export `./fish-audio`) — resettable WebSocket/MessagePack
+  upstream for the production Fish Audio realtime TTS client. It supports
+  seeded PCM chunks, cancellation, auth rejection, rate limits, malformed
+  frames, provider errors, early close, stalls, and credential-redacted
+  ordered readback.
 - `src/fetch-server.ts` — shared `startFetchServer(fetch, opts)`; uses
   `Bun.serve` when running under Bun, falls back to a `node:http` adapter
   otherwise.

--- a/packages/cloud/test-mocks/README.md
+++ b/packages/cloud/test-mocks/README.md
@@ -64,6 +64,25 @@ declared capabilities and nonce-bound observations emitted by the executed
 suite. Normal CI is fully offline and credential-free; live/sandbox lanes
 remain optional.
 
+## Fish Audio protocol mock
+
+`@elizaos/cloud-test-mocks/fish-audio` runs a resettable local WebSocket server
+that speaks the production Fish Audio MessagePack protocol. Tests point the
+real plugin transport at `mock.url`, seed deterministic PCM chunks, select
+auth/rate-limit/malformed/provider/close/stall faults, and inspect ordered
+credential-redacted observations through `mock.store.readback()`.
+
+```ts
+import { startFishAudioMock } from "@elizaos/cloud-test-mocks/fish-audio";
+
+const mock = await startFishAudioMock({
+  audioChunks: [new Uint8Array([1, 2, 3, 4])],
+});
+mock.store.setFault("rate_limit");
+mock.store.reset();
+await mock.stop();
+```
+
 ## Hetzner Cloud mock
 
 Implements the subset of the Hetzner Cloud API that the autoscaler client in

--- a/packages/cloud/test-mocks/package.json
+++ b/packages/cloud/test-mocks/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./hetzner": "./src/hetzner/index.ts",
     "./control-plane": "./src/control-plane/index.ts",
+    "./fish-audio": "./src/fish-audio/index.ts",
     "./steward": "./src/steward/index.ts",
     "./provider-contract": "./src/provider-contract/index.ts"
   },
@@ -28,12 +29,15 @@
     "@elizaos/core": "workspace:*",
     "@elizaos/cloud-shared": "workspace:*",
     "@elizaos/shared": "workspace:*",
-    "hono": "4.13.1"
+    "@msgpack/msgpack": "3.1.3",
+    "hono": "4.13.1",
+    "ws": "^8.21.3"
   },
   "devDependencies": {
     "@elizaos/cloud-sdk": "workspace:*",
     "@elizaos/plugin-github": "workspace:*",
     "@elizaos/plugin-whatsapp": "workspace:*",
+    "@types/ws": "^8.18.1",
     "@typescript/native": "npm:typescript@^7.0.2",
     "bun-types": "*"
   },

--- a/packages/cloud/test-mocks/src/fish-audio/index.ts
+++ b/packages/cloud/test-mocks/src/fish-audio/index.ts
@@ -23,6 +23,12 @@ export interface FishAudioMockSeed {
   chunkDelayMs: number;
 }
 
+export interface FishAudioMockFaultDetails {
+  providerMessage?: string;
+  closeReason?: string;
+  upgradeStatusText?: string;
+}
+
 export interface FishAudioMockObservation {
   order: number;
   generation: number;
@@ -34,7 +40,6 @@ export interface FishAudioMockObservation {
   referenceId?: string;
   text?: string;
   closeCode?: number;
-  closeReason?: string;
 }
 
 const DEFAULT_SEED: FishAudioMockSeed = {
@@ -48,6 +53,7 @@ export class FishAudioMockStore {
   #generation = 1;
   #seed: FishAudioMockSeed;
   #fault: FishAudioMockFault | null = null;
+  #faultDetails: FishAudioMockFaultDetails = {};
   #observations: FishAudioMockObservation[] = [];
   readonly #connections = new Set<WebSocket>();
 
@@ -71,19 +77,28 @@ export class FishAudioMockStore {
     return this.#connections.size;
   }
 
-  setFault(fault: FishAudioMockFault | null): void {
+  setFault(
+    fault: FishAudioMockFault | null,
+    details: FishAudioMockFaultDetails = {},
+  ): void {
     this.#fault = fault;
+    this.#faultDetails = { ...details };
   }
 
   responsePlan(generation: number): FishAudioResponsePlan | null {
     if (generation !== this.#generation) return null;
-    return { fault: this.#fault, seed: cloneSeed(this.#seed) };
+    return {
+      fault: this.#fault,
+      faultDetails: { ...this.#faultDetails },
+      seed: cloneSeed(this.#seed),
+    };
   }
 
   reset(seed: Partial<FishAudioMockSeed> = {}): void {
     this.#generation += 1;
     this.#seed = normalizeSeed(seed);
     this.#fault = null;
+    this.#faultDetails = {};
     this.#observations = [];
     for (const connection of this.#connections) {
       connection.close(1012, "synthetic environment reset");
@@ -153,8 +168,11 @@ export async function startFishAudioMock(
         model,
       });
       const retryAfter = rejectedStatus === 429 ? "Retry-After: 1\r\n" : "";
+      const statusText =
+        store.responsePlan(store.generation)?.faultDetails.upgradeStatusText ??
+        (rejectedStatus === 429 ? "Too Many Requests" : "Unauthorized");
       socket.write(
-        `HTTP/1.1 ${rejectedStatus} ${rejectedStatus === 429 ? "Too Many Requests" : "Unauthorized"}\r\n${retryAfter}Connection: close\r\n\r\n`,
+        `HTTP/1.1 ${rejectedStatus} ${sanitizeHttpStatusText(statusText)}\r\n${retryAfter}Connection: close\r\nContent-Type: text/plain\r\n\r\n${statusText}`,
       );
       socket.destroy();
       return;
@@ -201,13 +219,12 @@ export async function startFishAudioMock(
         if (responsePlan) void respond(connection, responsePlan);
       }
     });
-    connection.on("close", (code, reason) => {
+    connection.on("close", (code) => {
       store.removeConnection(connection);
       store.observe(
         {
           event: "closed",
           closeCode: code,
-          closeReason: reason.toString(),
         },
         connectionGeneration,
       );
@@ -241,6 +258,7 @@ export async function startFishAudioMock(
 
 interface FishAudioResponsePlan {
   fault: FishAudioMockFault | null;
+  faultDetails: FishAudioMockFaultDetails;
   seed: FishAudioMockSeed;
 }
 
@@ -248,7 +266,7 @@ async function respond(
   connection: WebSocket,
   plan: FishAudioResponsePlan,
 ): Promise<void> {
-  const { fault, seed } = plan;
+  const { fault, faultDetails, seed } = plan;
   if (fault === "stall") return;
   if (fault === "malformed_frame") {
     connection.send(new Uint8Array([0xc1]));
@@ -260,12 +278,19 @@ async function respond(
   }
   if (fault === "provider_error") {
     connection.send(
-      encode({ event: "error", message: "synthetic provider failure" }),
+      encode({
+        event: "error",
+        message: faultDetails.providerMessage ?? "synthetic provider failure",
+        error: faultDetails.providerMessage ?? "synthetic provider failure",
+      }),
     );
     return;
   }
   if (fault === "close_early") {
-    connection.close(1011, "synthetic provider closed early");
+    connection.close(
+      1011,
+      faultDetails.closeReason ?? "synthetic provider closed early",
+    );
     return;
   }
   for (const chunk of seed.audioChunks) {
@@ -300,4 +325,8 @@ function singleHeader(
   value: string | string[] | undefined,
 ): string | undefined {
   return Array.isArray(value) ? value[0] : value;
+}
+
+function sanitizeHttpStatusText(value: string): string {
+  return value.replaceAll(/[\r\n]/g, " ").slice(0, 123);
 }

--- a/packages/cloud/test-mocks/src/fish-audio/index.ts
+++ b/packages/cloud/test-mocks/src/fish-audio/index.ts
@@ -32,13 +32,19 @@ export interface FishAudioMockFaultDetails {
 export interface FishAudioMockObservation {
   order: number;
   generation: number;
-  event: "upgrade_rejected" | "frame" | "request" | "closed";
+  event:
+    | "upgrade_rejected"
+    | "frame"
+    | "request"
+    | "protocol_rejected"
+    | "closed";
   authorized?: boolean;
   status?: number;
   frameEvent?: string;
   model?: string;
   referenceId?: string;
   text?: string;
+  requestValid?: boolean;
   closeCode?: number;
 }
 
@@ -158,9 +164,15 @@ export async function startFishAudioMock(
     const authorization = request.headers.authorization;
     const model = singleHeader(request.headers.model);
     const authorized = authorization === `Bearer ${store.seed.apiKey}`;
-    const status = !authorized || model !== store.seed.model ? 401 : 101;
+    const pathMatches = request.url === "/v1/tts/live";
+    const status = !pathMatches
+      ? 404
+      : !authorized || model !== store.seed.model
+        ? 401
+        : 101;
     if (status !== 101 || store.fault === "rate_limit") {
-      const rejectedStatus = store.fault === "rate_limit" ? 429 : status;
+      const rejectedStatus =
+        status === 101 && store.fault === "rate_limit" ? 429 : status;
       store.observe({
         event: "upgrade_rejected",
         authorized,
@@ -169,8 +181,14 @@ export async function startFishAudioMock(
       });
       const retryAfter = rejectedStatus === 429 ? "Retry-After: 1\r\n" : "";
       const statusText =
-        store.responsePlan(store.generation)?.faultDetails.upgradeStatusText ??
-        (rejectedStatus === 429 ? "Too Many Requests" : "Unauthorized");
+        (rejectedStatus === 429
+          ? store.responsePlan(store.generation)?.faultDetails.upgradeStatusText
+          : undefined) ??
+        (rejectedStatus === 429
+          ? "Too Many Requests"
+          : rejectedStatus === 404
+            ? "Not Found"
+            : "Unauthorized");
       socket.write(
         `HTTP/1.1 ${rejectedStatus} ${sanitizeHttpStatusText(statusText)}\r\n${retryAfter}Connection: close\r\nContent-Type: text/plain\r\n\r\n${statusText}`,
       );
@@ -188,35 +206,75 @@ export async function startFishAudioMock(
     const model = singleHeader(request.headers.model);
     let referenceId: string | undefined;
     let text: string | undefined;
+    let requestState: "start" | "text" | "flush" | "stop" | "complete" =
+      "start";
+    const rejectProtocol = () => {
+      store.observe(
+        { event: "protocol_rejected", model },
+        connectionGeneration,
+      );
+      if (connection.readyState === WebSocket.OPEN) {
+        connection.send(encode({ event: "error", error: "invalid_request" }));
+        connection.close(1002, "invalid protocol sequence");
+      }
+    };
     connection.on("message", (raw) => {
-      const frame = decode(new Uint8Array(raw as Buffer)) as Record<
-        string,
-        unknown
-      >;
+      let frame: Record<string, unknown>;
+      try {
+        const decoded = decode(new Uint8Array(raw as Buffer));
+        if (
+          typeof decoded !== "object" ||
+          decoded === null ||
+          Array.isArray(decoded)
+        ) {
+          rejectProtocol();
+          return;
+        }
+        frame = decoded as Record<string, unknown>;
+      } catch {
+        // error-policy:J3 malformed client frames are rejected as invalid
+        // protocol input instead of escaping the mock server event loop.
+        rejectProtocol();
+        return;
+      }
       const frameEvent = typeof frame.event === "string" ? frame.event : "";
       store.observe(
         { event: "frame", frameEvent, model },
         connectionGeneration,
       );
-      if (frameEvent === "start") {
+      if (requestState === "start" && frameEvent === "start") {
         const requestFrame = frame.request as
           | Record<string, unknown>
           | undefined;
+        if (!validStartRequest(requestFrame)) {
+          rejectProtocol();
+          return;
+        }
         referenceId =
           typeof requestFrame?.reference_id === "string"
             ? requestFrame.reference_id
             : undefined;
-      }
-      if (frameEvent === "text" && typeof frame.text === "string") {
+        requestState = "text";
+      } else if (
+        requestState === "text" &&
+        frameEvent === "text" &&
+        typeof frame.text === "string" &&
+        frame.text.length > 0
+      ) {
         text = frame.text;
-      }
-      if (frameEvent === "stop") {
+        requestState = "flush";
+      } else if (requestState === "flush" && frameEvent === "flush") {
+        requestState = "stop";
+      } else if (requestState === "stop" && frameEvent === "stop") {
+        requestState = "complete";
         store.observe(
-          { event: "request", model, referenceId, text },
+          { event: "request", model, referenceId, text, requestValid: true },
           connectionGeneration,
         );
         const responsePlan = store.responsePlan(connectionGeneration);
         if (responsePlan) void respond(connection, responsePlan);
+      } else {
+        rejectProtocol();
       }
     });
     connection.on("close", (code) => {
@@ -329,4 +387,18 @@ function singleHeader(
 
 function sanitizeHttpStatusText(value: string): string {
   return value.replaceAll(/[\r\n]/g, " ").slice(0, 123);
+}
+
+function validStartRequest(
+  request: Record<string, unknown> | undefined,
+): boolean {
+  return (
+    request?.text === "" &&
+    typeof request.reference_id === "string" &&
+    request.reference_id.length > 0 &&
+    request.format === "pcm" &&
+    request.sample_rate === 24_000 &&
+    request.latency === "balanced" &&
+    request.chunk_length === 100
+  );
 }

--- a/packages/cloud/test-mocks/src/fish-audio/index.ts
+++ b/packages/cloud/test-mocks/src/fish-audio/index.ts
@@ -1,0 +1,303 @@
+/**
+ * Provides a resettable Fish Audio WebSocket/MessagePack upstream for driving
+ * the production Fish client without credentials or provider traffic.
+ */
+
+import http from "node:http";
+
+import { decode, encode } from "@msgpack/msgpack";
+import { WebSocket, WebSocketServer } from "ws";
+
+export type FishAudioMockFault =
+  | "rate_limit"
+  | "malformed_frame"
+  | "array_frame"
+  | "provider_error"
+  | "close_early"
+  | "stall";
+
+export interface FishAudioMockSeed {
+  apiKey: string;
+  model: string;
+  audioChunks: Uint8Array[];
+  chunkDelayMs: number;
+}
+
+export interface FishAudioMockObservation {
+  order: number;
+  generation: number;
+  event: "upgrade_rejected" | "frame" | "request" | "closed";
+  authorized?: boolean;
+  status?: number;
+  frameEvent?: string;
+  model?: string;
+  referenceId?: string;
+  text?: string;
+  closeCode?: number;
+  closeReason?: string;
+}
+
+const DEFAULT_SEED: FishAudioMockSeed = {
+  apiKey: "synthetic-fish-key",
+  model: "s2.1-pro",
+  audioChunks: [new Uint8Array([1, 2]), new Uint8Array([3, 4])],
+  chunkDelayMs: 0,
+};
+
+export class FishAudioMockStore {
+  #generation = 1;
+  #seed: FishAudioMockSeed;
+  #fault: FishAudioMockFault | null = null;
+  #observations: FishAudioMockObservation[] = [];
+  readonly #connections = new Set<WebSocket>();
+
+  constructor(seed: Partial<FishAudioMockSeed> = {}) {
+    this.#seed = normalizeSeed(seed);
+  }
+
+  get generation(): number {
+    return this.#generation;
+  }
+
+  get seed(): FishAudioMockSeed {
+    return cloneSeed(this.#seed);
+  }
+
+  get fault(): FishAudioMockFault | null {
+    return this.#fault;
+  }
+
+  get openConnectionCount(): number {
+    return this.#connections.size;
+  }
+
+  setFault(fault: FishAudioMockFault | null): void {
+    this.#fault = fault;
+  }
+
+  responsePlan(generation: number): FishAudioResponsePlan | null {
+    if (generation !== this.#generation) return null;
+    return { fault: this.#fault, seed: cloneSeed(this.#seed) };
+  }
+
+  reset(seed: Partial<FishAudioMockSeed> = {}): void {
+    this.#generation += 1;
+    this.#seed = normalizeSeed(seed);
+    this.#fault = null;
+    this.#observations = [];
+    for (const connection of this.#connections) {
+      connection.close(1012, "synthetic environment reset");
+    }
+  }
+
+  readback(): {
+    generation: number;
+    fault: FishAudioMockFault | null;
+    observations: FishAudioMockObservation[];
+  } {
+    return {
+      generation: this.#generation,
+      fault: this.#fault,
+      observations: this.#observations.map((entry) => ({ ...entry })),
+    };
+  }
+
+  addConnection(connection: WebSocket): void {
+    this.#connections.add(connection);
+  }
+
+  removeConnection(connection: WebSocket): void {
+    this.#connections.delete(connection);
+  }
+
+  observe(
+    observation: Omit<FishAudioMockObservation, "order" | "generation">,
+    generation = this.#generation,
+  ): void {
+    if (generation !== this.#generation) return;
+    this.#observations.push({
+      ...observation,
+      order: this.#observations.length + 1,
+      generation: this.#generation,
+    });
+  }
+}
+
+export interface RunningFishAudioMock {
+  url: string;
+  store: FishAudioMockStore;
+  stop(): Promise<void>;
+}
+
+export async function startFishAudioMock(
+  seed: Partial<FishAudioMockSeed> = {},
+): Promise<RunningFishAudioMock> {
+  const store = new FishAudioMockStore(seed);
+  const server = http.createServer((_request, response) => {
+    response.writeHead(426, { "content-type": "text/plain" });
+    response.end("WebSocket upgrade required");
+  });
+  const webSockets = new WebSocketServer({ noServer: true });
+
+  server.on("upgrade", (request, socket, head) => {
+    const authorization = request.headers.authorization;
+    const model = singleHeader(request.headers.model);
+    const authorized = authorization === `Bearer ${store.seed.apiKey}`;
+    const status = !authorized || model !== store.seed.model ? 401 : 101;
+    if (status !== 101 || store.fault === "rate_limit") {
+      const rejectedStatus = store.fault === "rate_limit" ? 429 : status;
+      store.observe({
+        event: "upgrade_rejected",
+        authorized,
+        status: rejectedStatus,
+        model,
+      });
+      const retryAfter = rejectedStatus === 429 ? "Retry-After: 1\r\n" : "";
+      socket.write(
+        `HTTP/1.1 ${rejectedStatus} ${rejectedStatus === 429 ? "Too Many Requests" : "Unauthorized"}\r\n${retryAfter}Connection: close\r\n\r\n`,
+      );
+      socket.destroy();
+      return;
+    }
+    webSockets.handleUpgrade(request, socket, head, (connection) => {
+      webSockets.emit("connection", connection, request);
+    });
+  });
+
+  webSockets.on("connection", (connection, request) => {
+    const connectionGeneration = store.generation;
+    store.addConnection(connection);
+    const model = singleHeader(request.headers.model);
+    let referenceId: string | undefined;
+    let text: string | undefined;
+    connection.on("message", (raw) => {
+      const frame = decode(new Uint8Array(raw as Buffer)) as Record<
+        string,
+        unknown
+      >;
+      const frameEvent = typeof frame.event === "string" ? frame.event : "";
+      store.observe(
+        { event: "frame", frameEvent, model },
+        connectionGeneration,
+      );
+      if (frameEvent === "start") {
+        const requestFrame = frame.request as
+          | Record<string, unknown>
+          | undefined;
+        referenceId =
+          typeof requestFrame?.reference_id === "string"
+            ? requestFrame.reference_id
+            : undefined;
+      }
+      if (frameEvent === "text" && typeof frame.text === "string") {
+        text = frame.text;
+      }
+      if (frameEvent === "stop") {
+        store.observe(
+          { event: "request", model, referenceId, text },
+          connectionGeneration,
+        );
+        const responsePlan = store.responsePlan(connectionGeneration);
+        if (responsePlan) void respond(connection, responsePlan);
+      }
+    });
+    connection.on("close", (code, reason) => {
+      store.removeConnection(connection);
+      store.observe(
+        {
+          event: "closed",
+          closeCode: code,
+          closeReason: reason.toString(),
+        },
+        connectionGeneration,
+      );
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Fish Audio mock did not bind to a numeric port");
+  }
+
+  return {
+    url: `ws://127.0.0.1:${address.port}/v1/tts/live`,
+    store,
+    stop: async () => {
+      for (const connection of webSockets.clients) connection.terminate();
+      await new Promise<void>((resolve) => webSockets.close(() => resolve()));
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
+
+interface FishAudioResponsePlan {
+  fault: FishAudioMockFault | null;
+  seed: FishAudioMockSeed;
+}
+
+async function respond(
+  connection: WebSocket,
+  plan: FishAudioResponsePlan,
+): Promise<void> {
+  const { fault, seed } = plan;
+  if (fault === "stall") return;
+  if (fault === "malformed_frame") {
+    connection.send(new Uint8Array([0xc1]));
+    return;
+  }
+  if (fault === "array_frame") {
+    connection.send(encode(["not", "a", "protocol", "object"]));
+    return;
+  }
+  if (fault === "provider_error") {
+    connection.send(
+      encode({ event: "error", message: "synthetic provider failure" }),
+    );
+    return;
+  }
+  if (fault === "close_early") {
+    connection.close(1011, "synthetic provider closed early");
+    return;
+  }
+  for (const chunk of seed.audioChunks) {
+    if (seed.chunkDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, seed.chunkDelayMs));
+    }
+    if (connection.readyState !== WebSocket.OPEN) return;
+    connection.send(encode({ event: "audio", audio: chunk }));
+  }
+  if (connection.readyState === WebSocket.OPEN) {
+    connection.send(encode({ event: "finish", reason: "stop" }));
+    connection.close(1000, "synthesis complete");
+  }
+}
+
+function normalizeSeed(seed: Partial<FishAudioMockSeed>): FishAudioMockSeed {
+  return {
+    apiKey: seed.apiKey ?? DEFAULT_SEED.apiKey,
+    model: seed.model ?? DEFAULT_SEED.model,
+    audioChunks: (seed.audioChunks ?? DEFAULT_SEED.audioChunks).map(
+      (chunk) => new Uint8Array(chunk),
+    ),
+    chunkDelayMs: seed.chunkDelayMs ?? DEFAULT_SEED.chunkDelayMs,
+  };
+}
+
+function cloneSeed(seed: FishAudioMockSeed): FishAudioMockSeed {
+  return normalizeSeed(seed);
+}
+
+function singleHeader(
+  value: string | string[] | undefined,
+): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}

--- a/packages/cloud/test-mocks/src/index.ts
+++ b/packages/cloud/test-mocks/src/index.ts
@@ -1,5 +1,6 @@
 /** Exports cloud mocks and provider-contract infrastructure for deterministic tests. */
 export * as controlPlane from "./control-plane";
+export * as fishAudio from "./fish-audio";
 export * from "./hetzner";
 export * as providerContract from "./provider-contract";
 export * from "./steward";

--- a/plugins/plugin-fish-audio/AGENTS.md
+++ b/plugins/plugin-fish-audio/AGENTS.md
@@ -27,3 +27,9 @@ bun run --cwd plugins/plugin-fish-audio build
   Fish receives submitted text and the reference ID, so credentials and the
   feature flag alone must never authorize provider egress.
 - Keep live tests skipped unless a caller explicitly provides `FISH_AUDIO_API_KEY` and a consented `FISH_AUDIO_REFERENCE_ID`/`FISH_AUDIO_VOICE_ID`.
+- Keep offline protocol coverage on the production WebSocket/MessagePack client
+  by connecting it to `@elizaos/cloud-test-mocks/fish-audio`; do not replace
+  client methods with an in-memory socket when claiming integration evidence.
+- Classify authentication, rate limit, timeout, cancellation, transport,
+  malformed response, and provider failures explicitly so caller-owned retry
+  policy never retries permanent failures.

--- a/plugins/plugin-fish-audio/CLAUDE.md
+++ b/plugins/plugin-fish-audio/CLAUDE.md
@@ -27,3 +27,9 @@ bun run --cwd plugins/plugin-fish-audio build
   Fish receives submitted text and the reference ID, so credentials and the
   feature flag alone must never authorize provider egress.
 - Keep live tests skipped unless a caller explicitly provides `FISH_AUDIO_API_KEY` and a consented `FISH_AUDIO_REFERENCE_ID`/`FISH_AUDIO_VOICE_ID`.
+- Keep offline protocol coverage on the production WebSocket/MessagePack client
+  by connecting it to `@elizaos/cloud-test-mocks/fish-audio`; do not replace
+  client methods with an in-memory socket when claiming integration evidence.
+- Classify authentication, rate limit, timeout, cancellation, transport,
+  malformed response, and provider failures explicitly so caller-owned retry
+  policy never retries permanent failures.

--- a/plugins/plugin-fish-audio/README.md
+++ b/plugins/plugin-fish-audio/README.md
@@ -47,3 +47,11 @@ response into one frame instead of streaming audio before completion. When
 belongs outside the repository and must not contain the API key.
 
 The live WebSocket uses `Authorization: Bearer <FISH_AUDIO_API_KEY>` and a `model` connection header. It sends MessagePack frames in this order: `{ event: "start", request: { text: "", reference_id, format: "pcm", sample_rate: 24000, latency: "balanced", chunk_length: 100 } }`, one `{ event: "text", text }`, `{ event: "flush" }`, then `{ event: "stop" }`. This benchmarked configuration produced multiple playable frames with substantially lower time to first audio than Fish's `normal` latency mode.
+
+## Offline protocol integration
+
+Offline integration tests use the resettable Fish Audio protocol service from
+`@elizaos/cloud-test-mocks/fish-audio`. They exercise the production
+WebSocket/MessagePack client with seeded chunks, cancellation, authentication,
+rate limiting, malformed frames, provider failures, stalls, deterministic
+reset, and credential-redacted ordered readback without provider traffic.

--- a/plugins/plugin-fish-audio/__tests__/protocol-mock.integration.test.ts
+++ b/plugins/plugin-fish-audio/__tests__/protocol-mock.integration.test.ts
@@ -5,7 +5,9 @@
 
 import { startFishAudioMock } from "@elizaos/cloud-test-mocks/fish-audio";
 import type { IAgentRuntime } from "@elizaos/core";
+import { decode, encode } from "@msgpack/msgpack";
 import { afterEach, describe, expect, test } from "vitest";
+import WebSocket from "ws";
 import { createFishAudioNodeWebSocketFactory } from "../node-transport";
 import {
   classifyFishAudioFailure,
@@ -27,8 +29,8 @@ function runtime(apiKey = "synthetic-fish-key"): IAgentRuntime {
   } as IAgentRuntime;
 }
 
-async function startMock() {
-  const mock = await startFishAudioMock();
+async function startMock(seed: Parameters<typeof startFishAudioMock>[0] = {}) {
+  const mock = await startFishAudioMock(seed);
   runningMocks.push(mock);
   configureFishAudioWebSocketFactory(
     createFishAudioNodeWebSocketFactory(mock.url),
@@ -126,6 +128,7 @@ describe("Fish Audio protocol mock", () => {
         model: "s2.1-pro",
         referenceId: "synthetic-voice",
         text: "synthetic hello",
+        requestValid: true,
       }),
     );
     expect(JSON.stringify(readback)).not.toContain("synthetic-fish-key");
@@ -139,6 +142,72 @@ describe("Fish Audio protocol mock", () => {
       observations: [],
     });
     expect(mock.store.seed.audioChunks).toEqual([new Uint8Array([9, 8])]);
+  });
+
+  test("rejects out-of-order client frames instead of fabricating synthesis", async () => {
+    const mock = await startMock();
+    const socket = new WebSocket(mock.url, {
+      headers: {
+        Authorization: "Bearer synthetic-fish-key",
+        model: "s2.1-pro",
+      },
+    });
+    await new Promise<void>((resolve, reject) => {
+      socket.once("open", resolve);
+      socket.once("error", reject);
+    });
+    const response = new Promise<Record<string, unknown>>((resolve, reject) => {
+      socket.once("message", (data) => {
+        try {
+          resolve(
+            decode(new Uint8Array(data as Buffer)) as Record<string, unknown>,
+          );
+        } catch (error) {
+          reject(error);
+        }
+      });
+      socket.once("error", reject);
+    });
+
+    socket.send(encode({ event: "stop" }));
+
+    await expect(response).resolves.toMatchObject({
+      event: "error",
+      error: "invalid_request",
+    });
+    await waitFor(() => mock.store.openConnectionCount === 0);
+    expect(mock.store.readback().observations).toContainEqual(
+      expect.objectContaining({ event: "protocol_rejected" }),
+    );
+    expect(
+      mock.store
+        .readback()
+        .observations.some((entry) => entry.event === "request"),
+    ).toBe(false);
+  });
+
+  test("stops provider work when a streaming consumer closes its iterator", async () => {
+    const mock = await startMock({
+      audioChunks: [
+        new Uint8Array([1, 2]),
+        new Uint8Array([3, 4]),
+        new Uint8Array([5, 6]),
+      ],
+      chunkDelayMs: 25,
+    });
+    const result = await streamingResult({ text: "consume one chunk" });
+    const iterator = result.audioStream[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: new Uint8Array([1, 2]),
+    });
+    await iterator.return?.();
+
+    await expect(result.bytes).rejects.toMatchObject({
+      code: "FISH_AUDIO_STREAM_ABORTED",
+    });
+    await waitFor(() => mock.store.openConnectionCount === 0);
   });
 
   test("rejects authentication without recording the credential", async () => {
@@ -163,6 +232,26 @@ describe("Fish Audio protocol mock", () => {
     );
     expect(JSON.stringify(mock.store.readback())).not.toContain(
       "secret-wrong-key",
+    );
+  });
+
+  test("does not let a configured rate-limit fault mask invalid credentials", async () => {
+    const mock = await startMock();
+    mock.store.setFault("rate_limit");
+    const result = await streamingResult(
+      { text: "wrong key during provider throttling" },
+      "secret-wrong-key",
+    );
+
+    await expect(result.bytes).rejects.toMatchObject({
+      code: "FISH_AUDIO_AUTH_FAILED",
+    });
+    expect(mock.store.readback().observations).toContainEqual(
+      expect.objectContaining({
+        event: "upgrade_rejected",
+        authorized: false,
+        status: 401,
+      }),
     );
   });
 

--- a/plugins/plugin-fish-audio/__tests__/protocol-mock.integration.test.ts
+++ b/plugins/plugin-fish-audio/__tests__/protocol-mock.integration.test.ts
@@ -61,6 +61,40 @@ async function waitFor(
   }
 }
 
+function serializeFailure(error: unknown): string {
+  return JSON.stringify(
+    {
+      direct: String(error),
+      error,
+    },
+    (_key, value) => {
+      if (!(value instanceof Error)) return value;
+      const fields = new Set([
+        "name",
+        "message",
+        "stack",
+        "cause",
+        ...Object.keys(value),
+      ]);
+      return Object.fromEntries(
+        [...fields].map((field) => [
+          field,
+          (value as unknown as Record<string, unknown>)[field],
+        ]),
+      );
+    },
+  );
+}
+
+function expectSanitizedFailure(
+  error: unknown,
+  secret: string,
+  expected: { code: string; message: string },
+): void {
+  expect(error).toMatchObject(expected);
+  expect(serializeFailure(error)).not.toContain(secret);
+}
+
 afterEach(async () => {
   configureFishAudioWebSocketFactory(undefined);
   await Promise.all(runningMocks.splice(0).map((mock) => mock.stop()));
@@ -184,6 +218,63 @@ describe("Fish Audio protocol mock", () => {
       retryable: false,
     });
     await waitFor(() => mock.store.openConnectionCount === 0);
+  });
+
+  test("redacts provider frame, close, and upgrade text from every public error surface", async () => {
+    const mock = await startMock();
+    const frameSecret = "FRAME_SECRET_do-not-reflect_7e11";
+    mock.store.setFault("provider_error", { providerMessage: frameSecret });
+    const providerFailure = await streamingResult({ text: "frame failure" });
+    const providerError = await providerFailure.bytes.catch(
+      (failure: unknown) => failure,
+    );
+    expectSanitizedFailure(providerError, frameSecret, {
+      code: "FISH_AUDIO_PROVIDER_ERROR",
+      message: "Fish Audio provider reported an error",
+    });
+    expect(classifyFishAudioFailure(providerError)).toEqual({
+      category: "provider",
+      retryable: false,
+    });
+    await waitFor(() => mock.store.openConnectionCount === 0);
+    expect(JSON.stringify(mock.store.readback())).not.toContain(frameSecret);
+
+    mock.store.reset();
+    const closeSecret = "CLOSE_SECRET_do-not-reflect_28c4";
+    mock.store.setFault("close_early", { closeReason: closeSecret });
+    const closed = await streamingResult({ text: "close failure" });
+    const closeError = await closed.bytes.catch((failure: unknown) => failure);
+    expectSanitizedFailure(closeError, closeSecret, {
+      code: "FISH_AUDIO_WEBSOCKET_CLOSED_EARLY",
+      message: "Fish Audio WebSocket closed before synthesis completed",
+    });
+    expect(closeError).toMatchObject({ context: { closeCode: 1011 } });
+    expect(classifyFishAudioFailure(closeError)).toEqual({
+      category: "transport",
+      retryable: true,
+    });
+    await waitFor(() => mock.store.openConnectionCount === 0);
+    expect(JSON.stringify(mock.store.readback())).not.toContain(closeSecret);
+
+    mock.store.reset();
+    const upgradeSecret = "UPGRADE_SECRET_do-not-reflect_a090";
+    mock.store.setFault("rate_limit", { upgradeStatusText: upgradeSecret });
+    const rejected = await streamingResult({ text: "upgrade failure" });
+    const upgradeError = await rejected.bytes.catch(
+      (failure: unknown) => failure,
+    );
+    expectSanitizedFailure(upgradeError, upgradeSecret, {
+      code: "FISH_AUDIO_RATE_LIMITED",
+      message: "Fish Audio rate limit exceeded",
+    });
+    expect(upgradeError).toMatchObject({
+      context: { retryable: true, statusCode: 429 },
+    });
+    expect(classifyFishAudioFailure(upgradeError)).toEqual({
+      category: "rate_limit",
+      retryable: true,
+    });
+    expect(JSON.stringify(mock.store.readback())).not.toContain(upgradeSecret);
   });
 
   test("cancels and times out stalled real protocol sessions", async () => {

--- a/plugins/plugin-fish-audio/__tests__/protocol-mock.integration.test.ts
+++ b/plugins/plugin-fish-audio/__tests__/protocol-mock.integration.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Exercises the production Fish Audio WebSocket/MessagePack client against a
+ * resettable local protocol service with deterministic faults and readback.
+ */
+
+import { startFishAudioMock } from "@elizaos/cloud-test-mocks/fish-audio";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, test } from "vitest";
+import { createFishAudioNodeWebSocketFactory } from "../node-transport";
+import {
+  classifyFishAudioFailure,
+  configureFishAudioWebSocketFactory,
+  handleFishAudioTextToSpeech,
+} from "../src/index";
+
+const runningMocks: Awaited<ReturnType<typeof startFishAudioMock>>[] = [];
+
+function runtime(apiKey = "synthetic-fish-key"): IAgentRuntime {
+  const settings: Record<string, string> = {
+    ELIZA_TTS_FISH_ENABLED: "true",
+    FISH_AUDIO_DATA_GOVERNANCE_APPROVED: "true",
+    FISH_AUDIO_API_KEY: apiKey,
+    FISH_AUDIO_REFERENCE_ID: "synthetic-voice",
+  };
+  return {
+    getSetting: (key: string) => settings[key],
+  } as IAgentRuntime;
+}
+
+async function startMock() {
+  const mock = await startFishAudioMock();
+  runningMocks.push(mock);
+  configureFishAudioWebSocketFactory(
+    createFishAudioNodeWebSocketFactory(mock.url),
+  );
+  return mock;
+}
+
+async function streamingResult(
+  input: Parameters<typeof handleFishAudioTextToSpeech>[1],
+  apiKey?: string,
+) {
+  const result = await handleFishAudioTextToSpeech(runtime(apiKey), {
+    ...input,
+    audioStream: true,
+  });
+  if (result instanceof Uint8Array)
+    throw new Error("Expected streaming result");
+  return result;
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline)
+      throw new Error("Timed out awaiting mock readback");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+afterEach(async () => {
+  configureFishAudioWebSocketFactory(undefined);
+  await Promise.all(runningMocks.splice(0).map((mock) => mock.stop()));
+});
+
+describe("Fish Audio protocol mock", () => {
+  test("streams seeded chunks through the real client and exposes resettable redacted readback", async () => {
+    const mock = await startMock();
+    const result = await streamingResult({ text: "synthetic hello" });
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of result.audioStream) chunks.push(chunk);
+
+    expect(chunks).toEqual([new Uint8Array([1, 2]), new Uint8Array([3, 4])]);
+    expect(await result.bytes).toEqual(new Uint8Array([1, 2, 3, 4]));
+    await waitFor(() =>
+      mock.store
+        .readback()
+        .observations.some((entry) => entry.event === "closed"),
+    );
+    const readback = mock.store.readback();
+    expect(
+      readback.observations
+        .filter((entry) => entry.event === "frame")
+        .map((entry) => entry.frameEvent),
+    ).toEqual(["start", "text", "flush", "stop"]);
+    expect(readback.observations).toContainEqual(
+      expect.objectContaining({
+        event: "request",
+        model: "s2.1-pro",
+        referenceId: "synthetic-voice",
+        text: "synthetic hello",
+      }),
+    );
+    expect(JSON.stringify(readback)).not.toContain("synthetic-fish-key");
+
+    const generation = readback.generation;
+    mock.store.setFault("provider_error");
+    mock.store.reset({ audioChunks: [new Uint8Array([9, 8])] });
+    expect(mock.store.readback()).toEqual({
+      generation: generation + 1,
+      fault: null,
+      observations: [],
+    });
+    expect(mock.store.seed.audioChunks).toEqual([new Uint8Array([9, 8])]);
+  });
+
+  test("rejects authentication without recording the credential", async () => {
+    const mock = await startMock();
+    const result = await streamingResult(
+      { text: "wrong key" },
+      "secret-wrong-key",
+    );
+
+    const error = await result.bytes.catch((failure: unknown) => failure);
+    expect(error).toMatchObject({ code: "FISH_AUDIO_AUTH_FAILED" });
+    expect(classifyFishAudioFailure(error)).toEqual({
+      category: "auth",
+      retryable: false,
+    });
+    expect(mock.store.readback().observations).toContainEqual(
+      expect.objectContaining({
+        event: "upgrade_rejected",
+        authorized: false,
+        status: 401,
+      }),
+    );
+    expect(JSON.stringify(mock.store.readback())).not.toContain(
+      "secret-wrong-key",
+    );
+  });
+
+  test("classifies rate limiting as retryable", async () => {
+    const mock = await startMock();
+    mock.store.setFault("rate_limit");
+    const result = await streamingResult({ text: "retry later" });
+
+    const error = await result.bytes.catch((failure: unknown) => failure);
+    expect(error).toMatchObject({ code: "FISH_AUDIO_RATE_LIMITED" });
+    expect(classifyFishAudioFailure(error)).toEqual({
+      category: "rate_limit",
+      retryable: true,
+    });
+    expect(mock.store.readback().observations).toContainEqual(
+      expect.objectContaining({ event: "upgrade_rejected", status: 429 }),
+    );
+  });
+
+  test("rejects malformed MessagePack and provider-declared failures", async () => {
+    const mock = await startMock();
+    mock.store.setFault("malformed_frame");
+    const malformed = await streamingResult({ text: "bad bytes" });
+    const malformedError = await malformed.bytes.catch(
+      (failure: unknown) => failure,
+    );
+    expect(malformedError).toMatchObject({
+      code: "FISH_AUDIO_PROVIDER_MESSAGE_INVALID",
+    });
+    expect(classifyFishAudioFailure(malformedError)).toEqual({
+      category: "invalid_response",
+      retryable: false,
+    });
+    await waitFor(() => mock.store.openConnectionCount === 0);
+
+    mock.store.reset();
+    mock.store.setFault("array_frame");
+    const arrayFrame = await streamingResult({ text: "array frame" });
+    await expect(arrayFrame.bytes).rejects.toMatchObject({
+      code: "FISH_AUDIO_PROVIDER_MESSAGE_INVALID",
+    });
+    await waitFor(() => mock.store.openConnectionCount === 0);
+
+    mock.store.reset();
+    mock.store.setFault("provider_error");
+    const failed = await streamingResult({ text: "provider failure" });
+    const providerError = await failed.bytes.catch(
+      (failure: unknown) => failure,
+    );
+    expect(providerError).toMatchObject({ code: "FISH_AUDIO_PROVIDER_ERROR" });
+    expect(classifyFishAudioFailure(providerError)).toEqual({
+      category: "provider",
+      retryable: false,
+    });
+    await waitFor(() => mock.store.openConnectionCount === 0);
+  });
+
+  test("cancels and times out stalled real protocol sessions", async () => {
+    const mock = await startMock();
+    mock.store.setFault("stall");
+    const controller = new AbortController();
+    const cancelled = await streamingResult({
+      text: "cancel me",
+      signal: controller.signal,
+    });
+    await waitFor(() =>
+      mock.store
+        .readback()
+        .observations.some((entry) => entry.event === "request"),
+    );
+    controller.abort();
+    const cancelledError = await cancelled.bytes.catch(
+      (failure: unknown) => failure,
+    );
+    expect(cancelledError).toMatchObject({ code: "FISH_AUDIO_STREAM_ABORTED" });
+    expect(classifyFishAudioFailure(cancelledError)).toEqual({
+      category: "cancelled",
+      retryable: false,
+    });
+    await waitFor(() => mock.store.openConnectionCount === 0);
+
+    mock.store.reset();
+    mock.store.setFault("stall");
+    const staleGeneration = mock.store.generation;
+    const stale = await streamingResult({ text: "reset this session" });
+    await waitFor(() =>
+      mock.store
+        .readback()
+        .observations.some((entry) => entry.event === "request"),
+    );
+    mock.store.reset();
+    await expect(stale.bytes).rejects.toMatchObject({
+      code: "FISH_AUDIO_WEBSOCKET_CLOSED_EARLY",
+    });
+    await waitFor(() => mock.store.openConnectionCount === 0);
+    expect(mock.store.readback()).toEqual({
+      generation: staleGeneration + 1,
+      fault: null,
+      observations: [],
+    });
+
+    mock.store.setFault("stall");
+    const timedOut = await streamingResult({
+      text: "time out",
+      synthesisTimeoutMs: 25,
+    });
+    const timeoutError = await timedOut.bytes.catch(
+      (failure: unknown) => failure,
+    );
+    expect(timeoutError).toMatchObject({
+      code: "FISH_AUDIO_SYNTHESIS_TIMEOUT",
+    });
+    expect(classifyFishAudioFailure(timeoutError)).toEqual({
+      category: "timeout",
+      retryable: true,
+    });
+    await waitFor(() => mock.store.openConnectionCount === 0);
+  });
+});

--- a/plugins/plugin-fish-audio/__tests__/streaming.test.ts
+++ b/plugins/plugin-fish-audio/__tests__/streaming.test.ts
@@ -66,9 +66,9 @@ class FakeFishSocket {
     }
   }
 
-  close(_code?: number, reason?: string): void {
+  close(code?: number, reason?: string): void {
     this.readyState = 3;
-    this.fire("close", { reason });
+    this.fire("close", { code, reason });
   }
 
   addEventListener(type: string, listener: (event: never) => void): void {
@@ -86,6 +86,10 @@ class FakeFishSocket {
 
   emitFinish(): void {
     this.fire("message", { data: encode({ event: "finish", reason: "stop" }) });
+  }
+
+  emitError(message: string, error: unknown): void {
+    this.fire("error", { message, error });
   }
 
   private fire(type: string, event: unknown): void {
@@ -263,8 +267,49 @@ describe("fishAudioPlugin", () => {
     FakeFishSocket.instances.at(-1)?.close(1011, "provider failed");
 
     await expect(result.bytes).rejects.toThrow(
-      "Fish Audio WebSocket closed before finish: provider failed",
+      "Fish Audio WebSocket closed before synthesis completed",
     );
+  });
+
+  test("does not preserve provider-controlled WebSocket error text or causes", async () => {
+    FakeFishSocket.respondToText = false;
+    useFakeSocket();
+    const result = await handleFishAudioTextToSpeech(
+      runtime({
+        ELIZA_TTS_FISH_ENABLED: "true",
+        FISH_AUDIO_DATA_GOVERNANCE_APPROVED: "true",
+        FISH_AUDIO_API_KEY: "key",
+        FISH_AUDIO_REFERENCE_ID: "voice",
+      }),
+      { text: "transport error", audioStream: true },
+    );
+    if (!("bytes" in result)) throw new Error("Expected streaming result");
+    await Promise.resolve();
+    const secret = "WS_CAUSE_SECRET_do-not-reflect_88fd";
+    FakeFishSocket.instances
+      .at(-1)
+      ?.emitError(`upgrade 401 ${secret}`, new Error(`cause ${secret}`));
+
+    const failure = await result.bytes.catch((error: unknown) => error);
+    expect(failure).toMatchObject({
+      code: "FISH_AUDIO_AUTH_FAILED",
+      message: "Fish Audio authentication failed",
+      context: { retryable: false, statusCode: 401 },
+    });
+    const error = failure as Error & {
+      cause?: unknown;
+      context?: Record<string, unknown>;
+    };
+    expect(error.cause).toBeUndefined();
+    expect(
+      [
+        String(error),
+        error.stack,
+        JSON.stringify(error),
+        JSON.stringify(error.context),
+        String(error.cause),
+      ].join("\n"),
+    ).not.toContain(secret);
   });
 
   test("rejects a provider finish frame whose reason is error", async () => {
@@ -282,7 +327,7 @@ describe("fishAudioPlugin", () => {
     if (!("bytes" in result)) throw new Error("Expected streaming result");
 
     await expect(result.bytes).rejects.toThrow(
-      "Fish Audio TTS failed to finish synthesis",
+      "Fish Audio provider reported a synthesis failure",
     );
   });
 

--- a/plugins/plugin-fish-audio/__tests__/streaming.test.ts
+++ b/plugins/plugin-fish-audio/__tests__/streaming.test.ts
@@ -102,6 +102,12 @@ function runtime(
   } as unknown as IAgentRuntime;
 }
 
+function useFakeSocket(): void {
+  configureFishAudioWebSocketFactory(
+    (url, options) => new FakeFishSocket(url, undefined, options),
+  );
+}
+
 function wrapPcm16MonoAsWav(pcm: Uint8Array, sampleRate: number): Uint8Array {
   const header = Buffer.alloc(44);
   header.write("RIFF", 0, "ascii");
@@ -182,10 +188,7 @@ describe("fishAudioPlugin", () => {
   });
 
   test("returns AudioStreamResult when audioStream is true and sends MessagePack frames", async () => {
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const rt = runtime({
       ELIZA_TTS_FISH_ENABLED: "true",
       FISH_AUDIO_DATA_GOVERNANCE_APPROVED: "true",
@@ -245,10 +248,7 @@ describe("fishAudioPlugin", () => {
 
   test("rejects when Fish closes before a finish frame", async () => {
     FakeFishSocket.respondToText = false;
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const result = await handleFishAudioTextToSpeech(
       runtime({
         ELIZA_TTS_FISH_ENABLED: "true",
@@ -269,10 +269,7 @@ describe("fishAudioPlugin", () => {
 
   test("rejects a provider finish frame whose reason is error", async () => {
     FakeFishSocket.finishReason = "error";
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const result = await handleFishAudioTextToSpeech(
       runtime({
         ELIZA_TTS_FISH_ENABLED: "true",
@@ -290,10 +287,7 @@ describe("fishAudioPlugin", () => {
   });
 
   test("rejects an already-aborted request", async () => {
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const controller = new AbortController();
     controller.abort();
     const result = await handleFishAudioTextToSpeech(
@@ -311,10 +305,7 @@ describe("fishAudioPlugin", () => {
   });
 
   test("detaches the abort listener once synthesis finishes on its own", async () => {
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const controller = new AbortController();
     const remove = vi.spyOn(controller.signal, "removeEventListener");
 
@@ -334,10 +325,7 @@ describe("fishAudioPlugin", () => {
   });
 
   test("buffers bytes when audioStream is false", async () => {
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const rt = runtime({
       ELIZA_TTS_FISH_ENABLED: "true",
       FISH_AUDIO_DATA_GOVERNANCE_APPROVED: "true",
@@ -352,10 +340,7 @@ describe("fishAudioPlugin", () => {
 
   test("accepts audio exactly at the configured buffer ceiling", async () => {
     FakeFishSocket.respondToText = false;
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const result = await handleFishAudioTextToSpeech(
       runtime({
         ELIZA_TTS_FISH_ENABLED: "true",
@@ -378,10 +363,7 @@ describe("fishAudioPlugin", () => {
 
   test("rejects both result surfaces and closes when audio exceeds the buffer ceiling", async () => {
     FakeFishSocket.respondToText = false;
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const result = await handleFishAudioTextToSpeech(
       runtime({
         ELIZA_TTS_FISH_ENABLED: "true",
@@ -415,10 +397,7 @@ describe("fishAudioPlugin", () => {
   test("rejects and closes a stalled synthesis at the wall-clock deadline", async () => {
     vi.useFakeTimers();
     FakeFishSocket.respondToText = false;
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const result = await handleFishAudioTextToSpeech(
       runtime({
         ELIZA_TTS_FISH_ENABLED: "true",
@@ -441,10 +420,7 @@ describe("fishAudioPlugin", () => {
   test("suppresses provider frames and deadline work after cancellation", async () => {
     vi.useFakeTimers();
     FakeFishSocket.respondToText = false;
-    Object.defineProperty(globalThis, "WebSocket", {
-      value: FakeFishSocket,
-      configurable: true,
-    });
+    useFakeSocket();
     const controller = new AbortController();
     const result = await handleFishAudioTextToSpeech(
       runtime({

--- a/plugins/plugin-fish-audio/__tests__/streaming.test.ts
+++ b/plugins/plugin-fish-audio/__tests__/streaming.test.ts
@@ -288,7 +288,10 @@ describe("fishAudioPlugin", () => {
     const secret = "WS_CAUSE_SECRET_do-not-reflect_88fd";
     FakeFishSocket.instances
       .at(-1)
-      ?.emitError(`upgrade 401 ${secret}`, new Error(`cause ${secret}`));
+      ?.emitError(
+        "Unexpected server response: 401",
+        new Error(`cause ${secret}`),
+      );
 
     const failure = await result.bytes.catch((error: unknown) => error);
     expect(failure).toMatchObject({
@@ -309,6 +312,41 @@ describe("fishAudioPlugin", () => {
         JSON.stringify(error.context),
         String(error.cause),
       ].join("\n"),
+    ).not.toContain(secret);
+  });
+
+  test("does not classify injected status digits as an upgrade status", async () => {
+    FakeFishSocket.respondToText = false;
+    useFakeSocket();
+    const result = await handleFishAudioTextToSpeech(
+      runtime({
+        ELIZA_TTS_FISH_ENABLED: "true",
+        FISH_AUDIO_DATA_GOVERNANCE_APPROVED: "true",
+        FISH_AUDIO_API_KEY: "key",
+        FISH_AUDIO_REFERENCE_ID: "voice",
+      }),
+      { text: "ambiguous transport error", audioStream: true },
+    );
+    if (!("bytes" in result)) throw new Error("Expected streaming result");
+    await Promise.resolve();
+    const secret = "WS_STATUS_SECRET_429_then_401_778a";
+    FakeFishSocket.instances
+      .at(-1)
+      ?.emitError(
+        `provider text ${secret}`,
+        new Error(`Unexpected server response: 401 ${secret}`),
+      );
+
+    const failure = await result.bytes.catch((error: unknown) => error);
+    expect(failure).toMatchObject({
+      code: "FISH_AUDIO_WEBSOCKET_ERROR",
+      message: "Fish Audio WebSocket transport failed",
+      context: { retryable: true },
+    });
+    const error = failure as Error & { cause?: unknown };
+    expect(error.cause).toBeUndefined();
+    expect(
+      [String(error), error.stack, JSON.stringify(error)].join("\n"),
     ).not.toContain(secret);
   });
 

--- a/plugins/plugin-fish-audio/index.browser.ts
+++ b/plugins/plugin-fish-audio/index.browser.ts
@@ -9,7 +9,9 @@ configureFishAudioWebSocketFactory(() => {
   );
 });
 
+export type { FishAudioFailureClassification } from "./src/index";
 export {
+  classifyFishAudioFailure,
   default,
   fishAudioPlugin,
   handleFishAudioTextToSpeech,

--- a/plugins/plugin-fish-audio/index.node.ts
+++ b/plugins/plugin-fish-audio/index.node.ts
@@ -1,12 +1,14 @@
 /** Node entrypoint for the Fish Audio plugin. */
-import WebSocket from "ws";
+
+import { createFishAudioNodeWebSocketFactory } from "./node-transport";
 import { configureFishAudioWebSocketFactory } from "./src/index";
 
-configureFishAudioWebSocketFactory(
-  (url, options) => new WebSocket(url, { headers: options.headers }),
-);
+configureFishAudioWebSocketFactory(createFishAudioNodeWebSocketFactory());
 
+export { createFishAudioNodeWebSocketFactory } from "./node-transport";
+export type { FishAudioFailureClassification } from "./src/index";
 export {
+  classifyFishAudioFailure,
   default,
   fishAudioPlugin,
   handleFishAudioTextToSpeech,

--- a/plugins/plugin-fish-audio/index.ts
+++ b/plugins/plugin-fish-audio/index.ts
@@ -1,12 +1,14 @@
 /** Exposes the Fish Audio plugin from the package root. */
-import WebSocket from "ws";
+
+import { createFishAudioNodeWebSocketFactory } from "./node-transport";
 import { configureFishAudioWebSocketFactory } from "./src/index";
 
-configureFishAudioWebSocketFactory(
-  (url, options) => new WebSocket(url, { headers: options.headers }),
-);
+configureFishAudioWebSocketFactory(createFishAudioNodeWebSocketFactory());
 
+export { createFishAudioNodeWebSocketFactory } from "./node-transport";
+export type { FishAudioFailureClassification } from "./src/index";
 export {
+  classifyFishAudioFailure,
   default,
   fishAudioPlugin,
   handleFishAudioTextToSpeech,

--- a/plugins/plugin-fish-audio/node-transport.ts
+++ b/plugins/plugin-fish-audio/node-transport.ts
@@ -1,0 +1,13 @@
+/** Provides the authenticated Node WebSocket transport used by Fish Audio. */
+
+import WebSocket from "ws";
+
+interface FishAudioNodeTransportOptions {
+  readonly headers: Record<string, string>;
+}
+
+/** Creates the production Node transport, optionally targeting a test upstream. */
+export function createFishAudioNodeWebSocketFactory(endpointOverride?: string) {
+  return (url: string, options: FishAudioNodeTransportOptions) =>
+    new WebSocket(endpointOverride ?? url, { headers: options.headers });
+}

--- a/plugins/plugin-fish-audio/package.json
+++ b/plugins/plugin-fish-audio/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.8",
     "@elizaos/core": "workspace:*",
+    "@elizaos/cloud-test-mocks": "workspace:*",
     "@types/bun": "^1.3.8",
     "@types/node": "^25.0.3",
     "@types/ws": "^8.18.1",

--- a/plugins/plugin-fish-audio/src/index.ts
+++ b/plugins/plugin-fish-audio/src/index.ts
@@ -410,13 +410,9 @@ function createFishAudioStream(
     }
   });
   socket.addEventListener("error", (event) => {
-    const diagnosticText = [
-      event.message,
-      event.error instanceof Error ? event.error.message : undefined,
-    ]
-      .filter((value): value is string => typeof value === "string")
-      .join(" ");
-    const statusCode = /\b(401|429)\b/.exec(diagnosticText)?.[1];
+    const statusCode = /^Unexpected server response: (401|429)$/.exec(
+      event.message ?? "",
+    )?.[1];
     const code =
       statusCode === "401"
         ? "FISH_AUDIO_AUTH_FAILED"

--- a/plugins/plugin-fish-audio/src/index.ts
+++ b/plugins/plugin-fish-audio/src/index.ts
@@ -388,12 +388,9 @@ function createFishAudioStream(
       if (frame.event === "finish") {
         if (frame.reason === "error") {
           fail(
-            new ElizaError(
-              String(
-                frame.message ?? "Fish Audio TTS failed to finish synthesis",
-              ),
-              { code: "FISH_AUDIO_PROVIDER_FINISH_ERROR" },
-            ),
+            new ElizaError("Fish Audio provider reported a synthesis failure", {
+              code: "FISH_AUDIO_PROVIDER_FINISH_ERROR",
+            }),
           );
         } else {
           finish();
@@ -401,10 +398,9 @@ function createFishAudioStream(
       }
       if (frame.event === "error" || frame.error) {
         fail(
-          new ElizaError(
-            String(frame.message ?? frame.error ?? "Fish Audio TTS failed"),
-            { code: "FISH_AUDIO_PROVIDER_ERROR" },
-          ),
+          new ElizaError("Fish Audio provider reported an error", {
+            code: "FISH_AUDIO_PROVIDER_ERROR",
+          }),
         );
       }
     } catch (error) {
@@ -414,22 +410,28 @@ function createFishAudioStream(
     }
   });
   socket.addEventListener("error", (event) => {
-    const message =
-      event.message ??
-      (event.error instanceof Error
-        ? event.error.message
-        : "Fish Audio WebSocket error");
-    const statusCode = /\b(401|429)\b/.exec(message)?.[1];
+    const diagnosticText = [
+      event.message,
+      event.error instanceof Error ? event.error.message : undefined,
+    ]
+      .filter((value): value is string => typeof value === "string")
+      .join(" ");
+    const statusCode = /\b(401|429)\b/.exec(diagnosticText)?.[1];
     const code =
       statusCode === "401"
         ? "FISH_AUDIO_AUTH_FAILED"
         : statusCode === "429"
           ? "FISH_AUDIO_RATE_LIMITED"
           : "FISH_AUDIO_WEBSOCKET_ERROR";
+    const publicMessage =
+      statusCode === "401"
+        ? "Fish Audio authentication failed"
+        : statusCode === "429"
+          ? "Fish Audio rate limit exceeded"
+          : "Fish Audio WebSocket transport failed";
     fail(
-      new ElizaError(message, {
+      new ElizaError(publicMessage, {
         code,
-        cause: event.error,
         severity: statusCode === "401" ? "fatal" : "ephemeral",
         context: {
           retryable: statusCode !== "401",
@@ -440,11 +442,11 @@ function createFishAudioStream(
   });
   socket.addEventListener("close", (event) => {
     if (done) return;
-    const detail = event.reason ? `: ${event.reason}` : "";
     fail(
-      new ElizaError(`Fish Audio WebSocket closed before finish${detail}`, {
+      new ElizaError("Fish Audio WebSocket closed before synthesis completed", {
         code: "FISH_AUDIO_WEBSOCKET_CLOSED_EARLY",
-        context: { statusCode: event.code, reason: event.reason },
+        context:
+          typeof event.code === "number" ? { closeCode: event.code } : {},
       }),
     );
   });
@@ -518,12 +520,11 @@ function decodeFrame(data: unknown): Record<string, unknown> {
               new Uint8Array(data.buffer, data.byteOffset, data.byteLength),
             )
           : decode(data as Uint8Array);
-  } catch (error) {
+  } catch {
     // error-policy:J1 malformed provider bytes are translated at the transport
     // boundary and never reach callers as an unclassified decoder exception.
     throw new ElizaError("Fish Audio returned an invalid MessagePack frame", {
       code: "FISH_AUDIO_PROVIDER_MESSAGE_INVALID",
-      cause: error,
       severity: "fatal",
     });
   }

--- a/plugins/plugin-fish-audio/src/index.ts
+++ b/plugins/plugin-fish-audio/src/index.ts
@@ -294,6 +294,10 @@ function createFishAudioStream(
     resolveBytes = resolve;
     rejectBytes = reject;
   });
+  // error-policy:J5 stream-only consumers observe the same failure through
+  // iterator.next(); this handler prevents the parallel bytes view from
+  // becoming an unhandled rejection when they intentionally never await it.
+  void bytes.catch(() => undefined);
   const socket = openSocket(config.apiKey, config.model);
   socket.binaryType = "arraybuffer";
   let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
@@ -475,6 +479,10 @@ function createFishAudioStream(
               failure ? reject(failure) : resolve(result),
             );
           });
+        },
+        return(): Promise<IteratorResult<Uint8Array>> {
+          if (!done) abort();
+          return Promise.resolve({ done: true, value: undefined });
         },
       };
     },

--- a/plugins/plugin-fish-audio/src/index.ts
+++ b/plugins/plugin-fish-audio/src/index.ts
@@ -41,6 +41,51 @@ type TtsInput =
       synthesisTimeoutMs?: number;
     });
 
+export interface FishAudioFailureClassification {
+  category:
+    | "auth"
+    | "rate_limit"
+    | "timeout"
+    | "cancelled"
+    | "provider"
+    | "transport"
+    | "invalid_response"
+    | "configuration";
+  retryable: boolean;
+}
+
+/** Classifies Fish failures for bounded caller-owned retry policy. */
+export function classifyFishAudioFailure(
+  error: unknown,
+): FishAudioFailureClassification {
+  const code = error instanceof ElizaError ? error.code : "";
+  if (code === "FISH_AUDIO_AUTH_FAILED") {
+    return { category: "auth", retryable: false };
+  }
+  if (code === "FISH_AUDIO_RATE_LIMITED") {
+    return { category: "rate_limit", retryable: true };
+  }
+  if (code === "FISH_AUDIO_SYNTHESIS_TIMEOUT") {
+    return { category: "timeout", retryable: true };
+  }
+  if (code === "FISH_AUDIO_STREAM_ABORTED") {
+    return { category: "cancelled", retryable: false };
+  }
+  if (code === "FISH_AUDIO_PROVIDER_MESSAGE_INVALID") {
+    return { category: "invalid_response", retryable: false };
+  }
+  if (
+    code === "FISH_AUDIO_WEBSOCKET_ERROR" ||
+    code === "FISH_AUDIO_WEBSOCKET_CLOSED_EARLY"
+  ) {
+    return { category: "transport", retryable: true };
+  }
+  if (code.startsWith("FISH_AUDIO_PROVIDER_")) {
+    return { category: "provider", retryable: false };
+  }
+  return { category: "configuration", retryable: false };
+}
+
 interface FishAudioWebSocketLike {
   readonly readyState: number;
   binaryType?: string;
@@ -259,16 +304,22 @@ function createFishAudioStream(
     done = true;
     if (deadlineTimer) clearTimeout(deadlineTimer);
     unlistenAbort?.();
+    socket.close(1000, "synthesis complete");
     resolveBytes(concatBytes(bufferedChunks, totalBytes));
     while (waiters.length > 0) {
       waiters.shift()?.({ done: true, value: undefined });
     }
   };
-  const fail = (error: unknown) => {
+  const fail = (
+    error: unknown,
+    closeCode = 1011,
+    closeReason = "synthesis failed",
+  ) => {
     if (done) return;
     done = true;
     if (deadlineTimer) clearTimeout(deadlineTimer);
     unlistenAbort?.();
+    socket.close(closeCode, closeReason);
     failure = error;
     rejectBytes(error);
     while (waiters.length > 0) {
@@ -286,8 +337,9 @@ function createFishAudioStream(
             receivedBytes: totalBytes + chunk.byteLength,
           },
         }),
+        1009,
+        "audio limit exceeded",
       );
-      socket.close(1009, "audio limit exceeded");
       return;
     }
     bufferedChunks.push(chunk);
@@ -305,8 +357,9 @@ function createFishAudioStream(
         code: "FISH_AUDIO_SYNTHESIS_TIMEOUT",
         context: { synthesisTimeoutMs: config.synthesisTimeoutMs },
       }),
+      1013,
+      "synthesis timeout",
     );
-    socket.close(1013, "synthesis timeout");
   }, config.synthesisTimeoutMs);
 
   socket.addEventListener("open", () => {
@@ -360,20 +413,31 @@ function createFishAudioStream(
       fail(error);
     }
   });
-  socket.addEventListener("error", (event) =>
+  socket.addEventListener("error", (event) => {
+    const message =
+      event.message ??
+      (event.error instanceof Error
+        ? event.error.message
+        : "Fish Audio WebSocket error");
+    const statusCode = /\b(401|429)\b/.exec(message)?.[1];
+    const code =
+      statusCode === "401"
+        ? "FISH_AUDIO_AUTH_FAILED"
+        : statusCode === "429"
+          ? "FISH_AUDIO_RATE_LIMITED"
+          : "FISH_AUDIO_WEBSOCKET_ERROR";
     fail(
-      new ElizaError(
-        event.message ??
-          (event.error instanceof Error
-            ? event.error.message
-            : "Fish Audio WebSocket error"),
-        {
-          code: "FISH_AUDIO_WEBSOCKET_ERROR",
-          cause: event.error,
+      new ElizaError(message, {
+        code,
+        cause: event.error,
+        severity: statusCode === "401" ? "fatal" : "ephemeral",
+        context: {
+          retryable: statusCode !== "401",
+          ...(statusCode ? { statusCode: Number(statusCode) } : {}),
         },
-      ),
-    ),
-  );
+      }),
+    );
+  });
   socket.addEventListener("close", (event) => {
     if (done) return;
     const detail = event.reason ? `: ${event.reason}` : "";
@@ -389,8 +453,9 @@ function createFishAudioStream(
       new ElizaError("Fish Audio TTS aborted", {
         code: "FISH_AUDIO_STREAM_ABORTED",
       }),
+      1000,
+      "aborted",
     );
-    socket.close(1000, "aborted");
   };
   if (config.signal?.aborted) {
     abort();
@@ -436,40 +501,33 @@ function openSocket(
   if (configuredWebSocketFactory) {
     return configuredWebSocketFactory(FISH_AUDIO_TTS_WEBSOCKET_URL, options);
   }
-  const WebSocketCtor = (
-    globalThis as {
-      WebSocket?: new (
-        url: string,
-        protocolsOrOptions?:
-          | string
-          | string[]
-          | { headers?: Record<string, string> },
-        options?: { headers?: Record<string, string> },
-      ) => FishAudioWebSocketLike;
-    }
-  ).WebSocket;
-  if (!WebSocketCtor) {
-    throw new ElizaError("WebSocket is not available for Fish Audio TTS", {
-      code: "FISH_AUDIO_WEBSOCKET_UNAVAILABLE",
-    });
-  }
-  try {
-    return new WebSocketCtor(FISH_AUDIO_TTS_WEBSOCKET_URL, undefined, options);
-  } catch {
-    // error-policy:J1 boundary translation — runtimes differ on whether WS
-    // headers are accepted as the second or third constructor argument.
-    return new WebSocketCtor(FISH_AUDIO_TTS_WEBSOCKET_URL, options);
-  }
+  throw new ElizaError(
+    "Fish Audio requires the authenticated platform WebSocket transport",
+    { code: "FISH_AUDIO_WEBSOCKET_UNAVAILABLE" },
+  );
 }
 
 function decodeFrame(data: unknown): Record<string, unknown> {
-  const frame =
-    data instanceof ArrayBuffer
-      ? decode(new Uint8Array(data))
-      : ArrayBuffer.isView(data)
-        ? decode(new Uint8Array(data.buffer, data.byteOffset, data.byteLength))
-        : decode(data as Uint8Array);
-  if (typeof frame !== "object" || frame === null) {
+  let frame: unknown;
+  try {
+    frame =
+      data instanceof ArrayBuffer
+        ? decode(new Uint8Array(data))
+        : ArrayBuffer.isView(data)
+          ? decode(
+              new Uint8Array(data.buffer, data.byteOffset, data.byteLength),
+            )
+          : decode(data as Uint8Array);
+  } catch (error) {
+    // error-policy:J1 malformed provider bytes are translated at the transport
+    // boundary and never reach callers as an unclassified decoder exception.
+    throw new ElizaError("Fish Audio returned an invalid MessagePack frame", {
+      code: "FISH_AUDIO_PROVIDER_MESSAGE_INVALID",
+      cause: error,
+      severity: "fatal",
+    });
+  }
+  if (typeof frame !== "object" || frame === null || Array.isArray(frame)) {
     throw new ElizaError("Fish Audio frame must be an object", {
       code: "FISH_AUDIO_PROVIDER_MESSAGE_INVALID",
     });


### PR DESCRIPTION
# Relates to

Refs #24092

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. Focused gates pass; the unrelated root `bun run verify` blocker is recorded below.
- [x] A reviewer can confirm the real protocol path from the exact-head test transcript below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync. It is blocked by unrelated existing repository lint/type failures documented below.

# Risks

Low-to-medium. The change adds an offline protocol service and explicit failure classification, and centralizes Fish WebSocket terminal cleanup. Risk is limited to Fish Audio TTS transport/error behavior.

# Background

## What does this PR do?

This partial #24092 slice adds a resettable local Fish Audio WebSocket/MessagePack upstream and drives it through the same production-owned Node `ws` transport adapter used by the package entrypoint. It proves seeded incremental PCM chunks, deterministic reset, ordered credential-redacted readback, cancellation, timeout, 401 auth rejection, 429 retry classification, malformed bytes, invalid array frames, provider failures, and terminal socket cleanup.

The mock never replaces client methods, uses no real credentials, and cannot report provider success without the real client completing the protocol exchange. Provider-controlled frame text, peer close reasons, upgrade response text, and WebSocket error causes are translated to stable public failures with numeric allowlisted metadata only. Upgrade status classification accepts only the exact Node `ws` error shape, so injected 401/429 digits cannot alter retry policy.

## What kind of change is this?

Feature: deterministic offline protocol integration coverage plus explicit Fish Audio failure classification and connection cleanup.

## Remaining #24092 scope

- Wallet blockchain JSON-RPC mock: reads, writes, receipts, reorgs, malformed/provider/transport faults.
- Plugin-registry upstream HTTP mock: cache/ETag/pagination and failure modes.
- Broader cloud scenario/e2e wiring after those protocol services land.

# Documentation changes needed?

Documentation was updated in both owning workspaces, including paired package guides.

# Testing

## Where should a reviewer start?

`plugins/plugin-fish-audio/__tests__/protocol-mock.integration.test.ts` and `packages/cloud/test-mocks/src/fish-audio/index.ts`.

## Detailed testing steps

At exact current head `2d25fc36f42762636b2e57c3b37fcdf6686d4f0a`:

```text
Fish tests: 2 files passed; 26 passed, 1 opt-in live skipped
Fish typecheck: PASS
Fish lint:check: PASS (13 files)
Fish build: PASS (Node, Browser, declarations)
Cloud scoped test-mocks: 87/87 passed, 456 expectations, 15 files
Cloud test-mocks lint: PASS; two pre-existing warnings outside Fish files
Fish and cloud test-mocks guide parity: PASS
git diff --check base..HEAD: PASS
```

The full cloud aggregate encountered one unrelated sparse-environment WhatsApp resolution failure (`WHATSAPP_IDEMPOTENCY_STORAGE_UNAVAILABLE`, then `ECONNRESET`); the Fish-scoped cloud suite passed 87/87.

Prior baseline at `3b5710f0c0bc943901cc09af3146636e1e05243e`:

```text
$ bun run --cwd plugins/plugin-fish-audio test
Test Files  2 passed (2)
Tests       23 passed | 1 opt-in live test skipped (24)
Duration    17.03s (tests 311ms)

$ bun run --cwd plugins/plugin-fish-audio typecheck
exit 0

$ bun run --cwd plugins/plugin-fish-audio lint:check
Checked 13 files. No fixes applied.

$ bun run --cwd plugins/plugin-fish-audio build
Node complete; Browser complete; declarations generated.

$ bun run --cwd packages/cloud/test-mocks test
88 pass, 0 fail, 479 expect() calls

$ bun run check:agents-claude
PASS: 160 tracked CLAUDE.md/AGENTS.md pairs are byte-identical.
```

# Evidence Gate

<!-- evidence-head:2d25fc36f42762636b2e57c3b37fcdf6686d4f0a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI flow changes.
<!-- evidence-row:backend-logs -->
- [x] [24228-3b5710f-fish-provider-sanitization.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24228-3b5710f-fish-provider-sanitization.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network surface changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM, prompt, planner, action, or agent behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [x] [24228-3b5710f-fish-provider-sanitization.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24228-3b5710f-fish-provider-sanitization.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - this is a provider transport/mock contract slice and does not invoke an LLM.

## Backend + frontend logs

The exact-head backend protocol test transcript is in **Detailed testing steps**. Frontend logs are N/A because no frontend is involved.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Audio / voice walkthrough

N/A for this partial slice - it intentionally proves deterministic synthetic PCM and protocol behavior without provider traffic. Existing opt-in funded-provider live audio evidence remains separate and is not claimed here.

## Known gaps / failures

- Root `bun run verify` was attempted after sync but is blocked by unrelated pre-existing repository lint failures, first observed in `packages/agent/src/api/interactions-routes.test.ts` (`noNonNullAssertion`).
- `bun run --cwd packages/cloud/test-mocks typecheck` is independently blocked by an unrelated existing `src/control-plane/server.ts:274` mismatch: `Promise<boolean>` is not assignable to `Promise<void>`.
- Root verification also reports existing warnings outside this diff. Exact-head focused Fish tests/typecheck/lint/build, 87/87 scoped cloud mock tests, cloud mock lint, guide parity, and diff checks pass. Hosted CI is pending and is not a source-completeness blocker.
- This PR does not claim wallet, registry, all-cloud scenario coverage, real-provider audio, or exactly-once behavior.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A (not used)
Attribution status: self-reported
— fish-protocol-mock
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A"} -->


