### PR TITLE
feat(testing): add wallet EVM RPC protocol mock

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -794,6 +794,7 @@
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
         "hono": "4.13.1",
+        "viem": "^2.48.8",
       },
       "devDependencies": {
         "@elizaos/cloud-sdk": "workspace:*",

--- a/packages/cloud/test-mocks/AGENTS.md
+++ b/packages/cloud/test-mocks/AGENTS.md
@@ -25,6 +25,11 @@ exits.
   `Job`/`JobStatus`/`JobType`/`Sandbox`/`SandboxStatus` types.
 - `src/steward/` (export `./steward`) — stateful loopback mock for authenticated
   Steward platform-user deactivation and deletion calls used by account lifecycle E2E.
+- `src/wallet-evm/` (export `./wallet-evm`) — resettable Base-compatible
+  JSON-RPC simulator for the production plugin-wallet viem transport. It owns
+  seeded balances, signed-transaction admission, deterministic mining/time,
+  effect-backed receipts, duplicate submission, reorg rollback, faults,
+  generation-fenced reset, and secret/raw-transaction-redacted readback.
 - `src/fetch-server.ts` — shared `startFetchServer(fetch, opts)`; uses
   `Bun.serve` when running under Bun, falls back to a `node:http` adapter
   otherwise.

--- a/packages/cloud/test-mocks/CLAUDE.md
+++ b/packages/cloud/test-mocks/CLAUDE.md
@@ -25,6 +25,11 @@ exits.
   `Job`/`JobStatus`/`JobType`/`Sandbox`/`SandboxStatus` types.
 - `src/steward/` (export `./steward`) — stateful loopback mock for authenticated
   Steward platform-user deactivation and deletion calls used by account lifecycle E2E.
+- `src/wallet-evm/` (export `./wallet-evm`) — resettable Base-compatible
+  JSON-RPC simulator for the production plugin-wallet viem transport. It owns
+  seeded balances, signed-transaction admission, deterministic mining/time,
+  effect-backed receipts, duplicate submission, reorg rollback, faults,
+  generation-fenced reset, and secret/raw-transaction-redacted readback.
 - `src/fetch-server.ts` — shared `startFetchServer(fetch, opts)`; uses
   `Bun.serve` when running under Bun, falls back to a `node:http` adapter
   otherwise.

--- a/packages/cloud/test-mocks/README.md
+++ b/packages/cloud/test-mocks/README.md
@@ -73,6 +73,10 @@ effects before emitting success receipts, emits reverted receipts without an
 effect, and rolls mined state and receipts back during a reorg. Seed/reset,
 auth, rate-limit/provider/malformed/stall faults, generation fencing, and
 credential/raw-transaction-redacted readback are available through the store.
+The HTTP boundary accepts only uncompressed UTF-8 `application/json`, caps the
+body at 64 KiB and the decoded graph at 16 levels/2,048 nodes, and returns only
+stable allowlisted protocol errors; dependency failures and adapter exceptions
+cannot reflect raw requests or credentials.
 
 The simulator intentionally implements a focused native-transfer subset, not
 a general EVM. Contract execution, logs, gas charging, and multichain behavior

--- a/packages/cloud/test-mocks/README.md
+++ b/packages/cloud/test-mocks/README.md
@@ -64,6 +64,20 @@ declared capabilities and nonce-bound observations emitted by the executed
 suite. Normal CI is fully offline and credential-free; live/sandbox lanes
 remain optional.
 
+## Wallet EVM JSON-RPC mock
+
+`@elizaos/cloud-test-mocks/wallet-evm` runs a resettable Base-compatible
+JSON-RPC HTTP simulator. It accepts real locally signed EIP-1559 transactions,
+deduplicates raw submissions, mines deterministic blocks, applies native-value
+effects before emitting success receipts, emits reverted receipts without an
+effect, and rolls mined state and receipts back during a reorg. Seed/reset,
+auth, rate-limit/provider/malformed/stall faults, generation fencing, and
+credential/raw-transaction-redacted readback are available through the store.
+
+The simulator intentionally implements a focused native-transfer subset, not
+a general EVM. Contract execution, logs, gas charging, and multichain behavior
+remain unsupported and must never be inferred from a passing receipt.
+
 ## Hetzner Cloud mock
 
 Implements the subset of the Hetzner Cloud API that the autoscaler client in

--- a/packages/cloud/test-mocks/package.json
+++ b/packages/cloud/test-mocks/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./hetzner": "./src/hetzner/index.ts",
     "./control-plane": "./src/control-plane/index.ts",
+    "./wallet-evm": "./src/wallet-evm/index.ts",
     "./steward": "./src/steward/index.ts",
     "./provider-contract": "./src/provider-contract/index.ts"
   },
@@ -28,7 +29,8 @@
     "@elizaos/core": "workspace:*",
     "@elizaos/cloud-shared": "workspace:*",
     "@elizaos/shared": "workspace:*",
-    "hono": "4.13.1"
+    "hono": "4.13.1",
+    "viem": "^2.48.8"
   },
   "devDependencies": {
     "@elizaos/cloud-sdk": "workspace:*",

--- a/packages/cloud/test-mocks/src/fetch-server.ts
+++ b/packages/cloud/test-mocks/src/fetch-server.ts
@@ -1,6 +1,7 @@
 /** Exports shared cloud mock helpers for deterministic local provider API tests. */
 import http from "node:http";
 import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 
 export interface FetchServerOptions {
   port?: number;
@@ -90,10 +91,16 @@ async function handleNodeRequest(
   incoming: http.IncomingMessage,
   outgoing: http.ServerResponse,
 ) {
-  const requestAbort = new AbortController();
-  const abortRequest = () => requestAbort.abort();
-  incoming.once("aborted", abortRequest);
-  outgoing.once("close", abortRequest);
+  const abortController = new AbortController();
+  const abortIncoming = () =>
+    abortController.abort(
+      new DOMException("Client disconnected", "AbortError"),
+    );
+  const abortOutgoing = () => {
+    if (!outgoing.writableEnded) abortIncoming();
+  };
+  incoming.once("aborted", abortIncoming);
+  outgoing.once("close", abortOutgoing);
   try {
     const headers = new Headers();
     for (const [key, value] of Object.entries(incoming.headers)) {
@@ -112,7 +119,7 @@ async function handleNodeRequest(
       headers,
       body: hasBody ? Readable.toWeb(incoming) : undefined,
       duplex: hasBody ? "half" : undefined,
-      signal: requestAbort.signal,
+      signal: abortController.signal,
     } as RequestInit & { duplex?: "half" });
 
     const response = await fetch(request);
@@ -120,16 +127,25 @@ async function handleNodeRequest(
     response.headers.forEach((value, key) => {
       outgoing.setHeader(key, value);
     });
-    outgoing.end(Buffer.from(await response.arrayBuffer()));
-  } catch (error) {
-    if (!outgoing.destroyed) {
-      outgoing.statusCode = 500;
-      outgoing.end(
-        error instanceof Error ? error.message : "mock server error",
+    if (!response.body) {
+      outgoing.end();
+    } else {
+      await pipeline(
+        Readable.fromWeb(
+          response.body as unknown as import("node:stream/web").ReadableStream,
+        ),
+        outgoing,
       );
     }
+  } catch (error) {
+    if (!outgoing.headersSent && !outgoing.destroyed) {
+      outgoing.statusCode = 500;
+      outgoing.end("mock server error");
+    } else if (!outgoing.destroyed) {
+      outgoing.destroy(error instanceof Error ? error : undefined);
+    }
   } finally {
-    incoming.off("aborted", abortRequest);
-    outgoing.off("close", abortRequest);
+    incoming.off("aborted", abortIncoming);
+    outgoing.off("close", abortOutgoing);
   }
 }

--- a/packages/cloud/test-mocks/src/fetch-server.ts
+++ b/packages/cloud/test-mocks/src/fetch-server.ts
@@ -90,6 +90,10 @@ async function handleNodeRequest(
   incoming: http.IncomingMessage,
   outgoing: http.ServerResponse,
 ) {
+  const requestAbort = new AbortController();
+  const abortRequest = () => requestAbort.abort();
+  incoming.once("aborted", abortRequest);
+  outgoing.once("close", abortRequest);
   try {
     const headers = new Headers();
     for (const [key, value] of Object.entries(incoming.headers)) {
@@ -108,6 +112,7 @@ async function handleNodeRequest(
       headers,
       body: hasBody ? Readable.toWeb(incoming) : undefined,
       duplex: hasBody ? "half" : undefined,
+      signal: requestAbort.signal,
     } as RequestInit & { duplex?: "half" });
 
     const response = await fetch(request);
@@ -117,7 +122,14 @@ async function handleNodeRequest(
     });
     outgoing.end(Buffer.from(await response.arrayBuffer()));
   } catch (error) {
-    outgoing.statusCode = 500;
-    outgoing.end(error instanceof Error ? error.message : "mock server error");
+    if (!outgoing.destroyed) {
+      outgoing.statusCode = 500;
+      outgoing.end(
+        error instanceof Error ? error.message : "mock server error",
+      );
+    }
+  } finally {
+    incoming.off("aborted", abortRequest);
+    outgoing.off("close", abortRequest);
   }
 }

--- a/packages/cloud/test-mocks/src/index.ts
+++ b/packages/cloud/test-mocks/src/index.ts
@@ -3,3 +3,4 @@ export * as controlPlane from "./control-plane";
 export * from "./hetzner";
 export * as providerContract from "./provider-contract";
 export * from "./steward";
+export * as walletEvm from "./wallet-evm";

--- a/packages/cloud/test-mocks/src/wallet-evm/index.ts
+++ b/packages/cloud/test-mocks/src/wallet-evm/index.ts
@@ -94,6 +94,10 @@ const DEFAULT_SEED: EvmRpcMockSeed = {
   revertRecipients: [],
 };
 
+export const EVM_RPC_MAX_REQUEST_BYTES = 64 * 1024;
+const EVM_RPC_MAX_JSON_DEPTH = 16;
+const EVM_RPC_MAX_JSON_NODES = 2_048;
+
 const ZERO_HASH = `0x${"0".repeat(64)}` as Hex;
 const ZERO_BLOOM = `0x${"0".repeat(512)}` as Hex;
 const ZERO_ADDRESS = `0x${"0".repeat(40)}` as Address;
@@ -246,13 +250,16 @@ export class EvmRpcMockStore {
     }
     let payload: JsonRpcRequest;
     try {
-      payload = parseRequest(await request.json());
+      payload = parseRequest(await readBoundedJsonRpcBody(request));
     } catch (error) {
       // error-policy:J3 untrusted JSON-RPC input becomes an explicit parse
       // error response and is never interpreted as a valid method call.
+      if (error instanceof JsonRpcAdmissionError) {
+        return jsonRpcHttpError(error.status, error.publicMessage);
+      }
       return jsonRpcResponse(null, undefined, {
         code: -32700,
-        message: error instanceof Error ? error.message : "Invalid JSON-RPC",
+        message: "Invalid JSON-RPC request",
       });
     }
 
@@ -327,10 +334,10 @@ export class EvmRpcMockStore {
       // error-policy:J1 the synthetic provider boundary translates execution
       // failures into canonical JSON-RPC errors rather than successful results.
       this.#observeFault(payload, "provider_error", generation);
+      const failure = publicRpcFailure(error);
       return jsonRpcResponse(payload.id, undefined, {
-        code: -32000,
-        message:
-          error instanceof Error ? error.message : "RPC execution failed",
+        code: failure.code,
+        message: failure.message,
       });
     }
   }
@@ -436,7 +443,7 @@ export class EvmRpcMockStore {
         );
       }
       default:
-        throw new Error(`Method not found: ${payload.method}`);
+        throw new JsonRpcProtocolError(-32601, "Method not found");
     }
   }
 
