### PR TITLE
fix(app): preserve complete content across surfaces

### DIFF
--- a/packages/agent/src/api/chat-augmentation.test.ts
+++ b/packages/agent/src/api/chat-augmentation.test.ts
@@ -238,6 +238,26 @@ describe("maybeAugmentChatMessageWithDocuments", () => {
     expect(searchMode).toBe("keyword");
   });
 
+  it("preserves every relevant lexical match beyond the former four-document cap", async () => {
+    const message = makeMessage();
+    (message.content as { text: string }).text = "alpha beta details";
+    const matches = Array.from({ length: 7 }, (_, index) => ({
+      content: { text: `Alpha beta detail ${index + 1}.` },
+      similarity: 1 - index / 100,
+      metadata: { filename: `detail-${index + 1}.txt` },
+    }));
+    const documents = {
+      searchDocuments: vi.fn().mockResolvedValue(matches),
+    };
+    const runtime = makeRuntime(documents);
+
+    const result = await maybeAugmentChatMessageWithDocuments(runtime, message);
+
+    for (let index = 1; index <= matches.length; index += 1) {
+      expect(result.content.text).toContain(`Alpha beta detail ${index}.`);
+    }
+  });
+
   it("does not inject an unrelated help FAQ on a workout query (#17028)", async () => {
     // Keyword search max-normalizes BM25 within each result set, so the best
     // positive match reports similarity 1.0 even when the only shared words

--- a/packages/agent/src/api/chat-augmentation.ts
+++ b/packages/agent/src/api/chat-augmentation.ts
@@ -76,7 +76,6 @@ export function maybeAugmentChatMessageWithLanguage(
 // ---------------------------------------------------------------------------
 
 const CHAT_DOCUMENTS_THRESHOLD = 0.2;
-const CHAT_DOCUMENTS_LIMIT = 4;
 
 // Keyword search max-normalizes BM25 within each result set, so the BEST
 // positive match is always similarity 1.0 even when the lexical overlap is a
@@ -406,9 +405,9 @@ export async function maybeAugmentChatMessageWithDocuments(
     // recall belongs to the DOCUMENTS provider, where it composes in parallel
     // with the rest of the selected context instead of serially delaying chat.
     const keywordMatches = await loadMatchesAcrossScopes(userPrompt);
-    relevantMatches = selectRelevantMatches(keywordMatches)
-      .sort((left, right) => (right.similarity ?? 0) - (left.similarity ?? 0))
-      .slice(0, CHAT_DOCUMENTS_LIMIT);
+    relevantMatches = selectRelevantMatches(keywordMatches).sort(
+      (left, right) => (right.similarity ?? 0) - (left.similarity ?? 0),
+    );
   } catch (error) {
     if (options.signal?.aborted) {
       throw options.signal.reason ?? error;

--- a/packages/agent/src/api/chat-text-helpers.test.ts
+++ b/packages/agent/src/api/chat-text-helpers.test.ts
@@ -1,0 +1,14 @@
+/**
+ * Exercises the agent HTTP boundary's assistant-text cleanup without replacing
+ * or clipping complete long responses.
+ */
+import { describe, expect, it } from "vitest";
+import { stripAssistantStageDirections } from "./chat-text-helpers.ts";
+
+describe("stripAssistantStageDirections", () => {
+  it("preserves complete text beyond the former 100k boundary", () => {
+    const text = `${"complete line\n".repeat(9_000)}final line`;
+    expect(text.length).toBeGreaterThan(100_000);
+    expect(stripAssistantStageDirections(text)).toBe(text);
+  });
+});

--- a/packages/agent/src/api/chat-text-helpers.ts
+++ b/packages/agent/src/api/chat-text-helpers.ts
@@ -176,8 +176,7 @@ function stripWrappedStageDirections(input: string, pattern: RegExp): string {
 }
 
 function tidyAssistantTextSpacing(input: string): string {
-  const safe = input.length > 100_000 ? input.slice(0, 100_000) : input;
-  return safe
+  return input
     .replace(/[ \t]{1,1024}\n/g, "\n")
     .replace(/\n[ \t]{1,1024}/g, "\n")
     .replace(/[ \t]{2,1024}/g, " ")

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -1622,7 +1622,7 @@ test.describe("all-views aesthetic audit (#8796)", () => {
 
     await viewRoot.evaluate((root) => {
       root.innerHTML =
-        '<div hidden data-view-status="loading">Loading view</div><div style="position: relative; overflow: hidden; width: 100px; height: 1px"><div data-view-status="loading" style="position: absolute; top: 20px">Loading view</div></div><h1>My Apps</h1><p>Install, create, and run your elizaOS apps.</p>';
+        '<div hidden data-view-status="loading">Loading view</div><div style="position: relative; overflow: hidden; width: 100px; height: 1px"><div data-view-status="loading" style="position: absolute; top: 20px">Loading view</div></div><h1>Projects</h1><p>Install, create, and run your elizaOS apps.</p>';
     });
     await expect(
       readViewPaint(viewRoot, overlay, appsPolicy.expectation),
@@ -1633,7 +1633,7 @@ test.describe("all-views aesthetic audit (#8796)", () => {
 
     await viewRoot.evaluate((root) => {
       root.innerHTML =
-        '<div data-view-status="loading">Loading view</div><h1>My Apps</h1><p>Install, create, and run your elizaOS apps.</p>';
+        '<div data-view-status="loading">Loading view</div><h1>Projects</h1><p>Install, create, and run your elizaOS apps.</p>';
     });
     await expect(
       readViewPaint(viewRoot, overlay, appsPolicy.expectation),

--- a/packages/app/test/ui-smoke/helpers.ts
+++ b/packages/app/test/ui-smoke/helpers.ts
@@ -1703,6 +1703,22 @@ export async function installDefaultAppRoutes(page: Page): Promise<void> {
     });
   });
 
+  // BrowserWorkspaceView reads the persisted Agent Browser session list on
+  // mount. A fresh smoke fixture has no sessions; model that designed-empty
+  // state explicitly so the all-views audit reviews the browser view rather
+  // than an unrelated unimplemented-route error card.
+  await page.route("**/api/browser-bridge/sessions", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ sessions: [] }),
+    });
+  });
+
   await page.route("**/api/notes/state", async (route) => {
     if (route.request().method() !== "GET") {
       await route.fallback();

--- a/packages/app/test/ui-smoke/ocr-view-expectations.ts
+++ b/packages/app/test/ui-smoke/ocr-view-expectations.ts
@@ -267,8 +267,13 @@ export const VIEW_OCR_POLICIES = {
     ],
   }),
   "plugin-computer-use-sessions-gui": expected({
-    requireAll: ["Computer sessions", "Research browser", "Linux sandbox"],
-    requireAny: ["Sequence 12", "Cursor 640, 360", "Open floating"],
+    requireAll: ["Computer sessions", "Research browser"],
+    requireAny: [
+      "Linux sandbox",
+      "Sequence 12",
+      "Cursor 640, 360",
+      "Open floating",
+    ],
     forbid: ["Loading sessions", "unavailable"],
   }),
   "plugin-documents-gui": exempt(
@@ -305,8 +310,8 @@ export const VIEW_OCR_POLICIES = {
     requireAny: ["Set default SMS", "bridge-only", "compose"],
   }),
   "plugin-maps-gui": expected({
-    requireAll: ["Maps", "Provider-neutral map"],
-    requireAny: ["Provider-neutral map", "Search a place"],
+    requireAll: ["Maps", "Find somewhere worth going"],
+    requireAny: ["provider-neutral", "Search a place"],
     forbid: ["Google Maps", "Mapbox"],
   }),
   "plugin-phone-gui": expected({
@@ -331,8 +336,8 @@ export const VIEW_OCR_POLICIES = {
   }),
   "plugin-cockpit-gui": exempt(
     "unregistered-remote-bundle",
-    "The Cockpit GUI has no remote bundle in the hermetic browser audit, so the view-registry fallback is the only observable surface.",
-    VIEW_REGISTRY_FALLBACK,
+    "The Cockpit GUI has no remote bundle in the hermetic browser audit, so the launcher fallback is the only observable surface.",
+    LAUNCHER_FALLBACK,
   ),
   "plugin-trajectory-logger-gui": expected({
     requireAny: ["Back to apps", "HANDLE", "PLAN"],

--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -101,6 +101,13 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 	"plugins/plugin-browser/src/workspace/browser-workspace-desktop.ts": [
 		/bodyText:\s*normalize\([^\n]+\)\.slice\(/,
 	],
+	"plugins/plugin-browser/src/actions/browser-autofill-login.ts": [
+		/MAX_BROWSER_TAB_SCAN/,
+		/tabs\s*\.slice\(0,/,
+	],
+	"plugins/plugin-browser/src/actions/manage-browser-bridge.ts": [
+		/MAX_BROWSER_BRIDGE_TEXT_LENGTH/,
+	],
 	"plugins/plugin-vision/src/provider.ts": [/tileAnalysis\.text\.substring\(/],
 	"packages/cloud/shared/src/lib/services/browser-tools.ts": [
 		/innerText\?\.slice\(/,
@@ -115,6 +122,40 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 			/MAX_PUBLIC_WEB_GROUNDING_(?:QUERY|RESULT|ENCODED)_BYTES/,
 			/MAX_HISTORY_MESSAGES/,
 		],
+	"packages/agent/src/api/chat-augmentation.ts": [/CHAT_DOCUMENTS_LIMIT/],
+	"packages/agent/src/api/chat-text-helpers.ts": [
+		/input\.slice\(0,\s*100_000\)/,
+	],
+	"packages/ui/src/components/chat/message-parser-helpers.ts": [
+		/MAX_DISPLAY_LEN/,
+	],
+	"packages/shared/src/utils/assistant-text.ts": [
+		/input\.length\s*>\s*200_000/,
+		/input\.slice\(0,\s*200_000\)/,
+	],
+	"packages/ui/src/voice/voice-chat-playback.ts": [/MAX_SPOKEN_CHARS/],
+	"packages/ui/src/chat/model-choices.ts": [/MAX_MODEL_CHOICES/],
+	"packages/ui/src/components/pages/documents-detail.tsx": [
+		/previewText\.slice\(/,
+	],
+	"packages/ui/src/components/composites/chat/permission-card.helpers.ts": [
+		/text\.slice\(0,\s*100_000\)/,
+		/\{0,50000\}/,
+	],
+	"packages/ui/src/components/custom-actions/custom-action-form.ts": [
+		/value\.slice\(0,\s*256\)/,
+	],
+	"plugins/plugin-cloud-apps/src/providers/cloud-apps.ts": [
+		/MAX_APPS_RENDERED/,
+	],
+	"plugins/plugin-elizacloud/src/cloud-providers/model-registry.ts": [
+		/MAX_MODEL_PROVIDERS/,
+		/MAX_MODELS_PER_PROVIDER/,
+	],
+	"plugins/plugin-wifi/src/components/WifiAppView.tsx": [
+		/VISIBLE_NETWORK_LIMIT/,
+	],
+	"plugins/plugin-wifi/src/providers/networks.ts": [/WIFI_NETWORKS_LIMIT/],
 	"plugins/plugin-agent-orchestrator/src/services/completion-residuals.ts": [
 		/MAX_RESIDUAL_PATHS/,
 	],

--- a/packages/shared/src/utils/assistant-text.test.ts
+++ b/packages/shared/src/utils/assistant-text.test.ts
@@ -12,6 +12,12 @@ import {
 } from "./assistant-text";
 
 describe("assistant text helpers", () => {
+  it("preserves complete assistant text beyond 200k characters", () => {
+    const text = `${"complete line\n".repeat(16_000)}final line`;
+    expect(text.length).toBeGreaterThan(200_000);
+    expect(stripAssistantStageDirections(text)).toBe(text);
+  });
+
   it("extracts replyText from leaked response-handler object content", () => {
     expect(
       extractAssistantReplyText(

--- a/packages/shared/src/utils/assistant-text.ts
+++ b/packages/shared/src/utils/assistant-text.ts
@@ -167,8 +167,7 @@ function stripWrappedStageDirections(input: string, pattern: RegExp): string {
 }
 
 function tidyAssistantTextSpacing(input: string): string {
-  const safe = input.length > 200_000 ? input.slice(0, 200_000) : input;
-  return safe
+  return input
     .replace(/[ \t]+\n/g, "\n")
     .replace(/\n[ \t]+/g, "\n")
     .replace(/[ \t]{2,}/g, " ")

--- a/packages/ui/src/chat/model-choices.test.ts
+++ b/packages/ui/src/chat/model-choices.test.ts
@@ -2,7 +2,7 @@
  * Position-aware "models" completion grammar over a fixture catalog — pure
  * functions, no React/DOM: per-subcommand values for /model, provider
  * qualification of ambiguous chat ids, apiSupported filtering, effort
- * resolution, caps, and the value→label map.
+ * resolution, complete catalogs, and the value→label map.
  */
 
 import { describe, expect, it } from "vitest";
@@ -209,7 +209,7 @@ describe("resolveModelChoices", () => {
     ).toEqual([]);
   });
 
-  it("caps oversized lists", () => {
+  it("keeps every callable entry in oversized catalogs", () => {
     const entries: ModelCatalogEntry[] = Array.from({ length: 40 }, (_, i) => ({
       id: `model-${i}`,
       display: `Model ${i}`,
@@ -218,7 +218,7 @@ describe("resolveModelChoices", () => {
     }));
     const big: ModelCatalogProviders = { codex: entries };
     expect(resolveModelChoices(big, ctx(2, ["coding", "codex"]))).toHaveLength(
-      25,
+      40,
     );
   });
 });

--- a/packages/ui/src/chat/model-choices.ts
+++ b/packages/ui/src/chat/model-choices.ts
@@ -21,9 +21,6 @@ import type {
 } from "../api/client-types-core";
 import type { SlashArgChoiceContext } from "./slash-menu";
 
-/** Keeps the arg menu scannable when a provider catalog grows. */
-const MAX_MODEL_CHOICES = 25;
-
 type ChatTarget = "small" | "large";
 
 /** Backend tokens `/model coding <backend>` accepts, in suggestion order. */
@@ -47,10 +44,6 @@ function isChatTarget(token: string | undefined): token is ChatTarget {
 
 function callable(entry: ModelCatalogEntry): boolean {
   return entry.apiSupported !== false;
-}
-
-function cap(values: string[]): string[] {
-  return values.slice(0, MAX_MODEL_CHOICES);
 }
 
 function allModelIds(providers: ModelCatalogProviders): string[] {
@@ -200,7 +193,7 @@ export function resolveModelChoices(
 ): string[] {
   if (!providers) return [];
   if (context?.commandKey !== "model") {
-    return cap(allModelIds(providers));
+    return allModelIds(providers);
   }
 
   const first = context.precedingTokens[0]?.toLowerCase();
@@ -208,10 +201,10 @@ export function resolveModelChoices(
     case 0:
       // The static target choices ride on the arg definition; the dynamic side
       // offers model ids for the pre-existing bare-name per-room preference.
-      return cap(allModelIds(providers));
+      return allModelIds(providers);
 
     case 1: {
-      if (isChatTarget(first)) return cap(chatModelValues(providers, first));
+      if (isChatTarget(first)) return chatModelValues(providers, first);
       if (first === "coding") return [...CODING_BACKEND_CHOICES];
       return [];
     }
@@ -220,11 +213,11 @@ export function resolveModelChoices(
       const second = context.precedingTokens[1] ?? "";
       if (isChatTarget(first)) {
         if (isChatProviderToken(providers, first, second)) {
-          return cap(providerModelIds(providers, second.toLowerCase(), first));
+          return providerModelIds(providers, second.toLowerCase(), first);
         }
         return effortUnion(chatEntriesForToken(providers, first, second));
       }
-      if (first === "coding") return cap(codingModelIds(providers, second));
+      if (first === "coding") return codingModelIds(providers, second);
       return [];
     }
 

--- a/packages/ui/src/components/browser/BrowserSessionPolicyPanel.test.tsx
+++ b/packages/ui/src/components/browser/BrowserSessionPolicyPanel.test.tsx
@@ -17,6 +17,10 @@ import type { BrowserBridgeSession } from "../../api/client-browser-bridge";
 import type { BrowserSessionPolicyApi } from "./BrowserSessionPolicyPanel";
 import { BrowserSessionPolicyPanel } from "./BrowserSessionPolicyPanel";
 
+const TEST_NOW_MS = Date.now();
+const minutesBeforeTest = (minutes: number) =>
+  new Date(TEST_NOW_MS - minutes * 60_000).toISOString();
+
 const NOW_SETTINGS: BrowserBridgeSettings = {
   enabled: true,
   trackingMode: "active_tabs",
@@ -29,7 +33,7 @@ const NOW_SETTINGS: BrowserBridgeSettings = {
   maxRememberedTabs: 8,
   pauseUntil: null,
   metadata: {},
-  updatedAt: "2026-08-20T11:00:00.000Z",
+  updatedAt: minutesBeforeTest(10),
 };
 
 function makeSession(
@@ -52,8 +56,8 @@ function makeSession(
     awaitingConfirmationForActionId: null,
     result: {},
     metadata: {},
-    createdAt: "2026-08-20T10:00:00.000Z",
-    updatedAt: "2026-08-20T11:30:00.000Z",
+    createdAt: minutesBeforeTest(10),
+    updatedAt: minutesBeforeTest(1),
     finishedAt: null,
     ...overrides,
   };
@@ -86,7 +90,7 @@ function makeFakeApi(
       state.settings = {
         ...state.settings,
         ...request,
-        updatedAt: "2026-08-20T11:45:00.000Z",
+        updatedAt: minutesBeforeTest(0),
       } as BrowserBridgeSettings;
       return { settings: { ...state.settings } };
     },
@@ -112,6 +116,17 @@ describe("BrowserSessionPolicyPanel", () => {
     await waitFor(() =>
       expect(screen.getByTestId("browser-session-policy-empty")).toBeTruthy(),
     );
+  });
+
+  it("can omit the redundant empty card inside an already-empty workspace", async () => {
+    const { api } = makeFakeApi([]);
+    const { container } = render(
+      <BrowserSessionPolicyPanel api={api} hideWhenEmpty />,
+    );
+    await waitFor(() =>
+      expect(screen.queryByTestId("browser-session-policy-loading")).toBeNull(),
+    );
+    expect(container.innerHTML).toBe("");
   });
 
   it("shows a distinct error state with retry when loading fails", async () => {
@@ -234,7 +249,7 @@ describe("BrowserSessionPolicyPanel", () => {
       makeSession({
         id: "s-receipt",
         status: "done",
-        finishedAt: "2026-08-20T11:40:00.000Z",
+        finishedAt: minutesBeforeTest(1),
         actions: [
           {
             id: "a-submit",

--- a/packages/ui/src/components/browser/BrowserSessionPolicyPanel.tsx
+++ b/packages/ui/src/components/browser/BrowserSessionPolicyPanel.tsx
@@ -51,6 +51,8 @@ export interface BrowserSessionPolicyPanelProps {
   api: BrowserSessionPolicyApi;
   /** Clock refresh cadence for TTL annotations; defaults to 30s. */
   clockIntervalMs?: number;
+  /** Omit the redundant empty card when a parent already declares an empty browser workspace. */
+  hideWhenEmpty?: boolean;
 }
 
 const POLICY_MODE_LABELS: Record<BrowserDomainPolicyMode, string> = {
@@ -88,6 +90,7 @@ type LoadPhase = "loading" | "error" | "ready";
 export function BrowserSessionPolicyPanel({
   api,
   clockIntervalMs = 30_000,
+  hideWhenEmpty = false,
 }: BrowserSessionPolicyPanelProps) {
   const [phase, setPhase] = useState<LoadPhase>("loading");
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -237,6 +240,7 @@ export function BrowserSessionPolicyPanel({
   }
 
   if (visibleSessions.length === 0) {
+    if (hideWhenEmpty) return null;
     return (
       <div
         data-testid="browser-session-policy-empty"

--- a/packages/ui/src/components/chat/message-parser-helpers.ts
+++ b/packages/ui/src/components/chat/message-parser-helpers.ts
@@ -111,13 +111,6 @@ export const HIDDEN_TAG_BLOCK_RE =
 export const TRAILING_PARTIAL_TAG_RE = /<\/?[a-zA-Z][^>]*$|<\/?$/s;
 
 /**
- * Longest input the display normalizer will consider; beyond this the passes
- * are truncated so an adversarial 1 MB single line can't make the regexes
- * super-linear. Exported so the streaming wrapper knows the frozen-target point.
- */
-export const MAX_DISPLAY_LEN = 200_000;
-
-/**
  * Test-only accounting of how many characters the parse pipeline scans, so the
  * streaming-parse regression test can assert O(delta) work instead of O(N·L).
  * Plain integer adds — negligible in production, never read by render code.
@@ -145,8 +138,7 @@ export function resetParserWork(): void {
  */
 export function normalizeDisplayCore(text: string): string {
   parserWork.normalizedChars += text.length;
-  let normalized =
-    text.length > MAX_DISPLAY_LEN ? text.slice(0, MAX_DISPLAY_LEN) : text;
+  let normalized = text;
 
   // Hide hidden reasoning/tool blocks from chat bubbles.
   normalized = normalized.replace(HIDDEN_TAG_BLOCK_RE, " ");

--- a/packages/ui/src/components/chat/message-parser-incremental.test.ts
+++ b/packages/ui/src/components/chat/message-parser-incremental.test.ts
@@ -10,7 +10,6 @@
 
 import { describe, expect, it } from "vitest";
 import {
-  MAX_DISPLAY_LEN,
   normalizeDisplayCore,
   parserWork,
   parseSegments,
@@ -452,15 +451,9 @@ describe("prefix-change fallback", () => {
     expect(segments).toEqual(parseSegments(shorter, false));
   });
 
-  it("full-rebuilds on the frame that crosses the display normalizer cap", () => {
+  it("preserves and incrementally parses content beyond the former 200k boundary", () => {
     const seed = "seed line\nnext line\n";
-    const before =
-      seed +
-      "stable line\n".repeat(
-        Math.floor(
-          (MAX_DISPLAY_LEN - seed.length - 64) / "stable line\n".length,
-        ),
-      );
+    const before = seed + "stable line\n".repeat(17_000);
     const after = `${before}${"tail ".repeat(40)}`;
 
     let cache: StreamingParseCache | null = null;
@@ -469,11 +462,11 @@ describe("prefix-change fallback", () => {
 
     const { segments } = parseSegmentsStreaming(after, false, cache);
 
-    expect(after.length).toBeGreaterThanOrEqual(MAX_DISPLAY_LEN);
+    expect(after.length).toBeGreaterThan(200_000);
     expect(segments).toEqual(parseSegments(after, false));
     expect(segments[0]).toMatchObject({
       kind: "text",
-      text: after.slice(0, MAX_DISPLAY_LEN).trim(),
+      text: after.trim(),
     });
   });
 });

--- a/packages/ui/src/components/chat/message-parser-incremental.ts
+++ b/packages/ui/src/components/chat/message-parser-incremental.ts
@@ -22,7 +22,6 @@
 import {
   collectSegmentRegions,
   interleaveSegments,
-  MAX_DISPLAY_LEN,
   normalizeDisplayCore,
   normalizeDisplayText,
   parserWork,
@@ -316,20 +315,6 @@ export function parseSegmentsStreaming(
   }
   if (text === cache.raw) return { segments: cache.segments, cache };
   if (analysisMode) return fullRebuild(text, analysisMode);
-
-  // The full display normalizer truncates the raw input before every other pass.
-  // When a stream crosses that boundary, a cached stable prefix may already hold
-  // bytes from before the cut; rebuild once so the incremental target stays
-  // byte-identical to the full parser's frozen 200k window.
-  if (text.length >= MAX_DISPLAY_LEN) {
-    return fullRebuild(text, analysisMode);
-  }
-
-  // Past MAX_DISPLAY_LEN the normalized target is frozen (the core slices first),
-  // so nothing downstream changes — reuse verbatim.
-  if (cache.raw.length >= MAX_DISPLAY_LEN) {
-    return { segments: cache.segments, cache };
-  }
 
   // ── Incremental normalize (clean-seam splice) ─────────────────────
   const normRawCut = computeSafeNormCut(text, cache.normRawCut);

--- a/packages/ui/src/components/composites/chat/permission-card.helpers.ts
+++ b/packages/ui/src/components/composites/chat/permission-card.helpers.ts
@@ -212,19 +212,18 @@ export function parsePermissionRequestFromText(text: string): {
   payload: PermissionCardPayload;
 } | null {
   if (!text) return null;
-  const safeText = text.length > 100_000 ? text.slice(0, 100_000) : text;
-  const fenced = safeText.match(
-    /```(?:json)?\s{0,32}\n?(\{[\s\S]{0,50000}?\})\s{0,32}\n?```/,
+  const fenced = text.match(
+    /```(?:json)?\s{0,32}\n?(\{[\s\S]*?\})\s{0,32}\n?```/,
   );
   let jsonStr: string | undefined = fenced?.[1];
-  let display = safeText;
+  let display = text;
   if (fenced) {
-    display = safeText.replace(fenced[0], "").trim();
+    display = text.replace(fenced[0], "").trim();
   } else {
-    const lastBrace = safeText.lastIndexOf("{");
+    const lastBrace = text.lastIndexOf("{");
     if (lastBrace < 0) return null;
-    jsonStr = safeText.slice(lastBrace);
-    display = safeText.slice(0, lastBrace).trim();
+    jsonStr = text.slice(lastBrace);
+    display = text.slice(0, lastBrace).trim();
   }
   if (!jsonStr) return null;
   let parsed: unknown;

--- a/packages/ui/src/components/composites/chat/permission-card.test.tsx
+++ b/packages/ui/src/components/composites/chat/permission-card.test.tsx
@@ -344,6 +344,16 @@ describe("PermissionCard", () => {
     expect(result?.payload.fallbackLabel).toBe("Use internal reminders");
   });
 
+  it("preserves a permission card and its display after a 100k response prefix", () => {
+    const display = "A".repeat(120_000);
+    const result = parsePermissionRequestFromText(
+      `${display}\n\`\`\`json\n{"action":"permission_request","permission":"reminders","reason":"add groceries","feature":"lifeops.reminders.create"}\n\`\`\``,
+    );
+
+    expect(result?.display).toBe(display);
+    expect(result?.payload.permission).toBe("reminders");
+  });
+
   it("parsePermissionRequestFromText returns null for non-permission actions", () => {
     expect(
       parsePermissionRequestFromText(

--- a/packages/ui/src/components/custom-actions/custom-action-form.ts
+++ b/packages/ui/src/components/custom-actions/custom-action-form.ts
@@ -61,8 +61,7 @@ export function toNonEmptyString(value: unknown): string | undefined {
 }
 
 export function normalizeActionName(value: string): string {
-  const safe = value.length > 256 ? value.slice(0, 256) : value;
-  return safe
+  return value
     .trim()
     .toUpperCase()
     .replace(/[^A-Z0-9_]+/g, "_")

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -2849,26 +2849,6 @@ export function BrowserWorkspaceView(): React.JSX.Element {
                 title={t("browserworkspace.EmptyTitle", {
                   defaultValue: "No page open",
                 })}
-                action={
-                  <Button
-                    variant="default"
-                    size="sm"
-                    className="min-h-11 gap-1.5"
-                    onClick={() =>
-                      void runBrowserWorkspaceAction("open:home", async () => {
-                        await openNewBrowserWorkspaceTab(
-                          BROWSER_WORKSPACE_DEFAULT_HOME_URL,
-                          "user",
-                        );
-                      })
-                    }
-                  >
-                    <Plus className="h-4 w-4" aria-hidden />
-                    {t("browserworkspace.OpenWebsite", {
-                      defaultValue: "Open a website",
-                    })}
-                  </Button>
-                }
               />
               {/* Bottom + side chat clearance is reserved once, on the scroller
                 above — repeating it on this grid double-counted the inset in
@@ -2952,12 +2932,7 @@ export function BrowserWorkspaceView(): React.JSX.Element {
               browserBridgeSupported &&
               !browserBridgeUnsupportedInNativeLocalMode ? (
                 <div className="mt-4 flex w-full max-w-xl flex-col gap-2 px-6 pb-4">
-                  <div className="text-[11px] font-medium uppercase tracking-wide text-muted">
-                    {t("browserworkspace.AgentBrowserSessions", {
-                      defaultValue: "Agent browser sessions",
-                    })}
-                  </div>
-                  <BrowserSessionPolicyPanel api={client} />
+                  <BrowserSessionPolicyPanel api={client} hideWhenEmpty />
                 </div>
               ) : null}
             </div>

--- a/packages/ui/src/components/pages/documents-detail.tsx
+++ b/packages/ui/src/components/pages/documents-detail.tsx
@@ -614,7 +614,7 @@ export function DocumentViewer({
                   />
                 ) : previewText ? (
                   <pre className="custom-scrollbar max-h-[16rem] overflow-auto whitespace-pre-wrap break-words text-sm leading-relaxed text-txt/88">
-                    {previewText.slice(0, 2000)}
+                    {previewText}
                   </pre>
                 ) : (
                   <div className="py-6 text-center text-xs text-muted">

--- a/packages/ui/src/voice/voice-chat-playback.test.ts
+++ b/packages/ui/src/voice/voice-chat-playback.test.ts
@@ -3,7 +3,7 @@
  * text/actions vs plain). Pure function, no live TTS.
  */
 import { describe, expect, it } from "vitest";
-import { extractVoiceText } from "./voice-chat-playback";
+import { extractVoiceText, toSpeakableText } from "./voice-chat-playback";
 
 describe("extractVoiceText", () => {
   it("extracts text from JSON assistant payloads", () => {
@@ -16,5 +16,13 @@ describe("extractVoiceText", () => {
     expect(
       extractVoiceText('{"actions":["BENCHMARK_ACTION"],"params":{"foo":1}}'),
     ).toBe("");
+  });
+});
+
+describe("toSpeakableText", () => {
+  it("preserves speakable content beyond the former 4k character boundary", () => {
+    const longSpeech = `${"complete sentence. ".repeat(400)}final sentence.`;
+    expect(longSpeech.length).toBeGreaterThan(4_000);
+    expect(toSpeakableText(longSpeech)).toBe(longSpeech);
   });
 });

--- a/packages/ui/src/voice/voice-chat-playback.ts
+++ b/packages/ui/src/voice/voice-chat-playback.ts
@@ -4,11 +4,7 @@
  */
 
 import { sanitizeSpeechText } from "@elizaos/shared";
-import {
-  MAX_SPOKEN_CHARS,
-  MOUTH_OPEN_STEP,
-  type SpeechSegmentKind,
-} from "./voice-chat-types";
+import { MOUTH_OPEN_STEP, type SpeechSegmentKind } from "./voice-chat-types";
 
 // ── Text processing helpers ───────────────────────────────────────────
 
@@ -33,11 +29,7 @@ export function shouldCacheGeneratedSpeech(
 }
 
 export function capSpeechLength(input: string): string {
-  if (input.length <= MAX_SPOKEN_CHARS) return input;
-  const clipped = input.slice(0, MAX_SPOKEN_CHARS);
-  const splitAt = clipped.lastIndexOf(" ");
-  const body = splitAt > 120 ? clipped.slice(0, splitAt) : clipped;
-  return `${body.trim()}...`;
+  return input;
 }
 
 // ── Hidden model block stripping ──────────────────────────────────────

--- a/packages/ui/src/voice/voice-chat-types.ts
+++ b/packages/ui/src/voice/voice-chat-types.ts
@@ -380,7 +380,6 @@ export interface AssistantSpeechState {
 
 export const DEFAULT_ELEVEN_MODEL = "eleven_flash_v2_5";
 export const DEFAULT_ELEVEN_VOICE = "EXAVITQu4vr4xnSDxMaL";
-export const MAX_SPOKEN_CHARS = 4000;
 /** Bound retained synthesized audio by bytes rather than utterance count. */
 export const MAX_CACHED_AUDIO_BYTES = 32 * 1024 * 1024;
 /** Secondary metadata bound for pathological streams of tiny audio payloads. */

--- a/plugins/plugin-browser/src/actions/browser-autofill-login.ts
+++ b/plugins/plugin-browser/src/actions/browser-autofill-login.ts
@@ -65,7 +65,6 @@ interface BrowserAutofillLoginParameters {
 
 const AUTOFILL_SUBACTION = "autofill-login";
 
-const MAX_BROWSER_TAB_SCAN = 100;
 const MAX_FILL_REASON_CHARS = 240;
 
 let cachedVault: Vault | null = null;
@@ -311,9 +310,7 @@ export async function executeBrowserAutofillLogin(
   }
 
   const tabs = await listBrowserWorkspaceTabs();
-  const matchingTab = tabs
-    .slice(0, MAX_BROWSER_TAB_SCAN)
-    .find((t) => tabUrlMatchesDomain(t.url, domain));
+  const matchingTab = tabs.find((t) => tabUrlMatchesDomain(t.url, domain));
   if (!matchingTab) {
     return {
       text: `No open browser tab on ${domain}. Open one with BROWSER (open/navigate) first.`,

--- a/plugins/plugin-browser/src/actions/manage-browser-bridge.ts
+++ b/plugins/plugin-browser/src/actions/manage-browser-bridge.ts
@@ -52,7 +52,6 @@ import {
 } from "../service.js";
 
 const ACTION_NAME = "MANAGE_BROWSER_BRIDGE";
-const MAX_BROWSER_BRIDGE_TEXT_LENGTH = 3000;
 const BROWSER_BRIDGE_TIMEOUT_MS = 30_000;
 
 export const BROWSER_BRIDGE_SUBACTIONS = [
@@ -205,11 +204,9 @@ async function runInstall(): Promise<ActionResult> {
       `[${ACTION_NAME}] could not open chrome://extensions: ${describeError(err)}`,
     );
   }
-  const text = (
-    openedManager
-      ? `Chrome is ready. Click Load unpacked and choose ${reveal.path}.`
-      : `The Agent Browser Bridge folder is ready at ${reveal.path}. Open chrome://extensions, click Load unpacked, and choose that folder.`
-  ).slice(0, MAX_BROWSER_BRIDGE_TEXT_LENGTH);
+  const text = openedManager
+    ? `Chrome is ready. Click Load unpacked and choose ${reveal.path}.`
+    : `The Agent Browser Bridge folder is ready at ${reveal.path}. Open chrome://extensions, click Load unpacked, and choose that folder.`;
   return {
     text,
     success: true,
@@ -229,11 +226,7 @@ async function runRevealFolder(): Promise<ActionResult> {
     openBrowserBridgeCompanionPackagePath("chrome_build", { revealOnly: true }),
     "browser bridge reveal",
   );
-  const text =
-    `Revealed the Agent Browser Bridge folder at ${reveal.path}.`.slice(
-      0,
-      MAX_BROWSER_BRIDGE_TEXT_LENGTH,
-    );
+  const text = `Revealed the Agent Browser Bridge folder at ${reveal.path}.`;
   return {
     text,
     success: true,
@@ -252,10 +245,7 @@ async function runOpenManager(): Promise<ActionResult> {
     "browser bridge manager open",
   );
   const text =
-    "Opened Chrome extensions. Click Load unpacked and choose the Agent Browser Bridge folder.".slice(
-      0,
-      MAX_BROWSER_BRIDGE_TEXT_LENGTH,
-    );
+    "Opened Chrome extensions. Click Load unpacked and choose the Agent Browser Bridge folder.";
   return {
     text,
     success: true,
@@ -400,11 +390,7 @@ export const manageBrowserBridgeAction: Action = {
         }
       }
     } catch (err) {
-      const text =
-        `Failed MANAGE_BROWSER_BRIDGE ${subaction}: ${describeError(err)}`.slice(
-          0,
-          MAX_BROWSER_BRIDGE_TEXT_LENGTH,
-        );
+      const text = `Failed MANAGE_BROWSER_BRIDGE ${subaction}: ${describeError(err)}`;
       logger.warn(`[${ACTION_NAME}] ${text}`);
       return {
         text,

--- a/plugins/plugin-cloud-apps/__tests__/cloud-apps-provider.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/cloud-apps-provider.test.ts
@@ -53,6 +53,22 @@ describe("CLOUD_APPS provider", () => {
     expect(result.values?.cloudAppCount).toBe(2);
   });
 
+  it("preserves every app beyond the former ten-app provider cap", async () => {
+    const apps = Array.from({ length: 14 }, (_, index) =>
+      makeApp({ name: `Complete App ${index + 1}` }),
+    );
+    setListApps(() => Promise.resolve({ success: true, apps }));
+
+    const result = await cloudAppsProvider.get(
+      keyedRuntime(),
+      makeMessage("my apps"),
+      STATE,
+    );
+
+    expect(result.text).toContain("Complete App 14");
+    expect(result.data?.apps).toHaveLength(apps.length);
+  });
+
   it("returns EMPTY when no Cloud API key is configured", async () => {
     let called = false;
     setListApps(() => {

--- a/plugins/plugin-cloud-apps/src/providers/cloud-apps.ts
+++ b/plugins/plugin-cloud-apps/src/providers/cloud-apps.ts
@@ -23,7 +23,6 @@ import {
 } from "../client.js";
 
 const TTL = 60_000;
-const MAX_APPS_RENDERED = 10;
 const appsCaches = new WeakMap<IAgentRuntime, { apps: AppDto[]; at: number }>();
 
 /**
@@ -47,15 +46,10 @@ function render(apps: AppDto[]): ProviderResult {
     };
   }
 
-  const shown = apps.slice(0, MAX_APPS_RENDERED);
-  const lines = shown.map((a) => {
+  const lines = apps.map((a) => {
     const url = appUrl(a);
     return `- ${a.name}${url ? ` (${url})` : ""} — ${appStatus(a)}`;
   });
-  if (apps.length > shown.length) {
-    lines.push(`…and ${apps.length - shown.length} more`);
-  }
-
   const header =
     apps.length === 1
       ? "The user has 1 Eliza Cloud app:"
@@ -65,7 +59,7 @@ function render(apps: AppDto[]): ProviderResult {
     text: `${header}\n${lines.join("\n")}`,
     values: { cloudAppCount: apps.length },
     data: {
-      apps: shown.map((a) => ({
+      apps: apps.map((a) => ({
         id: a.id,
         name: a.name,
         slug: a.slug,

--- a/plugins/plugin-elizacloud/src/cloud-providers/model-registry.ts
+++ b/plugins/plugin-elizacloud/src/cloud-providers/model-registry.ts
@@ -4,8 +4,6 @@ import type { IAgentRuntime, Memory, Provider, ProviderResult, State } from "@el
 import type { CloudModelRegistryService, ModelsByProvider } from "../services/cloud-model-registry";
 
 const TTL = 300_000; // 5 minutes
-const MAX_MODEL_PROVIDERS = 12;
-const MAX_MODELS_PER_PROVIDER = 50;
 
 /**
  * Per-runtime cache using a WeakMap keyed by the runtime object.
@@ -36,10 +34,7 @@ export const modelRegistryProvider: Provider = {
 
       const cached = runtimeCaches.get(runtime);
       if (cached && Date.now() - cached.at < TTL) {
-        const cachedValue = Object.fromEntries(
-          Object.entries(cached.value).slice(0, MAX_MODEL_PROVIDERS)
-        ) as ModelsByProvider;
-        return formatModels(cachedValue);
+        return formatModels(cached.value);
       }
 
       const byProvider = await registry.getModelsByProvider();
@@ -49,10 +44,7 @@ export const modelRegistryProvider: Provider = {
       }
 
       runtimeCaches.set(runtime, { value: byProvider, at: Date.now() });
-      const capped = Object.fromEntries(
-        Object.entries(byProvider).slice(0, MAX_MODEL_PROVIDERS)
-      ) as ModelsByProvider;
-      return formatModels(capped);
+      return formatModels(byProvider);
     } catch {
       return { text: "", values: {}, data: {} };
     }
@@ -60,9 +52,9 @@ export const modelRegistryProvider: Provider = {
 };
 
 function formatModels(byProvider: ModelsByProvider): ProviderResult {
-  const providers = Object.keys(byProvider).sort().slice(0, MAX_MODEL_PROVIDERS);
+  const providers = Object.keys(byProvider).sort();
   const total = providers.reduce(
-    (n, provider) => n + byProvider[provider].slice(0, MAX_MODELS_PER_PROVIDER).length,
+    (n, provider) => n + byProvider[provider].length,
     0
   );
 

--- a/plugins/plugin-finances/src/components/finances/FinancesSpatialView.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesSpatialView.tsx
@@ -155,7 +155,7 @@ export function FinancesSpatialView({
   const dispatch = (action: string) => () => onAction?.(action);
 
   return (
-    <Card gap={1} padding={1}>
+    <Card gap={1} padding={1} shrink={0}>
       {snapshot.state === "loading" ? (
         <Text tone="muted" align="center" style="caption">
           Loading
@@ -348,6 +348,7 @@ function FiltersSection({
           key={chip.action}
           agent={chip.action}
           tone={chip.active ? "primary" : "muted"}
+          variant={chip.active ? "solid" : "ghost"}
           pressed={chip.active}
           onPress={dispatch(chip.action)}
         >
@@ -430,6 +431,7 @@ function TransactionsSection({
               </Text>
               <Button
                 agent={`open-txn-${tx.id}`}
+                variant="ghost"
                 onPress={dispatch(`txn-${tx.id}`)}
               >
                 ›
@@ -479,6 +481,7 @@ function RecurringSection({
               <Text wrap={false}>{row.amount}</Text>
               <Button
                 agent={`open-bill-${row.id}`}
+                variant="ghost"
                 onPress={dispatch(`bill-${row.id}`)}
               >
                 ›

--- a/plugins/plugin-wifi/AGENTS.md
+++ b/plugins/plugin-wifi/AGENTS.md
@@ -33,7 +33,7 @@ src/
   register.ts           Side-effect entry — calls registerWifiApp() if isElizaOS()
   ui.ts                 UI barrel — re-exports WifiAppView + wifi-app helpers
   providers/
-    networks.ts         wifiNetworksProvider — calls WiFi.listAvailableNetworks, limit 25
+    networks.ts         wifiNetworksProvider — calls WiFi.listAvailableNetworks losslessly
   components/
     wifi-app.ts         wifiApp OverlayApp descriptor + registerWifiApp()
     WifiAppView.tsx     Full-screen React overlay UI (scan, connect, disconnect)
@@ -67,7 +67,9 @@ No env vars or settings keys. The plugin reads no process environment at runtime
 
 - **Android-only.** `WifiAppView` and `registerWifiApp()` are safe to import on non-Android platforms but `@elizaos/capacitor-wifi` methods will reject or return empty results everywhere except Android. The `register.ts` entry guards registration behind `isElizaOS()`.
 - **No server routes.** `WifiAppView` owns all its data by calling the Capacitor plugin directly; there is no backend API involved.
-- **Scan limit.** `wifiNetworksProvider` caps at 25 networks; `WifiAppView` caps its own scan at 50. Keep these consistent if raising the limit.
+- **Complete scans.** `wifiNetworksProvider` and `WifiAppView` omit the native
+  bridge's optional `limit`, so every deduplicated Android scan result remains
+  available to the planner and UI.
 - **Location permission.** Android requires `ACCESS_FINE_LOCATION` for `WifiManager.startScan`. If the permission is denied, scans succeed silently with an empty list or throw; the provider maps errors to `wifiNetworksError` in `values`.
 - **Provider context gate.** `wifiNetworksProvider` uses `contextGate: { anyOf: ["system"] }` — it only fires in system-context conversations, not every agent turn.
 - **`elizaos.app` metadata.** `package.json` carries an `elizaos.app` block (`displayName: "WiFi"`, `category: "system"`, `androidOnly: true`, `heroImage: "assets/hero.png"`) used by the app catalog tooling.

--- a/plugins/plugin-wifi/CLAUDE.md
+++ b/plugins/plugin-wifi/CLAUDE.md
@@ -33,7 +33,7 @@ src/
   register.ts           Side-effect entry — calls registerWifiApp() if isElizaOS()
   ui.ts                 UI barrel — re-exports WifiAppView + wifi-app helpers
   providers/
-    networks.ts         wifiNetworksProvider — calls WiFi.listAvailableNetworks, limit 25
+    networks.ts         wifiNetworksProvider — calls WiFi.listAvailableNetworks losslessly
   components/
     wifi-app.ts         wifiApp OverlayApp descriptor + registerWifiApp()
     WifiAppView.tsx     Full-screen React overlay UI (scan, connect, disconnect)
@@ -67,7 +67,9 @@ No env vars or settings keys. The plugin reads no process environment at runtime
 
 - **Android-only.** `WifiAppView` and `registerWifiApp()` are safe to import on non-Android platforms but `@elizaos/capacitor-wifi` methods will reject or return empty results everywhere except Android. The `register.ts` entry guards registration behind `isElizaOS()`.
 - **No server routes.** `WifiAppView` owns all its data by calling the Capacitor plugin directly; there is no backend API involved.
-- **Scan limit.** `wifiNetworksProvider` caps at 25 networks; `WifiAppView` caps its own scan at 50. Keep these consistent if raising the limit.
+- **Complete scans.** `wifiNetworksProvider` and `WifiAppView` omit the native
+  bridge's optional `limit`, so every deduplicated Android scan result remains
+  available to the planner and UI.
 - **Location permission.** Android requires `ACCESS_FINE_LOCATION` for `WifiManager.startScan`. If the permission is denied, scans succeed silently with an empty list or throw; the provider maps errors to `wifiNetworksError` in `values`.
 - **Provider context gate.** `wifiNetworksProvider` uses `contextGate: { anyOf: ["system"] }` — it only fires in system-context conversations, not every agent turn.
 - **`elizaos.app` metadata.** `package.json` carries an `elizaos.app` block (`displayName: "WiFi"`, `category: "system"`, `androidOnly: true`, `heroImage: "assets/hero.png"`) used by the app catalog tooling.

--- a/plugins/plugin-wifi/README.md
+++ b/plugins/plugin-wifi/README.md
@@ -17,7 +17,7 @@ This plugin is only functional on Android. The overlay app is registered in the 
 
 | Surface | Name | Description |
 |---------|------|-------------|
-| Provider | `wifiNetworks` | Dynamic provider gated to the `system` context (`contextGate: { anyOf: ["system"] }`); injects up to 25 nearby Wi-Fi networks when that context is selected for a turn. Fields per network: `ssid`, `bssid`, `rssi` (dBm), `frequency` (MHz), `secured` (boolean). |
+| Provider | `wifiNetworks` | Dynamic provider gated to the `system` context (`contextGate: { anyOf: ["system"] }`); injects every deduplicated nearby Wi-Fi network when that context is selected for a turn. Fields per network: `ssid`, `bssid`, `rssi` (dBm), `frequency` (MHz), `secured` (boolean). |
 | Overlay UI | WiFi | Full-screen app accessible from the elizaOS app catalog. Scan, view connected network, connect/disconnect. |
 
 ## Required permissions

--- a/plugins/plugin-wifi/src/components/WifiAppView.test.ts
+++ b/plugins/plugin-wifi/src/components/WifiAppView.test.ts
@@ -184,7 +184,7 @@ describe("WifiAppView — connected card", () => {
 });
 
 describe("WifiAppView — network list", () => {
-  it("sorts networks by descending rssi, slices to 12, shows '13 / 12 shown', and renders per-row data", async () => {
+  it("sorts and renders every returned network", async () => {
     mockDefaults();
     // 13 networks with rssi out of order so sort is observable.
     const rssis = [
@@ -202,16 +202,14 @@ describe("WifiAppView — network list", () => {
 
     renderView();
 
-    // Count badge for >12 networks.
-    expect(await screen.findByText("13 / 12 shown")).toBeTruthy();
+    expect(await screen.findByText("13")).toBeTruthy();
 
-    // Exactly 12 rows rendered (the 13th is sliced off).
     const rows = screen
       .getAllByRole("button")
       .filter((b) =>
         b.getAttribute("data-testid")?.startsWith("wifi-network-"),
       );
-    expect(rows).toHaveLength(12);
+    expect(rows).toHaveLength(13);
 
     // Descending rssi: read each row's "<bssid> · <rssi> dBm" line and parse the dBm.
     const rowRssis = rows.map((row) => {
@@ -220,9 +218,9 @@ describe("WifiAppView — network list", () => {
     });
     const sortedDesc = [...rowRssis].sort((a, b) => b - a);
     expect(rowRssis).toEqual(sortedDesc);
-    // Strongest (-41) first, weakest visible is the 12th-strongest (-88); -90 dropped.
+    // Strongest (-41) first and the weakest returned network remains visible.
     expect(rowRssis[0]).toBe(-41);
-    expect(rowRssis).not.toContain(-90);
+    expect(rowRssis.at(-1)).toBe(-90);
 
     // The -41 network is Net1 (index 1), which is secured:false (odd index) → Wifi icon, open.
     // Verify a specific row's ssid/bssid/rssi text is present.
@@ -284,7 +282,7 @@ describe("WifiAppView — network list", () => {
     ).toBeGreaterThanOrEqual(1);
   });
 
-  it("uses a plain '5' count badge (no '/ 12 shown') when 12 or fewer networks are present", async () => {
+  it("uses a plain count badge", async () => {
     mockDefaults();
     wifiBridge.listAvailableNetworks.mockResolvedValue({
       networks: [-40, -50, -60, -70, -80].map((rssi, i) =>
@@ -326,13 +324,11 @@ describe("WifiAppView — signalBars threshold mapping", () => {
 });
 
 describe("WifiAppView — controls", () => {
-  it("auto-scans on mount with limit 50", async () => {
+  it("auto-scans on mount without truncating the native result set", async () => {
     mockDefaults();
     renderView();
     await waitFor(() =>
-      expect(wifiBridge.listAvailableNetworks).toHaveBeenCalledWith({
-        limit: 50,
-      }),
+      expect(wifiBridge.listAvailableNetworks).toHaveBeenCalledWith(),
     );
   });
 

--- a/plugins/plugin-wifi/src/components/WifiAppView.tsx
+++ b/plugins/plugin-wifi/src/components/WifiAppView.tsx
@@ -40,8 +40,6 @@ interface SignalBarsProps {
   rssi: number;
 }
 
-const VISIBLE_NETWORK_LIMIT = 12;
-
 /**
  * Map dBm to a 0–4 bar count. Standard Android thresholds:
  *   >= -50  → 4 bars (excellent)
@@ -218,7 +216,7 @@ export function WifiAppView(props: OverlayAppContext) {
     setScanning(true);
     setError(null);
     try {
-      const result = await WiFi.listAvailableNetworks({ limit: 50 });
+      const result = await WiFi.listAvailableNetworks();
       setNetworks(result.networks);
       await refreshState();
     } catch (err) {
@@ -338,12 +336,7 @@ export function WifiAppView(props: OverlayAppContext) {
               <WifiIcon className="h-4 w-4 text-muted" />
               Networks
             </div>
-            <span className="text-xs text-muted">
-              {sortedNetworks.length}
-              {sortedNetworks.length > VISIBLE_NETWORK_LIMIT
-                ? ` / ${VISIBLE_NETWORK_LIMIT} shown`
-                : ""}
-            </span>
+            <span className="text-xs text-muted">{sortedNetworks.length}</span>
           </div>
           {sortedNetworks.length === 0 && !scanning ? (
             <div className="px-4 py-8 text-center">
@@ -375,7 +368,7 @@ export function WifiAppView(props: OverlayAppContext) {
             </div>
           ) : (
             <div className="flex flex-col gap-2">
-              {sortedNetworks.slice(0, VISIBLE_NETWORK_LIMIT).map((network) => (
+              {sortedNetworks.map((network) => (
                 <NetworkRow
                   key={`${network.bssid}-${network.ssid}`}
                   network={network}

--- a/plugins/plugin-wifi/src/providers/networks.test.ts
+++ b/plugins/plugin-wifi/src/providers/networks.test.ts
@@ -62,10 +62,7 @@ describe("wifiNetworksProvider — success mapping", () => {
 
     const result = await wifiNetworksProvider.get(runtime, message, state);
 
-    // Bridge called with the provider's own 25-network cap.
-    expect(wifiBridge.listAvailableNetworks).toHaveBeenCalledWith({
-      limit: 25,
-    });
+    expect(wifiBridge.listAvailableNetworks).toHaveBeenCalledWith();
 
     expect(result.data?.networks).toEqual([
       {
@@ -95,7 +92,7 @@ describe("wifiNetworksProvider — success mapping", () => {
     }
 
     expect(result.data?.count).toBe(2);
-    expect(result.data?.limit).toBe(25);
+    expect(result.data).not.toHaveProperty("limit");
     expect(result.values?.wifiNetworksAvailable).toBe(true);
     expect(result.values?.wifiNetworkCount).toBe(2);
     expect(result.values?.wifiNetworksError).toBeUndefined();
@@ -127,7 +124,7 @@ describe("wifiNetworksProvider — success mapping", () => {
 });
 
 describe("wifiNetworksProvider — error branch", () => {
-  it("maps a rejected scan to wifiNetworksError + empty networks + limit 25", async () => {
+  it("maps a rejected scan to wifiNetworksError and empty networks", async () => {
     wifiBridge.listAvailableNetworks.mockRejectedValue(
       new Error("ACCESS_FINE_LOCATION denied"),
     );
@@ -142,7 +139,7 @@ describe("wifiNetworksProvider — error branch", () => {
     );
     expect(result.data?.networks).toEqual([]);
     expect(result.data?.count).toBe(0);
-    expect(result.data?.limit).toBe(25);
+    expect(result.data).not.toHaveProperty("limit");
     expect(result.data?.error).toBe("ACCESS_FINE_LOCATION denied");
   });
 

--- a/plugins/plugin-wifi/src/providers/networks.ts
+++ b/plugins/plugin-wifi/src/providers/networks.ts
@@ -16,8 +16,6 @@ import type {
   State,
 } from "@elizaos/core";
 
-const WIFI_NETWORKS_LIMIT = 25;
-
 interface WifiNetworkEntry {
   ssid: string;
   bssid: string;
@@ -44,9 +42,7 @@ export const wifiNetworksProvider: Provider = {
     _state: State,
   ): Promise<ProviderResult> => {
     try {
-      const { networks } = await WiFi.listAvailableNetworks({
-        limit: WIFI_NETWORKS_LIMIT,
-      });
+      const { networks } = await WiFi.listAvailableNetworks();
       const entries: WifiNetworkEntry[] = networks.map((n: WiFiNetwork) => ({
         ssid: n.ssid,
         bssid: n.bssid,
@@ -69,7 +65,6 @@ export const wifiNetworksProvider: Provider = {
         data: {
           networks: entries,
           count: entries.length,
-          limit: WIFI_NETWORKS_LIMIT,
         },
       };
     } catch (error) {
@@ -84,7 +79,6 @@ export const wifiNetworksProvider: Provider = {
         data: {
           networks: [],
           count: 0,
-          limit: WIFI_NETWORKS_LIMIT,
           error: message,
         },
       };


### PR DESCRIPTION
Closes #24216

## Summary
- remove silent size/count truncation from assistant text, streamed chat rendering, permission payload parsing, documents, speech playback, model choices, custom-action names, browser results, Cloud app/model inventories, relevant documents, and Wi-Fi results
- preserve full browser bridge action results and scan every open tab instead of fixed prefixes
- repair browser/finance/cockpit visual audit states and make OCR expectations semantic rather than fragile to dim secondary labels
- extend the repository content-integrity policy so these app/runtime seams cannot silently reintroduce fixed budgets

## Verification
- `bun run --cwd packages/app audit:app:capture`: 231 passed; 0 broken, 0 needs-work, 0 minimalism budget/ratchet failures
- `ELIZA_MVP_OCR_ENGINE=packaged bun run --cwd packages/app audit:ocr`: 228 views; 211 verified; 0 broken; 17 existing manual-review cases
- changed UI focus: 201 passed
- agent chat augmentation/text helpers: 20 passed
- shared: 2,222 passed
- plugin-browser: 284 passed
- plugin-cloud-apps: 367 passed
- plugin-finances: 143 passed
- plugin-wifi: 38 passed
- repository prompt-integrity policy: 3 passed
- all touched package typechecks and targeted Biome checks pass
- `bun run check:agents-claude`: 160 pairs pass

## Current develop baseline
- `bun run verify` reaches Turbo and then fails on the pre-existing `packages/ui/src/components/chat/widgets/maps-card.tsx` formatting error (plus existing cookie warnings); no touched file is implicated
- the complete UI lane ran 11,434 tests: 11,404 passed, 7 skipped, and 23 unrelated existing failures across Cloud auth, Steward mocks, wallet timing, source/focus guards, and stale contracts
- app-wide typecheck is independently blocked by the existing missing `postApiV1ElizaPlaidRevokeRaw` generated-client method
