### PR TITLE
fix(dev): health watchdog holds its failure count through a replacement child's boot

### DIFF
--- a/packages/app-core/scripts/dev-ui.mjs
+++ b/packages/app-core/scripts/dev-ui.mjs
@@ -1308,6 +1308,10 @@ if (uiOnly) {
     },
     onSpawn: (child) => {
       apiProcess = child;
+      // The watchdog outlives API children. Every replacement generation is
+      // legitimately unhealthy while booting, whether it came from a source
+      // reload, a child-requested restart, a crash, or the watchdog itself.
+      apiHealthWatchdog?.beginRecovery();
       child.on("error", (err) => {
         console.error(
           `  ${green(logPrefix)} Failed to start API server: ${err.message}`,

--- a/packages/app-core/scripts/lib/dev-process-lifecycle.mjs
+++ b/packages/app-core/scripts/lib/dev-process-lifecycle.mjs
@@ -95,6 +95,16 @@ export function createApiHealthWatchdog({
   };
 
   return {
+    /**
+     * Mark a replacement child as booting. Supervisors must call this for
+     * every new generation, including source reloads and child-requested
+     * relaunches, because those replacements are just as unready as one the
+     * watchdog requested itself.
+     */
+    beginRecovery() {
+      failures = 0;
+      recoveringUntil = now() + recoveryGraceMs;
+    },
     start() {
       if (timer) return;
       timer = setInterval(() => void checkNow(), intervalMs);
@@ -104,6 +114,7 @@ export function createApiHealthWatchdog({
       if (timer) clearInterval(timer);
       timer = null;
       failures = 0;
+      recoveringUntil = 0;
     },
     checkNow,
   };

--- a/packages/app-core/scripts/lib/dev-process-lifecycle.mjs
+++ b/packages/app-core/scripts/lib/dev-process-lifecycle.mjs
@@ -65,21 +65,34 @@ export function createApiHealthWatchdog({
 }) {
   let timer = null;
   let failures = 0;
-  let checkInFlight = false;
+  let generation = 0;
+  let stopped = false;
+  const inFlightGenerations = new Set();
   /** Epoch ms until which unhealthy probes are boot, not wedge; 0 = off. */
   let recoveringUntil = 0;
 
   const checkNow = async () => {
-    if (checkInFlight || isShuttingDown()) return;
-    checkInFlight = true;
+    const probeGeneration = generation;
+    if (
+      stopped ||
+      isShuttingDown() ||
+      inFlightGenerations.has(probeGeneration)
+    ) {
+      return;
+    }
+    inFlightGenerations.add(probeGeneration);
     let healthy = false;
     try {
       healthy = (await check()) === true;
     } catch {
       healthy = false;
     } finally {
-      checkInFlight = false;
+      inFlightGenerations.delete(probeGeneration);
     }
+    // A probe belongs to the child generation that started it. Its result must
+    // not clear boot grace, add a failure, or restart after that child was
+    // replaced or the supervisor began shutting down.
+    if (stopped || isShuttingDown() || probeGeneration !== generation) return;
     if (healthy) {
       failures = 0;
       recoveringUntil = 0;
@@ -102,17 +115,22 @@ export function createApiHealthWatchdog({
      * watchdog requested itself.
      */
     beginRecovery() {
+      if (stopped || isShuttingDown()) return;
+      generation += 1;
       failures = 0;
       recoveringUntil = now() + recoveryGraceMs;
     },
     start() {
       if (timer) return;
+      stopped = false;
       timer = setInterval(() => void checkNow(), intervalMs);
       timer.unref?.();
     },
     stop() {
       if (timer) clearInterval(timer);
       timer = null;
+      stopped = true;
+      generation += 1;
       failures = 0;
       recoveringUntil = 0;
     },

--- a/packages/app-core/scripts/lib/dev-process-lifecycle.mjs
+++ b/packages/app-core/scripts/lib/dev-process-lifecycle.mjs
@@ -54,10 +54,20 @@ export function createApiHealthWatchdog({
   isShuttingDown = () => false,
   intervalMs = 5_000,
   failureThreshold = 3,
+  // A replacement child is not "ready" for the whole of its boot (~35s on a
+  // loaded box) — far longer than threshold × interval. Without a hold, the
+  // watchdog that just restarted a wedged child killed every replacement
+  // 15s into its boot, looping for 30+ restarts (live 2026-08-22). After a
+  // restart, failures are not counted until the first healthy probe, bounded
+  // by this grace so a replacement that never comes up is still restarted.
+  recoveryGraceMs = 180_000,
+  now = Date.now,
 }) {
   let timer = null;
   let failures = 0;
   let checkInFlight = false;
+  /** Epoch ms until which unhealthy probes are boot, not wedge; 0 = off. */
+  let recoveringUntil = 0;
 
   const checkNow = async () => {
     if (checkInFlight || isShuttingDown()) return;
@@ -72,11 +82,15 @@ export function createApiHealthWatchdog({
     }
     if (healthy) {
       failures = 0;
+      recoveringUntil = 0;
       return;
     }
+    if (recoveringUntil > 0 && now() < recoveringUntil) return;
+    recoveringUntil = 0;
     failures += 1;
     if (failures < failureThreshold) return;
     failures = 0;
+    recoveringUntil = now() + recoveryGraceMs;
     restart();
   };
 

--- a/packages/app-core/scripts/lib/dev-process-lifecycle.test.mjs
+++ b/packages/app-core/scripts/lib/dev-process-lifecycle.test.mjs
@@ -99,4 +99,32 @@ describe("createApiHealthWatchdog", () => {
     for (let i = 0; i < 3; i++) await watchdog.checkNow();
     expect(restart).toHaveBeenCalledTimes(2);
   });
+
+  it("holds unhealthy probes for a replacement started outside the watchdog", async () => {
+    let clock = 10_000;
+    let healthy = false;
+    const restart = vi.fn();
+    const watchdog = createApiHealthWatchdog({
+      check: async () => healthy,
+      restart,
+      failureThreshold: 3,
+      recoveryGraceMs: 60_000,
+      now: () => clock,
+    });
+
+    // Source reloads, child-requested restarts, and crash relaunches all enter
+    // through the supervisor's onSpawn hook rather than watchdog.restart().
+    watchdog.beginRecovery();
+    for (let i = 0; i < 10; i++) {
+      clock += 5_000;
+      await watchdog.checkNow();
+    }
+    expect(restart).not.toHaveBeenCalled();
+
+    healthy = true;
+    await watchdog.checkNow();
+    healthy = false;
+    for (let i = 0; i < 3; i++) await watchdog.checkNow();
+    expect(restart).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/app-core/scripts/lib/dev-process-lifecycle.test.mjs
+++ b/packages/app-core/scripts/lib/dev-process-lifecycle.test.mjs
@@ -6,6 +6,14 @@ import {
   createParentExitGuard,
 } from "./dev-process-lifecycle.mjs";
 
+function deferred() {
+  let resolve;
+  const promise = new Promise((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
 describe("createParentExitGuard", () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
@@ -126,5 +134,127 @@ describe("createApiHealthWatchdog", () => {
     healthy = false;
     for (let i = 0; i < 3; i++) await watchdog.checkNow();
     expect(restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a stale probe after a replacement and probes the new generation immediately", async () => {
+    let clock = 10_000;
+    const oldProbe = deferred();
+    const newProbe = deferred();
+    const check = vi
+      .fn()
+      .mockImplementationOnce(() => oldProbe.promise)
+      .mockImplementationOnce(() => newProbe.promise);
+    const restart = vi.fn();
+    const watchdog = createApiHealthWatchdog({
+      check,
+      restart,
+      failureThreshold: 1,
+      recoveryGraceMs: 60_000,
+      now: () => clock,
+    });
+
+    const staleCheck = watchdog.checkNow();
+    watchdog.beginRecovery();
+    const currentCheck = watchdog.checkNow();
+    expect(check).toHaveBeenCalledTimes(2);
+
+    newProbe.resolve(false);
+    await currentCheck;
+    oldProbe.resolve(false);
+    await staleCheck;
+    expect(restart).not.toHaveBeenCalled();
+
+    clock = 70_001;
+    await watchdog.checkNow();
+    expect(restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let a stale healthy probe clear replacement boot grace", async () => {
+    let clock = 10_000;
+    const oldProbe = deferred();
+    const restart = vi.fn();
+    const watchdog = createApiHealthWatchdog({
+      check: vi
+        .fn()
+        .mockImplementationOnce(() => oldProbe.promise)
+        .mockResolvedValue(false),
+      restart,
+      failureThreshold: 1,
+      recoveryGraceMs: 60_000,
+      now: () => clock,
+    });
+
+    const staleCheck = watchdog.checkNow();
+    watchdog.beginRecovery();
+    oldProbe.resolve(true);
+    await staleCheck;
+    clock = 60_000;
+    await watchdog.checkNow();
+    expect(restart).not.toHaveBeenCalled();
+
+    clock = 70_001;
+    await watchdog.checkNow();
+    expect(restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not restart when shutdown begins during an in-flight probe", async () => {
+    const probe = deferred();
+    let shuttingDown = false;
+    const restart = vi.fn();
+    const watchdog = createApiHealthWatchdog({
+      check: () => probe.promise,
+      restart,
+      isShuttingDown: () => shuttingDown,
+      failureThreshold: 1,
+    });
+
+    const pending = watchdog.checkNow();
+    shuttingDown = true;
+    probe.resolve(false);
+    await pending;
+    expect(restart).not.toHaveBeenCalled();
+  });
+
+  it("collapses overlapping probes within one child generation", async () => {
+    const probe = deferred();
+    const check = vi.fn(() => probe.promise);
+    const watchdog = createApiHealthWatchdog({
+      check,
+      restart: vi.fn(),
+    });
+
+    const first = watchdog.checkNow();
+    await watchdog.checkNow();
+    expect(check).toHaveBeenCalledTimes(1);
+    probe.resolve(true);
+    await first;
+  });
+
+  it("invalidates an in-flight probe and removes its interval when stopped", async () => {
+    vi.useFakeTimers();
+    try {
+      const probe = deferred();
+      const check = vi.fn(() => probe.promise);
+      const restart = vi.fn();
+      const watchdog = createApiHealthWatchdog({
+        check,
+        restart,
+        intervalMs: 100,
+        failureThreshold: 1,
+      });
+
+      watchdog.start();
+      await vi.advanceTimersByTimeAsync(100);
+      expect(check).toHaveBeenCalledTimes(1);
+      watchdog.stop();
+      probe.resolve(false);
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(500);
+      expect(check).toHaveBeenCalledTimes(1);
+      expect(restart).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/app-core/scripts/lib/dev-process-lifecycle.test.mjs
+++ b/packages/app-core/scripts/lib/dev-process-lifecycle.test.mjs
@@ -51,4 +51,52 @@ describe("createApiHealthWatchdog", () => {
     await watchdog.checkNow();
     expect(restart).toHaveBeenCalledTimes(1);
   });
+
+  it("holds the failure count through a replacement child's boot", async () => {
+    let clock = 0;
+    let healthy = false;
+    const restart = vi.fn();
+    const watchdog = createApiHealthWatchdog({
+      check: async () => healthy,
+      restart,
+      failureThreshold: 3,
+      recoveryGraceMs: 60_000,
+      now: () => clock,
+    });
+
+    for (let i = 0; i < 3; i++) await watchdog.checkNow();
+    expect(restart).toHaveBeenCalledTimes(1);
+
+    // The replacement is booting: ten more unhealthy probes inside the grace
+    // window must not bounce it again.
+    for (let i = 0; i < 10; i++) {
+      clock += 5_000;
+      await watchdog.checkNow();
+    }
+    expect(restart).toHaveBeenCalledTimes(1);
+
+    // It comes up; the hold clears and a later wedge is caught normally.
+    healthy = true;
+    await watchdog.checkNow();
+    healthy = false;
+    for (let i = 0; i < 3; i++) await watchdog.checkNow();
+    expect(restart).toHaveBeenCalledTimes(2);
+  });
+
+  it("restarts again when the replacement never becomes healthy within the grace", async () => {
+    let clock = 0;
+    const restart = vi.fn();
+    const watchdog = createApiHealthWatchdog({
+      check: async () => false,
+      restart,
+      failureThreshold: 3,
+      recoveryGraceMs: 60_000,
+      now: () => clock,
+    });
+    for (let i = 0; i < 3; i++) await watchdog.checkNow();
+    expect(restart).toHaveBeenCalledTimes(1);
+    clock = 61_000;
+    for (let i = 0; i < 3; i++) await watchdog.checkNow();
+    expect(restart).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
cc @lalalune

## What
`createApiHealthWatchdog` (dev-ui supervisor) restarts a wedged API child after 3 failed `/api/health` probes — but never pauses across the restart. A replacement child is not `ready` for its whole boot (~35s on a loaded box), so the watchdog killed every replacement 15s in. Live 2026-08-22: 32 consecutive wedge-restarts after one idle stall until a boot happened to win the race.

## Fix
After `restart()` the watchdog holds its failure count until the first healthy probe, bounded by `recoveryGraceMs` (180s) so a replacement that never comes up is still restarted. Tests cover the hold, the recovery, and the grace expiry.

<details><summary>Original commits (squashed here)</summary>

- 91902c5157f fix(dev): health watchdog holds its failure count through a replacement child's boot

</details>

---
Carried from the live Cerebras / eliza-code coding-agent deployment on nubilio (Discord, gemma-4-31b via plugin-elizacloud). Every fix below was found on a real trajectory, fixed, and re-probed live; each PR is the net diff of one area against current `develop`, squashed into one commit. Draft on purpose — @lalalune is picking up all coding-agent work; happy to split further or drop pieces.

Nothing here was run through `bun run verify` on a clean develop checkout (the carries were validated on the live box); CI is the gate.