@@ -451,16 +458,35 @@ export class EvmRpcMockStore {
     if (this.#transactions.has(hash)) {
       return { result: hash, outcome: "duplicate", transactionHash: hash };
     }
-    const parsed = parseTransaction(serialized);
+    let parsed: ReturnType<typeof parseTransaction>;
+    try {
+      parsed = parseTransaction(serialized);
+    } catch {
+      throw new JsonRpcProtocolError(
+        -32602,
+        "Invalid signed transaction encoding",
+      );
+    }
     if (parsed.chainId !== this.#seed.chainId) {
-      throw new Error(`Wrong chain ID: ${parsed.chainId ?? "missing"}`);
+      throw new JsonRpcProtocolError(-32602, "Wrong chain ID");
     }
     if (parsed.nonce === undefined) {
-      throw new Error("Signed transaction nonce is required");
+      throw new JsonRpcProtocolError(
+        -32602,
+        "Signed transaction nonce is required",
+      );
     }
-    const from = await recoverTransactionAddress({
-      serializedTransaction: serialized,
-    });
+    let from: Address;
+    try {
+      from = await recoverTransactionAddress({
+        serializedTransaction: serialized,
+      });
+    } catch {
+      throw new JsonRpcProtocolError(
+        -32602,
+        "Invalid signed transaction signature",
+      );
+    }
     const fromKey = normalizeAddress(from);
     const pendingFrom = [...this.#transactions.values()].filter(
       (transaction) =>
@@ -469,7 +495,8 @@ export class EvmRpcMockStore {
     );
     const expectedNonce = (this.#nonces.get(fromKey) ?? 0) + pendingFrom.length;
     if (parsed.nonce !== expectedNonce) {
-      throw new Error(
+      throw new JsonRpcProtocolError(
+        -32602,
         `Invalid nonce: expected ${expectedNonce}, received ${parsed.nonce}`,
       );
     }
@@ -479,7 +506,10 @@ export class EvmRpcMockStore {
     );
     const balance = this.#balances.get(fromKey) ?? 0n;
     if (balance < reservedValue + (parsed.value ?? 0n)) {
-      throw new Error("Insufficient funds for transaction value");
+      throw new JsonRpcProtocolError(
+        -32000,
+        "Insufficient funds for transaction value",
+      );
     }
     const transaction: StoredTransaction = {
       hash,
@@ -704,6 +734,123 @@ interface JsonRpcRequest {
   params: unknown[];
 }
 
+class JsonRpcAdmissionError extends Error {
+  constructor(
+    readonly status: number,
+    readonly publicMessage: string,
+  ) {
+    super(publicMessage);
+    this.name = "JsonRpcAdmissionError";
+  }
+}
+
+class JsonRpcProtocolError extends Error {
+  constructor(
+    readonly code: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "JsonRpcProtocolError";
+  }
+}
+
+async function readBoundedJsonRpcBody(request: Request): Promise<unknown> {
+  const contentType = request.headers
+    .get("content-type")
+    ?.split(";", 1)[0]
+    ?.trim()
+    .toLowerCase();
+  if (contentType !== "application/json") {
+    throw new JsonRpcAdmissionError(415, "JSON-RPC requires application/json");
+  }
+  const contentEncoding = request.headers
+    .get("content-encoding")
+    ?.trim()
+    .toLowerCase();
+  if (contentEncoding && contentEncoding !== "identity") {
+    throw new JsonRpcAdmissionError(
+      415,
+      "Compressed JSON-RPC bodies are unsupported",
+    );
+  }
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength !== null) {
+    if (!/^\d+$/.test(declaredLength)) {
+      throw new JsonRpcAdmissionError(400, "Invalid Content-Length");
+    }
+    if (Number(declaredLength) > EVM_RPC_MAX_REQUEST_BYTES) {
+      throw new JsonRpcAdmissionError(413, "JSON-RPC body is too large");
+    }
+  }
+  if (!request.body) {
+    throw new JsonRpcAdmissionError(400, "JSON-RPC body is required");
+  }
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let byteLength = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      byteLength += value.byteLength;
+      if (byteLength > EVM_RPC_MAX_REQUEST_BYTES) {
+        await reader.cancel("JSON-RPC body is too large");
+        throw new JsonRpcAdmissionError(413, "JSON-RPC body is too large");
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new JsonRpcAdmissionError(400, "JSON-RPC body must be UTF-8");
+  }
+  const value = JSON.parse(text) as unknown;
+  assertJsonRpcComplexity(value);
+  return value;
+}
+
+function assertJsonRpcComplexity(value: unknown): void {
+  const pending: Array<{ value: unknown; depth: number }> = [
+    { value, depth: 1 },
+  ];
+  let nodes = 0;
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current) break;
+    nodes += 1;
+    if (
+      nodes > EVM_RPC_MAX_JSON_NODES ||
+      current.depth > EVM_RPC_MAX_JSON_DEPTH
+    ) {
+      throw new JsonRpcAdmissionError(
+        400,
+        "JSON-RPC body exceeds structural limits",
+      );
+    }
+    if (Array.isArray(current.value)) {
+      for (const item of current.value) {
+        pending.push({ value: item, depth: current.depth + 1 });
+      }
+    } else if (typeof current.value === "object" && current.value !== null) {
+      for (const item of Object.values(current.value)) {
+        pending.push({ value: item, depth: current.depth + 1 });
+      }
+    }
+  }
+}
+
 function parseRequest(value: unknown): JsonRpcRequest {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error("JSON-RPC request must be an object");
@@ -752,21 +899,27 @@ function normalizeSeed(
 
 function normalizeAddress(value: unknown): string {
   if (typeof value !== "string" || !/^0x[0-9a-fA-F]{40}$/.test(value)) {
-    throw new Error("Expected a 20-byte EVM address");
+    throw new JsonRpcProtocolError(-32602, "Expected a 20-byte EVM address");
   }
   return value.toLowerCase();
 }
 
 function normalizeRawTransaction(value: unknown): Hex {
   if (typeof value !== "string" || !/^0x(?:[0-9a-fA-F]{2})+$/.test(value)) {
-    throw new Error("Expected non-empty, even-length raw transaction bytes");
+    throw new JsonRpcProtocolError(
+      -32602,
+      "Expected non-empty, even-length raw transaction bytes",
+    );
   }
   return value.toLowerCase() as Hex;
 }
 
 function normalizeTransactionHash(value: unknown): Hex {
   if (typeof value !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(value)) {
-    throw new Error("Expected a 32-byte transaction hash");
+    throw new JsonRpcProtocolError(
+      -32602,
+      "Expected a 32-byte transaction hash",
+    );
   }
   return value.toLowerCase() as Hex;
 }
@@ -788,6 +941,16 @@ function rawTransactionBytes(value: unknown): number {
   return typeof value === "string" && /^0x[0-9a-fA-F]*$/.test(value)
     ? (value.length - 2) / 2
     : 0;
+}
+
+function publicRpcFailure(error: unknown): {
+  code: number;
+  message: string;
+} {
+  if (error instanceof JsonRpcProtocolError) {
+    return { code: error.code, message: error.message };
+  }
+  return { code: -32603, message: "Synthetic RPC execution failed" };
 }
 
 function jsonRpcResponse(

--- a/packages/cloud/test-mocks/src/wallet-evm/index.ts
+++ b/packages/cloud/test-mocks/src/wallet-evm/index.ts
@@ -1,0 +1,745 @@
+/**
+ * Provides a resettable Base-compatible JSON-RPC chain simulator for driving
+ * production wallet HTTP transports without provider traffic or retained keys.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  type Address,
+  type Hex,
+  keccak256,
+  parseTransaction,
+  recoverTransactionAddress,
+  type TransactionSerialized,
+} from "viem";
+import { startFetchServer } from "../fetch-server";
+
+export type EvmRpcMockFault =
+  | "rate_limit"
+  | "provider_error"
+  | "malformed_json"
+  | "stall";
+
+export interface EvmRpcMockSeed {
+  chainId: number;
+  blockNumber: number;
+  timestamp: number;
+  blockTimeSeconds: number;
+  balances: Record<string, bigint>;
+  bearerToken?: string;
+}
+
+export interface EvmRpcMockObservation {
+  order: number;
+  generation: number;
+  method: string;
+  requestId?: string | number | null;
+  authorized: boolean;
+  outcome:
+    | "success"
+    | "accepted"
+    | "duplicate"
+    | "unauthorized"
+    | "rate_limited"
+    | "provider_error"
+    | "malformed"
+    | "stalled"
+    | "cancelled"
+    | "reset";
+  params?: unknown[];
+  transactionHash?: Hex;
+  rawTransactionBytes?: number;
+}
+
+interface StoredTransaction {
+  hash: Hex;
+  raw: Hex;
+  from: Address;
+  to?: Address;
+  value: bigint;
+  nonce: number;
+  state: "pending" | "mined";
+  receipt: Record<string, unknown> | null;
+}
+
+interface AppliedEffect {
+  transactionHash: Hex;
+  from: Address;
+  to?: Address;
+  previousFromBalance: bigint;
+  previousToBalance?: bigint;
+  previousNonce: number;
+}
+
+interface MinedBlock {
+  number: number;
+  hash: Hex;
+  effects: AppliedEffect[];
+}
+
+interface PendingResponse {
+  generation: number;
+  resolve: (response: Response) => void;
+}
+
+const DEFAULT_SEED: EvmRpcMockSeed = {
+  chainId: 8453,
+  blockNumber: 100,
+  timestamp: 1_800_000_000,
+  blockTimeSeconds: 2,
+  balances: {},
+};
+
+const ZERO_HASH = `0x${"0".repeat(64)}` as Hex;
+const ZERO_BLOOM = `0x${"0".repeat(512)}` as Hex;
+const ZERO_ADDRESS = `0x${"0".repeat(40)}` as Address;
+
+export class EvmRpcMockStore {
+  #generation = 1;
+  #seed: EvmRpcMockSeed;
+  #blockNumber: number;
+  #timestamp: number;
+  #fork = 0;
+  #fault: { kind: EvmRpcMockFault; method?: string } | null = null;
+  #balances = new Map<string, bigint>();
+  #nonces = new Map<string, number>();
+  #transactions = new Map<Hex, StoredTransaction>();
+  #blocks: MinedBlock[] = [];
+  #blockHashes = new Map<number, Hex>();
+  #observations: EvmRpcMockObservation[] = [];
+  #pendingResponses = new Set<PendingResponse>();
+
+  constructor(seed: Partial<EvmRpcMockSeed> = {}) {
+    this.#seed = normalizeSeed(seed);
+    this.#blockNumber = this.#seed.blockNumber;
+    this.#timestamp = this.#seed.timestamp;
+    this.#loadSeed();
+  }
+
+  get generation(): number {
+    return this.#generation;
+  }
+
+  get pendingResponseCount(): number {
+    return this.#pendingResponses.size;
+  }
+
+  setFault(kind: EvmRpcMockFault | null, method?: string): void {
+    this.#fault = kind ? { kind, method } : null;
+  }
+
+  reset(seed: Partial<EvmRpcMockSeed> = {}): void {
+    const staleResponses = [...this.#pendingResponses];
+    this.#generation += 1;
+    this.#seed = normalizeSeed(seed);
+    this.#blockNumber = this.#seed.blockNumber;
+    this.#timestamp = this.#seed.timestamp;
+    this.#fork = 0;
+    this.#fault = null;
+    this.#observations = [];
+    this.#transactions.clear();
+    this.#blocks = [];
+    this.#pendingResponses.clear();
+    this.#loadSeed();
+    for (const pending of staleResponses) {
+      pending.resolve(
+        jsonRpcHttpError(503, "Synthetic chain environment reset"),
+      );
+    }
+  }
+
+  mine(blockCount = 1): void {
+    if (!Number.isSafeInteger(blockCount) || blockCount < 1) {
+      throw new Error("blockCount must be a positive safe integer");
+    }
+    for (let index = 0; index < blockCount; index += 1) this.#mineOne();
+  }
+
+  reorg(depth = 1): void {
+    if (
+      !Number.isSafeInteger(depth) ||
+      depth < 1 ||
+      depth > this.#blocks.length
+    ) {
+      throw new Error("reorg depth must reference simulator-mined blocks");
+    }
+    for (let index = 0; index < depth; index += 1) {
+      const block = this.#blocks.pop();
+      if (!block) throw new Error("missing block during reorg");
+      for (const effect of [...block.effects].reverse()) {
+        this.#balances.set(
+          normalizeAddress(effect.from),
+          effect.previousFromBalance,
+        );
+        this.#nonces.set(normalizeAddress(effect.from), effect.previousNonce);
+        if (effect.to && effect.previousToBalance !== undefined) {
+          this.#balances.set(
+            normalizeAddress(effect.to),
+            effect.previousToBalance,
+          );
+        }
+        const transaction = this.#transactions.get(effect.transactionHash);
+        if (transaction) {
+          transaction.state = "pending";
+          transaction.receipt = null;
+        }
+      }
+      this.#blockHashes.delete(block.number);
+      this.#blockNumber -= 1;
+      this.#timestamp -= this.#seed.blockTimeSeconds;
+    }
+    this.#fork += 1;
+  }
+
+  readback(): {
+    generation: number;
+    chainId: number;
+    blockNumber: number;
+    timestamp: number;
+    fault: { kind: EvmRpcMockFault; method?: string } | null;
+    balances: Record<string, string>;
+    transactions: Array<{
+      hash: Hex;
+      from: Address;
+      to?: Address;
+      value: string;
+      nonce: number;
+      state: "pending" | "mined";
+    }>;
+    observations: EvmRpcMockObservation[];
+  } {
+    return {
+      generation: this.#generation,
+      chainId: this.#seed.chainId,
+      blockNumber: this.#blockNumber,
+      timestamp: this.#timestamp,
+      fault: this.#fault ? { ...this.#fault } : null,
+      balances: Object.fromEntries(
+        [...this.#balances.entries()].map(([address, balance]) => [
+          address,
+          balance.toString(),
+        ]),
+      ),
+      transactions: [...this.#transactions.values()].map((transaction) => ({
+        hash: transaction.hash,
+        from: transaction.from,
+        ...(transaction.to ? { to: transaction.to } : {}),
+        value: transaction.value.toString(),
+        nonce: transaction.nonce,
+        state: transaction.state,
+      })),
+      observations: this.#observations.map((entry) => ({
+        ...entry,
+        params: entry.params ? structuredClone(entry.params) : undefined,
+      })),
+    };
+  }
+
+  async handle(request: Request): Promise<Response> {
+    const generation = this.#generation;
+    if (request.method !== "POST") {
+      return new Response("JSON-RPC requires POST", { status: 405 });
+    }
+    let payload: JsonRpcRequest;
+    try {
+      payload = parseRequest(await request.json());
+    } catch (error) {
+      // error-policy:J3 untrusted JSON-RPC input becomes an explicit parse
+      // error response and is never interpreted as a valid method call.
+      return jsonRpcResponse(null, undefined, {
+        code: -32700,
+        message: error instanceof Error ? error.message : "Invalid JSON-RPC",
+      });
+    }
+
+    const authorized = this.#isAuthorized(request);
+    if (!authorized) {
+      this.#observe(
+        {
+          method: payload.method,
+          requestId: payload.id,
+          authorized: false,
+          outcome: "unauthorized",
+          params: summarizeParams(payload.method, payload.params),
+        },
+        generation,
+      );
+      return jsonRpcHttpError(401, "Unauthorized");
+    }
+
+    const fault = this.#matchingFault(payload.method);
+    if (fault === "rate_limit") {
+      this.#observeFault(payload, "rate_limited", generation);
+      return jsonRpcHttpError(429, "Rate limited", { "retry-after": "1" });
+    }
+    if (fault === "malformed_json") {
+      this.#observeFault(payload, "malformed", generation);
+      return new Response('{"jsonrpc":', {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (fault === "provider_error") {
+      this.#observeFault(payload, "provider_error", generation);
+      return jsonRpcResponse(payload.id, undefined, {
+        code: -32000,
+        message: "Synthetic provider failure",
+      });
+    }
+    if (fault === "stall") {
+      this.#observeFault(payload, "stalled", generation);
+      return new Promise<Response>((resolve) => {
+        const pending: PendingResponse = { generation, resolve };
+        this.#pendingResponses.add(pending);
+        request.signal.addEventListener(
+          "abort",
+          () => {
+            this.#pendingResponses.delete(pending);
+            this.#observeFault(payload, "cancelled", generation);
+            resolve(jsonRpcHttpError(499, "Client closed request"));
+          },
+          { once: true },
+        );
+      });
+    }
+
+    try {
+      const { result, outcome, transactionHash } =
+        await this.#dispatch(payload);
+      this.#observe(
+        {
+          method: payload.method,
+          requestId: payload.id,
+          authorized: true,
+          outcome,
+          params: summarizeParams(payload.method, payload.params),
+          ...(transactionHash ? { transactionHash } : {}),
+          ...(payload.method === "eth_sendRawTransaction"
+            ? { rawTransactionBytes: rawTransactionBytes(payload.params[0]) }
+            : {}),
+        },
+        generation,
+      );
+      return jsonRpcResponse(payload.id, result);
+    } catch (error) {
+      // error-policy:J1 the synthetic provider boundary translates execution
+      // failures into canonical JSON-RPC errors rather than successful results.
+      this.#observeFault(payload, "provider_error", generation);
+      return jsonRpcResponse(payload.id, undefined, {
+        code: -32000,
+        message:
+          error instanceof Error ? error.message : "RPC execution failed",
+      });
+    }
+  }
+
+  shutdown(): void {
+    for (const pending of this.#pendingResponses) {
+      pending.resolve(jsonRpcHttpError(503, "Synthetic RPC stopped"));
+    }
+    this.#pendingResponses.clear();
+  }
+
+  #loadSeed(): void {
+    this.#balances = new Map(
+      Object.entries(this.#seed.balances).map(([address, balance]) => [
+        normalizeAddress(address),
+        balance,
+      ]),
+    );
+    this.#nonces.clear();
+    this.#blockHashes.clear();
+    this.#blockHashes.set(
+      this.#blockNumber,
+      deterministicHash(
+        `generation:${this.#generation}:fork:0:block:${this.#blockNumber}`,
+      ),
+    );
+  }
+
+  #isAuthorized(request: Request): boolean {
+    if (!this.#seed.bearerToken) return true;
+    return (
+      request.headers.get("authorization") ===
+      `Bearer ${this.#seed.bearerToken}`
+    );
+  }
+
+  #matchingFault(method: string): EvmRpcMockFault | null {
+    if (!this.#fault) return null;
+    if (this.#fault.method && this.#fault.method !== method) return null;
+    return this.#fault.kind;
+  }
+
+  async #dispatch(payload: JsonRpcRequest): Promise<{
+    result: unknown;
+    outcome: "success" | "accepted" | "duplicate";
+    transactionHash?: Hex;
+  }> {
+    const success = (result: unknown) => ({
+      result,
+      outcome: "success" as const,
+    });
+    switch (payload.method) {
+      case "web3_clientVersion":
+        return success("elizaOS/synthetic-base/1.0");
+      case "eth_chainId":
+        return success(toQuantity(this.#seed.chainId));
+      case "eth_blockNumber":
+        return success(toQuantity(this.#blockNumber));
+      case "eth_getBalance":
+        return success(
+          toQuantity(
+            this.#balances.get(normalizeAddress(payload.params[0])) ?? 0n,
+          ),
+        );
+      case "eth_getTransactionCount":
+        return success(
+          toQuantity(
+            this.#nonces.get(normalizeAddress(payload.params[0])) ?? 0,
+          ),
+        );
+      case "eth_getBlockByNumber":
+        return success(this.#block(payload.params[0]));
+      case "eth_call":
+        return success("0x");
+      case "eth_estimateGas":
+        return success("0x5208");
+      case "eth_gasPrice":
+        return success("0x3b9aca00");
+      case "eth_maxPriorityFeePerGas":
+        return success("0x3b9aca00");
+      case "eth_feeHistory":
+        return success({
+          oldestBlock: toQuantity(this.#blockNumber),
+          baseFeePerGas: ["0x3b9aca00", "0x3b9aca00"],
+          gasUsedRatio: [0],
+          reward: [["0x3b9aca00"]],
+        });
+      case "eth_getCode":
+        return success("0x");
+      case "eth_sendRawTransaction":
+        return this.#submit(payload.params[0]);
+      case "eth_getTransactionReceipt":
+        return success(
+          this.#transactions.get(normalizeHash(payload.params[0]))?.receipt ??
+            null,
+        );
+      case "eth_getTransactionByHash": {
+        const transaction = this.#transactions.get(
+          normalizeHash(payload.params[0]),
+        );
+        return success(
+          transaction ? this.#transactionResponse(transaction) : null,
+        );
+      }
+      default:
+        throw new Error(`Method not found: ${payload.method}`);
+    }
+  }
+
+  async #submit(rawValue: unknown): Promise<{
+    result: Hex;
+    outcome: "accepted" | "duplicate";
+    transactionHash: Hex;
+  }> {
+    const raw = normalizeHash(rawValue);
+    const serialized = raw as TransactionSerialized;
+    const hash = keccak256(raw);
+    if (this.#transactions.has(hash)) {
+      return { result: hash, outcome: "duplicate", transactionHash: hash };
+    }
+    const parsed = parseTransaction(serialized);
+    if (parsed.chainId !== this.#seed.chainId) {
+      throw new Error(`Wrong chain ID: ${parsed.chainId ?? "missing"}`);
+    }
+    if (parsed.nonce === undefined) {
+      throw new Error("Signed transaction nonce is required");
+    }
+    const from = await recoverTransactionAddress({
+      serializedTransaction: serialized,
+    });
+    const transaction: StoredTransaction = {
+      hash,
+      raw,
+      from,
+      ...(parsed.to ? { to: parsed.to } : {}),
+      value: parsed.value ?? 0n,
+      nonce: parsed.nonce,
+      state: "pending",
+      receipt: null,
+    };
+    this.#transactions.set(hash, transaction);
+    return { result: hash, outcome: "accepted", transactionHash: hash };
+  }
+
+  #mineOne(): void {
+    this.#blockNumber += 1;
+    this.#timestamp += this.#seed.blockTimeSeconds;
+    const parentHash =
+      this.#blockHashes.get(this.#blockNumber - 1) ?? ZERO_HASH;
+    const blockHash = deterministicHash(
+      `generation:${this.#generation}:fork:${this.#fork}:block:${this.#blockNumber}:parent:${parentHash}`,
+    );
+    this.#blockHashes.set(this.#blockNumber, blockHash);
+    const effects: AppliedEffect[] = [];
+    for (const transaction of this.#transactions.values()) {
+      if (transaction.state !== "pending") continue;
+      const fromKey = normalizeAddress(transaction.from);
+      const toKey = transaction.to
+        ? normalizeAddress(transaction.to)
+        : undefined;
+      const previousFromBalance = this.#balances.get(fromKey) ?? 0n;
+      const previousToBalance = toKey
+        ? (this.#balances.get(toKey) ?? 0n)
+        : undefined;
+      const previousNonce = this.#nonces.get(fromKey) ?? 0;
+      const succeeds =
+        transaction.nonce === previousNonce &&
+        previousFromBalance >= transaction.value;
+      if (succeeds) {
+        this.#balances.set(fromKey, previousFromBalance - transaction.value);
+        if (toKey && previousToBalance !== undefined) {
+          this.#balances.set(toKey, previousToBalance + transaction.value);
+        }
+        this.#nonces.set(fromKey, previousNonce + 1);
+      }
+      effects.push({
+        transactionHash: transaction.hash,
+        from: transaction.from,
+        ...(transaction.to ? { to: transaction.to } : {}),
+        previousFromBalance,
+        ...(previousToBalance !== undefined ? { previousToBalance } : {}),
+        previousNonce,
+      });
+      transaction.state = "mined";
+      transaction.receipt = this.#receipt(transaction, blockHash, succeeds);
+    }
+    this.#blocks.push({ number: this.#blockNumber, hash: blockHash, effects });
+  }
+
+  #block(tag: unknown): Record<string, unknown> | null {
+    const number =
+      tag === "latest" ? this.#blockNumber : Number(BigInt(String(tag)));
+    if (number !== this.#blockNumber) return null;
+    const hash = this.#blockHashes.get(number) ?? ZERO_HASH;
+    return {
+      number: toQuantity(number),
+      hash,
+      parentHash: this.#blockHashes.get(number - 1) ?? ZERO_HASH,
+      nonce: "0x0000000000000000",
+      sha3Uncles: ZERO_HASH,
+      logsBloom: ZERO_BLOOM,
+      transactionsRoot: ZERO_HASH,
+      stateRoot: ZERO_HASH,
+      receiptsRoot: ZERO_HASH,
+      miner: ZERO_ADDRESS,
+      difficulty: "0x0",
+      totalDifficulty: "0x0",
+      extraData: "0x",
+      size: "0x1",
+      gasLimit: "0x1c9c380",
+      gasUsed: "0x0",
+      timestamp: toQuantity(this.#timestamp),
+      transactions: [],
+      uncles: [],
+      baseFeePerGas: "0x3b9aca00",
+      mixHash: ZERO_HASH,
+    };
+  }
+
+  #receipt(
+    transaction: StoredTransaction,
+    blockHash: Hex,
+    succeeds: boolean,
+  ): Record<string, unknown> {
+    return {
+      transactionHash: transaction.hash,
+      transactionIndex: "0x0",
+      blockHash,
+      blockNumber: toQuantity(this.#blockNumber),
+      from: transaction.from,
+      to: transaction.to ?? null,
+      cumulativeGasUsed: "0x5208",
+      gasUsed: "0x5208",
+      contractAddress: null,
+      logs: [],
+      logsBloom: ZERO_BLOOM,
+      status: succeeds ? "0x1" : "0x0",
+      effectiveGasPrice: "0x3b9aca00",
+      type: "0x2",
+    };
+  }
+
+  #transactionResponse(
+    transaction: StoredTransaction,
+  ): Record<string, unknown> {
+    return {
+      hash: transaction.hash,
+      from: transaction.from,
+      to: transaction.to ?? null,
+      nonce: toQuantity(transaction.nonce),
+      value: toQuantity(transaction.value),
+      gas: "0x5208",
+      gasPrice: "0x3b9aca00",
+      input: "0x",
+      blockHash: transaction.receipt?.blockHash ?? null,
+      blockNumber: transaction.receipt?.blockNumber ?? null,
+      transactionIndex: transaction.receipt ? "0x0" : null,
+      type: "0x2",
+      chainId: toQuantity(this.#seed.chainId),
+      v: "0x0",
+      r: ZERO_HASH,
+      s: ZERO_HASH,
+    };
+  }
+
+  #observeFault(
+    payload: JsonRpcRequest,
+    outcome: EvmRpcMockObservation["outcome"],
+    generation: number,
+  ): void {
+    this.#observe(
+      {
+        method: payload.method,
+        requestId: payload.id,
+        authorized: true,
+        outcome,
+        params: summarizeParams(payload.method, payload.params),
+      },
+      generation,
+    );
+  }
+
+  #observe(
+    observation: Omit<EvmRpcMockObservation, "order" | "generation">,
+    generation: number,
+  ): void {
+    if (generation !== this.#generation) return;
+    this.#observations.push({
+      ...observation,
+      generation,
+      order: this.#observations.length + 1,
+    });
+  }
+}
+
+export async function startEvmRpcMock(
+  seed: Partial<EvmRpcMockSeed> = {},
+): Promise<{
+  url: string;
+  store: EvmRpcMockStore;
+  stop(): Promise<void>;
+}> {
+  const store = new EvmRpcMockStore(seed);
+  const server = await startFetchServer((request) => store.handle(request));
+  return {
+    url: `http://${server.hostname}:${server.port}`,
+    store,
+    stop: async () => {
+      store.shutdown();
+      await server.stop();
+    },
+  };
+}
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  method: string;
+  params: unknown[];
+}
+
+function parseRequest(value: unknown): JsonRpcRequest {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("JSON-RPC request must be an object");
+  }
+  const input = value as Record<string, unknown>;
+  if (input.jsonrpc !== "2.0" || typeof input.method !== "string") {
+    throw new Error("Invalid JSON-RPC request envelope");
+  }
+  if (input.params !== undefined && !Array.isArray(input.params)) {
+    throw new Error("JSON-RPC params must be an array");
+  }
+  const id = input.id;
+  if (id !== null && typeof id !== "string" && typeof id !== "number") {
+    throw new Error("JSON-RPC id must be string, number, or null");
+  }
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: input.method,
+    params: input.params ?? [],
+  };
+}
+
+function normalizeSeed(seed: Partial<EvmRpcMockSeed>): EvmRpcMockSeed {
+  return {
+    chainId: seed.chainId ?? DEFAULT_SEED.chainId,
+    blockNumber: seed.blockNumber ?? DEFAULT_SEED.blockNumber,
+    timestamp: seed.timestamp ?? DEFAULT_SEED.timestamp,
+    blockTimeSeconds: seed.blockTimeSeconds ?? DEFAULT_SEED.blockTimeSeconds,
+    balances: Object.fromEntries(
+      Object.entries(seed.balances ?? DEFAULT_SEED.balances).map(
+        ([address, balance]) => [normalizeAddress(address), BigInt(balance)],
+      ),
+    ),
+    ...(seed.bearerToken ? { bearerToken: seed.bearerToken } : {}),
+  };
+}
+
+function normalizeAddress(value: unknown): string {
+  if (typeof value !== "string" || !/^0x[0-9a-fA-F]{40}$/.test(value)) {
+    throw new Error("Expected a 20-byte EVM address");
+  }
+  return value.toLowerCase();
+}
+
+function normalizeHash(value: unknown): Hex {
+  if (typeof value !== "string" || !/^0x[0-9a-fA-F]+$/.test(value)) {
+    throw new Error("Expected hex data");
+  }
+  return value.toLowerCase() as Hex;
+}
+
+function toQuantity(value: bigint | number): Hex {
+  return `0x${BigInt(value).toString(16)}`;
+}
+
+function deterministicHash(input: string): Hex {
+  return `0x${createHash("sha256").update(input).digest("hex")}`;
+}
+
+function summarizeParams(method: string, params: unknown[]): unknown[] {
+  if (method !== "eth_sendRawTransaction") return structuredClone(params);
+  return [{ rawTransactionBytes: rawTransactionBytes(params[0]) }];
+}
+
+function rawTransactionBytes(value: unknown): number {
+  return typeof value === "string" && /^0x[0-9a-fA-F]*$/.test(value)
+    ? (value.length - 2) / 2
+    : 0;
+}
+
+function jsonRpcResponse(
+  id: string | number | null,
+  result?: unknown,
+  error?: { code: number; message: string },
+): Response {
+  return Response.json({
+    jsonrpc: "2.0",
+    id,
+    ...(error ? { error } : { result }),
+  });
+}
+
+function jsonRpcHttpError(
+  status: number,
+  message: string,
+  headers: Record<string, string> = {},
+): Response {
+  return Response.json(
+    { error: message },
+    { status, headers: { ...headers, "content-type": "application/json" } },
+  );
+}

--- a/packages/cloud/test-mocks/src/wallet-evm/index.ts
+++ b/packages/cloud/test-mocks/src/wallet-evm/index.ts
@@ -18,7 +18,8 @@ export type EvmRpcMockFault =
   | "rate_limit"
   | "provider_error"
   | "malformed_json"
-  | "stall";
+  | "stall"
+  | "stall_after_accept";
 
 export interface EvmRpcMockSeed {
   chainId: number;
@@ -26,6 +27,7 @@ export interface EvmRpcMockSeed {
   timestamp: number;
   blockTimeSeconds: number;
   balances: Record<string, bigint>;
+  revertRecipients: string[];
   bearerToken?: string;
 }
 
@@ -49,6 +51,7 @@ export interface EvmRpcMockObservation {
   params?: unknown[];
   transactionHash?: Hex;
   rawTransactionBytes?: number;
+  responseFault?: "stalled";
 }
 
 interface StoredTransaction {
@@ -79,7 +82,7 @@ interface MinedBlock {
 
 interface PendingResponse {
   generation: number;
-  resolve: (response: Response) => void;
+  settle: (response: Response) => void;
 }
 
 const DEFAULT_SEED: EvmRpcMockSeed = {
@@ -88,6 +91,7 @@ const DEFAULT_SEED: EvmRpcMockSeed = {
   timestamp: 1_800_000_000,
   blockTimeSeconds: 2,
   balances: {},
+  revertRecipients: [],
 };
 
 const ZERO_HASH = `0x${"0".repeat(64)}` as Hex;
@@ -131,7 +135,7 @@ export class EvmRpcMockStore {
   reset(seed: Partial<EvmRpcMockSeed> = {}): void {
     const staleResponses = [...this.#pendingResponses];
     this.#generation += 1;
-    this.#seed = normalizeSeed(seed);
+    this.#seed = normalizeSeed(seed, this.#seed);
     this.#blockNumber = this.#seed.blockNumber;
     this.#timestamp = this.#seed.timestamp;
     this.#fork = 0;
@@ -142,7 +146,7 @@ export class EvmRpcMockStore {
     this.#pendingResponses.clear();
     this.#loadSeed();
     for (const pending of staleResponses) {
-      pending.resolve(
+      pending.settle(
         jsonRpcHttpError(503, "Synthetic chain environment reset"),
       );
     }
@@ -288,19 +292,7 @@ export class EvmRpcMockStore {
     }
     if (fault === "stall") {
       this.#observeFault(payload, "stalled", generation);
-      return new Promise<Response>((resolve) => {
-        const pending: PendingResponse = { generation, resolve };
-        this.#pendingResponses.add(pending);
-        request.signal.addEventListener(
-          "abort",
-          () => {
-            this.#pendingResponses.delete(pending);
-            this.#observeFault(payload, "cancelled", generation);
-            resolve(jsonRpcHttpError(499, "Client closed request"));
-          },
-          { once: true },
-        );
-      });
+      return this.#stall(request, payload, generation);
     }
 
     try {
@@ -317,9 +309,19 @@ export class EvmRpcMockStore {
           ...(payload.method === "eth_sendRawTransaction"
             ? { rawTransactionBytes: rawTransactionBytes(payload.params[0]) }
             : {}),
+          ...(fault === "stall_after_accept" &&
+          payload.method === "eth_sendRawTransaction"
+            ? { responseFault: "stalled" as const }
+            : {}),
         },
         generation,
       );
+      if (
+        fault === "stall_after_accept" &&
+        payload.method === "eth_sendRawTransaction"
+      ) {
+        return this.#stall(request, payload, generation);
+      }
       return jsonRpcResponse(payload.id, result);
     } catch (error) {
       // error-policy:J1 the synthetic provider boundary translates execution
@@ -335,7 +337,7 @@ export class EvmRpcMockStore {
 
   shutdown(): void {
     for (const pending of this.#pendingResponses) {
-      pending.resolve(jsonRpcHttpError(503, "Synthetic RPC stopped"));
+      pending.settle(jsonRpcHttpError(503, "Synthetic RPC stopped"));
     }
     this.#pendingResponses.clear();
   }
@@ -352,7 +354,7 @@ export class EvmRpcMockStore {
     this.#blockHashes.set(
       this.#blockNumber,
       deterministicHash(
-        `generation:${this.#generation}:fork:0:block:${this.#blockNumber}`,
+        `chain:${this.#seed.chainId}:block:${this.#blockNumber}:timestamp:${this.#timestamp}`,
       ),
     );
   }
@@ -422,12 +424,12 @@ export class EvmRpcMockStore {
         return this.#submit(payload.params[0]);
       case "eth_getTransactionReceipt":
         return success(
-          this.#transactions.get(normalizeHash(payload.params[0]))?.receipt ??
-            null,
+          this.#transactions.get(normalizeTransactionHash(payload.params[0]))
+            ?.receipt ?? null,
         );
       case "eth_getTransactionByHash": {
         const transaction = this.#transactions.get(
-          normalizeHash(payload.params[0]),
+          normalizeTransactionHash(payload.params[0]),
         );
         return success(
           transaction ? this.#transactionResponse(transaction) : null,
@@ -443,7 +445,7 @@ export class EvmRpcMockStore {
     outcome: "accepted" | "duplicate";
     transactionHash: Hex;
   }> {
-    const raw = normalizeHash(rawValue);
+    const raw = normalizeRawTransaction(rawValue);
     const serialized = raw as TransactionSerialized;
     const hash = keccak256(raw);
     if (this.#transactions.has(hash)) {
@@ -459,6 +461,26 @@ export class EvmRpcMockStore {
     const from = await recoverTransactionAddress({
       serializedTransaction: serialized,
     });
+    const fromKey = normalizeAddress(from);
+    const pendingFrom = [...this.#transactions.values()].filter(
+      (transaction) =>
+        transaction.state === "pending" &&
+        normalizeAddress(transaction.from) === fromKey,
+    );
+    const expectedNonce = (this.#nonces.get(fromKey) ?? 0) + pendingFrom.length;
+    if (parsed.nonce !== expectedNonce) {
+      throw new Error(
+        `Invalid nonce: expected ${expectedNonce}, received ${parsed.nonce}`,
+      );
+    }
+    const reservedValue = pendingFrom.reduce(
+      (total, transaction) => total + transaction.value,
+      0n,
+    );
+    const balance = this.#balances.get(fromKey) ?? 0n;
+    if (balance < reservedValue + (parsed.value ?? 0n)) {
+      throw new Error("Insufficient funds for transaction value");
+    }
     const transaction: StoredTransaction = {
       hash,
       raw,
@@ -479,7 +501,7 @@ export class EvmRpcMockStore {
     const parentHash =
       this.#blockHashes.get(this.#blockNumber - 1) ?? ZERO_HASH;
     const blockHash = deterministicHash(
-      `generation:${this.#generation}:fork:${this.#fork}:block:${this.#blockNumber}:parent:${parentHash}`,
+      `chain:${this.#seed.chainId}:fork:${this.#fork}:block:${this.#blockNumber}:parent:${parentHash}`,
     );
     this.#blockHashes.set(this.#blockNumber, blockHash);
     const effects: AppliedEffect[] = [];
@@ -494,15 +516,21 @@ export class EvmRpcMockStore {
         ? (this.#balances.get(toKey) ?? 0n)
         : undefined;
       const previousNonce = this.#nonces.get(fromKey) ?? 0;
-      const succeeds =
+      const admitted =
         transaction.nonce === previousNonce &&
         previousFromBalance >= transaction.value;
+      const executionReverted =
+        transaction.to !== undefined &&
+        this.#seed.revertRecipients.includes(normalizeAddress(transaction.to));
+      const succeeds = admitted && !executionReverted;
+      if (admitted) {
+        this.#nonces.set(fromKey, previousNonce + 1);
+      }
       if (succeeds) {
         this.#balances.set(fromKey, previousFromBalance - transaction.value);
         if (toKey && previousToBalance !== undefined) {
           this.#balances.set(toKey, previousToBalance + transaction.value);
         }
-        this.#nonces.set(fromKey, previousNonce + 1);
       }
       effects.push({
         transactionHash: transaction.hash,
@@ -622,6 +650,32 @@ export class EvmRpcMockStore {
       order: this.#observations.length + 1,
     });
   }
+
+  #stall(
+    request: Request,
+    payload: JsonRpcRequest,
+    generation: number,
+  ): Promise<Response> {
+    return new Promise<Response>((resolve) => {
+      let settled = false;
+      let pending: PendingResponse;
+      const onAbort = () => {
+        this.#observeFault(payload, "cancelled", generation);
+        pending.settle(jsonRpcHttpError(499, "Client closed request"));
+      };
+      const settle = (response: Response) => {
+        if (settled) return;
+        settled = true;
+        request.signal.removeEventListener("abort", onAbort);
+        this.#pendingResponses.delete(pending);
+        resolve(response);
+      };
+      pending = { generation, settle };
+      this.#pendingResponses.add(pending);
+      if (request.signal.aborted) onAbort();
+      else request.signal.addEventListener("abort", onAbort, { once: true });
+    });
+  }
 }
 
 export async function startEvmRpcMock(
@@ -673,18 +727,26 @@ function parseRequest(value: unknown): JsonRpcRequest {
   };
 }
 
-function normalizeSeed(seed: Partial<EvmRpcMockSeed>): EvmRpcMockSeed {
+function normalizeSeed(
+  seed: Partial<EvmRpcMockSeed>,
+  base: EvmRpcMockSeed = DEFAULT_SEED,
+): EvmRpcMockSeed {
   return {
-    chainId: seed.chainId ?? DEFAULT_SEED.chainId,
-    blockNumber: seed.blockNumber ?? DEFAULT_SEED.blockNumber,
-    timestamp: seed.timestamp ?? DEFAULT_SEED.timestamp,
-    blockTimeSeconds: seed.blockTimeSeconds ?? DEFAULT_SEED.blockTimeSeconds,
+    chainId: seed.chainId ?? base.chainId,
+    blockNumber: seed.blockNumber ?? base.blockNumber,
+    timestamp: seed.timestamp ?? base.timestamp,
+    blockTimeSeconds: seed.blockTimeSeconds ?? base.blockTimeSeconds,
     balances: Object.fromEntries(
-      Object.entries(seed.balances ?? DEFAULT_SEED.balances).map(
+      Object.entries(seed.balances ?? base.balances).map(
         ([address, balance]) => [normalizeAddress(address), BigInt(balance)],
       ),
     ),
-    ...(seed.bearerToken ? { bearerToken: seed.bearerToken } : {}),
+    revertRecipients: (seed.revertRecipients ?? base.revertRecipients).map(
+      normalizeAddress,
+    ),
+    ...((seed.bearerToken ?? base.bearerToken)
+      ? { bearerToken: seed.bearerToken ?? base.bearerToken }
+      : {}),
   };
 }
 
@@ -695,9 +757,16 @@ function normalizeAddress(value: unknown): string {
   return value.toLowerCase();
 }
 
-function normalizeHash(value: unknown): Hex {
-  if (typeof value !== "string" || !/^0x[0-9a-fA-F]+$/.test(value)) {
-    throw new Error("Expected hex data");
+function normalizeRawTransaction(value: unknown): Hex {
+  if (typeof value !== "string" || !/^0x(?:[0-9a-fA-F]{2})+$/.test(value)) {
+    throw new Error("Expected non-empty, even-length raw transaction bytes");
+  }
+  return value.toLowerCase() as Hex;
+}
+
+function normalizeTransactionHash(value: unknown): Hex {
+  if (typeof value !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(value)) {
+    throw new Error("Expected a 32-byte transaction hash");
   }
   return value.toLowerCase() as Hex;
 }

--- a/packages/cloud/test-mocks/test/fetch-server.node.test.ts
+++ b/packages/cloud/test-mocks/test/fetch-server.node.test.ts
@@ -1,0 +1,64 @@
+/** Proves the shared HTTP adapter preserves streaming and cancellation in a real Node subprocess. */
+
+import { afterEach, expect, it } from "bun:test";
+
+const children: Bun.Subprocess[] = [];
+
+afterEach(async () => {
+  for (const child of children.splice(0)) {
+    child.kill("SIGTERM");
+    await child.exited;
+  }
+});
+
+async function readLine(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<string> {
+  const decoder = new TextDecoder();
+  let line = "";
+  while (!line.includes("\n")) {
+    const { done, value } = await reader.read();
+    if (done) throw new Error("Node fixture exited before emitting a line");
+    line += decoder.decode(value, { stream: true });
+  }
+  return line.slice(0, line.indexOf("\n"));
+}
+
+it("streams, aborts disconnected work, and redacts adapter failures", async () => {
+  const child = Bun.spawn(
+    [
+      "node",
+      "--experimental-strip-types",
+      "test/fixtures/fetch-server-node-stream.ts",
+    ],
+    {
+      cwd: import.meta.dir.replace(/\/test$/, ""),
+      stdout: "pipe",
+      stderr: "inherit",
+    },
+  );
+  children.push(child);
+  const stdout = child.stdout.getReader();
+  const port = Number(await readLine(stdout));
+  expect(Number.isInteger(port)).toBe(true);
+
+  const startedAt = performance.now();
+  const controller = new AbortController();
+  const response = await fetch(`http://127.0.0.1:${port}/stream`, {
+    signal: controller.signal,
+  });
+  const body = response.body?.getReader();
+  if (!body) throw new Error("Node fixture returned no response body");
+  const first = await body.read();
+  expect(new TextDecoder().decode(first.value)).toBe("first\n");
+  expect(performance.now() - startedAt).toBeLessThan(750);
+
+  controller.abort("test disconnect");
+  expect(await readLine(stdout)).toBe("aborted");
+
+  const failed = await fetch(`http://127.0.0.1:${port}/throw`);
+  expect(failed.status).toBe(500);
+  const failureBody = await failed.text();
+  expect(failureBody).toBe("mock server error");
+  expect(failureBody).not.toContain("NODE_ADAPTER_SECRET");
+});

--- a/packages/cloud/test-mocks/test/fixtures/fetch-server-node-stream.ts
+++ b/packages/cloud/test-mocks/test/fixtures/fetch-server-node-stream.ts
@@ -1,0 +1,43 @@
+/** Runs the Node fallback HTTP adapter for subprocess streaming and cancellation proof. */
+
+import { startFetchServer } from "../../src/fetch-server.ts";
+
+const encoder = new TextEncoder();
+const server = await startFetchServer(
+  (request) => {
+    if (new URL(request.url).pathname === "/throw") {
+      throw new Error("NODE_ADAPTER_SECRET_do-not-reflect_9e37");
+    }
+    return new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode("first\n"));
+          const timer = setTimeout(() => {
+            controller.enqueue(encoder.encode("second\n"));
+            controller.close();
+          }, 1_000);
+          request.signal.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              process.stdout.write("aborted\n");
+              controller.error(request.signal.reason);
+            },
+            { once: true },
+          );
+        },
+      }),
+      { headers: { "content-type": "text/plain" } },
+    );
+  },
+  { hostname: "127.0.0.1", port: 0 },
+);
+
+process.stdout.write(`${server.port}\n`);
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.once(signal, async () => {
+    await server.stop();
+    process.exit(0);
+  });
+}

