### PR TITLE
fix(cloud): fence snapshot job authority

### DIFF
--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-snapshot-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-snapshot-authority.pglite.test.ts
@@ -592,6 +592,7 @@ describe("agent_snapshot worker authority", () => {
           generation: jobExecutionLeases.execution_generation,
           ownerId: jobExecutionLeases.owner_id,
           expiresAt: jobExecutionLeases.expires_at,
+          isLive: sql<boolean>`${jobExecutionLeases.expires_at} > NOW()`,
         })
         .from(jobExecutionLeases)
         .where(eq(jobExecutionLeases.job_id, claimed.id));
@@ -599,9 +600,9 @@ describe("agent_snapshot worker authority", () => {
         jobId: claimed.id,
         generation: claimed.execution_generation,
         ownerId: OWNER_ID,
-        expiresAt: expect.any(Date),
+        expiresAt: expect.anything(),
+        isLive: true,
       });
-      expect(lease?.expiresAt.getTime()).toBeGreaterThan(Date.now());
       expect(await sandboxState(identity)).toEqual(before);
 
       await expect(

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-snapshot-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-snapshot-authority.pglite.test.ts
@@ -163,6 +163,19 @@ async function snapshotJobs(identity: SandboxIdentity): Promise<Job[]> {
     )) as Job[];
 }
 
