### PR TITLE
fix(documents): preserve exact requester roles

### DIFF
--- a/packages/agent/src/api/document-access.ts
+++ b/packages/agent/src/api/document-access.ts
@@ -61,7 +61,13 @@ export const DOCUMENT_SCOPE_VALUES = new Set<DocumentVisibilityScope>([
 /** Namespaced tag prefix carrying the media-format facet on knowledge records. */
 export const MEDIA_FORMAT_TAG_PREFIX = "media-format:";
 
-export type RouteActorRole = "OWNER" | "USER" | "AGENT" | "RUNTIME";
+export type RouteActorRole =
+  | "OWNER"
+  | "ADMIN"
+  | "USER"
+  | "GUEST"
+  | "AGENT"
+  | "RUNTIME";
 
 export type RouteActor = {
   entityId: UUID;
@@ -282,6 +288,8 @@ export function canReadDocumentMemory(
   const scopedEntityId = documentScopedEntityId(memory);
   if (!scopedEntityId) return false;
 
+  if (actor.role === "GUEST") return false;
+
   if (actor.role === "AGENT" || actor.role === "RUNTIME") return true;
   if (actor.role === "OWNER") {
     return filters.scopedToEntityId
@@ -297,6 +305,8 @@ export function canMutateDocumentMemory(
 ): boolean {
   const metadata = asRecord(memory.metadata);
   const scope = getDocumentVisibilityScope(metadata);
+
+  if (actor.role === "GUEST") return false;
 
   if (scope === "global" || scope === "owner-private") {
     return actorCanManageOwnerDocuments(actor);

--- a/packages/agent/src/api/documents-service-loader.ts
+++ b/packages/agent/src/api/documents-service-loader.ts
@@ -28,6 +28,7 @@ export type DocumentAddedByRole =
   | "OWNER"
   | "ADMIN"
   | "USER"
+  | "GUEST"
   | "AGENT"
   | "RUNTIME";
 

--- a/packages/core/src/access-control/filter.test.ts
+++ b/packages/core/src/access-control/filter.test.ts
@@ -34,26 +34,26 @@ describe("actorFromAccessContext", () => {
 		).toEqual({ entityId: AGENT, role: "AGENT" });
 	});
 
-	it("maps OWNER, ADMIN, and isOwner to the OWNER tier", () => {
+	it("preserves OWNER and explicit owner binding without elevating ADMIN", () => {
 		expect(actorFromAccessContext(ctx({ role: "OWNER" }), AGENT).role).toBe(
 			"OWNER",
 		);
 		expect(actorFromAccessContext(ctx({ role: "ADMIN" }), AGENT).role).toBe(
-			"OWNER",
+			"ADMIN",
 		);
 		expect(actorFromAccessContext(ctx({ isOwner: true }), AGENT).role).toBe(
 			"OWNER",
 		);
 	});
 
-	it("maps USER, GUEST, and an unresolved role to the least-privileged USER tier", () => {
+	it("preserves USER and GUEST while leaving a missing role unresolved", () => {
 		expect(actorFromAccessContext(ctx({ role: "USER" }), AGENT).role).toBe(
 			"USER",
 		);
 		expect(actorFromAccessContext(ctx({ role: "GUEST" }), AGENT).role).toBe(
-			"USER",
+			"GUEST",
 		);
-		expect(actorFromAccessContext(ctx({}), AGENT).role).toBe("USER"); // no world resolved → fails closed
+		expect(actorFromAccessContext(ctx({}), AGENT).role).toBe("UNRESOLVED");
 	});
 });
 
@@ -72,6 +72,19 @@ describe("canReadScope", () => {
 			for (const role of roles) {
 				expect(canReadScope(scope, undefined, actor(role))).toBe(true);
 			}
+		}
+	});
+
+	it("denies every scope when authority is unresolved", () => {
+		for (const scope of [
+			"global",
+			"shared",
+			"room",
+			"owner-private",
+			"user-private",
+			"agent-private",
+		] as MemoryScope[]) {
+			expect(canReadScope(scope, SELF, actor("UNRESOLVED"))).toBe(false);
 		}
 	});
 
@@ -99,6 +112,10 @@ describe("canReadScope", () => {
 			it(`${scope}: a USER reads only their own`, () => {
 				expect(canReadScope(scope, SELF, actor("USER", SELF))).toBe(true);
 				expect(canReadScope(scope, OTHER, actor("USER", SELF))).toBe(false);
+			});
+
+			it(`${scope}: a GUEST cannot acquire a private document tier`, () => {
+				expect(canReadScope(scope, SELF, actor("GUEST", SELF))).toBe(false);
 			});
 
 			it(`${scope}: AGENT and RUNTIME read any`, () => {

--- a/packages/core/src/access-control/filter.ts
+++ b/packages/core/src/access-control/filter.ts
@@ -11,7 +11,7 @@
  * change; keep the two in lockstep. An unresolved role fails closed to the
  * least-privileged `USER` tier.
  */
-import { isAdminRank, type RoleName } from "../roles";
+import type { RoleName } from "../roles";
 import type { AccessContext, MemoryScope, UUID } from "../types";
 
 interface AccessScopedRecord {
@@ -42,10 +42,11 @@ function isMemoryScope(value: unknown): value is MemoryScope {
  * Read-side actor role: the core {@link RoleName} widened with the machine
  * tiers the scope ladder recognizes — `AGENT` (an agent reading its own store)
  * and `RUNTIME` (the documents read path that delegates to this ladder).
- * {@link actorFromAccessContext} only ever yields `OWNER`/`USER`/`AGENT`;
- * `RUNTIME` is supplied by the documents plugin, never minted from a message.
+ * {@link actorFromAccessContext} preserves explicit human roles, yields `AGENT`
+ * for self-read, and uses `UNRESOLVED` when authority is absent. `RUNTIME` is
+ * supplied by trusted internal callers, never minted from a message.
  */
-export type ActorRole = RoleName | "AGENT" | "RUNTIME";
+export type ActorRole = RoleName | "AGENT" | "RUNTIME" | "UNRESOLVED";
 
 export interface ScopeActor {
 	entityId: UUID;
@@ -54,10 +55,8 @@ export interface ScopeActor {
 
 /**
  * Collapse an {@link AccessContext} into the scope-ladder actor. A self-read
- * (requester is the agent) is `AGENT`; OWNER/ADMIN manage owner-scoped
- * memories; everyone else (USER/GUEST, or no role at all — e.g. a DM that
- * resolved no world) is `USER`, the least-privileged tier, so an unresolved
- * role fails closed rather than open.
+ * (requester is the agent) is `AGENT`; every explicit role remains distinct.
+ * Missing role authority becomes `UNRESOLVED`, which every scope denies.
  */
 export function actorFromAccessContext(
 	ctx: AccessContext,
@@ -66,10 +65,17 @@ export function actorFromAccessContext(
 	if (ctx.requesterEntityId === agentId) {
 		return { entityId: agentId, role: "AGENT" };
 	}
-	if (ctx.isOwner || isAdminRank(ctx.role)) {
+	if (ctx.isOwner || ctx.role === "OWNER") {
 		return { entityId: ctx.requesterEntityId, role: "OWNER" };
 	}
-	return { entityId: ctx.requesterEntityId, role: "USER" };
+	switch (ctx.role) {
+		case "ADMIN":
+		case "USER":
+		case "GUEST":
+			return { entityId: ctx.requesterEntityId, role: ctx.role };
+		default:
+			return { entityId: ctx.requesterEntityId, role: "UNRESOLVED" };
+	}
 }
 
 /**
@@ -87,6 +93,7 @@ export function canReadScope(
 	actor: ScopeActor,
 	opts?: { scopedToEntityId?: UUID },
 ): boolean {
+	if (actor.role === "UNRESOLVED") return false;
 	switch (scope) {
 		case "global":
 		case "shared":
@@ -103,6 +110,7 @@ export function canReadScope(
 		case "user-private":
 		case "private": {
 			if (!scopedEntityId) return false;
+			if (actor.role === "GUEST") return false;
 			if (actor.role === "AGENT" || actor.role === "RUNTIME") return true;
 			if (actor.role === "OWNER") {
 				return opts?.scopedToEntityId

--- a/packages/core/src/database/document-list-query.test.ts
+++ b/packages/core/src/database/document-list-query.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { DocumentListQueryParams, Memory, UUID } from "../types";
 import { MemoryType } from "../types";
 import {
+	canRequesterMutateDocument,
 	documentMutationSnapshotMatches,
 	isDocumentVisibleToRequester,
 	portableDocumentSearchTokens,
@@ -200,6 +201,36 @@ describe("document-list capability contract", () => {
 		expect(new Set(admin.documents.map((memory) => memory.id))).toEqual(
 			new Set([owned.id, other.id]),
 		);
+	});
+
+	it("keeps guest and unresolved document authority fail-closed", () => {
+		const global = document(3);
+		const privateDocument = {
+			...document(4),
+			metadata: {
+				type: MemoryType.DOCUMENT,
+				scope: "user-private",
+				scopedToEntityId: REQUESTER_ID,
+			},
+		};
+		const guestParams = {
+			...params,
+			requesterRole: "GUEST" as const,
+			requesterRoomIds: [ROOM_ID],
+		};
+		const unresolvedParams = {
+			...params,
+			requesterRole: "UNRESOLVED" as const,
+			requesterRoomIds: [ROOM_ID],
+		};
+
+		expect(isDocumentVisibleToRequester(global, guestParams)).toBe(true);
+		expect(isDocumentVisibleToRequester(privateDocument, guestParams)).toBe(
+			false,
+		);
+		expect(isDocumentVisibleToRequester(global, unresolvedParams)).toBe(false);
+		expect(canRequesterMutateDocument(global, guestParams)).toBe(false);
+		expect(canRequesterMutateDocument(global, unresolvedParams)).toBe(false);
 	});
 
 	it("uses locale-independent tokens that preserve punctuation and Unicode", () => {

--- a/packages/core/src/database/document-list-query.ts
+++ b/packages/core/src/database/document-list-query.ts
@@ -39,8 +39,10 @@ const DOCUMENT_LIST_ROLES = new Set([
 	"OWNER",
 	"ADMIN",
 	"USER",
+	"GUEST",
 	"AGENT",
 	"RUNTIME",
+	"UNRESOLVED",
 ]);
 const DOCUMENT_LIST_SCOPES = new Set([
 	"global",
@@ -412,6 +414,7 @@ export function isDocumentVisibleToRequester(
 	memory: Memory,
 	params: DocumentRequesterContext,
 ): boolean {
+	if (params.requesterRole === "UNRESOLVED") return false;
 	const snapshot = readDocumentMutationSnapshot(memory);
 	if (!snapshot) return false;
 	if (
@@ -425,6 +428,7 @@ export function isDocumentVisibleToRequester(
 	}
 	if (!params.requesterRoomIds.includes(snapshot.roomId)) return false;
 	if (snapshot.scope === "global") return true;
+	if (params.requesterRole === "GUEST") return false;
 	if (snapshot.scope !== "user-private") return false;
 	if (params.requesterRole === "ADMIN") return true;
 	return snapshot.scopedToEntityId === params.requesterEntityId;
@@ -435,6 +439,12 @@ export function canRequesterMutateDocument(
 	memory: Memory,
 	params: DocumentRequesterContext,
 ): boolean {
+	if (
+		params.requesterRole === "UNRESOLVED" ||
+		params.requesterRole === "GUEST"
+	) {
+		return false;
+	}
 	const snapshot = readDocumentMutationSnapshot(memory);
 	if (!snapshot) return false;
 	if (params.requesterRole === "OWNER") return true;

--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -388,7 +388,14 @@ async function getAddedByRole(
 	runtime: IAgentRuntime,
 	message: Memory,
 ): Promise<DocumentAddedByRole> {
-	return (await resolveDocumentRequesterRole(runtime, message)).role;
+	const role = (await resolveDocumentRequesterRole(runtime, message)).role;
+	if (role === "UNRESOLVED") {
+		throw new ElizaError("Document writer role is unresolved", {
+			code: "DOCUMENT_WRITER_ROLE_UNRESOLVED",
+			context: { entityId: message.entityId },
+		});
+	}
+	return role;
 }
 
 async function ensureWriteAccess(
@@ -397,6 +404,11 @@ async function ensureWriteAccess(
 	scope: DocumentVisibilityScope,
 	scopedToEntityId?: UUID,
 ): Promise<string | null> {
+	const requesterRole = (await resolveDocumentRequesterRole(runtime, message))
+		.role;
+	if (requesterRole === "UNRESOLVED" || requesterRole === "GUEST") {
+		return "A verified user identity is required to write documents.";
+	}
 	if (scope === "global" || scope === "owner-private") {
 		return (await hasRoleAccess(runtime, message, "OWNER"))
 			? null

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -182,10 +182,7 @@ export async function resolveDocumentRequesterRole(
 		const result = await checkSenderRole(runtime, message);
 		return {
 			entityId: message.entityId,
-			role:
-				result?.role === "OWNER" || result?.role === "ADMIN"
-					? result.role
-					: "USER",
+			role: result?.role ?? "UNRESOLVED",
 		};
 	} catch (cause) {
 		// error-policy:J2 Preserve role-resolution context and fail the read/write.
@@ -213,17 +210,14 @@ export async function resolveDocumentRequesterRole(
  *
  * The read runs for the entity the caller named, not the message author, so a
  * privileged sender cannot widen a request the caller deliberately scoped. An
- * absent role is treated as an unprivileged USER rather than inherited from
- * the sender: the safe reading of "unspecified" is the least privilege.
+ * absent role remains `UNRESOLVED` rather than inheriting or fabricating a
+ * lower role. The storage authorization boundary denies that state.
  */
 export async function resolveDocumentRequesterFromAccessContext(
 	runtime: IAgentRuntime,
 	accessContext: AccessContext,
 ): Promise<DocumentRequester> {
-	const role: DocumentListRequesterRole =
-		accessContext.role === "OWNER" || accessContext.role === "ADMIN"
-			? accessContext.role
-			: "USER";
+	const role: DocumentListRequesterRole = accessContext.role ?? "UNRESOLVED";
 	if (documentRoleHasGlobalVisibility(role)) {
 		return { entityId: accessContext.requesterEntityId, roomIds: [], role };
 	}

--- a/packages/core/src/features/documents/types.ts
+++ b/packages/core/src/features/documents/types.ts
@@ -193,6 +193,7 @@ export type DocumentAddedByRole =
 	| "OWNER"
 	| "ADMIN"
 	| "USER"
+	| "GUEST"
 	| "AGENT"
 	| "RUNTIME";
 

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -67,8 +67,10 @@ export type DocumentListRequesterRole =
 	| "OWNER"
 	| "ADMIN"
 	| "USER"
+	| "GUEST"
 	| "AGENT"
-	| "RUNTIME";
+	| "RUNTIME"
+	| "UNRESOLVED";
 
 /** Identity and room membership used by every document authorization query. */
 export interface DocumentRequesterContext {

--- a/plugins/plugin-documents/AGENTS.md
+++ b/plugins/plugin-documents/AGENTS.md
@@ -82,7 +82,10 @@ The plugin itself reads no env vars directly. The `routes.ts` handler reads one 
 Access control is role-based and requires the authenticated `AccessContext`
 provided by the host route boundary. Missing context returns `401`; the plugin
 never treats an absent caller as owner. Request headers alone are not an
-identity or authorization authority.
+identity or authorization authority. Preserve the caller's exact role through
+storage authorization: ADMIN is not OWNER, GUEST is not USER, and an unresolved
+role is rejected. Guests may read only global documents in their current rooms
+and may not mutate documents.
 
 ## How to extend
 
@@ -100,7 +103,7 @@ All scope/permission decisions live in `src/routes.ts` (`canReadDocumentMemory`,
 ## Conventions / gotchas
 
 - **No service ownership.** This plugin does not define `DocumentsServiceLike` — it imports it from `@elizaos/agent/api/documents-service-loader`. If the service times out during loading, the route returns 503 with a `Retry-After: 5` header; if the service is simply absent (e.g. agent not running), it returns 503 without that header.
-- **Scope defaults.** When no scope is specified on upload, the default is `user-private` for USER role, `agent-private` for AGENT role, and `global` for OWNER/RUNTIME.
+- **Scope defaults.** When no scope is specified on upload, the default is `user-private` for USER/ADMIN, `agent-private` for AGENT, and `global` for OWNER/RUNTIME. GUEST and unresolved callers cannot upload.
 - **Bundled and character documents** are read-only: `getDocumentEditability` and `getDocumentDeleteability` enforce this in the presenter, and the PATCH/DELETE handlers check these flags before proceeding.
 - **Image upload.** Images are stored as text. If `includeImageDescriptions: true` is passed in the metadata, the handler calls `runtime.useModel(ModelType.IMAGE_DESCRIPTION, ...)` to generate a description. If the model call fails, a warning is included in the response and the stored text explicitly says that image description was unavailable.
 - **YouTube URLs.** `POST /api/documents/url` detects YouTube URLs via `isYouTubeUrl()` from `@elizaos/core` and sets `source: "youtube"` in metadata; the transcript is fetched by `fetchDocumentFromUrl()`.

--- a/plugins/plugin-documents/CLAUDE.md
+++ b/plugins/plugin-documents/CLAUDE.md
@@ -82,7 +82,10 @@ The plugin itself reads no env vars directly. The `routes.ts` handler reads one 
 Access control is role-based and requires the authenticated `AccessContext`
 provided by the host route boundary. Missing context returns `401`; the plugin
 never treats an absent caller as owner. Request headers alone are not an
-identity or authorization authority.
+identity or authorization authority. Preserve the caller's exact role through
+storage authorization: ADMIN is not OWNER, GUEST is not USER, and an unresolved
+role is rejected. Guests may read only global documents in their current rooms
+and may not mutate documents.
 
 ## How to extend
 
@@ -100,7 +103,7 @@ All scope/permission decisions live in `src/routes.ts` (`canReadDocumentMemory`,
 ## Conventions / gotchas
 
 - **No service ownership.** This plugin does not define `DocumentsServiceLike` — it imports it from `@elizaos/agent/api/documents-service-loader`. If the service times out during loading, the route returns 503 with a `Retry-After: 5` header; if the service is simply absent (e.g. agent not running), it returns 503 without that header.
-- **Scope defaults.** When no scope is specified on upload, the default is `user-private` for USER role, `agent-private` for AGENT role, and `global` for OWNER/RUNTIME.
+- **Scope defaults.** When no scope is specified on upload, the default is `user-private` for USER/ADMIN, `agent-private` for AGENT, and `global` for OWNER/RUNTIME. GUEST and unresolved callers cannot upload.
 - **Bundled and character documents** are read-only: `getDocumentEditability` and `getDocumentDeleteability` enforce this in the presenter, and the PATCH/DELETE handlers check these flags before proceeding.
 - **Image upload.** Images are stored as text. If `includeImageDescriptions: true` is passed in the metadata, the handler calls `runtime.useModel(ModelType.IMAGE_DESCRIPTION, ...)` to generate a description. If the model call fails, a warning is included in the response and the stored text explicitly says that image description was unavailable.
 - **YouTube URLs.** `POST /api/documents/url` detects YouTube URLs via `isYouTubeUrl()` from `@elizaos/core` and sets `source: "youtube"` in metadata; the transcript is fetched by `fetchDocumentFromUrl()`.

--- a/plugins/plugin-documents/README.md
+++ b/plugins/plugin-documents/README.md
@@ -43,7 +43,10 @@ Documents are stored as memories in the runtime's `documents` table and chunked 
 
 The caller's role comes from the authenticated `AccessContext` supplied by the
 host route boundary. A request without that context returns `401`; request
-headers and `ELIZA_ADMIN_ENTITY_ID` never create an authenticated caller.
+headers and `ELIZA_ADMIN_ENTITY_ID` never create an authenticated caller. Roles
+remain exact at this boundary: ADMIN is not OWNER, GUEST is not USER, and an
+unresolved role is rejected. Guests may read global documents in rooms where
+they are current members, but cannot read private scopes or mutate documents.
 
 ## Configuration
 

--- a/plugins/plugin-documents/src/routes.actor.test.ts
+++ b/plugins/plugin-documents/src/routes.actor.test.ts
@@ -5,7 +5,7 @@
  * Verifies that:
  * - Missing AccessContext fails closed without minting a route actor.
  * - AccessContext with requesterEntityId resolves to the correct RouteActor.
- * - OWNER/ADMIN roles map to OWNER; USER/GUEST map to USER.
+ * - OWNER, ADMIN, USER, and GUEST remain distinct.
  * - Missing requesterEntityId returns null.
  */
 
@@ -36,13 +36,13 @@ describe("resolveRouteActor process-private principal authorization", () => {
     expect(actor?.entityId).toBe(OWNER_ID);
   });
 
-  it("grants OWNER permissions for ADMIN AccessContext role", () => {
+  it("preserves ADMIN without granting OWNER permissions", () => {
     const actor = resolveRouteActor(AGENT_ID, OWNER_ID, {
       requesterEntityId: OWNER_ID,
       role: "ADMIN",
     } satisfies AccessContext);
     expect(actor).not.toBeNull();
-    expect(actor?.role).toBe("OWNER");
+    expect(actor?.role).toBe("ADMIN");
   });
 
   it("grants USER permissions for USER AccessContext role", () => {
@@ -56,13 +56,21 @@ describe("resolveRouteActor process-private principal authorization", () => {
     expect(actor?.entityId).not.toBe(OWNER_ID);
   });
 
-  it("grants USER permissions for GUEST AccessContext role", () => {
+  it("preserves GUEST without granting USER permissions", () => {
     const actor = resolveRouteActor(AGENT_ID, OWNER_ID, {
       requesterEntityId: USER_ID,
       role: "GUEST",
     } satisfies AccessContext);
     expect(actor).not.toBeNull();
-    expect(actor?.role).toBe("USER");
+    expect(actor?.role).toBe("GUEST");
+  });
+
+  it("rejects a requester whose role authority is unresolved", () => {
+    expect(
+      resolveRouteActor(AGENT_ID, OWNER_ID, {
+        requesterEntityId: USER_ID,
+      } satisfies AccessContext),
+    ).toBeNull();
   });
 
   it("returns null when AccessContext lacks requesterEntityId", () => {

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -218,15 +218,10 @@ export function resolveRouteActor(
   // never be satisfied and the agent lost access to its own agent-private
   // documents. actorFromAccessContext is the single definition of that mapping.
   const scopeActor = actorFromAccessContext(accessContext, agentId);
-  // actorFromAccessContext only ever yields OWNER/USER/AGENT, but its static
-  // ActorRole type is wider (full RoleName). Narrow explicitly and fail closed
-  // to USER for anything outside the route-actor role set.
-  const role: RouteActorRole =
-    scopeActor.role === "OWNER" ||
-    scopeActor.role === "AGENT" ||
-    scopeActor.role === "RUNTIME"
-      ? scopeActor.role
-      : "USER";
+  // Preserve every explicit role. An unresolved role is not a lower role and
+  // cannot be translated into authorization, so reject it.
+  if (scopeActor.role === "UNRESOLVED") return null;
+  const role: RouteActorRole = scopeActor.role;
   return {
     entityId: scopeActor.entityId,
     role,
@@ -326,6 +321,12 @@ function filtersFromUploadBody(
   },
   actor: RouteActor,
 ): { scope: DocumentVisibilityScope; scopedToEntityId?: UUID; error?: string } {
+  if (actor.role === "GUEST") {
+    return {
+      scope: "user-private",
+      error: "Guests cannot upload documents.",
+    };
+  }
   const metadata = asRecord(body.metadata);
   const scope =
     parseDocumentScope(body.scope) ??

--- a/plugins/plugin-sql/src/__tests__/integration/document-list-query.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/document-list-query.real.test.ts
@@ -282,6 +282,35 @@ describe("document list query (real SQL parity)", () => {
     }
   });
 
+  it("keeps GUEST room-global and UNRESOLVED fail-closed across SQL and memory", async () => {
+    const documents = [
+      document(1),
+      document(2, {
+        metadata: {
+          scope: "user-private",
+          scopedToEntityId: REQUESTER_ID,
+        },
+      }),
+    ];
+    await seedSql(documents);
+    const inMemory = await seedInMemory(documents);
+    const baseParams = {
+      agentId,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [roomId],
+      limit: 10,
+      offset: 0,
+    };
+
+    for (const requesterRole of ["GUEST", "UNRESOLVED"] as const) {
+      const roleParams = { ...baseParams, requesterRole };
+      const sqlResult = await adapter.queryDocuments(roleParams);
+      const memoryResult = await inMemory.queryDocuments(roleParams);
+      expect(sqlResult).toEqual(memoryResult);
+      expect(ids(sqlResult.documents)).toEqual(requesterRole === "GUEST" ? [documents[0]?.id] : []);
+    }
+  });
+
   it("does not skip or duplicate equal-timestamp rows across keyset pages", async () => {
     const documents = Array.from({ length: 151 }, (_, index) => document(index));
     await seedSql(documents);

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -253,10 +253,19 @@ function documentVisibilityCondition(
   if (documentRoleHasGlobalVisibility(params.requesterRole)) {
     return validAuthorizationMetadata;
   }
+  if (params.requesterRole === "UNRESOLVED") {
+    return sql`false`;
+  }
   if (params.requesterRole === "ADMIN") {
     return sql`(
       ${validAuthorizationMetadata}
       AND ${metadata}->>'scope' IN ('global', 'user-private')
+    )`;
+  }
+  if (params.requesterRole === "GUEST") {
+    return sql`(
+      ${validAuthorizationMetadata}
+      AND ${metadata}->>'scope' = 'global'
     )`;
   }
   return sql`(


### PR DESCRIPTION
Closes #24246

Hard-cutover slice that removes document authorization role collapsing across core, agent routes, plugin routes, and SQL:

- ADMIN remains ADMIN instead of becoming OWNER
- GUEST remains GUEST instead of becoming USER
- missing role becomes explicit UNRESOLVED and fails closed
- guest reads are limited to global documents in current rooms; guest/unresolved mutation is denied
- SQL and in-memory authorization have real parity evidence

Validation:
- core focused authorization tests: 37 passed
- plugin-documents: 120 passed
- core build and packed-consumer verification passed
- plugin-sql focused real PGlite parity passed
- plugin-sql typecheck and changed-file Biome passed
- guide parity: 160 pairs passed
- root verify reaches unrelated current-develop Biome failures in untouched surrogate tests and access-control/agent files; all changed files pass Biome

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop / multi-agent
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— root document authorization lane
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop / multi-agent","skill_revision":"N/A - no repository contribution skill used"} -->