### PR TITLE
fix(documents): reject missing access context

### DIFF
--- a/plugins/plugin-documents/AGENTS.md
+++ b/plugins/plugin-documents/AGENTS.md
@@ -79,9 +79,10 @@ The plugin itself reads no env vars directly. The `routes.ts` handler reads one 
 |-------------|--------|---------|
 | `ELIZA_ADMIN_ENTITY_ID` | `runtime.getSetting(...)` | Identifies the OWNER actor for document access-control decisions |
 
-Access control is role-based, resolved from request headers:
-- `x-eliza-entity-id` / `x-eliza-actor-entity-id` — caller's entity UUID
-- Role inferred as `OWNER`, `USER`, or `AGENT` based on header vs known agent/owner IDs
+Access control is role-based and requires the authenticated `AccessContext`
+provided by the host route boundary. Missing context returns `401`; the plugin
+never treats an absent caller as owner. Request headers alone are not an
+identity or authorization authority.
 
 ## How to extend
 

--- a/plugins/plugin-documents/CLAUDE.md
+++ b/plugins/plugin-documents/CLAUDE.md
@@ -79,9 +79,10 @@ The plugin itself reads no env vars directly. The `routes.ts` handler reads one 
 |-------------|--------|---------|
 | `ELIZA_ADMIN_ENTITY_ID` | `runtime.getSetting(...)` | Identifies the OWNER actor for document access-control decisions |
 
-Access control is role-based, resolved from request headers:
-- `x-eliza-entity-id` / `x-eliza-actor-entity-id` — caller's entity UUID
-- Role inferred as `OWNER`, `USER`, or `AGENT` based on header vs known agent/owner IDs
+Access control is role-based and requires the authenticated `AccessContext`
+provided by the host route boundary. Missing context returns `401`; the plugin
+never treats an absent caller as owner. Request headers alone are not an
+identity or authorization authority.
 
 ## How to extend
 

--- a/plugins/plugin-documents/README.md
+++ b/plugins/plugin-documents/README.md
@@ -41,7 +41,9 @@ Documents are stored as memories in the runtime's `documents` table and chunked 
 | `user-private` | Scoped to a specific user entity |
 | `agent-private` | OWNER, AGENT, and RUNTIME |
 
-The caller's role is resolved from the `x-eliza-entity-id` / `x-eliza-actor-entity-id` request headers and the `ELIZA_ADMIN_ENTITY_ID` runtime setting.
+The caller's role comes from the authenticated `AccessContext` supplied by the
+host route boundary. A request without that context returns `401`; request
+headers and `ELIZA_ADMIN_ENTITY_ID` never create an authenticated caller.
 
 ## Configuration
 

--- a/plugins/plugin-documents/src/routes.actor.test.ts
+++ b/plugins/plugin-documents/src/routes.actor.test.ts
@@ -3,7 +3,7 @@
  * and process-private principal authorization (Requirement 8).
  *
  * Verifies that:
- * - Missing AccessContext returns OWNER (trunk-authorized owner boundary).
+ * - Missing AccessContext fails closed without minting a route actor.
  * - AccessContext with requesterEntityId resolves to the correct RouteActor.
  * - OWNER/ADMIN roles map to OWNER; USER/GUEST map to USER.
  * - Missing requesterEntityId returns null.
