### PR TITLE
test(matrix): add Client-Server protocol simulator

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -799,9 +799,11 @@
       "devDependencies": {
         "@elizaos/cloud-sdk": "workspace:*",
         "@elizaos/plugin-github": "workspace:*",
+        "@elizaos/plugin-matrix": "workspace:*",
         "@elizaos/plugin-whatsapp": "workspace:*",
         "@typescript/native": "npm:typescript@^7.0.2",
         "bun-types": "*",
+        "matrix-js-sdk": "^41.4.0",
       },
     },
     "packages/core": {

--- a/packages/cloud/test-mocks/AGENTS.md
+++ b/packages/cloud/test-mocks/AGENTS.md
@@ -25,6 +25,10 @@ exits.
   `Job`/`JobStatus`/`JobType`/`Sandbox`/`SandboxStatus` types.
 - `src/steward/` (export `./steward`) — stateful loopback mock for authenticated
   Steward platform-user deactivation and deletion calls used by account lifecycle E2E.
+- `src/matrix/` (export `./matrix`) — resettable Matrix Client-Server API subset
+  exercised by the real `matrix-js-sdk` and plugin service. It owns seeded users,
+  rooms, state/timeline events, sync and pagination cursors, joins, sends, faults,
+  request observations, and generation-safe long-poll invalidation.
 - `src/fetch-server.ts` — shared `startFetchServer(fetch, opts)`; uses
   `Bun.serve` when running under Bun, falls back to a `node:http` adapter
   otherwise.
@@ -89,6 +93,10 @@ teardown.
   (default 8791), `HOST`, `CONTROL_PLANE_TICK_MS`, `HCLOUD_API_BASE_URL`.
 - **Mockoon files are stateless** read-only fixtures — they do not share state
   with the Hono mocks; use the Hono mocks when behavior depends on prior writes.
+- **Matrix state is generation-bound.** `startMatrixClientServerMock()` uses
+  deterministic logical timestamps and transaction deduplication. Reset aborts
+  active long polls with `M_UNKNOWN_POS`, so an admitted old cursor cannot read
+  replacement-generation rooms. Canonical snapshots omit internal transaction IDs.
 
 ## Managed provider contract suites
 

--- a/packages/cloud/test-mocks/CLAUDE.md
+++ b/packages/cloud/test-mocks/CLAUDE.md
@@ -25,6 +25,10 @@ exits.
   `Job`/`JobStatus`/`JobType`/`Sandbox`/`SandboxStatus` types.
 - `src/steward/` (export `./steward`) — stateful loopback mock for authenticated
   Steward platform-user deactivation and deletion calls used by account lifecycle E2E.
+- `src/matrix/` (export `./matrix`) — resettable Matrix Client-Server API subset
+  exercised by the real `matrix-js-sdk` and plugin service. It owns seeded users,
+  rooms, state/timeline events, sync and pagination cursors, joins, sends, faults,
+  request observations, and generation-safe long-poll invalidation.
 - `src/fetch-server.ts` — shared `startFetchServer(fetch, opts)`; uses
   `Bun.serve` when running under Bun, falls back to a `node:http` adapter
   otherwise.
@@ -89,6 +93,10 @@ teardown.
   (default 8791), `HOST`, `CONTROL_PLANE_TICK_MS`, `HCLOUD_API_BASE_URL`.
 - **Mockoon files are stateless** read-only fixtures — they do not share state
   with the Hono mocks; use the Hono mocks when behavior depends on prior writes.
+- **Matrix state is generation-bound.** `startMatrixClientServerMock()` uses
+  deterministic logical timestamps and transaction deduplication. Reset aborts
+  active long polls with `M_UNKNOWN_POS`, so an admitted old cursor cannot read
+  replacement-generation rooms. Canonical snapshots omit internal transaction IDs.
 
 ## Managed provider contract suites
 

--- a/packages/cloud/test-mocks/README.md
+++ b/packages/cloud/test-mocks/README.md
@@ -76,6 +76,17 @@ Implements the subset of the Hetzner Cloud API that the autoscaler client in
 
 State is kept in memory and resets when the process exits.
 
+## Matrix Client-Server API mock
+
+`startMatrixClientServerMock()` from `@elizaos/cloud-test-mocks/matrix`
+starts a resettable loopback homeserver subset used through the real
+`matrix-js-sdk`. It implements version/capability discovery, access-token
+authentication, filters, `/sync` cursors, room state and live timelines,
+create/join, transaction-deduplicated sends, backward pagination, rate-limit
+metadata, faults, and authoritative snapshots. Reset cancels pre-reset long
+polls with `M_UNKNOWN_POS`; deterministic timestamps make reset/replay state
+byte-equivalent.
+
 ### Run standalone
 
 ```bash

--- a/packages/cloud/test-mocks/package.json
+++ b/packages/cloud/test-mocks/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./hetzner": "./src/hetzner/index.ts",
     "./control-plane": "./src/control-plane/index.ts",
+    "./matrix": "./src/matrix/index.ts",
     "./steward": "./src/steward/index.ts",
     "./provider-contract": "./src/provider-contract/index.ts"
   },
@@ -33,9 +34,11 @@
   "devDependencies": {
     "@elizaos/cloud-sdk": "workspace:*",
     "@elizaos/plugin-github": "workspace:*",
+    "@elizaos/plugin-matrix": "workspace:*",
     "@elizaos/plugin-whatsapp": "workspace:*",
     "@typescript/native": "npm:typescript@^7.0.2",
-    "bun-types": "*"
+    "bun-types": "*",
+    "matrix-js-sdk": "^41.4.0"
   },
   "elizaos": {
     "scripts": {

--- a/packages/cloud/test-mocks/src/fetch-server.ts
+++ b/packages/cloud/test-mocks/src/fetch-server.ts
@@ -1,6 +1,7 @@
 /** Exports shared cloud mock helpers for deterministic local provider API tests. */
 import http from "node:http";
 import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 
 export interface FetchServerOptions {
   port?: number;
@@ -90,6 +91,16 @@ async function handleNodeRequest(
   incoming: http.IncomingMessage,
   outgoing: http.ServerResponse,
 ) {
+  const abortController = new AbortController();
+  const abortIncoming = () =>
+    abortController.abort(
+      new DOMException("Client disconnected", "AbortError"),
+    );
+  const abortOutgoing = () => {
+    if (!outgoing.writableEnded) abortIncoming();
+  };
+  incoming.once("aborted", abortIncoming);
+  outgoing.once("close", abortOutgoing);
   try {
     const headers = new Headers();
     for (const [key, value] of Object.entries(incoming.headers)) {
@@ -108,6 +119,7 @@ async function handleNodeRequest(
       headers,
       body: hasBody ? Readable.toWeb(incoming) : undefined,
       duplex: hasBody ? "half" : undefined,
+      signal: abortController.signal,
     } as RequestInit & { duplex?: "half" });
 
     const response = await fetch(request);
@@ -115,9 +127,27 @@ async function handleNodeRequest(
     response.headers.forEach((value, key) => {
       outgoing.setHeader(key, value);
     });
-    outgoing.end(Buffer.from(await response.arrayBuffer()));
+    if (!response.body) {
+      outgoing.end();
+    } else {
+      await pipeline(
+        Readable.fromWeb(
+          response.body as unknown as import("node:stream/web").ReadableStream,
+        ),
+        outgoing,
+      );
+    }
   } catch (error) {
-    outgoing.statusCode = 500;
-    outgoing.end(error instanceof Error ? error.message : "mock server error");
+    if (!outgoing.headersSent && !outgoing.destroyed) {
+      outgoing.statusCode = 500;
+      outgoing.end(
+        error instanceof Error ? error.message : "mock server error",
+      );
+    } else if (!outgoing.destroyed) {
+      outgoing.destroy(error instanceof Error ? error : undefined);
+    }
+  } finally {
+    incoming.off("aborted", abortIncoming);
+    outgoing.off("close", abortOutgoing);
   }
 }

--- a/packages/cloud/test-mocks/src/index.ts
+++ b/packages/cloud/test-mocks/src/index.ts
@@ -1,5 +1,6 @@
 /** Exports cloud mocks and provider-contract infrastructure for deterministic tests. */
 export * as controlPlane from "./control-plane";
 export * from "./hetzner";
+export * as matrix from "./matrix";
 export * as providerContract from "./provider-contract";
 export * from "./steward";

--- a/packages/cloud/test-mocks/src/matrix/index.ts
+++ b/packages/cloud/test-mocks/src/matrix/index.ts
@@ -1,0 +1,4 @@
+/** Exports the resettable Matrix Client-Server API simulator and its seed/readback contracts. */
+
+export * from "./server.js";
+export * from "./types.js";

--- a/packages/cloud/test-mocks/src/matrix/server.ts
+++ b/packages/cloud/test-mocks/src/matrix/server.ts
@@ -12,13 +12,21 @@ import type {
 
 interface StoredEvent extends MatrixMockEventSeed {
   sequence: number;
-  transactionId?: string;
 }
 
 interface RoomState extends Omit<MatrixMockRoomSeed, "timeline"> {
   joined: boolean;
   joinedAt: number;
+  stateEvents: Array<Record<string, unknown>>;
   timeline: StoredEvent[];
+}
+
+interface IdentifierState {
+  roomIds: Set<string>;
+  eventIds: Set<string>;
+  aliases: Set<string>;
+  roomSequence: number;
+  eventSequence: number;
 }
 
 export interface RunningMatrixClientServerMock {
@@ -38,10 +46,14 @@ export async function startMatrixClientServerMock(
   let generation = 0;
   let eventSequence = 0;
   let requestSequence = 0;
-  let roomSequence = 0;
-  let eventIdSequence = 0;
-  let rooms = buildRooms(currentSeed, () => ++eventSequence);
+  let identifiers = collectSeedIdentifiers(currentSeed);
+  let rooms = buildRooms(
+    currentSeed,
+    () => ++eventSequence,
+    () => allocateEventId(identifiers),
+  );
   let requests: MatrixRequestObservation[] = [];
+  let transactionEvents = new Map<string, string>();
   const faults = new Map<string, MatrixMockFault[]>();
   const activeRequests = new Set<AbortController>();
 
@@ -156,21 +168,37 @@ export async function startMatrixClientServerMock(
           "synthetic Matrix generation changed",
         );
       }
-      return json(
-        buildSync(currentSeed, rooms, since, generation, eventSequence),
-      );
+      return json(buildSync(rooms, since, generation, eventSequence));
     }
     if (request.method === "POST" && path === "/createRoom") {
-      const roomId = `!created-${++roomSequence}:mock`;
       const name = readString(body, "name");
-      rooms.set(roomId, {
+      const aliasLocalpart = readString(body, "room_alias_name");
+      const canonicalAlias = aliasLocalpart
+        ? `#${aliasLocalpart}:mock`
+        : undefined;
+      if (canonicalAlias && identifiers.aliases.has(canonicalAlias)) {
+        return matrixError(
+          409,
+          "M_ROOM_IN_USE",
+          "room alias is already in use",
+        );
+      }
+      const roomId = allocateRoomId(identifiers);
+      if (canonicalAlias) identifiers.aliases.add(canonicalAlias);
+      const room: RoomState = {
         roomId,
         name: name ?? undefined,
+        canonicalAlias,
         joined: true,
         joinedAt: ++eventSequence,
         members: [{ userId: currentSeed.userId, displayName: "Synthetic Bot" }],
+        stateEvents: [],
         timeline: [],
-      });
+      };
+      room.stateEvents = roomStateEvents(currentSeed, room, () =>
+        allocateEventId(identifiers),
+      );
+      rooms.set(roomId, room);
       return json({ room_id: roomId });
     }
 
