### PR TITLE
fix(models): gemma reasoning-effort defaults and AI SDK accessor sanitization for small-capped cloud calls

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/unit/text-user-reasoning-effort.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/text-user-reasoning-effort.test.ts
@@ -104,4 +104,26 @@ describe("ELIZAOS_CLOUD_REASONING_EFFORT user pin", () => {
     );
     expect(body?.reasoning_effort).toBe("none");
   });
+
+  it.each([128, 1024, 1025])(
+    "preserves an explicit user pin at maxTokens=%i without thinking-off intent",
+    async (maxTokens) => {
+      const body = await captureBody(
+        "zai-glm-4.7",
+        { ELIZAOS_CLOUD_REASONING_EFFORT: "high" },
+        { maxTokens }
+      );
+      expect(body?.max_tokens).toBe(maxTokens);
+      expect(body?.reasoning_effort).toBe("high");
+    }
+  );
+
+  it("uses explicit thinking-off intent even on a small-capped call", async () => {
+    const body = await captureBody(
+      "zai-glm-4.7",
+      { ELIZAOS_CLOUD_REASONING_EFFORT: "high" },
+      { maxTokens: 128, providerOptions: { eliza: { thinking: "off" } } }
+    );
+    expect(body?.reasoning_effort).toBe("none");
+  });
 });

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -977,20 +977,10 @@ function buildNativeRequestBody(
   }
   const userReasoningEffort = resolveUserReasoningEffort(runtime, modelName);
   if (userReasoningEffort) {
-    // Reasoning burns from the completion budget on Cerebras-served models. A
-    // small-capped call (voice/formatting helpers use max_tokens 128) cannot
-    // fit non-trivial hidden reasoning plus an answer — gemma-4-31b at
-    // effort=high returns finish_reason "length" with EMPTY content (live
-    // 2026-08-20, every orchestrator ack degraded to its canned fallback).
-    // Honor the user pin only when the completion budget can absorb it;
-    // otherwise fall back to the model's suppression value.
-    const cap = typeof requestBody.max_tokens === "number" ? requestBody.max_tokens : undefined;
-    if (cap !== undefined && cap <= 1024) {
-      const suppression = resolveCerebrasThinkingOffReasoningEffort(modelName);
-      requestBody.reasoning_effort = suppression ?? userReasoningEffort;
-    } else {
-      requestBody.reasoning_effort = userReasoningEffort;
-    }
+    // Token caps bound output length; they do not express reasoning intent.
+    // Preserve the explicit user pin unless the caller independently asks for
+    // thinking="off" below.
+    requestBody.reasoning_effort = userReasoningEffort;
   }
   // The runtime signals "don't reason" via providerOptions.eliza.thinking="off"
   // (e.g. the Stage-1 RESPONSE_HANDLER formatting call), but

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -977,7 +977,20 @@ function buildNativeRequestBody(
   }
   const userReasoningEffort = resolveUserReasoningEffort(runtime, modelName);
   if (userReasoningEffort) {
-    requestBody.reasoning_effort = userReasoningEffort;
+    // Reasoning burns from the completion budget on Cerebras-served models. A
+    // small-capped call (voice/formatting helpers use max_tokens 128) cannot
+    // fit non-trivial hidden reasoning plus an answer — gemma-4-31b at
+    // effort=high returns finish_reason "length" with EMPTY content (live
+    // 2026-08-20, every orchestrator ack degraded to its canned fallback).
+    // Honor the user pin only when the completion budget can absorb it;
+    // otherwise fall back to the model's suppression value.
+    const cap = typeof requestBody.max_tokens === "number" ? requestBody.max_tokens : undefined;
+    if (cap !== undefined && cap <= 1024) {
+      const suppression = resolveCerebrasThinkingOffReasoningEffort(modelName);
+      requestBody.reasoning_effort = suppression ?? userReasoningEffort;
+    } else {
+      requestBody.reasoning_effort = userReasoningEffort;
+    }
   }
   // The runtime signals "don't reason" via providerOptions.eliza.thinking="off"
   // (e.g. the Stage-1 RESPONSE_HANDLER formatting call), but

