### PR TITLE
fix(documents): centralize route mutations

### DIFF
--- a/packages/agent/src/api/documents-service-loader.ts
+++ b/packages/agent/src/api/documents-service-loader.ts
@@ -91,6 +91,10 @@ export interface DocumentsServiceLike {
     documentId: UUID,
     accessContext: AccessContext,
   ): Promise<Memory | null>;
+  getMutableDocumentWithAccessContext?(
+    documentId: UUID,
+    accessContext: AccessContext,
+  ): Promise<Memory | null>;
   listDocumentFragmentsWithAccessContext?(
     documentId: UUID,
     accessContext: AccessContext,
@@ -111,11 +115,16 @@ export interface DocumentsServiceLike {
     documentId: UUID;
     content: string;
     message?: Memory;
+    accessContext?: AccessContext;
   }): Promise<{
     documentId: UUID;
     fragmentCount: number;
   }>;
   deleteDocument?(documentId: UUID, message?: Memory): Promise<void>;
+  deleteDocumentWithAccessContext?(
+    documentId: UUID,
+    accessContext: AccessContext,
+  ): Promise<void>;
   deleteMemory(memoryId: UUID): Promise<void>;
 }
 

--- a/packages/core/src/features/documents/service-authorization.real.test.ts
+++ b/packages/core/src/features/documents/service-authorization.real.test.ts
@@ -377,6 +377,11 @@ describe("DocumentService requester authorization", () => {
 			"getRoomsForParticipants",
 		);
 		const request = message();
+		const accessContext = {
+			requesterEntityId: USER_ID,
+			role: "USER" as const,
+			isOwner: false,
+		};
 
 		await runWithTrajectoryContext(
 			{ turnMemo: new Map<string, Promise<unknown>>() },
@@ -397,8 +402,11 @@ describe("DocumentService requester authorization", () => {
 					}),
 				).rejects.toMatchObject({ code: "DOCUMENT_NOT_FOUND" });
 				await expect(
-					service.deleteDocument(DELETE_DOCUMENT_ID, request),
-				).rejects.toMatchObject({ code: "DOCUMENT_MUTATION_FORBIDDEN" });
+					service.deleteDocumentWithAccessContext(
+						DELETE_DOCUMENT_ID,
+						accessContext,
+					),
+				).rejects.toMatchObject({ code: "DOCUMENT_NOT_FOUND" });
 			},
 		);
 

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -572,6 +572,29 @@ export class DocumentService extends Service {
 		});
 	}
 