@@ -184,9 +212,20 @@ export async function startMatrixClientServerMock(
       const ownMember = room.members.find(
         (member) => member.userId === currentSeed.userId,
       );
-      if (ownMember) ownMember.membership = "join";
-      else
+      if (ownMember) {
+        ownMember.membership = "join";
+        updateMemberState(room, currentSeed.userId, ownMember.displayName);
+      } else {
         room.members.push({ userId: currentSeed.userId, membership: "join" });
+        room.stateEvents.push(
+          memberStateEvent(
+            room.roomId,
+            allocateEventId(identifiers),
+            currentSeed.userId,
+            undefined,
+          ),
+        );
+      }
       return json({ room_id: room.roomId });
     }
 
@@ -197,11 +236,10 @@ export async function startMatrixClientServerMock(
       const transactionId = decodeURIComponent(sendMatch[3] ?? "");
       const room = rooms.get(roomId);
       if (!room?.joined) return matrixError(403, "M_FORBIDDEN", "not joined");
-      const existing = room.timeline.find(
-        (event) => event.transactionId === transactionId,
-      );
-      if (existing) return json({ event_id: existing.eventId });
-      const eventId = `$sent-${++eventIdSequence}:mock`;
+      const transactionKey = JSON.stringify([roomId, eventType, transactionId]);
+      const existingEventId = transactionEvents.get(transactionKey);
+      if (existingEventId) return json({ event_id: existingEventId });
+      const eventId = allocateEventId(identifiers);
       const sequence = ++eventSequence;
       room.timeline.push({
         eventId,
@@ -210,8 +248,8 @@ export async function startMatrixClientServerMock(
         content: requireRecord(body),
         originServerTs: 1_700_000_100_000 + sequence,
         sequence,
-        transactionId,
       });
+      transactionEvents.set(transactionKey, eventId);
       return json({ event_id: eventId });
     }
 
@@ -267,14 +305,8 @@ export async function startMatrixClientServerMock(
     enqueueInbound(roomId, event) {
       const room = rooms.get(roomId);
       if (!room) throw new Error(`unknown Matrix room '${roomId}'`);
-      if (
-        [...rooms.values()].some((candidateRoom) =>
-          candidateRoom.timeline.some(
-            (candidate) => candidate.eventId === event.eventId,
-          ),
-        )
-      )
-        return false;
+      if (identifiers.eventIds.has(event.eventId)) return false;
+      identifiers.eventIds.add(event.eventId);
       room.timeline.push({
         ...structuredClone(event),
         sequence: ++eventSequence,
@@ -287,10 +319,14 @@ export async function startMatrixClientServerMock(
       currentSeed = cloneSeed(nextSeed);
       eventSequence = 0;
       requestSequence = 0;
-      roomSequence = 0;
-      eventIdSequence = 0;
-      rooms = buildRooms(currentSeed, () => ++eventSequence);
+      identifiers = collectSeedIdentifiers(currentSeed);
+      rooms = buildRooms(
+        currentSeed,
+        () => ++eventSequence,
+        () => allocateEventId(identifiers),
+      );
       requests = [];
+      transactionEvents = new Map();
       faults.clear();
     },
     snapshot() {
@@ -303,32 +339,76 @@ export async function startMatrixClientServerMock(
 function buildRooms(
   seed: MatrixClientServerSeed,
   nextSequence: () => number,
+  nextEventId: () => string,
 ): Map<string, RoomState> {
   if (!seed.userId.startsWith("@") || !seed.accessToken)
     throw new Error("invalid Matrix account seed");
   const rooms = new Map<string, RoomState>();
-  const eventIds = new Set<string>();
   for (const room of seed.rooms) {
-    if (!room.roomId.startsWith("!") || rooms.has(room.roomId))
-      throw new Error("invalid or duplicate Matrix room seed");
     const timeline = (room.timeline ?? []).map((event) => {
-      if (!event.eventId || eventIds.has(event.eventId))
-        throw new Error("duplicate Matrix event seed");
-      eventIds.add(event.eventId);
       return { ...structuredClone(event), sequence: nextSequence() };
     });
-    rooms.set(room.roomId, {
+    const state: RoomState = {
       ...structuredClone(room),
       joined: room.joined ?? true,
       joinedAt: room.joined === false ? Number.MAX_SAFE_INTEGER : 0,
+      stateEvents: [],
       timeline,
-    });
+    };
+    state.stateEvents = roomStateEvents(seed, state, nextEventId);
+    rooms.set(room.roomId, state);
   }
   return rooms;
 }
 
+function collectSeedIdentifiers(seed: MatrixClientServerSeed): IdentifierState {
+  const roomIds = new Set<string>();
+  const eventIds = new Set<string>();
+  const aliases = new Set<string>();
+  for (const room of seed.rooms) {
+    if (!room.roomId.startsWith("!") || roomIds.has(room.roomId))
+      throw new Error("invalid or duplicate Matrix room seed");
+    roomIds.add(room.roomId);
+    if (room.canonicalAlias) {
+      if (
+        !room.canonicalAlias.startsWith("#") ||
+        aliases.has(room.canonicalAlias)
+      )
+        throw new Error("invalid or duplicate Matrix room alias seed");
+      aliases.add(room.canonicalAlias);
+    }
+    for (const event of room.timeline ?? []) {
+      if (!event.eventId || eventIds.has(event.eventId))
+        throw new Error("duplicate Matrix event seed");
+      eventIds.add(event.eventId);
+    }
+  }
+  return {
+    roomIds,
+    eventIds,
+    aliases,
+    roomSequence: 0,
+    eventSequence: 0,
+  };
+}
+
+function allocateRoomId(identifiers: IdentifierState): string {
+  let candidate: string;
+  do candidate = `!created-${++identifiers.roomSequence}:mock`;
+  while (identifiers.roomIds.has(candidate));
+  identifiers.roomIds.add(candidate);
+  return candidate;
+}
+
+function allocateEventId(identifiers: IdentifierState): string {
+  let candidate: string;
+  do candidate = `$generated-${++identifiers.eventSequence}:mock`;
+  while (identifiers.eventIds.has(candidate));
+  identifiers.eventIds.add(candidate);
+  return candidate;
+}
+
 function buildSync(
-  seed: MatrixClientServerSeed,
   rooms: Map<string, RoomState>,
   since: number | null,
   generation: number,
@@ -356,7 +436,7 @@ function buildSync(
             state: {
               events:
                 since === null || newlyJoined
-                  ? roomStateEvents(seed, room)
+                  ? room.stateEvents.map((event) => structuredClone(event))
                   : [],
             },
             timeline: {
@@ -382,22 +462,26 @@ function buildSync(
   };
 }
 
-function roomStateEvents(seed: MatrixClientServerSeed, room: RoomState) {
+function roomStateEvents(
+  seed: MatrixClientServerSeed,
+  room: RoomState,
+  nextEventId: () => string,
+) {
   const events: Array<Record<string, unknown>> = [
-    stateEvent(room.roomId, "$create:mock", "m.room.create", "", seed.userId, {
+    stateEvent(room.roomId, nextEventId(), "m.room.create", "", seed.userId, {
       creator: seed.userId,
       room_version: "10",
     }),
   ];
   if (room.name)
     events.push(
-      stateEvent(room.roomId, "$name:mock", "m.room.name", "", seed.userId, {
+      stateEvent(room.roomId, nextEventId(), "m.room.name", "", seed.userId, {
         name: room.name,
       }),
     );
   if (room.topic)
     events.push(
-      stateEvent(room.roomId, "$topic:mock", "m.room.topic", "", seed.userId, {
+      stateEvent(room.roomId, nextEventId(), "m.room.topic", "", seed.userId, {
         topic: room.topic,
       }),
     );
@@ -405,7 +489,7 @@ function roomStateEvents(seed: MatrixClientServerSeed, room: RoomState) {
     events.push(
       stateEvent(
         room.roomId,
-        "$alias:mock",
+        nextEventId(),
         "m.room.canonical_alias",
         "",
         seed.userId,
@@ -414,20 +498,40 @@ function roomStateEvents(seed: MatrixClientServerSeed, room: RoomState) {
     );
   for (const member of room.members) {
     events.push(
-      stateEvent(
+      memberStateEvent(
         room.roomId,
-        `$member-${encodeURIComponent(member.userId)}:mock`,
-        "m.room.member",
+        nextEventId(),
         member.userId,
-        member.userId,
-        {
-          membership: member.membership ?? "join",
-          displayname: member.displayName,
-        },
+        member.displayName,
+        member.membership,
       ),
     );
   }
   return events;
+}
+
+function memberStateEvent(
+  roomId: string,
+  eventId: string,
+  userId: string,
+  displayName: string | undefined,
+  membership: "join" | "invite" = "join",
+) {
+  return stateEvent(roomId, eventId, "m.room.member", userId, userId, {
+    membership,
+    displayname: displayName,
+  });
+}
+
+function updateMemberState(
+  room: RoomState,
+  userId: string,
+  displayName: string | undefined,
+): void {
+  const state = room.stateEvents.find(
+    (event) => event.type === "m.room.member" && event.state_key === userId,
+  );
+  if (state) state.content = { membership: "join", displayname: displayName };
 }
 
 function stateEvent(
@@ -472,9 +576,8 @@ function snapshot(
     rooms: [...rooms.values()].map((room) => ({
       roomId: room.roomId,
       joined: room.joined,
-      timeline: room.timeline.map(
-        ({ sequence: _sequence, transactionId: _transactionId, ...event }) =>
-          structuredClone(event),
+      timeline: room.timeline.map(({ sequence: _sequence, ...event }) =>
+        structuredClone(event),
       ),
     })),
   };

--- a/packages/cloud/test-mocks/src/matrix/server.ts
+++ b/packages/cloud/test-mocks/src/matrix/server.ts
@@ -268,7 +268,11 @@ export async function startMatrixClientServerMock(
       const room = rooms.get(roomId);
       if (!room) throw new Error(`unknown Matrix room '${roomId}'`);
       if (
-        room.timeline.some((candidate) => candidate.eventId === event.eventId)
+        [...rooms.values()].some((candidateRoom) =>
+          candidateRoom.timeline.some(
+            (candidate) => candidate.eventId === event.eventId,
+          ),
+        )
       )
         return false;
       room.timeline.push({
@@ -303,10 +307,10 @@ function buildRooms(
   if (!seed.userId.startsWith("@") || !seed.accessToken)
     throw new Error("invalid Matrix account seed");
   const rooms = new Map<string, RoomState>();
+  const eventIds = new Set<string>();
   for (const room of seed.rooms) {
     if (!room.roomId.startsWith("!") || rooms.has(room.roomId))
       throw new Error("invalid or duplicate Matrix room seed");
-    const eventIds = new Set<string>();
     const timeline = (room.timeline ?? []).map((event) => {
       if (!event.eventId || eventIds.has(event.eventId))
         throw new Error("duplicate Matrix event seed");

--- a/packages/cloud/test-mocks/src/matrix/server.ts
+++ b/packages/cloud/test-mocks/src/matrix/server.ts
@@ -29,6 +29,23 @@ interface IdentifierState {
   eventSequence: number;
 }
 
+const MATRIX_MAX_REQUEST_BYTES = 1024 * 1024;
+const MATRIX_MAX_JSON_DEPTH = 64;
+const MATRIX_MAX_JSON_NODES = 100_000;
+
+class MatrixRequestError extends Error {
+  constructor(
+    readonly status: 400 | 409 | 413,
+    readonly errcode:
+      | "M_BAD_JSON"
+      | "M_NOT_JSON"
+      | "M_TOO_LARGE"
+      | "M_UNKNOWN_POS",
+  ) {
+    super(errcode);
+  }
+}
+
 export interface RunningMatrixClientServerMock {
   url: string;
   port: number;
@@ -58,16 +75,41 @@ export async function startMatrixClientServerMock(
   const activeRequests = new Set<AbortController>();
 
   const server = await startFetchServer(async (request) => {
+    const admittedGeneration = generation;
+    const admittedSeed = cloneSeed(currentSeed);
     const url = new URL(request.url);
-    const body = await readJsonBody(request);
+    const resetController = new AbortController();
+    activeRequests.add(resetController);
+    let body: unknown;
+    try {
+      body = await readJsonBody(request, resetController.signal);
+    } catch (error) {
+      if (!(error instanceof MatrixRequestError)) throw error;
+      return matrixError(
+        error.status,
+        error.errcode,
+        error.errcode === "M_UNKNOWN_POS"
+          ? "synthetic Matrix generation changed"
+          : "invalid Matrix request body",
+      );
+    } finally {
+      activeRequests.delete(resetController);
+    }
+    if (generation !== admittedGeneration) {
+      return matrixError(
+        409,
+        "M_UNKNOWN_POS",
+        "synthetic Matrix generation changed",
+      );
+    }
     const authenticated =
       request.headers.get("authorization") ===
-      `Bearer ${currentSeed.accessToken}`;
+      `Bearer ${admittedSeed.accessToken}`;
     requests.push({
       sequence: ++requestSequence,
       method: request.method,
       path: url.pathname,
-      query: Object.fromEntries(url.searchParams),
+      query: sanitizedQuery(url.searchParams),
       authenticated,
       body,
     });
@@ -90,7 +132,7 @@ export async function startMatrixClientServerMock(
         !(await waitWithinGeneration(
           fault.delayMs,
           request.signal,
-          generation,
+          admittedGeneration,
           () => generation,
           activeRequests,
         ))
@@ -127,8 +169,8 @@ export async function startMatrixClientServerMock(
     }
     if (request.method === "GET" && path === "/account/whoami") {
       return json({
-        user_id: currentSeed.userId,
-        device_id: currentSeed.deviceId ?? "DEVICE",
+        user_id: admittedSeed.userId,
+        device_id: admittedSeed.deviceId ?? "DEVICE",
       });
     }
     if (request.method === "GET" && path === "/capabilities") {
@@ -143,7 +185,7 @@ export async function startMatrixClientServerMock(
       const parsedSince = parseSyncToken(rawSince);
       if (
         rawSince !== null &&
-        (!parsedSince || parsedSince.generation !== generation)
+        (!parsedSince || parsedSince.generation !== admittedGeneration)
       ) {
         return matrixError(
           409,
@@ -157,7 +199,7 @@ export async function startMatrixClientServerMock(
         !(await waitWithinGeneration(
           Math.min(readPositiveInt(url.searchParams.get("timeout"), 250), 250),
           request.signal,
-          generation,
+          admittedGeneration,
           () => generation,
           activeRequests,
         ))
@@ -168,7 +210,7 @@ export async function startMatrixClientServerMock(
           "synthetic Matrix generation changed",
         );
       }
-      return json(buildSync(rooms, since, generation, eventSequence));
+      return json(buildSync(rooms, since, admittedGeneration, eventSequence));
     }
     if (request.method === "POST" && path === "/createRoom") {
       const name = readString(body, "name");
@@ -191,11 +233,13 @@ export async function startMatrixClientServerMock(
         canonicalAlias,
         joined: true,
         joinedAt: ++eventSequence,
-        members: [{ userId: currentSeed.userId, displayName: "Synthetic Bot" }],
+        members: [
+          { userId: admittedSeed.userId, displayName: "Synthetic Bot" },
+        ],
         stateEvents: [],
         timeline: [],
       };
-      room.stateEvents = roomStateEvents(currentSeed, room, () =>
+      room.stateEvents = roomStateEvents(admittedSeed, room, () =>
         allocateEventId(identifiers),
       );
       rooms.set(roomId, room);
@@ -210,18 +254,18 @@ export async function startMatrixClientServerMock(
       room.joined = true;
       room.joinedAt = ++eventSequence;
       const ownMember = room.members.find(
-        (member) => member.userId === currentSeed.userId,
+        (member) => member.userId === admittedSeed.userId,
       );
       if (ownMember) {
         ownMember.membership = "join";
-        updateMemberState(room, currentSeed.userId, ownMember.displayName);
+        updateMemberState(room, admittedSeed.userId, ownMember.displayName);
       } else {
-        room.members.push({ userId: currentSeed.userId, membership: "join" });
+        room.members.push({ userId: admittedSeed.userId, membership: "join" });
         room.stateEvents.push(
           memberStateEvent(
             room.roomId,
             allocateEventId(identifiers),
-            currentSeed.userId,
+            admittedSeed.userId,
             undefined,
           ),
         );
@@ -243,7 +287,7 @@ export async function startMatrixClientServerMock(
       const sequence = ++eventSequence;
       room.timeline.push({
         eventId,
-        sender: currentSeed.userId,
+        sender: admittedSeed.userId,
         type: eventType,
         content: requireRecord(body),
         originServerTs: 1_700_000_100_000 + sequence,
@@ -618,15 +662,103 @@ function readPositiveInt(value: string | null, fallback: number): number {
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
 }
 
-async function readJsonBody(request: Request): Promise<unknown> {
+async function readJsonBody(
+  request: Request,
+  resetSignal: AbortSignal,
+): Promise<unknown> {
   if (request.method === "GET" || request.method === "HEAD") return undefined;
-  const text = await request.text();
-  if (!text) return {};
-  try {
-    return JSON.parse(text);
-  } catch {
-    return null;
+  const encoding = request.headers.get("content-encoding");
+  if (encoding !== null && encoding.toLowerCase() !== "identity")
+    throw new MatrixRequestError(400, "M_NOT_JSON");
+  const contentType = request.headers.get("content-type");
+  if (!contentType || !/^application\/json(?:\s*;|$)/i.test(contentType))
+    throw new MatrixRequestError(400, "M_NOT_JSON");
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength !== null) {
+    const length = Number(declaredLength);
+    if (!Number.isSafeInteger(length) || length < 0)
+      throw new MatrixRequestError(400, "M_BAD_JSON");
+    if (length > MATRIX_MAX_REQUEST_BYTES)
+      throw new MatrixRequestError(413, "M_TOO_LARGE");
   }
+
+  const reader = request.body?.getReader();
+  if (!reader) return {};
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  const onReset = () => void reader.cancel("Matrix generation reset");
+  resetSignal.addEventListener("abort", onReset, { once: true });
+  try {
+    while (true) {
+      if (resetSignal.aborted)
+        throw new MatrixRequestError(409, "M_UNKNOWN_POS");
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += value.byteLength;
+      if (received > MATRIX_MAX_REQUEST_BYTES) {
+        await reader.cancel("Matrix request body limit exceeded");
+        throw new MatrixRequestError(413, "M_TOO_LARGE");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    resetSignal.removeEventListener("abort", onReset);
+  }
+  if (resetSignal.aborted) throw new MatrixRequestError(409, "M_UNKNOWN_POS");
+  const bytes = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new MatrixRequestError(400, "M_BAD_JSON");
+  }
+  if (!text) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch {
+    throw new MatrixRequestError(400, "M_BAD_JSON");
+  }
+  assertJsonComplexity(parsed);
+  return parsed;
+}
+
+function assertJsonComplexity(value: unknown): void {
+  const pending: Array<{ value: unknown; depth: number }> = [
+    { value, depth: 0 },
+  ];
+  let nodes = 0;
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current) break;
+    nodes += 1;
+    if (
+      nodes > MATRIX_MAX_JSON_NODES ||
+      current.depth > MATRIX_MAX_JSON_DEPTH
+    ) {
+      throw new MatrixRequestError(413, "M_TOO_LARGE");
+    }
+    if (Array.isArray(current.value)) {
+      for (const child of current.value)
+        pending.push({ value: child, depth: current.depth + 1 });
+    } else if (current.value !== null && typeof current.value === "object") {
+      for (const child of Object.values(current.value))
+        pending.push({ value: child, depth: current.depth + 1 });
+    }
+  }
+}
+
+function sanitizedQuery(params: URLSearchParams): Record<string, string> {
+  const query = Object.fromEntries(params);
+  for (const key of ["access_token", "token", "key", "api_key"]) {
+    if (key in query) query[key] = "<redacted>";
+  }
+  return query;
 }
 
 function readString(value: unknown, key: string): string | null {

--- a/packages/cloud/test-mocks/src/matrix/server.ts
+++ b/packages/cloud/test-mocks/src/matrix/server.ts
@@ -1,0 +1,583 @@
+/** Hosts a resettable Matrix Client-Server API subset that real matrix-js-sdk clients reach over loopback HTTP. */
+
+import { startFetchServer } from "../fetch-server.js";
+import type {
+  MatrixClientServerSeed,
+  MatrixMockEventSeed,
+  MatrixMockFault,
+  MatrixMockRoomSeed,
+  MatrixMockSnapshot,
+  MatrixRequestObservation,
+} from "./types.js";
+
+interface StoredEvent extends MatrixMockEventSeed {
+  sequence: number;
+  transactionId?: string;
+}
+
+interface RoomState extends Omit<MatrixMockRoomSeed, "timeline"> {
+  joined: boolean;
+  joinedAt: number;
+  timeline: StoredEvent[];
+}
+
+export interface RunningMatrixClientServerMock {
+  url: string;
+  port: number;
+  enqueueFault(method: string, path: string, fault: MatrixMockFault): void;
+  enqueueInbound(roomId: string, event: MatrixMockEventSeed): boolean;
+  reset(seed?: MatrixClientServerSeed): void;
+  snapshot(): MatrixMockSnapshot;
+  stop(): Promise<void>;
+}
+
+export async function startMatrixClientServerMock(
+  initialSeed: MatrixClientServerSeed,
+): Promise<RunningMatrixClientServerMock> {
+  let currentSeed = cloneSeed(initialSeed);
+  let generation = 0;
+  let eventSequence = 0;
+  let requestSequence = 0;
+  let roomSequence = 0;
+  let eventIdSequence = 0;
+  let rooms = buildRooms(currentSeed, () => ++eventSequence);
+  let requests: MatrixRequestObservation[] = [];
+  const faults = new Map<string, MatrixMockFault[]>();
+  const activeRequests = new Set<AbortController>();
+
+  const server = await startFetchServer(async (request) => {
+    const url = new URL(request.url);
+    const body = await readJsonBody(request);
+    const authenticated =
+      request.headers.get("authorization") ===
+      `Bearer ${currentSeed.accessToken}`;
+    requests.push({
+      sequence: ++requestSequence,
+      method: request.method,
+      path: url.pathname,
+      query: Object.fromEntries(url.searchParams),
+      authenticated,
+      body,
+    });
+
+    if (
+      url.pathname === "/_matrix/client/versions" &&
+      request.method === "GET"
+    ) {
+      return json({ versions: ["v1.1", "v1.11"], unstable_features: {} });
+    }
+    if (!url.pathname.startsWith("/_matrix/client/v3/") || !authenticated) {
+      return matrixError(401, "M_UNKNOWN_TOKEN", "invalid access token");
+    }
+
+    const faultKey = `${request.method} ${url.pathname}`;
+    const fault = faults.get(faultKey)?.shift();
+    if (fault) {
+      if (
+        fault.delayMs &&
+        !(await waitWithinGeneration(
+          fault.delayMs,
+          request.signal,
+          generation,
+          () => generation,
+          activeRequests,
+        ))
+      ) {
+        return matrixError(
+          409,
+          "M_UNKNOWN_POS",
+          "synthetic Matrix generation changed",
+        );
+      }
+      const headers = new Headers({ "content-type": "application/json" });
+      if (fault.retryAfterMs !== undefined) {
+        headers.set("retry-after", String(fault.retryAfterMs / 1000));
+      }
+      return new Response(
+        fault.rawBody ??
+          JSON.stringify(
+            fault.body ?? {
+              errcode: "M_UNKNOWN",
+              error: "seeded Matrix fault",
+              retry_after_ms: fault.retryAfterMs,
+            },
+          ),
+        { status: fault.status ?? 500, headers },
+      );
+    }
+
+    const path = url.pathname.slice("/_matrix/client/v3".length);
+    if (request.method === "GET" && path === "/pushrules/") {
+      return json({ global: {} });
+    }
+    if (request.method === "POST" && /^\/user\/[^/]+\/filter$/.test(path)) {
+      return json({ filter_id: "filter-synthetic" });
+    }
+    if (request.method === "GET" && path === "/account/whoami") {
+      return json({
+        user_id: currentSeed.userId,
+        device_id: currentSeed.deviceId ?? "DEVICE",
+      });
+    }
+    if (request.method === "GET" && path === "/capabilities") {
+      return json({
+        capabilities: {
+          "m.room_versions": { default: "10", available: { "10": "stable" } },
+        },
+      });
+    }
+    if (request.method === "GET" && path === "/sync") {
+      const rawSince = url.searchParams.get("since");
+      const parsedSince = parseSyncToken(rawSince);
+      if (
+        rawSince !== null &&
+        (!parsedSince || parsedSince.generation !== generation)
+      ) {
+        return matrixError(
+          409,
+          "M_UNKNOWN_POS",
+          "synthetic Matrix sync cursor belongs to another generation",
+        );
+      }
+      const since = parsedSince?.sequence ?? null;
+      if (
+        since !== null &&
+        !(await waitWithinGeneration(
+          Math.min(readPositiveInt(url.searchParams.get("timeout"), 250), 250),
+          request.signal,
+          generation,
+          () => generation,
+          activeRequests,
+        ))
+      ) {
+        return matrixError(
+          409,
+          "M_UNKNOWN_POS",
+          "synthetic Matrix generation changed",
+        );
+      }
+      return json(
+        buildSync(currentSeed, rooms, since, generation, eventSequence),
+      );
+    }
+    if (request.method === "POST" && path === "/createRoom") {
+      const roomId = `!created-${++roomSequence}:mock`;
+      const name = readString(body, "name");
+      rooms.set(roomId, {
+        roomId,
+        name: name ?? undefined,
+        joined: true,
+        joinedAt: ++eventSequence,
+        members: [{ userId: currentSeed.userId, displayName: "Synthetic Bot" }],
+        timeline: [],
+      });
+      return json({ room_id: roomId });
+    }
+
+    const joinMatch = /^\/join\/(.+)$/.exec(path);
+    if (request.method === "POST" && joinMatch) {
+      const requested = decodeURIComponent(joinMatch[1] ?? "");
+      const room = resolveRoom(rooms, requested);
+      if (!room) return matrixError(404, "M_NOT_FOUND", "unknown room");
+      room.joined = true;
+      room.joinedAt = ++eventSequence;
+      const ownMember = room.members.find(
+        (member) => member.userId === currentSeed.userId,
+      );
+      if (ownMember) ownMember.membership = "join";
+      else
+        room.members.push({ userId: currentSeed.userId, membership: "join" });
+      return json({ room_id: room.roomId });
+    }
+
+    const sendMatch = /^\/rooms\/([^/]+)\/send\/([^/]+)\/([^/]+)$/.exec(path);
+    if (request.method === "PUT" && sendMatch) {
+      const roomId = decodeURIComponent(sendMatch[1] ?? "");
+      const eventType = decodeURIComponent(sendMatch[2] ?? "");
+      const transactionId = decodeURIComponent(sendMatch[3] ?? "");
+      const room = rooms.get(roomId);
+      if (!room?.joined) return matrixError(403, "M_FORBIDDEN", "not joined");
+      const existing = room.timeline.find(
+        (event) => event.transactionId === transactionId,
+      );
+      if (existing) return json({ event_id: existing.eventId });
+      const eventId = `$sent-${++eventIdSequence}:mock`;
+      const sequence = ++eventSequence;
+      room.timeline.push({
+        eventId,
+        sender: currentSeed.userId,
+        type: eventType,
+        content: requireRecord(body),
+        originServerTs: 1_700_000_100_000 + sequence,
+        sequence,
+        transactionId,
+      });
+      return json({ event_id: eventId });
+    }
+
+    const messagesMatch = /^\/rooms\/([^/]+)\/messages$/.exec(path);
+    if (request.method === "GET" && messagesMatch) {
+      const roomId = decodeURIComponent(messagesMatch[1] ?? "");
+      const room = rooms.get(roomId);
+      if (!room?.joined) return matrixError(403, "M_FORBIDDEN", "not joined");
+      const direction = url.searchParams.get("dir") ?? "b";
+      const limit = Math.min(
+        readPositiveInt(url.searchParams.get("limit"), 10),
+        100,
+      );
+      if (direction !== "b")
+        return matrixError(
+          400,
+          "M_INVALID_PARAM",
+          "only backward pagination is seeded",
+        );
+      const endIndex = parsePaginationToken(
+        url.searchParams.get("from"),
+        room.timeline.length,
+      );
+      const startIndex = Math.max(0, endIndex - limit);
+      const chunk = room.timeline
+        .slice(startIndex, endIndex)
+        .reverse()
+        .map(wireEvent);
+      return json({
+        start: `p${endIndex}`,
+        end: `p${startIndex}`,
+        chunk,
+        state: [],
+      });
+    }
+
+    return matrixError(
+      404,
+      "M_UNRECOGNIZED",
+      `unsupported Matrix path ${path}`,
+    );
+  });
+
+  return {
+    url: `http://${server.hostname}:${server.port}`,
+    port: server.port,
+    enqueueFault(method, path, fault) {
+      const key = `${method.toUpperCase()} ${path}`;
+      const queue = faults.get(key) ?? [];
+      queue.push(structuredClone(fault));
+      faults.set(key, queue);
+    },
+    enqueueInbound(roomId, event) {
+      const room = rooms.get(roomId);
+      if (!room) throw new Error(`unknown Matrix room '${roomId}'`);
+      if (
+        room.timeline.some((candidate) => candidate.eventId === event.eventId)
+      )
+        return false;
+      room.timeline.push({
+        ...structuredClone(event),
+        sequence: ++eventSequence,
+      });
+      return true;
+    },
+    reset(nextSeed = currentSeed) {
+      generation += 1;
+      for (const controller of activeRequests) controller.abort();
+      currentSeed = cloneSeed(nextSeed);
+      eventSequence = 0;
+      requestSequence = 0;
+      roomSequence = 0;
+      eventIdSequence = 0;
+      rooms = buildRooms(currentSeed, () => ++eventSequence);
+      requests = [];
+      faults.clear();
+    },
+    snapshot() {
+      return snapshot(generation, eventSequence, requests, rooms);
+    },
+    stop: server.stop,
+  };
+}
+
+function buildRooms(
+  seed: MatrixClientServerSeed,
+  nextSequence: () => number,
+): Map<string, RoomState> {
+  if (!seed.userId.startsWith("@") || !seed.accessToken)
+    throw new Error("invalid Matrix account seed");
+  const rooms = new Map<string, RoomState>();
+  for (const room of seed.rooms) {
+    if (!room.roomId.startsWith("!") || rooms.has(room.roomId))
+      throw new Error("invalid or duplicate Matrix room seed");
+    const eventIds = new Set<string>();
+    const timeline = (room.timeline ?? []).map((event) => {
+      if (!event.eventId || eventIds.has(event.eventId))
+        throw new Error("duplicate Matrix event seed");
+      eventIds.add(event.eventId);
+      return { ...structuredClone(event), sequence: nextSequence() };
+    });
+    rooms.set(room.roomId, {
+      ...structuredClone(room),
+      joined: room.joined ?? true,
+      joinedAt: room.joined === false ? Number.MAX_SAFE_INTEGER : 0,
+      timeline,
+    });
+  }
+  return rooms;
+}
+
+function buildSync(
+  seed: MatrixClientServerSeed,
+  rooms: Map<string, RoomState>,
+  since: number | null,
+  generation: number,
+  nextSequence: number,
+) {
+  const join = Object.fromEntries(
+    [...rooms.values()]
+      .filter((room) => room.joined)
+      .map((room) => {
+        const newlyJoined = since !== null && room.joinedAt > since;
+        const timeline = room.timeline.filter(
+          (event) => since === null || newlyJoined || event.sequence > since,
+        );
+        return [
+          room.roomId,
+          {
+            summary: {
+              "m.joined_member_count": room.members.filter(
+                (member) => (member.membership ?? "join") === "join",
+              ).length,
+              "m.invited_member_count": room.members.filter(
+                (member) => member.membership === "invite",
+              ).length,
+            },
+            state: {
+              events:
+                since === null || newlyJoined
+                  ? roomStateEvents(seed, room)
+                  : [],
+            },
+            timeline: {
+              events: timeline.map(wireEvent),
+              limited: false,
+              prev_batch: "p0",
+            },
+            ephemeral: { events: [] },
+            account_data: { events: [] },
+            unread_notifications: { highlight_count: 0, notification_count: 0 },
+          },
+        ];
+      }),
+  );
+  return {
+    next_batch: syncToken(generation, nextSequence),
+    rooms: { join, invite: {}, leave: {} },
+    presence: { events: [] },
+    account_data: { events: [] },
+    to_device: { events: [] },
+    device_lists: { changed: [], left: [] },
+    device_one_time_keys_count: {},
+  };
+}
+
+function roomStateEvents(seed: MatrixClientServerSeed, room: RoomState) {
+  const events: Array<Record<string, unknown>> = [
+    stateEvent(room.roomId, "$create:mock", "m.room.create", "", seed.userId, {
+      creator: seed.userId,
+      room_version: "10",
+    }),
+  ];
+  if (room.name)
+    events.push(
+      stateEvent(room.roomId, "$name:mock", "m.room.name", "", seed.userId, {
+        name: room.name,
+      }),
+    );
+  if (room.topic)
+    events.push(
+      stateEvent(room.roomId, "$topic:mock", "m.room.topic", "", seed.userId, {
+        topic: room.topic,
+      }),
+    );
+  if (room.canonicalAlias)
+    events.push(
+      stateEvent(
+        room.roomId,
+        "$alias:mock",
+        "m.room.canonical_alias",
+        "",
+        seed.userId,
+        { alias: room.canonicalAlias },
+      ),
+    );
+  for (const member of room.members) {
+    events.push(
+      stateEvent(
+        room.roomId,
+        `$member-${encodeURIComponent(member.userId)}:mock`,
+        "m.room.member",
+        member.userId,
+        member.userId,
+        {
+          membership: member.membership ?? "join",
+          displayname: member.displayName,
+        },
+      ),
+    );
+  }
+  return events;
+}
+
+function stateEvent(
+  roomId: string,
+  eventId: string,
+  type: string,
+  stateKey: string,
+  sender: string,
+  content: Record<string, unknown>,
+) {
+  return {
+    event_id: eventId,
+    room_id: roomId,
+    sender,
+    type,
+    state_key: stateKey,
+    origin_server_ts: 1_700_000_000_000,
+    content,
+  };
+}
+
+function wireEvent(event: MatrixMockEventSeed) {
+  return {
+    event_id: event.eventId,
+    sender: event.sender,
+    type: event.type ?? "m.room.message",
+    origin_server_ts: event.originServerTs,
+    content: event.content,
+  };
+}
+
+function snapshot(
+  generation: number,
+  eventSequence: number,
+  requests: MatrixRequestObservation[],
+  rooms: Map<string, RoomState>,
+): MatrixMockSnapshot {
+  return {
+    generation,
+    nextBatch: syncToken(generation, eventSequence),
+    requests: structuredClone(requests),
+    rooms: [...rooms.values()].map((room) => ({
+      roomId: room.roomId,
+      joined: room.joined,
+      timeline: room.timeline.map(
+        ({ sequence: _sequence, transactionId: _transactionId, ...event }) =>
+          structuredClone(event),
+      ),
+    })),
+  };
+}
+
+function resolveRoom(
+  rooms: Map<string, RoomState>,
+  idOrAlias: string,
+): RoomState | undefined {
+  return (
+    rooms.get(idOrAlias) ??
+    [...rooms.values()].find((room) => room.canonicalAlias === idOrAlias)
+  );
+}
+
+function parseSyncToken(
+  value: string | null,
+): { generation: number; sequence: number } | null {
+  if (value === null) return null;
+  const match = /^g(\d+)-s(\d+)$/.exec(value);
+  return match
+    ? { generation: Number(match[1]), sequence: Number(match[2]) }
+    : null;
+}
+
+function syncToken(generation: number, sequence: number): string {
+  return `g${generation}-s${sequence}`;
+}
+
+function parsePaginationToken(value: string | null, fallback: number): number {
+  if (value === null) return fallback;
+  const match = /^p(\d+)$/.exec(value);
+  return match ? Math.min(Number(match[1]), fallback) : fallback;
+}
+
+function readPositiveInt(value: string | null, fallback: number): number {
+  const parsed = value === null ? Number.NaN : Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+async function readJsonBody(request: Request): Promise<unknown> {
+  if (request.method === "GET" || request.method === "HEAD") return undefined;
+  const text = await request.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function readString(value: unknown, key: string): string | null {
+  const record = requireRecord(value);
+  const candidate = record[key];
+  return typeof candidate === "string" && candidate.trim() ? candidate : null;
+}
+
+function requireRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function cloneSeed(seed: MatrixClientServerSeed): MatrixClientServerSeed {
+  return structuredClone(seed);
+}
+
+function json(value: unknown, status = 200): Response {
+  return Response.json(value, { status });
+}
+
+function matrixError(status: number, errcode: string, error: string): Response {
+  return json({ errcode, error }, status);
+}
+
+async function waitWithinGeneration(
+  ms: number,
+  requestSignal: AbortSignal,
+  admittedGeneration: number,
+  readGeneration: () => number,
+  activeRequests: Set<AbortController>,
+): Promise<boolean> {
+  const resetController = new AbortController();
+  activeRequests.add(resetController);
+  try {
+    await delay(ms, AbortSignal.any([requestSignal, resetController.signal]));
+    return readGeneration() === admittedGeneration;
+  } catch {
+    // The caller translates cancellation/reset into an explicit stale cursor;
+    // no pre-reset request may resume against the replacement generation.
+    return false;
+  } finally {
+    activeRequests.delete(resetController);
+  }
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(signal.reason);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason);
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/packages/cloud/test-mocks/src/matrix/types.ts
+++ b/packages/cloud/test-mocks/src/matrix/types.ts
@@ -1,0 +1,58 @@
+/** Defines deterministic seed, fault, observation, and readback contracts for the Matrix Client-Server API simulator. */
+
+export interface MatrixMockEventSeed {
+  eventId: string;
+  sender: string;
+  type?: string;
+  content: Record<string, unknown>;
+  originServerTs: number;
+}
+
+export interface MatrixMockRoomSeed {
+  roomId: string;
+  name?: string;
+  topic?: string;
+  canonicalAlias?: string;
+  joined?: boolean;
+  members: Array<{
+    userId: string;
+    displayName?: string;
+    membership?: "join" | "invite";
+  }>;
+  timeline?: MatrixMockEventSeed[];
+}
+
+export interface MatrixClientServerSeed {
+  userId: string;
+  accessToken: string;
+  deviceId?: string;
+  rooms: MatrixMockRoomSeed[];
+}
+
+export interface MatrixMockFault {
+  status?: number;
+  body?: unknown;
+  rawBody?: string;
+  retryAfterMs?: number;
+  delayMs?: number;
+}
+
+export interface MatrixRequestObservation {
+  sequence: number;
+  method: string;
+  path: string;
+  query: Record<string, string>;
+  authenticated: boolean;
+  body: unknown;
+}
+
+export interface MatrixMockSnapshot {
+  generation: number;
+  nextBatch: string;
+  requests: MatrixRequestObservation[];
+  rooms: Array<{
+    roomId: string;
+    joined: boolean;
+    timeline: MatrixMockEventSeed[];
+  }>;
+}

--- a/packages/cloud/test-mocks/test/fetch-server.node.test.ts
+++ b/packages/cloud/test-mocks/test/fetch-server.node.test.ts
@@ -1,0 +1,58 @@
+/** Proves the shared HTTP adapter preserves streaming and cancellation in a real Node subprocess. */
+
+import { afterEach, expect, it } from "bun:test";
+
+const children: Bun.Subprocess[] = [];
+
+afterEach(async () => {
+  for (const child of children.splice(0)) {
+    child.kill("SIGTERM");
+    await child.exited;
+  }
+});
+
+async function readLine(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<string> {
+  const decoder = new TextDecoder();
+  let line = "";
+  while (!line.includes("\n")) {
+    const { done, value } = await reader.read();
+    if (done) throw new Error("Node fixture exited before emitting a line");
+    line += decoder.decode(value, { stream: true });
+  }
+  return line.slice(0, line.indexOf("\n"));
+}
+
+it("streams the first chunk without buffering and aborts work on disconnect", async () => {
+  const child = Bun.spawn(
+    [
+      "node",
+      "--experimental-strip-types",
+      "test/fixtures/fetch-server-node-stream.ts",
+    ],
+    {
+      cwd: import.meta.dir.replace(/\/test$/, ""),
+      stdout: "pipe",
+      stderr: "inherit",
+    },
+  );
+  children.push(child);
+  const stdout = child.stdout.getReader();
+  const port = Number(await readLine(stdout));
+  expect(Number.isInteger(port)).toBe(true);
+
+  const startedAt = performance.now();
+  const controller = new AbortController();
+  const response = await fetch(`http://127.0.0.1:${port}/stream`, {
+    signal: controller.signal,
+  });
+  const body = response.body?.getReader();
+  if (!body) throw new Error("Node fixture returned no response body");
+  const first = await body.read();
+  expect(new TextDecoder().decode(first.value)).toBe("first\n");
+  expect(performance.now() - startedAt).toBeLessThan(750);
+
+  controller.abort("test disconnect");
+  expect(await readLine(stdout)).toBe("aborted");
+});

--- a/packages/cloud/test-mocks/test/fixtures/fetch-server-node-stream.ts
+++ b/packages/cloud/test-mocks/test/fixtures/fetch-server-node-stream.ts
@@ -1,0 +1,38 @@
+/** Runs the Node fallback HTTP adapter for subprocess streaming and cancellation proof. */
+
+import { startFetchServer } from "../../src/fetch-server.ts";
+
+const encoder = new TextEncoder();
+const server = await startFetchServer(
+  (request) =>
+    new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode("first\n"));
+          const timer = setTimeout(() => {
+            controller.enqueue(encoder.encode("second\n"));
+            controller.close();
+          }, 1_000);
+          request.signal.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              process.stdout.write("aborted\n");
+              controller.error(request.signal.reason);
+            },
+            { once: true },
+          );
+        },
+      }),
+      { headers: { "content-type": "text/plain" } },
+    ),
+  { hostname: "127.0.0.1", port: 0 },
+);
+
+process.stdout.write(`${server.port}\n`);
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.once(signal, async () => {
+    await server.stop();
+    process.exit(0);
+  });
+}

--- a/packages/cloud/test-mocks/test/matrix-client-server.contract.test.ts
+++ b/packages/cloud/test-mocks/test/matrix-client-server.contract.test.ts
@@ -1,6 +1,7 @@
 /** Proves real matrix-js-sdk and MatrixService behavior against the resettable Client-Server API simulator. */
 
 import { afterEach, describe, expect, test } from "bun:test";
+import { connect } from "node:net";
 import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
 import { MatrixEventTypes, MatrixService } from "@elizaos/plugin-matrix";
 import {
@@ -114,6 +115,47 @@ async function waitFor(predicate: () => boolean, label: string): Promise<void> {
       throw new Error(`Timed out waiting for ${label}`);
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
+}
+
+async function openPartialCreateRoomRequest(
+  port: number,
+): Promise<{ finish(): void; response: Promise<string> }> {
+  const socket = connect({ host: "127.0.0.1", port });
+  await new Promise<void>((resolve, reject) => {
+    socket.once("connect", resolve);
+    socket.once("error", reject);
+  });
+  const first = '{"name":"old';
+  socket.write(
+    [
+      "POST /_matrix/client/v3/createRoom HTTP/1.1",
+      "Host: 127.0.0.1",
+      `Authorization: Bearer ${ACCESS_TOKEN}`,
+      "Content-Type: application/json",
+      "Transfer-Encoding: chunked",
+      "Connection: close",
+      "",
+      `${Buffer.byteLength(first).toString(16)}\r\n${first}\r\n`,
+    ].join("\r\n"),
+  );
+  const response = new Promise<string>((resolve, reject) => {
+    let raw = "";
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => {
+      raw += chunk;
+    });
+    socket.once("end", () => resolve(raw));
+    socket.once("error", reject);
+  });
+  return {
+    finish() {
+      const last = ' generation"}';
+      socket.end(
+        `${Buffer.byteLength(last).toString(16)}\r\n${last}\r\n0\r\n\r\n`,
+      );
+    },
+    response,
+  };
 }
 
 describe("Matrix Client-Server production boundary", () => {
@@ -538,6 +580,70 @@ describe("Matrix Client-Server production boundary", () => {
         (matrixEvent) => matrixEvent.event_id,
       ),
     ).toEqual(["$replacement:mock"]);
+  });
+
+  test("bounds strict JSON, redacts token queries, and fences partial writes across reset", async () => {
+    const mock = await startMatrixClientServerMock(seed);
+    stops.push(mock.stop);
+
+    const wrongMedia = await fetch(`${mock.url}/_matrix/client/v3/createRoom`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${ACCESS_TOKEN}`,
+        "content-type": "text/plain",
+      },
+      body: "{}",
+    });
+    expect(wrongMedia.status).toBe(400);
+    expect(await wrongMedia.json()).toMatchObject({ errcode: "M_NOT_JSON" });
+
+    let nested: unknown = "leaf";
+    for (let depth = 0; depth < 66; depth += 1) nested = { nested };
+    const tooDeep = await fetch(`${mock.url}/_matrix/client/v3/createRoom`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${ACCESS_TOKEN}`,
+        "content-type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify(nested),
+    });
+    expect(tooDeep.status).toBe(413);
+    expect(await tooDeep.json()).toMatchObject({ errcode: "M_TOO_LARGE" });
+
+    const whoami = await fetch(
+      `${mock.url}/_matrix/client/v3/account/whoami?access_token=query-secret`,
+      { headers: { authorization: `Bearer ${ACCESS_TOKEN}` } },
+    );
+    expect(whoami.status).toBe(200);
+    expect(mock.snapshot().requests.at(-1)?.query).toEqual({
+      access_token: "<redacted>",
+    });
+    expect(JSON.stringify(mock.snapshot())).not.toContain("query-secret");
+
+    const partial = await openPartialCreateRoomRequest(mock.port);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const replacementSeed = {
+      ...seed,
+      accessToken: "replacement-token",
+      rooms: seed.rooms.slice(0, 1),
+    };
+    mock.reset(replacementSeed);
+    partial.finish();
+    const rawResponse = await partial.response;
+    expect(
+      rawResponse === "" ||
+        (rawResponse.includes(" 409 ") &&
+          rawResponse.includes("M_UNKNOWN_POS")),
+    ).toBe(true);
+    expect(mock.snapshot().rooms.map(({ roomId }) => roomId)).toEqual([
+      ROOM_ID,
+    ]);
+    const afterReset = await fetch(
+      `${mock.url}/_matrix/client/v3/account/whoami`,
+      { headers: { authorization: "Bearer replacement-token" } },
+    );
+    expect(afterReset.status).toBe(200);
+    expect(await afterReset.json()).toMatchObject({ user_id: USER_ID });
   });
 
   test("replays the same effects to byte-equivalent provider state after reset", async () => {

--- a/packages/cloud/test-mocks/test/matrix-client-server.contract.test.ts
+++ b/packages/cloud/test-mocks/test/matrix-client-server.contract.test.ts
@@ -1,0 +1,464 @@
+/** Proves real matrix-js-sdk and MatrixService behavior against the resettable Client-Server API simulator. */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import { MatrixEventTypes, MatrixService } from "@elizaos/plugin-matrix";
+import {
+  ClientEvent,
+  createClient,
+  Direction,
+  EventType,
+  type MatrixClient,
+  Method,
+  RoomEvent,
+} from "matrix-js-sdk";
+import { startMatrixClientServerMock } from "../src/matrix";
+
+const USER_ID = "@bot:mock";
+const ACCESS_TOKEN = "matrix-contract-token";
+const ROOM_ID = "!general:mock";
+const SECOND_ROOM_ID = "!second:mock";
+
+const seed = {
+  userId: USER_ID,
+  accessToken: ACCESS_TOKEN,
+  deviceId: "SYNTHETIC",
+  rooms: [
+    {
+      roomId: ROOM_ID,
+      name: "Synthetic General",
+      topic: "Protocol contract room",
+      canonicalAlias: "#general:mock",
+      members: [
+        { userId: USER_ID, displayName: "Synthetic Bot" },
+        { userId: "@alice:mock", displayName: "Alice" },
+      ],
+      timeline: [
+        event("$seed-1:mock", "oldest", 1_700_000_000_001),
+        event("$seed-2:mock", "middle", 1_700_000_000_002),
+        event("$seed-3:mock", "newest", 1_700_000_000_003),
+      ],
+    },
+    {
+      roomId: SECOND_ROOM_ID,
+      name: "Join Target",
+      joined: false,
+      members: [{ userId: "@alice:mock", displayName: "Alice" }],
+      timeline: [],
+    },
+  ],
+};
+
+const stops: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(stops.splice(0).map((stop) => stop()));
+});
+
+function event(eventId: string, body: string, originServerTs: number) {
+  return {
+    eventId,
+    sender: "@alice:mock",
+    content: { msgtype: "m.text", body },
+    originServerTs,
+  };
+}
+
+function client(url: string, accessToken = ACCESS_TOKEN): MatrixClient {
+  return createClient({
+    baseUrl: url,
+    userId: USER_ID,
+    accessToken,
+    deviceId: "SYNTHETIC",
+  });
+}
+
+async function startAndWaitPrepared(matrixClient: MatrixClient): Promise<void> {
+  const prepared = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error("Matrix PREPARED timeout")),
+      2_000,
+    );
+    const listener = (state: string) => {
+      if (state !== "PREPARED") return;
+      clearTimeout(timeout);
+      matrixClient.removeListener(ClientEvent.Sync, listener);
+      resolve();
+    };
+    matrixClient.on(ClientEvent.Sync, listener);
+  });
+  await matrixClient.startClient({
+    initialSyncLimit: 10,
+    pollTimeout: 20,
+    disablePresence: true,
+  });
+  await prepared;
+}
+
+async function waitFor(predicate: () => boolean, label: string): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline)
+      throw new Error(`Timed out waiting for ${label}`);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+describe("Matrix Client-Server production boundary", () => {
+  test("syncs, joins, creates, sends, paginates, orders, deduplicates, and resets", async () => {
+    const mock = await startMatrixClientServerMock(seed);
+    stops.push(mock.stop);
+    const matrixClient = client(mock.url);
+    stops.push(async () => matrixClient.stopClient());
+    const timelineIds: string[] = [];
+    matrixClient.on(RoomEvent.Timeline, (matrixEvent) => {
+      const eventId = matrixEvent.getId();
+      if (eventId) timelineIds.push(eventId);
+    });
+
+    await startAndWaitPrepared(matrixClient);
+    expect(matrixClient.getRoom(ROOM_ID)?.getMyMembership()).toBe("join");
+    expect(matrixClient.getRoom(ROOM_ID)?.name).toBe("Synthetic General");
+    expect(timelineIds.slice(0, 3)).toEqual([
+      "$seed-1:mock",
+      "$seed-2:mock",
+      "$seed-3:mock",
+    ]);
+
+    const joined = await matrixClient.joinRoom(SECOND_ROOM_ID);
+    expect(joined.roomId).toBe(SECOND_ROOM_ID);
+    await waitFor(
+      () => matrixClient.getRoom(SECOND_ROOM_ID)?.getMyMembership() === "join",
+      "joined room sync",
+    );
+
+    const created = await matrixClient.createRoom({
+      name: "Created Through SDK",
+    });
+    expect(created.room_id).toMatch(/^!created-\d+:mock$/);
+    await matrixClient.sendTextMessage(ROOM_ID, "outbound through real SDK");
+
+    const firstPage = await matrixClient.createMessagesRequest(
+      ROOM_ID,
+      null,
+      2,
+      Direction.Backward,
+    );
+    expect(firstPage.chunk.map((item) => item.content.body)).toEqual([
+      "outbound through real SDK",
+      "newest",
+    ]);
+    const secondPage = await matrixClient.createMessagesRequest(
+      ROOM_ID,
+      firstPage.end ?? null,
+      2,
+      Direction.Backward,
+    );
+    expect(secondPage.chunk.map((item) => item.content.body)).toEqual([
+      "middle",
+      "oldest",
+    ]);
+
+    expect(
+      mock.enqueueInbound(
+        ROOM_ID,
+        event("$live-1:mock", "live one", Date.now()),
+      ),
+    ).toBe(true);
+    expect(
+      mock.enqueueInbound(
+        ROOM_ID,
+        event("$live-2:mock", "live two", Date.now() + 1),
+      ),
+    ).toBe(true);
+    expect(
+      mock.enqueueInbound(
+        ROOM_ID,
+        event("$live-2:mock", "duplicate", Date.now() + 2),
+      ),
+    ).toBe(false);
+    await waitFor(
+      () => timelineIds.includes("$live-2:mock"),
+      "ordered live sync",
+    );
+    expect(timelineIds.filter((id) => id === "$live-2:mock")).toHaveLength(1);
+    expect(timelineIds.indexOf("$live-1:mock")).toBeLessThan(
+      timelineIds.indexOf("$live-2:mock"),
+    );
+
+    const snapshot = mock.snapshot();
+    const room = snapshot.rooms.find(
+      (candidate) => candidate.roomId === ROOM_ID,
+    );
+    expect(room?.timeline.map((item) => item.content.body)).toEqual([
+      "oldest",
+      "middle",
+      "newest",
+      "outbound through real SDK",
+      "live one",
+      "live two",
+    ]);
+    expect(
+      snapshot.requests.every(
+        (request) =>
+          request.authenticated || request.path === "/_matrix/client/versions",
+      ),
+    ).toBe(true);
+
+    mock.reset();
+    expect(mock.snapshot()).toEqual(
+      expect.objectContaining({
+        generation: 1,
+        requests: [],
+        nextBatch: "g1-s3",
+      }),
+    );
+  });
+
+  test("surfaces retry-after and exercises auth, malformed, timeout, and cancellation", async () => {
+    const mock = await startMatrixClientServerMock(seed);
+    stops.push(mock.stop);
+    mock.enqueueFault("GET", "/_matrix/client/v3/account/whoami", {
+      status: 429,
+      retryAfterMs: 1,
+      body: {
+        errcode: "M_LIMIT_EXCEEDED",
+        error: "slow down",
+        retry_after_ms: 1,
+      },
+    });
+    const rateLimitedClient = client(mock.url);
+    await expect(rateLimitedClient.whoami()).rejects.toMatchObject({
+      httpStatus: 429,
+      data: { retry_after_ms: 1 },
+    });
+    expect(await rateLimitedClient.whoami()).toEqual({
+      user_id: USER_ID,
+      device_id: "SYNTHETIC",
+    });
+
+    const unauthorized = client(mock.url, "wrong-token");
+    await expect(unauthorized.whoami()).rejects.toMatchObject({
+      httpStatus: 401,
+    });
+
+    mock.enqueueFault("GET", "/_matrix/client/v3/account/whoami", {
+      status: 200,
+      rawBody: "not-json",
+    });
+    await expect(client(mock.url).whoami()).rejects.toThrow();
+
+    mock.enqueueFault("GET", "/_matrix/client/v3/account/whoami", {
+      status: 200,
+      delayMs: 100,
+      body: { user_id: USER_ID },
+    });
+    await expect(
+      client(mock.url).http.authedRequest(
+        Method.Get,
+        "/account/whoami",
+        {},
+        undefined,
+        {
+          localTimeoutMs: 10,
+        },
+      ),
+    ).rejects.toThrow();
+
+    mock.enqueueFault("GET", "/_matrix/client/v3/account/whoami", {
+      status: 200,
+      delayMs: 100,
+      body: { user_id: USER_ID },
+    });
+    const controller = new AbortController();
+    const pending = client(mock.url).http.authedRequest(
+      Method.Get,
+      "/account/whoami",
+      {},
+      undefined,
+      { abortSignal: controller.signal },
+    );
+    controller.abort(new Error("matrix contract cancellation"));
+    await expect(pending).rejects.toThrow();
+  });
+
+  test("drives the plugin inbound event and persistence path from real sync", async () => {
+    const mock = await startMatrixClientServerMock(seed);
+    stops.push(mock.stop);
+    const memories: Memory[] = [];
+    const emitted: string[] = [];
+    let connector: Record<string, unknown> | undefined;
+    const runtime = {
+      agentId: "00000000-0000-0000-0000-000000000093" as UUID,
+      character: { settings: {} },
+      getSetting(key: string) {
+        const settings: Record<string, unknown> = {
+          MATRIX_HOMESERVER: mock.url,
+          MATRIX_USER_ID: USER_ID,
+          MATRIX_ACCESS_TOKEN: ACCESS_TOKEN,
+          MATRIX_DEVICE_ID: "SYNTHETIC",
+          MATRIX_ENCRYPTION: false,
+          MATRIX_AUTO_JOIN: false,
+          MATRIX_REQUIRE_MENTION: false,
+          MATRIX_AUTO_REPLY: false,
+        };
+        return settings[key];
+      },
+      registerMessageConnector(value: Record<string, unknown>) {
+        connector = value;
+      },
+      emitEvent(type: string) {
+        emitted.push(type);
+      },
+      ensureConnection: async () => undefined,
+      createMemory: async (memory: Memory) => {
+        memories.push(memory);
+        return memory.id;
+      },
+      getService: () => null,
+      logger: { debug() {}, info() {}, warn() {}, error() {} },
+      reportError() {},
+    } as unknown as IAgentRuntime;
+
+    const service = await MatrixService.start(runtime);
+    stops.push(() => service.stop());
+    await waitFor(
+      () => memories.some((memory) => memory.content.text === "newest"),
+      "plugin inbound persistence",
+    );
+
+    expect(emitted).toContain(MatrixEventTypes.SYNC_COMPLETE);
+    expect(emitted).toContain(MatrixEventTypes.MESSAGE_RECEIVED);
+    expect(memories.map((memory) => memory.content.text)).toEqual([
+      "oldest",
+      "middle",
+      "newest",
+    ]);
+    expect(connector).toEqual(
+      expect.objectContaining({ source: "matrix", accountId: "default" }),
+    );
+  });
+
+  test("invalidates an in-flight old-generation sync before exposing reseeded state", async () => {
+    const mock = await startMatrixClientServerMock(seed);
+    stops.push(mock.stop);
+    const matrixClient = client(mock.url);
+    const oldCursor = mock.snapshot().nextBatch;
+    const oldGenerationSync = matrixClient.http.authedRequest(
+      Method.Get,
+      "/sync",
+      { since: oldCursor, timeout: 200 },
+    );
+    await waitFor(
+      () =>
+        mock
+          .snapshot()
+          .requests.some(
+            (request) =>
+              request.path === "/_matrix/client/v3/sync" &&
+              request.query.since === oldCursor,
+          ),
+      "old-generation sync admission",
+    );
+
+    const primaryRoom = seed.rooms.find((room) => room.roomId === ROOM_ID);
+    if (!primaryRoom) throw new Error("primary Matrix room seed missing");
+    const replacementSeed = {
+      ...seed,
+      rooms: [
+        {
+          ...primaryRoom,
+          timeline: [
+            event(
+              "$replacement:mock",
+              "replacement generation only",
+              1_800_000_000_000,
+            ),
+          ],
+        },
+      ],
+    };
+    mock.reset(replacementSeed);
+    await expect(oldGenerationSync).rejects.toMatchObject({
+      httpStatus: 409,
+      errcode: "M_UNKNOWN_POS",
+    });
+    await expect(
+      matrixClient.http.authedRequest(Method.Get, "/sync", {
+        since: oldCursor,
+      }),
+    ).rejects.toMatchObject({ httpStatus: 409, errcode: "M_UNKNOWN_POS" });
+
+    const replacement = (await matrixClient.http.authedRequest(
+      Method.Get,
+      "/sync",
+    )) as {
+      rooms: {
+        join: Record<
+          string,
+          { timeline: { events: Array<{ event_id: string }> } }
+        >;
+      };
+    };
+    expect(
+      replacement.rooms.join[ROOM_ID]?.timeline.events.map(
+        (matrixEvent) => matrixEvent.event_id,
+      ),
+    ).toEqual(["$replacement:mock"]);
+  });
+
+  test("replays the same effects to byte-equivalent provider state after reset", async () => {
+    const mock = await startMatrixClientServerMock(seed);
+    stops.push(mock.stop);
+    const firstClient = client(mock.url);
+    const outboundContent = {
+      msgtype: "m.text" as const,
+      body: "deterministic outbound",
+    };
+    const firstSend = await firstClient.sendEvent(
+      ROOM_ID,
+      EventType.RoomMessage,
+      outboundContent,
+      "stable-transaction",
+    );
+    const firstReplay = await firstClient.sendEvent(
+      ROOM_ID,
+      EventType.RoomMessage,
+      outboundContent,
+      "stable-transaction",
+    );
+    expect(firstReplay.event_id).toBe(firstSend.event_id);
+    mock.enqueueInbound(
+      ROOM_ID,
+      event(
+        "$deterministic-inbound:mock",
+        "deterministic inbound",
+        1_800_000_000_001,
+      ),
+    );
+    const first = mock.snapshot();
+
+    mock.reset(seed);
+    const secondClient = client(mock.url);
+    await secondClient.sendEvent(
+      ROOM_ID,
+      EventType.RoomMessage,
+      outboundContent,
+      "stable-transaction",
+    );
+    mock.enqueueInbound(
+      ROOM_ID,
+      event(
+        "$deterministic-inbound:mock",
+        "deterministic inbound",
+        1_800_000_000_001,
+      ),
+    );
+    const second = mock.snapshot();
+
+    expect(second.nextBatch.replace(/^g\d+-/, "")).toBe(
+      first.nextBatch.replace(/^g\d+-/, ""),
+    );
+    expect(JSON.stringify(second.rooms)).toBe(JSON.stringify(first.rooms));
+  });
+});

--- a/packages/cloud/test-mocks/test/matrix-client-server.contract.test.ts
+++ b/packages/cloud/test-mocks/test/matrix-client-server.contract.test.ts
@@ -177,6 +177,12 @@ describe("Matrix Client-Server production boundary", () => {
         event("$live-2:mock", "duplicate", Date.now() + 2),
       ),
     ).toBe(false);
+    expect(
+      mock.enqueueInbound(
+        SECOND_ROOM_ID,
+        event("$live-2:mock", "cross-room duplicate", Date.now() + 3),
+      ),
+    ).toBe(false);
     await waitFor(
       () => timelineIds.includes("$live-2:mock"),
       "ordered live sync",

--- a/packages/cloud/test-mocks/test/matrix-client-server.contract.test.ts
+++ b/packages/cloud/test-mocks/test/matrix-client-server.contract.test.ts
@@ -183,36 +183,37 @@ describe("Matrix Client-Server production boundary", () => {
 
     const transactionId = "same-transaction-across-distinct-routes";
     const routeClient = client(mock.url);
-    const first = await routeClient.sendEvent(
-      ROOM_ID,
-      EventType.RoomMessage,
-      { msgtype: "m.text", body: "first route" },
-      transactionId,
-    );
-    const replayed = await routeClient.sendEvent(
-      ROOM_ID,
-      EventType.RoomMessage,
-      { msgtype: "m.text", body: "first route" },
-      transactionId,
-    );
-    const otherRoom = await routeClient.sendEvent(
+    const sendRoute = (
+      roomId: string,
+      eventType: string,
+      content: Record<string, unknown>,
+    ) =>
+      routeClient.http.authedRequest<{ event_id: string }>(
+        Method.Put,
+        `/rooms/${encodeURIComponent(roomId)}/send/${encodeURIComponent(eventType)}/${encodeURIComponent(transactionId)}`,
+        undefined,
+        content,
+      );
+    const first = await sendRoute(ROOM_ID, "m.room.message", {
+      msgtype: "m.text",
+      body: "first route",
+    });
+    const replayed = await sendRoute(ROOM_ID, "m.room.message", {
+      msgtype: "m.text",
+      body: "first route",
+    });
+    const otherRoom = await sendRoute(
       OCCUPIED_CREATED_ROOM_ID,
-      EventType.RoomMessage,
+      "m.room.message",
       { msgtype: "m.text", body: "other room" },
-      transactionId,
     );
-    const otherType = await routeClient.sendEvent(
-      ROOM_ID,
-      EventType.Reaction,
-      {
-        "m.relates_to": {
-          event_id: first.event_id,
-          key: "ok",
-          rel_type: "m.annotation",
-        },
+    const otherType = await sendRoute(ROOM_ID, "m.reaction", {
+      "m.relates_to": {
+        event_id: first.event_id,
+        key: "ok",
+        rel_type: "m.annotation",
       },
-      transactionId,
-    );
+    });
     expect(replayed.event_id).toBe(first.event_id);
     expect(
       new Set([first.event_id, otherRoom.event_id, otherType.event_id]).size,
@@ -229,7 +230,7 @@ describe("Matrix Client-Server production boundary", () => {
         ),
     );
     expect(new Set(allEventIds).size).toBe(allEventIds.length);
-  });
+  }, 15_000);
 
   test("syncs, joins, creates, sends, paginates, orders, deduplicates, and resets", async () => {
     const mock = await startMatrixClientServerMock(seed);

--- a/packages/cloud/test-mocks/test/matrix-client-server.contract.test.ts
+++ b/packages/cloud/test-mocks/test/matrix-client-server.contract.test.ts
@@ -18,6 +18,8 @@ const USER_ID = "@bot:mock";
 const ACCESS_TOKEN = "matrix-contract-token";
 const ROOM_ID = "!general:mock";
 const SECOND_ROOM_ID = "!second:mock";
+const OCCUPIED_CREATED_ROOM_ID = "!created-1:mock";
+const EQUIVALENT_ROOM_ID = "!equivalent:mock";
 
 const seed = {
   userId: USER_ID,
@@ -34,8 +36,8 @@ const seed = {
         { userId: "@alice:mock", displayName: "Alice" },
       ],
       timeline: [
-        event("$seed-1:mock", "oldest", 1_700_000_000_001),
-        event("$seed-2:mock", "middle", 1_700_000_000_002),
+        event("$generated-1:mock", "oldest", 1_700_000_000_001),
+        event("$generated-2:mock", "middle", 1_700_000_000_002),
         event("$seed-3:mock", "newest", 1_700_000_000_003),
       ],
     },
@@ -46,6 +48,16 @@ const seed = {
       members: [{ userId: "@alice:mock", displayName: "Alice" }],
       timeline: [],
     },
+    ...[OCCUPIED_CREATED_ROOM_ID, EQUIVALENT_ROOM_ID].map((roomId) => ({
+      roomId,
+      name: "Equivalent State",
+      topic: "State must survive global SDK deduplication",
+      members: [
+        { userId: USER_ID, displayName: "Synthetic Bot" },
+        { userId: "@alice:mock", displayName: "Alice" },
+      ],
+      timeline: [],
+    })),
   ],
 };
 
@@ -105,6 +117,120 @@ async function waitFor(predicate: () => boolean, label: string): Promise<void> {
 }
 
 describe("Matrix Client-Server production boundary", () => {
+  test("allocates globally unique deterministic room, event, state, alias, and transaction identities", async () => {
+    const mock = await startMatrixClientServerMock(seed);
+    stops.push(mock.stop);
+    const matrixClient = client(mock.url);
+    stops.push(async () => matrixClient.stopClient());
+
+    const initial = (await matrixClient.http.authedRequest(
+      Method.Get,
+      "/sync",
+    )) as {
+      next_batch: string;
+      rooms: {
+        join: Record<
+          string,
+          {
+            state: { events: Array<{ event_id: string }> };
+            timeline: { events: Array<{ event_id: string }> };
+          }
+        >;
+      };
+    };
+    const initialEventIds = Object.values(initial.rooms.join).flatMap((room) =>
+      [...room.state.events, ...room.timeline.events].map(
+        (matrixEvent) => matrixEvent.event_id,
+      ),
+    );
+    expect(new Set(initialEventIds).size).toBe(initialEventIds.length);
+    expect(initialEventIds).toContain("$generated-1:mock");
+    expect(initialEventIds).toContain("$generated-2:mock");
+
+    mock.reset(seed);
+    const replay = (await matrixClient.http.authedRequest(
+      Method.Get,
+      "/sync",
+    )) as typeof initial;
+    expect(JSON.stringify(replay.rooms)).toBe(JSON.stringify(initial.rooms));
+    expect(replay.next_batch.replace(/^g\d+-/, "")).toBe(
+      initial.next_batch.replace(/^g\d+-/, ""),
+    );
+
+    await startAndWaitPrepared(matrixClient);
+    for (const roomId of [OCCUPIED_CREATED_ROOM_ID, EQUIVALENT_ROOM_ID]) {
+      const room = matrixClient.getRoom(roomId);
+      expect(room?.name).toBe("Equivalent State");
+      expect(
+        room?.currentState.getStateEvents(EventType.RoomTopic, "")?.getContent()
+          .topic,
+      ).toBe("State must survive global SDK deduplication");
+      expect(room?.getMember(USER_ID)?.membership).toBe("join");
+      expect(room?.getMember("@alice:mock")?.membership).toBe("join");
+    }
+
+    await expect(
+      matrixClient.createRoom({ room_alias_name: "general" }),
+    ).rejects.toMatchObject({ httpStatus: 409, errcode: "M_ROOM_IN_USE" });
+    const created = await matrixClient.createRoom({
+      name: "Collision-safe room",
+      room_alias_name: "collision-safe",
+    });
+    expect(created.room_id).toBe("!created-2:mock");
+    expect(mock.snapshot().rooms.map((room) => room.roomId)).toContain(
+      OCCUPIED_CREATED_ROOM_ID,
+    );
+
+    const transactionId = "same-transaction-across-distinct-routes";
+    const routeClient = client(mock.url);
+    const first = await routeClient.sendEvent(
+      ROOM_ID,
+      EventType.RoomMessage,
+      { msgtype: "m.text", body: "first route" },
+      transactionId,
+    );
+    const replayed = await routeClient.sendEvent(
+      ROOM_ID,
+      EventType.RoomMessage,
+      { msgtype: "m.text", body: "first route" },
+      transactionId,
+    );
+    const otherRoom = await routeClient.sendEvent(
+      OCCUPIED_CREATED_ROOM_ID,
+      EventType.RoomMessage,
+      { msgtype: "m.text", body: "other room" },
+      transactionId,
+    );
+    const otherType = await routeClient.sendEvent(
+      ROOM_ID,
+      EventType.Reaction,
+      {
+        "m.relates_to": {
+          event_id: first.event_id,
+          key: "ok",
+          rel_type: "m.annotation",
+        },
+      },
+      transactionId,
+    );
+    expect(replayed.event_id).toBe(first.event_id);
+    expect(
+      new Set([first.event_id, otherRoom.event_id, otherType.event_id]).size,
+    ).toBe(3);
+
+    const completeReadback = (await matrixClient.http.authedRequest(
+      Method.Get,
+      "/sync",
+    )) as typeof initial;
+    const allEventIds = Object.values(completeReadback.rooms.join).flatMap(
+      (room) =>
+        [...room.state.events, ...room.timeline.events].map(
+          (matrixEvent) => matrixEvent.event_id,
+        ),
+    );
+    expect(new Set(allEventIds).size).toBe(allEventIds.length);
+  });
+
   test("syncs, joins, creates, sends, paginates, orders, deduplicates, and resets", async () => {
     const mock = await startMatrixClientServerMock(seed);
     stops.push(mock.stop);
@@ -120,8 +246,8 @@ describe("Matrix Client-Server production boundary", () => {
     expect(matrixClient.getRoom(ROOM_ID)?.getMyMembership()).toBe("join");
     expect(matrixClient.getRoom(ROOM_ID)?.name).toBe("Synthetic General");
     expect(timelineIds.slice(0, 3)).toEqual([
-      "$seed-1:mock",
-      "$seed-2:mock",
+      "$generated-1:mock",
+      "$generated-2:mock",
       "$seed-3:mock",
     ]);
 


### PR DESCRIPTION
# Relates to

Refs #24093. This is an independent Matrix protocol slice; #24093 remains open for Instagram, shared generation/receipt/control composition, strict scenarios, and Cloud subprocess proof. It does not stack on the WeChat draft.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [ ] Repository-wide verification is blocked by the unchanged package failures below.
- [x] Exact-head real-SDK and production-service proof is recorded below.

# What changed

- Adds `startMatrixClientServerMock()`, a resettable loopback Matrix Client-Server API subset with seeded users, rooms, membership/state, ordered timelines, sync cursors, pagination, request observations, and queued faults.
- Drives the real `matrix-js-sdk` client for discovery, access-token auth, filters, capabilities, `/sync`, create/join, send, and `/messages`; no SDK or client methods are mocked.
- Drives production `MatrixService.start()` through its real SDK client and proves seeded inbound sync events emit plugin events and persist through the connector path.
- Uses generation-bound `next_batch` tokens. Reset aborts admitted long polls and both the in-flight request and replayed old cursor fail with `M_UNKNOWN_POS` before replacement state is visible.
- Uses deterministic logical timestamps plus a global collision-safe room/event/state identifier registry that reserves adversarial seed IDs before allocation. Alias conflicts fail without consuming IDs; transaction deduplication uses the complete send-route tuple; canonical snapshots omit internal dedup state. Reset/replay produces byte-equivalent provider room and `/sync` state.

# Testing

```text
Exact head: 1e3e571d9c38c3410ddeb2402451e764cf1ab6c4
matrix-client-server.contract.test.ts: 6 passed, 51 assertions
focused Matrix mock source TypeScript: passed
changed-file Biome: 4 files passed
AGENTS/CLAUDE parity: 160 pairs passed
```

# Evidence Gate

<!-- evidence-head:1e3e571d9c38c3410ddeb2402451e764cf1ab6c4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - protocol boundary only; real HTTP/sync artifacts and readback are direct evidence.
<!-- evidence-row:backend-logs -->
- [x] Exact-head real-SDK/production-service run passed 6/6 with 51 assertions.

```text
Matrix Client-Server production boundary: 6 pass, 0 fail, 51 assertions
real matrix-js-sdk: discovery -> auth -> filter -> sync -> join/create -> send -> pagination
production MatrixService: PREPARED + MATRIX_MESSAGE_RECEIVED + three persisted inbound memories
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM, prompt, action selection, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head authoritative provider-state snapshots and cursor/reset artifacts were asserted.

```text
provider readback: ordered seeded/outbound/live timeline; global state/timeline IDs unique across complete sync
pagination: newest-first page 1 and continuation page 2; live event IDs ordered and duplicate rejected
reset: old in-flight and replayed cursor -> 409 M_UNKNOWN_POS; replacement generation only visible to fresh sync
identity: occupied !created-1 and $generated-1/2 preserved; equivalent SDK room state retained; alias conflict non-mutating; full-route transaction keys distinct
replay: deterministic state/event IDs and logical timestamps; internal dedup keys absent; canonical room and sync JSON byte-equal
```
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual artifact.

# Known gaps / failures

- Partial draft: Instagram Graph remains unimplemented under #24093.
- This is a deterministic provider simulator, not provider qualification or live Matrix evidence. Encryption/device verification, media upload/download, edits/deletes/reactions/receipts/typing, server federation, and restart-persistent storage remain outside this slice.
- The simulator is not yet attached to #24076-#24078 lease, accepted-effect receipt, or subprocess control contracts. It does not claim Cloud E2E composition, cross-process persistence, or certification.
- Strict deterministic scenarios and Cloud subprocess execution remain open under #24093.
- `bun run --cwd packages/cloud/test-mocks typecheck` is blocked by unchanged `@elizaos/core/edge` resolution in shared code, existing `control-plane/server.ts` `Promise<boolean>` vs `Promise<void>`, and the existing `fake-indexeddb/auto` exports typing seen when the production Matrix service is imported. No changed source/test diagnostic remains. Focused Matrix mock source TypeScript passes.
- Full `bun run verify` was not run because these deterministic package blockers prevent it.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [matrix-protocol-mock]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A"} -->

