### PR TITLE
fix(agent): retire legacy empty pending-prompt rooms

### DIFF
--- a/packages/agent/src/services/pending-prompts/store.test.ts
+++ b/packages/agent/src/services/pending-prompts/store.test.ts
@@ -1,12 +1,4 @@
-/**
- * The pending-prompts room index is a set of every room the agent has ever
- * recorded a prompt in. Every mutating path writes back through `saveRoom`,
- * including the writes that leave a room EMPTY (`list()`'s retain-window purge,
- * `resolve()`, `forgetTask()`), so an unconditional re-register meant the index
- * only ever grew and `listAll()` paid one `getCache` per historical room
- * forever. These tests pin the retirement of emptied rooms, and pin that rooms
- * with live prompts are untouched.
- */
+/** Verifies indexed pending-prompt rooms retire when empty while live room behavior remains stable, using a deterministic serialized cache double. */
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, test } from "vitest";
 import { createPendingPromptsStore } from "./store.ts";
@@ -20,11 +12,13 @@ interface CacheDouble {
   store: Map<string, string>;
   getCalls: string[];
   index(): string[];
+  failNextIndexWrite(): void;
 }
 
 function makeCache(): CacheDouble {
   const store = new Map<string, string>();
   const getCalls: string[] = [];
+  let shouldFailIndexWrite = false;
   const runtime = {
     agentId: "agent-under-test",
     // The real cache round-trips through the adapter, so serialize rather than
@@ -35,6 +29,10 @@ function makeCache(): CacheDouble {
       return raw === undefined ? undefined : (JSON.parse(raw) as T);
     },
     setCache: async <T>(key: string, value: T): Promise<boolean> => {
+      if (key === ROOM_INDEX_KEY && shouldFailIndexWrite) {
+        shouldFailIndexWrite = false;
+        throw new Error("cache index write failed");
+      }
       store.set(key, JSON.stringify(value));
       return true;
     },
@@ -45,6 +43,9 @@ function makeCache(): CacheDouble {
     runtime,
     store,
     getCalls,
+    failNextIndexWrite(): void {
+      shouldFailIndexWrite = true;
+    },
     index(): string[] {
       const raw = store.get(ROOM_INDEX_KEY);
       return raw === undefined ? [] : (JSON.parse(raw) as string[]);
@@ -82,6 +83,40 @@ describe("pending-prompts room index", () => {
     cache.getCalls.length = 0;
     await expect(store.listAll()).resolves.toEqual([]);
     expect(cache.getCalls).toEqual([ROOM_INDEX_KEY]);
+  });
+
+  test("listAll retires empty rooms persisted by the pre-fix implementation", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+    cache.store.set(ROOM_INDEX_KEY, JSON.stringify(["legacy-room"]));
+    cache.store.set(roomCacheKey("legacy-room"), JSON.stringify([]));
+
+    await expect(store.listAll()).resolves.toEqual([]);
+
+    expect(cache.index()).toEqual([]);
+    expect(cache.store.has(roomCacheKey("legacy-room"))).toBe(false);
+  });
+
+  test("resolve retry finishes retirement after the row delete succeeds but the index write fails", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-a",
+      promptSnippet: "resolve me",
+      firedAt,
+    });
+    cache.failNextIndexWrite();
+
+    await expect(store.resolve("room-a", "task-a")).rejects.toThrow(
+      "cache index write failed",
+    );
+    expect(cache.store.has(roomCacheKey("room-a"))).toBe(false);
+    expect(cache.index()).toEqual(["room-a"]);
+
+    await expect(store.resolve("room-a", "task-a")).resolves.toBeUndefined();
+    expect(cache.index()).toEqual([]);
+    expect(cache.store.has(roomCacheKey("room-a"))).toBe(false);
   });
 
   test("the retain-window purge in list() retires the room it empties", async () => {

--- a/packages/agent/src/services/pending-prompts/store.test.ts
+++ b/packages/agent/src/services/pending-prompts/store.test.ts
@@ -1,0 +1,272 @@
+/**
+ * The pending-prompts room index is a set of every room the agent has ever
+ * recorded a prompt in. Every mutating path writes back through `saveRoom`,
+ * including the writes that leave a room EMPTY (`list()`'s retain-window purge,
+ * `resolve()`, `forgetTask()`), so an unconditional re-register meant the index
+ * only ever grew and `listAll()` paid one `getCache` per historical room
+ * forever. These tests pin the retirement of emptied rooms, and pin that rooms
+ * with live prompts are untouched.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, test } from "vitest";
+import { createPendingPromptsStore } from "./store.ts";
+
+const ROOM_INDEX_KEY = "eliza:lifeops:pending-prompts:rooms:v1";
+const roomCacheKey = (roomId: string) =>
+  `eliza:lifeops:pending-prompts:room:${roomId}:v1`;
+
+interface CacheDouble {
+  runtime: IAgentRuntime;
+  store: Map<string, string>;
+  getCalls: string[];
+  index(): string[];
+}
+
+function makeCache(): CacheDouble {
+  const store = new Map<string, string>();
+  const getCalls: string[] = [];
+  const runtime = {
+    agentId: "agent-under-test",
+    // The real cache round-trips through the adapter, so serialize rather than
+    // handing back live references.
+    getCache: async <T>(key: string): Promise<T | undefined> => {
+      getCalls.push(key);
+      const raw = store.get(key);
+      return raw === undefined ? undefined : (JSON.parse(raw) as T);
+    },
+    setCache: async <T>(key: string, value: T): Promise<boolean> => {
+      store.set(key, JSON.stringify(value));
+      return true;
+    },
+    deleteCache: async (key: string): Promise<boolean> => store.delete(key),
+  } as unknown as IAgentRuntime;
+
+  return {
+    runtime,
+    store,
+    getCalls,
+    index(): string[] {
+      const raw = store.get(ROOM_INDEX_KEY);
+      return raw === undefined ? [] : (JSON.parse(raw) as string[]);
+    },
+  };
+}
+
+const firedAt = "2026-08-22T00:00:00.000Z";
+
+describe("pending-prompts room index", () => {
+  test("500 recorded-then-resolved rooms leave an empty index and no cache rows", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    for (let i = 0; i < 500; i += 1) {
+      await store.record({
+        roomId: `room-${i}`,
+        taskId: `task-${i}`,
+        promptSnippet: "did you do the thing?",
+        firedAt,
+      });
+    }
+    expect(cache.index()).toHaveLength(500);
+
+    for (let i = 0; i < 500; i += 1) {
+      await store.resolve(`room-${i}`, `task-${i}`);
+    }
+
+    expect(cache.index()).toHaveLength(0);
+    expect(cache.store.has(roomCacheKey("room-0"))).toBe(false);
+    expect(cache.store.has(roomCacheKey("room-499"))).toBe(false);
+
+    // And the follow-on cost: listAll() reads the index, then one row per
+    // indexed room. With every room retired that is a single read.
+    cache.getCalls.length = 0;
+    await expect(store.listAll()).resolves.toEqual([]);
+    expect(cache.getCalls).toEqual([ROOM_INDEX_KEY]);
+  });
+
+  test("the retain-window purge in list() retires the room it empties", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-a",
+      promptSnippet: "expiring",
+      firedAt,
+      reopenWindowHours: 1,
+    });
+    expect(cache.index()).toEqual(["room-a"]);
+
+    // Two hours past the one-hour reopen window.
+    const later = new Date(Date.parse(firedAt) + 2 * 3_600_000);
+    await expect(store.list("room-a", { now: later })).resolves.toEqual([]);
+
+    expect(cache.index()).toEqual([]);
+    expect(cache.store.has(roomCacheKey("room-a"))).toBe(false);
+  });
+
+  test("forgetTask retires the rooms it empties and keeps the ones it does not", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    await store.record({
+      roomId: "room-a",
+      taskId: "shared-task",
+      promptSnippet: "a",
+      firedAt,
+    });
+    await store.record({
+      roomId: "room-b",
+      taskId: "shared-task",
+      promptSnippet: "b",
+      firedAt,
+    });
+    await store.record({
+      roomId: "room-b",
+      taskId: "other-task",
+      promptSnippet: "b2",
+      firedAt,
+    });
+
+    await store.forgetTask("shared-task");
+
+    expect(cache.index()).toEqual(["room-b"]);
+    expect(cache.store.has(roomCacheKey("room-a"))).toBe(false);
+    const remaining = await store.list("room-b");
+    expect(remaining.map((p) => p.taskId)).toEqual(["other-task"]);
+  });
+
+  // ---- no over-rejection: rooms with live prompts are untouched ----
+
+  test("a room keeps its index entry while any prompt remains", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-1",
+      promptSnippet: "first",
+      firedAt,
+    });
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-2",
+      promptSnippet: "second",
+      firedAt,
+    });
+
+    await store.resolve("room-a", "task-1");
+
+    expect(cache.index()).toEqual(["room-a"]);
+    const remaining = await store.list("room-a");
+    expect(remaining.map((p) => p.taskId)).toEqual(["task-2"]);
+  });
+
+  test("record/list/listAll still behave across live rooms", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-a",
+      promptSnippet: "  ping a  ",
+      firedAt: "2026-08-22T00:00:00.000Z",
+    });
+    await store.record({
+      roomId: "room-b",
+      taskId: "task-b",
+      promptSnippet: "ping b",
+      firedAt: "2026-08-22T01:00:00.000Z",
+      expiresAt: "2026-08-22T02:00:00.000Z",
+      expectedReplyKind: "yes_no",
+    });
+
+    expect(cache.index().slice().sort()).toEqual(["room-a", "room-b"]);
+
+    const roomA = await store.list("room-a");
+    expect(roomA).toEqual([
+      {
+        taskId: "task-a",
+        promptSnippet: "ping a",
+        firedAt: "2026-08-22T00:00:00.000Z",
+        expectedReplyKind: "any",
+      },
+    ]);
+
+    const all = await store.listAll();
+    // Newest first.
+    expect(all.map((p) => [p.roomId, p.taskId])).toEqual([
+      ["room-b", "task-b"],
+      ["room-a", "task-a"],
+    ]);
+    expect(all[0]?.expiresAt).toBe("2026-08-22T02:00:00.000Z");
+    expect(all[0]?.expectedReplyKind).toBe("yes_no");
+  });
+
+  test("re-recording the same task in a room replaces it without churning the index", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-a",
+      promptSnippet: "first",
+      firedAt,
+    });
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-a",
+      promptSnippet: "second",
+      firedAt,
+    });
+
+    expect(cache.index()).toEqual(["room-a"]);
+    const listed = await store.list("room-a");
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.promptSnippet).toBe("second");
+  });
+
+  test("resolving a task that is not there leaves the room and index alone", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-a",
+      promptSnippet: "still open",
+      firedAt,
+    });
+
+    await store.resolve("room-a", "task-that-was-never-recorded");
+
+    expect(cache.index()).toEqual(["room-a"]);
+    expect((await store.list("room-a")).map((p) => p.taskId)).toEqual([
+      "task-a",
+    ]);
+  });
+
+  test("clearAll still empties everything", async () => {
+    const cache = makeCache();
+    const store = createPendingPromptsStore(cache.runtime);
+
+    await store.record({
+      roomId: "room-a",
+      taskId: "task-a",
+      promptSnippet: "a",
+      firedAt,
+    });
+    await store.record({
+      roomId: "room-b",
+      taskId: "task-b",
+      promptSnippet: "b",
+      firedAt,
+    });
+
+    await store.clearAll();
+
+    expect(cache.index()).toEqual([]);
+    expect(cache.store.has(roomCacheKey("room-a"))).toBe(false);
+    expect(cache.store.has(roomCacheKey("room-b"))).toBe(false);
+    await expect(store.listAll()).resolves.toEqual([]);
+  });
+});

--- a/packages/agent/src/services/pending-prompts/store.ts
+++ b/packages/agent/src/services/pending-prompts/store.ts
@@ -12,7 +12,10 @@
  * window the entry is purged.
  *
  * Backing storage: runtime cache, keyed per room. Time-based retention removes
- * expired entries without discarding live prompts or changing their content.
+ * expired entries without discarding live prompts or changing their content,
+ * and a room is retired from the room index (and its cache row deleted) by the
+ * write that leaves it with no open prompts, so `listAll()` costs one read per
+ * room with LIVE prompts rather than per room ever prompted in.
  */
 
 import { type IAgentRuntime, toWellFormedUnicode } from "@elizaos/core";
@@ -163,13 +166,43 @@ async function loadRoom(
   return Array.isArray(stored) ? stored : [];
 }
 
+/**
+ * Write a room back, and keep the room index in step with it.
+ *
+ * Every mutating path funnels through here — `record()`, `list()`'s
+ * retain-window purge, `resolve()`, `forgetTask()` — so an unconditional
+ * `registerRoom` meant the very write that emptied a room put that room
+ * straight back into the index. The index then only ever grew, one entry per
+ * room the agent had ever prompted in, and only `clearAll()` could truncate
+ * it: `listAll()` paid one `getCache` per historical room forever and each of
+ * those rooms kept an empty cache row behind it.
+ *
+ * A write that leaves the room with no entries retires the room instead.
+ */
 async function saveRoom(
   cache: RuntimeCacheLike,
   roomId: string,
   entries: RecordedPendingPrompt[],
 ): Promise<void> {
+  if (entries.length === 0) {
+    await forgetRoom(cache, roomId);
+    return;
+  }
   await cache.setCache<RecordedPendingPrompt[]>(roomCacheKey(roomId), entries);
   await registerRoom(cache, roomId);
+}
+
+/** Drop a room's cache row and its index entry. */
+async function forgetRoom(
+  cache: RuntimeCacheLike,
+  roomId: string,
+): Promise<void> {
+  if (typeof cache.deleteCache === "function") {
+    await cache.deleteCache(roomCacheKey(roomId));
+  } else {
+    await cache.setCache<RecordedPendingPrompt[]>(roomCacheKey(roomId), []);
+  }
+  await unregisterRoom(cache, roomId);
 }
 
 async function registerRoom(
@@ -180,6 +213,18 @@ async function registerRoom(
   const next = new Set<string>(Array.isArray(stored) ? stored : []);
   next.add(roomId);
   await cache.setCache<string[]>(ROOM_INDEX_KEY, [...next]);
+}
+
+async function unregisterRoom(
+  cache: RuntimeCacheLike,
+  roomId: string,
+): Promise<void> {
+  const stored = await cache.getCache<string[]>(ROOM_INDEX_KEY);
+  if (!Array.isArray(stored) || !stored.includes(roomId)) return;
+  await cache.setCache<string[]>(
+    ROOM_INDEX_KEY,
+    stored.filter((id) => id !== roomId),
+  );
 }
 
 async function listRooms(cache: RuntimeCacheLike): Promise<string[]> {

--- a/packages/agent/src/services/pending-prompts/store.ts
+++ b/packages/agent/src/services/pending-prompts/store.ts
@@ -12,10 +12,8 @@
  * window the entry is purged.
  *
  * Backing storage: runtime cache, keyed per room. Time-based retention removes
- * expired entries without discarding live prompts or changing their content,
- * and a room is retired from the room index (and its cache row deleted) by the
- * write that leaves it with no open prompts, so `listAll()` costs one read per
- * room with LIVE prompts rather than per room ever prompted in.
+ * expired entries without discarding live prompts or changing their content.
+ * Empty rooms are removed from both their cache row and the room index.
  */
 
 import { type IAgentRuntime, toWellFormedUnicode } from "@elizaos/core";
@@ -166,19 +164,7 @@ async function loadRoom(
   return Array.isArray(stored) ? stored : [];
 }
 
-/**
- * Write a room back, and keep the room index in step with it.
- *
- * Every mutating path funnels through here — `record()`, `list()`'s
- * retain-window purge, `resolve()`, `forgetTask()` — so an unconditional
- * `registerRoom` meant the very write that emptied a room put that room
- * straight back into the index. The index then only ever grew, one entry per
- * room the agent had ever prompted in, and only `clearAll()` could truncate
- * it: `listAll()` paid one `getCache` per historical room forever and each of
- * those rooms kept an empty cache row behind it.
- *
- * A write that leaves the room with no entries retires the room instead.
- */
+/** Persist a non-empty room or retire all storage for an empty room. */
 async function saveRoom(
   cache: RuntimeCacheLike,
   roomId: string,
@@ -238,6 +224,61 @@ export function createPendingPromptsStore(
   const cache: RuntimeCacheLike = runtime;
   const withLock = getLockRunner(cache);
 
+  const listRoom = async (
+    roomId: string,
+    opts: { lookbackMinutes?: number; now?: Date },
+    retireIndexedEmptyRoom: boolean,
+  ): Promise<PendingPrompt[]> => {
+    const now = opts.now ?? new Date();
+    const lookbackCutoffMs =
+      typeof opts.lookbackMinutes === "number" && opts.lookbackMinutes > 0
+        ? now.getTime() - opts.lookbackMinutes * 60_000
+        : null;
+
+    const live = await withLock(MUTATION_LOCK_KEY, async () => {
+      const stored = await loadRoom(cache, roomId);
+      let mutated = false;
+      const kept: RecordedPendingPrompt[] = [];
+      for (const entry of stored) {
+        const retainMs = Date.parse(entry.retainUntilIso);
+        if (Number.isFinite(retainMs) && retainMs <= now.getTime()) {
+          mutated = true;
+          continue;
+        }
+        kept.push(entry);
+      }
+      // listAll already obtained roomId from the index. Retire an empty row
+      // even when it predates this implementation or a prior retirement
+      // deleted the row before its index update failed.
+      if (mutated || (retireIndexedEmptyRoom && kept.length === 0)) {
+        await saveRoom(cache, roomId, kept);
+      }
+      return kept;
+    });
+
+    const visible = live.filter((entry) => {
+      if (lookbackCutoffMs === null) return true;
+      const firedMs = Date.parse(entry.firedAt);
+      return Number.isFinite(firedMs) && firedMs >= lookbackCutoffMs;
+    });
+
+    return visible
+      .slice()
+      .sort((a, b) => Date.parse(b.firedAt) - Date.parse(a.firedAt))
+      .map<PendingPrompt>((entry) => {
+        const projected: PendingPrompt = {
+          taskId: entry.taskId,
+          promptSnippet: entry.promptSnippet,
+          firedAt: entry.firedAt,
+          expectedReplyKind: entry.expectedReplyKind,
+        };
+        if (entry.expiresAt !== undefined) {
+          projected.expiresAt = entry.expiresAt;
+        }
+        return projected;
+      });
+  };
+
   const store: PendingPromptsStore = {
     async record(
       input: PendingPromptRecordInput,
@@ -289,51 +330,7 @@ export function createPendingPromptsStore(
       roomId: string,
       opts: { lookbackMinutes?: number; now?: Date } = {},
     ): Promise<PendingPrompt[]> {
-      const now = opts.now ?? new Date();
-      const lookbackCutoffMs =
-        typeof opts.lookbackMinutes === "number" && opts.lookbackMinutes > 0
-          ? now.getTime() - opts.lookbackMinutes * 60_000
-          : null;
-
-      const live = await withLock(MUTATION_LOCK_KEY, async () => {
-        const stored = await loadRoom(cache, roomId);
-        let mutated = false;
-        const kept: RecordedPendingPrompt[] = [];
-        for (const entry of stored) {
-          const retainMs = Date.parse(entry.retainUntilIso);
-          if (Number.isFinite(retainMs) && retainMs <= now.getTime()) {
-            mutated = true;
-            continue;
-          }
-          kept.push(entry);
-        }
-        if (mutated) {
-          await saveRoom(cache, roomId, kept);
-        }
-        return kept;
-      });
-
-      const visible = live.filter((entry) => {
-        if (lookbackCutoffMs === null) return true;
-        const firedMs = Date.parse(entry.firedAt);
-        return Number.isFinite(firedMs) && firedMs >= lookbackCutoffMs;
-      });
-
-      return visible
-        .slice()
-        .sort((a, b) => Date.parse(b.firedAt) - Date.parse(a.firedAt))
-        .map<PendingPrompt>((entry) => {
-          const projected: PendingPrompt = {
-            taskId: entry.taskId,
-            promptSnippet: entry.promptSnippet,
-            firedAt: entry.firedAt,
-            expectedReplyKind: entry.expectedReplyKind,
-          };
-          if (entry.expiresAt !== undefined) {
-            projected.expiresAt = entry.expiresAt;
-          }
-          return projected;
-        });
+      return listRoom(roomId, opts, false);
     },
 
     async listAll(
@@ -342,7 +339,7 @@ export function createPendingPromptsStore(
       const rooms = await listRooms(cache);
       const perRoom = await Promise.all(
         rooms.map(async (roomId) =>
-          (await store.list(roomId, opts)).map((prompt) => ({
+          (await listRoom(roomId, opts, true)).map((prompt) => ({
             ...prompt,
             roomId,
           })),
@@ -357,7 +354,7 @@ export function createPendingPromptsStore(
       await withLock(MUTATION_LOCK_KEY, async () => {
         const existing = await loadRoom(cache, roomId);
         const next = existing.filter((entry) => entry.taskId !== taskId);
-        if (next.length !== existing.length) {
+        if (next.length !== existing.length || existing.length === 0) {
           await saveRoom(cache, roomId, next);
         }
       });
@@ -369,7 +366,7 @@ export function createPendingPromptsStore(
         for (const roomId of rooms) {
           const existing = await loadRoom(cache, roomId);
           const next = existing.filter((entry) => entry.taskId !== taskId);
-          if (next.length !== existing.length) {
+          if (next.length !== existing.length || existing.length === 0) {
             await saveRoom(cache, roomId, next);
           }
         }


### PR DESCRIPTION
# Relates to

Fixes #24180. Supersedes #24183 while preserving its authored implementation commit; this upstream-only lane cannot write to the contributor fork that owns the earlier PR head.

- [x] Targets `develop` and is rebased on `origin/develop@ffbe17703d1f02c54e128b212b74a35686bbf278` with zero conflicts.
- [x] Preserves the original contributor commit and adds the missing deployed-state and retry recovery coverage.
- [x] The database/cache evidence below exercises the changed behavior without code inspection.

# Risks

Low. The change removes cache rows and index entries only after a room has no retained prompts. Mutations remain serialized through the existing runtime-scoped lock. A failed index write is propagated, and retry now completes the partial retirement instead of retaining a permanent stale index entry.

# Background

## What does this PR do?

- Retires a room's cache row and room-index entry when retention purge, resolution, or task cleanup leaves it empty.
- Repairs already-indexed empty rooms created by the pre-fix implementation the next time `listAll()` traverses the known room index.
- Makes `resolve()` and `forgetTask()` retry-safe when row deletion succeeded but the subsequent index write failed.
- Preserves live rooms, ordering, prompt projection, replacement, unknown-task resolution, and `clearAll()` behavior.

## What kind of change is this?

Bug fix for unbounded cache-index growth and read amplification.

# Testing

Exact-head successful checks on `fc9a273c00aa8752849b1bd991a50276565b47c3` with Bun 1.3.14 and Node 24.15.0:

```text
bun install                                                   PASS (6,909 packages)
focused pending-prompts store + service suites                PASS (2 files, 16 tests)
changed-file Biome                                            PASS
bun run --cwd packages/agent build                            PASS
git diff --check origin/develop...HEAD                        PASS
```

The focused suite includes:

- 500 rooms recorded and fully resolved, leaving zero indexed rooms and zero room rows;
- a seeded pre-fix index plus empty room row, retired by `listAll()`;
- delete-success/index-write-failure followed by a successful `resolve()` retry;
- retain-window, `forgetTask`, live-room, replacement, ordering/projection, unknown-task, and `clearAll` contracts.

Repository-wide gates currently expose unrelated `develop` blockers:

- `bun run build` stops in untouched `plugins/plugin-spotify/src/__tests__/mock-spotify.ts` on TS2883 declaration portability errors.
- `bun run verify` reaches Turbo type/lint and stops in untouched Agent files, chiefly formatting in `src/api/accounts-routes.ts` and pre-existing non-null assertions in `src/api/interactions-routes.test.ts`.
- The full Agent lane was sampled through 75/513 isolated files before stopping after unrelated public-route allowlist drift and a missing built `@elizaos/plugin-meetings` export; the focused affected contract lane remains green.

# Evidence Gate

<!-- evidence-head:fc9a273c00aa8752849b1bd991a50276565b47c3 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - cache/store-only change with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - cache/store-only change with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction surface changed.
<!-- evidence-row:backend-logs -->
- [x] Focused Vitest output: 2 files and 16 tests passed on the exact head.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, provider, model, action, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Deterministic cache artifacts: the seeded legacy room index becomes empty, its empty room row is deleted, and a partially failed retirement becomes fully absent after retry.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Known gaps / failures

No changed-file or affected-contract failure remains. Repository and broad package blockers are listed under Testing and occur only in untouched current-develop surfaces.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@ffbe17703d1f02c54e128b212b74a35686bbf278:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-open-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@ffbe17703d1f02c54e128b212b74a35686bbf278:packages/skills/skills/contribute-to-eliza"} -->
