### PR TITLE
fix(agent): preserve complete entity UUIDs in roles provider roster

### DIFF
--- a/packages/agent/src/runtime/roles/src/provider.test.ts
+++ b/packages/agent/src/runtime/roles/src/provider.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Deterministic unit tests for rolesProvider.
+ * Verifies role roster generation, complete UUID fallback (never truncated),
+ * and best-effort name resolution for owners, admins, and users.
+ */
+import type { IAgentRuntime, Memory, State, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { rolesProvider } from "./provider.ts";
+
+const ROOM_ID = "00000000-0000-0000-0000-000000000010" as UUID;
+const WORLD_ID = "00000000-0000-0000-0000-000000000020" as UUID;
+const OWNER_ID = "11111111-2222-3333-4444-555566667777" as UUID;
+const ADMIN_ID = "88888888-9999-aaaa-bbbb-ccccddddeeee" as UUID;
+const USER_ID = "33333333-4444-5555-6666-777788889999" as UUID;
+
+function createMessage(entityId: UUID): Memory {
+  return {
+    id: "00000000-0000-0000-0000-000000000001" as UUID,
+    roomId: ROOM_ID,
+    entityId,
+    content: { text: "check roles" },
+  } as Memory;
+}
+
+describe("rolesProvider", () => {
+  it("preserves complete entity UUIDs when display names are not configured", async () => {
+    const runtime = {
+      agentId: "99999999-9999-9999-9999-999999999999" as UUID,
+      reportError: vi.fn(),
+      getRoom: vi.fn(async () => ({ id: ROOM_ID, worldId: WORLD_ID })),
+      getWorld: vi.fn(async () => ({
+        id: WORLD_ID,
+        metadata: {
+          ownership: { ownerId: OWNER_ID },
+          roles: {
+            [OWNER_ID]: "OWNER",
+            [ADMIN_ID]: "ADMIN",
+            [USER_ID]: "USER",
+          },
+        },
+      })),
+      getEntityById: vi.fn(async (_id: UUID) => null),
+    } as unknown as IAgentRuntime;
+
+    const result = await rolesProvider.get(
+      runtime,
+      createMessage(OWNER_ID),
+      {} as State,
+    );
+
+    expect(result.text).toContain(`Owners: ${OWNER_ID}`);
+    expect(result.text).toContain(`Admins: ${ADMIN_ID}`);
+    expect(result.text).toContain(`Users: ${USER_ID}`);
+    expect(result.text).not.toMatch(/Owners:\s*11111111(?:\s|$|,)/);
+    expect(result.text).not.toMatch(/Admins:\s*88888888(?:\s|$|,)/);
+  });
+
+  it("resolves display names when entity metadata is present", async () => {
+    const runtime = {
+      agentId: "99999999-9999-9999-9999-999999999999" as UUID,
+      reportError: vi.fn(),
+      getRoom: vi.fn(async () => ({ id: ROOM_ID, worldId: WORLD_ID })),
+      getWorld: vi.fn(async () => ({
+        id: WORLD_ID,
+        metadata: {
+          ownership: { ownerId: OWNER_ID },
+          roles: {
+            [OWNER_ID]: "OWNER",
+            [ADMIN_ID]: "ADMIN",
+          },
+        },
+      })),
+      getEntityById: vi.fn(async (id: UUID) => {
+        if (id === OWNER_ID) {
+          return { id, names: ["Alice Owner"] };
+        }
+        if (id === ADMIN_ID) {
+          return { id, metadata: { default: { name: "Bob Admin" } } };
+        }
+        return null;
+      }),
+    } as unknown as IAgentRuntime;
+
+    const result = await rolesProvider.get(
+      runtime,
+      createMessage(OWNER_ID),
+      {} as State,
+    );
+
+    expect(result.text).toContain("Owners: Alice Owner");
+    expect(result.text).toContain("Admins: Bob Admin");
+  });
+
+  it("falls back to complete UUID when getEntityById throws during name resolution", async () => {
+    const runtime = {
+      agentId: "99999999-9999-9999-9999-999999999999" as UUID,
+      reportError: vi.fn(),
+      getRoom: vi.fn(async () => ({ id: ROOM_ID, worldId: WORLD_ID })),
+      getWorld: vi.fn(async () => ({
+        id: WORLD_ID,
+        metadata: {
+          ownership: { ownerId: OWNER_ID },
+          roles: {
+            [OWNER_ID]: "OWNER",
+            [ADMIN_ID]: "ADMIN",
+          },
+        },
+      })),
+      getEntityById: vi.fn(async (id: UUID) => {
+        if (id === OWNER_ID) {
+          return { id, names: ["Alice Owner"] };
+        }
+        throw new Error("DB connection timeout");
+      }),
+    } as unknown as IAgentRuntime;
+
+    const result = await rolesProvider.get(
+      runtime,
+      createMessage(OWNER_ID),
+      {} as State,
+    );
+
+    expect(result.text).toContain("Owners: Alice Owner");
+    expect(result.text).toContain(`Admins: ${ADMIN_ID}`);
+    expect(result.text).not.toMatch(/Admins:\s*88888888(?:\s|$|,)/);
+  });
+});

--- a/packages/agent/src/runtime/roles/src/provider.ts
+++ b/packages/agent/src/runtime/roles/src/provider.ts
@@ -113,10 +113,11 @@ export const rolesProvider: Provider = {
                 | Record<string, Record<string, string>>
                 | undefined
             )?.default?.name ??
-            id.slice(0, 8);
+            id;
           results.push(name);
         } catch {
-          results.push(id.slice(0, 8));
+          // error-policy:J4 best-effort display resolution; fallback to complete entity UUID
+          results.push(id);
         }
       }
       return results;

