### PR TITLE
fix(runtime): let the model own app launch replies

### DIFF
--- a/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
+++ b/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
@@ -150,7 +150,7 @@ describe("POST /api/views/:id/navigate broadcast contract", () => {
     );
   });
 
-  it("records originating-client navigation without broadcasting to unrelated shells", async () => {
+  it("keeps originating-client navigation out of global state and unrelated shells", async () => {
     const { ctx, json, broadcastWs } = makeNavigateCtx("notes", {
       delivery: "originating-client",
     });
@@ -158,10 +158,7 @@ describe("POST /api/views/:id/navigate broadcast contract", () => {
     await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
 
     expect(broadcastWs).not.toHaveBeenCalled();
-    expect(getCurrentViewState()).toMatchObject({
-      viewId: "notes",
-      source: "agent",
-    });
+    expect(getCurrentViewState()).toBeNull();
     expect(json).toHaveBeenCalledWith(
       ctx.res,
       expect.objectContaining({ ok: true, viewId: "notes" }),
@@ -191,7 +188,7 @@ describe("POST /api/views/:id/navigate broadcast contract", () => {
     );
     expect(getCurrentViewState()).toMatchObject({
       viewId: "calendar",
-      source: "agent",
+      viewPath: null,
     });
     expect(json).toHaveBeenCalledWith(
       ctx.res,
@@ -269,6 +266,52 @@ describe("POST /api/views/:id/navigate broadcast contract", () => {
         completedActionDelivered: false,
       }),
     );
+    expect(getCurrentViewState()).toMatchObject({
+      viewId: "notes",
+      viewPath: null,
+    });
+  });
+
+  it("does not let concurrent caller-owned Browser paths overwrite shared state", async () => {
+    const shared = makeNavigateCtx("settings", {});
+    await expect(handleViewsRoutes(shared.ctx)).resolves.toBe(true);
+
+    const first = makeNavigateCtx("browser", {
+      clientId: "client-one",
+      delivery: "completed-action",
+      completedActionHandoffId: "handoff-one",
+      path: "/browser?browse=https%3A%2F%2Fone.example%2Fprivate",
+    });
+    const second = makeNavigateCtx("browser", {
+      clientId: "client-two",
+      delivery: "completed-action",
+      completedActionHandoffId: "handoff-two",
+      path: "/browser?browse=https%3A%2F%2Ftwo.example%2Fprivate",
+    });
+
+    await Promise.all([
+      handleViewsRoutes(first.ctx),
+      handleViewsRoutes(second.ctx),
+    ]);
+
+    expect(first.broadcastWsToClientId).toHaveBeenCalledWith(
+      "client-one",
+      expect.objectContaining({
+        viewPath: "/browser?browse=https%3A%2F%2Fone.example%2Fprivate",
+      }),
+    );
+    expect(second.broadcastWsToClientId).toHaveBeenCalledWith(
+      "client-two",
+      expect.objectContaining({
+        viewPath: "/browser?browse=https%3A%2F%2Ftwo.example%2Fprivate",
+      }),
+    );
+    expect(getCurrentViewState()).toMatchObject({
+      viewId: "browser",
+      viewPath: "/browser",
+    });
+    expect(JSON.stringify(getCurrentViewState())).not.toContain("one.example");
+    expect(JSON.stringify(getCurrentViewState())).not.toContain("two.example");
   });
 
   it("delivers app-chat navigation only to its originating client", async () => {

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -1155,9 +1155,15 @@ export async function handleViewsRoutes(
     // Clear the active-view context on close instead; the next real navigation
     // re-stamps it.
     const isCloseNavigation = action === "close" || action === "close-all";
-    if (isCloseNavigation) {
-      clearCurrentViewState();
-    } else {
+    // Caller-owned delivery is private renderer state. Recording it in the
+    // process-global current-view/provider context would leak one client's
+    // deep link to other clients and leave ghost state when its socket is stale.
+    // The targeted frame or completed action is the only commit edge for it.
+    const commitCurrentViewState = (committedViewPath: string | null) => {
+      if (isCloseNavigation) {
+        clearCurrentViewState();
+        return;
+      }
       const now = new Date().toISOString();
       const source = reportedSource;
       // Stamp `switchedAt` only when the view actually changes; a re-navigate to
@@ -1169,7 +1175,7 @@ export async function handleViewsRoutes(
         : (currentViewState?.switchedAt ?? now);
       currentViewState = {
         viewId: id,
-        viewPath,
+        viewPath: committedViewPath,
         viewLabel,
         viewType: resolvedViewType,
         ...(action ? { action } : {}),
@@ -1186,7 +1192,7 @@ export async function handleViewsRoutes(
         viewId: id,
         viewLabel,
         viewType: resolvedViewType,
-        viewPath,
+        viewPath: committedViewPath,
         // Carry freshness so Stage-1 can acknowledge a just-happened switch (#8788).
         ...(switchedAt ? { switchedAt } : {}),
         ...(source ? { source } : {}),
@@ -1201,7 +1207,7 @@ export async function handleViewsRoutes(
             source: `view-navigate:${source}`,
             viewId: id,
             viewLabel,
-            viewPath,
+            viewPath: committedViewPath,
             viewType: resolvedViewType,
             previousViewId,
             initiatedBy: source,
@@ -1220,6 +1226,15 @@ export async function handleViewsRoutes(
             );
           });
       }
+    };
+    const committedViewPath = callerOwnedDelivery
+      ? (entry?.path ?? null)
+      : viewPath;
+    // completed-action has a caller-scoped terminal fallback, so sanitized
+    // canonical state can commit immediately. Voice/originating-client has no
+    // fallback and commits only after its targeted renderer accepts delivery.
+    if (body?.delivery !== "originating-client") {
+      commitCurrentViewState(committedViewPath);
     }
 
     // Realtime voice returns navigation through its own control channel. App
@@ -1234,6 +1249,7 @@ export async function handleViewsRoutes(
       ? normalizeCompletedActionHandoffId(body?.completedActionHandoffId)
       : undefined;
     let completedActionDelivered = false;
+    let originatingClientDelivered = false;
     if (
       reportedSource !== "user" &&
       (!callerOwnedDelivery || shouldTargetCompletedAction)
@@ -1284,9 +1300,17 @@ export async function handleViewsRoutes(
           );
           return true;
         }
+        originatingClientDelivered =
+          !shouldTargetCompletedAction &&
+          typeof delivered === "number" &&
+          delivered > 0;
       } else {
         ctx.broadcastWs?.(frame);
       }
+    }
+
+    if (body?.delivery === "originating-client" && originatingClientDelivered) {
+      commitCurrentViewState(committedViewPath);
     }
 
     json(res, {

--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -1431,6 +1431,109 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		).toMatchObject({ tool: { name: "VIEWS", success: true } });
 	});
 
+	it("lets the model write the final reply after a deterministic tool completes", async () => {
+		let appCalls = 0;
+		const modelReply =
+			"Done — I opened [Nubs Color Pebble](/api/apps/local/nubs-color-pebble/) for you.";
+		const app = makeMockAction({
+			name: "APP",
+			suppressEarlyReply: true,
+			parameters: [
+				{
+					name: "action",
+					description: "App operation",
+					required: true,
+					schema: { type: "string" },
+				},
+				{
+					name: "app",
+					description: "Installed app name",
+					required: true,
+					schema: { type: "string" },
+				},
+			],
+			handler: async () => {
+				appCalls++;
+				return {
+					success: true,
+					text: '{"effect":"app_launch","status":"completed"}',
+					transcriptVisibility: "internal",
+					modelReplyRequired: true,
+					promptData: {
+						operation: "launch_app",
+						outcome: "success",
+						displayName: "Nubs Color Pebble",
+						link: {
+							label: "Open Nubs Color Pebble",
+							href: "/api/apps/local/nubs-color-pebble/",
+						},
+					},
+				};
+			},
+		});
+		const evaluator = {
+			name: "test.force_deterministic_app_launch",
+			priority: 10,
+			deterministicActions: ["APP"],
+			shouldRun: () => true,
+			evaluate: () => ({
+				requiresTool: true,
+				clearReply: true,
+				deterministicToolCall: {
+					name: "APP",
+					params: { action: "launch", app: "nubs-color-pebble" },
+				},
+			}),
+		} satisfies import("../runtime/response-handler-evaluators").ResponseHandlerEvaluator;
+		const runtime = makeRuntime({
+			actions: [app],
+			responseHandlerEvaluators: [evaluator],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({
+						contexts: ["general"],
+						replyText: "Opening that now.",
+					}),
+				},
+				{
+					expectModelType: ModelType.ACTION_PLANNER,
+					body: { text: modelReply, toolCalls: [] },
+				},
+			],
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("open Nubs Color Pebble"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		expect(appCalls).toBe(1);
+		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
+			ModelType.RESPONSE_HANDLER,
+			ModelType.ACTION_PLANNER,
+		]);
+		expect(
+			(getCalls(runtime)[1]?.params as Record<string, unknown>)?.tools,
+		).toBeUndefined();
+		expect(JSON.stringify(getCalls(runtime)[1]?.params)).toContain(
+			"already settled and complete",
+		);
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(modelReply);
+			expect(result.result.actionResults).toMatchObject([
+				{
+					success: true,
+					text: '{"effect":"app_launch","status":"completed"}',
+					transcriptVisibility: "internal",
+				},
+			]);
+		}
+	});
+
 	it("executes an owner-only deterministic call through the canonical gates without planning", async () => {
 		let calls = 0;
 		const ownerAction = makeMockAction({

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -3748,6 +3748,143 @@ describe("v5 planner loop — evaluator gate", () => {
 		).toBe("post_tool_model_reply");
 	});
 
+	it("falls back to the settled action when post-tool synthesis has a provider outage", async () => {
+		const providerError = Object.assign(new Error("provider unavailable"), {
+			statusCode: 503,
+		});
+		const useModel = vi
+			.fn()
+			.mockResolvedValueOnce({
+				text: "",
+				toolCalls: [
+					{
+						id: "app-1",
+						name: "APP",
+						arguments: { action: "launch", [TURN_SCOPE_ARG]: TURN_SCOPE_FINAL },
+					},
+				],
+			})
+			.mockRejectedValueOnce(providerError);
+
+		const result = await runPlannerLoop({
+			runtime: { useModel, logger: { warn: vi.fn() } },
+			context: { id: "ctx" },
+			tools: [{ name: "APP", description: "Launch an app." }],
+			executeToolCall: vi.fn(async () => ({
+				success: true,
+				text: '{"effect":"app_launch","status":"completed"}',
+				modelReplyFallback:
+					"The app launched successfully. [Open the app](http://127.0.0.1:3000/api/apps/local/demo/)",
+				modelReplyRequired: true,
+			})),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.finalMessage).toContain("The app launched successfully.");
+		expect(useModel).toHaveBeenCalledTimes(2);
+	});
+
+	it("falls back without replaying a directly seeded settled action on provider outage", async () => {
+		const providerError = Object.assign(new Error("provider unavailable"), {
+			statusCode: 503,
+		});
+		const executeToolCall = vi.fn();
+		const result = await runPlannerLoop({
+			runtime: {
+				useModel: vi.fn().mockRejectedValue(providerError),
+				logger: { warn: vi.fn() },
+			},
+			context: { id: "ctx" },
+			postToolReplySeed: {
+				toolCall: {
+					id: "app-settled",
+					name: "APP",
+					arguments: { action: "launch" },
+				},
+				result: {
+					success: true,
+					text: '{"effect":"app_launch","status":"completed"}',
+					modelReplyRequired: true,
+					modelReplyFallback:
+						"The app launched successfully. [Open the app](/api/apps/local/demo/)",
+				},
+			},
+			executeToolCall,
+			evaluate: vi.fn(),
+		});
+
+		expect(result.finalMessage).toBe(
+			"The app launched successfully. [Open the app](/api/apps/local/demo/)",
+		);
+		expect(executeToolCall).not.toHaveBeenCalled();
+	});
+
+	it("does not hide programmer errors during post-tool synthesis", async () => {
+		const useModel = vi
+			.fn()
+			.mockResolvedValueOnce({
+				text: "",
+				toolCalls: [
+					{
+						id: "app-1",
+						name: "APP",
+						arguments: { action: "launch", [TURN_SCOPE_ARG]: TURN_SCOPE_FINAL },
+					},
+				],
+			})
+			.mockRejectedValueOnce(new TypeError("broken planner adapter"));
+
+		await expect(
+			runPlannerLoop({
+				runtime: { useModel },
+				context: { id: "ctx" },
+				tools: [{ name: "APP", description: "Launch an app." }],
+				executeToolCall: vi.fn(async () => ({
+					success: true,
+					text: "internal receipt",
+					userFacingText: "The app launched successfully.",
+					modelReplyRequired: true,
+				})),
+				evaluate: vi.fn(),
+			}),
+		).rejects.toThrow("broken planner adapter");
+	});
+
+	it.each([
+		'{"effect":"app_launch","status":"completed"}',
+		"The tool executed successfully.",
+		"Opening that now.",
+	])("rejects unsafe post-tool synthesis prose: %s", async (synthesisText) => {
+		const useModel = vi
+			.fn()
+			.mockResolvedValueOnce({
+				text: "",
+				toolCalls: [
+					{
+						id: "app-1",
+						name: "APP",
+						arguments: { action: "launch", [TURN_SCOPE_ARG]: TURN_SCOPE_FINAL },
+					},
+				],
+			})
+			.mockResolvedValueOnce({ text: synthesisText, toolCalls: [] });
+
+		const result = await runPlannerLoop({
+			runtime: { useModel },
+			context: { id: "ctx" },
+			tools: [{ name: "APP", description: "Launch an app." }],
+			executeToolCall: vi.fn(async () => ({
+				success: true,
+				text: '{"effect":"app_launch","status":"completed"}',
+				userFacingText: "The app launched successfully.",
+				modelReplyRequired: true,
+			})),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.finalMessage).toBe("The app launched successfully.");
+	});
+
 	it("fails closed on a required-reply synthesis that invents a tool call, routing the completed action through the evaluator (#22609)", async () => {
 		const useModel = vi
 			.fn()

--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -395,6 +395,9 @@ export function projectActionResultForClipboard(
 		...(result.modelReplyRequired !== undefined
 			? { modelReplyRequired: result.modelReplyRequired }
 			: {}),
+		...(result.modelReplyFallback !== undefined
+			? { modelReplyFallback: result.modelReplyFallback }
+			: {}),
 		...(result.continueChain !== undefined
 			? { continueChain: result.continueChain }
 			: {}),
@@ -440,6 +443,9 @@ function projectSettledResultForObserver(
 			: {}),
 		...(projected.modelReplyRequired !== undefined
 			? { modelReplyRequired: projected.modelReplyRequired }
+			: {}),
+		...(projected.modelReplyFallback !== undefined
+			? { modelReplyFallback: projected.modelReplyFallback }
 			: {}),
 		...(projected.continueChain !== undefined
 			? { continueChain: projected.continueChain }
@@ -1084,6 +1090,7 @@ function actionResultToStreamingResult(
 				: result.values,
 		turnComplete: result.turnComplete,
 		modelReplyRequired: result.modelReplyRequired,
+		modelReplyFallback: result.modelReplyFallback,
 		continueChain: result.continueChain,
 	};
 	return actionResultToContentRecord(streamingResult, redactDiagnosticText);

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -386,9 +386,37 @@ async function runPlannerLoopIterations(
 				}
 			: merged;
 	})();
+	const postToolReplySeed = params.postToolReplySeed;
+	if (
+		postToolReplySeed &&
+		(postToolReplySeed.result.success !== true ||
+			postToolReplySeed.result.modelReplyRequired !== true)
+	) {
+		throw new Error(
+			"postToolReplySeed requires a successful result with modelReplyRequired",
+		);
+	}
+	const trajectoryContext = postToolReplySeed
+		? appendContextEvent(plannerContext, {
+				id: "post-tool-model-reply",
+				type: "instruction",
+				source: "planner-loop",
+				createdAt: Date.now(),
+				content:
+					"The tool result in this turn is already settled and complete. Write the final user-facing reply in the agent's natural voice from that result. Do not describe the work as starting, opening now, pending, or still in progress. If the result provides a link object, include it as a Markdown link using its label and href. Do not expose internal IDs or raw tool data.",
+			})
+		: plannerContext;
 	const trajectory: PlannerTrajectory = {
-		context: plannerContext,
-		steps: [],
+		context: trajectoryContext,
+		steps: postToolReplySeed
+			? [
+					{
+						iteration: 0,
+						toolCall: postToolReplySeed.toolCall,
+						result: postToolReplySeed.result,
+					},
+				]
+			: [],
 		archivedSteps: [],
 		plannedQueue: [],
 		evaluatorOutputs: [],
@@ -500,7 +528,7 @@ async function runPlannerLoopIterations(
 	// reply after its effect completes. This is deliberately narrower than the
 	// evaluator's general CONTINUE path: only an explicit final-scope tool call
 	// can arm it, and any subsequent tool call disarms it.
-	let pendingRequiredModelReply = false;
+	let pendingRequiredModelReply = postToolReplySeed !== undefined;
 	// Captures the most recent terminal-only refusal text the planner produced
 	// across iterations gated by `requireNonTerminalToolCall`. When Stage 1
 	// asserts `requiresTool=true` but no exposed tool can fulfill the request,

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -624,41 +624,66 @@ async function runPlannerLoopIterations(
 					return await callPlanner(args);
 				}
 			};
-			const plannerOutput = await callPlannerWithToolChoiceRetry({
-				runtime: params.runtime,
-				context: trajectory.context,
-				trajectory,
-				config,
-				modelType: params.modelType,
-				provider: params.provider,
-				// A successful final-scope action may ask for one natural closing
-				// sentence. That round is synthesis, not planning: remove the tool
-				// catalog entirely so callPlanner cannot default an omitted toolChoice
-				// to "required" and re-run the action. The branch below consumes this
-				// output exactly once, including when a non-compliant provider invents
-				// a tool call despite receiving no tools.
-				tools: synthesizingRequiredModelReply ? undefined : params.tools,
-				// Force a tool call ONLY while the turn's "use a real tool" requirement
-				// is still unmet. Once a non-terminal tool has executed, relax to
-				// "auto" so the planner is free to synthesize a terminal REPLY from
-				// the result instead of being pushed to re-call a tool every
-				// iteration. "auto" must be EXPLICIT: passing the caller's (undefined)
-				// choice would be a no-op because callPlanner defaults undefined back
-				// to "required".
-				toolChoice: synthesizingRequiredModelReply
-					? undefined
-					: requireNonTerminalToolCall
-						? hasExecutedNonTerminalTool(trajectory)
-							? "auto"
-							: "required"
-						: params.toolChoice,
-				recorder: params.recorder,
-				trajectoryId: params.trajectoryId,
-				parentStageId: params.parentStageId,
-				providerAttributionState: params.providerAttributionState,
-				iteration,
-				onUsage: observePlannerUsage,
-			});
+			let plannerOutput: Awaited<
+				ReturnType<typeof callPlannerWithToolChoiceRetry>
+			>;
+			try {
+				plannerOutput = await callPlannerWithToolChoiceRetry({
+					runtime: params.runtime,
+					context: trajectory.context,
+					trajectory,
+					config,
+					modelType: params.modelType,
+					provider: params.provider,
+					// A successful final-scope action may ask for one natural closing
+					// sentence. That round is synthesis, not planning: remove the tool
+					// catalog entirely so callPlanner cannot default an omitted toolChoice
+					// to "required" and re-run the action. The branch below consumes this
+					// output exactly once, including when a non-compliant provider invents
+					// a tool call despite receiving no tools.
+					tools: synthesizingRequiredModelReply ? undefined : params.tools,
+					// Force a tool call ONLY while the turn's "use a real tool" requirement
+					// is still unmet. Once a non-terminal tool has executed, relax to
+					// "auto" so the planner is free to synthesize a terminal REPLY from
+					// the result instead of being pushed to re-call a tool every
+					// iteration. "auto" must be EXPLICIT: passing the caller's (undefined)
+					// choice would be a no-op because callPlanner defaults undefined back
+					// to "required".
+					toolChoice: synthesizingRequiredModelReply
+						? undefined
+						: requireNonTerminalToolCall
+							? hasExecutedNonTerminalTool(trajectory)
+								? "auto"
+								: "required"
+							: params.toolChoice,
+					recorder: params.recorder,
+					trajectoryId: params.trajectoryId,
+					parentStageId: params.parentStageId,
+					providerAttributionState: params.providerAttributionState,
+					iteration,
+					onUsage: observePlannerUsage,
+				});
+			} catch (err) {
+				// error-policy:J4 the sole tool already committed; an expected model
+				// provider outage degrades to its vetted action-owned fallback without replay.
+				if (!synthesizingRequiredModelReply || !isModelProviderError(err)) {
+					throw err;
+				}
+				const relay = deterministicSuccessfulToolRelay(trajectory);
+				if (!relay) throw err;
+				params.runtime.logger?.warn?.(
+					{ iteration, err: err instanceof Error ? err.message : String(err) },
+					"[planner-loop] post-tool reply model failed; relaying completed action result",
+				);
+				return {
+					status: "finished",
+					trajectory,
+					finalMessage: userSafeFinalMessage(
+						terminalMessageWithFailureAuthority(trajectory, relay),
+						trajectory,
+					),
+				};
+			}
 			// Treat `messageToUser` as authoritative ONLY when the planner's structured
 			// output carried it as an explicit field. The native-tool-call code path
 			// in `parsePlannerOutput` falls back to `raw.text`, but in native mode
@@ -800,8 +825,18 @@ async function runPlannerLoopIterations(
 				const requiredModelReply = userSafeCapturedAnswerCandidate(
 					plannerOutput.messageToUser,
 				);
-				const finalMessage =
-					requiredModelReply ?? REQUIRED_MODEL_REPLY_FALLBACK_MESSAGE;
+				const finalMessage = userSafeFinalMessage(
+					terminalMessageWithFailureAuthority(
+						trajectory,
+						preferredFinalMessageFromToolOrModel(
+							trajectory,
+							requiredModelReply,
+							deterministicSuccessfulToolRelay(trajectory) ??
+								REQUIRED_MODEL_REPLY_FALLBACK_MESSAGE,
+						),
+					),
+					trajectory,
+				);
 				trajectory.steps.push({
 					iteration,
 					thought: plannerOutput.thought,
@@ -4812,7 +4847,11 @@ function deterministicSuccessfulToolRelay(
 	for (const step of [...trajectory.steps].reverse()) {
 		if (!step.toolCall || step.result?.success !== true) continue;
 		if (isTerminalToolCall(step.toolCall)) continue;
-		const candidate = getNonEmptyString(step.result.userFacingText);
+		const candidate =
+			getNonEmptyString(step.result.userFacingText) ??
+			(step.result.modelReplyRequired === true
+				? getNonEmptyString(step.result.modelReplyFallback)
+				: undefined);
 		if (candidate) return candidate;
 	}
 	return undefined;
@@ -6062,6 +6101,7 @@ export function actionResultToPlannerToolResult(
 		failureProvenance: result.failureProvenance,
 		turnComplete: result.turnComplete,
 		modelReplyRequired: result.modelReplyRequired,
+		modelReplyFallback: result.modelReplyFallback,
 		continueChain: result.continueChain,
 	};
 	if (options.summary) {

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -205,6 +205,8 @@ export interface PlannerToolResult {
 	 * action whose planner call explicitly declared final scope.
 	 */
 	modelReplyRequired?: boolean;
+	/** Vetted action-owned fallback for a failed required model synthesis. */
+	modelReplyFallback?: string;
 	/**
 	 * Explicit chain-control override. `false` unconditionally aborts the
 	 * remaining planner queue, including for legacy failure and fire-and-forget

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -262,6 +262,15 @@ export interface PlannerLoopResult {
 export interface PlannerLoopParams {
 	runtime: PlannerRuntime;
 	context: ContextObject;
+	/**
+	 * A sole tool result that already completed outside the planner loop and
+	 * explicitly requested a model-authored final reply. The loop starts from
+	 * this settled step and performs only the guarded no-tools synthesis round.
+	 */
+	postToolReplySeed?: {
+		toolCall: PlannerToolCall;
+		result: PlannerToolResult;
+	};
 	config?: Partial<ChainingLoopConfig>;
 	executeToolCall: (
 		toolCall: PlannerToolCall,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9431,6 +9431,41 @@ export async function runV5MessageRuntimeStage1(args: {
 					}
 				}
 
+				if (
+					!callbackDelivered &&
+					result.success === true &&
+					result.modelReplyRequired === true
+				) {
+					return runPlannerLoop({
+						runtime: plannerRuntime,
+						context: plannerContextAfterEarlyReply,
+						config: args.plannerLoopConfig,
+						postToolReplySeed: { toolCall, result },
+						executeToolCall: () => {
+							throw new Error(
+								"Post-tool reply synthesis cannot execute another tool",
+							);
+						},
+						evaluate: ({
+							runtime: plannerRuntimeForEval,
+							context,
+							trajectory,
+						}) =>
+							runEvaluator({
+								runtime: plannerRuntimeForEval,
+								context,
+								trajectory,
+								effects: evaluatorEffects,
+								recorder,
+								trajectoryId,
+							}),
+						evaluatorEffects,
+						recorder,
+						trajectoryId,
+						providerAttributionState: plannerState,
+					});
+				}
+
 				const reportableResultText = result.userFacingText?.trim();
 				const finalMessage =
 					!callbackDelivered &&

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -1021,9 +1021,12 @@ export interface ActionResult {
 	 * incomplete planner scope retain the normal evaluator path.
 	 *
 	 * Use for UI effects whose wording must remain model-owned (for example,
-	 * navigation). Do not pair it with canned `userFacingText`.
+	 * navigation). Do not pair it with canned `userFacingText`; use the narrowly
+	 * vetted `modelReplyFallback` only for provider-outage recovery.
 	 */
 	modelReplyRequired?: boolean;
+	/** Safe action-owned prose used only if required model synthesis is unavailable. */
+	modelReplyFallback?: string;
 
 	/**
 	 * Explicit chain-control override. `false` aborts the remaining planner queue

--- a/packages/ui/src/completed-action-navigation.test.ts
+++ b/packages/ui/src/completed-action-navigation.test.ts
@@ -87,6 +87,40 @@ describe("completed action navigation", () => {
     window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
   });
 
+  it("delivers an APP launch Browser fallback through the same renderer dedupe path", () => {
+    const listener = vi.fn((event: Event) => {
+      markCompletedActionNavigationHandled(
+        event,
+        (event as CustomEvent).detail,
+      );
+    });
+    window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
+
+    const delivered = dispatchViewActionHandoffDirect([
+      {
+        actionName: "APP",
+        success: true,
+        values: {
+          mode: "launch",
+          viewId: "browser",
+          viewPath: "/browser?browse=%2Fapi%2Fapps%2Flocal%2Fdemo%2F",
+          completedActionHandoffId: "handoff-app-browser",
+        },
+      },
+    ]);
+
+    expect(delivered).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+    const event = listener.mock.calls[0]?.[0];
+    if (!event) throw new Error("expected Browser navigation event");
+    expect((event as CustomEvent).detail).toMatchObject({
+      viewId: "browser",
+      viewPath: "/browser?browse=%2Fapi%2Fapps%2Flocal%2Fdemo%2F",
+      completedActionHandoffId: "handoff-app-browser",
+    });
+    window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
+  });
+
   it.each([
     ["WebSocket-first", websocketDelivery, terminalDelivery],
     ["terminal-first", terminalDelivery, websocketDelivery],

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.chrome.test.tsx
@@ -21,6 +21,14 @@ const walletStateHarness = vi.hoisted(() => ({
   plugins: [] as Array<{ name: string }>,
 }));
 
+const apiBaseHarness = vi.hoisted(() => ({
+  base: "https://remote-agent.example/api-root",
+}));
+
+vi.mock("../../utils/asset-url", () => ({
+  resolveApiUrl: (path: string) => `${apiBaseHarness.base}${path}`,
+}));
+
 vi.mock("../../state", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../state")>();
   const state = {
@@ -86,7 +94,10 @@ vi.mock("../../api", async (importOriginal) => {
 
 import { client } from "../../api";
 import { shellHistory } from "../../surface-realm-channel";
-import { BrowserWorkspaceView } from "./BrowserWorkspaceView";
+import {
+  BrowserWorkspaceView,
+  normalizeBrowserWorkspaceInputUrl,
+} from "./BrowserWorkspaceView";
 import {
   BROWSER_WALLET_READY_TYPE,
   BROWSER_WALLET_REQUEST_TYPE,
@@ -167,6 +178,36 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+});
+
+describe("Browser workspace URL normalization", () => {
+  const translate = (key: string, vars?: Record<string, unknown>): string =>
+    String(vars?.defaultValue ?? key);
+
+  it("resolves local app paths against the active remote agent API base", () => {
+    expect(
+      normalizeBrowserWorkspaceInputUrl("/api/apps/local/demo/", translate),
+    ).toBe("https://remote-agent.example/api-root/api/apps/local/demo/");
+  });
+
+  it("preserves external http(s) and adds https to a schemeless host", () => {
+    expect(
+      normalizeBrowserWorkspaceInputUrl("https://example.com/a", translate),
+    ).toBe("https://example.com/a");
+    expect(normalizeBrowserWorkspaceInputUrl("example.com/a", translate)).toBe(
+      "https://example.com/a",
+    );
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "data:text/html,no",
+    "http://[",
+    "//evil.example/path",
+    "/\\evil.example/path",
+  ])("rejects an unsafe or malformed target: %s", (url) => {
+    expect(() => normalizeBrowserWorkspaceInputUrl(url, translate)).toThrow();
+  });
 });
 
 describe("BrowserWorkspaceView fullscreen chrome (Notes/Calendar parity)", () => {

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -43,6 +43,7 @@ import { deriveSurfacePlacement } from "../../surface/native-surface-shell";
 import { useMobileNativeTabSurfaces } from "../../surface/use-mobile-native-tab-surfaces";
 import { resolveBrowserTabRenderPath } from "../../surface-embedding";
 import { openExternalUrl } from "../../utils";
+import { resolveApiUrl } from "../../utils/asset-url";
 import {
   BROWSER_TAB_PRELOAD_SCRIPT,
   setBrowserTabsRendererImpl,
@@ -309,17 +310,26 @@ function isBrowserWorkspaceSessionMode(
   return mode === "cloud";
 }
 
-function normalizeBrowserWorkspaceInputUrl(
+export function normalizeBrowserWorkspaceInputUrl(
   rawUrl: string,
   t: TranslateFn,
 ): string | null {
   const trimmed = rawUrl.trim();
   if (!trimmed) return null;
   if (trimmed === "about:blank") return trimmed;
+  if (/^\/[\\/]/.test(trimmed)) {
+    throw new Error(
+      t("browserworkspace.InvalidUrl", {
+        defaultValue: "Enter a valid http or https URL.",
+      }),
+    );
+  }
 
-  const candidate = /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed)
-    ? trimmed
-    : `https://${trimmed}`;
+  const candidate = trimmed.startsWith("/")
+    ? new URL(resolveApiUrl(trimmed), window.location.origin).toString()
+    : /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed)
+      ? trimmed
+      : `https://${trimmed}`;
 
   let parsed: URL;
   try {

--- a/packages/ui/src/view-action-handoff.test.ts
+++ b/packages/ui/src/view-action-handoff.test.ts
@@ -75,6 +75,37 @@ describe("view action handoff", () => {
     });
   });
 
+  it("accepts only a successful APP launch handoff addressed to Browser", () => {
+    expect(
+      findViewActionHandoff([
+        {
+          actionName: "APP",
+          success: true,
+          values: {
+            mode: "launch",
+            viewId: "browser",
+            viewPath: "/browser?browse=%2Fapi%2Fapps%2Flocal%2Fdemo%2F",
+            completedActionHandoffId: "handoff-app",
+          },
+        },
+      ]),
+    ).toEqual({
+      viewId: "browser",
+      viewPath: "/browser?browse=%2Fapi%2Fapps%2Flocal%2Fdemo%2F",
+      completedActionHandoffId: "handoff-app",
+    });
+
+    expect(
+      findViewActionHandoff([
+        {
+          actionName: "APP",
+          success: true,
+          values: { mode: "launch", viewId: "wallet", viewPath: "/wallet" },
+        },
+      ]),
+    ).toBeNull();
+  });
+
   it("ignores inherited handoff fields and delivery confirmations", () => {
     const inheritedMarker = Object.assign(
       Object.create({ completedActionDelivered: true }),

--- a/packages/ui/src/view-action-handoff.ts
+++ b/packages/ui/src/view-action-handoff.ts
@@ -56,16 +56,20 @@ export function findViewActionHandoff(
   if (!Array.isArray(actionResults)) return null;
   for (let index = actionResults.length - 1; index >= 0; index--) {
     const result = actionResults[index];
-    if (
-      readOwnValue(result, "success") !== true ||
-      readString(readOwnValue(result, "actionName"))?.toUpperCase() !== "VIEWS"
-    ) {
+    if (readOwnValue(result, "success") !== true) {
       continue;
     }
+    const actionName = readString(
+      readOwnValue(result, "actionName"),
+    )?.toUpperCase();
     const values = readOwnValue(result, "values");
     const mode = readString(readOwnValue(values, "mode"))?.toLowerCase();
     const viewId = readString(readOwnValue(values, "viewId"));
-    if ((mode === "show" || mode === "open") && viewId) {
+    const isViewsHandoff =
+      actionName === "VIEWS" && (mode === "show" || mode === "open");
+    const isAppBrowserHandoff =
+      actionName === "APP" && mode === "launch" && viewId === "browser";
+    if ((isViewsHandoff || isAppBrowserHandoff) && viewId) {
       const viewPath = readString(readOwnValue(values, "viewPath"));
       const subview = readString(readOwnValue(values, "subview"));
       const completedActionHandoffId = normalizeCompletedActionHandoffId(

--- a/plugins/plugin-app-control/src/actions/app-launch.test.ts
+++ b/plugins/plugin-app-control/src/actions/app-launch.test.ts
@@ -41,13 +41,21 @@ function client(): AppControlClient {
 }
 
 const message = {
-	content: { text: "open nubs color pebble" },
+	content: {
+		text: "open nubs color pebble",
+		metadata: { viewClientId: "chat-client-1" },
+	},
 } as Memory;
 
 describe("APP launch Browser handoff", () => {
 	it("opens the launch URL in Browser and keeps the run id internal", async () => {
 		const callback = vi.fn<HandlerCallback>();
-		const openBrowserView = vi.fn(async () => true);
+		const openBrowserView = vi.fn(async () => ({
+			path: "/browser?browse=app",
+			status: "delivered" as const,
+			completedActionDelivered: true,
+			completedActionHandoffId: "handoff-1",
+		}));
 
 		const result = await runLaunch({
 			client: client(),
@@ -58,6 +66,7 @@ describe("APP launch Browser handoff", () => {
 
 		expect(openBrowserView).toHaveBeenCalledWith(
 			"/api/apps/local/nubs-color-pebble/",
+			{ originatingClientId: "chat-client-1", realtimeVoice: false },
 		);
 		expect(result.text).toBe('{"effect":"app_launch","status":"completed"}');
 		expect(result.transcriptVisibility).toBe("internal");
@@ -71,6 +80,7 @@ describe("APP launch Browser handoff", () => {
 			appName: "nubs-color-pebble",
 			displayName: "Nubs Color Pebble",
 			openedInBrowser: true,
+			browserNavigationStatus: "delivered",
 			link: {
 				label: "Open Nubs Color Pebble",
 				href: "/api/apps/local/nubs-color-pebble/",
@@ -79,6 +89,9 @@ describe("APP launch Browser handoff", () => {
 		expect(result.values).toMatchObject({
 			openedInBrowser: true,
 			runId: "internal-run-id",
+			viewId: "browser",
+			viewPath: "/browser?browse=app",
+			completedActionHandoffId: "handoff-1",
 		});
 		expect(callback).not.toHaveBeenCalled();
 	});
@@ -87,7 +100,12 @@ describe("APP launch Browser handoff", () => {
 		const result = await runLaunch({
 			client: client(),
 			message,
-			openBrowserView: vi.fn(async () => false),
+			openBrowserView: vi.fn(async () => ({
+				path: "/browser?browse=app",
+				status: "unavailable" as const,
+				completedActionDelivered: false,
+				errorCode: "RENDERER_UNAVAILABLE" as const,
+			})),
 		});
 
 		expect(result.modelReplyRequired).toBe(true);
@@ -96,6 +114,8 @@ describe("APP launch Browser handoff", () => {
 			operation: "launch_app",
 			outcome: "success",
 			openedInBrowser: false,
+			browserNavigationStatus: "unavailable",
+			browserNavigationError: "RENDERER_UNAVAILABLE",
 			link: {
 				label: "Open Nubs Color Pebble",
 				href: "/api/apps/local/nubs-color-pebble/",

--- a/plugins/plugin-app-control/src/actions/app-launch.test.ts
+++ b/plugins/plugin-app-control/src/actions/app-launch.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it, vi } from "vitest";
 import type { AppControlClient } from "../client/api.js";
 import { runLaunch } from "./app-launch.js";
 
-function client(): AppControlClient {
+function client(
+	launchUrl = "/api/apps/local/nubs-color-pebble/",
+): AppControlClient {
 	return {
 		listInstalledApps: vi.fn(async () => [
 			{
@@ -20,14 +22,14 @@ function client(): AppControlClient {
 			needsRestart: false,
 			displayName: "Nubs Color Pebble",
 			launchType: "local",
-			launchUrl: "/api/apps/local/nubs-color-pebble/",
+			launchUrl,
 			run: {
 				runId: "internal-run-id",
 				appName: "nubs-color-pebble",
 				displayName: "Nubs Color Pebble",
 				pluginName: "nubs-color-pebble",
 				launchType: "local",
-				launchUrl: "/api/apps/local/nubs-color-pebble/",
+				launchUrl,
 				status: "running",
 				summary: null,
 				startedAt: "2026-08-21T00:00:00.000Z",
@@ -50,6 +52,8 @@ describe("APP launch Browser handoff", () => {
 		const openBrowserView = vi.fn(async () => ({
 			status: "renderer-delivered" as const,
 			openedInBrowser: true,
+			safeLaunchUrl: "/api/apps/local/nubs-color-pebble/",
+			safeMarkdownLaunchUrl: "/api/apps/local/nubs-color-pebble/",
 			viewPath: "/browser?browse=local",
 			completedActionDelivered: true as const,
 			completedActionHandoffId: "handoff-app",
@@ -70,6 +74,9 @@ describe("APP launch Browser handoff", () => {
 		expect(result.transcriptVisibility).toBe("internal");
 		expect(result.modelReplyRequired).toBe(true);
 		expect(result.userFacingText).toBeUndefined();
+		expect(result.modelReplyFallback).toBe(
+			"The app launched successfully. [Open the app](/api/apps/local/nubs-color-pebble/)",
+		);
 		expect(result.verifiedUserFacing).toBeUndefined();
 		expect(result.turnComplete).toBeUndefined();
 		expect(result.promptData).toEqual({
@@ -102,13 +109,17 @@ describe("APP launch Browser handoff", () => {
 			openBrowserView: vi.fn(async () => ({
 				status: "terminal-fallback" as const,
 				openedInBrowser: false,
+				safeLaunchUrl: "/api/apps/local/nubs-color-pebble/",
+				safeMarkdownLaunchUrl: "/api/apps/local/nubs-color-pebble/",
 				viewPath: "/browser?browse=local",
 				completedActionHandoffId: "handoff-fallback",
 			})),
 		});
 
 		expect(result.modelReplyRequired).toBe(true);
-		expect(result.userFacingText).toBeUndefined();
+		expect(result.modelReplyFallback).toContain(
+			"The app launched successfully.",
+		);
 		expect(result.promptData).toMatchObject({
 			operation: "launch_app",
 			outcome: "success",
@@ -124,5 +135,34 @@ describe("APP launch Browser handoff", () => {
 			viewPath: "/browser?browse=local",
 			completedActionHandoffId: "handoff-fallback",
 		});
+	});
+
+	it.each(["javascript:alert(1)", "data:text/html,unsafe", "http://["])(
+		"never exposes an unsafe launch URL to model-bound prompt data: %s",
+		async (launchUrl) => {
+			const result = await runLaunch({ client: client(launchUrl), message });
+
+			expect(result.success).toBe(true);
+			expect(result.values).toMatchObject({
+				browserNavigationStatus: "invalid-url",
+				openedInBrowser: false,
+			});
+			expect(result.promptData).not.toHaveProperty("link");
+			expect(result.modelReplyFallback).toBe("The app launched successfully.");
+			expect(JSON.stringify(result.promptData)).not.toContain(launchUrl);
+			expect(result.modelReplyFallback).not.toContain(launchUrl);
+		},
+	);
+
+	it("escapes a valid http URL before placing it in Markdown", async () => {
+		const launchUrl = "https://e.test/)%20[evil](javascript:alert(1))";
+		const result = await runLaunch({ client: client(launchUrl), message });
+		const href = (result.promptData?.link as { href?: string } | undefined)
+			?.href;
+
+		expect(href).toContain("%29");
+		expect(href).toContain("%28");
+		expect(href).not.toContain("](javascript:");
+		expect(result.modelReplyFallback).toContain(href);
 	});
 });

--- a/plugins/plugin-app-control/src/actions/app-launch.test.ts
+++ b/plugins/plugin-app-control/src/actions/app-launch.test.ts
@@ -1,0 +1,105 @@
+import type { HandlerCallback, Memory } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { AppControlClient } from "../client/api.js";
+import { runLaunch } from "./app-launch.js";
+
+function client(): AppControlClient {
+	return {
+		listInstalledApps: vi.fn(async () => [
+			{
+				name: "nubs-color-pebble",
+				displayName: "Nubs Color Pebble",
+				pluginName: "nubs-color-pebble",
+				version: "1.0.0",
+				installedAt: "2026-08-21T00:00:00.000Z",
+			},
+		]),
+		listAppRuns: vi.fn(),
+		launchApp: vi.fn(async () => ({
+			pluginInstalled: true,
+			needsRestart: false,
+			displayName: "Nubs Color Pebble",
+			launchType: "local",
+			launchUrl: "/api/apps/local/nubs-color-pebble/",
+			run: {
+				runId: "internal-run-id",
+				appName: "nubs-color-pebble",
+				displayName: "Nubs Color Pebble",
+				pluginName: "nubs-color-pebble",
+				launchType: "local",
+				launchUrl: "/api/apps/local/nubs-color-pebble/",
+				status: "running",
+				summary: null,
+				startedAt: "2026-08-21T00:00:00.000Z",
+				updatedAt: "2026-08-21T00:00:00.000Z",
+				lastHeartbeatAt: null,
+			},
+		})),
+		stopApp: vi.fn(),
+		stopAppRun: vi.fn(),
+	};
+}
+
+const message = {
+	content: { text: "open nubs color pebble" },
+} as Memory;
+
+describe("APP launch Browser handoff", () => {
+	it("opens the launch URL in Browser and keeps the run id internal", async () => {
+		const callback = vi.fn<HandlerCallback>();
+		const openBrowserView = vi.fn(async () => true);
+
+		const result = await runLaunch({
+			client: client(),
+			message,
+			callback,
+			openBrowserView,
+		});
+
+		expect(openBrowserView).toHaveBeenCalledWith(
+			"/api/apps/local/nubs-color-pebble/",
+		);
+		expect(result.text).toBe('{"effect":"app_launch","status":"completed"}');
+		expect(result.transcriptVisibility).toBe("internal");
+		expect(result.modelReplyRequired).toBe(true);
+		expect(result.userFacingText).toBeUndefined();
+		expect(result.verifiedUserFacing).toBeUndefined();
+		expect(result.turnComplete).toBeUndefined();
+		expect(result.promptData).toEqual({
+			operation: "launch_app",
+			outcome: "success",
+			appName: "nubs-color-pebble",
+			displayName: "Nubs Color Pebble",
+			openedInBrowser: true,
+			link: {
+				label: "Open Nubs Color Pebble",
+				href: "/api/apps/local/nubs-color-pebble/",
+			},
+		});
+		expect(result.values).toMatchObject({
+			openedInBrowser: true,
+			runId: "internal-run-id",
+		});
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it("keeps the app link in the model receipt when Browser navigation is unavailable", async () => {
+		const result = await runLaunch({
+			client: client(),
+			message,
+			openBrowserView: vi.fn(async () => false),
+		});
+
+		expect(result.modelReplyRequired).toBe(true);
+		expect(result.userFacingText).toBeUndefined();
+		expect(result.promptData).toMatchObject({
+			operation: "launch_app",
+			outcome: "success",
+			openedInBrowser: false,
+			link: {
+				label: "Open Nubs Color Pebble",
+				href: "/api/apps/local/nubs-color-pebble/",
+			},
+		});
+	});
+});

--- a/plugins/plugin-app-control/src/actions/app-launch.test.ts
+++ b/plugins/plugin-app-control/src/actions/app-launch.test.ts
@@ -41,20 +41,18 @@ function client(): AppControlClient {
 }
 
 const message = {
-	content: {
-		text: "open nubs color pebble",
-		metadata: { viewClientId: "chat-client-1" },
-	},
+	content: { text: "open nubs color pebble" },
 } as Memory;
 
 describe("APP launch Browser handoff", () => {
 	it("opens the launch URL in Browser and keeps the run id internal", async () => {
 		const callback = vi.fn<HandlerCallback>();
 		const openBrowserView = vi.fn(async () => ({
-			path: "/browser?browse=app",
-			status: "delivered" as const,
-			completedActionDelivered: true,
-			completedActionHandoffId: "handoff-1",
+			status: "renderer-delivered" as const,
+			openedInBrowser: true,
+			viewPath: "/browser?browse=local",
+			completedActionDelivered: true as const,
+			completedActionHandoffId: "handoff-app",
 		}));
 
 		const result = await runLaunch({
@@ -66,7 +64,7 @@ describe("APP launch Browser handoff", () => {
 
 		expect(openBrowserView).toHaveBeenCalledWith(
 			"/api/apps/local/nubs-color-pebble/",
-			{ originatingClientId: "chat-client-1", realtimeVoice: false },
+			message,
 		);
 		expect(result.text).toBe('{"effect":"app_launch","status":"completed"}');
 		expect(result.transcriptVisibility).toBe("internal");
@@ -80,7 +78,7 @@ describe("APP launch Browser handoff", () => {
 			appName: "nubs-color-pebble",
 			displayName: "Nubs Color Pebble",
 			openedInBrowser: true,
-			browserNavigationStatus: "delivered",
+			browserNavigationStatus: "renderer-delivered",
 			link: {
 				label: "Open Nubs Color Pebble",
 				href: "/api/apps/local/nubs-color-pebble/",
@@ -90,8 +88,9 @@ describe("APP launch Browser handoff", () => {
 			openedInBrowser: true,
 			runId: "internal-run-id",
 			viewId: "browser",
-			viewPath: "/browser?browse=app",
-			completedActionHandoffId: "handoff-1",
+			viewPath: "/browser?browse=local",
+			completedActionDelivered: true,
+			completedActionHandoffId: "handoff-app",
 		});
 		expect(callback).not.toHaveBeenCalled();
 	});
@@ -101,10 +100,10 @@ describe("APP launch Browser handoff", () => {
 			client: client(),
 			message,
 			openBrowserView: vi.fn(async () => ({
-				path: "/browser?browse=app",
-				status: "unavailable" as const,
-				completedActionDelivered: false,
-				errorCode: "RENDERER_UNAVAILABLE" as const,
+				status: "terminal-fallback" as const,
+				openedInBrowser: false,
+				viewPath: "/browser?browse=local",
+				completedActionHandoffId: "handoff-fallback",
 			})),
 		});
 
@@ -114,12 +113,16 @@ describe("APP launch Browser handoff", () => {
 			operation: "launch_app",
 			outcome: "success",
 			openedInBrowser: false,
-			browserNavigationStatus: "unavailable",
-			browserNavigationError: "RENDERER_UNAVAILABLE",
 			link: {
 				label: "Open Nubs Color Pebble",
 				href: "/api/apps/local/nubs-color-pebble/",
 			},
+		});
+		expect(result.values).toMatchObject({
+			browserNavigationStatus: "terminal-fallback",
+			viewId: "browser",
+			viewPath: "/browser?browse=local",
+			completedActionHandoffId: "handoff-fallback",
 		});
 	});
 });

--- a/plugins/plugin-app-control/src/actions/app-launch.ts
+++ b/plugins/plugin-app-control/src/actions/app-launch.ts
@@ -15,12 +15,14 @@ import {
 	targetReferenceLogView,
 } from "../params.js";
 import { formatAppCandidates, resolveInstalledApp } from "../resolve.js";
+import { openLaunchUrlInBrowserView } from "../services/browser-view-navigation.js";
 
 export interface RunLaunchInput {
 	client: AppControlClient;
 	message: Memory;
 	options?: Record<string, unknown>;
 	callback?: HandlerCallback;
+	openBrowserView?: (launchUrl: string) => Promise<boolean>;
 }
 
 export async function runLaunch({
@@ -28,6 +30,7 @@ export async function runLaunch({
 	message,
 	options,
 	callback,
+	openBrowserView = openLaunchUrlInBrowserView,
 }: RunLaunchInput): Promise<ActionResult> {
 	const target = extractLaunchTarget(message, options);
 	if (!target) {
@@ -74,6 +77,9 @@ export async function runLaunch({
 		return {
 			success: false,
 			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
 			data: { target: targetReferenceLogView(target) },
 		};
 	}
@@ -91,26 +97,51 @@ export async function runLaunch({
 			`[plugin-app-control] APP/launch ${appName} failed: ${message}`,
 		);
 		await callback?.({ text });
-		return { success: false, text, error: message };
+		return {
+			success: false,
+			text,
+			userFacingText: text,
+			verifiedUserFacing: true,
+			turnComplete: true,
+			error: message,
+		};
 	}
 	const runId = result.run?.runId ?? null;
-	const text = runId
-		? `Launched ${result.displayName}. Run ID: ${runId}.`
-		: `Launched ${result.displayName}.`;
+	const launchUrl = result.launchUrl?.trim() || null;
+	const opened = launchUrl ? await openBrowserView(launchUrl) : false;
 
 	logger.info(
 		`[plugin-app-control] APP/launch ${appName} runId=${runId ?? "<none>"}`,
 	);
 
-	await callback?.({ text });
 	return {
 		success: true,
-		text,
+		text: JSON.stringify({ effect: "app_launch", status: "completed" }),
+		transcriptVisibility: "internal",
+		// The effect is already complete. Give Eliza a bounded receipt and let the
+		// model own the conversational wording instead of posting canned action copy.
+		modelReplyRequired: true,
 		values: {
 			mode: "launch",
 			appName,
 			displayName: result.displayName,
 			runId,
+			openedInBrowser: opened,
+		},
+		promptData: {
+			operation: "launch_app",
+			outcome: "success",
+			appName,
+			displayName: result.displayName,
+			openedInBrowser: opened,
+			...(launchUrl
+				? {
+						link: {
+							label: `Open ${result.displayName}`,
+							href: launchUrl,
+						},
+					}
+				: {}),
 		},
 		data: { launch: result },
 	};

--- a/plugins/plugin-app-control/src/actions/app-launch.ts
+++ b/plugins/plugin-app-control/src/actions/app-launch.ts
@@ -95,8 +95,8 @@ export async function runLaunch({
 	try {
 		result = await client.launchApp(appName);
 	} catch (err) {
-		// Don't propagate — a thrown launch (HTTP 4xx/5xx, network error,
-		// race with concurrent uninstall) must not crash the planner turn.
+		// error-policy:J1 APP is the user-facing action boundary: translate a
+		// typed/transport launch rejection into one explicit failed action result.
 		const message = err instanceof Error ? err.message : String(err);
 		const text = `Failed to launch ${appName}: ${message}`;
 		logger.warn(
@@ -121,10 +121,14 @@ export async function runLaunch({
 	logger.info(
 		`[plugin-app-control] APP/launch ${appName} runId=${runId ?? "<none>"}`,
 	);
+	const safeFallbackText = browserNavigation.safeMarkdownLaunchUrl
+		? `The app launched successfully. [Open the app](${browserNavigation.safeMarkdownLaunchUrl})`
+		: "The app launched successfully.";
 
 	return {
 		success: true,
 		text: JSON.stringify({ effect: "app_launch", status: "completed" }),
+		modelReplyFallback: safeFallbackText,
 		transcriptVisibility: "internal",
 		// The effect is already complete. Give Eliza a bounded receipt and let the
 		// model own the conversational wording instead of posting canned action copy.
@@ -156,11 +160,11 @@ export async function runLaunch({
 			displayName: result.displayName,
 			openedInBrowser: browserNavigation.openedInBrowser,
 			browserNavigationStatus: browserNavigation.status,
-			...(launchUrl
+			...(browserNavigation.safeMarkdownLaunchUrl
 				? {
 						link: {
 							label: `Open ${result.displayName}`,
-							href: launchUrl,
+							href: browserNavigation.safeMarkdownLaunchUrl,
 						},
 					}
 				: {}),

--- a/plugins/plugin-app-control/src/actions/app-launch.ts
+++ b/plugins/plugin-app-control/src/actions/app-launch.ts
@@ -16,9 +16,7 @@ import {
 } from "../params.js";
 import { formatAppCandidates, resolveInstalledApp } from "../resolve.js";
 import {
-	appLaunchViewClientId,
-	type BrowserViewNavigationResult,
-	isRealtimeVoiceAppLaunch,
+	type BrowserNavigationResult,
 	openLaunchUrlInBrowserView,
 } from "../services/browser-view-navigation.js";
 
@@ -29,8 +27,8 @@ export interface RunLaunchInput {
 	callback?: HandlerCallback;
 	openBrowserView?: (
 		launchUrl: string,
-		options: { originatingClientId?: string; realtimeVoice?: boolean },
-	) => Promise<BrowserViewNavigationResult>;
+		message: Memory,
+	) => Promise<BrowserNavigationResult>;
 }
 
 export async function runLaunch({
@@ -116,13 +114,9 @@ export async function runLaunch({
 	}
 	const runId = result.run?.runId ?? null;
 	const launchUrl = result.launchUrl?.trim() || null;
-	const browserNavigation = launchUrl
-		? await openBrowserView(launchUrl, {
-				originatingClientId: appLaunchViewClientId(message),
-				realtimeVoice: isRealtimeVoiceAppLaunch(message),
-			})
-		: undefined;
-	const opened = browserNavigation?.completedActionDelivered === true;
+	const browserNavigation: BrowserNavigationResult = launchUrl
+		? await openBrowserView(launchUrl, message)
+		: { status: "target-unavailable", openedInBrowser: false };
 
 	logger.info(
 		`[plugin-app-control] APP/launch ${appName} runId=${runId ?? "<none>"}`,
@@ -140,12 +134,16 @@ export async function runLaunch({
 			appName,
 			displayName: result.displayName,
 			runId,
-			openedInBrowser: opened,
-			...(browserNavigation?.completedActionHandoffId
+			openedInBrowser: browserNavigation.openedInBrowser,
+			browserNavigationStatus: browserNavigation.status,
+			...(browserNavigation.viewPath
+				? { viewId: "browser", viewPath: browserNavigation.viewPath }
+				: {}),
+			...(browserNavigation.completedActionDelivered
+				? { completedActionDelivered: true }
+				: {}),
+			...(browserNavigation.completedActionHandoffId
 				? {
-						viewId: "browser",
-						viewPath: browserNavigation.path,
-						viewType: "gui",
 						completedActionHandoffId:
 							browserNavigation.completedActionHandoffId,
 					}
@@ -156,13 +154,8 @@ export async function runLaunch({
 			outcome: "success",
 			appName,
 			displayName: result.displayName,
-			openedInBrowser: opened,
-			browserNavigationStatus:
-				browserNavigation?.status ??
-				(launchUrl ? "unavailable" : "not-requested"),
-			...(browserNavigation?.errorCode
-				? { browserNavigationError: browserNavigation.errorCode }
-				: {}),
+			openedInBrowser: browserNavigation.openedInBrowser,
+			browserNavigationStatus: browserNavigation.status,
 			...(launchUrl
 				? {
 						link: {

--- a/plugins/plugin-app-control/src/actions/app-launch.ts
+++ b/plugins/plugin-app-control/src/actions/app-launch.ts
@@ -15,14 +15,23 @@ import {
 	targetReferenceLogView,
 } from "../params.js";
 import { formatAppCandidates, resolveInstalledApp } from "../resolve.js";
-import { openLaunchUrlInBrowserView } from "../services/browser-view-navigation.js";
+import {
+	appLaunchViewClientId,
+	type BrowserViewNavigationResult,
+	browserViewPathForLaunchUrl,
+	isRealtimeVoiceAppLaunch,
+	openLaunchUrlInBrowserView,
+} from "../services/browser-view-navigation.js";
 
 export interface RunLaunchInput {
 	client: AppControlClient;
 	message: Memory;
 	options?: Record<string, unknown>;
 	callback?: HandlerCallback;
-	openBrowserView?: (launchUrl: string) => Promise<boolean>;
+	openBrowserView?: (
+		launchUrl: string,
+		options: { originatingClientId?: string; realtimeVoice?: boolean },
+	) => Promise<BrowserViewNavigationResult>;
 }
 
 export async function runLaunch({
@@ -108,7 +117,13 @@ export async function runLaunch({
 	}
 	const runId = result.run?.runId ?? null;
 	const launchUrl = result.launchUrl?.trim() || null;
-	const opened = launchUrl ? await openBrowserView(launchUrl) : false;
+	const browserNavigation = launchUrl
+		? await openBrowserView(launchUrl, {
+				originatingClientId: appLaunchViewClientId(message),
+				realtimeVoice: isRealtimeVoiceAppLaunch(message),
+			})
+		: undefined;
+	const opened = browserNavigation?.completedActionDelivered === true;
 
 	logger.info(
 		`[plugin-app-control] APP/launch ${appName} runId=${runId ?? "<none>"}`,
@@ -127,6 +142,15 @@ export async function runLaunch({
 			displayName: result.displayName,
 			runId,
 			openedInBrowser: opened,
+			...(browserNavigation?.completedActionHandoffId
+				? {
+						viewId: "browser",
+						viewPath: browserNavigation.path,
+						viewType: "gui",
+						completedActionHandoffId:
+							browserNavigation.completedActionHandoffId,
+					}
+				: {}),
 		},
 		promptData: {
 			operation: "launch_app",
@@ -134,6 +158,11 @@ export async function runLaunch({
 			appName,
 			displayName: result.displayName,
 			openedInBrowser: opened,
+			browserNavigationStatus:
+				browserNavigation?.status ?? (launchUrl ? "unavailable" : "not-requested"),
+			...(browserNavigation?.errorCode
+				? { browserNavigationError: browserNavigation.errorCode }
+				: {}),
 			...(launchUrl
 				? {
 						link: {

--- a/plugins/plugin-app-control/src/actions/app-launch.ts
+++ b/plugins/plugin-app-control/src/actions/app-launch.ts
@@ -18,7 +18,6 @@ import { formatAppCandidates, resolveInstalledApp } from "../resolve.js";
 import {
 	appLaunchViewClientId,
 	type BrowserViewNavigationResult,
-	browserViewPathForLaunchUrl,
 	isRealtimeVoiceAppLaunch,
 	openLaunchUrlInBrowserView,
 } from "../services/browser-view-navigation.js";

--- a/plugins/plugin-app-control/src/actions/app-launch.ts
+++ b/plugins/plugin-app-control/src/actions/app-launch.ts
@@ -158,7 +158,8 @@ export async function runLaunch({
 			displayName: result.displayName,
 			openedInBrowser: opened,
 			browserNavigationStatus:
-				browserNavigation?.status ?? (launchUrl ? "unavailable" : "not-requested"),
+				browserNavigation?.status ??
+				(launchUrl ? "unavailable" : "not-requested"),
 			...(browserNavigation?.errorCode
 				? { browserNavigationError: browserNavigation.errorCode }
 				: {}),

--- a/plugins/plugin-app-control/src/actions/app.test.ts
+++ b/plugins/plugin-app-control/src/actions/app.test.ts
@@ -209,3 +209,78 @@ describe("APP stop mode", () => {
 		);
 	});
 });
+
+describe("APP launch handler delivery", () => {
+	it("carries the originating renderer through the real action handler", async () => {
+		const originalFetch = globalThis.fetch;
+		const requests: Record<string, unknown>[] = [];
+		globalThis.fetch = vi.fn(async (_url, init) => {
+			const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+			requests.push(body);
+			return new Response(
+				JSON.stringify({
+					ok: true,
+					completedActionDelivered: true,
+					completedActionHandoffId: body.completedActionHandoffId,
+				}),
+				{ status: 200 },
+			);
+		}) as typeof fetch;
+		const client: AppControlClient = {
+			listInstalledApps: async () => [
+				{
+					name: "demo",
+					displayName: "Demo",
+					pluginName: "demo",
+					version: "1.0.0",
+					installedAt: "2026-08-21T00:00:00.000Z",
+				},
+			],
+			listAppRuns: vi.fn(),
+			launchApp: async () => ({
+				pluginInstalled: true,
+				needsRestart: false,
+				displayName: "Demo",
+				launchType: "local",
+				launchUrl: "/api/apps/local/demo/",
+				run: null,
+			}),
+			stopApp: vi.fn(),
+			stopAppRun: vi.fn(),
+		};
+
+		try {
+			const action = createAppAction({
+				client,
+				hasOwnerAccess: async () => true,
+			});
+			const result = await action.handler(
+				{ agentId: "agent-1" } as IAgentRuntime,
+				{
+					entityId: "owner-1",
+					content: {
+						text: "launch demo",
+						metadata: { viewClientId: "origin-renderer" },
+					},
+				} as Memory,
+				undefined,
+				{ parameters: { action: "launch", app: "demo" } },
+				undefined,
+			);
+
+			expect(requests).toHaveLength(1);
+			expect(requests[0]).toMatchObject({
+				clientId: "origin-renderer",
+				delivery: "completed-action",
+			});
+			expect(result.values).toMatchObject({
+				mode: "launch",
+				viewId: "browser",
+				openedInBrowser: true,
+				completedActionDelivered: true,
+			});
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});

--- a/plugins/plugin-app-control/src/actions/view-delivery.ts
+++ b/plugins/plugin-app-control/src/actions/view-delivery.ts
@@ -1,0 +1,34 @@
+/** Identifies the renderer-owned delivery channel for view navigation actions. */
+
+import type { Memory } from "@elizaos/core";
+import { REALTIME_VOICE_CLIENT_TRANSPORT } from "@elizaos/shared";
+
+const SAFE_VIEW_CLIENT_ID = /^[A-Za-z0-9._-]{1,128}$/;
+
+export function readViewInteractionClientId(
+	message: Memory,
+): string | undefined {
+	const metadata = message.content.metadata;
+	if (
+		typeof metadata !== "object" ||
+		metadata === null ||
+		Array.isArray(metadata)
+	) {
+		return undefined;
+	}
+	const clientId = (metadata as Record<string, unknown>).viewClientId;
+	return typeof clientId === "string" && SAFE_VIEW_CLIENT_ID.test(clientId)
+		? clientId
+		: undefined;
+}
+
+export function isRealtimeVoiceTurn(message: Memory): boolean {
+	const metadata = message.content.metadata;
+	return (
+		typeof metadata === "object" &&
+		metadata !== null &&
+		!Array.isArray(metadata) &&
+		(metadata as Record<string, unknown>).clientTransport ===
+			REALTIME_VOICE_CLIENT_TRANSPORT
+	);
+}

--- a/plugins/plugin-app-control/src/actions/views-show.ts
+++ b/plugins/plugin-app-control/src/actions/views-show.ts
@@ -12,7 +12,6 @@ import type {
 	ViewType,
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
-import { REALTIME_VOICE_CLIENT_TRANSPORT } from "@elizaos/shared";
 import { SHARED_NAV_TARGETS } from "@elizaos/shared/views/shared-nav-targets";
 import { resolveSettingsSectionToken } from "@elizaos/ui/components/settings/settings-section-tokens";
 import { getAppControlApiBase } from "../loopback-api.js";
@@ -22,6 +21,7 @@ import {
 	userRequestMessageText,
 } from "../params.js";
 import { matchViewCommand } from "./view-command-matcher.js";
+import { isRealtimeVoiceTurn } from "./view-delivery.js";
 import type { ViewSummary, ViewsClient } from "./views-client.js";
 import { createViewsRequestHeaders } from "./views-request-auth.js";
 import { scoreView } from "./views-search.js";
@@ -57,16 +57,6 @@ const FILLER_WORDS = new Set([
 const DOCUMENT_SURFACE_WORDS =
 	/\b(?:documents?|docs?|files?|knowledge|uploads?|retrieval|papers?)\b/i;
 
-function isRealtimeVoiceTurn(message: Memory): boolean {
-	const metadata = message.content.metadata;
-	return (
-		typeof metadata === "object" &&
-		metadata !== null &&
-		!Array.isArray(metadata) &&
-		(metadata as Record<string, unknown>).clientTransport ===
-			REALTIME_VOICE_CLIENT_TRANSPORT
-	);
-}
 const NOTES_SURFACE_WORD = /\bnotes?\b/i;
 
 // Match a show-verb on WORD BOUNDARIES at the earliest position in the text.
@@ -372,6 +362,8 @@ function resolveRegisteredNotesView(
 
 export interface NavigateResult {
 	ok: boolean;
+	status: "accepted" | "unsupported-route" | "http-error" | "transport-error";
+	receiptStatus?: "delivered" | "not-delivered" | "malformed" | "not-requested";
 	/** Internal tool receipt for post-tool reasoning; never assistant prose. */
 	text: string;
 	/** Resolved sub-section the renderer was asked to focus (settings only). */
@@ -380,7 +372,6 @@ export interface NavigateResult {
 	completedActionDelivered?: true;
 	/** Renderer-observed idempotency key echoed by a supporting server. */
 	completedActionHandoffId?: string;
-	failureKind?: "unsupported-route" | "navigation-rejected" | "transport";
 }
 
 function navigationEffectReceipt({
@@ -473,6 +464,7 @@ export async function navigateToView(
 		);
 		if (resp.ok) {
 			let responseBody: unknown;
+			let malformedReceipt = false;
 			try {
 				responseBody = await resp.json();
 			} catch (error) {
@@ -480,6 +472,7 @@ export async function navigateToView(
 				// navigation fallback enabled; transport/body failures remain failures.
 				if (!(error instanceof SyntaxError)) throw error;
 				responseBody = null;
+				malformedReceipt = true;
 			}
 			const echoedCompletedActionHandoffId =
 				completedActionHandoffId &&
@@ -494,6 +487,15 @@ export async function navigateToView(
 					: undefined;
 			return {
 				ok: true,
+				status: "accepted",
+				receiptStatus: malformedReceipt
+					? "malformed"
+					: delivery === "completed-action"
+						? confirmsCompletedActionDelivery(responseBody) &&
+							(!completedActionHandoffId || echoedCompletedActionHandoffId)
+							? "delivered"
+							: "not-delivered"
+						: "not-requested",
 				text: navigationEffectReceipt({
 					status: "accepted",
 					view,
@@ -515,7 +517,7 @@ export async function navigateToView(
 		if (resp.status === 501 || resp.status === 404)
 			return {
 				ok: false,
-				failureKind: "unsupported-route",
+				status: "unsupported-route",
 				text: navigationEffectReceipt({
 					status: "unsupported-route",
 					view,
@@ -525,13 +527,23 @@ export async function navigateToView(
 				subview: resolvedSubview,
 			};
 
-		const body = await resp.text().catch(() => "");
+		let body = "";
+		try {
+			body = await resp.text();
+		} catch (error) {
+			// error-policy:J4 response diagnostics are optional; navigation already
+			// has an explicit HTTP failure and must remain failed.
+			logger.warn(
+				{ error },
+				"[plugin-app-control] Could not read navigation error body",
+			);
+		}
 		logger.warn(
 			`[plugin-app-control] VIEWS/show navigate returned ${resp.status}: ${body}`,
 		);
 		return {
 			ok: false,
-			failureKind: "navigation-rejected",
+			status: "http-error",
 			text: navigationEffectReceipt({
 				status: "unconfirmed",
 				view,
@@ -540,6 +552,8 @@ export async function navigateToView(
 			}),
 		};
 	} catch (err) {
+		// error-policy:J4 navigation transport failures preserve a visibly distinct
+		// failed action so the planner can recover without claiming the effect.
 		logger.warn(
 			`[plugin-app-control] VIEWS/show navigate failed: ${err instanceof Error ? err.message : String(err)}`,
 		);
@@ -547,7 +561,7 @@ export async function navigateToView(
 
 	return {
 		ok: false,
-		failureKind: "transport",
+		status: "transport-error",
 		text: navigationEffectReceipt({
 			status: "unconfirmed",
 			view,

--- a/plugins/plugin-app-control/src/actions/views-show.ts
+++ b/plugins/plugin-app-control/src/actions/views-show.ts
@@ -370,7 +370,7 @@ function resolveRegisteredNotesView(
 	return resolution.view.id === "documents" ? { kind: "none" } : resolution;
 }
 
-interface NavigateResult {
+export interface NavigateResult {
 	ok: boolean;
 	/** Internal tool receipt for post-tool reasoning; never assistant prose. */
 	text: string;
@@ -380,6 +380,7 @@ interface NavigateResult {
 	completedActionDelivered?: true;
 	/** Renderer-observed idempotency key echoed by a supporting server. */
 	completedActionHandoffId?: string;
+	failureKind?: "unsupported-route" | "navigation-rejected" | "transport";
 }
 
 function navigationEffectReceipt({
@@ -434,7 +435,7 @@ function resolveSubviewForView(
 	return token;
 }
 
-async function navigateToView(
+export async function navigateToView(
 	view: ViewSummary,
 	requestedViewType?: ViewType,
 	subview?: string,
@@ -514,6 +515,7 @@ async function navigateToView(
 		if (resp.status === 501 || resp.status === 404)
 			return {
 				ok: false,
+				failureKind: "unsupported-route",
 				text: navigationEffectReceipt({
 					status: "unsupported-route",
 					view,
@@ -527,6 +529,16 @@ async function navigateToView(
 		logger.warn(
 			`[plugin-app-control] VIEWS/show navigate returned ${resp.status}: ${body}`,
 		);
+		return {
+			ok: false,
+			failureKind: "navigation-rejected",
+			text: navigationEffectReceipt({
+				status: "unconfirmed",
+				view,
+				navigationLabel,
+				subview: resolvedSubview,
+			}),
+		};
 	} catch (err) {
 		logger.warn(
 			`[plugin-app-control] VIEWS/show navigate failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -535,6 +547,7 @@ async function navigateToView(
 
 	return {
 		ok: false,
+		failureKind: "transport",
 		text: navigationEffectReceipt({
 			status: "unconfirmed",
 			view,

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -37,6 +37,7 @@ import {
 	userRequestMessageText,
 } from "../params.js";
 import { matchViewCommand } from "./view-command-matcher.js";
+import { readViewInteractionClientId } from "./view-delivery.js";
 import {
 	createViewsClient,
 	parseViewInteractionResponse,
@@ -150,15 +151,6 @@ const DESKTOP_ONLY_VIEW_MODES = new Set<ViewsMode>([
 // app-control must not import orchestrator internals, so this constant is kept
 // local and points at the orchestrator's owning constant.
 const SUB_AGENT_RELAY_SOURCE = "sub_agent";
-const SAFE_VIEW_CLIENT_ID = /^[A-Za-z0-9._-]{1,128}$/;
-
-function readViewInteractionClientId(message: Memory): string | undefined {
-	const clientId = readContentMetadata(message).viewClientId;
-	return typeof clientId === "string" && SAFE_VIEW_CLIENT_ID.test(clientId)
-		? clientId
-		: undefined;
-}
-
 function lowerSource(source: unknown): string {
 	return typeof source === "string" ? source.toLowerCase() : "";
 }

--- a/plugins/plugin-app-control/src/services/browser-view-navigation.test.ts
+++ b/plugins/plugin-app-control/src/services/browser-view-navigation.test.ts
@@ -55,8 +55,13 @@ describe("Browser launch navigation", () => {
 		expect(body).toMatchObject({
 			clientId: "client-a",
 			delivery: "completed-action",
-			path: "/browser?browse=%2Fapi%2Fapps%2Flocal%2Fdemo%2F",
 		});
+		const viewPath = String(body.path);
+		const browseTarget = new URLSearchParams(viewPath.split("?")[1]).get(
+			"browse",
+		);
+		expect(viewPath.startsWith("/browser?browse=")).toBe(true);
+		expect(browseTarget).toBe("/api/apps/local/demo/");
 		expect(body.completedActionHandoffId).toEqual(expect.any(String));
 		expect(result).toMatchObject({
 			status: "renderer-delivered",
@@ -189,6 +194,33 @@ describe("Browser launch navigation", () => {
 		await expect(
 			openLaunchUrlInBrowserView("http://[", message("client-a")),
 		).resolves.toEqual({ status: "invalid-url", openedInBrowser: false });
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("normalizes local dot segments before the Browser consumes the target", async () => {
+		const result = await openLaunchUrlInBrowserView(
+			"/api/apps/local/demo/../safe/",
+			message(),
+		);
+		const browseTarget = new URLSearchParams(
+			result.viewPath?.split("?")[1],
+		).get("browse");
+		expect(new URL(browseTarget ?? "", "https://agent.example").pathname).toBe(
+			"/api/apps/local/safe/",
+		);
+	});
+
+	it("rejects network-path relative URLs before delivery", async () => {
+		const fetchMock = vi.fn();
+		setFetch(fetchMock);
+		for (const launchUrl of [
+			"//evil.example/api/apps/local/demo/",
+			"/\\evil.example/api/apps/local/demo/",
+		]) {
+			await expect(
+				openLaunchUrlInBrowserView(launchUrl, message()),
+			).resolves.toEqual({ status: "invalid-url", openedInBrowser: false });
+		}
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 });

--- a/plugins/plugin-app-control/src/services/browser-view-navigation.test.ts
+++ b/plugins/plugin-app-control/src/services/browser-view-navigation.test.ts
@@ -1,194 +1,194 @@
-/**
- * Verifies app launch navigation at the caller-owned loopback boundary with a
- * mocked HTTP transport and no renderer or network dependency.
- */
+/** Exercises Browser launch delivery through the real caller-owned navigation request contract. */
 
 import type { Memory } from "@elizaos/core";
+import { REALTIME_VOICE_CLIENT_TRANSPORT } from "@elizaos/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-	appLaunchViewClientId,
-	isRealtimeVoiceAppLaunch,
-	openLaunchUrlInBrowserView,
-} from "./browser-view-navigation.js";
+import { openLaunchUrlInBrowserView } from "./browser-view-navigation.js";
 
-function response(body: unknown, status = 200): Response {
-	return new Response(JSON.stringify(body), {
-		status,
-		headers: { "content-type": "application/json" },
-	});
+const originalFetch = globalThis.fetch;
+
+function setFetch(mock: ReturnType<typeof vi.fn>): void {
+	globalThis.fetch = mock as typeof fetch;
+}
+
+function message(clientId?: string, voice = false): Memory {
+	return {
+		content: {
+			text: "launch demo",
+			metadata: {
+				...(clientId ? { viewClientId: clientId } : {}),
+				...(voice ? { clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT } : {}),
+			},
+		},
+	} as Memory;
 }
 
 afterEach(() => {
-	vi.unstubAllGlobals();
-	vi.restoreAllMocks();
+	globalThis.fetch = originalFetch;
 });
 
-describe("app launch Browser navigation", () => {
-	it("does not issue a global request without a valid originating client", async () => {
-		const fetchMock = vi.fn();
-		vi.stubGlobal("fetch", fetchMock);
-
-		await expect(
-			openLaunchUrlInBrowserView("/api/apps/local/demo/"),
-		).resolves.toMatchObject({
-			status: "unavailable",
-			completedActionDelivered: false,
-			errorCode: "NO_ORIGINATING_CLIENT",
-		});
-		expect(fetchMock).not.toHaveBeenCalled();
-	});
-
-	it("requires an own delivered marker and matching handoff receipt", async () => {
-		const fetchMock = vi.fn(async () =>
-			response({
-				ok: true,
-				completedActionDelivered: true,
-				completedActionHandoffId: "handoff-a",
-			}),
+describe("Browser launch navigation", () => {
+	it("targets the originating app renderer and trusts only its matching receipt", async () => {
+		const fetchMock = vi.fn(
+			async (_url: string | URL | Request, init?: RequestInit) => {
+				const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				return new Response(
+					JSON.stringify({
+						ok: true,
+						completedActionDelivered: true,
+						completedActionHandoffId: body.completedActionHandoffId,
+					}),
+					{ status: 200 },
+				);
+			},
 		);
-		vi.stubGlobal("fetch", fetchMock);
+		setFetch(fetchMock);
 
-		await expect(
-			openLaunchUrlInBrowserView("/api/apps/local/demo/", {
-				originatingClientId: "client-a",
-				completedActionHandoffId: "handoff-a",
-			}),
-		).resolves.toMatchObject({
-			status: "delivered",
-			completedActionDelivered: true,
-			completedActionHandoffId: "handoff-a",
-		});
-		const request = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
-		expect(request).toMatchObject({
-			delivery: "completed-action",
+		const result = await openLaunchUrlInBrowserView(
+			"/api/apps/local/demo/",
+			message("client-a"),
+		);
+
+		const body = JSON.parse(
+			String(fetchMock.mock.calls[0]?.[1]?.body),
+		) as Record<string, unknown>;
+		expect(body).toMatchObject({
 			clientId: "client-a",
-			completedActionHandoffId: "handoff-a",
+			delivery: "completed-action",
+			path: "/browser?browse=%2Fapi%2Fapps%2Flocal%2Fdemo%2F",
+		});
+		expect(body.completedActionHandoffId).toEqual(expect.any(String));
+		expect(result).toMatchObject({
+			status: "renderer-delivered",
+			openedInBrowser: true,
+			completedActionDelivered: true,
+			completedActionHandoffId: body.completedActionHandoffId,
 		});
 	});
 
-	it("retains the terminal fallback for a stale renderer", async () => {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(async () =>
-				response({
-					ok: true,
-					completedActionDelivered: false,
-					completedActionHandoffId: "handoff-stale",
-				}),
-			),
+	it("uses the completed action without issuing a global request when no client id exists", async () => {
+		const fetchMock = vi.fn();
+		setFetch(fetchMock);
+
+		const result = await openLaunchUrlInBrowserView(
+			"/api/apps/local/demo/",
+			message(),
 		);
 
-		await expect(
-			openLaunchUrlInBrowserView("/api/apps/local/demo/", {
-				originatingClientId: "stale-client",
-				completedActionHandoffId: "handoff-stale",
-			}),
-		).resolves.toMatchObject({
-			status: "fallback",
-			completedActionDelivered: false,
-			completedActionHandoffId: "handoff-stale",
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(result).toMatchObject({
+			status: "terminal-fallback",
+			openedInBrowser: false,
+			completedActionHandoffId: expect.any(String),
 		});
 	});
 
-	it("rejects malformed receipts and translates transport timeouts", async () => {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(async () => new Response("not-json", { status: 200 })),
-		);
-		await expect(
-			openLaunchUrlInBrowserView("/api/apps/local/demo/", {
-				originatingClientId: "client-a",
+	it.each([
+		[
+			"stale renderer",
+			new Response('{"ok":true,"completedActionDelivered":false}', {
+				status: 200,
 			}),
-		).resolves.toMatchObject({ errorCode: "INVALID_RECEIPT" });
+			undefined,
+		],
+		[
+			"malformed receipt",
+			new Response("{", { status: 200 }),
+			"malformed-receipt",
+		],
+	] as const)(
+		"retains terminal fallback for a %s",
+		async (_name, response, failure) => {
+			setFetch(vi.fn(async () => response));
+			const result = await openLaunchUrlInBrowserView(
+				"/api/apps/local/demo/",
+				message("client-stale"),
+			);
+			expect(result).toMatchObject({
+				status: "terminal-fallback",
+				openedInBrowser: false,
+				completedActionHandoffId: expect.any(String),
+				...(failure ? { navigationFailure: failure } : {}),
+			});
+		},
+	);
 
-		vi.stubGlobal(
-			"fetch",
+	it("reports a timed-out early delivery while preserving terminal fallback", async () => {
+		setFetch(
 			vi.fn(async () => {
 				throw new DOMException("timed out", "TimeoutError");
 			}),
 		);
-		await expect(
-			openLaunchUrlInBrowserView("/api/apps/local/demo/", {
-				originatingClientId: "client-a",
-			}),
-		).resolves.toMatchObject({ errorCode: "TRANSPORT_FAILURE" });
+		const result = await openLaunchUrlInBrowserView(
+			"/api/apps/local/demo/",
+			message("client-timeout"),
+		);
+		expect(result).toMatchObject({
+			status: "terminal-fallback",
+			openedInBrowser: false,
+			navigationFailure: "transport-error",
+		});
 	});
 
-	it("translates a malformed launch URL before any transport call", async () => {
-		const fetchMock = vi.fn();
-		vi.stubGlobal("fetch", fetchMock);
-		await expect(
-			openLaunchUrlInBrowserView("http://[", {
-				originatingClientId: "client-a",
-			}),
-		).resolves.toMatchObject({ errorCode: "INVALID_LAUNCH_URL" });
-		expect(fetchMock).not.toHaveBeenCalled();
+	it("uses originating-client delivery for voice and never creates a terminal handoff", async () => {
+		const fetchMock = vi.fn(
+			async () => new Response('{"ok":true}', { status: 200 }),
+		);
+		setFetch(fetchMock);
+		const result = await openLaunchUrlInBrowserView(
+			"/api/apps/local/demo/",
+			message("voice-client", true),
+		);
+		const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+		expect(body).toMatchObject({
+			clientId: "voice-client",
+			delivery: "originating-client",
+		});
+		expect(body).not.toHaveProperty("completedActionHandoffId");
+		expect(result).toMatchObject({
+			status: "renderer-delivered",
+			openedInBrowser: true,
+		});
+		expect(result).not.toHaveProperty("completedActionHandoffId");
 	});
 
-	it("scopes concurrent requests to their respective clients", async () => {
-		const bodies: Array<Record<string, unknown>> = [];
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(async (_url: string, init?: RequestInit) => {
+	it("keeps concurrent renderer requests isolated", async () => {
+		const bodies: Record<string, unknown>[] = [];
+		setFetch(
+			vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
 				const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
 				bodies.push(body);
-				return response({
-					ok: true,
-					completedActionDelivered: true,
-					completedActionHandoffId: body.completedActionHandoffId,
-				});
+				return new Response(
+					JSON.stringify({
+						ok: true,
+						completedActionDelivered: true,
+						completedActionHandoffId: body.completedActionHandoffId,
+					}),
+					{ status: 200 },
+				);
 			}),
 		);
 
-		await Promise.all([
-			openLaunchUrlInBrowserView("/api/apps/local/a/", {
-				originatingClientId: "client-a",
-			}),
-			openLaunchUrlInBrowserView("/api/apps/local/b/", {
-				originatingClientId: "client-b",
-			}),
+		const [first, second] = await Promise.all([
+			openLaunchUrlInBrowserView("/api/apps/local/one/", message("client-one")),
+			openLaunchUrlInBrowserView("/api/apps/local/two/", message("client-two")),
 		]);
+
 		expect(bodies.map((body) => body.clientId).sort()).toEqual([
-			"client-a",
-			"client-b",
+			"client-one",
+			"client-two",
 		]);
+		expect(first.completedActionHandoffId).not.toBe(
+			second.completedActionHandoffId,
+		);
 	});
 
-	it("uses originating-client delivery for realtime voice", async () => {
-		const fetchMock = vi.fn(async () => response({ ok: true }));
-		vi.stubGlobal("fetch", fetchMock);
+	it("rejects malformed launch URLs before delivery", async () => {
+		const fetchMock = vi.fn();
+		setFetch(fetchMock);
 		await expect(
-			openLaunchUrlInBrowserView("/api/apps/local/demo/", {
-				originatingClientId: "voice-client",
-				realtimeVoice: true,
-			}),
-		).resolves.toMatchObject({
-			status: "delivered",
-			completedActionDelivered: true,
-		});
-		const request = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
-		expect(request).toMatchObject({
-			delivery: "originating-client",
-			clientId: "voice-client",
-		});
-		expect(request).not.toHaveProperty("completedActionHandoffId");
-	});
-
-	it("reads only safe caller and voice metadata", () => {
-		const message = {
-			content: {
-				metadata: {
-					viewClientId: "client.1",
-					clientTransport: "realtime_voice",
-				},
-			},
-		} as Memory;
-		expect(appLaunchViewClientId(message)).toBe("client.1");
-		expect(isRealtimeVoiceAppLaunch(message)).toBe(true);
-		expect(
-			appLaunchViewClientId({
-				content: { metadata: { viewClientId: "bad client" } },
-			} as Memory),
-		).toBeUndefined();
+			openLaunchUrlInBrowserView("http://[", message("client-a")),
+		).resolves.toEqual({ status: "invalid-url", openedInBrowser: false });
+		expect(fetchMock).not.toHaveBeenCalled();
 	});
 });

--- a/plugins/plugin-app-control/src/services/browser-view-navigation.test.ts
+++ b/plugins/plugin-app-control/src/services/browser-view-navigation.test.ts
@@ -114,6 +114,17 @@ describe("app launch Browser navigation", () => {
 		).resolves.toMatchObject({ errorCode: "TRANSPORT_FAILURE" });
 	});
 
+	it("translates a malformed launch URL before any transport call", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		await expect(
+			openLaunchUrlInBrowserView("http://[", {
+				originatingClientId: "client-a",
+			}),
+		).resolves.toMatchObject({ errorCode: "INVALID_LAUNCH_URL" });
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
 	it("scopes concurrent requests to their respective clients", async () => {
 		const bodies: Array<Record<string, unknown>> = [];
 		vi.stubGlobal(

--- a/plugins/plugin-app-control/src/services/browser-view-navigation.test.ts
+++ b/plugins/plugin-app-control/src/services/browser-view-navigation.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Verifies app launch navigation at the caller-owned loopback boundary with a
+ * mocked HTTP transport and no renderer or network dependency.
+ */
+
+import type { Memory } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	appLaunchViewClientId,
+	isRealtimeVoiceAppLaunch,
+	openLaunchUrlInBrowserView,
+} from "./browser-view-navigation.js";
+
+function response(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe("app launch Browser navigation", () => {
+	it("does not issue a global request without a valid originating client", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			openLaunchUrlInBrowserView("/api/apps/local/demo/"),
+		).resolves.toMatchObject({
+			status: "unavailable",
+			completedActionDelivered: false,
+			errorCode: "NO_ORIGINATING_CLIENT",
+		});
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("requires an own delivered marker and matching handoff receipt", async () => {
+		const fetchMock = vi.fn(async () =>
+			response({
+				ok: true,
+				completedActionDelivered: true,
+				completedActionHandoffId: "handoff-a",
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			openLaunchUrlInBrowserView("/api/apps/local/demo/", {
+				originatingClientId: "client-a",
+				completedActionHandoffId: "handoff-a",
+			}),
+		).resolves.toMatchObject({
+			status: "delivered",
+			completedActionDelivered: true,
+			completedActionHandoffId: "handoff-a",
+		});
+		const request = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+		expect(request).toMatchObject({
+			delivery: "completed-action",
+			clientId: "client-a",
+			completedActionHandoffId: "handoff-a",
+		});
+	});
+
+	it("retains the terminal fallback for a stale renderer", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				response({
+					ok: true,
+					completedActionDelivered: false,
+					completedActionHandoffId: "handoff-stale",
+				}),
+			),
+		);
+
+		await expect(
+			openLaunchUrlInBrowserView("/api/apps/local/demo/", {
+				originatingClientId: "stale-client",
+				completedActionHandoffId: "handoff-stale",
+			}),
+		).resolves.toMatchObject({
+			status: "fallback",
+			completedActionDelivered: false,
+			completedActionHandoffId: "handoff-stale",
+		});
+	});
+
+	it("rejects malformed receipts and translates transport timeouts", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => new Response("not-json", { status: 200 })),
+		);
+		await expect(
+			openLaunchUrlInBrowserView("/api/apps/local/demo/", {
+				originatingClientId: "client-a",
+			}),
+		).resolves.toMatchObject({ errorCode: "INVALID_RECEIPT" });
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				throw new DOMException("timed out", "TimeoutError");
+			}),
+		);
+		await expect(
+			openLaunchUrlInBrowserView("/api/apps/local/demo/", {
+				originatingClientId: "client-a",
+			}),
+		).resolves.toMatchObject({ errorCode: "TRANSPORT_FAILURE" });
+	});
+
+	it("scopes concurrent requests to their respective clients", async () => {
+		const bodies: Array<Record<string, unknown>> = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_url: string, init?: RequestInit) => {
+				const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				bodies.push(body);
+				return response({
+					ok: true,
+					completedActionDelivered: true,
+					completedActionHandoffId: body.completedActionHandoffId,
+				});
+			}),
+		);
+
+		await Promise.all([
+			openLaunchUrlInBrowserView("/api/apps/local/a/", {
+				originatingClientId: "client-a",
+			}),
+			openLaunchUrlInBrowserView("/api/apps/local/b/", {
+				originatingClientId: "client-b",
+			}),
+		]);
+		expect(bodies.map((body) => body.clientId).sort()).toEqual([
+			"client-a",
+			"client-b",
+		]);
+	});
+
+	it("uses originating-client delivery for realtime voice", async () => {
+		const fetchMock = vi.fn(async () => response({ ok: true }));
+		vi.stubGlobal("fetch", fetchMock);
+		await expect(
+			openLaunchUrlInBrowserView("/api/apps/local/demo/", {
+				originatingClientId: "voice-client",
+				realtimeVoice: true,
+			}),
+		).resolves.toMatchObject({
+			status: "delivered",
+			completedActionDelivered: true,
+		});
+		const request = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+		expect(request).toMatchObject({
+			delivery: "originating-client",
+			clientId: "voice-client",
+		});
+		expect(request).not.toHaveProperty("completedActionHandoffId");
+	});
+
+	it("reads only safe caller and voice metadata", () => {
+		const message = {
+			content: {
+				metadata: {
+					viewClientId: "client.1",
+					clientTransport: "realtime_voice",
+				},
+			},
+		} as Memory;
+		expect(appLaunchViewClientId(message)).toBe("client.1");
+		expect(isRealtimeVoiceAppLaunch(message)).toBe(true);
+		expect(
+			appLaunchViewClientId({
+				content: { metadata: { viewClientId: "bad client" } },
+			} as Memory),
+		).toBeUndefined();
+	});
+});

--- a/plugins/plugin-app-control/src/services/browser-view-navigation.ts
+++ b/plugins/plugin-app-control/src/services/browser-view-navigation.ts
@@ -7,7 +7,6 @@ import {
 	readViewInteractionClientId,
 } from "../actions/view-delivery.js";
 import { navigateToView } from "../actions/views-show.js";
-import { getAppControlApiBase } from "../loopback-api.js";
 
 export type BrowserNavigationStatus =
 	| "renderer-delivered"
@@ -18,6 +17,10 @@ export type BrowserNavigationStatus =
 export interface BrowserNavigationResult {
 	status: BrowserNavigationStatus;
 	openedInBrowser: boolean;
+	/** Canonical http(s) target safe to expose to the model or renderer. */
+	safeLaunchUrl?: string;
+	/** Same target escaped for a Markdown link destination. */
+	safeMarkdownLaunchUrl?: string;
 	viewPath?: string;
 	completedActionDelivered?: true;
 	completedActionHandoffId?: string;
@@ -35,14 +38,27 @@ function navigationFailure(
 }
 
 export function browserViewPathForLaunchUrl(launchUrl: string): string {
-	if (launchUrl.startsWith("/api/apps/local/")) {
-		return `/browser?browse=${encodeURIComponent(launchUrl)}`;
+	if (launchUrl.startsWith("/")) {
+		const relativeBase = "https://relative.invalid/";
+		const parsed = new URL(launchUrl, relativeBase);
+		if (parsed.origin !== new URL(relativeBase).origin) {
+			throw new TypeError("Unsupported network-path app launch URL");
+		}
+		if (!parsed.pathname.startsWith("/api/apps/local/")) {
+			throw new TypeError("Unsupported relative app launch URL");
+		}
+		const relativeUrl = `${parsed.pathname}${parsed.search}${parsed.hash}`;
+		return `/browser?browse=${encodeURIComponent(relativeUrl)}`;
 	}
-	const absoluteUrl = new URL(launchUrl, `${getAppControlApiBase()}/`);
+	const absoluteUrl = new URL(launchUrl);
 	if (absoluteUrl.protocol !== "http:" && absoluteUrl.protocol !== "https:") {
 		throw new TypeError("Unsupported app launch URL protocol");
 	}
 	return `/browser?browse=${encodeURIComponent(absoluteUrl.toString())}`;
+}
+
+function markdownSafeHref(url: string): string {
+	return url.replace(/\\/g, "%5C").replace(/\(/g, "%28").replace(/\)/g, "%29");
 }
 
 export async function openLaunchUrlInBrowserView(
@@ -50,8 +66,16 @@ export async function openLaunchUrlInBrowserView(
 	message: Memory,
 ): Promise<BrowserNavigationResult> {
 	let viewPath: string;
+	let safeLaunchUrl: string;
+	let safeMarkdownLaunchUrl: string;
 	try {
 		viewPath = browserViewPathForLaunchUrl(launchUrl);
+		safeLaunchUrl =
+			new URLSearchParams(viewPath.slice(viewPath.indexOf("?") + 1)).get(
+				"browse",
+			) ?? "";
+		if (!safeLaunchUrl) throw new TypeError("Missing Browser launch target");
+		safeMarkdownLaunchUrl = markdownSafeHref(safeLaunchUrl);
 	} catch {
 		// error-policy:J3 an invalid launch URL becomes an explicit typed result;
 		// it is never sent to a renderer or disguised as successful navigation.
@@ -66,12 +90,16 @@ export async function openLaunchUrlInBrowserView(
 				status: "target-unavailable",
 				openedInBrowser: false,
 				viewPath,
+				safeLaunchUrl,
+				safeMarkdownLaunchUrl,
 			};
 		}
 		return {
 			status: "terminal-fallback",
 			openedInBrowser: false,
 			viewPath,
+			safeLaunchUrl,
+			safeMarkdownLaunchUrl,
 			completedActionHandoffId: randomUUID(),
 		};
 	}
@@ -100,6 +128,8 @@ export async function openLaunchUrlInBrowserView(
 			status: navigation.ok ? "renderer-delivered" : "target-unavailable",
 			openedInBrowser: navigation.ok,
 			viewPath,
+			safeLaunchUrl,
+			safeMarkdownLaunchUrl,
 			...(!navigation.ok && failure ? { navigationFailure: failure } : {}),
 		};
 	}
@@ -110,6 +140,8 @@ export async function openLaunchUrlInBrowserView(
 		status: delivered ? "renderer-delivered" : "terminal-fallback",
 		openedInBrowser: delivered,
 		viewPath,
+		safeLaunchUrl,
+		safeMarkdownLaunchUrl,
 		...(delivered ? { completedActionDelivered: true as const } : {}),
 		...(completedActionHandoffId ? { completedActionHandoffId } : {}),
 		...(navigation.receiptStatus === "malformed"

--- a/plugins/plugin-app-control/src/services/browser-view-navigation.ts
+++ b/plugins/plugin-app-control/src/services/browser-view-navigation.ts
@@ -1,143 +1,121 @@
-/** Caller-scoped handoff from app launch results into Eliza's in-app Browser. */
+/** Delivers launched-app URLs to the Browser view owned by the requesting renderer. */
 
 import { randomUUID } from "node:crypto";
 import type { Memory } from "@elizaos/core";
-import { REALTIME_VOICE_CLIENT_TRANSPORT } from "@elizaos/shared";
+import {
+	isRealtimeVoiceTurn,
+	readViewInteractionClientId,
+} from "../actions/view-delivery.js";
 import { navigateToView } from "../actions/views-show.js";
 import { getAppControlApiBase } from "../loopback-api.js";
+
+export type BrowserNavigationStatus =
+	| "renderer-delivered"
+	| "terminal-fallback"
+	| "target-unavailable"
+	| "invalid-url";
+
+export interface BrowserNavigationResult {
+	status: BrowserNavigationStatus;
+	openedInBrowser: boolean;
+	viewPath?: string;
+	completedActionDelivered?: true;
+	completedActionHandoffId?: string;
+	navigationFailure?:
+		| "unsupported-route"
+		| "http-error"
+		| "transport-error"
+		| "malformed-receipt";
+}
+
+function navigationFailure(
+	status: Awaited<ReturnType<typeof navigateToView>>["status"],
+): BrowserNavigationResult["navigationFailure"] {
+	return status === "accepted" ? undefined : status;
+}
 
 export function browserViewPathForLaunchUrl(launchUrl: string): string {
 	if (launchUrl.startsWith("/api/apps/local/")) {
 		return `/browser?browse=${encodeURIComponent(launchUrl)}`;
 	}
-	const absoluteUrl = new URL(
-		launchUrl,
-		`${getAppControlApiBase()}/`,
-	).toString();
-	return `/browser?browse=${encodeURIComponent(absoluteUrl)}`;
-}
-
-const SAFE_VIEW_CLIENT_ID = /^[A-Za-z0-9._-]{1,128}$/;
-
-export function appLaunchViewClientId(message: Memory): string | undefined {
-	const metadata = message.content.metadata;
-	if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
-		return undefined;
+	const absoluteUrl = new URL(launchUrl, `${getAppControlApiBase()}/`);
+	if (absoluteUrl.protocol !== "http:" && absoluteUrl.protocol !== "https:") {
+		throw new TypeError("Unsupported app launch URL protocol");
 	}
-	const clientId = (metadata as Record<string, unknown>).viewClientId;
-	return typeof clientId === "string" && SAFE_VIEW_CLIENT_ID.test(clientId)
-		? clientId
-		: undefined;
-}
-
-export function isRealtimeVoiceAppLaunch(message: Memory): boolean {
-	const metadata = message.content.metadata;
-	return (
-		typeof metadata === "object" &&
-		metadata !== null &&
-		!Array.isArray(metadata) &&
-		(metadata as Record<string, unknown>).clientTransport ===
-			REALTIME_VOICE_CLIENT_TRANSPORT
-	);
-}
-
-export interface BrowserViewNavigationResult {
-	path: string;
-	status: "delivered" | "fallback" | "unavailable";
-	completedActionDelivered: boolean;
-	completedActionHandoffId?: string;
-	errorCode?:
-		| "NO_ORIGINATING_CLIENT"
-		| "INVALID_LAUNCH_URL"
-		| "RENDERER_UNAVAILABLE"
-		| "INVALID_RECEIPT"
-		| "NAVIGATION_REJECTED"
-		| "TRANSPORT_FAILURE";
+	return `/browser?browse=${encodeURIComponent(absoluteUrl.toString())}`;
 }
 
 export async function openLaunchUrlInBrowserView(
 	launchUrl: string,
-	options: {
-		originatingClientId?: string;
-		realtimeVoice?: boolean;
-		completedActionHandoffId?: string;
-	} = {},
-): Promise<BrowserViewNavigationResult> {
-	let path: string;
+	message: Memory,
+): Promise<BrowserNavigationResult> {
+	let viewPath: string;
 	try {
-		path = browserViewPathForLaunchUrl(launchUrl);
-	} catch (error) {
-		// error-policy:J4 malformed launch receipts become an explicit unavailable
-		// result so the action can retain the raw link without claiming navigation.
-		void error;
+		viewPath = browserViewPathForLaunchUrl(launchUrl);
+	} catch {
+		// error-policy:J3 an invalid launch URL becomes an explicit typed result;
+		// it is never sent to a renderer or disguised as successful navigation.
+		return { status: "invalid-url", openedInBrowser: false };
+	}
+
+	const originatingClientId = readViewInteractionClientId(message);
+	const voiceTurn = isRealtimeVoiceTurn(message);
+	if (!originatingClientId) {
+		if (voiceTurn) {
+			return {
+				status: "target-unavailable",
+				openedInBrowser: false,
+				viewPath,
+			};
+		}
 		return {
-			path: "/browser",
-			status: "unavailable",
-			completedActionDelivered: false,
-			errorCode: "INVALID_LAUNCH_URL",
+			status: "terminal-fallback",
+			openedInBrowser: false,
+			viewPath,
+			completedActionHandoffId: randomUUID(),
 		};
 	}
-	const originatingClientId = options.originatingClientId;
-	if (!originatingClientId || !SAFE_VIEW_CLIENT_ID.test(originatingClientId)) {
-		return {
-			path,
-			status: "unavailable",
-			completedActionDelivered: false,
-			errorCode: "NO_ORIGINATING_CLIENT",
-		};
-	}
-	const delivery = options.realtimeVoice
-		? "originating-client"
-		: "completed-action";
-	const completedActionHandoffId = options.realtimeVoice
-		? undefined
-		: (options.completedActionHandoffId ?? randomUUID());
-	const result = await navigateToView(
+
+	const completedActionHandoffId = voiceTurn ? undefined : randomUUID();
+	const navigation = await navigateToView(
 		{
 			id: "browser",
 			label: "Browser",
-			pluginName: "plugin-app-control",
-			path,
-			viewType: "gui",
+			path: viewPath,
+			pluginName: "@elizaos/builtin",
 			available: true,
+			viewType: "gui",
 		},
 		"gui",
 		undefined,
 		"Browser",
-		delivery,
+		voiceTurn ? "originating-client" : "completed-action",
 		originatingClientId,
 		completedActionHandoffId,
 	);
-	if (!result.ok) {
+
+	if (voiceTurn) {
+		const failure = navigationFailure(navigation.status);
 		return {
-			path,
-			status: "unavailable",
-			completedActionDelivered: false,
-			errorCode:
-				result.failureKind === "transport"
-					? "TRANSPORT_FAILURE"
-					: result.failureKind === "navigation-rejected"
-						? "NAVIGATION_REJECTED"
-						: "RENDERER_UNAVAILABLE",
+			status: navigation.ok ? "renderer-delivered" : "target-unavailable",
+			openedInBrowser: navigation.ok,
+			viewPath,
+			...(!navigation.ok && failure ? { navigationFailure: failure } : {}),
 		};
 	}
-	if (options.realtimeVoice) {
-		return { path, status: "delivered", completedActionDelivered: true };
-	}
-	const handoffEchoed =
-		result.completedActionHandoffId === completedActionHandoffId;
-	const delivered = result.completedActionDelivered === true && handoffEchoed;
+
+	const delivered = navigation.receiptStatus === "delivered";
+	const failure = navigationFailure(navigation.status);
 	return {
-		path,
-		status: delivered
-			? "delivered"
-			: handoffEchoed
-				? "fallback"
-				: "unavailable",
-		completedActionDelivered: delivered,
-		...(handoffEchoed && completedActionHandoffId
-			? { completedActionHandoffId }
-			: {}),
-		...(!handoffEchoed ? { errorCode: "INVALID_RECEIPT" as const } : {}),
+		status: delivered ? "renderer-delivered" : "terminal-fallback",
+		openedInBrowser: delivered,
+		viewPath,
+		...(delivered ? { completedActionDelivered: true as const } : {}),
+		...(completedActionHandoffId ? { completedActionHandoffId } : {}),
+		...(navigation.receiptStatus === "malformed"
+			? { navigationFailure: "malformed-receipt" as const }
+			: !navigation.ok && failure
+				? { navigationFailure: failure }
+				: {}),
 	};
 }

--- a/plugins/plugin-app-control/src/services/browser-view-navigation.ts
+++ b/plugins/plugin-app-control/src/services/browser-view-navigation.ts
@@ -1,6 +1,9 @@
-/** Canonical handoff from app-control results into Eliza's in-app Browser. */
+/** Caller-scoped handoff from app launch results into Eliza's in-app Browser. */
 
+import { randomUUID } from "node:crypto";
+import type { Memory } from "@elizaos/core";
 import { logger } from "@elizaos/core";
+import { REALTIME_VOICE_CLIENT_TRANSPORT } from "@elizaos/shared";
 import { createViewsRequestHeaders } from "../actions/views-request-auth.js";
 import { getAppControlApiBase } from "../loopback-api.js";
 
@@ -15,9 +18,71 @@ export function browserViewPathForLaunchUrl(launchUrl: string): string {
 	return `/browser?browse=${encodeURIComponent(absoluteUrl)}`;
 }
 
+const SAFE_VIEW_CLIENT_ID = /^[A-Za-z0-9._-]{1,128}$/;
+
+export function appLaunchViewClientId(message: Memory): string | undefined {
+	const metadata = message.content.metadata;
+	if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+		return undefined;
+	}
+	const clientId = (metadata as Record<string, unknown>).viewClientId;
+	return typeof clientId === "string" && SAFE_VIEW_CLIENT_ID.test(clientId)
+		? clientId
+		: undefined;
+}
+
+export function isRealtimeVoiceAppLaunch(message: Memory): boolean {
+	const metadata = message.content.metadata;
+	return (
+		typeof metadata === "object" &&
+		metadata !== null &&
+		!Array.isArray(metadata) &&
+		(metadata as Record<string, unknown>).clientTransport ===
+			REALTIME_VOICE_CLIENT_TRANSPORT
+	);
+}
+
+export interface BrowserViewNavigationResult {
+	path: string;
+	status: "delivered" | "fallback" | "unavailable";
+	completedActionDelivered: boolean;
+	completedActionHandoffId?: string;
+	errorCode?:
+		| "NO_ORIGINATING_CLIENT"
+		| "RENDERER_UNAVAILABLE"
+		| "INVALID_RECEIPT"
+		| "NAVIGATION_REJECTED"
+		| "TRANSPORT_FAILURE";
+}
+
+function ownValue(body: object, key: string): unknown {
+	return Object.getOwnPropertyDescriptor(body, key)?.value;
+}
+
 export async function openLaunchUrlInBrowserView(
 	launchUrl: string,
-): Promise<boolean> {
+	options: {
+		originatingClientId?: string;
+		realtimeVoice?: boolean;
+		completedActionHandoffId?: string;
+	} = {},
+): Promise<BrowserViewNavigationResult> {
+	const path = browserViewPathForLaunchUrl(launchUrl);
+	const originatingClientId = options.originatingClientId;
+	if (!originatingClientId || !SAFE_VIEW_CLIENT_ID.test(originatingClientId)) {
+		return {
+			path,
+			status: "unavailable",
+			completedActionDelivered: false,
+			errorCode: "NO_ORIGINATING_CLIENT",
+		};
+	}
+	const delivery = options.realtimeVoice
+		? "originating-client"
+		: "completed-action";
+	const completedActionHandoffId = options.realtimeVoice
+		? undefined
+		: (options.completedActionHandoffId ?? randomUUID());
 	try {
 		const response = await fetch(
 			`${getAppControlApiBase()}/api/views/browser/navigate`,
@@ -25,18 +90,80 @@ export async function openLaunchUrlInBrowserView(
 				method: "POST",
 				headers: createViewsRequestHeaders(),
 				body: JSON.stringify({
-					path: browserViewPathForLaunchUrl(launchUrl),
+					path,
 					viewType: "gui",
 					source: "agent",
+					delivery,
+					clientId: originatingClientId,
+					...(completedActionHandoffId ? { completedActionHandoffId } : {}),
 				}),
 				signal: AbortSignal.timeout(5_000),
 			},
 		);
-		return response.ok;
+		if (!response.ok) {
+			return {
+				path,
+				status: "unavailable",
+				completedActionDelivered: false,
+				errorCode:
+					response.status === 409
+						? "RENDERER_UNAVAILABLE"
+						: "NAVIGATION_REJECTED",
+			};
+		}
+		let body: unknown;
+		try {
+			body = await response.json();
+		} catch (error) {
+			// error-policy:J3 a malformed server receipt is an explicit unconfirmed
+			// result; it must never be promoted to renderer-observed delivery.
+			if (!(error instanceof SyntaxError)) throw error;
+			return {
+				path,
+				status: "unavailable",
+				completedActionDelivered: false,
+				errorCode: "INVALID_RECEIPT",
+			};
+		}
+		if (typeof body !== "object" || body === null || Array.isArray(body)) {
+			return {
+				path,
+				status: "unavailable",
+				completedActionDelivered: false,
+				errorCode: "INVALID_RECEIPT",
+			};
+		}
+		if (options.realtimeVoice) {
+			return {
+				path,
+				status: "delivered",
+				completedActionDelivered: true,
+			};
+		}
+		const handoffEchoed =
+			ownValue(body, "completedActionHandoffId") === completedActionHandoffId;
+		const delivered =
+			ownValue(body, "completedActionDelivered") === true && handoffEchoed;
+		return {
+			path,
+			status: delivered ? "delivered" : "fallback",
+			completedActionDelivered: delivered,
+			...(handoffEchoed && completedActionHandoffId
+				? { completedActionHandoffId }
+				: {}),
+			...(!handoffEchoed ? { errorCode: "INVALID_RECEIPT" as const } : {}),
+		};
 	} catch (err) {
+		// error-policy:J4 Browser navigation is an optional user-facing degrade;
+		// the action retains the launch link and reports the distinct failure.
 		logger.warn(
 			`[plugin-app-control] Browser view navigation failed: ${err instanceof Error ? err.message : String(err)}`,
 		);
-		return false;
+		return {
+			path,
+			status: "unavailable",
+			completedActionDelivered: false,
+			errorCode: "TRANSPORT_FAILURE",
+		};
 	}
 }

--- a/plugins/plugin-app-control/src/services/browser-view-navigation.ts
+++ b/plugins/plugin-app-control/src/services/browser-view-navigation.ts
@@ -1,0 +1,42 @@
+/** Canonical handoff from app-control results into Eliza's in-app Browser. */
+
+import { logger } from "@elizaos/core";
+import { createViewsRequestHeaders } from "../actions/views-request-auth.js";
+import { getAppControlApiBase } from "../loopback-api.js";
+
+export function browserViewPathForLaunchUrl(launchUrl: string): string {
+	if (launchUrl.startsWith("/api/apps/local/")) {
+		return `/browser?browse=${encodeURIComponent(launchUrl)}`;
+	}
+	const absoluteUrl = new URL(
+		launchUrl,
+		`${getAppControlApiBase()}/`,
+	).toString();
+	return `/browser?browse=${encodeURIComponent(absoluteUrl)}`;
+}
+
+export async function openLaunchUrlInBrowserView(
+	launchUrl: string,
+): Promise<boolean> {
+	try {
+		const response = await fetch(
+			`${getAppControlApiBase()}/api/views/browser/navigate`,
+			{
+				method: "POST",
+				headers: createViewsRequestHeaders(),
+				body: JSON.stringify({
+					path: browserViewPathForLaunchUrl(launchUrl),
+					viewType: "gui",
+					source: "agent",
+				}),
+				signal: AbortSignal.timeout(5_000),
+			},
+		);
+		return response.ok;
+	} catch (err) {
+		logger.warn(
+			`[plugin-app-control] Browser view navigation failed: ${err instanceof Error ? err.message : String(err)}`,
+		);
+		return false;
+	}
+}

--- a/plugins/plugin-app-control/src/services/browser-view-navigation.ts
+++ b/plugins/plugin-app-control/src/services/browser-view-navigation.ts
@@ -2,9 +2,8 @@
 
 import { randomUUID } from "node:crypto";
 import type { Memory } from "@elizaos/core";
-import { logger } from "@elizaos/core";
 import { REALTIME_VOICE_CLIENT_TRANSPORT } from "@elizaos/shared";
-import { createViewsRequestHeaders } from "../actions/views-request-auth.js";
+import { navigateToView } from "../actions/views-show.js";
 import { getAppControlApiBase } from "../loopback-api.js";
 
 export function browserViewPathForLaunchUrl(launchUrl: string): string {
@@ -56,10 +55,6 @@ export interface BrowserViewNavigationResult {
 		| "TRANSPORT_FAILURE";
 }
 
-function ownValue(body: object, key: string): unknown {
-	return Object.getOwnPropertyDescriptor(body, key)?.value;
-}
-
 export async function openLaunchUrlInBrowserView(
 	launchUrl: string,
 	options: {
@@ -72,11 +67,9 @@ export async function openLaunchUrlInBrowserView(
 	try {
 		path = browserViewPathForLaunchUrl(launchUrl);
 	} catch (error) {
-		// error-policy:J4 a malformed launch receipt cannot navigate a renderer;
-		// retain an explicit result so the action can still present the raw link.
-		logger.warn(
-			`[plugin-app-control] Invalid app launch URL: ${error instanceof Error ? error.message : String(error)}`,
-		);
+		// error-policy:J4 malformed launch receipts become an explicit unavailable
+		// result so the action can retain the raw link without claiming navigation.
+		void error;
 		return {
 			path: "/browser",
 			status: "unavailable",
@@ -99,95 +92,52 @@ export async function openLaunchUrlInBrowserView(
 	const completedActionHandoffId = options.realtimeVoice
 		? undefined
 		: (options.completedActionHandoffId ?? randomUUID());
-	try {
-		const response = await fetch(
-			`${getAppControlApiBase()}/api/views/browser/navigate`,
-			{
-				method: "POST",
-				headers: createViewsRequestHeaders(),
-				body: JSON.stringify({
-					path,
-					viewType: "gui",
-					source: "agent",
-					delivery,
-					clientId: originatingClientId,
-					...(completedActionHandoffId ? { completedActionHandoffId } : {}),
-				}),
-				signal: AbortSignal.timeout(5_000),
-			},
-		);
-		if (!response.ok) {
-			return {
-				path,
-				status: "unavailable",
-				completedActionDelivered: false,
-				errorCode:
-					response.status === 409
-						? "RENDERER_UNAVAILABLE"
-						: "NAVIGATION_REJECTED",
-			};
-		}
-		let body: unknown;
-		try {
-			body = await response.json();
-		} catch (error) {
-			// error-policy:J3 a malformed server receipt is an explicit unconfirmed
-			// result; it must never be promoted to renderer-observed delivery.
-			if (!(error instanceof SyntaxError)) throw error;
-			return {
-				path,
-				status: "unavailable",
-				completedActionDelivered: false,
-				errorCode: "INVALID_RECEIPT",
-			};
-		}
-		if (typeof body !== "object" || body === null || Array.isArray(body)) {
-			return {
-				path,
-				status: "unavailable",
-				completedActionDelivered: false,
-				errorCode: "INVALID_RECEIPT",
-			};
-		}
-		if (ownValue(body, "ok") !== true) {
-			return {
-				path,
-				status: "unavailable",
-				completedActionDelivered: false,
-				errorCode: "INVALID_RECEIPT",
-			};
-		}
-		if (options.realtimeVoice) {
-			return {
-				path,
-				status: "delivered",
-				completedActionDelivered: true,
-			};
-		}
-		const handoffEchoed =
-			ownValue(body, "completedActionHandoffId") === completedActionHandoffId;
-		const delivered =
-			ownValue(body, "completedActionDelivered") === true && handoffEchoed;
-		return {
+	const result = await navigateToView(
+		{
+			id: "browser",
+			label: "Browser",
+			pluginName: "plugin-app-control",
 			path,
-			status: delivered ? "delivered" : "fallback",
-			completedActionDelivered: delivered,
-			...(handoffEchoed && completedActionHandoffId
-				? { completedActionHandoffId }
-				: {}),
-			...(!handoffEchoed ? { errorCode: "INVALID_RECEIPT" as const } : {}),
-		};
-	} catch (err) {
-		// error-policy:J4 Browser navigation is an optional user-facing degrade;
-		// the action retains the launch link and reports the distinct failure.
-		logger.warn(
-			`[plugin-app-control] Browser view navigation failed: ${err instanceof Error ? err.message : String(err)}`,
-		);
+			viewType: "gui",
+			available: true,
+		},
+		"gui",
+		undefined,
+		"Browser",
+		delivery,
+		originatingClientId,
+		completedActionHandoffId,
+	);
+	if (!result.ok) {
 		return {
 			path,
 			status: "unavailable",
 			completedActionDelivered: false,
-			errorCode: "TRANSPORT_FAILURE",
+			errorCode:
+				result.failureKind === "transport"
+					? "TRANSPORT_FAILURE"
+					: result.failureKind === "navigation-rejected"
+						? "NAVIGATION_REJECTED"
+						: "RENDERER_UNAVAILABLE",
 		};
 	}
+	if (options.realtimeVoice) {
+		return { path, status: "delivered", completedActionDelivered: true };
+	}
+	const handoffEchoed =
+		result.completedActionHandoffId === completedActionHandoffId;
+	const delivered = result.completedActionDelivered === true && handoffEchoed;
+	return {
+		path,
+		status: delivered
+			? "delivered"
+			: handoffEchoed
+				? "fallback"
+				: "unavailable",
+		completedActionDelivered: delivered,
+		...(handoffEchoed && completedActionHandoffId
+			? { completedActionHandoffId }
+			: {}),
+		...(!handoffEchoed ? { errorCode: "INVALID_RECEIPT" as const } : {}),
+	};
 }

--- a/plugins/plugin-app-control/src/services/browser-view-navigation.ts
+++ b/plugins/plugin-app-control/src/services/browser-view-navigation.ts
@@ -49,6 +49,7 @@ export interface BrowserViewNavigationResult {
 	completedActionHandoffId?: string;
 	errorCode?:
 		| "NO_ORIGINATING_CLIENT"
+		| "INVALID_LAUNCH_URL"
 		| "RENDERER_UNAVAILABLE"
 		| "INVALID_RECEIPT"
 		| "NAVIGATION_REJECTED"
@@ -67,7 +68,22 @@ export async function openLaunchUrlInBrowserView(
 		completedActionHandoffId?: string;
 	} = {},
 ): Promise<BrowserViewNavigationResult> {
-	const path = browserViewPathForLaunchUrl(launchUrl);
+	let path: string;
+	try {
+		path = browserViewPathForLaunchUrl(launchUrl);
+	} catch (error) {
+		// error-policy:J4 a malformed launch receipt cannot navigate a renderer;
+		// retain an explicit result so the action can still present the raw link.
+		logger.warn(
+			`[plugin-app-control] Invalid app launch URL: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		return {
+			path: "/browser",
+			status: "unavailable",
+			completedActionDelivered: false,
+			errorCode: "INVALID_LAUNCH_URL",
+		};
+	}
 	const originatingClientId = options.originatingClientId;
 	if (!originatingClientId || !SAFE_VIEW_CLIENT_ID.test(originatingClientId)) {
 		return {
@@ -126,6 +142,14 @@ export async function openLaunchUrlInBrowserView(
 			};
 		}
 		if (typeof body !== "object" || body === null || Array.isArray(body)) {
+			return {
+				path,
+				status: "unavailable",
+				completedActionDelivered: false,
+				errorCode: "INVALID_RECEIPT",
+			};
+		}
+		if (ownValue(body, "ok") !== true) {
 			return {
 				path,
 				status: "unavailable",

--- a/plugins/plugin-app-control/tsconfig.json
+++ b/plugins/plugin-app-control/tsconfig.json
@@ -29,6 +29,9 @@
 			"@elizaos/capacitor-bun-runtime": [
 				"../plugin-native-bun-runtime/src/index.ts"
 			],
+			"@elizaos/capacitor-secure-store": [
+				"../plugin-native-secure-store/src/index.ts"
+			],
 			"@elizaos/ui": ["../../packages/ui/src/index.ts"],
 			"@elizaos/ui/*": ["../../packages/ui/src/*"]
 		}


### PR DESCRIPTION
## Behavior

- APP launch uses the canonical caller-owned VIEWS transport: chat uses `completed-action`; realtime voice uses `originating-client`; both carry the validated originating renderer ID.
- Browser-open success requires a typed renderer-observed delivery receipt with the exact handoff ID. Zero/stale clients, timeout, malformed or rejected responses remain explicit fallback/unavailable states.
- Caller-owned route state is transactional and records only the registered canonical path after the relevant commit edge, so concurrent clients cannot leak private `browse` URLs through global current-view context.
- Local `/api/apps/local/...` targets remain relative across the server boundary and resolve through the renderer canonical API-base helper, including native/session fallback. Network-path, non-http(s), and malformed targets are rejected.
- Unsafe launch URLs never enter model-bound prompt data. Valid links are escaped for Markdown presentation.
- Required post-tool synthesis uses the canonical final-message safety projection. Expected provider outages return a narrowly vetted action fallback without replaying the settled launch; programmer errors still throw.

## Exact tested revision

- Head: `6173a77ee74b5bc7c05a96b488c96183758746ac`
- Rebased/tested parent: `1d0457699ea1b69db8235cb61ab5a9e2e43b8dc9`
- Tree: `c9f91544beea5ccb85e2ba007d30415b03c95e05`

## Verification

- Core planner loop + happy path: 159 passed
- Agent real navigation route: 25 passed
- APP launch + Browser navigation: 16 passed
- UI handoff + completed navigation + BrowserWorkspace normalization/chrome: 46 passed
- Core typecheck: passed
- Biome on all 13 affected source/test files: passed
- `git diff --check`: passed
- Independent second-pass review: GO at exact head

## Environment-only broader gate limits

- `packages/app audit:app` built the view bundles until unrelated `plugin-task-coordinator` failed to resolve missing `@xterm/xterm`; capture generation did not start.
- Plugin/UI package typechecks are blocked by missing optional workspace dependencies such as `puppeteer-core`, Storybook, Tailwind/PostCSS, and UI libraries. The changed code has focused runtime coverage and touched-file lint/type evidence above.

AI provider/model: OpenAI / GPT-5.6 Sol
Client / agent tooling: Codex desktop / multi-agent
Attribution status: self-reported