--- a/plugins/plugin-wallet/AGENTS.md
+++ b/plugins/plugin-wallet/AGENTS.md
@@ -238,6 +238,11 @@ Extend `src/analytics/birdeye/service.ts`. The service proxies all calls through
 - **Auto-enable.** `auto-enable.ts` must remain a lightweight env-read module with no transitive plugin imports. The auto-enable engine loads it on every agent boot.
 - **UI surface is subpath-only.** The package root (`.`) is the server barrel and must never import `src/ui/**`. Hosts import `@elizaos/plugin-wallet/ui` (components/barrel) or rely on the manifest-driven renderer boot (`elizaos.appRegister: "register"` → `src/register.ts`). `src/ui/register-routes.ts` must execute exactly once; duplicate imports create duplicate shell pages.
 - **`walletAppPlugin` naming.** The UI descriptor is named `@elizaos/plugin-wallet:ui` with `packageName: "@elizaos/plugin-wallet"` so the views registry resolves the package dir while the app-route loader id stays distinct from the runtime `wallet` plugin. `normalizeAppRoutePluginId` strips `:ui`, so `ELIZA_SKIP_APP_ROUTE_PLUGINS=wallet` skips it.
+- **Offline EVM protocol proof.** Exercise `WalletProvider`'s real viem HTTP
+  clients against `@elizaos/cloud-test-mocks/wallet-evm`; do not replace
+  `PublicClient`, `WalletClient`, or their request methods when claiming JSON-RPC
+  integration evidence. The synthetic chain's receipts prove only its explicit
+  native-transfer state transition, never general EVM execution.
 - **View bundle.** `dist/views/bundle.js` is built by `vite.config.views.ts` (entry `src/ui/wallet-view-bundle.ts`, export `InventoryView`), not by the Node build. Both must run for a complete dist.
 
 ## Verification

