### PR TITLE
fix(discord): contain designed turn aborts and project interaction blocks

### DIFF
--- a/plugins/plugin-discord/__tests__/draft-stream.test.ts
+++ b/plugins/plugin-discord/__tests__/draft-stream.test.ts
@@ -64,6 +64,19 @@ function rowJson(component: unknown): {
 }
 
 describe("draft-stream finalize components (#14527)", () => {
+	it("discards a started stream without emitting an interruption bubble", async () => {
+		const { channel, sends } = makeChannel();
+		const controller = createDraftStreamController({ minInitialChars: 1 });
+		await controller.start(channel);
+		controller.update("pending text");
+
+		controller.discard();
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		expect(controller.isDone()).toBe(true);
+		expect(sends).toEqual([]);
+	});
+
 	it("attaches components to the finalized message", async () => {
 		const { channel, sends } = makeChannel();
 		const controller = createDraftStreamController();

--- a/plugins/plugin-discord/__tests__/draft-stream.test.ts
+++ b/plugins/plugin-discord/__tests__/draft-stream.test.ts
@@ -9,7 +9,7 @@ import type {
 	MessageActionRowComponentBuilder,
 	TextChannel,
 } from "discord.js";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createDraftStreamController } from "../draft-stream";
 import type { DiscordActionRow } from "../types";
 import { buildDiscordComponents } from "../utils";
@@ -96,6 +96,39 @@ describe("draft-stream finalize components (#14527)", () => {
 
 		expect(deletions).toEqual(["msg-1"]);
 		expect(controller.isDone()).toBe(true);
+	});
+
+	it("deletes a snapshot whose provider send settles during discard", async () => {
+		vi.useFakeTimers();
+		let resolveSend!: (message: DiscordMessage) => void;
+		const deletions: string[] = [];
+		const channel = {
+			send: () =>
+				new Promise<DiscordMessage>((resolve) => {
+					resolveSend = resolve;
+				}),
+		} as unknown as TextChannel;
+		const controller = createDraftStreamController({
+			throttleMs: 250,
+			minInitialChars: 1,
+		});
+		await controller.start(channel);
+		controller.update("partial response");
+		vi.advanceTimersByTime(250);
+		await Promise.resolve();
+
+		const discard = controller.discard();
+		resolveSend({
+			id: "late-snapshot",
+			delete: async () => {
+				deletions.push("late-snapshot");
+			},
+		} as DiscordMessage);
+		await discard;
+
+		expect(deletions).toEqual(["late-snapshot"]);
+		expect(controller.isDone()).toBe(true);
+		vi.useRealTimers();
 	});
 
 	it("attaches components to the finalized message", async () => {

--- a/plugins/plugin-discord/__tests__/draft-stream.test.ts
+++ b/plugins/plugin-discord/__tests__/draft-stream.test.ts
@@ -22,6 +22,7 @@ interface CapturedSend {
 function makeChannel() {
 	const sends: CapturedSend[] = [];
 	const edits: CapturedSend[] = [];
+	const deletions: string[] = [];
 	const channel = {
 		send: async (options: CapturedSend) => {
 			sends.push(options);
@@ -30,6 +31,9 @@ function makeChannel() {
 				content: options.content ?? "",
 				createdTimestamp: Date.now(),
 				attachments: { size: 0 },
+				delete: async () => {
+					deletions.push(`msg-${sends.length}`);
+				},
 				edit: async (editOptions: CapturedSend) => {
 					edits.push(editOptions);
 					return { id: `msg-${sends.length}` };
@@ -37,7 +41,7 @@ function makeChannel() {
 			};
 		},
 	} as unknown as TextChannel;
-	return { channel, sends, edits };
+	return { channel, sends, edits, deletions };
 }
 
 const choiceRow: DiscordActionRow = {
@@ -70,11 +74,28 @@ describe("draft-stream finalize components (#14527)", () => {
 		await controller.start(channel);
 		controller.update("pending text");
 
-		controller.discard();
+		await controller.discard();
 		await new Promise((resolve) => setTimeout(resolve, 300));
 
 		expect(controller.isDone()).toBe(true);
 		expect(sends).toEqual([]);
+	});
+
+	it("deletes an already-flushed partial snapshot when discarded", async () => {
+		const { channel, sends, deletions } = makeChannel();
+		const controller = createDraftStreamController({
+			throttleMs: 250,
+			minInitialChars: 1,
+		});
+		await controller.start(channel);
+		controller.update("partial response");
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		expect(sends).toHaveLength(1);
+
+		await controller.discard();
+
+		expect(deletions).toEqual(["msg-1"]);
+		expect(controller.isDone()).toBe(true);
 	});
 
 	it("attaches components to the finalized message", async () => {

--- a/plugins/plugin-discord/__tests__/generation-abort.test.ts
+++ b/plugins/plugin-discord/__tests__/generation-abort.test.ts
@@ -19,7 +19,10 @@
  * race-without-abort behavior).
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { runGenerationWithAbortableTimeout } from "../messages.ts";
+import {
+	isUserRequestedTurnAbort,
+	runGenerationWithAbortableTimeout,
+} from "../messages.ts";
 
 /** Deferred promise helper — lets a test control exactly when generation settles. */
 function deferred<T>() {
@@ -233,5 +236,20 @@ describe("runGenerationWithAbortableTimeout", () => {
 		expect(secondSignal).toBeDefined();
 		expect(secondSignal).not.toBe(firstSignal);
 		expect(secondSignal?.aborted).toBe(false);
+	});
+});
+
+describe("isUserRequestedTurnAbort", () => {
+	it("recognizes core's TURN_ABORTED error by code, not by message", () => {
+		const aborted = Object.assign(
+			new Error("Turn aborted: user requested to stop"),
+			{ code: "TURN_ABORTED" },
+		);
+		expect(isUserRequestedTurnAbort(aborted)).toBe(true);
+		expect(isUserRequestedTurnAbort(new Error("Turn aborted: anything"))).toBe(
+			false,
+		);
+		expect(isUserRequestedTurnAbort(new Error("Bad Request"))).toBe(false);
+		expect(isUserRequestedTurnAbort(undefined)).toBe(false);
 	});
 });

--- a/plugins/plugin-discord/__tests__/generation-abort.test.ts
+++ b/plugins/plugin-discord/__tests__/generation-abort.test.ts
@@ -18,6 +18,7 @@
  * Each test states whether it reproduces the pre-fix bug (RED against the old
  * race-without-abort behavior).
  */
+import { TurnAbortedError } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	designedTurnAbortReason,
@@ -241,15 +242,18 @@ describe("runGenerationWithAbortableTimeout", () => {
 
 describe("designedTurnAbortReason", () => {
 	it("requires core's TURN_ABORTED code and explicit reason", () => {
-		const aborted = Object.assign(
-			new Error("Turn aborted: user requested to stop"),
-			{ code: "TURN_ABORTED", reason: "user-requested" },
-		);
+		const aborted = new TurnAbortedError("user-requested");
 		expect(designedTurnAbortReason(aborted)).toBe("user-requested");
-		expect(
-			designedTurnAbortReason({ code: "TURN_ABORTED", reason: "runtime-stop" }),
-		).toBe("runtime-stop");
+		expect(designedTurnAbortReason(new TurnAbortedError("runtime-stop"))).toBe(
+			"runtime-stop",
+		);
 		expect(designedTurnAbortReason({ code: "TURN_ABORTED" })).toBeNull();
+		expect(
+			designedTurnAbortReason({
+				code: "TURN_ABORTED",
+				reason: "forged-provider-error",
+			}),
+		).toBeNull();
 		expect(
 			designedTurnAbortReason(new Error("Turn aborted: anything")),
 		).toBeNull();

--- a/plugins/plugin-discord/__tests__/generation-abort.test.ts
+++ b/plugins/plugin-discord/__tests__/generation-abort.test.ts
@@ -20,7 +20,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-	isUserRequestedTurnAbort,
+	designedTurnAbortReason,
 	runGenerationWithAbortableTimeout,
 } from "../messages.ts";
 
@@ -239,17 +239,21 @@ describe("runGenerationWithAbortableTimeout", () => {
 	});
 });
 
-describe("isUserRequestedTurnAbort", () => {
-	it("recognizes core's TURN_ABORTED error by code, not by message", () => {
+describe("designedTurnAbortReason", () => {
+	it("requires core's TURN_ABORTED code and explicit reason", () => {
 		const aborted = Object.assign(
 			new Error("Turn aborted: user requested to stop"),
-			{ code: "TURN_ABORTED" },
+			{ code: "TURN_ABORTED", reason: "user-requested" },
 		);
-		expect(isUserRequestedTurnAbort(aborted)).toBe(true);
-		expect(isUserRequestedTurnAbort(new Error("Turn aborted: anything"))).toBe(
-			false,
-		);
-		expect(isUserRequestedTurnAbort(new Error("Bad Request"))).toBe(false);
-		expect(isUserRequestedTurnAbort(undefined)).toBe(false);
+		expect(designedTurnAbortReason(aborted)).toBe("user-requested");
+		expect(
+			designedTurnAbortReason({ code: "TURN_ABORTED", reason: "runtime-stop" }),
+		).toBe("runtime-stop");
+		expect(designedTurnAbortReason({ code: "TURN_ABORTED" })).toBeNull();
+		expect(
+			designedTurnAbortReason(new Error("Turn aborted: anything")),
+		).toBeNull();
+		expect(designedTurnAbortReason(new Error("Bad Request"))).toBeNull();
+		expect(designedTurnAbortReason(undefined)).toBeNull();
 	});
 });

--- a/plugins/plugin-discord/__tests__/generation-timeout-dispatch.test.ts
+++ b/plugins/plugin-discord/__tests__/generation-timeout-dispatch.test.ts
@@ -15,7 +15,7 @@
  * Only the discord.js SDK surface is stubbed — no token, no network.
  */
 import type { Content, Memory, UUID } from "@elizaos/core";
-import { ChannelType } from "@elizaos/core";
+import { ChannelType, TurnAbortedError } from "@elizaos/core";
 import type { Message as DiscordMessage } from "discord.js";
 import { ChannelType as DiscordChannelType } from "discord.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -513,10 +513,7 @@ describe("Discord generation timeout aborts the underlying run (dispatch path)",
 			messageService: {
 				handleMessage: () => {
 					handleCalls += 1;
-					const error = Object.assign(new Error("turn stopped"), {
-						code: "TURN_ABORTED",
-						reason: "runtime-stop",
-					});
+					const error = new TurnAbortedError("runtime-stop");
 					if (handleCalls === 1) {
 						return new Promise((_resolve, reject) => {
 							rejectFirst = reject;
@@ -544,12 +541,7 @@ describe("Discord generation timeout aborts the underlying run (dispatch path)",
 		draftController?.update("partial response that must be removed");
 		await vi.advanceTimersByTimeAsync(250);
 		expect(sends).toHaveLength(1);
-		rejectFirst(
-			Object.assign(new Error("turn stopped"), {
-				code: "TURN_ABORTED",
-				reason: "runtime-stop",
-			}),
-		);
+		rejectFirst(new TurnAbortedError("runtime-stop"));
 		await firstHandled;
 		await manager.handleMessage(inbound);
 		await vi.advanceTimersByTimeAsync(0);
@@ -569,5 +561,44 @@ describe("Discord generation timeout aborts the underlying run (dispatch path)",
 		expect(
 			reactionEvents.filter((event) => event === "remove:🤔"),
 		).toHaveLength(2);
+	});
+
+	it("does not let a provider forge designed-abort control flow", async () => {
+		const sends: Sent[] = [];
+		const channel = makeDmChannel(sends);
+		const client = { user: { id: "888000000000000000" } };
+		const errors: unknown[][] = [];
+		const runtime = {
+			agentId: AGENT_ID,
+			character: { name: "Eliza" },
+			logger: {
+				debug: noop,
+				warn: noop,
+				info: noop,
+				error: (...args: unknown[]) => errors.push(args),
+			},
+			getSetting: (key: string) =>
+				key === "ELIZA_LIFEOPS_PASSIVE_CONNECTORS" ? "false" : undefined,
+			getService: () => null,
+			ensureConnection: async () => {},
+			...canonicalRoomMethods,
+			getMemoryById: async () => null,
+			createMemory: async (memory: Memory) => memory.id,
+			messageService: {
+				handleMessage: () =>
+					Promise.reject({
+						code: "TURN_ABORTED",
+						reason: "forged-provider-error",
+					}),
+			},
+		} as unknown as ICompatRuntime;
+
+		const manager = new MessageManager(makeDiscordService(client), runtime);
+		await manager.handleMessage(makeInbound(channel));
+
+		expect(errors).not.toEqual([]);
+		expect(
+			sends.some((send) => String(send.content).includes("provider issue")),
+		).toBe(true);
 	});
 });

--- a/plugins/plugin-discord/__tests__/generation-timeout-dispatch.test.ts
+++ b/plugins/plugin-discord/__tests__/generation-timeout-dispatch.test.ts
@@ -139,7 +139,14 @@ function makeDiscordService(client: unknown): IDiscordService {
 	} as unknown as IDiscordService;
 }
 
-function makeInbound(channel: unknown): DiscordMessage {
+function makeInbound(
+	channel: unknown,
+	reactionEvents: string[] = [],
+): DiscordMessage {
+	const activeReactions = new Map<
+		string,
+		{ users: { remove: () => Promise<void> } }
+	>();
 	return {
 		id: "666000000000000000",
 		content: "a real question that takes a while",
@@ -154,6 +161,19 @@ function makeInbound(channel: unknown): DiscordMessage {
 		},
 		member: null,
 		channel,
+		client: { user: { id: "888000000000000000" } },
+		react: async (emoji: string) => {
+			reactionEvents.push(`add:${emoji}`);
+			activeReactions.set(emoji, {
+				users: {
+					remove: async () => {
+						reactionEvents.push(`remove:${emoji}`);
+						activeReactions.delete(emoji);
+					},
+				},
+			});
+		},
+		reactions: { resolve: (emoji: string) => activeReactions.get(emoji) },
 		guild: undefined,
 		interaction: null,
 		reference: undefined,
@@ -448,5 +468,62 @@ describe("Discord generation timeout aborts the underlying run (dispatch path)",
 			String(s.content).includes("timed out"),
 		);
 		expect(timeoutReplies).toHaveLength(0);
+	});
+
+	it("silently settles designed aborts and releases an uncommitted inbound slot", async () => {
+		const sends: Sent[] = [];
+		const reactionEvents: string[] = [];
+		const channel = makeDmChannel(sends);
+		const client = { user: { id: "888000000000000000" } };
+		const errors: unknown[][] = [];
+		const infos: unknown[][] = [];
+		let handleCalls = 0;
+		const runtime = {
+			agentId: AGENT_ID,
+			character: { name: "Eliza" },
+			logger: {
+				debug: noop,
+				warn: noop,
+				info: (...args: unknown[]) => infos.push(args),
+				error: (...args: unknown[]) => errors.push(args),
+			},
+			getSetting: (key: string) =>
+				key === "ELIZA_LIFEOPS_PASSIVE_CONNECTORS" ? "false" : undefined,
+			getService: () => null,
+			ensureConnection: async () => {},
+			...canonicalRoomMethods,
+			getMemoryById: async () => null,
+			createMemory: async (memory: Memory) => memory.id,
+			messageService: {
+				handleMessage: async () => {
+					handleCalls += 1;
+					throw Object.assign(new Error("turn stopped"), {
+						code: "TURN_ABORTED",
+						reason: "runtime-stop",
+					});
+				},
+			},
+		} as unknown as ICompatRuntime;
+		const manager = new MessageManager(makeDiscordService(client), runtime);
+		const inbound = makeInbound(channel, reactionEvents);
+
+		await manager.handleMessage(inbound);
+		await manager.handleMessage(inbound);
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(handleCalls).toBe(2);
+		expect(sends).toEqual([]);
+		expect(errors).toEqual([]);
+		expect(infos).toEqual(
+			expect.arrayContaining([
+				expect.arrayContaining([
+					expect.objectContaining({ reason: "runtime-stop" }),
+				]),
+			]),
+		);
+		expect(reactionEvents).not.toContain("add:❌");
+		expect(
+			reactionEvents.filter((event) => event === "remove:🤔"),
+		).toHaveLength(2);
 	});
 });

--- a/plugins/plugin-discord/__tests__/generation-timeout-dispatch.test.ts
+++ b/plugins/plugin-discord/__tests__/generation-timeout-dispatch.test.ts
@@ -19,6 +19,10 @@ import { ChannelType } from "@elizaos/core";
 import type { Message as DiscordMessage } from "discord.js";
 import { ChannelType as DiscordChannelType } from "discord.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createDraftStreamController,
+	type DraftStreamController,
+} from "../draft-stream.ts";
 import { MessageManager } from "../messages.ts";
 import type { ICompatRuntime, IDiscordService } from "../types.ts";
 
@@ -110,14 +114,20 @@ function makeHangingRuntime(settings: Record<string, string> = {}): {
 	};
 }
 
-function makeDmChannel(sends: Sent[]) {
+function makeDmChannel(sends: Sent[], deleted: string[] = []) {
 	return {
 		id: "777000000000000000",
 		type: DiscordChannelType.DM,
 		isThread: () => false,
 		send: async (options: Sent) => {
 			sends.push(options);
-			return { id: "990000000000000001", ...options };
+			return {
+				id: `99000000000000000${sends.length}`,
+				...options,
+				delete: async () => {
+					deleted.push(`99000000000000000${sends.length}`);
+				},
+			};
 		},
 		sendTyping: async () => {},
 	};
@@ -472,12 +482,14 @@ describe("Discord generation timeout aborts the underlying run (dispatch path)",
 
 	it("silently settles designed aborts and releases an uncommitted inbound slot", async () => {
 		const sends: Sent[] = [];
+		const deleted: string[] = [];
 		const reactionEvents: string[] = [];
-		const channel = makeDmChannel(sends);
+		const channel = makeDmChannel(sends, deleted);
 		const client = { user: { id: "888000000000000000" } };
 		const errors: unknown[][] = [];
 		const infos: unknown[][] = [];
 		let handleCalls = 0;
+		let rejectFirst!: (error: unknown) => void;
 		const runtime = {
 			agentId: AGENT_ID,
 			character: { name: "Eliza" },
@@ -499,24 +511,52 @@ describe("Discord generation timeout aborts the underlying run (dispatch path)",
 			getMemoryById: async () => null,
 			createMemory: async (memory: Memory) => memory.id,
 			messageService: {
-				handleMessage: async () => {
+				handleMessage: () => {
 					handleCalls += 1;
-					throw Object.assign(new Error("turn stopped"), {
+					const error = Object.assign(new Error("turn stopped"), {
 						code: "TURN_ABORTED",
 						reason: "runtime-stop",
 					});
+					if (handleCalls === 1) {
+						return new Promise((_resolve, reject) => {
+							rejectFirst = reject;
+						});
+					}
+					return Promise.reject(error);
 				},
 			},
 		} as unknown as ICompatRuntime;
-		const manager = new MessageManager(makeDiscordService(client), runtime);
+		let draftController: DraftStreamController | undefined;
+		const manager = new MessageManager(makeDiscordService(client), runtime, {
+			draftStreamFactory: (options) => {
+				draftController = createDraftStreamController({
+					...options,
+					throttleMs: 250,
+					minInitialChars: 1,
+				});
+				return draftController;
+			},
+		});
 		const inbound = makeInbound(channel, reactionEvents);
 
-		await manager.handleMessage(inbound);
+		const firstHandled = manager.handleMessage(inbound);
+		await vi.advanceTimersByTimeAsync(0);
+		draftController?.update("partial response that must be removed");
+		await vi.advanceTimersByTimeAsync(250);
+		expect(sends).toHaveLength(1);
+		rejectFirst(
+			Object.assign(new Error("turn stopped"), {
+				code: "TURN_ABORTED",
+				reason: "runtime-stop",
+			}),
+		);
+		await firstHandled;
 		await manager.handleMessage(inbound);
 		await vi.advanceTimersByTimeAsync(0);
 
 		expect(handleCalls).toBe(2);
-		expect(sends).toEqual([]);
+		expect(sends).toHaveLength(1);
+		expect(deleted).toEqual(["990000000000000001"]);
 		expect(errors).toEqual([]);
 		expect(infos).toEqual(
 			expect.arrayContaining([

--- a/plugins/plugin-discord/__tests__/generation-timeout-dispatch.test.ts
+++ b/plugins/plugin-discord/__tests__/generation-timeout-dispatch.test.ts
@@ -488,7 +488,11 @@ describe("Discord generation timeout aborts the underlying run (dispatch path)",
 				error: (...args: unknown[]) => errors.push(args),
 			},
 			getSetting: (key: string) =>
-				key === "ELIZA_LIFEOPS_PASSIVE_CONNECTORS" ? "false" : undefined,
+				key === "ELIZA_LIFEOPS_PASSIVE_CONNECTORS"
+					? "false"
+					: key === "DISCORD_DRAFT_STREAMING"
+						? "true"
+						: undefined,
 			getService: () => null,
 			ensureConnection: async () => {},
 			...canonicalRoomMethods,

--- a/plugins/plugin-discord/__tests__/messages-url.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-url.test.ts
@@ -402,6 +402,30 @@ describe("beginDiscordOutboundDelivery dedupe window", () => {
 		).toBe("deliver");
 	});
 
+	it("treats distinct native interaction payloads as distinct deliveries", () => {
+		const state = new Map<string, DiscordOutboundDeliveryState>();
+		const first = beginDiscordOutboundDelivery({
+			channelId: "123",
+			text: "Choose one",
+			interactionIdentity: '[{"id":"first"}]',
+			now: 1_000,
+			state,
+		});
+		expect(first.kind).toBe("deliver");
+		if (first.kind !== "deliver") throw new Error("expected deliver");
+		first.reservation.commit("delivered", receipt("first"), 1_000);
+
+		expect(
+			beginDiscordOutboundDelivery({
+				channelId: "123",
+				text: "Choose one",
+				interactionIdentity: '[{"id":"second"}]',
+				now: 1_001,
+				state,
+			}).kind,
+		).toBe("deliver");
+	});
+
 	it("never expires or cap-evicts an active reservation", () => {
 		const state = new Map<string, DiscordOutboundDeliveryState>();
 		const activeParams = {

--- a/plugins/plugin-discord/__tests__/send-handler-interaction-projection.test.ts
+++ b/plugins/plugin-discord/__tests__/send-handler-interaction-projection.test.ts
@@ -1,0 +1,33 @@
+/**
+ * The sendMessageToTarget handler must project interaction blocks the same way
+ * the reply path does. Live regression 2026-08-17: a sub-agent completion relay
+ * carried a [FOLLOWUPS] block and handleSendMessage shipped the literal markup
+ * to the Discord channel. Deterministic unit over the projection helpers the
+ * handler now composes (buildDiscordReplyPayload → text without raw markers).
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildDiscordReplyPayload } from "../interactions";
+
+const RELAY_TEXT =
+	"wind-chimes ready. index.html created in app folder.\n\n[FOLLOWUPS]\nnavigate:/apps=View apps\nprompt:What can I do with this app?=Ask usage\n[/FOLLOWUPS]";
+
+describe("send-handler interaction projection (live FOLLOWUPS leak)", () => {
+	it("strips the raw block from the prose and yields components", () => {
+		const runtime = { getSetting: () => "https://nubilio.org" };
+		const rendered = buildDiscordReplyPayload(runtime, { text: RELAY_TEXT });
+		expect(rendered.text).not.toContain("[FOLLOWUPS]");
+		expect(rendered.text).not.toContain("[/FOLLOWUPS]");
+		expect(rendered.text).toContain("wind-chimes ready");
+		expect(rendered.components.length).toBeGreaterThan(0);
+	});
+
+	it("passes block-free text through byte-identical", () => {
+		const runtime = { getSetting: () => undefined };
+		const rendered = buildDiscordReplyPayload(runtime, {
+			text: "plain relay text, no blocks",
+		});
+		expect(rendered.text).toBe("plain relay text, no blocks");
+		expect(rendered.components).toEqual([]);
+	});
+});

--- a/plugins/plugin-discord/__tests__/service-account-pool.test.ts
+++ b/plugins/plugin-discord/__tests__/service-account-pool.test.ts
@@ -381,6 +381,52 @@ describe("DiscordService.getAccountLabel", () => {
 });
 
 describe("DiscordService account-scoped primitives", () => {
+	it("projects interaction-only and long relay payloads through the real send handler", async () => {
+		const { graph, runtime, service } = makeService();
+		const target = {
+			source: "discord",
+			channelId: graph.textChannel.id,
+		};
+
+		await service.handleSendMessage(runtime as never, target, {
+			text: "[FOLLOWUPS]\nnavigate:/apps=View apps\n[/FOLLOWUPS]",
+		});
+		const interactionOnlyPayload = graph.textChannel.send.mock.calls[0]?.[0];
+		expect(interactionOnlyPayload).toMatchObject({
+			content: "Choose an option:",
+			components: expect.any(Array),
+		});
+
+		graph.textChannel.send.mockClear();
+		await service.handleSendMessage(runtime as never, target, {
+			text: `${"x".repeat(2_050)}\n[FOLLOWUPS]\nnavigate:/apps=View apps\n[/FOLLOWUPS]`,
+		});
+		expect(graph.textChannel.send).toHaveBeenCalledTimes(2);
+		expect(graph.textChannel.send.mock.calls[0]?.[0]).not.toHaveProperty(
+			"components",
+		);
+		expect(graph.textChannel.send.mock.calls[1]?.[0]).toMatchObject({
+			components: expect.any(Array),
+		});
+	});
+
+	it("does not dedupe equal prose carrying distinct native controls", async () => {
+		const { graph, runtime, service } = makeService();
+		const target = {
+			source: "discord",
+			channelId: graph.textChannel.id,
+		};
+
+		await service.handleSendMessage(runtime as never, target, {
+			text: "Choose next.\n[FOLLOWUPS]\nnavigate:/apps=View apps\n[/FOLLOWUPS]",
+		});
+		await service.handleSendMessage(runtime as never, target, {
+			text: "Choose next.\n[FOLLOWUPS]\nnavigate:/settings=View settings\n[/FOLLOWUPS]",
+		});
+
+		expect(graph.textChannel.send).toHaveBeenCalledTimes(2);
+	});
+
 	it("registers account connectors and scopes wrapper calls to the selected account", async () => {
 		const { runtime, service } = makeService();
 		DiscordService.registerSendHandlers(runtime as never, service);

--- a/plugins/plugin-discord/__tests__/service-account-pool.test.ts
+++ b/plugins/plugin-discord/__tests__/service-account-pool.test.ts
@@ -388,26 +388,47 @@ describe("DiscordService account-scoped primitives", () => {
 			channelId: graph.textChannel.id,
 		};
 
-		await service.handleSendMessage(runtime as never, target, {
-			text: "[FOLLOWUPS]\nnavigate:/apps=View apps\n[/FOLLOWUPS]",
-		});
+		const interactionOnlyResult = await service.handleSendMessage(
+			runtime as never,
+			target,
+			{
+				text: "[FOLLOWUPS]\nnavigate:/apps=View apps\n[/FOLLOWUPS]",
+			},
+		);
+		expect(interactionOnlyResult.kind).toBe("delivered");
 		const interactionOnlyPayload = graph.textChannel.send.mock.calls[0]?.[0];
 		expect(interactionOnlyPayload).toMatchObject({
 			content: "Choose an option:",
 			components: expect.any(Array),
 		});
+		expect(interactionOnlyPayload.content).not.toContain("[FOLLOWUPS]");
+		const interactionOnlyMemory = runtime.createMemory.mock.calls[0]?.[0];
+		expect(interactionOnlyMemory?.content.text).toBe("Choose an option:");
+		expect(interactionOnlyMemory?.content.text).not.toContain("[FOLLOWUPS]");
 
 		graph.textChannel.send.mockClear();
-		await service.handleSendMessage(runtime as never, target, {
-			text: `${"x".repeat(2_050)}\n[FOLLOWUPS]\nnavigate:/apps=View apps\n[/FOLLOWUPS]`,
-		});
-		expect(graph.textChannel.send).toHaveBeenCalledTimes(2);
-		expect(graph.textChannel.send.mock.calls[0]?.[0]).not.toHaveProperty(
-			"components",
+		runtime.createMemory.mockClear();
+		const longResult = await service.handleSendMessage(
+			runtime as never,
+			target,
+			{
+				text: `${"x".repeat(2_050)}\n[FOLLOWUPS]\nnavigate:/apps=View apps\n[/FOLLOWUPS]`,
+			},
 		);
-		expect(graph.textChannel.send.mock.calls[1]?.[0]).toMatchObject({
+		expect(longResult.kind).toBe("delivered");
+		expect(graph.textChannel.send).toHaveBeenCalledTimes(2);
+		const firstChunk = graph.textChannel.send.mock.calls[0]?.[0];
+		const finalChunk = graph.textChannel.send.mock.calls[1]?.[0];
+		expect(firstChunk).not.toHaveProperty("components");
+		expect(firstChunk.content).not.toContain("[FOLLOWUPS]");
+		expect(finalChunk).toMatchObject({
 			components: expect.any(Array),
 		});
+		expect(finalChunk.content).not.toContain("[FOLLOWUPS]");
+		expect(runtime.createMemory).toHaveBeenCalledTimes(2);
+		for (const [memory] of runtime.createMemory.mock.calls) {
+			expect(memory.content.text).not.toContain("[FOLLOWUPS]");
+		}
 	});
 
 	it("does not dedupe equal prose carrying distinct native controls", async () => {
@@ -417,14 +438,19 @@ describe("DiscordService account-scoped primitives", () => {
 			channelId: graph.textChannel.id,
 		};
 
-		await service.handleSendMessage(runtime as never, target, {
+		const first = await service.handleSendMessage(runtime as never, target, {
 			text: "Choose next.\n[FOLLOWUPS]\nnavigate:/apps=View apps\n[/FOLLOWUPS]",
 		});
-		await service.handleSendMessage(runtime as never, target, {
+		const second = await service.handleSendMessage(runtime as never, target, {
 			text: "Choose next.\n[FOLLOWUPS]\nnavigate:/settings=View settings\n[/FOLLOWUPS]",
 		});
 
+		expect(first.kind).toBe("delivered");
+		expect(second.kind).toBe("delivered");
 		expect(graph.textChannel.send).toHaveBeenCalledTimes(2);
+		expect(graph.textChannel.send.mock.calls[0]?.[0].components).not.toEqual(
+			graph.textChannel.send.mock.calls[1]?.[0].components,
+		);
 	});
 
 	it("registers account connectors and scopes wrapper calls to the selected account", async () => {

--- a/plugins/plugin-discord/actions/messageConnector.outbound-media.test.ts
+++ b/plugins/plugin-discord/actions/messageConnector.outbound-media.test.ts
@@ -34,6 +34,7 @@ function createDiscordConnectorTestService<
 function createRuntime() {
 	return {
 		agentId: "agent-1",
+		getSetting: vi.fn(() => undefined),
 		logger: {
 			info: vi.fn(),
 			debug: vi.fn(),

--- a/plugins/plugin-discord/actions/messageConnector.test.ts
+++ b/plugins/plugin-discord/actions/messageConnector.test.ts
@@ -26,6 +26,7 @@ function createDiscordConnectorTestService<
 function createRuntime() {
 	return {
 		agentId: "agent-1",
+		getSetting: vi.fn(() => undefined),
 		registerMessageConnector: vi.fn(),
 		registerSendHandler: vi.fn(),
 		logger: {

--- a/plugins/plugin-discord/draft-stream.ts
+++ b/plugins/plugin-discord/draft-stream.ts
@@ -38,6 +38,8 @@ export interface DraftStreamController {
 		components?: ActionRowBuilder<MessageActionRowComponentBuilder>[],
 	) => Promise<DiscordMessage[]>;
 	abort: (reason?: string) => Promise<void>;
+	/** End streaming without emitting an interruption message. */
+	discard: () => void;
 	messageId: () => string | undefined;
 	isStarted: () => boolean;
 	isDone: () => boolean;
@@ -328,11 +330,22 @@ export function createDraftStreamController(
 		log("draft-stream: aborted");
 	};
 
+	const discard = (): void => {
+		if (done) {
+			return;
+		}
+		done = true;
+		clearThrottle();
+		pendingText = null;
+		log("draft-stream: discarded silently");
+	};
+
 	return {
 		start,
 		update,
 		finalize,
 		abort,
+		discard,
 		messageId: () => lastSentMessage?.id,
 		isStarted: () => started,
 		isDone: () => done,

--- a/plugins/plugin-discord/draft-stream.ts
+++ b/plugins/plugin-discord/draft-stream.ts
@@ -68,6 +68,7 @@ export function createDraftStreamController(
 	let throttleTimer: ReturnType<typeof setTimeout> | null = null;
 	let started = false;
 	let done = false;
+	const activeSnapshots = new Set<Promise<boolean>>();
 
 	const clearThrottle = () => {
 		if (throttleTimer) {
@@ -160,12 +161,31 @@ export function createDraftStreamController(
 		}
 	};
 
+	const sendTrackedSnapshot = (
+		text: string,
+		components?: ActionRowBuilder<MessageActionRowComponentBuilder>[],
+	): Promise<boolean> => {
+		const snapshot = sendSnapshot(text, components);
+		activeSnapshots.add(snapshot);
+		void snapshot.then(
+			() => activeSnapshots.delete(snapshot),
+			() => activeSnapshots.delete(snapshot),
+		);
+		return snapshot;
+	};
+
+	const waitForActiveSnapshots = async (): Promise<void> => {
+		while (activeSnapshots.size > 0) {
+			await Promise.allSettled([...activeSnapshots]);
+		}
+	};
+
 	const flush = async (): Promise<void> => {
 		clearThrottle();
 		if (pendingText !== null) {
 			const text = pendingText;
 			pendingText = null;
-			await sendSnapshot(text);
+			await sendTrackedSnapshot(text);
 		}
 	};
 
@@ -231,7 +251,10 @@ export function createDraftStreamController(
 		}
 
 		if (trimmed.length <= maxChars) {
-			await sendSnapshot(trimmed, components);
+			await sendTrackedSnapshot(trimmed, components);
+			if (done) {
+				return sentMessages;
+			}
 			done = true;
 			log("draft-stream: finalized (single message)");
 			return sentMessages;
@@ -257,9 +280,15 @@ export function createDraftStreamController(
 		const firstChunk = firstHead.trimEnd();
 		let remaining = trimmed.slice(firstHead.length).trimStart();
 
-		await sendSnapshot(firstChunk);
+		await sendTrackedSnapshot(firstChunk);
+		if (done) {
+			return sentMessages;
+		}
 
 		while (remaining.length > 0 && channel) {
+			if (done) {
+				break;
+			}
 			const nextBreak = findBreakPoint(
 				remaining,
 				maxChars,
@@ -337,6 +366,7 @@ export function createDraftStreamController(
 		done = true;
 		clearThrottle();
 		pendingText = null;
+		await waitForActiveSnapshots();
 		for (const message of [...sentMessages].reverse()) {
 			try {
 				await message.delete();

--- a/plugins/plugin-discord/draft-stream.ts
+++ b/plugins/plugin-discord/draft-stream.ts
@@ -39,7 +39,7 @@ export interface DraftStreamController {
 	) => Promise<DiscordMessage[]>;
 	abort: (reason?: string) => Promise<void>;
 	/** End streaming without emitting an interruption message. */
-	discard: () => void;
+	discard: () => Promise<void>;
 	messageId: () => string | undefined;
 	isStarted: () => boolean;
 	isDone: () => boolean;
@@ -330,13 +330,24 @@ export function createDraftStreamController(
 		log("draft-stream: aborted");
 	};
 
-	const discard = (): void => {
+	const discard = async (): Promise<void> => {
 		if (done) {
 			return;
 		}
 		done = true;
 		clearThrottle();
 		pendingText = null;
+		for (const message of [...sentMessages].reverse()) {
+			try {
+				await message.delete();
+			} catch (error) {
+				// error-policy:J6 designed-abort teardown is best-effort; failure to
+				// delete an already-sent snapshot is observable in connector logs.
+				warn(
+					`draft-stream: silent discard delete failed: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		}
 		log("draft-stream: discarded silently");
 	};
 

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -121,7 +121,7 @@ import {
 	sendMessageInChunks,
 } from "./utils";
 
-const INTERACTION_ONLY_FALLBACK_TEXT = "Choose an option:";
+export const INTERACTION_ONLY_FALLBACK_TEXT = "Choose an option:";
 
 // Filler tokens carrying no answer content — two single-fact replies differing
 // only in these words are the same fact reworded.
@@ -427,6 +427,7 @@ export interface DiscordOutboundDeliveryParams {
 	replyToMessageId?: string;
 	text?: string;
 	attachmentUrls?: readonly string[];
+	interactionIdentity?: string;
 	now?: number;
 	windowMs?: number;
 	state?: Map<string, DiscordOutboundDeliveryState>;
@@ -488,7 +489,8 @@ export function beginDiscordOutboundDelivery(
 ): BeginDiscordOutboundDeliveryResult {
 	const text = normalizeOutboundText(params.text);
 	const attachments = outboundAttachmentIdentity(params.attachmentUrls);
-	if (!text && !attachments) {
+	const interactionIdentity = params.interactionIdentity?.trim() ?? "";
+	if (!text && !attachments && !interactionIdentity) {
 		return {
 			kind: "deliver",
 			reservation: {
@@ -509,6 +511,7 @@ export function beginDiscordOutboundDelivery(
 		params.channelId,
 		params.replyToMessageId ?? "",
 		attachments,
+		interactionIdentity,
 		text,
 	].join("\u0000");
 
@@ -639,18 +642,22 @@ export interface AbortableTimeoutResult {
 }
 
 /**
- * A turn the USER cancelled (core's TurnAbortedError, code TURN_ABORTED —
- * raised when a stop/cancel ask aborts the in-flight planner turn of an
- * earlier message). Not a provider failure: the stop turn's own confirmation
- * is the notice, and "I hit a provider issue… Please retry." for the build the
- * user just cancelled is wrong on both counts (live 2026-08-22, tetris).
+ * Reads core's designed TurnAbortedError contract. Both user cancellation and
+ * runtime lifecycle shutdown use TURN_ABORTED, so callers preserve the reason
+ * instead of misclassifying every designed abort as user-requested. Designed
+ * aborts are control flow, not provider failures, and must not emit retry text.
  */
-export function isUserRequestedTurnAbort(error: unknown): boolean {
-	return (
+export function designedTurnAbortReason(error: unknown): string | null {
+	if (
 		typeof error === "object" &&
 		error !== null &&
-		(error as { code?: unknown }).code === "TURN_ABORTED"
-	);
+		(error as { code?: unknown }).code === "TURN_ABORTED" &&
+		typeof (error as { reason?: unknown }).reason === "string" &&
+		(error as { reason: string }).reason.trim().length > 0
+	) {
+		return (error as { reason: string }).reason;
+	}
+	return null;
 }
 
 /**
@@ -2376,6 +2383,9 @@ export class MessageManager {
 					// native Discord components, and strip their markers from the prose.
 					const rendered = buildDiscordReplyPayload(this.runtime, content);
 					const hasComponents = rendered.components.length > 0;
+					const interactionIdentity = hasComponents
+						? JSON.stringify(rendered.components)
+						: undefined;
 					let textContent = normalizeDiscordMessageText(rendered.text);
 					if (textContent.trim().length === 0 && hasComponents) {
 						textContent = INTERACTION_ONLY_FALLBACK_TEXT;
@@ -2421,7 +2431,7 @@ export class MessageManager {
 					// twice in response to the same inbound message (e.g.
 					// planner follow-up repeating action output).
 					if (hasText && content.inReplyTo) {
-						const dedupKey = `${content.inReplyTo}::${textContent.replace(/\s+/g, " ").trim()}`;
+						const dedupKey = `${content.inReplyTo}::${textContent.replace(/\s+/g, " ").trim()}::${interactionIdentity ?? ""}`;
 						const callbackDedup = message as DiscordMessage & {
 							_elizaSentReplyKeys?: Set<string>;
 							_elizaSentFactSignatures?: Array<Set<string>>;
@@ -2439,6 +2449,7 @@ export class MessageManager {
 						// lacks) through, regardless of delivery order.
 						const factSignature = numericFactSignatureTokens(textContent);
 						const repeatsPriorFact =
+							!hasComponents &&
 							factSignature !== null &&
 							callbackDedup._elizaSentFactSignatures.some((prior) =>
 								isSubsetOrEqual(factSignature, prior),
@@ -2480,6 +2491,7 @@ export class MessageManager {
 						attachmentUrls: content.attachments
 							?.map((media) => media.url)
 							.filter((url): url is string => typeof url === "string"),
+						interactionIdentity,
 					};
 					let outboundDedupe = beginDiscordOutboundDelivery(dedupeParams);
 					while (outboundDedupe.kind === "in_flight") {
@@ -2959,6 +2971,39 @@ export class MessageManager {
 					generationTimedOut &&
 					!!messageId &&
 					hasActiveTaskAgentWorkForMessage(this.runtime, messageId);
+				const designedAbortReason = designedTurnAbortReason(generationError);
+				if (designedAbortReason) {
+					typingController.stop();
+					statusReactions?.setDone();
+					await abortPendingDraft();
+					if (speakerLease) {
+						await releaseSpeakerLease(
+							this.runtime,
+							speakerLease,
+							"designed-turn-abort",
+						);
+					}
+					turnRecord = await this.closeTurnAsIngestOnly(turnRecord);
+					this.runtime.logger.info(
+						{
+							src: "plugin:discord",
+							agentId: this.runtime.agentId,
+							messageId: message.id,
+							memoryId: messageId,
+							roomId,
+							reason: designedAbortReason,
+						},
+						"Suppressing Discord failure reply for a designed turn abort",
+					);
+					if (!inboundMemoryCommitted) {
+						inboundMemoryCommitted =
+							await this.releaseMessageProcessingIfInboundNotPersisted(
+								message.id,
+								inboundMemoryId,
+							);
+					}
+					return;
+				}
 				this.runtime.logger.error(
 					{
 						src: "plugin:discord",
@@ -3008,29 +3053,6 @@ export class MessageManager {
 						},
 						"Suppressing Discord timeout handling while response dispatch is in flight",
 					);
-					return;
-				}
-
-				if (isUserRequestedTurnAbort(generationError)) {
-					statusReactions?.setDone();
-					await abortPendingDraft();
-					this.runtime.logger.warn(
-						{
-							src: "plugin:discord",
-							agentId: this.runtime.agentId,
-							messageId: message.id,
-							memoryId: messageId,
-							roomId,
-						},
-						"Suppressing Discord failure reply for a user-requested turn abort",
-					);
-					if (!inboundMemoryCommitted) {
-						inboundMemoryCommitted =
-							await this.releaseMessageProcessingIfInboundNotPersisted(
-								message.id,
-								inboundMemoryId,
-							);
-					}
 					return;
 				}
 

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -2975,7 +2975,7 @@ export class MessageManager {
 				if (designedAbortReason) {
 					typingController.stop();
 					statusReactions?.setDone();
-					await abortPendingDraft();
+					draftStream?.discard();
 					if (speakerLease) {
 						await releaseSpeakerLease(
 							this.runtime,

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -865,6 +865,7 @@ export class MessageManager {
 	private discordService: IDiscordService;
 	private accountId: string;
 	private statusReactionScope: StatusReactionScope;
+	private readonly draftStreamFactory: typeof createDraftStreamController;
 	private envelopeEnabled: boolean;
 	private draftStreamingEnabled: boolean;
 	private stalenessConfig: DiscordStalenessConfig;
@@ -881,7 +882,13 @@ export class MessageManager {
 	 * @param {ICompatRuntime} runtime - The agent runtime instance (with cross-core compat).
 	 * @throws {Error} If the Discord client is not initialized
 	 */
-	constructor(discordService: IDiscordService, runtime: ICompatRuntime) {
+	constructor(
+		discordService: IDiscordService,
+		runtime: ICompatRuntime,
+		options: {
+			draftStreamFactory?: typeof createDraftStreamController;
+		} = {},
+	) {
 		// Guard against null client - fail fast with a clear error
 		if (!discordService.client) {
 			const errorMsg =
@@ -895,6 +902,8 @@ export class MessageManager {
 
 		this.client = discordService.client;
 		this.runtime = runtime;
+		this.draftStreamFactory =
+			options.draftStreamFactory ?? createDraftStreamController;
 		this.attachmentManager = new AttachmentManager(this.runtime);
 		this.getChannelType = discordService.getChannelType;
 		this.discordService = discordService;
@@ -2097,7 +2106,7 @@ export class MessageManager {
 				this.discordService.trackStatusReaction?.(message.id, statusReactions);
 			}
 			const draftStream = this.draftStreamingEnabled
-				? createDraftStreamController({
+				? this.draftStreamFactory({
 						log: (entry) =>
 							this.runtime.logger.debug(
 								{ src: "plugin:discord", agentId: this.runtime.agentId },
@@ -2975,7 +2984,7 @@ export class MessageManager {
 				if (designedAbortReason) {
 					typingController.stop();
 					statusReactions?.setDone();
-					draftStream?.discard();
+					await draftStream?.discard();
 					if (speakerLease) {
 						await releaseSpeakerLease(
 							this.runtime,

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -639,6 +639,21 @@ export interface AbortableTimeoutResult {
 }
 
 /**
+ * A turn the USER cancelled (core's TurnAbortedError, code TURN_ABORTED —
+ * raised when a stop/cancel ask aborts the in-flight planner turn of an
+ * earlier message). Not a provider failure: the stop turn's own confirmation
+ * is the notice, and "I hit a provider issue… Please retry." for the build the
+ * user just cancelled is wrong on both counts (live 2026-08-22, tetris).
+ */
+export function isUserRequestedTurnAbort(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		(error as { code?: unknown }).code === "TURN_ABORTED"
+	);
+}
+
+/**
  * Runs a single generation attempt against a wall-clock timeout, wiring an
  * {@link AbortController} so that a timeout ACTUALLY CANCELS the underlying
  * work instead of leaving it running as an orphan.
@@ -2993,6 +3008,29 @@ export class MessageManager {
 						},
 						"Suppressing Discord timeout handling while response dispatch is in flight",
 					);
+					return;
+				}
+
+				if (isUserRequestedTurnAbort(generationError)) {
+					statusReactions?.setDone();
+					await abortPendingDraft();
+					this.runtime.logger.warn(
+						{
+							src: "plugin:discord",
+							agentId: this.runtime.agentId,
+							messageId: message.id,
+							memoryId: messageId,
+							roomId,
+						},
+						"Suppressing Discord failure reply for a user-requested turn abort",
+					);
+					if (!inboundMemoryCommitted) {
+						inboundMemoryCommitted =
+							await this.releaseMessageProcessingIfInboundNotPersisted(
+								message.id,
+								inboundMemoryId,
+							);
+					}
 					return;
 				}
 

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -26,6 +26,7 @@ import {
 	type Service,
 	ServiceType,
 	stringToUuid,
+	TurnAbortedError,
 	type UUID,
 } from "@elizaos/core";
 import {
@@ -648,14 +649,8 @@ export interface AbortableTimeoutResult {
  * aborts are control flow, not provider failures, and must not emit retry text.
  */
 export function designedTurnAbortReason(error: unknown): string | null {
-	if (
-		typeof error === "object" &&
-		error !== null &&
-		(error as { code?: unknown }).code === "TURN_ABORTED" &&
-		typeof (error as { reason?: unknown }).reason === "string" &&
-		(error as { reason: string }).reason.trim().length > 0
-	) {
-		return (error as { reason: string }).reason;
+	if (error instanceof TurnAbortedError && error.reason.trim().length > 0) {
+		return error.reason;
 	}
 	return null;
 }
@@ -2992,7 +2987,6 @@ export class MessageManager {
 							"designed-turn-abort",
 						);
 					}
-					turnRecord = await this.closeTurnAsIngestOnly(turnRecord);
 					this.runtime.logger.info(
 						{
 							src: "plugin:discord",
@@ -3010,6 +3004,14 @@ export class MessageManager {
 								message.id,
 								inboundMemoryId,
 							);
+					}
+					// A designed abort is terminal only once the inbound message is
+					// durable. If generation was cancelled before ingress persisted,
+					// leave the durable turn DISPATCHED and release the local admission
+					// slot so a gateway redelivery / crash sweep can retry without data
+					// loss. Marking REPLIED first made that retry impossible.
+					if (inboundMemoryCommitted) {
+						turnRecord = await this.closeTurnAsIngestOnly(turnRecord);
 					}
 					return;
 				}

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -149,6 +149,7 @@ import {
 	resolveDiscordRuntimeEntityId,
 	resolveElizaOwnerEntityId,
 } from "./identity";
+import { buildDiscordReplyPayload } from "./interactions";
 import {
 	beginDiscordOutboundDelivery,
 	createDiscordMessageMemoryOnce,
@@ -180,6 +181,7 @@ import type {
 } from "./types";
 import { DiscordEventTypes } from "./types";
 import {
+	buildDiscordComponents,
 	buildOutboundDiscordAttachment,
 	MAX_MESSAGE_LENGTH,
 	normalizeDiscordMessageText,
@@ -1967,7 +1969,19 @@ export class DiscordService extends Service implements IDiscordService {
 						? targetChannelGuild.name
 						: undefined;
 
-					const textContent = normalizeDiscordMessageText(content.text);
+					// Project embedded interaction blocks the same way the reply path
+					// does. This handler serves runtime.sendMessageToTarget — the
+					// sub-agent relay / progress / notice path — and sending
+					// `content.text` raw leaked literal `[FOLLOWUPS]…[/FOLLOWUPS]`
+					// markup to Discord (live 2026-08-17, wind-chimes relay). Blocks
+					// become action rows on the final chunk; block-free text is
+					// byte-identical to the previous behavior.
+					const rendered = buildDiscordReplyPayload(runtime, content);
+					const renderedComponents =
+						rendered.components.length > 0
+							? buildDiscordComponents(rendered.components)
+							: undefined;
+					const textContent = normalizeDiscordMessageText(rendered.text);
 					const outboundReplyToMessageId =
 						discordReplyReferenceFromContent(content);
 					if (textContent || files.length > 0) {
@@ -2061,6 +2075,9 @@ export class DiscordService extends Service implements IDiscordService {
 									const sent = await targetChannel.send({
 										content: chunks[chunks.length - 1],
 										files: files.length > 0 ? files : undefined,
+										...(renderedComponents
+											? { components: renderedComponents }
+											: {}),
 										...(outboundReplyToMessageId && chunks.length === 1
 											? {
 													reply: {
@@ -2076,6 +2093,9 @@ export class DiscordService extends Service implements IDiscordService {
 									const sent = await targetChannel.send({
 										content: chunks[0],
 										files: files.length > 0 ? files : undefined,
+										...(renderedComponents
+											? { components: renderedComponents }
+											: {}),
 										...(outboundReplyToMessageId
 											? {
 													reply: {

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -154,6 +154,7 @@ import {
 	beginDiscordOutboundDelivery,
 	createDiscordMessageMemoryOnce,
 	type DiscordOutboundDeliveryReservation,
+	INTERACTION_ONLY_FALLBACK_TEXT,
 	MessageManager,
 } from "./messages";
 import { chunkDiscordText } from "./messaging";
@@ -1981,7 +1982,14 @@ export class DiscordService extends Service implements IDiscordService {
 						rendered.components.length > 0
 							? buildDiscordComponents(rendered.components)
 							: undefined;
-					const textContent = normalizeDiscordMessageText(rendered.text);
+					const hasComponents = rendered.components.length > 0;
+					const interactionIdentity = hasComponents
+						? JSON.stringify(rendered.components)
+						: undefined;
+					let textContent = normalizeDiscordMessageText(rendered.text);
+					if (textContent.trim().length === 0 && hasComponents) {
+						textContent = INTERACTION_ONLY_FALLBACK_TEXT;
+					}
 					const outboundReplyToMessageId =
 						discordReplyReferenceFromContent(content);
 					if (textContent || files.length > 0) {
@@ -2019,6 +2027,7 @@ export class DiscordService extends Service implements IDiscordService {
 							attachmentUrls: content.attachments
 								?.map((media) => media.url)
 								.filter((url): url is string => typeof url === "string"),
+							interactionIdentity,
 						};
 						let outboundDedupe = beginDiscordOutboundDelivery(dedupeParams);
 						while (outboundDedupe.kind === "in_flight") {


### PR DESCRIPTION
## Behavior

- Projects embedded Discord interaction blocks through the real callback and send-handler paths without leaking raw markers.
- Delivers interaction-only replies with a visible fallback and keeps native controls on the final long-message chunk.
- Includes native interaction identity in callback and connector dedupe so equal prose with different controls remains distinct.
- Accepts only the canonical core `TurnAbortedError` as designed control flow; provider/plugin objects cannot forge `TURN_ABORTED` suppression.
- Classifies designed aborts before provider-failure logging, stops typing, settles reactions, releases coordination and uncommitted inbound admission, and closes a durable turn only after inbound persistence is proven.
- Silently discards draft streaming, including an already-flushed snapshot and a provider send that settles concurrently with discard.

## Exact revision

- Head: `498b1616657abd85c6fbcf2e8052e4a95acc01f4`
- Base: `1f7b2e252e097744a2a46ac61b14a8a0abc19648`
- Tree: `d981d7384af35e1a4430a154e5379f55de3a4de9`

## Verification

- Focused Discord Vitest: 8 files, 66 tests passed
- Core turn-controller/failure-suppression Vitest: 3 files, 29 tests passed
- Personal-assistant scheduler-overlap Vitest: 1 file, 7 tests passed
- `bun run --cwd plugins/plugin-discord typecheck`: passed
- `bun run --cwd plugins/plugin-discord lint:check`: passed (schema-version info only)
- `bun run --cwd plugins/plugin-discord build`: passed
- `git diff --check`: passed

The broader Discord suite passed 705 tests with 31 skipped. Its remaining failures are outside this diff: pre-existing generated-data/cache expectations and PGlite harness linkage; the two send-boundary mock regressions exposed by this PR were repaired and now pass 12/12.

Hosted CI is advisory for this maintainer-reviewed exact head; affected-path checks above are green.

AI provider/model: OpenAI / GPT-5 Codex
Client / agent tooling: Codex desktop / multi-agent
Attribution status: self-reported
