### PR TITLE
fix(documents): authorize list surfaces in service

### DIFF
--- a/packages/agent/src/api/documents-service-loader.ts
+++ b/packages/agent/src/api/documents-service-loader.ts
@@ -86,6 +86,9 @@ export interface DocumentsServiceLike {
     message?: Memory,
     options?: Record<string, unknown>,
   ): Promise<Memory[]>;
+  listAllDocumentsWithAccessContext?(
+    accessContext: AccessContext,
+  ): Promise<Memory[]>;
   getDocumentById?(documentId: UUID, message?: Memory): Promise<Memory | null>;
   getDocumentByIdWithAccessContext?(
     documentId: UUID,

--- a/packages/core/src/features/documents/service-list.test.ts
+++ b/packages/core/src/features/documents/service-list.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
 import { AgentRuntime } from "../../runtime";
 import {
+	type AccessContext,
 	type Character,
 	type Memory,
 	MemoryType,
@@ -101,6 +102,35 @@ function userMessage(): Memory {
 }
 
 describe("DocumentService list semantics", () => {
+	it("excludes room documents immediately after membership revocation", async () => {
+		const { adapter, runtime, service } = await makeHarness();
+		const revocationUserId =
+			"00000000-0000-0000-0000-00000000cafe" as UUID;
+		const revocationRoomId =
+			"00000000-0000-0000-0000-00000000da7a" as UUID;
+		await adapter.createRoomParticipants(
+			[AGENT_ID, revocationUserId],
+			revocationRoomId,
+		);
+		const roomDocument = documentMemory(700, { roomId: revocationRoomId });
+		await seedDocuments(runtime, [roomDocument]);
+		const accessContext = {
+			requesterEntityId: revocationUserId,
+			role: "USER",
+			isOwner: false,
+		} satisfies AccessContext;
+
+		await expect(
+			service.listAllDocumentsWithAccessContext(accessContext),
+		).resolves.toMatchObject([{ id: roomDocument.id }]);
+		await adapter.deleteParticipants([
+			{ entityId: revocationUserId, roomId: revocationRoomId },
+		]);
+		await expect(
+			service.listAllDocumentsWithAccessContext(accessContext),
+		).resolves.toEqual([]);
+	});
+
 	it("adds and updates keyword-searchable documents without an embedding model", async () => {
 		const { runtime, service } = await makeHarness();
 		expect(runtime.getModel(ModelType.TEXT_EMBEDDING)).toBeUndefined();

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -636,6 +636,65 @@ export class DocumentService extends Service {
 		);
 	}
 
+	async listAllDocumentsWithAccessContext(
+		accessContext: AccessContext,
+	): Promise<Memory[]> {
+		const documents: Memory[] = [];
+		let cursor: DocumentListCursor | undefined;
+		const seenCursors = new Set<string>();
+		do {
+			const page = await this.listDocumentsDetailedWithRequester(
+				{
+					limit: DOCUMENT_LIST_MAX_LIMIT,
+					...(cursor ? { cursor } : {}),
+				},
+				() =>
+					resolveDocumentRequesterFromAccessContext(
+						this.runtime,
+						accessContext,
+					),
+			);
+			documents.push(...page.documents);
+			if (!page.hasMore) break;
+			if (!page.nextCursor) {
+				throw new ElizaError(
+					"Document list reported another page without a continuation cursor",
+					{
+						code: "DOCUMENT_LIST_CURSOR_MISSING",
+						context: { returnedDocuments: page.documents.length },
+						severity: "fatal",
+					},
+				);
+			}
+			const serializedCursor = documentListCursorKey(page.nextCursor);
+			if (seenCursors.has(serializedCursor)) {
+				throw new ElizaError(
+					"Document list reported a repeating pagination cursor",
+					{
+						code: "DOCUMENT_LIST_CURSOR_LOOP",
+						context: { cursor: page.nextCursor },
+						severity: "fatal",
+					},
+				);
+			}
+			seenCursors.add(serializedCursor);
+			cursor = page.nextCursor;
+		} while (cursor);
+
+		const finalRequester = await resolveDocumentRequesterFromAccessContext(
+			this.runtime,
+			accessContext,
+		);
+		return documents.filter((document) =>
+			isDocumentVisibleToRequester(document, {
+				agentId: this.runtime.agentId,
+				requesterEntityId: finalRequester.entityId,
+				requesterRoomIds: finalRequester.roomIds,
+				requesterRole: finalRequester.role,
+			}),
+		);
+	}
+
 	private async listDocumentsDetailedWithRequester(
 		options: DocumentListOptions,
 		resolveRequester: DocumentRequesterResolver,

--- a/plugins/plugin-documents/AGENTS.md
+++ b/plugins/plugin-documents/AGENTS.md
@@ -85,11 +85,13 @@ storage authorization: ADMIN is not OWNER, GUEST is not USER, and an unresolved
 role is rejected. Guests may read only global documents in their current rooms
 and may not mutate documents.
 
-Parent and fragment REST reads must call the access-context-aware
-`DocumentService` methods. Do not use `runtime.getMemoryById()` or
-`getMemories()` and apply route-local authorization afterward: authorization
-belongs in the adapter query before rows, fragment bytes, counts, or pagination
-are constructed.
+List, facet, search, parent, and fragment REST reads must call the
+access-context-aware `DocumentService` methods. Do not use
+`runtime.getMemoryById()` or `getMemories()` and apply route-local authorization
+afterward: authorization belongs in the adapter query before rows, search
+ranking, fragment bytes, counts, or pagination are constructed. Route list and
+facet filters may narrow the already-authorized set for presentation, and
+fragment counts must use the authorized parent/fragment path.
 
 PATCH and DELETE must use the access-context-aware mutation methods. The route
 may inspect the already-authorized parent for editability, but it may not scan
@@ -100,7 +102,7 @@ adapter performs the atomic parent/revision mutation.
 
 **Add a new route:**
 1. Add the method + path to `DOCUMENT_ROUTES` in `src/plugin.ts`.
-2. Implement the handler branch inside `handleDocumentsRoutes()` in `src/routes.ts`. Follow the existing pattern: resolve actor, check access with `canReadDocumentMemory`/`canMutateDocumentMemory`, delegate to `documentsService`, call `json(res, ...)` or `error(res, ...)`.
+2. Implement the handler branch inside `handleDocumentsRoutes()` in `src/routes.ts`. Resolve the authenticated access context, delegate authorization to the access-context-aware `DocumentService` method, then call `json(res, ...)` or `error(res, ...)`.
 3. Every route must have a real caller (UI or agent action) per root CLAUDE.md rule 10.
 
 **Add a new presenter field:**
@@ -118,7 +120,7 @@ must never become a competing read authority or post-filter raw storage rows.
 - **Bundled and character documents** are read-only: `getDocumentEditability` and `getDocumentDeleteability` enforce this in the presenter, and the PATCH/DELETE handlers check these flags before proceeding.
 - **Image upload.** Images are stored as text. If `includeImageDescriptions: true` is passed in the metadata, the handler calls `runtime.useModel(ModelType.IMAGE_DESCRIPTION, ...)` to generate a description. If the model call fails, a warning is included in the response and the stored text explicitly says that image description was unavailable.
 - **YouTube URLs.** `POST /api/documents/url` detects YouTube URLs via `isYouTubeUrl()` from `@elizaos/core` and sets `source: "youtube"` in metadata; the transcript is fetched by `fetchDocumentFromUrl()`.
-- **Fragment pagination.** Fragment listing always paginates in batches of 500 (`FRAGMENT_BATCH_SIZE`). Large documents with many fragments will issue multiple `getMemories` calls.
+- **Fragment pagination.** `DocumentService` paginates authorized fragments through the adapter's document-fragment query. Routes must not scan the raw fragment table.
 - **Max body size.** Single and bulk upload endpoints cap at 32 MB (`DOCUMENT_UPLOAD_MAX_BODY_BYTES`). Bulk is further capped at 100 documents per request.
 - **rawPath routing.** All routes are registered with `rawPath: true`, meaning the agent server dispatches them directly without prefix stripping. The path `/api/documents` is absolute.
 - **OWNER_DOCUMENTS is host-adapted.** Do not add a second action here unless the PA-hosted approval, scheduler, and document-request behavior is moved with tests that prove parity.

--- a/plugins/plugin-documents/CLAUDE.md
+++ b/plugins/plugin-documents/CLAUDE.md
@@ -85,11 +85,13 @@ storage authorization: ADMIN is not OWNER, GUEST is not USER, and an unresolved
 role is rejected. Guests may read only global documents in their current rooms
 and may not mutate documents.
 
-Parent and fragment REST reads must call the access-context-aware
-`DocumentService` methods. Do not use `runtime.getMemoryById()` or
-`getMemories()` and apply route-local authorization afterward: authorization
-belongs in the adapter query before rows, fragment bytes, counts, or pagination
-are constructed.
+List, facet, search, parent, and fragment REST reads must call the
+access-context-aware `DocumentService` methods. Do not use
+`runtime.getMemoryById()` or `getMemories()` and apply route-local authorization
+afterward: authorization belongs in the adapter query before rows, search
+ranking, fragment bytes, counts, or pagination are constructed. Route list and
+facet filters may narrow the already-authorized set for presentation, and
+fragment counts must use the authorized parent/fragment path.
 
 PATCH and DELETE must use the access-context-aware mutation methods. The route
 may inspect the already-authorized parent for editability, but it may not scan
@@ -100,7 +102,7 @@ adapter performs the atomic parent/revision mutation.
 
 **Add a new route:**
 1. Add the method + path to `DOCUMENT_ROUTES` in `src/plugin.ts`.
-2. Implement the handler branch inside `handleDocumentsRoutes()` in `src/routes.ts`. Follow the existing pattern: resolve actor, check access with `canReadDocumentMemory`/`canMutateDocumentMemory`, delegate to `documentsService`, call `json(res, ...)` or `error(res, ...)`.
+2. Implement the handler branch inside `handleDocumentsRoutes()` in `src/routes.ts`. Resolve the authenticated access context, delegate authorization to the access-context-aware `DocumentService` method, then call `json(res, ...)` or `error(res, ...)`.
 3. Every route must have a real caller (UI or agent action) per root CLAUDE.md rule 10.
 
 **Add a new presenter field:**
@@ -118,7 +120,7 @@ must never become a competing read authority or post-filter raw storage rows.
 - **Bundled and character documents** are read-only: `getDocumentEditability` and `getDocumentDeleteability` enforce this in the presenter, and the PATCH/DELETE handlers check these flags before proceeding.
 - **Image upload.** Images are stored as text. If `includeImageDescriptions: true` is passed in the metadata, the handler calls `runtime.useModel(ModelType.IMAGE_DESCRIPTION, ...)` to generate a description. If the model call fails, a warning is included in the response and the stored text explicitly says that image description was unavailable.
 - **YouTube URLs.** `POST /api/documents/url` detects YouTube URLs via `isYouTubeUrl()` from `@elizaos/core` and sets `source: "youtube"` in metadata; the transcript is fetched by `fetchDocumentFromUrl()`.
-- **Fragment pagination.** Fragment listing always paginates in batches of 500 (`FRAGMENT_BATCH_SIZE`). Large documents with many fragments will issue multiple `getMemories` calls.
+- **Fragment pagination.** `DocumentService` paginates authorized fragments through the adapter's document-fragment query. Routes must not scan the raw fragment table.
 - **Max body size.** Single and bulk upload endpoints cap at 32 MB (`DOCUMENT_UPLOAD_MAX_BODY_BYTES`). Bulk is further capped at 100 documents per request.
 - **rawPath routing.** All routes are registered with `rawPath: true`, meaning the agent server dispatches them directly without prefix stripping. The path `/api/documents` is absolute.
 - **OWNER_DOCUMENTS is host-adapted.** Do not add a second action here unless the PA-hosted approval, scheduler, and document-request behavior is moved with tests that prove parity.

--- a/plugins/plugin-documents/README.md
+++ b/plugins/plugin-documents/README.md
@@ -47,9 +47,12 @@ headers and `ELIZA_ADMIN_ENTITY_ID` never create an authenticated caller. Roles
 remain exact at this boundary: ADMIN is not OWNER, GUEST is not USER, and an
 unresolved role is rejected. Guests may read global documents in rooms where
 they are current members, but cannot read private scopes or mutate documents.
-Single-document and fragment reads are resolved by `DocumentService` with that
-authenticated context; routes never fetch a parent row or scan fragment bytes
-and then attempt to filter the result locally.
+List, facet, search, single-document, and fragment reads are resolved by
+`DocumentService` with that authenticated context. Routes never fetch a parent
+row, scan the document tables, or rank search results and then attempt to apply
+authorization locally. List pagination and facet counts are constructed only
+from the service-authorized set; fragment counts use the authorized parent and
+fragment path.
 PATCH and DELETE resolve mutation authority through the same service. Deletes
 use the adapter's atomic snapshot operation instead of route-managed fragment
 and parent deletion.

--- a/plugins/plugin-documents/src/routes.canonical-read.test.ts
+++ b/plugins/plugin-documents/src/routes.canonical-read.test.ts
@@ -48,6 +48,7 @@ const fragment: Memory = {
 };
 
 const service = vi.hoisted(() => ({
+  listAllDocumentsWithAccessContext: vi.fn(),
   getDocumentByIdWithAccessContext: vi.fn(),
   getMutableDocumentWithAccessContext: vi.fn(),
   listDocumentFragmentsWithAccessContext: vi.fn(),
@@ -103,6 +104,7 @@ describe("canonical document REST reads", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     service.getDocumentByIdWithAccessContext.mockResolvedValue(document);
+    service.listAllDocumentsWithAccessContext.mockResolvedValue([document]);
     service.getMutableDocumentWithAccessContext.mockResolvedValue(document);
     service.listDocumentFragmentsWithAccessContext.mockResolvedValue([
       fragment,
@@ -113,6 +115,40 @@ describe("canonical document REST reads", () => {
       fragmentCount: 1,
     });
     service.deleteDocumentWithAccessContext.mockResolvedValue(undefined);
+  });
+
+  it("lists parents and counts fragments only through authorized service methods", async () => {
+    const { ctx, response, getMemoryById } = context("/api/documents");
+
+    await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      total: 1,
+      documents: [{ id: DOCUMENT_ID, fragmentCount: 1 }],
+    });
+    expect(service.listAllDocumentsWithAccessContext).toHaveBeenCalledWith(
+      accessContext,
+    );
+    expect(service.listDocumentFragmentsWithAccessContext).toHaveBeenCalledWith(
+      DOCUMENT_ID,
+      accessContext,
+    );
+    expect(getMemoryById).not.toHaveBeenCalled();
+    expect(service.getMemories).not.toHaveBeenCalled();
+  });
+
+  it("computes facets only from the canonically authorized document set", async () => {
+    const { ctx, response } = context("/api/documents/facets");
+
+    await expect(handleDocumentsRoutes(ctx)).resolves.toBe(true);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ counts: { all: 1, doc: 1 } });
+    expect(service.listAllDocumentsWithAccessContext).toHaveBeenCalledWith(
+      accessContext,
+    );
+    expect(service.getMemories).not.toHaveBeenCalled();
   });
 
   it("reads a parent and its count only through authorized service methods", async () => {

--- a/plugins/plugin-documents/src/routes.filters.test.ts
+++ b/plugins/plugin-documents/src/routes.filters.test.ts
@@ -2,8 +2,8 @@
  * Route-level tests for the first-class `roomId` filter and `mediaFormat` facet
  * added in #13593 (knowledge slice 1). Exercises `GET /api/documents` through
  * `handleDocumentsRoutes` with a mock documents service, asserting the new
- * filters compose with tags[] and that access control still applies after
- * filtering (owner-private items don't leak to a non-owner actor).
+ * filters compose with tags[] after the canonical service has authorized the
+ * requester's complete document set.
  */
 import type { AccessContext, Memory, UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
@@ -69,17 +69,18 @@ function seedDocuments(): Memory[] {
 }
 
 function makeRuntimeAndService(docs: Memory[]) {
-  let scanned = false;
   const documentsService = {
-    getMemories: vi.fn(
-      async (params: { tableName: string; offset?: number }) => {
-        if (params.tableName !== "documents") return [];
-        // Single batch: return all on first call, empty after.
-        if (scanned) return [];
-        scanned = true;
-        return docs;
-      },
+    getMemories: vi.fn(async () => []),
+    listAllDocumentsWithAccessContext: vi.fn(
+      async (accessContext: AccessContext) =>
+        docs.filter((doc) => {
+          const metadata = doc.metadata as Record<string, unknown>;
+          return accessContext.isOwner
+            ? metadata.scope === "owner-private"
+            : metadata.scopedToEntityId === accessContext.requesterEntityId;
+        }),
     ),
+    listDocumentFragmentsWithAccessContext: vi.fn(async () => []),
     countMemories: vi.fn(async () => docs.length),
     addDocument: vi.fn(),
     searchDocuments: vi.fn(async () => []),
@@ -383,6 +384,9 @@ describe("GET /api/documents/search — roomId pushed into service scope (#13593
       | { roomId?: string }
       | undefined;
     expect(scopeArg?.roomId).toBe(ROOM_A);
+    expect(searchDocuments.mock.calls[0][3]).toEqual(
+      makeAccessContext(OWNER_ENTITY),
+    );
   });
 
   it("keeps help-tagged fragment results when free-text search also has tag=help", async () => {

--- a/plugins/plugin-documents/src/routes.ts
+++ b/plugins/plugin-documents/src/routes.ts
@@ -11,7 +11,6 @@ import {
   actorCanManageOwnerDocuments,
   asRecord,
   asUuid,
-  canReadDocumentMemory,
   type DocumentReadableMemory,
   documentMediaFormat,
   documentTags,
@@ -72,7 +71,6 @@ export interface DocumentRouteContext extends RouteRequestContext {
 
 const DOCUMENTS_TABLE = "documents";
 const DOCUMENT_FRAGMENTS_TABLE = "document_fragments";
-const FRAGMENT_BATCH_SIZE = 500;
 const DOCUMENT_UPLOAD_MAX_BODY_BYTES = 32 * 1_048_576; // 32 MB
 const MAX_BULK_DOCUMENTS = 100;
 const DOCUMENT_CONTENT_TYPE_VALIDATION_ERROR =
@@ -504,97 +502,35 @@ function decodeMatchedPathComponent(
   }
 }
 
-async function mapDocumentFragmentsByDocumentId(
-  documentsService: DocumentsServiceLike,
-  roomId: UUID | undefined,
-  documentIds: readonly UUID[],
-): Promise<Map<UUID, number>> {
-  const fragmentCounts = new Map<UUID, number>();
-  const trackedDocumentIds = new Set(documentIds);
-  for (const documentId of trackedDocumentIds) {
-    fragmentCounts.set(documentId, 0);
-  }
-
-  if (trackedDocumentIds.size === 0) return fragmentCounts;
-
-  let offset = 0;
-  while (true) {
-    const fragmentBatch = await documentsService.getMemories({
-      tableName: DOCUMENT_FRAGMENTS_TABLE,
-      roomId,
-      count: FRAGMENT_BATCH_SIZE,
-      offset,
-    });
-
-    if (fragmentBatch.length === 0) break;
-
-    for (const memory of fragmentBatch) {
-      const metadata = asRecord(memory.metadata);
-      const documentId = metadata?.documentId;
-      if (
-        typeof documentId === "string" &&
-        trackedDocumentIds.has(documentId as UUID)
-      ) {
-        const currentCount = fragmentCounts.get(documentId as UUID) ?? 0;
-        fragmentCounts.set(documentId as UUID, currentCount + 1);
-      }
-    }
-
-    if (fragmentBatch.length < FRAGMENT_BATCH_SIZE) break;
-    offset += FRAGMENT_BATCH_SIZE;
-  }
-
-  return fragmentCounts;
-}
-
 async function listDocumentMemories({
   documentsService,
   agentId,
-  actor,
+  accessContext,
   filters,
   limit,
   offset,
 }: {
   documentsService: DocumentsServiceLike;
   agentId: UUID;
-  actor: RouteActor;
+  accessContext: AccessContext;
   filters: DocumentFilter;
   limit: number;
   offset: number;
 }): Promise<{ documents: Memory[]; total: number }> {
-  let scanOffset = 0;
-  let total = 0;
-  const documents: Memory[] = [];
-
-  while (true) {
-    const batch = await documentsService.getMemories({
-      tableName: DOCUMENTS_TABLE,
-      count: FRAGMENT_BATCH_SIZE,
-      offset: scanOffset,
-    });
-
-    if (batch.length === 0) break;
-
-    for (const memory of batch) {
-      if (
-        !isDocumentMemory(memory, agentId) ||
-        !matchesDocumentFilter(memory, filters) ||
-        !canReadDocumentMemory(memory, actor, filters)
-      ) {
-        continue;
-      }
-
-      if (total >= offset && documents.length < limit) {
-        documents.push(memory);
-      }
-      total += 1;
-    }
-
-    if (batch.length < FRAGMENT_BATCH_SIZE) break;
-    scanOffset += FRAGMENT_BATCH_SIZE;
+  if (!documentsService.listAllDocumentsWithAccessContext) {
+    throw new Error("Canonical document listing is unavailable");
   }
-
-  return { documents, total };
+  const matching = (
+    await documentsService.listAllDocumentsWithAccessContext(accessContext)
+  ).filter(
+    (memory) =>
+      isDocumentMemory(memory, agentId) &&
+      matchesDocumentFilter(memory, filters),
+  );
+  return {
+    documents: matching.slice(offset, offset + limit),
+    total: matching.length,
+  };
 }
 
 /**
@@ -608,12 +544,12 @@ async function listDocumentMemories({
 async function countDocumentFacets({
   documentsService,
   agentId,
-  actor,
+  accessContext,
   filters,
 }: {
   documentsService: DocumentsServiceLike;
   agentId: UUID;
-  actor: RouteActor;
+  accessContext: AccessContext;
   filters: DocumentFilter;
 }): Promise<Record<KnowledgeHubFacet, number>> {
   const counts: Record<KnowledgeHubFacet, number> = {
@@ -627,36 +563,26 @@ async function countDocumentFacets({
   // Drop the hub facet so the scan sees every bucket; keep the rest of the
   // narrowing (scope/room/tag/search) so counts match the visible list.
   const { knowledgeFacet: _ignored, ...baseFilters } = filters;
-  let scanOffset = 0;
-
-  while (true) {
-    const batch = await documentsService.getMemories({
-      tableName: DOCUMENTS_TABLE,
-      count: FRAGMENT_BATCH_SIZE,
-      offset: scanOffset,
-    });
-    if (batch.length === 0) break;
-
-    for (const memory of batch) {
-      if (
-        !isDocumentMemory(memory, agentId) ||
-        !matchesDocumentFilter(memory, baseFilters) ||
-        !canReadDocumentMemory(memory, actor, baseFilters)
-      ) {
-        continue;
-      }
-      const metadata = asRecord(memory.metadata);
-      const documentTags = Array.isArray(metadata?.tags)
-        ? metadata.tags.filter(
-            (value): value is string => typeof value === "string",
-          )
-        : [];
-      counts[documentHubFacet(metadata, documentTags)] += 1;
-      counts.all += 1;
+  if (!documentsService.listAllDocumentsWithAccessContext) {
+    throw new Error("Canonical document listing is unavailable");
+  }
+  const authorized =
+    await documentsService.listAllDocumentsWithAccessContext(accessContext);
+  for (const memory of authorized) {
+    if (
+      !isDocumentMemory(memory, agentId) ||
+      !matchesDocumentFilter(memory, baseFilters)
+    ) {
+      continue;
     }
-
-    if (batch.length < FRAGMENT_BATCH_SIZE) break;
-    scanOffset += FRAGMENT_BATCH_SIZE;
+    const metadata = asRecord(memory.metadata);
+    const documentTags = Array.isArray(metadata?.tags)
+      ? metadata.tags.filter(
+          (value): value is string => typeof value === "string",
+        )
+      : [];
+    counts[documentHubFacet(metadata, documentTags)] += 1;
+    counts.all += 1;
   }
 
   return counts;
@@ -839,10 +765,14 @@ export async function handleDocumentsRoutes(
     // every bucket is counted; the remaining scope/room/tag/search filters are
     // honored so the counts describe the current narrowing.
     const filters = filtersFromSearchParams(url, { includeTextQuery: true });
+    if (!documentsService.listAllDocumentsWithAccessContext) {
+      error(res, "Canonical document authorization is unavailable", 503);
+      return true;
+    }
     const counts = await countDocumentFacets({
       documentsService,
       agentId,
-      actor: routeActor,
+      accessContext,
       filters,
     });
     json(res, {
@@ -859,20 +789,38 @@ export async function handleDocumentsRoutes(
     const offset = parsePositiveInteger(url.searchParams.get("offset"), 0);
     const filters = filtersFromSearchParams(url, { includeTextQuery: true });
 
+    if (
+      !documentsService.listAllDocumentsWithAccessContext ||
+      !documentsService.listDocumentFragmentsWithAccessContext
+    ) {
+      error(res, "Canonical document authorization is unavailable", 503);
+      return true;
+    }
+    const listAuthorizedFragments =
+      documentsService.listDocumentFragmentsWithAccessContext.bind(
+        documentsService,
+      );
+
     const { documents, total } = await listDocumentMemories({
       documentsService,
       agentId,
-      actor: routeActor,
+      accessContext,
       filters,
       limit,
       offset,
     });
-    const documentIds = documents.filter(hasUuidId).map((doc) => doc.id);
-    const fragmentCounts = await mapDocumentFragmentsByDocumentId(
-      documentsService,
-      undefined,
-      documentIds,
+    const fragmentCountEntries = await Promise.all(
+      documents
+        .filter(hasUuidId)
+        .map(
+          async (doc) =>
+            [
+              doc.id,
+              (await listAuthorizedFragments(doc.id, accessContext)).length,
+            ] as const,
+        ),
     );
+    const fragmentCounts = new Map(fragmentCountEntries);
     const cleanedDocuments = documents.map((doc) =>
       presentDocument(
         doc,
@@ -933,12 +881,12 @@ export async function handleDocumentsRoutes(
       searchMessage,
       serviceSearchScope(filters),
       searchMode,
+      accessContext,
     );
 
     const filteredResults = results
       .filter((result) => (result.similarity ?? 0) >= threshold)
       .filter((result) => matchesDocumentFilter(result, filters))
-      .filter((result) => canReadDocumentMemory(result, routeActor, filters))
       .slice(0, limit)
       .map((result) => {
         const meta = asRecord(result.metadata);


### PR DESCRIPTION
Closes part of #24246.

## Outcome
- routes list and facet documents only from an AccessContext-authorized DocumentService result
- search authorization is pushed into DocumentService before ranking/capping
- per-document fragment counts use the authorized fragment query instead of a raw table scan
- list accumulation re-resolves membership before returning, so revocation applies immediately
- route contract tests spy on canonical methods and prove raw memory scans do not execute

## Verification
- `bun run --cwd plugins/plugin-documents test` — 126 passed
- `bun test packages/core/src/features/documents/service-list.test.ts -t 'excludes room documents immediately'` — 1 passed
- `bun run --cwd packages/core build` — passed, including packed consumer verification
- `bun run --cwd plugins/plugin-documents build` — passed
- `bun run --cwd plugins/plugin-documents lint` — passed
- `bun run check:agents-claude` — 159 pairs passed
- `bun run --cwd plugins/plugin-documents typecheck` — blocked by existing unresolved workspace exports (`@elizaos/ui/spatial`, `@elizaos/ui/api`, `@elizaos/shared`); package build succeeds
- full `service-list.test.ts` retains 3 pre-existing failures outside this slice; the new revocation test passes in isolation

## Attribution
- Model: OpenAI / gpt-5.6-sol
- Tool: Codex Desktop / multi-agent
- Skill: N/A - no repository contribution skill used