--- a/plugins/plugin-wallet/CLAUDE.md
+++ b/plugins/plugin-wallet/CLAUDE.md
@@ -238,6 +238,11 @@ Extend `src/analytics/birdeye/service.ts`. The service proxies all calls through
 - **Auto-enable.** `auto-enable.ts` must remain a lightweight env-read module with no transitive plugin imports. The auto-enable engine loads it on every agent boot.
 - **UI surface is subpath-only.** The package root (`.`) is the server barrel and must never import `src/ui/**`. Hosts import `@elizaos/plugin-wallet/ui` (components/barrel) or rely on the manifest-driven renderer boot (`elizaos.appRegister: "register"` → `src/register.ts`). `src/ui/register-routes.ts` must execute exactly once; duplicate imports create duplicate shell pages.
 - **`walletAppPlugin` naming.** The UI descriptor is named `@elizaos/plugin-wallet:ui` with `packageName: "@elizaos/plugin-wallet"` so the views registry resolves the package dir while the app-route loader id stays distinct from the runtime `wallet` plugin. `normalizeAppRoutePluginId` strips `:ui`, so `ELIZA_SKIP_APP_ROUTE_PLUGINS=wallet` skips it.
+- **Offline EVM protocol proof.** Exercise `WalletProvider`'s real viem HTTP
+  clients against `@elizaos/cloud-test-mocks/wallet-evm`; do not replace
+  `PublicClient`, `WalletClient`, or their request methods when claiming JSON-RPC
+  integration evidence. The synthetic chain's receipts prove only its explicit
+  native-transfer state transition, never general EVM execution.
 - **View bundle.** `dist/views/bundle.js` is built by `vite.config.views.ts` (entry `src/ui/wallet-view-bundle.ts`, export `InventoryView`), not by the Node build. Both must run for a complete dist.
 
 ## Verification

