### PR TITLE
fix(documents): authorize parent and fragment reads in store

### DIFF
--- a/packages/agent/src/api/documents-service-loader.ts
+++ b/packages/agent/src/api/documents-service-loader.ts
@@ -87,6 +87,14 @@ export interface DocumentsServiceLike {
     options?: Record<string, unknown>,
   ): Promise<Memory[]>;
   getDocumentById?(documentId: UUID, message?: Memory): Promise<Memory | null>;
+  getDocumentByIdWithAccessContext?(
+    documentId: UUID,
+    accessContext: AccessContext,
+  ): Promise<Memory | null>;
+  listDocumentFragmentsWithAccessContext?(
+    documentId: UUID,
+    accessContext: AccessContext,
+  ): Promise<Memory[]>;
   getMemories(params: {
     tableName: string;
     roomId?: UUID;

--- a/packages/core/src/database/document-list-query.test.ts
+++ b/packages/core/src/database/document-list-query.test.ts
@@ -10,6 +10,7 @@ import {
 	documentMutationSnapshotMatches,
 	isDocumentVisibleToRequester,
 	portableDocumentSearchTokens,
+	queryDocumentFragmentsInMemory,
 	queryDocumentsInMemory,
 	queryDocumentsWithCapability,
 	readDocumentMutationSnapshot,
@@ -231,6 +232,43 @@ describe("document-list capability contract", () => {
 		expect(isDocumentVisibleToRequester(global, unresolvedParams)).toBe(false);
 		expect(canRequesterMutateDocument(global, guestParams)).toBe(false);
 		expect(canRequesterMutateDocument(global, unresolvedParams)).toBe(false);
+	});
+
+	it("filters fragments by authorized parent before applying offset and limit", () => {
+		const firstParent = document(5);
+		const secondParent = document(6);
+		const fragment = (
+			index: number,
+			documentId: UUID,
+			createdAt: number,
+		): Memory => ({
+			...document(index),
+			createdAt,
+			metadata: {
+				type: MemoryType.FRAGMENT,
+				documentId,
+				documentRevision: 0,
+				position: index,
+			},
+		});
+		const firstFragments = [
+			fragment(7, firstParent.id as UUID, 3_000),
+			fragment(8, firstParent.id as UUID, 2_000),
+		];
+		const otherFragment = fragment(9, secondParent.id as UUID, 4_000);
+
+		const result = queryDocumentFragmentsInMemory(
+			[firstParent, secondParent, ...firstFragments, otherFragment],
+			{
+				...params,
+				requesterRole: "OWNER",
+				documentId: firstParent.id,
+				limit: 1,
+				offset: 1,
+			},
+		);
+
+		expect(result.map((memory) => memory.id)).toEqual([firstFragments[1]?.id]);
 	});
 
 	it("uses locale-independent tokens that preserve punctuation and Unicode", () => {

--- a/packages/core/src/database/document-list-query.ts
+++ b/packages/core/src/database/document-list-query.ts
@@ -663,6 +663,24 @@ export function validateDocumentFragmentQueryParams(
 			},
 		);
 	}
+	if (
+		params.offset !== undefined &&
+		(!Number.isSafeInteger(params.offset) || params.offset < 0)
+	) {
+		throw new ElizaError(
+			"Document fragment offset must be a non-negative integer",
+			{
+				code: "DOCUMENT_FRAGMENT_QUERY_INVALID",
+				context: { offset: params.offset },
+			},
+		);
+	}
+	if (params.documentId !== undefined && !isUuid(params.documentId)) {
+		throw new ElizaError("Document fragment parent id is invalid", {
+			code: "DOCUMENT_FRAGMENT_QUERY_INVALID",
+			context: { documentId: params.documentId },
+		});
+	}
 	if (params.embedding === undefined) {
 		if (params.matchThreshold !== undefined) {
 			throw new ElizaError(
@@ -902,6 +920,7 @@ export function queryDocumentFragmentsInMemory(
 			}
 			const documentId = memory.metadata?.documentId;
 			if (!isUuid(documentId)) return false;
+			if (params.documentId && documentId !== params.documentId) return false;
 			const parent = parents.get(documentId);
 			if (!parent || !isDocumentVisibleToRequester(parent, params))
 				return false;
@@ -956,7 +975,8 @@ export function queryDocumentFragmentsInMemory(
 	} else {
 		fragments.sort(compareDocumentOrder);
 	}
-	return fragments.slice(0, params.limit);
+	const offset = params.offset ?? 0;
+	return fragments.slice(offset, offset + params.limit);
 }
 
 export function hasDocumentListQueryCapability(

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -555,6 +555,48 @@ export class DocumentService extends Service {
 		});
 	}
 
+	async getDocumentByIdWithAccessContext(
+		documentId: UUID,
+		accessContext: AccessContext,
+	): Promise<Memory | null> {
+		const requester = await resolveDocumentRequesterFromAccessContext(
+			this.runtime,
+			accessContext,
+		);
+		return this.runtime.adapter.getDocument({
+			agentId: this.runtime.agentId,
+			documentId,
+			requesterEntityId: requester.entityId,
+			requesterRoomIds: requester.roomIds,
+			requesterRole: requester.role,
+		});
+	}
+
+	async listDocumentFragmentsWithAccessContext(
+		documentId: UUID,
+		accessContext: AccessContext,
+	): Promise<Memory[]> {
+		const requester = await resolveDocumentRequesterFromAccessContext(
+			this.runtime,
+			accessContext,
+		);
+		const fragments: Memory[] = [];
+		const pageSize = 1_000;
+		for (let offset = 0; ; offset += pageSize) {
+			const page = await this.runtime.adapter.queryDocumentFragments({
+				agentId: this.runtime.agentId,
+				documentId,
+				requesterEntityId: requester.entityId,
+				requesterRoomIds: requester.roomIds,
+				requesterRole: requester.role,
+				limit: pageSize,
+				offset,
+			});
+			fragments.push(...page);
+			if (page.length < pageSize) return fragments;
+		}
+	}
+
 	async listDocuments(
 		message?: Memory,
 		options: DocumentListOptions = {},

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -108,6 +108,8 @@ export interface DocumentGetQueryParams extends DocumentRequesterContext {
  */
 export interface DocumentFragmentQueryParams extends DocumentRequesterContext {
 	limit: number;
+	offset?: number;
+	documentId?: UUID;
 	roomId?: UUID;
 	worldId?: UUID;
 	entityId?: UUID;

--- a/plugins/plugin-documents/AGENTS.md
+++ b/plugins/plugin-documents/AGENTS.md
@@ -85,6 +85,12 @@ storage authorization: ADMIN is not OWNER, GUEST is not USER, and an unresolved
 role is rejected. Guests may read only global documents in their current rooms
 and may not mutate documents.
 
+Parent and fragment REST reads must call the access-context-aware
+`DocumentService` methods. Do not use `runtime.getMemoryById()` or
+`getMemories()` and apply route-local authorization afterward: authorization
+belongs in the adapter query before rows, fragment bytes, counts, or pagination
+are constructed.
+
 ## How to extend
 
 **Add a new route:**
@@ -96,7 +102,9 @@ and may not mutate documents.
 Add to `PresentedDocument` in `src/document-presenter.ts` and populate it in `presentDocument()`.
 
 **Add document scope enforcement logic:**
-All scope/permission decisions live in `src/routes.ts` (`canReadDocumentMemory`, `canMutateDocumentMemory`, `filtersFromUploadBody`). Do not scatter access checks into the presenter or service.
+Canonical read/mutation authorization belongs in `DocumentService` and its
+adapter queries. Route helpers may validate upload scope and presentation, but
+must never become a competing read authority or post-filter raw storage rows.
 
 ## Conventions / gotchas
 

--- a/plugins/plugin-documents/CLAUDE.md
+++ b/plugins/plugin-documents/CLAUDE.md
@@ -85,6 +85,12 @@ storage authorization: ADMIN is not OWNER, GUEST is not USER, and an unresolved
 role is rejected. Guests may read only global documents in their current rooms
 and may not mutate documents.
 
+Parent and fragment REST reads must call the access-context-aware
+`DocumentService` methods. Do not use `runtime.getMemoryById()` or
+`getMemories()` and apply route-local authorization afterward: authorization
+belongs in the adapter query before rows, fragment bytes, counts, or pagination
+are constructed.
+
 ## How to extend
 
 **Add a new route:**
@@ -96,7 +102,9 @@ and may not mutate documents.
 Add to `PresentedDocument` in `src/document-presenter.ts` and populate it in `presentDocument()`.
 
 **Add document scope enforcement logic:**
-All scope/permission decisions live in `src/routes.ts` (`canReadDocumentMemory`, `canMutateDocumentMemory`, `filtersFromUploadBody`). Do not scatter access checks into the presenter or service.
+Canonical read/mutation authorization belongs in `DocumentService` and its
+adapter queries. Route helpers may validate upload scope and presentation, but
+must never become a competing read authority or post-filter raw storage rows.
 
 ## Conventions / gotchas
 

--- a/plugins/plugin-documents/README.md
+++ b/plugins/plugin-documents/README.md
@@ -47,6 +47,9 @@ headers and `ELIZA_ADMIN_ENTITY_ID` never create an authenticated caller. Roles
 remain exact at this boundary: ADMIN is not OWNER, GUEST is not USER, and an
 unresolved role is rejected. Guests may read global documents in rooms where
 they are current members, but cannot read private scopes or mutate documents.
+Single-document and fragment reads are resolved by `DocumentService` with that
+authenticated context; routes never fetch a parent row or scan fragment bytes
+and then attempt to filter the result locally.
 
 ## Configuration
 

--- a/plugins/plugin-documents/src/routes.canonical-read.test.ts
+++ b/plugins/plugin-documents/src/routes.canonical-read.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Proves single-document and fragment REST reads cross the canonical
+ * access-context-aware document service before any parent or fragment bytes.
+ */
+import type { AccessContext, Memory, UUID } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DocumentRouteContext } from "./routes.ts";
+import { handleDocumentsRoutes } from "./routes.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const USER_ID = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-0000000000cc" as UUID;
+const DOCUMENT_ID = "00000000-0000-0000-0000-0000000000dd" as UUID;
+const FRAGMENT_ID = "00000000-0000-0000-0000-0000000000ee" as UUID;
+const accessContext = {
+  requesterEntityId: USER_ID,
+  role: "USER",
+  isOwner: false,
+} satisfies AccessContext;
+
+const document: Memory = {
+  id: DOCUMENT_ID,
+  agentId: AGENT_ID,
+  entityId: USER_ID,
+  roomId: ROOM_ID,
+  createdAt: 1_000,
+  content: { text: "authorized bytes" },
+  metadata: {
+    type: "document",
+    documentId: DOCUMENT_ID,
+    scope: "user-private",
+    scopedToEntityId: USER_ID,
+  } as Memory["metadata"],
+};
+const fragment: Memory = {
+  id: FRAGMENT_ID,
+  agentId: AGENT_ID,
+  entityId: USER_ID,
+  roomId: ROOM_ID,
+  createdAt: 1_001,
+  content: { text: "fragment bytes" },
+  metadata: {
+    type: "fragment",
+    documentId: DOCUMENT_ID,
+    documentRevision: 1,
+    position: 0,
+  } as Memory["metadata"],
+};
+
+const service = vi.hoisted(() => ({
+  getDocumentByIdWithAccessContext: vi.fn(),
+  listDocumentFragmentsWithAccessContext: vi.fn(),
+  getMemories: vi.fn(),
+}));
+
+vi.mock("@elizaos/agent/api/documents-service-loader", () => ({
+  getDocumentsService: vi.fn(async () => ({ service })),
+}));
+
+function context(pathname: string): {
+  ctx: DocumentRouteContext;
+  response: { status: number; body: unknown };
+  getMemoryById: ReturnType<typeof vi.fn>;
+} {
+  const response = { status: 0, body: undefined as unknown };
+  const getMemoryById = vi.fn(async () => {
+    throw new Error("raw parent read must not execute");
+  });
+  const ctx = {
+    req: { headers: {} },
+    res: { setHeader: vi.fn() },
+    method: "GET",
+    pathname,
+    url: new URL(`http://local${pathname}`),
+    accessContext,
+    runtime: {
+      agentId: AGENT_ID,
+      getSetting: vi.fn(),
+      getMemoryById,
+    },
+    json: (_res: unknown, body: unknown, status = 200) => {
+      response.status = status;
+      response.body = body;
+    },
+    error: (_res: unknown, message: string, status = 400) => {
+      response.status = status;
+      response.body = { error: message };
+    },
+    readJsonBody: vi.fn(async () => null),
+  } as unknown as DocumentRouteContext;
+  return { ctx, response, getMemoryById };
+}
+
+describe("canonical document REST reads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service.getDocumentByIdWithAccessContext.mockResolvedValue(document);
+    service.listDocumentFragmentsWithAccessContext.mockResolvedValue([
+      fragment,
+    ]);
+    service.getMemories.mockResolvedValue([]);
+  });
+
+  it("reads a parent and its count only through authorized service methods", async () => {
+    const { ctx, response, getMemoryById } = context(
+      `/api/documents/${DOCUMENT_ID}`,
+    );
+
+    await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+    expect(response.status).toBe(200);
+    expect(service.getDocumentByIdWithAccessContext).toHaveBeenCalledWith(
+      DOCUMENT_ID,
+      accessContext,
+    );
+    expect(service.listDocumentFragmentsWithAccessContext).toHaveBeenCalledWith(
+      DOCUMENT_ID,
+      accessContext,
+    );
+    expect(getMemoryById).not.toHaveBeenCalled();
+    expect(service.getMemories).not.toHaveBeenCalled();
+  });
+
+  it("loads fragment bytes only after the parent passes canonical authorization", async () => {
+    const { ctx, response, getMemoryById } = context(
+      `/api/documents/${DOCUMENT_ID}/fragments`,
+    );
+
+    await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      documentId: DOCUMENT_ID,
+      count: 1,
+      fragments: [{ id: FRAGMENT_ID, text: "fragment bytes" }],
+    });
+    expect(service.getDocumentByIdWithAccessContext).toHaveBeenCalledBefore(
+      service.listDocumentFragmentsWithAccessContext,
+    );
+    expect(getMemoryById).not.toHaveBeenCalled();
+    expect(service.getMemories).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -15,7 +15,6 @@ import {
   canReadDocumentMemory,
   type DocumentReadableMemory,
   documentMediaFormat,
-  documentScopedEntityId,
   documentTags,
   matchesDocumentFilter as matchesSharedDocumentFilter,
   parseDocumentScope,
@@ -506,36 +505,6 @@ function decodeMatchedPathComponent(
   }
 }
 
-async function countDocumentFragmentsForDocument(
-  documentsService: DocumentsServiceLike,
-  roomId: UUID | undefined,
-  documentId: UUID,
-): Promise<number> {
-  let offset = 0;
-  let fragmentCount = 0;
-
-  while (true) {
-    const fragmentBatch = await documentsService.getMemories({
-      tableName: DOCUMENT_FRAGMENTS_TABLE,
-      roomId,
-      count: FRAGMENT_BATCH_SIZE,
-      offset,
-    });
-
-    if (fragmentBatch.length === 0) break;
-
-    fragmentCount += fragmentBatch.filter((memory) => {
-      const metadata = asRecord(memory.metadata);
-      return metadata?.documentId === documentId;
-    }).length;
-
-    if (fragmentBatch.length < FRAGMENT_BATCH_SIZE) break;
-    offset += FRAGMENT_BATCH_SIZE;
-  }
-
-  return fragmentCount;
-}
-
 async function mapDocumentFragmentsByDocumentId(
   documentsService: DocumentsServiceLike,
   roomId: UUID | undefined,
@@ -749,11 +718,12 @@ export async function handleDocumentsRoutes(
   }
   const agentId = runtime.agentId as UUID;
   const ownerEntityId = getOwnerEntityId(runtime);
-  const routeActor = resolveRouteActor(
-    agentId,
-    ownerEntityId,
-    ctx.accessContext,
-  );
+  const accessContext = ctx.accessContext;
+  if (!accessContext) {
+    error(res, "Authentication required", 401);
+    return true;
+  }
+  const routeActor = resolveRouteActor(agentId, ownerEntityId, accessContext);
 
   if (!routeActor) {
     error(res, "Authentication required", 401);
@@ -1043,52 +1013,38 @@ export async function handleDocumentsRoutes(
     );
     if (!decodedDocumentId) return true;
     const documentId = decodedDocumentId as UUID;
-    const document = await runtime.getMemoryById(documentId);
     if (
-      !document ||
-      !isDocumentMemory(document, agentId) ||
-      !canReadDocumentMemory(document, routeActor, {
-        scopedToEntityId: documentScopedEntityId(document),
-      })
+      !documentsService.getDocumentByIdWithAccessContext ||
+      !documentsService.listDocumentFragmentsWithAccessContext
     ) {
+      error(res, "Canonical document authorization is unavailable", 503);
+      return true;
+    }
+    const document = await documentsService.getDocumentByIdWithAccessContext(
+      documentId,
+      accessContext,
+    );
+    if (!document) {
       error(res, "Document not found", 404);
       return true;
     }
 
-    const allFragments: Array<{
-      id: UUID;
-      text: string;
-      position: unknown;
-      createdAt: number;
-    }> = [];
-    let fragmentOffset = 0;
-
-    while (true) {
-      const fragmentBatch = await documentsService.getMemories({
-        tableName: DOCUMENT_FRAGMENTS_TABLE,
-        count: FRAGMENT_BATCH_SIZE,
-        offset: fragmentOffset,
-      });
-
-      if (fragmentBatch.length === 0) break;
-
-      for (const fragment of fragmentBatch) {
+    const fragments =
+      await documentsService.listDocumentFragmentsWithAccessContext(
+        documentId,
+        accessContext,
+      );
+    const documentFragments = fragments
+      .filter(hasUuidIdAndCreatedAt)
+      .map((fragment) => {
         const metadata = asRecord(fragment.metadata);
-        if (metadata?.documentId !== documentId) continue;
-        if (!hasUuidIdAndCreatedAt(fragment)) continue;
-        allFragments.push({
+        return {
           id: fragment.id,
           text: (fragment.content as { text?: string })?.text || "",
-          position: metadata.position,
+          position: metadata?.position,
           createdAt: fragment.createdAt,
-        });
-      }
-
-      if (fragmentBatch.length < FRAGMENT_BATCH_SIZE) break;
-      fragmentOffset += FRAGMENT_BATCH_SIZE;
-    }
-
-    const documentFragments = allFragments
+        };
+      })
       .sort((a, b) => {
         const posA = typeof a.position === "number" ? a.position : 0;
         const posB = typeof b.position === "number" ? b.position : 0;
@@ -1118,23 +1074,29 @@ export async function handleDocumentsRoutes(
     );
     if (!decodedDocumentId) return true;
     const documentId = decodedDocumentId as UUID;
-    const document = await runtime.getMemoryById(documentId);
-    if (
-      !document ||
-      !isDocumentMemory(document, agentId) ||
-      !canReadDocumentMemory(document, routeActor, {
-        scopedToEntityId: documentScopedEntityId(document),
-      })
-    ) {
+    if (!documentsService.getDocumentByIdWithAccessContext) {
+      error(res, "Canonical document authorization is unavailable", 503);
+      return true;
+    }
+    const document = await documentsService.getDocumentByIdWithAccessContext(
+      documentId,
+      accessContext,
+    );
+    if (!document) {
       error(res, "Document not found", 404);
       return true;
     }
 
-    const fragmentCount = await countDocumentFragmentsForDocument(
-      documentsService,
-      undefined,
-      documentId,
-    );
+    if (!documentsService.listDocumentFragmentsWithAccessContext) {
+      error(res, "Canonical document authorization is unavailable", 503);
+      return true;
+    }
+    const fragmentCount = (
+      await documentsService.listDocumentFragmentsWithAccessContext(
+        documentId,
+        accessContext,
+      )
+    ).length;
 
     json(res, {
       document: presentDocument(document, fragmentCount, {

--- a/plugins/plugin-sql/src/__tests__/integration/document-list-query.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/document-list-query.real.test.ts
@@ -311,6 +311,50 @@ describe("document list query (real SQL parity)", () => {
     }
   });
 
+  it("filters fragment pages by exact authorized parent before pagination", async () => {
+    const firstParent = document(1);
+    const secondParent = document(2);
+    const fragment = (index: number, documentId: UUID, createdAt: number): Memory =>
+      document(index, {
+        createdAt,
+        metadata: {
+          type: MemoryType.FRAGMENT,
+          documentId,
+          documentRevision: 0,
+          position: index,
+        },
+      });
+    const firstFragments = [
+      fragment(3, firstParent.id as UUID, 3_000),
+      fragment(4, firstParent.id as UUID, 2_000),
+    ];
+    const otherFragment = fragment(5, secondParent.id as UUID, 4_000);
+    const rows = [firstParent, secondParent, ...firstFragments, otherFragment];
+    await seedSql([firstParent, secondParent]);
+    await adapter.createMemories(
+      [...firstFragments, otherFragment].map((memory) => ({
+        memory,
+        tableName: "document_fragments",
+      }))
+    );
+    const inMemory = await seedInMemory(rows);
+    const query = {
+      agentId,
+      requesterEntityId: REQUESTER_ID,
+      requesterRoomIds: [roomId],
+      requesterRole: "OWNER" as const,
+      documentId: firstParent.id,
+      limit: 1,
+      offset: 1,
+    };
+
+    const sqlFragments = await adapter.queryDocumentFragments(query);
+    const memoryFragments = await inMemory.queryDocumentFragments(query);
+
+    expect(sqlFragments).toEqual(memoryFragments);
+    expect(ids(sqlFragments)).toEqual([firstFragments[1]?.id]);
+  });
+
   it("does not skip or duplicate equal-timestamp rows across keyset pages", async () => {
     const documents = Array.from({ length: 151 }, (_, index) => document(index));
     await seedSql(documents);

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -2194,6 +2194,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       if (params.roomId) conditions.push(eq(parent.roomId, params.roomId));
       if (params.worldId) conditions.push(eq(parent.worldId, params.worldId));
       if (params.entityId) conditions.push(eq(parent.entityId, params.entityId));
+      if (params.documentId) conditions.push(eq(parent.id, params.documentId));
 
       const parentJoin = sql`${parent.id}::text = ${fragment.metadata}->>'documentId'`;
       if (!params.embedding) {
@@ -2203,7 +2204,8 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           .innerJoin(parent, parentJoin)
           .where(and(...conditions))
           .orderBy(desc(fragment.createdAt), desc(fragment.id))
-          .limit(params.limit);
+          .limit(params.limit)
+          .offset(params.offset ?? 0);
         return rows.map((row) => memoryFromRow(row.memory));
       }
 
@@ -2225,7 +2227,8 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         .innerJoin(parent, parentJoin)
         .where(and(...conditions))
         .orderBy(asc(distance), desc(fragment.createdAt), desc(fragment.id))
-        .limit(params.limit);
+        .limit(params.limit)
+        .offset(params.offset ?? 0);
       return rows.map((row) =>
         memoryFromRow(
           row.memory,


### PR DESCRIPTION
Refs #24246

Moves single-document and fragment REST reads behind access-context-aware DocumentService methods and the native document-store query contract. Parent authorization now runs in the adapter before parent rows or fragment bytes are returned; fragment filtering by exact parent happens before offset/limit in both SQL and in-memory adapters. Route-level raw parent reads and fragment scans are removed for GET parent/fragment endpoints.

Verification:
- core document query contract: 13 passed
- plugin-documents full suite: 122 passed
- canonical route no-raw-read proof: 2 passed
- real PGlite exact-parent pagination parity: 1 passed
- plugin-sql typecheck passed
- core build and packed consumers passed
- changed-file Biome, diff check, and guide parity passed

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop / multi-agent
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— root membership-documents lane
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop / multi-agent","skill_revision":"N/A - no repository contribution skill used"} -->