### PR TITLE
fix(agent): preserve complete room UUID in roomSourceTag provider output

### DIFF
--- a/packages/agent/src/shared/conversation-format.test.ts
+++ b/packages/agent/src/shared/conversation-format.test.ts
@@ -76,4 +76,22 @@ describe("roomSourceTag", () => {
       } as never),
     ).toBe("[discord] general");
   });
+
+  it("preserves complete room UUID without eight-character truncation when name is missing", () => {
+    expect(
+      roomSourceTag({
+        id: "11111111-2222-3333-4444-555566667777",
+        source: "slack",
+        type: "GROUP",
+      } as never),
+    ).toBe("[slack] 11111111-2222-3333-4444-555566667777");
+
+    expect(
+      roomSourceTag({
+        id: "11111111-2222-3333-4444-555566667777",
+        name: "",
+        type: "DIRECT",
+      } as never),
+    ).toBe("[DIRECT] 11111111-2222-3333-4444-555566667777");
+  });
 });

--- a/packages/agent/src/shared/conversation-format.ts
+++ b/packages/agent/src/shared/conversation-format.ts
@@ -72,7 +72,7 @@ export function formatSpeakerLabel(
 export function roomSourceTag(room: Room | null): string {
   if (!room) return "[unknown]";
   const source = room.source || room.type;
-  const name = room.name || room.id.slice(0, 8);
+  const name = room.name || room.id;
   return `[${source}] ${name}`;
 }
 

--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -94,6 +94,10 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 		/options\.command\.substring\(/,
 		/options\.command\.slice\(/,
 	],
+	"packages/agent/src/shared/conversation-format.ts": [
+		/room\.id\.slice\(/,
+		/room\.id\.substring\(/,
+	],
 	"packages/agent/src/runtime/prompt-optimization.ts": [
 		/actionCompactionEnabled/,
 	],


### PR DESCRIPTION
## Summary

Render complete room UUIDs in `roomSourceTag` when a room has no custom display name, eliminating ambiguous eight-character prefix truncation in model-facing conversation context and provider outputs.

## Changes

- Update `roomSourceTag` in `packages/agent/src/shared/conversation-format.ts` to fall back to complete `room.id` rather than slicing to eight characters (`room.id.slice(0, 8)`).
- Extend `packages/agent/src/shared/conversation-format.test.ts` to assert that rooms without custom names render their full UUIDs across source platforms.
- Extend `packages/core/src/__tests__/prompt-integrity-policy.test.ts` to guard `packages/agent/src/shared/conversation-format.ts` against short-ID truncation regressions.

## Exact-head verification

Base: `cb4e01ff95e5412e2f4ab03820836267542e39f3`  
Head: `f5f14d02d40d99a41e454ac24a12e0908c00d254`

| Gate | Result |
| --- | --- |
| focused conversation format Vitest (`conversation-format.test.ts`) | 8/8 passed |
| prompt integrity policy audit (`prompt-integrity-policy.test.ts`) | 3/3 passed (573 assertions) |
| scoped Biome check | clean |
| `bun run --cwd packages/agent typecheck` | passed |
| `bun run --cwd packages/core typecheck` | passed |
| `git diff --check` | clean |

## Reviewer start

Start at `packages/agent/src/shared/conversation-format.ts:75` where `roomSourceTag` now preserves `room.id`. `packages/agent/src/shared/conversation-format.test.ts` verifies complete UUID rendering when `name` is omitted or empty.

## Risks

Low. Provider context retains complete room identifiers, preventing cross-room collisions and matching the repository-wide lossless context contract.

## Attribution

- Analysis, prompt integrity repair, and regression tests by Antigravity / Gemini 3.7.

## Evidence Gate

<!-- evidence-head:f5f14d02d40d99a41e454ac24a12e0908c00d254 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - conversation format provider output logic has no rendered visual UI surface`.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - conversation format provider output logic has no rendered visual UI surface`.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - deterministic provider and prompt-integrity suites exercise the complete changed boundary`.

<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - deterministic unit tests cover room identifier rendering`.

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs `N/A - no frontend path changes`.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - deterministic provider formatting helper; prompt integrity audit passes`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - no database or disk storage changes`.

<!-- evidence-row:ocr-review -->
- [x] OCR review `N/A - no rendered visual text changes`.

# Documentation changes needed?

No. Preserves existing room tag formatting structure with complete UUIDs.