--- a/plugins/plugin-wallet/README.md
+++ b/plugins/plugin-wallet/README.md
@@ -99,6 +99,9 @@ HTTP transports at the resettable Base simulator exported by
 balance, nonce, and call reads; ephemeral local signing and raw submission;
 deduplication; deterministic mining/time; effect-backed and reverted receipts;
 reorg rollback/re-inclusion; faults; reset isolation; and redacted readback.
+`WalletProvider` also translates raw-transaction submission failures into
+stable typed EVM errors so viem cannot include signed request bytes or provider
+credentials in public error messages.
 It does not claim contract execution, gas accounting, multichain coverage, or a
 real-provider transaction.
 

--- a/plugins/plugin-wallet/README.md
+++ b/plugins/plugin-wallet/README.md
@@ -91,6 +91,17 @@ All on-chain writes (`transfer`, `swap`, `bridge`, `gov`, `pump_fun_buy`) requir
 
 `src/audit/audit-log.ts` defines `AuditLogRow` plus hash-chain helpers for action validate/handler lifecycle events and signing requests. Runtime callers own where those rows are stored.
 
+## Offline EVM protocol integration
+
+The wallet EVM integration suite points the production `WalletProvider` viem
+HTTP transports at the resettable Base simulator exported by
+`@elizaos/cloud-test-mocks/wallet-evm`. It covers authenticated chain, block,
+balance, nonce, and call reads; ephemeral local signing and raw submission;
+deduplication; deterministic mining/time; effect-backed and reverted receipts;
+reorg rollback/re-inclusion; faults; reset isolation; and redacted readback.
+It does not claim contract execution, gas accounting, multichain coverage, or a
+real-provider transaction.
+
 ## SDK
 
 `src/sdk/` provides lower-level ERC-6551 token-bound account primitives, x402 micropayment protocol types, CCTP bridge helpers, and spend-policy tooling. These are primarily for plugin internals but are re-exported from the package barrel for external use. SDK source is MIT-licensed (attribution: agent-wallet-sdk); see `SDK-LICENSE`.

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/integration/protocol-mock.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/integration/protocol-mock.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Drives the production WalletProvider viem clients through a resettable local
+ * Base JSON-RPC simulator; no wallet or RPC client methods are replaced.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { afterEach, describe, expect, test } from "vitest";
+import { startEvmRpcMock } from "../../../../../../../packages/cloud/test-mocks/src/wallet-evm";
+import { WalletProvider } from "../../providers/wallet";
+
+const RECIPIENT = "0x2222222222222222222222222222222222222222" as const;
+const runningMocks: Awaited<ReturnType<typeof startEvmRpcMock>>[] = [];
+
+async function startMock(
+  balances: Record<string, bigint> = {},
+  bearerToken = "synthetic-rpc-token"
+) {
+  const mock = await startEvmRpcMock({ balances, bearerToken });
+  runningMocks.push(mock);
+  return mock;
+}
+
+function providerFor(
+  url: string,
+  account: ReturnType<typeof privateKeyToAccount>,
+  bearerToken = "synthetic-rpc-token"
+): WalletProvider {
+  const chain = WalletProvider.genChainFromName("base");
+  return new WalletProvider(
+    account,
+    {} as IAgentRuntime,
+    { base: chain },
+    {
+      base: {
+        rpcUrl: url,
+        headers: { Authorization: `Bearer ${bearerToken}` },
+      },
+    }
+  );
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("Timed out awaiting RPC state");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(runningMocks.splice(0).map((mock) => mock.stop()));
+});
+
+describe("wallet EVM JSON-RPC protocol mock", () => {
+  test("reads chain state, applies one signed transfer, deduplicates, and rolls it back on reorg", async () => {
+    const account = privateKeyToAccount(generatePrivateKey());
+    const openingBalance = 10_000_000_000_000_000n;
+    const transferValue = 1_000_000_000_000_000n;
+    const mock = await startMock({
+      [account.address]: openingBalance,
+      [RECIPIENT]: 0n,
+    });
+    const provider = providerFor(mock.url, account);
+    const publicClient = provider.getPublicClient("base");
+    const walletClient = provider.getWalletClient("base");
+
+    await expect(publicClient.getChainId()).resolves.toBe(8453);
+    await expect(publicClient.getBlockNumber()).resolves.toBe(100n);
+    const block = await publicClient.getBlock({ blockTag: "latest" });
+    expect(block.number).toBe(100n);
+    expect(block.timestamp).toBe(1_800_000_000n);
+    await expect(publicClient.getBalance({ address: account.address })).resolves.toBe(
+      openingBalance
+    );
+    await expect(
+      publicClient.call({
+        account: account.address,
+        to: RECIPIENT,
+        data: "0x",
+      })
+    ).resolves.toMatchObject({ data: undefined });
+
+    const raw = await account.signTransaction({
+      chainId: 8453,
+      type: "eip1559",
+      nonce: 0,
+      gas: 21_000n,
+      maxFeePerGas: 2_000_000_000n,
+      maxPriorityFeePerGas: 1_000_000_000n,
+      to: RECIPIENT,
+      value: transferValue,
+    });
+    const hash = await walletClient.sendRawTransaction({
+      serializedTransaction: raw,
+    });
+    await expect(walletClient.sendRawTransaction({ serializedTransaction: raw })).resolves.toBe(
+      hash
+    );
+    await expect(
+      publicClient.request({
+        method: "eth_getTransactionReceipt",
+        params: [hash],
+      })
+    ).resolves.toBeNull();
+
+    mock.store.mine();
+    const firstReceipt = await publicClient.getTransactionReceipt({ hash });
+    expect(firstReceipt.status).toBe("success");
+    await expect(publicClient.getBalance({ address: account.address })).resolves.toBe(
+      openingBalance - transferValue
+    );
+    await expect(publicClient.getBalance({ address: RECIPIENT })).resolves.toBe(transferValue);
+    await expect(publicClient.getTransactionCount({ address: account.address })).resolves.toBe(1);
+    expect(mock.store.readback()).toMatchObject({
+      blockNumber: 101,
+      timestamp: 1_800_000_002,
+      transactions: [{ hash, state: "mined", value: transferValue.toString() }],
+    });
+
+    mock.store.reorg(1);
+    await expect(
+      publicClient.request({
+        method: "eth_getTransactionReceipt",
+        params: [hash],
+      })
+    ).resolves.toBeNull();
+    await expect(publicClient.getBalance({ address: account.address })).resolves.toBe(
+      openingBalance
+    );
+    await expect(publicClient.getBalance({ address: RECIPIENT })).resolves.toBe(0n);
+    mock.store.mine();
+    const replacementReceipt = await publicClient.getTransactionReceipt({ hash });
+    expect(replacementReceipt.status).toBe("success");
+    expect(replacementReceipt.blockHash).not.toBe(firstReceipt.blockHash);
+
+    const readback = mock.store.readback();
+    expect(
+      readback.observations
+        .filter((entry) => entry.method === "eth_sendRawTransaction")
+        .map((entry) => entry.outcome)
+    ).toEqual(["accepted", "duplicate"]);
+    expect(JSON.stringify(readback)).not.toContain(raw);
+    expect(JSON.stringify(readback)).not.toContain("synthetic-rpc-token");
+  });
+
+  test("mines an explicit reverted receipt without applying a fabricated effect", async () => {
+    const account = privateKeyToAccount(generatePrivateKey());
+    const mock = await startMock({ [account.address]: 10n, [RECIPIENT]: 0n });
+    const provider = providerFor(mock.url, account);
+    const publicClient = provider.getPublicClient("base");
+    const walletClient = provider.getWalletClient("base");
+    const raw = await account.signTransaction({
+      chainId: 8453,
+      type: "eip1559",
+      nonce: 0,
+      gas: 21_000n,
+      maxFeePerGas: 2_000_000_000n,
+      maxPriorityFeePerGas: 1_000_000_000n,
+      to: RECIPIENT,
+      value: 11n,
+    });
+    const hash = await walletClient.sendRawTransaction({
+      serializedTransaction: raw,
+    });
+
+    mock.store.mine();
+
+    await expect(publicClient.getTransactionReceipt({ hash })).resolves.toMatchObject({
+      status: "reverted",
+    });
+    await expect(publicClient.getBalance({ address: account.address })).resolves.toBe(10n);
+    await expect(publicClient.getBalance({ address: RECIPIENT })).resolves.toBe(0n);
+  });
+
+  test("enforces synthetic auth without retaining credentials", async () => {
+    const account = privateKeyToAccount(generatePrivateKey());
+    const mock = await startMock({}, "expected-synthetic-token");
+    const client = providerFor(mock.url, account, "wrong-synthetic-token").getPublicClient("base");
+
+    await expect(client.getChainId()).rejects.toThrow();
+    expect(mock.store.readback().observations).toContainEqual(
+      expect.objectContaining({
+        method: "eth_chainId",
+        authorized: false,
+        outcome: "unauthorized",
+      })
+    );
+    const serialized = JSON.stringify(mock.store.readback());
+    expect(serialized).not.toContain("expected-synthetic-token");
+    expect(serialized).not.toContain("wrong-synthetic-token");
+  });
+
+  test("surfaces rate-limit, provider, malformed, and timeout failures from real HTTP", async () => {
+    const account = privateKeyToAccount(generatePrivateKey());
+    const mock = await startMock();
+    const client = providerFor(mock.url, account).getPublicClient("base");
+
+    mock.store.setFault("rate_limit", "eth_blockNumber");
+    await expect(client.getBlockNumber()).rejects.toThrow();
+    mock.store.setFault("provider_error", "eth_blockNumber");
+    await expect(client.getBlockNumber()).rejects.toThrow("Synthetic provider failure");
+    mock.store.setFault("malformed_json", "eth_blockNumber");
+    await expect(client.getBlockNumber()).rejects.toThrow();
+    mock.store.setFault("stall", "eth_blockNumber");
+    await expect(client.getBlockNumber()).rejects.toThrow();
+    expect(
+      mock.store
+        .readback()
+        .observations.filter((entry) => entry.method === "eth_blockNumber")
+        .map((entry) => entry.outcome),
+    ).toEqual(
+      expect.arrayContaining([
+        "rate_limited",
+        "provider_error",
+        "malformed",
+        "stalled",
+      ]),
+    );
+    mock.store.reset();
+    expect(mock.store.pendingResponseCount).toBe(0);
+  }, 10_000);
+
+  test("generation-fences a stalled request across reset", async () => {
+    const account = privateKeyToAccount(generatePrivateKey());
+    const mock = await startMock();
+    const client = providerFor(mock.url, account).getPublicClient("base");
+    mock.store.setFault("stall", "eth_blockNumber");
+    const stalled = client.getBlockNumber();
+    await waitFor(() => mock.store.pendingResponseCount === 1);
+    const staleGeneration = mock.store.generation;
+
+    mock.store.reset({ blockNumber: 700, timestamp: 1_900_000_000 });
+
+    await expect(stalled).rejects.toThrow();
+    expect(mock.store.readback()).toMatchObject({
+      generation: staleGeneration + 1,
+      blockNumber: 700,
+      timestamp: 1_900_000_000,
+      fault: null,
+      transactions: [],
+      observations: [],
+    });
+    expect(mock.store.pendingResponseCount).toBe(0);
+  });
+});

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/integration/protocol-mock.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/integration/protocol-mock.test.ts
@@ -6,7 +6,10 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { afterEach, describe, expect, test } from "vitest";
-import { startEvmRpcMock } from "../../../../../../../packages/cloud/test-mocks/src/wallet-evm";
+import {
+  EVM_RPC_MAX_REQUEST_BYTES,
+  startEvmRpcMock,
+} from "../../../../../../../packages/cloud/test-mocks/src/wallet-evm";
 import { WalletProvider } from "../../providers/wallet";
 
 const RECIPIENT = "0x2222222222222222222222222222222222222222" as const;