+	async getMutableDocumentWithAccessContext(
+		documentId: UUID,
+		accessContext: AccessContext,
+	): Promise<Memory | null> {
+		const requester = await resolveDocumentRequesterFromAccessContext(
+			this.runtime,
+			accessContext,
+		);
+		const requestContext = {
+			agentId: this.runtime.agentId,
+			requesterEntityId: requester.entityId,
+			requesterRoomIds: requester.roomIds,
+			requesterRole: requester.role,
+		};
+		const document = await this.runtime.adapter.getDocument({
+			...requestContext,
+			documentId,
+		});
+		return document && canRequesterMutateDocument(document, requestContext)
+			? document
+			: null;
+	}
+
 	async listDocumentFragmentsWithAccessContext(
 		documentId: UUID,
 		accessContext: AccessContext,
@@ -798,6 +821,24 @@ export class DocumentService extends Service {
 
 	async deleteDocument(documentId: UUID, message?: Memory): Promise<void> {
 		const requester = await resolveDocumentRequester(this.runtime, message);
+		await this.deleteDocumentForRequester(documentId, requester);
+	}
+
+	async deleteDocumentWithAccessContext(
+		documentId: UUID,
+		accessContext: AccessContext,
+	): Promise<void> {
+		const requester = await resolveDocumentRequesterFromAccessContext(
+			this.runtime,
+			accessContext,
+		);
+		await this.deleteDocumentForRequester(documentId, requester);
+	}
+
+	private async deleteDocumentForRequester(
+		documentId: UUID,
+		requester: DocumentRequester,
+	): Promise<void> {
 		const document = await this.runtime.adapter.getDocument({
 			agentId: this.runtime.agentId,
 			documentId,
@@ -806,22 +847,6 @@ export class DocumentService extends Service {
 			requesterRole: requester.role,
 		});
 		if (!document) {
-			// A hidden document owned by this runtime is a forbidden mutation, while
-			// foreign-agent and non-document rows remain indistinguishable from a
-			// missing UUID. This preserves tenant isolation across the unscoped probe.
-			const existingUnscoped = await this.runtime.getMemoryById(documentId);
-			if (
-				existingUnscoped?.agentId === this.runtime.agentId &&
-				readDocumentMutationSnapshot(existingUnscoped)
-			) {
-				throw new ElizaError(
-					`Document ${documentId} cannot be deleted by this requester`,
-					{
-						code: "DOCUMENT_MUTATION_FORBIDDEN",
-						context: { documentId, requesterRole: requester.role },
-					},
-				);
-			}
 			throw new ElizaError(`Document ${documentId} not found`, {
 				code: "DOCUMENT_NOT_FOUND",
 				context: { documentId },
@@ -2201,14 +2226,17 @@ export class DocumentService extends Service {
 		documentId: UUID;
 		content: string;
 		message?: Memory;
+		accessContext?: AccessContext;
 	}): Promise<{
 		documentId: UUID;
 		fragmentCount: number;
 	}> {
-		const requester = await resolveDocumentRequester(
-			this.runtime,
-			options.message,
-		);
+		const requester = options.accessContext
+			? await resolveDocumentRequesterFromAccessContext(
+					this.runtime,
+					options.accessContext,
+				)
+			: await resolveDocumentRequester(this.runtime, options.message);
 		const requestContext = {
 			agentId: this.runtime.agentId,
 			requesterEntityId: requester.entityId,

--- a/plugins/plugin-documents/AGENTS.md
+++ b/plugins/plugin-documents/AGENTS.md
@@ -91,6 +91,11 @@ Parent and fragment REST reads must call the access-context-aware
 belongs in the adapter query before rows, fragment bytes, counts, or pagination
 are constructed.
 
+PATCH and DELETE must use the access-context-aware mutation methods. The route
+may inspect the already-authorized parent for editability, but it may not scan
+or delete fragments itself; `DocumentService` owns snapshot validation and the
+adapter performs the atomic parent/revision mutation.
+
 ## How to extend
 
 **Add a new route:**

--- a/plugins/plugin-documents/CLAUDE.md
+++ b/plugins/plugin-documents/CLAUDE.md
@@ -91,6 +91,11 @@ Parent and fragment REST reads must call the access-context-aware
 belongs in the adapter query before rows, fragment bytes, counts, or pagination
 are constructed.
 
+PATCH and DELETE must use the access-context-aware mutation methods. The route
+may inspect the already-authorized parent for editability, but it may not scan
+or delete fragments itself; `DocumentService` owns snapshot validation and the
+adapter performs the atomic parent/revision mutation.
+
 ## How to extend
 
 **Add a new route:**

--- a/plugins/plugin-documents/README.md
+++ b/plugins/plugin-documents/README.md
@@ -50,6 +50,9 @@ they are current members, but cannot read private scopes or mutate documents.
 Single-document and fragment reads are resolved by `DocumentService` with that
 authenticated context; routes never fetch a parent row or scan fragment bytes
 and then attempt to filter the result locally.
+PATCH and DELETE resolve mutation authority through the same service. Deletes
+use the adapter's atomic snapshot operation instead of route-managed fragment
+and parent deletion.
 
 ## Configuration
 

--- a/plugins/plugin-documents/src/routes.canonical-read.test.ts
+++ b/plugins/plugin-documents/src/routes.canonical-read.test.ts
@@ -1,6 +1,6 @@
 /**
- * Proves single-document and fragment REST reads cross the canonical
- * access-context-aware document service before any parent or fragment bytes.
+ * Proves document REST reads and mutations cross the canonical
+ * access-context-aware service before parent, fragment, or mutation access.
  */
 import type { AccessContext, Memory, UUID } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -49,15 +49,23 @@ const fragment: Memory = {
 
 const service = vi.hoisted(() => ({
   getDocumentByIdWithAccessContext: vi.fn(),
+  getMutableDocumentWithAccessContext: vi.fn(),
   listDocumentFragmentsWithAccessContext: vi.fn(),
   getMemories: vi.fn(),
+  updateDocument: vi.fn(),
+  deleteDocumentWithAccessContext: vi.fn(),
+  deleteMemory: vi.fn(),
 }));
 
 vi.mock("@elizaos/agent/api/documents-service-loader", () => ({
   getDocumentsService: vi.fn(async () => ({ service })),
 }));
 
-function context(pathname: string): {
+function context(
+  pathname: string,
+  method = "GET",
+  requestBody: unknown = null,
+): {
   ctx: DocumentRouteContext;
   response: { status: number; body: unknown };
   getMemoryById: ReturnType<typeof vi.fn>;
@@ -69,7 +77,7 @@ function context(pathname: string): {
   const ctx = {
     req: { headers: {} },
     res: { setHeader: vi.fn() },
-    method: "GET",
+    method,
     pathname,
     url: new URL(`http://local${pathname}`),
     accessContext,
@@ -86,7 +94,7 @@ function context(pathname: string): {
       response.status = status;
       response.body = { error: message };
     },
-    readJsonBody: vi.fn(async () => null),
+    readJsonBody: vi.fn(async () => requestBody),
   } as unknown as DocumentRouteContext;
   return { ctx, response, getMemoryById };
 }
@@ -95,10 +103,16 @@ describe("canonical document REST reads", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     service.getDocumentByIdWithAccessContext.mockResolvedValue(document);
+    service.getMutableDocumentWithAccessContext.mockResolvedValue(document);
     service.listDocumentFragmentsWithAccessContext.mockResolvedValue([
       fragment,
     ]);
     service.getMemories.mockResolvedValue([]);
+    service.updateDocument.mockResolvedValue({
+      documentId: DOCUMENT_ID,
+      fragmentCount: 1,
+    });
+    service.deleteDocumentWithAccessContext.mockResolvedValue(undefined);
   });
 
   it("reads a parent and its count only through authorized service methods", async () => {
@@ -139,5 +153,45 @@ describe("canonical document REST reads", () => {
     );
     expect(getMemoryById).not.toHaveBeenCalled();
     expect(service.getMemories).not.toHaveBeenCalled();
+  });
+
+  it("updates through the canonical mutation authority without a raw parent read", async () => {
+    const { ctx, response, getMemoryById } = context(
+      `/api/documents/${DOCUMENT_ID}`,
+      "PATCH",
+      { content: "updated bytes" },
+    );
+
+    await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+    expect(response.status).toBe(200);
+    expect(service.getMutableDocumentWithAccessContext).toHaveBeenCalledWith(
+      DOCUMENT_ID,
+      accessContext,
+    );
+    expect(service.updateDocument).toHaveBeenCalledWith({
+      documentId: DOCUMENT_ID,
+      content: "updated bytes",
+      accessContext,
+    });
+    expect(getMemoryById).not.toHaveBeenCalled();
+  });
+
+  it("deletes atomically through DocumentService without raw fragment mutation", async () => {
+    const { ctx, response, getMemoryById } = context(
+      `/api/documents/${DOCUMENT_ID}`,
+      "DELETE",
+    );
+
+    await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+    expect(response.status).toBe(200);
+    expect(service.deleteDocumentWithAccessContext).toHaveBeenCalledWith(
+      DOCUMENT_ID,
+      accessContext,
+    );
+    expect(response.body).toMatchObject({ ok: true, deletedFragments: 1 });
+    expect(getMemoryById).not.toHaveBeenCalled();
+    expect(service.deleteMemory).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -11,7 +11,6 @@ import {
   actorCanManageOwnerDocuments,
   asRecord,
   asUuid,
-  canMutateDocumentMemory,
   canReadDocumentMemory,
   type DocumentReadableMemory,
   documentMediaFormat,
@@ -546,36 +545,6 @@ async function mapDocumentFragmentsByDocumentId(
   }
 
   return fragmentCounts;
-}
-
-async function listDocumentFragmentsForDocument(
-  documentsService: DocumentsServiceLike,
-  roomId: UUID | undefined,
-  documentId: UUID,
-): Promise<UUID[]> {
-  let offset = 0;
-  const fragmentIds: UUID[] = [];
-
-  while (true) {
-    const fragmentBatch = await documentsService.getMemories({
-      tableName: DOCUMENT_FRAGMENTS_TABLE,
-      roomId,
-      count: FRAGMENT_BATCH_SIZE,
-      offset,
-    });
-
-    for (const memory of fragmentBatch) {
-      const metadata = asRecord(memory.metadata);
-      if (metadata?.documentId === documentId && hasUuidId(memory)) {
-        fragmentIds.push(memory.id);
-      }
-    }
-
-    if (fragmentBatch.length < FRAGMENT_BATCH_SIZE) break;
-    offset += FRAGMENT_BATCH_SIZE;
-  }
-
-  return fragmentIds;
 }
 
 async function listDocumentMemories({
@@ -1114,12 +1083,15 @@ export async function handleDocumentsRoutes(
     );
     if (!decodedDocumentId) return true;
     const documentId = decodedDocumentId as UUID;
-    const document = await runtime.getMemoryById(documentId);
-    if (
-      !document ||
-      !isDocumentMemory(document, agentId) ||
-      !canMutateDocumentMemory(document, routeActor)
-    ) {
+    if (!documentsService.getMutableDocumentWithAccessContext) {
+      error(res, "Canonical document authorization is unavailable", 503);
+      return true;
+    }
+    const document = await documentsService.getMutableDocumentWithAccessContext(
+      documentId,
+      accessContext,
+    );
+    if (!document) {
       error(res, "Document not found", 404);
       return true;
     }
@@ -1143,11 +1115,7 @@ export async function handleDocumentsRoutes(
     const result = await documentsService.updateDocument({
       documentId,
       content: body.content,
-      message: buildRouteMessage({
-        agentId,
-        text: body.content,
-        actor: routeActor,
-      }),
+      accessContext,
     });
 
     json(res, {
@@ -1166,12 +1134,20 @@ export async function handleDocumentsRoutes(
     );
     if (!decodedDocumentId) return true;
     const documentId = decodedDocumentId as UUID;
-    const existingDocument = await runtime.getMemoryById(documentId);
     if (
-      !existingDocument ||
-      !isDocumentMemory(existingDocument, agentId) ||
-      !canMutateDocumentMemory(existingDocument, routeActor)
+      !documentsService.getMutableDocumentWithAccessContext ||
+      !documentsService.listDocumentFragmentsWithAccessContext ||
+      !documentsService.deleteDocumentWithAccessContext
     ) {
+      error(res, "Canonical document authorization is unavailable", 503);
+      return true;
+    }
+    const existingDocument =
+      await documentsService.getMutableDocumentWithAccessContext(
+        documentId,
+        accessContext,
+      );
+    if (!existingDocument) {
       error(res, "Document not found", 404);
       return true;
     }
@@ -1186,20 +1162,20 @@ export async function handleDocumentsRoutes(
       return true;
     }
 
-    const fragmentIds = await listDocumentFragmentsForDocument(
-      documentsService,
-      undefined,
+    const fragmentCount = (
+      await documentsService.listDocumentFragmentsWithAccessContext(
+        documentId,
+        accessContext,
+      )
+    ).length;
+    await documentsService.deleteDocumentWithAccessContext(
       documentId,
+      accessContext,
     );
-
-    for (const fragmentId of fragmentIds) {
-      await documentsService.deleteMemory(fragmentId);
-    }
-    await documentsService.deleteMemory(documentId);
 
     json(res, {
       ok: true,
-      deletedFragments: fragmentIds.length,
+      deletedFragments: fragmentCount,
     });
     return true;
   }


### PR DESCRIPTION
Refs #24246

Hard-cuts route-local PATCH/DELETE authority:

- mutable-parent lookup is access-context-aware and owned by DocumentService
- update accepts the authenticated AccessContext instead of reconstructing authority from a synthetic message
- delete uses DocumentService snapshot validation and the adapter atomic parent/revision delete
- removes unscoped forbidden-vs-not-found probe and route-managed fragment/parent deletion
- deterministic route spies prove no raw parent read, fragment scan, or deleteMemory mutation executes

Verification:
- plugin-documents full suite: 124 passed
- canonical route read/mutation proof: 4 passed
- core real-PGlite authorization/revocation: 4 passed
- core build and packed consumers passed
- changed-file Biome, diff check, guide parity passed

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop / multi-agent
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— root membership-documents lane
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop / multi-agent","skill_revision":"N/A - no repository contribution skill used"} -->