--- a/packages/core/src/__tests__/prompt-integrity-policy.test.ts
+++ b/packages/core/src/__tests__/prompt-integrity-policy.test.ts
@@ -94,6 +94,10 @@ const guardedSources: Record<string, readonly RegExp[]> = {
 		/options\.command\.substring\(/,
 		/options\.command\.slice\(/,
 	],
+	"packages/agent/src/runtime/roles/src/provider.ts": [
+		/id\.slice\(/,
+		/id\.substring\(/,
+	],
 	"packages/agent/src/runtime/prompt-optimization.ts": [
 		/actionCompactionEnabled/,
 	],


### PR DESCRIPTION
## Summary

Preserve complete entity UUIDs in `rolesProvider` when entity display names are unavailable or lookup fails, eliminating ambiguous eight-character prefix truncation in model-facing role rosters and annotating the best-effort name resolution catch handler with the canonical error policy.

## Changes

- Update `resolveNames` in `packages/agent/src/runtime/roles/src/provider.ts` to fall back to complete `id` rather than slicing to eight characters (`id.slice(0, 8)`).
- Annotate `resolveNames` catch block with `// error-policy:J4 best-effort display resolution; fallback to complete entity UUID`.
- Add unit test suite in `packages/agent/src/runtime/roles/src/provider.test.ts` verifying complete entity UUID roster rendering across owners, admins, and users under both successful and failed entity lookups.
- Extend `packages/core/src/__tests__/prompt-integrity-policy.test.ts` to guard `packages/agent/src/runtime/roles/src/provider.ts` against short-ID truncation regressions.

## Exact-head verification

Base: `0076c563ffec3e240b58126ee449c7416b474191`  
Head: `09ededdfa225f558810da698567431970d4a7713`

| Gate | Result |
| --- | --- |
| focused roles provider Vitest (`provider.test.ts`) | 3/3 passed |
| prompt integrity policy audit (`prompt-integrity-policy.test.ts`) | 3/3 passed (573 assertions) |
| scoped Biome check | clean |
| `bun run --cwd packages/agent typecheck` | passed |
| `bun run --cwd packages/core typecheck` | passed |
| `git diff --check` | clean |

## Reviewer start

Start at `packages/agent/src/runtime/roles/src/provider.ts:116, 119` where `resolveNames` now preserves `id` and carries the `// error-policy:J4` annotation. `packages/agent/src/runtime/roles/src/provider.test.ts` exercises display-name fallback and throwing lookup behavior.

## Risks

Low. Model-facing `## Roles` roster retains complete entity identifiers, preventing identity collisions and conforming to the repository-wide prompt integrity contract.

## Attribution

- Analysis, prompt integrity repair, error-policy annotation, and test suite by Antigravity / Gemini 3.7.

## Evidence Gate

<!-- evidence-head:09ededdfa225f558810da698567431970d4a7713 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - roles provider output context has no rendered visual UI surface`.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - roles provider output context has no rendered visual UI surface`.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - deterministic provider and prompt-integrity suites exercise the complete changed boundary`.

<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - deterministic unit tests cover role roster formatting`.

<!-- evidence-row:frontend-logs -->
- [x] Frontend logs `N/A - no frontend path changes`.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - deterministic provider formatting helper; prompt integrity audit passes`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - no database or disk storage changes`.

<!-- evidence-row:ocr-review -->
- [x] OCR review `N/A - no rendered visual text changes`.

# Documentation changes needed?

No. Preserves existing role roster formatting with complete UUIDs.