+async function deleteJobs(identity: SandboxIdentity): Promise<Job[]> {
+  return (await dbWrite
+    .select()
+    .from(jobs)
+    .where(
+      and(
+        eq(jobs.agent_id, identity.agentId),
+        eq(jobs.organization_id, identity.organizationId),
+        eq(jobs.type, JOB_TYPES.AGENT_DELETE),
+      ),
+    )) as Job[];
+}
+
 async function sandboxState(identity: SandboxIdentity) {
   const [sandbox] = await dbWrite
     .select({
@@ -515,6 +528,147 @@ describe("agent_snapshot worker authority", () => {
       },
       CONTAINER_TIER_REJECTION,
     );
+  });
+
+  test("keeps durable execution ownership while capture blocks a concurrent delete", async () => {
+    const identity = await seedSandbox({
+      executionTier: "dedicated-lazy",
+      status: "running",
+      poolStatus: null,
+      deletedAt: null,
+      deletionAttemptId: null,
+    });
+    const enqueued = await enqueueSnapshot(new ProvisioningJobService(), identity, "manual");
+    const before = await sandboxState(identity);
+    if (!before) throw new Error("Snapshot target disappeared before processing");
+    const captureEntered = Promise.withResolvers<Job>();
+    const releaseCapture = Promise.withResolvers<void>();
+    const service = new ProvisioningJobService({
+      executionOwnerId: OWNER_ID,
+      executeJob: async (job) => {
+        captureEntered.resolve(job);
+        await releaseCapture.promise;
+        await jobsRepository.settleExecution(
+          job,
+          "completed",
+          { completed_at: new Date() },
+          OWNER_ID,
+        );
+      },
+    });
+    const processing = service.processPendingJobs(1, {
+      jobTypes: [JOB_TYPES.AGENT_SNAPSHOT],
+    });
+    let runningGeneration: string | null = null;
+
+    try {
+      const claimed = await Promise.race([
+        captureEntered.promise,
+        processing.then((result) => {
+          throw new Error(
+            `Snapshot processing settled before capture gate: ${JSON.stringify(result)}`,
+          );
+        }),
+      ]);
+      expect(claimed.id).toBe(enqueued.job.id);
+      expect(claimed.execution_generation).toEqual(expect.any(String));
+      runningGeneration = claimed.execution_generation;
+      const [running] = await dbWrite
+        .select({
+          status: jobs.status,
+          executionGeneration: jobs.execution_generation,
+          executionQuiescedAt: jobs.execution_quiesced_at,
+        })
+        .from(jobs)
+        .where(eq(jobs.id, claimed.id));
+      expect(running).toEqual({
+        status: "in_progress",
+        executionGeneration: claimed.execution_generation,
+        executionQuiescedAt: null,
+      });
+      const [lease] = await dbWrite
+        .select({
+          jobId: jobExecutionLeases.job_id,
+          generation: jobExecutionLeases.execution_generation,
+          ownerId: jobExecutionLeases.owner_id,
+          expiresAt: jobExecutionLeases.expires_at,
+        })
+        .from(jobExecutionLeases)
+        .where(eq(jobExecutionLeases.job_id, claimed.id));
+      expect(lease).toMatchObject({
+        jobId: claimed.id,
+        generation: claimed.execution_generation,
+        ownerId: OWNER_ID,
+        expiresAt: expect.any(Date),
+      });
+      expect(lease?.expiresAt.getTime()).toBeGreaterThan(Date.now());
+      expect(await sandboxState(identity)).toEqual(before);
+
+      await expect(
+        new ProvisioningJobService().enqueueAgentDeleteOnce({
+          ...identity,
+          authorization: "user_request",
+        }),
+      ).rejects.toMatchObject({
+        status: 409,
+        code: "session_not_ready",
+        message: expect.stringContaining("non-quiescent agent_snapshot"),
+        details: {
+          conflictingJobId: claimed.id,
+          conflictingJobType: JOB_TYPES.AGENT_SNAPSHOT,
+          conflictingJobStatus: "in_progress",
+        },
+      });
+      expect(await deleteJobs(identity)).toHaveLength(0);
+      const [stillRunning] = await dbWrite
+        .select({
+          status: jobs.status,
+          executionGeneration: jobs.execution_generation,
+          executionQuiescedAt: jobs.execution_quiesced_at,
+        })
+        .from(jobs)
+        .where(eq(jobs.id, claimed.id));
+      expect(stillRunning).toEqual(running);
+      expect(await sandboxState(identity)).toEqual(before);
+    } finally {
+      releaseCapture.resolve();
+    }
+
+    await expect(processing).resolves.toMatchObject({
+      claimed: 1,
+      succeeded: 1,
+      retried: 0,
+      failed: 0,
+    });
+    const [settled] = await dbWrite
+      .select({
+        status: jobs.status,
+        executionGeneration: jobs.execution_generation,
+        executionQuiescedAt: jobs.execution_quiesced_at,
+      })
+      .from(jobs)
+      .where(eq(jobs.id, enqueued.job.id));
+    expect(settled).toMatchObject({
+      status: "completed",
+      executionGeneration: runningGeneration,
+      executionQuiescedAt: expect.any(Date),
+    });
+    expect(await dbWrite.select().from(jobExecutionLeases)).toHaveLength(0);
+    expect(await sandboxState(identity)).toEqual(before);
+
+    const deletion = await new ProvisioningJobService().enqueueAgentDeleteOnce({
+      ...identity,
+      authorization: "user_request",
+    });
+    expect(deletion).toMatchObject({ created: true, job: { status: "pending" } });
+    expect(await deleteJobs(identity)).toHaveLength(1);
+    expect(await sandboxState(identity)).toMatchObject({
+      status: "deletion_pending",
+      deletionAttemptId: expect.any(String),
+      lifecycleJobId: null,
+      lifecycleGeneration: null,
+      lifecycleRevision: before.lifecycleRevision + 1,
+    });
   });
 
   for (const executionTier of CONTAINER_BACKED_EXECUTION_TIERS) {

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-snapshot-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-snapshot-authority.pglite.test.ts
@@ -1,0 +1,557 @@
+/**
+ * Drives agent_snapshot admission and worker preflight against real PGlite
+ * state. The harness proves the locked enqueue/read/reuse/insert boundary and
+ * the claimed-job lease/rejection boundary; only the final snapshot handler is
+ * replaced so no network capture can obscure the authority result.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { and, eq, sql } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../db/client";
+import { jobsRepository } from "../../db/repositories/jobs";
+import {
+  agentSandboxBackups,
+  agentSandboxes,
+  CONTAINER_BACKED_EXECUTION_TIERS,
+} from "../../db/schemas/agent-sandboxes";
+import { jobExecutionLeases } from "../../db/schemas/job-execution-leases";
+import type { Job } from "../../db/schemas/jobs";
+import { jobs } from "../../db/schemas/jobs";
+import { organizations } from "../../db/schemas/organizations";
+import { users } from "../../db/schemas/users";
+import { PROVISIONING_JOB_TEST_TABLES } from "./__tests__/tier-upgrade-pglite-schema";
+import { JOB_TYPES } from "./provisioning-job-types";
+import {
+  CONTAINER_BACKED_TARGET_REJECTION_REASON,
+  ProvisioningJobService,
+  provisioningJobService,
+} from "./provisioning-jobs";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
+const PGLITE_TIMEOUT = 300_000;
+const OWNER_ID = "00000000-0000-4000-8000-000000229480";
+const DELETION_ATTEMPT_ID = "00000000-0000-4000-8000-000000229481";
+const REACHABLE_BRIDGE = "http://10.0.0.5:8080";
+const SNAPSHOT_POOL_REJECTION = "Agent snapshot cannot target pool-owned capacity";
+const SNAPSHOT_DELETED_REJECTION = "Agent snapshot cannot target a deleted agent";
+const SNAPSHOT_DELETION_REJECTION =
+  "Agent snapshot cannot start while agent deletion is in progress";
+const CONTAINER_TIER_REJECTION = "Agent job requires a container-backed execution tier";
+const SNAPSHOT_TYPES = ["manual", "auto"] as const;
+
+type SnapshotType = (typeof SNAPSHOT_TYPES)[number];
+
+interface SandboxIdentity {
+  agentId: string;
+  organizationId: string;
+  userId: string;
+}
+
+interface SeedSandboxOptions {
+  executionTier?: string;
+  status?: string;
+  poolStatus?: "unclaimed" | null;
+  deletedAt?: Date | null;
+  deletionAttemptId?: string | null;
+  bridgeUrl?: string | null;
+}
+
+interface AuthorityMutation {
+  executionTier?: string;
+  status?: string;
+  poolStatus?: "unclaimed" | null;
+  deletedAt?: Date | null;
+  deletionAttemptId?: string | null;
+}
+
+let pgliteReady = true;
+let sequence = 0;
+
+function unique(prefix: string): string {
+  sequence += 1;
+  return `${prefix}-${sequence}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedOwner(): Promise<{ organizationId: string; userId: string }> {
+  const [organization] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Snapshot Authority", slug: unique("snapshot-authority") })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ organization_id: organization.id, steward_user_id: unique("steward") })
+    .returning();
+  return { organizationId: organization.id, userId: user.id };
+}
+
+async function seedSandbox(options: SeedSandboxOptions = {}): Promise<SandboxIdentity> {
+  const owner = await seedOwner();
+  const deletionAttemptId = options.deletionAttemptId ?? null;
+  const [sandbox] = await dbWrite
+    .insert(agentSandboxes)
+    .values({
+      organization_id: owner.organizationId,
+      user_id: owner.userId,
+      agent_name: unique("snapshot-agent"),
+      execution_tier: (options.executionTier ?? "dedicated-lazy") as never,
+      status: (options.status ?? "running") as never,
+      bridge_url: options.bridgeUrl === undefined ? REACHABLE_BRIDGE : options.bridgeUrl,
+      pool_status: (options.poolStatus ?? null) as never,
+      deleted_at: options.deletedAt ?? null,
+      deletion_attempt_id: deletionAttemptId,
+      deletion_started_at: deletionAttemptId ? new Date("2026-08-22T00:00:00.000Z") : null,
+    })
+    .returning();
+  return { agentId: sandbox.id, ...owner };
+}
+
+async function mutateAuthority(
+  identity: SandboxIdentity,
+  mutation: AuthorityMutation,
+): Promise<void> {
+  await dbWrite
+    .update(agentSandboxes)
+    .set({
+      ...(mutation.executionTier !== undefined
+        ? { execution_tier: mutation.executionTier as never }
+        : {}),
+      ...(mutation.status !== undefined ? { status: mutation.status as never } : {}),
+      ...(mutation.poolStatus !== undefined ? { pool_status: mutation.poolStatus as never } : {}),
+      ...(mutation.deletedAt !== undefined ? { deleted_at: mutation.deletedAt } : {}),
+      ...(mutation.deletionAttemptId !== undefined
+        ? {
+            deletion_attempt_id: mutation.deletionAttemptId,
+            deletion_started_at: mutation.deletionAttemptId
+              ? new Date("2026-08-22T00:00:00.000Z")
+              : null,
+          }
+        : {}),
+    })
+    .where(
+      and(
+        eq(agentSandboxes.id, identity.agentId),
+        eq(agentSandboxes.organization_id, identity.organizationId),
+      ),
+    );
+}
+
+function enqueueSnapshot(
+  service: ProvisioningJobService,
+  identity: SandboxIdentity,
+  snapshotType: SnapshotType,
+) {
+  return service.enqueueAgentSnapshotOnce({ ...identity, snapshotType });
+}
+
+async function snapshotJobs(identity: SandboxIdentity): Promise<Job[]> {
+  return (await dbWrite
+    .select()
+    .from(jobs)
+    .where(
+      and(
+        eq(jobs.agent_id, identity.agentId),
+        eq(jobs.organization_id, identity.organizationId),
+        eq(jobs.type, JOB_TYPES.AGENT_SNAPSHOT),
+      ),
+    )) as Job[];
+}
+
+async function sandboxState(identity: SandboxIdentity) {
+  const [sandbox] = await dbWrite
+    .select({
+      status: agentSandboxes.status,
+      executionTier: agentSandboxes.execution_tier,
+      poolStatus: agentSandboxes.pool_status,
+      deletedAt: agentSandboxes.deleted_at,
+      deletionAttemptId: agentSandboxes.deletion_attempt_id,
+      deletionStartedAt: agentSandboxes.deletion_started_at,
+      lastBackupAt: agentSandboxes.last_backup_at,
+      lastBackupAttemptAt: agentSandboxes.last_backup_attempt_at,
+      backupUnsupportedReason: agentSandboxes.backup_unsupported_reason,
+      error: agentSandboxes.error_message,
+      lifecycleJobId: agentSandboxes.lifecycle_job_id,
+      lifecycleGeneration: agentSandboxes.lifecycle_execution_generation,
+      lifecycleRevision: agentSandboxes.lifecycle_revision,
+    })
+    .from(agentSandboxes)
+    .where(
+      and(
+        eq(agentSandboxes.id, identity.agentId),
+        eq(agentSandboxes.organization_id, identity.organizationId),
+      ),
+    );
+  return sandbox;
+}
+
+async function expectAdmissionRejection(
+  snapshotType: SnapshotType,
+  options: SeedSandboxOptions,
+  expectedMessage: string,
+): Promise<void> {
+  const service = new ProvisioningJobService();
+  const identity = await seedSandbox(options);
+
+  await expect(enqueueSnapshot(service, identity, snapshotType)).rejects.toMatchObject({
+    status: 409,
+    code: "session_not_ready",
+    message: expectedMessage,
+  });
+  expect(await snapshotJobs(identity)).toHaveLength(0);
+}
+
+async function expectTerminalWorkerRejection(
+  mutation: AuthorityMutation,
+  expectedMessage: string,
+): Promise<void> {
+  const identity = await seedSandbox({
+    executionTier: "dedicated-lazy",
+    status: "running",
+    poolStatus: null,
+    deletedAt: null,
+    deletionAttemptId: null,
+  });
+  const enqueued = await enqueueSnapshot(new ProvisioningJobService(), identity, "manual");
+  await mutateAuthority(identity, mutation);
+  const before = await sandboxState(identity);
+  let handlerCalls = 0;
+  const service = new ProvisioningJobService({
+    executionOwnerId: OWNER_ID,
+    executeJob: async (job) => {
+      handlerCalls += 1;
+      await jobsRepository.settleExecution(
+        job,
+        "completed",
+        { completed_at: new Date() },
+        OWNER_ID,
+      );
+    },
+  });
+  const ordinaryFailure = spyOn(jobsRepository, "incrementAttempt");
+
+  try {
+    const result = await service.processPendingJobs(1, {
+      jobTypes: [JOB_TYPES.AGENT_SNAPSHOT],
+    });
+
+    expect(result).toMatchObject({ claimed: 1, succeeded: 0, retried: 0, failed: 1 });
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]?.error).toContain(expectedMessage);
+    expect(handlerCalls).toBe(0);
+    expect(ordinaryFailure).not.toHaveBeenCalled();
+
+    const [rejected] = await dbWrite.select().from(jobs).where(eq(jobs.id, enqueued.job.id));
+    expect(rejected).toMatchObject({
+      status: "failed",
+      attempts: 1,
+      execution_quiesced_at: expect.anything(),
+      completed_at: expect.anything(),
+    });
+    const [misaligned] = await dbWrite
+      .select({ count: sql<number>`count(*)::int` })
+      .from(jobs)
+      .where(
+        and(
+          eq(jobs.id, enqueued.job.id),
+          sql`(
+            ${jobs.completed_at} IS DISTINCT FROM ${jobs.execution_quiesced_at}
+            OR ${jobs.completed_at} IS DISTINCT FROM ${jobs.updated_at}
+          )`,
+        ),
+      );
+    expect(misaligned?.count).toBe(0);
+    expect(await dbWrite.select().from(jobExecutionLeases)).toHaveLength(0);
+    expect(
+      await dbWrite
+        .select()
+        .from(agentSandboxBackups)
+        .where(eq(agentSandboxBackups.sandbox_record_id, identity.agentId)),
+    ).toHaveLength(0);
+    expect(await sandboxState(identity)).toEqual(before);
+
+    const secondPass = await service.processPendingJobs(1, {
+      jobTypes: [JOB_TYPES.AGENT_SNAPSHOT],
+    });
+    expect(secondPass).toMatchObject({ claimed: 0, succeeded: 0, retried: 0, failed: 0 });
+    const [afterReplay] = await dbWrite
+      .select({ attempts: jobs.attempts })
+      .from(jobs)
+      .where(eq(jobs.id, enqueued.job.id));
+    expect(afterReplay?.attempts).toBe(1);
+  } finally {
+    ordinaryFailure.mockRestore();
+  }
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    return;
+  }
+  try {
+    for (const ddl of PROVISIONING_JOB_TEST_TABLES) {
+      await dbWrite.execute(sql.raw(ddl));
+    }
+  } catch {
+    pgliteReady = false;
+  }
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  expect(pgliteReady).toBe(true);
+  process.env.ELIZA_SNAPSHOT_JOBS_ENABLED = "true";
+  await dbWrite.delete(jobExecutionLeases);
+  await dbWrite.delete(jobs);
+  await dbWrite.delete(agentSandboxBackups);
+  await dbWrite.delete(agentSandboxes);
+});
+
+afterAll(async () => {
+  delete process.env.ELIZA_SNAPSHOT_JOBS_ENABLED;
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("agent_snapshot enqueue authority", () => {
+  for (const snapshotType of SNAPSHOT_TYPES) {
+    test(`keeps generic tier rejection first for ${snapshotType} snapshots`, async () => {
+      const service = new ProvisioningJobService();
+      const identity = await seedSandbox({
+        executionTier: "future-container",
+        status: "deletion_pending",
+        poolStatus: "unclaimed",
+        deletedAt: new Date("2026-08-22T00:00:00.000Z"),
+        deletionAttemptId: DELETION_ATTEMPT_ID,
+      });
+
+      await expect(enqueueSnapshot(service, identity, snapshotType)).rejects.toMatchObject({
+        status: 409,
+        code: "session_not_ready",
+        details: {
+          reason: CONTAINER_BACKED_TARGET_REJECTION_REASON,
+          jobType: JOB_TYPES.AGENT_SNAPSHOT,
+        },
+      });
+      expect(await snapshotJobs(identity)).toHaveLength(0);
+    });
+
+    test(`rejects pool-owned ${snapshotType} snapshots before deletion state`, async () => {
+      await expectAdmissionRejection(
+        snapshotType,
+        {
+          executionTier: "dedicated-lazy",
+          status: "deletion_pending",
+          poolStatus: "unclaimed",
+          deletedAt: new Date("2026-08-22T00:00:00.000Z"),
+          deletionAttemptId: DELETION_ATTEMPT_ID,
+        },
+        SNAPSHOT_POOL_REJECTION,
+      );
+    });
+
+    test(`rejects deleted ${snapshotType} snapshots before deletion attempts`, async () => {
+      await expectAdmissionRejection(
+        snapshotType,
+        {
+          executionTier: "dedicated-always",
+          status: "deletion_pending",
+          poolStatus: null,
+          deletedAt: new Date("2026-08-22T00:00:00.000Z"),
+          deletionAttemptId: DELETION_ATTEMPT_ID,
+        },
+        SNAPSHOT_DELETED_REJECTION,
+      );
+    });
+
+    test(`rejects deletion-owned ${snapshotType} snapshots`, async () => {
+      await expectAdmissionRejection(
+        snapshotType,
+        {
+          executionTier: "custom",
+          status: "deletion_pending",
+          poolStatus: null,
+          deletedAt: null,
+          deletionAttemptId: DELETION_ATTEMPT_ID,
+        },
+        SNAPSHOT_DELETION_REJECTION,
+      );
+    });
+  }
+
+  test("rejects changed authority before reusing an active snapshot job", async () => {
+    const service = new ProvisioningJobService();
+    const identity = await seedSandbox({
+      executionTier: "dedicated-lazy",
+      status: "running",
+      poolStatus: null,
+      deletedAt: null,
+      deletionAttemptId: null,
+    });
+    const first = await enqueueSnapshot(service, identity, "manual");
+    await mutateAuthority(identity, {
+      status: "deletion_pending",
+      poolStatus: "unclaimed",
+      deletedAt: new Date("2026-08-22T00:00:00.000Z"),
+      deletionAttemptId: DELETION_ATTEMPT_ID,
+    });
+
+    await expect(enqueueSnapshot(service, identity, "manual")).rejects.toMatchObject({
+      status: 409,
+      code: "session_not_ready",
+      message: SNAPSHOT_POOL_REJECTION,
+    });
+    const active = await snapshotJobs(identity);
+    expect(active).toHaveLength(1);
+    expect(active[0]).toMatchObject({ id: first.job.id, status: "pending" });
+  });
+
+  for (const executionTier of CONTAINER_BACKED_EXECUTION_TIERS) {
+    test(`admits explicit-null manual and auto snapshots for ${executionTier}`, async () => {
+      const service = new ProvisioningJobService();
+      const identity = await seedSandbox({
+        executionTier,
+        status: "running",
+        poolStatus: null,
+        deletedAt: null,
+        deletionAttemptId: null,
+      });
+
+      const manual = await enqueueSnapshot(service, identity, "manual");
+      const auto = await enqueueSnapshot(service, identity, "auto");
+
+      expect(manual).toMatchObject({ created: true, job: { status: "pending" } });
+      expect(auto).toMatchObject({ created: true, job: { status: "pending" } });
+      const persisted = await snapshotJobs(identity);
+      expect(persisted).toHaveLength(2);
+      expect(
+        new Set(persisted.map((job) => (job.data as { snapshotType: string }).snapshotType)),
+      ).toEqual(new Set(["manual", "auto"]));
+    });
+  }
+});
+
+describe("agent_snapshot scheduled admission", () => {
+  test("safely refuses a due soft-deleted row selected by the real scheduler", async () => {
+    const identity = await seedSandbox({
+      executionTier: "dedicated-lazy",
+      status: "running",
+      poolStatus: null,
+      deletedAt: new Date("2026-08-22T00:00:00.000Z"),
+      deletionAttemptId: null,
+    });
+
+    const result = await provisioningJobService.enqueueScheduledBackups({ maxAgents: 10 });
+
+    expect(result).toMatchObject({ scanned: 1, enqueued: 0 });
+    expect(await snapshotJobs(identity)).toHaveLength(0);
+  });
+
+  test("safely refuses a due deletion-owned row selected by the real scheduler", async () => {
+    const identity = await seedSandbox({
+      executionTier: "dedicated-always",
+      status: "running",
+      poolStatus: null,
+      deletedAt: null,
+      deletionAttemptId: DELETION_ATTEMPT_ID,
+    });
+
+    const result = await provisioningJobService.enqueueScheduledBackups({ maxAgents: 10 });
+
+    expect(result).toMatchObject({ scanned: 1, enqueued: 0 });
+    expect(await snapshotJobs(identity)).toHaveLength(0);
+  });
+});
+
+describe("agent_snapshot worker authority", () => {
+  test("terminally rejects pool ownership before deleted and deletion-attempt state", async () => {
+    await expectTerminalWorkerRejection(
+      {
+        status: "deletion_pending",
+        poolStatus: "unclaimed",
+        deletedAt: new Date("2026-08-22T00:00:00.000Z"),
+        deletionAttemptId: DELETION_ATTEMPT_ID,
+      },
+      SNAPSHOT_POOL_REJECTION,
+    );
+  });
+
+  test("terminally rejects deletion before a deletion attempt", async () => {
+    await expectTerminalWorkerRejection(
+      {
+        status: "deletion_pending",
+        poolStatus: null,
+        deletedAt: new Date("2026-08-22T00:00:00.000Z"),
+        deletionAttemptId: DELETION_ATTEMPT_ID,
+      },
+      SNAPSHOT_DELETED_REJECTION,
+    );
+  });
+
+  test("terminally rejects deletion-owned capacity", async () => {
+    await expectTerminalWorkerRejection(
+      {
+        status: "deletion_pending",
+        poolStatus: null,
+        deletedAt: null,
+        deletionAttemptId: DELETION_ATTEMPT_ID,
+      },
+      SNAPSHOT_DELETION_REJECTION,
+    );
+  });
+
+  test("keeps generic tier rejection ahead of snapshot-specific authority", async () => {
+    await expectTerminalWorkerRejection(
+      {
+        executionTier: "future-container",
+        status: "deletion_pending",
+        poolStatus: "unclaimed",
+        deletedAt: new Date("2026-08-22T00:00:00.000Z"),
+        deletionAttemptId: DELETION_ATTEMPT_ID,
+      },
+      CONTAINER_TIER_REJECTION,
+    );
+  });
+
+  for (const executionTier of CONTAINER_BACKED_EXECUTION_TIERS) {
+    test(`dispatches an explicit-null ${executionTier} snapshot`, async () => {
+      const identity = await seedSandbox({
+        executionTier,
+        status: "running",
+        poolStatus: null,
+        deletedAt: null,
+        deletionAttemptId: null,
+      });
+      const enqueued = await enqueueSnapshot(new ProvisioningJobService(), identity, "manual");
+      const before = await sandboxState(identity);
+      let handlerCalls = 0;
+      const service = new ProvisioningJobService({
+        executionOwnerId: OWNER_ID,
+        executeJob: async (job) => {
+          handlerCalls += 1;
+          await jobsRepository.settleExecution(
+            job,
+            "completed",
+            { completed_at: new Date() },
+            OWNER_ID,
+          );
+        },
+      });
+
+      const result = await service.processPendingJobs(1, {
+        jobTypes: [JOB_TYPES.AGENT_SNAPSHOT],
+      });
+
+      expect(result).toMatchObject({ claimed: 1, succeeded: 1, retried: 0, failed: 0 });
+      expect(handlerCalls).toBe(1);
+      const [completed] = await dbWrite.select().from(jobs).where(eq(jobs.id, enqueued.job.id));
+      expect(completed).toMatchObject({ status: "completed", attempts: 0 });
+      expect(await dbWrite.select().from(jobExecutionLeases)).toHaveLength(0);
+      expect(await sandboxState(identity)).toEqual(before);
+    });
+  }
+});

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -1010,10 +1010,26 @@ interface LifecycleSandboxRow {
   replacement_cleanup_sandbox_id: string | null;
   deletion_attempt_id: string | null;
   deletion_started_at: Date | null;
+  deleted_at: Date | null;
   billing_status: AgentBillingStatus;
   shutdown_warning_sent_at: Date | null;
   scheduled_shutdown_at: Date | null;
   pool_status: AgentSandboxPoolStatus | null;
+}
+
+function snapshotAuthorityRejection(
+  sandbox: Pick<LifecycleSandboxRow, "pool_status" | "deleted_at" | "deletion_attempt_id">,
+): string | undefined {
+  if (sandbox.pool_status !== null) {
+    return "Agent snapshot cannot target pool-owned capacity";
+  }
+  if (sandbox.deleted_at !== null) {
+    return "Agent snapshot cannot target a deleted agent";
+  }
+  if (sandbox.deletion_attempt_id !== null) {
+    return "Agent snapshot cannot start while agent deletion is in progress";
+  }
+  return undefined;
 }
 
 interface LifecycleJobOptions<TData extends object> {
@@ -1573,6 +1589,7 @@ export class ProvisioningJobService {
         replacement_cleanup_sandbox_id: agentSandboxes.replacement_cleanup_sandbox_id,
         deletion_attempt_id: agentSandboxes.deletion_attempt_id,
         deletion_started_at: agentSandboxes.deletion_started_at,
+        deleted_at: agentSandboxes.deleted_at,
         billing_status: agentSandboxes.billing_status,
         shutdown_warning_sent_at: agentSandboxes.shutdown_warning_sent_at,
         scheduled_shutdown_at: agentSandboxes.scheduled_shutdown_at,
@@ -3082,6 +3099,12 @@ export class ProvisioningJobService {
       logName: "agent_snapshot",
       logExtras: { snapshotType },
       idempotencyPredicates: [sql`${jobs.data}->>'snapshotType' = ${snapshotType}`],
+      validateSandbox: (sandbox) => {
+        const rejection = snapshotAuthorityRejection(sandbox);
+        if (rejection) {
+          throw new ApiError(409, "session_not_ready", rejection);
+        }
+      },
     });
   }
 
@@ -4382,7 +4405,12 @@ export class ProvisioningJobService {
       }
 
       const [sandboxAuthority] = await tx
-        .select({ executionTier: agentSandboxes.execution_tier })
+        .select({
+          executionTier: agentSandboxes.execution_tier,
+          pool_status: agentSandboxes.pool_status,
+          deleted_at: agentSandboxes.deleted_at,
+          deletion_attempt_id: agentSandboxes.deletion_attempt_id,
+        })
         .from(agentSandboxes)
         .where(
           and(
@@ -4408,6 +4436,21 @@ export class ProvisioningJobService {
             executionTier: sandboxAuthority?.executionTier ?? "missing",
           },
         );
+      }
+
+      if (job.type === JOB_TYPES.AGENT_SNAPSHOT && sandboxAuthority) {
+        const rejection = snapshotAuthorityRejection(sandboxAuthority);
+        if (rejection) {
+          throw new RejectedAgentExecutionError(rejection, {
+            jobId: job.id,
+            jobType: job.type,
+            columnAgentId: job.agent_id,
+            columnOrganizationId: job.organization_id,
+            payloadAgentId: identity.agentId,
+            payloadOrganizationId: identity.organizationId,
+            executionTier: sandboxAuthority.executionTier,
+          });
+        }
       }
 
       if (!EXCLUSIVE_AGENT_LIFECYCLE_JOB_TYPES.includes(job.type as ProvisioningJobType)) return;


### PR DESCRIPTION
# Relates to

- #22947 — micro-slice O: atomically fence durable `agent_snapshot` enqueue and locked worker claim-time authority. This does not close the issue.
- #24162 has merged; this PR is no longer stacked or on hold and now targets `develop` directly.
- #24312 has also merged and separately fences stale snapshot persistence at the inner service/CAS boundary.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] The branch is refreshed onto current `develop` with a two-file, related-only delta.
- [x] Exact-head focused tests, package gates, differential evidence, and the unrelated root-verify blocker are recorded below.
- [x] The requested post-preflight snapshot/delete race is exercised deterministically.

No merge or auto-merge is authorized.

# Exact sync and scope

- [x] Exact candidate head: `c5daa7a06f67eae8a85a3618f030aae2795f73f6`.
- [x] Exact validated `develop` base: `ed4d4a3d9a`.
- [x] The branch was refreshed with ordinary merge commits only; no rebase or force-push was used.
- [x] The delta is exactly two files: one production file and one PGlite test file.
- [x] `git diff --check origin/develop...HEAD` passes and the worktree is clean.

# Risks

Medium. Snapshot jobs read live container state and persist a durable backup. A manual request, scheduler pass, historical active job, or forged queued row could previously reach reuse/insertion or worker dispatch after execution authority had moved to pool, deleted, or deletion-owned state. This change rejects those states at the database authority boundaries and adds a deterministic proof that ordinary delete enqueue cannot overlap a claimed snapshot capture.

# Background

## What does this PR do?

For manual and automatic snapshot enqueue, the locked lifecycle row includes `deleted_at`. Under the existing advisory lock and `SELECT ... FOR UPDATE`, snapshot admission validates, in order:

1. the generic container-tier contract;
2. `pool_status IS NULL`;
3. `deleted_at IS NULL`;
4. `deletion_attempt_id IS NULL`.

Validation happens before active-job reuse and before insertion, so a row whose authority changed cannot inherit or create snapshot work. The exact snapshot-specific messages are:

- `Agent snapshot cannot target pool-owned capacity`
- `Agent snapshot cannot target a deleted agent`
- `Agent snapshot cannot start while agent deletion is in progress`

At worker claim time, the exact job identity/generation/lease checks, advisory lock, and row lock re-read all four authority fields. After the generic tier fence and before the non-exclusive early return, an invalid `agent_snapshot` uses the existing terminal `rejectClaimedExecution` transition. It does not enter ordinary retry, handler dispatch, or lifecycle failure writeback.

The review-requested post-preflight race was also audited against the real repository path. A successful claim atomically moves the snapshot to `in_progress`, assigns a fresh `execution_generation`, clears quiescence, and installs a lease. The worker starts heartbeat renewal before preflight and handler dispatch. Delete enqueue cancels only `pending` jobs and rejects every non-delete `in_progress` job for the agent, independently of `exclusive` metadata. The snapshot remains owned until exact generation/lease settlement, and stale recovery excludes a live lease.

The new deterministic test pauses the handler after preflight, proves the exact generation and database-live lease, attempts delete, and asserts:

- HTTP/API conflict status `409` naming `agent_snapshot`;
- zero delete-job rows;
- no deletion attempt and no delete handler call;
- delete succeeds only after the snapshot is released and settled.

`agent_snapshot` deliberately remains non-exclusive. Marking it `exclusive: true` would regress the supported manual-plus-automatic admission case: the worker conflict scan would see the other pending snapshot and reject the first capture. The durable `in_progress` job ownership already provides the symmetry delete enqueue observes.

This PR does not claim that every direct service call is physically serialized with the network capture. The service/CAS stale-persistence residual is separate and is now covered by merged #24312. This PR remains limited to enqueue and locked claim-time authority plus proof of the ordinary delete-enqueue interleaving.

Historical production-file authors were inventoried before implementation: Bill Ding, lalalune, ngngocnhan1997-hub, nothingxnowhere, nubs/NubsCarson, Shaw, Sol, Stan, and Tradi3. The new test path had no history. Open-PR file overlap was inventoried before implementation; the only overlap at the time was the intentional #24162 stack base, which has since merged.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No user-facing documentation change is required. This tightens existing internal lifecycle authority.

# Testing

## Where should a reviewer start?

1. `packages/cloud/shared/src/lib/services/provisioning-jobs.ts`
2. `packages/cloud/shared/src/lib/services/provisioning-jobs-snapshot-authority.pglite.test.ts`
3. The test `keeps durable execution ownership while capture blocks a concurrent delete`

## Detailed testing steps

Exact candidate: `c5daa7a06f67eae8a85a3618f030aae2795f73f6`  
Exact validated base: `ed4d4a3d9a`  
Toolchain: Node `24.15.0`, Bun `1.3.14`.

- `bun --conditions=eliza-source --config=/dev/null test packages/cloud/shared/src/lib/services/provisioning-job-types.test.ts packages/cloud/shared/src/lib/services/provisioning-jobs-container-tier-guard.pglite.test.ts packages/cloud/shared/src/lib/services/provisioning-jobs-snapshot-authority.pglite.test.ts packages/cloud/shared/src/lib/services/provisioning-jobs-snapshot-gate.test.ts`
  - 62 tests pass, 0 fail, 283 assertions on the exact head.
  - Snapshot-authority suite: 22/22, including the deterministic paused-handler delete race.
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/provisioning-jobs.ts packages/cloud/shared/src/lib/services/provisioning-jobs-snapshot-authority.pglite.test.ts` — passes.
- `bunx tsc6 --noEmit -p packages/cloud/shared/tsconfig.json` — passes.
- `bun run --cwd packages/cloud/shared check:tenant-scope` — passes across 129 repository files.
- `git diff --check origin/develop...HEAD` — passes.
- `git diff --exit-code origin/develop...HEAD -- packages/app-core packages/ui packages/shared/src/i18n packages/core/src/i18n` — passes; the PR has no UI or i18n delta.

Original clean-stack differential evidence for the 21 authority tests was captured at exact then-parent `731f9d60c675018993cde3786105087be3704d0f`: 9 passed and 12 failed before the production fence. Failures were named by invariant, not inferred from totals:

- pool-owned manual/auto admission;
- deleted manual/auto admission;
- deletion-owned manual/auto admission;
- changed authority before active-job reuse;
- due soft-deleted and deletion-owned scheduler rows;
- worker pool, deleted, and deletion-owned rejection.

The generic tier-precedence tests and the explicit-null `dedicated-lazy`, `dedicated-always`, and `custom` positive cases already passed on that baseline. The new post-preflight delete test is intentionally a proof of pre-existing durable job ownership rather than a production-differential failure.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:c5daa7a06f67eae8a85a3618f030aae2795f73f6 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Backend-only lifecycle authority change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Backend-only lifecycle authority change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - No user-driven visual flow or frontend behavior changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - No live snapshot was enqueued; deterministic exact-head PGlite tests exercise admission, scheduler, worker ownership, and settlement.
<!-- evidence-row:frontend-logs -->
- [x] N/A - No frontend code, console behavior, or browser request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - No agent prompt, action, inference provider, model, or LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - No external durable artifact was created; exact database/job effects are asserted in isolated PGlite tests.
<!-- evidence-row:ocr-review -->
- [x] N/A - No rendered visual surface or visible text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - No prompt, action, inference provider, model, or LLM behavior changes.

## Backend + frontend logs

N/A - Exercising invalid snapshot authority live could read a real container and create a durable backup. Exact-head PGlite tests prove the locked database boundaries without live mutation.

## Screenshots (before / after) + video walkthrough

N/A - Backend-only change with no UI surface.

## Audio / voice walkthrough

N/A - No audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

- `bun run verify` on exact head `c5daa7a06f67eae8a85a3618f030aae2795f73f6` exits 1 at the repository-wide `check:i18n` gate before package typecheck/lint. It reports 9 English keys missing in unrelated `packages/ui` files plus large existing translation gaps. The exact PR diff contains no `packages/ui`, `packages/app-core`, or i18n file, and the focused tests, shared `tsc6`, focused Biome, tenant-scope gate, and diff checks pass.
- This PR fences enqueue and claim-time snapshot authority. It does not relabel an isolated database proof as deployed E2E and does not close #22947.
- No live row, snapshot job, backup, lifecycle writeback, credential, deployment, migration, worker, provider resource, or infrastructure setting was changed.
- Hosted CI is not claimed as green; only exact-head local exit codes are used as proof.

AI provider/model: OpenAI / GPT-5.6
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-snapshot-job-authority]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5.6","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->