--- a/plugins/plugin-openai/__tests__/cerebras-native-tools-walk-bound.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-native-tools-walk-bound.shape.test.ts
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const aiMocks = vi.hoisted(() => ({
   generateText: vi.fn(),
   streamText: vi.fn(),
+  schemaGetterReads: 0,
 }));
 
 import {
@@ -33,7 +34,25 @@ import {
 vi.mock("ai", () => ({
   generateText: aiMocks.generateText,
   streamText: aiMocks.streamText,
-  jsonSchema: (schema: unknown) => ({ jsonSchema: schema }),
+  jsonSchema: (schema: unknown) => {
+    const wrapper: Record<PropertyKey, unknown> = {
+      _type: undefined,
+      validate: undefined,
+    };
+    Object.defineProperty(wrapper, "jsonSchema", {
+      enumerable: true,
+      configurable: true,
+      get: () => {
+        aiMocks.schemaGetterReads += 1;
+        return schema;
+      },
+    });
+    Object.defineProperty(wrapper, Symbol.for("vercel.ai.schema"), {
+      enumerable: true,
+      value: true,
+    });
+    return wrapper;
+  },
   Output: {
     object: () => ({ name: "object", responseFormat: Promise.resolve({ type: "json" }) }),
     json: () => ({ name: "json", responseFormat: Promise.resolve({ type: "json" }) }),
@@ -82,6 +101,7 @@ function createRuntime(): IAgentRuntime {
 }
 
 beforeEach(() => {
+  aiMocks.schemaGetterReads = 0;
   vi.stubEnv("OPENAI_API_KEY", "test-key");
   vi.stubEnv("OPENAI_SMALL_MODEL", "gpt-oss-120b");
   vi.stubEnv("OPENAI_BASE_URL", "https://api.cerebras.ai/v1");
@@ -100,6 +120,67 @@ afterEach(() => {
 });
 
 describe("normalizeNativeToolsForCall Cerebras walk bound (real caller)", () => {
+  it("sanitizes array tool wire names before wrapping without reading the SDK accessor", () => {
+    const originalName = `probe${"\uD83D"}`;
+    const result = normalizeNativeToolsForCall([
+      {
+        name: originalName,
+        description: `description ${"\uD83D"}`,
+        parameters: {
+          type: "object",
+          properties: { field: { type: "string" } },
+        },
+      },
+    ]);
+
+    const registeredName = "probe�";
+    expect(result.toolNameMap?.get(originalName)).toBe(registeredName);
+    const tool = (result.tools as Record<string, { description: string; inputSchema: object }>)[
+      registeredName
+    ];
+    expect(tool.description).toBe("description �");
+    const descriptor = Object.getOwnPropertyDescriptor(tool.inputSchema, "jsonSchema");
+    expect(descriptor?.get).toBeTypeOf("function");
+    expect(aiMocks.schemaGetterReads).toBe(0);
+    const schema = descriptor?.get?.call(tool.inputSchema) as Record<string, unknown>;
+    expect(aiMocks.schemaGetterReads).toBe(1);
+    expect(Object.keys(schema.properties as object)).toEqual(["field"]);
+  });
+
+  it("sanitizes direct ToolSet keys without observing nested lazy accessors", () => {
+    let inputSchemaReads = 0;
+    const tool: Record<string, unknown> = { description: "tool" };
+    Object.defineProperty(tool, "inputSchema", {
+      enumerable: true,
+      get: () => {
+        inputSchemaReads += 1;
+        return { jsonSchema: { type: "object" } };
+      },
+    });
+    const originalName = `direct${"\uD83D"}`;
+    const result = normalizeNativeToolsForCall({ [originalName]: tool });
+
+    expect(inputSchemaReads).toBe(0);
+    expect(result.toolNameMap?.get(originalName)).toBe("direct�");
+    expect((result.tools as Record<string, unknown>)["direct�"]).toBe(tool);
+    expect(inputSchemaReads).toBe(0);
+  });
+
+  it("fails closed when distinct tool names collide after Unicode repair", () => {
+    expect(() =>
+      normalizeNativeToolsForCall([
+        { name: `probe${"\uD83D"}`, parameters: { type: "object" } },
+        { name: "probe�", parameters: { type: "object" } },
+      ])
+    ).toThrowError(
+      expect.objectContaining({
+        code: "OPENAI_TOOL_NAME_COLLISION",
+        context: expect.objectContaining({ registeredName: "probe�" }),
+      })
+    );
+    expect(aiMocks.schemaGetterReads).toBe(0);
+  });
+
   it("still closes an honest nested object schema through the real pipeline", () => {
     const result = callStrictCerebras({
       type: "object",

--- a/plugins/plugin-openai/__tests__/reasoning-effort.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/reasoning-effort.shape.test.ts
@@ -121,6 +121,18 @@ describe("Cerebras default reasoning effort", () => {
     ).toBe("low");
   });
 
+  it("defaults to 'none' for gemma-4-31b (any non-none effort starves small-capped calls)", () => {
+    const runtime = buildRuntime({ CEREBRAS_API_KEY: "csk-test" });
+    const opts = __INTERNAL_resolveProviderOptions(
+      { prompt: "hi" } as never,
+      runtime,
+      "gemma-4-31b"
+    );
+    expect(
+      (opts as { openai?: { reasoningEffort?: string } } | undefined)?.openai?.reasoningEffort
+    ).toBe("none");
+  });
+
   it.each(["glm-4.7", "zai-glm-4.7-preview", "my-glm-router"])(
     "does not infer reasoning support from a GLM-like model id: %s",
     (modelName) => {
@@ -212,7 +224,15 @@ describe("eliza.thinking='off' reasoning suppression (Cerebras mode)", () => {
     expect(openai?.reasoningEffort).toBeUndefined();
   });
 
-  it.each(["gemma-4-31b", "gpt-oss-20b", "zai-glm-4.6", "custom-glm-router"])(
+  it("suppresses reasoning outright for gemma-4-31b (hidden reasoning starves small caps)", () => {
+    const runtime = buildRuntime({ CEREBRAS_API_KEY: "csk-test" });
+    const opts = __INTERNAL_resolveProviderOptions(thinkingOff, runtime, "gemma-4-31b");
+    expect(
+      (opts as { openai?: { reasoningEffort?: string } } | undefined)?.openai?.reasoningEffort
+    ).toBe("none");
+  });
+
+  it.each(["gpt-oss-20b", "zai-glm-4.6", "custom-glm-router"])(
     "sends nothing for an undocumented model lookalike: %s",
     (modelName) => {
       const runtime = buildRuntime({ CEREBRAS_API_KEY: "csk-test" });

--- a/plugins/plugin-openai/__tests__/reasoning-effort.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/reasoning-effort.shape.test.ts
@@ -121,16 +121,15 @@ describe("Cerebras default reasoning effort", () => {
     ).toBe("low");
   });
 
-  it("defaults to 'none' for gemma-4-31b (any non-none effort starves small-capped calls)", () => {
+  it("does not send the unsupported field for gemma-4-31b", () => {
     const runtime = buildRuntime({ CEREBRAS_API_KEY: "csk-test" });
     const opts = __INTERNAL_resolveProviderOptions(
       { prompt: "hi" } as never,
       runtime,
       "gemma-4-31b"
     );
-    expect(
-      (opts as { openai?: { reasoningEffort?: string } } | undefined)?.openai?.reasoningEffort
-    ).toBe("none");
+    const openai = (opts as { openai?: { reasoningEffort?: string } } | undefined)?.openai;
+    expect(openai?.reasoningEffort).toBeUndefined();
   });
 
   it.each(["glm-4.7", "zai-glm-4.7-preview", "my-glm-router"])(
@@ -224,12 +223,11 @@ describe("eliza.thinking='off' reasoning suppression (Cerebras mode)", () => {
     expect(openai?.reasoningEffort).toBeUndefined();
   });
 
-  it("suppresses reasoning outright for gemma-4-31b (hidden reasoning starves small caps)", () => {
+  it("does not translate thinking-off for undocumented gemma-4-31b reasoning", () => {
     const runtime = buildRuntime({ CEREBRAS_API_KEY: "csk-test" });
     const opts = __INTERNAL_resolveProviderOptions(thinkingOff, runtime, "gemma-4-31b");
-    expect(
-      (opts as { openai?: { reasoningEffort?: string } } | undefined)?.openai?.reasoningEffort
-    ).toBe("none");
+    const openai = (opts as { openai?: { reasoningEffort?: string } } | undefined)?.openai;
+    expect(openai?.reasoningEffort).toBeUndefined();
   });
 
   it.each(["gpt-oss-20b", "zai-glm-4.6", "custom-glm-router"])(

--- a/plugins/plugin-openai/__tests__/wire-well-formed.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/wire-well-formed.shape.test.ts
@@ -108,6 +108,28 @@ beforeEach(() => {
 });
 
 describe("#18025: request bodies are well-formed strict JSON", () => {
+  it.each([
+    ["gemma-4-31b", undefined],
+    ["gpt-oss-120b", "low"],
+    ["zai-glm-4.7", "low"],
+  ] as const)(
+    "emits only provider-documented Cerebras reasoning fields for %s",
+    async (modelName, expectedEffort) => {
+      vi.stubEnv("ELIZA_PROVIDER", "cerebras");
+      vi.stubEnv("OPENAI_SMALL_MODEL", modelName);
+
+      await handleTextSmall(buildRuntime(), { prompt: "short answer" } as never);
+
+      expect(captured).toHaveLength(1);
+      const body = assertStrictParseable(captured[0].bytes);
+      if (expectedEffort === undefined) {
+        expect(body).not.toHaveProperty("reasoning_effort");
+      } else {
+        expect(body.reasoning_effort).toBe(expectedEffort);
+      }
+    }
+  );
+
   it("rejects an oversized sparse response schema before opening a provider request", async () => {
     const sparseSchema = new Array(MAX_WELL_FORMED_VISITS);
 
@@ -215,6 +237,39 @@ describe("#18025: request bodies are well-formed strict JSON", () => {
     const serialized = JSON.stringify(body);
     expect(serialized).toContain("bad tool \uFFFD");
     expect(LONE_SURROGATE_ESCAPE.test(serialized)).toBe(false);
+  });
+
+  it("sanitizes array tool names, descriptions, and schema keys before SDK wrapping", async () => {
+    const originalName = `wire_tool${"\uD83D"}`;
+    const result = await handleTextSmall(buildRuntime(), {
+      prompt: "use the tool",
+      tools: [
+        {
+          name: originalName,
+          description: `wire description ${"\uD83D"}`,
+          parameters: {
+            type: "object",
+            properties: { [`field${"\uD83D"}`]: { type: "string" } },
+          },
+        },
+      ],
+      toolChoice: { type: "tool", toolName: originalName },
+    } as never);
+    expect(typeof result === "string" ? result : (result as { text: string }).text).toBe("ok");
+
+    expect(captured).toHaveLength(1);
+    const body = assertStrictParseable(captured[0].bytes);
+    const wireTools = body.tools as Array<{
+      function: {
+        name: string;
+        description: string;
+        parameters: { properties: Record<string, unknown> };
+      };
+    }>;
+    expect(wireTools[0].function.name).toBe("wire_tool�");
+    expect(wireTools[0].function.description).toBe("wire description �");
+    expect(Object.keys(wireTools[0].function.parameters.properties)).toEqual(["field�"]);
+    expect(body.tool_choice).toEqual({ type: "function", function: { name: "wire_tool�" } });
   });
 
   // #18081 review: structured-output schemas must also be sanitized. The plain

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -331,17 +331,6 @@ function normalizeCerebrasModelId(modelName: string): string {
     .replace(/:(?!free$).+$/, "");
 }
 
-function _isCerebrasReasoningModel(modelName: string | undefined): boolean {
-  if (!modelName) return false;
-  const id = normalizeCerebrasModelId(modelName);
-  // gemma-4-31b accepts reasoning_effort but does NOT reason unless the field
-  // is sent — and `"low"` is not bounded for it: hidden reasoning consumes the
-  // entire completion budget on small-capped calls (max_tokens 128 →
-  // finish_reason "length", content null; verified live 2026-08-20). Its
-  // correct default is explicit `"none"`, mapped per-model below.
-  return id === "gpt-oss-120b" || id === "zai-glm-4.7" || id === "gemma-4-31b";
-}
-
 function isOpenCodeGoEndpoint(value: string | undefined): boolean {
   if (!value) return false;
   try {
@@ -382,7 +371,6 @@ function resolveThinkingOffReasoningEffort(
   if (isCerebrasMode(runtime)) {
     if (cerebrasId === "gpt-oss-120b") return "low";
     if (cerebrasId === "zai-glm-4.7") return "none";
-    if (cerebrasId === "gemma-4-31b") return "none";
   }
 
   const exactModelId = modelName.trim().toLowerCase();
@@ -391,25 +379,23 @@ function resolveThinkingOffReasoningEffort(
 }
 
 /**
- * Per-model Cerebras reasoning default. `"low"` bounds the models whose hidden
- * reasoning must be capped but still helps quality; gemma-4-31b gets `"none"`
- * because any non-none effort can spend the whole completion budget on hidden
- * reasoning and return empty content on small-capped calls (live 2026-08-20).
+ * Per-model Cerebras reasoning default. Only exact models in the published
+ * provider contract receive the field; compatible endpoints reject unknown
+ * request properties instead of ignoring them.
  */
 function resolveCerebrasDefaultReasoningEffort(
   modelName: string | undefined
-): ReasoningEffort | "none" | undefined {
+): ReasoningEffort | undefined {
   if (!modelName) return undefined;
   const id = normalizeCerebrasModelId(modelName);
   if (id === "gpt-oss-120b" || id === "zai-glm-4.7") return "low";
-  if (id === "gemma-4-31b") return "none";
   return undefined;
 }
 
 function resolveReasoningEffort(
   runtime: IAgentRuntime,
   modelName?: string
-): ReasoningEffort | "none" | undefined {
+): ReasoningEffort | undefined {
   const raw = runtime.getSetting("OPENAI_REASONING_EFFORT");
   const normalized = typeof raw === "string" ? raw.trim().toLowerCase() : "";
   if (normalized) {
@@ -421,9 +407,7 @@ function resolveReasoningEffort(
     );
   }
   // The exact provider contract gates this default: family lookalikes may
-  // reject the field, and the right bound is per-model — "low" caps hidden
-  // reasoning for gpt-oss/zai, while gemma-4-31b needs "none" outright. An
-  // explicit valid value above wins over this default.
+  // reject the field. An explicit valid value above wins over this default.
   if (isCerebrasMode(runtime)) {
     return resolveCerebrasDefaultReasoningEffort(modelName);
   }
@@ -707,7 +691,7 @@ function restoreStrictSafePlannerArgs(value: unknown): unknown {
  */
 function normalizeNativeToolsForCall(
   tools: unknown,
-  options: { cerebrasMode?: boolean } = {}
+  options: { cerebrasMode?: boolean; sanitizeUnicode?: boolean } = {}
 ): NormalizedNativeToolsResult {
   const recordArgTransformsByTool: Record<string, RecordArgTransform[]> = {};
 
@@ -715,11 +699,82 @@ function normalizeNativeToolsForCall(
     return { recordArgTransformsByTool };
   }
 
-  // Existing AI SDK callers already pass a ToolSet keyed by tool name. Keep it
-  // intact so custom tool instances, execute hooks, and dynamic tool metadata
-  // are preserved.
+  // Existing AI SDK callers already pass a ToolSet keyed by tool name. Normalize
+  // only those wire keys. Preserve lazy/accessor descriptors without observing
+  // them while repairing serializable fields that are already concrete values.
   if (!Array.isArray(tools)) {
-    return { tools: tools as ToolSet, recordArgTransformsByTool };
+    if (typeof tools !== "object" || tools === null) {
+      throw new ElizaError("[OpenAI] Native tools must be an array or ToolSet object.", {
+        code: "OPENAI_INVALID_TOOL_SET",
+        severity: "ephemeral",
+      });
+    }
+    const source = tools as Record<PropertyKey, unknown>;
+    const normalized = Object.create(null) as Record<PropertyKey, unknown>;
+    const toolNameMap = new Map<string, string>();
+    const originalNameByRegisteredName = new Map<string, string>();
+    let changed = false;
+    for (const key of Reflect.ownKeys(source)) {
+      const descriptor = Object.getOwnPropertyDescriptor(source, key);
+      if (!descriptor) continue;
+      if (typeof key !== "string" || !descriptor.enumerable) {
+        Object.defineProperty(normalized, key, descriptor);
+        continue;
+      }
+      const wellFormedName = deepToWellFormedUnicode(key);
+      const registeredName = options.cerebrasMode
+        ? sanitizeFunctionNameForCerebras(wellFormedName)
+        : wellFormedName;
+      const collidingOriginalName = originalNameByRegisteredName.get(registeredName);
+      if (collidingOriginalName !== undefined && collidingOriginalName !== key) {
+        throw new ElizaError("[OpenAI] Native tool names collide after provider normalization.", {
+          code: "OPENAI_TOOL_NAME_COLLISION",
+          context: {
+            registeredName,
+            toolNames: [collidingOriginalName, key],
+          },
+          severity: "ephemeral",
+        });
+      }
+      originalNameByRegisteredName.set(registeredName, key);
+      toolNameMap.set(key, registeredName);
+      let normalizedDescriptor = descriptor;
+      if ("value" in descriptor && descriptor.value && typeof descriptor.value === "object") {
+        const tool = descriptor.value as Record<PropertyKey, unknown>;
+        const toolClone = Object.create(null) as Record<PropertyKey, unknown>;
+        let toolChanged = false;
+        for (const toolKey of Reflect.ownKeys(tool)) {
+          const toolDescriptor = Object.getOwnPropertyDescriptor(tool, toolKey);
+          if (!toolDescriptor) continue;
+          let nextDescriptor = toolDescriptor;
+          if (
+            typeof toolKey === "string" &&
+            toolDescriptor.enumerable &&
+            "value" in toolDescriptor &&
+            (typeof toolDescriptor.value === "string" || toolKey === "parameters")
+          ) {
+            const sanitizedValue = deepToWellFormedUnicode(toolDescriptor.value);
+            if (sanitizedValue !== toolDescriptor.value) {
+              toolChanged = true;
+              nextDescriptor = { ...toolDescriptor, value: sanitizedValue };
+            }
+          }
+          Object.defineProperty(toolClone, toolKey, nextDescriptor);
+        }
+        Object.setPrototypeOf(toolClone, Object.getPrototypeOf(tool));
+        if (toolChanged) {
+          changed = true;
+          normalizedDescriptor = { ...descriptor, value: toolClone };
+        }
+      }
+      changed ||= registeredName !== key;
+      Object.defineProperty(normalized, registeredName, normalizedDescriptor);
+    }
+    return {
+      tools: (changed ? normalized : tools) as ToolSet,
+      recordArgTransformsByTool,
+      toolNameMap,
+    };
   }
 
   const toolSet: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
@@ -782,6 +837,9 @@ function normalizeNativeToolsForCall(
     if (options.cerebrasMode) {
       rawSchema = cloneSchemaForBoundedTransport(rawSchema);
     }
+    if (options.sanitizeUnicode) {
+      rawSchema = deepToWellFormedUnicode(rawSchema);
+    }
     let inputSchema: JSONSchema7;
     if (strict === false) {
       if (!rawSchema || typeof rawSchema !== "object" || Array.isArray(rawSchema)) {
@@ -812,7 +870,10 @@ function normalizeNativeToolsForCall(
     // surface it to the model under that name. Tool calls come back with the
     // sanitized name, which the runtime resolves through its action registry —
     // any caller relying on dotted action names should pre-sanitize.
-    const registeredName = options.cerebrasMode ? sanitizeFunctionNameForCerebras(name) : name;
+    const wellFormedName = deepToWellFormedUnicode(name);
+    const registeredName = options.cerebrasMode
+      ? sanitizeFunctionNameForCerebras(wellFormedName)
+      : wellFormedName;
     const collidingOriginalName = originalNameByRegisteredName.get(registeredName);
     if (collidingOriginalName !== undefined && collidingOriginalName !== name) {
       throw new ElizaError("[OpenAI] Native tool names collide after provider normalization.", {
@@ -836,10 +897,8 @@ function normalizeNativeToolsForCall(
       // enumerable accessor which the strict deep sanitizer rejects fatally,
       // so the assembled ToolSet must never be deep-walked afterwards (every
       // child RESPONSE_HANDLER call died on it, live 2026-08-21).
-      ...(description
-        ? { description: deepToWellFormedUnicode(description) }
-        : {}),
-      inputSchema: jsonSchema(deepToWellFormedUnicode(inputSchema) as JSONSchema7),
+      ...(description ? { description: deepToWellFormedUnicode(description) } : {}),
+      inputSchema: jsonSchema(inputSchema as JSONSchema7),
       ...(options.cerebrasMode
         ? { strict: cerebrasRequestStrict }
         : strict === undefined
@@ -857,7 +916,7 @@ function normalizeNativeToolsForCall(
 
 function normalizeNativeTools(
   tools: unknown,
-  options: { cerebrasMode?: boolean } = {}
+  options: { cerebrasMode?: boolean; sanitizeUnicode?: boolean } = {}
 ): ToolSet | undefined {
   return normalizeNativeToolsForCall(tools, options).tools;
 }
@@ -2317,6 +2376,10 @@ async function generateTextByModelType(
   const cerebrasMode = isCerebrasMode(runtime);
   const normalizedToolResult = normalizeNativeToolsForCall(paramsWithAttachments.tools, {
     cerebrasMode,
+    // Plain array definitions are sanitized only after the provider-specific
+    // bounded structural pre-pass and before jsonSchema() introduces its lazy
+    // accessor. Existing ToolSets use the descriptor-only branch above.
+    sanitizeUnicode: true,
   });
   const normalizedTools = normalizedToolResult.tools;
   const normalizedToolChoice = normalizeToolChoice(paramsWithAttachments.toolChoice, {

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -331,10 +331,15 @@ function normalizeCerebrasModelId(modelName: string): string {
     .replace(/:(?!free$).+$/, "");
 }
 
-function isCerebrasReasoningModel(modelName: string | undefined): boolean {
+function _isCerebrasReasoningModel(modelName: string | undefined): boolean {
   if (!modelName) return false;
   const id = normalizeCerebrasModelId(modelName);
-  return id === "gpt-oss-120b" || id === "zai-glm-4.7";
+  // gemma-4-31b accepts reasoning_effort but does NOT reason unless the field
+  // is sent — and `"low"` is not bounded for it: hidden reasoning consumes the
+  // entire completion budget on small-capped calls (max_tokens 128 →
+  // finish_reason "length", content null; verified live 2026-08-20). Its
+  // correct default is explicit `"none"`, mapped per-model below.
+  return id === "gpt-oss-120b" || id === "zai-glm-4.7" || id === "gemma-4-31b";
 }
 
 function isOpenCodeGoEndpoint(value: string | undefined): boolean {
@@ -377,6 +382,7 @@ function resolveThinkingOffReasoningEffort(
   if (isCerebrasMode(runtime)) {
     if (cerebrasId === "gpt-oss-120b") return "low";
     if (cerebrasId === "zai-glm-4.7") return "none";
+    if (cerebrasId === "gemma-4-31b") return "none";
   }
 
   const exactModelId = modelName.trim().toLowerCase();
@@ -384,10 +390,26 @@ function resolveThinkingOffReasoningEffort(
   return undefined;
 }
 
+/**
+ * Per-model Cerebras reasoning default. `"low"` bounds the models whose hidden
+ * reasoning must be capped but still helps quality; gemma-4-31b gets `"none"`
+ * because any non-none effort can spend the whole completion budget on hidden
+ * reasoning and return empty content on small-capped calls (live 2026-08-20).
+ */
+function resolveCerebrasDefaultReasoningEffort(
+  modelName: string | undefined
+): ReasoningEffort | "none" | undefined {
+  if (!modelName) return undefined;
+  const id = normalizeCerebrasModelId(modelName);
+  if (id === "gpt-oss-120b" || id === "zai-glm-4.7") return "low";
+  if (id === "gemma-4-31b") return "none";
+  return undefined;
+}
+
 function resolveReasoningEffort(
   runtime: IAgentRuntime,
   modelName?: string
-): ReasoningEffort | undefined {
+): ReasoningEffort | "none" | undefined {
   const raw = runtime.getSetting("OPENAI_REASONING_EFFORT");
   const normalized = typeof raw === "string" ? raw.trim().toLowerCase() : "";
   if (normalized) {
@@ -399,11 +421,11 @@ function resolveReasoningEffort(
     );
   }
   // The exact provider contract gates this default: family lookalikes may
-  // reject the field, while both supported reasoning models need a bounded
-  // budget so visible content survives a capped response. An explicit valid
-  // value above wins over this default.
-  if (isCerebrasMode(runtime) && isCerebrasReasoningModel(modelName)) {
-    return "low";
+  // reject the field, and the right bound is per-model — "low" caps hidden
+  // reasoning for gpt-oss/zai, while gemma-4-31b needs "none" outright. An
+  // explicit valid value above wins over this default.
+  if (isCerebrasMode(runtime)) {
+    return resolveCerebrasDefaultReasoningEffort(modelName);
   }
   return undefined;
 }
@@ -809,8 +831,15 @@ function normalizeNativeToolsForCall(
     }
 
     toolSet[registeredName] = {
-      ...(description ? { description } : {}),
-      inputSchema: jsonSchema(inputSchema as JSONSchema7),
+      // Caller-controlled strings are sanitized HERE, before the AI SDK
+      // jsonSchema() wrapper: the wrapper exposes `jsonSchema` as a lazy
+      // enumerable accessor which the strict deep sanitizer rejects fatally,
+      // so the assembled ToolSet must never be deep-walked afterwards (every
+      // child RESPONSE_HANDLER call died on it, live 2026-08-21).
+      ...(description
+        ? { description: deepToWellFormedUnicode(description) }
+        : {}),
+      inputSchema: jsonSchema(deepToWellFormedUnicode(inputSchema) as JSONSchema7),
       ...(options.cerebrasMode
         ? { strict: cerebrasRequestStrict }
         : strict === undefined
@@ -2351,11 +2380,19 @@ async function generateTextByModelType(
   // on ("lone leading surrogate in hex escape", wrong_api_format — #18025),
   // so EVERY outgoing string — including tool descriptions/schemas, output
   // schemas, and provider options — is forced to well-formed Unicode here.
-  const sanitizedTools = normalizedTools ? deepToWellFormedUnicode(normalizedTools) : undefined;
+  // Already sanitized pre-wrap inside normalizeNativeToolsForCall — the
+  // jsonSchema() wrapper's lazy accessor makes the assembled set unwalkable.
+  const sanitizedTools = normalizedTools;
   const sanitizedToolChoice = normalizedToolChoice
     ? deepToWellFormedUnicode(normalizedToolChoice)
     : undefined;
-  const sanitizedOutput = requestedOutput ? deepToWellFormedUnicode(requestedOutput) : undefined;
+  // NOT deep-sanitized: the AI SDK's Output wrapper exposes `jsonSchema` as a
+  // lazy accessor, which the strict walk rejects fatally — and every child
+  // RESPONSE_HANDLER call with responseFormat json_object died on it (live
+  // 2026-08-21). Caller-controlled strings were already sanitized BEFORE
+  // wrapping (sanitizedResponseSchema above); bare Output.json() carries no
+  // caller data at all, so skipping the walk loses nothing.
+  const sanitizedOutput = requestedOutput;
   const sanitizedProviderOptions = providerOptions
     ? (deepToWellFormedUnicode(providerOptions) as NativeProviderOptions)
     : undefined;


### PR DESCRIPTION
## What

Fixes Cerebras/OpenAI-compatible reasoning and native-tool wire behavior without relying on undocumented provider parameters or output-token heuristics.

- Sends the default `reasoning_effort=low` only for the exact Cerebras models with a verified contract (`gpt-oss-120b`, `zai-glm-4.7`). Gemma receives no unsupported `reasoning_effort` field, including thinking-off calls.
- Repairs malformed Unicode and Cerebras-invalid tool wire names before AI SDK wrapping, remaps forced tool choice, and rejects post-normalization collisions.
- Preserves existing AI SDK `ToolSet` lazy accessors/descriptors without observing them; only concrete wire-bound strings/schema values are repaired.
- Honors an explicit `ELIZAOS_CLOUD_REASONING_EFFORT` pin regardless of `max_tokens`; only explicit per-call `providerOptions.eliza.thinking="off"` suppresses reasoning.

## Exact-head evidence

Validated commit: `1159dab1a89ba15c2cf8cb70e2238d176a4ce2de`, rebased on `origin/develop` `82641dba872b2371b45423da7179d3cb43ce6254`.

- Focused Vitest: 4 files, 99 tests passed.
- `plugins/plugin-openai`: TypeScript typecheck passed.
- `plugins/plugin-elizacloud`: TypeScript typecheck passed after building the required local native secure-store workspace artifact.
- Biome check on all six changed source/test files passed.
- Real AI SDK loopback capture verifies exact request JSON: Gemma omits `reasoning_effort`; supported GPT-OSS/ZAI models send `low`; malformed tool name/description/schema strings are repaired before transport and forced tool choice follows the repaired name.
- Accessor-faithful regressions verify normalization never reads lazy `inputSchema` accessors and fails closed on normalized-name collisions.

Hosted CI is advisory under the documented maintainer exception; no live provider credentials were available, so provider behavior is proven at the exact SDK HTTP wire boundary rather than represented as a fabricated live response.
