### PR TITLE
feat(identity): add authenticated person-link attestations

### DIFF
--- a/packages/core/src/types/identity.ts
+++ b/packages/core/src/types/identity.ts
@@ -270,6 +270,62 @@ export interface IdentityJournalPage {
 	nextCursor: string | null;
 }
 
+export const IDENTITY_PERSON_LINK_ACTOR_ROLES = ["OWNER", "ADMIN"] as const;
+export type IdentityPersonLinkActorRole =
+	(typeof IDENTITY_PERSON_LINK_ACTOR_ROLES)[number];
+
+/** Immutable evidence that an authenticated operator attested two principals are one person. */
+export interface IdentityPersonLinkAttestation {
+	contractVersion: typeof IDENTITY_AUTHORITY_CONTRACT_VERSION;
+	id: UUID;
+	agentId: UUID;
+	leftPrincipalId: UUID;
+	rightPrincipalId: UUID;
+	actorPrincipalId: UUID;
+	actorRole: IdentityPersonLinkActorRole;
+	authority: "authenticated_private_route";
+	transport: "http" | "in_process";
+	reason: string;
+	idempotencyKey: string;
+	requestDigest: string;
+	expectedGeneration: number;
+	committedGeneration: number;
+	createdAt: string;
+}
+
+export interface AttestIdentityPersonLinkRequest {
+	agentId: UUID;
+	leftPrincipalId: UUID;
+	rightPrincipalId: UUID;
+	actorPrincipalId: UUID;
+	actorRole: IdentityPersonLinkActorRole;
+	authority: "authenticated_private_route";
+	transport: "http" | "in_process";
+	reason: string;
+	idempotencyKey: string;
+	requestDigest: string;
+	expectedGeneration: number;
+}
+
+export interface VerifyIdentityPersonLinkRequest {
+	agentId: UUID;
+	leftPrincipalId: UUID;
+	rightPrincipalId: UUID;
+	expectedGeneration: number;
+}
+
+export type IdentityPersonLinkVerification =
+	| {
+			decision: "attested";
+			generation: number;
+			attestation: IdentityPersonLinkAttestation;
+	  }
+	| {
+			decision: "not_attested";
+			generation: number;
+			reason: "no_attestation";
+	  };
+
 /** Single runtime authority for identity reads and reversible mutations. */
 export abstract class IdentityResolutionService extends Service {
 	static override readonly serviceType = ServiceType.IDENTITY_RESOLUTION;
@@ -303,6 +359,12 @@ export abstract class IdentityResolutionService extends Service {
 	abstract evaluateOwnerBinding(
 		request: EvaluateOwnerBindingRequest,
 	): Promise<OwnerBindingEvaluation>;
+	abstract attestPersonLink(
+		request: AttestIdentityPersonLinkRequest,
+	): Promise<IdentityPersonLinkAttestation>;
+	abstract verifyPersonLink(
+		request: VerifyIdentityPersonLinkRequest,
+	): Promise<IdentityPersonLinkVerification>;
 	abstract proposeMerge(
 		request: ProposeIdentityMergeRequest,
 	): Promise<IdentityMergePlan>;

--- a/plugins/plugin-sql/AGENTS.md
+++ b/plugins/plugin-sql/AGENTS.md
@@ -13,9 +13,12 @@ The exported `plugin` object (`src/index.ts` / `src/index.node.ts` / `src/index.
 | Kind | Name | Description |
 |------|------|-------------|
 | Service | `AdvancedMemoryStorageService` (`serviceType = "memoryStorage"`) | Implements `MemoryStorageProvider`; persists long-term memories and session summaries to dedicated SQL tables via the runtime memory API |
+| Service | `SqlIdentityResolutionService` (`serviceType = "IDENTITY_RESOLUTION"`) | Canonical generation-fenced identity authority for claims, person-link attestations, reversible redirects, merge/split journals, and owner-binding reads |
+| Route | `POST /api/identity/person-links/attest` | Private OWNER/ADMIN ingress; requires an authenticated `AccessContext`, derives actor authority from it, and records immutable same-person evidence without merging principals |
+| Route | `GET /api/identity/person-links/verify` | Private exact-generation verification; also requires OWNER/ADMIN `AccessContext` |
 | Schema | `schema` (all tables) | Passed as `plugin.schema` so `DatabaseMigrationService` can auto-migrate at startup |
 
-No actions, providers, evaluators, routes, or event handlers are registered by this plugin.
+No actions, providers, evaluators, or event handlers are registered by this plugin. Identity mutation is never model-callable.
 
 ## Layout
 
@@ -34,6 +37,8 @@ plugins/plugin-sql/
     utils/
       string-to-uuid.ts         String-to-UUID conversion utility
     connector-credential-store.ts  ConnectorCredentialStore/Vault interfaces + factory
+    routes/
+      identity-person-link.ts    Authenticated operator attestation + verification routes
     migration-service.ts        DatabaseMigrationService — discovers plugin schemas, runs migrations, re-applies RLS
     migrations.ts               One-off migrations (e.g., entity RLS backfill)
     rls.ts                      Row Level Security helpers (install/apply/uninstall)
@@ -53,6 +58,7 @@ plugins/plugin-sql/
       agent.ts / room.ts / memory.ts / entity.ts / ...  One file per table
     services/
       advanced-memory-storage.ts  AdvancedMemoryStorageService implementation
+      sql-identity-resolution.ts  Canonical identity authority implementation
     stores/
       agent.store.ts / memory.store.ts / room.store.ts / ...  Query logic split by domain
     runtime-migrator/

--- a/plugins/plugin-sql/CLAUDE.md
+++ b/plugins/plugin-sql/CLAUDE.md
@@ -13,9 +13,12 @@ The exported `plugin` object (`src/index.ts` / `src/index.node.ts` / `src/index.
 | Kind | Name | Description |
 |------|------|-------------|
 | Service | `AdvancedMemoryStorageService` (`serviceType = "memoryStorage"`) | Implements `MemoryStorageProvider`; persists long-term memories and session summaries to dedicated SQL tables via the runtime memory API |
+| Service | `SqlIdentityResolutionService` (`serviceType = "IDENTITY_RESOLUTION"`) | Canonical generation-fenced identity authority for claims, person-link attestations, reversible redirects, merge/split journals, and owner-binding reads |
+| Route | `POST /api/identity/person-links/attest` | Private OWNER/ADMIN ingress; requires an authenticated `AccessContext`, derives actor authority from it, and records immutable same-person evidence without merging principals |
+| Route | `GET /api/identity/person-links/verify` | Private exact-generation verification; also requires OWNER/ADMIN `AccessContext` |
 | Schema | `schema` (all tables) | Passed as `plugin.schema` so `DatabaseMigrationService` can auto-migrate at startup |
 
-No actions, providers, evaluators, routes, or event handlers are registered by this plugin.
+No actions, providers, evaluators, or event handlers are registered by this plugin. Identity mutation is never model-callable.
 
 ## Layout
 
@@ -34,6 +37,8 @@ plugins/plugin-sql/
     utils/
       string-to-uuid.ts         String-to-UUID conversion utility
     connector-credential-store.ts  ConnectorCredentialStore/Vault interfaces + factory
+    routes/
+      identity-person-link.ts    Authenticated operator attestation + verification routes
     migration-service.ts        DatabaseMigrationService — discovers plugin schemas, runs migrations, re-applies RLS
     migrations.ts               One-off migrations (e.g., entity RLS backfill)
     rls.ts                      Row Level Security helpers (install/apply/uninstall)
@@ -53,6 +58,7 @@ plugins/plugin-sql/
       agent.ts / room.ts / memory.ts / entity.ts / ...  One file per table
     services/
       advanced-memory-storage.ts  AdvancedMemoryStorageService implementation
+      sql-identity-resolution.ts  Canonical identity authority implementation
     stores/
       agent.store.ts / memory.store.ts / room.store.ts / ...  Query logic split by domain
     runtime-migrator/

--- a/plugins/plugin-sql/README.md
+++ b/plugins/plugin-sql/README.md
@@ -12,6 +12,24 @@ bun add @elizaos/plugin-sql
 
 This plugin registers a `DatabaseAdapter` with the elizaOS agent runtime so that all core runtime persistence (memories, entities, rooms, tasks, cache, logs, relationships, etc.) works against a real SQL backend. On Node/Bun it selects PostgreSQL when `POSTGRES_URL` is set, otherwise falls back to embedded PGlite. In the browser build it always uses PGlite (WASM).
 
+## Identity authority
+
+The plugin registers `SqlIdentityResolutionService` as the runtime's canonical
+identity authority. Its private person-link endpoints let an authenticated
+OWNER or ADMIN attest that two preserved principals represent the same person
+without merging or deleting either principal:
+
+- `POST /api/identity/person-links/attest` accepts the two principal IDs, the
+  exact expected identity generation, a reason, and an idempotency key. Actor,
+  role, authority kind, and transport evidence are derived from a required
+  authenticated `AccessContext`; missing context fails closed.
+- `GET /api/identity/person-links/verify` verifies the pair at an exact
+  generation and returns `attested` or `not_attested`.
+
+The attestation request rejects unknown fields, including client-authored
+`confirmed`, `verified`, actor, and role values. Attestations are immutable
+audit evidence and never create canonical redirects or merge-journal rows.
+
 ## Database Schema
 
 The plugin uses the following main tables:

--- a/plugins/plugin-sql/src/__tests__/identity-authority-schema.test.ts
+++ b/plugins/plugin-sql/src/__tests__/identity-authority-schema.test.ts
@@ -10,6 +10,7 @@ import {
   identityClaimTable,
   identityMergeConfirmationTable,
   identityMergeJournalTable,
+  identityPersonLinkAttestationTable,
 } from "../schema/identityAuthority";
 
 describe("canonical identity authority schema", () => {
@@ -84,6 +85,24 @@ describe("canonical identity authority schema", () => {
       ])
     );
     expect(confirmation.foreignKeys).toHaveLength(3);
+  });
+
+  it("binds immutable person-link evidence to an operator and generation", () => {
+    const config = getTableConfig(identityPersonLinkAttestationTable);
+
+    expect(config.name).toBe("identity_person_link_attestations");
+    expect(config.foreignKeys).toHaveLength(4);
+    expect(config.uniqueConstraints.map((constraint) => constraint.name)).toContain(
+      "identity_person_link_attestation_idempotency_unique"
+    );
+    expect(config.checks.map((constraint) => constraint.name)).toEqual(
+      expect.arrayContaining([
+        "identity_person_link_attestation_order_check",
+        "identity_person_link_attestation_actor_role_check",
+        "identity_person_link_attestation_authority_check",
+        "identity_person_link_attestation_generation_check",
+      ])
+    );
   });
 
   it("keeps versioned redirects and forbids self-canonicalization", () => {

--- a/plugins/plugin-sql/src/__tests__/identity-person-link-registration.test.ts
+++ b/plugins/plugin-sql/src/__tests__/identity-person-link-registration.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Verifies the SQL plugin activates the canonical identity service and its
+ * private person-link routes without registering any model-callable action.
+ */
+import { IdentityResolutionService } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { plugin } from "../index";
+
+describe("identity person-link registration", () => {
+  it("registers one canonical service and private routes, with no actions", () => {
+    expect(
+      plugin.services?.some(
+        (service) => service.serviceType === IdentityResolutionService.serviceType
+      )
+    ).toBe(true);
+    expect(plugin.routes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "identity-person-link-attest",
+          type: "POST",
+          public: false,
+        }),
+        expect.objectContaining({
+          name: "identity-person-link-verify",
+          type: "GET",
+          public: false,
+        }),
+      ])
+    );
+    expect(plugin.actions).toBeUndefined();
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/identity-person-link-attestation.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/identity-person-link-attestation.real.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Exercises authenticated person-link ingress against a real migrated PGlite
+ * authority, including stale generations, forged fields, replay, and proof
+ * that attestations never create redirects or merge journals.
+ */
+import { IdentityResolutionService, type RouteHandlerContext, type UUID } from "@elizaos/core";
+import { count, eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { identityPersonLinkRoutes } from "../../routes/identity-person-link";
+import { entityTable } from "../../schema/entity";
+import {
+  identityAuthorityStateTable,
+  identityCanonicalRedirectTable,
+  identityMergeJournalTable,
+  identityPersonLinkAttestationTable,
+} from "../../schema/identityAuthority";
+import { SqlIdentityResolutionService } from "../../services/sql-identity-resolution";
+import type { DrizzleDatabase } from "../../types";
+import { createIsolatedTestDatabase } from "../test-helpers";
+
+const actorId = crypto.randomUUID() as UUID;
+const leftId = crypto.randomUUID() as UUID;
+const rightId = crypto.randomUUID() as UUID;
+const otherLeftId = crypto.randomUUID() as UUID;
+const otherRightId = crypto.randomUUID() as UUID;
+
+describe.sequential("authenticated identity person-link ingress", () => {
+  let cleanup: () => Promise<void>;
+  let db: DrizzleDatabase;
+  let runtime: Awaited<ReturnType<typeof createIsolatedTestDatabase>>["runtime"];
+  let service: SqlIdentityResolutionService;
+  let agentId: UUID;
+
+  const attestRoute = identityPersonLinkRoutes.find(
+    (route) => route.name === "identity-person-link-attest"
+  );
+  const verifyRoute = identityPersonLinkRoutes.find(
+    (route) => route.name === "identity-person-link-verify"
+  );
+
+  beforeAll(async () => {
+    const setup = await createIsolatedTestDatabase("identity-person-link-attestation-real");
+    cleanup = setup.cleanup;
+    db = setup.adapter.getDatabase() as DrizzleDatabase;
+    runtime = setup.runtime;
+    agentId = setup.testAgentId;
+    service = new SqlIdentityResolutionService(runtime);
+    vi.spyOn(runtime, "getService").mockImplementation((type) =>
+      type === IdentityResolutionService.serviceType ? service : null
+    );
+    await db.insert(entityTable).values(
+      [actorId, leftId, rightId, otherLeftId, otherRightId].map((id) => ({
+        id,
+        agentId,
+        names: [id],
+        metadata: {},
+      }))
+    );
+  });
+
+  afterAll(async () => {
+    await cleanup?.();
+  });
+
+  function context(args: {
+    body?: unknown;
+    query?: Record<string, string>;
+    role?: "OWNER" | "ADMIN" | "USER";
+  }): RouteHandlerContext {
+    return {
+      body: args.body,
+      params: {},
+      query: args.query ?? {},
+      headers: {},
+      method: args.query ? "GET" : "POST",
+      path: args.query ? "/api/identity/person-links/verify" : "/api/identity/person-links/attest",
+      runtime,
+      inProcess: false,
+      ...(args.role
+        ? {
+            accessContext: {
+              requesterEntityId: actorId,
+              role: args.role,
+              isOwner: args.role === "OWNER",
+            },
+          }
+        : {}),
+    };
+  }
+
+  it("persists server-derived ADMIN evidence and verifies it at the committed generation", async () => {
+    expect(attestRoute).toMatchObject({ type: "POST", public: false });
+    expect(verifyRoute).toMatchObject({ type: "GET", public: false });
+    if (!attestRoute?.routeHandler || !verifyRoute?.routeHandler) throw new Error("routes missing");
+
+    const body = {
+      leftPrincipalId: rightId,
+      rightPrincipalId: leftId,
+      expectedGeneration: 0,
+      reason: "Operator checked both authenticated accounts",
+      idempotencyKey: "person-link-admin-1",
+    };
+    const created = await attestRoute.routeHandler(context({ body, role: "ADMIN" }));
+    expect(created.status).toBe(201);
+    expect(created.body).toMatchObject({
+      attestation: {
+        actorPrincipalId: actorId,
+        actorRole: "ADMIN",
+        authority: "authenticated_private_route",
+        transport: "http",
+        expectedGeneration: 0,
+        committedGeneration: 1,
+      },
+    });
+
+    const rows = await db.select().from(identityPersonLinkAttestationTable);
+    expect(rows).toHaveLength(1);
+    const persisted = rows[0];
+    if (!persisted) throw new Error("attestation missing");
+    expect(persisted).toMatchObject({
+      leftPrincipalId: [leftId, rightId].sort()[0],
+      rightPrincipalId: [leftId, rightId].sort()[1],
+      actorPrincipalId: actorId,
+      actorRole: "ADMIN",
+      expectedGeneration: 0,
+      committedGeneration: 1,
+    });
+    expect(await db.select().from(identityCanonicalRedirectTable)).toHaveLength(0);
+    expect(await db.select().from(identityMergeJournalTable)).toHaveLength(0);
+    const updateError = await db
+      .update(identityPersonLinkAttestationTable)
+      .set({ reason: "tampered" })
+      .where(eq(identityPersonLinkAttestationTable.id, persisted.id))
+      .then(
+        () => null,
+        (error: unknown) => error
+      );
+    const deleteError = await db
+      .delete(identityPersonLinkAttestationTable)
+      .where(eq(identityPersonLinkAttestationTable.id, persisted.id))
+      .then(
+        () => null,
+        (error: unknown) => error
+      );
+    expect(updateError).toHaveProperty("cause.code", "55000");
+    expect(deleteError).toHaveProperty("cause.code", "55000");
+
+    const verified = await verifyRoute.routeHandler(
+      context({
+        role: "OWNER",
+        query: {
+          leftPrincipalId: leftId,
+          rightPrincipalId: rightId,
+          expectedGeneration: "1",
+        },
+      })
+    );
+    expect(verified).toMatchObject({
+      status: 200,
+      body: {
+        verification: {
+          decision: "attested",
+          generation: 1,
+          attestation: { actorRole: "ADMIN", committedGeneration: 1 },
+        },
+      },
+    });
+    const staleVerification = await verifyRoute.routeHandler(
+      context({
+        role: "OWNER",
+        query: {
+          leftPrincipalId: leftId,
+          rightPrincipalId: rightId,
+          expectedGeneration: "0",
+        },
+      })
+    );
+    expect(staleVerification).toMatchObject({
+      status: 409,
+      body: { error: "IDENTITY_GENERATION_CONFLICT" },
+    });
+
+    const replayed = await attestRoute.routeHandler(context({ body, role: "ADMIN" }));
+    expect(replayed).toEqual(created);
+    expect(await db.select().from(identityPersonLinkAttestationTable)).toHaveLength(1);
+  });
+
+  it("rejects model-shaped authority fields and non-admin users before mutation", async () => {
+    if (!attestRoute?.routeHandler) throw new Error("attest route missing");
+    const [before] = await db.select().from(identityAuthorityStateTable);
+    const beforeCount = await db
+      .select({ value: count() })
+      .from(identityPersonLinkAttestationTable);
+    const forged = await attestRoute.routeHandler(
+      context({
+        role: "OWNER",
+        body: {
+          leftPrincipalId: otherLeftId,
+          rightPrincipalId: otherRightId,
+          expectedGeneration: 1,
+          reason: "model says same person",
+          idempotencyKey: "forged-authority",
+          confirmed: true,
+          verified: true,
+          actorRole: "OWNER",
+        },
+      })
+    );
+    expect(forged).toMatchObject({
+      status: 400,
+      body: { error: "IDENTITY_PERSON_LINK_INPUT_INVALID" },
+    });
+    const ordinaryUser = await attestRoute.routeHandler(
+      context({
+        role: "USER",
+        body: {
+          leftPrincipalId: otherLeftId,
+          rightPrincipalId: otherRightId,
+          expectedGeneration: 1,
+          reason: "not authorized",
+          idempotencyKey: "ordinary-user",
+        },
+      })
+    );
+    expect(ordinaryUser).toMatchObject({
+      status: 403,
+      body: { error: "IDENTITY_PERSON_LINK_AUTHORITY_REQUIRED" },
+    });
+    const [after] = await db.select().from(identityAuthorityStateTable);
+    const afterCount = await db.select({ value: count() }).from(identityPersonLinkAttestationTable);
+    expect(after?.generation).toBe(before?.generation);
+    expect(afterCount[0]?.value).toBe(beforeCount[0]?.value);
+  });
+
+  it("rejects a missing access context before service or database access", async () => {
+    if (!attestRoute?.routeHandler) throw new Error("attest route missing");
+    const attestSpy = vi.spyOn(service, "attestPersonLink");
+    const callsBefore = attestSpy.mock.calls.length;
+    const [before] = await db.select().from(identityAuthorityStateTable);
+    const beforeCount = await db
+      .select({ value: count() })
+      .from(identityPersonLinkAttestationTable);
+    const missingContext = await attestRoute.routeHandler(
+      context({
+        body: {
+          leftPrincipalId: otherLeftId,
+          rightPrincipalId: otherRightId,
+          expectedGeneration: 1,
+          reason: "must not inherit configured owner",
+          idempotencyKey: "missing-access-context",
+        },
+      })
+    );
+    expect(missingContext).toMatchObject({
+      status: 403,
+      body: { error: "IDENTITY_PERSON_LINK_AUTHORITY_REQUIRED" },
+    });
+    expect(attestSpy.mock.calls).toHaveLength(callsBefore);
+    const [after] = await db.select().from(identityAuthorityStateTable);
+    const afterCount = await db.select({ value: count() }).from(identityPersonLinkAttestationTable);
+    expect(after?.generation).toBe(before?.generation);
+    expect(afterCount[0]?.value).toBe(beforeCount[0]?.value);
+  });
+
+  it("allows exactly one concurrent attestation at a generation and leaves no merge artifacts", async () => {
+    if (!attestRoute?.routeHandler) throw new Error("attest route missing");
+    const request = (leftPrincipalId: UUID, rightPrincipalId: UUID, idempotencyKey: string) =>
+      attestRoute.routeHandler?.(
+        context({
+          role: "OWNER",
+          body: {
+            leftPrincipalId,
+            rightPrincipalId,
+            expectedGeneration: 1,
+            reason: "concurrent operator decision",
+            idempotencyKey,
+          },
+        })
+      );
+    const outcomes = await Promise.all([
+      request(otherLeftId, otherRightId, "generation-race-left"),
+      request(leftId, otherLeftId, "generation-race-right"),
+    ]);
+    expect(outcomes.map((result) => result?.status).sort()).toEqual([201, 409]);
+    const [state] = await db
+      .select()
+      .from(identityAuthorityStateTable)
+      .where(eq(identityAuthorityStateTable.agentId, agentId));
+    expect(state?.generation).toBe(2);
+    expect(await db.select().from(identityPersonLinkAttestationTable)).toHaveLength(2);
+    expect(await db.select().from(identityCanonicalRedirectTable)).toHaveLength(0);
+    expect(await db.select().from(identityMergeJournalTable)).toHaveLength(0);
+  });
+});

--- a/plugins/plugin-sql/src/identity-person-link-attestation-guard.ts
+++ b/plugins/plugin-sql/src/identity-person-link-attestation-guard.ts
@@ -1,0 +1,48 @@
+/**
+ * Installs the database-enforced append-only guard for authenticated person-link
+ * evidence after runtime migration has materialized the authority table.
+ */
+import { sql } from "drizzle-orm";
+import type { DrizzleDatabase } from "./types";
+
+function resultRows(value: unknown): readonly unknown[] {
+  if (Array.isArray(value)) return value;
+  if (typeof value !== "object" || value === null) return [];
+  const rows = (value as { rows?: unknown }).rows;
+  return Array.isArray(rows) ? rows : [];
+}
+
+/** Install or refresh the trigger that rejects attestation UPDATE and DELETE. */
+export async function applyIdentityPersonLinkAttestationGuard(
+  db: DrizzleDatabase
+): Promise<boolean> {
+  const present = await db.execute(sql`
+    SELECT 1 AS present
+      FROM information_schema.tables
+     WHERE table_schema = 'public'
+       AND table_name = 'identity_person_link_attestations'
+     LIMIT 1
+  `);
+  if (resultRows(present).length === 0) return false;
+
+  await db.execute(sql`
+    CREATE OR REPLACE FUNCTION reject_identity_person_link_attestation_mutation()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      RAISE EXCEPTION 'identity_person_link_attestations is append-only'
+        USING ERRCODE = '55000';
+    END;
+    $$
+  `);
+  await db.execute(
+    sql`DROP TRIGGER IF EXISTS identity_person_link_attestation_append_only ON identity_person_link_attestations`
+  );
+  await db.execute(sql`
+    CREATE TRIGGER identity_person_link_attestation_append_only
+    BEFORE UPDATE OR DELETE ON identity_person_link_attestations
+    FOR EACH ROW EXECUTE FUNCTION reject_identity_person_link_attestation_mutation()
+  `);
+  return true;
+}

--- a/plugins/plugin-sql/src/index.browser.ts
+++ b/plugins/plugin-sql/src/index.browser.ts
@@ -26,8 +26,10 @@ import {
   type PgliteManagerCache,
   type PgliteSingletonCache,
 } from "./pglite/manager-cache";
+import { identityPersonLinkRoutes } from "./routes/identity-person-link";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
+import { SqlIdentityResolutionService } from "./services/sql-identity-resolution";
 
 const GLOBAL_SINGLETONS = Symbol.for("elizaos.plugin-sql.global-singletons");
 
@@ -114,11 +116,8 @@ export const plugin: Plugin = {
   description: "A plugin for SQL database access (PGlite WASM in browser).",
   priority: 0,
   schema: schema,
-  // Identity authority is exported for explicit hosts and integration tests,
-  // but remains cutover-gated until owner claims are backfilled. Registering
-  // it early would make role resolution prefer an empty authority over the
-  // verified owner-pairing compatibility path.
-  services: [AdvancedMemoryStorageService],
+  services: [AdvancedMemoryStorageService, SqlIdentityResolutionService],
+  routes: [...identityPersonLinkRoutes],
   init: async (_config, runtime: IAgentRuntime) => {
     const runtimeWithAdapter = runtime as IAgentRuntime & RuntimeWithAdapterRegistrar;
     logger.info({ src: "plugin:sql" }, "plugin-sql (browser) init starting");

--- a/plugins/plugin-sql/src/index.node.ts
+++ b/plugins/plugin-sql/src/index.node.ts
@@ -51,8 +51,10 @@ import {
   type PgliteManagerCache,
   type PgliteSingletonCache,
 } from "./pglite/manager-cache";
+import { identityPersonLinkRoutes } from "./routes/identity-person-link";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
+import { SqlIdentityResolutionService } from "./services/sql-identity-resolution";
 import { stringToUuid } from "./utils/string-to-uuid";
 import { resolvePgliteDir } from "./utils.node.ts";
 
@@ -179,11 +181,8 @@ export const plugin: Plugin = {
   description: "A plugin for SQL database access with dynamic schema migrations",
   priority: 0,
   schema: schema,
-  // Identity authority is exported for explicit hosts and integration tests,
-  // but remains cutover-gated until owner claims are backfilled. Registering
-  // it early would make role resolution prefer an empty authority over the
-  // verified owner-pairing compatibility path.
-  services: [AdvancedMemoryStorageService],
+  services: [AdvancedMemoryStorageService, SqlIdentityResolutionService],
+  routes: [...identityPersonLinkRoutes],
   init: async (_config, runtime: IAgentRuntime) => {
     const runtimeWithAdapter = runtime as IAgentRuntime & RuntimeWithAdapterRegistrar;
     runtime.logger.info(

--- a/plugins/plugin-sql/src/index.ts
+++ b/plugins/plugin-sql/src/index.ts
@@ -51,8 +51,10 @@ import {
   type PgliteManagerCache,
   type PgliteSingletonCache,
 } from "./pglite/manager-cache";
+import { identityPersonLinkRoutes } from "./routes/identity-person-link";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
+import { SqlIdentityResolutionService } from "./services/sql-identity-resolution";
 import { resolvePgliteDir } from "./utils";
 import { stringToUuid } from "./utils/string-to-uuid";
 
@@ -174,11 +176,8 @@ export const plugin: Plugin = {
   description: "A plugin for SQL database access with dynamic schema migrations",
   priority: 0,
   schema: schema,
-  // Identity authority is exported for explicit hosts and integration tests,
-  // but remains cutover-gated until owner claims are backfilled. Registering
-  // it early would make role resolution prefer an empty authority over the
-  // verified owner-pairing compatibility path.
-  services: [AdvancedMemoryStorageService],
+  services: [AdvancedMemoryStorageService, SqlIdentityResolutionService],
+  routes: [...identityPersonLinkRoutes],
   init: async (_, runtime: IAgentRuntime) => {
     const runtimeWithAdapter = runtime as IAgentRuntime & RuntimeWithAdapterRegistrar;
     runtime.logger.info(

--- a/plugins/plugin-sql/src/migration-service.ts
+++ b/plugins/plugin-sql/src/migration-service.ts
@@ -3,10 +3,12 @@
  * registered plugin: collects each plugin's `schema` export, runs the
  * legacy entity-RLS backfill (`migrateToEntityRLS`), drives `RuntimeMigrator`
  * per plugin (continuing past individual failures and aggregating them into
- * one error), and — when `ENABLE_DATA_ISOLATION=true` — re-applies Row Level
- * Security across all tables once every migration succeeds.
+ * one error), installs post-schema database guards, and — when
+ * `ENABLE_DATA_ISOLATION=true` — re-applies Row Level Security across all
+ * tables once every migration succeeds.
  */
 import { type IDatabaseAdapter, logger, type Plugin } from "@elizaos/core";
+import { applyIdentityPersonLinkAttestationGuard } from "./identity-person-link-attestation-guard";
 import { applyMessageSearchObjects, messageSearchTableExists } from "./message-search";
 import { migrateToEntityRLS } from "./migrations";
 import { applyEntityRLSToAllTables, applyRLSToNewTables, installRLSFunctions } from "./rls";
@@ -39,6 +41,7 @@ export class DatabaseMigrationService {
   private migrator: RuntimeMigrator | null = null;
   private readonly databaseBackend: DatabaseBackend;
   private messageSearchObjectsSettled = false;
+  private identityPersonLinkGuardSettled = false;
 
   constructor(options: DatabaseMigrationServiceOptions = {}) {
     this.databaseBackend = options.databaseBackend ?? "unknown";
@@ -148,6 +151,12 @@ export class DatabaseMigrationService {
 
     if (failureCount === 0) {
       logger.info({ src: "plugin:sql", successCount }, "All migrations completed successfully");
+
+      if (!this.identityPersonLinkGuardSettled) {
+        this.identityPersonLinkGuardSettled = await applyIdentityPersonLinkAttestationGuard(
+          this.db
+        );
+      }
 
       // Install the message full-text/trigram search objects on the migrated
       // `memories` table (#13534). Idempotent; runs after the table exists so the

--- a/plugins/plugin-sql/src/routes/identity-person-link.ts
+++ b/plugins/plugin-sql/src/routes/identity-person-link.ts
@@ -1,0 +1,172 @@
+/**
+ * Private authenticated ingress for person-link attestations. The transport
+ * derives the operator principal and role from its trusted boundary; request
+ * bodies cannot claim confirmation, verification, actor, or authority fields.
+ */
+import {
+  ElizaError,
+  type IdentityPersonLinkActorRole,
+  IdentityResolutionService,
+  type Route,
+  type RouteHandlerContext,
+  type RouteHandlerResult,
+  type UUID,
+  validateUuid,
+} from "@elizaos/core";
+import { computeIdentityPersonLinkRequestDigest } from "../services/sql-identity-resolution";
+
+const ATTEST_PATH = "/api/identity/person-links/attest";
+const VERIFY_PATH = "/api/identity/person-links/verify";
+const ATTEST_FIELDS = new Set([
+  "leftPrincipalId",
+  "rightPrincipalId",
+  "expectedGeneration",
+  "reason",
+  "idempotencyKey",
+]);
+
+function json(status: number, body: unknown): RouteHandlerResult {
+  return {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+    body,
+  };
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function requiredString(value: unknown, maxLength: number): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized.length > 0 && normalized.length <= maxLength ? normalized : null;
+}
+
+function expectedGeneration(value: unknown): number | null {
+  return Number.isSafeInteger(value) && Number(value) >= 0 ? Number(value) : null;
+}
+
+function queryValue(value: string | string[] | undefined): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function authenticatedActor(
+  ctx: RouteHandlerContext
+): { principalId: UUID; role: IdentityPersonLinkActorRole } | RouteHandlerResult {
+  if (!ctx.accessContext) {
+    return json(403, { error: "IDENTITY_PERSON_LINK_AUTHORITY_REQUIRED" });
+  }
+  const role = ctx.accessContext.role;
+  if (role !== "OWNER" && role !== "ADMIN") {
+    return json(403, { error: "IDENTITY_PERSON_LINK_AUTHORITY_REQUIRED" });
+  }
+  return { principalId: ctx.accessContext.requesterEntityId, role };
+}
+
+function identityFailure(ctx: RouteHandlerContext, error: unknown): RouteHandlerResult {
+  if (error instanceof ElizaError) {
+    const conflictCodes = new Set([
+      "IDENTITY_GENERATION_CONFLICT",
+      "IDENTITY_IDEMPOTENCY_CONFLICT",
+      "IDENTITY_PERSON_LINK_ALREADY_CANONICAL",
+    ]);
+    const notFound = error.code === "IDENTITY_PRINCIPAL_NOT_FOUND";
+    return json(notFound ? 404 : conflictCodes.has(error.code) ? 409 : 400, {
+      error: error.code,
+      message: error.message,
+    });
+  }
+  // error-policy:J1 route boundary translation — unexpected authority or SQL
+  // failures are reported and returned as explicit failure, never success.
+  ctx.runtime.reportError("identity-person-link-route", error, { path: ctx.path });
+  return json(500, { error: "IDENTITY_PERSON_LINK_FAILED" });
+}
+
+async function attest(ctx: RouteHandlerContext): Promise<RouteHandlerResult> {
+  const body = record(ctx.body);
+  if (!body || Object.keys(body).some((key) => !ATTEST_FIELDS.has(key))) {
+    return json(400, { error: "IDENTITY_PERSON_LINK_INPUT_INVALID" });
+  }
+  const leftPrincipalId = validateUuid(body.leftPrincipalId);
+  const rightPrincipalId = validateUuid(body.rightPrincipalId);
+  const generation = expectedGeneration(body.expectedGeneration);
+  const reason = requiredString(body.reason, 500);
+  const idempotencyKey = requiredString(body.idempotencyKey, 200);
+  if (!leftPrincipalId || !rightPrincipalId || generation === null || !reason || !idempotencyKey) {
+    return json(400, { error: "IDENTITY_PERSON_LINK_INPUT_INVALID" });
+  }
+  const actor = authenticatedActor(ctx);
+  if ("status" in actor) return actor;
+  const service = ctx.runtime.getService<IdentityResolutionService>(
+    IdentityResolutionService.serviceType
+  );
+  if (!service) return json(503, { error: "IDENTITY_AUTHORITY_UNAVAILABLE" });
+  const requestWithoutDigest = {
+    agentId: ctx.runtime.agentId,
+    leftPrincipalId,
+    rightPrincipalId,
+    actorPrincipalId: actor.principalId,
+    actorRole: actor.role,
+    authority: "authenticated_private_route" as const,
+    transport: ctx.inProcess ? ("in_process" as const) : ("http" as const),
+    reason,
+    idempotencyKey,
+    expectedGeneration: generation,
+  };
+  try {
+    const attestation = await service.attestPersonLink({
+      ...requestWithoutDigest,
+      requestDigest: computeIdentityPersonLinkRequestDigest(requestWithoutDigest),
+    });
+    return json(201, { attestation });
+  } catch (error) {
+    return identityFailure(ctx, error);
+  }
+}
+
+async function verify(ctx: RouteHandlerContext): Promise<RouteHandlerResult> {
+  const actor = authenticatedActor(ctx);
+  if ("status" in actor) return actor;
+  const leftPrincipalId = validateUuid(queryValue(ctx.query.leftPrincipalId));
+  const rightPrincipalId = validateUuid(queryValue(ctx.query.rightPrincipalId));
+  const generationText = queryValue(ctx.query.expectedGeneration);
+  const generation = generationText === null ? null : expectedGeneration(Number(generationText));
+  if (!leftPrincipalId || !rightPrincipalId || generation === null) {
+    return json(400, { error: "IDENTITY_PERSON_LINK_INPUT_INVALID" });
+  }
+  const service = ctx.runtime.getService<IdentityResolutionService>(
+    IdentityResolutionService.serviceType
+  );
+  if (!service) return json(503, { error: "IDENTITY_AUTHORITY_UNAVAILABLE" });
+  try {
+    const verification = await service.verifyPersonLink({
+      agentId: ctx.runtime.agentId,
+      leftPrincipalId,
+      rightPrincipalId,
+      expectedGeneration: generation,
+    });
+    return json(200, { verification });
+  } catch (error) {
+    return identityFailure(ctx, error);
+  }
+}
+
+export const identityPersonLinkRoutes: readonly Route[] = [
+  {
+    name: "identity-person-link-attest",
+    path: ATTEST_PATH,
+    type: "POST",
+    public: false,
+    routeHandler: attest,
+  },
+  {
+    name: "identity-person-link-verify",
+    path: VERIFY_PATH,
+    type: "GET",
+    public: false,
+    routeHandler: verify,
+  },
+];

--- a/plugins/plugin-sql/src/schema/identityAuthority.ts
+++ b/plugins/plugin-sql/src/schema/identityAuthority.ts
@@ -1,8 +1,9 @@
 /**
  * Durable canonical-identity authority tables for account-scoped claims,
- * non-destructive principal redirects, and reversible merge/split journals.
- * These tables preserve identity provenance independently from legacy entity
- * metadata while keeping OWNER authority tied to an explicit binding.
+ * authenticated person-link evidence, non-destructive principal redirects,
+ * and reversible merge/split journals. These tables preserve provenance
+ * independently from legacy entity metadata while keeping OWNER authority
+ * tied to an explicit binding.
  */
 import { sql } from "drizzle-orm";
 import {
@@ -127,6 +128,83 @@ export const identityAuthorityStateTable = pgTable(
       foreignColumns: [agentTable.id],
     }).onDelete("cascade"),
     check("identity_authority_state_generation_check", sql`${table.generation} >= 0`),
+  ]
+);
+
+export const identityPersonLinkAttestationTable = pgTable(
+  "identity_person_link_attestations",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`).notNull(),
+    agentId: uuid("agent_id").notNull(),
+    leftPrincipalId: uuid("left_principal_id").notNull(),
+    rightPrincipalId: uuid("right_principal_id").notNull(),
+    actorPrincipalId: uuid("actor_principal_id").notNull(),
+    actorRole: text("actor_role").notNull(),
+    authority: text("authority").notNull(),
+    transport: text("transport").notNull(),
+    reason: text("reason").notNull(),
+    idempotencyKey: text("idempotency_key").notNull(),
+    requestDigest: text("request_digest").notNull(),
+    expectedGeneration: bigint("expected_generation", { mode: "number" }).notNull(),
+    committedGeneration: bigint("committed_generation", { mode: "number" }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().default(sql`now()`),
+  },
+  (table) => [
+    unique("identity_person_link_attestation_idempotency_unique").on(
+      table.agentId,
+      table.idempotencyKey
+    ),
+    index("identity_person_link_attestation_pair_idx").on(
+      table.agentId,
+      table.leftPrincipalId,
+      table.rightPrincipalId,
+      table.createdAt
+    ),
+    foreignKey({
+      name: "fk_identity_person_link_attestation_agent",
+      columns: [table.agentId],
+      foreignColumns: [agentTable.id],
+    }).onDelete("cascade"),
+    foreignKey({
+      name: "fk_identity_person_link_attestation_left",
+      columns: [table.leftPrincipalId, table.agentId],
+      foreignColumns: [entityTable.id, entityTable.agentId],
+    }).onDelete("restrict"),
+    foreignKey({
+      name: "fk_identity_person_link_attestation_right",
+      columns: [table.rightPrincipalId, table.agentId],
+      foreignColumns: [entityTable.id, entityTable.agentId],
+    }).onDelete("restrict"),
+    foreignKey({
+      name: "fk_identity_person_link_attestation_actor",
+      columns: [table.actorPrincipalId, table.agentId],
+      foreignColumns: [entityTable.id, entityTable.agentId],
+    }).onDelete("restrict"),
+    check(
+      "identity_person_link_attestation_order_check",
+      sql`${table.leftPrincipalId} < ${table.rightPrincipalId}`
+    ),
+    check(
+      "identity_person_link_attestation_actor_role_check",
+      sql`${table.actorRole} IN ('OWNER', 'ADMIN')`
+    ),
+    check(
+      "identity_person_link_attestation_authority_check",
+      sql`${table.authority} = 'authenticated_private_route'`
+    ),
+    check(
+      "identity_person_link_attestation_transport_check",
+      sql`${table.transport} IN ('http', 'in_process')`
+    ),
+    check(
+      "identity_person_link_attestation_generation_check",
+      sql`${table.expectedGeneration} >= 0 AND ${table.committedGeneration} = ${table.expectedGeneration} + 1`
+    ),
+    check("identity_person_link_attestation_reason_check", sql`length(trim(${table.reason})) > 0`),
+    check(
+      "identity_person_link_attestation_idempotency_check",
+      sql`length(trim(${table.idempotencyKey})) > 0`
+    ),
   ]
 );
 

--- a/plugins/plugin-sql/src/schema/index.ts
+++ b/plugins/plugin-sql/src/schema/index.ts
@@ -40,6 +40,7 @@ export {
   identityClaimTable,
   identityMergeConfirmationTable,
   identityMergeJournalTable,
+  identityPersonLinkAttestationTable,
 } from "./identityAuthority";
 export { logTable } from "./log";
 export { longTermMemories } from "./longTermMemories";

--- a/plugins/plugin-sql/src/services/sql-identity-resolution.ts
+++ b/plugins/plugin-sql/src/services/sql-identity-resolution.ts
@@ -1,10 +1,11 @@
 /**
- * SQL-backed canonical identity authority. Merge and split serialize through
- * the per-agent generation row and commit journal, confirmation consumption,
- * and versioned redirects in one transaction. Source entities and claims are
- * immutable inputs; consumer projections follow redirects and repair later.
+ * SQL-backed canonical identity authority. Authenticated person-link evidence,
+ * merge, and split serialize through the per-agent generation row. Attestation
+ * evidence is append-only; merges use confirmation consumption and versioned
+ * redirects so source principals remain intact.
  */
 import {
+  type AttestIdentityPersonLinkRequest,
   type CommitIdentityMergeRequest,
   ElizaError,
   type IAgentRuntime,
@@ -18,6 +19,8 @@ import {
   type IdentityJournalPage,
   type IdentityMergeConfirmation,
   type IdentityMergePlan,
+  type IdentityPersonLinkAttestation,
+  type IdentityPersonLinkVerification,
   IdentityResolutionService,
   type JsonObject,
   type MergeJournal,
@@ -26,6 +29,7 @@ import {
   type Service,
   type SplitIdentityRequest,
   type UUID,
+  type VerifyIdentityPersonLinkRequest,
 } from "@elizaos/core";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { and, desc, eq, inArray, lt, or, sql } from "drizzle-orm";
@@ -38,6 +42,7 @@ import {
   identityClaimTable,
   identityMergeConfirmationTable,
   identityMergeJournalTable,
+  identityPersonLinkAttestationTable,
 } from "../schema/identityAuthority";
 import { type DrizzleDatabase, getDb } from "../types";
 
@@ -57,6 +62,7 @@ const PENDING_CONSUMERS = Object.freeze([
 type JournalRow = typeof identityMergeJournalTable.$inferSelect;
 type RedirectRow = typeof identityCanonicalRedirectTable.$inferSelect;
 type ClaimRow = typeof identityClaimTable.$inferSelect;
+type PersonLinkAttestationRow = typeof identityPersonLinkAttestationTable.$inferSelect;
 
 function fail(code: string, message: string, context: Record<string, unknown> = {}): never {
   throw new ElizaError(message, { code, context, severity: "fatal" });
@@ -105,6 +111,27 @@ export function computeIdentityRequestDigest(
   return digest(`elizaos:identity:${operation}:v1`, canonicalizeIdentityRequest(operation, value));
 }
 
+function normalizePersonLinkPair(left: UUID, right: UUID): readonly [UUID, UUID] {
+  if (left === right) {
+    fail("IDENTITY_PERSON_LINK_INPUT_INVALID", "Person-link principals must be distinct.");
+  }
+  return left < right ? [left, right] : [right, left];
+}
+
+export function computeIdentityPersonLinkRequestDigest(
+  value: Omit<AttestIdentityPersonLinkRequest, "requestDigest">
+): string {
+  const [leftPrincipalId, rightPrincipalId] = normalizePersonLinkPair(
+    value.leftPrincipalId,
+    value.rightPrincipalId
+  );
+  return digest("elizaos:identity:person-link-attestation:v1", {
+    ...value,
+    leftPrincipalId,
+    rightPrincipalId,
+  });
+}
+
 function assertRequestDigest(
   actual: string,
   operation: Parameters<typeof computeIdentityRequestDigest>[0],
@@ -119,6 +146,26 @@ function assertRequestDigest(
       }
     );
   }
+}
+
+function mapPersonLinkAttestation(row: PersonLinkAttestationRow): IdentityPersonLinkAttestation {
+  return {
+    contractVersion: IDENTITY_AUTHORITY_CONTRACT_VERSION,
+    id: row.id as UUID,
+    agentId: row.agentId as UUID,
+    leftPrincipalId: row.leftPrincipalId as UUID,
+    rightPrincipalId: row.rightPrincipalId as UUID,
+    actorPrincipalId: row.actorPrincipalId as UUID,
+    actorRole: row.actorRole as IdentityPersonLinkAttestation["actorRole"],
+    authority: "authenticated_private_route",
+    transport: row.transport as IdentityPersonLinkAttestation["transport"],
+    reason: row.reason,
+    idempotencyKey: row.idempotencyKey,
+    requestDigest: row.requestDigest,
+    expectedGeneration: row.expectedGeneration,
+    committedGeneration: row.committedGeneration,
+    createdAt: iso(row.createdAt),
+  };
 }
 
 function newId(): UUID {
@@ -464,6 +511,212 @@ export class SqlIdentityResolutionService extends IdentityResolutionService {
       generation: cluster.generation,
       reason: "verified_owner_binding",
     };
+  }
+
+  async attestPersonLink(
+    request: AttestIdentityPersonLinkRequest
+  ): Promise<IdentityPersonLinkAttestation> {
+    this.assertAgent(request.agentId);
+    const [leftPrincipalId, rightPrincipalId] = normalizePersonLinkPair(
+      request.leftPrincipalId,
+      request.rightPrincipalId
+    );
+    const reason = request.reason.trim();
+    const idempotencyKey = request.idempotencyKey.trim();
+    if (
+      !Number.isSafeInteger(request.expectedGeneration) ||
+      request.expectedGeneration < 0 ||
+      reason.length === 0 ||
+      reason.length > 500 ||
+      idempotencyKey.length === 0 ||
+      idempotencyKey.length > 200 ||
+      (request.actorRole !== "OWNER" && request.actorRole !== "ADMIN") ||
+      request.authority !== "authenticated_private_route" ||
+      (request.transport !== "http" && request.transport !== "in_process")
+    ) {
+      fail("IDENTITY_PERSON_LINK_INPUT_INVALID", "Person-link attestation input is invalid.");
+    }
+    const digestInput: Omit<AttestIdentityPersonLinkRequest, "requestDigest"> = {
+      agentId: request.agentId,
+      leftPrincipalId,
+      rightPrincipalId,
+      actorPrincipalId: request.actorPrincipalId,
+      actorRole: request.actorRole,
+      authority: request.authority,
+      transport: request.transport,
+      reason,
+      idempotencyKey,
+      expectedGeneration: request.expectedGeneration,
+    };
+    const expectedDigest = computeIdentityPersonLinkRequestDigest(digestInput);
+    if (request.requestDigest !== expectedDigest) {
+      fail(
+        "IDENTITY_REQUEST_DIGEST_MISMATCH",
+        "Person-link attestation digest does not match the request."
+      );
+    }
+
+    return this.db.transaction(async (tx) => {
+      await tx
+        .insert(identityAuthorityStateTable)
+        .values({ agentId: request.agentId })
+        .onConflictDoNothing();
+      const [state] = await tx
+        .select()
+        .from(identityAuthorityStateTable)
+        .where(eq(identityAuthorityStateTable.agentId, request.agentId))
+        .for("update")
+        .limit(1);
+      if (!state) return fail("IDENTITY_STATE_MISSING", "Identity authority state is missing.");
+
+      const [existing] = await tx
+        .select()
+        .from(identityPersonLinkAttestationTable)
+        .where(
+          and(
+            eq(identityPersonLinkAttestationTable.agentId, request.agentId),
+            eq(identityPersonLinkAttestationTable.idempotencyKey, idempotencyKey)
+          )
+        )
+        .limit(1);
+      if (existing) {
+        if (existing.requestDigest !== expectedDigest) {
+          fail(
+            "IDENTITY_IDEMPOTENCY_CONFLICT",
+            "Person-link attestation key was reused for another request."
+          );
+        }
+        return mapPersonLinkAttestation(existing);
+      }
+      if (state.generation !== request.expectedGeneration) {
+        fail("IDENTITY_GENERATION_CONFLICT", "Identity graph changed before attestation.");
+      }
+
+      const requiredPrincipalIds = [
+        ...new Set([leftPrincipalId, rightPrincipalId, request.actorPrincipalId]),
+      ];
+      const principals = await tx
+        .select({ id: entityTable.id })
+        .from(entityTable)
+        .where(
+          and(
+            eq(entityTable.agentId, request.agentId),
+            inArray(entityTable.id, requiredPrincipalIds)
+          )
+        );
+      if (new Set(principals.map((row) => row.id)).size !== requiredPrincipalIds.length) {
+        fail(
+          "IDENTITY_PRINCIPAL_NOT_FOUND",
+          "Both person-link principals and the authenticated actor must exist."
+        );
+      }
+      const redirects = await tx
+        .select()
+        .from(identityCanonicalRedirectTable)
+        .where(
+          and(
+            eq(identityCanonicalRedirectTable.agentId, request.agentId),
+            eq(identityCanonicalRedirectTable.status, "active")
+          )
+        );
+      if (
+        follow(leftPrincipalId, redirects).canonical ===
+        follow(rightPrincipalId, redirects).canonical
+      ) {
+        fail(
+          "IDENTITY_PERSON_LINK_ALREADY_CANONICAL",
+          "Person-link principals already resolve to one canonical principal."
+        );
+      }
+
+      const now = new Date();
+      const bumped = await tx
+        .update(identityAuthorityStateTable)
+        .set({
+          generation: sql`${identityAuthorityStateTable.generation} + 1`,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(identityAuthorityStateTable.agentId, request.agentId),
+            eq(identityAuthorityStateTable.generation, request.expectedGeneration)
+          )
+        )
+        .returning();
+      if (!bumped[0]) {
+        fail("IDENTITY_GENERATION_CONFLICT", "Identity graph changed before attestation.");
+      }
+      const [inserted] = await tx
+        .insert(identityPersonLinkAttestationTable)
+        .values({
+          id: newId(),
+          agentId: request.agentId,
+          leftPrincipalId,
+          rightPrincipalId,
+          actorPrincipalId: request.actorPrincipalId,
+          actorRole: request.actorRole,
+          authority: request.authority,
+          transport: request.transport,
+          reason,
+          idempotencyKey,
+          requestDigest: expectedDigest,
+          expectedGeneration: request.expectedGeneration,
+          committedGeneration: bumped[0].generation,
+          createdAt: now,
+        })
+        .returning();
+      if (!inserted) {
+        fail("IDENTITY_PERSON_LINK_COMMIT_FAILED", "Person-link attestation did not commit.");
+      }
+      return mapPersonLinkAttestation(inserted);
+    });
+  }
+
+  async verifyPersonLink(
+    request: VerifyIdentityPersonLinkRequest
+  ): Promise<IdentityPersonLinkVerification> {
+    this.assertAgent(request.agentId);
+    if (!Number.isSafeInteger(request.expectedGeneration) || request.expectedGeneration < 0) {
+      fail("IDENTITY_PERSON_LINK_INPUT_INVALID", "Verification generation is invalid.");
+    }
+    const [leftPrincipalId, rightPrincipalId] = normalizePersonLinkPair(
+      request.leftPrincipalId,
+      request.rightPrincipalId
+    );
+    return this.db.transaction(async (tx) => {
+      const [state] = await tx
+        .select()
+        .from(identityAuthorityStateTable)
+        .where(eq(identityAuthorityStateTable.agentId, request.agentId))
+        .for("update")
+        .limit(1);
+      const generation = state?.generation ?? 0;
+      if (generation !== request.expectedGeneration) {
+        fail("IDENTITY_GENERATION_CONFLICT", "Identity graph changed before verification.");
+      }
+      const [attestation] = await tx
+        .select()
+        .from(identityPersonLinkAttestationTable)
+        .where(
+          and(
+            eq(identityPersonLinkAttestationTable.agentId, request.agentId),
+            eq(identityPersonLinkAttestationTable.leftPrincipalId, leftPrincipalId),
+            eq(identityPersonLinkAttestationTable.rightPrincipalId, rightPrincipalId)
+          )
+        )
+        .orderBy(
+          desc(identityPersonLinkAttestationTable.createdAt),
+          desc(identityPersonLinkAttestationTable.id)
+        )
+        .limit(1);
+      return attestation
+        ? {
+            decision: "attested",
+            generation,
+            attestation: mapPersonLinkAttestation(attestation),
+          }
+        : { decision: "not_attested", generation, reason: "no_attestation" };
+    });
   }
 
   async proposeMerge(request: ProposeIdentityMergeRequest): Promise<IdentityMergePlan> {


### PR DESCRIPTION
# Relates to

Relates to #23099. Part of #24242.

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] Focused real-database, schema, registration, type, format, and guide-parity gates pass at the exact PR head.
- [x] A reviewer can verify the authority and no-mutation invariants from the evidence below.

# Sync with develop

- [x] Rebased onto current `origin/develop`; zero conflicts.
- [ ] `bun run verify` was not run under the program's fast-merge policy; focused changed-surface proof is recorded below.

# Risks

Medium. This activates the existing SQL identity authority in default, Node, and browser plugin entries. The cutover is intentional: identity reads now fail closed through the canonical service instead of falling back to legacy metadata. This repository has no current users to migrate. The new attestation surface records evidence only; it cannot create redirects, merge journals, or delete principals.

# Background

## What does this PR do?

- Adds an immutable `identity_person_link_attestations` authority table with tenant, actor, role, transport, digest, idempotency, and generation evidence.
- Adds generation-fenced `attestPersonLink` and `verifyPersonLink` operations to the canonical `IdentityResolutionService` and SQL implementation.
- Registers `SqlIdentityResolutionService` in all SQL plugin runtimes.
- Adds private `POST /api/identity/person-links/attest` and `GET /api/identity/person-links/verify` routes.
- Derives actor principal and OWNER/ADMIN role from the authenticated server boundary. Request bodies cannot supply actor, role, authority, `confirmed`, or `verified` values.
- Installs a PostgreSQL/PGlite trigger that rejects attestation UPDATE and DELETE with SQLSTATE `55000`.
- Keeps principals intact and creates no canonical redirect or merge-journal row.

## What kind of change is this?

Security feature and intentional identity-authority hard cut.

# Documentation changes needed?

Updated the SQL README and paired CLAUDE/AGENTS package guides.

# Testing

## Where should a reviewer start?

- `plugins/plugin-sql/src/routes/identity-person-link.ts`
- `plugins/plugin-sql/src/services/sql-identity-resolution.ts`
- `plugins/plugin-sql/src/__tests__/integration/identity-person-link-attestation.real.test.ts`

## Detailed testing steps

At head `05b1b1f72623bdbd655295f58ca4a48a773e51dd`:

- Schema + registration: 2 files, 6 tests passed.
- Real migrated PGlite ingress: 1 file, 4 tests passed.
- `bun run --cwd packages/core typecheck`: passed.
- `bun run --cwd plugins/plugin-sql typecheck`: passed.
- Changed-file Biome: 13 files checked, no fixes needed.
- `bun run check:agents-claude`: 159 pairs identical.
- `git diff --check origin/develop...HEAD`: passed.
- Full multi-target core build passed before final rebase; the final contract and SQL typechecks passed after rebase.

The real-PGlite test proves server-derived ADMIN evidence, normalized unordered pairs, exact-generation verification, stale-generation rejection, exact replay, forged authority-field rejection, USER denial, missing-`AccessContext` fail-closed denial before service/DB access, one-winner concurrent fencing, SQLSTATE `55000` update/delete denial, and zero redirect/merge-journal artifacts.

# Evidence Gate

<!-- evidence-head:05b1b1f72623bdbd655295f58ca4a48a773e51dd -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - private backend authority routes only.
<!-- evidence-row:backend-logs -->
- [x] Real migrated-PGlite migration logs and exact persisted-row assertions are recorded by the focused integration test.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no action, provider, prompt, planner, or model surface exists; registration tests assert `plugin.actions` is absent.
<!-- evidence-row:domain-artifacts -->
- [x] Real attestation, generation, redirect, and journal rows are inspected in the PGlite test; mutation attempts return SQLSTATE `55000`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - this surface is deliberately outside the model/action catalog. The adversarial proof injects model-shaped `confirmed`, `verified`, and actor-role fields directly at the route boundary and observes rejection before mutation.

## Backend + frontend logs

The real test migrates 209 SQL statements into isolated PGlite, records the operator evidence, then reads the authority generation and domain rows. Frontend logs are N/A.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice surface change.

## Known gaps / failures

- `bun run verify` and broad package test lanes were not run under the fast-merge policy; the exact changed authority paths, real database, types, and formatting were exercised.
- No external PostgreSQL instance was used. The same PL/pgSQL trigger and Drizzle schema ran through real PGlite migrations.
- This slice records and verifies same-person evidence but deliberately does not consume it into a principal merge. Reversible merge/split remains a separate explicit authority operation.
- Open PR #24222 also evolves claim lifecycle and may require normal conflict resolution if it lands later; this PR does not duplicate its dormant claim APIs.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop / multi-agent
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [identity-person-link-attestation]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop / multi-agent","skill_revision":"N/A - no repository contribution skill used"} -->