@@ -313,6 +316,71 @@ describe("wallet EVM JSON-RPC protocol mock", () => {
     ).toEqual(expect.arrayContaining(["rate_limited", "provider_error", "malformed"]));
     mock.store.reset();
     expect(mock.store.pendingResponseCount).toBe(0);
+  });
+
+  test("bounds request admission and never reflects raw transactions or credentials", async () => {
+    const bearerToken = "BOUNDARY_BEARER_SECRET_7f92";
+    const mock = await startMock({}, bearerToken);
+    const rpc = (
+      body: BodyInit,
+      headers: Record<string, string> = { "content-type": "application/json" }
+    ) =>
+      fetch(mock.url, {
+        method: "POST",
+        headers: { authorization: `Bearer ${bearerToken}`, ...headers },
+        body,
+      });
+    const envelope = (params: unknown[]) =>
+      JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_sendRawTransaction", params });
+
+    const wrongType = await rpc(envelope([]), { "content-type": "text/plain" });
+    expect(wrongType.status).toBe(415);
+    const encoded = await rpc(envelope([]), {
+      "content-type": "application/json",
+      "content-encoding": "gzip",
+    });
+    expect(encoded.status).toBe(415);
+    const oversized = await rpc(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "eth_chainId",
+        params: [],
+        padding: "x".repeat(EVM_RPC_MAX_REQUEST_BYTES),
+      })
+    );
+    expect(oversized.status).toBe(413);
+    const invalidUtf8 = await rpc(new Uint8Array([0xff, 0xfe]));
+    expect(invalidUtf8.status).toBe(400);
+
+    let deeplyNested: unknown = "leaf";
+    for (let depth = 0; depth < 20; depth += 1) deeplyNested = [deeplyNested];
+    const deep = await rpc(
+      JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_call", params: [deeplyNested] })
+    );
+    expect(deep.status).toBe(400);
+    const wide = await rpc(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "eth_call",
+        params: [Array.from({ length: 2_100 }, () => 0)],
+      })
+    );
+    expect(wide.status).toBe(400);
+
+    const distinctiveRaw = `0x${"deadbeef".repeat(40)}`;
+    const invalidTransaction = await rpc(envelope([distinctiveRaw]));
+    expect(invalidTransaction.status).toBe(200);
+    const invalidTransactionBody = await invalidTransaction.text();
+    expect(invalidTransactionBody).toContain("Invalid signed transaction encoding");
+    expect(invalidTransactionBody).not.toContain(distinctiveRaw);
+    expect(invalidTransactionBody).not.toContain(bearerToken);
+
+    const serializedReadback = JSON.stringify(mock.store.readback());
+    expect(mock.store.readback().transactions).toEqual([]);
+    expect(serializedReadback).not.toContain(distinctiveRaw);
+    expect(serializedReadback).not.toContain(bearerToken);
   });
 
   test("generation-fences a stalled request across reset", async () => {

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/integration/protocol-mock.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/integration/protocol-mock.test.ts
@@ -14,9 +14,10 @@ const runningMocks: Awaited<ReturnType<typeof startEvmRpcMock>>[] = [];
 
 async function startMock(
   balances: Record<string, bigint> = {},
-  bearerToken = "synthetic-rpc-token"
+  bearerToken = "synthetic-rpc-token",
+  revertRecipients: string[] = []
 ) {
-  const mock = await startEvmRpcMock({ balances, bearerToken });
+  const mock = await startEvmRpcMock({ balances, bearerToken, revertRecipients });
   runningMocks.push(mock);
   return mock;
 }
@@ -64,6 +65,7 @@ describe("wallet EVM JSON-RPC protocol mock", () => {
     const provider = providerFor(mock.url, account);
     const publicClient = provider.getPublicClient("base");
     const walletClient = provider.getWalletClient("base");
+    const initialState = mock.store.readback();
 
     await expect(publicClient.getChainId()).resolves.toBe(8453);
     await expect(publicClient.getBlockNumber()).resolves.toBe(100n);
@@ -142,11 +144,28 @@ describe("wallet EVM JSON-RPC protocol mock", () => {
     ).toEqual(["accepted", "duplicate"]);
     expect(JSON.stringify(readback)).not.toContain(raw);
     expect(JSON.stringify(readback)).not.toContain("synthetic-rpc-token");
+
+    mock.store.reset();
+    const replayState = mock.store.readback();
+    const { generation: _initialGeneration, ...initialWorld } = initialState;
+    const { generation: _replayGeneration, ...replayedWorld } = replayState;
+    expect(replayedWorld).toEqual(initialWorld);
+    const replayedBlock = await publicClient.getBlock({ blockTag: "latest" });
+    expect(replayedBlock.hash).toBe(block.hash);
+    expect(replayedBlock.timestamp).toBe(block.timestamp);
+    await expect(publicClient.getBalance({ address: account.address })).resolves.toBe(
+      openingBalance
+    );
   });
 
   test("mines an explicit reverted receipt without applying a fabricated effect", async () => {
     const account = privateKeyToAccount(generatePrivateKey());
-    const mock = await startMock({ [account.address]: 10n, [RECIPIENT]: 0n });
+    const openingBalance = 100n;
+    const mock = await startMock(
+      { [account.address]: openingBalance, [RECIPIENT]: 0n },
+      "synthetic-rpc-token",
+      [RECIPIENT]
+    );
     const provider = providerFor(mock.url, account);
     const publicClient = provider.getPublicClient("base");
     const walletClient = provider.getWalletClient("base");
@@ -169,9 +188,93 @@ describe("wallet EVM JSON-RPC protocol mock", () => {
     await expect(publicClient.getTransactionReceipt({ hash })).resolves.toMatchObject({
       status: "reverted",
     });
-    await expect(publicClient.getBalance({ address: account.address })).resolves.toBe(10n);
+    await expect(publicClient.getBalance({ address: account.address })).resolves.toBe(
+      openingBalance
+    );
     await expect(publicClient.getBalance({ address: RECIPIENT })).resolves.toBe(0n);
+    await expect(publicClient.getTransactionCount({ address: account.address })).resolves.toBe(1);
+
+    const insufficient = await account.signTransaction({
+      chainId: 8453,
+      type: "eip1559",
+      nonce: 1,
+      gas: 21_000n,
+      maxFeePerGas: 2_000_000_000n,
+      maxPriorityFeePerGas: 1_000_000_000n,
+      to: "0x3333333333333333333333333333333333333333",
+      value: openingBalance + 1n,
+    });
+    await expect(
+      walletClient.sendRawTransaction({ serializedTransaction: insufficient })
+    ).rejects.toThrow("Insufficient funds");
+    expect(mock.store.readback().transactions).toHaveLength(1);
+    await expect(
+      publicClient.request({
+        method: "eth_getTransactionReceipt",
+        params: ["0x01"],
+      })
+    ).rejects.toThrow("32-byte transaction hash");
+    await expect(
+      walletClient.sendRawTransaction({
+        serializedTransaction: "0x1" as `0x02${string}`,
+      })
+    ).rejects.toThrow("even-length raw transaction bytes");
   });
+
+  test("deduplicates a retry after an ambiguous post-accept timeout", async () => {
+    const account = privateKeyToAccount(generatePrivateKey());
+    const mock = await startMock({
+      [account.address]: 1_000n,
+      [RECIPIENT]: 0n,
+    });
+    const provider = providerFor(mock.url, account);
+    const publicClient = provider.getPublicClient("base");
+    const walletClient = provider.getWalletClient("base");
+    const raw = await account.signTransaction({
+      chainId: 8453,
+      type: "eip1559",
+      nonce: 0,
+      gas: 21_000n,
+      maxFeePerGas: 2_000_000_000n,
+      maxPriorityFeePerGas: 1_000_000_000n,
+      to: RECIPIENT,
+      value: 100n,
+    });
+    mock.store.setFault("stall_after_accept", "eth_sendRawTransaction");
+
+    await expect(walletClient.sendRawTransaction({ serializedTransaction: raw })).rejects.toThrow();
+    await waitFor(() => mock.store.pendingResponseCount === 0);
+    const accepted = mock.store.readback();
+    expect(accepted.transactions).toHaveLength(1);
+    expect(accepted.observations).toContainEqual(
+      expect.objectContaining({
+        method: "eth_sendRawTransaction",
+        outcome: "accepted",
+        responseFault: "stalled",
+      })
+    );
+    expect(accepted.observations).toContainEqual(
+      expect.objectContaining({
+        method: "eth_sendRawTransaction",
+        outcome: "cancelled",
+      })
+    );
+    const hash = accepted.transactions[0]?.hash;
+    if (!hash) throw new Error("Expected admitted transaction hash");
+
+    mock.store.setFault(null);
+    await expect(walletClient.sendRawTransaction({ serializedTransaction: raw })).resolves.toBe(
+      hash
+    );
+    expect(mock.store.readback().transactions).toHaveLength(1);
+    mock.store.mine();
+    await expect(publicClient.getTransactionReceipt({ hash })).resolves.toMatchObject({
+      status: "success",
+    });
+    await expect(publicClient.getBalance({ address: RECIPIENT })).resolves.toBe(100n);
+
+    expect(mock.store.pendingResponseCount).toBe(0);
+  }, 10_000);
 
   test("enforces synthetic auth without retaining credentials", async () => {
     const account = privateKeyToAccount(generatePrivateKey());
@@ -191,7 +294,7 @@ describe("wallet EVM JSON-RPC protocol mock", () => {
     expect(serialized).not.toContain("wrong-synthetic-token");
   });
 
-  test("surfaces rate-limit, provider, malformed, and timeout failures from real HTTP", async () => {
+  test("surfaces rate-limit, provider, and malformed failures from real HTTP", async () => {
     const account = privateKeyToAccount(generatePrivateKey());
     const mock = await startMock();
     const client = providerFor(mock.url, account).getPublicClient("base");
@@ -202,24 +305,15 @@ describe("wallet EVM JSON-RPC protocol mock", () => {
     await expect(client.getBlockNumber()).rejects.toThrow("Synthetic provider failure");
     mock.store.setFault("malformed_json", "eth_blockNumber");
     await expect(client.getBlockNumber()).rejects.toThrow();
-    mock.store.setFault("stall", "eth_blockNumber");
-    await expect(client.getBlockNumber()).rejects.toThrow();
     expect(
       mock.store
         .readback()
         .observations.filter((entry) => entry.method === "eth_blockNumber")
-        .map((entry) => entry.outcome),
-    ).toEqual(
-      expect.arrayContaining([
-        "rate_limited",
-        "provider_error",
-        "malformed",
-        "stalled",
-      ]),
-    );
+        .map((entry) => entry.outcome)
+    ).toEqual(expect.arrayContaining(["rate_limited", "provider_error", "malformed"]));
     mock.store.reset();
     expect(mock.store.pendingResponseCount).toBe(0);
-  }, 10_000);
+  });
 
   test("generation-fences a stalled request across reset", async () => {
     const account = privateKeyToAccount(generatePrivateKey());

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/integration/protocol-mock.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/integration/protocol-mock.test.ts
@@ -321,6 +321,8 @@ describe("wallet EVM JSON-RPC protocol mock", () => {
   test("bounds request admission and never reflects raw transactions or credentials", async () => {
     const bearerToken = "BOUNDARY_BEARER_SECRET_7f92";
     const mock = await startMock({}, bearerToken);
+    const account = privateKeyToAccount(generatePrivateKey());
+    const walletClient = providerFor(mock.url, account, bearerToken).getWalletClient("base");
     const rpc = (
       body: BodyInit,
       headers: Record<string, string> = { "content-type": "application/json" }
@@ -376,6 +378,18 @@ describe("wallet EVM JSON-RPC protocol mock", () => {
     expect(invalidTransactionBody).toContain("Invalid signed transaction encoding");
     expect(invalidTransactionBody).not.toContain(distinctiveRaw);
     expect(invalidTransactionBody).not.toContain(bearerToken);
+
+    let clientFailure = "";
+    try {
+      await walletClient.sendRawTransaction({
+        serializedTransaction: distinctiveRaw as `0x02${string}`,
+      });
+    } catch (error) {
+      clientFailure = error instanceof Error ? error.message : String(error);
+    }
+    expect(clientFailure).toContain("Invalid signed transaction encoding");
+    expect(clientFailure).not.toContain(distinctiveRaw);
+    expect(clientFailure).not.toContain(bearerToken);
 
     const serializedReadback = JSON.stringify(mock.store.readback());
     expect(mock.store.readback().transactions).toEqual([]);

--- a/plugins/plugin-wallet/src/chains/evm/providers/wallet.ts
+++ b/plugins/plugin-wallet/src/chains/evm/providers/wallet.ts
@@ -25,6 +25,7 @@ import type {
   Address,
   Chain,
   HttpTransport,
+  HttpTransportConfig,
   PrivateKeyAccount,
   PublicClient,
   TestClient,
@@ -72,6 +73,67 @@ function headersWithoutAuthorization(headersInit?: HeadersInit): Headers {
 
 /** Viem aborts the underlying HTTP request when this network deadline expires. */
 const WALLET_RPC_FETCH_TIMEOUT_MS = 4000;
+
+function walletHttpTransport(url: string, config: HttpTransportConfig = {}): HttpTransport {
+  const base = http(url, config);
+  const protectedTransport: HttpTransport = (transportConfig) => {
+    const transport = base(transportConfig);
+    const protectedRequest: typeof transport.request = async (request, options) => {
+      try {
+        return await transport.request(request, options);
+      } catch (error) {
+        // error-policy:J1 raw signed transactions are secret-bearing request
+        // bytes, so this public wallet boundary emits a typed stable failure
+        // without retaining the unsafe viem cause or request-body metadata.
+        if (request.method === "eth_sendRawTransaction") {
+          throw sanitizeRawTransactionSubmissionError(error);
+        }
+        throw error;
+      }
+    };
+    return {
+      ...transport,
+      config: { ...transport.config, request: protectedRequest },
+      request: protectedRequest,
+    };
+  };
+  return protectedTransport;
+}
+
+function sanitizeRawTransactionSubmissionError(error: unknown): EVMError {
+  const messages: string[] = [];
+  let current: unknown = error;
+  for (let depth = 0; depth < 8 && current instanceof Error; depth += 1) {
+    messages.push(current.message);
+    current = current.cause;
+  }
+  const diagnostic = messages.join("\n");
+  if (diagnostic.includes("Insufficient funds for transaction value")) {
+    return new EVMError(
+      EVMErrorCode.INSUFFICIENT_FUNDS,
+      "Insufficient funds for transaction value"
+    );
+  }
+  if (diagnostic.includes("Expected non-empty, even-length raw transaction bytes")) {
+    return new EVMError(
+      EVMErrorCode.INVALID_PARAMS,
+      "Expected non-empty, even-length raw transaction bytes"
+    );
+  }
+  if (diagnostic.includes("Invalid signed transaction encoding")) {
+    return new EVMError(EVMErrorCode.INVALID_PARAMS, "Invalid signed transaction encoding");
+  }
+  if (diagnostic.includes("Invalid signed transaction signature")) {
+    return new EVMError(EVMErrorCode.INVALID_PARAMS, "Invalid signed transaction signature");
+  }
+  if (diagnostic.includes("Wrong chain ID")) {
+    return new EVMError(EVMErrorCode.INVALID_PARAMS, "Wrong chain ID");
+  }
+  if (diagnostic.includes("Invalid nonce:")) {
+    return new EVMError(EVMErrorCode.INVALID_PARAMS, "Invalid transaction nonce");
+  }
+  return new EVMError(EVMErrorCode.NETWORK_ERROR, "Raw transaction submission failed");
+}
 
 function isRetryableManagedRpcStatus(status: number): boolean {
   return (
@@ -292,13 +354,13 @@ export class WalletProvider {
         fallbackRpcUrl &&
         this._cloudRpcDisabled.has(chainName)
       ) {
-        return http(fallbackRpcUrl, {
+        return walletHttpTransport(fallbackRpcUrl, {
           timeout: WALLET_RPC_FETCH_TIMEOUT_MS,
           retryCount: 0,
         });
       }
 
-      return http(managedRpc.rpcUrl, {
+      return walletHttpTransport(managedRpc.rpcUrl, {
         timeout: WALLET_RPC_FETCH_TIMEOUT_MS,
         retryCount: 0,
         fetchFn:
@@ -351,12 +413,12 @@ export class WalletProvider {
 
     const customRpc = chain.rpcUrls.custom;
     if (customRpc) {
-      return http(customRpc.http[0], {
+      return walletHttpTransport(customRpc.http[0], {
         timeout: WALLET_RPC_FETCH_TIMEOUT_MS,
         retryCount: 0,
       });
     }
-    return http(chain.rpcUrls.default.http[0], {
+    return walletHttpTransport(chain.rpcUrls.default.http[0], {
       timeout: WALLET_RPC_FETCH_TIMEOUT_MS,
       retryCount: 0,
     });


### PR DESCRIPTION
# Relates to

Refs #24092

- [x] This PR targets `develop` and was rebased onto current `origin/develop` before publication.
- [x] The production `WalletProvider` and viem HTTP transports are exercised without replacing client/request methods.
- [x] This is a partial wallet EVM slice; registry, multichain, general EVM execution, and Cloud scenario composition remain open.

# Risks

Low-to-medium. The new service is test-only, but this PR also propagates Node HTTP client disconnects into the shared mock fetch request signal so stalled mock handlers clean up promptly.

# Background

## What does this PR do?

Adds a resettable Base-compatible JSON-RPC loopback under `@elizaos/cloud-test-mocks/wallet-evm` and drives it through plugin-wallet's production `WalletProvider`, viem public client, wallet client, real HTTP transport, and ephemeral local signing.

The slice proves authenticated chain/block/time/balance/nonce/call reads; strict signed raw transaction admission; deterministic mining; pending and mined receipts; duplicate submission; ambiguous post-accept timeout followed by byte-identical retry with exactly one effect; explicit execution revert versus pre-admission rejection; reorg rollback/re-inclusion; 401/429/provider/malformed/stall/cancellation behavior; generation-fenced reset; deterministic reset/replay hashes; and credential/raw-transaction-redacted readback. Request admission is bounded by media type, encoding, 64 KiB, UTF-8, depth, and node count before dispatch/effects. Only typed allowlisted RPC failures cross the mock boundary. `WalletProvider` also translates raw-submission failures so viem cannot reintroduce signed request bytes through its public error metadata. The shared Node adapter streams responses, propagates disconnect cancellation, and replaces pre-header exceptions with a stable redacted failure.

The mock cannot claim general EVM fidelity: contract execution, logs, gas charging, multichain behavior, Cloud control/receipt composition, and real-chain evidence remain unsupported and explicit.

## Remaining #24092 scope

- Plugin-registry production upstream HTTP/cache/ETag/artifact slice.
- Multichain and broader wallet route/action coverage.
- Shared synthetic control/receipt and Cloud scenario/E2E composition after foundation contracts land.

# Testing

## Where should a reviewer start?

`plugins/plugin-wallet/src/chains/evm/__tests__/integration/protocol-mock.test.ts` and `packages/cloud/test-mocks/src/wallet-evm/index.ts`.

## Detailed testing steps

At exact head `35b69f1720f4089758830149bf89a932f0870001`:

```text
$ bun run --cwd plugins/plugin-wallet test -- src/chains/evm/__tests__/integration/protocol-mock.test.ts
Test Files  1 passed (1)
Tests       7 passed (7)

$ bun run --cwd packages/cloud/test-mocks test
89 pass, 0 fail, 486 expect() calls

$ bun run --cwd plugins/plugin-wallet typecheck
exit 0

$ bun run --cwd plugins/plugin-wallet test -- src/chains/evm/__tests__/unit/wallet-provider-timeout.test.ts src/chains/evm/__tests__/unit/wallet-provider-cache.test.ts
Test Files  2 passed (2)
Tests       4 passed (4)

$ bun run --cwd packages/cloud/test-mocks lint:check
Checked 38 files; 2 pre-existing warnings, 0 errors.

$ bun run --cwd plugins/plugin-wallet lint:check
Checked 298 files; 0 errors.

$ bun run --cwd plugins/plugin-wallet build
Node/browser/declarations/view bundle completed.

$ bun run check:agents-claude
PASS: 159 tracked pairs are byte-identical.
```

# Evidence Gate

<!-- evidence-head:35b69f1720f4089758830149bf89a932f0870001 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI flow changes.
<!-- evidence-row:backend-logs -->
- [x] [24271-35b69f1-wallet-rpc-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24271-35b69f1-wallet-rpc-tests.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network surface changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no LLM, prompt, planner, or agent behavior is changed.
<!-- evidence-row:domain-artifacts -->
- [x] [24271-35b69f1-wallet-rpc-readback.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-9/24271-35b69f1-wallet-rpc-readback.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Known gaps / failures

- `bun run --cwd packages/cloud/test-mocks typecheck` is blocked outside this diff at `src/control-plane/server.ts:274`: `Promise<boolean>` is not assignable to `Promise<void>`.
- Full plugin-wallet Vitest baseline: 352 tests pass, 1 skip, 1 unrelated assertion fails (`wallet-provider-behavior.test.ts` expects 20 displayed chains but current code returns 24); six unrelated suites fail import resolution because shared/plugin/UI dist artifacts are stale or missing in the shared checkout.
- Root `bun run verify` was not claimed because the narrower aggregate baselines already fail outside this diff.
- No real key, funded wallet, provider credential, live chain, general contract execution, gas accounting, registry upstream, or all-Cloud scenario behavior is claimed.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— wallet-rpc-mock
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
