### PR TITLE
fix(core): enable bounded ADMIN role management

### DIFF
--- a/packages/core/src/features/advanced-capabilities/actions/role.admin-authority.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/role.admin-authority.test.ts
@@ -258,6 +258,7 @@ describe("ROLE bounded ADMIN authority", () => {
 
 	it("reauthorizes between batch writes and stops after a concurrent demotion", async () => {
 		const test = harness();
+		const callback = vi.fn(async () => undefined);
 		const authorizedWorld = structuredClone(test.world) as World;
 		const revokedWorld = {
 			...structuredClone(test.world),
@@ -287,15 +288,45 @@ describe("ROLE bounded ADMIN authority", () => {
 					],
 				},
 			},
+			callback,
 		);
 
 		expect(result).toMatchObject({
-			success: false,
-			error: "INSUFFICIENT_PERMISSIONS",
-			data: { requesterRole: "USER" },
+			success: true,
+			text: "Updated 1 role; 1 failed.",
+			userFacingText: "Updated 1 role; 1 failed.",
+			verifiedUserFacing: true,
+			turnComplete: true,
+			values: { successCount: 1, failureCount: 1 },
+			data: {
+				successCount: 1,
+				failureCount: 1,
+				authorizationStop: {
+					entityId: IDS.user,
+					error: "INSUFFICIENT_PERMISSIONS",
+					requesterRole: "USER",
+				},
+				failures: [
+					{
+						entityId: IDS.user,
+						error: "INSUFFICIENT_PERMISSIONS",
+						requesterRole: "USER",
+					},
+				],
+			},
 		});
 		expect(test.getWorld).toHaveBeenCalledTimes(3);
 		expect(test.updateWorld).toHaveBeenCalledTimes(1);
+		expect(callback).toHaveBeenCalledOnce();
+		expect(callback).toHaveBeenCalledWith({
+			text: "Updated 1 role; 1 failed.",
+			actions: ["ROLE"],
+		});
+		expect(
+			(authorizedWorld.metadata as { roles: Record<string, string> }).roles[
+				IDS.guest
+			],
+		).toBe("USER");
 		expect(
 			(authorizedWorld.metadata as { roles: Record<string, string> }).roles[
 				IDS.user

--- a/packages/core/src/features/advanced-capabilities/actions/role.admin-authority.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/role.admin-authority.test.ts
@@ -285,22 +285,25 @@ describe("ROLE bounded ADMIN authority", () => {
 					assignments: [
 						{ entityId: IDS.guest, newRole: "USER" },
 						{ entityId: IDS.user, newRole: "ADMIN" },
+						{ entityId: IDS.peerAdmin, newRole: "USER" },
 					],
 				},
 			},
 			callback,
 		);
 
-		expect(result).toMatchObject({
+		expect(result).toEqual({
 			success: true,
-			text: "Updated 1 role; 1 failed.",
-			userFacingText: "Updated 1 role; 1 failed.",
+			text: "Updated 1 role; 2 failed.",
+			userFacingText: "Updated 1 role; 2 failed.",
 			verifiedUserFacing: true,
 			turnComplete: true,
-			values: { successCount: 1, failureCount: 1 },
+			values: { successCount: 1, failureCount: 2 },
 			data: {
+				actionName: "ROLE",
+				op: "assign",
 				successCount: 1,
-				failureCount: 1,
+				failureCount: 2,
 				authorizationStop: {
 					entityId: IDS.user,
 					error: "INSUFFICIENT_PERMISSIONS",
@@ -311,15 +314,27 @@ describe("ROLE bounded ADMIN authority", () => {
 						entityId: IDS.user,
 						error: "INSUFFICIENT_PERMISSIONS",
 						requesterRole: "USER",
+						skipped: true,
+						reason:
+							"Only OWNERs and ADMINs can manage roles; tell the user they lack permission.",
+					},
+					{
+						entityId: IDS.peerAdmin,
+						error: "ROLE_BATCH_STOPPED_AFTER_AUTHORIZATION_CHANGE",
+						requesterRole: "USER",
+						skipped: true,
+						reason:
+							"Not attempted because role management authority changed earlier in the batch.",
 					},
 				],
+				worldId: IDS.world,
 			},
 		});
 		expect(test.getWorld).toHaveBeenCalledTimes(3);
 		expect(test.updateWorld).toHaveBeenCalledTimes(1);
 		expect(callback).toHaveBeenCalledOnce();
 		expect(callback).toHaveBeenCalledWith({
-			text: "Updated 1 role; 1 failed.",
+			text: "Updated 1 role; 2 failed.",
 			actions: ["ROLE"],
 		});
 		expect(
@@ -332,6 +347,11 @@ describe("ROLE bounded ADMIN authority", () => {
 				IDS.user
 			],
 		).toBe("USER");
+		expect(
+			(authorizedWorld.metadata as { roles: Record<string, string> }).roles[
+				IDS.peerAdmin
+			],
+		).toBe("ADMIN");
 	});
 
 	it.each([

--- a/packages/core/src/features/advanced-capabilities/actions/role.admin-authority.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/role.admin-authority.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Verifies the real ROLE action admits ADMIN callers while its assignment
+ * hierarchy prevents peer, owner, self, and OWNER-grant escalation.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { canActionRun } from "../../../runtime/action-gate.ts";
+import { DEFAULT_CONTEXT_DEFINITIONS } from "../../../runtime/default-contexts.ts";
+import type {
+	IAgentRuntime,
+	Memory,
+	UUID,
+	World,
+} from "../../../types/index.ts";
+import { ChannelType } from "../../../types/index.ts";
+import { roleAction } from "./role.ts";
+
+const IDS = {
+	agent: "00000000-0000-4000-8000-000000000001" as UUID,
+	admin: "00000000-0000-4000-8000-000000000002" as UUID,
+	owner: "00000000-0000-4000-8000-000000000003" as UUID,
+	peerAdmin: "00000000-0000-4000-8000-000000000004" as UUID,
+	user: "00000000-0000-4000-8000-000000000005" as UUID,
+	guest: "00000000-0000-4000-8000-000000000006" as UUID,
+	room: "00000000-0000-4000-8000-000000000007" as UUID,
+	world: "00000000-0000-4000-8000-000000000008" as UUID,
+} as const;
+
+function harness(actor: "OWNER" | "ADMIN" | "USER" = "ADMIN") {
+	const actorId =
+		actor === "OWNER" ? IDS.owner : actor === "USER" ? IDS.user : IDS.admin;
+	const world = {
+		id: IDS.world,
+		agentId: IDS.agent,
+		name: "Test world",
+		serverId: "test",
+		metadata: {
+			ownership: { ownerId: IDS.owner },
+			roles: {
+				[IDS.owner]: "OWNER",
+				[IDS.admin]: "ADMIN",
+				[IDS.peerAdmin]: "ADMIN",
+				[IDS.user]: "USER",
+				[IDS.guest]: "GUEST",
+			},
+			roleSources: {
+				[IDS.owner]: "owner",
+				[IDS.admin]: "manual",
+				[IDS.peerAdmin]: "manual",
+				[IDS.user]: "manual",
+			},
+		},
+	} as unknown as World;
+	const updateWorld = vi.fn(async () => undefined);
+	const getWorld = vi.fn(async () => world);
+	const runtime = {
+		agentId: IDS.agent,
+		getRoom: vi.fn(async () => ({
+			id: IDS.room,
+			worldId: IDS.world,
+			messageServerId: "test",
+		})),
+		getWorld,
+		updateWorld,
+	} as unknown as IAgentRuntime;
+	const message = {
+		id: "00000000-0000-4000-8000-000000000009" as UUID,
+		entityId: actorId,
+		agentId: IDS.agent,
+		roomId: IDS.room,
+		content: { text: "manage roles", channelType: ChannelType.GROUP },
+		createdAt: Date.now(),
+	} as Memory;
+	return { getWorld, message, runtime, updateWorld, world };
+}
+
+async function assign(
+	target: UUID,
+	newRole: string,
+	actor: "OWNER" | "ADMIN" | "USER" = "ADMIN",
+) {
+	const test = harness(actor);
+	const result = await roleAction.handler(
+		test.runtime,
+		test.message,
+		undefined,
+		{
+			parameters: {
+				action: "assign",
+				assignments: [{ entityId: target, newRole }],
+			},
+		},
+	);
+	return { ...test, result };
+}
+
+async function list(actor: "OWNER" | "ADMIN" | "USER") {
+	const test = harness(actor);
+	const result = await roleAction.handler(
+		test.runtime,
+		test.message,
+		undefined,
+		{ parameters: { action: "list" } },
+	);
+	return { ...test, result };
+}
+
+describe("ROLE bounded ADMIN authority", () => {
+	it("advertises ADMIN as the minimum role", () => {
+		expect(roleAction.roleGate).toEqual({ minRole: "ADMIN" });
+	});
+
+	it("uses the shared action gate through settings without broadening admin context", () => {
+		expect(
+			canActionRun(roleAction, {
+				message: harness().message,
+				activeContexts: ["settings"],
+				userRoles: ["ADMIN"],
+			}),
+		).toBe(true);
+		expect(
+			canActionRun(roleAction, {
+				message: harness("USER").message,
+				activeContexts: ["settings"],
+				userRoles: ["USER"],
+			}),
+		).toBe(false);
+		expect(
+			DEFAULT_CONTEXT_DEFINITIONS.find(({ id }) => id === "settings")?.roleGate,
+		).toEqual({ minRole: "ADMIN" });
+		expect(
+			DEFAULT_CONTEXT_DEFINITIONS.find(({ id }) => id === "admin")?.roleGate,
+		).toEqual({ minRole: "OWNER" });
+	});
+
+	it("allows ADMIN to promote a lower-ranked USER to ADMIN", async () => {
+		const { result, updateWorld, world } = await assign(IDS.user, "ADMIN");
+
+		expect(result).toMatchObject({
+			success: true,
+			values: { successCount: 1 },
+		});
+		expect(updateWorld).toHaveBeenCalledTimes(1);
+		expect(
+			(world.metadata as { roles: Record<string, string> }).roles[IDS.user],
+		).toBe("ADMIN");
+	});
+
+	it("retains OWNER management of lower-ranked participants", async () => {
+		const { result, updateWorld } = await assign(IDS.user, "ADMIN", "OWNER");
+
+		expect(result).toMatchObject({
+			success: true,
+			values: { successCount: 1 },
+		});
+		expect(updateWorld).toHaveBeenCalledTimes(1);
+	});
+
+	it("fails closed when a lower-ranked caller reaches the handler directly", async () => {
+		const { result, updateWorld } = await assign(IDS.guest, "USER", "USER");
+
+		expect(result).toMatchObject({
+			success: false,
+			error: "INSUFFICIENT_PERMISSIONS",
+			data: { requesterRole: "USER" },
+		});
+		expect(updateWorld).not.toHaveBeenCalled();
+	});
+
+	it("denies a lower-ranked direct list before exposing role assignments", async () => {
+		const { result, updateWorld } = await list("USER");
+
+		expect(result).toMatchObject({
+			success: false,
+			error: "INSUFFICIENT_PERMISSIONS",
+			data: { op: "list", requesterRole: "USER" },
+		});
+		expect(result.text).not.toContain(IDS.owner);
+		expect(updateWorld).not.toHaveBeenCalled();
+	});
+
+	it("rechecks ADMIN authority immediately before a role write", async () => {
+		const test = harness();
+		const revokedWorld = {
+			...test.world,
+			metadata: {
+				...test.world.metadata,
+				roles: {
+					...(test.world.metadata as { roles: Record<string, string> }).roles,
+					[IDS.admin]: "USER",
+				},
+			},
+		} as World;
+		test.getWorld
+			.mockResolvedValueOnce(test.world)
+			.mockResolvedValueOnce(revokedWorld);
+
+		const result = await roleAction.handler(
+			test.runtime,
+			test.message,
+			undefined,
+			{
+				parameters: {
+					action: "assign",
+					assignments: [{ entityId: IDS.guest, newRole: "USER" }],
+				},
+			},
+		);
+
+		expect(result).toMatchObject({
+			success: false,
+			error: "INSUFFICIENT_PERMISSIONS",
+			data: { requesterRole: "USER" },
+		});
+		expect(test.getWorld).toHaveBeenCalledTimes(2);
+		expect(test.updateWorld).not.toHaveBeenCalled();
+	});
+
+	it("writes the exact authorized snapshot without a hidden world refetch", async () => {
+		const test = harness();
+		const authorizedWorld = structuredClone(test.world) as World;
+		const revokedWorld = {
+			...structuredClone(test.world),
+			metadata: {
+				...structuredClone(test.world.metadata),
+				roles: {
+					...(test.world.metadata as { roles: Record<string, string> }).roles,
+					[IDS.admin]: "USER",
+				},
+			},
+		} as World;
+		test.getWorld
+			.mockResolvedValueOnce(test.world)
+			.mockResolvedValueOnce(authorizedWorld)
+			.mockResolvedValueOnce(revokedWorld);
+
+		const result = await roleAction.handler(
+			test.runtime,
+			test.message,
+			undefined,
+			{
+				parameters: {
+					action: "assign",
+					assignments: [{ entityId: IDS.guest, newRole: "USER" }],
+				},
+			},
+		);
+
+		expect(result).toMatchObject({ success: true });
+		expect(test.getWorld).toHaveBeenCalledTimes(2);
+		expect(test.updateWorld).toHaveBeenCalledWith(authorizedWorld);
+		expect(
+			(authorizedWorld.metadata as { roles: Record<string, string> }).roles[
+				IDS.guest
+			],
+		).toBe("USER");
+	});
+
+	it("reauthorizes between batch writes and stops after a concurrent demotion", async () => {
+		const test = harness();
+		const authorizedWorld = structuredClone(test.world) as World;
+		const revokedWorld = {
+			...structuredClone(test.world),
+			metadata: {
+				...structuredClone(test.world.metadata),
+				roles: {
+					...(test.world.metadata as { roles: Record<string, string> }).roles,
+					[IDS.admin]: "USER",
+				},
+			},
+		} as World;
+		test.getWorld
+			.mockResolvedValueOnce(test.world)
+			.mockResolvedValueOnce(authorizedWorld)
+			.mockResolvedValueOnce(revokedWorld);
+
+		const result = await roleAction.handler(
+			test.runtime,
+			test.message,
+			undefined,
+			{
+				parameters: {
+					action: "assign",
+					assignments: [
+						{ entityId: IDS.guest, newRole: "USER" },
+						{ entityId: IDS.user, newRole: "ADMIN" },
+					],
+				},
+			},
+		);
+
+		expect(result).toMatchObject({
+			success: false,
+			error: "INSUFFICIENT_PERMISSIONS",
+			data: { requesterRole: "USER" },
+		});
+		expect(test.getWorld).toHaveBeenCalledTimes(3);
+		expect(test.updateWorld).toHaveBeenCalledTimes(1);
+		expect(
+			(authorizedWorld.metadata as { roles: Record<string, string> }).roles[
+				IDS.user
+			],
+		).toBe("USER");
+	});
+
+	it.each([
+		["peer ADMIN", IDS.peerAdmin, "USER"],
+		["OWNER", IDS.owner, "USER"],
+		["self", IDS.admin, "USER"],
+		["OWNER grant", IDS.user, "OWNER"],
+	] as const)("denies changing %s", async (_label, target, newRole) => {
+		const { result, updateWorld } = await assign(target, newRole);
+
+		expect(result).toMatchObject({
+			success: false,
+			values: { successCount: 0, failureCount: 1 },
+		});
+		expect(updateWorld).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/actions/role.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/role.ts
@@ -18,10 +18,11 @@ import {
 	getLiveEntityMetadataFromMessage,
 	normalizeRole,
 	type RoleName,
+	type RolesWorldMetadata,
+	recordRoleGrant,
 	resolveCanonicalOwnerId,
 	resolveEntityRole,
 	resolveWorldForMessage,
-	setEntityRole,
 } from "../../../roles.ts";
 import type {
 	Action,
@@ -110,6 +111,18 @@ interface RoleHandlerParams {
 	role?: string;
 	label?: string;
 	assignments?: unknown;
+}
+
+type ResolvedRoleWorldResult = NonNullable<
+	Awaited<ReturnType<typeof resolveWorldForMessage>>
+>;
+type ResolvedRoleWorld = ResolvedRoleWorldResult & {
+	world: NonNullable<ResolvedRoleWorldResult["world"]>;
+};
+
+interface RoleManagerAuthorization {
+	resolved: ResolvedRoleWorld;
+	requesterRole: RoleName;
 }
 
 function readParams(
@@ -423,59 +436,27 @@ async function applyAssignments(args: {
 	message: Memory;
 	assignments: RoleAssignment[];
 	op: "assign" | "revoke";
+	authorization: RoleManagerAuthorization;
 	callback?: HandlerCallback;
 }): Promise<ActionResult> {
-	const { runtime, message, assignments, op, callback } = args;
-
-	const resolved = await resolveWorldForMessage(runtime, message);
-	// Planner-facing only: the canned "no world context" boilerplate shipped
-	// visibly next to the evaluator's own error reply. The evaluator owns
-	// phrasing the failure to the user, in voice.
-	if (!resolved) {
-		return {
-			success: false,
-			text: "Cannot manage roles — no world context for this room; tell the user roles are unavailable here.",
-			error: "WORLD_NOT_FOUND",
-			data: { actionName: "ROLE", op },
-		};
-	}
-
-	const { world, metadata } = resolved;
-	if (!world) {
-		return {
-			success: false,
-			text: "Cannot manage roles — no world context for this room; tell the user roles are unavailable here.",
-			error: "WORLD_NOT_FOUND",
-			data: { actionName: "ROLE", op },
-		};
-	}
-	const requesterRole = await resolveEntityRole(
-		runtime,
-		world,
-		metadata,
-		message.entityId,
-		{ liveEntityMetadata: getLiveEntityMetadataFromMessage(message) },
-	);
-
-	// #12087 Item 17: the declared `roleGate: { minRole: "OWNER" }` is the
-	// enforced entry gate (canActionRun blocks anyone below OWNER before the
-	// handler runs on every exposure/execution path). This assertion agrees with
-	// it — the previous `|| requesterRole === "ADMIN"` branch was dead under the
-	// gate and contradicted the declaration. Per-assignment `canModifyRole` below
-	// still bounds which target roles an OWNER may set.
-	if (requesterRole !== "OWNER") {
-		return {
-			success: false,
-			text: "Only OWNERs can manage roles; tell the user they lack permission.",
-			error: "INSUFFICIENT_PERMISSIONS",
-			data: { actionName: "ROLE", op, requesterRole },
-		};
-	}
+	const { runtime, message, assignments, op, authorization, callback } = args;
 
 	const successes: Array<{ entityId: UUID; newRole: RoleName }> = [];
 	const failures: Array<{ entityId: UUID; reason: string }> = [];
 
-	for (const { entityId, newRole } of assignments) {
+	for (const [index, { entityId, newRole }] of assignments.entries()) {
+		// The first assignment uses the handler's final authorization snapshot.
+		// Reauthorize every later batch item so a demotion between writes stops the
+		// batch before another mutation. The authorized snapshot is also the exact
+		// world passed to updateWorld; no role helper may refetch behind this fence.
+		const currentAuthorization =
+			index === 0
+				? authorization
+				: await authorizeRoleManager({ runtime, message, op });
+		if (!("resolved" in currentAuthorization)) return currentAuthorization;
+		const { world, metadata } = currentAuthorization.resolved;
+		const { requesterRole } = currentAuthorization;
+
 		if (entityId === runtime.agentId) {
 			failures.push({ entityId, reason: "Cannot change agent's own role" });
 			continue;
@@ -524,7 +505,9 @@ async function applyAssignments(args: {
 			continue;
 		}
 
-		await setEntityRole(runtime, message, entityId, newRole);
+		recordRoleGrant(metadata, entityId, newRole);
+		(world as { metadata: RolesWorldMetadata }).metadata = metadata;
+		await runtime.updateWorld(world);
 		successes.push({ entityId, newRole });
 		logger.info(
 			{
@@ -562,28 +545,17 @@ async function applyAssignments(args: {
 			op,
 			successCount: successes.length,
 			failureCount: failures.length,
-			worldId: world.id,
+			worldId: authorization.resolved.world.id,
 		},
 	};
 }
 
 async function handleList(args: {
 	runtime: IAgentRuntime;
-	message: Memory;
+	resolved: ResolvedRoleWorld;
 	callback?: HandlerCallback;
 }): Promise<ActionResult> {
-	const { runtime, message, callback } = args;
-	const resolved = await resolveWorldForMessage(runtime, message);
-	// Planner-facing only: "No world context found." is internal-state
-	// tool-speak; the evaluator owns phrasing the failure to the user.
-	if (!resolved) {
-		return {
-			success: false,
-			text: "No world context found for this room; tell the user roles are unavailable here.",
-			error: "WORLD_NOT_FOUND",
-			data: { actionName: "ROLE", op: "list" },
-		};
-	}
+	const { runtime, resolved, callback } = args;
 	const roles = resolved.metadata.roles ?? {};
 	const entries = Object.entries(roles);
 	// Resolve display names so chat sees "Pat: ADMIN", not a raw UUID dump;
@@ -616,10 +588,46 @@ async function handleList(args: {
 	};
 }
 
+async function authorizeRoleManager(args: {
+	runtime: IAgentRuntime;
+	message: Memory;
+	op: RoleOp;
+}): Promise<RoleManagerAuthorization | ActionResult> {
+	const { runtime, message, op } = args;
+	const resolved = await resolveWorldForMessage(runtime, message);
+	if (!resolved?.world) {
+		return {
+			success: false,
+			text: "Cannot manage roles — no world context for this room; tell the user roles are unavailable here.",
+			error: "WORLD_NOT_FOUND",
+			data: { actionName: "ROLE", op },
+		};
+	}
+	const requesterRole = await resolveEntityRole(
+		runtime,
+		resolved.world,
+		resolved.metadata,
+		message.entityId,
+		{ liveEntityMetadata: getLiveEntityMetadataFromMessage(message) },
+	);
+	if (requesterRole !== "OWNER" && requesterRole !== "ADMIN") {
+		return {
+			success: false,
+			text: "Only OWNERs and ADMINs can manage roles; tell the user they lack permission.",
+			error: "INSUFFICIENT_PERMISSIONS",
+			data: { actionName: "ROLE", op, requesterRole },
+		};
+	}
+	return {
+		resolved: { ...resolved, world: resolved.world },
+		requesterRole,
+	};
+}
+
 export const roleAction: Action = {
 	name: "ROLE",
 	contexts: ["admin", "settings"],
-	roleGate: { minRole: "OWNER" },
+	roleGate: { minRole: "ADMIN" },
 	suppressPostActionContinuation: true,
 	description:
 		"Manage world roles OWNER/ADMIN/USER/GUEST. Ops assign, revoke, list. Use assignments[] or target name.",
@@ -727,9 +735,15 @@ export const roleAction: Action = {
 				data: { actionName: "ROLE", op: params.op ?? null },
 			};
 		}
+		const authorization = await authorizeRoleManager({ runtime, message, op });
+		if (!("resolved" in authorization)) return authorization;
 
 		if (op === "list") {
-			return handleList({ runtime, message, callback });
+			return handleList({
+				runtime,
+				resolved: authorization.resolved,
+				callback,
+			});
 		}
 
 		const defaultRole: RoleName | null = op === "revoke" ? "GUEST" : null;
@@ -754,12 +768,22 @@ export const roleAction: Action = {
 				data: { actionName: "ROLE", op, errors },
 			};
 		}
+		// Name/assignment resolution can cross storage boundaries. Recheck current
+		// authority immediately before any role write so a concurrent demotion or
+		// owner change cannot reuse the preliminary disclosure gate.
+		const finalAuthorization = await authorizeRoleManager({
+			runtime,
+			message,
+			op,
+		});
+		if (!("resolved" in finalAuthorization)) return finalAuthorization;
 
 		return applyAssignments({
 			runtime,
 			message,
 			assignments,
 			op,
+			authorization: finalAuthorization,
 			callback,
 		});
 	},

--- a/packages/core/src/features/advanced-capabilities/actions/role.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/role.ts
@@ -447,6 +447,7 @@ async function applyAssignments(args: {
 		reason: string;
 		error?: string;
 		requesterRole?: RoleName;
+		skipped?: boolean;
 	}> = [];
 	let authorizationStop:
 		| { entityId: UUID; error: string; requesterRole?: RoleName }
@@ -483,10 +484,23 @@ async function applyAssignments(args: {
 			};
 			failures.push({
 				...authorizationStop,
+				skipped: true,
 				reason:
 					currentAuthorization.text ??
 					"Role management authority changed before this assignment.",
 			});
+			for (const skippedAssignment of assignments.slice(index + 1)) {
+				failures.push({
+					entityId: skippedAssignment.entityId,
+					error: "ROLE_BATCH_STOPPED_AFTER_AUTHORIZATION_CHANGE",
+					...(authorizationStop.requesterRole
+						? { requesterRole: authorizationStop.requesterRole }
+						: {}),
+					skipped: true,
+					reason:
+						"Not attempted because role management authority changed earlier in the batch.",
+				});
+			}
 			break;
 		}
 		const { world, metadata } = currentAuthorization.resolved;

--- a/packages/core/src/features/advanced-capabilities/actions/role.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/role.ts
@@ -442,7 +442,15 @@ async function applyAssignments(args: {
 	const { runtime, message, assignments, op, authorization, callback } = args;
 
 	const successes: Array<{ entityId: UUID; newRole: RoleName }> = [];
-	const failures: Array<{ entityId: UUID; reason: string }> = [];
+	const failures: Array<{
+		entityId: UUID;
+		reason: string;
+		error?: string;
+		requesterRole?: RoleName;
+	}> = [];
+	let authorizationStop:
+		| { entityId: UUID; error: string; requesterRole?: RoleName }
+		| undefined;
 
 	for (const [index, { entityId, newRole }] of assignments.entries()) {
 		// The first assignment uses the handler's final authorization snapshot.
@@ -453,7 +461,34 @@ async function applyAssignments(args: {
 			index === 0
 				? authorization
 				: await authorizeRoleManager({ runtime, message, op });
-		if (!("resolved" in currentAuthorization)) return currentAuthorization;
+		if (!("resolved" in currentAuthorization)) {
+			const denialData = asRecord(currentAuthorization.data);
+			const error =
+				typeof currentAuthorization.error === "string"
+					? currentAuthorization.error
+					: currentAuthorization.error instanceof Error
+						? currentAuthorization.error.message
+						: "ROLE_REAUTHORIZATION_FAILED";
+			const requesterRole = normalizeRole(
+				typeof denialData?.requesterRole === "string"
+					? denialData.requesterRole
+					: undefined,
+			);
+			authorizationStop = {
+				entityId,
+				error,
+				...(requesterRole === "GUEST" && denialData?.requesterRole == null
+					? {}
+					: { requesterRole }),
+			};
+			failures.push({
+				...authorizationStop,
+				reason:
+					currentAuthorization.text ??
+					"Role management authority changed before this assignment.",
+			});
+			break;
+		}
 		const { world, metadata } = currentAuthorization.resolved;
 		const { requesterRole } = currentAuthorization;
 
@@ -545,6 +580,8 @@ async function applyAssignments(args: {
 			op,
 			successCount: successes.length,
 			failureCount: failures.length,
+			failures,
+			...(authorizationStop ? { authorizationStop } : {}),
 			worldId: authorization.resolved.world.id,
 		},
 	};


### PR DESCRIPTION
# Relates to

Refs #23100. This is the bounded canonical ROLE-action tranche; it intentionally does not close principal-kind separation, CAS/versioned persistence, durable audit records, complete gate inventory, UI transitions, or cross-surface acceptance.

- [x] Targets `develop` and is rebased onto `origin/develop@024b8e8c25268abcf7e5e92502bd7ca297cd95b7` with zero conflicts.
- [x] Multiple independent review waves found and drove repairs for direct-list disclosure, hidden write refetch, concealed partial effects, and incomplete skipped-suffix receipts.
- [x] Source, focused tests, package build/typecheck, and exact-head deterministic evidence are complete for this tranche.

# Risks

Medium authorization change. ADMIN participants can reach the canonical ROLE action through the existing ADMIN-gated `settings` context. Every operation has a direct-handler ADMIN/OWNER boundary; every mutation uses the exact authorized world snapshot, reauthorizes between batch writes, and reports every committed, failed, or skipped assignment.

# What this PR does

- changes the canonical ROLE action gate from OWNER to ADMIN while leaving the shared `admin` context OWNER-only;
- gates `list` before exposing the world role map, including direct handler invocation;
- retains hierarchy restrictions: ADMIN can change only lower-ranked targets, cannot change peers/OWNER/self, and cannot grant OWNER;
- rechecks current authority after name/assignment resolution and between batch writes;
- removes the hidden `setEntityRole` refetch and writes the exact snapshot used for authorization and hierarchy checks;
- stops a batch after concurrent authority loss while truthfully returning the committed prefix and explicitly marking the complete unprocessed suffix as skipped failures;
- adds real-handler adversarial tests for direct USER denial, hierarchy, stale authority, hidden-refetch mutation, and three-item concurrent demotion.

# Scope boundary

This PR does not add optimistic concurrency/CAS to `World`, distinguish human/service principals, add durable role-change audit storage, change UI/API/connector surfaces, or claim live-model/multi-user acceptance. Those remain in #23100.

# Testing

Exact head `aea9d70bdee7c2396d6267b11c21fb485237706f`:

- PASS — `bun run --cwd packages/core test src/features/advanced-capabilities/actions/role.admin-authority.test.ts src/roles.test.ts`: 58/58.
- PASS — pre-rebase patch-equivalent expanded role/surrogate suite: 62/62, 222 assertions.
- PASS — `bun run --cwd packages/core typecheck`.
- PASS — `bun run --cwd packages/core build:node`.
- PASS — scoped Biome and `git diff --check`.
- PASS — `bun install --frozen-lockfile` at the exact dependency graph.
- ROOT HOLD — `bun run verify` reaches unrelated current-base Biome failures in `packages/core/src/features/documents/service-list.test.ts`, `packages/core/src/validation/secrets.ts`, and other untouched warning diagnostics. This PR's two changed files are Biome-clean and all scoped gates pass.

# Evidence Gate

<!-- evidence-head:aea9d70bdee7c2396d6267b11c21fb485237706f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - deterministic real-handler receipts cover the complete bounded source contract; deployed persistent-world logs require protected acceptance credentials/tenancy.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - live-model planner evidence requires configured credentials and a persistent multi-participant world and remains a protected acceptance hold.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no generated or visual domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text surface changed.

# Protected merge / acceptance holds

- Live-model planner-to-ROLE evidence in a persistent OWNER/ADMIN/USER world requires model credentials and an authorized shared tenant/world.
- CAS/versioned writes and durable audit persistence remain required before #23100 can close; this PR does not claim atomic concurrency beyond binding each write to its authorized snapshot and stopping between writes.
- The PR remains ready for review while these acceptance holds are explicit.

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@024b8e8c25268abcf7e5e92502bd7ca297cd95b7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [bounded-admin-role]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex-desktop","skill_revision":"elizaOS/eliza@024b8e8c25268abcf7e5e92502bd7ca297cd95b7:packages/skills/skills/contribute-to-eliza"} -->