@@ -18,19 +18,12 @@ const OWNER_ID = "00000000-0000-0000-0000-000000000002" as UUID;
 const USER_ID = "00000000-0000-0000-0000-000000000003" as UUID;
 
 describe("resolveRouteActor process-private principal authorization", () => {
-  it("returns OWNER for trunk-authorized owner boundary (no AccessContext)", () => {
-    const actor = resolveRouteActor(AGENT_ID, OWNER_ID);
-    expect(actor).not.toBeNull();
-    expect(actor?.role).toBe("OWNER");
-    expect(actor?.entityId).toBe(OWNER_ID);
-  });
-
-  it("returns OWNER with agentId fallback when ownerEntityId is absent", () => {
-    const actor = resolveRouteActor(AGENT_ID);
-    expect(actor).not.toBeNull();
-    expect(actor?.role).toBe("OWNER");
-    expect(actor?.entityId).toBe(AGENT_ID);
-  });
+  it.each([OWNER_ID, undefined])(
+    "fails closed without AccessContext when ownerEntityId is %s",
+    (ownerEntityId) => {
+      expect(resolveRouteActor(AGENT_ID, ownerEntityId)).toBeNull();
+    },
+  );
 
   it("grants OWNER permissions for OWNER AccessContext role", () => {
     const actor = resolveRouteActor(AGENT_ID, OWNER_ID, {

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -208,17 +208,7 @@ export function resolveRouteActor(
   ownerEntityId?: UUID,
   accessContext?: AccessContext,
 ): RouteActor | null {
-  // No accessContext means trunk-authorized owner boundary — preserve existing
-  // unfiltered behavior by returning OWNER.
-  if (!accessContext) {
-    return {
-      entityId: ownerEntityId ?? agentId,
-      role: "OWNER",
-      ownerEntityId,
-    };
-  }
-
-  if (!accessContext.requesterEntityId) return null;
+  if (!accessContext?.requesterEntityId) return null;
 
   // Delegate the RoleName -> RouteActorRole mapping to core rather than
   // restating it. The local version collapsed everything that was not
@@ -752,6 +742,23 @@ export async function handleDocumentsRoutes(
 
   if (!pathname.startsWith("/api/documents")) return false;
 
+  if (!runtime?.agentId) {
+    error(res, "Agent runtime is not available", 503);
+    return true;
+  }
+  const agentId = runtime.agentId as UUID;
+  const ownerEntityId = getOwnerEntityId(runtime);
+  const routeActor = resolveRouteActor(
+    agentId,
+    ownerEntityId,
+    ctx.accessContext,
+  );
+
+  if (!routeActor) {
+    error(res, "Authentication required", 401);
+    return true;
+  }
+
   const { service: documentsService, reason } =
     await getDocumentsService(runtime);
   if (!documentsService) {
@@ -769,23 +776,6 @@ export async function handleDocumentsRoutes(
         503,
       );
     }
-    return true;
-  }
-
-  if (!runtime?.agentId) {
-    error(res, "Agent runtime is not available", 503);
-    return true;
-  }
-  const agentId = runtime.agentId as UUID;
-  const ownerEntityId = getOwnerEntityId(runtime);
-  const routeActor = resolveRouteActor(
-    agentId,
-    ownerEntityId,
-    ctx.accessContext,
-  );
-
-  if (!routeActor) {
-    error(res, "Authentication required", 401);
     return true;
   }
   // Preserve the runtime guard across the nested async location resolver.

--- a/plugins/plugin-documents/test/routes.test.ts
+++ b/plugins/plugin-documents/test/routes.test.ts
@@ -39,7 +39,7 @@ function buildCtx(args: {
   pathname: string;
   body?: unknown;
   runtime?: Partial<NonNullable<DocumentRouteContext["runtime"]>>;
-  accessContext?: AccessContext;
+  accessContext?: AccessContext | null;
 }): {
   ctx: DocumentRouteContext;
   res: MockResponse;
@@ -64,12 +64,14 @@ function buildCtx(args: {
     pathname: args.pathname,
     url: new URL(`http://localhost${args.pathname}`),
     accessContext:
-      args.accessContext ??
-      ({
-        requesterEntityId: OWNER_ENTITY_ID,
-        role: "OWNER",
-        isOwner: true,
-      } satisfies AccessContext),
+      args.accessContext === null
+        ? undefined
+        : (args.accessContext ??
+          ({
+            requesterEntityId: OWNER_ENTITY_ID,
+            role: "OWNER",
+            isOwner: true,
+          } satisfies AccessContext)),
     runtime: {
       agentId: AGENT_ID,
       getSetting: () => undefined,
@@ -111,6 +113,36 @@ describe("document routes", () => {
     vi.clearAllMocks();
     __setDocumentFetchImplForTests(undefined);
   });
+
+  it.each([
+    ["list", "GET", "/api/documents", undefined],
+    [
+      "upload",
+      "POST",
+      "/api/documents",
+      { content: "private", filename: "private.txt" },
+    ],
+  ])(
+    "rejects unauthenticated %s before document access",
+    async (_label, method, pathname, body) => {
+      const getMemoryById = vi.fn();
+      const { ctx, res } = buildCtx({
+        method,
+        pathname,
+        body,
+        accessContext: null,
+        runtime: { getMemoryById },
+      });
+
+      await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toEqual({ error: "Authentication required" });
+      expect(getMemoryById).not.toHaveBeenCalled();
+      expect(searchDocuments).not.toHaveBeenCalled();
+      expect(addDocument).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([{}, { url: {} }, { url: "   " }])(
     "rejects malformed URL upload body %# with a 400",


### PR DESCRIPTION
# Relates to

First hard-cutover slice of #24246 under program #24242.

- [x] Targets `develop` and is rebased onto current `origin/develop`
  (`f19b4fae99e3d9903ce9c45cc71429b2e558baf0`) with zero conflicts.
- [x] Pinned Bun 1.3.14 install, focused tests/build, guide parity, and root
  verify were run. Root verify's unrelated develop blocker is recorded below.
- [x] The denial and no-document-access assertions below let a reviewer verify
  the changed boundary without reading implementation code.

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts.
- [x] Focused package proof is green. Root verify reaches repository-wide
  typecheck/lint and fails on pre-existing agent files outside this diff.

# Risks

Medium and intentionally breaking. Any internal caller that bypassed the host
authentication boundary and relied on missing context becoming OWNER now gets
401. That is the requested empty-state hard cutover, not a compatibility path.

# Background

## What does this PR do?

- Deletes the document route's implicit OWNER actor for absent `AccessContext`.
- Checks authenticated actor context before resolving document-service state,
  preventing unauthenticated callers from learning service readiness or
  touching document reads/mutations.
- Adds list and upload denial tests proving 401 and zero memory/search/add calls.
- Updates paired package guides and README to make the authenticated host
  boundary authoritative; request headers and `ELIZA_ADMIN_ENTITY_ID` do not
  authenticate a caller.

## What kind of change is this?

Security bug fix and deliberate hard-cutover behavior change.

# Documentation changes needed?

Updated `CLAUDE.md`, byte-identical `AGENTS.md`, and package `README.md`.

# Testing

## Where should a reviewer start?

`plugins/plugin-documents/test/routes.test.ts` tests “rejects unauthenticated
list/upload before document access.”

## Detailed testing steps

- `bun run --cwd plugins/plugin-documents test` — 8 files, 119 tests passed.
- `bun run --cwd plugins/plugin-documents build` — JS, view, and type builds
  passed.
- `bun run check:agents-claude` — 160 pairs identical.
- Biome check on the three changed TypeScript files — passed.
- `git diff --check origin/develop...HEAD` — passed.
- `bun run verify` — reached the workspace lint/typecheck stage; unrelated
  current-develop failure recorded below.

# Evidence Gate

<!-- evidence-head:c7cdfe73dd9b020405535ea0f1d3b87ef2ca3925 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - HTTP authorization boundary only.
<!-- evidence-row:backend-logs -->
- [x] Inline deterministic route receipt: both unauthenticated GET list and POST
  upload returned `{ "error": "Authentication required" }` with status 401;
  `getMemoryById`, `searchDocuments`, and `addDocument` were each asserted
  uncalled. Full package run: 119/119 passed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or caller behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model path changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the required artifact is absence of any document read/write; that is
  asserted structurally by the three untouched spies above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic HTTP authorization boundary.

## Backend + frontend logs

The focused Vitest run completed all 119 tests. The two new adversarial cells
each observed 401 and proved no document memory read, search, or persistence.
Frontend is N/A.

## Screenshots (before / after) + video walkthrough

N/A - no rendered surface.

## Audio / voice walkthrough

N/A - no audio surface.

## Known gaps / failures

Root `bun run verify` fails on unrelated current-develop lint in
`packages/agent/src/api/interactions-routes.test.ts` (pre-existing forbidden
non-null assertions) and formatting in
`packages/agent/src/api/accounts-routes.ts`. Neither file is touched by this
branch. The changed package's test, build, and lint checks are green.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop / multi-agent
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [hard-cutover-membership-documents]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop / multi-agent","skill_revision":"N/A - no repository contribution skill used"} -->
